### PR TITLE
feat: useAnchor/anchorRect extracted from Select, and a Tooltip on it

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -16,8 +16,8 @@
 > **Plan (next session):**
 >
 > 1. Merge release-please #17 and publish 1.0.0.
-> 2. Extract `useAnchor(ref)` from `Select` → `Tooltip`, then
->    Menu/MenuBar/ContextMenu.
+> 2. Menu/MenuBar/ContextMenu on `useAnchor` (generalize
+>    examples/menu.jsx).
 > 3. `<textarea>` polish: Ctrl+arrow word movement, PageUp/Down,
 >    Shift+click extend, drawn scrollbar.
 > 4. `Select` follow-ups: type-ahead (jump to the option matching typed
@@ -60,8 +60,8 @@ merged theme (`ThemeProvider`; `SelectThemeProvider` is an alias) and a
   arrows/Home/End/PageUp/Down)
 - **Switch animation** — thumb snaps today; animate via
   requestAnimationFrame on the window ref, or step-render
-- **Tooltip** — `<popup>` + hover timer; extract the anchoring math from
-  `Select` into a shared `useAnchor(ref)` hook
+- **Tooltip** — DONE: `useAnchor(ref)`/`anchorRect()` extracted from
+  `Select` (and now flip at screen edges), `Tooltip` built on them
 - **Menu/MenuBar, ContextMenu** — generalize examples/menu.jsx
 - **`Select` type-ahead / PageUp-PageDown** — keyboard navigation itself
   is done (#34: Up/Down/Home/End/Enter/Escape, shared pointer+keyboard

--- a/docs/components.md
+++ b/docs/components.md
@@ -103,6 +103,58 @@ move by ten steps.
 The thumb is centred on its value, so the usable travel is the track width
 minus one thumb width — otherwise `min` and `max` would be unreachable.
 
+## `Tooltip`
+
+A hover hint in a `<popup>`, so it can extend past the owner window.
+
+```jsx
+import { Tooltip } from 'react-x11';
+
+<Tooltip label="Back to zero">
+  <Button onPress={reset}>Reset</Button>
+</Tooltip>;
+```
+
+| prop        |                                                    |
+| ----------- | -------------------------------------------------- |
+| `label`     | the hint text (nothing shows without it)           |
+| `placement` | `'top'` (default), `'bottom'`, `'left'`, `'right'` |
+| `delay`     | ms of hover before showing (default 500)           |
+| `fontSize`  | label size, also used to size the popup            |
+
+Wraps its children in a row box carrying the hover handlers and the anchor
+ref, so it composes around any element. Hides immediately on leave and on
+mousedown — a tooltip lingering over the menu you just opened is the
+classic annoyance. The popup is sized from the _measured_ label, because a
+`<popup>` is a real X window and needs its size before layout.
+
+## `useAnchor(ref)` / `anchorRect(node, options)`
+
+The placement math behind `Select` and `Tooltip`, exported for building
+your own popup-based widgets.
+
+```jsx
+const ref = useRef(null);
+const measure = useAnchor(ref);
+
+// screen coordinates for a <popup>, given the size you intend to use
+const rect = measure({ placement: 'bottom', align: 'center', width, height });
+// -> { x, y, width, height, placement }
+```
+
+| option            |                                                            |
+| ----------------- | ---------------------------------------------------------- |
+| `placement`       | `'bottom'` (default), `'top'`, `'left'`, `'right'`         |
+| `align`           | `'start'` (default), `'center'`, `'end'` on the cross axis |
+| `offset`          | gap from the anchor in px (default 2)                      |
+| `width`, `height` | size of the popup you are positioning                      |
+
+`placement` is a **preference, not a promise**: a menu near the bottom of
+the screen flips above its trigger rather than opening off-screen, and the
+result is clamped into the screen either way. The side actually used comes
+back as `placement`. Where screen geometry is unavailable it places without
+clamping.
+
 ---
 
 The other components — `Button`, `Checkbox`, `Radio`/`RadioGroup`,

--- a/examples/widgets.jsx
+++ b/examples/widgets.jsx
@@ -1,6 +1,6 @@
 // Widget gallery: every standard component in one window — Button,
 // Checkbox, Radio/RadioGroup, Switch, Slider, ProgressBar, Select,
-// <textinput>.
+// Tooltip, <textinput>.
 // Run with: npm run examples:widgets  (needs an X server / DISPLAY)
 import React, { useEffect, useState } from 'react';
 import {
@@ -13,6 +13,7 @@ import {
   Select,
   Slider,
   Switch,
+  Tooltip,
 } from '../src/index.js';
 
 function Row({ label, children }) {
@@ -56,7 +57,9 @@ function App() {
           <Button primary onPress={() => setPresses((n) => n + 1)}>
             Press me
           </Button>
-          <Button onPress={() => setPresses(0)}>Reset</Button>
+          <Tooltip label="Back to zero">
+            <Button onPress={() => setPresses(0)}>Reset</Button>
+          </Tooltip>
           <Button disabled>Disabled</Button>
           <text color="#2d3436">{`${presses}×`}</text>
         </Row>

--- a/src/components.js
+++ b/src/components.js
@@ -1,7 +1,14 @@
 // Widget components built purely on the host primitives — no reconciler
 // support needed. Plain createElement (no JSX) so the library stays
 // build-step-free for consumers.
-import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 const h = React.createElement;
 
@@ -65,6 +72,117 @@ function useControl(disabled, onActivate) {
       };
   return { hover: hover && !disabled, focused: focused && !disabled, props };
 }
+
+/** The X screen the node's window lives on, if reachable (the smoke-test
+ *  mock app has no screen geometry — callers must cope with null). */
+function screenOf(node) {
+  const app = node?.app;
+  const screen = (app?.display ?? app?.X?.display)?.screen?.[0];
+  return screen?.pixel_width ? screen : null;
+}
+
+/**
+ * Where to put a `<popup>` anchored to a drawn node, in **screen**
+ * coordinates: the owner window's position plus the node's laid-out rect.
+ *
+ * `placement` is a preference, not a promise — a menu near the bottom of
+ * the screen flips above its trigger rather than opening off-screen, and
+ * the result is clamped into the screen either way. The chosen side comes
+ * back as `placement` so the caller can style accordingly.
+ */
+export function anchorRect(node, options = {}) {
+  if (!node?.abs) return null;
+  const {
+    placement = 'bottom',
+    align = 'start',
+    offset = 2,
+    width = node.abs.width,
+    height = 0,
+  } = options;
+
+  const win = node.root?.window;
+  const ax = (win?.x ?? 0) + node.abs.x;
+  const ay = (win?.y ?? 0) + node.abs.y;
+  const aw = node.abs.width;
+  const ah = node.abs.height;
+
+  const screen = screenOf(node);
+  const sw = screen?.pixel_width;
+  const sh = screen?.pixel_height;
+
+  const alignAlong = (start, size, extent) =>
+    align === 'center'
+      ? start + (size - extent) / 2
+      : align === 'end'
+        ? start + size - extent
+        : start;
+
+  let side = placement;
+  let x;
+  let y;
+
+  if (side === 'bottom' || side === 'top') {
+    const below = ay + ah + offset;
+    const above = ay - height - offset;
+    if (side === 'bottom' && sh != null && below + height > sh && above >= 0) {
+      side = 'top';
+    } else if (
+      side === 'top' &&
+      above < 0 &&
+      (sh == null || below + height <= sh)
+    ) {
+      side = 'bottom';
+    }
+    y = side === 'bottom' ? below : above;
+    x = alignAlong(ax, aw, width);
+  } else {
+    const after = ax + aw + offset;
+    const before = ax - width - offset;
+    if (side === 'right' && sw != null && after + width > sw && before >= 0) {
+      side = 'left';
+    } else if (
+      side === 'left' &&
+      before < 0 &&
+      (sw == null || after + width <= sw)
+    ) {
+      side = 'right';
+    }
+    x = side === 'right' ? after : before;
+    y = alignAlong(ay, ah, height);
+  }
+
+  if (sw != null) x = Math.max(0, Math.min(x, sw - width));
+  if (sh != null && height) y = Math.max(0, Math.min(y, sh - height));
+
+  return { x: Math.round(x), y: Math.round(y), width, height, placement: side };
+}
+
+/**
+ * useAnchor(ref) — stable `measure(options)` returning `anchorRect` for the
+ * referenced node. The anchoring math `Select` used to inline, shared with
+ * `Tooltip` and anything else that hangs a `<popup>` off a drawn node.
+ */
+export function useAnchor(ref) {
+  return useCallback((options) => anchorRect(ref.current, options), [ref]);
+}
+
+/** Measured size of a single-line label, for sizing a popup around it.
+ *  Falls back to a rough estimate where no font stack is available. */
+function measureLabel(node, text, style) {
+  const fonts = node?.app?.fonts;
+  const size = style?.size ?? DEFAULT_LABEL_SIZE;
+  if (!fonts?.layout) {
+    return { width: String(text).length * size * 0.55, height: size * 1.4 };
+  }
+  const layout = fonts.layout(String(text), {
+    family: style?.family ?? 'sans-serif',
+    size,
+    weight: style?.weight ?? 'normal',
+  });
+  return { width: layout.width, height: layout.height };
+}
+
+const DEFAULT_LABEL_SIZE = 13;
 
 /** String/number children become a <text>; elements pass through. */
 function labelContent(children, textProps) {
@@ -498,6 +616,109 @@ export function Slider({
   );
 }
 
+const TOOLTIP_PADDING_X = 8;
+const TOOLTIP_PADDING_Y = 4;
+
+/**
+ * <Tooltip label placement delay>…</Tooltip> — a hover hint in a `<popup>`,
+ * so it can extend past the owner window's bounds.
+ *
+ * Wraps its children in a row box that carries the hover handlers and the
+ * anchor ref. Shows after `delay` ms of hover, hides immediately on leave
+ * (and on mousedown — a tooltip lingering over a menu you just opened is
+ * the classic annoyance). `placement` flips automatically near a screen
+ * edge, via the same `useAnchor` math `Select` uses.
+ *
+ * The popup is sized from the measured label, since a `<popup>` is a real
+ * X window and needs its size up front rather than after layout.
+ */
+export function Tooltip({
+  label,
+  children,
+  placement = 'top',
+  delay = 500,
+  fontSize = DEFAULT_LABEL_SIZE,
+  ...boxProps
+}) {
+  const theme = useTheme();
+  const ref = useRef(null);
+  const measureAnchor = useAnchor(ref);
+  const [rect, setRect] = useState(null);
+  const timer = useRef(null);
+
+  const cancel = () => {
+    if (timer.current) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
+  };
+  const hide = () => {
+    cancel();
+    setRect(null);
+  };
+
+  // a pending timer must not outlive the component
+  useEffect(() => cancel, []);
+
+  const show = () => {
+    const node = ref.current;
+    if (!node || !label) return;
+    const text = measureLabel(node, label, { size: fontSize });
+    const width = Math.ceil(text.width) + TOOLTIP_PADDING_X * 2 + 2;
+    const height = Math.ceil(text.height) + TOOLTIP_PADDING_Y * 2 + 2;
+    const next = measureAnchor({ placement, align: 'center', width, height });
+    if (next) setRect(next);
+  };
+
+  const onMouseEnter = () => {
+    cancel();
+    timer.current = setTimeout(() => {
+      timer.current = null;
+      show();
+    }, delay);
+  };
+
+  return h(
+    'box',
+    {
+      ref,
+      flexDirection: 'row',
+      alignItems: 'center',
+      onMouseEnter,
+      onMouseLeave: hide,
+      onMouseDown: hide,
+      ...boxProps,
+    },
+    children,
+    rect &&
+      h(
+        'popup',
+        {
+          x: rect.x,
+          y: rect.y,
+          width: rect.width,
+          height: rect.height,
+          windowType: 'tooltip',
+          backgroundColor: theme.text,
+        },
+        h(
+          'box',
+          {
+            flexGrow: 1,
+            borderWidth: 1,
+            borderColor: theme.text,
+            borderRadius: 3,
+            backgroundColor: theme.text,
+            justifyContent: 'center',
+            paddingLeft: TOOLTIP_PADDING_X,
+            paddingRight: TOOLTIP_PADDING_X,
+          },
+          h('text', { color: theme.background, fontSize }, label),
+        ),
+      ),
+  );
+}
+
 function normalizeOption(option) {
   return typeof option === 'object' && option !== null
     ? option
@@ -561,19 +782,24 @@ export function Select({
   const scrollRef = useRef(null);
   const activeRef = useRef(null);
 
+  const measureAnchor = useAnchor(triggerRef);
+
   const normalized = options.map(normalizeOption);
   const current = normalized.find((o) => o.value === value);
+  const menuHeight = Math.min(
+    normalized.length * ITEM_HEIGHT + 8,
+    MAX_MENU_HEIGHT,
+  );
 
   const close = () => setOpen(false);
   const openMenu = () => {
     const node = triggerRef.current;
     if (!node) return;
-    const win = node.root?.window;
-    setAnchor({
-      x: (win?.x ?? 0) + node.abs.x,
-      y: (win?.y ?? 0) + node.abs.y + node.abs.height + 2,
-      width: node.abs.width,
-    });
+    // shared anchoring: also flips the menu above the trigger when there is
+    // no room below, instead of opening off the bottom of the screen
+    const rect = measureAnchor({ placement: 'bottom', height: menuHeight + 2 });
+    if (!rect) return;
+    setAnchor(rect);
     const selected = normalized.findIndex((o) => o.value === value);
     setActiveIndex(selected >= 0 ? selected : 0);
     setOpen(true);
@@ -622,11 +848,6 @@ export function Select({
   useEffect(() => {
     if (open) scrollRef.current?.scrollIntoView(activeRef.current);
   }, [open, activeIndex]);
-
-  const menuHeight = Math.min(
-    normalized.length * ITEM_HEIGHT + 8,
-    MAX_MENU_HEIGHT,
-  );
 
   return h(
     'box',

--- a/src/index.js
+++ b/src/index.js
@@ -15,6 +15,9 @@ export {
   Switch,
   ProgressBar,
   Slider,
+  Tooltip,
+  useAnchor,
+  anchorRect,
 } from './components.js';
 
 import { render, createRoot, unmountComponentAtNode } from './Reconciler.js';

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1776,3 +1776,181 @@ test('Slider: thumb stays within the track at both extremes', async () => {
     ReactX11.unmountComponentAtNode(app);
   }
 });
+
+test('anchorRect places, flips at a screen edge and clamps', async () => {
+  const { anchorRect } = await import('../src/index.js');
+  // a stand-in node: laid-out rect, owner window position, screen size
+  const node = (
+    abs,
+    win = { x: 100, y: 50 },
+    screen = { pixel_width: 1000, pixel_height: 800 },
+  ) => ({
+    abs,
+    root: { window: win },
+    app: { display: { screen: [screen] } },
+  });
+
+  // default: below the anchor, left edges aligned, in screen coordinates
+  const below = anchorRect(node({ x: 10, y: 20, width: 160, height: 30 }), {
+    height: 100,
+  });
+  assert.deepStrictEqual(
+    [below.x, below.y, below.placement],
+    [110, 102, 'bottom'],
+    'win.x + abs.x, and win.y + abs.y + height + offset',
+  );
+
+  // no room below -> flips above the anchor
+  const flipped = anchorRect(node({ x: 10, y: 700, width: 160, height: 30 }), {
+    height: 100,
+  });
+  assert.strictEqual(flipped.placement, 'top');
+  assert.strictEqual(flipped.y, 50 + 700 - 100 - 2, 'sits above the anchor');
+
+  // ... but only if there is room above; otherwise it stays below
+  const noRoomEither = anchorRect(
+    node(
+      { x: 10, y: 10, width: 160, height: 30 },
+      { x: 0, y: 0 },
+      { pixel_width: 1000, pixel_height: 60 },
+    ),
+    { height: 100 },
+  );
+  assert.strictEqual(noRoomEither.placement, 'bottom');
+
+  // centre alignment and right-edge clamping
+  const centred = anchorRect(node({ x: 10, y: 20, width: 100, height: 30 }), {
+    width: 40,
+    height: 10,
+    align: 'center',
+  });
+  assert.strictEqual(centred.x, 100 + 10 + (100 - 40) / 2);
+
+  const clamped = anchorRect(node({ x: 850, y: 20, width: 100, height: 30 }), {
+    width: 300,
+    height: 10,
+  });
+  assert.strictEqual(clamped.x, 1000 - 300, 'clamped to the right edge');
+
+  // side placement flips when it would overflow
+  const right = anchorRect(node({ x: 10, y: 20, width: 100, height: 30 }), {
+    placement: 'right',
+    width: 80,
+    height: 40,
+  });
+  assert.deepStrictEqual(
+    [right.placement, right.x],
+    ['right', 100 + 10 + 100 + 2],
+  );
+
+  const flipsLeft = anchorRect(
+    node({ x: 800, y: 20, width: 100, height: 30 }),
+    {
+      placement: 'right',
+      width: 300,
+      height: 40,
+    },
+  );
+  assert.strictEqual(flipsLeft.placement, 'left');
+
+  // no screen geometry (headless mock): still places, just never clamps
+  const noScreen = anchorRect({
+    abs: { x: 5, y: 5, width: 50, height: 20 },
+    root: { window: { x: 0, y: 0 } },
+    app: {},
+  });
+  assert.deepStrictEqual([noScreen.x, noScreen.y], [5, 27]);
+
+  assert.strictEqual(anchorRect(null), null, 'no node -> no rect');
+});
+
+test('Tooltip shows after the delay in a popup and hides on leave', async () => {
+  const { Tooltip, Button } = await import('../src/index.js');
+  const app = createMockApp();
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 300, height: 120 },
+      React.createElement(
+        'box',
+        { flexGrow: 1, padding: 20 },
+        React.createElement(
+          Tooltip,
+          { label: 'Save the file', delay: 20 },
+          React.createElement(Button, { onPress: () => {} }, 'Save'),
+        ),
+      ),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const wrapper = wnd._reactX11Node.children[0].children[0];
+  const { x, y, width, height } = wrapper.abs;
+  const cx = x + width / 2;
+  const cy = y + height / 2;
+
+  assert.strictEqual(app.windows.length, 1, 'no popup before hovering');
+
+  wnd.emit('mousemove', { x: cx, y: cy });
+  await tick();
+  assert.strictEqual(app.windows.length, 1, 'nothing shows before the delay');
+
+  await new Promise((r) => setTimeout(r, 60));
+  await tick();
+  assert.strictEqual(app.windows.length, 2, 'popup appears after the delay');
+  const tip = app.windows[1];
+  assert.strictEqual(tip.attributes.overrideRedirect, true);
+  assert.strictEqual(tip.attributes.windowType, 'tooltip');
+  assert.ok(tip.attributes.width > 0 && tip.attributes.height > 0);
+
+  // leaving hides it
+  wnd.emit('mousemove', { x: 0, y: 0 });
+  // mousemove runs at ContinuousEventPriority, so React schedules the
+  // update rather than flushing it synchronously the way keydown does
+  await tick();
+  await tick();
+  assert.strictEqual(tip.destroyed, true, 'popup destroyed on mouse leave');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('Tooltip does not show if the pointer leaves before the delay', async () => {
+  const { Tooltip, Button } = await import('../src/index.js');
+  const app = createMockApp();
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 300, height: 120 },
+      React.createElement(
+        'box',
+        { flexGrow: 1, padding: 20 },
+        React.createElement(
+          Tooltip,
+          { label: 'Never seen', delay: 50 },
+          React.createElement(Button, { onPress: () => {} }, 'Save'),
+        ),
+      ),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const wrapper = wnd._reactX11Node.children[0].children[0];
+
+  wnd.emit('mousemove', {
+    x: wrapper.abs.x + 2,
+    y: wrapper.abs.y + wrapper.abs.height / 2,
+  });
+  await tick();
+  wnd.emit('mousemove', { x: 0, y: 0 }); // leave well before the delay
+  await tick();
+
+  await new Promise((r) => setTimeout(r, 90));
+  await tick();
+  assert.strictEqual(app.windows.length, 1, 'the pending timer was cancelled');
+
+  ReactX11.unmountComponentAtNode(app);
+});


### PR DESCRIPTION
Next planned item: extract the anchoring math from `Select`, then build `Tooltip` on it.

## `anchorRect` / `useAnchor`

`Select` inlined its own placement — owner window position plus the trigger's laid-out rect — with **no screen awareness**, so a `Select` near the bottom of the screen opened its menu off the bottom of the display.

```jsx
const measure = useAnchor(ref);
const rect = measure({ placement: 'bottom', align: 'center', width, height });
// -> { x, y, width, height, placement }
```

| option | |
| --- | --- |
| `placement` | `'bottom'` (default), `'top'`, `'left'`, `'right'` |
| `align` | `'start'` (default), `'center'`, `'end'` on the cross axis |
| `offset` | gap from the anchor (default 2) |
| `width`, `height` | size of the popup being positioned |

`placement` is a **preference, not a promise**: it flips to the opposite side when there's no room — but only if the opposite side actually has room — and clamps into the screen either way. The side actually used comes back as `placement`.

`Select` now uses it and **gains the screen-edge flip for free**.

## `Tooltip`

```jsx
<Tooltip label="Back to zero">
  <Button onPress={reset}>Reset</Button>
</Tooltip>
```

Hover with a delay (500ms default), rendered in a `<popup>` so it can extend past the owner window. Hides on leave and on mousedown — a tooltip lingering over the menu you just opened is the classic annoyance.

The popup is sized from the **measured** label via the app's font stack, because a `<popup>` is a real X window and needs its size up front rather than after layout. Where no font stack is reachable (the headless mock) it falls back to an estimate.

## Screenshot

Real XQuartz, hovering `Reset` in `examples/widgets.jsx`:

![tooltip](https://github.com/user-attachments/assets/9474e6af-3e6e-4820-b0b5-a98a70ce8dee)

Two things worth recording from producing that shot, both consequences of how XQuartz works:

- `GetImage` on the **root** window returns black — rootless XQuartz has no composited root content, so the framed-screenshot trick (`GetImage` on the frame) can't include a second top-level window. A composited grab is needed to show a popup together with its owner.
- Floating the owner window via Apple-WM `SetWindowLevel(Floating)` **hides the tooltip behind it**, since `<popup>` windows are normal-level. Fine for `screenshots:framed` (single window), but worth knowing before reaching for it elsewhere.

## Tests

54/54, lint clean. New:

- `anchorRect` placement, edge flipping, the *no room either side* case, centre alignment, right-edge clamping, side flipping, and the no-screen-geometry fallback.
- Tooltip shows after the delay as an override-redirect `windowType: 'tooltip'` popup and hides on leave.
- Tooltip does **not** show when the pointer leaves before the delay (the pending timer is cancelled).

One thing the tests taught me: `mousemove` runs at `ContinuousEventPriority`, so React schedules rather than flushing synchronously the way `keydown` does — the hide assertion needs two ticks. Noted in the test.
