### PR TITLE
chore(deps): ntk 3.5.3 — fills bounded to their bounding box

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -15,14 +15,9 @@
 >
 > **Plan (next session):**
 >
-> 1. Upstream (ntk): bound `_fillPolys`/`_strokePolys` to the path's
->    bounding box. They clear and composite the whole surface per
->    operation, so 50 small rounded boxes cost 8.16 Mpx in `npm run bench`
->    — the same pattern the glyph path had before ntk 3.5.2.
-> 2. `Select`/menu follow-up: PageUp/PageDown in the open menu.
-> 3. Then merge release-please #17 and publish 1.0.0 (the owner wants the
->    planned widget work in first).
-> 4. Upstream (ntk): distribute half-leading inside TextLayout itself
+> 1. `Select`/menu follow-up: PageUp/PageDown in the open menu.
+> 2. Then merge release-please #17 and publish 1.0.0.
+> 3. Upstream (ntk): distribute half-leading inside TextLayout itself
 >    (makes the #29 paint shift a no-op) + an opt-in cap-height trim
 >    (`text-box-trim` analog); `maxLines`/ellipsis for `<text>`.
 
@@ -79,14 +74,14 @@ merged theme (`ThemeProvider`; `SelectThemeProvider` is an alias) and a
 - **Bidi caret polish** — caret positions are bidi-correct now (ntk
   caret API), but arrow keys still move logically; visual-order movement
   - split caret at direction boundaries is a later refinement
-- **Full-surface mask composites in fills (ntk)** — `_fillPolys` and
-  `_strokePolys` clear and composite the _entire_ surface per operation,
-  so 50 small rounded boxes cost 8.16 Mpx in `npm run bench`. Bound them
-  to the path's bounding box. The glyph path had the same problem and was
-  fixed in ntk 3.5.2 (sidorares/ntk#81): rectangular clips now go through
-  `SetPictureClipRectangles` server-side, and `TextLayout.draw` batches
-  the whole layout, so a clipped paragraph costs the same as an unclipped
-  one (1 composite / 0.16 Mpx, down from 25 / 4.0).
+- **Full-surface mask composites — DONE upstream.** Both paths are now
+  bounded: glyphs in ntk 3.5.2 (sidorares/ntk#81 — rectangular clips go
+  through `SetPictureClipRectangles` server-side, `TextLayout.draw`
+  batches the whole layout) and fills/strokes in 3.5.3
+  (sidorares/ntk#83 — mask work bounded to the path bbox). A clipped
+  paragraph now costs the same as an unclipped one, and 50 small boxes
+  dropped 8.16 -> 0.22 Mpx. Still full-surface: `drawImage` (two sites),
+  and react-x11 repaints the whole window per frame (§8.4 below).
 - **`opacity`** — needs offscreen composition (pixmap + Composite);
   ntk can do it, renderer needs a group-opacity paint path
 - **Dirty-rect painting** — still full-window repaint per frame

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^3.5.2",
+        "ntk": "^3.5.3",
         "react-reconciler": "^0.33.0"
       },
       "devDependencies": {
@@ -4071,9 +4071,9 @@
       }
     },
     "node_modules/ntk": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-3.5.2.tgz",
-      "integrity": "sha512-Cwn2a2x6FH8UzADpLasNUBESeGpip3bpb/KmNjA5WJzhZZ8KhVjMwdhTFODstJqXPR8JbPjFcf4hdpK7F2bmMA==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-3.5.3.tgz",
+      "integrity": "sha512-CExdcfHwAEyNIbzbWqv8OxQD4BAC/25RZ395k2V0PoiE8XULgbAGtg/wMgSvNyCtdVvLSRLVNuEt9PbPe42ITw==",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^3.5.2",
+    "ntk": "^3.5.3",
     "react-reconciler": "^0.33.0"
   },
   "peerDependencies": {

--- a/scripts/bench/baseline.json
+++ b/scripts/bench/baseline.json
@@ -21,7 +21,7 @@
     "bytesIn": 32,
     "replies": 1,
     "composites": 51,
-    "compositePixels": 8160000
+    "compositePixels": 224800
   },
   "mount: window with 40 boxes and labels": {
     "requests": 125,


### PR DESCRIPTION
Picks up sidorares/ntk#83 and re-saves the baseline.

```
                                  composites      Mpx
shapes: 50 filled rounded boxes           51   8.16 -> 0.22
```

**37× less pixel work**, request count unchanged at 175 — which is the whole reason the composited-area metric exists.

With 3.5.2's glyph work, every drawing scenario in the benchmark is now bounded to what it actually touches:

```
text: paragraph, no clip              32 reqs   1 composite   0.16 Mpx
text: paragraph, inside a rect clip   43 reqs   1 composite   0.16 Mpx
shapes: 50 filled rounded boxes      175 reqs  51 composites  0.22 Mpx
mount: window, 40 boxes and labels   125 reqs  41 composites  0.44 Mpx
```

69/69 tests pass against 3.5.3.

## Remaining known cost

Neither is measured as a problem yet, both recorded in NEXT_STEPS:

- `drawImage` still composites full-surface (two sites in ntk)
- react-x11 repaints the whole window per frame rather than tracking dirty rects (§8.4)

The roadmap is now down to `Select`/menu PageUp/PageDown, then 1.0.0.