### PR TITLE
feat: a right-click edit menu for <textinput> and <textarea>

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -279,9 +279,25 @@ Interactions: click/drag selection, double-click word select, triple-click
 select all, Backspace/Delete, arrows (+Shift extends), Home/End, Ctrl+A,
 Ctrl+C/X/V on CLIPBOARD, middle-click paste from PRIMARY, selections own
 PRIMARY (X11 conventions), **Ctrl+Z / Ctrl+Shift+Z** (Ctrl+Y too) to undo
-and redo. Focusable by default; shows the text cursor.
-`ev.preventDefault()` in your `onKeyDown`/`onMouseDown` suppresses the
-built-in editing behavior.
+and redo, and a **right-click menu**. Focusable by default; shows the text
+cursor. `ev.preventDefault()` in your `onKeyDown`/`onMouseDown` suppresses
+the built-in editing behavior.
+
+### The right-click menu
+
+Right-clicking gives Undo / Redo / Cut / Copy / Paste / Select All with no
+wiring, the way a browser gives `<input>` one — each row live only when it
+would do something, and every row running the same code the keyboard
+shortcut does. Right-clicking **inside** a selection keeps it (the menu is
+about to act on it); outside one, the caret moves there first.
+
+Arrows walk the rows, skipping the disabled ones, Enter chooses, Escape or
+a press anywhere outside closes. The selection stays visibly highlighted
+while the menu is up, even though the popup holds the keyboard.
+
+To replace it with your own, set `contextMenu={false}` and render a
+`ContextMenu` — `onContextMenu` still fires. To suppress it for one event,
+call `ev.preventDefault()` in an `onContextMenu` handler.
 
 **Ref**: the node, plus `value`, `undo()` / `redo()` and `canUndo` /
 `canRedo` — enough for a toolbar button beside the field.

--- a/docs/events.md
+++ b/docs/events.md
@@ -45,6 +45,7 @@ props — they can never go stale.
 | `onMouseDown` / `onMouseUp` / `onMouseMove` | move is coalesced to once per frame by ntk                                            |
 | `onMouseEnter` / `onMouseLeave`             | do not propagate; synthesized by hover-path diffing                                   |
 | `onWheel`                                   | X buttons 4–7; default action scrolls the nearest `<scrollview>`                      |
+| `onContextMenu`                             | right-click (button 3), after `onMouseDown`; default action opens the element's menu  |
 | `onKeyDown` / `onKeyUp`                     | delivered to the focused node (or the window); Tab cycles focus in `tabIndex` order   |
 | `onFocus` / `onBlur`                        | focus follows mousedown (nearest `focusable` ancestor) and Tab traversal              |
 

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -488,8 +488,14 @@ export function ContextMenu({
       ref,
       focusable: true,
       onMouseDown: (ev) => {
-        if (ev.button === 3) openAt(ev);
-        else if (rect) close();
+        if (ev.button !== 3 && rect) close();
+      },
+      onContextMenu: (ev) => {
+        // this menu replaces whatever the element under the pointer would
+        // have opened on its own — without the preventDefault a
+        // <textinput> in here would show its edit menu underneath ours
+        ev.preventDefault();
+        openAt(ev);
       },
       onKeyDown: (ev) => {
         if (!rect) return;

--- a/src/editmenu.js
+++ b/src/editmenu.js
@@ -1,0 +1,185 @@
+/**
+ * The built-in edit menu for `<textinput>` / `<textarea>` — geometry and
+ * painting.
+ *
+ * A browser gives `<input>` a context menu without being asked, and that is
+ * the bar here: a bare `<textinput>` gets Undo/Cut/Copy/Paste with no
+ * wiring at all. That rules out building it from the `Menu` components,
+ * which live a layer above the nodes and cannot be mounted from one — so
+ * the rows are measured and drawn here, and the node hangs them in a
+ * `<popup>` (see `TextInputNode._openEditMenu`).
+ *
+ * Deliberately free of node imports: this takes plain data, a measuring
+ * function and a 2d context. It can be tested without a tree, and falls
+ * back to fixed metrics when there are no fonts, which is how the headless
+ * tests see it.
+ */
+
+const ROW_HEIGHT = 22;
+const SEPARATOR_HEIGHT = 7;
+const PAD_X = 10;
+const PAD_Y = 4;
+const SHORTCUT_GAP = 28;
+const MIN_WIDTH = 150;
+// headless (no fonts): enough to keep the rows a plausible size
+const FALLBACK_CHAR_WIDTH = 7;
+
+/** Matches the widget palette's defaults, so the built-in menu and a
+ * `ContextMenu` next to it do not look like different toolkits. */
+export const EDIT_MENU_COLORS = {
+  background: 'white',
+  border: '#b2bec3',
+  text: '#2d3436',
+  dim: '#7f8c8d',
+  highlight: '#2980b9',
+  highlightText: 'white',
+  separator: '#dfe6e9',
+};
+
+/** Palette for a node: its theme where it has one, defaults otherwise. */
+export function editMenuColors(theme) {
+  if (!theme) return EDIT_MENU_COLORS;
+  return {
+    background: theme.background ?? EDIT_MENU_COLORS.background,
+    border: theme.border ?? EDIT_MENU_COLORS.border,
+    text: theme.text ?? EDIT_MENU_COLORS.text,
+    dim: theme.dim ?? EDIT_MENU_COLORS.dim,
+    highlight: theme.hoverBackground ?? EDIT_MENU_COLORS.highlight,
+    highlightText: theme.hoverText ?? EDIT_MENU_COLORS.highlightText,
+    separator: theme.track ?? EDIT_MENU_COLORS.separator,
+  };
+}
+
+/**
+ * Lay the rows out and size the popup that holds them.
+ *
+ * @param {Array<{id?, label?, shortcut?, separator?, enabled?}>} items
+ * @param {(text: string) => number|null} [measure] text width, or null when
+ *   nothing can be measured yet
+ */
+export function editMenuGeometry(items, measure) {
+  const widthOf = (text) => {
+    if (!text) return 0;
+    const w = measure?.(text);
+    return typeof w === 'number' && w > 0
+      ? w
+      : text.length * FALLBACK_CHAR_WIDTH;
+  };
+  const rows = [];
+  let y = PAD_Y;
+  let widest = 0;
+  for (const item of items) {
+    const height = item.separator ? SEPARATOR_HEIGHT : ROW_HEIGHT;
+    rows.push({ ...item, y, height });
+    y += height;
+    if (item.separator) continue;
+    widest = Math.max(
+      widest,
+      widthOf(item.label) +
+        (item.shortcut ? SHORTCUT_GAP + widthOf(item.shortcut) : 0),
+    );
+  }
+  return {
+    rows,
+    width: Math.max(MIN_WIDTH, Math.ceil(widest + PAD_X * 2)),
+    height: Math.ceil(y + PAD_Y),
+  };
+}
+
+/** Row under a y coordinate, or -1. Separators and disabled rows are not
+ * hoverable — moving onto one clears the highlight rather than leaving a
+ * stale row lit. */
+export function editMenuIndexAt(geometry, y) {
+  for (let i = 0; i < geometry.rows.length; i++) {
+    const row = geometry.rows[i];
+    if (row.separator || row.enabled === false) continue;
+    if (y >= row.y && y < row.y + row.height) return i;
+  }
+  return -1;
+}
+
+/** The next selectable row in `dir`, wrapping, or -1 if there are none. */
+export function editMenuStep(geometry, from, dir) {
+  const rows = geometry.rows;
+  if (rows.length === 0) return -1;
+  let i = from < 0 ? (dir > 0 ? -1 : rows.length) : from;
+  for (let k = 0; k < rows.length; k++) {
+    i += dir;
+    if (i < 0) i = rows.length - 1;
+    if (i >= rows.length) i = 0;
+    const row = rows[i];
+    if (!row.separator && row.enabled !== false) return i;
+  }
+  return -1;
+}
+
+function panelPath(ctx, width, height, radius) {
+  ctx.beginPath();
+  if (radius > 0 && typeof ctx.roundRect === 'function') {
+    ctx.roundRect(0.5, 0.5, width - 1, height - 1, radius);
+  } else {
+    ctx.rect(0.5, 0.5, width - 1, height - 1);
+  }
+}
+
+/**
+ * @param {object} ctx ntk 2d context, translated to the popup's origin
+ * @param {object} opts
+ * @param {(text: string, color: string) => object|null} opts.layoutOf shaped
+ *   text, or null when there are no fonts — the rows still paint, unlabelled
+ */
+export function paintEditMenu(
+  ctx,
+  { geometry, active = -1, colors = EDIT_MENU_COLORS, layoutOf, radius = 4 },
+) {
+  const { width, height, rows } = geometry;
+
+  panelPath(ctx, width, height, radius);
+  ctx.fillStyle = colors.background;
+  ctx.fill();
+  ctx.strokeStyle = colors.border;
+  ctx.lineWidth = 1;
+  ctx.stroke();
+
+  const label = (text, color, x, row) => {
+    const layout = layoutOf?.(text, color);
+    if (!layout) return;
+    const line = layout.lines?.[0];
+    const ink = line ? line.ascent + line.descent : layout.height;
+    layout.draw(ctx, x, row.y + Math.max(0, (row.height - ink) / 2));
+  };
+
+  for (let i = 0; i < rows.length; i++) {
+    const row = rows[i];
+    if (row.separator) {
+      ctx.fillStyle = colors.separator;
+      ctx.fillRect(
+        PAD_X,
+        Math.round(row.y + row.height / 2) + 0.5,
+        width - PAD_X * 2,
+        1,
+      );
+      continue;
+    }
+    const disabled = row.enabled === false;
+    const on = i === active && !disabled;
+    if (on) {
+      ctx.fillStyle = colors.highlight;
+      ctx.fillRect(1, row.y, width - 2, row.height);
+    }
+    const color = disabled
+      ? colors.dim
+      : on
+        ? colors.highlightText
+        : colors.text;
+    label(row.label, color, PAD_X, row);
+    if (row.shortcut) {
+      // the shortcut column stays quieter than the label, except in the
+      // highlighted row where it has to stay legible on the accent
+      const shortcutColor = on ? colors.highlightText : colors.dim;
+      const layout = layoutOf?.(row.shortcut, shortcutColor);
+      const w = layout?.width ?? 0;
+      label(row.shortcut, shortcutColor, width - PAD_X - w, row);
+    }
+  }
+}

--- a/src/events.js
+++ b/src/events.js
@@ -10,6 +10,7 @@ import {
 
 const XK_TAB = 0xff09;
 const WHEEL_BUTTONS = { 4: [0, -48], 5: [0, 48], 6: [-48, 0], 7: [48, 0] };
+const RIGHT_BUTTON = 3;
 // X11 KeyButMask bit for Mod1 (Alt on virtually every layout), same bitmask
 // `shiftKey`/`ctrlKey` above already read `buttons` from.
 const MOD1_MASK = 8;
@@ -269,6 +270,18 @@ export class EventManager {
       });
       if (!ev.defaultPrevented) {
         target._defaultMouseDown?.(ev);
+      }
+      // Right-click is two events, as in the DOM: mousedown, then a
+      // separate contextmenu whose default action opens the element's own
+      // menu. Handlers that only want to suppress the menu can do it
+      // without also giving up the caret placement mousedown just did.
+      if (native.keycode === RIGHT_BUTTON) {
+        const menuEv = this.dispatch('ContextMenu', target, native, {
+          button: native.keycode,
+        });
+        if (!menuEv.defaultPrevented) {
+          target?._defaultContextMenu?.(menuEv);
+        }
       }
     });
   }

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -26,6 +26,13 @@ import {
 } from './styles.js';
 import { EventManager } from './events.js';
 import { runWithPriority, DiscreteEventPriority } from './priority.js';
+import {
+  editMenuColors,
+  editMenuGeometry,
+  editMenuIndexAt,
+  editMenuStep,
+  paintEditMenu,
+} from './editmenu.js';
 
 const DRAWN_KINDS = new Set([
   'box',
@@ -1418,6 +1425,7 @@ const XK_PAGE_UP = 0xff55;
 const XK_PAGE_DOWN = 0xff56;
 const XK_END = 0xff57;
 const XK_DELETE = 0xffff;
+const XK_ESCAPE = 0xff1b;
 
 /** Undo entries kept per input. Snapshots of a single field are small; the
  * cap is what stops a long-lived form from growing without bound. */
@@ -1466,6 +1474,8 @@ export class TextInputNode extends Node {
     this._historyIndex = 0;
     this._historyValue = this.value;
     this._undoRun = null;
+    // the open built-in edit menu, if any (see _openEditMenu)
+    this._editMenu = null;
     this.yoga.setMeasureFunc((width, widthMode) => {
       const preferred = 150;
       const w =
@@ -1885,6 +1895,22 @@ export class TextInputNode extends Node {
   _defaultMouseDown(ev) {
     // wherever the caret lands, editing resumes as a new undo entry
     this._breakUndoRun();
+    if (ev.button === 3) {
+      // A right-click is about to open a menu that acts on the selection,
+      // so it must not be the thing that throws the selection away: a click
+      // inside one keeps it, and only a click outside moves the caret. Both
+      // GTK and Qt behave this way, and it is why this cannot fall through
+      // to the caret placement below — that also started a drag nobody
+      // asked for.
+      const i = this._indexAtPoint(ev);
+      const [a, b] = this._selection();
+      if (i < a || i > b) {
+        this._caret = i;
+        this._anchor = i;
+        this._repaint();
+      }
+      return;
+    }
     if (ev.button === 2) {
       // X11 middle-click: paste the PRIMARY selection at the click position
       const i = this._indexAtPoint(ev);
@@ -1926,6 +1952,13 @@ export class TextInputNode extends Node {
     if (this._caret !== this._anchor) this._copySelection('PRIMARY');
   }
 
+  /** The selection stays lit while its own menu is up: the popup holds the
+   * keyboard, so `_focused` is false, but the text the menu is about to act
+   * on has to stay visibly selected. */
+  _showsSelection() {
+    return this._focused || Boolean(this._editMenu);
+  }
+
   _defaultMouseDrag(ev) {
     if (!this._dragging) return;
     this._caret = this._indexAtPoint(ev);
@@ -1936,6 +1969,192 @@ export class TextInputNode extends Node {
     if (!this._dragging) return;
     this._dragging = false;
     if (this._caret !== this._anchor) this._copySelection('PRIMARY');
+  }
+
+  // --- the built-in edit menu -----------------------------------------
+  //
+  // Right-click gets Undo/Cut/Copy/Paste with no wiring, the way a browser
+  // gives `<input>` one. The rows cannot be `Menu` components — those are
+  // React over the nodes, and a node cannot mount one — so the menu is a
+  // `<popup>` built here with a `<canvas>` child that paints the rows
+  // (src/editmenu.js) and handles its own pointer and key events. That
+  // reuses the popup's pointer grab, dismissal and focus rather than
+  // reinventing them. `contextMenu={false}` opts out, as does
+  // `preventDefault()` in an `onContextMenu` handler.
+
+  /** The rows, with each one enabled only when it would do something. */
+  _editMenuItems() {
+    const [a, b] = this._selection();
+    const hasSelection = a !== b;
+    const length = this._chars().length;
+    return [
+      { id: 'undo', label: 'Undo', shortcut: 'Ctrl+Z', enabled: this.canUndo },
+      {
+        id: 'redo',
+        label: 'Redo',
+        shortcut: 'Ctrl+Shift+Z',
+        enabled: this.canRedo,
+      },
+      { separator: true },
+      { id: 'cut', label: 'Cut', shortcut: 'Ctrl+X', enabled: hasSelection },
+      { id: 'copy', label: 'Copy', shortcut: 'Ctrl+C', enabled: hasSelection },
+      {
+        id: 'paste',
+        label: 'Paste',
+        shortcut: 'Ctrl+V',
+        // whether CLIPBOARD holds anything is an async round trip, so the
+        // row stays live whenever there is a clipboard to ask
+        enabled: Boolean(this._clipboardApi()),
+      },
+      { separator: true },
+      {
+        id: 'selectAll',
+        label: 'Select All',
+        shortcut: 'Ctrl+A',
+        enabled: length > 0 && !(a === 0 && b === length),
+      },
+    ];
+  }
+
+  /** Run a row. Everything here is the keyboard path's own entry point, so
+   * the menu can never drift from what the shortcuts do. */
+  _runEditAction(id) {
+    const [a, b] = this._selection();
+    if (id === 'undo') this.undo();
+    else if (id === 'redo') this.redo();
+    else if (id === 'copy') this._copySelection();
+    else if (id === 'cut') {
+      this._copySelection();
+      if (a !== b) this._deleteRange(a, b);
+    } else if (id === 'paste') this._pasteFrom();
+    else if (id === 'selectAll') {
+      this._anchor = 0;
+      this._caret = this._chars().length;
+      this._breakUndoRun();
+      this._repaint();
+    }
+  }
+
+  _defaultContextMenu(ev) {
+    if (this.props.contextMenu === false) return;
+    this._openEditMenu(ev);
+  }
+
+  /** Where the popup goes: at the pointer in root coordinates, pulled back
+   * inside the screen when it would hang off the right or bottom edge. */
+  _editMenuOrigin(ev, size) {
+    const owner = this.root;
+    const native = ev.nativeEvent;
+    let x = native?.rootx;
+    let y = native?.rooty;
+    if (x == null || y == null) {
+      // no native event (synthesized, or a test): fall back to the node's
+      // own position within its window plus wherever that window is
+      const origin = owner?.window?._screenOrigin ?? { x: 0, y: 0 };
+      x = origin.x + (ev.x ?? this.abs.x);
+      y = origin.y + (ev.y ?? this.abs.y);
+    }
+    const screen = this.app?.X?.display?.screen?.[0];
+    if (screen?.pixel_width) {
+      x = Math.max(0, Math.min(x, screen.pixel_width - size.width));
+      y = Math.max(0, Math.min(y, screen.pixel_height - size.height));
+    }
+    return { x, y };
+  }
+
+  _openEditMenu(ev) {
+    this._closeEditMenu();
+    const items = this._editMenuItems();
+    const geometry = editMenuGeometry(
+      items,
+      (text) => this._layoutOf(text)?.width,
+    );
+    const { x, y } = this._editMenuOrigin(ev, geometry);
+    const colors = editMenuColors(this.theme);
+    const style = this._textStyle();
+    const state = { active: -1 };
+
+    const canvas = new CanvasNode(
+      {
+        focusable: true,
+        style: { flexGrow: 1 },
+        onDraw: (ctx) =>
+          paintEditMenu(ctx, {
+            geometry,
+            active: state.active,
+            colors,
+            radius: this.theme?.radius ?? 4,
+            layoutOf: (text, color) =>
+              this.app?.fonts?.layout([{ text, ...style, color }], style),
+          }),
+        onMouseMove: (mv) => {
+          const next = editMenuIndexAt(geometry, mv.y);
+          if (next === state.active) return;
+          state.active = next;
+          popup.invalidate(false);
+        },
+        onMouseUp: (mv) => {
+          const i = editMenuIndexAt(geometry, mv.y);
+          if (i !== -1) this._chooseEditMenu(geometry.rows[i].id);
+          else this._closeEditMenu();
+        },
+        onKeyDown: (k) => {
+          if (k.keysym === XK_ESCAPE) return this._closeEditMenu();
+          if (k.keysym === XK_UP || k.keysym === XK_DOWN) {
+            state.active = editMenuStep(
+              geometry,
+              state.active,
+              k.keysym === XK_DOWN ? 1 : -1,
+            );
+            popup.invalidate(false);
+            return;
+          }
+          if (k.keysym === XK_RETURN || k.keysym === XK_KP_ENTER) {
+            const row = geometry.rows[state.active];
+            if (row && !row.separator) this._chooseEditMenu(row.id);
+          }
+        },
+      },
+      this.app,
+    );
+
+    const popup = new PopupNode(
+      this.app,
+      {
+        x,
+        y,
+        width: geometry.width,
+        height: geometry.height,
+        windowType: 'popup_menu',
+      },
+      {
+        grab: true,
+        // a press outside the menu closes it and goes no further, which is
+        // what the grab is for
+        onDismiss: () => this._closeEditMenu(),
+      },
+    );
+    popup.insertBefore(canvas, null);
+    this.insertBefore(popup, null);
+    popup.realize(null);
+    this._editMenu = popup;
+    // the menu takes the keyboard so arrows and Escape reach it rather than
+    // editing the text behind it
+    popup.events?.focus?.(canvas);
+  }
+
+  _chooseEditMenu(id) {
+    this._closeEditMenu();
+    if (id) this._runEditAction(id);
+  }
+
+  _closeEditMenu() {
+    const popup = this._editMenu;
+    if (!popup) return;
+    this._editMenu = null;
+    this.removeChild(popup);
+    // focus goes back to the field, so typing carries on where it left off
+    if (!this.destroyed) this.focus();
   }
 
   _defaultFocus() {
@@ -1962,6 +2181,9 @@ export class TextInputNode extends Node {
   destroySubtree() {
     clearInterval(this._blinkTimer);
     this._blinkTimer = null;
+    // the popup is a child, so the walk below destroys it — just drop the
+    // handle so a later close does not try to remove it twice
+    this._editMenu = null;
     super.destroySubtree();
   }
 
@@ -2034,7 +2256,7 @@ export class TextInputNode extends Node {
     const originX = content.x - this._scrollX;
 
     const [a, b] = this._selection();
-    if (this._focused && a !== b && !isEmpty) {
+    if (this._showsSelection() && a !== b && !isEmpty) {
       const selStart = this._prefixWidth(a);
       const selEnd = this._prefixWidth(b);
       ctx.fillStyle = this.props.selectionColor ?? '#b3d4fc';
@@ -2303,7 +2525,7 @@ export class TextAreaNode extends TextInputNode {
     const originY = content.y - this._scrollY;
 
     const [a, b] = this._selection();
-    if (this._focused && a !== b && !isEmpty) {
+    if (this._showsSelection() && a !== b && !isEmpty) {
       const posA = layout.caretPosition(a);
       const posB = layout.caretPosition(b);
       ctx.fillStyle = this.props.selectionColor ?? '#b3d4fc';

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -151,6 +151,12 @@ export interface TextInputProps extends DrawnProps<TextInputNode> {
   maxLength?: number;
   selectionColor?: Color;
   caretColor?: Color;
+  /**
+   * `false` turns off the built-in right-click edit menu (Undo/Redo, Cut,
+   * Copy, Paste, Select All). `onContextMenu` still fires, so this is how
+   * you replace it with your own rather than suppressing it per-event.
+   */
+  contextMenu?: false;
 }
 
 export interface TextAreaProps extends TextInputProps {

--- a/src/types/events.d.ts
+++ b/src/types/events.d.ts
@@ -111,6 +111,14 @@ export interface PointerHandlers<T = DrawnNode> {
   onMouseLeave?: (ev: MouseEvent<T>) => void;
   onWheel?: (ev: WheelEvent<T>) => void;
   onWheelCapture?: (ev: WheelEvent<T>) => void;
+  /**
+   * Right-click (button 3), dispatched after `onMouseDown` — so suppressing
+   * the menu does not also give up whatever mousedown did. `preventDefault()`
+   * skips the element's own menu, which today means the edit menu on
+   * `<textinput>` and `<textarea>`.
+   */
+  onContextMenu?: (ev: MouseEvent<T>) => void;
+  onContextMenuCapture?: (ev: MouseEvent<T>) => void;
 }
 
 export interface KeyboardHandlers<T = DrawnNode> {

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -3744,6 +3744,273 @@ test('textarea: undo restores across lines, Enter is its own step', async () => 
   ReactX11.unmountComponentAtNode(app);
 });
 
+// --- right-click / the built-in edit menu ----------------------------------
+
+// A focused <textinput> with everything selected, plus a working clipboard.
+async function mountSelected(props = {}) {
+  const app = createMockApp();
+  const writes = [];
+  app.clipboard = {
+    write(text, opts) {
+      writes.push([text, opts?.selection ?? 'CLIPBOARD']);
+      return Promise.resolve();
+    },
+    read: () => Promise.resolve('pasted'),
+  };
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 300, height: 80 },
+      React.createElement('textinput', {
+        defaultValue: 'hello world',
+        ...props,
+      }),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const input = wnd._reactX11Node.children[0];
+  wnd.emit('mousedown', { x: 5, y: 5, keycode: 1 });
+  wnd.emit('mouseup', { x: 5, y: 5, keycode: 1 });
+  pressKey(app, wnd, { keysym: 0x61, codepoint: 0x61, buttons: CTRL }); // ctrl+a
+  return { app, wnd, input, writes };
+}
+
+const rightClick = (wnd, x = 40, y = 10) =>
+  wnd.emit('mousedown', { x, y, keycode: 3 });
+
+test('textinput: right-click keeps the selection it lands inside', async () => {
+  const { app, wnd, input } = await mountSelected();
+  assert.deepStrictEqual(input._selection(), [0, 11]);
+
+  rightClick(wnd);
+  assert.deepStrictEqual(
+    input._selection(),
+    [0, 11],
+    'the menu is about to act on it — it must survive the click',
+  );
+  assert.strictEqual(input._dragging, false, 'and no drag was started');
+  assert.strictEqual(
+    input._showsSelection(),
+    true,
+    'still painted while the menu holds the keyboard',
+  );
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('textinput: right-click outside the selection moves the caret', async () => {
+  const { app, wnd, input } = await mountSelected();
+  input._indexAtPoint = () => 3; // stub: headless text measures 0x0
+  input._caret = 6;
+  input._anchor = 8; // a selection of [6, 8] — the click at 3 is outside it
+
+  rightClick(wnd);
+  assert.deepStrictEqual(input._selection(), [3, 3], 'caret follows the click');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('textinput: right-click opens a menu whose rows match the state', async () => {
+  const { app, wnd, input } = await mountSelected();
+  const before = app.windows.length;
+
+  rightClick(wnd);
+  assert.ok(input._editMenu, 'a popup is open');
+  assert.strictEqual(app.windows.length, before + 1, 'and it is a real window');
+
+  const rows = Object.fromEntries(
+    input
+      ._editMenuItems()
+      .filter((i) => !i.separator)
+      .map((i) => [i.id, i.enabled]),
+  );
+  assert.deepStrictEqual(rows, {
+    undo: false, // nothing has been edited yet
+    redo: false,
+    cut: true, // there is a selection
+    copy: true,
+    paste: true, // there is a clipboard to ask
+    selectAll: false, // everything is already selected
+  });
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('textinput: choosing Copy closes the menu and copies', async () => {
+  const { app, wnd, input, writes } = await mountSelected();
+  rightClick(wnd);
+
+  input._chooseEditMenu('copy');
+  assert.strictEqual(input._editMenu, null, 'the menu closes');
+  assert.deepStrictEqual(writes.at(-1), ['hello world', 'CLIPBOARD']);
+  assert.deepStrictEqual(input._selection(), [0, 11], 'selection survives');
+  assert.strictEqual(input._focused, true, 'focus comes back to the field');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('textinput: Cut through the menu is one undoable step', async () => {
+  const { app, wnd, input } = await mountSelected();
+  rightClick(wnd);
+  input._chooseEditMenu('cut');
+
+  assert.strictEqual(input.value, '');
+  assert.strictEqual(input.canUndo, true);
+  input.undo();
+  assert.strictEqual(input.value, 'hello world', 'one undo brings it back');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('textinput: Escape closes the menu, leaving the text alone', async () => {
+  const { app, wnd, input } = await mountSelected();
+  rightClick(wnd);
+  const popup = input._editMenu;
+  const canvas = popup.children[0];
+
+  canvas.props.onKeyDown({ keysym: 0xff1b }); // Escape
+  assert.strictEqual(input._editMenu, null);
+  assert.strictEqual(input.value, 'hello world');
+  assert.strictEqual(input._focused, true);
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('textinput: arrows walk the menu, skipping disabled rows', async () => {
+  const { app, wnd, input } = await mountSelected();
+  rightClick(wnd);
+  const canvas = input._editMenu.children[0];
+  const items = input._editMenuItems();
+
+  // Undo and Redo are disabled and Select All is too, so Down from nothing
+  // lands on Cut — the first row that would actually do something
+  canvas.props.onKeyDown({ keysym: 0xff54 }); // Down
+  canvas.props.onKeyDown({ keysym: 0xff0d }); // Enter
+  assert.strictEqual(input._editMenu, null, 'Enter chose a row and closed');
+  assert.strictEqual(input.value, '', 'and the row it chose was Cut');
+  assert.strictEqual(items[3].id, 'cut');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('textinput: onContextMenu fires, and preventDefault suppresses the menu', async () => {
+  const seen = [];
+  const { app, wnd, input } = await mountSelected({
+    onContextMenu: (ev) => {
+      seen.push(ev.button);
+      ev.preventDefault();
+    },
+  });
+
+  rightClick(wnd);
+  assert.deepStrictEqual(seen, [3], 'the handler ran');
+  assert.strictEqual(
+    input._editMenu,
+    null,
+    'and the built-in menu stayed shut',
+  );
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('textinput: contextMenu={false} opts out of the built-in menu', async () => {
+  const { app, wnd, input } = await mountSelected({ contextMenu: false });
+  rightClick(wnd);
+  assert.strictEqual(input._editMenu, null);
+  assert.deepStrictEqual(
+    input._selection(),
+    [0, 11],
+    'opting out still must not eat the selection',
+  );
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('textinput: a press outside dismisses the menu', async () => {
+  const { app, wnd, input } = await mountSelected();
+  rightClick(wnd);
+  const popup = input._editMenu;
+
+  popup.props.onDismiss({});
+  assert.strictEqual(input._editMenu, null);
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('ContextMenu around a textinput replaces the built-in menu', async () => {
+  const { ContextMenu } = await import('../src/index.js');
+  const findKind = (node, kind) =>
+    node.kind === kind
+      ? node
+      : node.children.reduce((f, c) => f ?? findKind(c, kind), null);
+  const app = createMockApp();
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 300, height: 120 },
+      React.createElement(
+        ContextMenu,
+        {
+          items: [{ id: 'app', label: 'App action' }],
+          style: { flexGrow: 1 },
+        },
+        React.createElement('textinput', { defaultValue: 'hello' }),
+      ),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const input = findKind(wnd._reactX11Node, 'textinput');
+  const before = app.windows.length;
+
+  // land the press on the textinput itself, so both menus are in play
+  wnd.emit('mousedown', { x: 20, y: 8, keycode: 3, rootx: 300, rooty: 200 });
+  await tick();
+
+  assert.strictEqual(
+    input._editMenu,
+    null,
+    'the built-in menu defers to the one wrapped around it',
+  );
+  assert.strictEqual(
+    app.windows.length,
+    before + 1,
+    'exactly one popup, not two stacked on each other',
+  );
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('textarea: right-click gets the same menu', async () => {
+  const app = createMockApp();
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 300, height: 200 },
+      React.createElement('textarea', { defaultValue: 'a\nb', rows: 3 }),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const area = wnd._reactX11Node.children[0];
+  wnd.emit('mousedown', { x: 5, y: 5, keycode: 1 });
+  wnd.emit('mouseup', { x: 5, y: 5, keycode: 1 });
+
+  rightClick(wnd, 20, 20);
+  assert.ok(area._editMenu, 'the editing core is shared, so the menu is too');
+  area._chooseEditMenu('selectAll');
+  assert.deepStrictEqual(area._selection(), [0, 3]);
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
 test('textarea: PageDown/PageUp move by a viewport of lines', async () => {
   const app = createMockApp();
   ReactX11.render(

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -142,6 +142,12 @@ function Elements() {
         disabled={!inputRef.current?.canUndo}
         onPress={() => void inputRef.current?.undo()}
       />
+      <textinput
+        contextMenu={false}
+        onContextMenu={(ev: MouseEvent<TextInputNode>) => {
+          if (ev.button === 3) ev.preventDefault();
+        }}
+      />
       <textarea rows={4} defaultValue="multi" />
       <image src="./logo.png" style={{ width: 32, height: 32 }} />
       <canvas


### PR DESCRIPTION
Closes #88. Right-clicking a text control now gives Undo / Redo / Cut / Copy / Paste / Select All with no wiring at all, the way a browser gives `<input>` one.

![the built-in edit menu on a real textinput](https://github.com/user-attachments/assets/0dd790e0-cccf-48f3-afe5-3a0bf7dabe6d)

Rendered by this branch at 5bd00bf: a real `<textinput>` in node-x11's in-process X server, selected and right-clicked through the real event pipeline, popup composited over its window. Note what the picture is actually showing — Undo/Redo greyed because nothing has been edited yet, Select All greyed because everything already is, and the selection still lit behind the menu.

## The bug came first

It made the feature impossible rather than merely missing. Button 3 fell through to the caret-placement path, so a right-click **collapsed the selection** and started a drag nobody began:

```
selection before right-click : [ 0, 11 ]  "hello world"
selection after  right-click : [ 11, 11 ] ""
_dragging                    : true
```

Select, right-click, Copy — the one thing anyone opens this menu for — could not have worked even once a menu existed. A press **inside** a selection now keeps it; only a press outside moves the caret, which is what GTK and Qt both do.

The selection also stays visibly highlighted while the menu is up. The popup holds the keyboard so `_focused` is false, but the text the menu is about to act on has to keep looking selected.

## onContextMenu

A real synthetic event now, dispatched **after** MouseDown rather than instead of it — suppressing the menu should not also cost you the caret placement mousedown just did. It fires for every drawn element, so a right-click on a `<box>` is finally handleable too.

## Why it is not built from `Menu`

Those are React over the nodes, and a node cannot mount one — which is the whole difficulty in "works out of the box". So the menu is a `<popup>` holding a `<canvas>` that paints the rows: that buys the popup's pointer grab, dismissal and focus handling rather than reinventing them. Geometry and painting live in `src/editmenu.js`, free of node imports so they can be measured and drawn without a tree, and falling back to fixed metrics where there are no fonts — which is how the headless tests see it.

Every row runs the same code path as its keyboard shortcut, so the menu cannot drift from what Ctrl+C does.

## Composition

`ContextMenu` now opens on `onContextMenu` and calls `preventDefault()`, so wrapping a `<textinput>` in one **replaces** the built-in menu instead of stacking a second popup on it. There is a test for exactly that. Opt-outs:

| | |
| --- | --- |
| `contextMenu={false}` | permanently, per element |
| `ev.preventDefault()` in `onContextMenu` | per event |

## Tests

Twelve, covering the selection rule both ways, the rows and their enablement, each action, Escape, arrow navigation skipping disabled rows, dismissal, both opt-outs, `<textarea>`, and the composition case. 225 pass; lint and typecheck green. Types and `test/types/api.tsx` moved with the props, per AGENTS.md.
