### PR TITLE
fix: size a Select's menu to its longest option, not the selected one

### DIFF
--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -4,7 +4,8 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { useTheme } from './theme.js';
-import { useAnchor } from './anchor.js';
+import { measureLabel, screenOf, useAnchor } from './anchor.js';
+import { DEFAULT_TEXT_STYLE } from '../styles.js';
 import { typeAheadChar, useTypeAhead } from './typeahead.js';
 import {
   XK_DOWN,
@@ -23,10 +24,55 @@ const ITEM_HEIGHT = 28;
 
 const MAX_MENU_HEIGHT = 220;
 
+// The menu's chrome, named rather than inline because the width calculation
+// and the layout have to agree: a measurement that drifts from the padding it
+// is measuring for clips the very labels it exists to fit.
+const ITEM_PAD_LEFT = 10;
+const ITEM_PAD_RIGHT = 10;
+const MENU_PAD = 4; // the scrollview's own padding
+const MENU_BORDER = 1;
+// the scrollbar is drawn *over* the content rather than insetting it
+// (`nodes.js`, SCROLLBAR_WIDTH), so a menu that scrolls reserves the room
+const SCROLLBAR_WIDTH = 6;
+
 function normalizeOption(option) {
   return typeof option === 'object' && option !== null
     ? option
     : { value: option, label: String(option) };
+}
+
+/**
+ * How wide the menu has to be to show its **longest** option, not merely the
+ * selected one. Sizing it to the trigger — which is only ever as wide as the
+ * current value — left every longer label to wrap inside a fixed 28px row and
+ * overlap the option under it.
+ *
+ * Labels are measured at the size they are painted: a `<text>` resolves its
+ * style against `DEFAULT_TEXT_STYLE` rather than inheriting from the boxes
+ * around it, so the option rows are 14px whatever the trigger is set to. The
+ * selected one is measured bold, which is how `Option` draws it.
+ *
+ * The result is never narrower than the trigger it hangs off, and never wider
+ * than the screen it has to open on — `anchorRect` can slide a popup left to
+ * fit, but nothing can rescue one that is wider than the display.
+ */
+function menuWidth(node, options, value, scrolls) {
+  let widest = 0;
+  for (const option of options) {
+    const { width } = measureLabel(node, option.label, {
+      size: DEFAULT_TEXT_STYLE.size,
+      weight: option.value === value ? 'bold' : 'normal',
+    });
+    if (width > widest) widest = width;
+  }
+  const chrome =
+    (MENU_BORDER + MENU_PAD) * 2 +
+    ITEM_PAD_LEFT +
+    ITEM_PAD_RIGHT +
+    (scrolls ? SCROLLBAR_WIDTH : 0);
+  const width = Math.max(node.abs.width, Math.ceil(widest) + chrome);
+  const screen = screenOf(node);
+  return screen ? Math.min(width, screen.pixel_width) : width;
 }
 
 function Option({ option, selected, active, onPick, onHover, nodeRef }) {
@@ -43,7 +89,8 @@ function Option({ option, selected, active, onPick, onHover, nodeRef }) {
       style: {
         height: ITEM_HEIGHT,
         justifyContent: 'center',
-        paddingLeft: 10,
+        paddingLeft: ITEM_PAD_LEFT,
+        paddingRight: ITEM_PAD_RIGHT,
         cursor: 'pointer',
         backgroundColor: active ? theme.hoverBackground : theme.background,
       },
@@ -96,18 +143,22 @@ export function Select({
 
   const normalized = options.map(normalizeOption);
   const current = normalized.find((o) => o.value === value);
-  const menuHeight = Math.min(
-    normalized.length * ITEM_HEIGHT + 8,
-    MAX_MENU_HEIGHT,
-  );
+  const contentHeight = normalized.length * ITEM_HEIGHT + MENU_PAD * 2;
+  const menuHeight = Math.min(contentHeight, MAX_MENU_HEIGHT);
+  const scrolls = contentHeight > MAX_MENU_HEIGHT;
 
   const close = () => setOpen(false);
   const openMenu = () => {
     const node = triggerRef.current;
     if (!node) return;
     // shared anchoring: also flips the menu above the trigger when there is
-    // no room below, instead of opening off the bottom of the screen
-    const rect = measureAnchor({ placement: 'bottom', height: menuHeight + 2 });
+    // no room below, and slides it left when the menu is wider than the
+    // trigger and would otherwise open off the right edge
+    const rect = measureAnchor({
+      placement: 'bottom',
+      height: menuHeight + 2,
+      width: menuWidth(node, normalized, value, scrolls),
+    });
     if (!rect) return;
     setAnchor(rect);
     const selected = normalized.findIndex((o) => o.value === value);
@@ -251,14 +302,14 @@ export function Select({
             style: {
               flexGrow: 1,
               flexShrink: 1,
-              borderWidth: 1,
+              borderWidth: MENU_BORDER,
               borderColor: theme.border,
               backgroundColor: theme.background,
             },
           },
           h(
             'scrollview',
-            { ref: scrollRef, style: { flexGrow: 1, padding: 4 } },
+            { ref: scrollRef, style: { flexGrow: 1, padding: MENU_PAD } },
             normalized.map((option, index) =>
               h(Option, {
                 key: String(option.value),

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1285,6 +1285,129 @@ test('Select: an overlong menu scrolls the active option into view', async () =>
   ReactX11.unmountComponentAtNode(app);
 });
 
+// The menu used to take the trigger's width, and the trigger is only ever as
+// wide as the *selected* value — so picking a short option made every longer
+// one wrap inside a fixed 28px row and overlap the option beneath it.
+test('Select: the menu fits its longest option, not the selected one', async () => {
+  const { Select } = await import('../src/index.js');
+  const { measureLabel } = await import('../src/components/anchor.js');
+  const { DEFAULT_TEXT_STYLE } = await import('../src/styles.js');
+
+  const LONGEST = 'a considerably longer option than the trigger';
+  const options = ['S', 'medium one', LONGEST];
+
+  const openWith = async (selected) => {
+    const app = createMockApp();
+    ReactX11.render(
+      React.createElement(
+        'window',
+        { width: 400, height: 200 },
+        React.createElement(
+          'box',
+          { style: { flexGrow: 1, padding: 10 } },
+          React.createElement(Select, {
+            options,
+            value: selected,
+            style: { width: 60 },
+          }),
+        ),
+      ),
+      null,
+      app,
+    );
+    await tick();
+    const wnd = app.windows[0];
+    const findFocusable = (node) => {
+      if (node.props?.focusable) return node;
+      for (const child of node.children) {
+        if (child.isWindow) continue;
+        const hit = findFocusable(child);
+        if (hit) return hit;
+      }
+      return null;
+    };
+    const trigger = findFocusable(wnd._reactX11Node);
+    const x = trigger.abs.x + 10;
+    const y = trigger.abs.y + trigger.abs.height / 2;
+    wnd.emit('mousedown', { x, y, keycode: 1 });
+    wnd.emit('mouseup', { x, y, keycode: 1 });
+    await tick();
+    return { app, trigger, popup: app.windows[1] };
+  };
+
+  const { app, trigger, popup } = await openWith('S');
+  assert.ok(
+    popup.attributes.width > trigger.abs.width,
+    `menu (${popup.attributes.width}) should outgrow the trigger (${trigger.abs.width})`,
+  );
+
+  // the longest label plus the row's own left padding has to fit, or the text
+  // wraps into the row below it — which is the bug
+  const longest = measureLabel(trigger, LONGEST, {
+    size: DEFAULT_TEXT_STYLE.size,
+  }).width;
+  assert.ok(
+    popup.attributes.width >= Math.ceil(longest) + 10,
+    `menu (${popup.attributes.width}) should fit the longest label (${Math.ceil(longest)})`,
+  );
+  ReactX11.unmountComponentAtNode(app);
+
+  // and it does not depend on which option is selected: the widest one is
+  // measured bold, the way Option paints it, so that case is the wider one
+  const withLongSelected = await openWith(LONGEST);
+  assert.ok(
+    withLongSelected.popup.attributes.width >= popup.attributes.width,
+    'selecting the longest option must not shrink the menu',
+  );
+  ReactX11.unmountComponentAtNode(withLongSelected.app);
+});
+
+test('Select: the menu is never narrower than the trigger', async () => {
+  const { Select } = await import('../src/index.js');
+  const app = createMockApp();
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 400, height: 200 },
+      React.createElement(
+        'box',
+        { style: { flexGrow: 1, padding: 10 } },
+        React.createElement(Select, {
+          options: ['a', 'b'],
+          value: 'a',
+          style: { width: 240 },
+        }),
+      ),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const findFocusable = (node) => {
+    if (node.props?.focusable) return node;
+    for (const child of node.children) {
+      if (child.isWindow) continue;
+      const hit = findFocusable(child);
+      if (hit) return hit;
+    }
+    return null;
+  };
+  const trigger = findFocusable(wnd._reactX11Node);
+  const x = trigger.abs.x + 10;
+  const y = trigger.abs.y + trigger.abs.height / 2;
+  wnd.emit('mousedown', { x, y, keycode: 1 });
+  wnd.emit('mouseup', { x, y, keycode: 1 });
+  await tick();
+
+  assert.strictEqual(
+    app.windows[1].attributes.width,
+    trigger.abs.width,
+    'two one-letter options still open a menu the width of the trigger',
+  );
+  ReactX11.unmountComponentAtNode(app);
+});
+
 test('text spans collect nested styles', () => {
   const app = createMockApp();
   ReactX11.render(


### PR DESCRIPTION
The popup took the trigger's width, and the trigger is only ever as wide as
the value currently in it. Any option with a longer label then wrapped inside
a row whose height is fixed at 28px and overlapped the option under it — and
because wrapping doubles those rows, a six-item list could also grow past the
height cap and put a scrollbar over the text on its way out.

Reported against a field picker whose selected value was the shortest of its
options. Both shots are rendered headlessly by the code they show — before at
0ed08d1 on master, after at 469aa8b on this branch — driving the same field
list through the real event pipeline to open the menu, with `Amount` selected:

**Before** — `Expense type` and `Submitted by` wrap into the row beneath, and
the list has overflowed into a scrollbar:

![before](https://github.com/user-attachments/assets/a8e540de-b4b8-4f73-ba1b-57f51ec894b5)

**After** — every label on one line, and no scrollbar because nothing wraps:

![after](https://github.com/user-attachments/assets/2c0aae9b-a3eb-4ab5-aae0-4088b01ce847)

## What it does

The menu measures every label and takes the widest. Two details decide
whether that measurement matches what the rows are painted at:

- a `<text>` resolves its style against `DEFAULT_TEXT_STYLE` rather than
  inheriting from the boxes around it, so an option row is 14px whatever size
  the trigger is set to — measuring at `measureLabel`'s own default of 13
  would undersize the menu by about a character on a long label;
- the selected option is drawn bold, so it is measured bold.

Room for the scrollbar is reserved only when the list actually scrolls, since
`nodes.js` draws it over the content instead of insetting it.

The width is clamped both ways: never narrower than the trigger it hangs off,
which would look broken, and never wider than the screen it opens on.
`anchorRect` already slides a popup left to keep it in the screen, so a menu
wider than its trigger does not run off the right edge — that clamp simply had
nothing to do before, because the width always came from a trigger that was on
screen already.

`ContextMenu` has done this since it was written (`menuListWidth` in
`Menu.js`); this is `Select` catching up, with the same `measureLabel` helper.

## Notes

The menu's chrome is named rather than inline now, because the width
calculation and the layout have to agree: a measurement that drifts from the
padding it is measuring for clips the very labels it exists to fit. The option
rows gain the right-hand padding the calculation assumes.

## Tests

Two new cases in `test/smoke.test.js`, either side of the fix:

- the menu outgrows a narrow trigger and fits its longest label, and picking
  the longest option does not shrink it back;
- two one-letter options still open a menu exactly the trigger's width, so the
  `max()` is not over-correcting.

The first fails on `master` and passes here. 250 tests, `lint` and `typecheck`
green.


