### PR TITLE
feat: Table — sticky header, resizable columns, virtualized rows

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -335,6 +335,50 @@ and wrap, Home/End jump to the ends, disabled tabs are skipped. Arrows
 select as they move, the way a desktop notebook behaves; `manual` splits
 focus from selection, which is what you want when a panel is expensive.
 
+## `Table`
+
+A grid with a header that stays put, resizable columns, and only the rows in
+view actually built.
+
+```jsx
+<Table
+  columns={[
+    { id: 'name', label: 'Name', width: 220 },
+    { id: 'size', label: 'Size', width: 90, align: 'right' },
+  ]}
+  rows={files}
+  onSelect={(id, row) => open(row)}
+/>
+```
+
+| prop                           |                                                     |
+| ------------------------------ | --------------------------------------------------- |
+| `columns`                      | `{ id, label, width, align, value, render }[]`      |
+| `rows`                         | `{ id, … }[]` — `id` identifies the row             |
+| `rowHeight`                    | every row is this tall (24 by default)              |
+| `sort` / `defaultSort`         | `{ column, direction }`; reported by `onSortChange` |
+| `selected` / `defaultSelected` | selected row id; reported by `onSelect(id, row)`    |
+| `onActivate(id, row)`          | Enter on the selection                              |
+| `onColumnResize(id, width)`    | after a header drag                                 |
+
+`value(row)` feeds sorting and the default cell text; `render(row)` replaces
+the cell contents entirely.
+
+**Rows must all be `rowHeight` tall.** That is the price of the table only
+building what is on screen: with ten thousand rows it mounts the twenty or
+so in the viewport and swaps them as you scroll, and everything above and
+below is a single spacer box, so the scrollbar still measures the whole
+list. Sorting a hundred thousand rows is still the caller's problem — pass
+`sort` and sort the data yourself when that matters.
+
+The **table** holds the focus, not the row: a row is unmounted as soon as it
+scrolls out of view, and focus would go with it. Up/Down move the selection,
+PageUp/PageDown by a viewport, Home/End to the ends, and the selection is
+kept on screen without building the rows in between.
+
+The header scrolls sideways with the body but never vertically. Dragging the
+grip at a header's right edge resizes that column; the body follows.
+
 ## `Tree`
 
 A disclosure tree: file browsers, outline panes, property inspectors.

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -209,6 +209,7 @@ same reason. Pass any of them explicitly to opt out.
 | prop                |                                                                                  |
 | ------------------- | -------------------------------------------------------------------------------- |
 | `onScroll(ev)`      | `{scrollX, scrollY, contentWidth, contentHeight, viewportWidth, viewportHeight}` |
+| `onViewport(ev)`    | `{width, height, contentWidth, contentHeight}` whenever they change              |
 | `scrollbar={false}` | hide the drawn scrollbars                                                        |
 | `scrollbarColor`    | thumb color                                                                      |
 
@@ -230,6 +231,12 @@ belongs to them.
 X sends buttons 6 and 7 for a horizontal wheel; **Shift + vertical wheel**
 scrolls sideways too, for mice and touchpads that have none. When both bars
 show, each stops short of the other's corner.
+
+`onViewport` fires from **layout**, not from scrolling, so it arrives for a
+list nobody has scrolled yet. That is what a virtualized list needs before
+it can decide how many rows are worth building: layout runs on the frame
+clock, after the commit that mounted the node, so an effect cannot read the
+size off the ref. `Table` is built on it.
 
 `scrollIntoView(node)` scrolls the minimum amount that makes a descendant
 node fully visible, and is safe to call from an effect right after that

--- a/examples/app.jsx
+++ b/examples/app.jsx
@@ -14,6 +14,7 @@ import {
   createRoot,
   createStyles,
   SplitPane,
+  Table,
   Tabs,
   Tree,
 } from '../src/index.js';
@@ -76,6 +77,7 @@ const SECTIONS = [
   { id: 'widgets', label: 'Widgets' },
   { id: 'tasks', label: 'Tasks' },
   { id: 'tree', label: 'Tree' },
+  { id: 'table', label: 'Table' },
 ];
 
 // A stand-in project, enough to show nesting, a lazy-looking empty branch
@@ -130,11 +132,51 @@ function TreePanel() {
   );
 }
 
+// Enough rows that building them all would be silly — the table mounts the
+// twenty or so on screen and swaps them as you scroll.
+const ROWS = Array.from({ length: 10000 }, (_, i) => ({
+  id: i,
+  name: `file-${String(i).padStart(5, '0')}.js`,
+  kind: ['source', 'test', 'doc', 'asset'][i % 4],
+  size: (i * 37) % 4096,
+  modified: `2026-07-${String((i % 28) + 1).padStart(2, '0')}`,
+}));
+
+const COLUMNS = [
+  { id: 'name', label: 'Name', width: 200 },
+  { id: 'kind', label: 'Kind', width: 90 },
+  { id: 'size', label: 'Size', width: 90, align: 'right' },
+  { id: 'modified', label: 'Modified', width: 120 },
+];
+
+function TablePanel() {
+  const [picked, setPicked] = useState(null);
+  return (
+    <box style={s.treePanel}>
+      <text style={s.treeHint}>
+        {ROWS.length.toLocaleString()} rows — drag a header edge to resize,
+        click one to sort
+      </text>
+      <Table
+        columns={COLUMNS}
+        rows={ROWS}
+        selected={picked}
+        onSelect={setPicked}
+        style={{ flexGrow: 1 }}
+      />
+      <text style={s.treeHint}>
+        {picked == null ? 'nothing selected' : `selected: ${ROWS[picked].name}`}
+      </text>
+    </box>
+  );
+}
+
 const PANELS = {
   form: () => <FormPanel />,
   widgets: () => <WidgetsPanel />,
   tasks: () => <TasksPanel />,
   tree: () => <TreePanel />,
+  table: () => <TablePanel />,
 };
 
 function App() {

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -1,0 +1,382 @@
+// Widget components built purely on the host primitives — no reconciler
+// support needed. Plain createElement (no JSX) so the library stays
+// build-step-free for consumers.
+
+import React, { useMemo, useRef, useState } from 'react';
+import { createStyles } from '../styles.js';
+import { useTheme } from './theme.js';
+import {
+  XK_DOWN,
+  XK_END,
+  XK_HOME,
+  XK_PAGE_DOWN,
+  XK_PAGE_UP,
+  XK_RETURN,
+  XK_UP,
+} from './keys.js';
+
+const h = React.createElement;
+
+const ROW_HEIGHT = 24;
+const GRIP = 6;
+const MIN_COLUMN = 40;
+// rows kept either side of the viewport, so a fast scroll does not show a
+// gap before the next frame catches up
+const OVERSCAN = 4;
+
+const s = createStyles({
+  root: { flexGrow: 1, minHeight: 0, minWidth: 0 },
+  headerClip: { flexShrink: 0, overflow: 'hidden' },
+  headerRow: { flexDirection: 'row', flexShrink: 0 },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    height: ROW_HEIGHT,
+    paddingLeft: 8,
+    flexShrink: 0,
+    cursor: 'pointer',
+    transition: { backgroundColor: 80 },
+  },
+  headerLabel: { fontSize: 12 },
+  grip: {
+    width: GRIP,
+    flexShrink: 0,
+    cursor: 'col-resize',
+    alignSelf: 'stretch',
+  },
+  body: { flexGrow: 1, minHeight: 0 },
+  rows: { flexDirection: 'column', flexShrink: 0 },
+  row: {
+    flexDirection: 'row',
+    height: ROW_HEIGHT,
+    flexShrink: 0,
+    alignItems: 'center',
+    cursor: 'pointer',
+  },
+  cell: {
+    height: ROW_HEIGHT,
+    justifyContent: 'center',
+    paddingLeft: 8,
+    flexShrink: 0,
+    overflow: 'hidden',
+  },
+  cellText: { fontSize: 12 },
+  spacer: { flexShrink: 0 },
+  sortMark: { width: 8, height: 5, marginLeft: 4 },
+});
+
+const value = (row, column) =>
+  column.value ? column.value(row) : row[column.id];
+
+function compare(a, b) {
+  if (typeof a === 'number' && typeof b === 'number') return a - b;
+  return String(a ?? '').localeCompare(String(b ?? ''));
+}
+
+/**
+ * <Table columns rows/> — a grid with a header that stays put, resizable
+ * columns, and only the rows in view actually built.
+ *
+ *   <Table
+ *     columns={[{ id: 'name', label: 'Name', width: 220 }]}
+ *     rows={[{ id: 1, name: 'index.js' }]}
+ *   />
+ *
+ * Columns are `{ id, label, width, align, value, render }`. `value(row)`
+ * feeds sorting and the default cell text; `render(row)` replaces the cell
+ * entirely.
+ *
+ * **Rows must all be `rowHeight` tall** (24 by default). That is what lets
+ * the table skip building the rows nobody can see: with ten thousand rows
+ * it mounts the thirty or so in the viewport, and scrolling swaps them.
+ * Everything above and below is one spacer box apiece, so the scrollbar
+ * still measures the whole list.
+ *
+ * Sorting is uncontrolled unless you pass `sort`; the header reports
+ * `onSortChange({ column, direction })` either way. Selection is
+ * `selected` + `onSelect`, or uncontrolled with `defaultSelected`.
+ */
+export function Table({
+  columns = [],
+  rows = [],
+  rowHeight = ROW_HEIGHT,
+  sort,
+  defaultSort,
+  onSortChange,
+  selected,
+  defaultSelected,
+  onSelect,
+  onActivate,
+  onColumnResize,
+  style,
+  ...boxProps
+}) {
+  const theme = useTheme();
+  const [ownSort, setOwnSort] = useState(defaultSort ?? null);
+  const [ownSelected, setOwnSelected] = useState(defaultSelected);
+  const [widths, setWidths] = useState(() =>
+    Object.fromEntries(columns.map((c) => [c.id, c.width ?? 120])),
+  );
+  const [scrollX, setScrollX] = useState(0);
+  const [view, setView] = useState({ top: 0, height: 0 });
+
+  const body = useRef(null);
+  const widthsRef = useRef(widths);
+  widthsRef.current = widths;
+  const drag = useRef(null);
+
+  const activeSort = sort === undefined ? ownSort : sort;
+  const current = selected ?? ownSelected;
+
+  const sorted = useMemo(() => {
+    if (!activeSort) return rows;
+    const column = columns.find((c) => c.id === activeSort.column);
+    if (!column) return rows;
+    const sign = activeSort.direction === 'desc' ? -1 : 1;
+    return [...rows].sort(
+      (a, b) => sign * compare(value(a, column), value(b, column)),
+    );
+  }, [rows, columns, activeSort]);
+
+  const currentRef = useRef(current);
+  currentRef.current = current;
+
+  const columnWidth = (c) => widths[c.id] ?? c.width ?? 120;
+  const totalWidth = columns.reduce((n, c) => n + columnWidth(c), 0);
+
+  // the slice worth building: what is on screen, plus a little either side
+  const first = Math.max(0, Math.floor(view.top / rowHeight) - OVERSCAN);
+  const visibleCount =
+    view.height > 0
+      ? Math.ceil(view.height / rowHeight) + OVERSCAN * 2
+      : sorted.length;
+  const last = Math.min(sorted.length, first + visibleCount);
+  const slice = sorted.slice(first, last);
+
+  const toggleSort = (column) => {
+    const next =
+      activeSort?.column === column.id && activeSort.direction === 'asc'
+        ? { column: column.id, direction: 'desc' }
+        : { column: column.id, direction: 'asc' };
+    if (sort === undefined) setOwnSort(next);
+    onSortChange?.(next);
+  };
+
+  const pick = (row) => {
+    if (!row) return;
+    currentRef.current = row.id;
+    if (selected === undefined) setOwnSelected(row.id);
+    onSelect?.(row.id, row);
+    // keep the selection on screen without building the rows in between
+    const index = sorted.findIndex((r) => r.id === row.id);
+    const top = index * rowHeight;
+    const node = body.current;
+    if (!node) return;
+    if (top < node.scrollY) node.scrollTo({ y: top });
+    else if (top + rowHeight > node.scrollY + node.abs.height) {
+      node.scrollTo({ y: top + rowHeight - node.abs.height });
+    }
+  };
+
+  const step = (delta) => {
+    const index = sorted.findIndex((r) => r.id === currentRef.current);
+    const next = Math.min(
+      Math.max(0, (index === -1 ? -1 : index) + delta),
+      sorted.length - 1,
+    );
+    return sorted[next];
+  };
+
+  const onKeyDown = (ev) => {
+    const page = Math.max(1, Math.floor(view.height / rowHeight) - 1);
+    switch (ev.keysym) {
+      case XK_UP:
+        pick(step(-1));
+        return;
+      case XK_DOWN:
+        pick(step(1));
+        return;
+      case XK_PAGE_UP:
+        pick(step(-page));
+        return;
+      case XK_PAGE_DOWN:
+        pick(step(page));
+        return;
+      case XK_HOME:
+        pick(sorted[0]);
+        return;
+      case XK_END:
+        pick(sorted[sorted.length - 1]);
+        return;
+      case XK_RETURN: {
+        const row = sorted.find((r) => r.id === currentRef.current);
+        if (row) onActivate?.(row.id, row);
+        return;
+      }
+      default:
+    }
+  };
+
+  const resizeProps = (column) => ({
+    focusable: true,
+    onMouseDown: (ev) => {
+      drag.current = { id: column.id, from: ev.x, width: columnWidth(column) };
+      ev.capturePointer();
+    },
+    onMouseMove: (ev) => {
+      const d = drag.current;
+      if (!d) return;
+      const next = Math.max(MIN_COLUMN, d.width + (ev.x - d.from));
+      if (next === widthsRef.current[d.id]) return;
+      widthsRef.current = { ...widthsRef.current, [d.id]: next };
+      setWidths(widthsRef.current);
+      onColumnResize?.(d.id, next);
+    },
+    onMouseUp: () => {
+      drag.current = null;
+    },
+  });
+
+  const cell = (row, column) =>
+    h(
+      'box',
+      {
+        key: column.id,
+        style: [
+          s.cell,
+          { width: columnWidth(column) },
+          column.align === 'right' && {
+            alignItems: 'flex-end',
+            paddingRight: 8,
+          },
+        ],
+      },
+      column.render
+        ? column.render(row)
+        : h(
+            'text',
+            {
+              style: [
+                s.cellText,
+                {
+                  color: row.id === current ? theme.hoverText : theme.text,
+                },
+              ],
+            },
+            String(value(row, column) ?? ''),
+          ),
+    );
+
+  return h(
+    'box',
+    {
+      theme,
+      // the *table* takes focus, not the row: a virtualized row is
+      // unmounted as soon as it scrolls out, and focus would go with it
+      focusable: true,
+      ...boxProps,
+      style: [s.root, style],
+      onKeyDown,
+    },
+    // the header scrolls sideways with the body but never vertically, so it
+    // lives outside the scrollview and is shifted by the body's scrollX
+    h(
+      'box',
+      { style: [s.headerClip, { backgroundColor: theme.surfaceHover }] },
+      h(
+        'box',
+        { style: [s.headerRow, { marginLeft: -scrollX, width: totalWidth }] },
+        columns.map((column) =>
+          h(
+            'box',
+            {
+              key: column.id,
+              style: [s.header, { width: columnWidth(column) }],
+              focusable: true,
+              onClick: () => toggleSort(column),
+            },
+            h(
+              'text',
+              { style: [s.headerLabel, { color: theme.text }] },
+              column.label ?? column.id,
+            ),
+            activeSort?.column === column.id &&
+              h('canvas', {
+                style: s.sortMark,
+                onDraw: (ctx, { width: w, height: hgt }) => {
+                  ctx.fillStyle = theme.dim;
+                  ctx.beginPath();
+                  if (activeSort.direction === 'asc') {
+                    ctx.moveTo(0, hgt);
+                    ctx.lineTo(w, hgt);
+                    ctx.lineTo(w / 2, 0);
+                  } else {
+                    ctx.moveTo(0, 0);
+                    ctx.lineTo(w, 0);
+                    ctx.lineTo(w / 2, hgt);
+                  }
+                  ctx.closePath();
+                  ctx.fill();
+                },
+              }),
+            h('box', { style: { flexGrow: 1 } }),
+            h('box', {
+              ...resizeProps(column),
+              style: [s.grip, { backgroundColor: theme.border }],
+            }),
+          ),
+        ),
+      ),
+    ),
+    h(
+      'scrollview',
+      {
+        ref: body,
+        style: s.body,
+        onScroll: (ev) => {
+          setScrollX(ev.scrollX);
+          setView((v) =>
+            v.top === ev.scrollY ? v : { ...v, top: ev.scrollY },
+          );
+        },
+        // layout, not scrolling, is what first tells a list how much of it
+        // is worth building
+        onViewport: (v) =>
+          setView((prev) =>
+            prev.height === v.height ? prev : { ...prev, height: v.height },
+          ),
+      },
+      h(
+        'box',
+        { style: [s.rows, { width: totalWidth }] },
+        first > 0 &&
+          h('box', { style: [s.spacer, { height: first * rowHeight }] }),
+        slice.map((row) =>
+          h(
+            'box',
+            {
+              key: row.id,
+              style: [
+                s.row,
+                { height: rowHeight },
+                {
+                  backgroundColor:
+                    row.id === current ? theme.hoverBackground : 'transparent',
+                },
+                row.id !== current && {
+                  ':hover': { backgroundColor: theme.surfaceHover },
+                },
+              ],
+              onClick: () => pick(row),
+            },
+            columns.map((column) => cell(row, column)),
+          ),
+        ),
+        last < sorted.length &&
+          h('box', {
+            style: [s.spacer, { height: (sorted.length - last) * rowHeight }],
+          }),
+      ),
+    ),
+  );
+}

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -23,6 +23,11 @@ const MIN_COLUMN = 40;
 // rows kept either side of the viewport, so a fast scroll does not show a
 // gap before the next frame catches up
 const OVERSCAN = 4;
+// What to build before the viewport has been measured. onViewport cannot
+// arrive until layout has run, which is a frame after the first commit, so
+// there is always one render that has to guess — and guessing "all of them"
+// means ten thousand rows land in the tree for a frame.
+const ASSUMED_ROWS = 40;
 
 const s = createStyles({
   root: { flexGrow: 1, minHeight: 0, minWidth: 0 },
@@ -149,7 +154,7 @@ export function Table({
   const visibleCount =
     view.height > 0
       ? Math.ceil(view.height / rowHeight) + OVERSCAN * 2
-      : sorted.length;
+      : ASSUMED_ROWS;
   const last = Math.min(sorted.length, first + visibleCount);
   const slice = sorted.slice(first, last);
 

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -16,5 +16,6 @@ export { ContextMenu, MenuBar } from './Menu.js';
 export { Select } from './Select.js';
 export { Tabs } from './Tabs.js';
 export { Tree } from './Tree.js';
+export { Table } from './Table.js';
 export { SplitPane } from './SplitPane.js';
 export { Canvas3D } from './Canvas3D.js';

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ export {
   Select,
   Tabs,
   Tree,
+  Table,
   SplitPane,
   SelectThemeProvider,
   ThemeProvider,

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -749,8 +749,31 @@ export class Node {
       this._roundedPath(ctx, this.style.borderRadius ?? 0);
       ctx.clip();
     }
-    for (const child of order) child.paint(ctx);
+    for (const child of order) {
+      if (child._offscreen()) continue;
+      child.paint(ctx);
+    }
     if (clip) ctx.restore();
+  }
+
+  /**
+   * Entirely outside the window, so there is nothing to draw. Worth doing
+   * for its own sake, but it is also a correctness fix: X's render traps
+   * are 16.16 fixed point, so a coordinate past ±32767 overflows the
+   * request. A scrolled list is exactly how you get there — the frame
+   * between a scroll and the re-render that follows it can hold rows
+   * ninety thousand pixels above the viewport.
+   */
+  _offscreen() {
+    const window = this.root?.abs;
+    if (!window) return false;
+    const { x, y, width, height } = this.abs;
+    return (
+      x + width <= 0 ||
+      y + height <= 0 ||
+      x >= window.width ||
+      y >= window.height
+    );
   }
 }
 
@@ -1100,11 +1123,44 @@ export class ScrollViewNode extends Node {
     this._resolveScrollIntoView();
     this.scrollY = Math.min(Math.max(0, this.scrollY), this._maxScroll('y'));
     this.scrollX = Math.min(Math.max(0, this.scrollX), this._maxScroll('x'));
+    this._reportViewport();
     for (const child of this.children) {
       if (!child.isWindow) {
         child.absolutize(this.abs.x - this.scrollX, this.abs.y - this.scrollY);
       }
     }
+  }
+
+  /**
+   * Tell the owner how big the viewport and the content turned out, when
+   * either changes. Layout happens on the frame clock, *after* the commit
+   * that mounted the node, so an effect cannot read this off the ref —
+   * which is exactly what a list needs before it can decide how many rows
+   * are worth building. Fired from layout rather than from scrolling, so
+   * it also arrives for a list nobody has scrolled yet.
+   */
+  _reportViewport() {
+    const next = {
+      width: this.abs.width,
+      height: this.abs.height,
+      contentWidth: this.contentWidth,
+      contentHeight: this.contentHeight,
+    };
+    const last = this._lastViewport;
+    if (
+      last &&
+      last.width === next.width &&
+      last.height === next.height &&
+      last.contentWidth === next.contentWidth &&
+      last.contentHeight === next.contentHeight
+    ) {
+      return;
+    }
+    this._lastViewport = next;
+    // during layout: defer, or a setState from the handler would re-enter
+    // the pass that is still running
+    const notify = this.props.onViewport;
+    if (notify) setImmediate(() => !this.destroyed && notify(next));
   }
 
   /**

--- a/test/table.test.js
+++ b/test/table.test.js
@@ -97,6 +97,33 @@ test('only the rows in view are built', async () => {
   ReactX11.unmountComponentAtNode(app);
 });
 
+test('the first render, before anything is measured, is still bounded', () => {
+  const app = createMockApp();
+  // no awaits: this is the tree as the very first commit leaves it, before
+  // layout has run and onViewport could have said how tall the viewport is.
+  // Rendering "all of them" here put 130,000 nodes in the tree and froze the
+  // window for the best part of a second.
+  ReactX11.render(
+    h(
+      'window',
+      { width: 300, height: 200 },
+      h(Table, { columns: COLUMNS, rows: makeRows(10_000) }),
+    ),
+    null,
+    app,
+  );
+
+  let nodes = 0;
+  const walk = (n) => {
+    nodes++;
+    n.children.forEach((c) => !c.isWindow && walk(c));
+  };
+  walk(root(app));
+  assert.ok(nodes < 1000, `first commit built ${nodes} nodes for 10,000 rows`);
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
 test('the scrollbar still measures the whole list', async () => {
   const app = mount({}, 10_000);
   await settle();

--- a/test/table.test.js
+++ b/test/table.test.js
@@ -1,0 +1,271 @@
+// Table: a header that stays put, resizable columns, and only the rows in
+// view actually built.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import ReactX11, { Table } from '../src/index.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+// layout, then the deferred onViewport, then the render it causes
+const settle = async () => {
+  for (let i = 0; i < 4; i++) await tick();
+};
+const root = (app) => app.windows[0]._reactX11Node;
+
+const XK = { HOME: 0xff50, UP: 0xff52, DOWN: 0xff54, END: 0xff57 };
+
+/** The table holds the focus itself — see the note in Table.js. */
+const focusTable = (app) =>
+  find(app.windows[0]._reactX11Node, (n) => n.props.focusable)?.focus();
+
+function press(app, keysym) {
+  const keycode = (keysym % 248) + 8;
+  app.X.keycode2keysyms[keycode] = [keysym];
+  app.windows[0].emit('keydown', { keycode, buttons: 0 });
+}
+
+const find = (node, pred) =>
+  pred(node)
+    ? node
+    : node.children.reduce(
+        (a, c) => a || (c.isWindow ? null : find(c, pred)),
+        null,
+      );
+
+const texts = (app) => {
+  const out = [];
+  const walk = (n) => {
+    if (n.kind === 'text') out.push(String(n.props.children));
+    n.children.forEach((c) => !c.isWindow && walk(c));
+  };
+  walk(root(app));
+  return out;
+};
+
+const COLUMNS = [
+  { id: 'name', label: 'Name', width: 120 },
+  { id: 'size', label: 'Size', width: 80, align: 'right' },
+];
+
+const makeRows = (n) =>
+  Array.from({ length: n }, (_, i) => ({
+    id: i,
+    name: `file-${String(i).padStart(4, '0')}.js`,
+    size: (i * 37) % 1000,
+  }));
+
+function mount(props, rowCount = 8, height = 200) {
+  const app = createMockApp();
+  ReactX11.render(
+    h(
+      'window',
+      { width: 300, height },
+      h(Table, { columns: COLUMNS, rows: makeRows(rowCount), ...props }),
+    ),
+    null,
+    app,
+  );
+  return app;
+}
+
+test('renders a header and the rows under it', async () => {
+  const app = mount({}, 3);
+  await settle();
+  const shown = texts(app);
+  assert.ok(shown.includes('Name') && shown.includes('Size'), 'header labels');
+  assert.ok(shown.includes('file-0000.js'));
+  assert.ok(shown.includes('file-0002.js'));
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('only the rows in view are built', async () => {
+  // 10k rows in a 200px window: about eight fit, plus the overscan
+  const app = mount({}, 10_000);
+  await settle();
+
+  const built = texts(app).filter((t) => t.endsWith('.js')).length;
+  assert.ok(built > 0, 'something rendered');
+  assert.ok(
+    built < 40,
+    `only the visible slice is built, got ${built} rows for 10,000`,
+  );
+  assert.ok(texts(app).includes('file-0000.js'), 'starting at the top');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('the scrollbar still measures the whole list', async () => {
+  const app = mount({}, 10_000);
+  await settle();
+  const body = find(root(app), (n) => n.kind === 'scrollview');
+
+  assert.strictEqual(
+    body.contentHeight,
+    10_000 * 24,
+    'the spacers stand in for the rows that were not built',
+  );
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('scrolling swaps which rows exist', async () => {
+  const app = mount({}, 10_000);
+  await settle();
+  const body = find(root(app), (n) => n.kind === 'scrollview');
+
+  body.scrollTo({ y: 24 * 500 });
+  await settle();
+
+  const shown = texts(app);
+  assert.ok(shown.includes('file-0500.js'), 'the rows at that offset exist');
+  assert.ok(!shown.includes('file-0000.js'), 'and the ones at the top do not');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('clicking a header sorts, and clicking again reverses', async () => {
+  const changes = [];
+  const app = mount({ onSortChange: (next) => changes.push(next) }, 4);
+  await settle();
+
+  const header = find(
+    root(app),
+    (n) => n.kind === 'text' && String(n.props.children) === 'Size',
+  ).parent;
+  const click = (node) => {
+    const x = node.abs.x + 4;
+    const y = node.abs.y + node.abs.height / 2;
+    app.windows[0].emit('mousedown', { x, y, keycode: 1 });
+    app.windows[0].emit('mouseup', { x, y, keycode: 1 });
+  };
+
+  click(header);
+  await settle();
+  assert.deepStrictEqual(changes.at(-1), { column: 'size', direction: 'asc' });
+  const asc = texts(app)
+    .filter((t) => /^\d+$/.test(t))
+    .map(Number);
+  assert.deepStrictEqual(
+    [...asc].sort((a, b) => a - b),
+    asc,
+    'ascending',
+  );
+
+  click(header);
+  await settle();
+  assert.deepStrictEqual(changes.at(-1), { column: 'size', direction: 'desc' });
+  const desc = texts(app)
+    .filter((t) => /^\d+$/.test(t))
+    .map(Number);
+  assert.deepStrictEqual(
+    [...desc].sort((a, b) => b - a),
+    desc,
+    'descending',
+  );
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('Up/Down move the selection, Home/End jump to the ends', async () => {
+  const picked = [];
+  const app = mount(
+    { onSelect: (id) => picked.push(id), defaultSelected: 0 },
+    50,
+  );
+  await settle();
+  focusTable(app);
+
+  press(app, XK.DOWN);
+  press(app, XK.DOWN);
+  await settle();
+  assert.deepStrictEqual(picked, [1, 2], 'two presses, two rows');
+
+  press(app, XK.END);
+  await settle();
+  assert.strictEqual(picked.at(-1), 49);
+  press(app, XK.HOME);
+  await settle();
+  assert.strictEqual(picked.at(-1), 0);
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('the selection is kept on screen, even when it is not built yet', async () => {
+  const app = mount({ defaultSelected: 0 }, 10_000);
+  await settle();
+  const body = find(root(app), (n) => n.kind === 'scrollview');
+  focusTable(app);
+
+  press(app, XK.END);
+  await settle();
+
+  assert.ok(
+    body.scrollY > 24 * 9000,
+    `scrolled to the end of the list, got ${body.scrollY}`,
+  );
+  assert.ok(texts(app).includes('file-9999.js'), 'and that row now exists');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('dragging a header grip resizes that column', async () => {
+  const resized = [];
+  const app = mount({ onColumnResize: (id, w) => resized.push([id, w]) }, 4);
+  await settle();
+
+  const grip = find(root(app), (n) => n.style.cursor === 'col-resize');
+  const y = grip.abs.y + grip.abs.height / 2;
+  app.windows[0].emit('mousedown', { x: grip.abs.x + 2, y, keycode: 1 });
+  app.windows[0].emit('mousemove', { x: grip.abs.x + 62, y });
+  await settle();
+
+  assert.deepStrictEqual(resized.at(-1), ['name', 180], '120 + 60');
+  const cell = find(
+    root(app),
+    (n) => n.kind === 'text' && String(n.props.children) === 'file-0000.js',
+  ).parent;
+  assert.strictEqual(cell.abs.width, 180, 'the body column followed');
+
+  app.windows[0].emit('mouseup', { x: grip.abs.x + 62, y, keycode: 1 });
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('the header scrolls sideways with the body but not down', async () => {
+  const app = mount({}, 40, 120);
+  await settle();
+  const body = find(root(app), (n) => n.kind === 'scrollview');
+  const header = find(
+    root(app),
+    (n) => n.kind === 'text' && String(n.props.children) === 'Name',
+  ).parent;
+  const headerY = header.abs.y;
+
+  body.scrollTo({ y: 200 });
+  await settle();
+  assert.strictEqual(header.abs.y, headerY, 'it stayed put vertically');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('clicking a row selects it', async () => {
+  const picked = [];
+  const app = mount({ onSelect: (id, row) => picked.push([id, row.name]) }, 6);
+  await settle();
+
+  const cell = find(
+    root(app),
+    (n) => n.kind === 'text' && String(n.props.children) === 'file-0003.js',
+  ).parent;
+  const x = cell.abs.x + 10;
+  const y = cell.abs.y + cell.abs.height / 2;
+  app.windows[0].emit('mousedown', { x, y, keycode: 1 });
+  app.windows[0].emit('mouseup', { x, y, keycode: 1 });
+  await settle();
+
+  assert.deepStrictEqual(picked, [[3, 'file-0003.js']]);
+
+  ReactX11.unmountComponentAtNode(app);
+});


### PR DESCRIPTION
The one real apps hit first, and the last of the structural controls from the survey.

```jsx
<Table
  columns={[
    { id: 'name', label: 'Name', width: 220 },
    { id: 'size', label: 'Size', width: 90, align: 'right' },
  ]}
  rows={files}
  onSelect={(id, row) => open(row)}
/>
```

The showcase tab carries **10,000 rows and mounts 26** — scrolled to row 4,000 here, with the thumb sized against the whole list:

![table](https://github.com/user-attachments/assets/5bff4a85-22e9-423e-8854-25caaedc5af9)

## Virtualization

Rows must all be `rowHeight` tall, and that is what buys it: the table builds the twenty or so in the viewport and swaps them as you scroll. Above and below is one spacer box apiece, so `contentHeight` is still `rows.length * rowHeight` and the scrollbar measures the whole list.

The **table** holds the focus, not the row — a virtualized row is unmounted the moment it scrolls out, and focus would go with it. Up/Down move the selection, PageUp/PageDown by a viewport, Home/End to the ends, and the selection is kept on screen without building the rows in between (End on 10,000 rows scrolls to the bottom and mounts only what lands there).

Sorting a hundred thousand rows is still the caller's problem: pass `sort` and sort the data yourself when that matters.

## Two things it needed underneath

**`<scrollview onViewport>`** reports the measured viewport and content whenever they change. Layout runs on the frame clock, *after* the commit that mounted the node, so an effect cannot read the size off the ref — and a list has to know it before it can decide how many rows to build. It fires from layout rather than from scrolling, so it also arrives for a list nobody has scrolled yet.

**Painting now skips nodes entirely outside the window.** This began as an optimisation and turned out to be a crash fix. X's render traps are 16.16 fixed point, so a coordinate past ±32767 overflows the request — and the frame between a scroll and the re-render that follows it holds rows ninety thousand pixels above the viewport. Scrolling the example threw `ERR_OUT_OF_RANGE` from inside `AddTraps` until this landed. Any deeply scrolled content would have hit it, table or not.

## Fixed after the first review pass: the first render

Clicking the Table tab froze the window for the best part of a second. Profiled: **875ms of layout and paint, and 130,075 nodes** in the tree for a table showing twenty rows.

`onViewport` cannot arrive until layout has run, which is a frame after the first commit, so there is always one render that has to guess how many rows are worth building — and it guessed *all of them*. Virtualization kicked in on the second render and threw the other 9,980 away, which is why this was a freeze rather than a permanent slowdown, and why every test that settled first was blind to it.

It now assumes forty rows until told otherwise. Same click, measured the same way: **15ms and 596 nodes**.

| tab     | layout+paint | nodes   |
| ------- | ------------ | ------- |
| Widgets | 30ms         | 138     |
| Tasks   | 11ms         | 116     |
| Tree    | 4ms          | 95      |
| Table (before) | **875ms** | **130,075** |
| Table (after)  | 15ms  | 596     |

The regression test asserts the tree immediately after the first commit, with no awaits — that is the only moment the bug existed.

## Tests

Ten new in `test/table.test.js`, including the claims that matter rather than just the API: only the visible slice is built (asserting fewer than 40 rows exist for 10,000), `contentHeight` still covering the whole list, scrolling swapping which rows exist, sort ascending then descending actually reordering the cells, keyboard selection, the selection being scrolled to when it is not built yet, header-grip resizing moving the body column, and the header not scrolling vertically.

`npm test` 185 passing, `npm run lint` clean.

One note on the screenshot script rather than the component: reading `node.abs` immediately after a programmatic scroll gives content coordinates, because the re-render it triggers has not laid out yet. That cost me a confused ten minutes and is worth knowing when writing these harnesses — the fix is to let a frame pass before measuring.

That closes the structural gaps from the survey. Remaining, in rough order: undo/redo in the text controls, a generic Popover, and a file open/save dialog.
