### PR TITLE
feat: component queries and in-process DevTools inspection in react-x11/test

### DIFF
--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -33,6 +33,14 @@ What you get:
 a non-default standalone (e.g. devtools on another machine — handy when the
 X app runs on a headless box).
 
+The same backend, minus the socket, powers `react-x11/test`'s component
+inspection: `inspect()`/`setHook` in
+[testing.md](testing.md#inspectnode-and-sethook) drive the renderer
+interface the backend registers at injection, entirely in-process — no
+standalone app, no `ws`, no env variable. If a test run does set
+`REACT_X11_DEVTOOLS=1`, the two share one renderer registration (see the
+guard in `connect()`).
+
 ## How it works (and its sharp edges)
 
 `src/DevToolsIntegration.js`. When `REACT_X11_DEVTOOLS` is set, the hook is

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -100,6 +100,69 @@ reports `dialog`. The widgets set their own: `Button` is `button`,
 `ProgressBar` `progressbar`. When AT-SPI lands, these are the names it will
 publish.
 
+## Components
+
+The queries above see what a user sees. Sometimes a test needs the React
+side instead — _which component_ made this node, with what props and state —
+and this is the layer for it. Prefer the user-visible queries when either
+would do; reach here when the question is genuinely about a component.
+
+```js
+const row = screen.getByComponent('TaskRow'); // also RegExp or predicate
+within(row).getByText('buy milk'); // scoped to that instance
+
+ownerChainOf(node); // ['Label', 'TaskRow', 'App'] — who wrote the JSX
+sourceOf(node); // { file, line, column } of the JSX that made it
+```
+
+`getByComponent` returns, per rendered instance, the topmost host nodes of
+its output — the container `within()` wants next. Ownership is React's JSX
+owner (_who wrote the element_), so content passed as children belongs to
+the component whose JSX it appears in, and a miss lists the component names
+that are in the tree. All of this reads debug info development React records
+on every fiber (`_debugOwner`, `_debugStack` — the same data
+[click-to-component](click-to-component.md) navigates by), so it costs no
+setup and no dependency, and returns nothing in production builds.
+
+### `inspect(node)` and `setHook`
+
+```js
+const c = await inspect(screen.getByText('buy milk'));
+c.name; // 'TaskRow' — the nearest mounted component
+c.props; // its live props object (treat as read-only)
+c.hooks; // [{ id, name: 'State', value, editable, source, subHooks }]
+
+await c.setHook(0, 41); // set a useState/useReducer value…
+await c.setHook(1, ['filter', 'text'], 'milk'); // …or a path inside one
+```
+
+This drives the **React DevTools backend in-process**: the same
+react-debug-tools inspection and the same override path the DevTools app
+uses, minus its WebSocket — nothing listens on anything, and `ws` is never
+loaded ([devtools.md](devtools.md) has the wiring). It needs the
+`react-devtools-core` package in your devDependencies; the queries above
+work without it.
+
+What to know before leaning on it:
+
+- **Reading hooks re-runs the component.** That is how react-debug-tools
+  recovers hook names: the render function is invoked once under a stub
+  dispatcher, output discarded, `console` muted. A render-counting test
+  will see it.
+- **Values:** `props` and editable hook values are the live objects;
+  everything else is DevTools' copy — primitives exact, deep objects as
+  the same previews the DevTools panel shows.
+- **Only `useState`/`useReducer` are settable** (`editable: true`; a
+  reducer is bypassed, not driven — no action runs). Hooks are addressed
+  by their `id`, an index the Rules of Hooks fix for the life of the
+  component. Anything else — an Effect, a Memo, a `useContext` value —
+  `setHook` refuses by name; for context, wrap a provider.
+- **Nearest component is tree ancestry** (what the DevTools panel would
+  select), where `getByComponent`/`ownerChainOf` are JSX ownership; the
+  two differ for content passed as children.
+- `setHook` resolves after React re-rendered and repainted (it is
+  `act`-wrapped), so a query straight after it sees the result.
+
 ## Driving it
 
 `userEvent` is the layer to reach for: each call injects input **and**

--- a/src/ClickToComponent.js
+++ b/src/ClickToComponent.js
@@ -17,8 +17,10 @@ import { setClickToComponentHandler } from './events.js';
 const STACK_FRAME = /^\s*at\s+(?:(.+?)\s+\()?(.+?):(\d+):(\d+)\)?\s*$/;
 
 /** The first stack frame outside React/the reconciler/node internals — the
- * user's own JSX call site for whatever element this Error was captured at. */
-function resolveLocation(debugStack) {
+ * user's own JSX call site for whatever element this Error was captured at.
+ * Exported because `react-x11/test`'s `sourceOf` answers the same question
+ * for a test that a click answers for an editor. */
+export function resolveLocation(debugStack) {
   const stack = debugStack?.stack;
   if (!stack) return null;
   for (const line of stack.split('\n').slice(1)) {

--- a/src/DevToolsIntegration.js
+++ b/src/DevToolsIntegration.js
@@ -48,7 +48,14 @@ export function connect(renderer) {
   // to pass was discarded in silence. The renderer's name and version now
   // come from the host config, where Reconciler.js already sets them
   // (`rendererPackageName`, `rendererVersion`).
-  renderer.injectIntoDevTools();
+  //
+  // Unless it is already registered: `react-x11/test`'s inspect() drives
+  // the same backend in-process and may have injected first — a second
+  // inject would register a duplicate renderer with the hook, and the
+  // standalone app would show two copies of every tree.
+  if (!global.__REACT_DEVTOOLS_GLOBAL_HOOK__?.rendererInterfaces?.size) {
+    renderer.injectIntoDevTools();
+  }
 
   watchForAgent();
 }

--- a/src/testing/components.js
+++ b/src/testing/components.js
@@ -1,0 +1,413 @@
+// The component layer of `react-x11/test`: which component made this node,
+// with what props and hooks — and set that state through React's own
+// machinery rather than by poking at internals.
+//
+// Two layers, with different requirements:
+//
+// **The fiber layer** (`ownerChainOf`, `sourceOf`, the `ByComponent`
+// queries) reads what development React already records on every fiber: the
+// JSX owner chain (`_debugOwner`) and the call-site Error (`_debugStack`).
+// Every retained node keeps its host fiber (`node._reactFiber`, set in
+// Reconciler.createInstance), so this needs no dependency and no setup —
+// only React in development mode, which a test run is.
+//
+// **The inspection layer** (`inspect`, and the `setHook` it hands out)
+// drives the React DevTools backend — the same code the standalone DevTools
+// app talks to — entirely in this process. `injectIntoDevTools()` parks a
+// full renderer interface on the global hook before any bridge, agent or
+// socket exists, and that interface is the expensive-to-own half of
+// DevTools: hook trees with names and source locations (react-debug-tools),
+// and overrides that go through `enqueueConcurrentRenderForLane` so React
+// actually re-renders. The WebSocket transport of docs/devtools.md is the
+// half this deliberately skips: nothing here opens a socket or listens on
+// anything, and `ws` is never imported. It needs the `react-devtools-core`
+// package (a devDependency here; add it to yours) — the fiber layer works
+// without it.
+
+import { Renderer } from '../Reconciler.js';
+import Reflection from 'react-reconciler/reflection.js';
+import { resolveLocation } from '../ClickToComponent.js';
+import { act, mountedEntries } from './harness.js';
+
+const { findCurrentFiberUsingSlowPath } = Reflection;
+
+// ---------------------------------------------------------------------------
+// The fiber layer
+// ---------------------------------------------------------------------------
+
+/** The display name of a fiber's type: function and class components, and
+ * the memo/forwardRef wrappers around them. Null for hosts and everything
+ * else — which is what lets the owner walks below skip non-components. */
+function fiberTypeName(type) {
+  if (typeof type === 'function') return type.displayName || type.name || null;
+  if (typeof type === 'object' && type !== null) {
+    // memo(Component) keeps the inner type on `.type`, forwardRef on
+    // `.render`; either way the name lives on the inner function
+    return type.displayName || fiberTypeName(type.render ?? type.type) || null;
+  }
+  return null;
+}
+
+/**
+ * The components that created this node, nearest first — `['Label',
+ * 'TaskRow', 'App']`. This is React's JSX owner chain (who *wrote* the
+ * element), not tree ancestry: content passed as children belongs to the
+ * component whose JSX it appears in, which is the answer a failing test
+ * wants. Empty outside development mode, where React records no owners.
+ */
+export function ownerChainOf(node) {
+  const names = [];
+  for (
+    let owner = node?._reactFiber?._debugOwner;
+    owner;
+    owner = owner._debugOwner
+  ) {
+    const name = fiberTypeName(owner.type);
+    if (name) names.push(name);
+  }
+  return names;
+}
+
+/**
+ * The source location of the JSX that created this node — `{ file, line,
+ * column }` — from the call-site Error development React captures on every
+ * element. The same resolution click-to-component uses for the editor jump.
+ */
+export function sourceOf(node) {
+  return resolveLocation(node?._reactFiber?._debugStack) ?? null;
+}
+
+function componentMatches(name, expected) {
+  if (expected instanceof RegExp) return expected.test(name);
+  if (typeof expected === 'function') return Boolean(expected(name));
+  return name === String(expected);
+}
+
+function nearestMatchingOwner(node, expected) {
+  for (
+    let owner = node?._reactFiber?._debugOwner;
+    owner;
+    owner = owner._debugOwner
+  ) {
+    const name = fiberTypeName(owner.type);
+    if (name && componentMatches(name, expected)) return owner;
+  }
+  return null;
+}
+
+// A fiber and its alternate are the same component instance; two nodes
+// created in different renders can hold either half of the pair.
+function sameInstance(a, b) {
+  return a === b || (b != null && a === b.alternate);
+}
+
+/**
+ * The host roots of every rendered instance of a component: for each
+ * instance, the topmost host nodes of its output, in paint order. That is
+ * the node `within()` wants next — scoping to it covers the instance's
+ * whole subtree, slotted children included, the way a container does.
+ */
+export function queryAllByComponent(root, expected) {
+  const found = [];
+  const visit = (node, parentOwner) => {
+    if (!node || node.destroyed) return;
+    const owner = nearestMatchingOwner(node, expected);
+    // A node whose matching owner is the same instance as its host
+    // parent's is interior to output already collected. Children created
+    // by the instance's own render props inherit it through `parentOwner`.
+    if (owner && !sameInstance(owner, parentOwner)) found.push(node);
+    for (const child of node.children ?? []) {
+      visit(child, owner ?? parentOwner);
+    }
+  };
+  visit(root, null);
+  return found;
+}
+
+/** What a ByComponent miss prints: the component names that *are* in the
+ * tree, which is the list the caller was trying to spell one of. */
+export function componentInventory(root, limit = 12) {
+  const names = new Set();
+  const visit = (node) => {
+    if (!node || node.destroyed) return;
+    for (
+      let owner = node._reactFiber?._debugOwner;
+      owner;
+      owner = owner._debugOwner
+    ) {
+      const name = fiberTypeName(owner.type);
+      if (name) names.add(name);
+    }
+    for (const child of node.children ?? []) visit(child);
+  };
+  visit(root);
+  if (names.size === 0) {
+    return '  (no components — is React running in development mode?)';
+  }
+  return [...names]
+    .slice(0, limit)
+    .map((name) => `  <${name}>`)
+    .join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// The inspection layer
+// ---------------------------------------------------------------------------
+
+let devtoolsReady = null;
+
+/**
+ * Install the DevTools global hook and register the renderer, once, and
+ * hand back the backend's renderer interface. No socket: installing the
+ * hook is `initialize()`; the interface appears at `injectIntoDevTools()`;
+ * `connectToDevTools` — the WebSocket half — is simply never called. If the
+ * app under test already enabled REACT_X11_DEVTOOLS, its interface is
+ * reused rather than injecting the renderer a second time.
+ */
+function rendererInterface() {
+  if (devtoolsReady) return devtoolsReady;
+  devtoolsReady = (async () => {
+    let hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+    if (!hook?.rendererInterfaces?.size) {
+      // the backend bundle expects browser-ish globals, exactly as
+      // DevToolsIntegration.prepare() shims them
+      global.self ??= global;
+      global.window ??= global;
+      let mod;
+      try {
+        mod = await import('react-devtools-core');
+      } catch (err) {
+        throw new Error(
+          'react-x11/test: inspect() drives the React DevTools backend ' +
+            'in-process, which needs the react-devtools-core package — ' +
+            'add it to your devDependencies. Original error: ' +
+            err.message,
+        );
+      }
+      const api = mod.default?.initialize ? mod.default : mod;
+      // The backend can also patch console (component stacks appended to
+      // console.error, and so on). A test harness must not: every setting
+      // that touches console goes in off.
+      api.initialize({
+        appendComponentStack: false,
+        breakOnConsoleErrors: false,
+        showInlineWarningsAndErrors: false,
+        hideConsoleLogsInStrictMode: false,
+      });
+      hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+      Renderer.injectIntoDevTools();
+    }
+    const interfaces = [...hook.rendererInterfaces.values()];
+    const ri = interfaces[interfaces.length - 1];
+    // The backend queues every commit's tree deltas for a frontend that
+    // will never attach here; one flush (to no listeners) discards the
+    // queue and stops it growing for the rest of the run.
+    ri.flushInitialOperations();
+    return ri;
+  })();
+  return devtoolsReady;
+}
+
+/** The reconciler internals the hook holds for our renderer —
+ * `scheduleUpdate` and friends. Dev builds only. */
+function rendererInternals() {
+  const renderers = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__?.renderers;
+  if (!renderers?.size) return null;
+  return [...renderers.values()][renderers.size - 1];
+}
+
+/**
+ * The backend only observes commits, so a root mounted before the hook
+ * existed — the normal case, since the hook installs lazily on the first
+ * `inspect()` — is invisible until its next commit. One re-render commit
+ * per unobserved root brings its whole tree in; `scheduleUpdate` is the
+ * same internals call DevTools itself uses to apply an override.
+ */
+async function refreshUnobservedRoots(ri) {
+  const internals = rendererInternals();
+  if (typeof internals?.scheduleUpdate !== 'function') return;
+  for (const entry of mountedEntries()) {
+    const node = entry.windowNode;
+    if (!node || node.destroyed) continue;
+    if (ri.getElementIDForHostInstance(node) != null) continue;
+    const fiber = node._reactFiber;
+    if (!fiber) continue;
+    await act(() => internals.scheduleUpdate(fiber), entry);
+  }
+}
+
+async function resolveElementID(ri, node) {
+  let id = ri.getElementIDForHostInstance(node);
+  if (id == null) {
+    await refreshUnobservedRoots(ri);
+    id = ri.getElementIDForHostInstance(node);
+  }
+  return id ?? null;
+}
+
+/**
+ * The current-generation fiber of the inspected component, found by
+ * walking tree ancestry from the node until the display name DevTools
+ * reported matches. Values are read from this fiber, so they are the
+ * committed ones — the node's own `_reactFiber` was captured at mount and
+ * may be the retired half of the alternate pair, one render behind.
+ * Null when no ancestor carries that name (an exotic wrapper, say) — the
+ * caller then falls back to DevTools' own value copies.
+ */
+function currentComponentFiber(node, displayName) {
+  let fiber = node?._reactFiber ?? null;
+  if (!fiber || displayName == null) return null;
+  try {
+    fiber = findCurrentFiberUsingSlowPath(fiber) ?? fiber;
+  } catch {
+    // detached or mid-update — read from the captured generation instead
+  }
+  for (let f = fiber; f; f = f.return) {
+    if (fiberTypeName(f.type) === displayName) return f;
+  }
+  return null;
+}
+
+/** The value in the component's Nth hook slot — `id` is React's own index
+ * over the hooks that occupy one, which is how the override path addresses
+ * them too. For useState/useReducer the slot's `memoizedState` *is* the
+ * value; only they are read this way. */
+function hookSlotValue(fiber, nativeIndex, fallback) {
+  let slot = fiber.memoizedState;
+  for (let i = 0; i < nativeIndex && slot; i++) slot = slot.next ?? null;
+  return slot ? slot.memoizedState : fallback;
+}
+
+function mapHooks(data, fiber) {
+  if (!Array.isArray(data)) return [];
+  const map = (h) => ({
+    id: h.id ?? null,
+    name: h.name,
+    // live value for the editable hooks; DevTools' copy (primitives exact,
+    // deep objects as previews) for the rest
+    value:
+      h.isStateEditable && h.id != null && fiber
+        ? hookSlotValue(fiber, h.id, h.value)
+        : h.value,
+    editable: h.isStateEditable === true,
+    source: h.hookSource
+      ? {
+          file: h.hookSource.fileName,
+          line: h.hookSource.lineNumber,
+          column: h.hookSource.columnNumber,
+        }
+      : null,
+    subHooks: Array.isArray(h.subHooks) ? h.subHooks.map(map) : [],
+  });
+  return data.map(map);
+}
+
+let inspectRequestID = 0;
+
+/**
+ * The React side of a node: the nearest mounted component above it (the
+ * one DevTools would select), its live props, its hooks — named and with
+ * source locations, via react-debug-tools — and `setHook` to change what
+ * useState/useReducer hold.
+ *
+ * Two costs to know about. Reading hooks **re-invokes the component's
+ * render function** (under a stub dispatcher, output discarded) — that is
+ * how react-debug-tools recovers hook names, and a render-counting test
+ * will see it. And the nearest component is tree ancestry, where
+ * `ownerChainOf`/`getByComponent` are JSX ownership; the two differ for
+ * content passed as children.
+ */
+export async function inspect(target) {
+  if (!target || typeof target !== 'object' || !target._reactFiber) {
+    throw new Error(
+      'react-x11/test: inspect() takes a rendered node, the kind a query ' +
+        'returns.',
+    );
+  }
+  const ri = await rendererInterface();
+  const id = await resolveElementID(ri, target);
+  if (id == null) {
+    throw new Error(
+      'react-x11/test: inspect() could not map this node to a component — ' +
+        'it may have unmounted, or React is not in development mode.',
+    );
+  }
+  const res = ri.inspectElement(++inspectRequestID, id, null, true);
+  if (res.type !== 'full-data') {
+    const detail = res.message ? ` — ${res.message}` : '';
+    throw new Error(
+      `react-x11/test: inspect() failed with "${res.type}"${detail}`,
+    );
+  }
+  const v = res.value;
+  const name = ri.getDisplayNameForElementID(id);
+  const fiber = currentComponentFiber(target, name);
+  const hooks = mapHooks(v.hooks?.data, fiber);
+
+  return {
+    /** DevTools' element id — stable for the life of the instance. */
+    id,
+    name,
+    /** The component's live props object. Treat it as read-only: to render
+     * with different props, render with different props. */
+    props: fiber ? fiber.memoizedProps : (v.props?.data ?? null),
+    /** Class component state; null for function components. */
+    state: fiber?.tag === 1 ? fiber.memoizedState : (v.state?.data ?? null),
+    /** Legacy class context only — a `useContext` value appears among the
+     * hooks instead, and is not settable (wrap a provider). */
+    context: v.context?.data ?? null,
+    hooks,
+    /** Owner names, nearest first — who rendered this component. */
+    owners: Array.isArray(v.owners)
+      ? v.owners.map((o) => o.displayName).filter(Boolean)
+      : [],
+
+    /**
+     * Set a useState/useReducer value: `setHook(id, value)` or
+     * `setHook(id, path, value)` for a path inside it. `id` is the hook's
+     * `id` as listed in `hooks` — an index the Rules of Hooks fix for the
+     * life of the component, so validating against this snapshot cannot go
+     * stale. The write goes through the reconciler's own override path
+     * (the one DevTools uses), inside `act()`, so React has re-rendered
+     * and repainted by the time the promise resolves. A reducer is
+     * bypassed, not driven: the value is placed, no action runs.
+     */
+    async setHook(hookID, ...rest) {
+      const [path, value] = rest.length >= 2 ? rest : [[], rest[0]];
+      if (!v.canEditHooks) {
+        throw new Error(
+          'react-x11/test: this reconciler build exposes no hook ' +
+            'overrides — setHook() needs react-reconciler in development ' +
+            'mode (NODE_ENV not "production").',
+        );
+      }
+      const flat = [];
+      const collect = (list) => {
+        for (const h of list) {
+          flat.push(h);
+          collect(h.subHooks);
+        }
+      };
+      collect(hooks);
+      const hit = flat.find((h) => h.id === hookID);
+      if (!hit || !hit.editable) {
+        const editable = flat
+          .filter((h) => h.editable)
+          .map(
+            (h) =>
+              `  ${h.id}: ${h.name}` +
+              (h.source ? ` (${h.source.file}:${h.source.line})` : ''),
+          );
+        throw new Error(
+          `react-x11/test: hook ${hookID} ` +
+            (hit
+              ? `is a ${hit.name} hook — only useState/useReducer state ` +
+                'can be set'
+              : 'does not exist on this component') +
+            `. Editable hooks:\n${editable.join('\n') || '  (none)'}`,
+        );
+      }
+      await act(() => ri.overrideValueAtPath('hooks', id, hookID, path, value));
+    },
+  };
+}

--- a/src/testing/index.d.ts
+++ b/src/testing/index.d.ts
@@ -92,6 +92,15 @@ export interface Queries {
   queryAllByTestName(name: string): DrawnNode[];
   findByTestName(name: string, options?: WaitOptions): Promise<DrawnNode>;
 
+  getByComponent(component: ComponentMatch): DrawnNode;
+  getAllByComponent(component: ComponentMatch): DrawnNode[];
+  queryByComponent(component: ComponentMatch): DrawnNode | null;
+  queryAllByComponent(component: ComponentMatch): DrawnNode[];
+  findByComponent(
+    component: ComponentMatch,
+    options?: WaitOptions,
+  ): Promise<DrawnNode>;
+
   getByPlaceholder(
     text: string | RegExp,
     options?: TextMatchOptions,
@@ -116,6 +125,13 @@ export interface Queries {
   /** Everything under here, in paint order — the escape hatch. */
   all(predicate?: (node: DrawnNode) => boolean): DrawnNode[];
 }
+
+/**
+ * How ByComponent names a component: exact display name, RegExp, or a
+ * predicate over the name. Owner-based (who wrote the JSX), so it needs
+ * development React.
+ */
+export type ComponentMatch = string | RegExp | ((name: string) => boolean);
 
 export interface TextMatchOptions {
   /** Exact, case-sensitive match. Default is a trimmed substring match. */
@@ -188,6 +204,70 @@ export function textOf(node: DrawnNode): string;
 
 /** The role a node reports: its `role` prop, else its element kind. */
 export function roleOf(node: DrawnNode): string;
+
+/**
+ * The components that created this node, nearest first — the JSX owner
+ * chain, not tree ancestry. Empty outside development React.
+ */
+export function ownerChainOf(node: DrawnNode): string[];
+
+/** Where the JSX that created this node lives, from React's own call-site
+ * capture (development mode). Null when there is no debug info. */
+export function sourceOf(node: DrawnNode): {
+  functionName?: string;
+  file: string;
+  line: number;
+  column: number;
+} | null;
+
+export interface InspectedHook {
+  /** React's index over the hooks that occupy a slot — how `setHook`
+   * addresses it. Null for hooks that don't (useContext). */
+  id: number | null;
+  /** react-debug-tools' name: 'State', 'Reducer', 'Effect', 'Context', or
+   * a custom hook's name with its primitives in `subHooks`. */
+  name: string;
+  /** Live for editable hooks; DevTools' copy (deep objects appear as
+   * previews, the way the DevTools panel shows them) for the rest. */
+  value: unknown;
+  /** True for useState/useReducer — the hooks `setHook` can write. */
+  editable: boolean;
+  source: { file: string; line: number; column: number } | null;
+  subHooks: InspectedHook[];
+}
+
+export interface InspectedComponent {
+  /** DevTools' element id — stable for the life of the instance. */
+  id: number;
+  name: string | null;
+  /** The live props object. Treat as read-only. */
+  props: Record<string, unknown> | null;
+  /** Class component state; null for function components. */
+  state: unknown;
+  /** Legacy class context only; `useContext` values appear in `hooks`. */
+  context: unknown;
+  hooks: InspectedHook[];
+  /** Owner names, nearest first — who rendered this component. */
+  owners: string[];
+  /** Set a useState/useReducer value (optionally at a path inside it),
+   * through React's own override machinery, `act`-wrapped. */
+  setHook(hookID: number, value: unknown): Promise<void>;
+  setHook(
+    hookID: number,
+    path: Array<string | number>,
+    value: unknown,
+  ): Promise<void>;
+}
+
+/**
+ * The React side of a node: the nearest mounted component above it, its
+ * props and named hooks, and `setHook` to change useState/useReducer
+ * state. Drives the React DevTools backend in-process — no WebSocket, but
+ * `react-devtools-core` must be installed, and reading hooks re-invokes
+ * the component's render function (react-debug-tools recovers names that
+ * way).
+ */
+export function inspect(node: DrawnNode): Promise<InspectedComponent>;
 
 export interface PointerOptions {
   /** Offset from the node's centre. */

--- a/src/testing/index.js
+++ b/src/testing/index.js
@@ -37,6 +37,7 @@ export {
 } from './harness.js';
 
 export { within, textOf, roleOf } from './queries.js';
+export { inspect, ownerChainOf, sourceOf } from './components.js';
 export {
   fireEvent,
   userEvent,

--- a/src/testing/queries.js
+++ b/src/testing/queries.js
@@ -14,6 +14,8 @@
 //   getAllBy* one or more, or throw
 //   findBy*   getBy*, retried until it appears or the timeout expires
 
+import { queryAllByComponent, componentInventory } from './components.js';
+
 const DEFAULT_TIMEOUT = 1000;
 
 /** Depth-first, in paint order, including `<popup>` subtrees. */
@@ -98,11 +100,11 @@ function inventory(root, limit = 12) {
   return lines.join('\n');
 }
 
-function one(root, found, what) {
+function one(root, found, what, printTree = inventory) {
   if (found.length === 1) return found[0];
   if (found.length === 0) {
     throw new Error(
-      `react-x11/test: no element found for ${what}.\nThe tree holds:\n${inventory(root)}`,
+      `react-x11/test: no element found for ${what}.\nThe tree holds:\n${printTree(root)}`,
     );
   }
   throw new Error(
@@ -170,26 +172,44 @@ export function within(root) {
           typeof n.props?.placeholder === 'string' &&
           matches(n.props.placeholder, text, exact),
       ),
+
+    /**
+     * Host nodes by the component that created them (the JSX owner): for
+     * each rendered instance, the topmost host nodes of its output — so
+     * `within(getByComponent('TaskRow'))` scopes the other queries to that
+     * instance. Exact name, RegExp, or predicate over the name; needs
+     * development React, which records the owner on every element.
+     */
+    queryAllByComponent: (component) => queryAllByComponent(root, component),
   };
 
   // getBy / queryBy / getAllBy / findBy are all mechanical from queryAllBy
   for (const [key, queryAll] of Object.entries(q)) {
     if (!key.startsWith('queryAll')) continue;
     const suffix = key.slice('queryAll'.length); // 'ByText', 'ByRole', …
+    // a ByComponent miss lists the components in the tree — the caller was
+    // trying to spell one of those, not an element kind
+    const printTree = suffix === 'ByComponent' ? componentInventory : inventory;
     const label = (arg) =>
-      `${suffix.replace(/^By/, '')} ${JSON.stringify(arg)}`;
+      `${suffix.replace(/^By/, '')} ${
+        arg instanceof RegExp
+          ? String(arg)
+          : typeof arg === 'function'
+            ? arg.name || '(predicate)'
+            : JSON.stringify(arg)
+      }`;
     q[`getAll${suffix}`] = (...args) => {
       const found = queryAll(...args);
       if (found.length === 0) {
         throw new Error(
           `react-x11/test: no element found for ${label(args[0])}.\n` +
-            `The tree holds:\n${inventory(root)}`,
+            `The tree holds:\n${printTree(root)}`,
         );
       }
       return found;
     };
     q[`get${suffix}`] = (...args) =>
-      one(root, queryAll(...args), label(args[0]));
+      one(root, queryAll(...args), label(args[0]), printTree);
     q[`query${suffix}`] = (...args) => {
       const found = queryAll(...args);
       if (found.length > 1) return one(root, found, label(args[0]));

--- a/test/component-testing.test.js
+++ b/test/component-testing.test.js
@@ -1,0 +1,214 @@
+// The component layer of `react-x11/test` (issue #154): ByComponent
+// queries, owner chains and source locations from React's debug info, and —
+// through the React DevTools backend loaded in-process, no WebSocket — hook
+// inspection and hook overrides. Everything goes through the published
+// entry, the way a user's test would.
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+
+import {
+  renderX11,
+  cleanup,
+  act,
+  screen,
+  within,
+  textOf,
+  inspect,
+  ownerChainOf,
+  sourceOf,
+} from '../src/testing/index.js';
+
+const h = React.createElement;
+
+afterEach(cleanup);
+
+function Label({ text }) {
+  return h('text', null, text);
+}
+
+function useCounter(start) {
+  const [count, setCount] = React.useState(start);
+  return [count, setCount];
+}
+
+function Row({ id }) {
+  const [count] = useCounter(id * 10);
+  return h(
+    'box',
+    { style: { height: 20 } },
+    h(Label, { text: `row ${id}: ${count}` }),
+  );
+}
+
+let renders = 0;
+let addRow;
+
+function List() {
+  renders++;
+  const [rows, setRows] = React.useState([1, 2]);
+  const [meta] = React.useState({ nested: { deep: 'a' }, tag: 'x' });
+  React.useEffect(() => {
+    addRow = () => setRows((r) => [...r, r.length + 1]);
+  }, []);
+  return h(
+    'box',
+    { style: { flexDirection: 'column' } },
+    rows.map((id) => h(Row, { id, key: id })),
+    h('text', null, `tag: ${meta.nested.deep}`),
+  );
+}
+
+test('ByComponent finds each instance host root, by owner', async () => {
+  await renderX11(h(List), { backend: 'mock' });
+
+  const rowRoots = screen.getAllByComponent('Row');
+  assert.strictEqual(rowRoots.length, 2, 'one host root per instance');
+  assert.ok(
+    rowRoots.every((n) => n.kind === 'box'),
+    'the topmost host node of each instance, not its leaves',
+  );
+  // scoping to an instance root covers that instance's subtree
+  within(rowRoots[1]).getByText('row 2: 20');
+  assert.strictEqual(within(rowRoots[0]).queryByText('row 2: 20'), null);
+
+  assert.strictEqual(screen.getAllByComponent(/^R/).length, 2, 'RegExp');
+  assert.strictEqual(screen.queryByComponent('Nope'), null);
+  assert.strictEqual(
+    screen.getAllByComponent('Label').length,
+    2,
+    'one per Label instance — the trailing <text> is owned by List',
+  );
+});
+
+test('a ByComponent miss lists the components that are there', async () => {
+  await renderX11(h(List), { backend: 'mock' });
+  assert.throws(
+    () => screen.getByComponent('Missing'),
+    /no element found for Component "Missing"[\s\S]*<List>[\s\S]*<Row>[\s\S]*<Label>/,
+    'the failure names the components in the tree, not the element kinds',
+  );
+  assert.throws(() => screen.getByComponent('Row'), /found 2 elements/);
+});
+
+test('ownerChainOf and sourceOf read React debug info off any node', async () => {
+  await renderX11(h(List), { backend: 'mock' });
+  const label = within(screen.getAllByComponent('Row')[0]).getByText(/row 1/);
+
+  assert.deepStrictEqual(ownerChainOf(label), ['Label', 'Row', 'List']);
+
+  const source = sourceOf(label);
+  assert.ok(
+    source.file.endsWith('component-testing.test.js'),
+    `the <text> was created in this file, got ${source?.file}`,
+  );
+  assert.ok(source.line > 0 && source.column > 0);
+});
+
+test('inspect() reads props and named hooks, with live state values', async () => {
+  await renderX11(h(List), { backend: 'mock' });
+
+  // This first inspect() is also the interesting one for wiring: the
+  // DevTools hook did not exist when the root mounted, so the backend has
+  // observed no commits and the element map is empty. inspect() installs
+  // the hook, forces one commit per unobserved root, and proceeds.
+  const list = await inspect(screen.getByText(/^tag:/));
+  assert.strictEqual(list.name, 'List');
+  assert.deepStrictEqual(
+    list.hooks.map((hk) => hk.name),
+    ['State', 'State', 'Effect'],
+  );
+  assert.deepStrictEqual(list.hooks[0].value, [1, 2]);
+  // deep, not a DevTools preview — the value is read off the live fiber
+  assert.deepStrictEqual(list.hooks[1].value, {
+    nested: { deep: 'a' },
+    tag: 'x',
+  });
+  assert.strictEqual(list.hooks[1].editable, true);
+  assert.strictEqual(list.hooks[2].editable, false, 'an Effect is not');
+  assert.ok(
+    list.hooks[0].source.file.endsWith('component-testing.test.js'),
+    'hooks carry their source location',
+  );
+
+  // a custom hook keeps its name, with its primitives nested under it
+  const row = await inspect(screen.getAllByComponent('Row')[0]);
+  assert.strictEqual(row.name, 'Row');
+  assert.deepStrictEqual(row.props, { id: 1 });
+  assert.deepStrictEqual(row.owners, ['List']);
+  assert.strictEqual(row.hooks[0].name, 'Counter');
+  assert.strictEqual(row.hooks[0].subHooks[0].name, 'State');
+  assert.strictEqual(row.hooks[0].subHooks[0].value, 10);
+});
+
+test('inspect() re-invokes the render function to name the hooks', async () => {
+  await renderX11(h(List), { backend: 'mock' });
+  await inspect(screen.getByText(/^tag:/)); // attach + refresh commit
+  const before = renders;
+  await inspect(screen.getByText(/^tag:/));
+  assert.strictEqual(
+    renders,
+    before + 1,
+    'react-debug-tools runs the component once per inspect',
+  );
+});
+
+test('setHook writes useState through React, and the tree repaints', async () => {
+  await renderX11(h(List), { backend: 'mock' });
+
+  const row = await inspect(screen.getAllByComponent('Row')[0]);
+  const counter = row.hooks[0].subHooks[0];
+  await row.setHook(counter.id, 99);
+  screen.getByText('row 1: 99');
+
+  // the override holds its own against unrelated re-renders above — it
+  // replaced the hook's state, it did not shadow it
+  await act(() => addRow());
+  screen.getByText('row 3: 30');
+  screen.getByText('row 1: 99');
+});
+
+test('setHook takes a path into the state value', async () => {
+  await renderX11(h(List), { backend: 'mock' });
+  const list = await inspect(screen.getByText(/^tag:/));
+  await list.setHook(list.hooks[1].id, ['nested', 'deep'], 'zz');
+  screen.getByText('tag: zz');
+  // the untouched half of the object survives the copy-with-set
+  const again = await inspect(screen.getByText(/^tag:/));
+  assert.strictEqual(again.hooks[1].value.tag, 'x');
+});
+
+test('setHook refuses hooks that are not state, and names the ones that are', async () => {
+  await renderX11(h(List), { backend: 'mock' });
+  const list = await inspect(screen.getByText(/^tag:/));
+  const effect = list.hooks.find((hk) => hk.name === 'Effect');
+  await assert.rejects(
+    () => list.setHook(effect.id, 1),
+    /is a Effect hook[\s\S]*Editable hooks:[\s\S]*0: State/,
+  );
+  await assert.rejects(
+    () => list.setHook(99, 1),
+    /does not exist on this component/,
+  );
+});
+
+test('the change lands in the retained tree, not only in React state', async () => {
+  await renderX11(h(List), { backend: 'mock' });
+  const list = await inspect(screen.getByText(/^tag:/));
+  await list.setHook(1, ['nested', 'deep'], 'painted');
+  assert.strictEqual(textOf(screen.getByText(/^tag:/)), 'tag: painted');
+});
+
+test('inspection works against the real in-process X server too', async () => {
+  // the other tests use the mock for speed; the wiring must not care
+  function Wide() {
+    const [w] = React.useState(300);
+    return h('box', { style: { width: w, height: 40 } });
+  }
+  await renderX11(h(Wide), { width: 320, height: 80 });
+  const c = await inspect(screen.getByComponent('Wide'));
+  assert.strictEqual(c.name, 'Wide');
+  assert.strictEqual(c.hooks[0].value, 300);
+  await c.setHook(0, 120);
+  assert.strictEqual(screen.getByComponent('Wide').abs.width, 120);
+});

--- a/test/types/test-api.tsx
+++ b/test/types/test-api.tsx
@@ -27,6 +27,9 @@ import {
   roleOf,
   screenPointOf,
   pointOutsideWindows,
+  inspect,
+  ownerChainOf,
+  sourceOf,
 } from '../../src/testing/index.js';
 import {
   XK_RETURN,
@@ -109,6 +112,25 @@ async function suite() {
   clock.set(100);
   const _now: number = clock.now;
   clock.restore();
+
+  // components
+  const row = getByComponentOf();
+  function getByComponentOf() {
+    return screen.getByComponent(/^Task/);
+  }
+  void screen.getAllByComponent('TaskRow').length;
+  void screen.queryByComponent((name) => name.startsWith('T'));
+  void (await screen.findByComponent('TaskRow', { timeout: 200 }));
+  const _chain: string[] = ownerChainOf(row);
+  const _source: number | undefined = sourceOf(row)?.line;
+  const inspected = await inspect(row);
+  const _name: string | null = inspected.name;
+  void inspected.props?.label;
+  const hook = inspected.hooks[0];
+  const _editable: boolean = hook.editable;
+  void hook.subHooks.length;
+  await inspected.setHook(0, 41);
+  await inspected.setHook(0, ['nested', 'deep'], 'zz');
 
   // keysyms
   const _k: number = keysymOf('é');


### PR DESCRIPTION
Closes #154 — the exploration and critique live there; this PR is the additive implementation.

## What `react-x11/test` gains

**Fiber layer** — no new dependency, development React only:

- `getByComponent` / `queryAllByComponent` / `findByComponent` / … : per rendered instance, the topmost host nodes of its output, matched by **JSX owner** (exact name, RegExp, or predicate). `within(getByComponent('TaskRow'))` then scopes the existing queries to that instance. A miss lists the component names that are in the tree, in the spirit of the existing failure messages.
- `ownerChainOf(node)` → `['Label', 'TaskRow', 'App']`; `sourceOf(node)` → `{ file, line, column }` — both reading the `_debugOwner` / `_debugStack` info click-to-component already navigates by (its `resolveLocation` is now exported and shared).

**Inspection layer** — drives the React DevTools backend in-process:

```js
const c = await inspect(screen.getByText('buy milk'));
c.name;               // 'TaskRow'
c.props;              // live props object
c.hooks;              // [{ id, name: 'State', value, editable, source, subHooks }]
await c.setHook(0, 41);                    // useState/useReducer only
await c.setHook(1, ['filter', 'text'], 'milk');
```

- `injectIntoDevTools()` parks the backend's `RendererInterface` on the global hook before any bridge/agent/socket exists; `inspect()` uses that interface directly. **No socket is opened and `ws` is never imported** — `connectToDevTools` is simply not called. `react-devtools-core` is loaded lazily with a clear add-it-to-devDependencies error; the fiber layer works without it.
- Hook names/sources come from react-debug-tools via `inspectElement`; values for the **editable** hooks (and `props`) are read live off the current-generation fiber (`findCurrentFiberUsingSlowPath`), so deep state asserts exactly — no bridge dehydration, and none of the serializer's dropped-duplicate-reference behaviour.
- `setHook` goes through the reconciler's own override path (`overrideValueAtPath` → `enqueueConcurrentRenderForLane`), wrapped in the harness `act()`, so the repaint has landed when it resolves. Non-editable hooks are refused by name with the editable ones listed; hook ids are validated against the snapshot, which cannot go stale because the Rules of Hooks fix the slot order for the life of the component.
- Sharp edges found during the exploration are deliberately **not** exposed: no `overrideProps` (silently reverted by the next parent re-render — `rerender()` is the honest tool), no context override (legacy-only; wrap a provider).

## Wiring details worth reviewing

- **Lazy attach**: the backend only observes commits, so a root mounted before the first `inspect()` is invisible to it. `inspect()` self-heals: one `scheduleUpdate` commit per unobserved root (the same internals call DevTools uses for overrides), inside `act()`.
- The backend's pending-operations queue (kept for a frontend that never attaches) is flushed once at attach so it cannot grow for the rest of the run; DevTools' console patching is disabled via `initialize(settings)`.
- `DevToolsIntegration.connect()` now skips `injectIntoDevTools()` when an interface is already registered, so a test run that also sets `REACT_X11_DEVTOOLS=1` doesn't register the renderer twice (the standalone app would show every tree duplicated).
- ByComponent error labels: RegExp/predicate arguments now print as `/Row$/` instead of `{}` (small fix in the shared query deriver).

## Docs

- `docs/testing.md`: new **Components** section — the API, and the caveats stated plainly (reading hooks re-invokes the render function; ownership vs ancestry; what is and isn't settable; dev builds only).
- `docs/devtools.md`: the same backend minus the socket now powers test-time inspection; note on the shared renderer registration.

## Tests

`test/component-testing.test.js`, all through the published entry: instance host roots + scoping, owner-based matching for slotted children, miss messages, `ownerChainOf`/`sourceOf`, deep live hook values, the inspect-re-renders behaviour pinned as an assertion, `setHook` top-level + deep path + surviving unrelated re-renders + refusal messages, lazy attach on the first inspect, and a smoke test against the real in-process X server (mock backend elsewhere for speed).

`npm test` 342 pass · `npm run lint` clean on changed files · `npm run typecheck` (type tests extended) · `npm run docs:build` green.

Not screenshot-eligible: no pixel changes.
