### PR TITLE
feat!: ntk 4, so a mermaid fence is a code block

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,8 @@ no override-redirect staging (issue #4).
   `<svg>`, `<tex>`) wrapping ntk's document widgets in standalone mode:
   the widget's `layout(width)`/`contentHeight` feeds a yoga measure
   function, `draw(ctx, x, y)` paints, `onInvalidate` (ntk ≥ 3.4.0)
-  reflows on async content (mermaid, images).
+  reflows on async content (HtmlView images and SVGs; MarkdownView is
+  synchronous).
 - `src/components/` — the widget set, plain React over the host
   primitives (no reconciler support needed). One module per widget, with
   the shared plumbing in `theme.js` (palette, `useTheme`, `useControl`),

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -44,12 +44,11 @@ Shipped in `src/richnodes.js`: `<markdown>`,
 mode — `layout(width)`/`contentHeight` feed a yoga measure function,
 `draw(ctx, x, y)` paints into the window context, `linkAt` is wired into
 the mousedown default action (`onLink` prop), and `<scrollview>` wrapping
-works via the normal measured-height path. Async content (mermaid models,
-HTML images) reflows through the widgets' `onInvalidate` hook —
-implemented upstream as sidorares/ntk#75, released in **ntk 3.4.0**
-(the dependency is bumped). `<mermaid>` needs no dedicated element
-(markdown fences cover it); `<paragraph>` stays out (see below —
-maxLines/ellipsis would be a TextLayout feature first).
+works via the normal measured-height path. Async content (HTML images)
+reflows through the widgets' `onInvalidate` hook — implemented upstream as
+sidorares/ntk#75, released in **ntk 3.4.0** (the dependency is bumped).
+`<paragraph>` stays out (see below — maxLines/ellipsis would be a
+TextLayout feature first).
 
 Left for later: per-link pointer cursor (cursor is per-node today),
 `<tex>` baseline alignment with surrounding `<text>`.
@@ -250,8 +249,8 @@ react-nodegui, react-native-gtk4, React Native Fabric, react-three-fiber,
   - Per-window frame clock: event coalescing (mousemove=last, expose=union),
     fence-based server sync, `requestAnimationFrame`, double-buffered backing
     store — `lib/window.js`.
-  - Document widgets: `HtmlView`, `MarkdownView`, `SvgView`, `TexView`,
-    mermaid — all windowless, with a standalone `layout(width)` +
+  - Document widgets: `HtmlView`, `MarkdownView`, `SvgView`, `TexView` —
+    all windowless, with a standalone `layout(width)` +
     `draw(ctx, x, y)` mode that makes them embeddable.
   - An in-process pure-JS X server (in node-x11) with XRender — hermetic
     tests with pixel readback, no `$DISPLAY` (already used by
@@ -469,7 +468,7 @@ primitives — they need no reconciler support once focus/hover/events exist):
   over ntk's widgets in standalone mode (`layout(width)` +
   `draw(ctx, x, y)` + `contentHeight` slots directly into a yoga measure
   function). Needs `onInvalidate` (already in ntk's source repo for
-  markdown/mermaid async content — must be in the next published version).
+  HtmlView async content — must be in the next published version).
 
 Deliberately out of scope for now: accessibility (AT-SPI), IME/compose input,
 Wayland.
@@ -595,10 +594,13 @@ menus/tooltips.
 - Should the widget set (Phase 2/3) live in this package or a
   `@react-x11/widgets` sibling once primitives stabilize?
 - Where do the rich-content formats belong — ntk, here, or their own module?
-  ANSWERED in [RICH_CONTENT.md](RICH_CONTENT.md): mostly stay in ntk, mermaid
-  extracts (89 MB of the 116 MB dependency closure), and selectable text needs
-  one read-only ntk accessor rather than a rewrite. That doc supersedes the
-  "left for later" note in §1 and adds three ntk items to §8.
+  Analysed in [RICH_CONTENT.md](RICH_CONTENT.md); the decision and the staged
+  plan live in [sidorares/ntk#106](https://github.com/sidorares/ntk/issues/106).
+  Mermaid is **dropped outright** rather than extracted — it was 155 MB of
+  install closure for a grammar. html and markdown move here behind subpath
+  exports; svg and tex stay in ntk. Selectable text still needs one read-only
+  ntk accessor rather than a rewrite. That supersedes the "left for later"
+  note in §1 and adds items to §8.
 - ESM migration here (ntk is ESM-with-TLA; the dynamic-import dance in
   `src/Reconciler.js` disappears if react-x11 goes ESM).
 

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -9,10 +9,11 @@
 > Since then: a **documentation site** with react-x11 running in the browser
 > (#92), and a right-click edit menu for the text controls (#90).
 >
-> Upstream, all released: **ntk 3.9.0** on **node-x11 (x11) 3.3.0**. Between
+> Upstream, all released: **ntk 4.0.0** on **node-x11 (x11) 3.3.0**. Between
 > them they carry the window-manager surface, focus events, clipboard,
-> cursors, the ~10x faster software RENDER compositor, and the RENDER colour
-> guard.
+> cursors, the ~10x faster software RENDER compositor, the RENDER colour
+> guard, and region-based damage. ntk 4 dropped mermaid — see
+> [sidorares/ntk#106](https://github.com/sidorares/ntk/issues/106).
 >
 > **Published npm version is 1.2.0**; release-please **PR #69 is 2.0.0**,
 > holding the breaking change from #68 (style is the only style channel).

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ and [docs/](docs/README.md) for the full API reference.
 | `<textinput>`  | single-line editor: caret/selection via ntk's TextLayout caret API, clipboard (CLIPBOARD + X11 PRIMARY), word select, undo/redo, right-click menu |
 | `<image>`      | PNG/JPEG from `src`, natural-size aware                                                                                                           |
 | `<canvas>`     | escape hatch: `onDraw={(ctx, {width, height}) => …}` with ntk's canvas-like 2d context (XRender-backed)                                           |
-| `<markdown>`   | ntk MarkdownView: headings, tables, highlighted fences, math, mermaid; `onLink`                                                                   |
+| `<markdown>`   | ntk MarkdownView: headings, tables, highlighted fences, math; `onLink`                                                                            |
 | `<html>`       | ntk HtmlView: CSS cascade, block/flex layout, images; `onLink`                                                                                    |
 | `<svg>`        | static SVG through ntk SvgView, sized like `<image>`                                                                                              |
 | `<tex>`        | a KaTeX formula (ntk `layoutTex`), intrinsically sized                                                                                            |

--- a/RICH_CONTENT.md
+++ b/RICH_CONTENT.md
@@ -1,5 +1,17 @@
 # Where rich content belongs: ntk, react-x11, or a module of its own
 
+> **Status: this is the analysis, not the decision.** The decision and the
+> staged plan live in
+> [sidorares/ntk#106](https://github.com/sidorares/ntk/issues/106). It
+> diverges from the recommendation below on three points: **mermaid is
+> dropped outright** rather than extracted to a module, `<html>` and
+> `<markdown>` **do move here** behind subpath exports once the provider
+> weight is gone, and `<tex>` and `<svg>` stay in ntk. The measurements in
+> this document still hold, and re-measuring in isolated install trees put
+> mermaid's own closure at 155 MB rather than the 89 MB reported here — the
+> difference is what npm hoisting hides. Mermaid removal shipped as
+> sidorares/ntk#113.
+
 `<tex>`, `<svg>`, `<markdown>`, `<html>` and mermaid fences are all
 implemented in ntk today and wrapped by `src/richnodes.js`. This document
 weighs three outcomes for each — **(1)** leave in ntk, **(2)** reimplement

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -544,9 +544,9 @@ offers, the element reports the document's content height — so rich content
 participates in flex layout and scrolls naturally inside a `<scrollview>`.
 Spacing comes from the box model (`padding` prop), not a widget page margin.
 
-Async content (a ` ```mermaid ` fence, an `<img>`) reflows when it
-arrives via ntk's `onInvalidate` widget hook (ntk ≥ 3.4.0 — the declared
-dependency).
+Async content — an `<img>` inside `<html>` — reflows when it arrives via
+ntk's `onInvalidate` widget hook (ntk ≥ 3.4.0 — the declared dependency).
+`<markdown>` lays out synchronously and never needs a second pass.
 
 `<markdown>`, `<html>` and `<tex>` take their content as a **string
 child** (the react-markdown convention) or a `source` prop; the child
@@ -564,8 +564,7 @@ Some *markdown*.
 ### `<markdown>`
 
 ntk `MarkdownView`: headings, emphasis, lists, quotes, tables,
-syntax-highlighted code fences, `math`/`latex` fences (KaTeX), `mermaid`
-fences (flowchart/sequence, async).
+syntax-highlighted code fences, `math`/`latex` fences (KaTeX).
 
 | prop               |                                                                                 |
 | ------------------ | ------------------------------------------------------------------------------- |

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -545,8 +545,9 @@ participates in flex layout and scrolls naturally inside a `<scrollview>`.
 Spacing comes from the box model (`padding` prop), not a widget page margin.
 
 Async content — an `<img>` inside `<html>` — reflows when it arrives via
-ntk's `onInvalidate` widget hook (ntk ≥ 3.4.0 — the declared dependency).
-`<markdown>` lays out synchronously and never needs a second pass.
+ntk's `onInvalidate` widget hook (added in ntk 3.4.0; the declared
+dependency is ntk 4). `<markdown>` lays out synchronously and never needs a
+second pass.
 
 `<markdown>`, `<html>` and `<tex>` take their content as a **string
 child** (the react-markdown convention) or a `source` prop; the child

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,24 +16,24 @@ tests can import them without opening a window.
 
 Roughly in the order worth reading them:
 
-|                                      |                                                                                              |
-| ------------------------------------ | -------------------------------------------------------------------------------------------- |
-| [`simple.jsx`](simple.jsx)           | hello world: flex layout and text, no pixel math. `npm run examples:simple`                  |
-| [`simple-nojsx.js`](simple-nojsx.js) | the same thing in plain node with `React.createElement` — no build step at all               |
-| [`xeyes.jsx`](xeyes.jsx)             | the `<canvas>` escape hatch: custom drawing plus hooks for state and polling                 |
-| [`dashboard.jsx`](dashboard.jsx)     | context for theming, `useState`/`useEffect`/`useMemo`, a custom hook, hover and focus states |
-| [`tasks.jsx`](tasks.jsx)             | `useReducer`, dispatch through context, list rendering, `<scrollview>`, keyboard throughout  |
-| [`form.jsx`](form.jsx)               | `<textinput>`, `Select`, `RadioGroup`, `Slider`, `Checkbox`, and a modal `Dialog`            |
-| [`widgets.jsx`](widgets.jsx)         | the gallery: every standard component in one window, with a live `<markdown>` preview        |
-| [`menu.jsx`](menu.jsx)               | `MenuBar` and `ContextMenu` over real `<popup>` windows that flip at screen edges            |
-| [`theming.jsx`](theming.jsx)         | the style engine end to end: three themes in light and dark, switched at runtime             |
-| [`richtext.jsx`](richtext.jsx)       | `<markdown>` with mermaid and math, a live `<tex>` formula, JSX `<svg>`, `<image>`           |
-| [`windows.jsx`](windows.jsx)         | many top-level windows from one React tree, sharing state, closing via `onCloseRequest`      |
-| [`app.jsx`](app.jsx)                 | the showcase: `SplitPane` + `Tabs` hosting `form`, `widgets` and `tasks` as panels           |
-| [`gl.jsx`](gl.jsx)                   | raw GL in a `<glarea>`, compiled to a server-side display list                               |
-| [`three.jsx`](three.jsx)             | a react-three-fiber-shaped `<Canvas3D>` scene: meshes, lights, textures                      |
-| [`stress/`](stress/index.jsx)        | **the big one**: six panels to poke at by hand, with a frame log — see below                 |
-| [`wm.jsx`](wm.jsx)                   | **a reparenting window manager** — see below                                                 |
+|                                      |                                                                                               |
+| ------------------------------------ | --------------------------------------------------------------------------------------------- |
+| [`simple.jsx`](simple.jsx)           | hello world: flex layout and text, no pixel math. `npm run examples:simple`                   |
+| [`simple-nojsx.js`](simple-nojsx.js) | the same thing in plain node with `React.createElement` — no build step at all                |
+| [`xeyes.jsx`](xeyes.jsx)             | the `<canvas>` escape hatch: custom drawing plus hooks for state and polling                  |
+| [`dashboard.jsx`](dashboard.jsx)     | context for theming, `useState`/`useEffect`/`useMemo`, a custom hook, hover and focus states  |
+| [`tasks.jsx`](tasks.jsx)             | `useReducer`, dispatch through context, list rendering, `<scrollview>`, keyboard throughout   |
+| [`form.jsx`](form.jsx)               | `<textinput>`, `Select`, `RadioGroup`, `Slider`, `Checkbox`, and a modal `Dialog`             |
+| [`widgets.jsx`](widgets.jsx)         | the gallery: every standard component in one window, with a live `<markdown>` preview         |
+| [`menu.jsx`](menu.jsx)               | `MenuBar` and `ContextMenu` over real `<popup>` windows that flip at screen edges             |
+| [`theming.jsx`](theming.jsx)         | the style engine end to end: three themes in light and dark, switched at runtime              |
+| [`richtext.jsx`](richtext.jsx)       | `<markdown>` with highlighted and math fences, a live `<tex>` formula, JSX `<svg>`, `<image>` |
+| [`windows.jsx`](windows.jsx)         | many top-level windows from one React tree, sharing state, closing via `onCloseRequest`       |
+| [`app.jsx`](app.jsx)                 | the showcase: `SplitPane` + `Tabs` hosting `form`, `widgets` and `tasks` as panels            |
+| [`gl.jsx`](gl.jsx)                   | raw GL in a `<glarea>`, compiled to a server-side display list                                |
+| [`three.jsx`](three.jsx)             | a react-three-fiber-shaped `<Canvas3D>` scene: meshes, lights, textures                       |
+| [`stress/`](stress/index.jsx)        | **the big one**: six panels to poke at by hand, with a frame log — see below                  |
+| [`wm.jsx`](wm.jsx)                   | **a reparenting window manager** — see below                                                  |
 
 `app.jsx` is where a new control should get demonstrated: it imports the
 panel each of `form`, `widgets` and `tasks` exports, so adding a widget

--- a/examples/richtext.jsx
+++ b/examples/richtext.jsx
@@ -1,4 +1,4 @@
-// Rich content elements: <markdown> (with mermaid + math fences) in a
+// Rich content elements: <markdown> (with highlighted + math fences) in a
 // scrollview, a live-updating <tex> formula, a declarative JSX <svg> and an
 // <image> — all drawn client-side through ntk's document widgets and image
 // pipeline. Run with: npm run examples:richtext  (needs an X server)
@@ -29,18 +29,6 @@ root.render(<markdown onLink={openBrowser}>{README}</markdown>);
 
 \`\`\`math
 \\int_{-\\infty}^{\\infty} e^{-x^2}\\,dx = \\sqrt{\\pi}
-\`\`\`
-
-## Mermaid
-
-Parses asynchronously; the element reflows when the model arrives
-(ntk's \`onInvalidate\` hook):
-
-\`\`\`mermaid
-flowchart LR
-  A[React tree] --> B[retained nodes]
-  B --> C[yoga layout]
-  C --> D((XRender))
 \`\`\`
 
 ## Tables & links

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^3.10.2",
+        "ntk": "^4.0.0",
         "react-reconciler": "^0.33.0"
       },
       "devDependencies": {
@@ -34,19 +34,6 @@
       },
       "peerDependencies": {
         "react": "^19.0.0"
-      }
-    },
-    "node_modules/@antfu/install-pkg": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
-      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
-      "license": "MIT",
-      "dependencies": {
-        "package-manager-detector": "^1.3.0",
-        "tinyexec": "^1.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -376,33 +363,6 @@
       "engines": {
         "node": "^22.18.0 || >=24.11.0"
       }
-    },
-    "node_modules/@braintree/sanitize-url": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
-      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
-      "license": "MIT"
-    },
-    "node_modules/@chevrotain/types": {
-      "version": "11.1.2",
-      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
-      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/@dagrejs/dagre": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-3.0.0.tgz",
-      "integrity": "sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@dagrejs/graphlib": "4.0.1"
-      }
-    },
-    "node_modules/@dagrejs/graphlib": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-4.0.1.tgz",
-      "integrity": "sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==",
-      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.28.1",
@@ -1069,23 +1029,6 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
-    "node_modules/@iconify/types": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
-      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
-      "license": "MIT"
-    },
-    "node_modules/@iconify/utils": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.4.tgz",
-      "integrity": "sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==",
-      "license": "MIT",
-      "dependencies": {
-        "@antfu/install-pkg": "^1.1.0",
-        "@iconify/types": "^2.0.0",
-        "import-meta-resolve": "^4.2.0"
-      }
-    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1125,15 +1068,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@mermaid-js/parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
-      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
-      "license": "MIT",
-      "dependencies": {
-        "@chevrotain/types": "~11.1.2"
-      }
-    },
     "node_modules/@swc/helpers": {
       "version": "0.5.23",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
@@ -1141,259 +1075,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@types/d3": {
-      "version": "7.4.3",
-      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
-      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-array": "*",
-        "@types/d3-axis": "*",
-        "@types/d3-brush": "*",
-        "@types/d3-chord": "*",
-        "@types/d3-color": "*",
-        "@types/d3-contour": "*",
-        "@types/d3-delaunay": "*",
-        "@types/d3-dispatch": "*",
-        "@types/d3-drag": "*",
-        "@types/d3-dsv": "*",
-        "@types/d3-ease": "*",
-        "@types/d3-fetch": "*",
-        "@types/d3-force": "*",
-        "@types/d3-format": "*",
-        "@types/d3-geo": "*",
-        "@types/d3-hierarchy": "*",
-        "@types/d3-interpolate": "*",
-        "@types/d3-path": "*",
-        "@types/d3-polygon": "*",
-        "@types/d3-quadtree": "*",
-        "@types/d3-random": "*",
-        "@types/d3-scale": "*",
-        "@types/d3-scale-chromatic": "*",
-        "@types/d3-selection": "*",
-        "@types/d3-shape": "*",
-        "@types/d3-time": "*",
-        "@types/d3-time-format": "*",
-        "@types/d3-timer": "*",
-        "@types/d3-transition": "*",
-        "@types/d3-zoom": "*"
-      }
-    },
-    "node_modules/@types/d3-array": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
-      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-axis": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
-      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "node_modules/@types/d3-brush": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
-      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "node_modules/@types/d3-chord": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
-      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-color": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
-      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-contour": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
-      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-array": "*",
-        "@types/geojson": "*"
-      }
-    },
-    "node_modules/@types/d3-delaunay": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-dispatch": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
-      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-drag": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
-      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "node_modules/@types/d3-dsv": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
-      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-ease": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
-      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-fetch": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
-      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-dsv": "*"
-      }
-    },
-    "node_modules/@types/d3-force": {
-      "version": "3.0.10",
-      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
-      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-format": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
-      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-geo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
-      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/geojson": "*"
-      }
-    },
-    "node_modules/@types/d3-hierarchy": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
-      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-interpolate": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
-      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-color": "*"
-      }
-    },
-    "node_modules/@types/d3-path": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
-      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-polygon": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
-      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-quadtree": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
-      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-random": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.4.tgz",
-      "integrity": "sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-scale": {
-      "version": "4.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
-      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-time": "*"
-      }
-    },
-    "node_modules/@types/d3-scale-chromatic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
-      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-selection": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
-      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-shape": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
-      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-path": "*"
-      }
-    },
-    "node_modules/@types/d3-time": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
-      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-time-format": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
-      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-timer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
-      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
-      "license": "MIT"
-    },
-    "node_modules/@types/d3-transition": {
-      "version": "3.0.9",
-      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
-      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-selection": "*"
-      }
-    },
-    "node_modules/@types/d3-zoom": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
-      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/d3-interpolate": "*",
-        "@types/d3-selection": "*"
       }
     },
     "node_modules/@types/estree": {
@@ -1408,12 +1089,6 @@
       "resolved": "https://registry.npmjs.org/@types/gensync/-/gensync-1.0.5.tgz",
       "integrity": "sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/geojson": {
-      "version": "7946.0.16",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
-      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
     "node_modules/@types/jsesc": {
@@ -1438,23 +1113,6 @@
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
-      }
-    },
-    "node_modules/@types/trusted-types": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
-      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@upsetjs/venn.js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
-      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
-      "license": "MIT",
-      "optionalDependencies": {
-        "d3-selection": "^3.0.0",
-        "d3-transition": "^3.0.1"
       }
     },
     "node_modules/acorn": {
@@ -1973,15 +1631,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cose-base": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
-      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
-      "license": "MIT",
-      "dependencies": {
-        "layout-base": "^1.0.0"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2037,514 +1686,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/cytoscape": {
-      "version": "3.34.0",
-      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
-      "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10"
-      }
-    },
-    "node_modules/cytoscape-cose-bilkent": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
-      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "cose-base": "^1.0.0"
-      },
-      "peerDependencies": {
-        "cytoscape": "^3.2.0"
-      }
-    },
-    "node_modules/cytoscape-fcose": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
-      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "cose-base": "^2.2.0"
-      },
-      "peerDependencies": {
-        "cytoscape": "^3.2.0"
-      }
-    },
-    "node_modules/cytoscape-fcose/node_modules/cose-base": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
-      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
-      "license": "MIT",
-      "dependencies": {
-        "layout-base": "^2.0.0"
-      }
-    },
-    "node_modules/cytoscape-fcose/node_modules/layout-base": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
-      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
-      "license": "MIT"
-    },
-    "node_modules/d3": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
-      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "3",
-        "d3-axis": "3",
-        "d3-brush": "3",
-        "d3-chord": "3",
-        "d3-color": "3",
-        "d3-contour": "4",
-        "d3-delaunay": "6",
-        "d3-dispatch": "3",
-        "d3-drag": "3",
-        "d3-dsv": "3",
-        "d3-ease": "3",
-        "d3-fetch": "3",
-        "d3-force": "3",
-        "d3-format": "3",
-        "d3-geo": "3",
-        "d3-hierarchy": "3",
-        "d3-interpolate": "3",
-        "d3-path": "3",
-        "d3-polygon": "3",
-        "d3-quadtree": "3",
-        "d3-random": "3",
-        "d3-scale": "4",
-        "d3-scale-chromatic": "3",
-        "d3-selection": "3",
-        "d3-shape": "3",
-        "d3-time": "3",
-        "d3-time-format": "4",
-        "d3-timer": "3",
-        "d3-transition": "3",
-        "d3-zoom": "3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-array": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
-      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
-      "license": "ISC",
-      "dependencies": {
-        "internmap": "1 - 2"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-axis": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
-      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-brush": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
-      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-drag": "2 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-selection": "3",
-        "d3-transition": "3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-chord": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
-      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-path": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-color": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
-      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-contour": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
-      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-delaunay": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
-      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
-      "license": "ISC",
-      "dependencies": {
-        "delaunator": "5"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-dispatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
-      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-drag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
-      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-selection": "3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-dsv": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
-      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
-      "license": "ISC",
-      "dependencies": {
-        "commander": "7",
-        "iconv-lite": "0.6",
-        "rw": "1"
-      },
-      "bin": {
-        "csv2json": "bin/dsv2json.js",
-        "csv2tsv": "bin/dsv2dsv.js",
-        "dsv2dsv": "bin/dsv2dsv.js",
-        "dsv2json": "bin/dsv2json.js",
-        "json2csv": "bin/json2dsv.js",
-        "json2dsv": "bin/json2dsv.js",
-        "json2tsv": "bin/json2dsv.js",
-        "tsv2csv": "bin/dsv2dsv.js",
-        "tsv2json": "bin/dsv2json.js"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-dsv/node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/d3-ease": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
-      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-fetch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
-      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-dsv": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-force": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
-      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-quadtree": "1 - 3",
-        "d3-timer": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-format": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
-      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-geo": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
-      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2.5.0 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-hierarchy": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
-      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-interpolate": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
-      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
-      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-polygon": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
-      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-quadtree": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
-      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-random": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
-      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-sankey": {
-      "version": "0.12.3",
-      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
-      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-array": "1 - 2",
-        "d3-shape": "^1.2.0"
-      }
-    },
-    "node_modules/d3-sankey/node_modules/d3-array": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
-      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "internmap": "^1.0.0"
-      }
-    },
-    "node_modules/d3-sankey/node_modules/d3-path": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
-      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-sankey/node_modules/d3-shape": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
-      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-path": "1"
-      }
-    },
-    "node_modules/d3-sankey/node_modules/internmap": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
-      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
-      "license": "ISC"
-    },
-    "node_modules/d3-scale": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
-      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2.10.0 - 3",
-        "d3-format": "1 - 3",
-        "d3-interpolate": "1.2.0 - 3",
-        "d3-time": "2.1.1 - 3",
-        "d3-time-format": "2 - 4"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-scale-chromatic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
-      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3",
-        "d3-interpolate": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-selection": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-shape": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
-      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-path": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
-      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-array": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-time-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
-      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-time": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-timer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
-      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/d3-transition": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
-      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-color": "1 - 3",
-        "d3-dispatch": "1 - 3",
-        "d3-ease": "1 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-timer": "1 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "d3-selection": "2 - 3"
-      }
-    },
-    "node_modules/d3-zoom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
-      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
-      "license": "ISC",
-      "dependencies": {
-        "d3-dispatch": "1 - 3",
-        "d3-drag": "2 - 3",
-        "d3-interpolate": "1 - 3",
-        "d3-selection": "2 - 3",
-        "d3-transition": "2 - 3"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/dagre-d3-es": {
-      "version": "7.0.14",
-      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
-      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
-      "license": "MIT",
-      "dependencies": {
-        "d3": "^7.9.0",
-        "lodash-es": "^4.17.21"
-      }
-    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -2598,12 +1739,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/dayjs": {
-      "version": "1.11.21",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
-      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
-      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2664,15 +1799,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/delaunator": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
-      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
-      "license": "ISC",
-      "dependencies": {
-        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/dfa": {
@@ -2741,15 +1867,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
-      "license": "(MPL-2.0 OR Apache-2.0)",
-      "optionalDependencies": {
-        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/domutils": {
@@ -3012,17 +2129,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es-toolkit": {
-      "version": "1.50.0",
-      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
-      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
-      "license": "MIT",
-      "workspaces": [
-        "docs",
-        "benchmarks",
-        "tests/types"
-      ]
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -3589,12 +2695,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/hachure-fill": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
-      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
-      "license": "MIT"
-    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -3736,18 +2836,6 @@
         "node": ">=20.19.0"
       }
     },
-    "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3779,6 +2867,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
       "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3808,15 +2897,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/internmap": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
-      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -4396,17 +3476,6 @@
         "json-buffer": "3.0.1"
       }
     },
-    "node_modules/khroma": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
-      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
-    },
-    "node_modules/layout-base": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
-      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
-      "license": "MIT"
-    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -4455,12 +3524,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash-es": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
-      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
-      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -4522,63 +3585,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/mermaid": {
-      "version": "11.16.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
-      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
-      "license": "MIT",
-      "dependencies": {
-        "@braintree/sanitize-url": "^7.1.2",
-        "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.2.0",
-        "@types/d3": "^7.4.3",
-        "@upsetjs/venn.js": "^2.0.0",
-        "cytoscape": "^3.33.3",
-        "cytoscape-cose-bilkent": "^4.1.0",
-        "cytoscape-fcose": "^2.2.0",
-        "d3": "^7.9.0",
-        "d3-sankey": "^0.12.3",
-        "dagre-d3-es": "7.0.14",
-        "dayjs": "^1.11.20",
-        "dompurify": "^3.3.3",
-        "es-toolkit": "^1.45.1",
-        "katex": "^0.16.45",
-        "khroma": "^2.1.0",
-        "marked": "^16.3.0",
-        "roughjs": "^4.6.6",
-        "stylis": "^4.3.6",
-        "ts-dedent": "^2.2.0",
-        "uuid": "^11.1.0 || ^12 || ^13 || ^14.0.0"
-      }
-    },
-    "node_modules/mermaid/node_modules/katex": {
-      "version": "0.16.47",
-      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
-      "integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
-      "funding": [
-        "https://opencollective.com/katex",
-        "https://github.com/sponsors/katex"
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^8.3.0"
-      },
-      "bin": {
-        "katex": "cli.js"
-      }
-    },
-    "node_modules/mermaid/node_modules/marked": {
-      "version": "16.4.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
-      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 20"
       }
     },
     "node_modules/minimatch": {
@@ -4679,12 +3685,11 @@
       }
     },
     "node_modules/ntk": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-3.10.2.tgz",
-      "integrity": "sha512-mdyncuH3Cg1kOGCM/WJwiXku4oysSRVAUvODLtBuBogvCejHAB3yZLhqP53fnUqre7HbC6OTSyW5fs61NfUFhA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-4.0.0.tgz",
+      "integrity": "sha512-hQj1H+ONAOhcS4ld81Fvgm0wAJNioJuGwdvNAZYKgqnTKOMkam/vuP6g47ECmK9lryalFZUWVdYN/kr5bioXqQ==",
       "license": "MIT",
       "dependencies": {
-        "@dagrejs/dagre": "^3.0.0",
         "bidi-js": "^1.0.3",
         "canvas-fontstyle": "^1.0.1",
         "css-select": "^7.0.0",
@@ -4698,7 +3703,6 @@
         "keysym": "0.0.6",
         "linebreak": "^1.1.0",
         "marked": "^18.0.7",
-        "mermaid": "^11.16.0",
         "parse-color": "^1.0.0",
         "pngjs": "^7.0.0",
         "postcss": "^8.5.23",
@@ -4900,12 +3904,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/package-manager-detector": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.8.0.tgz",
-      "integrity": "sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==",
-      "license": "MIT"
-    },
     "node_modules/pako": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
@@ -4938,12 +3936,6 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-0.5.3.tgz",
       "integrity": "sha512-RwBeO/B/vZR3dfKL1ye/vx8MHZ40ugzpyfeVG5GsiuGnrlMWe2o8wxBbLCpw9CsxV+wHuzYlCiWnybrIA0ling=="
-    },
-    "node_modules/path-data-parser": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
-      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
-      "license": "MIT"
     },
     "node_modules/path-exists": {
       "version": "4.0.0",
@@ -4985,22 +3977,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.19.0"
-      }
-    },
-    "node_modules/points-on-curve": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
-      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
-      "license": "MIT"
-    },
-    "node_modules/points-on-path": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
-      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
-      "license": "MIT",
-      "dependencies": {
-        "path-data-parser": "0.1.0",
-        "points-on-curve": "0.2.0"
       }
     },
     "node_modules/polyline-miter-util": {
@@ -5271,30 +4247,6 @@
       "integrity": "sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==",
       "license": "MIT"
     },
-    "node_modules/robust-predicates": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
-      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
-      "license": "Unlicense"
-    },
-    "node_modules/roughjs": {
-      "version": "4.6.6",
-      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
-      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
-      "license": "MIT",
-      "dependencies": {
-        "hachure-fill": "^0.5.2",
-        "path-data-parser": "^0.1.0",
-        "points-on-curve": "^0.2.0",
-        "points-on-path": "^0.2.1"
-      }
-    },
-    "node_modules/rw": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/safe-array-concat": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
@@ -5349,12 +4301,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -5668,12 +4614,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/stylis": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
-      "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
-      "license": "MIT"
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5705,24 +4645,6 @@
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
-    },
-    "node_modules/tinyexec": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
-      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/ts-dedent": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.3.0.tgz",
-      "integrity": "sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.10"
-      }
     },
     "node_modules/tslib": {
       "version": "2.8.1",
@@ -5932,19 +4854,6 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^3.10.2",
+    "ntk": "^4.0.0",
     "react-reconciler": "^0.33.0"
   },
   "peerDependencies": {

--- a/scripts/check-stress.jsx
+++ b/scripts/check-stress.jsx
@@ -254,8 +254,8 @@ const check = (ok, what) => {
  *
  * The sleep before it is for React, not for the frame: a click's setState
  * commits on a task, so the tree has to exist before there is anything to lay
- * out. Async content (a mermaid model, an HTML image) invalidates again later,
- * hence more than one round.
+ * out. Async content (an HTML image) invalidates again later, hence more than
+ * one round.
  */
 async function settle(rounds = 4) {
   for (let i = 0; i < rounds; i++) {

--- a/src/richnodes.js
+++ b/src/richnodes.js
@@ -1,7 +1,7 @@
 // Rich-content elements: thin retained-node wrappers over ntk's document
 // widgets in standalone mode (`layout(width)` + `draw(ctx, x, y)` +
 // `contentHeight`). One yoga measure function per node feeds the widget's
-// own layout into flexbox; async content (mermaid models, images) arrives
+// own layout into flexbox; async content (HtmlView images and SVGs) arrives
 // through the widget's `onInvalidate` hook (ntk >= 3.4.0).
 import { MarkdownView, HtmlView, SvgView, layoutTex } from 'ntk';
 
@@ -54,8 +54,9 @@ class DocumentViewNode extends Node {
     if (this.view || !this.app?.fonts) return this.view;
     this.view = this._createView();
     if (this.view) {
-      // ntk >= 3.4.0 notifies here when async content (a mermaid model, an
-      // image) invalidates the widget layout; harmless no-op before that
+      // ntk >= 3.4.0 notifies here when async content (an HtmlView image or
+      // SVG) invalidates the widget layout; MarkdownView never fires it —
+      // its layout is synchronous — and the assignment is a harmless no-op
       this.view.onInvalidate = () => this._contentInvalidated();
       this._setSource(this.view);
     }
@@ -136,7 +137,7 @@ class DocumentViewNode extends Node {
 
 /**
  * <markdown source>: ntk MarkdownView — headings, emphasis, lists, quotes,
- * tables, syntax-highlighted fences, math fences, async mermaid fences.
+ * tables, syntax-highlighted fences, math fences.
  * Props: source, theme, onLink(href, ev). Spacing comes from the box model
  * (padding prop), not the widget's own page padding.
  */

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -837,43 +837,29 @@ test('<tex> lays out and draws a formula', async () => {
   }
 });
 
-test('<markdown> mermaid fence reflows into a diagram (ntk onInvalidate)', async () => {
+test('<html> repaints when async content arrives (ntk onInvalidate)', async () => {
   const { app } = await createHeadlessApp();
   try {
+    // an <img> decodes off the render pass, so the first paint has nothing to
+    // draw there; HtmlView then fires onInvalidate, which is the only thing
+    // that gets the element re-measured and painted again
+    const svg =
+      'data:image/svg+xml,' +
+      encodeURIComponent(
+        '<svg viewBox="0 0 4 4"><rect width="4" height="4" fill="#0000ff"/></svg>',
+      );
     const wnd = await render(
       React.createElement(
         'window',
-        { width: 300, height: 200, style: { backgroundColor: 'white' } },
-        React.createElement('markdown', {
-          source: '```mermaid\nflowchart LR\n  A[Hello] --> B[World]\n```',
+        { width: 200, height: 120, style: { backgroundColor: 'white' } },
+        React.createElement('html', {
+          source: `<div style="margin:0;padding:0"><img width="40" height="40" src="${svg}"></div>`,
         }),
       ),
       app,
     );
     const ctx = wnd.getContext('2d');
-
-    // the fence first paints as a code block; when the async mermaid model
-    // arrives the widget fires onInvalidate and the element reflows into
-    // diagram node boxes (theme fill #ececff). The grammar loads lazily,
-    // so allow more time than the default waitForInk deadline.
-    const isNodeFill = ([r, g, b]) =>
-      r > 220 && g > 220 && b > 245 && b > r + 8;
-    const deadline = Date.now() + 10000;
-    for (;;) {
-      const image = await readPixels(ctx, 300, 200);
-      let hits = 0;
-      for (let y = 0; y < 120; y++) {
-        for (let x = 0; x < 300; x++) {
-          if (isNodeFill(px(image, 300, x, y))) hits++;
-        }
-      }
-      if (hits > 50) break;
-      if (Date.now() > deadline) {
-        assert.fail(`mermaid diagram never painted (${hits} fill pixels)`);
-      }
-      await new Promise((resolve) => setTimeout(resolve, 50));
-    }
-
+    await waitForPixel(ctx, 200, 120, 20, 20, [0, 0, 255], 'html svg img blue');
     ReactX11.unmountComponentAtNode(app);
   } finally {
     await app.close();

--- a/website/scripts/build-demo-bundles.mjs
+++ b/website/scripts/build-demo-bundles.mjs
@@ -140,13 +140,7 @@ await esbuild.build({
     'node:module': path.join(shimsDir, 'module.js'),
     // keysym reads its JSON tables with fs at load time; this build inlines them
     keysym: path.join(shimsDir, 'keysym.js'),
-    // heavy optional ntk deps no demo needs. mermaid, dompurify and dagre go
-    // when the ntk floor moves past sidorares/ntk#113, which deletes the
-    // fence that reaches them — until then dropping the aliases bundles the
-    // real mermaid and the runtime goes from 2.3 MB to 5.6 MB.
-    mermaid: path.join(stubsDir, 'mermaid.js'),
-    dompurify: path.join(stubsDir, 'dompurify.js'),
-    '@dagrejs/dagre': path.join(stubsDir, 'dagre.js'),
+    // heavy optional ntk dep no demo needs
     pngjs: path.join(stubsDir, 'pngjs.js'),
   },
 });

--- a/website/scripts/build-demo-bundles.mjs
+++ b/website/scripts/build-demo-bundles.mjs
@@ -140,7 +140,10 @@ await esbuild.build({
     'node:module': path.join(shimsDir, 'module.js'),
     // keysym reads its JSON tables with fs at load time; this build inlines them
     keysym: path.join(shimsDir, 'keysym.js'),
-    // heavy optional ntk deps: only <markdown> mermaid fences need these
+    // heavy optional ntk deps no demo needs. mermaid, dompurify and dagre go
+    // when the ntk floor moves past sidorares/ntk#113, which deletes the
+    // fence that reaches them — until then dropping the aliases bundles the
+    // real mermaid and the runtime goes from 2.3 MB to 5.6 MB.
     mermaid: path.join(stubsDir, 'mermaid.js'),
     dompurify: path.join(stubsDir, 'dompurify.js'),
     '@dagrejs/dagre': path.join(stubsDir, 'dagre.js'),

--- a/website/scripts/stubs/dagre.js
+++ b/website/scripts/stubs/dagre.js
@@ -1,3 +1,0 @@
-// Inert stub: @dagrejs/dagre is only used by the mermaid flowchart layout,
-// which is not available in the playground bundle.
-module.exports = require('./unavailable.js')('@dagrejs/dagre');

--- a/website/scripts/stubs/dompurify.js
+++ b/website/scripts/stubs/dompurify.js
@@ -1,3 +1,0 @@
-// Inert stub: dompurify is only reached through mermaid, which is stubbed
-// out of the playground bundle too. See scripts/stubs/unavailable.js.
-module.exports = require('./unavailable.js')('dompurify');

--- a/website/scripts/stubs/mermaid.js
+++ b/website/scripts/stubs/mermaid.js
@@ -1,3 +1,0 @@
-// Inert stub: mermaid diagram parsing is not available in the playground
-// bundle. See scripts/stubs/unavailable.js.
-module.exports = require('./unavailable.js')('mermaid');

--- a/website/scripts/stubs/unavailable.js
+++ b/website/scripts/stubs/unavailable.js
@@ -1,5 +1,5 @@
-// Factory for inert module stubs: heavy optional dependencies (yoga-layout,
-// mermaid, …) are aliased to modules built from this so the playground
+// Factory for inert module stubs: heavy optional dependencies (pngjs, …)
+// are aliased to modules built from this so the playground
 // bundle stays small. Importing the stub is free; *using* it throws with a
 // clear message. The proxy answers the interop probes esbuild's ESM<->CJS
 // helpers make (`__esModule`, `default`, symbols) without throwing.


### PR DESCRIPTION
ntk 4.0.0 removes mermaid rendering — it was 155 MB of install closure for a
grammar, since mermaid's renderer needs a browser and ntk laid the diagrams
out itself. See sidorares/ntk#106 for the analysis and the staged plan, and
sidorares/ntk#113 for the removal. Nothing here ever implemented mermaid; it
only described it and depended on the package that did.

Two commits: the docs and tests first, then the bump that makes it real.

## What changes for users

A markdown fence tagged mermaid renders as a plain highlighted code block
instead of a diagram, and `MarkdownView` has no `onInvalidate` option
upstream any more — a mermaid model was the only content that could arrive
after its layout, so the hook had nothing left to report. `richnodes` still
assigns the property for both document elements; `MarkdownView` ignores it
and `HtmlView` needs it for images and SVGs, so the shared wiring is
unchanged.

npm removed 111 packages on the bump.

## Test coverage moved rather than went

The integration test for a mermaid fence reflowing into a diagram was the
only coverage of `_contentInvalidated`. It is now an `<html>` test over the
same path: an async image arrives, `HtmlView` fires `onInvalidate`, the
element re-measures and repaints. Unwiring `onInvalidate` fails it with the
placeholder grey still on screen, which is the check being made.

## The playground stubs, and why they took two commits

Removing the mermaid, dompurify and dagre aliases from the demo bundler
while the installed ntk could still reach mermaid pulls the real package in:
the runtime went from 2.3 MB to 5.6 MB. So they stayed through the first
commit and go with the bump. The runtime now builds at 2307 KB with no
mermaid string in it at all.

## Verified

On the real 4.0.0 from npm: 247 tests, lint, typecheck, prettier, the stress
check with damage still bounded, and all 10 site demos plus share links
green. The first commit was also verified against a locally patched ntk
before 4.0.0 existed, so both halves are known good independently.

`RICH_CONTENT.md` keeps its analysis and gains a status banner: the decision
lives in sidorares/ntk#106, it diverges from that document on three points,
and re-measuring in isolated install trees put mermaid's closure at 155 MB
rather than the 89 MB reported there — the gap is what npm hoisting hides.

BREAKING CHANGE: requires ntk 4. A markdown fence tagged mermaid renders as
a code block rather than a diagram.
