### PR TITLE
fix: popups anchor to the window, not to the corner of the screen

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -519,3 +519,9 @@ The `Select` source (`src/components/Select.js`) is the reference for building
 your own: hover/focus state with `useState`, a `<popup>` for anything that
 must escape the window bounds, and a ref to the trigger node for anchoring
 (`node.abs` + `node.root.window.x/y`).
+
+The window's screen position comes from the server (`TranslateCoordinates`),
+refreshed when the window is realized and whenever it is configured — not
+from `window.x`/`y`. Once a reparenting window manager has put the window
+inside its frame, those are relative to the _frame_, and a popup placed with
+them lands near the corner of the screen instead of under its trigger.

--- a/src/components/anchor.js
+++ b/src/components/anchor.js
@@ -30,9 +30,13 @@ export function anchorRect(node, options = {}) {
     height = 0,
   } = options;
 
+  // `_screenOrigin` is what the server says; `x`/`y` are frame-relative
+  // under a reparenting WM and are only a fallback (the headless mock has
+  // no server to ask)
   const win = node.root?.window;
-  const ax = (win?.x ?? 0) + node.abs.x;
-  const ay = (win?.y ?? 0) + node.abs.y;
+  const origin = win?._screenOrigin ?? { x: win?.x ?? 0, y: win?.y ?? 0 };
+  const ax = origin.x + node.abs.x;
+  const ay = origin.y + node.abs.y;
   const aw = node.abs.width;
   const ah = node.abs.height;
 

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -2189,7 +2189,34 @@ export class WindowNode extends Node {
     // <glarea>s mounted before the window existed own a child X window too
     this._realizeGlAreas(this);
     wnd.map?.();
+    // ask before anything can be anchored to it, so the first popup is
+    // placed as well as the second
+    this._refreshScreenOrigin();
     this.invalidate(true);
+  }
+
+  /**
+   * Where this window's top-left corner actually is on the screen, cached
+   * on the ntk window for `anchorRect` to read.
+   *
+   * It cannot be taken from `window.x`/`y`. Those come from ConfigureNotify,
+   * and once a reparenting window manager has put the window inside its
+   * frame — which is every WM worth the name — those coordinates are
+   * relative to the *frame*, not the root. A popup anchored with them lands
+   * near the corner of the screen instead of under its trigger. The server
+   * will translate for us, and its answer is right whatever the WM did.
+   */
+  _refreshScreenOrigin() {
+    const wnd = this.window;
+    const X = this.app?.X;
+    const root = X?.display?.screen?.[0]?.root;
+    if (!wnd || root == null || typeof X.TranslateCoordinates !== 'function') {
+      return;
+    }
+    X.TranslateCoordinates(wnd.id, root, 0, 0, (err, res) => {
+      if (err || this.destroyed || !this.window) return;
+      this.window._screenOrigin = { x: res.destX, y: res.destY };
+    });
   }
 
   /** Walk the drawn subtree and give every <glarea> its child X window. */
@@ -2259,6 +2286,9 @@ export class WindowNode extends Node {
     wnd.on('resize', (ev) => {
       this.needsLayout = true;
       this.invalidate(true);
+      // a move or a reparent arrives the same way, and either changes where
+      // popups anchored to this window belong
+      this._refreshScreenOrigin();
       this.props.onResize?.(ev);
     });
     // the frame clock emits 'draw' when the backing store content is invalid

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -5,6 +5,7 @@ import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import React from 'react';
 import ReactX11 from '../src/index.js';
+import { anchorRect } from '../src/components/anchor.js';
 
 // End-to-end test: react-x11 -> real ntk client -> node-x11's pure-JS
 // in-process X server. No $DISPLAY needed (see ntk docs/xserver.md).
@@ -274,6 +275,59 @@ test('popup is override-redirect on the server and paints', async () => {
 
     const ctx = popupWindow.getContext('2d');
     await waitForPixel(ctx, 60, 40, 30, 20, [255, 0, 0], 'popup content red');
+
+    ReactX11.unmountComponentAtNode(app);
+    await settle(app);
+  } finally {
+    await app.close();
+  }
+});
+
+test('a popup anchors to the window even once a WM has reframed it', async () => {
+  const { app } = await createHeadlessApp();
+  try {
+    const ref = React.createRef();
+    const wnd = await render(
+      React.createElement(
+        'window',
+        { width: 200, height: 120, x: 0, y: 0 },
+        React.createElement('box', {
+          ref,
+          style: { marginTop: 30, marginLeft: 20, width: 80, height: 20 },
+        }),
+      ),
+      app,
+    );
+    await settle(app);
+
+    const root = app.X.display.screen[0].root;
+    // Stand in for a reparenting window manager: a frame at (150, 90) with
+    // the client inside it, offset by a titlebar. After this the client's
+    // ConfigureNotify coordinates are relative to the frame, which is
+    // exactly the case that put popups in the corner of the screen.
+    const frame = app.X.AllocID();
+    app.X.CreateWindow(frame, root, 150, 90, 220, 150);
+    app.X.ReparentWindow(wnd.id, frame, 10, 25);
+    app.X.MapWindow(frame);
+    await settle(app);
+
+    wnd._reactX11Node._refreshScreenOrigin();
+    await settle(app);
+
+    const node = ref.current;
+    const rect = anchorRect(node, { placement: 'bottom', height: 40 });
+    // frame at 150,90 + client at 10,25 inside it + the box at 20,30
+    assert.strictEqual(rect.x, 150 + 10 + 20, 'x is measured from the root');
+    assert.strictEqual(
+      rect.y,
+      90 + 25 + 30 + 20 + 2,
+      'and y clears the trigger, in root coordinates',
+    );
+    assert.deepStrictEqual(
+      wnd._screenOrigin,
+      { x: 160, y: 115 },
+      'the origin came from the server, not from ConfigureNotify',
+    );
 
     ReactX11.unmountComponentAtNode(app);
     await settle(app);


### PR DESCRIPTION
A `<popup>` is placed in **root** coordinates, worked out as the owner window's position plus the trigger's laid-out rect. The window's position came from `window.x`/`y`, which ntk keeps current from ConfigureNotify — and that is the trap.

**Once a reparenting window manager has put the window inside its frame — which is every WM worth the name — ConfigureNotify reports coordinates relative to the *frame*, not the root.** Adding a frame-relative origin to a window-relative rect gives neither, and the menu opens near the corner of the screen.

That also explains "the first time": ICCCM has the WM send a *synthetic* ConfigureNotify carrying root-relative coordinates when it moves a window. Move the window once and the cached value becomes correct, so the bug looks like a first-open glitch rather than what it is.

## The fix

The server will translate on request, and its answer is right whatever the WM did. The origin now comes from `TranslateCoordinates(window, root, 0, 0)`, cached on the window and refreshed:

- when the window is **realized** — before anything can be anchored to it, so the first popup is placed as well as the second;
- whenever it is **configured** — a move or a reparent both arrive that way.

`window.x`/`y` remain the fallback for the headless mock, which has no server to ask.

This is one place; `Select`, both menus and `Tooltip` all anchor through the same `anchorRect`.

## Test

It stands a real frame up inside the in-process X server rather than mocking the geometry: a frame window at `150,90` with the client reparented `10,25` inside it, which is what a titlebar does to you. Then it asserts the anchor lands at `150+10+20` across and clears the trigger going down, and that the cached origin is `{160, 115}` — the value only the server knows.

It fails without the fix, placing the popup at the client-relative coordinates that put it in the corner.

`npm test` 187 passing, `npm run lint` clean.
