### PR TITLE
docs: bring the roadmap and AGENTS pointers back in line with the tree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -343,9 +343,19 @@ overlay (`REACT_X11_DEBUG_LAYOUT=1`). Element default actions (textinput
 editing, scrollview wheel) run via `_default*` hooks on nodes AFTER user
 prop handlers, skipped on `preventDefault()`. The window-manager example
 (issue #3) is done — on ntk 3.9.0 and node-x11 3.2.0, which grew the
-substructure-redirect support it needed. Next: `<select>`/menus as
-components, DevTools highlight-on-hover, npm publish. Open GitHub issues:
-#4 top-down rendering, #13 react-native-dom-like architecture.
+substructure-redirect support it needed. Also done since: the widget set
+including `Select`, `Menu`/`MenuBar`/`ContextMenu`, `Tabs`, `Tree`,
+`SplitPane` and a virtualized `Table`; DevTools highlight-on-hover (the
+DOM-ish host-instance contract, `getClientRects` + `ownerDocument`);
+TypeScript declarations; and undo/redo in `<textinput>`/`<textarea>`.
+`react-x11` is published on npm, with release-please keeping a release PR
+open for the next version.
+
+Next: a right-click menu for the text controls, a generic Popover, a file
+open/save dialog. Open GitHub issues: **#85** keyboard layout switching is
+ignored (non-Latin layouts always type Latin), **#86** `sans-serif`
+resolves to a CJK font on macOS, **#88** no right-click menu in the text
+controls — and right-click collapses the selection.
 
 ## Pull requests
 

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -93,9 +93,13 @@ merged theme (`ThemeProvider`; `SelectThemeProvider` is an alias) and a
   resizable, clamped against the live container size). `examples/app.jsx`
   hosts `form`, `widgets` and `tasks` as tabs by importing the panel each
   now exports — new controls get demonstrated there rather than in yet
-  another example. Still missing, roughly in order: Table with
-  virtualization, undo/redo in the text controls, a generic Popover, and a
-  file open/save dialog
+  another example. Table with virtualization is DONE (built on
+  `onViewport`), and undo/redo in the text controls is DONE (#84:
+  coalescing runs, snapshot history, `undo()`/`redo()`/`canUndo`/`canRedo`
+  on the node). Still missing, roughly in order: a **right-click menu for
+  the text controls** (issue #88 — and right-click currently collapses the
+  selection, which is a bug on its own), a generic Popover, and a file
+  open/save dialog
 - **Horizontal scrolling — DONE.** `<scrollview>` scrolls on both axes:
   `scrollX`/`contentWidth`, a second draggable bar, `scrollTo({x, y})`,
   horizontal wheel and Shift+wheel, and `scrollIntoView` on both axes. The
@@ -143,7 +147,12 @@ merged theme (`ThemeProvider`; `SelectThemeProvider` is an alias) and a
   WM_DELETE_WINDOW and dispatches at discrete priority (unmount/hide/quit
   is the handler's choice); see examples/windows.jsx
 - **Keyboard**: AltGr/compose/IME not handled (ntk TODO), key repeat is
-  server-side (works), keymap beyond index 0/1 unhandled
+  server-side (works), keymap beyond index 0/1 unhandled — that last one is
+  **issue #85**, and it costs more than it looks: index 0/1 is group 1, so
+  a non-Latin layout can never be typed. Linux carries the active group in
+  bits 13–14 of the event state; XQuartz has no groups at all and rewrites
+  the keymap instead, so both mechanisms are needed. No `onContextMenu`
+  either (#88)
 
 ### 3a. Styling — DONE
 
@@ -164,17 +173,18 @@ already required. See [docs/styling.md](docs/styling.md).
 
 ### 4. Ecosystem / DX
 
-- npm publish (merge release-please #17 → 1.0.0, then examples via
-  `npx`?), CHANGELOG is automated
+- npm publish — DONE, `react-x11` is on npm (1.2.0 latest) and CHANGELOG is
+  automated; release-please keeps a release PR open for the next version.
+  Still open: running the examples via `npx`?
 - README screenshots are now committed under `docs/img/` and regenerated
   by script (see AGENTS.md Pull requests section for the rule: PR-only
   images go to GitHub attachments, committed images only when globally
   useful — README qualifies)
 - API docs live in `docs/` (elements/components/events/devtools)
-- window-manager example (#3) — SubstructureRedirect is plumbed in ntk
-  (`child-event`); would exercise `<foreign>`-style window wrapping
+- window-manager example (#3) — DONE, `examples/wm.jsx` + `examples/wm-core.js`
+  on ntk 3.9.0 / node-x11 3.2.0, with `test/wm.test.js` driving it headlessly
 - react-native-dom-like packaging (#13) and mylittledom reuse (#10) are
-  superseded by the native architecture; consider closing those issues
+  superseded by the native architecture — both closed, along with #4
 
 Goal: **react-like ergonomics on top of ntk** — good enough to develop and debug
 real GUI apps. This document records the current state, what we learned from


### PR DESCRIPTION
Follow-up to #87. Docs only — no source, examples or tests change.

Both files were still describing work that has since shipped, which makes them actively misleading given AGENTS.md points at NEXT_STEPS as the source of truth for what's next.

**AGENTS.md** named `<select>`/menus, DevTools highlight-on-hover and npm publish as what comes next. All three are done — `Select.js`/`Menu.js` ship, the DOM-ish host-instance contract for highlighting landed in #25 (`getClientRects` + `ownerDocument` are in `nodes.js` today), and `react-x11` is on npm at 1.2.0. It also listed #4 and #13 as the open issues; both are closed. Open now: #85, #86, #88.

**NEXT_STEPS §2** listed Table virtualization and undo/redo in the text controls as still missing. Table is built on `onViewport`, and undo/redo landed in #84. Remaining: the right-click menu (#88), a generic Popover, a file open/save dialog.

**NEXT_STEPS §3** — "keymap beyond index 0/1 unhandled" turns out to be exactly #85, so it now records what that costs (index 0/1 is group 1, so a non-Latin layout can never be typed) and why Linux and XQuartz need different mechanisms.

**NEXT_STEPS §4** — npm publish and the window-manager example are done; the issues it suggested closing (#10, #13) are closed.

### Audit that produced this

- Open issues before: none stale. #85, #86 and #88 are all real, unimplemented gaps — nothing to close.
- Open PRs: this one, #87, and #69 (release-please, ready to cut 2.0.0 — undo/redo is in master and unreleased).
- #86 got a comment recording that the `PATH` workaround is confirmed working; #85 got one cross-referencing the roadmap line and naming the one test that still needs a human at the keyboard.