### PR TITLE
feat(examples): a reparenting window manager, frames and all

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,13 @@ that are easy to get wrong, all of which cost time here:
 - **Drags need a real pointer grab.** react-x11's `capturePointer()` only
   routes events that already arrived at the window; the X grab is what
   keeps the server sending them once the pointer leaves the frame.
+- **Icons come from two places.** `_NET_WM_ICON` (EWMH) is ARGB pixels in a
+  property, what GTK and Qt set; `WM_HINTS` (ICCCM) points at a server-side
+  pixmap plus an optional 1-bit mask, what xterm and the other classic
+  clients still set. Reading only one leaves half the windows blank. A
+  depth-1 icon is a stencil, not a picture — draw the set bits in the
+  frame's foreground and leave the rest transparent, or it arrives as a
+  black square.
 
 ## Framed screenshots
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,18 +65,28 @@ no override-redirect staging (issue #4).
 - `test/smoke.test.js` — headless tests over a mock ntk app object.
 - `test/integration.test.js` — end-to-end against node-x11's in-process
   pure-JS X server with pixel-readback assertions. No `$DISPLAY` needed.
+- `test/wm.test.js` — the window-manager example against that same server,
+  two connections: one plays the WM, the other an application. Needs
+  x11 >= 3.2.0, which is where substructure redirect landed.
 
 ## Commands
 
 - `npm test` — node:test. **Headless: no X server needed.** Primary feedback
   loop; keep it green and extend it when touching the host config.
 - `npm run lint` / `npm run format` — ESLint 9 (flat config) + Prettier.
-- `npm run examples:{app,theming,simple,simple-nojsx,xeyes,dashboard,tasks,menu,form,richtext,widgets,windows}`
+- `npm run examples:{app,theming,simple,simple-nojsx,xeyes,dashboard,tasks,menu,form,richtext,widgets,windows,wm}`
   — need a running X server (`DISPLAY` set; XQuartz on macOS, Xvfb for
   automation). `examples:app` is the showcase: it hosts `form`, `widgets`
   and `tasks` as tabs by importing the panel each of them exports, so a new
   control gets demonstrated there rather than in yet another example. All examples export their App and skip auto-running under
   `REACT_X11_NO_AUTORUN=1` so scripts/tests can import them.
+- `npm run examples:wm` — the reparenting **window manager** (issue #3). It
+  claims the root window, so it needs a display no other WM owns: run
+  `Xephyr :10 -screen 1200x800` and point it there. `examples/wm-core.js`
+  is the protocol half (claim the root, answer map/configure requests, keep
+  the client list, EWMH, alt+tab) and `examples/wm.jsx` is the React half —
+  each frame is a `<window>` whose titlebar, buttons and eight resize
+  handles are components. Notes below under "Writing a window manager".
 - `npm run examples:tasks:hot` — the tasks example with hot reloading via
   React **Fast Refresh**: edit `examples/tasks.jsx` while it runs and the
   edited components update in place — connection, window, and component
@@ -114,6 +124,46 @@ no override-redirect staging (issue #4).
   they are generated on demand, not committed). Needs a real `DISPLAY`
   with a **reparenting** WM; `npm run screenshots` has no WM at all and
   therefore no frames. See "Framed screenshots" below.
+
+## Writing a window manager
+
+`examples/wm.jsx` is the other side of everything above: instead of being a
+client the window manager decorates, it _is_ the window manager. The things
+that are easy to get wrong, all of which cost time here:
+
+- **Frames must not unmount while they hold a client.** The client is
+  reparented _into_ the frame, and X destroys children with their parent —
+  so minimizing unmaps the frame rather than removing it from the tree, and
+  a client that withdraws is reparented back to the root before its frame
+  goes away. `addToSaveSet` covers only the case where the WM itself exits.
+- **ConfigureRequest carries a value mask.** The geometry fields that the
+  mask does not name hold the window's _current_ values, not a request.
+  Honour the mask or you will "move" windows to where they already are.
+- **Redirect the frame too, before reparenting into it.** A window's
+  requests go to whoever holds SubstructureRedirect on its _parent_, and
+  after the reparent that is the frame, not the root. Miss this and a
+  client that resizes itself does it behind the WM's back, leaving the
+  window a different size from the frame drawn around it.
+- **Answer requests you refuse** (ICCCM 4.1.5). A reparented client's own
+  ConfigureNotify has frame-relative coordinates, and a refused request
+  produces none at all — clients that resize themselves then hang. Both are
+  answered with `sendConfigureNotify` in root coordinates.
+- **Do not select `ButtonPress` on a client window.** Only one client at a
+  time may hold it and the application already does, so it fails with
+  BadAccess. Click-to-focus uses a synchronous `grabButton` plus
+  `app.allowEvents('replay')`, which hands the same click back to the app.
+- **Focus only viewable windows.** `SetInputFocus` on a window that is not
+  yet mapped is a BadMatch, so focus is taken after the frame is attached
+  and both are mapped, not when the client is first seen.
+- **Resolve keycodes from `GetKeyboardMapping`,** not from ntk's
+  `keycode2keysyms`: that copy is filled from a reply that may not have
+  landed, and a keycode guessed from a half-built map grabs a key nobody
+  presses. Grab every keycode that carries the keysym, and every
+  combination of CapsLock/NumLock — a passive grab only fires on an exact
+  modifier match.
+- **Drags need a real pointer grab.** react-x11's `capturePointer()` only
+  routes events that already arrived at the window; the X grab is what
+  keeps the server sending them once the pointer leaves the frame.
 
 ## Framed screenshots
 
@@ -255,10 +305,11 @@ phase 2 (events, `<scrollview>`), phase 3's `<popup>` and `<textinput>`
 (on ntk 3.2.0: clipboard, cursors, setLineDash), and the layout debug
 overlay (`REACT_X11_DEBUG_LAYOUT=1`). Element default actions (textinput
 editing, scrollview wheel) run via `_default*` hooks on nodes AFTER user
-prop handlers, skipped on `preventDefault()`. Next: `<select>`/menus as
+prop handlers, skipped on `preventDefault()`. The window-manager example
+(issue #3) is done — on ntk 3.9.0 and node-x11 3.2.0, which grew the
+substructure-redirect support it needed. Next: `<select>`/menus as
 components, DevTools highlight-on-hover, npm publish. Open GitHub issues:
-#3 window manager example, #4 top-down rendering, #13
-react-native-dom-like architecture.
+#4 top-down rendering, #13 react-native-dom-like architecture.
 
 ## Pull requests
 

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -506,8 +506,12 @@ menus/tooltips.
 - DevTools: highlight-on-hover from the DevTools tree to the window
   (we own hit rects, so this is easy), inspect computed yoga layout.
 - Hot reload example (react-refresh + a file watcher), widget-gallery
-  example, window-manager example via SubstructureRedirect
-  (`child-event`/`map_request` support already exists in ntk) — issue #3.
+  example — both done. Window-manager example via SubstructureRedirect —
+  **done** (`examples/wm.jsx`, issue #3). ntk's `child-event` turned out to
+  drop the event payload, so a ConfigureRequest arrived without the
+  geometry needed to answer it; fixed upstream along with property reads
+  and the rest of the WM surface (ntk 3.9.0), over substructure redirect in
+  node-x11's in-process server (3.2.0) so it can be tested headlessly.
 - npm publish with the examples runnable via `npx`.
 
 ## 10. Open questions

--- a/README.md
+++ b/README.md
@@ -155,7 +155,9 @@ User handlers run before element default actions and can
 
 ## Examples
 
-All need an X server (`DISPLAY` set; XQuartz on macOS, Xvfb for automation):
+All need an X server (`DISPLAY` set; XQuartz on macOS, Xvfb for automation).
+[`examples/README.md`](examples/README.md) describes each one and how to
+explore them:
 
 ```sh
 npm run examples:simple        # hello world (JSX via tsx)
@@ -184,17 +186,18 @@ resizes, focuses and closes them. The frames are ordinary react-x11
 components with `onMouseDown` handlers, and the application is a foreign X
 window reparented inside.
 
-It has to own the display, so run it against a nested server rather than
-the one managing your desktop:
+Only one window manager may own a display, so run it against a nested
+server rather than the one managing your desktop:
 
 ```sh
 Xephyr :10 -screen 1200x800 &
-DISPLAY=unix/:10 npm run examples:wm
+DISPLAY=:10 npm run examples:wm
 DISPLAY=:10 xterm &                    # give it something to manage
 ```
 
-(`unix/:10` rather than `:10` because node-x11 on macOS only takes the unix
-socket when the display name asks for it; on Linux `:10` is enough.)
+To have it manage your real session instead — including replacing
+`quartz-wm` on macOS, which XQuartz has a hook for — see
+[`examples/README.md`](examples/README.md#the-window-manager).
 
 ### Hot reloading
 

--- a/README.md
+++ b/README.md
@@ -169,10 +169,32 @@ npm run examples:menu          # right-click context menu via <popup>
 npm run examples:form          # <textinput> + Select dropdowns
 npm run examples:gl            # raw GL in a <glarea> (display-list cube)
 npm run examples:three         # <Canvas3D> scene: meshes, lights, textures
+npm run examples:wm            # a reparenting window manager (see below)
 ```
 
 The two GL examples additionally need a server with **indirect GLX**
 enabled (`+iglx` / `AllowIndirectGLX` — off by default on many).
+
+### Window manager
+
+`examples:wm` is a real reparenting window manager: it takes over the root
+window, puts every application's window inside a frame it draws, and moves,
+resizes, focuses and closes them. The frames are ordinary react-x11
+`<window>`s — the titlebar, the buttons and the eight resize handles are
+components with `onMouseDown` handlers, and the application is a foreign X
+window reparented inside.
+
+It has to own the display, so run it against a nested server rather than
+the one managing your desktop:
+
+```sh
+Xephyr :10 -screen 1200x800 &
+DISPLAY=unix/:10 npm run examples:wm
+DISPLAY=:10 xterm &                    # give it something to manage
+```
+
+(`unix/:10` rather than `:10` because node-x11 on macOS only takes the unix
+socket when the display name asks for it; on Linux `:10` is enough.)
 
 ### Hot reloading
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,208 @@
+# Examples
+
+Runnable demos, each a single file you can read top to bottom. They all need
+an X server — a Linux desktop, XQuartz on macOS, or `Xvfb`/`Xephyr` for
+something disposable — and they all read `$DISPLAY`.
+
+```sh
+npm run examples:simple        # start here
+```
+
+Every example also exports its `App` (and most export a panel) and skips
+auto-running under `REACT_X11_NO_AUTORUN=1`, so the screenshot scripts and
+tests can import them without opening a window.
+
+## The tour
+
+Roughly in the order worth reading them:
+
+|                                      |                                                                                              |
+| ------------------------------------ | -------------------------------------------------------------------------------------------- |
+| [`simple.jsx`](simple.jsx)           | hello world: flex layout and text, no pixel math. `npm run examples:simple`                  |
+| [`simple-nojsx.js`](simple-nojsx.js) | the same thing in plain node with `React.createElement` — no build step at all               |
+| [`xeyes.jsx`](xeyes.jsx)             | the `<canvas>` escape hatch: custom drawing plus hooks for state and polling                 |
+| [`dashboard.jsx`](dashboard.jsx)     | context for theming, `useState`/`useEffect`/`useMemo`, a custom hook, hover and focus states |
+| [`tasks.jsx`](tasks.jsx)             | `useReducer`, dispatch through context, list rendering, `<scrollview>`, keyboard throughout  |
+| [`form.jsx`](form.jsx)               | `<textinput>`, `Select`, `RadioGroup`, `Slider`, `Checkbox`, and a modal `Dialog`            |
+| [`widgets.jsx`](widgets.jsx)         | the gallery: every standard component in one window, with a live `<markdown>` preview        |
+| [`menu.jsx`](menu.jsx)               | `MenuBar` and `ContextMenu` over real `<popup>` windows that flip at screen edges            |
+| [`theming.jsx`](theming.jsx)         | the style engine end to end: three themes in light and dark, switched at runtime             |
+| [`richtext.jsx`](richtext.jsx)       | `<markdown>` with mermaid and math, a live `<tex>` formula, JSX `<svg>`, `<image>`           |
+| [`windows.jsx`](windows.jsx)         | many top-level windows from one React tree, sharing state, closing via `onCloseRequest`      |
+| [`app.jsx`](app.jsx)                 | the showcase: `SplitPane` + `Tabs` hosting `form`, `widgets` and `tasks` as panels           |
+| [`gl.jsx`](gl.jsx)                   | raw GL in a `<glarea>`, compiled to a server-side display list                               |
+| [`three.jsx`](three.jsx)             | a react-three-fiber-shaped `<Canvas3D>` scene: meshes, lights, textures                      |
+| [`wm.jsx`](wm.jsx)                   | **a reparenting window manager** — see below                                                 |
+
+`app.jsx` is where a new control should get demonstrated: it imports the
+panel each of `form`, `widgets` and `tasks` exports, so adding a widget
+there shows it off without yet another example file.
+
+The two GL examples need a server with **indirect GLX** enabled — it is off
+by default nearly everywhere. Xorg takes `+iglx` on the command line or
+`AllowIndirectGLX` in the config; XQuartz has its own setting:
+
+```sh
+defaults write org.xquartz.X11 enable_iglx -bool true   # then restart XQuartz
+```
+
+## Hot reloading
+
+```sh
+npm run examples:tasks:hot     # then edit examples/tasks.jsx while it runs
+```
+
+Edited components update in place through React Fast Refresh — the
+connection, the window and component state (the task list, half-typed input)
+all survive. [`tasks-hot.jsx`](tasks-hot.jsx) is the accept boundary,
+[`hmr-register.mjs`](hmr-register.mjs) is the loader chain, and
+[`tasks-context.js`](tasks-context.js) exists so context identity survives a
+reload. The constraints on what may live inside a hot module are in
+[AGENTS.md](../AGENTS.md#commands).
+
+## The window manager
+
+[`wm.jsx`](wm.jsx) is a real reparenting window manager: it takes over the
+root window, puts every application's window inside a frame it draws, and
+moves, resizes, focuses and closes them.
+
+- [`wm-core.js`](wm-core.js) — the protocol half: claim the root, answer map
+  and configure requests, keep the client list, EWMH, alt+tab
+- [`wm.jsx`](wm.jsx) — the React half: frames, taskbar, drag gestures
+
+Every frame is an ordinary `<window>`. The titlebar, its three buttons and
+the eight resize handles are components with `onMouseDown` handlers, and the
+application being managed is a foreign X window reparented inside.
+
+Drag the titlebar to move and any edge or corner to resize. The three
+titlebar buttons are minimize, maximize and close, in that order;
+double-clicking the titlebar also maximizes. Click anywhere in a window to
+focus and raise it, or alt+tab to cycle. Minimized windows go to the
+taskbar and come back when you click them there.
+
+**Only one window manager may run on a display at a time**, so it cannot
+just be started alongside the one you already have — it will exit with
+`another window manager is already running on this display`. Pick one of the
+two ways below.
+
+### A nested server (recommended, and safe)
+
+`Xephyr` is an X server that displays in a window on your existing desktop.
+Nothing outside that window is affected, and you can kill it at any time.
+
+```sh
+Xephyr :10 -screen 1200x800 &          # a 1200x800 "screen" in a window
+DISPLAY=:10 npm run examples:wm        # the window manager owns :10
+DISPLAY=:10 xterm &                    # give it something to manage
+DISPLAY=:10 xclock -geometry 200x200 &
+```
+
+Any X client works, including the other examples in this folder:
+
+```sh
+DISPLAY=:10 npm run examples:widgets
+```
+
+On Linux, `Xephyr` is usually in a package called `xserver-xephyr` or
+`xorg-x11-server-Xephyr`. On macOS it ships with XQuartz at
+`/opt/X11/bin/Xephyr`, and runs inside your XQuartz session.
+
+> **macOS:** if `DISPLAY=:10` fails with `ECONNREFUSED`, use
+> `DISPLAY=unix/:10`. node-x11 used to read a plain `:N` on macOS as TCP
+> port `6000+N`; `unix/` forces the socket and works on every version.
+
+### Replacing the window manager you already have
+
+If you want it managing your real session, the previous window manager has
+to go. How depends on the platform.
+
+**Linux.** Start a bare X session and make this the window manager it
+launches, rather than fighting a desktop environment:
+
+```sh
+echo "cd $PWD && exec npm run examples:wm" > ~/.xinitrc
+startx
+```
+
+Replacing the window manager of a _running_ session works with the
+standalone ones (`openbox`, `i3`, `xfwm4` — stop it, start this) but not
+under GNOME, where `mutter` is the session compositor and killing it logs
+you out.
+
+**macOS.** XQuartz starts `quartz-wm` from
+`/opt/X11/etc/X11/xinit/xinitrc.d/99-quartz-wm.sh`, whose first line is a
+hook for exactly this:
+
+```sh
+[ -n "${USERWM}" -a -x "${USERWM}" ] && exec "${USERWM}"
+```
+
+So point `USERWM` at an executable and XQuartz runs it _instead of_
+`quartz-wm`. Do not just kill `quartz-wm`: that script `exec`s it, making it
+the X session's main process, so killing it takes the whole session down.
+
+1. Write a launcher, somewhere stable, and make it executable:
+
+   ```sh
+   cat > ~/react-x11-wm.sh <<'EOF'
+   #!/bin/sh
+   # XQuartz hands us DISPLAY=:N, which older node-x11 reads as TCP on macOS.
+   # Harmless once that is fixed, and it cannot be worked around from outside:
+   # the window manager is started *by* the server.
+   [ "${DISPLAY#*/}" = "$DISPLAY" ] && DISPLAY="unix/$DISPLAY"
+   export DISPLAY
+   cd /path/to/react-x11
+   exec node --import ./node_modules/tsx/dist/loader.mjs examples/wm.jsx \
+     > /tmp/react-x11-wm.log 2>&1
+   EOF
+   chmod +x ~/react-x11-wm.sh
+   ```
+
+   Use an absolute path to `node` if you use a version manager — XQuartz is
+   launched by `launchd` and will not have your shell's `PATH`.
+
+2. Put it in the environment `launchd` hands to XQuartz, then restart
+   XQuartz so the new session picks it up:
+
+   ```sh
+   launchctl setenv USERWM ~/react-x11-wm.sh
+   osascript -e 'tell application "XQuartz" to quit'
+   open -a XQuartz
+   ```
+
+3. Open something to manage — XQuartz's Applications menu, or:
+
+   ```sh
+   xterm &
+   ```
+
+   `/tmp/react-x11-wm.log` has anything that went wrong.
+
+To put `quartz-wm` back:
+
+```sh
+launchctl unsetenv USERWM
+osascript -e 'tell application "XQuartz" to quit'
+open -a XQuartz
+```
+
+XQuartz runs **rootless** by default: each top-level X window becomes a
+macOS window and there is no visible root, so the desktop background and the
+taskbar have nowhere to appear. For the full effect turn that off before
+restarting —
+
+```sh
+defaults write org.xquartz.X11 rootless -bool false
+```
+
+— which gives a real full-screen X root; XQuartz's menu then has an item for
+switching between it and macOS. Set it back to `true` when you are done.
+
+### Writing your own
+
+The things that are easy to get wrong — why a frame must not unmount while
+it holds a client, why the frame needs redirecting too, why `ButtonPress`
+cannot be selected on a client window — are collected in
+[AGENTS.md](../AGENTS.md#writing-a-window-manager). `test/wm.test.js` drives
+the whole thing headlessly against node-x11's in-process X server, which is
+the fastest way to try a change.

--- a/examples/README.md
+++ b/examples/README.md
@@ -80,6 +80,27 @@ double-clicking the titlebar also maximizes. Click anywhere in a window to
 focus and raise it, or alt+tab to cycle. Minimized windows go to the
 taskbar and come back when you click them there.
 
+#### Where the icons come from
+
+The icon in each titlebar and taskbar entry is the application's own, and
+there are two standards for finding it — clients use one or the other, so a
+window manager that reads only one shows blanks for half of them:
+
+- **`_NET_WM_ICON`** (EWMH, modern) — ARGB pixels in a property, in as many
+  sizes as the application cares to offer. This is what GTK and Qt set, and
+  the window manager picks the smallest size that is still big enough.
+- **`WM_HINTS`** (ICCCM, older) — the property names a _pixmap_ living on
+  the server, optionally with a 1-bit mask saying which of its pixels count.
+  This is what xterm, xclock and xlogo still set, so it is the one you can
+  see working locally. A 1-bit icon carries no colour of its own and is
+  drawn as a stencil in the titlebar's foreground.
+
+A third route exists on Linux desktops and is deliberately not implemented
+here: match `WM_CLASS` against a freedesktop `.desktop` file and look the
+`Icon=` name up in an icon theme. That is how applications that ship no icon
+at all still get one, but it is a filesystem convention rather than anything
+X knows about.
+
 **Only one window manager may run on a display at a time**, so it cannot
 just be started alongside the one you already have — it will exit with
 `another window manager is already running on this display`. Pick one of the

--- a/examples/wm-core.js
+++ b/examples/wm-core.js
@@ -22,6 +22,7 @@ const MOD2 = 16;
 export const BORDER = 4;
 export const TITLE_H = 26;
 export const TASKBAR_H = 32;
+export const ICON_SIZE = 16;
 
 export const frameWidth = (clientWidth) => clientWidth + 2 * BORDER;
 export const frameHeight = (clientHeight) =>
@@ -34,6 +35,97 @@ const CW_WIDTH = 0x04;
 const CW_HEIGHT = 0x08;
 
 const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+// ---------------------------------------------------------------------------
+// Application icons
+//
+// There are two standards and clients use one or the other. EWMH
+// `_NET_WM_ICON` is the modern one: ARGB pixels in a property, in as many
+// sizes as the application cares to offer, which is what GTK and Qt set.
+// ICCCM `WM_HINTS` is what came before it: a pointer to a pixmap living on
+// the server, which is what xterm and the rest of the classic clients still
+// set. A window manager that only reads one of them shows blanks for half
+// the windows on a normal desktop.
+//
+// (A third route exists on Linux desktops — match `WM_CLASS` against a
+// freedesktop .desktop file and look the name up in an icon theme — which is
+// how applications that ship no icon at all still get one. That is a
+// filesystem convention rather than an X one, so it is out of scope here.)
+// ---------------------------------------------------------------------------
+
+const ICON_PIXMAP_HINT = 0x04; // WM_HINTS flags
+const ICON_MASK_HINT = 0x20;
+
+/** Prefer the smallest icon that is still at least `wanted` across. */
+function betterFit(candidate, current, wanted) {
+  if (!current) return true;
+  const fits = candidate >= wanted;
+  const fitted = current >= wanted;
+  if (fits !== fitted) return fits;
+  return fits ? candidate < current : candidate > current;
+}
+
+/**
+ * `_NET_WM_ICON`: a run of [width, height, width*height ARGB pixels] blocks,
+ * repeated once per size the application offers.
+ */
+export function parseNetWmIcon(words, wanted) {
+  let best = null;
+  for (let i = 0; i + 2 <= words.length;) {
+    const width = words[i];
+    const height = words[i + 1];
+    const count = width * height;
+    if (!width || !height || i + 2 + count > words.length) break;
+    if (betterFit(width, best?.width, wanted)) {
+      best = { width, height, pixels: words.slice(i + 2, i + 2 + count) };
+    }
+    i += 2 + count;
+  }
+  if (!best) return null;
+  const data = Buffer.alloc(best.width * best.height * 4);
+  for (let n = 0; n < best.pixels.length; n++) {
+    const argb = best.pixels[n];
+    data[n * 4] = (argb >>> 16) & 0xff;
+    data[n * 4 + 1] = (argb >>> 8) & 0xff;
+    data[n * 4 + 2] = argb & 0xff;
+    data[n * 4 + 3] = (argb >>> 24) & 0xff;
+  }
+  return { width: best.width, height: best.height, data };
+}
+
+/** Bit (x, y) of a depth-1 image: rows padded to 32 bits, LSB leftmost. */
+function bitAt(image, width, x, y) {
+  const stride = Math.ceil(width / 32) * 4;
+  return (image.data[y * stride + (x >> 3)] >> (x & 7)) & 1;
+}
+
+/**
+ * Read a drawable as RGBA. A depth-1 icon is a stencil rather than a
+ * picture — it carries no colour of its own, so it is drawn in the
+ * titlebar's foreground with the unset bits left transparent, which is what
+ * makes xlogo's outline read on a dark frame instead of arriving as a black
+ * square. Deeper icons come back as four bytes per pixel, BGRX.
+ */
+function drawableToRgba(image, width, height) {
+  const data = Buffer.alloc(width * height * 4);
+  if (image.depth === 1) {
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const n = (y * width + x) * 4;
+        data[n] = data[n + 1] = data[n + 2] = 0xff;
+        data[n + 3] = bitAt(image, width, x, y) ? 0xff : 0x00;
+      }
+    }
+    return data;
+  }
+  for (let n = 0; n < width * height; n++) {
+    data[n * 4] = image.data[n * 4 + 2];
+    data[n * 4 + 1] = image.data[n * 4 + 1];
+    data[n * 4 + 2] = image.data[n * 4];
+    data[n * 4 + 3] = 0xff;
+  }
+  return data;
+}
 
 /**
  * Where a resize drag leaves the window. `edges` is which sides the handle
@@ -134,6 +226,7 @@ export class WindowManager {
     this.root.on('configure_request', (ev) => this.onConfigureRequest(ev));
 
     await this.announce();
+    await this.internWatchedAtoms();
     this.paintDesktop();
     this.watchClientClicks();
 
@@ -177,6 +270,22 @@ export class WindowManager {
       ].map((name) => this.root.atom(name)),
     );
     await this.root.setProperty('_NET_SUPPORTED', supported, { type: 'ATOM' });
+  }
+
+  /**
+   * The properties worth reacting to when a client changes one. A
+   * PropertyNotify names the atom that changed, so knowing these ids up
+   * front turns "something changed, re-read everything" into one targeted
+   * read — and applications change properties a lot.
+   */
+  async internWatchedAtoms() {
+    const [wmName, netWmName, netWmIcon, wmHints] = await Promise.all(
+      ['WM_NAME', '_NET_WM_NAME', '_NET_WM_ICON', 'WM_HINTS'].map((name) =>
+        this.root.atom(name),
+      ),
+    );
+    this._titleAtoms = new Set([wmName, netWmName]);
+    this._iconAtoms = new Set([netWmIcon, wmHints]);
   }
 
   /**
@@ -306,6 +415,7 @@ export class WindowManager {
         .getProperty('WM_TRANSIENT_FOR', { as: 'numbers' })
         .catch(() => null)
     )?.[0];
+    const icon = await this.readIcon(window).catch(() => null);
 
     const minWidth = Math.max(hints.minWidth ?? 0, 80);
     const minHeight = Math.max(hints.minHeight ?? 0, 40);
@@ -327,6 +437,7 @@ export class WindowManager {
       id: window.id,
       window,
       title,
+      icon,
       ...this.placeWindow(width, height),
       width,
       height,
@@ -356,7 +467,12 @@ export class WindowManager {
     // a client unmapping itself is withdrawing (ICCCM); ours stay mapped
     // while minimized, because minimizing unmaps the frame instead
     window.on('unmap', () => this.forget(window.id, { gone: false }));
-    window.on('property', () => this.refreshTitle(window.id));
+    // a client may retitle itself or swap its icon at any time; re-read only
+    // the property that actually changed
+    window.on('property', (ev) => {
+      if (this._titleAtoms?.has(ev.atom)) this.refreshTitle(window.id);
+      else if (this._iconAtoms?.has(ev.atom)) this.refreshIcon(window.id);
+    });
 
     // no focus yet: the client is still unmapped and unframed, and
     // SetInputFocus on a window that is not viewable is a BadMatch.
@@ -382,6 +498,86 @@ export class WindowManager {
       this.focusTopmost();
     }
     this._changed();
+  }
+
+  /** GetImage as a promise. */
+  _getImage(drawable, width, height) {
+    return new Promise((resolve, reject) =>
+      this.X.GetImage(
+        2,
+        drawable,
+        0,
+        0,
+        width,
+        height,
+        0xffffffff,
+        (err, image) => (err ? reject(err) : resolve(image)),
+      ),
+    );
+  }
+
+  _getGeometry(drawable) {
+    return new Promise((resolve, reject) =>
+      this.X.GetGeometry(drawable, (err, geometry) =>
+        err ? reject(err) : resolve(geometry),
+      ),
+    );
+  }
+
+  /**
+   * The application's icon as RGBA, at whatever size it offers closest to
+   * `wanted`. `_NET_WM_ICON` first, then the ICCCM pixmap, then nothing —
+   * plenty of windows have no icon at all and that is not an error.
+   */
+  async readIcon(window, wanted = ICON_SIZE) {
+    const words = await window
+      .getProperty('_NET_WM_ICON', { as: 'numbers' })
+      .catch(() => null);
+    const modern = words?.length ? parseNetWmIcon(words, wanted) : null;
+    if (modern) return modern;
+    return this.readPixmapIcon(window).catch(() => null);
+  }
+
+  /**
+   * The ICCCM route: WM_HINTS names a pixmap, and optionally a 1-bit mask
+   * saying which of its pixels count. Both live on the server, so this is a
+   * read back rather than a property parse.
+   */
+  async readPixmapIcon(window) {
+    const hints = await window
+      .getProperty('WM_HINTS', { as: 'numbers' })
+      .catch(() => null);
+    if (!hints || hints.length < 9 || !(hints[0] & ICON_PIXMAP_HINT))
+      return null;
+
+    const { width, height } = await this._getGeometry(hints[3]);
+    const image = await this._getImage(hints[3], width, height);
+    const data = drawableToRgba(image, width, height);
+
+    // A separate mask says which pixels of a colour icon count. A depth-1
+    // icon needs none — its own bits already are the shape — and a client
+    // that names one anyway points it back at the icon itself.
+    const maskId = hints[0] & ICON_MASK_HINT ? hints[7] : 0;
+    if (image.depth > 1 && maskId && maskId !== hints[3]) {
+      const mask = await this._getImage(maskId, width, height).catch(
+        () => null,
+      );
+      if (mask?.depth === 1) {
+        for (let y = 0; y < height; y++) {
+          for (let x = 0; x < width; x++) {
+            if (!bitAt(mask, width, x, y)) data[(y * width + x) * 4 + 3] = 0;
+          }
+        }
+      }
+    }
+    return { width, height, data };
+  }
+
+  async refreshIcon(id) {
+    const client = this.clients.get(id);
+    if (!client) return;
+    const icon = await this.readIcon(client.window).catch(() => null);
+    if (icon !== client.icon) this._update(id, { icon });
   }
 
   async refreshTitle(id) {

--- a/examples/wm-core.js
+++ b/examples/wm-core.js
@@ -1,0 +1,599 @@
+// The X11 half of the window manager: everything that talks to the server
+// and to the applications being managed. It owns no pixels — it keeps a list
+// of managed clients and tells React about it, and wm.jsx draws the frames.
+//
+// A window manager on X11 is an ordinary client with one privilege: it holds
+// SubstructureRedirect on the root window, so when an application asks to be
+// shown or resized the server asks *us* instead of doing it. Everything
+// below follows from that one fact.
+
+// X11 protocol constants, spelled out rather than imported: x11 is ntk's
+// dependency, not this package's.
+const SUBSTRUCTURE_NOTIFY = 0x00080000; // event masks
+const SUBSTRUCTURE_REDIRECT = 0x00100000;
+const BUTTON_PRESS_EVENT = 4; // event types, not mask bits
+const MAPPING_NOTIFY = 34;
+const MOD1 = 8; // modifiers: Alt, and the two locks that ride along with it
+const LOCK = 2;
+const MOD2 = 16;
+
+// Frame geometry. The client window is reparented into the frame at
+// (BORDER, BORDER + TITLE_H); everything outside that rect is ours to draw.
+export const BORDER = 4;
+export const TITLE_H = 26;
+export const TASKBAR_H = 32;
+
+export const frameWidth = (clientWidth) => clientWidth + 2 * BORDER;
+export const frameHeight = (clientHeight) =>
+  clientHeight + 2 * BORDER + TITLE_H;
+
+// ConfigureRequest value mask bits (X11 CWX, CWY, CWWidth, CWHeight)
+const CW_X = 0x01;
+const CW_Y = 0x02;
+const CW_WIDTH = 0x04;
+const CW_HEIGHT = 0x08;
+
+const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+/**
+ * Where a resize drag leaves the window. `edges` is which sides the handle
+ * moves ('n', 's', 'e', 'w' in any combination); the opposite side stays
+ * exactly where it was, including when the size runs into a limit — which
+ * is the whole reason this is one function and not four lines at each call
+ * site. Pure, so the awkward part is the part that is easy to reason about.
+ */
+export function resizeRect(start, edges, dx, dy, limits) {
+  const { minWidth, minHeight, maxWidth, maxHeight } = limits;
+  let { x, y, width, height } = start;
+
+  if (edges.includes('e')) {
+    width = clamp(start.width + dx, minWidth, maxWidth);
+  } else if (edges.includes('w')) {
+    width = clamp(start.width - dx, minWidth, maxWidth);
+    x = start.x + start.width - width; // right edge pinned
+  }
+  if (edges.includes('s')) {
+    height = clamp(start.height + dy, minHeight, maxHeight);
+  } else if (edges.includes('n')) {
+    height = clamp(start.height - dy, minHeight, maxHeight);
+    y = start.y + start.height - height; // bottom edge pinned
+  }
+  return { x, y, width, height };
+}
+
+/**
+ * The managed-client registry. React subscribes to it with
+ * useSyncExternalStore, so every change here — a new window, a new title, a
+ * drag in progress — is one re-render of the frames.
+ */
+export class WindowManager {
+  constructor(app) {
+    this.app = app;
+    this.X = app.X;
+    this.root = app.rootWindow();
+    this.screen = app.display.screen[0];
+    this.clients = new Map(); // client window id -> record
+    this.focused = null;
+    this._listeners = new Set();
+    this._snapshot = [];
+    this._ourWindows = new Set(); // frames and the taskbar
+    this._placed = 0;
+    this._serial = 0;
+  }
+
+  get workArea() {
+    return {
+      width: this.screen.pixel_width,
+      height: this.screen.pixel_height - TASKBAR_H,
+    };
+  }
+
+  // ---- the store React reads -------------------------------------------
+
+  subscribe = (onChange) => {
+    this._listeners.add(onChange);
+    return () => this._listeners.delete(onChange);
+  };
+
+  getSnapshot = () => this._snapshot;
+
+  /** Rebuild the immutable snapshot and wake React. */
+  _changed() {
+    this._snapshot = [...this.clients.values()].map((client) => ({
+      ...client,
+      focused: client.id === this.focused,
+    }));
+    this.publishState();
+    for (const listener of this._listeners) listener();
+  }
+
+  _update(id, patch) {
+    const client = this.clients.get(id);
+    if (!client) return null;
+    Object.assign(client, patch);
+    this._changed();
+    return client;
+  }
+
+  // ---- becoming the window manager --------------------------------------
+
+  /**
+   * Claim the root and adopt whatever is already on screen. Rejects if
+   * another window manager holds the redirect — only one client may.
+   */
+  async start() {
+    try {
+      await this.root.selectInput(SUBSTRUCTURE_REDIRECT | SUBSTRUCTURE_NOTIFY);
+    } catch {
+      throw new Error(
+        'another window manager is already running on this display',
+      );
+    }
+
+    this.root.on('map_request', (ev) => this.manage(ev.window));
+    this.root.on('configure_request', (ev) => this.onConfigureRequest(ev));
+
+    await this.announce();
+    this.paintDesktop();
+    this.watchClientClicks();
+
+    // adoptExisting first: it round-trips, and ntk fills in the keyboard
+    // map asynchronously right after connecting — grabbing before that
+    // reply lands would find no keycode for Tab and silently do nothing
+    await this.adoptExisting();
+    await this.grabAltTab();
+  }
+
+  /**
+   * The EWMH handshake. Toolkits look for _NET_SUPPORTING_WM_CHECK before
+   * they believe a standards-aware window manager is running, and change
+   * how they behave when they do not find one — so this is not decoration,
+   * it is what makes GTK and Qt applications act normally.
+   */
+  async announce() {
+    // the check window is a dummy that points at itself, which is how a
+    // client tells a live window manager from a stale leftover property
+    const check = this.app.createWindow({ width: 1, height: 1 });
+    this._ourWindows.add(check.id);
+    await check.setProperty('_NET_SUPPORTING_WM_CHECK', [check.id], {
+      type: 'WINDOW',
+    });
+    await check.setProperty('_NET_WM_NAME', 'react-x11-wm');
+    await this.root.setProperty('_NET_SUPPORTING_WM_CHECK', [check.id], {
+      type: 'WINDOW',
+    });
+
+    const supported = await Promise.all(
+      [
+        '_NET_SUPPORTING_WM_CHECK',
+        '_NET_CLIENT_LIST',
+        '_NET_ACTIVE_WINDOW',
+        '_NET_WM_NAME',
+        '_NET_CLOSE_WINDOW',
+        '_NET_WM_STATE',
+        '_NET_WM_STATE_MAXIMIZED_HORZ',
+        '_NET_WM_STATE_MAXIMIZED_VERT',
+        '_NET_WM_STATE_HIDDEN',
+      ].map((name) => this.root.atom(name)),
+    );
+    await this.root.setProperty('_NET_SUPPORTED', supported, { type: 'ATOM' });
+  }
+
+  /**
+   * Publish the client list and which window is active. Called on every
+   * store change, including each motion event of a drag — so it compares
+   * first: two X requests per pixel of mouse movement would be absurd.
+   */
+  publishState() {
+    const ids = [...this.clients.keys()];
+    const signature = `${ids.join(',')}|${this.focused}`;
+    if (signature === this._published) return;
+    this._published = signature;
+    this.root.setProperty('_NET_CLIENT_LIST', ids, { type: 'WINDOW' });
+    this.root.setProperty('_NET_ACTIVE_WINDOW', [this.focused ?? 0], {
+      type: 'WINDOW',
+    });
+  }
+
+  /**
+   * Click-to-focus for the client area. Each managed window gets a
+   * synchronous button grab (see manage), which freezes the pointer and
+   * delivers the press here first; we raise and focus, then hand the very
+   * same click on to the application with allowEvents('replay').
+   *
+   * One subscription to the raw event stream rather than a listener per
+   * window, because asking for the ButtonPress *mask* on a client window
+   * would fail: only one client at a time may hold it, and the application
+   * already does. The grab is what delivers these, not the mask.
+   */
+  watchClientClicks() {
+    this.X.on('event', (ev) => {
+      if (ev.type !== BUTTON_PRESS_EVENT || !this.clients.has(ev.wid)) return;
+      this.focus(ev.wid);
+      this.app.allowEvents('replay');
+    });
+  }
+
+  /** A plain colour behind everything, so the desktop is not a black hole. */
+  paintDesktop(color = 0x1b1d23) {
+    this.X.ChangeWindowAttributes(this.root.id, { backgroundPixel: color });
+    this.X.ClearArea(this.root.id, 0, 0, 0, 0, 0);
+  }
+
+  /**
+   * Alt+Tab, the one keyboard gesture. A window manager cannot just listen
+   * for keys — they go to the focused application — so it asks the server
+   * for this one combination on the root, which leaves every other key
+   * belonging to whoever is focused.
+   *
+   * Re-run whenever the keyboard map changes: the keycode that was Tab a
+   * moment ago may not be any more, and a grab on the old one is a grab on
+   * a key nobody presses.
+   */
+  async grabAltTab() {
+    const TAB = 0xff09; // XK_Tab
+    const { min_keycode: min, max_keycode: max } = this.app.display;
+    // ask the server for the map rather than reading ntk's copy: that one
+    // is filled in from a reply that may not have landed yet, and a keycode
+    // guessed from a half-built map grabs the wrong key
+    const map = await new Promise((resolve) =>
+      this.X.GetKeyboardMapping(min, max - min, (err, list) =>
+        resolve(err ? [] : list),
+      ),
+    );
+    // a layout can put the same keysym on more than one keycode, and any of
+    // them is a real Tab
+    const keycodes = new Set(
+      map.flatMap((syms, i) => (syms.includes(TAB) ? [min + i] : [])),
+    );
+    if (!keycodes.size) return;
+
+    for (const keycode of this._tabKeycodes ?? []) {
+      this.X.UngrabKey(this.root.id, keycode, 0x8000 /* AnyModifier */);
+    }
+    this._tabKeycodes = keycodes;
+
+    // CapsLock and NumLock are part of the modifier state, and a grab only
+    // fires on an exact match — so grab every combination of them, or
+    // alt+tab silently stops working the moment either lock is on
+    for (const keycode of keycodes) {
+      for (const lock of [0, LOCK, MOD2, LOCK | MOD2]) {
+        this.X.GrabKey(this.root.id, false, MOD1 | lock, keycode, 1, 1);
+      }
+    }
+    if (this._watchingKeymap) return;
+    this._watchingKeymap = true;
+    this.X.on('event', (ev) => {
+      if (ev.type === MAPPING_NOTIFY) this.grabAltTab();
+    });
+    this.root.on('keydown', (ev) => {
+      if (this._tabKeycodes.has(ev.keycode)) this.focusNext();
+    });
+  }
+
+  /**
+   * Windows mapped before we started have no frame and will never send a
+   * MapRequest — a window manager has to go and find them.
+   */
+  async adoptExisting() {
+    const tree = await new Promise((resolve, reject) =>
+      this.root.queryTree((err, res) => (err ? reject(err) : resolve(res))),
+    );
+    for (const window of tree.children) {
+      const attributes = await window.getAttributes().catch(() => null);
+      // override-redirect windows (menus, tooltips) opt out of management,
+      // and an unmapped one will ask for itself when it is ready
+      if (!attributes || attributes.overrideRedirect) continue;
+      if (attributes.mapState !== 2) continue;
+      await this.manage(window);
+    }
+  }
+
+  // ---- the client lifecycle ---------------------------------------------
+
+  /** Take a client window under management. The frame follows from React. */
+  async manage(window) {
+    if (this.clients.has(window.id)) return;
+    if (window.id === this.root.id || this._ourWindows.has(window.id)) return;
+
+    const hints = await window.getSizeHints().catch(() => ({}));
+    const title = (await window.getTitle().catch(() => null)) ?? 'untitled';
+    // WM_TRANSIENT_FOR marks a dialog belonging to another window: it stays
+    // above its parent and stays out of the taskbar, which is where the
+    // application itself belongs
+    const transientFor = (
+      await window
+        .getProperty('WM_TRANSIENT_FOR', { as: 'numbers' })
+        .catch(() => null)
+    )?.[0];
+
+    const minWidth = Math.max(hints.minWidth ?? 0, 80);
+    const minHeight = Math.max(hints.minHeight ?? 0, 40);
+    // a window may not open larger than there is room for, frame included —
+    // clients routinely ask for more than the screen has
+    const area = this.workArea;
+    const width = clamp(
+      window.width || 400,
+      minWidth,
+      Math.max(minWidth, area.width - 2 * BORDER),
+    );
+    const height = clamp(
+      window.height || 300,
+      minHeight,
+      Math.max(minHeight, area.height - 2 * BORDER - TITLE_H),
+    );
+
+    const client = {
+      id: window.id,
+      window,
+      title,
+      ...this.placeWindow(width, height),
+      width,
+      height,
+      minWidth,
+      minHeight,
+      maxWidth: hints.maxWidth || Infinity,
+      maxHeight: hints.maxHeight || Infinity,
+      transientFor: transientFor || null,
+      maximized: false,
+      minimized: false,
+      restore: null,
+      serial: ++this._serial,
+      frame: null, // the ntk window of the React <window>, once realized
+    };
+    this.clients.set(window.id, client);
+
+    // If we exit, the server puts the client back where it found it instead
+    // of destroying it along with our frame.
+    window.addToSaveSet();
+
+    // A click anywhere in the client raises and focuses it. The grab is
+    // synchronous, so we see the press before the application does and
+    // decide what happens to it (see watchClientClicks).
+    window.grabButton({ button: 1, pointerMode: 0 });
+
+    window.on('destroy', () => this.forget(window.id, { gone: true }));
+    // a client unmapping itself is withdrawing (ICCCM); ours stay mapped
+    // while minimized, because minimizing unmaps the frame instead
+    window.on('unmap', () => this.forget(window.id, { gone: false }));
+    window.on('property', () => this.refreshTitle(window.id));
+
+    // no focus yet: the client is still unmapped and unframed, and
+    // SetInputFocus on a window that is not viewable is a BadMatch.
+    // attachFrame takes the focus once it is really on screen.
+    this._changed();
+  }
+
+  /**
+   * Stop managing a window. Unless it is already gone, it goes back to
+   * being a child of the root — our frame is about to be unmounted, and
+   * children die with their parent.
+   */
+  forget(id, { gone }) {
+    const client = this.clients.get(id);
+    if (!client) return;
+    if (!gone) {
+      client.window.reparentTo(this.root, client.x, client.y);
+      client.window.removeFromSaveSet();
+    }
+    this.clients.delete(id);
+    if (this.focused === id) {
+      this.focused = null;
+      this.focusTopmost();
+    }
+    this._changed();
+  }
+
+  async refreshTitle(id) {
+    const client = this.clients.get(id);
+    if (!client) return;
+    const title =
+      (await client.window.getTitle().catch(() => null)) ?? 'untitled';
+    if (title !== client.title) this._update(id, { title });
+  }
+
+  /**
+   * The frame's X window, handed over once React has realized it: the
+   * client is reparented inside and both are shown.
+   */
+  attachFrame(id, frame) {
+    const client = this.clients.get(id);
+    if (!client || client.frame === frame) return;
+    client.frame = frame;
+    this._ourWindows.add(frame.id);
+
+    // Redirect the frame *before* reparenting into it. A window's requests
+    // are redirected by whoever holds SubstructureRedirect on its parent —
+    // and after the reparent that is this frame, not the root. Without
+    // this, a client resizing itself would silently do it behind our back,
+    // and its window would no longer match the frame drawn around it.
+    frame.on('configure_request', (ev) => this.onConfigureRequest(ev));
+    frame.on('map_request', (ev) => ev.window.map());
+
+    client.window.reparentTo(frame, BORDER, BORDER + TITLE_H);
+    client.window.resize(client.width, client.height);
+    client.window.map();
+    this.notifyGeometry(client);
+    // now that it is really on screen it can take the keyboard
+    this.focus(id);
+  }
+
+  /**
+   * A client asking to move or resize itself. The value mask says which
+   * fields it actually set — the rest carry the window's current values and
+   * mean nothing.
+   */
+  onConfigureRequest(ev) {
+    const client = this.clients.get(ev.window.id);
+    if (!client) {
+      // not ours yet: let it have what it asked for, so its geometry is
+      // already right by the time it maps and we frame it
+      const values = {};
+      if (ev.mask & CW_X) values.x = ev.x;
+      if (ev.mask & CW_Y) values.y = ev.y;
+      if (ev.mask & CW_WIDTH) values.width = ev.width;
+      if (ev.mask & CW_HEIGHT) values.height = ev.height;
+      if (Object.keys(values).length) {
+        this.X.ConfigureWindow(ev.window.id, values);
+      }
+      return;
+    }
+    // a maximized window does not get to resize itself; ICCCM says tell it
+    // so, or it waits forever for a ConfigureNotify that is not coming
+    if (client.maximized) return this.notifyGeometry(client);
+    this.setGeometry(client.id, {
+      width: ev.mask & CW_WIDTH ? ev.width : client.width,
+      height: ev.mask & CW_HEIGHT ? ev.height : client.height,
+    });
+  }
+
+  // ---- geometry ----------------------------------------------------------
+
+  /** Cascade new windows so they do not all land on top of each other. */
+  placeWindow(width, height) {
+    const step = 28;
+    const slot = this._placed++ % 8;
+    const area = this.workArea;
+    return {
+      x: Math.max(
+        0,
+        Math.min(40 + slot * step, area.width - frameWidth(width)),
+      ),
+      y: Math.max(
+        0,
+        Math.min(40 + slot * step, area.height - frameHeight(height)),
+      ),
+    };
+  }
+
+  /**
+   * Apply a frame rect. Callers that drag an edge have already decided the
+   * exact rect (see resizeRect); everything else gets its size clamped here.
+   */
+  setGeometry(id, rect) {
+    const client = this.clients.get(id);
+    if (!client) return;
+    const next = {
+      x: Math.round(rect.x ?? client.x),
+      y: Math.round(rect.y ?? client.y),
+      width: clamp(
+        Math.round(rect.width ?? client.width),
+        client.minWidth,
+        client.maxWidth,
+      ),
+      height: clamp(
+        Math.round(rect.height ?? client.height),
+        client.minHeight,
+        client.maxHeight,
+      ),
+    };
+    const resized =
+      next.width !== client.width || next.height !== client.height;
+    const updated = this._update(id, next);
+    // a plain move does not touch the client: it rides along inside the
+    // frame, and one ConfigureWindow per motion event is enough
+    if (resized) updated.window.resize(next.width, next.height);
+    this.notifyGeometry(updated);
+  }
+
+  toggleMaximize(id) {
+    const client = this.clients.get(id);
+    if (!client) return;
+    const area = this.workArea;
+    const next = client.maximized
+      ? { ...client.restore, maximized: false, restore: null }
+      : {
+          restore: {
+            x: client.x,
+            y: client.y,
+            width: client.width,
+            height: client.height,
+          },
+          maximized: true,
+          x: 0,
+          y: 0,
+          width: area.width - 2 * BORDER,
+          height: area.height - 2 * BORDER - TITLE_H,
+        };
+    const updated = this._update(id, next);
+    updated.window.resize(updated.width, updated.height);
+    this.notifyGeometry(updated);
+  }
+
+  minimize(id) {
+    const client = this._update(id, { minimized: true });
+    // unmap the frame rather than unmounting it: the client is a child of
+    // the frame now, and children are destroyed with their parent
+    client?.frame?.unmap();
+    if (this.focused === id) {
+      this.focused = null;
+      this.focusTopmost();
+      this._changed();
+    }
+  }
+
+  restore(id) {
+    const client = this._update(id, { minimized: false });
+    client?.frame?.map();
+    this.focus(id);
+  }
+
+  // ---- focus and stacking -------------------------------------------------
+
+  focus(id) {
+    const client = this.clients.get(id);
+    if (!client || client.minimized || this.focused === id) return;
+    this.focused = id;
+    // raise the frame, not the client: the client lives inside it now
+    client.frame?.raise();
+    // dialogs belonging to this window ride above it
+    for (const other of this.clients.values()) {
+      if (other.transientFor === id) other.frame?.raise();
+    }
+    client.window.focus();
+    this._changed();
+  }
+
+  focusTopmost() {
+    const next = [...this.clients.values()]
+      .filter((client) => !client.minimized)
+      .sort((a, b) => b.serial - a.serial)[0];
+    if (next) this.focus(next.id);
+  }
+
+  /** Alt+Tab: the next window in the list, wrapping. */
+  focusNext() {
+    const open = [...this.clients.values()].filter(
+      (client) => !client.minimized,
+    );
+    if (!open.length) return;
+    const index = open.findIndex((client) => client.id === this.focused);
+    const next = open[(index + 1) % open.length];
+    // bump it to the top of the focus order so repeated Alt+Tab keeps moving
+    next.serial = ++this._serial;
+    this.focus(next.id);
+  }
+
+  async close(id) {
+    await this.clients.get(id)?.window.close();
+  }
+
+  /**
+   * ICCCM 4.1.5: a reparented client's own ConfigureNotify carries
+   * coordinates relative to its frame, which is not what it asked about.
+   * Tell it where it really is, in root coordinates.
+   */
+  notifyGeometry(client) {
+    client?.window.sendConfigureNotify({
+      x: client.x + BORDER,
+      y: client.y + BORDER + TITLE_H,
+      width: client.width,
+      height: client.height,
+    });
+  }
+
+  /** Windows we created ourselves — never candidates for management. */
+  claim(window) {
+    this._ourWindows.add(window.id);
+  }
+}

--- a/examples/wm.jsx
+++ b/examples/wm.jsx
@@ -18,13 +18,16 @@
 import React, {
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useSyncExternalStore,
 } from 'react';
+import { Image } from 'ntk';
 import { createRoot, createStyles } from '../src/index.js';
 
 import {
   BORDER,
+  ICON_SIZE,
   TASKBAR_H,
   TITLE_H,
   WindowManager,
@@ -79,11 +82,13 @@ const s = createStyles({
     gap: 6,
   },
   taskbarItem: {
-    paddingLeft: 10,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingLeft: 8,
     paddingRight: 10,
     height: 22,
     borderRadius: 4,
-    justifyContent: 'center',
     backgroundColor: theme.taskbarItem,
     cursor: 'pointer',
     ':hover': { backgroundColor: '#57606f' },
@@ -170,6 +175,25 @@ function useDrag(frameRef, onMove) {
   return { onMouseDown, onMouseMove, onMouseUp };
 }
 
+/**
+ * The application's icon, whatever size it gave us, scaled into `size` by
+ * the server: ntk uploads the pixels once as a picture and XRender does the
+ * rest, so a 48x48 icon in a 16px slot costs one composite per repaint.
+ * Renders nothing when the window has no icon — plenty do not.
+ */
+function Icon({ icon, size = ICON_SIZE }) {
+  // the same icon object rides along in every snapshot, so this uploads once
+  const image = useMemo(() => (icon ? new Image(icon) : null), [icon]);
+  useEffect(() => () => image?.destroy(), [image]);
+  if (!image) return null;
+  return (
+    <canvas
+      style={{ width: size, height: size }}
+      onDraw={(ctx) => ctx.drawImage(image, 0, 0, size, size)}
+    />
+  );
+}
+
 function TitleButton({ glyph, onPress, close }) {
   return (
     <box
@@ -242,6 +266,7 @@ function Frame({ wm, client }) {
         onMouseMove={move.onMouseMove}
         onMouseUp={move.onMouseUp}
       >
+        <Icon icon={client.icon} />
         <text style={[s.title, client.focused && s.titleActive]}>
           {client.title}
         </text>
@@ -320,6 +345,7 @@ function Taskbar({ wm, clients }) {
               client.minimized ? wm.restore(client.id) : wm.focus(client.id)
             }
           >
+            <Icon icon={client.icon} />
             <text style={s.taskbarLabel}>
               {client.minimized ? `· ${client.title}` : client.title}
             </text>

--- a/examples/wm.jsx
+++ b/examples/wm.jsx
@@ -1,0 +1,361 @@
+// A reparenting window manager, written in React.
+//
+// Every frame you see is a react-x11 <window>: the titlebar, the buttons and
+// the resize handles are ordinary components with ordinary event handlers,
+// and the application being managed is a foreign X window reparented inside
+// that frame. wm-core.js does the protocol half — claiming the root,
+// answering map and configure requests, keeping the client list — and this
+// file is the part you can restyle.
+//
+// Run it against a nested server so it does not fight the one managing your
+// desktop:
+//
+//   Xephyr :10 -screen 1200x800 &
+//   DISPLAY=unix/:10 npm run examples:wm
+//   DISPLAY=:10 xterm &            # give it something to manage
+//
+// Run with: npm run examples:wm  (needs an X server / DISPLAY with no other WM)
+import React, {
+  useCallback,
+  useEffect,
+  useRef,
+  useSyncExternalStore,
+} from 'react';
+import { createRoot, createStyles } from '../src/index.js';
+
+import {
+  BORDER,
+  TASKBAR_H,
+  TITLE_H,
+  WindowManager,
+  frameHeight,
+  frameWidth,
+  resizeRect,
+} from './wm-core.js';
+
+const theme = {
+  frame: '#2f3542',
+  frameActive: '#3742fa',
+  title: '#f1f2f6',
+  titleDim: '#a4b0be',
+  taskbar: '#1e2029',
+  taskbarItem: '#2f3542',
+  button: '#57606f',
+  close: '#ff4757',
+};
+
+const s = createStyles({
+  frame: { backgroundColor: theme.frame },
+  titlebar: {
+    height: TITLE_H,
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingLeft: 8,
+    gap: 6,
+    cursor: 'move',
+  },
+  title: { flexGrow: 1, color: theme.titleDim, fontSize: 12 },
+  titleActive: { color: theme.title },
+  button: {
+    width: 18,
+    height: 18,
+    borderRadius: 9,
+    backgroundColor: theme.button,
+    alignItems: 'center',
+    justifyContent: 'center',
+    cursor: 'pointer',
+    ':hover': { backgroundColor: '#7f8fa6' },
+  },
+  closeButton: { ':hover': { backgroundColor: theme.close } },
+  buttonGlyph: { fontSize: 9, color: theme.title },
+
+  taskbarWindow: { backgroundColor: theme.taskbar },
+  taskbar: {
+    flexGrow: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingLeft: 8,
+    paddingRight: 8,
+    gap: 6,
+  },
+  taskbarItem: {
+    paddingLeft: 10,
+    paddingRight: 10,
+    height: 22,
+    borderRadius: 4,
+    justifyContent: 'center',
+    backgroundColor: theme.taskbarItem,
+    cursor: 'pointer',
+    ':hover': { backgroundColor: '#57606f' },
+  },
+  taskbarItemActive: { backgroundColor: theme.frameActive },
+  taskbarLabel: { fontSize: 11, color: theme.title },
+  hint: { fontSize: 11, color: theme.titleDim },
+  spacer: { flexGrow: 1 },
+});
+
+// The eight resize handles, named by the edges each one drags. resizeRect
+// turns that plus a pointer delta into a new rect; handleStyle turns it into
+// a strip along the frame's border.
+const HANDLES = ['nw', 'n', 'ne', 'e', 'se', 's', 'sw', 'w'];
+
+const CURSORS = {
+  n: 'ns-resize',
+  s: 'ns-resize',
+  e: 'ew-resize',
+  w: 'ew-resize',
+  nw: 'nwse-resize',
+  se: 'nwse-resize',
+  ne: 'nesw-resize',
+  sw: 'nesw-resize',
+};
+
+/**
+ * A handle hugs the edges it drags and spans the side along the other axis,
+ * inset by BORDER so the corners keep their own square. Corners drag both
+ * axes and so are pinned on both.
+ */
+function handleStyle(edges) {
+  const vertical = edges.includes('n') || edges.includes('s');
+  const horizontal = edges.includes('e') || edges.includes('w');
+  const spanX = vertical && !horizontal ? BORDER : undefined;
+  const spanY = horizontal && !vertical ? BORDER : undefined;
+  return {
+    position: 'absolute',
+    cursor: CURSORS[edges],
+    top: edges.includes('n') ? 0 : spanY,
+    bottom: edges.includes('s') ? 0 : spanY,
+    left: edges.includes('w') ? 0 : spanX,
+    right: edges.includes('e') ? 0 : spanX,
+    width: horizontal ? BORDER : undefined,
+    height: vertical ? BORDER : undefined,
+  };
+}
+
+/**
+ * A pointer drag that keeps working outside the window. Pointer capture
+ * routes the events to this node; the X pointer grab is what makes the
+ * server keep sending them once the pointer leaves the frame — without it a
+ * drag stops at the window edge.
+ */
+function useDrag(frameRef, onMove) {
+  const start = useRef(null);
+
+  const onMouseDown = useCallback(
+    (ev) => {
+      start.current = { x: ev.nativeEvent.rootx, y: ev.nativeEvent.rooty };
+      ev.capturePointer();
+      frameRef.current?.grabPointer({ ownerEvents: false });
+      ev.stopPropagation();
+    },
+    [frameRef],
+  );
+
+  const onMouseMove = useCallback(
+    (ev) => {
+      if (!start.current) return;
+      onMove(
+        ev.nativeEvent.rootx - start.current.x,
+        ev.nativeEvent.rooty - start.current.y,
+      );
+    },
+    [onMove],
+  );
+
+  const onMouseUp = useCallback(() => {
+    start.current = null;
+    frameRef.current?.ungrabPointer();
+  }, [frameRef]);
+
+  return { onMouseDown, onMouseMove, onMouseUp };
+}
+
+function TitleButton({ glyph, onPress, close }) {
+  return (
+    <box
+      style={[s.button, close && s.closeButton]}
+      onMouseDown={(ev) => ev.stopPropagation()}
+      onClick={onPress}
+    >
+      <text style={s.buttonGlyph}>{glyph}</text>
+    </box>
+  );
+}
+
+function Frame({ wm, client }) {
+  const frameRef = useRef(null);
+  // the rect the current drag started from, so every move is measured
+  // against where the window was when the pointer went down
+  const origin = useRef(null);
+  const lastClick = useRef(0);
+
+  // Hand the frame's X window to the core once React has created it: that
+  // is when the client can be reparented inside and shown.
+  useEffect(() => {
+    if (frameRef.current) wm.attachFrame(client.id, frameRef.current);
+  }, [wm, client.id]);
+
+  const remember = () => {
+    origin.current = {
+      x: client.x,
+      y: client.y,
+      width: client.width,
+      height: client.height,
+    };
+  };
+
+  const move = useDrag(frameRef, (dx, dy) => {
+    const from = origin.current;
+    if (from) wm.setGeometry(client.id, { x: from.x + dx, y: from.y + dy });
+  });
+
+  const onTitleDown = (ev) => {
+    wm.focus(client.id);
+    const now = Date.now();
+    if (now - lastClick.current < 400) {
+      lastClick.current = 0;
+      wm.toggleMaximize(client.id);
+      return;
+    }
+    lastClick.current = now;
+    if (client.maximized) return; // a maximized window does not drag
+    remember();
+    move.onMouseDown(ev);
+  };
+
+  return (
+    <window
+      ref={frameRef}
+      x={client.x}
+      y={client.y}
+      width={frameWidth(client.width)}
+      height={frameHeight(client.height)}
+      overrideRedirect
+      style={[
+        s.frame,
+        client.focused && { backgroundColor: theme.frameActive },
+      ]}
+    >
+      <box
+        style={s.titlebar}
+        onMouseDown={onTitleDown}
+        onMouseMove={move.onMouseMove}
+        onMouseUp={move.onMouseUp}
+      >
+        <text style={[s.title, client.focused && s.titleActive]}>
+          {client.title}
+        </text>
+        <TitleButton glyph="—" onPress={() => wm.minimize(client.id)} />
+        <TitleButton
+          glyph={client.maximized ? '❐' : '□'}
+          onPress={() => wm.toggleMaximize(client.id)}
+        />
+        <TitleButton glyph="✕" close onPress={() => wm.close(client.id)} />
+      </box>
+
+      {!client.maximized &&
+        HANDLES.map((edges) => (
+          <ResizeHandle
+            key={edges}
+            edges={edges}
+            wm={wm}
+            client={client}
+            frameRef={frameRef}
+            origin={origin}
+            remember={remember}
+          />
+        ))}
+    </window>
+  );
+}
+
+function ResizeHandle({ edges, wm, client, frameRef, origin, remember }) {
+  const drag = useDrag(frameRef, (dx, dy) => {
+    const from = origin.current;
+    if (!from) return;
+    wm.setGeometry(client.id, resizeRect(from, edges, dx, dy, client));
+  });
+
+  return (
+    <box
+      style={handleStyle(edges)}
+      onMouseDown={(ev) => {
+        wm.focus(client.id);
+        remember();
+        drag.onMouseDown(ev);
+      }}
+      onMouseMove={drag.onMouseMove}
+      onMouseUp={drag.onMouseUp}
+    />
+  );
+}
+
+function Taskbar({ wm, clients }) {
+  const ref = useRef(null);
+  useEffect(() => {
+    if (ref.current) wm.claim(ref.current);
+  }, [wm]);
+
+  const area = wm.workArea;
+  // dialogs belong to the window they came from, not to the taskbar
+  const taskbarClients = clients.filter((client) => !client.transientFor);
+
+  return (
+    <window
+      ref={ref}
+      x={0}
+      y={area.height}
+      width={area.width}
+      height={TASKBAR_H}
+      overrideRedirect
+      style={s.taskbarWindow}
+    >
+      <box style={s.taskbar}>
+        {/* dialogs belong to the window they came from, not to the taskbar */}
+        {taskbarClients.map((client) => (
+          <box
+            key={client.id}
+            style={[s.taskbarItem, client.focused && s.taskbarItemActive]}
+            onClick={() =>
+              client.minimized ? wm.restore(client.id) : wm.focus(client.id)
+            }
+          >
+            <text style={s.taskbarLabel}>
+              {client.minimized ? `· ${client.title}` : client.title}
+            </text>
+          </box>
+        ))}
+        <box style={s.spacer} />
+        <text style={s.hint}>
+          {taskbarClients.length} window{taskbarClients.length === 1 ? '' : 's'}{' '}
+          · alt+tab
+        </text>
+      </box>
+    </window>
+  );
+}
+
+function Desktop({ wm }) {
+  const clients = useSyncExternalStore(wm.subscribe, wm.getSnapshot);
+
+  return (
+    <>
+      <Taskbar wm={wm} clients={clients} />
+      {/* minimized frames stay mounted — the client is a child of the frame
+          now, and unmounting one would take the application with it. The
+          core unmaps them instead. */}
+      {clients.map((client) => (
+        <Frame key={client.id} wm={wm} client={client} />
+      ))}
+    </>
+  );
+}
+
+export default Desktop;
+
+if (!process.env.REACT_X11_NO_AUTORUN) {
+  const root = await createRoot();
+  const wm = new WindowManager(root.app);
+  await wm.start();
+  root.render(<Desktop wm={wm} />);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^3.7.2",
+        "ntk": "^3.9.0",
         "react-reconciler": "^0.33.0"
       },
       "devDependencies": {
@@ -4660,9 +4660,9 @@
       }
     },
     "node_modules/ntk": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-3.7.2.tgz",
-      "integrity": "sha512-DvZXBF+yLBV/uNrUZfuiBvPBGFv8hVmIzX4Awo0VLb3kHphI1FTEBvpwdrps7fp/ZM+FboPWTxhlRfF59HJk1Q==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-3.9.0.tgz",
+      "integrity": "sha512-9UGPaLWw9/KQSumiDks9V2QhTvuVe1bZk7xdigRZRuClYm7gPrdx/5D/nHzvQlPHNregMGiAmMsVk42SU17ORQ==",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",
@@ -4683,7 +4683,7 @@
         "parse-color": "^1.0.0",
         "pngjs": "^7.0.0",
         "postcss": "^8.5.23",
-        "x11": "^3.1.2",
+        "x11": "^3.2.0",
         "yoga-layout": "^3.2.1"
       },
       "engines": {
@@ -6052,9 +6052,9 @@
       }
     },
     "node_modules/x11": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/x11/-/x11-3.1.3.tgz",
-      "integrity": "sha512-wHrZzmCpMAoniXMd1C3anM9l6a/oeCwlydiD4ut9Cw678vj7EfIvlYZ6O2LvH9RaN2h0vxksByYMlPVpuRDk7A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/x11/-/x11-3.2.0.tgz",
+      "integrity": "sha512-emn6pTOcSXAYcJMjE9UsNPkiP6ImtqfMO0EC/J5JyMJ4Za14kIoYxBHE9PW/S8NKxRE+R/k3iCueQNPOqaWoAQ==",
       "engines": {
         "node": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "examples:gl": "tsx examples/gl.jsx",
     "examples:three": "tsx examples/three.jsx",
     "examples:windows": "tsx examples/windows.jsx",
+    "examples:wm": "tsx examples/wm.jsx",
     "screenshots": "tsx scripts/screenshots.jsx",
     "screenshots:framed": "tsx scripts/screenshots-framed.jsx",
     "bench": "tsx scripts/bench/protocol.js"
@@ -47,7 +48,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^3.7.2",
+    "ntk": "^3.9.0",
     "react-reconciler": "^0.33.0"
   },
   "peerDependencies": {

--- a/test/wm.test.js
+++ b/test/wm.test.js
@@ -1,0 +1,320 @@
+// The window-manager example, headless. node-x11's in-process X server
+// redirects substructure requests (x11 >= 3.2.0), so a WM can be driven end
+// to end without a display: a second connection plays the application.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient, StaticFontSource } from 'ntk';
+
+import {
+  BORDER,
+  TASKBAR_H,
+  TITLE_H,
+  WindowManager,
+  frameHeight,
+  frameWidth,
+  resizeRect,
+} from '../examples/wm-core.js';
+
+const SCREEN = { width: 800, height: 600 };
+
+async function headlessPair() {
+  const server = xserver.createServer(SCREEN);
+  const connect = async () => {
+    const [serverEnd, clientEnd] = xserver.createStreamPair();
+    server.addClientStream(serverEnd);
+    return createClient({
+      stream: clientEnd,
+      fontSource: new StaticFontSource(),
+    });
+  };
+  return { server, wmApp: await connect(), clientApp: await connect() };
+}
+
+const settle = (app) =>
+  new Promise((resolve) => app.X.GetInputFocus(() => setImmediate(resolve)));
+
+/**
+ * Drain round trips until `predicate` holds. Taking a window under
+ * management is a chain of awaited replies — size hints, title,
+ * WM_TRANSIENT_FOR — so a fixed number of settles is a guess; this is not.
+ */
+async function until(app, predicate, what) {
+  for (let i = 0; i < 200; i++) {
+    if (predicate()) return;
+    await settle(app);
+  }
+  assert.fail(`timed out waiting for ${what}`);
+}
+
+/** A window manager with a fake frame per client — this tests wm-core, not JSX. */
+async function startWM(wmApp) {
+  const wm = new WindowManager(wmApp);
+  await wm.start();
+  // React normally hands the frame over once it has realized the <window>;
+  // here the test plays that part.
+  const frames = new Map();
+  wm.attachFakeFrames = () => {
+    for (const client of wm.clients.values()) {
+      if (client.frame) continue;
+      const frame = wmApp.createWindow({
+        x: client.x,
+        y: client.y,
+        width: frameWidth(client.width),
+        height: frameHeight(client.height),
+      });
+      frames.set(client.id, frame);
+      wm.attachFrame(client.id, frame);
+    }
+  };
+  return { wm, frames };
+}
+
+// --- the pure part ----------------------------------------------------------
+
+test('resizeRect pins the edge the handle is not dragging', () => {
+  const start = { x: 100, y: 50, width: 200, height: 120 };
+  const limits = { minWidth: 80, minHeight: 40, maxWidth: 400, maxHeight: 300 };
+
+  const east = resizeRect(start, 'e', 40, 0, limits);
+  assert.deepEqual(east, { x: 100, y: 50, width: 240, height: 120 });
+
+  // dragging west moves x and width together: the right edge stays at 300
+  const west = resizeRect(start, 'w', 40, 0, limits);
+  assert.equal(west.x + west.width, 300);
+  assert.equal(west.x, 140);
+
+  const north = resizeRect(start, 'n', 0, 30, limits);
+  assert.equal(north.y + north.height, 170, 'bottom edge stays');
+
+  const corner = resizeRect(start, 'se', 50, 60, limits);
+  assert.deepEqual(corner, { x: 100, y: 50, width: 250, height: 180 });
+});
+
+test('resizeRect stops moving when the size hits its limit', () => {
+  const start = { x: 100, y: 50, width: 200, height: 120 };
+  const limits = {
+    minWidth: 150,
+    minHeight: 100,
+    maxWidth: 400,
+    maxHeight: 300,
+  };
+
+  // asking to shrink past the minimum from the west: width clamps AND the
+  // window stops sliding, or it would keep moving with its far edge pinned
+  const west = resizeRect(start, 'w', 999, 0, limits);
+  assert.equal(west.width, 150);
+  assert.equal(west.x + west.width, 300, 'right edge still pinned');
+
+  const north = resizeRect(start, 'n', 0, 999, limits);
+  assert.equal(north.height, 100);
+  assert.equal(north.y + north.height, 170, 'bottom edge still pinned');
+});
+
+// --- against a real server --------------------------------------------------
+
+test('a mapped client is framed, reparented and focused', async () => {
+  const { wmApp, clientApp } = await headlessPair();
+  const { wm, frames } = await startWM(wmApp);
+
+  const app = clientApp.createWindow({
+    width: 300,
+    height: 200,
+    title: 'hello',
+  });
+  app.map();
+  await until(wmApp, () => wm.clients.size === 1, 'the client to be managed');
+
+  const client = [...wm.clients.values()][0];
+  assert.equal(client.title, 'hello', 'title read from the client');
+  assert.equal(client.width, 300);
+  assert.equal(client.height, 200);
+
+  wm.attachFakeFrames();
+  await settle(wmApp);
+
+  const frame = frames.get(client.id);
+  const tree = await new Promise((resolve, reject) =>
+    frame.queryTree((err, res) => (err ? reject(err) : resolve(res))),
+  );
+  assert.deepEqual(
+    tree.children.map((w) => w.id),
+    [app.id],
+    'the client lives inside the frame',
+  );
+  assert.equal(wm.focused, app.id, 'and takes the focus once it is viewable');
+
+  await wmApp.close();
+  await clientApp.close();
+});
+
+test('size hints constrain what the window manager will do', async () => {
+  const { wmApp, clientApp } = await headlessPair();
+  const { wm } = await startWM(wmApp);
+
+  const app = clientApp.createWindow({ width: 300, height: 200 });
+  app.setSizeHints({
+    minWidth: 250,
+    minHeight: 150,
+    maxWidth: 500,
+    maxHeight: 400,
+  });
+  await settle(clientApp);
+  app.map();
+  await until(wmApp, () => wm.clients.size === 1, 'the client to be managed');
+
+  const client = [...wm.clients.values()][0];
+  assert.equal(client.minWidth, 250);
+  assert.equal(client.maxHeight, 400);
+
+  wm.attachFakeFrames();
+  wm.setGeometry(client.id, { width: 10, height: 10 });
+  assert.equal(wm.clients.get(client.id).width, 250, 'clamped to the minimum');
+  assert.equal(wm.clients.get(client.id).height, 150);
+
+  wm.setGeometry(client.id, { width: 9999, height: 9999 });
+  assert.equal(wm.clients.get(client.id).width, 500, 'clamped to the maximum');
+  assert.equal(wm.clients.get(client.id).height, 400);
+
+  await wmApp.close();
+  await clientApp.close();
+});
+
+test('a client asking to resize itself is answered, honouring the value mask', async () => {
+  const { wmApp, clientApp } = await headlessPair();
+  const { wm } = await startWM(wmApp);
+
+  const app = clientApp.createWindow({ width: 300, height: 200 });
+  app.map();
+  await until(wmApp, () => wm.clients.size === 1, 'the client to be managed');
+  wm.attachFakeFrames();
+  await settle(wmApp);
+
+  const client = [...wm.clients.values()][0];
+  const before = { x: client.x, y: client.y };
+
+  app.resize(360, 240); // CWWidth | CWHeight only
+  await until(
+    wmApp,
+    () => wm.clients.get(client.id).width === 360,
+    'the configure request to be honoured',
+  );
+
+  const after = wm.clients.get(client.id);
+  assert.equal(after.width, 360, 'the size it asked for');
+  assert.equal(after.height, 240);
+  assert.equal(
+    after.x,
+    before.x,
+    'position untouched — it was not in the mask',
+  );
+  assert.equal(after.y, before.y);
+
+  await wmApp.close();
+  await clientApp.close();
+});
+
+test('maximize fills the work area and restores to where it was', async () => {
+  const { wmApp, clientApp } = await headlessPair();
+  const { wm } = await startWM(wmApp);
+
+  const app = clientApp.createWindow({ width: 300, height: 200 });
+  app.map();
+  await until(wmApp, () => wm.clients.size === 1, 'the client to be managed');
+  wm.attachFakeFrames();
+
+  const id = [...wm.clients.keys()][0];
+  const before = { ...wm.clients.get(id) };
+
+  wm.toggleMaximize(id);
+  const max = wm.clients.get(id);
+  assert.equal(max.maximized, true);
+  assert.equal(frameWidth(max.width), SCREEN.width, 'frame spans the screen');
+  assert.equal(
+    frameHeight(max.height),
+    SCREEN.height - TASKBAR_H,
+    'and stops at the taskbar',
+  );
+
+  wm.toggleMaximize(id);
+  const restored = wm.clients.get(id);
+  assert.equal(restored.maximized, false);
+  assert.equal(restored.x, before.x);
+  assert.equal(restored.y, before.y);
+  assert.equal(restored.width, before.width);
+  assert.equal(restored.height, before.height);
+
+  await wmApp.close();
+  await clientApp.close();
+});
+
+test('a destroyed client is dropped and the focus moves on', async () => {
+  const { wmApp, clientApp } = await headlessPair();
+  const { wm } = await startWM(wmApp);
+
+  const first = clientApp.createWindow({ width: 200, height: 150 });
+  first.map();
+  await until(wmApp, () => wm.clients.size === 1, 'the first client');
+  wm.attachFakeFrames();
+  const second = clientApp.createWindow({ width: 200, height: 150 });
+  second.map();
+  await until(wmApp, () => wm.clients.size === 2, 'the second client');
+  wm.attachFakeFrames();
+  await settle(wmApp);
+
+  assert.equal(wm.focused, second.id, 'the newest window has the focus');
+
+  second.destroy();
+  await until(wmApp, () => wm.clients.size === 1, 'the client to be forgotten');
+  assert.equal(wm.focused, first.id, 'focus fell back to what is left');
+
+  await wmApp.close();
+  await clientApp.close();
+});
+
+test('an override-redirect window is left alone', async () => {
+  const { wmApp, clientApp } = await headlessPair();
+  const { wm } = await startWM(wmApp);
+
+  const menu = clientApp.createWindow({
+    width: 120,
+    height: 80,
+    overrideRedirect: true,
+  });
+  menu.map();
+  // a normal window mapped after it: once this one is managed we know the
+  // menu was skipped rather than merely still in flight
+  const normal = clientApp.createWindow({ width: 200, height: 150 });
+  normal.map();
+  await until(wmApp, () => wm.clients.size === 1, 'the normal window');
+
+  assert.deepEqual(
+    [...wm.clients.keys()],
+    [normal.id],
+    'menus and tooltips are not ours to frame',
+  );
+  const attrs = await wmApp.createWindow({ id: menu.id }).getAttributes();
+  assert.equal(attrs.mapState, 2, 'the menu mapped itself');
+
+  await wmApp.close();
+  await clientApp.close();
+});
+
+test('a second window manager is refused', async () => {
+  const { wmApp, clientApp } = await headlessPair();
+  await startWM(wmApp);
+
+  await assert.rejects(
+    () => new WindowManager(clientApp).start(),
+    /another window manager is already running/,
+  );
+
+  await wmApp.close();
+  await clientApp.close();
+});
+
+test('the frame is the client plus its decoration', () => {
+  assert.equal(frameWidth(300), 300 + 2 * BORDER);
+  assert.equal(frameHeight(200), 200 + 2 * BORDER + TITLE_H);
+});

--- a/test/wm.test.js
+++ b/test/wm.test.js
@@ -14,6 +14,7 @@ import {
   WindowManager,
   frameHeight,
   frameWidth,
+  parseNetWmIcon,
   resizeRect,
 } from '../examples/wm-core.js';
 
@@ -112,6 +113,36 @@ test('resizeRect stops moving when the size hits its limit', () => {
   assert.equal(north.y + north.height, 170, 'bottom edge still pinned');
 });
 
+// _NET_WM_ICON packs every size the application offers into one property,
+// each as [width, height, width*height ARGB pixels].
+const iconBlock = (size, argb) => [
+  size,
+  size,
+  ...Array(size * size).fill(argb),
+];
+
+test('parseNetWmIcon picks a size and converts ARGB to RGBA', () => {
+  const words = [...iconBlock(8, 0xff112233), ...iconBlock(32, 0xff445566)];
+
+  // the smallest one that is still big enough for what we draw
+  assert.equal(parseNetWmIcon(words, 16).width, 32);
+  assert.equal(parseNetWmIcon(words, 8).width, 8);
+  // nothing is big enough: take the largest there is rather than nothing
+  assert.equal(parseNetWmIcon(words, 64).width, 32);
+
+  const icon = parseNetWmIcon(iconBlock(2, 0x80aabbcc), 2);
+  assert.equal(icon.width, 2);
+  assert.equal(icon.data.length, 2 * 2 * 4);
+  assert.deepEqual([...icon.data.subarray(0, 4)], [0xaa, 0xbb, 0xcc, 0x80]);
+});
+
+test('parseNetWmIcon rejects a truncated or empty property', () => {
+  assert.equal(parseNetWmIcon([], 16), null);
+  assert.equal(parseNetWmIcon([0, 0], 16), null);
+  // claims 4x4 but carries three pixels
+  assert.equal(parseNetWmIcon([4, 4, 1, 2, 3], 16), null);
+});
+
 // --- against a real server --------------------------------------------------
 
 test('a mapped client is framed, reparented and focused', async () => {
@@ -144,6 +175,56 @@ test('a mapped client is framed, reparented and focused', async () => {
     'the client lives inside the frame',
   );
   assert.equal(wm.focused, app.id, 'and takes the focus once it is viewable');
+
+  await wmApp.close();
+  await clientApp.close();
+});
+
+test("a client's _NET_WM_ICON is read, and re-read when it changes", async () => {
+  const { wmApp, clientApp } = await headlessPair();
+  const { wm } = await startWM(wmApp);
+
+  const app = clientApp.createWindow({ width: 200, height: 150 });
+  await app.setProperty('_NET_WM_ICON', iconBlock(16, 0xff203040), {
+    type: 'CARDINAL',
+  });
+  app.map();
+  await until(wmApp, () => wm.clients.size === 1, 'the client to be managed');
+
+  const id = [...wm.clients.keys()][0];
+  assert.equal(wm.clients.get(id).icon?.width, 16, 'icon read at manage time');
+  assert.deepEqual(
+    [...wm.clients.get(id).icon.data.subarray(0, 4)],
+    [0x20, 0x30, 0x40, 0xff],
+  );
+
+  // swapping the icon arrives as a PropertyNotify naming _NET_WM_ICON
+  await app.setProperty('_NET_WM_ICON', iconBlock(8, 0xffaabbcc), {
+    type: 'CARDINAL',
+  });
+  await until(
+    wmApp,
+    () => wm.clients.get(id).icon?.width === 8,
+    'the new icon to be picked up',
+  );
+  assert.deepEqual(
+    [...wm.clients.get(id).icon.data.subarray(0, 4)],
+    [0xaa, 0xbb, 0xcc, 0xff],
+  );
+
+  await wmApp.close();
+  await clientApp.close();
+});
+
+test('a client with no icon is managed all the same', async () => {
+  const { wmApp, clientApp } = await headlessPair();
+  const { wm } = await startWM(wmApp);
+
+  const app = clientApp.createWindow({ width: 200, height: 150 });
+  app.map();
+  await until(wmApp, () => wm.clients.size === 1, 'the client to be managed');
+
+  assert.equal(wm.clients.get(app.id).icon, null, 'no icon, not an error');
 
   await wmApp.close();
   await clientApp.close();


### PR DESCRIPTION
Closes #3.

A real reparenting window manager, written in React. It takes over the root window, puts every application's window inside a frame it draws, and moves, resizes, focuses and closes them.

Every frame is an ordinary react-x11 `<window>`: the titlebar, the three buttons and the eight resize handles are components with ordinary `onMouseDown` handlers, and the application being managed is a foreign X window reparented inside that frame.

![wm-scene](https://github.com/user-attachments/assets/b46482ba-0cd6-47e6-ab8b-fbd17bef86db)

Three windows under management — `xterm`, `xclock`, and react-x11's own `examples/form.jsx`. The focused window's titlebar takes the accent colour, and the taskbar lists everything.

## What it does

- **move** — drag the titlebar
- **resize** — any of eight edges and corners, with the opposite edge pinned, honouring `WM_NORMAL_HINTS` min/max
- **maximize / restore** — the titlebar button, or a double-click on the titlebar
- **minimize** — to the taskbar, and back
- **close** — `WM_DELETE_WINDOW` when the client advertised it, `KillClient` when it did not
- **focus** — click anywhere in a window (titlebar *or* client area) to focus and raise; alt+tab to cycle
- **icons** — `_NET_WM_ICON` (EWMH) and the `WM_HINTS` icon pixmap (ICCCM), in the titlebar and taskbar
- **titles** — `_NET_WM_NAME`/`WM_NAME`, updated live from `PropertyNotify`
- **dialogs** — `WM_TRANSIENT_FOR` keeps them above their parent and out of the taskbar
- **EWMH** — `_NET_SUPPORTING_WM_CHECK`, `_NET_SUPPORTED`, `_NET_CLIENT_LIST`, `_NET_ACTIVE_WINDOW`, which is what makes GTK and Qt clients believe a real window manager is running

Windows already on screen when it starts are adopted, and the save-set means clients outlive it if it exits.

![wm-states](https://github.com/user-attachments/assets/65469f37-c35e-4768-bd75-4393d1cb7bc5)

`form` restored after being maximized, `xterm` minimized — the dimmed `· xterm` in the taskbar.

### Icons

![wm-icons](https://github.com/user-attachments/assets/c0eed9b7-7759-4892-9c37-dc4e31450b8c)

Applications advertise an icon two different ways and clients use one or the other, so a window manager that reads only one shows blanks for half of them. `_NET_WM_ICON` (EWMH) is ARGB pixels in a property, in as many sizes as the application offers — what GTK and Qt set. `WM_HINTS` (ICCCM) names a pixmap on the server plus an optional 1-bit mask — what `xterm`, `xclock` and `xlogo` above still set, and therefore the one you can watch working without a modern toolkit around.

Both end up as RGBA uploaded once as an ntk `Image`, so XRender does the scaling: a 48x48 icon in a 16px slot is one composite per repaint, not a client-side resample. A depth-1 icon is a stencil rather than a picture — set bits drawn in the frame's foreground, the rest transparent — because treating it as an image gives `xlogo` as a black square.

Deliberately not implemented, and said so in the docs: the freedesktop route of matching `WM_CLASS` to a `.desktop` file and looking the name up in an icon theme. That is how applications shipping no icon at all still get one, but it is a filesystem convention rather than anything X knows about.

## Layout

| | |
| --- | --- |
| `examples/wm-core.js` | the protocol half — claim the root, answer map and configure requests, keep the client list, EWMH, alt+tab |
| `examples/wm.jsx` | the React half — frames, taskbar, drag gestures |

The seam is a store: `wm-core` keeps the client list and exposes `subscribe`/`getSnapshot`, React reads it with `useSyncExternalStore`, so every change — a new window, a new title, a drag in flight — is one re-render of the frames.

## Running it

It wants the display to itself, so run it against a nested server rather than the one managing your desktop:

```sh
Xephyr :10 -screen 1200x800 &
DISPLAY=unix/:10 npm run examples:wm
DISPLAY=:10 xterm &                    # give it something to manage
```

## The parts that were actually hard

All now written down in `AGENTS.md` under "Writing a window manager", because none of them are guessable:

- **A frame cannot unmount while it holds a client.** The client is reparented *into* the frame, and X destroys children with their parent — so minimizing unmaps the frame instead of removing it from the tree, and a client that withdraws is reparented back to the root before its frame goes away.
- **After reparenting, a client's requests are redirected by whoever holds `SubstructureRedirect` on its *new* parent** — the frame, not the root. Miss it and a client that resizes itself does so behind the window manager's back, leaving the window a different size from the frame drawn around it. The headless test is what caught this.
- **`ConfigureRequest` carries a value mask.** Fields the mask does not name hold the window's *current* values, not a request.
- **`ButtonPress` cannot be selected on a client window** — only one client at a time may hold it and the application already does. Click-to-focus is a synchronous `grabButton` plus `allowEvents('replay')`, which hands the very same click on to the application.
- **`SetInputFocus` on a window that is not viewable is a `BadMatch`,** so focus is taken after the frame is attached and both are mapped.
- **Keycodes come from `GetKeyboardMapping`, and the grab is redone on `MappingNotify`** — the map can change under a running window manager, and a grab on a stale keycode is a grab on a key nobody presses.
- **Drags need a real pointer grab.** `capturePointer()` only routes events that already arrived at the window; the X grab is what keeps the server sending them once the pointer leaves the frame.

## Tests

`test/wm.test.js` — 14 cases driving the whole thing headlessly over node-x11's in-process X server, two connections, one playing the application: framing and reparenting, size-hint clamping, a client resizing itself, maximize/restore, a destroyed client and where the focus goes, override-redirect windows being left alone, a second window manager being refused, icons read and re-read when they change, and the pure resize-anchor and icon-parsing maths.

Full suite: **202 passing.**

Also driven through real input (XTEST) against Xephyr with `xterm`, `xclock` and react-x11's own examples as clients — that is where the screenshots come from.

## Upstream

Needs **ntk >= 3.9.0** and **x11 >= 3.2.0**, both released, both of which grew the support this uses:

- sidorares/node-x11#233 — substructure redirect in the JS X server, without which a WM could not be tested headlessly at all
- sidorares/ntk#95 — the substructure event payloads (a `ConfigureRequest` used to arrive stripped of the geometry needed to answer it), property reads, and the frame helpers
- sidorares/ntk#97 — `setProperty`, for the EWMH handshake

