### PR TITLE
feat: standard widget set — Button, Checkbox, Radio/RadioGroup, Switch, ProgressBar

### DIFF
--- a/examples/widgets.jsx
+++ b/examples/widgets.jsx
@@ -1,0 +1,122 @@
+// Widget gallery: every standard component in one window — Button,
+// Checkbox, Radio/RadioGroup, Switch, ProgressBar, Select, <textinput>.
+// Run with: npm run examples:widgets  (needs an X server / DISPLAY)
+import React, { useEffect, useState } from 'react';
+import {
+  createRoot,
+  Button,
+  Checkbox,
+  ProgressBar,
+  Radio,
+  RadioGroup,
+  Select,
+  Switch,
+} from '../src/index.js';
+
+function Row({ label, children }) {
+  return (
+    <box flexDirection="row" alignItems="center" gap={12}>
+      <text color="#7f8c8d" width={90}>
+        {label}
+      </text>
+      {children}
+    </box>
+  );
+}
+
+function App() {
+  const [agreed, setAgreed] = useState(true);
+  const [notify, setNotify] = useState(false);
+  const [flavor, setFlavor] = useState('vanilla');
+  const [speed, setSpeed] = useState('fast');
+  const [presses, setPresses] = useState(0);
+  const [progress, setProgress] = useState(0.2);
+
+  // demo animation: creep the progress bar while "notifications" are on
+  useEffect(() => {
+    if (!notify) return undefined;
+    const t = setInterval(
+      () => setProgress((p) => (p >= 1 ? 0 : p + 0.02)),
+      100,
+    );
+    return () => clearInterval(t);
+  }, [notify]);
+
+  return (
+    <window width={460} height={430} title="widgets" backgroundColor="#f5f6fa">
+      <box flexGrow={1} padding={16} gap={14}>
+        <text fontSize={20} color="#2d3436">
+          Widget gallery
+        </text>
+
+        <Row label="Button">
+          <Button primary onPress={() => setPresses((n) => n + 1)}>
+            Press me
+          </Button>
+          <Button onPress={() => setPresses(0)}>Reset</Button>
+          <Button disabled>Disabled</Button>
+          <text color="#2d3436">{`${presses}×`}</text>
+        </Row>
+
+        <Row label="Checkbox">
+          <box gap={6}>
+            <Checkbox checked={agreed} onChange={setAgreed}>
+              I agree to nothing in particular
+            </Checkbox>
+            <Checkbox checked={false} disabled>
+              Disabled
+            </Checkbox>
+          </box>
+        </Row>
+
+        <Row label="Radio">
+          <RadioGroup value={flavor} onChange={setFlavor}>
+            <Radio value="vanilla">Vanilla</Radio>
+            <Radio value="chocolate">Chocolate</Radio>
+            <Radio value="pistachio">Pistachio</Radio>
+          </RadioGroup>
+        </Row>
+
+        <Row label="Switch">
+          <Switch checked={notify} onChange={setNotify} />
+          <text color="#2d3436">{notify ? 'notifications on' : 'off'}</text>
+        </Row>
+
+        <Row label="Progress">
+          <box flexGrow={1}>
+            <ProgressBar value={progress} />
+          </box>
+          <text color="#7f8c8d">{`${Math.round(progress * 100)}%`}</text>
+        </Row>
+
+        <Row label="Select">
+          <Select
+            width={160}
+            options={['fast', 'faster', 'ludicrous']}
+            value={speed}
+            onChange={setSpeed}
+          />
+        </Row>
+
+        <Row label="Input">
+          <textinput
+            flexGrow={1}
+            placeholder="Type here…"
+            padding={8}
+            borderRadius={4}
+            borderWidth={1}
+            borderColor="#b2bec3"
+            backgroundColor="white"
+          />
+        </Row>
+      </box>
+    </window>
+  );
+}
+
+export default App;
+
+if (!process.env.REACT_X11_NO_AUTORUN) {
+  const root = await createRoot();
+  root.render(<App />);
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "examples:menu": "tsx examples/menu.jsx",
     "examples:form": "tsx examples/form.jsx",
     "examples:richtext": "tsx examples/richtext.jsx",
+    "examples:widgets": "tsx examples/widgets.jsx",
     "screenshots": "tsx scripts/screenshots.jsx"
   },
   "repository": {

--- a/src/components.js
+++ b/src/components.js
@@ -1,14 +1,20 @@
 // Widget components built purely on the host primitives — no reconciler
 // support needed. Plain createElement (no JSX) so the library stays
 // build-step-free for consumers.
-import React, { useContext, useRef, useState } from 'react';
+import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
 
 const h = React.createElement;
 
 const ITEM_HEIGHT = 28;
 const MAX_MENU_HEIGHT = 220;
 
-const SelectTheme = {
+const XK_RETURN = 0xff0d;
+const XK_LEFT = 0xff51;
+const XK_UP = 0xff52;
+const XK_RIGHT = 0xff53;
+const XK_DOWN = 0xff54;
+
+const DefaultTheme = {
   border: '#b2bec3',
   borderActive: '#2980b9',
   background: 'white',
@@ -16,10 +22,326 @@ const SelectTheme = {
   dim: '#7f8c8d',
   hoverBackground: '#2980b9',
   hoverText: 'white',
+  accent: '#2980b9',
+  accentHover: '#1f6693',
+  accentText: 'white',
+  surfaceHover: '#f1f2f6',
+  track: '#dfe6e9',
 };
 
-const SelectThemeContext = React.createContext(SelectTheme);
-export const SelectThemeProvider = SelectThemeContext.Provider;
+const ThemeContext = React.createContext(DefaultTheme);
+/** Themes all widgets; partial palettes merge over the defaults. */
+export const ThemeProvider = ThemeContext.Provider;
+export const SelectThemeProvider = ThemeContext.Provider; // back-compat alias
+
+function useTheme() {
+  const theme = useContext(ThemeContext);
+  return theme === DefaultTheme ? theme : { ...DefaultTheme, ...theme };
+}
+
+/** Shared interactive-control plumbing: hover/focus state plus the box
+ * props wiring them, click + Space/Enter activation. */
+function useControl(disabled, onActivate) {
+  const [hover, setHover] = useState(false);
+  const [focused, setFocused] = useState(false);
+  const props = disabled
+    ? {}
+    : {
+        focusable: true,
+        cursor: 'pointer',
+        onMouseEnter: () => setHover(true),
+        onMouseLeave: () => setHover(false),
+        onFocus: () => setFocused(true),
+        onBlur: () => setFocused(false),
+        onClick: () => onActivate?.(),
+        onKeyDown: (ev) => {
+          if (ev.codepoint === 32 || ev.keysym === XK_RETURN) onActivate?.();
+        },
+      };
+  return { hover: hover && !disabled, focused: focused && !disabled, props };
+}
+
+/** String/number children become a <text>; elements pass through. */
+function labelContent(children, textProps) {
+  return React.Children.map(children, (child) =>
+    typeof child === 'string' || typeof child === 'number'
+      ? h('text', textProps, child)
+      : child,
+  );
+}
+
+/**
+ * <Button onPress primary disabled …boxProps>label</Button> — the standard
+ * push button the examples kept re-implementing: hover/focus feedback,
+ * Space/Enter activation, pointer cursor.
+ */
+export function Button({
+  children,
+  label,
+  onPress,
+  primary = false,
+  disabled = false,
+  ...boxProps
+}) {
+  const theme = useTheme();
+  const { hover, focused, props } = useControl(disabled, onPress);
+  const background = disabled
+    ? theme.surfaceHover
+    : primary
+      ? hover
+        ? theme.accentHover
+        : theme.accent
+      : hover
+        ? theme.surfaceHover
+        : theme.background;
+  const color = disabled ? theme.dim : primary ? theme.accentText : theme.text;
+  return h(
+    'box',
+    {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: 8,
+      paddingTop: 8,
+      paddingBottom: 8,
+      paddingLeft: 16,
+      paddingRight: 16,
+      borderRadius: 4,
+      borderWidth: 1,
+      borderColor: disabled
+        ? theme.border
+        : focused
+          ? primary
+            ? theme.accentHover
+            : theme.borderActive
+          : primary
+            ? theme.accent
+            : theme.border,
+      backgroundColor: background,
+      ...props,
+      ...boxProps,
+    },
+    labelContent(children ?? label, { color }),
+  );
+}
+
+/**
+ * <Checkbox checked onChange disabled>label</Checkbox> — 16px check well +
+ * label row; click or Space toggles (onChange receives the next value).
+ */
+export function Checkbox({
+  children,
+  label,
+  checked = false,
+  onChange,
+  disabled = false,
+  ...boxProps
+}) {
+  const theme = useTheme();
+  const { focused, props } = useControl(disabled, () => onChange?.(!checked));
+  const fill = disabled ? theme.dim : theme.accent;
+  return h(
+    'box',
+    {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: 8,
+      ...props,
+      ...boxProps,
+    },
+    h(
+      'box',
+      {
+        width: 16,
+        height: 16,
+        borderRadius: 3,
+        borderWidth: 1,
+        borderColor: checked
+          ? fill
+          : focused
+            ? theme.borderActive
+            : theme.border,
+        backgroundColor: checked ? fill : theme.background,
+        alignItems: 'center',
+        justifyContent: 'center',
+      },
+      checked &&
+        h('canvas', {
+          width: 10,
+          height: 8,
+          onDraw: (ctx) => {
+            ctx.strokeStyle = theme.accentText;
+            ctx.lineWidth = 2;
+            ctx.beginPath();
+            ctx.moveTo(1, 4);
+            ctx.lineTo(3.5, 6.5);
+            ctx.lineTo(9, 1);
+            ctx.stroke();
+          },
+        }),
+    ),
+    labelContent(children ?? label, {
+      color: disabled ? theme.dim : theme.text,
+    }),
+  );
+}
+
+const RadioGroupContext = React.createContext(null);
+
+/**
+ * <RadioGroup value onChange>…<Radio value=…>label</Radio>…</RadioGroup> —
+ * exclusive choice. Arrow keys move the selection through the group in
+ * mount order (wrapping); click or Space selects the focused radio.
+ */
+export function RadioGroup({ value, onChange, children, ...boxProps }) {
+  const order = useRef([]).current;
+  const ctx = useMemo(
+    () => ({
+      value,
+      onChange,
+      register: (v) => {
+        order.push(v);
+        return () => order.splice(order.indexOf(v), 1);
+      },
+      move: (delta) => {
+        if (order.length === 0) return;
+        const i = order.indexOf(value);
+        const next = order[(i + delta + order.length) % order.length];
+        if (next !== value) onChange?.(next);
+      },
+    }),
+    [value, onChange, order],
+  );
+  return h(
+    'box',
+    { gap: 6, ...boxProps },
+    h(RadioGroupContext.Provider, { value: ctx }, children),
+  );
+}
+
+export function Radio({ value, children, label, disabled = false }) {
+  const theme = useTheme();
+  const group = useContext(RadioGroupContext);
+  if (!group) {
+    throw new Error('react-x11: <Radio> must be inside a <RadioGroup>');
+  }
+  useEffect(() => group.register(value), [group, value]);
+  const selected = group.value === value;
+  const { focused, props } = useControl(disabled, () => {
+    if (!selected) group.onChange?.(value);
+  });
+  const onKeyDown = props.onKeyDown;
+  if (onKeyDown) {
+    props.onKeyDown = (ev) => {
+      if (ev.keysym === XK_DOWN || ev.keysym === XK_RIGHT) group.move(1);
+      else if (ev.keysym === XK_UP || ev.keysym === XK_LEFT) group.move(-1);
+      else onKeyDown(ev);
+    };
+  }
+  const fill = disabled ? theme.dim : theme.accent;
+  return h(
+    'box',
+    { flexDirection: 'row', alignItems: 'center', gap: 8, ...props },
+    h(
+      'box',
+      {
+        width: 16,
+        height: 16,
+        borderRadius: 8,
+        borderWidth: 1,
+        borderColor: selected
+          ? fill
+          : focused
+            ? theme.borderActive
+            : theme.border,
+        backgroundColor: theme.background,
+        alignItems: 'center',
+        justifyContent: 'center',
+      },
+      selected &&
+        h('box', {
+          width: 8,
+          height: 8,
+          borderRadius: 4,
+          backgroundColor: fill,
+        }),
+    ),
+    labelContent(children ?? label, {
+      color: disabled ? theme.dim : theme.text,
+    }),
+  );
+}
+
+/**
+ * <Switch checked onChange disabled/> — Checkbox semantics in a sliding
+ * pill; the thumb sits at the end matching the state.
+ */
+export function Switch({
+  checked = false,
+  onChange,
+  disabled = false,
+  ...boxProps
+}) {
+  const theme = useTheme();
+  const { focused, props } = useControl(disabled, () => onChange?.(!checked));
+  return h(
+    'box',
+    {
+      width: 36,
+      height: 20,
+      borderRadius: 10,
+      padding: 2,
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: checked ? 'flex-end' : 'flex-start',
+      backgroundColor: disabled
+        ? theme.track
+        : checked
+          ? theme.accent
+          : focused
+            ? theme.dim
+            : theme.border,
+      ...props,
+      ...boxProps,
+    },
+    h('box', {
+      width: 16,
+      height: 16,
+      borderRadius: 8,
+      backgroundColor: theme.background,
+    }),
+  );
+}
+
+/**
+ * <ProgressBar value/> — determinate progress, value in [0, 1].
+ */
+export function ProgressBar({
+  value = 0,
+  color,
+  trackColor,
+  height = 8,
+  ...boxProps
+}) {
+  const theme = useTheme();
+  const clamped = Math.min(1, Math.max(0, value));
+  return h(
+    'box',
+    {
+      height,
+      borderRadius: height / 2,
+      backgroundColor: trackColor ?? theme.track,
+      overflow: 'hidden',
+      flexDirection: 'row',
+      ...boxProps,
+    },
+    h('box', {
+      width: `${clamped * 100}%`,
+      borderRadius: height / 2,
+      backgroundColor: color ?? theme.accent,
+    }),
+  );
+}
 
 function normalizeOption(option) {
   return typeof option === 'object' && option !== null
@@ -28,7 +350,7 @@ function normalizeOption(option) {
 }
 
 function Option({ option, selected, onPick }) {
-  const theme = useContext(SelectThemeContext);
+  const theme = useTheme();
   const [hover, setHover] = useState(false);
   return h(
     'box',
@@ -68,7 +390,7 @@ export function Select({
   width,
   ...boxProps
 }) {
-  const theme = useContext(SelectThemeContext);
+  const theme = useTheme();
   const [open, setOpen] = useState(false);
   const [anchor, setAnchor] = useState(null);
   const [focused, setFocused] = useState(false);

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,17 @@ export {
   unmountComponentAtNode,
   Renderer,
 } from './Reconciler.js';
-export { Select, SelectThemeProvider } from './components.js';
+export {
+  Select,
+  SelectThemeProvider,
+  ThemeProvider,
+  Button,
+  Checkbox,
+  Radio,
+  RadioGroup,
+  Switch,
+  ProgressBar,
+} from './components.js';
 
 import { render, createRoot, unmountComponentAtNode } from './Reconciler.js';
 

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -983,3 +983,217 @@ test('rich content elements mount, update and unmount headlessly', async () => {
   ReactX11.unmountComponentAtNode(app);
   assert.ok(wnd.destroyed, 'clean unmount');
 });
+
+// --- standard widgets (components.js) --------------------------------------
+
+const findAllFocusable = (node, out = []) => {
+  if (node.props?.focusable) out.push(node);
+  for (const child of node.children) {
+    if (!child.isWindow) findAllFocusable(child, out);
+  }
+  return out;
+};
+
+const clickNode = (wnd, node) => {
+  const x = node.abs.x + node.abs.width / 2;
+  const y = node.abs.y + node.abs.height / 2;
+  wnd.emit('mousedown', { x, y, keycode: 1 });
+  wnd.emit('mouseup', { x, y, keycode: 1 });
+};
+
+test('Button fires onPress via click and Space; disabled is inert', async () => {
+  const { Button } = await import('../src/index.js');
+  const app = createMockApp();
+  const presses = [];
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 300, height: 200 },
+      React.createElement(
+        'box',
+        { flexGrow: 1, padding: 10, gap: 10, alignItems: 'flex-start' },
+        React.createElement(Button, {
+          label: 'Go',
+          onPress: () => presses.push('go'),
+        }),
+        React.createElement(Button, {
+          label: 'Nope',
+          disabled: true,
+          onPress: () => presses.push('nope'),
+        }),
+      ),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const focusables = findAllFocusable(wnd._reactX11Node);
+  assert.strictEqual(focusables.length, 1, 'disabled button is not focusable');
+  const [go] = focusables;
+
+  clickNode(wnd, go);
+  assert.deepStrictEqual(presses, ['go']);
+  // the click focused it; Space activates
+  pressKey(app, wnd, { codepoint: 32 });
+  assert.deepStrictEqual(presses, ['go', 'go']);
+
+  // clicking the disabled button does nothing
+  const disabledText = (function find(n) {
+    if (
+      n.kind === 'text' &&
+      n.children.some((c) => c.kind === 'textchunk' && c.text === 'Nope')
+    ) {
+      return n;
+    }
+    for (const c of n.children) {
+      if (c.isWindow) continue;
+      const hit = find(c);
+      if (hit) return hit;
+    }
+    return null;
+  })(wnd._reactX11Node);
+  clickNode(wnd, disabledText.parent);
+  assert.deepStrictEqual(presses, ['go', 'go']);
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('Checkbox and Switch toggle through onChange', async () => {
+  const { Checkbox, Switch } = await import('../src/index.js');
+  const app = createMockApp();
+  const log = [];
+  function Wrapper() {
+    const [checked, setChecked] = React.useState(false);
+    const [on, setOn] = React.useState(false);
+    return React.createElement(
+      'box',
+      { flexGrow: 1, padding: 10, gap: 10, alignItems: 'flex-start' },
+      React.createElement(
+        Checkbox,
+        {
+          checked,
+          onChange: (next) => {
+            log.push(['check', next]);
+            setChecked(next);
+          },
+        },
+        'Enable',
+      ),
+      React.createElement(Switch, {
+        checked: on,
+        onChange: (next) => {
+          log.push(['switch', next]);
+          setOn(next);
+        },
+      }),
+    );
+  }
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 300, height: 200 },
+      React.createElement(Wrapper),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const [checkbox, sw] = findAllFocusable(wnd._reactX11Node);
+
+  clickNode(wnd, checkbox);
+  await tick();
+  pressKey(app, wnd, { codepoint: 32 }); // Space toggles back
+  await tick();
+  clickNode(wnd, sw);
+  await tick();
+  assert.deepStrictEqual(log, [
+    ['check', true],
+    ['check', false],
+    ['switch', true],
+  ]);
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('RadioGroup: click selects, arrow keys move selection (wrapping)', async () => {
+  const { Radio, RadioGroup } = await import('../src/index.js');
+  const app = createMockApp();
+  const picks = [];
+  function Wrapper() {
+    const [value, setValue] = React.useState('a');
+    return React.createElement(
+      RadioGroup,
+      {
+        value,
+        onChange: (v) => {
+          picks.push(v);
+          setValue(v);
+        },
+      },
+      React.createElement(Radio, { value: 'a' }, 'A'),
+      React.createElement(Radio, { value: 'b' }, 'B'),
+      React.createElement(Radio, { value: 'c' }, 'C'),
+    );
+  }
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 300, height: 200 },
+      React.createElement(Wrapper),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const radios = findAllFocusable(wnd._reactX11Node);
+  assert.strictEqual(radios.length, 3);
+
+  clickNode(wnd, radios[1]); // select B (and focus it)
+  await tick();
+  pressKey(app, wnd, { keysym: 0xff54 }); // Down -> C
+  await tick();
+  pressKey(app, wnd, { keysym: 0xff54 }); // Down wraps -> A
+  await tick();
+  pressKey(app, wnd, { keysym: 0xff52 }); // Up wraps back -> C
+  await tick();
+  assert.deepStrictEqual(picks, ['b', 'c', 'a', 'c']);
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('ProgressBar fill width follows value', async () => {
+  const { ProgressBar } = await import('../src/index.js');
+  const app = createMockApp();
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 300, height: 100 },
+      React.createElement(
+        'box',
+        { flexGrow: 1, padding: 0 },
+        React.createElement(ProgressBar, { value: 0.5, width: 200 }),
+      ),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const track = (function find(n) {
+    if (n.props?.overflow === 'hidden' && n.kind === 'box') return n;
+    for (const c of n.children) {
+      if (c.isWindow) continue;
+      const hit = find(c);
+      if (hit) return hit;
+    }
+    return null;
+  })(wnd._reactX11Node);
+  assert.ok(track, 'progress track renders');
+  assert.strictEqual(track.abs.width, 200);
+  const fill = track.children[0];
+  assert.ok(
+    Math.abs(fill.abs.width - 100) <= 1,
+    `fill should be ~half the track, got ${fill.abs.width}`,
+  );
+  ReactX11.unmountComponentAtNode(app);
+});


### PR DESCRIPTION
Stacked on #29 (which is stacked on #28); retarget as those merge.

Roadmap §2 ("Standard UI components"): plain React components over the host primitives — no reconciler support needed. The examples had re-implemented Button three times; it is now a component.

## What's included

- **ThemeProvider** — one palette for all widgets (`SelectThemeProvider` kept as an alias); partial palettes merge over the defaults now.
- **useControl** (internal) — shared hover/focus wiring, click + Space/Enter activation, pointer cursor, `disabled`.
- **Button** `onPress primary disabled` — hover shades, focus ring; string children wrap in `<text>` automatically.
- **Checkbox** `checked onChange` — 16px well, canvas checkmark, label children.
- **Radio / RadioGroup** `value onChange` — arrow keys move the selection through the group in mount order with wrapping (registration via context).
- **Switch** — checkbox semantics in a sliding pill (thumb position via `justifyContent`, no animation yet).
- **ProgressBar** `value∈[0,1]` — percent-width fill (yoga percent widths pass through).
- `examples/widgets.jsx` gallery — `npm run examples:widgets`.

## Tests

Four new smoke tests drive the widgets through the real event pipeline (mock ntk app): Button click/Space/disabled, Checkbox+Switch toggling, RadioGroup arrow-key wrapping, ProgressBar percent-width layout. 41 tests green.

## Screenshot

Rendered by this PR's own code (in-process X server, Arial, `feat/widgets` @ 293f50b) — gallery after two "Press me" clicks with the input focused:

<img width="460" height="430" alt="widgets" src="https://github.com/user-attachments/assets/2911dfc4-2ab6-4883-b310-eeb5b1962667" />

