### PR TITLE
fix: scrollbars can be dragged with the pointer

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -84,8 +84,10 @@ merged theme (`ThemeProvider`; `SelectThemeProvider` is an alias) and a
 - **Pointer capture for userland** — DONE: `ev.capturePointer()` /
   `ev.releasePointer()` route move/up to the capturing node, released on
   mouseup and on unmount; hover freezes during a capture
-- **Multi-line `<textarea>`** — DONE (#32). Polish left: Ctrl+arrow word
-  movement, PageUp/Down, Shift+click extend, drawn scrollbar
+- **Multi-line `<textarea>`** — DONE (#32), and the polish that was listed
+  here after it (Ctrl+arrow word movement, PageUp/Down, Shift+click extend,
+  the drawn scrollbar) has since landed too. The scrollbar is draggable in
+  both `<textarea>` and `<scrollview>`
 - **Bidi caret polish** — caret positions are bidi-correct now (ntk
   caret API), but arrow keys still move logically; visual-order movement
   - split caret at direction boundaries is a later refinement

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -179,7 +179,15 @@ window, valid after layout).
 ## `<scrollview>`
 
 A clipped viewport over its (overflowing) children. Wheel events scroll it
-by default; a scrollbar thumb is drawn when content overflows.
+by default; a scrollbar thumb is drawn when content overflows, and the thumb
+can be dragged.
+
+The bar belongs to the scroller, not to the content painted under it — the
+same rule a browser applies — so a press on the thumb never reaches the row
+behind it. Dragging keeps the grip where it was taken, so the thumb does not
+jump to the pointer, and a press on the track pages towards it, like
+PageUp/PageDown. `<textarea>` behaves the same way, and there a bar press
+never moves the caret.
 
 With `flexGrow` and no explicit size it defaults to **`flex-basis: 0`** —
 what CSS's `flex: 1` means — so it takes the space left over instead of

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -907,6 +907,67 @@ export class ImageNode extends Node {
   }
 }
 
+const SCROLLBAR_WIDTH = 6;
+const SCROLLBAR_MIN_THUMB = 20;
+// the visible bar is thin; the pointer target is not
+const SCROLLBAR_SLOP = 4;
+
+/**
+ * Geometry of a vertical scrollbar, or null when there is nothing to
+ * scroll. Shared by `<scrollview>` and `<textarea>` so what is painted and
+ * what the pointer hits cannot drift apart.
+ */
+function scrollbarGeometry({
+  x,
+  y,
+  width,
+  height,
+  scroll,
+  content,
+  inset = 0,
+}) {
+  if (height <= 0 || !(content > height)) return null;
+  const thumbHeight = Math.max(
+    SCROLLBAR_MIN_THUMB,
+    (height * height) / content,
+  );
+  const range = content - height;
+  const travel = height - thumbHeight;
+  return {
+    x: x + width - SCROLLBAR_WIDTH - inset,
+    width: SCROLLBAR_WIDTH,
+    trackY: y,
+    trackHeight: height,
+    thumbY: y + (range > 0 ? (scroll / range) * travel : 0),
+    thumbHeight,
+    range,
+    travel,
+  };
+}
+
+/** Is this point on the bar (with slop), and if so, on the thumb? */
+function scrollbarHit(bar, x, y) {
+  if (!bar) return null;
+  if (x < bar.x - SCROLLBAR_SLOP || x > bar.x + bar.width + SCROLLBAR_SLOP) {
+    return null;
+  }
+  if (y < bar.trackY || y > bar.trackY + bar.trackHeight) return null;
+  return y >= bar.thumbY && y <= bar.thumbY + bar.thumbHeight
+    ? 'thumb'
+    : 'track';
+}
+
+function paintScrollbarThumb(ctx, bar, color) {
+  ctx.fillStyle = color || 'rgba(0, 0, 0, 0.25)';
+  ctx.beginPath();
+  if (typeof ctx.roundRect === 'function') {
+    ctx.roundRect(bar.x, bar.thumbY, bar.width, bar.thumbHeight, 3);
+  } else {
+    ctx.rect(bar.x, bar.thumbY, bar.width, bar.thumbHeight);
+  }
+  ctx.fill();
+}
+
 /**
  * <scrollview>: a clipped viewport over its (overflowing) children. The
  * scroll offset is applied during absolutize, so painting and hit testing
@@ -1034,30 +1095,60 @@ export class ScrollViewNode extends Node {
 
   paint(ctx) {
     super.paint(ctx);
-    this._paintScrollbar(ctx);
+    const bar = this._scrollbar();
+    if (bar) {
+      paintScrollbarThumb(ctx, bar, this.props.scrollbarColor);
+    }
   }
 
-  _paintScrollbar(ctx) {
-    if (this.props.scrollbar === false) return;
-    const viewport = this.abs.height;
-    if (!(this.contentHeight > viewport)) return;
-    const trackWidth = 6;
-    const thumbHeight = Math.max(
-      20,
-      (viewport * viewport) / this.contentHeight,
-    );
-    const range = this.contentHeight - viewport;
-    const thumbY =
-      this.abs.y + (this.scrollY / range) * (viewport - thumbHeight);
-    const thumbX = this.abs.x + this.abs.width - trackWidth - 2;
-    ctx.fillStyle = this.props.scrollbarColor || 'rgba(0, 0, 0, 0.25)';
-    ctx.beginPath();
-    if (typeof ctx.roundRect === 'function') {
-      ctx.roundRect(thumbX, thumbY, trackWidth, thumbHeight, 3);
-    } else {
-      ctx.rect(thumbX, thumbY, trackWidth, thumbHeight);
+  /** null when the bar is switched off or there is nothing to scroll. */
+  _scrollbar() {
+    if (this.props.scrollbar === false) return null;
+    return scrollbarGeometry({
+      x: this.abs.x,
+      y: this.abs.y,
+      width: this.abs.width,
+      height: this.abs.height,
+      scroll: this.scrollY,
+      content: this.contentHeight,
+      inset: 2,
+    });
+  }
+
+  /**
+   * The bar belongs to the scroller, not to the content under it — the same
+   * rule a browser applies. Without this a press on the thumb would be
+   * delivered to whatever child happens to be painted beneath it.
+   */
+  hitTest(x, y) {
+    if (scrollbarHit(this._scrollbar(), x, y)) return this;
+    return super.hitTest(x, y);
+  }
+
+  _defaultMouseDown(ev) {
+    const bar = this._scrollbar();
+    const hit = scrollbarHit(bar, ev.x, ev.y);
+    if (!hit) return;
+    if (hit === 'thumb') {
+      // remember where in the thumb it was grabbed, so it does not jump
+      this._barGrab = ev.y - bar.thumbY;
+      ev.capturePointer();
+      return;
     }
-    ctx.fill();
+    // a press on the track pages towards it, like PageUp/PageDown
+    this.scrollBy(ev.y < bar.thumbY ? -this.abs.height : this.abs.height);
+  }
+
+  _defaultMouseDrag(ev) {
+    if (this._barGrab == null) return;
+    const bar = this._scrollbar();
+    if (!bar || bar.travel <= 0) return;
+    const top = ev.y - this._barGrab - bar.trackY;
+    this.scrollTo((top / bar.travel) * bar.range);
+  }
+
+  _defaultMouseUp() {
+    this._barGrab = null;
   }
 }
 
@@ -1565,6 +1656,49 @@ export class TextInputNode extends Node {
  * caret (wheel scrolls too). `rows` (default 3) sets the preferred height.
  */
 export class TextAreaNode extends TextInputNode {
+  /**
+   * The bar takes the press before the caret does — otherwise grabbing the
+   * thumb would drop the caret into whatever text sits behind it and start
+   * a selection drag.
+   */
+  _defaultMouseDown(ev) {
+    const bar = this._scrollbar();
+    const hit = scrollbarHit(bar, ev.x, ev.y);
+    if (!hit) return super._defaultMouseDown(ev);
+    if (hit === 'thumb') {
+      this._barGrab = ev.y - bar.thumbY;
+      ev.capturePointer();
+      return;
+    }
+    const page = this.contentBox().height;
+    this._scrollTo(this._scrollY + (ev.y < bar.thumbY ? -page : page), bar);
+  }
+
+  _defaultMouseDrag(ev) {
+    if (this._barGrab == null) return super._defaultMouseDrag(ev);
+    const bar = this._scrollbar();
+    if (!bar || bar.travel <= 0) return;
+    this._scrollTo(
+      ((ev.y - this._barGrab - bar.trackY) / bar.travel) * bar.range,
+      bar,
+    );
+  }
+
+  _defaultMouseUp(ev) {
+    if (this._barGrab != null) {
+      this._barGrab = null;
+      return;
+    }
+    super._defaultMouseUp(ev);
+  }
+
+  _scrollTo(y, bar) {
+    const next = Math.min(Math.max(0, y), bar.range);
+    if (next === this._scrollY) return;
+    this._scrollY = next;
+    this.root?.invalidate(false);
+  }
+
   constructor(props, app) {
     super(props, app, 'textarea');
     this._scrollY = 0;
@@ -1712,25 +1846,21 @@ export class TextAreaNode extends TextInputNode {
 
   /** Thumb for the vertical overflow, same look as <scrollview>'s. */
   _paintScrollbar(ctx, layout) {
-    if (this.props.scrollbar === false) return;
+    const bar = this._scrollbar(layout);
+    if (bar) paintScrollbarThumb(ctx, bar, this.props.scrollbarColor);
+  }
+
+  _scrollbar(layout = this._valueLayout()) {
+    if (this.props.scrollbar === false || !layout) return null;
     const content = this.contentBox();
-    const viewport = content.height;
-    const total = layout.height;
-    if (!(total > viewport)) return;
-    const trackWidth = 6;
-    const thumbHeight = Math.max(20, (viewport * viewport) / total);
-    const range = total - viewport;
-    const thumbY =
-      content.y + (this._scrollY / range) * (viewport - thumbHeight);
-    const thumbX = content.x + content.width - trackWidth;
-    ctx.fillStyle = this.props.scrollbarColor || 'rgba(0, 0, 0, 0.25)';
-    ctx.beginPath();
-    if (typeof ctx.roundRect === 'function') {
-      ctx.roundRect(thumbX, thumbY, trackWidth, thumbHeight, 3);
-    } else {
-      ctx.rect(thumbX, thumbY, trackWidth, thumbHeight);
-    }
-    ctx.fill();
+    return scrollbarGeometry({
+      x: content.x,
+      y: content.y,
+      width: content.width,
+      height: content.height,
+      scroll: this._scrollY,
+      content: layout.height,
+    });
   }
 
   _paintContent(ctx) {

--- a/test/scrollbar.test.js
+++ b/test/scrollbar.test.js
@@ -1,0 +1,203 @@
+// Dragging the scrollbar with the pointer: the thumb follows the pointer,
+// the track pages, and the bar belongs to the scroller rather than to the
+// content painted under it.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import ReactX11 from '../src/index.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+// 10 rows of 40 in a 100-tall viewport: 400 of content, 300 of scroll range
+function mount() {
+  const app = createMockApp();
+  const ref = React.createRef();
+  ReactX11.render(
+    h(
+      'window',
+      { width: 200, height: 100 },
+      h(
+        'scrollview',
+        { ref, style: { flexGrow: 1 } },
+        ...Array.from({ length: 10 }, (_, i) =>
+          h('box', { key: i, style: { height: 40, flexShrink: 0 } }),
+        ),
+      ),
+    ),
+    null,
+    app,
+  );
+  return { app, wnd: app.windows[0] };
+}
+
+const scroller = (app) => app.windows[0]._reactX11Node.children[0];
+
+const drag = (wnd, from, to) => {
+  wnd.emit('mousedown', { x: from.x, y: from.y, keycode: 1 });
+  wnd.emit('mousemove', { x: to.x, y: to.y });
+  wnd.emit('mouseup', { x: to.x, y: to.y, keycode: 1 });
+};
+
+test('dragging the thumb scrolls in proportion to the pointer', async () => {
+  const { app, wnd } = mount();
+  await tick();
+  const sv = scroller(app);
+  const bar = sv._scrollbar();
+  assert.ok(bar, 'the bar shows when the content overflows');
+  assert.strictEqual(sv.scrollY, 0);
+
+  // grab the middle of the thumb and take it half way down the travel
+  wnd.emit('mousedown', {
+    x: bar.x + 2,
+    y: bar.thumbY + bar.thumbHeight / 2,
+    keycode: 1,
+  });
+  wnd.emit('mousemove', {
+    x: bar.x + 2,
+    y: bar.thumbY + bar.thumbHeight / 2 + bar.travel / 2,
+  });
+  assert.ok(
+    Math.abs(sv.scrollY - bar.range / 2) < 1,
+    `half the travel should be half the range, got ${sv.scrollY}`,
+  );
+
+  // and past the end clamps rather than overscrolling
+  wnd.emit('mousemove', { x: bar.x + 2, y: 10_000 });
+  assert.strictEqual(sv.scrollY, bar.range);
+
+  wnd.emit('mouseup', { x: bar.x + 2, y: 10_000, keycode: 1 });
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('the drag keeps its grip on the thumb, without jumping', async () => {
+  const { app, wnd } = mount();
+  await tick();
+  const sv = scroller(app);
+  const bar = sv._scrollbar();
+
+  // press near the *bottom* of the thumb and do not move: nothing should
+  // happen — a jump-to-pointer implementation would scroll here
+  wnd.emit('mousedown', {
+    x: bar.x + 2,
+    y: bar.thumbY + bar.thumbHeight - 1,
+    keycode: 1,
+  });
+  assert.strictEqual(sv.scrollY, 0, 'grabbing the thumb does not move it');
+  wnd.emit('mouseup', { x: bar.x + 2, y: bar.thumbY, keycode: 1 });
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('a press on the track pages towards the pointer', async () => {
+  const { app, wnd } = mount();
+  await tick();
+  const sv = scroller(app);
+  const bar = sv._scrollbar();
+
+  wnd.emit('mousedown', {
+    x: bar.x + 2,
+    y: bar.trackY + bar.trackHeight - 2,
+    keycode: 1,
+  });
+  assert.strictEqual(sv.scrollY, 100, 'one viewport down');
+  wnd.emit('mouseup', { x: bar.x + 2, y: bar.trackY, keycode: 1 });
+
+  wnd.emit('mousedown', { x: bar.x + 2, y: bar.trackY + 1, keycode: 1 });
+  assert.strictEqual(sv.scrollY, 0, 'and back up again');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('the bar takes the press even with content painted under it', async () => {
+  const app = createMockApp();
+  const clicks = [];
+  ReactX11.render(
+    h(
+      'window',
+      { width: 200, height: 100 },
+      h(
+        'scrollview',
+        { style: { flexGrow: 1 } },
+        ...Array.from({ length: 10 }, (_, i) =>
+          h('box', {
+            key: i,
+            style: { height: 40, flexShrink: 0 },
+            onClick: () => clicks.push(i),
+          }),
+        ),
+      ),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const sv = scroller(app);
+  const bar = sv._scrollbar();
+
+  drag(
+    app.windows[0],
+    { x: bar.x + 2, y: bar.thumbY + 2 },
+    { x: bar.x + 2, y: bar.thumbY + 2 },
+  );
+  assert.deepStrictEqual(clicks, [], 'the row under the bar was not clicked');
+
+  // a press just inside the content does still reach the row
+  drag(app.windows[0], { x: 10, y: 10 }, { x: 10, y: 10 });
+  assert.deepStrictEqual(clicks, [0]);
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('a <textarea> bar drag scrolls it, and never moves the caret', async () => {
+  const app = createMockApp();
+  ReactX11.render(
+    h(
+      'window',
+      { width: 200, height: 80 },
+      h('textarea', { value: 'many lines', style: { flexGrow: 1 } }),
+    ),
+    null,
+    app,
+  );
+  await tick();
+
+  const area = app.windows[0]._reactX11Node.children[0];
+  // the mock has no font metrics, so stand in for the laid-out text: all
+  // the bar needs from it is a height
+  area._valueLayout = () => ({ height: 600 });
+
+  const bar = area._scrollbar();
+  assert.ok(bar, 'text taller than the box gets a thumb');
+  const caretBefore = area._caret;
+
+  area._defaultMouseDown({
+    x: bar.x + 2,
+    y: bar.thumbY + 2,
+    capturePointer() {},
+  });
+  area._defaultMouseDrag({ x: bar.x + 2, y: bar.thumbY + 2 + bar.travel / 2 });
+  assert.strictEqual(area._caret, caretBefore, 'the caret stayed put');
+  assert.ok(
+    Math.abs(area._scrollY - bar.range / 2) < 1,
+    `half the travel is half the range, got ${area._scrollY}`,
+  );
+
+  area._defaultMouseDrag({ x: bar.x + 2, y: 10_000 });
+  assert.strictEqual(area._scrollY, bar.range, 'and clamps at the end');
+  area._defaultMouseUp({});
+
+  // a press in the text still reaches the caret logic
+  area._scrollY = 0;
+  const content = area.contentBox();
+  let placed = false;
+  area._indexAtPoint = () => {
+    placed = true;
+    return 3;
+  };
+  area._defaultMouseDown({ x: content.x + 5, y: content.y + 5, detail: 1 });
+  assert.ok(placed, 'a press away from the bar still places the caret');
+
+  ReactX11.unmountComponentAtNode(app);
+});


### PR DESCRIPTION
The thumb was painted but inert — the only way to scroll was the wheel, or the keyboard in a `<textarea>`.

## Three things were needed

**One geometry, shared.** The bar's rect now comes from a single helper used by both painting and hit testing, so what is drawn and what the pointer can grab cannot drift apart.

**The bar belongs to the scroller, not the content.** `<scrollview>` overrides `hitTest`, so a press on the thumb targets the scroller rather than whatever child happens to be painted beneath it — the rule a browser applies. Without it the press went to the row behind the thumb, which is also why this was not simply a missing handler.

**The drag keeps its grip.** It remembers where in the thumb the press landed, so the thumb does not jump to the pointer. There is a test for that specifically: press near the bottom edge of the thumb and move nothing, and nothing scrolls — a jump-to-pointer implementation fails it.

Beyond that: a press on the track pages towards the pointer, matching PageUp/PageDown; the pointer is captured for the drag, so wandering outside the widget keeps scrolling; and the hit target is widened past the six painted pixels.

`<textarea>` gets the same treatment and takes the press *before* its caret logic — otherwise grabbing the thumb dropped the caret into the text behind it and started a selection drag.

## Tests

Six new, in `test/scrollbar.test.js`: proportional drag, clamping at both ends, the grip not jumping, track paging in both directions, a press on the bar not reaching the content under it, and the textarea drag leaving the caret alone while a press in the text still places it.

The textarea case stubs the laid-out text height rather than running against the in-process X server. I tried it end-to-end first: the frame the scroll schedules is delivered by ntk's frame clock *after* the connection closes, which fails the test from outside it with `client is in closing state`. That is a harness race rather than a product bug, and the routing it would have added is already covered by the mock-based tests above it.

`npm test` 141 passing, `npm run lint` clean.
