### PR TITLE
fix: textinput caret stuck when typing trailing spaces

### DIFF
--- a/src/nodes.js
+++ b/src/nodes.js
@@ -691,10 +691,36 @@ export class TextInputNode extends Node {
     return (this.props.fontSize ?? DEFAULT_TEXT_STYLE.size) * 1.4;
   }
 
+  /** Advance of a space in the current style. TextLayout strips trailing
+   * whitespace (correct for wrapped paragraphs), so caret math has to add
+   * it back explicitly. */
+  _spaceAdvance() {
+    const fonts = this.app?.fonts;
+    if (!fonts) return 0;
+    const s = this._textStyle();
+    const key = `${s.family}|${s.size}|${s.weight}|${s.style}`;
+    if (this._spaceAdvanceKey !== key) {
+      this._spaceAdvanceKey = key;
+      this._spaceAdvanceValue =
+        fonts.layout('x x', s).width - fonts.layout('xx', s).width;
+    }
+    return this._spaceAdvanceValue;
+  }
+
   _prefixWidth(count) {
     if (count <= 0) return 0;
-    const layout = this._layoutOf(this._chars().slice(0, count).join(''));
-    return layout ? layout.width : 0;
+    const prefix = this._chars().slice(0, count);
+    // trailing whitespace measures as zero in TextLayout — count it apart
+    let spaces = 0;
+    while (
+      spaces < prefix.length &&
+      /\s/.test(prefix[prefix.length - 1 - spaces])
+    ) {
+      spaces++;
+    }
+    const solid = prefix.slice(0, prefix.length - spaces).join('');
+    const layout = solid ? this._layoutOf(solid) : null;
+    return (layout ? layout.width : 0) + spaces * this._spaceAdvance();
   }
 
   _selection() {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -268,6 +268,51 @@ test('textinput renders its value through the ntk text stack', async () => {
   }
 });
 
+test('textinput caret advances past trailing spaces', async () => {
+  const { app } = await createHeadlessApp();
+  try {
+    const ref = React.createRef();
+    await render(
+      React.createElement(
+        'window',
+        { width: 200, height: 60 },
+        React.createElement('textinput', {
+          ref,
+          defaultValue: 'hi  x',
+          flexGrow: 1,
+        }),
+      ),
+      app,
+    );
+    const input = ref.current;
+
+    // TextLayout strips trailing whitespace, so prefix widths must add
+    // space advances back: each typed space moves the caret.
+    const w2 = input._prefixWidth(2); // "hi"
+    const w3 = input._prefixWidth(3); // "hi "
+    const w4 = input._prefixWidth(4); // "hi  "
+    const w5 = input._prefixWidth(5); // "hi  x"
+    assert.ok(w3 > w2, `caret must advance after a space (${w3} > ${w2})`);
+    assert.ok(w4 > w3, `and after a second space (${w4} > ${w3})`);
+    assert.ok(w5 > w4, `and after the next character (${w5} > ${w4})`);
+    // the explicit space advance should match real shaping: "hi  x" vs
+    // measured solid text should agree within a pixel
+    const full = app.fonts.layout('hi  x', {
+      family: 'sans-serif',
+      size: 14,
+    }).width;
+    assert.ok(
+      Math.abs(w5 - full) < 1.5,
+      `synthetic advance tracks shaping (${w5} vs ${full})`,
+    );
+
+    ReactX11.unmountComponentAtNode(app);
+    await settle(app);
+  } finally {
+    await app.close();
+  }
+});
+
 test('renders <text> through the ntk text stack', async () => {
   const { app } = await createHeadlessApp();
   try {


### PR DESCRIPTION
Pressing space in `<textinput>` did not move the caret

**Cause:** ntk's `TextLayout` strips trailing whitespace per line — correct for wrapped paragraph text, but caret positions here are computed as *width of the text before the caret*, so `"hello "` measured the same as `"hello"` and the caret stuck until the next non-space character. (Verified directly: `layout('hi ').width === layout('hi').width`.)

**Fix:** `_prefixWidth` measures the solid part of the prefix and adds explicit advances for the trailing whitespace run. The space advance is derived from shaping (`width('x x') − width('xx')`), cached per text style, so it stays correct across fonts/sizes/kerning. `_indexAtX` (click-to-caret) and selection rectangles go through the same helper, so they're fixed too.

**Test:** new integration test measures prefix widths of `"hi  x"` through the real text stack — each space must advance the caret — and asserts the synthetic advance agrees with fully-shaped text within 1.5px. 27/27 hermetic tests pass.
