### PR TITLE
chore(deps): ntk 3.5.2 — clipped text no longer costs 25x

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -15,15 +15,10 @@
 >
 > **Plan (next session):**
 >
-> 1. Upstream (ntk): make the clipped glyph path cheap. `npm run bench`
->    shows a clipped paragraph costs 25 composites / 4.0 Mpx against 1 /
->    0.16 Mpx unclipped — the mask path runs per line over the whole
->    surface. Two fixes: use `SetPictureClipRectangles` on the destination
->    when the clip stack is all axis-aligned rects (the common case:
->    contentBox, scrollview, overflow hidden), and bound the fallback mask
->    to the glyph bbox. Also batch `TextLayout.draw` per paragraph rather
->    than per line. Same full-surface problem affects every fill
->    (`_fillPolys`): 50 small boxes cost 8.16 Mpx.
+> 1. Upstream (ntk): bound `_fillPolys`/`_strokePolys` to the path's
+>    bounding box. They clear and composite the whole surface per
+>    operation, so 50 small rounded boxes cost 8.16 Mpx in `npm run bench`
+>    — the same pattern the glyph path had before ntk 3.5.2.
 > 2. `Select`/menu follow-up: PageUp/PageDown in the open menu.
 > 3. Then merge release-please #17 and publish 1.0.0 (the owner wants the
 >    planned widget work in first).
@@ -84,14 +79,14 @@ merged theme (`ThemeProvider`; `SelectThemeProvider` is an alias) and a
 - **Bidi caret polish** — caret positions are bidi-correct now (ntk
   caret API), but arrow keys still move logically; visual-order movement
   - split caret at direction boundaries is a later refinement
-- **Full-surface mask composites (ntk)** — clipping is correct since ntk
-  3.5.1, but the mask path (`_fillPolys`, `drawGlyphs`) clears and
-  composites the _entire_ surface per operation. Measured by
-  `npm run bench`: a clipped 12-line paragraph does 25 composites over
-  4.0 Mpx where the ink covers 0.08 Mpx, and 50 small filled boxes do
-  8.16 Mpx. Bound these to the damaged rect, and prefer
-  `SetPictureClipRectangles` for rectangular clips so glyphs clip
-  server-side with no mask at all.
+- **Full-surface mask composites in fills (ntk)** — `_fillPolys` and
+  `_strokePolys` clear and composite the _entire_ surface per operation,
+  so 50 small rounded boxes cost 8.16 Mpx in `npm run bench`. Bound them
+  to the path's bounding box. The glyph path had the same problem and was
+  fixed in ntk 3.5.2 (sidorares/ntk#81): rectangular clips now go through
+  `SetPictureClipRectangles` server-side, and `TextLayout.draw` batches
+  the whole layout, so a clipped paragraph costs the same as an unclipped
+  one (1 composite / 0.16 Mpx, down from 25 / 4.0).
 - **`opacity`** — needs offscreen composition (pixmap + Composite);
   ntk can do it, renderer needs a group-opacity paint path
 - **Dirty-rect painting** — still full-window repaint per frame

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^3.5.1",
+        "ntk": "^3.5.2",
         "react-reconciler": "^0.33.0"
       },
       "devDependencies": {
@@ -4071,9 +4071,9 @@
       }
     },
     "node_modules/ntk": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-3.5.1.tgz",
-      "integrity": "sha512-lzihMzMIALUMWazYS0xYyGviQDvEjS/hC559Rr73aWUZkMjZc7DeHxA6CGiY5reCdDhiT20SrOoagWJxGi1DgQ==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-3.5.2.tgz",
+      "integrity": "sha512-Cwn2a2x6FH8UzADpLasNUBESeGpip3bpb/KmNjA5WJzhZZ8KhVjMwdhTFODstJqXPR8JbPjFcf4hdpK7F2bmMA==",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^3.5.1",
+    "ntk": "^3.5.2",
     "react-reconciler": "^0.33.0"
   },
   "peerDependencies": {

--- a/scripts/bench/baseline.json
+++ b/scripts/bench/baseline.json
@@ -1,19 +1,19 @@
 {
   "text: paragraph, no clip": {
-    "requests": 43,
-    "bytesOut": 6192,
+    "requests": 32,
+    "bytesOut": 5884,
     "bytesIn": 32,
     "replies": 1,
     "composites": 1,
     "compositePixels": 160000
   },
   "text: paragraph, inside a rect clip": {
-    "requests": 91,
-    "bytesOut": 7576,
+    "requests": 43,
+    "bytesOut": 6064,
     "bytesIn": 32,
     "replies": 1,
-    "composites": 25,
-    "compositePixels": 4000000
+    "composites": 1,
+    "compositePixels": 160000
   },
   "shapes: 50 filled rounded boxes": {
     "requests": 175,


### PR DESCRIPTION
Picks up sidorares/ntk#81 and re-saves the benchmark baseline so the committed numbers record the improvement.

```
                              requests   composites      Mpx
text: paragraph, no clip       43 -> 32     1 ->  1   0.16 -> 0.16
text: paragraph, rect clip     91 -> 43    25 ->  1   4.00 -> 0.16
```

**Clipping text is now free relative to not clipping it**, and the unclipped path got cheaper too from batching the whole layout into one glyph composite instead of one per line.

This is the loop the benchmark was added for working end to end: it caught a 25× regression I had introduced, the fix landed upstream, and the baseline diff now shows the win rather than anyone having to take my word for it.

69/69 tests pass against 3.5.2.

## Next

The remaining full-surface path is fills — `_fillPolys`/`_strokePolys` clear and composite the entire surface per operation, so **50 small rounded boxes still cost 8.16 Mpx**. Same fix as the glyph path (bound to the path's bounding box), now the top NEXT_STEPS item.

Note: `npm i ntk@^3.5.2` failed with `ETARGET` against a stale cached packument even though the registry had it; `--prefer-online` resolved it. Worth knowing if CI picks up an old version right after a publish.