### PR TITLE
feat: rich-content elements <markdown>, <html>, <svg>, <tex>

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,8 +34,8 @@ no override-redirect staging (issue #4).
 - `src/richnodes.js` — rich-content elements (`<markdown>`, `<html>`,
   `<svg>`, `<tex>`) wrapping ntk's document widgets in standalone mode:
   the widget's `layout(width)`/`contentHeight` feeds a yoga measure
-  function, `draw(ctx, x, y)` paints, `onInvalidate` (ntk > 3.3.0,
-  sidorares/ntk#75) reflows on async content (mermaid, images).
+  function, `draw(ctx, x, y)` paints, `onInvalidate` (ntk ≥ 3.4.0)
+  reflows on async content (mermaid, images).
 - `src/styles.js` — flat style props → yoga setters; paint prop
   classification; text style resolution.
 - `src/events.js` — `EventManager`: ntk window events → synthetic events
@@ -63,7 +63,7 @@ no override-redirect staging (issue #4).
 - The package is **ESM** (`"type": "module"`). ntk is ESM with top-level
   await in its graph; yoga-layout is ESM WASM. Everything imports statically
   now (no `require`).
-- ntk >= 3.3.0 comes from npm. Yoga is imported **from ntk**, so renderer
+- ntk >= 3.4.0 comes from npm. Yoga is imported **from ntk**, so renderer
   and ntk widgets share one WASM instance — do not add a direct
   yoga-layout dependency. `<textinput>` caret math uses ntk 3.3.0's
   `TextLayout.caretPosition`/`indexAt`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,11 @@ no override-redirect staging (issue #4).
 - `src/nodes.js` — the retained node tree: `WindowNode` (real X window,
   paint/event/flex root), `BoxNode`, `TextNode` (+ spans/chunks),
   `ImageNode`, `CanvasNode`. Layout (yoga), painting, hit testing.
+- `src/richnodes.js` — rich-content elements (`<markdown>`, `<html>`,
+  `<svg>`, `<tex>`) wrapping ntk's document widgets in standalone mode:
+  the widget's `layout(width)`/`contentHeight` feeds a yoga measure
+  function, `draw(ctx, x, y)` paints, `onInvalidate` (ntk > 3.3.0,
+  sidorares/ntk#75) reflows on async content (mermaid, images).
 - `src/styles.js` — flat style props → yoga setters; paint prop
   classification; text style resolution.
 - `src/events.js` — `EventManager`: ntk window events → synthetic events

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -18,29 +18,22 @@
 
 ## Roadmap refresh — what's missing now (for the next session)
 
-### 1. Expose ntk's rich-content widgets as elements
+### 1. Expose ntk's rich-content widgets as elements — DONE
 
-ntk ships document viewers with a standalone mode
-(`layout(width)` + `draw(ctx, x, y)` + `contentHeight` + `onInvalidate`)
-that slots directly into a yoga measure function + `_paintContent`. One
-generic `NtkViewNode` base can wrap them all:
+Shipped in `src/richnodes.js` (branch `feat/rich-content`): `<markdown>`,
+`<html>`, `<svg>`, `<tex>` wrap the ntk document widgets in standalone
+mode — `layout(width)`/`contentHeight` feed a yoga measure function,
+`draw(ctx, x, y)` paints into the window context, `linkAt` is wired into
+the mousedown default action (`onLink` prop), and `<scrollview>` wrapping
+works via the normal measured-height path. Async content (mermaid models,
+HTML images) reflows through the widgets' `onInvalidate` hook — filed and
+implemented upstream as sidorares/ntk#75 (needs the next ntk release;
+static content works on 3.3.0). `<mermaid>` needs no dedicated element
+(markdown fences cover it); `<paragraph>` stays out (see below —
+maxLines/ellipsis would be a TextLayout feature first).
 
-- `<markdown source>` — MarkdownView (incl. code fences, tables, math,
-  async mermaid via `onInvalidate` → `root.invalidate(true)`)
-- `<html source stylesheet onLink>` — HtmlView (its own CSS cascade; also
-  gives us `linkAt` for click handling)
-- `<svg source>` — SvgView
-- `<tex source displayMode>` — TexView
-- `<mermaid source>` — via MarkdownView's mermaid path or `layoutMermaid`
-- `<paragraph>` — NOT needed as a new element: `<text>` already does
-  multi-span shaped paragraphs; consider instead exposing `TextLayout`
-  options we don't surface yet (maxLines/ellipsis would need ntk support).
-- image and canvas2d already exist as `<image>` / `<canvas>`.
-
-Interaction questions to solve: scrolling (wrap in `<scrollview>` — needs
-measure-height plumbing), link clicks (HtmlView/MarkdownView `linkAt(x,y)`
-→ wire into the hit-test/default-action path), invalidation for async
-content (mermaid), and resource loading (`loadResource`/`baseUrl` props).
+Left for later: per-link pointer cursor (cursor is per-node today),
+`<tex>` baseline alignment with surrounding `<text>`.
 
 ### 2. Standard UI components (plain React, like `Select`)
 

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -26,9 +26,9 @@ mode — `layout(width)`/`contentHeight` feed a yoga measure function,
 `draw(ctx, x, y)` paints into the window context, `linkAt` is wired into
 the mousedown default action (`onLink` prop), and `<scrollview>` wrapping
 works via the normal measured-height path. Async content (mermaid models,
-HTML images) reflows through the widgets' `onInvalidate` hook — filed and
-implemented upstream as sidorares/ntk#75 (needs the next ntk release;
-static content works on 3.3.0). `<mermaid>` needs no dedicated element
+HTML images) reflows through the widgets' `onInvalidate` hook —
+implemented upstream as sidorares/ntk#75, released in **ntk 3.4.0**
+(the dependency is bumped). `<mermaid>` needs no dedicated element
 (markdown fences cover it); `<paragraph>` stays out (see below —
 maxLines/ellipsis would be a TextLayout feature first).
 

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -18,9 +18,9 @@
 
 ## Roadmap refresh — what's missing now (for the next session)
 
-### 1. Expose ntk's rich-content widgets as elements — DONE
+### 1. Expose ntk's rich-content widgets as elements — DONE (PR #27)
 
-Shipped in `src/richnodes.js` (branch `feat/rich-content`): `<markdown>`,
+Shipped in `src/richnodes.js`: `<markdown>`,
 `<html>`, `<svg>`, `<tex>` wrap the ntk document widgets in standalone
 mode — `layout(width)`/`contentHeight` feed a yoga measure function,
 `draw(ctx, x, y)` paints into the window context, `linkAt` is wired into

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ and [docs/](docs/README.md) for the full API reference.
 | `<textinput>`  | single-line editor: caret/selection via ntk's TextLayout caret API, clipboard (CLIPBOARD + X11 PRIMARY), word select |
 | `<image>`      | PNG/JPEG from `src`, natural-size aware                                                                              |
 | `<canvas>`     | escape hatch: `onDraw={(ctx, {width, height}) => …}` with ntk's canvas-like 2d context (XRender-backed)              |
+| `<markdown>`   | ntk MarkdownView: headings, tables, highlighted fences, math, mermaid; `onLink`                                      |
+| `<html>`       | ntk HtmlView: CSS cascade, block/flex layout, images; `onLink`                                                       |
+| `<svg>`        | static SVG through ntk SvgView, sized like `<image>`                                                                 |
+| `<tex>`        | a KaTeX formula (ntk `layoutTex`), intrinsically sized                                                               |
 
 Widget **components** (plain React on top of the primitives): `Select` — a
 dropdown built on `<popup>`, themable via `SelectThemeProvider`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,6 +2,7 @@
 
 - [elements.md](elements.md) — the host elements: `<window>`, `<popup>`,
   `<box>`, `<scrollview>`, `<text>`, `<textinput>`, `<image>`, `<canvas>`,
+  and the rich-content wrappers `<markdown>`, `<html>`, `<svg>`, `<tex>`,
   their props and refs.
 - [components.md](components.md) — widget components built on the
   primitives: `Select`.

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -153,3 +153,68 @@ The escape hatch: a retained node whose content you paint.
 conical, `setLineDash`, round caps/joins, images, text — XRender-backed),
 translated to the node's origin and clipped to its bounds. `onDraw` runs on
 every repaint of the window.
+
+---
+
+## Rich content
+
+Thin wrappers over ntk's document widgets in standalone mode. The widget's
+own layout feeds a yoga measure function: given the width the flexbox
+offers, the element reports the document's content height — so rich content
+participates in flex layout and scrolls naturally inside a `<scrollview>`.
+Spacing comes from the box model (`padding` prop), not a widget page margin.
+
+Async content (a ` ```mermaid ` fence, an `<img>`) needs ntk > 3.3.0's
+`onInvalidate` widget hook to trigger a reflow when it arrives
+([sidorares/ntk#75](https://github.com/sidorares/ntk/pull/75)); everything
+static works on 3.3.0.
+
+### `<markdown>`
+
+ntk `MarkdownView`: headings, emphasis, lists, quotes, tables,
+syntax-highlighted code fences, `math`/`latex` fences (KaTeX), `mermaid`
+fences (flowchart/sequence, async).
+
+| prop               |                                                                                 |
+| ------------------ | ------------------------------------------------------------------------------- |
+| `source`           | markdown text                                                                   |
+| `onLink(href, ev)` | a rendered link was clicked                                                     |
+| `theme`            | MarkdownView theme overrides (`{size, color, family, linkColor, codeTheme, …}`) |
+
+### `<html>`
+
+ntk `HtmlView`: its own CSS cascade (document `<style>`s plus the
+`stylesheet` prop), block/flex layout, images.
+
+| prop                           |                                               |
+| ------------------------------ | --------------------------------------------- |
+| `source`                       | HTML document or fragment                     |
+| `stylesheet`                   | extra author CSS (string or array)            |
+| `baseUrl`                      | resolve relative image `src` against this     |
+| `loadResource(url, {element})` | custom resource loader (or `null` to disable) |
+| `onLink(href, ev, element)`    | a link was clicked                            |
+| `theme`                        | base look (`{family, size, color}`)           |
+
+### `<svg>`
+
+ntk `SvgView` (static SVG via Path2D — paths, shapes, gradients,
+transforms, basic text). Sized like `<image>`: natural `viewBox` size,
+aspect-preserving shrink-to-width, or explicit `width`/`height` (the
+drawing scales to the content box).
+
+| prop     |            |
+| -------- | ---------- |
+| `source` | SVG markup |
+
+### `<tex>`
+
+A KaTeX formula via ntk `layoutTex` — an intrinsically-sized box (no
+wrapping), drawn as server-side glyphs/rects.
+
+| prop          |                                         |
+| ------------- | --------------------------------------- |
+| `source`      | TeX source                              |
+| `size`        | base font size (the formula em), px     |
+| `color`       | ink color (default `#222222`)           |
+| `displayMode` | KaTeX display mode (default `false`)    |
+| `katex`       | extra KaTeX options (macros, strict, …) |

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -168,6 +168,19 @@ Async content (a ` ```mermaid ` fence, an `<img>`) reflows when it
 arrives via ntk's `onInvalidate` widget hook (ntk ≥ 3.4.0 — the declared
 dependency).
 
+`<markdown>`, `<html>` and `<tex>` take their content as a **string
+child** (the react-markdown convention) or a `source` prop; the child
+wins when both are present. Use a template-literal expression — JSX
+collapses newlines in literal text:
+
+```jsx
+<markdown onLink={open}>{`
+# Hi
+
+Some *markdown*.
+`}</markdown>
+```
+
 ### `<markdown>`
 
 ntk `MarkdownView`: headings, emphasis, lists, quotes, tables,
@@ -176,6 +189,7 @@ fences (flowchart/sequence, async).
 
 | prop               |                                                                                 |
 | ------------------ | ------------------------------------------------------------------------------- |
+| children           | markdown text (string), or use `source`                                         |
 | `source`           | markdown text                                                                   |
 | `onLink(href, ev)` | a rendered link was clicked                                                     |
 | `theme`            | MarkdownView theme overrides (`{size, color, family, linkColor, codeTheme, …}`) |
@@ -187,6 +201,7 @@ ntk `HtmlView`: its own CSS cascade (document `<style>`s plus the
 
 | prop                           |                                               |
 | ------------------------------ | --------------------------------------------- |
+| children                       | HTML markup (string), or use `source`         |
 | `source`                       | HTML document or fragment                     |
 | `stylesheet`                   | extra author CSS (string or array)            |
 | `baseUrl`                      | resolve relative image `src` against this     |
@@ -201,9 +216,28 @@ transforms, basic text). Sized like `<image>`: natural `viewBox` size,
 aspect-preserving shrink-to-width, or explicit `width`/`height` (the
 drawing scales to the content box).
 
-| prop     |            |
-| -------- | ---------- |
-| `source` | SVG markup |
+Content is **JSX children, like SVG in React DOM** — SVG elements are
+declarative children with camelCase props (`strokeWidth`, `fillRule`;
+native-camelCase attributes like `viewBox` stay as-is), re-rendered on
+any prop change:
+
+```jsx
+<svg viewBox="0 0 24 24" width={40} height={40}>
+  <circle cx={12} cy={12} r={10} fill={active ? '#2980b9' : '#ccc'} />
+  <path d="M8 12l3 3 5-6" stroke="white" strokeWidth={2} fill="none" />
+</svg>
+```
+
+A `source` markup string is also accepted (children win when both are
+present). Supported elements/attributes are SvgView's (unsupported tags
+are skipped); per-child event handlers are not dispatched — put handlers
+on the `<svg>` element itself.
+
+| prop      |                                   |
+| --------- | --------------------------------- |
+| children  | declarative SVG elements          |
+| `source`  | SVG markup string                 |
+| `viewBox` | coordinate system (children form) |
 
 ### `<tex>`
 
@@ -212,6 +246,7 @@ wrapping), drawn as server-side glyphs/rects.
 
 | prop          |                                         |
 | ------------- | --------------------------------------- |
+| children      | TeX source (string), or use `source`    |
 | `source`      | TeX source                              |
 | `size`        | base font size (the formula em), px     |
 | `color`       | ink color (default `#222222`)           |

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -164,10 +164,9 @@ offers, the element reports the document's content height — so rich content
 participates in flex layout and scrolls naturally inside a `<scrollview>`.
 Spacing comes from the box model (`padding` prop), not a widget page margin.
 
-Async content (a ` ```mermaid ` fence, an `<img>`) needs ntk > 3.3.0's
-`onInvalidate` widget hook to trigger a reflow when it arrives
-([sidorares/ntk#75](https://github.com/sidorares/ntk/pull/75)); everything
-static works on 3.3.0.
+Async content (a ` ```mermaid ` fence, an `<img>`) reflows when it
+arrives via ntk's `onInvalidate` widget hook (ntk ≥ 3.4.0 — the declared
+dependency).
 
 ### `<markdown>`
 

--- a/examples/richtext.jsx
+++ b/examples/richtext.jsx
@@ -1,21 +1,21 @@
 // Rich content elements: <markdown> (with mermaid + math fences) in a
-// scrollview, a live-updating <tex> formula, and an inline <svg> — all
-// drawn client-side through ntk's document widgets.
+// scrollview, a live-updating <tex> formula, and a declarative JSX <svg>
+// — all drawn client-side through ntk's document widgets.
 // Run with: npm run examples:richtext  (needs an X server / DISPLAY)
 import React, { useState } from 'react';
 import { createRoot } from '../src/index.js';
 
 const MARKDOWN = `# react-x11 rich content
 
-Everything below is one \`<markdown source>\` element — ntk's
-**MarkdownView** wrapped in a yoga measure function, scrolling inside a
-\`<scrollview>\`.
+Everything below is one \`<markdown>\` element (content as a string
+child, react-markdown style) — ntk's **MarkdownView** wrapped in a yoga
+measure function, scrolling inside a \`<scrollview>\`.
 
 ## Code
 
 \`\`\`js
 const root = await createRoot();
-root.render(<markdown source={README} onLink={openBrowser} />);
+root.render(<markdown onLink={openBrowser}>{README}</markdown>);
 \`\`\`
 
 ## Math
@@ -49,13 +49,31 @@ Click [the ntk repository](https://github.com/sidorares/ntk) — links
 dispatch \`onLink\`.
 `;
 
-const LOGO = `<svg viewBox="0 0 24 24">
-  <circle cx="12" cy="12" r="10" fill="#61dafb" opacity="0.25"/>
-  <ellipse cx="12" cy="12" rx="10" ry="4" fill="none" stroke="#2980b9" stroke-width="1"/>
-  <ellipse cx="12" cy="12" rx="10" ry="4" fill="none" stroke="#2980b9" stroke-width="1" transform="rotate(60 12 12)"/>
-  <ellipse cx="12" cy="12" rx="10" ry="4" fill="none" stroke="#2980b9" stroke-width="1" transform="rotate(120 12 12)"/>
-  <circle cx="12" cy="12" r="2" fill="#c0392b"/>
-</svg>`;
+// Declarative SVG, like React DOM: elements as JSX children, camelCase
+// props, re-rendered on any prop/state change.
+function Logo({ spin }) {
+  const orbit = (angle) => (
+    <ellipse
+      cx={12}
+      cy={12}
+      rx={10}
+      ry={4}
+      fill="none"
+      stroke="#2980b9"
+      strokeWidth={1}
+      transform={`rotate(${angle + spin} 12 12)`}
+    />
+  );
+  return (
+    <svg viewBox="0 0 24 24" width={40} height={40}>
+      <circle cx={12} cy={12} r={10} fill="#61dafb" opacity={0.25} />
+      {orbit(0)}
+      {orbit(60)}
+      {orbit(120)}
+      <circle cx={12} cy={12} r={2} fill="#c0392b" />
+    </svg>
+  );
+}
 
 function App() {
   const [n, setN] = useState(2);
@@ -73,12 +91,10 @@ function App() {
         padding={12}
         backgroundColor="#f4f4f4"
       >
-        <svg source={LOGO} width={40} height={40} />
-        <tex
-          source={`e^{i\\pi} + 1 = 0 \\qquad x^{${n}}`}
-          size={26}
-          displayMode
-        />
+        <Logo spin={n * 15} />
+        <tex size={26} displayMode>
+          {`e^{i\\pi} + 1 = 0 \\qquad x^{${n}}`}
+        </tex>
         <box flexGrow={1} />
         <box
           backgroundColor="#3498db"
@@ -92,10 +108,11 @@ function App() {
       </box>
       <scrollview flexGrow={1}>
         <markdown
-          source={MARKDOWN}
           padding={16}
           onLink={(href) => console.log('link clicked:', href)}
-        />
+        >
+          {MARKDOWN}
+        </markdown>
       </scrollview>
     </window>
   );

--- a/examples/richtext.jsx
+++ b/examples/richtext.jsx
@@ -1,0 +1,105 @@
+// Rich content elements: <markdown> (with mermaid + math fences) in a
+// scrollview, a live-updating <tex> formula, and an inline <svg> — all
+// drawn client-side through ntk's document widgets.
+// Run with: npm run examples:richtext  (needs an X server / DISPLAY)
+import React, { useState } from 'react';
+import { createRoot } from '../src/index.js';
+
+const MARKDOWN = `# react-x11 rich content
+
+Everything below is one \`<markdown source>\` element — ntk's
+**MarkdownView** wrapped in a yoga measure function, scrolling inside a
+\`<scrollview>\`.
+
+## Code
+
+\`\`\`js
+const root = await createRoot();
+root.render(<markdown source={README} onLink={openBrowser} />);
+\`\`\`
+
+## Math
+
+\`\`\`math
+\\int_{-\\infty}^{\\infty} e^{-x^2}\\,dx = \\sqrt{\\pi}
+\`\`\`
+
+## Mermaid
+
+Parses asynchronously; the element reflows when the model arrives
+(ntk's \`onInvalidate\` hook):
+
+\`\`\`mermaid
+flowchart LR
+  A[React tree] --> B[retained nodes]
+  B --> C[yoga layout]
+  C --> D((XRender))
+\`\`\`
+
+## Tables & links
+
+| element      | widget       |
+| ------------ | ------------ |
+| \`<markdown>\` | MarkdownView |
+| \`<html>\`     | HtmlView     |
+| \`<svg>\`      | SvgView      |
+| \`<tex>\`      | layoutTex    |
+
+Click [the ntk repository](https://github.com/sidorares/ntk) — links
+dispatch \`onLink\`.
+`;
+
+const LOGO = `<svg viewBox="0 0 24 24">
+  <circle cx="12" cy="12" r="10" fill="#61dafb" opacity="0.25"/>
+  <ellipse cx="12" cy="12" rx="10" ry="4" fill="none" stroke="#2980b9" stroke-width="1"/>
+  <ellipse cx="12" cy="12" rx="10" ry="4" fill="none" stroke="#2980b9" stroke-width="1" transform="rotate(60 12 12)"/>
+  <ellipse cx="12" cy="12" rx="10" ry="4" fill="none" stroke="#2980b9" stroke-width="1" transform="rotate(120 12 12)"/>
+  <circle cx="12" cy="12" r="2" fill="#c0392b"/>
+</svg>`;
+
+function App() {
+  const [n, setN] = useState(2);
+  return (
+    <window
+      width={560}
+      height={640}
+      title="rich content"
+      backgroundColor="white"
+    >
+      <box
+        flexDirection="row"
+        alignItems="center"
+        gap={12}
+        padding={12}
+        backgroundColor="#f4f4f4"
+      >
+        <svg source={LOGO} width={40} height={40} />
+        <tex
+          source={`e^{i\\pi} + 1 = 0 \\qquad x^{${n}}`}
+          size={26}
+          displayMode
+        />
+        <box flexGrow={1} />
+        <box
+          backgroundColor="#3498db"
+          borderRadius={6}
+          padding={8}
+          cursor="pointer"
+          onClick={() => setN((v) => (v % 9) + 1)}
+        >
+          <text color="white">bump exponent</text>
+        </box>
+      </box>
+      <scrollview flexGrow={1}>
+        <markdown
+          source={MARKDOWN}
+          padding={16}
+          onLink={(href) => console.log('link clicked:', href)}
+        />
+      </scrollview>
+    </window>
+  );
+}
+
+const root = await createRoot();
+root.render(<App />);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^3.3.0",
+        "ntk": "^3.4.0",
         "react-reconciler": "^0.33.0"
       },
       "devDependencies": {
@@ -4071,9 +4071,9 @@
       }
     },
     "node_modules/ntk": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-3.3.0.tgz",
-      "integrity": "sha512-kzp0DV+x5wDqbgHjQhwdUrAuA+NflP6JRRE10mQldZmS4JX8SiIzU9OcfTIZ0OyG4Ven3BtsfCkUygGloBlCig==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-3.4.0.tgz",
+      "integrity": "sha512-wcreMQBVkwC58Ah520CTXplLt6MlR3SSFiBH5Mv6O6PikY15nQpyfSiuyxEM0lH0jbosGc4p0wO56aVD33gsLw==",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "examples:dashboard": "tsx examples/dashboard.jsx",
     "examples:tasks": "tsx examples/tasks.jsx",
     "examples:menu": "tsx examples/menu.jsx",
-    "examples:form": "tsx examples/form.jsx"
+    "examples:form": "tsx examples/form.jsx",
+    "examples:richtext": "tsx examples/richtext.jsx"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^3.3.0",
+    "ntk": "^3.4.0",
     "react-reconciler": "^0.33.0"
   },
   "peerDependencies": {

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -26,7 +26,13 @@ import {
   ScrollViewNode,
   TextInputNode,
 } from './nodes.js';
-import { MarkdownNode, HtmlNode, SvgNode, TexNode } from './richnodes.js';
+import {
+  MarkdownNode,
+  HtmlNode,
+  SvgNode,
+  SvgChildNode,
+  TexNode,
+} from './richnodes.js';
 
 const require = createRequire(import.meta.url);
 const packageJson = require('../package.json');
@@ -81,12 +87,18 @@ const HostConfig = {
   scheduleMicrotask: queueMicrotask,
 
   getRootHostContext() {
-    return { isInsideText: false };
+    return { isInsideText: false, isInsideSvg: false, isInsideRichText: false };
   },
 
   getChildHostContext(parentHostContext, type) {
     return {
       isInsideText: parentHostContext.isInsideText || type === 'text',
+      // <svg> children are declarative SVG elements, not react-x11 nodes
+      isInsideSvg: parentHostContext.isInsideSvg || type === 'svg',
+      // <markdown>/<html>/<tex> take their content as a string child
+      // (react-markdown style); no elements are allowed inside
+      isInsideRichText:
+        type === 'markdown' || type === 'html' || type === 'tex',
     };
   },
 
@@ -103,6 +115,20 @@ const HostConfig = {
   resetAfterCommit() {},
 
   createInstance(type, props, rootContainer, hostContext, internalHandle) {
+    if (hostContext.isInsideSvg) {
+      // Inside <svg> every element is a declarative SVG element (React-DOM
+      // style: <circle cx={12} strokeWidth={2} />); SvgView skips tags it
+      // does not support.
+      const node = new SvgChildNode(type, props, rootContainer);
+      node._reactFiber = internalHandle;
+      return node;
+    }
+    if (hostContext.isInsideRichText) {
+      throw new Error(
+        `react-x11: <${type}> is not allowed inside <markdown>/<html>/<tex>; ` +
+          'their content is a string child (or the source prop).',
+      );
+    }
     if (hostContext.isInsideText && type !== 'text') {
       throw new Error(
         `react-x11: <${type}> is not allowed inside <text>; only nested ` +
@@ -163,10 +189,15 @@ const HostConfig = {
   },
 
   createTextInstance(text, rootContainer, hostContext) {
-    if (!hostContext.isInsideText) {
+    if (
+      !hostContext.isInsideText &&
+      !hostContext.isInsideRichText &&
+      !hostContext.isInsideSvg
+    ) {
       throw new Error(
         `react-x11: raw text ${JSON.stringify(text)} must be wrapped in a ` +
-          '<text> element.',
+          '<text> element (or be the string child of <markdown>/<html>/' +
+          '<tex>/an SVG <text>).',
       );
     }
     return new TextChunkNode(text, rootContainer);

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -26,6 +26,7 @@ import {
   ScrollViewNode,
   TextInputNode,
 } from './nodes.js';
+import { MarkdownNode, HtmlNode, SvgNode, TexNode } from './richnodes.js';
 
 const require = createRequire(import.meta.url);
 const packageJson = require('../package.json');
@@ -39,6 +40,10 @@ const HOST_TYPES = [
   'canvas',
   'scrollview',
   'textinput',
+  'markdown',
+  'html',
+  'svg',
+  'tex',
 ];
 
 const isEventProp = (name) => /^on[A-Z]/.test(name);
@@ -133,6 +138,18 @@ const HostConfig = {
         break;
       case 'canvas':
         node = new CanvasNode(props, rootContainer);
+        break;
+      case 'markdown':
+        node = new MarkdownNode(props, rootContainer);
+        break;
+      case 'html':
+        node = new HtmlNode(props, rootContainer);
+        break;
+      case 'svg':
+        node = new SvgNode(props, rootContainer);
+        break;
+      case 'tex':
+        node = new TexNode(props, rootContainer);
         break;
       default:
         throw new Error(

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -19,6 +19,10 @@ const DRAWN_KINDS = new Set([
   'canvas',
   'scrollview',
   'textinput',
+  'markdown',
+  'html',
+  'svg',
+  'tex',
 ]);
 
 // DevTools' measureHostInstance dereferences instance.ownerDocument

--- a/src/richnodes.js
+++ b/src/richnodes.js
@@ -6,7 +6,17 @@
 import { MarkdownView, HtmlView, SvgView, layoutTex } from 'ntk';
 
 import { Node } from './nodes.js';
-import { Yoga } from './styles.js';
+import { Yoga, isLayoutProp, isPaintProp } from './styles.js';
+
+/** Joined text of string children (react-markdown style), or null when the
+ * element has none — then the `source` prop is the content. */
+function stringChildrenOf(node) {
+  let text = null;
+  for (const child of node.children) {
+    if (child.kind === 'textchunk') text = (text ?? '') + child.text;
+  }
+  return text;
+}
 
 // Fallback width for measuring under an unconstrained yoga width
 // (position: absolute without width, unbounded row). Flowed documents have
@@ -16,9 +26,11 @@ const PREFERRED_WIDTH = 480;
 /**
  * Base for <markdown> and <html>: width-driven document flow. Subclasses
  * implement _createView() (a widget with layout/draw/contentHeight) and
- * _setSource(view). The view is created lazily because the headless mock
- * app in smoke tests has no font manager — everything measures 0×0 there,
- * like <text>.
+ * _setSource(view). Content is a string child (like react-markdown:
+ * <markdown>{`# Hi`}</markdown> — use a template-literal expression, JSX
+ * literal text collapses newlines) or the `source` prop; children win.
+ * The view is created lazily because the headless mock app in smoke tests
+ * has no font manager — everything measures 0×0 there, like <text>.
  */
 class DocumentViewNode extends Node {
   constructor(kind, props, app) {
@@ -55,6 +67,16 @@ class DocumentViewNode extends Node {
     this._laidOutWidth = -1;
     this.yoga?.markDirty();
     this.root?.invalidate(true);
+  }
+
+  _source() {
+    return stringChildrenOf(this) ?? this.props.source ?? '';
+  }
+
+  /** String children changed (chunk added/removed/edited). */
+  _textContentChanged() {
+    if (this.view) this._setSource(this.view);
+    this._contentInvalidated();
   }
 
   _layoutAt(width) {
@@ -132,7 +154,7 @@ export class MarkdownNode extends DocumentViewNode {
   }
 
   _setSource(view) {
-    view.setMarkdown(this.props.source ?? '');
+    view.setMarkdown(this._source());
   }
 }
 
@@ -161,45 +183,159 @@ export class HtmlNode extends DocumentViewNode {
   }
 
   _setSource(view) {
-    view.setHtml(this.props.source ?? '', { baseUrl: this.props.baseUrl });
+    view.setHtml(this._source(), { baseUrl: this.props.baseUrl });
+  }
+}
+
+// SVG attributes that are camelCase in SVG itself; every other camelCase
+// prop (strokeWidth, fillRule, textAnchor, …) kebab-cases, like React DOM.
+const SVG_CAMEL_ATTRS = new Set([
+  'viewBox',
+  'preserveAspectRatio',
+  'gradientUnits',
+  'gradientTransform',
+  'spreadMethod',
+  'patternUnits',
+  'patternContentUnits',
+  'patternTransform',
+  'clipPathUnits',
+  'maskUnits',
+  'maskContentUnits',
+  'markerWidth',
+  'markerHeight',
+  'markerUnits',
+  'refX',
+  'refY',
+  'textLength',
+  'lengthAdjust',
+  'stdDeviation',
+]);
+
+const toSvgAttrib = (name) =>
+  SVG_CAMEL_ATTRS.has(name)
+    ? name
+    : name.replace(/[A-Z]/g, (c) => '-' + c.toLowerCase());
+
+function svgAttribs(props, skip) {
+  const attribs = {};
+  for (const key of Object.keys(props)) {
+    const value = props[key];
+    if (key === 'children' || value == null) continue;
+    if (typeof value === 'function') continue;
+    if (skip && skip(key)) continue;
+    attribs[toSvgAttrib(key)] = String(value);
+  }
+  return attribs;
+}
+
+/**
+ * An element inside <svg>: no yoga node, no painting of its own — it only
+ * carries a tag name and props, and is serialized into the htmlparser2-style
+ * DOM that SvgView consumes. Prop/child changes bubble to the owning
+ * SvgNode via the _textContentChanged channel (also used by text chunks,
+ * so string children of an SVG <text> invalidate the same way).
+ */
+export class SvgChildNode extends Node {
+  constructor(tag, props, app) {
+    super(tag, props, app, { yoga: false });
+    this.isSvgChild = true;
+  }
+
+  _textContentChanged() {
+    this.parent?._textContentChanged();
+  }
+
+  applyProps(newProps, oldProps) {
+    super.applyProps(newProps, oldProps);
+    this._textContentChanged();
+  }
+
+  toDom() {
+    return {
+      type: 'tag',
+      name: this.kind,
+      attribs: svgAttribs(this.props),
+      children: this.children
+        .map((c) =>
+          c.kind === 'textchunk'
+            ? { type: 'text', data: c.text }
+            : c.isSvgChild
+              ? c.toDom()
+              : null,
+        )
+        .filter(Boolean),
+    };
   }
 }
 
 /**
- * <svg source>: ntk SvgView. Sized like <image>: natural (viewBox) size,
- * kept to its aspect ratio when only the width is constrained; scales to
- * the content box. Parsing is synchronous — no fonts needed until text.
+ * <svg>: ntk SvgView. Content is either JSX children (React-DOM style —
+ * <svg viewBox="0 0 24 24"><circle cx={12} … />; children win when both
+ * are present) or a `source` markup string. Sized like <image>: natural
+ * (viewBox) size, kept to its aspect ratio when only the width is
+ * constrained; scales to the content box.
  */
 export class SvgNode extends Node {
   constructor(props, app) {
     super('svg', props, app);
     this.view = null;
-    this._error = null;
-    this._parse();
+    this._stale = true;
     this._configureMeasure();
   }
 
-  _parse() {
+  /** Any change to the svg subtree (props, children, text) lands here. */
+  _textContentChanged() {
+    this._stale = true;
+    // markDirty is only legal on nodes with a measure function (it is
+    // unset when width and height are both fixed)
+    if (this._hasMeasure) this.yoga?.markDirty();
+    this.root?.invalidate(true);
+  }
+
+  _ensureView() {
+    if (!this._stale) return this.view;
+    this._stale = false;
     this.view = null;
-    this._error = null;
-    const source = this.props.source;
-    if (!source) return;
     try {
-      this.view = new SvgView(null).setSvg(String(source));
+      const children = this.children.filter(
+        (c) => c.isSvgChild || c.kind === 'textchunk',
+      );
+      if (children.length > 0) {
+        const skip = (key) =>
+          key === 'source' ||
+          isLayoutProp(key) ||
+          isPaintProp(key) ||
+          key === 'cursor' ||
+          key === 'focusable' ||
+          key === 'pointerEvents';
+        this.view = new SvgView(null).setSvgDom({
+          type: 'tag',
+          name: 'svg',
+          attribs: svgAttribs(this.props, skip),
+          children: children.map((c) =>
+            c.kind === 'textchunk' ? { type: 'text', data: c.text } : c.toDom(),
+          ),
+        });
+      } else if (this.props.source) {
+        this.view = new SvgView(null).setSvg(String(this.props.source));
+      }
     } catch (err) {
-      this._error = err;
       console.error('react-x11: <svg> failed to parse:', err.message);
     }
+    return this.view;
   }
 
   _configureMeasure() {
     if (this.props.width != null && this.props.height != null) {
-      this.yoga.unsetMeasureFunc();
+      if (this._hasMeasure) this.yoga.unsetMeasureFunc();
+      this._hasMeasure = false;
       return;
     }
+    this._hasMeasure = true;
     this.yoga.setMeasureFunc((width, widthMode) => {
-      const natW = this.view?.naturalWidth ?? 0;
-      const natH = this.view?.naturalHeight ?? 0;
+      const view = this._ensureView();
+      const natW = view?.naturalWidth ?? 0;
+      const natH = view?.naturalHeight ?? 0;
       let w = natW;
       if (
         widthMode !== Yoga.MEASURE_MODE_UNDEFINED &&
@@ -213,21 +349,19 @@ export class SvgNode extends Node {
   }
 
   applyProps(newProps, oldProps) {
-    const before = oldProps ?? this.props;
     super.applyProps(newProps, oldProps);
     this._configureMeasure();
-    if (newProps.source !== before.source) {
-      this._parse();
-      this.yoga.markDirty();
-      this.root?.invalidate(true);
-    }
+    // attributes live in props (children form) or in `source`; either way
+    // the SvgView is cheap to rebuild on the next measure/paint
+    this._textContentChanged();
   }
 
   _paintContent(ctx) {
-    if (!this.view) return;
+    const view = this._ensureView();
+    if (!view) return;
     const content = this.contentBox();
     if (content.width <= 0 || content.height <= 0) return;
-    this.view.draw(ctx, content.x, content.y, content.width, content.height);
+    view.draw(ctx, content.x, content.y, content.width, content.height);
   }
 }
 
@@ -248,8 +382,16 @@ export class TexNode extends Node {
     });
   }
 
+  /** Formula text changed via string children. */
+  _textContentChanged() {
+    this._boxKey = null;
+    this.yoga?.markDirty();
+    this.root?.invalidate(true);
+  }
+
   _ensureBox() {
-    const { source, size, color, displayMode, katex } = this.props;
+    const { size, color, displayMode, katex } = this.props;
+    const source = stringChildrenOf(this) ?? this.props.source;
     if (!source) return null;
     const key = `${source}|${size}|${color}|${displayMode}`;
     if (this._boxKey === key) return this.box;

--- a/src/richnodes.js
+++ b/src/richnodes.js
@@ -1,0 +1,295 @@
+// Rich-content elements: thin retained-node wrappers over ntk's document
+// widgets in standalone mode (`layout(width)` + `draw(ctx, x, y)` +
+// `contentHeight`). One yoga measure function per node feeds the widget's
+// own layout into flexbox; async content (mermaid models, images) arrives
+// through the widget's `onInvalidate` hook (ntk > 3.3.0 — sidorares/ntk#75;
+// static content works without it).
+import { MarkdownView, HtmlView, SvgView, layoutTex } from 'ntk';
+
+import { Node } from './nodes.js';
+import { Yoga } from './styles.js';
+
+// Fallback width for measuring under an unconstrained yoga width
+// (position: absolute without width, unbounded row). Flowed documents have
+// no natural width, so pick something readable.
+const PREFERRED_WIDTH = 480;
+
+/**
+ * Base for <markdown> and <html>: width-driven document flow. Subclasses
+ * implement _createView() (a widget with layout/draw/contentHeight) and
+ * _setSource(view). The view is created lazily because the headless mock
+ * app in smoke tests has no font manager — everything measures 0×0 there,
+ * like <text>.
+ */
+class DocumentViewNode extends Node {
+  constructor(kind, props, app) {
+    super(kind, props, app);
+    this.view = null;
+    this._laidOutWidth = -1;
+    this.yoga.setMeasureFunc((width, widthMode) => {
+      const view = this._ensureView();
+      if (!view) return { width: 0, height: 0 };
+      const unconstrained =
+        widthMode === Yoga.MEASURE_MODE_UNDEFINED ||
+        !Number.isFinite(width) ||
+        width <= 0;
+      const w = Math.max(1, Math.ceil(unconstrained ? PREFERRED_WIDTH : width));
+      const height = this._layoutAt(w);
+      return { width: w, height: Math.ceil(height) };
+    });
+  }
+
+  _ensureView() {
+    if (this.view || !this.app?.fonts) return this.view;
+    this.view = this._createView();
+    if (this.view) {
+      // ntk > 3.3.0 notifies here when async content (a mermaid model, an
+      // image) invalidates the widget layout; harmless no-op before that
+      this.view.onInvalidate = () => this._contentInvalidated();
+      this._setSource(this.view);
+    }
+    return this.view;
+  }
+
+  _contentInvalidated() {
+    if (this.destroyed) return;
+    this._laidOutWidth = -1;
+    this.yoga?.markDirty();
+    this.root?.invalidate(true);
+  }
+
+  _layoutAt(width) {
+    if (this._laidOutWidth !== width) {
+      this.view.layout(width);
+      this._laidOutWidth = width;
+    }
+    return this.view.contentHeight;
+  }
+
+  /** Props that require rebuilding the view (theme and loader options are
+   * constructor-only in the ntk widgets). Subclasses extend. */
+  _viewProps() {
+    return ['theme'];
+  }
+
+  applyProps(newProps, oldProps) {
+    const before = oldProps ?? this.props;
+    super.applyProps(newProps, oldProps);
+    if (!this.view) return;
+    if (this._viewProps().some((key) => newProps[key] !== before[key])) {
+      this.view = null; // rebuilt (and re-sourced) on next measure/paint
+      this._contentInvalidated();
+      return;
+    }
+    if (newProps.source !== before.source) {
+      this._setSource(this.view);
+      this._contentInvalidated();
+    }
+  }
+
+  _paintContent(ctx) {
+    const view = this._ensureView();
+    if (!view) return;
+    const content = this.contentBox();
+    if (content.width <= 0) return;
+    this._layoutAt(Math.max(1, Math.ceil(content.width)));
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(this.abs.x, this.abs.y, this.abs.width, this.abs.height);
+    ctx.clip();
+    // links recorded by draw() are in window coordinates, so linkAt can
+    // take synthetic-event coordinates directly (_defaultMouseDown)
+    view.draw(ctx, content.x, content.y);
+    ctx.restore();
+  }
+
+  _defaultMouseDown(ev) {
+    if (ev.button !== 1 || !this.view || !this.props.onLink) return;
+    const hit = this.view.linkAt(ev.x, ev.y);
+    if (!hit) return;
+    // MarkdownView.linkAt returns the href, HtmlView an { href, element }
+    if (typeof hit === 'string') this.props.onLink(hit, ev);
+    else this.props.onLink(hit.href, ev, hit.element);
+  }
+}
+
+/**
+ * <markdown source>: ntk MarkdownView — headings, emphasis, lists, quotes,
+ * tables, syntax-highlighted fences, math fences, async mermaid fences.
+ * Props: source, theme, onLink(href, ev). Spacing comes from the box model
+ * (padding prop), not the widget's own page padding.
+ */
+export class MarkdownNode extends DocumentViewNode {
+  constructor(props, app) {
+    super('markdown', props, app);
+  }
+
+  _createView() {
+    return new MarkdownView(null, {
+      fonts: this.app.fonts,
+      theme: this.props.theme,
+      padding: 0,
+    });
+  }
+
+  _setSource(view) {
+    view.setMarkdown(this.props.source ?? '');
+  }
+}
+
+/**
+ * <html source>: ntk HtmlView — its own CSS cascade (document <style>s plus
+ * the `stylesheet` prop), flexbox/block layout, images. Props: source,
+ * stylesheet, baseUrl, loadResource, theme, onLink(href, ev, element).
+ */
+export class HtmlNode extends DocumentViewNode {
+  constructor(props, app) {
+    super('html', props, app);
+  }
+
+  _viewProps() {
+    return ['theme', 'stylesheet', 'baseUrl', 'loadResource'];
+  }
+
+  _createView() {
+    return new HtmlView(null, {
+      fonts: this.app.fonts,
+      theme: this.props.theme,
+      stylesheet: this.props.stylesheet,
+      baseUrl: this.props.baseUrl,
+      loadResource: this.props.loadResource,
+    });
+  }
+
+  _setSource(view) {
+    view.setHtml(this.props.source ?? '', { baseUrl: this.props.baseUrl });
+  }
+}
+
+/**
+ * <svg source>: ntk SvgView. Sized like <image>: natural (viewBox) size,
+ * kept to its aspect ratio when only the width is constrained; scales to
+ * the content box. Parsing is synchronous — no fonts needed until text.
+ */
+export class SvgNode extends Node {
+  constructor(props, app) {
+    super('svg', props, app);
+    this.view = null;
+    this._error = null;
+    this._parse();
+    this._configureMeasure();
+  }
+
+  _parse() {
+    this.view = null;
+    this._error = null;
+    const source = this.props.source;
+    if (!source) return;
+    try {
+      this.view = new SvgView(null).setSvg(String(source));
+    } catch (err) {
+      this._error = err;
+      console.error('react-x11: <svg> failed to parse:', err.message);
+    }
+  }
+
+  _configureMeasure() {
+    if (this.props.width != null && this.props.height != null) {
+      this.yoga.unsetMeasureFunc();
+      return;
+    }
+    this.yoga.setMeasureFunc((width, widthMode) => {
+      const natW = this.view?.naturalWidth ?? 0;
+      const natH = this.view?.naturalHeight ?? 0;
+      let w = natW;
+      if (
+        widthMode !== Yoga.MEASURE_MODE_UNDEFINED &&
+        Number.isFinite(width) &&
+        width < w
+      ) {
+        w = width;
+      }
+      return { width: w, height: natW > 0 ? (w * natH) / natW : natH };
+    });
+  }
+
+  applyProps(newProps, oldProps) {
+    const before = oldProps ?? this.props;
+    super.applyProps(newProps, oldProps);
+    this._configureMeasure();
+    if (newProps.source !== before.source) {
+      this._parse();
+      this.yoga.markDirty();
+      this.root?.invalidate(true);
+    }
+  }
+
+  _paintContent(ctx) {
+    if (!this.view) return;
+    const content = this.contentBox();
+    if (content.width <= 0 || content.height <= 0) return;
+    this.view.draw(ctx, content.x, content.y, content.width, content.height);
+  }
+}
+
+/**
+ * <tex source displayMode size color>: a KaTeX formula via ntk layoutTex.
+ * Layout is synchronous and headless; the box has an intrinsic size (no
+ * wrapping). Invalid TeX renders nothing and logs once.
+ */
+export class TexNode extends Node {
+  constructor(props, app) {
+    super('tex', props, app);
+    this.box = null;
+    this._boxKey = null;
+    this.yoga.setMeasureFunc(() => {
+      const box = this._ensureBox();
+      if (!box) return { width: 0, height: 0 };
+      return { width: Math.ceil(box.width), height: Math.ceil(box.height) };
+    });
+  }
+
+  _ensureBox() {
+    const { source, size, color, displayMode, katex } = this.props;
+    if (!source) return null;
+    const key = `${source}|${size}|${color}|${displayMode}`;
+    if (this._boxKey === key) return this.box;
+    this._boxKey = key;
+    this.box = null;
+    try {
+      this.box = layoutTex(String(source), {
+        size,
+        color,
+        displayMode: displayMode ?? false,
+        katex,
+      });
+    } catch (err) {
+      console.error('react-x11: <tex> failed to layout:', err.message);
+    }
+    return this.box;
+  }
+
+  applyProps(newProps, oldProps) {
+    const before = oldProps ?? this.props;
+    super.applyProps(newProps, oldProps);
+    if (
+      newProps.source !== before.source ||
+      newProps.size !== before.size ||
+      newProps.color !== before.color ||
+      newProps.displayMode !== before.displayMode
+    ) {
+      this.yoga.markDirty();
+      this.root?.invalidate(true);
+    }
+  }
+
+  _paintContent(ctx) {
+    const box = this._ensureBox();
+    // TexBox.draw issues raw XRender requests through ctx.window.app —
+    // it needs a real ntk 2d context (headless mock contexts skip)
+    if (!box || !ctx.window?.app?.display) return;
+    const content = this.contentBox();
+    ctx.fillStyle = this.props.color ?? '#222222';
+    box.draw(ctx, content.x, content.y);
+  }
+}

--- a/src/richnodes.js
+++ b/src/richnodes.js
@@ -2,8 +2,7 @@
 // widgets in standalone mode (`layout(width)` + `draw(ctx, x, y)` +
 // `contentHeight`). One yoga measure function per node feeds the widget's
 // own layout into flexbox; async content (mermaid models, images) arrives
-// through the widget's `onInvalidate` hook (ntk > 3.3.0 — sidorares/ntk#75;
-// static content works without it).
+// through the widget's `onInvalidate` hook (ntk >= 3.4.0).
 import { MarkdownView, HtmlView, SvgView, layoutTex } from 'ntk';
 
 import { Node } from './nodes.js';
@@ -43,7 +42,7 @@ class DocumentViewNode extends Node {
     if (this.view || !this.app?.fonts) return this.view;
     this.view = this._createView();
     if (this.view) {
-      // ntk > 3.3.0 notifies here when async content (a mermaid model, an
+      // ntk >= 3.4.0 notifies here when async content (a mermaid model, an
       // image) invalidates the widget layout; harmless no-op before that
       this.view.onInvalidate = () => this._contentInvalidated();
       this._setSource(this.view);

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -351,3 +351,150 @@ test('renders <text> through the ntk text stack', async () => {
     await app.close();
   }
 });
+
+// Scan a region until it contains at least `minInk` pixels matching `match`.
+async function waitForInk(ctx, w, h, region, match, minInk, what) {
+  const deadline = Date.now() + 3000;
+  for (;;) {
+    const image = await readPixels(ctx, w, h);
+    const hits = [];
+    for (let y = region.y; y < region.y + region.height; y++) {
+      for (let x = region.x; x < region.x + region.width; x++) {
+        if (match(px(image, w, x, y))) hits.push([x, y]);
+      }
+    }
+    if (hits.length >= minInk) return hits;
+    if (Date.now() > deadline) {
+      assert.fail(`${what}: found only ${hits.length}/${minInk} pixels`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+const isDark = ([r, g, b]) => r < 128 && g < 128 && b < 128;
+
+test('<markdown> renders through MarkdownView and dispatches onLink', async () => {
+  const { app } = await createHeadlessApp();
+  try {
+    const clicked = [];
+    const wnd = await render(
+      React.createElement(
+        'window',
+        { width: 300, height: 200, backgroundColor: 'white' },
+        React.createElement('markdown', {
+          source: '# Heading\n\n[the link](https://example.com/)',
+          onLink: (href) => clicked.push(href),
+        }),
+      ),
+      app,
+    );
+    const ctx = wnd.getContext('2d');
+
+    // heading ink (2em bold) in the top region
+    await waitForInk(
+      ctx,
+      300,
+      200,
+      { x: 0, y: 0, width: 200, height: 50 },
+      isDark,
+      20,
+      'markdown heading ink',
+    );
+    // the link paragraph paints in the theme link color; click it
+    const linkPixels = await waitForInk(
+      ctx,
+      300,
+      200,
+      { x: 0, y: 0, width: 300, height: 120 },
+      ([r, g, b]) => b > 140 && b - r > 60 && b - g > 40,
+      5,
+      'link-colored ink',
+    );
+    const [lx, ly] = linkPixels[Math.floor(linkPixels.length / 2)];
+    wnd.emit('mousedown', { x: lx, y: ly, keycode: 1 });
+    wnd.emit('mouseup', { x: lx, y: ly, keycode: 1 });
+    assert.deepStrictEqual(clicked, ['https://example.com/']);
+
+    ReactX11.unmountComponentAtNode(app);
+  } finally {
+    await app.close();
+  }
+});
+
+test('<html> renders styled boxes through HtmlView', async () => {
+  const { app } = await createHeadlessApp();
+  try {
+    const wnd = await render(
+      React.createElement(
+        'window',
+        { width: 200, height: 120, backgroundColor: 'white' },
+        React.createElement('html', {
+          source:
+            '<div style="width: 80px; height: 40px; background: #0000ff; margin: 0"></div>',
+        }),
+      ),
+      app,
+    );
+    const ctx = wnd.getContext('2d');
+    await waitForPixel(ctx, 200, 120, 20, 20, [0, 0, 255], 'html div blue');
+    ReactX11.unmountComponentAtNode(app);
+  } finally {
+    await app.close();
+  }
+});
+
+test('<svg> scales its viewBox into the content box', async () => {
+  const { app } = await createHeadlessApp();
+  try {
+    const wnd = await render(
+      React.createElement(
+        'window',
+        { width: 100, height: 100, backgroundColor: 'white' },
+        React.createElement('svg', {
+          width: 60,
+          height: 60,
+          source:
+            '<svg viewBox="0 0 10 10"><rect x="0" y="0" width="10" height="10" fill="#ff0000"/></svg>',
+        }),
+      ),
+      app,
+    );
+    const ctx = wnd.getContext('2d');
+    await waitForPixel(ctx, 100, 100, 30, 30, [255, 0, 0], 'svg rect red');
+    await waitForPixel(ctx, 100, 100, 80, 80, [255, 255, 255], 'outside white');
+    ReactX11.unmountComponentAtNode(app);
+  } finally {
+    await app.close();
+  }
+});
+
+test('<tex> lays out and draws a formula', async () => {
+  const { app } = await createHeadlessApp();
+  try {
+    const wnd = await render(
+      React.createElement(
+        'window',
+        { width: 200, height: 80, backgroundColor: 'white' },
+        React.createElement('tex', {
+          source: 'x = \\frac{1}{2}',
+          size: 32,
+          displayMode: true,
+        }),
+      ),
+      app,
+    );
+    const ctx = wnd.getContext('2d');
+    await waitForInk(
+      ctx,
+      200,
+      80,
+      { x: 0, y: 0, width: 150, height: 80 },
+      isDark,
+      15,
+      'tex formula ink',
+    );
+    ReactX11.unmountComponentAtNode(app);
+  } finally {
+    await app.close();
+  }
+});

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -541,3 +541,72 @@ test('<markdown> mermaid fence reflows into a diagram (ntk onInvalidate)', async
     await app.close();
   }
 });
+
+test('<svg> JSX children render and update declaratively', async () => {
+  const { app } = await createHeadlessApp();
+  try {
+    const ui = (fill) =>
+      React.createElement(
+        'window',
+        { width: 100, height: 100, backgroundColor: 'white' },
+        React.createElement(
+          'svg',
+          { viewBox: '0 0 10 10', width: 60, height: 60 },
+          React.createElement('rect', {
+            x: 0,
+            y: 0,
+            width: 10,
+            height: 10,
+            fill,
+          }),
+        ),
+      );
+
+    const wnd = await render(ui('#ff0000'), app);
+    const ctx = wnd.getContext('2d');
+    await waitForPixel(ctx, 100, 100, 30, 30, [255, 0, 0], 'children rect red');
+
+    // prop update on the SVG child re-renders the drawing
+    await render(ui('#00ff00'), app);
+    await waitForPixel(
+      ctx,
+      100,
+      100,
+      30,
+      30,
+      [0, 255, 0],
+      'children rect green',
+    );
+
+    ReactX11.unmountComponentAtNode(app);
+  } finally {
+    await app.close();
+  }
+});
+
+test('<markdown> accepts its content as a string child', async () => {
+  const { app } = await createHeadlessApp();
+  try {
+    const wnd = await render(
+      React.createElement(
+        'window',
+        { width: 300, height: 100, backgroundColor: 'white' },
+        React.createElement('markdown', null, '# From a child string'),
+      ),
+      app,
+    );
+    const ctx = wnd.getContext('2d');
+    await waitForInk(
+      ctx,
+      300,
+      100,
+      { x: 0, y: 0, width: 280, height: 50 },
+      isDark,
+      20,
+      'child-string markdown heading ink',
+    );
+    ReactX11.unmountComponentAtNode(app);
+  } finally {
+    await app.close();
+  }
+});

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -498,3 +498,46 @@ test('<tex> lays out and draws a formula', async () => {
     await app.close();
   }
 });
+
+test('<markdown> mermaid fence reflows into a diagram (ntk onInvalidate)', async () => {
+  const { app } = await createHeadlessApp();
+  try {
+    const wnd = await render(
+      React.createElement(
+        'window',
+        { width: 300, height: 200, backgroundColor: 'white' },
+        React.createElement('markdown', {
+          source: '```mermaid\nflowchart LR\n  A[Hello] --> B[World]\n```',
+        }),
+      ),
+      app,
+    );
+    const ctx = wnd.getContext('2d');
+
+    // the fence first paints as a code block; when the async mermaid model
+    // arrives the widget fires onInvalidate and the element reflows into
+    // diagram node boxes (theme fill #ececff). The grammar loads lazily,
+    // so allow more time than the default waitForInk deadline.
+    const isNodeFill = ([r, g, b]) =>
+      r > 220 && g > 220 && b > 245 && b > r + 8;
+    const deadline = Date.now() + 10000;
+    for (;;) {
+      const image = await readPixels(ctx, 300, 200);
+      let hits = 0;
+      for (let y = 0; y < 120; y++) {
+        for (let x = 0; x < 300; x++) {
+          if (isNodeFill(px(image, 300, x, y))) hits++;
+        }
+      }
+      if (hits > 50) break;
+      if (Date.now() > deadline) {
+        assert.fail(`mermaid diagram never painted (${hits} fill pixels)`);
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+
+    ReactX11.unmountComponentAtNode(app);
+  } finally {
+    await app.close();
+  }
+});

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -62,6 +62,25 @@ function createMockApp() {
         drawImage(...args) {
           ops.push(['drawImage']);
         },
+        // enough of the canvas surface for SvgView.draw to run headlessly
+        scale(sx, sy) {
+          ops.push(['scale', sx, sy]);
+        },
+        transform() {},
+        setTransform() {},
+        getTransform() {
+          return { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 };
+        },
+        arc() {},
+        ellipse() {},
+        bezierCurveTo() {},
+        quadraticCurveTo() {},
+        createLinearGradient() {
+          return { addColorStop() {} };
+        },
+        createRadialGradient() {
+          return { addColorStop() {} };
+        },
       };
       const wnd = {
         id: app.windows.length + 100,
@@ -932,4 +951,33 @@ test('DevTools agent highlight tints the hovered node', async () => {
   );
 
   ReactX11.unmountComponentAtNode(app);
+});
+
+test('rich content elements mount, update and unmount headlessly', async () => {
+  const app = createMockApp();
+  const ui = (md) =>
+    React.createElement(
+      'window',
+      { width: 400, height: 300 },
+      React.createElement('markdown', { source: md }),
+      React.createElement('html', { source: '<p>hello</p>' }),
+      React.createElement('svg', {
+        source:
+          '<svg viewBox="0 0 10 10"><rect width="10" height="10" fill="#f00"/></svg>',
+        width: 20,
+        height: 20,
+      }),
+      React.createElement('tex', { source: 'x^2', size: 20 }),
+    );
+
+  ReactX11.render(ui('# One'), null, app);
+  await tick(); // paint flush: no fonts on the mock app, must not throw
+  const [wnd] = app.windows;
+  assert.ok(wnd.mapped, 'window mounted with rich content children');
+
+  ReactX11.render(ui('# Two'), null, app);
+  await tick();
+
+  ReactX11.unmountComponentAtNode(app);
+  assert.ok(wnd.destroyed, 'clean unmount');
 });

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -959,15 +959,17 @@ test('rich content elements mount, update and unmount headlessly', async () => {
     React.createElement(
       'window',
       { width: 400, height: 300 },
-      React.createElement('markdown', { source: md }),
+      React.createElement('markdown', null, md), // string child (react-markdown style)
       React.createElement('html', { source: '<p>hello</p>' }),
+      React.createElement(
+        'svg',
+        { viewBox: '0 0 10 10', width: 20, height: 20 },
+        React.createElement('rect', { width: 10, height: 10, fill: '#f00' }),
+      ),
       React.createElement('svg', {
-        source:
-          '<svg viewBox="0 0 10 10"><rect width="10" height="10" fill="#f00"/></svg>',
-        width: 20,
-        height: 20,
+        source: '<svg viewBox="0 0 10 10"><circle r="5" fill="#00f"/></svg>',
       }),
-      React.createElement('tex', { source: 'x^2', size: 20 }),
+      React.createElement('tex', { size: 20 }, 'x^2'),
     );
 
   ReactX11.render(ui('# One'), null, app);


### PR DESCRIPTION
## What

Roadmap item 1 from NEXT_STEPS.md: ntk's document widgets exposed as drawn elements. `src/richnodes.js` wraps them in standalone mode — the widget's `layout(width)`/`contentHeight` feeds a yoga **measure function**, so documents participate in flex layout and scroll naturally inside a `<scrollview>`; `draw(ctx, x, y)` paints into the owning window's context like any other drawn node.

| element | ntk widget | notes |
| --- | --- | --- |
| `<markdown source onLink theme>` | MarkdownView | headings, tables, highlighted fences, math fences, async mermaid |
| `<html source stylesheet baseUrl loadResource onLink theme>` | HtmlView | its own CSS cascade, images |
| `<svg source>` | SvgView | sized like `<image>` (natural viewBox size, aspect-preserving) |
| `<tex source size color displayMode katex>` | layoutTex | intrinsic size, synchronous, server-side glyphs |

- **Content, React-DOM style**: `<svg>` takes declarative SVG elements as JSX children (`<svg viewBox="0 0 24 24"><circle cx={12} strokeWidth={2} …/></svg>`) — camelCase props map to SVG attributes, any prop/state change re-renders the drawing; a `source` markup string also works (children win). `<markdown>`/`<html>`/`<tex>` take their content as a **string child** (the react-markdown convention — its `source` prop was retired in favor of children), with `source` kept for programmatic use.
- **Link clicks**: MarkdownView/HtmlView `linkAt` is wired into the mousedown default action — links recorded by `draw()` are already in window coordinates, so synthetic-event coordinates pass straight through. `preventDefault()` in your own `onMouseDown` suppresses it, like every other default action.
- **Async content** (mermaid models, HTML images) reflows via the widgets' `onInvalidate` hook — sidorares/ntk#75, released in **ntk 3.4.0**; the dependency is bumped to `^3.4.0` and a pixel-verified integration test covers the full chain (mermaid fence paints as a code block, then reflows into the diagram).
- Widget page padding is zeroed — spacing comes from the box model (`padding` prop), consistent with the other elements.
- `<tex>` painting is skipped on non-ntk contexts (TexBox issues raw XRender requests), which keeps the headless mock-app path safe.

## Tests

- integration (in-process X server, pixel readback): markdown heading ink **plus an end-to-end link click on the actual rendered link pixels** → `onLink` dispatch; `<html>` styled-div pixel check; `<svg>` viewBox scaling pixel check; `<tex>` formula ink.
- smoke: the four elements mount, update and unmount against the headless mock app (no fonts → measure 0×0, no crash).
- `npm test`: 36 pass, 0 fail; lint clean (adds: SVG-children render + declarative prop update re-renders, markdown-as-string-child).

## Docs & example

`docs/elements.md` (new Rich content section), README element table, `examples/richtext.jsx` (`npm run examples:richtext`).