### PR TITLE
chore: x11 3.2.2, for a RENDER compositor that is ~10x faster

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6085,9 +6085,9 @@
       }
     },
     "node_modules/x11": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/x11/-/x11-3.2.1.tgz",
-      "integrity": "sha512-CMI01cF9v0KBwj8HVnGQK/Pfs/j3pNbj6YcCqtFOBtRbVk/U2iB94VRQbt9toxEsebmwRD49RWuk2g+gQF0khQ==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/x11/-/x11-3.2.2.tgz",
+      "integrity": "sha512-ubw7st7po3n9oSCRcdlwm9tD48hxNbIwzxgodzFUGOkO5L2/HbN3ejGBCWBopFXjid+0oJHoF6MGIew/goBDNQ==",
       "engines": {
         "node": ">=18"
       }


### PR DESCRIPTION
Picks up [node-x11 3.2.2](https://github.com/sidorares/node-x11/releases/tag/v3.2.2), which is where the playground's frame time actually lives.

3.2.2 specialises the composite spans a toolkit emits rather than running everything through the general per-pixel loop: constant-source fills, untransformed blits, a8 coverage, and paint through an a8 mask. That moves the share of composited pixels on a fast path from ~40% to 98.6%.

The one non-obvious part is why it was 40% and not higher: ntk expresses flat paint as a **1x1 pixmap with repeat**, not through `CreateSolidFill`, so every masked composite in a react-x11 repaint was missing the constant-source path over that single detail.

### What it does for the site

Measured on the `tasks` demo through the playground bundle, per pointer move:

| | ms/move |
|---|---:|
| x11 3.2.1 | ~29.5 |
| x11 3.2.2 | **1.8 – 4.6** |

The spread is run-to-run, not load-dependent — the profile is now over a third idle, waiting on the frame clock, so the compositor has stopped being what sets the pace.

### Scope

Lockfile only. x11 stays a transitive dependency through ntk's `^3.2.x`; nothing in `src/` imports it directly, only the demo bundler reaches into the package.

### Checks

- `npm test` — 225 pass
- `npm --prefix website test` — bundle, all 10 demos, and share links green

🤖 Generated with [Claude Code](https://claude.com/claude-code)