### PR TITLE
feat: lights and lit materials

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -283,17 +283,23 @@ names wherever the concept survives the translation to fixed-function GL.
 </Canvas3D>
 ```
 
-| element               | notes                                                                                              |
-| --------------------- | -------------------------------------------------------------------------------------------------- |
-| `<group>`             | transform only; nests children                                                                     |
-| `<mesh>`              | one geometry child + one material child                                                            |
-| `<boxGeometry>`       | `args={[width, height, depth, widthSeg, heightSeg, depthSeg]}`                                     |
-| `<planeGeometry>`     | `args={[width, height, widthSeg, heightSeg]}`                                                      |
-| `<sphereGeometry>`    | `args={[radius, widthSeg, heightSeg]}`                                                             |
-| `<cylinderGeometry>`  | `args={[radiusTop, radiusBottom, height, radialSeg, heightSeg, openEnded]}`                        |
-| `<torusGeometry>`     | `args={[radius, tube, radialSeg, tubularSeg]}`                                                     |
-| `<bufferGeometry>`    | `position` / `normal` / `uv` / `index` arrays; normals are derived from the triangles when omitted |
-| `<meshBasicMaterial>` | `color`, `wireframe`, `opacity`, `transparent`, `side` (`front` \| `back` \| `double`)             |
+| element                 | notes                                                                                                     |
+| ----------------------- | --------------------------------------------------------------------------------------------------------- |
+| `<group>`               | transform only; nests children                                                                            |
+| `<mesh>`                | one geometry child + one material child                                                                   |
+| `<boxGeometry>`         | `args={[width, height, depth, widthSeg, heightSeg, depthSeg]}`                                            |
+| `<planeGeometry>`       | `args={[width, height, widthSeg, heightSeg]}`                                                             |
+| `<sphereGeometry>`      | `args={[radius, widthSeg, heightSeg]}`                                                                    |
+| `<cylinderGeometry>`    | `args={[radiusTop, radiusBottom, height, radialSeg, heightSeg, openEnded]}`                               |
+| `<torusGeometry>`       | `args={[radius, tube, radialSeg, tubularSeg]}`                                                            |
+| `<bufferGeometry>`      | `position` / `normal` / `uv` / `index` arrays; normals are derived from the triangles when omitted        |
+| `<meshBasicMaterial>`   | unlit flat colour: `color`, `wireframe`, `opacity`, `transparent`, `side` (`front` \| `back` \| `double`) |
+| `<meshLambertMaterial>` | diffuse shading; the same props plus `emissive`                                                           |
+| `<meshPhongMaterial>`   | + `specular`, `shininess` (default 30)                                                                    |
+| `<ambientLight>`        | `color`, `intensity` — costs no light unit                                                                |
+| `<directionalLight>`    | `position` is the direction the light comes from                                                          |
+| `<pointLight>`          | `position`, plus `distance`/`decay` for attenuation                                                       |
+| `<spotLight>`           | + `angle` in radians, `penumbra`, `target`                                                                |
 
 Transforms are `position`, `rotation` (XYZ euler radians) and `scale`, each
 a `[x, y, z]` tuple (or one number for a uniform scale), plus `visible`.
@@ -307,11 +313,18 @@ material re-sends neither; changing a geometry's `args` recompiles just
 that list. `test/scene3d.test.js` asserts exactly this on the encoded
 command stream.
 
+**Lighting is the fixed-function pipeline**: per-vertex Gouraud shading and
+**8 light units** in total — more than eight non-ambient lights warns and
+uses the first eight. `<ambientLight>` costs no unit; its colour rides on
+the first light's ambient term. A lit material in a scene with no lights
+falls back to flat colour rather than rendering black. Light positions are
+world space, so a light inside a rotating `<group>` moves with it.
+
 Not implemented, and failing with an error naming the reason:
 `<shaderMaterial>` (the protocol encodes no shaders), `<instancedMesh>`,
-`<points>`, `<line>`, post-processing. Lighting materials
-(`<meshLambertMaterial>`, `<meshPhongMaterial>`), lights and camera
-elements are the next phase — see [glx-plan.md](glx-plan.md).
+`<points>`, `<line>`, post-processing — and no shadows, which need
+framebuffer objects. Camera elements, textures and pointer interaction are
+the phases still to come — see [glx-plan.md](glx-plan.md).
 
 ---
 

--- a/examples/three.jsx
+++ b/examples/three.jsx
@@ -46,18 +46,34 @@ function App() {
           glx={{ DEPTH_SIZE: 24 }}
           camera={{ position: [0, 2.6, 8.5], target: [0, -0.2, 0], fov: 45 }}
         >
+          <ambientLight intensity={0.35} />
+          <pointLight position={[5, 6, 6]} intensity={1} />
+          <directionalLight
+            position={[-6, 2, 3]}
+            intensity={0.4}
+            color="#9ecbff"
+          />
+
           <group rotation={[0, angle, 0]}>
             <mesh position={[-1.6, 0, 0]} rotation={[0.5, 0.4, 0]}>
               <boxGeometry args={[1.4, 1.4, 1.4]} />
-              <meshBasicMaterial color="#2980b9" wireframe={wireframe} />
+              <meshPhongMaterial
+                color="#2980b9"
+                shininess={60}
+                wireframe={wireframe}
+              />
             </mesh>
             <mesh position={[1.6, 0, 0]}>
               <sphereGeometry args={[0.9, 24, 16]} />
-              <meshBasicMaterial color="#e67e22" wireframe={wireframe} />
+              <meshPhongMaterial
+                color="#e67e22"
+                shininess={12}
+                wireframe={wireframe}
+              />
             </mesh>
             <mesh position={[0, -1.4, 0]} rotation={[Math.PI / 2, 0, 0]}>
               <torusGeometry args={[1.1, 0.28, 12, 36]} />
-              <meshBasicMaterial color="#27ae60" wireframe={wireframe} />
+              <meshLambertMaterial color="#27ae60" wireframe={wireframe} />
             </mesh>
           </group>
         </Canvas3D>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5408,9 +5408,9 @@
       }
     },
     "node_modules/x11": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/x11/-/x11-3.1.2.tgz",
-      "integrity": "sha512-AmtrdsEPQy0LCQEWNdOogTlmS97zvbq17qt/QZ0pk4p8sYij+z9SAlPtNK+amzJADkjSOeJv6rhTQJUQc19aRg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/x11/-/x11-3.1.3.tgz",
+      "integrity": "sha512-wHrZzmCpMAoniXMd1C3anM9l6a/oeCwlydiD4ut9Cw678vj7EfIvlYZ6O2LvH9RaN2h0vxksByYMlPVpuRDk7A==",
       "engines": {
         "node": ">=18"
       }

--- a/src/scene3d.js
+++ b/src/scene3d.js
@@ -18,6 +18,7 @@ import {
   compose,
   identity,
   lookAt,
+  multiply,
   orthographic,
   perspective,
 } from './mat4.js';
@@ -32,12 +33,21 @@ export const MATERIAL_KINDS = new Set([
   'meshLambertMaterial',
   'meshPhongMaterial',
 ]);
-export const OBJECT_KINDS = new Set(['mesh', 'group']);
+export const LIGHT_KINDS = new Set([
+  'ambientLight',
+  'directionalLight',
+  'pointLight',
+  'spotLight',
+]);
+export const OBJECT_KINDS = new Set(['mesh', 'group', ...LIGHT_KINDS]);
 export const SCENE_KINDS = new Set([
   ...GEOMETRY_KINDS,
   ...MATERIAL_KINDS,
   ...OBJECT_KINDS,
 ]);
+
+// fixed-function GL has exactly eight light units
+const MAX_LIGHTS = 8;
 
 /**
  * react-three-fiber names that indirect GLX cannot implement — the protocol
@@ -143,6 +153,17 @@ export class GroupNode extends Object3DNode {
   }
 }
 
+/** `<pointLight position={[4, 5, 3]} intensity={1} />` and friends. */
+export class LightNode extends Object3DNode {
+  constructor(kind, props, app) {
+    super(kind, props, app);
+  }
+
+  get isLight() {
+    return true;
+  }
+}
+
 /** `<boxGeometry args={[1, 1, 1]} />`, `<bufferGeometry position={…} />` */
 export class GeometryNode extends Object3DNode {
   constructor(kind, props, app) {
@@ -217,6 +238,7 @@ export class MaterialNode extends Object3DNode {
 export function createSceneNode(kind, props, app) {
   if (kind === 'mesh') return new MeshNode(props, app);
   if (kind === 'group') return new GroupNode(props, app);
+  if (LIGHT_KINDS.has(kind)) return new LightNode(kind, props, app);
   if (GEOMETRY_KINDS.has(kind)) return new GeometryNode(kind, props, app);
   if (MATERIAL_KINDS.has(kind)) return new MaterialNode(kind, props, app);
   return null;
@@ -260,6 +282,24 @@ const rgba = (color, fallback = [1, 1, 1, 1]) => {
   return cssColor(color) ?? fallback;
 };
 
+/** Lights with their world matrices, in tree order. */
+function collectLights(nodes, parentMatrix, out = []) {
+  for (const node of nodes) {
+    if (!node.isObject3D || !node.visible) continue;
+    const world = multiply(parentMatrix, node.localMatrix());
+    if (node.isLight) out.push({ node, world });
+    collectLights(node.children, world, out);
+  }
+  return out;
+}
+
+const scaled = ([r, g, b], intensity) => [
+  r * intensity,
+  g * intensity,
+  b * intensity,
+  1,
+];
+
 /**
  * Per-surface GL bookkeeping: the display list of every geometry, and the
  * material state last sent (so an unchanged material costs nothing).
@@ -271,6 +311,9 @@ export class SceneRenderer {
     this.nextList = 1;
     this.materialKey = null;
     this.initialized = false;
+    this.enabledLights = 0;
+    this.lit = false;
+    this.warnedLightLimit = false;
   }
 
   /** Draw the scene under `surface`; false when there is nothing 3D to draw. */
@@ -296,6 +339,11 @@ export class SceneRenderer {
     gl.MatrixMode(gl.MODELVIEW);
     gl.LoadIdentity();
     gl.MultMatrixf(view);
+
+    // light positions are transformed by the modelview matrix in force when
+    // they are sent, and it is the view matrix right now — so world-space
+    // positions land in eye space exactly as GL expects
+    this.applyLights(gl, collectLights(roots, identity()));
 
     for (const node of roots) this.drawObject(gl, node);
     return true;
@@ -346,26 +394,209 @@ export class SceneRenderer {
     return id;
   }
 
+  /**
+   * Fixed-function GL has eight light units. `<ambientLight>` has no unit of
+   * its own — its colour is summed into the first light's GL_AMBIENT term
+   * (and into a dummy unit when it is the only light in the scene).
+   */
+  applyLights(gl, lights) {
+    let ambient = [0, 0, 0];
+    const units = [];
+    for (const light of lights) {
+      const { node } = light;
+      const intensity = node.props.intensity ?? 1;
+      const [r, g, b] = rgba(node.props.color, [1, 1, 1, 1]);
+      if (node.kind === 'ambientLight') {
+        ambient = [
+          ambient[0] + r * intensity,
+          ambient[1] + g * intensity,
+          ambient[2] + b * intensity,
+        ];
+        continue;
+      }
+      units.push({ node, intensity, color: [r, g, b] });
+    }
+
+    if (units.length > MAX_LIGHTS && !this.warnedLightLimit) {
+      this.warnedLightLimit = true;
+      console.warn(
+        `react-x11: ${units.length} lights in the scene; fixed-function GL ` +
+          `has ${MAX_LIGHTS} light units, so the rest are ignored.`,
+      );
+    }
+    const used = units.slice(0, MAX_LIGHTS);
+    this.lit = used.length > 0 || ambient.some((c) => c > 0);
+
+    if (!this.lit) {
+      for (let i = 0; i < this.enabledLights; i++) gl.Disable(gl.LIGHT0 + i);
+      this.enabledLights = 0;
+      return;
+    }
+
+    // ambient-only scenes still need one unit, to carry the ambient term
+    const count = Math.max(used.length, 1);
+    for (let i = 0; i < count; i++) {
+      const unit = gl.LIGHT0 + i;
+      gl.Enable(unit);
+      gl.Lightfv(unit, gl.AMBIENT, i === 0 ? [...ambient, 1] : [0, 0, 0, 1]);
+      const light = used[i];
+      if (!light) {
+        // the dummy unit for a scene lit only by <ambientLight>
+        gl.Lightfv(unit, gl.DIFFUSE, [0, 0, 0, 1]);
+        gl.Lightfv(unit, gl.SPECULAR, [0, 0, 0, 1]);
+        gl.Lightfv(unit, gl.POSITION, [0, 0, 1, 0]);
+        continue;
+      }
+      const { node, intensity, color } = light;
+      const world = lights.find((l) => l.node === node).world;
+      const position = [world[12], world[13], world[14]];
+      gl.Lightfv(unit, gl.DIFFUSE, scaled(color, intensity));
+      gl.Lightfv(
+        unit,
+        gl.SPECULAR,
+        scaled(color, node.props.specular === false ? 0 : intensity),
+      );
+
+      if (node.kind === 'directionalLight') {
+        // w = 0: a direction, pointing from the scene toward the light
+        gl.Lightfv(unit, gl.POSITION, [...position, 0]);
+        gl.Lightfv(unit, gl.SPOT_DIRECTION, [0, 0, -1, 0]);
+        gl.Lightfv(unit, gl.SPOT_CUTOFF, 180, 0, 0, 0);
+      } else {
+        gl.Lightfv(unit, gl.POSITION, [...position, 1]);
+        const distance = node.props.distance ?? 0;
+        // three.js decay=2 is physical falloff; map it onto GL attenuation
+        const decay = node.props.decay ?? 0;
+        gl.Lightfv(unit, gl.CONSTANT_ATTENUATION, 1, 0, 0, 0);
+        gl.Lightfv(
+          unit,
+          gl.LINEAR_ATTENUATION,
+          distance > 0 ? 1 / distance : 0,
+          0,
+          0,
+          0,
+        );
+        gl.Lightfv(
+          unit,
+          gl.QUADRATIC_ATTENUATION,
+          decay > 1 && distance > 0 ? 1 / (distance * distance) : 0,
+          0,
+          0,
+          0,
+        );
+        if (node.kind === 'spotLight') {
+          const target = node.props.target ?? [0, 0, 0];
+          const dir = [
+            target[0] - position[0],
+            target[1] - position[1],
+            target[2] - position[2],
+          ];
+          const len = Math.hypot(dir[0], dir[1], dir[2]) || 1;
+          gl.Lightfv(
+            unit,
+            gl.SPOT_DIRECTION,
+            dir[0] / len,
+            dir[1] / len,
+            dir[2] / len,
+            0,
+          );
+          const angle = node.props.angle ?? Math.PI / 6;
+          gl.Lightfv(
+            unit,
+            gl.SPOT_CUTOFF,
+            Math.min(90, (angle * 180) / Math.PI),
+            0,
+            0,
+            0,
+          );
+          gl.Lightfv(
+            unit,
+            gl.SPOT_EXPONENT,
+            (node.props.penumbra ?? 0) * 128,
+            0,
+            0,
+            0,
+          );
+        } else {
+          gl.Lightfv(unit, gl.SPOT_CUTOFF, 180, 0, 0, 0);
+        }
+      }
+    }
+    for (let i = count; i < this.enabledLights; i++) gl.Disable(gl.LIGHT0 + i);
+    this.enabledLights = count;
+    // the material state depends on whether lighting is on
+    this.materialKey = null;
+  }
+
   /** Material state is per frame, so one geometry list can serve many meshes. */
   applyMaterial(gl, material) {
+    const kind = material?.kind ?? 'meshBasicMaterial';
     const props = material?.props ?? {};
     const [r, g, b, a] = rgba(props.color);
     const opacity = props.opacity ?? 1;
     const alpha = a * opacity;
-    const key = `${material?.kind}|${r},${g},${b},${alpha}|${props.wireframe}|${props.side}|${props.transparent}`;
+    // <meshBasicMaterial> is unlit by definition, and a lit material with no
+    // light in the scene would render black — fall back to flat colour
+    const lit = kind !== 'meshBasicMaterial' && this.lit;
+    const key = [
+      kind,
+      lit,
+      r,
+      g,
+      b,
+      alpha,
+      props.wireframe,
+      props.side,
+      props.transparent,
+      props.shininess,
+      props.specular,
+      props.emissive,
+    ].join('|');
     if (key === this.materialKey) return;
     this.materialKey = key;
 
-    // <meshBasicMaterial> is unlit; the lit materials arrive with the lights
-    gl.Disable(gl.LIGHTING);
-    if (alpha < 1 || props.transparent) {
+    const blended = alpha < 1 || props.transparent;
+    if (blended) {
       gl.Enable(gl.BLEND);
       gl.BlendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA);
-      gl.Color4f(r, g, b, alpha);
     } else {
       gl.Disable(gl.BLEND);
-      gl.Color3f(r, g, b);
     }
+
+    if (lit) {
+      gl.Enable(gl.LIGHTING);
+      // colour reaches the shading equation as the surface reflectance
+      gl.Materialfv(gl.FRONT_AND_BACK, gl.AMBIENT_AND_DIFFUSE, [
+        r,
+        g,
+        b,
+        alpha,
+      ]);
+      gl.Materialfv(
+        gl.FRONT_AND_BACK,
+        gl.EMISSION,
+        rgba(props.emissive, [0, 0, 0, 1]),
+      );
+      if (kind === 'meshPhongMaterial') {
+        gl.Materialfv(
+          gl.FRONT_AND_BACK,
+          gl.SPECULAR,
+          rgba(props.specular, [1, 1, 1, 1]),
+        );
+        gl.Materialf(gl.FRONT_AND_BACK, gl.SHININESS, props.shininess ?? 30);
+      } else {
+        // Lambert: diffuse only
+        gl.Materialfv(gl.FRONT_AND_BACK, gl.SPECULAR, [0, 0, 0, 1]);
+        gl.Materialf(gl.FRONT_AND_BACK, gl.SHININESS, 0);
+      }
+      // both faces are shaded when both are drawn
+      gl.LightModelf(gl.LIGHT_MODEL_TWO_SIDE, props.side === 'double' ? 1 : 0);
+    } else {
+      gl.Disable(gl.LIGHTING);
+      if (blended) gl.Color4f(r, g, b, alpha);
+      else gl.Color3f(r, g, b);
+    }
+
     gl.PolygonMode(gl.FRONT_AND_BACK, props.wireframe ? gl.LINE : gl.FILL);
     if (props.side === 'double') {
       gl.Disable(gl.CULL_FACE);

--- a/test/scene3d.test.js
+++ b/test/scene3d.test.js
@@ -382,3 +382,111 @@ test('3D elements outside a <glarea> say where they belong', async () => {
     await app.close();
   }
 });
+
+test('lights drive the lit materials, and ambient needs no unit of its own', async () => {
+  const { app, backend, tap } = await createGlApp();
+  try {
+    const instance = await render(
+      h(
+        'window',
+        { width: 320, height: 240 },
+        h(
+          Canvas3D,
+          { flexGrow: 1, camera: { position: [0, 0, 6] } },
+          h('ambientLight', { intensity: 0.3 }),
+          h('pointLight', { position: [4, 5, 3], intensity: 1 }),
+          h(
+            'mesh',
+            {},
+            h('boxGeometry', { args: [1, 1, 1] }),
+            h('meshPhongMaterial', { color: '#2980b9', shininess: 40 }),
+          ),
+        ),
+      ),
+      app,
+    );
+    const surface = findSurface(instance._reactX11Node);
+    await waitFor(() => surface.gl?.contextTag > 0, 'the GL context');
+    takeFrameControl(surface);
+
+    backend.calls.length = 0;
+    tap.reset();
+    await drawFrame(surface, app, tap);
+
+    // one light unit: the ambient term rides on it, the point light drives it
+    const enabled = backend.calls.filter(
+      (c) => c[0] === 'enable' && c[1] === 0x4000, // GL_LIGHT0
+    );
+    assert.equal(enabled.length, 1, 'GL_LIGHT0 enabled, and only it');
+    assert.ok(
+      backend.calls.some((c) => c[0] === 'enable' && c[1] === 0x0b50), // LIGHTING
+      'lighting turned on for a lit material',
+    );
+
+    const lightCalls = backend.calls.filter((c) => c[0] === 'light');
+    // backend.light(lightEnum, pname, params)
+    const position = lightCalls.find((c) => c[2] === 0x1203); // GL_POSITION
+    assert.deepEqual(
+      position[3].map((v) => Math.round(v)),
+      [4, 5, 3, 1],
+      'a point light: world position with w = 1',
+    );
+    const ambient = lightCalls.find((c) => c[2] === 0x1200); // GL_AMBIENT
+    assert.ok(
+      Math.abs(ambient[3][0] - 0.3) < 1e-3,
+      `<ambientLight intensity={0.3}> lands in GL_AMBIENT, got ${ambient[3][0]}`,
+    );
+
+    const material = backend.calls.filter((c) => c[0] === 'material');
+    assert.ok(
+      material.some((c) => c[2] === 0x1602), // AMBIENT_AND_DIFFUSE
+      'the material colour becomes the surface reflectance',
+    );
+    assert.ok(
+      material.some((c) => c[2] === 0x1601 && c[3][0] === 40), // SHININESS
+      'phong shininess reaches the server',
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test('a lit material with no lights falls back to flat colour', async () => {
+  const { app, backend, tap } = await createGlApp();
+  try {
+    const instance = await render(
+      h(
+        'window',
+        { width: 320, height: 240 },
+        h(
+          Canvas3D,
+          { flexGrow: 1 },
+          h(
+            'mesh',
+            {},
+            h('boxGeometry', { args: [1, 1, 1] }),
+            h('meshLambertMaterial', { color: 'tomato' }),
+          ),
+        ),
+      ),
+      app,
+    );
+    const surface = findSurface(instance._reactX11Node);
+    await waitFor(() => surface.gl?.contextTag > 0, 'the GL context');
+    takeFrameControl(surface);
+
+    backend.calls.length = 0;
+    await drawFrame(surface, app, tap);
+
+    assert.ok(
+      backend.calls.some((c) => c[0] === 'disable' && c[1] === 0x0b50),
+      'lighting stays off, so the mesh is not rendered black',
+    );
+    assert.ok(
+      backend.calls.some((c) => c[0] === 'color'),
+      'the colour is sent flat instead',
+    );
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
Phase 3 of [docs/glx-plan.md](docs/glx-plan.md), on top of the `<glarea>` surface and the scene tree from #50.

<!-- drag in: three-lights.png -->

```jsx
<Canvas3D flexGrow={1} camera={{ position: [0, 2.6, 8.5], fov: 45 }}>
  <ambientLight intensity={0.35} />
  <pointLight position={[5, 6, 6]} intensity={1} />
  <directionalLight position={[-6, 2, 3]} intensity={0.4} color="#9ecbff" />

  <mesh>
    <sphereGeometry args={[0.9, 24, 16]} />
    <meshPhongMaterial color="#e67e22" shininess={12} />
  </mesh>
</Canvas3D>
```

`<ambientLight>`, `<directionalLight>`, `<pointLight>` and `<spotLight>`, with `<meshLambertMaterial>` and `<meshPhongMaterial>` to receive them — the fixed-function pipeline's own per-vertex shading, which is what indirect GLX gives us.

The details that are not obvious from the r3f names:

- **Eight light units, total.** More than eight non-ambient lights warns and uses the first eight.
- **`<ambientLight>` costs no unit.** Its colour rides on the first light's ambient term, with a dummy unit when it is the only light in the scene — `LightModelfv` is not in the GLX command set, so the light-model ambient cannot be set directly.
- **Light positions are world space**, so a light inside a rotating `<group>` moves with it. They are sent while the modelview matrix is still the view matrix, which is exactly what GL wants.
- **A lit material with no lights falls back to flat colour** rather than rendering black.
- Material state stays per frame, so the display lists from #50 are untouched: adding lights does not recompile geometry.

### The node-x11 fix underneath

Writing this turned up an encoder bug: `Lightfv` and `Materialfv` always wrote four floats, but those commands are variable length — the count is fixed by the pname. Every scalar parameter (spot cutoff, spot exponent, attenuation, shininess) was a `BadLength` and got dropped by the server, so spot lights and attenuation could not work at all. Fixed in sidorares/node-x11#231, released as **x11 3.1.3**, which arrives here transitively through ntk; the lockfile bump is the second commit.

### Testing

Two more cases in `test/scene3d.test.js` against the in-process X server with its GLX emulator: that one point light plus `<ambientLight intensity={0.3}>` enables exactly one unit with the ambient term on it, the world position lands in `GL_POSITION` with `w = 1`, the material colour becomes `GL_AMBIENT_AND_DIFFUSE` and phong shininess reaches the server; and that a lit material with no lights disables lighting and sends a flat colour instead.

Screenshot is `examples/three.jsx` (`npm run examples:three`) on XQuartz, rendered by this branch against the published x11 3.1.3 — specular highlight on the sphere, shaded cube faces, smooth Lambert torus. That also settles the plan's open question about whether XQuartz's indirect GLX handles lighting: it does.