### PR TITLE
perf: scroll a viewport by blitting the surviving band, repainting only the exposed strip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -426,6 +426,26 @@ onDraw>`, `value`, `placeholder`. `children` and event handlers are
   reason: a scrollview's content extent is not what reaches the surface, and
   mid-scroll it can be ninety thousand pixels away.
 
+  On top of that bound sits the **scroll-blit fast path** (issue #138,
+  `_applyScrollBlits`): when a frame is a _pure_ single-axis scroll of one
+  viewport, the surviving band is `CopyArea`'d inside ntk's backing pixmap
+  (`Window.scrollRegion`, ntk >= 4.3, feature-detected) and the frame's
+  damage narrows to the exposed strip plus the scrollbar repair rects — per
+  wheel notch on a 500-row list that is 44 requests and 0.065 Mpx of
+  Composite work instead of 89 and 0.33. Everything about it is a gate that
+  falls back to the plain repaint: too-small viewports and page-sized jumps
+  are not worth the bookkeeping (`SCROLL_BLIT_MIN_AREA`,
+  `SCROLL_BLIT_MIN_KEEP`), fractional offsets and diagonal deltas cannot
+  blit, any other claim near the viewport (checked at `invalidate` time,
+  _before_ rects coalesce and hide it), a border/borderRadius on the
+  scrollview, an overlapping non-descendant, a debug overlay or DevTools
+  highlight all bail. The invariant, pinned by a pixel test in
+  `test/scroll-blit.test.js`, is that a blitted frame is byte-identical to
+  the repaint it replaced; `REACT_X11_NO_SCROLL_BLIT=1` turns the path off
+  for A/B measurement and as field first aid. The bench's scroll scenario
+  measures the _fallback_ (CI installs ntk from npm) — re-save the baseline
+  when the ntk floor gains `scrollRegion`, so the diff records the win.
+
   **Where scrolling actually spent its time was neither of those.** Profiling a
   50,000-row table found the cost in ntk's `clip()`: intersecting a clip
   allocated a full-surface a8 pixmap, rasterized into it and composited the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -408,10 +408,12 @@ onDraw>`, `value`, `placeholder`. `children` and event handlers are
 
   Presentation is ntk's job, and the two halves have to match to be worth
   anything: **ntk >= 3.10.2** copies just the rects the drawing reported, where
-  earlier versions blit the whole window however little changed. That is the
-  floor in `package.json` for this reason, not for an API — against 3.10.1 the
-  region list still computes and paints correctly, it just does not reach the
-  screen any faster (NEXT_STEPS §8 item 4). The reporting channel is the clip:
+  earlier versions blit the whole window however little changed. That was the
+  floor in `package.json` for a long time for this reason rather than for an
+  API — against 3.10.1 the region list still computes and paints correctly, it
+  just does not reach the screen any faster (NEXT_STEPS §8 item 4). The floor
+  is now **4.3.0**, and that one _is_ an API: `Window.scrollRegion`, which the
+  scroll-blit path below calls. The reporting channel is the clip:
   ntk takes each operation's clip rectangle as the region it might have touched,
   so a pass that is not clipped reports nothing and gives up the bound for the
   whole frame — which is why the frame clips per rect even though culling
@@ -429,7 +431,9 @@ onDraw>`, `value`, `placeholder`. `children` and event handlers are
   On top of that bound sits the **scroll-blit fast path** (issue #138,
   `_applyScrollBlits`): when a frame is a _pure_ single-axis scroll of one
   viewport, the surviving band is `CopyArea`'d inside ntk's backing pixmap
-  (`Window.scrollRegion`, ntk >= 4.3, feature-detected) and the frame's
+  (`Window.scrollRegion`, ntk >= 4.3.0 — the floor, though the call stays
+  feature-detected so a mock or a deduped older copy degrades rather than
+  throws) and the frame's
   damage narrows to the exposed strip plus the scrollbar repair rects — per
   wheel notch on a 500-row list that is 44 requests and 0.065 Mpx of
   Composite work instead of 89 and 0.33. Everything about it is a gate that
@@ -442,9 +446,12 @@ onDraw>`, `value`, `placeholder`. `children` and event handlers are
   highlight all bail. The invariant, pinned by a pixel test in
   `test/scroll-blit.test.js`, is that a blitted frame is byte-identical to
   the repaint it replaced; `REACT_X11_NO_SCROLL_BLIT=1` turns the path off
-  for A/B measurement and as field first aid. The bench's scroll scenario
-  measures the _fallback_ (CI installs ntk from npm) — re-save the baseline
-  when the ntk floor gains `scrollRegion`, so the diff records the win.
+  for A/B measurement and as field first aid. The bench's scroll scenario is
+  baselined **with the blit live**, and that is what fences it: `--check`
+  only fails on an _increase_, so against fallback numbers a change that
+  silently stopped the fast path from firing would pass unnoticed. The fence
+  is verifiable — `REACT_X11_NO_SCROLL_BLIT=1 npm run bench -- --check` must
+  fail, and does (887 requests and 3.28 Mpx against a 437 / 0.65 baseline).
 
   **Where scrolling actually spent its time was neither of those.** Profiling a
   50,000-row table found the cost in ntk's `clip()`: intersecting a clip

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -105,6 +105,14 @@ Full repaints are the renderer's main performance bug class (see
 them. Expected full repaints exist too — a resize, the first frame after a
 mount, ntk invalidating its backing store — and their reasons say so.
 
+## `REACT_X11_NO_SCROLL_BLIT`
+
+Disables the scroll-blit fast path (a pure scroll `CopyArea`s the
+surviving band and repaints only the exposed strip), so a scroll frame
+repaints its whole viewport again. For measuring the blit against the
+plain path on the same build, and as first aid if a scroll ever
+misrenders. Read once at startup, like the switches above.
+
 ## Invalidation reasons
 
 Every internal `invalidate()` call now names why it ran, from a small

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^4.2.0",
+        "ntk": "^4.3.0",
         "react-reconciler": "^0.33.0"
       },
       "devDependencies": {
@@ -3676,9 +3676,9 @@
       }
     },
     "node_modules/ntk": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-4.2.0.tgz",
-      "integrity": "sha512-eEyMGldEierK/dTTV+Atf2ALkmvWbJWtHzhjWRTEbBSgp2DEikvohSnZ1FKzuCdYknFfMYZmPblvcwOKUx9ZEA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-4.3.0.tgz",
+      "integrity": "sha512-A8G5O963J/X7QWFByStYdGPg8iRQfuMkjITOuw4Ounc/koWfa011XODJ6mMmcg1yFGq5NsE5CroHiF4D480Hkg==",
       "license": "MIT",
       "dependencies": {
         "bidi-js": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^4.2.0",
+    "ntk": "^4.3.0",
     "react-reconciler": "^0.33.0"
   },
   "peerDependencies": {

--- a/scripts/bench/baseline.json
+++ b/scripts/bench/baseline.json
@@ -32,11 +32,19 @@
     "compositePixels": 224800
   },
   "mount: window with 40 boxes and labels": {
-    "requests": 86,
-    "bytesOut": 3652,
-    "bytesIn": 160,
-    "replies": 3,
+    "requests": 89,
+    "bytesOut": 3752,
+    "bytesIn": 192,
+    "replies": 4,
     "composites": 21,
     "compositePixels": 298240
+  },
+  "scroll: 10 notches over 500 rows": {
+    "requests": 887,
+    "bytesOut": 40772,
+    "bytesIn": 704,
+    "replies": 22,
+    "composites": 211,
+    "compositePixels": 3282640
   }
 }

--- a/scripts/bench/baseline.json
+++ b/scripts/bench/baseline.json
@@ -8,8 +8,8 @@
     "compositePixels": 160000
   },
   "text: paragraph, inside a rect clip": {
-    "requests": 43,
-    "bytesOut": 6064,
+    "requests": 40,
+    "bytesOut": 6040,
     "bytesIn": 32,
     "replies": 1,
     "composites": 1,
@@ -24,8 +24,8 @@
     "compositePixels": 160000
   },
   "shapes: 50 filled rounded boxes": {
-    "requests": 169,
-    "bytesOut": 15008,
+    "requests": 175,
+    "bytesOut": 15056,
     "bytesIn": 32,
     "replies": 1,
     "composites": 51,
@@ -40,11 +40,11 @@
     "compositePixels": 298240
   },
   "scroll: 10 notches over 500 rows": {
-    "requests": 887,
-    "bytesOut": 40772,
+    "requests": 437,
+    "bytesOut": 17732,
     "bytesIn": 704,
     "replies": 22,
-    "composites": 211,
-    "compositePixels": 3282640
+    "composites": 111,
+    "compositePixels": 650000
   }
 }

--- a/scripts/bench/protocol.js
+++ b/scripts/bench/protocol.js
@@ -247,12 +247,13 @@ const SCENARIOS = [
   [
     // Ten wheel notches over a long list, mounted and settled beforehand so
     // only the scrolling is measured. This is the scenario the scroll-blit
-    // fast path (issue #138) exists for: with an ntk that has
-    // Window.scrollRegion the surviving band is CopyArea'd and only the
-    // exposed strip repaints; without one it falls back to repainting the
-    // viewport each notch. The committed baseline is the fallback (CI
-    // installs ntk from npm) — re-save it when the ntk floor gains
-    // scrollRegion, so the diff records the win.
+    // fast path (issue #138) exists for: the surviving band is CopyArea'd
+    // through ntk's Window.scrollRegion and only the exposed strip repaints.
+    //
+    // Baselined with the blit live, which is the whole point of having it
+    // here: --check only fails on an increase, so a change that quietly
+    // stopped the fast path firing would sail past a fallback baseline and
+    // land squarely on this one (887 requests, 3.28 Mpx, against 437/0.65).
     'scroll: 10 notches over 500 rows',
     (() => {
       let root;

--- a/scripts/bench/protocol.js
+++ b/scripts/bench/protocol.js
@@ -59,10 +59,18 @@ async function connect() {
 const settle = (app) =>
   new Promise((resolve) => app.X.GetInputFocus(() => resolve()));
 
-/** Run `fn`, measuring only what it causes (setup is drained first). */
+/** Run `fn`, measuring only what it causes (setup is drained first). A
+ * scenario may be `{ prepare, run }`: `prepare` builds state — a mounted
+ * tree, say — whose cost is drained and *not* measured, so `run` can time
+ * an interaction rather than a mount. */
 async function measure(name, fn) {
   const { app, stats } = await connect();
   await settle(app);
+  if (typeof fn !== 'function') {
+    await fn.prepare(app);
+    await settle(app);
+    fn = fn.run;
+  }
   const mark = {
     requests: stats.requests,
     bytesOut: stats.bytesOut,
@@ -235,6 +243,72 @@ const SCENARIOS = [
       );
       await new Promise((r) => setImmediate(r));
     },
+  ],
+  [
+    // Ten wheel notches over a long list, mounted and settled beforehand so
+    // only the scrolling is measured. This is the scenario the scroll-blit
+    // fast path (issue #138) exists for: with an ntk that has
+    // Window.scrollRegion the surviving band is CopyArea'd and only the
+    // exposed strip repaints; without one it falls back to repainting the
+    // viewport each notch. The committed baseline is the fallback (CI
+    // installs ntk from npm) — re-save it when the ntk floor gains
+    // scrollRegion, so the diff records the win.
+    'scroll: 10 notches over 500 rows',
+    (() => {
+      let root;
+      const frame = () => {
+        root._scheduled = false;
+        root.flush();
+      };
+      return {
+        prepare: async (app) => {
+          const instance = await new Promise((resolve) =>
+            ReactX11.render(
+              React.createElement(
+                'window',
+                { width: W, height: H, style: { backgroundColor: '#f5f6fa' } },
+                React.createElement(
+                  'scrollview',
+                  { style: { flexGrow: 1 } },
+                  Array.from({ length: 500 }, (_, i) =>
+                    React.createElement(
+                      'box',
+                      {
+                        key: i,
+                        style: {
+                          flexDirection: 'row',
+                          flexShrink: 0,
+                          gap: 6,
+                          padding: 4,
+                          backgroundColor: i % 2 ? '#ffffff' : '#eef1f5',
+                        },
+                      },
+                      React.createElement(
+                        'text',
+                        { style: { fontSize: 11 } },
+                        `row ${i}: the quick brown fox`,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              resolve,
+              app,
+            ),
+          );
+          root = instance._reactX11Node;
+          frame();
+        },
+        run: async (app) => {
+          const scroller = root.children[0];
+          for (let i = 0; i < 10; i++) {
+            scroller.scrollBy(48);
+            frame();
+            await new Promise((resolve) => app.X.GetInputFocus(resolve));
+          }
+        },
+      };
+    })(),
   ],
 ];
 

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -112,6 +112,72 @@ const INVALIDATE_REASONS = new Set([
 // property write.
 const EMPTY_REASONS = Object.freeze([]);
 
+// --- scroll blitting (issue #138) ---------------------------------------
+//
+// A pure-scroll frame does not have to repaint the viewport: the band that
+// stays visible is already in ntk's backing pixmap, one CopyArea away from
+// its new position (ntk >= 4.3, Window.scrollRegion). The frame then only
+// repaints the strip the scroll exposed, plus the scrollbar tracks. The
+// gates below decide when that is safe *and* worth it; every failure falls
+// back to today's full-viewport repaint, so the fast path can cost
+// correctness nothing — the worst mistake it can make is not firing.
+
+// Below this viewport area a repaint is one cheap pass and the blit's
+// bookkeeping (a safety walk over the tree, extra damage rects, an extra
+// request) costs more than it saves.
+const SCROLL_BLIT_MIN_AREA = 48 * 1024;
+
+// Escape hatch, read once like the other switches: for measuring the blit
+// against the plain path on the same build, and as first aid if a scroll
+// ever misrenders in the field.
+const NO_SCROLL_BLIT = Boolean(process.env.REACT_X11_NO_SCROLL_BLIT);
+
+// If less than this fraction of the viewport survives the shift, the
+// exposed strip is most of a repaint anyway.
+const SCROLL_BLIT_MIN_KEEP = 0.5;
+
+const rectContains = (outer, inner) =>
+  outer.x <= inner.x &&
+  outer.y <= inner.y &&
+  outer.x + outer.width >= inner.x + inner.width &&
+  outer.y + outer.height >= inner.y + inner.height;
+
+const isIntegerRect = (r) =>
+  Number.isInteger(r.x) &&
+  Number.isInteger(r.y) &&
+  Number.isInteger(r.width) &&
+  Number.isInteger(r.height);
+
+/** `rect` shrunk by `by` on every side. */
+function insetRect(rect, by) {
+  return {
+    x: rect.x + by,
+    y: rect.y + by,
+    width: rect.width - 2 * by,
+    height: rect.height - 2 * by,
+  };
+}
+
+/** The full track strip a scrollbar occupies (thumb travel included), with
+ * a pixel of slop for the thumb's antialiased corners. */
+function scrollbarTrackRect(bar) {
+  const rect =
+    bar.axis === 'x'
+      ? {
+          x: bar.trackStart,
+          y: bar.crossStart,
+          width: bar.trackLength,
+          height: SCROLLBAR_WIDTH,
+        }
+      : {
+          x: bar.crossStart,
+          y: bar.trackStart,
+          width: SCROLLBAR_WIDTH,
+          height: bar.trackLength,
+        };
+  return insetRect(rect, -1);
+}
+
 // REACT_X11_DEBUG_PAINT: each frame strokes its damage rects in the next of
 // these, so a region repainting every frame strobes visibly.
 const FLASH_COLORS = [
@@ -1740,6 +1806,18 @@ export class ScrollViewNode extends Node {
           : clampScroll(want.y, this._maxScroll('y')),
     };
     if (next.x === this.scrollX && next.y === this.scrollY) return;
+    const root = this.root;
+    if (root) {
+      // The offsets whose pixels are on screen, captured before the first
+      // change of the frame: the frame's blit fast path (issue #138) shifts
+      // from *these* to wherever layout settles, however many scrollTo
+      // calls land in between.
+      this._pendingBlitFrom ??= { x: this.scrollX, y: this.scrollY };
+      (root._pendingScrolls ??= new Set()).add(this);
+      // ... and the claim about to be recorded is the scroll itself, not a
+      // reason to un-blit it
+      root._scrollClaim = this;
+    }
     this.scrollX = next.x;
     this.scrollY = next.y;
     this.props.onScroll?.({
@@ -1755,8 +1833,11 @@ export class ScrollViewNode extends Node {
     // layout change all the same — children's absolute positions move — hence
     // both arguments. Unbounded, every wheel notch repainted the whole window,
     // which is the whole cost of scrolling: the client work is negligible next
-    // to what the server then has to redraw.
+    // to what the server then has to redraw. (When the frame turns out to be
+    // a *pure* scroll, _applyScrollBlits later narrows this claim to the
+    // exposed strip and blits the rest — see WindowNode.)
     this.root?.invalidate(true, this, 'scroll');
+    if (root) root._scrollClaim = null;
   }
 
   /** `scrollBy(dy)`, or `scrollBy({x, y})` for either axis. */
@@ -3632,6 +3713,29 @@ export class WindowNode extends Node {
         stack: new Error('invalidated here').stack,
       };
     }
+    // A claim near a viewport that is waiting to blit makes that frame no
+    // longer a pure scroll — checked here, at claim time, because once the
+    // rects coalesce a change inside the viewport is indistinguishable from
+    // the scroll's own claim. (Unbounded claims need no check: FULL_DAMAGE
+    // fails the blit's damage gate by itself.)
+    const pendingScrolls = this._pendingScrolls;
+    if (
+      pendingScrolls?.size &&
+      damage &&
+      damage !== NO_DAMAGE &&
+      this._scrollClaim !== damage
+    ) {
+      const rect = damage.paintBounds ? damage.paintBounds() : damage;
+      for (const sv of [...pendingScrolls]) {
+        if (
+          !sv.abs ||
+          rectsOverlap(rect, insetRect(sv.abs, -(DAMAGE_SLOP * 2 + 1)))
+        ) {
+          pendingScrolls.delete(sv);
+          sv._pendingBlitFrom = null;
+        }
+      }
+    }
     if (layoutChanged && !damage) this._damage = FULL_DAMAGE;
     else if (!layoutChanged && !damage) this._damage = FULL_DAMAGE;
     else if (this._damage !== FULL_DAMAGE) {
@@ -3689,6 +3793,10 @@ export class WindowNode extends Node {
     } else if (this._reflowed.size) {
       this._reflowed.clear();
     }
+    // after layout (the claims above included), before the damage is taken:
+    // a frame that turns out to be a pure scroll blits the surviving band
+    // and narrows its claim to the exposed strip
+    this._applyScrollBlits(width, height);
     if (!this.needsPaint) return;
     this.needsPaint = false;
     const damage = this._takeDamage(width, height);
@@ -3729,6 +3837,198 @@ export class WindowNode extends Node {
         end: performance.now(),
       });
     }
+  }
+
+  /**
+   * The scroll-blit fast path (issue #138): when the frame is a *pure*
+   * scroll of one viewport, ask ntk to CopyArea the band that stays visible
+   * into its new place inside the backing store, and narrow this frame's
+   * damage from the whole viewport to the strip the scroll exposed (plus
+   * the scrollbar tracks, whose pixels the blit dragged along).
+   *
+   * Everything here is a gate, cheapest first, and every gate falls back to
+   * the claim scrollTo already recorded — the full-viewport repaint that
+   * has always been the behavior. The fast path can therefore cost
+   * correctness nothing: the worst mistake it can make is not firing.
+   */
+  _applyScrollBlits(width, height) {
+    const pending = this._pendingScrolls;
+    if (!pending?.size) return;
+    const nodes = [...pending];
+    pending.clear();
+    const from = nodes[0]._pendingBlitFrom;
+    for (const n of nodes) n._pendingBlitFrom = null;
+    // two viewports scrolling in one frame is rare enough that sorting out
+    // whether their regions interact is not worth it
+    if (nodes.length !== 1) return;
+    const node = nodes[0];
+    if (NO_SCROLL_BLIT || !from || node.destroyed || node.root !== this) return;
+    const wnd = this.window;
+    if (typeof wnd?.scrollRegion !== 'function') return; // ntk without #139
+    // the debug overlays and the DevTools highlight draw over the whole
+    // window; a blit would drag shifted copies of them along
+    if (debugPaint || process.env.REACT_X11_DEBUG_LAYOUT || this._highlight) {
+      return;
+    }
+    if (!Array.isArray(this._damage)) return; // unbounded frame already
+    // children clip to the border box, so a border ring or rounded corner
+    // would be shifted like content
+    if (node.style.borderWidth > 0 || node.style.borderRadius > 0) return;
+    const vp = node.abs;
+    // fractional geometry or offsets change every pixel; only a whole-pixel
+    // shift is a copy
+    if (!isIntegerRect(vp)) return;
+    if (!Number.isInteger(from.x) || !Number.isInteger(from.y)) return;
+    const dx = node.scrollX - from.x;
+    const dy = node.scrollY - from.y;
+    if (!Number.isInteger(dx) || !Number.isInteger(dy)) return;
+    if (dx === 0 && dy === 0) return;
+    // one axis at a time: a diagonal scroll needs an L of strips whose
+    // pieces overlap the bar rects, and overlapping damage rects merge into
+    // their box (translucent paint must not run twice) — the merges balloon
+    // toward the whole viewport and the blit stops paying. Wheels scroll
+    // one axis per event, so this costs almost nothing real.
+    if (dx !== 0 && dy !== 0) return;
+    if (Math.abs(dx) >= vp.width || Math.abs(dy) >= vp.height) return;
+    // the worth-it heuristics: below these, the plain repaint is one cheap
+    // pass and the blit's bookkeeping outweighs it
+    const area = vp.width * vp.height;
+    if (area < SCROLL_BLIT_MIN_AREA) return;
+    const kept = (vp.width - Math.abs(dx)) * (vp.height - Math.abs(dy));
+    if (kept < area * SCROLL_BLIT_MIN_KEEP) return;
+    // the band shifts in from inside the window; a viewport poking out of
+    // it has nothing there to shift
+    if (
+      vp.x < 0 ||
+      vp.y < 0 ||
+      vp.x + vp.width > width ||
+      vp.y + vp.height > height
+    ) {
+      return;
+    }
+    // A pure scroll and nothing else: the frame's only claim touching the
+    // viewport must be the viewport claim itself (scrollTo's, with its
+    // slop). Any other rect reaching in — a virtualized table's row swap, a
+    // hover restyle mid-scroll — means content changed, and changed pixels
+    // must not be blitted around.
+    const keep = [];
+    let sawClaim = false;
+    const slopped = insetRect(vp, -(DAMAGE_SLOP + 1));
+    for (const rect of this._damage) {
+      if (!rectsOverlap(rect, vp)) {
+        keep.push(rect);
+        continue;
+      }
+      if (rectContains(rect, vp) && rectContains(slopped, rect)) {
+        sawClaim = true;
+        continue;
+      }
+      return;
+    }
+    if (!sawClaim) return;
+    if (!this._scrollBlitSafe(node, vp)) return;
+    // scroll offsets grow down/right; the pixels move the other way
+    // (0 - x rather than -x: negating +0 yields -0, which survives into
+    // request buffers and test comparisons)
+    if (!wnd.scrollRegion({ ...vp }, 0 - dx, 0 - dy)) return;
+    let rects = keep;
+    // the strip the shift exposed, full breadth — it also covers the corner
+    // gutter beside the bars, whose old pixels the blit did not overwrite
+    const axis = dy !== 0 ? 'y' : 'x';
+    const delta = dy !== 0 ? dy : dx;
+    rects = addDamageRect(
+      rects,
+      axis === 'y'
+        ? {
+            x: vp.x,
+            y: delta > 0 ? vp.y + vp.height - delta : vp.y,
+            width: vp.width,
+            height: Math.abs(delta),
+          }
+        : {
+            x: delta > 0 ? vp.x + vp.width - delta : vp.x,
+            y: vp.y,
+            width: Math.abs(delta),
+            height: vp.height,
+          },
+    );
+    // Scrollbar repair. The scrolled axis's thumb moved *and* the blit
+    // dragged a copy of the old thumb along: repaint the dragged copy's
+    // rect and the new thumb's rect — small rects, where the full track
+    // would run the viewport's whole length and merge with the strip into
+    // most of the viewport. The cross-axis bar did not move, but its band's
+    // pixels were shifted like everything else, so its track repaints
+    // whole; it lies along the strip, so their merge stays a band.
+    const scrolledBar = node._scrollbar(axis);
+    if (scrolledBar) {
+      const savedX = node.scrollX;
+      const savedY = node.scrollY;
+      node.scrollX = from.x;
+      node.scrollY = from.y;
+      const oldBar = node._scrollbar(axis);
+      node.scrollX = savedX;
+      node.scrollY = savedY;
+      if (oldBar) {
+        rects = addDamageRect(rects, {
+          x: oldBar.x - 1 - dx,
+          y: oldBar.y - 1 - dy,
+          width: oldBar.width + 2,
+          height: oldBar.height + 2,
+        });
+      }
+      rects = addDamageRect(rects, {
+        x: scrolledBar.x - 1,
+        y: scrolledBar.y - 1,
+        width: scrolledBar.width + 2,
+        height: scrolledBar.height + 2,
+      });
+    }
+    const crossBar = node._scrollbar(axis === 'y' ? 'x' : 'y');
+    if (crossBar) rects = addDamageRect(rects, scrollbarTrackRect(crossBar));
+    this._damage = rects;
+  }
+
+  /**
+   * May the viewport's pixels be moved wholesale? Only if every pixel in it
+   * belongs to the scrolled content (or to a plain solid fill behind it):
+   * any node outside the scrollview's subtree whose drawing reaches into
+   * the viewport — an overlapping sibling, an ancestor's border ring or
+   * rounded corner, an enclosing scrollview's scrollbar — would have its
+   * pixels dragged along by the blit, so any of them is a no.
+   */
+  _scrollBlitSafe(scrollview, vp) {
+    const ancestors = new Set();
+    for (let n = scrollview.parent; n && n !== this; n = n.parent) {
+      ancestors.add(n);
+    }
+    const check = (parent) => {
+      for (const child of parent.children) {
+        if (child === scrollview) continue; // the scrolled content itself
+        if (child.isWindow || !child.yoga || child.hidden) continue;
+        if (child.style?.display === 'none') continue;
+        if (ancestors.has(child)) {
+          // on the path down: its solid background under the viewport is
+          // translation-invariant, its border ring and corners are not
+          const inset = Math.max(
+            child.style?.borderWidth ?? 0,
+            child.style?.borderRadius ?? 0,
+          );
+          if (inset > 0 && !rectContains(insetRect(child.abs, inset), vp)) {
+            return false;
+          }
+          if (typeof child._scrollbars === 'function') {
+            for (const bar of child._scrollbars()) {
+              if (rectsOverlap(scrollbarTrackRect(bar), vp)) return false;
+            }
+          }
+          if (!check(child)) return false;
+          continue;
+        }
+        if (rectsOverlap(child._subtreeBounds(), vp)) return false;
+      }
+      return true;
+    };
+    return check(this);
   }
 
   /** Repaint one damage rect, or the whole window when `damage` is null. */

--- a/test/helpers/mock-app.js
+++ b/test/helpers/mock-app.js
@@ -193,6 +193,13 @@ export function createMockApp() {
         getContext() {
           return ctx;
         },
+        // ntk >= 4.3 (sidorares/ntk#139): the scroll-blit fast path. Records
+        // and accepts; a test wanting the fallback deletes the method or
+        // replaces it with one returning false.
+        scrollRegion(rect, dx, dy) {
+          wnd.calls.push(['scrollRegion', rect, dx, dy]);
+          return true;
+        },
         on(name, fn) {
           (handlers[name] ??= []).push(fn);
         },

--- a/test/scroll-blit.test.js
+++ b/test/scroll-blit.test.js
@@ -1,0 +1,366 @@
+// The scroll-blit fast path (issue #138): a pure scroll asks ntk to
+// CopyArea the surviving band (Window.scrollRegion, sidorares/ntk#139) and
+// repaints only the exposed strip plus the scrollbar repair rects. Every
+// gate must fall back to the full-viewport repaint scrollTo always claimed.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import React from 'react';
+import ReactX11 from '../src/index.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient, StaticFontSource } from 'ntk';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+// 20 rows of 40px in a 400x400 window: content 800, plenty to scroll, and
+// a viewport comfortably above the worth-it area gate.
+function mount({ windowProps = {}, scrollProps = {}, extra = null } = {}) {
+  const app = createMockApp();
+  const ref = React.createRef();
+  ReactX11.render(
+    h(
+      'window',
+      { width: 400, height: 400, ...windowProps },
+      h(
+        'scrollview',
+        { ref, style: { flexGrow: 1 }, ...scrollProps },
+        ...Array.from({ length: 20 }, (_, i) =>
+          h('box', {
+            key: i,
+            style: {
+              height: 40,
+              flexShrink: 0,
+              backgroundColor: i % 2 ? '#ffffff' : '#eef1f5',
+            },
+          }),
+        ),
+      ),
+      extra,
+    ),
+    null,
+    app,
+  );
+  const wnd = app.windows[0];
+  return { app, wnd, root: wnd._reactX11Node, ref };
+}
+
+const blits = (wnd) => wnd.calls.filter(([name]) => name === 'scrollRegion');
+
+test('a pure scroll blits the viewport and claims only the strip and thumb', async () => {
+  const { wnd, root, ref } = mount();
+  await tick();
+  wnd.calls.length = 0;
+
+  ref.current.scrollTo(48);
+  await tick();
+
+  assert.deepStrictEqual(blits(wnd), [
+    ['scrollRegion', { x: 0, y: 0, width: 400, height: 400 }, 0, -48],
+  ]);
+  const rects = root._lastDamageRects;
+  assert.ok(rects, 'the frame stayed bounded');
+  const area = rects.reduce((sum, r) => sum + r.width * r.height, 0);
+  assert.ok(
+    area < 400 * 400 * 0.25,
+    `repainted ${area}px² — the strip and thumb rects, not the viewport ` +
+      JSON.stringify(rects),
+  );
+  // the exposed strip is the bottom 48 rows
+  const strip = rects.find((r) => r.width === 400);
+  assert.ok(strip, `a full-width strip in ${JSON.stringify(rects)}`);
+  assert.strictEqual(strip.y + strip.height, 400);
+  assert.ok(strip.height >= 48);
+});
+
+test('scrolling back up exposes a strip at the top', async () => {
+  const { wnd, root, ref } = mount();
+  await tick();
+  ref.current.scrollTo(96);
+  await tick();
+  wnd.calls.length = 0;
+
+  ref.current.scrollTo(48);
+  await tick();
+  assert.deepStrictEqual(blits(wnd), [
+    ['scrollRegion', { x: 0, y: 0, width: 400, height: 400 }, 0, 48],
+  ]);
+  const strip = root._lastDamageRects.find((r) => r.width === 400);
+  assert.strictEqual(strip.y, 0);
+  assert.ok(strip.height >= 48);
+});
+
+test('several scrollTo calls in one frame blit once, by the net delta', async () => {
+  const { wnd, ref } = mount();
+  await tick();
+  wnd.calls.length = 0;
+  ref.current.scrollBy(48);
+  ref.current.scrollBy(48);
+  ref.current.scrollBy(-16);
+  await tick();
+  assert.deepStrictEqual(blits(wnd), [
+    ['scrollRegion', { x: 0, y: 0, width: 400, height: 400 }, 0, -80],
+  ]);
+});
+
+test('other damage inside the viewport keeps the full repaint', async () => {
+  const { wnd, root, ref } = mount();
+  await tick();
+  const row = root.children[0].children[2];
+  wnd.calls.length = 0;
+  ref.current.scrollTo(48);
+  // a second change lands in the same frame, inside the viewport
+  root.invalidate(false, row);
+  await tick();
+  assert.strictEqual(blits(wnd).length, 0, 'not a pure scroll: no blit');
+});
+
+test('a fractional target keeps the full repaint', async () => {
+  const { wnd, ref } = mount();
+  await tick();
+  wnd.calls.length = 0;
+  ref.current.scrollTo(48.5);
+  await tick();
+  assert.strictEqual(blits(wnd).length, 0);
+});
+
+test('a small viewport is not worth the bookkeeping', async () => {
+  const app = createMockApp();
+  const ref = React.createRef();
+  ReactX11.render(
+    h(
+      'window',
+      { width: 200, height: 100 },
+      h(
+        'scrollview',
+        { ref, style: { flexGrow: 1 } },
+        ...Array.from({ length: 10 }, (_, i) =>
+          h('box', { key: i, style: { height: 40, flexShrink: 0 } }),
+        ),
+      ),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  wnd.calls.length = 0;
+  ref.current.scrollTo(40);
+  await tick();
+  assert.strictEqual(blits(wnd).length, 0);
+});
+
+test('a page-sized jump repaints instead of blitting a sliver', async () => {
+  const { wnd, ref } = mount();
+  await tick();
+  wnd.calls.length = 0;
+  ref.current.scrollTo(240); // 60% of the viewport: less than half survives
+  await tick();
+  assert.strictEqual(blits(wnd).length, 0);
+});
+
+test('a border on the scrollview keeps the full repaint', async () => {
+  const { wnd, ref } = mount({
+    scrollProps: {
+      style: { flexGrow: 1, borderWidth: 2, borderColor: '#333333' },
+    },
+  });
+  await tick();
+  wnd.calls.length = 0;
+  ref.current.scrollTo(48);
+  await tick();
+  assert.strictEqual(blits(wnd).length, 0);
+});
+
+test('an overlapping sibling above the viewport keeps the full repaint', async () => {
+  const { wnd, ref } = mount({
+    extra: h('box', {
+      style: {
+        position: 'absolute',
+        left: 150,
+        top: 150,
+        width: 100,
+        height: 40,
+        backgroundColor: '#ffcc00',
+      },
+    }),
+  });
+  await tick();
+  wnd.calls.length = 0;
+  ref.current.scrollTo(48);
+  await tick();
+  assert.strictEqual(blits(wnd).length, 0, 'its pixels must not be dragged');
+});
+
+test('an ntk without scrollRegion gets the old behavior untouched', async () => {
+  const { wnd, root, ref } = mount();
+  await tick();
+  delete wnd.scrollRegion;
+  wnd.calls.length = 0;
+  ref.current.scrollTo(48);
+  await tick();
+  assert.strictEqual(blits(wnd).length, 0);
+  // the claim stays the viewport — which fills this window, so the frame
+  // reports the old full repaint
+  assert.strictEqual(root._lastDamage, null);
+});
+
+test('a refused blit falls back to the full repaint', async () => {
+  const { wnd, root, ref } = mount();
+  await tick();
+  wnd.scrollRegion = () => false; // e.g. ntk with no valid backing store
+  ref.current.scrollTo(48);
+  await tick();
+  assert.strictEqual(root._lastDamage, null);
+});
+
+test('the scrolled thumb is repainted at both its old and new place', async () => {
+  const { wnd, root, ref } = mount();
+  await tick();
+  // start mid-list, so the dragged copy of the old thumb stays on screen
+  ref.current.scrollTo(96);
+  await tick();
+  const sv = root.children[0];
+  const before = sv._scrollbar('y');
+  wnd.calls.length = 0;
+  ref.current.scrollTo(144);
+  await tick();
+  const after = sv._scrollbar('y');
+  assert.notStrictEqual(before.thumbStart, after.thumbStart);
+  const rects = root._lastDamageRects;
+  const covers = (r, x, y) =>
+    x >= r.x && x < r.x + r.width && y >= r.y && y < r.y + r.height;
+  // the new thumb, and the blit-dragged copy of the old one (shifted up)
+  for (const point of [
+    [after.x + 3, after.y + 3],
+    [before.x + 3, before.y + 3 - 48],
+  ]) {
+    assert.ok(
+      rects.some((r) => covers(r, point[0], point[1])),
+      `damage misses thumb pixel at ${point}: ${JSON.stringify(rects)}`,
+    );
+  }
+});
+
+// --- pixel truth against the real ntk + in-process X server --------------
+//
+// The whole optimisation stands on one invariant: a blitted scroll frame is
+// byte-identical to the full repaint it replaced. Skipped when the
+// installed ntk has no scrollRegion yet (the fast path never fires there,
+// which the mock tests above already cover).
+
+const require = createRequire(import.meta.url);
+
+async function createHeadlessApp() {
+  const server = xserver.createServer({ width: 640, height: 480 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const fontSource = new StaticFontSource();
+  fontSource.add(
+    readFileSync(
+      join(
+        dirname(require.resolve('katex/package.json')),
+        'dist',
+        'fonts',
+        'KaTeX_Main-Regular.ttf',
+      ),
+    ),
+    { family: 'Test Main' },
+  );
+  fontSource.alias('sans-serif', 'Test Main');
+  return await createClient({ stream: clientEnd, fontSource });
+}
+
+const settle = (app) =>
+  new Promise((resolve, reject) =>
+    app.X.GetInputFocus((err) => (err ? reject(err) : resolve())),
+  );
+
+const readPixels = (ctx, w, h) =>
+  new Promise((resolve, reject) =>
+    ctx.getImageData(0, 0, w, h, (err, data) =>
+      err ? reject(err) : resolve(data),
+    ),
+  );
+
+test('a blitted scroll is byte-identical to the repaint it replaced', async (t) => {
+  const app = await createHeadlessApp();
+  try {
+    const ref = React.createRef();
+    const instance = await new Promise((resolve) =>
+      ReactX11.render(
+        h(
+          'window',
+          { width: 400, height: 300, style: { backgroundColor: '#f5f6fa' } },
+          h(
+            'scrollview',
+            { ref, style: { flexGrow: 1 } },
+            ...Array.from({ length: 40 }, (_, i) =>
+              h(
+                'box',
+                {
+                  key: i,
+                  style: {
+                    height: 40,
+                    flexShrink: 0,
+                    padding: 6,
+                    backgroundColor: i % 2 ? '#ffffff' : '#dbe4ee',
+                  },
+                },
+                h(
+                  'text',
+                  { style: { fontSize: 12, color: '#20304a' } },
+                  `row ${i} — some content`,
+                ),
+              ),
+            ),
+          ),
+        ),
+        resolve,
+        app,
+      ),
+    );
+    if (typeof instance.scrollRegion !== 'function') {
+      t.skip('installed ntk has no Window.scrollRegion yet');
+      return;
+    }
+    const root = instance._reactX11Node;
+    const frame = () => {
+      root._scheduled = false;
+      root.flush();
+    };
+    frame();
+    await settle(app);
+
+    // scroll through the fast path, and prove it really took it
+    let blitCalls = 0;
+    const realScrollRegion = instance.scrollRegion.bind(instance);
+    instance.scrollRegion = (...args) => {
+      blitCalls += 1;
+      return realScrollRegion(...args);
+    };
+    ref.current.scrollTo(48);
+    frame();
+    await settle(app);
+    assert.strictEqual(blitCalls, 1, 'the fast path fired');
+    assert.ok(root._lastDamageRects, 'and the frame stayed bounded');
+    const blitted = await readPixels(root._ctx, 400, 300);
+
+    // repaint the same state from scratch: the ground truth
+    root.invalidate(false);
+    frame();
+    await settle(app);
+    const repainted = await readPixels(root._ctx, 400, 300);
+    assert.ok(
+      Buffer.from(blitted.data).equals(Buffer.from(repainted.data)),
+      'blitted pixels differ from a full repaint of the same state',
+    );
+  } finally {
+    ReactX11.unmountComponentAtNode(app);
+    await app.close();
+  }
+});


### PR DESCRIPTION
Closes #138. The policy half of scroll-blitting; the mechanism is `Window.scrollRegion` (sidorares/ntk#139, merged there first — this PR feature-detects it and is fully functional, at today's behavior, without it).

**Stacked on #137**: branched from `feat/runtime-diagnostics`, whose tracer this PR's measurements and bench scenario dogfood. GitHub will retarget this to `master` when #137 merges.

## What changes

A wheel notch used to re-render the whole viewport at the new offset. Now `WindowNode.flush` resolves each frame's pending scrolls between layout and `_takeDamage`: when the frame is a **pure single-axis scroll of one viewport**, ntk blits the surviving band inside its backing pixmap and the frame's damage narrows to:

- the exposed strip (full breadth — it also covers the corner gutter beside the bars, whose old pixels the blit does not overwrite),
- the scrolled axis's thumb, at its **old (blit-dragged) and new** places — small rects, where a full track rect would coalesce with the strip into most of the viewport,
- the cross-axis bar's track, which lies along the strip so their merge stays a band.

## The gates (all fall back to today's full-viewport repaint)

Cheapest first, per the worth-it heuristics discussed in the issue:

| gate | why |
| --- | --- |
| `wnd.scrollRegion` absent | ntk < 4.3: the whole feature is additive |
| `REACT_X11_NO_SCROLL_BLIT=1` | A/B measurement, field first aid (read once at startup) |
| viewport area < 48k px² | one cheap repaint pass beats the bookkeeping |
| < 50% of the viewport survives | a page jump is mostly strip anyway |
| fractional offsets / diagonal delta | sub-pixel shifts change every pixel; diagonal strips + bar rects coalesce toward the viewport |
| frame not a pure scroll | checked **at `invalidate` time** — once rects coalesce, a change inside the viewport is indistinguishable from the scroll's own claim |
| safety walk | overlapping non-descendants, ancestor border rings / rounded corners / enclosing scrollbars, a border on the viewport itself, debug overlays, DevTools highlight |

The worst mistake the fast path can make is not firing.

## Correctness

The invariant, pinned against the in-process X server in `test/scroll-blit.test.js`: **a blitted frame is byte-identical to the full repaint it replaced** (readback compare, with a spy proving the fast path actually fired). With the ntk floor now at 4.3.0 that test **runs in CI** rather than skipping itself — 299/299, 0 skipped.

Twelve mock-app tests cover the fast path's shape (blit args, strip and thumb damage, net delta across several `scrollTo`s in one frame) and every bail: extra damage in the viewport, fractional target, small viewport, page jump, border, overlapping sibling, missing/refusing `scrollRegion`.

No screenshots: the point of this PR is that the pixels are provably unchanged.

## Numbers

Same build, in-process server, 500-row list in a 400x400 window, 10 notches of 48px, only `REACT_X11_NO_SCROLL_BLIT` differing:

| per notch | repaint (old) | blit |
| --- | --- | --- |
| requests | 89 | 44 |
| bytes out | 4.0 KB | 1.7 KB |
| Render Composites | 21.1 | 11.1 |
| **Composite Mpx** | **0.328** | **0.065** |

Last-notch damage: `[{0,352,400,48}, {391,16,8,23}]` -- the strip and the thumb, nothing else.

The bench gains a `scroll: 10 notches over 500 rows` scenario (with a `prepare`/`run` split so the mount is drained, not measured), **baselined with the blit live** at 437 requests / 0.65 Mpx. That direction is deliberate and is what fences the optimization: `--check` only fails on an *increase*, so against fallback numbers a change that quietly stopped the fast path from firing would have read as an improvement-shaped no-op and passed. Verified both ways -- `REACT_X11_NO_SCROLL_BLIT=1 npm run bench -- --check` exits 1, naming all four metrics; the normal run exits 0.

## ntk floor

`d215bba` raises the floor to **ntk >= 4.3.0** (published with `Window.scrollRegion`). Not a breaking change for consumers: ntk is a regular dependency, so an upgrading install resolves it without anyone doing anything, and scrolled pixels are byte-identical either way -- hence `chore(deps)` with no `BREAKING CHANGE` footer, which would otherwise force a major release for a dependency npm handles on its own. The call site stays feature-detected regardless, so a mock window in someone's tests or a deduped older copy degrades to the plain repaint instead of throwing.

## Merge order

1. ~~sidorares/ntk#139, then an ntk release~~ -- done, ntk 4.3.0 is published
2. #137 (this PR's base)
3. this PR
