### PR TITLE
feat: Tree — disclosure rows with a file-browser keyboard model

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -74,16 +74,21 @@ merged theme (`ThemeProvider`; `SelectThemeProvider` is an alias) and a
 - **Menu/MenuBar, ContextMenu** — DONE: built on `useAnchor`, with
   separators, disabled items, shortcuts, checkmarks, nested submenus and
   full keyboard navigation; `examples/menu.jsx` rewritten on them
+- **Tree — DONE.** Disclosure rows with the keyboard model a file browser
+  has: Up/Down over the visible rows, Right/Left to open and step in or
+  close and step out, type-ahead by prefix, and a twisty that opens a
+  branch without moving the selection. Branch-ness is `children` being an
+  array, so an empty one is a directory whose contents are not loaded yet
 - **Tabs / SplitPane — DONE.** The two containers an application window is
   built from: `Tabs` (one panel at a time, roving focus, horizontal or
   vertical, lazy panels) and `SplitPane` (a draggable divider, keyboard
   resizable, clamped against the live container size). `examples/app.jsx`
   hosts `form`, `widgets` and `tasks` as tabs by importing the panel each
   now exports — new controls get demonstrated there rather than in yet
-  another example. Still missing, roughly in order: Tree, horizontal
-  scrolling in `<scrollview>` (which Table needs first), Table with
-  virtualization, undo/redo in the text controls, a generic Popover, and a
-  file open/save dialog
+  another example. Still missing, roughly in order: horizontal scrolling in
+  `<scrollview>` (which Table needs first), Table with virtualization,
+  undo/redo in the text controls, a generic Popover, and a file open/save
+  dialog
 - **`Select`/menu keyboard — DONE.** Arrows, Home/End, PageUp/PageDown,
   type-ahead, submenus. Keyboard navigation
   is done (#34: Up/Down/Home/End/Enter/Escape, shared pointer+keyboard

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Widget **components** (plain React on top of the primitives, themable via
 `Slider`, `ProgressBar`, `Select`, `Tooltip`, `MenuBar`/`ContextMenu`,
 `Dialog` — a modal built on `<popup trapFocus>`, which traps Tab and
 restores focus when it closes — plus the two containers an application
-window is built from: `Tabs` and `SplitPane`. See
+window is built from: `Tabs`, `Tree` and `SplitPane`. See
 [docs/components.md](docs/components.md).
 
 ### 3D

--- a/docs/components.md
+++ b/docs/components.md
@@ -335,6 +335,43 @@ and wrap, Home/End jump to the ends, disabled tabs are skipped. Arrows
 select as they move, the way a desktop notebook behaves; `manual` splits
 focus from selection, which is what you want when a panel is expensive.
 
+## `Tree`
+
+A disclosure tree: file browsers, outline panes, property inspectors.
+
+```jsx
+<Tree
+  items={[{ id: 'src', label: 'src', children: [{ id: 'a', label: 'a.js' }] }]}
+  defaultExpanded={['src']}
+  onSelect={(id, item) => open(item)}
+/>
+```
+
+| prop                           |                                                          |
+| ------------------------------ | -------------------------------------------------------- |
+| `items`                        | `{ id, label, children, disabled }[]`                    |
+| `expanded` / `defaultExpanded` | ids of open branches; controlled with `onExpandedChange` |
+| `selected` / `defaultSelected` | selected id; controlled with `onSelect`                  |
+| `onSelect(id, item)`           | the selection moved                                      |
+| `onActivate(id, item)`         | Enter or Space on a row                                  |
+
+An item with a `children` **array** is a branch, even when the array is
+empty — that is how an unexpanded directory shows a twisty before its
+contents are known. Load lazily by handing back `children: []` and filling
+it in when `onExpandedChange` fires.
+
+The twisty is its own hit target: clicking it opens a branch **without**
+moving the selection, the way a file browser lets you peek inside a folder
+you have not chosen. Clicking the label selects.
+
+The tree is a single tab stop. Up/Down walk the rows that are currently
+visible, skipping disabled ones. Right expands a branch and, if it is
+already open, steps into it; Left collapses it and, if it is already closed,
+steps out to the parent. Home/End jump to the ends, Enter and Space
+activate, and typing letters jumps by prefix — the same type-ahead `Select`
+and the menus use, so a quick "bu" refines rather than jumping twice. The
+tree scrolls the focused row into view as you move.
+
 ## `SplitPane`
 
 Two panes with a divider you can drag.

--- a/examples/app.jsx
+++ b/examples/app.jsx
@@ -10,7 +10,13 @@
 // own with `npm run examples:form`.
 // Run with: npm run examples:app  (needs an X server / DISPLAY)
 import React, { useState } from 'react';
-import { createRoot, createStyles, SplitPane, Tabs } from '../src/index.js';
+import {
+  createRoot,
+  createStyles,
+  SplitPane,
+  Tabs,
+  Tree,
+} from '../src/index.js';
 import { FormPanel } from './form.jsx';
 import { WidgetsPanel } from './widgets.jsx';
 import { TasksPanel } from './tasks.jsx';
@@ -57,6 +63,8 @@ const s = createStyles({
     backgroundColor: '$panel',
   },
   statusText: { fontSize: 11, color: '$dim' },
+  treePanel: { flexGrow: 1, minHeight: 0, padding: 12, gap: 8 },
+  treeHint: { fontSize: 11, color: '$dim', flexShrink: 0 },
 });
 
 // The strip lives in the sidebar and the panel on the other side of the
@@ -67,13 +75,66 @@ const SECTIONS = [
   { id: 'form', label: 'Form' },
   { id: 'widgets', label: 'Widgets' },
   { id: 'tasks', label: 'Tasks' },
-  { id: 'soon', label: 'Tree (soon)', disabled: true },
+  { id: 'tree', label: 'Tree' },
 ];
+
+// A stand-in project, enough to show nesting, a lazy-looking empty branch
+// and a row that cannot be opened.
+const FILES = [
+  {
+    id: 'src',
+    label: 'src',
+    children: [
+      { id: 'index', label: 'index.js' },
+      { id: 'nodes', label: 'nodes.js' },
+      {
+        id: 'components',
+        label: 'components',
+        children: [
+          { id: 'button', label: 'Button.js' },
+          { id: 'tabs', label: 'Tabs.js' },
+          { id: 'tree', label: 'Tree.js' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'docs',
+    label: 'docs',
+    children: [
+      { id: 'elements', label: 'elements.md' },
+      { id: 'styling', label: 'styling.md' },
+      { id: 'img', label: 'img', children: [] },
+    ],
+  },
+  { id: 'readme', label: 'README.md' },
+  { id: 'lock', label: 'package-lock.json', disabled: true },
+];
+
+function TreePanel() {
+  const [picked, setPicked] = useState('nodes');
+  return (
+    <box style={s.treePanel}>
+      <text style={s.treeHint}>
+        Arrows to walk, Right/Left to open and close, type a name
+      </text>
+      <Tree
+        items={FILES}
+        defaultExpanded={['src', 'docs']}
+        selected={picked}
+        onSelect={setPicked}
+        style={{ flexGrow: 1 }}
+      />
+      <text style={s.treeHint}>selected: {picked}</text>
+    </box>
+  );
+}
 
 const PANELS = {
   form: () => <FormPanel />,
   widgets: () => <WidgetsPanel />,
   tasks: () => <TasksPanel />,
+  tree: () => <TreePanel />,
 };
 
 function App() {

--- a/src/components/Tree.js
+++ b/src/components/Tree.js
@@ -1,0 +1,284 @@
+// Widget components built purely on the host primitives — no reconciler
+// support needed. Plain createElement (no JSX) so the library stays
+// build-step-free for consumers.
+
+import React, { useMemo, useRef, useState } from 'react';
+import { createStyles } from '../styles.js';
+import { labelContent, useTheme } from './theme.js';
+import { typeAheadChar, useTypeAhead } from './typeahead.js';
+import {
+  XK_DOWN,
+  XK_END,
+  XK_HOME,
+  XK_LEFT,
+  XK_RETURN,
+  XK_RIGHT,
+  XK_UP,
+} from './keys.js';
+
+const h = React.createElement;
+
+const INDENT = 14;
+const TWISTY = 12;
+const ROW_HEIGHT = 22;
+
+const s = createStyles({
+  root: { flexGrow: 1, minHeight: 0 },
+  row: {
+    height: ROW_HEIGHT,
+    flexShrink: 0,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingRight: 8,
+    cursor: 'pointer',
+    transition: { backgroundColor: 80 },
+  },
+  twisty: {
+    width: TWISTY,
+    height: TWISTY,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  glyph: { width: 7, height: 7 },
+});
+
+/** Rows the tree can show right now: the roots, plus the children of every
+ * expanded branch, in the order they are drawn. Depth comes with them so a
+ * row only has to indent itself. */
+function visibleRows(items, expanded, depth = 0, out = [], parent = null) {
+  for (const item of items) {
+    const branch = Array.isArray(item.children);
+    out.push({ item, depth, parent, branch });
+    if (branch && expanded.has(item.id)) {
+      visibleRows(item.children, expanded, depth + 1, out, item);
+    }
+  }
+  return out;
+}
+
+/**
+ * <Tree items expanded selected/> — a disclosure tree: file browsers,
+ * outline panes, property inspectors.
+ *
+ *   <Tree items={[{ id: 'src', label: 'src', children: [...] }]} />
+ *
+ * Each item is `{ id, label, children, disabled }`. An item with a
+ * `children` array is a branch, even when the array is empty — that is how
+ * an unexpanded directory shows a twisty before its contents are known.
+ * Load lazily by handing back `children: []` and filling it in from
+ * `onExpandedChange`.
+ *
+ * Expansion and selection are each controlled (`expanded` + `onExpandedChange`,
+ * `selected` + `onSelect`) or uncontrolled (`defaultExpanded`,
+ * `defaultSelected`).
+ *
+ * The tree is a single tab stop. Up/Down walk the rows that are visible,
+ * Right expands a branch and then steps into it, Left collapses and then
+ * steps out to the parent, Home/End jump to the ends, Enter and Space
+ * activate, and typing letters jumps to a matching row — the same
+ * type-ahead `Select` and the menus use.
+ */
+export function Tree({
+  items = [],
+  expanded,
+  defaultExpanded = [],
+  onExpandedChange,
+  selected,
+  defaultSelected,
+  onSelect,
+  onActivate,
+  style,
+  ...boxProps
+}) {
+  const theme = useTheme();
+  const [ownExpanded, setOwnExpanded] = useState(
+    () => new Set(defaultExpanded),
+  );
+  const [ownSelected, setOwnSelected] = useState(defaultSelected);
+  const typeAhead = useTypeAhead();
+  const scroller = useRef(null);
+  const rowRefs = useRef(new Map());
+
+  const openSet = useMemo(
+    () => (expanded ? new Set(expanded) : ownExpanded),
+    [expanded, ownExpanded],
+  );
+  const current = selected ?? ownSelected;
+  const rows = useMemo(() => visibleRows(items, openSet), [items, openSet]);
+
+  // Held-down or fast keys arrive in a burst, and every handler in that
+  // burst sees the render they started from — so what is open and what is
+  // selected are mirrored here and updated the moment they change, or three
+  // Downs in a row all step off the same starting point.
+  const openRef = useRef(openSet);
+  openRef.current = openSet;
+  const currentRef = useRef(current);
+  currentRef.current = current;
+
+  const setExpanded = (next) => {
+    openRef.current = next;
+    if (expanded === undefined) setOwnExpanded(next);
+    onExpandedChange?.([...next]);
+  };
+
+  const toggle = (id, open) => {
+    const next = new Set(openRef.current);
+    if (open ?? !next.has(id)) next.add(id);
+    else next.delete(id);
+    setExpanded(next);
+  };
+
+  const goTo = (row) => {
+    if (!row) return;
+    const id = row.item.id;
+    currentRef.current = id;
+    if (selected === undefined) setOwnSelected(id);
+    onSelect?.(id, row.item);
+    const node = rowRefs.current.get(id);
+    node?.focus?.();
+    if (node) scroller.current?.scrollIntoView?.(node);
+  };
+
+  const onKeyDown = (ev) => {
+    // recomputed per keystroke rather than taken from the render, for the
+    // same reason
+    const rows = visibleRows(items, openRef.current);
+    const index = rows.findIndex((r) => r.item.id === currentRef.current);
+    const step = (delta) => {
+      for (let i = index + delta; i >= 0 && i < rows.length; i += delta) {
+        if (!rows[i].item.disabled) return rows[i];
+      }
+      return null;
+    };
+    const row = rows[index];
+    switch (ev.keysym) {
+      case XK_UP:
+        goTo(step(-1));
+        return;
+      case XK_DOWN:
+        goTo(step(1));
+        return;
+      case XK_RIGHT:
+        // open it, then walk into it — one key does both, in order
+        if (row?.branch && !openRef.current.has(row.item.id)) {
+          toggle(row.item.id, true);
+        } else if (row?.branch) goTo(step(1));
+        return;
+      case XK_LEFT:
+        if (row?.branch && openRef.current.has(row.item.id)) {
+          toggle(row.item.id, false);
+        } else if (row?.parent) {
+          goTo(rows.find((r) => r.item.id === row.parent.id));
+        }
+        return;
+      case XK_HOME:
+        goTo(rows.find((r) => !r.item.disabled));
+        return;
+      case XK_END:
+        goTo([...rows].reverse().find((r) => !r.item.disabled));
+        return;
+      default:
+    }
+    if (ev.keysym === XK_RETURN || ev.codepoint === 32) {
+      if (row?.branch) toggle(row.item.id);
+      if (row) onActivate?.(row.item.id, row.item);
+      return;
+    }
+    const char = typeAheadChar(ev);
+    if (!char) return;
+    const found = typeAhead(
+      char,
+      rows,
+      index,
+      (r) => r.item.label,
+      (r) => !r.item.disabled,
+    );
+    if (found >= 0) goTo(rows[found]);
+  };
+
+  return h(
+    'scrollview',
+    {
+      theme,
+      ref: scroller,
+      ...boxProps,
+      style: [s.root, style],
+      onKeyDown,
+    },
+    rows.map(({ item, depth, branch }) =>
+      h(
+        'box',
+        {
+          key: item.id,
+          ref: (node) => {
+            if (node) rowRefs.current.set(item.id, node);
+            else rowRefs.current.delete(item.id);
+          },
+          focusable: !item.disabled,
+          tabIndex: item.id === current ? 0 : -1,
+          disabled: item.disabled,
+          onClick: () => !item.disabled && goTo({ item, depth, branch }),
+          style: [
+            s.row,
+            { paddingLeft: 4 + depth * INDENT },
+            {
+              backgroundColor:
+                item.id === current ? theme.hoverBackground : 'transparent',
+            },
+            !item.disabled && {
+              ':hover': {
+                backgroundColor:
+                  item.id === current
+                    ? theme.hoverBackground
+                    : theme.surfaceHover,
+              },
+            },
+          ],
+        },
+        h(
+          'box',
+          {
+            style: s.twisty,
+            // the twisty is its own hit target: clicking it opens the
+            // branch without moving the selection, the way a file browser
+            // lets you peek inside a folder you have not chosen
+            onClick: branch
+              ? (ev) => {
+                  ev.stopPropagation();
+                  toggle(item.id);
+                }
+              : undefined,
+          },
+          branch &&
+            h('canvas', {
+              style: s.glyph,
+              onDraw: (ctx, { width: w, height: hgt }) => {
+                ctx.fillStyle =
+                  item.id === current ? theme.hoverText : theme.dim;
+                ctx.beginPath();
+                if (openSet.has(item.id)) {
+                  ctx.moveTo(0, 0);
+                  ctx.lineTo(w, 0);
+                  ctx.lineTo(w / 2, hgt);
+                } else {
+                  ctx.moveTo(0, 0);
+                  ctx.lineTo(w, hgt / 2);
+                  ctx.lineTo(0, hgt);
+                }
+                ctx.closePath();
+                ctx.fill();
+              },
+            }),
+        ),
+        labelContent(item.label, {
+          color: item.disabled
+            ? theme.dim
+            : item.id === current
+              ? theme.hoverText
+              : theme.text,
+        }),
+      ),
+    ),
+  );
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -15,5 +15,6 @@ export { Tooltip } from './Tooltip.js';
 export { ContextMenu, MenuBar } from './Menu.js';
 export { Select } from './Select.js';
 export { Tabs } from './Tabs.js';
+export { Tree } from './Tree.js';
 export { SplitPane } from './SplitPane.js';
 export { Canvas3D } from './Canvas3D.js';

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ export { createStyles, flattenStyle } from './styles.js';
 export {
   Select,
   Tabs,
+  Tree,
   SplitPane,
   SelectThemeProvider,
   ThemeProvider,

--- a/test/tree.test.js
+++ b/test/tree.test.js
@@ -1,0 +1,321 @@
+// Tree: disclosure rows with keyboard navigation, the control a file
+// browser or outline pane is built from.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import ReactX11, { Tree } from '../src/index.js';
+import { createMockApp } from './helpers/mock-app.js';
+import { TYPE_AHEAD_TIMEOUT } from '../src/components/typeahead.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+const settle = async () => {
+  await tick();
+  await tick();
+};
+const root = (app) => app.windows[0]._reactX11Node;
+
+const XK = {
+  HOME: 0xff50,
+  LEFT: 0xff51,
+  UP: 0xff52,
+  RIGHT: 0xff53,
+  DOWN: 0xff54,
+  END: 0xff57,
+  RETURN: 0xff0d,
+};
+
+function press(app, keysym, key) {
+  const codepoint = key ? key.codePointAt(0) : undefined;
+  const keycode = ((keysym ?? codepoint) % 248) + 8;
+  app.X.keycode2keysyms[keycode] = [keysym ?? codepoint];
+  app.windows[0].emit('keydown', { keycode, codepoint, buttons: 0 });
+}
+
+const find = (node, pred) =>
+  pred(node)
+    ? node
+    : node.children.reduce(
+        (a, c) => a || (c.isWindow ? null : find(c, pred)),
+        null,
+      );
+
+/** Every row label the tree is showing, in order. */
+const labels = (app) => {
+  const out = [];
+  const walk = (n) => {
+    if (n.kind === 'text') out.push(String(n.props.children));
+    n.children.forEach((c) => !c.isWindow && walk(c));
+  };
+  walk(root(app));
+  return out;
+};
+
+const rowFor = (app, text) =>
+  find(root(app), (n) => n.kind === 'text' && String(n.props.children) === text)
+    ?.parent;
+
+const click = (app, node, at) => {
+  const x = at?.x ?? node.abs.x + node.abs.width / 2;
+  const y = at?.y ?? node.abs.y + node.abs.height / 2;
+  app.windows[0].emit('mousedown', { x, y, keycode: 1 });
+  app.windows[0].emit('mouseup', { x, y, keycode: 1 });
+};
+
+const ITEMS = [
+  {
+    id: 'src',
+    label: 'src',
+    children: [
+      { id: 'nodes', label: 'nodes.js' },
+      {
+        id: 'components',
+        label: 'components',
+        children: [
+          { id: 'button', label: 'Button.js' },
+          { id: 'tree', label: 'Tree.js' },
+        ],
+      },
+    ],
+  },
+  { id: 'readme', label: 'README.md' },
+  { id: 'locked', label: 'locked.bin', disabled: true },
+];
+
+function mount(props) {
+  const app = createMockApp();
+  ReactX11.render(
+    h(
+      'window',
+      { width: 260, height: 200 },
+      h(Tree, { items: ITEMS, ...props }),
+    ),
+    null,
+    app,
+  );
+  return app;
+}
+
+test('only the roots show until a branch is expanded', async () => {
+  const app = mount();
+  await settle();
+  assert.deepStrictEqual(labels(app), ['src', 'README.md', 'locked.bin']);
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('defaultExpanded opens branches, nested ones included', async () => {
+  const app = mount({ defaultExpanded: ['src', 'components'] });
+  await settle();
+  assert.deepStrictEqual(labels(app), [
+    'src',
+    'nodes.js',
+    'components',
+    'Button.js',
+    'Tree.js',
+    'README.md',
+    'locked.bin',
+  ]);
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('clicking the twisty expands without selecting the row', async () => {
+  const picked = [];
+  const app = mount({ onSelect: (id) => picked.push(id) });
+  await settle();
+
+  const row = rowFor(app, 'src');
+  click(app, row, { x: row.abs.x + 8, y: row.abs.y + row.abs.height / 2 });
+  await settle();
+
+  assert.ok(labels(app).includes('nodes.js'), 'the branch opened');
+  assert.deepStrictEqual(picked, [], 'and the selection did not move');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('clicking the label selects the row', async () => {
+  const picked = [];
+  const app = mount({ onSelect: (id) => picked.push(id) });
+  await settle();
+
+  click(app, rowFor(app, 'README.md'));
+  await settle();
+  assert.deepStrictEqual(picked, ['readme']);
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('Right opens a branch, then walks into it; Left closes, then walks out', async () => {
+  const picked = [];
+  const app = mount({
+    defaultSelected: 'src',
+    onSelect: (id) => picked.push(id),
+  });
+  await settle();
+  rowFor(app, 'src').focus();
+
+  press(app, XK.RIGHT);
+  await settle();
+  assert.ok(labels(app).includes('nodes.js'), 'first Right expands');
+  assert.deepStrictEqual(picked, [], 'and stays put');
+
+  press(app, XK.RIGHT);
+  await settle();
+  assert.deepStrictEqual(picked, ['nodes'], 'second Right steps inside');
+
+  press(app, XK.LEFT);
+  await settle();
+  assert.deepStrictEqual(
+    picked,
+    ['nodes', 'src'],
+    'Left on a leaf goes out to the parent',
+  );
+
+  press(app, XK.LEFT);
+  await settle();
+  assert.ok(!labels(app).includes('nodes.js'), 'and Left again collapses it');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('Up/Down walk the visible rows and skip disabled ones', async () => {
+  const picked = [];
+  const app = mount({
+    defaultExpanded: ['src'],
+    defaultSelected: 'src',
+    onSelect: (id) => picked.push(id),
+  });
+  await settle();
+  rowFor(app, 'src').focus();
+
+  press(app, XK.DOWN);
+  press(app, XK.DOWN);
+  press(app, XK.DOWN);
+  await settle();
+  assert.deepStrictEqual(picked, ['nodes', 'components', 'readme']);
+
+  press(app, XK.DOWN);
+  await settle();
+  assert.deepStrictEqual(
+    picked.at(-1),
+    'readme',
+    'the disabled row is not landed on, and there is nothing past it',
+  );
+
+  press(app, XK.HOME);
+  await settle();
+  assert.strictEqual(picked.at(-1), 'src');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('type-ahead jumps to a row by prefix', async () => {
+  const picked = [];
+  const app = mount({
+    defaultExpanded: ['src', 'components'],
+    defaultSelected: 'src',
+    onSelect: (id) => picked.push(id),
+  });
+  await settle();
+  rowFor(app, 'src').focus();
+
+  press(app, null, 'B');
+  await settle();
+  assert.strictEqual(picked.at(-1), 'button', 'B found Button.js');
+
+  // keystrokes inside the timeout accumulate into one query, so this is
+  // "bu" refining onto the row it is already on rather than a fresh jump
+  press(app, null, 'u');
+  await settle();
+  assert.strictEqual(picked.at(-1), 'button');
+
+  // past the timeout it starts a new query
+  await new Promise((resolve) => setTimeout(resolve, TYPE_AHEAD_TIMEOUT + 60));
+  press(app, null, 'R');
+  await settle();
+  assert.strictEqual(picked.at(-1), 'readme');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('Enter toggles a branch and reports the activation', async () => {
+  const activated = [];
+  const app = mount({
+    defaultSelected: 'src',
+    onActivate: (id) => activated.push(id),
+  });
+  await settle();
+  rowFor(app, 'src').focus();
+
+  press(app, XK.RETURN);
+  await settle();
+  assert.ok(labels(app).includes('nodes.js'), 'Enter opened it');
+  assert.deepStrictEqual(activated, ['src']);
+
+  press(app, XK.RETURN);
+  await settle();
+  assert.ok(!labels(app).includes('nodes.js'), 'and Enter again closed it');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('controlled expansion reports changes and follows the prop', async () => {
+  const app = createMockApp();
+  const changes = [];
+  const render = (open) =>
+    ReactX11.render(
+      h(
+        'window',
+        { width: 260, height: 200 },
+        h(Tree, {
+          items: ITEMS,
+          expanded: open,
+          onExpandedChange: (next) => changes.push(next),
+        }),
+      ),
+      null,
+      app,
+    );
+
+  render([]);
+  await settle();
+  assert.ok(!labels(app).includes('nodes.js'));
+
+  const row = rowFor(app, 'src');
+  click(app, row, { x: row.abs.x + 8, y: row.abs.y + row.abs.height / 2 });
+  await settle();
+  assert.deepStrictEqual(changes, [['src']], 'it asked, rather than deciding');
+  assert.ok(!labels(app).includes('nodes.js'), 'and did not open itself');
+
+  render(['src']);
+  await settle();
+  assert.ok(labels(app).includes('nodes.js'), 'the prop opens it');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('a branch with no children still shows a twisty', async () => {
+  const app = createMockApp();
+  ReactX11.render(
+    h(
+      'window',
+      { width: 260, height: 200 },
+      h(Tree, { items: [{ id: 'empty', label: 'empty', children: [] }] }),
+    ),
+    null,
+    app,
+  );
+  await settle();
+
+  // an unexpanded directory has to look openable before its contents are
+  // known — that is how lazy loading is signalled
+  const row = rowFor(app, 'empty');
+  assert.ok(
+    find(row, (n) => n.kind === 'canvas'),
+    'the twisty is drawn even with an empty children array',
+  );
+
+  ReactX11.unmountComponentAtNode(app);
+});


### PR DESCRIPTION
Next on the list after Tabs and SplitPane, and it fills in the `Tree (soon)` tab #75 left disabled.

```jsx
<Tree
  items={[{ id: 'src', label: 'src', children: [{ id: 'a', label: 'a.js' }] }]}
  defaultExpanded={['src']}
  onSelect={(id, item) => open(item)}
/>
```

![tree](https://github.com/user-attachments/assets/c324cbdf-c66a-4d02-a5d4-f75b51a3e531)

## The parts that make it a tree rather than a list

**Branch-ness is `children` being an array** — an empty one is still a branch. That is how a directory shows a twisty before anyone knows what is in it; hand back `children: []` and fill it in when `onExpandedChange` fires to load lazily.

**Right and Left each do two things in order.** Right expands a collapsed branch, and steps into it if it is already open; Left collapses an open one, and steps out to the parent if it is already closed. That pairing is what makes a tree navigable without the mouse, and it is the part a list-shaped implementation gets wrong.

**The twisty is its own hit target.** Clicking it opens a branch *without* moving the selection — the way a file browser lets you peek inside a folder you have not chosen. Clicking the label selects. In the screenshot, `components` was opened by its twisty while the selection stayed on `nodes.js`.

Type-ahead comes from the same `useTypeAhead` that `Select` and the menus use, so a quick "bu" refines onto the row rather than jumping twice, and repeating a letter cycles.

## The bug worth knowing about

Expansion and selection are mirrored in refs, and the visible-row list is recomputed per keystroke rather than taken from the render. A burst of keys — held-down arrows, or fast typing — all arrives before React re-renders, so handlers reading the last rendered value step off the same starting point every time. **Three Downs in a row moved one row** before this. Same class of bug as the SplitPane drag in #75; the tests press three times in a row precisely to catch it.

## Tests

Ten new in `test/tree.test.js`, driving real mouse and key events: roots-only until expanded, `defaultExpanded` including nested branches, twisty-vs-label click behaviour, the Right/Left pairing, Up/Down skipping disabled rows, type-ahead (including that keystrokes inside the timeout accumulate into one query), Enter toggling and reporting, controlled expansion asking rather than deciding, and the empty-children twisty.

`npm test` 168 passing, `npm run lint` clean. Committed screenshots untouched — the showcase is not in the screenshots script.

Next: horizontal scrolling in `<scrollview>`, which Table needs before it can exist.