### PR TITLE
fix: transitions start from now, not from the last frame drawn

### DIFF
--- a/src/nodes.js
+++ b/src/nodes.js
@@ -246,7 +246,11 @@ export class Node {
         from,
         to,
         duration,
-        start: this.root?.frameTime ?? 0,
+        // *now*, not the last frame's timestamp: between two user actions
+        // the window is idle and draws nothing, so the previous frame can
+        // be seconds old — and the first tick would then find the
+        // transition already over and jump straight to the end
+        start: now(),
       });
       this.root?._startAnimating(this);
     }
@@ -2148,10 +2152,8 @@ export class WindowNode extends Node {
     // ids of the child windows in the order the *server* stacks them,
     // bottom to top — see _restackWindowChildren
     this._xStack = [];
-    // nodes with a transition in flight, and the timestamp the current
-    // frame is being rendered for
+    // nodes with a transition in flight
     this._animating = new Set();
-    this.frameTime = 0;
     // nodes with `@width`/`@height` blocks, and the size they last matched
     // against
     this._sizeQueryNodes = new Set();
@@ -2488,7 +2490,6 @@ export class WindowNode extends Node {
    * and it stops on its own the frame the last one lands.
    */
   _advanceAnimations(now) {
-    this.frameTime = now;
     if (this._animating.size === 0) return;
     for (const node of [...this._animating]) {
       if (node.destroyed || !node._tickAnimations(now)) {

--- a/test/style.test.js
+++ b/test/style.test.js
@@ -356,6 +356,56 @@ test('a transition eases a colour instead of snapping to it', async () => {
   }
 });
 
+test('a transition after an idle spell still runs', async () => {
+  const { setAnimationClock } = await import('../src/nodes.js');
+  let clock = 1000;
+  setAnimationClock(() => clock);
+  try {
+    const app = createMockApp();
+    ReactX11.render(
+      h(
+        'window',
+        { width: 100, height: 100 },
+        h('box', {
+          style: {
+            width: 40,
+            height: 40,
+            backgroundColor: '#000000',
+            transition: 100,
+            ':hover': { backgroundColor: '#ffffff' },
+          },
+        }),
+      ),
+      null,
+      app,
+    );
+    await tick();
+    const window = nodeOf(app);
+    const box = window.children[0];
+
+    // nothing happens for five seconds — a window with no animation running
+    // draws no frames, so this is the normal state of any idle UI
+    clock = 6000;
+    moveMouse(app.windows[0], 20, 20);
+
+    clock = 6050; // half way through the transition
+    window._advanceAnimations(clock);
+    const mid = box.style.backgroundColor;
+    assert.match(
+      mid,
+      /^rgba\(/,
+      'the transition is mid-flight; it used to measure its start from the ' +
+        'last frame drawn, so an idle gap made it finish before its first tick',
+    );
+
+    clock = 6200;
+    window._advanceAnimations(clock);
+    assert.strictEqual(box.style.backgroundColor, '#ffffff');
+  } finally {
+    setAnimationClock(() => Date.now());
+  }
+});
+
 test('an interrupted transition reverses from where it got to', async () => {
   const { setAnimationClock } = await import('../src/nodes.js');
   let clock = 0;


### PR DESCRIPTION
You were right to ask. The Switch animation was not disabled — it was **broken in every real application**, and only worked in the tests.

## What was wrong

A transition recorded its start time as `root.frameTime`: the timestamp of the last frame the window drew. A window with nothing animating draws no frames, so between two user actions that value is however long the user spent thinking — seconds, usually. The first tick then computed an elapsed time far past the duration, clamped to the end, and the value jumped.

So the animation was not skipped; it ran to completion inside a single frame.

Measured against a real X connection with the real clock, toggling the Switch:

```
before: left=2   abs.x=22
during: 21ms:38  42ms:38  63ms:38  84ms:38  105ms:38   ← one step, then nothing
after : left=18  abs.x=38
```

and after the fix:

```
during: 20ms:28  42ms:33  62ms:35  82ms:37  102ms:38   ← moving
```

`start: now()` is what a transition means: it starts when the value changes, not when the window last happened to paint. `frameTime` had no other reader, so it goes.

## Why the tests were blind

They inject a fixed clock and never advance it between mounting and acting — which is precisely the case where "the last frame" and "now" are the same instant. Every transition test, including `Switch: the thumb slides between the ends instead of snapping`, passes with the bug in place.

The new test simulates a **five-second idle gap** before the change, then advances the clock into the middle of the transition. It fails without the fix. That is the shape these tests were missing: the gap between the last paint and the interaction.

`npm test` 186 passing, `npm run lint` clean.