### PR TITLE
feat: runtime diagnostics — protocol tracer, paint flashing, invalidation reasons

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,6 +331,14 @@ multiplying the server's work many times over.
 - `npm run bench -- --save` rewrites `scripts/bench/baseline.json`
 - `npm run bench -- --check` fails if a metric regressed past tolerance
 
+For a live app rather than the bench scenarios, `REACT_X11_TRACE=summary`
+(or `requests`, or `chrome:/tmp/t.json` for Perfetto) traces the protocol
+with the same splitter, `REACT_X11_DEBUG_PAINT=1` flashes damage rects and
+`=full` warns — with reason and stack — on silent full-window repaints,
+which are the regression class the bench numbers hide until re-run. See
+docs/debugging.md; the switches are read once at startup and cost nothing
+when off.
+
 Re-run it when touching painting, layout flushing, or anything in ntk's
 drawing path, and update the baseline in the same PR that changes it, so
 the diff records the cost.

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,9 @@
   and how the declarations are kept from drifting.
 - [devtools.md](devtools.md) — React DevTools integration and other
   debugging aids.
+- [debugging.md](debugging.md) — runtime diagnostics: protocol tracing
+  (`REACT_X11_TRACE`, `startTrace()`), repaint flashing and full-repaint
+  warnings (`REACT_X11_DEBUG_PAINT`), invalidation reasons.
 - [click-to-component.md](click-to-component.md) — Alt+Click a rendered
   element to open its JSX source line in your editor.
 - [ecosystem.md](ecosystem.md) — which npm packages work with react-x11 and

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -1,0 +1,117 @@
+# Runtime diagnostics
+
+Three switches answer the three questions a slow or misbehaving frame
+raises: _what went on the wire_ (`REACT_X11_TRACE`), _what got repainted_
+(`REACT_X11_DEBUG_PAINT`), and _why_ (invalidation reasons, printed by
+both). They complement [devtools.md](devtools.md) (component tree) and
+`REACT_X11_DEBUG_LAYOUT=1` (outline every drawn node, colour by depth).
+
+X11 is a network protocol even on a local socket, and the renderer's
+performance model — damage rects, one `CopyArea` per presented rect — is
+invisible at runtime without these. The failure mode they exist for is the
+silent full-window repaint: correct pixels, quietly costing the whole
+window every frame.
+
+Everything here is built to cost nothing when off: the environment
+switches are read **once at startup** (a `process.env` read is a real
+environment lookup, and these sit on the frame path), the tracer module is
+not even imported unless `REACT_X11_TRACE` is set or you import
+`react-x11/debug` yourself, stacks are only captured under
+`REACT_X11_DEBUG_PAINT=full` or `+stacks`, and the per-frame reason
+bookkeeping is a handful of set insertions. Measuring the renderer must
+not change what it measures.
+
+## Protocol tracing — `REACT_X11_TRACE`
+
+```sh
+REACT_X11_TRACE=summary npm run examples:dashboard
+# at exit:
+# react-x11 trace: 4211 requests (312.4KB out), 89 replies, 41 events, 0 errors (48.1KB in)
+#     1780  Render.CompositeGlyphs32
+#      512  Render.Composite
+#      ...
+```
+
+- `summary` — request/byte totals and an opcode histogram, printed to
+  stderr when the process exits.
+- `requests` — one stderr line per request as it is sent
+  (`x11 → Render.FillRectangles 36B`), plus one line per painted frame
+  (`frame 412: 320x24@8,40 reasons=style-state`). X errors are decoded and
+  name the failing request.
+- `chrome:/tmp/trace.json` — [Chrome Trace Event
+  JSON](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU),
+  written at exit. Open it in Perfetto or `about:tracing`: React commits
+  and painted frames are slices, requests and errors are instant events —
+  so "this interaction sent 4000 requests" becomes "3600 of them were
+  `CompositeGlyphs32` inside one commit".
+
+Append `+stacks` to `requests` or `chrome` to capture a JS stack per
+request (node-x11's seq2stack mechanism). An X error is asynchronous — it
+arrives long after the call that caused it returned — and the captured
+stack is the only thing that maps it back to your code. It costs an
+`Error` capture per request, so it is opt-in.
+
+The tracer attaches to a connection _after_ its handshake, so the
+connection-setup packet — the one carrying the X auth cookie — is
+structurally invisible to it, and payload bytes are never recorded: only
+opcode, length and direction.
+
+### `startTrace()` — the same thing as an API
+
+```js
+import { startTrace } from 'react-x11/debug';
+
+const trace = startTrace(); // sink: 'summary' | 'requests' | 'chrome'
+await interaction();
+const { requests, bytesOut, replies, byOpcode } = trace.stop();
+```
+
+With no `app` the trace follows every connection the renderer has open or
+opens later; pass `startTrace({ app })` to trace one specific connection
+(the bench harness does this). `byOpcode` maps decoded request names —
+`'CopyArea'`, `'Render.CompositeGlyphs32'` — to counts. This is the same
+splitter `npm run bench` uses, promoted to a runtime feature; for
+committed regression numbers still use the bench (`scripts/bench/`), whose
+in-process server keeps them deterministic.
+
+## Repaint flashing — `REACT_X11_DEBUG_PAINT`
+
+```sh
+REACT_X11_DEBUG_PAINT=1 npm run examples:dashboard
+```
+
+Every painted frame strokes its damage rects in a colour that rotates per
+frame. A region repainting every frame strobes; one that painted once
+leaves a single quiet outline. This is the browser's "paint flashing" for
+this renderer.
+
+```sh
+REACT_X11_DEBUG_PAINT=full npm run examples:dashboard
+```
+
+Additionally warns — with the invalidation's reasons and the stack of the
+`invalidate()` call that made the frame unbounded — whenever a frame
+degrades to a full-window repaint:
+
+```
+react-x11: full-window repaint (800x600) reasons=props
+Error: invalidated here
+    at WindowNode.invalidate (src/nodes.js:…)
+    at ...
+```
+
+Full repaints are the renderer's main performance bug class (see
+"Protocol efficiency" in AGENTS.md); before this switch nothing surfaced
+them. Expected full repaints exist too — a resize, the first frame after a
+mount, ntk invalidating its backing store — and their reasons say so.
+
+## Invalidation reasons
+
+Every internal `invalidate()` call now names why it ran, from a small
+closed set: `props`, `style-state`, `theme`, `animation`, `scroll`,
+`text`, `content`, `child-list`, `focus`, `caret`, `resize`, `mount`,
+`expose`, `highlight`. The frame's collected reasons are what
+`REACT_X11_TRACE=requests` frame lines, the chrome trace's frame slices,
+the full-repaint warning and `examples/stress/perf.js` print. After a
+frame they are readable on the window node as `root._lastReasons`
+(instrumentation surface, like `root._lastDamageRects` — not public API).

--- a/examples/stress/perf.js
+++ b/examples/stress/perf.js
@@ -110,7 +110,11 @@ export function watchFrames(root, { label = '', quiet = 0 } = {}) {
     totalMs += ms;
 
     if (area >= quiet) {
-      const line = `${fmt(rects)}  ${(area / 1000).toFixed(1)}kpx  ${ms.toFixed(1)}ms`;
+      // why the frame happened, from invalidate()'s reason argument
+      const why = root._lastReasons?.length
+        ? `  [${root._lastReasons.join('+')}]`
+        : '';
+      const line = `${fmt(rects)}  ${(area / 1000).toFixed(1)}kpx  ${ms.toFixed(1)}ms${why}`;
       if (line === lastLine) repeats += 1;
       else {
         flushRepeats();

--- a/package.json
+++ b/package.json
@@ -93,6 +93,10 @@
     "./jsx-dev-runtime": {
       "types": "./src/jsx-dev-runtime.d.ts",
       "default": "./src/jsx-dev-runtime.js"
+    },
+    "./debug": {
+      "types": "./src/debug.d.ts",
+      "default": "./src/debug.js"
     }
   },
   "types": "./src/index.d.ts"

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -32,6 +32,11 @@ import {
 } from './nodes.js';
 import { flattenStyle } from './styles.js';
 import { defaultRootHandlers, setErrorHandler } from './errors.js';
+import {
+  registerApp,
+  unregisterApp,
+  hooks as traceHooks,
+} from './trace-registry.js';
 import { GlAreaNode } from './glnodes.js';
 import { SCENE_KINDS, UNSUPPORTED_KINDS, createSceneNode } from './scene3d.js';
 import {
@@ -154,6 +159,7 @@ const HostConfig = {
   },
 
   prepareForCommit() {
+    traceHooks.commitStart?.();
     return null;
   },
 
@@ -163,6 +169,7 @@ const HostConfig = {
   resetAfterCommit() {
     flushWindowRestacks();
     flushTokenChecks();
+    traceHooks.commitEnd?.();
   },
 
   createInstance(type, props, rootContainer, hostContext, internalHandle) {
@@ -451,6 +458,15 @@ if (process.env.REACT_X11_CLICK_TO_COMPONENT || process.env.REACT_X11_EDITOR) {
   clickToComponent.install();
 }
 
+if (process.env.REACT_X11_TRACE) {
+  // Protocol tracing (docs/debugging.md). Dynamic import like DevTools
+  // above: debug.js writes files, which the playground bundle must not
+  // drag in. The trace itself attaches per connection, as each root
+  // registers the app it connected (or borrowed).
+  const debug = await import('./debug.js');
+  debug.startEnvTrace(process.env.REACT_X11_TRACE);
+}
+
 const roots = new Map();
 let cachedNtkApp = null;
 
@@ -475,6 +491,7 @@ async function connect(options) {
 async function connectApp() {
   if (cachedNtkApp) return cachedNtkApp;
   cachedNtkApp = await connect({});
+  registerApp(cachedNtkApp);
   return cachedNtkApp;
 }
 
@@ -612,6 +629,10 @@ export async function createRoot(options = {}) {
   let unmounted = false;
   if (onDisconnect) watchConnection(app, onDisconnect, () => unmounted);
 
+  // borrowed or owned, this is now a connection the renderer draws through,
+  // which is what a REACT_X11_TRACE / startTrace() session follows
+  registerApp(app);
+
   return {
     app,
     render(element, callback) {
@@ -627,7 +648,10 @@ export async function createRoot(options = {}) {
       Renderer.updateContainerSync(null, container, null, null);
       Renderer.flushSyncWork();
       if (rest.onUncaughtError) setErrorHandler(app, null);
-      if (owned) await app.close();
+      if (owned) {
+        unregisterApp(app);
+        await app.close();
+      }
     },
   };
 }

--- a/src/debug.d.ts
+++ b/src/debug.d.ts
@@ -1,0 +1,44 @@
+// Hand-written declarations for `react-x11/debug` (docs/debugging.md).
+
+export type TraceSink = 'summary' | 'requests' | 'chrome';
+
+export interface TraceStats {
+  /** Requests sent since the trace attached. */
+  requests: number;
+  bytesOut: number;
+  /** Replies received (each one is a round trip the client waited for). */
+  replies: number;
+  events: number;
+  errors: number;
+  bytesIn: number;
+  /** Decoded request name — e.g. 'CopyArea', 'Render.CompositeGlyphs32' —
+   * to how many times it was sent. */
+  byOpcode: Map<string, number>;
+}
+
+export interface TraceOptions {
+  /** Trace one specific ntk App. Without it, the trace follows every
+   * connection the renderer has open or opens later. */
+  app?: unknown;
+  /** 'summary' (default): totals at stop. 'requests': a stderr line per
+   * request and per frame. 'chrome': Trace Event JSON written to `path`. */
+  sink?: TraceSink;
+  /** Output file for the 'chrome' sink. Default 'react-x11-trace.json'. */
+  path?: string;
+  /** Capture a JS stack per request (node-x11's seq2stack), so an async X
+   * error names the call that sent it. One Error capture per request. */
+  seq2stack?: boolean;
+}
+
+export interface TraceSession {
+  /** Live totals; the same object `stop()` returns. */
+  stats: TraceStats;
+  /** Detach from every connection, flush the sink, return the totals. */
+  stop(): TraceStats;
+}
+
+export function startTrace(options?: TraceOptions): TraceSession;
+
+/** What `REACT_X11_TRACE=<spec>` calls at startup. Grammar:
+ * `summary` | `requests[+stacks]` | `chrome[+stacks]:<path>`. */
+export function startEnvTrace(spec: string): TraceSession | null;

--- a/src/debug.js
+++ b/src/debug.js
@@ -1,0 +1,540 @@
+// react-x11/debug — runtime X11 protocol tracing and frame diagnostics.
+//
+// The environment switch (read once by the Reconciler at import time):
+//
+//   REACT_X11_TRACE=summary                 opcode histogram + byte totals at exit
+//   REACT_X11_TRACE=requests                one stderr line per request + per frame
+//   REACT_X11_TRACE=chrome:/tmp/trace.json  Chrome Trace Event JSON at exit
+//
+// append `+stacks` to `requests` or `chrome` to capture a JS stack per
+// request (node-x11's seq2stack), so an async X error names the call that
+// sent the offending request. That costs an Error capture per request, so
+// it is not on by default.
+//
+// The API (any connection, not only the renderer's):
+//
+//   import { startTrace } from 'react-x11/debug';
+//   const trace = startTrace({ sink: 'chrome', path: '/tmp/t.json' });
+//   ...
+//   const { requests, bytesOut, replies, byOpcode } = trace.stop();
+//
+// With no `app`, the trace follows every connection the renderer has open
+// or opens later. Pass `app` to trace one specific connection instead.
+//
+// The tracer attaches to a connection *after* its handshake: it wraps the
+// pack stream that carries framed requests and adds a listener beside
+// node-x11's own on the socket. The connection-setup packet — the one that
+// carries the X auth cookie — was written before either hook existed, so
+// the tracer cannot observe it. Redaction by construction, not by filter.
+// Payload bytes are never recorded either — only opcode, length and
+// direction — so window contents and property values stay off the log.
+import { writeFileSync } from 'node:fs';
+import { onApp, hooks } from './trace-registry.js';
+
+// --- names --------------------------------------------------------------
+
+// Core request opcodes 1..119 in protocol order (`-` marks a hole), plus
+// 127. Kept as one word list so the table reads like the protocol index.
+const CORE_REQUESTS = `- CreateWindow ChangeWindowAttributes
+  GetWindowAttributes DestroyWindow DestroySubwindows ChangeSaveSet
+  ReparentWindow MapWindow MapSubwindows UnmapWindow UnmapSubwindows
+  ConfigureWindow CirculateWindow GetGeometry QueryTree InternAtom
+  GetAtomName ChangeProperty DeleteProperty GetProperty ListProperties
+  SetSelectionOwner GetSelectionOwner ConvertSelection SendEvent GrabPointer
+  UngrabPointer GrabButton UngrabButton ChangeActivePointerGrab GrabKeyboard
+  UngrabKeyboard GrabKey UngrabKey AllowEvents GrabServer UngrabServer
+  QueryPointer GetMotionEvents TranslateCoordinates WarpPointer
+  SetInputFocus GetInputFocus QueryKeymap OpenFont CloseFont QueryFont
+  QueryTextExtents ListFonts ListFontsWithInfo SetFontPath GetFontPath
+  CreatePixmap FreePixmap CreateGC ChangeGC CopyGC SetDashes
+  SetClipRectangles FreeGC ClearArea CopyArea CopyPlane PolyPoint PolyLine
+  PolySegment PolyRectangle PolyArc FillPoly PolyFillRectangle PolyFillArc
+  PutImage GetImage PolyText8 PolyText16 ImageText8 ImageText16
+  CreateColormap FreeColormap CopyColormapAndFree InstallColormap
+  UninstallColormap ListInstalledColormaps AllocColor AllocNamedColor
+  AllocColorCells AllocColorPlanes FreeColors StoreColors StoreNamedColor
+  QueryColors LookupColor CreateCursor CreateGlyphCursor FreeCursor
+  RecolorCursor QueryBestSize QueryExtension ListExtensions
+  ChangeKeyboardMapping GetKeyboardMapping ChangeKeyboardControl
+  GetKeyboardControl Bell ChangePointerControl GetPointerControl
+  SetScreenSaver GetScreenSaver ChangeHosts ListHosts SetAccessControl
+  SetCloseDownMode KillClient RotateProperties ForceScreenSaver
+  SetPointerMapping GetPointerMapping SetModifierMapping
+  GetModifierMapping`
+  .trim()
+  .split(/\s+/);
+CORE_REQUESTS[127] = 'NoOperation';
+
+const RENDER_MINORS = `QueryVersion QueryPictFormats QueryPictIndexValues -
+  CreatePicture ChangePicture SetPictureClipRectangles FreePicture
+  Composite - Trapezoids Triangles TriStrip TriFan - - - CreateGlyphSet
+  ReferenceGlyphSet FreeGlyphSet AddGlyphs - FreeGlyphs CompositeGlyphs8
+  CompositeGlyphs16 CompositeGlyphs32 FillRectangles CreateCursor
+  SetPictureTransform QueryFilters SetPictureFilter CreateAnimCursor
+  AddTraps CreateSolidFill CreateLinearGradient CreateRadialGradient
+  CreateConicalGradient`
+  .trim()
+  .split(/\s+/);
+
+const CORE_ERRORS = `- Request Value Window Pixmap Atom Cursor Font Match
+  Drawable Access Alloc Colormap GC IDChoice Name Length Implementation`
+  .trim()
+  .split(/\s+/);
+
+/** A `-` in the word lists above is a hole, not a name. */
+const named = (table, index) => {
+  const name = table[index];
+  return name && name !== '-' ? name : null;
+};
+
+/** Extension major opcodes this connection negotiated, from the display. */
+function extensionTable(app) {
+  const table = new Map();
+  const display = app?.display ?? app?.X?.display;
+  if (!display || typeof display !== 'object') return table;
+  for (const [key, value] of Object.entries(display)) {
+    const major = value?.majorOpcode;
+    if (typeof major === 'number' && major >= 128) {
+      table.set(major, {
+        name: key,
+        minors: key === 'Render' ? RENDER_MINORS : null,
+      });
+    }
+  }
+  return table;
+}
+
+function opcodeName(extensions, major, minor) {
+  if (major < 128) return named(CORE_REQUESTS, major) ?? `core${major}`;
+  const ext = extensions.get(major);
+  if (!ext) return `ext${major}.${minor}`;
+  const minorName = ext.minors ? named(ext.minors, minor) : null;
+  return `${ext.name}.${minorName ?? minor}`;
+}
+
+// --- framing ------------------------------------------------------------
+
+const EMPTY = Buffer.alloc(0);
+// Nothing ntk sends comes near this; a length beyond it means the parser
+// lost the frame boundary (it attached mid-burst), so it resynchronises by
+// dropping its buffer rather than swallowing the stream forever.
+const MAX_SANE_LENGTH = 1 << 26;
+
+/**
+ * Incremental parser for the client->server direction of a post-handshake
+ * X11 stream: framed requests, BIG-REQUESTS aware (a 16-bit length of 0
+ * means the real 32-bit length follows the header).
+ */
+function requestParser(onRequest) {
+  let buf = EMPTY;
+  return (chunk) => {
+    buf = buf.length ? Buffer.concat([buf, chunk]) : chunk;
+    for (;;) {
+      if (buf.length < 4) return;
+      const major = buf[0];
+      const minor = buf[1];
+      let len = buf.readUInt16LE(2) * 4;
+      if (len === 0) {
+        if (buf.length < 8) return;
+        len = buf.readUInt32LE(4) * 4;
+      }
+      if (len < 4 || len > MAX_SANE_LENGTH) {
+        buf = EMPTY; // desynchronised; drop and re-align on the next put
+        return;
+      }
+      if (buf.length < len) return;
+      onRequest(major, minor, len);
+      buf = buf.subarray(len);
+    }
+  };
+}
+
+/**
+ * Incremental parser for the server->client direction: 32-byte units, with
+ * replies (type 1) and GenericEvents (code 35) carrying extra length.
+ */
+function inboundParser(onUnit) {
+  let buf = EMPTY;
+  return (chunk) => {
+    buf = buf.length ? Buffer.concat([buf, chunk]) : chunk;
+    for (;;) {
+      if (buf.length < 32) return;
+      const type = buf[0];
+      const code = type & 0x7f;
+      let total = 32;
+      if (type === 1 || code === 35) {
+        total = 32 + buf.readUInt32LE(4) * 4;
+        if (total > MAX_SANE_LENGTH) {
+          buf = EMPTY;
+          return;
+        }
+        if (buf.length < total) return;
+      }
+      if (type === 0) {
+        onUnit('error', total, {
+          errorCode: buf[1],
+          seq: buf.readUInt16LE(2),
+          minor: buf.readUInt16LE(8),
+          major: buf[10],
+        });
+      } else if (type === 1) {
+        onUnit('reply', total, null);
+      } else {
+        onUnit('event', total, { code });
+      }
+      buf = buf.subarray(total);
+    }
+  };
+}
+
+// --- seq2stack ----------------------------------------------------------
+
+// How many recent requests keep their captured stack. A trace can run for
+// minutes; an unbounded map of Error objects would not.
+const STACK_WINDOW = 2048;
+
+/**
+ * node-x11 captures a stack per request when the client was created with
+ * `{ debug: true }` (its "seq2stack" mode). A connection made without it
+ * can still get the same accessor installed after the fact — same
+ * mechanism, plus a sliding window so a long trace stays bounded.
+ */
+function enableSeq2Stack(X) {
+  if (!X || X.seq2stack) return Boolean(X?.seq2stack);
+  const desc = Object.getOwnPropertyDescriptor(X, 'seq_num');
+  if (desc && !('value' in desc)) return false; // someone else's accessor
+  try {
+    let value = X.seq_num ?? 0;
+    X.seq2stack = {};
+    Object.defineProperty(X, 'seq_num', {
+      configurable: true,
+      get: () => value,
+      set: function seqNumSetter(v) {
+        value = v;
+        const err = new Error();
+        Error.captureStackTrace(err, seqNumSetter);
+        err.timestamp = Date.now();
+        X.seq2stack[v] = err;
+        delete X.seq2stack[v - STACK_WINDOW];
+      },
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** The stack captured for a wire sequence number (16-bit, so it has to be
+ * widened against the client's full counter before the lookup). */
+function stackForSeq(X, seq16) {
+  const map = X?.seq2stack;
+  if (!map) return null;
+  const current = X.seq_num ?? 0;
+  const base = current & ~0xffff;
+  for (const candidate of [base + seq16, base - 0x10000 + seq16]) {
+    if (candidate >= 0 && candidate <= current && map[candidate]) {
+      return map[candidate].stack;
+    }
+  }
+  return null;
+}
+
+// --- the session --------------------------------------------------------
+
+const usec = () => Math.round(performance.now() * 1000);
+
+// A Chrome trace is buffered in memory until stop; this is the ceiling.
+const MAX_TRACE_EVENTS = 1_000_000;
+
+function createSession({ sink, path }) {
+  const stats = {
+    requests: 0,
+    bytesOut: 0,
+    replies: 0,
+    events: 0,
+    errors: 0,
+    bytesIn: 0,
+    /** decoded request name -> count, e.g. 'Render.CompositeGlyphs32' */
+    byOpcode: new Map(),
+  };
+  const chrome = sink === 'chrome' ? [] : null;
+  let dropped = 0;
+  let frames = 0;
+  let commitStarted = 0;
+  let finished = false;
+
+  const record = (event) => {
+    if (!chrome) return;
+    if (chrome.length >= MAX_TRACE_EVENTS) {
+      dropped += 1;
+      return;
+    }
+    chrome.push(event);
+  };
+
+  const line = (text) => process.stderr.write(`${text}\n`);
+
+  return {
+    stats,
+
+    request(name, bytes) {
+      stats.requests += 1;
+      stats.bytesOut += bytes;
+      stats.byOpcode.set(name, (stats.byOpcode.get(name) ?? 0) + 1);
+      if (sink === 'requests') {
+        line(`x11 → ${name} ${bytes}B`);
+      }
+      record({
+        name,
+        ph: 'i',
+        s: 't',
+        ts: usec(),
+        pid: process.pid,
+        tid: 1,
+        cat: 'x11',
+        args: { bytes },
+      });
+    },
+
+    inbound(kind, bytes, info, X, extensions) {
+      stats.bytesIn += bytes;
+      if (kind === 'reply') stats.replies += 1;
+      else if (kind === 'event') stats.events += 1;
+      else {
+        stats.errors += 1;
+        const errorName =
+          named(CORE_ERRORS, info.errorCode) ?? `#${info.errorCode}`;
+        const request = opcodeName(extensions, info.major, info.minor);
+        const stack = stackForSeq(X, info.seq);
+        if (sink === 'requests') {
+          line(`x11 ← Error ${errorName} on ${request} (seq ${info.seq})`);
+          if (stack) line(stack.replace(/^Error\n?/, ''));
+        }
+        record({
+          name: `Error ${errorName} (${request})`,
+          ph: 'i',
+          s: 'p',
+          ts: usec(),
+          pid: process.pid,
+          tid: 1,
+          cat: 'x11,error',
+          args: { seq: info.seq, stack: stack ?? undefined },
+        });
+      }
+    },
+
+    frame({ rects, reasons, start, end }) {
+      frames += 1;
+      const full = !rects;
+      const area = full
+        ? null
+        : rects.reduce((sum, r) => sum + r.width * r.height, 0);
+      if (sink === 'requests') {
+        const where = full
+          ? 'FULL WINDOW'
+          : rects.map((r) => `${r.width}x${r.height}@${r.x},${r.y}`).join(' ');
+        const why = reasons?.length ? ` reasons=${reasons.join('+')}` : '';
+        line(`frame ${frames}: ${where}${why}`);
+      }
+      record({
+        name: 'frame',
+        ph: 'X',
+        ts: Math.round(start * 1000),
+        dur: Math.max(1, Math.round((end - start) * 1000)),
+        pid: process.pid,
+        tid: 1,
+        cat: 'react-x11',
+        args: {
+          full,
+          rects: rects?.length ?? 0,
+          area,
+          reasons: reasons ?? [],
+        },
+      });
+    },
+
+    commitStart() {
+      commitStarted = usec();
+    },
+
+    commitEnd() {
+      if (!commitStarted) return;
+      record({
+        name: 'commit',
+        ph: 'X',
+        ts: commitStarted,
+        dur: Math.max(1, usec() - commitStarted),
+        pid: process.pid,
+        tid: 1,
+        cat: 'react-x11',
+      });
+      commitStarted = 0;
+    },
+
+    finish() {
+      if (finished) return stats;
+      finished = true;
+      if (sink === 'summary') {
+        const top = [...stats.byOpcode.entries()]
+          .sort((a, b) => b[1] - a[1])
+          .slice(0, 8);
+        const kb = (n) => `${(n / 1024).toFixed(1)}KB`;
+        line(
+          `react-x11 trace: ${stats.requests} requests (${kb(stats.bytesOut)} out), ` +
+            `${stats.replies} replies, ${stats.events} events, ` +
+            `${stats.errors} errors (${kb(stats.bytesIn)} in)`,
+        );
+        for (const [name, count] of top) {
+          line(`  ${String(count).padStart(7)}  ${name}`);
+        }
+      }
+      if (chrome) {
+        if (dropped) {
+          chrome.push({
+            name: `trace truncated: ${dropped} events dropped`,
+            ph: 'i',
+            s: 'g',
+            ts: usec(),
+            pid: process.pid,
+            tid: 1,
+            cat: 'react-x11',
+          });
+        }
+        writeFileSync(
+          path,
+          JSON.stringify({ traceEvents: chrome, displayTimeUnit: 'ms' }),
+        );
+        line(`react-x11 trace: wrote ${chrome.length} events to ${path}`);
+      }
+      return stats;
+    },
+  };
+}
+
+// --- attaching ----------------------------------------------------------
+
+/**
+ * Attach the session's counters to one connection. Returns a detacher, or
+ * null when the connection has nothing to attach to (a mock app in tests).
+ */
+function attachApp(app, session, { seq2stack }) {
+  const X = app?.X;
+  const packStream = X?.pack_stream;
+  if (!packStream || typeof packStream.put !== 'function') return null;
+  const extensions = extensionTable(app);
+  if (seq2stack) enableSeq2Stack(X);
+
+  let active = true;
+  const parseOut = requestParser((major, minor, len) => {
+    session.request(opcodeName(extensions, major, minor), len);
+  });
+  const parseIn = inboundParser((kind, bytes, info) => {
+    session.inbound(kind, bytes, info, X, extensions);
+  });
+
+  const origPut = packStream.put;
+  const tracedPut = function (...args) {
+    if (active && Buffer.isBuffer(args[0])) parseOut(args[0]);
+    return origPut.apply(this, args);
+  };
+  packStream.put = tracedPut;
+
+  const onData = (chunk) => {
+    if (active && Buffer.isBuffer(chunk)) parseIn(chunk);
+  };
+  const stream = X.stream;
+  if (typeof stream?.on === 'function') stream.on('data', onData);
+
+  return () => {
+    active = false;
+    // only unhook what is still ours — another trace may have wrapped on top
+    if (packStream.put === tracedPut) packStream.put = origPut;
+    if (typeof stream?.removeListener === 'function') {
+      stream.removeListener('data', onData);
+    }
+  };
+}
+
+// --- public API ---------------------------------------------------------
+
+/**
+ * Start tracing. `sink` is 'summary' (default), 'requests' or 'chrome'
+ * (which needs `path`). With no `app` the trace follows every connection
+ * the renderer has open or opens later; pass one to trace it alone.
+ * `seq2stack: true` captures a JS stack per request so an asynchronous X
+ * error can name the call that sent it — an Error capture per request, so
+ * off by default.
+ *
+ * Returns `{ stats, stop }`; `stop()` detaches everything, flushes the
+ * sink and returns the totals.
+ */
+export function startTrace(options = {}) {
+  const {
+    app,
+    sink = 'summary',
+    path = 'react-x11-trace.json',
+    seq2stack = false,
+  } = options;
+  if (!['summary', 'requests', 'chrome'].includes(sink)) {
+    throw new Error(
+      `react-x11/debug: unknown trace sink ${JSON.stringify(sink)} — ` +
+        "expected 'summary', 'requests' or 'chrome'.",
+    );
+  }
+  const session = createSession({ sink, path });
+  const detachers = [];
+  const attach = (a) => {
+    const detach = attachApp(a, session, { seq2stack });
+    if (detach) detachers.push(detach);
+  };
+  const unsubscribe = app ? null : onApp(attach);
+  if (app) attach(app);
+
+  const frame = (info) => session.frame(info);
+  if (sink === 'requests' || sink === 'chrome') hooks.frame = frame;
+  const commitStart = () => session.commitStart();
+  const commitEnd = () => session.commitEnd();
+  if (sink === 'chrome') {
+    hooks.commitStart = commitStart;
+    hooks.commitEnd = commitEnd;
+  }
+
+  let stopped = false;
+  return {
+    stats: session.stats,
+    stop() {
+      if (stopped) return session.stats;
+      stopped = true;
+      unsubscribe?.();
+      for (const detach of detachers) detach();
+      if (hooks.frame === frame) hooks.frame = null;
+      if (hooks.commitStart === commitStart) hooks.commitStart = null;
+      if (hooks.commitEnd === commitEnd) hooks.commitEnd = null;
+      return session.finish();
+    },
+  };
+}
+
+/**
+ * The REACT_X11_TRACE entry point, called by the Reconciler at import time.
+ * Grammar: `summary`, `requests[+stacks]`, `chrome[+stacks]:<path>`.
+ * The trace runs until the process exits, then flushes its sink.
+ */
+export function startEnvTrace(spec) {
+  const match = /^(summary|requests|chrome)(\+stacks)?(?::(.*))?$/.exec(spec);
+  if (!match) {
+    console.warn(
+      `react-x11: REACT_X11_TRACE=${JSON.stringify(spec)} not understood — ` +
+        "expected 'summary', 'requests[+stacks]' or 'chrome[+stacks]:<path>'.",
+    );
+    return null;
+  }
+  const [, sink, stacks, path] = match;
+  const trace = startTrace({
+    sink,
+    path: path || 'react-x11-trace.json',
+    seq2stack: Boolean(stacks),
+  });
+  process.on('exit', () => trace.stop());
+  return trace;
+}

--- a/src/events.js
+++ b/src/events.js
@@ -116,7 +116,7 @@ export class EventManager {
         this._makeEvent(focused ? 'focus' : 'blur', native, this.node),
       );
     });
-    this.node.invalidate(false);
+    this.node.invalidate(false, null, 'focus');
   }
 
   _public(node) {
@@ -482,7 +482,7 @@ export class EventManager {
       old.props.onBlur?.(this._makeEvent('blur', null, old));
       // the ring/caret it was drawing has to go, and it may be in another
       // window than the new focus (owner window ↔ its popup)
-      old.root?.invalidate(false, old);
+      old.root?.invalidate(false, old, 'focus');
     }
     if (node) {
       // keys only reach a node whose window has the X focus
@@ -491,7 +491,7 @@ export class EventManager {
       this._scrollIntoView(node);
       if (this.windowFocused) node._defaultFocus?.();
       node.props.onFocus?.(this._makeEvent('focus', null, node));
-      node.root?.invalidate(false, node);
+      node.root?.invalidate(false, node, 'focus');
     }
   }
 

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -28,6 +28,7 @@ import {
 } from './styles.js';
 import { EventManager } from './events.js';
 import { callHandler } from './errors.js';
+import { hooks as traceHooks } from './trace-registry.js';
 import { runWithPriority, DiscreteEventPriority } from './priority.js';
 import {
   editMenuColors,
@@ -84,6 +85,43 @@ const NO_DAMAGE = Symbol('no-damage');
 // it — so damage grows by a pixel on each side before anything is culled
 // against it.
 const DAMAGE_SLOP = 1;
+
+// What an invalidate() may name as its reason — a small closed set, so the
+// frame log, the tracer and the full-repaint warning can print "why" next
+// to "where". A typo'd reason would silently vanish from every report, so
+// DEV validates against this list.
+const INVALIDATE_REASONS = new Set([
+  'props', // a React commit changed what a node draws
+  'style-state', // :hover/:focus/:active/:disabled restyle
+  'theme', // a theme/token change restyled a subtree
+  'animation', // a transition frame
+  'scroll', // scrollTo/scrollBy/scrollIntoView, textarea/textinput panning
+  'text', // text content, input value or caret editing
+  'content', // async content arrived (image decode, rich-content reflow)
+  'child-list', // children were added, removed or reordered
+  'focus', // focus moved: ring/caret handover between nodes
+  'caret', // the caret blink timer
+  'resize', // the window changed size
+  'mount', // the window was just realized; its first frame
+  'expose', // ntk asked for a redraw (backing store invalidated)
+  'highlight', // DevTools hover highlight
+]);
+
+// A frame with no recorded reasons shares one frozen empty list, so the
+// per-frame cost of the reason machinery when nothing is reading it is a
+// property write.
+const EMPTY_REASONS = Object.freeze([]);
+
+// REACT_X11_DEBUG_PAINT: each frame strokes its damage rects in the next of
+// these, so a region repainting every frame strobes visibly.
+const FLASH_COLORS = [
+  '#e6194b',
+  '#3cb44b',
+  '#ffe119',
+  '#4363d8',
+  '#f58231',
+  '#911eb4',
+];
 
 // How many rectangles a frame's damage is allowed to hold.
 //
@@ -286,6 +324,15 @@ const DEV = process.env.NODE_ENV !== 'production';
 let now = () => Date.now();
 export function setAnimationClock(fn) {
   now = fn;
+}
+
+// REACT_X11_DEBUG_PAINT, read once: a process.env read is a real
+// environment lookup, and this switch sits on invalidate() and the paint
+// loop — the diagnostics must cost nothing when they are off. Indirected
+// like the animation clock so tests can flip it without a subprocess.
+let debugPaint = process.env.REACT_X11_DEBUG_PAINT || '';
+export function setDebugPaint(mode) {
+  debugPaint = mode || '';
 }
 
 /** Did anything the text stack measures or paints with change? */
@@ -562,7 +609,7 @@ export class Node {
     this._retarget(next);
     // a state block may only set paint properties, so the node's own region
     // is the whole of what changed
-    this.root?.invalidate(false, this);
+    this.root?.invalidate(false, this, 'style-state');
   }
 
   get isWindow() {
@@ -650,7 +697,7 @@ export class Node {
       // the invalidation TextNode.applyProps would have done has to happen
       // here too — otherwise the cached layout keeps painting the old colour
       if (textStyleChanged(this.style, before)) this._textContentChanged();
-      this.root?.invalidate(true);
+      this.root?.invalidate(true, null, 'theme');
     }
     for (const child of this.children) child._themeChanged();
   }
@@ -767,10 +814,10 @@ export class Node {
     const root = this.root;
     if (!root) return;
     if (!this._sizePinned()) {
-      root.invalidate(true);
+      root.invalidate(true, null, 'child-list');
       return;
     }
-    root.invalidate(true, before);
+    root.invalidate(true, before, 'child-list');
     root._reflowed.add(this);
   }
 
@@ -841,6 +888,7 @@ export class Node {
         : this._paintChanged(newProps, prev, style, prevStyle)
           ? this
           : NO_DAMAGE,
+      'props',
     );
   }
 
@@ -885,7 +933,7 @@ export class Node {
           : Yoga.DISPLAY_FLEX,
       );
     }
-    this.root?.invalidate(true);
+    this.root?.invalidate(true, null, 'props');
   }
 
   /**
@@ -1286,7 +1334,7 @@ export class TextChunkNode extends Node {
   setText(text) {
     this.text = String(text);
     this.parent?._textContentChanged();
-    this.root?.invalidate(true);
+    this.root?.invalidate(true, null, 'text');
   }
 
   _textContentChanged() {
@@ -1423,7 +1471,7 @@ export class ImageNode extends Node {
       this.image = image;
       if (this.yoga) {
         this.yoga.markDirty?.();
-        this.root?.invalidate(true);
+        this.root?.invalidate(true, null, 'content');
       }
     } catch (err) {
       console.error(`react-x11: failed to load image ${src}:`, err.message);
@@ -1708,7 +1756,7 @@ export class ScrollViewNode extends Node {
     // both arguments. Unbounded, every wheel notch repainted the whole window,
     // which is the whole cost of scrolling: the client work is negligible next
     // to what the server then has to redraw.
-    this.root?.invalidate(true, this);
+    this.root?.invalidate(true, this, 'scroll');
   }
 
   /** `scrollBy(dy)`, or `scrollBy({x, y})` for either axis. */
@@ -1731,7 +1779,7 @@ export class ScrollViewNode extends Node {
   scrollIntoView(node) {
     if (!node) return;
     this._scrollIntoViewTarget = node;
-    this.root?.invalidate(true);
+    this.root?.invalidate(true, null, 'scroll');
   }
 
   _resolveScrollIntoView() {
@@ -1855,7 +1903,9 @@ export class CanvasNode extends Node {
     // made every re-render of a component that draws through <canvas> repaint
     // the whole window, which is what a Checkbox's tick and a Select's chevron
     // both do.
-    if (newProps.onDraw !== before.onDraw) this.root?.invalidate(false, this);
+    if (newProps.onDraw !== before.onDraw) {
+      this.root?.invalidate(false, this, 'props');
+    }
   }
 
   _paintContent(ctx) {
@@ -2015,7 +2065,7 @@ export class TextInputNode extends Node {
 
   _repaint() {
     this._caretOn = true;
-    this.root?.invalidate(false, this);
+    this.root?.invalidate(false, this, 'text');
   }
 
   /**
@@ -2556,7 +2606,7 @@ export class TextInputNode extends Node {
           const next = editMenuIndexAt(geometry, mv.y);
           if (next === state.active) return;
           state.active = next;
-          popup.invalidate(false);
+          popup.invalidate(false, null, 'style-state');
         },
         onMouseUp: (mv) => {
           const i = editMenuIndexAt(geometry, mv.y);
@@ -2571,7 +2621,7 @@ export class TextInputNode extends Node {
               state.active,
               k.keysym === XK_DOWN ? 1 : -1,
             );
-            popup.invalidate(false);
+            popup.invalidate(false, null, 'style-state');
             return;
           }
           if (k.keysym === XK_RETURN || k.keysym === XK_KP_ENTER) {
@@ -2629,10 +2679,10 @@ export class TextInputNode extends Node {
       this._caretOn = !this._caretOn;
       // twice a second, forever, for as long as a field has focus: the one
       // repaint that most wants to cost only the field it happens in
-      this.root?.invalidate(false, this);
+      this.root?.invalidate(false, this, 'caret');
     }, 530);
     this._blinkTimer.unref?.();
-    this.root?.invalidate(false, this);
+    this.root?.invalidate(false, this, 'focus');
   }
 
   _defaultBlur() {
@@ -2642,7 +2692,7 @@ export class TextInputNode extends Node {
     this._breakUndoRun();
     clearInterval(this._blinkTimer);
     this._blinkTimer = null;
-    this.root?.invalidate(false, this);
+    this.root?.invalidate(false, this, 'focus');
   }
 
   destroySubtree() {
@@ -2670,9 +2720,9 @@ export class TextInputNode extends Node {
     }
     if (metricsChanged) {
       this.yoga.markDirty();
-      this.root?.invalidate(true);
+      this.root?.invalidate(true, null, 'props');
     } else if (newProps.value !== before.value) {
-      this.root?.invalidate(false);
+      this.root?.invalidate(false, null, 'text');
     }
   }
 
@@ -2798,7 +2848,7 @@ export class TextAreaNode extends TextInputNode {
     const next = Math.min(Math.max(0, y), bar.range);
     if (next === this._scrollY) return;
     this._scrollY = next;
-    this.root?.invalidate(false);
+    this.root?.invalidate(false, null, 'scroll');
   }
 
   constructor(props, app) {
@@ -2856,7 +2906,7 @@ export class TextAreaNode extends TextInputNode {
     super.applyProps(newProps, oldProps);
     if (newProps.rows !== before.rows) {
       this.yoga.markDirty();
-      this.root?.invalidate(true);
+      this.root?.invalidate(true, null, 'props');
     }
   }
 
@@ -2874,7 +2924,7 @@ export class TextAreaNode extends TextInputNode {
     const next = Math.min(Math.max(0, this._scrollY + dy), max);
     if (next === this._scrollY) return;
     this._scrollY = next;
-    this.root?.invalidate(false);
+    this.root?.invalidate(false, null, 'scroll');
   }
 
   /** Visual lines that fit in the viewport — one Page keypress worth. */
@@ -3112,7 +3162,7 @@ export class WindowNode extends Node {
     // ask before anything can be anchored to it, so the first popup is
     // placed as well as the second
     this._refreshScreenOrigin();
-    this.invalidate(true);
+    this.invalidate(true, null, 'mount');
   }
 
   /**
@@ -3224,7 +3274,7 @@ export class WindowNode extends Node {
     if (typeof wnd.on !== 'function') return;
     wnd.on('resize', (ev) => {
       this.needsLayout = true;
-      this.invalidate(true);
+      this.invalidate(true, null, 'resize');
       // a move or a reparent arrives the same way, and either changes where
       // popups anchored to this window belong
       this._refreshScreenOrigin();
@@ -3232,6 +3282,7 @@ export class WindowNode extends Node {
     });
     // the frame clock emits 'draw' when the backing store content is invalid
     wnd.on('draw', () => {
+      (this._frameReasons ??= new Set()).add('expose');
       this.needsPaint = true;
       this.flush();
     });
@@ -3447,6 +3498,7 @@ export class WindowNode extends Node {
     this.invalidate(
       layoutChanged || geometryChanged,
       ownPaintChanged ? this : NO_DAMAGE,
+      'props',
     );
   }
 
@@ -3480,7 +3532,7 @@ export class WindowNode extends Node {
     // invalidate anyway, but a React prop change does not — and a transition
     // no one schedules only runs when something else dirties the window,
     // by which time its start is stale and it snaps to the end.
-    this.invalidate(false, damageForAnimation(node));
+    this.invalidate(false, damageForAnimation(node), 'animation');
   }
 
   /**
@@ -3511,7 +3563,7 @@ export class WindowNode extends Node {
     // claimed too — one just landed on its final value and that last frame
     // still has to paint it, which is why every transition used to end with a
     // full-window repaint.
-    for (const claim of claims) this.invalidate(false, claim);
+    for (const claim of claims) this.invalidate(false, claim, 'animation');
   }
 
   setHidden(hidden) {
@@ -3534,8 +3586,13 @@ export class WindowNode extends Node {
    *    repaints in full. Partial painting is therefore opt-in per call
    *    site, and forgetting to pass a node costs speed rather than
    *    correctness.
+   *
+   * `reason` is one word from INVALIDATE_REASONS saying *why* — purely
+   * diagnostic, collected per frame into `_lastReasons` so the frame log,
+   * REACT_X11_DEBUG_PAINT=full and the tracer can attribute a repaint.
+   * Omitting it costs nothing but attribution.
    */
-  invalidate(layoutChanged, damage = null) {
+  invalidate(layoutChanged, damage = null, reason = null) {
     if (this.destroyed || !this.window) return;
     if (!layoutChanged && damage === NO_DAMAGE) {
       // Nothing this node draws changed, so it contributes no region — and
@@ -3549,6 +3606,14 @@ export class WindowNode extends Node {
       // change records its own region and schedules its own frame.
       return;
     }
+    if (reason) {
+      if (DEV && !INVALIDATE_REASONS.has(reason)) {
+        console.warn(
+          `react-x11: invalidate() got unknown reason ${JSON.stringify(reason)}`,
+        );
+      }
+      (this._frameReasons ??= new Set()).add(reason);
+    }
     if (layoutChanged) this.needsLayout = true;
     // A layout change with no bound named repaints everything, because a
     // reflow can move any node and one that moved leaves stale pixels at a
@@ -3558,6 +3623,15 @@ export class WindowNode extends Node {
     // so both the old and the new position of anything that moved are inside
     // the bound. Scrolling is the case that matters: it reflows a viewport's
     // contents and nothing else, and it happens at input rate.
+    if (!damage && this._damage !== FULL_DAMAGE && debugPaint === 'full') {
+      // This call is what makes the coming frame unbounded, so this stack —
+      // not flush's — is the one that answers "who repainted the window".
+      // Captured only under the debug switch: stacks are not free.
+      this._fullRepaintCause = {
+        reason: reason ?? '(no reason given)',
+        stack: new Error('invalidated here').stack,
+      };
+    }
     if (layoutChanged && !damage) this._damage = FULL_DAMAGE;
     else if (!layoutChanged && !damage) this._damage = FULL_DAMAGE;
     else if (this._damage !== FULL_DAMAGE) {
@@ -3618,10 +3692,26 @@ export class WindowNode extends Node {
     if (!this.needsPaint) return;
     this.needsPaint = false;
     const damage = this._takeDamage(width, height);
+    if (debugPaint === 'full' && !damage && width > 0 && height > 0) {
+      // Silent full-window repaints are the perf bug class this renderer
+      // actually has (see AGENTS.md); this is what surfaces them. The stack
+      // is the invalidate() call that made the frame unbounded, not this
+      // flush — flush is always the same place.
+      const cause = this._fullRepaintCause;
+      console.warn(
+        `react-x11: full-window repaint (${width}x${height}) ` +
+          `reasons=${this._lastReasons?.join('+') || '(none)'}` +
+          (cause ? `\n${cause.stack}` : ''),
+      );
+    }
+    this._fullRepaintCause = null;
     if (typeof this.window.getContext !== 'function') return; // headless mock
     // ntk getContext creates a fresh context (with window-event
     // subscriptions) on every call — cache one per window
     const ctx = (this._ctx ??= this.window.getContext('2d'));
+    const frameHook = traceHooks.frame;
+    const started = frameHook ? performance.now() : 0;
+    if (debugPaint) this._flashTick = (this._flashTick ?? 0) + 1;
     // One pass per damage rect, and a single pass over the whole window when
     // there is no bound. Each pass clips to one rect rather than to all of
     // them at once, which is what keeps ntk's server-side rectangular-clip
@@ -3629,6 +3719,15 @@ export class WindowNode extends Node {
     // falls back to rasterizing a full-surface mask.
     for (const rect of damage ?? [null]) {
       this._paintRegion(ctx, rect, width, height);
+    }
+    if (frameHook) {
+      frameHook({
+        root: this,
+        rects: damage,
+        reasons: this._lastReasons,
+        start: started,
+        end: performance.now(),
+      });
     }
   }
 
@@ -3664,6 +3763,19 @@ export class WindowNode extends Node {
         ctx.fillStyle = 'rgba(41, 128, 185, 0.35)';
         ctx.fillRect(r.x, r.y, r.width, r.height);
       }
+      if (debugPaint) {
+        // Stroke the pass's rect in this frame's colour ("repaint rainbow"):
+        // a region repainting every frame strobes, one that repaints once
+        // leaves a single outline behind. Inset a pixel so the stroke
+        // survives the clip on all four sides.
+        const r = damage ?? { x: 0, y: 0, width, height };
+        ctx.strokeStyle =
+          FLASH_COLORS[(this._flashTick ?? 0) % FLASH_COLORS.length];
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.rect(r.x + 1, r.y + 1, r.width - 2, r.height - 2);
+        ctx.stroke();
+      }
     } finally {
       this._paintDamage = null;
       if (damage) ctx.restore();
@@ -3686,8 +3798,17 @@ export class WindowNode extends Node {
     // REACT_X11_DEBUG_LAYOUT to report; null means it repainted everything.
     // `_lastDamage` is the box around the rects, which is what a caller
     // wanting one number for "where did this frame paint" means by it.
+    // `_lastReasons` is why: every reason invalidate() was given since the
+    // previous frame, for the frame log and the full-repaint warning.
     this._lastDamage = null;
     this._lastDamageRects = null;
+    const reasons = this._frameReasons;
+    if (reasons?.size) {
+      this._lastReasons = [...reasons];
+      reasons.clear();
+    } else {
+      this._lastReasons = EMPTY_REASONS;
+    }
     if (damage === FULL_DAMAGE || !damage) return null;
     const rects = [];
     for (const claimed of damage) {
@@ -3725,7 +3846,7 @@ export class WindowNode extends Node {
   setHighlight(node) {
     if (this._highlight === node) return;
     this._highlight = node;
-    this.invalidate(false);
+    this.invalidate(false, null, 'highlight');
   }
 
   /** REACT_X11_DEBUG_LAYOUT=1: outline every drawn node, color by depth. */

--- a/src/richnodes.js
+++ b/src/richnodes.js
@@ -67,7 +67,7 @@ class DocumentViewNode extends Node {
     if (this.destroyed) return;
     this._laidOutWidth = -1;
     this.yoga?.markDirty();
-    this.root?.invalidate(true);
+    this.root?.invalidate(true, null, 'content');
   }
 
   _source() {
@@ -295,7 +295,7 @@ export class SvgNode extends Node {
     // markDirty is only legal on nodes with a measure function (it is
     // unset when width and height are both fixed)
     if (this._hasMeasure) this.yoga?.markDirty();
-    this.root?.invalidate(true);
+    this.root?.invalidate(true, null, 'props');
   }
 
   _ensureView() {
@@ -392,7 +392,7 @@ export class TexNode extends Node {
   _textContentChanged() {
     this._boxKey = null;
     this.yoga?.markDirty();
-    this.root?.invalidate(true);
+    this.root?.invalidate(true, null, 'text');
   }
 
   _ensureBox() {
@@ -426,7 +426,7 @@ export class TexNode extends Node {
       newProps.displayMode !== before.displayMode
     ) {
       this.yoga.markDirty();
-      this.root?.invalidate(true);
+      this.root?.invalidate(true, null, 'props');
     }
   }
 

--- a/src/trace-registry.js
+++ b/src/trace-registry.js
@@ -1,0 +1,51 @@
+// The seam between the renderer and the optional debug module.
+//
+// Reconciler.js and nodes.js import this file, so it has to stay safe to
+// bundle for the browser playground: no node builtins, no side effects,
+// nothing but a registry of live connections and a pair of hook slots. The
+// heavy half (protocol parsing, sinks, file writing) lives in debug.js and
+// is only loaded when the user imports `react-x11/debug` or sets
+// REACT_X11_TRACE.
+
+/** ntk Apps the renderer currently draws through. */
+const apps = new Set();
+const appListeners = new Set();
+
+export function registerApp(app) {
+  if (!app || apps.has(app)) return;
+  apps.add(app);
+  for (const fn of [...appListeners]) fn(app);
+}
+
+/** A root that owned its connection closed it; stop offering it to traces. */
+export function unregisterApp(app) {
+  apps.delete(app);
+}
+
+/**
+ * Call `fn` for every current connection and every future one, until the
+ * returned function is called. This is how a trace with no explicit `app`
+ * follows the renderer: `createRoot()` may not have connected yet when the
+ * trace starts.
+ */
+export function onApp(fn) {
+  appListeners.add(fn);
+  for (const app of apps) fn(app);
+  return () => appListeners.delete(fn);
+}
+
+/**
+ * Hook slots the hot paths poll. A slot is null almost always, and the cost
+ * of an unset hook is one property read — which is the whole design: the
+ * frame loop must not pay for a tracer nobody started.
+ *
+ *  - `frame({ root, rects, reasons, start, end })` — after a window painted.
+ *    `rects` is the damage list, null for a full repaint; times come from
+ *    `performance.now()`.
+ *  - `commitStart()` / `commitEnd()` — around a React commit.
+ */
+export const hooks = {
+  frame: null,
+  commitStart: null,
+  commitEnd: null,
+};

--- a/test/debug-paint.test.js
+++ b/test/debug-paint.test.js
@@ -1,0 +1,164 @@
+// REACT_X11_DEBUG_PAINT (issue #127): damage-rect flashing, the
+// full-repaint warning with its captured stack, and the invalidation
+// reasons both of them print. Headless over the mock app; the switch is
+// flipped through setDebugPaint, the runtime seam for the once-read env.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import ReactX11 from '../src/index.js';
+import { setDebugPaint } from '../src/nodes.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+function mount(children, windowProps = {}) {
+  const app = createMockApp();
+  ReactX11.render(
+    h('window', { width: 200, height: 100, ...windowProps }, children),
+    null,
+    app,
+  );
+  return { app, wnd: app.windows[0], root: app.windows[0]._reactX11Node };
+}
+
+const strokes = (wnd) =>
+  wnd.ctx.ops.filter(([op, , width]) => op === 'stroke' && width === 2);
+
+// stateful (a :hover block), so setStyleState really repaints
+const hoverBox = (ref) =>
+  h('box', {
+    ref,
+    style: {
+      width: 80,
+      height: 40,
+      backgroundColor: '#111111',
+      ':hover': { backgroundColor: '#333333' },
+    },
+  });
+
+test('flashing strokes each damage rect, in a colour that rotates', async (t) => {
+  setDebugPaint('1');
+  t.after(() => setDebugPaint(''));
+  const ref = React.createRef();
+  const { wnd } = mount(hoverBox(ref));
+  await tick(); // mount frame paints (and flashes) once
+  wnd.ctx.ops.length = 0;
+
+  // a bounded repaint: restyle the box twice, two frames, two colours
+  ref.current.setStyleState(':hover', true);
+  await tick();
+  const first = strokes(wnd);
+  assert.strictEqual(first.length, 1, 'one damage rect, one flash stroke');
+  wnd.ctx.ops.length = 0;
+  ref.current.setStyleState(':hover', false);
+  await tick();
+  const second = strokes(wnd);
+  assert.strictEqual(second.length, 1);
+  assert.notStrictEqual(
+    first[0][1],
+    second[0][1],
+    'the flash colour rotates per frame',
+  );
+});
+
+test('flashing is off (and free) by default', async () => {
+  const ref = React.createRef();
+  const { wnd } = mount(hoverBox(ref));
+  await tick();
+  wnd.ctx.ops.length = 0;
+  ref.current.setStyleState(':hover', true);
+  await tick();
+  const painted = wnd.ctx.ops.some(([op]) => op === 'fillRect');
+  assert.ok(painted, 'the hover restyle repainted');
+  assert.strictEqual(strokes(wnd).length, 0);
+});
+
+test('=full warns on a full-window repaint, naming reason and origin', async (t) => {
+  setDebugPaint('full');
+  t.after(() => setDebugPaint(''));
+  const warnings = [];
+  const original = console.warn;
+  console.warn = (...args) => warnings.push(args.join(' '));
+  t.after(() => (console.warn = original));
+
+  const { root } = mount(h('box', { style: { flexGrow: 1 } }));
+  await tick(); // the mount frame is legitimately full — and says why
+  assert.ok(
+    warnings.some(
+      (w) => w.includes('full-window repaint') && w.includes('mount'),
+    ),
+    `mount frame warns with its reason, got: ${warnings.join('\n')}`,
+  );
+
+  warnings.length = 0;
+  function culpritInvalidate() {
+    root.invalidate(false, null, 'highlight');
+  }
+  culpritInvalidate();
+  await tick();
+  const warning = warnings.find((w) => w.includes('full-window repaint'));
+  assert.ok(warning, 'an unbounded invalidate warns');
+  assert.match(warning, /reasons=highlight/);
+  assert.match(
+    warning,
+    /culpritInvalidate/,
+    'the stack is the invalidate call, not the flush',
+  );
+});
+
+test('a bounded frame does not warn under =full', async (t) => {
+  setDebugPaint('full');
+  t.after(() => setDebugPaint(''));
+  const warnings = [];
+  const original = console.warn;
+  console.warn = (...args) => warnings.push(args.join(' '));
+  t.after(() => (console.warn = original));
+
+  const ref = React.createRef();
+  mount(
+    h('box', {
+      ref,
+      style: { width: 80, height: 40, backgroundColor: '#111111' },
+    }),
+  );
+  await tick();
+  warnings.length = 0;
+  ref.current.setStyleState(':hover', true); // bounded: the box's own rect
+  await tick();
+  assert.strictEqual(warnings.length, 0, warnings.join('\n'));
+});
+
+test('a frame collects reasons and clears them for the next one', async () => {
+  const ref = React.createRef();
+  const { root } = mount(
+    h(
+      'scrollview',
+      { ref, style: { flexGrow: 1 } },
+      ...Array.from({ length: 10 }, (_, i) =>
+        h('box', { key: i, style: { height: 40, flexShrink: 0 } }),
+      ),
+    ),
+  );
+  await tick();
+  ref.current.scrollTo(60);
+  await tick();
+  assert.deepStrictEqual(root._lastReasons, ['scroll']);
+
+  // nothing happened since: the next frame reports no stale reasons
+  root.needsPaint = true;
+  root._scheduled = false;
+  root.flush();
+  assert.deepStrictEqual(root._lastReasons, []);
+});
+
+test('an unknown reason warns in DEV instead of vanishing silently', async (t) => {
+  const warnings = [];
+  const original = console.warn;
+  console.warn = (...args) => warnings.push(args.join(' '));
+  t.after(() => (console.warn = original));
+  const { root } = mount(h('box', { style: { flexGrow: 1 } }));
+  await tick();
+  root.invalidate(false, null, 'tyop');
+  assert.ok(warnings.some((w) => w.includes('unknown reason')));
+});

--- a/test/trace.test.js
+++ b/test/trace.test.js
@@ -1,0 +1,196 @@
+// The protocol tracer (react-x11/debug, issue #127): request framing and
+// opcode naming against the in-process X server, sink behaviour, and the
+// detach contract. The tracer attaches post-handshake by construction, so
+// there is no auth-cookie case to test — the bytes are gone before it can
+// look.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { readFileSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import React from 'react';
+import ReactX11 from '../src/index.js';
+import { startTrace, startEnvTrace } from '../src/debug.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient, StaticFontSource } from 'ntk';
+
+const require = createRequire(import.meta.url);
+const fontDir = join(
+  dirname(require.resolve('katex/package.json')),
+  'dist',
+  'fonts',
+);
+
+async function createHeadlessApp() {
+  const server = xserver.createServer({ width: 640, height: 480 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const fontSource = new StaticFontSource();
+  fontSource.add(readFileSync(join(fontDir, 'KaTeX_Main-Regular.ttf')), {
+    family: 'Test Main',
+  });
+  fontSource.alias('sans-serif', 'Test Main');
+  const app = await createClient({ stream: clientEnd, fontSource });
+  return app;
+}
+
+const settle = (app, roundTrips = 1) =>
+  Array.from({ length: roundTrips }).reduce(
+    (chain) =>
+      chain.then(
+        () =>
+          new Promise((resolve, reject) =>
+            app.X.GetInputFocus((err) => (err ? reject(err) : resolve())),
+          ),
+      ),
+    Promise.resolve(),
+  );
+
+function render(element, app) {
+  return new Promise((resolve) => {
+    ReactX11.render(element, (instance) => resolve(instance), app);
+  });
+}
+
+test('counts framed requests and decodes their names exactly', async () => {
+  const app = await createHeadlessApp();
+  try {
+    await settle(app); // a quiet, aligned stream before attaching
+    const trace = startTrace({ app });
+    assert.strictEqual(trace.stats.requests, 0);
+    assert.strictEqual(trace.stats.bytesOut, 0);
+
+    // GetInputFocus is a 4-byte request with a reply: the counts it should
+    // produce are exact, which pins both the framing and the naming.
+    await settle(app, 2);
+    assert.strictEqual(trace.stats.requests, 2);
+    assert.strictEqual(trace.stats.bytesOut, 8);
+    assert.strictEqual(trace.stats.replies, 2);
+    assert.strictEqual(trace.stats.byOpcode.get('GetInputFocus'), 2);
+
+    const stats = trace.stop();
+    // stopping detaches: nothing after it is counted
+    await settle(app, 2);
+    assert.strictEqual(stats.requests, 2);
+    assert.strictEqual(trace.stats.requests, 2);
+  } finally {
+    await app.close();
+  }
+});
+
+test('a rendered tree shows up as named core and Render requests', async () => {
+  const app = await createHeadlessApp();
+  try {
+    await settle(app);
+    const trace = startTrace({ app });
+    await render(
+      React.createElement(
+        'window',
+        { width: 300, height: 200, style: { backgroundColor: '#204060' } },
+        React.createElement('box', {
+          style: { width: 80, height: 40, backgroundColor: '#e74c3c' },
+        }),
+      ),
+      app,
+    );
+    await settle(app, 3);
+    const stats = trace.stop();
+    assert.ok(stats.byOpcode.get('CreateWindow') >= 1, 'window creation');
+    const names = [...stats.byOpcode.keys()];
+    assert.ok(
+      names.some((n) => n.startsWith('Render.')),
+      `paint should issue Render requests, saw: ${names.join(', ')}`,
+    );
+    // decoded, not numeric: nothing should have fallen back to extN.M
+    assert.ok(
+      names.every((n) => !/^core\d/.test(n)),
+      `unnamed core opcode in ${names.join(', ')}`,
+    );
+    assert.ok(stats.bytesIn > 0);
+  } finally {
+    ReactX11.unmountComponentAtNode(app);
+    await app.close();
+  }
+});
+
+test('chrome sink writes a valid trace with commits, frames and requests', async () => {
+  const app = await createHeadlessApp();
+  const path = join(mkdtempSync(join(tmpdir(), 'rx11-trace-')), 'trace.json');
+  try {
+    await settle(app);
+    const trace = startTrace({ app, sink: 'chrome', path });
+    const instance = await render(
+      React.createElement(
+        'window',
+        { width: 300, height: 200 },
+        React.createElement('box', {
+          style: { width: 80, height: 40, backgroundColor: '#27ae60' },
+        }),
+      ),
+      app,
+    );
+    // run the scheduled frame deterministically (see AGENTS.md on the
+    // stalled frame clock under synthetic input)
+    const root = instance._reactX11Node;
+    root._scheduled = false;
+    root.flush();
+    await settle(app, 2);
+    trace.stop();
+
+    const parsed = JSON.parse(readFileSync(path, 'utf8'));
+    assert.ok(Array.isArray(parsed.traceEvents));
+    const phases = new Set(parsed.traceEvents.map((e) => e.ph));
+    assert.ok(phases.has('i'), 'request instants');
+    assert.ok(phases.has('X'), 'slices');
+    const names = new Set(parsed.traceEvents.map((e) => e.name));
+    assert.ok(names.has('commit'), 'a React commit slice');
+    assert.ok(names.has('frame'), 'a painted frame slice');
+    const frame = parsed.traceEvents.find((e) => e.name === 'frame');
+    assert.ok(
+      frame.args.reasons.includes('mount'),
+      'the first frame is the mount',
+    );
+  } finally {
+    ReactX11.unmountComponentAtNode(app);
+    await app.close();
+  }
+});
+
+test('seq2stack maps an X error back to the request that caused it', async () => {
+  const app = await createHeadlessApp();
+  const path = join(mkdtempSync(join(tmpdir(), 'rx11-trace-')), 'trace.json');
+  try {
+    await settle(app);
+    const trace = startTrace({ app, sink: 'chrome', path, seq2stack: true });
+    // a request against a drawable that does not exist errors asynchronously
+    function offendingRequest() {
+      app.X.GetGeometry(0x7fffffff, () => {});
+    }
+    offendingRequest();
+    await settle(app, 2);
+    trace.stop();
+    const parsed = JSON.parse(readFileSync(path, 'utf8'));
+    const error = parsed.traceEvents.find((e) =>
+      String(e.name).startsWith('Error'),
+    );
+    assert.ok(error, 'the error reached the trace');
+    assert.match(error.name, /GetGeometry/);
+    assert.match(String(error.args.stack), /offendingRequest/);
+  } finally {
+    await app.close();
+  }
+});
+
+test('is inert on a mock app and rejects unknown sinks', async () => {
+  const trace = startTrace({ app: createMockApp() }); // no pack_stream: no-op
+  assert.strictEqual(trace.stats.requests, 0);
+  trace.stop();
+  assert.throws(() => startTrace({ sink: 'xml' }), /unknown trace sink/);
+  assert.strictEqual(startEnvTrace('nonsense'), null);
+  const env = startEnvTrace('summary');
+  assert.ok(env);
+  env.stop();
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -7,6 +7,7 @@
  * thing that keeps hand-written declarations honest.
  */
 import React, { useRef, useState } from 'react';
+import { startTrace } from 'react-x11/debug';
 import {
   Button,
   Canvas3D,
@@ -391,6 +392,17 @@ async function main() {
   render(<Popup />, () => {}, root.app);
   render(<Events />, () => {}, root.app);
   unmountComponentAtNode(root.app);
+
+  // react-x11/debug — the protocol tracer
+  const trace = startTrace({ sink: 'chrome', path: '/tmp/t.json' });
+  const everything = startTrace();
+  const one = startTrace({ app: root.app, seq2stack: true });
+  const stats = trace.stop();
+  const n: number = stats.requests + stats.bytesOut + stats.replies;
+  const perOpcode: Map<string, number> = everything.stop().byOpcode;
+  // @ts-expect-error — not a sink
+  startTrace({ sink: 'xml' });
+  void [n, perOpcode, one.stats.errors, one.stop()];
 }
 
 void main;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,8 @@
     "paths": {
       "react-x11": ["./src/index.d.ts"],
       "react-x11/jsx-runtime": ["./src/jsx-runtime.d.ts"],
-      "react-x11/jsx-dev-runtime": ["./src/jsx-dev-runtime.d.ts"]
+      "react-x11/jsx-dev-runtime": ["./src/jsx-dev-runtime.d.ts"],
+      "react-x11/debug": ["./src/debug.d.ts"]
     }
   },
   "include": ["src/**/*.d.ts", "test/types/**/*.tsx", "test/types/**/*.ts"]

--- a/website/scripts/build-demo-bundles.mjs
+++ b/website/scripts/build-demo-bundles.mjs
@@ -77,6 +77,15 @@ const nodeOnlyModules = {
         path: path.join(stubsDir, 'node-only.js'),
       }),
     );
+    // The protocol tracer writes files (node:fs); like the two above it is
+    // dynamically imported behind an env var the playground never sets. The
+    // importer check keeps the stub from eating some dependency's own
+    // ./debug.js.
+    build.onResolve({ filter: /^\.\/debug\.js$/ }, (args) =>
+      args.importer.startsWith(path.join(repoRoot, 'src'))
+        ? { path: path.join(stubsDir, 'node-only.js') }
+        : null,
+    );
   },
 };
 

--- a/website/scripts/stubs/node-only.js
+++ b/website/scripts/stubs/node-only.js
@@ -10,4 +10,11 @@ export async function prepare() {}
 export function connect() {}
 export function attachHighlightAgent() {}
 export function install() {}
+// debug.js (the REACT_X11_TRACE tracer — writes files, so node-only)
+export function startTrace() {
+  return { stats: {}, stop: () => ({}) };
+}
+export function startEnvTrace() {
+  return null;
+}
 export default {};

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -181,6 +181,7 @@ const ORDER = [
   'events.md',
   'typescript.md',
   'devtools.md',
+  'debugging.md',
   'click-to-component.md',
   'glx.md',
   'ecosystem.md',


### PR DESCRIPTION
Closes #127.

Three diagnostics with the same character: the hard half already existed, the visible half never shipped. All of it is built to cost **nothing when off** — the env switches are read once at startup (a `process.env` read is a real environment lookup, and these sit on `invalidate()` and the paint loop), the tracer module is only imported on demand, stacks are only captured under the switches, and a frame with no recorded reasons shares one frozen empty list.

## 1. Protocol tracing — `REACT_X11_TRACE` + `react-x11/debug`

The bench's X11 stream splitter (`scripts/bench/xcount.js`) promoted to a runtime feature, BIG-REQUESTS and GenericEvent aware:

- `REACT_X11_TRACE=summary` — opcode histogram + byte totals at exit
- `REACT_X11_TRACE=requests` — one stderr line per decoded request (`x11 → Render.CompositeGlyphs32 152B`) and per painted frame (`frame 412: 320x24@8,40 reasons=style-state`); X errors decoded, naming the failing request
- `REACT_X11_TRACE=chrome:/tmp/t.json` — Chrome Trace Event JSON for Perfetto / `about:tracing`: React commits and painted frames as slices, requests and errors as instant events — so "this interaction sent 4000 requests" becomes "3600 were `CompositeGlyphs32` inside one commit"
- `+stacks` (on `requests`/`chrome`) — a JS stack per request via node-x11's seq2stack, installable on a live client, so an **asynchronous X error names the call that sent it**

Programmatic form, following every renderer connection or one given `app`:

```js
import { startTrace } from 'react-x11/debug';
const trace = startTrace({ sink: 'chrome', path: '/tmp/t.json' });
// ...
const { requests, bytesOut, replies, byOpcode } = trace.stop();
```

**Redaction by construction:** the tracer attaches after the handshake — the connection-setup packet carrying the X auth cookie is written before either hook exists — and it records opcode, length and direction, never payload bytes.

The seam is `src/trace-registry.js` (a Set of live connections + three hook slots), which is all the Reconciler and nodes.js ever import; the heavy half lives in `src/debug.js`, stubbed out of the playground bundle like the other node-only modules.

## 2. Damage flashing — `REACT_X11_DEBUG_PAINT`

`=1` strokes each frame's damage rects in a colour rotating per frame — a region repainting every frame strobes; one that painted once leaves a single quiet outline. `=full` additionally warns whenever a frame degrades to a full-window repaint — the renderer's main perf bug class (see `66b951b`), previously surfaced by nothing — with the frame's reasons and **the stack of the `invalidate()` call that made it unbounded**, not flush's.

Rendered by this PR's code (in-process X server, `GetImage` readback) at f6e7021:

| mount frame (legitimately full) | hover row 2 (bounded, next colour) | hover moves 2 → 5 (two rects, next colour) |
| --- | --- | --- |
| ![flash-mount](https://github.com/user-attachments/assets/29602de6-6361-4fb0-97c7-0ad55febbe91) | ![flash-hover-row2](https://github.com/user-attachments/assets/f04dbe34-62d3-46b4-9d62-baee7d3a0139) | ![flash-hover-row5](https://github.com/user-attachments/assets/7ed45dce-3074-4c9e-abaa-efb28dd13bab) |

## 3. Invalidation reasons

`invalidate(layoutChanged, damage, reason)` — one word from a closed set (`props`, `style-state`, `theme`, `animation`, `scroll`, `text`, `content`, `child-list`, `focus`, `caret`, `resize`, `mount`, `expose`, `highlight`), validated in DEV, collected per frame into `root._lastReasons`. All ~35 internal call sites annotated; the frame log (`examples/stress/perf.js`), the trace and the full-repaint warning print them, so "what made this frame repaint" is finally answerable.

## Tests / checks

- `test/trace.test.js` — exact framing/naming against the in-process server (2 × `GetInputFocus` → exactly 2 requests, 8 bytes, 2 replies), a rendered tree producing named core + `Render.*` requests, chrome sink validity (commit/frame slices, request instants, mount reason), seq2stack mapping a `BadDrawable` back to the offending call, detach-on-stop, inert on mock apps
- `test/debug-paint.test.js` — flash strokes + colour rotation, off-by-default is stroke-free on a real repaint, `=full` warning carries reason + origin stack, bounded frames don't warn, reasons collect and clear per frame, unknown reasons warn in DEV
- `npm test` 286/286 · `npm run typecheck` · `npm run lint` · `npm run bench -- --check` no regressions · website gates (bundle/demos/share) green
- docs: `docs/debugging.md` (+ sidebar), AGENTS.md pointer
