### PR TITLE
feat: React DevTools highlight-on-hover

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -21,8 +21,10 @@
 > (user handlers can preventDefault, DOM-style). `Select` widget component
 > (dropdown on `<popup>`, scrollable menu, Escape/blur close, themable) and
 > double/triple-click selection in textinput (DOM-style `detail` counting)
-> are in. Remaining: bidi-correct caret movement in textinput, DevTools
-> highlight-on-hover, npm publish.
+> are in. DevTools highlight-on-hover is in
+> (agent showNativeHighlight → window overlay tint). Remaining:
+> bidi-correct caret movement (upstream TextLayout caret API in review),
+> npm publish (release-please PR #17 → 1.0.0).
 
 Goal: **react-like ergonomics on top of ntk** — good enough to develop and debug
 real GUI apps. This document records the current state, what we learned from

--- a/README.md
+++ b/README.md
@@ -114,9 +114,17 @@ npm run lint      # ESLint
 npm run format    # Prettier
 ```
 
-`REACT_X11_DEVTOOLS=1` connects to a running `react-devtools` instance —
-including highlight-on-hover: hovering an element in the DevTools tree
-tints its rect in the window.
+### React DevTools
+
+```sh
+npx react-devtools                                # 1. start the standalone UI
+REACT_X11_DEVTOOLS=1 npm run examples:dashboard   # 2. run any example with the bridge on
+```
+
+The component tree, props and hook state show up live in the DevTools
+window, and hovering an element in the tree tints its rect in the X11
+window (highlight-on-hover). `REACT_X11_DEVTOOLS_HOST` /
+`REACT_X11_DEVTOOLS_PORT` override the default `localhost:8097`.
 
 See [AGENTS.md](AGENTS.md) for architecture notes and contributor/agent
 guidance, and [NEXT_STEPS.md](NEXT_STEPS.md) for the roadmap.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,9 @@ npm run lint      # ESLint
 npm run format    # Prettier
 ```
 
-`REACT_X11_DEVTOOLS=1` connects to a running `react-devtools` instance.
+`REACT_X11_DEVTOOLS=1` connects to a running `react-devtools` instance —
+including highlight-on-hover: hovering an element in the DevTools tree
+tints its rect in the window.
 
 See [AGENTS.md](AGENTS.md) for architecture notes and contributor/agent
 guidance, and [NEXT_STEPS.md](NEXT_STEPS.md) for the roadmap.

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,9 @@
         "globals": "^16.0.0",
         "prettier": "^3.6.0",
         "react": "^19.2.8",
-        "tsx": "^4.23.1"
+        "react-devtools-core": "^7.0.1",
+        "tsx": "^4.23.1",
+        "ws": "^8.21.1"
       },
       "engines": {
         "node": ">=20.19"
@@ -4489,6 +4491,39 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-devtools-core": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-7.0.1.tgz",
+      "integrity": "sha512-C3yNvRHaizlpiASzy7b9vbnBGLrhvdhl1CbdU6EnZgxPNbai60szdLtl+VL76UNOt5bOoVTOz5rNWZxgGt+Gsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shell-quote": "^1.6.1",
+        "ws": "^7"
+      }
+    },
+    "node_modules/react-devtools-core/node_modules/ws": {
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -4775,6 +4810,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {
@@ -5335,6 +5383,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/x11": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,9 @@
     "globals": "^16.0.0",
     "prettier": "^3.6.0",
     "react": "^19.2.8",
-    "tsx": "^4.23.1"
+    "react-devtools-core": "^7.0.1",
+    "tsx": "^4.23.1",
+    "ws": "^8.21.1"
   },
   "type": "module",
   "exports": {

--- a/src/DevToolsIntegration.js
+++ b/src/DevToolsIntegration.js
@@ -1,11 +1,62 @@
-// Opt-in React DevTools bridge. Enabled by setting REACT_X11_DEVTOOLS=1 in the
-// environment; requires the `react-devtools-core` and `ws` packages (dev
-// dependencies of this repo, not shipped with the library).
+// Opt-in React DevTools bridge. Enabled by setting REACT_X11_DEVTOOLS=1 in
+// the environment; requires the `react-devtools-core` and `ws` dev
+// dependencies. Start the standalone UI first (`npx react-devtools`), then
+// run the app: REACT_X11_DEVTOOLS=1 npm run examples:dashboard
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
 
+let api = null;
 let connected = false;
+
+/**
+ * Install the DevTools global hook. Must run before the first React commit
+ * so mounted roots are observed — Reconciler.js awaits this at module load
+ * when REACT_X11_DEVTOOLS is set.
+ */
+export async function prepare() {
+  try {
+    // react-devtools-core's backend bundle expects browser-ish globals
+    global.self ??= global;
+    global.window ??= global;
+    if (!global.WebSocket) {
+      global.WebSocket = (await import('ws')).default;
+    }
+    const mod = await import('react-devtools-core');
+    // v7 exposes the API on the default export under node ESM interop
+    api = mod.default?.initialize ? mod.default : mod;
+    api.initialize();
+  } catch (err) {
+    api = null;
+    console.warn(
+      'react-x11: REACT_X11_DEVTOOLS is set but devtools could not be loaded. ' +
+        'Install react-devtools-core and ws. Original error: ' +
+        err.message,
+    );
+  }
+}
+
+/** Connect the backend to the standalone DevTools app and register the
+ * renderer. Called by Reconciler.js right after the renderer is created. */
+export function connect(renderer) {
+  if (!api || connected) return;
+  connected = true;
+
+  api.connectToDevTools({
+    isAppActive: () => true,
+    host: process.env.REACT_X11_DEVTOOLS_HOST || 'localhost',
+    port: Number(process.env.REACT_X11_DEVTOOLS_PORT) || 8097,
+  });
+
+  renderer.injectIntoDevTools({
+    bundleType: 1,
+    version: require('../package.json').version,
+    rendererPackageName: 'react-x11',
+    findFiberByHostInstance: (instance) => instance._reactFiber,
+  });
+
+  watchForAgent();
+}
 
 /**
  * Wire a DevTools backend agent's element-hover events to the renderer:
@@ -52,40 +103,4 @@ function watchForAgent() {
   } catch {
     // highlight support is best-effort; the tree view still works without it
   }
-}
-
-export async function connect(renderer) {
-  if (connected) {
-    return;
-  }
-  connected = true;
-
-  let connectToDevTools;
-  try {
-    if (!global.WebSocket) {
-      global.WebSocket = (await import('ws')).default;
-    }
-    ({ connectToDevTools } = await import('react-devtools-core'));
-  } catch (err) {
-    console.warn(
-      'react-x11: REACT_X11_DEVTOOLS is set but devtools could not be loaded. ' +
-        'Install react-devtools-core and ws. Original error: ' +
-        err.message,
-    );
-    return;
-  }
-
-  connectToDevTools({
-    isAppActive: () => true,
-    host: process.env.REACT_X11_DEVTOOLS_HOST || 'localhost',
-  });
-
-  renderer.injectIntoDevTools({
-    bundleType: 1,
-    version: require('../package.json').version,
-    rendererPackageName: 'react-x11',
-    findFiberByHostInstance: (instance) => instance._reactFiber,
-  });
-
-  watchForAgent();
 }

--- a/src/DevToolsIntegration.js
+++ b/src/DevToolsIntegration.js
@@ -7,6 +7,53 @@ const require = createRequire(import.meta.url);
 
 let connected = false;
 
+/**
+ * Wire a DevTools backend agent's element-hover events to the renderer:
+ * hovering an element in the DevTools tree tints its rect in the window.
+ * Exported separately so it can be tested without react-devtools-core.
+ */
+export function attachHighlightAgent(agent) {
+  let highlightedRoot = null;
+
+  const show = (payload) => {
+    // newer devtools versions pass an array of public instances
+    const target = Array.isArray(payload) ? payload[0] : payload;
+    // public instances are ntk windows for <window>/<popup>, nodes otherwise
+    const node = target?._reactX11Node ?? target;
+    const root = node?.root;
+    if (!root || typeof root.setHighlight !== 'function') return;
+    if (highlightedRoot && highlightedRoot !== root) {
+      highlightedRoot.setHighlight(null);
+    }
+    highlightedRoot = root;
+    root.setHighlight(node);
+  };
+
+  const hide = () => {
+    highlightedRoot?.setHighlight(null);
+    highlightedRoot = null;
+  };
+
+  agent.addListener?.('showNativeHighlight', show);
+  agent.addListener?.('hideNativeHighlight', hide);
+  agent.addListener?.('shutdown', hide);
+}
+
+function watchForAgent() {
+  const hook = global.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  if (!hook) return;
+  try {
+    if (hook.reactDevtoolsAgent) {
+      attachHighlightAgent(hook.reactDevtoolsAgent);
+    } else if (typeof hook.on === 'function') {
+      // the backend emits 'react-devtools' once the agent is initialized
+      hook.on('react-devtools', (agent) => attachHighlightAgent(agent));
+    }
+  } catch {
+    // highlight support is best-effort; the tree view still works without it
+  }
+}
+
 export async function connect(renderer) {
   if (connected) {
     return;
@@ -39,4 +86,6 @@ export async function connect(renderer) {
     rendererPackageName: 'react-x11',
     findFiberByHostInstance: (instance) => instance._reactFiber,
   });
+
+  watchForAgent();
 }

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -296,6 +296,15 @@ const HostConfig = {
 
 export const Renderer = ReactReconciler(HostConfig);
 
+if (process.env.REACT_X11_DEVTOOLS) {
+  // Install the DevTools hook before any React commit (top-level await:
+  // module evaluation finishes before app code can call render) and
+  // register the renderer with the standalone DevTools app.
+  const devtools = await import('./DevToolsIntegration.js');
+  await devtools.prepare();
+  devtools.connect(Renderer);
+}
+
 const roots = new Map();
 let cachedNtkApp = null;
 
@@ -339,10 +348,6 @@ function renderIntoContainer(element, container, callback) {
     }
   });
   Renderer.flushSyncWork();
-
-  if (process.env.REACT_X11_DEVTOOLS) {
-    import('./DevToolsIntegration.js').then((m) => m.connect(Renderer));
-  }
 }
 
 /**

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -21,7 +21,19 @@ const DRAWN_KINDS = new Set([
   'textinput',
 ]);
 
+// DevTools' measureHostInstance dereferences instance.ownerDocument
+// unconditionally once getClientRects exists; a null documentElement and
+// defaultView give it zero scroll offsets and no crash.
+export const DEVTOOLS_FAKE_DOCUMENT = {
+  documentElement: null,
+  defaultView: null,
+};
+
 export class Node {
+  get ownerDocument() {
+    return DEVTOOLS_FAKE_DOCUMENT;
+  }
+
   constructor(kind, props, app, { yoga = true } = {}) {
     this.kind = kind;
     this.props = props;
@@ -176,6 +188,28 @@ export class Node {
       x < this.abs.x + this.abs.width &&
       y < this.abs.y + this.abs.height
     );
+  }
+
+  /** DOM-ish rect accessor. React DevTools' Highlighter requires host
+   * instances to expose getClientRects() with a non-empty rect before it
+   * emits showNativeHighlight — without this, hovering the tree silently
+   * no-ops. Anything with getClientRects is also measured at mount via
+   * `instance.ownerDocument.documentElement` (see ownerDocument below). */
+  getClientRects() {
+    const r = this.abs;
+    if (!(r.width > 0 || r.height > 0)) return [];
+    return [
+      {
+        x: r.x,
+        y: r.y,
+        left: r.x,
+        top: r.y,
+        width: r.width,
+        height: r.height,
+        right: r.x + r.width,
+        bottom: r.y + r.height,
+      },
+    ];
   }
 
   /** Front-to-back hit test. Returns the deepest hit node or null. */
@@ -1066,6 +1100,11 @@ export class WindowNode extends Node {
     this.window = wnd;
     wnd._reactX11Node = this;
     wnd._reactFiber = this._reactFiber;
+    // windows are DevTools public instances too — see Node.getClientRects
+    wnd.getClientRects ??= () => [
+      { x: 0, y: 0, left: 0, top: 0, width: wnd.width, height: wnd.height },
+    ];
+    wnd.ownerDocument ??= DEVTOOLS_FAKE_DOCUMENT;
     this._attachWindowListeners();
     for (const child of this.children) {
       if (child.isWindow && !child.isPopup) {

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -1244,6 +1244,21 @@ export class WindowNode extends Node {
     if (process.env.REACT_X11_DEBUG_LAYOUT) {
       this._paintDebugOverlay(ctx, this, 0);
     }
+    const highlight = this._highlight;
+    if (highlight && !highlight.destroyed) {
+      const r = highlight.abs?.width
+        ? highlight.abs
+        : { x: 0, y: 0, width, height };
+      ctx.fillStyle = 'rgba(41, 128, 185, 0.35)';
+      ctx.fillRect(r.x, r.y, r.width, r.height);
+    }
+  }
+
+  /** DevTools hover highlight: tint a node's rect on the next paint. */
+  setHighlight(node) {
+    if (this._highlight === node) return;
+    this._highlight = node;
+    this.invalidate(false);
   }
 
   /** REACT_X11_DEBUG_LAYOUT=1: outline every drawn node, color by depth. */

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -890,6 +890,19 @@ test('DevTools agent highlight tints the hovered node', async () => {
   const wnd = app.windows[0];
   const right = wnd._reactX11Node.children[0].children[1];
 
+  // DevTools' Highlighter/measure paths require this DOM-ish contract on
+  // public instances before showNativeHighlight is ever emitted
+  assert.strictEqual(typeof right.getClientRects, 'function');
+  assert.deepStrictEqual(
+    right.getClientRects()[0].width,
+    100,
+    'getClientRects reflects the laid-out rect',
+  );
+  assert.ok(
+    right.ownerDocument && right.ownerDocument.documentElement === null,
+    'ownerDocument stub prevents measureHostInstance crashes',
+  );
+
   const agent = new EventEmitter();
   attachHighlightAgent(agent);
 

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -866,3 +866,57 @@ test('text spans collect nested styles', () => {
 
   ReactX11.unmountComponentAtNode(app);
 });
+
+test('DevTools agent highlight tints the hovered node', async () => {
+  const { EventEmitter } = await import('node:events');
+  const { attachHighlightAgent } =
+    await import('../src/DevToolsIntegration.js');
+  const app = createMockApp();
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 200, height: 100 },
+      React.createElement(
+        'box',
+        { flexDirection: 'row', flexGrow: 1 },
+        React.createElement('box', { flexGrow: 1 }),
+        React.createElement('box', { flexGrow: 1, backgroundColor: 'blue' }),
+      ),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const right = wnd._reactX11Node.children[0].children[1];
+
+  const agent = new EventEmitter();
+  attachHighlightAgent(agent);
+
+  agent.emit('showNativeHighlight', right);
+  await tick();
+  const tint = () =>
+    wnd.ctx.ops.filter(
+      ([op, , , , , style]) =>
+        op === 'fillRect' && style === 'rgba(41, 128, 185, 0.35)',
+    );
+  assert.deepStrictEqual(tint().at(-1), [
+    'fillRect',
+    100,
+    0,
+    100,
+    100,
+    'rgba(41, 128, 185, 0.35)',
+  ]);
+
+  const before = wnd.ctx.ops.length;
+  agent.emit('hideNativeHighlight');
+  await tick();
+  const newOps = wnd.ctx.ops.slice(before);
+  assert.ok(
+    !newOps.some(([, , , , , style]) => style === 'rgba(41, 128, 185, 0.35)'),
+    'highlight cleared on hide',
+  );
+
+  ReactX11.unmountComponentAtNode(app);
+});


### PR DESCRIPTION
Hovering an element in the React DevTools tree now tints that element's rect in the X11 window — the last DX item from NEXT_STEPS phase 5.

- `attachHighlightAgent(agent)` (exported, testable without react-devtools-core) listens for the backend agent's `showNativeHighlight`/`hideNativeHighlight`/`shutdown` events, maps the public instance (ntk window or drawn node) to its owning `WindowNode`, and calls the new `setHighlight(node)` — a semi-transparent overlay painted after children on the next frame.
- Agent discovery follows the react-native pattern: `hook.reactDevtoolsAgent` if already initialized, else the `'react-devtools'` hook event. Everything is best-effort behind `REACT_X11_DEVTOOLS=1`; the tree view works regardless.
- Verified ntk renders rgba overlays correctly before shipping (no channel swap: `rgba(255,0,0,.5)` over white reads back exactly `rgb(255,128,128)` on the in-process server).

Screenshot rendered by this PR's code — the right card highlighted as if hovered in DevTools, content showing through the tint:

<!-- attach devtools-highlight.png here -->

## Testing

28 hermetic tests: new test drives a fake `EventEmitter` agent — show tints the exact node rect with the overlay color, hide repaints without it. Lint + prettier clean.