### PR TITLE
feat: tab order, focus scopes, and a Dialog built on them

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -21,10 +21,10 @@
 >    for the protocol blockers, then `<glarea>`, the `<mesh>` scene tree on
 >    a display-list compiler, and lights. Left: textures, mesh pointer
 >    events, README screenshots.
-> 2. **Queued behind it (§11):** the menu/tooltip **safe polygon**, the
->    **focus-state** gaps — starting with the ntk `FocusIn`/`FocusOut` hole
->    that hides window focus changes from us — and the AT-SPI
->    accessibility work the research in §11.3 scopes out.
+> 2. **Queued behind it (§11):** the menu/tooltip **safe polygon** (done)
+>    and the **focus-state** gaps (done: window focus, the public focus API,
+>    `tabIndex` ordering, focus scopes/modals and focus restore) — next in
+>    §11 is the AT-SPI accessibility work the research in §11.3 scopes out.
 > 3. Then merge release-please #17 and publish 1.0.0.
 > 4. Upstream (ntk): distribute half-leading inside TextLayout itself
 >    (makes the #29 paint shift a no-op) + an opt-in cap-height trim
@@ -504,7 +504,7 @@ plus a small close delay as the fallback. Notes for the implementation:
 - Worth a hermetic test: synthesize a diagonal pointer path across a sibling
   row and assert the submenu stays open, which is exactly the bug today.
 
-### 11.2 Focus state — audit and gaps (mostly DONE)
+### 11.2 Focus state — audit and gaps (DONE)
 
 Done since: X `FocusIn`/`FocusOut` and `SetInputFocus` are exposed by ntk
 (sidorares/ntk#89) and used here — the focused node keeps focus across a
@@ -512,9 +512,31 @@ window blur but stops looking active; `focus()`/`blur()`/`focused` and
 `autoFocus` are public; focusing inside a `<scrollview>` scrolls into view;
 and popups can hold a pointer grab so a press anywhere else dismisses them
 (gap 3's real fix, and the cause of menus surviving a click on the window
-frame). Still open from the list below: a proper focus _scope_ per popup
-(so Tab is trapped in a modal), `tabIndex` ordering, and restoring focus
-when a popup closes. The original audit follows.
+frame).
+
+The rest of the list is done too:
+
+- **`tabIndex` ordering** — DOM sequential focus order (positive indices
+  ascending, then the implicit-zero group in tree order); `tabIndex={-1}`
+  is focusable by press/`focus()` but never tabbed to, and an explicit
+  `tabIndex` implies `focusable`. `disabled` opts back out.
+- **Focus scopes** — `trapFocus` on any node (a `<popup>`, in practice)
+  owns a scope: Tab only visits focusables inside it, a press outside it
+  does not move focus, and popping the scope restores focus to whatever
+  had it before — so `<popup trapFocus grab>` + `autoFocus` _is_ a modal
+  dialog, with no per-widget bookkeeping. Scopes nest.
+- **Focus inside a popup** — an override-redirect window never gets the X
+  input focus, so a popup's `EventManager` now **delegates focus to the
+  owner window's** (`EventManager.focusManager`): a node inside the popup
+  can be the owner window's focused node, keys arrive at the owner and
+  dispatch to it, then bubble out through the popup's place in the JSX
+  tree. That removes the reason for the focusable-proxy trick, though
+  `Menu`/`Select` still use theirs (their rows are not focusable and the
+  trigger wants the keys — a press inside a popup on nothing focusable
+  deliberately leaves the owner's focus alone).
+
+Left as polish: converting `Menu`/`Select` to the delegated path, and a
+`Dialog` widget over `<popup trapFocus>`. The original audit follows.
 
 Everything below is how it works **today**; the state lives in
 `EventManager` (`src/events.js`), one instance per `<window>`:

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -66,6 +66,8 @@ merged theme (`ThemeProvider`; `SelectThemeProvider` is an alias) and a
   requestAnimationFrame on the window ref, or step-render
 - **Tooltip** — DONE: `useAnchor(ref)`/`anchorRect()` extracted from
   `Select` (and now flip at screen edges), `Tooltip` built on them
+- **Dialog** — DONE: a modal over `<popup trapFocus grab>`, centred with
+  `centerRect()`; see §11.2
 - **Menu/MenuBar, ContextMenu** — DONE: built on `useAnchor`, with
   separators, disabled items, shortcuts, checkmarks, nested submenus and
   full keyboard navigation; `examples/menu.jsx` rewritten on them
@@ -535,8 +537,14 @@ The rest of the list is done too:
   trigger wants the keys — a press inside a popup on nothing focusable
   deliberately leaves the owner's focus alone).
 
-Left as polish: converting `Menu`/`Select` to the delegated path, and a
-`Dialog` widget over `<popup trapFocus>`. The original audit follows.
+`Dialog` (`src/components/Dialog.js`) is the first consumer: a modal in a
+`<popup trapFocus grab>` centred over the owner window, Escape to close,
+`autoFocus` inside to pick the first stop, focus handed back on close —
+demoed by the "Clear" confirmation in `examples/form.jsx`. It does **not**
+enforce pointer modality (widgets behind it stay clickable); a full-window
+overlay in the owner window would, and is the obvious follow-up along with
+converting `Menu`/`Select` to the delegated focus path. The original audit
+follows.
 
 Everything below is how it works **today**; the state lives in
 `EventManager` (`src/events.js`), one instance per `<window>`:

--- a/README.md
+++ b/README.md
@@ -96,8 +96,11 @@ and [docs/](docs/README.md) for the full API reference.
 | `<tex>`        | a KaTeX formula (ntk `layoutTex`), intrinsically sized                                                               |
 | `<glarea>`     | an OpenGL surface over indirect GLX; the 3D scene below lives inside it                                              |
 
-Widget **components** (plain React on top of the primitives): `Select` — a
-dropdown built on `<popup>`, themable via `SelectThemeProvider`.
+Widget **components** (plain React on top of the primitives, themable via
+`ThemeProvider`): `Button`, `Checkbox`, `Radio`/`RadioGroup`, `Switch`,
+`Slider`, `ProgressBar`, `Select`, `Tooltip`, `MenuBar`/`ContextMenu` and
+`Dialog` — a modal built on `<popup trapFocus>`, which traps Tab and
+restores focus when it closes. See [docs/components.md](docs/components.md).
 
 ### 3D
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -137,6 +137,56 @@ mousedown — a tooltip lingering over the menu you just opened is the
 classic annoyance. The popup is sized from the _measured_ label, because a
 `<popup>` is a real X window and needs its size before layout.
 
+## `Dialog`
+
+A modal dialog in a `<popup trapFocus grab>`, centred over the owner window.
+
+```jsx
+import { Button, Dialog } from 'react-x11';
+
+<Dialog
+  open={confirming}
+  title="Clear the form?"
+  onClose={() => setConfirming(false)}
+  actions={
+    <>
+      <Button label="Cancel" onPress={() => setConfirming(false)} />
+      <Button primary autoFocus label="Clear" onPress={clear} />
+    </>
+  }
+>
+  The name and the greeting below it will be discarded.
+</Dialog>;
+```
+
+| prop              |                                                              |
+| ----------------- | ------------------------------------------------------------ |
+| `open`            | renders nothing when false; the popup exists only while true |
+| `title`           | bold heading (optional)                                      |
+| `children`        | body content; strings become `<text>`                        |
+| `actions`         | elements for the right-aligned button row                    |
+| `onClose`         | Escape, or a press outside the dialog                        |
+| `width`, `height` | popup size (default 360×170)                                 |
+
+The focus behaviour is the **renderer's**, not the component's: `trapFocus`
+keeps Tab inside the dialog, stops presses elsewhere from moving focus, and
+hands focus back to whatever had it — usually the button that opened the
+dialog — when it closes. See
+[Focus scopes](events.md#focus-scopes-modals). Put `autoFocus` on a control
+inside to pick the first stop; with nothing to focus, the dialog surface
+takes focus itself (`tabIndex={-1}`) so Escape and Tab work immediately.
+
+Escape closes because keys go to the focused node inside the popup and
+bubble out through the popup's place in the JSX tree; `grab` makes a press
+anywhere else in the session close it too. **Pointer modality is not
+enforced** — widgets in the owner window stay clickable behind the dialog —
+so it is for confirmations, not for guarding state.
+
+A `<popup>` is a real X window and needs its size up front, hence explicit
+`width`/`height` rather than sizing to content. Placement comes from
+`centerRect(node, {width, height})`, exported alongside `anchorRect` for
+window-centred popups of your own.
+
 ## `MenuBar` / `ContextMenu`
 
 Pull-down and right-click menus, both rendered in `<popup>` windows so they

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -38,7 +38,10 @@ pass through to yoga.
 ## Interaction props
 
 `cursor` (`'pointer'`, `'text'`, `'wait'`, `'move'`, `'crosshair'`,
-resize arrows, … — the ntk cursor name map), `focusable`,
+resize arrows, … — the ntk cursor name map), `focusable`, `tabIndex`
+(sequential focus order; `-1` is focusable but not tabbable), `autoFocus`,
+`trapFocus` (own a focus scope — Tab and presses stay inside it, focus is
+restored when it unmounts), `disabled` (never focusable),
 `pointerEvents: 'none'`, and the event handlers listed in
 [events.md](events.md).
 
@@ -97,10 +100,16 @@ event root. Anchor with `ev.nativeEvent.rootx/rooty` (pointer in screen
 coordinates) or a ref's `abs` rect plus the owner window's `x`/`y`.
 Same props as `<window>`; conditional rendering controls its lifetime.
 
-| prop        |                                                                           |
-| ----------- | ------------------------------------------------------------------------- |
-| `grab`      | hold a pointer grab while the popup is up — how menus behave on X (below) |
-| `onDismiss` | a press landed outside the popup: close it                                |
+| prop        |                                                                             |
+| ----------- | --------------------------------------------------------------------------- |
+| `grab`      | hold a pointer grab while the popup is up — how menus behave on X (below)   |
+| `onDismiss` | a press landed outside the popup: close it                                  |
+| `trapFocus` | own a focus scope: a modal (see [events.md](events.md#focus-scopes-modals)) |
+
+A popup never receives the X input focus, but nodes inside it can hold the
+**owner window's** focus and receive keys — with `trapFocus` and `autoFocus`
+that is a modal dialog. See
+[Focus inside a `<popup>`](events.md#focus-inside-a-popup).
 
 **`grab` is what makes a menu dismissable.** Without it, a press that lands
 anywhere else — another application, the root window, or even this app's own

--- a/docs/events.md
+++ b/docs/events.md
@@ -45,7 +45,7 @@ props — they can never go stale.
 | `onMouseDown` / `onMouseUp` / `onMouseMove` | move is coalesced to once per frame by ntk                                            |
 | `onMouseEnter` / `onMouseLeave`             | do not propagate; synthesized by hover-path diffing                                   |
 | `onWheel`                                   | X buttons 4–7; default action scrolls the nearest `<scrollview>`                      |
-| `onKeyDown` / `onKeyUp`                     | delivered to the focused node (or the window); Tab cycles focus                       |
+| `onKeyDown` / `onKeyUp`                     | delivered to the focused node (or the window); Tab cycles focus in `tabIndex` order   |
 | `onFocus` / `onBlur`                        | focus follows mousedown (nearest `focusable` ancestor) and Tab traversal              |
 
 ## Pointer capture
@@ -77,7 +77,84 @@ default), `autoFocus` takes it at mount, and every drawn node has
 `<scrollview>` scrolls it into view. Mousedown focuses the nearest
 focusable ancestor of the hit node; Tab / Shift+Tab cycle through focusable
 nodes in tree order. Keyboard
-events route to the focused node's ancestor chain.
+events route to the focused node's ancestor chain. `disabled` opts a node
+back out of focus, whatever else it says.
+
+### Tab order
+
+`tabIndex` sets the sequential focus order, following the DOM's rules:
+
+- nodes with a **positive** `tabIndex` come first, in ascending order;
+- then everything focusable without one (the implicit `0` group), in tree
+  order;
+- `tabIndex={-1}` is focusable — by a press, and by `focus()` — but Tab
+  never lands on it;
+- an explicit `tabIndex` makes a node focusable without also passing
+  `focusable`.
+
+Tab out of a node that is not in the tab order (`tabIndex={-1}`, or a node
+outside the current focus scope) and traversal starts from the beginning of
+the order.
+
+```jsx
+<box tabIndex={1} />   {/* visited first  */}
+<box tabIndex={2} />   {/* then this      */}
+<box focusable />      {/* then tree order */}
+<box tabIndex={-1} />  {/* clickable, never tabbed to */}
+```
+
+### Focus scopes (modals)
+
+`trapFocus` makes a node own a **focus scope**. While it is the innermost
+scope:
+
+- Tab / Shift+Tab only visit focusables inside it — the rest of the window
+  is unreachable by keyboard;
+- a press outside it does not move focus (poking at the window behind a
+  modal is inert as far as focus goes — the press itself still dispatches,
+  so pair it with `grab` + `onDismiss` for a real modal);
+- when the scope unmounts, focus goes back to whatever had it before the
+  scope opened — no bookkeeping in the widget.
+
+That is a modal dialog, with the popup taking focus at mount:
+
+```jsx
+function Dialog({ open, x, y, onClose }) {
+  if (!open) return null;
+  return (
+    <popup
+      trapFocus
+      grab
+      x={x}
+      y={y}
+      width={280}
+      height={120}
+      onDismiss={onClose}
+    >
+      <textinput autoFocus />
+      <Button label="OK" onPress={onClose} />
+    </popup>
+  );
+}
+```
+
+Scopes nest (a modal opened from a modal); the innermost one wins, and
+popping it hands focus back to the outer one. Programmatic `focus()` is
+never blocked by a scope — the trap is about Tab and presses.
+
+### Focus inside a `<popup>`
+
+An override-redirect window never receives the X input focus, so a popup
+cannot hold focus itself: the **owner window** does, and a node inside the
+popup can be the focused node of that window. Keys arrive at the owner
+window and are dispatched to it, then bubble out through the popup's
+position in the JSX tree into the owner's handlers, so nothing has to
+proxy them.
+
+One consequence worth knowing: a press inside a popup that lands on nothing
+focusable leaves the owner window's focus alone. Menus depend on it —
+their rows are not focusable, and the trigger keeps handling keys while the
+menu is open (`Menu`, `Select`).
 
 ### Window focus
 

--- a/examples/form.jsx
+++ b/examples/form.jsx
@@ -1,13 +1,16 @@
 // A small form, exercising the widget set the way an app would: <textinput>
 // with autoFocus, a <Select> dropdown (a real <popup> window), a RadioGroup,
 // a Slider and a Checkbox — submit with Enter or the button, and the result
-// is styled by what you picked.
+// is styled by what you picked. "Clear" opens a <Dialog>: a modal popup that
+// traps Tab, closes on Escape, and hands focus back to the button that
+// opened it.
 // Run with: npm run examples:form  (needs an X server / DISPLAY)
 import React, { useState } from 'react';
 import {
   Button,
   Checkbox,
   createRoot,
+  Dialog,
   Radio,
   RadioGroup,
   Select,
@@ -30,6 +33,7 @@ function App() {
   const [weight, setWeight] = useState('normal');
   const [shout, setShout] = useState(false);
   const [greeting, setGreeting] = useState(null);
+  const [confirming, setConfirming] = useState(false);
 
   const submit = () =>
     setGreeting({
@@ -39,6 +43,13 @@ function App() {
       weight,
       shout,
     });
+
+  const clear = () => {
+    setName('');
+    setShout(false);
+    setGreeting(null);
+    setConfirming(false);
+  };
 
   return (
     <window width={420} height={380} title="form" backgroundColor="#f5f6fa">
@@ -94,8 +105,25 @@ function App() {
         <box flexDirection="row" alignItems="center" gap={12}>
           <Checkbox checked={shout} onChange={setShout} label="Shout it" />
           <box flexGrow={1} />
+          <Button label="Clear" onPress={() => setConfirming(true)} />
           <Button primary label="Sign" onPress={submit} />
         </box>
+
+        <Dialog
+          open={confirming}
+          title="Clear the form?"
+          onClose={() => setConfirming(false)}
+          width={320}
+          height={150}
+          actions={
+            <>
+              <Button label="Cancel" onPress={() => setConfirming(false)} />
+              <Button primary autoFocus label="Clear" onPress={clear} />
+            </>
+          }
+        >
+          The name and the greeting below it will be discarded.
+        </Dialog>
 
         <box flexGrow={1} justifyContent="center" alignItems="center">
           {greeting && (

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -252,13 +252,19 @@ const HostConfig = {
   finalizeInitialChildren(instance, type, props) {
     // Popups are not attached to the container or realized by a parent
     // window; commitMount realizes them against the screen root. autoFocus
-    // needs commitMount too — the node has to be in the tree first.
-    return type === 'popup' || Boolean(props.autoFocus);
+    // and trapFocus need commitMount too — the node has to be in the tree
+    // first, so it can find the EventManager that owns focus.
+    return (
+      type === 'popup' || Boolean(props.autoFocus) || Boolean(props.trapFocus)
+    );
   },
 
   commitMount(instance, type, props) {
     if (type === 'popup') {
       instance.realize(null);
+    }
+    if (props.trapFocus) {
+      instance._syncFocusScope?.();
     }
     if (props.autoFocus && typeof instance.focus === 'function') {
       instance.focus();

--- a/src/components/Dialog.js
+++ b/src/components/Dialog.js
@@ -1,0 +1,138 @@
+// Widget components built purely on the host primitives — no reconciler
+// support needed. Plain createElement (no JSX) so the library stays
+// build-step-free for consumers.
+
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { labelContent, useTheme } from './theme.js';
+import { centerRect } from './anchor.js';
+import { XK_ESCAPE } from './keys.js';
+
+const h = React.createElement;
+
+const DEFAULT_WIDTH = 360;
+
+const DEFAULT_HEIGHT = 170;
+
+/**
+ * <Dialog open title onClose actions>…</Dialog> — a modal dialog in a
+ * `<popup trapFocus grab>`, centred over the owner window.
+ *
+ * The focus behaviour is the renderer's, not this component's: `trapFocus`
+ * keeps Tab inside the dialog, stops presses elsewhere from moving focus,
+ * and hands focus back to whatever had it — usually the button that opened
+ * the dialog — when it closes. Put `autoFocus` on a control inside to choose
+ * the first stop; otherwise the dialog surface itself takes focus, so
+ * Escape and Tab work immediately (`docs/events.md`, "Focus scopes").
+ *
+ * Escape closes: keys go to the focused node inside the popup and bubble out
+ * through the popup's place in the JSX tree. `grab` makes a press anywhere
+ * else in the session close it too. Pointer modality is *not* enforced —
+ * widgets in the owner window stay clickable behind the dialog, so use it
+ * for confirmations rather than as a security boundary.
+ *
+ * A `<popup>` is a real X window and needs its size up front, hence explicit
+ * `width`/`height` rather than sizing to content.
+ */
+export function Dialog({
+  open,
+  title,
+  children,
+  onClose,
+  actions,
+  width = DEFAULT_WIDTH,
+  height = DEFAULT_HEIGHT,
+  ...boxProps
+}) {
+  const theme = useTheme();
+  const anchor = useRef(null);
+  const surface = useRef(null);
+  const [rect, setRect] = useState(null);
+
+  // the popup needs screen coordinates, which are only knowable once the
+  // anchor is laid out inside a realized window — hence a layout effect
+  // rather than placement at render time
+  useLayoutEffect(() => {
+    if (!open) {
+      setRect(null);
+      return;
+    }
+    const next = centerRect(anchor.current, { width, height });
+    if (next) setRect(next);
+  }, [open, width, height]);
+
+  // nothing inside claimed focus (no autoFocus): the dialog takes it itself,
+  // the way a browser focuses a <dialog> element, so keys have somewhere to
+  // land and the trap has an inside
+  useEffect(() => {
+    const node = surface.current;
+    if (!rect || !node || node.focusWithin) return;
+    node.focus();
+  }, [rect]);
+
+  const onKeyDown = (ev) => {
+    if (ev.keysym === XK_ESCAPE) {
+      ev.preventDefault();
+      onClose?.();
+    }
+  };
+
+  return h(
+    'box',
+    // out of flow: an anchor for the window geometry, never part of layout
+    { ref: anchor, position: 'absolute', width: 0, height: 0 },
+    rect &&
+      h(
+        'popup',
+        {
+          x: rect.x,
+          y: rect.y,
+          width: rect.width,
+          height: rect.height,
+          trapFocus: true,
+          grab: true,
+          windowType: 'dialog',
+          backgroundColor: theme.background,
+          onDismiss: () => onClose?.(),
+          onKeyDown,
+        },
+        h(
+          'box',
+          {
+            ref: surface,
+            // focusable but not tabbable: a fallback focus holder, never a
+            // stop in the dialog's own tab order
+            tabIndex: -1,
+            flexGrow: 1,
+            padding: 16,
+            gap: 12,
+            borderWidth: 1,
+            borderColor: theme.border,
+            backgroundColor: theme.background,
+            ...boxProps,
+          },
+          title &&
+            h(
+              'text',
+              { fontSize: 15, fontWeight: 'bold', color: theme.text },
+              title,
+            ),
+          h(
+            'box',
+            { flexGrow: 1, gap: 8 },
+            labelContent(children, { color: theme.text }),
+          ),
+          actions &&
+            h(
+              'box',
+              {
+                flexDirection: 'row',
+                justifyContent: 'flex-end',
+                alignItems: 'center',
+                gap: 8,
+              },
+              actions,
+            ),
+        ),
+      ),
+  );
+}

--- a/src/components/anchor.js
+++ b/src/components/anchor.js
@@ -88,6 +88,28 @@ export function anchorRect(node, options = {}) {
 }
 
 /**
+ * Where to put a `<popup>` of this size **centred over the owner window**,
+ * in screen coordinates, clamped into the screen. A dialog is anchored to
+ * the window rather than to a widget, which is the one placement
+ * `anchorRect` cannot express.
+ */
+export function centerRect(node, { width, height }) {
+  if (!node) return null;
+  const win = node.root?.window;
+  const ww = win?.width ?? width;
+  const wh = win?.height ?? height;
+  let x = (win?.x ?? 0) + (ww - width) / 2;
+  let y = (win?.y ?? 0) + (wh - height) / 2;
+
+  const screen = screenOf(node);
+  if (screen) {
+    x = Math.max(0, Math.min(x, screen.pixel_width - width));
+    y = Math.max(0, Math.min(y, screen.pixel_height - height));
+  }
+  return { x: Math.round(x), y: Math.round(y), width, height };
+}
+
+/**
  * useAnchor(ref) — stable `measure(options)` returning `anchorRect` for the
  * referenced node. The anchoring math `Select` used to inline, shared with
  * `Tooltip` and anything else that hangs a `<popup>` off a drawn node.

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -3,8 +3,9 @@
 // theme.js (palette + control props), anchor.js (popup geometry),
 // typeahead.js and keys.js.
 export { ThemeProvider, SelectThemeProvider } from './theme.js';
-export { anchorRect, useAnchor } from './anchor.js';
+export { anchorRect, centerRect, useAnchor } from './anchor.js';
 export { Button } from './Button.js';
+export { Dialog } from './Dialog.js';
 export { Checkbox } from './Checkbox.js';
 export { Radio, RadioGroup } from './Radio.js';
 export { Switch } from './Switch.js';

--- a/src/events.js
+++ b/src/events.js
@@ -18,11 +18,38 @@ export class EventManager {
     this.downNode = null;
     this.capturedNode = null;
     this.focused = null;
+    // what had focus before `focused`, so a focus scope opened by something
+    // that focuses itself still knows where to hand focus back
+    this._previousFocus = null;
+    // focus scopes, innermost last: [{ node, restore }]
+    this.scopes = [];
+    // resolved lazily for popups: the manager that owns focus (focusManager)
+    this._focusOwner = null;
     // whether the X server sends keys to this window at all. Assume yes
     // until told otherwise: ntk < 3.7 never reports focus changes, and a
     // toolkit that believed it was unfocused would blink no caret at all.
     this.windowFocused = true;
     this._lastClick = { time: 0, x: 0, y: 0, detail: 0 };
+  }
+
+  /**
+   * The manager that owns focus for this window — normally itself, but for a
+   * `<popup>` the nearest enclosing real window's manager. Override-redirect
+   * windows never receive the X input focus, so a popup cannot hold it: keys
+   * arrive at the owner window, and routing them into the popup's subtree is
+   * only possible if both windows share one notion of "the focused node".
+   * Nodes inside a popup are still ordinary tree nodes, so capture/bubble
+   * from them reaches the owner window's handlers.
+   */
+  get focusManager() {
+    if (!this.node.isPopup) return this;
+    // a popup's parent is a node in the owner window (or an outer popup,
+    // whose own delegate resolves recursively). Remember it: the parent link
+    // is cut before the deletion bookkeeping runs, and unmounting a modal is
+    // exactly when the owner has to hear about it (focus restore).
+    const manager = this.node.parent?.root?.events;
+    if (manager && manager !== this) this._focusOwner = manager.focusManager;
+    return this._focusOwner ?? this;
   }
 
   /** DOM-style click counting: repeated presses within 400ms / 4px bump
@@ -209,11 +236,7 @@ export class EventManager {
         return;
       }
       this.downNode = target;
-      // DOM-like: mousedown moves focus to the nearest focusable ancestor
-      const focusable = this._path(target)
-        .reverse()
-        .find((n) => this._isFocusable(n));
-      this.focus(focusable ?? null);
+      this._focusFromPress(target);
       const ev = this.dispatch('MouseDown', target, native, {
         button: native.keycode,
         detail: this._clickDetail(native),
@@ -277,8 +300,34 @@ export class EventManager {
     return this.capturedNode;
   }
 
+  /**
+   * DOM-like: mousedown moves focus to the nearest focusable ancestor of the
+   * hit node. A press outside an open focus scope leaves focus where it is —
+   * a modal keeps focus even when the user pokes at what is behind it.
+   */
+  _focusFromPress(target) {
+    const manager = this.focusManager;
+    const scope = manager._scopeRoot();
+    if (scope !== manager.node && !this._within(target, scope)) return;
+    const focusable = this._path(target)
+      .reverse()
+      .find((n) => this._isFocusable(n));
+    // a press inside a popup on nothing focusable leaves the owner window's
+    // focus alone: the press never reached that window, and menus rely on it
+    // (their rows are not focusable, the trigger keeps the keys)
+    if (!focusable && manager !== this) return;
+    manager.focus(focusable ?? null);
+  }
+
+  /** Focusable: `focusable`, an explicit `tabIndex` (including a negative
+   * one, focusable but not tabbable), or a kind that is focusable by default
+   * (`<textinput>`). `focusable={false}` and `disabled` opt back out. */
   _isFocusable(node) {
-    return node.props.focusable ?? node.focusableByDefault ?? false;
+    if (node.props.disabled) return false;
+    return (
+      node.props.focusable ??
+      (node.props.tabIndex != null ? true : (node.focusableByDefault ?? false))
+    );
   }
 
   _onMouseOut(native) {
@@ -339,8 +388,10 @@ export class EventManager {
       const wnd = this.node.window;
       const syms = wnd.X?.keycode2keysyms?.[native.keycode];
       const keysym = syms?.[0];
-      const target =
-        this.focused && !this.focused.destroyed ? this.focused : this.node;
+      // the focused node may live inside a <popup> of this window: focus is
+      // shared with the popup (see focusManager), key delivery follows it
+      const focused = this.focusManager.focused;
+      const target = focused && !focused.destroyed ? focused : this.node;
       const ev = this.dispatch(name, target, native, {
         keycode: native.keycode,
         keysym,
@@ -363,12 +414,18 @@ export class EventManager {
   }
 
   focus(node) {
+    const manager = this.focusManager;
+    if (manager !== this) return manager.focus(node);
     if (node === this.focused) return;
     const old = this.focused;
+    this._previousFocus = old;
     this.focused = node;
     if (old && !old.destroyed) {
       old._defaultBlur?.();
       old.props.onBlur?.(this._makeEvent('blur', null, old));
+      // the ring/caret it was drawing has to go, and it may be in another
+      // window than the new focus (owner window ↔ its popup)
+      old.root?.invalidate(false);
     }
     if (node) {
       // keys only reach a node whose window has the X focus
@@ -376,7 +433,63 @@ export class EventManager {
       this._scrollIntoView(node);
       if (this.windowFocused) node._defaultFocus?.();
       node.props.onFocus?.(this._makeEvent('focus', null, node));
+      node.root?.invalidate(false);
     }
+  }
+
+  /**
+   * Focus scopes. A node with `trapFocus` — a modal `<popup>`, typically —
+   * pushes one: while it is the innermost scope Tab only visits focusables
+   * inside it, and presses outside it leave focus alone. Popping the scope
+   * (usually when the modal unmounts) hands focus back to whatever had it
+   * before the scope opened, which is what makes a dialog feel finished
+   * rather than abandoned.
+   */
+  pushScope(node) {
+    const manager = this.focusManager;
+    if (manager !== this) return manager.pushScope(node);
+    if (this.scopes.some((s) => s.node === node)) return;
+    // commitMount runs children before parents, so a scope's own autoFocus
+    // may already have taken focus by the time the scope registers — then
+    // the node to come back to is the one focused before that.
+    const focused = this.focused;
+    const restore =
+      focused && this._within(focused, node) ? this._previousFocus : focused;
+    this.scopes.push({ node, restore });
+  }
+
+  popScope(node) {
+    const manager = this.focusManager;
+    if (manager !== this) return manager.popScope(node);
+    const index = this.scopes.findIndex((s) => s.node === node);
+    if (index === -1) return;
+    const [scope] = this.scopes.splice(index, 1);
+    const focused = this.focused;
+    // focus only comes back if it was inside the scope that just closed
+    if (focused && !this._within(focused, node)) return;
+    const restore = scope.restore;
+    const alive = restore && !restore.destroyed && this._isFocusable(restore);
+    this.focus(alive ? restore : null);
+  }
+
+  /** The innermost live focus scope, or the window node when there is none.
+   * Destroyed scopes are dropped; a hidden one is skipped but kept, since
+   * unhiding it puts the trap back. */
+  _scopeRoot() {
+    while (this.scopes.length > 0 && this.scopes.at(-1).node.destroyed) {
+      this.scopes.pop();
+    }
+    for (let i = this.scopes.length - 1; i >= 0; i--) {
+      if (!this.scopes[i].node.hidden) return this.scopes[i].node;
+    }
+    return this.node;
+  }
+
+  _within(node, root) {
+    for (let n = node; n; n = n.parent) {
+      if (n === root) return true;
+    }
+    return false;
   }
 
   /** Tab to something inside a scrollview and it should be on screen. */
@@ -389,7 +502,11 @@ export class EventManager {
     }
   }
 
-  _focusables() {
+  /** Focusable nodes in tree order, from `root` down. Windows are their own
+   * focus roots, so a nested `<window>` or `<popup>` is not walked into —
+   * except when it _is_ the root, which is how a modal popup's own
+   * focusables are reached. */
+  _focusables(root = this._scopeRoot()) {
     const out = [];
     const walk = (node) => {
       if (node.hidden) return;
@@ -398,25 +515,54 @@ export class EventManager {
         if (!child.isWindow) walk(child);
       }
     };
-    walk(this.node);
+    walk(root);
     return out;
   }
 
+  /** Tab order, following the DOM's sequential focus navigation: positive
+   * `tabIndex` first in ascending order, then the implicit-zero group in tree
+   * order. `tabIndex={-1}` is focusable by press and `focus()` but never
+   * tabbable. Ties keep tree order (the sort is made stable by index). */
+  _tabbables(root) {
+    return this._focusables(root)
+      .map((node, i) => ({ node, i, order: node.props.tabIndex ?? 0 }))
+      .filter((e) => e.order >= 0)
+      .sort((a, b) => {
+        if (a.order === b.order) return a.i - b.i;
+        if (a.order === 0) return 1;
+        if (b.order === 0) return -1;
+        return a.order - b.order;
+      })
+      .map((e) => e.node);
+  }
+
   _cycleFocus(backwards) {
-    const list = this._focusables();
+    const manager = this.focusManager;
+    if (manager !== this) return manager._cycleFocus(backwards);
+    const list = this._tabbables();
     if (list.length === 0) return;
     const index = list.indexOf(this.focused);
-    const next = backwards
-      ? list[(index <= 0 ? list.length : index) - 1]
-      : list[(index + 1) % list.length];
-    this.focus(next);
+    if (index === -1) {
+      // nothing focused, or focus sits outside the current scope: Tab enters
+      this.focus(backwards ? list[list.length - 1] : list[0]);
+      return;
+    }
+    this.focus(
+      backwards
+        ? list[(index || list.length) - 1]
+        : list[(index + 1) % list.length],
+    );
   }
 
   /** Called when a node leaves the tree so stale references don't linger. */
   forget(node) {
     if (this.downNode === node) this.downNode = null;
     if (this.capturedNode === node) this.capturedNode = null;
-    if (this.focused === node) this.focused = null;
     this.hoverPath = this.hoverPath.filter((n) => n !== node);
+    const manager = this.focusManager;
+    // a scope closing restores focus, so pop before the focus reference goes
+    manager.popScope(node);
+    if (manager.focused === node) manager.focused = null;
+    if (manager._previousFocus === node) manager._previousFocus = null;
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -16,10 +16,12 @@ export {
   ProgressBar,
   Slider,
   Tooltip,
+  Dialog,
   MenuBar,
   ContextMenu,
   useAnchor,
   anchorRect,
+  centerRect,
   Canvas3D,
 } from './components/index.js';
 

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -173,6 +173,9 @@ export class Node {
     if (this.yoga) {
       layoutChanged = applyLayoutStyle(this.yoga, newProps, oldProps ?? prev);
     }
+    if (Boolean(newProps.trapFocus) !== Boolean((oldProps ?? prev).trapFocus)) {
+      this._syncFocusScope();
+    }
     this.root?.invalidate(layoutChanged);
   }
 
@@ -194,20 +197,52 @@ export class Node {
    * X input focus to the window if the window manager gave it away.
    */
   focus() {
-    this.root?.events?.focus(this);
+    this._focusManager()?.focus(this);
     return this;
   }
 
   /** Give up focus, leaving the window with nothing focused. */
   blur() {
-    const events = this.root?.events;
+    const events = this._focusManager();
     if (events?.focused === this) events.focus(null);
     return this;
   }
 
   /** Whether this node has the owning window's focus. */
   get focused() {
-    return this.root?.events?.focused === this;
+    return this._focusManager()?.focused === this;
+  }
+
+  /** Whether focus is on this node or inside it — CSS `:focus-within`. A
+   * `<popup>` counts as inside the node it hangs off in the JSX tree, which
+   * is what a modal needs to know before taking focus itself. */
+  get focusWithin() {
+    const focused = this._focusManager()?.focused;
+    return Boolean(focused) && this.contains(focused);
+  }
+
+  /** Whether `node` is this node or a descendant of it (DOM `contains`). */
+  contains(node) {
+    for (let n = node; n; n = n.parent) {
+      if (n === this) return true;
+    }
+    return false;
+  }
+
+  /** Where focus for this node lives: its own window's EventManager, or —
+   * inside a `<popup>`, which never receives the X input focus — the owner
+   * window's (see EventManager.focusManager). */
+  _focusManager() {
+    return this.root?.events?.focusManager ?? null;
+  }
+
+  /** Register or drop this node's focus scope to match the `trapFocus` prop.
+   * Idempotent: called at mount (commitMount) and on every prop update. */
+  _syncFocusScope() {
+    const events = this._focusManager();
+    if (!events) return;
+    if (this.props.trapFocus) events.pushScope(this);
+    else events.popScope(this);
   }
 
   /** Drawn, visible children in paint order (stable sort by zIndex). */
@@ -1668,6 +1703,9 @@ export class WindowNode extends Node {
   applyProps(newProps, oldProps) {
     const before = oldProps ?? this.props;
     this.props = newProps;
+    if (Boolean(newProps.trapFocus) !== Boolean(before.trapFocus)) {
+      this._syncFocusScope();
+    }
     const wnd = this.window;
     if (!wnd) {
       // not realized yet: refresh creation attributes instead

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -188,6 +188,7 @@ function pressKey(app, wnd, { keysym, codepoint, buttons = 0 }) {
 
 const XK = {
   BackSpace: 0xff08,
+  Tab: 0xff09,
   Return: 0xff0d,
   Left: 0xff51,
 };
@@ -2057,6 +2058,191 @@ test('Tab into a scrollview scrolls the focused node into view', async () => {
   await tick();
   await tick();
   assert.ok(scroll.scrollY > 0, `scrolled to reveal it (${scroll.scrollY})`);
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('tabIndex orders Tab traversal; -1 focuses but never tabs', async () => {
+  const app = createMockApp();
+  const box = (tabIndex, extra) =>
+    React.createElement('box', {
+      key: String(tabIndex),
+      focusable: true,
+      width: 100,
+      height: 20,
+      ...(tabIndex == null ? {} : { tabIndex }),
+      ...extra,
+    });
+  const refs = { plain: null, two: null, one: null, skip: null };
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 200, height: 200 },
+      box(null, { ref: (n) => (refs.plain = n) }),
+      box(2, { ref: (n) => (refs.two = n) }),
+      box(1, { ref: (n) => (refs.one = n) }),
+      box(-1, { ref: (n) => (refs.skip = n) }),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const tab = () => pressKey(app, wnd, { keysym: XK.Tab });
+
+  // positive tabIndex first in ascending order, then the implicit-zero group
+  tab();
+  assert.strictEqual(refs.one.focused, true, 'tabIndex 1 goes first');
+  tab();
+  assert.strictEqual(refs.two.focused, true, 'then tabIndex 2');
+  tab();
+  assert.strictEqual(refs.plain.focused, true, 'then the implicit-zero group');
+  tab();
+  assert.strictEqual(refs.one.focused, true, 'and it wraps around');
+
+  // tabIndex={-1}: never reached by Tab, but focusable by press and focus()
+  const skip = refs.skip;
+  wnd.emit('mousedown', { x: 5, y: skip.abs.y + 5, keycode: 1 });
+  wnd.emit('mouseup', { x: 5, y: skip.abs.y + 5, keycode: 1 });
+  assert.strictEqual(skip.focused, true, 'a press focuses tabIndex={-1}');
+  tab();
+  assert.strictEqual(
+    refs.one.focused,
+    true,
+    'Tab out of it re-enters the tab order at the start',
+  );
+  skip.focus();
+  assert.strictEqual(skip.focused, true, 'focus() works on it too');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('<popup> shares the owner window focus, so keys reach into it', async () => {
+  const app = createMockApp();
+  const seen = [];
+  let inner = null;
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 300, height: 200, onKeyDown: () => seen.push('window') },
+      React.createElement(
+        'popup',
+        { x: 40, y: 40, width: 120, height: 40 },
+        React.createElement('box', {
+          ref: (n) => (inner = n),
+          focusable: true,
+          autoFocus: true,
+          width: 100,
+          height: 20,
+          onKeyDown: () => seen.push('box'),
+        }),
+      ),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const popup = app.windows[1];
+
+  assert.ok(
+    popup.attributes.overrideRedirect,
+    'the popup is override-redirect',
+  );
+  assert.strictEqual(inner.focused, true, 'a node inside the popup has focus');
+  assert.strictEqual(
+    wnd._reactX11Node.events.focused,
+    inner,
+    'focus is held by the owner window, which is what the X server keys',
+  );
+  assert.strictEqual(inner.focusWithin, true, 'focusWithin on the node itself');
+  assert.strictEqual(
+    wnd._reactX11Node.focusWithin,
+    true,
+    'and on the owner window, reaching through the popup',
+  );
+
+  // the key arrives at the owner window (the popup never gets the X focus)
+  // and is dispatched to the popup node, bubbling out into the owner tree
+  pressKey(app, wnd, { codepoint: 0x78 });
+  assert.deepStrictEqual(seen, ['box', 'window']);
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('<popup trapFocus> traps Tab and restores focus when it closes', async () => {
+  const app = createMockApp();
+  const refs = { trigger: null, other: null, first: null, second: null };
+  const App = ({ open }) =>
+    React.createElement(
+      'window',
+      { width: 300, height: 200 },
+      React.createElement('box', {
+        ref: (n) => (refs.trigger = n),
+        focusable: true,
+        width: 100,
+        height: 20,
+      }),
+      React.createElement('box', {
+        ref: (n) => (refs.other = n),
+        focusable: true,
+        width: 100,
+        height: 20,
+      }),
+      open &&
+        React.createElement(
+          'popup',
+          { x: 40, y: 60, width: 140, height: 60, trapFocus: true },
+          React.createElement('box', {
+            ref: (n) => (refs.first = n),
+            focusable: true,
+            autoFocus: true,
+            width: 120,
+            height: 20,
+          }),
+          React.createElement('box', {
+            ref: (n) => (refs.second = n),
+            focusable: true,
+            width: 120,
+            height: 20,
+          }),
+        ),
+    );
+
+  ReactX11.render(React.createElement(App, { open: false }), null, app);
+  await tick();
+  const wnd = app.windows[0];
+  refs.trigger.focus();
+  assert.strictEqual(refs.trigger.focused, true, 'the trigger has focus');
+
+  ReactX11.render(React.createElement(App, { open: true }), null, app);
+  await tick();
+  assert.strictEqual(refs.first.focused, true, 'the modal took focus');
+
+  const tab = () => pressKey(app, wnd, { keysym: XK.Tab });
+  tab();
+  assert.strictEqual(refs.second.focused, true, 'Tab moves within the modal');
+  tab();
+  assert.strictEqual(
+    refs.first.focused,
+    true,
+    'and wraps inside it — the trigger is never reached',
+  );
+
+  // a press on the window behind the modal does not steal focus
+  const y = refs.trigger.abs.y + 5;
+  wnd.emit('mousedown', { x: 5, y, keycode: 1 });
+  wnd.emit('mouseup', { x: 5, y, keycode: 1 });
+  assert.strictEqual(refs.trigger.focused, false, 'the press was inert');
+  assert.strictEqual(refs.first.focused, true, 'focus stayed in the modal');
+
+  ReactX11.render(React.createElement(App, { open: false }), null, app);
+  await tick();
+  assert.strictEqual(
+    refs.trigger.focused,
+    true,
+    'closing the modal handed focus back to the trigger',
+  );
 
   ReactX11.unmountComponentAtNode(app);
 });

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -2247,6 +2247,102 @@ test('<popup trapFocus> traps Tab and restores focus when it closes', async () =
   ReactX11.unmountComponentAtNode(app);
 });
 
+test('Dialog: modal popup, Escape closes it, focus goes back', async () => {
+  const { Dialog, Button } = await import('../src/index.js');
+  const app = createMockApp();
+  const closed = [];
+  let trigger = null;
+  let input = null;
+  const App = ({ open }) =>
+    React.createElement(
+      'window',
+      { width: 400, height: 300 },
+      React.createElement(Button, {
+        ref: (n) => (trigger = n),
+        label: 'Open',
+        onPress: () => {},
+      }),
+      React.createElement(
+        Dialog,
+        {
+          open,
+          title: 'Really?',
+          onClose: () => closed.push('close'),
+          actions: React.createElement(Button, { label: 'OK' }),
+        },
+        React.createElement('textinput', {
+          ref: (n) => (input = n),
+          autoFocus: true,
+        }),
+      ),
+    );
+
+  ReactX11.render(React.createElement(App, { open: false }), null, app);
+  await tick();
+  const wnd = app.windows[0];
+  assert.strictEqual(app.windows.length, 1, 'no popup while closed');
+  trigger.focus();
+
+  ReactX11.render(React.createElement(App, { open: true }), null, app);
+  await tick();
+  const dialog = app.windows[1];
+  assert.ok(dialog, 'the dialog is a popup window');
+  assert.strictEqual(dialog.attributes.overrideRedirect, true);
+  assert.strictEqual(dialog.attributes.windowType, 'dialog');
+  assert.strictEqual(dialog.attributes.grab, true, 'grabs, so it dismisses');
+  assert.strictEqual(input.focused, true, 'autoFocus inside the dialog won');
+
+  // Escape reaches the dialog by bubbling out of the focused node
+  pressKey(app, wnd, { keysym: 0xff1b });
+  await tick();
+  assert.deepStrictEqual(closed, ['close'], 'Escape asked to close');
+
+  ReactX11.render(React.createElement(App, { open: false }), null, app);
+  await tick();
+  assert.strictEqual(dialog.destroyed, true, 'popup gone');
+  assert.strictEqual(
+    trigger.focused,
+    true,
+    'and focus returned to what opened it',
+  );
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('Dialog: with nothing to autoFocus, the surface takes focus', async () => {
+  const { Dialog } = await import('../src/index.js');
+  const app = createMockApp();
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 400, height: 300 },
+      React.createElement(
+        Dialog,
+        { open: true, title: 'Note' },
+        'Nothing focusable in here.',
+      ),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const dialog = app.windows[1];
+  const surface = dialog._reactX11Node.children[0];
+
+  assert.strictEqual(
+    surface.focused,
+    true,
+    'the dialog surface holds focus so keys have a target',
+  );
+  assert.strictEqual(
+    surface.props.tabIndex,
+    -1,
+    'but it is not a stop in the tab order',
+  );
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
 test('context menu: a press outside — the window frame — dismisses it', async () => {
   const app = createMockApp();
   const picked = [];


### PR DESCRIPTION
Closes the focus-state gaps NEXT_STEPS §11.2 left open — `tabIndex` ordering, a
focus scope per popup, and focus restore — then builds the first widget on top
of them, `Dialog`.

## Tab order

`tabIndex` sets the sequential focus order, following the DOM's rules: positive
indices ascending first, then the implicit-zero group in tree order.
`tabIndex={-1}` is focusable by press and `focus()` but never tabbed to, an
explicit `tabIndex` implies `focusable`, and `disabled` opts back out. Tab from
a node outside the order re-enters at the start.

## Focus scopes

`trapFocus` makes a node own a scope. While it is the innermost one, Tab only
visits focusables inside it, a press outside does not move focus, and popping
the scope hands focus back to whatever had it before the scope opened. Scopes
nest; a hidden one stops trapping. The restore target survives the fact that
`commitMount` runs children before parents, so a scope whose own `autoFocus`
fires first still knows where to go back to.

## Focus inside a `<popup>`

An override-redirect window never receives the X input focus, so a popup's
`EventManager` now delegates focus to the owner window's
(`EventManager.focusManager`). A node inside a popup can be the owner window's
focused node: keys arrive at the owner, dispatch to that node, then bubble out
through the popup's place in the JSX tree. That removes the reason for the
focusable-proxy trick — `Menu`/`Select` keep theirs for now, because a press
inside a popup that hits nothing focusable deliberately leaves the owner's
focus alone, which is what keeps their non-focusable rows working.

Nodes also gained `contains()` and `focusWithin` — the `:focus-within` read a
widget needs before taking focus itself.

## `Dialog`

`<popup trapFocus grab>` centred over the owner window, with a title, body and
action row: Escape closes, `autoFocus` inside picks the first stop, and focus
returns to the button that opened it. Pointer modality is deliberately **not**
enforced (widgets behind stay clickable) — a full-window overlay would do that
and is noted in NEXT_STEPS. Demoed as the "Clear" confirmation in
`examples/form.jsx`.

Opened, focus on the `autoFocus` action:

<!-- drag in: dialog-open.png -->
<img width="320" height="150" alt="dialog-open" src="https://github.com/user-attachments/assets/375b0d54-0456-405c-b933-06d92a5aaf2c" />


After Tab — focus moved to *Cancel*, inside the trap, never out to the window
behind:

<!-- drag in: dialog-tab.png -->
<img width="320" height="150" alt="dialog-tab" src="https://github.com/user-attachments/assets/f686d3a4-4300-4050-8071-8e2011ae79a6" />


Both rendered by this branch's own code at 1300b22, headlessly into node-x11's
in-process X server and driven through the real event pipeline (click "Clear",
then a Tab keypress on the owner window).

## Testing

- `npm test` — 106/106 pass, including new smoke tests for `tabIndex` order and
  `-1`, keys routing into a popup with bubbling into the owner tree, trap +
  restore across open/close, and the two `Dialog` behaviours.
- `npm run lint` clean; `npm run bench -- --check` shows no protocol
  regressions.
- One existing behaviour was preserved on purpose rather than by luck: without
  the "press on nothing focusable inside a popup leaves the owner's focus
  alone" rule, the ContextMenu test caught a closed menu on a disabled-row
  click.

Docs: `docs/events.md` gained "Tab order", "Focus scopes (modals)" and "Focus
inside a `<popup>`"; `docs/elements.md` documents `tabIndex`/`trapFocus`/
`disabled`; `docs/components.md` has a `Dialog` section; README's widget list
is no longer just `Select`.
