### PR TITLE
feat!: <textinput onChange> passes a synthetic event, and controls take a `name`

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -145,13 +145,13 @@ synthetic event with no leading value, matching the DOM
 
 ### `Checkbox`
 
-| prop                 |                                            |
-| -------------------- | ------------------------------------------ |
-| `checked`            | current value (controlled)                 |
-| `onChange(next, ev)` | the **next** value first, then the event   |
-| `name`               | field name, for form libraries             |
-| `children` / `label` | label to the right of the 16px check well  |
-| `disabled`           | inert, dimmed                              |
+| prop                 |                                           |
+| -------------------- | ----------------------------------------- |
+| `checked`            | current value (controlled)                |
+| `onChange(next, ev)` | the **next** value first, then the event  |
+| `name`               | field name, for form libraries            |
+| `children` / `label` | label to the right of the 16px check well |
+| `disabled`           | inert, dimmed                             |
 
 ### `Radio` / `RadioGroup`
 
@@ -210,8 +210,8 @@ import { Select } from 'react-x11';
 />;
 ```
 
-| prop                       |                                           |
-| -------------------------- | ----------------------------------------- |
+| prop                           |                                           |
+| ------------------------------ | ----------------------------------------- |
 | `options`                      | array of `{value, label}` or plain values |
 | `value`, `onChange(value, ev)` | selection                                 |
 | `name`                         | field name, for form libraries            |

--- a/docs/components.md
+++ b/docs/components.md
@@ -106,6 +106,34 @@ import { Button, Checkbox, RadioGroup, Radio, Switch, ProgressBar } from 'react-
 Label text is the children (or a `label` prop); a bare string is wrapped in
 a `<text>` for you, so `<Button>Save</Button>` needs no `<text>`.
 
+### The change event, and `name`
+
+Every value control — `Checkbox`, `Switch`, `RadioGroup`, `Select`,
+`Slider` — calls `onChange(next, ev)`. The **next value comes first**, which
+is the whole ergonomic point of these widgets (`onChange={setChecked}` is
+the common case and stays a one-liner), and the second argument carries the
+field identity a form library needs:
+
+```js
+{ type: 'change',
+  target: { type: 'checkbox', name: 'agree', value: true, checked: true },
+  currentTarget: /* the same object */,
+  name: 'agree', value: true }
+```
+
+`target` is a plain descriptor rather than a node: a widget is several nodes
+and none of them holds its value. Its shape is what formik's `handleChange`
+and react-hook-form's event reader destructure — `target.type` is how they
+tell a checkbox from a text field, which is why it is set even though nothing
+in react-x11 reads it. There is no `preventDefault`: the value has already
+changed by the time the handler runs.
+
+`name` is inert here. It exists so a form library has somewhere to put one;
+see [docs/ecosystem/forms.md](ecosystem/forms.md). The host elements
+`<textinput>` and `<textarea>` are different — they hand you a single
+synthetic event with no leading value, matching the DOM
+([elements.md](elements.md#the-change-event)).
+
 ### `Button`
 
 | prop                 |                                           |
@@ -120,16 +148,18 @@ a `<text>` for you, so `<Button>Save</Button>` needs no `<text>`.
 | prop                 |                                            |
 | -------------------- | ------------------------------------------ |
 | `checked`            | current value (controlled)                 |
-| `onChange(next)`     | receives the **next** value, not the event |
+| `onChange(next, ev)` | the **next** value first, then the event   |
+| `name`               | field name, for form libraries             |
 | `children` / `label` | label to the right of the 16px check well  |
 | `disabled`           | inert, dimmed                              |
 
 ### `Radio` / `RadioGroup`
 
-`RadioGroup` takes `value`, `onChange(value)`, `style` and any box props;
-each `Radio` takes the `value` it selects, plus `children`/`label` and
-`disabled` — and nothing else, so per-radio styling goes on the group. A
+`RadioGroup` takes `value`, `onChange(value, ev)`, `name`, `style` and any
+box props; each `Radio` takes the `value` it selects, plus `children`/`label`
+and `disabled` — and nothing else, so per-radio styling goes on the group. A
 `Radio` outside a `RadioGroup` throws rather than silently doing nothing.
+`name` lives on the group the way it does in HTML: the group is the field.
 
 Arrow keys move the selection through the group in **mount order**,
 wrapping — Up/Left back, Down/Right forward — which is how a native radio
@@ -137,8 +167,8 @@ group behaves; click or Space selects the focused one.
 
 ### `Switch`
 
-`checked`, `onChange(next)` and `disabled`, the same semantics as
-`Checkbox` in a sliding pill. The thumb is absolutely positioned and
+`checked`, `onChange(next, ev)`, `name` and `disabled`, the same semantics
+as `Checkbox` in a sliding pill. The thumb is absolutely positioned and
 animates on `left` (`transition: { left: 120 }`) because `justifyContent`
 would flip between the ends with nothing in between to animate — the worked
 example in [styling.md](styling.md#transitions).
@@ -182,10 +212,11 @@ import { Select } from 'react-x11';
 
 | prop                       |                                           |
 | -------------------------- | ----------------------------------------- |
-| `options`                  | array of `{value, label}` or plain values |
-| `value`, `onChange(value)` | selection                                 |
-| `placeholder`              | trigger text when nothing is selected     |
-| `style` + any box props    | forwarded to the trigger box              |
+| `options`                      | array of `{value, label}` or plain values |
+| `value`, `onChange(value, ev)` | selection                                 |
+| `name`                         | field name, for form libraries            |
+| `placeholder`                  | trigger text when nothing is selected     |
+| `style` + any box props        | forwarded to the trigger box              |
 
 Behavior: click / Space / Enter toggles the menu; Escape, focus loss, or
 picking closes it; the option list scrolls when taller than 220px; the
@@ -239,12 +270,13 @@ import { Slider } from 'react-x11';
 />;
 ```
 
-| prop                       |                                                         |
-| -------------------------- | ------------------------------------------------------- |
-| `value`, `onChange(value)` | current value (controlled)                              |
-| `min`, `max`, `step`       | range and quantisation (defaults 0, 100, 1)             |
-| `height`                   | the bar thickness (default 4); width comes from `style` |
-| `disabled`                 | inert, dimmed                                           |
+| prop                           |                                                         |
+| ------------------------------ | ------------------------------------------------------- |
+| `value`, `onChange(value, ev)` | current value (controlled)                              |
+| `name`                         | field name, for form libraries                          |
+| `min`, `max`, `step`           | range and quantisation (defaults 0, 100, 1)             |
+| `height`                       | the bar thickness (default 4); width comes from `style` |
+| `disabled`                     | inert, dimmed                                           |
 
 Dragging uses [pointer capture](events.md#pointer-capture): the press
 captures, so the thumb keeps following a pointer that has wandered far

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -52,10 +52,14 @@ command.
    core package too — `@tanstack/query-core`, not just
    `@tanstack/react-query`, which has no hits of its own.
 
-4. **Does it expect DOM-shaped events?** react-x11's `<textinput>` calls
-   `onChange(newString)`, not `onChange(event)`. A library whose handler does
-   `event.target.value` mounts fine and then breaks on the first keystroke.
-   Grep for `target.value`.
+4. **Does it expect DOM-shaped events?** Since 2.0.0 the answer is usually
+   fine: `<textinput onChange>` hands over a synthetic event with
+   `target.value`, `target.name` and a writable `target.value`, so
+   `event.target.value` reads the way it does in the DOM. What to check
+   instead is the **opposite** direction — a library whose field contract is
+   value-in/value-out (`field.handleChange(value)`) now needs one unwrap per
+   field, and a bare `onChange={field.handleChange}` stores the event object
+   with no error. Grep your own code for `onChange={` on a `<textinput>`.
 
 A library that passes all four is almost always a drop-in. A library that
 fails 2 or 3 usually has a headless core published separately — that is the
@@ -369,46 +373,27 @@ better one for dense plots.
 These mount without a single error message. The first sign of trouble is a
 keystroke.
 
-| Package                           | Error                                                              | Use instead                                                        |
-| --------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------ |
-| `downshift`                       | `TypeError: Cannot read properties of undefined (reading 'value')` | react-x11's built-in `Select`                                      |
-| `formik` (`getFieldProps` spread) | _(nothing — no error, no warning, the field never updates)_        | `@tanstack/react-form` — [forms](ecosystem/forms.md#tanstack-form) |
+**Two entries left this table in 2.0.0.** `downshift` (a TypeError on the
+first keystroke) and `formik`'s `getFieldProps` spread (silent, no error,
+the field simply never updated) both had one cause: `<textinput>` called
+`onChange(newString)` rather than `onChange(event)`. It now passes a
+synthetic event, and both work — see
+[forms](ecosystem/forms.md). They are recorded here because the symptoms are
+what a 1.x user searches for.
 
-Both have the same cause: react-x11's `<textinput>` calls
-`onChange(newString)`, never `onChange(event)`.
+Nothing currently fails on first interaction. Two shapes to know about
+anyway, because they are the ones this class of bug takes here:
 
-```jsx
-const c = useCombobox({ items: ['alpha', 'beta'] });
-return <textinput {...c.getInputProps()} />;
-// mounts clean; the first keystroke calls onChange('al') and
-// downshift's handler does event.target.value
-```
-
-Note the missing `react-x11:` prefix — the throw comes from downshift, so
-nothing in the message suggests the renderer is involved. You will also see
-downshift's own dev warning if you only wire the input:
-`downshift: You forgot to call the getMenuProps getter function on your
-component / element.`
-
-Formik is the same shape, one degree quieter. `handleChange` treats a string
-argument as its curried field-name form, returns a handler, and never
-touches state — `values` stays `{"host":""}` and `touched` stays `{}` with
-nothing logged. Never spread `getFieldProps` onto a react-x11 host. If you
-must use Formik, drive it by hand:
-
-```jsx
-<textinput
-  value={f.values.host}
-  onChange={(v) => f.setFieldValue('host', v)}
-  onBlur={() => f.setFieldTouched('host')}
-/>
-```
-
-The render-prop form of `<Formik>` works this way and `f.submitForm()`
-delivers the right values. There is a sharper edge nearby: passing a
-non-string object to `handleChange` — a hand-rolled fake event, say —
-throws `TypeError: Cannot read properties of undefined (reading 'type')`
-instead of no-opping.
+- A handler that reads `event.nativeEvent.<something>` **unguarded** works
+  for a keystroke and throws for a paste or an undo, where there is no X
+  event to report. downshift reads
+  `event.nativeEvent.preventDownshiftDefault` this way; it is safe only
+  because it also checks `hasOwnProperty('nativeEvent')` first and the
+  property is always present.
+- A library that writes through a ref — `ref.value = ''` — needs the node to
+  have a value **setter**. `<textinput>` does; most nodes do not, and the
+  failure is a TypeError thrown from inside the commit phase, which takes the
+  render down rather than one handler.
 
 ### Silent failures
 

--- a/docs/ecosystem/forms.md
+++ b/docs/ecosystem/forms.md
@@ -1,15 +1,38 @@
 # Forms and validation
 
-There is no `<form>` element here, and `<textinput>` fires
-`onChange(newString)` rather than `onChange(event)` — see
-[elements](../elements.md). Those two facts sort the form libraries
-cleanly: the ones with a value-in/value-out field contract work unmodified,
-the ones built on `register()`-style DOM prop bags need their controlled
-API, and the ones that only have the DOM path do not work at all.
+There is no `<form>` element here, so nothing submits itself — wire
+`handleSubmit` to a `Button`'s `onPress` or to `<textinput onSubmit>`.
 
-Formik is in the last group, and it is the one that costs people the most
-time because one of its two failure modes is silent. It is written up in the
-[negative-results register](../ecosystem.md#first-interaction).
+Everything else on this page changed in **2.0.0**. `<textinput>` used to fire
+`onChange(newString)`; it now fires `onChange(ev)` with a synthetic event
+carrying `ev.target.value`, `ev.target.name` and a writable `ev.target.value`
+(issue #115, see [elements](../elements.md#the-change-event)). That was the
+one incompatibility that mattered, and with it gone the DOM-shaped form
+libraries work through their normal APIs rather than through an adapter:
+
+| library                | 1.2.0                             | 2.0.0                                                    |
+| ---------------------- | --------------------------------- | -------------------------------------------------------- |
+| `react-hook-form`      | `<Controller>` only               | `register()` works, `<Controller>` too                   |
+| `formik`               | broke silently on `getFieldProps` | `handleChange`, `<Field>`, spread all work               |
+| `downshift`            | TypeError on the first keystroke  | works                                                    |
+| `@tanstack/react-form` | `onChange={field.handleChange}`   | `onChange={(ev) => field.handleChange(ev.target.value)}` |
+
+The last row is the cost. A library whose field contract is value-in/
+value-out no longer lines up by accident, so it gains one unwrap per field —
+and a bare `onChange={field.handleChange}` now stores the **event object**
+as the field value rather than erroring, which is the quiet failure mode to
+watch for when upgrading. Grep for `onChange={field.handleChange}` and for
+`onChange={set` before you ship.
+
+Each row was established by running the library headless against this
+renderer, not by reading its documentation: react-hook-form@7.84.0,
+formik@2.4.9, downshift@9.4.0, @tanstack/react-form@1.33.2.
+
+The widget layer keeps its own shape — `Checkbox`, `Switch`, `RadioGroup`,
+`Select` and `Slider` call `onChange(next, ev)`, value first, with the
+form-library-shaped event second
+([components](../components.md#the-change-event-and-name)). Pass the second
+argument straight to `formik.handleChange` or to RHF's `field.onChange`.
 
 ## TanStack Form {#tanstack-form}
 
@@ -20,10 +43,14 @@ touched tracking, sync and async validation (including Standard Schema, so
 zod/valibot/arktype plug in directly), and submission handling. Fields are
 value-in/value-out — no DOM events, no refs.
 
-The field contract is `field.state.value` + `field.handleChange(value)`, and
-`<textinput>` fires `onChange(text)` with the raw string. They meet in the
-middle with no glue at all, which makes this the form library to reach for
-first.
+The field contract is `field.state.value` + `field.handleChange(value)` —
+a value, not an event. Since 2.0.0 `<textinput>` fires an event, so each
+field unwraps it: `onChange={(ev) => field.handleChange(ev.target.value)}`.
+One expression, and it is the same one a DOM app writes.
+
+Watch for the bare form. `onChange={field.handleChange}` used to be exactly
+right and now stores the event object as the field's value — no error, no
+warning, and validation sees an object where it expected a string.
 
 ```jsx
 import React from 'react';
@@ -46,7 +73,7 @@ function ConnectForm({ connect }) {
           <box style={{ flexDirection: 'column' }}>
             <textinput
               value={field.state.value}
-              onChange={field.handleChange}
+              onChange={(ev) => field.handleChange(ev.target.value)}
             />
             {field.state.meta.errors.length > 0 && (
               <text style={{ color: '#cc4444' }}>
@@ -65,9 +92,10 @@ function ConnectForm({ connect }) {
 - No `<form>` element exists, so there is no submit-on-Enter for free. Wire
   `form.handleSubmit()` to a button's `onPress` and/or a window-level Enter
   key handler.
-- `Checkbox` and `Select` take `onChange(checked)`/`onChange(value)`, so
-  `field.handleChange` works across the widget set — but confirm the value
-  shape per component.
+- The **widgets** are the exception: `Checkbox`, `Switch`, `RadioGroup`,
+  `Select` and `Slider` still pass the next value first, so
+  `onChange={field.handleChange}` is right there and needs no unwrap. Only
+  the host elements `<textinput>`/`<textarea>` changed.
 - Validation errors from a zod schema are error _objects_
   (`errors[0].message`), not strings; a plain string validator returns
   strings. A `<text>` child must be a string, so render `.message`.
@@ -84,8 +112,8 @@ renderer-specific — the interesting part is only where it plugs in:
 - **TanStack Form** — pass a schema straight into a field's
   `validators: { onChange: z.string().min(3, 'too short') }`. Zod 4
   implements Standard Schema, so no resolver package is needed.
-- **React Hook Form** — via `@hookform/resolvers/zod` and the `Controller`
-  pattern below.
+- **React Hook Form** — via `@hookform/resolvers/zod`, with either
+  `register()` or `Controller`; see below.
 - **Standalone** — validating a settings file or a config blob before
   rendering is just `schema.safeParse(data)`.
 
@@ -124,21 +152,47 @@ function Settings({ raw }) {
 
 ## React Hook Form {#react-hook-form}
 
-**Adapter — use `<Controller>`, not `register()`.** react-hook-form@7.83.0
-with @hookform/resolvers@5.5.7.
+**Out of the box, both APIs.** react-hook-form@7.84.0 with
+@hookform/resolvers@5.5.7.
 
 RHF's headline API is uncontrolled-first: `register()` returns DOM-shaped
 props (`{name, ref, onChange(e), onBlur(e)}`) and reads `e.target.value` off
-native events. That path is unusable here — `<textinput onChange>` passes a
-raw string, and there is no `name` prop or DOM ref to attach.
+the event. Since 2.0.0 that is exactly what `<textinput>` provides, so the
+terse spread works:
 
-But RHF has always shipped a second, controlled API — `<Controller>` /
-`useController` — for external controlled components, and that path never
-touches the DOM. It works today with **zero adapter code**, because
-`field.onChange` accepts a plain value; RHF only unwraps `.target` when the
-argument actually looks like an event. RHF guards all its DOM checks behind
-`isWeb = typeof window !== 'undefined'`, so headless Node is a supported
-environment rather than an accident.
+```jsx
+const { register, handleSubmit } = useForm({ defaultValues: { host: '' } });
+<textinput {...register('host')} />;
+```
+
+Three things had to line up, and all three now do: `name` exists as a prop,
+`onChange` receives an event whose `target.value` is the new text, and the
+`ref` RHF attaches lands on a node whose `value` is **writable** — RHF
+assigns `ref.value = ''` while registering the field, which used to throw
+`TypeError: Cannot set property value of #<TextInputNode> which has only a
+getter` from inside the commit phase and take the render down with it.
+
+Verified working through `register()`: typing updates `getValues()`,
+`handleSubmit` receives them, `setValue(name, v)` writes through the ref so
+the field redraws, and `setFocus(name)` focuses the node.
+
+One asymmetry to know about: **`reset()` updates form state but does not
+clear an uncontrolled field's text.** RHF only writes values back through
+refs on the reset path when its `isWeb` probe
+(`typeof window !== 'undefined' && window.HTMLElement && document`) passes,
+which it never does here. `setValue()` is not gated that way and does write
+through. If you need `reset()` to clear the display, make the field
+controlled — `<Controller>`, below — or assign `ref.current.value = ''`
+yourself.
+
+`<Controller>` / `useController` still works, unchanged, and is the better
+choice when you want the field controlled. `field.onChange` accepts either a
+plain value or an event, so both of these are fine:
+
+```jsx
+onChange={(ev) => field.onChange(ev.target.value)}   // explicit
+onChange={field.onChange}                            // RHF unwraps .target
+```
 
 ```jsx
 import React from 'react';
@@ -167,7 +221,7 @@ function ConnectForm({ connect }) {
           <box style={{ flexDirection: 'column' }}>
             <textinput
               value={field.value}
-              onChange={field.onChange} // raw string in — no event unwrap needed
+              onChange={field.onChange}
               onBlur={field.onBlur}
             />
             {fieldState.error && <text>{fieldState.error.message}</text>}
@@ -180,11 +234,69 @@ function ConnectForm({ connect }) {
 }
 ```
 
-- Every field needs the `Controller` wrapper (or `useController`). The
-  `register()` spread that makes RHF terse on the web is off the table, and
-  with it the uncontrolled-inputs performance story: every controlled field
-  re-renders its `Controller` subtree on keystroke.
-- `setFocus(name)` is a no-op — it wants a DOM ref with `.focus()`. Use
-  react-x11's own focus handling instead.
+- A `Controller` field is controlled, so its subtree re-renders on every
+  keystroke. `register()` does not, which is the same performance argument
+  RHF makes on the web — and it now applies here too.
+- `setFocus(name)` works: it calls `.focus()` on whatever the ref holds, and
+  a `<textinput>` node has one.
 - `handleSubmit` returns a function. Call it: `handleSubmit(fn)` in an
   `onPress` is the curried form, and there is no submit event to pass.
+
+## Formik {#formik}
+
+**Out of the box.** formik@2.4.9.
+
+Formik was the clearest casualty of the old `onChange(string)` contract, and
+it failed _silently_: `handleChange` treats a string argument as its curried
+field-name form, returns a handler, and never touches state — so spreading
+`getFieldProps` onto a `<textinput>` left `values` at its initial object and
+`touched` empty, with nothing logged. That is fixed by the event, not by an
+adapter. All three of Formik's field styles now work:
+
+```jsx
+import { Formik, Field, useFormik } from 'formik';
+
+// 1. the spread
+<textinput {...formik.getFieldProps('host')} />
+
+// 2. by hand
+<textinput
+  name="host"
+  value={formik.values.host}
+  onChange={formik.handleChange}
+  onBlur={formik.handleBlur}
+/>
+
+// 3. <Field> with a render prop
+<Field name="host">
+  {({ field }) => <textinput {...field} />}
+</Field>
+```
+
+`handleChange` reads `target.name` to decide which field to write, so the
+`name` prop is not optional in any of these — that is what the synthetic
+event carries it for.
+
+The widgets need one small bridge, because their `onChange` puts the value
+first:
+
+```jsx
+<Checkbox
+  name="agree"
+  checked={formik.values.agree}
+  onChange={(_next, ev) => formik.handleChange(ev)}
+>
+  I agree
+</Checkbox>
+```
+
+`ev.target` is `{ type: 'checkbox', name, value, checked }`, which is exactly
+what `handleChange` destructures — including `type`, which is how it knows to
+take `checked` rather than `value`.
+
+- `<Formik>`'s render-prop form and `useFormik` both work; there is no
+  `<form>` element, so call `submitForm()` (or `handleSubmit()`) yourself
+  from a `Button` or from `<textinput onSubmit>`.
+- Passing a non-event object to `handleChange` — a hand-rolled fake event
+  with no `target` — still throws `TypeError: Cannot read properties of
+undefined (reading 'type')` rather than no-opping. Pass the real event.

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -339,17 +339,21 @@ across kerning, shaping boundaries and trailing whitespace.
 handler in the library gets, rather than a bare string:
 
 ```jsx
-<textinput name="email" value={email} onChange={(ev) => setEmail(ev.target.value)} />
+<textinput
+  name="email"
+  value={email}
+  onChange={(ev) => setEmail(ev.target.value)}
+/>
 ```
 
-| on the event                     |                                                  |
-| -------------------------------- | ------------------------------------------------ |
-| `ev.value`, `ev.target.value`    | the text **after** the edit                      |
-| `ev.name`, `ev.target.name`      | the `name` prop                                  |
-| `ev.type`                        | `'change'` or `'submit'`                         |
-| `ev.target`, `ev.currentTarget`  | the node (they are the same — this does not bubble) |
-| `ev.nativeEvent`                 | the X key event, or **null** — see below         |
-| `preventDefault`, `stopPropagation` | present for uniformity; nothing reads them    |
+| on the event                        |                                                     |
+| ----------------------------------- | --------------------------------------------------- |
+| `ev.value`, `ev.target.value`       | the text **after** the edit                         |
+| `ev.name`, `ev.target.name`         | the `name` prop                                     |
+| `ev.type`                           | `'change'` or `'submit'`                            |
+| `ev.target`, `ev.currentTarget`     | the node (they are the same — this does not bubble) |
+| `ev.nativeEvent`                    | the X key event, or **null** — see below            |
+| `preventDefault`, `stopPropagation` | present for uniformity; nothing reads them          |
 
 Two details worth knowing:
 
@@ -357,8 +361,8 @@ Two details worth knowing:
   `props.value` is still the old string until the parent re-renders. That is
   what makes `e.target.value` mean here what it means in the DOM, and it is
   why react-hook-form and formik work — see
-  [docs/ecosystem/forms.md](ecosystem/forms.md). It is true *while the
-  handler runs*: `ev.target` is the live node, so a handler that stashes the
+  [docs/ecosystem/forms.md](ecosystem/forms.md). It is true _while the
+  handler runs_: `ev.target` is the live node, so a handler that stashes the
   event and reads `ev.target.value` later sees whatever the control holds
   then. `ev.value` is a snapshot and always safe.
 - **`ev.nativeEvent` can be null.** A keystroke carries the X key event that

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -324,13 +324,53 @@ across kerning, shaping boundaries and trailing whitespace.
 
 | prop                              |                                            |
 | --------------------------------- | ------------------------------------------ |
-| `value` + `onChange(text)`        | controlled mode (display follows the prop) |
+| `value` + `onChange(ev)`          | controlled mode (display follows the prop) |
 | `defaultValue`                    | uncontrolled mode                          |
-| `onSubmit(text, ev)`              | Enter                                      |
+| `onSubmit(ev)`                    | Enter                                      |
+| `name`                            | field name, echoed on the event            |
 | `placeholder`, `placeholderColor` | shown when empty                           |
 | `maxLength`                       | code-point limit                           |
 | `selectionColor`, `caretColor`    | selection/caret paint                      |
 | text style props                  | as `<text>`                                |
+
+### The change event
+
+`onChange` and `onSubmit` get a synthetic event, the same shape every other
+handler in the library gets, rather than a bare string:
+
+```jsx
+<textinput name="email" value={email} onChange={(ev) => setEmail(ev.target.value)} />
+```
+
+| on the event                     |                                                  |
+| -------------------------------- | ------------------------------------------------ |
+| `ev.value`, `ev.target.value`    | the text **after** the edit                      |
+| `ev.name`, `ev.target.name`      | the `name` prop                                  |
+| `ev.type`                        | `'change'` or `'submit'`                         |
+| `ev.target`, `ev.currentTarget`  | the node (they are the same — this does not bubble) |
+| `ev.nativeEvent`                 | the X key event, or **null** — see below         |
+| `preventDefault`, `stopPropagation` | present for uniformity; nothing reads them    |
+
+Two details worth knowing:
+
+- **`ev.target.value` is the new value even in controlled mode**, where
+  `props.value` is still the old string until the parent re-renders. That is
+  what makes `e.target.value` mean here what it means in the DOM, and it is
+  why react-hook-form and formik work — see
+  [docs/ecosystem/forms.md](ecosystem/forms.md). It is true *while the
+  handler runs*: `ev.target` is the live node, so a handler that stashes the
+  event and reads `ev.target.value` later sees whatever the control holds
+  then. `ev.value` is a snapshot and always safe.
+- **`ev.nativeEvent` can be null.** A keystroke carries the X key event that
+  produced it, but an edit can also come from a paste resolving, an undo, or
+  a value the parent pushed back — none of which has an X event behind it.
+  Guard it. (Not academic: downshift reads
+  `event.nativeEvent.preventDownshiftDefault` unguarded, so a null there is a
+  TypeError rather than a no-op.)
+
+The node behind `ev.target` is writable, too. `node.value = ''` sets the text
+without firing `onChange`, the way assigning to a DOM input's `value` does —
+that is how react-hook-form's `register()` resets a field through its ref.
 
 Interactions: click/drag selection, double-click word select, triple-click
 select all, Backspace/Delete, arrows (+Shift extends), Home/End, Ctrl+A,

--- a/examples/form.jsx
+++ b/examples/form.jsx
@@ -61,7 +61,7 @@ export function FormPanel() {
         autoFocus
         value={name}
         placeholder="Your name"
-        onChange={setName}
+        onChange={(ev) => setName(ev.target.value)}
         onSubmit={submit}
         style={{
           padding: 8,

--- a/examples/stress/controls.jsx
+++ b/examples/stress/controls.jsx
@@ -276,13 +276,13 @@ export function ControlsPanel() {
               <text style={s.title}>Text entry</text>
               <textinput
                 value={note}
-                onChange={setNote}
+                onChange={(ev) => setNote(ev.target.value)}
                 placeholder="single line"
                 style={{ width: '100%' }}
               />
               <textarea
                 value={longText}
-                onChange={setLongText}
+                onChange={(ev) => setLongText(ev.target.value)}
                 rows={4}
                 style={{ width: '100%' }}
               />

--- a/examples/stress/mixed.jsx
+++ b/examples/stress/mixed.jsx
@@ -220,7 +220,7 @@ export function MixedPanel() {
             <text style={s.title}>a form, for focus</text>
             <textinput
               value={name}
-              onChange={setName}
+              onChange={(ev) => setName(ev.target.value)}
               placeholder="your name"
               style={{ width: '100%' }}
             />

--- a/examples/tasks.jsx
+++ b/examples/tasks.jsx
@@ -62,7 +62,7 @@ function AddTask() {
         autoFocus
         value={draft}
         placeholder="Add a task…"
-        onChange={setDraft}
+        onChange={(ev) => setDraft(ev.target.value)}
         onSubmit={add}
         style={{
           flexGrow: 1,

--- a/examples/widgets.jsx
+++ b/examples/widgets.jsx
@@ -147,7 +147,7 @@ export function WidgetsPanel() {
           <textarea
             rows={4}
             value={note}
-            onChange={setNote}
+            onChange={(ev) => setNote(ev.target.value)}
             style={{
               flexGrow: 0,
               padding: 8,

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -3,19 +3,22 @@
 // build-step-free for consumers.
 
 import React from 'react';
+import { changeEvent } from './change.js';
 import { labelContent, useControl, useTheme } from './theme.js';
 
 const h = React.createElement;
 
 /**
  * <Checkbox checked onChange disabled>label</Checkbox> — 16px check well +
- * label row; click or Space toggles (onChange receives the next value).
+ * label row; click or Space toggles. `onChange(next, ev)`: the next value
+ * first, then a form-library-shaped change event carrying `name`.
  */
 export function Checkbox({
   children,
   label,
   checked = false,
   onChange,
+  name,
   disabled = false,
   style,
   ...boxProps
@@ -25,7 +28,9 @@ export function Checkbox({
     focused,
     props,
     style: controlStyle,
-  } = useControl(disabled, () => onChange?.(!checked));
+  } = useControl(disabled, () =>
+    onChange?.(!checked, changeEvent('checkbox', name, !checked)),
+  );
   const fill = disabled ? theme.dim : theme.accent;
   return h(
     'box',

--- a/src/components/Radio.js
+++ b/src/components/Radio.js
@@ -3,6 +3,7 @@
 // build-step-free for consumers.
 
 import React, { useContext, useEffect, useMemo, useRef } from 'react';
+import { changeEvent } from './change.js';
 import { labelContent, useControl, useTheme } from './theme.js';
 import { XK_DOWN, XK_LEFT, XK_RIGHT, XK_UP } from './keys.js';
 
@@ -11,16 +12,26 @@ const h = React.createElement;
 const RadioGroupContext = React.createContext(null);
 
 /**
- * <RadioGroup value onChange>…<Radio value=…>label</Radio>…</RadioGroup> —
- * exclusive choice. Arrow keys move the selection through the group in
+ * <RadioGroup value onChange name>…<Radio value=…>label</Radio>…</RadioGroup>
+ * — exclusive choice. Arrow keys move the selection through the group in
  * mount order (wrapping); click or Space selects the focused radio.
+ * `name` lives on the group, not the radios, the way it does in HTML: it is
+ * the group that is one form field. `onChange(next, ev)`.
  */
-export function RadioGroup({ value, onChange, children, style, ...boxProps }) {
+export function RadioGroup({
+  value,
+  onChange,
+  name,
+  children,
+  style,
+  ...boxProps
+}) {
   const order = useRef([]).current;
-  const ctx = useMemo(
-    () => ({
+  const ctx = useMemo(() => {
+    const emit = (next) => onChange?.(next, changeEvent('radio', name, next));
+    return {
       value,
-      onChange,
+      emit,
       register: (v) => {
         order.push(v);
         return () => order.splice(order.indexOf(v), 1);
@@ -29,11 +40,10 @@ export function RadioGroup({ value, onChange, children, style, ...boxProps }) {
         if (order.length === 0) return;
         const i = order.indexOf(value);
         const next = order[(i + delta + order.length) % order.length];
-        if (next !== value) onChange?.(next);
+        if (next !== value) emit(next);
       },
-    }),
-    [value, onChange, order],
-  );
+    };
+  }, [value, onChange, name, order]);
   return h(
     'box',
     { ...boxProps, style: [{ gap: 6 }, style] },
@@ -54,7 +64,7 @@ export function Radio({ value, children, label, disabled = false }) {
     props,
     style: controlStyle,
   } = useControl(disabled, () => {
-    if (!selected) group.onChange?.(value);
+    if (!selected) group.emit(value);
   });
   const onKeyDown = props.onKeyDown;
   if (onKeyDown) {

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -4,6 +4,7 @@
 
 import React, { useEffect, useRef, useState } from 'react';
 import { useTheme } from './theme.js';
+import { changeEvent } from './change.js';
 import { measureLabel, screenOf, useAnchor } from './anchor.js';
 import { DEFAULT_TEXT_STYLE } from '../styles.js';
 import { typeAheadChar, useTypeAhead } from './typeahead.js';
@@ -125,6 +126,7 @@ export function Select({
   value,
   options = [],
   onChange,
+  name,
   placeholder = 'Select…',
   style,
   ...boxProps
@@ -167,9 +169,12 @@ export function Select({
   };
   const toggle = () => (open ? close() : openMenu());
 
+  const emit = (next) =>
+    onChange?.(next, changeEvent('select-one', name, next));
+
   const pick = (option) => {
     close();
-    if (option.value !== value) onChange?.(option.value);
+    if (option.value !== value) emit(option.value);
   };
 
   const move = (delta) => {
@@ -225,7 +230,7 @@ export function Select({
     const i = typeAhead(char, normalized, current, (o) => o.label);
     if (i < 0) return;
     if (open) setActiveIndex(i);
-    else if (normalized[i].value !== value) onChange?.(normalized[i].value);
+    else if (normalized[i].value !== value) emit(normalized[i].value);
   };
 
   // keep the highlighted option visible while arrowing through a menu that

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -4,6 +4,7 @@
 
 import React, { useRef, useState } from 'react';
 import { useTheme } from './theme.js';
+import { changeEvent } from './change.js';
 import {
   XK_DOWN,
   XK_END,
@@ -37,6 +38,7 @@ export function Slider({
   max = 100,
   step = 1,
   onChange,
+  name,
   disabled = false,
   height = 4,
   style,
@@ -60,7 +62,7 @@ export function Slider({
   const fraction = (clamp(value) - min) / span;
 
   const emit = (next) => {
-    if (next !== value) onChange?.(next);
+    if (next !== value) onChange?.(next, changeEvent('range', name, next));
   };
 
   /** Pointer x -> value, using the track's laid-out rect. */

--- a/src/components/Switch.js
+++ b/src/components/Switch.js
@@ -4,6 +4,7 @@
 
 import React from 'react';
 import { createStyles } from '../styles.js';
+import { changeEvent } from './change.js';
 import { useControl, useTheme } from './theme.js';
 
 const h = React.createElement;
@@ -50,14 +51,17 @@ const THUMB_ON = TRACK_WIDTH - THUMB - INSET;
 export function Switch({
   checked = false,
   onChange,
+  name,
   disabled = false,
   style,
   ...boxProps
 }) {
   const theme = useTheme();
-  const control = useControl(disabled, () => onChange?.(!checked), {
-    styled: true,
-  });
+  const control = useControl(
+    disabled,
+    () => onChange?.(!checked, changeEvent('checkbox', name, !checked)),
+    { styled: true },
+  );
   return h(
     'box',
     {

--- a/src/components/change.js
+++ b/src/components/change.js
@@ -1,0 +1,30 @@
+// The change event the widgets pass as their `onChange`'s *second*
+// argument.
+//
+// The host elements `<textinput>`/`<textarea>` hand their handler a single
+// synthetic event (issue #115). The widgets cannot: `onChange={setChecked}`
+// is the whole ergonomic point of them, and the next value has to stay the
+// first argument. So the event is additive — the first argument is the
+// value, the second is this — which is enough for a form library, because
+// every one of them reads the field out of `ev.target`.
+//
+// `target` is a plain descriptor rather than a node: a widget is a
+// composition of nodes with no single element holding its value, and
+// `{ type, name, value, checked }` is exactly the shape formik's
+// `handleChange` and react-hook-form's `getEventValue` destructure. `type`
+// is what tells them a checkbox from a text field, which is why it is set
+// even though nothing in react-x11 reads it.
+//
+// There is no `preventDefault` — the value has already changed by the time
+// the handler runs, so there would be nothing to prevent.
+
+/**
+ * @param {string} type - `'checkbox'`, `'radio'`, `'select-one'`, `'range'`…
+ * @param {string|undefined} name - the widget's `name` prop
+ * @param {unknown} value - the value the widget just moved to
+ */
+export function changeEvent(type, name, value) {
+  const target = { type, name, value };
+  if (type === 'checkbox') target.checked = Boolean(value);
+  return { type: 'change', target, currentTarget: target, name, value };
+}

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -2055,6 +2055,11 @@ export class TextInputNode extends Node {
     this.defaultCursor = 'text';
     this._value =
       props.defaultValue != null ? String(props.defaultValue) : null;
+    // set only while an onChange/onSubmit handler is on the stack — see
+    // `get value()` and `_fireValueEvent`
+    this._pendingValue = null;
+    // the X key event driving the current edit, for `ev.nativeEvent`
+    this._keyNative = null;
     this._caret = this._chars().length;
     this._anchor = this._caret;
     this._scrollX = 0;
@@ -2083,8 +2088,103 @@ export class TextInputNode extends Node {
   }
 
   get value() {
+    // While an onChange handler is running, the control's value is the one
+    // the edit produced — the DOM behaves the same way, and it is what makes
+    // `ev.target.value` right in *controlled* mode, where `props.value` is
+    // still the old string until the parent re-renders.
+    if (this._pendingValue !== null) return this._pendingValue;
     if (this.props.value != null) return String(this.props.value);
     return this._value ?? '';
+  }
+
+  /**
+   * Writing `node.value = 'x'` sets the text the way typing would, minus the
+   * `onChange` — assigning to a DOM input's `value` does not fire one
+   * either. It exists because form libraries reset a field through the ref:
+   * react-hook-form's `register()` does `ref.value = ''` on mount and on
+   * `reset()`, and a getter-only `value` made that a TypeError during commit.
+   *
+   * On a **controlled** input `props.value` still wins the next time the
+   * parent renders, exactly as in the DOM.
+   */
+  set value(next) {
+    const text = next == null ? '' : String(next);
+    if (text === this._value) return;
+    this._value = text;
+    const len = Array.from(text).length;
+    this._caret = Math.min(this._caret, len);
+    this._anchor = Math.min(this._anchor, len);
+    // same bookkeeping a value arriving through props gets: its own undo
+    // entry, so Ctrl+Z steps back through a programmatic reset too
+    this._noteExternalValue();
+    this._repaint();
+  }
+
+  /** The `name` prop, so `ev.target.name` reads the way the DOM does. */
+  get name() {
+    return this.props.name;
+  }
+
+  /**
+   * The synthetic event `onChange` and `onSubmit` are handed. Same shape
+   * every other handler in the system gets — `_makeEvent` builds it — with
+   * the value on both `ev.value` and `ev.target.value`, and `name` mirrored
+   * the same way, because that is what every DOM form library reads.
+   *
+   * `_makeEvent` lives on the owning window's EventManager; a node that is
+   * not attached to one (a unit test, an edit that outlives its window) gets
+   * an equivalent object rather than nothing.
+   */
+  _makeValueEvent(type, native) {
+    // not dispatched through the tree, so currentTarget is the target —
+    // exactly what the DOM reports for a handler on the element itself
+    const extra = {
+      value: this.value,
+      name: this.props.name,
+      currentTarget: this,
+    };
+    const events = this.root?.events;
+    if (events) return events._makeEvent(type, native, this, extra);
+    const ev = {
+      type,
+      x: native?.x ?? 0,
+      y: native?.y ?? 0,
+      target: this,
+      nativeEvent: native ?? null,
+      shiftKey: Boolean(native?.buttons & 1),
+      ctrlKey: Boolean(native?.buttons & 4),
+      defaultPrevented: false,
+      propagationStopped: false,
+      preventDefault() {
+        ev.defaultPrevented = true;
+      },
+      stopPropagation() {
+        ev.propagationStopped = true;
+      },
+      capturePointer() {},
+      releasePointer() {},
+      ...extra,
+    };
+    return ev;
+  }
+
+  /**
+   * Call `onChange`/`onSubmit` with `value` as the control's current value,
+   * whatever `props.value` still says. Restored in a `finally` so a throwing
+   * handler cannot leave the control reporting a value it never took.
+   */
+  _fireValueEvent(prop, value, native = null) {
+    const handler = this.props[prop];
+    if (!handler) return;
+    native ??= this._keyNative;
+    const previous = this._pendingValue;
+    this._pendingValue = value;
+    const type = prop === 'onSubmit' ? 'submit' : 'change';
+    try {
+      callHandler(this, prop, handler, this._makeValueEvent(type, native));
+    } finally {
+      this._pendingValue = previous;
+    }
   }
 
   _chars() {
@@ -2173,7 +2273,7 @@ export class TextInputNode extends Node {
         beforeCaret,
         beforeAnchor,
       });
-      this.props.onChange?.(next);
+      this._fireValueEvent('onChange', next);
     }
     this._repaint();
   }
@@ -2228,7 +2328,7 @@ export class TextInputNode extends Node {
     const len = Array.from(value).length;
     this._caret = Math.min(Math.max(0, caret), len);
     this._anchor = Math.min(Math.max(0, anchor), len);
-    if (value !== previous) this.props.onChange?.(value);
+    if (value !== previous) this._fireValueEvent('onChange', value);
     this._repaint();
   }
 
@@ -2352,13 +2452,32 @@ export class TextInputNode extends Node {
 
   // --- default actions (run after user handlers unless preventDefault) ---
 
+  /**
+   * Remember the X event driving the edit so the `onChange` it produces can
+   * carry it on `nativeEvent`. Subclasses override `_editKeyDown`, not this,
+   * so the bookkeeping cannot be forgotten in one of them.
+   *
+   * Only keystrokes get this far. A paste resolves a promise, an undo is not
+   * an input event at all, and a value pushed from a parent has no X event
+   * behind it — those report `nativeEvent: null`, which is the truth.
+   */
   _defaultKeyDown(ev) {
+    const previous = this._keyNative;
+    this._keyNative = ev.nativeEvent ?? null;
+    try {
+      this._editKeyDown(ev);
+    } finally {
+      this._keyNative = previous;
+    }
+  }
+
+  _editKeyDown(ev) {
     const [a, b] = this._selection();
     const hasSelection = a !== b;
     const k = ev.keysym;
 
     if (k === XK_RETURN || k === XK_KP_ENTER) {
-      this.props.onSubmit?.(this.value, ev);
+      this._fireValueEvent('onSubmit', this.value, ev.nativeEvent);
       return;
     }
     if (k === XK_BACKSPACE) {
@@ -3033,13 +3152,13 @@ export class TextAreaNode extends TextInputNode {
     return layout.indexAt(x, line.y + (line.ascent + line.descent) / 2);
   }
 
-  _defaultKeyDown(ev) {
+  _editKeyDown(ev) {
     const k = ev.keysym;
     const layout = this._valueLayout();
 
     if (k === XK_RETURN || k === XK_KP_ENTER) {
       if (ev.ctrlKey) {
-        this.props.onSubmit?.(this.value, ev);
+        this._fireValueEvent('onSubmit', this.value, ev.nativeEvent);
         return;
       }
       this._goalX = null;
@@ -3080,7 +3199,7 @@ export class TextAreaNode extends TextInputNode {
       return;
     }
     this._goalX = null;
-    super._defaultKeyDown(ev);
+    super._editKeyDown(ev);
   }
 
   /** Thumb for the vertical overflow, same look as <scrollview>'s. */

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -62,6 +62,40 @@ export function useTheme(): Theme;
 /** Props a widget passes through to the `<box>` it renders. */
 type WidgetProps = Omit<BoxProps, 'children' | 'style' | 'ref'>;
 
+/**
+ * The second argument a widget's `onChange` gets, after the next value.
+ *
+ * The value stays first — `onChange={setChecked}` is what these widgets are
+ * for — and this carries the field identity a form library needs.
+ * `target` is a plain descriptor, not a node: a widget is several nodes and
+ * none of them holds its value. Its shape is what formik's `handleChange`
+ * and react-hook-form's event reader destructure, `type` included.
+ */
+export interface WidgetChangeEvent<V = unknown> {
+  type: 'change';
+  target: {
+    /** `'checkbox'`, `'radio'`, `'select-one'`, `'range'`. */
+    type: string;
+    name?: string;
+    value: V;
+    /** Checkbox and switch only. */
+    checked?: boolean;
+  };
+  currentTarget: WidgetChangeEvent<V>['target'];
+  name?: string;
+  value: V;
+}
+
+/** Widgets that are one form field: they take a `name` and echo it back. */
+interface NamedWidget {
+  /**
+   * Field name, echoed on the change event as `ev.name` and
+   * `ev.target.name`. Nothing in react-x11 reads it — it is there so a form
+   * library has somewhere to put one.
+   */
+  name?: string;
+}
+
 export interface ButtonProps extends WidgetProps {
   children?: ReactNode;
   label?: string;
@@ -72,19 +106,19 @@ export interface ButtonProps extends WidgetProps {
 }
 export const Button: ComponentType<ButtonProps>;
 
-export interface CheckboxProps extends WidgetProps {
+export interface CheckboxProps extends WidgetProps, NamedWidget {
   children?: ReactNode;
   label?: string;
   checked?: boolean;
-  onChange?: (checked: boolean) => void;
+  onChange?: (checked: boolean, ev: WidgetChangeEvent<boolean>) => void;
   disabled?: boolean;
   style?: StyleProp;
 }
 export const Checkbox: ComponentType<CheckboxProps>;
 
-export interface RadioGroupProps<T = unknown> extends WidgetProps {
+export interface RadioGroupProps<T = unknown> extends WidgetProps, NamedWidget {
   value?: T;
-  onChange?: (value: T) => void;
+  onChange?: (value: T, ev: WidgetChangeEvent<T>) => void;
   children?: ReactNode;
   style?: StyleProp;
 }
@@ -98,9 +132,9 @@ export interface RadioProps<T = unknown> {
 }
 export function Radio<T = unknown>(props: RadioProps<T>): ReactNode;
 
-export interface SwitchProps extends WidgetProps {
+export interface SwitchProps extends WidgetProps, NamedWidget {
   checked?: boolean;
-  onChange?: (checked: boolean) => void;
+  onChange?: (checked: boolean, ev: WidgetChangeEvent<boolean>) => void;
   disabled?: boolean;
   style?: StyleProp;
 }
@@ -116,12 +150,12 @@ export interface ProgressBarProps extends WidgetProps {
 }
 export const ProgressBar: ComponentType<ProgressBarProps>;
 
-export interface SliderProps extends WidgetProps {
+export interface SliderProps extends WidgetProps, NamedWidget {
   value?: number;
   min?: number;
   max?: number;
   step?: number;
-  onChange?: (value: number) => void;
+  onChange?: (value: number, ev: WidgetChangeEvent<number>) => void;
   disabled?: boolean;
   height?: number;
   style?: StyleProp;
@@ -156,10 +190,10 @@ export const Dialog: ComponentType<DialogProps>;
 /** An option, or a plain value used as both value and label. */
 export type SelectOption<T = unknown> = { value: T; label: string } | T;
 
-export interface SelectProps<T = unknown> extends WidgetProps {
+export interface SelectProps<T = unknown> extends WidgetProps, NamedWidget {
   value?: T;
   options?: readonly SelectOption<T>[];
-  onChange?: (value: T) => void;
+  onChange?: (value: T, ev: WidgetChangeEvent<T>) => void;
   placeholder?: string;
   style?: StyleProp;
 }

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -13,9 +13,11 @@ import type {
   TextInputNode,
 } from './nodes.js';
 import type {
+  ChangeEvent,
   EventHandlers,
   MouseEvent,
   ScrollEvent,
+  SubmitEvent,
   SyntheticEvent,
   ViewportEvent,
 } from './events.js';
@@ -189,9 +191,20 @@ export interface TextInputProps extends DrawnProps<TextInputNode> {
   value?: string;
   /** Uncontrolled mode. */
   defaultValue?: string;
-  onChange?: (text: string) => void;
+  /**
+   * Field name, echoed on the event as `ev.name` and `ev.target.name`.
+   * Nothing in the renderer reads it — it exists so form libraries, which
+   * key a field by its name, have somewhere to put one.
+   */
+  name?: string;
+  /**
+   * The value changed. `ev.target.value` and `ev.value` are both the new
+   * text, so `(ev) => setText(ev.target.value)` and `(ev) => setText(ev.value)`
+   * both read naturally.
+   */
+  onChange?: (ev: ChangeEvent<TextInputNode>) => void;
   /** Enter — or Ctrl+Enter in a `<textarea>`. */
-  onSubmit?: (text: string, ev: unknown) => void;
+  onSubmit?: (ev: SubmitEvent<TextInputNode>) => void;
   placeholder?: string;
   placeholderColor?: Color;
   /** Code-point limit. */

--- a/src/types/events.d.ts
+++ b/src/types/events.d.ts
@@ -4,7 +4,7 @@
  * DOM. See docs/events.md.
  */
 
-import type { DrawnNode } from './nodes.js';
+import type { DrawnNode, TextInputNode } from './nodes.js';
 
 /** The raw ntk/X11 event a synthetic one was made from. */
 export interface NativeEvent {
@@ -77,6 +77,38 @@ export interface KeyboardEvent<T = DrawnNode> extends SyntheticEvent<T> {
 }
 
 export interface FocusEvent<T = DrawnNode> extends SyntheticEvent<T> {}
+
+/**
+ * `<textinput onChange>` / `<textarea onChange>`. The value is on both
+ * `ev.value` and `ev.target.value` — the second is what every DOM form
+ * library reads, and it is the *new* value even in controlled mode, where
+ * `props.value` is still the old string until the parent re-renders.
+ *
+ * `nativeEvent` is the X key event when a keystroke drove the edit, and null
+ * when nothing did — a paste resolving, an undo, a value the parent pushed
+ * back. Guard it.
+ */
+export interface ChangeEvent<T = TextInputNode> extends Omit<
+  SyntheticEvent<T>,
+  'nativeEvent'
+> {
+  type: 'change';
+  value: string;
+  /** The control's `name` prop, mirrored from `target.name`. */
+  name?: string;
+  nativeEvent: NativeEvent | null;
+}
+
+/**
+ * `<textinput onSubmit>` — Enter, or Ctrl+Enter in a `<textarea>`. Same
+ * shape as {@link ChangeEvent}; `nativeEvent` is the X key event.
+ */
+export interface SubmitEvent<T = TextInputNode> extends Omit<
+  ChangeEvent<T>,
+  'type'
+> {
+  type: 'submit';
+}
 
 /** `<scrollview onScroll>`. */
 export interface ScrollEvent {

--- a/src/types/nodes.d.ts
+++ b/src/types/nodes.d.ts
@@ -50,7 +50,19 @@ export interface ScrollViewNode extends DrawnNode {
 
 /** `<textinput>` / `<textarea>`. */
 export interface TextInputNode extends DrawnNode {
-  readonly value: string;
+  /**
+   * The control's current text. Inside an `onChange` handler this is the
+   * value the edit produced, even in controlled mode — which is what makes
+   * `ev.target.value` mean what a DOM form library expects it to.
+   *
+   * Writable, as a DOM input's `value` is: assigning sets the text without
+   * firing `onChange`, and on a controlled input the next render puts
+   * `props.value` back. react-hook-form's `register()` resets a field this
+   * way.
+   */
+  value: string;
+  /** The `name` prop, for form libraries that key fields by it. */
+  readonly name?: string;
   /**
    * Step back one edit, as Ctrl+Z does. False when there is nothing to
    * undo. Controlled inputs report the restored value through `onChange`,

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -832,8 +832,8 @@ test('textinput: typing, backspace, arrows, submit (uncontrolled)', async () => 
       { width: 200, height: 50 },
       React.createElement('textinput', {
         defaultValue: '',
-        onChange: (v) => changes.push(v),
-        onSubmit: (v) => (submitted = v),
+        onChange: (ev) => changes.push(ev.target.value),
+        onSubmit: (ev) => (submitted = ev.target.value),
         style: { flexGrow: 1 },
       }),
     ),
@@ -878,7 +878,7 @@ test('textinput: controlled value does not change until props do', async () => {
         { width: 200, height: 50 },
         React.createElement('textinput', {
           value,
-          onChange: (v) => changes.push(v),
+          onChange: (ev) => changes.push(ev.target.value),
           style: { flexGrow: 1 },
         }),
       ),
@@ -901,6 +901,185 @@ test('textinput: controlled value does not change until props do', async () => {
   assert.strictEqual(input.value, 'abcx');
 
   ReactX11.unmountComponentAtNode(app);
+});
+
+// issue #115: onChange/onSubmit hand over a synthetic event like every other
+// handler, so `e.target.value` — what react-hook-form, formik and every
+// tutorial's controlled input read — is the value the edit produced.
+test('textinput: onChange gets a synthetic event carrying value and name', async () => {
+  const app = createMockApp();
+  const events = [];
+  // `ev.target` is the live node, so what it reports has to be sampled while
+  // the handler runs — that is the moment form libraries read it
+  const seen = [];
+  const record = (ev) => {
+    events.push(ev);
+    seen.push({ value: ev.target.value, name: ev.target.name });
+  };
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 200, height: 50 },
+      React.createElement('textinput', {
+        // controlled and never re-rendered: props.value stays 'ab', so a
+        // stale read is visible rather than hidden by the uncontrolled path
+        value: 'ab',
+        name: 'email',
+        onChange: record,
+        onSubmit: record,
+        style: { flexGrow: 1 },
+      }),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const input = wnd._reactX11Node.children[0];
+  wnd.emit('mousedown', { x: 10, y: 10, keycode: 1 });
+  wnd.emit('mouseup', { x: 10, y: 10, keycode: 1 });
+
+  pressKey(app, wnd, { keysym: 0x63, codepoint: 0x63 }); // c
+  assert.strictEqual(events.length, 1);
+  const change = events[0];
+  assert.strictEqual(change.type, 'change');
+  assert.strictEqual(change.value, 'abc');
+  assert.strictEqual(change.name, 'email');
+  assert.strictEqual(change.target, input, 'target is the public node');
+  assert.strictEqual(change.currentTarget, input);
+  assert.deepStrictEqual(
+    seen[0],
+    { value: 'abc', name: 'email' },
+    'target.value is the new value, not the stale controlled prop',
+  );
+  assert.strictEqual(typeof change.preventDefault, 'function');
+  assert.strictEqual(typeof change.stopPropagation, 'function');
+  // a keystroke carries the X event it came from — downshift reads
+  // `ev.nativeEvent.preventDownshiftDefault` and a null there is a TypeError
+  assert.strictEqual(change.nativeEvent?.codepoint, 0x63);
+
+  // and the control is back to reporting its prop once the handler returns
+  assert.strictEqual(input.value, 'ab');
+
+  pressKey(app, wnd, { keysym: XK.Return });
+  const submit = events[1];
+  assert.strictEqual(submit.type, 'submit');
+  assert.strictEqual(submit.value, 'ab');
+  assert.strictEqual(submit.target, input);
+  assert.strictEqual(submit.name, 'email');
+  assert.deepStrictEqual(seen[1], { value: 'ab', name: 'email' });
+  assert.ok(submit.nativeEvent, 'submit carries the key event it came from');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+// react-hook-form's register() hands the field ref back and writes through
+// it: `ref.value = ''` on mount and on reset(). A getter-only `value` made
+// that a TypeError during commit, which took the whole render down.
+test('textinput: node.value is writable, the way a DOM input is', async () => {
+  const app = createMockApp();
+  const changes = [];
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 200, height: 50 },
+      React.createElement('textinput', {
+        defaultValue: 'start',
+        onChange: (ev) => changes.push(ev.value),
+        style: { flexGrow: 1 },
+      }),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const input = wnd._reactX11Node.children[0];
+
+  input.value = 'written';
+  assert.strictEqual(input.value, 'written');
+  assert.deepStrictEqual(changes, [], 'assigning does not fire onChange');
+
+  input.value = '';
+  assert.strictEqual(input.value, '');
+  // and it took an undo entry, like a value pushed in through props
+  assert.strictEqual(input.undo(), true);
+  assert.strictEqual(input.value, 'written');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('textarea: Ctrl+Enter submits with the same event shape', async () => {
+  const app = createMockApp();
+  let submitted = null;
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 200, height: 90 },
+      React.createElement('textarea', {
+        defaultValue: 'note',
+        name: 'body',
+        onSubmit: (ev) => (submitted = ev),
+        style: { flexGrow: 1 },
+      }),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  wnd.emit('mousedown', { x: 10, y: 10, keycode: 1 });
+  wnd.emit('mouseup', { x: 10, y: 10, keycode: 1 });
+  pressKey(app, wnd, { keysym: XK.Return, buttons: CTRL });
+  assert.strictEqual(submitted?.type, 'submit');
+  assert.strictEqual(submitted.value, 'note');
+  assert.strictEqual(submitted.target.value, 'note');
+  assert.strictEqual(submitted.name, 'body');
+  assert.strictEqual(submitted.target.name, 'body');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+// a throwing handler must not leave the control reporting a value it never
+// took — `_pendingValue` is restored in a finally
+test('textinput: a throwing onChange does not strand the pending value', async () => {
+  const app = createMockApp();
+  const errors = [];
+  const console_error = console.error;
+  console.error = (...args) => errors.push(args);
+  try {
+    ReactX11.render(
+      React.createElement(
+        'window',
+        { width: 200, height: 50 },
+        React.createElement('textinput', {
+          value: 'ab',
+          onChange: () => {
+            throw new Error('boom');
+          },
+          style: { flexGrow: 1 },
+        }),
+      ),
+      null,
+      app,
+    );
+    await tick();
+    const wnd = app.windows[0];
+    const input = wnd._reactX11Node.children[0];
+    wnd.emit('mousedown', { x: 10, y: 10, keycode: 1 });
+    wnd.emit('mouseup', { x: 10, y: 10, keycode: 1 });
+    pressKey(app, wnd, { keysym: 0x63, codepoint: 0x63 });
+    assert.strictEqual(input.value, 'ab');
+    assert.strictEqual(
+      errors.length,
+      1,
+      'the throw is reported, not swallowed',
+    );
+    ReactX11.unmountComponentAtNode(app);
+  } finally {
+    console.error = console_error;
+    process.exitCode = 0;
+  }
 });
 
 test('textinput: clipboard shortcuts and middle-click PRIMARY paste', async () => {
@@ -1697,6 +1876,92 @@ test('Checkbox and Switch toggle through onChange', async () => {
     ['check', false],
     ['switch', true],
   ]);
+  ReactX11.unmountComponentAtNode(app);
+});
+
+// issue #115: the widgets keep `onChange(next)` — that is what they are for
+// — and carry the form-library-shaped event as a second argument.
+test("widgets pass a named change event as onChange's second argument", async () => {
+  const { Checkbox, RadioGroup, Radio, Slider } =
+    await import('../src/index.js');
+  const app = createMockApp();
+  const events = [];
+  function Wrapper() {
+    const [checked, setChecked] = React.useState(false);
+    const [flavour, setFlavour] = React.useState('a');
+    return React.createElement(
+      'box',
+      {
+        style: { flexGrow: 1, padding: 10, gap: 10, alignItems: 'flex-start' },
+      },
+      React.createElement(
+        Checkbox,
+        {
+          checked,
+          name: 'agree',
+          onChange: (next, ev) => {
+            events.push(ev);
+            setChecked(next);
+          },
+        },
+        'Agree',
+      ),
+      React.createElement(
+        RadioGroup,
+        {
+          value: flavour,
+          name: 'flavour',
+          onChange: (next, ev) => {
+            events.push(ev);
+            setFlavour(next);
+          },
+        },
+        React.createElement(Radio, { value: 'a' }, 'A'),
+        React.createElement(Radio, { value: 'b' }, 'B'),
+      ),
+      React.createElement(Slider, {
+        value: 10,
+        name: 'volume',
+        onChange: (next, ev) => events.push(ev),
+        style: { width: 100 },
+      }),
+    );
+  }
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 300, height: 240 },
+      React.createElement(Wrapper),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const focusable = findAllFocusable(wnd._reactX11Node);
+
+  clickNode(wnd, focusable[0]); // the checkbox
+  await tick();
+  clickNode(wnd, focusable[2]); // the second radio
+  await tick();
+  // the slider moves by keyboard: a click's value depends on laid-out width
+  focusable[3].focus?.();
+  pressKey(app, wnd, { keysym: 0xff53 }); // Right
+  await tick();
+
+  assert.deepStrictEqual(
+    events.map((ev) => [ev.target.type, ev.name, ev.value]),
+    [
+      ['checkbox', 'agree', true],
+      ['radio', 'flavour', 'b'],
+      ['range', 'volume', 11],
+    ],
+  );
+  // formik reads target.checked for a checkbox, react-hook-form reads it
+  // after testing target.type — both have to find it
+  assert.strictEqual(events[0].target.checked, true);
+  assert.strictEqual(events[0].target.name, 'agree');
+  assert.strictEqual(events[1].target.checked, undefined);
   ReactX11.unmountComponentAtNode(app);
 });
 
@@ -3546,7 +3811,7 @@ test('textinput: Ctrl+arrow moves by word, Ctrl+Backspace/Delete removes one', a
       { width: 300, height: 80 },
       React.createElement('textinput', {
         defaultValue: 'foo-bar baz_qux end',
-        onChange: (v) => changes.push(v),
+        onChange: (ev) => changes.push(ev.target.value),
       }),
     ),
     null,
@@ -3779,9 +4044,9 @@ test('textinput: undo in controlled mode reports through onChange', async () => 
         { width: 300, height: 80 },
         React.createElement('textinput', {
           value,
-          onChange: (v) => {
-            changes.push(v);
-            render(v);
+          onChange: (ev) => {
+            changes.push(ev.target.value);
+            render(ev.target.value);
           },
         }),
       ),

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -36,6 +36,7 @@ import {
   useTheme,
 } from '../../src/index.js';
 import type {
+  ChangeEvent,
   DrawnNode,
   KeyboardEvent,
   MouseEvent,
@@ -46,6 +47,7 @@ import type {
   StyleProp,
   TextInputNode,
   WheelEvent,
+  WidgetChangeEvent,
 } from '../../src/index.js';
 
 // --- styles ----------------------------------------------------------------
@@ -136,12 +138,24 @@ function Elements() {
       <textinput
         ref={inputRef}
         value={text}
-        onChange={setText}
-        onSubmit={(value) => void value.length}
+        name="subject"
+        // issue #115: both idioms have to type-check — `ev.target.value` is
+        // what every DOM form library reads, `ev.value` is the short form
+        onChange={(ev) => setText(ev.target.value || ev.value)}
+        onSubmit={(ev) => void (ev.value.length + (ev.name?.length ?? 0))}
         placeholder="type"
         maxLength={40}
         focusable
         tabIndex={0}
+      />
+      <textarea
+        name="body"
+        onChange={(ev: ChangeEvent<TextInputNode>) => {
+          ev.preventDefault();
+          void (ev.type === 'change' && ev.target.value);
+          // null for an edit with no single X event behind it
+          void ev.nativeEvent?.keycode;
+        }}
       />
       <Button
         label="Undo"
@@ -288,20 +302,42 @@ function Widgets() {
         <Checkbox checked={checked} onChange={setChecked}>
           check
         </Checkbox>
-        <Switch checked={checked} onChange={setChecked} />
+        {/* issue #115: the next value stays first, so `onChange={setChecked}`
+            still checks; the form event is an optional second argument */}
+        <Checkbox
+          checked={checked}
+          name="agree"
+          onChange={(next, ev: WidgetChangeEvent<boolean>) => {
+            void (ev.target.type === 'checkbox' && ev.target.checked);
+            setChecked(next);
+          }}
+        />
+        <Switch checked={checked} name="notify" onChange={setChecked} />
         <ProgressBar value={0.4} color="#2980b9" />
-        <Slider value={20} min={0} max={100} step={5} onChange={() => {}} />
+        <Slider
+          value={20}
+          min={0}
+          max={100}
+          step={5}
+          name="volume"
+          onChange={(v, ev) => void (v.toFixed() + ev.target.type)}
+        />
         <Tooltip label="hi" placement="bottom" delay={200}>
           <box />
         </Tooltip>
 
-        <RadioGroup<string> value="a" onChange={(v) => void v.toUpperCase()}>
+        <RadioGroup<string>
+          value="a"
+          name="flavour"
+          onChange={(v, ev) => void (v.toUpperCase() + ev.name)}
+        >
           <Radio value="a">A</Radio>
           <Radio value="b" label="B" />
         </RadioGroup>
 
         <Select<number>
           value={1}
+          name="qty"
           options={[{ value: 1, label: 'one' }]}
           onChange={(v) => void v.toFixed()}
         />

--- a/website/src/demos/tasks.js
+++ b/website/src/demos/tasks.js
@@ -82,7 +82,7 @@ function App() {
       <box style={{ flexDirection: 'row', gap: 8 }}>
         <textinput
           value={draft}
-          onChange={setDraft}
+          onChange={(ev) => setDraft(ev.target.value)}
           onSubmit={submit}
           placeholder="what needs doing?"
           style={{


### PR DESCRIPTION
Closes #115.

## The problem

Every event in the system is a synthetic event object with `target` /
`currentTarget` / `preventDefault` — except the one people wire up first.
`<textinput onChange>` handed the handler a bare string, `onSubmit` got
`(text, ev: unknown)`, and there was no `name` prop anywhere. Every DOM form
library reads `e.target.value` and `e.target.name`; here that was
`undefined.value` on the first keystroke.

## The change

`onChange` and `onSubmit` route through the existing `_makeEvent`:

```jsx
<textinput name="email" value={v} onChange={(ev) => setV(ev.target.value)} />
```

The value is on both `ev.value` and `ev.target.value`, `name` likewise, and
`target` is the public node like every other handler in the system.

Three details that only showed up once a real library was pointed at it:

- **`ev.target.value` is the new value even in controlled mode**, where
  `props.value` is still the old string until the parent re-renders. A
  `_pendingValue` covers the duration of the handler, restored in a `finally`
  so a throwing handler cannot strand it.
- **`node.value` is writable.** react-hook-form's `register()` assigns
  `ref.value = ''` while registering a field; against a getter-only accessor
  that threw from inside `commitAttachRef` and took the whole render down.
  Assigning now sets the text without firing `onChange` — as on a DOM input —
  and takes its own undo entry.
- **`ev.nativeEvent` is the X key event** when a keystroke drove the edit.
  downshift reads `event.nativeEvent.preventDownshiftDefault` unguarded, so a
  null there is a `TypeError` rather than a no-op. It stays null for a paste,
  an undo, or a value pushed back by a parent — nothing X-side produced those.

The widget layer keeps `onChange(next)` — `onChange={setChecked}` is the
whole point of it — and gains the form event as an additive second argument
plus `name`: `Checkbox`, `Switch`, `RadioGroup`, `Select`, `Slider`.
`ev.target` there is a `{ type, name, value, checked }` descriptor, which is
the shape formik's `handleChange` and react-hook-form's event reader
destructure.

## Verified, not assumed

The ecosystem docs' standard is "established by running the library, not by
reading its documentation", so this was too — headless against this renderer,
14 checks:

| library | before | after |
| --- | --- | --- |
| `react-hook-form` 7.84.0 | `<Controller>` only | `register()`, `handleSubmit`, `setValue`, `setFocus`, `<Controller>` |
| `formik` 2.4.9 | silent no-op on `getFieldProps` | spread, `handleChange`, `<Field>`, and a `Checkbox` |
| `downshift` 9.4.0 | TypeError on the first keystroke | works |
| `@tanstack/react-form` 1.33.2 | no glue | **one unwrap per field** |

That last row is the cost, and `docs/ecosystem/forms.md` leads with it: a
library whose field contract is value-in/value-out no longer lines up by
accident, and a bare `onChange={field.handleChange}` now stores the event
object as the field value with no error. `react-hook-form`'s `reset()` is
also written up precisely — it updates form state but does not clear an
uncontrolled field's text, because RHF only writes back through refs when its
`isWeb` probe passes. `setValue()` is not gated that way and does.

## Docs

- `docs/elements.md` — a "The change event" section: the full event shape,
  why `target.value` is the new value, and that `ev.target` is live so a
  handler stashing the event sees later state.
- `docs/components.md` — "The change event, and `name`" for the widget layer.
- `docs/ecosystem/forms.md` — rewritten around what now works, with a new
  Formik section and the TanStack unwrap called out.
- `docs/ecosystem.md` — two entries leave the negative-results register; the
  `nativeEvent` and value-setter shapes replace them as what to watch for.

No visual change, so no screenshots.

## Checks

`npm test` 304 pass / 0 fail (5 new tests), `npm run typecheck`,
`npm run lint`, and `website`'s three gates green — including the `tasks`
demo, which drives a `<textinput>` through the real renderer with injected
input.