### PR TITLE
feat: undo and redo in <textinput> and <textarea>

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,21 +95,21 @@ Everything else is laid out by yoga and drawn client-side into the window's
 double-buffered 2d context — see [NEXT_STEPS.md](NEXT_STEPS.md) for the architecture rationale
 and [docs/](docs/README.md) for the full API reference.
 
-| element        | what it is                                                                                                           |
-| -------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `<window>`     | a real X11 window; the flex, paint and event root                                                                    |
-| `<popup>`      | an override-redirect window at screen coordinates — menus, tooltips, dropdowns                                       |
-| `<box>`        | flex container: layout props → yoga, plus backgrounds, borders (solid/dashed, radius), overflow clipping, zIndex     |
-| `<scrollview>` | clipped, wheel-scrollable viewport with a drawn scrollbar                                                            |
-| `<text>`       | shaped, wrapped text (bidi, ligatures, font fallback); nested `<text>` elements are style spans                      |
-| `<textinput>`  | single-line editor: caret/selection via ntk's TextLayout caret API, clipboard (CLIPBOARD + X11 PRIMARY), word select |
-| `<image>`      | PNG/JPEG from `src`, natural-size aware                                                                              |
-| `<canvas>`     | escape hatch: `onDraw={(ctx, {width, height}) => …}` with ntk's canvas-like 2d context (XRender-backed)              |
-| `<markdown>`   | ntk MarkdownView: headings, tables, highlighted fences, math, mermaid; `onLink`                                      |
-| `<html>`       | ntk HtmlView: CSS cascade, block/flex layout, images; `onLink`                                                       |
-| `<svg>`        | static SVG through ntk SvgView, sized like `<image>`                                                                 |
-| `<tex>`        | a KaTeX formula (ntk `layoutTex`), intrinsically sized                                                               |
-| `<glarea>`     | an OpenGL surface over indirect GLX; the 3D scene below lives inside it                                              |
+| element        | what it is                                                                                                                      |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `<window>`     | a real X11 window; the flex, paint and event root                                                                               |
+| `<popup>`      | an override-redirect window at screen coordinates — menus, tooltips, dropdowns                                                  |
+| `<box>`        | flex container: layout props → yoga, plus backgrounds, borders (solid/dashed, radius), overflow clipping, zIndex                |
+| `<scrollview>` | clipped, wheel-scrollable viewport with a drawn scrollbar                                                                       |
+| `<text>`       | shaped, wrapped text (bidi, ligatures, font fallback); nested `<text>` elements are style spans                                 |
+| `<textinput>`  | single-line editor: caret/selection via ntk's TextLayout caret API, clipboard (CLIPBOARD + X11 PRIMARY), word select, undo/redo |
+| `<image>`      | PNG/JPEG from `src`, natural-size aware                                                                                         |
+| `<canvas>`     | escape hatch: `onDraw={(ctx, {width, height}) => …}` with ntk's canvas-like 2d context (XRender-backed)                         |
+| `<markdown>`   | ntk MarkdownView: headings, tables, highlighted fences, math, mermaid; `onLink`                                                 |
+| `<html>`       | ntk HtmlView: CSS cascade, block/flex layout, images; `onLink`                                                                  |
+| `<svg>`        | static SVG through ntk SvgView, sized like `<image>`                                                                            |
+| `<tex>`        | a KaTeX formula (ntk `layoutTex`), intrinsically sized                                                                          |
+| `<glarea>`     | an OpenGL surface over indirect GLX; the 3D scene below lives inside it                                                         |
 
 Widget **components** (plain React on top of the primitives, themable via
 `ThemeProvider`): `Button`, `Checkbox`, `Radio`/`RadioGroup`, `Switch`,

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -278,9 +278,30 @@ across kerning, shaping boundaries and trailing whitespace.
 Interactions: click/drag selection, double-click word select, triple-click
 select all, Backspace/Delete, arrows (+Shift extends), Home/End, Ctrl+A,
 Ctrl+C/X/V on CLIPBOARD, middle-click paste from PRIMARY, selections own
-PRIMARY (X11 conventions). Focusable by default; shows the text cursor.
+PRIMARY (X11 conventions), **Ctrl+Z / Ctrl+Shift+Z** (Ctrl+Y too) to undo
+and redo. Focusable by default; shows the text cursor.
 `ev.preventDefault()` in your `onKeyDown`/`onMouseDown` suppresses the
 built-in editing behavior.
+
+**Ref**: the node, plus `value`, `undo()` / `redo()` and `canUndo` /
+`canRedo` — enough for a toolbar button beside the field.
+
+### Undo
+
+Consecutive typing coalesces into one undo step, so Ctrl+Z takes back a
+word rather than a keystroke; a run of Backspaces coalesces the same way.
+A run ends at whitespace, at anything that moves the caret (arrows,
+Home/End, a click, focus leaving the field), and around edits that are
+their own step whatever surrounds them: a paste, a cut, a replaced
+selection, Ctrl+Backspace, and a `<textarea>` newline. Undo restores the
+selection and puts the caret back where the undone edit started.
+
+Undo is a stack of snapshots of the states the control has shown, capped
+at 200. A **controlled** `value` reports the restored text through
+`onChange` and waits for the prop to come back, exactly as typing does —
+so a parent that filters or rejects a value gets the same say over an undo
+that it has over an edit. A value changed from outside (a form reset)
+becomes its own entry, and undoing steps back through it.
 
 ## `<textarea>`
 

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -1419,6 +1419,22 @@ const XK_PAGE_DOWN = 0xff56;
 const XK_END = 0xff57;
 const XK_DELETE = 0xffff;
 
+/** Undo entries kept per input. Snapshots of a single field are small; the
+ * cap is what stops a long-lived form from growing without bound. */
+const UNDO_LIMIT = 200;
+
+/**
+ * The letter of a Ctrl chord, independent of Shift. ntk derives `codepoint`
+ * from the *shifted* keysym, so Ctrl+Shift+Z arrives as `Z` while Ctrl+Z
+ * arrives as `z` — the keysym does not shift, so match on that and fall
+ * back to the codepoint when the keymap has not been read yet.
+ */
+function ctrlChordLetter(ev) {
+  const code = ev.keysym ?? ev.codepoint;
+  if (code == null) return null;
+  return code >= 0x41 && code <= 0x5a ? code + 0x20 : code;
+}
+
 /**
  * <textinput>: single-line editable text. Caret/selection via ntk TextLayout
  * prefix measurement, editing via the EventManager default-action hooks
@@ -1442,6 +1458,14 @@ export class TextInputNode extends Node {
     this._caretOn = false;
     this._blinkTimer = null;
     this._dragging = false;
+    // undo/redo: snapshots of every state this input has shown, oldest
+    // first, with _historyIndex on the current one
+    this._history = [
+      { value: this.value, caret: this._caret, anchor: this._anchor },
+    ];
+    this._historyIndex = 0;
+    this._historyValue = this.value;
+    this._undoRun = null;
     this.yoga.setMeasureFunc((width, widthMode) => {
       const preferred = 150;
       const w =
@@ -1519,16 +1543,148 @@ export class TextInputNode extends Node {
     this.root?.invalidate(false);
   }
 
-  _commit(nextChars, caret) {
+  /**
+   * The one place the value changes. `kind` names the edit for undo
+   * coalescing (`type`, `delete-back`, `delete-forward`); anything left
+   * unnamed — a paste, a cut, a replaced selection, a newline — is its own
+   * undo step.
+   */
+  _commit(nextChars, caret, kind = null) {
     const next = nextChars.join('');
     const previous = this.value;
+    const beforeCaret = this._caret;
+    const beforeAnchor = this._anchor;
     this._caret = caret;
     this._anchor = caret;
     if (this.props.value == null) this._value = next;
     if (next !== previous) {
+      // `this.value` is still the old one in controlled mode — the parent
+      // has not answered onChange yet — so record what we computed
+      this._recordEdit(kind, {
+        value: next,
+        caret,
+        anchor: caret,
+        beforeCaret,
+        beforeAnchor,
+      });
       this.props.onChange?.(next);
     }
     this._repaint();
+  }
+
+  // --- undo/redo ------------------------------------------------------
+  //
+  // Full-value snapshots rather than a diff log: a single field is small,
+  // and a snapshot is the only representation that stays right when the
+  // value is controlled and the parent rewrites what we send it. Each
+  // entry also carries the caret from *before* the edit that produced it,
+  // so undoing puts the caret back where the typing happened rather than
+  // where the run ended.
+
+  /** True while there is an earlier state to go back to. */
+  get canUndo() {
+    return this._historyIndex > 0;
+  }
+
+  /** True while an undone state is still ahead. */
+  get canRedo() {
+    return this._historyIndex < this._history.length - 1;
+  }
+
+  /** Step back one edit. Returns false when there is nothing to undo. */
+  undo() {
+    if (!this.canUndo) return false;
+    const undone = this._history[this._historyIndex];
+    const target = this._history[--this._historyIndex];
+    // the caret goes where the undone edit started, not where it ended
+    this._applyHistory(target.value, undone.beforeCaret, undone.beforeAnchor);
+    return true;
+  }
+
+  /** Step forward one undone edit. False when there is nothing to redo. */
+  redo() {
+    if (!this.canRedo) return false;
+    const target = this._history[++this._historyIndex];
+    this._applyHistory(target.value, target.caret, target.anchor);
+    return true;
+  }
+
+  /** End the coalescing run: the next edit starts a fresh undo entry. */
+  _breakUndoRun() {
+    this._undoRun = null;
+  }
+
+  _applyHistory(value, caret, anchor) {
+    this._breakUndoRun();
+    const previous = this.value;
+    if (this.props.value == null) this._value = value;
+    this._historyValue = value;
+    const len = Array.from(value).length;
+    this._caret = Math.min(Math.max(0, caret), len);
+    this._anchor = Math.min(Math.max(0, anchor), len);
+    if (value !== previous) this.props.onChange?.(value);
+    this._repaint();
+  }
+
+  /**
+   * Fold the edit into the open run, or start a new entry. A run continues
+   * while the same kind of edit keeps happening at the caret it left off
+   * at, so a word of typing — or a run of backspaces — undoes as one step.
+   */
+  _recordEdit(kind, entry) {
+    const top = this._history[this._historyIndex];
+    const continues =
+      kind != null &&
+      kind === this._undoRun &&
+      // a replaced selection is a distinct edit, however it was typed
+      entry.beforeCaret === entry.beforeAnchor &&
+      top?.caret === entry.beforeCaret;
+    if (continues) {
+      top.value = entry.value;
+      top.caret = entry.caret;
+      top.anchor = entry.anchor;
+    } else {
+      this._pushHistory(kind, entry);
+    }
+    this._historyValue = entry.value;
+  }
+
+  _pushHistory(kind, entry) {
+    // a fresh edit after an undo drops whatever was ahead
+    this._history.length = this._historyIndex + 1;
+    this._history.push(entry);
+    if (this._history.length > UNDO_LIMIT) this._history.shift();
+    this._historyIndex = this._history.length - 1;
+    this._undoRun = kind;
+  }
+
+  /**
+   * A controlled `value` that changed to something we did not commit was
+   * edited outside the control — a form reset, or an onChange that filters
+   * what it is given. It becomes its own history entry, so undo walks back
+   * through states that really existed. The neighbour checks catch the
+   * parent echoing an undo back at us, or refusing one: that moves through
+   * the history instead of appending to it, which is what keeps a filtering
+   * onChange from growing the stack on every keystroke.
+   */
+  _noteExternalValue() {
+    const value = this.value;
+    if (value === this._historyValue) return;
+    this._breakUndoRun();
+    if (this._history[this._historyIndex + 1]?.value === value) {
+      this._historyIndex++;
+    } else if (this._history[this._historyIndex - 1]?.value === value) {
+      this._historyIndex--;
+    } else {
+      this._pushHistory(null, {
+        value,
+        caret: this._caret,
+        anchor: this._anchor,
+        beforeCaret: this._caret,
+        beforeAnchor: this._anchor,
+      });
+    }
+    this._historyValue = value;
   }
 
   /** Single-line: newlines collapse to spaces (textarea overrides). */
@@ -1536,7 +1692,7 @@ export class TextInputNode extends Node {
     return String(text).replace(/[\r\n]+/g, ' ');
   }
 
-  _insert(text) {
+  _insert(text, kind = null) {
     const insert = Array.from(this._normalizeInsert(text));
     if (this.props.maxLength != null) {
       const room =
@@ -1549,18 +1705,21 @@ export class TextInputNode extends Node {
     this._commit(
       [...chars.slice(0, a), ...insert, ...chars.slice(b)],
       a + insert.length,
+      kind,
     );
   }
 
-  _deleteRange(from, to) {
+  _deleteRange(from, to, kind = null) {
     const chars = this._chars();
-    this._commit([...chars.slice(0, from), ...chars.slice(to)], from);
+    this._commit([...chars.slice(0, from), ...chars.slice(to)], from, kind);
   }
 
   _moveCaret(index, extend) {
     const len = this._chars().length;
     this._caret = Math.min(Math.max(0, index), len);
     if (!extend) this._anchor = this._caret;
+    // typing that resumes somewhere else is a new edit, not the old one
+    this._breakUndoRun();
     this._repaint();
   }
 
@@ -1599,13 +1758,19 @@ export class TextInputNode extends Node {
     if (k === XK_BACKSPACE) {
       if (hasSelection) this._deleteRange(a, b);
       else if (ev.ctrlKey) this._deleteRange(this._wordBoundary(a, -1), a);
-      else if (a > 0) this._deleteRange(a - 1, a);
+      else if (a > 0) this._deleteRange(a - 1, a, 'delete-back');
       return;
     }
     if (k === XK_DELETE) {
       if (hasSelection) this._deleteRange(a, b);
       else if (ev.ctrlKey) this._deleteRange(a, this._wordBoundary(a, 1));
-      else this._deleteRange(a, Math.min(a + 1, this._chars().length));
+      else {
+        this._deleteRange(
+          a,
+          Math.min(a + 1, this._chars().length),
+          'delete-forward',
+        );
+      }
       return;
     }
     if (k === XK_LEFT) {
@@ -1639,22 +1804,34 @@ export class TextInputNode extends Node {
       return;
     }
     if (ev.ctrlKey) {
-      if (ev.codepoint === 0x61 /* a */) {
+      const letter = ctrlChordLetter(ev);
+      if (letter === 0x61 /* a */) {
         this._anchor = 0;
         this._caret = this._chars().length;
+        this._breakUndoRun();
         this._repaint();
-      } else if (ev.codepoint === 0x63 /* c */) {
+      } else if (letter === 0x63 /* c */) {
         this._copySelection();
-      } else if (ev.codepoint === 0x78 /* x */) {
+      } else if (letter === 0x78 /* x */) {
         this._copySelection();
         if (hasSelection) this._deleteRange(a, b);
-      } else if (ev.codepoint === 0x76 /* v */) {
+      } else if (letter === 0x76 /* v */) {
         this._pasteFrom();
+      } else if (letter === 0x7a /* z */) {
+        // Ctrl+Shift+Z redoes, the way it does in GTK and Qt
+        if (ev.shiftKey) this.redo();
+        else this.undo();
+      } else if (letter === 0x79 /* y */) {
+        this.redo();
       }
       return;
     }
     if (ev.codepoint != null && ev.codepoint >= 0x20 && ev.codepoint !== 0x7f) {
-      this._insert(String.fromCodePoint(ev.codepoint));
+      const ch = String.fromCodePoint(ev.codepoint);
+      this._insert(ch, 'type');
+      // undo a word at a time: the space that ends a word joins the run it
+      // ends, and the next word starts a fresh one
+      if (/\s/.test(ch)) this._breakUndoRun();
     }
   }
 
@@ -1706,6 +1883,8 @@ export class TextInputNode extends Node {
   }
 
   _defaultMouseDown(ev) {
+    // wherever the caret lands, editing resumes as a new undo entry
+    this._breakUndoRun();
     if (ev.button === 2) {
       // X11 middle-click: paste the PRIMARY selection at the click position
       const i = this._indexAtPoint(ev);
@@ -1773,6 +1952,8 @@ export class TextInputNode extends Node {
   _defaultBlur() {
     this._focused = false;
     this._caretOn = false;
+    // coming back to a field later is a new edit, not more of the old one
+    this._breakUndoRun();
     clearInterval(this._blinkTimer);
     this._blinkTimer = null;
     this.root?.invalidate(false);
@@ -1793,6 +1974,7 @@ export class TextInputNode extends Node {
     ).length;
     this._caret = Math.min(this._caret, len);
     this._anchor = Math.min(this._anchor, len);
+    this._noteExternalValue();
     let metricsChanged = false;
     for (const key of TEXT_LAYOUT_PROPS) {
       if (this.style[key] !== beforeStyle[key]) metricsChanged = true;
@@ -1939,6 +2121,12 @@ export class TextAreaNode extends TextInputNode {
   /** Multi-line: preserve newlines (normalize CRLF). */
   _normalizeInsert(text) {
     return String(text).replace(/\r\n?/g, '\n');
+  }
+
+  /** Undo moves the caret, so the Up/Down goal column no longer applies. */
+  _applyHistory(value, caret, anchor) {
+    this._goalX = null;
+    super._applyHistory(value, caret, anchor);
   }
 
   /** Wrapped, styled layout of the value (or placeholder), cached per

--- a/src/types/nodes.d.ts
+++ b/src/types/nodes.d.ts
@@ -51,6 +51,16 @@ export interface ScrollViewNode extends DrawnNode {
 /** `<textinput>` / `<textarea>`. */
 export interface TextInputNode extends DrawnNode {
   readonly value: string;
+  /**
+   * Step back one edit, as Ctrl+Z does. False when there is nothing to
+   * undo. Controlled inputs report the restored value through `onChange`,
+   * so the display follows the same round trip typing does.
+   */
+  undo(): boolean;
+  /** Step forward one undone edit, as Ctrl+Shift+Z does. */
+  redo(): boolean;
+  readonly canUndo: boolean;
+  readonly canRedo: boolean;
 }
 
 /**

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -3491,6 +3491,259 @@ test('textinput: shift+click extends the selection from the anchor', async () =>
   ReactX11.unmountComponentAtNode(app);
 });
 
+// --- undo/redo -------------------------------------------------------------
+
+// Mounts a focused <textinput> and returns helpers for driving it.
+async function mountInput(props = {}) {
+  const app = createMockApp();
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 300, height: 80 },
+      React.createElement('textinput', props),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const input = wnd._reactX11Node.children[0];
+  wnd.emit('mousedown', { x: 5, y: 5, keycode: 1 });
+  wnd.emit('mouseup', { x: 5, y: 5, keycode: 1 });
+  await tick();
+  return {
+    app,
+    wnd,
+    input,
+    type: (text) => {
+      for (const ch of text) {
+        const cp = ch.codePointAt(0);
+        pressKey(app, wnd, { keysym: cp, codepoint: cp });
+      }
+    },
+    key: (keysym, buttons = 0) => pressKey(app, wnd, { keysym, buttons }),
+    unmount: () => ReactX11.unmountComponentAtNode(app),
+  };
+}
+
+const XK_z = 0x7a;
+const XK_y = 0x79;
+const XK_END = 0xff57;
+const CTRL = 4;
+const SHIFT = 1;
+
+test('textinput: Ctrl+Z undoes a run of typing, Ctrl+Shift+Z redoes it', async () => {
+  const { input, type, key, unmount } = await mountInput({ defaultValue: '' });
+
+  type('hi');
+  assert.strictEqual(input.value, 'hi');
+
+  key(XK_z, CTRL);
+  assert.strictEqual(input.value, '', 'a run of typing undoes as one step');
+  assert.strictEqual(input._caret, 0, 'caret goes back where the run started');
+  assert.strictEqual(input.canUndo, false);
+
+  key(XK_z, CTRL | SHIFT);
+  assert.strictEqual(input.value, 'hi');
+  assert.strictEqual(input._caret, 2, 'redo restores the caret it ended at');
+
+  // Ctrl+Y redoes too, for the Windows-shaped muscle memory
+  key(XK_z, CTRL);
+  key(XK_y, CTRL);
+  assert.strictEqual(input.value, 'hi');
+  assert.strictEqual(input.canRedo, false);
+
+  unmount();
+});
+
+test('textinput: undo works a word at a time', async () => {
+  const { input, type, key, unmount } = await mountInput({ defaultValue: '' });
+
+  type('hello world');
+  key(XK_z, CTRL);
+  assert.strictEqual(input.value, 'hello ', 'the space ends the run it joins');
+  key(XK_z, CTRL);
+  assert.strictEqual(input.value, '');
+
+  unmount();
+});
+
+test('textinput: caret moves and deletes break the undo run', async () => {
+  const { input, type, key, unmount } = await mountInput({ defaultValue: '' });
+
+  type('ab');
+  key(XK.Left); // moving the caret starts a new edit
+  type('X');
+  assert.strictEqual(input.value, 'aXb');
+
+  key(XK_z, CTRL);
+  assert.strictEqual(input.value, 'ab', 'only the second run comes back off');
+  assert.strictEqual(input._caret, 1, 'caret where the undone insert happened');
+
+  key(XK_z, CTRL);
+  assert.strictEqual(input.value, '');
+
+  // backspaces coalesce with each other, not with the typing before them
+  key(XK_y, CTRL);
+  key(XK_y, CTRL);
+  assert.strictEqual(input.value, 'aXb');
+  key(XK_END);
+  key(XK.BackSpace);
+  key(XK.BackSpace);
+  assert.strictEqual(input.value, 'a');
+  key(XK_z, CTRL);
+  assert.strictEqual(input.value, 'aXb', 'both backspaces undo together');
+  assert.strictEqual(input._caret, 3, 'caret back where deleting started');
+
+  unmount();
+});
+
+test('textinput: a fresh edit drops the redo tail', async () => {
+  const { input, type, key, unmount } = await mountInput({ defaultValue: '' });
+
+  type('one ');
+  type('two');
+  key(XK_z, CTRL);
+  assert.strictEqual(input.value, 'one ');
+  assert.strictEqual(input.canRedo, true);
+
+  type('six');
+  assert.strictEqual(input.value, 'one six');
+  assert.strictEqual(input.canRedo, false, '"two" is no longer reachable');
+
+  key(XK_z, CTRL);
+  assert.strictEqual(input.value, 'one ');
+
+  unmount();
+});
+
+test('textinput: a paste is its own undo step', async () => {
+  const { app, wnd, input, type, key, unmount } = await mountInput({
+    defaultValue: '',
+  });
+  app.clipboard = {
+    write: () => Promise.resolve(),
+    read: () => Promise.resolve('pasted'),
+  };
+
+  type('ab');
+  pressKey(app, wnd, { keysym: 0x76, codepoint: 0x76, buttons: CTRL }); // ctrl+v
+  await tick();
+  assert.strictEqual(input.value, 'abpasted');
+
+  key(XK_z, CTRL);
+  assert.strictEqual(input.value, 'ab', 'the paste undoes without the typing');
+  key(XK_z, CTRL);
+  assert.strictEqual(input.value, '');
+
+  unmount();
+});
+
+test('textinput: undo in controlled mode reports through onChange', async () => {
+  const app = createMockApp();
+  const changes = [];
+  const render = (value) =>
+    ReactX11.render(
+      React.createElement(
+        'window',
+        { width: 300, height: 80 },
+        React.createElement('textinput', {
+          value,
+          onChange: (v) => {
+            changes.push(v);
+            render(v);
+          },
+        }),
+      ),
+      null,
+      app,
+    );
+  render('');
+  await tick();
+  const wnd = app.windows[0];
+  const input = wnd._reactX11Node.children[0];
+  wnd.emit('mousedown', { x: 5, y: 5, keycode: 1 });
+  wnd.emit('mouseup', { x: 5, y: 5, keycode: 1 });
+
+  pressKey(app, wnd, { keysym: 0x68, codepoint: 0x68 }); // h
+  pressKey(app, wnd, { keysym: 0x69, codepoint: 0x69 }); // i
+  assert.strictEqual(input.value, 'hi');
+
+  pressKey(app, wnd, { keysym: XK_z, buttons: CTRL });
+  assert.deepStrictEqual(
+    changes,
+    ['h', 'hi', ''],
+    'undo asks for the old value',
+  );
+  assert.strictEqual(input.value, '', 'and the display follows the prop back');
+
+  pressKey(app, wnd, { keysym: XK_z, buttons: CTRL | SHIFT });
+  assert.strictEqual(input.value, 'hi');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('textinput: a value changed from outside becomes its own undo step', async () => {
+  const app = createMockApp();
+  const render = (value) =>
+    ReactX11.render(
+      React.createElement(
+        'window',
+        { width: 300, height: 80 },
+        React.createElement('textinput', { value }),
+      ),
+      null,
+      app,
+    );
+  render('typed');
+  await tick();
+  const wnd = app.windows[0];
+  const input = wnd._reactX11Node.children[0];
+  wnd.emit('mousedown', { x: 5, y: 5, keycode: 1 });
+  wnd.emit('mouseup', { x: 5, y: 5, keycode: 1 });
+
+  render(''); // the form was reset behind the control's back
+  assert.strictEqual(input.canUndo, true);
+  assert.strictEqual(input.undo(), true, 'undo asks for the pre-reset value');
+  assert.strictEqual(input._historyValue, 'typed');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('textarea: undo restores across lines, Enter is its own step', async () => {
+  const app = createMockApp();
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 300, height: 200 },
+      React.createElement('textarea', { defaultValue: '', rows: 4 }),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const area = wnd._reactX11Node.children[0];
+  wnd.emit('mousedown', { x: 5, y: 5, keycode: 1 });
+  wnd.emit('mouseup', { x: 5, y: 5, keycode: 1 });
+
+  for (const cp of [0x61, 0x62])
+    pressKey(app, wnd, { keysym: cp, codepoint: cp });
+  pressKey(app, wnd, { keysym: XK.Return });
+  for (const cp of [0x63, 0x64])
+    pressKey(app, wnd, { keysym: cp, codepoint: cp });
+  assert.strictEqual(area.value, 'ab\ncd');
+
+  pressKey(app, wnd, { keysym: XK_z, buttons: CTRL });
+  assert.strictEqual(area.value, 'ab\n');
+  pressKey(app, wnd, { keysym: XK_z, buttons: CTRL });
+  assert.strictEqual(area.value, 'ab', 'the newline undoes on its own');
+  pressKey(app, wnd, { keysym: XK_z, buttons: CTRL });
+  assert.strictEqual(area.value, '');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
 test('textarea: PageDown/PageUp move by a viewport of lines', async () => {
   const app = createMockApp();
   ReactX11.render(

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -42,6 +42,7 @@ import type {
   ScrollViewNode,
   Style,
   StyleProp,
+  TextInputNode,
   WheelEvent,
 } from '../../src/index.js';
 
@@ -88,6 +89,7 @@ function Elements() {
   const boxRef = useRef<DrawnNode>(null);
   const scrollRef = useRef<ScrollViewNode>(null);
   const winRef = useRef<NtkWindow>(null);
+  const inputRef = useRef<TextInputNode>(null);
   const [text, setText] = useState('');
 
   return (
@@ -126,6 +128,7 @@ function Elements() {
       </scrollview>
 
       <textinput
+        ref={inputRef}
         value={text}
         onChange={setText}
         onSubmit={(value) => void value.length}
@@ -133,6 +136,11 @@ function Elements() {
         maxLength={40}
         focusable
         tabIndex={0}
+      />
+      <Button
+        label="Undo"
+        disabled={!inputRef.current?.canUndo}
+        onPress={() => void inputRef.current?.undo()}
       />
       <textarea rows={4} defaultValue="multi" />
       <image src="./logo.png" style={{ width: 32, height: 32 }} />


### PR DESCRIPTION
Ctrl+Z undoes, Ctrl+Shift+Z and Ctrl+Y redo, in both `<textinput>` and
`<textarea>` — they share an editing core, so it lands in one place. The
bindings run as element default actions, so `ev.preventDefault()` in your own
`onKeyDown` suppresses them the way it suppresses the rest of the editing
behaviour.

![undo and redo in a real textinput](https://github.com/user-attachments/assets/aced0b8d-0943-44bc-908f-5b5e49ed5c34)

Rendered by this branch's own code at 5ec8310: a real `<textinput>` in
node-x11's in-process X server, typed into and undone through the real event
pipeline, read back with `GetImage`.

## Granularity

This is the decision worth reviewing. One entry per keystroke is useless —
undoing a sentence becomes a held-down Ctrl+Z — so consecutive typing
coalesces into one entry, and a run of backspaces coalesces separately from
it. A run ends:

- **at whitespace**, so undo takes back a word at a time — the second frame
  above;
- **at anything that moves the caret** (arrows, Home/End, a click, blur),
  since editing that resumes elsewhere is a new edit;
- **around edits that are their own step** whatever surrounds them: a paste,
  a cut, a replaced selection, Ctrl+Backspace, a `<textarea>` newline.

Each entry also carries the caret from _before_ the edit that produced it,
which is what makes undo land where the edit happened rather than where the
run ended. Type `ab`, move to the middle, type `X`: undoing that `X` puts the
caret back in the middle, not at the end.

## Controlled inputs

Entries are whole-value snapshots rather than a diff log, capped at 200. A
single field is small, and a snapshot is the only representation that survives
the controlled case: a controlled `value` reports the restored text through
`onChange` and waits for the prop to come back, exactly as typing already
does — so a parent that filters or rejects values gets the same say over an
undo as it has over an edit.

A value that changes from outside, a form reset say, becomes its own entry and
undo steps back through it. The neighbour checks in `_noteExternalValue` are
what keep an `onChange` that rewrites every value it is given from growing the
stack on each keystroke.

## API

`undo()`, `redo()`, `canUndo` and `canRedo` on the node, so a toolbar button
beside the field is a ref away. Declarations and a line in the type test come
with it.

## One thing changing outside the feature

The Ctrl chord now matches on the **keysym** instead of the codepoint. ntk
derives `codepoint` from the _shifted_ keysym, so Ctrl+Shift+Z arrives as `Z`
while Ctrl+Z arrives as `z`, and the two would otherwise look like different
keys. Ctrl+Shift+A/C/X/V consequently now do what Ctrl+A/C/X/V do, where
before they did nothing — which is what X11 terminals do anyway.

## Tests

Eight cases in `test/smoke.test.js`: coalescing, word granularity, run breaks,
the redo tail dropping on a fresh edit, paste as its own step, controlled mode
round-tripping through `onChange`, a value changed from outside, and a
`<textarea>` undoing across lines. `npm test`, `npm run lint` and
`npm run typecheck` are green.

No rendering, layout or painting code is touched.
