### PR TITLE
feat: Tabs and SplitPane, and a showcase example that hosts the others

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,9 +71,11 @@ no override-redirect staging (issue #4).
 - `npm test` — node:test. **Headless: no X server needed.** Primary feedback
   loop; keep it green and extend it when touching the host config.
 - `npm run lint` / `npm run format` — ESLint 9 (flat config) + Prettier.
-- `npm run examples:{simple,simple-nojsx,xeyes,dashboard,tasks,menu,form,richtext,widgets,windows}`
+- `npm run examples:{app,simple,simple-nojsx,xeyes,dashboard,tasks,menu,form,richtext,widgets,windows}`
   — need a running X server (`DISPLAY` set; XQuartz on macOS, Xvfb for
-  automation). All examples export their App and skip auto-running under
+  automation). `examples:app` is the showcase: it hosts `form`, `widgets`
+  and `tasks` as tabs by importing the panel each of them exports, so a new
+  control gets demonstrated there rather than in yet another example. All examples export their App and skip auto-running under
   `REACT_X11_NO_AUTORUN=1` so scripts/tests can import them.
 - `npm run examples:tasks:hot` — the tasks example with hot reloading via
   React **Fast Refresh**: edit `examples/tasks.jsx` while it runs and the

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -74,6 +74,16 @@ merged theme (`ThemeProvider`; `SelectThemeProvider` is an alias) and a
 - **Menu/MenuBar, ContextMenu** — DONE: built on `useAnchor`, with
   separators, disabled items, shortcuts, checkmarks, nested submenus and
   full keyboard navigation; `examples/menu.jsx` rewritten on them
+- **Tabs / SplitPane — DONE.** The two containers an application window is
+  built from: `Tabs` (one panel at a time, roving focus, horizontal or
+  vertical, lazy panels) and `SplitPane` (a draggable divider, keyboard
+  resizable, clamped against the live container size). `examples/app.jsx`
+  hosts `form`, `widgets` and `tasks` as tabs by importing the panel each
+  now exports — new controls get demonstrated there rather than in yet
+  another example. Still missing, roughly in order: Tree, horizontal
+  scrolling in `<scrollview>` (which Table needs first), Table with
+  virtualization, undo/redo in the text controls, a generic Popover, and a
+  file open/save dialog
 - **`Select`/menu keyboard — DONE.** Arrows, Home/End, PageUp/PageDown,
   type-ahead, submenus. Keyboard navigation
   is done (#34: Up/Down/Home/End/Enter/Escape, shared pointer+keyboard

--- a/README.md
+++ b/README.md
@@ -113,9 +113,11 @@ and [docs/](docs/README.md) for the full API reference.
 
 Widget **components** (plain React on top of the primitives, themable via
 `ThemeProvider`): `Button`, `Checkbox`, `Radio`/`RadioGroup`, `Switch`,
-`Slider`, `ProgressBar`, `Select`, `Tooltip`, `MenuBar`/`ContextMenu` and
+`Slider`, `ProgressBar`, `Select`, `Tooltip`, `MenuBar`/`ContextMenu`,
 `Dialog` — a modal built on `<popup trapFocus>`, which traps Tab and
-restores focus when it closes. See [docs/components.md](docs/components.md).
+restores focus when it closes — plus the two containers an application
+window is built from: `Tabs` and `SplitPane`. See
+[docs/components.md](docs/components.md).
 
 ### 3D
 
@@ -157,6 +159,7 @@ All need an X server (`DISPLAY` set; XQuartz on macOS, Xvfb for automation):
 
 ```sh
 npm run examples:simple        # hello world (JSX via tsx)
+npm run examples:app           # the showcase: Tabs + SplitPane hosting the rest
 npm run examples:simple-nojsx  # the same, plain node — no build step
 npm run examples:xeyes         # canvas drawing + hooks
 npm run examples:dashboard     # context theming, custom hooks, components

--- a/docs/components.md
+++ b/docs/components.md
@@ -302,6 +302,67 @@ The helpers are exported for widgets of your own:
 **screen** coordinates, because the trigger and the popup are different X
 windows.
 
+## `Tabs`
+
+One panel visible at a time, switched by a strip of tabs.
+
+```jsx
+<Tabs
+  items={[
+    { id: 'general', label: 'General', content: <GeneralPage /> },
+    { id: 'advanced', label: 'Advanced', content: () => <AdvancedPage /> },
+    { id: 'legacy', label: 'Legacy', disabled: true },
+  ]}
+/>
+```
+
+| prop                     |                                                    |
+| ------------------------ | -------------------------------------------------- |
+| `items`                  | `{ id, label, content, disabled }[]`               |
+| `value` / `defaultValue` | selected id — controlled with `value` + `onChange` |
+| `onChange(id)`           | a tab was chosen                                   |
+| `orientation`            | `'horizontal'` (default) or `'vertical'`           |
+| `manual`                 | arrows move focus only; Enter or Space commits     |
+
+`content` may be a node or a function. A function is called only while that
+tab is selected, which is how to avoid building a panel nobody is looking
+at. Items with no `content` at all make `Tabs` a pure navigator — useful
+when the panel lives elsewhere, as in `examples/app.jsx`, where the strip is
+in one half of a `SplitPane` and the panel in the other.
+
+The strip is a **single tab stop**. Left/Right (Up/Down when vertical) move
+and wrap, Home/End jump to the ends, disabled tabs are skipped. Arrows
+select as they move, the way a desktop notebook behaves; `manual` splits
+focus from selection, which is what you want when a panel is expensive.
+
+## `SplitPane`
+
+Two panes with a divider you can drag.
+
+```jsx
+<SplitPane direction="row" defaultSize={220} min={120} minSecond={300}>
+  <Sidebar />
+  <Editor />
+</SplitPane>
+```
+
+| prop                   |                                                 |
+| ---------------------- | ----------------------------------------------- |
+| `direction`            | `'row'` (default) or `'column'`                 |
+| `size` / `defaultSize` | the **first** pane's width or height, in pixels |
+| `onResize(size)`       | after a drag or a key step                      |
+| `min` / `minSecond`    | how small either pane may get                   |
+
+Only the first pane's size is stored; the second takes what is left, so a
+window resize can never leave a gap. The drag clamps against the container
+as it is laid out at that moment, so the limits stay honest when the window
+changes underneath it.
+
+The divider is focusable: arrows move it by 16px, Home/End drive it to
+either limit. Dragging captures the pointer, so it keeps tracking after the
+pointer leaves the six pixels it started on, and it keeps the grip where it
+was taken rather than jumping to the pointer.
+
 ## `Canvas3D`
 
 The entry point to the [3D scene](elements.md#3d-scene-mesh-group-geometries-materials)

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -38,6 +38,14 @@ Numbers are pixels, strings like `'50%'` / `'auto'` pass through to yoga.
 - **Visibility**: `display` (`flex`, `none`), `overflow` (`visible`,
   `hidden`, `scroll`)
 
+**yoga defaults `flexShrink` to 0, where CSS defaults it to 1.** An item
+whose base size comes from its content therefore refuses to shrink, and
+content wider than the space available pushes the row past its container
+instead of being squeezed into it. Write `flex: 1` in full —
+`{ flexGrow: 1, flexBasis: 0, minWidth: 0 }` — for anything that should take
+the space that is left rather than the space its content wants.
+`<scrollview>` applies exactly that to itself by default.
+
 ## Paint properties
 
 - `backgroundColor` — any CSS color string (`'#2980b9'`,

--- a/examples/app.jsx
+++ b/examples/app.jsx
@@ -40,7 +40,12 @@ const s = createStyles({
   },
   hint: { fontSize: 11, color: '$dim', paddingLeft: 12, paddingRight: 12 },
   spacer: { flexGrow: 1 },
-  content: { flexGrow: 1, minHeight: 0, backgroundColor: '$panel' },
+  content: {
+    flexGrow: 1,
+    minHeight: 0,
+    minWidth: 0,
+    backgroundColor: '$panel',
+  },
   status: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/examples/app.jsx
+++ b/examples/app.jsx
@@ -1,0 +1,130 @@
+// The showcase: one window that hosts the other examples as tabs, laid out
+// with the two container controls an application needs before anything else.
+//
+//   SplitPane  — a sidebar you can drag wider, with a vertical Tabs strip
+//                in it and the selected panel filling the rest
+//   Tabs       — one panel visible at a time, arrows to move between them
+//
+// Each panel is imported from the example that owns it, so this file adds a
+// layout and nothing else: examples/form.jsx and friends still run on their
+// own with `npm run examples:form`.
+// Run with: npm run examples:app  (needs an X server / DISPLAY)
+import React, { useState } from 'react';
+import { createRoot, createStyles, SplitPane, Tabs } from '../src/index.js';
+import { FormPanel } from './form.jsx';
+import { WidgetsPanel } from './widgets.jsx';
+import { TasksPanel } from './tasks.jsx';
+
+const PALETTE = {
+  bg: '#f5f6fa',
+  panel: '#ffffff',
+  text: '#2d3436',
+  dim: '#7f8c8d',
+  edge: '#dfe6e9',
+};
+
+const s = createStyles({
+  window: { backgroundColor: '$bg' },
+  sidebar: {
+    flexGrow: 1,
+    backgroundColor: '$panel',
+    paddingTop: 12,
+    paddingBottom: 12,
+  },
+  title: {
+    fontSize: 15,
+    color: '$text',
+    paddingLeft: 12,
+    paddingRight: 12,
+    paddingBottom: 8,
+  },
+  hint: { fontSize: 11, color: '$dim', paddingLeft: 12, paddingRight: 12 },
+  spacer: { flexGrow: 1 },
+  content: { flexGrow: 1, minHeight: 0, backgroundColor: '$panel' },
+  status: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    paddingLeft: 12,
+    paddingRight: 12,
+    height: 24,
+    flexShrink: 0,
+    backgroundColor: '$panel',
+  },
+  statusText: { fontSize: 11, color: '$dim' },
+});
+
+// The strip lives in the sidebar and the panel on the other side of the
+// divider, so Tabs is used here purely as the navigator: give it items with
+// no `content` and it renders the strip alone. (Hand it `content` instead
+// and it owns the panel too — see docs/components.md.)
+const SECTIONS = [
+  { id: 'form', label: 'Form' },
+  { id: 'widgets', label: 'Widgets' },
+  { id: 'tasks', label: 'Tasks' },
+  { id: 'soon', label: 'Tree (soon)', disabled: true },
+];
+
+const PANELS = {
+  form: () => <FormPanel />,
+  widgets: () => <WidgetsPanel />,
+  tasks: () => <TasksPanel />,
+};
+
+function App() {
+  const [section, setSection] = useState('form');
+  const [sidebar, setSidebar] = useState(150);
+  const active = SECTIONS.find((item) => item.id === section);
+
+  return (
+    <window
+      title="react-x11"
+      width={720}
+      height={520}
+      minWidth={420}
+      minHeight={320}
+      theme={PALETTE}
+      style={s.window}
+    >
+      <SplitPane
+        direction="row"
+        size={sidebar}
+        onResize={setSidebar}
+        min={110}
+        minSecond={260}
+      >
+        <box style={s.sidebar}>
+          <text style={s.title}>Examples</text>
+          {/* the strip is the navigator: one panel at a time, and the
+              panels are built lazily so switching does not pay for the
+              ones nobody is looking at */}
+          <Tabs
+            orientation="vertical"
+            items={SECTIONS}
+            value={section}
+            onChange={setSection}
+            style={{ flexGrow: 0 }}
+          />
+          <box style={s.spacer} />
+          <text style={s.hint}>Up/Down to switch{'\n'}drag the edge →</text>
+        </box>
+
+        <box style={s.content}>
+          <box style={s.status}>
+            <text style={s.statusText}>
+              {active?.label} — sidebar {String(sidebar)}px
+            </text>
+          </box>
+          {PANELS[section]?.()}
+        </box>
+      </SplitPane>
+    </window>
+  );
+}
+
+export default App;
+
+if (!process.env.REACT_X11_NO_AUTORUN) {
+  const root = await createRoot();
+  root.render(<App />);
+}

--- a/examples/form.jsx
+++ b/examples/form.jsx
@@ -26,7 +26,9 @@ const COLORS = [
 
 const WEIGHTS = ['normal', 'bold'];
 
-function App() {
+/** The form itself, without a window round it — so examples/app.jsx can
+ * show it in a tab. */
+export function FormPanel() {
   const [name, setName] = useState('');
   const [color, setColor] = useState('#2980b9');
   const [size, setSize] = useState(20);
@@ -52,107 +54,111 @@ function App() {
   };
 
   return (
+    <box style={{ flexGrow: 1, padding: 16, gap: 12 }}>
+      <text style={{ fontSize: 20, color: '#2d3436' }}>Sign the guestbook</text>
+
+      <textinput
+        autoFocus
+        value={name}
+        placeholder="Your name"
+        onChange={setName}
+        onSubmit={submit}
+        style={{
+          padding: 8,
+          borderRadius: 4,
+          borderWidth: 1,
+          borderColor: '#b2bec3',
+          backgroundColor: 'white',
+        }}
+      />
+
+      <box style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+        <Select
+          options={COLORS}
+          value={color}
+          onChange={setColor}
+          style={{ flexGrow: 1 }}
+        />
+        <RadioGroup
+          value={weight}
+          onChange={setWeight}
+          style={{ flexDirection: 'row', gap: 12 }}
+        >
+          {WEIGHTS.map((w) => (
+            <Radio key={w} value={w} label={w} />
+          ))}
+        </RadioGroup>
+      </box>
+
+      <box style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+        <text style={{ color: '#636e72' }}>size</text>
+        <Slider
+          min={12}
+          max={32}
+          value={size}
+          onChange={setSize}
+          style={{ flexGrow: 1 }}
+        />
+        <text style={{ color: '#636e72' }}>{String(size)}</text>
+      </box>
+
+      <box style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
+        <Checkbox checked={shout} onChange={setShout} label="Shout it" />
+        <box style={{ flexGrow: 1 }} />
+        <Button label="Clear" onPress={() => setConfirming(true)} />
+        <Button primary label="Sign" onPress={submit} />
+      </box>
+
+      <Dialog
+        open={confirming}
+        title="Clear the form?"
+        onClose={() => setConfirming(false)}
+        width={320}
+        height={150}
+        actions={
+          <>
+            <Button label="Cancel" onPress={() => setConfirming(false)} />
+            <Button primary autoFocus label="Clear" onPress={clear} />
+          </>
+        }
+      >
+        The name and the greeting below it will be discarded.
+      </Dialog>
+
+      <box
+        style={{
+          flexGrow: 1,
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        {greeting && (
+          <text
+            style={{
+              fontSize: greeting.size,
+              fontWeight: greeting.weight,
+              color: greeting.color,
+            }}
+          >
+            {greeting.shout
+              ? `HELLO, ${greeting.name.toUpperCase()}!`
+              : `Hello, ${greeting.name}!`}
+          </text>
+        )}
+      </box>
+    </box>
+  );
+}
+
+function App() {
+  return (
     <window
       width={420}
       height={380}
       title="form"
       style={{ backgroundColor: '#f5f6fa' }}
     >
-      <box style={{ flexGrow: 1, padding: 16, gap: 12 }}>
-        <text style={{ fontSize: 20, color: '#2d3436' }}>
-          Sign the guestbook
-        </text>
-
-        <textinput
-          autoFocus
-          value={name}
-          placeholder="Your name"
-          onChange={setName}
-          onSubmit={submit}
-          style={{
-            padding: 8,
-            borderRadius: 4,
-            borderWidth: 1,
-            borderColor: '#b2bec3',
-            backgroundColor: 'white',
-          }}
-        />
-
-        <box style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
-          <Select
-            options={COLORS}
-            value={color}
-            onChange={setColor}
-            style={{ flexGrow: 1 }}
-          />
-          <RadioGroup
-            value={weight}
-            onChange={setWeight}
-            style={{ flexDirection: 'row', gap: 12 }}
-          >
-            {WEIGHTS.map((w) => (
-              <Radio key={w} value={w} label={w} />
-            ))}
-          </RadioGroup>
-        </box>
-
-        <box style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
-          <text style={{ color: '#636e72' }}>size</text>
-          <Slider
-            min={12}
-            max={32}
-            value={size}
-            onChange={setSize}
-            style={{ flexGrow: 1 }}
-          />
-          <text style={{ color: '#636e72' }}>{String(size)}</text>
-        </box>
-
-        <box style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
-          <Checkbox checked={shout} onChange={setShout} label="Shout it" />
-          <box style={{ flexGrow: 1 }} />
-          <Button label="Clear" onPress={() => setConfirming(true)} />
-          <Button primary label="Sign" onPress={submit} />
-        </box>
-
-        <Dialog
-          open={confirming}
-          title="Clear the form?"
-          onClose={() => setConfirming(false)}
-          width={320}
-          height={150}
-          actions={
-            <>
-              <Button label="Cancel" onPress={() => setConfirming(false)} />
-              <Button primary autoFocus label="Clear" onPress={clear} />
-            </>
-          }
-        >
-          The name and the greeting below it will be discarded.
-        </Dialog>
-
-        <box
-          style={{
-            flexGrow: 1,
-            justifyContent: 'center',
-            alignItems: 'center',
-          }}
-        >
-          {greeting && (
-            <text
-              style={{
-                fontSize: greeting.size,
-                fontWeight: greeting.weight,
-                color: greeting.color,
-              }}
-            >
-              {greeting.shout
-                ? `HELLO, ${greeting.name.toUpperCase()}!`
-                : `Hello, ${greeting.name}!`}
-            </text>
-          )}
-        </box>
-      </box>
+      <FormPanel />
     </window>
   );
 }

--- a/examples/tasks.jsx
+++ b/examples/tasks.jsx
@@ -114,7 +114,9 @@ function FilterButton({ filter, current, label }) {
   );
 }
 
-function App() {
+/** The list itself, without a window round it — so examples/app.jsx can
+ * show it in a tab. The dispatch provider comes with it. */
+export function TasksPanel() {
   const [state, dispatch] = useReducer(reducer, initialState);
 
   const visible = useMemo(() => {
@@ -127,50 +129,52 @@ function App() {
 
   return (
     <DispatchContext.Provider value={dispatch}>
-      <window
-        width={420}
-        height={400}
-        title="tasks"
-        style={{ backgroundColor: '#f5f6fa' }}
-      >
-        <box style={{ flexGrow: 1, padding: 16, gap: 12 }}>
-          <text style={{ fontSize: 20, color: '#2d3436' }}>Tasks</text>
+      <box style={{ flexGrow: 1, padding: 16, gap: 12 }}>
+        <text style={{ fontSize: 20, color: '#2d3436' }}>Tasks</text>
 
-          <AddTask />
+        <AddTask />
 
-          <box style={{ flexDirection: 'row', gap: 8 }}>
-            <FilterButton filter="all" current={state.filter} label="All" />
-            <FilterButton
-              filter="active"
-              current={state.filter}
-              label="Active"
-            />
-            <FilterButton filter="done" current={state.filter} label="Done" />
-          </box>
-
-          <scrollview
-            style={{
-              flexGrow: 1,
-              backgroundColor: 'white',
-              borderRadius: 8,
-              borderWidth: 1,
-              borderColor: '#dfe6e9',
-              padding: 6,
-              gap: 2,
-            }}
-          >
-            {visible.map((task) => (
-              <TaskRow key={task.id} task={task} />
-            ))}
-          </scrollview>
-
-          <text style={{ color: '#7f8c8d' }}>
-            {String(remaining)} remaining — click or Tab + Space to toggle,
-            wheel to scroll
-          </text>
+        <box style={{ flexDirection: 'row', gap: 8 }}>
+          <FilterButton filter="all" current={state.filter} label="All" />
+          <FilterButton filter="active" current={state.filter} label="Active" />
+          <FilterButton filter="done" current={state.filter} label="Done" />
         </box>
-      </window>
+
+        <scrollview
+          style={{
+            flexGrow: 1,
+            backgroundColor: 'white',
+            borderRadius: 8,
+            borderWidth: 1,
+            borderColor: '#dfe6e9',
+            padding: 6,
+            gap: 2,
+          }}
+        >
+          {visible.map((task) => (
+            <TaskRow key={task.id} task={task} />
+          ))}
+        </scrollview>
+
+        <text style={{ color: '#7f8c8d' }}>
+          {String(remaining)} remaining — click or Tab + Space to toggle, wheel
+          to scroll
+        </text>
+      </box>
     </DispatchContext.Provider>
+  );
+}
+
+function App() {
+  return (
+    <window
+      width={420}
+      height={400}
+      title="tasks"
+      style={{ backgroundColor: '#f5f6fa' }}
+    >
+      <TasksPanel />
+    </window>
   );
 }
 

--- a/examples/widgets.jsx
+++ b/examples/widgets.jsx
@@ -136,7 +136,11 @@ export function WidgetsPanel() {
       </Row>
 
       <Row label="Markdown" alignItems="flex-start">
-        <box style={{ flexGrow: 1, gap: 8 }}>
+        {/* `flex: 1` in full — grow *and* a zero basis. yoga defaults
+            flexShrink to 0 (CSS says 1), so with a content-sized basis the
+            markdown's natural width became a floor and pushed the row past
+            the window edge */}
+        <box style={{ flexGrow: 1, flexBasis: 0, minWidth: 0, gap: 8 }}>
           {/* the textarea is the source, the <markdown> element is the
               preview: every keystroke re-parses through ntk's
               MarkdownView, which is cheap enough for a document this size */}

--- a/examples/widgets.jsx
+++ b/examples/widgets.jsx
@@ -26,7 +26,9 @@ function Row({ label, children, alignItems = 'center' }) {
   );
 }
 
-function App() {
+/** The gallery itself, without a window round it — so examples/app.jsx can
+ * show it in a tab. */
+export function WidgetsPanel() {
   const [agreed, setAgreed] = useState(true);
   const [notify, setNotify] = useState(false);
   const [flavor, setFlavor] = useState('vanilla');
@@ -49,87 +51,101 @@ function App() {
   }, [notify]);
 
   return (
-    <window
-      width={460}
-      height={720}
-      title="widgets"
-      style={{ backgroundColor: '#f5f6fa' }}
-    >
-      <box style={{ flexGrow: 1, padding: 16, gap: 14 }}>
-        <text style={{ fontSize: 20, color: '#2d3436' }}>Widget gallery</text>
+    <box style={{ flexGrow: 1, padding: 16, gap: 14 }}>
+      <text style={{ fontSize: 20, color: '#2d3436' }}>Widget gallery</text>
 
-        <Row label="Button">
-          <Button primary onPress={() => setPresses((n) => n + 1)}>
-            Press me
-          </Button>
-          <Tooltip label="Back to zero">
-            <Button onPress={() => setPresses(0)}>Reset</Button>
-          </Tooltip>
-          <Button disabled>Disabled</Button>
-          <text style={{ color: '#2d3436' }}>{`${presses}×`}</text>
-        </Row>
+      <Row label="Button">
+        <Button primary onPress={() => setPresses((n) => n + 1)}>
+          Press me
+        </Button>
+        <Tooltip label="Back to zero">
+          <Button onPress={() => setPresses(0)}>Reset</Button>
+        </Tooltip>
+        <Button disabled>Disabled</Button>
+        <text style={{ color: '#2d3436' }}>{`${presses}×`}</text>
+      </Row>
 
-        <Row label="Checkbox">
-          <box style={{ gap: 6 }}>
-            <Checkbox checked={agreed} onChange={setAgreed}>
-              I agree to nothing in particular
-            </Checkbox>
-            <Checkbox checked={false} disabled>
-              Disabled
-            </Checkbox>
-          </box>
-        </Row>
+      <Row label="Checkbox">
+        <box style={{ gap: 6 }}>
+          <Checkbox checked={agreed} onChange={setAgreed}>
+            I agree to nothing in particular
+          </Checkbox>
+          <Checkbox checked={false} disabled>
+            Disabled
+          </Checkbox>
+        </box>
+      </Row>
 
-        <Row label="Radio">
-          <RadioGroup value={flavor} onChange={setFlavor}>
-            <Radio value="vanilla">Vanilla</Radio>
-            <Radio value="chocolate">Chocolate</Radio>
-            <Radio value="pistachio">Pistachio</Radio>
-          </RadioGroup>
-        </Row>
+      <Row label="Radio">
+        <RadioGroup value={flavor} onChange={setFlavor}>
+          <Radio value="vanilla">Vanilla</Radio>
+          <Radio value="chocolate">Chocolate</Radio>
+          <Radio value="pistachio">Pistachio</Radio>
+        </RadioGroup>
+      </Row>
 
-        <Row label="Switch">
-          <Switch checked={notify} onChange={setNotify} />
-          <text style={{ color: '#2d3436' }}>
-            {notify ? 'notifications on' : 'off'}
-          </text>
-        </Row>
+      <Row label="Switch">
+        <Switch checked={notify} onChange={setNotify} />
+        <text style={{ color: '#2d3436' }}>
+          {notify ? 'notifications on' : 'off'}
+        </text>
+      </Row>
 
-        <Row label="Slider">
-          <Slider
-            value={volume}
-            min={0}
-            max={100}
-            step={5}
-            onChange={setVolume}
-            style={{ width: 200 }}
-          />
-          <text style={{ color: '#2d3436' }}>{`${volume}`}</text>
-        </Row>
+      <Row label="Slider">
+        <Slider
+          value={volume}
+          min={0}
+          max={100}
+          step={5}
+          onChange={setVolume}
+          style={{ width: 200 }}
+        />
+        <text style={{ color: '#2d3436' }}>{`${volume}`}</text>
+      </Row>
 
-        <Row label="Progress">
-          <box style={{ flexGrow: 1 }}>
-            <ProgressBar value={progress} />
-          </box>
-          <text
-            style={{ color: '#7f8c8d' }}
-          >{`${Math.round(progress * 100)}%`}</text>
-        </Row>
+      <Row label="Progress">
+        <box style={{ flexGrow: 1 }}>
+          <ProgressBar value={progress} />
+        </box>
+        <text
+          style={{ color: '#7f8c8d' }}
+        >{`${Math.round(progress * 100)}%`}</text>
+      </Row>
 
-        <Row label="Select">
-          <Select
-            options={['fast', 'faster', 'ludicrous']}
-            value={speed}
-            onChange={setSpeed}
-            style={{ width: 160 }}
-          />
-        </Row>
+      <Row label="Select">
+        <Select
+          options={['fast', 'faster', 'ludicrous']}
+          value={speed}
+          onChange={setSpeed}
+          style={{ width: 160 }}
+        />
+      </Row>
 
-        <Row label="Input">
-          <textinput
-            placeholder="Type here…"
+      <Row label="Input">
+        <textinput
+          placeholder="Type here…"
+          style={{
+            flexGrow: 1,
+            padding: 8,
+            borderRadius: 4,
+            borderWidth: 1,
+            borderColor: '#b2bec3',
+            backgroundColor: 'white',
+          }}
+        />
+      </Row>
+
+      <Row label="Markdown" alignItems="flex-start">
+        <box style={{ flexGrow: 1, gap: 8 }}>
+          {/* the textarea is the source, the <markdown> element is the
+              preview: every keystroke re-parses through ntk's
+              MarkdownView, which is cheap enough for a document this size */}
+          <textarea
+            rows={4}
+            value={note}
+            onChange={setNote}
             style={{
-              flexGrow: 1,
+              flexGrow: 0,
               padding: 8,
               borderRadius: 4,
               borderWidth: 1,
@@ -137,41 +153,33 @@ function App() {
               backgroundColor: 'white',
             }}
           />
-        </Row>
+          <scrollview
+            style={{
+              height: 110,
+              padding: 4,
+              borderRadius: 4,
+              borderWidth: 1,
+              borderColor: '#dfe6e9',
+              backgroundColor: 'white',
+            }}
+          >
+            <markdown style={{ padding: 6 }}>{note}</markdown>
+          </scrollview>
+        </box>
+      </Row>
+    </box>
+  );
+}
 
-        <Row label="Markdown" alignItems="flex-start">
-          <box style={{ flexGrow: 1, gap: 8 }}>
-            {/* the textarea is the source, the <markdown> element is the
-                preview: every keystroke re-parses through ntk's
-                MarkdownView, which is cheap enough for a document this size */}
-            <textarea
-              rows={4}
-              value={note}
-              onChange={setNote}
-              style={{
-                flexGrow: 0,
-                padding: 8,
-                borderRadius: 4,
-                borderWidth: 1,
-                borderColor: '#b2bec3',
-                backgroundColor: 'white',
-              }}
-            />
-            <scrollview
-              style={{
-                height: 110,
-                padding: 4,
-                borderRadius: 4,
-                borderWidth: 1,
-                borderColor: '#dfe6e9',
-                backgroundColor: 'white',
-              }}
-            >
-              <markdown style={{ padding: 6 }}>{note}</markdown>
-            </scrollview>
-          </box>
-        </Row>
-      </box>
+function App() {
+  return (
+    <window
+      width={460}
+      height={720}
+      title="widgets"
+      style={{ backgroundColor: '#f5f6fa' }}
+    >
+      <WidgetsPanel />
     </window>
   );
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "examples:app": "tsx examples/app.jsx",
     "examples:simple": "tsx examples/simple.jsx",
     "examples:simple-nojsx": "node examples/simple-nojsx.js",
     "examples:xeyes": "tsx examples/xeyes.jsx",

--- a/src/components/SplitPane.js
+++ b/src/components/SplitPane.js
@@ -1,0 +1,175 @@
+// Widget components built purely on the host primitives — no reconciler
+// support needed. Plain createElement (no JSX) so the library stays
+// build-step-free for consumers.
+
+import React, { useRef, useState } from 'react';
+import { createStyles } from '../styles.js';
+import { useTheme } from './theme.js';
+import { XK_DOWN, XK_END, XK_HOME, XK_LEFT, XK_RIGHT, XK_UP } from './keys.js';
+
+const h = React.createElement;
+
+const DIVIDER = 6;
+const KEY_STEP = 16;
+
+const s = createStyles({
+  root: { flexGrow: 1, minHeight: 0, minWidth: 0 },
+  pane: { minHeight: 0, minWidth: 0 },
+  grow: { flexGrow: 1, minHeight: 0, minWidth: 0 },
+  divider: {
+    flexShrink: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+    transition: { backgroundColor: 100 },
+  },
+  // the grab handle is a hairline; the *target* is the whole divider
+  grip: { borderRadius: 1 },
+});
+
+/**
+ * <SplitPane> — two panes with a divider you can drag.
+ *
+ *   <SplitPane direction="row" defaultSize={220}>
+ *     <Sidebar />
+ *     <Editor />
+ *   </SplitPane>
+ *
+ * `size` is the first pane's width (or height, when `direction="column"`)
+ * in pixels: controlled with `size` + `onResize`, uncontrolled with
+ * `defaultSize`. The second pane takes what is left, so only one number is
+ * ever stored and a window resize cannot leave a gap.
+ *
+ * `min` and `minSecond` keep either pane from collapsing; the drag clamps
+ * against the container's laid-out size, so it stays honest when the window
+ * changes underneath it.
+ *
+ * The divider is focusable: arrows move it by 16px, Home/End drive it to
+ * either limit. Dragging captures the pointer, so it keeps tracking after
+ * the pointer leaves the six pixels it started on.
+ */
+export function SplitPane({
+  direction = 'row',
+  size,
+  defaultSize = 200,
+  min = 40,
+  minSecond = 40,
+  onResize,
+  children,
+  style,
+  ...boxProps
+}) {
+  const theme = useTheme();
+  const [first, second] = React.Children.toArray(children);
+  const [uncontrolled, setUncontrolled] = useState(defaultSize);
+  const [dragging, setDragging] = useState(false);
+  const rootRef = useRef(null);
+  const grab = useRef(0);
+  const vertical = direction === 'column';
+  const current = size ?? uncontrolled;
+
+  // the live size and drag flag, mirrored in refs: a press and the moves
+  // that follow can all land before React re-renders, and a handler closing
+  // over the last rendered value would drop everything after the first
+  const sizeRef = useRef(current);
+  sizeRef.current = current;
+  const draggingRef = useRef(false);
+
+  /** Clamp against the container as laid out right now. */
+  const commit = (next) => {
+    const box = rootRef.current?.abs;
+    const total = (vertical ? box?.height : box?.width) ?? 0;
+    const room = Math.max(min, total - DIVIDER - minSecond);
+    const clamped = Math.min(Math.max(min, next), total > 0 ? room : next);
+    if (clamped === sizeRef.current) return;
+    sizeRef.current = clamped;
+    if (size === undefined) setUncontrolled(clamped);
+    onResize?.(clamped);
+  };
+
+  const dividerProps = {
+    focusable: true,
+    onMouseDown: (ev) => {
+      const box = rootRef.current?.abs;
+      // where in the divider it was taken, so it does not jump on press
+      grab.current = (vertical ? ev.y - box.y : ev.x - box.x) - sizeRef.current;
+      ev.capturePointer();
+      draggingRef.current = true;
+      setDragging(true);
+    },
+    onMouseMove: (ev) => {
+      if (!draggingRef.current) return;
+      const box = rootRef.current?.abs;
+      if (!box) return;
+      commit((vertical ? ev.y - box.y : ev.x - box.x) - grab.current);
+    },
+    onMouseUp: () => {
+      draggingRef.current = false;
+      setDragging(false);
+    },
+    onKeyDown: (ev) => {
+      const back = vertical ? XK_UP : XK_LEFT;
+      const forward = vertical ? XK_DOWN : XK_RIGHT;
+      switch (ev.keysym) {
+        case back:
+          commit(sizeRef.current - KEY_STEP);
+          return;
+        case forward:
+          commit(sizeRef.current + KEY_STEP);
+          return;
+        case XK_HOME:
+          commit(min);
+          return;
+        case XK_END:
+          commit(Number.MAX_SAFE_INTEGER);
+          return;
+        default:
+      }
+    },
+  };
+
+  return h(
+    'box',
+    {
+      theme,
+      ref: rootRef,
+      ...boxProps,
+      style: [s.root, { flexDirection: vertical ? 'column' : 'row' }, style],
+    },
+    h(
+      'box',
+      {
+        style: [
+          s.pane,
+          vertical
+            ? { height: current, flexShrink: 0 }
+            : { width: current, flexShrink: 0 },
+        ],
+      },
+      first ?? null,
+    ),
+    h(
+      'box',
+      {
+        ...dividerProps,
+        style: [
+          s.divider,
+          vertical
+            ? { height: DIVIDER, cursor: 'row-resize' }
+            : { width: DIVIDER, cursor: 'col-resize' },
+          { backgroundColor: dragging ? theme.surfaceHover : 'transparent' },
+          { ':hover': { backgroundColor: theme.surfaceHover } },
+        ],
+      },
+      h('box', {
+        style: [
+          s.grip,
+          vertical
+            ? { height: 2, alignSelf: 'stretch' }
+            : { width: 2, alignSelf: 'stretch' },
+          { backgroundColor: theme.border },
+        ],
+      }),
+    ),
+    h('box', { style: s.grow }, second ?? null),
+  );
+}

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -1,0 +1,202 @@
+// Widget components built purely on the host primitives — no reconciler
+// support needed. Plain createElement (no JSX) so the library stays
+// build-step-free for consumers.
+
+import React, { useRef, useState } from 'react';
+import { createStyles } from '../styles.js';
+import { labelContent, useTheme } from './theme.js';
+import {
+  XK_DOWN,
+  XK_END,
+  XK_HOME,
+  XK_LEFT,
+  XK_RETURN,
+  XK_RIGHT,
+  XK_UP,
+} from './keys.js';
+
+const h = React.createElement;
+
+const INDICATOR = 2;
+
+const s = createStyles({
+  root: { flexGrow: 1, minHeight: 0 },
+  strip: { flexShrink: 0, gap: 2 },
+  tab: {
+    paddingTop: 6,
+    paddingBottom: 6,
+    paddingLeft: 12,
+    paddingRight: 12,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    cursor: 'pointer',
+    transition: { backgroundColor: 100 },
+  },
+  // the selected marker is a box rather than a border: borders are
+  // all-edges here, and this has to sit on one side
+  indicator: { position: 'absolute', transition: { backgroundColor: 100 } },
+  panel: { flexGrow: 1, minHeight: 0, minWidth: 0 },
+});
+
+/**
+ * <Tabs items value onChange orientation/> — one visible panel at a time,
+ * switched by a strip of tabs.
+ *
+ *   <Tabs items={[{ id: 'a', label: 'A', content: <box/> }]} />
+ *
+ * Each item is `{ id, label, content, disabled }`. `content` may be a node,
+ * or a function called only while that tab is selected — which is how to
+ * avoid building a panel nobody is looking at.
+ *
+ * Controlled with `value` + `onChange`, uncontrolled otherwise. The strip is
+ * a single tab stop: Left/Right (Up/Down when vertical) move and wrap,
+ * Home/End jump to the ends, and disabled tabs are skipped. Arrows select as
+ * they move, the way a desktop notebook behaves; pass `manual` to move focus
+ * only and commit with Enter or Space, which is what you want when a panel
+ * is expensive to build.
+ */
+export function Tabs({
+  items = [],
+  value,
+  defaultValue,
+  onChange,
+  orientation = 'horizontal',
+  manual = false,
+  style,
+  ...boxProps
+}) {
+  const theme = useTheme();
+  const firstEnabled = items.find((item) => !item.disabled)?.id;
+  const [uncontrolled, setUncontrolled] = useState(
+    defaultValue ?? firstEnabled,
+  );
+  const [focusedId, setFocusedId] = useState(null);
+  const selected = value ?? uncontrolled;
+  const vertical = orientation === 'vertical';
+  const tabRefs = useRef(new Map());
+
+  const select = (id) => {
+    if (id == null || id === selected) return;
+    if (value === undefined) setUncontrolled(id);
+    onChange?.(id);
+  };
+
+  /** The next enabled tab `delta` steps away, wrapping. */
+  const step = (from, delta) => {
+    const n = items.length;
+    if (n === 0) return null;
+    for (let i = 1; i <= n; i++) {
+      const item = items[(((from + delta * i) % n) + n) % n];
+      if (item && !item.disabled) return item;
+    }
+    return null;
+  };
+
+  const goTo = (item) => {
+    if (!item) return;
+    tabRefs.current.get(item.id)?.focus?.();
+    if (!manual) select(item.id);
+  };
+
+  const onKeyDown = (ev) => {
+    const back = vertical ? XK_UP : XK_LEFT;
+    const forward = vertical ? XK_DOWN : XK_RIGHT;
+    const current = items.findIndex(
+      (item) => item.id === (focusedId ?? selected),
+    );
+    switch (ev.keysym) {
+      case back:
+        goTo(step(current === -1 ? 0 : current, -1));
+        return;
+      case forward:
+        goTo(step(current === -1 ? 0 : current, 1));
+        return;
+      case XK_HOME:
+        goTo(items.find((item) => !item.disabled));
+        return;
+      case XK_END:
+        goTo([...items].reverse().find((item) => !item.disabled));
+        return;
+      default:
+    }
+    // in manual mode focus and selection differ, so commit what the focus
+    // is on rather than what is already selected
+    if (manual && (ev.keysym === XK_RETURN || ev.codepoint === 32)) {
+      select(focusedId);
+    }
+  };
+
+  const active = items.find((item) => item.id === selected);
+  const content =
+    typeof active?.content === 'function' ? active.content() : active?.content;
+
+  const indicatorStyle = vertical
+    ? { top: 0, bottom: 0, left: 0, width: INDICATOR }
+    : { left: 0, right: 0, bottom: 0, height: INDICATOR };
+
+  return h(
+    'box',
+    {
+      theme,
+      ...boxProps,
+      style: [s.root, { flexDirection: vertical ? 'row' : 'column' }, style],
+    },
+    h(
+      'box',
+      {
+        style: [s.strip, { flexDirection: vertical ? 'column' : 'row' }],
+        onKeyDown,
+      },
+      items.map((item) =>
+        h(
+          'box',
+          {
+            key: item.id,
+            ref: (node) => {
+              if (node) tabRefs.current.set(item.id, node);
+              else tabRefs.current.delete(item.id);
+            },
+            focusable: !item.disabled,
+            tabIndex: item.id === selected ? 0 : -1,
+            disabled: item.disabled,
+            onFocus: () => setFocusedId(item.id),
+            onClick: () => !item.disabled && select(item.id),
+            style: [
+              s.tab,
+              {
+                backgroundColor:
+                  item.id === selected ? theme.surfaceHover : 'transparent',
+              },
+              !item.disabled && {
+                ':hover': { backgroundColor: theme.surfaceHover },
+              },
+            ],
+          },
+          labelContent(item.label, {
+            color: item.disabled
+              ? theme.dim
+              : item.id === selected
+                ? theme.text
+                : theme.dim,
+          }),
+          h('box', {
+            style: [
+              s.indicator,
+              indicatorStyle,
+              {
+                backgroundColor:
+                  item.id === selected
+                    ? theme.accent
+                    : item.id === focusedId
+                      ? theme.borderActive
+                      : 'transparent',
+              },
+            ],
+          }),
+        ),
+      ),
+    ),
+    h('box', { style: s.panel }, content ?? null),
+  );
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -14,4 +14,6 @@ export { Slider } from './Slider.js';
 export { Tooltip } from './Tooltip.js';
 export { ContextMenu, MenuBar } from './Menu.js';
 export { Select } from './Select.js';
+export { Tabs } from './Tabs.js';
+export { SplitPane } from './SplitPane.js';
 export { Canvas3D } from './Canvas3D.js';

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,8 @@ export {
 export { createStyles, flattenStyle } from './styles.js';
 export {
   Select,
+  Tabs,
+  SplitPane,
   SelectThemeProvider,
   ThemeProvider,
   Button,

--- a/test/tabs-splitpane.test.js
+++ b/test/tabs-splitpane.test.js
@@ -1,0 +1,330 @@
+// Tabs and SplitPane: the two container controls an application window
+// needs before anything else.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import ReactX11, { SplitPane, Tabs } from '../src/index.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+// a state update from a key press lands a render *and* a layout flush later
+const settle = async () => {
+  await tick();
+  await tick();
+};
+const root = (app) => app.windows[0]._reactX11Node;
+
+const XK = {
+  LEFT: 0xff51,
+  UP: 0xff52,
+  RIGHT: 0xff53,
+  DOWN: 0xff54,
+  HOME: 0xff50,
+  END: 0xff57,
+};
+
+function press(app, wnd, keysym, codepoint) {
+  const keycode = (keysym % 248) + 8;
+  app.X.keycode2keysyms[keycode] = [keysym];
+  wnd.emit('keydown', { keycode, codepoint, buttons: 0 });
+}
+
+const find = (node, pred) =>
+  pred(node)
+    ? node
+    : node.children.reduce(
+        (a, c) => a || (c.isWindow ? null : find(c, pred)),
+        null,
+      );
+
+const labelled = (node, text) =>
+  find(node, (n) => n.kind === 'text' && String(n.props.children) === text)
+    ?.parent;
+
+/** A real press, so the update runs at discrete priority and flushes the
+ * way it does for a user — calling the handler by hand schedules a
+ * concurrent update a single tick would not deliver. */
+const click = (wnd, node) => {
+  const x = node.abs.x + node.abs.width / 2;
+  const y = node.abs.y + node.abs.height / 2;
+  wnd.emit('mousedown', { x, y, keycode: 1 });
+  wnd.emit('mouseup', { x, y, keycode: 1 });
+};
+
+const ITEMS = [
+  { id: 'one', label: 'One', content: h('text', null, 'first panel') },
+  { id: 'two', label: 'Two', disabled: true, content: h('text', null, 'nope') },
+  { id: 'three', label: 'Three', content: h('text', null, 'third panel') },
+];
+
+function mountTabs(props) {
+  const app = createMockApp();
+  ReactX11.render(
+    h(
+      'window',
+      { width: 300, height: 200 },
+      h(Tabs, { items: ITEMS, ...props }),
+    ),
+    null,
+    app,
+  );
+  return app;
+}
+
+const panelText = (app) =>
+  find(
+    root(app),
+    (n) => n.kind === 'text' && /panel/.test(String(n.props.children)),
+  )?.props.children;
+
+test('Tabs shows one panel, and clicking a tab switches it', async () => {
+  const app = mountTabs();
+  await tick();
+  assert.strictEqual(panelText(app), 'first panel', 'the first enabled tab');
+
+  click(app.windows[0], labelled(root(app), 'Three'));
+  await tick();
+  assert.strictEqual(panelText(app), 'third panel');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('arrows move and wrap, skipping disabled tabs', async () => {
+  const changes = [];
+  const app = mountTabs({ onChange: (id) => changes.push(id) });
+  await tick();
+  const wnd = app.windows[0];
+  labelled(root(app), 'One').focus();
+
+  press(app, wnd, XK.RIGHT);
+  await tick();
+  assert.deepStrictEqual(
+    changes,
+    ['three'],
+    'the disabled tab is stepped over',
+  );
+  assert.strictEqual(panelText(app), 'third panel');
+
+  press(app, wnd, XK.RIGHT);
+  await tick();
+  assert.deepStrictEqual(changes, ['three', 'one'], 'and it wraps round');
+
+  press(app, wnd, XK.END);
+  await tick();
+  assert.strictEqual(changes.at(-1), 'three', 'End goes to the last enabled');
+  press(app, wnd, XK.HOME);
+  await tick();
+  assert.strictEqual(changes.at(-1), 'one');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('a disabled tab is not focusable and cannot be selected', async () => {
+  const app = mountTabs();
+  await tick();
+  const two = labelled(root(app), 'Two');
+  assert.strictEqual(two.props.focusable, false);
+  click(app.windows[0], two);
+  await tick();
+  assert.strictEqual(panelText(app), 'first panel', 'the click did nothing');
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('manual mode moves focus without selecting until Enter', async () => {
+  const app = mountTabs({ manual: true });
+  await tick();
+  const wnd = app.windows[0];
+  labelled(root(app), 'One').focus();
+
+  press(app, wnd, XK.RIGHT);
+  await tick();
+  assert.strictEqual(
+    panelText(app),
+    'first panel',
+    'still showing the old panel',
+  );
+
+  press(app, wnd, 0xff0d); // Return
+  await tick();
+  assert.strictEqual(panelText(app), 'third panel', 'Enter commits it');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('vertical Tabs use Up/Down instead', async () => {
+  const app = mountTabs({ orientation: 'vertical' });
+  await tick();
+  const wnd = app.windows[0];
+  labelled(root(app), 'One').focus();
+
+  press(app, wnd, XK.RIGHT);
+  await tick();
+  assert.strictEqual(panelText(app), 'first panel', 'Right does nothing');
+  press(app, wnd, XK.DOWN);
+  await tick();
+  assert.strictEqual(panelText(app), 'third panel');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('content given as a function is only built while selected', async () => {
+  let built = 0;
+  const app = createMockApp();
+  ReactX11.render(
+    h(
+      'window',
+      { width: 300, height: 200 },
+      h(Tabs, {
+        items: [
+          { id: 'a', label: 'A', content: h('text', null, 'a panel') },
+          {
+            id: 'b',
+            label: 'B',
+            content: () => {
+              built++;
+              return h('text', null, 'b panel');
+            },
+          },
+        ],
+      }),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  assert.strictEqual(built, 0, 'the hidden panel was never built');
+
+  click(app.windows[0], labelled(root(app), 'B'));
+  await tick();
+  assert.ok(built > 0, 'and is built once shown');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+// --- SplitPane -------------------------------------------------------------
+
+function mountSplit(props) {
+  const app = createMockApp();
+  ReactX11.render(
+    h(
+      'window',
+      { width: 400, height: 200 },
+      h(
+        SplitPane,
+        { defaultSize: 100, ...props },
+        h('box', { style: { flexGrow: 1, backgroundColor: 'red' } }),
+        h('box', { style: { flexGrow: 1, backgroundColor: 'blue' } }),
+      ),
+    ),
+    null,
+    app,
+  );
+  return app;
+}
+
+const divider = (app) =>
+  find(root(app), (n) => /resize$/.test(n.style.cursor ?? ''));
+
+test('SplitPane sizes the first pane and gives the rest to the second', async () => {
+  const app = mountSplit();
+  await tick();
+  const [first, , second] = root(app).children[0].children;
+  assert.strictEqual(first.abs.width, 100);
+  assert.strictEqual(second.abs.width, 400 - 100 - 6, 'the divider takes 6');
+  assert.strictEqual(first.abs.height, 200, 'panes fill across the other axis');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('dragging the divider resizes, and clamps at both minimums', async () => {
+  const sizes = [];
+  const app = mountSplit({
+    onResize: (n) => sizes.push(n),
+    min: 50,
+    minSecond: 80,
+  });
+  await tick();
+  const wnd = app.windows[0];
+  const d = divider(app);
+
+  wnd.emit('mousedown', { x: d.abs.x + 3, y: 100, keycode: 1 });
+  wnd.emit('mousemove', { x: 250, y: 100 });
+  await tick();
+  const [first] = root(app).children[0].children;
+  assert.ok(
+    Math.abs(first.abs.width - 247) <= 3,
+    `dragged to ~247, got ${first.abs.width}`,
+  );
+
+  wnd.emit('mousemove', { x: 5, y: 100 });
+  await tick();
+  assert.strictEqual(root(app).children[0].children[0].abs.width, 50, 'min');
+
+  wnd.emit('mousemove', { x: 395, y: 100 });
+  await tick();
+  assert.strictEqual(
+    root(app).children[0].children[0].abs.width,
+    400 - 6 - 80,
+    'the second pane keeps its minimum',
+  );
+  wnd.emit('mouseup', { x: 395, y: 100, keycode: 1 });
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('the divider takes the grab point with it, without jumping', async () => {
+  const app = mountSplit();
+  await tick();
+  const wnd = app.windows[0];
+  const d = divider(app);
+
+  // press at the right-hand edge of the divider and do not move
+  wnd.emit('mousedown', { x: d.abs.x + 5, y: 100, keycode: 1 });
+  wnd.emit('mousemove', { x: d.abs.x + 5, y: 100 });
+  await tick();
+  assert.strictEqual(
+    root(app).children[0].children[0].abs.width,
+    100,
+    'no jump on press',
+  );
+  wnd.emit('mouseup', { x: d.abs.x + 5, y: 100, keycode: 1 });
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('the divider is focusable and moves with the arrow keys', async () => {
+  const app = mountSplit();
+  await tick();
+  const wnd = app.windows[0];
+  divider(app).focus();
+
+  press(app, wnd, XK.RIGHT);
+  await settle();
+  assert.strictEqual(root(app).children[0].children[0].abs.width, 116);
+  press(app, wnd, XK.LEFT);
+  press(app, wnd, XK.LEFT);
+  await settle();
+  assert.strictEqual(
+    root(app).children[0].children[0].abs.width,
+    84,
+    'each press steps from the last, not from the last render',
+  );
+
+  press(app, wnd, XK.HOME);
+  await settle();
+  assert.strictEqual(root(app).children[0].children[0].abs.width, 40, 'to min');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('a column split divides the other way', async () => {
+  const app = mountSplit({ direction: 'column', defaultSize: 60 });
+  await tick();
+  const [first, d, second] = root(app).children[0].children;
+  assert.strictEqual(first.abs.height, 60);
+  assert.strictEqual(second.abs.height, 200 - 60 - 6);
+  assert.strictEqual(d.style.cursor, 'row-resize');
+
+  ReactX11.unmountComponentAtNode(app);
+});


### PR DESCRIPTION
The two containers an application window is built from — and the two that were blocking any real layout.

## Tabs

```jsx
<Tabs items={[
  { id: 'general', label: 'General', content: <GeneralPage /> },
  { id: 'advanced', label: 'Advanced', content: () => <AdvancedPage /> },
  { id: 'legacy', label: 'Legacy', disabled: true },
]} />
```

`content` may be a function, called only while that tab is selected, so a panel nobody is looking at is never built. The strip is a **single tab stop**: arrows move and wrap, Home/End jump to the ends, disabled tabs are skipped. Arrows select as they move, the way a desktop notebook behaves — `manual` splits focus from selection for when a panel is expensive to build. `orientation="vertical"` swaps the arrows for Up/Down.

Items with no `content` make it a pure navigator, which is how the example below uses it.

## SplitPane

```jsx
<SplitPane direction="row" defaultSize={220} min={120} minSecond={300}>
  <Sidebar />
  <Editor />
</SplitPane>
```

Only the first pane's size is stored; the second takes what is left, so a window resize cannot leave a gap. The drag clamps against the container **as laid out at that moment**, so the limits stay honest when the window changes underneath it. The divider is focusable — arrows step it by 16px, Home/End drive it to either limit — and dragging captures the pointer, so it keeps tracking outside the six pixels it started on, and keeps the grip where it was taken rather than jumping.

## The bug worth knowing about

Both keep their live values in refs rather than reading React state in the handlers. A press and the moves that follow can all land before React re-renders, so a handler closing over the last rendered value drops everything after the first. The arrow-key test presses twice in a row and fails without it — as did the drag, which is why `Slider`'s pattern was not simply copied.

## The example

`examples/app.jsx` is the consolidated showcase: a sidebar you can drag wider, a vertical tab strip navigating it, the panel filling the rest.

![app-form](https://github.com/user-attachments/assets/22273f4c-b39d-4373-aee6-0923dc907ed7)

Dragging the divider to 237px and switching to Widgets with the tab strip:

![app-widgets-wide](https://github.com/user-attachments/assets/6e0b06fb-884f-4603-a2a0-c4142cfee7ca)

It adds layout and **nothing else**. `form`, `widgets` and `tasks` each now export the panel they used to keep inside their own window, and still run standalone with `npm run examples:form` and friends — so this consolidates without duplicating, and a new control gets demonstrated here rather than in yet another example. The disabled "Tree (soon)" tab is a placeholder for what comes next.

## Also here: a layout bug the showcase exposed

Putting the widget gallery in a pane made it obvious that its markdown row was already too wide — 428px of editor and preview starting 118px in, so 86px ran off the right edge at the gallery's own 460px.

The row's container had `flexGrow: 1`, which reads like `flex: 1` but is not: **yoga defaults `flexShrink` to 0 where CSS defaults it to 1**, so with a content-sized basis the markdown's natural width became a floor the row could not shrink below. `{ flexGrow: 1, flexBasis: 0, minWidth: 0 }` is `flex: 1` in full — the same thing `<scrollview>` already applies to itself. Now documented next to the layout props, since this is the second time that default has bitten.

![widgets-fixed](https://github.com/user-attachments/assets/8736af0f-3647-42c6-9405-80c3b8151e0d)

Measured against the real text stack rather than the mock, since the mock has no font metrics and reported no overflow at all. What remains is the button row below ~380px, where three fixed-size buttons and a counter genuinely do not fit — a design question for the example, not a layout bug.

## Tests

Eleven new in `test/tabs-splitpane.test.js`: click and arrow selection, wrapping past disabled tabs, Home/End, vertical orientation, manual mode, lazy panel construction, pane sizing, drag with clamping at both minimums, the grip not jumping, keyboard resize, and the column direction.

One note on test technique: these drive real mouse and key events rather than calling handlers. Calling `props.onClick()` by hand schedules a concurrent update that a single tick does not deliver, so those tests passed for the wrong reason at first.

`npm test` 152 passing, `npm run lint` clean. Committed screenshots are untouched — `examples/app.jsx` is not in the screenshots script.
