### PR TITLE
docs: record what the perf findings turned into

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -491,6 +491,14 @@ onDraw>`, `value`, `placeholder`. `children` and event handlers are
   the scheduler would have run. `test/dirty-rect.test.js` and
   `scripts/check-stress.jsx` both do this.
 
+- **Request count is not a proxy for cost here; pixel work is.** ntk brackets
+  every glyph run under a clip with a `SetPictureClipRectangles` pair, which is
+  379 requests a scroll notch — 37% of all of them. Deleting every one of them
+  changed the frame time by _nothing_, 681ms either way: they are 8-byte
+  requests with no server pixel work behind them. The change that did move the
+  needle was skipping clips nobody needed, because each of those rebuilt an a8
+  mask. Measure a change in wall clock or in Composite pixels before optimising
+  a request count — `npm run bench` reports both for that reason.
 - **Interpolate colours premultiplied.** `transparent` is _black_ at zero
   alpha, so lerping the four straight channels drags every fade-in towards
   black on the way: half way from `transparent` to a near-white hover fill

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -496,9 +496,20 @@ File these as ntk issues; react-x11 should not work around them long-term.
    `_NET_WM_STATE_ABOVE` but exposes no fullscreen / maximize / minimize.
 3. **Re-export the Yoga instance** so renderer and HtmlView share one WASM
    module and version — DONE (sidorares/ntk#58), `import { Yoga } from 'ntk'`.
-4. **Rect-level presentation.** `_presentNow` blits the full window; accept
-   dirty rects from the renderer and `CopyArea` only those. Coarse full-window
-   blit is fine at first but wasteful for caret blink / hover highlights.
+4. **Rect-level presentation** — DONE (sidorares/ntk#110). A drawing operation
+   reports its clip rectangle through `_markDirty`, the window accumulates the
+   union, and the present copies that instead of the surface. No caller API:
+   an operation that was not clipped reports nothing and the frame falls back
+   to a full blit, and that fallback absorbs, so one unbounded operation keeps
+   the whole frame unbounded rather than copying less than was drawn. A hover
+   repaint of two tab headers went from 4.20 Mpx copied to 0.03. Scrolling
+   barely moved — those frames repaint most of the window anyway.
+
+   Still coarse in one way: the region is a bounding box, not a list of rects,
+   so two small changes at opposite corners copy everything between them. That
+   is the same limitation the renderer's own damage tracking has, and the two
+   would want fixing together.
+
 5. **Clipboard/selection helper** — DONE (sidorares/ntk#69). ntk owns
    CLIPBOARD/PRIMARY acquisition, TARGETS negotiation and string transfer,
    including INCR for large payloads; this is what `<textinput>` cut/paste


### PR DESCRIPTION
Two loose ends from profiling the stress app, one done upstream and one deliberately not done.

**Rect-level presentation is done** — sidorares/ntk#110 — so NEXT_STEPS §8 item 4 closes. A drawing operation reports its clip rectangle, the window unions those, and the present copies the union rather than the surface. A hover repaint of two tab headers went from **4.20 Mpx copied to 0.03**. The remaining coarseness is written down: the region is a bounding box, not a list of rects, which is the same limitation the renderer's own damage tracking has.

**The other one is recorded because it went nowhere, which is the useful part.** ntk brackets every glyph run under a clip with a `SetPictureClipRectangles` pair — 379 requests a scroll notch, 37% of the total, and an obvious-looking thing to remove. Deleting every one of them changed the frame time by **nothing**:

```
                        requests/notch    wall clock/notch
with the clip pairs               1014              681 ms
without them                       635              681 ms
```

They are 8-byte requests with no server pixel work behind them. Removing them properly would have meant touching the twenty sites that draw onto the window picture, with wrong clipping as the failure mode, for no measurable gain. So the note in AGENTS.md is: **request count is not a proxy for cost here, pixel work is** — measure wall clock or Composite pixels first. The change that *did* pay was skipping clips that clip nothing, worth a third of the frame, because each of those rebuilt an a8 mask.

No code changes.