### PR TITLE
feat: TypeScript declarations for the public API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,4 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run format:check
+      - run: npm run typecheck

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,12 +68,22 @@ no override-redirect staging (issue #4).
 - `test/wm.test.js` — the window-manager example against that same server,
   two connections: one plays the WM, the other an application. Needs
   x11 >= 3.2.0, which is where substructure redirect landed.
+- `src/index.d.ts` + `src/types/*.d.ts` — hand-written TypeScript
+  declarations for the public API, and `src/jsx-runtime.{js,d.ts}` (plus the
+  dev variant) so a project can set `jsxImportSource: "react-x11"` and have
+  JSX check against the X11 elements. See
+  [docs/typescript.md](docs/typescript.md) and the note below.
+- `test/types/api.tsx` — compiled, not run: the type tests.
 
 ## Commands
 
 - `npm test` — node:test. **Headless: no X server needed.** Primary feedback
   loop; keep it green and extend it when touching the host config.
 - `npm run lint` / `npm run format` — ESLint 9 (flat config) + Prettier.
+- `npm run typecheck` — `tsc` over the declarations and `test/types/api.tsx`.
+  Runs in CI beside lint. **A prop change is not done until the `.d.ts` and a
+  line in the type test change with it** — hand-written declarations drift
+  silently otherwise, and nothing else catches it.
 - `npm run examples:{app,theming,simple,simple-nojsx,xeyes,dashboard,tasks,menu,form,richtext,widgets,windows,wm}`
   — need a running X server (`DISPLAY` set; XQuartz on macOS, Xvfb for
   automation). `examples:app` is the showcase: it hosts `form`, `widgets`
@@ -124,6 +134,25 @@ no override-redirect staging (issue #4).
   they are generated on demand, not committed). Needs a real `DISPLAY`
   with a **reparenting** WM; `npm run screenshots` has no WM at all and
   therefore no frames. See "Framed screenshots" below.
+
+## TypeScript declarations
+
+The types are hand-written against the JavaScript, so the only thing keeping
+them true is `npm run typecheck` plus the cases in `test/types/api.tsx`.
+Two things about the shape that are not obvious:
+
+- **JSX comes from `react-x11/jsx-runtime`, not from augmenting React.**
+  Augmentation was tried and does not compile: `text`, `image`, `canvas`,
+  `html` and `svg` are DOM element names too, already declared by
+  `@types/react` with incompatible props, and declaration merging cannot
+  replace an existing member. Owning the namespace also makes `<div>` an
+  error, which augmenting could never do.
+- **`createStyles` takes a mapped parameter**, `{ [K in keyof T]: Style }`,
+  not a bare `T extends Record<string, Style>`. With the bare form the
+  object literal loses freshness during inference and TypeScript stops
+  reporting unknown properties — the mapped form keeps `Style` as each
+  value's contextual type, so a typo in a style key is caught the way the
+  runtime validation catches it.
 
 ## Writing a window manager
 

--- a/README.md
+++ b/README.md
@@ -249,10 +249,56 @@ and enables the feature in one go; `REACT_X11_CLICK_TO_COMPONENT=1` does
 the same with the default editor
 (`cursor`). See [docs/click-to-component.md](docs/click-to-component.md).
 
+## TypeScript
+
+Types ship with the package — no `@types/react-x11` to install. Point JSX at
+react-x11 and the X11 elements type-check:
+
+```jsonc
+// tsconfig.json
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "react-x11",
+  },
+}
+```
+
+```tsx
+import { createRoot, createStyles, Button } from 'react-x11';
+import type { MouseEvent } from 'react-x11';
+
+const s = createStyles({
+  root: { flexGrow: 1, padding: 12, gap: 8 },
+  //          ^ flexDirection: 'sideways' would not compile,
+  //            and neither would a layout property inside ':hover'
+});
+
+<window title="hi" width={320} height={200} style={s.root}>
+  <box onClick={(ev: MouseEvent) => console.log(ev.detail)}>
+    <text style={{ fontSize: 18 }}>hello</text>
+  </box>
+  <Button primary onPress={() => {}}>
+    ok
+  </Button>
+</window>;
+```
+
+`jsxImportSource` is what makes `<div>` an error rather than something that
+compiles and then throws at runtime: react-x11 owns the JSX namespace
+instead of adding to React's, which it could not do anyway — `text`,
+`image`, `canvas`, `html` and `svg` are all DOM element names too, with
+incompatible props.
+
+Style props, element props, event objects, ref types and every widget are
+typed; `style` accepts the same nested arrays with falsy entries the runtime
+does. See [docs/typescript.md](docs/typescript.md).
+
 ## Developing
 
 ```sh
 npm test             # hermetic: mock smoke tests + in-process X server pixels
+npm run typecheck    # tsc over the declarations and the type tests
 npm run lint         # ESLint
 npm run format       # Prettier
 npm run screenshots  # regenerate docs/img/*.png headlessly (no X server)

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,9 @@
   primitives: `Select`.
 - [events.md](events.md) — the synthetic event system: dispatch phases,
   event object shape, focus, cursors, default actions.
+- [typescript.md](typescript.md) — the bundled types: one tsconfig option,
+  why JSX comes from `react-x11/jsx-runtime` rather than an augmentation,
+  and how the declarations are kept from drifting.
 - [devtools.md](devtools.md) — React DevTools integration and other
   debugging aids.
 - [click-to-component.md](click-to-component.md) — Alt+Click a rendered

--- a/docs/typescript.md
+++ b/docs/typescript.md
@@ -1,0 +1,117 @@
+# TypeScript
+
+Types ship with the package. There is no `@types/react-x11`, and nothing to
+build — the declarations are hand-written `.d.ts` files next to the
+JavaScript they describe.
+
+## Setup
+
+```jsonc
+// tsconfig.json
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "react-x11",
+    "moduleResolution": "bundler", // or "node16" / "nodenext"
+  },
+}
+```
+
+`jsxImportSource` is the whole configuration. Without it JSX resolves
+against React's namespace, which describes the DOM.
+
+## Why a JSX runtime and not an augmentation
+
+The usual way a library adds elements to JSX is to merge into React's
+namespace:
+
+```ts
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements {
+      window: WindowProps;
+    }
+  }
+}
+```
+
+That cannot work here. Five element names — `text`, `image`, `canvas`,
+`html`, `svg` — are also HTML or SVG element names, already declared by
+`@types/react` with completely different props, and declaration merging
+cannot replace an existing member:
+
+```
+Interface 'IntrinsicElements' incorrectly extends interface 'ReactX11Elements'.
+  The types of 'text.ref' are incompatible between these types.
+    Type 'Ref<SVGTextElement>' is not assignable to type 'Ref<DrawnNode>'.
+```
+
+So react-x11 provides its own JSX source instead — `react-x11/jsx-runtime`,
+which re-exports React's actual runtime and carries a `JSX` namespace of its
+own. That turns out to be the better answer regardless: the namespace holds
+the X11 elements _and nothing else_, so
+
+```tsx
+<div /> // error: Property 'div' does not exist on type 'JSX.IntrinsicElements'
+```
+
+is caught at compile time rather than throwing at runtime. An augmentation
+could never have done that, because `@types/react` declares every HTML and
+SVG tag unconditionally.
+
+If you need extra elements of your own, `IntrinsicElements` is an interface,
+so merging still works:
+
+```ts
+declare module 'react-x11/jsx-runtime' {
+  namespace JSX {
+    interface IntrinsicElements {
+      'my-element': { value?: number };
+    }
+  }
+}
+```
+
+## What is typed
+
+|                             |                                                                               |
+| --------------------------- | ----------------------------------------------------------------------------- |
+| `src/types/style.d.ts`      | `Style`, `StyleProp`, the yoga enums, state blocks, transitions, size queries |
+| `src/types/events.d.ts`     | `SyntheticEvent` and the mouse / wheel / keyboard / focus shapes              |
+| `src/types/nodes.d.ts`      | what a `ref` gives you: `DrawnNode`, `ScrollViewNode`, ntk's `Window`         |
+| `src/types/elements.d.ts`   | every host element's props, including the 3D scene                            |
+| `src/types/components.d.ts` | the widget set, `Theme`, the anchoring helpers                                |
+| `src/index.d.ts`            | the entry: `createRoot`, `render`, and re-exports of the above                |
+
+A few deliberate looseness decisions:
+
+- **`Color` is `string`.** It is a CSS colour or a `$token` resolved against
+  the nearest `theme`; narrowing it would reject valid values without
+  catching much.
+- **`ctx` and `gl` are `any`.** They are ntk's 2d context and its indirect
+  GLX context, and ntk ships no types. Typing them here would mean
+  maintaining a second, drifting copy of ntk's API.
+- **`Renderer` is `any`.** It is the react-reconciler instance, an escape
+  hatch rather than a supported surface.
+
+Style values are as precise as the runtime is: `flexDirection` only takes
+the four yoga values, a state block only takes paint properties (the same
+rule `createStyles` enforces at runtime), and `width` takes
+`number | '50%' | 'auto'`.
+
+## Keeping them honest
+
+Hand-written declarations drift. `test/types/api.tsx` is compiled by
+`npm run typecheck` — in CI alongside lint — and exercises the API the way
+the examples do, including `@ts-expect-error` lines for things that must
+_not_ compile:
+
+```tsx
+// @ts-expect-error — layout properties may not go in a state block
+createStyles({ bad: { ':hover': { padding: 4 } } });
+```
+
+Those fail the build if the rejection stops happening, which is the half of
+a type test that usually goes missing.
+
+When you change a prop, change the declaration and add a line to that file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@babel/core": "^8.0.1",
         "@babel/plugin-transform-react-jsx": "^8.0.1",
         "@eslint/js": "^9.32.0",
+        "@types/react": "^19.2.17",
         "eslint": "^9.32.0",
         "eslint-plugin-react": "^7.37.5",
         "globals": "^16.0.0",
@@ -25,6 +26,7 @@
         "react-devtools-core": "^7.0.1",
         "react-refresh": "^0.18.0",
         "tsx": "^4.23.1",
+        "typescript": "^5.9.3",
         "ws": "^8.21.1"
       },
       "engines": {
@@ -1428,6 +1430,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -2017,6 +2029,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/fb55"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cytoscape": {
       "version": "3.34.0",
@@ -5819,6 +5838,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "test": "node --test",
+    "typecheck": "tsc -p tsconfig.json",
     "lint": "eslint .",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
@@ -61,6 +62,7 @@
     "@babel/core": "^8.0.1",
     "@babel/plugin-transform-react-jsx": "^8.0.1",
     "@eslint/js": "^9.32.0",
+    "@types/react": "^19.2.17",
     "eslint": "^9.32.0",
     "eslint-plugin-react": "^7.37.5",
     "globals": "^16.0.0",
@@ -70,10 +72,23 @@
     "react-devtools-core": "^7.0.1",
     "react-refresh": "^0.18.0",
     "tsx": "^4.23.1",
+    "typescript": "^5.9.3",
     "ws": "^8.21.1"
   },
   "type": "module",
   "exports": {
-    ".": "./src/index.js"
-  }
+    ".": {
+      "types": "./src/index.d.ts",
+      "default": "./src/index.js"
+    },
+    "./jsx-runtime": {
+      "types": "./src/jsx-runtime.d.ts",
+      "default": "./src/jsx-runtime.js"
+    },
+    "./jsx-dev-runtime": {
+      "types": "./src/jsx-dev-runtime.d.ts",
+      "default": "./src/jsx-dev-runtime.js"
+    }
+  },
+  "types": "./src/index.d.ts"
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,66 @@
+/**
+ * react-x11 — a React renderer whose host environment is an X11 server.
+ *
+ * These declarations are hand-written against the JavaScript in `src/`. The
+ * host elements (`<window>`, `<box>`, `<text>`, …) are added to React's JSX
+ * namespace below, so JSX type-checks with no tsconfig changes beyond
+ * `"jsx": "react-jsx"`.
+ */
+
+import type { ReactNode } from 'react';
+import type { NtkApp } from './types/nodes.js';
+import type { ReactX11Elements } from './types/elements.js';
+
+export * from './types/style.js';
+export * from './types/events.js';
+export * from './types/nodes.js';
+export * from './types/elements.js';
+export * from './types/components.js';
+
+/** A mounted tree, as returned by {@link createRoot}. */
+export interface Root {
+  /** The ntk `App` this root renders through. */
+  readonly app: NtkApp;
+  render(element: ReactNode, callback?: () => void): void;
+  unmount(): void;
+}
+
+/**
+ * Connect to the X server and make a root:
+ *
+ * ```tsx
+ * const root = await createRoot();   // connects via $DISPLAY
+ * root.render(<App />);
+ * ```
+ *
+ * Pass an ntk `App` to render into a connection you already have.
+ */
+export function createRoot(container?: NtkApp): Promise<Root>;
+
+/**
+ * Legacy entry point. Without a container it connects to the X server and
+ * resolves once mounted; with one it mounts synchronously.
+ */
+export function render(
+  element: ReactNode,
+  callback?: () => void,
+): Promise<void>;
+export function render(
+  element: ReactNode,
+  callback: (() => void) | undefined,
+  container: NtkApp,
+): void;
+
+export function unmountComponentAtNode(container: NtkApp): void;
+
+/** The react-reconciler instance. Escape hatch; not a stable API. */
+export const Renderer: any;
+
+declare const ReactX11: {
+  render: typeof render;
+  createRoot: typeof createRoot;
+  unmountComponentAtNode: typeof unmountComponentAtNode;
+};
+export default ReactX11;
+
+export type { ReactX11Elements };

--- a/src/jsx-dev-runtime.d.ts
+++ b/src/jsx-dev-runtime.d.ts
@@ -1,0 +1,21 @@
+/** Development counterpart of jsx-runtime.d.ts — the same JSX namespace. */
+
+import type * as React from 'react';
+import type { ReactX11Elements } from './types/elements.js';
+
+export { Fragment, jsxDEV } from 'react/jsx-dev-runtime';
+
+export namespace JSX {
+  type ElementType = React.JSX.ElementType;
+  type Element = React.JSX.Element;
+  type ElementClass = React.JSX.ElementClass;
+  type ElementAttributesProperty = React.JSX.ElementAttributesProperty;
+  type ElementChildrenAttribute = React.JSX.ElementChildrenAttribute;
+  type LibraryManagedAttributes<C, P> = React.JSX.LibraryManagedAttributes<
+    C,
+    P
+  >;
+  type IntrinsicAttributes = React.JSX.IntrinsicAttributes;
+  type IntrinsicClassAttributes<T> = React.JSX.IntrinsicClassAttributes<T>;
+  interface IntrinsicElements extends ReactX11Elements {}
+}

--- a/src/jsx-dev-runtime.js
+++ b/src/jsx-dev-runtime.js
@@ -1,0 +1,2 @@
+// Development counterpart of jsx-runtime.js — see the note there.
+export { Fragment, jsxDEV } from 'react/jsx-dev-runtime';

--- a/src/jsx-runtime.d.ts
+++ b/src/jsx-runtime.d.ts
@@ -1,0 +1,39 @@
+/**
+ * The JSX namespace for react-x11. Set
+ *
+ *   { "compilerOptions": { "jsx": "react-jsx", "jsxImportSource": "react-x11" } }
+ *
+ * and `<window>`, `<box>`, `<text>` … type-check, while `<div>` does not.
+ *
+ * This has to be a JSX *source* rather than an augmentation of React's own
+ * namespace: five element names — `text`, `image`, `canvas`, `html`, `svg` —
+ * also exist in `@types/react` as HTML or SVG elements with incompatible
+ * props, and declaration merging cannot replace an existing member. Owning
+ * the namespace is also what makes `<div>` an error here, which augmenting
+ * could never do.
+ */
+
+import type * as React from 'react';
+import type { ReactX11Elements } from './types/elements.js';
+
+export { Fragment, jsx, jsxs } from 'react/jsx-runtime';
+
+export namespace JSX {
+  type ElementType = React.JSX.ElementType;
+  type Element = React.JSX.Element;
+  type ElementClass = React.JSX.ElementClass;
+  type ElementAttributesProperty = React.JSX.ElementAttributesProperty;
+  type ElementChildrenAttribute = React.JSX.ElementChildrenAttribute;
+  type LibraryManagedAttributes<C, P> = React.JSX.LibraryManagedAttributes<
+    C,
+    P
+  >;
+  type IntrinsicAttributes = React.JSX.IntrinsicAttributes;
+  type IntrinsicClassAttributes<T> = React.JSX.IntrinsicClassAttributes<T>;
+
+  /**
+   * The X11 host elements — and only those. An interface so a project can
+   * still declare extra elements of its own by merging into it.
+   */
+  interface IntrinsicElements extends ReactX11Elements {}
+}

--- a/src/jsx-runtime.js
+++ b/src/jsx-runtime.js
@@ -1,0 +1,6 @@
+// The automatic JSX runtime, so a project can set
+// `"jsxImportSource": "react-x11"` and have JSX type-check against the X11
+// elements instead of the DOM's. At runtime this is React's own runtime —
+// the elements are host components either way; only the *types* differ, and
+// they have to come from somewhere TypeScript will look.
+export { Fragment, jsx, jsxs } from 'react/jsx-runtime';

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -1,0 +1,311 @@
+/**
+ * The widget set: plain React over the host primitives, themable through
+ * `ThemeProvider`. See docs/components.md.
+ */
+
+import type { ComponentType, Provider, ReactNode, RefObject } from 'react';
+import type { Color, StyleProp } from './style.js';
+import type { BoxProps, GlAreaProps, Vec3 } from './elements.js';
+import type { DrawnNode, Rect } from './nodes.js';
+import type { MouseEvent } from './events.js';
+
+/**
+ * The palette every widget reads. A theme overrides what it cares about and
+ * inherits the rest; the shape tokens are what let a theme be more than a
+ * recolour.
+ */
+export interface Theme {
+  border: string;
+  borderActive: string;
+  background: string;
+  text: string;
+  dim: string;
+  hoverBackground: string;
+  hoverText: string;
+  accent: string;
+  accentHover: string;
+  accentText: string;
+  surfaceHover: string;
+  track: string;
+  radius: number;
+  radiusSmall: number;
+  borderWidth: number;
+  fontSize: number;
+  paddingX: number;
+  paddingY: number;
+}
+
+/** Themes every widget below it; partial palettes merge over the defaults. */
+export const ThemeProvider: Provider<Partial<Theme>>;
+/** Back-compat alias of {@link ThemeProvider}. */
+export const SelectThemeProvider: Provider<Partial<Theme>>;
+
+/** Props a widget passes through to the `<box>` it renders. */
+type WidgetProps = Omit<BoxProps, 'children' | 'style' | 'ref'>;
+
+export interface ButtonProps extends WidgetProps {
+  children?: ReactNode;
+  label?: string;
+  onPress?: (ev: MouseEvent<DrawnNode>) => void;
+  primary?: boolean;
+  disabled?: boolean;
+  style?: StyleProp;
+}
+export const Button: ComponentType<ButtonProps>;
+
+export interface CheckboxProps extends WidgetProps {
+  children?: ReactNode;
+  label?: string;
+  checked?: boolean;
+  onChange?: (checked: boolean) => void;
+  disabled?: boolean;
+  style?: StyleProp;
+}
+export const Checkbox: ComponentType<CheckboxProps>;
+
+export interface RadioGroupProps<T = unknown> extends WidgetProps {
+  value?: T;
+  onChange?: (value: T) => void;
+  children?: ReactNode;
+  style?: StyleProp;
+}
+export function RadioGroup<T = unknown>(props: RadioGroupProps<T>): ReactNode;
+
+export interface RadioProps<T = unknown> {
+  value: T;
+  children?: ReactNode;
+  label?: string;
+  disabled?: boolean;
+}
+export function Radio<T = unknown>(props: RadioProps<T>): ReactNode;
+
+export interface SwitchProps extends WidgetProps {
+  checked?: boolean;
+  onChange?: (checked: boolean) => void;
+  disabled?: boolean;
+  style?: StyleProp;
+}
+export const Switch: ComponentType<SwitchProps>;
+
+export interface ProgressBarProps extends WidgetProps {
+  /** 0 to 1. */
+  value?: number;
+  color?: Color;
+  trackColor?: Color;
+  height?: number;
+  style?: StyleProp;
+}
+export const ProgressBar: ComponentType<ProgressBarProps>;
+
+export interface SliderProps extends WidgetProps {
+  value?: number;
+  min?: number;
+  max?: number;
+  step?: number;
+  onChange?: (value: number) => void;
+  disabled?: boolean;
+  height?: number;
+  style?: StyleProp;
+}
+export const Slider: ComponentType<SliderProps>;
+
+export type Placement = 'top' | 'bottom' | 'left' | 'right';
+
+export interface TooltipProps extends WidgetProps {
+  label: string;
+  children?: ReactNode;
+  placement?: Placement;
+  /** ms before it appears (default 500). */
+  delay?: number;
+  fontSize?: number;
+  style?: StyleProp;
+}
+export const Tooltip: ComponentType<TooltipProps>;
+
+export interface DialogProps extends WidgetProps {
+  open?: boolean;
+  title?: string;
+  children?: ReactNode;
+  onClose?: () => void;
+  actions?: ReactNode;
+  width?: number;
+  height?: number;
+  style?: StyleProp;
+}
+export const Dialog: ComponentType<DialogProps>;
+
+/** An option, or a plain value used as both value and label. */
+export type SelectOption<T = unknown> = { value: T; label: string } | T;
+
+export interface SelectProps<T = unknown> extends WidgetProps {
+  value?: T;
+  options?: readonly SelectOption<T>[];
+  onChange?: (value: T) => void;
+  placeholder?: string;
+  style?: StyleProp;
+}
+export function Select<T = unknown>(props: SelectProps<T>): ReactNode;
+
+export interface MenuItem {
+  label?: string;
+  /** Present and truthy makes this a submenu parent. */
+  items?: MenuItem[];
+  disabled?: boolean;
+  /** Shown right-aligned; purely a label, not a binding. */
+  shortcut?: string;
+  checked?: boolean;
+  /** A horizontal rule instead of an item. */
+  separator?: boolean;
+  onSelect?: () => void;
+  [key: string]: unknown;
+}
+
+export interface ContextMenuProps extends WidgetProps {
+  items?: readonly MenuItem[];
+  children?: ReactNode;
+  onSelect?: (item: MenuItem) => void;
+  fontSize?: number;
+  style?: StyleProp;
+}
+export const ContextMenu: ComponentType<ContextMenuProps>;
+
+export interface MenuBarMenu {
+  label: string;
+  items: MenuItem[];
+}
+
+export interface MenuBarProps extends WidgetProps {
+  menus?: readonly MenuBarMenu[];
+  onSelect?: (item: MenuItem) => void;
+  fontSize?: number;
+  style?: StyleProp;
+}
+export const MenuBar: ComponentType<MenuBarProps>;
+
+export interface TabItem {
+  id: string;
+  label: string;
+  content?: ReactNode;
+  disabled?: boolean;
+}
+
+export interface TabsProps extends WidgetProps {
+  items?: readonly TabItem[];
+  value?: string;
+  defaultValue?: string;
+  onChange?: (id: string) => void;
+  orientation?: 'horizontal' | 'vertical';
+  /** Arrow keys move the highlight without selecting until Enter/Space. */
+  manual?: boolean;
+  style?: StyleProp;
+}
+export const Tabs: ComponentType<TabsProps>;
+
+export interface TreeItem {
+  id: string;
+  label: string;
+  /** An array — even an empty one — makes this a branch. */
+  children?: TreeItem[];
+  disabled?: boolean;
+}
+
+export interface TreeProps extends WidgetProps {
+  items?: readonly TreeItem[];
+  expanded?: readonly string[];
+  defaultExpanded?: readonly string[];
+  onExpandedChange?: (expanded: string[]) => void;
+  selected?: string | null;
+  defaultSelected?: string | null;
+  onSelect?: (id: string) => void;
+  onActivate?: (id: string) => void;
+  style?: StyleProp;
+}
+export const Tree: ComponentType<TreeProps>;
+
+export interface TableColumn<Row = any> {
+  id: string;
+  label?: string;
+  width?: number;
+  align?: 'left' | 'right' | 'center';
+  /** Pull the cell value out of a row; defaults to `row[id]`. */
+  value?: (row: Row) => unknown;
+  render?: (row: Row, column: TableColumn<Row>) => ReactNode;
+}
+
+export interface TableSort {
+  id: string;
+  direction: 'asc' | 'desc';
+}
+
+export interface TableProps<Row = any> extends WidgetProps {
+  columns?: readonly TableColumn<Row>[];
+  rows?: readonly Row[];
+  rowHeight?: number;
+  sort?: TableSort | null;
+  defaultSort?: TableSort | null;
+  onSortChange?: (sort: TableSort | null) => void;
+  selected?: string | number | null;
+  defaultSelected?: string | number | null;
+  onSelect?: (id: string | number) => void;
+  onActivate?: (id: string | number) => void;
+  onColumnResize?: (id: string, width: number) => void;
+  style?: StyleProp;
+}
+export function Table<Row = any>(props: TableProps<Row>): ReactNode;
+
+export interface SplitPaneProps extends WidgetProps {
+  direction?: 'row' | 'column';
+  size?: number;
+  defaultSize?: number;
+  /** Minimum size of the first pane. */
+  min?: number;
+  /** Minimum size of the second. */
+  minSecond?: number;
+  onResize?: (size: number) => void;
+  /** Exactly two children: the two panes. */
+  children?: ReactNode;
+  style?: StyleProp;
+}
+export const SplitPane: ComponentType<SplitPaneProps>;
+
+export interface Canvas3DProps extends Omit<GlAreaProps, 'onDraw'> {
+  camera?: {
+    position?: Vec3;
+    /** Vertical field of view in degrees. */
+    fov?: number;
+    near?: number;
+    far?: number;
+    target?: Vec3;
+  };
+  children?: ReactNode;
+}
+export const Canvas3D: ComponentType<Canvas3DProps>;
+
+// --- anchoring helpers -----------------------------------------------------
+
+export interface AnchorOptions {
+  placement?: Placement;
+  /** Gap between the anchor and the popup, in px. */
+  gap?: number;
+  width?: number;
+  height?: number;
+  /** Flip to the opposite side when there is no room (default true). */
+  flip?: boolean;
+}
+
+/**
+ * Where to put a `<popup>` relative to a node, in screen coordinates,
+ * flipped at screen edges.
+ */
+export function anchorRect(node: DrawnNode, options?: AnchorOptions): Rect;
+
+/** Centre a popup of this size on the node's screen. */
+export function centerRect(
+  node: DrawnNode,
+  size: { width: number; height: number },
+): Rect;
+
+/** `anchorRect` bound to a ref, recomputed on demand. */
+export function useAnchor(
+  ref: RefObject<DrawnNode | null>,
+): (options?: AnchorOptions) => Rect | null;

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -1,0 +1,382 @@
+/**
+ * The host elements. Only `<window>`, `<popup>` and `<glarea>` are real X11
+ * windows; everything else is a retained node laid out by yoga and painted
+ * into the owning window. See docs/elements.md.
+ */
+
+import type { Ref, ReactNode, Key } from 'react';
+import type { Color, Cursor, StyleProp } from './style.js';
+import type {
+  DrawnNode,
+  NtkWindow,
+  ScrollViewNode,
+  TextInputNode,
+} from './nodes.js';
+import type {
+  EventHandlers,
+  MouseEvent,
+  ScrollEvent,
+  SyntheticEvent,
+  ViewportEvent,
+} from './events.js';
+
+/** Props every element takes. */
+export interface CommonProps {
+  key?: Key;
+  children?: ReactNode;
+  style?: StyleProp;
+}
+
+/** Focus and interaction, on drawn elements and windows alike. */
+export interface InteractionProps {
+  focusable?: boolean;
+  /** Sequential focus order; `-1` is focusable but not tabbable. */
+  tabIndex?: number;
+  autoFocus?: boolean;
+  /**
+   * Own a focus scope: Tab and presses stay inside, and focus is restored
+   * when it unmounts. This is what makes a modal.
+   */
+  trapFocus?: boolean;
+  /** Never focusable, and the trigger for a `:disabled` style block. */
+  disabled?: boolean;
+}
+
+export interface DrawnProps<T = DrawnNode>
+  extends CommonProps, InteractionProps, EventHandlers<T> {
+  ref?: Ref<T>;
+}
+
+// --- windows ---------------------------------------------------------------
+
+/** ICCCM `WM_NORMAL_HINTS` — what the window manager will let the user do. */
+export interface SizeHintProps {
+  minWidth?: number;
+  minHeight?: number;
+  maxWidth?: number;
+  maxHeight?: number;
+  widthInc?: number;
+  heightInc?: number;
+  baseWidth?: number;
+  baseHeight?: number;
+  minAspect?: [number, number];
+  maxAspect?: [number, number];
+  gravity?: number;
+  /** `false` pins min and max size to the current size. */
+  resizable?: boolean;
+}
+
+export type WindowType =
+  | 'normal'
+  | 'dialog'
+  | 'utility'
+  | 'toolbar'
+  | 'splash'
+  | 'menu'
+  | 'dropdown_menu'
+  | 'popup_menu'
+  | 'tooltip'
+  | 'notification'
+  | 'dock'
+  | 'desktop'
+  | (string & {});
+
+export interface WindowProps
+  extends
+    CommonProps,
+    InteractionProps,
+    EventHandlers<DrawnNode>,
+    SizeHintProps {
+  ref?: Ref<NtkWindow>;
+  /** Window title (UTF-8, via `WM_NAME` + `_NET_WM_NAME`). */
+  title?: string;
+  /** Window geometry — window state, not yoga style: the user may resize. */
+  width?: number;
+  height?: number;
+  x?: number;
+  y?: number;
+  /** Palette that `$token` style values resolve against, for this subtree. */
+  theme?: Record<string, string | number>;
+  /** ICCCM `WM_CLASS`. */
+  wmClass?: string | [string, string] | { instance: string; class?: string };
+  /** EWMH `_NET_WM_WINDOW_TYPE`, or a list of fallbacks. */
+  windowType?: WindowType | WindowType[];
+  alwaysOnTop?: boolean;
+  /** ConfigureNotify — the tree reflows on its own. */
+  onResize?: (ev: SyntheticEvent<NtkWindow>) => void;
+  onExpose?: (ev: SyntheticEvent<NtkWindow>) => void;
+  /** The WM close button; opts the window into `WM_DELETE_WINDOW`. */
+  onCloseRequest?: (ev: SyntheticEvent<NtkWindow>) => void;
+}
+
+export interface PopupProps extends WindowProps {
+  /**
+   * Hold a pointer grab while the popup is up — what makes a menu
+   * dismissable, since without it a press on another window never reaches
+   * this client at all. Needs ntk >= 3.7.0.
+   */
+  grab?: boolean;
+  /** A press landed outside the popup: close it. */
+  onDismiss?: (ev: MouseEvent<DrawnNode>) => void;
+}
+
+// --- drawn elements --------------------------------------------------------
+
+export interface BoxProps extends DrawnProps<DrawnNode> {}
+
+export interface ScrollViewProps extends DrawnProps<ScrollViewNode> {
+  onScroll?: (ev: ScrollEvent) => void;
+  /** Fired from layout, so it arrives for a list nobody has scrolled yet. */
+  onViewport?: (ev: ViewportEvent) => void;
+  scrollbar?: boolean;
+  scrollbarColor?: Color;
+}
+
+export interface TextProps extends DrawnProps<DrawnNode> {
+  /** Strings and numbers are only legal inside `<text>`. */
+  children?: ReactNode;
+}
+
+export interface TextInputProps extends DrawnProps<TextInputNode> {
+  /** Controlled mode: the display follows the prop. */
+  value?: string;
+  /** Uncontrolled mode. */
+  defaultValue?: string;
+  onChange?: (text: string) => void;
+  /** Enter — or Ctrl+Enter in a `<textarea>`. */
+  onSubmit?: (text: string, ev: unknown) => void;
+  placeholder?: string;
+  placeholderColor?: Color;
+  /** Code-point limit. */
+  maxLength?: number;
+  selectionColor?: Color;
+  caretColor?: Color;
+}
+
+export interface TextAreaProps extends TextInputProps {
+  /** Preferred height in text lines (default 3). */
+  rows?: number;
+}
+
+export interface ImageProps extends DrawnProps<DrawnNode> {
+  /** File path; PNG or JPEG, decoded in JS. */
+  src: string;
+}
+
+/** What `onDraw` is told about the node it is painting. */
+export interface DrawInfo {
+  width: number;
+  height: number;
+  node: DrawnNode;
+}
+
+export interface CanvasProps extends DrawnProps<DrawnNode> {
+  /**
+   * Paint the node. `ctx` is ntk's canvas-like 2d context, translated to
+   * the node's origin and clipped to its bounds. Runs on every repaint.
+   */
+  onDraw?: (ctx: any, info: DrawInfo) => void;
+}
+
+// --- rich content ----------------------------------------------------------
+
+export interface MarkdownProps extends DrawnProps<DrawnNode> {
+  /** Markdown text, or pass it as children. */
+  source?: string;
+  onLink?: (href: string, ev: MouseEvent<DrawnNode>) => void;
+  theme?: Record<string, unknown>;
+}
+
+export interface HtmlProps extends DrawnProps<DrawnNode> {
+  source?: string;
+  stylesheet?: string | string[];
+  baseUrl?: string;
+  loadResource?: ((url: string, info: { element: unknown }) => unknown) | null;
+  onLink?: (href: string, ev: MouseEvent<DrawnNode>, element: unknown) => void;
+  theme?: Record<string, unknown>;
+}
+
+export interface SvgProps extends DrawnProps<DrawnNode> {
+  source?: string;
+  viewBox?: string;
+}
+
+export interface TexProps extends DrawnProps<DrawnNode> {
+  source?: string;
+  /** Base font size — the formula's em, in px. */
+  size?: number;
+  color?: Color;
+}
+
+// --- GL --------------------------------------------------------------------
+
+export type FrameLoop = 'demand' | 'always';
+
+export interface GlAreaProps extends DrawnProps<DrawnNode> {
+  /** CSS colour, or `[r, g, b, a]` floats. Default black. */
+  clearColor?: Color | [number, number, number, number];
+  /** `'demand'` (default) redraws on change; `'always'` runs continuously. */
+  frameLoop?: FrameLoop;
+  /** Visual spec for ntk's `chooseGLXConfig`, e.g. `{ DEPTH_SIZE: 24 }`. */
+  glx?: Record<string, unknown>;
+  /** Runs once, with the context current: one-time state, uploads, lists. */
+  onCreated?: (gl: any, info: DrawInfo) => void;
+  /** Draw one frame. Viewport and clear happen before, SwapBuffers after. */
+  onDraw?: (gl: any, info: DrawInfo) => void;
+  /** No GL surface — no GLX, or no matching visual. */
+  onError?: (err: Error) => void;
+  /** A click inside the surface that hit no mesh. */
+  onPointerMissed?: (ev: MouseEvent<DrawnNode>) => void;
+}
+
+// --- 3D scene --------------------------------------------------------------
+
+export type Vec3 = [number, number, number];
+
+/** A pointer event that hit a mesh. */
+export interface MeshPointerEvent {
+  /** Where the ray hit, in world space. */
+  point: Vec3;
+  distance: number;
+  object: unknown;
+  nativeEvent: unknown;
+  stopPropagation(): void;
+}
+
+export interface Object3DProps {
+  key?: Key;
+  children?: ReactNode;
+  position?: Vec3;
+  /** XYZ euler angles, in radians. */
+  rotation?: Vec3;
+  /** A tuple, or one number for a uniform scale. */
+  scale?: Vec3 | number;
+  visible?: boolean;
+  cursor?: Cursor;
+  onClick?: (ev: MeshPointerEvent) => void;
+  onPointerDown?: (ev: MeshPointerEvent) => void;
+  onPointerUp?: (ev: MeshPointerEvent) => void;
+  onPointerMove?: (ev: MeshPointerEvent) => void;
+  onPointerOver?: (ev: MeshPointerEvent) => void;
+  onPointerOut?: (ev: MeshPointerEvent) => void;
+}
+
+export interface GroupProps extends Object3DProps {}
+/** One geometry child and one material child. */
+export interface MeshProps extends Object3DProps {}
+
+export interface GeometryProps {
+  key?: Key;
+}
+/** `[width, height, depth, widthSeg, heightSeg, depthSeg]` */
+export interface BoxGeometryProps extends GeometryProps {
+  args?: number[];
+}
+/** `[width, height, widthSeg, heightSeg]` */
+export interface PlaneGeometryProps extends GeometryProps {
+  args?: number[];
+}
+/** `[radius, widthSeg, heightSeg]` */
+export interface SphereGeometryProps extends GeometryProps {
+  args?: number[];
+}
+/** `[radiusTop, radiusBottom, height, radialSeg, heightSeg, openEnded]` */
+export interface CylinderGeometryProps extends GeometryProps {
+  args?: (number | boolean)[];
+}
+/** `[radius, tube, radialSeg, tubularSeg]` */
+export interface TorusGeometryProps extends GeometryProps {
+  args?: number[];
+}
+export interface BufferGeometryProps extends GeometryProps {
+  position?: ArrayLike<number>;
+  /** Derived from the triangles when omitted. */
+  normal?: ArrayLike<number>;
+  uv?: ArrayLike<number>;
+  index?: ArrayLike<number>;
+}
+
+/** An ntk `Image`, or anything with `{ width, height, data }` RGBA bytes. */
+export interface Texture {
+  width: number;
+  height: number;
+  data: ArrayLike<number>;
+}
+
+export type MaterialSide = 'front' | 'back' | 'double';
+
+export interface MaterialProps {
+  key?: Key;
+  color?: Color;
+  map?: Texture;
+  wireframe?: boolean;
+  opacity?: number;
+  transparent?: boolean;
+  side?: MaterialSide;
+}
+export interface MeshBasicMaterialProps extends MaterialProps {}
+export interface MeshLambertMaterialProps extends MaterialProps {
+  emissive?: Color;
+}
+export interface MeshPhongMaterialProps extends MeshLambertMaterialProps {
+  specular?: Color;
+  /** Default 30. */
+  shininess?: number;
+}
+
+export interface LightProps {
+  key?: Key;
+  color?: Color;
+  intensity?: number;
+}
+/** Costs no light unit. */
+export interface AmbientLightProps extends LightProps {}
+/** `position` is the direction the light comes from. */
+export interface DirectionalLightProps extends LightProps {
+  position?: Vec3;
+}
+export interface PointLightProps extends LightProps {
+  position?: Vec3;
+  distance?: number;
+  decay?: number;
+}
+export interface SpotLightProps extends PointLightProps {
+  /** Radians. */
+  angle?: number;
+  penumbra?: number;
+  target?: Vec3;
+}
+
+/** Every host element react-x11 renders. */
+export interface ReactX11Elements {
+  window: WindowProps;
+  popup: PopupProps;
+  box: BoxProps;
+  scrollview: ScrollViewProps;
+  text: TextProps;
+  textinput: TextInputProps;
+  textarea: TextAreaProps;
+  image: ImageProps;
+  canvas: CanvasProps;
+  markdown: MarkdownProps;
+  html: HtmlProps;
+  svg: SvgProps;
+  tex: TexProps;
+  glarea: GlAreaProps;
+
+  group: GroupProps;
+  mesh: MeshProps;
+  boxGeometry: BoxGeometryProps;
+  planeGeometry: PlaneGeometryProps;
+  sphereGeometry: SphereGeometryProps;
+  cylinderGeometry: CylinderGeometryProps;
+  torusGeometry: TorusGeometryProps;
+  bufferGeometry: BufferGeometryProps;
+  meshBasicMaterial: MeshBasicMaterialProps;
+  meshLambertMaterial: MeshLambertMaterialProps;
+  meshPhongMaterial: MeshPhongMaterialProps;
+  ambientLight: AmbientLightProps;
+  directionalLight: DirectionalLightProps;
+  pointLight: PointLightProps;
+  spotLight: SpotLightProps;
+}

--- a/src/types/events.d.ts
+++ b/src/types/events.d.ts
@@ -1,0 +1,129 @@
+/**
+ * Synthetic events. Dispatched capture → target → bubble over the drawn
+ * tree by front-to-back hit testing, the same shape React gives you in the
+ * DOM. See docs/events.md.
+ */
+
+import type { DrawnNode } from './nodes.js';
+
+/** The raw ntk/X11 event a synthetic one was made from. */
+export interface NativeEvent {
+  /** X event type number. */
+  type: number;
+  name?: string;
+  /** Window-relative pointer position. */
+  x: number;
+  y: number;
+  /** Screen coordinates — what you anchor a `<popup>` at. */
+  rootx: number;
+  rooty: number;
+  /** X modifier/button mask. */
+  buttons: number;
+  keycode?: number;
+  codepoint?: number;
+  time?: number;
+  [key: string]: unknown;
+}
+
+export interface SyntheticEvent<T = DrawnNode> {
+  type: string;
+  /** The node the event was dispatched at (the public instance). */
+  target: T;
+  /** The node whose handler is running. */
+  currentTarget: T | null;
+  /** Window coordinates. */
+  x: number;
+  y: number;
+  /** Coordinates relative to `target`'s box. */
+  localX: number;
+  localY: number;
+  nativeEvent: NativeEvent;
+  shiftKey: boolean;
+  ctrlKey: boolean;
+  defaultPrevented: boolean;
+  propagationStopped: boolean;
+  /** Suppress the element's built-in behaviour (editing, wheel scrolling…). */
+  preventDefault(): void;
+  stopPropagation(): void;
+  /**
+   * Route the rest of this gesture's `mousemove`/`mouseup` to this node even
+   * once the pointer leaves it. Released on mouseup and on unmount.
+   */
+  capturePointer(): void;
+  releasePointer(): void;
+}
+
+export interface MouseEvent<T = DrawnNode> extends SyntheticEvent<T> {
+  /** X button number: 1 left, 2 middle, 3 right. */
+  button: number;
+  /** DOM-style click count — 2 is a double click, 3 a triple. */
+  detail: number;
+}
+
+export interface WheelEvent<T = DrawnNode> extends SyntheticEvent<T> {
+  deltaX: number;
+  deltaY: number;
+}
+
+export interface KeyboardEvent<T = DrawnNode> extends SyntheticEvent<T> {
+  /** X keycode. */
+  keycode: number;
+  /** X keysym (`XK_*`), or undefined if the map has no entry. */
+  keysym?: number;
+  /** Unicode code point, 0 when the key produces no character. */
+  codepoint: number;
+  /** The character the key produced, `''` for non-printing keys. */
+  key: string;
+}
+
+export interface FocusEvent<T = DrawnNode> extends SyntheticEvent<T> {}
+
+/** `<scrollview onScroll>`. */
+export interface ScrollEvent {
+  scrollX: number;
+  scrollY: number;
+  contentWidth: number;
+  contentHeight: number;
+  viewportWidth: number;
+  viewportHeight: number;
+}
+
+/** `<scrollview onViewport>` — fired from layout, not from scrolling. */
+export interface ViewportEvent {
+  width: number;
+  height: number;
+  contentWidth: number;
+  contentHeight: number;
+}
+
+/** Handlers every drawn element and `<window>` accepts. */
+export interface PointerHandlers<T = DrawnNode> {
+  onClick?: (ev: MouseEvent<T>) => void;
+  onClickCapture?: (ev: MouseEvent<T>) => void;
+  onMouseDown?: (ev: MouseEvent<T>) => void;
+  onMouseDownCapture?: (ev: MouseEvent<T>) => void;
+  onMouseUp?: (ev: MouseEvent<T>) => void;
+  onMouseUpCapture?: (ev: MouseEvent<T>) => void;
+  onMouseMove?: (ev: MouseEvent<T>) => void;
+  onMouseMoveCapture?: (ev: MouseEvent<T>) => void;
+  /** Does not propagate — synthesized by hover-path diffing. */
+  onMouseEnter?: (ev: MouseEvent<T>) => void;
+  onMouseLeave?: (ev: MouseEvent<T>) => void;
+  onWheel?: (ev: WheelEvent<T>) => void;
+  onWheelCapture?: (ev: WheelEvent<T>) => void;
+}
+
+export interface KeyboardHandlers<T = DrawnNode> {
+  onKeyDown?: (ev: KeyboardEvent<T>) => void;
+  onKeyDownCapture?: (ev: KeyboardEvent<T>) => void;
+  onKeyUp?: (ev: KeyboardEvent<T>) => void;
+  onKeyUpCapture?: (ev: KeyboardEvent<T>) => void;
+}
+
+export interface FocusHandlers<T = DrawnNode> {
+  onFocus?: (ev: FocusEvent<T>) => void;
+  onBlur?: (ev: FocusEvent<T>) => void;
+}
+
+export interface EventHandlers<T = DrawnNode>
+  extends PointerHandlers<T>, KeyboardHandlers<T>, FocusHandlers<T> {}

--- a/src/types/nodes.d.ts
+++ b/src/types/nodes.d.ts
@@ -1,0 +1,98 @@
+/**
+ * What a `ref` gives you. Drawn elements hand back their retained node;
+ * `<window>` and `<popup>` hand back the live ntk `Window`, so the whole
+ * ntk API is available from a ref.
+ */
+
+/** A rectangle within the owning window, valid after layout. */
+export interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+/** The retained node behind a drawn element. */
+export interface DrawnNode {
+  /** Element name — `'box'`, `'text'`, … */
+  readonly type: string;
+  /** Position and size within the owning window, valid after layout. */
+  readonly abs: Rect;
+  readonly parent: DrawnNode | null;
+  readonly children: readonly DrawnNode[];
+  /** Take the keyboard focus, if this node is focusable. */
+  focus(): void;
+  blur(): void;
+  getClientRects(): Rect[];
+}
+
+export interface ScrollTarget {
+  x?: number;
+  y?: number;
+}
+
+/** `<scrollview>`: a node that also scrolls. */
+export interface ScrollViewNode extends DrawnNode {
+  readonly scrollX: number;
+  readonly scrollY: number;
+  readonly contentWidth: number;
+  readonly contentHeight: number;
+  /** A number scrolls the vertical axis; an object moves either or both. */
+  scrollTo(to: number | ScrollTarget): void;
+  scrollBy(by: number | ScrollTarget): void;
+  /**
+   * Scroll the minimum amount on both axes that makes a descendant fully
+   * visible. Safe to call right after that node mounts — the request is
+   * resolved on the next layout pass, when it has geometry.
+   */
+  scrollIntoView(node: DrawnNode): void;
+}
+
+/** `<textinput>` / `<textarea>`. */
+export interface TextInputNode extends DrawnNode {
+  readonly value: string;
+}
+
+/**
+ * ntk's `Window`, as handed back by a `<window>` or `<popup>` ref. This
+ * covers what a react-x11 program usually reaches for; ntk has more (see
+ * its docs/window.md), and the index signature keeps the rest reachable
+ * without pretending this is a full description of the class.
+ */
+export interface NtkWindow {
+  readonly id: number;
+  width: number;
+  height: number;
+  x: number;
+  y: number;
+  map(): void;
+  unmap(): void;
+  raise(): NtkWindow;
+  lower(): NtkWindow;
+  move(x: number, y: number): void;
+  resize(width: number, height: number): void;
+  moveResize(x: number, y: number, width: number, height: number): void;
+  setTitle(title: string): NtkWindow;
+  setCursor(name: string | null): NtkWindow;
+  focus(revertTo?: number): NtkWindow;
+  getContext(name: '2d' | 'opengl' | 'x11', ...args: unknown[]): unknown;
+  requestAnimationFrame(cb: (time: number) => void): number;
+  cancelAnimationFrame(id: number): void;
+  destroy(): void;
+  on(event: string, handler: (...args: any[]) => void): unknown;
+  off?(event: string, handler: (...args: any[]) => void): unknown;
+  [key: string]: any;
+}
+
+/**
+ * An ntk `App` — the X connection. `createRoot()` makes one for you; pass
+ * your own to render into an existing connection.
+ */
+export interface NtkApp {
+  readonly X: any;
+  readonly display: any;
+  createWindow(args?: Record<string, unknown>): NtkWindow;
+  rootWindow(screen?: number): NtkWindow;
+  close(): Promise<void>;
+  [key: string]: any;
+}

--- a/src/types/style.d.ts
+++ b/src/types/style.d.ts
@@ -1,0 +1,203 @@
+/**
+ * The `style` prop: layout (yoga), paint, text, and the three block forms —
+ * pseudo-states, window size queries, transitions. See docs/styling.md.
+ */
+
+/**
+ * A CSS colour string (`'#2980b9'`, `'tomato'`, `'rgba(0,0,0,.5)'`), or a
+ * `$token` resolved against the nearest `theme` prop — see
+ * {@link https://github.com/sidorares/react-x11/blob/master/docs/styling.md#theme-tokens Theme tokens}.
+ */
+export type Color = string;
+
+/** A yoga length: pixels, a percentage, or `'auto'`. */
+export type Dimension = number | `${number}%` | 'auto';
+
+/** A yoga length that has no `auto` form. */
+export type Length = number | `${number}%`;
+
+export type FlexDirection = 'row' | 'row-reverse' | 'column' | 'column-reverse';
+
+export type Justify =
+  | 'flex-start'
+  | 'center'
+  | 'flex-end'
+  | 'space-between'
+  | 'space-around'
+  | 'space-evenly';
+
+export type Align =
+  | 'auto'
+  | 'flex-start'
+  | 'center'
+  | 'flex-end'
+  | 'stretch'
+  | 'baseline'
+  | 'space-between'
+  | 'space-around';
+
+export type FlexWrap = 'nowrap' | 'wrap' | 'wrap-reverse';
+export type PositionType = 'static' | 'relative' | 'absolute';
+export type Display = 'flex' | 'none';
+export type Overflow = 'visible' | 'hidden' | 'scroll';
+export type BorderStyle = 'solid' | 'dashed';
+export type PointerEvents = 'auto' | 'none';
+export type TextAlign = 'left' | 'right' | 'center' | 'start' | 'end';
+export type FontStyle = 'normal' | 'italic' | 'oblique';
+export type FontWeight = number | 'normal' | 'bold';
+
+/**
+ * Cursor names, as ntk maps them to the X cursor font. Any other string is
+ * passed through to ntk, which may know shapes this list does not.
+ */
+export type Cursor =
+  | 'default'
+  | 'pointer'
+  | 'text'
+  | 'move'
+  | 'crosshair'
+  | 'wait'
+  | 'progress'
+  | 'help'
+  | 'not-allowed'
+  | 'grab'
+  | 'grabbing'
+  | 'ew-resize'
+  | 'ns-resize'
+  | 'nwse-resize'
+  | 'nesw-resize'
+  | 'col-resize'
+  | 'row-resize'
+  | 'none'
+  | (string & {});
+
+/** Everything yoga lays out. */
+export interface LayoutStyle {
+  width?: Dimension;
+  height?: Dimension;
+  minWidth?: Length;
+  minHeight?: Length;
+  maxWidth?: Length;
+  maxHeight?: Length;
+  flexDirection?: FlexDirection;
+  justifyContent?: Justify;
+  alignItems?: Align;
+  alignSelf?: Align;
+  alignContent?: Align;
+  flexWrap?: FlexWrap;
+  flexGrow?: number;
+  flexShrink?: number;
+  flexBasis?: Dimension;
+  position?: PositionType;
+  top?: Length;
+  right?: Length;
+  bottom?: Length;
+  left?: Length;
+  margin?: Dimension;
+  marginTop?: Dimension;
+  marginRight?: Dimension;
+  marginBottom?: Dimension;
+  marginLeft?: Dimension;
+  padding?: Length;
+  paddingTop?: Length;
+  paddingRight?: Length;
+  paddingBottom?: Length;
+  paddingLeft?: Length;
+  gap?: number;
+  rowGap?: number;
+  columnGap?: number;
+  aspectRatio?: number;
+  display?: Display;
+  overflow?: Overflow;
+  borderWidth?: number;
+}
+
+/**
+ * Properties that only affect painting, never geometry — the only ones a
+ * `:hover`/`:focus`/`:active`/`:disabled` block may set, because a state
+ * block that could reflow the tree would jitter on pointer move.
+ */
+export interface PaintStyle {
+  backgroundColor?: Color;
+  borderColor?: Color;
+  borderRadius?: number;
+  zIndex?: number;
+}
+
+/** Text properties. All affect measurement except `color`. */
+export interface TextStyle {
+  color?: Color;
+  fontFamily?: string;
+  fontSize?: number;
+  fontWeight?: FontWeight;
+  fontStyle?: FontStyle;
+  textAlign?: TextAlign;
+  lineHeight?: number;
+}
+
+/** What a pseudo-state block may change: paint properties, plus `color`. */
+export interface StateStyle extends PaintStyle {
+  color?: Color;
+}
+
+/** Every property a style may set, before the block forms. */
+export interface StyleProperties extends LayoutStyle, PaintStyle, TextStyle {
+  borderStyle?: BorderStyle;
+  cursor?: Cursor;
+  pointerEvents?: PointerEvents;
+}
+
+/**
+ * How long a change takes: one duration in ms for everything animatable, or
+ * a duration per property. Enums, percentages, `'auto'` and `zIndex` snap
+ * rather than animate.
+ */
+export type Transition = number | { [K in keyof StyleProperties]?: number };
+
+/**
+ * A window size query — the X11 analogue of `@media`, asking about the
+ * window a style is laid out in: `'@width >= 600'`, `'@height < 400'`.
+ * Unlike a state block, a size query may set layout properties.
+ */
+export type SizeQuery = `@${'width' | 'height'} ${string}`;
+
+/** The named blocks a style may carry, beside its own properties. */
+export interface StyleBlocks {
+  transition?: Transition;
+  ':hover'?: StateStyle;
+  ':focus'?: StateStyle;
+  ':active'?: StateStyle;
+  ':disabled'?: StateStyle;
+}
+
+/**
+ * A style: the properties themselves, the state blocks, and any number of
+ * size-query blocks keyed `'@width >= 600'`.
+ */
+export type Style = StyleProperties &
+  StyleBlocks & { [K in SizeQuery]?: StyleProperties };
+
+/**
+ * What a `style` prop accepts: an object, or a nested array of them with
+ * falsy entries skipped and later entries winning. This is what replaces
+ * the cascade — precedence is written at the call site.
+ */
+export type StyleProp = Style | false | null | undefined | readonly StyleProp[];
+
+/** A sheet of named styles, as returned by `createStyles`. */
+export type StyleSheet<T> = { readonly [K in keyof T]: Readonly<Style> };
+
+/**
+ * Declare styles once, outside render. Identity is the point: a hoisted
+ * style object lets the renderer skip an update with a `===` check. It also
+ * validates keys, which a bare object literal cannot — and so does this
+ * signature: the parameter is mapped rather than a bare type parameter so
+ * each value keeps `Style` as its contextual type, which is what makes
+ * TypeScript reject an unknown property instead of widening it away.
+ */
+export function createStyles<T extends Record<string, unknown>>(sheet: {
+  [K in keyof T]: Style;
+}): StyleSheet<T>;
+
+/** Flatten a `StyleProp` into a single style object. */
+export function flattenStyle(style: StyleProp): Style;

--- a/test/jsx-runtime.test.js
+++ b/test/jsx-runtime.test.js
@@ -1,0 +1,28 @@
+// `jsxImportSource: "react-x11"` makes the compiler emit imports from
+// react-x11/jsx-runtime, so those modules have to exist and work at runtime,
+// not just carry the JSX types. Nothing else in the suite loads them.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import * as reactRuntime from 'react/jsx-runtime';
+import * as reactDevRuntime from 'react/jsx-dev-runtime';
+
+import * as runtime from '../src/jsx-runtime.js';
+import * as devRuntime from '../src/jsx-dev-runtime.js';
+
+test('the JSX runtime is React’s own', () => {
+  assert.equal(runtime.jsx, reactRuntime.jsx);
+  assert.equal(runtime.jsxs, reactRuntime.jsxs);
+  assert.equal(runtime.Fragment, reactRuntime.Fragment);
+});
+
+test('the development JSX runtime is too', () => {
+  assert.equal(devRuntime.jsxDEV, reactDevRuntime.jsxDEV);
+  assert.equal(devRuntime.Fragment, reactDevRuntime.Fragment);
+});
+
+test('it builds the elements the renderer expects', () => {
+  const element = runtime.jsx('box', { style: { flexGrow: 1 } });
+  assert.equal(element.type, 'box');
+  assert.deepEqual(element.props.style, { flexGrow: 1 });
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -1,0 +1,361 @@
+/**
+ * Type tests. Not run — compiled. `npm run typecheck` fails if the public
+ * API stops matching src/index.d.ts, and the `@ts-expect-error` lines fail
+ * if something that should be rejected starts being accepted.
+ *
+ * Keep this exercising the API the way the examples do; it is the only
+ * thing that keeps hand-written declarations honest.
+ */
+import React, { useRef, useState } from 'react';
+import {
+  Button,
+  Canvas3D,
+  Checkbox,
+  ContextMenu,
+  createRoot,
+  createStyles,
+  Dialog,
+  flattenStyle,
+  MenuBar,
+  ProgressBar,
+  Radio,
+  RadioGroup,
+  render,
+  Select,
+  Slider,
+  SplitPane,
+  Switch,
+  Table,
+  Tabs,
+  ThemeProvider,
+  Tooltip,
+  Tree,
+  unmountComponentAtNode,
+  useAnchor,
+} from '../../src/index.js';
+import type {
+  DrawnNode,
+  KeyboardEvent,
+  MouseEvent,
+  NtkWindow,
+  ScrollEvent,
+  ScrollViewNode,
+  Style,
+  StyleProp,
+  WheelEvent,
+} from '../../src/index.js';
+
+// --- styles ----------------------------------------------------------------
+
+const s = createStyles({
+  root: { flexGrow: 1, padding: 16, gap: 12, backgroundColor: '#f5f6fa' },
+  row: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  half: { width: '50%', marginLeft: 'auto' },
+  title: { fontSize: 20, color: '$text', fontWeight: 'bold' },
+  card: {
+    borderRadius: 8,
+    borderWidth: 1,
+    borderStyle: 'dashed',
+    cursor: 'pointer',
+    transition: 120,
+    ':hover': { backgroundColor: '#eee' },
+    ':disabled': { color: '#999' },
+  },
+  responsive: {
+    flexDirection: 'column',
+    '@width >= 600': { flexDirection: 'row', gap: 24 },
+  },
+  perProperty: { transition: { backgroundColor: 200, left: 120 } },
+});
+
+// arrays, falsy entries, nesting
+const composed: StyleProp = [s.root, false, null, [s.row, { padding: 4 }]];
+const flat: Style = flattenStyle(composed);
+const grow: number | undefined = flat.flexGrow;
+
+// @ts-expect-error — 'sideways' is not a flexDirection
+createStyles({ bad: { flexDirection: 'sideways' } });
+
+// @ts-expect-error — layout properties may not go in a state block
+createStyles({ bad: { ':hover': { padding: 4 } } });
+
+// @ts-expect-error — unknown style property
+createStyles({ bad: { colour: 'red' } });
+
+// --- elements --------------------------------------------------------------
+
+function Elements() {
+  const boxRef = useRef<DrawnNode>(null);
+  const scrollRef = useRef<ScrollViewNode>(null);
+  const winRef = useRef<NtkWindow>(null);
+  const [text, setText] = useState('');
+
+  return (
+    <window
+      ref={winRef}
+      title="types"
+      width={480}
+      height={320}
+      minWidth={320}
+      resizable={false}
+      windowType="dialog"
+      wmClass={['app', 'App']}
+      style={s.root}
+      onCloseRequest={() => {}}
+      onResize={(ev) => void ev.nativeEvent.rootx}
+    >
+      <box
+        ref={boxRef}
+        style={[s.row, s.card]}
+        onClick={(ev) => void ev.detail}
+      >
+        <text style={s.title}>hello</text>
+        <text>{text}</text>
+        <text>{42}</text>
+      </box>
+
+      <scrollview
+        ref={scrollRef}
+        scrollbar
+        scrollbarColor="#ccc"
+        style={s.responsive}
+        onScroll={(ev: ScrollEvent) => void ev.scrollY}
+        onViewport={(ev) => void ev.contentHeight}
+      >
+        <box style={{ height: 800 }} />
+      </scrollview>
+
+      <textinput
+        value={text}
+        onChange={setText}
+        onSubmit={(value) => void value.length}
+        placeholder="type"
+        maxLength={40}
+        focusable
+        tabIndex={0}
+      />
+      <textarea rows={4} defaultValue="multi" />
+      <image src="./logo.png" style={{ width: 32, height: 32 }} />
+      <canvas
+        style={{ flexGrow: 1 }}
+        onDraw={(ctx, { width, height }) => {
+          ctx.fillStyle = 'tomato';
+          ctx.fillRect(0, 0, width / 2, height);
+        }}
+      />
+      <markdown source="# hi" onLink={(href) => void href.length} />
+      <html source="<p>hi</p>" stylesheet="p { margin: 0 }" />
+      <svg source="<svg/>" />
+      <tex source="e^{i\\pi}" size={18} color="#222" />
+    </window>
+  );
+}
+
+// --- events ----------------------------------------------------------------
+
+function Events() {
+  return (
+    <box
+      onMouseDown={(ev: MouseEvent) => {
+        ev.capturePointer();
+        ev.stopPropagation();
+        void ev.nativeEvent.rootx;
+        void ev.button;
+      }}
+      onWheel={(ev: WheelEvent) => {
+        ev.preventDefault();
+        void (ev.deltaX + ev.deltaY);
+      }}
+      onKeyDown={(ev: KeyboardEvent) => {
+        void ev.key;
+        void ev.codepoint;
+        void ev.shiftKey;
+      }}
+      onMouseEnter={() => {}}
+      onFocus={() => {}}
+    />
+  );
+}
+
+// The DOM is not the host here, so its elements are not in scope at all.
+// This is what owning the JSX namespace buys over augmenting React's, where
+// `@types/react` would keep declaring every HTML and SVG tag.
+// @ts-expect-error — 'div' is not a react-x11 element
+const _div = <div />;
+// @ts-expect-error — 'img' is not one either, despite <image> existing
+const _img = <img />;
+// @ts-expect-error — <box> has no 'className'
+const _classy = <box className="nope" />;
+
+// --- popups ----------------------------------------------------------------
+
+function Popup() {
+  return (
+    <popup x={40} y={40} width={120} height={80} grab onDismiss={() => {}}>
+      <box />
+    </popup>
+  );
+}
+
+// --- 3D --------------------------------------------------------------------
+
+function Scene() {
+  return (
+    <Canvas3D
+      style={{ flexGrow: 1 }}
+      camera={{ position: [0, 2, 6], fov: 45 }}
+      onPointerMissed={() => {}}
+    >
+      <ambientLight intensity={0.35} />
+      <pointLight position={[5, 6, 6]} distance={20} />
+      <group rotation={[0, 0.5, 0]}>
+        <mesh
+          position={[-1.6, 0, 0]}
+          scale={1.2}
+          onClick={(ev) => void ev.distance}
+        >
+          <boxGeometry args={[1.4, 1.4, 1.4]} />
+          <meshPhongMaterial color="#2980b9" shininess={60} side="double" />
+        </mesh>
+        <mesh>
+          <bufferGeometry position={[0, 0, 0, 1, 0, 0, 0, 1, 0]} />
+          <meshBasicMaterial wireframe opacity={0.5} transparent />
+        </mesh>
+      </group>
+    </Canvas3D>
+  );
+}
+
+function RawGl() {
+  return (
+    <glarea
+      style={{ flexGrow: 1 }}
+      clearColor={[0, 0, 0, 1]}
+      frameLoop="always"
+      glx={{ DEPTH_SIZE: 24 }}
+      onCreated={(gl) => gl.Enable(gl.DEPTH_TEST)}
+      onDraw={(gl, { width }) => gl.Viewport(0, 0, width, width)}
+      onError={(err) => void err.message}
+    />
+  );
+}
+
+// --- components ------------------------------------------------------------
+
+function Widgets() {
+  const anchorRef = useRef<DrawnNode>(null);
+  const anchor = useAnchor(anchorRef);
+  const [checked, setChecked] = useState(false);
+
+  return (
+    <ThemeProvider value={{ accent: '#2980b9', radius: 6 }}>
+      <box ref={anchorRef} style={s.row}>
+        <Button primary onPress={() => void anchor()}>
+          press
+        </Button>
+        <Button label="labelled" disabled />
+        <Checkbox checked={checked} onChange={setChecked}>
+          check
+        </Checkbox>
+        <Switch checked={checked} onChange={setChecked} />
+        <ProgressBar value={0.4} color="#2980b9" />
+        <Slider value={20} min={0} max={100} step={5} onChange={() => {}} />
+        <Tooltip label="hi" placement="bottom" delay={200}>
+          <box />
+        </Tooltip>
+
+        <RadioGroup<string> value="a" onChange={(v) => void v.toUpperCase()}>
+          <Radio value="a">A</Radio>
+          <Radio value="b" label="B" />
+        </RadioGroup>
+
+        <Select<number>
+          value={1}
+          options={[{ value: 1, label: 'one' }]}
+          onChange={(v) => void v.toFixed()}
+        />
+        <Select options={['plain', 'values']} />
+      </box>
+
+      <Tabs
+        items={[{ id: 'a', label: 'A', content: <box /> }]}
+        defaultValue="a"
+        orientation="vertical"
+        manual
+        onChange={(id) => void id.length}
+      />
+      <Tree
+        items={[
+          { id: 'src', label: 'src', children: [{ id: 'a', label: 'a.js' }] },
+        ]}
+        defaultExpanded={['src']}
+        onActivate={(id) => void id}
+      />
+      <Table<{ id: string; size: number }>
+        columns={[
+          { id: 'id', label: 'Name' },
+          {
+            id: 'size',
+            label: 'Size',
+            align: 'right',
+            value: (row) => row.size,
+          },
+        ]}
+        rows={[{ id: 'a', size: 1 }]}
+        defaultSort={{ id: 'size', direction: 'desc' }}
+        onSelect={(id) => void id}
+      />
+      <SplitPane direction="row" defaultSize={200} min={80}>
+        <box />
+        <box />
+      </SplitPane>
+      <MenuBar
+        menus={[
+          { label: 'File', items: [{ label: 'Open' }, { separator: true }] },
+        ]}
+        onSelect={(item) => void item.label}
+      />
+      <ContextMenu items={[{ label: 'Copy', shortcut: 'Ctrl+C' }]}>
+        <box />
+      </ContextMenu>
+      <Dialog
+        open
+        title="Sure?"
+        onClose={() => {}}
+        actions={<Button label="OK" />}
+      >
+        <text>body</text>
+      </Dialog>
+    </ThemeProvider>
+  );
+}
+
+// @ts-expect-error — Slider takes a number, not a string
+const _badSlider = <Slider value="20" />;
+
+// @ts-expect-error — Tabs items need an id
+const _badTabs = <Tabs items={[{ label: 'A' }]} />;
+
+// --- entry points ----------------------------------------------------------
+
+async function main() {
+  const root = await createRoot();
+  root.render(<Elements />);
+  root.render(<Widgets />, () => {});
+  void root.app.X;
+  root.unmount();
+
+  await render(<Scene />);
+  render(<RawGl />, undefined, root.app);
+  render(<Popup />, () => {}, root.app);
+  render(<Events />, () => {}, root.app);
+  unmountComponentAtNode(root.app);
+}
+
+void main;
+void grow;
+void _div;
+void _img;
+void _classy;
+void _badSlider;
+void _badTabs;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "react-x11",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": false,
+    "types": [],
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "react-x11": ["./src/index.d.ts"],
+      "react-x11/jsx-runtime": ["./src/jsx-runtime.d.ts"],
+      "react-x11/jsx-dev-runtime": ["./src/jsx-dev-runtime.d.ts"]
+    }
+  },
+  "include": ["src/**/*.d.ts", "test/types/**/*.tsx", "test/types/**/*.ts"]
+}


### PR DESCRIPTION
Types ship with the package — no `@types/react-x11`, and nothing to build. Hand-written `.d.ts` files next to the JavaScript they describe.

```jsonc
// tsconfig.json — the whole configuration
{
  "compilerOptions": {
    "jsx": "react-jsx",
    "jsxImportSource": "react-x11"
  }
}
```

```tsx
import { createRoot, createStyles, Button } from 'react-x11';
import type { MouseEvent } from 'react-x11';

const s = createStyles({ root: { flexGrow: 1, padding: 12, gap: 8 } });

<window title="hi" width={320} height={200} style={s.root}>
  <box onClick={(ev: MouseEvent) => console.log(ev.detail)}>
    <text style={{ fontSize: 18 }}>hello</text>
  </box>
  <Button primary onPress={() => {}}>ok</Button>
</window>;
```

## The interesting part: JSX does not come from augmenting React

The obvious approach is to merge into React's namespace. **It does not compile:**

```
Interface 'IntrinsicElements' incorrectly extends interface 'ReactX11Elements'.
  The types of 'text.ref' are incompatible between these types.
    Type 'Ref<SVGTextElement>' is not assignable to type 'Ref<DrawnNode>'.
```

Five element names — `text`, `image`, `canvas`, `html`, `svg` — are also HTML or SVG element names, already declared by `@types/react` with incompatible props, and declaration merging cannot replace an existing member.

So react-x11 ships its own JSX source: `react-x11/jsx-runtime`, which re-exports React's actual runtime and carries a `JSX` namespace of its own. That turned out to be the better answer regardless — the namespace holds the X11 elements **and nothing else**:

```tsx
<div />; // error: Property 'div' does not exist on type 'JSX.IntrinsicElements'
```

An augmentation could never have done that, since `@types/react` declares every HTML and SVG tag unconditionally. `IntrinsicElements` stays an interface, so a project can still merge in elements of its own.

## What is typed

| | |
| --- | --- |
| `src/types/style.d.ts` | `Style`, `StyleProp`, the yoga enums, state blocks, transitions, size queries |
| `src/types/events.d.ts` | `SyntheticEvent` and the mouse / wheel / keyboard / focus shapes |
| `src/types/nodes.d.ts` | what a `ref` gives you: `DrawnNode`, `ScrollViewNode`, ntk's `Window` |
| `src/types/elements.d.ts` | every host element's props, including the 3D scene |
| `src/types/components.d.ts` | the widget set, `Theme`, the anchoring helpers |
| `src/index.d.ts` | the entry: `createRoot`, `render`, and re-exports of the above |

Values are as precise as the runtime is — `flexDirection` takes the four yoga values, `width` takes `number | '50%' | 'auto'`, and a state block takes paint properties only, the same rule `createStyles` enforces at runtime. Deliberately loose and said so in the docs: `Color` is `string` (a CSS colour or a `$token`), and the 2d and GL contexts are `any`, because ntk ships no types and a second copy of its API here would drift.

## A TypeScript gotcha worth recording

`createStyles` takes a **mapped** parameter:

```ts
export function createStyles<T extends Record<string, unknown>>(
  sheet: { [K in keyof T]: Style },
): StyleSheet<T>;
```

With the natural `T extends Record<string, Style>` the object literal loses freshness during inference and TypeScript silently stops reporting unknown properties — `createStyles({ bad: { ':hover': { padding: 4 } } })` compiled fine. The mapped form keeps `Style` as each value's contextual type, so a typo in a style key fails to compile the way the runtime validation rejects it. The type test caught this; review would not have.

## Kept honest by compilation

`npm run typecheck` compiles `test/types/api.tsx`, which exercises the API the way the examples do and carries `@ts-expect-error` lines for what must *not* compile:

```tsx
// @ts-expect-error — layout properties may not go in a state block
createStyles({ bad: { ':hover': { padding: 4 } } });
```

Those fail the build if the rejection stops happening — the half of a type test that usually goes missing. Every negative case reports a real error:

```
src/bad.tsx(3,24): Type '"sideways"' is not assignable to type 'FlexDirection | undefined'.
src/bad.tsx(4,37): 'padding' does not exist in type 'StateStyle'.
src/bad.tsx(5,18): Property 'div' does not exist on type 'JSX.IntrinsicElements'.
src/bad.tsx(6,23): Property 'className' does not exist on type 'DrawnProps<DrawnNode>'.
src/bad.tsx(7,26): Type 'string' is not assignable to type 'number'.
src/bad.tsx(9,44): Property 'notAThing' does not exist on type 'MouseEvent<DrawnNode>'.
```

Wired into CI beside lint. `test/jsx-runtime.test.js` covers the runtime modules, since nothing else loads them and a broken re-export would not show up in a type check.

**Verified end to end** by installing the packed package into a scratch project outside this repo — no `paths` mapping, just `jsxImportSource` — and type-checking there, so the `exports` map and the declaration resolution are exercised the way a user will hit them.

## Also

- `AGENTS.md` gains a note that a prop change is not done until the `.d.ts` and a line in the type test change with it.
- `docs/typescript.md` for the setup, the augmentation story, and what is deliberately loose.
- New devDependencies: `typescript`, `@types/react`. Neither is needed at runtime.

Full suite: **205 passing**, lint, format and typecheck clean.