### PR TITLE
feat: textarea/textinput polish — word movement, PageUp/Down, shift+click, scrollbar

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -15,8 +15,8 @@
 >
 > **Plan (next session):**
 >
-> 1. `<textarea>` polish: Ctrl+arrow word movement, PageUp/Down,
->    Shift+click extend, drawn scrollbar.
+> 1. Upstream (ntk): make glyph drawing honour the 2d clip mask — text
+>    currently paints outside clipped boxes (see §3).
 > 2. `Select`/menu follow-up: PageUp/PageDown in the open menu.
 > 3. Then merge release-please #17 and publish 1.0.0 (the owner wants the
 >    planned widget work in first).
@@ -77,6 +77,14 @@ merged theme (`ThemeProvider`; `SelectThemeProvider` is an alias) and a
 - **Bidi caret polish** — caret positions are bidi-correct now (ntk
   caret API), but arrow keys still move logically; visual-order movement
   - split caret at direction boundaries is a later refinement
+- **Text ignores the 2d clip (ntk bug)** — `TextLayout.draw` composites
+  glyphs straight onto `ctx.picture` via `drawGlyphRuns`, while fill/stroke
+  intersect their coverage with `ctx.clipMask` first. So shapes clip and
+  text does not: scrolled-away `<textarea>` lines, a horizontally scrolled
+  `<textinput>`, and `<text>` inside a `<scrollview>` all paint outside
+  their box. Masked wherever the clip coincides with an X window edge
+  (popups), which is why menus look fine. Fix belongs in ntk — glyph
+  compositing should honour the clip mask.
 - **`opacity`** — needs offscreen composition (pixmap + Composite);
   ntk can do it, renderer needs a group-opacity paint path
 - **Dirty-rect painting** — still full-window repaint per frame

--- a/src/events.js
+++ b/src/events.js
@@ -76,6 +76,10 @@ export class EventManager {
       target: this._public(target),
       currentTarget: null,
       nativeEvent: native,
+      // X11 modifier mask: bit 0 Shift, bit 2 Control. Carried on every
+      // event, not just keys — shift+click needs it too.
+      shiftKey: Boolean(native?.buttons & 1),
+      ctrlKey: Boolean(native?.buttons & 4),
       defaultPrevented: false,
       propagationStopped: false,
       preventDefault() {

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -739,6 +739,8 @@ const XK_LEFT = 0xff51;
 const XK_UP = 0xff52;
 const XK_RIGHT = 0xff53;
 const XK_DOWN = 0xff54;
+const XK_PAGE_UP = 0xff55;
+const XK_PAGE_DOWN = 0xff56;
 const XK_END = 0xff57;
 const XK_DELETE = 0xffff;
 
@@ -921,23 +923,35 @@ export class TextInputNode extends Node {
     }
     if (k === XK_BACKSPACE) {
       if (hasSelection) this._deleteRange(a, b);
+      else if (ev.ctrlKey) this._deleteRange(this._wordBoundary(a, -1), a);
       else if (a > 0) this._deleteRange(a - 1, a);
       return;
     }
     if (k === XK_DELETE) {
       if (hasSelection) this._deleteRange(a, b);
+      else if (ev.ctrlKey) this._deleteRange(a, this._wordBoundary(a, 1));
       else this._deleteRange(a, Math.min(a + 1, this._chars().length));
       return;
     }
     if (k === XK_LEFT) {
-      if (!ev.shiftKey && hasSelection) this._moveCaret(a, false);
-      else this._moveCaret(this._caret - 1, ev.shiftKey);
+      if (ev.ctrlKey) {
+        this._moveCaret(this._wordBoundary(this._caret, -1), ev.shiftKey);
+      } else if (!ev.shiftKey && hasSelection) {
+        this._moveCaret(a, false);
+      } else {
+        this._moveCaret(this._caret - 1, ev.shiftKey);
+      }
       if (ev.shiftKey) this._copySelection('PRIMARY');
       return;
     }
     if (k === XK_RIGHT) {
-      if (!ev.shiftKey && hasSelection) this._moveCaret(b, false);
-      else this._moveCaret(this._caret + 1, ev.shiftKey);
+      if (ev.ctrlKey) {
+        this._moveCaret(this._wordBoundary(this._caret, 1), ev.shiftKey);
+      } else if (!ev.shiftKey && hasSelection) {
+        this._moveCaret(b, false);
+      } else {
+        this._moveCaret(this._caret + 1, ev.shiftKey);
+      }
       if (ev.shiftKey) this._copySelection('PRIMARY');
       return;
     }
@@ -996,6 +1010,26 @@ export class TextInputNode extends Node {
     return [a, b];
   }
 
+  /**
+   * Caret index one word away, the way Ctrl+arrow moves in a text editor:
+   * skip any run of non-word characters, then the word itself. Word
+   * characters are letters, digits and underscore, so "foo-bar" is two
+   * words and "foo_bar" is one.
+   */
+  _wordBoundary(from, dir) {
+    const chars = this._chars();
+    const isWord = (c) => /[\p{L}\p{N}_]/u.test(c);
+    let i = Math.max(0, Math.min(from, chars.length));
+    if (dir > 0) {
+      while (i < chars.length && !isWord(chars[i])) i++;
+      while (i < chars.length && isWord(chars[i])) i++;
+    } else {
+      while (i > 0 && !isWord(chars[i - 1])) i--;
+      while (i > 0 && isWord(chars[i - 1])) i--;
+    }
+    return i;
+  }
+
   _defaultMouseDown(ev) {
     if (ev.button === 2) {
       // X11 middle-click: paste the PRIMARY selection at the click position
@@ -1016,6 +1050,14 @@ export class TextInputNode extends Node {
       const [a, b] = this._wordRangeAt(i);
       this._anchor = a;
       this._caret = b;
+      this._ownSelection();
+      return;
+    }
+    // shift+click extends from the existing anchor rather than starting a
+    // fresh selection, and keeps dragging from there
+    if (ev.shiftKey) {
+      this._caret = i;
+      this._dragging = true;
       this._ownSelection();
       return;
     }
@@ -1230,6 +1272,13 @@ export class TextAreaNode extends TextInputNode {
     this.root?.invalidate(false);
   }
 
+  /** Visual lines that fit in the viewport — one Page keypress worth. */
+  _pageLines() {
+    const height = this.contentBox().height;
+    const line = this._lineHeight() || 1;
+    return Math.max(1, Math.floor(height / line));
+  }
+
   /** Caret index on an adjacent visual line, keeping the goal column. */
   _verticalMove(layout, delta) {
     const pos = layout.caretPosition(this._caret);
@@ -1267,6 +1316,19 @@ export class TextAreaNode extends TextInputNode {
       if (ev.shiftKey) this._copySelection('PRIMARY');
       return;
     }
+    if (
+      (k === XK_PAGE_UP || k === XK_PAGE_DOWN) &&
+      layout &&
+      this.value.length > 0
+    ) {
+      const i = this._verticalMove(
+        layout,
+        this._pageLines() * (k === XK_PAGE_UP ? -1 : 1),
+      );
+      this._moveCaret(i, ev.shiftKey);
+      if (ev.shiftKey) this._copySelection('PRIMARY');
+      return;
+    }
     if ((k === XK_HOME || k === XK_END) && layout && this.value.length > 0) {
       const pos = layout.caretPosition(this._caret);
       const line = layout.lines[pos.line];
@@ -1283,6 +1345,29 @@ export class TextAreaNode extends TextInputNode {
     }
     this._goalX = null;
     super._defaultKeyDown(ev);
+  }
+
+  /** Thumb for the vertical overflow, same look as <scrollview>'s. */
+  _paintScrollbar(ctx, layout) {
+    if (this.props.scrollbar === false) return;
+    const content = this.contentBox();
+    const viewport = content.height;
+    const total = layout.height;
+    if (!(total > viewport)) return;
+    const trackWidth = 6;
+    const thumbHeight = Math.max(20, (viewport * viewport) / total);
+    const range = total - viewport;
+    const thumbY =
+      content.y + (this._scrollY / range) * (viewport - thumbHeight);
+    const thumbX = content.x + content.width - trackWidth;
+    ctx.fillStyle = this.props.scrollbarColor || 'rgba(0, 0, 0, 0.25)';
+    ctx.beginPath();
+    if (typeof ctx.roundRect === 'function') {
+      ctx.roundRect(thumbX, thumbY, trackWidth, thumbHeight, 3);
+    } else {
+      ctx.rect(thumbX, thumbY, trackWidth, thumbHeight);
+    }
+    ctx.fill();
   }
 
   _paintContent(ctx) {
@@ -1339,6 +1424,8 @@ export class TextAreaNode extends TextInputNode {
       ctx.fillStyle = this.props.caretColor ?? this._textStyle().color;
       ctx.fillRect(originX + pos.x, originY + pos.y, 1.5, pos.height);
     }
+    // inside the clip, so the thumb is bounded by the content box
+    this._paintScrollbar(ctx, layout);
     ctx.restore();
   }
 }

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -2554,3 +2554,211 @@ test('menu type-ahead applies to the deepest open submenu', async () => {
 
   ReactX11.unmountComponentAtNode(app);
 });
+
+test('textinput: Ctrl+arrow moves by word, Ctrl+Backspace/Delete removes one', async () => {
+  const app = createMockApp();
+  const changes = [];
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 300, height: 80 },
+      React.createElement('textinput', {
+        defaultValue: 'foo-bar baz_qux end',
+        onChange: (v) => changes.push(v),
+      }),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const input = wnd._reactX11Node.children[0];
+  wnd.emit('mousedown', { x: 5, y: 5, keycode: 1 });
+  wnd.emit('mouseup', { x: 5, y: 5, keycode: 1 });
+  await tick();
+
+  const caret = () => input._selection()[0];
+  const ctrl = (keysym) => pressKey(app, wnd, { keysym, buttons: 4 });
+
+  // 'foo-bar baz_qux end' — '-' is not a word char, '_' is
+  input._caret = 0;
+  input._anchor = 0;
+  ctrl(0xff53); // Ctrl+Right
+  assert.strictEqual(caret(), 3, 'end of "foo"');
+  ctrl(0xff53);
+  assert.strictEqual(caret(), 7, 'end of "bar" (hyphen is a separator)');
+  ctrl(0xff53);
+  assert.strictEqual(caret(), 15, 'end of "baz_qux" (underscore joins)');
+
+  ctrl(0xff51); // Ctrl+Left
+  assert.strictEqual(caret(), 8, 'start of "baz_qux"');
+
+  // Ctrl+Backspace removes the word before the caret
+  ctrl(0xff08);
+  await tick();
+  assert.strictEqual(changes.at(-1), 'foo-bar baz_qux end'.replace('bar ', ''));
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('textinput: shift+click extends the selection from the anchor', async () => {
+  const app = createMockApp();
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 300, height: 80 },
+      React.createElement('textinput', { defaultValue: 'hello world' }),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const input = wnd._reactX11Node.children[0];
+
+  // click to place the caret, then shift+click elsewhere
+  wnd.emit('mousedown', { x: 5, y: 5, keycode: 1 });
+  wnd.emit('mouseup', { x: 5, y: 5, keycode: 1 });
+  await tick();
+  input._caret = 2;
+  input._anchor = 2;
+
+  // stub the hit index so the test does not depend on font metrics
+  const realIndexAt = input._indexAtPoint;
+  input._indexAtPoint = () => 8;
+  wnd.emit('mousedown', { x: 60, y: 5, keycode: 1, buttons: 1 });
+  wnd.emit('mouseup', { x: 60, y: 5, keycode: 1, buttons: 1 });
+  input._indexAtPoint = realIndexAt;
+
+  assert.deepStrictEqual(
+    input._selection(),
+    [2, 8],
+    'anchor kept, caret moved to the shift+clicked index',
+  );
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('textarea: PageDown/PageUp move by a viewport of lines', async () => {
+  const app = createMockApp();
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 300, height: 200 },
+      React.createElement('textarea', {
+        defaultValue: Array.from({ length: 40 }, (_, i) => `line ${i}`).join(
+          '\n',
+        ),
+        rows: 4,
+      }),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const area = wnd._reactX11Node.children[0];
+  // keys route to the focused node, so focus it the way a user would
+  wnd.emit('mousedown', { x: 5, y: 5, keycode: 1 });
+  wnd.emit('mouseup', { x: 5, y: 5, keycode: 1 });
+  await tick();
+
+  // the mock app has no font stack, so drive the layout the node uses
+  const LINES = 40;
+  const lineH = 10;
+  const fakeLayout = {
+    height: LINES * lineH,
+    lines: Array.from({ length: LINES }, (_, i) => ({
+      x: 0,
+      y: i * lineH,
+      width: 50,
+      ascent: 8,
+      descent: 2,
+    })),
+    caretPosition: (i) => ({
+      x: 0,
+      y: Math.floor(i / 8) * lineH,
+      height: lineH,
+      line: Math.floor(i / 8),
+    }),
+    // y is mid-line, so floor maps it to the line containing it
+    indexAt: (x, y) => Math.floor(y / lineH) * 8,
+    draw: () => {},
+  };
+  area._valueLayout = () => fakeLayout;
+  area._lineHeight = () => lineH;
+  area._focused = true;
+  area._caret = 0;
+  area._anchor = 0;
+
+  const pageLines = area._pageLines();
+  assert.ok(pageLines > 1, `viewport holds ${pageLines} lines`);
+
+  pressKey(app, wnd, { keysym: 0xff56 }); // Page Down
+  assert.strictEqual(
+    area._selection()[0],
+    pageLines * 8,
+    'caret moved down one viewport of lines',
+  );
+
+  pressKey(app, wnd, { keysym: 0xff55 }); // Page Up
+  assert.strictEqual(area._selection()[0], 0, 'and back up again');
+
+  // past the top clamps to the start rather than going negative
+  pressKey(app, wnd, { keysym: 0xff55 });
+  assert.strictEqual(area._selection()[0], 0);
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('textarea: draws a scrollbar thumb only when the text overflows', async () => {
+  const app = createMockApp();
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 300, height: 200 },
+      React.createElement('textarea', { defaultValue: 'x', rows: 3 }),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const area = wnd._reactX11Node.children[0];
+  const content = area.contentBox();
+
+  const paintWith = (layoutHeight) => {
+    area._valueLayout = () => ({
+      height: layoutHeight,
+      lines: [{ x: 0, y: 0, width: 10, ascent: 8, descent: 2 }],
+      caretPosition: () => ({ x: 0, y: 0, height: 10, line: 0 }),
+      indexAt: () => 0,
+      draw: () => {},
+    });
+    wnd.ctx.ops.length = 0;
+    area.paint(wnd.ctx);
+    return wnd.ctx.ops;
+  };
+
+  // the clip path is a 'rect' too, so identify the thumb by its 6px track
+  const findThumb = (ops) =>
+    ops.find(([op, , , w]) => (op === 'roundRect' || op === 'rect') && w === 6);
+
+  // fits: no thumb
+  let ops = paintWith(content.height - 5);
+  assert.ok(!findThumb(ops), 'no scrollbar when the content fits');
+
+  // overflows: a thumb is drawn inside the content box
+  ops = paintWith(content.height * 4);
+  const thumb = findThumb(ops);
+  assert.ok(thumb, 'thumb drawn when the content overflows');
+  const [, tx, ty, tw, th] = thumb;
+  assert.ok(tw > 0 && th >= 20, 'thumb has a usable size');
+  assert.ok(
+    tx + tw <= content.x + content.width + 0.01,
+    'thumb sits inside the content box',
+  );
+  assert.ok(ty >= content.y - 0.01, 'thumb starts at or below the top');
+
+  ReactX11.unmountComponentAtNode(app);
+});


### PR DESCRIPTION
The four items NEXT_STEPS listed for `<textarea>`.

- **Ctrl+Left/Right move by word**, and Ctrl+Backspace/Delete remove one. Word characters are letters, digits and underscore — so `foo-bar` is two words and `foo_bar` is one. (Both inputs, not just textarea.)
- **PageUp/PageDown** move a viewport of visual lines, reusing the goal-column vertical move so the column is preserved.
- **Shift+click extends** the selection from the existing anchor rather than starting a fresh one, and keeps dragging from there.
- **A drawn scrollbar** when the text overflows, matching `<scrollview>`'s (6px track, 20px minimum thumb, `scrollbar={false}` and `scrollbarColor` honoured).

## A gap this exposed

**Mouse events carried no modifier flags at all** — only the keyboard path built `shiftKey`/`ctrlKey`. Shift+click could not have worked, and neither could ctrl+click for any userland handler. Both are now set on every synthetic event from the X11 modifier mask (bit 0 Shift, bit 2 Control).

## Screenshot

Real XQuartz. Thumb at the right, and `Shift+click extends` selected by three Ctrl+Shift+Right presses:

![textarea](https://github.com/user-attachments/assets/67b3f4e5-daf3-4dd3-b3bf-1edc2050ca30)

## A pre-existing bug this screenshot revealed — not fixed here

Look above the textarea in that image: the scrolled-away lines are painting **outside** the widget, over the label. That is not caused by this PR (scrolling landed in #32); it is an **ntk** bug I traced while checking my own work:

- fill and stroke paths intersect their coverage with `ctx.clipMask` before compositing → **shapes respect the clip**
- `TextLayout.draw` calls `drawGlyphRuns(app, op, src.id, ctx.picture.id, …)`, compositing glyphs straight onto the picture and never touching `clipMask` → **text ignores the clip**

So anything clipped that contains text bleeds: scrolled `<textarea>` lines, a horizontally scrolled `<textinput>`, `<text>` inside a `<scrollview>`, and `overflow: hidden` boxes. It's invisible wherever the clip happens to coincide with an X window edge — which is why the `Select` and menu popups have always looked correct.

The fix belongs in ntk (glyph compositing should honour the clip mask), so it is filed in NEXT_STEPS §3 and queued as the next task rather than worked around here. My scrollbar is a `fillRect`, so it clips correctly.

## Tests

69/69, lint clean. Four new: word movement across `-` and `_` boundaries plus Ctrl+Backspace, shift+click keeping the anchor, PageUp/PageDown moving a viewport of lines and clamping at the top, and the thumb appearing only on overflow and sitting inside the content box.
