### PR TITLE
feat: window states, undecorated windows, and a hidden pointer

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -88,6 +88,10 @@ A real X11 window; the flex, paint and event root for its subtree.
 | `onResize(ev)`              | ConfigureNotify — the tree reflows automatically                     |
 | `onExpose(ev)`              | after a repaint was required                                         |
 | `onCloseRequest(ev)`        | WM close button (opts into `WM_DELETE_WINDOW`)                       |
+| `states`                    | EWMH `_NET_WM_STATE` — controlled, see below                         |
+| `fullscreen`, `alwaysOnTop` | boolean sugar for two of those states                                |
+| `decorations`               | `false` asks the WM for no titlebar or border                        |
+| `onStatesChange(states)`    | what the window manager actually did                                 |
 | `theme`                     | palette that `$token` style values resolve against, for this subtree |
 
 Windows may be nested inside other windows (real X11 child windows).
@@ -126,7 +130,7 @@ are free, so no `sizeHints` object is needed.
 | size hints    | `minWidth`, `minHeight`, `maxWidth`, `maxHeight`, `widthInc`, `heightInc`, `baseWidth`, `baseHeight`, `minAspect`, `maxAspect`, `gravity` |
 | `wmClass`     | `'instance'`, `['instance', 'Class']` or `{instance, class}`                                                                              |
 | `windowType`  | `'dialog'`, `'utility'`, `'tooltip'`… or an array of fallbacks                                                                            |
-| `alwaysOnTop` | keep above normal windows                                                                                                                 |
+| `decorations` | `false` asks for no titlebar or border                                                                                                    |
 
 ```jsx
 <window width={400} height={300} resizable={false} windowType="dialog" />
@@ -137,8 +141,61 @@ On a `<window>` these names are the window's, not yoga's: `width`/`height`
 are the real geometry the user can drag, and `minWidth`/`maxHeight` are what
 the WM enforces. A window's _contents_ are laid out by its `style`.
 
-`alwaysOnTop` uses EWMH `_NET_WM_STATE_ABOVE`, falling back to Apple-WM
-window levels on XQuartz, where quartz-wm does not support that state.
+`decorations={false}` writes `_MOTIF_WM_HINTS` — honoured by Mutter, KWin,
+Xfwm, Openbox and i3. A window manager that ignores it simply decorates the
+window; there is no way to force the matter.
+
+### Window state
+
+`states` is EWMH `_NET_WM_STATE`: `modal`, `sticky`, `maximized` (or
+`maximized_vert`/`maximized_horz` individually), `shaded`, `skip_taskbar`,
+`skip_pager`, `hidden`, `fullscreen`, `above`, `below`, `demands_attention`,
+`focused`. `fullscreen` and `alwaysOnTop` are boolean sugar for the two
+everyone reaches for — `fullscreen` and `above` — and they union with
+`states` rather than competing with it.
+
+```jsx
+<window
+  states={['skip_taskbar']}
+  fullscreen={isFullscreen}
+  onStatesChange={(states) => setFullscreen(states.includes('fullscreen'))}
+/>
+```
+
+**These are controlled props, and the reason is not React convention.** On X
+the window manager changes state behind the app's back constantly: the user
+hits maximize, a global hotkey leaves fullscreen, a tiling WM has its own
+opinion. react-x11 therefore diffs `states` against the _previous props_,
+never against what the window currently has — so a prop is re-sent only when
+the app changes its mind, and a WM that disagreed is not fought on the next
+commit. `onStatesChange` is the other half: it reports what the WM actually
+did, and subscribing to it is what makes react-x11 watch the property, so a
+window without a handler costs nothing.
+
+States are applied **before the window is mapped**, which is what EWMH 7.7
+requires and the only way to open already fullscreen instead of flashing at
+the normal size first.
+
+`alwaysOnTop` falls back to Apple-WM window levels on XQuartz, where
+quartz-wm does not support `_NET_WM_STATE_ABOVE`.
+
+### Kiosk
+
+There is no `kiosk` prop, because it is not one thing — it is a window with
+no decoration, no taskbar entry, nothing above it, and no pointer:
+
+```jsx
+<window
+  fullscreen
+  decorations={false}
+  states={['above', 'skip_taskbar', 'skip_pager']}
+  style={{ cursor: 'none', flexGrow: 1 }}
+/>
+```
+
+`cursor: 'none'` hides the pointer outright (ntk ≥ 4.2.0). It is not the
+same as leaving `cursor` unset, which inherits whatever the root window's
+cursor is — see [styling.md](styling.md).
 
 ## `<popup>`
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -174,7 +174,13 @@ a window manager is free to refuse.
 
 ## Cursors
 
-The `cursor` prop (`'pointer'`, `'text'`, `'wait'`, `'move'`,
+The `cursor` style property (`'pointer'`, `'text'`, `'wait'`, `'move'`,
 `'crosshair'`, `'ew-resize'`, `'ns-resize'`, `'grab'`, `'not-allowed'`, …)
 applies the deepest hovered node's cursor to the window, via ntk's cursor
 cache over the standard X cursor font.
+
+`cursor: 'none'` hides the pointer (ntk ≥ 4.2.0) — the kiosk case. It is
+the one name that is not a glyph in that font, so ntk builds it from an
+empty 1×1 mask. Note it is **not** the same as setting no cursor at all:
+with none of a node's ancestors naming one, the window inherits the root
+window's cursor and the pointer stays visible.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^4.0.0",
+        "ntk": "^4.2.0",
         "react-reconciler": "^0.33.0"
       },
       "devDependencies": {
@@ -3457,15 +3457,6 @@
         "katex": "cli.js"
       }
     },
-    "node_modules/keysym": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/keysym/-/keysym-0.0.6.tgz",
-      "integrity": "sha512-3eRCY4N8H4GjocCRJ/WlbCJuoCuEPApkta8VIhuj9nTW50tcQyDCjz1gyzUjYSJqrPcKfh/NlUxxXYdGk4BK3g==",
-      "license": "MIT/X11",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3685,9 +3676,9 @@
       }
     },
     "node_modules/ntk": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-4.0.0.tgz",
-      "integrity": "sha512-hQj1H+ONAOhcS4ld81Fvgm0wAJNioJuGwdvNAZYKgqnTKOMkam/vuP6g47ECmK9lryalFZUWVdYN/kr5bioXqQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-4.2.0.tgz",
+      "integrity": "sha512-eEyMGldEierK/dTTV+Atf2ALkmvWbJWtHzhjWRTEbBSgp2DEikvohSnZ1FKzuCdYknFfMYZmPblvcwOKUx9ZEA==",
       "license": "MIT",
       "dependencies": {
         "bidi-js": "^1.0.3",
@@ -3700,13 +3691,12 @@
         "htmlparser2": "^12.0.0",
         "jpeg-js": "^0.4.4",
         "katex": "^0.18.1",
-        "keysym": "0.0.6",
         "linebreak": "^1.1.0",
         "marked": "^18.0.7",
         "parse-color": "^1.0.0",
         "pngjs": "^7.0.0",
         "postcss": "^8.5.23",
-        "x11": "^3.3.0",
+        "x11": "^3.4.0",
         "yoga-layout": "^3.2.1"
       },
       "engines": {
@@ -4994,9 +4984,9 @@
       }
     },
     "node_modules/x11": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/x11/-/x11-3.3.0.tgz",
-      "integrity": "sha512-9qlNgMV50wUjviS4CzRqMpmIpftROjhSN5/a+UsWatEHnXKmOmX0E4exO8iTk647u47h6q3m8NKd+uMt+VwyXQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/x11/-/x11-3.5.0.tgz",
+      "integrity": "sha512-1Eo8mBRPDZNbz/dWdZJL+5kF9+plIc+fQYXSgIrfD5EUj6SfOmYPkdS3ydds+2KRPHmeE0+p/Ka18GumzVreeA==",
       "engines": {
         "node": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^4.0.0",
+    "ntk": "^4.2.0",
     "react-reconciler": "^0.33.0"
   },
   "peerDependencies": {

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -334,6 +334,52 @@ export const WINDOW_HINT_PROPS = [
   'maxAspect',
   'gravity',
 ];
+/**
+ * The `_NET_WM_STATE` names these props ask for. `states` is the general
+ * mechanism; `fullscreen` and `alwaysOnTop` are sugar for the two everyone
+ * reaches for, and they union rather than compete with `states`.
+ */
+export function windowStates(props) {
+  const states = new Set(props.states ?? []);
+  if (props.fullscreen) states.add('fullscreen');
+  if (props.alwaysOnTop) states.add('above');
+  return states;
+}
+
+/**
+ * One state per message. EWMH gives a `_NET_WM_STATE` ClientMessage two
+ * state slots — which is what `'maximized'` uses, expanding to the
+ * vert/horz pair — so anything longer has to be several messages, and
+ * splitting by name is the only chunking that cannot land a pair across a
+ * boundary. These are rare, deliberate calls; the round trips do not matter.
+ */
+function applyWindowStates(wnd, names, action) {
+  if (typeof wnd?.setWmState !== 'function') return;
+  for (const name of names) {
+    // an unsupported state resolves false rather than throwing; a window
+    // that went away mid-flight is not worth an unhandled rejection
+    Promise.resolve(wnd.setWmState(name, action)).catch(() => {});
+  }
+}
+
+// _MOTIF_WM_HINTS: flags, functions, decorations, input_mode, status.
+// flags = 2 is MWM_HINTS_DECORATIONS, i.e. "only the decorations field
+// here means anything". The property's type atom is the property's own
+// name, not CARDINAL — the one thing that is easy to get wrong, and a WM
+// that reads the type will ignore the hint if it is.
+const MOTIF_HINTS = '_MOTIF_WM_HINTS';
+const MOTIF_DECORATIONS = (on) => [2, 0, on ? 1 : 0, 0, 0];
+
+function applyDecorations(wnd, on) {
+  if (typeof wnd?.setProperty !== 'function') return;
+  Promise.resolve(
+    wnd.setProperty(MOTIF_HINTS, MOTIF_DECORATIONS(on), {
+      type: MOTIF_HINTS,
+      format: 32,
+    }),
+  ).catch(() => {});
+}
+
 const WINDOW_SEMANTIC_NAMES = new Set([
   'width',
   'height',
@@ -3053,6 +3099,14 @@ export class WindowNode extends Node {
     this._restackWindowChildren();
     // <glarea>s mounted before the window existed own a child X window too
     this._realizeGlAreas(this);
+    // Before the map, deliberately. EWMH 7.7 gives an unmapped window a
+    // different mechanism — it *declares* its initial state by writing the
+    // property, where a mapped one has to *ask* the window manager — and
+    // declaring is the only way to open already fullscreen rather than
+    // flashing at the normal size first. Same for the Motif hint: a WM
+    // reads decorations when it frames the window, which is at map time.
+    if (this.props.decorations === false) applyDecorations(wnd, false);
+    applyWindowStates(wnd, [...windowStates(this.props)], 'add');
     wnd.map?.();
     // ask before anything can be anchored to it, so the first popup is
     // placed as well as the second
@@ -3127,8 +3181,27 @@ export class WindowNode extends Node {
     if (!shallowEqual(next.windowType, prev.windowType) && next.windowType) {
       wnd.setWindowType?.(next.windowType);
     }
-    if (Boolean(next.alwaysOnTop) !== Boolean(prev.alwaysOnTop)) {
-      wnd.setAlwaysOnTop?.(Boolean(next.alwaysOnTop));
+    // Diffed against the *previous props*, never against what the window
+    // manager currently has. That is what makes these controlled: on X the
+    // WM changes state behind the app's back all the time — the user hits
+    // maximize, a hotkey leaves fullscreen — and a prop re-asserted every
+    // commit would fight it. React only hears about reality through
+    // `onStatesChange`, and only re-asks when the app itself changes its
+    // mind.
+    const before = windowStates(prev);
+    const now = windowStates(next);
+    applyWindowStates(
+      wnd,
+      [...now].filter((s) => !before.has(s)),
+      'add',
+    );
+    applyWindowStates(
+      wnd,
+      [...before].filter((s) => !now.has(s)),
+      'remove',
+    );
+    if (next.decorations !== prev.decorations) {
+      applyDecorations(wnd, next.decorations !== false);
     }
   }
 
@@ -3164,6 +3237,21 @@ export class WindowNode extends Node {
     wnd.on('expose', (ev) => {
       this.props.onExpose?.(ev);
     });
+    // What the window manager actually did, which is the other half of the
+    // controlled pair — the props say what to ask for, this says what is
+    // true. Subscribing is what makes ntk select PropertyChange and watch
+    // `_NET_WM_STATE`, so it is opt-in: a window with no handler pays
+    // nothing. Read at realize time like onCloseRequest, since the
+    // subscription is a property of the X window, not of a render.
+    if (this.props.onStatesChange && typeof wnd.getWmStates === 'function') {
+      wnd.on('statechange', (states) => {
+        // a WM state change is something the user did to the window, so it
+        // carries the same priority a click would
+        runWithPriority(DiscreteEventPriority, () => {
+          this.props.onStatesChange?.(states);
+        });
+      });
+    }
     // WM close button: with an onCloseRequest prop the window opts into the
     // WM_DELETE_WINDOW protocol and the handler decides what happens
     // (unmount, hide, quit). Without it the WM default stands (the server

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -101,13 +101,60 @@ export interface WindowProps
   wmClass?: string | [string, string] | { instance: string; class?: string };
   /** EWMH `_NET_WM_WINDOW_TYPE`, or a list of fallbacks. */
   windowType?: WindowType | WindowType[];
+  /**
+   * EWMH `_NET_WM_STATE`. **Controlled**: this is what the window is asked
+   * to be, and {@link WindowProps.onStatesChange} is what it actually is —
+   * on X the window manager changes state behind the app's back, so the two
+   * diverge and react-x11 does not force reality back to the prop.
+   *
+   * Applied before the window is mapped, which is the only way to open
+   * already fullscreen rather than flashing at the normal size first.
+   */
+  states?: WindowState[];
+  /** Sugar for `states={['fullscreen']}`; they union. */
+  fullscreen?: boolean;
+  /** Sugar for `states={['above']}`; they union. */
   alwaysOnTop?: boolean;
+  /**
+   * `false` asks for no titlebar or border, via `_MOTIF_WM_HINTS`. Honoured
+   * by Mutter, KWin, Xfwm, Openbox and i3; a WM that ignores the hint
+   * simply decorates the window.
+   */
+  decorations?: boolean;
   /** ConfigureNotify — the tree reflows on its own. */
   onResize?: (ev: SyntheticEvent<NtkWindow>) => void;
   onExpose?: (ev: SyntheticEvent<NtkWindow>) => void;
+  /**
+   * The states the window manager now has on the window. Subscribing is
+   * what makes react-x11 watch `_NET_WM_STATE`, so a window with no handler
+   * costs nothing.
+   */
+  onStatesChange?: (states: WindowState[]) => void;
   /** The WM close button; opts the window into `WM_DELETE_WINDOW`. */
   onCloseRequest?: (ev: SyntheticEvent<NtkWindow>) => void;
 }
+
+/**
+ * `_NET_WM_STATE` names, lower-cased without the atom prefix. `'maximized'`
+ * is the one that is not an atom: EWMH maximizes an axis at a time, and it
+ * expands to the vert/horz pair.
+ */
+export type WindowState =
+  | 'modal'
+  | 'sticky'
+  | 'maximized'
+  | 'maximized_vert'
+  | 'maximized_horz'
+  | 'shaded'
+  | 'skip_taskbar'
+  | 'skip_pager'
+  | 'hidden'
+  | 'fullscreen'
+  | 'above'
+  | 'below'
+  | 'demands_attention'
+  | 'focused'
+  | (string & {});
 
 export interface PopupProps extends WindowProps {
   /**

--- a/test/helpers/mock-app.js
+++ b/test/helpers/mock-app.js
@@ -170,6 +170,19 @@ export function createMockApp() {
         setAlwaysOnTop(on) {
           wnd.calls.push(['setAlwaysOnTop', on]);
         },
+        // ntk >= 4.1: the general _NET_WM_STATE surface. Resolves to whether
+        // the WM advertises the state; the mock says yes.
+        setWmState(names, action = 'add') {
+          wnd.calls.push(['setWmState', names, action]);
+          return Promise.resolve(true);
+        },
+        getWmStates() {
+          return Promise.resolve(wnd.wmStates ?? []);
+        },
+        setProperty(name, value, options) {
+          wnd.calls.push(['setProperty', name, value, options]);
+          return Promise.resolve(wnd);
+        },
         setActions() {
           wnd.calls.push(['setActions']);
         },

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -723,19 +723,26 @@ test('window manager hints pass through at creation and on update', () => {
     ['setSizeHints', { minWidth: 300, maxWidth: 900, resizable: false }],
   ]);
 
-  // alwaysOnTop toggles both ways
+  // alwaysOnTop toggles both ways. It is sugar for the 'above' state now,
+  // so it goes out through the same _NET_WM_STATE path as everything else
   wnd.calls.length = 0;
   render({ alwaysOnTop: true });
   assert.ok(
-    wnd.calls.some(([name, on]) => name === 'setAlwaysOnTop' && on === true),
-    'setAlwaysOnTop(true) on enable',
+    wnd.calls.some(
+      ([name, s, action]) =>
+        name === 'setWmState' && s === 'above' && action === 'add',
+    ),
+    "alwaysOnTop adds 'above'",
   );
 
   wnd.calls.length = 0;
   render({ alwaysOnTop: false });
   assert.ok(
-    wnd.calls.some(([name, on]) => name === 'setAlwaysOnTop' && on === false),
-    'setAlwaysOnTop(false) on disable',
+    wnd.calls.some(
+      ([name, s, action]) =>
+        name === 'setWmState' && s === 'above' && action === 'remove',
+    ),
+    "dropping alwaysOnTop removes 'above'",
   );
 
   ReactX11.unmountComponentAtNode(app);
@@ -4452,4 +4459,167 @@ test('injectIntoDevTools registers the renderer metadata from the host config', 
     undefined,
     'extraDevToolsConfig is null, so no rendererConfig is advertised',
   );
+});
+
+// --- window states (#122) ---------------------------------------------------
+
+const stateCalls = (wnd) =>
+  wnd.calls.filter(([name]) => name === 'setWmState').map(([, s, a]) => [s, a]);
+
+test('window states are declared before the map, so a window can open fullscreen', async () => {
+  // EWMH 7.7: an unmapped window *declares* its state by writing the
+  // property; a mapped one has to *ask* the WM. Only the first can open
+  // already fullscreen instead of flashing at the normal size first.
+  const app = createMockApp();
+  ReactX11.render(
+    React.createElement('window', { width: 100, height: 80, fullscreen: true }),
+    null,
+    app,
+  );
+  await tick();
+
+  const wnd = app.windows[0];
+  const names = wnd.calls.map(([name]) => name);
+  assert.ok(names.includes('setWmState'), 'the state was asked for');
+  assert.ok(
+    names.indexOf('setWmState') < names.indexOf('map'),
+    'and asked for before the map, which is what makes it the initial state',
+  );
+  assert.deepStrictEqual(stateCalls(wnd), [['fullscreen', 'add']]);
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('states, fullscreen and alwaysOnTop union rather than compete', async () => {
+  const app = createMockApp();
+  ReactX11.render(
+    React.createElement('window', {
+      width: 100,
+      height: 80,
+      states: ['skip_taskbar', 'skip_pager'],
+      fullscreen: true,
+      alwaysOnTop: true,
+    }),
+    null,
+    app,
+  );
+  await tick();
+
+  assert.deepStrictEqual(
+    stateCalls(app.windows[0])
+      .map(([s]) => s)
+      .sort(),
+    ['above', 'fullscreen', 'skip_pager', 'skip_taskbar'],
+    'the booleans are sugar over the same set, not a second channel',
+  );
+  // one message per name: EWMH carries two states per ClientMessage and
+  // 'maximized' already uses both slots, so splitting by name is the only
+  // chunking that cannot land a pair across a boundary
+  for (const [name] of stateCalls(app.windows[0])) {
+    assert.strictEqual(typeof name, 'string', 'one state per message');
+  }
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('a state change sends only the difference, and only when props change', async () => {
+  const app = createMockApp();
+  const render = (states) =>
+    ReactX11.render(
+      React.createElement('window', { width: 100, height: 80, states }),
+      null,
+      app,
+    );
+  render(['fullscreen', 'skip_taskbar']);
+  await tick();
+  const wnd = app.windows[0];
+
+  // a re-render with an equal-but-fresh array must not re-send anything:
+  // re-asserting every commit is exactly how a controlled prop would fight
+  // a window manager that changed the state behind our back
+  wnd.calls.length = 0;
+  render(['fullscreen', 'skip_taskbar']);
+  await tick();
+  assert.deepStrictEqual(
+    stateCalls(wnd),
+    [],
+    'unchanged states are not re-sent',
+  );
+
+  wnd.calls.length = 0;
+  render(['fullscreen', 'above']);
+  await tick();
+  assert.deepStrictEqual(
+    stateCalls(wnd).sort(),
+    [
+      ['above', 'add'],
+      ['skip_taskbar', 'remove'],
+    ],
+    'only the difference, in both directions',
+  );
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('onStatesChange reports what the window manager actually did', async () => {
+  const app = createMockApp();
+  const seen = [];
+  ReactX11.render(
+    React.createElement('window', {
+      width: 100,
+      height: 80,
+      fullscreen: true,
+      onStatesChange: (states) => seen.push(states),
+    }),
+    null,
+    app,
+  );
+  await tick();
+
+  // the user hit the WM's un-fullscreen hotkey: reality diverges from the
+  // prop, and the app hears about it rather than react-x11 forcing it back
+  app.windows[0].emit('statechange', ['above']);
+  await tick();
+  assert.deepStrictEqual(seen, [['above']]);
+
+  // and react-x11 does not re-assert 'fullscreen' in response
+  const wnd = app.windows[0];
+  wnd.calls.length = 0;
+  await tick();
+  assert.deepStrictEqual(stateCalls(wnd), [], 'the WM is not fought');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('decorations={false} writes _MOTIF_WM_HINTS with its own type atom', async () => {
+  const app = createMockApp();
+  const render = (decorations) =>
+    ReactX11.render(
+      React.createElement('window', { width: 100, height: 80, decorations }),
+      null,
+      app,
+    );
+  render(false);
+  await tick();
+
+  const wnd = app.windows[0];
+  const motif = wnd.calls.find(([name]) => name === 'setProperty');
+  assert.ok(motif, 'the hint was written');
+  assert.deepStrictEqual(motif[1], '_MOTIF_WM_HINTS');
+  assert.deepStrictEqual(motif[2], [2, 0, 0, 0, 0], 'flags=2, decorations=0');
+  assert.strictEqual(
+    motif[3].type,
+    '_MOTIF_WM_HINTS',
+    'the type atom is the property itself, not CARDINAL — a WM that checks ' +
+      'the type ignores the hint otherwise',
+  );
+  assert.strictEqual(motif[3].format, 32);
+
+  wnd.calls.length = 0;
+  render(true);
+  await tick();
+  const back = wnd.calls.find(([name]) => name === 'setProperty');
+  assert.deepStrictEqual(back[2], [2, 0, 1, 0, 0], 'decorations back on');
+
+  ReactX11.unmountComponentAtNode(app);
 });

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -103,6 +103,10 @@ function Elements() {
       resizable={false}
       windowType="dialog"
       wmClass={['app', 'App']}
+      states={['skip_taskbar', 'maximized']}
+      fullscreen={false}
+      decorations={false}
+      onStatesChange={(states) => void states.includes('fullscreen')}
       style={s.root}
       onCloseRequest={() => {}}
       onResize={(ev) => void ev.nativeEvent.rootx}


### PR DESCRIPTION
Closes #122. Needs ntk 4.2.0, bumped here.

`<window>` exposed one of the thirteen states EWMH defines — `alwaysOnTop`, hard-wired to `_NET_WM_STATE_ABOVE`. No fullscreen, no maximize, no staying out of the taskbar, no way to ask for attention, and no way to hear that the window manager had changed any of it.

```jsx
<window
  states={['skip_taskbar']}
  fullscreen={isFullscreen}
  decorations={false}
  onStatesChange={(s) => setFullscreen(s.includes('fullscreen'))}
/>
```

`states` is the general mechanism; `fullscreen` and `alwaysOnTop` are sugar for the two everyone reaches for, and they union with `states` rather than competing with it. `alwaysOnTop` is kept rather than deleted — it now goes out through the same `_NET_WM_STATE` path as everything else, so it is a spelling, not a second channel.

## The two things worth reviewing

**Controlled, and not out of React convention.** On X the WM changes state behind the app's back constantly — the user hits maximize, a hotkey leaves fullscreen, a tiling WM has its own opinion. So `states` is diffed against the **previous props**, never against what the window currently has. A prop is re-sent only when the app changes its mind; a WM that disagreed is not fought on the next commit. There is a test for exactly this: after a `statechange` that contradicts the prop, react-x11 sends nothing.

**Applied before the map.** EWMH 7.7 gives unmapped and mapped windows different mechanisms and they are not interchangeable — an unmapped window *declares* its initial state by writing the property, a mapped one *asks* the WM. Only the first can open already fullscreen instead of flashing at the normal size first. This is what ntk 4.1's unmapped path was for, and there is a test asserting the `setWmState` call lands before `map`.

Two smaller judgement calls:

- **One state per message.** A `_NET_WM_STATE` ClientMessage has two state slots, and `'maximized'` already uses both when it expands to the vert/horz pair. Splitting by name is the only chunking that cannot land a pair across a boundary. These are rare calls, so the extra round trips are free.
- **`_MOTIF_WM_HINTS`' type atom is the property's own name**, not `CARDINAL`. Easy to get wrong, and a WM that checks the type ignores the hint if it is — so the test asserts the type, not just the value.

## `cursor: 'none'` needed no code

The style channel already passes the cursor name straight to `setCursor`, and `Cursor` in `types/style.d.ts` already listed `'none'`. It *threw* in ntk until 4.2.0 — so the types were promising something that failed at runtime, and the bump alone fixes it. Documented with the distinction that actually catches people: hiding the pointer is not the same as setting no cursor, which inherits the root window's and leaves it visible.

## Kiosk is a recipe, not a prop

Per the issue. It is not one thing — fullscreen, undecorated, above, out of the taskbar and pager, no pointer — and `docs/elements.md` now spells it out as five lines of JSX.

## Test plan

- `npm test` — 255 pass, 5 new in `test/smoke.test.js`: states are declared before the map; `states`/`fullscreen`/`alwaysOnTop` union; a change sends only the difference and an unchanged re-render sends nothing; `onStatesChange` reports the WM's version and react-x11 does not re-assert against it; `_MOTIF_WM_HINTS` carries flags=2 with its own type atom, both ways.
- The existing `alwaysOnTop` assertions were rewritten rather than deleted — it toggles both ways still, now through `setWmState('above', …)`.
- `npm run lint`, `npm run typecheck` — clean. `WindowState` added to `types/elements.d.ts` and exercised in `test/types/api.tsx`.

No screenshots: everything here is a request to the window manager, and the in-process X server used for headless capture has no WM at all — there is nothing for it to honour, so a screenshot would show the undecorated, non-fullscreen window either way. The assertions above check the wire instead.
