### PR TITLE
feat!: createRoot takes options, and owns the connection it opened

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -39,24 +39,49 @@
 import { createRoot, render, unmountComponentAtNode, Select } from 'react-x11';
 ```
 
-### `await createRoot(container?)` → `{ app, render(element), unmount() }`
+### `await createRoot(options?)` → `{ app, render(element), unmount() }`
 
-The modern entry point. Without a `container` it connects to the X server
-named by `$DISPLAY` (the returned `app` is the [ntk](https://github.com/sidorares/ntk)
-App — one X connection). Pass an existing ntk App (or a mock) to render
-into it — that's how the hermetic tests drive the renderer against
-node-x11's in-process X server:
+The entry point. With no options it connects to the X server named by
+`$DISPLAY`; the returned `app` is the [ntk](https://github.com/sidorares/ntk)
+App, one X connection.
+
+**Every root without `app` opens its own connection and owns it**, so two
+roots are two independent trees, and `await root.unmount()` closes what it
+opened — without which the socket stays up and the process does not exit.
+A root given an `app` borrows it and never closes it: that connection
+belongs to whoever made it.
+
+| option                                                 |                                                         |
+| ------------------------------------------------------ | ------------------------------------------------------- |
+| `display`                                              | `':1'`, `'host:0.0'`, a socket path. Default `$DISPLAY` |
+| `app`                                                  | render into a connection you already have               |
+| `stream`                                               | an already-connected duplex stream                      |
+| `fontSource`                                           | pluggable system-font lookup — ntk's docs/fonts.md      |
+| `glxVisual`                                            | visual id for `getContext('opengl')`                    |
+| `onXError`                                             | X protocol errors nothing claimed. Default warns        |
+| `onUncaughtError` `onCaughtError` `onRecoverableError` | React's error channels; default log                     |
+| `onDisconnect(reason, err)`                            | the connection ended — `'closed'` or `'error'`          |
+
+`display`, `stream`, `fontSource`, `glxVisual` and `onXError` go straight
+to ntk's `createClient`. Anything else it understands, build the client
+yourself and pass it as `app` — which is also how the hermetic tests drive
+the renderer against node-x11's in-process X server:
 
 ```js
 import xserver from 'x11/lib/xserver/index.js';
-import { createClient } from 'ntk';
 
 const server = xserver.createServer({ width: 640, height: 480 });
 const [serverEnd, clientEnd] = xserver.createStreamPair();
 server.addClientStream(serverEnd);
-const app = await createClient({ stream: clientEnd });
-const root = await createRoot(app); // no $DISPLAY needed
+const root = await createRoot({ stream: clientEnd }); // no $DISPLAY needed
 ```
+
+`onDisconnect` fires when the connection ends without being asked to —
+server exit, ssh drop, kill — and not for one this root closed. It invites
+a reconnect loop, so: **a reconnect is not a reconnect.** Every window id,
+pixmap, glyph set and font is invalidated with the connection. Tear the
+root down and build a new one; nothing survives, and react-x11 promises
+nothing more than telling you it happened.
 
 ### `render(element, callback?, container?)`
 

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -440,19 +440,69 @@ if (process.env.REACT_X11_CLICK_TO_COMPONENT || process.env.REACT_X11_EDITOR) {
 const roots = new Map();
 let cachedNtkApp = null;
 
-async function connectApp() {
-  if (cachedNtkApp) return cachedNtkApp;
+/**
+ * Open a connection this process owns. The wrapper is here for one reason:
+ * to say what is wrong when there is no server, which is the first thing
+ * anyone hits and the least self-explanatory failure in the library.
+ */
+async function connect(options) {
   try {
-    cachedNtkApp = await createClient();
+    return await createClient(options);
   } catch (err) {
+    const display = options.display ?? process.env.DISPLAY ?? '<unset>';
     throw new Error(
       'react-x11: could not connect to the X server. Is an X server running ' +
-        `and DISPLAY set (DISPLAY=${process.env.DISPLAY || '<unset>'})? ` +
-        'Original error: ' +
+        `and DISPLAY set (DISPLAY=${display})? Original error: ` +
         err.message,
     );
   }
+}
+
+async function connectApp() {
+  if (cachedNtkApp) return cachedNtkApp;
+  cachedNtkApp = await connect({});
   return cachedNtkApp;
+}
+
+/** An ntk App, told apart from an options bag by what only an App has. */
+const isNtkApp = (v) =>
+  Boolean(v) && typeof v.createWindow === 'function' && typeof v.X === 'object';
+
+// What a root that opens its own connection forwards to ntk. `stream` is
+// how you reach a server that is not on the other end of $DISPLAY — an
+// in-process one, a tunnel — and is what the tests connect through.
+const CONNECT_OPTIONS = [
+  'display',
+  'stream',
+  'fontSource',
+  'glxVisual',
+  'onXError',
+];
+
+const DEFAULT_ERROR_HANDLERS = {
+  onUncaughtError: (error) => console.error('react-x11: uncaught error', error),
+  onCaughtError: (error) => console.error('react-x11: caught error', error),
+  onRecoverableError: (error) =>
+    console.error('react-x11: recoverable error', error),
+};
+
+/**
+ * The connection ended without us asking. `end` is the stream closing —
+ * server exit, ssh drop, kill. An `error` may be either a transport failure
+ * or an X protocol error ntk already reports through `onXError`; only the
+ * former ends the connection, and only it carries no `majorOpcode`.
+ */
+function watchConnection(app, onDisconnect, deliberate) {
+  let done = false;
+  const fire = (reason, err) => {
+    if (done || deliberate()) return;
+    done = true;
+    onDisconnect(reason, err);
+  };
+  app.X.on('end', () => fire('closed'));
+  app.X.on('error', (err) => {
+    if (err?.majorOpcode === undefined) fire('error', err);
+  });
 }
 
 function renderIntoContainer(element, container, callback) {
@@ -496,22 +546,73 @@ export function render(element, callback, container) {
 }
 
 /**
- * Modern entry point:
+ * The entry point:
  *
- *   const root = await createRoot();       // connects via DISPLAY
+ *   const root = await createRoot();                 // connects via $DISPLAY
+ *   const root = await createRoot({ display: ':1' });
+ *   const root = await createRoot({ app });          // a connection you have
  *   root.render(<App />);
+ *   await root.unmount();
  *
- * Pass an ntk App (or a mock) to render into an existing connection.
+ * Every root without `app` opens **its own** connection and owns it, so two
+ * roots are two independent trees; `unmount()` closes what it opened. A root
+ * given an `app` borrows it and never closes it — that connection belongs to
+ * whoever made it.
+ *
+ * `display`, `fontSource`, `glxVisual` and `onXError` go straight to ntk.
+ * Anything else ntk understands, build the client yourself and pass `app`.
  */
-export async function createRoot(container) {
-  const app = container ?? (await connectApp());
+export async function createRoot(options = {}) {
+  if (isNtkApp(options)) {
+    throw new Error(
+      'react-x11: createRoot takes an options object — pass the connection ' +
+        'as createRoot({ app }).',
+    );
+  }
+  const { app: borrowed, onDisconnect, ...rest } = options;
+  const owned = borrowed === undefined;
+  const app = owned
+    ? await connect(
+        Object.fromEntries(
+          CONNECT_OPTIONS.filter((k) => rest[k] !== undefined).map((k) => [
+            k,
+            rest[k],
+          ]),
+        ),
+      )
+    : borrowed;
+
+  const container = Renderer.createContainer(
+    app,
+    ConcurrentRoot,
+    null,
+    false,
+    null,
+    '',
+    rest.onUncaughtError ?? DEFAULT_ERROR_HANDLERS.onUncaughtError,
+    rest.onCaughtError ?? DEFAULT_ERROR_HANDLERS.onCaughtError,
+    rest.onRecoverableError ?? DEFAULT_ERROR_HANDLERS.onRecoverableError,
+    null,
+  );
+
+  let unmounted = false;
+  if (onDisconnect) watchConnection(app, onDisconnect, () => unmounted);
+
   return {
     app,
     render(element, callback) {
-      renderIntoContainer(element, app, callback);
+      Renderer.updateContainerSync(element, container, null, () => {
+        callback?.(Renderer.getPublicRootInstance(container), app);
+      });
+      Renderer.flushSyncWork();
     },
-    unmount() {
-      unmountComponentAtNode(app);
+    /** Unmounts, then closes the connection unless `app` was passed in. */
+    async unmount() {
+      if (unmounted) return;
+      unmounted = true;
+      Renderer.updateContainerSync(null, container, null, null);
+      Renderer.flushSyncWork();
+      if (owned) await app.close();
     },
   };
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,25 +17,65 @@ export * from './types/nodes.js';
 export * from './types/elements.js';
 export * from './types/components.js';
 
+/** What React reports alongside an error it caught. */
+export interface ErrorInfo {
+  componentStack?: string;
+}
+
+export interface RootOptions {
+  /** `':1'`, `'host:0.0'`, or a unix socket path. Defaults to `$DISPLAY`. */
+  display?: string;
+  /**
+   * Render into a connection you already have — tests, embedding, a client
+   * built with options this bag does not carry. A borrowed connection is
+   * never closed by {@link Root.unmount}.
+   */
+  app?: NtkApp;
+  /** An already-connected duplex stream, instead of dialling `$DISPLAY`. */
+  stream?: unknown;
+  /** Pluggable system-font lookup; see ntk's docs/fonts.md. */
+  fontSource?: unknown;
+  /** A visual id for `getContext('opengl')`, instead of querying for one. */
+  glxVisual?: unknown;
+  /** X protocol errors no request callback claimed. Default warns. */
+  onXError?: (err: Error) => void;
+  onUncaughtError?: (error: unknown, errorInfo: ErrorInfo) => void;
+  onCaughtError?: (error: unknown, errorInfo: ErrorInfo) => void;
+  onRecoverableError?: (error: unknown, errorInfo: ErrorInfo) => void;
+  /**
+   * The X connection ended without being asked to — server exit, ssh drop,
+   * kill. Not called for a connection this root closed itself.
+   *
+   * A reconnect is not a reconnect: every window id, pixmap, glyph set and
+   * font is invalidated with the connection. Tear the root down and build a
+   * new one; nothing survives.
+   */
+  onDisconnect?: (reason: 'closed' | 'error', err?: Error) => void;
+}
+
 /** A mounted tree, as returned by {@link createRoot}. */
 export interface Root {
   /** The ntk `App` this root renders through. */
   readonly app: NtkApp;
   render(element: ReactNode, callback?: () => void): void;
-  unmount(): void;
+  /** Unmounts, then closes the connection unless `app` was passed in. */
+  unmount(): Promise<void>;
 }
 
 /**
  * Connect to the X server and make a root:
  *
  * ```tsx
- * const root = await createRoot();   // connects via $DISPLAY
+ * const root = await createRoot();                 // connects via $DISPLAY
+ * const other = await createRoot({ display: ':1' });
  * root.render(<App />);
+ * await root.unmount();
  * ```
  *
- * Pass an ntk `App` to render into a connection you already have.
+ * Each root without `app` opens its own connection and owns it, so two
+ * roots are two independent trees.
  */
-export function createRoot(container?: NtkApp): Promise<Root>;
+export function createRoot(options?: RootOptions): Promise<Root>;
 
 /**
  * Legacy entry point. Without a container it connects to the X server and

--- a/test/create-root.test.js
+++ b/test/create-root.test.js
@@ -1,0 +1,174 @@
+// createRoot's contract: an options object, one connection per root, and a
+// connection the root closes only when it opened it (#114).
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import React from 'react';
+import xserver from 'x11/lib/xserver/index.js';
+import { StaticFontSource } from 'ntk';
+import { createRoot } from '../src/index.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+const win = (title) =>
+  h('window', { width: 60, height: 40, title }, h('box', { style: {} }));
+
+const require = createRequire(import.meta.url);
+const fontDir = join(
+  dirname(require.resolve('katex/package.json')),
+  'dist',
+  'fonts',
+);
+
+/** A stream onto node-x11's in-process X server, so a root can open a real
+ * connection of its own with no $DISPLAY. */
+function headlessStream() {
+  const server = xserver.createServer({ width: 320, height: 240 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const fontSource = new StaticFontSource();
+  fontSource.add(readFileSync(join(fontDir, 'KaTeX_Main-Regular.ttf')), {
+    family: 'Test Main',
+  });
+  fontSource.alias('sans-serif', 'Test Main');
+  return { stream: clientEnd, fontSource };
+}
+
+test('two roots are two trees, not one replacing the other', async () => {
+  // the memoised connection made both createRoot() calls resolve the same
+  // app, and `roots` was keyed by it — so the second render silently
+  // replaced the first root's tree
+  const app = createMockApp();
+  const a = await createRoot({ app });
+  const b = await createRoot({ app });
+  a.render(win('a'));
+  b.render(win('b'));
+  await tick();
+
+  assert.strictEqual(app.windows.length, 2, 'both trees mounted');
+  await a.unmount();
+  await b.unmount();
+});
+
+test('a root that opened the connection closes it on unmount', async () => {
+  const root = await createRoot(headlessStream());
+  root.render(win('owned'));
+  await tick();
+  assert.notStrictEqual(root.app.X._closing, true, 'up while rendering');
+
+  await root.unmount();
+  assert.strictEqual(
+    root.app.X._closing,
+    true,
+    'the socket it opened is closed, so the process can exit',
+  );
+});
+
+test('a borrowed connection is never closed', async () => {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(win('borrowed'));
+  await tick();
+  await root.unmount();
+  assert.strictEqual(app.closed, 0, 'not ours to close');
+});
+
+test('unmount is idempotent', async () => {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(win('x'));
+  await tick();
+  await root.unmount();
+  await root.unmount();
+  assert.strictEqual(app.closed, 0);
+});
+
+test('the old createRoot(app) signature throws, naming the new one', async () => {
+  const app = createMockApp();
+  await assert.rejects(() => createRoot(app), /createRoot\(\{ app \}\)/);
+});
+
+test('createRoot exposes the connection it rendered through', async () => {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  assert.strictEqual(root.app, app);
+  await root.unmount();
+});
+
+test('onDisconnect reports the connection ending, once', async () => {
+  const app = createMockApp();
+  const seen = [];
+  const root = await createRoot({
+    app,
+    onDisconnect: (reason, err) => seen.push([reason, err?.message]),
+  });
+  root.render(win('x'));
+  await tick();
+
+  app.X.emit('end');
+  assert.deepStrictEqual(seen, [['closed', undefined]], 'server exit');
+
+  app.X.emit('end');
+  assert.strictEqual(seen.length, 1, 'a dropped connection does not end twice');
+
+  await root.unmount();
+});
+
+test('onDisconnect tells a transport failure from an X protocol error', async () => {
+  const app = createMockApp();
+  const seen = [];
+  const root = await createRoot({
+    app,
+    onDisconnect: (reason, err) => seen.push([reason, err?.message]),
+  });
+  root.render(win('x'));
+  await tick();
+
+  // an X protocol error carries an opcode, and is ntk's onXError business
+  const protocolError = new Error('Bad window');
+  protocolError.majorOpcode = 2;
+  protocolError.seq = 9;
+  app.X.emit('error', protocolError);
+  assert.deepStrictEqual(seen, [], 'the connection is still up');
+
+  const transport = new Error('ECONNRESET');
+  transport.code = 'ECONNRESET';
+  app.X.emit('error', transport);
+  assert.deepStrictEqual(seen, [['error', 'ECONNRESET']]);
+
+  await root.unmount();
+});
+
+test('unmounting is not a disconnect', async () => {
+  const app = createMockApp();
+  const seen = [];
+  const root = await createRoot({ app, onDisconnect: (r) => seen.push(r) });
+  root.render(win('x'));
+  await tick();
+  await root.unmount();
+  app.X.emit('end');
+  assert.deepStrictEqual(seen, [], 'we closed it, so nothing was lost');
+});
+
+test('error handlers belong to the root, not the module', async () => {
+  const app = createMockApp();
+  const caught = [];
+  const root = await createRoot({
+    app,
+    onUncaughtError: (error) => caught.push(error.message),
+  });
+  const Boom = () => {
+    throw new Error('boom');
+  };
+  try {
+    root.render(h('window', { width: 10, height: 10 }, h(Boom)));
+  } catch {
+    // React rethrows after reporting; the report is what is under test
+  }
+  assert.deepStrictEqual(caught, ['boom']);
+  await root.unmount();
+});

--- a/test/helpers/mock-app.js
+++ b/test/helpers/mock-app.js
@@ -7,6 +7,8 @@ export { React };
 // A minimal stand-in for an ntk application object, so the renderer can be
 // exercised without a running X server.
 export function createMockApp() {
+  // enough of an emitter for the connection watch in createRoot
+  const listeners = {};
   const app = {
     X: {
       display: { screen: [{ root: 1 }] },
@@ -17,8 +19,19 @@ export function createMockApp() {
       ConfigureWindow(id, options) {
         app.configureCalls.push([id, options]);
       },
+      on(event, fn) {
+        (listeners[event] ??= []).push(fn);
+      },
+      emit(event, ...args) {
+        for (const fn of listeners[event] ?? []) fn(...args);
+      },
     },
     configureCalls: [],
+    closed: 0,
+    close() {
+      app.closed++;
+      return Promise.resolve();
+    },
     windows: [],
     createWindow(attributes) {
       const handlers = {};

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -357,7 +357,18 @@ async function main() {
   root.render(<Elements />);
   root.render(<Widgets />, () => {});
   void root.app.X;
-  root.unmount();
+  await root.unmount();
+
+  // the option bag, and a root that borrows a connection rather than owning
+  const other = await createRoot({
+    display: ':1',
+    onXError: (err) => void err.message,
+    onUncaughtError: (error, info) => void [error, info.componentStack],
+    onDisconnect: (reason, err) => void [reason, err?.message],
+  });
+  await other.unmount();
+  const borrowing = await createRoot({ app: root.app });
+  await borrowing.unmount();
 
   await render(<Scene />);
   render(<RawGl />, undefined, root.app);

--- a/website/scripts/check-bundle.mjs
+++ b/website/scripts/check-bundle.mjs
@@ -84,7 +84,7 @@ const [clientEnd, serverEnd] = rx.createStreamPair();
 server.addClientStream(serverEnd);
 
 const app = await rx.ntk.createClient({ stream: clientEnd });
-const root = await rx.reactX11.createRoot(app);
+const root = await rx.reactX11.createRoot({ app });
 const React = rx.React;
 
 function Demo() {

--- a/website/scripts/check-demos.mjs
+++ b/website/scripts/check-demos.mjs
@@ -258,7 +258,10 @@ async function runDemo(demo) {
     timers.timeouts.forEach(clearTimeout);
     for (const root of roots) {
       try {
-        root.unmount();
+        // async since #114: the tree comes down synchronously, the socket
+        // closes after. Handle the promise — an unhandled rejection here
+        // would be reported as a demo failure by the uncaught handler above
+        await root.unmount();
       } catch {
         /* already gone */
       }

--- a/website/static/demo/runner/index.html
+++ b/website/static/demo/runner/index.html
@@ -121,11 +121,11 @@ function setupGlx(srv) {
 
 // --- running one edit ------------------------------------------------------
 
-// The X connection and the server outlive a single Run: react-x11 caches
-// its ntk App at module scope, so tearing the server down between runs
-// would leave the next `await createRoot()` holding a dead socket. Instead
-// the previous tree is unmounted — which destroys its X windows through the
-// same path a real app's shutdown takes.
+// The server outlives a single Run; the connection does not. Every
+// `createRoot()` dials DISPLAY afresh through the 'demo' protocol above and
+// owns what it opened, so unmounting the previous tree destroys its X
+// windows *and* closes its stream — the same path a real app's shutdown
+// takes. The server keeps running and hands the next Run a new one.
 const mounted = new Set();
 let timers = { intervals: [], timeouts: [] };
 
@@ -168,7 +168,11 @@ function teardown() {
   timers.timeouts.forEach(clearTimeout);
   timers = { intervals: [], timeouts: [] };
   for (const root of mounted) {
-    try { root.unmount(); } catch { /* already gone */ }
+    // unmount() brings the tree down synchronously and closes the socket
+    // after; the promise is not awaited here because teardown must stay
+    // synchronous, but it has to be handled or a dead connection becomes an
+    // unhandled rejection in the middle of the next Run
+    try { root.unmount()?.catch(() => {}); } catch { /* already gone */ }
   }
   mounted.clear();
 }


### PR DESCRIPTION
Refs #114 — the API half. The legacy-entry-point retirement is deliberately not here; see below.

## What was wrong

`createRoot(container?)` took an optional ntk App and nothing else, and the connection came from a module-level memoised `connectApp` calling ntk's `createClient` with no arguments. Three consequences:

- **No connection options reachable.** No display other than `$DISPLAY`, no `fontSource` — which is why #86 has no user-side workaround — no `glxVisual`, no `onXError`, so X protocol errors fell back to ntk's `console.warn`.
- **Two roots silently became one.** Both `createRoot()` calls resolved the same memoised app, and `roots` was keyed by the container, so the second root's `render` replaced the first root's tree with no warning.
- **`unmount` closed nothing.** The socket stayed open and the process did not exit.

## What it is now

```js
const root = await createRoot();                    // $DISPLAY
const other = await createRoot({ display: ':1' });  // its own connection
const embedded = await createRoot({ app });         // borrows yours
await root.unmount();                               // closes what it opened
```

`display`, `stream`, `fontSource`, `glxVisual` and `onXError` go through to ntk; `onUncaughtError`/`onCaughtError`/`onRecoverableError` go to React; `onDisconnect(reason, err)` reports the connection ending underneath you. Each root without `app` opens its own connection and keeps its own fiber container, so two roots are two trees. A borrowed `app` is never closed — that connection belongs to whoever made it.

Two judgement calls worth flagging:

- **`stream` is not in the issue's option list.** It earns its place: it is how you reach a server that is not on the other end of `$DISPLAY`, and it is what lets the new tests open a *real owned* connection against node-x11's in-process server and assert the socket actually closes. Without it the owning path is untestable headlessly.
- **`onDisconnect` distinguishes transport failure from X protocol error by the absence of a `majorOpcode`.** node-x11 emits both as `error` on the client; only the transport one ends the connection, and the protocol one is already ntk's `onXError` business. The alternative — reporting every X error as a disconnect — would fire on benign races.

The reconnect trap is documented, not implemented: every window id, pixmap, glyph set and font dies with the connection, so the only honest answer is to tear the root down and build a new one. `docs/README.md` says so in those words.

## What is not here

Retiring the legacy `render(element, callback?, container?)` / `unmountComponentAtNode(container)` pair. That is in the issue as a "while in here", but it is ~330 call sites across 14 test files and 4 scripts — a diff that would bury the API change it is attached to. The pair still works unchanged; the migration is a separate PR.

## Test plan

- `npm test` — 260 pass, 10 new in `test/create-root.test.js`: two roots are two trees, an owned connection closes on unmount and a borrowed one does not, `unmount` is idempotent, `createRoot(app)` throws naming the new form, `onDisconnect` fires once on end, distinguishes transport from protocol errors, and stays quiet for our own unmount, and the error handlers are per-root.
- The owned-connection test connects for real through `{ stream }` to node-x11's in-process X server and asserts `X._closing` afterwards, so "closes what it opened" is checked against a live socket rather than a mock.
- `npm run lint`, `npm run typecheck` — clean. `src/index.d.ts` gains `RootOptions` and `test/types/api.tsx` exercises it, per AGENTS.md.
