### PR TITLE
perf: paint a region, not the box around it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -397,11 +397,16 @@ onDraw>`, `value`, `placeholder`. `children` and event handlers are
   anything translucent. And a list whose rects nearly fill their box collapses
   back to the box, because a pass is not free: `SPLIT_SAVING` is the threshold.
 
-  Presentation is ntk's job. Up to and including 3.10.1 it is a full-window
-  `CopyArea` — server-side blit time, not wire traffic. From 3.10.2 it copies
-  only the rects the drawing reported (NEXT_STEPS §8 item 4), which is what
-  makes the renderer-side region list visible on screen rather than just
-  cheaper to compute.
+  Presentation is ntk's job, and the two halves have to match to be worth
+  anything: **ntk >= 3.10.2** copies just the rects the drawing reported, where
+  earlier versions blit the whole window however little changed. That is the
+  floor in `package.json` for this reason, not for an API — against 3.10.1 the
+  region list still computes and paints correctly, it just does not reach the
+  screen any faster (NEXT_STEPS §8 item 4). The reporting channel is the clip:
+  ntk takes each operation's clip rectangle as the region it might have touched,
+  so a pass that is not clipped reports nothing and gives up the bound for the
+  whole frame — which is why the frame clips per rect even though culling
+  already skips the work.
 
   A scroll is the one layout change that carries a damage bound:
   `invalidate(true, node)` asserts the reflow is confined to that node's
@@ -417,9 +422,8 @@ onDraw>`, `value`, `placeholder`. `children` and event handlers are
   allocated a full-surface a8 pixmap, rasterized into it and composited the
   whole surface — per clip, and a frame nests them constantly. 3412 of 3900
   Composite requests over twenty wheel notches came from there. Fixed upstream
-  in sidorares/ntk#107, shipped in **ntk 3.10.1**, which is the floor this
-  package now depends on. Per wheel notch on the 50,000-row table, same
-  harness, only the ntk clip code differing:
+  in sidorares/ntk#107, shipped in **ntk 3.10.1**. Per wheel notch on the
+  50,000-row table, same harness, only the ntk clip code differing:
 
   |                 | 3.10.0 | 3.10.1 |
   | --------------- | ------ | ------ |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -387,8 +387,21 @@ onDraw>`, `value`, `placeholder`. `children` and event handlers are
     means adding it to `paintPropsChanged`, which is why `borderStyle` is
     named there explicitly alongside `color`.
 
-  Presentation is still ntk's job and still a full-window `CopyArea` — that
-  costs server-side blit time, not wire traffic (NEXT_STEPS §8 item 4).
+  Damage is a **list of rects, capped at four**, not the box around them, so
+  two changes at opposite corners no longer repaint everything between them.
+  The frame paints a pass per rect and clips each pass to that one rect —
+  deliberately, because ntk's server-side clip fast path only recognises a
+  single rectangle and a multi-rect clip path falls back to rasterizing a
+  full-surface mask. Rects that overlap are merged rather than kept, since a
+  node inside two of them would otherwise be painted twice, which is wrong for
+  anything translucent. And a list whose rects nearly fill their box collapses
+  back to the box, because a pass is not free: `SPLIT_SAVING` is the threshold.
+
+  Presentation is ntk's job. Up to and including 3.10.1 it is a full-window
+  `CopyArea` — server-side blit time, not wire traffic. From 3.10.2 it copies
+  only the rects the drawing reported (NEXT_STEPS §8 item 4), which is what
+  makes the renderer-side region list visible on screen rather than just
+  cheaper to compute.
 
   A scroll is the one layout change that carries a damage bound:
   `invalidate(true, node)` asserts the reflow is confined to that node's

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -506,9 +506,9 @@ File these as ntk issues; react-x11 should not work around them long-term.
    barely moved — those frames repaint most of the window anyway.
 
    The box that was left — two small changes at opposite corners copying
-   everything between them — is gone too, on both sides at once
-   (sidorares/ntk#112, and the renderer half in this repo). Damage is a short
-   list of rectangles
+   everything between them — is gone too, on both sides at once: DONE
+   (sidorares/ntk#112, released as **3.10.2**, plus the renderer half in this
+   repo). Damage is a short list of rectangles
    rather than the box around them: the renderer paints a pass per rectangle,
    each clipped to just that one so ntk's server-side rectangular-clip fast
    path still applies, and ntk accumulates the reported clips into a list and

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -505,10 +505,23 @@ File these as ntk issues; react-x11 should not work around them long-term.
    repaint of two tab headers went from 4.20 Mpx copied to 0.03. Scrolling
    barely moved — those frames repaint most of the window anyway.
 
-   Still coarse in one way: the region is a bounding box, not a list of rects,
-   so two small changes at opposite corners copy everything between them. That
-   is the same limitation the renderer's own damage tracking has, and the two
-   would want fixing together.
+   The box that was left — two small changes at opposite corners copying
+   everything between them — is gone too, on both sides at once
+   (sidorares/ntk#112, and the renderer half in this repo). Damage is a short
+   list of rectangles
+   rather than the box around them: the renderer paints a pass per rectangle,
+   each clipped to just that one so ntk's server-side rectangular-clip fast
+   path still applies, and ntk accumulates the reported clips into a list and
+   copies each. Both lists are capped — 4 rectangles in the renderer, where one
+   costs a whole pass over the tree, 8 in ntk, where one costs a CopyArea — and
+   both collapse back to the surrounding box when splitting would not save at
+   least a quarter of it, so nothing changes for the common case of changes near
+   each other. Measured through the stress app's Damage panel, "scattered" mode
+   (four cells at the corners of a 24x16 grid): **2508 kpx painted and copied
+   per five frames, down to 51 kpx** — 49x. "every cell" is unchanged at 2508
+   kpx, which is what makes that number mean something, and hovering two
+   adjacent tab headers is unchanged at 33 kpx because the collapse rule
+   declines to split it.
 
 5. **Clipboard/selection helper** — DONE (sidorares/ntk#69). ntk owns
    CLIPBOARD/PRIMARY acquisition, TARGETS negotiation and string transfer,

--- a/examples/README.md
+++ b/examples/README.md
@@ -70,15 +70,21 @@ carry a live step counter until the counter's own re-measure turned every
 step into a full repaint. Read the log next to the window:
 
 ```
-  frame  damage rect                area      paint
-     14  82x63 @ 210,404            5.2kpx    0.8ms
+  frame  damage rect                            area      paint
+     14  82x63 @ 210,404                        5.2kpx    0.8ms
      15  … ×4
-     16  FULL WINDOW                700.0kpx  9.1ms
+     16  FULL WINDOW                            700.0kpx  9.1ms
+     17  40x26 @ 8,96 + 40x26 @ 941,632  [box +9186%]  2.1kpx  0.6ms
 ```
 
 `FULL WINDOW` is correct for a resize, a tab switch or anything that changes
 layout — text that re-measures makes the frame full by definition. It is a
 regression anywhere else.
+
+A frame that changed things far apart from each other paints a rect each rather
+than the box around them, and prints them all. `[box +N%]` is how much bigger a
+single box would have been — the Damage panel's "scattered" mode is there to
+produce large numbers for it on purpose.
 
 Wire-level numbers (requests, bytes, `Composite` pixels) are not here on
 purpose: `npm run bench` drives the same paths against an in-process server

--- a/examples/stress/damage.jsx
+++ b/examples/stress/damage.jsx
@@ -12,12 +12,11 @@
 //                 narrowing has regressed.
 //   "one row"     a wide, short rect.
 //   "one column"  a narrow, tall rect.
-//   "scattered"   the *union* of the changed cells, which for cells at
-//                 opposite corners is legitimately the whole grid — that is
-//                 the union being coarse, not a bug. One rect per frame is
-//                 the model (`_damage` is a single rect); a region list is a
-//                 possible future change and this is the case that would
-//                 justify it.
+//   "scattered"   four rects, one per corner cell — not the box around them,
+//                 which would be the whole grid. This mode is what justified
+//                 making `_damage` a list of rects rather than one box; the
+//                 frame log prints each rect and how much bigger a single box
+//                 would have been.
 //   "every cell"  FULL WINDOW, and it should be, which is what makes the
 //                 other rows meaningful.
 //
@@ -74,8 +73,8 @@ function hotCells(mode, n, rows, cols) {
   else if (mode === 'column')
     for (let i = 0; i < rows; i++) hot.add(`${i}:${c}`);
   else if (mode === 'scattered') {
-    // four cells spread to the corners, so the union is close to the grid —
-    // the case that makes a single damage rect look bad, honestly
+    // four cells spread to the corners, so the box around them is the whole
+    // grid and only a list of rects can bound this frame usefully
     hot.add(`0:0`);
     hot.add(`${rows - 1}:${cols - 1}`);
     hot.add(`0:${cols - 1}`);

--- a/examples/stress/perf.js
+++ b/examples/stress/perf.js
@@ -12,16 +12,37 @@
 // come from `npm run bench`, which drives the same paths against an
 // in-process server where a byte count means something reproducible.
 
-const fmt = (damage) =>
-  damage
-    ? `${damage.width}x${damage.height} @ ${damage.x},${damage.y}`
-    : 'FULL WINDOW';
+const fmt = (rects) => {
+  if (!rects) return 'FULL WINDOW';
+  const one = (r) => `${r.width}x${r.height} @ ${r.x},${r.y}`;
+  // A frame paints a list of rects, and the whole point of the list is that it
+  // can be smaller than the box around it — so when there is more than one,
+  // say how much smaller. `+N%` is what a single box would have cost on top.
+  if (rects.length === 1) return one(rects[0]);
+  const area = rects.reduce((sum, r) => sum + r.width * r.height, 0);
+  const box = boxOf(rects);
+  const over = ((box.width * box.height) / area - 1) * 100;
+  return `${rects.map(one).join(' + ')}  [box +${over.toFixed(0)}%]`;
+};
+
+function boxOf(rects) {
+  let { x, y } = rects[0];
+  let right = x + rects[0].width;
+  let bottom = y + rects[0].height;
+  for (const r of rects.slice(1)) {
+    x = Math.min(x, r.x);
+    y = Math.min(y, r.y);
+    right = Math.max(right, r.x + r.width);
+    bottom = Math.max(bottom, r.y + r.height);
+  }
+  return { x, y, width: right - x, height: bottom - y };
+}
 
 /**
  * Wrap a WindowNode's `flush()` to log what each painted frame cost.
  *
  * `flush()` is the whole frame: it runs layout if needed, calls
- * `_takeDamage()` (which leaves the region it settled on in `_lastDamage`,
+ * `_takeDamage()` (which leaves the rects it settled on in `_lastDamageRects`,
  * null meaning "repainted everything") and then paints. Wrapping it catches
  * every repaint however it was triggered — a React commit, a hover, a caret
  * blink — without the app having to cooperate.
@@ -74,22 +95,22 @@ export function watchFrames(root, { label = '', quiet = 0 } = {}) {
     // A headless window has no getContext, so flush bailed before painting.
     if (typeof root.window?.getContext !== 'function') return result;
 
-    const damage = root._lastDamage;
+    const rects = root._lastDamageRects;
     const full = {
       width: root.window.width ?? 0,
       height: root.window.height ?? 0,
     };
-    const area = damage
-      ? damage.width * damage.height
+    const area = rects
+      ? rects.reduce((sum, r) => sum + r.width * r.height, 0)
       : full.width * full.height;
 
     frames += 1;
-    if (!damage) fullFrames += 1;
+    if (!rects) fullFrames += 1;
     totalArea += area;
     totalMs += ms;
 
     if (area >= quiet) {
-      const line = `${fmt(damage)}  ${(area / 1000).toFixed(1)}kpx  ${ms.toFixed(1)}ms`;
+      const line = `${fmt(rects)}  ${(area / 1000).toFixed(1)}kpx  ${ms.toFixed(1)}ms`;
       if (line === lastLine) repeats += 1;
       else {
         flushRepeats();

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^3.10.1",
+        "ntk": "^3.10.2",
         "react-reconciler": "^0.33.0"
       },
       "devDependencies": {
@@ -4679,9 +4679,9 @@
       }
     },
     "node_modules/ntk": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-3.10.1.tgz",
-      "integrity": "sha512-YMlXilqPttOn/D03vli2ypJlXQU8Ri7KL2YQR0nPpvQjhD19MSszcaXG9vEvKq72uNssSB00a4qjtMQjUBeWNg==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-3.10.2.tgz",
+      "integrity": "sha512-mdyncuH3Cg1kOGCM/WJwiXku4oysSRVAUvODLtBuBogvCejHAB3yZLhqP53fnUqre7HbC6OTSyW5fs61NfUFhA==",
       "license": "MIT",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^3.10.1",
+    "ntk": "^3.10.2",
     "react-reconciler": "^0.33.0"
   },
   "peerDependencies": {

--- a/scripts/check-stress.jsx
+++ b/scripts/check-stress.jsx
@@ -12,11 +12,13 @@
 // swallows a render error and the renderer reports it through console.error,
 // so a broken panel looks like an empty panel.
 //
-// The last two checks are the ones with teeth. The Damage panel exists to
-// demonstrate that a commit touching one cell of several hundred repaints one
-// cell; that is checkable here rather than by eye. And "every cell" is checked
-// too, because if *that* also came back bounded the one-cell result would
-// prove nothing.
+// The damage checks at the end are the ones with teeth. The Damage panel exists
+// to demonstrate that a commit touching one cell of several hundred repaints one
+// cell; that is checkable here rather than by eye. "scattered" is checked too,
+// because four cells at the grid's corners are only bounded usefully by a list
+// of rects and this is what notices if that ever collapses back to one box. And
+// "every cell" is checked because if *that* also came back small the other two
+// would prove nothing.
 import { readFileSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
@@ -266,14 +268,37 @@ async function settle(rounds = 4) {
 }
 
 /** Click, let React commit, then paint exactly one frame and report the
- * region it repainted. This is the damage measurement. */
+ * rects it repainted. This is the damage measurement. */
 async function frameAfter(node) {
   click(node);
   await sleep(30);
   root._scheduled = false;
   root.flush();
-  return root._lastDamage;
+  return root._lastDamageRects;
 }
+
+const rectsArea = (rects) =>
+  rects ? rects.reduce((sum, r) => sum + r.width * r.height, 0) : W * H;
+
+const rectsBox = (rects) => {
+  if (!rects) return { width: W, height: H };
+  let x = Infinity;
+  let y = Infinity;
+  let right = -Infinity;
+  let bottom = -Infinity;
+  for (const r of rects) {
+    x = Math.min(x, r.x);
+    y = Math.min(y, r.y);
+    right = Math.max(right, r.x + r.width);
+    bottom = Math.max(bottom, r.y + r.height);
+  }
+  return { width: right - x, height: bottom - y };
+};
+
+const describe = (rects) =>
+  rects
+    ? rects.map((r) => `${r.width}x${r.height}`).join(' + ')
+    : 'FULL WINDOW';
 
 // --- walk the panels -------------------------------------------------------
 
@@ -350,17 +375,55 @@ if (
   // cell change alone.
   await frameAfter(step);
   const one = await frameAfter(step);
-  const oneArea = one ? one.width * one.height : W * H;
+  const oneArea = rectsArea(one);
   realError(
-    `\n  one cell    ${one ? `${one.width}x${one.height}` : 'FULL WINDOW'} — ${(oneArea / 1000).toFixed(1)}kpx`,
+    `\n  one cell    ${describe(one)} — ${(oneArea / 1000).toFixed(1)}kpx`,
   );
   check(
     one && oneArea < (W * H) / 8,
-    `a one-cell change should bound its damage, got ${
-      one ? `${one.width}x${one.height}` : 'FULL WINDOW'
-    } of a ${W}x${H} window`,
+    `a one-cell change should bound its damage, got ${describe(one)} of a ` +
+      `${W}x${H} window`,
   );
 
+  // "scattered" recolours the four corner cells, so the box around them is the
+  // whole grid and only a list of rects can bound the frame usefully. This is
+  // the assertion that a region list is still a region list: if damage ever
+  // collapses back to one box, this frame's area jumps by two orders of
+  // magnitude while every other check in this file still passes.
+  const scattered = labeled('scattered');
+  if (
+    check(
+      scattered,
+      `the "scattered" button is missing; on screen: ${JSON.stringify(
+        labelsOnScreen().slice(0, 20),
+      )}`,
+    )
+  ) {
+    click(scattered);
+    await settle();
+    await frameAfter(labeled('step'));
+    const four = await frameAfter(labeled('step'));
+    const fourArea = rectsArea(four);
+    const box = rectsBox(four);
+    const boxArea = box.width * box.height;
+    realError(
+      `  scattered   ${describe(four)} — ${(fourArea / 1000).toFixed(1)}kpx ` +
+        `(one box would be ${(boxArea / 1000).toFixed(1)}kpx)`,
+    );
+    check(
+      four && four.length > 1,
+      `four cells at the grid's corners should claim several rects, got ` +
+        `${describe(four)}`,
+    );
+    check(
+      fourArea < boxArea / 4,
+      `the rects should be a fraction of the box around them, got ` +
+        `${(fourArea / 1000).toFixed(1)}kpx of ${(boxArea / 1000).toFixed(1)}kpx`,
+    );
+  }
+
+  click(labeled('one cell'));
+  await settle();
   const all = labeled('every cell');
   if (
     check(
@@ -373,9 +436,9 @@ if (
     click(all);
     await settle();
     const every = await frameAfter(labeled('step'));
-    const everyArea = every ? every.width * every.height : W * H;
+    const everyArea = rectsArea(every);
     realError(
-      `  every cell  ${every ? `${every.width}x${every.height}` : 'FULL WINDOW'} — ${(everyArea / 1000).toFixed(1)}kpx`,
+      `  every cell  ${describe(every)} — ${(everyArea / 1000).toFixed(1)}kpx`,
     );
     // The counterpart assertion: if recolouring all 384 cells also came back
     // small, the one-cell number would prove nothing about narrowing.

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -76,7 +76,22 @@ const NO_DAMAGE = Symbol('no-damage');
 // against it.
 const DAMAGE_SLOP = 1;
 
-function unionDamage(a, b) {
+// How many rectangles a frame's damage is allowed to hold.
+//
+// Kept much smaller than the equivalent cap in ntk, because a rectangle costs
+// more here: ntk pays one extra CopyArea per rectangle, while this pays a whole
+// extra pass over the tree — `paintOrder()` allocates and sorts per node — plus
+// a clip. Four is enough for the shapes that actually occur (a ticker and a
+// table row; a control and the status line it updates) and cheap enough that
+// the worst case is not worth avoiding.
+const MAX_DAMAGE_RECTS = 4;
+
+// How much of the box around them several rectangles have to save to be worth
+// painting separately. Two adjacent tab headers describe nearly the same area
+// either way and are better off as one pass; two corners of the window are not.
+const SPLIT_SAVING = 0.75;
+
+function unionRect(a, b) {
   if (!b) return a ?? null;
   if (!a) return { ...b };
   const x = Math.min(a.x, b.x);
@@ -89,6 +104,17 @@ function unionDamage(a, b) {
   };
 }
 
+function rectArea(r) {
+  return Math.max(0, r.width) * Math.max(0, r.height);
+}
+
+/** The box around a non-empty list of rects. */
+function rectsBounds(rects) {
+  let out = rects[0];
+  for (let i = 1; i < rects.length; i++) out = unionRect(out, rects[i]);
+  return out;
+}
+
 /** Do two rects share any area? Touching edges do not count. */
 function rectsOverlap(a, b) {
   return (
@@ -97,6 +123,87 @@ function rectsOverlap(a, b) {
     a.y < b.y + b.height &&
     b.y < a.y + a.height
   );
+}
+
+/**
+ * Merge overlapping rects until none of them overlap.
+ *
+ * Disjointness is not tidiness here, it is correctness. Each rect gets its own
+ * pass over the tree, and a node inside two of them would be painted twice —
+ * harmless for opaque drawing, wrong for anything translucent, which would
+ * blend over itself. Merging removes the question and saves the duplicated
+ * pass at the same time.
+ */
+function coalesceRects(rects) {
+  const out = [];
+  for (const rect of rects) {
+    let merged = rect;
+    for (let i = out.length - 1; i >= 0; i--) {
+      if (!rectsOverlap(out[i], merged)) continue;
+      merged = unionRect(merged, out[i]);
+      out.splice(i, 1);
+      // start the scan again: having grown, the rect can now reach ones
+      // already passed over
+      i = out.length;
+    }
+    out.push(merged);
+  }
+  return out;
+}
+
+/**
+ * Add one rect to a capped, disjoint damage list, returning a new list.
+ *
+ * Over the cap, the pair whose merge wastes the least area is merged — waste
+ * being the area the merged rect covers that neither of the two did, so
+ * neighbours go first and far-apart rects last. That merge can itself overlap a
+ * third rect, so the result is coalesced again.
+ */
+function addDamageRect(rects, add) {
+  let out = coalesceRects(
+    (rects ?? []).concat([
+      { x: add.x, y: add.y, width: add.width, height: add.height },
+    ]),
+  );
+  while (out.length > MAX_DAMAGE_RECTS) {
+    let bestI = 0;
+    let bestJ = 1;
+    let bestWaste = Infinity;
+    for (let i = 0; i < out.length; i++) {
+      for (let j = i + 1; j < out.length; j++) {
+        const waste =
+          rectArea(unionRect(out[i], out[j])) -
+          rectArea(out[i]) -
+          rectArea(out[j]);
+        if (waste < bestWaste) {
+          bestWaste = waste;
+          bestI = i;
+          bestJ = j;
+        }
+      }
+    }
+    const merged = unionRect(out[bestI], out[bestJ]);
+    out = coalesceRects(
+      out.filter((_, k) => k !== bestI && k !== bestJ).concat([merged]),
+    );
+  }
+  return out;
+}
+
+/**
+ * The rects a frame actually paints, given the ones that were claimed.
+ *
+ * Each one costs a pass over the tree and a clip, so a list whose pieces nearly
+ * fill the box around them is better served by one pass over that box. Both
+ * answers cover every claimed pixel, so this is a cost decision and never a
+ * correctness one.
+ */
+function damageToPaint(rects) {
+  if (rects.length < 2) return rects;
+  const box = rectsBounds(rects);
+  let sum = 0;
+  for (const r of rects) sum += rectArea(r);
+  return sum > rectArea(box) * SPLIT_SAVING ? [box] : rects;
 }
 
 /**
@@ -873,7 +980,7 @@ export class Node {
     for (const child of this.children) {
       if (child.isWindow || !child.yoga || child.hidden) continue;
       if (child.style?.display === 'none') continue;
-      bounds = unionDamage(bounds, child._subtreeBounds());
+      bounds = unionRect(bounds, child._subtreeBounds());
     }
     return bounds;
   }
@@ -3315,8 +3422,11 @@ export class WindowNode extends Node {
     else if (!layoutChanged && !damage) this._damage = FULL_DAMAGE;
     else if (this._damage !== FULL_DAMAGE) {
       // a node, or a bare rect for a caller that has a region rather than a
-      // node — a subtree that is about to be removed, say
-      this._damage = unionDamage(
+      // node — a subtree that is about to be removed, say. Claims accumulate
+      // as a list of rects rather than one box around them all, so two changes
+      // at opposite corners of the window no longer repaint everything
+      // between them.
+      this._damage = addDamageRect(
         this._damage,
         damage.paintBounds ? damage.paintBounds() : damage,
       );
@@ -3359,7 +3469,7 @@ export class WindowNode extends Node {
           this._damage =
             this._damage === FULL_DAMAGE
               ? FULL_DAMAGE
-              : unionDamage(this._damage, node.paintBounds());
+              : addDamageRect(this._damage, node.paintBounds());
       }
       this._reflowed.clear();
     } else if (this._reflowed.size) {
@@ -3372,6 +3482,18 @@ export class WindowNode extends Node {
     // ntk getContext creates a fresh context (with window-event
     // subscriptions) on every call — cache one per window
     const ctx = (this._ctx ??= this.window.getContext('2d'));
+    // One pass per damage rect, and a single pass over the whole window when
+    // there is no bound. Each pass clips to one rect rather than to all of
+    // them at once, which is what keeps ntk's server-side rectangular-clip
+    // fast path: a clip path holding several rects is not a rectangle, and
+    // falls back to rasterizing a full-surface mask.
+    for (const rect of damage ?? [null]) {
+      this._paintRegion(ctx, rect, width, height);
+    }
+  }
+
+  /** Repaint one damage rect, or the whole window when `damage` is null. */
+  _paintRegion(ctx, damage, width, height) {
     if (damage) {
       // The clip is belt to the culling's braces: it bounds the server-side
       // mask work for whatever *does* paint, and it contains any node that
@@ -3409,7 +3531,7 @@ export class WindowNode extends Node {
   }
 
   /**
-   * The region this frame will repaint, or null for the whole window.
+   * The rects this frame will repaint, or null for the whole window.
    *
    * Clamped to the window: damage is recorded when a node invalidates, and
    * the window may have been resized since. A region that no longer
@@ -3421,9 +3543,31 @@ export class WindowNode extends Node {
     const damage = this._damage;
     this._damage = null;
     // what the frame about to run settled on, for the tests and for
-    // REACT_X11_DEBUG_LAYOUT to report; null means it repainted everything
+    // REACT_X11_DEBUG_LAYOUT to report; null means it repainted everything.
+    // `_lastDamage` is the box around the rects, which is what a caller
+    // wanting one number for "where did this frame paint" means by it.
     this._lastDamage = null;
+    this._lastDamageRects = null;
     if (damage === FULL_DAMAGE || !damage) return null;
+    const rects = [];
+    for (const claimed of damage) {
+      const clamped = this._clampDamage(claimed, width, height);
+      // one claim covering the window makes the whole frame unbounded, so
+      // there is nothing to learn from the rest of the list
+      if (clamped === FULL_DAMAGE) return null;
+      if (clamped) rects.push(clamped);
+    }
+    if (!rects.length) return null;
+    this._lastDamageRects = damageToPaint(rects);
+    this._lastDamage = rectsBounds(this._lastDamageRects);
+    return this._lastDamageRects;
+  }
+
+  /**
+   * One claimed rect snapped to whole pixels inside the window: null when
+   * nothing of it is left, `FULL_DAMAGE` when it covers the window.
+   */
+  _clampDamage(damage, width, height) {
     const x = Math.max(0, Math.floor(damage.x));
     const y = Math.max(0, Math.floor(damage.y));
     const right = Math.min(width, Math.ceil(damage.x + damage.width));
@@ -3431,9 +3575,10 @@ export class WindowNode extends Node {
     if (right <= x || bottom <= y) return null;
     // covering the window is the same as not being bounded at all, and the
     // full path is one fill instead of a clip plus a fill
-    if (x === 0 && y === 0 && right >= width && bottom >= height) return null;
-    this._lastDamage = { x, y, width: right - x, height: bottom - y };
-    return this._lastDamage;
+    if (x === 0 && y === 0 && right >= width && bottom >= height) {
+      return FULL_DAMAGE;
+    }
+    return { x, y, width: right - x, height: bottom - y };
   }
 
   /** DevTools hover highlight: tint a node's rect on the next paint. */

--- a/test/dirty-rect.test.js
+++ b/test/dirty-rect.test.js
@@ -54,6 +54,12 @@ const readPixels = (ctx, w, h) =>
     ),
   );
 
+// Wait for the server to work through everything sent so far. A test that
+// closes the app with a paint still in flight gets "client is in closing
+// state" out of the blit that follows it.
+const settled = (app) =>
+  new Promise((resolve) => app.X.GetInputFocus(() => resolve()));
+
 /**
  * Mount `element` and hand back the root WindowNode plus the refs given.
  * A ref is the way in: `getPublicInstance` returns the ntk window for
@@ -80,8 +86,9 @@ function differences(a, b) {
 
 /**
  * Apply `change`, paint the frame it asked for, then paint a full frame of
- * the same tree and compare. `damage` is the region the first frame used —
- * null when it repainted everything.
+ * the same tree and compare. `damage` is the box around the region the first
+ * frame used and `rects` the rectangles it actually painted — both null when
+ * it repainted everything.
  */
 async function paintBothWays(app, root, change) {
   const ctx = (root._ctx ??= root.window.getContext('2d'));
@@ -92,6 +99,7 @@ async function paintBothWays(app, root, change) {
   root.flush();
   await settle();
   const damage = root._lastDamage;
+  const rects = root._lastDamageRects;
   const partial = await readPixels(ctx, W, H);
 
   root.needsPaint = true;
@@ -100,7 +108,7 @@ async function paintBothWays(app, root, change) {
   await settle();
   const full = await readPixels(ctx, W, H);
 
-  return { damage, partial, full, diff: differences(partial, full) };
+  return { damage, rects, partial, full, diff: differences(partial, full) };
 }
 
 // Styles are hoisted so a `:hover` block is the only thing that can change
@@ -158,23 +166,168 @@ test('a hover state repaints only that row, with identical pixels', async () => 
   }
 });
 
-test('two hovered rows accumulate into one region spanning both', async () => {
+// --- damage is a list of rects, not the box around them --------------------
+//
+// Two changes far apart used to be claimed as the one rect containing both, so
+// hovering the first and last row of a list repainted the list. They are now
+// kept separate and painted in a pass each, and the rows between them are not
+// touched at all. The list is capped and collapsed back to its box when
+// splitting would not save enough to pay for the extra passes, so the common
+// case — changes near each other — is unchanged.
+
+test('two rows far apart are painted as two rects, not the box around them', async () => {
   const app = await headlessApp();
   try {
     const refs = Array.from({ length: 8 }, () => React.createRef());
     await mount(app, rowsElement(refs));
     const root = refs[0].current.root;
 
-    const { damage, diff } = await paintBothWays(app, root, () => {
+    const { damage, rects, diff } = await paintBothWays(app, root, () => {
       refs[1].current.setStyleState(':hover', true);
       refs[6].current.setStyleState(':hover', true);
     });
 
     assert.ok(damage, 'two paint-only changes still bound the repaint');
+    assert.equal(rects.length, 2, 'one rect per row, not one spanning both');
+    for (const rect of rects) {
+      assert.ok(
+        rect.height <= ROW_H + 2 * SLOP,
+        `each rect is one row tall, got ${rect.height}`,
+      );
+    }
+    // the box around them spans rows 1..6; the rects together are a third of it
     assert.ok(
       damage.height > 4 * ROW_H,
-      `union should span rows 1..6, got height ${damage.height}`,
+      `the box should span rows 1..6, got height ${damage.height}`,
     );
+    const painted = rects.reduce((sum, r) => sum + r.width * r.height, 0);
+    assert.ok(
+      painted < damage.width * damage.height * 0.5,
+      `painted ${painted}px of a ${damage.width * damage.height}px box`,
+    );
+    assert.equal(diff, 0, `${diff} pixels differ from a full repaint`);
+  } finally {
+    await app.close();
+  }
+});
+
+test('the rows between two far-apart changes are not painted', async () => {
+  const app = await headlessApp();
+  try {
+    // The pixel comparisons cannot show this: repainting a row that did not
+    // change produces the same pixels, just at a cost. So count the paints.
+    const refs = Array.from({ length: 8 }, () => React.createRef());
+    await mount(app, rowsElement(refs));
+    const root = refs[0].current.root;
+
+    const painted = new Set();
+    for (const [i, ref] of refs.entries()) {
+      const node = ref.current;
+      const original = node.paint.bind(node);
+      node.paint = (ctx) => {
+        painted.add(i);
+        return original(ctx);
+      };
+    }
+
+    refs[1].current.setStyleState(':hover', true);
+    refs[6].current.setStyleState(':hover', true);
+    root.flush();
+    await settled(app);
+
+    assert.deepEqual(
+      [...painted].sort(),
+      [1, 6],
+      'only the two changed rows should have painted',
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test('two rows near each other collapse into one rect', async () => {
+  const app = await headlessApp();
+  try {
+    const refs = Array.from({ length: 8 }, () => React.createRef());
+    await mount(app, rowsElement(refs));
+    const root = refs[0].current.root;
+
+    // Adjacent rows: two rects of ~20px separated by a 3px gap describe 40px
+    // of the 43px box around them, so a second pass would buy nothing.
+    const { rects, diff } = await paintBothWays(app, root, () => {
+      refs[3].current.setStyleState(':hover', true);
+      refs[4].current.setStyleState(':hover', true);
+    });
+
+    assert.equal(rects.length, 1, 'not worth splitting');
+    assert.ok(
+      rects[0].height <= 2 * ROW_H + 3 + 2 * SLOP,
+      `both rows and the gap, got ${rects[0].height}`,
+    );
+    assert.equal(diff, 0, `${diff} pixels differ from a full repaint`);
+  } finally {
+    await app.close();
+  }
+});
+
+test('overlapping claims are merged, so no node is painted twice', async () => {
+  const app = await headlessApp();
+  try {
+    // Two rects sharing area would put a node in the overlap through two
+    // passes. That is invisible for opaque drawing and wrong for anything
+    // translucent, which would blend over itself — so they have to merge.
+    const refs = Array.from({ length: 8 }, () => React.createRef());
+    await mount(app, rowsElement(refs));
+    const root = refs[0].current.root;
+
+    root.invalidate(false, { x: 20, y: 20, width: 60, height: 60 });
+    root.invalidate(false, { x: 50, y: 50, width: 60, height: 60 });
+
+    assert.equal(root._damage.length, 1, 'the two claims merged');
+    assert.deepEqual(root._damage[0], { x: 20, y: 20, width: 90, height: 90 });
+    root.flush(); // consume the frame these claims scheduled, before closing
+    await settled(app);
+  } finally {
+    await app.close();
+  }
+});
+
+test('the number of rects stays capped, however many rows change', async () => {
+  const app = await headlessApp();
+  try {
+    const refs = Array.from({ length: 8 }, () => React.createRef());
+    await mount(app, rowsElement(refs));
+    const root = refs[0].current.root;
+
+    // every other row: more separate regions than the cap allows
+    const { rects, diff } = await paintBothWays(app, root, () => {
+      for (const i of [0, 2, 4, 6])
+        refs[i].current.setStyleState(':hover', true);
+      refs[7].current.setStyleState(':hover', true);
+    });
+
+    assert.ok(rects, 'still bounded');
+    assert.ok(rects.length <= 4, `at most the cap, got ${rects.length}`);
+    assert.equal(diff, 0, `${diff} pixels differ from a full repaint`);
+  } finally {
+    await app.close();
+  }
+});
+
+test('a claim covering the window gives up the bound entirely', async () => {
+  const app = await headlessApp();
+  try {
+    const refs = Array.from({ length: 8 }, () => React.createRef());
+    await mount(app, rowsElement(refs));
+    const root = refs[0].current.root;
+
+    const { damage, rects, diff } = await paintBothWays(app, root, () => {
+      refs[2].current.setStyleState(':hover', true);
+      root.invalidate(false, { x: -10, y: -10, width: W + 20, height: H + 20 });
+    });
+
+    assert.equal(damage, null, 'no point clipping to the whole window');
+    assert.equal(rects, null);
     assert.equal(diff, 0, `${diff} pixels differ from a full repaint`);
   } finally {
     await app.close();

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -100,11 +100,15 @@ this layer does:
   glyph pages — is cached instead of asked for again.
 
 The consequence is that an update's cost tracks the _drawing it implies_,
-not the window's area. Repaints today are whole-window, coalesced onto ntk's
-frame clock (dirty-rect painting is on the roadmap), but a whole-window
-repaint of a real UI is a few dozen batched operations, not a framebuffer —
-which is why a react-x11 program stays comfortable on a display forwarded
-over ssh, where shipping frames would not be.
+not the window's area. Repaints are coalesced onto ntk's frame clock and
+bounded to the region that changed — a short list of rectangles, so two
+changes at opposite corners of the window do not drag everything between them
+along — and any subtree that does not reach into that region is skipped
+before a single request goes out. A layout change is still a full repaint,
+because a node that moved leaves stale pixels where it used to be; even then a
+whole-window repaint of a real UI is a few dozen batched operations, not a
+framebuffer, which is why a react-x11 program stays comfortable on a display
+forwarded over ssh, where shipping frames would not be.
 
 Because that is the design, it is also measured rather than assumed:
 `npm run bench` reports requests, bytes, replies, RENDER composites and


### PR DESCRIPTION
The last structural item in the dirty-rect work. Damage was a single rect on both sides — the renderer's `_damage` and ntk's presented region — so two small changes at opposite corners cost everything between them. This is the renderer half; sidorares/ntk#112 is the other.

`_damage` is now a short list of rects, and a frame paints a pass per rect.

### Why each pass clips to one rect and not to all of them

This is the part that shaped the design rather than falling out of it. ntk's server-side clip fast path (sidorares/ntk#107) only recognises a single axis-aligned rectangle; a clip path holding several is not a rectangle, so it falls back to rasterizing a full-surface a8 mask *per clip* — exactly the cost #107 removed. So the frame pushes one rect per pass. A pleasant consequence: `_paintDamage` stays a single rect and the culling in `_outsideDamage()` needs no change at all.

### Overlapping rects are merged, and that is correctness

A node inside two damage rects would go through two passes. That is invisible for opaque drawing and wrong for anything translucent — the second pass would blend over the first. So the list is kept pairwise disjoint: adding a rect merges it into any it overlaps, to a fixed point, and the cap-merge below re-coalesces because merging two rects can create an overlap with a third.

### The cap, and when splitting is worth it

Capped at **four**, against ntk's eight, because a rect costs more here: ntk pays an extra `CopyArea`, this pays a whole extra pass over the tree (`paintOrder()` allocates and sorts per node) plus a clip. Past the cap the pair whose merge wastes the least area is merged.

And a list whose rects nearly fill the box around them collapses back to the box before anything is painted — under `SPLIT_SAVING`, a split has to save a quarter of its box to be worth a second pass. So hovering two adjacent tab headers costs exactly what it did before this change. Both answers cover every claimed pixel, which makes the collapse a cost decision and never a correctness one.

### Measured

Stress app's Damage panel, against the in-process pure-JS X server, five commits per scenario. The "scattered" mode — four cells at the corners of a 24x16 grid — exists for precisely this case; its comment used to say a region list "is a possible future change and this is the case that would justify it", and this PR updates it.

| scenario | painted before | painted after |
| --- | --- | --- |
| four cells at the grid's corners | 2508 kpx | **51 kpx** |
| every cell in the grid | 2508 kpx | 2508 kpx |
| hover two adjacent tab headers | 33 kpx | 33 kpx |

Row two is what makes row one mean something: damage that genuinely covers the grid still costs the grid. Row three is the collapse rule declining a split that would not pay. Per frame, the scattered case is a 483 kpx box replaced by 5.2 kpx of rects.

With ntk#112 installed the blits track the painted area exactly (20 blits, 51 kpx), and the window still matches the backing store pixel for pixel afterwards — 0 differ — which is what would catch painting or copying too little.

### Tests

Six new tests in `test/dirty-rect.test.js`, including one that counts node paints to show the rows *between* two far-apart changes are not painted at all, which the existing pixel comparisons cannot see: repainting an unchanged row produces identical pixels, just at a cost.

Each verified non-vacuous by planting the corresponding fault and confirming exactly the expected test fails — cap removed, always collapse, never collapse, coalescing disabled, the window-covering claim no longer giving up the bound, and only the first rect painted. That last one is the dangerous direction, and it is caught by the pixel-equality check every test in the file already runs.

247 tests pass; lint, typecheck and both font passes of `npm run stress:check` are clean. `npm run bench` matches baseline apart from the `inside a rect clip` scenario, which flaps between 40 and 43 requests — confirmed pre-existing by running five iterations on each side of the change (2/5 and 1/5 at 43).

### ntk 3.10.2 is in, so this is complete end to end

ntk#112 merged and 3.10.2 is published, carrying both halves of the presentation work (#110's rect-level present and #112's region list). The dependency is bumped in this branch and everything above was re-measured against the published package rather than a hand-assembled `lib/` — same numbers: scattered paints **and blits** 51 kpx where a box costs 2508, every cell still costs 2508, window matches the backing store pixel for pixel.

The floor moves to `^3.10.2` because that is where the two halves match, not for an API. Against 3.10.1 the region list still computed and painted correctly; it just could not be blitted as one.

### Two follow-ons in the same branch

- **`npm run stress:check` now guards this.** It asserted one-changed-cell and every-changed-cell, and neither notices if damage stops being a list — both are single-rect cases either way. It now drives "scattered" too and checks the frame claims several rects totalling a fraction of their box (5.2 kpx against 483 kpx). Verified by planting the collapse: those two checks fail and every other check in the file still passes, which is exactly the blind spot they close.
- **`website/docs/intro.md` still told readers repaints were whole-window** and that dirty-rect painting was on the roadmap. That stopped being true at #100; it now describes what actually happens, including that a layout change is still a full repaint and why.

