### PR TITLE
fix: a throwing event handler no longer takes the process with it

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -59,7 +59,7 @@ belongs to whoever made it.
 | `fontSource`                                           | pluggable system-font lookup — ntk's docs/fonts.md      |
 | `glxVisual`                                            | visual id for `getContext('opengl')`                    |
 | `onXError`                                             | X protocol errors nothing claimed. Default warns        |
-| `onUncaughtError` `onCaughtError` `onRecoverableError` | React's error channels; default log                     |
+| `onUncaughtError` `onCaughtError` `onRecoverableError` | `(error, errorInfo)`; default logs the component stack  |
 | `onDisconnect(reason, err)`                            | the connection ended — `'closed'` or `'error'`          |
 
 `display`, `stream`, `fontSource`, `glxVisual` and `onXError` go straight
@@ -75,6 +75,11 @@ const [serverEnd, clientEnd] = xserver.createStreamPair();
 server.addClientStream(serverEnd);
 const root = await createRoot({ stream: clientEnd }); // no $DISPLAY needed
 ```
+
+`onUncaughtError` covers one channel React does not: a throw from an **event
+handler**, which no error boundary can catch because the handler ran from an
+X event rather than a render. See
+[events.md](events.md#when-a-handler-throws).
 
 `onDisconnect` fires when the connection ends without being asked to —
 server exit, ssh drop, kill — and not for one this root closed. It invites

--- a/docs/events.md
+++ b/docs/events.md
@@ -18,6 +18,33 @@ events dispatched over the drawn node tree with DOM-like semantics.
 `ev.stopPropagation()` stops the walk. Handlers always read from current
 props — they can never go stale.
 
+### When a handler throws
+
+**No error boundary can catch it.** A boundary only sees throws React
+itself invoked, and a handler runs from an X event, so React is not on the
+stack. react-x11 therefore catches it at the dispatcher: the error is
+reported with the element, the handler name and the component that rendered
+the node, `process.exitCode` is set to 1 so the crash is still visible to CI
+and to a supervisor, and **dispatch continues** — one bad tooltip handler
+must not stop the handlers after it, or the frame loop.
+
+```
+react-x11: onClick on <box> in Panel threw. It ran from an X event rather
+than a render, so no error boundary could catch it; dispatch continues.
+```
+
+`createRoot({ onUncaughtError })` takes it over completely, which is the
+point of it being overridable: for a kiosk, crashing loudly is correct.
+
+```js
+const root = await createRoot({
+  onUncaughtError: (error, info) => {
+    telemetry.report(error, info.componentStack);
+    process.exit(1);
+  },
+});
+```
+
 ## Event object
 
 ```

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -31,6 +31,7 @@ import {
   WINDOW_HINT_PROPS,
 } from './nodes.js';
 import { flattenStyle } from './styles.js';
+import { defaultRootHandlers, setErrorHandler } from './errors.js';
 import { GlAreaNode } from './glnodes.js';
 import { SCENE_KINDS, UNSUPPORTED_KINDS, createSceneNode } from './scene3d.js';
 import {
@@ -492,12 +493,7 @@ const CONNECT_OPTIONS = [
   'onXError',
 ];
 
-const DEFAULT_ERROR_HANDLERS = {
-  onUncaughtError: (error) => console.error('react-x11: uncaught error', error),
-  onCaughtError: (error) => console.error('react-x11: caught error', error),
-  onRecoverableError: (error) =>
-    console.error('react-x11: recoverable error', error),
-};
+const DEFAULT_ERROR_HANDLERS = defaultRootHandlers;
 
 /**
  * The connection ended without us asking. `end` is the stream closing —
@@ -608,6 +604,11 @@ export async function createRoot(options = {}) {
     null,
   );
 
+  // A throw from an event handler has no React on the stack, so it never
+  // reaches the container above — the root's handler is reached through the
+  // container instead, which is what the nodes carry.
+  if (rest.onUncaughtError) setErrorHandler(app, rest.onUncaughtError);
+
   let unmounted = false;
   if (onDisconnect) watchConnection(app, onDisconnect, () => unmounted);
 
@@ -625,6 +626,7 @@ export async function createRoot(options = {}) {
       unmounted = true;
       Renderer.updateContainerSync(null, container, null, null);
       Renderer.flushSyncWork();
+      if (rest.onUncaughtError) setErrorHandler(app, null);
       if (owned) await app.close();
     },
   };

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,98 @@
+// Where a throw from user code goes when React is not on the stack.
+//
+// An event handler runs from an X event, not from a render, so no error
+// boundary can catch it — a boundary only sees throws React itself invoked.
+// Left bare, the throw unwinds out of the dispatcher into ntk's socket
+// `data` handler and takes the process with it, or wedges the frame loop,
+// which is worse: it looks like a hang rather than a crash.
+
+// container -> the root's onUncaughtError, when it set one
+const perContainer = new WeakMap();
+
+export function setErrorHandler(container, fn) {
+  if (fn) perContainer.set(container, fn);
+  else perContainer.delete(container);
+}
+
+/** The component that rendered this node, which is the name worth printing
+ * — `<box>` alone never tells anyone whose box it was. */
+function ownerName(node) {
+  const type = node?._reactFiber?._debugOwner?.type;
+  if (!type) return null;
+  return type.displayName || type.name || '(anonymous)';
+}
+
+/** A GUI process whose tree threw must not exit 0 — that lies to CI and to
+ * a supervisor. Guarded because the playground bundle runs in a browser. */
+function markFailed() {
+  if (typeof process !== 'undefined' && process) process.exitCode = 1;
+}
+
+/**
+ * Report a throw from a user callback, then carry on.
+ *
+ * Carrying on is the point: one bad tooltip handler must not stop the rest
+ * of the dispatch or the frame loop. The default still refuses to swallow —
+ * it logs what threw and where, and sets `process.exitCode`. A root that
+ * passed `onUncaughtError` decides for itself, because for a kiosk "crash
+ * loudly" is the right answer and for a text editor it is not.
+ */
+export function reportHandlerError(node, handler, error) {
+  const element = node?.kind ? `<${node.kind}>` : '(unknown)';
+  const owner = ownerName(node);
+  const custom = node?.app && perContainer.get(node.app);
+  if (custom) {
+    custom(error, {
+      componentStack: owner ? `\n    in ${owner}` : undefined,
+      element,
+      handler,
+      node,
+    });
+    return;
+  }
+  console.error(
+    `react-x11: ${handler} on ${element}${owner ? ` in ${owner}` : ''} threw. ` +
+      'It ran from an X event rather than a render, so no error boundary ' +
+      'could catch it; dispatch continues.',
+    error,
+  );
+  markFailed();
+}
+
+/** Wrap a call to user code so a throw is reported instead of escaping. */
+export function callHandler(node, handler, fn, ev) {
+  try {
+    fn(ev);
+  } catch (error) {
+    reportHandlerError(node, handler, error);
+  }
+}
+
+/**
+ * The root error callbacks React itself invokes, as `(error, errorInfo)`.
+ * `errorInfo.componentStack` is the whole reason a boundary is debuggable,
+ * and printing it beside the error is most of what makes these useful.
+ */
+export const defaultRootHandlers = {
+  onUncaughtError(error, errorInfo) {
+    console.error(
+      'react-x11: uncaught error' + (errorInfo?.componentStack ?? ''),
+      error,
+    );
+    markFailed();
+  },
+  onCaughtError(error, errorInfo) {
+    // an error boundary handled this one, so the process is still healthy
+    console.error(
+      'react-x11: error caught by a boundary' +
+        (errorInfo?.componentStack ?? ''),
+      error,
+    );
+  },
+  onRecoverableError(error, errorInfo) {
+    console.error(
+      'react-x11: recoverable error' + (errorInfo?.componentStack ?? ''),
+      error,
+    );
+  },
+};

--- a/src/events.js
+++ b/src/events.js
@@ -7,6 +7,7 @@ import {
   DiscreteEventPriority,
   ContinuousEventPriority,
 } from './priority.js';
+import { callHandler } from './errors.js';
 
 const XK_TAB = 0xff09;
 const WHEEL_BUTTONS = { 4: [0, -48], 5: [0, 48], 6: [-48, 0], 7: [48, 0] };
@@ -187,11 +188,15 @@ export class EventManager {
       target,
       extra,
     );
+    // Each handler is called inside callHandler: a throw here has no React
+    // on the stack to catch it, so bare it would unwind into ntk's socket
+    // handler and take the process. Reported and stepped over instead —
+    // one bad handler must not stop the ones after it, or the frame loop.
     for (const n of path) {
       const handler = n.props[`on${name}Capture`];
       if (handler) {
         ev.currentTarget = this._public(n);
-        handler(ev);
+        callHandler(n, `on${name}Capture`, handler, ev);
         if (ev.propagationStopped) return ev;
       }
     }
@@ -199,7 +204,7 @@ export class EventManager {
       const handler = path[i].props[`on${name}`];
       if (handler) {
         ev.currentTarget = this._public(path[i]);
-        handler(ev);
+        callHandler(path[i], `on${name}`, handler, ev);
         if (ev.propagationStopped) return ev;
       }
     }
@@ -226,9 +231,15 @@ export class EventManager {
     }
     if (this._pressOutside(native)) {
       runWithPriority(DiscreteEventPriority, () => {
-        this.node.props.onDismiss?.(
-          this._makeEvent('dismiss', native, this.node),
-        );
+        const onDismiss = this.node.props.onDismiss;
+        if (onDismiss) {
+          callHandler(
+            this.node,
+            'onDismiss',
+            onDismiss,
+            this._makeEvent('dismiss', native, this.node),
+          );
+        }
       });
       return;
     }

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -27,6 +27,7 @@ import {
   resolveSizeQueries,
 } from './styles.js';
 import { EventManager } from './events.js';
+import { callHandler } from './errors.js';
 import { runWithPriority, DiscreteEventPriority } from './priority.js';
 import {
   editMenuColors,
@@ -3180,7 +3181,8 @@ export class WindowNode extends Node {
         if (this._wmDeleteAtom != null && ev.data?.[0] === this._wmDeleteAtom) {
           // a WM close is a user action: discrete priority, like clicks
           runWithPriority(DiscreteEventPriority, () => {
-            this.props.onCloseRequest?.(ev);
+            const handler = this.props.onCloseRequest;
+            if (handler) callHandler(this, 'onCloseRequest', handler, ev);
           });
         }
       });

--- a/test/handler-errors.test.js
+++ b/test/handler-errors.test.js
@@ -1,0 +1,177 @@
+// A throwing event handler must not take the process with it (#113).
+//
+// The handler runs from an X event, not from a render, so React is not on
+// the stack and no error boundary can catch it. Left bare the throw unwinds
+// into ntk's socket handler; these tests pin the contract that replaced it.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import { createRoot } from '../src/index.js';
+import { createMockApp, pressButton } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+/** Capture console.error and process.exitCode around a body. */
+async function captured(body) {
+  const errors = [];
+  const origError = console.error;
+  const origCode = process.exitCode;
+  console.error = (...a) => errors.push(a.map(String).join(' '));
+  try {
+    await body();
+  } finally {
+    console.error = origError;
+    process.exitCode = origCode;
+  }
+  return errors;
+}
+
+const app0 = () => createMockApp();
+
+test('a throwing onClick is reported, and the dispatch survives it', async () => {
+  const app = app0();
+  const root = await createRoot({ app });
+  const seen = [];
+  root.render(
+    h(
+      'window',
+      { width: 100, height: 60 },
+      h(
+        'box',
+        { onClick: () => seen.push('outer') },
+        h('box', {
+          style: { width: 40, height: 20 },
+          onClick: () => {
+            throw new Error('boom');
+          },
+        }),
+      ),
+    ),
+  );
+  await tick();
+
+  let exitCode;
+  const errors = await captured(async () => {
+    pressButton(app.windows[0], 10, 10);
+    await tick();
+    exitCode = process.exitCode;
+  });
+
+  assert.match(errors.join('\n'), /onClick on <box>/, 'names what threw');
+  assert.match(errors.join('\n'), /boom/, 'and carries the error');
+  assert.strictEqual(exitCode, 1, 'a crashed handler must not exit 0');
+  assert.deepStrictEqual(
+    seen,
+    ['outer'],
+    'the bubble phase continued past the throw',
+  );
+
+  await root.unmount();
+});
+
+test('the message names the component that rendered the node', async () => {
+  const app = app0();
+  const root = await createRoot({ app });
+  function Panel() {
+    return h('box', {
+      style: { width: 40, height: 20 },
+      onClick: () => {
+        throw new Error('boom');
+      },
+    });
+  }
+  root.render(h('window', { width: 100, height: 60 }, h(Panel)));
+  await tick();
+
+  const errors = await captured(async () => {
+    pressButton(app.windows[0], 10, 10);
+    await tick();
+  });
+  assert.match(
+    errors.join('\n'),
+    /in Panel/,
+    '<box> alone never says whose box it was',
+  );
+
+  await root.unmount();
+});
+
+test('onUncaughtError takes over, and then nothing is logged or exits nonzero', async () => {
+  const app = app0();
+  const caught = [];
+  const root = await createRoot({
+    app,
+    onUncaughtError: (error, info) => caught.push([error.message, info]),
+  });
+  root.render(
+    h(
+      'window',
+      { width: 100, height: 60 },
+      h('box', {
+        style: { width: 40, height: 20 },
+        onClick: () => {
+          throw new Error('boom');
+        },
+      }),
+    ),
+  );
+  await tick();
+
+  let exitCode;
+  const errors = await captured(async () => {
+    process.exitCode = undefined;
+    pressButton(app.windows[0], 10, 10);
+    await tick();
+    exitCode = process.exitCode;
+  });
+
+  assert.strictEqual(caught.length, 1, 'the root handler saw it');
+  assert.strictEqual(caught[0][0], 'boom');
+  assert.strictEqual(caught[0][1].handler, 'onClick');
+  assert.strictEqual(caught[0][1].element, '<box>');
+  assert.deepStrictEqual(errors, [], 'and the default said nothing');
+  assert.strictEqual(
+    exitCode,
+    undefined,
+    'a kiosk that wants to crash loudly decides that itself',
+  );
+
+  await root.unmount();
+});
+
+test('the root handler is dropped on unmount, so the default comes back', async () => {
+  const app = app0();
+  const caught = [];
+  const first = await createRoot({
+    app,
+    onUncaughtError: (error) => caught.push(error.message),
+  });
+  first.render(h('window', { width: 100, height: 60 }));
+  await tick();
+  await first.unmount();
+
+  const second = await createRoot({ app });
+  second.render(
+    h(
+      'window',
+      { width: 100, height: 60 },
+      h('box', {
+        style: { width: 40, height: 20 },
+        onClick: () => {
+          throw new Error('boom');
+        },
+      }),
+    ),
+  );
+  await tick();
+
+  const errors = await captured(async () => {
+    pressButton(app.windows[app.windows.length - 1], 10, 10);
+    await tick();
+  });
+  assert.deepStrictEqual(caught, [], 'the unmounted root heard nothing');
+  assert.match(errors.join('\n'), /boom/, 'the default is back');
+
+  await second.unmount();
+});


### PR DESCRIPTION
Closes #113. Builds on #133, now merged: part 2 of the issue — "make the three root callbacks options on createRoot" — landed there, so this is parts 1 and 3.

## The bug

Handlers were invoked bare. A throw in `onClick` unwound through the dispatcher into ntk's socket `data` handler and killed the process — or wedged the frame loop, which is worse, because a hang looks like a bug in your code rather than a crash. No error boundary could have helped: the handler ran from an X event, so React was never on the stack.

Every call into user code from an X event now goes through `callHandler` — both dispatch loops, `onDismiss`, and the WM-close path. A throw is reported and dispatch **carries on**, because one bad tooltip handler must not stop the handlers after it or the frame loop.

## What the message says

The element alone was never enough — `<box>` does not tell you whose box it was. The fiber's `_debugOwner` does:

```
react-x11: onClick on <box> in Panel threw. It ran from an X event rather
than a render, so no error boundary could catch it; dispatch continues.
```

The sentence about boundaries is deliberate. The issue notes this blocks any serious error-boundary story, and a user who has just written one deserves to be told why it did not fire rather than left to work it out.

The default also sets `process.exitCode = 1` — a GUI process whose tree threw must not exit 0, which lies to CI and to systemd. Guarded for the playground bundle, which has no real `process`.

## Overridable, and why that matters

`createRoot({ onUncaughtError })` takes it over completely. That is the point of the knob: for a kiosk, crashing loudly is correct; for an editor with unsaved work it is the wrong answer.

The handler is reached **through the container**, not the fiber root — a throw from an event never reaches the root React would route it to, so the usual channel is unavailable. It is dropped when that root unmounts, so a second root on the same connection gets the default rather than a dead root's handler. There is a test for that specifically.

## Part 3: the root callbacks

They now take `(error, errorInfo)` and print `errorInfo.componentStack`. react-reconciler 0.33 has been passing it all along and the hardcoded one-parameter stubs dropped it on the floor — that stack is most of what makes a caught error debuggable.

I did not wire in `ClickToComponent`'s `resolveLocation` frame-stripping, which the issue suggests as a further improvement. That module is dev-only, dynamically imported behind two env vars, and stubbed out entirely in the website bundle; importing it eagerly from the dispatch path would drag it into every build to reformat a stack. The component name gets the reader to the same place.

## Test plan

- `npm test` — 264 pass, 4 new in `test/handler-errors.test.js`: a throwing `onClick` is reported and the bubble phase continues past it with `process.exitCode` set; the message names the rendering component; `onUncaughtError` takes over and then nothing is logged and the exit code is left alone; the handler is dropped on unmount so the default returns.
- `npm run lint`, `npm run typecheck` — clean.
- `website && npm test` — bundle, 10 demos and share links green; `errors.js` is new module surface in the bundle.
