### PR TITLE
chore(deps): ntk 3.7.1 — TeX content honours the 2d clip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^3.7.0",
+        "ntk": "^3.7.1",
         "react-reconciler": "^0.33.0"
       },
       "devDependencies": {
@@ -4071,9 +4071,9 @@
       }
     },
     "node_modules/ntk": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-3.7.0.tgz",
-      "integrity": "sha512-glW4cetF2PxQ0tzYBLWkKqyOKScS0+88Q29JBIncKPcQEXzPnDFAcxk5KoQ7T2iPAaN+UQWXSbBAi6hkrmuTRQ==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-3.7.1.tgz",
+      "integrity": "sha512-q9VLiXF+BZvSMYYbt28VxPdOVGi4EQs0OBan9sXG5I+KB3Eeq1qZQ0GJ6HcxHYWsh7sj2Z1SexIRF/7UwsMYYA==",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^3.7.0",
+    "ntk": "^3.7.1",
     "react-reconciler": "^0.33.0"
   },
   "peerDependencies": {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -433,6 +433,72 @@ test('centered text is vertically balanced (half-leading)', async () => {
   }
 });
 
+test('rich content scrolled out of a scrollview leaves no ink behind', async () => {
+  const { app } = await createHeadlessApp();
+  try {
+    // a math fence: KaTeX draws glyph runs and vector shapes of its own,
+    // which used to bypass the 2d clip and paint over whatever was above
+    // the scrollview once they were scrolled out (fixed in ntk 3.7.1)
+    const source = `# Heading\n\n\`\`\`math\n\\sqrt{\\frac{x+1}{2}}\n\`\`\`\n\n${'filler paragraph. '.repeat(40)}\n`;
+    const wnd = await render(
+      React.createElement(
+        'window',
+        { width: 300, height: 300, backgroundColor: 'white' },
+        React.createElement(
+          'box',
+          { flexGrow: 1, padding: 20 },
+          React.createElement('box', { height: 60 }), // the band above it
+          React.createElement(
+            'scrollview',
+            { flexGrow: 1 },
+            React.createElement('markdown', { source }),
+          ),
+        ),
+      ),
+      app,
+    );
+    const ctx = wnd.getContext('2d');
+    const node = wnd._reactX11Node;
+    const scroll = node.children[0].children[1];
+
+    // wait until the document has laid out and drawn something
+    await waitForInk(
+      ctx,
+      300,
+      300,
+      { x: 20, y: 80, width: 260, height: 200 },
+      isDark,
+      20,
+      'markdown ink inside the scrollview',
+    );
+
+    const inkAbove = async () => {
+      const image = await readPixels(ctx, 300, 300);
+      let n = 0;
+      for (let y = 20; y < 79; y++) {
+        for (let x = 20; x < 280; x++) if (isDark(px(image, 300, x, y))) n++;
+      }
+      return n;
+    };
+    assert.equal(await inkAbove(), 0, 'nothing above it to begin with');
+
+    for (const offset of [120, 160, 200]) {
+      scroll.scrollTo(offset);
+      await new Promise((resolve) => setTimeout(resolve, 120));
+      assert.equal(
+        await inkAbove(),
+        0,
+        `nothing painted above the scrollview at offset ${offset}`,
+      );
+    }
+
+    ReactX11.unmountComponentAtNode(app);
+    await settle(app);
+  } finally {
+    await app.close();
+  }
+});
+
 test('<markdown> renders through MarkdownView and dispatches onLink', async () => {
   const { app } = await createHeadlessApp();
   try {


### PR DESCRIPTION
Picks up sidorares/ntk#91, the fix for the bug reported here: scroll the rich-content demo so a math fence leaves the `<scrollview>` and the formula keeps painting over whatever is above it.

KaTeX content draws its own glyph runs and trapezoidized vector shapes (radicals, stretchy delimiters) rather than going through `fillText`, and those went straight to the destination picture — bypassing the clip that every fill, stroke and ordinary text run respects.

The regression test here is pixel-level over the in-process X server: a math fence in a scrolling document, sampled at three scroll offsets, must leave the band *above* the viewport untouched. Measured on the old ntk that band picked up 39 and then 325 stray pixels as the formula moved through it; now zero at every offset.