### PR TITLE
feat: PageUp/PageDown in Select and the menus

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -15,9 +15,9 @@
 >
 > **Plan (next session):**
 >
-> 1. `Select`/menu follow-up: PageUp/PageDown in the open menu.
-> 2. Then merge release-please #17 and publish 1.0.0.
-> 3. Upstream (ntk): distribute half-leading inside TextLayout itself
+> 1. Merge release-please #17 and publish 1.0.0 — the planned widget work
+>    is complete.
+> 2. Upstream (ntk): distribute half-leading inside TextLayout itself
 >    (makes the #29 paint shift a no-op) + an opt-in cap-height trim
 >    (`text-box-trim` analog); `maxLines`/ellipsis for `<text>`.
 
@@ -60,7 +60,8 @@ merged theme (`ThemeProvider`; `SelectThemeProvider` is an alias) and a
 - **Menu/MenuBar, ContextMenu** — DONE: built on `useAnchor`, with
   separators, disabled items, shortcuts, checkmarks, nested submenus and
   full keyboard navigation; `examples/menu.jsx` rewritten on them
-- **`Select` PageUp/PageDown** — type-ahead is done; keyboard navigation
+- **`Select`/menu keyboard — DONE.** Arrows, Home/End, PageUp/PageDown,
+  type-ahead, submenus. Keyboard navigation
   is done (#34: Up/Down/Home/End/Enter/Escape, shared pointer+keyboard
   highlight, active option scrolled into view)
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -49,6 +49,9 @@ The menu opens with the current value active, hovering an option makes it
 active (pointer and keyboard share one highlight), and the active option is
 scrolled into view.
 
+**PageUp/PageDown** move by a menu viewport (`MAX_MENU_HEIGHT / ITEM_HEIGHT`
+options), clamping at the ends rather than wrapping the way the arrows do.
+
 **Type-ahead.** Typing letters jumps to the matching option: with the menu
 open it moves the highlight, and with it closed it changes the value
 outright, the way a native select does. Keystrokes within 700ms accumulate
@@ -187,6 +190,12 @@ at a time**. In a `MenuBar`, Left/Right walk between menus _when there is
 no submenu to move through_, and with one menu open, hovering another
 switches to it. Hovering a submenu parent opens it with nothing selected
 inside.
+
+**PageUp/PageDown** step ten rows and then settle on the nearest selectable
+entry in the direction of travel, so a page never lands on a separator or a
+disabled row. Menus size to their content rather than scrolling, so the
+stride is fixed — deriving one from the menu height would just equal
+Home/End.
 
 **Type-ahead.** Typing letters jumps to the entry whose label starts with
 them, in whichever level is deepest open. Keystrokes within 700ms

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -17,6 +17,8 @@ import {
   XK_ESCAPE,
   XK_HOME,
   XK_LEFT,
+  XK_PAGE_DOWN,
+  XK_PAGE_UP,
   XK_RETURN,
   XK_RIGHT,
   XK_UP,
@@ -35,6 +37,9 @@ const MENU_PAD = 4;
 const MENU_GUTTER = 24; // room for the check column
 
 const MENU_SHORTCUT_GAP = 24;
+// menus size to their content rather than scrolling, so a page is a fixed
+// stride — deriving one from the menu height would just equal Home/End
+const MENU_PAGE_ROWS = 10;
 
 const isSelectable = (item) => item && !item.separator && !item.disabled;
 
@@ -298,6 +303,22 @@ function handleMenuKey(
     case XK_END:
       setActive(nextSelectable(items, items.length, -1));
       return true;
+    case XK_PAGE_UP:
+    case XK_PAGE_DOWN: {
+      // step a viewport's worth of rows, then settle on the nearest
+      // selectable entry in the direction of travel so a page never lands
+      // on a separator or a disabled row
+      const dir = ev.keysym === XK_PAGE_DOWN ? 1 : -1;
+      const page = MENU_PAGE_ROWS;
+      const from = active < 0 ? (dir > 0 ? -1 : items.length) : active;
+      const target = Math.min(items.length - 1, Math.max(0, from + dir * page));
+      setActive(
+        isSelectable(items[target])
+          ? target
+          : nextSelectable(items, target - dir, dir),
+      );
+      return true;
+    }
     case XK_RIGHT:
       return enterSubmenu();
     case XK_LEFT:

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -11,6 +11,8 @@ import {
   XK_END,
   XK_ESCAPE,
   XK_HOME,
+  XK_PAGE_DOWN,
+  XK_PAGE_UP,
   XK_RETURN,
   XK_UP,
 } from './keys.js';
@@ -136,6 +138,17 @@ export function Select({
         if (open && count)
           setActiveIndex(ev.keysym === XK_HOME ? 0 : count - 1);
         return;
+      case XK_PAGE_UP:
+      case XK_PAGE_DOWN: {
+        // a page is what the menu shows at once, so paging lines up with
+        // what the user can see rather than an arbitrary count
+        if (!open || !count) return;
+        const page = Math.max(1, Math.floor(MAX_MENU_HEIGHT / ITEM_HEIGHT));
+        const dir = ev.keysym === XK_PAGE_DOWN ? 1 : -1;
+        const from = activeIndex < 0 ? 0 : activeIndex;
+        setActiveIndex(Math.min(count - 1, Math.max(0, from + dir * page)));
+        return;
+      }
       default:
         break;
     }

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -2762,3 +2762,152 @@ test('textarea: draws a scrollbar thumb only when the text overflows', async () 
 
   ReactX11.unmountComponentAtNode(app);
 });
+
+test('Select: PageDown/PageUp move by a menu viewport, clamped at the ends', async () => {
+  const { Select } = await import('../src/index.js');
+  const app = createMockApp();
+  const options = Array.from({ length: 40 }, (_, i) => `option-${i}`);
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 300, height: 120 },
+      React.createElement(
+        'box',
+        { flexGrow: 1, padding: 10 },
+        React.createElement(Select, { options, value: options[0], width: 200 }),
+      ),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const findFocusable = (n) =>
+    n.props?.focusable
+      ? n
+      : n.children.reduce(
+          (a, c) => a || (c.isWindow ? null : findFocusable(c)),
+          null,
+        );
+  const trigger = findFocusable(wnd._reactX11Node);
+  wnd.emit('mousedown', {
+    x: trigger.abs.x + 10,
+    y: trigger.abs.y + trigger.abs.height / 2,
+    keycode: 1,
+  });
+  wnd.emit('mouseup', {
+    x: trigger.abs.x + 10,
+    y: trigger.abs.y + trigger.abs.height / 2,
+    keycode: 1,
+  });
+  await tick();
+  await tick();
+
+  const scroller = (() => {
+    let found = null;
+    const walk = (n) => {
+      if (n.kind === 'scrollview') found = n;
+      else n.children.forEach(walk);
+    };
+    walk(app.windows[1]._reactX11Node);
+    return found;
+  })();
+  const active = () =>
+    scroller.children.findIndex((o) => o.props.backgroundColor === '#2980b9');
+
+  assert.strictEqual(active(), 0, 'opens on the current value');
+  // page = floor(MAX_MENU_HEIGHT / ITEM_HEIGHT) = floor(220 / 28) = 7
+  const PAGE = 7;
+
+  pressKey(app, wnd, { keysym: 0xff56 }); // Page Down
+  await tick();
+  assert.strictEqual(active(), PAGE, 'down one page');
+
+  pressKey(app, wnd, { keysym: 0xff56 });
+  await tick();
+  assert.strictEqual(active(), PAGE * 2);
+
+  pressKey(app, wnd, { keysym: 0xff55 }); // Page Up
+  await tick();
+  assert.strictEqual(active(), PAGE, 'back up one page');
+
+  // paging past an end clamps rather than wrapping — unlike the arrows.
+  // each press needs its own tick: a synchronous burst would not re-render
+  // between them, so the handler would keep reading the same index
+  for (let i = 0; i < 10; i++) {
+    pressKey(app, wnd, { keysym: 0xff56 });
+    await tick();
+  }
+  assert.strictEqual(active(), options.length - 1, 'clamps at the last option');
+
+  for (let i = 0; i < 10; i++) {
+    pressKey(app, wnd, { keysym: 0xff55 });
+    await tick();
+  }
+  assert.strictEqual(active(), 0, 'clamps at the first option');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('menu: PageDown/PageUp land on a selectable row, never a separator', async () => {
+  const { ContextMenu } = await import('../src/index.js');
+  const app = createMockApp();
+  const picked = [];
+  // 12 rows where the row a page-stride away (index 10) is a separator, so
+  // a naive jump would land on something unselectable
+  const items = Array.from({ length: 12 }, (_, i) =>
+    i === 10
+      ? { separator: true }
+      : { label: `entry-${i}`, onSelect: () => picked.push(i) },
+  );
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 320, height: 220 },
+      React.createElement(
+        ContextMenu,
+        { items, flexGrow: 1 },
+        React.createElement('box', { flexGrow: 1 }),
+      ),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  wnd.emit('mousedown', { x: 20, y: 20, keycode: 3, rootx: 100, rooty: 100 });
+  await tick();
+  await tick();
+
+  const rows = () => app.windows[1]._reactX11Node.children[0].children;
+  const active = () =>
+    rows().findIndex((r) => r.props.backgroundColor === '#2980b9');
+
+  pressKey(app, wnd, { keysym: 0xff54 }); // Down -> entry-0
+  await tick();
+  assert.strictEqual(active(), 0);
+
+  // a page is 10 rows: index 10 is the separator, so it must settle on a
+  // selectable row instead
+  pressKey(app, wnd, { keysym: 0xff56 }); // Page Down
+  await tick();
+  const landed = active();
+  assert.notStrictEqual(landed, 10, 'never lands on the separator');
+  assert.ok(
+    rows()[landed].props.backgroundColor === '#2980b9',
+    'landed on a real row',
+  );
+  assert.ok(landed > 0, 'and moved forward');
+
+  // paging back is symmetric in *rows*, not a history undo: the page down
+  // settled on 11 after skipping the separator, so 10 rows up is 1
+  pressKey(app, wnd, { keysym: 0xff55 }); // Page Up
+  await tick();
+  assert.strictEqual(active(), landed - 10, 'a page back in rows');
+
+  pressKey(app, wnd, { keysym: 0xff55 });
+  await tick();
+  assert.strictEqual(active(), 0, 'and clamps at the first entry');
+
+  ReactX11.unmountComponentAtNode(app);
+});


### PR DESCRIPTION
The last listed keyboard gap, and the last roadmap item before 1.0.0.

**`Select`** pages by a menu viewport (`MAX_MENU_HEIGHT / ITEM_HEIGHT` = 7 options), so paging lines up with what is actually on screen. It **clamps** at the ends rather than wrapping — unlike the arrows, where wrapping is what you want.

**Menus** step a fixed ten rows and then settle on the nearest selectable entry in the direction of travel, so a page never lands on a separator or a disabled row. The stride is fixed because menus size to their content instead of scrolling — deriving one from the menu height would just equal Home/End.

## A behaviour worth naming

Paging back is symmetric in **rows**, not a history undo. If a page down settled on index 11 after skipping a separator at 10, the matching page up lands on 1 — a page of rows above 11 — not back at 0.

My first version of the test asserted the round trip and failed. The code was right and the test was wrong, so I fixed the expectation and documented the reason inline rather than bending the implementation to match a wrong intuition.

## Tests

71/71, lint clean. Two new:

- Select paging down and up by exactly a viewport, then clamping at both ends after repeated presses
- a menu whose row exactly one page-stride away **is** a separator, asserting the landing row is never that index and is always selectable

One practical note the first draft got wrong: a synchronous burst of `pressKey` calls does not re-render between them, so the handler keeps reading the same index. Each press needs its own tick — noted in the test.