### PR TITLE
chore: protocol-traffic benchmark, baseline, and efficiency rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,51 @@ Two things the script has to get right:
   reparented the client is no longer a child of root and the request
   answers `BadWindow` (opcode 130).
 
+## Protocol efficiency
+
+X11 is a network protocol even on a local socket. The three libraries have
+distinct jobs, and this one is the layer that decides _how often_ anything
+is drawn, so cost is a design concern here rather than an afterthought:
+
+- **node-x11** — the protocol and minimal ergonomics. No policy, no
+  drawing strategy.
+- **ntk** — ergonomics and higher-level primitives over it; owns how
+  drawing is _encoded_.
+- **react-x11** — React primitives and ecosystem over ntk; owns how often
+  drawing _happens_.
+
+Rules, in rough order of how much they usually matter:
+
+1. **Use server-side primitives instead of client-side pixel work.**
+   XRender composites, glyph caches, `CopyArea`, server-side clip
+   rectangles. Reach for readback or per-pixel manipulation last.
+2. **Batch into as few requests as possible.** A shaped paragraph is one
+   glyph run batch, not one request per word or per character. Prefer one
+   request covering N items over N requests.
+3. **Bound work to the damaged area.** An operation over the whole surface
+   costs the same on the wire as one over a 20x20 rect and vastly more in
+   the server. This is the failure mode request counts do not show.
+4. **Avoid round trips.** A request that waits for a reply stalls the
+   pipeline; cache what the server already told us (atoms, geometry,
+   glyph pages) rather than asking again.
+5. **Prefer server-side text rendering.** Shape once, upload glyphs once,
+   draw whole runs.
+
+### Measuring it
+
+`npm run bench` runs scenarios against the in-process X server and reports
+requests, bytes, replies, Render composites and **the pixel area those
+composites touch**. That last metric exists because the others hide the
+most common regression: a change can add almost nothing to the wire while
+multiplying the server's work many times over.
+
+- `npm run bench -- --save` rewrites `scripts/bench/baseline.json`
+- `npm run bench -- --check` fails if a metric regressed past tolerance
+
+Re-run it when touching painting, layout flushing, or anything in ntk's
+drawing path, and update the baseline in the same PR that changes it, so
+the diff records the cost.
+
 ## Gotchas
 
 - The package is **ESM** (`"type": "module"`). ntk is ESM with top-level

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -15,8 +15,15 @@
 >
 > **Plan (next session):**
 >
-> 1. Upstream (ntk): make glyph drawing honour the 2d clip mask — text
->    currently paints outside clipped boxes (see §3).
+> 1. Upstream (ntk): make the clipped glyph path cheap. `npm run bench`
+>    shows a clipped paragraph costs 25 composites / 4.0 Mpx against 1 /
+>    0.16 Mpx unclipped — the mask path runs per line over the whole
+>    surface. Two fixes: use `SetPictureClipRectangles` on the destination
+>    when the clip stack is all axis-aligned rects (the common case:
+>    contentBox, scrollview, overflow hidden), and bound the fallback mask
+>    to the glyph bbox. Also batch `TextLayout.draw` per paragraph rather
+>    than per line. Same full-surface problem affects every fill
+>    (`_fillPolys`): 50 small boxes cost 8.16 Mpx.
 > 2. `Select`/menu follow-up: PageUp/PageDown in the open menu.
 > 3. Then merge release-please #17 and publish 1.0.0 (the owner wants the
 >    planned widget work in first).
@@ -77,14 +84,14 @@ merged theme (`ThemeProvider`; `SelectThemeProvider` is an alias) and a
 - **Bidi caret polish** — caret positions are bidi-correct now (ntk
   caret API), but arrow keys still move logically; visual-order movement
   - split caret at direction boundaries is a later refinement
-- **Text ignores the 2d clip (ntk bug)** — `TextLayout.draw` composites
-  glyphs straight onto `ctx.picture` via `drawGlyphRuns`, while fill/stroke
-  intersect their coverage with `ctx.clipMask` first. So shapes clip and
-  text does not: scrolled-away `<textarea>` lines, a horizontally scrolled
-  `<textinput>`, and `<text>` inside a `<scrollview>` all paint outside
-  their box. Masked wherever the clip coincides with an X window edge
-  (popups), which is why menus look fine. Fix belongs in ntk — glyph
-  compositing should honour the clip mask.
+- **Full-surface mask composites (ntk)** — clipping is correct since ntk
+  3.5.1, but the mask path (`_fillPolys`, `drawGlyphs`) clears and
+  composites the _entire_ surface per operation. Measured by
+  `npm run bench`: a clipped 12-line paragraph does 25 composites over
+  4.0 Mpx where the ink covers 0.08 Mpx, and 50 small filled boxes do
+  8.16 Mpx. Bound these to the damaged rect, and prefer
+  `SetPictureClipRectangles` for rectangular clips so glyphs clip
+  server-side with no mask at all.
 - **`opacity`** — needs offscreen composition (pixmap + Composite);
   ntk can do it, renderer needs a group-opacity paint path
 - **Dirty-rect painting** — still full-window repaint per frame

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^3.5.0",
+        "ntk": "^3.5.1",
         "react-reconciler": "^0.33.0"
       },
       "devDependencies": {
@@ -4071,9 +4071,9 @@
       }
     },
     "node_modules/ntk": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-3.5.0.tgz",
-      "integrity": "sha512-ySIrWXW//0RwkjxWyPTwu5uZapapF1XvwoDB3wA7VwaRJM+nNKl8SKG/dyd1TSjKtgisQSSDIV5yagQpSnvJNA==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-3.5.1.tgz",
+      "integrity": "sha512-lzihMzMIALUMWazYS0xYyGviQDvEjS/hC559Rr73aWUZkMjZc7DeHxA6CGiY5reCdDhiT20SrOoagWJxGi1DgQ==",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "examples:widgets": "tsx examples/widgets.jsx",
     "examples:windows": "tsx examples/windows.jsx",
     "screenshots": "tsx scripts/screenshots.jsx",
-    "screenshots:framed": "tsx scripts/screenshots-framed.jsx"
+    "screenshots:framed": "tsx scripts/screenshots-framed.jsx",
+    "bench": "tsx scripts/bench/protocol.js"
   },
   "repository": {
     "type": "git",
@@ -41,7 +42,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^3.5.0",
+    "ntk": "^3.5.1",
     "react-reconciler": "^0.33.0"
   },
   "peerDependencies": {

--- a/scripts/bench/baseline.json
+++ b/scripts/bench/baseline.json
@@ -1,0 +1,34 @@
+{
+  "text: paragraph, no clip": {
+    "requests": 43,
+    "bytesOut": 6192,
+    "bytesIn": 32,
+    "replies": 1,
+    "composites": 1,
+    "compositePixels": 160000
+  },
+  "text: paragraph, inside a rect clip": {
+    "requests": 91,
+    "bytesOut": 7576,
+    "bytesIn": 32,
+    "replies": 1,
+    "composites": 25,
+    "compositePixels": 4000000
+  },
+  "shapes: 50 filled rounded boxes": {
+    "requests": 175,
+    "bytesOut": 15056,
+    "bytesIn": 32,
+    "replies": 1,
+    "composites": 51,
+    "compositePixels": 8160000
+  },
+  "mount: window with 40 boxes and labels": {
+    "requests": 125,
+    "bytesOut": 5464,
+    "bytesIn": 160,
+    "replies": 3,
+    "composites": 41,
+    "compositePixels": 436480
+  }
+}

--- a/scripts/bench/protocol.js
+++ b/scripts/bench/protocol.js
@@ -1,0 +1,250 @@
+// Protocol-traffic benchmark: how much X11 work does each scenario cost?
+//
+//   npm run bench            # print the current numbers
+//   npm run bench -- --save  # rewrite the committed baseline
+//   npm run bench -- --check # fail if a metric regressed past its tolerance
+//
+// Runs against node-x11's in-process pure-JS X server, so the numbers are
+// deterministic and need no $DISPLAY.
+//
+// Metrics, and why each is here:
+//
+//   requests / bytesOut  round trips and wire cost of talking to the server
+//   replies              requests that forced the client to wait
+//   composites / pixels  Render Composite calls and the area they touch —
+//                        request counts hide this completely (a Composite
+//                        request is 36 bytes whether it touches ten pixels
+//                        or the whole surface), and it is where "correct
+//                        but does far too much pixel work" shows up
+import { readFileSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import React from 'react';
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient, StaticFontSource } from 'ntk';
+
+import { compositePixels, countStream } from './xcount.js';
+
+process.env.REACT_X11_NO_AUTORUN = '1';
+const ReactX11 = (await import('../../src/index.js')).default;
+
+const require = createRequire(import.meta.url);
+const fontDir = join(
+  dirname(require.resolve('katex/package.json')),
+  'dist',
+  'fonts',
+);
+const baselinePath = join(
+  dirname(new URL(import.meta.url).pathname),
+  'baseline.json',
+);
+
+const W = 400;
+const H = 400;
+
+async function connect() {
+  const server = xserver.createServer({ width: W, height: H });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const { stats } = countStream(clientEnd);
+  const source = new StaticFontSource();
+  source.add(readFileSync(join(fontDir, 'KaTeX_Main-Regular.ttf')), {
+    family: 'Bench',
+  });
+  source.alias('sans-serif', 'Bench');
+  const app = await createClient({ stream: clientEnd, fontSource: source });
+  return { app, stats };
+}
+
+const settle = (app) =>
+  new Promise((resolve) => app.X.GetInputFocus(() => resolve()));
+
+/** Run `fn`, measuring only what it causes (setup is drained first). */
+async function measure(name, fn) {
+  const { app, stats } = await connect();
+  await settle(app);
+  const mark = {
+    requests: stats.requests,
+    bytesOut: stats.bytesOut,
+    bytesIn: stats.bytesIn,
+    replies: stats.replies,
+    composites: stats.composites.length,
+  };
+  await fn(app);
+  await settle(app);
+
+  const after = compositePixels(stats, app.display.Render.majorOpcode);
+  const beforePx = compositePixels(
+    { composites: stats.composites.slice(0, mark.composites) },
+    app.display.Render.majorOpcode,
+  );
+  const result = {
+    requests: stats.requests - mark.requests,
+    bytesOut: stats.bytesOut - mark.bytesOut,
+    bytesIn: stats.bytesIn - mark.bytesIn,
+    replies: stats.replies - mark.replies,
+    composites: after.composites - beforePx.composites,
+    compositePixels: after.pixels - beforePx.pixels,
+  };
+  await app.close();
+  return [name, result];
+}
+
+// --- scenarios ---------------------------------------------------------
+
+function pixmapCtx(app) {
+  const pixmap = app.createPixmap({ width: W, height: H, depth: 24 });
+  const ctx = pixmap.getContext('2d');
+  ctx.fillStyle = 'white';
+  ctx.fillRect(0, 0, W, H);
+  return ctx;
+}
+
+const PARAGRAPH = Array.from(
+  { length: 12 },
+  (_, i) => `Line ${i}: the quick brown fox jumps over the lazy dog`,
+).join('\n');
+
+function paragraphLayout(app) {
+  return app.fonts.layout(
+    [{ text: PARAGRAPH, family: 'sans-serif', size: 13, color: 'black' }],
+    { family: 'sans-serif', size: 13 },
+    { maxWidth: 380 },
+  );
+}
+
+const SCENARIOS = [
+  [
+    'text: paragraph, no clip',
+    async (app) => {
+      const ctx = pixmapCtx(app);
+      paragraphLayout(app).draw(ctx, 5, 5);
+    },
+  ],
+  [
+    'text: paragraph, inside a rect clip',
+    async (app) => {
+      const ctx = pixmapCtx(app);
+      const layout = paragraphLayout(app);
+      ctx.save();
+      ctx.beginPath();
+      ctx.rect(0, 0, 380, 200);
+      ctx.clip();
+      layout.draw(ctx, 5, 5);
+      ctx.restore();
+    },
+  ],
+  [
+    'shapes: 50 filled rounded boxes',
+    async (app) => {
+      const ctx = pixmapCtx(app);
+      for (let i = 0; i < 50; i++) {
+        ctx.fillStyle = i % 2 ? '#2980b9' : '#dfe6e9';
+        ctx.beginPath();
+        ctx.roundRect(
+          4 + (i % 10) * 38,
+          4 + Math.floor(i / 10) * 38,
+          34,
+          34,
+          4,
+        );
+        ctx.fill();
+      }
+    },
+  ],
+  [
+    'mount: window with 40 boxes and labels',
+    async (app) => {
+      await new Promise((resolve) =>
+        ReactX11.render(
+          React.createElement(
+            'window',
+            { width: W, height: H, backgroundColor: '#f5f6fa' },
+            React.createElement(
+              'box',
+              { flexGrow: 1, padding: 8, gap: 2 },
+              Array.from({ length: 40 }, (_, i) =>
+                React.createElement(
+                  'box',
+                  {
+                    key: i,
+                    flexDirection: 'row',
+                    gap: 6,
+                    padding: 2,
+                    backgroundColor: i % 2 ? '#ffffff' : '#eef1f5',
+                  },
+                  React.createElement('text', { fontSize: 11 }, `row ${i}`),
+                ),
+              ),
+            ),
+          ),
+          resolve,
+          app,
+        ),
+      );
+      await new Promise((r) => setImmediate(r));
+    },
+  ],
+];
+
+// --- run ---------------------------------------------------------------
+
+const results = {};
+for (const [name, fn] of SCENARIOS) {
+  const [key, value] = await measure(name, fn);
+  results[key] = value;
+}
+
+const args = process.argv.slice(2);
+if (args.includes('--save')) {
+  writeFileSync(baselinePath, `${JSON.stringify(results, null, 2)}\n`);
+  console.log(`wrote ${baselinePath}`);
+}
+
+const pad = (v, n) => String(v).padStart(n);
+console.log(
+  `${'scenario'.padEnd(38)} ${pad('reqs', 6)} ${pad('bytesOut', 9)} ${pad('replies', 8)} ${pad('composites', 11)} ${pad('Mpx', 8)}`,
+);
+for (const [name, r] of Object.entries(results)) {
+  console.log(
+    `${name.padEnd(38)} ${pad(r.requests, 6)} ${pad(r.bytesOut, 9)} ${pad(r.replies, 8)} ${pad(r.composites, 11)} ${pad((r.compositePixels / 1e6).toFixed(2), 8)}`,
+  );
+}
+
+if (args.includes('--check')) {
+  let baseline;
+  try {
+    baseline = JSON.parse(readFileSync(baselinePath, 'utf8'));
+  } catch {
+    console.error('\nno baseline — run `npm run bench -- --save` first');
+    process.exit(1);
+  }
+  // generous, so this catches step changes rather than noise
+  const TOLERANCE = 1.15;
+  const regressions = [];
+  for (const [name, now] of Object.entries(results)) {
+    const was = baseline[name];
+    if (!was) continue;
+    for (const metric of [
+      'requests',
+      'bytesOut',
+      'composites',
+      'compositePixels',
+    ]) {
+      const limit = was[metric] * TOLERANCE + 2;
+      if (now[metric] > limit) {
+        regressions.push(
+          `${name} — ${metric}: ${was[metric]} -> ${now[metric]}`,
+        );
+      }
+    }
+  }
+  if (regressions.length) {
+    console.error('\nprotocol regressions:');
+    for (const r of regressions) console.error(`  ${r}`);
+    process.exit(1);
+  }
+  console.log('\nno regressions against the baseline');
+}
+
+process.exit(0);

--- a/scripts/bench/xcount.js
+++ b/scripts/bench/xcount.js
@@ -1,0 +1,154 @@
+// Counting X11 stream wrapper: an in-process "benchmarking proxy".
+//
+// Sits between the client and the server stream and parses both directions
+// well enough to count protocol units, not just bytes:
+//
+//   requests  — first 2 bytes are (major, minor/data), length in 4-byte
+//               units at [2..4). A length of 0 means BIG-REQUESTS: the
+//               real 32-bit length follows.
+//   replies   — first byte 1, extra length (4-byte units) at [4..8)
+//   errors    — first byte 0, always 32 bytes
+//   events    — anything else, 32 bytes (GenericEvent carries extra)
+/**
+ * Attach counters to an existing X11 stream without replacing it: wrap
+ * `write` for the client->server direction and intercept the 'data' event
+ * for server->client. Replacing the stream with a Duplex instead means
+ * owning backpressure, which is easy to get subtly wrong and would make
+ * the measurement itself a variable.
+ */
+export function countStream(inner) {
+  const stats = {
+    requests: 0,
+    bytesOut: 0,
+    replies: 0,
+    events: 0,
+    errors: 0,
+    bytesIn: 0,
+    byOpcode: new Map(),
+    // (major, minor, w, h) for every 36-byte request, so Render Composite
+    // pixel area can be totalled once the extension opcode is known
+    composites: [],
+  };
+
+  let outBuf = Buffer.alloc(0);
+  let inBuf = Buffer.alloc(0);
+  let handshakeOut = false; // first client message is the connection setup
+  let handshakeIn = false;
+
+  const countRequests = () => {
+    for (;;) {
+      if (!handshakeOut) {
+        // setup request: 12-byte header + padded auth strings
+        if (outBuf.length < 12) return;
+        const n = outBuf.readUInt16LE(6);
+        const d = outBuf.readUInt16LE(8);
+        const total = 12 + ((n + 3) & ~3) + ((d + 3) & ~3);
+        if (outBuf.length < total) return;
+        outBuf = outBuf.subarray(total);
+        handshakeOut = true;
+        continue;
+      }
+      if (outBuf.length < 4) return;
+      const opcode = outBuf[0];
+      let len = outBuf.readUInt16LE(2) * 4;
+      if (len === 0) {
+        if (outBuf.length < 8) return;
+        len = outBuf.readUInt32LE(4) * 4;
+      }
+      if (len === 0 || outBuf.length < len) return;
+      stats.requests += 1;
+      stats.byOpcode.set(opcode, (stats.byOpcode.get(opcode) ?? 0) + 1);
+      if (len === 36) {
+        stats.composites.push([
+          opcode,
+          outBuf[1],
+          outBuf.readUInt16LE(32),
+          outBuf.readUInt16LE(34),
+        ]);
+      }
+      outBuf = outBuf.subarray(len);
+    }
+  };
+
+  const countReplies = () => {
+    for (;;) {
+      if (!handshakeIn) {
+        if (inBuf.length < 8) return;
+        const extra = inBuf.readUInt16LE(6) * 4;
+        const total = 8 + extra;
+        if (inBuf.length < total) return;
+        inBuf = inBuf.subarray(total);
+        handshakeIn = true;
+        continue;
+      }
+      if (inBuf.length < 32) return;
+      const type = inBuf[0];
+      let total = 32;
+      if (type === 1) {
+        total = 32 + inBuf.readUInt32LE(4) * 4;
+        if (inBuf.length < total) return;
+        stats.replies += 1;
+      } else if (type === 0) {
+        stats.errors += 1;
+      } else {
+        stats.events += 1;
+      }
+      inBuf = inBuf.subarray(total);
+    }
+  };
+
+  const write = inner.write.bind(inner);
+  inner.write = (chunk, ...rest) => {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    stats.bytesOut += buf.length;
+    outBuf = Buffer.concat([outBuf, buf]);
+    countRequests();
+    return write(chunk, ...rest);
+  };
+
+  const emit = inner.emit.bind(inner);
+  inner.emit = (name, ...args) => {
+    if (name === 'data') {
+      const buf = args[0];
+      stats.bytesIn += buf.length;
+      inBuf = Buffer.concat([inBuf, buf]);
+      countReplies();
+    }
+    return emit(name, ...args);
+  };
+
+  return { stream: inner, stats };
+}
+
+/**
+ * Pixels touched by Render Composite. Requests and bytes miss this
+ * entirely — a Composite request is 36 bytes whether it touches ten
+ * pixels or the whole surface — so a change can look free on the wire
+ * while multiplying the server's work.
+ */
+export function compositePixels(stats, renderOpcode) {
+  let px = 0;
+  let n = 0;
+  for (const [major, minor, w, h] of stats.composites) {
+    if (major === renderOpcode && minor === 8) {
+      px += w * h;
+      n += 1;
+    }
+  }
+  return { composites: n, pixels: px };
+}
+
+export function summarize(stats, topOpcodes = 6) {
+  const top = [...stats.byOpcode.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, topOpcodes);
+  return {
+    requests: stats.requests,
+    bytesOut: stats.bytesOut,
+    replies: stats.replies,
+    events: stats.events,
+    errors: stats.errors,
+    bytesIn: stats.bytesIn,
+    topOpcodes: top,
+  };
+}


### PR DESCRIPTION
Nothing in the repo measured how much X11 traffic we spend, so regressions were invisible. This adds a benchmark, a committed baseline, and the rules they enforce.

## `npm run bench`

Scenarios run against node-x11's in-process pure-JS X server — deterministic, no `$DISPLAY` — with a counting wrapper on the client stream that parses both directions.

```
scenario                                 reqs  bytesOut  replies  composites      Mpx
text: paragraph, no clip                   43      6192        1           1     0.16
text: paragraph, inside a rect clip        91      7576        1          25     4.00
shapes: 50 filled rounded boxes           175     15056        1          51     8.16
mount: window with 40 boxes and labels    125      5464        3          41     0.44
```

- `--save` rewrites `scripts/bench/baseline.json`
- `--check` fails past a 15% tolerance, so it catches step changes rather than noise

**The `Mpx` column is the point.** Requests and bytes miss the most common regression entirely: a Render `Composite` request is 36 bytes whether it touches ten pixels or the whole surface. Composited area is recoverable from the wire (minor opcode 8, width/height at fixed offsets), so the benchmark totals it.

## It immediately caught my own regression

I added the clipped-glyph path in ntk#79 last session. It is correct, and I said at the time I wasn't sure it was efficient. It isn't:

**91 requests and 25 composites over 4.0 Mpx for a clipped paragraph, against 43 / 1 / 0.16 Mpx unclipped** — 25× the pixel work, for a paragraph whose ink covers 0.08 Mpx.

The cause: `TextLayout.draw` flushes per line, and each clipped flush clears and composites the *whole surface* three times. The same full-surface pattern affects every fill (`_fillPolys`) — 50 small boxes cost 8.16 Mpx.

An earlier measurement of mine suggested the overhead was only +6 requests. That was wrong: I was measuring against ntk 3.5.0, which didn't have the fix installed yet. Re-measuring against the published 3.5.1 gave the numbers above.

Both are recorded in NEXT_STEPS with the fix: use `SetPictureClipRectangles` on the destination when the clip stack is all axis-aligned rects — the common case (contentBox, scrollview, `overflow: hidden`) — so glyphs clip server-side with no mask at all; bound the fallback mask to the glyph bbox; and batch `TextLayout.draw` per paragraph rather than per line. `SetPictureClipRectangles` is already bound in node-x11.

## AGENTS.md — "Protocol efficiency"

States what each library is responsible for (node-x11: protocol + minimal ergonomics, no policy; ntk: how drawing is *encoded*; react-x11: how often drawing *happens*), then the rules in priority order: server-side primitives over client-side pixel work, batch into as few requests as possible, bound work to the damaged area, avoid round trips, prefer server-side text rendering. Plus when to re-run the benchmark and to update the baseline in the same PR that changes it.

**ntk should get its own copy** of the rules and its own benchmark over primitives (fills, strokes, glyph runs, images) — this one covers the react-x11 end. I'd do that as a follow-up.

69/69 tests, lint clean.