### PR TITLE
feat: window manager hints as <window> props; type hint on <popup>

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -374,10 +374,16 @@ File these as ntk issues; react-x11 should not work around them long-term.
    `saveUnder`, input-only class are all silently ignored (`lib/window.js`).
    react-x11 passes `overrideRedirect: true` today and it does nothing.
    Blocking `<popup>`.
-2. **UTF-8 window titles + EWMH.** `setTitle` writes only latin `WM_NAME`;
-   add `_NET_WM_NAME` (UTF8_STRING), `_NET_WM_WINDOW_TYPE`
-   (MENU/TOOLTIP/DIALOG — the WM-friendly alternative to overrideRedirect),
-   `WM_CLASS`, icons.
+2. **UTF-8 window titles + EWMH** — DONE. `_NET_WM_NAME` shipped in ntk
+   3.3.0; `WM_NORMAL_HINTS`, `WM_CLASS`, `_NET_WM_WINDOW_TYPE` and
+   always-on-top in **ntk 3.5.0** (sidorares/ntk#77), surfaced here as
+   `<window resizable sizeHints wmClass windowType alwaysOnTop>` and a
+   default `windowType="dropdown_menu"` on `<popup>`. Note the type hint is
+   _additive_, not a replacement for override-redirect: the spec asks for it
+   on override-redirect windows so compositors can style menus consistently,
+   while override-redirect is still what stops the WM repositioning them.
+   Still missing upstream: `_NET_WM_ICON`, `_NET_WM_STATE` (fullscreen /
+   maximize / minimize), `_NET_WM_PID`.
 3. **Re-export the Yoga instance** so renderer and HtmlView share one WASM
    module and version.
 4. **Rect-level presentation.** `_presentNow` blits the full window; accept

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -54,10 +54,37 @@ A real X11 window; the flex, paint and event root for its subtree.
 | `backgroundColor`           | full-window clear color (default white)                              |
 | `onResize(ev)`              | ConfigureNotify — the tree reflows automatically                     |
 | `onExpose(ev)`              | after a repaint was required                                         |
+| `onCloseRequest(ev)`        | WM close button (opts into `WM_DELETE_WINDOW`)                       |
 
 Windows may be nested inside other windows (real X11 child windows).
 **Ref**: the live ntk `Window` — `getContext('2d')`,
 `requestAnimationFrame`, `setCursor`, the whole ntk API.
+
+### Window manager hints
+
+Properties the window manager reads (ntk ≥ 3.5.0). All work at mount and
+update; unchanged values are not re-sent.
+
+| prop          |                                                                                                                         |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `resizable`   | `false` pins min and max size to the current size                                                                       |
+| `sizeHints`   | `{minWidth, minHeight, maxWidth, maxHeight, widthInc, heightInc, baseWidth, baseHeight, minAspect, maxAspect, gravity}` |
+| `wmClass`     | `'instance'`, `['instance', 'Class']` or `{instance, class}`                                                            |
+| `windowType`  | `'dialog'`, `'utility'`, `'tooltip'`… or an array of fallbacks                                                          |
+| `alwaysOnTop` | keep above normal windows                                                                                               |
+
+```jsx
+<window width={400} height={300} resizable={false} windowType="dialog" />
+<window sizeHints={{ minWidth: 320, minHeight: 200 }} />
+```
+
+`sizeHints` is an object rather than flat `minWidth`/`maxWidth` props
+because those names are yoga layout style everywhere else — `<window>`
+already has the wrinkle that `width`/`height` are window state, and
+overloading two more would compound it.
+
+`alwaysOnTop` uses EWMH `_NET_WM_STATE_ABOVE`, falling back to Apple-WM
+window levels on XQuartz, where quartz-wm does not support that state.
 
 ## `<popup>`
 
@@ -68,6 +95,13 @@ the tree does not affect its position on screen); it is its own paint and
 event root. Anchor with `ev.nativeEvent.rootx/rooty` (pointer in screen
 coordinates) or a ref's `abs` rect plus the owner window's `x`/`y`.
 Same props as `<window>`; conditional rendering controls its lifetime.
+
+Defaults to `windowType="dropdown_menu"`; pass `windowType` to override
+(`"tooltip"`, `"popup_menu"`, …). The hint is **additive** — override-
+redirect is what keeps the WM from moving or decorating the popup, and
+stays on. The EWMH spec asks for the type hint on override-redirect
+windows too, so compositing managers can give menus and tooltips
+consistent shadows and animations.
 
 ## `<box>`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^3.4.0",
+        "ntk": "^3.5.0",
         "react-reconciler": "^0.33.0"
       },
       "devDependencies": {
@@ -4071,9 +4071,9 @@
       }
     },
     "node_modules/ntk": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-3.4.0.tgz",
-      "integrity": "sha512-wcreMQBVkwC58Ah520CTXplLt6MlR3SSFiBH5Mv6O6PikY15nQpyfSiuyxEM0lH0jbosGc4p0wO56aVD33gsLw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-3.5.0.tgz",
+      "integrity": "sha512-ySIrWXW//0RwkjxWyPTwu5uZapapF1XvwoDB3wA7VwaRJM+nNKl8SKG/dyd1TSjKtgisQSSDIV5yagQpSnvJNA==",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",
@@ -4094,7 +4094,7 @@
         "parse-color": "^1.0.0",
         "pngjs": "^7.0.0",
         "postcss": "^8.5.23",
-        "x11": "^3.1.1",
+        "x11": "^3.1.2",
         "yoga-layout": "^3.2.1"
       },
       "engines": {
@@ -5408,9 +5408,9 @@
       }
     },
     "node_modules/x11": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/x11/-/x11-3.1.1.tgz",
-      "integrity": "sha512-FeTpXbOVBogU8ndjZCM5YQvjIDDRkoGqLiTA7eJJFz9xXRfBzyTcPxIDaSQfgRDNMnpIK8M9GmknfjQ+tLc4lQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/x11/-/x11-3.1.2.tgz",
+      "integrity": "sha512-AmtrdsEPQy0LCQEWNdOogTlmS97zvbq17qt/QZ0pk4p8sYij+z9SAlPtNK+amzJADkjSOeJv6rhTQJUQc19aRg==",
       "engines": {
         "node": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^3.4.0",
+    "ntk": "^3.5.0",
     "react-reconciler": "^0.33.0"
   },
   "peerDependencies": {

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -35,6 +35,18 @@ export const DEVTOOLS_FAKE_DOCUMENT = {
   defaultView: null,
 };
 
+/** Equality for props that may be a scalar, an array or a plain object
+ *  (window hints are all three shapes), so an unchanged inline object
+ *  literal does not re-send the property every render. */
+function shallowEqual(a, b) {
+  if (a === b) return true;
+  if (typeof a !== 'object' || typeof b !== 'object' || !a || !b) return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  const ka = Object.keys(a);
+  const kb = Object.keys(b);
+  return ka.length === kb.length && ka.every((k) => a[k] === b[k]);
+}
+
 export class Node {
   get ownerDocument() {
     return DEVTOOLS_FAKE_DOCUMENT;
@@ -1372,6 +1384,42 @@ export class WindowNode extends Node {
     this.invalidate(true);
   }
 
+  /**
+   * Window-manager hints that changed since the last render (ntk >= 3.5.0).
+   * Creation is handled by ntk's Window constructor — every non-event prop
+   * is forwarded there as a creation attribute — so this only has to cover
+   * updates.
+   *
+   * `sizeHints` is an object rather than flat minWidth/maxWidth props on
+   * purpose: those names are yoga layout style, and a `<window>` already
+   * has the confusing split where width/height are window state instead.
+   */
+  _applyWindowHints(next, prev) {
+    const wnd = this.window;
+
+    if (
+      next.resizable !== prev.resizable ||
+      !shallowEqual(next.sizeHints, prev.sizeHints)
+    ) {
+      wnd.setSizeHints?.({
+        ...next.sizeHints,
+        ...(next.resizable === false && { resizable: false }),
+      });
+    }
+    if (!shallowEqual(next.wmClass, prev.wmClass) && next.wmClass) {
+      const c = next.wmClass;
+      if (Array.isArray(c)) wnd.setClass?.(c[0], c[1]);
+      else if (typeof c === 'object') wnd.setClass?.(c.instance, c.class);
+      else wnd.setClass?.(c);
+    }
+    if (!shallowEqual(next.windowType, prev.windowType) && next.windowType) {
+      wnd.setWindowType?.(next.windowType);
+    }
+    if (Boolean(next.alwaysOnTop) !== Boolean(prev.alwaysOnTop)) {
+      wnd.setAlwaysOnTop?.(Boolean(next.alwaysOnTop));
+    }
+  }
+
   // window geometry props are window state, not yoga style — never feed
   // width/height into the root yoga node (flush() sets them from the real
   // window size, which the user may have changed by resizing)
@@ -1477,6 +1525,7 @@ export class WindowNode extends Node {
     if (newProps.title !== before.title) {
       wnd.setTitle?.(newProps.title || '');
     }
+    this._applyWindowHints(newProps, before);
     const geometryChanged =
       newProps.width !== before.width ||
       newProps.height !== before.height ||
@@ -1608,7 +1657,20 @@ export class WindowNode extends Node {
  */
 export class PopupNode extends WindowNode {
   constructor(app, attributes, props) {
-    super(app, { ...attributes, overrideRedirect: true }, props);
+    // override-redirect stays: it is what keeps the window manager from
+    // repositioning or decorating a menu. The EWMH type hint is additive —
+    // the spec asks for it on override-redirect windows too, so compositing
+    // managers can give menus and tooltips consistent shadows/animations.
+    // `windowType` overrides the default (e.g. "tooltip", "popup_menu").
+    super(
+      app,
+      {
+        ...attributes,
+        overrideRedirect: true,
+        windowType: attributes.windowType ?? 'dropdown_menu',
+      },
+      props,
+    );
     this.isPopup = true;
   }
 }

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -744,3 +744,63 @@ test('<textarea> edits multi-line text with line-aware caret movement', async ()
     await app.close();
   }
 });
+
+test('window hints reach the X server as real properties', async () => {
+  const { app } = await createHeadlessApp();
+  try {
+    // the render callback resolves to the live ntk window (getPublicInstance)
+    const wnd = await render(
+      React.createElement('window', {
+        width: 300,
+        height: 200,
+        resizable: false,
+        wmClass: ['react-x11', 'React-X11'],
+        windowType: 'dialog',
+      }),
+      app,
+    );
+    await settle(app, 6); // deferred InternAtom -> ChangeProperty chains
+
+    const X = app.X;
+    const win = wnd.id;
+    assert.ok(win > 0, 'render resolved to a realized ntk window');
+
+    const getProp = (atom, type = 0) =>
+      new Promise((resolve, reject) =>
+        X.GetProperty(0, win, atom, type, 0, 1024, (err, p) =>
+          err ? reject(err) : resolve(p),
+        ),
+      );
+    const intern = (name) =>
+      new Promise((resolve, reject) =>
+        X.InternAtom(false, name, (err, a) => (err ? reject(err) : resolve(a))),
+      );
+
+    // WM_NORMAL_HINTS: resizable={false} pins min and max to the size
+    const hints = await getProp(X.atoms.WM_NORMAL_HINTS);
+    const w = [];
+    for (let i = 0; i + 4 <= hints.data.length; i += 4) {
+      w.push(hints.data.readUInt32LE(i));
+    }
+    assert.strictEqual(w.length, 18, 'XSizeHints is 18 words');
+    assert.strictEqual(w[0] & 16, 16, 'PMinSize set');
+    assert.strictEqual(w[0] & 32, 32, 'PMaxSize set');
+    assert.deepStrictEqual([w[5], w[6]], [300, 200], 'min == created size');
+    assert.deepStrictEqual([w[7], w[8]], [300, 200], 'max == created size');
+
+    const cls = await getProp(X.atoms.WM_CLASS);
+    assert.strictEqual(cls.data.toString('latin1'), 'react-x11\0React-X11\0');
+
+    const [typeAtom, dialog] = await Promise.all([
+      intern('_NET_WM_WINDOW_TYPE'),
+      intern('_NET_WM_WINDOW_TYPE_DIALOG'),
+    ]);
+    const type = await getProp(typeAtom);
+    assert.strictEqual(type.data.readUInt32LE(0), dialog);
+
+    ReactX11.unmountComponentAtNode(app);
+    await settle(app);
+  } finally {
+    await app.close();
+  }
+});

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -132,6 +132,18 @@ function createMockApp() {
           wnd.title = title;
           wnd.calls.push(['setTitle', title]);
         },
+        setSizeHints(hints) {
+          wnd.calls.push(['setSizeHints', hints]);
+        },
+        setClass(instance, className) {
+          wnd.calls.push(['setClass', instance, className]);
+        },
+        setWindowType(type) {
+          wnd.calls.push(['setWindowType', type]);
+        },
+        setAlwaysOnTop(on) {
+          wnd.calls.push(['setAlwaysOnTop', on]);
+        },
         setActions() {
           wnd.calls.push(['setActions']);
         },
@@ -559,6 +571,72 @@ test('scrollview scrollIntoView scrolls the minimum amount', async () => {
   ReactX11.unmountComponentAtNode(app);
 });
 
+test('window manager hints pass through at creation and on update', () => {
+  const app = createMockApp();
+  const render = (props) =>
+    ReactX11.render(
+      React.createElement('window', { width: 200, height: 100, ...props }),
+      null,
+      app,
+    );
+
+  // creation goes through ntk's Window constructor as creation attributes
+  render({
+    resizable: false,
+    wmClass: ['react-x11', 'React-X11'],
+    windowType: 'dialog',
+    sizeHints: { minWidth: 120 },
+  });
+  const wnd = app.windows[0];
+  assert.strictEqual(wnd.attributes.resizable, false);
+  assert.deepStrictEqual(wnd.attributes.wmClass, ['react-x11', 'React-X11']);
+  assert.strictEqual(wnd.attributes.windowType, 'dialog');
+  assert.deepStrictEqual(wnd.attributes.sizeHints, { minWidth: 120 });
+
+  const hintCalls = () =>
+    wnd.calls.filter(([name]) => name.startsWith('set') && name !== 'setTitle');
+
+  // a re-render with identical hints must not re-send them: sizeHints is an
+  // inline object literal, so identity changes every render
+  wnd.calls.length = 0;
+  render({
+    resizable: false,
+    wmClass: ['react-x11', 'React-X11'],
+    windowType: 'dialog',
+    sizeHints: { minWidth: 120 },
+  });
+  assert.deepStrictEqual(hintCalls(), [], 'unchanged hints are not re-sent');
+
+  // changing one hint sends only that one
+  wnd.calls.length = 0;
+  render({
+    resizable: false,
+    wmClass: ['react-x11', 'React-X11'],
+    windowType: 'dialog',
+    sizeHints: { minWidth: 300, maxWidth: 900 },
+  });
+  assert.deepStrictEqual(hintCalls(), [
+    ['setSizeHints', { minWidth: 300, maxWidth: 900, resizable: false }],
+  ]);
+
+  // alwaysOnTop toggles both ways
+  wnd.calls.length = 0;
+  render({ alwaysOnTop: true });
+  assert.ok(
+    wnd.calls.some(([name, on]) => name === 'setAlwaysOnTop' && on === true),
+    'setAlwaysOnTop(true) on enable',
+  );
+
+  wnd.calls.length = 0;
+  render({ alwaysOnTop: false });
+  assert.ok(
+    wnd.calls.some(([name, on]) => name === 'setAlwaysOnTop' && on === false),
+    'setAlwaysOnTop(false) on disable',
+  );
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
 test('popup mounts as an override-redirect window and unmounts cleanly', () => {
   const app = createMockApp();
   const render = (open) =>
@@ -590,6 +668,10 @@ test('popup mounts as an override-redirect window and unmounts cleanly', () => {
   assert.strictEqual(app.windows.length, 2);
   const popup = app.windows[1];
   assert.strictEqual(popup.attributes.overrideRedirect, true);
+  // the EWMH type hint is additive — override-redirect still keeps the WM
+  // from moving or decorating the menu; the hint only lets compositing
+  // managers style it consistently (wm-spec asks for it on o-r windows)
+  assert.strictEqual(popup.attributes.windowType, 'dropdown_menu');
   assert.deepStrictEqual([popup.attributes.x, popup.attributes.y], [300, 150]);
   assert.strictEqual(popup.mapped, true);
 


### PR DESCRIPTION
Surfaces ntk 3.5.0's window hints (sidorares/ntk#77), now published.

```jsx
<window resizable={false} windowType="dialog" />
<window sizeHints={{ minWidth: 320, minHeight: 200 }} />
<window wmClass={['react-x11', 'React-X11']} alwaysOnTop />
```

| prop | |
|---|---|
| `resizable` | `false` pins min and max to the current size |
| `sizeHints` | `{minWidth, minHeight, maxWidth, maxHeight, widthInc, heightInc, baseWidth, baseHeight, minAspect, maxAspect, gravity}` |
| `wmClass` | `'instance'`, `['instance', 'Class']` or `{instance, class}` |
| `windowType` | `'dialog'`, `'utility'`, `'tooltip'`… or an array of fallbacks |
| `alwaysOnTop` | keep above normal windows |

Creation needed no plumbing — `windowAttributes()` already forwards every non-event prop to ntk's `Window` constructor. The work is the **update** path plus not re-sending unchanged hints, which matters because `sizeHints` is typically an inline object literal whose identity changes every render.

`sizeHints` is an object rather than flat `minWidth`/`maxWidth` props on purpose: those names are yoga layout style everywhere else, and `<window>` already carries the wrinkle that `width`/`height` are window state rather than style. Overloading two more names would compound it.

## `<popup>` and override-redirect

`<popup>` now defaults to `windowType="dropdown_menu"` (overridable).

I want to correct something I said when proposing this: it does **not** retire override-redirect. The [EWMH spec](https://specifications.freedesktop.org/wm-spec/1.5/ar01s05.html) asks for the type hint on override-redirect windows *precisely so* compositing managers can apply consistent decorations to menus and tooltips — and notes DROPDOWN_MENU/POPUP_MENU are typically used on override-redirect windows. Override-redirect remains what stops the window manager repositioning or decorating a menu; dropping it would hand menu placement back to the WM, with behaviour varying per WM. So the hint is **additive**.

## Verification

Hermetic (`test/integration.test.js`): react-x11 → real ntk → in-process X server, reading the properties back over the wire — 18-word `WM_NORMAL_HINTS`, the NUL-terminated `WM_CLASS` pair, and the interned `_NET_WM_WINDOW_TYPE_DIALOG` atom.

Against real XQuartz/quartz-wm:

```
WM_NORMAL_HINTS flags=48 min=[360,240] max=[360,240]
WM_CLASS = "react-x11\0React-X11\0"
_NET_WM_WINDOW_TYPE matches DIALOG: true
after resize request to 900x700 -> actual 360x240      <- WM refused it
```

That last line is the functional proof: `resizable={false}` actually prevents resizing, it doesn't just write a property.

Smoke tests cover creation, the no-op re-render, single-hint updates and `alwaysOnTop` toggling both ways. `npm test` 48/48, lint clean. Docs in `docs/elements.md`; NEXT_STEPS §8.2 marked done with the remaining upstream gaps (`_NET_WM_ICON`, `_NET_WM_STATE`, `_NET_WM_PID`).

No screenshots: nothing here changes rendered output.