### PR TITLE
feat: a dialog the window manager knows belongs to its parent (`transientFor`, `windowIdOf`)

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -283,7 +283,11 @@ classic annoyance. The popup is sized from the _measured_ label, because a
 
 ## `Dialog`
 
-A modal dialog in a `<popup trapFocus grab>`, centred over the owner window.
+A dialog in a `<popup>`, centred over the owner window — and one the
+**window manager knows is a dialog**: it is a managed window with
+`WM_TRANSIENT_FOR` pointing at its owner, so it is framed, movable, closable
+through the WM, out of the taskbar and alt-tab list, and (on a full EWMH
+window manager) stacked above its owner and iconified with it.
 
 ```jsx
 import { Button, Dialog } from 'react-x11';
@@ -309,7 +313,8 @@ import { Button, Dialog } from 'react-x11';
 | `title`           | bold heading (optional)                                      |
 | `children`        | body content; strings become `<text>`                        |
 | `actions`         | elements for the right-aligned button row                    |
-| `onClose`         | Escape, or a press outside the dialog                        |
+| `onClose`         | Escape, or the window manager's close button                 |
+| `managed`         | `false` for the override-redirect popup 1.x shipped (below)  |
 | `width`, `height` | popup size (default 360×170)                                 |
 
 The focus behaviour is the **renderer's**, not the component's: `trapFocus`
@@ -321,10 +326,32 @@ inside to pick the first stop; with nothing to focus, the dialog surface
 takes focus itself (`tabIndex={-1}`) so Escape and Tab work immediately.
 
 Escape closes because keys go to the focused node inside the popup and
-bubble out through the popup's place in the JSX tree; `grab` makes a press
-anywhere else in the session close it too. **Pointer modality is not
+bubble out through the popup's place in the JSX tree; so does the window
+manager's close button, through `onCloseRequest`. **Pointer modality is not
 enforced** — widgets in the owner window stay clickable behind the dialog —
-so it is for confirmations, not for guarding state.
+so it is for confirmations, not for guarding state. (`_NET_WM_STATE_MODAL`
+is the mechanism that would enforce it, and it means nothing without the
+`WM_TRANSIENT_FOR` this now sets; that is why the property had to come
+first.)
+
+### `managed`
+
+| `managed`        | what you get                                                                                                                                        |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `true` (default) | a WM-managed window: frame, titlebar, movable, WM close button, transient for its owner, out of the taskbar. A press outside does **not** close it. |
+| `false`          | the override-redirect popup: no frame, not movable, a pointer grab, and a press anywhere outside calls `onClose`.                                   |
+
+They are one choice, not two: a client-side pointer grab over a window the
+window manager is trying to let the user drag swallows the press that would
+start the drag, so `grab` and the frame turn on and off together. A managed
+dialog staying open when you click elsewhere is not a regression — it is what
+a dialog does. `managed={false}` is the right shape for a transient
+confirmation on a display with no window manager at all.
+
+The owner is resolved automatically: `Dialog` already keeps an out-of-flow
+`<box>` inside the owner window for placement, and a ref to any drawn node
+resolves to the window that owns it
+([`transientFor`](elements.md#transientfor--a-window-that-belongs-to-another)).
 
 A `<popup>` is a real X window and needs its size up front, hence explicit
 `width`/`height` rather than sizing to content. Placement comes from

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -91,6 +91,7 @@ A real X11 window; the flex, paint and event root for its subtree.
 | `states`                    | EWMH `_NET_WM_STATE` — controlled, see below                         |
 | `fullscreen`, `alwaysOnTop` | boolean sugar for two of those states                                |
 | `decorations`               | `false` asks the WM for no titlebar or border                        |
+| `transientFor`              | ICCCM `WM_TRANSIENT_FOR` — the window this one belongs to (below)    |
 | `onStatesChange(states)`    | what the window manager actually did                                 |
 | `theme`                     | palette that `$token` style values resolve against, for this subtree |
 
@@ -140,6 +141,63 @@ are free, so no `sizeHints` object is needed.
 On a `<window>` these names are the window's, not yoga's: `width`/`height`
 are the real geometry the user can drag, and `minWidth`/`maxHeight` are what
 the WM enforces. A window's _contents_ are laid out by its `style`.
+
+### `transientFor` — a window that belongs to another
+
+Without it, every secondary top-level window an app opens is, to the window
+manager, an unrelated second application: its own taskbar and alt-tab entry,
+placed wherever new windows go, stacked independently, and it does not
+minimise with the window it belongs to.
+
+```jsx
+const main = useRef(null);
+
+<window ref={main} title="editor">…</window>
+<window transientFor={main} windowType="dialog" title="Preferences">…</window>
+```
+
+Takes a ref to a `<window>`/`<popup>`, a ref to **any drawn node** (resolved
+to the window that owns it — so an out-of-flow `<box>` inside the owner is a
+perfectly good handle), a raw XID, `'root'` for "transient for this client's
+whole window group", or `null` to clear.
+
+Measured against quartz-wm — the thinnest EWMH implementation in the stack,
+so this is a floor rather than a best case:
+
+| the client sets       | the WM allows                                                 | the WM adds to `_NET_WM_STATE` |
+| --------------------- | ------------------------------------------------------------- | ------------------------------ |
+| nothing               | close, minimize, move, resize, maximize horz/vert, fullscreen | —                              |
+| `transientFor`        | close, minimize, move, resize                                 | skip_taskbar, skip_pager       |
+| `windowType="dialog"` | close, minimize, move, resize                                 | skip_taskbar, skip_pager       |
+
+Rows two and three matching is the EWMH rule working as specified: a managed
+window with `WM_TRANSIENT_FOR` and no `_NET_WM_WINDOW_TYPE` **is** a dialog.
+The converse does not hold — a `dialog` type with no owner is a dialog
+belonging to nobody, with nothing to stack above or iconify with — so set
+both, which is what real toolkits do. A fuller window manager also restacks
+the transient above its owner and iconifies it alongside; quartz-wm does
+neither, and both are policy rather than spec.
+
+**It is inert on an override-redirect window**, which is every `<popup>` by
+default: the WM never manages those, so nothing reads the property. ICCCM
+4.1.2.6 draws exactly that distinction — `WM_TRANSIENT_FOR` for windows the
+WM manages, override-redirect plus a pointer grab for menus. ntk warns if
+you ask it to write the property on one.
+
+Resolution happens in the **commit phase**, not at element creation: a React
+ref is not something ntk should be asked to understand. Refs attach in the
+layout phase, after every mutation, so on the commit that mounts two sibling
+`<window>`s the second realizes while the first one's ref is still null —
+that owner is retried on the frame the mount schedules rather than dropped.
+
+`windowIdOf(refOrInstance)` is the same resolution, exported: it returns the
+XID a ref points at, or null. It is also what an xdg-desktop-portal
+`parent_window` handle needs — `` `x11:${id.toString(16)}` ``, lowercase hex
+with **no** `0x` prefix. Both shipping portal backends happen to tolerate a
+prefix, which is exactly why it is easy to get wrong and never notice; Qt's
+parser returns 0 on failure with no error path, so the symptom would be a
+silently unparented, non-modal dialog. `useWindowId(ref)` is the hook form
+and returns a getter, like `useAnchor`.
 
 `decorations={false}` writes `_MOTIF_WM_HINTS` — honoured by Mutter, KWin,
 Xfwm, Openbox and i3. A window manager that ignores it simply decorates the
@@ -207,11 +265,12 @@ event root. Anchor with `ev.nativeEvent.rootx/rooty` (pointer in screen
 coordinates) or a ref's `abs` rect plus the owner window's `x`/`y`.
 Same props as `<window>`; conditional rendering controls its lifetime.
 
-| prop        |                                                                             |
-| ----------- | --------------------------------------------------------------------------- |
-| `grab`      | hold a pointer grab while the popup is up — how menus behave on X (below)   |
-| `onDismiss` | a press landed outside the popup: close it                                  |
-| `trapFocus` | own a focus scope: a modal (see [events.md](events.md#focus-scopes-modals)) |
+| prop               |                                                                             |
+| ------------------ | --------------------------------------------------------------------------- |
+| `grab`             | hold a pointer grab while the popup is up — how menus behave on X (below)   |
+| `onDismiss`        | a press landed outside the popup: close it                                  |
+| `trapFocus`        | own a focus scope: a modal (see [events.md](events.md#focus-scopes-modals)) |
+| `overrideRedirect` | `false` makes it a WM-managed window instead — a real dialog (below)        |
 
 A popup never receives the X input focus, but nodes inside it can hold the
 **owner window's** focus and receive keys — with `trapFocus` and `autoFocus`
@@ -229,6 +288,28 @@ normally, and only the root popup of a menu needs the grab. Needs
 ntk ≥ 3.7.0; on older ntk the popup behaves as it did before.
 
 `Select`, `ContextMenu` and `MenuBar` already do this.
+
+### A managed `<popup>` is a dialog
+
+`overrideRedirect` defaults to `true` and is what makes a menu a menu.
+Passing `false` gives up all of that on purpose and hands the window to the
+window manager: it is reparented into a frame, so it has a titlebar, can be
+moved, and has a WM close button (`onCloseRequest`). Together with
+`transientFor` that is a real dialog — above its owner, out of the taskbar
+and alt-tab list, minimising with the owner.
+
+```jsx
+<popup overrideRedirect={false} transientFor={anchor} windowType="dialog"
+       title="Preferences" trapFocus>
+```
+
+Turn `grab` off with it. A client-side pointer grab over a window the WM is
+trying to let the user drag swallows the press that would start the drag.
+That also means a press outside no longer dismisses it — which is correct: a
+real dialog does not close because you clicked elsewhere.
+
+The [`Dialog`](components.md#dialog) component does exactly this, and takes
+`managed={false}` to go back to the override-redirect shape.
 
 Defaults to `windowType="dropdown_menu"`; pass `windowType` to override
 (`"tooltip"`, `"popup_menu"`, …). The hint is **additive** — override-

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -83,6 +83,9 @@ function windowAttributes(props) {
   const hints = {};
   for (const key of Object.keys(props)) {
     if (key === 'children' || key === 'style' || isEventProp(key)) continue;
+    // resolved in the commit phase against a ref that has not attached yet
+    // at createInstance time — WindowNode._applyTransientFor
+    if (key === 'transientFor') continue;
     if (WINDOW_HINT_PROPS.includes(key)) {
       hints[key] = props[key];
       continue;

--- a/src/components/Dialog.js
+++ b/src/components/Dialog.js
@@ -14,8 +14,30 @@ const DEFAULT_WIDTH = 360;
 const DEFAULT_HEIGHT = 170;
 
 /**
- * <Dialog open title onClose actions>…</Dialog> — a modal dialog in a
- * `<popup trapFocus grab>`, centred over the owner window.
+ * <Dialog open title onClose actions>…</Dialog> — a dialog in a `<popup>`,
+ * centred over the owner window.
+ *
+ * **The window manager knows it is a dialog** (issue #130). The popup is a
+ * managed window — `overrideRedirect={false}` — with `WM_TRANSIENT_FOR`
+ * pointing at the window that owns it, resolved from the anchor this
+ * component already keeps for placement. Measured against quartz-wm, the
+ * thinnest EWMH implementation in the stack: the dialog is reparented into a
+ * real frame, so it has a titlebar and can be moved and closed the way every
+ * other window can; it loses maximize and fullscreen; and the WM puts
+ * SKIP_TASKBAR and SKIP_PAGER on it, so it is not a second entry in the
+ * taskbar or the alt-tab list. A fuller WM also stacks it above its owner
+ * and iconifies it alongside.
+ *
+ * `managed={false}` goes back to the override-redirect popup 1.x shipped: no
+ * frame, not movable, dismissed by a press anywhere outside (a pointer
+ * grab). That is the right shape for a transient confirmation on a display
+ * with no window manager at all, and the wrong one for anything the user
+ * might want to move.
+ *
+ * The two differ in how a press outside behaves, and it is not a bug either
+ * way: a managed dialog stays open, because a real dialog does. Escape and
+ * the WM close button both call `onClose`; so does a press outside when
+ * `managed={false}`.
  *
  * The focus behaviour is the renderer's, not this component's: `trapFocus`
  * keeps Tab inside the dialog, stops presses elsewhere from moving focus,
@@ -24,11 +46,11 @@ const DEFAULT_HEIGHT = 170;
  * the first stop; otherwise the dialog surface itself takes focus, so
  * Escape and Tab work immediately (`docs/events.md`, "Focus scopes").
  *
- * Escape closes: keys go to the focused node inside the popup and bubble out
- * through the popup's place in the JSX tree. `grab` makes a press anywhere
- * else in the session close it too. Pointer modality is *not* enforced —
- * widgets in the owner window stay clickable behind the dialog, so use it
- * for confirmations rather than as a security boundary.
+ * Pointer modality is *not* enforced — widgets in the owner window stay
+ * clickable behind the dialog, so use it for confirmations rather than as a
+ * security boundary. `_NET_WM_STATE_MODAL` is the mechanism for that, and it
+ * belongs to the `states` work; it means nothing without the
+ * `WM_TRANSIENT_FOR` this now sets, which is why that had to come first.
  *
  * A `<popup>` is a real X window and needs its size up front, hence explicit
  * `width`/`height` rather than sizing to content.
@@ -39,6 +61,7 @@ export function Dialog({
   children,
   onClose,
   actions,
+  managed = true,
   width = DEFAULT_WIDTH,
   height = DEFAULT_HEIGHT,
   style,
@@ -94,9 +117,20 @@ export function Dialog({
           width: rect.width,
           height: rect.height,
           trapFocus: true,
-          grab: true,
+          // A managed window is the window manager's to move, and a
+          // client-side pointer grab over one is a fight nobody wins — the
+          // press that would start a titlebar drag is swallowed instead. So
+          // the grab and the frame are the same choice, made once.
+          overrideRedirect: !managed,
+          grab: !managed,
           windowType: 'dialog',
-          onDismiss: () => onClose?.(),
+          // inert on an override-redirect window, and ntk warns if asked to
+          // write it there, so only the managed dialog claims an owner
+          transientFor: managed ? anchor : undefined,
+          title: managed ? title : undefined,
+          onDismiss: managed ? undefined : () => onClose?.(),
+          // the WM's close button, which a managed dialog now has
+          onCloseRequest: managed ? () => onClose?.() : undefined,
           onKeyDown,
           style: { backgroundColor: theme.background },
         },

--- a/src/components/anchor.js
+++ b/src/components/anchor.js
@@ -102,8 +102,17 @@ export function centerRect(node, { width, height }) {
   const win = node.root?.window;
   const ww = win?.width ?? width;
   const wh = win?.height ?? height;
-  let x = (win?.x ?? 0) + (ww - width) / 2;
-  let y = (win?.y ?? 0) + (wh - height) / 2;
+  // `_screenOrigin` for the same reason `anchorRect` uses it: `x`/`y` come
+  // from ConfigureNotify, and under a reparenting window manager those can be
+  // relative to the *frame* rather than the root — which would centre the
+  // dialog off by the size of the decoration. The server's own answer is
+  // right whatever the WM did. (quartz-wm happens to report root-relative
+  // coordinates, so the two agree there; that is not something to rely on.)
+  // The raw coordinates stay as the fallback, since the headless mock has no
+  // server to ask.
+  const origin = win?._screenOrigin ?? { x: win?.x ?? 0, y: win?.y ?? 0 };
+  let x = origin.x + (ww - width) / 2;
+  let y = origin.y + (wh - height) / 2;
 
   const screen = screenOf(node);
   if (screen) {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,8 +7,8 @@
  * `"jsx": "react-jsx"`.
  */
 
-import type { ReactNode } from 'react';
-import type { NtkApp } from './types/nodes.js';
+import type { ReactNode, RefObject } from 'react';
+import type { DrawnNode, NtkApp, NtkWindow } from './types/nodes.js';
 import type { ReactX11Elements } from './types/elements.js';
 
 export * from './types/style.js';
@@ -16,6 +16,36 @@ export * from './types/events.js';
 export * from './types/nodes.js';
 export * from './types/elements.js';
 export * from './types/components.js';
+
+/**
+ * The XID of the X11 window a ref points at, or `null` if there is not one
+ * yet. Accepts a `<window>`/`<popup>` ref (whose `current` is the live ntk
+ * window), a ref to any drawn node (resolved to the window that owns it),
+ * the ref object itself, or a raw XID.
+ *
+ * This is the walk `transientFor` resolves its prop through, and the one an
+ * xdg-desktop-portal `parent_window` handle needs — `x11:` followed by
+ * lowercase hex with no `0x` prefix.
+ */
+export function windowIdOf(
+  target:
+    | NtkWindow
+    | DrawnNode
+    | RefObject<NtkWindow | DrawnNode | null>
+    | number
+    | null
+    | undefined,
+): number | null;
+
+/**
+ * `windowIdOf` bound to a ref. Returns a **getter**, stable across renders,
+ * the same shape {@link useAnchor} has — refs attach after the commit that
+ * created the window, so a value read during render would be null on the
+ * render that matters.
+ */
+export function useWindowId(
+  ref: RefObject<NtkWindow | DrawnNode | null>,
+): () => number | null;
 
 /** What React reports alongside an error it caught. */
 export interface ErrorInfo {

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ export {
   Renderer,
 } from './Reconciler.js';
 export { createStyles, flattenStyle } from './styles.js';
+export { windowIdOf, useWindowId } from './windowid.js';
 export {
   Select,
   Tabs,

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -28,6 +28,7 @@ import {
 } from './styles.js';
 import { EventManager } from './events.js';
 import { callHandler } from './errors.js';
+import { windowIdOf } from './windowid.js';
 import { hooks as traceHooks } from './trace-registry.js';
 import { runWithPriority, DiscreteEventPriority } from './priority.js';
 import {
@@ -3239,6 +3240,10 @@ export class WindowNode extends Node {
     // reads decorations when it frames the window, which is at map time.
     if (this.props.decorations === false) applyDecorations(wnd, false);
     applyWindowStates(wnd, [...windowStates(this.props)], 'add');
+    // ICCCM 4.1.2.6 has the window manager read WM_TRANSIENT_FOR when the
+    // transient is mapped, so this belongs before the map too. ntk writes it
+    // with predefined atoms and no round trip, so "before" is free.
+    this._applyTransientFor(this.props.transientFor);
     wnd.map?.();
     // ask before anything can be anchored to it, so the first popup is
     // placed as well as the second
@@ -3335,6 +3340,65 @@ export class WindowNode extends Node {
     if (next.decorations !== prev.decorations) {
       applyDecorations(wnd, next.decorations !== false);
     }
+    if (next.transientFor !== prev.transientFor) {
+      this._pendingTransientFor = undefined;
+      this._applyTransientFor(next.transientFor);
+    } else if (this._pendingTransientFor !== undefined) {
+      // the owner was not realized last time round; every commit is another
+      // chance, and a sibling window earlier in the tree is realized by now
+      this._applyTransientFor(this._pendingTransientFor);
+    }
+  }
+
+  /**
+   * Write `WM_TRANSIENT_FOR`, resolving whatever the prop holds — a ref to a
+   * `<window>`/`<popup>`, a ref to any drawn node (resolved to the window
+   * that owns it), a raw XID, `'root'` for the client's whole window group,
+   * or `null` to clear.
+   *
+   * Resolution has to happen here rather than in `windowAttributes`, which
+   * copies every non-event prop straight into ntk's creation attributes: a
+   * React ref is not something ntk should be asked to understand.
+   *
+   * **Refs attach in the layout phase, after every mutation.** So on the
+   * commit that mounts two sibling `<window>`s, the second one realizes
+   * while the first one's ref is still null — the owner is unresolvable
+   * exactly when a single-tree multi-window app needs it. That is what
+   * `_pendingTransientFor` is for: an unresolved owner is retried on the
+   * next commit rather than dropped, and the frame this window schedules on
+   * mount gives it one without waiting for an unrelated re-render.
+   */
+  _applyTransientFor(owner) {
+    const wnd = this.window;
+    if (!wnd || typeof wnd.setTransientFor !== 'function') return;
+    if (owner == null) {
+      this._pendingTransientFor = undefined;
+      // only clear a property we actually wrote; a bare `undefined` on mount
+      // must not cost a DeleteProperty on every window in the app
+      if (this._transientForId != null) {
+        this._transientForId = null;
+        wnd.setTransientFor(null);
+      }
+      return;
+    }
+    const id = owner === 'root' ? 'root' : windowIdOf(owner);
+    if (id == null) {
+      this._pendingTransientFor = owner;
+      return;
+    }
+    this._pendingTransientFor = undefined;
+    if (id === this._transientForId) return;
+    if (id === wnd.id) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn(
+          'react-x11: transientFor points at the window itself. A window ' +
+            'cannot own itself; the property is ignored.',
+        );
+      }
+      return;
+    }
+    this._transientForId = id;
+    wnd.setTransientFor(id);
   }
 
   /** The WM size hints among these props. */
@@ -3523,8 +3587,12 @@ export class WindowNode extends Node {
     }
     const wnd = this.window;
     if (!wnd) {
-      // not realized yet: refresh creation attributes instead
+      // not realized yet: refresh creation attributes instead. `transientFor`
+      // is the one prop that must not travel this way — it holds a React ref
+      // until the commit phase resolves it, and ntk's hint handling reads a
+      // key by that name.
       this.attributes = { ...this.attributes, ...newProps };
+      delete this.attributes.transientFor;
       return;
     }
 
@@ -3764,6 +3832,13 @@ export class WindowNode extends Node {
 
   flush() {
     if (this.destroyed || !this.yoga || !this.window) return;
+    // a transientFor whose owner was not realized yet at commit time. The
+    // frame after the mount is the first moment refs have attached, so the
+    // common "two <window>s in one tree" case resolves here rather than
+    // waiting for the app to re-render for some unrelated reason.
+    if (this._pendingTransientFor !== undefined) {
+      this._applyTransientFor(this._pendingTransientFor);
+    }
     this._advanceAnimations(now());
     const width = this.window.width ?? this.props.width ?? 0;
     const height = this.window.height ?? this.props.height ?? 0;
@@ -4200,16 +4275,22 @@ export class PopupNode extends WindowNode {
   }
 
   constructor(app, attributes, props) {
-    // override-redirect stays: it is what keeps the window manager from
-    // repositioning or decorating a menu. The EWMH type hint is additive —
-    // the spec asks for it on override-redirect windows too, so compositing
-    // managers can give menus and tooltips consistent shadows/animations.
-    // `windowType` overrides the default (e.g. "tooltip", "popup_menu").
+    // Override-redirect is the default and is what keeps the window manager
+    // from repositioning or decorating a menu — but it is now a default
+    // rather than a fact, because it is the one bit standing between
+    // `<popup>` and a real, WM-managed dialog: `overrideRedirect={false}`
+    // gives a decorated, movable window the WM will stack above its owner
+    // and iconify with it. Menus, tooltips and `Select` keep the default.
+    //
+    // The EWMH type hint is additive — the spec asks for it on
+    // override-redirect windows too, so compositing managers can give menus
+    // and tooltips consistent shadows/animations. `windowType` overrides the
+    // default (e.g. "tooltip", "popup_menu").
     super(
       app,
       {
         ...attributes,
-        overrideRedirect: true,
+        overrideRedirect: attributes.overrideRedirect ?? true,
         windowType: attributes.windowType ?? 'dropdown_menu',
       },
       props,

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -145,6 +145,20 @@ export interface DialogProps extends WidgetProps {
   open?: boolean;
   title?: string;
   children?: ReactNode;
+  /**
+   * `true` (the default) makes the dialog a **window-manager-managed**
+   * window with `WM_TRANSIENT_FOR` pointing at its owner: framed, movable,
+   * closable through the WM, out of the taskbar and alt-tab list, and — on a
+   * full EWMH window manager — stacked above its owner and iconified with
+   * it. A press outside does **not** close it, because a real dialog does
+   * not close that way; Escape and the WM close button both call
+   * {@link DialogProps.onClose}.
+   *
+   * `false` is the override-redirect popup 1.x shipped: no frame, not
+   * movable, and a press anywhere outside dismisses it (a pointer grab).
+   * Right for a transient confirmation on a display with no window manager.
+   */
+  managed?: boolean;
   onClose?: () => void;
   actions?: ReactNode;
   width?: number;

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -102,6 +102,27 @@ export interface WindowProps
   /** EWMH `_NET_WM_WINDOW_TYPE`, or a list of fallbacks. */
   windowType?: WindowType | WindowType[];
   /**
+   * ICCCM `WM_TRANSIENT_FOR` — the window this one belongs to. It is what
+   * makes a second top-level window a *dialog* rather than an unrelated
+   * application window: the WM stacks it above its owner, keeps it out of
+   * the taskbar and pager, iconifies it alongside, places it relative to the
+   * owner and gives it a dialog's reduced frame.
+   *
+   * Takes a ref to a `<window>`/`<popup>`, a ref to any drawn node (resolved
+   * to the window that owns it), a raw XID, or `'root'` for "transient for
+   * this client's whole window group".
+   *
+   * Resolved in the commit phase. An owner that is not realized yet — a
+   * sibling `<window>` mounting in the same commit, whose ref attaches only
+   * in the layout phase — is retried rather than dropped.
+   *
+   * **Inert on an override-redirect window**, which is every `<popup>` by
+   * default: the WM does not manage those, so nothing reads the property.
+   * Pass `overrideRedirect={false}` to make the popup a managed window
+   * first. ICCCM 4.1.2.6 draws exactly that distinction.
+   */
+  transientFor?: Ref<NtkWindow | DrawnNode> | number | 'root' | null;
+  /**
    * EWMH `_NET_WM_STATE`. **Controlled**: this is what the window is asked
    * to be, and {@link WindowProps.onStatesChange} is what it actually is —
    * on X the window manager changes state behind the app's back, so the two
@@ -163,6 +184,18 @@ export interface PopupProps extends WindowProps {
    * this client at all. Needs ntk >= 3.7.0.
    */
   grab?: boolean;
+  /**
+   * `true` (the default) keeps the window manager out entirely, which is
+   * what makes a menu a menu — no frame, no repositioning, no taskbar entry.
+   *
+   * `false` makes the popup an ordinary managed window: decorated, movable,
+   * closable through the WM, and — with {@link WindowProps.transientFor} —
+   * stacked above its owner and iconified with it. That is the combination
+   * that turns a `<popup>` into a real dialog. Turn `grab` off with it: a
+   * client-side pointer grab over a window the WM is trying to let the user
+   * drag is a fight nobody wins.
+   */
+  overrideRedirect?: boolean;
   /** A press landed outside the popup: close it. */
   onDismiss?: (ev: MouseEvent<DrawnNode>) => void;
 }

--- a/src/windowid.js
+++ b/src/windowid.js
@@ -1,0 +1,60 @@
+// One supported way to turn a ref into the XID of the window it belongs to.
+//
+// The walk itself is not new — `anchor.js` has done it for popup placement
+// since the beginning — but it was private, and two features need it at
+// once: `transientFor` resolves its prop through this, and the
+// xdg-desktop-portal work needs it to build a `parent_window` handle.
+
+import { useCallback } from 'react';
+
+/**
+ * The XID of the X11 window a ref points at, or `null` if there is not one
+ * (yet). Accepts:
+ *
+ * - a `<window>` / `<popup>` ref — `getPublicInstance` hands back the live
+ *   ntk window, so `ref.current.id` is the XID;
+ * - a ref to any **drawn** node — resolved to the window that owns it;
+ * - a raw XID, returned unchanged;
+ * - the ref object itself, so `windowIdOf(ref)` works as well as
+ *   `windowIdOf(ref.current)`.
+ *
+ * `null` is a real answer, not a failure: a ref is empty until the node
+ * mounts, and a `<window>` has no XID until the commit phase realizes it.
+ */
+export function windowIdOf(target) {
+  if (target == null) return null;
+  if (typeof target === 'number') return target;
+  // a ref object, so callers need not remember which one this takes
+  if (typeof target === 'object' && 'current' in target && !target.isWindow) {
+    return windowIdOf(target.current);
+  }
+  // an ntk Window (what a <window>/<popup> ref holds), or a WindowNode that
+  // has been realized
+  if (typeof target.id === 'number') return target.id;
+  if (typeof target.window?.id === 'number') return target.window.id;
+  // a drawn node: `root` is the WindowNode that owns it
+  if (typeof target.root?.window?.id === 'number') return target.root.window.id;
+  return null;
+}
+
+/**
+ * `windowIdOf` bound to a ref: returns a **getter**, stable across renders,
+ * the same shape `useAnchor` has. It is a getter rather than the id itself
+ * because refs attach after the commit that created the window, so a value
+ * read during render would be null on the render that matters.
+ *
+ * ```js
+ * const windowId = useWindowId(anchorRef);
+ * // …later, in an effect or a handler:
+ * const parentWindow = `x11:${windowId().toString(16)}`; // xdg-desktop-portal
+ * ```
+ *
+ * Note the format: lowercase hex, **no** `0x`. Both shipping portal backends
+ * happen to tolerate a prefix, which is exactly why it is easy to get wrong
+ * and never notice — and Qt's parser returns 0 on failure with no error
+ * path, so a third backend would give an unparented, non-modal dialog rather
+ * than an exception.
+ */
+export function useWindowId(ref) {
+  return useCallback(() => windowIdOf(ref), [ref]);
+}

--- a/test/helpers/mock-app.js
+++ b/test/helpers/mock-app.js
@@ -167,6 +167,11 @@ export function createMockApp() {
         setWindowType(type) {
           wnd.calls.push(['setWindowType', type]);
         },
+        // ntk >= 4.3: ICCCM WM_TRANSIENT_FOR
+        setTransientFor(owner) {
+          wnd.transientFor = owner;
+          wnd.calls.push(['setTransientFor', owner]);
+        },
         setAlwaysOnTop(on) {
           wnd.calls.push(['setAlwaysOnTop', on]);
         },

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1783,6 +1783,174 @@ test('ProgressBar fill width follows value', async () => {
   ReactX11.unmountComponentAtNode(app);
 });
 
+// issue #130 -------------------------------------------------------------
+//
+// The hard part is not writing the property, it is resolving the prop: refs
+// attach in the *layout* phase, after every mutation, so on the commit that
+// mounts two sibling <window>s the second realizes while the first one's ref
+// is still null. That is the case a multi-window app is made of.
+test('transientFor resolves a ref that attaches after the window realized', async () => {
+  const app = createMockApp();
+  const main = React.createRef();
+  const App = () =>
+    React.createElement(
+      React.Fragment,
+      null,
+      React.createElement('window', { ref: main, width: 300, height: 200 }),
+      React.createElement('window', {
+        width: 200,
+        height: 100,
+        transientFor: main,
+      }),
+    );
+  ReactX11.render(React.createElement(App), null, app);
+  const [owner, transient] = app.windows;
+  // realize() ran with main.current still null, so nothing could be written
+  assert.strictEqual(transient.transientFor, undefined);
+  assert.ok(main.current, 'the ref attached in the layout phase');
+
+  // the frame the mount scheduled is the first moment it can be resolved
+  transient._reactX11Node.flush();
+  assert.strictEqual(transient.transientFor, owner.id);
+  // and it is not re-sent on every frame
+  transient.calls.length = 0;
+  transient._reactX11Node.flush();
+  assert.strictEqual(
+    transient.calls.some((c) => c[0] === 'setTransientFor'),
+    false,
+  );
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('transientFor takes an XID, a drawn-node ref, and null to clear', async () => {
+  const app = createMockApp();
+  const anchor = React.createRef();
+  const render = (transientFor) =>
+    ReactX11.render(
+      React.createElement(
+        'window',
+        { width: 300, height: 200 },
+        React.createElement('box', { ref: anchor }),
+        React.createElement('window', {
+          width: 200,
+          height: 100,
+          transientFor,
+        }),
+      ),
+      null,
+      app,
+    );
+
+  render(4242);
+  await tick();
+  const [owner, transient] = app.windows;
+  assert.strictEqual(transient.transientFor, 4242, 'a raw XID passes through');
+
+  // a ref to a *drawn* node resolves to the window that owns it
+  render(anchor);
+  assert.strictEqual(transient.transientFor, owner.id);
+
+  render('root');
+  assert.strictEqual(transient.transientFor, 'root', 'the window-group form');
+
+  transient.calls.length = 0;
+  render(null);
+  assert.strictEqual(transient.transientFor, null, 'null clears it');
+
+  // and a window that never set one does not spend a DeleteProperty saying so
+  const fresh = createMockApp();
+  ReactX11.render(
+    React.createElement('window', { width: 100, height: 100 }),
+    null,
+    fresh,
+  );
+  await tick();
+  assert.strictEqual(
+    fresh.windows[0].calls.some((c) => c[0] === 'setTransientFor'),
+    false,
+  );
+
+  ReactX11.unmountComponentAtNode(app);
+  ReactX11.unmountComponentAtNode(fresh);
+});
+
+test('a <popup> can opt out of override-redirect and be WM-managed', async () => {
+  const app = createMockApp();
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 300, height: 200 },
+      React.createElement('popup', {
+        x: 10,
+        y: 10,
+        width: 120,
+        height: 80,
+      }),
+      React.createElement('popup', {
+        x: 20,
+        y: 20,
+        width: 120,
+        height: 80,
+        overrideRedirect: false,
+        windowType: 'dialog',
+      }),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const [, menu, dialog] = app.windows;
+  assert.strictEqual(
+    menu.attributes.overrideRedirect,
+    true,
+    'menus keep the default that makes them menus',
+  );
+  assert.strictEqual(menu.attributes.windowType, 'dropdown_menu');
+  assert.strictEqual(dialog.attributes.overrideRedirect, false);
+  assert.strictEqual(dialog.attributes.windowType, 'dialog');
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
+test('windowIdOf resolves windows, drawn nodes, refs and raw ids', async () => {
+  const { windowIdOf } = await import('../src/index.js');
+  const app = createMockApp();
+  const windowRef = React.createRef();
+  const boxRef = React.createRef();
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { ref: windowRef, width: 300, height: 200 },
+      React.createElement('box', { ref: boxRef }),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const id = app.windows[0].id;
+
+  assert.strictEqual(windowIdOf(windowRef), id, 'a <window> ref');
+  assert.strictEqual(windowIdOf(windowRef.current), id, 'and its instance');
+  assert.strictEqual(
+    windowIdOf(boxRef),
+    id,
+    'a drawn node resolves to its window',
+  );
+  assert.strictEqual(windowIdOf(boxRef.current), id);
+  assert.strictEqual(windowIdOf(1234), 1234, 'a raw XID');
+  assert.strictEqual(windowIdOf(null), null);
+  assert.strictEqual(windowIdOf(React.createRef()), null, 'an empty ref');
+
+  // the portal handle format: lowercase hex, no 0x
+  assert.strictEqual(
+    `x11:${windowIdOf(windowRef).toString(16)}`,
+    `x11:${id.toString(16)}`,
+  );
+
+  ReactX11.unmountComponentAtNode(app);
+});
+
 test('multiple root windows share one tree; onCloseRequest handles WM close', async () => {
   const app = createMockApp();
   const events = [];
@@ -2469,9 +2637,17 @@ test('Dialog: modal popup, Escape closes it, focus goes back', async () => {
   await tick();
   const dialog = app.windows[1];
   assert.ok(dialog, 'the dialog is a popup window');
-  assert.strictEqual(dialog.attributes.overrideRedirect, true);
+  // issue #130: a dialog is a *managed* window, so the WM frames it, keeps it
+  // out of the taskbar and lets the user move it — and a client pointer grab
+  // over a window the WM is trying to drag is a fight nobody wins
+  assert.strictEqual(dialog.attributes.overrideRedirect, false);
   assert.strictEqual(dialog.attributes.windowType, 'dialog');
-  assert.strictEqual(dialog.attributes.grab, true, 'grabs, so it dismisses');
+  assert.strictEqual(dialog.attributes.grab, false);
+  assert.strictEqual(
+    'transientFor' in dialog.attributes,
+    false,
+    'the ref is resolved in the commit phase, never handed to ntk',
+  );
   assert.strictEqual(input.focused, true, 'autoFocus inside the dialog won');
 
   // Escape reaches the dialog by bubbling out of the focused node

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -34,6 +34,8 @@ import {
   unmountComponentAtNode,
   useAnchor,
   useTheme,
+  useWindowId,
+  windowIdOf,
 } from '../../src/index.js';
 import type {
   DrawnNode,
@@ -217,6 +219,42 @@ function Popup() {
   );
 }
 
+// issue #130: transientFor takes a ref to a window, a ref to a drawn node, a
+// raw XID or 'root'; a <popup> can opt out of override-redirect to become a
+// WM-managed dialog
+function TransientWindows() {
+  const owner = useRef<NtkWindow>(null);
+  const anchor = useRef<DrawnNode>(null);
+  const windowId = useWindowId(anchor);
+  const parentWindow = () => `x11:${(windowId() ?? 0).toString(16)}`;
+  return (
+    <>
+      <window ref={owner} title="editor">
+        <box ref={anchor} />
+      </window>
+      <window transientFor={owner} windowType="dialog" title="Preferences" />
+      <window transientFor={anchor} />
+      <window transientFor={windowIdOf(owner) ?? 0} />
+      <window transientFor="root" />
+      <window transientFor={null} onExpose={() => void parentWindow()} />
+      <popup
+        x={0}
+        y={0}
+        width={200}
+        height={120}
+        overrideRedirect={false}
+        transientFor={anchor}
+        windowType="dialog"
+      >
+        <box />
+      </popup>
+    </>
+  );
+}
+
+// @ts-expect-error — a string is not a window, a node, an XID or 'root'
+const _badTransient = <window transientFor="mainWindow" />;
+
 // --- 3D --------------------------------------------------------------------
 
 function Scene() {
@@ -356,6 +394,10 @@ function Widgets() {
         actions={<Button label="OK" />}
       >
         <text>body</text>
+      </Dialog>
+      {/* the 1.x shape: override-redirect, dismissed by a press outside */}
+      <Dialog open managed={false} onClose={() => {}}>
+        <text>unmanaged</text>
       </Dialog>
     </ThemeProvider>
   );


### PR DESCRIPTION
Closes #130. ntk's writer (sidorares/ntk#126) shipped in **4.3.0**, which is
already the floor in `package.json`.

## The problem

Nothing told the window manager that one window belonged to another.
`WM_TRANSIENT_FOR` was written nowhere, there was no prop for it, and
`Dialog` sidestepped the whole question by being an override-redirect
`<popup>` — trading "a second entry in the taskbar" for "no titlebar, cannot
be moved, no WM close button, and it outlives its owner's minimise".

## Three pieces

**`transientFor` on `<window>` and `<popup>`** — a ref to a
`<window>`/`<popup>`, a ref to any drawn node (resolved to the window that
owns it), a raw XID, `'root'` for the client's window group, or `null`.

The part that is not obvious: **refs attach in the layout phase, after every
mutation**, so on the commit that mounts two sibling `<window>`s the second
realizes while the first one's ref is still `null` — which is exactly the
multi-window case the prop exists for. An unresolved owner is remembered and
retried on the frame the mount already schedules, rather than dropped. There
is a test that pins the ordering rather than the outcome.

**`overrideRedirect` is a default rather than a fact on `<popup>`** — one
`??`. Menus, tooltips and `Select` are unchanged; `false` hands the window to
the WM, which is what lets a popup be a real dialog.

**`windowIdOf` / `useWindowId`** — the ref-to-XID walk `anchor.js` has done
privately since the beginning, exported. `transientFor` resolves through it,
and it is what an xdg-desktop-portal `parent_window` handle needs:
`` `x11:${id.toString(16)}` ``, lowercase hex, **no** `0x`. Easy to get wrong
and never notice, because both shipping backends tolerate a prefix and Qt's
parser returns 0 with no error path — the symptom of a third, stricter
backend would be a silently unparented, non-modal dialog.

## `Dialog`

Managed by default, with `transientFor` taken from the anchor it already
keeps for placement. `managed={false}` is the 1.x shape.

Rendered by this branch at `a486669`, captured off the real X server through
the WM frame (the same `GetImage`-on-the-frame recipe `npm run
screenshots:framed` uses):

| `managed={false}` (1.x) | default |
| --- | --- |
| ![dialog-a486669-unmanaged](https://github.com/user-attachments/assets/77ba4b28-b712-4a5b-a48d-348118794e06) | ![dialog-a486669-managed](https://github.com/user-attachments/assets/e54e48a5-cb76-4eea-812c-84e15f817a81) |

The right-hand one is 22px taller: that is quartz-wm's titlebar, with
maximize greyed out — the dialog treatment.

The grab and the frame are **one** choice, not two: a client-side pointer
grab over a window the WM is trying to let the user drag swallows the press
that would start the drag. So a managed dialog no longer closes when you
click outside it, which is what a dialog does; Escape and the WM close button
(`onCloseRequest`) both call `onClose`.

## Measured, on a real window manager

quartz-wm — the thinnest EWMH implementation in the stack, so a floor rather
than a best case. Reading back what the WM wrote onto the window:

| the client sets | the WM allows | the WM adds to `_NET_WM_STATE` |
| --- | --- | --- |
| nothing | close, minimize, move, resize, maximize horz/vert, fullscreen | — |
| `transientFor` | close, minimize, move, resize | skip_taskbar, skip_pager |

Also confirmed against the live connection: the property lands with the
owner's XID; a **drawn-node** ref resolves to its owner window; the deferred
sibling-`<window>` case resolves; and `<popup overrideRedirect={false}>` is
genuinely reparented into a WM frame.

## Also in here

`centerRect` now places from `_screenOrigin` rather than `x`/`y` — which
`anchorRect`, ten lines above it in the same file, has always done, with a
comment explaining that ConfigureNotify coordinates can be frame-relative
under a reparenting WM. `Dialog` is its only caller and it is the second
reason a dialog can appear in the wrong place. (quartz-wm happens to report
root-relative coordinates, so the two agree there; that is not something to
rely on.)

## Deliberately not here

`_NET_WM_STATE_MODAL` belongs to the `states` work. EWMH defines modality
*relative to* the transient-for window, so it means nothing without this —
that ordering is the reason #130 came first, and it is now recorded in
`docs/components.md` where `Dialog` explains that pointer modality is not
enforced.

## Checks

`npm test` 303 pass / 0 fail (4 new tests), `npm run typecheck`,
`npm run lint`, and `website`'s three gates green.
