### PR TITLE
docs: fix three stale claims in the reference, and document flattenStyle

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -43,8 +43,9 @@ style you pass one resolves against it — see
 each in light and dark — and `npm run examples:theming` switches between
 them at runtime.
 
-`SelectThemeProvider` is the same component under an older name, kept as a
-back-compat alias from when the palette only reached `Select`.
+`SelectThemeProvider` is the same export under an older name — a back-compat
+alias from when the palette only reached `Select`. It themes every widget
+just the same; prefer `ThemeProvider`.
 
 ## Basic controls
 
@@ -189,23 +190,11 @@ single letter cycles through the options starting with it.
 
 ### Theming
 
-```jsx
-import { SelectThemeProvider } from 'react-x11';
-
-<SelectThemeProvider
-  value={{
-    border: '#444',
-    borderActive: '#f39c12',
-    background: '#2f3640',
-    text: '#f5f6fa',
-    dim: '#95a5a6',
-    hoverBackground: '#f39c12',
-    hoverText: '#1e272e',
-  }}
->
-  <Select … />
-</SelectThemeProvider>;
-```
+`Select` has no provider of its own — it reads the palette from
+[`ThemeProvider`](#theming) like every other widget. The trigger is
+`background`/`text` in a `border` box that turns `borderActive` on focus or
+while open, the chevron and the placeholder text are `dim`, and the menu
+highlight is `hoverBackground`/`hoverText`.
 
 ## `Slider`
 
@@ -224,12 +213,12 @@ import { Slider } from 'react-x11';
 />;
 ```
 
-| prop                       |                                                        |
-| -------------------------- | ------------------------------------------------------ |
-| `value`, `onChange(value)` | current value (controlled)                             |
-| `min`, `max`, `step`       | range and quantisation (defaults 0, 100, 1)            |
-| `width`, `height`          | track width; `height` is the bar thickness (default 4) |
-| `disabled`                 | inert, dimmed                                          |
+| prop                       |                                                         |
+| -------------------------- | ------------------------------------------------------- |
+| `value`, `onChange(value)` | current value (controlled)                              |
+| `min`, `max`, `step`       | range and quantisation (defaults 0, 100, 1)             |
+| `height`                   | the bar thickness (default 4); width comes from `style` |
+| `disabled`                 | inert, dimmed                                           |
 
 Dragging uses [pointer capture](events.md#pointer-capture): the press
 captures, so the thumb keeps following a pointer that has wandered far

--- a/docs/events.md
+++ b/docs/events.md
@@ -26,11 +26,12 @@ props — they can never go stale.
   x, y,                             // window coordinates
   localX, localY,                   // target-relative
   nativeEvent,                      // the raw ntk/X11 event
+  shiftKey, ctrlKey,                // on every event, not just keys
   preventDefault(), stopPropagation(),
   capturePointer(), releasePointer(),   // see Pointer capture below
   // mouse: button, detail (DOM-style click count: 2 = double, 3 = triple)
   // wheel: deltaX, deltaY
-  // keyboard: keycode, keysym, codepoint, key, shiftKey, ctrlKey
+  // keyboard: keycode, keysym, codepoint, key
 }
 ```
 

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -91,6 +91,16 @@ still exists now that its id registry is gone. It also validates keys, which
 a bare object literal cannot: an unknown style property is an error at
 declaration instead of a silent no-op.
 
+## `flattenStyle`
+
+`flattenStyle(style)` collapses whatever the `style` prop accepts — an
+object, an array, nested arrays, holes — into one plain object, which is what
+the reconciler itself does before applying props. Two details are worth
+knowing if you call it: a lone object is returned **as-is**, not copied, so
+`===` still identifies a hoisted style; and a state block merges with one
+already collected rather than replacing it, so
+`[{ ':hover': { color } }, { ':hover': { backgroundColor } }]` keeps both.
+
 ## In components
 
 Every component takes `style` and merges it after its own, so an override


### PR DESCRIPTION
Started from one confusing name and turned into an audit of `docs/` against the code.

## The name

`SelectThemeProvider` is not Select-specific and never was after the first release — `src/components/theme.js` assigns both names to the same object:

```js
export const ThemeProvider = ThemeContext.Provider;
export const SelectThemeProvider = ThemeContext.Provider; // back-compat alias
```

So `SelectThemeProvider === ThemeProvider` is true. The name is a fossil of commit `70324ae`, where the palette was introduced for `Select` alone as `SelectTheme` / `SelectThemeContext`. It grew into the library-wide theme, picked up the shape tokens, and got renamed; the old export stayed so existing code kept working.

The docs explained that correctly in the Theming section — and then the `Select` → Theming section demonstrated theming by wrapping a `<Select>` in `SelectThemeProvider`, which is the one place a reader met the name in use. That reads as a Select-scoped provider and contradicts the note 140 lines above.

## Fixed

- **The `Select` theming example** now points at `ThemeProvider` in prose and names the tokens `Select` actually reads, verified against `Select.js`. The back-compat note is the only remaining mention of the old name and says outright that it themes every widget.
- **`Slider` documented a `width` prop that does not exist.** The table said `` `width`, `height` ``; `Slider` destructures no `width`. Width travels in `style` — the code sample directly above the table already showed `style={{ width: 200 }}`, and styling.md had already recorded the change. The table was the leftover.
- **`shiftKey` / `ctrlKey` were filed under the keyboard-only comment** in the event-object block. `_makeEvent` sets them on every event, with a comment naming shift+click as the reason, and `SyntheticEvent` in `events.d.ts` declares them unconditionally. A reader would have assumed `onClick` carried no modifier state.
- **`flattenStyle` was undocumented.** Exported from the package root and declared in `style.d.ts`, but absent from all nine pages — the only public export with no prose. Now documented next to `createStyles`, with the two behaviours that matter: a lone object comes back uncopied so `===` identity survives, and state blocks merge rather than replace.

Prettier realigned two tables in components.md; `website/docs/reference/` regenerates from these files and is gitignored.

## Checked, no changes needed

| checked | result |
| --- | --- |
| 28 public exports vs docs | all covered once `flattenStyle` is added |
| widget props: source ↔ every prop table | none missing, none phantom |
| 14 host elements | all documented |
| 52 style properties | all documented |
| dispatched events vs events.md | complete |
| every numeric default | 16px check well, ProgressBar 8, Slider 4, menu 220px, type-ahead 700ms, tooltip 500ms, Dialog 360×170, SAFE_HOVER_DELAY 320, key step 16, anchor offset 2 — all match |
| keyboard tables, seven widgets | nothing documented that is not handled; Space via `codepoint === 32` correct throughout |
| item shapes for Menu, Tab, Tree, Table | match source and the declarations |
| 3D elements and `UNSUPPORTED_KINDS` | match |
| internal links and anchors | none broken |
| referenced file paths, `npm run` targets | all exist |
| 42 code fences | six are deliberate fragments — sibling elements, object literals, an open `<mesh>` tag; none broken |

## Not touched, worth a look

- **`onMouseOut` works but is undocumented.** `_onMouseOut` dispatches it on the window node; there is no prose and no type declaration, and `InteractionProps` has no index signature, so TypeScript users cannot pass it. Fixing it properly means editing `events.d.ts`, which is code, not docs — happy to do it either way.
- **`item.key` on menu items** is used as the React key fallback for duplicate labels. It type-checks through the index signature but is undocumented.
- **Unstated defaults**: `SplitPane`'s `defaultSize` 200, `min` 40, `minSecond` 40, and `TableColumn.width` 120.
- **The ntk minimum-version notes** across elements.md are all satisfied by the declared `^3.9.0`. Accurate as history, arguably noise now.

No screenshots: prose-only, nothing rendered changes.
