### PR TITLE
fix: straight alpha for GL and colour interpolation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -411,6 +411,22 @@ the diff records the cost.
   resized the window).
 - Windows cannot be nested inside `<box>` (throws); raw strings are only
   legal inside `<text>` (throws otherwise).
+- **Never test an unreleased ntk by symlinking the checkout into
+  `node_modules`.** ntk then resolves `x11` from _its own_ `node_modules`
+  while the tests import `x11/lib/xserver` from this one, so the client and
+  the in-process server are different module instances and property work
+  fails with `Bad atom` on ChangeProperty/GetProperty — deterministically,
+  and with nothing in the message pointing at the cause. `npm pack` in the
+  ntk checkout and `npm install --no-save /tmp/ntk-<version>.tgz` instead;
+  that resolves one `x11` and the suite passes.
+- ntk's `cssColor` returns **premultiplied** components (right for XRender,
+  since 3.9.1). Anything heading for **GL** or for **interpolation** wants
+  `cssColorStraight` — `glClearColor` and material colours take unassociated
+  alpha, and a lerp that formats its result back into an `rgba()` string only
+  round-trips on straight values. `src/glnodes.js`, `src/scene3d.js` and
+  `src/styles.js` use the straight parser for exactly that reason. Note that
+  opaque colours are identical either way, so a test with `#000000` and
+  `#ffffff` cannot tell the two apart.
 - **Bun honours `tsconfig.json`'s `compilerOptions.paths` at runtime**, and
   ours maps `react-x11` at the declarations for the type tests. So inside
   this repo `bun` resolves the bare specifier to `src/index.d.ts` and dies

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^3.9.0",
+        "ntk": "^3.10.0",
         "react-reconciler": "^0.33.0"
       },
       "devDependencies": {
@@ -4679,9 +4679,9 @@
       }
     },
     "node_modules/ntk": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-3.9.0.tgz",
-      "integrity": "sha512-9UGPaLWw9/KQSumiDks9V2QhTvuVe1bZk7xdigRZRuClYm7gPrdx/5D/nHzvQlPHNregMGiAmMsVk42SU17ORQ==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-3.10.0.tgz",
+      "integrity": "sha512-SByAuk7OFO7RgZ390KHoTKBm8X9b1yAA+ps5l6tX8RmL66mYQf+aeDRPgH9ten7OPCKpoFIGVqhf5SnmsRx1Lw==",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",
@@ -4702,7 +4702,7 @@
         "parse-color": "^1.0.0",
         "pngjs": "^7.0.0",
         "postcss": "^8.5.23",
-        "x11": "^3.2.0",
+        "x11": "^3.3.0",
         "yoga-layout": "^3.2.1"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^3.9.0",
+    "ntk": "^3.10.0",
     "react-reconciler": "^0.33.0"
   },
   "peerDependencies": {

--- a/src/glnodes.js
+++ b/src/glnodes.js
@@ -5,7 +5,7 @@
 // (NEXT_STEPS §4), sized and positioned by the parent's yoga layout like any
 // other drawn node. Everything about the surface is here; the scene graph
 // that draws into it comes later (docs/glx-plan.md).
-import { cssColor } from 'ntk';
+import { cssColorStraight } from 'ntk';
 
 import { Node } from './nodes.js';
 import { ScenePointer, sceneWantsPointer } from './pointer3d.js';
@@ -34,11 +34,17 @@ export function glxConfig(app, spec) {
   return promise;
 }
 
-/** clearColor as a CSS string or an [r, g, b, a] float tuple. */
+/**
+ * clearColor as a CSS string or an [r, g, b, a] float tuple.
+ *
+ * Straight alpha, not premultiplied: this goes to `glClearColor`, and GL
+ * takes unassociated components. ntk's `cssColor` premultiplies for XRender,
+ * which would darken any translucent clear colour.
+ */
 function clearColorOf(props) {
   const value = props.clearColor ?? 'black';
   if (Array.isArray(value)) return value.length === 4 ? value : [...value, 1];
-  const parsed = cssColor(value);
+  const parsed = cssColorStraight(value);
   return parsed ?? [0, 0, 0, 1];
 }
 

--- a/src/scene3d.js
+++ b/src/scene3d.js
@@ -8,7 +8,7 @@
 // frame, so every geometry is compiled into a **server-side display list**
 // once and replayed with a single CallList. A frame is then matrices +
 // material state + one CallList per mesh, whatever the triangle count.
-import { cssColor } from 'ntk';
+import { cssColorStraight } from 'ntk';
 
 import {
   GEOMETRY_BUILDERS,
@@ -290,10 +290,13 @@ export function cameraMatrices(spec, { width, height }) {
   };
 }
 
+// Material and light colours, straight alpha — these become GL state, and GL
+// takes unassociated components. ntk's `cssColor` premultiplies for XRender,
+// which would render a translucent material dark.
 const rgba = (color, fallback = [1, 1, 1, 1]) => {
   if (!color) return fallback;
   if (Array.isArray(color)) return color.length === 4 ? color : [...color, 1];
-  return cssColor(color) ?? fallback;
+  return cssColorStraight(color) ?? fallback;
 };
 
 /** Lights with their world matrices, in tree order. */

--- a/src/styles.js
+++ b/src/styles.js
@@ -3,7 +3,7 @@
 // Numbers are pixels; strings like '50%' / 'auto' pass through to yoga.
 // Yoga comes from ntk (>= 3.1.0) so renderer and ntk widgets share one
 // WASM instance and enum set.
-import { Yoga, cssColor } from 'ntk';
+import { Yoga, cssColorStraight } from 'ntk';
 
 export { Yoga };
 
@@ -390,14 +390,20 @@ const rgba = (c) =>
  * through ntk's own CSS colour parser, so anything the paint path accepts
  * animates. Anything else — a percentage string, `auto`, an enum — has no
  * meaningful midpoint and returns null, which the caller treats as a snap.
+ *
+ * The colours are parsed **straight**, not premultiplied. The result is
+ * formatted back into an `rgba()` string, and that round trip only closes on
+ * unassociated components: premultiplied ones get scaled by alpha a second
+ * time when the paint path parses the string again, so a midpoint of a
+ * translucent colour would come out darker than either end.
  */
 export function interpolate(from, to, t) {
   if (typeof from === 'number' && typeof to === 'number') {
     return from + (to - from) * t;
   }
   if (typeof from === 'string' && typeof to === 'string') {
-    const a = cssColor(from);
-    const b = cssColor(to);
+    const a = cssColorStraight(from);
+    const b = cssColorStraight(to);
     if (!a || !b) return null;
     return rgba(a.map((v, i) => v + (b[i] - v) * t));
   }

--- a/test/style.test.js
+++ b/test/style.test.js
@@ -297,6 +297,44 @@ test('REACT_X11_STYLE_ONLY: a flat style prop is an error that names the fix', a
 
 // --- transitions -----------------------------------------------------------
 
+test('interpolating a translucent colour does not darken it', async () => {
+  const { interpolate } = await import('../src/styles.js');
+
+  // Interpolating a colour with itself must return itself. This is the whole
+  // bug in one line: the components are parsed, lerped, and formatted back
+  // into an rgba() string, so they have to be *straight*. Premultiplied ones
+  // get scaled by alpha again when the paint path re-parses the string, and
+  // half-alpha red comes back as rgba(128, 0, 0, 0.5) — the same alpha at
+  // half the brightness.
+  assert.strictEqual(
+    interpolate('rgba(255, 0, 0, 0.5)', 'rgba(255, 0, 0, 0.5)', 0.5),
+    'rgba(255, 0, 0, 0.5)',
+  );
+
+  // both endpoints, too
+  assert.strictEqual(
+    interpolate('rgba(0, 0, 255, 0.25)', 'rgba(255, 0, 0, 0.75)', 0),
+    'rgba(0, 0, 255, 0.25)',
+  );
+  assert.strictEqual(
+    interpolate('rgba(0, 0, 255, 0.25)', 'rgba(255, 0, 0, 0.75)', 1),
+    'rgba(255, 0, 0, 0.75)',
+  );
+
+  // and the midpoint moves both colour and alpha
+  assert.strictEqual(
+    interpolate('rgba(0, 0, 0, 0)', 'rgba(255, 255, 255, 1)', 0.5),
+    'rgba(128, 128, 128, 0.5)',
+  );
+
+  // opaque colours are unaffected either way, which is why the existing
+  // transition test never caught this
+  assert.strictEqual(
+    interpolate('#000000', '#ffffff', 0.5),
+    'rgba(128, 128, 128, 1)',
+  );
+});
+
 test('a transition eases a colour instead of snapping to it', async () => {
   const { setAnimationClock } = await import('../src/nodes.js');
   let clock = 1000;


### PR DESCRIPTION
ntk 3.9.1 made `cssColor` return **premultiplied** components. Correct for XRender — and wrong for all three places react-x11 consumes it, none of which are the paint path.

Unblocked: ntk **3.10.0** is published with the exports this needs, and the lockfile is updated.

## What breaks

**GL takes straight alpha.** `glClearColor` in `src/glnodes.js` and 3D material colours in `src/scene3d.js` get unassociated components; premultiplied ones render translucent colours dark.

**Interpolation has to round-trip.** `interpolate` in `src/styles.js` parses two colours, lerps per channel, and formats the result back into an `rgba()` string — which the paint path then parses again, applying alpha a second time:

```
rgba(255, 0, 0, 0.5)  ->  cssColor  ->  [0.5, 0, 0, 0.5]  ->  rgba(128, 0, 0, 0.5)
```

Same alpha, half the brightness, at every point of every transition involving a translucent colour.

All three now use `cssColorStraight`.

## The paint path wanted 3.9.1

Worth being clear that this is not a revert. `src/nodes.js` passes colour **strings** to `ctx.fillStyle`, so premultiplying inside ntk *fixed* translucent fills here — the `rgba(0, 0, 0, 0.25)` scrim was rendering too dark before. Only the three array-consuming sites needed the other form.

## Why the suite was silent

The existing transition test eases `#000000` to `#ffffff`. Premultiplying is the identity at alpha 1, so the two forms are **indistinguishable** to it — that test could never have caught this.

The new test interpolates a colour with *itself* and asserts it comes back unchanged, which is the bug in one line. Planting the premultiplied parse back fails it with exactly the diff above: actual `rgba(128, 0, 0, 0.5)`, expected `rgba(255, 0, 0, 0.5)`.

## A trap worth writing down

Verifying against unreleased ntk by **symlinking the checkout** into `node_modules` produced a deterministic and completely misleading failure. ntk resolves `x11` from its own `node_modules` while the tests import `x11/lib/xserver` from this one, so client and in-process server were different module instances and property work failed with `Bad atom` on ChangeProperty and GetProperty. It read as a WM regression in an unrelated test, 8 runs out of 8.

`npm pack` in the ntk checkout and `npm install --no-save` the tarball resolves one `x11`. Both that and the which-parser-when rule are now in AGENTS.md.

## Checks

Against the published 3.10.0: `npm test` 231 passing, plus lint, typecheck, `prettier --check` and `npm run bench -- --check` all green — no protocol regressions.