### PR TITLE
perf: bound React updates to the nodes that actually changed

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -377,6 +377,15 @@ the diff records the cost.
   - **cull on `_subtreeBounds()`, never `abs`.** A child of a non-clipping
     parent can be drawn outside it, so a parent whose own rect misses the
     damage may still own a node inside it.
+  - **a node only claims damage if something it _draws_ changed.** Paint
+    style is compared by value, so a style object React rebuilt with the same
+    contents costs nothing; every non-style prop is compared too, because
+    that is where a subclass's content lives — `<image src>`, `<canvas
+onDraw>`, `value`, `placeholder`. `children` and event handlers are
+    skipped, child mutations having their own invalidation paths. Adding a
+    prop that affects paint needs nothing; adding paint-relevant _style_
+    means adding it to `paintPropsChanged`, which is why `borderStyle` is
+    named there explicitly alongside `color`.
 
   Presentation is still ntk's job and still a full-window `CopyArea` — that
   costs server-side blit time, not wire traffic (NEXT_STEPS §8 item 4).
@@ -427,6 +436,13 @@ the diff records the cost.
   `src/styles.js` use the straight parser for exactly that reason. Note that
   opaque colours are identical either way, so a test with `#000000` and
   `#ffffff` cannot tell the two apart.
+- **A frame that claims no damage repaints everything**, deliberately — the
+  safe default when nothing can say what changed. It also means a test that
+  changes one thing cannot demonstrate a missed repaint: with nothing bounding
+  the region, the fallback covers the bug and the test passes either way. Pair
+  it with a second change that _does_ bound the frame. Three tests in
+  `test/dirty-rect.test.js` passed with the bug planted before their premises
+  were tightened, so each now asserts its own premise.
 - **Bun honours `tsconfig.json`'s `compilerOptions.paths` at runtime**, and
   ours maps `react-x11` at the declarations for the type tests. So inside
   this repo `bun` resolves the bare specifier to `src/index.d.ts` and dies

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -148,13 +148,21 @@ merged theme (`ThemeProvider`; `SelectThemeProvider` is an alias) and a
   pins the invariant by painting each case twice — bounded, then full — and
   comparing the readbacks.
 
-  Still full-window: **arbitrary React updates**. `applyProps` names the node
-  it changed, but React rebuilds sibling style objects on every render, so a
-  commit typically updates every node it touched and the union covers the
-  container. Narrowing that means asking each node whether its _own_ paint
-  actually changed, which `paintPropsChanged` answers for boxes but not for
-  the content of `<text>`/`<image>`/`<canvas>` — those repaint through their
-  own paths. Worth doing next; it is the case the bench measures.
+  **Arbitrary React updates are bounded too.** A commit calls `applyProps` on
+  every node it walked, and React rebuilds sibling style objects on every
+  render, so the union used to cover the container. Now a node only claims
+  damage if something it _draws_ changed: paint-relevant style compared by
+  value, plus any non-style prop, since that is where a subclass's content
+  lives — `<image src>`, `<canvas onDraw>`, a `value`, a `placeholder`.
+  `children`, event handlers and `style` are skipped, the first because child
+  mutations invalidate through their own paths. One row of forty recoloured
+  through `setState`: 5160 -> 732 bytes out, 45 -> 4 composites, 0.297 ->
+  0.015 Mpx, damaging 386x14 instead of the window.
+
+  The fallback is safe by construction: if no node claims damage, the frame
+  repaints everything. That is worth knowing when writing tests here — a
+  single changed prop cannot demonstrate a missed repaint, because nothing
+  bounds the region. It takes a second change that _does_ bound it.
 
 - **Stacking of real windows** — DONE for child `<window>`s: JSX order
   (and `zIndex`) is the stacking order, applied with ConfigureWindow

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -14,6 +14,7 @@ import {
   resolveStyleStates,
   hasStateStyles,
   isStyleProp,
+  isEventProp,
   EMPTY_STYLE,
   transitionFor,
   interpolate,
@@ -559,8 +560,49 @@ export class Node {
     // This is how every React update arrives, so it is where partial
     // painting pays for itself. `applyLayoutStyle` has just told us whether
     // anything can have *moved*: if not, this node's own region bounds what
-    // changed — a new colour, a new label, a different border.
-    this.root?.invalidate(layoutChanged, layoutChanged ? null : this);
+    // changed — a new colour, a new label, a different border. And if
+    // nothing it draws changed at all, it contributes no damage, which is
+    // what keeps a commit from widening the region to every node it touched.
+    this.root?.invalidate(
+      layoutChanged,
+      layoutChanged
+        ? null
+        : this._paintChanged(newProps, prev, style, prevStyle)
+          ? this
+          : NO_DAMAGE,
+    );
+  }
+
+  /**
+   * Did anything this node *draws* change?
+   *
+   * Deliberately conservative, because the cost of a wrong "no" is a stale
+   * pixel that nothing will come back to fix. Paint-relevant style is asked
+   * about by value, so a style object React rebuilt with the same contents
+   * costs nothing — that is the whole point, since React rebuilds sibling
+   * styles on every render and a commit would otherwise damage every node it
+   * walked.
+   *
+   * Everything else falls back to "yes it changed", which is what makes this
+   * safe without knowing about subclasses: `<image src>`, `<canvas onDraw>`,
+   * a `value`, a `placeholder`, a `caretColor` — any prop a subclass paints
+   * from is a prop, so a change to it lands here as an inequality and damages
+   * the node. Three kinds are skipped because they cannot affect this node's
+   * own drawing:
+   *
+   *  - `children`, which the reconciler mutates through appendChild /
+   *    removeChild / commitTextUpdate, each of which invalidates on its own;
+   *  - event handlers, rebuilt every render and never painted;
+   *  - `style`, already compared by value above.
+   */
+  _paintChanged(newProps, prev, style, prevStyle) {
+    if (style !== prevStyle && paintPropsChanged(style, prevStyle)) return true;
+    const keys = new Set([...Object.keys(newProps), ...Object.keys(prev)]);
+    for (const key of keys) {
+      if (key === 'children' || key === 'style' || isEventProp(key)) continue;
+      if (newProps[key] !== prev[key]) return true;
+    }
+    return false;
   }
 
   setHidden(hidden) {

--- a/src/styles.js
+++ b/src/styles.js
@@ -513,7 +513,12 @@ export function paintPropsChanged(props, oldProps = {}) {
   for (const key of PAINT_PROPS) {
     if (props[key] !== oldProps[key]) return true;
   }
-  return props.color !== oldProps.color;
+  // `color` and `borderStyle` paint but are deliberately not in PAINT_PROPS:
+  // that set also decides what a state block is allowed to set, and widening
+  // it would change validation rather than just this comparison
+  return (
+    props.color !== oldProps.color || props.borderStyle !== oldProps.borderStyle
+  );
 }
 
 /** Resolved text style (TextLayout base style) from props + inherited. */

--- a/test/dirty-rect.test.js
+++ b/test/dirty-rect.test.js
@@ -338,3 +338,178 @@ test('a layout change is never painted partially', async () => {
     await app.close();
   }
 });
+
+// --- React-driven updates --------------------------------------------------
+//
+// The cases above drive the renderer's own paint-only entry points. These go
+// through React instead, which is harder: a commit calls applyProps on every
+// node it walked, and React rebuilds sibling style objects on every render.
+// Damage stays bounded only because a node whose drawing did not actually
+// change contributes none.
+
+/** Mount `body(state)` under a component and return a state setter. */
+async function mountStateful(app, body) {
+  const ref = React.createRef();
+  let setState;
+  function App() {
+    const [state, set] = React.useState(0);
+    setState = set;
+    return React.createElement(
+      'window',
+      { width: W, height: H, style: { backgroundColor: '#f5f6fa' } },
+      React.createElement(
+        'box',
+        { ref, style: { flexGrow: 1, padding: 6, gap: 3 } },
+        body(state),
+      ),
+    );
+  }
+  await new Promise((resolve) =>
+    ReactX11.render(React.createElement(App), resolve, app),
+  );
+  await new Promise((r) => setImmediate(r));
+  return { root: ref.current.root, setState: (v) => setState(v) };
+}
+
+test('a React update bounds the repaint to the row that changed', async () => {
+  const app = await headlessApp();
+  try {
+    // styles built inline every render, the way an app really writes them:
+    // all eight rows get a fresh style object, only one differs in value
+    const { root, setState } = await mountStateful(app, (state) =>
+      Array.from({ length: 8 }, (_, i) =>
+        React.createElement(
+          'box',
+          {
+            key: i,
+            style: {
+              height: ROW_H,
+              backgroundColor:
+                i === 4 && state ? '#ffd479' : i % 2 ? '#ffffff' : '#e6e9ef',
+            },
+          },
+          React.createElement('text', { style: { fontSize: 10 } }, `row ${i}`),
+        ),
+      ),
+    );
+
+    const ctx = (root._ctx ??= root.window.getContext('2d'));
+    const settle = () =>
+      new Promise((resolve) => app.X.GetInputFocus(() => resolve()));
+
+    setState(1);
+    for (let i = 0; i < 5; i++) {
+      await new Promise((r) => setImmediate(r));
+      await settle();
+    }
+    root.flush();
+    await settle();
+    const damage = root._lastDamage;
+    const partial = await readPixels(ctx, W, H);
+
+    root.needsPaint = true;
+    root._damage = null;
+    root.flush();
+    await settle();
+    const full = await readPixels(ctx, W, H);
+    const diff = differences(partial, full);
+
+    assert.ok(damage, 'the commit did not widen the region to everything');
+    assert.ok(
+      damage.height <= ROW_H + 4,
+      `one row expected, got ${damage.width}x${damage.height} — the seven ` +
+        'rows whose style objects were rebuilt unchanged must contribute none',
+    );
+    assert.equal(diff, 0, `${diff} pixels differ from a full repaint`);
+  } finally {
+    await app.close();
+  }
+});
+
+test('a non-style prop the node paints from still damages it', async () => {
+  const app = await headlessApp();
+  try {
+    // Two things change in ONE commit: a row's colour, which bounds the
+    // damage to a thin strip, and the field's `placeholder`, which is a prop
+    // painted whenever the value is empty. TextInputNode's own applyProps
+    // does not invalidate for `placeholder` — it only reacts to text metrics
+    // and to `value` — so the base class has to notice the changed prop.
+    //
+    // Both halves are load-bearing. Changing the placeholder alone proves
+    // nothing: with no node claiming damage the frame falls back to a full
+    // repaint, which is correct by construction and hides the bug. It is
+    // only when something *else* bounds the region that a node failing to
+    // claim its own is left with stale pixels. <canvas> would not test this
+    // either — CanvasNode invalidates unconditionally on any update.
+    const fieldRef = React.createRef();
+    let setState;
+    function App() {
+      const [state, set] = React.useState(0);
+      setState = set;
+      return React.createElement(
+        'window',
+        { width: W, height: H, style: { backgroundColor: '#f5f6fa' } },
+        React.createElement(
+          'box',
+          { style: { flexGrow: 1, padding: 6, gap: 3 } },
+          [
+            React.createElement('box', {
+              key: 'row',
+              style: {
+                height: ROW_H,
+                backgroundColor: state ? '#ffd479' : '#e6e9ef',
+              },
+            }),
+            React.createElement('textinput', {
+              key: 'field',
+              ref: fieldRef,
+              value: '',
+              placeholder: state ? 'changed placeholder' : 'first',
+              style: { height: 22, backgroundColor: '#ffffff' },
+            }),
+          ],
+        ),
+      );
+    }
+    await new Promise((resolve) =>
+      ReactX11.render(React.createElement(App), resolve, app),
+    );
+    await new Promise((r) => setImmediate(r));
+
+    const root = fieldRef.current.root;
+    const ctx = (root._ctx ??= root.window.getContext('2d'));
+    const settle = () =>
+      new Promise((resolve) => app.X.GetInputFocus(() => resolve()));
+
+    setState(1);
+    for (let i = 0; i < 5; i++) {
+      await new Promise((r) => setImmediate(r));
+      await settle();
+    }
+    root.flush();
+    await settle();
+    const damage = root._lastDamage;
+    const partial = await readPixels(ctx, W, H);
+
+    root.needsPaint = true;
+    root._damage = null;
+    root.flush();
+    await settle();
+    const full = await readPixels(ctx, W, H);
+    const diff = differences(partial, full);
+
+    // the premise: the frame really was bounded, so a node that failed to
+    // claim damage would have been culled
+    assert.ok(
+      damage,
+      'the frame must be bounded for this test to mean anything',
+    );
+    assert.equal(
+      diff,
+      0,
+      `the field kept its old placeholder: ${diff} pixels differ from a full repaint`,
+    );
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
#100 bounded the interaction paths — hover, focus, caret — but left **arbitrary React updates repainting the whole window**. A commit calls `applyProps` on every node it walked, and React rebuilds sibling style objects on every render, so each of them claimed damage and the union covered the container.

A node now claims damage only if something it *draws* changed.

- **Paint-relevant style, compared by value.** A style object rebuilt with the same contents costs nothing — the case that matters, since that is what React does to every sibling.
- **Every non-style prop, compared too.** That is where a subclass's content lives: an image `src`, a canvas `onDraw`, a `value`, a `placeholder`. Any change lands here as an inequality, so this stays correct without the base class knowing about subclasses.
- **Skipped:** `children`, event handlers, and `style`. The first because child mutations invalidate through `appendChild` / `removeChild` / `commitTextUpdate` on their own.

## Measured

One row of forty recoloured through `setState`:

| | requests | bytesOut | composites | Mpx | damage |
| --- | --- | --- | --- | --- | --- |
| full | 113 | 5160 | 45 | 0.297 | whole window |
| bounded | **30** | **732** | **4** | **0.015** | **386x14** |

`borderStyle` joins `color` as a named comparison in `paintPropsChanged`. Neither belongs in `PAINT_PROPS`: that set also decides what a state block may set, so widening it would change validation rather than just this comparison.

## Both tests verified by planting the bug back

- skipping the prop loop leaves a **stale placeholder, 656 pixels**;
- never claiming damage leaves the recoloured row unpainted.

## How the second test had to be built

Worth recording, because it is a trap for the next one. **If no node claims damage the frame repaints everything** — safe by construction, and it means a single changed prop *cannot* demonstrate a missed repaint: nothing bounds the region, so the fallback covers the bug and the test passes either way.

My first two attempts were vacuous for exactly that reason. One used `<canvas>`, which invalidates unconditionally; the next changed only the placeholder, so the frame fell back to full. The test now changes a row's colour **and** the placeholder in one commit, so the frame is genuinely bounded and a node that failed to claim its region is culled — and it asserts that premise rather than assuming it.

Three tests in this file have now passed with a planted fault before their premises were tightened. That pattern is written into AGENTS.md.

## Checks

`npm test` 232 passing, plus lint, typecheck, `prettier --check` and `npm run bench -- --check` — no protocol regressions.

Independent of #101; both are on master's current tip.