### PR TITLE
fix: row gaps in the feature grid, and bun as a JSX runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -392,6 +392,23 @@ the diff records the cost.
   resized the window).
 - Windows cannot be nested inside `<box>` (throws); raw strings are only
   legal inside `<text>` (throws otherwise).
+- **Bun honours `tsconfig.json`'s `compilerOptions.paths` at runtime**, and
+  ours maps `react-x11` at the declarations for the type tests. So inside
+  this repo `bun` resolves the bare specifier to `src/index.d.ts` and dies
+  on `The constant "Renderer" must be initialized`; Node ignores `paths` and
+  resolves `src/index.js`. The examples import `../src/index.js` relatively,
+  so they run fine under `bun` — but a script here that uses the package
+  name will not. Outside the repo (a normal install) there is no such
+  mapping and `bun hello.jsx` just works, which is what
+  `website/docs/getting-started.md` documents.
+- `bun --hot` cannot drive Fast Refresh for this renderer: `import.meta.hot`
+  is `undefined` in the CLI runtime (that API is the bundler's), so no accept
+  boundary can be declared, and a reload re-instantiates every module —
+  `react` included. The mounted reconciler then holds a different React than
+  the reloaded components call and the first hook throws
+  `resolveDispatcher(...) is null`. Hot reloading stays on
+  `examples/hmr-register.mjs`, which deliberately keeps `node_modules` and
+  `src/` out of the hot graph for exactly this reason.
 
 ## Style
 

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -66,7 +66,7 @@ is nothing to add:
 bun hello.jsx
 ```
 
-Under Node, [`tsx`](https://tsx.is/) is the shortest route:
+Under Node, [`tsx`](https://tsx.hirok.io/) is the shortest route:
 
 ```bash
 npx tsx hello.jsx

--- a/website/docs/getting-started.md
+++ b/website/docs/getting-started.md
@@ -59,7 +59,14 @@ const root = await createRoot();
 root.render(<App />);
 ```
 
-JSX needs a loader — [`tsx`](https://tsx.is/) is the shortest route:
+JSX needs a loader. [Bun](https://bun.com/) transforms it natively, so there
+is nothing to add:
+
+```bash
+bun hello.jsx
+```
+
+Under Node, [`tsx`](https://tsx.is/) is the shortest route:
 
 ```bash
 npx tsx hello.jsx
@@ -134,6 +141,15 @@ at module top level (those bindings become `let`s initialised in a
 microtask — use the default import, `React.createContext`), and identity
 that must survive a reload (contexts, stores) belongs in its own module that
 the reload does not touch.
+
+`bun --hot` is not a substitute. Its `import.meta.hot` API belongs to the
+bundler and dev server, not the CLI runtime, where the property is
+`undefined` — so there is no way to declare an accept boundary, and a reload
+re-instantiates every module including `react`. The reconciler that is still
+mounted then holds a different React than the reloaded components call, and
+the first hook throws `resolveDispatcher(...) is null`. `bun --watch` works,
+but it restarts the process: new connection, new window, no state. Fast
+Refresh needs the loader hooks above.
 
 ## React DevTools
 

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -70,10 +70,17 @@
   width: 100%;
 }
 
+/* Infima's .row gutters are horizontal only, so the six cards wrap onto a
+   second flex line with nothing between them. The gap belongs here and not
+   on .featureCard: the card is height:100% of its stretched column, so a
+   margin-bottom overflows past the column instead of separating the lines. */
+.features :global(.row) {
+  row-gap: 1.5rem;
+}
+
 .featureCard {
   height: 100%;
   padding: 1.25rem;
-  margin-bottom: 1rem;
   border: 1px solid var(--ifm-color-emphasis-200);
   border-radius: var(--ifm-card-border-radius);
 }


### PR DESCRIPTION
## The grid

The six landing-page feature cards wrap onto a second flex line with nothing between them.

`.featureCard` *does* carry `margin-bottom: 1rem` — but it also carries `height: 100%`. The card fills its stretched column exactly, so that margin overflows past the column rather than separating the lines. Infima's `.row` has horizontal gutters only. So the gap belongs on the row, and the dead margin goes:

```css
.features :global(.row) {
  row-gap: 1.5rem;
}
```

Measured in the page: `row-gap` `0px` → `24px`, and the distance from row 1's card bottom to row 2's card top `0` → `24`.

**Before** — rows touching:

![grid-before](https://github.com/user-attachments/assets/ca126dbd-db38-4133-83eb-57cfafc0c9fc)

**After** — 24px between the lines:

![grid-after](https://github.com/user-attachments/assets/482928e8-24a7-4d4e-9f8b-a947352093f5)

<sub>Both rendered from this branch at `5236d2fb75eeb247b370c108ecb85b715d776260`, same viewport and same crop, dark theme; only the stylesheet differs.</sub>

## bun

Two claims worth testing rather than assuming, since `bun hello.jsx` is shorter than `npx tsx hello.jsx`.

**`bun hello.jsx` works.** Verified two ways — the getting-started snippet verbatim against a real display, and the same tree against node-x11's in-process X server with pixel readback:

| check | result |
| --- | --- |
| background fill at 6,6 | `[255, 0, 0]` |
| distinct colours | 17 |
| antialiased glyph pixels | 196 |

So yoga layout, RENDER compositing and glyph rasterisation all run under bun, not just module loading. It is now documented beside `npx tsx`.

**`bun --hot` does not work**, and the guide now says why so nobody repeats the experiment:

- `import.meta.hot` is `undefined` in the CLI runtime — that API belongs to the bundler and dev server — so no accept boundary can be declared;
- a reload re-instantiates **every** module, `react` included. Instrumented across a reload: `react=NEW-INSTANCE reactx11=NEW-INSTANCE app=NEW-INSTANCE`;
- the still-mounted reconciler therefore holds a different React than the reloaded components call, and the first hook throws `TypeError: null is not an object (evaluating 'resolveDispatcher().useState')`. Zero renders of the edited component.

`bun --watch` works, but it restarts the process: new connection, new window, no state. That is strictly worse than what is already here, so nothing changed. Fast Refresh stays on the loader hooks — which keep `node_modules` and `src/` out of the hot graph for precisely this reason.

## One repo-only trap, in AGENTS.md

bun honours `tsconfig.json`'s `compilerOptions.paths` at runtime; ours maps `react-x11` at the declarations for the type tests. So *inside this repo* bun resolves the bare specifier to `src/index.d.ts` and dies on `The constant "Renderer" must be initialized`. Node ignores `paths`. The examples import `../src/index.js` relatively and are unaffected, and a normal install has no such mapping — but a script added here that uses the package name would hit it.

## Checks

`npm run lint`, `prettier --check` and `npm run build` for the site are green.