### PR TITLE
fix: stop passing DevTools a config it throws away

### DIFF
--- a/docs/click-to-component.md
+++ b/docs/click-to-component.md
@@ -36,8 +36,10 @@ custom URI scheme.
 babel/jsx-source plugin, no build-time instrumentation:
 
 - every host node already carries a reference to the fiber that created it
-  (`node._reactFiber`, set in `createInstance` — the same reference
-  DevTools' `findFiberByHostInstance` uses);
+  (`node._reactFiber`, set in `createInstance`). It is this feature's own
+  back-reference, not a DevTools one: `findFiberByHostInstance` is gone
+  from react-reconciler 0.33, and click-to-component works with DevTools
+  absent;
 - React 19 captures a real `Error` at every JSX call site in development
   mode (`fiber._debugStack`) and tracks who rendered what
   (`fiber._debugOwner`) — no `__source`/`__self` babel transform needed;

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -25,7 +25,9 @@ What you get:
 - **props, hooks and state** when selecting a component;
 - **highlight-on-hover** — hovering an element in the tree tints its rect
   in the X11 window;
-- the Profiler tab.
+- the Profiler's commit list and flamegraph. **Not** its Timeline view,
+  which needs `injectProfilingHooks` — this reconciler build does not
+  expose it, so there is nothing to enable.
 
 `REACT_X11_DEVTOOLS_HOST` / `REACT_X11_DEVTOOLS_PORT` point the backend at
 a non-default standalone (e.g. devtools on another machine — handy when the
@@ -40,6 +42,13 @@ the renderer via `injectIntoDevTools`.
 
 Notes for maintainers:
 
+- **`injectIntoDevTools()` takes no arguments** in react-reconciler 0.33.
+  What it reports comes from the host config — `rendererPackageName`,
+  `rendererVersion`, `extraDevToolsConfig` — and an argument passed here is
+  ignored without a word, which is how react-x11 shipped for a while with
+  its renderer name and version quietly missing (#121). A test in
+  `test/smoke.test.js` asserts what reaches the hook, so the next
+  reconciler bump cannot repeat it.
 - react-devtools-core v7 requires `initialize()` before
   `connectToDevTools`, exposes its API on the **default export** under
   node ESM interop, and expects browser-ish globals (`self`, `window`) —

--- a/examples/hmr-refresh.js
+++ b/examples/hmr-refresh.js
@@ -21,12 +21,9 @@ import RefreshRuntime from 'react-refresh/runtime';
 RefreshRuntime.injectIntoGlobalHook(globalThis);
 
 const ReactX11 = await import('../src/index.js');
-ReactX11.Renderer.injectIntoDevTools({
-  bundleType: 1, // dev
-  version: '0.0.1', // display metadata only
-  rendererPackageName: 'react-x11',
-  findFiberByHostInstance: (instance) => instance._reactFiber,
-});
+// no argument: react-reconciler 0.33 takes none, and the renderer metadata
+// comes from the host config in src/Reconciler.js
+ReactX11.Renderer.injectIntoDevTools();
 
 export function performReactRefresh() {
   // null = nothing pending (no component re-registered with new code)

--- a/src/DevToolsIntegration.js
+++ b/src/DevToolsIntegration.js
@@ -2,10 +2,6 @@
 // the environment; requires the `react-devtools-core` and `ws` dev
 // dependencies. Start the standalone UI first (`npx react-devtools`), then
 // run the app: REACT_X11_DEVTOOLS=1 npm run examples:dashboard
-import { createRequire } from 'node:module';
-
-const require = createRequire(import.meta.url);
-
 let api = null;
 let connected = false;
 
@@ -48,12 +44,11 @@ export function connect(renderer) {
     port: Number(process.env.REACT_X11_DEVTOOLS_PORT) || 8097,
   });
 
-  renderer.injectIntoDevTools({
-    bundleType: 1,
-    version: require('../package.json').version,
-    rendererPackageName: 'react-x11',
-    findFiberByHostInstance: (instance) => instance._reactFiber,
-  });
+  // No argument: react-reconciler 0.33 takes none, and the object this used
+  // to pass was discarded in silence. The renderer's name and version now
+  // come from the host config, where Reconciler.js already sets them
+  // (`rendererPackageName`, `rendererVersion`).
+  renderer.injectIntoDevTools();
 
   watchForAgent();
 }

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -103,8 +103,18 @@ const HostConfig = {
   isPrimaryRenderer: true,
   warnsIfNotActing: false,
 
+  // What DevTools shows for this renderer. These are the whole story in
+  // react-reconciler 0.33: `injectIntoDevTools()` takes no arguments and
+  // reads them from here.
   rendererVersion: packageJson.version,
   rendererPackageName: packageJson.name,
+  // Surfaces as `internals.rendererConfig`, which is where a renderer puts
+  // things only its own DevTools integration understands — React Native's
+  // `getInspectorDataForViewTag` is the archetype. Nothing in the standalone
+  // DevTools reads it for a renderer like this one, so there is nothing
+  // honest to put here. In particular `findFiberByHostInstance` does not
+  // belong here: 0.33 dropped it, and DevTools 7 only ever tested it for
+  // *presence*, to tell a fiber renderer from the pre-fiber kind.
   extraDevToolsConfig: null,
 
   scheduleTimeout: setTimeout,

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -4410,3 +4410,46 @@ test('menu: PageDown/PageUp land on a selectable row, never a separator', async 
 
   ReactX11.unmountComponentAtNode(app);
 });
+
+test('injectIntoDevTools registers the renderer metadata from the host config', async () => {
+  // react-reconciler 0.33 dropped injectIntoDevTools' parameter; the config
+  // that used to be passed there was silently discarded, taking the
+  // renderer's name and version with it (#121). What the hook receives is
+  // the only observable, so assert on that rather than on the call.
+  const { Renderer } = await import('../src/index.js');
+  const { readFileSync } = await import('node:fs');
+  const pkg = JSON.parse(
+    readFileSync(new URL('../package.json', import.meta.url), 'utf8'),
+  );
+
+  const injected = [];
+  const previous = global.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  global.__REACT_DEVTOOLS_GLOBAL_HOOK__ = {
+    supportsFiber: true,
+    inject: (internals) => {
+      injected.push(internals);
+      return 1;
+    },
+  };
+  try {
+    Renderer.injectIntoDevTools();
+  } finally {
+    if (previous === undefined) delete global.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+    else global.__REACT_DEVTOOLS_GLOBAL_HOOK__ = previous;
+  }
+
+  assert.strictEqual(injected.length, 1, 'the hook was injected into');
+  const internals = injected[0];
+  assert.strictEqual(internals.rendererPackageName, pkg.name);
+  assert.strictEqual(internals.version, pkg.version);
+  assert.strictEqual(
+    typeof internals.currentDispatcherRef,
+    'object',
+    'the field DevTools 7 actually keys off to pick the fiber renderer',
+  );
+  assert.strictEqual(
+    internals.rendererConfig,
+    undefined,
+    'extraDevToolsConfig is null, so no rendererConfig is advertised',
+  );
+});


### PR DESCRIPTION
Closes #121.

The diagnosis in the issue is right: react-reconciler 0.33 changed `injectIntoDevTools` to take no parameters, both call sites still passed a config object, and it was discarded in silence. Fixed at both.

## Where this diverges from the proposed fix, and why

The issue proposes moving the config to `extraDevToolsConfig` so `findFiberByHostInstance` is registered. Checking the installed versions, there is nothing left for it to register into:

- **`findFiberByHostInstance` appears zero times in react-reconciler 0.33.0.** It is not read from the host config, not read from `extraDevToolsConfig`, not placed on `internals`.
- **`extraDevToolsConfig` surfaces as `internals.rendererConfig`** — `react-reconciler.development.js:19621`. `grep -rn rendererConfig node_modules/react-devtools-core/dist/` returns nothing: the standalone DevTools never reads it. It is the React Native-shaped slot, for things only a renderer's own DevTools integration understands.
- **DevTools 7 only ever tested `findFiberByHostInstance` for presence**, at `backend.js:14591`, to pick the fiber attach path over the pre-fiber one — and it is an `||` with `renderer.currentDispatcherRef != null`, which the reconciler always sets. So even in 0.32 the function was doing nothing here beyond satisfying a typeof check.
- **`rendererPackageName` and `rendererVersion` were already correct**, as top-level host-config fields at `src/Reconciler.js:106-107`. Moving them into `extraDevToolsConfig` would have *removed* them from where the reconciler reads them.

So the real loss from the 0.33 bump was the renderer's name and version, and those are fixed by deleting the ignored argument and letting the host config do its job. `extraDevToolsConfig` stays `null` with a comment explaining what belongs there and why nothing does, rather than an object that looks like it works.

## Docs

Both overclaims are corrected rather than softened:

- `click-to-component.md` said `node._reactFiber` is "the same reference DevTools' `findFiberByHostInstance` uses". It is the feature's own back-reference, and click-to-component works with DevTools absent entirely.
- `devtools.md` listed "the Profiler tab" flatly. The commit list and flamegraph work; the Timeline view needs `injectProfilingHooks`, which appears **zero** times in this reconciler build — verified, not inferred.

A maintainer note now records that `injectIntoDevTools()` takes no arguments and ignores one without complaint, since that is precisely how this regressed unnoticed.

## Test plan

- `npm test` — 251 pass, one new in `test/smoke.test.js`. It installs a fake `__REACT_DEVTOOLS_GLOBAL_HOOK__`, calls `Renderer.injectIntoDevTools()`, and asserts on what reaches `hook.inject`: the package name, the version, a `currentDispatcherRef`, and no `rendererConfig`. The hook argument is the only observable this bug ever had — nothing looked at it, which is why the regression survived a version bump — so that is what the guard watches.
- `npm run lint`, `npm run typecheck` — clean. Removing the ignored argument also retired the only `createRequire` in `DevToolsIntegration.js`.

No screenshots: nothing here changes what is painted.
