### PR TITLE
feat: 3D over indirect GLX — <glarea> surface and the <mesh> scene tree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,9 @@ react-like ergonomics on top of [ntk](https://github.com/sidorares/ntk) /
 [node-x11](https://github.com/sidorares/node-x11) — pure JavaScript
 implementations of the X11 protocol, no native bridge.
 
-Architecture (see NEXT_STEPS.md for the full rationale): only `<window>`
-and `<popup>` map to real X11 windows; everything else is a retained
+Architecture (see NEXT_STEPS.md for the full rationale): only `<window>`,
+`<popup>` and `<glarea>` map to real X11 windows (`<glarea>` because GLX
+needs its own visual); everything else is a retained
 lightweight node — one yoga-layout node each — painted into the owning
 window's double-buffered 2d context on ntk's frame clock, with synthetic
 capture/bubble events dispatched via front-to-back hit testing. X11
@@ -31,6 +32,10 @@ no override-redirect staging (issue #4).
 - `src/nodes.js` — the retained node tree: `WindowNode` (real X window,
   paint/event/flex root), `BoxNode`, `TextNode` (+ spans/chunks),
   `ImageNode`, `CanvasNode`. Layout (yoga), painting, hit testing.
+- `src/glnodes.js` — `<glarea>`: the GL surface. A child X window on a
+  GLX visual (ntk's `chooseGLXConfig`), positioned by the parent's yoga
+  rect, drawing `onDraw` frames on its own frame clock. First step of
+  docs/glx-plan.md.
 - `src/richnodes.js` — rich-content elements (`<markdown>`, `<html>`,
   `<svg>`, `<tex>`) wrapping ntk's document widgets in standalone mode:
   the widget's `layout(width)`/`contentHeight` feeds a yoga measure

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,11 @@ no override-redirect staging (issue #4).
   GLX visual (ntk's `chooseGLXConfig`), positioned by the parent's yoga
   rect, drawing `onDraw` frames on its own frame clock. First step of
   docs/glx-plan.md.
+- `src/scene3d.js` — the 3D scene tree inside a `<glarea>`: `<mesh>`,
+  `<group>`, geometry/material nodes and the renderer that compiles each
+  geometry into a server-side **display list** (a frame is matrices +
+  material state + one `CallList` per mesh). `src/geometry3d.js` generates
+  the primitives, `src/mat4.js` is the matrix math.
 - `src/richnodes.js` — rich-content elements (`<markdown>`, `<html>`,
   `<svg>`, `<tex>`) wrapping ntk's document widgets in standalone mode:
   the widget's `layout(width)`/`contentHeight` feeds a yoga measure

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -17,10 +17,11 @@
 >
 > 1. **3D components over indirect GLX** — the one large feature going in
 >    before 1.0.0. Plan, with the feasibility work already done, is in
->    [docs/glx-plan.md](docs/glx-plan.md). Starts with two ntk blockers:
->    `getContext('opengl')` passes the context XID where the protocol
->    wants MakeCurrent's tag (every draw fails), and `createWindow` cannot
->    take a visual.
+>    [docs/glx-plan.md](docs/glx-plan.md). Phase 0 (the ntk blockers:
+>    MakeCurrent's context tag, `createWindow` visuals, server-side visual
+>    discovery) is sidorares/ntk#85; Phase 1 — the `<glarea>` surface
+>    element — is done here and waiting on that release. Next up: the
+>    display-list geometry compiler and `<mesh>` (plan §5, phase 2).
 > 2. Then merge release-please #17 and publish 1.0.0.
 > 3. Upstream (ntk): distribute half-leading inside TextLayout itself
 >    (makes the #29 paint shift a no-op) + an opt-in cap-height trim

--- a/docs/components.md
+++ b/docs/components.md
@@ -215,6 +215,45 @@ takes focus when the menu opens.
 Switching between `MenuBar` menus reuses the same X window and moves it
 rather than destroying and recreating one, so there is no flicker.
 
+## `Canvas3D`
+
+The entry point to the [3D scene](elements.md#3d-scene-mesh-group-geometries-materials)
+— a thin wrapper over the `<glarea>` host element, named `Canvas3D` rather
+than r3f's `Canvas` because react-x11 already has a `<canvas>` element (the
+2D `onDraw` escape hatch).
+
+```jsx
+import { Canvas3D } from 'react-x11';
+
+<Canvas3D
+  flexGrow={1}
+  clearColor="#12161f"
+  camera={{ position: [0, 2, 6], fov: 45 }}
+>
+  <group rotation={[0, angle, 0]}>
+    <mesh position={[-1.6, 0, 0]}>
+      <boxGeometry args={[1.4, 1.4, 1.4]} />
+      <meshBasicMaterial color="#2980b9" />
+    </mesh>
+    <mesh position={[1.6, 0, 0]}>
+      <sphereGeometry args={[0.9, 24, 16]} />
+      <meshBasicMaterial color="#e67e22" wireframe />
+    </mesh>
+  </group>
+</Canvas3D>;
+```
+
+Takes every `<glarea>` prop (layout props, `clearColor`, `frameLoop`, `glx`,
+`onCreated`, `onDraw`, `onError`) plus:
+
+- `camera` — `{ position, target, up, fov, near, far }`, or
+  `{ orthographic: true, zoom }`. Defaults to a perspective camera at
+  `[0, 0, 5]` looking at the origin with a 50° vertical field of view.
+
+Animate by changing props from a `requestAnimationFrame` loop on the window
+ref (see `examples/three.jsx`) — a scene only redraws when something
+changes, unless `frameLoop="always"`.
+
 ## `useAnchor(ref)` / `anchorRect(node, options)`
 
 The placement math behind `Select` and `Tooltip`, exported for building

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -1,8 +1,8 @@
 # Elements
 
-Only `<window>` and `<popup>` are backed by real X11 windows, created
-top-down in React's commit phase so every `CreateWindow` names its actual
-parent. Everything else is a retained lightweight node — one
+Only `<window>`, `<popup>` and `<glarea>` are backed by real X11 windows,
+created top-down in React's commit phase so every `CreateWindow` names its
+actual parent. Everything else is a retained lightweight node — one
 [yoga-layout](https://www.yogalayout.dev/) node each — painted into the
 owning window's double-buffered 2d context on ntk's frame clock.
 
@@ -259,8 +259,59 @@ drawn in the parent, so 2D content cannot overlap it — a HUD needs a
 sibling `<popup>`. Pointer events over the surface go to its own window;
 `<glarea>` does not take part in the parent's hit testing yet.
 
-See `examples/gl.jsx` and [glx-plan.md](glx-plan.md) for where this is
-going (a react-three-fiber-shaped `<mesh>` set on top).
+`onDraw` is the raw escape hatch; for a scene, put 3D elements inside
+(below) and let the renderer drive the GL. See `examples/gl.jsx` for the
+raw form, `examples/three.jsx` for the declarative one.
+
+---
+
+## 3D scene: `<mesh>`, `<group>`, geometries, materials
+
+Inside a `<glarea>` (or the [`Canvas3D`](components.md#canvas3d) component
+that wraps it) the children are **scene** elements, not drawn ones — a
+separate tree with no yoga and no 2D painting, using react-three-fiber's
+names wherever the concept survives the translation to fixed-function GL.
+
+```jsx
+<Canvas3D flexGrow={1} camera={{ position: [0, 2, 6], fov: 45 }}>
+  <group rotation={[0, angle, 0]}>
+    <mesh position={[-1.6, 0, 0]} rotation={[0.5, 0.4, 0]} scale={1.2}>
+      <boxGeometry args={[1.4, 1.4, 1.4]} />
+      <meshBasicMaterial color="#2980b9" />
+    </mesh>
+  </group>
+</Canvas3D>
+```
+
+| element               | notes                                                                                              |
+| --------------------- | -------------------------------------------------------------------------------------------------- |
+| `<group>`             | transform only; nests children                                                                     |
+| `<mesh>`              | one geometry child + one material child                                                            |
+| `<boxGeometry>`       | `args={[width, height, depth, widthSeg, heightSeg, depthSeg]}`                                     |
+| `<planeGeometry>`     | `args={[width, height, widthSeg, heightSeg]}`                                                      |
+| `<sphereGeometry>`    | `args={[radius, widthSeg, heightSeg]}`                                                             |
+| `<cylinderGeometry>`  | `args={[radiusTop, radiusBottom, height, radialSeg, heightSeg, openEnded]}`                        |
+| `<torusGeometry>`     | `args={[radius, tube, radialSeg, tubularSeg]}`                                                     |
+| `<bufferGeometry>`    | `position` / `normal` / `uv` / `index` arrays; normals are derived from the triangles when omitted |
+| `<meshBasicMaterial>` | `color`, `wireframe`, `opacity`, `transparent`, `side` (`front` \| `back` \| `double`)             |
+
+Transforms are `position`, `rotation` (XYZ euler radians) and `scale`, each
+a `[x, y, z]` tuple (or one number for a uniform scale), plus `visible`.
+
+**Geometry lives on the server.** GLX encodes no vertex arrays, so vertices
+can only travel as immediate-mode commands — a 1 000-triangle mesh re-sent
+every frame is ~96 KB per frame. Each geometry is therefore compiled into a
+**display list** once, and a frame is matrices + material state + one
+`CallList` per mesh, whatever the triangle count. Changing a transform or a
+material re-sends neither; changing a geometry's `args` recompiles just
+that list. `test/scene3d.test.js` asserts exactly this on the encoded
+command stream.
+
+Not implemented, and failing with an error naming the reason:
+`<shaderMaterial>` (the protocol encodes no shaders), `<instancedMesh>`,
+`<points>`, `<line>`, post-processing. Lighting materials
+(`<meshLambertMaterial>`, `<meshPhongMaterial>`), lights and camera
+elements are the next phase — see [glx-plan.md](glx-plan.md).
 
 ---
 

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -211,6 +211,59 @@ every repaint of the window.
 
 ---
 
+## `<glarea>`
+
+An OpenGL surface in the layout — the only drawn element that owns a real X
+window, because GLX needs a drawable created for a GL-capable visual and
+cannot share the XRender pipeline the rest of the tree paints through
+(NEXT_STEPS §4). Needs ntk ≥ 3.6.0 and a server with **indirect GLX**
+enabled (`+iglx` / `AllowIndirectGLX` — off by default on many).
+
+```jsx
+<glarea
+  flexGrow={1}
+  clearColor="#0b1021"
+  frameLoop="always"
+  onCreated={(gl) => gl.Enable(gl.DEPTH_TEST)}
+  onDraw={(gl, { width, height }) => {
+    gl.MatrixMode(gl.PROJECTION);
+    gl.LoadIdentity();
+    gl.Frustum(-1, 1, -height / width, height / width, 2, 20);
+    // ... immediate-mode or display-list drawing
+  }}
+/>
+```
+
+- `onDraw(gl, { width, height, node })` — draw one frame. The viewport is
+  set and the buffers are cleared before it, `SwapBuffers` follows it.
+- `onCreated(gl, info)` — runs once, when the context is current: one-time
+  GL state, texture uploads, display-list compilation.
+- `clearColor` — CSS colour or `[r, g, b, a]` floats (default black).
+- `frameLoop` — `'demand'` (default) redraws on prop, size and expose
+  changes only; `'always'` renders continuously on ntk's frame clock.
+- `glx` — a visual spec for ntk's `chooseGLXConfig`, e.g.
+  `{ DEPTH_SIZE: 24 }`. One query per app, shared by every `<glarea>`.
+- `onError(err)` — no GL surface (no GLX, no matching visual). Without a
+  handler the failure is a console warning.
+
+`gl` is ntk's indirect-GLX context: fixed-function OpenGL 1.4 (immediate
+mode, matrices, lighting, textures, display lists) — no shaders, no vertex
+arrays, since the GLX protocol does not encode them. **Geometry belongs in
+display lists**: every immediate-mode vertex is a command on the wire, so a
+mesh re-sent per frame costs kilobytes per frame, while a compiled list
+costs one `CallList`.
+
+Layout treats it as a leaf: it is sized and positioned like any other node,
+and its X window follows that rect. The window is stacked above everything
+drawn in the parent, so 2D content cannot overlap it — a HUD needs a
+sibling `<popup>`. Pointer events over the surface go to its own window;
+`<glarea>` does not take part in the parent's hit testing yet.
+
+See `examples/gl.jsx` and [glx-plan.md](glx-plan.md) for where this is
+going (a react-three-fiber-shaped `<mesh>` set on top).
+
+---
+
 ## Rich content
 
 Thin wrappers over ntk's document widgets in standalone mode. The widget's

--- a/docs/glx-plan.md
+++ b/docs/glx-plan.md
@@ -1,12 +1,13 @@
 # Plan: 3D components over indirect GLX
 
-Status: **phases 0 and 1 are implemented** (2026-07-27). Phase 0 is
-sidorares/ntk#85 — the context tag, GLX visuals on `createWindow`, and
-visual discovery over the protocol instead of `glxinfo`. Phase 1 is the
-`<glarea>` element here (docs/elements.md), which waits on that ntk
-release. Phase 2 (display lists, `<mesh>`) is next. Everything in "What
-was verified" below was measured against XQuartz + node-x11 3.1.2 +
-ntk 3.5.3, not assumed.
+Status: **phases 0, 1 and 2 are implemented** (2026-07-27). Phase 0 shipped
+in ntk 3.6.0 (sidorares/ntk#85): the context tag, GLX visuals on
+`createWindow`, visual discovery over the protocol instead of `glxinfo`.
+Phase 1 is the `<glarea>` element, phase 2 the scene tree — `<mesh>`,
+`<group>`, the primitive geometries and `<meshBasicMaterial>` over a
+display-list compiler (docs/elements.md). Phase 3 (lights, lit materials,
+camera elements) is next. Everything in "What was verified" below was
+measured against XQuartz + node-x11 3.1.2 + ntk 3.5.3, not assumed.
 
 Goal: a react-three-fiber-shaped component set — `<mesh>`, geometries,
 materials, lights, a camera — rendering through **indirect GLX**, i.e. the
@@ -189,10 +190,13 @@ on ntk's `requestAnimationFrame`. `Canvas3D` moves to phase 2 — the
 surface duties live in the host element, so the component only earns its
 keep once there is a scene tree to own.
 
-**Phase 2 — geometry.** Display-list compiler, `<mesh>`,
-`<bufferGeometry>` + the primitive geometries, `<meshBasicMaterial>`.
-Success: a spinning wireframe/solid cube whose per-frame cost does not
-grow with triangle count.
+**Phase 2 — geometry. DONE.** Display-list compiler, `<mesh>`, `<group>`,
+`<bufferGeometry>` + box/plane/sphere/cylinder/torus,
+`<meshBasicMaterial>`, the `camera` prop and the `Canvas3D` component.
+The per-frame cost is independent of triangle count and
+`test/scene3d.test.js` asserts it on the encoded command stream: a 6 000-
+vertex sphere compiles once, and the steady-state frame is under 30 GL
+commands with no vertices in it.
 
 **Phase 3 — shading.** Lights, `meshLambert`/`meshPhong`, `ShadeModel`,
 normals, `<perspectiveCamera>`/`<orthographicCamera>`, `<group>`.
@@ -239,9 +243,10 @@ should be defended by the benchmark rather than by intent.
 
 ## 7. Open questions
 
-- Does XQuartz's indirect GLX handle display lists and lighting reliably,
-  or only the trivial path the probe exercised? **Test early in Phase 2** —
-  the entire design rests on display lists working.
+- ~~Does XQuartz's indirect GLX handle display lists reliably?~~ **Yes** —
+  `examples/three.jsx` draws box/sphere/torus from display lists with depth
+  testing and back-face culling on XQuartz. Lighting is still untested
+  there (phase 3).
 - Is there a depth-buffer-capable visual reachable via `GetVisualConfigs`
   on both XQuartz and Xvfb/llvmpipe?
 - Does `SwapBuffers` interact sanely with ntk's frame clock and the

--- a/docs/glx-plan.md
+++ b/docs/glx-plan.md
@@ -1,8 +1,12 @@
 # Plan: 3D components over indirect GLX
 
-Status: **plan only, nothing implemented.** Written to be picked up in a
-later session. Everything in "What was verified" below was measured on
-2026-07-27 against XQuartz + node-x11 3.1.2 + ntk 3.5.3, not assumed.
+Status: **phases 0 and 1 are implemented** (2026-07-27). Phase 0 is
+sidorares/ntk#85 — the context tag, GLX visuals on `createWindow`, and
+visual discovery over the protocol instead of `glxinfo`. Phase 1 is the
+`<glarea>` element here (docs/elements.md), which waits on that ntk
+release. Phase 2 (display lists, `<mesh>`) is next. Everything in "What
+was verified" below was measured against XQuartz + node-x11 3.1.2 +
+ntk 3.5.3, not assumed.
 
 Goal: a react-three-fiber-shaped component set — `<mesh>`, geometries,
 materials, lights, a camera — rendering through **indirect GLX**, i.e. the
@@ -166,7 +170,7 @@ the protocol limit: `shaderMaterial`, `<Effects>`, shadows,
 
 Each phase should land as its own PR with tests, per the usual workflow.
 
-**Phase 0 — unblock (upstream ntk).**
+**Phase 0 — unblock (upstream ntk). DONE — sidorares/ntk#85.**
 
 1. Use `MakeCurrent`'s returned context tag in
    `RenderingContextOpenGL`. Verified fix; this alone makes
@@ -178,10 +182,12 @@ Each phase should land as its own PR with tests, per the usual workflow.
    `GetVisualConfigs` path, choosing a visual with a depth buffer.
    Shelling out cannot work headlessly or on CI.
 
-**Phase 1 — surface.** `<glarea>` host element; `Canvas3D` with clear
-colour, viewport, frame loop on ntk's `requestAnimationFrame`, and
-`SwapBuffers`. Success: a window that clears to a colour and resizes
-correctly.
+**Phase 1 — surface. DONE.** `<glarea>` host element: a child X window on
+a GLX visual, sized by the parent's yoga rect, with clear colour, viewport,
+`onCreated`/`onDraw`, `SwapBuffers` and a demand-or-continuous frame loop
+on ntk's `requestAnimationFrame`. `Canvas3D` moves to phase 2 — the
+surface duties live in the host element, so the component only earns its
+keep once there is a scene tree to own.
 
 **Phase 2 — geometry.** Display-list compiler, `<mesh>`,
 `<bufferGeometry>` + the primitive geometries, `<meshBasicMaterial>`.

--- a/examples/gl.jsx
+++ b/examples/gl.jsx
@@ -1,0 +1,138 @@
+// <glarea>: an OpenGL surface in the flex layout, with 2D widgets around it.
+// The cube is compiled into a server-side display list once and replayed
+// with one CallList per frame — immediate-mode vertices would be ~50
+// commands on the wire every frame instead.
+//
+// Run with: npm run examples:gl  (needs an X server with indirect GLX)
+import React, { useState } from 'react';
+
+import { Button, Switch } from '../src/components/index.js';
+import { createRoot } from '../src/index.js';
+
+const CUBE_LIST = 1;
+
+// (x, y, z) corners of a unit cube, per face, with a face colour each
+const FACES = [
+  {
+    color: [0.16, 0.5, 0.73],
+    v: [
+      [-1, -1, 1],
+      [1, -1, 1],
+      [1, 1, 1],
+      [-1, 1, 1],
+    ],
+  },
+  {
+    color: [0.12, 0.4, 0.6],
+    v: [
+      [-1, -1, -1],
+      [-1, 1, -1],
+      [1, 1, -1],
+      [1, -1, -1],
+    ],
+  },
+  {
+    color: [0.9, 0.49, 0.13],
+    v: [
+      [-1, 1, -1],
+      [-1, 1, 1],
+      [1, 1, 1],
+      [1, 1, -1],
+    ],
+  },
+  {
+    color: [0.75, 0.4, 0.1],
+    v: [
+      [-1, -1, -1],
+      [1, -1, -1],
+      [1, -1, 1],
+      [-1, -1, 1],
+    ],
+  },
+  {
+    color: [0.15, 0.68, 0.38],
+    v: [
+      [1, -1, -1],
+      [1, 1, -1],
+      [1, 1, 1],
+      [1, -1, 1],
+    ],
+  },
+  {
+    color: [0.11, 0.55, 0.3],
+    v: [
+      [-1, -1, -1],
+      [-1, -1, 1],
+      [-1, 1, 1],
+      [-1, 1, -1],
+    ],
+  },
+];
+
+function compileCube(gl) {
+  gl.NewList(CUBE_LIST, gl.COMPILE);
+  gl.Begin(gl.QUADS);
+  for (const face of FACES) {
+    gl.Color3f(...face.color);
+    for (const [x, y, z] of face.v) gl.Vertex3f(x, y, z);
+  }
+  gl.End();
+  gl.EndList();
+}
+
+function Scene({ spinning }) {
+  const [angle, setAngle] = useState(25);
+
+  return (
+    <glarea
+      flexGrow={1}
+      clearColor="#12161f"
+      glx={{ DEPTH_SIZE: 24 }}
+      frameLoop={spinning ? 'always' : 'demand'}
+      onCreated={(gl) => {
+        gl.Enable(gl.DEPTH_TEST);
+        compileCube(gl);
+      }}
+      onDraw={(gl, { width, height }) => {
+        const aspect = height / Math.max(1, width);
+        gl.MatrixMode(gl.PROJECTION);
+        gl.LoadIdentity();
+        gl.Frustum(-1, 1, -aspect, aspect, 2.5, 20);
+        gl.MatrixMode(gl.MODELVIEW);
+        gl.LoadIdentity();
+        gl.Translatef(0, 0, -9);
+        gl.Rotatef(angle * 0.7, 1, 0, 0);
+        gl.Rotatef(angle, 0, 1, 0);
+        gl.CallList(CUBE_LIST);
+        if (spinning) setAngle((a) => a + 1.5);
+      }}
+    />
+  );
+}
+
+function App() {
+  const [spinning, setSpinning] = useState(true);
+
+  return (
+    <window width={520} height={400} title="react-x11 — <glarea>">
+      <box flexGrow={1} padding={12} gap={12} backgroundColor="#f4f6f8">
+        <Scene spinning={spinning} />
+        <box flexDirection="row" alignItems="center" gap={12}>
+          <Switch checked={spinning} onChange={setSpinning} />
+          <text fontSize={13}>Spin</text>
+          <box flexGrow={1} />
+          <Button onPress={() => setSpinning((s) => !s)}>
+            {spinning ? 'Pause' : 'Play'}
+          </Button>
+        </box>
+      </box>
+    </window>
+  );
+}
+
+export default App;
+
+if (!process.env.REACT_X11_NO_AUTORUN) {
+  const root = await createRoot();
+  root.render(<App />);
+}

--- a/examples/three.jsx
+++ b/examples/three.jsx
@@ -1,0 +1,85 @@
+// A react-three-fiber-shaped scene over indirect GLX: <Canvas3D> with
+// <mesh>, geometries and materials. Each geometry is compiled into a
+// server-side display list once — a frame is matrices plus one CallList per
+// mesh, whatever the triangle count.
+//
+// Run with: npm run examples:three  (needs an X server with indirect GLX)
+import React, { useEffect, useRef, useState } from 'react';
+
+import { Button, Canvas3D, Switch } from '../src/components/index.js';
+import { createRoot } from '../src/index.js';
+
+/** Advance a value every frame while `running`, via the window frame clock. */
+function useSpin(running, windowRef) {
+  const [angle, setAngle] = useState(0.6);
+  const frame = useRef(0);
+  useEffect(() => {
+    const wnd = windowRef.current;
+    if (!running || !wnd?.requestAnimationFrame) return;
+    let cancelled = false;
+    const tick = () => {
+      if (cancelled) return;
+      setAngle((a) => a + 0.02);
+      frame.current = wnd.requestAnimationFrame(tick);
+    };
+    frame.current = wnd.requestAnimationFrame(tick);
+    return () => {
+      cancelled = true;
+      wnd.cancelAnimationFrame?.(frame.current);
+    };
+  }, [running, windowRef]);
+  return angle;
+}
+
+function App() {
+  const windowRef = useRef(null);
+  const [running, setRunning] = useState(true);
+  const [wireframe, setWireframe] = useState(false);
+  const angle = useSpin(running, windowRef);
+
+  return (
+    <window ref={windowRef} width={560} height={460} title="react-x11 — 3D">
+      <box flexGrow={1} padding={12} gap={12} backgroundColor="#f4f6f8">
+        <Canvas3D
+          flexGrow={1}
+          clearColor="#12161f"
+          glx={{ DEPTH_SIZE: 24 }}
+          camera={{ position: [0, 2.6, 8.5], target: [0, -0.2, 0], fov: 45 }}
+        >
+          <group rotation={[0, angle, 0]}>
+            <mesh position={[-1.6, 0, 0]} rotation={[0.5, 0.4, 0]}>
+              <boxGeometry args={[1.4, 1.4, 1.4]} />
+              <meshBasicMaterial color="#2980b9" wireframe={wireframe} />
+            </mesh>
+            <mesh position={[1.6, 0, 0]}>
+              <sphereGeometry args={[0.9, 24, 16]} />
+              <meshBasicMaterial color="#e67e22" wireframe={wireframe} />
+            </mesh>
+            <mesh position={[0, -1.4, 0]} rotation={[Math.PI / 2, 0, 0]}>
+              <torusGeometry args={[1.1, 0.28, 12, 36]} />
+              <meshBasicMaterial color="#27ae60" wireframe={wireframe} />
+            </mesh>
+          </group>
+        </Canvas3D>
+
+        <box flexDirection="row" alignItems="center" gap={12}>
+          <Switch checked={running} onChange={setRunning} />
+          <text fontSize={13}>Spin</text>
+          <Switch checked={wireframe} onChange={setWireframe} />
+          <text fontSize={13}>Wireframe</text>
+          <box flexGrow={1} />
+          <Button onPress={() => setRunning((r) => !r)}>
+            {running ? 'Pause' : 'Play'}
+          </Button>
+        </box>
+      </box>
+    </window>
+  );
+}
+
+export default App;
+
+if (!process.env.REACT_X11_NO_AUTORUN) {
+  const root = await createRoot();
+  root.render(<App />);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^3.5.3",
+        "ntk": "^3.6.0",
         "react-reconciler": "^0.33.0"
       },
       "devDependencies": {
@@ -4071,9 +4071,9 @@
       }
     },
     "node_modules/ntk": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-3.5.3.tgz",
-      "integrity": "sha512-CExdcfHwAEyNIbzbWqv8OxQD4BAC/25RZ395k2V0PoiE8XULgbAGtg/wMgSvNyCtdVvLSRLVNuEt9PbPe42ITw==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-3.6.0.tgz",
+      "integrity": "sha512-o0X6vruHDEfl8+NA3lDxwV3nNuWmenIax59lxGjdCz0iYH9CD46cTxJjriUsV+iF/Xh3IssrvyeNDJ7LE+N7Kg==",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "examples:form": "tsx examples/form.jsx",
     "examples:richtext": "tsx examples/richtext.jsx",
     "examples:widgets": "tsx examples/widgets.jsx",
+    "examples:gl": "tsx examples/gl.jsx",
     "examples:windows": "tsx examples/windows.jsx",
     "screenshots": "tsx scripts/screenshots.jsx",
     "screenshots:framed": "tsx scripts/screenshots-framed.jsx",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^3.5.3",
+    "ntk": "^3.6.0",
     "react-reconciler": "^0.33.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "examples:richtext": "tsx examples/richtext.jsx",
     "examples:widgets": "tsx examples/widgets.jsx",
     "examples:gl": "tsx examples/gl.jsx",
+    "examples:three": "tsx examples/three.jsx",
     "examples:windows": "tsx examples/windows.jsx",
     "screenshots": "tsx scripts/screenshots.jsx",
     "screenshots:framed": "tsx scripts/screenshots-framed.jsx",

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -28,6 +28,7 @@ import {
   TextAreaNode,
 } from './nodes.js';
 import { GlAreaNode } from './glnodes.js';
+import { SCENE_KINDS, UNSUPPORTED_KINDS, createSceneNode } from './scene3d.js';
 import {
   MarkdownNode,
   HtmlNode,
@@ -91,7 +92,12 @@ const HostConfig = {
   scheduleMicrotask: queueMicrotask,
 
   getRootHostContext() {
-    return { isInsideText: false, isInsideSvg: false, isInsideRichText: false };
+    return {
+      isInsideText: false,
+      isInsideSvg: false,
+      isInsideRichText: false,
+      isInside3d: false,
+    };
   },
 
   getChildHostContext(parentHostContext, type) {
@@ -103,6 +109,8 @@ const HostConfig = {
       // (react-markdown style); no elements are allowed inside
       isInsideRichText:
         type === 'markdown' || type === 'html' || type === 'tex',
+      // inside <glarea> the children are scene nodes, not drawn nodes
+      isInside3d: parentHostContext.isInside3d || type === 'glarea',
     };
   },
 
@@ -137,6 +145,24 @@ const HostConfig = {
       throw new Error(
         `react-x11: <${type}> is not allowed inside <text>; only nested ` +
           '<text> spans and strings are.',
+      );
+    }
+    if (hostContext.isInside3d) {
+      const scene = createSceneNode(type, props, rootContainer);
+      if (scene) {
+        scene._reactFiber = internalHandle;
+        return scene;
+      }
+      if (UNSUPPORTED_KINDS[type]) {
+        throw new Error(
+          `react-x11: <${type}> cannot work over indirect GLX — ` +
+            `${UNSUPPORTED_KINDS[type]}. See docs/glx-plan.md.`,
+        );
+      }
+      throw new Error(
+        `react-x11: <${type}> is not a 3D element; inside <glarea> only ` +
+          [...SCENE_KINDS].map((t) => `<${t}>`).join(', ') +
+          ' are.',
       );
     }
     let node;
@@ -188,6 +214,12 @@ const HostConfig = {
         node = new GlAreaNode(props, rootContainer);
         break;
       default:
+        if (SCENE_KINDS.has(type) || UNSUPPORTED_KINDS[type]) {
+          throw new Error(
+            `react-x11: <${type}> is a 3D element and only works inside ` +
+              '<glarea> (or the <Canvas3D> component).',
+          );
+        }
         throw new Error(
           `react-x11: unknown element type <${type}>. Supported: ` +
             HOST_TYPES.map((t) => `<${t}>`).join(', ') +

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -27,6 +27,7 @@ import {
   TextInputNode,
   TextAreaNode,
 } from './nodes.js';
+import { GlAreaNode } from './glnodes.js';
 import {
   MarkdownNode,
   HtmlNode,
@@ -52,6 +53,7 @@ const HOST_TYPES = [
   'html',
   'svg',
   'tex',
+  'glarea',
 ];
 
 const isEventProp = (name) => /^on[A-Z]/.test(name);
@@ -181,6 +183,9 @@ const HostConfig = {
         break;
       case 'tex':
         node = new TexNode(props, rootContainer);
+        break;
+      case 'glarea':
+        node = new GlAreaNode(props, rootContainer);
         break;
       default:
         throw new Error(

--- a/src/components/Canvas3D.js
+++ b/src/components/Canvas3D.js
@@ -1,0 +1,28 @@
+import { createElement as h } from 'react';
+
+/**
+ * `<Canvas3D>` — the react-three-fiber-shaped entry point to the 3D scene.
+ * A thin wrapper over the `<glarea>` host element: it is the surface that
+ * owns the GL context, and the scene lives in its children.
+ *
+ * ```jsx
+ * <Canvas3D flexGrow={1} camera={{ position: [3, 3, 6], fov: 50 }}>
+ *   <mesh rotation={[0.4, 0.8, 0]}>
+ *     <boxGeometry args={[1, 1, 1]} />
+ *     <meshBasicMaterial color="#2980b9" />
+ *   </mesh>
+ * </Canvas3D>
+ * ```
+ *
+ * Props are `<glarea>`'s (layout props, `clearColor`, `frameLoop`, `glx`,
+ * `onCreated`, `onDraw`, `onError`) plus `camera`:
+ * `{ position, target, up, fov, near, far, orthographic, zoom }`.
+ *
+ * The name is `Canvas3D`, not r3f's `Canvas`, because react-x11 already has
+ * a `<canvas>` host element — the 2D `onDraw` escape hatch.
+ */
+export function Canvas3D({ children, ...props }) {
+  return h('glarea', props, children);
+}
+
+export default Canvas3D;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -13,3 +13,4 @@ export { Slider } from './Slider.js';
 export { Tooltip } from './Tooltip.js';
 export { ContextMenu, MenuBar } from './Menu.js';
 export { Select } from './Select.js';
+export { Canvas3D } from './Canvas3D.js';

--- a/src/geometry3d.js
+++ b/src/geometry3d.js
@@ -1,0 +1,223 @@
+// Geometry generators for the primitive `<*Geometry>` elements. Each takes
+// the same `args` tuple as its three.js counterpart and returns plain
+// arrays — positions, normals, uvs and a triangle index — which the display
+// list compiler turns into one server-side list (src/scene3d.js).
+
+/**
+ * Build a parametric surface as a (segmentsX+1) x (segmentsY+1) vertex grid.
+ * `point(u, v)` returns [position, normal] for u, v in 0..1.
+ */
+function grid(segmentsX, segmentsY, point) {
+  const positions = [];
+  const normals = [];
+  const uvs = [];
+  const index = [];
+  for (let iy = 0; iy <= segmentsY; iy++) {
+    for (let ix = 0; ix <= segmentsX; ix++) {
+      const u = ix / segmentsX;
+      const v = iy / segmentsY;
+      const [p, n] = point(u, v);
+      positions.push(p[0], p[1], p[2]);
+      normals.push(n[0], n[1], n[2]);
+      uvs.push(u, 1 - v);
+    }
+  }
+  const stride = segmentsX + 1;
+  for (let iy = 0; iy < segmentsY; iy++) {
+    for (let ix = 0; ix < segmentsX; ix++) {
+      const a = iy * stride + ix;
+      const b = a + 1;
+      const c = a + stride;
+      const d = c + 1;
+      index.push(a, c, b, b, c, d);
+    }
+  }
+  return { positions, normals, uvs, index };
+}
+
+function merge(parts) {
+  const out = { positions: [], normals: [], uvs: [], index: [] };
+  for (const part of parts) {
+    const offset = out.positions.length / 3;
+    out.positions.push(...part.positions);
+    out.normals.push(...part.normals);
+    out.uvs.push(...part.uvs);
+    for (const i of part.index) out.index.push(i + offset);
+  }
+  return out;
+}
+
+export function planeGeometry([width = 1, height = 1, ws = 1, hs = 1] = []) {
+  return grid(ws, hs, (u, v) => [
+    [(u - 0.5) * width, (0.5 - v) * height, 0],
+    [0, 0, 1],
+  ]);
+}
+
+export function boxGeometry([
+  width = 1,
+  height = 1,
+  depth = 1,
+  ws = 1,
+  hs = 1,
+  ds = 1,
+] = []) {
+  // one grid per face, oriented by (right, up, normal) basis vectors
+  const face = (right, up, normal, w, h, segU, segV, offset) =>
+    grid(segU, segV, (u, v) => {
+      const su = (u - 0.5) * w;
+      const sv = (0.5 - v) * h;
+      return [
+        [
+          right[0] * su + up[0] * sv + normal[0] * offset,
+          right[1] * su + up[1] * sv + normal[1] * offset,
+          right[2] * su + up[2] * sv + normal[2] * offset,
+        ],
+        normal,
+      ];
+    });
+
+  const x = width / 2;
+  const y = height / 2;
+  const z = depth / 2;
+  return merge([
+    face([0, 0, 1], [0, 1, 0], [-1, 0, 0], depth, height, ds, hs, x), // -x
+    face([0, 0, -1], [0, 1, 0], [1, 0, 0], depth, height, ds, hs, x), // +x
+    face([1, 0, 0], [0, 0, -1], [0, 1, 0], width, depth, ws, ds, y), // +y
+    face([1, 0, 0], [0, 0, 1], [0, -1, 0], width, depth, ws, ds, y), // -y
+    face([-1, 0, 0], [0, 1, 0], [0, 0, -1], width, height, ws, hs, z), // -z
+    face([1, 0, 0], [0, 1, 0], [0, 0, 1], width, height, ws, hs, z), // +z
+  ]);
+}
+
+export function sphereGeometry([radius = 1, ws = 32, hs = 16] = []) {
+  return grid(ws, hs, (u, v) => {
+    const theta = u * Math.PI * 2;
+    const phi = v * Math.PI;
+    const n = [
+      -Math.sin(phi) * Math.cos(theta),
+      Math.cos(phi),
+      Math.sin(phi) * Math.sin(theta),
+    ];
+    return [[n[0] * radius, n[1] * radius, n[2] * radius], n];
+  });
+}
+
+export function cylinderGeometry([
+  radiusTop = 1,
+  radiusBottom = 1,
+  height = 1,
+  radialSegments = 32,
+  heightSegments = 1,
+  openEnded = false,
+] = []) {
+  const half = height / 2;
+  const slope = (radiusBottom - radiusTop) / height;
+  const side = grid(radialSegments, heightSegments, (u, v) => {
+    const theta = u * Math.PI * 2;
+    const radius = radiusTop + (radiusBottom - radiusTop) * v;
+    const cos = Math.cos(theta);
+    const sin = Math.sin(theta);
+    const len = Math.hypot(1, slope) || 1;
+    return [
+      [radius * sin, half - v * height, radius * cos],
+      [sin / len, slope / len, cos / len],
+    ];
+  });
+  if (openEnded) return side;
+
+  // caps: a triangle fan around the centre, expressed as a 1-segment grid
+  const cap = (radius, y, dir) =>
+    grid(radialSegments, 1, (u, v) => {
+      const theta = u * Math.PI * 2 * dir;
+      const r = v * radius;
+      return [
+        [r * Math.sin(theta), y, r * Math.cos(theta)],
+        [0, dir, 0],
+      ];
+    });
+  const parts = [side];
+  if (radiusTop > 0) parts.push(cap(radiusTop, half, 1));
+  if (radiusBottom > 0) parts.push(cap(radiusBottom, -half, -1));
+  return merge(parts);
+}
+
+export function torusGeometry([
+  radius = 1,
+  tube = 0.4,
+  radialSegments = 12,
+  tubularSegments = 48,
+] = []) {
+  return grid(tubularSegments, radialSegments, (u, v) => {
+    const theta = u * Math.PI * 2;
+    const phi = v * Math.PI * 2;
+    const cx = radius * Math.cos(theta);
+    const cz = radius * Math.sin(theta);
+    const n = [
+      Math.cos(theta) * Math.cos(phi),
+      Math.sin(phi),
+      Math.sin(theta) * Math.cos(phi),
+    ];
+    return [[cx + tube * n[0], tube * n[1], cz + tube * n[2]], n];
+  });
+}
+
+export const GEOMETRY_BUILDERS = {
+  boxGeometry,
+  planeGeometry,
+  sphereGeometry,
+  cylinderGeometry,
+  torusGeometry,
+};
+
+/** `<bufferGeometry position={…} normal={…} uv={…} index={…} />` */
+export function bufferGeometry(props) {
+  const positions = props.position ?? props.positions ?? [];
+  const count = positions.length / 3;
+  let normals = props.normal ?? props.normals;
+  const index = props.index ?? null;
+  if (!normals) normals = faceNormals(positions, index, count);
+  return {
+    positions,
+    normals,
+    uvs: props.uv ?? props.uvs ?? new Array(count * 2).fill(0),
+    index,
+  };
+}
+
+/** Flat normals from the triangles themselves, averaged per vertex. */
+function faceNormals(positions, index, count) {
+  const normals = new Array(count * 3).fill(0);
+  const tri = index ?? Array.from({ length: count }, (_, i) => i);
+  for (let i = 0; i + 2 < tri.length; i += 3) {
+    const [a, b, c] = [tri[i], tri[i + 1], tri[i + 2]];
+    const ax = positions[a * 3];
+    const ay = positions[a * 3 + 1];
+    const az = positions[a * 3 + 2];
+    const ux = positions[b * 3] - ax;
+    const uy = positions[b * 3 + 1] - ay;
+    const uz = positions[b * 3 + 2] - az;
+    const vx = positions[c * 3] - ax;
+    const vy = positions[c * 3 + 1] - ay;
+    const vz = positions[c * 3 + 2] - az;
+    const nx = uy * vz - uz * vy;
+    const ny = uz * vx - ux * vz;
+    const nz = ux * vy - uy * vx;
+    for (const v of [a, b, c]) {
+      normals[v * 3] += nx;
+      normals[v * 3 + 1] += ny;
+      normals[v * 3 + 2] += nz;
+    }
+  }
+  for (let i = 0; i < normals.length; i += 3) {
+    const len = Math.hypot(normals[i], normals[i + 1], normals[i + 2]);
+    if (len > 0) {
+      normals[i] /= len;
+      normals[i + 1] /= len;
+      normals[i + 2] /= len;
+    } else {
+      normals[i + 1] = 1;
+    }
+  }
+  return normals;
+}

--- a/src/glnodes.js
+++ b/src/glnodes.js
@@ -1,0 +1,228 @@
+// <glarea>: the one drawn element that owns a real X window.
+//
+// GLX needs a drawable created for a GL-capable visual, and GL output cannot
+// share the parent window's XRender pipeline — so this is a child X window
+// (NEXT_STEPS §4), sized and positioned by the parent's yoga layout like any
+// other drawn node. Everything about the surface is here; the scene graph
+// that draws into it comes later (docs/glx-plan.md).
+import { cssColor } from 'ntk';
+
+import { Node } from './nodes.js';
+
+// One visual query per (app, spec): GetFBConfigs is a round trip and every
+// <glarea> in an app wants the same answer.
+const configCache = new WeakMap();
+
+export function glxConfig(app, spec) {
+  const key = JSON.stringify(spec ?? null);
+  let perApp = configCache.get(app);
+  if (!perApp) configCache.set(app, (perApp = new Map()));
+  let promise = perApp.get(key);
+  if (!promise) {
+    promise =
+      typeof app.chooseGLXConfig === 'function'
+        ? app.chooseGLXConfig(spec)
+        : Promise.reject(
+            new Error(
+              'react-x11: <glarea> needs ntk >= 3.6.0 (app.chooseGLXConfig)',
+            ),
+          );
+    perApp.set(key, promise);
+  }
+  return promise;
+}
+
+/** clearColor as a CSS string or an [r, g, b, a] float tuple. */
+function clearColorOf(props) {
+  const value = props.clearColor ?? 'black';
+  if (Array.isArray(value)) return value.length === 4 ? value : [...value, 1];
+  const parsed = cssColor(value);
+  return parsed ?? [0, 0, 0, 1];
+}
+
+const px = (v) => Math.max(1, Math.round(v || 0));
+
+/**
+ * `<glarea>` — an OpenGL surface in the layout.
+ *
+ * ```jsx
+ * <glarea flexGrow={1} clearColor="#0b1021" frameLoop="always"
+ *         onDraw={(gl, { width, height }) => { ... }} />
+ * ```
+ *
+ * Props: layout props as usual, plus
+ * - `onDraw(gl, { width, height, node })` — draw a frame. The viewport and
+ *   the clear are already done; `SwapBuffers` follows.
+ * - `onCreated(gl, { width, height, node })` — once, when the context is
+ *   current: one-time GL state (`Enable(DEPTH_TEST)`, display lists).
+ * - `clearColor` — CSS colour or `[r, g, b, a]` floats (default black).
+ * - `frameLoop` — `'demand'` (default: redraw on prop/size/expose changes)
+ *   or `'always'` (drive ntk's frame clock continuously).
+ * - `glx` — a `chooseGLXConfig` spec, e.g. `{ DEPTH_SIZE: 24 }`.
+ *
+ * The X child window is stacked above everything drawn in the parent, so 2D
+ * content cannot overlap it — put HUD content in a sibling `<popup>`.
+ */
+export class GlAreaNode extends Node {
+  constructor(props, app) {
+    super('glarea', props, app);
+    this.window = null;
+    this.gl = null;
+    this.rect = null; // geometry last sent to the X window
+    this._realizing = false;
+    this._frameScheduled = false;
+    this._created = false;
+  }
+
+  get isGlArea() {
+    return true;
+  }
+
+  _setRoot(root) {
+    super._setRoot(root);
+    // the owning window may already exist (a <glarea> mounted into a live
+    // tree); otherwise WindowNode.realize picks the subtree up
+    if (root?.window) this.realize();
+  }
+
+  /** Create the GL child window. Async: the visual comes from the server. */
+  realize() {
+    if (this.window || this.destroyed || this._realizing) return;
+    const parent = this.root?.window;
+    if (!parent || typeof this.app?.createWindow !== 'function') return;
+    this._realizing = true;
+    glxConfig(this.app, this.props.glx).then(
+      (config) => {
+        this._realizing = false;
+        if (this.destroyed || this.window) return;
+        this._create(config, parent);
+      },
+      (err) => {
+        this._realizing = false;
+        this.error = err;
+        this.props.onError?.(err);
+        if (!this.props.onError) {
+          console.warn(`react-x11: <glarea> has no GL surface: ${err.message}`);
+        }
+      },
+    );
+  }
+
+  _create(config, parent) {
+    const rect = this._geometry();
+    const wnd = this.app.createWindow({
+      parent,
+      x: rect.x,
+      y: rect.y,
+      width: rect.width,
+      height: rect.height,
+      visual: config.visual,
+      depth: config.depth,
+      // GL draws into the window itself: no 2d backing pixmap, and the
+      // frame clock is ours to drive
+      backingStore: false,
+    });
+    this.window = wnd;
+    this.rect = rect;
+    this.config = config;
+    wnd._reactX11Node = this;
+    this.gl = wnd.getContext('opengl', config);
+    wnd.on?.('expose', () => this.requestFrame());
+    wnd.map?.();
+    this.requestFrame();
+  }
+
+  _geometry() {
+    return {
+      x: Math.round(this.abs.x),
+      y: Math.round(this.abs.y),
+      width: px(this.abs.width),
+      height: px(this.abs.height),
+    };
+  }
+
+  absolutize(originX, originY) {
+    super.absolutize(originX, originY);
+    this._syncGeometry();
+  }
+
+  _syncGeometry() {
+    const wnd = this.window;
+    if (!wnd) return;
+    const rect = this._geometry();
+    const prev = this.rect;
+    if (
+      prev &&
+      prev.x === rect.x &&
+      prev.y === rect.y &&
+      prev.width === rect.width &&
+      prev.height === rect.height
+    ) {
+      return;
+    }
+    this.rect = rect;
+    if (typeof wnd.setState === 'function') wnd.setState(rect);
+    else {
+      wnd.move?.(rect.x, rect.y);
+      wnd.resize?.(rect.width, rect.height);
+    }
+    this.requestFrame();
+  }
+
+  /** Draw one frame on the child window's next frame tick. */
+  requestFrame() {
+    if (!this.window || this.destroyed || this._frameScheduled) return;
+    this._frameScheduled = true;
+    const schedule =
+      typeof this.window.requestAnimationFrame === 'function'
+        ? (cb) => this.window.requestAnimationFrame(cb)
+        : (cb) => setImmediate(cb);
+    schedule(() => {
+      this._frameScheduled = false;
+      this._drawFrame();
+    });
+  }
+
+  _drawFrame() {
+    const gl = this.gl;
+    if (!gl || this.destroyed) return;
+    const { width, height } = this.rect;
+    const info = { width, height, node: this };
+    if (!this._created) {
+      this._created = true;
+      this.props.onCreated?.(gl, info);
+    }
+    gl.Viewport(0, 0, width, height);
+    const [r, g, b, a] = clearColorOf(this.props);
+    gl.ClearColor(r, g, b, a);
+    gl.Clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+    this.props.onDraw?.(gl, info);
+    gl.SwapBuffers();
+    if (this.props.frameLoop === 'always') this.requestFrame();
+  }
+
+  applyProps(newProps, oldProps) {
+    super.applyProps(newProps, oldProps);
+    // onDraw/clearColor are read at frame time, so any update is a new frame
+    this.requestFrame();
+  }
+
+  setHidden(hidden) {
+    super.setHidden(hidden);
+    if (hidden) this.window?.unmap?.();
+    else this.window?.map?.();
+  }
+
+  // the child window covers this rect: nothing to paint into the parent's
+  // 2d context, and no drawn children are allowed under it
+  paint() {}
+
+  destroySubtree() {
+    if (this.destroyed) return;
+    super.destroySubtree();
+    this.gl?.destroy?.();
+    this.gl = null;
+    this.window?.destroy?.();
+    this.window = null;
+  }
+}

--- a/src/glnodes.js
+++ b/src/glnodes.js
@@ -8,6 +8,7 @@
 import { cssColor } from 'ntk';
 
 import { Node } from './nodes.js';
+import { SceneRenderer } from './scene3d.js';
 
 // One visual query per (app, spec): GetFBConfigs is a round trip and every
 // <glarea> in an app wants the same answer.
@@ -72,6 +73,7 @@ export class GlAreaNode extends Node {
     this._realizing = false;
     this._frameScheduled = false;
     this._created = false;
+    this.scene = new SceneRenderer(this);
   }
 
   get isGlArea() {
@@ -196,6 +198,7 @@ export class GlAreaNode extends Node {
     const [r, g, b, a] = clearColorOf(this.props);
     gl.ClearColor(r, g, b, a);
     gl.Clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+    this.scene.render(gl, info);
     this.props.onDraw?.(gl, info);
     gl.SwapBuffers();
     if (this.props.frameLoop === 'always') this.requestFrame();
@@ -213,6 +216,26 @@ export class GlAreaNode extends Node {
     else this.window?.map?.();
   }
 
+  /** scene children (<mesh>, <group>, …) attach to this surface. */
+  insertBefore(child, beforeChild) {
+    super.insertBefore(child, beforeChild);
+    child._setSurface?.(this);
+    this.requestFrame();
+  }
+
+  removeChild(child) {
+    super.removeChild(child);
+    this.invalidateGeometry(child);
+    this.requestFrame();
+  }
+
+  /** A removed geometry's display list is no longer needed server-side. */
+  invalidateGeometry(node) {
+    if (!node) return;
+    if (node.isGeometry) this.scene.forget(this.gl, node);
+    for (const child of node.children ?? []) this.invalidateGeometry(child);
+  }
+
   // the child window covers this rect: nothing to paint into the parent's
   // 2d context, and no drawn children are allowed under it
   paint() {}
@@ -220,6 +243,7 @@ export class GlAreaNode extends Node {
   destroySubtree() {
     if (this.destroyed) return;
     super.destroySubtree();
+    this.scene.dispose(this.gl);
     this.gl?.destroy?.();
     this.gl = null;
     this.window?.destroy?.();

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ export {
   ContextMenu,
   useAnchor,
   anchorRect,
+  Canvas3D,
 } from './components/index.js';
 
 import { render, createRoot, unmountComponentAtNode } from './Reconciler.js';

--- a/src/mat4.js
+++ b/src/mat4.js
@@ -1,0 +1,158 @@
+// 4x4 matrices in OpenGL's column-major order, as Float32Array(16) — the
+// layout MultMatrixf/LoadMatrixf expect on the wire, so nothing is
+// transposed on the way out.
+
+export function identity() {
+  // prettier-ignore
+  return new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+}
+
+/** out = a * b (apply b first, then a — same convention as GL). */
+export function multiply(a, b, out = new Float32Array(16)) {
+  for (let col = 0; col < 4; col++) {
+    const b0 = b[col * 4];
+    const b1 = b[col * 4 + 1];
+    const b2 = b[col * 4 + 2];
+    const b3 = b[col * 4 + 3];
+    for (let row = 0; row < 4; row++) {
+      out[col * 4 + row] =
+        a[row] * b0 + a[4 + row] * b1 + a[8 + row] * b2 + a[12 + row] * b3;
+    }
+  }
+  return out;
+}
+
+/**
+ * Compose position / euler rotation (XYZ order, radians) / scale into a
+ * transform, the same order three.js uses: T * Rx * Ry * Rz * S.
+ */
+export function compose(position, rotation, scale, out = new Float32Array(16)) {
+  const [px, py, pz] = position;
+  const [rx, ry, rz] = rotation;
+  const [sx, sy, sz] = scale;
+  const cx = Math.cos(rx);
+  const sxr = Math.sin(rx);
+  const cy = Math.cos(ry);
+  const syr = Math.sin(ry);
+  const cz = Math.cos(rz);
+  const szr = Math.sin(rz);
+
+  // rotation matrix for the XYZ euler order
+  const r00 = cy * cz;
+  const r01 = -cy * szr;
+  const r02 = syr;
+  const r10 = sxr * syr * cz + cx * szr;
+  const r11 = -sxr * syr * szr + cx * cz;
+  const r12 = -sxr * cy;
+  const r20 = -cx * syr * cz + sxr * szr;
+  const r21 = cx * syr * szr + sxr * cz;
+  const r22 = cx * cy;
+
+  out[0] = r00 * sx;
+  out[1] = r10 * sx;
+  out[2] = r20 * sx;
+  out[3] = 0;
+  out[4] = r01 * sy;
+  out[5] = r11 * sy;
+  out[6] = r21 * sy;
+  out[7] = 0;
+  out[8] = r02 * sz;
+  out[9] = r12 * sz;
+  out[10] = r22 * sz;
+  out[11] = 0;
+  out[12] = px;
+  out[13] = py;
+  out[14] = pz;
+  out[15] = 1;
+  return out;
+}
+
+/** Perspective projection; `fov` is the vertical field of view in degrees. */
+export function perspective(
+  fov,
+  aspect,
+  near,
+  far,
+  out = new Float32Array(16),
+) {
+  const f = 1 / Math.tan((fov * Math.PI) / 360);
+  out.fill(0);
+  out[0] = f / aspect;
+  out[5] = f;
+  out[10] = (far + near) / (near - far);
+  out[11] = -1;
+  out[14] = (2 * far * near) / (near - far);
+  return out;
+}
+
+export function orthographic(
+  left,
+  right,
+  bottom,
+  top,
+  near,
+  far,
+  out = new Float32Array(16),
+) {
+  out.fill(0);
+  out[0] = 2 / (right - left);
+  out[5] = 2 / (top - bottom);
+  out[10] = -2 / (far - near);
+  out[12] = -(right + left) / (right - left);
+  out[13] = -(top + bottom) / (top - bottom);
+  out[14] = -(far + near) / (far - near);
+  out[15] = 1;
+  return out;
+}
+
+function normalize(v) {
+  const len = Math.hypot(v[0], v[1], v[2]) || 1;
+  return [v[0] / len, v[1] / len, v[2] / len];
+}
+
+function cross(a, b) {
+  return [
+    a[1] * b[2] - a[2] * b[1],
+    a[2] * b[0] - a[0] * b[2],
+    a[0] * b[1] - a[1] * b[0],
+  ];
+}
+
+/** View matrix for a camera at `eye` looking at `target`. */
+export function lookAt(
+  eye,
+  target,
+  up = [0, 1, 0],
+  out = new Float32Array(16),
+) {
+  const z = normalize([
+    eye[0] - target[0],
+    eye[1] - target[1],
+    eye[2] - target[2],
+  ]);
+  let x = cross(up, z);
+  if (Math.hypot(x[0], x[1], x[2]) < 1e-6) {
+    // up is parallel to the view direction: nudge it so the basis stays sane
+    x = cross([up[0] + 1e-4, up[1], up[2] + 1e-4], z);
+  }
+  x = normalize(x);
+  const y = cross(z, x);
+
+  out[0] = x[0];
+  out[1] = y[0];
+  out[2] = z[0];
+  out[3] = 0;
+  out[4] = x[1];
+  out[5] = y[1];
+  out[6] = z[1];
+  out[7] = 0;
+  out[8] = x[2];
+  out[9] = y[2];
+  out[10] = z[2];
+  out[11] = 0;
+  out[12] = -(x[0] * eye[0] + x[1] * eye[1] + x[2] * eye[2]);
+  out[13] = -(y[0] * eye[0] + y[1] * eye[1] + y[2] * eye[2]);
+  out[14] = -(z[0] * eye[0] + z[1] * eye[1] + z[2] * eye[2]);
+  out[15] = 1;
+  return out;
+}

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -1474,8 +1474,19 @@ export class WindowNode extends Node {
         child.realize(wnd);
       }
     }
+    // <glarea>s mounted before the window existed own a child X window too
+    this._realizeGlAreas(this);
     wnd.map?.();
     this.invalidate(true);
+  }
+
+  /** Walk the drawn subtree and give every <glarea> its child X window. */
+  _realizeGlAreas(node) {
+    for (const child of node.children) {
+      if (child.isWindow) continue;
+      if (child.isGlArea) child.realize();
+      else this._realizeGlAreas(child);
+    }
   }
 
   /**

--- a/src/scene3d.js
+++ b/src/scene3d.js
@@ -1,0 +1,390 @@
+// The 3D scene tree: `<mesh>`, `<group>`, geometries and materials living
+// inside a `<glarea>`, drawn through indirect GLX (docs/glx-plan.md).
+//
+// It is deliberately separate from the 2D drawn tree — no yoga, no painting
+// into the parent's 2d context. The rule that shapes everything here is a
+// protocol one: GLX encodes no vertex arrays, so geometry can only travel as
+// immediate-mode commands. Sending a mesh per frame costs kilobytes per
+// frame, so every geometry is compiled into a **server-side display list**
+// once and replayed with a single CallList. A frame is then matrices +
+// material state + one CallList per mesh, whatever the triangle count.
+import { cssColor } from 'ntk';
+
+import {
+  GEOMETRY_BUILDERS,
+  bufferGeometry as buildBufferGeometry,
+} from './geometry3d.js';
+import {
+  compose,
+  identity,
+  lookAt,
+  orthographic,
+  perspective,
+} from './mat4.js';
+import { Node } from './nodes.js';
+
+export const GEOMETRY_KINDS = new Set([
+  ...Object.keys(GEOMETRY_BUILDERS),
+  'bufferGeometry',
+]);
+export const MATERIAL_KINDS = new Set([
+  'meshBasicMaterial',
+  'meshLambertMaterial',
+  'meshPhongMaterial',
+]);
+export const OBJECT_KINDS = new Set(['mesh', 'group']);
+export const SCENE_KINDS = new Set([
+  ...GEOMETRY_KINDS,
+  ...MATERIAL_KINDS,
+  ...OBJECT_KINDS,
+]);
+
+/**
+ * react-three-fiber names that indirect GLX cannot implement — the protocol
+ * encodes no shaders, no framebuffer objects and no instancing, so these
+ * fail loudly instead of rendering something that only looks right.
+ */
+export const UNSUPPORTED_KINDS = {
+  shaderMaterial: 'GLSL shaders: the GLX protocol encodes no shader objects',
+  rawShaderMaterial: 'GLSL shaders: the GLX protocol encodes no shader objects',
+  instancedMesh: 'instancing: no vertex arrays or instanced draw commands',
+  points: 'point clouds need vertex arrays, which GLX does not encode',
+  line: 'line geometry needs vertex arrays, which GLX does not encode',
+  effectComposer: 'post-processing needs framebuffer objects',
+};
+
+const asTriple = (value, fallback) => {
+  if (value == null) return fallback;
+  if (typeof value === 'number') return [value, value, value];
+  return [value[0] ?? 0, value[1] ?? 0, value[2] ?? 0];
+};
+
+/** Base for anything with a transform: `<mesh>`, `<group>`. */
+export class Object3DNode extends Node {
+  constructor(kind, props, app) {
+    super(kind, props, app, { yoga: false });
+    this.surface = null; // owning GlAreaNode
+    this._matrix = identity();
+    this._matrixDirty = true;
+  }
+
+  get isObject3D() {
+    return true;
+  }
+
+  /** scene nodes are not part of the 2D tree; they follow the surface. */
+  _setRoot() {}
+
+  _setSurface(surface) {
+    if (this.surface === surface) return;
+    this.surface = surface;
+    for (const child of this.children) child._setSurface?.(surface);
+  }
+
+  insertBefore(child, beforeChild) {
+    super.insertBefore(child, beforeChild);
+    child._setSurface?.(this.surface);
+    this.surface?.requestFrame();
+  }
+
+  removeChild(child) {
+    super.removeChild(child);
+    this.surface?.invalidateGeometry?.(child);
+    this.surface?.requestFrame();
+  }
+
+  applyProps(newProps) {
+    this.props = newProps;
+    this._matrixDirty = true;
+    this.surface?.requestFrame();
+  }
+
+  setHidden(hidden) {
+    this.hidden = hidden;
+    this.surface?.requestFrame();
+  }
+
+  localMatrix() {
+    if (this._matrixDirty) {
+      const p = this.props;
+      compose(
+        asTriple(p.position, [0, 0, 0]),
+        asTriple(p.rotation, [0, 0, 0]),
+        asTriple(p.scale, [1, 1, 1]),
+        this._matrix,
+      );
+      this._matrixDirty = false;
+    }
+    return this._matrix;
+  }
+
+  get visible() {
+    return !this.hidden && this.props.visible !== false;
+  }
+}
+
+export class MeshNode extends Object3DNode {
+  constructor(props, app) {
+    super('mesh', props, app);
+  }
+
+  get geometry() {
+    return this.children.find((c) => c.isGeometry) ?? null;
+  }
+
+  get material() {
+    return this.children.find((c) => c.isMaterial) ?? null;
+  }
+}
+
+export class GroupNode extends Object3DNode {
+  constructor(props, app) {
+    super('group', props, app);
+  }
+}
+
+/** `<boxGeometry args={[1, 1, 1]} />`, `<bufferGeometry position={…} />` */
+export class GeometryNode extends Object3DNode {
+  constructor(kind, props, app) {
+    super(kind, props, app);
+    this.version = 0;
+    this._data = null;
+  }
+
+  get isObject3D() {
+    return false;
+  }
+
+  get isGeometry() {
+    return true;
+  }
+
+  applyProps(newProps) {
+    const before = this.props;
+    this.props = newProps;
+    if (!sameGeometryProps(before, newProps)) {
+      // a new shape: drop the cached arrays and the server-side list
+      this._data = null;
+      this.version++;
+    }
+    this.surface?.requestFrame();
+  }
+
+  /** { positions, normals, uvs, index } — memoized per prop version. */
+  data() {
+    if (!this._data) {
+      const build = GEOMETRY_BUILDERS[this.kind];
+      this._data = build
+        ? build(this.props.args ?? [])
+        : buildBufferGeometry(this.props);
+    }
+    return this._data;
+  }
+}
+
+function sameGeometryProps(a, b) {
+  if (a === b) return true;
+  const keys = new Set([...Object.keys(a ?? {}), ...Object.keys(b ?? {})]);
+  for (const key of keys) {
+    const av = a?.[key];
+    const bv = b?.[key];
+    if (av === bv) continue;
+    if (Array.isArray(av) && Array.isArray(bv)) {
+      if (av.length !== bv.length || av.some((v, i) => v !== bv[i]))
+        return false;
+      continue;
+    }
+    return false;
+  }
+  return true;
+}
+
+/** `<meshBasicMaterial color="#2980b9" wireframe />` */
+export class MaterialNode extends Object3DNode {
+  constructor(kind, props, app) {
+    super(kind, props, app);
+  }
+
+  get isObject3D() {
+    return false;
+  }
+
+  get isMaterial() {
+    return true;
+  }
+}
+
+export function createSceneNode(kind, props, app) {
+  if (kind === 'mesh') return new MeshNode(props, app);
+  if (kind === 'group') return new GroupNode(props, app);
+  if (GEOMETRY_KINDS.has(kind)) return new GeometryNode(kind, props, app);
+  if (MATERIAL_KINDS.has(kind)) return new MaterialNode(kind, props, app);
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// rendering
+
+const DEFAULT_CAMERA = {
+  position: [0, 0, 5],
+  target: [0, 0, 0],
+  up: [0, 1, 0],
+  fov: 50,
+  near: 0.1,
+  far: 1000,
+  zoom: 1,
+};
+
+function cameraMatrices(spec, { width, height }) {
+  const camera = { ...DEFAULT_CAMERA, ...spec };
+  const aspect = width / Math.max(1, height);
+  const projection = camera.orthographic
+    ? orthographic(
+        -aspect / camera.zoom,
+        aspect / camera.zoom,
+        -1 / camera.zoom,
+        1 / camera.zoom,
+        camera.near,
+        camera.far,
+      )
+    : perspective(camera.fov, aspect, camera.near, camera.far);
+  return {
+    projection,
+    view: lookAt(camera.position, camera.target, camera.up),
+  };
+}
+
+const rgba = (color, fallback = [1, 1, 1, 1]) => {
+  if (!color) return fallback;
+  if (Array.isArray(color)) return color.length === 4 ? color : [...color, 1];
+  return cssColor(color) ?? fallback;
+};
+
+/**
+ * Per-surface GL bookkeeping: the display list of every geometry, and the
+ * material state last sent (so an unchanged material costs nothing).
+ */
+export class SceneRenderer {
+  constructor(surface) {
+    this.surface = surface;
+    this.lists = new Map(); // GeometryNode -> { id, version }
+    this.nextList = 1;
+    this.materialKey = null;
+    this.initialized = false;
+  }
+
+  /** Draw the scene under `surface`; false when there is nothing 3D to draw. */
+  render(gl, info) {
+    const roots = this.surface.children.filter((c) => c.isObject3D);
+    if (roots.length === 0) return false;
+
+    if (!this.initialized) {
+      this.initialized = true;
+      gl.Enable(gl.DEPTH_TEST);
+      gl.Enable(gl.NORMALIZE); // scaled meshes keep unit-length normals
+      gl.ShadeModel(gl.SMOOTH);
+    }
+    this.materialKey = null;
+
+    const { projection, view } = cameraMatrices(
+      this.surface.props.camera,
+      info,
+    );
+    gl.MatrixMode(gl.PROJECTION);
+    gl.LoadIdentity();
+    gl.MultMatrixf(projection);
+    gl.MatrixMode(gl.MODELVIEW);
+    gl.LoadIdentity();
+    gl.MultMatrixf(view);
+
+    for (const node of roots) this.drawObject(gl, node);
+    return true;
+  }
+
+  drawObject(gl, node) {
+    if (!node.visible) return;
+    gl.PushMatrix();
+    gl.MultMatrixf(node.localMatrix());
+    if (node.kind === 'mesh') this.drawMesh(gl, node);
+    for (const child of node.children) {
+      if (child.isObject3D) this.drawObject(gl, child);
+    }
+    gl.PopMatrix();
+  }
+
+  drawMesh(gl, mesh) {
+    const geometry = mesh.geometry;
+    if (!geometry) return;
+    this.applyMaterial(gl, mesh.material);
+    gl.CallList(this.listFor(gl, geometry));
+  }
+
+  /** Compile once, replay forever — this is the whole point of the design. */
+  listFor(gl, geometry) {
+    const cached = this.lists.get(geometry);
+    if (cached && cached.version === geometry.version) return cached.id;
+    const id = cached ? cached.id : this.nextList++;
+    const { positions, normals, uvs, index } = geometry.data();
+    const count = index ? index.length : positions.length / 3;
+
+    gl.NewList(id, gl.COMPILE);
+    gl.Begin(gl.TRIANGLES);
+    for (let i = 0; i < count; i++) {
+      const v = index ? index[i] : i;
+      if (normals && normals.length > v * 3 + 2) {
+        gl.Normal3f(normals[v * 3], normals[v * 3 + 1], normals[v * 3 + 2]);
+      }
+      if (uvs && uvs.length > v * 2 + 1) {
+        gl.TexCoord2f(uvs[v * 2], uvs[v * 2 + 1]);
+      }
+      gl.Vertex3f(positions[v * 3], positions[v * 3 + 1], positions[v * 3 + 2]);
+    }
+    gl.End();
+    gl.EndList();
+
+    this.lists.set(geometry, { id, version: geometry.version });
+    return id;
+  }
+
+  /** Material state is per frame, so one geometry list can serve many meshes. */
+  applyMaterial(gl, material) {
+    const props = material?.props ?? {};
+    const [r, g, b, a] = rgba(props.color);
+    const opacity = props.opacity ?? 1;
+    const alpha = a * opacity;
+    const key = `${material?.kind}|${r},${g},${b},${alpha}|${props.wireframe}|${props.side}|${props.transparent}`;
+    if (key === this.materialKey) return;
+    this.materialKey = key;
+
+    // <meshBasicMaterial> is unlit; the lit materials arrive with the lights
+    gl.Disable(gl.LIGHTING);
+    if (alpha < 1 || props.transparent) {
+      gl.Enable(gl.BLEND);
+      gl.BlendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
+      gl.Color4f(r, g, b, alpha);
+    } else {
+      gl.Disable(gl.BLEND);
+      gl.Color3f(r, g, b);
+    }
+    gl.PolygonMode(gl.FRONT_AND_BACK, props.wireframe ? gl.LINE : gl.FILL);
+    if (props.side === 'double') {
+      gl.Disable(gl.CULL_FACE);
+    } else {
+      gl.Enable(gl.CULL_FACE);
+      gl.CullFace(props.side === 'back' ? gl.FRONT : gl.BACK);
+    }
+  }
+
+  /** Drop a removed geometry's list so the id can be reused. */
+  forget(gl, node) {
+    const entry = this.lists.get(node);
+    if (!entry) return;
+    this.lists.delete(node);
+    gl?.DeleteLists?.(entry.id, 1);
+  }
+
+  dispose(gl) {
+    for (const { id } of this.lists.values()) gl?.DeleteLists?.(id, 1);
+    this.lists.clear();
+  }
+}

--- a/test/glarea.test.js
+++ b/test/glarea.test.js
@@ -1,0 +1,215 @@
+// <glarea>: the GL surface element. Hermetic — node-x11's in-process X
+// server with its GLX emulator (x11/browser/glx) registered as an extension,
+// so the GL commands a frame emits land as calls on a RecordingBackend and
+// the whole path (visual query -> child window -> context tag -> frame) is
+// asserted without a display or a GPU.
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { test } from 'node:test';
+
+import React from 'react';
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient, StaticFontSource } from 'ntk';
+
+import ReactX11 from '../src/index.js';
+
+const require = createRequire(import.meta.url);
+const { createGlxExtension, RecordingBackend } = require('x11/browser/glx');
+
+const h = React.createElement;
+
+async function createGlApp() {
+  const server = xserver.createServer({ width: 640, height: 480 });
+  const backend = new RecordingBackend();
+  const surfaces = new Map();
+  server.registerExtension(
+    'GLX',
+    createGlxExtension({
+      backend,
+      getDrawableSurface: (xid) => surfaces.get(xid) || null,
+    }),
+  );
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const xErrors = [];
+  const app = await createClient({
+    stream: clientEnd,
+    fontSource: new StaticFontSource(),
+    onXError: (err) => xErrors.push(err),
+  });
+  return { app, backend, xErrors };
+}
+
+const render = (element, app) =>
+  new Promise((resolve) => ReactX11.render(element, resolve, app));
+
+const settle = async (app, roundTrips = 3) => {
+  for (let i = 0; i < roundTrips; i++) {
+    await new Promise((resolve, reject) =>
+      app.X.GetInputFocus((err) => (err ? reject(err) : resolve())),
+    );
+  }
+};
+
+// the frame runs on the child window's frame clock (a fenced round trip),
+// so poll rather than guess how many ticks it takes
+async function waitFor(check, what, timeout = 3000) {
+  const deadline = Date.now() + timeout;
+  for (;;) {
+    if (check()) return;
+    if (Date.now() > deadline) assert.fail(`timed out waiting for ${what}`);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+const getAttributes = (app, wid) =>
+  new Promise((resolve, reject) =>
+    app.X.GetWindowAttributes(wid, (err, attrs) =>
+      err ? reject(err) : resolve(attrs),
+    ),
+  );
+
+test('<glarea> gets a GL child window and draws a frame', async () => {
+  const { app, backend, xErrors } = await createGlApp();
+  try {
+    const drawn = [];
+    const instance = await render(
+      h(
+        'window',
+        { width: 320, height: 240 },
+        h('box', { padding: 20, flexGrow: 1 }, [
+          h('glarea', {
+            key: 'gl',
+            flexGrow: 1,
+            clearColor: '#3366cc',
+            onCreated: (gl) => gl.Enable(gl.DEPTH_TEST),
+            onDraw: (gl, info) => {
+              drawn.push(info);
+              gl.Begin(gl.TRIANGLES);
+              gl.Vertex3f(0, 0, 0);
+              gl.End();
+            },
+          }),
+        ]),
+      ),
+      app,
+    );
+
+    await waitFor(() => drawn.length > 0, 'the first frame');
+    await settle(app);
+
+    const node = instance._reactX11Node;
+    const area = node.children[0].children[0];
+    assert.equal(area.kind, 'glarea');
+    assert.ok(area.window, '<glarea> owns a real X window');
+    assert.ok(area.gl.contextTag > 0, 'the GL context is current');
+
+    // yoga sized it: 320x240 window, 20px padding all round
+    assert.deepEqual(
+      { width: area.rect.width, height: area.rect.height },
+      { width: 280, height: 200 },
+    );
+    assert.deepEqual(drawn[0], {
+      width: 280,
+      height: 200,
+      node: area,
+    });
+
+    const attrs = await getAttributes(app, area.window.id);
+    assert.equal(
+      attrs.visual,
+      area.config.visual,
+      'the child window uses the GL visual',
+    );
+
+    // onCreated first, then viewport/clear/user draw for the frame. A GL
+    // window has no backing store, so the Expose that follows MapWindow
+    // legitimately repeats the frame — assert the first one.
+    const calls = backend.calls.map((c) => c[0]).filter((c) => c !== 'resize');
+    assert.deepEqual(
+      calls.slice(0, 8),
+      [
+        'enable',
+        'viewport',
+        'clearColor',
+        'clear',
+        'begin',
+        'vertex',
+        'end',
+        'finish',
+      ],
+      'one frame of GL commands reached the server',
+    );
+    const [, ...rgba] = backend.calls.find((c) => c[0] === 'clearColor');
+    assert.ok(
+      Math.abs(rgba[0] - 0x33 / 255) < 1e-3 &&
+        Math.abs(rgba[1] - 0x66 / 255) < 1e-3 &&
+        Math.abs(rgba[2] - 0xcc / 255) < 1e-3,
+      `clearColor parsed from CSS, got ${rgba}`,
+    );
+    assert.deepEqual(
+      backend.calls.find((c) => c[0] === 'viewport').slice(1),
+      [0, 0, 280, 200],
+    );
+    assert.equal(xErrors.length, 0, xErrors.map((e) => e.message).join(', '));
+
+    ReactX11.unmountComponentAtNode(app);
+    await settle(app);
+  } finally {
+    await app.close();
+  }
+});
+
+test('<glarea> follows layout changes and redraws once per change', async () => {
+  const { app, backend, xErrors } = await createGlApp();
+  try {
+    const frames = [];
+    const tree = (padding) =>
+      h(
+        'window',
+        { width: 320, height: 240 },
+        h('box', { padding, flexGrow: 1 }, [
+          h('glarea', {
+            key: 'gl',
+            flexGrow: 1,
+            onDraw: (gl, info) => frames.push([info.width, info.height]),
+          }),
+        ]),
+      );
+
+    const instance = await render(tree(10), app);
+    await waitFor(() => frames.length > 0, 'the first frame');
+    assert.deepEqual(frames.at(-1), [300, 220]);
+
+    backend.calls.length = 0;
+    await render(tree(40), app);
+    await waitFor(
+      () => frames.some(([w]) => w === 240),
+      'a frame at the new size',
+    );
+    await settle(app);
+
+    const node = instance._reactX11Node;
+    const area = node.children[0].children[0];
+    assert.deepEqual(
+      { width: area.rect.width, height: area.rect.height },
+      { width: 240, height: 160 },
+      'the X child window followed the yoga rect',
+    );
+    assert.deepEqual(
+      backend.calls.find((c) => c[0] === 'viewport').slice(1),
+      [0, 0, 240, 160],
+      'and so did the GL viewport',
+    );
+    // demand-driven by default: a settled scene stops issuing frames
+    const before = frames.length;
+    await settle(app, 6);
+    assert.equal(frames.length, before, 'no frames without a change');
+    assert.equal(xErrors.length, 0, xErrors.map((e) => e.message).join(', '));
+
+    ReactX11.unmountComponentAtNode(app);
+    await settle(app);
+  } finally {
+    await app.close();
+  }
+});

--- a/test/glarea.test.js
+++ b/test/glarea.test.js
@@ -196,8 +196,11 @@ test('<glarea> follows layout changes and redraws once per change', async () => 
       { width: 240, height: 160 },
       'the X child window followed the yoga rect',
     );
+    // the resize can be preceded by one more frame at the old size (an
+    // Expose while the window is being moved), so it is the latest frame
+    // that has to match
     assert.deepEqual(
-      backend.calls.find((c) => c[0] === 'viewport').slice(1),
+      backend.calls.findLast((c) => c[0] === 'viewport').slice(1),
       [0, 0, 240, 160],
       'and so did the GL viewport',
     );

--- a/test/scene3d.test.js
+++ b/test/scene3d.test.js
@@ -1,0 +1,379 @@
+// The 3D scene: every geometry is compiled into one server-side display
+// list, and a frame is matrices + material state + one CallList per mesh —
+// never the vertices again. That is a protocol property, so it is asserted
+// on the **encoded GLX command stream** (the bytes react-x11 writes), not on
+// pixels and not on what the server-side emulator ends up drawing: a display
+// list replays into the backend either way, which would hide a regression
+// that re-sends geometry every frame.
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { test } from 'node:test';
+
+import React from 'react';
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient, StaticFontSource } from 'ntk';
+
+import ReactX11, { Canvas3D } from '../src/index.js';
+
+const require = createRequire(import.meta.url);
+const { createGlxExtension, RecordingBackend } = require('x11/browser/glx');
+
+const h = React.createElement;
+
+// GLX request minor opcodes (x11 lib/ext/glx.js)
+const GLX_RENDER = 1;
+const GLX_NEW_LIST = 101;
+const GLX_END_LIST = 102;
+
+// GL render-command opcodes (x11 lib/ext/glxrender.js)
+const GL = {
+  CallList: 1,
+  Begin: 4,
+  Color3f: 8,
+  End: 23,
+  Normal3f: 30,
+  Vertex3f: 70,
+  PolygonMode: 101,
+  MultMatrixf: 180,
+  PopMatrix: 183,
+  PushMatrix: 184,
+};
+
+/** Record what the client writes and decode the GLX traffic out of it. */
+function tapRequests(stream) {
+  const chunks = [];
+  const write = stream.write.bind(stream);
+  stream.write = (chunk, ...rest) => {
+    chunks.push(Buffer.from(chunk));
+    return write(chunk, ...rest);
+  };
+  return {
+    reset: () => (chunks.length = 0),
+    glx(major) {
+      const buffer = Buffer.concat(chunks);
+      const minors = [];
+      const commands = new Map();
+      let offset = 0;
+      while (offset + 4 <= buffer.length) {
+        const words = buffer.readUInt16LE(offset + 2);
+        if (words === 0) break; // BigRequests form: not used here
+        const end = offset + words * 4;
+        if (end > buffer.length) break;
+        if (buffer[offset] === major) {
+          const minor = buffer[offset + 1];
+          minors.push(minor);
+          if (minor === GLX_RENDER) {
+            // [major][minor][length][contextTag] then GL commands
+            let at = offset + 8;
+            while (at + 4 <= end) {
+              const length = buffer.readUInt16LE(at);
+              const opcode = buffer.readUInt16LE(at + 2);
+              if (length < 4) break;
+              commands.set(opcode, (commands.get(opcode) ?? 0) + 1);
+              at += length;
+            }
+          }
+        }
+        offset = end;
+      }
+      return {
+        requests: (minor) => minors.filter((m) => m === minor).length,
+        count: (opcode) => commands.get(opcode) ?? 0,
+        total: [...commands.values()].reduce((a, b) => a + b, 0),
+      };
+    },
+  };
+}
+
+async function createGlApp() {
+  const server = xserver.createServer({ width: 640, height: 480 });
+  const backend = new RecordingBackend();
+  server.registerExtension(
+    'GLX',
+    createGlxExtension({ backend, getDrawableSurface: () => null }),
+  );
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const xErrors = [];
+  const app = await createClient({
+    stream: clientEnd,
+    fontSource: new StaticFontSource(),
+    onXError: (err) => xErrors.push(err),
+  });
+  return { app, backend, xErrors, tap: tapRequests(clientEnd) };
+}
+
+const render = (element, app) =>
+  new Promise((resolve) => ReactX11.render(element, resolve, app));
+
+const settle = async (app, roundTrips = 3) => {
+  for (let i = 0; i < roundTrips; i++) {
+    await new Promise((resolve, reject) =>
+      app.X.GetInputFocus((err) => (err ? reject(err) : resolve())),
+    );
+  }
+};
+
+async function waitFor(check, what, timeout = 3000) {
+  const deadline = Date.now() + timeout;
+  for (;;) {
+    if (check()) return;
+    if (Date.now() > deadline) assert.fail(`timed out waiting for ${what}`);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+/** The <glarea> node under a rendered window instance. */
+function findSurface(node) {
+  if (node.isGlArea) return node;
+  for (const child of node.children ?? []) {
+    const found = findSurface(child);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** Draw one more frame the way an animation tick or an expose would. */
+async function drawFrame(surface, app, tap) {
+  const done = new Promise((resolve) => {
+    const original = surface._drawFrame.bind(surface);
+    surface._drawFrame = (...args) => {
+      surface._drawFrame = original;
+      original(...args);
+      resolve();
+    };
+  });
+  surface.requestFrame();
+  await done;
+  await settle(app);
+  return tap;
+}
+
+test('a mesh compiles once, then every frame is one CallList', async () => {
+  const { app, tap, xErrors } = await createGlApp();
+  try {
+    const scene = (rotation) =>
+      h(
+        'window',
+        { width: 320, height: 240 },
+        h(
+          Canvas3D,
+          { flexGrow: 1, camera: { position: [0, 0, 6] } },
+          h(
+            'mesh',
+            { rotation },
+            h('boxGeometry', { args: [1, 1, 1] }),
+            h('meshBasicMaterial', { color: '#2980b9' }),
+          ),
+        ),
+      );
+
+    const instance = await render(scene([0, 0, 0]), app);
+    const surface = findSurface(instance._reactX11Node);
+    await waitFor(() => surface.gl?.contextTag > 0, 'the GL context');
+    await drawFrame(surface, app, tap);
+
+    const first = tap.glx(app.display.GLX.majorOpcode);
+    assert.equal(first.requests(GLX_NEW_LIST), 1, 'one display list compiled');
+    assert.equal(first.requests(GLX_END_LIST), 1);
+    // a unit box is 12 triangles: 36 vertices, sent once
+    assert.equal(first.count(GL.Vertex3f), 36, 'the geometry, sent once');
+    assert.equal(first.count(GL.Normal3f), 36);
+    assert.ok(first.count(GL.CallList) >= 1, 'and replayed by CallList');
+
+    // a transform change re-sends matrices, never geometry
+    tap.reset();
+    await render(scene([0, 0.4, 0]), app);
+    await drawFrame(surface, app, tap);
+
+    const moved = tap.glx(app.display.GLX.majorOpcode);
+    assert.equal(moved.count(GL.Vertex3f), 0, 'no geometry re-sent');
+    assert.equal(moved.requests(GLX_NEW_LIST), 0, 'no recompile');
+    assert.equal(moved.count(GL.CallList), 1, 'one CallList for the mesh');
+    assert.ok(
+      moved.count(GL.MultMatrixf) >= 3,
+      'projection, view and the model matrix',
+    );
+    assert.equal(xErrors.length, 0, xErrors.map((e) => e.message).join(', '));
+
+    ReactX11.unmountComponentAtNode(app);
+    await settle(app);
+  } finally {
+    await app.close();
+  }
+});
+
+test('per-frame cost does not grow with triangle count', async () => {
+  const { app, tap } = await createGlApp();
+  try {
+    const instance = await render(
+      h(
+        'window',
+        { width: 320, height: 240 },
+        h(
+          Canvas3D,
+          { flexGrow: 1 },
+          h(
+            'mesh',
+            {},
+            h('sphereGeometry', { args: [1, 32, 32] }),
+            h('meshBasicMaterial', { color: 'tomato' }),
+          ),
+        ),
+      ),
+      app,
+    );
+    const surface = findSurface(instance._reactX11Node);
+    await waitFor(() => surface.gl?.contextTag > 0, 'the GL context');
+    await drawFrame(surface, app, tap);
+
+    const compile = tap.glx(app.display.GLX.majorOpcode);
+    assert.ok(
+      compile.count(GL.Vertex3f) > 5000,
+      `the sphere really is big (${compile.count(GL.Vertex3f)} vertices)`,
+    );
+
+    // steady state: the same scene, whatever its triangle count
+    tap.reset();
+    await drawFrame(surface, app, tap);
+    const steady = tap.glx(app.display.GLX.majorOpcode);
+    assert.equal(steady.count(GL.Vertex3f), 0, 'no vertices in a steady frame');
+    assert.equal(steady.count(GL.CallList), 1);
+    assert.ok(
+      steady.total < 30,
+      `a frame is O(meshes): ${steady.total} GL commands`,
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test('changing geometry args recompiles that list once', async () => {
+  const { app, tap } = await createGlApp();
+  try {
+    const scene = (size) =>
+      h(
+        'window',
+        { width: 320, height: 240 },
+        h(
+          Canvas3D,
+          { flexGrow: 1 },
+          h(
+            'mesh',
+            {},
+            h('boxGeometry', { args: [size, size, size] }),
+            h('meshBasicMaterial', { color: 'white' }),
+          ),
+        ),
+      );
+
+    const instance = await render(scene(1), app);
+    const surface = findSurface(instance._reactX11Node);
+    await waitFor(() => surface.gl?.contextTag > 0, 'the GL context');
+    await drawFrame(surface, app, tap);
+
+    tap.reset();
+    await render(scene(2), app);
+    await drawFrame(surface, app, tap);
+    const resized = tap.glx(app.display.GLX.majorOpcode);
+    assert.equal(resized.requests(GLX_NEW_LIST), 1, 'exactly one recompile');
+    assert.equal(resized.count(GL.Vertex3f), 36, 'the new box, once');
+
+    tap.reset();
+    await drawFrame(surface, app, tap);
+    const steady = tap.glx(app.display.GLX.majorOpcode);
+    assert.equal(steady.requests(GLX_NEW_LIST), 0, 'back to the cheap frame');
+    assert.equal(steady.count(GL.Vertex3f), 0);
+  } finally {
+    await app.close();
+  }
+});
+
+test('groups nest transforms and each material switches state once', async () => {
+  const { app, tap } = await createGlApp();
+  try {
+    const instance = await render(
+      h(
+        'window',
+        { width: 320, height: 240 },
+        h(
+          Canvas3D,
+          { flexGrow: 1 },
+          h(
+            'group',
+            { position: [0, 1, 0] },
+            h(
+              'mesh',
+              { position: [-1, 0, 0] },
+              h('boxGeometry', { args: [1, 1, 1] }),
+              h('meshBasicMaterial', { color: 'red' }),
+            ),
+            h(
+              'mesh',
+              { position: [1, 0, 0] },
+              h('boxGeometry', { args: [1, 1, 1] }),
+              h('meshBasicMaterial', { color: 'blue', wireframe: true }),
+            ),
+          ),
+        ),
+      ),
+      app,
+    );
+    const surface = findSurface(instance._reactX11Node);
+    await waitFor(() => surface.gl?.contextTag > 0, 'the GL context');
+    await drawFrame(surface, app, tap);
+
+    tap.reset();
+    await drawFrame(surface, app, tap);
+    const frame = tap.glx(app.display.GLX.majorOpcode);
+    assert.equal(frame.count(GL.CallList), 2, 'both meshes drawn');
+    assert.equal(frame.count(GL.PushMatrix), 3, 'group + two meshes');
+    assert.equal(frame.count(GL.PopMatrix), 3);
+    assert.equal(frame.count(GL.Color3f), 2, 'one colour per material');
+    assert.equal(frame.count(GL.PolygonMode), 2, 'wireframe switches state');
+  } finally {
+    await app.close();
+  }
+});
+
+test('unsupported r3f elements fail with the protocol reason', async () => {
+  const { app } = await createGlApp();
+  const errors = [];
+  const consoleError = console.error;
+  console.error = (...args) => errors.push(args.join(' '));
+  try {
+    await render(
+      h(
+        'window',
+        { width: 100, height: 100 },
+        h(Canvas3D, {}, h('mesh', {}, h('shaderMaterial', {}))),
+      ),
+      app,
+    ).catch(() => {});
+    assert.match(
+      errors.join('\n'),
+      /shaderMaterial.*GLSL shaders.*no shader objects/s,
+      'the error names the protocol limit',
+    );
+  } finally {
+    console.error = consoleError;
+    await app.close();
+  }
+});
+
+test('3D elements outside a <glarea> say where they belong', async () => {
+  const { app } = await createGlApp();
+  const errors = [];
+  const consoleError = console.error;
+  console.error = (...args) => errors.push(args.join(' '));
+  try {
+    await render(
+      h('window', { width: 100, height: 100 }, h('mesh', {})),
+      app,
+    ).catch(() => {});
+    assert.match(errors.join('\n'), /<mesh> is a 3D element.*<glarea>/s);
+  } finally {
+    console.error = consoleError;
+    await app.close();
+  }
+});

--- a/test/scene3d.test.js
+++ b/test/scene3d.test.js
@@ -133,18 +133,19 @@ function findSurface(node) {
   return null;
 }
 
-/** Draw one more frame the way an animation tick or an expose would. */
+/**
+ * Take the frame clock out of the picture: from here on frames happen only
+ * when the test asks for one, so command counts are exact. The scheduling
+ * path itself is covered by test/glarea.test.js.
+ */
+function takeFrameControl(surface) {
+  surface.requestFrame = () => {};
+  return surface;
+}
+
+/** Draw one frame the way an animation tick or an expose would. */
 async function drawFrame(surface, app, tap) {
-  const done = new Promise((resolve) => {
-    const original = surface._drawFrame.bind(surface);
-    surface._drawFrame = (...args) => {
-      surface._drawFrame = original;
-      original(...args);
-      resolve();
-    };
-  });
-  surface.requestFrame();
-  await done;
+  surface._drawFrame();
   await settle(app);
   return tap;
 }
@@ -171,6 +172,7 @@ test('a mesh compiles once, then every frame is one CallList', async () => {
     const instance = await render(scene([0, 0, 0]), app);
     const surface = findSurface(instance._reactX11Node);
     await waitFor(() => surface.gl?.contextTag > 0, 'the GL context');
+    takeFrameControl(surface);
     await drawFrame(surface, app, tap);
 
     const first = tap.glx(app.display.GLX.majorOpcode);
@@ -225,6 +227,7 @@ test('per-frame cost does not grow with triangle count', async () => {
     );
     const surface = findSurface(instance._reactX11Node);
     await waitFor(() => surface.gl?.contextTag > 0, 'the GL context');
+    takeFrameControl(surface);
     await drawFrame(surface, app, tap);
 
     const compile = tap.glx(app.display.GLX.majorOpcode);
@@ -270,6 +273,7 @@ test('changing geometry args recompiles that list once', async () => {
     const instance = await render(scene(1), app);
     const surface = findSurface(instance._reactX11Node);
     await waitFor(() => surface.gl?.contextTag > 0, 'the GL context');
+    takeFrameControl(surface);
     await drawFrame(surface, app, tap);
 
     tap.reset();
@@ -321,6 +325,7 @@ test('groups nest transforms and each material switches state once', async () =>
     );
     const surface = findSurface(instance._reactX11Node);
     await waitFor(() => surface.gl?.contextTag > 0, 'the GL context');
+    takeFrameControl(surface);
     await drawFrame(surface, app, tap);
 
     tap.reset();


### PR DESCRIPTION
Phase 1 of [docs/glx-plan.md](docs/glx-plan.md), on the ntk 3.6.0 release that carries phase 0 (sidorares/ntk#85: MakeCurrent's context tag, visuals on `createWindow`, `chooseGLXConfig`, `cssColor`).

`<glarea>` is the third element that owns a real X window, and the first drawn one: GLX needs a drawable created for a GL-capable visual and cannot share the XRender pipeline the rest of the tree paints through. So it is a child X window — sized and positioned by the parent's yoga rect like any other node, with its own frame clock.

<!-- drag in: glarea.png -->

```jsx
<glarea
  flexGrow={1}
  clearColor="#12161f"
  glx={{ DEPTH_SIZE: 24 }}
  frameLoop={spinning ? 'always' : 'demand'}
  onCreated={(gl) => { gl.Enable(gl.DEPTH_TEST); compileCube(gl); }}
  onDraw={(gl, { width, height }) => {
    gl.MatrixMode(gl.PROJECTION);
    ...
    gl.CallList(CUBE_LIST);
  }}
/>
```

The viewport is set and the buffers cleared before `onDraw`, `SwapBuffers` follows it. `onCreated` runs once when the context is current — one-time GL state, texture uploads, display-list compilation.

**Frames are demand-driven by default.** Prop, size and expose changes redraw; `frameLoop="always"` opts into continuous rendering on ntk's frame clock. This layer owns how often drawing happens, so the default is the cheap one. The visual comes from `app.chooseGLXConfig`, queried once per app and shared by every surface.

Layout treats the surface as a leaf and its X window follows the computed rect. Being a child window it stacks above everything drawn in the parent, so a HUD needs a sibling `<popup>`; pointer events go to the surface's own window, and hit-test integration is phase 5.

### Testing

`test/glarea.test.js` is hermetic — node-x11's in-process X server with its GLX emulator registered as an extension, so the GL commands a frame emits land as calls on a recording backend:

- the child window carries the GL visual, and the frame emits viewport / clear / user commands that actually reach the GL backend, which is only possible with a correct context tag
- `clearColor` parses from CSS, the viewport matches the yoga rect
- a layout change moves the X window and the GL viewport together
- a settled scene stops drawing — the demand loop really is demand-driven

`examples/gl.jsx` (`npm run examples:gl`) is the screenshot above: a cube compiled into a server-side display list once and replayed with one `CallList` per frame, with 2D widgets laid out around it. Verified on XQuartz — the screenshot is rendered by this branch.

### Notes

`Canvas3D` moves to phase 2: the surface duties the plan gave it live in the host element, so the component only earns its keep once there is a scene tree to own. Next up is the display-list geometry compiler and `<mesh>`.