### PR TITLE
feat: pointer capture for userland, and a Slider built on it

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -1,36 +1,28 @@
 # NEXT_STEPS.md — making react-x11 actually usable
 
-> **Status (2026-07-27):** Phases 0–5 are done. #28 (sans-serif README
-> screenshots) and #29 (CSS half-leading for text) are on master. #30
-> (`Button`/`Checkbox`/`Radio`/`Switch`/`ProgressBar` + `ThemeProvider`),
-> #31 (`<window onCloseRequest>` + examples overhaul), and #32 (multi-line
-> `<textarea>`) were merged into their stacked base **after** that base had
-> already landed as #29, so their commits never reached master — **#33**
-> lands them (no new code).
+> **Status (2026-07-27):** Phases 0–5 are done and merged: the widget set
+> (#30), examples overhaul + `<window onCloseRequest>` (#31), multi-line
+> `<textarea>` (#32), `Select` keyboard navigation + `scrollview`
+> `scrollIntoView` (#34), framed screenshots via the real WM (#36), and
+> window-manager hints as `<window>` props (#37). Pointer capture
+> (`ev.capturePointer()`) and `Slider` are the newest.
 >
-> In review on top of that: **#34** `Select` keyboard navigation (Up/Down
-> open + move with wrapping, Home/End, Enter/Space pick, Escape close;
-> pointer and keyboard share one highlight), a `scrollIntoView(node)`
-> primitive on `<scrollview>`, and the `flexShrink` fix that made a menu
-> longer than `MAX_MENU_HEIGHT` actually scroll instead of being clipped by
-> the popup edge.
+> Upstream, all released: ntk **3.5.0** — `WM_NORMAL_HINTS`, `WM_CLASS`,
+> `_NET_WM_WINDOW_TYPE`, always-on-top (ntk#77) — on node-x11 **3.1.2**,
+> which carries the Apple-WM `FrameHitTest` fix (node-x11#229).
 >
-> Upstream: ntk **3.4.0** (async rich-content `onInvalidate`); everything
-> we filed through #75 is released. npm publish still waits on
-> release-please **PR #17 (1.0.0)**.
+> npm publish still waits on release-please **PR #17 (1.0.0)**.
 >
 > **Plan (next session):**
 >
-> 1. Merge #33 → #34, then release-please #17 and publish 1.0.0.
-> 2. Pointer capture for userland (EventManager already drags via
->    downNode; expose it), then build `Slider` on it.
-> 3. Extract `useAnchor(ref)` from `Select` → `Tooltip`, then
+> 1. Merge release-please #17 and publish 1.0.0.
+> 2. Extract `useAnchor(ref)` from `Select` → `Tooltip`, then
 >    Menu/MenuBar/ContextMenu.
-> 4. `<textarea>` polish: Ctrl+arrow word movement, PageUp/Down,
+> 3. `<textarea>` polish: Ctrl+arrow word movement, PageUp/Down,
 >    Shift+click extend, drawn scrollbar.
-> 5. `Select` follow-ups: type-ahead (jump to the option matching typed
+> 4. `Select` follow-ups: type-ahead (jump to the option matching typed
 >    letters) and PageUp/PageDown in the open menu.
-> 6. Upstream (ntk): distribute half-leading inside TextLayout itself
+> 5. Upstream (ntk): distribute half-leading inside TextLayout itself
 >    (makes the #29 paint shift a no-op) + an opt-in cap-height trim
 >    (`text-box-trim` analog); `maxLines`/ellipsis for `<text>`.
 
@@ -63,9 +55,9 @@ merged theme (`ThemeProvider`; `SelectThemeProvider` is an alias) and a
 `useControl` hook (hover/focus, click + Space/Enter, disabled). Gallery:
 `examples/widgets.jsx`. Still open:
 
-- **Slider** — drag via the `_defaultMouseDrag`-style pattern but in
-  userland (onMouseDown + window-level move? needs pointer-capture
-  exposure — see renderer gaps below)
+- **Slider** — DONE: `ev.capturePointer()` exposes pointer capture to
+  userland, and `Slider` is built on it (drag past the widget bounds,
+  arrows/Home/End/PageUp/Down)
 - **Switch animation** — thumb snaps today; animate via
   requestAnimationFrame on the window ref, or step-render
 - **Tooltip** — `<popup>` + hover timer; extract the anchoring math from
@@ -77,9 +69,9 @@ merged theme (`ThemeProvider`; `SelectThemeProvider` is an alias) and a
 
 ### 3. Renderer gaps found while building the above
 
-- **Pointer capture for userland** — `EventManager` has downNode-based
-  dragging internally; expose `ev.capturePointer()` or deliver move/up to
-  the mousedown target while dragging (Slider needs this)
+- **Pointer capture for userland** — DONE: `ev.capturePointer()` /
+  `ev.releasePointer()` route move/up to the capturing node, released on
+  mouseup and on unmount; hover freezes during a capture
 - **Multi-line `<textarea>`** — DONE (#32). Polish left: Ctrl+arrow word
   movement, PageUp/Down, Shift+click extend, drawn scrollbar
 - **Bidi caret polish** — caret positions are bidi-correct now (ntk

--- a/docs/components.md
+++ b/docs/components.md
@@ -69,8 +69,46 @@ import { SelectThemeProvider } from 'react-x11';
 </SelectThemeProvider>;
 ```
 
-More components (Checkbox, Radio, Switch, …) are planned — see
-NEXT_STEPS.md. The `Select` source (`src/components.js`) is the reference
-for building your own: hover/focus state with `useState`, a `<popup>` for
-anything that must escape the window bounds, and a ref to the trigger node
-for anchoring (`node.abs` + `node.root.window.x/y`).
+## `Slider`
+
+A draggable value control.
+
+```jsx
+import { Slider } from 'react-x11';
+
+<Slider
+  value={volume}
+  min={0}
+  max={100}
+  step={5}
+  width={200}
+  onChange={setVolume}
+/>;
+```
+
+| prop                       |                                                        |
+| -------------------------- | ------------------------------------------------------ |
+| `value`, `onChange(value)` | current value (controlled)                             |
+| `min`, `max`, `step`       | range and quantisation (defaults 0, 100, 1)            |
+| `width`, `height`          | track width; `height` is the bar thickness (default 4) |
+| `disabled`                 | inert, dimmed                                          |
+
+Dragging uses [pointer capture](events.md#pointer-capture): the press
+captures, so the thumb keeps following a pointer that has wandered far
+outside the widget, and releasing out there still ends the drag.
+
+Keyboard: arrows step, `Home`/`End` jump to the ends, `PageUp`/`PageDown`
+move by ten steps.
+
+The thumb is centred on its value, so the usable travel is the track width
+minus one thumb width — otherwise `min` and `max` would be unreachable.
+
+---
+
+The other components — `Button`, `Checkbox`, `Radio`/`RadioGroup`,
+`Switch`, `ProgressBar` — are demoed together in `examples/widgets.jsx`.
+
+The `Select` source (`src/components.js`) is the reference for building
+your own: hover/focus state with `useState`, a `<popup>` for anything that
+must escape the window bounds, and a ref to the trigger node for anchoring
+(`node.abs` + `node.root.window.x/y`).

--- a/docs/events.md
+++ b/docs/events.md
@@ -27,6 +27,7 @@ props — they can never go stale.
   localX, localY,                   // target-relative
   nativeEvent,                      // the raw ntk/X11 event
   preventDefault(), stopPropagation(),
+  capturePointer(), releasePointer(),   // see Pointer capture below
   // mouse: button, detail (DOM-style click count: 2 = double, 3 = triple)
   // wheel: deltaX, deltaY
   // keyboard: keycode, keysym, codepoint, key, shiftKey, ctrlKey
@@ -46,6 +47,27 @@ props — they can never go stale.
 | `onWheel`                                   | X buttons 4–7; default action scrolls the nearest `<scrollview>`                      |
 | `onKeyDown` / `onKeyUp`                     | delivered to the focused node (or the window); Tab cycles focus                       |
 | `onFocus` / `onBlur`                        | focus follows mousedown (nearest `focusable` ancestor) and Tab traversal              |
+
+## Pointer capture
+
+`ev.capturePointer()` routes every following `mousemove` and `mouseup` to
+the capturing node instead of whatever is under the pointer, so a drag
+keeps working past the widget's own bounds — and a release far outside it
+still ends the gesture. This is what `Slider` is built on:
+
+```jsx
+onMouseDown: (ev) => {
+  ev.capturePointer();
+  setDragging(true);
+},
+onMouseMove: (ev) => { if (dragging) setValue(valueAt(ev)); },
+onMouseUp: () => setDragging(false),
+```
+
+Capture is released automatically on `mouseup` (like the DOM's implicit
+pointer capture) and when the capturing node unmounts; `ev.releasePointer()`
+ends it early. While captured, hover stays where it was — dragging must not
+light up every widget the pointer crosses.
 
 ## Focus
 

--- a/examples/widgets.jsx
+++ b/examples/widgets.jsx
@@ -1,5 +1,6 @@
 // Widget gallery: every standard component in one window — Button,
-// Checkbox, Radio/RadioGroup, Switch, ProgressBar, Select, <textinput>.
+// Checkbox, Radio/RadioGroup, Switch, Slider, ProgressBar, Select,
+// <textinput>.
 // Run with: npm run examples:widgets  (needs an X server / DISPLAY)
 import React, { useEffect, useState } from 'react';
 import {
@@ -10,6 +11,7 @@ import {
   Radio,
   RadioGroup,
   Select,
+  Slider,
   Switch,
 } from '../src/index.js';
 
@@ -30,6 +32,7 @@ function App() {
   const [flavor, setFlavor] = useState('vanilla');
   const [speed, setSpeed] = useState('fast');
   const [presses, setPresses] = useState(0);
+  const [volume, setVolume] = useState(40);
   const [progress, setProgress] = useState(0.2);
 
   // demo animation: creep the progress bar while "notifications" are on
@@ -43,7 +46,7 @@ function App() {
   }, [notify]);
 
   return (
-    <window width={460} height={530} title="widgets" backgroundColor="#f5f6fa">
+    <window width={460} height={580} title="widgets" backgroundColor="#f5f6fa">
       <box flexGrow={1} padding={16} gap={14}>
         <text fontSize={20} color="#2d3436">
           Widget gallery
@@ -80,6 +83,18 @@ function App() {
         <Row label="Switch">
           <Switch checked={notify} onChange={setNotify} />
           <text color="#2d3436">{notify ? 'notifications on' : 'off'}</text>
+        </Row>
+
+        <Row label="Slider">
+          <Slider
+            value={volume}
+            min={0}
+            max={100}
+            step={5}
+            width={200}
+            onChange={setVolume}
+          />
+          <text color="#2d3436">{`${volume}`}</text>
         </Row>
 
         <Row label="Progress">

--- a/src/components.js
+++ b/src/components.js
@@ -15,6 +15,8 @@ const XK_LEFT = 0xff51;
 const XK_UP = 0xff52;
 const XK_RIGHT = 0xff53;
 const XK_DOWN = 0xff54;
+const XK_PAGE_UP = 0xff55;
+const XK_PAGE_DOWN = 0xff56;
 const XK_END = 0xff57;
 
 const DefaultTheme = {
@@ -342,6 +344,156 @@ export function ProgressBar({
       width: `${clamped * 100}%`,
       borderRadius: height / 2,
       backgroundColor: color ?? theme.accent,
+    }),
+  );
+}
+
+const SLIDER_THUMB = 16;
+
+/**
+ * <Slider value min max step onChange disabled …boxProps> — draggable
+ * value control.
+ *
+ * Dragging uses pointer capture (`ev.capturePointer()`): once the press
+ * lands, move and up events keep coming to the track even when the pointer
+ * leaves it, so the thumb still tracks a pointer that has wandered far
+ * outside the widget — and releasing out there still ends the drag.
+ *
+ * Keyboard: arrows step, Home/End jump to the ends, PageUp/PageDown move
+ * by ten steps.
+ */
+export function Slider({
+  value = 0,
+  min = 0,
+  max = 100,
+  step = 1,
+  onChange,
+  disabled = false,
+  width,
+  height = 4,
+  ...boxProps
+}) {
+  const theme = useTheme();
+  const [focused, setFocused] = useState(false);
+  const [dragging, setDragging] = useState(false);
+  const trackRef = useRef(null);
+
+  const span = max - min || 1;
+  const clamp = (v) => Math.min(max, Math.max(min, v));
+  const quantize = (v) => {
+    if (!step) return clamp(v);
+    // round to the step grid measured from min, then trim float noise so
+    // 0.1-style steps do not accumulate 0.30000000000000004
+    const snapped = min + Math.round((v - min) / step) * step;
+    const decimals = (String(step).split('.')[1] ?? '').length;
+    return clamp(decimals ? Number(snapped.toFixed(decimals)) : snapped);
+  };
+  const fraction = (clamp(value) - min) / span;
+
+  const emit = (next) => {
+    if (next !== value) onChange?.(next);
+  };
+
+  /** Pointer x -> value, using the track's laid-out rect. */
+  const valueAt = (ev) => {
+    const node = trackRef.current;
+    if (!node?.abs?.width) return value;
+    // the thumb is centred on the value, so the usable travel is the track
+    // minus one thumb width — otherwise min/max are unreachable at the ends
+    const travel = Math.max(1, node.abs.width - SLIDER_THUMB);
+    const x = ev.x - node.abs.x - SLIDER_THUMB / 2;
+    return quantize(min + (Math.min(travel, Math.max(0, x)) / travel) * span);
+  };
+
+  const controlProps = disabled
+    ? {}
+    : {
+        focusable: true,
+        cursor: 'pointer',
+        onFocus: () => setFocused(true),
+        onBlur: () => setFocused(false),
+        onMouseDown: (ev) => {
+          ev.capturePointer();
+          setDragging(true);
+          emit(valueAt(ev));
+        },
+        onMouseMove: (ev) => {
+          if (dragging) emit(valueAt(ev));
+        },
+        onMouseUp: () => setDragging(false),
+        onKeyDown: (ev) => {
+          const big = (step || 1) * 10;
+          switch (ev.keysym) {
+            case XK_LEFT:
+            case XK_DOWN:
+              emit(quantize(clamp(value - (step || 1))));
+              return;
+            case XK_RIGHT:
+            case XK_UP:
+              emit(quantize(clamp(value + (step || 1))));
+              return;
+            case XK_HOME:
+              emit(min);
+              return;
+            case XK_END:
+              emit(max);
+              return;
+            case XK_PAGE_UP:
+              emit(quantize(clamp(value + big)));
+              return;
+            case XK_PAGE_DOWN:
+              emit(quantize(clamp(value - big)));
+              return;
+            default:
+              break;
+          }
+        },
+      };
+
+  return h(
+    'box',
+    {
+      ref: trackRef,
+      width,
+      height: SLIDER_THUMB,
+      justifyContent: 'center',
+      ...controlProps,
+      ...boxProps,
+    },
+    // track
+    h(
+      'box',
+      {
+        height,
+        borderRadius: height / 2,
+        backgroundColor: theme.track,
+        flexDirection: 'row',
+        alignItems: 'center',
+        pointerEvents: 'none',
+      },
+      h('box', {
+        width: `${fraction * 100}%`,
+        height,
+        borderRadius: height / 2,
+        backgroundColor: disabled ? theme.dim : theme.accent,
+      }),
+    ),
+    // thumb, centred on the value within the same travel the math uses
+    h('box', {
+      position: 'absolute',
+      left: `${fraction * 100}%`,
+      marginLeft: -SLIDER_THUMB * fraction,
+      width: SLIDER_THUMB,
+      height: SLIDER_THUMB,
+      borderRadius: SLIDER_THUMB / 2,
+      borderWidth: 1,
+      borderColor: disabled
+        ? theme.border
+        : focused || dragging
+          ? theme.accentHover
+          : theme.border,
+      backgroundColor: disabled ? theme.surfaceHover : theme.background,
+      pointerEvents: 'none',
     }),
   );
 }

--- a/src/events.js
+++ b/src/events.js
@@ -16,6 +16,7 @@ export class EventManager {
     this.node = windowNode;
     this.hoverPath = [];
     this.downNode = null;
+    this.capturedNode = null;
     this.focused = null;
     this._lastClick = { time: 0, x: 0, y: 0, detail: 0 };
   }
@@ -82,6 +83,16 @@ export class EventManager {
       },
       stopPropagation() {
         ev.propagationStopped = true;
+      },
+      // Pointer capture, DOM-like: while captured, mousemove/mouseup go to
+      // the capturing node instead of whatever is under the pointer, so a
+      // drag keeps working past the widget's own bounds. Released
+      // automatically on mouseup and when the node unmounts.
+      capturePointer: () => {
+        this.capturedNode = target;
+      },
+      releasePointer: () => {
+        if (this.capturedNode === target) this.capturedNode = null;
       },
       ...extra,
     };
@@ -160,10 +171,13 @@ export class EventManager {
   _onMouseUp(native) {
     if (WHEEL_BUTTONS[native.keycode]) return; // wheel release
     runWithPriority(DiscreteEventPriority, () => {
-      const target = this._hit(native);
+      const captured = this._captured();
+      const target = captured ?? this._hit(native);
       const ev = this.dispatch('MouseUp', target, native, {
         button: native.keycode,
       });
+      // capture ends with the gesture, like implicit DOM pointer capture
+      this.capturedNode = null;
       if (this.downNode && !this.downNode.destroyed) {
         this.downNode._defaultMouseUp?.(ev);
       }
@@ -188,14 +202,23 @@ export class EventManager {
 
   _onMouseMove(native) {
     runWithPriority(ContinuousEventPriority, () => {
-      const target = this._hit(native);
-      this._updateHover(this._path(target), native);
+      const captured = this._captured();
+      const target = captured ?? this._hit(native);
+      // while captured, hover stays put: dragging a slider must not light
+      // up every widget the pointer crosses
+      this._updateHover(captured ? this.hoverPath : this._path(target), native);
       const ev = this.dispatch('MouseMove', target, native);
       // drags deliver to the pressed node even when the pointer leaves it
       if (this.downNode && !this.downNode.destroyed) {
         this.downNode._defaultMouseDrag?.(ev);
       }
     });
+  }
+
+  /** The capturing node, dropping it if it has gone away. */
+  _captured() {
+    if (this.capturedNode?.destroyed) this.capturedNode = null;
+    return this.capturedNode;
   }
 
   _isFocusable(node) {
@@ -323,6 +346,7 @@ export class EventManager {
   /** Called when a node leaves the tree so stale references don't linger. */
   forget(node) {
     if (this.downNode === node) this.downNode = null;
+    if (this.capturedNode === node) this.capturedNode = null;
     if (this.focused === node) this.focused = null;
     this.hoverPath = this.hoverPath.filter((n) => n !== node);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ export {
   RadioGroup,
   Switch,
   ProgressBar,
+  Slider,
 } from './components.js';
 
 import { render, createRoot, unmountComponentAtNode } from './Reconciler.js';

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1580,3 +1580,199 @@ test('multiple root windows share one tree; onCloseRequest handles WM close', as
 
   ReactX11.unmountComponentAtNode(app);
 });
+
+test('Slider: drag keeps tracking after the pointer leaves the widget', async () => {
+  const { Slider } = await import('../src/index.js');
+  const app = createMockApp();
+  const seen = [];
+  const Host = () => {
+    const [v, setV] = React.useState(0);
+    seen.push(v);
+    return React.createElement(
+      'window',
+      { width: 400, height: 120 },
+      React.createElement(
+        'box',
+        { flexGrow: 1, padding: 20 },
+        React.createElement(Slider, {
+          value: v,
+          min: 0,
+          max: 100,
+          step: 1,
+          width: 200,
+          onChange: setV,
+        }),
+      ),
+    );
+  };
+  ReactX11.render(React.createElement(Host), null, app);
+  await tick();
+
+  const wnd = app.windows[0];
+  const track = (function find(n) {
+    if (n.props?.focusable) return n;
+    for (const c of n.children) {
+      if (c.isWindow) continue;
+      const hit = find(c);
+      if (hit) return hit;
+    }
+    return null;
+  })(wnd._reactX11Node);
+  assert.ok(track, 'slider track is focusable');
+
+  const { x, y, width, height } = track.abs;
+  const cy = y + height / 2;
+  const THUMB = 16;
+  const travel = width - THUMB; // thumb is centred on the value
+  const atFraction = (f) => x + THUMB / 2 + travel * f;
+
+  // press at the middle -> 50
+  wnd.emit('mousedown', { x: atFraction(0.5), y: cy, keycode: 1 });
+  await tick();
+  assert.strictEqual(seen.at(-1), 50, 'press sets the value under the pointer');
+
+  // drag while still inside
+  wnd.emit('mousemove', { x: atFraction(0.25), y: cy });
+  await tick();
+  assert.strictEqual(seen.at(-1), 25);
+
+  // pointer leaves the widget entirely (far below and to the right).
+  // without pointer capture this would dispatch to whatever is under the
+  // pointer and the slider would stop following.
+  wnd.emit('mousemove', { x: atFraction(0.9), y: cy + 400 });
+  await tick();
+  assert.strictEqual(seen.at(-1), 90, 'still tracking outside the widget');
+
+  // and clamps past the ends
+  wnd.emit('mousemove', { x: x - 500, y: cy });
+  await tick();
+  assert.strictEqual(seen.at(-1), 0, 'clamps at min');
+
+  // release out of bounds ends the drag; later moves are ignored
+  wnd.emit('mouseup', { x: x - 500, y: cy, keycode: 1 });
+  await tick();
+  const afterRelease = seen.at(-1);
+  wnd.emit('mousemove', { x: atFraction(0.75), y: cy });
+  await tick();
+  assert.strictEqual(seen.at(-1), afterRelease, 'no tracking after release');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('Slider: keyboard steps, Home/End and PageUp/Down', async () => {
+  const { Slider } = await import('../src/index.js');
+  const app = createMockApp();
+  let current = 50;
+  const Host = () => {
+    const [v, setV] = React.useState(50);
+    current = v;
+    return React.createElement(
+      'window',
+      { width: 300, height: 100 },
+      React.createElement(
+        'box',
+        { flexGrow: 1, padding: 10 },
+        React.createElement(Slider, {
+          value: v,
+          min: 0,
+          max: 100,
+          step: 2,
+          width: 200,
+          onChange: setV,
+        }),
+      ),
+    );
+  };
+  ReactX11.render(React.createElement(Host), null, app);
+  await tick();
+
+  const wnd = app.windows[0];
+  const track = (function find(n) {
+    if (n.props?.focusable) return n;
+    for (const c of n.children) {
+      if (c.isWindow) continue;
+      const hit = find(c);
+      if (hit) return hit;
+    }
+    return null;
+  })(wnd._reactX11Node);
+
+  // focus it without changing the value: click, then reset
+  wnd.emit('mousedown', { x: track.abs.x, y: track.abs.y + 8, keycode: 1 });
+  wnd.emit('mouseup', { x: track.abs.x, y: track.abs.y + 8, keycode: 1 });
+  await tick();
+
+  const press = async (keysym) => {
+    pressKey(app, wnd, { keysym });
+    await tick();
+  };
+
+  await press(0xff53); // Right
+  const afterRight = current;
+  await press(0xff51); // Left
+  assert.strictEqual(current, afterRight - 2, 'arrows move by step');
+
+  await press(0xff57); // End
+  assert.strictEqual(current, 100);
+  await press(0xff50); // Home
+  assert.strictEqual(current, 0);
+
+  await press(0xff55); // PageUp -> ten steps
+  assert.strictEqual(current, 20);
+  await press(0xff56); // PageDown
+  assert.strictEqual(current, 0);
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('Slider: thumb stays within the track at both extremes', async () => {
+  const { Slider } = await import('../src/index.js');
+  const findTrack = (n) =>
+    n.props?.focusable
+      ? n
+      : n.children.reduce(
+          (a, c) => a || (c.isWindow ? null : findTrack(c)),
+          null,
+        );
+
+  for (const [value, expected] of [
+    [0, 'flush left'],
+    [50, 'centred'],
+    [100, 'flush right'],
+  ]) {
+    const app = createMockApp();
+    ReactX11.render(
+      React.createElement(
+        'window',
+        { width: 400, height: 100 },
+        React.createElement(
+          'box',
+          { flexGrow: 1, padding: 20 },
+          React.createElement(Slider, { value, min: 0, max: 100, width: 200 }),
+        ),
+      ),
+      null,
+      app,
+    );
+    await tick();
+    const track = findTrack(app.windows[0]._reactX11Node);
+    const thumb = track.children.find((c) => c.props.position === 'absolute');
+    assert.ok(
+      thumb.abs.x >= track.abs.x - 0.5,
+      `${expected}: thumb past the left edge at ${value}`,
+    );
+    assert.ok(
+      thumb.abs.x + thumb.abs.width <= track.abs.x + track.abs.width + 0.5,
+      `${expected}: thumb past the right edge at ${value}`,
+    );
+    if (value === 50) {
+      const thumbMid = thumb.abs.x + thumb.abs.width / 2;
+      const trackMid = track.abs.x + track.abs.width / 2;
+      assert.ok(
+        Math.abs(thumbMid - trackMid) < 1,
+        'midpoint value centres the thumb',
+      );
+    }
+    ReactX11.unmountComponentAtNode(app);
+  }
+});


### PR DESCRIPTION
Closes the renderer gap NEXT_STEPS listed as blocking `Slider`.

## The gap

`EventManager` already delivered drags to the pressed node — but only through internal `_defaultMouseDrag` hooks (used by `<textinput>` for drag-select). Userland `onMouseMove`/`onMouseUp` still dispatched to whatever was under the pointer, so a drag that wandered outside the widget stopped reaching it.

## `ev.capturePointer()`

```jsx
onMouseDown: (ev) => { ev.capturePointer(); setDragging(true); },
onMouseMove: (ev) => { if (dragging) setValue(valueAt(ev)); },
onMouseUp:   () => setDragging(false),
```

Routes subsequent `mousemove`/`mouseup` to the capturing node regardless of hit testing. `ev.releasePointer()` ends it early; capture is dropped automatically on `mouseup` (like the DOM's implicit pointer capture) and when the capturing node unmounts. **Hover freezes while captured** — dragging must not light up every widget the pointer crosses.

## `Slider`

```jsx
<Slider value={volume} min={0} max={100} step={5} width={200} onChange={setVolume} />
```

Arrows step, `Home`/`End` jump to the ends, `PageUp`/`PageDown` move by ten steps. Values quantise to the step grid measured from `min`, with float noise trimmed so `0.1`-style steps don't yield `0.30000000000000004`.

The thumb is centred on its value, so the usable travel is the track width minus one thumb width — otherwise `min` and `max` are unreachable at the ends. A test pins that: flush left at min, centred at the midpoint, flush right at max (measured `[20,36]` / `[112,128]` / `[204,220]` on a `[20,220]` track).

## Screenshot

Rendered by this branch — `examples/widgets.jsx` now includes a Slider row:

![widgets](https://github.com/user-attachments/assets/ba74570a-a58a-4207-8f19-34b17744b11f)

## Tests

51/51, lint clean. Three new:

- **drag keeps tracking after the pointer leaves the widget** — presses mid-track, drags inside, then moves 400px below and far to the right, and asserts the value still follows; then checks clamping and that a release out of bounds ends the drag. I verified this test **fails** when `capturePointer` is stubbed to a no-op, so it's testing the feature rather than passing incidentally.
- keyboard steps / Home / End / PageUp / PageDown
- thumb geometry at both extremes

Docs: pointer capture in `docs/events.md`, `Slider` in `docs/components.md` (which also stopped claiming Checkbox/Radio/Switch are "planned" — they shipped in #30). NEXT_STEPS §2 and §3 updated.
