### PR TITLE
feat: Select keyboard navigation + scrollview scrollIntoView

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -1,18 +1,38 @@
 # NEXT_STEPS.md — making react-x11 actually usable
 
-> **Status (2026-07-26, end of session):** Everything below through phase 5
-> is DONE and merged (or in review): retained drawn-node architecture
-> (PR #22, incl. top-down commit-phase window creation from #21),
-> `<scrollview>`/`<popup>`/`<textinput>`/`Select`/cursor
-> prop/`borderStyle="dashed"`/debug overlay (#22, #23), trailing-space
-> caret fix (#24), DevTools bridge + highlight-on-hover with the
-> DOM-contract fixes that make selection & highlight actually work (#25 —
-> in review), docs + README overhaul + caret-API adoption (this branch,
-> stacked on #25). Upstream: ntk **3.3.0** released with everything we
-> filed (#56 #58 #60 #63 #68 #69 #70 and the TextLayout caret API #73);
-> `<textinput>` now uses `caretPosition`/`indexAt` — caret math is exact
-> across kerning/bidi/trailing whitespace. npm publish: release-please
-> **PR #17 (1.0.0)** — merge it to publish.
+> **Status (2026-07-27):** Phases 0–5 are done. #28 (sans-serif README
+> screenshots) and #29 (CSS half-leading for text) are on master. #30
+> (`Button`/`Checkbox`/`Radio`/`Switch`/`ProgressBar` + `ThemeProvider`),
+> #31 (`<window onCloseRequest>` + examples overhaul), and #32 (multi-line
+> `<textarea>`) were merged into their stacked base **after** that base had
+> already landed as #29, so their commits never reached master — **#33**
+> lands them (no new code).
+>
+> In review on top of that: **#34** `Select` keyboard navigation (Up/Down
+> open + move with wrapping, Home/End, Enter/Space pick, Escape close;
+> pointer and keyboard share one highlight), a `scrollIntoView(node)`
+> primitive on `<scrollview>`, and the `flexShrink` fix that made a menu
+> longer than `MAX_MENU_HEIGHT` actually scroll instead of being clipped by
+> the popup edge.
+>
+> Upstream: ntk **3.4.0** (async rich-content `onInvalidate`); everything
+> we filed through #75 is released. npm publish still waits on
+> release-please **PR #17 (1.0.0)**.
+>
+> **Plan (next session):**
+>
+> 1. Merge #33 → #34, then release-please #17 and publish 1.0.0.
+> 2. Pointer capture for userland (EventManager already drags via
+>    downNode; expose it), then build `Slider` on it.
+> 3. Extract `useAnchor(ref)` from `Select` → `Tooltip`, then
+>    Menu/MenuBar/ContextMenu.
+> 4. `<textarea>` polish: Ctrl+arrow word movement, PageUp/Down,
+>    Shift+click extend, drawn scrollbar.
+> 5. `Select` follow-ups: type-ahead (jump to the option matching typed
+>    letters) and PageUp/PageDown in the open menu.
+> 6. Upstream (ntk): distribute half-leading inside TextLayout itself
+>    (makes the #29 paint shift a no-op) + an opt-in cap-height trim
+>    (`text-box-trim` analog); `maxLines`/ellipsis for `<text>`.
 
 ---
 
@@ -51,15 +71,17 @@ merged theme (`ThemeProvider`; `SelectThemeProvider` is an alias) and a
 - **Tooltip** — `<popup>` + hover timer; extract the anchoring math from
   `Select` into a shared `useAnchor(ref)` hook
 - **Menu/MenuBar, ContextMenu** — generalize examples/menu.jsx
+- **`Select` type-ahead / PageUp-PageDown** — keyboard navigation itself
+  is done (#34: Up/Down/Home/End/Enter/Escape, shared pointer+keyboard
+  highlight, active option scrolled into view)
 
 ### 3. Renderer gaps found while building the above
 
 - **Pointer capture for userland** — `EventManager` has downNode-based
   dragging internally; expose `ev.capturePointer()` or deliver move/up to
   the mousedown target while dragging (Slider needs this)
-- **Multi-line `<textarea>`** — TextLayout is already multi-line and the
-  caret API returns `{y, line}`; needs vertical caret movement, scroll-Y,
-  wrap-aware Home/End
+- **Multi-line `<textarea>`** — DONE (#32). Polish left: Ctrl+arrow word
+  movement, PageUp/Down, Shift+click extend, drawn scrollbar
 - **Bidi caret polish** — caret positions are bidi-correct now (ntk
   caret API), but arrow keys still move logically; visual-order movement
   - split caret at direction boundaries is a later refinement

--- a/docs/components.md
+++ b/docs/components.md
@@ -35,6 +35,20 @@ Behavior: click / Space / Enter toggles the menu; Escape, focus loss, or
 picking closes it; the option list scrolls when taller than 220px; the
 trigger participates in Tab traversal.
 
+Keyboard, while the trigger is focused (the popup is override-redirect and
+never takes focus, so the trigger keeps handling keys with the menu open):
+
+| key               | closed         | open                                    |
+| ----------------- | -------------- | --------------------------------------- |
+| `Down` / `Up`     | opens the menu | move the active option, wrapping around |
+| `Home` / `End`    | —              | first / last option                     |
+| `Enter` / `Space` | opens the menu | pick the active option                  |
+| `Escape`          | —              | close without picking                   |
+
+The menu opens with the current value active, hovering an option makes it
+active (pointer and keyboard share one highlight), and the active option is
+scrolled into view.
+
 ### Theming
 
 ```jsx

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -86,8 +86,13 @@ by default; a scrollbar thumb is drawn when content overflows.
 | `scrollbar={false}`                                  | hide the drawn scrollbar |
 | `scrollbarColor`                                     | thumb color              |
 
-**Ref**: the node, plus `scrollTo(y)` / `scrollBy(dy)` and `scrollY` /
-`contentHeight`.
+**Ref**: the node, plus `scrollTo(y)` / `scrollBy(dy)` /
+`scrollIntoView(node)` and `scrollY` / `contentHeight`.
+
+`scrollIntoView(node)` scrolls the minimum amount that makes a descendant
+node fully visible, and is safe to call from an effect right after that
+node mounts: the request is resolved on the next layout pass, when the
+node actually has geometry.
 
 ## `<text>`
 

--- a/src/components.js
+++ b/src/components.js
@@ -9,10 +9,13 @@ const ITEM_HEIGHT = 28;
 const MAX_MENU_HEIGHT = 220;
 
 const XK_RETURN = 0xff0d;
+const XK_ESCAPE = 0xff1b;
+const XK_HOME = 0xff50;
 const XK_LEFT = 0xff51;
 const XK_UP = 0xff52;
 const XK_RIGHT = 0xff53;
 const XK_DOWN = 0xff54;
+const XK_END = 0xff57;
 
 const DefaultTheme = {
   border: '#b2bec3',
@@ -349,25 +352,26 @@ function normalizeOption(option) {
     : { value: option, label: String(option) };
 }
 
-function Option({ option, selected, onPick }) {
+function Option({ option, selected, active, onPick, onHover, nodeRef }) {
   const theme = useTheme();
-  const [hover, setHover] = useState(false);
+  // one highlight, shared by pointer and keyboard: hovering moves the
+  // active index rather than tracking a second, competing state
   return h(
     'box',
     {
+      ref: nodeRef,
       height: ITEM_HEIGHT,
       justifyContent: 'center',
       paddingLeft: 10,
       cursor: 'pointer',
-      backgroundColor: hover ? theme.hoverBackground : theme.background,
-      onMouseEnter: () => setHover(true),
-      onMouseLeave: () => setHover(false),
+      backgroundColor: active ? theme.hoverBackground : theme.background,
+      onMouseEnter: () => onHover?.(),
       onClick: () => onPick(option),
     },
     h(
       'text',
       {
-        color: hover ? theme.hoverText : theme.text,
+        color: active ? theme.hoverText : theme.text,
         fontWeight: selected ? 'bold' : 'normal',
       },
       option.label,
@@ -381,6 +385,12 @@ function Option({ option, selected, onPick }) {
  * anchored below the trigger (owner window position + trigger rect).
  * Closes on pick, Escape, toggling the trigger, or focus loss within the
  * owner window.
+ *
+ * Keyboard (the trigger keeps focus while the menu is open — the popup is
+ * override-redirect and never takes it): Up/Down open the menu, then move
+ * the active option with wrapping; Home/End jump to the ends; Enter/Space
+ * pick the active option (or open the menu when closed); Escape closes.
+ * The active option is scrolled into view.
  */
 export function Select({
   value,
@@ -394,17 +404,16 @@ export function Select({
   const [open, setOpen] = useState(false);
   const [anchor, setAnchor] = useState(null);
   const [focused, setFocused] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
   const triggerRef = useRef(null);
+  const scrollRef = useRef(null);
+  const activeRef = useRef(null);
 
   const normalized = options.map(normalizeOption);
   const current = normalized.find((o) => o.value === value);
 
   const close = () => setOpen(false);
-  const toggle = () => {
-    if (open) {
-      close();
-      return;
-    }
+  const openMenu = () => {
     const node = triggerRef.current;
     if (!node) return;
     const win = node.root?.window;
@@ -413,13 +422,54 @@ export function Select({
       y: (win?.y ?? 0) + node.abs.y + node.abs.height + 2,
       width: node.abs.width,
     });
+    const selected = normalized.findIndex((o) => o.value === value);
+    setActiveIndex(selected >= 0 ? selected : 0);
     setOpen(true);
   };
+  const toggle = () => (open ? close() : openMenu());
 
   const pick = (option) => {
     close();
     if (option.value !== value) onChange?.(option.value);
   };
+
+  const move = (delta) => {
+    const count = normalized.length;
+    if (!count) return;
+    setActiveIndex((i) => (i < 0 ? 0 : (i + delta + count) % count));
+  };
+
+  const onKeyDown = (ev) => {
+    const count = normalized.length;
+    switch (ev.keysym) {
+      case XK_ESCAPE:
+        if (open) close();
+        return;
+      case XK_DOWN:
+      case XK_UP:
+        if (open) move(ev.keysym === XK_DOWN ? 1 : -1);
+        else openMenu();
+        return;
+      case XK_HOME:
+      case XK_END:
+        if (open && count)
+          setActiveIndex(ev.keysym === XK_HOME ? 0 : count - 1);
+        return;
+      default:
+        break;
+    }
+    if (ev.codepoint === 32 || ev.keysym === XK_RETURN) {
+      const option = open ? normalized[activeIndex] : null;
+      if (option) pick(option);
+      else toggle();
+    }
+  };
+
+  // keep the highlighted option visible while arrowing through a menu that
+  // overflows MAX_MENU_HEIGHT (resolved on the popup's next layout pass)
+  useEffect(() => {
+    if (open) scrollRef.current?.scrollIntoView(activeRef.current);
+  }, [open, activeIndex]);
 
   const menuHeight = Math.min(
     normalized.length * ITEM_HEIGHT + 8,
@@ -449,10 +499,7 @@ export function Select({
         setFocused(false);
         close();
       },
-      onKeyDown: (ev) => {
-        if (ev.keysym === 0xff1b /* Escape */) close();
-        if (ev.codepoint === 32 || ev.keysym === 0xff0d) toggle();
-      },
+      onKeyDown,
       ...boxProps,
     },
     h(
@@ -489,18 +536,26 @@ export function Select({
           'box',
           {
             flexGrow: 1,
+            // yoga's default flexShrink is 0: without this the frame keeps
+            // its content height, the scrollview inside it never shrinks to
+            // the viewport, and a menu longer than MAX_MENU_HEIGHT gets
+            // clipped by the popup's edge instead of scrolling
+            flexShrink: 1,
             borderWidth: 1,
             borderColor: theme.border,
             backgroundColor: theme.background,
           },
           h(
             'scrollview',
-            { flexGrow: 1, padding: 4 },
-            normalized.map((option) =>
+            { ref: scrollRef, flexGrow: 1, padding: 4 },
+            normalized.map((option, index) =>
               h(Option, {
                 key: String(option.value),
                 option,
                 selected: option.value === value,
+                active: index === activeIndex,
+                nodeRef: index === activeIndex ? activeRef : undefined,
+                onHover: () => setActiveIndex(index),
                 onPick: pick,
               }),
             ),

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -589,6 +589,7 @@ export class ScrollViewNode extends Node {
     }
     this.contentHeight =
       bottom + this.yoga.getComputedPadding(Yoga.EDGE_BOTTOM);
+    this._resolveScrollIntoView();
     this.scrollY = Math.min(
       Math.max(0, this.scrollY),
       Math.max(0, this.contentHeight - this.abs.height),
@@ -615,6 +616,39 @@ export class ScrollViewNode extends Node {
 
   scrollBy(dy) {
     this.scrollTo(this.scrollY + dy);
+  }
+
+  /**
+   * Scroll the minimum amount that brings a descendant fully into view.
+   * The request is queued rather than applied immediately: absolute rects
+   * only exist after a layout pass, so a caller reacting to a mount (a
+   * list widget moving its selection, say) would otherwise measure a node
+   * that has no geometry yet. `absolutize` resolves it against freshly
+   * computed yoga positions.
+   */
+  scrollIntoView(node) {
+    if (!node) return;
+    this._scrollIntoViewTarget = node;
+    this.root?.invalidate(true);
+  }
+
+  _resolveScrollIntoView() {
+    const target = this._scrollIntoViewTarget;
+    if (!target) return;
+    this._scrollIntoViewTarget = null;
+    if (target.destroyed || !target.yoga) return;
+    // offset of the target within our content box, summed up the chain so
+    // targets nested below a direct child work too
+    let top = 0;
+    for (let n = target; n && n !== this; n = n.parent) {
+      if (!n.yoga) return; // not (or no longer) inside this scrollview
+      top += n.yoga.getComputedTop();
+      if (!n.parent) return;
+    }
+    const bottom = top + target.yoga.getComputedHeight();
+    const viewport = this.abs.height;
+    if (bottom > this.scrollY + viewport) this.scrollY = bottom - viewport;
+    if (top < this.scrollY) this.scrollY = top;
   }
 
   paint(ctx) {

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -516,6 +516,49 @@ test('scrollview scrolls, clamps and offsets hit testing', async () => {
   ReactX11.unmountComponentAtNode(app);
 });
 
+test('scrollview scrollIntoView scrolls the minimum amount', async () => {
+  const app = createMockApp();
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 100, height: 100 },
+      React.createElement(
+        'scrollview',
+        { flexGrow: 1 },
+        [0, 1, 2].map((i) =>
+          React.createElement('box', { key: i, height: 60 }),
+        ),
+      ),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const sv = app.windows[0]._reactX11Node.children[0];
+
+  // last child (content 120..180) into a 100px viewport: scroll to its bottom
+  sv.scrollIntoView(sv.children[2]);
+  await tick();
+  assert.strictEqual(sv.scrollY, 80);
+
+  // first child is above the viewport: align its top
+  sv.scrollIntoView(sv.children[0]);
+  await tick();
+  assert.strictEqual(sv.scrollY, 0);
+
+  // already fully visible → no movement
+  sv.scrollIntoView(sv.children[0]);
+  await tick();
+  assert.strictEqual(sv.scrollY, 0);
+
+  // a node outside this scrollview is ignored
+  sv.scrollIntoView(app.windows[0]._reactX11Node);
+  await tick();
+  assert.strictEqual(sv.scrollY, 0);
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
 test('popup mounts as an override-redirect window and unmounts cleanly', () => {
   const app = createMockApp();
   const render = (open) =>
@@ -846,6 +889,201 @@ test('Select opens a popup menu, picks an option, closes on Escape', async () =>
   pressKey(app, wnd, { keysym: 0xff1b }); // Escape
   await tick();
   assert.strictEqual(app.windows[2].destroyed, true);
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('Select: arrow keys move the active option, Enter picks it', async () => {
+  const { Select } = await import('../src/index.js');
+  const XK_DOWN = 0xff54;
+  const XK_UP = 0xff52;
+  const XK_HOME = 0xff50;
+  const XK_END = 0xff57;
+  const HOVER_BG = '#2980b9';
+
+  const app = createMockApp();
+  const picks = [];
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 240, height: 120 },
+      React.createElement(
+        'box',
+        { flexGrow: 1, padding: 10 },
+        React.createElement(Select, {
+          options: ['red', 'green', 'blue'],
+          value: 'green',
+          width: 160,
+          onChange: (v) => picks.push(v),
+        }),
+      ),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+
+  const findFocusable = (node) => {
+    if (node.props?.focusable) return node;
+    for (const child of node.children) {
+      if (child.isWindow) continue;
+      const hit = findFocusable(child);
+      if (hit) return hit;
+    }
+    return null;
+  };
+  const trigger = findFocusable(wnd._reactX11Node);
+  const cx = trigger.abs.x + 10;
+  const cy = trigger.abs.y + trigger.abs.height / 2;
+
+  // the active option is the one painted with the highlight background
+  const activeIndex = () => {
+    const popup = app.windows.at(-1);
+    let scroller = null;
+    const walk = (n) => {
+      if (n.kind === 'scrollview') scroller = n;
+      else n.children.forEach(walk);
+    };
+    walk(popup._reactX11Node);
+    return scroller.children.findIndex(
+      (o) => o.props.backgroundColor === HOVER_BG,
+    );
+  };
+
+  // click focuses the trigger and opens the menu on the selected option
+  wnd.emit('mousedown', { x: cx, y: cy, keycode: 1 });
+  wnd.emit('mouseup', { x: cx, y: cy, keycode: 1 });
+  await tick();
+  assert.strictEqual(activeIndex(), 1, 'opens on the current value');
+
+  pressKey(app, wnd, { keysym: XK_DOWN });
+  await tick();
+  assert.strictEqual(activeIndex(), 2);
+
+  pressKey(app, wnd, { keysym: XK_DOWN }); // wraps
+  await tick();
+  assert.strictEqual(activeIndex(), 0);
+
+  pressKey(app, wnd, { keysym: XK_UP }); // wraps back
+  await tick();
+  assert.strictEqual(activeIndex(), 2);
+
+  pressKey(app, wnd, { keysym: XK_HOME });
+  await tick();
+  assert.strictEqual(activeIndex(), 0);
+
+  pressKey(app, wnd, { keysym: XK_END });
+  await tick();
+  assert.strictEqual(activeIndex(), 2);
+
+  // Enter picks the active option (not the one under the pointer)
+  pressKey(app, wnd, { keysym: XK.Return });
+  await tick();
+  assert.deepStrictEqual(picks, ['blue']);
+  assert.strictEqual(app.windows[1].destroyed, true, 'menu closes on pick');
+
+  // with the menu closed, Down reopens it — focus stayed on the trigger
+  pressKey(app, wnd, { keysym: XK_DOWN });
+  await tick();
+  assert.strictEqual(app.windows.length, 3, 'Down reopens the menu');
+  assert.strictEqual(activeIndex(), 1, 'still anchored on the current value');
+
+  pressKey(app, wnd, { keysym: 0xff1b }); // Escape
+  await tick();
+  assert.strictEqual(app.windows[2].destroyed, true);
+  assert.deepStrictEqual(picks, ['blue'], 'Escape does not pick');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('Select: an overlong menu scrolls the active option into view', async () => {
+  const { Select } = await import('../src/index.js');
+  const XK_DOWN = 0xff54;
+  const XK_END = 0xff57;
+  const ITEM_HEIGHT = 28;
+  const options = Array.from({ length: 12 }, (_, i) => `option-${i}`);
+
+  const app = createMockApp();
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 300, height: 120 },
+      React.createElement(
+        'box',
+        { flexGrow: 1, padding: 10 },
+        React.createElement(Select, { options, value: options[0], width: 220 }),
+      ),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+
+  const findFocusable = (node) => {
+    if (node.props?.focusable) return node;
+    for (const child of node.children) {
+      if (child.isWindow) continue;
+      const hit = findFocusable(child);
+      if (hit) return hit;
+    }
+    return null;
+  };
+  const trigger = findFocusable(wnd._reactX11Node);
+  wnd.emit('mousedown', {
+    x: trigger.abs.x + 10,
+    y: trigger.abs.y + trigger.abs.height / 2,
+    keycode: 1,
+  });
+  wnd.emit('mouseup', {
+    x: trigger.abs.x + 10,
+    y: trigger.abs.y + trigger.abs.height / 2,
+    keycode: 1,
+  });
+  // scrollIntoView resolves on the popup's next layout pass, so a key press
+  // needs the effect's tick plus the flush it schedules
+  const settle = async () => {
+    await tick();
+    await tick();
+  };
+  await settle();
+
+  const scroller = (() => {
+    let found = null;
+    const walk = (n) => {
+      if (n.kind === 'scrollview') found = n;
+      else n.children.forEach(walk);
+    };
+    walk(app.windows[1]._reactX11Node);
+    return found;
+  })();
+
+  // the frame must shrink to the popup so the viewport is the clamped menu
+  // height, not the full content height — otherwise nothing ever scrolls
+  assert.ok(
+    scroller.contentHeight > scroller.abs.height,
+    `menu should overflow: content ${scroller.contentHeight} vs viewport ${scroller.abs.height}`,
+  );
+  assert.strictEqual(scroller.scrollY, 0);
+
+  // arrowing down only scrolls once the active option leaves the viewport
+  const visible = Math.floor((scroller.abs.height - 4) / ITEM_HEIGHT);
+  for (let i = 0; i < visible - 1; i++) pressKey(app, wnd, { keysym: XK_DOWN });
+  await settle();
+  assert.strictEqual(scroller.scrollY, 0, 'still within the viewport');
+
+  pressKey(app, wnd, { keysym: XK_DOWN });
+  await settle();
+  assert.ok(scroller.scrollY > 0, 'scrolls to keep the active option visible');
+
+  // End jumps to the last option: scrolled to the bottom of the content
+  pressKey(app, wnd, { keysym: XK_END });
+  await settle();
+  assert.strictEqual(
+    scroller.scrollY,
+    4 + options.length * ITEM_HEIGHT - scroller.abs.height,
+  );
 
   ReactX11.unmountComponentAtNode(app);
 });


### PR DESCRIPTION
Closes the most visible widget gap: `<Select>` was mouse-only.

## Keyboard

The trigger keeps focus while the menu is open — the popup is
override-redirect and never takes focus — so the trigger handles keys in
both states:

| key               | closed         | open                                    |
| ----------------- | -------------- | --------------------------------------- |
| `Down` / `Up`     | opens the menu | move the active option, wrapping around |
| `Home` / `End`    | —              | first / last option                     |
| `Enter` / `Space` | opens the menu | pick the active option                  |
| `Escape`          | —              | close without picking                   |

The menu opens with the current value active. Pointer and keyboard share
**one** highlight — hovering sets the active index rather than tracking a
second, competing hover state — so arrowing away from the mouse no longer
paints two highlighted rows.

## `scrollIntoView` on `<scrollview>`

New ref method: `scrollIntoView(node)` scrolls the minimum amount that
makes a descendant fully visible. The request is *queued* and resolved on
the next layout pass rather than applied immediately — a caller reacting
to a mount (exactly this case) would otherwise measure a node that has no
geometry yet.

## Layout fix found while screenshotting this

The popup's frame box had `flexGrow: 1` but yoga's default `flexShrink`
of **0**, so it kept its full content height, the scrollview inside it
never shrank to the viewport, and a menu longer than `MAX_MENU_HEIGHT`
was clipped by the popup's edge instead of scrolling. **Scrolling long
Select menus never worked before this.** `ScrollViewNode` already
compensated for itself (same reasoning is commented in `nodes.js`); the
wrapper box did not.

## Screenshots

Rendered by this PR's own code: a 12-option `Select` driven purely by
synthetic key events into the in-process X server, captured from the
popup window itself.

Menu opened with `Down` — active on the current value (`Cerulean`, bold =
selected):

![select-kbd-open](https://github.com/user-attachments/assets/89eb83d1-eadc-44f8-83d9-9f28473fea35)
<img width="220" height="222" alt="select-kbd-open" src="https://github.com/user-attachments/assets/77424eb2-4304-4fae-9e8d-642148cd4df6" />

After 6 more `Down`s — `Indigo` active, viewport scrolled just enough to
keep it visible (note the scrollbar thumb):

![select-kbd-scrolled](https://github.com/user-attachments/assets/1beb7fbd-07d7-4751-be11-8f743232cc1b)
<img width="220" height="222" alt="select-kbd-scrolled" src="https://github.com/user-attachments/assets/a8b1b0c1-de49-4688-8355-a8ff5b0b39c4" />

`End` — last option active, scrolled to the bottom:

![select-kbd-end](https://github.com/user-attachments/assets/f1d5948d-f27c-4392-b68e-c6b988770ca5)

<img width="220" height="222" alt="select-kbd-end" src="https://github.com/user-attachments/assets/20acd526-8edd-4e61-b77a-a9da347e87e3" />

## Tests

`npm test` — 46/46. New: keyboard navigation end to end, an overlong menu
scrolling the active option into view (this fails without the
`flexShrink` fix), and `scrollIntoView`'s minimum-scroll behavior
including the already-visible and not-a-descendant cases.
