### PR TITLE
feat: MenuBar and ContextMenu on useAnchor

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -16,8 +16,8 @@
 > **Plan (next session):**
 >
 > 1. Merge release-please #17 and publish 1.0.0.
-> 2. Menu/MenuBar/ContextMenu on `useAnchor` (generalize
->    examples/menu.jsx).
+> 2. Submenus for `MenuBar`/`ContextMenu` (nested `items`), and
+>    type-ahead in menus.
 > 3. `<textarea>` polish: Ctrl+arrow word movement, PageUp/Down,
 >    Shift+click extend, drawn scrollbar.
 > 4. `Select` follow-ups: type-ahead (jump to the option matching typed
@@ -62,7 +62,9 @@ merged theme (`ThemeProvider`; `SelectThemeProvider` is an alias) and a
   requestAnimationFrame on the window ref, or step-render
 - **Tooltip** — DONE: `useAnchor(ref)`/`anchorRect()` extracted from
   `Select` (and now flip at screen edges), `Tooltip` built on them
-- **Menu/MenuBar, ContextMenu** — generalize examples/menu.jsx
+- **Menu/MenuBar, ContextMenu** — DONE: built on `useAnchor`, with
+  separators, disabled items, shortcuts, checkmarks and full keyboard
+  navigation; `examples/menu.jsx` rewritten on them
 - **`Select` type-ahead / PageUp-PageDown** — keyboard navigation itself
   is done (#34: Up/Down/Home/End/Enter/Escape, shared pointer+keyboard
   highlight, active option scrolled into view)

--- a/docs/components.md
+++ b/docs/components.md
@@ -128,6 +128,49 @@ mousedown — a tooltip lingering over the menu you just opened is the
 classic annoyance. The popup is sized from the _measured_ label, because a
 `<popup>` is a real X window and needs its size before layout.
 
+## `MenuBar` / `ContextMenu`
+
+Pull-down and right-click menus, both rendered in `<popup>` windows so they
+escape the owner window, both anchored with `useAnchor`.
+
+```jsx
+import { MenuBar, ContextMenu } from 'react-x11';
+
+<MenuBar
+  menus={[
+    {
+      label: 'File',
+      items: [
+        { label: 'New', shortcut: 'Ctrl+N', onSelect: newFile },
+        { separator: true },
+        { label: 'Save As…', disabled: true },
+        { label: 'Wrap lines', checked: wrap, onSelect: toggleWrap },
+      ],
+    },
+  ]}
+/>;
+
+<ContextMenu items={items} flexGrow={1}>
+  <text>Right-click me</text>
+</ContextMenu>;
+```
+
+Item shape: `{ label, onSelect, shortcut, disabled, separator, checked }`.
+Both take an `onSelect(item)` prop as well, fired after the item's own.
+
+**Keyboard.** Up/Down move the active item, **skipping separators and
+disabled entries** and wrapping; Home/End jump to the ends; Enter/Space
+activate; Escape closes. In a `MenuBar`, Left/Right walk between menus, and
+with one menu open, hovering another switches to it.
+
+Both keep focus on a node in the _owner_ window — the popup is
+override-redirect and never takes focus — which is the same arrangement
+`Select` uses. `ContextMenu`'s wrapper is focusable for that reason and
+takes focus when the menu opens.
+
+Switching between `MenuBar` menus reuses the same X window and moves it
+rather than destroying and recreating one, so there is no flicker.
+
 ## `useAnchor(ref)` / `anchorRect(node, options)`
 
 The placement math behind `Select` and `Tooltip`, exported for building

--- a/examples/menu.jsx
+++ b/examples/menu.jsx
@@ -1,92 +1,89 @@
-// Context menu via <popup> — an override-redirect X11 window (ntk >= 3.1.0)
-// positioned at the pointer. Right-click anywhere to open it; pick an entry
-// or left-click elsewhere to close. Shows conditional rendering of a real
-// second window, component composition, and screen-coordinate anchoring.
+// Menus: a MenuBar of pull-down menus plus a ContextMenu on right-click.
+// Both render into <popup> — override-redirect X11 windows anchored with
+// useAnchor, so they escape the owner window and flip at screen edges.
+//
+// Keyboard: click or Enter opens a bar menu, Left/Right walk the bar,
+// Up/Down move within a menu (skipping separators and disabled entries),
+// Enter picks, Escape closes.
+//
 // Run with: npm run examples:menu  (needs an X server / DISPLAY)
 import React, { useState } from 'react';
-import { createRoot } from '../src/index.js';
-
-const CHOICES = ['Cut', 'Copy', 'Paste', 'Rename…', 'Delete'];
-const ITEM_HEIGHT = 28;
-
-function MenuItem({ label, onSelect }) {
-  const [hover, setHover] = useState(false);
-  return (
-    <box
-      height={ITEM_HEIGHT}
-      cursor="pointer"
-      justifyContent="center"
-      paddingLeft={12}
-      backgroundColor={hover ? '#2980b9' : 'white'}
-      onMouseEnter={() => setHover(true)}
-      onMouseLeave={() => setHover(false)}
-      onClick={() => onSelect(label)}
-    >
-      <text color={hover ? 'white' : '#2d3436'}>{label}</text>
-    </box>
-  );
-}
-
-function ContextMenu({ at, onSelect }) {
-  return (
-    <popup
-      x={at.x}
-      y={at.y}
-      width={160}
-      height={CHOICES.length * ITEM_HEIGHT + 10}
-      backgroundColor="white"
-    >
-      <box
-        flexGrow={1}
-        padding={4}
-        borderWidth={1}
-        borderColor="#b2bec3"
-        backgroundColor="white"
-      >
-        {CHOICES.map((label) => (
-          <MenuItem key={label} label={label} onSelect={onSelect} />
-        ))}
-      </box>
-    </popup>
-  );
-}
+import { createRoot, ContextMenu, MenuBar } from '../src/index.js';
 
 function App() {
-  const [menuAt, setMenuAt] = useState(null);
   const [last, setLast] = useState('(none)');
+  const [wrap, setWrap] = useState(true);
+  const note = (label) => () => setLast(label);
+
+  const menus = [
+    {
+      label: 'File',
+      items: [
+        { label: 'New', shortcut: 'Ctrl+N', onSelect: note('New') },
+        { label: 'Open…', shortcut: 'Ctrl+O', onSelect: note('Open…') },
+        { separator: true },
+        { label: 'Save', shortcut: 'Ctrl+S', onSelect: note('Save') },
+        { label: 'Save As…', disabled: true },
+        { separator: true },
+        { label: 'Quit', shortcut: 'Ctrl+Q', onSelect: note('Quit') },
+      ],
+    },
+    {
+      label: 'Edit',
+      items: [
+        { label: 'Undo', shortcut: 'Ctrl+Z', onSelect: note('Undo') },
+        { label: 'Redo', shortcut: 'Ctrl+Y', disabled: true },
+        { separator: true },
+        { label: 'Cut', shortcut: 'Ctrl+X', onSelect: note('Cut') },
+        { label: 'Copy', shortcut: 'Ctrl+C', onSelect: note('Copy') },
+        { label: 'Paste', shortcut: 'Ctrl+V', onSelect: note('Paste') },
+      ],
+    },
+    {
+      label: 'View',
+      items: [
+        {
+          label: 'Wrap lines',
+          checked: wrap,
+          onSelect: () => {
+            setWrap((w) => !w);
+            setLast('Wrap lines');
+          },
+        },
+        { label: 'Zoom in', shortcut: 'Ctrl++', onSelect: note('Zoom in') },
+        { label: 'Zoom out', shortcut: 'Ctrl+-', onSelect: note('Zoom out') },
+      ],
+    },
+  ];
+
+  const contextItems = [
+    { label: 'Cut', shortcut: 'Ctrl+X', onSelect: note('Cut (context)') },
+    { label: 'Copy', shortcut: 'Ctrl+C', onSelect: note('Copy (context)') },
+    { label: 'Paste', disabled: true },
+    { separator: true },
+    { label: 'Delete', onSelect: note('Delete (context)') },
+  ];
 
   return (
-    <window
-      width={420}
-      height={240}
-      title="popup menu"
-      backgroundColor="#f5f6fa"
-      onMouseDown={(ev) => {
-        if (ev.button === 3) {
-          // anchor at the pointer, in screen coordinates
-          setMenuAt({ x: ev.nativeEvent.rootx, y: ev.nativeEvent.rooty });
-        } else {
-          setMenuAt(null);
-        }
-      }}
-    >
-      <box flexGrow={1} justifyContent="center" alignItems="center" gap={8}>
-        <text fontSize={18} color="#2d3436">
-          Right-click for a menu
-        </text>
-        <text color="#7f8c8d">
-          last choice: <text color="#2980b9">{last}</text>
-        </text>
-      </box>
-      {menuAt && (
+    <window width={460} height={280} title="menus" backgroundColor="#f5f6fa">
+      <box flexGrow={1}>
+        <MenuBar menus={menus} />
         <ContextMenu
-          at={menuAt}
-          onSelect={(label) => {
-            setLast(label);
-            setMenuAt(null);
-          }}
-        />
-      )}
+          items={contextItems}
+          flexGrow={1}
+          justifyContent="center"
+          alignItems="center"
+          gap={10}
+        >
+          <text fontSize={18} color="#2d3436">
+            Right-click anywhere below the bar
+          </text>
+          <text color="#7f8c8d">
+            last choice: <text color="#2980b9">{last}</text>
+          </text>
+          <text color="#7f8c8d">wrap lines: {wrap ? 'on' : 'off'}</text>
+        </ContextMenu>
+      </box>
     </window>
   );
 }

--- a/src/components.js
+++ b/src/components.js
@@ -719,6 +719,398 @@ export function Tooltip({
   );
 }
 
+// --- menus ------------------------------------------------------------------
+
+const MENU_ITEM_HEIGHT = 26;
+const MENU_SEPARATOR_HEIGHT = 7;
+const MENU_MIN_WIDTH = 140;
+const MENU_PAD = 4;
+const MENU_GUTTER = 24; // room for the check column
+const MENU_SHORTCUT_GAP = 24;
+
+const isSelectable = (item) => item && !item.separator && !item.disabled;
+
+/** Total popup height for a menu's items (separators are shorter). */
+function menuListHeight(items) {
+  const body = items.reduce(
+    (sum, item) =>
+      sum + (item.separator ? MENU_SEPARATOR_HEIGHT : MENU_ITEM_HEIGHT),
+    0,
+  );
+  return body + MENU_PAD * 2 + 2;
+}
+
+/** Widest label + shortcut, measured, so the popup can be sized up front. */
+function menuListWidth(node, items, fontSize) {
+  let widest = 0;
+  for (const item of items) {
+    if (item.separator) continue;
+    const label = measureLabel(node, item.label ?? '', {
+      size: fontSize,
+    }).width;
+    const shortcut = item.shortcut
+      ? measureLabel(node, item.shortcut, { size: fontSize }).width +
+        MENU_SHORTCUT_GAP
+      : 0;
+    widest = Math.max(widest, label + shortcut);
+  }
+  return Math.max(
+    MENU_MIN_WIDTH,
+    Math.ceil(widest) + MENU_GUTTER + MENU_PAD * 2 + 12,
+  );
+}
+
+/** Next selectable index in `dir`, wrapping, skipping separators/disabled. */
+function nextSelectable(items, from, dir) {
+  const n = items.length;
+  if (!n) return -1;
+  for (let step = 1; step <= n; step++) {
+    const i = (from + dir * step + n * step) % n;
+    if (isSelectable(items[i])) return i;
+  }
+  return -1;
+}
+
+function MenuRow({ item, active, onHover, onSelect, fontSize }) {
+  const theme = useTheme();
+  if (item.separator) {
+    return h(
+      'box',
+      { height: MENU_SEPARATOR_HEIGHT, justifyContent: 'center' },
+      h('box', { height: 1, backgroundColor: theme.border }),
+    );
+  }
+  const dim = item.disabled;
+  return h(
+    'box',
+    {
+      height: MENU_ITEM_HEIGHT,
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingLeft: 8,
+      paddingRight: 8,
+      cursor: dim ? undefined : 'pointer',
+      backgroundColor: active ? theme.hoverBackground : theme.background,
+      onMouseEnter: dim ? undefined : onHover,
+      onClick: dim ? undefined : () => onSelect(item),
+    },
+    h(
+      'box',
+      { width: MENU_GUTTER - 8, alignItems: 'center' },
+      item.checked &&
+        h('text', {
+          color: active ? theme.hoverText : theme.text,
+          fontSize,
+          children: '✓',
+        }),
+    ),
+    h(
+      'text',
+      {
+        color: dim ? theme.dim : active ? theme.hoverText : theme.text,
+        fontSize,
+      },
+      item.label,
+    ),
+    h('box', { flexGrow: 1 }),
+    item.shortcut &&
+      h(
+        'text',
+        {
+          color: dim ? theme.dim : active ? theme.hoverText : theme.dim,
+          fontSize,
+        },
+        item.shortcut,
+      ),
+  );
+}
+
+/**
+ * The menu popup itself: an override-redirect `<popup>` at `rect` holding a
+ * list of items. Shared by `MenuBar` and `ContextMenu`; `rect` comes from
+ * `useAnchor`, so menus flip at screen edges like `Select`'s.
+ */
+function MenuPopup({ rect, items, activeIndex, onHover, onSelect, fontSize }) {
+  const theme = useTheme();
+  return h(
+    'popup',
+    {
+      x: rect.x,
+      y: rect.y,
+      width: rect.width,
+      height: rect.height,
+      windowType: 'popup_menu',
+      backgroundColor: theme.background,
+    },
+    h(
+      'box',
+      {
+        flexGrow: 1,
+        flexShrink: 1,
+        padding: MENU_PAD,
+        borderWidth: 1,
+        borderColor: theme.border,
+        backgroundColor: theme.background,
+      },
+      items.map((item, index) =>
+        h(MenuRow, {
+          key: item.separator ? `sep-${index}` : (item.key ?? item.label),
+          item,
+          active: index === activeIndex,
+          fontSize,
+          onHover: () => onHover(index),
+          onSelect,
+        }),
+      ),
+    ),
+  );
+}
+
+/**
+ * Keyboard handling shared by every menu: Up/Down move the active item
+ * (skipping separators and disabled entries, wrapping), Home/End jump to
+ * the ends, Enter/Space activate, Escape closes. Returns true when the key
+ * was consumed so callers can add their own (MenuBar adds Left/Right).
+ */
+function handleMenuKey(
+  ev,
+  { items, activeIndex, setActiveIndex, select, close },
+) {
+  switch (ev.keysym) {
+    case XK_ESCAPE:
+      close();
+      return true;
+    case XK_DOWN:
+      setActiveIndex(nextSelectable(items, activeIndex, 1));
+      return true;
+    case XK_UP:
+      setActiveIndex(nextSelectable(items, activeIndex, -1));
+      return true;
+    case XK_HOME:
+      setActiveIndex(nextSelectable(items, -1, 1));
+      return true;
+    case XK_END:
+      setActiveIndex(nextSelectable(items, items.length, -1));
+      return true;
+    default:
+      break;
+  }
+  if (ev.codepoint === 32 || ev.keysym === XK_RETURN) {
+    const item = items[activeIndex];
+    if (isSelectable(item)) select(item);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * <ContextMenu items>…</ContextMenu> — right-click anywhere in the children
+ * to open a menu at the pointer.
+ *
+ * The wrapper is focusable and takes focus when the menu opens, because the
+ * popup is override-redirect and never gets focus itself — the same trick
+ * `Select` uses to keep arrow keys working while its menu is open.
+ */
+export function ContextMenu({
+  items = [],
+  children,
+  onSelect,
+  fontSize = DEFAULT_LABEL_SIZE,
+  ...boxProps
+}) {
+  const ref = useRef(null);
+  const [rect, setRect] = useState(null);
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  const close = () => {
+    setRect(null);
+    setActiveIndex(-1);
+  };
+  const select = (item) => {
+    close();
+    item.onSelect?.(item);
+    onSelect?.(item);
+  };
+
+  const openAt = (ev) => {
+    const node = ref.current;
+    if (!node || !items.length) return;
+    const width = menuListWidth(node, items, fontSize);
+    const height = menuListHeight(items);
+    const screen = screenOf(node);
+    // anchored at the pointer rather than at a widget: clamp by hand, since
+    // there is no anchor rect to flip around
+    const x = ev.nativeEvent?.rootx ?? ev.x;
+    const y = ev.nativeEvent?.rooty ?? ev.y;
+    setRect({
+      x: screen ? Math.max(0, Math.min(x, screen.pixel_width - width)) : x,
+      y: screen ? Math.max(0, Math.min(y, screen.pixel_height - height)) : y,
+      width,
+      height,
+    });
+    setActiveIndex(-1);
+    node.root?.events?.focus?.(node);
+  };
+
+  return h(
+    'box',
+    {
+      ref,
+      focusable: true,
+      onMouseDown: (ev) => {
+        if (ev.button === 3) openAt(ev);
+        else if (rect) close();
+      },
+      onKeyDown: (ev) => {
+        if (!rect) return;
+        handleMenuKey(ev, {
+          items,
+          activeIndex,
+          setActiveIndex,
+          select,
+          close,
+        });
+      },
+      onBlur: close,
+      ...boxProps,
+    },
+    children,
+    rect &&
+      h(MenuPopup, {
+        rect,
+        items,
+        activeIndex,
+        fontSize,
+        onHover: setActiveIndex,
+        onSelect: select,
+      }),
+  );
+}
+
+/**
+ * <MenuBar menus={[{ label, items }]}/> — a horizontal bar of pull-down
+ * menus. Click or Enter opens; with one open, hovering another switches to
+ * it and Left/Right walk the bar; the usual menu keys work inside.
+ */
+export function MenuBar({
+  menus = [],
+  onSelect,
+  fontSize = DEFAULT_LABEL_SIZE,
+  ...boxProps
+}) {
+  const theme = useTheme();
+  const [openIndex, setOpenIndex] = useState(-1);
+  const [rect, setRect] = useState(null);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const refs = useRef([]);
+
+  const items = openIndex >= 0 ? (menus[openIndex]?.items ?? []) : [];
+
+  const close = () => {
+    setOpenIndex(-1);
+    setRect(null);
+    setActiveIndex(-1);
+  };
+
+  const openMenu = (index) => {
+    const node = refs.current[index];
+    const menu = menus[index];
+    if (!node || !menu?.items?.length) return;
+    const width = menuListWidth(node, menu.items, fontSize);
+    const height = menuListHeight(menu.items);
+    const next = anchorRect(node, { placement: 'bottom', width, height });
+    if (!next) return;
+    setRect(next);
+    setOpenIndex(index);
+    setActiveIndex(-1);
+  };
+
+  const select = (item) => {
+    close();
+    item.onSelect?.(item);
+    onSelect?.(item);
+  };
+
+  const moveMenu = (dir) => {
+    if (!menus.length) return;
+    const n = menus.length;
+    openMenu((openIndex + dir + n) % n);
+  };
+
+  return h(
+    'box',
+    {
+      flexDirection: 'row',
+      alignItems: 'center',
+      backgroundColor: theme.surfaceHover,
+      ...boxProps,
+    },
+    menus.map((menu, index) =>
+      h(
+        'box',
+        {
+          key: menu.label,
+          ref: (node) => {
+            refs.current[index] = node;
+          },
+          focusable: true,
+          cursor: 'pointer',
+          paddingLeft: 10,
+          paddingRight: 10,
+          paddingTop: 6,
+          paddingBottom: 6,
+          backgroundColor:
+            openIndex === index ? theme.hoverBackground : 'transparent',
+          onClick: () => (openIndex === index ? close() : openMenu(index)),
+          // with a menu already open, hovering the bar switches menus —
+          // standard pull-down behaviour
+          onMouseEnter: () => {
+            if (openIndex >= 0 && openIndex !== index) openMenu(index);
+          },
+          onBlur: () => {
+            if (openIndex === index) close();
+          },
+          onKeyDown: (ev) => {
+            if (ev.keysym === XK_LEFT) return moveMenu(-1);
+            if (ev.keysym === XK_RIGHT) return moveMenu(1);
+            if (openIndex !== index) {
+              if (ev.codepoint === 32 || ev.keysym === XK_RETURN) {
+                openMenu(index);
+              }
+              return;
+            }
+            handleMenuKey(ev, {
+              items,
+              activeIndex,
+              setActiveIndex,
+              select,
+              close,
+            });
+          },
+        },
+        h(
+          'text',
+          {
+            color: openIndex === index ? theme.hoverText : theme.text,
+            fontSize,
+          },
+          menu.label,
+        ),
+      ),
+    ),
+    openIndex >= 0 &&
+      rect &&
+      h(MenuPopup, {
+        rect,
+        items,
+        activeIndex,
+        fontSize,
+        onHover: setActiveIndex,
+        onSelect: select,
+      }),
+  );
+}
+
 function normalizeOption(option) {
   return typeof option === 'object' && option !== null
     ? option

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,8 @@ export {
   ProgressBar,
   Slider,
   Tooltip,
+  MenuBar,
+  ContextMenu,
   useAnchor,
   anchorRect,
 } from './components.js';

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -35,6 +35,13 @@ export const DEVTOOLS_FAKE_DOCUMENT = {
   defaultView: null,
 };
 
+/** CSS's `transparent` keyword means "paint nothing". ntk's colour parser
+ *  does not know it and throws deep inside the 2d context, taking the whole
+ *  frame with it, so filter it out at the source alongside null/''. */
+function isPaintedColor(color) {
+  return Boolean(color) && color !== 'transparent';
+}
+
 /** Equality for props that may be a scalar, an array or a plain object
  *  (window hints are all three shapes), so an unchanged inline object
  *  literal does not re-send the property every render. */
@@ -302,7 +309,7 @@ export class Node {
 
   _paintBackground(ctx) {
     const { backgroundColor, borderRadius = 0 } = this.props;
-    if (!backgroundColor) return;
+    if (!isPaintedColor(backgroundColor)) return;
     ctx.fillStyle = backgroundColor;
     if (borderRadius > 0) {
       this._roundedPath(ctx, borderRadius);
@@ -314,7 +321,7 @@ export class Node {
 
   _paintBorder(ctx) {
     const { borderWidth = 0, borderColor, borderRadius = 0 } = this.props;
-    if (!(borderWidth > 0) || !borderColor) return;
+    if (!(borderWidth > 0) || !isPaintedColor(borderColor)) return;
     // dashed borders need ntk >= 3.2.0 (setLineDash); solid fallback below
     const dashed =
       this.props.borderStyle === 'dashed' &&

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1954,3 +1954,263 @@ test('Tooltip does not show if the pointer leaves before the delay', async () =>
 
   ReactX11.unmountComponentAtNode(app);
 });
+
+const MENU_ITEMS = (picked) => [
+  { label: 'Cut', shortcut: 'Ctrl+X', onSelect: () => picked.push('Cut') },
+  { label: 'Copy', onSelect: () => picked.push('Copy') },
+  { separator: true },
+  { label: 'Paste', disabled: true, onSelect: () => picked.push('Paste') },
+  { label: 'Delete', onSelect: () => picked.push('Delete') },
+];
+
+/** Index of the highlighted row inside the newest popup. */
+function activeMenuIndex(app) {
+  const popup = app.windows.at(-1);
+  const rows = popup._reactX11Node.children[0].children;
+  return rows.findIndex((r) => r.props.backgroundColor === '#2980b9');
+}
+
+test('ContextMenu opens at the pointer and skips separators/disabled', async () => {
+  const { ContextMenu } = await import('../src/index.js');
+  const app = createMockApp();
+  const picked = [];
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 300, height: 200 },
+      React.createElement(
+        ContextMenu,
+        { items: MENU_ITEMS(picked), flexGrow: 1 },
+        React.createElement('box', { flexGrow: 1 }),
+      ),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+
+  assert.strictEqual(app.windows.length, 1, 'closed until right-click');
+
+  // right-click (button 3) opens at the pointer, in screen coordinates
+  wnd.emit('mousedown', {
+    x: 40,
+    y: 30,
+    keycode: 3,
+    rootx: 540,
+    rooty: 430,
+  });
+  await tick();
+  assert.strictEqual(app.windows.length, 2, 'menu opened');
+  const menu = app.windows[1];
+  assert.strictEqual(menu.attributes.overrideRedirect, true);
+  assert.strictEqual(menu.attributes.windowType, 'popup_menu');
+  assert.deepStrictEqual(
+    [menu.attributes.x, menu.attributes.y],
+    [540, 430],
+    'anchored at the pointer in screen coordinates',
+  );
+  assert.strictEqual(activeMenuIndex(app), -1, 'nothing active until a key');
+
+  // Down from nothing -> first selectable
+  pressKey(app, wnd, { keysym: 0xff54 });
+  await tick();
+  assert.strictEqual(activeMenuIndex(app), 0, 'Cut');
+
+  pressKey(app, wnd, { keysym: 0xff54 });
+  await tick();
+  assert.strictEqual(activeMenuIndex(app), 1, 'Copy');
+
+  // next Down must skip the separator (2) AND the disabled Paste (3)
+  pressKey(app, wnd, { keysym: 0xff54 });
+  await tick();
+  assert.strictEqual(
+    activeMenuIndex(app),
+    4,
+    'Delete — separator and disabled skipped',
+  );
+
+  // wraps back to the first selectable
+  pressKey(app, wnd, { keysym: 0xff54 });
+  await tick();
+  assert.strictEqual(activeMenuIndex(app), 0, 'wraps');
+
+  // Up wraps the other way, also skipping
+  pressKey(app, wnd, { keysym: 0xff52 });
+  await tick();
+  assert.strictEqual(activeMenuIndex(app), 4);
+
+  // End / Home
+  pressKey(app, wnd, { keysym: 0xff50 });
+  await tick();
+  assert.strictEqual(activeMenuIndex(app), 0, 'Home -> first selectable');
+
+  // Enter activates
+  pressKey(app, wnd, { keysym: XK.Return });
+  await tick();
+  assert.deepStrictEqual(picked, ['Cut']);
+  assert.strictEqual(app.windows[1].destroyed, true, 'closes after selecting');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('ContextMenu: Escape closes without selecting; disabled items are inert', async () => {
+  const { ContextMenu } = await import('../src/index.js');
+  const app = createMockApp();
+  const picked = [];
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 300, height: 200 },
+      React.createElement(
+        ContextMenu,
+        { items: MENU_ITEMS(picked), flexGrow: 1 },
+        React.createElement('box', { flexGrow: 1 }),
+      ),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+
+  wnd.emit('mousedown', { x: 10, y: 10, keycode: 3, rootx: 100, rooty: 100 });
+  await tick();
+  const menu = app.windows[1];
+
+  // clicking the disabled row does nothing
+  const rows = menu._reactX11Node.children[0].children;
+  const paste = rows[3];
+  menu.emit('mousedown', {
+    x: paste.abs.x + 5,
+    y: paste.abs.y + paste.abs.height / 2,
+    keycode: 1,
+  });
+  menu.emit('mouseup', {
+    x: paste.abs.x + 5,
+    y: paste.abs.y + paste.abs.height / 2,
+    keycode: 1,
+  });
+  await tick();
+  assert.deepStrictEqual(picked, [], 'disabled item is inert');
+  assert.strictEqual(menu.destroyed, false, 'and does not close the menu');
+
+  pressKey(app, wnd, { keysym: 0xff1b }); // Escape
+  await tick();
+  assert.strictEqual(menu.destroyed, true);
+  assert.deepStrictEqual(picked, []);
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('MenuBar opens menus, switches on hover and walks with Left/Right', async () => {
+  const { MenuBar } = await import('../src/index.js');
+  const app = createMockApp();
+  const picked = [];
+  const menus = [
+    {
+      label: 'File',
+      items: [
+        { label: 'New', onSelect: () => picked.push('New') },
+        { label: 'Open', onSelect: () => picked.push('Open') },
+      ],
+    },
+    {
+      label: 'Edit',
+      items: [{ label: 'Undo', onSelect: () => picked.push('Undo') }],
+    },
+  ];
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 320, height: 200 },
+      React.createElement(MenuBar, { menus }),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const bar = wnd._reactX11Node.children[0];
+  const [fileBtn, editBtn] = bar.children.filter((c) => c.props.focusable);
+
+  const clickNode = (node) => {
+    const x = node.abs.x + node.abs.width / 2;
+    const y = node.abs.y + node.abs.height / 2;
+    wnd.emit('mousedown', { x, y, keycode: 1 });
+    wnd.emit('mouseup', { x, y, keycode: 1 });
+  };
+
+  clickNode(fileBtn);
+  await tick();
+  assert.strictEqual(app.windows.length, 2, 'File menu opened');
+  const fileMenu = app.windows[1];
+  // anchored below the button, in screen coordinates
+  assert.strictEqual(
+    fileMenu.attributes.y,
+    fileBtn.abs.y + fileBtn.abs.height + 2,
+  );
+
+  // hovering Edit while File is open switches menus. The <popup> keeps its
+  // place in the tree, so React reuses the same X window and moves it —
+  // no destroy/recreate flicker between menus.
+  wnd.emit('mousemove', {
+    x: editBtn.abs.x + editBtn.abs.width / 2,
+    y: editBtn.abs.y + editBtn.abs.height / 2,
+  });
+  await tick();
+  await tick(); // mousemove is continuous priority
+  assert.strictEqual(app.windows.length, 2, 'window reused, not recreated');
+  assert.strictEqual(fileMenu.destroyed, false);
+  assert.strictEqual(fileMenu.x, editBtn.abs.x, 'moved under Edit');
+
+  // Left walks back to File
+  pressKey(app, wnd, { keysym: 0xff51 });
+  await tick();
+  assert.strictEqual(fileMenu.x, fileBtn.abs.x, 'moved back under File');
+
+  // Down then Enter picks the first item of the File menu
+  pressKey(app, wnd, { keysym: 0xff54 });
+  await tick();
+  pressKey(app, wnd, { keysym: XK.Return });
+  await tick();
+  assert.deepStrictEqual(picked, ['New']);
+  assert.strictEqual(fileMenu.destroyed, true, 'closes after selecting');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('backgroundColor/borderColor "transparent" paints nothing (and does not throw)', async () => {
+  const app = createMockApp();
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 100, height: 60 },
+      React.createElement('box', {
+        flexGrow: 1,
+        backgroundColor: 'transparent',
+        borderWidth: 2,
+        borderColor: 'transparent',
+      }),
+      React.createElement('box', {
+        flexGrow: 1,
+        backgroundColor: '#ff0000',
+      }),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const ops = app.windows[0].ctx.ops;
+  // ntk's colour parser has no 'transparent' keyword and throws inside the
+  // 2d context, which would take down the whole frame
+  const fills = ops.filter(([op]) => op === 'fillRect').map((o) => o[5]);
+  assert.ok(!fills.includes('transparent'), 'no transparent fill was issued');
+  assert.ok(fills.includes('#ff0000'), 'real colours still paint');
+  assert.ok(
+    !ops.some(([op, style]) => op === 'stroke' && style === 'transparent'),
+    'no transparent stroke was issued',
+  );
+
+  ReactX11.unmountComponentAtNode(app);
+});


### PR DESCRIPTION
Generalises `examples/menu.jsx` — previously an ad-hoc right-click list — into two components sharing one menu implementation, both built on the `useAnchor` extracted in #39.

```jsx
<MenuBar menus={[{ label: 'File', items: [
  { label: 'New', shortcut: 'Ctrl+N', onSelect: newFile },
  { separator: true },
  { label: 'Save As…', disabled: true },
  { label: 'Wrap lines', checked: wrap, onSelect: toggleWrap },
]}]} />

<ContextMenu items={items} flexGrow={1}>
  <text>Right-click me</text>
</ContextMenu>
```

Item shape: `{ label, onSelect, shortcut, disabled, separator, checked }`.

**Keyboard.** Up/Down move the active item, **skipping separators and disabled entries**, wrapping; Home/End jump; Enter/Space activate; Escape closes. In a `MenuBar`, Left/Right walk the bar; with one menu open, hovering another switches to it.

Both keep focus on a node in the *owner* window, because the popup is override-redirect and never takes focus — the same arrangement `Select` uses. `ContextMenu`'s wrapper is focusable for that reason and takes focus when the menu opens.

## Screenshot

`examples/menu.jsx`, rewritten on these components — Edit open, `Undo` active via keyboard, `Redo` disabled, a separator, shortcuts right-aligned:

![menubar](https://github.com/user-attachments/assets/5f6e7b9e-9d34-4274-a4fc-660b3604bdb3)

## A crash this surfaced

`backgroundColor="transparent"` is valid CSS, but ntk's colour parser doesn't know the keyword and threw from inside the 2d context — taking down the **entire frame**, not just that box. My first run of the rewritten example died on it.

Both paint paths now treat `'transparent'` as "paint nothing", alongside `null`/`''`. Worth fixing rather than just avoiding, since any CSS-minded user will reach for it. Covered by its own test.

## One thing my test got wrong first

I asserted that switching `MenuBar` menus destroys the old popup and creates a new one. It doesn't — the `<popup>` keeps its place in the tree, so React reuses the X window and just moves it. That's the better behaviour (no flicker), so I corrected the test rather than the code, and documented it.

## Tests

58/58, lint clean. New: context menu opening at the pointer in screen coordinates with the right `windowType`, Down/Up/Home/End skipping separators *and* disabled rows and wrapping, Enter selecting, Escape closing without selecting, disabled rows inert to clicks, MenuBar open/hover-switch/Left-Right/select, and the `transparent` guard.
