### PR TITLE
feat: nested submenus for MenuBar and ContextMenu

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -16,8 +16,8 @@
 > **Plan (next session):**
 >
 > 1. Merge release-please #17 and publish 1.0.0.
-> 2. Submenus for `MenuBar`/`ContextMenu` (nested `items`), and
->    type-ahead in menus.
+> 2. Type-ahead in menus and `Select` (jump to the entry matching typed
+>    letters).
 > 3. `<textarea>` polish: Ctrl+arrow word movement, PageUp/Down,
 >    Shift+click extend, drawn scrollbar.
 > 4. `Select` follow-ups: type-ahead (jump to the option matching typed
@@ -63,8 +63,8 @@ merged theme (`ThemeProvider`; `SelectThemeProvider` is an alias) and a
 - **Tooltip** — DONE: `useAnchor(ref)`/`anchorRect()` extracted from
   `Select` (and now flip at screen edges), `Tooltip` built on them
 - **Menu/MenuBar, ContextMenu** — DONE: built on `useAnchor`, with
-  separators, disabled items, shortcuts, checkmarks and full keyboard
-  navigation; `examples/menu.jsx` rewritten on them
+  separators, disabled items, shortcuts, checkmarks, nested submenus and
+  full keyboard navigation; `examples/menu.jsx` rewritten on them
 - **`Select` type-ahead / PageUp-PageDown** — keyboard navigation itself
   is done (#34: Up/Down/Home/End/Enter/Escape, shared pointer+keyboard
   highlight, active option scrolled into view)

--- a/docs/components.md
+++ b/docs/components.md
@@ -155,13 +155,36 @@ import { MenuBar, ContextMenu } from 'react-x11';
 </ContextMenu>;
 ```
 
-Item shape: `{ label, onSelect, shortcut, disabled, separator, checked }`.
-Both take an `onSelect(item)` prop as well, fired after the item's own.
+Item shape: `{ label, onSelect, shortcut, disabled, separator, checked,
+items }`. Both take an `onSelect(item)` prop as well, fired after the
+item's own.
+
+**Submenus.** Give an item its own `items` and it becomes a submenu parent,
+marked with `▸` and opening to the side:
+
+```jsx
+{ label: 'Export', items: [
+    { label: 'PNG', onSelect: exportPng },
+    { label: 'SVG', onSelect: exportSvg },
+] }
+```
+
+Nesting is unlimited. Each level is its own `<popup>`, anchored to its
+parent row with `placement: 'right'`, so it flips to the left near a screen
+edge like any other anchored popup.
 
 **Keyboard.** Up/Down move the active item, **skipping separators and
-disabled entries** and wrapping; Home/End jump to the ends; Enter/Space
-activate; Escape closes. In a `MenuBar`, Left/Right walk between menus, and
-with one menu open, hovering another switches to it.
+disabled entries** and wrapping; Home/End jump to the ends; Right opens a
+submenu (selecting its first item) and Left leaves one; Enter/Space
+activate — or open a submenu, for a parent row; Escape closes **one level
+at a time**. In a `MenuBar`, Left/Right walk between menus _when there is
+no submenu to move through_, and with one menu open, hovering another
+switches to it. Hovering a submenu parent opens it with nothing selected
+inside.
+
+Open state is a single path of active indices — one per open level — so
+moving the selection at any level truncates the path and closes deeper
+levels for free.
 
 Both keep focus on a node in the _owner_ window — the popup is
 override-redirect and never takes focus — which is the same arrangement

--- a/examples/menu.jsx
+++ b/examples/menu.jsx
@@ -4,7 +4,8 @@
 //
 // Keyboard: click or Enter opens a bar menu, Left/Right walk the bar,
 // Up/Down move within a menu (skipping separators and disabled entries),
-// Enter picks, Escape closes.
+// Right opens a submenu and Left leaves it, Enter picks, Escape closes one
+// level at a time.
 //
 // Run with: npm run examples:menu  (needs an X server / DISPLAY)
 import React, { useState } from 'react';
@@ -24,6 +25,15 @@ function App() {
         { separator: true },
         { label: 'Save', shortcut: 'Ctrl+S', onSelect: note('Save') },
         { label: 'Save As…', disabled: true },
+        {
+          label: 'Export',
+          items: [
+            { label: 'PNG image', onSelect: note('Export → PNG') },
+            { label: 'SVG vector', onSelect: note('Export → SVG') },
+            { separator: true },
+            { label: 'PDF', disabled: true },
+          ],
+        },
         { separator: true },
         { label: 'Quit', shortcut: 'Ctrl+Q', onSelect: note('Quit') },
       ],

--- a/src/components.js
+++ b/src/components.js
@@ -771,7 +771,7 @@ function nextSelectable(items, from, dir) {
   return -1;
 }
 
-function MenuRow({ item, active, onHover, onSelect, fontSize }) {
+function MenuRow({ item, active, onHover, onSelect, fontSize, nodeRef }) {
   const theme = useTheme();
   if (item.separator) {
     return h(
@@ -781,9 +781,11 @@ function MenuRow({ item, active, onHover, onSelect, fontSize }) {
     );
   }
   const dim = item.disabled;
+  const hasSubmenu = item.items?.length > 0;
   return h(
     'box',
     {
+      ref: nodeRef,
       height: MENU_ITEM_HEIGHT,
       flexDirection: 'row',
       alignItems: 'center',
@@ -801,7 +803,7 @@ function MenuRow({ item, active, onHover, onSelect, fontSize }) {
         h('text', {
           color: active ? theme.hoverText : theme.text,
           fontSize,
-          children: '✓',
+          children: '\u2713',
         }),
     ),
     h(
@@ -822,16 +824,84 @@ function MenuRow({ item, active, onHover, onSelect, fontSize }) {
         },
         item.shortcut,
       ),
+    hasSubmenu &&
+      h('text', {
+        color: dim ? theme.dim : active ? theme.hoverText : theme.dim,
+        fontSize,
+        children: '\u25b8',
+      }),
   );
 }
 
+/** Items at `depth`, walking `path` down through nested `items`. */
+function levelItems(rootItems, path, depth) {
+  let items = rootItems;
+  for (let d = 0; d < depth; d++) items = items[path[d]]?.items ?? [];
+  return items;
+}
+
 /**
- * The menu popup itself: an override-redirect `<popup>` at `rect` holding a
- * list of items. Shared by `MenuBar` and `ContextMenu`; `rect` comes from
- * `useAnchor`, so menus flip at screen edges like `Select`'s.
+ * One level of a menu: an override-redirect `<popup>` at `rect` holding the
+ * items for `depth`, plus — recursively — its open submenu.
+ *
+ * Open state is a single `path` of active indices, one per level, rather
+ * than a flat index: `path.length` is how many levels are open, `path[d]`
+ * which row is active at level `d` (-1 for none). Moving the selection at
+ * any level truncates the path, which closes deeper levels for free.
  */
-function MenuPopup({ rect, items, activeIndex, onHover, onSelect, fontSize }) {
+function MenuLevel({
+  rect,
+  rootItems,
+  path,
+  depth,
+  setPath,
+  onSelect,
+  fontSize,
+}) {
   const theme = useTheme();
+  const items = levelItems(rootItems, path, depth);
+  const active = path[depth] ?? -1;
+  const childItems = items[active]?.items;
+  const childOpen = path.length > depth + 1 && childItems?.length > 0;
+
+  const activeRowRef = useRef(null);
+  const [childRect, setChildRect] = useState(null);
+
+  useEffect(() => {
+    if (!childOpen) {
+      setChildRect(null);
+      return;
+    }
+    const node = activeRowRef.current;
+    // the parent popup is always laid out by the time a submenu can be
+    // reached (it has to be hovered or arrowed into first), but guard
+    // anyway rather than anchoring off a zero rect
+    if (!node?.abs?.width) return;
+    setChildRect(
+      anchorRect(node, {
+        placement: 'right',
+        align: 'start',
+        offset: 0,
+        width: menuListWidth(node, childItems, fontSize),
+        height: menuListHeight(childItems),
+      }),
+    );
+  }, [childOpen, active, depth, fontSize, rect.x, rect.y]);
+
+  const hover = (index) => {
+    const base = [...path.slice(0, depth), index];
+    // hovering a parent row opens its submenu with nothing selected inside
+    setPath(items[index]?.items?.length ? [...base, -1] : base);
+  };
+
+  const choose = (item) => {
+    if (item.items?.length) {
+      setPath([...path.slice(0, depth), items.indexOf(item), -1]);
+      return;
+    }
+    onSelect(item);
+  };
+
   return h(
     'popup',
     {
@@ -856,47 +926,81 @@ function MenuPopup({ rect, items, activeIndex, onHover, onSelect, fontSize }) {
         h(MenuRow, {
           key: item.separator ? `sep-${index}` : (item.key ?? item.label),
           item,
-          active: index === activeIndex,
+          active: index === active,
           fontSize,
-          onHover: () => onHover(index),
-          onSelect,
+          nodeRef: index === active ? activeRowRef : undefined,
+          onHover: () => hover(index),
+          onSelect: choose,
         }),
       ),
     ),
+    childOpen &&
+      childRect &&
+      h(MenuLevel, {
+        rect: childRect,
+        rootItems,
+        path,
+        depth: depth + 1,
+        setPath,
+        onSelect,
+        fontSize,
+      }),
   );
 }
 
 /**
- * Keyboard handling shared by every menu: Up/Down move the active item
- * (skipping separators and disabled entries, wrapping), Home/End jump to
- * the ends, Enter/Space activate, Escape closes. Returns true when the key
- * was consumed so callers can add their own (MenuBar adds Left/Right).
+ * Keyboard handling shared by every menu, operating on the deepest open
+ * level: Up/Down move the active item (skipping separators and disabled
+ * entries, wrapping), Home/End jump to the ends, Right enters a submenu,
+ * Left leaves one, Enter/Space activate, Escape closes one level.
+ *
+ * Returns true when the key was consumed. Left and Right fall through when
+ * there is no submenu to enter or leave, so `MenuBar` can walk the bar.
  */
-function handleMenuKey(
-  ev,
-  { items, activeIndex, setActiveIndex, select, close },
-) {
+function handleMenuKey(ev, { rootItems, path, setPath, select, close }) {
+  const depth = path.length - 1;
+  if (depth < 0) return false;
+  const items = levelItems(rootItems, path, depth);
+  const active = path[depth];
+  const setActive = (i) => setPath([...path.slice(0, depth), i]);
+  const enterSubmenu = () => {
+    const sub = items[active]?.items;
+    if (!sub?.length) return false;
+    setPath([...path, nextSelectable(sub, -1, 1)]);
+    return true;
+  };
+
   switch (ev.keysym) {
     case XK_ESCAPE:
-      close();
+      if (depth > 0) setPath(path.slice(0, -1));
+      else close();
       return true;
     case XK_DOWN:
-      setActiveIndex(nextSelectable(items, activeIndex, 1));
+      setActive(nextSelectable(items, active, 1));
       return true;
     case XK_UP:
-      setActiveIndex(nextSelectable(items, activeIndex, -1));
+      setActive(nextSelectable(items, active, -1));
       return true;
     case XK_HOME:
-      setActiveIndex(nextSelectable(items, -1, 1));
+      setActive(nextSelectable(items, -1, 1));
       return true;
     case XK_END:
-      setActiveIndex(nextSelectable(items, items.length, -1));
+      setActive(nextSelectable(items, items.length, -1));
       return true;
+    case XK_RIGHT:
+      return enterSubmenu();
+    case XK_LEFT:
+      if (depth > 0) {
+        setPath(path.slice(0, -1));
+        return true;
+      }
+      return false;
     default:
       break;
   }
   if (ev.codepoint === 32 || ev.keysym === XK_RETURN) {
-    const item = items[activeIndex];
+    if (enterSubmenu()) return true;
+    const item = items[active];
     if (isSelectable(item)) select(item);
     return true;
   }
@@ -920,11 +1024,11 @@ export function ContextMenu({
 }) {
   const ref = useRef(null);
   const [rect, setRect] = useState(null);
-  const [activeIndex, setActiveIndex] = useState(-1);
+  const [path, setPath] = useState([]);
 
   const close = () => {
     setRect(null);
-    setActiveIndex(-1);
+    setPath([]);
   };
   const select = (item) => {
     close();
@@ -948,7 +1052,7 @@ export function ContextMenu({
       width,
       height,
     });
-    setActiveIndex(-1);
+    setPath([-1]);
     node.root?.events?.focus?.(node);
   };
 
@@ -964,9 +1068,9 @@ export function ContextMenu({
       onKeyDown: (ev) => {
         if (!rect) return;
         handleMenuKey(ev, {
-          items,
-          activeIndex,
-          setActiveIndex,
+          rootItems: items,
+          path,
+          setPath,
           select,
           close,
         });
@@ -976,12 +1080,14 @@ export function ContextMenu({
     },
     children,
     rect &&
-      h(MenuPopup, {
+      path.length > 0 &&
+      h(MenuLevel, {
         rect,
-        items,
-        activeIndex,
+        rootItems: items,
+        path,
+        depth: 0,
+        setPath,
         fontSize,
-        onHover: setActiveIndex,
         onSelect: select,
       }),
   );
@@ -1001,7 +1107,7 @@ export function MenuBar({
   const theme = useTheme();
   const [openIndex, setOpenIndex] = useState(-1);
   const [rect, setRect] = useState(null);
-  const [activeIndex, setActiveIndex] = useState(-1);
+  const [path, setPath] = useState([]);
   const refs = useRef([]);
 
   const items = openIndex >= 0 ? (menus[openIndex]?.items ?? []) : [];
@@ -1009,7 +1115,7 @@ export function MenuBar({
   const close = () => {
     setOpenIndex(-1);
     setRect(null);
-    setActiveIndex(-1);
+    setPath([]);
   };
 
   const openMenu = (index) => {
@@ -1022,7 +1128,7 @@ export function MenuBar({
     if (!next) return;
     setRect(next);
     setOpenIndex(index);
-    setActiveIndex(-1);
+    setPath([-1]);
   };
 
   const select = (item) => {
@@ -1060,7 +1166,7 @@ export function MenuBar({
           paddingTop: 6,
           paddingBottom: 6,
           backgroundColor:
-            openIndex === index ? theme.hoverBackground : 'transparent',
+            openIndex === index ? theme.hoverBackground : undefined,
           onClick: () => (openIndex === index ? close() : openMenu(index)),
           // with a menu already open, hovering the bar switches menus —
           // standard pull-down behaviour
@@ -1071,21 +1177,26 @@ export function MenuBar({
             if (openIndex === index) close();
           },
           onKeyDown: (ev) => {
-            if (ev.keysym === XK_LEFT) return moveMenu(-1);
-            if (ev.keysym === XK_RIGHT) return moveMenu(1);
             if (openIndex !== index) {
               if (ev.codepoint === 32 || ev.keysym === XK_RETURN) {
                 openMenu(index);
-              }
+              } else if (ev.keysym === XK_LEFT) moveMenu(-1);
+              else if (ev.keysym === XK_RIGHT) moveMenu(1);
               return;
             }
-            handleMenuKey(ev, {
-              items,
-              activeIndex,
-              setActiveIndex,
+            // the menu gets first refusal: Left leaves a submenu and Right
+            // enters one, and only when there is no submenu to move through
+            // do they walk the bar
+            const consumed = handleMenuKey(ev, {
+              rootItems: items,
+              path,
+              setPath,
               select,
               close,
             });
+            if (consumed) return;
+            if (ev.keysym === XK_LEFT) moveMenu(-1);
+            else if (ev.keysym === XK_RIGHT) moveMenu(1);
           },
         },
         h(
@@ -1100,12 +1211,14 @@ export function MenuBar({
     ),
     openIndex >= 0 &&
       rect &&
-      h(MenuPopup, {
+      path.length > 0 &&
+      h(MenuLevel, {
         rect,
-        items,
-        activeIndex,
+        rootItems: items,
+        path,
+        depth: 0,
+        setPath,
         fontSize,
-        onHover: setActiveIndex,
         onSelect: select,
       }),
   );

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -2076,21 +2076,22 @@ test('ContextMenu: Escape closes without selecting; disabled items are inert', a
 
   wnd.emit('mousedown', { x: 10, y: 10, keycode: 3, rootx: 100, rooty: 100 });
   await tick();
+  await tick(); // the popup lays out a tick after creation
   const menu = app.windows[1];
 
-  // clicking the disabled row does nothing
   const rows = menu._reactX11Node.children[0].children;
+  assert.ok(rows[0].abs.width > 0, 'rows are laid out — clicks below are real');
+
+  const clickRow = (row) => {
+    const x = row.abs.x + 5;
+    const y = row.abs.y + row.abs.height / 2;
+    menu.emit('mousedown', { x, y, keycode: 1 });
+    menu.emit('mouseup', { x, y, keycode: 1 });
+  };
+
+  // clicking the disabled row does nothing
   const paste = rows[3];
-  menu.emit('mousedown', {
-    x: paste.abs.x + 5,
-    y: paste.abs.y + paste.abs.height / 2,
-    keycode: 1,
-  });
-  menu.emit('mouseup', {
-    x: paste.abs.x + 5,
-    y: paste.abs.y + paste.abs.height / 2,
-    keycode: 1,
-  });
+  clickRow(paste);
   await tick();
   assert.deepStrictEqual(picked, [], 'disabled item is inert');
   assert.strictEqual(menu.destroyed, false, 'and does not close the menu');
@@ -2099,6 +2100,44 @@ test('ContextMenu: Escape closes without selecting; disabled items are inert', a
   await tick();
   assert.strictEqual(menu.destroyed, true);
   assert.deepStrictEqual(picked, []);
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('ContextMenu: clicking an enabled row selects it and closes', async () => {
+  const { ContextMenu } = await import('../src/index.js');
+  const app = createMockApp();
+  const picked = [];
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 300, height: 200 },
+      React.createElement(
+        ContextMenu,
+        { items: MENU_ITEMS(picked), flexGrow: 1 },
+        React.createElement('box', { flexGrow: 1 }),
+      ),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  wnd.emit('mousedown', { x: 10, y: 10, keycode: 3, rootx: 100, rooty: 100 });
+  await tick();
+  await tick(); // the popup lays out a tick after creation
+
+  const menu = app.windows[1];
+  const copy = menu._reactX11Node.children[0].children[1];
+  assert.ok(copy.abs.width > 0, 'row is laid out');
+  const x = copy.abs.x + 5;
+  const y = copy.abs.y + copy.abs.height / 2;
+  menu.emit('mousedown', { x, y, keycode: 1 });
+  menu.emit('mouseup', { x, y, keycode: 1 });
+  await tick();
+
+  assert.deepStrictEqual(picked, ['Copy']);
+  assert.strictEqual(menu.destroyed, true, 'closes after selecting');
 
   ReactX11.unmountComponentAtNode(app);
 });
@@ -2211,6 +2250,164 @@ test('backgroundColor/borderColor "transparent" paints nothing (and does not thr
     !ops.some(([op, style]) => op === 'stroke' && style === 'transparent'),
     'no transparent stroke was issued',
   );
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+const NESTED_ITEMS = (picked) => [
+  { label: 'New', onSelect: () => picked.push('New') },
+  {
+    label: 'Export',
+    items: [
+      { label: 'PNG', onSelect: () => picked.push('PNG') },
+      { separator: true },
+      { label: 'SVG', onSelect: () => picked.push('SVG') },
+      { label: 'PDF', disabled: true },
+    ],
+  },
+  { label: 'Quit', onSelect: () => picked.push('Quit') },
+];
+
+/** Rows of the popup at `index` among the app's windows. */
+const rowsOf = (app, index) =>
+  app.windows[index]._reactX11Node.children[0].children;
+const activeIn = (app, index) =>
+  rowsOf(app, index).findIndex((r) => r.props.backgroundColor === '#2980b9');
+
+async function openNested(app, picked) {
+  const { ContextMenu } = await import('../src/index.js');
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 320, height: 220 },
+      React.createElement(
+        ContextMenu,
+        { items: NESTED_ITEMS(picked), flexGrow: 1 },
+        React.createElement('box', { flexGrow: 1 }),
+      ),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  wnd.emit('mousedown', { x: 20, y: 20, keycode: 3, rootx: 200, rooty: 120 });
+  // a popup lays out one tick after it is created: without this second
+  // tick its rows still have zero rects and pointer assertions are vacuous
+  await tick();
+  await tick();
+  return wnd;
+}
+
+test('submenu: Right opens it, Left leaves, Escape closes one level', async () => {
+  const app = createMockApp();
+  const picked = [];
+  const wnd = await openNested(app, picked);
+  assert.strictEqual(app.windows.length, 2, 'root menu open');
+
+  // move onto Export (index 1)
+  pressKey(app, wnd, { keysym: 0xff54 }); // Down -> New
+  await tick();
+  pressKey(app, wnd, { keysym: 0xff54 }); // Down -> Export
+  await tick();
+  assert.strictEqual(activeIn(app, 1), 1, 'Export active');
+  assert.strictEqual(app.windows.length, 2, 'not opened by arrowing alone');
+
+  // Right enters the submenu, selecting its first selectable item
+  pressKey(app, wnd, { keysym: 0xff53 });
+  await tick();
+  await tick();
+  assert.strictEqual(app.windows.length, 3, 'submenu popup opened');
+  assert.strictEqual(activeIn(app, 2), 0, 'PNG active');
+
+  // Down inside the submenu skips the separator to SVG, and PDF is disabled
+  pressKey(app, wnd, { keysym: 0xff54 });
+  await tick();
+  assert.strictEqual(activeIn(app, 2), 2, 'SVG (separator skipped)');
+  pressKey(app, wnd, { keysym: 0xff54 });
+  await tick();
+  assert.strictEqual(
+    activeIn(app, 2),
+    0,
+    'wraps past disabled PDF back to PNG',
+  );
+
+  // Left leaves the submenu without closing the root
+  pressKey(app, wnd, { keysym: 0xff51 });
+  await tick();
+  await tick();
+  assert.strictEqual(app.windows[2].destroyed, true, 'submenu closed');
+  assert.strictEqual(app.windows[1].destroyed, false, 'root menu still open');
+  assert.strictEqual(activeIn(app, 1), 1, 'Export still active');
+
+  // Enter also opens a submenu
+  pressKey(app, wnd, { keysym: XK.Return });
+  await tick();
+  await tick();
+  assert.strictEqual(app.windows.length, 4, 'reopened via Enter');
+
+  // Escape closes one level at a time
+  pressKey(app, wnd, { keysym: 0xff1b });
+  await tick();
+  await tick();
+  assert.strictEqual(app.windows[3].destroyed, true, 'submenu closed');
+  assert.strictEqual(app.windows[1].destroyed, false, 'root survives');
+  pressKey(app, wnd, { keysym: 0xff1b });
+  await tick();
+  assert.strictEqual(app.windows[1].destroyed, true, 'root closed');
+  assert.deepStrictEqual(picked, []);
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('submenu: selecting a nested item closes every level', async () => {
+  const app = createMockApp();
+  const picked = [];
+  const wnd = await openNested(app, picked);
+
+  pressKey(app, wnd, { keysym: 0xff54 }); // New
+  await tick();
+  pressKey(app, wnd, { keysym: 0xff54 }); // Export
+  await tick();
+  pressKey(app, wnd, { keysym: 0xff53 }); // into submenu -> PNG
+  await tick();
+  await tick();
+  pressKey(app, wnd, { keysym: XK.Return });
+  await tick();
+
+  assert.deepStrictEqual(picked, ['PNG']);
+  assert.strictEqual(app.windows[1].destroyed, true, 'root closed');
+  assert.strictEqual(app.windows[2].destroyed, true, 'submenu closed');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('submenu: hovering a parent row opens it with nothing selected inside', async () => {
+  const app = createMockApp();
+  const picked = [];
+  await openNested(app, picked);
+  const menu = app.windows[1];
+  const exportRow = rowsOf(app, 1)[1];
+
+  menu.emit('mousemove', {
+    x: exportRow.abs.x + 5,
+    y: exportRow.abs.y + exportRow.abs.height / 2,
+  });
+  // hover is continuous priority (scheduled, not flushed), and the submenu
+  // rect is then measured in an effect — so this settles over a few ticks
+  for (let i = 0; i < 4; i++) await tick();
+  assert.strictEqual(app.windows.length, 3, 'submenu opened on hover');
+  assert.strictEqual(activeIn(app, 2), -1, 'nothing active inside yet');
+
+  // hovering a sibling closes the submenu again
+  const quitRow = rowsOf(app, 1)[2];
+  menu.emit('mousemove', {
+    x: quitRow.abs.x + 5,
+    y: quitRow.abs.y + quitRow.abs.height / 2,
+  });
+  for (let i = 0; i < 4; i++) await tick();
+  assert.strictEqual(app.windows[2].destroyed, true, 'submenu closed');
+  assert.strictEqual(activeIn(app, 1), 2, 'Quit active');
 
   ReactX11.unmountComponentAtNode(app);
 });


### PR DESCRIPTION
An item with its own `items` becomes a submenu parent, marked with `▸` and opening to the side:

```jsx
{ label: 'Export', items: [
    { label: 'PNG image', onSelect: exportPng },
    { label: 'SVG vector', onSelect: exportSvg },
    { separator: true },
    { label: 'PDF', disabled: true },
] }
```

Nesting is unlimited. Each level is its own `<popup>` anchored to its parent row with `placement: 'right'`, so it flips left near a screen edge like any other anchored popup.

## Path-based open state

Open state moves from a flat `activeIndex` to a single **path** of active indices — one per open level. `path.length` is how many levels are open, `path[d]` which row is active at level `d`. Moving the selection at any level truncates the path, so deeper levels close for free rather than needing separate bookkeeping.

## Keyboard

Right opens a submenu (selecting its first selectable item), Left leaves one, Enter opens a parent row rather than selecting it, Escape closes **one level at a time**. In a `MenuBar` the menu gets first refusal on Left/Right, so they only walk the bar when there's no submenu to move through — the standard behaviour. Hovering a submenu parent opens it with nothing selected inside.

## Screenshot

`examples/menu.jsx`, File open, arrowed to `Export`, Right pressed:

![submenu](https://github.com/user-attachments/assets/877e8615-670f-4c2c-95b9-9312bd76ba21)

## Tests that were passing vacuously

Worth flagging, because it affected already-merged work: **a popup lays out one tick after it is created.** Assertions made a single tick after opening a menu were clicking rows whose rects were still `0x0`, so the events hit nothing.

That silently defanged the "a disabled row is inert" test from #40 — it could not have failed. Fixed here:

- menu-opening helpers wait the extra tick
- an explicit `assert.ok(rows[0].abs.width > 0)` pins that rows really are laid out before any pointer assertion
- a new positive-control test checks an **enabled** row does select and close, so "disabled does nothing" now means something

I found this because the new hover test failed for the same reason, then checked whether clicking any row worked at all. It didn't.

## Tests

62/62, lint clean. New: Right/Left/Escape level navigation, separator-and-disabled skipping *inside* a submenu, selecting a nested item closing every level, and hover-opening a parent with nothing selected inside.
