### PR TITLE
feat: safe-polygon hover for submenus and tooltips

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -470,7 +470,7 @@ menus/tooltips.
 Found while using the widget set. Both are worth doing before 1.0.0 gets
 much use, and neither depends on the GLX work.
 
-### 11.1 "Safe polygon" for menus, submenus and tooltips
+### 11.1 "Safe polygon" for menus, submenus and tooltips — DONE
 
 Submenus open and switch **on hover with no delay and no exit tolerance**
 (`Menu.js`, the `hover(index)` path). Moving the pointer diagonally from a
@@ -479,6 +479,12 @@ each of which immediately re-points `path` and closes the submenu the user
 was aiming at. Tooltips have the same shape of problem: any pixel outside
 the trigger dismisses them, so a tooltip with interactive content cannot be
 reached.
+
+Fixed: the helpers live in `src/components/anchor.js` (`movingToward`,
+`safePolygon`, `pointInPolygon`, `screenPoint`, `SAFE_HOVER_DELAY`), and
+both `MenuLevel` and `Tooltip` use them; a tooltip now also stays up while
+the pointer is over it, so tooltip content is reachable. What follows is
+the original description.
 
 The fix is floating-ui's [`safePolygon`](https://floating-ui.com/docs/usehover#safepolygon):
 while a child surface is open, build a triangle from the pointer's position

--- a/docs/components.md
+++ b/docs/components.md
@@ -215,6 +215,27 @@ takes focus when the menu opens.
 Switching between `MenuBar` menus reuses the same X window and moves it
 rather than destroying and recreating one, so there is no flicker.
 
+### Safe-polygon hover
+
+Reaching a submenu means moving the pointer _diagonally_ across the rows in
+between, and reaching a tooltip means leaving the trigger it belongs to — so
+naive hover handling closes both just as the user aims at them. `MenuBar`,
+`ContextMenu` and `Tooltip` therefore use
+[floating-ui's safePolygon](https://floating-ui.com/docs/usehover#safepolygon)
+idea: the triangle between where the pointer was and the near edge of the
+open surface counts as still hovering the parent.
+
+While the pointer is inside that triangle, hover changes are held back —
+but only for `SAFE_HOVER_DELAY` (320 ms), so a pointer that stops there
+still means what it landed on. Leaving the triangle switches immediately,
+and reaching the surface keeps it open for as long as the pointer stays.
+
+The helpers are exported for widgets of your own:
+`movingToward(point, apex, rect)`, `safePolygon(apex, rect, buffer)`,
+`pointInPolygon(point, polygon)` and `screenPoint(ev)`. All coordinates are
+**screen** coordinates, because the trigger and the popup are different X
+windows.
+
 ## `Canvas3D`
 
 The entry point to the [3D scene](elements.md#3d-scene-mesh-group-geometries-materials)

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -8,7 +8,10 @@ import {
   DEFAULT_LABEL_SIZE,
   anchorRect,
   measureLabel,
+  movingToward,
+  SAFE_HOVER_DELAY,
   screenOf,
+  screenPoint,
 } from './anchor.js';
 import { typeAheadChar, useTypeAhead } from './typeahead.js';
 import {
@@ -84,7 +87,15 @@ function nextSelectable(items, from, dir) {
   return -1;
 }
 
-function MenuRow({ item, active, onHover, onSelect, fontSize, nodeRef }) {
+function MenuRow({
+  item,
+  active,
+  onHover,
+  onMove,
+  onSelect,
+  fontSize,
+  nodeRef,
+}) {
   const theme = useTheme();
   if (item.separator) {
     return h(
@@ -107,6 +118,7 @@ function MenuRow({ item, active, onHover, onSelect, fontSize, nodeRef }) {
       cursor: dim ? undefined : 'pointer',
       backgroundColor: active ? theme.hoverBackground : theme.background,
       onMouseEnter: dim ? undefined : onHover,
+      onMouseMove: dim ? undefined : onMove,
       onClick: dim ? undefined : () => onSelect(item),
     },
     h(
@@ -201,10 +213,63 @@ function MenuLevel({
     );
   }, [childOpen, active, depth, fontSize, rect.x, rect.y]);
 
-  const hover = (index) => {
+  // "safe polygon" hover: while a submenu is open, the triangle between the
+  // pointer and the submenu's near edge counts as still hovering the parent
+  // row, so moving diagonally across the rows in between does not close the
+  // submenu being aimed at (docs/components.md).
+  const apexRef = useRef(null);
+  const pendingRef = useRef(null);
+
+  const cancelPending = () => {
+    if (pendingRef.current) {
+      clearTimeout(pendingRef.current);
+      pendingRef.current = null;
+    }
+  };
+
+  // any change to the open path — including the pointer reaching the
+  // submenu — retires a deferred switch: it would close what was reached
+  useEffect(() => cancelPending, []);
+  useEffect(cancelPending, [path.join(','), childOpen]);
+
+  const applyHover = (index) => {
     const base = [...path.slice(0, depth), index];
     // hovering a parent row opens its submenu with nothing selected inside
     setPath(items[index]?.items?.length ? [...base, -1] : base);
+  };
+
+  const hover = (index, ev) => {
+    const point = screenPoint(ev);
+    if (
+      index !== active &&
+      childOpen &&
+      childRect &&
+      movingToward(point, apexRef.current, childRect)
+    ) {
+      // heading for the open submenu: hold the switch, but not forever —
+      // a pointer that stops inside the triangle still meant this row
+      cancelPending();
+      pendingRef.current = setTimeout(() => {
+        pendingRef.current = null;
+        applyHover(index);
+      }, SAFE_HOVER_DELAY);
+      return;
+    }
+    cancelPending();
+    applyHover(index);
+  };
+
+  const move = (index, ev) => {
+    // over the row that owns the open submenu: remember where the pointer
+    // is, so its exit point becomes the apex of the polygon
+    if (index === active) {
+      apexRef.current = screenPoint(ev) ?? apexRef.current;
+      return;
+    }
+    // over another row: mouseEnter only fired once, but the pointer is
+    // still moving — re-decide, so leaving the polygon switches at once
+    // instead of waiting out the delay
+    hover(index, ev);
   };
 
   const choose = (item) => {
@@ -242,7 +307,8 @@ function MenuLevel({
           active: index === active,
           fontSize,
           nodeRef: index === active ? activeRowRef : undefined,
-          onHover: () => hover(index),
+          onHover: (ev) => hover(index, ev),
+          onMove: (ev) => move(index, ev),
           onSelect: choose,
         }),
       ),

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -4,7 +4,14 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { useTheme } from './theme.js';
-import { DEFAULT_LABEL_SIZE, measureLabel, useAnchor } from './anchor.js';
+import {
+  DEFAULT_LABEL_SIZE,
+  measureLabel,
+  movingToward,
+  SAFE_HOVER_DELAY,
+  screenPoint,
+  useAnchor,
+} from './anchor.js';
 
 const h = React.createElement;
 
@@ -50,6 +57,25 @@ export function Tooltip({
     setRect(null);
   };
 
+  // safe-polygon hover (docs/components.md): leaving the trigger *toward*
+  // the tooltip keeps it up, so a tooltip with content in it can be
+  // reached instead of vanishing the moment the pointer moves
+  const apex = useRef(null);
+  const hideSoon = () => {
+    cancel();
+    timer.current = setTimeout(() => {
+      timer.current = null;
+      setRect(null);
+    }, SAFE_HOVER_DELAY);
+  };
+  const onMouseMove = (ev) => {
+    apex.current = screenPoint(ev) ?? apex.current;
+  };
+  const onMouseLeave = (ev) => {
+    if (rect && movingToward(screenPoint(ev), apex.current, rect)) hideSoon();
+    else hide();
+  };
+
   // a pending timer must not outlive the component
   useEffect(() => cancel, []);
 
@@ -78,7 +104,8 @@ export function Tooltip({
       flexDirection: 'row',
       alignItems: 'center',
       onMouseEnter,
-      onMouseLeave: hide,
+      onMouseMove,
+      onMouseLeave,
       onMouseDown: hide,
       ...boxProps,
     },
@@ -97,6 +124,10 @@ export function Tooltip({
         h(
           'box',
           {
+            // the pointer reaching the tooltip keeps it up; leaving it
+            // dismisses, as if the trigger had been left
+            onMouseEnter: cancel,
+            onMouseLeave: hide,
             flexGrow: 1,
             borderWidth: 1,
             borderColor: theme.text,

--- a/src/components/anchor.js
+++ b/src/components/anchor.js
@@ -113,3 +113,77 @@ export function measureLabel(node, text, style) {
 }
 
 export const DEFAULT_LABEL_SIZE = 13;
+
+/** How long a hover change is held back while the pointer crosses the
+ *  polygon — long enough to be forgiving, short enough not to feel stuck. */
+export const SAFE_HOVER_DELAY = 320;
+
+/**
+ * "Safe polygon" hover, after
+ * [floating-ui](https://floating-ui.com/docs/usehover#safepolygon).
+ *
+ * A submenu opens to the side of its parent row, so reaching it means
+ * moving the pointer *diagonally* across the rows in between — and those
+ * rows would each take the hover and close the submenu being aimed at. The
+ * fix is to treat the triangle between where the pointer was and the near
+ * edge of the child surface as "still hovering the parent": while the
+ * pointer is inside it, hover changes are held back.
+ *
+ * `apex` is where the pointer was while it was still over the parent (its
+ * exit point, near enough), `rect` the child popup — both in **screen**
+ * coordinates, because parent and child are different X windows.
+ */
+export function movingToward(point, apex, rect, buffer = 8) {
+  if (!point || !apex || !rect?.width) return false;
+  return pointInPolygon(point, safePolygon(apex, rect, buffer));
+}
+
+/** The triangle from `apex` to the child's near edge, grown by `buffer`. */
+export function safePolygon(apex, rect, buffer = 8) {
+  const left = rect.x;
+  const right = rect.x + rect.width;
+  const top = rect.y;
+  const bottom = rect.y + rect.height;
+
+  // the edge the pointer has to cross to reach the child
+  let a;
+  let b;
+  if (apex.x <= left) {
+    a = { x: left, y: top - buffer };
+    b = { x: left, y: bottom + buffer };
+  } else if (apex.x >= right) {
+    a = { x: right, y: top - buffer };
+    b = { x: right, y: bottom + buffer };
+  } else if (apex.y <= top) {
+    a = { x: left - buffer, y: top };
+    b = { x: right + buffer, y: top };
+  } else {
+    a = { x: left - buffer, y: bottom };
+    b = { x: right + buffer, y: bottom };
+  }
+  return [apex, a, b];
+}
+
+/** Ray casting; the polygon is a triangle here but the test is general. */
+export function pointInPolygon(point, polygon) {
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const pi = polygon[i];
+    const pj = polygon[j];
+    const straddles = pi.y > point.y !== pj.y > point.y;
+    if (
+      straddles &&
+      point.x < ((pj.x - pi.x) * (point.y - pi.y)) / (pj.y - pi.y) + pi.x
+    ) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
+
+/** Pointer position of an event in screen coordinates, or null. */
+export function screenPoint(ev) {
+  const native = ev?.nativeEvent;
+  if (native?.rootx == null || native?.rooty == null) return null;
+  return { x: native.rootx, y: native.rooty };
+}

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1916,6 +1916,74 @@ test('Tooltip shows after the delay in a popup and hides on leave', async () => 
   ReactX11.unmountComponentAtNode(app);
 });
 
+test('Tooltip stays up when the pointer moves toward it, and is reachable', async () => {
+  const { Tooltip, Button } = await import('../src/index.js');
+  const app = createMockApp();
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 300, height: 160 },
+      React.createElement(
+        'box',
+        { flexGrow: 1, padding: 20 },
+        React.createElement(
+          Tooltip,
+          { label: 'Save the file', delay: 20 },
+          React.createElement(Button, { onPress: () => {} }, 'Save'),
+        ),
+      ),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const wrapper = wnd._reactX11Node.children[0].children[0];
+  const { x, y, width, height } = wrapper.abs;
+  const cx = x + width / 2;
+  const cy = y + height / 2;
+
+  wnd.emit('mousemove', { x: cx, y: cy, rootx: cx, rooty: cy });
+  await new Promise((r) => setTimeout(r, 60));
+  await tick();
+  assert.strictEqual(app.windows.length, 2, 'tooltip shown');
+  const tip = app.windows[1];
+
+  // leaving the trigger straight at the tooltip keeps it up. The tooltip
+  // flips below the trigger here (it is near the top of the window), so
+  // "toward it" is the gap just above its top edge.
+  const rect = tip.attributes;
+  const near =
+    rect.y > cy ? { toward: rect.y - 2 } : { toward: rect.y + rect.height + 2 };
+  wnd.emit('mousemove', {
+    x: 0,
+    y: 0,
+    rootx: rect.x + rect.width / 2,
+    rooty: near.toward,
+  });
+  await tick();
+  await tick();
+  assert.strictEqual(tip.destroyed, false, 'still up while heading for it');
+
+  // and the pointer reaching it keeps it up for as long as it stays
+  const content = tip._reactX11Node.children[0];
+  tip.emit('mousemove', {
+    x: content.abs.x + 2,
+    y: content.abs.y + 2,
+  });
+  await new Promise((r) => setTimeout(r, 400));
+  await tick();
+  assert.strictEqual(tip.destroyed, false, 'hovering the tooltip holds it');
+
+  // leaving the tooltip dismisses it
+  tip.emit('mousemove', { x: -20, y: -20 });
+  await tick();
+  await tick();
+  assert.strictEqual(tip.destroyed, true, 'gone once the pointer leaves');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
 test('Tooltip does not show if the pointer leaves before the delay', async () => {
   const { Tooltip, Button } = await import('../src/index.js');
   const app = createMockApp();
@@ -2408,6 +2476,110 @@ test('submenu: hovering a parent row opens it with nothing selected inside', asy
   for (let i = 0; i < 4; i++) await tick();
   assert.strictEqual(app.windows[2].destroyed, true, 'submenu closed');
   assert.strictEqual(activeIn(app, 1), 2, 'Quit active');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('submenu: a diagonal path toward it keeps it open (safe polygon)', async () => {
+  const app = createMockApp();
+  const picked = [];
+  await openNested(app, picked);
+  const menu = app.windows[1];
+  const rows = rowsOf(app, 1);
+  const exportRow = rows[1];
+  const quitRow = rows[2];
+
+  // over the parent row: the submenu opens
+  const overExport = {
+    x: exportRow.abs.x + 5,
+    y: exportRow.abs.y + exportRow.abs.height / 2,
+  };
+  menu.emit('mousemove', {
+    ...overExport,
+    rootx: overExport.x,
+    rooty: overExport.y,
+  });
+  for (let i = 0; i < 4; i++) await tick();
+  assert.strictEqual(app.windows.length, 3, 'submenu opened on hover');
+
+  // a second move records where the pointer is on its way out, near the
+  // right edge of the row — the apex of the safe polygon
+  const apex = {
+    x: exportRow.abs.x + exportRow.abs.width - 4,
+    y: overExport.y,
+  };
+  menu.emit('mousemove', { ...apex, rootx: apex.x, rooty: apex.y });
+  await tick();
+
+  const submenu = app.windows[2].attributes;
+  // now the diagonal: the pointer is over Quit, but heading into the gap
+  // in front of the submenu — this is what used to close it
+  menu.emit('mousemove', {
+    x: quitRow.abs.x + 5,
+    y: quitRow.abs.y + quitRow.abs.height / 2,
+    rootx: submenu.x - 3,
+    rooty: submenu.y + 10,
+  });
+  for (let i = 0; i < 4; i++) await tick();
+
+  assert.strictEqual(app.windows[2].destroyed, false, 'submenu still open');
+  assert.strictEqual(activeIn(app, 1), 1, 'Export still the active row');
+
+  // moving away from the submenu switches immediately, as before
+  menu.emit('mousemove', {
+    x: quitRow.abs.x + 5,
+    y: quitRow.abs.y + quitRow.abs.height / 2,
+    rootx: quitRow.abs.x + 5,
+    rooty: quitRow.abs.y + 40,
+  });
+  for (let i = 0; i < 4; i++) await tick();
+  assert.strictEqual(app.windows[2].destroyed, true, 'submenu closed');
+  assert.strictEqual(activeIn(app, 1), 2, 'Quit active');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('submenu: a pointer that stops inside the safe polygon still switches', async () => {
+  const app = createMockApp();
+  const picked = [];
+  await openNested(app, picked);
+  const menu = app.windows[1];
+  const rows = rowsOf(app, 1);
+  const exportRow = rows[1];
+  const quitRow = rows[2];
+
+  const overExport = {
+    x: exportRow.abs.x + 5,
+    y: exportRow.abs.y + exportRow.abs.height / 2,
+  };
+  menu.emit('mousemove', {
+    ...overExport,
+    rootx: overExport.x,
+    rooty: overExport.y,
+  });
+  for (let i = 0; i < 4; i++) await tick();
+  menu.emit('mousemove', {
+    x: exportRow.abs.x + exportRow.abs.width - 4,
+    y: overExport.y,
+    rootx: exportRow.abs.x + exportRow.abs.width - 4,
+    rooty: overExport.y,
+  });
+  await tick();
+
+  const submenu = app.windows[2].attributes;
+  menu.emit('mousemove', {
+    x: quitRow.abs.x + 5,
+    y: quitRow.abs.y + quitRow.abs.height / 2,
+    rootx: submenu.x - 3,
+    rooty: submenu.y + 10,
+  });
+  for (let i = 0; i < 4; i++) await tick();
+  assert.strictEqual(activeIn(app, 1), 1, 'held back at first');
+
+  // the hold is a delay, not a veto: a pointer parked there meant that row
+  await new Promise((resolve) => setTimeout(resolve, 400));
+  for (let i = 0; i < 4; i++) await tick();
+  assert.strictEqual(activeIn(app, 1), 2, 'Quit active once the delay lapses');
 
   ReactX11.unmountComponentAtNode(app);
 });


### PR DESCRIPTION
First item of the queue in NEXT_STEPS.md §11 — the hover bug found while using the widget set.

**The bug.** Reaching a submenu means moving the pointer *diagonally* across the rows in between, and each of those rows took the hover and closed the submenu being aimed at. Tooltips had the same problem from the other side: any pixel outside the trigger dismissed them, so a tooltip with content in it could never be reached.

**The fix**, after [floating-ui's `safePolygon`](https://floating-ui.com/docs/usehover#safepolygon): the triangle between where the pointer was and the near edge of the open surface counts as still hovering the parent.

- It is a **delay, not a veto** — a pointer that stops inside the triangle still means the row it landed on, after `SAFE_HOVER_DELAY` (320 ms).
- Leaving the triangle switches **immediately**, which is why the decision is re-made on every `mousemove` rather than only on `mouseenter`: crossing a sibling row fires enter once but move many times, and waiting out the delay in that case would feel stuck.
- Tooltips additionally stay up while the pointer is over them, so tooltip content is reachable at all.

The geometry lives next to the other popup math in `src/components/anchor.js` and is exported for widgets of your own — `movingToward(point, apex, rect)`, `safePolygon(apex, rect, buffer)`, `pointInPolygon`, `screenPoint(ev)`, `SAFE_HOVER_DELAY`. Everything is in **screen** coordinates, because the trigger and the popup are different X windows.

### Testing

Four cases, all through the real event pipeline over the mock app:

- a diagonal path across a sibling row leaves the submenu open and the parent row active — this is exactly the bug;
- a path *away* from the submenu closes it immediately, as before (the pre-existing test for that behaviour is untouched and still passes);
- a pointer parked inside the triangle switches once the delay lapses;
- a tooltip survives the trip from its trigger, stays up while hovered, and goes when the pointer leaves it.

Next in the queue: the focus-state gaps (§11.2), starting upstream in ntk with the `FocusIn`/`FocusOut` hole.