### PR TITLE
feat: <scrollview> scrolls on both axes

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -85,10 +85,15 @@ merged theme (`ThemeProvider`; `SelectThemeProvider` is an alias) and a
   resizable, clamped against the live container size). `examples/app.jsx`
   hosts `form`, `widgets` and `tasks` as tabs by importing the panel each
   now exports — new controls get demonstrated there rather than in yet
-  another example. Still missing, roughly in order: horizontal scrolling in
-  `<scrollview>` (which Table needs first), Table with virtualization,
-  undo/redo in the text controls, a generic Popover, and a file open/save
-  dialog
+  another example. Still missing, roughly in order: Table with
+  virtualization, undo/redo in the text controls, a generic Popover, and a
+  file open/save dialog
+- **Horizontal scrolling — DONE.** `<scrollview>` scrolls on both axes:
+  `scrollX`/`contentWidth`, a second draggable bar, `scrollTo({x, y})`,
+  horizontal wheel and Shift+wheel, and `scrollIntoView` on both axes. The
+  extent is measured through the subtree the way `scrollWidth` is, so a row
+  stretched to the viewport with overflowing cells — a table — still has
+  something to scroll
 - **`Select`/menu keyboard — DONE.** Arrows, Home/End, PageUp/PageDown,
   type-ahead, submenus. Keyboard navigation
   is done (#34: Up/Down/Home/End/Enter/Escape, shared pointer+keyboard

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -188,9 +188,9 @@ window, valid after layout).
 
 ## `<scrollview>`
 
-A clipped viewport over its (overflowing) children. Wheel events scroll it
-by default; a scrollbar thumb is drawn when content overflows, and the thumb
-can be dragged.
+A clipped viewport over its (overflowing) children, on **both axes**. Wheel
+events scroll it by default; a scrollbar thumb is drawn on each axis that
+overflows, and the thumb can be dragged.
 
 The bar belongs to the scroller, not to the content painted under it — the
 same rule a browser applies — so a press on the thumb never reaches the row
@@ -206,14 +206,30 @@ grows past its own bounds as rows are added and the footer is pushed out of
 view. `flexShrink` defaults to `1` and `minHeight`/`minWidth` to `0` for the
 same reason. Pass any of them explicitly to opt out.
 
-| prop                                                 |                          |
-| ---------------------------------------------------- | ------------------------ |
-| `onScroll({scrollY, contentHeight, viewportHeight})` | after scrolling          |
-| `scrollbar={false}`                                  | hide the drawn scrollbar |
-| `scrollbarColor`                                     | thumb color              |
+| prop                |                                                                                  |
+| ------------------- | -------------------------------------------------------------------------------- |
+| `onScroll(ev)`      | `{scrollX, scrollY, contentWidth, contentHeight, viewportWidth, viewportHeight}` |
+| `scrollbar={false}` | hide the drawn scrollbars                                                        |
+| `scrollbarColor`    | thumb color                                                                      |
 
-**Ref**: the node, plus `scrollTo(y)` / `scrollBy(dy)` /
-`scrollIntoView(node)` and `scrollY` / `contentHeight`.
+**Ref**: the node, plus `scrollTo` / `scrollBy` / `scrollIntoView(node)` and
+`scrollX` / `scrollY` / `contentWidth` / `contentHeight`.
+
+`scrollTo(y)` takes a number for the vertical axis, as it always has;
+`scrollTo({x, y})` moves either, leaving alone whichever you omit.
+`scrollBy` matches. `scrollIntoView(node)` scrolls the minimum amount on
+both axes.
+
+Horizontal content comes from children that will not shrink — a row of
+fixed-width cells, say. The extent is measured **through the subtree**, the
+way `scrollWidth` is in a browser: a row that stretches to the viewport
+while its own cells overflow it still reports something to scroll. Anything
+that clips its own children ends that measurement, since their overflow
+belongs to them.
+
+X sends buttons 6 and 7 for a horizontal wheel; **Shift + vertical wheel**
+scrolls sideways too, for mice and touchpads that have none. When both bars
+show, each stops short of the other's corner.
 
 `scrollIntoView(node)` scrolls the minimum amount that makes a descendant
 node fully visible, and is safe to call from an effect right after that

--- a/src/events.js
+++ b/src/events.js
@@ -235,15 +235,24 @@ export class EventManager {
       const wheel = WHEEL_BUTTONS[native.keycode];
       const target = this._hit(native);
       if (wheel) {
+        const shift = Boolean(native.buttons & 1);
+        // X sends buttons 6/7 for a horizontal wheel; Shift+vertical is the
+        // convention for mice and touchpads that have none
+        const [dx, dy] =
+          shift && wheel[0] === 0 ? [wheel[1], 0] : [wheel[0], wheel[1]];
         const ev = this.dispatch('Wheel', target, native, {
-          deltaX: wheel[0],
-          deltaY: wheel[1],
+          deltaX: dx,
+          deltaY: dy,
         });
         if (!ev.defaultPrevented) {
           // default action: scroll the nearest enclosing <scrollview>
           for (let n = target; n; n = n.parent) {
-            if (n.kind === 'scrollview' || n.kind === 'textarea') {
-              n.scrollBy(ev.deltaY);
+            if (n.kind === 'scrollview') {
+              n.scrollBy({ x: ev.deltaX, y: ev.deltaY });
+              break;
+            }
+            if (n.kind === 'textarea') {
+              n.scrollBy(ev.deltaY); // one axis only: it wraps
               break;
             }
             if (n === this.node) break;

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -957,47 +957,73 @@ const SCROLLBAR_MIN_THUMB = 20;
 // the visible bar is thin; the pointer target is not
 const SCROLLBAR_SLOP = 4;
 
+const clampScroll = (v, max) => Math.min(Math.max(0, v), max);
+
 /**
- * Geometry of a vertical scrollbar, or null when there is nothing to
- * scroll. Shared by `<scrollview>` and `<textarea>` so what is painted and
- * what the pointer hits cannot drift apart.
+ * Geometry of a scrollbar on either axis, or null when there is nothing to
+ * scroll along it. Shared by `<scrollview>` and `<textarea>` so what is
+ * painted and what the pointer hits cannot drift apart — and written once
+ * for both axes so the two cannot drift from each other either.
+ *
+ * `viewport`/`content`/`scroll` are along the axis; `across`/`crossSize`
+ * place the bar on the other one. `shorten` keeps the two bars out of each
+ * other's corner when both are showing.
  */
 function scrollbarGeometry({
-  x,
-  y,
-  width,
-  height,
-  scroll,
+  axis = 'y',
+  start,
+  viewport,
   content,
+  across: crossStart0,
+  crossSize,
+  scroll,
   inset = 0,
+  shorten = 0,
 }) {
-  if (height <= 0 || !(content > height)) return null;
-  const thumbHeight = Math.max(
+  const length = viewport - shorten;
+  if (length <= 0 || !(content > viewport)) return null;
+  const thumbLength = Math.max(
     SCROLLBAR_MIN_THUMB,
-    (height * height) / content,
+    (length * length) / content,
   );
-  const range = content - height;
-  const travel = height - thumbHeight;
+  const range = content - viewport;
+  const travel = Math.max(0, length - thumbLength);
+  const thumbStart = start + (range > 0 ? (scroll / range) * travel : 0);
+  const crossStart = crossStart0 + crossSize - SCROLLBAR_WIDTH - inset;
   return {
-    x: x + width - SCROLLBAR_WIDTH - inset,
-    width: SCROLLBAR_WIDTH,
-    trackY: y,
-    trackHeight: height,
-    thumbY: y + (range > 0 ? (scroll / range) * travel : 0),
-    thumbHeight,
+    axis,
+    trackStart: start,
+    trackLength: length,
+    thumbStart,
+    thumbLength,
+    crossStart,
     range,
     travel,
+    // the thumb as a rect, for painting
+    x: axis === 'x' ? thumbStart : crossStart,
+    y: axis === 'x' ? crossStart : thumbStart,
+    width: axis === 'x' ? thumbLength : SCROLLBAR_WIDTH,
+    height: axis === 'x' ? SCROLLBAR_WIDTH : thumbLength,
   };
 }
+
+/** The coordinate along a bar's own axis, and across it. */
+const along = (bar, x, y) => (bar.axis === 'x' ? x : y);
+const across = (bar, x, y) => (bar.axis === 'x' ? y : x);
 
 /** Is this point on the bar (with slop), and if so, on the thumb? */
 function scrollbarHit(bar, x, y) {
   if (!bar) return null;
-  if (x < bar.x - SCROLLBAR_SLOP || x > bar.x + bar.width + SCROLLBAR_SLOP) {
+  const c = across(bar, x, y);
+  if (
+    c < bar.crossStart - SCROLLBAR_SLOP ||
+    c > bar.crossStart + SCROLLBAR_WIDTH + SCROLLBAR_SLOP
+  ) {
     return null;
   }
-  if (y < bar.trackY || y > bar.trackY + bar.trackHeight) return null;
-  return y >= bar.thumbY && y <= bar.thumbY + bar.thumbHeight
+  const a = along(bar, x, y);
+  if (a < bar.trackStart || a > bar.trackStart + bar.trackLength) return null;
+  return a >= bar.thumbStart && a <= bar.thumbStart + bar.thumbLength
     ? 'thumb'
     : 'track';
 }
@@ -1006,9 +1032,9 @@ function paintScrollbarThumb(ctx, bar, color) {
   ctx.fillStyle = color || 'rgba(0, 0, 0, 0.25)';
   ctx.beginPath();
   if (typeof ctx.roundRect === 'function') {
-    ctx.roundRect(bar.x, bar.thumbY, bar.width, bar.thumbHeight, 3);
+    ctx.roundRect(bar.x, bar.y, bar.width, bar.height, 3);
   } else {
-    ctx.rect(bar.x, bar.thumbY, bar.width, bar.thumbHeight);
+    ctx.rect(bar.x, bar.y, bar.width, bar.height);
   }
   ctx.fill();
 }
@@ -1023,7 +1049,9 @@ export class ScrollViewNode extends Node {
   constructor(props, app) {
     super('scrollview', props, app);
     this.scrollY = 0;
+    this.scrollX = 0;
     this.contentHeight = 0;
+    this.contentWidth = 0;
     // these defaults fill in for style the author did not set, so they read
     // the resolved style, not the props
     const style = this.style;
@@ -1065,44 +1093,91 @@ export class ScrollViewNode extends Node {
       width: this.yoga.getComputedWidth(),
       height: this.yoga.getComputedHeight(),
     };
-    let bottom = 0;
-    for (const child of this.children) {
-      if (child.yoga && !child.isWindow) {
-        bottom = Math.max(
-          bottom,
-          child.yoga.getComputedTop() + child.yoga.getComputedHeight(),
-        );
-      }
-    }
+    const { right, bottom } = this._measureContent();
     this.contentHeight =
       bottom + this.yoga.getComputedPadding(Yoga.EDGE_BOTTOM);
+    this.contentWidth = right + this.yoga.getComputedPadding(Yoga.EDGE_RIGHT);
     this._resolveScrollIntoView();
-    this.scrollY = Math.min(
-      Math.max(0, this.scrollY),
-      Math.max(0, this.contentHeight - this.abs.height),
-    );
+    this.scrollY = Math.min(Math.max(0, this.scrollY), this._maxScroll('y'));
+    this.scrollX = Math.min(Math.max(0, this.scrollX), this._maxScroll('x'));
     for (const child of this.children) {
       if (!child.isWindow) {
-        child.absolutize(this.abs.x, this.abs.y - this.scrollY);
+        child.absolutize(this.abs.x - this.scrollX, this.abs.y - this.scrollY);
       }
     }
   }
 
-  scrollTo(y) {
-    const max = Math.max(0, this.contentHeight - this.abs.height);
-    const next = Math.min(Math.max(0, y), max);
-    if (next === this.scrollY) return;
-    this.scrollY = next;
+  /**
+   * How far the content actually reaches, measured through the subtree
+   * rather than off the direct children. A row that stretches to the
+   * viewport while its own cells overflow it — a table, in other words —
+   * reports the viewport width at the top level and says nothing about the
+   * cells, so a shallow measurement would find nothing to scroll. This is
+   * what `scrollWidth`/`scrollHeight` mean in a browser.
+   *
+   * Anything that clips its own children ends the walk: their overflow is
+   * that node's business, not ours.
+   */
+  _measureContent() {
+    let right = 0;
+    let bottom = 0;
+    const walk = (node, dx, dy) => {
+      for (const child of node.children) {
+        if (child.isWindow || !child.yoga || child.hidden) continue;
+        const x = dx + child.yoga.getComputedLeft();
+        const y = dy + child.yoga.getComputedTop();
+        right = Math.max(right, x + child.yoga.getComputedWidth());
+        bottom = Math.max(bottom, y + child.yoga.getComputedHeight());
+        if (!child.clipsChildren()) walk(child, x, y);
+      }
+    };
+    walk(this, 0, 0);
+    return { right, bottom };
+  }
+
+  _maxScroll(axis) {
+    return axis === 'x'
+      ? Math.max(0, this.contentWidth - this.abs.width)
+      : Math.max(0, this.contentHeight - this.abs.height);
+  }
+
+  /**
+   * `scrollTo(y)` scrolls vertically, as it always has; `scrollTo({x, y})`
+   * moves either axis, leaving out whichever is omitted.
+   */
+  scrollTo(to) {
+    const want = typeof to === 'number' ? { y: to } : { x: to?.x, y: to?.y };
+    const next = {
+      x:
+        want.x == null
+          ? this.scrollX
+          : clampScroll(want.x, this._maxScroll('x')),
+      y:
+        want.y == null
+          ? this.scrollY
+          : clampScroll(want.y, this._maxScroll('y')),
+    };
+    if (next.x === this.scrollX && next.y === this.scrollY) return;
+    this.scrollX = next.x;
+    this.scrollY = next.y;
     this.props.onScroll?.({
-      scrollY: next,
+      scrollX: next.x,
+      scrollY: next.y,
+      contentWidth: this.contentWidth,
       contentHeight: this.contentHeight,
+      viewportWidth: this.abs.width,
       viewportHeight: this.abs.height,
     });
     this.root?.invalidate(true);
   }
 
-  scrollBy(dy) {
-    this.scrollTo(this.scrollY + dy);
+  /** `scrollBy(dy)`, or `scrollBy({x, y})` for either axis. */
+  scrollBy(by) {
+    if (typeof by === 'number') return this.scrollTo(this.scrollY + by);
+    this.scrollTo({
+      x: by?.x == null ? undefined : this.scrollX + by.x,
+      y: by?.y == null ? undefined : this.scrollY + by.y,
+    });
   }
 
   /**
@@ -1127,37 +1202,56 @@ export class ScrollViewNode extends Node {
     // offset of the target within our content box, summed up the chain so
     // targets nested below a direct child work too
     let top = 0;
+    let left = 0;
     for (let n = target; n && n !== this; n = n.parent) {
       if (!n.yoga) return; // not (or no longer) inside this scrollview
       top += n.yoga.getComputedTop();
+      left += n.yoga.getComputedLeft();
       if (!n.parent) return;
     }
     const bottom = top + target.yoga.getComputedHeight();
-    const viewport = this.abs.height;
-    if (bottom > this.scrollY + viewport) this.scrollY = bottom - viewport;
+    const rightEdge = left + target.yoga.getComputedWidth();
+    if (bottom > this.scrollY + this.abs.height) {
+      this.scrollY = bottom - this.abs.height;
+    }
     if (top < this.scrollY) this.scrollY = top;
+    if (rightEdge > this.scrollX + this.abs.width) {
+      this.scrollX = rightEdge - this.abs.width;
+    }
+    if (left < this.scrollX) this.scrollX = left;
   }
 
   paint(ctx) {
     super.paint(ctx);
-    const bar = this._scrollbar();
-    if (bar) {
+    for (const bar of this._scrollbars()) {
       paintScrollbarThumb(ctx, bar, this.props.scrollbarColor);
     }
   }
 
-  /** null when the bar is switched off or there is nothing to scroll. */
-  _scrollbar() {
+  /** null when the bar is switched off or there is nothing to scroll on
+   * that axis. */
+  _scrollbar(axis = 'y') {
     if (this.props.scrollbar === false) return null;
+    const horizontal = axis === 'x';
+    // when both bars show, each stops short of the other's corner
+    const other = horizontal
+      ? this.contentHeight > this.abs.height
+      : this.contentWidth > this.abs.width;
     return scrollbarGeometry({
-      x: this.abs.x,
-      y: this.abs.y,
-      width: this.abs.width,
-      height: this.abs.height,
-      scroll: this.scrollY,
-      content: this.contentHeight,
+      axis,
+      start: horizontal ? this.abs.x : this.abs.y,
+      viewport: horizontal ? this.abs.width : this.abs.height,
+      content: horizontal ? this.contentWidth : this.contentHeight,
+      across: horizontal ? this.abs.y : this.abs.x,
+      crossSize: horizontal ? this.abs.height : this.abs.width,
+      scroll: horizontal ? this.scrollX : this.scrollY,
       inset: 2,
+      shorten: other ? SCROLLBAR_WIDTH + 2 : 0,
     });
+  }
+
+  _scrollbars() {
+    return [this._scrollbar('y'), this._scrollbar('x')].filter(Boolean);
   }
 
   /**
@@ -1166,30 +1260,38 @@ export class ScrollViewNode extends Node {
    * delivered to whatever child happens to be painted beneath it.
    */
   hitTest(x, y) {
-    if (scrollbarHit(this._scrollbar(), x, y)) return this;
+    for (const bar of this._scrollbars()) {
+      if (scrollbarHit(bar, x, y)) return this;
+    }
     return super.hitTest(x, y);
   }
 
   _defaultMouseDown(ev) {
-    const bar = this._scrollbar();
-    const hit = scrollbarHit(bar, ev.x, ev.y);
-    if (!hit) return;
-    if (hit === 'thumb') {
-      // remember where in the thumb it was grabbed, so it does not jump
-      this._barGrab = ev.y - bar.thumbY;
-      ev.capturePointer();
+    for (const bar of this._scrollbars()) {
+      const hit = scrollbarHit(bar, ev.x, ev.y);
+      if (!hit) continue;
+      const at = along(bar, ev.x, ev.y);
+      if (hit === 'thumb') {
+        // remember where in the thumb it was grabbed, so it does not jump
+        this._barGrab = { axis: bar.axis, offset: at - bar.thumbStart };
+        ev.capturePointer();
+        return;
+      }
+      // a press on the track pages towards it, like PageUp/PageDown
+      const page = bar.axis === 'x' ? this.abs.width : this.abs.height;
+      const delta = at < bar.thumbStart ? -page : page;
+      this.scrollBy(bar.axis === 'x' ? { x: delta } : { y: delta });
       return;
     }
-    // a press on the track pages towards it, like PageUp/PageDown
-    this.scrollBy(ev.y < bar.thumbY ? -this.abs.height : this.abs.height);
   }
 
   _defaultMouseDrag(ev) {
     if (this._barGrab == null) return;
-    const bar = this._scrollbar();
+    const bar = this._scrollbar(this._barGrab.axis);
     if (!bar || bar.travel <= 0) return;
-    const top = ev.y - this._barGrab - bar.trackY;
-    this.scrollTo((top / bar.travel) * bar.range);
+    const at = along(bar, ev.x, ev.y) - this._barGrab.offset - bar.trackStart;
+    const to = (at / bar.travel) * bar.range;
+    this.scrollTo(bar.axis === 'x' ? { x: to } : { y: to });
   }
 
   _defaultMouseUp() {
@@ -1711,12 +1813,12 @@ export class TextAreaNode extends TextInputNode {
     const hit = scrollbarHit(bar, ev.x, ev.y);
     if (!hit) return super._defaultMouseDown(ev);
     if (hit === 'thumb') {
-      this._barGrab = ev.y - bar.thumbY;
+      this._barGrab = ev.y - bar.thumbStart;
       ev.capturePointer();
       return;
     }
     const page = this.contentBox().height;
-    this._scrollTo(this._scrollY + (ev.y < bar.thumbY ? -page : page), bar);
+    this._scrollTo(this._scrollY + (ev.y < bar.thumbStart ? -page : page), bar);
   }
 
   _defaultMouseDrag(ev) {
@@ -1724,7 +1826,7 @@ export class TextAreaNode extends TextInputNode {
     const bar = this._scrollbar();
     if (!bar || bar.travel <= 0) return;
     this._scrollTo(
-      ((ev.y - this._barGrab - bar.trackY) / bar.travel) * bar.range,
+      ((ev.y - this._barGrab - bar.trackStart) / bar.travel) * bar.range,
       bar,
     );
   }
@@ -1897,14 +1999,15 @@ export class TextAreaNode extends TextInputNode {
 
   _scrollbar(layout = this._valueLayout()) {
     if (this.props.scrollbar === false || !layout) return null;
-    const content = this.contentBox();
+    const box = this.contentBox();
     return scrollbarGeometry({
-      x: content.x,
-      y: content.y,
-      width: content.width,
-      height: content.height,
-      scroll: this._scrollY,
+      axis: 'y',
+      start: box.y,
+      viewport: box.height,
       content: layout.height,
+      across: box.x,
+      crossSize: box.width,
+      scroll: this._scrollY,
     });
   }
 

--- a/test/scrollbar.test.js
+++ b/test/scrollbar.test.js
@@ -51,12 +51,12 @@ test('dragging the thumb scrolls in proportion to the pointer', async () => {
   // grab the middle of the thumb and take it half way down the travel
   wnd.emit('mousedown', {
     x: bar.x + 2,
-    y: bar.thumbY + bar.thumbHeight / 2,
+    y: bar.thumbStart + bar.thumbLength / 2,
     keycode: 1,
   });
   wnd.emit('mousemove', {
     x: bar.x + 2,
-    y: bar.thumbY + bar.thumbHeight / 2 + bar.travel / 2,
+    y: bar.thumbStart + bar.thumbLength / 2 + bar.travel / 2,
   });
   assert.ok(
     Math.abs(sv.scrollY - bar.range / 2) < 1,
@@ -81,11 +81,11 @@ test('the drag keeps its grip on the thumb, without jumping', async () => {
   // happen — a jump-to-pointer implementation would scroll here
   wnd.emit('mousedown', {
     x: bar.x + 2,
-    y: bar.thumbY + bar.thumbHeight - 1,
+    y: bar.thumbStart + bar.thumbLength - 1,
     keycode: 1,
   });
   assert.strictEqual(sv.scrollY, 0, 'grabbing the thumb does not move it');
-  wnd.emit('mouseup', { x: bar.x + 2, y: bar.thumbY, keycode: 1 });
+  wnd.emit('mouseup', { x: bar.x + 2, y: bar.thumbStart, keycode: 1 });
 
   ReactX11.unmountComponentAtNode(app);
 });
@@ -98,13 +98,13 @@ test('a press on the track pages towards the pointer', async () => {
 
   wnd.emit('mousedown', {
     x: bar.x + 2,
-    y: bar.trackY + bar.trackHeight - 2,
+    y: bar.trackStart + bar.trackLength - 2,
     keycode: 1,
   });
   assert.strictEqual(sv.scrollY, 100, 'one viewport down');
-  wnd.emit('mouseup', { x: bar.x + 2, y: bar.trackY, keycode: 1 });
+  wnd.emit('mouseup', { x: bar.x + 2, y: bar.trackStart, keycode: 1 });
 
-  wnd.emit('mousedown', { x: bar.x + 2, y: bar.trackY + 1, keycode: 1 });
+  wnd.emit('mousedown', { x: bar.x + 2, y: bar.trackStart + 1, keycode: 1 });
   assert.strictEqual(sv.scrollY, 0, 'and back up again');
 
   ReactX11.unmountComponentAtNode(app);
@@ -138,8 +138,8 @@ test('the bar takes the press even with content painted under it', async () => {
 
   drag(
     app.windows[0],
-    { x: bar.x + 2, y: bar.thumbY + 2 },
-    { x: bar.x + 2, y: bar.thumbY + 2 },
+    { x: bar.x + 2, y: bar.thumbStart + 2 },
+    { x: bar.x + 2, y: bar.thumbStart + 2 },
   );
   assert.deepStrictEqual(clicks, [], 'the row under the bar was not clicked');
 
@@ -166,7 +166,12 @@ test('a <textarea> bar drag scrolls it, and never moves the caret', async () => 
   const area = app.windows[0]._reactX11Node.children[0];
   // the mock has no font metrics, so stand in for the laid-out text: all
   // the bar needs from it is a height
-  area._valueLayout = () => ({ height: 600 });
+  area._valueLayout = () => ({
+    height: 600,
+    // enough of a layout for the bar; painting asks for the caret too
+    caretPosition: () => ({ x: 0, y: 0, height: 12 }),
+    lines: [],
+  });
 
   const bar = area._scrollbar();
   assert.ok(bar, 'text taller than the box gets a thumb');
@@ -174,10 +179,13 @@ test('a <textarea> bar drag scrolls it, and never moves the caret', async () => 
 
   area._defaultMouseDown({
     x: bar.x + 2,
-    y: bar.thumbY + 2,
+    y: bar.thumbStart + 2,
     capturePointer() {},
   });
-  area._defaultMouseDrag({ x: bar.x + 2, y: bar.thumbY + 2 + bar.travel / 2 });
+  area._defaultMouseDrag({
+    x: bar.x + 2,
+    y: bar.thumbStart + 2 + bar.travel / 2,
+  });
   assert.strictEqual(area._caret, caretBefore, 'the caret stayed put');
   assert.ok(
     Math.abs(area._scrollY - bar.range / 2) < 1,
@@ -198,6 +206,178 @@ test('a <textarea> bar drag scrolls it, and never moves the caret', async () => 
   };
   area._defaultMouseDown({ x: content.x + 5, y: content.y + 5, detail: 1 });
   assert.ok(placed, 'a press away from the bar still places the caret');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+// --- horizontal ------------------------------------------------------------
+
+/** A row of fixed-width cells: wider than the viewport, and unable to
+ * shrink, which is what a table of columns looks like. */
+function mountWide() {
+  const app = createMockApp();
+  const ref = React.createRef();
+  ReactX11.render(
+    h(
+      'window',
+      { width: 200, height: 100 },
+      h(
+        'scrollview',
+        { ref, style: { flexGrow: 1 } },
+        h(
+          'box',
+          { style: { flexDirection: 'row', flexShrink: 0 } },
+          ...Array.from({ length: 6 }, (_, i) =>
+            h('box', {
+              key: i,
+              style: { width: 100, height: 40, flexShrink: 0 },
+            }),
+          ),
+        ),
+      ),
+    ),
+    null,
+    app,
+  );
+  return { app, wnd: app.windows[0], ref };
+}
+
+test('content wider than the viewport scrolls sideways', async () => {
+  const { app, wnd } = mountWide();
+  await tick();
+  const sv = scroller(app);
+
+  assert.strictEqual(sv.contentWidth, 600, 'six 100px cells');
+  const bar = sv._scrollbar('x');
+  assert.ok(bar, 'a horizontal bar appears');
+  assert.strictEqual(bar.axis, 'x');
+  assert.strictEqual(bar.range, 600 - 200);
+
+  wnd.emit('mousedown', {
+    x: bar.thumbStart + bar.thumbLength / 2,
+    y: bar.crossStart + 2,
+    keycode: 1,
+  });
+  wnd.emit('mousemove', {
+    x: bar.thumbStart + bar.thumbLength / 2 + bar.travel / 2,
+    y: bar.crossStart + 2,
+  });
+  assert.ok(
+    Math.abs(sv.scrollX - bar.range / 2) < 1,
+    `half the travel is half the range, got ${sv.scrollX}`,
+  );
+  wnd.emit('mouseup', { x: 0, y: 0, keycode: 1 });
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('a sideways scroll moves the content, not just the number', async () => {
+  const { app, ref } = mountWide();
+  await tick();
+  const sv = scroller(app);
+  const firstCell = sv.children[0].children[0];
+  const before = firstCell.abs.x;
+
+  ref.current.scrollTo({ x: 150 });
+  await tick();
+  assert.strictEqual(
+    firstCell.abs.x,
+    before - 150,
+    'children are laid out shifted by the scroll',
+  );
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('scrollTo takes a number for y, or an object for either axis', async () => {
+  const { app, ref } = mountWide();
+  await tick();
+  const sv = scroller(app);
+
+  ref.current.scrollTo(10); // the shape that existed before
+  await tick();
+  assert.strictEqual(sv.scrollY, 0, 'nothing to scroll vertically here');
+  ref.current.scrollTo({ x: 1000 });
+  await tick();
+  assert.strictEqual(sv.scrollX, 400, 'clamped to the range');
+  ref.current.scrollBy({ x: -50 });
+  await tick();
+  assert.strictEqual(sv.scrollX, 350);
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('the horizontal wheel scrolls sideways, and Shift+wheel does too', async () => {
+  const { app, wnd } = mountWide();
+  await tick();
+  const sv = scroller(app);
+
+  // X button 7 is a wheel-right
+  wnd.emit('mousedown', { x: 50, y: 50, keycode: 7 });
+  await tick();
+  assert.ok(sv.scrollX > 0, `wheel-right scrolled to ${sv.scrollX}`);
+
+  const after = sv.scrollX;
+  // Shift + wheel-down, for mice with no horizontal wheel (buttons bit 1)
+  wnd.emit('mousedown', { x: 50, y: 50, keycode: 5, buttons: 1 });
+  await tick();
+  assert.ok(sv.scrollX > after, 'Shift turned a vertical wheel sideways');
+  assert.strictEqual(sv.scrollY, 0, 'and did not scroll down as well');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('scrollIntoView brings a node in from either side', async () => {
+  const { app, ref } = mountWide();
+  await tick();
+  const sv = scroller(app);
+  const last = sv.children[0].children[5];
+
+  ref.current.scrollIntoView(last);
+  await tick();
+  assert.strictEqual(sv.scrollX, 400, 'scrolled right the minimum amount');
+
+  ref.current.scrollIntoView(sv.children[0].children[0]);
+  await tick();
+  assert.strictEqual(sv.scrollX, 0, 'and back left again');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('with both bars showing, neither runs into the other corner', async () => {
+  const app = createMockApp();
+  ReactX11.render(
+    h(
+      'window',
+      { width: 200, height: 100 },
+      h(
+        'scrollview',
+        { style: { flexGrow: 1 } },
+        ...Array.from({ length: 5 }, (_, i) =>
+          h('box', {
+            key: i,
+            style: { width: 400, height: 40, flexShrink: 0 },
+          }),
+        ),
+      ),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const sv = scroller(app);
+
+  const vertical = sv._scrollbar('y');
+  const horizontal = sv._scrollbar('x');
+  assert.ok(vertical && horizontal, 'both axes overflow');
+  assert.ok(
+    vertical.trackLength < sv.abs.height,
+    'the vertical track stops short of the corner',
+  );
+  assert.ok(
+    horizontal.trackLength < sv.abs.width,
+    'and so does the horizontal one',
+  );
 
   ReactX11.unmountComponentAtNode(app);
 });


### PR DESCRIPTION
Everything was vertical: `scrollY`, `contentHeight`, one bar, and a wheel handler that ignored the `deltaX` it was already computing. Tables, code views and log panes all need the other axis, so it exists now on the same footing — and Table cannot be built without it.

`scrollX`/`contentWidth` join the node and the `onScroll` payload, a second draggable bar appears when the content is wider than the viewport, and `scrollIntoView` brings a node in from either side.

```js
ref.current.scrollTo(120);          // vertical, exactly as before
ref.current.scrollTo({ x: 160 });   // either axis; omitted ones stay put
ref.current.scrollBy({ x: -40, y: 20 });
```

A table-shaped grid — fixed columns that will not shrink — scrolled to `{x: 160, y: 40}`, with both bars showing:

![hscroll](https://github.com/user-attachments/assets/ad6228f3-78a8-43d0-8010-10489061b7e1)

## The part that was not obvious

The extent has to be measured **through the subtree**, the way `scrollWidth` is in a browser. A row that stretches to the viewport while its own cells overflow it — which is exactly what a table looks like — reports the *viewport* width at the top level and says nothing about the cells. Measuring only the direct children found nothing to scroll, and the first horizontal test failed on precisely that: `contentWidth` came back as 200 for 600px of cells.

Anything that clips its own children ends the walk, since their overflow is that node's business. This also makes the vertical measurement more correct than it was, and every pre-existing test still passes.

## Smaller things

The scrollbar geometry is now written once for both axes instead of twice, for the same reason painting and hit testing already shared it: two copies drift. When both bars show, each stops short of the other's corner.

X sends buttons 6 and 7 for a horizontal wheel and those now scroll sideways; **Shift + vertical wheel** does too, for the mice and touchpads that have no horizontal one.

## Tests

Six new: content wider than the viewport producing a bar and dragging proportionally, the children actually being laid out shifted (not just the number changing), the `scrollTo` number-or-object shapes with clamping, the horizontal wheel and the Shift variant, `scrollIntoView` from both sides, and both bars keeping out of each other's corner.

`npm test` 174 passing, `npm run lint` clean.

Next: Table, which this unblocks — with virtualization, since a 10k-row scrollview currently builds 10k nodes.