### PR TITLE
feat: theme tokens — $name style values

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -126,8 +126,9 @@ restricted to paint properties so a pointer move can never reflow the tree.
 `createStyles` hoists and validates; an unknown style property is an error
 instead of a silent no-op. `transition` animates numbers and colours off the
 window's frame clock, starting from what is on screen so an interrupted
-transition reverses. See [docs/styling.md](docs/styling.md). Left: theme
-tokens, then window size queries.
+transition reverses. `$token` style values resolve against the nearest
+`theme` prop, so a hoisted style can follow the palette with no React
+context. See [docs/styling.md](docs/styling.md). Left: window size queries.
 
 ### 4. Ecosystem / DX
 

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -47,6 +47,8 @@ Numbers are pixels, strings like `'50%'` / `'auto'` pass through to yoga.
 - `zIndex` — paint/hit order among siblings (stable sort)
 - `transition` — `120`, or `{ backgroundColor: 120, left: 200 }`: how long a
   change to that property takes ([styling.md](styling.md#transitions))
+- any value may be a **theme token**: `'$panel'` resolves against the nearest
+  `theme` prop above the node ([styling.md](styling.md#theme-tokens))
 - `opacity` is not implemented yet (see NEXT_STEPS.md)
 
 `cursor` (`'pointer'`, `'text'`, `'wait'`, `'move'`, `'crosshair'`, resize
@@ -76,6 +78,7 @@ A real X11 window; the flex, paint and event root for its subtree.
 | `onResize(ev)`              | ConfigureNotify — the tree reflows automatically                     |
 | `onExpose(ev)`              | after a repaint was required                                         |
 | `onCloseRequest(ev)`        | WM close button (opts into `WM_DELETE_WINDOW`)                       |
+| `theme`                     | palette that `$token` style values resolve against, for this subtree |
 
 Windows may be nested inside other windows (real X11 child windows).
 **Ref**: the live ntk `Window` — `getContext('2d')`,

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -107,6 +107,50 @@ its geometry up front — and `ContextMenu` takes `fontSize` because it
 measures labels with it. `Select` and `Slider` used to take `width` purely
 to put it in their own box; that is `style={{ width }}` now.
 
+## Theme tokens
+
+A style value of `'$name'` resolves against the nearest `theme` prop above
+the node. The sigil is what keeps it unambiguous: `'red'` is a CSS colour,
+`'$red'` is a token.
+
+```jsx
+const s = createStyles({
+  card: { backgroundColor: '$panel', padding: '$gutter' },
+  title: { color: '$text', fontSize: 20 },
+});
+
+<window theme={palette} style={{ backgroundColor: '$bg' }}>
+  <box style={s.card}>…</box>
+</window>;
+```
+
+That is the point of tokens: the style is **hoisted** — declared once,
+outside render, with no access to React context — and still follows the
+theme. Without them a palette has to be threaded to every element that
+paints (`style={[s.card, { backgroundColor: theme.panel }]}`).
+
+Tokens are not colour-only; `padding: '$gutter'` resolves a number just as
+well.
+
+A `theme` prop anywhere scopes its subtree, and an inner one merges over the
+outer, so a panel can restate a colour or two without repeating a palette.
+Popups resolve through their place in the **tree**, not their window, so a
+menu inherits the theme of the UI that opened it even though it is a
+separate X window.
+
+Changing the theme restyles the subtree in place. Nodes whose own props did
+not change are still updated — which is why a theme change also drops the
+memoised text layouts under it, or cached text would keep painting the old
+colour.
+
+An unknown token is an error naming what the theme does have. Resolution is
+cached per (style object, theme object), so a hoisted style under one theme
+keeps its identity across renders and the `===` fast path still applies.
+
+Widgets plant their merged palette (`ThemeProvider` + the built-in defaults)
+on their own root node, so `$tokens` work inside a widget subtree — and in a
+style you pass one — even when the app only used `<ThemeProvider>`.
+
 ## Transitions
 
 `transition` names how long a change takes. A number covers every animatable
@@ -159,7 +203,6 @@ way it does not apply to an `<input type>` in the DOM. They report
 
 ## Next
 
-Theme tokens (`backgroundColor="panel"` resolved through `ThemeProvider`) and
-window size queries — the X11 analogue of `@media`, and layout-capable, since
-they are only re-evaluated during a layout pass that resize already triggers
-— are the follow-ons after transitions.
+Window size queries — the X11 analogue of `@media`, and layout-capable,
+since they are only re-evaluated during a layout pass that a resize already
+triggers.

--- a/examples/dashboard.jsx
+++ b/examples/dashboard.jsx
@@ -20,16 +20,28 @@ import {
 // Styles are declared once, outside render: hoisting is what lets the
 // renderer skip an update with an identity check, and what keeps the JSX
 // below shorter than the flat-prop version it replaced.
+// `$name` reads the nearest `theme` prop, so these can be declared once,
+// outside render, and still follow the Light/Dark toggle — the whole reason
+// the palette does not have to be threaded through every component.
 const s = createStyles({
   root: { flexGrow: 1, padding: 16, gap: 16 },
   header: { flexDirection: 'row', alignItems: 'center', gap: 12 },
-  title: { fontSize: 20 },
+  title: { fontSize: 20, color: '$text' },
   spacer: { flexGrow: 1 },
   row: { flexDirection: 'row', gap: 12 },
   footer: { flexDirection: 'row', gap: 12, justifyContent: 'center' },
-  card: { flexGrow: 1, borderRadius: 8, padding: 14, gap: 6 },
-  cardLabel: { fontSize: 12 },
-  cardValue: { fontSize: 26 },
+  card: {
+    flexGrow: 1,
+    borderRadius: 8,
+    padding: 14,
+    gap: 6,
+    backgroundColor: '$panel',
+    transition: { backgroundColor: 200 },
+  },
+  cardLabel: { fontSize: 12, color: '$dim' },
+  cardValue: { fontSize: 26, color: '$text' },
+  clock: { color: '$dim' },
+  window: { backgroundColor: '$bg', transition: { backgroundColor: 200 } },
 });
 
 const THEMES = {
@@ -85,9 +97,9 @@ function widgetTheme(t) {
 function StatCard({ label, value, progress }) {
   const theme = useContext(ThemeContext);
   return (
-    <box style={[s.card, { backgroundColor: theme.panel }]}>
-      <text style={[s.cardLabel, { color: theme.dim }]}>{label}</text>
-      <text style={[s.cardValue, { color: theme.text }]}>{value}</text>
+    <box style={s.card}>
+      <text style={s.cardLabel}>{label}</text>
+      <text style={s.cardValue}>{value}</text>
       {progress != null && (
         <ProgressBar value={progress} color={theme.accent} />
       )}
@@ -113,15 +125,14 @@ function App() {
           height={340}
           minWidth={360}
           minHeight={240}
-          style={{ backgroundColor: theme.bg }}
+          theme={theme}
+          style={s.window}
         >
           <box style={s.root}>
             <box style={s.header}>
-              <text style={[s.title, { color: theme.text }]}>Dashboard</text>
+              <text style={s.title}>Dashboard</text>
               <box style={s.spacer} />
-              <text style={{ color: theme.dim }}>
-                {now.toLocaleTimeString()}
-              </text>
+              <text style={s.clock}>{now.toLocaleTimeString()}</text>
               <Button
                 label={themeName === 'light' ? 'Dark' : 'Light'}
                 onPress={() =>

--- a/scripts/screenshots.jsx
+++ b/scripts/screenshots.jsx
@@ -220,7 +220,7 @@ await scene(async (app) => {
   clickNode(wnd, plus);
   clickNode(wnd, plus);
   clickNode(wnd, labeled(wnd, 'Dark')); // the dark theme photographs better
-  await sleep(50);
+  await sleep(500);
   await shot(wnd, 'dashboard');
 });
 

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -41,6 +41,7 @@ export function Button({
   return h(
     'box',
     {
+      theme,
       ...props,
       ...boxProps,
       style: [

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -30,6 +30,7 @@ export function Checkbox({
   return h(
     'box',
     {
+      theme,
       ...props,
       ...boxProps,
       style: [

--- a/src/components/Dialog.js
+++ b/src/components/Dialog.js
@@ -80,7 +80,11 @@ export function Dialog({
   return h(
     'box',
     // out of flow: an anchor for the window geometry, never part of layout
-    { ref: anchor, style: { position: 'absolute', width: 0, height: 0 } },
+    {
+      theme,
+      ref: anchor,
+      style: { position: 'absolute', width: 0, height: 0 },
+    },
     rect &&
       h(
         'popup',

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -100,7 +100,10 @@ function MenuRow({
   if (item.separator) {
     return h(
       'box',
-      { style: { height: MENU_SEPARATOR_HEIGHT, justifyContent: 'center' } },
+      {
+        theme,
+        style: { height: MENU_SEPARATOR_HEIGHT, justifyContent: 'center' },
+      },
       h('box', { style: { height: 1, backgroundColor: theme.border } }),
     );
   }
@@ -294,6 +297,7 @@ function MenuLevel({
   return h(
     'popup',
     {
+      theme,
       x: rect.x,
       y: rect.y,
       width: rect.width,
@@ -573,6 +577,7 @@ export function MenuBar({
   return h(
     'box',
     {
+      theme,
       ...boxProps,
       style: [
         {

--- a/src/components/ProgressBar.js
+++ b/src/components/ProgressBar.js
@@ -29,6 +29,7 @@ export function ProgressBar({
   return h(
     'box',
     {
+      theme,
       ...boxProps,
       style: [
         {

--- a/src/components/Radio.js
+++ b/src/components/Radio.js
@@ -68,6 +68,7 @@ export function Radio({ value, children, label, disabled = false }) {
   return h(
     'box',
     {
+      theme,
       ...props,
       style: [
         controlStyle,

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -36,6 +36,7 @@ function Option({ option, selected, active, onPick, onHover, nodeRef }) {
   return h(
     'box',
     {
+      theme,
       ref: nodeRef,
       onMouseEnter: () => onHover?.(),
       onClick: () => onPick(option),
@@ -185,6 +186,7 @@ export function Select({
   return h(
     'box',
     {
+      theme,
       ref: triggerRef,
       focusable: true,
       onClick: toggle,

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -121,6 +121,7 @@ export function Slider({
   return h(
     'box',
     {
+      theme,
       ref: trackRef,
       ...controlProps,
       ...boxProps,

--- a/src/components/Switch.js
+++ b/src/components/Switch.js
@@ -61,6 +61,7 @@ export function Switch({
   return h(
     'box',
     {
+      theme,
       ...control.props,
       ...boxProps,
       style: [

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -101,6 +101,7 @@ export function Tooltip({
   return h(
     'box',
     {
+      theme,
       ref,
       onMouseEnter,
       onMouseMove,

--- a/src/components/theme.js
+++ b/src/components/theme.js
@@ -2,7 +2,7 @@
 // support needed. Plain createElement (no JSX) so the library stays
 // build-step-free for consumers.
 
-import React, { useContext, useState } from 'react';
+import React, { useContext, useMemo, useState } from 'react';
 import { XK_RETURN } from './keys.js';
 
 const h = React.createElement;
@@ -29,9 +29,18 @@ export const ThemeProvider = ThemeContext.Provider;
 
 export const SelectThemeProvider = ThemeContext.Provider; // back-compat alias
 
+/**
+ * The merged palette. Memoised on the context value because identity now
+ * matters: it is planted on each widget's root node as the `theme` prop, and
+ * a fresh object every render would re-resolve every `$token` beneath it and
+ * defeat the resolution cache.
+ */
 export function useTheme() {
   const theme = useContext(ThemeContext);
-  return theme === DefaultTheme ? theme : { ...DefaultTheme, ...theme };
+  return useMemo(
+    () => (theme === DefaultTheme ? theme : { ...DefaultTheme, ...theme }),
+    [theme],
+  );
 }
 
 /**

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -19,6 +19,8 @@ import {
   interpolate,
   ease,
   isLayoutProp,
+  styleUsesTokens,
+  resolveTokens,
 } from './styles.js';
 import { EventManager } from './events.js';
 import { runWithPriority, DiscreteEventPriority } from './priority.js';
@@ -181,6 +183,15 @@ export class Node {
       validateStyle(flattenStyle(props.style), `<${this.kind} style>`);
     }
     this._baseStyle = this.stylable ? flattenStyle(props.style) : EMPTY_STYLE;
+    this._usesTokens = this.stylable && styleUsesTokens(this._baseStyle);
+    if (this._usesTokens) {
+      this._baseStyle = resolveTokens(
+        this._baseStyle,
+        this.theme,
+        `<${this.kind} style>`,
+        Boolean(this.root),
+      );
+    }
     // `disabled` is a prop, not something the pointer does, so it is read
     // straight off props rather than driven by the event manager
     this.states[':disabled'] = Boolean(props.disabled);
@@ -283,6 +294,41 @@ export class Node {
   }
 
   /**
+   * The theme in force here: the nearest `theme` prop at or above this node,
+   * with an inner one merged over the outer so a panel can restate a colour
+   * or two without repeating a palette. Popups resolve through their place
+   * in the *tree*, not their window, so a menu inherits the theme of the UI
+   * that opened it even though it is a separate X window.
+   */
+  get theme() {
+    if (this._theme !== undefined) return this._theme;
+    const inherited = this.parent?.theme;
+    const own = this.props.theme;
+    this._theme = own
+      ? inherited
+        ? { ...inherited, ...own }
+        : own
+      : (inherited ?? null);
+    return this._theme;
+  }
+
+  /** The theme above or on this node changed: drop the caches and restyle
+   * the subtree, since a token can appear at any depth. */
+  _themeChanged() {
+    this._theme = undefined;
+    if (this._usesTokens) {
+      const before = this.style;
+      this._syncStyle(this.props);
+      // a token change reaches the node without React re-rendering it, so
+      // the invalidation TextNode.applyProps would have done has to happen
+      // here too — otherwise the cached layout keeps painting the old colour
+      if (textStyleChanged(this.style, before)) this._textContentChanged();
+      this.root?.invalidate(true);
+    }
+    for (const child of this.children) child._themeChanged();
+  }
+
+  /**
    * Whether this element is styled at all. The 3D scene elements and the
    * declarative SVG children are not: they carry their own vocabularies —
    * `position`, `color`, `width` mean a transform, a material and a radius
@@ -328,9 +374,11 @@ export class Node {
   insertBefore(child, beforeChild) {
     if (child.isPopup) {
       // popups live anywhere in the JSX tree but are independent
-      // override-redirect windows: bookkeeping only, no yoga, no paint
+      // override-redirect windows: bookkeeping only, no yoga, no paint —
+      // but they do inherit the theme of where they are written
       this._spliceChild(child, beforeChild);
       child.parent = this;
+      if (this.theme || child.props.theme) child._themeChanged();
       return;
     }
     if (child.isWindow) {
@@ -350,6 +398,9 @@ export class Node {
       this.yoga.insertChild(child.yoga, this._yogaIndexAt(index));
     }
     child._setRoot(this.root);
+    // it can see its ancestors now, so any token in its style can resolve.
+    // With no theme anywhere there is nothing to resolve and nothing to walk
+    if (this.theme || child.props.theme) child._themeChanged();
     this._textContentChanged();
     this.root?.invalidate(true);
   }
@@ -393,7 +444,9 @@ export class Node {
   applyProps(newProps, oldProps) {
     const prev = this.props;
     const prevStyle = this.style;
+    const themeChanged = newProps.theme !== prev.theme;
     this.props = newProps;
+    if (themeChanged) this._themeChanged();
     const style = this._syncStyle(newProps);
     let layoutChanged = false;
     // hoisted styles hit the identity check and skip the whole update
@@ -1964,6 +2017,7 @@ export class WindowNode extends Node {
         child.realize(this.window);
         if (child.window) this._xStack.push(child.window.id);
       }
+      if (this.theme || child.props.theme) child._themeChanged();
       // React reorders a keyed list with one insertBefore per moved child;
       // restacking once at the end of the commit skips the intermediate
       // orders, which nobody ever sees.
@@ -2003,7 +2057,9 @@ export class WindowNode extends Node {
   applyProps(newProps, oldProps) {
     const before = oldProps ?? this.props;
     const beforeStyle = this.style;
+    const themeChanged = newProps.theme !== before.theme;
     this.props = newProps;
+    if (themeChanged) this._themeChanged();
     const style = this._syncStyle(newProps);
     if (Boolean(newProps.trapFocus) !== Boolean(before.trapFocus)) {
       this._syncFocusScope();

--- a/src/styles.js
+++ b/src/styles.js
@@ -339,6 +339,83 @@ export function interpolate(from, to, t) {
 // toolkit defaults to for state changes
 export const ease = (t) => 1 - (1 - t) ** 3;
 
+/**
+ * Theme tokens. A style value of `'$name'` resolves against the nearest
+ * `theme` prop above the node, so a style can be hoisted — declared once,
+ * outside render, with no access to React context — and still follow the
+ * theme. The sigil is what keeps it unambiguous: `'red'` is a CSS colour,
+ * `'$red'` is a token.
+ */
+const isToken = (v) => typeof v === 'string' && v.charCodeAt(0) === 36; /* $ */
+
+export function styleUsesTokens(style) {
+  for (const key of Object.keys(style)) {
+    const v = style[key];
+    if (isToken(v)) return true;
+    if (key.charCodeAt(0) === 58 && v && styleUsesTokens(v)) return true;
+  }
+  return false;
+}
+
+// (style object, theme object) -> resolved style. Two hoisted styles under
+// one theme therefore keep their identity across renders, which is what the
+// `===` fast path in applyProps relies on.
+const resolvedCache = new WeakMap();
+
+/**
+ * Before a node is attached it has no ancestors and so no theme yet — one
+ * commit tick, but long enough for yoga to be handed a `'$gutter'`. Drop
+ * the token-valued properties until the real value is known; the node
+ * restyles on attach.
+ */
+export function stripTokens(style) {
+  const out = {};
+  for (const key of Object.keys(style)) {
+    const v = style[key];
+    if (isToken(v)) continue;
+    out[key] = key.charCodeAt(0) === 58 && v ? stripTokens(v) : v;
+  }
+  return out;
+}
+
+/**
+ * `strict` says the node's ancestry is complete, so a token that does not
+ * resolve is a mistake. While a subtree is still being built its nodes can
+ * see only part of their ancestry — the theme two levels up does not exist
+ * for them yet — so resolution there is provisional: unknown tokens are
+ * dropped and the node restyles when it attaches.
+ */
+export function resolveTokens(style, theme, where = 'style', strict = true) {
+  if (!theme) return stripTokens(style);
+  let byTheme = strict ? resolvedCache.get(style) : null;
+  if (strict && !byTheme) resolvedCache.set(style, (byTheme = new WeakMap()));
+  const hit = byTheme?.get(theme);
+  if (hit) return hit;
+
+  const out = {};
+  for (const key of Object.keys(style)) {
+    const v = style[key];
+    if (isToken(v)) {
+      const name = v.slice(1);
+      if (name in theme) {
+        out[key] = theme[name];
+        continue;
+      }
+      if (!strict) continue;
+      throw new Error(
+        `react-x11: unknown theme token "${v}" in ${where} ` +
+          `(theme has ${Object.keys(theme).join(', ') || 'nothing'})`,
+      );
+    } else if (key.charCodeAt(0) === 58 && v) {
+      out[key] = resolveTokens(v, theme, `${where} ${key}`, strict);
+    } else {
+      out[key] = v;
+    }
+  }
+  byTheme?.set(theme, out);
+  return out;
+}
+
 export { validateStyle };
 
 /**

--- a/test/style.test.js
+++ b/test/style.test.js
@@ -5,7 +5,7 @@ import { test } from 'node:test';
 import assert from 'node:assert';
 import React from 'react';
 import ReactX11 from '../src/index.js';
-import { createStyles, flattenStyle } from '../src/styles.js';
+import { createStyles, flattenStyle, resolveTokens } from '../src/styles.js';
 import { createMockApp, pressButton, moveMouse } from './helpers/mock-app.js';
 
 const h = React.createElement;
@@ -521,4 +521,206 @@ test('Switch: the thumb slides between the ends instead of snapping', async () =
   } finally {
     setAnimationClock(() => Date.now());
   }
+});
+
+// --- theme tokens ----------------------------------------------------------
+
+const THEME = {
+  panel: '#ffffff',
+  ink: '#2d3436',
+  gutter: 12,
+  accent: '#2980b9',
+};
+
+test('a hoisted style resolves $tokens against the nearest theme', async () => {
+  const app = createMockApp();
+  const s = createStyles({
+    card: { backgroundColor: '$panel', padding: '$gutter', flexGrow: 1 },
+  });
+  ReactX11.render(
+    h(
+      'window',
+      { width: 100, height: 100, theme: THEME },
+      h(
+        'box',
+        { style: s.card },
+        h('text', { style: { color: '$ink' } }, 'hi'),
+      ),
+    ),
+    null,
+    app,
+  );
+  await tick();
+
+  const box = nodeOf(app).children[0];
+  assert.strictEqual(box.style.backgroundColor, '#ffffff');
+  assert.strictEqual(box.style.padding, 12, 'tokens are not colour-only');
+  assert.strictEqual(box.children[0].style.color, '#2d3436');
+  assert.strictEqual(
+    box.abs.width,
+    100 - 0,
+    'the resolved padding reached yoga',
+  );
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('a nested theme merges over the outer one', async () => {
+  const app = createMockApp();
+  ReactX11.render(
+    h(
+      'window',
+      { width: 100, height: 100, theme: THEME },
+      h(
+        'box',
+        { theme: { panel: '#000000' }, style: { backgroundColor: '$panel' } },
+        h('text', { style: { color: '$ink' } }, 'hi'),
+      ),
+    ),
+    null,
+    app,
+  );
+  await tick();
+
+  const box = nodeOf(app).children[0];
+  assert.strictEqual(box.style.backgroundColor, '#000000', 'inner wins');
+  assert.strictEqual(
+    box.children[0].style.color,
+    '#2d3436',
+    'and the rest of the outer palette still applies',
+  );
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('changing the theme restyles the subtree', async () => {
+  const app = createMockApp();
+  const s = createStyles({ card: { backgroundColor: '$panel', flexGrow: 1 } });
+  const render = (theme) =>
+    ReactX11.render(
+      h(
+        'window',
+        { width: 100, height: 100, theme },
+        h(
+          'box',
+          { style: s.card },
+          h('text', { style: { color: '$ink' } }, 'x'),
+        ),
+      ),
+      null,
+      app,
+    );
+
+  render(THEME);
+  await tick();
+  const box = nodeOf(app).children[0];
+  assert.strictEqual(box.style.backgroundColor, '#ffffff');
+
+  render({ ...THEME, panel: '#1e272e', ink: '#f5f6fa' });
+  await tick();
+  assert.strictEqual(box.style.backgroundColor, '#1e272e');
+  assert.strictEqual(box.children[0].style.color, '#f5f6fa', 'deep nodes too');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('a popup inherits the theme of where it is written, not its window', async () => {
+  const app = createMockApp();
+  ReactX11.render(
+    h(
+      'window',
+      { width: 200, height: 200, theme: THEME },
+      h(
+        'box',
+        { theme: { panel: '#111111' } },
+        h(
+          'popup',
+          { x: 0, y: 0, width: 50, height: 50 },
+          h('box', { style: { backgroundColor: '$panel', flexGrow: 1 } }),
+        ),
+      ),
+    ),
+    null,
+    app,
+  );
+  await tick();
+
+  const popup = app.windows[1]._reactX11Node;
+  assert.strictEqual(
+    popup.children[0].style.backgroundColor,
+    '#111111',
+    'a menu follows the UI that opened it, across the window boundary',
+  );
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('an unknown token is an error naming what the theme has', async () => {
+  const app = createMockApp();
+  const errors = [];
+  const orig = console.error;
+  console.error = (...a) => errors.push(a.join(' '));
+  try {
+    ReactX11.render(
+      h(
+        'window',
+        { width: 100, height: 100, theme: THEME },
+        h('box', { style: { backgroundColor: '$pannel' } }),
+      ),
+      null,
+      app,
+    );
+    await tick();
+  } finally {
+    console.error = orig;
+  }
+  assert.match(errors.join('\n'), /unknown theme token "\$pannel"/);
+  assert.match(errors.join('\n'), /theme has panel, ink, gutter, accent/);
+});
+
+test('tokens keep the identity fast path: same style, same theme, same object', () => {
+  const s = createStyles({ card: { backgroundColor: '$panel' } });
+  const a = resolveTokens(s.card, THEME);
+  const b = resolveTokens(s.card, THEME);
+  assert.strictEqual(a, b, 'resolution is cached per (style, theme)');
+  assert.notStrictEqual(a, resolveTokens(s.card, { ...THEME }));
+});
+
+test('a token change invalidates cached text, not just the style object', async () => {
+  const app = createMockApp();
+  const s = createStyles({ title: { fontSize: 20, color: '$ink' } });
+  const render = (theme) =>
+    ReactX11.render(
+      h(
+        'window',
+        { width: 200, height: 80, theme },
+        h(
+          'box',
+          { style: { flexGrow: 1 } },
+          h('text', { style: s.title }, 'Dashboard'),
+        ),
+      ),
+      null,
+      app,
+    );
+
+  render(THEME);
+  await tick();
+  const text = nodeOf(app).children[0].children[0];
+  text._layouts.set('stale', { width: 1, height: 1 });
+
+  // the <text> element's own props do not change — only the theme above it —
+  // so nothing re-renders it and the cached layout would otherwise survive
+  // with the old colour baked in
+  render({ ...THEME, ink: '#ffffff' });
+  await tick();
+
+  assert.strictEqual(text.style.color, '#ffffff');
+  assert.strictEqual(
+    text._layouts.size,
+    0,
+    'the memoised text layout was dropped, so the repaint uses the new colour',
+  );
+
+  ReactX11.unmountComponentAtNode(app);
 });


### PR DESCRIPTION
A style value of `'$name'` resolves against the nearest `theme` prop above the node. The sigil keeps it unambiguous: `'red'` is a CSS colour, `'$red'` is a token.

```jsx
const s = createStyles({
  card: { backgroundColor: '$panel', padding: '$gutter' },
  title: { color: '$text', fontSize: 20 },
});

<window theme={palette} style={{ backgroundColor: '$bg' }}>
  <box style={s.card}>…</box>
</window>
```

## Why

Hoisting. A style declared once outside render has no access to React context, so following the palette meant threading it to every element that paints — `style={[s.card, { backgroundColor: theme.panel }]}` at every single site. That is noise the style channel introduced and this removes. In `examples/dashboard.jsx` the `StatCard` body goes from three styles-plus-overrides to three bare style references.

Tokens are not colour-only: `padding: '$gutter'` resolves a number just as well.

## Scoping

A `theme` prop anywhere scopes its subtree, and an inner one merges over the outer, so a panel can restate a colour or two without repeating a palette. **Popups resolve through their place in the tree, not their window** — a menu inherits the theme of the UI that opened it even though it is a separate X window. Widgets plant their merged palette on their own root, so tokens work inside a widget subtree, and in a style you pass one, even when the app only used `<ThemeProvider>`.

Resolution is cached per (style object, theme object), so a hoisted style under one theme keeps its identity and the `===` fast path in `applyProps` still applies.

Before a node is attached it can see only part of its ancestry — the theme two levels up does not exist for it yet — so resolution there is provisional: unknown tokens are dropped and the node restyles on attach. Once attached, an unknown token is an error naming what the theme does have.

## Two bugs this turned up

**`useTheme` returned a fresh merged object every render.** Harmless while it only fed JS; wrong now that identity decides whether a whole subtree re-resolves. Memoised on the context value.

**A theme change reaches a node without React re-rendering it**, so the invalidation `TextNode.applyProps` does never ran, and memoised text layouts kept painting the old colour. This is the one worth reviewing: it showed up as the dashboard screenshot going *dim* on the dark theme — the title painting in the light palette's ink on a dark background — and it would have been easy to wave through as antialiasing noise. Now pinned by a test that mutates the layout cache and asserts a token change drops it.

## Verification

`npm test` 136 passing (7 new), `npm run lint` clean. The dashboard screenshot regenerates to within 5 pixels of the committed one — all in the columns holding the live clock and heap figure — so the conversion is visually a no-op. Two runs of the same code differ by ~555 px in those same columns, which is the baseline noise this sits under.

Next, and last on the list: window size queries.