### PR TITLE
docs: an ecosystem page, and say who this is for

### DIFF
--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -25,14 +25,27 @@
 > 2. **§11 accessibility (AT-SPI)** is next and now unblocked: it depended on
 >    window-level focus, which shipped. §11.3 scopes it out; a
 >    `@react-x11/a11y` sibling package is the likely shape.
-> 3. The two open issues, both real and both mine to fix: **#86**
+> 3. The two oldest open issues, both real and both mine to fix: **#86**
 >    (`sans-serif` resolves to a CJK font on macOS) and **#85** (keyboard
 >    layout switching ignored — needs the Linux group bits _and_ XQuartz's
->    keymap rewrite).
+>    keymap rewrite; §15 has the wider version of that problem). The rest of
+>    the backlog is now filed too — #113–#130 here, and the upstream half as
+>    sidorares/ntk#115–#126, sidorares/node-x11#243–#247 and
+>    sidorares/dbus-native#389–#392.
 > 4. Upstream (ntk): distribute half-leading inside TextLayout itself
 >    (makes the #29 paint shift a no-op) + an opt-in cap-height trim
 >    (`text-box-trim` analog); `maxLines`/ellipsis for `<text>` (neither
 >    exists in `src/` yet).
+> 5. **Write the pages that do not exist** (#128): remote display — the
+>    case the architecture is actually for, and the only one with no page
+>    at all — security (X11 has no client isolation, and the `-X`/`-Y`
+>    decision), and packaging (§13). The ecosystem half of that list is
+>    answered: [docs/ecosystem.md](docs/ecosystem.md) and a page per
+>    category beside it say which npm libraries work here, which need an
+>    adapter and which cannot. None of the three left is engineering, all
+>    three are load-bearing, and the first two are an afternoon each.
+> 6. **Decide the §12 list before merging #69.** Every rename in it is one
+>    commit while 2.0.0 is unreleased and a deprecation cycle afterwards.
 
 ---
 
@@ -184,6 +197,34 @@ merged theme (`ThemeProvider`; `SelectThemeProvider` is an alias) and a
   done (#90) — dispatched from button 3, `preventDefault()` suppresses the
   built-in edit menu
 
+  The "(ntk TODO)" parenthetical is doing too much work. Text entry today is
+  **one keysym per key event, committed straight into the field**:
+  `src/events.js:435` takes `keycode2keysyms[keycode][0]` and ntk's
+  `lib/window.js:340` picks `syms[capital ? 1 : 0]`, so levels 2–4 are
+  unreachable. Three consequences, in increasing order of severity:
+
+  - **AltGr is dead.** `@` on a German layout, `€` on most European ones,
+    `ł` on Polish, `ã` on US-International — none of them can be typed.
+    Same line as #85, and fixing it properly means resolving the group
+    _and_ the shift / lock / level3 / level5 modifiers, applying caps only
+    to alphabetic keysyms — the current rule applies it to everything, so
+    **Caps Lock turns `1` into `!`**.
+  - **No Compose and no dead keys.** `dead_acute` then `e` produces two
+    nothings rather than `é`. That is a trie over the system Compose table
+    plus `$XCOMPOSEFILE`/`~/.XCompose` when present — pure data, no
+    protocol.
+  - **No input method at all.** No preedit string, no candidate window, no
+    commit event. `<textinput>` has a caret, a selection, an undo stack and
+    a clipboard, and **nowhere for uncommitted composition text to live**.
+    CJK is not partially working; it is structurally absent.
+
+  Staged in §15; the level rule and the Compose engine are
+  sidorares/ntk#116. Stage 1 is entirely inside ntk and is worth more than
+  any widget polish left on this list — it is the difference between "works
+  for English" and "works". Stage 0, saying so in `README.md` and under
+  `<textinput>` in [docs/elements.md](docs/elements.md), costs nothing and
+  should not wait for stage 1.
+
 ### 3a. Styling — DONE
 
 Style moved out of the flat prop namespace into `style` (object or array,
@@ -215,6 +256,36 @@ already required. See [docs/styling.md](docs/styling.md).
   images go to GitHub attachments, committed images only when globally
   useful — README qualifies)
 - API docs live in `docs/` (elements/components/events/devtools)
+- **`docs/` is reference-only** (#128). Every page is either a feature tour
+  or an API listing: no tutorial, no troubleshooting page, no FAQ. That
+  works for a reader already sold. The one who has not decided yet gets
+  intro → getting-started → the reference pages → "read `examples/`", and
+  the errors they will actually hit have no page at all:
+  `Cannot open display` with no `$DISPLAY` (XQuartz needs a _fresh_
+  terminal after install, which nothing says);
+  `fontconfig matching needs node (fc-match CLI)` in a container;
+  `sans-serif` resolving to a CJK font on macOS (#86, a filed bug with no
+  troubleshooting entry); `SyntaxError: Unexpected token '<'` from a `.jsx`
+  under plain `node`; and
+  `react-x11: <box height=…> is a style property`, which is a deliberately
+  good error that deserves a page explaining the model. A
+  `docs/troubleshooting.md` keyed by the **exact error text**, so a search
+  engine lands on it, is the highest ratio of usefulness to effort in the
+  documentation. The library half of that gap is closed —
+  [docs/ecosystem.md](docs/ecosystem.md) plus a page per category beside it
+- **The site has an in-page X server and the docs do not use it.** Every
+  runnable snippet in `docs/` could carry an "open in playground" link with
+  its source; the bundle and the share/permalink machinery already exist
+  (`website/scripts/check-share.mjs`). "Click to run this in your browser,
+  against a real X server implementation" is a documentation experience
+  approximately no systems library has, and it is already built
+- **A `bin` field** (the open question above) plus `examples` in `files`,
+  so `npx react-x11 examples <name>` works. Scoped as the _demo_ runner,
+  not an app runner: the examples already export their `App` and honour
+  `REACT_X11_NO_AUTORUN`, so it is a switch statement. The app runner —
+  `react-x11 app.jsx` setting up the JSX loader — is worth it separately,
+  because it deletes the "JSX needs a loader, here are three options"
+  paragraph from the first-run experience
 - window-manager example (#3) — DONE, `examples/wm.jsx` + `examples/wm-core.js`
   on ntk 3.9.0 / node-x11 3.2.0, with `test/wm.test.js` driving it headlessly
 - react-native-dom-like packaging (#13) and mylittledom reuse (#10) are
@@ -542,6 +613,74 @@ File these as ntk issues; react-x11 should not work around them long-term.
     `FocusIn`/`FocusOut` and the `FocusChange` mask are mapped, and
     `window.focus(revertTo)` wraps `SetInputFocus`. This is what §11.2 was
     waiting on.
+11. **One PR for the property writers, not seven** (sidorares/ntk#118, with
+    the `_NET_WM_STATE` half as sidorares/ntk#117 and the react-x11 props
+    as #122). `setProperty(name, value, {type, format})` and `atom(name)`
+    already exist in `lib/window.js`, so most of the missing window
+    properties are three-line methods over machinery that is already there.
+    Batch them: `addProtocol` (read-modify-write — the current
+    `WM_PROTOCOLS` write **clobbers**, so every protocol added after the
+    first silently erases the one before it), `sendClientMessage`,
+    `setWmHints` (the `input`/`WM_TAKE_FOCUS` model — this is the "keyboard
+    sometimes doesn't work under a reparenting WM" bug), `setPid` +
+    `WM_CLIENT_MACHINE` + `_NET_WM_PING`, `setIcon` (`_NET_WM_ICON`),
+    `setState` for the thirteen `_NET_WM_STATE` atoms rather than only
+    `ABOVE`, `setMotifHints` for an undecorated window, `setTransientFor`
+    (sidorares/ntk#126, which is what #130 needs) and the
+    `USPosition`/`PPosition` hints. Each of these on its own is a
+    three-repo release chain — node-x11 → ntk → here — and batching is what
+    makes that survivable.
+
+    **Trap on all of them:** `setProperty` is `async` and its two
+    `InternAtom` awaits can reject while the connection is closing, while
+    `WindowNode._applyWindowHints` calls the hint setters synchronously and
+    drops the promises. Every new property setter inherits that
+    unhandled-rejection hazard until they are wrapped the way `setTitle`
+    wraps its deferred chain (the `safeRelease` + serial-guard pattern in
+    `lib/window.js`).
+
+    The two that unblock a whole persona each: `_NET_WM_STATE_FULLSCREEN`
+    plus `_MOTIF_WM_HINTS` with `decorations=0`, which is
+    `<window fullscreen undecorated>` and is the entire ask of anyone
+    shipping a kiosk or an appliance; and `_NET_WM_ICON`, which is a short
+    writer and is the difference between "a program" and "an app" in the
+    taskbar and the alt-tab list. `examples/wm-core.js` already _reads_
+    `_NET_WM_ICON`; nothing writes it.
+
+12. **Delete the `keysym` dependency** (sidorares/ntk#115). ntk uses
+    exactly one thing from it — `keysym.fromKeysym(sym).unicode` in
+    `lib/window.js` — and the package reads its JSON tables with
+    `fs.readFileSync(__dirname + …)` at module load, which is why nothing
+    importing ntk can be bundled or put in a Node SEA (§13). The rule it
+    implements is small: keysyms `0x01000000..0x0110FFFF` map to
+    `sym & 0xFFFFFF`, Latin-1 keysyms map to themselves, and the remainder
+    is a table. Inline it as `lib/text/keysym-unicode.js`, a plain object
+    literal, zero I/O. That unblocks bundling, SEA and the browser build at
+    once and drops a 2013 unmaintained transitive off the dependency
+    surface. The website has already written the replacement —
+    `website/scripts/browser-shims/keysym.js`, whose comment says exactly
+    this — so the knowledge exists and is trapped in the docs site.
+13. **The XKB level rule and a Compose engine** (sidorares/ntk#116, §15
+    stage 1). Replace `symInd = capital ? 1 : 0` with the real level
+    resolution, then a Compose/dead-key trie, and emit through a new event
+    that carries a **string** rather than a codepoint —
+    `wnd.on('textinput', ({ text, preedit, cursor }) => …)` — so the
+    renderer never has to know which backend produced it. node-x11 ships
+    `lib/ext/xkb.js` and nothing uses it.
+14. **Buffer the output stream** (sidorares/node-x11#244, §14). This one is
+    node-x11 rather than ntk: `xcore.js` does `pack_stream.put(packet)`
+    then `pack_stream.flush()` per request unconditionally, and
+    `framebuffer.js`'s `flush()` walks the queue writing each buffer with
+    no `writev` and no concatenation, so the 86 requests of the mount bench
+    scenario are 86 writes for 3652 bytes. Add an explicit flush policy —
+    accumulate, and force a flush when a reply-expecting request is queued
+    (`xcore.js` already knows which those are), when the buffer crosses
+    16 KB, when the loop is about to idle, or on an explicit `X.flush()` —
+    and concatenate the queue into one write. **The right high-level flush
+    point is ntk's `_present()`: one write per frame**, which is
+    sidorares/ntk#125. Then `setNoDelay(true)` on TCP connections, exposed
+    as `createClient({ tcpNoDelay })`, which is only safe once the
+    buffering lands.
 
 ## 9. Phased plan
 
@@ -593,7 +732,19 @@ menus/tooltips.
   stackMode) — matters once `<popup>` exists; drawn nodes get correct order
   from the render list for free.
 - Should the widget set (Phase 2/3) live in this package or a
-  `@react-x11/widgets` sibling once primitives stabilize?
+  `@react-x11/widgets` sibling once primitives stabilize? **Answered, and
+  worth writing down rather than leaving open: the widgets stay in core,
+  and the siblings that do get split out live in this repo as npm
+  workspaces.** The widgets are plain React over the primitives with no
+  extra dependency, so splitting them buys nothing and costs a
+  peer-version matrix. The packages that genuinely want to be separate are
+  the ones with dependencies core must not take — `@react-x11/desktop`
+  (D-Bus: portals, notifications, tray, global menu, #129) and
+  `@react-x11/a11y` (AT-SPI, §11.3) — and each of those in its own
+  repository turns every change into another land-release-bump chain on
+  top of the node-x11 → ntk → here one that already exists. Workspaces
+  with release-please's manifest mode, versioned in lockstep, keeps it to
+  one release.
 - Where do the rich-content formats belong — ntk, here, or their own module?
   Analysed in [RICH_CONTENT.md](RICH_CONTENT.md); the decision and the staged
   plan live in [sidorares/ntk#106](https://github.com/sidorares/ntk/issues/106).
@@ -603,7 +754,22 @@ menus/tooltips.
   ntk accessor rather than a rewrite. That supersedes the "left for later"
   note in §1 and adds items to §8.
 - ESM migration here (ntk is ESM-with-TLA; the dynamic-import dance in
-  `src/Reconciler.js` disappears if react-x11 goes ESM).
+  `src/Reconciler.js` disappears if react-x11 goes ESM). **Stale on both
+  halves.** `package.json` already declares `"type": "module"`, and there
+  is no top-level await anywhere in ntk's `lib` — the TLA is in
+  `yoga-layout`'s `wrapAssembly(await loadYoga())`, which ntk re-exports,
+  so going ESM would not have removed it either. The dynamic imports in
+  `src/Reconciler.js` are env-gated feature loading for
+  `REACT_X11_DEVTOOLS` and `REACT_X11_CLICK_TO_COMPONENT`, not an ESM
+  workaround; they are themselves top-level awaits and are not going
+  anywhere. What replaces the question is a stated runner support matrix,
+  to go in the testing page §16 asks for: `node --test` and Vitest with
+  `environment: 'node'` are supported (**not** jsdom — a jsdom environment
+  defines `window` and `document` and silently changes how several
+  libraries behave); Jest works with `--experimental-vm-modules` and is
+  unsupported; Jest with a CJS transform **cannot** work, because the
+  transform cannot represent yoga's top-level await. Write the negative
+  result down and do not build a Jest preset.
 
 ## 11. Queued after the 3D work
 
@@ -763,3 +929,496 @@ protocol at all.
   `Text` from the text nodes, state changes on prop updates) is a sizeable
   project on its own — a `@react-x11/a11y` sibling package is probably the
   right shape, kept out of the core render path.
+
+## 12. Before 2.0.0 freezes the API
+
+1.2.0 is what is published; #69 is 2.0.0 and unreleased. Every rename in
+this section costs one commit while that is true, and costs a deprecation
+cycle, a codemod and a migration guide afterwards. Several of them are not
+judgement calls at all — the types, the docs and the implementation already
+disagree, and the only question is which of the three wins.
+
+### 12.1 `createRoot` takes options, and a root owns its connection
+
+Today `createRoot(container?)` takes an ntk App, and the connection is made
+by `connectApp()`, which calls ntk's `createClient()` **with no arguments**
+and memoises the result in a module-level `cachedNtkApp`. `createClient`
+takes an options object — `fontSource`, `glxVisual`, `onXError`, and which
+display to connect to — and none of it is reachable (#114). In order of
+severity:
+
+- You cannot render to a display other than `$DISPLAY`. Not awkwardly —
+  there is no parameter.
+- You cannot supply a `fontSource`, so #86 has no user-side workaround.
+- `onXError` is unset, so ntk warns instead and protocol errors that no
+  request callback claims are effectively invisible.
+- **Two `createRoot()` calls with no argument silently share one fiber
+  root**, because `roots` is keyed by container and both resolve the same
+  memoised app. The second `render()` replaces the first tree with no
+  warning.
+- `Root.unmount()` goes through `unmountComponentAtNode` and never closes
+  the app, so the socket stays open and the process does not exit.
+- Nothing listens for the connection ending. A server going away is
+  silence.
+
+So: `createRoot(options?)` with `display`, `app` (borrow a connection you
+already have — what the tests actually mean today), `fonts`, `scale`
+(§12.5), `screen`, `onXError`, the three React error callbacks, and
+`onDisconnect`. Delete `cachedNtkApp`; each root without `app` opens its own
+connection and closes it, a root given `app` borrows and must not. Key
+`roots` off the root object.
+
+**Trap:** `onDisconnect` invites a reconnect loop, and a reconnect is not a
+reconnect — every window id, pixmap, glyph set and font is invalidated with
+the connection. Do not promise reconnection; document the pattern (tear the
+root down, build a new one, re-render) and stop there.
+
+Fold in a `react-x11/ntk` subpath re-exporting `createClient`,
+`StaticFontSource` and `Clipboard`, so a user who needs a font source does
+not `npm install ntk` separately and hope the version matches the one we
+resolved. Also worth surfacing there: node-x11's `seq2stack` debug mode,
+which maps a protocol error back to the JS stack that sent the request. It
+is the most useful debugging facility in the stack and it is currently
+unreachable.
+
+### 12.2 Errors have to survive
+
+Three separate holes, one options bag (#113):
+
+- `src/Reconciler.js` passes React three arrow stubs that each take only
+  `(error)`. React 19 calls them with `(error, errorInfo)`, and
+  `errorInfo.componentStack` — the entire reason error boundaries are
+  debuggable — is dropped on the floor. Forward both, make all three
+  overridable, and run the stack through the frame-stripping already
+  written for `src/ClickToComponent.js` so the top of the trace is the
+  user's component and not eight frames of react-reconciler.
+- **The default uncaught printer must set `process.exitCode = 1`.** A GUI
+  process that crashed its tree and exits 0 lies to CI and to systemd.
+- `src/events.js` dispatches capture and bubble in two loops and calls
+  `handler(ev)` **bare**. A throwing `onClick` unwinds through the
+  dispatcher into ntk's socket data handler, where there is no error
+  boundary because React is not on the stack — the handler was called from
+  an X event, not from a render. Same for `onDismiss` and
+  `onCloseRequest`. Wrap each invocation, route the throw to the root's
+  reporter with the node's element type and handler name attached. The
+  default should log and continue dispatching — one bad tooltip handler
+  should not kill the frame loop — but it must be overridable, because for
+  a kiosk "crash loudly" is the correct policy.
+
+### 12.3 The naming sweep
+
+Every widget invented its own callback name: `Button.onPress`,
+`Slider.onChange(value)`, `Tree.onSelect`/`onActivate`,
+`Menu.onSelect(item)`, `Dialog.onClose`, against the host elements'
+`<popup onDismiss>` and `<window onCloseRequest>`. One rule, applied
+everywhere: **`onChange(value)`** for a controlled value,
+**`onSelect(id)`** for a selection change, **`onActivate(id)`** for "the
+user chose this thing", **`onClick(ev)`** for a control with no value, and
+**`onRequestClose(ev)`** for "the user asked to dismiss this; you decide
+whether it closes" on `<window>`, `<popup>` and `Dialog`.
+
+In the same pass: several widgets accept flat style props (`Dialog width`
+and `height`, `ProgressBar height`, `Slider height`, `Tooltip fontSize`,
+`Menu fontSize`) while host elements throw on exactly that. It is not a
+rule violation — widgets are plain components and `assertNoFlatStyleProps`
+only runs on host elements — but it teaches the opposite of what we enforce
+one level down. Move them into `style`.
+
+And a real bug hiding in the same area: `Button` spreads
+`{ theme, ...props, ...boxProps, style }`, so a caller-supplied `onClick`
+**clobbers** `useControl`'s activation handler. Space and Enter keep working
+while the mouse silently does something else. Compose the two handlers
+rather than letting one overwrite the other.
+
+### 12.4 `<textinput onChange>` hands you a raw string
+
+`this.props.onChange?.(next)` — a bare string, where every other event in
+the system is a synthetic event object, and `src/events.js` already builds
+that shape. Make it one, put the value on both `ev.value` and
+`ev.target.value`, and add the `name` prop that does not exist today
+(#115). This is what stands between us and every DOM form library:
+`react-hook-form` and `formik` both read `e.target.name` and
+`e.target.value`, and the distance from "real adapter" to "fifty-line
+adapter" is exactly this change. Same treatment for `onSubmit`, whose
+declared signature is `(text: string, ev: unknown)` — the `unknown` is an
+admission.
+
+### 12.5 HiDPI — pick the mechanism before anything freezes
+
+There is no notion of a pixel scale anywhere in react-x11, ntk or the app
+(#116). `src/nodes.js` creates yoga nodes on the default Config
+(pointScaleFactor 1); `src/styles.js` passes `fontSize` straight through as
+a device-pixel size; nothing reads `Xft.dpi`, `GDK_SCALE`/`QT_SCALE_FACTOR`,
+or the RandR per-output mm/pixel ratio. **On a 4K panel at `Xft.dpi=192` —
+the default GNOME/KDE 2× setup — every widget and every glyph renders at
+exactly half the size of every GTK and Qt app on the same desktop.** That is
+not cosmetic; the app is unreadable, and it is the state on a large share of
+the machines people actually run.
+
+Scale is a **root** concern, not a style concern, because it has to multiply
+layout, font sizes and the paint transform together. Three wiring points,
+all small: one `Yoga.Config` per root with `setPointScaleFactor(scale)`;
+multiply the resolved font pixel size in `src/styles.js`; and
+`ctx.scale(scale, scale)` once at the top of `WindowNode.flush`, with the
+`<window width/height>` props multiplied on the way to `createWindow`.
+`node.abs` and `getClientRects()` stay in **logical** units, so `anchorRect`
+and everything built on it need no change. Yoga's point scale is exactly the
+answer to the objection that a float scale breaks the integer dirty-rect
+math: layout stays logical, computed edges snap to physical pixels so
+borders stay crisp, and rounding damage rects outward at the paint boundary
+holds the invariant.
+
+`'auto'` resolves the way GTK4 and Qt6 do: `GDK_SCALE`/`QT_SCALE_FACTOR` →
+`Xft.dpi` parsed out of the root window's `RESOURCE_MANAGER` property → the
+RandR primary output's `pixel_width / (mm_width / 25.4) / 96` rounded to the
+nearest 0.25 → 1. Plus `REACT_X11_SCALE` to override. Static at startup is
+an acceptable v1 — a mid-session DPI change is rare and we do not select
+root-window events today — but say so rather than leaving it to be
+discovered.
+
+**Separately, and do not confuse the two:** the hardcoded component
+constants (`DefaultTheme.fontSize`, `paddingX`/`paddingY`, the Checkbox and
+Radio wells, `SLIDER_THUMB`, the Switch geometry) should move into the theme
+regardless, as `theme.controlSize`, `theme.thumbSize` and friends. That is a
+user-facing accessibility knob — scale type and controls independently of
+the display — where root `scale` is a display-correctness mechanism.
+Shipping both without distinguishing them double-scales everything.
+
+### 12.6 The smaller breaking items
+
+- **Refs.** A ref on a drawn element gives the react-x11 node; a ref on
+  `<window>`/`<popup>` gives the raw ntk `Window`, so there is no way to
+  reach the `WindowNode` — its children, its theme, its layout root, its
+  screen origin. Invert it: the ref is the react-x11 node in both cases,
+  with `node.ntk` as the escape hatch. One rule instead of two.
+- **`DrawnNode.type`.** The declaration says `readonly type: string`; the
+  implementation sets `this.kind` and there is no `get type()` anywhere.
+  Add the getter — `type` is the right public name (#120).
+- **`node.screenRect()`.** `getClientRects()` is in window coordinates and
+  the screen origin lives on `window._screenOrigin`, so everything needing
+  screen coordinates re-derives it by reaching into a private field —
+  `src/components/anchor.js` already does, with a comment explaining why.
+  Anchoring, drag-and-drop, accessibility and IME candidate placement all
+  want this.
+- **`AnchorOptions` is wrong in four places** (#120). It declares
+  `{ placement, gap, width, height, flip }`; `anchor.js` destructures
+  `{ placement, align, offset, width, height }`. `gap` and `flip` are
+  inert, `align` is undeclared, and `anchorRect()` returns `null` for a
+  node with no `.abs` while the type says `Rect`. Fix the implementation
+  where the declaration is right and the declaration where the
+  implementation is right.
+- **`<window onResize|onExpose|onCloseRequest>` forward the raw ntk event**
+  while the types declare `SyntheticEvent<NtkWindow>`. Wrap them, since
+  every other handler in the system receives a synthetic event.
+- **`<image width|height>` and `<svg width|height>`** are documented, read
+  by the measure code, and **throw** in development because neither node
+  declares `semanticNames` (#118). Reachable only in production, where they
+  are silently accepted — the worst possible split. `style={{ width }}`
+  already works, so delete the branches and the doc lines.
+- **Delete the legacy entry points.** The three-way overloaded
+  `render(element, callback?, container?)` and its partner
+  `unmountComponentAtNode` both exist for familiarity with an API React
+  itself removed in 18. The default export goes with them.
+- **`SelectThemeProvider`** is a back-compat alias with nothing to be
+  compatible with.
+- **`ThemeProvider` is two theming systems wearing one name** (#119). It is
+  literally `ThemeContext.Provider` — it puts no node in the tree — while
+  [docs/styling.md](docs/styling.md) documents the **`theme` prop** as the
+  scope `$token` values resolve against. Widgets bridge them by hand, each
+  planting `theme={theme}` on its own root box. A user who writes
+  `<ThemeProvider value={dark}>` and then `<box style={{ color: '$text' }}>`
+  gets nothing and nothing tells them why. Make it a real component that
+  supplies the context _and_ the prop scope.
+- **Export the hooks every app writes by hand.** The package exports
+  exactly one, `useAnchor`. `useTheme` exists in `src/components/theme.js`
+  and is not exported from any index, so every consumer either
+  re-implements it or deep-imports. Add `useTheme`, `useApp`, `useWindow`,
+  `useWindowSize`, `useScreen` and `useClipboard` — the last of which wraps
+  a feature that ships today, is reachable only through an internal
+  `node._clipboardApi()`, and is documented in zero pages.
+- **A `screen` option on `createRoot`.** Multiple X _screens_ (`:0.0`,
+  `:0.1`) are separate root windows that no window can move between —
+  Zaphod multihead, and more usefully multi-GPU signage and control rooms.
+  `display.screen` is an array and every consumer hardcodes `[0]`.
+  Constrain a root to one screen and let a program open two roots; do
+  **not** build a migration abstraction, because X does not allow it and an
+  API that mostly throws is worse than none. This is here only because the
+  option is free this week.
+
+### 12.7 Then say what stability means
+
+Write a short stability page and ship it with the release, then hold it:
+exported functions and components, host element names and their props, and
+style property names are covered by semver; node classes, `Renderer` and
+anything reached through `root.app` are escape hatches that may change in a
+minor; **exact pixel output is not covered**, because text shaping and
+layout follow fontkit and yoga and a patch bump to either can move a glyph.
+Pin them if you snapshot. Adopt React's `experimental_` prefix so the
+ambitious things can ship before their shape is frozen, and add
+`warnOnce(oldName, newName, since)` in DEV — without it every future rename
+is a hard break.
+
+One structural hazard to write down now: `files: ["src"]` publishes every
+internal module, and the `exports` map is the only thing keeping them
+private. The moment a `./test` or `./offscreen` subpath is added, someone
+will add `"./*": "./src/*"` for convenience and the entire internal tree
+becomes API by accident. Add a test asserting the `exports` key set equals
+an expected list, so that cannot happen without a decision.
+
+## 13. Distribution
+
+Nothing in this document has ever asked how an end user ships the result,
+and the answer, reproduced from a clean directory, is that they cannot.
+
+1. **A single-file bundle fails.** Bundling with
+   `esbuild --bundle --platform=node --format=esm` produces a bundle that
+   throws at load: `Dynamic require of "events" is not supported`, from
+   node-x11's `xcore.js`. node-x11 is CJS and esbuild's interop cannot
+   resolve `require('events')`. Workaroundable with a `--banner:js` that
+   reconstructs `require` from `node:module`, and not discoverable —
+   sidorares/node-x11#246.
+2. **With that worked around it fails again, and this one is a hard stop.**
+   `keysym@0.0.6` does `fs.readFileSync(__dirname + '/data/keysyms.json')`
+   at module load. It is imported by ntk's `lib/window.js` and sits on the
+   critical path of every keypress. It cannot be bundled, cannot go in a
+   Node SEA — the SEA documentation is explicit that module loading does
+   not read from the file system — and cannot go in an AppImage without
+   shipping `node_modules`. §8 item 12 deletes it (sidorares/ntk#115).
+3. **The default font source shells out to a CLI.** `FontconfigFontSource`
+   calls `fc-match` through `child_process` and then opens font _files_
+   from host paths. A slim container, a kiosk image, a SEA or an AppImage
+   has neither. No document mentions this, and the error when it happens
+   names fontconfig rather than the packaging decision that caused it —
+   sidorares/ntk#121.
+4. **No `.desktop` entry, no icon install, no autostart.** A Linux GUI app
+   without one has no launcher entry, no MIME associations, no
+   `DBusActivatable` and no autostart.
+
+The cruel part is that the hard bit is already solved, for the browser:
+`website/scripts/browser-shims/keysym.js` is a drop-in replacement whose
+comment says precisely why the original cannot be bundled, and
+`website/scripts/build-demo-bundles.mjs` bundles the whole stack with
+esbuild. That knowledge needs to come out of the docs site.
+
+Fix the two blockers upstream, then productize as a packaging page (#128)
+with four tiers and a working configuration for each:
+
+| tier                      | what it is                                      | what it needs                                          |
+| ------------------------- | ----------------------------------------------- | ------------------------------------------------------ |
+| `npm i` + `node app.js`   | the default                                     | nothing                                                |
+| one `.mjs`                | `esbuild --bundle --platform=node --format=esm` | the keysym fix, an ESM entry for node-x11              |
+| SEA binary                | `node --experimental-sea-config`                | the above, `mainFormat: "module"`, fonts as SEA assets |
+| AppImage / flatpak / .deb | desktop distribution                            | the above, plus `.desktop` and icons                   |
+
+Worth saying explicitly in that page: **yoga-layout is already
+bundler-safe** — its WASM is base64-inlined in
+`dist/binaries/yoga-wasm-base64-esm.js`, so there is no `.wasm` file to ship
+alongside the binary. That is a real differentiator against every
+native-canvas alternative and nobody knows it.
+
+Two API pieces belong with it. `createRoot({ fonts: 'system' | 'bundled' |
+FontSource })`, where `'bundled'` is a `StaticFontSource` over a font subset
+shipped in the package — the website already does exactly this
+(`website/scripts/demo-fonts.js`) — because `'bundled'` is the only correct
+default for a container, a SEA or a kiosk, **and it makes rendering
+deterministic**, which sidesteps #86 for anyone who opts in and is what an
+image-diff test harness needs. And a `.desktop` generator rather than prose,
+`writeDesktopEntry({ id, name, exec, icon, categories, mimeTypes,
+startupWmClass })`, with the icon PNGs generated from a React component
+through the offscreen renderer (#124) so the app icon, `_NET_WM_ICON` and
+the launcher icon all come from one source.
+
+Finally, a CI `bundle` job that runs the esbuild build and executes the
+result against Xvfb. It is the only way the two blockers stay fixed; both
+were introduced silently by transitive dependencies and neither was noticed
+for years.
+
+## 14. Remote display, and the protocol ceiling
+
+The central architectural claim in the README is that the wire carries
+drawing rather than pixels, which is worth the most exactly when the display
+is somewhere else. There is no page about that. `ssh -X` appears once in the
+entire docs tree, as one row of the "you need an X server" table in
+`website/docs/getting-started.md`. Nothing anywhere mentions latency, `-X`
+versus `-Y`, `ForwardX11Timeout`, when `-C` helps, Xvnc, Xpra, or what
+actually costs a round trip.
+
+The bench has the raw material for the argument. Mounting a window with 40
+boxes and labels is 86 requests, 3652 bytes and **3 replies**; every
+paint-only scenario in `scripts/bench/baseline.json` costs exactly one.
+Replies are what a link charges for — bytes are nearly free at these sizes
+and round trips are not — and `replies` is the only column that tracks them.
+What is missing is the latency half: nothing in the repo measures what those
+replies cost at a realistic RTT, so the page cannot yet be written with
+numbers rather than adjectives. Three pieces of work follow:
+
+1. **A remote-display page** (#128). The measurements below once they
+   exist; `-X` versus `-Y` and why we should be the toolkit that works
+   under `-X`; the twenty-minute `ForwardX11Timeout` and the fact that
+   several distributions ship `ForwardX11Trusted yes` and quietly turn `-X`
+   into `-Y`; why `-C` is usually the wrong lever here and where it is the
+   right one; XQuartz, Xvnc, containers, multi-seat; Xwayland yes for app
+   windows and no for shell components. And, honestly, where VNC still wins
+   — video, and an existing app you cannot rewrite — because the comparison
+   is only credible with that in it.
+2. **An RTT mode in the bench, and `replies` as a gate.**
+   `scripts/bench/protocol.js` already collects and prints `replies`, and
+   the `--check` loop asserts on requests, bytes, composites and composite
+   pixels — everything except the one metric that predicts how the app
+   feels on a link. Add it, with a _tighter_ tolerance than the others
+   (round trips should be near-constant per scenario), and add
+   `npm run bench -- --rtt 80`, which is a delaying `Transform` around the
+   stream pair `test/integration.test.js` already builds. Then a code path
+   that adds a round trip fails CI instead of failing a user's WAN link.
+3. **The unmeasured ceiling: one socket write per request.** §8 item 14.
+   One write per request, no `writev`, no concatenation, and no
+   `setNoDelay` anywhere in the tree — so TCP X connections run with Nagle
+   on, which is invisible on the Unix socket where all the benchmarking
+   happens and is not invisible on a WAN. Turn it off without buffering
+   first and you trade a stall for packet amplification, which is worse on
+   lossy links. Buffer, flush per frame, then disable Nagle. Add `writes`
+   and `flushes` to `baseline.json` while doing it — `xcount.js` already
+   wraps `write`, so it is one line — and the 277-request clips scenario
+   should collapse to a handful of writes.
+
+One more remote-specific cost, worth a paragraph in the page and then a fix
+(sidorares/ntk#122): `<image src>` uploads raw BGRA through `PutImage` with
+no compression, so a 1920x1080 photograph is 8.3 MB on the wire. It is
+uploaded **once** and cached as a server-side pixmap, which is the right
+design, but there is no downscale-before-upload path — scaling with
+`style={{ width, height }}` scales on the server, after you have paid for
+the full-resolution transfer. Decoding, box-filtering in JS and uploading
+the size actually drawn is a small change and a bigger remote win than any
+protocol micro-optimisation on this list.
+
+## 15. Keyboard levels, Compose, and input methods
+
+§7's "deliberately out of scope for now: accessibility (AT-SPI),
+IME/compose input, Wayland" was written before the widget set,
+`<textinput>`, `<textarea>`, undo/redo and the edit menu shipped. It has not
+aged well: a text-editing toolkit that cannot type Japanese, Chinese,
+Korean, Thai, or a French `é` on a US-International layout is an
+English-only toolkit, and nothing currently says so while i18next is
+documented as working and ntk shapes bidi text.
+
+Being pure JS does not block any of this, which is why it ranks where it
+does. XIM is an X11 protocol carried over ClientMessages and window
+properties, implementable directly on node-x11. ibus exposes
+`org.freedesktop.IBus.InputContext` on the session bus with
+`ProcessKeyEvent(keyval, keycode, state)` plus `UpdatePreeditText` and
+`CommitText` signals; fcitx5 speaks D-Bus too, and both implement XIM as a
+fallback.
+
+**Stage 0 — say it, today.** A paragraph in `README.md` under Known issues
+and one under `<textinput>` in [docs/elements.md](docs/elements.md). A user
+who discovers this by typing into a demo concludes the project is broken; a
+user who reads it concludes it is honest. Costs nothing, blocks nothing.
+
+**Stage 1 — fix key→text in ntk** (§8 item 13, sidorares/ntk#116). The XKB
+level rule plus a Compose engine, emitting a string rather than a codepoint.
+**This alone makes every European layout work and needs no D-Bus.** It also
+closes half of #85.
+
+**Stage 2 — a preedit model in the renderer, backend-agnostic.**
+`onCompositionStart` / `onCompositionUpdate` / `onCompositionEnd` on the
+text controls, using react-dom's names because they are the names people
+know. `TextInputNode` keeps `_preedit` next to `_caret`, draws it at the
+caret with an underline run, and reports the caret's **screen rect** back so
+a candidate window lands in the right place — which is what
+`node.screenRect()` (§12.6) is for, and is the one change the core needs.
+
+**Stage 3 — the backends**, in `@react-x11/desktop/im` for ibus and fcitx
+over D-Bus, and `react-x11/xim` for XIM. Keep XIM: it works with any XIM
+server, and it works **over a forwarded display where the remote box has no
+session bus**, which is precisely the deployment this project is best at.
+XIM is ClientMessage and properties, so it belongs next to the protocol, not
+in the D-Bus package.
+
+## 16. Testing as something users can have
+
+The substrate here is unusually good and the product is unusually absent.
+`node --test` runs about ten thousand lines across fifteen files with no X
+server, and seven of those files drive node-x11's in-process pure-JS X
+server and read real pixels back with `GetImage`. None of it is reachable by
+anyone who installs the package: `exports` lists exactly `.`,
+`./jsx-runtime` and `./jsx-dev-runtime`, and `files` is `["src"]`. Meanwhile
+seven test files each rebuild `createServer` + `createStreamPair` +
+`StaticFontSource` from scratch and seven others import a hand-rolled
+193-line mock 2d context.
+
+Ship `react-x11/test` (#123). `x11` and `pngjs` are already in the install
+closure through ntk, so the dependency cost is genuinely zero.
+
+- `renderX11(<App/>, { width, height, backend, fonts, rtt, trace })`
+  returning the real `WindowNode` root, not an opaque handle — every
+  existing test reaches into `root._ctx`, `root._lastDamage`,
+  `root._lastDamageRects` and `root.flush()`, and a shipped harness weaker
+  than the private one is not worth shipping. Make those four supported
+  names and keep the underscored ones as aliases for a major.
+- `act()` that owns all three phases. `await React.act(...)` works today —
+  the claim that `act` is broken is wrong, and the real defect is narrower:
+  the documented `render(el, cb, app)` path resolves its callback before
+  passive effects run, so a mount effect that calls `setState` has not
+  landed when the test asserts. Every existing test works around it with an
+  ad-hoc `setImmediate` or the `settle()` round-trip helper. React's `act`
+  flushes React, not the frame; this renderer paints on ntk's frame clock,
+  and the server has seen nothing until a reply round-trips. The helper has
+  to flush React, then the frame clock, then drain the connection.
+
+  While in there: `warnsIfNotActing: false` in the host config is **dead
+  configuration** — react-reconciler 0.33 reads it as a bare expression
+  statement and discards it; the warning is gated on
+  `globalThis.IS_REACT_ACT_ENVIRONMENT`. Delete the key or comment it as
+  inert.
+
+- **Real input, through the real translation layer.** Tests currently do
+  `wnd.emit('mousedown', …)`, which skips keycode→keysym lookup, modifier
+  masks, wheel-button mapping, click-detail timing, pointer capture and
+  grabs — i.e. most of `src/events.js`. node-x11's server already has
+  `injectPointerMove`, `injectButton` and `injectKey` in
+  `lib/xserver/input.js`, plus a real US keymap with `keycodeForKeysym`,
+  and **nothing in this repo uses any of it.** Build
+  `fireEvent`/`userEvent` on those. Budget for fixing real bugs when it
+  lands: injected input goes through the server's grab and focus state
+  machine, so `<popup grab>` dismissal, `trapFocus` scopes and pointer
+  capture become testable for the first time, and some of them will fail on
+  first contact.
+- **Pixel and snapshot helpers**, which `test/integration.test.js` has
+  already written and debugged: `readPixels`, BGRA→RGB, a tolerance
+  compare, a `waitForPixel` poll. Ship them, and drop the default tolerance
+  from 40 to something honest once fonts are pinned — 40 will not notice a
+  wrong colour token.
+- **Pin the fonts, and write down why.** Glyph _indices_ travel on the wire
+  here, so font resolution is a determinism hazard in a way it is not for a
+  DOM renderer. `scripts/screenshots.jsx` already freezes `TZ`, `Date` and
+  `process.memoryUsage` with exactly the right rationale, and then resolves
+  the font family through fontconfig anyway. `test/integration.test.js`
+  does it correctly with a `StaticFontSource`. The rule: **no test or
+  snapshot script resolves a family through `FontconfigFontSource`** — with
+  one deliberately unpinned smoke test that asserts the resolved family
+  _name_, since pinning otherwise makes #86 undetectable.
+- `withFrameClock(clock => …)`, because `setAnimationClock` exists at
+  `src/nodes.js:266` precisely so tests can drive transitions and is
+  unreachable from the package — `test/style.test.js` reaches it through
+  `await import('../src/nodes.js')` and hand-restores it in six places,
+  each of which would leak if the test threw.
+
+The cheapest real win in this section is not the harness though — it is that
+`test/dirty-rect.test.js` already contains a **differential oracle**,
+`paintBothWays`, which paints a change bounded and then in full and compares
+the readbacks. It is applied to a hand-written list of scenarios. Randomise
+the input with a seeded generator over a small tree grammar and it becomes a
+property test with an oracle that cannot lie: partial paint ≡ full paint for
+any tree and any mutation; `mount(B)` ≡ `mount(A)` then `update(A→B)`, which
+is the property that catches `commitUpdate` bugs and which nothing currently
+tests; permuted `insertBefore`/`removeChild` sequences producing the same
+child list must produce the same paint; and the same mutations must produce
+an identical opcode histogram, because non-determinism there means something
+is keyed on iteration order or a timer. A small seeded generator, no new
+dependency.
+
+And the CI gaps, which are cheap and currently total: `npm run bench --
+--check` is not run by anything, despite the baseline being checked in;
+neither is `stress:check`; there is no xvfb job, so nothing ever runs
+against a real X server; and `npm run screenshots` regenerates
+`docs/img/*.png` with nothing comparing them.

--- a/README.md
+++ b/README.md
@@ -41,11 +41,53 @@ uploaded once, so drawing a line afterwards names them by index, about a byte
 per glyph; gradients, scaling, alpha compositing and clipping are single
 server-side requests rather than loops over a pixel array; nothing is read
 back. An update costs what the _drawing_ costs, not what the window's area
-costs — which is why this stays comfortable on a display forwarded over ssh.
+costs. Going full-screen on a 4K panel does not multiply your bandwidth,
+because you were not sending pixels at 1080p either — which is why this
+stays comfortable on a display forwarded over ssh. Mounting a window with
+forty rows and their labels is 86 requests and 3.6 KB on the wire.
 
 Because that is the design it is measured rather than assumed: `npm run
 bench` reports requests, bytes, replies, RENDER composites and the pixel area
 those composites touch, against a checked-in baseline.
+
+### Where this fits
+
+X11 is the wire protocol, which means the display can be somewhere the
+program is not, and the program can be somewhere a browser engine cannot go.
+That is the shape of the problem this is good at:
+
+- **the display is elsewhere** — a headless server over `ssh -X`, a
+  container pointed at the host, a thin client, an X terminal, a
+  deliberately dumb workstation;
+- **the machine cannot afford a browser engine** — a kiosk, an appliance, an
+  instrument panel, an ARM board with 512 MB, a locked-down box where
+  installing must not compile anything and root is not on offer;
+- **you want the UI in the same process as the rest of your program** —
+  `fs`, `serialport`, `pg` and your components in one heap, one event loop,
+  no IPC bridge and no second bundler;
+- **you want GUI tests that run in CI with no display server** — `npm test`
+  here renders real pixels through the real protocol into node-x11's
+  in-process X server, on a machine with no `$DISPLAY`, on macOS.
+
+And the shape it is not good at, so you can stop here rather than in week
+three:
+
+- **three platforms.** X11 only. macOS means XQuartz — a separate install, a
+  non-native look and no menu bar integration. Windows is out; if you need
+  Windows, use Electron or Tauri.
+- **native Wayland.** There is no Wayland backend and there is not going to
+  be one; that would be a different renderer, not a flag. Ordinary
+  application windows work fine on a Wayland desktop through Xwayland, which
+  is not going away — but the desktop-shell half of X11 (panel struts,
+  global key grabs, screen capture, and the window-manager example below)
+  needs a real X session.
+- **reusing web components.** There is no DOM. Your MUI, your Tailwind and
+  your `recharts` do not come with you; the state, data-fetching, validation
+  and math libraries mostly do. [docs/ecosystem.md](docs/ecosystem.md) says
+  which is which, and what the failure looks like when it is the wrong one.
+- **60 fps, video, or a webview.** `<html>` renders a subset through ntk's
+  own layout engine and is not a browser.
+- **text entry outside Latin.** See [Known issues](#known-issues).
 
 | `examples/dashboard.jsx` — context theming, hooks | `examples/tasks.jsx` — useReducer, textinput, scrollview |
 | ------------------------------------------------- | -------------------------------------------------------- |
@@ -183,7 +225,10 @@ User handlers run before element default actions and can
 
 ## Examples
 
-All need an X server (`DISPLAY` set; XQuartz on macOS, Xvfb for automation).
+All need an X server — but "an X server" is a broader thing than it sounds:
+your Linux desktop, XQuartz on macOS, `Xvfb` for automation, `Xephyr` for a
+disposable screen, a VNC server, or your own display reached over `ssh -X`
+from wherever the program actually runs.
 [`examples/README.md`](examples/README.md) describes each one and how to
 explore them:
 
@@ -348,8 +393,8 @@ the browser, so `npm run docs:test` fails when a demo stops matching the API.
 
 ## Known issues
 
-Two that are worth knowing before you hit them, both predating the current
-release and both tracked:
+Three that are worth knowing before you hit them, all predating the current
+release and all tracked:
 
 - **Non-Latin keyboard layouts type Latin**
   ([#85](https://github.com/sidorares/react-x11/issues/85)). Keysyms are
@@ -363,7 +408,38 @@ release and both tracked:
   Homebrew's fontconfig ships no macOS system-font aliases and answers
   Hiragino Sans. Latin looks fine, Cyrillic comes out on full-width
   advances. Put `/opt/X11/bin` first on `PATH` until this is fixed.
+- **Text entry is one codepoint per key event.** A key press is resolved to
+  a single keysym and committed straight into the field, with no composition
+  stage anywhere in the stack. So AltGr levels do not work (`@` on a German
+  layout, `€`, `ł`, `ã` on US-International), dead keys and Compose
+  sequences do not work (`dead_acute` then `e` produces nothing, not `é`),
+  and there is no input method integration, so CJK is not partially working
+  — it is structurally absent. The text controls have a caret, a selection,
+  an undo stack and a clipboard, and nowhere for uncommitted composition
+  text to live. Fixing the level rule is an ntk change that also closes half
+  of [#85](https://github.com/sidorares/react-x11/issues/85); a preedit
+  model and an ibus/fcitx/XIM backend are the rest.
 
-# See also
+## Security
 
-https://github.com/chentsulin/awesome-react-renderer
+X11 has no isolation between clients: any program on a display can read any
+other program's window contents, grab the keyboard, and synthesize or record
+input. That is the 1987 design, not a gap in this library, and it cuts both
+ways — do not run untrusted programs on a display you use, and do not treat
+a react-x11 window as a confidential surface. Your `$XAUTHORITY` cookie is a
+bearer token; treat it like a password.
+
+`ssh -X` runs your app as an untrusted client and restricts most of the
+above; `ssh -Y` turns the restrictions off. **Prefer `-X` — react-x11 should
+work under it, and if it does not, that is a bug worth filing.**
+
+## See also
+
+- [awesome-react-renderer](https://github.com/chentsulin/awesome-react-renderer)
+  — the catalogue of React renderers, which is how most people find things
+  like this.
+- [ntk](https://github.com/sidorares/ntk) — the toolkit underneath: windows,
+  the XRender-backed 2d context, the text stack, the frame clock.
+- [node-x11](https://github.com/sidorares/node-x11) — the X11 protocol in
+  JavaScript, including the in-process X server the tests and the playground
+  run against.

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,17 @@
   debugging aids.
 - [click-to-component.md](click-to-component.md) — Alt+Click a rendered
   element to open its JSX source line in your editor.
+- [ecosystem.md](ecosystem.md) — which npm packages work with react-x11 and
+  which do not: the rule that decides it, a compatibility table across 12
+  categories, and a register of the verbatim errors the incompatible ones
+  produce. Per-category pages:
+  [state](ecosystem/state.md), [data fetching](ecosystem/data-fetching.md),
+  [forms](ecosystem/forms.md), [icons](ecosystem/icons.md),
+  [theming](ecosystem/theming.md), [animation](ecosystem/animation.md),
+  [headless components](ecosystem/headless.md),
+  [layout](ecosystem/layout.md), [routing](ecosystem/routing.md),
+  [i18n](ecosystem/i18n.md), [testing](ecosystem/testing.md),
+  [dev tooling](ecosystem/dev-tooling.md).
 
 ## Entry points
 

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -1,0 +1,488 @@
+# Ecosystem
+
+react-x11 is a React renderer with no DOM: there is no `document`, no
+`window` global, no CSSOM, and the host elements are `<box>`/`<text>`/`<svg>`
+rather than `<div>`/`<span>`. So any package that only touches React —
+hooks, context, state, reconciliation — works unchanged, and any package
+that reaches for `document`, `window`, `HTMLElement`, CSS, or renders a
+`<div>` does not.
+
+That one rule decides every verdict below. Each of them was established by
+running the library against react-x11 1.2.0, not by reading its
+documentation — the two exceptions are React DevTools and Fast Refresh,
+which are already wired into this repo, so their pages document the working
+setup rather than re-deriving it.
+
+## The 30-second test
+
+Before installing anything, ask the four questions in order. Each one has a
+command.
+
+1. **Does it import?** `node --input-type=module -e "import('the-package')"`.
+   A package that hard-requires `react-dom`, or whose `exports` map has only
+   browser conditions, fails here — see
+   [import time](#install-and-import-time) below. Caveat: if anything else in
+   your tree already pulled `react-dom` in, this test passes and the problem
+   moves to the [silent](#silent-failures) column. Run
+   `npm ls react-dom` before you trust a pass.
+2. **Does it render host elements?** Grep the shipped code for tag names:
+
+   ```sh
+   grep -rEoh '"(div|span|button|input|form|style|a)"' \
+     node_modules/the-package --include='*.js' --include='*.mjs' | sort -u
+   ```
+
+   Anything that emits DOM tags cannot render here, no matter how headless
+   the README says it is. This one is a reliable verdict: zustand and
+   `@tanstack/react-table` print nothing; recharts, react-select and Headless
+   UI print a list.
+
+3. **Does it read DOM globals?** Same shape, different pattern:
+
+   ```sh
+   grep -rnE 'typeof window|typeof document|HTMLElement|getBoundingClientRect' \
+     node_modules/the-package --include='*.js' --include='*.mjs'
+   ```
+
+   This one is a pointer, not a verdict — _read the hits_. A minified UMD
+   bundle and an `isSSR = typeof window === "undefined"` default both match
+   harmlessly. What you are looking for is an environment probe whose result
+   gates a feature, because that is the silent-failure shape: the library
+   decides it is doing SSR and quietly turns things off. Check the transitive
+   core package too — `@tanstack/query-core`, not just
+   `@tanstack/react-query`, which has no hits of its own.
+
+4. **Does it expect DOM-shaped events?** react-x11's `<textinput>` calls
+   `onChange(newString)`, not `onChange(event)`. A library whose handler does
+   `event.target.value` mounts fine and then breaks on the first keystroke.
+   Grep for `target.value`.
+
+A library that passes all four is almost always a drop-in. A library that
+fails 2 or 3 usually has a headless core published separately — that is the
+pattern behind half the adapters on this page.
+
+## What works
+
+Fifty-three packages and two Node built-ins, across 12 categories. **Out of
+the box** means install and use; **adapter** means a small amount of glue,
+written out in full on the category page.
+
+### State management
+
+| Package                                      | Integration                                          |                                     |
+| -------------------------------------------- | ---------------------------------------------------- | ----------------------------------- |
+| `zustand`                                    | out of the box                                       | [state](ecosystem/state.md#zustand) |
+| `jotai`                                      | out of the box                                       | [state](ecosystem/state.md#jotai)   |
+| `valtio`                                     | out of the box                                       | [state](ecosystem/state.md#valtio)  |
+| `xstate` + `@xstate/react`                   | out of the box                                       | [state](ecosystem/state.md#xstate)  |
+| `redux` + `@reduxjs/toolkit` + `react-redux` | out of the box — **pin react-redux ≥ 9**             | [state](ecosystem/state.md#redux)   |
+| `immer`                                      | out of the box                                       | [state](ecosystem/state.md#immer)   |
+| `mobx` + `mobx-react-lite`                   | adapter — no code, but `react-dom` must be installed | [state](ecosystem/state.md#mobx)    |
+
+### Data fetching
+
+| Package                 | Integration        |                                                            |
+| ----------------------- | ------------------ | ---------------------------------------------------------- |
+| `@tanstack/react-query` | adapter, ~12 lines | [data fetching](ecosystem/data-fetching.md#tanstack-query) |
+| `swr`                   | adapter, 1 line    | [data fetching](ecosystem/data-fetching.md#swr)            |
+
+### Forms and validation
+
+| Package                | Integration                                    |                                             |
+| ---------------------- | ---------------------------------------------- | ------------------------------------------- |
+| `@tanstack/react-form` | out of the box                                 | [forms](ecosystem/forms.md#tanstack-form)   |
+| `zod`                  | out of the box                                 | [forms](ecosystem/forms.md#zod)             |
+| `react-hook-form`      | adapter — use `<Controller>`, not `register()` | [forms](ecosystem/forms.md#react-hook-form) |
+
+### Icons
+
+| Package                              | Integration                           |                                              |
+| ------------------------------------ | ------------------------------------- | -------------------------------------------- |
+| `@iconify/utils` + `@iconify-json/*` | out of the box                        | [icons](ecosystem/icons.md#iconify)          |
+| `@heroicons/react`                   | out of the box — size it with `style` | [icons](ecosystem/icons.md#heroicons-react)  |
+| `lucide`                             | adapter, ~10 lines                    | [icons](ecosystem/icons.md#lucide)           |
+| `lucide-static`                      | adapter, ~12 lines (`iconSource`)     | [icons](ecosystem/icons.md#lucide-static)    |
+| `react-icons`                        | adapter, ~15 lines                    | [icons](ecosystem/icons.md#react-icons)      |
+| `@tabler/icons`                      | adapter — `iconSource`                | [icons](ecosystem/icons.md#tabler-icons)     |
+| `@phosphor-icons/core`               | adapter — `iconSource`                | [icons](ecosystem/icons.md#phosphor-icons)   |
+| `heroicons` (the asset package)      | adapter — `iconSource`                | [icons](ecosystem/icons.md#heroicons-assets) |
+| `feather-icons`                      | adapter, ~5 lines                     | [icons](ecosystem/icons.md#feather-icons)    |
+
+### Theming, palettes and colour
+
+| Package                               | Integration                         |                                                          |
+| ------------------------------------- | ----------------------------------- | -------------------------------------------------------- |
+| `@radix-ui/colors`                    | out of the box                      | [theming](ecosystem/theming.md#radix-colors)             |
+| `@catppuccin/palette`                 | out of the box                      | [theming](ecosystem/theming.md#catppuccin)               |
+| `@material/material-color-utilities`  | out of the box from a source colour | [theming](ecosystem/theming.md#material-color-utilities) |
+| `colord`                              | out of the box                      | [theming](ecosystem/theming.md#colord)                   |
+| `culori`                              | out of the box                      | [theming](ecosystem/theming.md#culori)                   |
+| `open-props`                          | out of the box for colours          | [theming](ecosystem/theming.md#open-props)               |
+| `tailwindcss` (`/colors` export only) | adapter, ~3 lines — oklch → hex     | [theming](ecosystem/theming.md#tailwind-colors)          |
+| `daltonize`                           | adapter, ~4 lines                   | [theming](ecosystem/theming.md#daltonize)                |
+
+### Animation
+
+| Package                            | Integration                       |                                                            |
+| ---------------------------------- | --------------------------------- | ---------------------------------------------------------- |
+| `popmotion`                        | out of the box                    | [animation](ecosystem/animation.md#popmotion)              |
+| `d3-ease`                          | out of the box                    | [animation](ecosystem/animation.md#d3-ease)                |
+| `d3-interpolate`                   | out of the box                    | [animation](ecosystem/animation.md#d3-interpolate)         |
+| `@tweenjs/tween.js`                | out of the box                    | [animation](ecosystem/animation.md#tweenjs)                |
+| `flubber`                          | out of the box                    | [animation](ecosystem/animation.md#flubber)                |
+| `react-transition-group`           | out of the box — with `nodeRef`   | [animation](ecosystem/animation.md#react-transition-group) |
+| `@react-spring/core` + `/animated` | adapter, ~20 lines (`createHost`) | [animation](ecosystem/animation.md#react-spring)           |
+
+### Headless components
+
+| Package                 | Integration    |                                                  |
+| ----------------------- | -------------- | ------------------------------------------------ |
+| `react-stately`         | out of the box | [headless](ecosystem/headless.md#react-stately)  |
+| `@tanstack/react-table` | out of the box | [headless](ecosystem/headless.md#tanstack-table) |
+
+### Layout and positioning
+
+| Package                  | Integration                                          |                                                |
+| ------------------------ | ---------------------------------------------------- | ---------------------------------------------- |
+| `@floating-ui/core`      | adapter, ~35 lines (platform object)                 | [layout](ecosystem/layout.md#floating-ui)      |
+| `@tanstack/virtual-core` | adapter, ~40 lines — the core, not the React wrapper | [layout](ecosystem/layout.md#tanstack-virtual) |
+
+### Routing
+
+| Package        | Integration                                  |                                              |
+| -------------- | -------------------------------------------- | -------------------------------------------- |
+| `wouter`       | out of the box — `wouter/memory-location`    | [routing](ecosystem/routing.md#wouter)       |
+| `react-router` | out of the box — `MemoryRouter`, no `<Link>` | [routing](ecosystem/routing.md#react-router) |
+
+### Internationalization
+
+| Package                     | Integration    |                           |
+| --------------------------- | -------------- | ------------------------- |
+| `i18next` + `react-i18next` | out of the box | [i18n](ecosystem/i18n.md) |
+
+### Testing
+
+| Package                | Integration                                        |                                                     |
+| ---------------------- | -------------------------------------------------- | --------------------------------------------------- |
+| `node:test` (built-in) | out of the box                                     | [testing](ecosystem/testing.md#runners)             |
+| `vitest`               | out of the box                                     | [testing](ecosystem/testing.md#vitest)              |
+| `msw`                  | out of the box — `msw/node`                        | [testing](ecosystem/testing.md#msw)                 |
+| `fast-check`           | out of the box                                     | [testing](ecosystem/testing.md#fast-check)          |
+| `sinon`                | out of the box — one required `toFake` restriction | [testing](ecosystem/testing.md#sinon)               |
+| `pixelmatch`           | out of the box                                     | [testing](ecosystem/testing.md#pixelmatch)          |
+| `react-test-renderer`  | out of the box — but deprecated upstream           | [testing](ecosystem/testing.md#react-test-renderer) |
+
+### Developer tooling
+
+| Package                                    | Integration                                                |                                                            |
+| ------------------------------------------ | ---------------------------------------------------------- | ---------------------------------------------------------- |
+| `react-devtools-core`                      | out of the box — already wired behind `REACT_X11_DEVTOOLS` | [dev tooling](ecosystem/dev-tooling.md#react-devtools)     |
+| `react-refresh` + `hot-module-replacement` | out of the box — setup already in-repo                     | [dev tooling](ecosystem/dev-tooling.md#react-refresh)      |
+| `node --inspect` (built-in)                | out of the box                                             | [dev tooling](ecosystem/dev-tooling.md#node-inspect)       |
+| `0x`                                       | out of the box                                             | [dev tooling](ecosystem/dev-tooling.md#0x)                 |
+| `@welldone-software/why-did-you-render`    | out of the box                                             | [dev tooling](ecosystem/dev-tooling.md#why-did-you-render) |
+
+## What does not work
+
+Everything below was reproduced against react-x11 1.2.0. The error text is
+verbatim — if you got here by searching for one of these strings, this is
+the right page.
+
+Failures come in four flavours, and they cost very different amounts of
+time:
+
+- **Install and import time** — loud, immediate, cheap.
+- **Render time** — loud, immediate, and the message usually names the
+  offending element.
+- **First interaction** — the tree mounts clean and breaks on the first
+  keystroke. Expensive, because the stack trace points at the library, not
+  at the renderer.
+- **Silent** — no error, ever. The most expensive class by a wide margin;
+  read that table even if nothing is broken yet.
+
+### Install and import time
+
+| Package                                   | Error                                                                                                                                                 | Use instead                                                                                                  |
+| ----------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `react-redux@8`                           | `npm error code ERESOLVE` … `peer react@"^16.8 \|\| ^17.0 \|\| ^18.0" from react-redux@8.1.3`                                                         | `react-redux@9` — [state](ecosystem/state.md#redux)                                                          |
+| `react-redux@8` (past ERESOLVE)           | `Error: Cannot find module 'react-dom'` from `react-redux/lib/utils/reactBatchedUpdates.js`                                                           | `react-redux@9`                                                                                              |
+| `@tanstack/react-virtual`                 | `Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'react-dom' imported from node_modules/@tanstack/react-virtual/dist/esm/index.js`                  | `@tanstack/virtual-core` — [layout](ecosystem/layout.md#tanstack-virtual)                                    |
+| `styled-components`                       | `TypeError: styled.div is not a function`                                                                                                             | `createStyles`/`ThemeProvider` + a palette package — [theming](ecosystem/theming.md)                         |
+| `react-scan`                              | `Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './auto' is not defined by "exports" in node_modules/react-scan/package.json imported from …` | React's own `<Profiler>`, or why-did-you-render — [dev tooling](ecosystem/dev-tooling.md#why-did-you-render) |
+| `@testing-library/react` (no `react-dom`) | `Error: Cannot find module 'react-dom/test-utils'`                                                                                                    | `node:test` or `vitest` — [testing](ecosystem/testing.md)                                                    |
+| `jest` (no ESM config)                    | `Jest encountered an unexpected token` … `SyntaxError: Cannot use import statement outside a module`                                                  | `node:test`/`vitest`, or Jest in ESM mode — [testing](ecosystem/testing.md#jest)                             |
+| `jest` (transformed to CJS)               | `SyntaxError: Cannot use 'import.meta' outside a module`                                                                                              | as above                                                                                                     |
+
+`styled-components` deserves a note because the error is actively
+misleading. It fires at module-evaluation time, mentions neither react-x11
+nor the DOM, and sends people hunting for a version mismatch:
+
+```js
+import styled from 'styled-components';
+const Panel = styled.div`
+  background: #1e1e2e;
+`; // throws right here
+```
+
+Under plain Node ESM — which is how react-x11 apps run, with no bundler —
+the default import resolves to the CJS module namespace, so `styled` is an
+object with `ServerStyleSheet` and friends on it, and no `.div`. Working
+around the interop with `const styled = sc.default ?? sc` only moves you to
+`react-x11: unknown element type <div>`. See the
+[silent failures](#silent-failures) table for what happens if you then try
+`styled('box')`.
+
+The two Jest entries are the same dead end from two directions. Full text:
+
+```
+Jest encountered an unexpected token
+…
+    node_modules/react-x11/src/Reconciler.js:27
+    const _require = (0, _nodeModule.createRequire)(import.meta.url);
+                                                           ^^^^
+    SyntaxError: Cannot use 'import.meta' outside a module
+```
+
+`react-x11/src/Reconciler.js` and `src/DevToolsIntegration.js` both call
+`createRequire(import.meta.url)`, which cannot be down-compiled to CJS. Jest
+_can_ run react-x11 tests, but only in real ESM mode — see
+[testing](ecosystem/testing.md#jest). `node:test` and `vitest` need no
+transform at all.
+
+### Render time
+
+The renderer's own errors are prefixed `react-x11:` and name the element it
+could not create. This is the most common failure by far, and the tag it
+names tells you which library layer broke.
+
+| Package                              | Error                                                                                                                                                                                                                        | Use instead                                                                                    |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `framer-motion`                      | `react-x11: uncaught error Error: react-x11: unknown element type <div>. Supported: <window>, <popup>, <box>, <text>, <image>, <canvas>, <scrollview>, <textinput>, <textarea>, <markdown>, <html>, <svg>, <tex>, <glarea>.` | popmotion, `@tweenjs/tween.js`, d3-ease + d3-interpolate — [animation](ecosystem/animation.md) |
+| `framer-motion` (value layer)        | `ReferenceError: HTMLElement is not defined`                                                                                                                                                                                 | popmotion — [animation](ecosystem/animation.md#popmotion)                                      |
+| `recharts`                           | `react-x11: uncaught error Error: react-x11: unknown element type <div>. …`                                                                                                                                                  | d3-scale + d3-shape into the `<svg>` host — [below](#charting)                                 |
+| `formik` (`<Form>` with a `<Field>`) | `react-x11: uncaught error Error: react-x11: unknown element type <input>. …`                                                                                                                                                | `@tanstack/react-form` — [forms](ecosystem/forms.md#tanstack-form)                             |
+| `formik` (`<Form>` alone)            | `react-x11: uncaught error Error: react-x11: unknown element type <form>. …`                                                                                                                                                 | as above                                                                                       |
+| `@headlessui/react` (`Switch`)       | `react-x11: uncaught error Error: react-x11: unknown element type <button>. …`                                                                                                                                               | react-x11's built-in widgets — [components](components.md)                                     |
+| `@headlessui/react` (`Dialog`)       | `react-x11: uncaught error Error: react-x11: unknown element type <span>. …`                                                                                                                                                 | react-x11's built-in `Dialog`                                                                  |
+| `@radix-ui/react-dialog`             | `react-x11: uncaught error Error: react-x11: unknown element type <button>. …`                                                                                                                                               | react-x11's built-in `Dialog`                                                                  |
+| `react-select`                       | `react-x11: uncaught error Error: react-x11: unknown element type <style>. …`                                                                                                                                                | react-x11's built-in `Select`                                                                  |
+| `@emotion/styled`                    | `react-x11: uncaught error Error: react-x11: unknown element type <style>. …`                                                                                                                                                | `createStyles` + `ThemeProvider` — [styling](styling.md)                                       |
+| `react-dropzone`                     | `react-x11: uncaught error Error: react-x11: unknown element type <input>. …`                                                                                                                                                | nothing yet — file drop is the XDND protocol, renderer-side work                               |
+| `react-router-dom` (`BrowserRouter`) | `react-x11: uncaught error ReferenceError: document is not defined` at `getUrlBasedHistory`                                                                                                                                  | `MemoryRouter` — [routing](ecosystem/routing.md#react-router)                                  |
+| `react-router-dom` (`<Link>`)        | `react-x11: uncaught error Error: react-x11: unknown element type <a>. …`                                                                                                                                                    | `useNavigate()` on a `<box onClick>`                                                           |
+| `lucide-react`                       | `react-x11: uncaught error Error: react-x11: <svg width=…> is a style property — pass it in style: <svg style={{ width: … }} />`                                                                                             | `@iconify-json/lucide`, or `lucide` — [icons](ecosystem/icons.md)                              |
+| `@tabler/icons-react`                | `react-x11: uncaught error Error: react-x11: <svg width=…> is a style property — pass it in style: <svg style={{ width: … }} />`                                                                                             | `@iconify-json/tabler`, or `@tabler/icons` — [icons](ecosystem/icons.md#tabler-icons)          |
+| `@phosphor-icons/react`              | `react-x11: uncaught error Error: react-x11: <svg width=…> is a style property — pass it in style: <svg style={{ width: … }} />`                                                                                             | `@iconify-json/ph`, or `@phosphor-icons/core` — [icons](ecosystem/icons.md#phosphor-icons)     |
+| `@testing-library/react`             | `ReferenceError: document is not defined` at `render (node_modules/@testing-library/react/dist/pure.js:256:5)`                                                                                                               | `node:test`/`vitest` against the node tree — [testing](ecosystem/testing.md)                   |
+| `@testing-library/dom` (`within`)    | `TypeError: Expected container to be an Element, a Document or a DocumentFragment but got WindowNode.`                                                                                                                       | walk `node.children`/`node.props` — [testing](ecosystem/testing.md)                            |
+| `@testing-library/dom` (`screen`)    | `TypeError: For queries bound to document.body a global document has to be available... Learn more: https://testing-library.com/s/screen-global-error`                                                                       | nothing — there is no accessibility tree behind react-x11 today                                |
+| `@testing-library/user-event`        | `TypeError: Cannot read properties of undefined (reading 'Symbol(Node prepared with document state workarounds)')`                                                                                                           | emit raw ntk events on the window — [testing](ecosystem/testing.md#driving-events)             |
+| `jest-image-snapshot`                | `TypeError: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received an instance of Object`                                                               | `getImageData` + `pngjs` + `pixelmatch` — [testing](ecosystem/testing.md#pixelmatch)           |
+| `react-x11` test selectors           | `Error: Test selector API is not supported by this renderer.`                                                                                                                                                                | nothing — `supportsTestSelectors` is `false`                                                   |
+
+Four of those need the detail, because the obvious workaround does not
+work.
+
+**framer-motion cannot be rescued by dropping to its value layer.** The
+`motion.div` failure is the expected one; the interesting one is what
+happens when you reach past it:
+
+```js
+import { animate, motionValue } from 'framer-motion';
+const mv = motionValue(0);
+mv.on('change', (v) => console.log(v));
+animate(mv, 100, { duration: 0.1 });
+// ReferenceError: HTMLElement is not defined
+```
+
+`motion-dom` feature-detects the Web Animations API by testing
+`subject instanceof HTMLElement`, so `animate()` on a plain `motionValue`
+still throws once keyframes resolve — asynchronously, from
+`motion-dom/src/animation/waapi/supports/waapi.ts`. Use popmotion's
+`animate()` instead: same author lineage, no DOM assumption.
+
+**The Radix escape hatch is worse than the error.**
+`<Dialog.Portal><Dialog.Content /></Dialog.Portal>` produces no error and no
+output at all — Radix's `Portal` is SSR-guarded, finds no `document`, and
+renders nothing, so the dialog silently never appears. Every Radix primitive
+has that shape. (`@radix-ui/colors`, by contrast, is pure data and is
+[recommended](ecosystem/theming.md#radix-colors).)
+
+**react-dropzone fails twice.** Deleting the `<input>` does not rescue it:
+with only `<box {...getRootProps()} />` you get past the reconciler and then
+hit `react-x11: uncaught error ReferenceError: window is not defined`,
+thrown from react-dropzone's own mount effect.
+
+**The three `*-react` icon packages produce a byte-identical error**, and it
+is not "unknown element type" — react-x11 has a real `<svg>` host, so the
+icon gets further than every other DOM library here and then dies on the
+flat `width`/`height` props those wrappers set unconditionally. There is no
+prop you can pass to avoid it. `@heroicons/react` is the
+[exception](ecosystem/icons.md#heroicons-react): it sizes with a class name
+rather than flat attributes, so it renders.
+
+Two more index notes for searchers:
+
+- `react-select` reports `<style>`, not `<div>`. It is built on Emotion, and
+  the first host it emits is Emotion's injected style tag — so this is the
+  CSS-in-JS failure rather than the component failure.
+- `formik` reports `<input>` when your `<Form>` has a `<Field>` in it and
+  `<form>` when it does not, because the reconciler completes children
+  first.
+- `react-router-dom`'s `<Link>` with a bare string child hits the raw-text
+  error first: `react-x11: raw text "go" must be wrapped in a <text> element
+(or be the string child of <markdown>/<html>/<tex>/an SVG <text>).`
+
+#### Charting, without recharts {#charting}
+
+There is no charting entry in the compatibility table, but the substitute
+for `recharts` is small: compute with `d3-scale` + `d3-shape` and emit the
+path into react-x11's own `<svg>` host.
+
+```jsx
+import { scaleLinear } from 'd3-scale';
+import { line } from 'd3-shape';
+
+const data = [
+  [0, 3],
+  [1, 7],
+  [2, 4],
+  [3, 9],
+  [4, 6],
+];
+const x = scaleLinear().domain([0, 4]).range([0, 200]);
+const y = scaleLinear().domain([0, 10]).range([100, 0]);
+const d = line()
+  .x((p) => x(p[0]))
+  .y((p) => y(p[1]))(data);
+
+<svg style={{ width: 200, height: 100 }} viewBox="0 0 200 100">
+  <path d={d} stroke="#89b4fa" fill="none" strokeWidth={2} />
+</svg>;
+```
+
+The `<canvas>` host with an `onDraw` handler is the other option, and the
+better one for dense plots.
+
+### First interaction
+
+These mount without a single error message. The first sign of trouble is a
+keystroke.
+
+| Package                           | Error                                                              | Use instead                                                        |
+| --------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------ |
+| `downshift`                       | `TypeError: Cannot read properties of undefined (reading 'value')` | react-x11's built-in `Select`                                      |
+| `formik` (`getFieldProps` spread) | _(nothing — no error, no warning, the field never updates)_        | `@tanstack/react-form` — [forms](ecosystem/forms.md#tanstack-form) |
+
+Both have the same cause: react-x11's `<textinput>` calls
+`onChange(newString)`, never `onChange(event)`.
+
+```jsx
+const c = useCombobox({ items: ['alpha', 'beta'] });
+return <textinput {...c.getInputProps()} />;
+// mounts clean; the first keystroke calls onChange('al') and
+// downshift's handler does event.target.value
+```
+
+Note the missing `react-x11:` prefix — the throw comes from downshift, so
+nothing in the message suggests the renderer is involved. You will also see
+downshift's own dev warning if you only wire the input:
+`downshift: You forgot to call the getMenuProps getter function on your
+component / element.`
+
+Formik is the same shape, one degree quieter. `handleChange` treats a string
+argument as its curried field-name form, returns a handler, and never
+touches state — `values` stays `{"host":""}` and `touched` stays `{}` with
+nothing logged. Never spread `getFieldProps` onto a react-x11 host. If you
+must use Formik, drive it by hand:
+
+```jsx
+<textinput
+  value={f.values.host}
+  onChange={(v) => f.setFieldValue('host', v)}
+  onBlur={() => f.setFieldTouched('host')}
+/>
+```
+
+The render-prop form of `<Formik>` works this way and `f.submitForm()`
+delivers the right values. There is a sharper edge nearby: passing a
+non-string object to `handleChange` — a hand-rolled fake event, say —
+throws `TypeError: Cannot read properties of undefined (reading 'type')`
+instead of no-opping.
+
+### Silent failures
+
+No error is ever printed. Read this table before you spend an afternoon.
+
+| Package                                                | What happens                                                                                                                                                  | Fix                                                                                                                               |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `swr`                                                  | `(silent) data never refetches when the X11 window regains focus — no error, no warning, revalidateOnFocus just never fires`                                  | define `globalThis.window` before importing swr, or use `@tanstack/react-query` — [data fetching](ecosystem/data-fetching.md#swr) |
+| `@tanstack/react-virtual` (with `react-dom` installed) | `(silent) with react-dom installed the import resolves and the list renders, but the flushSync re-measure applies to react-dom's reconciler, not react-x11's` | `@tanstack/virtual-core` — [layout](ecosystem/layout.md#tanstack-virtual)                                                         |
+| `react-scan`                                           | `(silent) no error, no output — onRender never fires and getReport() stays empty`                                                                             | React's own `<Profiler>` (verified working), or why-did-you-render                                                                |
+| `@radix-ui/react-dialog` (`Dialog.Portal`)             | renders nothing; the SSR guard finds no `document`                                                                                                            | react-x11's built-in `Dialog`                                                                                                     |
+| `styled-components` (`styled('box')`)                  | renders with no error and hands the box a single `className` prop, which react-x11 ignores — the CSS goes nowhere                                             | `createStyles` + `ThemeProvider`                                                                                                  |
+| `tailwindcss/colors` (raw values)                      | v4 ships `oklch()` strings; ntk's parser returns null and paints nothing                                                                                      | convert with `culori` — [theming](ecosystem/theming.md#tailwind-colors)                                                           |
+
+The swr one is the most expensive, so here it is in full. `useSWR` fetches
+on mount, caches and dedupes correctly. What never happens is focus
+revalidation, because swr computes its environment once at import:
+
+```js
+// swr/dist/_internal/config-context-*.mjs
+const IS_SERVER = !isWindowDefined || isLegacyDeno;
+```
+
+In Node there is no global `window`, so `initCache`'s `if (!IS_SERVER)`
+branch never runs and neither `initFocus` nor `initReconnect` is ever
+called — swr registers zero listeners. The documented React Native escape
+hatch does not help either: a custom `initFocus` passed through
+`<SWRConfig value={{ provider, initFocus }}>` is never called, because the
+guard sits above it. The workaround, and its one gotcha, are on the
+[data fetching](ecosystem/data-fetching.md#swr) page.
+
+The `@tanstack/react-virtual` entry is subtle in a different way. `react-dom`
+is a _required_ peer, so a default `npm i @tanstack/react-virtual` installs
+it and the import-time error above never appears. `react-dom@19`'s
+`flushSync()` called outside any react-dom root runs the callback and does
+not throw — so nothing warns you that the synchronous flush the virtualizer
+depends on is happening in the wrong renderer.
+
+## Adding a library that is not listed
+
+Run the [30-second test](#the-30-second-test) first; it settles most cases
+without an install. If it passes, the fastest real check is a render:
+
+```jsx
+// probe.jsx — needs a display: run under $DISPLAY, or `xvfb-run -a`
+import ReactX11 from 'react-x11';
+import { TheThing } from 'the-package';
+
+await ReactX11.render(
+  <window width={300} height={200} title="probe">
+    <box style={{ flexGrow: 1 }}>
+      <TheThing />
+    </box>
+  </window>,
+);
+```
+
+Four outcomes, and each one tells you where to look:
+
+- **`react-x11: unknown element type <…>`** — the library renders DOM hosts.
+  Look for a headless core published as a separate package; that is what
+  rescued TanStack Virtual, Floating UI and react-spring.
+- **`react-x11: <… width=…> is a style property`** — it got as far as a real
+  react-x11 host and then passed a flat style prop. Usually fixable by
+  wrapping the component rather than replacing it.
+- **`ReferenceError: document is not defined`** (or `window`, or
+  `HTMLElement`) — a DOM global at module or mount time. Check whether the
+  library has a documented environment-override seam, the way
+  `@tanstack/react-query`'s `environmentManager` does.
+- **It renders.** Then type into it, click it, and resize the window. The
+  event-shape and silent classes only show up here.
+
+If you establish a result — either direction — open an issue on
+[the react-x11 repository](https://github.com/sidorares/react-x11/issues)
+with the package name, its exact version, the code you ran, and the verbatim
+output. Negative results are as useful as positive ones on this page; most
+of what is above started as somebody's wasted afternoon.

--- a/docs/ecosystem/_category_.json
+++ b/docs/ecosystem/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Ecosystem by category",
+  "position": 20
+}

--- a/docs/ecosystem/animation.md
+++ b/docs/ecosystem/animation.md
@@ -1,0 +1,394 @@
+# Animation
+
+react-x11 has a built-in `transition` style property with a fixed easing
+curve — see [styling](../styling.md#transitions). Everything on this page
+exists to cover what that cannot express: springs with velocity carry-over,
+interruption, arbitrary easing curves, shape morphing, and keeping an element
+mounted while it animates out.
+
+There is one constraint every entry shares: **there is no `opacity` style
+property**, and `validateStyle` throws on unknown properties. The classic
+fade does not port literally; animate a colour, a size or a position instead.
+
+Two patterns recur. The cheap one is `onUpdate → setState → style prop`:
+every frame is a React render plus a commit, which react-x11 turns into a
+partial repaint of the node whose paint changed. Keep the animated component
+a leaf — a `<box>`, not the window root — and it is fine at spring frame
+rates. The expensive-to-set-up, cheap-to-run one is the
+[react-spring host](#react-spring), which applies frames imperatively and
+bypasses React entirely.
+
+Headless Node has no `requestAnimationFrame`. In a real app the right clock
+is the ntk window's `requestAnimationFrame`, reachable through a ref on
+`<window>`, which paces frames to X connection latency; a 16 ms
+`setInterval` works everywhere else.
+
+`framer-motion` is not on this page. Both its component layer and its bare
+value layer fail — see the
+[negative-results register](../ecosystem.md#render-time), which also explains
+why reaching past `motion.*` does not help.
+
+## popmotion {#popmotion}
+
+**Out of the box.** popmotion@11.0.5.
+
+Framer's low-level animation toolkit: `animate()` tweens or springs a plain
+JS value and calls `onUpdate(v)` every frame. No components, no DOM — the
+value goes wherever you point it. This is the smallest way to get real
+springs, with velocity and overshoot, without adopting the react-spring host.
+
+```jsx
+import React, { useEffect, useState } from 'react';
+import { animate } from 'popmotion';
+
+function Bar() {
+  const [w, setW] = useState(20);
+  useEffect(() => {
+    const anim = animate({
+      from: 20,
+      to: 200,
+      stiffness: 300,
+      damping: 20,
+      onUpdate: setW,
+    });
+    return () => anim.stop();
+  }, []);
+  return <box style={{ width: w, height: 30, backgroundColor: '#3366ff' }} />;
+}
+```
+
+popmotion's `framesync` detects the missing `requestAnimationFrame` and falls
+back to a 16.7 ms `setTimeout`, so it works headless with no configuration.
+For latency-adaptive pacing, `animate()` accepts a custom `driver` you can
+back with the ntk window's clock.
+
+- Springs on layout properties (width, margin) cost a yoga layout pass per
+  frame — the same trade react-x11's own layout transitions make.
+- `animate` also interpolates colour strings (`'#f00' → '#00f'`), and the
+  `rgba(...)` strings it emits are accepted by the paint path.
+- popmotion's `styler` and DOM helpers are irrelevant here. Use only the
+  value APIs: `animate`, `spring`, `decay`, `mix`.
+
+## d3-ease {#d3-ease}
+
+**Out of the box.** d3-ease@3.0.1.
+
+Pure easing functions: `ease(t)` maps normalized time to normalized progress,
+and nothing else. Thirty-plus curves — cubic, elastic, bounce, back — each a
+few lines of maths with no environment dependencies. This is the zero-cost
+way to get the curves the built-in `transition` does not have.
+
+Compute `t` from wall time, pass `ease(t)` to an interpolator, push the
+result into a style prop.
+
+```jsx
+import React, { useEffect, useState } from 'react';
+import { easeCubicOut } from 'd3-ease';
+import { interpolateNumber } from 'd3-interpolate';
+
+function useTimeline(duration, ease, onFrame) {
+  useEffect(() => {
+    const start = Date.now();
+    const timer = setInterval(() => {
+      const t = Math.min(1, (Date.now() - start) / duration);
+      onFrame(ease(t));
+      if (t >= 1) clearInterval(timer);
+    }, 16);
+    return () => clearInterval(timer);
+  }, []);
+}
+
+const width = interpolateNumber(10, 200);
+
+function Gauge() {
+  const [f, setF] = useState(0);
+  useTimeline(250, easeCubicOut, setF);
+  return (
+    <box style={{ width: width(f), height: 24, backgroundColor: '#204080' }} />
+  );
+}
+```
+
+- ESM-only since v3 — `require()` fails, `import` works. react-x11 apps are
+  ESM anyway.
+- It is only the curve; you own the clock and the interpolation.
+- Overshooting curves (elastic, back) produce values outside the from/to
+  range. That is the point of them, but clamp before feeding anything
+  react-x11 validates as non-negative.
+
+## d3-interpolate {#d3-interpolate}
+
+**Out of the box.** d3-interpolate@3.0.1.
+
+`interpolate(a, b)` returns `t => value` for numbers, colours in any CSS
+space, strings with embedded numbers, dates, arrays and nested objects. Pure
+maths, no DOM.
+
+Worth knowing: `interpolateRgb` emits `'rgb(r, g, b)'` strings and the paint
+path takes them as-is, so colour animation needs no conversion. react-x11 has
+an internal interpolator for its own `transition` styles, but it is not
+exported and handles only what transitions need — d3-interpolate is the
+general tool for hand-rolled timelines.
+
+```jsx
+import { easeCubicOut } from 'd3-ease';
+import { interpolateNumber, interpolateRgb } from 'd3-interpolate';
+
+const width = interpolateNumber(10, 200);
+const color = interpolateRgb('#204080', '#e04040');
+
+function Gauge() {
+  const [f, setF] = useState(0);
+  useTimeline(250, easeCubicOut, setF); // see d3-ease above
+  return (
+    <box style={{ width: width(f), height: 24, backgroundColor: color(f) }} />
+  );
+}
+```
+
+- ESM-only since v3.
+- Generic `interpolate(a, b)` on objects interpolates _every_ numeric-looking
+  key, so interpolating a whole style object will happily produce fractional
+  values for properties that want integers. Interpolate the two or three
+  properties you mean.
+- There is no `opacity`; to fade, interpolate a colour's alpha into
+  `backgroundColor: 'rgba(...)'`.
+- `interpolateArray` over polygon points feeding `<canvas onDraw>` is a good
+  use of the general form.
+
+## `@tweenjs/tween.js` {#tweenjs}
+
+**Out of the box.** @tweenjs/tween.js@25.0.0.
+
+`new Tween(obj).to(target, ms).easing(...).onUpdate(...).start()`, and then
+_you_ call `tween.update(time)` on whatever clock you own. Since v18 there is
+no implicit global loop — nothing runs until you pump it.
+
+The explicit clock is the feature here: in a real app, pump from the ntk
+window's `requestAnimationFrame`, which paces updates to X connection
+latency. Use one `Group` per window if you run many tweens, so
+`group.update(now)` steps them all from the same tick.
+
+```jsx
+import React, { useEffect, useState } from 'react';
+import { Tween, Easing } from '@tweenjs/tween.js';
+
+function Panel() {
+  const [pos, setPos] = useState({ x: 0, h: 10 });
+  useEffect(() => {
+    const state = { x: 0, h: 10 };
+    const tween = new Tween(state)
+      .to({ x: 150, h: 60 }, 300)
+      .easing(Easing.Cubic.Out)
+      .onUpdate(() => setPos({ ...state }))
+      .start();
+    const timer = setInterval(() => {
+      if (!tween.update()) clearInterval(timer); // update() is false when done
+    }, 16);
+    return () => clearInterval(timer);
+  }, []);
+  return (
+    <box
+      style={{
+        marginLeft: pos.x,
+        width: 40,
+        height: pos.h,
+        backgroundColor: '#00aa55',
+      }}
+    />
+  );
+}
+```
+
+- Tweens numbers only, including numbers nested in objects and arrays.
+  Colours need pre-decomposition into channels; use d3-interpolate or
+  popmotion instead.
+- Nothing animates until something calls `update()`. Forgetting the pump is
+  the classic first bug.
+- `onUpdate` mutates the source object, so spread it into fresh state
+  (`setPos({ ...state })`) or React skips the re-render on identity.
+
+## flubber {#flubber}
+
+**Out of the box.** flubber@0.4.2.
+
+Shape-morphing interpolators for SVG paths: `interpolate(from, to)` returns
+`t => d-string`, handling ring alignment, point insertion and topology
+changes so intermediate frames look sensible instead of self-intersecting.
+Shape morphing is the one animation the `<svg>` host makes easy, and flubber
+is the standard tool for it.
+
+```jsx
+import React, { useEffect, useState } from 'react';
+import flubber from 'flubber'; // CJS: default import, no named ESM exports
+const { interpolate } = flubber;
+
+const morph = interpolate(
+  'M50,10 L90,90 L10,90 Z',
+  'M10,10 L90,10 L90,90 L10,90 Z',
+);
+const svgFor = (d) =>
+  `<svg viewBox="0 0 100 100"><path d="${d}" fill="#cc3355"/></svg>`;
+
+function Morph() {
+  const [t, setT] = useState(0);
+  useEffect(() => {
+    const start = Date.now();
+    const timer = setInterval(() => {
+      const p = Math.min(1, (Date.now() - start) / 200);
+      setT(p);
+      if (p >= 1) clearInterval(timer);
+    }, 16);
+    return () => clearInterval(timer);
+  }, []);
+  return <svg source={svgFor(morph(t))} style={{ width: 100, height: 100 }} />;
+}
+```
+
+- `import { interpolate } from 'flubber'` throws — it is a CJS package, so
+  use the default-import form above.
+- Build the interpolator once (module scope or `useMemo`). Construction does
+  the expensive ring matching; sampling is cheap.
+- Every frame is a full SVG parse and rasterize of the `source` string. Fine
+  for icons and small figures; for large scenes prefer `<canvas onDraw>` and
+  draw the interpolated points yourself.
+- Old but stable (0.4.2 since 2017) — finished rather than unmaintained.
+
+## react-transition-group {#react-transition-group}
+
+**Out of the box — with `nodeRef`.** react-transition-group@4.4.5.
+
+A transition _state machine_, not an animator: `<Transition in={bool}
+timeout={ms}>` walks its child through `entering`/`entered`/`exiting`/
+`exited` on a timer and keeps the child mounted during exit. You decide what
+each state looks like. It is the standard way to keep an element mounted
+while it animates out, which react-x11 has no built-in answer for.
+
+Two rules. Always pass `nodeRef` — without it, v4 falls back to
+`ReactDOM.findDOMNode`, which would receive a react-x11 node it cannot
+understand. And map states to styles yourself, pairing with the built-in
+`transition` style so the state flip _tweens_ instead of snapping. That
+combination is the whole "CSSTransition" story here, since there are no class
+names.
+
+```jsx
+import React, { useRef } from 'react';
+import { Transition } from 'react-transition-group';
+
+function Panel({ shown }) {
+  const nodeRef = useRef(null);
+  return (
+    <Transition
+      nodeRef={nodeRef}
+      in={shown}
+      timeout={150}
+      mountOnEnter
+      unmountOnExit
+    >
+      {(state) => (
+        <box
+          ref={nodeRef}
+          style={{
+            transition: 150, // let react-x11 tween the flip
+            width: 100,
+            height: 50,
+            backgroundColor: state === 'entered' ? '#ff0000' : '#0000ff',
+          }}
+        />
+      )}
+    </Transition>
+  );
+}
+```
+
+- **`react-dom` must be present in `node_modules`.** `cjs/Transition.js`
+  requires it at module scope for the `findDOMNode` fallback, even when
+  `nodeRef` means it is never called. It is a peer dependency: install it, it
+  will not be rendered with.
+- `CSSTransition` is pointless here — it toggles class names, and there are
+  none. Use plain `Transition`.
+- `timeout` and your visual transition duration are independent numbers. Keep
+  them equal, or the state flips mid-tween.
+- `addEndListener` works; call the provided `done` yourself.
+
+## `@react-spring/core` {#react-spring}
+
+**Adapter, ~20 lines.** @react-spring/core@10.1.2,
+@react-spring/animated@10.1.2.
+
+The platform-independent half of react-spring: `useSpring`, `useTransition`,
+`useTrail`, `SpringValue`, `Controller`. `@react-spring/animated` provides
+`createHost`, the documented seam for building a non-DOM target — it is how
+`@react-spring/native` and `/three` exist.
+
+Springs, interruption with velocity carry-over, and `api.start()` are exactly
+what the built-in duration-only `transition` cannot express. Two public
+seams do the work:
+
+- `Globals.assign({ now, requestAnimationFrame })` points react-spring's
+  frame loop at a clock.
+- `createHost(['box', …], { applyAnimatedValues })` produces `animated.box`.
+  Every frame, react-spring calls `applyAnimatedValues(instance, props)`
+  where `instance` is the react-x11 node your ref points at — and
+  `node.applyProps(next, prev)` is the same imperative path the reconciler's
+  own `commitUpdate` uses. Frames bypass React entirely: a component renders
+  once while hundreds of frames apply.
+
+```jsx
+// spring-x11.js — the adapter
+import { Globals } from '@react-spring/core';
+import { createHost } from '@react-spring/animated';
+
+Globals.assign({
+  now: Date.now,
+  // real app: cb => ntkWindow.requestAnimationFrame(cb)  (ref on <window>)
+  requestAnimationFrame: (cb) => setTimeout(() => cb(Date.now()), 16),
+});
+
+const host = createHost(['box', 'text', 'window'], {
+  applyAnimatedValues(instance, props) {
+    if (!instance || typeof instance.applyProps !== 'function') return false;
+    const prev = instance.props;
+    const next = { ...prev, ...props };
+    // frames carry only animated leaves — keep the static style keys
+    if (props.style) next.style = { ...prev.style, ...props.style };
+    instance.applyProps(next, prev);
+  },
+});
+
+export const animated = host.animated;
+```
+
+```jsx
+import React, { useEffect } from 'react';
+import { useSpring } from '@react-spring/core';
+import { animated } from './spring-x11.js';
+
+function Bar() {
+  const [style, api] = useSpring(() => ({
+    from: { width: 20, backgroundColor: '#204080' },
+  }));
+  useEffect(() => {
+    api.start({ width: 180, backgroundColor: '#e04040' });
+  }, []);
+  return <animated.box style={{ ...style, height: 30 }} />;
+}
+```
+
+- **Merge `style` one level deep in `applyAnimatedValues`** — this is the
+  number-one silent failure. On animation frames react-spring calls
+  `props.getValue(true)` for _animated leaves only_, so static keys
+  (`height: 30` next to an animated `width`) are absent from the payload and
+  a naive `{...prev, ...props}` merge wipes them. The box then paints
+  nothing, with no error.
+- Hex, `rgb()` and `rgba()` colour strings interpolate out of the box. Named
+  CSS colours are not enabled by default in `@react-spring/shared` — stick to
+  hex and rgb.
+- Do not use `useScroll`, `useResize`, `useInView` or `useReducedMotion` from
+  core; they observe the DOM `window` and `matchMedia`.
+  `Globals.assign({ skipAnimation })` is the manual reduced-motion switch.
+- Style arrays (`style={[a, b]}`) defeat the shallow merge. Flatten first —
+  react-x11 exports `flattenStyle`.
+- Driving the clock from `setImmediate` runs frames as fast as the event loop
+  turns, which is fine for tests and wasteful for apps. Use the ntk window
+  clock or a 16 ms timeout.

--- a/docs/ecosystem/data-fetching.md
+++ b/docs/ecosystem/data-fetching.md
@@ -1,0 +1,201 @@
+# Data fetching
+
+A react-x11 app is an ordinary Node process, so `fetch`, undici, `ky` and
+`graphql-request` all work unmodified. What needs care is the _cache_ layer
+on top, because every stale-while-revalidate library decides whether it is
+"on a server" by looking for a global `window` — and in a react-x11 process
+there isn't one.
+
+That check is the whole story on this page. Get it wrong and nothing throws;
+the app just stops refetching.
+
+## TanStack Query {#tanstack-query}
+
+**Adapter, ~12 lines.** @tanstack/react-query@5.101.4 (query-core 5.101.4).
+
+Query and mutation cache for server state: `useQuery` deduplicates, caches,
+retries and background-refetches; `useMutation` handles writes with
+invalidation. The core is renderer-agnostic, and the environment coupling
+lives in three small managers — `focusManager`, `onlineManager`,
+`environmentManager` — all replaceable.
+
+The trap is query-core's environment probe:
+
+```js
+// @tanstack/query-core src/utils.ts
+export const isServer = typeof window === 'undefined' || 'Deno' in globalThis;
+```
+
+A react-x11 process has no `window`, so query-core decides it is doing SSR.
+Concretely:
+
+- `retry` defaults to **0** instead of 3;
+- stale timers are never scheduled and `refetchInterval` is disabled;
+- `gcTime` defaults to **Infinity** instead of 5 minutes — the cache never
+  collects;
+- the default `focusManager` setup wants
+  `window.addEventListener('visibilitychange')`, so focus refetching is
+  inert.
+
+The escape hatch shipped in v5: `environmentManager.setIsServer()`,
+re-exported from `@tanstack/react-query`. Pair it with react-x11's window
+focus events, which fire on the X `FocusIn`/`FocusOut` the window manager
+delivers.
+
+```jsx
+// query-x11.js — the whole adapter
+import {
+  environmentManager,
+  focusManager,
+  onlineManager,
+} from '@tanstack/react-query';
+
+environmentManager.setIsServer(() => false); // we are a client, not SSR
+focusManager.setEventListener(() => () => {}); // drop the visibilitychange probe
+onlineManager.setEventListener(() => () => {}); // assume online (or probe for real)
+
+export const windowFocusProps = {
+  onFocus: () => focusManager.setFocused(true),
+  onBlur: () => focusManager.setFocused(false),
+};
+```
+
+```jsx
+import React from 'react';
+import ReactX11 from 'react-x11';
+import {
+  QueryClient,
+  QueryClientProvider,
+  useQuery,
+} from '@tanstack/react-query';
+import { windowFocusProps } from './query-x11.js';
+
+const client = new QueryClient();
+
+function Weather() {
+  const { data, status } = useQuery({
+    queryKey: ['weather'],
+    queryFn: () => fetch('https://wttr.in/?format=3').then((r) => r.text()),
+  });
+  return <text>{status === 'pending' ? 'loading…' : data}</text>;
+}
+
+ReactX11.render(
+  <window width={360} height={120} title="weather" {...windowFocusProps}>
+    <QueryClientProvider client={client}>
+      <Weather />
+    </QueryClientProvider>
+  </window>,
+);
+```
+
+Focusing the window after being away now refetches stale queries, exactly
+like refocusing a browser tab.
+
+- **Call `setIsServer` before creating the `QueryClient`** — the managers
+  are module singletons.
+- With several app windows in one process, switching between two of your own
+  windows fires blur-then-focus, which counts as a focus event and refetches
+  stale queries. Same semantics as switching browser tabs; raise `staleTime`
+  if that is too eager.
+- `onlineManager` defaults to online under Node (there is no
+  `navigator.onLine`). Wire it to NetworkManager over D-Bus if you want real
+  offline handling.
+- `@tanstack/react-query-devtools` is DOM-rendered and not usable.
+
+## SWR {#swr}
+
+**Adapter, 1 line — but read the dead end first.** swr@2.4.2.
+
+Basic operation works unmodified: `useSWR` fetches on mount, caches, dedupes
+and re-renders through `useSyncExternalStore`.
+
+Focus and reconnect revalidation do not, and they fail silently. SWR
+computes its environment once at import time, with no override:
+
+```js
+// swr/dist/_internal/config-context-*.mjs
+const isWindowDefined = typeof window != 'undefined';
+const IS_SERVER = !isWindowDefined || isLegacyDeno;
+```
+
+Revalidation event sources are registered only `if (!IS_SERVER)` —
+_including_ a custom `initFocus`/`initReconnect` passed through the
+cache-provider config. So the "wire your own focus events via the provider
+option" approach from SWR's docs is dead code under Node: your `initFocus`
+is never called, and swr ends up with zero registered listeners. Unlike
+TanStack Query there is no `setIsServer`.
+
+Two ways out. The simple one is to drive revalidation yourself with
+`mutate`; a key filter of `() => true` revalidates every key in the cache,
+so hang it off `<window onFocus>`:
+
+```jsx
+import React from 'react';
+import ReactX11 from 'react-x11';
+import useSWR, { mutate } from 'swr';
+
+const fetcher = (url) => fetch(url).then((r) => r.text());
+
+function Weather() {
+  const { data } = useSWR('https://wttr.in/?format=3', fetcher);
+  return <text>{data ?? 'loading…'}</text>;
+}
+
+ReactX11.render(
+  // the adapter is this one prop: revalidate everything on window focus
+  <window
+    width={360}
+    height={120}
+    title="weather"
+    onFocus={() => mutate(() => true)}
+  >
+    <Weather />
+  </window>,
+);
+```
+
+The thorough one is to make `IS_SERVER` false, which turns swr's own
+machinery back on. It has to happen **before the first import of swr**:
+
+```js
+// swr-env.js — imported first, before anything that imports swr
+const listeners = new Map();
+const target = {
+  addEventListener: (t, fn) =>
+    listeners.set(t, [...(listeners.get(t) ?? []), fn]),
+  removeEventListener: (t, fn) =>
+    listeners.set(
+      t,
+      (listeners.get(t) ?? []).filter((f) => f !== fn),
+    ),
+};
+globalThis.window ??= target;
+globalThis.document ??= target;
+
+/** Call from your <window onFocus> handler. */
+export const fireFocus = () =>
+  (listeners.get('focus') ?? []).forEach((fn) => fn());
+```
+
+With that in place swr registers `visibilitychange`, `focus`, `online` and
+`offline` listeners and `revalidateOnFocus` behaves. Two gotchas:
+
+- Fire only `'focus'`. An `'offline'` event sets swr's internal online flag
+  false and silently suppresses the deferred revalidation.
+- `focusThrottleInterval` defaults to 5000 ms, so a focus that lands within
+  five seconds of the last revalidation is dropped — which looks exactly
+  like the shim not working. Lower it while you are testing the wiring.
+
+- **`revalidateOnFocus` and `revalidateOnReconnect` are inert** unless you
+  define the globals. Nothing warns you.
+- The global `mutate` import targets the _default_ cache. If you mount a
+  custom `provider` via `<SWRConfig>`, calls to the global `mutate` silently
+  miss it — use `useSWRConfig().mutate` from inside the tree.
+- Suspense mode throws
+  `Fallback data is required when using Suspense in SSR.` because SWR
+  believes it is on a server. Provide `fallbackData`, or avoid
+  `suspense: true`.
+- `preload()` is an SSR-gated no-op under Node.
+- If you want focus revalidation with retries and cache GC done properly,
+  prefer TanStack Query above — it ships a supported environment override.

--- a/docs/ecosystem/dev-tooling.md
+++ b/docs/ecosystem/dev-tooling.md
@@ -1,0 +1,252 @@
+# Developer tooling
+
+This is the payoff of a pure-JS stack: a react-x11 app is an ordinary Node
+process, so the whole V8 and React tooling story applies unmodified. Nothing
+on this page needs an adapter.
+
+The four tools answer four different questions, and it is worth knowing which
+is which before you reach for one:
+
+| Question                                       | Tool                                             |
+| ---------------------------------------------- | ------------------------------------------------ |
+| Which component rendered, and with what props? | [React DevTools](#react-devtools)                |
+| Was that render _wasted_?                      | [why-did-you-render](#why-did-you-render)        |
+| Where did the milliseconds go?                 | [`node --inspect`](#node-inspect), [`0x`](#0x)   |
+| Why is memory growing?                         | [`node --inspect`](#node-inspect) heap snapshots |
+
+`react-scan` is not on this page: its documented entry point does not resolve
+under bare Node, and its programmatic API silently never fires. See the
+[negative-results register](../ecosystem.md#silent-failures). React's own
+`<Profiler>` works unchanged under react-x11 and covers the same ground for
+commit timings.
+
+## React DevTools {#react-devtools}
+
+**Out of the box — already wired behind an env var.** react-devtools-core@7.0.1.
+
+`react-devtools-core` is the backend half of React DevTools, made for exactly
+this situation: a React tree running outside a browser page. It connects over
+WebSocket to the standalone DevTools UI and streams the fiber tree, props,
+hooks and profiler data. The integration lives in
+`src/DevToolsIntegration.js` and costs nothing when off.
+
+```sh
+npm i -D react-devtools-core ws
+
+# terminal 1 — standalone UI, listens on :8097
+npx react-devtools
+
+# terminal 2 — any app
+REACT_X11_DEVTOOLS=1 npm run examples:dashboard
+```
+
+`src/Reconciler.js` checks `REACT_X11_DEVTOOLS` at module load and, via
+top-level await, installs the DevTools global hook _before the first commit_
+— that ordering is what makes mounted roots visible.
+`REACT_X11_DEVTOOLS_HOST` and `REACT_X11_DEVTOOLS_PORT` point the backend at
+a UI elsewhere, which is useful when the app runs on a headless box next to
+the X server.
+
+Working today: the live component tree, props/hooks/state inspection, and
+highlight-on-hover — hovering an element in the tree tints its rect in the
+X11 window. See [devtools](../devtools.md) for the full walkthrough.
+
+- **Start the standalone UI first**, or wait for the backend's retry. The app
+  side retries; the UI side does not attach to an already-running app unless
+  the hook was installed at startup, and `REACT_X11_DEVTOOLS` cannot be
+  turned on after the fact.
+- The Profiler's commit-oriented views (flamegraph, ranked) work with the dev
+  reconciler. The **Timeline** view cannot — it needs `injectProfilingHooks`,
+  which react-reconciler 0.33 does not expose at all.
+- `injectIntoDevTools` takes zero arguments in react-reconciler 0.33, so the
+  config object passed to it is silently discarded and
+  `findFiberByHostInstance` is never registered — DevTools cannot map a host
+  node back to its fiber. The tree, props and highlight features do not need
+  it. Do not add options to that call expecting them to do anything; the
+  supported channel is `extraDevToolsConfig` on the host config.
+
+## react-refresh {#react-refresh}
+
+**Out of the box — the setup is already in the repo.** react-refresh@0.18.0
+with hot-module-replacement@4.0.0.
+
+Fast Refresh without a bundler: edit a component, and the mounted X11 window
+updates in place with hook state intact. `examples/hmr-register.mjs` and
+`examples/hmr-refresh.js` are the two halves.
+
+```sh
+node --enable-source-maps --import ./examples/hmr-register.mjs examples/tasks-hot.jsx
+```
+
+Node 22.15 or newer is required, for synchronous `module.registerHooks`.
+`hmr-register.mjs` stacks two loader layers: babel (classic JSX transform
+plus `react-refresh/babel`) instruments every `.jsx` component, and above it
+`hot-module-replacement` rewrites static imports into live bindings and wires
+`import.meta.hot`. `hmr-refresh.js` is the runtime half, and its ordering is
+load-bearing: `RefreshRuntime.injectIntoGlobalHook(globalThis)` must patch
+the DevTools hook _before_ the renderer registers, which is why the react-x11
+import below it is dynamic.
+
+The hot boundary excludes `node_modules` and `src/`, so React, the renderer
+and `react-refresh/runtime` stay singletons — the X connection and the
+mounted window survive reloads, and only app modules re-execute.
+
+```js
+// Minimal hot entry for an app (mirrors examples/tasks-hot.jsx):
+import { performReactRefresh } from './examples/hmr-refresh.js'; // FIRST import
+import ReactX11 from 'react-x11'; // safe now: the global hook is patched
+import { App } from './app-ui.jsx'; // hot: lives in the reloadable graph
+
+ReactX11.render(<App />);
+import.meta.hot?.accept('./app-ui.jsx', () => {
+  performReactRefresh();
+});
+```
+
+- **Named imports in hot modules re-initialize in a microtask** after a
+  reload, so module top-level code must not call them synchronously. Use the
+  default import at top level (`React.createContext(...)`, not
+  `createContext(...)`). Inside components anything goes.
+- The import-rewrite layer emits replacements with no trailing semicolon, so
+  hot modules want one statement per line.
+- Stack traces through hot modules are off by the prelude's four lines.
+  Dev-only.
+- Fast Refresh needs the dev reconciler (`NODE_ENV` unset or `development`).
+  There is no production hot path, by design.
+
+## `node --inspect` {#node-inspect}
+
+**Out of the box.** Node built-in.
+
+Node's V8 inspector protocol: `node --inspect` exposes a debug port, and
+Chrome's `chrome://inspect` (or VS Code's auto-attach) connects a full
+DevTools instance — sourcemap-aware CPU profiler, heap snapshots, allocation
+timelines, live debugging.
+
+Everything that costs time in a react-x11 app is visible as ordinary JS
+frames, which is why this is the recommended profiling path:
+
+- **CPU profiles of commits.** Reconciler frames (`performUnitOfWork`,
+  `completeWork`), yoga layout (`calculateLayout`), style resolution and ntk
+  paint/flush show up in one call tree. That answers "is it React, layout, or
+  painting" in a single recording.
+- **Heap snapshots of retained nodes.** Every drawn element is a retained
+  node object reachable from the ntk window's `_reactX11Node`. Snapshot,
+  filter the constructor list, and leaked subtrees — a `<popup>` that never
+  unmounted, listeners held after close — are directly countable. Two
+  snapshots plus "Objects allocated between…" isolates a leak per
+  interaction.
+
+```sh
+# interactive: profile a running app from Chrome
+node --inspect --import tsx examples/dashboard.jsx
+# chrome://inspect -> Open dedicated DevTools for Node -> Performance / Memory
+
+# capture-on-exit CPU profile, no UI needed
+node --cpu-prof --cpu-prof-dir=./profiles --import tsx examples/dashboard.jsx
+
+# heap snapshot of a live app without restarting it
+kill -USR1 <pid>   # inspector comes up on :9229, then attach and snapshot
+```
+
+- **Profile with `NODE_ENV=production` when chasing React costs.** The dev
+  reconciler's stack-frame bookkeeping (`runWithFiberInDEV`) inflates commit
+  times and clutters the tree. For layout and paint costs it matters less.
+- The inspector port is an arbitrary-code-execution door. Bind it to
+  `127.0.0.1` (the default) and never expose it on a network; for remote
+  boxes, tunnel it with `ssh -L 9229:localhost:9229`.
+- This and the React DevTools Profiler are complementary: DevTools names the
+  _components_ per commit, the V8 profiler names the _functions_.
+
+## `0x` {#0x}
+
+**Out of the box.** 0x@6.0.0.
+
+A single-command flamegraph generator: `0x -- node app.js` runs the process
+under the V8 sampling profiler and, on exit, writes a self-contained
+interactive `flamegraph.html`. No integration at all, and the interesting
+frames are directly searchable — `performUnitOfWork`/`completeWork`, `yoga`,
+and your own components.
+
+```sh
+# profile an example, write the output into a throwaway dir
+npx 0x --output-dir /tmp/rx11-prof -- node --import tsx examples/dashboard.jsx
+# interact with the window until the slow thing happens, then Ctrl-C
+# -> file:///tmp/rx11-prof/flamegraph.html
+
+# tips inside the flamegraph UI:
+#   search "yoga"              -> layout cost
+#   search "performUnitOfWork" -> react reconcile cost
+#   "Merge" view               -> collapses recursion for a cleaner ranking
+```
+
+**Why 0x and not clinic.js:** Clinic's flame command is a wrapper around 0x,
+so for flamegraphs it adds moving parts without adding signal. Its other
+tools target server event-loop and async-I/O patterns that do not map onto a
+GUI render loop, and the package has been dormant since early 2024 while 0x
+keeps shipping.
+
+- Sampling profiler: sub-millisecond handlers need a longer capture to show
+  up, so drive the interaction in a loop.
+- Profile with `NODE_ENV=production` when measuring React itself.
+- Running through the tsx loader is fine, though frames from `.jsx` files
+  show transformed function names. Component names usually survive.
+- 0x answers "where does CPU time go", and says nothing about _which commit_
+  or _why it re-rendered_. Pair it with the DevTools Profiler and
+  why-did-you-render. For heap questions use `node --inspect`; 0x is CPU-only.
+
+## why-did-you-render {#why-did-you-render}
+
+**Out of the box.** @welldone-software/why-did-you-render@10.0.1.
+
+Patches the `React` namespace so that components you flag report _avoidable_
+re-renders — props or hook state that changed by reference but are equal by
+value. It hooks React itself, not `react-dom`, which is exactly why it works
+under a custom renderer.
+
+```jsx
+import React from 'react';
+import whyDidYouRender from '@welldone-software/why-did-you-render';
+import ReactX11 from 'react-x11';
+
+whyDidYouRender(React); // before anything renders
+
+const Label = ({ user }) => <text>{`hi ${user.name}`}</text>;
+Label.whyDidYouRender = true;
+
+// Every render passes a fresh-but-equal object — the classic wasted render:
+const App = () => (
+  <window width={300} height={200} title="wdyr">
+    <box style={{ flexGrow: 1 }}>
+      <Label user={{ name: 'ada' }} />
+    </box>
+  </window>
+);
+
+ReactX11.render(<App />);
+// terminal: "Label … props.user: different objects that are equal by value."
+```
+
+- Props tracking reports a re-render caused by a new-but-deep-equal object
+  prop with `diffType: 'deepEquals'` and the offending path. Hook tracking
+  (`trackHooks`, on by default) reports `setState` with an equal-by-value
+  object the same way.
+- The default notifier prints readable `console.group` output in a terminal —
+  no browser console needed. A custom `notifier` receives the structured
+  `{displayName, reason: {propsDifferences, hookDifferences}}` object, which
+  is also how you assert on wasted renders in tests.
+- Works with the automatic JSX runtime as compiled by tsx and esbuild; the
+  babel alias the docs describe for webpack setups is not needed.
+- **Install it before components are defined and before the first render** —
+  the patch wraps `React.createElement` and the hook entry points on the
+  namespace.
+- Dev-only by design. With `NODE_ENV=production` React's prod build drops the
+  internals it reads; under plain `node`/`tsx` you get the dev build, which
+  is the right mode for it anyway.
+- Updates scheduled outside an event handler flush on a delayed task in React
+  19, so in a scripted repro, wait a macrotask before asserting the
+  notification fired.
+
+This complements React DevTools: DevTools tells you _that_ a component
+rendered; why-did-you-render tells you the render was _wasted_ and which
+value to memoize.

--- a/docs/ecosystem/forms.md
+++ b/docs/ecosystem/forms.md
@@ -1,0 +1,190 @@
+# Forms and validation
+
+There is no `<form>` element here, and `<textinput>` fires
+`onChange(newString)` rather than `onChange(event)` — see
+[elements](../elements.md). Those two facts sort the form libraries
+cleanly: the ones with a value-in/value-out field contract work unmodified,
+the ones built on `register()`-style DOM prop bags need their controlled
+API, and the ones that only have the DOM path do not work at all.
+
+Formik is in the last group, and it is the one that costs people the most
+time because one of its two failure modes is silent. It is written up in the
+[negative-results register](../ecosystem.md#first-interaction).
+
+## TanStack Form {#tanstack-form}
+
+**Out of the box.** @tanstack/react-form@1.33.2 (form-core 1.33.2).
+
+A headless, framework-agnostic form state manager: field values, dirty and
+touched tracking, sync and async validation (including Standard Schema, so
+zod/valibot/arktype plug in directly), and submission handling. Fields are
+value-in/value-out — no DOM events, no refs.
+
+The field contract is `field.state.value` + `field.handleChange(value)`, and
+`<textinput>` fires `onChange(text)` with the raw string. They meet in the
+middle with no glue at all, which makes this the form library to reach for
+first.
+
+```jsx
+import React from 'react';
+import { useForm } from '@tanstack/react-form';
+import { Button } from 'react-x11';
+import { z } from 'zod';
+
+function ConnectForm({ connect }) {
+  const form = useForm({
+    defaultValues: { host: '', display: ':0' },
+    onSubmit: async ({ value }) => connect(value),
+  });
+  return (
+    <box style={{ flexDirection: 'column', gap: 8 }}>
+      <form.Field
+        name="host"
+        validators={{ onChange: z.string().min(3, 'too short') }}
+      >
+        {(field) => (
+          <box style={{ flexDirection: 'column' }}>
+            <textinput
+              value={field.state.value}
+              onChange={field.handleChange}
+            />
+            {field.state.meta.errors.length > 0 && (
+              <text style={{ color: '#cc4444' }}>
+                {field.state.meta.errors[0].message}
+              </text>
+            )}
+          </box>
+        )}
+      </form.Field>
+      <Button label="Connect" onPress={() => form.handleSubmit()} />
+    </box>
+  );
+}
+```
+
+- No `<form>` element exists, so there is no submit-on-Enter for free. Wire
+  `form.handleSubmit()` to a button's `onPress` and/or a window-level Enter
+  key handler.
+- `Checkbox` and `Select` take `onChange(checked)`/`onChange(value)`, so
+  `field.handleChange` works across the widget set — but confirm the value
+  shape per component.
+- Validation errors from a zod schema are error _objects_
+  (`errors[0].message`), not strings; a plain string validator returns
+  strings. A `<text>` child must be a string, so render `.message`.
+- The package also ships SSR and Next helpers under subpaths; the root
+  import used here pulls in no react-dom.
+
+## zod {#zod}
+
+**Out of the box.** zod@4.4.3.
+
+TypeScript-first schema validation. Pure computation, no DOM, nothing
+renderer-specific — the interesting part is only where it plugs in:
+
+- **TanStack Form** — pass a schema straight into a field's
+  `validators: { onChange: z.string().min(3, 'too short') }`. Zod 4
+  implements Standard Schema, so no resolver package is needed.
+- **React Hook Form** — via `@hookform/resolvers/zod` and the `Controller`
+  pattern below.
+- **Standalone** — validating a settings file or a config blob before
+  rendering is just `schema.safeParse(data)`.
+
+```jsx
+import { z } from 'zod';
+
+const settings = z.object({
+  display: z.string().regex(/^:\d+$/, 'DISPLAY looks like :0'),
+  scale: z.coerce.number().min(0.5).max(3).default(1),
+});
+
+function Settings({ raw }) {
+  const parsed = settings.safeParse(raw);
+  if (!parsed.success) {
+    // render the issues instead of crashing the app
+    return (
+      <box style={{ flexDirection: 'column' }}>
+        {parsed.error.issues.map((i) => (
+          <text
+            key={i.path.join('.')}
+          >{`${i.path.join('.')}: ${i.message}`}</text>
+        ))}
+      </box>
+    );
+  }
+  return <text>display {parsed.data.display}</text>;
+}
+```
+
+- Zod 4 field errors surface as issue objects; render `issue.message`, not
+  the issue itself.
+- `valibot` and `arktype` are equally viable (also Standard Schema). zod is
+  documented here because both verified form integrations used it.
+- Bundle-size arguments from the web world do not apply — an X11 app ships
+  no bundle.
+
+## React Hook Form {#react-hook-form}
+
+**Adapter — use `<Controller>`, not `register()`.** react-hook-form@7.83.0
+with @hookform/resolvers@5.5.7.
+
+RHF's headline API is uncontrolled-first: `register()` returns DOM-shaped
+props (`{name, ref, onChange(e), onBlur(e)}`) and reads `e.target.value` off
+native events. That path is unusable here — `<textinput onChange>` passes a
+raw string, and there is no `name` prop or DOM ref to attach.
+
+But RHF has always shipped a second, controlled API — `<Controller>` /
+`useController` — for external controlled components, and that path never
+touches the DOM. It works today with **zero adapter code**, because
+`field.onChange` accepts a plain value; RHF only unwraps `.target` when the
+argument actually looks like an event. RHF guards all its DOM checks behind
+`isWeb = typeof window !== 'undefined'`, so headless Node is a supported
+environment rather than an accident.
+
+```jsx
+import React from 'react';
+import { useForm, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Button } from 'react-x11';
+import { z } from 'zod';
+
+const schema = z.object({
+  host: z.string().min(3, 'too short'),
+  display: z.string(),
+});
+
+function ConnectForm({ connect }) {
+  const { control, handleSubmit } = useForm({
+    defaultValues: { host: '', display: ':0' },
+    resolver: zodResolver(schema),
+    mode: 'onChange',
+  });
+  return (
+    <box style={{ flexDirection: 'column', gap: 8 }}>
+      <Controller
+        name="host"
+        control={control}
+        render={({ field, fieldState }) => (
+          <box style={{ flexDirection: 'column' }}>
+            <textinput
+              value={field.value}
+              onChange={field.onChange} // raw string in — no event unwrap needed
+              onBlur={field.onBlur}
+            />
+            {fieldState.error && <text>{fieldState.error.message}</text>}
+          </box>
+        )}
+      />
+      <Button label="Connect" onPress={handleSubmit(connect)} />
+    </box>
+  );
+}
+```
+
+- Every field needs the `Controller` wrapper (or `useController`). The
+  `register()` spread that makes RHF terse on the web is off the table, and
+  with it the uncontrolled-inputs performance story: every controlled field
+  re-renders its `Controller` subtree on keystroke.
+- `setFocus(name)` is a no-op — it wants a DOM ref with `.focus()`. Use
+  react-x11's own focus handling instead.
+- `handleSubmit` returns a function. Call it: `handleSubmit(fn)` in an
+  `onPress` is the curried form, and there is no submit event to pass.

--- a/docs/ecosystem/headless.md
+++ b/docs/ecosystem/headless.md
@@ -1,0 +1,180 @@
+# Headless components
+
+"Headless" is a promise that gets broken a lot. A library that returns DOM
+prop bags — `getInputProps()`, `useButton()` — is not headless in any sense
+that helps here; it is DOM-coupled with the rendering deferred. The two
+packages below are the real thing: they own state and collections, return
+plain values, and never touch a ref.
+
+Everything else that markets itself as headless is in the
+[negative-results register](../ecosystem.md#what-does-not-work) — Headless
+UI, the Radix primitives and downshift all fail, the last one silently until
+the first keystroke.
+
+For finished widgets, react-x11 ships its own: `Button`, `Checkbox`,
+`Radio`/`RadioGroup`, `Switch`, `ProgressBar`, `Select`, `Slider`, `Tooltip`,
+`Dialog`, `MenuBar`/`ContextMenu`, `Tabs`, `Table`, `Tree`, `SplitPane`. See
+[components](../components.md).
+
+## react-stately {#react-stately}
+
+**Out of the box.** react-stately@3.48.0.
+
+The state-machine half of React Aria: `useListState`, `useTreeState`,
+`useTableState`, `useSelectState`, `useToggleState`, `useSliderState`,
+`useComboBoxState`, `useMenuTriggerState`, `useNumberFieldState` and about
+thirty-five more, plus the `Item`/`Section` collection API. Each hook owns
+selection, disabled-key traversal, expansion and typeahead-ready collections
+— everything a widget needs _except_ rendering and event binding, which is
+exactly the part react-x11 supplies.
+
+There is no seam to bridge: the hooks take props, return state, and never
+touch a ref. A scan of the shipped `dist/` finds no runtime reference to
+`document`, `window` or `getBoundingClientRect` in any hook, and its
+dependencies (`@internationalized/*`, `@react-types/shared`,
+`use-sync-external-store`) are DOM-free.
+
+```jsx
+import React from 'react';
+import { useListState, Item } from 'react-stately';
+
+function Picker() {
+  const state = useListState({
+    children: [
+      <Item key="alpha">Alpha</Item>,
+      <Item key="beta">Beta</Item>,
+      <Item key="gamma">Gamma</Item>,
+    ],
+    selectionMode: 'multiple',
+  });
+  const mgr = state.selectionManager;
+  return (
+    <box
+      style={{ flexDirection: 'column' }}
+      focusable
+      onKeyDown={(ev) => {
+        if (ev.key === 'ArrowDown')
+          mgr.setFocusedKey(
+            state.collection.getKeyAfter(mgr.focusedKey) ?? mgr.focusedKey,
+          );
+        if (ev.codepoint === 32) mgr.toggleSelection(mgr.focusedKey);
+      }}
+    >
+      {[...state.collection].map((item) => (
+        <box
+          key={item.key}
+          style={{ height: 20, justifyContent: 'center' }}
+          onClick={() => mgr.toggleSelection(item.key)}
+        >
+          <text>
+            {(mgr.isSelected(item.key) ? '* ' : '  ') + item.rendered}
+          </text>
+        </box>
+      ))}
+    </box>
+  );
+}
+```
+
+- **Only `react-stately` is portable.** `react-aria` (the hooks that produce
+  DOM props and bind DOM events) and `react-aria-components` are not — do not
+  follow Adobe's docs into `useListBox` or `useButton`, which return DOM prop
+  bags.
+- As of 3.48 the package is consolidated: the old `@react-stately/*` packages
+  are bundled in, with per-hook subpath exports
+  (`react-stately/useListState`) for lean imports.
+- The collection API wants `<Item>`/`<Section>` elements, or an `items` plus
+  render-function pair. It is a compile target of its own, slightly
+  ceremonious for a three-entry menu.
+- `useAsyncList` pulls in fetch-based loading state — fine under Node, but it
+  is the one hook with I/O opinions.
+- Drag-and-drop hooks (`useDraggableCollectionState`) hold state fine, but
+  everything that would _feed_ them events is DOM-side. Expect to write the
+  event plumbing.
+
+## `@tanstack/react-table` {#tanstack-table}
+
+**Out of the box.** @tanstack/react-table@8.21.3 (table-core 8.21.3).
+
+A headless table engine: column defs, row models, sorting, filtering,
+grouping, pagination, column sizing, visibility and pinning — as pure state
+plus derived row models. It renders nothing; you map `getHeaderGroups()` and
+`getRowModel().rows` to whatever the host renderer draws.
+
+No adapter at all. It imports only `react` — no `react-dom`, no `document` —
+and `flexRender` just resolves a column def to a string or element, which
+lands in `<text>` fine. `column.getToggleSortingHandler()` goes straight onto
+a header `onClick`.
+
+```jsx
+import React from 'react';
+import {
+  useReactTable,
+  getCoreRowModel,
+  getSortedRowModel,
+  createColumnHelper,
+  flexRender,
+} from '@tanstack/react-table';
+
+const col = createColumnHelper();
+const columns = [
+  col.accessor('name', { header: 'Name' }),
+  col.accessor('port', { header: 'Port', cell: (i) => `:${i.getValue()}` }),
+];
+
+function Servers({ data }) {
+  const [sorting, setSorting] = React.useState([]);
+  const table = useReactTable({
+    data,
+    columns,
+    state: { sorting },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+  return (
+    <box style={{ flexDirection: 'column' }}>
+      {table.getHeaderGroups().map((hg) => (
+        <box key={hg.id} style={{ flexDirection: 'row', height: 20 }}>
+          {hg.headers.map((h) => (
+            <box
+              key={h.id}
+              style={{ width: 120 }}
+              onClick={h.column.getToggleSortingHandler()}
+            >
+              <text>
+                {flexRender(h.column.columnDef.header, h.getContext())}
+              </text>
+            </box>
+          ))}
+        </box>
+      ))}
+      {table.getRowModel().rows.map((row) => (
+        <box key={row.id} style={{ flexDirection: 'row', height: 20 }}>
+          {row.getVisibleCells().map((cell) => (
+            <text key={cell.id} style={{ width: 120 }}>
+              {flexRender(cell.column.columnDef.cell, cell.getContext())}
+            </text>
+          ))}
+        </box>
+      ))}
+    </box>
+  );
+}
+```
+
+The natural pairing is inside the existing `Table` component, or raw
+`<box style={{ flexDirection: 'row' }}>` rows: TanStack owns the data logic,
+react-x11 owns painting.
+
+- Column _resizing_ helpers (`header.getResizeHandler`) expect DOM mouse or
+  touch events with `clientX`. Write your own drag handling off
+  `onMouseDown`/`onMouseMove` — react-x11 events carry `x`/`y`.
+- `flexRender` output goes into `<text>`. A column def whose `cell` returns
+  DOM elements will throw the renderer's unknown-element error; return
+  strings or react-x11 elements.
+- For thousands of rows, pair it with a virtualizer — see
+  [layout](layout.md#tanstack-virtual). TanStack Table will happily hand you
+  10,000 row objects and let the renderer drown.
+- State updates driven from outside a React event land one frame later than
+  the call, the same as any react-x11 update.

--- a/docs/ecosystem/i18n.md
+++ b/docs/ecosystem/i18n.md
@@ -1,0 +1,93 @@
+# Internationalization
+
+## i18next + react-i18next
+
+**Out of the box.** i18next@26.3.6, react-i18next@17.0.11.
+
+i18next is the de-facto JS i18n core — resources, interpolation, plurals,
+namespaces, backends — and react-i18next binds it to React with
+`useTranslation`, `<Trans>` for translations containing markup, and
+provider-driven re-render on language change.
+
+The core has no DOM in it and react-i18next renders whatever elements you
+hand it, so the whole stack runs unmodified: interpolation, count-based
+plurals, `<Trans>`, and `i18n.changeLanguage('de')` re-rendering the mounted
+tree in place. Node ships full ICU, so `Intl.NumberFormat` and
+`Intl.DateTimeFormat` formatting work too.
+
+Two react-x11-specific rules:
+
+1. **`<Trans>` component maps must use react-x11 elements.**
+   `components={{ 1: <span/> }}` throws
+   `react-x11: <span> is not allowed inside <text>` — inside a `<text>`, only
+   strings and nested `<text>` spans are legal. Use `<text style={...}/>` as
+   the wrapper.
+2. **Turn off HTML escaping.** i18next escapes interpolated values for an
+   HTML sink by default, and react-x11 draws raw glyphs, so `O'Brien` renders
+   as `O&#39;Brien`. Set `interpolation: { escapeValue: false }`.
+
+```jsx
+import React from 'react';
+import i18next from 'i18next';
+import {
+  I18nextProvider,
+  initReactI18next,
+  useTranslation,
+  Trans,
+} from 'react-i18next';
+
+const i18n = i18next.createInstance();
+await i18n.use(initReactI18next).init({
+  lng: 'en',
+  resources: {
+    en: {
+      translation: {
+        greeting: 'Hello, {{name}}!',
+        items_one: '{{count}} item',
+        items_other: '{{count}} items',
+        rich: 'Press <1>Enter</1> to save',
+      },
+    },
+  },
+  interpolation: { escapeValue: false }, // no HTML sink to escape for
+});
+
+function Status() {
+  const { t } = useTranslation();
+  return (
+    <box style={{ flexDirection: 'column' }}>
+      <text>{t('greeting', { name: 'X11' })}</text>
+      <text>{t('items', { count: 2 })}</text>
+      <text>
+        <Trans
+          i18nKey="rich"
+          components={{ 1: <text style={{ color: '#e00' }} /> }}
+        />
+      </text>
+    </box>
+  );
+}
+
+// mount under <I18nextProvider i18n={i18n}> inside your <window>;
+// i18n.changeLanguage('de') re-renders live
+```
+
+For loading translations from disk, `i18next-fs-backend` is the natural
+desktop choice; `i18next-http-backend` also works, since Node has `fetch`.
+
+## What is missing below the string
+
+These are react-x11 gaps rather than i18next ones, and they matter more than
+the library choice:
+
+- **Layout is computed left-to-right unconditionally.** react-x11 calls
+  yoga's `calculateLayout` with `DIRECTION_LTR` and there is no `direction`
+  style property, so an Arabic or Hebrew UI will mirror wrong even though
+  every string translates correctly. Yoga supports `DIRECTION_RTL`; wiring it
+  up is renderer work that has not been done.
+- **There is no X input method.** Input is limited to what the keyboard path
+  produces, with no XIM integration, so languages that need composition —
+  CJK, dead keys — can be _displayed_ but not typed.
+- `<Trans>` with the default `<strong>`- and `<em>`-style numbered tags in
+  translations is fine as long as every referenced component is a `<text>`
+  span. An accidental DOM tag fails loudly at render, which is the good case.

--- a/docs/ecosystem/icons.md
+++ b/docs/ecosystem/icons.md
@@ -1,0 +1,410 @@
+# Icons
+
+react-x11 has a real `<svg>` host, so icons get further than most DOM
+libraries — which is exactly why the failures here are unusual. Two renderer
+facts shape every entry on this page:
+
+1. **ntk's `SvgView` ignores presentation attributes on the root `<svg>`
+   element.** Inheritance starts from its own defaults, so an icon that puts
+   `fill="none" stroke="currentColor" stroke-width="2"` on the root renders
+   as solid black blobs — wrong glyphs, not just the wrong colour. Moving
+   those attributes onto an inner `<g>` fixes it, because `<g>` does
+   inherit.
+2. **Flat style props on `<svg>` throw.** `<svg width={24}>` is
+   `react-x11: <svg width=…> is a style property — pass it in style`. Size
+   with `style={{ width: 24 }}`; the `viewBox` keeps the aspect ratio.
+
+Fact 2 is why `lucide-react`, `@tabler/icons-react` and
+`@phosphor-icons/react` cannot work at all — see the
+[negative-results register](../ecosystem.md#render-time). `@heroicons/react`
+is the exception, and it is documented below.
+
+## The `iconSource` wrapper {#iconsource}
+
+Four of the packages below ship whole SVG _strings_ with paint attributes on
+the root. They all need the same twelve lines, so write it once:
+
+```js
+// icon-source.js — re-root an icon's paint attributes onto a <g> so they
+// survive SvgView, and pin `color` there so currentColor resolves.
+const ROOT = /<svg([^>]*)>([\s\S]*)<\/svg>\s*$/;
+
+export function iconSource(svgText, color = '#000') {
+  const [, root, body] = ROOT.exec(svgText);
+  const viewBox = /viewBox="[^"]*"/.exec(root)?.[0] ?? '';
+  const paint = (
+    root.match(
+      /(?:fill|stroke|stroke-width|stroke-linecap|stroke-linejoin|fill-rule|clip-rule)="[^"]*"/g,
+    ) ?? []
+  ).join(' ');
+  return `<svg xmlns="http://www.w3.org/2000/svg" ${viewBox}><g color="${color}" ${paint}>${body}</g></svg>`;
+}
+```
+
+`SvgView` maps `currentColor` to the inherited `color`, which defaults to
+`#000` — so the `color` attribute on the `<g>` is what makes recolouring
+work. Note that `svgText.replaceAll('currentColor', color)` on its own is
+_not_ enough: it fixes the colour but not the dropped `fill="none"`, so
+stroke icons still paint as filled blobs.
+
+Cache the wrapped strings per (name, style, colour); parsing per mount is
+avoidable work.
+
+## Iconify {#iconify}
+
+**Out of the box.** @iconify/utils@3.1.4 with any `@iconify-json/*` set.
+
+Iconify publishes every major icon set as JSON data — `@iconify-json/tabler`,
+`@iconify-json/mdi`, `@iconify-json/ph`, `@iconify-json/lucide`,
+`@iconify-json/heroicons` — plus `@iconify/utils`, a framework-free toolkit
+that looks an icon up and builds SVG markup from it.
+
+This is the highest-leverage route: one pipeline, 200,000+ icons across every
+set, no React wrapper to fight. It is also the only string-SVG route that
+needs **no re-rooting adapter**, because `iconToSVG` returns the icon body
+separately from the root attributes, and the paint attributes live inside the
+body rather than on the root.
+
+```jsx
+import { getIconData, iconToSVG, iconToHTML, replaceIDs } from '@iconify/utils';
+import { icons as tabler } from '@iconify-json/tabler';
+
+function iconSvg(name, color = '#000') {
+  const data = getIconData(tabler, name); // null if unknown
+  const built = iconToSVG(data, { height: 24 });
+  return iconToHTML(replaceIDs(built.body), built.attributes).replaceAll(
+    'currentColor',
+    color,
+  );
+}
+
+function Icon({ name, size = 24, color }) {
+  return <svg source={iconSvg(name, color)} style={{ width: size }} />;
+}
+
+// <Icon name="home" color="#7c3aed" />
+// <Icon name="settings" size={16} color="#0891b2" />
+```
+
+- `replaceIDs` matters for icons containing gradients or clip paths;
+  duplicate `id`s across two mounted icons would collide inside one
+  rasterized document. Harmless across separate `<svg>` nodes, but free to
+  keep.
+- Pick per-set packages (`@iconify-json/tabler` is about 5,000 icons in one
+  JSON) rather than the monolithic `@iconify/json`, which is all 200,000+ and
+  roughly 100 MB.
+- There are no events inside a rasterized SVG. Wrap it in a
+  `<box onClick>`.
+
+## `@heroicons/react` {#heroicons-react}
+
+**Out of the box — size it with `style`.** @heroicons/react@2.2.0.
+
+The exception among the `*-react` icon packages. Heroicons' React components
+size themselves with a Tailwind class name rather than flat `width`/`height`
+attributes, so react-x11's `<svg>` host accepts them and the path paints. Do
+not lump this one in with lucide-react, `@tabler/icons-react` or
+`@phosphor-icons/react`, all three of which throw.
+
+```jsx
+import { BeakerIcon } from '@heroicons/react/24/solid';
+
+<box style={{ flexGrow: 1 }}>
+  <BeakerIcon style={{ width: 24, height: 24 }} />
+</box>;
+```
+
+The `className` it sets is ignored by the renderer, so you must pass
+`style={{ width, height }}` yourself — an icon with no size will lay out at
+its natural size or collapse, depending on the surrounding flex box.
+
+There is no recolour channel through the component, so if you need a themed
+icon use the asset package below, or `@iconify-json/heroicons`.
+
+## `lucide` {#lucide}
+
+**Adapter, ~10 lines.** lucide@1.28.0.
+
+Lucide's core package. Alongside the DOM-oriented `createIcons`, every icon
+is exported as plain data: an array of `[tag, attrs]` pairs. No DOM, no
+React, tree-shakeable per icon.
+
+This is the best-fitting icon package for react-x11, because the data shape
+skips string parsing entirely — each pair becomes a JSX child of `<svg>`,
+which react-x11 serializes through `SvgChildNode` (camelCase to kebab
+attributes) into ntk's `SvgView`.
+
+```jsx
+import { createElement } from 'react';
+import { House, Sun } from 'lucide';
+
+function Icon({ icon, size = 24, color = '#000', strokeWidth = 2 }) {
+  return (
+    <svg viewBox="0 0 24 24" style={{ width: size, height: size }}>
+      <g
+        fill="none"
+        stroke={color}
+        strokeWidth={strokeWidth}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        {icon.map(([tag, attrs], i) =>
+          createElement(tag, { key: i, ...attrs }),
+        )}
+      </g>
+    </svg>
+  );
+}
+
+// <Icon icon={House} color="#16a34a" />
+// <Icon icon={theme === 'dark' ? Sun : House} color={accent} />
+```
+
+Prop changes on SVG children invalidate and repaint correctly — swapping
+`icon` or `color` in state re-renders the icon.
+
+- Omitting the `<g>` and putting `stroke`/`fill` on the `<svg>` silently
+  renders black filled blobs.
+- Function props on SVG children are dropped by the serializer, so there are
+  no per-child events. Wrap the `<svg>` in a `<box onClick>` for a clickable
+  icon.
+- `className` on a child serializes to a `class-name` attribute — harmless,
+  but do not rely on classes for styling.
+
+## `lucide-static` {#lucide-static}
+
+**Adapter — the [`iconSource` wrapper](#iconsource).** lucide-static@1.28.0.
+
+The framework-free build of Lucide: every icon is a named export that is just
+an SVG markup string. 24×24 viewBox, stroke-based, `stroke="currentColor"`
+with round caps and joins — all on the root element, which is why it needs
+the wrapper.
+
+```jsx
+import * as lucide from 'lucide-static';
+import { iconSource } from './icon-source.js';
+
+const Icon = ({ name, size = 24, color = '#000' }) => (
+  <svg source={iconSource(lucide[name], color)} style={{ width: size }} />
+);
+
+// <Icon name="House" color="#e11d48" />
+// <Icon name="Sun" size={16} color="#eab308" />
+```
+
+Use the `lucide` data package above where you can; reach for this one when
+you want the markup string itself (asset pipelines, caching a pre-built
+sheet).
+
+## `react-icons` {#react-icons}
+
+**Adapter, ~15 lines.** react-icons@5.7.0.
+
+The standard React icon aggregator — Font Awesome, Material, Lucide,
+Bootstrap, Simple Icons and about fifty more, tens of thousands of icons
+behind one API. Out of the box it throws, because `IconBase` always sets
+`height`/`width` (default `"1em"`) as flat props on `<svg>`.
+
+The adapter sidesteps `IconBase` entirely. An icon component called with
+empty props returns the `IconBase` element, whose props carry exactly what is
+needed: `attr` (the set's root attributes — `viewBox`, and for stroke-based
+sets the paint attributes) and `children` (the icon's paths as ready-made
+React elements). Re-rooting those attributes onto an inner `<g>` handles
+fact 1 above.
+
+```jsx
+import { FaHeart } from 'react-icons/fa';
+import { LuHouse } from 'react-icons/lu';
+
+// Works for both fill sets (fa, md, …) and stroke sets (lu, fi, …).
+function RIcon({ icon: I, size = 24, color = '#000' }) {
+  const { attr = {}, children } = I({}).props; // IconBase element
+  const { viewBox = '0 0 24 24', ...paint } = attr;
+  return (
+    <svg viewBox={viewBox} style={{ width: size, height: size }}>
+      <g
+        color={color}
+        fill="currentColor"
+        stroke="currentColor"
+        strokeWidth={0}
+        {...paint}
+      >
+        {children}
+      </g>
+    </svg>
+  );
+}
+
+// <RIcon icon={FaHeart} color="#e11d48" />   fill-based
+// <RIcon icon={LuHouse} color="#2563eb" />   stroke-based
+```
+
+- `I({})` inside render leans on each icon being a plain function component
+  wrapping `GenIcon`. That has been react-icons' shape since v4, but it is an
+  internal one — if it changes, prefer `lucide` or the Iconify pipeline,
+  which have no such seam.
+- `IconContext` (global size/colour config) is bypassed; pass props instead.
+- The `title` prop emits an SVG `<title>` child, and there is no tooltip or
+  assistive-technology surface behind a rasterized SVG. Omit it.
+- react-icons is heavy on disk — every set is bundled. If you only need one
+  style, `lucide` or `@iconify-json/<set>` is a much smaller install.
+
+## `@tabler/icons` {#tabler-icons}
+
+**Adapter — the [`iconSource` wrapper](#iconsource).** @tabler/icons@3.46.0.
+
+The framework-free Tabler package: 5,000+ MIT icons as SVG files under
+`icons/outline/` (stroke-based, 24×24) and `icons/filled/`, with an `exports`
+map that resolves file paths directly. It also ships
+`tabler-nodes-outline.json`/`-filled.json` — per-icon node arrays, the same
+idea as `lucide`'s data exports.
+
+```jsx
+import fs from 'node:fs';
+import { iconSource } from './icon-source.js';
+
+const tabler = (name, style = 'outline') =>
+  fs.readFileSync(
+    new URL(import.meta.resolve(`@tabler/icons/${style}/${name}.svg`)),
+    'utf8',
+  );
+
+const Icon = ({ name, style, size = 24, color = '#000' }) => (
+  <svg
+    source={iconSource(tabler(name, style), color)}
+    style={{ width: size }}
+  />
+);
+
+// <Icon name="home" color="#dc2626" />
+// <Icon name="settings" style="filled" size={16} />
+```
+
+Honestly, though: **prefer `@iconify-json/tabler` + `@iconify/utils`**, which
+serves identical art with no adapter at all. This package earns its place
+when you want the files themselves (design pipelines, asset preprocessing) or
+the JSON node arrays.
+
+- Outline icons start with a `<path stroke="none" d="M0 0h24v24H0z"
+fill="none"/>` bounds rect; it inherits nothing and paints nothing.
+  Harmless.
+- `@tabler/icons-react` throws. See the
+  [register](../ecosystem.md#render-time).
+
+## `@phosphor-icons/core` {#phosphor-icons}
+
+**Adapter — the [`iconSource` wrapper](#iconsource).**
+@phosphor-icons/core@2.1.1.
+
+Phosphor's framework-free package: raw SVG files under
+`assets/<weight>/<name>.svg` for six weights (`thin`, `light`, `regular`,
+`bold`, `fill`, `duotone`), 256×256 viewBox, fill-based.
+
+Because Phosphor is fill-based, the raw file _does_ render legible black
+glyphs — the default fill happens to match — so the wrapper is only
+mandatory for colour. The `duotone` weight relies on per-path opacity, which
+survives fine either way.
+
+```jsx
+import fs from 'node:fs';
+import { iconSource } from './icon-source.js';
+
+const phosphor = (name, weight = 'regular') => {
+  const file = weight === 'regular' ? name : `${name}-${weight}`;
+  return fs.readFileSync(
+    new URL(
+      import.meta.resolve(`@phosphor-icons/core/assets/${weight}/${file}.svg`),
+    ),
+    'utf8',
+  );
+};
+
+const Icon = ({ name, weight, size = 24, color = '#000' }) => (
+  <svg
+    source={iconSource(phosphor(name, weight), color)}
+    style={{ width: size }}
+  />
+);
+
+// <Icon name="house" color="#0ea5e9" />
+// <Icon name="house" weight="fill" size={32} />
+```
+
+- Non-`regular` weights use suffixed filenames
+  (`assets/bold/house-bold.svg`); the helper above accounts for it.
+- `@iconify-json/ph` serves the same set with no adapter and no filesystem
+  access. Prefer it unless you want the files.
+- `@phosphor-icons/react` throws. See the
+  [register](../ecosystem.md#render-time).
+
+## `heroicons` (the asset package) {#heroicons-assets}
+
+**Adapter — the [`iconSource` wrapper](#iconsource).** heroicons@2.2.0.
+
+The Tailwind-house set as plain SVG files: `24/outline/*.svg` (stroke-based),
+`24/solid/`, `20/solid/` and `16/solid/`. No JS at all — the `heroicons` npm
+package is just the files.
+
+```jsx
+import fs from 'node:fs';
+import { iconSource } from './icon-source.js';
+
+const heroicon = (name, style = '24/outline') =>
+  fs.readFileSync(
+    new URL(import.meta.resolve(`heroicons/${style}/${name}.svg`)),
+    'utf8',
+  );
+
+const Icon = ({ name, style, size = 24, color = '#000' }) => (
+  <svg
+    source={iconSource(heroicon(name, style), color)}
+    style={{ width: size }}
+  />
+);
+
+// <Icon name="home" color="#f59e0b" />
+// <Icon name="home" style="24/solid" color="#0ea5e9" />
+```
+
+Use this rather than `@heroicons/react` when you need to recolour — the React
+components render fine but give you no colour channel. `heroicons` has no JS
+index, so enumerate the directory if you need a picker.
+
+**Prefer `@iconify-json/heroicons`** through the [Iconify](#iconify)
+pipeline: it is the same art, with no adapter and no filesystem access. Reach
+for the asset package when you specifically want the files.
+
+## `feather-icons` {#feather-icons}
+
+**Adapter, ~5 lines.** feather-icons@4.29.2.
+
+The classic 24×24 stroke set, 287 icons. Feather exposes `.contents` — the
+inner SVG markup, without a root element — which makes the adapter a template
+literal instead of a regex: build the root and the `<g>` yourself and fact 1
+never applies.
+
+```jsx
+import feather from 'feather-icons';
+
+function featherSvg(name, color = '#000', strokeWidth = 2) {
+  return `<svg viewBox="0 0 24 24"><g fill="none" stroke="${color}"
+    stroke-width="${strokeWidth}" stroke-linecap="round" stroke-linejoin="round"
+    >${feather.icons[name].contents}</g></svg>`;
+}
+
+const Icon = ({ name, size = 24, color, strokeWidth }) => (
+  <svg source={featherSvg(name, color, strokeWidth)} style={{ width: size }} />
+);
+
+// <Icon name="alert-circle" color="#f59e0b" />
+```
+
+- **Prefer Lucide.** Feather is in maintenance mode upstream — no new icons
+  in years. Lucide is its actively-developed fork with five times the
+  coverage and the same visual language. Reach for Feather only if you are
+  matching an existing design.
+- Raw `feather.icons.x.toSvg()` into `<svg source>` renders wrong, because
+  `toSvg()` puts every paint attribute on the root. `toSvg({ color })` sets
+  `color` on the root too, where it is equally ignored. Always go through
+  `.contents`.
+- `feather.replace()` (the DOM `<i data-feather>` swapper) is browser-only.

--- a/docs/ecosystem/layout.md
+++ b/docs/ecosystem/layout.md
@@ -1,0 +1,216 @@
+# Layout and positioning
+
+Layout itself is yoga's job — see [styling](../styling.md). The two packages
+here cover the parts yoga does not: placing a popup relative to a trigger
+across screen edges, and rendering a long list without building a node per
+row.
+
+Both are the _core_ half of a library whose React wrapper is DOM-bound. That
+is the recurring shape in this section of the ecosystem: the algorithm is
+portable, the wrapper is not, and the core is published separately precisely
+so that non-DOM hosts can use it.
+
+## `@floating-ui/core` {#floating-ui}
+
+**Adapter, ~35 lines (a platform object).** @floating-ui/core@1.8.0.
+
+The positioning engine underneath Floating UI, published without any DOM
+code. You hand `computePosition` a `platform` object — `getElementRects`,
+`getDimensions`, `getClippingRect`, `isRTL` — and get back the full
+middleware pipeline (`offset`, `flip`, `shift`, `size`, `arrow`,
+`autoPlacement`, `hide`) with the placement vocabulary every web developer
+already knows.
+
+The seam is exactly where `anchorRect()` already works: a drawn node's
+`node.abs` rect plus the owning window's screen origin gives the reference
+rect in screen coordinates, `screenOf(node)` gives the clipping rect, and the
+popup-to-be is just `{width, height}`. The result's `{x, y, placement}` drops
+straight into `<popup x y>`.
+
+```jsx
+import { computePosition, offset, flip, shift } from '@floating-ui/core';
+
+// The screen a node is on. Same three lines the built-in anchorRect uses;
+// it is not exported from the package, so keep a copy.
+function screenOf(node) {
+  const app = node?.app;
+  const screen = (app?.display ?? app?.X?.display)?.screen?.[0];
+  return screen?.pixel_width ? screen : null;
+}
+
+// reference = a drawn node (post-layout); floating = the popup's {width, height}
+function screenRectOf(node) {
+  const win = node.root?.window;
+  const origin = win?._screenOrigin ?? { x: win?.x ?? 0, y: win?.y ?? 0 };
+  return {
+    x: origin.x + node.abs.x,
+    y: origin.y + node.abs.y,
+    width: node.abs.width,
+    height: node.abs.height,
+  };
+}
+
+const platform = {
+  getElementRects: ({ reference, floating }) => ({
+    reference: screenRectOf(reference),
+    floating: { x: 0, y: 0, width: floating.width, height: floating.height },
+  }),
+  getDimensions: (el) => el.abs ?? el, // node or plain {width, height}
+  getClippingRect: ({ element }) => {
+    const s = screenOf(element?.node ?? element);
+    return s
+      ? { x: 0, y: 0, width: s.pixel_width, height: s.pixel_height }
+      : { x: 0, y: 0, width: Infinity, height: Infinity };
+  },
+  isElement: () => true,
+  isRTL: () => false,
+};
+
+const { x, y, placement } = await computePosition(
+  triggerNode, // from a ref on the trigger <box>
+  { width: 200, height: 150, node: triggerNode },
+  {
+    placement: 'bottom-start',
+    middleware: [offset(4), flip(), shift({ padding: 8 })],
+    platform,
+  },
+);
+// -> <popup x={x} y={y}> ; placement tells you which side won
+```
+
+What this buys over the built-in `anchorRect` is middleware composition
+(`shift` with padding, `size` to clamp long menus, `arrow`) and alignment
+fallback — `flip` with `crossAxis: 'alignment'` switches `bottom-start` to
+`bottom-end` when that is what fits. `anchorRect`'s `placement`, `align` and
+`offset` options map 1:1 onto `placement` plus the `offset()` middleware.
+
+- `computePosition` is async — `await` it, even though this platform is fully
+  synchronous.
+- `getClippingRect` above is screen 0's full rect, the same single-monitor
+  simplification `screenOf` has today. On a dual-head X display, popups clamp
+  to the bounding box of both monitors.
+- **`@floating-ui/dom` and `@floating-ui/react` are not usable** — they are
+  the DOM platform and DOM interactions respectively. Only `core` and its
+  `@floating-ui/utils` dependency belong in an X11 app.
+- The safe-polygon hover logic in `anchor.js` has no equivalent in `core`;
+  that lives in `@floating-ui/react`'s `useHover`, which is DOM-bound. Keep
+  the built-in one.
+
+## `@tanstack/virtual-core` {#tanstack-virtual}
+
+**Adapter, ~40 lines.** @tanstack/virtual-core@3.17.7.
+
+The virtualization engine behind `useVirtualizer`: given a count, an
+`estimateSize`, the viewport rect and the scroll offset, it computes which
+items are visible (`getVirtualItems()`), the total scrollable size
+(`getTotalSize()`), and offsets for `scrollToIndex`. All DOM touchpoints are
+constructor options, which is what makes this work.
+
+**Do not import `@tanstack/react-virtual`.** Its first line is
+`import { flushSync } from "react-dom"`. Without react-dom installed it fails
+to resolve; _with_ react-dom installed it silently flushes into the wrong
+reconciler — see the
+[silent-failures table](../ecosystem.md#silent-failures). Everything the
+React wrapper adds is the hook below.
+
+Three seams wire to `<scrollview>`:
+
+- `observeElementRect` → `<scrollview onViewport>`, which fires from layout
+  with `{width, height, contentWidth, contentHeight}` — including before any
+  scroll, which is what a list needs on mount;
+- `observeElementOffset` → `<scrollview onScroll>` (`scrollY`);
+- `scrollToFn` → `ref.scrollTo(offset)`.
+
+One non-obvious requirement: `getScrollElement()` must return something with
+`scrollHeight`/`clientHeight`, because virtual-core duck-types Element vs
+Window with `'scrollHeight' in el`. A getter shim over the scrollview node's
+`contentHeight`/`abs.height` satisfies it.
+
+```jsx
+import React from 'react';
+import { Virtualizer } from '@tanstack/virtual-core';
+
+function useX11Virtualizer({ count, estimateSize, overscan = 2 }) {
+  const ref = React.useRef(null);
+  const obs = React.useRef({});
+  const [, rerender] = React.useReducer((n) => n + 1, 0);
+  const [element] = React.useState(() => ({
+    // element-shaped view of the node
+    get scrollHeight() {
+      return ref.current?.contentHeight ?? 0;
+    },
+    get clientHeight() {
+      return ref.current?.abs.height ?? 0;
+    },
+    get scrollWidth() {
+      return ref.current?.contentWidth ?? 0;
+    },
+    get clientWidth() {
+      return ref.current?.abs.width ?? 0;
+    },
+  }));
+  const [v] = React.useState(
+    () =>
+      new Virtualizer({
+        count,
+        estimateSize,
+        overscan,
+        getScrollElement: () => (ref.current ? element : null),
+        observeElementRect: (_i, cb) => {
+          obs.current.rect = cb;
+        },
+        observeElementOffset: (_i, cb) => {
+          obs.current.offset = cb;
+          cb(0, false);
+        },
+        scrollToFn: (offset) => ref.current?.scrollTo(offset),
+        onChange: () => rerender(),
+      }),
+  );
+  v.setOptions({ ...v.options, count, onChange: () => rerender() });
+  React.useEffect(() => v._didMount(), []);
+  React.useEffect(() => v._willUpdate());
+  return {
+    virtualizer: v,
+    scrollviewProps: {
+      ref,
+      onViewport: (r) => obs.current.rect?.(r),
+      onScroll: (s) => obs.current.offset?.(s.scrollY, true),
+    },
+  };
+}
+```
+
+```jsx
+function BigList() {
+  const { virtualizer, scrollviewProps } = useX11Virtualizer({
+    count: 10000,
+    estimateSize: () => 24,
+  });
+  return (
+    <scrollview {...scrollviewProps} style={{ flexGrow: 1 }}>
+      <box style={{ height: virtualizer.getTotalSize() }}>
+        {virtualizer.getVirtualItems().map((item) => (
+          <text
+            key={item.key}
+            style={{ position: 'absolute', top: item.start, height: item.size }}
+          >
+            {`row ${item.index}`}
+          </text>
+        ))}
+      </box>
+    </scrollview>
+  );
+}
+```
+
+- **First paint shows zero rows.** Layout runs on the frame clock after the
+  mount commit, `onViewport` reports a tick later, and the list fills in on
+  the next frame. Fine interactively; tests must tick a few times.
+- `estimateSize` is the only measurement. Dynamic per-item measurement
+  (`measureElement`) is built on `ResizeObserver` and
+  `getBoundingClientRect`. For variable-height rows, pass exact sizes:
+  `estimateSize: (i) => heights[i]`.
+- `_didMount`/`_willUpdate` are underscored but are the documented pattern
+  for custom framework adapters — the official React, Vue and Svelte adapters
+  call exactly these.

--- a/docs/ecosystem/routing.md
+++ b/docs/ecosystem/routing.md
@@ -1,0 +1,146 @@
+# Routing
+
+There is no URL bar and no `history` object, so every router on this page
+runs on an in-memory location. That is not a workaround — both libraries ship
+a first-party memory backend, because both already support React Native and
+testing.
+
+What consistently does not survive is the _link_ element. `<Link>` renders an
+`<a>` host in both routers, and there is no `<a>` here. Navigate imperatively
+from a `<box onClick>` instead; that is two lines and it is all you lose.
+
+Also worth saying up front: a desktop app usually wants stack or tab
+navigation semantics rather than URL paths. These libraries give you the
+matching machinery, not a back stack — build that on top if you need it.
+
+## wouter {#wouter}
+
+**Out of the box — with `wouter/memory-location`.** wouter@3.10.0.
+
+A 2 kB router: `<Router>`, `<Route>`, `<Switch>`, `useLocation`, pattern
+params. Location sources are pluggable hooks and the package ships a
+non-browser one, so there is no adapter to write.
+
+```jsx
+import React from 'react';
+import ReactX11 from 'react-x11';
+import { Router, Route, Switch } from 'wouter';
+import { memoryLocation } from 'wouter/memory-location';
+
+const { hook, navigate } = memoryLocation({ path: '/' });
+
+// the react-x11 replacement for <Link>
+const NavText = ({ href, children }) => (
+  <box style={{ height: 20 }} onClick={() => navigate(href)}>
+    <text style={{ color: '#08c' }}>{children}</text>
+  </box>
+);
+
+const App = () => (
+  <window width={400} height={300} title="routed">
+    <box style={{ flexGrow: 1, flexDirection: 'column' }}>
+      <Router hook={hook}>
+        <box style={{ flexDirection: 'row', gap: 8, height: 20 }}>
+          <NavText href="/">home</NavText>
+          <NavText href="/about">about</NavText>
+        </box>
+        <Switch>
+          <Route path="/">
+            <text>home page</text>
+          </Route>
+          <Route path="/about">
+            <text>about page</text>
+          </Route>
+          <Route>
+            <text>not found</text>
+          </Route>
+        </Switch>
+      </Router>
+    </box>
+  </window>
+);
+
+ReactX11.render(<App />);
+```
+
+- **Always mount the memory hook at the top.** A `<Route>` outside a
+  `<Router hook={...}>` falls back to `useBrowserLocation` and crashes
+  immediately with `ReferenceError: location is not defined`.
+- **`<Link>` does not work.** It renders an `<a>` host element.
+  `<Link asChild>` avoids the `<a>` but still does not navigate: its click
+  guard checks `event.button !== 0`, and react-x11's synthetic
+  `MouseEvent.button` is the X button number, which is `1` for left.
+- `useLocation()[1]` gives you the same `navigate` from inside components;
+  the module-level one from `memoryLocation` is just more convenient with a
+  single router.
+- `useHashLocation` and `useBrowserLocation` are browser-only. Everything
+  else — matching, params, nesting, `useRoute` — is pure.
+- `memoryLocation({ record: true })` keeps a `history` array, which is the
+  raw material for a back stack and handy to assert on in tests.
+
+## react-router {#react-router}
+
+**Out of the box — `MemoryRouter`, and none of the DOM components.**
+react-router 7.18.2.
+
+The router core — `useRoutes`, `useNavigate`, `useParams`, `useLocation`,
+loaders, actions — is DOM-free. Import from `react-router`, not
+`react-router-dom`; the DOM package re-exports the core plus the browser
+entry points, and the browser entry points are exactly what fails.
+
+```jsx
+import React from 'react';
+import ReactX11 from 'react-x11';
+import {
+  MemoryRouter,
+  Routes,
+  Route,
+  useNavigate,
+  useLocation,
+} from 'react-router';
+
+function Home() {
+  const navigate = useNavigate();
+  return (
+    <box style={{ flexDirection: 'column' }}>
+      <text>home page</text>
+      <box style={{ height: 20 }} onClick={() => navigate('/about')}>
+        <text>go to about</text>
+      </box>
+    </box>
+  );
+}
+
+function About() {
+  const loc = useLocation();
+  return <text>{`about page (${loc.pathname})`}</text>;
+}
+
+ReactX11.render(
+  <window width={300} height={200} title="routed">
+    <box style={{ flexGrow: 1 }}>
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/about" element={<About />} />
+          <Route path="*" element={<text>not found</text>} />
+        </Routes>
+      </MemoryRouter>
+    </box>
+  </window>,
+);
+```
+
+- **`BrowserRouter` and `HashRouter` both fail** — they call
+  `createBrowserHistory`, which needs `window.history`. The error is
+  `react-x11: uncaught error ReferenceError: document is not defined` at
+  `getUrlBasedHistory`, and note that `render()` does not throw: react-x11
+  logs it and the window count stays 0.
+- **`<Link>`, `<NavLink>` and `<Form>` all render `<a>`/`<form>` hosts** and
+  cannot work. Use `useNavigate()` on a `<box onClick>`.
+- A `<Link>` with a bare string child hits the raw-text error before the
+  element error: `react-x11: raw text "go" must be wrapped in a <text>
+element`. Both are in the
+  [register](../ecosystem.md#render-time).
+- If you do not need loaders and actions, wouter above is the smaller
+  dependency by a wide margin.

--- a/docs/ecosystem/state.md
+++ b/docs/ecosystem/state.md
@@ -1,0 +1,361 @@
+# State management
+
+Every store here is renderer-agnostic: they subscribe through React's own
+`useSyncExternalStore` and never touch a host environment. The out-of-React
+surface matters more in a desktop app than on the web — an X event callback,
+an ntk timer or a D-Bus signal handler can write to the store directly, and
+every subscribed component under every `<window>` re-renders.
+
+Versions below are what was tested; anything newer in the same major is
+expected to behave the same.
+
+## zustand {#zustand}
+
+**Out of the box.** zustand@5.0.14.
+
+A small unopinionated store: `create((set) => ({...}))` returns a hook that
+components call with a selector. Subscription goes through
+`useSyncExternalStore` imported from `react` itself, and the store is usable
+outside React via `useStore.getState()` / `useStore.subscribe()`. The
+default recommendation for app state: zero DOM, zero adapter.
+
+```jsx
+import React from 'react';
+import ReactX11 from 'react-x11';
+import { create } from 'zustand';
+
+const useStore = create((set) => ({
+  n: 0,
+  inc: () => set((s) => ({ n: s.n + 1 })),
+}));
+
+function App() {
+  const n = useStore((s) => s.n);
+  return (
+    <window width={200} height={100} title="counter">
+      <box style={{ padding: 8 }} onClick={() => useStore.getState().inc()}>
+        <text>count: {n}</text>
+      </box>
+    </window>
+  );
+}
+
+ReactX11.render(<App />);
+```
+
+Because the store is module-level rather than tree-level, several windows
+share it for free.
+
+- `zustand/middleware`'s `persist` defaults to `localStorage`; pass a
+  `storage` backed by `node:fs` (`createJSONStorage(() => fileStorage)`).
+- `zustand/traditional` (`createWithEqualityFn`) also works; the
+  shallow-compare helper is pure.
+
+## jotai {#jotai}
+
+**Out of the box.** jotai@2.20.2.
+
+Bottom-up atomic state: `atom(initial)` defines a unit of state,
+`useAtom`/`useAtomValue`/`useSetAtom` read and write it, and derived atoms
+recompute from their dependencies. Atoms are pure and the React bindings
+import only `react`.
+
+The explicit-store pattern is the right one for a desktop app: create the
+store at startup, hand it to the tree, and let X event handlers or
+background work call `store.set(...)`. One store shared by several
+`<window>` trees keeps them in sync automatically.
+
+```jsx
+import React from 'react';
+import ReactX11 from 'react-x11';
+import { atom, createStore, Provider, useAtomValue } from 'jotai';
+
+const countAtom = atom(0);
+const doubledAtom = atom((get) => get(countAtom) * 2);
+const store = createStore();
+
+function App() {
+  const doubled = useAtomValue(doubledAtom);
+  return (
+    <window width={200} height={100} title="jotai">
+      <text>doubled: {doubled}</text>
+    </window>
+  );
+}
+
+ReactX11.render(
+  <Provider store={store}>
+    <App />
+  </Provider>,
+);
+setInterval(() => store.set(countAtom, (n) => n + 1), 1000);
+```
+
+- `jotai/utils`' `atomWithStorage` defaults to `localStorage`; supply a
+  custom storage (sync or async).
+- Async atoms suspend; wrap consumers in `<React.Suspense>` — react-x11
+  renders fallbacks like any React 19 host — or use `loadable()`.
+
+## valtio {#valtio}
+
+**Out of the box.** valtio@2.3.2.
+
+Proxy-based state: `proxy(obj)` returns an object you mutate directly;
+`useSnapshot(state)` returns an immutable snapshot and tracks which
+properties were read, re-rendering only when those change.
+
+Mutation-from-anywhere maps well onto X event handlers and ntk callbacks.
+`subscribe(state, cb)` is handy for pushing state into non-React things —
+writing a selection to the X clipboard, updating a window title
+imperatively.
+
+```jsx
+import React from 'react';
+import ReactX11 from 'react-x11';
+import { proxy, useSnapshot } from 'valtio';
+
+const state = proxy({ n: 0, log: [] });
+
+function App() {
+  const snap = useSnapshot(state);
+  return (
+    <window width={220} height={120} title="valtio">
+      <box
+        style={{ padding: 8 }}
+        onClick={() => {
+          state.n += 1;
+          state.log.push(Date.now());
+        }}
+      >
+        <text>clicked {snap.n} times</text>
+      </box>
+    </window>
+  );
+}
+
+ReactX11.render(<App />);
+```
+
+- Valtio 2 no longer deep-clones snapshots the way v1 did in dev; read the
+  v2 migration notes if you are coming from v1 examples.
+- `valtio/utils`' `devtools()` targets the Redux DevTools browser extension.
+  It is a no-op without one, and there is nothing to connect to under X11.
+
+## XState {#xstate}
+
+**Out of the box.** xstate@5.32.5, @xstate/react@6.1.0.
+
+`createMachine` describes states, events, guards and actions; `createActor`
+interprets one; `@xstate/react` provides `useMachine`, `useActor`,
+`useActorRef` and `useSelector`. The interpreter has no environment coupling
+and the React bindings subscribe via `useSyncExternalStore`.
+
+Desktop chrome is where statecharts earn their keep: drag-resize state,
+modal and focus flows, a connection lifecycle (`connecting → connected →
+retrying`), long-running jobs with cancellation. An actor started at app
+level can outlive any single `<window>` and drive several of them.
+
+```jsx
+import React from 'react';
+import ReactX11 from 'react-x11';
+import { createMachine, createActor } from 'xstate';
+import { useSelector } from '@xstate/react';
+
+const toggle = createMachine({
+  id: 'toggle',
+  initial: 'off',
+  states: {
+    off: { on: { TOGGLE: 'on' } },
+    on: { on: { TOGGLE: 'off' } },
+  },
+});
+const actor = createActor(toggle).start();
+
+function App() {
+  const value = useSelector(actor, (s) => s.value);
+  return (
+    <window width={220} height={120} title="xstate">
+      <box
+        style={{ padding: 8 }}
+        onClick={() => actor.send({ type: 'TOGGLE' })}
+      >
+        <text>state: {value}</text>
+      </box>
+    </window>
+  );
+}
+
+ReactX11.render(<App />);
+```
+
+- `useMachine(machine)` inside a component works too and gives you a
+  component-scoped actor; the external-actor pattern above is better for
+  machines shared across windows.
+- `@statelyai/inspect` connects over WebSocket to Stately's editor. The
+  transport works from Node; the iframe inspector expects a browser.
+
+## Redux {#redux}
+
+**Out of the box — pin `react-redux@>=9`.** react-redux@9.3.0,
+@reduxjs/toolkit@2.12.0, redux@5.0.1.
+
+react-redux 9 dropped the `react-dom`/`react-native` imports it used for
+`unstable_batchedUpdates` and subscribes through React's own
+`useSyncExternalStore`, so it is renderer-agnostic and needs no shim here.
+redux core and RTK are pure JS throughout, listener and observable
+middleware included.
+
+```jsx
+import React from 'react';
+import ReactX11 from 'react-x11';
+import { configureStore, createSlice } from '@reduxjs/toolkit';
+import { Provider, useSelector, useDispatch } from 'react-redux';
+
+const counter = createSlice({
+  name: 'counter',
+  initialState: { n: 0 },
+  reducers: {
+    inc: (s) => {
+      s.n += 1;
+    }, // immer draft — mutation is fine
+  },
+});
+const store = configureStore({ reducer: { counter: counter.reducer } });
+
+function Counter() {
+  const n = useSelector((s) => s.counter.n);
+  const dispatch = useDispatch();
+  return (
+    <box style={{ padding: 8 }} onClick={() => dispatch(counter.actions.inc())}>
+      <text>count: {n}</text>
+    </box>
+  );
+}
+
+ReactX11.render(
+  <Provider store={store}>
+    <window width={220} height={120} title="redux">
+      <Counter />
+    </window>
+  </Provider>,
+);
+```
+
+- **The version pin is the one thing you must know.** react-redux 8 imports
+  `react-dom` unconditionally, and the failure is a module-resolution error
+  at startup, not a runtime warning. Both of its failure modes — the npm
+  `ERESOLVE` on React 19 and the `Cannot find module 'react-dom'` behind
+  `--legacy-peer-deps` — are in the
+  [negative-results register](../ecosystem.md#install-and-import-time).
+- RTK's `devTools: true` (the default) looks for the Redux DevTools
+  extension global; harmless when absent. `@redux-devtools/cli` is a remote
+  devtools server if you want inspection.
+- RTK Query works, but `setupListeners()` wires
+  `window.addEventListener('focus'|'online')`, which are absent under Node.
+  Pass a custom handler to `setupListeners(dispatch, customHandler)` wired
+  to `<window onFocus>`, the same way as the
+  [TanStack Query adapter](data-fetching.md#tanstack-query).
+
+## Immer {#immer}
+
+**Out of the box.** immer@11.1.15.
+
+`produce(base, recipe)` runs a mutating recipe against a Proxy draft and
+returns a structurally-shared immutable result. Curried `produce(recipe)` is
+a drop-in `setState` updater. Pure JS, no environment assumptions — and it
+is already inside `@reduxjs/toolkit`'s `createSlice` reducers and available
+as zustand middleware (`zustand/middleware/immer`).
+
+```jsx
+import React from 'react';
+import ReactX11 from 'react-x11';
+import { produce } from 'immer';
+
+function App() {
+  const [state, setState] = React.useState({
+    items: [{ label: 'a', done: false }],
+  });
+  const toggle = (i) =>
+    setState(
+      produce((draft) => {
+        draft.items[i].done = !draft.items[i].done;
+      }),
+    );
+  return (
+    <window width={260} height={160} title="todo">
+      {state.items.map((it, i) => (
+        <box key={it.label} style={{ padding: 4 }} onClick={() => toggle(i)}>
+          <text>
+            {it.done ? '[x] ' : '[ ] '}
+            {it.label}
+          </text>
+        </box>
+      ))}
+    </window>
+  );
+}
+
+ReactX11.render(<App />);
+```
+
+Nothing to adapt. Useful directly with `useState`/`useReducer` for the
+nested state desktop apps accumulate — tree views, multi-pane layouts.
+
+## MobX {#mobx}
+
+**Adapter — no code, but `react-dom` must be installed.** mobx@6.16.1,
+mobx-react-lite@4.1.1.
+
+Observable state via `makeAutoObservable`/`observable`, with
+`mobx-react-lite`'s `observer()` HOC re-rendering components when the
+observables they dereference change. mobx core is pure JS.
+
+The wrinkle: **every build of mobx-react-lite unconditionally does
+`import { unstable_batchedUpdates } from "react-dom"`** at module load, to
+install React's batcher as mobx's reaction scheduler. In a react-x11 app
+react-dom is not otherwise present, so the import fails at startup with
+`Cannot find module 'react-dom'`.
+
+The fix is `npm install react-dom`. Its top-level entry is Node-safe (it is
+the same entry SSR uses), react-x11 never renders through it, and React 19's
+`unstable_batchedUpdates` is a thin wrapper that batches correctly for any
+renderer. With react-dom present, `observer` subscribes through
+`use-sync-external-store` and mutations from X event handlers or timers
+re-render the tree.
+
+```jsx
+// prerequisite: npm install react-dom  (satisfies mobx-react-lite's import;
+// react-x11 does not render through it)
+import React from 'react';
+import ReactX11 from 'react-x11';
+import { makeAutoObservable, runInAction } from 'mobx';
+import { observer } from 'mobx-react-lite';
+
+const store = makeAutoObservable({ n: 0 });
+
+const App = observer(function App() {
+  return (
+    <window width={220} height={120} title="mobx">
+      <box
+        style={{ padding: 8 }}
+        onClick={() =>
+          runInAction(() => {
+            store.n += 1;
+          })
+        }
+      >
+        <text>count: {store.n}</text>
+      </box>
+    </window>
+  );
+});
+
+ReactX11.render(<App />);
+```
+
+- Without react-dom the app fails at import time, not render time; the error
+  names mobx-react-lite in its require stack.
+- `mobx-react` (the bigger sibling) layers on mobx-react-lite, so the same
+  note applies. Prefer `-lite`.
+- Do not import from `react-dom` yourself. It is a compatibility shim here,
+  nothing more.

--- a/docs/ecosystem/testing.md
+++ b/docs/ecosystem/testing.md
@@ -1,0 +1,509 @@
+# Testing
+
+None of Testing Library works here, and no amount of shimming will change
+that — the queries are built on a document, and there is no accessibility
+tree behind react-x11 today. All five failure modes are recorded in the
+[negative-results register](../ecosystem.md#render-time); do not spend an
+afternoon on a jsdom shim, because it only makes the query fail differently.
+
+What replaces it is more direct and, for a renderer, more useful: mount into
+a real X connection with no display, then assert on the node tree, on the
+recorded paint operations, or on actual pixels.
+
+## The harness {#harness}
+
+node-x11 ships a pure-JS X server that runs in your test process, so a
+react-x11 test needs no `$DISPLAY`, no Xvfb, and no native dependency. This
+is the same harness the renderer's own integration tests use.
+
+```jsx
+// helpers/harness.jsx
+import React from 'react';
+import ReactX11 from 'react-x11';
+import { createClient } from 'ntk';
+import xserver from 'x11/lib/xserver/index.js';
+
+export async function createHeadlessApp() {
+  const server = xserver.createServer({ width: 640, height: 480 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  return await createClient({ stream: clientEnd });
+}
+
+/** ReactX11.render's callback hands back the ntk window instance. */
+export const render = (element, app) =>
+  new Promise((resolve) =>
+    ReactX11.render(element, (wnd) => resolve(wnd), app),
+  );
+
+export const tick = () => new Promise((r) => setImmediate(r));
+```
+
+```jsx
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { createHeadlessApp, render, tick } from './helpers/harness.jsx';
+
+test('paints a box', async () => {
+  const app = await createHeadlessApp();
+  const wnd = await render(
+    <window width={320} height={240} title="probe">
+      <box style={{ flexGrow: 1, backgroundColor: '#204080' }} />
+    </window>,
+    app,
+  );
+  await tick(); // layout runs on the frame clock, after the commit
+
+  const node = wnd._reactX11Node; // the root drawn node
+  assert.equal(node.children[0].kind, 'box');
+  assert.deepEqual(node.children[0].abs, {
+    x: 0,
+    y: 0,
+    width: 320,
+    height: 240,
+  });
+
+  ReactX11.unmountComponentAtNode(app);
+});
+```
+
+**The `tick()` is not optional.** `render`'s callback resolves at commit
+time; layout runs a task later on the frame clock, so every `abs` rect is
+`{x: 0, y: 0, width: 0, height: 0}` until you yield once. Assert on `kind`
+and `props` immediately if you like, but never on geometry.
+
+`wnd._reactX11Node` is the root of the drawn tree. Each node carries `kind`
+(the element name), `props`, `children`, and `abs` — its laid-out rect. That
+is the queryable surface: walk it. It is not a DOM and it does not pretend to
+be one. `ownerDocument` and `getClientRects()` do exist on nodes, but only
+because React DevTools' `measureHostInstance` dereferences them.
+
+Text is a two-level structure: a `<text>` node holds `textchunk` children
+whose `.text` is the string. A collector is three lines:
+
+```js
+export function textOf(node) {
+  const out = [];
+  (function walk(n) {
+    if (n.kind === 'textchunk') out.push(n.text);
+    (n.children ?? []).forEach(walk);
+  })(node);
+  return out.join('');
+}
+```
+
+If you want to run without any X server at all — faster, and enough for most
+component tests — write a small mock ntk app that records canvas operations
+instead of painting them, and pass it as the third argument to
+`ReactX11.render`. That is what the renderer's unit tests do; there is no
+mock published in the package, so it is yours to write and yours to keep
+minimal.
+
+## Driving events {#driving-events}
+
+`@testing-library/user-event` throws on `setup()` — see the
+[register](../ecosystem.md#render-time). Emit the raw ntk event on the window
+instead. react-x11 subscribes to the ntk window's emitter, so this exercises
+the whole synthetic-event path: hit testing, capture, bubble, default
+actions.
+
+```jsx
+test('a synthetic click reaches the handler', async () => {
+  const app = await createHeadlessApp();
+  let clicks = 0;
+  const wnd = await render(
+    <window width={200} height={100}>
+      <box style={{ flexGrow: 1 }} onClick={() => (clicks += 1)} />
+    </window>,
+    app,
+  );
+  await tick();
+
+  wnd.emit('mousedown', { x: 20, y: 20, button: 1, buttons: 1 });
+  wnd.emit('mouseup', { x: 20, y: 20, button: 1, buttons: 0 });
+  await tick();
+
+  assert.equal(clicks, 1);
+  ReactX11.unmountComponentAtNode(app);
+});
+```
+
+Keyboard input is the same shape — `wnd.emit('keydown', { keycode, codepoint,
+buttons })` — with the keysym registered in `app.X.keycode2keysyms` so the
+renderer can resolve it. Note `button` is the X button number, so left is
+`1`, not `0`.
+
+## Runners {#runners}
+
+**`node:test` (built-in) is the baseline.** react-x11's own suite uses it, it
+needs no transform, and it handles the ESM graph — including the top-level
+await inside `yoga-layout` — without configuration. Run `.jsx` files through
+`tsx`: `node --import tsx --test 'test/**/*.test.jsx'`.
+
+### Vitest {#vitest}
+
+**Out of the box.** vitest@4.1.10.
+
+The familiar choice for anyone arriving from a web project: native ESM,
+built-in JSX and TypeScript transform, watch mode, snapshots. A `.test.jsx`
+file that mounts a tree, drives a prop update and asserts on both the node
+tree and the paint-op log runs green with no flags.
+
+The one setting that matters:
+
+```js
+// vitest.config.mjs
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: { environment: 'node' }, // the default; never 'jsdom'
+  esbuild: { jsx: 'automatic' },
+});
+```
+
+**Never `environment: 'jsdom'`.** react-x11 needs no DOM, and a jsdom
+environment _defines_ `window` and `document`, which silently flips
+environment detection in third-party libraries — `@tanstack/query-core`
+decides it is in a browser and changes retry and refetch behaviour, for one.
+`'node'` is Vitest's default; just do not cargo-cult a web project's config
+across.
+
+- Vitest runs test files in worker threads by default. The in-process X
+  server works there, but `pool: 'forks'` is the escape hatch if long-lived
+  server streams misbehave.
+- `vi.useFakeTimers()` shares the [sinon caveat](#sinon): pass an explicit
+  `toFake` list, or React's scheduling and the renderer's paint scheduling
+  freeze.
+
+### Jest {#jest}
+
+**Works, but only in real ESM mode.** jest@30.4.2.
+
+Jest's default CJS path cannot work at all. `babel-jest` down-compiles to
+CommonJS, and `react-x11/src/Reconciler.js` and `src/DevToolsIntegration.js`
+both call `createRequire(import.meta.url)`, which has no CJS equivalent — so
+following Jest's own suggestions leads to
+`SyntaxError: Cannot use 'import.meta' outside a module`. Both dead ends are
+in the [register](../ecosystem.md#install-and-import-time).
+
+The configuration that does work:
+
+```js
+// jest.config.mjs — run with NODE_OPTIONS=--experimental-vm-modules
+export default {
+  extensionsToTreatAsEsm: ['.jsx'],
+  transform: {
+    '\\.jsx$': [
+      'babel-jest',
+      {
+        presets: [
+          [
+            '@babel/preset-env',
+            { modules: false, targets: { node: 'current' } },
+          ],
+          ['@babel/preset-react', { runtime: 'automatic' }],
+        ],
+      },
+    ],
+  },
+};
+```
+
+`modules: false` is the load-bearing part: stop transforming to CJS and Jest
+runs the same ESM graph everything else does. If you have the choice,
+`node:test` or Vitest need none of this.
+
+## msw {#msw}
+
+**Out of the box — `msw/node`.** msw@2.15.0.
+
+Request-level API mocking. In Node, `setupServer` patches the runtime's
+request internals (`http`, `https`, `fetch`/undici, `XMLHttpRequest`) so
+handlers written as `http.get(url, resolver)` intercept real requests — no
+service worker, no DOM, despite the name.
+
+A react-x11 app's data layer is ordinary Node networking, so msw slots in
+with zero adapter: components genuinely call `fetch`, msw answers, state
+updates, the renderer repaints.
+
+```jsx
+import { setupServer } from 'msw/node';
+import { http, HttpResponse } from 'msw';
+
+const server = setupServer(
+  http.get('https://api.example.test/user', () =>
+    HttpResponse.json({ name: 'Ada' }),
+  ),
+);
+before(() => server.listen({ onUnhandledRequest: 'error' }));
+after(() => server.close());
+
+function User() {
+  const [name, setName] = React.useState('loading');
+  React.useEffect(() => {
+    let alive = true;
+    fetch('https://api.example.test/user')
+      .then((r) => r.json())
+      .then((d) => alive && setName(d.name));
+    return () => {
+      alive = false;
+    };
+  }, []);
+  return <text>{name}</text>;
+}
+```
+
+- The fetch → `setState` → commit round trip is asynchronous, and a single
+  `setImmediate` tick is **not** enough. Poll the tree with a deadline.
+- `server.listen()` patches process-wide networking. Call `server.close()` in
+  `after`, or the X server harness and msw can both be left holding process
+  state between files.
+- Requests to the in-process X server are plain streams, not HTTP, so msw
+  never sees or interferes with the X11 connection.
+- `onUnhandledRequest: 'error'` turns any unmocked request into a loud
+  failure, which is the right default for hermetic UI tests.
+- nock also works. Prefer it only if you specifically need its scope-level
+  assertions (`scope.done()`) on legacy `http.request`-based clients.
+
+## fast-check {#fast-check}
+
+**Out of the box.** fast-check@4.9.0.
+
+Property-based testing: describe generators, state a property, and
+fast-check runs it against hundreds of random inputs, then _shrinks_ any
+failure to a minimal counterexample and prints a replay seed.
+
+This is a good fit because the renderer has oracles that cannot lie:
+
+- **Convergence** — `mount(A)` then `update(A → B)` must produce the same
+  tree as a fresh `mount(B)`.
+- **Damage soundness** — a partial repaint must equal a forced full repaint.
+
+```jsx
+import fc from 'fast-check';
+
+const { node } = fc.letrec((tie) => ({
+  node: fc.oneof(
+    { maxDepth: 3 },
+    fc.record({
+      kind: fc.constant('text'),
+      label: fc.constantFrom('a', 'hello x11'),
+    }),
+    fc.record({
+      kind: fc.constant('box'),
+      style: fc.record(
+        {
+          width: fc.integer({ min: 10, max: 120 }),
+          flexDirection: fc.constantFrom('row', 'column'),
+        },
+        { requiredKeys: [] },
+      ),
+      children: fc.array(tie('node'), { maxLength: 3 }),
+    }),
+  ),
+}));
+
+const toEl = (s, key) =>
+  s.kind === 'text' ? (
+    <text key={key}>{s.label}</text>
+  ) : (
+    <box key={key} style={s.style}>
+      {s.children.map(toEl)}
+    </box>
+  );
+const win = (kids) => (
+  <window width={320} height={240}>
+    {kids.map(toEl)}
+  </window>
+);
+const snap = (n) => ({
+  kind: n.kind,
+  abs: { ...n.abs },
+  children: n.children.map(snap),
+});
+
+await fc.assert(
+  fc.asyncProperty(
+    fc.array(node, { maxLength: 4 }),
+    fc.array(node, { maxLength: 4 }),
+    async (a, b) => {
+      const app1 = await createHeadlessApp();
+      const w1 = await render(win(a), app1);
+      await tick();
+      await render(win(b), app1); // update path
+      await tick();
+      const app2 = await createHeadlessApp();
+      const w2 = await render(win(b), app2); // fresh-mount path
+      await tick();
+      assert.deepStrictEqual(snap(w1._reactX11Node), snap(w2._reactX11Node));
+    },
+  ),
+  { numRuns: 30 },
+);
+```
+
+- Compare structure (`kind` plus `abs` rects), not paint-op logs: op logs
+  accumulate across paints on the update path, so they only match after
+  forcing a full repaint on both sides.
+- Keep trees shallow. Each run is a real yoga layout pass, so budget runs
+  accordingly in CI.
+- Include a mid-sequence unmount/remount and `key` permutations in generators
+  before trusting the property. Index keys exercise much less of
+  `insertBefore`/`removeChild` than keyed reorders do.
+- Sixty lines of seeded PRNG would also do this job with no dependency. What
+  fast-check buys is shrinking and `{ seed, path }` replay, which is worth
+  one dev-dependency for a differential suite meant to run forever.
+
+## sinon {#sinon}
+
+**Out of the box, with one required restriction.** sinon@22.1.0.
+
+Spies, stubs and `@sinonjs/fake-timers`. Fake timers work — a toast component
+that auto-dismisses via `setTimeout` dismisses on `clock.tick(1000)` — but
+the default configuration is a trap.
+
+**Never fake `setImmediate` or `queueMicrotask`.** Sinon's default `toFake`
+list includes them; React's scheduler drives work with them in Node, and the
+renderer schedules paints via `setImmediate` when there is no frame clock.
+Fake them and every render, effect flush and repaint freezes until a
+`clock.tick`, which usually presents as a test that hangs at the first
+`await`. Always pass an explicit list:
+
+```js
+const clock = sinon.useFakeTimers({
+  toFake: ['setTimeout', 'clearTimeout', 'Date'],
+});
+```
+
+Faking `Date` is more interesting than it looks: the renderer's animation
+clock reads `Date.now()` at call time, so a fake `Date` does reach style
+transitions.
+
+```jsx
+test('toast auto-dismisses', async () => {
+  const clock = sinon.useFakeTimers({
+    toFake: ['setTimeout', 'clearTimeout', 'Date'],
+  });
+  try {
+    const app = await createHeadlessApp();
+    const wnd = await render(
+      <window width={100} height={50}>
+        <Toast />
+      </window>,
+      app,
+    );
+    await tick(); // mount + passive effect
+    clock.tick(1000); // fires the timeout synchronously
+    await tick();
+    await tick(); // setState -> commit -> repaint: two tasks
+    assert.strictEqual(wnd._reactX11Node.children.length, 0);
+  } finally {
+    clock.restore(); // always; a leaked fake Date poisons the file
+  }
+});
+```
+
+- Two `setImmediate` ticks after `clock.tick`, not one — the timer callback's
+  `setState` commits on a later task than the tick itself.
+- `clock.restore()` in `finally`, every time. A leaked fake `Date` breaks
+  every subsequent test's transitions and timestamps in the same process.
+- The text-input caret blink uses `setInterval`; faking `setInterval` without
+  ticking leaves the caret timer pending. Mostly harmless, but it shows up in
+  `clock.countTimers()`.
+- **Versus `node:test` mock timers**: both pass on the same component.
+  `t.mock.timers.enable({ apis: ['setTimeout'] })` plus
+  `t.mock.timers.tick(1000)` does the plain-timer case with zero dependencies
+  and auto-restores. Prefer it, and reach for sinon when you need fake `Date`
+  (the animation clock), `clock.countTimers()`, or spies and stubs.
+
+## pixelmatch {#pixelmatch}
+
+**Out of the box.** pixelmatch@7.2.0.
+
+The standard perceptual image-diff primitive: two RGBA buffers plus an output
+buffer in, changed-pixel count and a painted diff image out. Anti-aliasing
+aware, zero dependencies.
+
+react-x11 can screenshot itself with no display — render through the harness
+above and read pixels back with `getImageData`. `jest-image-snapshot` cannot
+do this for you (it wants a Buffer and receives a window object; see the
+[register](../ecosystem.md#render-time)), but the pipeline underneath it is
+four lines.
+
+Two impedance notes at the seam. `ctx.getImageData(x, y, w, h, cb)` is
+callback-style and yields an image whose `.data` is **BGRA**, so swap
+channels and set alpha to 255. And pixel readback races the paint: poll a
+known pixel before taking the comparison frame.
+
+```jsx
+import pixelmatch from 'pixelmatch';
+import { PNG } from 'pngjs';
+
+const readRGBA = (ctx, w, h) =>
+  new Promise((res, rej) =>
+    ctx.getImageData(0, 0, w, h, (err, image) => {
+      if (err) return rej(err);
+      const out = new Uint8Array(w * h * 4);
+      for (let i = 0; i < out.length; i += 4) {
+        // BGRA -> RGBA
+        out[i] = image.data[i + 2];
+        out[i + 1] = image.data[i + 1];
+        out[i + 2] = image.data[i];
+        out[i + 3] = 255;
+      }
+      res(out);
+    }),
+  );
+
+const before = await readRGBA(wnd.getContext('2d'), 320, 240);
+// ...re-render with the changed prop, wait for the repaint...
+const after = await readRGBA(wnd.getContext('2d'), 320, 240);
+
+const diff = new PNG({ width: 320, height: 240 });
+const changed = pixelmatch(before, after, diff.data, 320, 240, {
+  threshold: 0.1,
+});
+if (changed > 0) fs.writeFileSync('diff.png', PNG.sync.write(diff));
+```
+
+- **Fonts are the determinism problem.** Glyph indices travel on the wire, so
+  pin every family with ntk's `StaticFontSource` and never let a snapshot
+  script fall through to `FontconfigFontSource`. Pinned, two renders of the
+  same tree diff to exactly zero pixels; unpinned, the diff is noise.
+- `threshold` is a per-pixel colour distance, not a pass/fail budget. Gate on
+  the returned count.
+- Buffers must have identical dimensions; pixelmatch throws otherwise. A
+  window resize between shots needs a re-read, not a crop.
+- fontkit version bumps change hinting and advance rounding. Treat pixel
+  diffs as tolerance-based regression testing, and use tree or op-log
+  assertions for exact CI gating.
+- Against a _real_ X server under Xvfb, expect nonzero noise from the
+  server's own rendering. The zero-noise floor is specific to the in-process
+  JS server.
+
+## react-test-renderer {#react-test-renderer}
+
+**Works, but do not build on it.** react-test-renderer@19.2.8.
+
+React's own headless renderer treats _any_ string element type as a host
+element, so react-x11 vocabulary passes through untouched and coarse JSON
+snapshots work today. Two things keep it from being a recommendation:
+
+1. **It is deprecated.** Importing it prints
+   `react-test-renderer is deprecated`. It still ships and works in 19.2.x,
+   but the React team explicitly discourages new usage.
+2. **It bypasses the actual renderer.** No prop validation, no style
+   resolution, no yoga layout, no paint. A tree that snapshots fine under
+   react-test-renderer can still throw
+   `react-x11: <box width=…> is a style property` or lay out wrong under
+   react-x11.
+
+The harness above is barely more code and exercises the real
+`createInstance`/`commitUpdate` path, with layout, for the same "no X server"
+cost. Acceptable as a bridge for teams porting an existing
+react-test-renderer suite; wrong foundation for new react-x11 tests.
+
+- Set `globalThis.IS_REACT_ACT_ENVIRONMENT = true` in test setup or every
+  `act` call warns. Harmless, but noisy.
+- `toJSON()` records the raw props object with none of react-x11's
+  resolution, so snapshots are of _input_, not of what would render.

--- a/docs/ecosystem/theming.md
+++ b/docs/ecosystem/theming.md
@@ -1,0 +1,477 @@
+# Theming, palettes and colour
+
+react-x11's theme is a plain object of hex strings and numbers — see
+[components](../components.md#theming) for the token list and
+[styling](../styling.md#theme-tokens) for how `$token` resolves. So every
+palette package on this page is used the same way: pick keys at
+theme-build time, hand the result to `<ThemeProvider>` and `<window theme>`,
+and the renderer never knows the package exists.
+
+One rule governs the whole page: **ntk's colour parser accepts hex, `rgb()`,
+`rgba()`, `hsl()` and CSS colour names, and returns null for anything else —
+and a null colour paints nothing, silently.** Modern token sets are
+increasingly `oklch()`-first, so conversion is not optional. That is the
+single sharpest edge here.
+
+CSS-in-JS is not on this page at all. `styled-components` and
+`@emotion/styled` both fail, in interestingly different ways, and are written
+up in the [negative-results register](../ecosystem.md#what-does-not-work).
+Use `createStyles` plus one of the palettes below.
+
+## `@radix-ui/colors` {#radix-colors}
+
+**Out of the box.** @radix-ui/colors@3.0.0.
+
+Thirty named 12-step colour scales (plus dark, alpha and P3 variants) shipped
+as plain JS objects of hex strings — no React, no DOM, no CSS. Each step has
+a documented job: 1–2 app backgrounds, 3–5 component backgrounds, 6–8
+borders, 9–10 solid fills, 11–12 text. That semantic contract is what makes
+it a theme _generator_ rather than a swatch book.
+
+Because every scale has identical structure, one function produces any
+light/dark pairing.
+
+```jsx
+import { slate, slateDark, grass, grassDark } from '@radix-ui/colors';
+import { ThemeProvider, Button } from 'react-x11';
+
+function radixTheme({ gray, accent }, dark = false) {
+  const g = Object.values(gray);
+  const a = Object.values(accent);
+  return {
+    canvas: g[0],
+    panel: g[1],
+    background: g[2],
+    text: g[11],
+    dim: g[10],
+    border: g[6],
+    borderActive: a[7],
+    accent: a[8],
+    accentHover: a[9],
+    accentText: dark ? g[11] : '#ffffff',
+    hoverBackground: a[8],
+    hoverText: '#ffffff',
+    surfaceHover: g[3],
+    track: g[5],
+    radius: 6,
+    radiusSmall: 4,
+    borderWidth: 1,
+    fontSize: 14,
+    paddingX: 16,
+    paddingY: 6,
+  };
+}
+
+const light = radixTheme({ gray: slate, accent: grass });
+const dark = radixTheme({ gray: slateDark, accent: grassDark }, true);
+
+<window theme={light} style={{ backgroundColor: '$canvas' }}>
+  <ThemeProvider value={light}>
+    <Button primary>OK</Button>
+  </ThemeProvider>
+</window>;
+```
+
+- The dark scales are _separate exports_ (`slateDark`, not `slate.dark`).
+- `Object.values()` ordering relies on the package's insertion order
+  (`blue1`…`blue12`). It holds in 3.0.0, but indexing by key
+  (``accent[`${name}9`]``) is sturdier if the scale name is handy.
+- Steps 9 and 10 of some scales — yellow, lime, amber, sky, mint — are light
+  enough that `accentText: '#ffffff'` fails contrast. Pick per scale, or
+  compute it with [colord](#colord).
+- The alpha variants (`slateA`) are `#rrggbbaa`, which parses fine, but
+  remember a translucent widget composites against the window background, not
+  against whatever is behind the window.
+- The P3 variants (`blueP3`) are `color(display-p3 …)` strings. The parser
+  returns null and nothing is painted. Stick to the sRGB exports.
+
+## `@catppuccin/palette` {#catppuccin}
+
+**Out of the box.** @catppuccin/palette@1.8.0.
+
+Four flavours (latte is light; frappé, macchiato and mocha are dark), each
+with 14 accents and a 12-step neutral ladder whose names _are_ UI roles —
+`base`/`mantle`/`crust` for backgrounds, `surface0-2`, `overlay0-2`,
+`subtext0-1`, `text`. Of all the palette packages this one maps most directly
+onto the theme shape.
+
+`flavor.dark` decides whether accent-coloured fills get dark or light text.
+Catppuccin accents are pastel, so on dark flavours the readable text on an
+accent is _dark_, not white.
+
+```jsx
+import { flavors } from '@catppuccin/palette';
+import { ThemeProvider, Button } from 'react-x11';
+
+function catppuccinTheme(flavor, accent = 'mauve') {
+  const c = Object.fromEntries(
+    Object.entries(flavor.colors).map(([k, v]) => [k, v.hex]),
+  );
+  const onAccent = flavor.dark ? c.crust : c.base;
+  return {
+    canvas: c.base,
+    panel: c.mantle,
+    background: c.surface0,
+    text: c.text,
+    dim: c.subtext0,
+    border: c.surface1,
+    borderActive: c[accent],
+    accent: c[accent],
+    accentHover: c.lavender,
+    accentText: onAccent,
+    hoverBackground: c[accent],
+    hoverText: onAccent,
+    surfaceHover: c.surface1,
+    track: c.surface2,
+    radius: 6,
+    radiusSmall: 4,
+    borderWidth: 1,
+    fontSize: 14,
+    paddingX: 16,
+    paddingY: 6,
+  };
+}
+
+const mocha = catppuccinTheme(flavors.mocha);
+const latte = catppuccinTheme(flavors.latte, 'blue');
+```
+
+- `accentHover` has no canonical Catppuccin answer — the palette defines flat
+  accents, not interaction ramps. Picking a neighbouring accent, as above, is
+  a taste call; deriving a real hover shade is a one-liner with
+  [colord](#colord) or [culori](#culori).
+- The package is ESM-first with an `exports` map, so un-exported subpaths
+  fail. The root import is all you need.
+- Latte's accents sit around 4:1 contrast on `base` — fine for fills,
+  marginal for small accent-coloured _text_. Same caveat as every pastel
+  scheme.
+
+## `@material/material-color-utilities` {#material-color-utilities}
+
+**Out of the box from a source colour.**
+@material/material-color-utilities@0.4.0.
+
+Google's reference implementation of the Material 3 colour system: the HCT
+colour space, tonal palettes, and `themeFromSourceColor(argb)`, which turns a
+single seed colour into complete light and dark schemes. It is the only
+package here that _generates_ a coherent scheme from one input, which is
+exactly the shape `<window theme>` wants.
+
+M3 roles map nearly 1:1 onto the theme shape: `surface → background`,
+`onSurface → text`, `outlineVariant → border`, `primary → accent`,
+`onPrimary → accentText`.
+
+```jsx
+import {
+  themeFromSourceColor,
+  argbFromHex,
+  hexFromArgb,
+} from '@material/material-color-utilities';
+import { ThemeProvider, Button } from 'react-x11';
+
+function materialTheme(scheme) {
+  const c = Object.fromEntries(
+    Object.entries(scheme.toJSON()).map(([k, v]) => [k, hexFromArgb(v)]),
+  );
+  return {
+    canvas: c.background,
+    panel: c.surfaceVariant,
+    background: c.surface,
+    text: c.onSurface,
+    dim: c.onSurfaceVariant,
+    border: c.outlineVariant,
+    borderActive: c.primary,
+    accent: c.primary,
+    accentHover: c.inversePrimary,
+    accentText: c.onPrimary,
+    hoverBackground: c.primary,
+    hoverText: c.onPrimary,
+    surfaceHover: c.surfaceVariant,
+    track: c.outlineVariant,
+    radius: 8,
+    radiusSmall: 4,
+    borderWidth: 1,
+    fontSize: 14,
+    paddingX: 16,
+    paddingY: 6,
+  };
+}
+
+const m3 = themeFromSourceColor(argbFromHex('#6750A4'));
+const light = materialTheme(m3.schemes.light); // accent #6750a4
+const dark = materialTheme(m3.schemes.dark); //   accent #cfbcff
+```
+
+- **The published ESM uses extensionless relative imports**, so plain `node`
+  fails with `ERR_MODULE_NOT_FOUND`. Under tsx — which is how react-x11 JSX
+  runs anyway — or any bundler, it resolves fine.
+- `themeFromImage`/`sourceColorFromImage` call `document.createElement('canvas')`
+  and are dead here. `sourceColorFromImageBytes(rgbaBytes)` is exported and
+  pure: decode a PNG or JPEG yourself with pngjs or jpeg-js and hand it the
+  RGBA array. Downscale first — the Celebi quantizer walks every opaque
+  pixel, and it skips pixels with alpha below 255.
+- `accentHover` has no M3 role. `inversePrimary` is serviceable; a tone step
+  via `theme.palettes.primary.tone(n)` is more faithful.
+- 0.4.0 has sat unchanged for a while. The upstream repo is active but npm
+  releases are slow — pin it.
+
+## colord {#colord}
+
+**Out of the box.** colord@2.9.3.
+
+A tiny immutable colour-manipulation library: parse, `darken`/`lighten`/
+`alpha`/`mix`, `isDark()`, output as hex/rgb/hsl. The `a11y` plugin adds WCAG
+`contrast()` and `isReadable()`.
+
+The theme shape wants colours no palette ships — `accentHover`,
+`surfaceHover`, and the right `accentText` for an arbitrary accent. colord
+answers all three in a line each, which turns any single brand colour into a
+complete theme without hand-tuning.
+
+```jsx
+import { colord, extend } from 'colord';
+import a11yPlugin from 'colord/plugins/a11y';
+extend([a11yPlugin]);
+
+/** One brand colour -> the interactive slice of a react-x11 theme. */
+function accentSlice(accent) {
+  const c = colord(accent);
+  const onAccent = c.contrast('#ffffff') >= 4.5 ? '#ffffff' : '#1b1b1b';
+  return {
+    accent,
+    accentHover: c.darken(0.06).toHex(),
+    borderActive: accent,
+    hoverBackground: accent,
+    accentText: onAccent,
+    hoverText: onAccent,
+  };
+}
+
+const theme = { ...baseTheme, ...accentSlice('#1f883d') };
+// colord('#1f883d').contrast('#ffffff') === 4.51 -> white text, just barely
+```
+
+- Plugins must be `extend`-ed before use; forgetting yields
+  `c.contrast is not a function` at theme-build time.
+- `darken()` works in HSL, which shifts saturated hues perceptibly. For a 6%
+  hover nudge nobody notices; for accent _ramps_ that must stay on-hue, use
+  culori's OKLCH interpolation.
+- Maintenance is quiet (2.9.3 since 2023) but the library is complete and
+  dependency-free. Low risk.
+
+## culori {#culori}
+
+**Out of the box.** culori@4.0.2.
+
+Parses every CSS Color 4 syntax, converts between about thirty colour spaces
+(OKLCH and OKLab included), interpolates in any of them, builds scales, and
+computes WCAG contrast. Two distinct jobs here:
+
+1. **Gateway for modern colour strings.** Growing amounts of design-token
+   output — Tailwind v4, Open Props' OKLCH variants, design systems
+   exporting CSS Color 4 — are `oklch()`-first, and ntk's parser returns null
+   for those. `formatHex(str)` is the one-call fix.
+2. **Perceptual ramps.** Hover, active and disabled shades interpolated in
+   OKLCH keep hue and perceived lightness honest where HSL manipulation
+   drifts.
+
+```jsx
+import { formatHex, interpolate, wcagContrast } from 'culori';
+
+// A perceptual ramp from one accent: 0 = accent, higher = lighter.
+const ramp = interpolate(['#0969da', '#ffffff'], 'oklch');
+const accent = '#0969da';
+
+const theme = {
+  ...baseTheme,
+  accent,
+  accentHover: formatHex(ramp(0.15)), // #3d81e2 — stays on-hue
+  borderActive: accent,
+  track: formatHex(ramp(0.75)),
+  accentText: wcagContrast(accent, '#fff') >= 4.5 ? '#ffffff' : '#1b1b1b',
+};
+
+// Gateway use: any CSS Color 4 string -> something ntk can paint.
+formatHex('oklch(54.6% 0.245 262.881)'); // '#155dfc'
+```
+
+- It is the heavyweight of the pair. Prefer colord for "darken this a bit",
+  culori when you need OKLCH, CSS Color 4 parsing, or scales. Using both is
+  fine — neither touches the render path.
+- `formatHex` clips out-of-sRGB-gamut results channelwise; for scales from
+  vivid P3-ish seeds, `clampChroma` first gives cleaner ramps.
+- Dual-published: ESM source plus a bundled CJS. The `/fn` and `/css`
+  subpaths for tree-shaken builds are ESM-only.
+
+## `open-props` {#open-props}
+
+**Out of the box for colours.** open-props@1.7.23.
+
+Open Props is a CSS-custom-properties design system, but it does have a JS
+export: the root import resolves to a flat frozen object of about 1,830
+entries keyed by custom-property name (`'--gray-0'`, `'--indigo-7'`), values
+as strings. No DOM, no dependencies.
+
+Only the colour half is worth having here, so **prefer
+[`@radix-ui/colors`](#radix-colors)** if all you want is a palette — it is
+hex throughout, has documented step semantics, and ships separate dark
+scales. Open Props earns its place when a project already uses it and you
+want the same swatches on both sides.
+
+The colour tokens — 13 hues × 13 steps — are plain hex, so building a theme
+is pure key-picking. The step convention is roughly: 0–2 backgrounds, 3–5
+borders and muted, 6–9 solids, 10–12 deep text.
+
+```jsx
+import OP from 'open-props';
+
+const rem = (s) => Math.round(parseFloat(s) * 16); // '1.1rem' -> 18
+
+const theme = {
+  canvas: OP['--gray-0'],
+  panel: OP['--gray-1'],
+  background: OP['--gray-1'],
+  text: OP['--gray-9'],
+  dim: OP['--gray-6'],
+  border: OP['--gray-3'],
+  borderActive: OP['--indigo-7'],
+  accent: OP['--indigo-7'],
+  accentHover: OP['--indigo-8'],
+  accentText: '#ffffff',
+  hoverBackground: OP['--indigo-7'],
+  hoverText: '#ffffff',
+  surfaceHover: OP['--gray-2'],
+  track: OP['--gray-3'],
+  radius: parseInt(OP['--radius-2']),
+  radiusSmall: parseInt(OP['--radius-1']),
+  borderWidth: 1,
+  fontSize: rem(OP['--font-size-1']),
+  paddingX: 16,
+  paddingY: 6,
+};
+```
+
+- **The non-colour tokens do not map onto react-x11 style.** Sizes are `rem`
+  strings where react-x11 wants pixel numbers, easings are `cubic-bezier()`
+  strings where react-x11 takes named easings, and shadows reference
+  `var(--shadow-color)` and have no equivalent at all. Treat this as a colour
+  library that happens to carry other tokens; convert what you use and ignore
+  the animation and shadow tokens entirely.
+- Key names include the `--` prefix, so it is bracket access everywhere;
+  camelCase aliases exist too (`OP.gray0`).
+- Unlike Radix there are no separate dark scales — a dark theme is your own
+  key-picking (`--gray-12` canvas, `--gray-9` borders).
+
+## `tailwindcss/colors` {#tailwind-colors}
+
+**Adapter, ~3 lines — and the failure without it is silent.**
+tailwindcss@4.3.3.
+
+Tailwind-the-framework is a non-starter here: it emits CSS class utilities
+for a CSSOM, and react-x11's style channel is a validated object system. The
+_palette_ is a different story — 22 named scales × 11 steps, importable as
+plain JS from `tailwindcss/colors` without touching any of the CSS
+machinery, and it is the palette half your users already think in. The
+package has zero dependencies, so installing it purely for the colours costs
+about 770 KB unpacked and pulls in nothing else.
+
+Since v4 every value is an `oklch()` string. ntk's parser returns null for
+those, and a null colour paints **nothing** — no error, just an invisible
+widget. Convert at theme-build time:
+
+```jsx
+import colors from 'tailwindcss/colors';
+import { formatHex } from 'culori';
+
+// The whole adapter: one call per value.
+const hex = (c) => formatHex(c); // 'oklch(54.6% …)' -> '#155dfc'
+
+const theme = {
+  canvas: hex(colors.slate[50]),
+  panel: hex(colors.slate[100]),
+  background: hex(colors.slate[100]),
+  text: hex(colors.slate[900]),
+  dim: hex(colors.slate[500]),
+  border: hex(colors.slate[300]),
+  borderActive: hex(colors.blue[600]),
+  accent: hex(colors.blue[600]),
+  accentHover: hex(colors.blue[700]),
+  accentText: '#ffffff',
+  hoverBackground: hex(colors.blue[600]),
+  hoverText: '#ffffff',
+  surfaceHover: hex(colors.slate[200]),
+  track: hex(colors.slate[300]),
+  radius: 6,
+  radiusSmall: 4,
+  borderWidth: 1,
+  fontSize: 14,
+  paddingX: 16,
+  paddingY: 6,
+};
+```
+
+- **Do not pass the raw values through.** This is the sharpest edge on the
+  page; everything else here is smooth.
+- `formatHex` gamut-clips, but Tailwind's vivid 500s are chosen to survive
+  sRGB conversion, so in practice the clipped hex closely matches what
+  Tailwind v3 shipped.
+- Installing a whole CSS framework for a data file is aesthetically odd; if
+  that grates, `@radix-ui/colors` does the same job natively in hex. Zero
+  dependencies means it is only odd, not costly.
+
+## `daltonize` {#daltonize}
+
+**Adapter, ~4 lines. Niche — reach for it only if you are shipping an
+explicit colour-vision variant; for everyday contrast work
+[colord](#colord)'s `a11y` plugin is the tool.** daltonize@1.0.2.
+
+A single-function package: `daltonize([r, g, b], type)` where `type` is
+`'protanope' | 'deuteranope' | 'tritanope'`, returning a corrected triplet.
+It implements the classic LMS-space daltonization algorithm — simulate the
+deficiency, take the error against the original, redistribute it into
+channels the viewer _can_ see. Pure arithmetic, 9 KB, zero dependencies;
+despite the README's image-oriented pitch, nothing in it touches a canvas.
+
+Themes are small closed sets of colours, which makes whole-theme
+daltonization trivial: map the correction over every value and offer it as an
+accessibility variant next to light and dark. The adapter is only hex ↔
+triplet plumbing.
+
+```jsx
+import { daltonize } from 'daltonize';
+import { colord } from 'colord';
+
+const toRgb = (hex) => {
+  const { r, g, b } = colord(hex).toRgb();
+  return [r, g, b];
+};
+const toHex = (rgb) => colord({ r: rgb[0], g: rgb[1], b: rgb[2] }).toHex();
+
+/** Colourblind-corrected variant of any react-x11 theme. */
+function daltonizeTheme(theme, type = 'deuteranope') {
+  return Object.fromEntries(
+    Object.entries(theme).map(([k, v]) => [
+      k,
+      typeof v === 'string' && v.startsWith('#')
+        ? toHex(daltonize(toRgb(v), type))
+        : v, // radius, fontSize, … pass through
+    ]),
+  );
+}
+
+const accessible = daltonizeTheme(githubLight);
+// '#1f883d' (GitHub green) -> '#1f7206' for deuteranopia
+```
+
+- **Correction, not validation.** It shifts colours so information carried by
+  problem hues survives; it does not check or fix contrast. A low-contrast
+  theme stays low-contrast. Pair it with colord's `a11y` plugin or culori's
+  `wcagContrast`.
+- Only the three dichromatic extremes are modelled — anomalous trichromacy,
+  which is the common mild case, is not. Corrections can look aggressive to a
+  mildly affected viewer, so offer it as an opt-in variant rather than a
+  default.
+- Handles opaque triplets only. Run it on the RGB part and reattach alpha
+  yourself if the theme uses `#rrggbbaa`.
+- The package is small and finished rather than maintained (last release 2023) and its `repository` field is a placeholder. Vendoring the ~40 lines
+  is a fair alternative to the dependency.

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -8,8 +8,12 @@
 // page deleted from docs/ disappears here too (the output tree is rebuilt
 // from scratch).
 //
-// react-x11's docs/ is flat: README.md (the index) plus one .md per topic,
-// with images in docs/img/. For each markdown file this script:
+// react-x11's docs/ is README.md (the index) plus one .md per topic, with
+// images in docs/img/. A topic that grew into a section keeps its pages in a
+// subdirectory (docs/ecosystem/), which becomes a Docusaurus category —
+// drop a `_category_.json` next to them to label it, and it is copied
+// through with the other non-markdown assets. For each markdown file this
+// script:
 //   - adds Docusaurus front matter (title from the first `# heading`,
 //     sidebar_position following the section order below, and a
 //     custom_edit_url pointing at the real source file in the repo, since
@@ -179,6 +183,22 @@ const ORDER = [
   'devtools.md',
   'click-to-component.md',
   'glx.md',
+  'ecosystem.md',
+  // docs/ecosystem/ — same order as the compatibility tables on the landing
+  // page. Matched by basename, and sorting happens per directory, so these
+  // never collide with the top-level names above.
+  'state.md',
+  'data-fetching.md',
+  'forms.md',
+  'icons.md',
+  'theming.md',
+  'animation.md',
+  'headless.md',
+  'layout.md',
+  'routing.md',
+  'i18n.md',
+  'testing.md',
+  'dev-tooling.md',
 ];
 
 syncFile('README.md', 'index.md', {
@@ -187,20 +207,36 @@ syncFile('README.md', 'index.md', {
   slug: '/reference',
 });
 
-const topicFiles = fs
-  .readdirSync(srcDir)
-  .filter((f) => f.endsWith('.md') && f !== 'README.md')
-  .sort((a, b) => {
-    const ia = ORDER.indexOf(a);
-    const ib = ORDER.indexOf(b);
-    return (
-      (ia === -1 ? ORDER.length : ia) - (ib === -1 ? ORDER.length : ib) ||
-      a.localeCompare(b)
-    );
+const byOrder = (a, b) => {
+  const ia = ORDER.indexOf(a);
+  const ib = ORDER.indexOf(b);
+  return (
+    (ia === -1 ? ORDER.length : ia) - (ib === -1 ? ORDER.length : ib) ||
+    a.localeCompare(b)
+  );
+};
+
+// Sync one directory's markdown, then recurse. sidebar_position restarts per
+// directory because Docusaurus only compares positions within one category.
+function syncDir(dir = '') {
+  const entries = fs.readdirSync(path.join(srcDir, dir), {
+    withFileTypes: true,
   });
-topicFiles.forEach((file, i) => {
-  syncFile(file, file, { sidebarPosition: i + 2 });
-});
+  const files = entries
+    .filter((e) => e.isFile() && e.name.endsWith('.md'))
+    .map((e) => e.name)
+    .filter((name) => !(dir === '' && name === 'README.md'))
+    .sort(byOrder);
+  files.forEach((name, i) => {
+    const rel = path.join(dir, name);
+    syncFile(rel, rel, { sidebarPosition: i + 2 });
+  });
+  return entries
+    .filter((e) => e.isDirectory())
+    .reduce((n, e) => n + syncDir(path.join(dir, e.name)), files.length);
+}
+
+const topicCount = syncDir();
 
 const assets = copyAssets();
 
@@ -214,6 +250,6 @@ fs.rmSync(imgOut, { recursive: true, force: true });
 fs.cpSync(imgSrc, imgOut, { recursive: true });
 
 console.log(
-  `sync-docs: wrote ${1 + topicFiles.length} reference pages ` +
+  `sync-docs: wrote ${1 + topicCount} reference pages ` +
     `(+ ${assets} assets) to ${path.relative(websiteDir, outDir)}`,
 );


### PR DESCRIPTION
An ecosystem page: which npm packages work with react-x11, which do not, and
what the failure looks like when it is the wrong one. Plus the README and
NEXT_STEPS updates that go with it.

## The page

`docs/ecosystem.md` plus twelve per-category pages under `docs/ecosystem/`.
One rule decides every verdict — this renderer has no DOM, so anything
touching only React comes across, and anything reaching for `document`,
`window`, `HTMLElement` or a CSS string does not — and the page opens with
the 30-second test a reader can apply before installing anything.

Every verdict was established by running the library against a headless
react-x11 render, not by reading its README. That turned up things a survey
would have got wrong: `<Controller>` makes react-hook-form work today with no
adapter, `react-redux` needs a hard pin to v9, and `@tanstack/react-virtual`
works only through `virtual-core` because the React wrapper imports
`react-dom`.

![eco-page](https://github.com/user-attachments/assets/3b8356be-8020-4626-8a3a-78a5736440bf)

## The half worth having

Failures sort into four classes by how much time they waste — install,
render, first interaction, and silent — and each row carries the verbatim
error, so searching the string lands here instead of on a new issue.

Two are worth calling out. `styled-components` fails with `TypeError:
styled.div is not a function`, which names neither this library nor the DOM
and sends people hunting for a version mismatch; the real cause is CJS
interop under plain Node ESM. And `swr` never errors at all — it fetches,
caches and dedupes correctly, and simply never revalidates on focus, because
`IS_SERVER` is computed at import before any config can override it.

![eco-negative](https://github.com/user-attachments/assets/c905e8a9-8fc7-4413-bdf1-caca2ebf0656)

Category pages carry the working examples. Icons are the fiddliest, because
ntk's `SvgView` ignores presentation attributes on the root `<svg>`, so
stroke icons need re-rooting onto a `<g>` — which is why the iconify pipeline
is the recommended route and the `*-react` icon packages cannot work at all.

![eco-icons](https://github.com/user-attachments/assets/ea1be4b8-5ec6-4cf5-bf00-736ccd87de9e)

## Site plumbing

`docs/ecosystem/` is the first subdirectory under `docs/`, and
`sync-docs.mjs` only walked a flat directory. It now recurses, restarts
`sidebar_position` per directory, and copies `_category_.json` through so the
subdirectory becomes a labelled sidebar category.

## README

A reader could previously finish the README without learning whether their
situation was in scope, and Wayland — the platform question everyone asks —
appeared nowhere in the repo. A new *Where this fits* section says what this
is good at and, more usefully, what it is not: three platforms, native
Wayland, reusing web components, video, and text entry outside Latin.

*Known issues* gains a third entry. Text entry is one codepoint per key
event, so AltGr levels, dead keys and Compose sequences do not work and input
methods are structurally absent. That is a larger limitation than either bug
already listed and no page said so. There is also a short Security note — X
has no client isolation and `$XAUTHORITY` is a bearer token — and the wire
paragraph now carries a real number from the checked-in bench baseline
instead of asking to be believed.

## NEXT_STEPS

Picks up the backlog now filed as issues, and adds sections on the 2.0.0 API
window, distribution, remote display, keyboard input and testing. Figures
that could not be checked against `scripts/bench/baseline.json` or source were
dropped rather than carried over, and pages that do not exist yet are
described as work rather than linked.

## Checks

`npm test` 250 passing, `npm run docs:build` clean, `npm run docs:test` 10
demos green and share links round-tripping, Prettier clean. Screenshots above
were rendered from this branch's build.

