### PR TITLE
feat!: the value widgets pass a change event too, so one signature covers the library

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -93,11 +93,11 @@ import { Button, Checkbox, RadioGroup, Radio, Switch, ProgressBar } from 'react-
 <Button primary onPress={save}>
   Save
 </Button>
-<Checkbox checked={wrap} onChange={setWrap}>Wrap lines</Checkbox>
-<Switch checked={live} onChange={setLive} />
+<Checkbox checked={wrap} onChange={(ev) => setWrap(ev.value)}>Wrap lines</Checkbox>
+<Switch checked={live} onChange={(ev) => setLive(ev.value)} />
 <ProgressBar value={0.4} style={{ width: 200 }} />
 
-<RadioGroup value={size} onChange={setSize}>
+<RadioGroup value={size} onChange={(ev) => setSize(ev.value)}>
   <Radio value="s">Small</Radio>
   <Radio value="m">Medium</Radio>
 </RadioGroup>;
@@ -109,10 +109,15 @@ a `<text>` for you, so `<Button>Save</Button>` needs no `<text>`.
 ### The change event, and `name`
 
 Every value control — `Checkbox`, `Switch`, `RadioGroup`, `Select`,
-`Slider` — calls `onChange(next, ev)`. The **next value comes first**, which
-is the whole ergonomic point of these widgets (`onChange={setChecked}` is
-the common case and stays a one-liner), and the second argument carries the
-field identity a form library needs:
+`Slider` — calls `onChange(ev)` with a change event, the **same signature**
+`<textinput>` and `<textarea>` use
+([elements.md](elements.md#the-change-event)). The new value is `ev.value`:
+
+```jsx
+<Checkbox checked={agreed} onChange={(ev) => setAgreed(ev.value)}>
+  I agree
+</Checkbox>
+```
 
 ```js
 { type: 'change',
@@ -121,18 +126,29 @@ field identity a form library needs:
   name: 'agree', value: true }
 ```
 
-`target` is a plain descriptor rather than a node: a widget is several nodes
-and none of them holds its value. Its shape is what formik's `handleChange`
-and react-hook-form's event reader destructure — `target.type` is how they
-tell a checkbox from a text field, which is why it is set even though nothing
-in react-x11 reads it. There is no `preventDefault`: the value has already
-changed by the time the handler runs.
+One signature is the point. It is what lets a form library's handler be
+passed straight to any control in the library, with no per-widget adapter:
 
-`name` is inert here. It exists so a form library has somewhere to put one;
-see [docs/ecosystem/forms.md](ecosystem/forms.md). The host elements
-`<textinput>` and `<textarea>` are different — they hand you a single
-synthetic event with no leading value, matching the DOM
-([elements.md](elements.md#the-change-event)).
+```jsx
+<textinput name="host" value={f.values.host} onChange={f.handleChange} />
+<Checkbox  name="agree" checked={f.values.agree} onChange={f.handleChange} />
+```
+
+`target` is a plain descriptor rather than a node, and that is the one place
+this differs from the host elements: a widget is several nodes with no single
+element holding its value, so there is nothing honest to point at. Its shape
+is what formik's `handleChange` and react-hook-form's event reader
+destructure — `target.type` is how they tell a checkbox from a text field,
+which is why it is set even though nothing in react-x11 reads it. There is no
+`preventDefault`: the value has already changed by the time the handler runs.
+
+**The line is `name`.** A widget that takes one is a form field and reports
+an event. `Tabs`, `Tree`, `Table` and the menus are not form fields — you
+would never register a tab strip with formik — and keep their plain callbacks
+(`Tabs` calls `onChange(id)`).
+
+`name` is otherwise inert; it exists so a form library has somewhere to put
+one. See [docs/ecosystem/forms.md](ecosystem/forms.md).
 
 ### `Button`
 
@@ -148,14 +164,14 @@ synthetic event with no leading value, matching the DOM
 | prop                 |                                           |
 | -------------------- | ----------------------------------------- |
 | `checked`            | current value (controlled)                |
-| `onChange(next, ev)` | the **next** value first, then the event  |
+| `onChange(ev)`       | a change event; the value is `ev.value`   |
 | `name`               | field name, for form libraries            |
 | `children` / `label` | label to the right of the 16px check well |
 | `disabled`           | inert, dimmed                             |
 
 ### `Radio` / `RadioGroup`
 
-`RadioGroup` takes `value`, `onChange(value, ev)`, `name`, `style` and any
+`RadioGroup` takes `value`, `onChange(ev)`, `name`, `style` and any
 box props; each `Radio` takes the `value` it selects, plus `children`/`label`
 and `disabled` — and nothing else, so per-radio styling goes on the group. A
 `Radio` outside a `RadioGroup` throws rather than silently doing nothing.
@@ -167,7 +183,7 @@ group behaves; click or Space selects the focused one.
 
 ### `Switch`
 
-`checked`, `onChange(next, ev)`, `name` and `disabled`, the same semantics
+`checked`, `onChange(ev)`, `name` and `disabled`, the same semantics
 as `Checkbox` in a sliding pill. The thumb is absolutely positioned and
 animates on `left` (`transition: { left: 120 }`) because `justifyContent`
 would flip between the ends with nothing in between to animate — the worked
@@ -205,18 +221,18 @@ import { Select } from 'react-x11';
     { value: '#c0392b', label: 'Red' },
     'green', // shorthand: value === label
   ]}
-  onChange={(value) => setColor(value)}
+  onChange={(ev) => setColor(ev.value)}
   placeholder="Pick a color…"
 />;
 ```
 
-| prop                           |                                           |
-| ------------------------------ | ----------------------------------------- |
-| `options`                      | array of `{value, label}` or plain values |
-| `value`, `onChange(value, ev)` | selection                                 |
-| `name`                         | field name, for form libraries            |
-| `placeholder`                  | trigger text when nothing is selected     |
-| `style` + any box props        | forwarded to the trigger box              |
+| prop                    |                                           |
+| ----------------------- | ----------------------------------------- |
+| `options`               | array of `{value, label}` or plain values |
+| `value`, `onChange(ev)` | selection                                 |
+| `name`                  | field name, for form libraries            |
+| `placeholder`           | trigger text when nothing is selected     |
+| `style` + any box props | forwarded to the trigger box              |
 
 Behavior: click / Space / Enter toggles the menu; Escape, focus loss, or
 picking closes it; the option list scrolls when taller than 220px; the
@@ -266,17 +282,17 @@ import { Slider } from 'react-x11';
   max={100}
   step={5}
   style={{ width: 200 }}
-  onChange={setVolume}
+  onChange={(ev) => setVolume(ev.value)}
 />;
 ```
 
-| prop                           |                                                         |
-| ------------------------------ | ------------------------------------------------------- |
-| `value`, `onChange(value, ev)` | current value (controlled)                              |
-| `name`                         | field name, for form libraries                          |
-| `min`, `max`, `step`           | range and quantisation (defaults 0, 100, 1)             |
-| `height`                       | the bar thickness (default 4); width comes from `style` |
-| `disabled`                     | inert, dimmed                                           |
+| prop                    |                                                         |
+| ----------------------- | ------------------------------------------------------- |
+| `value`, `onChange(ev)` | current value (controlled)                              |
+| `name`                  | field name, for form libraries                          |
+| `min`, `max`, `step`    | range and quantisation (defaults 0, 100, 1)             |
+| `height`                | the bar thickness (default 4); width comes from `style` |
+| `disabled`              | inert, dimmed                                           |
 
 Dragging uses [pointer capture](events.md#pointer-capture): the press
 captures, so the thumb keeps following a pointer that has wandered far

--- a/docs/ecosystem/forms.md
+++ b/docs/ecosystem/forms.md
@@ -3,36 +3,42 @@
 There is no `<form>` element here, so nothing submits itself — wire
 `handleSubmit` to a `Button`'s `onPress` or to `<textinput onSubmit>`.
 
-Everything else on this page changed in **2.0.0**. `<textinput>` used to fire
-`onChange(newString)`; it now fires `onChange(ev)` with a synthetic event
-carrying `ev.target.value`, `ev.target.name` and a writable `ev.target.value`
-(issue #115, see [elements](../elements.md#the-change-event)). That was the
-one incompatibility that mattered, and with it gone the DOM-shaped form
-libraries work through their normal APIs rather than through an adapter:
+Everything else follows from **one signature**. Every value control in the
+library — the host elements `<textinput>` and `<textarea>`, and the widgets
+`Checkbox`, `Switch`, `RadioGroup`, `Select` and `Slider` — calls
+`onChange(ev)` with a change event carrying `ev.value`, `ev.target.value`,
+`ev.target.name` and, for a checkbox, `ev.target.checked`. That is the shape
+every DOM form library reads, so a library's handler goes straight in:
 
-| library                | 1.2.0                             | 2.0.0                                                    |
-| ---------------------- | --------------------------------- | -------------------------------------------------------- |
-| `react-hook-form`      | `<Controller>` only               | `register()` works, `<Controller>` too                   |
-| `formik`               | broke silently on `getFieldProps` | `handleChange`, `<Field>`, spread all work               |
-| `downshift`            | TypeError on the first keystroke  | works                                                    |
-| `@tanstack/react-form` | `onChange={field.handleChange}`   | `onChange={(ev) => field.handleChange(ev.target.value)}` |
+```jsx
+<textinput name="host"  value={f.values.host}   onChange={f.handleChange} />
+<Checkbox  name="agree" checked={f.values.agree} onChange={f.handleChange} />
+<Select    name="size"  value={f.values.size} options={sizes} onChange={f.handleChange} />
+```
 
-The last row is the cost. A library whose field contract is value-in/
-value-out no longer lines up by accident, so it gains one unwrap per field —
-and a bare `onChange={field.handleChange}` now stores the **event object**
-as the field value rather than erroring, which is the quiet failure mode to
-watch for when upgrading. Grep for `onChange={field.handleChange}` and for
-`onChange={set` before you ship.
+No adapter, no per-widget bridge, nothing to remember about which control
+you are wiring.
 
-Each row was established by running the library headless against this
-renderer, not by reading its documentation: react-hook-form@7.84.0,
+| library                | how it goes in                                            |
+| ---------------------- | --------------------------------------------------------- |
+| `react-hook-form`      | `{...register('host')}`, or `<Controller>` for a widget   |
+| `formik`               | `onChange={handleChange}`, `getFieldProps`, or `<Field>`  |
+| `downshift`            | `getInputProps()` spread onto a `<textinput>`             |
+| `@tanstack/react-form` | `onChange={(ev) => field.handleChange(ev.value)}` — below |
+
+Every row was established by running the library headless against this
+renderer rather than by reading its documentation: react-hook-form@7.84.0,
 formik@2.4.9, downshift@9.4.0, @tanstack/react-form@1.33.2.
 
-The widget layer keeps its own shape — `Checkbox`, `Switch`, `RadioGroup`,
-`Select` and `Slider` call `onChange(next, ev)`, value first, with the
-form-library-shaped event second
-([components](../components.md#the-change-event-and-name)). Pass the second
-argument straight to `formik.handleChange` or to RHF's `field.onChange`.
+**The one thing to know**: a library whose field contract is
+value-in/value-out — TanStack Form is the one here — needs the value taken
+off the event, and a bare `onChange={field.handleChange}` stores the _event
+object_ as the field value with no error. See below.
+
+**Where the line falls.** A control that takes a `name` is a form field and
+reports an event. `Tabs`, `Tree`, `Table` and the menus are not form fields
+and keep their plain callbacks
+([components](../components.md#the-change-event-and-name)).
 
 ## TanStack Form {#tanstack-form}
 
@@ -44,13 +50,19 @@ zod/valibot/arktype plug in directly), and submission handling. Fields are
 value-in/value-out — no DOM events, no refs.
 
 The field contract is `field.state.value` + `field.handleChange(value)` —
-a value, not an event. Since 2.0.0 `<textinput>` fires an event, so each
-field unwraps it: `onChange={(ev) => field.handleChange(ev.target.value)}`.
-One expression, and it is the same one a DOM app writes.
+a **value, not an event**. react-x11's controls fire an event, so each field
+takes the value off it:
 
-Watch for the bare form. `onChange={field.handleChange}` used to be exactly
-right and now stores the event object as the field's value — no error, no
-warning, and validation sees an object where it expected a string.
+```jsx
+onChange={(ev) => field.handleChange(ev.value)}
+```
+
+One expression, the same one a DOM app writes, and it is identical for a
+`<textinput>` and for a `Checkbox`.
+
+Watch for the bare form: `onChange={field.handleChange}` stores the event
+object as the field's value — no error, no warning, and validation sees an
+object where it expected a string.
 
 ```jsx
 import React from 'react';
@@ -73,7 +85,7 @@ function ConnectForm({ connect }) {
           <box style={{ flexDirection: 'column' }}>
             <textinput
               value={field.state.value}
-              onChange={(ev) => field.handleChange(ev.target.value)}
+              onChange={(ev) => field.handleChange(ev.value)}
             />
             {field.state.meta.errors.length > 0 && (
               <text style={{ color: '#cc4444' }}>
@@ -157,8 +169,8 @@ function Settings({ raw }) {
 
 RHF's headline API is uncontrolled-first: `register()` returns DOM-shaped
 props (`{name, ref, onChange(e), onBlur(e)}`) and reads `e.target.value` off
-the event. Since 2.0.0 that is exactly what `<textinput>` provides, so the
-terse spread works:
+the event. That is exactly what `<textinput>` provides, so the terse spread
+works:
 
 ```jsx
 const { register, handleSubmit } = useForm({ defaultValues: { host: '' } });
@@ -277,14 +289,13 @@ import { Formik, Field, useFormik } from 'formik';
 `name` prop is not optional in any of these — that is what the synthetic
 event carries it for.
 
-The widgets need one small bridge, because their `onChange` puts the value
-first:
+The widgets need no bridge — same handler, same signature:
 
 ```jsx
 <Checkbox
   name="agree"
   checked={formik.values.agree}
-  onChange={(_next, ev) => formik.handleChange(ev)}
+  onChange={formik.handleChange}
 >
   I agree
 </Checkbox>

--- a/examples/form.jsx
+++ b/examples/form.jsx
@@ -76,12 +76,12 @@ export function FormPanel() {
         <Select
           options={COLORS}
           value={color}
-          onChange={setColor}
+          onChange={(ev) => setColor(ev.value)}
           style={{ flexGrow: 1 }}
         />
         <RadioGroup
           value={weight}
-          onChange={setWeight}
+          onChange={(ev) => setWeight(ev.value)}
           style={{ flexDirection: 'row', gap: 12 }}
         >
           {WEIGHTS.map((w) => (
@@ -96,14 +96,18 @@ export function FormPanel() {
           min={12}
           max={32}
           value={size}
-          onChange={setSize}
+          onChange={(ev) => setSize(ev.value)}
           style={{ flexGrow: 1 }}
         />
         <text style={{ color: '#636e72' }}>{String(size)}</text>
       </box>
 
       <box style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
-        <Checkbox checked={shout} onChange={setShout} label="Shout it" />
+        <Checkbox
+          checked={shout}
+          onChange={(ev) => setShout(ev.value)}
+          label="Shout it"
+        />
         <box style={{ flexGrow: 1 }} />
         <Button label="Clear" onPress={() => setConfirming(true)} />
         <Button primary label="Sign" onPress={submit} />

--- a/examples/gl.jsx
+++ b/examples/gl.jsx
@@ -125,7 +125,7 @@ function App() {
       >
         <Scene spinning={spinning} />
         <box style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
-          <Switch checked={spinning} onChange={setSpinning} />
+          <Switch checked={spinning} onChange={(ev) => setSpinning(ev.value)} />
           <text style={{ fontSize: 13 }}>Spin</text>
           <box style={{ flexGrow: 1 }} />
           <Button onPress={() => setSpinning((s) => !s)}>

--- a/examples/stress/charts.jsx
+++ b/examples/stress/charts.jsx
@@ -45,7 +45,7 @@ function Control({ label, value, min, max, step, onChange, format }) {
         min={min}
         max={max}
         step={step}
-        onChange={onChange}
+        onChange={(ev) => onChange(ev.value)}
         style={{ flexGrow: 1 }}
       />
       <text style={s.ctlValue}>{format ? format(value) : String(value)}</text>
@@ -128,7 +128,7 @@ function WaveCard() {
       />
       <box style={s.ctl}>
         <text style={s.ctlLabel}>fill</text>
-        <Switch checked={filled} onChange={setFilled} />
+        <Switch checked={filled} onChange={(ev) => setFilled(ev.value)} />
       </box>
     </box>
   );
@@ -195,7 +195,7 @@ function DonutCard() {
                 value={v}
                 min={0}
                 max={50}
-                onChange={set(i)}
+                onChange={(ev) => set(i)(ev.value)}
                 style={{ flexGrow: 1 }}
               />
               <text style={s.ctlValue}>{String(v)}</text>

--- a/examples/stress/controls.jsx
+++ b/examples/stress/controls.jsx
@@ -220,15 +220,20 @@ export function ControlsPanel() {
                 <Checkbox
                   key={key}
                   checked={checks[key]}
-                  onChange={(v) => setChecks((c) => ({ ...c, [key]: v }))}
+                  onChange={(ev) =>
+                    setChecks((c) => ({ ...c, [key]: ev.value }))
+                  }
                   label={`Checkbox ${key}`}
                 />
               ))}
               <box style={s.row}>
                 <text style={s.label}>Switch</text>
-                <Switch checked={toggle} onChange={setToggle} />
+                <Switch
+                  checked={toggle}
+                  onChange={(ev) => setToggle(ev.value)}
+                />
               </box>
-              <RadioGroup value={radio} onChange={setRadio}>
+              <RadioGroup value={radio} onChange={(ev) => setRadio(ev.value)}>
                 <Radio value="a" label="Option A" />
                 <Radio value="b" label="Option B" />
                 <Radio value="c" label="Option C (disabled)" disabled />
@@ -242,7 +247,7 @@ export function ControlsPanel() {
                 <Select
                   options={FRUIT}
                   value={fruit}
-                  onChange={setFruit}
+                  onChange={(ev) => setFruit(ev.value)}
                   style={{ flexGrow: 1 }}
                 />
               </box>
@@ -252,7 +257,7 @@ export function ControlsPanel() {
                   value={level}
                   min={0}
                   max={100}
-                  onChange={setLevel}
+                  onChange={(ev) => setLevel(ev.value)}
                   style={{ flexGrow: 1 }}
                 />
                 <text style={s.hint}>{String(level)}</text>

--- a/examples/stress/damage.jsx
+++ b/examples/stress/damage.jsx
@@ -134,15 +134,15 @@ export function DamagePanel() {
       <box style={s.row}>
         <Button primary label="step" onPress={bump} />
         <text style={s.label}>animate</text>
-        <Switch checked={animate} onChange={setAnimate} />
+        <Switch checked={animate} onChange={(ev) => setAnimate(ev.value)} />
         <text style={s.label}>labels</text>
-        <Switch checked={labels} onChange={setLabels} />
+        <Switch checked={labels} onChange={(ev) => setLabels(ev.value)} />
         <text style={s.label}>cols {String(cols)}</text>
         <Slider
           value={cols}
           min={4}
           max={40}
-          onChange={setCols}
+          onChange={(ev) => setCols(ev.value)}
           style={{ width: 90 }}
         />
         <text style={s.label}>rows {String(rows)}</text>
@@ -150,7 +150,7 @@ export function DamagePanel() {
           value={rows}
           min={4}
           max={25}
-          onChange={setRows}
+          onChange={(ev) => setRows(ev.value)}
           style={{ width: 90 }}
         />
       </box>

--- a/examples/stress/data.jsx
+++ b/examples/stress/data.jsx
@@ -218,11 +218,11 @@ function TickerTable() {
       <text style={s.title}>Live ticker</text>
       <box style={s.row}>
         <text style={s.hint}>live</text>
-        <Switch checked={live} onChange={setLive} />
+        <Switch checked={live} onChange={(ev) => setLive(ev.value)} />
         <text style={s.hint}>{perTick} rows/tick</text>
         <Switch
           checked={perTick > 2}
-          onChange={(on) => setPerTick(on ? 12 : 2)}
+          onChange={(ev) => setPerTick(ev.value ? 12 : 2)}
         />
       </box>
       <Table

--- a/examples/stress/mixed.jsx
+++ b/examples/stress/mixed.jsx
@@ -150,7 +150,7 @@ export function MixedPanel() {
       <box style={s.row}>
         <text style={s.head}>Mixed</text>
         <text style={s.hint}>animate</text>
-        <Switch checked={running} onChange={setRunning} />
+        <Switch checked={running} onChange={(ev) => setRunning(ev.value)} />
         <text style={s.hint}>
           a clock at 1s and a bar at 80ms — some frames carry one change, some
           two, and the union of two small rects should still be small
@@ -185,7 +185,7 @@ export function MixedPanel() {
                 value={amplitude}
                 min={0}
                 max={38}
-                onChange={setAmplitude}
+                onChange={(ev) => setAmplitude(ev.value)}
                 style={{ flexGrow: 1 }}
               />
             </box>
@@ -202,7 +202,7 @@ export function MixedPanel() {
                 min={0}
                 max={900}
                 step={20}
-                onChange={setThreshold}
+                onChange={(ev) => setThreshold(ev.value)}
                 style={{ flexGrow: 1 }}
               />
             </box>

--- a/examples/stress/typography.jsx
+++ b/examples/stress/typography.jsx
@@ -121,7 +121,7 @@ export function TypographyPanel() {
           value={size}
           min={8}
           max={28}
-          onChange={setSize}
+          onChange={(ev) => setSize(ev.value)}
           style={{ width: 120 }}
         />
         <text style={s.hint}>column {String(width)}%</text>
@@ -129,7 +129,7 @@ export function TypographyPanel() {
           value={width}
           min={40}
           max={100}
-          onChange={setWidth}
+          onChange={(ev) => setWidth(ev.value)}
           style={{ width: 120 }}
         />
       </box>

--- a/examples/theming.jsx
+++ b/examples/theming.jsx
@@ -121,7 +121,7 @@ export function ThemingPanel() {
         <Select
           value={name}
           options={THEME_OPTIONS}
-          onChange={setName}
+          onChange={(ev) => setName(ev.value)}
           style={{ width: 150 }}
         />
         <Button
@@ -160,14 +160,20 @@ export function ThemingPanel() {
               <text style={s.heading}>Toggles</text>
               <Checkbox
                 checked={agreed}
-                onChange={setAgreed}
+                onChange={(ev) => setAgreed(ev.value)}
                 label="Checkbox"
               />
               <box style={s.row}>
-                <Switch checked={notify} onChange={setNotify} />
+                <Switch
+                  checked={notify}
+                  onChange={(ev) => setNotify(ev.value)}
+                />
                 <text style={s.note}>Switch</text>
               </box>
-              <RadioGroup value={flavour} onChange={setFlavour}>
+              <RadioGroup
+                value={flavour}
+                onChange={(ev) => setFlavour(ev.value)}
+              >
                 <Radio value="vanilla" label="Vanilla" />
                 <Radio value="pistachio" label="Pistachio" />
               </RadioGroup>
@@ -183,7 +189,7 @@ export function ThemingPanel() {
                   value={volume}
                   min={0}
                   max={100}
-                  onChange={setVolume}
+                  onChange={(ev) => setVolume(ev.value)}
                   style={{ flexGrow: 1 }}
                 />
                 <text style={s.note}>{String(volume)}</text>

--- a/examples/three.jsx
+++ b/examples/three.jsx
@@ -139,11 +139,14 @@ function App() {
         </Canvas3D>
 
         <box style={{ flexDirection: 'row', alignItems: 'center', gap: 12 }}>
-          <Switch checked={running} onChange={setRunning} />
+          <Switch checked={running} onChange={(ev) => setRunning(ev.value)} />
           <text style={{ fontSize: 13 }}>Spin</text>
-          <Switch checked={wireframe} onChange={setWireframe} />
+          <Switch
+            checked={wireframe}
+            onChange={(ev) => setWireframe(ev.value)}
+          />
           <text style={{ fontSize: 13 }}>Wireframe</text>
-          <Switch checked={textured} onChange={setTextured} />
+          <Switch checked={textured} onChange={(ev) => setTextured(ev.value)} />
           <text style={{ fontSize: 13 }}>Texture</text>
           <box style={{ flexGrow: 1 }} />
           <text style={{ fontSize: 13, color: '#5b6570' }}>

--- a/examples/widgets.jsx
+++ b/examples/widgets.jsx
@@ -67,7 +67,7 @@ export function WidgetsPanel() {
 
       <Row label="Checkbox">
         <box style={{ gap: 6 }}>
-          <Checkbox checked={agreed} onChange={setAgreed}>
+          <Checkbox checked={agreed} onChange={(ev) => setAgreed(ev.value)}>
             I agree to nothing in particular
           </Checkbox>
           <Checkbox checked={false} disabled>
@@ -77,7 +77,7 @@ export function WidgetsPanel() {
       </Row>
 
       <Row label="Radio">
-        <RadioGroup value={flavor} onChange={setFlavor}>
+        <RadioGroup value={flavor} onChange={(ev) => setFlavor(ev.value)}>
           <Radio value="vanilla">Vanilla</Radio>
           <Radio value="chocolate">Chocolate</Radio>
           <Radio value="pistachio">Pistachio</Radio>
@@ -85,7 +85,7 @@ export function WidgetsPanel() {
       </Row>
 
       <Row label="Switch">
-        <Switch checked={notify} onChange={setNotify} />
+        <Switch checked={notify} onChange={(ev) => setNotify(ev.value)} />
         <text style={{ color: '#2d3436' }}>
           {notify ? 'notifications on' : 'off'}
         </text>
@@ -97,7 +97,7 @@ export function WidgetsPanel() {
           min={0}
           max={100}
           step={5}
-          onChange={setVolume}
+          onChange={(ev) => setVolume(ev.value)}
           style={{ width: 200 }}
         />
         <text style={{ color: '#2d3436' }}>{`${volume}`}</text>
@@ -116,7 +116,7 @@ export function WidgetsPanel() {
         <Select
           options={['fast', 'faster', 'ludicrous']}
           value={speed}
-          onChange={setSpeed}
+          onChange={(ev) => setSpeed(ev.value)}
           style={{ width: 160 }}
         />
       </Row>

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -10,8 +10,9 @@ const h = React.createElement;
 
 /**
  * <Checkbox checked onChange disabled>label</Checkbox> — 16px check well +
- * label row; click or Space toggles. `onChange(next, ev)`: the next value
- * first, then a form-library-shaped change event carrying `name`.
+ * label row; click or Space toggles. `onChange(ev)` gets a change event, the
+ * same shape `<textinput>` fires: the next value is `ev.value`, and
+ * `ev.target` carries `name`/`checked` for a form library.
  */
 export function Checkbox({
   children,
@@ -29,7 +30,7 @@ export function Checkbox({
     props,
     style: controlStyle,
   } = useControl(disabled, () =>
-    onChange?.(!checked, changeEvent('checkbox', name, !checked)),
+    onChange?.(changeEvent('checkbox', name, !checked)),
   );
   const fill = disabled ? theme.dim : theme.accent;
   return h(

--- a/src/components/Radio.js
+++ b/src/components/Radio.js
@@ -16,7 +16,8 @@ const RadioGroupContext = React.createContext(null);
  * — exclusive choice. Arrow keys move the selection through the group in
  * mount order (wrapping); click or Space selects the focused radio.
  * `name` lives on the group, not the radios, the way it does in HTML: it is
- * the group that is one form field. `onChange(next, ev)`.
+ * the group that is one form field. `onChange(ev)`, with the chosen value
+ * on `ev.value`.
  */
 export function RadioGroup({
   value,
@@ -28,7 +29,7 @@ export function RadioGroup({
 }) {
   const order = useRef([]).current;
   const ctx = useMemo(() => {
-    const emit = (next) => onChange?.(next, changeEvent('radio', name, next));
+    const emit = (next) => onChange?.(changeEvent('radio', name, next));
     return {
       value,
       emit,

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -170,8 +170,7 @@ export function Select({
   };
   const toggle = () => (open ? close() : openMenu());
 
-  const emit = (next) =>
-    onChange?.(next, changeEvent('select-one', name, next));
+  const emit = (next) => onChange?.(changeEvent('select-one', name, next));
 
   const pick = (option) => {
     close();

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -62,7 +62,7 @@ export function Slider({
   const fraction = (clamp(value) - min) / span;
 
   const emit = (next) => {
-    if (next !== value) onChange?.(next, changeEvent('range', name, next));
+    if (next !== value) onChange?.(changeEvent('range', name, next));
   };
 
   /** Pointer x -> value, using the track's laid-out rect. */

--- a/src/components/Switch.js
+++ b/src/components/Switch.js
@@ -38,6 +38,7 @@ const THUMB_ON = TRACK_WIDTH - THUMB - INSET;
 /**
  * <Switch checked onChange disabled style/> — Checkbox semantics in a
  * sliding pill; the thumb slides to the end matching the state.
+ * `onChange(ev)`, as `Checkbox`.
  *
  * The hover and focus tints are `:hover`/`:focus` blocks rather than React
  * state: the renderer already knows which node the pointer is over and
@@ -59,7 +60,7 @@ export function Switch({
   const theme = useTheme();
   const control = useControl(
     disabled,
-    () => onChange?.(!checked, changeEvent('checkbox', name, !checked)),
+    () => onChange?.(changeEvent('checkbox', name, !checked)),
     { styled: true },
   );
   return h(

--- a/src/components/change.js
+++ b/src/components/change.js
@@ -1,19 +1,23 @@
-// The change event the widgets pass as their `onChange`'s *second*
-// argument.
+// The change event the value widgets hand their `onChange`.
 //
-// The host elements `<textinput>`/`<textarea>` hand their handler a single
-// synthetic event (issue #115). The widgets cannot: `onChange={setChecked}`
-// is the whole ergonomic point of them, and the next value has to stay the
-// first argument. So the event is additive — the first argument is the
-// value, the second is this — which is enough for a form library, because
-// every one of them reads the field out of `ev.target`.
+// One signature across the library: `<textinput>` and `<textarea>` pass a
+// synthetic event, and so do `Checkbox`, `Switch`, `RadioGroup`, `Select`
+// and `Slider`. That is what lets `onChange={formik.handleChange}` be wired
+// to any of them without a per-widget adapter — a form library reads the
+// field out of `ev.target`, and it now finds one there whatever it is
+// attached to.
 //
-// `target` is a plain descriptor rather than a node: a widget is a
-// composition of nodes with no single element holding its value, and
-// `{ type, name, value, checked }` is exactly the shape formik's
-// `handleChange` and react-hook-form's `getEventValue` destructure. `type`
-// is what tells them a checkbox from a text field, which is why it is set
-// even though nothing in react-x11 reads it.
+// The line is `name`: a widget that takes one is a form field and reports an
+// event. `Tabs`, `Tree`, `Table` and the menus are not form fields and keep
+// their plain callbacks.
+//
+// `target` is a plain descriptor rather than a node, which is the one place
+// this differs from the host elements. A widget is a composition of nodes
+// with no single element holding its value, so there is nothing honest to
+// point at — and `{ type, name, value, checked }` is exactly the shape
+// formik's `handleChange` and react-hook-form's event reader destructure.
+// `type` is what tells them a checkbox from a text field, which is why it is
+// set even though nothing in react-x11 reads it.
 //
 // There is no `preventDefault` — the value has already changed by the time
 // the handler runs, so there would be nothing to prevent.

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -63,13 +63,17 @@ export function useTheme(): Theme;
 type WidgetProps = Omit<BoxProps, 'children' | 'style' | 'ref'>;
 
 /**
- * The second argument a widget's `onChange` gets, after the next value.
+ * What a value widget's `onChange` receives — one signature across the
+ * library, so `onChange={formik.handleChange}` wires to a `Checkbox` exactly
+ * as it does to a `<textinput>`.
  *
- * The value stays first — `onChange={setChecked}` is what these widgets are
- * for — and this carries the field identity a form library needs.
+ * The new value is `ev.value`, so `onChange={(ev) => setChecked(ev.value)}`
+ * is the plain-React form.
+ *
  * `target` is a plain descriptor, not a node: a widget is several nodes and
- * none of them holds its value. Its shape is what formik's `handleChange`
- * and react-hook-form's event reader destructure, `type` included.
+ * none of them holds its value, so there is nothing honest to point at. Its
+ * shape is what formik's `handleChange` and react-hook-form's event reader
+ * destructure, `type` included.
  */
 export interface WidgetChangeEvent<V = unknown> {
   type: 'change';
@@ -110,7 +114,7 @@ export interface CheckboxProps extends WidgetProps, NamedWidget {
   children?: ReactNode;
   label?: string;
   checked?: boolean;
-  onChange?: (checked: boolean, ev: WidgetChangeEvent<boolean>) => void;
+  onChange?: (ev: WidgetChangeEvent<boolean>) => void;
   disabled?: boolean;
   style?: StyleProp;
 }
@@ -118,7 +122,7 @@ export const Checkbox: ComponentType<CheckboxProps>;
 
 export interface RadioGroupProps<T = unknown> extends WidgetProps, NamedWidget {
   value?: T;
-  onChange?: (value: T, ev: WidgetChangeEvent<T>) => void;
+  onChange?: (ev: WidgetChangeEvent<T>) => void;
   children?: ReactNode;
   style?: StyleProp;
 }
@@ -134,7 +138,7 @@ export function Radio<T = unknown>(props: RadioProps<T>): ReactNode;
 
 export interface SwitchProps extends WidgetProps, NamedWidget {
   checked?: boolean;
-  onChange?: (checked: boolean, ev: WidgetChangeEvent<boolean>) => void;
+  onChange?: (ev: WidgetChangeEvent<boolean>) => void;
   disabled?: boolean;
   style?: StyleProp;
 }
@@ -155,7 +159,7 @@ export interface SliderProps extends WidgetProps, NamedWidget {
   min?: number;
   max?: number;
   step?: number;
-  onChange?: (value: number, ev: WidgetChangeEvent<number>) => void;
+  onChange?: (ev: WidgetChangeEvent<number>) => void;
   disabled?: boolean;
   height?: number;
   style?: StyleProp;
@@ -207,7 +211,7 @@ export type SelectOption<T = unknown> = { value: T; label: string } | T;
 export interface SelectProps<T = unknown> extends WidgetProps, NamedWidget {
   value?: T;
   options?: readonly SelectOption<T>[];
-  onChange?: (value: T, ev: WidgetChangeEvent<T>) => void;
+  onChange?: (ev: WidgetChangeEvent<T>) => void;
   placeholder?: string;
   style?: StyleProp;
 }

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1216,7 +1216,7 @@ test('Select opens a popup menu, picks an option, closes on Escape', async () =>
         React.createElement(Select, {
           options: ['red', 'green', 'blue'],
           value: null,
-          onChange: (v) => picks.push(v),
+          onChange: (ev) => picks.push(ev.value),
           style: { width: 160 },
         }),
       ),
@@ -1292,7 +1292,7 @@ test('Select: arrow keys move the active option, Enter picks it', async () => {
         React.createElement(Select, {
           options: ['red', 'green', 'blue'],
           value: 'green',
-          onChange: (v) => picks.push(v),
+          onChange: (ev) => picks.push(ev.value),
           style: { width: 160 },
         }),
       ),
@@ -1836,18 +1836,18 @@ test('Checkbox and Switch toggle through onChange', async () => {
         Checkbox,
         {
           checked,
-          onChange: (next) => {
-            log.push(['check', next]);
-            setChecked(next);
+          onChange: (ev) => {
+            log.push(['check', ev.value]);
+            setChecked(ev.value);
           },
         },
         'Enable',
       ),
       React.createElement(Switch, {
         checked: on,
-        onChange: (next) => {
-          log.push(['switch', next]);
-          setOn(next);
+        onChange: (ev) => {
+          log.push(['switch', ev.value]);
+          setOn(ev.value);
         },
       }),
     );
@@ -1879,9 +1879,10 @@ test('Checkbox and Switch toggle through onChange', async () => {
   ReactX11.unmountComponentAtNode(app);
 });
 
-// issue #115: the widgets keep `onChange(next)` — that is what they are for
-// — and carry the form-library-shaped event as a second argument.
-test("widgets pass a named change event as onChange's second argument", async () => {
+// One signature across the library: the value widgets hand `onChange` a
+// change event, exactly as `<textinput>` does, so a form library's handler
+// can be passed straight in with no per-widget adapter.
+test('value widgets pass a named change event to onChange', async () => {
   const { Checkbox, RadioGroup, Radio, Slider } =
     await import('../src/index.js');
   const app = createMockApp();
@@ -1899,9 +1900,9 @@ test("widgets pass a named change event as onChange's second argument", async ()
         {
           checked,
           name: 'agree',
-          onChange: (next, ev) => {
+          onChange: (ev) => {
             events.push(ev);
-            setChecked(next);
+            setChecked(ev.value);
           },
         },
         'Agree',
@@ -1911,9 +1912,9 @@ test("widgets pass a named change event as onChange's second argument", async ()
         {
           value: flavour,
           name: 'flavour',
-          onChange: (next, ev) => {
+          onChange: (ev) => {
             events.push(ev);
-            setFlavour(next);
+            setFlavour(ev.value);
           },
         },
         React.createElement(Radio, { value: 'a' }, 'A'),
@@ -1922,7 +1923,7 @@ test("widgets pass a named change event as onChange's second argument", async ()
       React.createElement(Slider, {
         value: 10,
         name: 'volume',
-        onChange: (next, ev) => events.push(ev),
+        onChange: (ev) => events.push(ev),
         style: { width: 100 },
       }),
     );
@@ -1962,6 +1963,52 @@ test("widgets pass a named change event as onChange's second argument", async ()
   assert.strictEqual(events[0].target.checked, true);
   assert.strictEqual(events[0].target.name, 'agree');
   assert.strictEqual(events[1].target.checked, undefined);
+  // the event is the *only* argument: a handler taking one parameter, which
+  // is what `onChange={formik.handleChange}` is, must receive the event and
+  // not a bare value
+  for (const ev of events) {
+    assert.strictEqual(typeof ev, 'object');
+    assert.strictEqual(ev.type, 'change');
+  }
+  ReactX11.unmountComponentAtNode(app);
+});
+
+// The contract that matters, stated as the thing a user actually writes.
+// A form library's handler reads the field out of `ev.target`, so passing it
+// straight to a widget only works while the event is the first argument.
+test('a one-parameter handler is handed the event, not the value', async () => {
+  const { Checkbox } = await import('../src/index.js');
+  const app = createMockApp();
+  const seen = [];
+  // exactly the shape of formik's handleChange: one parameter, destructures
+  // the field out of `.target`
+  const handleChange = ({ target }) =>
+    seen.push([target.name, target.type, target.checked]);
+  function Wrapper() {
+    const [checked, setChecked] = React.useState(false);
+    return React.createElement(Checkbox, {
+      name: 'agree',
+      checked,
+      onChange: (ev) => {
+        handleChange(ev);
+        setChecked(ev.value);
+      },
+    });
+  }
+  ReactX11.render(
+    React.createElement(
+      'window',
+      { width: 200, height: 100 },
+      React.createElement(Wrapper),
+    ),
+    null,
+    app,
+  );
+  await tick();
+  const wnd = app.windows[0];
+  clickNode(wnd, findAllFocusable(wnd._reactX11Node)[0]);
+  await tick();
+  assert.deepStrictEqual(seen, [['agree', 'checkbox', true]]);
   ReactX11.unmountComponentAtNode(app);
 });
 
@@ -1975,9 +2022,9 @@ test('RadioGroup: click selects, arrow keys move selection (wrapping)', async ()
       RadioGroup,
       {
         value,
-        onChange: (v) => {
-          picks.push(v);
-          setValue(v);
+        onChange: (ev) => {
+          picks.push(ev.value);
+          setValue(ev.value);
         },
       },
       React.createElement(Radio, { value: 'a' }, 'A'),
@@ -2288,7 +2335,7 @@ test('Slider: drag keeps tracking after the pointer leaves the widget', async ()
           min: 0,
           max: 100,
           step: 1,
-          onChange: setV,
+          onChange: (ev) => setV(ev.value),
           style: { width: 200 },
         }),
       ),
@@ -2366,7 +2413,7 @@ test('Slider: keyboard steps, Home/End and PageUp/Down', async () => {
           min: 0,
           max: 100,
           step: 2,
-          onChange: setV,
+          onChange: (ev) => setV(ev.value),
           style: { width: 200 },
         }),
       ),
@@ -3036,7 +3083,7 @@ test('Slider keeps its width as the value changes (no drag feedback loop)', asyn
           min: 0,
           max: 100,
           value: v,
-          onChange: setV,
+          onChange: (ev) => setV(ev.value),
           style: { flexGrow: 1 },
         }),
       ),
@@ -3855,7 +3902,7 @@ test('Select: type-ahead jumps, refines and cycles', async () => {
         React.createElement(Select, {
           options,
           value: v,
-          onChange: setV,
+          onChange: (ev) => setV(ev.value),
           style: { width: 200 },
         }),
       ),

--- a/test/test-entry.test.js
+++ b/test/test-entry.test.js
@@ -226,9 +226,9 @@ test('Select opens a real popup window and picking closes it', async () => {
     return h(Select, {
       value,
       options: ['alpha', 'beta'],
-      onChange: (v) => {
-        picked.push(v);
-        setValue(v);
+      onChange: (ev) => {
+        picked.push(ev.value);
+        setValue(ev.value);
       },
       style: { width: 160 },
     });

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -337,20 +337,26 @@ function Widgets() {
           press
         </Button>
         <Button label="labelled" disabled />
-        <Checkbox checked={checked} onChange={setChecked}>
+        <Checkbox checked={checked} onChange={(ev) => setChecked(ev.value)}>
           check
         </Checkbox>
-        {/* issue #115: the next value stays first, so `onChange={setChecked}`
-            still checks; the form event is an optional second argument */}
+        {/* one signature across the library: the value widgets hand over a
+            change event, exactly as <textinput> does, so a form library's
+            handler can be passed straight in */}
         <Checkbox
           checked={checked}
           name="agree"
-          onChange={(next, ev: WidgetChangeEvent<boolean>) => {
+          onChange={(ev: WidgetChangeEvent<boolean>) => {
             void (ev.target.type === 'checkbox' && ev.target.checked);
-            setChecked(next);
+            void ev.name;
+            setChecked(ev.value);
           }}
         />
-        <Switch checked={checked} name="notify" onChange={setChecked} />
+        <Switch
+          checked={checked}
+          name="notify"
+          onChange={(ev) => setChecked(ev.value)}
+        />
         <ProgressBar value={0.4} color="#2980b9" />
         <Slider
           value={20}
@@ -358,7 +364,7 @@ function Widgets() {
           max={100}
           step={5}
           name="volume"
-          onChange={(v, ev) => void (v.toFixed() + ev.target.type)}
+          onChange={(ev) => void (ev.value.toFixed() + ev.target.type)}
         />
         <Tooltip label="hi" placement="bottom" delay={200}>
           <box />
@@ -367,7 +373,7 @@ function Widgets() {
         <RadioGroup<string>
           value="a"
           name="flavour"
-          onChange={(v, ev) => void (v.toUpperCase() + ev.name)}
+          onChange={(ev) => void (ev.value.toUpperCase() + ev.name)}
         >
           <Radio value="a">A</Radio>
           <Radio value="b" label="B" />
@@ -377,7 +383,7 @@ function Widgets() {
           value={1}
           name="qty"
           options={[{ value: 1, label: 'one' }]}
-          onChange={(v) => void v.toFixed()}
+          onChange={(ev) => void ev.value.toFixed()}
         />
         <Select options={['plain', 'values']} />
       </box>

--- a/website/src/demos/widgets.js
+++ b/website/src/demos/widgets.js
@@ -36,17 +36,17 @@ function Controls() {
       </box>
 
       <box style={{ flexDirection: 'row', gap: 20, alignItems: 'center' }}>
-        <Checkbox checked={checked} onChange={setChecked}>
+        <Checkbox checked={checked} onChange={(ev) => setChecked(ev.value)}>
           Remember me
         </Checkbox>
-        <Switch checked={on} onChange={setOn} />
+        <Switch checked={on} onChange={(ev) => setOn(ev.value)} />
         <text style={{ fontSize: 13 }}>{on ? 'on' : 'off'}</text>
       </box>
 
       <box style={{ gap: 6 }}>
         <text style={{ fontSize: 13 }}>Volume: {volume}</text>
         <Slider value={volume} min={0} max={100} step={5}
-                onChange={setVolume} style={{ width: 260 }} />
+                onChange={(ev) => setVolume(ev.value)} style={{ width: 260 }} />
         <ProgressBar value={volume / 100} style={{ width: 260 }} />
       </box>
 
@@ -54,7 +54,7 @@ function Controls() {
         <text style={{ fontSize: 13 }}>Fruit</text>
         <Select
           value={fruit}
-          onChange={setFruit}
+          onChange={(ev) => setFruit(ev.value)}
           style={{ width: 150 }}
           options={['apple', 'pear', 'cherry', 'quince']}
         />


### PR DESCRIPTION
Follow-up to #142, which gave the host elements a synthetic event but left
the widgets on `onChange(next, ev)` — value first, event second. That kept
them a special case for exactly the thing the event existed to fix: a form
library's handler could be passed straight to a `<textinput>` and needed a
per-widget bridge everywhere else.

## One signature

`Checkbox`, `Switch`, `RadioGroup`, `Select` and `Slider` now call
`onChange(ev)`, the same shape `<textinput>` and `<textarea>` use:

```jsx
<textinput name="host"  value={f.values.host}    onChange={f.handleChange} />
<Checkbox  name="agree" checked={f.values.agree} onChange={f.handleChange} />
<Select    name="size"  value={f.values.size}    onChange={f.handleChange} options={sizes} />
```

No adapter, no per-widget bridge, nothing to remember about which control
you are wiring.

## Verified, not reasoned about

Run headless against the renderer, the way the ecosystem docs require:

| wired straight in | result |
| --- | --- |
| `formik.handleChange` → `Checkbox` | ✅ |
| `formik.handleChange` → `Switch` | ✅ |
| `formik.handleChange` → `RadioGroup` | ✅ |
| `formik.handleChange` → `Slider` | ✅ |
| react-hook-form `field.onChange` → `Checkbox` via `<Controller>` | ✅ |

Before this, every one of those needed `(_next, ev) => handleChange(ev)`.

A regression test pins the contract as the thing a user actually writes — a
**one-parameter** handler that destructures `{ target }`, which is the shape
of `formik.handleChange` — so a future change back to value-first fails
loudly rather than silently passing a boolean where a form library expects
an event.

## The cost

`onChange={setChecked}` becomes `onChange={(ev) => setChecked(ev.value)}`.
Forty-odd call sites across the examples, the stress app, the playground
demos and the tests, all updated. That is the trade: a little more to type at
every call site, against one signature to learn and no adapter at the
boundary. Worth it, and it was the wrong call in #142.

## Where the line falls

Now stated in the docs rather than implied: **a control that takes a `name`
is a form field and reports an event.** `Tabs`, `Tree`, `Table` and the menus
are not form fields — nobody registers a tab strip with formik — and keep
their plain callbacks (`Tabs` still calls `onChange(id)`).

`ev.target` stays a plain `{ type, name, value, checked }` descriptor rather
than a node, which is the one remaining difference from the host elements: a
widget is several nodes with no single element holding its value, so there is
nothing honest to point at — and that shape is precisely what formik's
`handleChange` and react-hook-form's event reader destructure.

## Docs

`docs/ecosystem/forms.md` loses the 1.2.0-vs-2.0.0 comparison table. 1.2.0
has no users to migrate, so the page now just describes the API, which is
shorter and reads better. `docs/components.md` leads with the shared
signature and the `name` rule.

## Checks

`npm test` 323 pass / 0 fail (one new test), `npm run typecheck`,
`npm run lint`, `npm run format:check`, and `website`'s three gates green —
including the `widgets` demo, which drives a `Checkbox`, `Switch`, `Slider`
and `Select` through the real renderer with injected input.

No visual change, so no screenshots.