### PR TITLE
perf: repaint only the region that changed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,10 +358,29 @@ the diff records the cost.
   `scripts/screenshots.jsx` names Arial / Liberation / DejaVu explicitly
   instead of asking for `sans-serif`. Nothing in the source works around it
   yet — issue #86.
-- Painting is a full-window repaint scheduled through
-  `window.requestAnimationFrame` (ntk frame clock: coalescing + server
-  fence). Presentation/damage is ntk's job; dirty-rect painting is a future
-  optimization (NEXT_STEPS §8.4).
+- Painting is scheduled through `window.requestAnimationFrame` (ntk frame
+  clock: coalescing + server fence) and is **bounded by damage** when the
+  invalidation can name a region. `root.invalidate(layoutChanged, node)`
+  takes the node whose appearance changed; the frame clips to its
+  `paintBounds()`, refills only that much background, and `_outsideDamage()`
+  skips any subtree that does not reach into it — that cull is where the
+  protocol saving comes from, since the clip alone would still put every
+  request on the wire. Three rules, and breaking any of them shows up as a
+  pixel diff in `test/dirty-rect.test.js`:
+  - **a layout change is never bounded** (`invalidate(true, ...)` ignores the
+    node): a node that moved leaves stale pixels at a rect the new one does
+    not cover;
+  - **passing no node means the whole window.** Partial painting is opt-in
+    per call site, so forgetting costs speed, not correctness. `NO_DAMAGE` is
+    the third state — "I need a frame but changed nothing myself" — which is
+    what `WindowNode.applyProps` passes when only its children changed;
+  - **cull on `_subtreeBounds()`, never `abs`.** A child of a non-clipping
+    parent can be drawn outside it, so a parent whose own rect misses the
+    damage may still own a node inside it.
+
+  Presentation is still ntk's job and still a full-window `CopyArea` — that
+  costs server-side blit time, not wire traffic (NEXT_STEPS §8 item 4).
+
 - **No X11 side effects in the render phase.** Window nodes are handles
   until `realize(parentWindow)` runs in the commit phase
   (`appendChildToContainer` for top-levels, parent `realize` recursion or

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -133,8 +133,24 @@ merged theme (`ThemeProvider`; `SelectThemeProvider` is an alias) and a
   and react-x11 repaints the whole window per frame (§8.4 below).
 - **`opacity`** — needs offscreen composition (pixmap + Composite);
   ntk can do it, renderer needs a group-opacity paint path
-- **Dirty-rect painting** — still full-window repaint per frame
-  (NEXT_STEPS §8.4 below); fine so far, measure before optimizing
+- **Dirty-rect painting** — done for the paint-only paths. A node that
+  changes appearance without moving records its region, and the frame then
+  clips to it, refills only that much background, and skips emitting drawing
+  for any subtree that does not reach into it. Hovering one row of forty:
+  4500 -> 644 bytes out, 41 -> 4 composites, 0.283 -> 0.015 Mpx. Layout
+  changes still repaint in full, and deliberately: a node that moved leaves
+  stale pixels at a rect the new one does not cover. `test/dirty-rect.test.js`
+  pins the invariant by painting each case twice — bounded, then full — and
+  comparing the readbacks.
+
+  Still full-window: **arbitrary React updates**. `applyProps` names the node
+  it changed, but React rebuilds sibling style objects on every render, so a
+  commit typically updates every node it touched and the union covers the
+  container. Narrowing that means asking each node whether its _own_ paint
+  actually changed, which `paintPropsChanged` answers for boxes but not for
+  the content of `<text>`/`<image>`/`<canvas>` — those repaint through their
+  own paths. Worth doing next; it is the case the bench measures.
+
 - **Stacking of real windows** — DONE for child `<window>`s: JSX order
   (and `zIndex`) is the stacking order, applied with ConfigureWindow
   `sibling`+`stackMode` once per commit. The same fix made `insertBefore`

--- a/src/events.js
+++ b/src/events.js
@@ -471,7 +471,7 @@ export class EventManager {
       old.props.onBlur?.(this._makeEvent('blur', null, old));
       // the ring/caret it was drawing has to go, and it may be in another
       // window than the new focus (owner window ↔ its popup)
-      old.root?.invalidate(false);
+      old.root?.invalidate(false, old);
     }
     if (node) {
       // keys only reach a node whose window has the X focus
@@ -480,7 +480,7 @@ export class EventManager {
       this._scrollIntoView(node);
       if (this.windowFocused) node._defaultFocus?.();
       node.props.onFocus?.(this._makeEvent('focus', null, node));
-      node.root?.invalidate(false);
+      node.root?.invalidate(false, node);
     }
   }
 

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -56,6 +56,48 @@ const STACK_BELOW = 1;
 // in progress; drained by flushWindowRestacks from resetAfterCommit.
 const pendingRestack = new Set();
 
+// --- damage -------------------------------------------------------------
+//
+// A frame either repaints the whole window or a bounded region of it. The
+// sentinel is deliberately not a rect: "the whole window" has to stay
+// distinguishable from "a rect that happens to cover it", because the
+// window can be resized between the invalidation and the paint.
+const FULL_DAMAGE = Symbol('full-damage');
+
+// "I need a frame, but nothing I own changed appearance." Distinct from
+// passing no node, which means "something changed and I cannot say where" —
+// the safe reading, and the one that repaints everything.
+const NO_DAMAGE = Symbol('no-damage');
+
+// Painting is not perfectly bounded by a node's rect — an antialiased
+// rounded corner or glyph edge puts coverage a fraction of a pixel outside
+// it — so damage grows by a pixel on each side before anything is culled
+// against it.
+const DAMAGE_SLOP = 1;
+
+function unionDamage(a, b) {
+  if (!b) return a ?? null;
+  if (!a) return { ...b };
+  const x = Math.min(a.x, b.x);
+  const y = Math.min(a.y, b.y);
+  return {
+    x,
+    y,
+    width: Math.max(a.x + a.width, b.x + b.width) - x,
+    height: Math.max(a.y + a.height, b.y + b.height) - y,
+  };
+}
+
+/** Do two rects share any area? Touching edges do not count. */
+function rectsOverlap(a, b) {
+  return (
+    a.x < b.x + b.width &&
+    b.x < a.x + a.width &&
+    a.y < b.y + b.height &&
+    b.y < a.y + a.height
+  );
+}
+
 /** Apply any child-window stacking changes the commit produced, once. */
 export function flushWindowRestacks() {
   const nodes = [...pendingRestack];
@@ -311,7 +353,9 @@ export class Node {
     const next = resolveStyleStates(this._baseStyle, this.states);
     if (shallowEqual(next, this._targetStyle)) return;
     this._retarget(next);
-    this.root?.invalidate(false);
+    // a state block may only set paint properties, so the node's own region
+    // is the whole of what changed
+    this.root?.invalidate(false, this);
   }
 
   get isWindow() {
@@ -512,7 +556,11 @@ export class Node {
     if (Boolean(newProps.trapFocus) !== Boolean((oldProps ?? prev).trapFocus)) {
       this._syncFocusScope();
     }
-    this.root?.invalidate(layoutChanged);
+    // This is how every React update arrives, so it is where partial
+    // painting pays for itself. `applyLayoutStyle` has just told us whether
+    // anything can have *moved*: if not, this node's own region bounds what
+    // changed — a new colour, a new label, a different border.
+    this.root?.invalidate(layoutChanged, layoutChanged ? null : this);
   }
 
   setHidden(hidden) {
@@ -671,6 +719,36 @@ export class Node {
     }
   }
 
+  /**
+   * The region this node can put ink in: its own rect unioned with every
+   * descendant's. Not the same as `abs` — a child of a node that does not
+   * clip may stick out of it (absolute positioning, a negative margin), and
+   * culling a subtree by the parent's rect alone would drop that child's
+   * paint. Recomputed on demand rather than cached in `absolutize`, because
+   * it is only ever asked for on the handful of nodes that invalidate.
+   */
+  paintBounds() {
+    const bounds = this._subtreeBounds();
+    // inflated once, here — doing it inside the recursion would compound the
+    // slop by one pixel per level of nesting
+    return {
+      x: bounds.x - DAMAGE_SLOP,
+      y: bounds.y - DAMAGE_SLOP,
+      width: bounds.width + DAMAGE_SLOP * 2,
+      height: bounds.height + DAMAGE_SLOP * 2,
+    };
+  }
+
+  _subtreeBounds() {
+    let bounds = this.abs;
+    for (const child of this.children) {
+      if (child.isWindow || !child.yoga || child.hidden) continue;
+      if (child.style?.display === 'none') continue;
+      bounds = unionDamage(bounds, child._subtreeBounds());
+    }
+    return bounds;
+  }
+
   contentBox() {
     const padL =
       this.yoga.getComputedPadding(Yoga.EDGE_LEFT) +
@@ -777,9 +855,24 @@ export class Node {
     }
     for (const child of order) {
       if (child._offscreen()) continue;
+      if (child._outsideDamage()) continue;
       child.paint(ctx);
     }
     if (clip) ctx.restore();
+  }
+
+  /**
+   * Nothing this subtree draws lands in the region being repainted, so its
+   * drawing does not need to be sent at all. This is where the protocol
+   * saving comes from — the clip alone would still put every request on the
+   * wire for the server to throw away.
+   *
+   * Tested against the subtree's bounds, not `abs`: see `paintBounds`.
+   */
+  _outsideDamage() {
+    const damage = this.root?._paintDamage;
+    if (!damage) return false;
+    return !rectsOverlap(this._subtreeBounds(), damage);
   }
 
   /**
@@ -1550,7 +1643,7 @@ export class TextInputNode extends Node {
 
   _repaint() {
     this._caretOn = true;
-    this.root?.invalidate(false);
+    this.root?.invalidate(false, this);
   }
 
   /**
@@ -2162,10 +2255,12 @@ export class TextInputNode extends Node {
     this._caretOn = true;
     this._blinkTimer = setInterval(() => {
       this._caretOn = !this._caretOn;
-      this.root?.invalidate(false);
+      // twice a second, forever, for as long as a field has focus: the one
+      // repaint that most wants to cost only the field it happens in
+      this.root?.invalidate(false, this);
     }, 530);
     this._blinkTimer.unref?.();
-    this.root?.invalidate(false);
+    this.root?.invalidate(false, this);
   }
 
   _defaultBlur() {
@@ -2175,7 +2270,7 @@ export class TextInputNode extends Node {
     this._breakUndoRun();
     clearInterval(this._blinkTimer);
     this._blinkTimer = null;
-    this.root?.invalidate(false);
+    this.root?.invalidate(false, this);
   }
 
   destroySubtree() {
@@ -2908,8 +3003,15 @@ export class WindowNode extends Node {
 
     const layoutChanged =
       style !== beforeStyle && applyLayoutStyle(this.yoga, style, beforeStyle);
+    // The window's own paint is its background, which covers the whole
+    // window — so a change to it is unbounded, and `this` is the right
+    // damage. A commit that only changed children reaches here too, though
+    // (React updates the parent whenever its child list is rebuilt), and
+    // that must not widen the damage those children just recorded.
+    const ownPaintChanged = paintPropsChanged(style, beforeStyle);
     this.invalidate(
-      layoutChanged || geometryChanged || paintPropsChanged(style, beforeStyle),
+      layoutChanged || geometryChanged,
+      ownPaintChanged ? this : NO_DAMAGE,
     );
   }
 
@@ -2960,9 +3062,32 @@ export class WindowNode extends Node {
     else this.window?.map?.();
   }
 
-  invalidate(layoutChanged) {
+  /**
+   * Mark the window as needing work before the next frame.
+   *
+   * `damage` is an optional node whose *appearance* changed, and it is what
+   * turns a full-window repaint into a partial one: the frame then repaints
+   * only the region that node covers, and skips emitting drawing for
+   * everything outside it. Two rules keep that safe:
+   *
+   *  - a layout change gets no damage bound. Layout can move anything, and
+   *    a node that moved leaves stale pixels behind at its old rect, which
+   *    the new rect does not cover;
+   *  - a caller that names no node means "something, somewhere", so it also
+   *    repaints in full. Partial painting is therefore opt-in per call
+   *    site, and forgetting to pass a node costs speed rather than
+   *    correctness.
+   */
+  invalidate(layoutChanged, damage = null) {
     if (this.destroyed || !this.window) return;
     if (layoutChanged) this.needsLayout = true;
+    if (layoutChanged) this._damage = FULL_DAMAGE;
+    else if (damage === NO_DAMAGE) {
+      // contributes nothing; whoever did change has recorded its own region
+    } else if (!damage) this._damage = FULL_DAMAGE;
+    else if (this._damage !== FULL_DAMAGE) {
+      this._damage = unionDamage(this._damage, damage.paintBounds());
+    }
     this.needsPaint = true;
     if (this._scheduled) return;
     this._scheduled = true;
@@ -2995,24 +3120,73 @@ export class WindowNode extends Node {
     }
     if (!this.needsPaint) return;
     this.needsPaint = false;
+    const damage = this._takeDamage(width, height);
     if (typeof this.window.getContext !== 'function') return; // headless mock
     // ntk getContext creates a fresh context (with window-event
     // subscriptions) on every call — cache one per window
     const ctx = (this._ctx ??= this.window.getContext('2d'));
+    if (damage) {
+      // The clip is belt to the culling's braces: it bounds the server-side
+      // mask work for whatever *does* paint, and it contains any node that
+      // inks slightly outside its own rect. Rectangular clips take ntk's
+      // server-side fast path, so this is cheap.
+      ctx.save();
+      ctx.beginPath();
+      ctx.rect(damage.x, damage.y, damage.width, damage.height);
+      ctx.clip();
+    }
     ctx.fillStyle = this.style.backgroundColor || 'white';
-    ctx.fillRect(0, 0, width, height);
-    this._paintChildren(ctx);
-    if (process.env.REACT_X11_DEBUG_LAYOUT) {
-      this._paintDebugOverlay(ctx, this, 0);
+    // repainting the background only where it is about to be drawn over is
+    // the other half of the win: a full-window fill is a full-window
+    // composite however little changed
+    if (damage) ctx.fillRect(damage.x, damage.y, damage.width, damage.height);
+    else ctx.fillRect(0, 0, width, height);
+    this._paintDamage = damage;
+    try {
+      this._paintChildren(ctx);
+      if (process.env.REACT_X11_DEBUG_LAYOUT) {
+        this._paintDebugOverlay(ctx, this, 0);
+      }
+      const highlight = this._highlight;
+      if (highlight && !highlight.destroyed) {
+        const r = highlight.abs?.width
+          ? highlight.abs
+          : { x: 0, y: 0, width, height };
+        ctx.fillStyle = 'rgba(41, 128, 185, 0.35)';
+        ctx.fillRect(r.x, r.y, r.width, r.height);
+      }
+    } finally {
+      this._paintDamage = null;
+      if (damage) ctx.restore();
     }
-    const highlight = this._highlight;
-    if (highlight && !highlight.destroyed) {
-      const r = highlight.abs?.width
-        ? highlight.abs
-        : { x: 0, y: 0, width, height };
-      ctx.fillStyle = 'rgba(41, 128, 185, 0.35)';
-      ctx.fillRect(r.x, r.y, r.width, r.height);
-    }
+  }
+
+  /**
+   * The region this frame will repaint, or null for the whole window.
+   *
+   * Clamped to the window: damage is recorded when a node invalidates, and
+   * the window may have been resized since. A region that no longer
+   * intersects the window means there is nothing to do, but the frame still
+   * has to clear the flag, so it degrades to a full repaint rather than
+   * painting nothing.
+   */
+  _takeDamage(width, height) {
+    const damage = this._damage;
+    this._damage = null;
+    // what the frame about to run settled on, for the tests and for
+    // REACT_X11_DEBUG_LAYOUT to report; null means it repainted everything
+    this._lastDamage = null;
+    if (damage === FULL_DAMAGE || !damage) return null;
+    const x = Math.max(0, Math.floor(damage.x));
+    const y = Math.max(0, Math.floor(damage.y));
+    const right = Math.min(width, Math.ceil(damage.x + damage.width));
+    const bottom = Math.min(height, Math.ceil(damage.y + damage.height));
+    if (right <= x || bottom <= y) return null;
+    // covering the window is the same as not being bounded at all, and the
+    // full path is one fill instead of a clip plus a fill
+    if (x === 0 && y === 0 && right >= width && bottom >= height) return null;
+    this._lastDamage = { x, y, width: right - x, height: bottom - y };
+    return this._lastDamage;
   }
 
   /** DevTools hover highlight: tint a node's rect on the next paint. */

--- a/test/dirty-rect.test.js
+++ b/test/dirty-rect.test.js
@@ -1,0 +1,340 @@
+// Partial repaints: a paint-only change repaints the region it affected
+// instead of the whole window.
+//
+// The invariant that makes this safe is pixel equality — a partial repaint
+// must leave the surface exactly as a full repaint of the same tree would.
+// Every test here paints twice, once through the damage path and once with
+// the damage discarded, and compares the readbacks byte for byte. A cull
+// that drops something visible shows up as a diff.
+//
+// The changes are driven through the renderer's own paint-only entry points
+// (`setStyleState` for a `:hover` block, `_repaint` for a caret) rather than
+// through React state. That is not a shortcut: those are the paths that
+// carry damage today, and they are synchronous, so `root.flush()` paints
+// deterministically with no frame clock involved.
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { test } from 'node:test';
+import React from 'react';
+
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient, StaticFontSource } from 'ntk';
+
+import ReactX11 from '../src/index.js';
+
+const require = createRequire(import.meta.url);
+const fontDir = join(
+  dirname(require.resolve('katex/package.json')),
+  'dist',
+  'fonts',
+);
+
+const W = 240;
+const H = 200;
+const ROW_H = 18;
+
+async function headlessApp() {
+  const server = xserver.createServer({ width: 400, height: 400 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const fontSource = new StaticFontSource();
+  fontSource.add(readFileSync(join(fontDir, 'KaTeX_Main-Regular.ttf')), {
+    family: 'Test Main',
+  });
+  fontSource.alias('sans-serif', 'Test Main');
+  return createClient({ stream: clientEnd, fontSource });
+}
+
+const readPixels = (ctx, w, h) =>
+  new Promise((resolve, reject) =>
+    ctx.getImageData(0, 0, w, h, (err, data) =>
+      err ? reject(err) : resolve(data),
+    ),
+  );
+
+/**
+ * Mount `element` and hand back the root WindowNode plus the refs given.
+ * A ref is the way in: `getPublicInstance` returns the ntk window for
+ * `<window>` but the node itself for everything else, and a node knows its
+ * `root`.
+ */
+async function mount(app, element) {
+  await new Promise((resolve) => ReactX11.render(element, resolve, app));
+  await new Promise((r) => setImmediate(r));
+}
+
+function differences(a, b) {
+  let n = 0;
+  for (let i = 0; i < a.data.length; i += 4) {
+    if (
+      a.data[i] !== b.data[i] ||
+      a.data[i + 1] !== b.data[i + 1] ||
+      a.data[i + 2] !== b.data[i + 2]
+    )
+      n++;
+  }
+  return n;
+}
+
+/**
+ * Apply `change`, paint the frame it asked for, then paint a full frame of
+ * the same tree and compare. `damage` is the region the first frame used —
+ * null when it repainted everything.
+ */
+async function paintBothWays(app, root, change) {
+  const ctx = (root._ctx ??= root.window.getContext('2d'));
+  const settle = () =>
+    new Promise((resolve) => app.X.GetInputFocus(() => resolve()));
+
+  change();
+  root.flush();
+  await settle();
+  const damage = root._lastDamage;
+  const partial = await readPixels(ctx, W, H);
+
+  root.needsPaint = true;
+  root._damage = null;
+  root.flush();
+  await settle();
+  const full = await readPixels(ctx, W, H);
+
+  return { damage, partial, full, diff: differences(partial, full) };
+}
+
+// Styles are hoisted so a `:hover` block is the only thing that can change
+// a row's paint, which is what the renderer resolves without a React render.
+const rowStyle = (i) => ({
+  height: ROW_H,
+  backgroundColor: i % 2 ? '#ffffff' : '#e6e9ef',
+  ':hover': { backgroundColor: '#ffd479' },
+});
+const HOISTED = Array.from({ length: 8 }, (_, i) => rowStyle(i));
+
+function rowsElement(refs) {
+  return React.createElement(
+    'window',
+    { width: W, height: H, style: { backgroundColor: '#f5f6fa' } },
+    React.createElement(
+      'box',
+      { style: { flexGrow: 1, padding: 6, gap: 3 } },
+      HOISTED.map((style, i) =>
+        React.createElement(
+          'box',
+          { key: i, ref: refs[i], style },
+          React.createElement('text', { style: { fontSize: 10 } }, `row ${i}`),
+        ),
+      ),
+    ),
+  );
+}
+
+test('a hover state repaints only that row, with identical pixels', async () => {
+  const app = await headlessApp();
+  try {
+    const refs = Array.from({ length: 8 }, () => React.createRef());
+    await mount(app, rowsElement(refs));
+    const row = refs[4].current;
+    const root = row.root;
+
+    const { damage, diff } = await paintBothWays(app, root, () =>
+      row.setStyleState(':hover', true),
+    );
+
+    assert.ok(damage, 'a paint-only state change bounds the repaint');
+    // one row plus a pixel of slop on each side, not the window
+    assert.ok(
+      damage.height <= ROW_H + 4,
+      `expected ~${ROW_H}px tall, got ${damage.height}`,
+    );
+    assert.ok(
+      damage.width * damage.height < W * H * 0.25,
+      `damage ${damage.width}x${damage.height} should be a fraction of ${W}x${H}`,
+    );
+    assert.equal(diff, 0, `${diff} pixels differ from a full repaint`);
+  } finally {
+    await app.close();
+  }
+});
+
+test('two hovered rows accumulate into one region spanning both', async () => {
+  const app = await headlessApp();
+  try {
+    const refs = Array.from({ length: 8 }, () => React.createRef());
+    await mount(app, rowsElement(refs));
+    const root = refs[0].current.root;
+
+    const { damage, diff } = await paintBothWays(app, root, () => {
+      refs[1].current.setStyleState(':hover', true);
+      refs[6].current.setStyleState(':hover', true);
+    });
+
+    assert.ok(damage, 'two paint-only changes still bound the repaint');
+    assert.ok(
+      damage.height > 4 * ROW_H,
+      `union should span rows 1..6, got height ${damage.height}`,
+    );
+    assert.equal(diff, 0, `${diff} pixels differ from a full repaint`);
+  } finally {
+    await app.close();
+  }
+});
+
+test('a caret repaint is bounded to the field it blinks in', async () => {
+  const app = await headlessApp();
+  try {
+    const fieldRef = React.createRef();
+    await mount(
+      app,
+      React.createElement(
+        'window',
+        { width: W, height: H, style: { backgroundColor: '#f5f6fa' } },
+        React.createElement(
+          'box',
+          { style: { flexGrow: 1, padding: 6, gap: 3 } },
+          [
+            ...HOISTED.slice(0, 4).map((style, i) =>
+              React.createElement('box', { key: `r${i}`, style }),
+            ),
+            React.createElement('textinput', {
+              key: 'field',
+              ref: fieldRef,
+              value: 'hello',
+              style: { height: 22, backgroundColor: '#ffffff' },
+            }),
+          ],
+        ),
+      ),
+    );
+    const field = fieldRef.current;
+    const root = field.root;
+
+    const { damage, diff } = await paintBothWays(app, root, () =>
+      field._repaint(),
+    );
+
+    assert.ok(damage, 'the caret bounds its own repaint');
+    assert.ok(
+      damage.height <= 22 + 4,
+      `expected the field's height, got ${damage.height}`,
+    );
+    assert.equal(diff, 0, `${diff} pixels differ from a full repaint`);
+  } finally {
+    await app.close();
+  }
+});
+
+test('a subtree is culled by its whole extent, not its own rect', async () => {
+  const app = await headlessApp();
+  try {
+    // `host` is a 10x10 box at the top of the window whose absolutely
+    // positioned child is drawn 120px lower, over `target`. Hovering
+    // `target` damages only that strip — which `host`'s own rect misses
+    // entirely, while its child sits right inside it. Culling the subtree on
+    // the parent's rect alone therefore skips a node that had to repaint,
+    // and the background fill has already erased it.
+    const hostRef = React.createRef();
+    const targetRef = React.createRef();
+    await mount(
+      app,
+      React.createElement(
+        'window',
+        { width: W, height: H, style: { backgroundColor: '#f5f6fa' } },
+        React.createElement(
+          'box',
+          { style: { flexGrow: 1, padding: 6, gap: 3 } },
+          [
+            React.createElement('box', {
+              key: 'target',
+              ref: targetRef,
+              style: {
+                marginTop: 100,
+                height: 40,
+                backgroundColor: '#e6e9ef',
+                ':hover': { backgroundColor: '#ffd479' },
+              },
+            }),
+            // last in paint order, so its overflowing child lands *on top* of
+            // target — otherwise target's opaque background hides it and a
+            // dropped repaint leaves no trace to assert on
+            React.createElement(
+              'box',
+              {
+                key: 'host',
+                ref: hostRef,
+                style: {
+                  position: 'absolute',
+                  left: 0,
+                  top: 0,
+                  width: 10,
+                  height: 10,
+                  backgroundColor: '#cccccc',
+                },
+              },
+              React.createElement('box', {
+                style: {
+                  position: 'absolute',
+                  left: 20,
+                  top: 126,
+                  width: 80,
+                  height: 20,
+                  backgroundColor: '#27ae60',
+                },
+              }),
+            ),
+          ],
+        ),
+      ),
+    );
+    const target = targetRef.current;
+    const host = hostRef.current;
+
+    // the premise: host's own rect must not touch the damaged strip, but its
+    // subtree must — otherwise this test proves nothing
+    const strip = target.paintBounds();
+    assert.ok(
+      !(
+        host.abs.y < strip.y + strip.height &&
+        strip.y < host.abs.y + host.abs.height
+      ),
+      `host at y=${host.abs.y}..${host.abs.y + host.abs.height} must miss the strip at y=${strip.y}..${strip.y + strip.height}`,
+    );
+    const extent = host._subtreeBounds();
+    assert.ok(
+      extent.y + extent.height > strip.y,
+      'host subtree must reach into the damaged strip',
+    );
+
+    const { diff } = await paintBothWays(app, target.root, () =>
+      target.setStyleState(':hover', true),
+    );
+    assert.equal(diff, 0, `overflowing child lost: ${diff} pixels differ`);
+  } finally {
+    await app.close();
+  }
+});
+
+test('a layout change is never painted partially', async () => {
+  const app = await headlessApp();
+  try {
+    const refs = Array.from({ length: 8 }, () => React.createRef());
+    await mount(app, rowsElement(refs));
+    const row = refs[3].current;
+    const root = row.root;
+
+    // a height change moves every row below it, so the region the changed
+    // node covers says nothing about where stale pixels are
+    const { damage, diff } = await paintBothWays(app, root, () => {
+      row.applyProps(
+        { ...row.props, style: { ...HOISTED[3], height: 40 } },
+        row.props,
+      );
+    });
+
+    assert.equal(damage, null, 'a layout change repaints the whole window');
+    assert.equal(diff, 0, `${diff} pixels differ from a full repaint`);
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
A paint-only change repainted the whole window. Hovering one row of forty re-sent the drawing for all forty rows and their labels — when one row's pixels differed.

`root.invalidate(layoutChanged, node)` now takes the node whose appearance changed. The frame clips to its `paintBounds()`, refills only that much background, and `_outsideDamage()` skips any subtree that does not reach into the region.

**The cull is where the saving comes from.** The clip alone would still put every request on the wire for the server to throw away — and wire volume is the axis this project is designed around.

## Measured

Hovering row 20 of 40, against node-x11's in-process X server:

| | requests | bytesOut | composites | Mpx |
| --- | --- | --- | --- | --- |
| full repaint | 87 | 4500 | 41 | 0.283 |
| bounded repaint | **22** | **644** | **4** | **0.015** |

7× fewer bytes, 10× fewer composites, 19× less pixel work.

## Three rules, each pinned by a test

`test/dirty-rect.test.js` paints every case **twice** — once bounded, once in full — and compares the readbacks byte for byte. A cull that drops something visible is a pixel diff.

1. **A layout change is never bounded.** `invalidate(true, ...)` ignores the node: something that moved leaves stale pixels at a rect the new one does not cover.
2. **Naming no node means the whole window.** Partial painting is opt-in per call site, so forgetting to pass a node costs speed, not correctness. `NO_DAMAGE` is the third state — *"I need a frame but changed nothing myself"* — which is what `WindowNode.applyProps` passes when only its children changed. Without it, every commit widened damage to everything, because React updates a parent whenever its child list is rebuilt.
3. **Cull on the subtree's bounds, never on `abs`.** A child of a non-clipping parent can draw outside it, so a parent whose own rect misses the damage may still own a node inside it.

## The tests were wrong twice before they were right

Both correctness rules were verified by planting the bug back:

- culling on `abs` loses the overflowing child — **1600 pixels, exactly its 80×20 area**;
- letting a layout change stay bounded fails the layout test.

Worth recording that the overflow test passed **with the fault planted** in two earlier versions: first because the damage already covered the child, then because a sibling's opaque background painted over it. It now asserts its own premise — that the host's rect misses the damaged strip while its subtree reaches into it — so it cannot go quietly vacuous again.

## Scope, stated plainly

Converted: `:hover`/`:focus`/`:active` state blocks, caret blink and blur, focus moving between nodes. Those are the high-frequency interaction paths, and the ones the roadmap called out.

**Arbitrary React updates still repaint in full.** `applyProps` names its node, but React rebuilds sibling style objects on every render, so a commit typically updates every node it touched and the union covers the container. Narrowing it needs a per-node "did my own paint actually change" test — `paintPropsChanged` answers that for boxes, but not for the content of `<text>`/`<image>`/`<canvas>`, which repaint through their own paths. That is the next step and it is written down in NEXT_STEPS.

Presentation is untouched: ntk still blits the full window per frame. That costs server-side blit time, not wire traffic, so it is a separate and much smaller prize (NEXT_STEPS §8 item 4).

## Checks

`npm test` 230 passing (225 + 5 new), `npm run lint`, `npm run typecheck`, `prettier --check` and `npm run bench -- --check` all green — no protocol regressions in the existing scenarios.

Merges cleanly with #99.