### PR TITLE
feat: type-ahead in Select and the menus

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -16,8 +16,8 @@
 > **Plan (next session):**
 >
 > 1. Merge release-please #17 and publish 1.0.0.
-> 2. Type-ahead in menus and `Select` (jump to the entry matching typed
->    letters).
+> 2. Split `src/components.js` (1500+ lines, 13 components) into
+>    `src/components/`.
 > 3. `<textarea>` polish: Ctrl+arrow word movement, PageUp/Down,
 >    Shift+click extend, drawn scrollbar.
 > 4. `Select` follow-ups: type-ahead (jump to the option matching typed
@@ -65,7 +65,7 @@ merged theme (`ThemeProvider`; `SelectThemeProvider` is an alias) and a
 - **Menu/MenuBar, ContextMenu** — DONE: built on `useAnchor`, with
   separators, disabled items, shortcuts, checkmarks, nested submenus and
   full keyboard navigation; `examples/menu.jsx` rewritten on them
-- **`Select` type-ahead / PageUp-PageDown** — keyboard navigation itself
+- **`Select` PageUp/PageDown** — type-ahead is done; keyboard navigation
   is done (#34: Up/Down/Home/End/Enter/Escape, shared pointer+keyboard
   highlight, active option scrolled into view)
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -49,6 +49,12 @@ The menu opens with the current value active, hovering an option makes it
 active (pointer and keyboard share one highlight), and the active option is
 scrolled into view.
 
+**Type-ahead.** Typing letters jumps to the matching option: with the menu
+open it moves the highlight, and with it closed it changes the value
+outright, the way a native select does. Keystrokes within 700ms accumulate
+into one query (`b`,`l` finds _blueberry_, not _banana_); repeating a
+single letter cycles through the options starting with it.
+
 ### Theming
 
 ```jsx
@@ -181,6 +187,12 @@ at a time**. In a `MenuBar`, Left/Right walk between menus _when there is
 no submenu to move through_, and with one menu open, hovering another
 switches to it. Hovering a submenu parent opens it with nothing selected
 inside.
+
+**Type-ahead.** Typing letters jumps to the entry whose label starts with
+them, in whichever level is deepest open. Keystrokes within 700ms
+accumulate into one query, so `c`,`a` finds _Carrot_ rather than jumping to
+_Apple_ first; repeating a single letter cycles through the entries
+starting with it. Disabled entries and separators are never matched.
 
 Open state is a single path of active indices — one per open level — so
 moving the selection at any level truncates the path and closes deeper

--- a/src/components.js
+++ b/src/components.js
@@ -166,6 +166,59 @@ export function useAnchor(ref) {
   return useCallback((options) => anchorRect(ref.current, options), [ref]);
 }
 
+const TYPE_AHEAD_TIMEOUT = 700;
+
+/**
+ * Type-ahead: typing letters jumps to the entry whose label starts with
+ * them. Shared by `Select` and the menus.
+ *
+ * Keystrokes within `timeout` accumulate into one query, so "ca" finds
+ * Carrot rather than jumping to Apple then Carrot. Two behaviours the
+ * platform conventions call for:
+ *
+ * - a growing query searches from the *current* entry, so refining a
+ *   prefix keeps you on it while it still matches;
+ * - repeating one letter ("c", "c", "c") cycles through the entries
+ *   starting with it instead of sticking on the first.
+ *
+ * Returns the matching index, or -1.
+ */
+function useTypeAhead(timeout = TYPE_AHEAD_TIMEOUT) {
+  const state = useRef({ text: '', at: 0 });
+  return useCallback(
+    (char, items, current, labelOf, selectable) => {
+      if (!char || char.length !== 1) return -1;
+      const now = Date.now();
+      const s = state.current;
+      s.text = now - s.at > timeout ? char : s.text + char;
+      s.at = now;
+
+      const query = s.text.toLowerCase();
+      const cycling = query.length > 1 && /^(.)\1+$/.test(query);
+      const needle = cycling ? query[0] : query;
+      const from =
+        cycling || query.length === 1 ? (current ?? -1) + 1 : (current ?? 0);
+
+      const n = items.length;
+      for (let k = 0; k < n; k++) {
+        const i = (((from + k) % n) + n) % n;
+        const item = items[i];
+        if (selectable && !selectable(item)) continue;
+        const label = String(labelOf(item) ?? '').toLowerCase();
+        if (label.startsWith(needle)) return i;
+      }
+      return -1;
+    },
+    [timeout],
+  );
+}
+
+/** A printable character usable for type-ahead. Space is excluded: it
+ *  activates the focused entry everywhere in this widget set. */
+function typeAheadChar(ev) {
+  return ev.key && ev.key.length === 1 && ev.codepoint > 32 ? ev.key : null;
+}
+
 /** Measured size of a single-line label, for sizing a popup around it.
  *  Falls back to a rough estimate where no font stack is available. */
 function measureLabel(node, text, style) {
@@ -957,7 +1010,10 @@ function MenuLevel({
  * Returns true when the key was consumed. Left and Right fall through when
  * there is no submenu to enter or leave, so `MenuBar` can walk the bar.
  */
-function handleMenuKey(ev, { rootItems, path, setPath, select, close }) {
+function handleMenuKey(
+  ev,
+  { rootItems, path, setPath, select, close, typeAhead },
+) {
   const depth = path.length - 1;
   if (depth < 0) return false;
   const items = levelItems(rootItems, path, depth);
@@ -1004,6 +1060,13 @@ function handleMenuKey(ev, { rootItems, path, setPath, select, close }) {
     if (isSelectable(item)) select(item);
     return true;
   }
+
+  const char = typeAheadChar(ev);
+  if (char && typeAhead) {
+    const i = typeAhead(char, items, active, (it) => it.label, isSelectable);
+    if (i >= 0) setActive(i);
+    return true;
+  }
   return false;
 }
 
@@ -1025,6 +1088,7 @@ export function ContextMenu({
   const ref = useRef(null);
   const [rect, setRect] = useState(null);
   const [path, setPath] = useState([]);
+  const typeAhead = useTypeAhead();
 
   const close = () => {
     setRect(null);
@@ -1073,6 +1137,7 @@ export function ContextMenu({
           setPath,
           select,
           close,
+          typeAhead,
         });
       },
       onBlur: close,
@@ -1109,6 +1174,7 @@ export function MenuBar({
   const [rect, setRect] = useState(null);
   const [path, setPath] = useState([]);
   const refs = useRef([]);
+  const typeAhead = useTypeAhead();
 
   const items = openIndex >= 0 ? (menus[openIndex]?.items ?? []) : [];
 
@@ -1193,6 +1259,7 @@ export function MenuBar({
               setPath,
               select,
               close,
+              typeAhead,
             });
             if (consumed) return;
             if (ev.keysym === XK_LEFT) moveMenu(-1);
@@ -1288,6 +1355,7 @@ export function Select({
   const activeRef = useRef(null);
 
   const measureAnchor = useAnchor(triggerRef);
+  const typeAhead = useTypeAhead();
 
   const normalized = options.map(normalizeOption);
   const current = normalized.find((o) => o.value === value);
@@ -1345,7 +1413,20 @@ export function Select({
       const option = open ? normalized[activeIndex] : null;
       if (option) pick(option);
       else toggle();
+      return;
     }
+
+    // type-ahead: with the menu open it moves the highlight; closed, it
+    // changes the value outright, the way a native select does
+    const char = typeAheadChar(ev);
+    if (!char) return;
+    const current = open
+      ? activeIndex
+      : normalized.findIndex((o) => o.value === value);
+    const i = typeAhead(char, normalized, current, (o) => o.label);
+    if (i < 0) return;
+    if (open) setActiveIndex(i);
+    else if (normalized[i].value !== value) onChange?.(normalized[i].value);
   };
 
   // keep the highlighted option visible while arrowing through a menu that

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -2411,3 +2411,146 @@ test('submenu: hovering a parent row opens it with nothing selected inside', asy
 
   ReactX11.unmountComponentAtNode(app);
 });
+
+const typeChar = (app, wnd, ch) =>
+  pressKey(app, wnd, { keysym: ch.charCodeAt(0), codepoint: ch.charCodeAt(0) });
+
+test('Select: type-ahead jumps, refines and cycles', async () => {
+  const { Select } = await import('../src/index.js');
+  const app = createMockApp();
+  const options = ['apple', 'banana', 'blueberry', 'cherry'];
+  let current = null;
+  const Host = () => {
+    const [v, setV] = React.useState(null);
+    current = v;
+    return React.createElement(
+      'window',
+      { width: 300, height: 120 },
+      React.createElement(
+        'box',
+        { flexGrow: 1, padding: 10 },
+        React.createElement(Select, {
+          options,
+          value: v,
+          width: 200,
+          onChange: setV,
+        }),
+      ),
+    );
+  };
+  ReactX11.render(React.createElement(Host), null, app);
+  await tick();
+  const wnd = app.windows[0];
+  const findFocusable = (n) =>
+    n.props?.focusable
+      ? n
+      : n.children.reduce(
+          (a, c) => a || (c.isWindow ? null : findFocusable(c)),
+          null,
+        );
+  const trigger = findFocusable(wnd._reactX11Node);
+  const cx = trigger.abs.x + 10;
+  const cy = trigger.abs.y + trigger.abs.height / 2;
+
+  // closed: type-ahead changes the value outright, like a native select
+  wnd.emit('mousedown', { x: cx, y: cy, keycode: 1 });
+  wnd.emit('mouseup', { x: cx, y: cy, keycode: 1 });
+  await tick();
+  pressKey(app, wnd, { keysym: 0xff1b }); // close again, keep focus
+  await tick();
+
+  typeChar(app, wnd, 'c');
+  await tick();
+  assert.strictEqual(current, 'cherry', 'closed type-ahead selects');
+
+  // open it and use type-ahead on the highlight
+  await new Promise((r) => setTimeout(r, 800)); // let the query expire
+  wnd.emit('mousedown', { x: cx, y: cy, keycode: 1 });
+  wnd.emit('mouseup', { x: cx, y: cy, keycode: 1 });
+  await tick();
+
+  const activeIndex = () => {
+    const popup = app.windows.at(-1);
+    let scroller = null;
+    const walk = (n) => {
+      if (n.kind === 'scrollview') scroller = n;
+      else n.children.forEach(walk);
+    };
+    walk(popup._reactX11Node);
+    return scroller.children.findIndex(
+      (o) => o.props.backgroundColor === '#2980b9',
+    );
+  };
+
+  typeChar(app, wnd, 'b');
+  await tick();
+  assert.strictEqual(activeIndex(), 1, 'b -> banana');
+
+  // a growing query searches from the current entry
+  typeChar(app, wnd, 'l');
+  await tick();
+  assert.strictEqual(activeIndex(), 2, 'bl -> blueberry');
+
+  // repeating one letter cycles rather than sticking
+  await new Promise((r) => setTimeout(r, 800));
+  typeChar(app, wnd, 'b');
+  await tick();
+  assert.strictEqual(activeIndex(), 1, 'b -> banana again');
+  typeChar(app, wnd, 'b');
+  await tick();
+  assert.strictEqual(activeIndex(), 2, 'bb cycles to blueberry');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('menu type-ahead moves the active row and skips disabled entries', async () => {
+  const app = createMockApp();
+  const picked = [];
+  const wnd = await openNested(app, picked); // New / Export / Quit
+
+  typeChar(app, wnd, 'q');
+  await tick();
+  assert.strictEqual(activeIn(app, 1), 2, 'q -> Quit');
+
+  typeChar(app, wnd, 'e');
+  await tick();
+  // 'qe' matches nothing, so the active row stays put
+  assert.strictEqual(activeIn(app, 1), 2, 'no match leaves the selection');
+
+  await new Promise((r) => setTimeout(r, 800));
+  typeChar(app, wnd, 'e');
+  await tick();
+  assert.strictEqual(activeIn(app, 1), 1, 'e -> Export');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('menu type-ahead applies to the deepest open submenu', async () => {
+  const app = createMockApp();
+  const picked = [];
+  const wnd = await openNested(app, picked);
+
+  // into Export's submenu: PNG / --- / SVG / PDF(disabled)
+  pressKey(app, wnd, { keysym: 0xff54 });
+  await tick();
+  pressKey(app, wnd, { keysym: 0xff54 });
+  await tick();
+  pressKey(app, wnd, { keysym: 0xff53 });
+  await tick();
+  await tick();
+  assert.strictEqual(app.windows.length, 3, 'submenu open');
+  assert.strictEqual(activeIn(app, 2), 0, 'PNG active');
+
+  typeChar(app, wnd, 's');
+  await tick();
+  assert.strictEqual(activeIn(app, 2), 2, 's -> SVG, inside the submenu');
+  assert.strictEqual(activeIn(app, 1), 1, 'parent row unchanged');
+
+  // the disabled PDF is never matched
+  await new Promise((r) => setTimeout(r, 800));
+  typeChar(app, wnd, 'p');
+  await tick();
+  assert.strictEqual(activeIn(app, 2), 0, 'p -> PNG, never the disabled PDF');
+
+  ReactX11.unmountComponentAtNode(app);
+});


### PR DESCRIPTION
Typing letters jumps to the entry whose label starts with them — the last of the listed keyboard gaps.

Keystrokes within 700ms accumulate into one query, so `b`,`l` finds *blueberry* rather than jumping to *banana* first. Two behaviours the platform conventions call for that a naive prefix search gets wrong:

- **a growing query searches from the current entry**, so refining a prefix keeps you on it while it still matches;
- **repeating one letter cycles** through the entries starting with it, instead of sticking on the first match.

`Select`: moves the highlight while the menu is open, and changes the value outright while closed — the way a native select does.

Menus: applies to the **deepest open submenu**, and never matches separators or disabled entries.

Space is deliberately excluded — it activates the focused entry everywhere in this widget set.

## Tests

65/65, lint clean. Three new, covering the parts that are easy to get wrong rather than just "it jumps":

- `b` → banana, then `l` within the window → blueberry (refinement searches from the current entry), then after the query expires `b`,`b` cycles banana → blueberry
- a query matching nothing leaves the selection alone
- type-ahead inside a submenu moves the submenu's row and leaves the parent's alone, and never lands on the disabled entry

The Select test takes ~1.6s because it genuinely waits out the 700ms query window twice — that's the behaviour under test, not padding.

## Note

`src/components.js` is now 1500+ lines across 13 components. Splitting it into `src/components/` is queued as the next change, as a **move-only** PR so it stays reviewable — which is why it isn't bundled here.