### PR TITLE
feat(examples): live markdown preview in the widget gallery

### DIFF
--- a/examples/widgets.jsx
+++ b/examples/widgets.jsx
@@ -1,6 +1,7 @@
 // Widget gallery: every standard component in one window — Button,
 // Checkbox, Radio/RadioGroup, Switch, Slider, ProgressBar, Select,
-// Tooltip, <textinput>.
+// Tooltip, <textinput> — plus a live <markdown> preview of what you type
+// into the <textarea>.
 // Run with: npm run examples:widgets  (needs an X server / DISPLAY)
 import React, { useEffect, useState } from 'react';
 import {
@@ -16,9 +17,9 @@ import {
   Tooltip,
 } from '../src/index.js';
 
-function Row({ label, children }) {
+function Row({ label, children, alignItems = 'center' }) {
   return (
-    <box flexDirection="row" alignItems="center" gap={12}>
+    <box flexDirection="row" alignItems={alignItems} gap={12}>
       <text color="#7f8c8d" width={90}>
         {label}
       </text>
@@ -35,6 +36,9 @@ function App() {
   const [presses, setPresses] = useState(0);
   const [volume, setVolume] = useState(40);
   const [progress, setProgress] = useState(0.2);
+  const [note, setNote] = useState(
+    '## Live preview\n\nType **markdown** — `code`, [links](https://x.org)\nand lists all render below.\n',
+  );
 
   // demo animation: creep the progress bar while "notifications" are on
   useEffect(() => {
@@ -47,7 +51,7 @@ function App() {
   }, [notify]);
 
   return (
-    <window width={460} height={580} title="widgets" backgroundColor="#f5f6fa">
+    <window width={460} height={720} title="widgets" backgroundColor="#f5f6fa">
       <box flexGrow={1} padding={16} gap={14}>
         <text fontSize={20} color="#2d3436">
           Widget gallery
@@ -128,19 +132,33 @@ function App() {
           />
         </Row>
 
-        <Row label="Textarea">
-          <textarea
-            flexGrow={1}
-            rows={3}
-            defaultValue={
-              'Multi-line editing:\nEnter for a newline, arrows move by visual line, selection spans lines.'
-            }
-            padding={8}
-            borderRadius={4}
-            borderWidth={1}
-            borderColor="#b2bec3"
-            backgroundColor="white"
-          />
+        <Row label="Markdown" alignItems="flex-start">
+          <box flexGrow={1} gap={8}>
+            {/* the textarea is the source, the <markdown> element is the
+                preview: every keystroke re-parses through ntk's
+                MarkdownView, which is cheap enough for a document this size */}
+            <textarea
+              flexGrow={0}
+              rows={4}
+              value={note}
+              onChange={setNote}
+              padding={8}
+              borderRadius={4}
+              borderWidth={1}
+              borderColor="#b2bec3"
+              backgroundColor="white"
+            />
+            <scrollview
+              height={110}
+              padding={4}
+              borderRadius={4}
+              borderWidth={1}
+              borderColor="#dfe6e9"
+              backgroundColor="white"
+            >
+              <markdown padding={6}>{note}</markdown>
+            </scrollview>
+          </box>
         </Row>
       </box>
     </window>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^3.7.1",
+        "ntk": "^3.7.2",
         "react-reconciler": "^0.33.0"
       },
       "devDependencies": {
@@ -4071,9 +4071,9 @@
       }
     },
     "node_modules/ntk": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-3.7.1.tgz",
-      "integrity": "sha512-q9VLiXF+BZvSMYYbt28VxPdOVGi4EQs0OBan9sXG5I+KB3Eeq1qZQ0GJ6HcxHYWsh7sj2Z1SexIRF/7UwsMYYA==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-3.7.2.tgz",
+      "integrity": "sha512-DvZXBF+yLBV/uNrUZfuiBvPBGFv8hVmIzX4Awo0VLb3kHphI1FTEBvpwdrps7fp/ZM+FboPWTxhlRfF59HJk1Q==",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^3.7.1",
+    "ntk": "^3.7.2",
     "react-reconciler": "^0.33.0"
   },
   "peerDependencies": {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -499,6 +499,41 @@ test('rich content scrolled out of a scrollview leaves no ink behind', async () 
   }
 });
 
+test('<markdown> survives a document being typed down to nothing', async () => {
+  const { app } = await createHeadlessApp();
+  try {
+    let setText;
+    const Host = () => {
+      const [text, set] = React.useState('# hello\n\nsome **text**');
+      setText = set;
+      return React.createElement(
+        'window',
+        { width: 300, height: 200, backgroundColor: 'white' },
+        React.createElement(
+          'scrollview',
+          { flexGrow: 1 },
+          React.createElement('markdown', { padding: 6 }, text),
+        ),
+      );
+    };
+    await render(React.createElement(Host), app);
+
+    // a live preview goes through these states on the way to empty, and a
+    // blank block lays out with no spans at all — which used to throw
+    // inside TextLayout and take the frame with it (ntk 3.7.2)
+    for (const value of ['# h', '#', '', ' ', '\n\n', '- ']) {
+      setText(value);
+      await new Promise((resolve) => setTimeout(resolve, 60));
+    }
+    await settle(app);
+
+    ReactX11.unmountComponentAtNode(app);
+    await settle(app);
+  } finally {
+    await app.close();
+  }
+});
+
 test('<markdown> renders through MarkdownView and dispatches onLink', async () => {
   const { app } = await createHeadlessApp();
   try {


### PR DESCRIPTION
The gallery's `<textarea>` now feeds a `<markdown>` element below it, so what you type renders as you type:

```jsx
<Row label="Markdown" alignItems="flex-start">
  <box flexGrow={1} gap={8}>
    <textarea rows={4} value={note} onChange={setNote} … />
    <scrollview height={110} …>
      <markdown padding={6}>{note}</markdown>
    </scrollview>
  </box>
</Row>
```

Two rich-content pieces of the library wired to each other, which is the thing people ask about first. Every keystroke re-parses through ntk's MarkdownView — cheap enough for a document this size, and noted in the code.

**One catch, worth knowing before merging:** typing into it turned up a crash in ntk, filed as sidorares/ntk#93 — a blank block lays out with *no spans at all* and `TextLayout` took its fallback metrics from `spans[0]`:

```
TypeError: undefined is not an object (evaluating 'baseSpan.font')
    at new TextLayout (ntk/lib/text/layout.js:191)
    at _layoutBlocks (ntk/lib/widgets/markdownview.js:190)
```

Until that release lands, the preview works as long as the document never goes fully blank — clearing the textarea entirely is what triggers it. Happy to hold this PR until the ntk fix ships if you would rather not merge a demo with a known way to crash it.