### PR TITLE
feat: window size queries — '@width >= 600' style blocks

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -128,7 +128,9 @@ instead of a silent no-op. `transition` animates numbers and colours off the
 window's frame clock, starting from what is on screen so an interrupted
 transition reverses. `$token` style values resolve against the nearest
 `theme` prop, so a hoisted style can follow the palette with no React
-context. See [docs/styling.md](docs/styling.md). Left: window size queries.
+context, and `'@width >= 600'` blocks restyle for the window's size —
+layout included, since they only re-run inside a layout pass a resize
+already required. See [docs/styling.md](docs/styling.md).
 
 ### 4. Ecosystem / DX
 

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -49,6 +49,8 @@ Numbers are pixels, strings like `'50%'` / `'auto'` pass through to yoga.
   change to that property takes ([styling.md](styling.md#transitions))
 - any value may be a **theme token**: `'$panel'` resolves against the nearest
   `theme` prop above the node ([styling.md](styling.md#theme-tokens))
+- `'@width >= 600'` blocks restyle for the window's size, layout included
+  ([styling.md](styling.md#window-size-queries))
 - `opacity` is not implemented yet (see NEXT_STEPS.md)
 
 `cursor` (`'pointer'`, `'text'`, `'wait'`, `'move'`, `'crosshair'`, resize

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -188,6 +188,35 @@ pays a layout pass per frame for it. `Switch` is the worked example — the
 thumb is absolutely positioned and slides on `left`, because
 `justifyContent` would flip between the ends with nothing in between.
 
+## Window size queries
+
+`'@width >= 600'` and friends are the X11 analogue of `@media`: what a style
+can usefully ask about here is the window it is laid out in, not the screen.
+
+```jsx
+const s = createStyles({
+  bar: {
+    flexDirection: 'column',
+    gap: 4,
+    '@width >= 600': { flexDirection: 'row', gap: 16 },
+  },
+});
+```
+
+`width` and `height`, with `>=`, `<=`, `>` or `<`. Blocks that match are
+merged in declaration order, before state blocks — so a `:hover` inside the
+wide layout still wins over the wide layout.
+
+**A size query may set layout properties, unlike a state block.** That is
+not an inconsistency: a pointer state must never reflow the tree, but a size
+query is only ever re-evaluated inside a layout pass that a resize has
+already required, so it costs nothing extra. Nodes that declare one are
+registered with their window and re-resolved just before it lays out, and
+only when the size actually changed.
+
+A malformed query is an error rather than a key that silently never
+matches.
+
 ## Decided
 
 - **`':hover'`, not `_hover`.** The CSS spelling costs a pair of quotes and
@@ -203,6 +232,5 @@ way it does not apply to an `<input type>` in the DOM. They report
 
 ## Next
 
-Window size queries — the X11 analogue of `@media`, and layout-capable,
-since they are only re-evaluated during a layout pass that a resize already
-triggers.
+`opacity` (needs offscreen composition — see NEXT_STEPS §3), and per-node
+container queries if the window-level ones prove too coarse.

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -21,6 +21,8 @@ import {
   isLayoutProp,
   styleUsesTokens,
   resolveTokens,
+  styleHasSizeQueries,
+  resolveSizeQueries,
 } from './styles.js';
 import { EventManager } from './events.js';
 import { runWithPriority, DiscreteEventPriority } from './priority.js';
@@ -195,6 +197,23 @@ export class Node {
     // `disabled` is a prop, not something the pointer does, so it is read
     // straight off props rather than driven by the event manager
     this.states[':disabled'] = Boolean(props.disabled);
+    // window size queries fold into the base before state blocks, so a
+    // `:hover` inside the wide layout still wins over the wide layout
+    const queried = styleHasSizeQueries(this._baseStyle);
+    if (queried !== this._queried) {
+      this._queried = queried;
+      const root = this.root;
+      if (root?._sizeQueryNodes) {
+        if (queried) root._sizeQueryNodes.add(this);
+        else root._sizeQueryNodes.delete(this);
+      }
+    }
+    if (queried) {
+      this._baseStyle = resolveSizeQueries(
+        this._baseStyle,
+        this.root?.querySize ?? null,
+      );
+    }
     this._stateful = hasStateStyles(this._baseStyle);
     return this._retarget(
       this._stateful
@@ -288,6 +307,19 @@ export class Node {
     return this.kind === 'window';
   }
 
+  /** Join the owning window's size-query registry, and take the current
+   * size into account — a node mounted after a resize has to match against
+   * the size the window is now, not the one it started at. */
+  _registerSizeQueries() {
+    if (this._queried && this.root?._sizeQueryNodes) {
+      this.root._sizeQueryNodes.add(this);
+      if (this.root.querySize) this._sizeQueriesChanged();
+    }
+    for (const child of this.children) {
+      if (!child.isWindow) child._registerSizeQueries();
+    }
+  }
+
   /** Style names this element claims as its own semantics (see WindowNode). */
   get semanticNames() {
     return NO_SEMANTIC_NAMES;
@@ -310,6 +342,18 @@ export class Node {
         : own
       : (inherited ?? null);
     return this._theme;
+  }
+
+  /** The owning window resized: re-resolve, since a query block may now
+   * match that did not, or the other way round. */
+  _sizeQueriesChanged() {
+    if (!this._queried || this.destroyed) return;
+    const before = this.style;
+    this._syncStyle(this.props);
+    if (textStyleChanged(this.style, before)) this._textContentChanged();
+    if (this.yoga && this.style !== before) {
+      applyLayoutStyle(this.yoga, this.style, before);
+    }
   }
 
   /** The theme above or on this node changed: drop the caches and restyle
@@ -398,6 +442,7 @@ export class Node {
       this.yoga.insertChild(child.yoga, this._yogaIndexAt(index));
     }
     child._setRoot(this.root);
+    child._registerSizeQueries();
     // it can see its ancestors now, so any token in its style can resolve.
     // With no theme anywhere there is nothing to resolve and nothing to walk
     if (this.theme || child.props.theme) child._themeChanged();
@@ -1818,6 +1863,10 @@ export class WindowNode extends Node {
     // frame is being rendered for
     this._animating = new Set();
     this.frameTime = 0;
+    // nodes with `@width`/`@height` blocks, and the size they last matched
+    // against
+    this._sizeQueryNodes = new Set();
+    this.querySize = null;
   }
 
   /** Create the real X11 window (commit phase only). Children windows are
@@ -2118,6 +2167,27 @@ export class WindowNode extends Node {
     );
   }
 
+  /**
+   * Re-evaluate the size-query blocks for this window's current size, just
+   * before laying out. This is the whole reason a size query may carry
+   * layout properties while a state block may not: it only ever runs inside
+   * a layout pass the resize already required.
+   */
+  _resolveSizeQueries(width, height) {
+    if (this._sizeQueryNodes.size === 0) {
+      this.querySize = this.querySize ?? { width, height };
+      return;
+    }
+    if (this.querySize?.width === width && this.querySize?.height === height) {
+      return;
+    }
+    this.querySize = { width, height };
+    for (const node of [...this._sizeQueryNodes]) {
+      if (node.destroyed) this._sizeQueryNodes.delete(node);
+      else node._sizeQueriesChanged();
+    }
+  }
+
   /** A node in this window started a transition. */
   _startAnimating(node) {
     this._animating.add(node);
@@ -2167,6 +2237,7 @@ export class WindowNode extends Node {
     const width = this.window.width ?? this.props.width ?? 0;
     const height = this.window.height ?? this.props.height ?? 0;
     if (this.needsLayout) {
+      this._resolveSizeQueries(width, height);
       this.yoga.setWidth(width);
       this.yoga.setHeight(height);
       this.yoga.calculateLayout(width, height, Yoga.DIRECTION_LTR);

--- a/src/styles.js
+++ b/src/styles.js
@@ -178,8 +178,77 @@ export const isStyleProp = (name) => STYLE_PROPS.has(name);
 
 const isState = (key) => key.charCodeAt(0) === 58; /* ':' */
 
+/**
+ * Window size queries: `'@width >= 600'`. The X11 analogue of `@media` —
+ * what a style can usefully ask about here is the window it is being laid
+ * out in, not the screen.
+ *
+ * Unlike a state block, a size query *may* set layout properties. That is
+ * not an inconsistency: pointer state changes must never reflow the tree,
+ * but a size query is only ever re-evaluated during a layout pass that a
+ * resize has already triggered, so it costs nothing extra.
+ */
+const SIZE_QUERY = /^@(width|height)\s*(>=|<=|>|<)\s*(\d+(?:\.\d+)?)$/;
+const isSizeQuery = (key) => key.charCodeAt(0) === 64; /* '@' */
+
+const parsedQueries = new Map();
+function parseSizeQuery(key) {
+  let q = parsedQueries.get(key);
+  if (q === undefined) {
+    const m = SIZE_QUERY.exec(key);
+    q = m ? { axis: m[1], op: m[2], value: Number(m[3]) } : null;
+    parsedQueries.set(key, q);
+  }
+  return q;
+}
+
+function queryMatches(q, size) {
+  const v = size[q.axis];
+  if (v == null) return false;
+  return q.op === '>='
+    ? v >= q.value
+    : q.op === '<='
+      ? v <= q.value
+      : q.op === '>'
+        ? v > q.value
+        : v < q.value;
+}
+
+export function styleHasSizeQueries(style) {
+  for (const key of Object.keys(style)) if (isSizeQuery(key)) return true;
+  return false;
+}
+
+/**
+ * Merge the size-query blocks that match `size`, in declaration order, over
+ * the base. Returns the style itself when nothing matches, so the identity
+ * fast path survives the common case.
+ */
+export function resolveSizeQueries(style, size) {
+  if (!size) return style;
+  let out = style;
+  for (const key of Object.keys(style)) {
+    if (!isSizeQuery(key)) continue;
+    const q = parseSizeQuery(key);
+    if (!q || !queryMatches(q, size)) continue;
+    if (out === style) out = { ...style };
+    Object.assign(out, style[key]);
+  }
+  return out;
+}
+
 function validateStyle(style, where) {
   for (const key of Object.keys(style)) {
+    if (isSizeQuery(key)) {
+      if (!parseSizeQuery(key)) {
+        throw new Error(
+          `react-x11: bad size query "${key}" in ${where} ` +
+            '(expected e.g. "@width >= 600" on width or height)',
+        );
+      }
+      validateStyle(style[key] ?? {}, `${where} ${key}`);
+      continue;
+    }
     if (isState(key)) {
       if (!STATE_KEYS.includes(key)) {
         throw new Error(

--- a/test/size-queries.test.js
+++ b/test/size-queries.test.js
@@ -1,0 +1,171 @@
+// Window size queries: the X11 analogue of @media. What a style can usefully
+// ask about here is the window it is laid out in, not the screen.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import ReactX11 from '../src/index.js';
+import { createStyles } from '../src/styles.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+const nodeOf = (app) => app.windows[0]._reactX11Node;
+
+const responsive = createStyles({
+  bar: {
+    flexDirection: 'column',
+    gap: 4,
+    '@width >= 600': { flexDirection: 'row', gap: 16 },
+  },
+});
+
+function mount(width) {
+  const app = createMockApp();
+  ReactX11.render(
+    h(
+      'window',
+      { width, height: 300 },
+      h(
+        'box',
+        { style: responsive.bar },
+        h('box', { key: 'a', style: { width: 10, height: 10 } }),
+        h('box', { key: 'b', style: { width: 10, height: 10 } }),
+      ),
+    ),
+    null,
+    app,
+  );
+  return app;
+}
+
+test('a size query matches against the window it is laid out in', async () => {
+  const narrow = mount(400);
+  await tick();
+  assert.strictEqual(nodeOf(narrow).children[0].style.flexDirection, 'column');
+  assert.strictEqual(nodeOf(narrow).children[0].style.gap, 4);
+  ReactX11.unmountComponentAtNode(narrow);
+
+  const wide = mount(800);
+  await tick();
+  assert.strictEqual(nodeOf(wide).children[0].style.flexDirection, 'row');
+  assert.strictEqual(nodeOf(wide).children[0].style.gap, 16);
+  ReactX11.unmountComponentAtNode(wide);
+});
+
+test('resizing the window re-evaluates, and relays out', async () => {
+  const app = mount(400);
+  await tick();
+  const box = nodeOf(app).children[0];
+  assert.strictEqual(box.style.flexDirection, 'column');
+
+  // what a real ConfigureNotify does
+  const wnd = app.windows[0];
+  wnd.width = 800;
+  wnd.emit('resize', { width: 800, height: 300 });
+  await tick();
+
+  assert.strictEqual(box.style.flexDirection, 'row', 'the query now matches');
+  assert.strictEqual(box.style.gap, 16);
+  // and the change reached yoga, not just the style bag: side by side with
+  // the wide gap, rather than stacked with the narrow one
+  const [a, b] = box.children;
+  assert.strictEqual(a.abs.y, b.abs.y, 'the two boxes share a row');
+  assert.strictEqual(b.abs.x - a.abs.x, 26, '10 wide plus the 16 gap');
+
+  wnd.width = 400;
+  wnd.emit('resize', { width: 400, height: 300 });
+  await tick();
+  assert.strictEqual(box.style.flexDirection, 'column', 'and back again');
+  assert.strictEqual(
+    box.children[1].abs.y - box.children[0].abs.y,
+    14,
+    'stacked again, with the narrow gap',
+  );
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('size queries may carry layout properties, unlike state blocks', () => {
+  // the rule: a pointer state must never reflow the tree, but a size query
+  // is only re-evaluated inside a layout pass the resize already required
+  createStyles({ a: { '@width >= 600': { padding: 20, flexGrow: 2 } } });
+  assert.throws(
+    () => createStyles({ b: { ':hover': { padding: 20 } } }),
+    /not allowed inside ":hover"/,
+  );
+});
+
+test('a bad query is an error that shows the shape', () => {
+  assert.throws(
+    () => createStyles({ a: { '@width => 600': {} } }),
+    /bad size query "@width => 600"/,
+  );
+  assert.throws(
+    () => createStyles({ a: { '@depth >= 600': {} } }),
+    /bad size query/,
+  );
+});
+
+test('a state block inside the matched size still wins', async () => {
+  const app = createMockApp();
+  ReactX11.render(
+    h(
+      'window',
+      { width: 800, height: 300 },
+      h('box', {
+        style: {
+          backgroundColor: 'white',
+          '@width >= 600': { backgroundColor: 'grey' },
+          ':hover': { backgroundColor: 'red' },
+        },
+        focusable: true,
+      }),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const box = nodeOf(app).children[0];
+  assert.strictEqual(box.style.backgroundColor, 'grey');
+
+  box.setStyleState(':hover', true);
+  assert.strictEqual(
+    box.style.backgroundColor,
+    'red',
+    'state blocks fold in after the size, so hover wins',
+  );
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('a node mounted after a resize matches the size the window is now', async () => {
+  const app = createMockApp();
+  const render = (extra) =>
+    ReactX11.render(
+      h(
+        'window',
+        { width: 800, height: 300 },
+        h(
+          'box',
+          { style: { flexGrow: 1 } },
+          ...(extra ? [h('box', { style: responsive.bar })] : []),
+        ),
+      ),
+      null,
+      app,
+    );
+
+  render(false);
+  await tick();
+  render(true);
+  await tick();
+
+  const late = nodeOf(app).children[0].children[0];
+  assert.strictEqual(
+    late.style.flexDirection,
+    'row',
+    'it did not miss the query just because it arrived late',
+  );
+
+  ReactX11.unmountComponentAtNode(app);
+});


### PR DESCRIPTION
> Independent of #73 — both branch off master, neither touches the other's code.

The X11 analogue of `@media`. What a style can usefully ask about here is the window it is laid out in, not the screen.

```jsx
const s = createStyles({
  bar: {
    flexDirection: 'column',
    gap: 4,
    '@width >= 600': { flexDirection: 'row', gap: 16 },
  },
});
```

`width` and `height`, with `>=`, `<=`, `>` or `<`. Matching blocks merge in declaration order, **before** state blocks — so a `:hover` written inside the wide layout still wins over the wide layout itself.

## The asymmetry, and why it holds

**A size query may set layout properties; a state block may not.** That was stated as the rule when state blocks landed and this is the case it was reserved for. A pointer state must never reflow the tree — that is what keeps hover a repaint. A size query is only ever re-evaluated *inside a layout pass the resize already required*, so carrying `flexDirection` or `gap` costs nothing beyond what was already happening.

Concretely: nodes that declare a query register with their window, and the window re-resolves them immediately before `calculateLayout`, only when the size actually changed. A window with no queries under it does no work at all — the registry is empty and the check is one `Set.size`.

## Details worth a look

A node mounted *after* a resize matches the size the window is now, not the one it started at — it takes the current size when it joins the registry.

A malformed query (`'@width => 600'`, `'@depth >= 600'`) is an error naming the expected shape, rather than a key that silently never matches. Given these are strings, that seemed worth more than permissiveness.

## Tests

Six new in `test/size-queries.test.js`, including a resize that asserts **geometry**, not just the style bag: two fixed boxes end up side by side with the wide gap after growing, stacked with the narrow one after shrinking back. That is what shows the change reached yoga rather than only the resolved style.

`npm test` 142 passing, `npm run lint` clean.

https://claude.ai/code/session_013R34DvuxQKamzcafrA8RDd
