### PR TITLE
docs: the wrong fc-match on macOS silently picks a CJK font

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,6 +283,15 @@ the diff records the cost.
   `yoga.markDirty()`. The mock app in smoke tests has no `fonts`, so text
   measures 0×0 headlessly — pixel-level text assertions live in the
   integration test (StaticFontSource + KaTeX's bundled font, no fontconfig).
+- **Font family resolution shells out to `fc-match`**, so it follows `PATH`.
+  On macOS that usually finds Homebrew's fontconfig before XQuartz's, and
+  Homebrew's ships no macOS system-font aliases: `sans-serif` resolves to
+  Hiragino Sans, whose Cyrillic sits on full-width advances while its Latin
+  stays proportional — so the wrong font is easy to miss until someone types
+  a non-Latin script. Put `/opt/X11/bin` first on `PATH`. This is also why
+  `scripts/screenshots.jsx` names Arial / Liberation / DejaVu explicitly
+  instead of asking for `sans-serif`. Nothing in the source works around it
+  yet — issue #86.
 - Painting is a full-window repaint scheduled through
   `window.requestAnimationFrame` (ntk frame clock: coalescing + server
   fence). Presentation/damage is ntk's job; dirty-rect painting is a future

--- a/examples/README.md
+++ b/examples/README.md
@@ -46,6 +46,24 @@ by default nearly everywhere. Xorg takes `+iglx` on the command line or
 defaults write org.xquartz.X11 enable_iglx -bool true   # then restart XQuartz
 ```
 
+### Fonts on macOS
+
+If the demos come up in what looks like a Japanese system font — and Cyrillic
+in particular renders spread out, one full-width advance per letter, while
+Latin looks fine — the wrong `fc-match` is first on your `PATH`. ntk resolves
+font families by shelling out to it, and Homebrew's fontconfig ships no macOS
+system-font aliases, so its idea of `sans-serif` is close to arbitrary: it
+answers Hiragino Sans, with Comic Sans as the runner-up. XQuartz's fontconfig
+is the one whose configuration matches the server you are drawing to.
+
+```sh
+PATH=/opt/X11/bin:$PATH npm run examples:theming
+```
+
+`fc-match sans-serif` from each of them shows the difference. Tracked in
+[#86](https://github.com/sidorares/react-x11/issues/86) — nothing in the
+source works around it yet.
+
 ## Hot reloading
 
 ```sh


### PR DESCRIPTION
Documentation only — no source change, per #86 staying open until we do something about font resolution properly.

ntk resolves font families by shelling out to `fc-match`, so it follows `PATH`. On macOS that usually finds Homebrew's fontconfig before XQuartz's, and Homebrew's ships no macOS system-font aliases:

| fc-match | first four for `sans-serif` |
| --- | --- |
| `/opt/homebrew/bin` | HiraginoSans-W4, **Comic Sans MS**, Microsoft Sans Serif, Noto Sans Mongolian |
| `/opt/X11/bin` | Verdana, Arial, Helvetica, Helvetica-Light |

Hiragino draws Cyrillic on full-width advances while its Latin stays proportional, so nothing looks wrong until someone types a non-Latin script — and then it reads as a letter-spacing bug rather than as the wrong font being used for everything. Confirmed on XQuartz 2.8.6: cyr/latin advance ratio 1.37 with Homebrew's, 1.00 with XQuartz's.

Two places, because two audiences:

- **AGENTS.md** — beside the existing text-measurement gotcha, for anyone working on the text stack. Notes that this is also why `scripts/screenshots.jsx` names Arial / Liberation / DejaVu explicitly rather than asking for `sans-serif`.
- **examples/README.md** — beside the other macOS notes, since running a demo is when it actually bites.

No screenshots: nothing rendered changes.