### PR TITLE
feat: screenshots:framed — capture examples with the WM's window frame

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 node_modules/
 *.log
 .DS_Store
+
+# framed screenshots are machine-specific (they capture the local WM's
+# decorations), so they are generated on demand rather than committed
+docs/img/framed/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,34 @@ no override-redirect staging (issue #4).
   sets text in a system sans-serif (Arial / Liberation / DejaVu — small
   serif text reads as a document, not a UI). Run it whenever a change
   affects how the examples look.
+- `npm run screenshots:framed [scene…]` — the same examples captured
+  **with the window manager's frame**, into `docs/img/framed/`
+  (gitignored — the decorations are whatever WM is running locally, so
+  they are generated on demand, not committed). Needs a real `DISPLAY`
+  with a **reparenting** WM; `npm run screenshots` has no WM at all and
+  therefore no frames. See "Framed screenshots" below.
+
+## Framed screenshots
+
+A reparenting WM puts the client window inside a frame window that is a
+child of root, and draws the decoration into it — so the frame is ordinary
+X pixels and `GetImage` can read it. On XQuartz this works because
+quartz-wm renders the Aqua titlebar through the Apple-WM extension's
+`FrameDraw`; on Linux any normal WM does the same with its own theme.
+
+Two things the script has to get right:
+
+- **Find the frame**: walk up from the client window to the ancestor whose
+  parent is root. `ntk`'s `window.queryTree()` or `X.QueryTree` both do.
+- **Beat occlusion**: `GetImage` on a window returns the current _screen_
+  contents of that region, so an overlapping window is captured instead of
+  yours. The script floats the window first — Apple-WM
+  `SetWindowLevel(Floating)` where available, plus `RaiseWindow`.
+  Note quartz-wm does **not** advertise `_NET_WM_STATE_ABOVE`, so on
+  XQuartz the Apple-WM window level is the only always-on-top mechanism.
+- Apple-WM's `SetWindowLevel` wants the **frame**, not the client: once
+  reparented the client is no longer a child of root and the request
+  answers `BadWindow` (opcode 130).
 
 ## Gotchas
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "examples:richtext": "tsx examples/richtext.jsx",
     "examples:widgets": "tsx examples/widgets.jsx",
     "examples:windows": "tsx examples/windows.jsx",
-    "screenshots": "tsx scripts/screenshots.jsx"
+    "screenshots": "tsx scripts/screenshots.jsx",
+    "screenshots:framed": "tsx scripts/screenshots-framed.jsx"
   },
   "repository": {
     "type": "git",

--- a/scripts/screenshots-framed.jsx
+++ b/scripts/screenshots-framed.jsx
@@ -1,0 +1,184 @@
+// Capture examples WITH their window-manager frame, against a real X server.
+//
+//   npm run screenshots:framed              # all scenes
+//   npm run screenshots:framed widgets form # just these
+//
+// Unlike `npm run screenshots` (which renders into node-x11's in-process X
+// server and therefore has no window manager and no frames), this needs a
+// real DISPLAY with a *reparenting* WM: quartz-wm on XQuartz, mutter/openbox
+// /etc. on Linux. Such a WM puts the client window inside a frame window
+// that is a child of root, and draws the decoration into it — on XQuartz via
+// the Apple-WM extension's FrameDraw, so the Aqua titlebar is real X pixels
+// that GetImage can read.
+//
+// GetImage on a window returns the current *screen* contents of that region,
+// so anything overlapping the window would be captured instead of it. To
+// avoid that the window is floated above everything else: Apple-WM's
+// SetWindowLevel(Floating) where available, plus a plain RaiseWindow.
+import { createClient } from 'ntk';
+import { PNG } from 'pngjs';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import React from 'react';
+
+process.env.REACT_X11_NO_AUTORUN = '1';
+const ReactX11 = (await import('../src/index.js')).default;
+
+const outDir =
+  process.env.SHOT_DIR ??
+  join(
+    dirname(new URL(import.meta.url).pathname),
+    '..',
+    'docs',
+    'img',
+    'framed',
+  );
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// --- scenes ----------------------------------------------------------------
+
+const SCENES = {
+  widgets: () => import('../examples/widgets.jsx'),
+  dashboard: () => import('../examples/dashboard.jsx'),
+  tasks: () => import('../examples/tasks.jsx'),
+  form: () => import('../examples/form.jsx'),
+};
+
+const wanted = process.argv.slice(2).filter((a) => !a.startsWith('-'));
+const scenes = wanted.length ? wanted : Object.keys(SCENES);
+for (const name of scenes) {
+  if (!SCENES[name]) {
+    console.error(
+      `unknown scene "${name}" (have: ${Object.keys(SCENES).join(', ')})`,
+    );
+    process.exit(2);
+  }
+}
+
+// --- X helpers -------------------------------------------------------------
+
+const cb2p =
+  (fn) =>
+  (...args) =>
+    new Promise((res, rej) => fn(...args, (e, v) => (e ? rej(e) : res(v))));
+
+/** Float the window above everything so GetImage cannot capture an
+ *  overlapping window instead. Apple-WM window levels are the only
+ *  always-on-top mechanism on XQuartz — quartz-wm does not advertise
+ *  _NET_WM_STATE_ABOVE.
+ *
+ *  Pass the FRAME, not the client: once a WM has reparented us the client
+ *  is no longer a child of root, and SetWindowLevel answers BadWindow for
+ *  it (opcode 130). The level belongs on the window the WM manages. */
+async function floatOnTop(app, wid) {
+  const X = app.X;
+  let via = 'RaiseWindow';
+  const appleWM = await new Promise((res) =>
+    X.require('apple-wm', (err, ext) => res(err ? null : ext)),
+  ).catch(() => null);
+  if (appleWM) {
+    appleWM.SetWindowLevel(wid, appleWM.WindowLevel.Floating);
+    via = 'Apple-WM SetWindowLevel(Floating)';
+  }
+  X.RaiseWindow(wid);
+  return via;
+}
+
+/** Walk up from the client window to the frame the WM reparented it into:
+ *  the ancestor whose parent is root. Returns the client itself when no
+ *  reparenting WM is running (nothing to capture but the client). */
+async function findFrame(app, wid) {
+  const X = app.X;
+  const queryTree = cb2p(X.QueryTree.bind(X));
+  const root = app.display.screen[0].root;
+  let frame = wid;
+  for (let hops = 0; hops < 8; hops++) {
+    const { parent } = await queryTree(frame);
+    if (!parent || parent === root) break;
+    frame = parent;
+  }
+  return { frame, reparented: frame !== wid };
+}
+
+async function capture(app, drawable, file) {
+  const X = app.X;
+  const geom = await cb2p(X.GetGeometry.bind(X))(drawable);
+  const img = await cb2p(X.GetImage.bind(X))(
+    2 /* ZPixmap */,
+    drawable,
+    0,
+    0,
+    geom.width,
+    geom.height,
+    0xffffffff,
+  );
+  const png = new PNG({ width: geom.width, height: geom.height });
+  for (let i = 0; i < geom.width * geom.height; i++) {
+    png.data[i * 4 + 0] = img.data[i * 4 + 2]; // BGRA -> RGBA
+    png.data[i * 4 + 1] = img.data[i * 4 + 1];
+    png.data[i * 4 + 2] = img.data[i * 4 + 0];
+    png.data[i * 4 + 3] = 255;
+  }
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, PNG.sync.write(png));
+  return geom;
+}
+
+// --- run -------------------------------------------------------------------
+
+if (!process.env.DISPLAY) {
+  console.error(
+    'no DISPLAY — this script needs a real X server with a reparenting window\n' +
+      'manager (XQuartz on macOS, any normal WM on Linux). For headless,\n' +
+      'frameless screenshots use `npm run screenshots`.',
+  );
+  process.exit(1);
+}
+
+// One connection for every scene: closing an ntk app while property round
+// trips are still in flight can hang (see AGENTS.md), and reconnecting per
+// scene is slower for no benefit.
+const app = await createClient();
+const created = [];
+const origCreate = app.createWindow.bind(app);
+app.createWindow = (attrs) => {
+  const w = origCreate(attrs);
+  created.push(w);
+  return w;
+};
+
+/** Drain pending round trips so a following close() cannot race them. */
+const settle = () =>
+  cb2p(app.X.GetGeometry.bind(app.X))(app.display.screen[0].root);
+
+for (const name of scenes) {
+  const { default: App } = await SCENES[name]();
+  created.length = 0;
+
+  await new Promise((resolve) =>
+    ReactX11.render(React.createElement(App), resolve, app),
+  );
+  await sleep(400); // map + WM reparent + first paint
+
+  const wnd = created[0];
+  const { frame, reparented } = await findFrame(app, wnd.id);
+  const via = await floatOnTop(app, frame);
+  await sleep(500); // let the WM restack and redraw the frame
+
+  const geom = await capture(app, frame, join(outDir, `${name}.png`));
+  console.log(
+    `${name}: ${geom.width}x${geom.height} ` +
+      (reparented
+        ? `(framed, raised via ${via})`
+        : '(NO frame — no reparenting WM running?)'),
+  );
+
+  ReactX11.unmountComponentAtNode(app);
+  await settle();
+  await sleep(150);
+}
+
+await settle();
+await app.close();
+process.exit(0);


### PR DESCRIPTION
`npm run screenshots` renders into node-x11's in-process X server, which has **no window manager**, so its images are frameless. This adds a companion script that runs the same examples against a real `DISPLAY` and captures the WM frame around them.

```
npm run screenshots:framed            # all scenes
npm run screenshots:framed widgets    # just one
```

## Why this works

A *reparenting* WM puts the client window inside a frame window that is a child of root, and draws the decoration into it — so the frame is ordinary X pixels that `GetImage` can read. On XQuartz that holds because quartz-wm renders the Aqua titlebar through the Apple-WM extension's `FrameDraw`. On Linux any normal WM does the same with its own theme.

## Two things it has to get right

- **Occlusion.** `GetImage` on a window returns the current *screen* contents of that region, so an overlapping window gets captured instead of yours. The target is floated first: Apple-WM `SetWindowLevel(Floating)` plus `RaiseWindow`. Worth noting quartz-wm does **not** advertise `_NET_WM_STATE_ABOVE` (I dumped its 41-atom `_NET_SUPPORTED`), so on XQuartz the Apple-WM window level is the only always-on-top mechanism there is.
- **`SetWindowLevel` takes the frame, not the client.** Once reparented the client is no longer a child of root, and the request answers `BadWindow` (opcode 130). Hit this for real on the first run.

Also uses a single connection for all scenes — closing an ntk app with property round trips still in flight hangs (the gotcha already noted in AGENTS.md), and reconnecting per scene bought nothing.

## Output

`docs/img/framed/`, **gitignored**: the decorations are whatever WM is running locally, so committing macOS Aqua frames would misrepresent what a Linux user sees. Generated on demand instead.

## Screenshots

Produced by this script, unmodified:

![dashboard](https://github.com/user-attachments/assets/150b2bb1-11f9-4092-adeb-0441dbf9864c)

![widgets](https://github.com/user-attachments/assets/6307f5cc-5c89-4cc3-b288-46682b983c7d)

![tasks](https://github.com/user-attachments/assets/97a01dba-bec1-4b48-8849-b9e84b920b83)

![form](https://github.com/user-attachments/assets/b451c479-46e6-4d6f-94f9-e61fc93a1102)

`npm test` 46/46, lint clean. AGENTS.md documents the command and the frame/occlusion mechanics.
