### PR TITLE
feat: Select widget component, double-click word selection, form example

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -18,9 +18,11 @@
 > TextLayout prefix widths, Ctrl+C/X/V, PRIMARY middle-click paste and
 > select-to-own, controlled/uncontrolled, placeholder, blink, hover text
 > cursor), `borderStyle="dashed"`, and EventManager default-action hooks
-> (user handlers can preventDefault, DOM-style). Remaining: `<select>` on
-> top of popup, word-select/double-click and bidi-correct caret movement in
-> textinput, DevTools highlight-on-hover, npm publish.
+> (user handlers can preventDefault, DOM-style). `Select` widget component
+> (dropdown on `<popup>`, scrollable menu, Escape/blur close, themable) and
+> double/triple-click selection in textinput (DOM-style `detail` counting)
+> are in. Remaining: bidi-correct caret movement in textinput, DevTools
+> highlight-on-hover, npm publish.
 
 Goal: **react-like ergonomics on top of ntk** — good enough to develop and debug
 real GUI apps. This document records the current state, what we learned from

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ context — see [NEXT_STEPS.md](NEXT_STEPS.md) for why.
 | `<image>`      | PNG/JPEG from `src`, natural-size aware                                                                                                                                                                                |
 | `<canvas>`     | escape hatch: `onDraw={(ctx, {width, height}) => …}` with ntk's canvas-like 2d context (XRender-backed)                                                                                                                |
 
+On top of the primitives the package exports widget **components** (plain
+React, no reconciler support needed): `Select` — a dropdown built on
+`<popup>` with keyboard support and a themable appearance
+(`SelectThemeProvider`).
+
 Events are synthetic with capture/bubble phases and hit testing over the
 drawn tree: `onClick`, `onMouseDown/Up/Move`, `onMouseEnter/Leave`,
 `onWheel` (default action scrolls the nearest `<scrollview>`),
@@ -95,6 +100,7 @@ npm run examples:xeyes         # canvas drawing + hooks
 npm run examples:dashboard     # context theming, custom hooks, components
 npm run examples:tasks         # useReducer, scrollview, keyboard interaction
 npm run examples:menu          # right-click context menu via <popup>
+npm run examples:form          # <textinput> + Select dropdowns
 ```
 
 `REACT_X11_DEBUG_LAYOUT=1` outlines every laid-out node (color = tree

--- a/examples/form.jsx
+++ b/examples/form.jsx
@@ -1,0 +1,108 @@
+// A small form: <textinput> + the <Select> widget component (dropdown built
+// on <popup>), submit via Enter or button, result styled by the selections.
+// Run with: npm run examples:form  (needs an X server / DISPLAY)
+import React, { useState } from 'react';
+import { createRoot, Select } from '../src/index.js';
+
+const COLORS = [
+  { value: '#2980b9', label: 'Blue' },
+  { value: '#c0392b', label: 'Red' },
+  { value: '#27ae60', label: 'Green' },
+  { value: '#8e44ad', label: 'Purple' },
+];
+
+const SIZES = [
+  { value: 14, label: 'Small' },
+  { value: 20, label: 'Medium' },
+  { value: 28, label: 'Large' },
+];
+
+function Button({ label, onPress }) {
+  const [hover, setHover] = useState(false);
+  return (
+    <box
+      focusable
+      cursor="pointer"
+      padding={8}
+      paddingLeft={16}
+      paddingRight={16}
+      borderRadius={4}
+      backgroundColor={hover ? '#1f6693' : '#2980b9'}
+      alignItems="center"
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      onClick={onPress}
+      onKeyDown={(ev) => {
+        if (ev.codepoint === 32 || ev.keysym === 0xff0d) onPress();
+      }}
+    >
+      <text color="white">{label}</text>
+    </box>
+  );
+}
+
+function App() {
+  const [name, setName] = useState('');
+  const [color, setColor] = useState('#2980b9');
+  const [size, setSize] = useState(20);
+  const [greeting, setGreeting] = useState(null);
+
+  const submit = () =>
+    setGreeting({ name: name.trim() || 'stranger', color, size });
+
+  return (
+    <window width={400} height={320} title="form" backgroundColor="#f5f6fa">
+      <box flexGrow={1} padding={16} gap={12}>
+        <text fontSize={20} color="#2d3436">
+          Sign the guestbook
+        </text>
+
+        <textinput
+          value={name}
+          placeholder="Your name"
+          onChange={setName}
+          onSubmit={submit}
+          padding={8}
+          borderRadius={4}
+          borderWidth={1}
+          borderColor="#b2bec3"
+          backgroundColor="white"
+        />
+
+        <box flexDirection="row" gap={12}>
+          <Select
+            flexGrow={1}
+            options={COLORS}
+            value={color}
+            onChange={setColor}
+          />
+          <Select
+            flexGrow={1}
+            options={SIZES}
+            value={size}
+            onChange={setSize}
+          />
+        </box>
+
+        <box flexDirection="row">
+          <Button label="Sign" onPress={submit} />
+        </box>
+
+        <box flexGrow={1} justifyContent="center" alignItems="center">
+          {greeting && (
+            <text fontSize={greeting.size} color={greeting.color}>
+              Hello, {greeting.name}!
+            </text>
+          )}
+        </box>
+      </box>
+    </window>
+  );
+}
+
+export default App;
+
+if (!process.env.REACT_X11_NO_AUTORUN) {
+  const root = await createRoot();
+  root.render(<App />);
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "examples:xeyes": "tsx examples/xeyes.jsx",
     "examples:dashboard": "tsx examples/dashboard.jsx",
     "examples:tasks": "tsx examples/tasks.jsx",
-    "examples:menu": "tsx examples/menu.jsx"
+    "examples:menu": "tsx examples/menu.jsx",
+    "examples:form": "tsx examples/form.jsx"
   },
   "repository": {
     "type": "git",

--- a/src/components.js
+++ b/src/components.js
@@ -1,0 +1,189 @@
+// Widget components built purely on the host primitives — no reconciler
+// support needed. Plain createElement (no JSX) so the library stays
+// build-step-free for consumers.
+import React, { useContext, useRef, useState } from 'react';
+
+const h = React.createElement;
+
+const ITEM_HEIGHT = 28;
+const MAX_MENU_HEIGHT = 220;
+
+const SelectTheme = {
+  border: '#b2bec3',
+  borderActive: '#2980b9',
+  background: 'white',
+  text: '#2d3436',
+  dim: '#7f8c8d',
+  hoverBackground: '#2980b9',
+  hoverText: 'white',
+};
+
+const SelectThemeContext = React.createContext(SelectTheme);
+export const SelectThemeProvider = SelectThemeContext.Provider;
+
+function normalizeOption(option) {
+  return typeof option === 'object' && option !== null
+    ? option
+    : { value: option, label: String(option) };
+}
+
+function Option({ option, selected, onPick }) {
+  const theme = useContext(SelectThemeContext);
+  const [hover, setHover] = useState(false);
+  return h(
+    'box',
+    {
+      height: ITEM_HEIGHT,
+      justifyContent: 'center',
+      paddingLeft: 10,
+      cursor: 'pointer',
+      backgroundColor: hover ? theme.hoverBackground : theme.background,
+      onMouseEnter: () => setHover(true),
+      onMouseLeave: () => setHover(false),
+      onClick: () => onPick(option),
+    },
+    h(
+      'text',
+      {
+        color: hover ? theme.hoverText : theme.text,
+        fontWeight: selected ? 'bold' : 'normal',
+      },
+      option.label,
+    ),
+  );
+}
+
+/**
+ * <Select value options onChange placeholder width …boxProps> — a dropdown
+ * built on <popup>. The menu is a real override-redirect X11 window
+ * anchored below the trigger (owner window position + trigger rect).
+ * Closes on pick, Escape, toggling the trigger, or focus loss within the
+ * owner window.
+ */
+export function Select({
+  value,
+  options = [],
+  onChange,
+  placeholder = 'Select…',
+  width,
+  ...boxProps
+}) {
+  const theme = useContext(SelectThemeContext);
+  const [open, setOpen] = useState(false);
+  const [anchor, setAnchor] = useState(null);
+  const [focused, setFocused] = useState(false);
+  const triggerRef = useRef(null);
+
+  const normalized = options.map(normalizeOption);
+  const current = normalized.find((o) => o.value === value);
+
+  const close = () => setOpen(false);
+  const toggle = () => {
+    if (open) {
+      close();
+      return;
+    }
+    const node = triggerRef.current;
+    if (!node) return;
+    const win = node.root?.window;
+    setAnchor({
+      x: (win?.x ?? 0) + node.abs.x,
+      y: (win?.y ?? 0) + node.abs.y + node.abs.height + 2,
+      width: node.abs.width,
+    });
+    setOpen(true);
+  };
+
+  const pick = (option) => {
+    close();
+    if (option.value !== value) onChange?.(option.value);
+  };
+
+  const menuHeight = Math.min(
+    normalized.length * ITEM_HEIGHT + 8,
+    MAX_MENU_HEIGHT,
+  );
+
+  return h(
+    'box',
+    {
+      ref: triggerRef,
+      focusable: true,
+      cursor: 'pointer',
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 8,
+      width,
+      padding: 8,
+      paddingLeft: 10,
+      paddingRight: 10,
+      borderWidth: 1,
+      borderRadius: 4,
+      borderColor: focused || open ? theme.borderActive : theme.border,
+      backgroundColor: theme.background,
+      onClick: toggle,
+      onFocus: () => setFocused(true),
+      onBlur: () => {
+        setFocused(false);
+        close();
+      },
+      onKeyDown: (ev) => {
+        if (ev.keysym === 0xff1b /* Escape */) close();
+        if (ev.codepoint === 32 || ev.keysym === 0xff0d) toggle();
+      },
+      ...boxProps,
+    },
+    h(
+      'text',
+      { color: current ? theme.text : theme.dim },
+      current ? current.label : placeholder,
+    ),
+    h('box', { flexGrow: 1 }),
+    h('canvas', {
+      width: 10,
+      height: 6,
+      onDraw: (ctx, { width: w, height: hgt }) => {
+        ctx.fillStyle = theme.dim;
+        ctx.beginPath();
+        ctx.moveTo(0, 0);
+        ctx.lineTo(w, 0);
+        ctx.lineTo(w / 2, hgt);
+        ctx.closePath();
+        ctx.fill();
+      },
+    }),
+    open &&
+      anchor &&
+      h(
+        'popup',
+        {
+          x: anchor.x,
+          y: anchor.y,
+          width: anchor.width,
+          height: menuHeight + 2,
+          backgroundColor: theme.background,
+        },
+        h(
+          'box',
+          {
+            flexGrow: 1,
+            borderWidth: 1,
+            borderColor: theme.border,
+            backgroundColor: theme.background,
+          },
+          h(
+            'scrollview',
+            { flexGrow: 1, padding: 4 },
+            normalized.map((option) =>
+              h(Option, {
+                key: String(option.value),
+                option,
+                selected: option.value === value,
+                onPick: pick,
+              }),
+            ),
+          ),
+        ),
+      ),
+  );
+}

--- a/src/events.js
+++ b/src/events.js
@@ -17,6 +17,22 @@ export class EventManager {
     this.hoverPath = [];
     this.downNode = null;
     this.focused = null;
+    this._lastClick = { time: 0, x: 0, y: 0, detail: 0 };
+  }
+
+  /** DOM-style click counting: repeated presses within 400ms / 4px bump
+   * `detail` (2 = double click, 3 = triple …). */
+  _clickDetail(native) {
+    const now = Date.now();
+    const last = this._lastClick;
+    const detail =
+      now - last.time < 400 &&
+      Math.abs(native.x - last.x) <= 4 &&
+      Math.abs(native.y - last.y) <= 4
+        ? last.detail + 1
+        : 1;
+    this._lastClick = { time: now, x: native.x, y: native.y, detail };
+    return detail;
   }
 
   attach() {
@@ -133,6 +149,7 @@ export class EventManager {
       this.focus(focusable ?? null);
       const ev = this.dispatch('MouseDown', target, native, {
         button: native.keycode,
+        detail: this._clickDetail(native),
       });
       if (!ev.defaultPrevented) {
         target._defaultMouseDown?.(ev);

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ export {
   unmountComponentAtNode,
   Renderer,
 } from './Reconciler.js';
+export { Select, SelectThemeProvider } from './components.js';
 
 import { render, createRoot, unmountComponentAtNode } from './Reconciler.js';
 

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -847,6 +847,20 @@ export class TextInputNode extends Node {
     return chars.length;
   }
 
+  /** Word range around a code-point index (whitespace-delimited). */
+  _wordRangeAt(index) {
+    const chars = this._chars();
+    if (chars.length === 0) return [0, 0];
+    let i = Math.min(index, chars.length - 1);
+    const isSpace = (c) => /\s/.test(c);
+    if (isSpace(chars[i]) && i > 0) i--;
+    let a = i;
+    let b = i;
+    while (a > 0 && !isSpace(chars[a - 1])) a--;
+    while (b < chars.length && !isSpace(chars[b])) b++;
+    return [a, b];
+  }
+
   _defaultMouseDown(ev) {
     if (ev.button === 2) {
       // X11 middle-click: paste the PRIMARY selection at the click position
@@ -857,10 +871,28 @@ export class TextInputNode extends Node {
       return;
     }
     const i = this._indexAtX(ev.x);
+    if (ev.detail >= 3) {
+      this._anchor = 0;
+      this._caret = this._chars().length;
+      this._ownSelection();
+      return;
+    }
+    if (ev.detail === 2) {
+      const [a, b] = this._wordRangeAt(i);
+      this._anchor = a;
+      this._caret = b;
+      this._ownSelection();
+      return;
+    }
     this._caret = i;
     this._anchor = i;
     this._dragging = true;
     this._repaint();
+  }
+
+  _ownSelection() {
+    this._repaint();
+    if (this._caret !== this._anchor) this._copySelection('PRIMARY');
   }
 
   _defaultMouseDrag(ev) {

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -50,6 +50,15 @@ function createMockApp() {
         setLineDash(segments) {
           ops.push(['setLineDash', segments]);
         },
+        moveTo(x, y) {
+          ops.push(['moveTo', x, y]);
+        },
+        lineTo(x, y) {
+          ops.push(['lineTo', x, y]);
+        },
+        closePath() {
+          ops.push(['closePath']);
+        },
         drawImage(...args) {
           ops.push(['drawImage']);
         },
@@ -695,6 +704,120 @@ test('dashed borders emit setLineDash when the context supports it', async () =>
   const dashOps = app.windows[0].ctx.ops.filter(([op]) => op === 'setLineDash');
   assert.deepStrictEqual(dashOps[0], ['setLineDash', [6, 4]]);
   assert.deepStrictEqual(dashOps.at(-1), ['setLineDash', []]);
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('textinput: double-click selects word, triple-click selects all', async () => {
+  const app = createMockApp();
+  app.clipboard = {
+    writes: [],
+    write(text, opts) {
+      this.writes.push([text, opts?.selection ?? 'CLIPBOARD']);
+      return Promise.resolve();
+    },
+    read() {
+      return Promise.resolve('');
+    },
+  };
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 200, height: 50 },
+      React.createElement('textinput', {
+        defaultValue: 'hello world',
+        flexGrow: 1,
+      }),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const input = wnd._reactX11Node.children[0];
+
+  const clickAt = (x, y) => {
+    wnd.emit('mousedown', { x, y, keycode: 1 });
+    wnd.emit('mouseup', { x, y, keycode: 1 });
+  };
+
+  clickAt(10, 10); // focus, detail 1
+  clickAt(10, 10); // detail 2 → word select
+  assert.deepStrictEqual(input._selection(), [6, 11]);
+  assert.deepStrictEqual(app.clipboard.writes.at(-1), ['world', 'PRIMARY']);
+
+  clickAt(10, 10); // detail 3 → select all
+  assert.deepStrictEqual(input._selection(), [0, 11]);
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('Select opens a popup menu, picks an option, closes on Escape', async () => {
+  const { Select } = await import('../src/index.js');
+  const app = createMockApp();
+  const picks = [];
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 240, height: 120 },
+      React.createElement(
+        'box',
+        { flexGrow: 1, padding: 10 },
+        React.createElement(Select, {
+          options: ['red', 'green', 'blue'],
+          value: null,
+          width: 160,
+          onChange: (v) => picks.push(v),
+        }),
+      ),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const windowNode = wnd._reactX11Node;
+
+  const findFocusable = (node) => {
+    if (node.props?.focusable) return node;
+    for (const child of node.children) {
+      if (child.isWindow) continue;
+      const hit = findFocusable(child);
+      if (hit) return hit;
+    }
+    return null;
+  };
+  const trigger = findFocusable(windowNode);
+  assert.ok(trigger, 'Select trigger should be focusable');
+  const cx = trigger.abs.x + 10;
+  const cy = trigger.abs.y + trigger.abs.height / 2;
+
+  wnd.emit('mousedown', { x: cx, y: cy, keycode: 1 });
+  wnd.emit('mouseup', { x: cx, y: cy, keycode: 1 });
+  await tick();
+
+  assert.strictEqual(app.windows.length, 2, 'menu popup window created');
+  const popup = app.windows[1];
+  assert.strictEqual(popup.attributes.overrideRedirect, true);
+  assert.strictEqual(popup.attributes.width, trigger.abs.width);
+  await tick();
+
+  // click the first option inside the popup's own window
+  popup.emit('mousedown', { x: 20, y: 19, keycode: 1 });
+  popup.emit('mouseup', { x: 20, y: 19, keycode: 1 });
+  await tick();
+  assert.deepStrictEqual(picks, ['red']);
+  assert.strictEqual(popup.destroyed, true, 'menu closes after picking');
+
+  // reopen (wait out the multi-click window), then Escape closes
+  await new Promise((resolve) => setTimeout(resolve, 450));
+  wnd.emit('mousedown', { x: cx, y: cy, keycode: 1 });
+  wnd.emit('mouseup', { x: cx, y: cy, keycode: 1 });
+  await tick();
+  assert.strictEqual(app.windows.length, 3, 'menu reopened');
+  pressKey(app, wnd, { keysym: 0xff1b }); // Escape
+  await tick();
+  assert.strictEqual(app.windows[2].destroyed, true);
 
   ReactX11.unmountComponentAtNode(app);
 });


### PR DESCRIPTION
First widget **component** on top of the primitives — no reconciler changes needed, validating the NEXT_STEPS claim that the widget library can be plain React.

## Select

`Select` (exported from the package root): a dropdown whose menu is a real override-redirect `<popup>` window anchored below the trigger (owner window position + trigger rect), with a scrollable option list (`<scrollview>`), hover/focus/selected states, keyboard support (Space/Enter toggles, Escape closes), close-on-blur/pick, and a themable appearance via `SelectThemeProvider`. The dropdown arrow is a tiny `<canvas>` triangle so it needs no font glyph.

## textinput polish

- `EventManager` now counts clicks DOM-style (400ms/4px) and attaches `detail` to MouseDown/Click.
- Double-click selects the word under the pointer; triple-click selects all — both take ownership of the X11 PRIMARY selection.

## Example

`examples/form.jsx` (`npm run examples:form`): `<textinput>` + two `Select`s + submit; the greeting renders in the chosen color and size.

## Screenshots (rendered by this PR's code)

`examples/form.jsx` driven through the real event path on the in-process X server: "Andrey" typed into the input, **Red** picked from the first Select's popup menu, form submitted — the greeting renders red at the chosen size:

<img width="400" height="320" alt="form" src="https://github.com/user-attachments/assets/968d02cf-2597-4d6a-9769-c00f033993db" />

The open Select menu — its own override-redirect X11 window, with the hover highlight from a synthetic mousemove:

<img width="167" height="122" alt="select-menu" src="https://github.com/user-attachments/assets/35681744-c596-4a69-865a-df06fae9ccc4" />

## Testing

26 hermetic tests (`npm test`, no $DISPLAY). New: Select popup lifecycle driven through **both** windows' event managers (trigger click in the owner window → popup created with the trigger's width and `overrideRedirect`; option click inside the popup window → `onChange` + close; Escape via the focused trigger → close), and double/triple-click selection incl. PRIMARY writes. Lint + prettier clean.