### PR TITLE
feat: window focus, a public focus API, and menus that dismiss on an outside press

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -504,7 +504,17 @@ plus a small close delay as the fallback. Notes for the implementation:
 - Worth a hermetic test: synthesize a diagonal pointer path across a sibling
   row and assert the submenu stays open, which is exactly the bug today.
 
-### 11.2 Focus state — audit and gaps
+### 11.2 Focus state — audit and gaps (mostly DONE)
+
+Done since: X `FocusIn`/`FocusOut` and `SetInputFocus` are exposed by ntk
+(sidorares/ntk#89) and used here — the focused node keeps focus across a
+window blur but stops looking active; `focus()`/`blur()`/`focused` and
+`autoFocus` are public; focusing inside a `<scrollview>` scrolls into view;
+and popups can hold a pointer grab so a press anywhere else dismisses them
+(gap 3's real fix, and the cause of menus surviving a click on the window
+frame). Still open from the list below: a proper focus _scope_ per popup
+(so Tab is trapped in a modal), `tabIndex` ordering, and restoring focus
+when a popup closes. The original audit follows.
 
 Everything below is how it works **today**; the state lives in
 `EventManager` (`src/events.js`), one instance per `<window>`:

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -96,6 +96,23 @@ event root. Anchor with `ev.nativeEvent.rootx/rooty` (pointer in screen
 coordinates) or a ref's `abs` rect plus the owner window's `x`/`y`.
 Same props as `<window>`; conditional rendering controls its lifetime.
 
+| prop        |                                                                           |
+| ----------- | ------------------------------------------------------------------------- |
+| `grab`      | hold a pointer grab while the popup is up — how menus behave on X (below) |
+| `onDismiss` | a press landed outside the popup: close it                                |
+
+**`grab` is what makes a menu dismissable.** Without it, a press that lands
+anywhere else — another application, the root window, or even this app's own
+**window frame**, which belongs to the window manager — never reaches the
+client, so the menu stays open behind whatever was clicked. With the grab,
+that press is redirected to the popup instead, arrives outside its bounds,
+and `onDismiss` fires. The client's own windows still receive their own
+presses (X owner-events), so submenus and the owner window keep working
+normally, and only the root popup of a menu needs the grab. Needs
+ntk ≥ 3.7.0; on older ntk the popup behaves as it did before.
+
+`Select`, `ContextMenu` and `MenuBar` already do this.
+
 Defaults to `windowType="dropdown_menu"`; pass `windowType` to override
 (`"tooltip"`, `"popup_menu"`, …). The hint is **additive** — override-
 redirect is what keeps the WM from moving or decorating the popup, and

--- a/docs/events.md
+++ b/docs/events.md
@@ -72,9 +72,26 @@ light up every widget the pointer crosses.
 ## Focus
 
 `focusable` opts a node into focus (`<textinput>` is focusable by
-default). Mousedown focuses the nearest focusable ancestor of the hit node;
-Tab / Shift+Tab cycle through focusable nodes in tree order. Keyboard
+default), `autoFocus` takes it at mount, and every drawn node has
+`focus()` / `blur()` / `focused` on its ref. Focusing a node inside a
+`<scrollview>` scrolls it into view. Mousedown focuses the nearest
+focusable ancestor of the hit node; Tab / Shift+Tab cycle through focusable
+nodes in tree order. Keyboard
 events route to the focused node's ancestor chain.
+
+### Window focus
+
+Node focus is per `<window>`, and the window itself may or may not be the
+one the X server sends keys to — that is the window manager's call.
+`<window onFocus>` / `<window onBlur>` report it (ntk ≥ 3.7.0, X
+`FocusIn`/`FocusOut`).
+
+While the window is unfocused the focused node **keeps** focus, exactly as
+`document.activeElement` survives a window blur in a browser — it just
+stops looking active: a `<textinput>` caret stops blinking, and resumes
+when the window is focused again. Calling `focus()` on a node in a window
+that does not have the input focus asks for it (X `SetInputFocus`), though
+a window manager is free to refuse.
 
 ## Cursors
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^3.6.0",
+        "ntk": "^3.7.0",
         "react-reconciler": "^0.33.0"
       },
       "devDependencies": {
@@ -4071,9 +4071,9 @@
       }
     },
     "node_modules/ntk": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-3.6.0.tgz",
-      "integrity": "sha512-o0X6vruHDEfl8+NA3lDxwV3nNuWmenIax59lxGjdCz0iYH9CD46cTxJjriUsV+iF/Xh3IssrvyeNDJ7LE+N7Kg==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-3.7.0.tgz",
+      "integrity": "sha512-glW4cetF2PxQ0tzYBLWkKqyOKScS0+88Q29JBIncKPcQEXzPnDFAcxk5KoQ7T2iPAaN+UQWXSbBAi6hkrmuTRQ==",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^3.6.0",
+    "ntk": "^3.7.0",
     "react-reconciler": "^0.33.0"
   },
   "peerDependencies": {

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -249,15 +249,19 @@ const HostConfig = {
     parentInstance.insertBefore(child, null);
   },
 
-  finalizeInitialChildren(instance, type) {
+  finalizeInitialChildren(instance, type, props) {
     // Popups are not attached to the container or realized by a parent
-    // window; commitMount realizes them against the screen root.
-    return type === 'popup';
+    // window; commitMount realizes them against the screen root. autoFocus
+    // needs commitMount too — the node has to be in the tree first.
+    return type === 'popup' || Boolean(props.autoFocus);
   },
 
-  commitMount(instance, type) {
+  commitMount(instance, type, props) {
     if (type === 'popup') {
       instance.realize(null);
+    }
+    if (props.autoFocus && typeof instance.focus === 'function') {
+      instance.focus();
     }
   },
 

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -181,6 +181,7 @@ function MenuLevel({
   depth,
   setPath,
   onSelect,
+  onDismiss,
   fontSize,
 }) {
   const theme = useTheme();
@@ -289,6 +290,13 @@ function MenuLevel({
       height: rect.height,
       windowType: 'popup_menu',
       backgroundColor: theme.background,
+      // the root level holds the pointer grab for the whole menu: a press
+      // anywhere else — including this app's own window frame, which
+      // belongs to the window manager — closes it instead of vanishing
+      // into whatever was clicked. Submenus need no grab of their own;
+      // owner-events still delivers their presses to them.
+      grab: depth === 0,
+      onDismiss: depth === 0 ? onDismiss : undefined,
     },
     h(
       'box',
@@ -496,6 +504,7 @@ export function ContextMenu({
         setPath,
         fontSize,
         onSelect: select,
+        onDismiss: close,
       }),
   );
 }
@@ -629,6 +638,7 @@ export function MenuBar({
         setPath,
         fontSize,
         onSelect: select,
+        onDismiss: close,
       }),
   );
 }

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -233,6 +233,10 @@ export function Select({
           width: anchor.width,
           height: menuHeight + 2,
           backgroundColor: theme.background,
+          // a press anywhere else closes the menu, the window frame
+          // included — see PopupNode's `grab`
+          grab: true,
+          onDismiss: close,
         },
         h(
           'box',

--- a/src/events.js
+++ b/src/events.js
@@ -18,6 +18,10 @@ export class EventManager {
     this.downNode = null;
     this.capturedNode = null;
     this.focused = null;
+    // whether the X server sends keys to this window at all. Assume yes
+    // until told otherwise: ntk < 3.7 never reports focus changes, and a
+    // toolkit that believed it was unfocused would blink no caret at all.
+    this.windowFocused = true;
     this._lastClick = { time: 0, x: 0, y: 0, detail: 0 };
   }
 
@@ -45,6 +49,33 @@ export class EventManager {
     wnd.on('mouseout', (ev) => this._onMouseOut(ev));
     wnd.on('keydown', (ev) => this._onKey('KeyDown', ev));
     wnd.on('keyup', (ev) => this._onKey('KeyUp', ev));
+    // window-level focus (ntk >= 3.7.0): the window manager decides which
+    // window gets keys, and the focused node's caret/ring has to follow
+    wnd.on('focus', (ev) => this._onWindowFocus(true, ev));
+    wnd.on('blur', (ev) => this._onWindowFocus(false, ev));
+  }
+
+  /**
+   * The DOM keeps `document.activeElement` across a window blur — the
+   * element stays focused, it just stops looking active — and so do we: the
+   * node keeps focus, its default focus behaviour (a blinking caret) is
+   * suspended, and `<window onFocus/onBlur>` gets told.
+   */
+  _onWindowFocus(focused, native) {
+    if (this.windowFocused === focused) return;
+    this.windowFocused = focused;
+    const node = this.focused;
+    if (node && !node.destroyed) {
+      if (focused) node._defaultFocus?.();
+      else node._defaultBlur?.();
+    }
+    runWithPriority(DiscreteEventPriority, () => {
+      const prop = focused ? 'onFocus' : 'onBlur';
+      this.node.props[prop]?.(
+        this._makeEvent(focused ? 'focus' : 'blur', native, this.node),
+      );
+    });
+    this.node.invalidate(false);
   }
 
   _public(node) {
@@ -135,7 +166,28 @@ export class EventManager {
     return ev;
   }
 
+  /** A press the X server sent us only because we hold a pointer grab:
+   *  it landed outside this window, so it is a dismissal, not a click. */
+  _pressOutside(native) {
+    const wnd = this.node.window;
+    if (!wnd || typeof this.node.props.onDismiss !== 'function') return false;
+    return (
+      native.x < 0 ||
+      native.y < 0 ||
+      native.x >= (wnd.width ?? 0) ||
+      native.y >= (wnd.height ?? 0)
+    );
+  }
+
   _onMouseDown(native) {
+    if (this._pressOutside(native)) {
+      runWithPriority(DiscreteEventPriority, () => {
+        this.node.props.onDismiss?.(
+          this._makeEvent('dismiss', native, this.node),
+        );
+      });
+      return;
+    }
     runWithPriority(DiscreteEventPriority, () => {
       const wheel = WHEEL_BUTTONS[native.keycode];
       const target = this._hit(native);
@@ -319,8 +371,21 @@ export class EventManager {
       old.props.onBlur?.(this._makeEvent('blur', null, old));
     }
     if (node) {
-      node._defaultFocus?.();
+      // keys only reach a node whose window has the X focus
+      if (!this.windowFocused) this.node.window?.focus?.();
+      this._scrollIntoView(node);
+      if (this.windowFocused) node._defaultFocus?.();
       node.props.onFocus?.(this._makeEvent('focus', null, node));
+    }
+  }
+
+  /** Tab to something inside a scrollview and it should be on screen. */
+  _scrollIntoView(node) {
+    for (let n = node.parent; n; n = n.parent) {
+      if (typeof n.scrollIntoView === 'function') {
+        n.scrollIntoView(node);
+        return;
+      }
     }
   }
 

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -188,6 +188,28 @@ export class Node {
     this.root?.invalidate(true);
   }
 
+  /**
+   * Focus this node, as clicking it would: the owning window's focus moves
+   * here, `onBlur` fires on whatever had it, `onFocus` here. Also pulls the
+   * X input focus to the window if the window manager gave it away.
+   */
+  focus() {
+    this.root?.events?.focus(this);
+    return this;
+  }
+
+  /** Give up focus, leaving the window with nothing focused. */
+  blur() {
+    const events = this.root?.events;
+    if (events?.focused === this) events.focus(null);
+    return this;
+  }
+
+  /** Whether this node has the owning window's focus. */
+  get focused() {
+    return this.root?.events?.focused === this;
+  }
+
   /** Drawn, visible children in paint order (stable sort by zIndex). */
   paintOrder() {
     const drawn = this.children.filter(
@@ -1761,6 +1783,27 @@ export class WindowNode extends Node {
  * in commitMount.
  */
 export class PopupNode extends WindowNode {
+  /**
+   * `grab`: hold a pointer grab while this popup is up. That is how menus
+   * work on X — without it a press that lands anywhere else (another app,
+   * the root, or this app's own window *frame*, which belongs to the window
+   * manager) never reaches us, so the menu stays open behind whatever the
+   * user clicked. With the grab, that press arrives here instead, outside
+   * our bounds, and `onDismiss` fires. Needs ntk >= 3.7.0; without it the
+   * popup simply behaves as before.
+   */
+  realize(parentWindow) {
+    super.realize(parentWindow);
+    if (this.props.grab && !this.destroyed) {
+      this.window?.grabPointer?.({}, () => {});
+    }
+  }
+
+  destroySubtree() {
+    if (this.props.grab) this.window?.ungrabPointer?.();
+    super.destroySubtree();
+  }
+
   constructor(app, attributes, props) {
     // override-redirect stays: it is what keeps the window manager from
     // repositioning or decorating a menu. The EWMH type hint is additive —

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -118,6 +118,16 @@ function createMockApp() {
           wnd.destroyed = true;
           wnd.calls.push(['destroy']);
         },
+        // ntk >= 3.7.0: menus hold a pointer grab while they are up
+        grabPointer(options, cb) {
+          wnd.grabbed = true;
+          wnd.calls.push(['grabPointer']);
+          cb?.(null, 0);
+        },
+        ungrabPointer() {
+          wnd.grabbed = false;
+          wnd.calls.push(['ungrabPointer']);
+        },
         resize(width, height) {
           wnd.width = width;
           wnd.height = height;
@@ -1862,6 +1872,180 @@ test('anchorRect places, flips at a screen edge and clamps', async () => {
   assert.deepStrictEqual([noScreen.x, noScreen.y], [5, 27]);
 
   assert.strictEqual(anchorRect(null), null, 'no node -> no rect');
+});
+
+test('window focus: the focused node keeps focus but stops looking active', async () => {
+  const app = createMockApp();
+  const events = [];
+  ReactX11.render(
+    React.createElement(
+      'window',
+      {
+        width: 200,
+        height: 100,
+        onFocus: () => events.push('window:focus'),
+        onBlur: () => events.push('window:blur'),
+      },
+      React.createElement('textinput', {
+        defaultValue: 'hi',
+        width: 120,
+        height: 24,
+      }),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const input = wnd._reactX11Node.children[0];
+
+  input.focus();
+  assert.strictEqual(input.focused, true, 'node focused');
+  assert.ok(input._blinkTimer, 'caret blinking');
+
+  // the window manager gives the keyboard to someone else
+  wnd.emit('blur', {});
+  await tick();
+  assert.strictEqual(
+    input.focused,
+    true,
+    'the node keeps focus, as in the DOM',
+  );
+  assert.strictEqual(input._blinkTimer, null, 'but the caret stops blinking');
+  assert.deepStrictEqual(events, ['window:blur']);
+
+  wnd.emit('focus', {});
+  await tick();
+  assert.ok(
+    input._blinkTimer,
+    'caret resumes when the window is focused again',
+  );
+  assert.deepStrictEqual(events, ['window:blur', 'window:focus']);
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('focus(): ref API, autoFocus, and blur', async () => {
+  const app = createMockApp();
+  const seen = [];
+  const ref = React.createRef();
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 200, height: 100 },
+      React.createElement('box', {
+        ref,
+        focusable: true,
+        width: 40,
+        height: 20,
+        onFocus: () => seen.push('a:focus'),
+        onBlur: () => seen.push('a:blur'),
+      }),
+      React.createElement('box', {
+        focusable: true,
+        autoFocus: true,
+        width: 40,
+        height: 20,
+        onFocus: () => seen.push('b:focus'),
+      }),
+    ),
+    null,
+    app,
+  );
+  await tick();
+
+  assert.deepStrictEqual(seen, ['b:focus'], 'autoFocus took it at mount');
+
+  ref.current.focus();
+  assert.deepStrictEqual(seen, ['b:focus', 'a:focus']);
+  assert.strictEqual(ref.current.focused, true);
+
+  ref.current.blur();
+  assert.strictEqual(ref.current.focused, false);
+  assert.deepStrictEqual(seen, ['b:focus', 'a:focus', 'a:blur']);
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('Tab into a scrollview scrolls the focused node into view', async () => {
+  const app = createMockApp();
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 200, height: 100 },
+      React.createElement(
+        'scrollview',
+        { flexGrow: 1 },
+        ...Array.from({ length: 12 }, (_, i) =>
+          React.createElement('box', {
+            key: i,
+            focusable: true,
+            height: 30,
+            flexShrink: 0,
+          }),
+        ),
+      ),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const scroll = wnd._reactX11Node.children[0];
+  const last = scroll.children[scroll.children.length - 1];
+
+  assert.strictEqual(scroll.scrollY, 0, 'starts at the top');
+  last.focus();
+  await tick();
+  await tick();
+  assert.ok(scroll.scrollY > 0, `scrolled to reveal it (${scroll.scrollY})`);
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('context menu: a press outside — the window frame — dismisses it', async () => {
+  const app = createMockApp();
+  const picked = [];
+  await openNested(app, picked);
+  const menu = app.windows[1];
+
+  // the root level asks for a pointer grab; that is what makes the press
+  // below reach us at all instead of going to the window manager
+  assert.strictEqual(menu.attributes.grab, true, 'root menu grabs the pointer');
+  assert.ok(menu.grabbed, 'and the grab was taken');
+
+  // a press on the title bar arrives here, outside our bounds
+  menu.emit('mousedown', { x: -40, y: -12, keycode: 1 });
+  await tick();
+  await tick();
+  assert.strictEqual(menu.destroyed, true, 'menu closed');
+  assert.deepStrictEqual(picked, [], 'and nothing was selected');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('a press inside the menu is a normal click, not a dismissal', async () => {
+  const app = createMockApp();
+  const picked = [];
+  await openNested(app, picked);
+  const menu = app.windows[1];
+  const row = rowsOf(app, 1)[0];
+
+  menu.emit('mousedown', {
+    x: row.abs.x + 4,
+    y: row.abs.y + row.abs.height / 2,
+    keycode: 1,
+  });
+  menu.emit('mouseup', {
+    x: row.abs.x + 4,
+    y: row.abs.y + row.abs.height / 2,
+    keycode: 1,
+  });
+  await tick();
+  await tick();
+  assert.deepStrictEqual(picked, ['New'], 'the row was selected');
+
+  ReactX11.unmountComponentAtNode(app);
 });
 
 test('Tooltip shows after the delay in a popup and hides on leave', async () => {


### PR DESCRIPTION
NEXT_STEPS §11.2, plus the menu bug found while testing — which turned out to be the same subject, input routing.

### Menus that close

> right click to open a context menu, then click on a window frame — window goes in front of the menu

Because the press went to the **window manager's** frame window, and we never heard about it. The X answer is the one every toolkit uses: hold a **pointer grab** while a menu is up, so presses that would have gone elsewhere are redirected to the menu instead.

`<popup grab onDismiss>` does that. The redirected press arrives outside the popup's bounds, which is the signal that it is a dismissal rather than a click, and `onDismiss` fires. X owner-events keeps the client's own windows receiving their own presses, so submenus and the owner window are unaffected and only the root popup of a menu needs the grab. Wired into `ContextMenu`, `MenuBar` and `Select`.

Needs ntk ≥ 3.7.0 (sidorares/ntk#89, where `grabPointer` grew real arguments and `ungrabPointer` appeared at all). Feature-detected: on today's ntk the popup behaves exactly as before, which is why CI passes here.

### Window focus

The event manager now hears X `FocusIn`/`FocusOut` through ntk's new `focus`/`blur` events, and `<window onFocus/onBlur>` surfaces them.

The focused node **keeps** focus across a window blur — as `document.activeElement` survives one in a browser — it just stops looking active: a `<textinput>` caret stops blinking and resumes when the window is focused again. Calling `focus()` on a node whose window does not hold the input focus now asks for it via `SetInputFocus`.

### A public focus API

`focus()`, `blur()` and `focused` on every drawn node's ref, plus an `autoFocus` prop applied at `commitMount`. Components had been reaching into `node.root.events.focus(node)` for this. Focusing a node inside a `<scrollview>` now scrolls it into view, which Tab traversal never did.

### Testing

Through the real event pipeline over the mock app: a press outside a context menu closes it while a press inside still selects a row; a window blur keeps node focus but stops the caret and fires `<window onBlur>`; `autoFocus`, `ref.focus()`, `ref.blur()` and `focused` behave; and Tab into a long scrollview scrolls the target into view.

Still open from §11.2, and left for a follow-up: a focus *scope* per popup so Tab is trapped in a modal, `tabIndex` ordering, and restoring focus when a popup closes.