### PR TITLE
feat: textures and pointer events on meshes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,8 @@ no override-redirect staging (issue #4).
   `<group>`, geometry/material nodes and the renderer that compiles each
   geometry into a server-side **display list** (a frame is matrices +
   material state + one `CallList` per mesh). `src/geometry3d.js` generates
-  the primitives, `src/mat4.js` is the matrix math.
+  the primitives, `src/mat4.js` is the matrix math, `src/raycast3d.js` +
+  `src/pointer3d.js` are picking and mesh pointer events.
 - `src/richnodes.js` — rich-content elements (`<markdown>`, `<html>`,
   `<svg>`, `<tex>`) wrapping ntk's document widgets in standalone mode:
   the widget's `layout(width)`/`contentHeight` feeds a yoga measure

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -283,23 +283,23 @@ names wherever the concept survives the translation to fixed-function GL.
 </Canvas3D>
 ```
 
-| element                 | notes                                                                                                     |
-| ----------------------- | --------------------------------------------------------------------------------------------------------- |
-| `<group>`               | transform only; nests children                                                                            |
-| `<mesh>`                | one geometry child + one material child                                                                   |
-| `<boxGeometry>`         | `args={[width, height, depth, widthSeg, heightSeg, depthSeg]}`                                            |
-| `<planeGeometry>`       | `args={[width, height, widthSeg, heightSeg]}`                                                             |
-| `<sphereGeometry>`      | `args={[radius, widthSeg, heightSeg]}`                                                                    |
-| `<cylinderGeometry>`    | `args={[radiusTop, radiusBottom, height, radialSeg, heightSeg, openEnded]}`                               |
-| `<torusGeometry>`       | `args={[radius, tube, radialSeg, tubularSeg]}`                                                            |
-| `<bufferGeometry>`      | `position` / `normal` / `uv` / `index` arrays; normals are derived from the triangles when omitted        |
-| `<meshBasicMaterial>`   | unlit flat colour: `color`, `wireframe`, `opacity`, `transparent`, `side` (`front` \| `back` \| `double`) |
-| `<meshLambertMaterial>` | diffuse shading; the same props plus `emissive`                                                           |
-| `<meshPhongMaterial>`   | + `specular`, `shininess` (default 30)                                                                    |
-| `<ambientLight>`        | `color`, `intensity` — costs no light unit                                                                |
-| `<directionalLight>`    | `position` is the direction the light comes from                                                          |
-| `<pointLight>`          | `position`, plus `distance`/`decay` for attenuation                                                       |
-| `<spotLight>`           | + `angle` in radians, `penumbra`, `target`                                                                |
+| element                 | notes                                                                                                            |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `<group>`               | transform only; nests children                                                                                   |
+| `<mesh>`                | one geometry child + one material child                                                                          |
+| `<boxGeometry>`         | `args={[width, height, depth, widthSeg, heightSeg, depthSeg]}`                                                   |
+| `<planeGeometry>`       | `args={[width, height, widthSeg, heightSeg]}`                                                                    |
+| `<sphereGeometry>`      | `args={[radius, widthSeg, heightSeg]}`                                                                           |
+| `<cylinderGeometry>`    | `args={[radiusTop, radiusBottom, height, radialSeg, heightSeg, openEnded]}`                                      |
+| `<torusGeometry>`       | `args={[radius, tube, radialSeg, tubularSeg]}`                                                                   |
+| `<bufferGeometry>`      | `position` / `normal` / `uv` / `index` arrays; normals are derived from the triangles when omitted               |
+| `<meshBasicMaterial>`   | unlit flat colour: `color`, `map`, `wireframe`, `opacity`, `transparent`, `side` (`front` \| `back` \| `double`) |
+| `<meshLambertMaterial>` | diffuse shading; the same props plus `emissive`                                                                  |
+| `<meshPhongMaterial>`   | + `specular`, `shininess` (default 30)                                                                           |
+| `<ambientLight>`        | `color`, `intensity` — costs no light unit                                                                       |
+| `<directionalLight>`    | `position` is the direction the light comes from                                                                 |
+| `<pointLight>`          | `position`, plus `distance`/`decay` for attenuation                                                              |
+| `<spotLight>`           | + `angle` in radians, `penumbra`, `target`                                                                       |
 
 Transforms are `position`, `rotation` (XYZ euler radians) and `scale`, each
 a `[x, y, z]` tuple (or one number for a uniform scale), plus `visible`.
@@ -312,6 +312,30 @@ every frame is ~96 KB per frame. Each geometry is therefore compiled into a
 material re-sends neither; changing a geometry's `args` recompiles just
 that list. `test/scene3d.test.js` asserts exactly this on the encoded
 command stream.
+
+### Textures
+
+`map` on any material takes an ntk `Image` — or anything with
+`{ width, height, data }` in RGBA byte order:
+
+```jsx
+import { Image, loadImage } from 'ntk';
+
+const texture = await loadImage('crate.png');
+
+<mesh>
+  <boxGeometry args={[1, 1, 1]} />
+  <meshPhongMaterial map={texture} color="#ffffff" />
+</mesh>;
+```
+
+The pixels are uploaded once, on first use, and only rebound afterwards —
+the same rule as geometry, since a texture is kilobytes that must not cross
+the wire twice. The upload goes through `RenderLarge`, so it is one chunked
+request rather than a stream of commands. Texture coordinates come from the
+geometry (the primitives all generate them); the texture is applied in
+`GL_MODULATE`, so the material `color` tints it and lighting still applies.
+Filtering is linear and wrapping repeats.
 
 ### Pointer events on meshes
 
@@ -352,8 +376,8 @@ world space, so a light inside a rotating `<group>` moves with it.
 Not implemented, and failing with an error naming the reason:
 `<shaderMaterial>` (the protocol encodes no shaders), `<instancedMesh>`,
 `<points>`, `<line>`, post-processing — and no shadows, which need
-framebuffer objects. Camera elements and textures are the phases still to
-come — see [glx-plan.md](glx-plan.md).
+framebuffer objects. Camera elements are the one r3f concept still missing
+— the `camera` prop covers it for now. See [glx-plan.md](glx-plan.md).
 
 ---
 

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -313,6 +313,35 @@ material re-sends neither; changing a geometry's `args` recompiles just
 that list. `test/scene3d.test.js` asserts exactly this on the encoded
 command stream.
 
+### Pointer events on meshes
+
+`<mesh>` and `<group>` take `onClick`, `onPointerDown`, `onPointerUp`,
+`onPointerMove`, `onPointerOver` and `onPointerOut`, plus a `cursor` prop
+applied while the pointer is over them. `<glarea>`/`<Canvas3D>` takes
+`onPointerMissed` for clicks that hit nothing.
+
+```jsx
+<mesh
+  cursor="pointer"
+  onPointerOver={() => setHovered(true)}
+  onPointerOut={() => setHovered(false)}
+  onClick={(ev) => console.log('hit at', ev.point, 'distance', ev.distance)}
+>
+```
+
+The event carries `object` (the mesh that was hit), `point` (world
+coordinates), `distance`, `face`, `uv`, the pixel `x`/`y`, `nativeEvent`,
+and `stopPropagation()` — events bubble from the mesh up through its
+`<group>` ancestors. Only the nearest hit is dispatched.
+
+**Picking is client-side raycasting**, not GPU picking: a ray through the
+clicked pixel is intersected with the same CPU-side geometry the display
+lists were compiled from, using the world matrices of the last frame drawn.
+Reading pixels back would be a round trip per event, and on XQuartz GL
+output is not readable through `GetImage` at all. Only meshes that — or
+whose ancestors — have handlers are tested, and the surface asks the X
+server for pointer events only when the scene has at least one handler.
+
 **Lighting is the fixed-function pipeline**: per-vertex Gouraud shading and
 **8 light units** in total — more than eight non-ambient lights warns and
 uses the first eight. `<ambientLight>` costs no unit; its colour rides on
@@ -323,8 +352,8 @@ world space, so a light inside a rotating `<group>` moves with it.
 Not implemented, and failing with an error naming the reason:
 `<shaderMaterial>` (the protocol encodes no shaders), `<instancedMesh>`,
 `<points>`, `<line>`, post-processing — and no shadows, which need
-framebuffer objects. Camera elements, textures and pointer interaction are
-the phases still to come — see [glx-plan.md](glx-plan.md).
+framebuffer objects. Camera elements and textures are the phases still to
+come — see [glx-plan.md](glx-plan.md).
 
 ---
 

--- a/docs/glx-plan.md
+++ b/docs/glx-plan.md
@@ -201,8 +201,10 @@ commands with no vertices in it.
 **Phase 3 — shading.** Lights, `meshLambert`/`meshPhong`, `ShadeModel`,
 normals, `<perspectiveCamera>`/`<orthographicCamera>`, `<group>`.
 
-**Phase 4 — textures.** `TexImage2D` from ntk `Image`, texture cache,
-`map` prop on materials, `TexParameter` filtering/wrap.
+**Phase 4 — textures. DONE.** `map` on any material takes an ntk `Image`;
+`TexImage2D` uploads once through `RenderLarge`, the texture is cached per
+surface and only rebound afterwards, `GL_MODULATE` keeps the material
+colour and the lighting, filtering is linear and wrapping repeats.
 
 **Phase 5 — interaction. DONE.** `onClick`, `onPointerDown`/`Up`/`Move`,
 `onPointerOver`/`Out` and `cursor` on `<mesh>`/`<group>`, plus
@@ -258,8 +260,10 @@ should be defended by the benchmark rather than by intent.
   the GL child window always sit on top? (Affects whether HUD overlays are
   possible — likely "always on top", so overlays would need a sibling
   window.)
-- Is `RenderLarge` needed for compiling big display lists in one request,
-  and is it correctly implemented in node-x11?
+- ~~Is `RenderLarge` correctly implemented in node-x11?~~ **Yes** — texture
+  uploads go through it and land correctly on XQuartz. Display lists never
+  needed it: the vertex commands are ordinary `Render` batches, which the
+  pipeline already splits at 64 KB.
 
 ---
 

--- a/docs/glx-plan.md
+++ b/docs/glx-plan.md
@@ -204,9 +204,12 @@ normals, `<perspectiveCamera>`/`<orthographicCamera>`, `<group>`.
 **Phase 4 — textures.** `TexImage2D` from ntk `Image`, texture cache,
 `map` prop on materials, `TexParameter` filtering/wrap.
 
-**Phase 5 — interaction.** `onClick`/`onPointerOver` on `<mesh>` via
-**client-side** raycasting against the CPU-side geometry — there is no GPU
-picking here. Reuse the existing event plumbing on the `<glarea>` window.
+**Phase 5 — interaction. DONE.** `onClick`, `onPointerDown`/`Up`/`Move`,
+`onPointerOver`/`Out` and `cursor` on `<mesh>`/`<group>`, plus
+`onPointerMissed` on the surface. Client-side raycasting against the
+CPU-side geometry with the world matrices of the last frame drawn; events
+bubble with `stopPropagation()`, and the surface selects X pointer events
+only when the scene has a handler.
 
 **Phase 6 — docs and example.** `docs/3d.md`, an `examples/three.jsx`
 comparable to the widget gallery, README screenshots.

--- a/examples/three.jsx
+++ b/examples/three.jsx
@@ -6,8 +6,29 @@
 // Run with: npm run examples:three  (needs an X server with indirect GLX)
 import React, { useEffect, useRef, useState } from 'react';
 
+import { Image } from 'ntk';
+
 import { Button, Canvas3D, Switch } from '../src/components/index.js';
 import { createRoot } from '../src/index.js';
+
+/** A procedural checker, uploaded to the server once and bound per frame. */
+function checkerTexture(size = 64, squares = 8) {
+  const data = Buffer.alloc(size * size * 4);
+  const step = size / squares;
+  for (let y = 0; y < size; y++) {
+    for (let x = 0; x < size; x++) {
+      const dark = (Math.floor(x / step) + Math.floor(y / step)) % 2 === 0;
+      const i = (y * size + x) * 4;
+      data[i] = dark ? 0x20 : 0xf2;
+      data[i + 1] = dark ? 0x30 : 0xf6;
+      data[i + 2] = dark ? 0x45 : 0xf8;
+      data[i + 3] = 255;
+    }
+  }
+  return new Image({ width: size, height: size, data });
+}
+
+const CHECKER = checkerTexture();
 
 /** Advance a value every frame while `running`, via the window frame clock. */
 function useSpin(running, windowRef) {
@@ -35,6 +56,7 @@ function App() {
   const windowRef = useRef(null);
   const [running, setRunning] = useState(true);
   const [wireframe, setWireframe] = useState(false);
+  const [textured, setTextured] = useState(true);
   const [hovered, setHovered] = useState(null);
   const [picked, setPicked] = useState(null);
   const angle = useSpin(running, windowRef);
@@ -77,6 +99,7 @@ function App() {
               <boxGeometry args={[1.4, 1.4, 1.4]} />
               <meshPhongMaterial
                 color={tint('box', '#2980b9')}
+                map={textured ? CHECKER : undefined}
                 shininess={60}
                 wireframe={wireframe}
               />
@@ -113,6 +136,8 @@ function App() {
           <text fontSize={13}>Spin</text>
           <Switch checked={wireframe} onChange={setWireframe} />
           <text fontSize={13}>Wireframe</text>
+          <Switch checked={textured} onChange={setTextured} />
+          <text fontSize={13}>Texture</text>
           <box flexGrow={1} />
           <text fontSize={13} color="#5b6570">
             {picked ? `picked: ${picked}` : 'click a shape'}

--- a/examples/three.jsx
+++ b/examples/three.jsx
@@ -35,7 +35,20 @@ function App() {
   const windowRef = useRef(null);
   const [running, setRunning] = useState(true);
   const [wireframe, setWireframe] = useState(false);
+  const [hovered, setHovered] = useState(null);
+  const [picked, setPicked] = useState(null);
   const angle = useSpin(running, windowRef);
+
+  // pointer props shared by every mesh: hover highlight and click to pick,
+  // both resolved by raycasting against the geometry on the client
+  const pointer = (name) => ({
+    cursor: 'pointer',
+    onPointerOver: () => setHovered(name),
+    onPointerOut: () => setHovered((h) => (h === name ? null : h)),
+    onClick: () => setPicked((p) => (p === name ? null : name)),
+  });
+  const lift = (name) => (hovered === name ? 1.12 : 1);
+  const tint = (name, color) => (picked === name ? '#f1c40f' : color);
 
   return (
     <window ref={windowRef} width={560} height={460} title="react-x11 — 3D">
@@ -55,25 +68,42 @@ function App() {
           />
 
           <group rotation={[0, angle, 0]}>
-            <mesh position={[-1.6, 0, 0]} rotation={[0.5, 0.4, 0]}>
+            <mesh
+              position={[-1.6, 0, 0]}
+              rotation={[0.5, 0.4, 0]}
+              scale={lift('box')}
+              {...pointer('box')}
+            >
               <boxGeometry args={[1.4, 1.4, 1.4]} />
               <meshPhongMaterial
-                color="#2980b9"
+                color={tint('box', '#2980b9')}
                 shininess={60}
                 wireframe={wireframe}
               />
             </mesh>
-            <mesh position={[1.6, 0, 0]}>
+            <mesh
+              position={[1.6, 0, 0]}
+              scale={lift('ball')}
+              {...pointer('ball')}
+            >
               <sphereGeometry args={[0.9, 24, 16]} />
               <meshPhongMaterial
-                color="#e67e22"
+                color={tint('ball', '#e67e22')}
                 shininess={12}
                 wireframe={wireframe}
               />
             </mesh>
-            <mesh position={[0, -1.4, 0]} rotation={[Math.PI / 2, 0, 0]}>
+            <mesh
+              position={[0, -1.4, 0]}
+              rotation={[Math.PI / 2, 0, 0]}
+              scale={lift('ring')}
+              {...pointer('ring')}
+            >
               <torusGeometry args={[1.1, 0.28, 12, 36]} />
-              <meshLambertMaterial color="#27ae60" wireframe={wireframe} />
+              <meshLambertMaterial
+                color={tint('ring', '#27ae60')}
+                wireframe={wireframe}
+              />
             </mesh>
           </group>
         </Canvas3D>
@@ -84,6 +114,9 @@ function App() {
           <Switch checked={wireframe} onChange={setWireframe} />
           <text fontSize={13}>Wireframe</text>
           <box flexGrow={1} />
+          <text fontSize={13} color="#5b6570">
+            {picked ? `picked: ${picked}` : 'click a shape'}
+          </text>
           <Button onPress={() => setRunning((r) => !r)}>
             {running ? 'Pause' : 'Play'}
           </Button>

--- a/src/glnodes.js
+++ b/src/glnodes.js
@@ -8,6 +8,7 @@
 import { cssColor } from 'ntk';
 
 import { Node } from './nodes.js';
+import { ScenePointer, sceneWantsPointer } from './pointer3d.js';
 import { SceneRenderer } from './scene3d.js';
 
 // One visual query per (app, spec): GetFBConfigs is a round trip and every
@@ -74,6 +75,8 @@ export class GlAreaNode extends Node {
     this._frameScheduled = false;
     this._created = false;
     this.scene = new SceneRenderer(this);
+    this.pointer = new ScenePointer(this);
+    this._pointerDirty = true;
   }
 
   get isGlArea() {
@@ -194,6 +197,7 @@ export class GlAreaNode extends Node {
       this._created = true;
       this.props.onCreated?.(gl, info);
     }
+    this._syncPointerListeners();
     gl.Viewport(0, 0, width, height);
     const [r, g, b, a] = clearColorOf(this.props);
     gl.ClearColor(r, g, b, a);
@@ -216,17 +220,36 @@ export class GlAreaNode extends Node {
     else this.window?.map?.();
   }
 
+  /**
+   * X pointer events are only worth selecting when something in the scene
+   * listens for them — the r3f rule that only handler-bearing objects take
+   * part in picking, applied one level up, to the wire.
+   */
+  _syncPointerListeners() {
+    if (!this._pointerDirty || !this.window || this.pointer.attached) return;
+    this._pointerDirty = false;
+    if (!sceneWantsPointer(this.children)) return;
+    this.pointer.attach(this.window);
+  }
+
+  /** A scene node was added, removed, or gained/lost pointer handlers. */
+  _sceneChanged() {
+    this._pointerDirty = true;
+    this.requestFrame();
+  }
+
   /** scene children (<mesh>, <group>, …) attach to this surface. */
   insertBefore(child, beforeChild) {
     super.insertBefore(child, beforeChild);
     child._setSurface?.(this);
-    this.requestFrame();
+    this._sceneChanged();
   }
 
   removeChild(child) {
     super.removeChild(child);
     this.invalidateGeometry(child);
-    this.requestFrame();
+    this.pointer.forget(child);
+    this._sceneChanged();
   }
 
   /** A removed geometry's display list is no longer needed server-side. */

--- a/src/mat4.js
+++ b/src/mat4.js
@@ -156,3 +156,80 @@ export function lookAt(
   out[15] = 1;
   return out;
 }
+
+/** Inverse of an affine or projective 4x4; null when singular. */
+export function invert(m, out = new Float32Array(16)) {
+  const [
+    a00,
+    a01,
+    a02,
+    a03,
+    a10,
+    a11,
+    a12,
+    a13,
+    a20,
+    a21,
+    a22,
+    a23,
+    a30,
+    a31,
+    a32,
+    a33,
+  ] = m;
+
+  const b00 = a00 * a11 - a01 * a10;
+  const b01 = a00 * a12 - a02 * a10;
+  const b02 = a00 * a13 - a03 * a10;
+  const b03 = a01 * a12 - a02 * a11;
+  const b04 = a01 * a13 - a03 * a11;
+  const b05 = a02 * a13 - a03 * a12;
+  const b06 = a20 * a31 - a21 * a30;
+  const b07 = a20 * a32 - a22 * a30;
+  const b08 = a20 * a33 - a23 * a30;
+  const b09 = a21 * a32 - a22 * a31;
+  const b10 = a21 * a33 - a23 * a31;
+  const b11 = a22 * a33 - a23 * a32;
+
+  const det =
+    b00 * b11 - b01 * b10 + b02 * b09 + b03 * b08 - b04 * b07 + b05 * b06;
+  if (!det) return null;
+  const d = 1 / det;
+
+  out[0] = (a11 * b11 - a12 * b10 + a13 * b09) * d;
+  out[1] = (a02 * b10 - a01 * b11 - a03 * b09) * d;
+  out[2] = (a31 * b05 - a32 * b04 + a33 * b03) * d;
+  out[3] = (a22 * b04 - a21 * b05 - a23 * b03) * d;
+  out[4] = (a12 * b08 - a10 * b11 - a13 * b07) * d;
+  out[5] = (a00 * b11 - a02 * b08 + a03 * b07) * d;
+  out[6] = (a32 * b02 - a30 * b05 - a33 * b01) * d;
+  out[7] = (a20 * b05 - a22 * b02 + a23 * b01) * d;
+  out[8] = (a10 * b10 - a11 * b08 + a13 * b06) * d;
+  out[9] = (a01 * b08 - a00 * b10 - a03 * b06) * d;
+  out[10] = (a30 * b04 - a31 * b02 + a33 * b00) * d;
+  out[11] = (a21 * b02 - a20 * b04 - a23 * b00) * d;
+  out[12] = (a11 * b07 - a10 * b09 - a12 * b06) * d;
+  out[13] = (a00 * b09 - a01 * b07 + a02 * b06) * d;
+  out[14] = (a31 * b01 - a30 * b03 - a32 * b00) * d;
+  out[15] = (a20 * b03 - a21 * b01 + a22 * b00) * d;
+  return out;
+}
+
+/** Apply a matrix to a point, dividing through by w. */
+export function transformPoint(m, [x, y, z]) {
+  const w = m[3] * x + m[7] * y + m[11] * z + m[15] || 1;
+  return [
+    (m[0] * x + m[4] * y + m[8] * z + m[12]) / w,
+    (m[1] * x + m[5] * y + m[9] * z + m[13]) / w,
+    (m[2] * x + m[6] * y + m[10] * z + m[14]) / w,
+  ];
+}
+
+/** Apply a matrix to a direction (no translation, no w divide). */
+export function transformDirection(m, [x, y, z]) {
+  return [
+    m[0] * x + m[4] * y + m[8] * z,
+    m[1] * x + m[5] * y + m[9] * z,
+    m[2] * x + m[6] * y + m[10] * z,
+  ];
+}

--- a/src/pointer3d.js
+++ b/src/pointer3d.js
@@ -1,0 +1,158 @@
+// Pointer events for the 3D scene: X pointer events on the <glarea> window,
+// raycast against the CPU-side geometry (raycast3d.js), dispatched to the
+// mesh they hit and bubbled up its ancestors.
+//
+// The surface owns one X window, so this is a second, small event pipeline
+// beside the 2D EventManager rather than part of it: the hit test is a ray,
+// not a rect, and the events carry 3D information.
+import {
+  runWithPriority,
+  DiscreteEventPriority,
+  ContinuousEventPriority,
+} from './priority.js';
+import { hasPointerHandlers, raycast } from './raycast3d.js';
+
+/** Does anything in this subtree listen for pointer events? */
+export function sceneWantsPointer(nodes) {
+  for (const node of nodes) {
+    if (!node.isObject3D) continue;
+    if (hasPointerHandlers(node)) return true;
+    if (sceneWantsPointer(node.children)) return true;
+  }
+  return false;
+}
+
+/** The dispatch path: the mesh that was hit, then its ancestors. */
+function bubblePath(node, surface) {
+  const path = [];
+  for (let n = node; n && n !== surface; n = n.parent) path.push(n);
+  return path;
+}
+
+export class ScenePointer {
+  constructor(surface) {
+    this.surface = surface;
+    this.hovered = null;
+    this.pressed = null;
+    this.attached = false;
+  }
+
+  attach(wnd) {
+    if (this.attached || typeof wnd.on !== 'function') return;
+    this.attached = true;
+    wnd.on('mousedown', (ev) => this._onPointer('pointerdown', ev));
+    wnd.on('mouseup', (ev) => this._onPointer('pointerup', ev));
+    wnd.on('mousemove', (ev) => this._onPointer('pointermove', ev));
+    wnd.on('mouseout', () => this._onLeave());
+  }
+
+  /** The nearest hit under the pointer, or null. */
+  _pick(ev) {
+    const camera = this.surface.scene.camera;
+    if (!camera) return null;
+    const [hit] = raycast(this.surface, ev.x, ev.y, camera);
+    return hit ?? null;
+  }
+
+  _makeEvent(type, hit, native, target) {
+    let stopped = false;
+    return {
+      type,
+      target,
+      object: hit?.object ?? null,
+      point: hit?.point ?? null,
+      distance: hit?.distance ?? null,
+      face: hit?.face ?? null,
+      uv: hit?.uv ?? null,
+      x: native?.x,
+      y: native?.y,
+      nativeEvent: native,
+      surface: this.surface,
+      stopPropagation() {
+        stopped = true;
+      },
+      get propagationStopped() {
+        return stopped;
+      },
+    };
+  }
+
+  /** Call `on<Name>` along the bubble path until one stops propagation. */
+  _dispatch(name, hit, native, node = hit?.object) {
+    if (!node) return null;
+    const prop = `on${name[0].toUpperCase()}${name.slice(1)}`;
+    let event = null;
+    for (const target of bubblePath(node, this.surface)) {
+      const handler = target.props?.[prop];
+      if (typeof handler !== 'function') continue;
+      event = event ?? this._makeEvent(name.toLowerCase(), hit, native, target);
+      event.target = target;
+      handler(event);
+      if (event.propagationStopped) break;
+    }
+    return event;
+  }
+
+  _onPointer(type, native) {
+    const priority =
+      type === 'pointermove' ? ContinuousEventPriority : DiscreteEventPriority;
+    runWithPriority(priority, () => {
+      const hit = this._pick(native);
+      if (type === 'pointermove') {
+        this._updateHover(hit, native);
+        if (hit) this._dispatch('pointerMove', hit, native);
+        return;
+      }
+      if (type === 'pointerdown') {
+        this.pressed = hit?.object ?? null;
+        if (hit) this._dispatch('pointerDown', hit, native);
+        else
+          this.surface.props.onPointerMissed?.(
+            this._makeEvent('pointermissed', null, native, null),
+          );
+        return;
+      }
+      // pointerup: a click is down and up on the same object
+      if (hit) this._dispatch('pointerUp', hit, native);
+      if (hit && this.pressed === hit.object) {
+        this._dispatch('click', hit, native);
+      }
+      this.pressed = null;
+    });
+  }
+
+  /** enter/leave, diffed against the object hovered last time. */
+  _updateHover(hit, native) {
+    const next = hit?.object ?? null;
+    if (next === this.hovered) return;
+    const previous = this.hovered;
+    this.hovered = next;
+    if (previous && !previous.destroyed) {
+      this._dispatch('pointerOut', null, native, previous);
+    }
+    if (next) this._dispatch('pointerOver', hit, native);
+    this._applyCursor(next);
+  }
+
+  _applyCursor(node) {
+    const wnd = this.surface.window;
+    if (typeof wnd?.setCursor !== 'function') return;
+    const cursor = node?.props?.cursor ?? null;
+    if (cursor === this._cursor) return;
+    this._cursor = cursor;
+    wnd.setCursor(cursor);
+  }
+
+  _onLeave() {
+    if (!this.hovered) return;
+    runWithPriority(ContinuousEventPriority, () => {
+      this._updateHover(null, null);
+    });
+  }
+
+  /** A node left the tree: drop references to it. */
+  forget(node) {
+    if (this.hovered === node) this.hovered = null;
+    if (this.pressed === node) this.pressed = null;
+  }
+}

--- a/src/raycast3d.js
+++ b/src/raycast3d.js
@@ -1,0 +1,141 @@
+// Client-side picking for the 3D scene.
+//
+// There is no GPU picking here: reading pixels back over the protocol is a
+// round trip per event, and on XQuartz GL output is not even readable
+// through GetImage. So the ray is cast against the CPU-side geometry — the
+// same arrays the display lists were compiled from — the way three.js does
+// it. Only meshes that (or whose ancestors) have pointer handlers take part,
+// which is r3f's one optimization that matters.
+import { invert, multiply, transformDirection, transformPoint } from './mat4.js';
+
+const EPSILON = 1e-8;
+
+function normalize([x, y, z]) {
+  const len = Math.hypot(x, y, z) || 1;
+  return [x / len, y / len, z / len];
+}
+
+/**
+ * Möller–Trumbore. Returns the ray parameter at the intersection, or null.
+ * `dir` need not be unit length: `t` is then in the same units as `dir`,
+ * which is what keeps object-space hits comparable in world space.
+ */
+function intersectTriangle(origin, dir, a, b, c) {
+  const e1 = [b[0] - a[0], b[1] - a[1], b[2] - a[2]];
+  const e2 = [c[0] - a[0], c[1] - a[1], c[2] - a[2]];
+  const p = [
+    dir[1] * e2[2] - dir[2] * e2[1],
+    dir[2] * e2[0] - dir[0] * e2[2],
+    dir[0] * e2[1] - dir[1] * e2[0],
+  ];
+  const det = e1[0] * p[0] + e1[1] * p[1] + e1[2] * p[2];
+  if (Math.abs(det) < EPSILON) return null;
+  const inv = 1 / det;
+  const t0 = [origin[0] - a[0], origin[1] - a[1], origin[2] - a[2]];
+  const u = (t0[0] * p[0] + t0[1] * p[1] + t0[2] * p[2]) * inv;
+  if (u < 0 || u > 1) return null;
+  const q = [
+    t0[1] * e1[2] - t0[2] * e1[1],
+    t0[2] * e1[0] - t0[0] * e1[2],
+    t0[0] * e1[1] - t0[1] * e1[0],
+  ];
+  const v = (dir[0] * q[0] + dir[1] * q[1] + dir[2] * q[2]) * inv;
+  if (v < 0 || u + v > 1) return null;
+  const t = (e2[0] * q[0] + e2[1] * q[1] + e2[2] * q[2]) * inv;
+  return t > EPSILON ? { t, u, v } : null;
+}
+
+/**
+ * The world-space ray through a pixel of the surface.
+ * @returns {{origin: number[], direction: number[]}}
+ */
+export function rayThrough(x, y, { width, height, projection, view }) {
+  const inverse = invert(multiply(projection, view));
+  if (!inverse) return null;
+  const ndcX = (2 * x) / width - 1;
+  const ndcY = 1 - (2 * y) / height;
+  const near = transformPoint(inverse, [ndcX, ndcY, -1]);
+  const far = transformPoint(inverse, [ndcX, ndcY, 1]);
+  return {
+    origin: near,
+    direction: normalize([
+      far[0] - near[0],
+      far[1] - near[1],
+      far[2] - near[2],
+    ]),
+  };
+}
+
+const POINTER_PROPS = [
+  'onClick',
+  'onPointerDown',
+  'onPointerUp',
+  'onPointerMove',
+  'onPointerOver',
+  'onPointerOut',
+];
+
+export const hasPointerHandlers = (node) =>
+  POINTER_PROPS.some((name) => typeof node.props?.[name] === 'function');
+
+/** Meshes worth testing: they, or an ancestor, listen for pointer events. */
+function pickable(nodes, inherited, out = []) {
+  for (const node of nodes) {
+    if (!node.isObject3D || !node.visible) continue;
+    const listening = inherited || hasPointerHandlers(node);
+    if (listening && node.kind === 'mesh' && node.geometry) out.push(node);
+    pickable(node.children, listening, out);
+  }
+  return out;
+}
+
+/**
+ * Intersect the scene under `surface` with the ray through pixel (x, y).
+ * `world` matrices come from the last rendered frame.
+ * @returns {Array<{object, distance, point, face}>} nearest first
+ */
+export function raycast(surface, x, y, camera) {
+  const ray = rayThrough(x, y, camera);
+  if (!ray) return [];
+  const hits = [];
+
+  for (const mesh of pickable(surface.children, false)) {
+    const world = mesh._world;
+    const toObject = world ? invert(world) : null;
+    if (!toObject) continue;
+    const origin = transformPoint(toObject, ray.origin);
+    const direction = transformDirection(toObject, ray.direction);
+    const { positions, index } = mesh.geometry.data();
+    const count = index ? index.length : positions.length / 3;
+    const vertex = (i) => {
+      const v = index ? index[i] : i;
+      return [positions[v * 3], positions[v * 3 + 1], positions[v * 3 + 2]];
+    };
+
+    let best = null;
+    for (let i = 0; i + 2 < count; i += 3) {
+      const hit = intersectTriangle(
+        origin,
+        direction,
+        vertex(i),
+        vertex(i + 1),
+        vertex(i + 2),
+      );
+      if (hit && (!best || hit.t < best.t)) best = { ...hit, face: i / 3 };
+    }
+    if (!best) continue;
+    hits.push({
+      object: mesh,
+      distance: best.t,
+      point: [
+        ray.origin[0] + ray.direction[0] * best.t,
+        ray.origin[1] + ray.direction[1] * best.t,
+        ray.origin[2] + ray.direction[2] * best.t,
+      ],
+      face: best.face,
+      uv: [best.u, best.v],
+    });
+  }
+
+  return hits.sort((a, b) => a.distance - b.distance);
+}

--- a/src/raycast3d.js
+++ b/src/raycast3d.js
@@ -6,7 +6,12 @@
 // same arrays the display lists were compiled from — the way three.js does
 // it. Only meshes that (or whose ancestors) have pointer handlers take part,
 // which is r3f's one optimization that matters.
-import { invert, multiply, transformDirection, transformPoint } from './mat4.js';
+import {
+  invert,
+  multiply,
+  transformDirection,
+  transformPoint,
+} from './mat4.js';
 
 const EPSILON = 1e-8;
 

--- a/src/scene3d.js
+++ b/src/scene3d.js
@@ -318,6 +318,8 @@ export class SceneRenderer {
     this.surface = surface;
     this.lists = new Map(); // GeometryNode -> { id, version }
     this.nextList = 1;
+    this.textures = new Map(); // image -> texture id
+    this.nextTexture = 1;
     this.materialKey = null;
     this.initialized = false;
     this.enabledLights = 0;
@@ -380,6 +382,37 @@ export class SceneRenderer {
     if (!geometry) return;
     this.applyMaterial(gl, mesh.material);
     gl.CallList(this.listFor(gl, geometry));
+  }
+
+  /**
+   * Upload once, bind per frame. Texture pixels are the same problem as
+   * geometry — kilobytes that must not cross the wire twice — so an ntk
+   * `Image` is uploaded on first use and only rebound afterwards.
+   * `map` is an ntk Image, or anything with { width, height, data } in
+   * RGBA byte order.
+   */
+  textureFor(gl, image) {
+    const cached = this.textures.get(image);
+    if (cached) return cached;
+    const id = this.nextTexture++;
+    gl.BindTexture(gl.TEXTURE_2D, id);
+    gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+    gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.REPEAT);
+    gl.TexParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.REPEAT);
+    gl.TexImage2D(
+      gl.TEXTURE_2D,
+      0,
+      gl.RGBA,
+      image.width,
+      image.height,
+      0,
+      gl.RGBA,
+      gl.UNSIGNED_BYTE,
+      image.data,
+    );
+    this.textures.set(image, id);
+    return id;
   }
 
   /** Compile once, replay forever — this is the whole point of the design. */
@@ -553,6 +586,8 @@ export class SceneRenderer {
     // <meshBasicMaterial> is unlit by definition, and a lit material with no
     // light in the scene would render black — fall back to flat colour
     const lit = kind !== 'meshBasicMaterial' && this.lit;
+    // texturing is state like everything else here, so it is part of the key
+    const map = props.map ?? null;
     const key = [
       kind,
       lit,
@@ -566,6 +601,7 @@ export class SceneRenderer {
       props.shininess,
       props.specular,
       props.emissive,
+      map ? (this.textures.get(map) ?? 'new') : 'none',
     ].join('|');
     if (key === this.materialKey) return;
     this.materialKey = key;
@@ -612,6 +648,15 @@ export class SceneRenderer {
       else gl.Color3f(r, g, b);
     }
 
+    if (map?.width && map?.data) {
+      gl.Enable(gl.TEXTURE_2D);
+      gl.BindTexture(gl.TEXTURE_2D, this.textureFor(gl, map));
+      // MODULATE: the texture is tinted by the colour and the lighting
+      gl.TexEnvi(gl.TEXTURE_ENV, gl.TEXTURE_ENV_MODE, gl.MODULATE);
+    } else {
+      gl.Disable(gl.TEXTURE_2D);
+    }
+
     gl.PolygonMode(gl.FRONT_AND_BACK, props.wireframe ? gl.LINE : gl.FILL);
     if (props.side === 'double') {
       gl.Disable(gl.CULL_FACE);
@@ -632,5 +677,7 @@ export class SceneRenderer {
   dispose(gl) {
     for (const { id } of this.lists.values()) gl?.DeleteLists?.(id, 1);
     this.lists.clear();
+    if (this.textures.size) gl?.DeleteTextures?.([...this.textures.values()]);
+    this.textures.clear();
   }
 }

--- a/src/scene3d.js
+++ b/src/scene3d.js
@@ -23,6 +23,7 @@ import {
   perspective,
 } from './mat4.js';
 import { Node } from './nodes.js';
+import { hasPointerHandlers } from './raycast3d.js';
 
 export const GEOMETRY_KINDS = new Set([
   ...Object.keys(GEOMETRY_BUILDERS),
@@ -94,19 +95,27 @@ export class Object3DNode extends Node {
   insertBefore(child, beforeChild) {
     super.insertBefore(child, beforeChild);
     child._setSurface?.(this.surface);
-    this.surface?.requestFrame();
+    this.surface?._sceneChanged?.();
   }
 
   removeChild(child) {
     super.removeChild(child);
     this.surface?.invalidateGeometry?.(child);
-    this.surface?.requestFrame();
+    this.surface?.pointer?.forget(child);
+    this.surface?._sceneChanged?.();
   }
 
   applyProps(newProps) {
+    const before = this.props;
     this.props = newProps;
     this._matrixDirty = true;
-    this.surface?.requestFrame();
+    // gaining or losing handlers changes whether the surface needs X
+    // pointer events at all
+    if (hasPointerHandlers({ props: before }) !== hasPointerHandlers(this)) {
+      this.surface?._sceneChanged?.();
+    } else {
+      this.surface?.requestFrame();
+    }
   }
 
   setHidden(hidden) {
@@ -257,7 +266,7 @@ const DEFAULT_CAMERA = {
   zoom: 1,
 };
 
-function cameraMatrices(spec, { width, height }) {
+export function cameraMatrices(spec, { width, height }) {
   const camera = { ...DEFAULT_CAMERA, ...spec };
   const aspect = width / Math.max(1, height);
   const projection = camera.orthographic
@@ -333,6 +342,8 @@ export class SceneRenderer {
       this.surface.props.camera,
       info,
     );
+    // kept for picking: rays are cast against the frame that is on screen
+    this.camera = { projection, view, width: info.width, height: info.height };
     gl.MatrixMode(gl.PROJECTION);
     gl.LoadIdentity();
     gl.MultMatrixf(projection);
@@ -345,17 +356,21 @@ export class SceneRenderer {
     // positions land in eye space exactly as GL expects
     this.applyLights(gl, collectLights(roots, identity()));
 
-    for (const node of roots) this.drawObject(gl, node);
+    for (const node of roots) this.drawObject(gl, node, identity());
     return true;
   }
 
-  drawObject(gl, node) {
+  drawObject(gl, node, parentWorld) {
     if (!node.visible) return;
+    // the world matrix is recorded rather than recomputed later: picking
+    // rays are transformed by exactly what was drawn
+    const world = multiply(parentWorld, node.localMatrix());
+    node._world = world;
     gl.PushMatrix();
     gl.MultMatrixf(node.localMatrix());
     if (node.kind === 'mesh') this.drawMesh(gl, node);
     for (const child of node.children) {
-      if (child.isObject3D) this.drawObject(gl, child);
+      if (child.isObject3D) this.drawObject(gl, child, world);
     }
     gl.PopMatrix();
   }

--- a/test/pointer3d.test.js
+++ b/test/pointer3d.test.js
@@ -67,7 +67,11 @@ function findSurface(node) {
 /** Mount a scene and draw one frame, so picking has a camera to work with. */
 async function mount(app, scene, size = { width: 400, height: 300 }) {
   const instance = await render(
-    h('window', size, h(Canvas3D, { flexGrow: 1, ...scene.canvas }, scene.children)),
+    h(
+      'window',
+      size,
+      h(Canvas3D, { flexGrow: 1, ...scene.canvas }, scene.children),
+    ),
     app,
   );
   const surface = findSurface(instance._reactX11Node);
@@ -145,14 +149,7 @@ test('hover enters and leaves as the pointer crosses a mesh', async () => {
     pointer(surface, 'mousemove', 5, 5); // off it
     pointer(surface, 'mousemove', 200, 150); // back on
 
-    assert.deepEqual(log, [
-      'over',
-      'move',
-      'move',
-      'out',
-      'over',
-      'move',
-    ]);
+    assert.deepEqual(log, ['over', 'move', 'move', 'out', 'over', 'move']);
   } finally {
     await app.close();
   }
@@ -179,7 +176,11 @@ test('the nearest mesh wins, and events bubble to the group', async () => {
 
     assert.deepEqual(hits, ['near'], 'only the nearest mesh is hit');
     assert.equal(groupClicks.length, 1, 'and the click bubbles to the group');
-    assert.equal(groupClicks[0].object.props.position[2], 2, 'with the hit mesh on it');
+    assert.equal(
+      groupClicks[0].object.props.position[2],
+      2,
+      'with the hit mesh on it',
+    );
   } finally {
     await app.close();
   }

--- a/test/pointer3d.test.js
+++ b/test/pointer3d.test.js
@@ -1,0 +1,273 @@
+// Pointer events on meshes: a ray through the clicked pixel, cast against
+// the CPU-side geometry, dispatched to the mesh it hits and bubbled up.
+// Hermetic — the in-process X server with node-x11's GLX emulator; pointer
+// events are fed to the surface window the way the server would.
+import assert from 'node:assert/strict';
+import { createRequire } from 'node:module';
+import { test } from 'node:test';
+
+import React from 'react';
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient, StaticFontSource } from 'ntk';
+
+import ReactX11, { Canvas3D } from '../src/index.js';
+
+const require = createRequire(import.meta.url);
+const { createGlxExtension, RecordingBackend } = require('x11/browser/glx');
+
+const h = React.createElement;
+
+async function createGlApp() {
+  const server = xserver.createServer({ width: 640, height: 480 });
+  server.registerExtension(
+    'GLX',
+    createGlxExtension({
+      backend: new RecordingBackend(),
+      getDrawableSurface: () => null,
+    }),
+  );
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const app = await createClient({
+    stream: clientEnd,
+    fontSource: new StaticFontSource(),
+  });
+  return { app };
+}
+
+const render = (element, app) =>
+  new Promise((resolve) => ReactX11.render(element, resolve, app));
+
+const settle = async (app, roundTrips = 2) => {
+  for (let i = 0; i < roundTrips; i++) {
+    await new Promise((resolve, reject) =>
+      app.X.GetInputFocus((err) => (err ? reject(err) : resolve())),
+    );
+  }
+};
+
+async function waitFor(check, what, timeout = 3000) {
+  const deadline = Date.now() + timeout;
+  for (;;) {
+    if (check()) return;
+    if (Date.now() > deadline) assert.fail(`timed out waiting for ${what}`);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+}
+
+function findSurface(node) {
+  if (node.isGlArea) return node;
+  for (const child of node.children ?? []) {
+    const found = findSurface(child);
+    if (found) return found;
+  }
+  return null;
+}
+
+/** Mount a scene and draw one frame, so picking has a camera to work with. */
+async function mount(app, scene, size = { width: 400, height: 300 }) {
+  const instance = await render(
+    h('window', size, h(Canvas3D, { flexGrow: 1, ...scene.canvas }, scene.children)),
+    app,
+  );
+  const surface = findSurface(instance._reactX11Node);
+  await waitFor(() => surface.gl?.contextTag > 0, 'the GL context');
+  surface.requestFrame = () => {};
+  surface._drawFrame();
+  await settle(app);
+  return surface;
+}
+
+// what the X server delivers to the surface window
+const pointer = (surface, type, x, y) =>
+  surface.window.emit(type, { x, y, type: 0, buttons: 0 });
+
+const CUBE = (props = {}) =>
+  h(
+    'mesh',
+    props,
+    h('boxGeometry', { args: [2, 2, 2] }),
+    h('meshBasicMaterial', { color: 'tomato' }),
+  );
+
+test('a click on a mesh hits it, and a click past it misses', async () => {
+  const { app } = await createGlApp();
+  try {
+    const clicks = [];
+    const missed = [];
+    const surface = await mount(app, {
+      canvas: {
+        camera: { position: [0, 0, 6] },
+        onPointerMissed: () => missed.push(true),
+      },
+      children: CUBE({ onClick: (ev) => clicks.push(ev) }),
+    });
+
+    // dead centre: the cube fills the middle of a 400x300 viewport
+    pointer(surface, 'mousedown', 200, 150);
+    pointer(surface, 'mouseup', 200, 150);
+    assert.equal(clicks.length, 1, 'one click on the cube');
+
+    const [ev] = clicks;
+    assert.equal(ev.object.kind, 'mesh');
+    assert.ok(ev.distance > 3 && ev.distance < 6, `distance ${ev.distance}`);
+    assert.ok(
+      Math.abs(ev.point[0]) < 0.01 && Math.abs(ev.point[1]) < 0.01,
+      `the hit point is on the axis: ${ev.point}`,
+    );
+    assert.ok(ev.point[2] > 0.9, 'and on the near face');
+
+    // a corner of the viewport is past the cube
+    pointer(surface, 'mousedown', 5, 5);
+    pointer(surface, 'mouseup', 5, 5);
+    assert.equal(clicks.length, 1, 'no second click');
+    assert.equal(missed.length, 1, 'onPointerMissed instead');
+  } finally {
+    await app.close();
+  }
+});
+
+test('hover enters and leaves as the pointer crosses a mesh', async () => {
+  const { app } = await createGlApp();
+  try {
+    const log = [];
+    const surface = await mount(app, {
+      canvas: { camera: { position: [0, 0, 6] } },
+      children: CUBE({
+        onPointerOver: () => log.push('over'),
+        onPointerOut: () => log.push('out'),
+        onPointerMove: () => log.push('move'),
+      }),
+    });
+
+    pointer(surface, 'mousemove', 200, 150);
+    pointer(surface, 'mousemove', 201, 150); // still on the cube
+    pointer(surface, 'mousemove', 5, 5); // off it
+    pointer(surface, 'mousemove', 200, 150); // back on
+
+    assert.deepEqual(log, [
+      'over',
+      'move',
+      'move',
+      'out',
+      'over',
+      'move',
+    ]);
+  } finally {
+    await app.close();
+  }
+});
+
+test('the nearest mesh wins, and events bubble to the group', async () => {
+  const { app } = await createGlApp();
+  try {
+    const hits = [];
+    const groupClicks = [];
+    const surface = await mount(app, {
+      canvas: { camera: { position: [0, 0, 10] } },
+      children: h(
+        'group',
+        { onClick: (ev) => groupClicks.push(ev) },
+        // same place, one in front of the other
+        CUBE({ position: [0, 0, 2], onClick: () => hits.push('near') }),
+        CUBE({ position: [0, 0, -2], onClick: () => hits.push('far') }),
+      ),
+    });
+
+    pointer(surface, 'mousedown', 200, 150);
+    pointer(surface, 'mouseup', 200, 150);
+
+    assert.deepEqual(hits, ['near'], 'only the nearest mesh is hit');
+    assert.equal(groupClicks.length, 1, 'and the click bubbles to the group');
+    assert.equal(groupClicks[0].object.props.position[2], 2, 'with the hit mesh on it');
+  } finally {
+    await app.close();
+  }
+});
+
+test('stopPropagation keeps an event off the ancestors', async () => {
+  const { app } = await createGlApp();
+  try {
+    const seen = [];
+    const surface = await mount(app, {
+      canvas: { camera: { position: [0, 0, 6] } },
+      children: h(
+        'group',
+        { onClick: () => seen.push('group') },
+        CUBE({
+          onClick: (ev) => {
+            seen.push('mesh');
+            ev.stopPropagation();
+          },
+        }),
+      ),
+    });
+
+    pointer(surface, 'mousedown', 200, 150);
+    pointer(surface, 'mouseup', 200, 150);
+    assert.deepEqual(seen, ['mesh']);
+  } finally {
+    await app.close();
+  }
+});
+
+test('a transform moves what the ray hits', async () => {
+  const { app } = await createGlApp();
+  try {
+    const hits = [];
+    const scene = (x) => ({
+      canvas: { camera: { position: [0, 0, 6] } },
+      children: CUBE({ position: [x, 0, 0], onClick: () => hits.push(x) }),
+    });
+    const surface = await mount(app, scene(0));
+
+    pointer(surface, 'mousedown', 200, 150);
+    pointer(surface, 'mouseup', 200, 150);
+    assert.deepEqual(hits, [0], 'centred cube is under the centre pixel');
+
+    // move it far to the left and redraw: the centre pixel now misses
+    await render(
+      h(
+        'window',
+        { width: 400, height: 300 },
+        h(
+          Canvas3D,
+          { flexGrow: 1, camera: { position: [0, 0, 6] } },
+          CUBE({ position: [-6, 0, 0], onClick: () => hits.push(-6) }),
+        ),
+      ),
+      app,
+    );
+    surface._drawFrame();
+    await settle(app);
+
+    pointer(surface, 'mousedown', 200, 150);
+    pointer(surface, 'mouseup', 200, 150);
+    assert.deepEqual(hits, [0], 'nothing under the centre any more');
+  } finally {
+    await app.close();
+  }
+});
+
+test('X pointer events are only selected when the scene listens', async () => {
+  const { app } = await createGlApp();
+  try {
+    const quiet = await mount(app, {
+      canvas: {},
+      children: CUBE(),
+    });
+    assert.equal(
+      quiet.pointer.attached,
+      false,
+      'no handlers: no motion events asked for',
+    );
+
+    const listening = await mount(app, {
+      canvas: {},
+      children: CUBE({ onClick: () => {} }),
+    });
+    assert.equal(listening.pointer.attached, true);
+  } finally {
+    await app.close();
+  }
+});

--- a/test/scene3d.test.js
+++ b/test/scene3d.test.js
@@ -502,3 +502,106 @@ test('a lit material with no lights falls back to flat colour', async () => {
     await app.close();
   }
 });
+
+test('a texture is uploaded once and only rebound afterwards', async () => {
+  const { app, backend, tap } = await createGlApp();
+  try {
+    // a 2x2 RGBA checker, the shape ntk's Image has
+    const map = {
+      width: 2,
+      height: 2,
+      data: Buffer.from([
+        255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255, 255, 255, 255, 255,
+      ]),
+    };
+    const scene = (color) =>
+      h(
+        'window',
+        { width: 320, height: 240 },
+        h(
+          Canvas3D,
+          { flexGrow: 1 },
+          h(
+            'mesh',
+            {},
+            h('planeGeometry', { args: [2, 2] }),
+            h('meshBasicMaterial', { map, color }),
+          ),
+        ),
+      );
+
+    const instance = await render(scene('white'), app);
+    const surface = findSurface(instance._reactX11Node);
+    await waitFor(() => surface.gl?.contextTag > 0, 'the GL context');
+    takeFrameControl(surface);
+    // no clearing here: the upload happens on the very first frame, which
+    // the mount already drew
+    await drawFrame(surface, app, tap);
+    const first = frameCalls(backend);
+    const uploads = first.filter((c) => c[0] === 'texImage2D');
+    assert.equal(uploads.length, 1, 'uploaded on first use');
+    assert.deepEqual(
+      [uploads[0][4], uploads[0][5]],
+      [2, 2],
+      'with the image size',
+    );
+    assert.ok(
+      first.some((c) => c[0] === 'bindTexture'),
+      'and bound for the draw',
+    );
+
+    // a material change re-sends state, never the pixels
+    backend.calls.length = 0;
+    await render(scene('tomato'), app);
+    await drawFrame(surface, app, tap);
+    const second = frameCalls(backend);
+    assert.equal(
+      second.filter((c) => c[0] === 'texImage2D').length,
+      0,
+      'no re-upload',
+    );
+    assert.ok(
+      second.some((c) => c[0] === 'bindTexture'),
+      'just a rebind',
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test('a material without a map turns texturing off', async () => {
+  const { app, backend, tap } = await createGlApp();
+  try {
+    const instance = await render(
+      h(
+        'window',
+        { width: 320, height: 240 },
+        h(
+          Canvas3D,
+          { flexGrow: 1 },
+          h(
+            'mesh',
+            {},
+            h('boxGeometry', { args: [1, 1, 1] }),
+            h('meshBasicMaterial', { color: 'white' }),
+          ),
+        ),
+      ),
+      app,
+    );
+    const surface = findSurface(instance._reactX11Node);
+    await waitFor(() => surface.gl?.contextTag > 0, 'the GL context');
+    takeFrameControl(surface);
+
+    backend.calls.length = 0;
+    await drawFrame(surface, app, tap);
+    const calls = frameCalls(backend);
+    assert.ok(
+      calls.some((c) => c[0] === 'disable' && c[1] === 0x0de1), // GL_TEXTURE_2D
+      'texturing disabled for an untextured mesh',
+    );
+    assert.equal(calls.filter((c) => c[0] === 'texImage2D').length, 0);
+  } finally {
+    await app.close();
+  }
+});

--- a/test/scene3d.test.js
+++ b/test/scene3d.test.js
@@ -143,6 +143,17 @@ function takeFrameControl(surface) {
   return surface;
 }
 
+/**
+ * The GL calls of a single frame. A frame already scheduled by the mount can
+ * still land after the test clears the buffer — it draws the same scene, so
+ * the content is right either way, but counting across two frames is not.
+ * SwapBuffers ends a frame, and the emulator surfaces that as `finish`.
+ */
+function frameCalls(backend) {
+  const end = backend.calls.findIndex((c) => c[0] === 'finish');
+  return end === -1 ? backend.calls : backend.calls.slice(0, end + 1);
+}
+
 /** Draw one frame the way an animation tick or an expose would. */
 async function drawFrame(surface, app, tap) {
   surface._drawFrame();
@@ -414,16 +425,17 @@ test('lights drive the lit materials, and ambient needs no unit of its own', asy
     await drawFrame(surface, app, tap);
 
     // one light unit: the ambient term rides on it, the point light drives it
-    const enabled = backend.calls.filter(
+    const calls = frameCalls(backend);
+    const enabled = calls.filter(
       (c) => c[0] === 'enable' && c[1] === 0x4000, // GL_LIGHT0
     );
     assert.equal(enabled.length, 1, 'GL_LIGHT0 enabled, and only it');
     assert.ok(
-      backend.calls.some((c) => c[0] === 'enable' && c[1] === 0x0b50), // LIGHTING
+      calls.some((c) => c[0] === 'enable' && c[1] === 0x0b50), // LIGHTING
       'lighting turned on for a lit material',
     );
 
-    const lightCalls = backend.calls.filter((c) => c[0] === 'light');
+    const lightCalls = calls.filter((c) => c[0] === 'light');
     // backend.light(lightEnum, pname, params)
     const position = lightCalls.find((c) => c[2] === 0x1203); // GL_POSITION
     assert.deepEqual(
@@ -437,7 +449,7 @@ test('lights drive the lit materials, and ambient needs no unit of its own', asy
       `<ambientLight intensity={0.3}> lands in GL_AMBIENT, got ${ambient[3][0]}`,
     );
 
-    const material = backend.calls.filter((c) => c[0] === 'material');
+    const material = calls.filter((c) => c[0] === 'material');
     assert.ok(
       material.some((c) => c[2] === 0x1602), // AMBIENT_AND_DIFFUSE
       'the material colour becomes the surface reflectance',


### PR DESCRIPTION
Phase 5 of [docs/glx-plan.md](docs/glx-plan.md).

```jsx
<mesh
  cursor="pointer"
  onPointerOver={() => setHovered(true)}
  onPointerOut={() => setHovered(false)}
  onClick={(ev) => console.log('hit at', ev.point, 'distance', ev.distance)}
>
  <boxGeometry args={[1.4, 1.4, 1.4]} />
  <meshPhongMaterial color={picked ? '#f1c40f' : '#2980b9'} />
</mesh>
```

`<mesh>` and `<group>` take `onClick`, `onPointerDown`, `onPointerUp`, `onPointerMove`, `onPointerOver`, `onPointerOut` and a `cursor` prop; the surface takes `onPointerMissed`. The event carries the hit — `object`, world `point`, `distance`, `face`, `uv`, the pixel `x`/`y`, `nativeEvent` — and bubbles from the mesh up its `<group>` ancestors, with `stopPropagation()`.

**Picking is client-side raycasting, not GPU picking.** A ray through the clicked pixel is intersected with the same CPU-side geometry the display lists were compiled from, using the world matrices recorded during the last frame drawn. Reading pixels back would be a round trip per event, and on XQuartz GL output is not readable through `GetImage` at all — the plan called this out before any of it was written.

Two things keep it cheap, the r3f rule applied at two levels:

- only meshes that, or whose ancestors, have handlers are tested at all;
- the surface asks the X server for pointer events only once the scene has at least one handler, so a scene with no handlers selects **no motion events on the wire**.

### Testing

`test/pointer3d.test.js`, hermetic over the in-process X server: a click at the centre reports a hit point on the cube's near face at a plausible distance, a click past it fires `onPointerMissed`, hover fires over/move/out as the pointer crosses and re-enters, the nearest of two overlapping meshes wins and the click bubbles to the group carrying the hit mesh, `stopPropagation()` cuts the path, moving a mesh moves what the ray hits, and a handler-free scene never attaches the X listeners.

`examples/three.jsx` is now interactive — hovering lifts a shape, clicking picks it and the label under the canvas follows. Note XTEST is not advertised by XQuartz, so the real-server check there is visual rather than scripted; the dispatch path itself is covered hermetically.

Phase 4 (textures) and the README screenshots are what is left of the plan.