### PR TITLE
examples: the icon wall scrolls, so a scroll frame is measurable too

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -16,25 +16,25 @@ tests can import them without opening a window.
 
 Roughly in the order worth reading them:
 
-|                                      |                                                                                                |
-| ------------------------------------ | ---------------------------------------------------------------------------------------------- |
-| [`simple.jsx`](simple.jsx)           | hello world: flex layout and text, no pixel math. `npm run examples:simple`                    |
-| [`simple-nojsx.js`](simple-nojsx.js) | the same thing in plain node with `React.createElement` — no build step at all                 |
-| [`xeyes.jsx`](xeyes.jsx)             | the `<canvas>` escape hatch: custom drawing plus hooks for state and polling                   |
-| [`dashboard.jsx`](dashboard.jsx)     | context for theming, `useState`/`useEffect`/`useMemo`, a custom hook, hover and focus states   |
-| [`tasks.jsx`](tasks.jsx)             | `useReducer`, dispatch through context, list rendering, `<scrollview>`, keyboard throughout    |
-| [`form.jsx`](form.jsx)               | `<textinput>`, `Select`, `RadioGroup`, `Slider`, `Checkbox`, and a modal `Dialog`              |
-| [`widgets.jsx`](widgets.jsx)         | the gallery: every standard component in one window, with a live `<markdown>` preview          |
-| [`menu.jsx`](menu.jsx)               | `MenuBar` and `ContextMenu` over real `<popup>` windows that flip at screen edges              |
-| [`theming.jsx`](theming.jsx)         | the style engine end to end: three themes in light and dark, switched at runtime               |
-| [`richtext.jsx`](richtext.jsx)       | `<markdown>` with highlighted and math fences, a live `<tex>` formula, JSX `<svg>`, `<image>`  |
-| [`windows.jsx`](windows.jsx)         | many top-level windows from one React tree, sharing state, closing via `onCloseRequest`        |
-| [`app.jsx`](app.jsx)                 | the showcase: `SplitPane` + `Tabs` hosting `form`, `widgets` and `tasks` as panels             |
-| [`gl.jsx`](gl.jsx)                   | raw GL in a `<glarea>`, compiled to a server-side display list                                 |
-| [`three.jsx`](three.jsx)             | a react-three-fiber-shaped `<Canvas3D>` scene: meshes, lights, textures                        |
-| [`icons.jsx`](icons.jsx)             | 400 icon-sized `<svg>`s that reflow on resize, with a cached-glyph control — a paint benchmark |
-| [`stress/`](stress/index.jsx)        | **the big one**: six panels to poke at by hand, with a frame log — see below                   |
-| [`wm.jsx`](wm.jsx)                   | **a reparenting window manager** — see below                                                   |
+|                                      |                                                                                                 |
+| ------------------------------------ | ----------------------------------------------------------------------------------------------- |
+| [`simple.jsx`](simple.jsx)           | hello world: flex layout and text, no pixel math. `npm run examples:simple`                     |
+| [`simple-nojsx.js`](simple-nojsx.js) | the same thing in plain node with `React.createElement` — no build step at all                  |
+| [`xeyes.jsx`](xeyes.jsx)             | the `<canvas>` escape hatch: custom drawing plus hooks for state and polling                    |
+| [`dashboard.jsx`](dashboard.jsx)     | context for theming, `useState`/`useEffect`/`useMemo`, a custom hook, hover and focus states    |
+| [`tasks.jsx`](tasks.jsx)             | `useReducer`, dispatch through context, list rendering, `<scrollview>`, keyboard throughout     |
+| [`form.jsx`](form.jsx)               | `<textinput>`, `Select`, `RadioGroup`, `Slider`, `Checkbox`, and a modal `Dialog`               |
+| [`widgets.jsx`](widgets.jsx)         | the gallery: every standard component in one window, with a live `<markdown>` preview           |
+| [`menu.jsx`](menu.jsx)               | `MenuBar` and `ContextMenu` over real `<popup>` windows that flip at screen edges               |
+| [`theming.jsx`](theming.jsx)         | the style engine end to end: three themes in light and dark, switched at runtime                |
+| [`richtext.jsx`](richtext.jsx)       | `<markdown>` with highlighted and math fences, a live `<tex>` formula, JSX `<svg>`, `<image>`   |
+| [`windows.jsx`](windows.jsx)         | many top-level windows from one React tree, sharing state, closing via `onCloseRequest`         |
+| [`app.jsx`](app.jsx)                 | the showcase: `SplitPane` + `Tabs` hosting `form`, `widgets` and `tasks` as panels              |
+| [`gl.jsx`](gl.jsx)                   | raw GL in a `<glarea>`, compiled to a server-side display list                                  |
+| [`three.jsx`](three.jsx)             | a react-three-fiber-shaped `<Canvas3D>` scene: meshes, lights, textures                         |
+| [`icons.jsx`](icons.jsx)             | 400 icon-sized `<svg>`s that reflow and scroll, with a cached-glyph control — a paint benchmark |
+| [`stress/`](stress/index.jsx)        | **the big one**: six panels to poke at by hand, with a frame log — see below                    |
+| [`wm.jsx`](wm.jsx)                   | **a reparenting window manager** — see below                                                    |
 
 `app.jsx` is where a new control should get demonstrated: it imports the
 panel each of `form`, `widgets` and `tasks` exports, so adding a widget

--- a/examples/icons.jsx
+++ b/examples/icons.jsx
@@ -3,6 +3,7 @@
 //   npm run examples:icons                    400 icons from `source` strings
 //   npm run examples:icons -- --mode=jsx      the same icons as JSX children
 //   npm run examples:icons -- --count=800 --size=16
+//   npm run examples:icons -- --count=1200    tall enough to scroll on sight
 //   npm run examples:icons -- --quiet         log only frames over 50kpx
 //
 // Everything is drivable from the window: the **glyph control** switch swaps
@@ -10,6 +11,22 @@
 // set count and size. Press 1 / 2 for the two SVG modes. Drag the window
 // edge to reflow. The grid and the cell count stay identical throughout, so
 // frame logs from either side of the switch are directly comparable.
+//
+// The wall lives in a `<scrollview>`, which puts the *other* expensive frame
+// on the wheel: a scroll moves every cell without changing one of them. Those
+// frames log as `scroll`, and the damage column is where to look — the scroll
+// blit (issue #138) copies the surviving band in the backing pixmap and
+// repaints only the strip the scroll exposed, so a wheel notch reads as
+// `2 rect 26kpx` where the same viewport repainted whole is `211kpx`. A big
+// enough jump keeps less than half the viewport, misses the blit's gate and
+// falls back to the full repaint — the two lines sitting next to each other
+// in the log is the point. `REACT_X11_NO_SCROLL_BLIT=1` turns the fast path
+// off to measure against it.
+//
+// At the default 400 x 20px the wall is 544px tall and the viewport is 790,
+// so there is nothing to scroll until you raise `count` past ~600 or drag the
+// window smaller. That is deliberate: the numbers this example was baselined
+// with are the ones an untouched window still produces.
 //
 // Why this shape: `<svg>` has no cached rasterization, so `SvgView.draw`
 // re-walks the parsed document on every repaint — Path2D, flatten, stroke
@@ -183,11 +200,18 @@ const s = createStyles({
   ctl: { flexDirection: 'row', alignItems: 'center', gap: 6 },
   ctlLabel: { fontSize: 11, color: '#7f8c8d' },
   ctlValue: { fontSize: 11, color: '#2d3436', width: 30 },
+  // The viewport: it takes the space the header leaves and lets the wall
+  // overflow it. ScrollViewNode supplies the `flex-basis: 0` and the
+  // `min-height: 0` that a scroll container always wants, so `flexGrow` is
+  // the whole declaration.
+  scroller: { flexGrow: 1 },
   // `flexWrap` is the whole point: the column count is a function of the
   // window width, so every resize is a real reflow of all `count` cells
-  // rather than a stretch of a fixed grid.
+  // rather than a stretch of a fixed grid. The wrap still happens at the
+  // viewport width inside the scrollview — what the scroll container took
+  // away is `flexGrow`, since in there the wall has to size to its content
+  // or there would be nothing to scroll.
   grid: {
-    flexGrow: 1,
     flexDirection: 'row',
     flexWrap: 'wrap',
     alignContent: 'flex-start',
@@ -358,9 +382,13 @@ function App({
             step={2}
             onChange={setSize}
           />
-          <text style={s.hint}>drag an edge to reflow · 1 source · 2 jsx</text>
+          <text style={s.hint}>
+            drag an edge to reflow · wheel to scroll · 1 source · 2 jsx
+          </text>
         </box>
-        <box style={s.grid}>{cells}</box>
+        <scrollview style={s.scroller}>
+          <box style={s.grid}>{cells}</box>
+        </scrollview>
       </box>
     </window>
   );
@@ -522,8 +550,8 @@ if (!process.env.REACT_X11_NO_AUTORUN) {
         if (watcher) return;
         watcher = watchPaint(node, { quiet });
         process.stdout.write(
-          `\n  drag an edge to reflow · the switch swaps svg for the glyph` +
-            ` control · sliders change count and size\n\n` +
+          `\n  drag an edge to reflow · wheel to scroll · the switch swaps` +
+            ` svg for the glyph control · sliders change count and size\n\n` +
             `  frame  damage    area    client   server    total  why\n` +
             `  ${'-'.repeat(64)}\n`,
         );


### PR DESCRIPTION
The icon wall now lives in a `<scrollview>`, so the example reaches the
other expensive frame too: a scroll moves every cell without changing one
of them.

![icons-scroll-top](https://github.com/user-attachments/assets/50895730-7bd1-41f8-8ac7-fe298bf00cce)

![icons-scroll-bottom](https://github.com/user-attachments/assets/7d264eaa-07fd-45a8-8ac8-df18545b0942)

## Why

`icons.jsx` measures the frame where 400 `<svg>` cells redraw with unchanged
content, which today means a resize. A scroll is that same population of
cells at a new offset, and it is the frame the scroll blit from #138 exists
for. Putting the wall in a viewport makes both reachable from one window,
against one frame log, without restarting.

## What the log shows

Scrolling a 520x405 window at the default count:

```
  frame  damage    area    client   server    total  why
      3  FULL       211kpx     34.4ms    284.4ms    318.8ms  resize+expose
      4  2 rect      26kpx      9.0ms     56.6ms     65.6ms  scroll
      5  3 rect      76kpx     12.3ms    136.4ms    148.6ms  scroll
      6  1 rect     196kpx     11.7ms    514.2ms    525.9ms  scroll
```

A wheel notch is 2 rects and 26kpx where the same viewport repainted whole
is 211kpx. Frame 6 is the other half of the story: a jump big enough to keep
under half the viewport misses the blit's gate and falls back to the full
repaint. Both lines in one log is the point. `REACT_X11_NO_SCROLL_BLIT=1`
turns the fast path off to measure against it.

## Notes

- `s.grid` loses its `flexGrow`. Inside the viewport the wall has to size to
  its content, or there is nothing to scroll. The wrap still happens at the
  viewport width, so a resize is the same reflow it was.
- Slider defaults are untouched, so the paint baseline from #147 still holds.
  At 400 icons of 20px the wall is 544px against a 790px viewport, and
  nothing scrolls until count passes ~600 or the window gets smaller.
  `npm run examples:icons -- --count=1200` starts it tall enough to scroll
  on sight.

Screenshots are 900 icons at the default size, rendered by this branch
against XQuartz and read back with `xwd`: the viewport at rest, then the
same window after scrolling to the end. The scrollbar thumb is the tell.

