### PR TITLE
feat: style transitions, and a Switch thumb that slides

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -62,12 +62,11 @@ merged theme (`ThemeProvider`; `SelectThemeProvider` is an alias) and a
 - **Slider** — DONE: `ev.capturePointer()` exposes pointer capture to
   userland, and `Slider` is built on it (drag past the widget bounds,
   arrows/Home/End/PageUp/Down)
-- **Switch animation** — thumb snaps today. Waiting on style transitions
-  (`transition: { backgroundColor: 150 }`) rather than a hand-rolled
-  requestAnimationFrame loop per widget: the same mechanism animates every
-  `:hover` tint. Deferred out of the style-channel prototype
-  ([docs/styling.md](docs/styling.md)) so the animation
-  loop lands as its own change
+- **Switch animation** — DONE via style transitions, not a per-widget
+  requestAnimationFrame loop: the thumb is absolutely positioned and slides
+  on `left`, and the same `transition` declaration eases the track colour.
+  The frame loop runs only while something is unfinished
+  ([docs/styling.md](docs/styling.md))
 - **Tooltip** — DONE: `useAnchor(ref)`/`anchorRect()` extracted from
   `Select` (and now flip at screen edges), `Tooltip` built on them
 - **Dialog** — DONE: a modal over `<popup trapFocus grab>`, centred with
@@ -125,8 +124,10 @@ hints unnest from `sizeHints`. Inline `:hover`/`:focus`/`:active`/`:disabled`
 blocks resolve in the renderer — a repaint, no React render — and are
 restricted to paint properties so a pointer move can never reflow the tree.
 `createStyles` hoists and validates; an unknown style property is an error
-instead of a silent no-op. See [docs/styling.md](docs/styling.md). Left:
-transitions, then theme tokens and window size queries.
+instead of a silent no-op. `transition` animates numbers and colours off the
+window's frame clock, starting from what is on screen so an interrupted
+transition reverses. See [docs/styling.md](docs/styling.md). Left: theme
+tokens, then window size queries.
 
 ### 4. Ecosystem / DX
 

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -45,6 +45,8 @@ Numbers are pixels, strings like `'50%'` / `'auto'` pass through to yoga.
 - `borderWidth`, `borderColor`, `borderRadius`, `borderStyle`
   (`'solid'` default, `'dashed'`)
 - `zIndex` — paint/hit order among siblings (stable sort)
+- `transition` — `120`, or `{ backgroundColor: 120, left: 200 }`: how long a
+  change to that property takes ([styling.md](styling.md#transitions))
 - `opacity` is not implemented yet (see NEXT_STEPS.md)
 
 `cursor` (`'pointer'`, `'text'`, `'wait'`, `'move'`, `'crosshair'`, resize

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -107,16 +107,47 @@ its geometry up front — and `ContextMenu` takes `fontSize` because it
 measures labels with it. `Select` and `Slider` used to take `width` purely
 to put it in their own box; that is `style={{ width }}` now.
 
+## Transitions
+
+`transition` names how long a change takes. A number covers every animatable
+property; an object picks them individually.
+
+```jsx
+<box
+  style={{
+    backgroundColor: theme.surface,
+    transition: 120, // or { backgroundColor: 120, left: 200 }
+    ':hover': { backgroundColor: theme.surfaceHover },
+  }}
+/>
+```
+
+Numbers lerp and colours lerp per channel through ntk's own CSS colour
+parser, so anything the paint path accepts animates. A value with no
+meaningful midpoint — an enum like `flexDirection`, a percentage, `auto` —
+snaps instead, and `zIndex` is excluded on purpose: restacking every frame is
+not an animation.
+
+The easing is a fixed ease-out cubic. A transition starts from **what is on
+screen**, not from the declared value, so interrupting one reverses from
+where it got to rather than jumping to the end first.
+
+The animation _is_ the repaint loop: the window keeps asking its frame clock
+for frames while any transition is unfinished, and stops the frame the last
+one lands. Nothing polls, and there is no per-widget
+`requestAnimationFrame`.
+
+Transitions may animate layout properties, unlike state blocks. That is not
+an inconsistency: a pointer move must never reflow the tree, but an author
+who writes `transition: { left: 200 }` has asked for animated layout and
+pays a layout pass per frame for it. `Switch` is the worked example — the
+thumb is absolutely positioned and slides on `left`, because
+`justifyContent` would flip between the ends with nothing in between.
+
 ## Decided
 
 - **`':hover'`, not `_hover`.** The CSS spelling costs a pair of quotes and
   buys transfer from every other styling system.
-- **Transitions come later.** They are what turns `:hover` from a
-  nice-to-have into the reason to adopt this — and they are also the one
-  item that puts an animation loop in the renderer, so they land as their
-  own change rather than riding along with the namespace split. When they
-  do, they close the "Switch animation" item in NEXT_STEPS §2, which is
-  really a request for this feature.
 
 ## Elements that are not styled
 

--- a/src/components/Switch.js
+++ b/src/components/Switch.js
@@ -8,28 +8,44 @@ import { useControl, useTheme } from './theme.js';
 
 const h = React.createElement;
 
+const TRACK_WIDTH = 36;
+const THUMB = 16;
+const INSET = 2;
+
 const s = createStyles({
   track: {
-    width: 36,
+    width: TRACK_WIDTH,
     height: 20,
     borderRadius: 10,
-    padding: 2,
-    flexDirection: 'row',
-    alignItems: 'center',
+    justifyContent: 'center',
+    transition: { backgroundColor: 120 },
   },
-  thumb: { width: 16, height: 16, borderRadius: 8 },
-  on: { justifyContent: 'flex-end' },
-  off: { justifyContent: 'flex-start' },
+  // absolutely positioned so the thumb slides on `left`: `justifyContent`
+  // would flip it between the ends with nothing in between to animate
+  thumb: {
+    position: 'absolute',
+    width: THUMB,
+    height: THUMB,
+    borderRadius: THUMB / 2,
+    transition: { left: 120 },
+  },
 });
+
+const THUMB_OFF = INSET;
+const THUMB_ON = TRACK_WIDTH - THUMB - INSET;
 
 /**
  * <Switch checked onChange disabled style/> — Checkbox semantics in a
- * sliding pill; the thumb sits at the end matching the state.
+ * sliding pill; the thumb slides to the end matching the state.
  *
  * The hover and focus tints are `:hover`/`:focus` blocks rather than React
  * state: the renderer already knows which node the pointer is over and
  * which one has focus, so lighting the track up is a repaint of one node
  * instead of a re-render of this component and everything under it.
+ *
+ * The slide is a `transition` on `left`, so the animation is the renderer's
+ * frame clock rather than a requestAnimationFrame loop written here — and
+ * the same declaration animates the track colour with it.
  */
 export function Switch({
   checked = false,
@@ -50,7 +66,6 @@ export function Switch({
       style: [
         control.style,
         s.track,
-        checked ? s.on : s.off,
         {
           backgroundColor: disabled
             ? theme.track
@@ -67,6 +82,14 @@ export function Switch({
         style,
       ],
     },
-    h('box', { style: [s.thumb, { backgroundColor: theme.background }] }),
+    h('box', {
+      style: [
+        s.thumb,
+        {
+          left: checked ? THUMB_ON : THUMB_OFF,
+          backgroundColor: theme.background,
+        },
+      ],
+    }),
   );
 }

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -15,6 +15,10 @@ import {
   hasStateStyles,
   isStyleProp,
   EMPTY_STYLE,
+  transitionFor,
+  interpolate,
+  ease,
+  isLayoutProp,
 } from './styles.js';
 import { EventManager } from './events.js';
 import { runWithPriority, DiscreteEventPriority } from './priority.js';
@@ -64,6 +68,13 @@ function isPaintedColor(color) {
 }
 
 const DEV = process.env.NODE_ENV !== 'production';
+
+// Frame timestamps for transitions. Indirected so tests can drive the clock
+// instead of sleeping through real animations.
+let now = () => Date.now();
+export function setAnimationClock(fn) {
+  now = fn;
+}
 
 /** Did anything the text stack measures or paints with change? */
 function textStyleChanged(style, before) {
@@ -148,6 +159,8 @@ export class Node {
     this.abs = { x: 0, y: 0, width: 0, height: 0 };
     // node states that style blocks can react to, owned by EventManager
     this.states = { ':hover': false, ':focus': false, ':active': false };
+    // in-flight transitions: prop -> {from, to, start, duration}
+    this._anim = null;
     this._syncStyle(props);
     this.yoga = yoga ? Yoga.Node.create() : null;
     if (this.yoga) {
@@ -172,10 +185,77 @@ export class Node {
     // straight off props rather than driven by the event manager
     this.states[':disabled'] = Boolean(props.disabled);
     this._stateful = hasStateStyles(this._baseStyle);
-    this.style = this._stateful
-      ? resolveStyleStates(this._baseStyle, this.states)
-      : this._baseStyle;
+    return this._retarget(
+      this._stateful
+        ? resolveStyleStates(this._baseStyle, this.states)
+        : this._baseStyle,
+    );
+  }
+
+  /**
+   * Point the node at a new resolved style. Properties with a `transition`
+   * animate there from whatever is on screen right now — which is what makes
+   * an interrupted transition reverse from where it got to, rather than
+   * jumping to the end first. Everything else takes effect immediately.
+   */
+  _retarget(target) {
+    const displayed = this.style;
+    this._targetStyle = target;
+    if (displayed === undefined || this.destroyed) {
+      this.style = target;
+      return this.style;
+    }
+    for (const prop of Object.keys(target)) {
+      const to = target[prop];
+      const from = displayed[prop];
+      if (from === to || from === undefined) continue;
+      const duration = transitionFor(target, prop);
+      if (duration <= 0) continue;
+      if (interpolate(from, to, 0.5) === null) continue; // no midpoint: snap
+      (this._anim ??= new Map()).set(prop, {
+        from,
+        to,
+        duration,
+        start: this.root?.frameTime ?? 0,
+      });
+      this.root?._startAnimating(this);
+    }
+    this.style = this._anim?.size
+      ? { ...target, ...this._animatedValues() }
+      : target;
     return this.style;
+  }
+
+  _animatedValues() {
+    const values = {};
+    for (const [prop, a] of this._anim) values[prop] = a.value ?? a.from;
+    return values;
+  }
+
+  /**
+   * Advance every in-flight transition to `now`. Returns true while any is
+   * still running, so the window keeps asking for frames.
+   */
+  _tickAnimations(now) {
+    if (!this._anim?.size) return false;
+    let layoutChanged = false;
+    const before = this.style;
+    for (const [prop, a] of this._anim) {
+      const t = a.duration > 0 ? Math.min(1, (now - a.start) / a.duration) : 1;
+      a.value = t >= 1 ? a.to : (interpolate(a.from, a.to, ease(t)) ?? a.to);
+      if (t >= 1) this._anim.delete(prop);
+      if (isLayoutProp(prop)) layoutChanged = true;
+    }
+    this.style = this._anim.size
+      ? { ...this._targetStyle, ...this._animatedValues() }
+      : this._targetStyle;
+    if (layoutChanged && this.yoga) {
+      applyLayoutStyle(this.yoga, this.style, before);
+      // a transition on a layout property costs a layout pass per frame —
+      // the author asked for that by transitioning one (docs/styling.md)
+      if (this.root) this.root.needsLayout = true;
+    }
+    return this._anim.size > 0;
   }
 
   /**
@@ -188,9 +268,9 @@ export class Node {
     this.states[name] = on;
     if (!this._stateful || this.destroyed) return;
     const next = resolveStyleStates(this._baseStyle, this.states);
-    const changed = !shallowEqual(next, this.style);
-    this.style = next;
-    if (changed) this.root?.invalidate(false);
+    if (shallowEqual(next, this._targetStyle)) return;
+    this._retarget(next);
+    this.root?.invalidate(false);
   }
 
   get isWindow() {
@@ -1681,6 +1761,10 @@ export class WindowNode extends Node {
     // ids of the child windows in the order the *server* stacks them,
     // bottom to top — see _restackWindowChildren
     this._xStack = [];
+    // nodes with a transition in flight, and the timestamp the current
+    // frame is being rendered for
+    this._animating = new Set();
+    this.frameTime = 0;
   }
 
   /** Create the real X11 window (commit phase only). Children windows are
@@ -1978,6 +2062,28 @@ export class WindowNode extends Node {
     );
   }
 
+  /** A node in this window started a transition. */
+  _startAnimating(node) {
+    this._animating.add(node);
+  }
+
+  /**
+   * Step every in-flight transition to `now`, then keep the frame clock
+   * running while any is unfinished — the animation *is* the repaint loop,
+   * and it stops on its own the frame the last one lands.
+   */
+  _advanceAnimations(now) {
+    this.frameTime = now;
+    if (this._animating.size === 0) return;
+    for (const node of [...this._animating]) {
+      if (node.destroyed || !node._tickAnimations(now)) {
+        this._animating.delete(node);
+      }
+    }
+    this.needsPaint = true;
+    if (this._animating.size > 0) this.invalidate(false);
+  }
+
   setHidden(hidden) {
     if (hidden) this.window?.unmap?.();
     else this.window?.map?.();
@@ -2001,6 +2107,7 @@ export class WindowNode extends Node {
 
   flush() {
     if (this.destroyed || !this.yoga || !this.window) return;
+    this._advanceAnimations(now());
     const width = this.window.width ?? this.props.width ?? 0;
     const height = this.window.height ?? this.props.height ?? 0;
     if (this.needsLayout) {

--- a/src/styles.js
+++ b/src/styles.js
@@ -3,7 +3,7 @@
 // Numbers are pixels; strings like '50%' / 'auto' pass through to yoga.
 // Yoga comes from ntk (>= 3.1.0) so renderer and ntk widgets share one
 // WASM instance and enum set.
-import { Yoga } from 'ntk';
+import { Yoga, cssColor } from 'ntk';
 
 export { Yoga };
 
@@ -167,6 +167,7 @@ const STYLE_PROPS = new Set([
   ...TEXT_LAYOUT_PROPS,
   'color',
   'borderStyle',
+  'transition',
   // CSS concepts even though they read as behaviour; React Native has been
   // moving pointerEvents into style for the same reason
   'cursor',
@@ -269,6 +270,74 @@ export function hasStateStyles(style) {
   for (const key of STATE_KEYS) if (style[key]) return true;
   return false;
 }
+
+/**
+ * Style properties a transition can animate: numbers and colours. Enums
+ * (`flexDirection`), `zIndex` (restacking every frame is not an animation)
+ * and `transition` itself are excluded — a change to those snaps.
+ */
+const NOT_ANIMATABLE = new Set([
+  'transition',
+  'zIndex',
+  'flexDirection',
+  'justifyContent',
+  'alignItems',
+  'alignSelf',
+  'alignContent',
+  'flexWrap',
+  'position',
+  'display',
+  'overflow',
+  'cursor',
+  'pointerEvents',
+  'borderStyle',
+  'fontFamily',
+  'fontWeight',
+  'fontStyle',
+  'textAlign',
+]);
+
+export const isAnimatableProp = (name) =>
+  STYLE_PROPS.has(name) && !NOT_ANIMATABLE.has(name);
+
+/**
+ * `transition: 150` — every animatable property that changes, over 150ms.
+ * `transition: { backgroundColor: 150 }` — only these, with their own
+ * durations. Returns a lookup of prop -> ms, or null.
+ */
+export function transitionFor(style, prop) {
+  const t = style.transition;
+  if (t == null || !isAnimatableProp(prop)) return 0;
+  if (typeof t === 'number') return t;
+  return t[prop] ?? 0;
+}
+
+const rgba = (c) =>
+  c &&
+  `rgba(${Math.round(c[0] * 255)}, ${Math.round(c[1] * 255)}, ${Math.round(c[2] * 255)}, ${c[3]})`;
+
+/**
+ * Interpolate one style value. Numbers lerp; colours lerp per channel
+ * through ntk's own CSS colour parser, so anything the paint path accepts
+ * animates. Anything else — a percentage string, `auto`, an enum — has no
+ * meaningful midpoint and returns null, which the caller treats as a snap.
+ */
+export function interpolate(from, to, t) {
+  if (typeof from === 'number' && typeof to === 'number') {
+    return from + (to - from) * t;
+  }
+  if (typeof from === 'string' && typeof to === 'string') {
+    const a = cssColor(from);
+    const b = cssColor(to);
+    if (!a || !b) return null;
+    return rgba(a.map((v, i) => v + (b[i] - v) * t));
+  }
+  return null;
+}
+
+// ease-out cubic: fast to start, settles gently — the shape almost every UI
+// toolkit defaults to for state changes
+export const ease = (t) => 1 - (1 - t) ** 3;
 
 export { validateStyle };
 

--- a/test/style.test.js
+++ b/test/style.test.js
@@ -294,3 +294,231 @@ test('REACT_X11_STYLE_ONLY: a flat style prop is an error that names the fix', a
   assert.match(out, /style=\{\{ padding: … \}\}/, 'the error shows the fix');
   assert.match(out, /window ok/, '<window width>/<window minWidth> stay props');
 });
+
+// --- transitions -----------------------------------------------------------
+
+test('a transition eases a colour instead of snapping to it', async () => {
+  const { setAnimationClock } = await import('../src/nodes.js');
+  let clock = 1000;
+  setAnimationClock(() => clock);
+  try {
+    const app = createMockApp();
+    ReactX11.render(
+      h(
+        'window',
+        { width: 100, height: 100 },
+        h('box', {
+          style: {
+            width: 40,
+            height: 40,
+            backgroundColor: '#000000',
+            transition: 100,
+            ':hover': { backgroundColor: '#ffffff' },
+          },
+        }),
+      ),
+      null,
+      app,
+    );
+    await tick();
+
+    const root = nodeOf(app);
+    const box = root.children[0];
+    assert.strictEqual(box.style.backgroundColor, '#000000');
+
+    moveMouse(app.windows[0], 20, 20);
+    assert.strictEqual(
+      box.style.backgroundColor,
+      '#000000',
+      'the frame the pointer arrives still shows the old value',
+    );
+
+    clock = 1050; // half way, eased
+    root._advanceAnimations(clock);
+    const mid = box.style.backgroundColor;
+    assert.match(mid, /^rgba\(/, 'interpolated through ntk’s colour parser');
+    const channel = Number(mid.slice(5).split(',')[0]);
+    assert.ok(
+      channel > 0 && channel < 255,
+      `midpoint should be grey, got ${mid}`,
+    );
+
+    clock = 1200; // past the end
+    root._advanceAnimations(clock);
+    assert.strictEqual(
+      box.style.backgroundColor,
+      '#ffffff',
+      'lands exactly on the declared value, not on a rounded rgba()',
+    );
+    assert.strictEqual(root._animating.size, 0, 'and stops asking for frames');
+  } finally {
+    setAnimationClock(() => Date.now());
+  }
+});
+
+test('an interrupted transition reverses from where it got to', async () => {
+  const { setAnimationClock } = await import('../src/nodes.js');
+  let clock = 0;
+  setAnimationClock(() => clock);
+  try {
+    const app = createMockApp();
+    ReactX11.render(
+      h(
+        'window',
+        { width: 100, height: 100 },
+        h('box', {
+          style: {
+            width: 40,
+            height: 40,
+            backgroundColor: '#000000',
+            transition: 100,
+            ':hover': { backgroundColor: '#ffffff' },
+          },
+        }),
+      ),
+      null,
+      app,
+    );
+    await tick();
+    const root = nodeOf(app);
+    const box = root.children[0];
+
+    moveMouse(app.windows[0], 20, 20);
+    clock = 30;
+    root._advanceAnimations(clock);
+    const partway = box.style.backgroundColor;
+
+    moveMouse(app.windows[0], 90, 90); // leave before it finished
+    assert.strictEqual(
+      box.style.backgroundColor,
+      partway,
+      'the reverse starts from the current on-screen value, not from the end',
+    );
+    clock = 200;
+    root._advanceAnimations(clock);
+    assert.strictEqual(box.style.backgroundColor, '#000000');
+  } finally {
+    setAnimationClock(() => Date.now());
+  }
+});
+
+test('transitions cover layout too, and relayout as they run', async () => {
+  const { setAnimationClock } = await import('../src/nodes.js');
+  let clock = 0;
+  setAnimationClock(() => clock);
+  try {
+    const app = createMockApp();
+    const ui = (left) =>
+      h(
+        'window',
+        { width: 200, height: 100 },
+        h('box', {
+          style: {
+            position: 'absolute',
+            left,
+            width: 20,
+            height: 20,
+            transition: { left: 100 },
+          },
+        }),
+      );
+    ReactX11.render(ui(0), null, app);
+    await tick();
+    const root = nodeOf(app);
+    const box = root.children[0];
+    assert.strictEqual(box.abs.x, 0);
+
+    ReactX11.render(ui(100), null, app);
+    clock = 50;
+    root._advanceAnimations(clock);
+    root.flush();
+    assert.ok(
+      box.abs.x > 0 && box.abs.x < 100,
+      `mid-transition the box is laid out part way, got ${box.abs.x}`,
+    );
+
+    clock = 500;
+    root._advanceAnimations(clock);
+    root.flush();
+    assert.strictEqual(box.abs.x, 100);
+  } finally {
+    setAnimationClock(() => Date.now());
+  }
+});
+
+test('a property with no midpoint snaps rather than animating', async () => {
+  const app = createMockApp();
+  ReactX11.render(
+    h(
+      'window',
+      { width: 100, height: 100 },
+      h('box', {
+        style: {
+          flexDirection: 'row',
+          transition: 100,
+          ':hover': { backgroundColor: 'red' },
+        },
+      }),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const root = nodeOf(app);
+  ReactX11.render(
+    h(
+      'window',
+      { width: 100, height: 100 },
+      h('box', { style: { flexDirection: 'column', transition: 100 } }),
+    ),
+    null,
+    app,
+  );
+  assert.strictEqual(
+    root.children[0].style.flexDirection,
+    'column',
+    'an enum has no midpoint: it takes effect at once',
+  );
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('Switch: the thumb slides between the ends instead of snapping', async () => {
+  const { Switch } = await import('../src/index.js');
+  const { setAnimationClock } = await import('../src/nodes.js');
+  let clock = 0;
+  setAnimationClock(() => clock);
+  try {
+    const app = createMockApp();
+    const render = (checked) =>
+      ReactX11.render(
+        h(
+          'window',
+          { width: 100, height: 60 },
+          h(Switch, { checked, onChange: () => {} }),
+        ),
+        null,
+        app,
+      );
+
+    render(false);
+    await tick();
+    const root = nodeOf(app);
+    const thumb = root.children[0].children[0];
+    const off = thumb.abs.x;
+
+    render(true);
+    clock = 60;
+    root._advanceAnimations(clock);
+    root.flush();
+    const mid = thumb.abs.x;
+    assert.ok(mid > off, `thumb should have moved by mid-flight, got ${mid}`);
+
+    clock = 400;
+    root._advanceAnimations(clock);
+    root.flush();
+    assert.ok(thumb.abs.x > mid, 'and keeps going to the on position');
+    assert.strictEqual(root._animating.size, 0, 'then the frame loop stops');
+  } finally {
+    setAnimationClock(() => Date.now());
+  }
+});


### PR DESCRIPTION
`transition` names how long a change to a style property takes — a number covers every animatable property, an object picks them individually.

```jsx
<box style={{
  backgroundColor: theme.surface,
  transition: 120,                       // or { backgroundColor: 120, left: 200 }
  ':hover': { backgroundColor: theme.surfaceHover },
}} />
```

## What animates

Numbers lerp; colours lerp per channel through ntk's own `cssColor`, so anything the paint path accepts animates and **no new dependency is added** — that is the parser NEXT_STEPS always intended to reuse. A value with no meaningful midpoint — an enum like `flexDirection`, a percentage, `auto` — snaps instead. `zIndex` is excluded on purpose: restacking every frame is not an animation.

Easing is a fixed ease-out cubic.

## Two properties worth calling out

**A transition starts from what is on screen**, not from the declared value. Interrupting one therefore reverses from where it got to instead of jumping to the end and running back — the difference between a toggle that feels alive and one that stutters when you change your mind mid-flight. There is a test for exactly that.

**The animation is the repaint loop.** The window keeps asking its frame clock for frames while any transition is unfinished, and stops the frame the last one lands. Nothing polls, and no widget owns a `requestAnimationFrame` loop. The clock is injectable, which is how the tests drive six frames without sleeping through a real animation.

## Layout, and why that isn't inconsistent

State blocks are paint-only — a pointer move must never reflow the tree. Transitions may animate layout properties, because an author who writes `transition: { left: 200 }` has asked for animated layout and pays a layout pass per frame for it. The two rules answer different questions.

## Switch

This closes the **"Switch animation"** item that has been open in NEXT_STEPS §2 since the widget set landed — and closes it the way the roadmap hoped, with no hand-rolled loop in the widget. The thumb is absolutely positioned and slides on `left`, because `justifyContent` would flip between the ends with nothing in between to interpolate. The same declaration eases the track colour with it.

Rendered by this PR's own code at successive points of the transition (the clock is driven, so these are real frames, not a mock-up):

![switch-transition](https://github.com/user-attachments/assets/ee7f1b90-53e1-4e63-8b9d-98b5316aa1d3)

Note how front-loaded the movement is — that is the ease-out cubic, most of the distance covered in the first third.

## Tests

`npm test` 129 passing, 5 new: the eased midpoint, the interrupted reverse, a layout transition relaying out as it runs, a no-midpoint property snapping, and the Switch thumb moving between frames. `npm run lint` clean. The committed screenshots are unchanged — the widget gallery is not part of that set.

Next on the list: theme tokens, then window size queries.