### PR TITLE
fix: a transition started by a prop change draws its own first frame

### DIFF
--- a/src/nodes.js
+++ b/src/nodes.js
@@ -3341,6 +3341,13 @@ export class WindowNode extends Node {
   /** A node in this window started a transition. */
   _startAnimating(node) {
     this._animating.add(node);
+    // The transition has to schedule its own first frame: it starts at the
+    // *old* value, so to whoever caused it the displayed style hasn't changed
+    // and their damage test contributes nothing. `setStyleState` happens to
+    // invalidate anyway, but a React prop change does not — and a transition
+    // no one schedules only runs when something else dirties the window,
+    // by which time its start is stale and it snaps to the end.
+    this.invalidate(false, damageForAnimation(node));
   }
 
   /**

--- a/test/style.test.js
+++ b/test/style.test.js
@@ -575,6 +575,69 @@ test('transitions cover layout too, and relayout as they run', async () => {
   }
 });
 
+test('a transition started by a prop change schedules its own frames', async () => {
+  const { setAnimationClock } = await import('../src/nodes.js');
+  let clock = 1000;
+  setAnimationClock(() => clock);
+  try {
+    const app = createMockApp();
+    const ui = (backgroundColor) =>
+      h(
+        'window',
+        { width: 100, height: 100 },
+        h('box', {
+          style: { flexGrow: 1, backgroundColor, transition: 200 },
+        }),
+      );
+    ReactX11.render(ui('#000000'), null, app);
+    await tick();
+    const root = nodeOf(app);
+    const box = root.children[0];
+    const ops = app.windows[0].ctx.ops;
+    const opsBefore = ops.length;
+
+    // No hover, no focus, no other damage: the colour change is the whole
+    // update. The commit's own damage test cannot see it — the first
+    // displayed frame of a transition equals the previous style — so the
+    // transition must schedule its first frame itself, or it only runs
+    // when something else happens to dirty the window.
+    ReactX11.render(ui('#ffffff'), null, app);
+
+    clock = 1100; // half way
+    await tick();
+    await tick();
+    const mid = box.style.backgroundColor;
+    assert.match(
+      mid,
+      /^rgba\(/,
+      'the transition ticked with nothing else waking the window',
+    );
+    const channel = Number(mid.slice(5).split(',')[0]);
+    assert.ok(
+      channel > 0 && channel < 255,
+      `midpoint should be grey, got ${mid}`,
+    );
+    assert.ok(
+      ops.slice(opsBefore).some((op) => op[0] === 'fillRect' && op[5] === mid),
+      'the intermediate value actually painted',
+    );
+
+    clock = 1300; // past the end
+    await tick();
+    await tick();
+    assert.strictEqual(box.style.backgroundColor, '#ffffff');
+    assert.strictEqual(root._animating.size, 0, 'and stops asking for frames');
+    assert.ok(
+      ops
+        .slice(opsBefore)
+        .some((op) => op[0] === 'fillRect' && op[5] === '#ffffff'),
+      'the final value painted too',
+    );
+  } finally {
+    setAnimationClock(() => Date.now());
+  }
+});
+
 test('a property with no midpoint snaps rather than animating', async () => {
   const app = createMockApp();
   ReactX11.render(


### PR DESCRIPTION
A transition started by a React prop change never ran. It registered in the
node's `_anim` map and then sat there: no repaint, no interpolation, the
displayed value frozen at its starting point indefinitely. Anything else that
happened to dirty the window would wake it — and by then its `start` was long
past, so it snapped to the end rather than animating.

![transition-filmstrip](https://github.com/user-attachments/assets/96b9efee-c20c-4c41-8ec4-bb6825de6f2e)

Both rows above are the same scene, rendered by this branch's own code into
node-x11's in-process X server and photographed every 150ms of real time: one
box whose `backgroundColor` and `left` both carry a 600ms transition, changed
by a single `ReactX11.render` with different props. Nothing else touches the
window — no pointer, no focus, no second render — so the transition is the
only thing that could ask for a frame. The top row runs `_startAnimating` as
it was before this branch.

## Why

A transition starts at the *old* value. `_retarget` sets
`this.style = { ...target, ...this._animatedValues() }`, and `_animatedValues`
returns each property's `from` — so the style the node displays on the frame a
transition begins is value-equal to the one before it. That is deliberate, and
it is what lets an interrupted transition reverse from where it got to.

It also means the commit that started the transition cannot see it.
`applyProps` asks `_paintChanged` what changed, `paintPropsChanged` compares
the displayed style against the previous one, finds them equal, and passes
`NO_DAMAGE`. `invalidate` returns early on `NO_DAMAGE` before touching
`needsPaint` or scheduling a flush, which is exactly what it should do for a
re-render whose output is identical. Nothing was wrong on that side.

The gap was that `_startAnimating` only did `this._animating.add(node)`. The
window now had an animation to advance and no frame booked in which to advance
it.

Hover, focus and press never showed this because `setStyleState` calls
`invalidate` unconditionally after retargeting, which happens to schedule the
frame the transition needed. Only the prop-update path was affected — which is
why the `:hover` transitions in the examples all look fine.

## The fix

`_startAnimating` claims the region and schedules the frame itself. Putting it
there rather than in `applyProps` covers every path that can start a
transition, including any future one, instead of the single path that was
reported.

The claim comes from `damageForAnimation`, the same function
`_advanceAnimations` uses for every subsequent frame: the node's own bounds for
a paint-only transition, the parent for an out-of-flow layout one, and a full
repaint for a layout property in flow. So the first frame is bounded exactly as
the rest of the transition is, and a colour fade still costs a repaint of the
thing that faded. The extra `invalidate` on the `setStyleState` path is a
no-op in practice — damage rects accumulate and `_scheduled` already dedupes
the frame.

## Test

`test/style.test.js`: *a transition started by a prop change schedules its own
frames*. It mounts the box, re-renders it with a new `backgroundColor`, and
then never calls `invalidate`, `flush` or `_advanceAnimations` by hand — only
the mocked animation clock moves between `setImmediate` ticks, so the frames
have to come from the renderer. It asserts the midpoint is an interpolated
grey both in `node.style` and in the mock context's recorded `fillRect` ops,
so the assertion is about pixels rather than about a mutated style object.

Against `master` it fails on the first assertion with the colour still at its
starting value, which is the reported bug. 248 tests pass with the fix.

