### PR TITLE
feat: click-to-component — Alt/Option+Click opens the source in your editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,18 @@ Two more debugging aids:
   elements, or the live [ntk](https://github.com/sidorares/ntk) window for
   `<window>`/`<popup>` — the whole ntk API is a ref away.
 
+## Click to component
+
+```sh
+REACT_X11_EDITOR=code npm run examples:tasks
+```
+
+Alt+Click any rendered element (Option+Click on macOS/XQuartz) to open the
+JSX line that created it in your editor. `REACT_X11_EDITOR` picks the CLI
+and enables the feature in one go; `REACT_X11_CLICK_TO_COMPONENT=1` does
+the same with the default editor
+(`cursor`). See [docs/click-to-component.md](docs/click-to-component.md).
+
 ## Developing
 
 ```sh

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,8 @@
   event object shape, focus, cursors, default actions.
 - [devtools.md](devtools.md) — React DevTools integration and other
   debugging aids.
+- [click-to-component.md](click-to-component.md) — Alt+Click a rendered
+  element to open its JSX source line in your editor.
 
 ## Entry points
 
@@ -45,12 +47,14 @@ on ntk's frame clock.
 
 ## Environment variables
 
-| variable                   | effect                                                  |
-| -------------------------- | ------------------------------------------------------- |
-| `DISPLAY`                  | X server to connect to (standard X11)                   |
-| `REACT_X11_DEVTOOLS=1`     | connect to a running `react-devtools` (see devtools.md) |
-| `REACT_X11_DEVTOOLS_HOST`  | devtools host (default `localhost`)                     |
-| `REACT_X11_DEVTOOLS_PORT`  | devtools port (default `8097`)                          |
-| `REACT_X11_DEBUG_LAYOUT=1` | outline every laid-out node, color-coded by tree depth  |
+| variable                         | effect                                                                                   |
+| -------------------------------- | ---------------------------------------------------------------------------------------- |
+| `DISPLAY`                        | X server to connect to (standard X11)                                                    |
+| `REACT_X11_DEVTOOLS=1`           | connect to a running `react-devtools` (see devtools.md)                                  |
+| `REACT_X11_DEVTOOLS_HOST`        | devtools host (default `localhost`)                                                      |
+| `REACT_X11_DEVTOOLS_PORT`        | devtools port (default `8097`)                                                           |
+| `REACT_X11_DEBUG_LAYOUT=1`       | outline every laid-out node, color-coded by tree depth                                   |
+| `REACT_X11_CLICK_TO_COMPONENT=1` | Alt+Click opens the clicked element's source, using `cursor` (see click-to-component.md) |
+| `REACT_X11_EDITOR`               | editor CLI for click-to-component — setting this alone also enables it                   |
 
 - [glx-plan.md](glx-plan.md) — plan for 3D components over indirect GLX

--- a/docs/click-to-component.md
+++ b/docs/click-to-component.md
@@ -1,0 +1,80 @@
+# Click to component
+
+Alt+Click any rendered element to jump straight to the JSX line that created
+it, in your editor. On macOS/XQuartz that's **Option+Click** — Option is
+what XQuartz maps to X11's Mod1 by default; the installed-feature log line
+says whichever one applies to your platform.
+
+## Setup
+
+```sh
+REACT_X11_EDITOR=code npm run examples:tasks   # naming an editor enables it
+# or, to use the default (cursor):
+REACT_X11_CLICK_TO_COMPONENT=1 npm run examples:tasks
+```
+
+Alt/Option+Click a task row, a button, anything — its owning component's source
+opens at the exact line, the clicked element flashes blue for a moment, and
+the console prints what was resolved:
+
+```
+[click-to-component] TaskRow → examples/tasks.jsx:42:7
+```
+
+Alt+Shift+Click also logs the full ownership chain (who rendered who, up to
+the root) to the console — handy when the immediate owner is a shared
+wrapper rather than the component you actually meant.
+
+`REACT_X11_EDITOR` picks the editor (`cursor` by default): `code`,
+`code-insiders`, `windsurf`, `vim`, `nvim`, or any other value, treated as a
+custom URI scheme.
+
+## How it works
+
+`src/ClickToComponent.js`, installed from `Reconciler.js` when either
+`REACT_X11_CLICK_TO_COMPONENT` or `REACT_X11_EDITOR` is set. No
+babel/jsx-source plugin, no build-time instrumentation:
+
+- every host node already carries a reference to the fiber that created it
+  (`node._reactFiber`, set in `createInstance` — the same reference
+  DevTools' `findFiberByHostInstance` uses);
+- React 19 captures a real `Error` at every JSX call site in development
+  mode (`fiber._debugStack`) and tracks who rendered what
+  (`fiber._debugOwner`) — no `__source`/`__self` babel transform needed;
+- Node's `--enable-source-maps` (already on for both the plain `tsx`
+  examples and `examples:tasks:hot`'s loader) has rewritten that Error's
+  stack to original source before we ever see it, so resolving a location
+  is just parsing stack-trace text and skipping frames inside
+  `node_modules` — no source-map library required (this is the one place
+  the design diverges from a browser DOM version of the same idea: a
+  browser doesn't remap `Error.stack` for you, so a tool like
+  [show-component](https://github.com/sidorares/show-component) has to
+  resolve source maps itself at runtime).
+
+Alt+Click is recognized in `EventManager._onMouseDown`
+(`src/events.js`) — `native.buttons & 8` is X11's `Mod1Mask` bit, the same
+`buttons` bitmask `shiftKey`/`ctrlKey` already read elsewhere in that file —
+ahead of the normal press handling, so it never also starts a drag or moves
+focus.
+
+GUI editors (cursor/code/code-insiders/windsurf, or any unrecognized
+`REACT_X11_EDITOR` value treated as a raw scheme) are opened by navigating
+their registered URI scheme — `open cursor://file/abs/path:line:col` on
+macOS, `xdg-open` elsewhere — the same idea show-component uses in a
+browser via `window.location.href`, just handed to the OS instead. This is
+noticeably faster than spawning the editor's CLI shim directly: a CLI like
+`cursor -g ...` is a wrapper script that re-detects and re-execs the real
+app on every call, while the URI scheme is delivered straight to the
+already-running instance by Launch Services / xdg-open. vim and nvim have
+no URI scheme to navigate, so those are still spawned directly with a
+`+call cursor(line, column)` argument.
+
+## Caveats
+
+- Needs React running in development mode (fiber debug fields are stripped
+  in production builds).
+- A node's `_reactFiber` is only refreshed on mount, not on every update —
+  usually harmless (the JSX call site of a given element rarely moves
+  between renders of the same tree shape), but a node that was
+  conditionally re-typed can point at a stale-but-structurally-similar
+  fiber.

--- a/src/ClickToComponent.js
+++ b/src/ClickToComponent.js
@@ -1,0 +1,179 @@
+// Click-to-component: Alt+Click a rendered element to open the exact JSX
+// line that created it in your editor. Opt-in via REACT_X11_CLICK_TO_COMPONENT
+// (see docs/click-to-component.md); wired up from Reconciler.js the same way
+// REACT_X11_DEVTOOLS wires up DevToolsIntegration.js.
+//
+// Unlike DOM click-to-component tools this needs no babel/jsx-source plugin
+// and no source-map resolution of its own: React 19 already captures a real
+// `Error` (fiber._debugStack) at every JSX call site in development mode,
+// and Node's `--enable-source-maps` (which tsx and this repo's hot-reload
+// loader both enable) has already rewritten that Error's stack to point at
+// original source — we only have to parse the stack text and skip the
+// frames inside React/the reconciler itself.
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { setClickToComponentHandler } from './events.js';
+
+const STACK_FRAME = /^\s*at\s+(?:(.+?)\s+\()?(.+?):(\d+):(\d+)\)?\s*$/;
+
+/** The first stack frame outside React/the reconciler/node internals — the
+ * user's own JSX call site for whatever element this Error was captured at. */
+function resolveLocation(debugStack) {
+  const stack = debugStack?.stack;
+  if (!stack) return null;
+  for (const line of stack.split('\n').slice(1)) {
+    const match = line.match(STACK_FRAME);
+    if (!match) continue;
+    const [, functionName, rawFile, lineStr, columnStr] = match;
+    if (
+      rawFile.includes('/node_modules/') ||
+      rawFile.startsWith('node:') ||
+      rawFile === '<anonymous>'
+    ) {
+      continue;
+    }
+    const file = rawFile.startsWith('file://')
+      ? fileURLToPath(rawFile)
+      : rawFile;
+    return {
+      functionName,
+      file,
+      line: Number(lineStr),
+      column: Number(columnStr),
+    };
+  }
+  return null;
+}
+
+function componentName(fiber) {
+  const owner = fiber._debugOwner;
+  const type = owner?.type;
+  if (type) return type.displayName || type.name || '(anonymous)';
+  return typeof fiber.type === 'string' ? `<${fiber.type}>` : '(unknown)';
+}
+
+/** Alt+Shift+Click: who-rendered-who, from the clicked element up to the
+ * root, each with its own source location — handy when the immediate owner
+ * isn't the component you meant (a shared wrapper, a list item, ...). */
+function logOwnerChain(fiber) {
+  const chain = [];
+  for (let owner = fiber._debugOwner; owner; owner = owner._debugOwner) {
+    const location = resolveLocation(owner._debugStack);
+    const name = owner.type?.displayName || owner.type?.name || '(anonymous)';
+    chain.push(
+      location
+        ? `${name} (${location.file}:${location.line}:${location.column})`
+        : name,
+    );
+  }
+  if (chain.length > 0) {
+    console.log('[click-to-component] owner chain:\n  ' + chain.join('\n  '));
+  }
+}
+
+// GUI editors: navigate their registered URI scheme (same idea as
+// https://github.com/sidorares/show-component, minus the browser) instead of
+// spawning their CLI shim. The CLI wrapper (e.g. `cursor -g ...`) round-trips
+// through a shell script that re-detects and re-execs the real app, which is
+// visibly slower than the OS handing the URL straight to the already-running
+// instance via Launch Services (macOS) / xdg-open (Linux).
+const EDITOR_SCHEMES = {
+  cursor: 'cursor',
+  code: 'vscode',
+  vscode: 'vscode',
+  'code-insiders': 'vscode-insiders',
+  'vscode-insiders': 'vscode-insiders',
+  windsurf: 'windsurf',
+};
+
+// Terminal editors have no URI scheme to navigate — spawn them directly.
+const EDITOR_CLI = {
+  vim: (file, line, column) => [
+    'vim',
+    [`+call cursor(${line},${column})`, file],
+  ],
+  nvim: (file, line, column) => [
+    'nvim',
+    [`+call cursor(${line},${column})`, file],
+  ],
+};
+
+const OPEN_URI_COMMAND = process.platform === 'darwin' ? 'open' : 'xdg-open';
+
+function editorUri(scheme, file, line, column) {
+  return `${scheme}://file${encodeURI(file)}:${line}:${column}`;
+}
+
+function openInEditor({ file, line, column }) {
+  const name = process.env.REACT_X11_EDITOR || 'cursor';
+  let bin, args;
+  if (EDITOR_CLI[name]) {
+    [bin, args] = EDITOR_CLI[name](file, line, column);
+  } else {
+    // an unrecognized name is assumed to be a URI scheme itself, so any
+    // editor that registers one works without a matching entry above
+    const scheme = EDITOR_SCHEMES[name] || name;
+    bin = OPEN_URI_COMMAND;
+    args = [editorUri(scheme, file, line, column)];
+  }
+  const child = spawn(bin, args, { detached: true, stdio: 'ignore' });
+  child.on('error', (err) => {
+    console.warn(
+      `react-x11: click-to-component could not launch "${bin}" (${err.code ?? err.message}). ` +
+        'Set REACT_X11_EDITOR to your editor CLI (cursor, code, code-insiders, windsurf, vim, nvim).',
+    );
+  });
+  child.unref();
+}
+
+/** Briefly tint the clicked node so there is visual confirmation of what was
+ * resolved, reusing the same overlay the DevTools hover highlight paints. */
+function flashHighlight(node) {
+  const root = node?.root;
+  if (typeof root?.setHighlight !== 'function') return;
+  root.setHighlight(node);
+  setTimeout(() => root.setHighlight(null), 300);
+}
+
+function handleClick(node, native) {
+  const fiber = node?._reactFiber;
+  if (!fiber) {
+    console.warn(
+      'react-x11: click-to-component — this element has no fiber info.',
+    );
+    return;
+  }
+  const location = resolveLocation(fiber._debugStack);
+  if (!location) {
+    console.warn(
+      'react-x11: click-to-component — no source location found. This needs ' +
+        'React running in development mode (fiber._debugStack).',
+    );
+    return;
+  }
+  console.log(
+    `[click-to-component] ${componentName(fiber)} → ` +
+      `${location.file}:${location.line}:${location.column}`,
+  );
+  if (native?.buttons & 1) {
+    // Alt+Shift+Click
+    logOwnerChain(fiber);
+  }
+  flashHighlight(node);
+  openInEditor(location);
+}
+
+// The bit checked in events.js is X11's Mod1Mask either way — this is only
+// about what the user actually has to press. XQuartz maps the Option key to
+// Mod1 by default ("Option keys send Alt_L and Alt_R" in its Input
+// preferences); everywhere else Mod1 is the physical Alt key.
+const MODIFIER_LABEL = process.platform === 'darwin' ? 'Option' : 'Alt';
+
+export function install() {
+  setClickToComponentHandler(handleClick);
+  console.log(
+    `react-x11: click-to-component enabled — ${MODIFIER_LABEL}+Click an ` +
+      `element to open its source (${MODIFIER_LABEL}+Shift+Click also logs ` +
+      'the owner chain).',
+  );
+}

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -405,6 +405,13 @@ if (process.env.REACT_X11_DEVTOOLS) {
   devtools.connect(Renderer);
 }
 
+if (process.env.REACT_X11_CLICK_TO_COMPONENT || process.env.REACT_X11_EDITOR) {
+  // Naming an editor already means you want the feature on — no need to
+  // also set REACT_X11_CLICK_TO_COMPONENT=1 just to pick one.
+  const clickToComponent = await import('./ClickToComponent.js');
+  clickToComponent.install();
+}
+
 const roots = new Map();
 let cachedNtkApp = null;
 

--- a/src/events.js
+++ b/src/events.js
@@ -10,6 +10,18 @@ import {
 
 const XK_TAB = 0xff09;
 const WHEEL_BUTTONS = { 4: [0, -48], 5: [0, 48], 6: [-48, 0], 7: [48, 0] };
+// X11 KeyButMask bit for Mod1 (Alt on virtually every layout), same bitmask
+// `shiftKey`/`ctrlKey` above already read `buttons` from.
+const MOD1_MASK = 8;
+
+// Click-to-component hook (see ClickToComponent.js). At most one handler is
+// installed, gated by REACT_X11_CLICK_TO_COMPONENT — checked ahead of the
+// normal press handling so an Alt+Click never also starts a drag or moves
+// focus.
+let clickToComponentHandler = null;
+export function setClickToComponentHandler(fn) {
+  clickToComponentHandler = fn;
+}
 
 export class EventManager {
   constructor(windowNode) {
@@ -207,6 +219,10 @@ export class EventManager {
   }
 
   _onMouseDown(native) {
+    if (clickToComponentHandler && Boolean(native.buttons & MOD1_MASK)) {
+      clickToComponentHandler(this._hit(native), native);
+      return;
+    }
     if (this._pressOutside(native)) {
       runWithPriority(DiscreteEventPriority, () => {
         this.node.props.onDismiss?.(

--- a/test/click-to-component.test.js
+++ b/test/click-to-component.test.js
@@ -1,0 +1,88 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import React from 'react';
+import ReactX11 from '../src/index.js';
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient, StaticFontSource } from 'ntk';
+
+// vim exercises the direct-CLI-spawn path (as opposed to the GUI editors'
+// URI-scheme navigation via `open`/`xdg-open`) without any OS-level
+// side effect: with stdio ignored there is no tty, so vim exits immediately.
+process.env.REACT_X11_EDITOR = 'vim';
+
+const require = createRequire(import.meta.url);
+const fontDir = join(
+  dirname(require.resolve('katex/package.json')),
+  'dist',
+  'fonts',
+);
+
+async function createHeadlessApp() {
+  const server = xserver.createServer({ width: 640, height: 480 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const fontSource = new StaticFontSource();
+  fontSource.add(readFileSync(join(fontDir, 'KaTeX_Main-Regular.ttf')), {
+    family: 'Test Main',
+  });
+  fontSource.alias('sans-serif', 'Test Main');
+  const app = await createClient({ stream: clientEnd, fontSource });
+  return { server, app };
+}
+
+function Leaf() {
+  return React.createElement('box', {
+    id: 'leaf',
+    width: 50,
+    height: 50,
+    backgroundColor: 'red',
+  });
+}
+
+test('Alt+Click resolves the fiber to its JSX call site and logs it', async () => {
+  const clickToComponent = await import('../src/ClickToComponent.js');
+  clickToComponent.install();
+
+  const { app } = await createHeadlessApp();
+  const instance = await new Promise((resolve) => {
+    ReactX11.render(
+      React.createElement(
+        'window',
+        { width: 200, height: 200 },
+        React.createElement(Leaf),
+      ),
+      (i) => resolve(i),
+      app,
+    );
+  });
+
+  const windowNode = instance._reactX11Node;
+  // layout/paint run off the initial commit; give it a tick before hit-testing
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  const target = windowNode.hitTest(10, 10);
+  assert.strictEqual(target?.kind, 'box');
+  assert.strictEqual(target._reactFiber?._debugOwner?.type?.name, 'Leaf');
+
+  let resolved = null;
+  const originalLog = console.log;
+  console.log = (...args) => {
+    const msg = args.join(' ');
+    if (msg.startsWith('[click-to-component]') && msg.includes('→')) {
+      resolved = msg;
+    }
+    originalLog(...args);
+  };
+  try {
+    // buttons: 8 = X11 Mod1Mask (Alt)
+    windowNode.events._onMouseDown({ x: 10, y: 10, keycode: 1, buttons: 8 });
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.ok(resolved, 'expected a resolved-location log line');
+  assert.match(resolved, /Leaf/);
+  assert.match(resolved, /click-to-component\.test\.js:\d+:\d+$/);
+});


### PR DESCRIPTION
## Summary

Alt+Click (Option+Click on macOS/XQuartz) any rendered element to jump straight to the JSX line that created it, in your editor. Inspired by [show-component](https://github.com/sidorares/show-component), but reimplemented rather than imported — that project is DOM/browser-specific (event listeners on `document`, `window.location.href` navigation) and react-x11 isn't a browser, so most of it didn't carry over. What did carry over cleanly is the core idea: no babel/jsx-source plugin, no build step. React 19 already captures a real `Error` at every JSX call site in dev mode (`fiber._debugStack`) and tracks who rendered what (`fiber._debugOwner`), and Node's `--enable-source-maps` (already on for this repo's `tsx` examples and the hot-reload loader) has already remapped that stack to original source — so resolving a location is just parsing stack text and skipping frames inside `node_modules`.

- `src/ClickToComponent.js` — resolves a fiber to its source location, flashes the clicked node via the existing DevTools highlight overlay, and opens the editor.
- `src/events.js` — recognizes Alt+Click (X11's `Mod1Mask` bit) in `EventManager._onMouseDown`, ahead of the normal press path so it never starts a drag or moves focus.
- `src/Reconciler.js` — wires it up (same pattern as the existing `REACT_X11_DEVTOOLS` gate).
- GUI editors (cursor/code/code-insiders/windsurf) are opened by navigating their registered URI scheme via `open`/`xdg-open` — the same idea show-component uses via `window.location.href` in a browser, just handed to the OS instead. Noticeably faster than spawning the editor's CLI shim, which re-detects and re-execs the real app on every call. vim/nvim have no such scheme and are spawned directly.
- Opt-in via `REACT_X11_CLICK_TO_COMPONENT=1`, or just `REACT_X11_EDITOR=<name>` (naming an editor already implies wanting the feature on).
- Alt+Shift+Click also logs the full ownership chain to the console.

Docs: `docs/click-to-component.md`, plus pointers from `README.md` and `docs/README.md`.

## Test plan

- [x] `npm test` — 108/108 passing, including a new headless regression test (`test/click-to-component.test.js`) that renders into the in-process X server, simulates an Alt+Click, and asserts the resolved fiber source location matches the actual JSX call site.
- [x] `npx eslint .` / `npx prettier --check .` — clean.
- [x] Manually verified against a real XQuartz display: `REACT_X11_EDITOR=cursor npm run examples:tasks`, Option+Click various elements, confirmed Cursor opens at the exact line and the highlight flash renders.