### PR TITLE
feat: create X11 windows top-down in the commit phase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,13 +51,17 @@ windowless controls, a small widget library, and yoga-layout powered layout.
   add it to the mock. `test/integration.test.js` runs end-to-end against
   node-x11's in-process pure-JS X server (see ntk `docs/xserver.md`), so no
   `$DISPLAY` is needed even for the real-client path.
-- Child (non-top-level) windows are created with `overrideRedirect: true`,
-  then reparented into their parent and mapped in `commitMount`/`appendChild`.
-  That ordering is load-bearing; the first smoke test pins it.
+- Host instances are lightweight handles; `createInstance` performs **no
+  X11 calls** (the render phase is discardable under concurrent React).
+  Real windows are created **top-down** in the commit phase — `realize()`
+  walks the handle tree from `appendChildToContainer`/`appendChild`, so
+  every `CreateWindow` names its actual parent and nothing is ever
+  reparented (issue #4). That ordering is load-bearing; the first smoke
+  test pins it.
 - `render()` uses `updateContainerSync` + `flushSyncWork`, so mounts/updates
   are applied synchronously — tests rely on that.
-- Instance bookkeeping uses `__children` arrays and a `_reactFiber` field
-  stashed on ntk window objects.
+- Instance bookkeeping lives on the handle (`children`, `props`, `window`);
+  a `_reactFiber` field is stashed on ntk window objects for DevTools.
 - Text nodes are not supported (`createTextInstance` throws on purpose).
 
 ## Style

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -23,6 +23,38 @@ function windowAttributes(props) {
 
 let currentUpdatePriority = NoEventPriority;
 
+// Host instances are lightweight handles, not X11 windows. React creates
+// instances bottom-up (completeWork) during the render phase, where the
+// parent window cannot exist yet and where concurrent rendering may still
+// discard the work. The real CreateWindow calls happen top-down in the
+// commit phase (see realize), so every window names its actual parent from
+// the start — no ReparentWindow, no override-redirect staging (issue #4).
+function createHandle(props, rootContainer, fiber) {
+  return {
+    props,
+    container: rootContainer,
+    fiber,
+    children: [],
+    window: null,
+  };
+}
+
+function realize(handle, parentWindow) {
+  const attributes = windowAttributes(handle.props);
+  if (parentWindow) {
+    attributes.parent = parentWindow;
+  }
+  const wnd = handle.container.createWindow(attributes);
+  wnd._reactFiber = handle.fiber;
+  handle.window = wnd;
+  for (const child of handle.children) {
+    realize(child, wnd);
+  }
+  // Children map before their parent, so the subtree appears at once when
+  // the outermost window maps.
+  wnd.map();
+}
+
 const HostConfig = {
   supportsMutation: true,
   supportsPersistence: false,
@@ -43,18 +75,18 @@ const HostConfig = {
   noTimeout: -1,
   scheduleMicrotask: queueMicrotask,
 
-  getRootHostContext(rootContainer) {
-    return {
-      rootWindowId: rootContainer.X.display.screen[0].root,
-    };
+  getRootHostContext() {
+    return {};
   },
 
-  getChildHostContext(parentHostContext, type) {
-    return { parent: parentHostContext, type };
+  getChildHostContext(parentHostContext) {
+    return parentHostContext;
   },
 
   getPublicInstance(instance) {
-    return instance;
+    // Refs attach in the layout phase, after the mutation phase realized
+    // the window, so this is always the live ntk window.
+    return instance.window || instance;
   },
 
   prepareForCommit() {
@@ -69,61 +101,40 @@ const HostConfig = {
         `react-x11: unknown element type <${type}>. Only <window> is supported for now.`,
       );
     }
-    const attributes = windowAttributes(props);
-    // Windows that are not direct children of the root get reparented into
-    // their parent window on commit; overrideRedirect keeps the window
-    // manager from decorating them in the meantime.
-    if (typeof hostContext.rootWindowId === 'undefined') {
-      attributes.overrideRedirect = true;
-    }
-    const wnd = rootContainer.createWindow(attributes);
-    if (!attributes.overrideRedirect) {
-      wnd.map();
-    }
-    wnd._reactFiber = internalHandle;
-    return wnd;
+    // No X11 calls here: this runs in the render phase, which concurrent
+    // React may discard. The window is created in the commit phase.
+    return createHandle(props, rootContainer, internalHandle);
   },
 
   appendInitialChild(parentInstance, child) {
-    if (parentInstance.__children) {
-      parentInstance.__children.push(child);
-    } else {
-      parentInstance.__children = [child];
-    }
+    parentInstance.children.push(child);
   },
 
   finalizeInitialChildren() {
-    // Return true so commitMount runs and reparents buffered children.
-    return true;
+    return false;
   },
 
-  commitMount(instance, type) {
-    if (type !== 'window' || !instance.__children) {
-      return;
-    }
-    for (const child of instance.__children) {
-      if (child.reparentTo) {
-        child.reparentTo(instance, child.x, child.y);
-        child.map();
-      }
-    }
-  },
+  commitMount() {},
 
   appendChild(parentInstance, child) {
-    if (child.id && parentInstance.id && child.reparentTo) {
-      child.reparentTo(parentInstance, child.x, child.y);
-      child.map();
+    const index = parentInstance.children.indexOf(child);
+    if (index !== -1) {
+      parentInstance.children.splice(index, 1);
     }
-    if (parentInstance.__children) {
-      parentInstance.__children.push(child);
-    } else {
-      parentInstance.__children = [child];
+    parentInstance.children.push(child);
+    if (!child.window) {
+      realize(child, parentInstance.window);
     }
+    // An already-realized child means a reorder among siblings; X11
+    // stacking order is not modelled yet.
   },
 
-  appendChildToContainer() {
-    // Top-level windows are created directly on the X connection and mapped
-    // in createInstance; nothing to attach to the container.
+  appendChildToContainer(container, child) {
+    if (!child.window) {
+      // Top-level window: realize the whole subtree top-down against the
+      // screen root.
+      realize(child, null);
+    }
   },
 
   insertBefore(parentInstance, child) {
@@ -131,51 +142,52 @@ const HostConfig = {
     HostConfig.appendChild(parentInstance, child);
   },
 
-  insertInContainerBefore() {},
+  insertInContainerBefore(container, child) {
+    HostConfig.appendChildToContainer(container, child);
+  },
 
   removeChild(parentInstance, child) {
-    if (parentInstance.__children) {
-      const index = parentInstance.__children.indexOf(child);
-      if (index !== -1) {
-        parentInstance.__children.splice(index, 1);
-      }
+    const index = parentInstance.children.indexOf(child);
+    if (index !== -1) {
+      parentInstance.children.splice(index, 1);
     }
-    if (child.destroy) {
-      child.destroy();
+    if (child.window) {
+      // DestroyWindow destroys all subwindows server-side as well.
+      child.window.destroy();
+      child.window = null;
     }
   },
 
   removeChildFromContainer(container, child) {
-    if (child.destroy) {
-      child.destroy();
+    if (child.window) {
+      child.window.destroy();
+      child.window = null;
     }
   },
 
   clearContainer() {},
 
   commitUpdate(instance, type, oldProps, newProps) {
-    if (type !== 'window') {
+    instance.props = newProps;
+    const wnd = instance.window;
+    if (type !== 'window' || !wnd) {
       return;
     }
     if (newProps.title !== oldProps.title) {
-      instance.setTitle(newProps.title || '');
+      wnd.setTitle(newProps.title || '');
     }
     if (
       newProps.width !== oldProps.width ||
       newProps.height !== oldProps.height
     ) {
-      instance.resize(newProps.width, newProps.height);
+      wnd.resize(newProps.width, newProps.height);
     }
     if (newProps.x !== oldProps.x || newProps.y !== oldProps.y) {
-      instance.move(newProps.x, newProps.y);
+      wnd.move(newProps.x, newProps.y);
     }
     for (const key of Object.keys(newProps)) {
-      if (
-        isEventProp(key) &&
-        newProps[key] !== oldProps[key] &&
-        instance.setProp
-      ) {
-        instance.setProp(key, newProps[key]);
+      if (isEventProp(key) && newProps[key] !== oldProps[key] && wnd.setProp) {
+        wnd.setProp(key, newProps[key]);
       }
     }
   },
@@ -195,21 +207,25 @@ const HostConfig = {
   resetTextContent() {},
 
   hideInstance(instance) {
-    if (instance.unmap) {
-      instance.unmap();
+    if (instance.window) {
+      instance.window.unmap();
     }
   },
 
   unhideInstance(instance) {
-    if (instance.map) {
-      instance.map();
+    if (instance.window) {
+      instance.window.map();
     }
   },
 
   hideTextInstance() {},
   unhideTextInstance() {},
 
-  detachDeletedInstance() {},
+  detachDeletedInstance(instance) {
+    // Descendants of a destroyed window were destroyed server-side by
+    // DestroyWindow; drop the JS-side reference.
+    instance.window = null;
+  },
   preparePortalMount() {},
   prepareScopeUpdate() {},
   getInstanceFromScope() {

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -72,22 +72,28 @@ test('renders a top-level window with a child window', () => {
   ReactX11.render(element, null, app);
 
   assert.strictEqual(app.windows.length, 2);
-  const [child, top] = [app.windows[0], app.windows[1]];
+  // Windows are created top-down: the parent window first, then children
+  // created directly against it (issue #4) — no reparenting involved.
+  const [top, child] = [app.windows[0], app.windows[1]];
 
   assert.strictEqual(top.attributes.title, 'main');
   assert.strictEqual(top.mapped, true, 'top-level window should be mapped');
 
-  assert.strictEqual(child.attributes.overrideRedirect, true);
   assert.strictEqual(
-    child.parent,
+    child.attributes.parent,
     top,
-    'child should be reparented into the top window',
+    'child should be created with its parent window from the start',
   );
   assert.strictEqual(
-    child.mapped,
-    true,
-    'child should be mapped after reparenting',
+    child.attributes.overrideRedirect,
+    undefined,
+    'no override-redirect staging is needed with top-down creation',
   );
+  assert.ok(
+    !child.calls.some(([name]) => name === 'reparentTo'),
+    'child should never be reparented',
+  );
+  assert.strictEqual(child.mapped, true, 'child should be mapped');
 
   ReactX11.unmountComponentAtNode(app);
 });
@@ -110,6 +116,39 @@ test('applies prop updates to the window', () => {
   ReactX11.unmountComponentAtNode(app);
 });
 
+test('adds a child to an already-mounted window top-down', () => {
+  const app = createMockApp();
+  const render = (withChild) =>
+    ReactX11.render(
+      React.createElement(
+        'window',
+        { width: 300, height: 200 },
+        withChild
+          ? React.createElement('window', { width: 10, height: 10 })
+          : null,
+      ),
+      null,
+      app,
+    );
+
+  render(false);
+  assert.strictEqual(app.windows.length, 1);
+  const top = app.windows[0];
+
+  render(true);
+  assert.strictEqual(app.windows.length, 2);
+  const child = app.windows[1];
+  assert.strictEqual(
+    child.attributes.parent,
+    top,
+    'late-added child should be created against its real parent',
+  );
+  assert.strictEqual(child.mapped, true);
+  assert.ok(!child.calls.some(([name]) => name === 'reparentTo'));
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
 test('destroys windows that are removed', () => {
   const app = createMockApp();
   const render = (withChild) =>
@@ -127,7 +166,7 @@ test('destroys windows that are removed', () => {
 
   render(true);
   assert.strictEqual(app.windows.length, 2);
-  const child = app.windows.find((w) => w.attributes.overrideRedirect);
+  const child = app.windows.find((w) => w.attributes.parent);
 
   render(false);
   assert.strictEqual(


### PR DESCRIPTION
Fixes #4.

X11 wants windows created top-down (`CreateWindow(child, parent)` requires the parent to exist), while React's reconciler creates host instances strictly bottom-up: `createInstance` has exactly one call site, inside `completeWork`, which runs only after all children have completed. That hasn't changed since 2017 — the "move createInstance to beginWork" TODO is [still on React main today](https://github.com/facebook/react/blob/b685b40d870b90a975da28c8d22ecf0ba910b1a1/packages/react-reconciler/src/ReactFiberCompleteWork.js#L1405) — and it's structural, not neglect: `completeWork` is part of the render phase, which concurrent React may discard (interruption, Suspense), so instance creation can't move earlier without making render-phase side effects worse. Full research traces are in [the issue comment](https://github.com/sidorares/react-x11/issues/4#issuecomment-5082500571).

The fix doesn't need the reconciler to change — only *when* the renderer talks to the X server:

- `createInstance` now returns a lightweight handle (`{props, children, window: null, ...}`) and performs **no X11 calls**; `appendInitialChild` just links handles.
- The commit phase provides genuine top-down entry points: `appendChildToContainer` receives the fully-linked root handle on mount, and `appendChild` receives an already-realized parent on updates. `realize()` walks the handle subtree from there, creating each window directly against its real parent.

Consequences:

- The request stream matches hand-written Xlib: parent first, then children — **no `ReparentWindow`, no `overrideRedirect` staging**, fewer round trips, no transient root-window children for the WM to interfere with.
- All X11 side effects now happen in the commit phase, which React runs exactly once — the old code could leak server-side windows when a discarded concurrent render had already called `createWindow`.
- Children map before their parent, so a subtree appears atomically when the outermost window maps.
- Refs are unaffected: they attach in the layout phase, after the mutation phase realized the window, so `getPublicInstance` returns the live ntk window as before.

Testing: smoke tests updated to pin the new creation order (parent first, `parent` attribute set at creation, no reparent calls), plus a new test for the late-added-child (`appendChild`) path. All 7 tests pass, including the end-to-end test against node-x11's in-process X server; eslint clean.
