### PR TITLE
perf: cache rendered <svg> and <tex> content, keyed on what is drawn

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -113,6 +113,39 @@ repaints its whole viewport again. For measuring the blit against the
 plain path on the same build, and as first aid if a scroll ever
 misrenders. Read once at startup, like the switches above.
 
+## The paint cache — `REACT_X11_NO_PAINT_CACHE`, `REACT_X11_PAINT_CACHE=verify`
+
+`<svg>` and `<tex>` render their content once and composite the result on
+later repaints, keyed on _what is drawn_ rather than on which node drew it —
+so a wall of 400 cells holding eight distinct icons keeps eight rendered
+copies, and a repaint of unchanged content is one composite per cell. Your own
+drawings opt in with [`<canvas cacheKey>`](elements.md#cachekey--draw-it-once).
+
+Three switches, all read once at startup:
+
+- `REACT_X11_NO_PAINT_CACHE=1` disables it entirely, so everything paints
+  live. For measuring against the cached path on the same build, and as first
+  aid if anything ever renders stale — same role as `REACT_X11_NO_SCROLL_BLIT`.
+- `REACT_X11_PAINT_CACHE=verify` re-renders every cache hit and compares a
+  digest of the drawing calls against the one recorded when the entry was
+  made. A cache key that fails to name something the drawing reads then says
+  so, loudly, at the moment it would otherwise have shown a stale pixel:
+
+  ```
+  react-x11: paint cache key does not cover the paint of <canvas>.
+    key: canvas|64x24@1|spark:3
+    The drawing changed while the key did not, so a cached frame would show
+    stale pixels. Add whatever changed to the key.
+  ```
+
+  Slow by construction — it does all the work the cache exists to avoid, plus
+  the comparison. Worth leaving on while developing a `cacheKey`.
+
+- `REACT_X11_DEBUG_PAINT_CACHE=1` prints a line per frame: entries, bytes
+  held, and hits/misses/renders/evictions. Rising `renders` on a still screen
+  means keys that change when they should not; rising `evictions` means the
+  working set does not fit the budget.
+
 ## Invalidation reasons
 
 Every internal `invalidate()` call now names why it ran, from a small

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -545,6 +545,32 @@ conical, `setLineDash`, round caps/joins, images, text — XRender-backed),
 translated to the node's origin and clipped to its bounds. `onDraw` runs on
 every repaint of the window.
 
+### `cacheKey` — draw it once
+
+A drawing that does not change between frames does not have to be redrawn
+between frames. Give the canvas a `cacheKey` and its content is rendered once
+and composited on later repaints; two canvases with the same key share the one
+rendered copy.
+
+```jsx
+<canvas cacheKey={`spark:${series.id}:${w}x${h}`} onDraw={drawSparkline} />
+```
+
+Opt-in, and the reason matters: `onDraw` is an opaque closure. Nothing in the
+renderer can know what it reads — a prop, a ref, a clock — and its identity
+changes on every render unless you memoize it, so it is not a key either. Only
+you know, so you say.
+
+**The key must name every input the drawing reads.** One that leaves something
+out shows stale pixels, which is the hardest kind of bug to see. Develop with
+`REACT_X11_PAINT_CACHE=verify`, which turns exactly that mistake into a loud
+complaint — see [Runtime diagnostics](debugging.md#the-paint-cache--react_x11_no_paint_cache-react_x11_paint_cacheverify).
+Leave `cacheKey` unset for anything animated, or driven by state outside the
+props.
+
+`<svg>` and `<tex>` do this automatically: their content is fully described by
+their props, so the renderer can build the key itself.
+
 ---
 
 ## `<glarea>`
@@ -800,6 +826,29 @@ on the `<svg>` element itself.
 | children  | declarative SVG elements          |
 | `source`  | SVG markup string                 |
 | `viewBox` | coordinate system (children form) |
+
+**`currentColor` and recolouring.** `fill="currentColor"` and
+`stroke="currentColor"` resolve to the node's `color` style, so one icon
+serves every state the UI puts it in:
+
+```jsx
+<svg
+  source={icons.gauge}
+  style={{
+    width: 20,
+    height: 20,
+    color: '$fg',
+    ':hover': { color: '$accent' },
+  }}
+/>
+```
+
+A drawing whose paint is entirely `currentColor` — or entirely one colour — is
+cached as coverage rather than as pixels, so recolouring it is a composite and
+not a re-render, and every colour of it shares one rendered copy. Drawings with
+two colours or a gradient bake their colours in, which is right: those colours
+belong to the drawing rather than to the UI. Nothing to configure either way.
+`REACT_X11_DEBUG_PAINT_CACHE=1` shows what is being kept.
 
 ### `<tex>`
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -107,6 +107,62 @@ the whole window, which is this renderer's main performance bug class (see
 [debugging.md](debugging.md)). `reason` joins the closed set the diagnostics
 print.
 
+### Drawing once instead of every frame
+
+A drawing that does not change between frames does not have to be redrawn
+between frames. Implement two more methods and your element is rendered once
+and composited on later repaints, sharing one rendered copy with every other
+node that produces the same key:
+
+| method                  |                                                                               |
+| ----------------------- | ----------------------------------------------------------------------------- |
+| `paintCachePlan()`      | `null` to opt out this frame, or `{ key, x, y, width, height, format, tint }` |
+| `paintCached(ctx, box)` | draw, at the **origin of `box`** — not at `this.abs`                          |
+
+```js
+paintCachePlan() {
+  const width = Math.round(this.abs.width);
+  const height = Math.round(this.abs.height);
+  if (width <= 0 || height <= 0) return null;
+  return {
+    key: `sparkline|${width}x${height}|${this.props.seriesId}`,
+    x: Math.round(this.abs.x),
+    y: Math.round(this.abs.y),
+    width,
+    height,
+    format: 'argb32',
+    tint: null,
+  };
+}
+
+paintCached(ctx, box) {
+  this.drawSeries(ctx, box.x, box.y, box.width, box.height);
+}
+```
+
+`format: 'a8'` stores coverage rather than colour and paints through `tint`,
+so one rendered copy serves every colour the drawing is ever asked for — the
+right choice for a monochrome drawing, and it keeps the colour out of the key.
+
+**The key is the entire correctness surface.** It must name every input
+`paintCached` reads, and it should be derived from the same values
+`applyProps` compares so the two cannot drift. A key that misses something
+shows stale pixels, which is the hardest kind of bug to see — so develop with
+`REACT_X11_PAINT_CACHE=verify`, which re-renders every hit and complains
+loudly when the drawing changed while the key did not. Return `null` for
+anything animated, hovered, focused or blinking.
+
+Two footguns worth naming. `paintCached` draws in **surface-local**
+coordinates: reaching for `this.abs.x` inside it is the first thing to check
+when a cached element paints in the wrong place. And the cache is per X
+connection and keyed only on your string, so make the key specific enough
+that two different drawings cannot collide — prefix it with your element
+name, as above.
+
+`globalAlpha`, the clip and any ancestor translation are applied when the
+cached copy is composited, so an ancestor animating opacity is a cache hit
+rather than a reason to opt out.
+
 ### Elements that own a real X window
 
 `drawn: false` is for a node backed by its own child X window rather than

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^5.2.0",
+        "ntk": "^5.3.0",
         "react-reconciler": "^0.33.0"
       },
       "devDependencies": {
@@ -3676,9 +3676,9 @@
       }
     },
     "node_modules/ntk": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-5.2.0.tgz",
-      "integrity": "sha512-uxrwkU1vSwwGuL8n+TY9M0nVY/LbbJp1BJXpgFY88xnoPGaj6KugCw4cr/Tn5YnjBWe56rKpRM/atvKuhOq1WQ==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-5.3.0.tgz",
+      "integrity": "sha512-jAnEhhcMfbvJ5sj3M2LDv4a17IhNl2q9HRFGj02zPskcKoaqeU1m1nOMXNK6mI0GDcKM4X52qHeLIOGtRYHLMA==",
       "license": "MIT",
       "dependencies": {
         "bidi-js": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^5.2.0",
+    "ntk": "^5.3.0",
     "react-reconciler": "^0.33.0"
   },
   "peerDependencies": {

--- a/scripts/bench/baseline.json
+++ b/scripts/bench/baseline.json
@@ -48,19 +48,19 @@
     "compositePixels": 650000
   },
   "svg: 100 unchanged icons, full repaint": {
-    "requests": 1082,
-    "bytesOut": 198808,
+    "requests": 107,
+    "bytesOut": 3708,
     "bytesIn": 128,
     "replies": 4,
-    "composites": 501,
-    "compositePixels": 199475
+    "composites": 101,
+    "compositePixels": 200000
   },
   "svg: 10 unchanged icons in a damaged row": {
-    "requests": 183,
-    "bytesOut": 12076,
+    "requests": 42,
+    "bytesOut": 980,
     "bytesIn": 128,
     "replies": 4,
-    "composites": 115,
-    "compositePixels": 17584
+    "composites": 11,
+    "compositePixels": 10292
   }
 }

--- a/scripts/bench/baseline.json
+++ b/scripts/bench/baseline.json
@@ -48,8 +48,8 @@
     "compositePixels": 650000
   },
   "svg: 100 unchanged icons, full repaint": {
-    "requests": 107,
-    "bytesOut": 3708,
+    "requests": 106,
+    "bytesOut": 3704,
     "bytesIn": 128,
     "replies": 4,
     "composites": 101,

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -30,6 +30,7 @@ import { EventManager, discrete } from './events.js';
 import { addPendingFrame, clearPendingFrame } from './frames.js';
 import { callHandler } from './errors.js';
 import { windowIdOf } from './windowid.js';
+import { paintCacheFor } from './paintcache.js';
 import { hooks as traceHooks } from './trace-registry.js';
 import { runWithPriority, DiscreteEventPriority } from './priority.js';
 import {
@@ -1239,7 +1240,14 @@ export class Node {
   paint(ctx) {
     if (this.hidden) return;
     this._paintBackground(ctx);
-    this._paintContent(ctx);
+    // The paint cache covers a node's *content* — the expensive part — and
+    // not its box: background and border are one composite each, and keeping
+    // them out keeps their styles out of the key. A node that does not
+    // implement the protocol has no `paintCachePlan` and pays one property
+    // lookup for the privilege.
+    const cache = this.paintCachePlan && this.root?._paintCache;
+    if (cache) cache.paint(this, ctx);
+    else this._paintContent(ctx);
     this._paintChildren(ctx);
     this._paintBorder(ctx);
   }
@@ -1309,6 +1317,35 @@ export class Node {
   }
 
   _paintContent(ctx) {}
+
+  /**
+   * The paint-cache protocol (issue #149). A node implements both methods or
+   * neither; the base class has neither, so nothing is cached until it opts
+   * in, and no existing or future node changes behaviour by default.
+   *
+   *   paintCachePlan(ctx) -> null | {
+   *     key,             // identity: same key must mean same pixels
+   *     x, y,            // where the surface goes, in device pixels
+   *     width, height,   // its size, in device pixels
+   *     format,          // 'argb32', or 'a8' for coverage that gets tinted
+   *     tint,            // the colour an 'a8' surface is painted through
+   *   }
+   *   paintCached(ctx, box) -> void   // draw at the origin of `box`
+   *
+   * Returning null opts out for this frame, which is the right answer
+   * whenever the paint depends on something the key cannot see.
+   *
+   * **The key is the entire correctness surface.** It must name every input
+   * `paintCached` reads, derived from the same values `applyProps` compares
+   * so the two cannot drift. Never cache a paint that depends on state
+   * outside the key — a focus ring, a hover, a caret blink, anything
+   * animating. Run with `REACT_X11_PAINT_CACHE=verify` to have a key that
+   * misses something fail loudly instead of showing a stale pixel.
+   *
+   * `paintCached` draws in *surface-local* coordinates: `box` is at the
+   * origin, not at `this.abs`. Reaching for `this.abs.x` inside it is the
+   * mistake to look for first when a cached node draws in the wrong place.
+   */
 
   /**
    * Whether anything in this subtree actually reaches outside the clip box.
@@ -2029,6 +2066,57 @@ export class CanvasNode extends Node {
         height: this.abs.height,
         node: this,
       });
+    } finally {
+      ctx.restore();
+    }
+  }
+
+  /**
+   * `<canvas cacheKey>` opts a drawing into the paint cache.
+   *
+   * This one has to be opt-in, and the reason is worth stating: `onDraw` is
+   * an opaque closure. Nothing here can know what it reads — a prop, a ref, a
+   * clock, a module variable — and its identity changes on every render
+   * unless the app memoizes it, so it is not a key either. Only the author
+   * knows, so the author says:
+   *
+   *   <canvas cacheKey={`spark:${series.id}:${w}x${h}`} onDraw={draw} />
+   *
+   * The rule is the protocol's rule: the key must name every input the
+   * drawing reads. A `cacheKey` that leaves one out shows stale pixels, so
+   * develop with `REACT_X11_PAINT_CACHE=verify`, which turns exactly that
+   * mistake into a loud complaint.
+   *
+   * `<canvas>` needs no `paintCached`: it already draws origin-relative, so
+   * the cached render and the live one are the same code.
+   */
+  paintCachePlan() {
+    const { cacheKey, onDraw } = this.props;
+    if (cacheKey == null || typeof onDraw !== 'function') return null;
+    const width = Math.ceil(this.abs.width);
+    const height = Math.ceil(this.abs.height);
+    if (width <= 0 || height <= 0) return null;
+    return {
+      key: `canvas|${width}x${height}@1|${cacheKey}`,
+      x: Math.round(this.abs.x),
+      y: Math.round(this.abs.y),
+      width,
+      height,
+      format: 'argb32',
+      tint: null,
+    };
+  }
+
+  paintCached(ctx, box) {
+    const onDraw = this.props.onDraw;
+    if (typeof onDraw !== 'function') return;
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(box.x, box.y, box.width, box.height);
+    ctx.clip();
+    ctx.translate(box.x, box.y);
+    try {
+      onDraw(ctx, { width: box.width, height: box.height, node: this });
     } finally {
       ctx.restore();
     }
@@ -4066,9 +4154,14 @@ export class WindowNode extends Node {
     // them at once, which is what keeps ntk's server-side rectangular-clip
     // fast path: a clip path holding several rects is not a rectangle, and
     // falls back to rasterizing a full-surface mask.
+    this._paintCache ??= paintCacheFor(this.app);
+    this._paintCache?.beginFrame();
     for (const rect of damage ?? [null]) {
       this._paintRegion(ctx, rect, width, height);
     }
+    // after every region: an entry drawn in one damage rect must not be
+    // evicted before the next rect of the same frame asks for it
+    this._paintCache?.endFrame();
     if (frameHook) {
       frameHook({
         root: this,

--- a/src/paintcache.js
+++ b/src/paintcache.js
@@ -1,0 +1,344 @@
+// Content-keyed cache of rendered node content (issue #149).
+//
+// Damage culling already skips subtrees *outside* the damage rect, so an
+// unchanged icon in an untouched region costs nothing. This is for the other
+// case: a node **inside damage but unchanged**. A theme change, an expose, a
+// resize, a sibling's damage rect covering a row of icons, the strip a scroll
+// exposes — all of them repaint content that is byte-identical to last frame.
+//
+// ## Keyed by content, not by node
+//
+// Per-node ownership would make 400 cells of the same icon into 400 identical
+// surfaces. Keying on what is drawn collapses them to one entry per distinct
+// drawing — the icon wall's 400 cells become 8 — and it removes invalidation
+// entirely: a changed prop produces a different key, so there is never a stale
+// entry to detect and evict.
+//
+// ## Coverage, where the drawing allows it
+//
+// A drawing that commits to a single colour is cached as an a8 coverage
+// surface and painted through the current fill colour, so hover, `:disabled`
+// and a theme flip all reuse one entry and the colour stays out of the key.
+// Multi-colour drawings bake their colours in, which is right, because those
+// colours belong to the drawing. `SvgView.paintKind` decides which is which.
+//
+// ## Self-limiting, on purpose
+//
+// X gives no back-pressure: the first sign of overspending is `BadAlloc` on
+// `CreatePixmap`, delivered as an async error with no useful attribution. So
+// there is a byte budget with LRU eviction (copying `trimGlyphPages` and its
+// 8MB), a per-item area cap so one big illustration cannot evict the whole
+// useful set, and a "seen twice" gate, because a node painted once and never
+// again is a pure loss under a cache.
+// Namespace import, not a named one: `Surface` arrives in a later ntk than
+// this package pins, and a named import of something absent is a *load-time*
+// SyntaxError — the whole renderer, not just the cache. Same shape as the
+// `typeof wnd?.scrollRegion !== 'function'` guard for ntk without #139.
+import * as ntk from 'ntk';
+
+/** Stale pixels are undebuggable, and every other optimization here has an
+ * escape hatch — see NO_SCROLL_BLIT. */
+const DISABLED = process.env.REACT_X11_NO_PAINT_CACHE === '1';
+
+/**
+ * `verify` re-renders every hit and compares a digest of the drawing calls
+ * against the one recorded when the entry was made. A key that fails to name
+ * something the paint depends on then fails *loudly*, at the moment it would
+ * otherwise have shown a stale pixel — which is the one bug this design can
+ * have, and the one that is hardest to find by looking. Slow by construction:
+ * it does all the work the cache exists to avoid, plus the comparison.
+ */
+const VERIFY = process.env.REACT_X11_PAINT_CACHE === 'verify';
+
+const DEBUG = process.env.REACT_X11_DEBUG_PAINT_CACHE === '1';
+
+/** Same budget as ntk's server-side glyph cache, for the same reason: it is
+ * enough for any real working set and small enough that a runaway shows up
+ * as eviction churn rather than as server memory. */
+const DEFAULT_BUDGET = 8 << 20;
+
+/**
+ * No single entry may take more than this. One 800x600 illustration is 1.9MB
+ * of argb32 and would evict the entire useful set for something drawn once.
+ * Widget-sized things stay well under it.
+ */
+const MAX_ITEM_PIXELS = 256 * 256;
+
+/** How many distinct keys the "seen twice" gate remembers before starting
+ * over. Bounded because a page cycling through unique content would otherwise
+ * grow this forever; the cost of forgetting is one extra live paint. */
+const MAX_PENDING = 4096;
+
+/** Whether a context is drawing 1:1 into device space.
+ *
+ * A cached surface is pixels at a fixed size and orientation. Under a scaled
+ * or rotated CTM, compositing it would *resample* those pixels where a live
+ * paint would re-rasterize at the right size, so the cache has to stand
+ * aside. react-x11 only ever translates during paint, and only inside
+ * `<canvas>`, so this is insurance rather than a live case.
+ */
+function isDeviceSpace(ctx) {
+  const m = ctx.getTransform?.();
+  if (!m) return true;
+  return (
+    m.a === 1 && m.b === 0 && m.c === 0 && m.d === 1 && m.e === 0 && m.f === 0
+  );
+}
+
+// --- the verify-mode digest ------------------------------------------------
+
+/** Fold a string into a 32-bit FNV-1a hash. */
+function fold(hash, text) {
+  let h = hash;
+  for (let i = 0; i < text.length; i++) {
+    h ^= text.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+/** One drawing-call argument, as a string a digest can eat. Coordinates are
+ * quantized to 1/64 because that is the fixed-point grid X renders on, so
+ * float noise below it is not a difference. */
+function stamp(value) {
+  if (typeof value === 'number') return String(Math.round(value * 64) / 64);
+  if (value && typeof value === 'object') {
+    if (value._cmds) return JSON.stringify(value._cmds);
+    return JSON.stringify(value);
+  }
+  return String(value);
+}
+
+/**
+ * A context that records everything drawn through it, then draws it. The
+ * digest of that recording is what verify mode compares — client-side, so
+ * catching a key bug costs no round trip and needs no pixel readback.
+ */
+function recordingContext(ctx, state) {
+  return new Proxy(ctx, {
+    get(target, prop) {
+      const value = target[prop];
+      if (typeof value !== 'function') return value;
+      return (...args) => {
+        state.digest = fold(state.digest, prop);
+        for (const arg of args) state.digest = fold(state.digest, stamp(arg));
+        return value.apply(target, args);
+      };
+    },
+    set(target, prop, value) {
+      state.digest = fold(fold(state.digest, `=${String(prop)}`), stamp(value));
+      target[prop] = value;
+      return true;
+    },
+  });
+}
+
+// --- the cache -------------------------------------------------------------
+
+/**
+ * One cache per X connection. Surfaces are server-side resources, so two
+ * roots on two displays must not share entries — and two roots on the *same*
+ * display should, which is why this hangs off the app rather than the root.
+ */
+export class PaintCache {
+  constructor(app, { budget = DEFAULT_BUDGET, verify = VERIFY } = {}) {
+    this.app = app;
+    this.budget = budget;
+    this.verify = verify;
+    /** key -> entry. Map iteration is insertion order, so re-inserting on
+     * access makes this an LRU list for free — same trick as getGlyphPage. */
+    this.entries = new Map();
+    /** keys seen once, waiting to be seen again (the "seen twice" gate) */
+    this.pending = new Map();
+    this.bytes = 0;
+    /** entries touched this frame, which eviction must not take */
+    this.inUse = new Set();
+    this.stats = {
+      hits: 0,
+      misses: 0,
+      renders: 0,
+      evictions: 0,
+      tooBig: 0,
+      failed: 0,
+    };
+  }
+
+  beginFrame() {
+    this.inUse.clear();
+  }
+
+  endFrame() {
+    this._trim();
+    if (DEBUG) {
+      const s = this.stats;
+      console.log(
+        `react-x11: paint cache ${this.entries.size} entries, ` +
+          `${(this.bytes / 1024).toFixed(0)}KB — hits ${s.hits} misses ${s.misses} ` +
+          `renders ${s.renders} evictions ${s.evictions}` +
+          (s.tooBig ? ` too-big ${s.tooBig}` : '') +
+          (s.failed ? ` failed ${s.failed}` : ''),
+      );
+    }
+  }
+
+  /**
+   * Paint `node`'s content, through the cache when it can be.
+   *
+   * Every path here falls back to painting live, so the cache can cost
+   * correctness nothing: the worst mistake it can make is not firing.
+   */
+  paint(node, ctx) {
+    const plan = node.paintCachePlan(ctx);
+    if (!plan || !isDeviceSpace(ctx)) return node._paintContent(ctx);
+
+    if (plan.width * plan.height > MAX_ITEM_PIXELS) {
+      this.stats.tooBig++;
+      return node._paintContent(ctx);
+    }
+
+    const hit = this.entries.get(plan.key);
+    if (hit) {
+      // re-insert to mark recent
+      this.entries.delete(plan.key);
+      this.entries.set(plan.key, hit);
+      this.inUse.add(hit);
+      this.stats.hits++;
+      if (this.verify) this._verify(node, hit, plan);
+      return this._blit(ctx, hit, plan);
+    }
+
+    this.stats.misses++;
+    const seen = (this.pending.get(plan.key) ?? 0) + 1;
+    if (seen < 2) {
+      if (this.pending.size >= MAX_PENDING) this.pending.clear();
+      this.pending.set(plan.key, seen);
+      return node._paintContent(ctx);
+    }
+    this.pending.delete(plan.key);
+
+    const entry = this._render(node, plan);
+    if (!entry) return node._paintContent(ctx);
+    this.entries.set(plan.key, entry);
+    this.bytes += entry.bytes;
+    this.inUse.add(entry);
+    return this._blit(ctx, entry, plan);
+  }
+
+  _render(node, plan) {
+    try {
+      const surface = new ntk.Surface(this.app, {
+        width: plan.width,
+        height: plan.height,
+        format: plan.format,
+      });
+      const box = { x: 0, y: 0, width: plan.width, height: plan.height };
+      const state = { digest: 0x811c9dc5 };
+      surface.render((sctx) =>
+        node.paintCached(
+          this.verify ? recordingContext(sctx, state) : sctx,
+          box,
+        ),
+      );
+      this.stats.renders++;
+      return {
+        key: plan.key,
+        surface,
+        bytes: surface.bytes,
+        digest: this.verify ? state.digest : 0,
+      };
+    } catch (err) {
+      // A server that will not give us a pixmap, a node whose paint threw:
+      // either way the live paint below is still correct.
+      this.stats.failed++;
+      if (DEBUG)
+        console.warn('react-x11: paint cache render failed:', err.message);
+      return null;
+    }
+  }
+
+  _blit(ctx, entry, plan) {
+    // an a8 entry is coverage: the fill colour is what actually gets painted
+    if (plan.format === 'a8') {
+      const before = ctx.fillStyle;
+      ctx.fillStyle = plan.tint;
+      ctx.drawImage(entry.surface, plan.x, plan.y);
+      ctx.fillStyle = before;
+      return;
+    }
+    ctx.drawImage(entry.surface, plan.x, plan.y);
+  }
+
+  /**
+   * Re-render a hit and compare digests. A mismatch means the key did not
+   * name everything the paint reads, which is the one way this design
+   * produces a wrong pixel rather than a slow frame.
+   */
+  _verify(node, entry, plan) {
+    const state = { digest: 0x811c9dc5 };
+    let scratch = null;
+    try {
+      scratch = new ntk.Surface(this.app, {
+        width: plan.width,
+        height: plan.height,
+        format: plan.format,
+      });
+      scratch.render((sctx) =>
+        node.paintCached(recordingContext(sctx, state), {
+          x: 0,
+          y: 0,
+          width: plan.width,
+          height: plan.height,
+        }),
+      );
+    } catch {
+      return; // verification is best-effort; never break a frame over it
+    } finally {
+      scratch?.destroy();
+    }
+    if (state.digest === entry.digest) return;
+    console.error(
+      `react-x11: paint cache key does not cover the paint of <${node.kind}>.\n` +
+        `  key: ${plan.key}\n` +
+        '  The drawing changed while the key did not, so a cached frame would ' +
+        'show stale pixels. Add whatever changed to the key.',
+    );
+  }
+
+  /** Evict least-recently-used entries until the budget is met. Entries drawn
+   * this frame are never taken — evicting one would guarantee re-rendering it
+   * next frame. */
+  _trim() {
+    if (this.bytes <= this.budget) return;
+    for (const [key, entry] of this.entries) {
+      if (this.bytes <= this.budget) break;
+      if (this.inUse.has(entry)) continue;
+      this.entries.delete(key);
+      this.bytes -= entry.bytes;
+      entry.surface.destroy();
+      this.stats.evictions++;
+    }
+  }
+
+  destroy() {
+    for (const entry of this.entries.values()) entry.surface.destroy();
+    this.entries.clear();
+    this.pending.clear();
+    this.bytes = 0;
+    this.inUse.clear();
+  }
+}
+
+/** Whether the installed ntk can make the surfaces this needs. Older ones
+ * cannot, and the answer is simply that nothing is cached. */
+export const paintCacheSupported = () => typeof ntk.Surface === 'function';
+
+/**
+ * The cache for an app, created on first use. Null when caching is off, when
+ * the installed ntk is too old, or when the app cannot make surfaces — the
+ * headless mock in the smoke tests has no Render extension, and every node
+ * there must paint live.
+ */
+export function paintCacheFor(app) {
+  if (DISABLED || !paintCacheSupported() || !app?.display?.Render) return null;
+  return (app._paintCache ??= new PaintCache(app));
+}

--- a/src/richnodes.js
+++ b/src/richnodes.js
@@ -6,7 +6,12 @@
 import { MarkdownView, HtmlView, SvgView, layoutTex } from 'ntk';
 
 import { Node } from './nodes.js';
-import { Yoga, isLayoutProp, isPaintProp } from './styles.js';
+import {
+  Yoga,
+  isLayoutProp,
+  isPaintProp,
+  DEFAULT_TEXT_STYLE,
+} from './styles.js';
 
 /** Joined text of string children (react-markdown style), or null when the
  * element has none — then the `source` prop is the content. */
@@ -302,6 +307,7 @@ export class SvgNode extends Node {
     if (!this._stale) return this.view;
     this._stale = false;
     this.view = null;
+    this._docKey = null;
     try {
       const children = this.children.filter(
         (c) => c.isSvgChild || c.kind === 'textchunk',
@@ -314,16 +320,26 @@ export class SvgNode extends Node {
           key === 'cursor' ||
           key === 'focusable' ||
           key === 'pointerEvents';
-        this.view = new SvgView(null).setSvgDom({
+        const dom = {
           type: 'tag',
           name: 'svg',
           attribs: svgAttribs(this.props, skip),
           children: children.map((c) =>
             c.kind === 'textchunk' ? { type: 'text', data: c.text } : c.toDom(),
           ),
-        });
+        };
+        // The document's identity, for the paint cache. Built here rather
+        // than at paint time on purpose: this runs once per content change,
+        // where paint runs every frame — and it is the serialization that
+        // makes two cells holding the same drawing one cache entry instead
+        // of two. Key order follows prop order, so two logically identical
+        // documents written differently miss rather than collide, which is
+        // the harmless direction.
+        this._docKey = JSON.stringify(dom);
+        this.view = new SvgView(null).setSvgDom(dom);
       } else if (this.props.source) {
-        this.view = new SvgView(null).setSvg(String(this.props.source));
+        this._docKey = String(this.props.source);
+        this.view = new SvgView(null).setSvg(this._docKey);
       }
     } catch (err) {
       console.error('react-x11: <svg> failed to parse:', err.message);
@@ -367,7 +383,76 @@ export class SvgNode extends Node {
     if (!view) return;
     const content = this.contentBox();
     if (content.width <= 0 || content.height <= 0) return;
-    view.draw(ctx, content.x, content.y, content.width, content.height);
+    view.draw(ctx, content.x, content.y, content.width, content.height, {
+      color: this._currentColor(),
+    });
+  }
+
+  /** What `fill="currentColor"` resolves to here. */
+  _currentColor() {
+    return this.style.color ?? DEFAULT_TEXT_STYLE.color;
+  }
+
+  /**
+   * Cache plan (see `Node._paintContent` for the protocol).
+   *
+   * The key is the document, the size it is drawn at, and the device scale.
+   * Everything else that could change the pixels is either handled at blit
+   * time or deliberately excluded:
+   *
+   *  - `globalAlpha`, the clip and any ancestor translation are applied by
+   *    `drawImage`, so an ancestor animating opacity is a cache *hit*;
+   *  - colour is out of the key for a `mono` document, because the entry is
+   *    coverage and the colour arrives at blit time — one entry then serves
+   *    hover, `:disabled` and every theme;
+   *  - a `multi` document bakes its colours, so the resolved colour joins the
+   *    key. It rarely varies, so the extra component costs nothing.
+   *
+   * Sizes are rounded so the blit is unscaled: a scaled `drawImage` brackets
+   * every composite with SetPictureTransform and a filter change, which for
+   * a wall of icons is four extra requests each. The cost is that a cached
+   * drawing sits on the pixel grid where a live one could straddle it, which
+   * for icon-sized content is not visible.
+   */
+  paintCachePlan() {
+    const view = this._ensureView();
+    if (!view || !this._docKey) return null;
+    const content = this.contentBox();
+    const width = Math.round(content.width);
+    const height = Math.round(content.height);
+    if (width <= 0 || height <= 0) return null;
+
+    const mono = view.paintKind === 'mono';
+    // a mono document paints in exactly one colour: its own, or ours
+    const tint = !mono
+      ? null
+      : view.soloPaint === 'currentColor'
+        ? this._currentColor()
+        : view.soloPaint;
+    if (mono && !tint) return null; // nothing in the document paints at all
+
+    const size = `${width}x${height}@1`;
+    return {
+      key: mono
+        ? `svg|${size}|${this._docKey}`
+        : `svg|${size}|${this._currentColor()}|${this._docKey}`,
+      x: Math.round(content.x),
+      y: Math.round(content.y),
+      width,
+      height,
+      format: mono ? 'a8' : 'argb32',
+      tint,
+    };
+  }
+
+  paintCached(ctx, box) {
+    const view = this._ensureView();
+    if (!view) return;
+    // Into a coverage surface, only the alpha of a paint survives, and the
+    // tint arrives at blit time — so any opaque colour renders the same mask.
+    view.draw(ctx, box.x, box.y, box.width, box.height, {
+      color: view.paintKind === 'mono' ? '#ffffff' : this._currentColor(),
+    });
   }
 }
 
@@ -438,5 +523,44 @@ export class TexNode extends Node {
     const content = this.contentBox();
     ctx.fillStyle = this.style.color ?? '#222222';
     box.draw(ctx, content.x, content.y);
+  }
+
+  /**
+   * A formula is the other thing in the tree that is expensive to draw and
+   * never changes on its own, and `_boxKey` already says what it is made of.
+   *
+   * Note what content-keying adds over that memo: `_boxKey` caches the
+   * *layout* per node, so a document showing the same formula twice lays it
+   * out twice and rasterizes it twice on every frame. One cache entry serves
+   * both.
+   *
+   * The colour is in the key rather than tinted, because a TexBox draws
+   * through glyph and trapezoid composites whose colour is the context's
+   * fill at draw time; rendering it as coverage would need the box to promise
+   * it never sets a colour of its own, which it does not.
+   */
+  paintCachePlan() {
+    const box = this._ensureBox();
+    if (!box || !this._boxKey) return null;
+    const content = this.contentBox();
+    const width = Math.ceil(content.width);
+    const height = Math.ceil(content.height);
+    if (width <= 0 || height <= 0) return null;
+    return {
+      key: `tex|${width}x${height}@1|${this.style.color ?? ''}|${this._boxKey}`,
+      x: Math.round(content.x),
+      y: Math.round(content.y),
+      width,
+      height,
+      format: 'argb32',
+      tint: null,
+    };
+  }
+
+  paintCached(ctx, box) {
+    const laid = this._ensureBox();
+    if (!laid || !ctx.window?.app?.display) return;
+    ctx.fillStyle = this.style.color ?? '#222222';
+    laid.draw(ctx, box.x, box.y);
   }
 }

--- a/src/testing/pixels.js
+++ b/src/testing/pixels.js
@@ -9,9 +9,11 @@
 //
 // Two details the readback demands:
 //
-// - **BGRA, not RGBA.** X hands back the server's native byte order, so
-//   `[i+2], [i+1], [i]` is red, green, blue. Getting this wrong swaps red
-//   and blue, which looks like a colour bug in the code under test.
+// - **Straight RGBA.** `getImageData` normalizes the server's native byte
+//   order and premultiplication away, so `[i], [i+1], [i+2]` is red, green,
+//   blue — the canvas contract. This used to be a raw BGRA readback the
+//   caller had to un-swizzle, and reading it the old way now swaps red and
+//   blue, which looks like a colour bug in the code under test.
 // - **Antialiasing means tolerance.** A glyph edge or a rounded corner is
 //   never exactly the fill colour, so every comparison here takes one.
 
@@ -46,7 +48,9 @@ function readImage(ctx, x, y, width, height) {
 /** `[r, g, b]` at a window coordinate. */
 export async function pixelAt(ctx, x, y) {
   const image = await readImage(ctx, x, y, 1, 1);
-  return [image.data[2], image.data[1], image.data[0]];
+  // ntk's getImageData speaks straight RGBA, like canvas — the server's own
+  // byte order is its business, not ours
+  return [image.data[0], image.data[1], image.data[2]];
 }
 
 /** Whether two colours are the same within a tolerance. */
@@ -108,9 +112,9 @@ export async function countPixels(
   let n = 0;
   for (let i = 0; i < width * height; i++) {
     const rgb = [
-      image.data[i * 4 + 2],
-      image.data[i * 4 + 1],
       image.data[i * 4],
+      image.data[i * 4 + 1],
+      image.data[i * 4 + 2],
     ];
     if (rgb.every((c, k) => Math.abs(c - target[k]) <= tolerance)) n++;
   }
@@ -135,9 +139,11 @@ export async function toPNG(ctx, file, region = {}) {
   const image = await readImage(ctx, x, y, width, height);
   const png = new PNG({ width, height });
   for (let i = 0; i < width * height; i++) {
-    png.data[i * 4 + 0] = image.data[i * 4 + 2]; // BGRA -> RGBA
+    // both sides are straight RGBA now; only the alpha is ours to decide,
+    // and a screenshot wants an opaque one
+    png.data[i * 4 + 0] = image.data[i * 4 + 0];
     png.data[i * 4 + 1] = image.data[i * 4 + 1];
-    png.data[i * 4 + 2] = image.data[i * 4 + 0];
+    png.data[i * 4 + 2] = image.data[i * 4 + 2];
     png.data[i * 4 + 3] = 255;
   }
   const buffer = PNG.sync.write(png);

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -275,6 +275,21 @@ export interface CanvasProps extends DrawnProps<DrawnNode> {
    * the node's origin and clipped to its bounds. Runs on every repaint.
    */
   onDraw?: (ctx: any, info: DrawInfo) => void;
+  /**
+   * Opt this drawing into the paint cache: render it once and composite it
+   * on later repaints, instead of running `onDraw` again.
+   *
+   * Opt-in because only you know what `onDraw` reads — the key has to name
+   * every input the drawing depends on, and a key that leaves one out shows
+   * stale pixels. Include the things that change the picture:
+   *
+   *     <canvas cacheKey={`spark:${series.id}:${w}x${h}`} onDraw={draw} />
+   *
+   * Develop with `REACT_X11_PAINT_CACHE=verify`, which turns a key that
+   * misses an input into a loud complaint rather than a wrong pixel. Leave
+   * unset for anything animated or driven by state outside the props.
+   */
+  cacheKey?: string | number;
 }
 
 // --- rich content ----------------------------------------------------------

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -57,10 +57,10 @@ const readPixels = (ctx, w, h) =>
     ),
   );
 
-// BGRA readback -> [r, g, b]
+// getImageData is straight RGBA, like canvas -> [r, g, b]
 const px = (image, w, x, y) => {
   const i = (y * w + x) * 4;
-  return [image.data[i + 2], image.data[i + 1], image.data[i]];
+  return [image.data[i], image.data[i + 1], image.data[i + 2]];
 };
 
 const isNear = (rgb, want, tol = 40) =>

--- a/test/paint-cache.test.js
+++ b/test/paint-cache.test.js
@@ -9,7 +9,7 @@ import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import React from 'react';
-import ReactX11 from '../src/index.js';
+import { createRoot } from '../src/index.js';
 
 import xserver from 'x11/lib/xserver/index.js';
 import { createClient, StaticFontSource } from 'ntk';
@@ -43,10 +43,12 @@ const settle = (app) =>
 
 /** Mount a tree and return the root node plus a frame pump. */
 async function mount(app, element) {
+  const x11Root = await createRoot({ app });
   const instance = await new Promise((resolve) =>
-    ReactX11.render(element, resolve, app),
+    x11Root.render(element, resolve),
   );
   const root = instance._reactX11Node;
+  root._x11Root = x11Root; // so a test can re-render into the same root
   const frame = () => {
     root._scheduled = false;
     root.flush();
@@ -166,7 +168,7 @@ test('a different document is a different entry, not a stale one', async () => {
   assert.equal(cache.entries.size, 1);
 
   await new Promise((resolve) =>
-    ReactX11.render(wall(SQUARE('#0000ff'), 4), resolve, app),
+    ctl.root._x11Root.render(wall(SQUARE('#0000ff'), 4), resolve),
   );
   ctl.frame();
   await settle(app);
@@ -209,7 +211,7 @@ test('a monochrome drawing recolours without re-rendering', async () => {
   assert.ok(near(px(8, 8), [255, 0, 0]), `red first: got ${px(8, 8)}`);
 
   await new Promise((resolve) =>
-    ReactX11.render(coloured('#0000ff'), resolve, app),
+    ctl.root._x11Root.render(coloured('#0000ff'), resolve),
   );
   ctl.frame();
   await settle(app);
@@ -433,7 +435,7 @@ test('<canvas cacheKey> is opt-in, and caches when opted in', async () => {
   assert.equal(draws, 4);
 
   await new Promise((resolve) =>
-    ReactX11.render(cells({ cacheKey: 'green:16x16' }), resolve, app),
+    ctl.root._x11Root.render(cells({ cacheKey: 'green:16x16' }), resolve),
   );
   ctl.frame();
   await settle(app);
@@ -474,4 +476,88 @@ test('the same formula twice is one <tex> entry', async () => {
   await repaint(app, ctl);
   assert.equal(cache.stats.renders, renders, 'and a repaint re-renders none');
   await app.close();
+});
+
+// --- a third-party element opts in ------------------------------------------
+//
+// The protocol lives on Node and the registry takes a Node subclass, so the
+// two compose with no registry API of their own. This is the proof, and the
+// reason `paintCachePlan` is worth having on the base class rather than
+// hidden inside <svg>.
+
+test('a registered element can opt into the cache', async () => {
+  const { registerElement, unregisterElement } = await import('../src/host.js');
+  const { Node } = await import('../src/nodes.js');
+
+  let paints = 0;
+  class SwatchNode extends Node {
+    constructor(props, app) {
+      super('swatch', props, app);
+    }
+    paintCachePlan() {
+      const w = Math.round(this.abs.width);
+      const h = Math.round(this.abs.height);
+      if (w <= 0 || h <= 0) return null;
+      return {
+        key: `swatch|${w}x${h}|${this.props.tone}`,
+        x: Math.round(this.abs.x),
+        y: Math.round(this.abs.y),
+        width: w,
+        height: h,
+        format: 'argb32',
+        tint: null,
+      };
+    }
+    paintCached(ctx, box) {
+      paints++;
+      ctx.fillStyle = this.props.tone;
+      ctx.fillRect(box.x, box.y, box.width, box.height);
+    }
+  }
+
+  registerElement('swatch', {
+    create: (props, app) => new SwatchNode(props, app),
+    semanticNames: ['tone'],
+    override: true,
+  });
+
+  const app = await headlessApp();
+  try {
+    const ctl = await mount(
+      app,
+      React.createElement(
+        'window',
+        { width: W, height: H, style: { backgroundColor: '#ffffff' } },
+        ...Array.from({ length: 4 }, (_, i) =>
+          React.createElement('swatch', {
+            key: i,
+            tone: '#00aa00',
+            style: {
+              position: 'absolute',
+              left: i * 20,
+              top: 0,
+              width: 16,
+              height: 16,
+            },
+          }),
+        ),
+      ),
+    );
+
+    const cache = ctl.root._paintCache;
+    assert.equal(cache.entries.size, 1, 'four swatches, one rendered copy');
+    const before = paints;
+    await repaint(app, ctl);
+    assert.equal(
+      paints,
+      before,
+      'a cached repaint calls paintCached not at all',
+    );
+
+    const px = await pixels(app, ctl.root);
+    assert.ok(near(px(8, 8), [0, 170, 0]), `and it painted: got ${px(8, 8)}`);
+  } finally {
+    unregisterElement('swatch');
+    await app.close();
+  }
 });

--- a/test/paint-cache.test.js
+++ b/test/paint-cache.test.js
@@ -14,16 +14,6 @@ import ReactX11 from '../src/index.js';
 import xserver from 'x11/lib/xserver/index.js';
 import { createClient, StaticFontSource } from 'ntk';
 
-import { paintCacheSupported } from '../src/paintcache.js';
-
-// The cache needs ntk's Surface, which lands in a later ntk than package.json
-// pins; without it the renderer paints live and everything below is vacuous.
-// Skipped with a reason rather than quietly passing — a green run that tested
-// nothing is worse than a red one.
-const skip = paintCacheSupported()
-  ? false
-  : 'needs ntk with Surface (sidorares/ntk#157) — the cache is inert without it';
-
 const require = createRequire(import.meta.url);
 const fontDir = join(
   dirname(require.resolve('katex/package.json')),
@@ -121,7 +111,7 @@ function wall(source, count, extra = {}) {
   );
 }
 
-test({ skip }, 'identical drawings share one rendered copy', async () => {
+test('identical drawings share one rendered copy', async () => {
   const app = await headlessApp();
   const ctl = await mount(app, wall(SQUARE('#00aa00'), 5));
   const cache = ctl.root._paintCache;
@@ -141,7 +131,7 @@ test({ skip }, 'identical drawings share one rendered copy', async () => {
   await app.close();
 });
 
-test({ skip }, 'a repaint of unchanged content is all hits', async () => {
+test('a repaint of unchanged content is all hits', async () => {
   const app = await headlessApp();
   const ctl = await mount(app, wall(SQUARE('#00aa00'), 5));
   const cache = ctl.root._paintCache;
@@ -158,7 +148,7 @@ test({ skip }, 'a repaint of unchanged content is all hits', async () => {
   await app.close();
 });
 
-test({ skip }, 'a drawing painted once is never cached', async () => {
+test('a drawing painted once is never cached', async () => {
   // the "seen twice" gate: a node painted once and never again is a pure loss
   const app = await headlessApp();
   const ctl = await mount(app, wall(SQUARE('#00aa00'), 1));
@@ -169,139 +159,113 @@ test({ skip }, 'a drawing painted once is never cached', async () => {
   await app.close();
 });
 
-test(
-  { skip },
-  'a different document is a different entry, not a stale one',
-  async () => {
-    const app = await headlessApp();
-    const ctl = await mount(app, wall(SQUARE('#00aa00'), 4));
-    const cache = ctl.root._paintCache;
-    assert.equal(cache.entries.size, 1);
+test('a different document is a different entry, not a stale one', async () => {
+  const app = await headlessApp();
+  const ctl = await mount(app, wall(SQUARE('#00aa00'), 4));
+  const cache = ctl.root._paintCache;
+  assert.equal(cache.entries.size, 1);
 
-    await new Promise((resolve) =>
-      ReactX11.render(wall(SQUARE('#0000ff'), 4), resolve, app),
-    );
-    ctl.frame();
-    await settle(app);
+  await new Promise((resolve) =>
+    ReactX11.render(wall(SQUARE('#0000ff'), 4), resolve, app),
+  );
+  ctl.frame();
+  await settle(app);
 
-    assert.equal(cache.entries.size, 2, 'the old entry is not reused');
-    const px = await pixels(app, ctl.root);
-    assert.ok(near(px(8, 8), [0, 0, 255]), `repainted blue: got ${px(8, 8)}`);
-    await app.close();
-  },
-);
+  assert.equal(cache.entries.size, 2, 'the old entry is not reused');
+  const px = await pixels(app, ctl.root);
+  assert.ok(near(px(8, 8), [0, 0, 255]), `repainted blue: got ${px(8, 8)}`);
+  await app.close();
+});
 
-test(
-  { skip },
-  'a monochrome drawing recolours without re-rendering',
-  async () => {
-    // the point of caching coverage rather than colour: one entry serves every
-    // colour the UI asks for, so a hover or a theme flip is a composite
-    const coloured = (colour) =>
-      React.createElement(
-        'window',
-        { width: W, height: H, style: { backgroundColor: '#ffffff' } },
-        ...Array.from({ length: 4 }, (_, i) =>
-          React.createElement('svg', {
-            key: i,
-            source: SQUARE('currentColor'),
-            style: {
-              position: 'absolute',
-              left: i * 20,
-              top: 0,
-              width: 16,
-              height: 16,
-              color: colour,
-            },
-          }),
-        ),
-      );
-
-    const app = await headlessApp();
-    const ctl = await mount(app, coloured('#ff0000'));
-    const cache = ctl.root._paintCache;
-    const entries = cache.entries.size;
-    const renders = cache.stats.renders;
-    let px = await pixels(app, ctl.root);
-    assert.ok(near(px(8, 8), [255, 0, 0]), `red first: got ${px(8, 8)}`);
-
-    await new Promise((resolve) =>
-      ReactX11.render(coloured('#0000ff'), resolve, app),
-    );
-    ctl.frame();
-    await settle(app);
-
-    assert.equal(
-      cache.entries.size,
-      entries,
-      'no new entry for the new colour',
-    );
-    assert.equal(cache.stats.renders, renders, 'and nothing re-rendered');
-    px = await pixels(app, ctl.root);
-    assert.ok(near(px(8, 8), [0, 0, 255]), `now blue: got ${px(8, 8)}`);
-    await app.close();
-  },
-);
-
-test(
-  { skip },
-  'a multi-colour drawing bakes its colours and keeps them',
-  async () => {
-    const app = await headlessApp();
-    const ctl = await mount(app, wall(TWO_COLOUR, 4));
-    const cache = ctl.root._paintCache;
-    assert.equal(cache.entries.size, 1);
-
-    const px = await pixels(app, ctl.root);
-    assert.ok(near(px(8, 3), [255, 0, 0]), `top half red: got ${px(8, 3)}`);
-    assert.ok(
-      near(px(8, 13), [0, 0, 255]),
-      `bottom half blue: got ${px(8, 13)}`,
-    );
-
-    await repaint(app, ctl);
-    const after = await pixels(app, ctl.root);
-    assert.ok(
-      near(after(8, 3), [255, 0, 0]),
-      'still red after a cached repaint',
-    );
-    assert.ok(near(after(8, 13), [0, 0, 255]), 'still blue');
-    await app.close();
-  },
-);
-
-test(
-  { skip },
-  'a drawing too big to be worth caching paints live',
-  async () => {
-    const app = await headlessApp();
-    const big = {
-      position: 'absolute',
-      left: 0,
-      top: 0,
-      width: 400,
-      height: 400,
-    };
-    const ctl = await mount(
-      app,
-      React.createElement(
-        'window',
-        { width: W, height: H },
-        ...Array.from({ length: 3 }, (_, i) =>
-          React.createElement('svg', {
-            key: i,
-            source: SQUARE('#00aa00'),
-            style: big,
-          }),
-        ),
+test('a monochrome drawing recolours without re-rendering', async () => {
+  // the point of caching coverage rather than colour: one entry serves every
+  // colour the UI asks for, so a hover or a theme flip is a composite
+  const coloured = (colour) =>
+    React.createElement(
+      'window',
+      { width: W, height: H, style: { backgroundColor: '#ffffff' } },
+      ...Array.from({ length: 4 }, (_, i) =>
+        React.createElement('svg', {
+          key: i,
+          source: SQUARE('currentColor'),
+          style: {
+            position: 'absolute',
+            left: i * 20,
+            top: 0,
+            width: 16,
+            height: 16,
+            color: colour,
+          },
+        }),
       ),
     );
-    const cache = ctl.root._paintCache;
-    assert.equal(cache.entries.size, 0, '400x400 is past the per-item cap');
-    assert.ok(cache.stats.tooBig > 0, 'and it says so');
-    await app.close();
-  },
-);
+
+  const app = await headlessApp();
+  const ctl = await mount(app, coloured('#ff0000'));
+  const cache = ctl.root._paintCache;
+  const entries = cache.entries.size;
+  const renders = cache.stats.renders;
+  let px = await pixels(app, ctl.root);
+  assert.ok(near(px(8, 8), [255, 0, 0]), `red first: got ${px(8, 8)}`);
+
+  await new Promise((resolve) =>
+    ReactX11.render(coloured('#0000ff'), resolve, app),
+  );
+  ctl.frame();
+  await settle(app);
+
+  assert.equal(cache.entries.size, entries, 'no new entry for the new colour');
+  assert.equal(cache.stats.renders, renders, 'and nothing re-rendered');
+  px = await pixels(app, ctl.root);
+  assert.ok(near(px(8, 8), [0, 0, 255]), `now blue: got ${px(8, 8)}`);
+  await app.close();
+});
+
+test('a multi-colour drawing bakes its colours and keeps them', async () => {
+  const app = await headlessApp();
+  const ctl = await mount(app, wall(TWO_COLOUR, 4));
+  const cache = ctl.root._paintCache;
+  assert.equal(cache.entries.size, 1);
+
+  const px = await pixels(app, ctl.root);
+  assert.ok(near(px(8, 3), [255, 0, 0]), `top half red: got ${px(8, 3)}`);
+  assert.ok(near(px(8, 13), [0, 0, 255]), `bottom half blue: got ${px(8, 13)}`);
+
+  await repaint(app, ctl);
+  const after = await pixels(app, ctl.root);
+  assert.ok(near(after(8, 3), [255, 0, 0]), 'still red after a cached repaint');
+  assert.ok(near(after(8, 13), [0, 0, 255]), 'still blue');
+  await app.close();
+});
+
+test('a drawing too big to be worth caching paints live', async () => {
+  const app = await headlessApp();
+  const big = {
+    position: 'absolute',
+    left: 0,
+    top: 0,
+    width: 400,
+    height: 400,
+  };
+  const ctl = await mount(
+    app,
+    React.createElement(
+      'window',
+      { width: W, height: H },
+      ...Array.from({ length: 3 }, (_, i) =>
+        React.createElement('svg', {
+          key: i,
+          source: SQUARE('#00aa00'),
+          style: big,
+        }),
+      ),
+    ),
+  );
+  const cache = ctl.root._paintCache;
+  assert.equal(cache.entries.size, 0, '400x400 is past the per-item cap');
+  assert.ok(cache.stats.tooBig > 0, 'and it says so');
+  await app.close();
+});
 
 // --- verify mode -----------------------------------------------------------
 //
@@ -344,33 +308,29 @@ async function drive(cache, node, ctx, times) {
   }
 }
 
-test(
-  { skip },
-  'verify mode says nothing when the key tells the truth',
-  async () => {
-    const app = await headlessApp();
-    const { PaintCache } = await import('../src/paintcache.js');
-    const cache = new PaintCache(app, { verify: true });
-    const ctx = app
-      .createPixmap({ width: 32, height: 32, depth: 32 })
-      .getContext('2d');
+test('verify mode says nothing when the key tells the truth', async () => {
+  const app = await headlessApp();
+  const { PaintCache } = await import('../src/paintcache.js');
+  const cache = new PaintCache(app, { verify: true });
+  const ctx = app
+    .createPixmap({ width: 32, height: 32, depth: 32 })
+    .getContext('2d');
 
-    const errors = [];
-    const real = console.error;
-    console.error = (...a) => errors.push(a.join(' '));
-    try {
-      // one colour forever: the drawing really is a function of the key
-      await drive(cache, lyingNode(['#00aa00']), ctx, 4);
-    } finally {
-      console.error = real;
-    }
-    assert.equal(cache.stats.hits, 2, 'gate, render, then two hits');
-    assert.deepEqual(errors, [], 'and no complaint');
-    await app.close();
-  },
-);
+  const errors = [];
+  const real = console.error;
+  console.error = (...a) => errors.push(a.join(' '));
+  try {
+    // one colour forever: the drawing really is a function of the key
+    await drive(cache, lyingNode(['#00aa00']), ctx, 4);
+  } finally {
+    console.error = real;
+  }
+  assert.equal(cache.stats.hits, 2, 'gate, render, then two hits');
+  assert.deepEqual(errors, [], 'and no complaint');
+  await app.close();
+});
 
-test({ skip }, 'verify mode catches a key that misses an input', async () => {
+test('verify mode catches a key that misses an input', async () => {
   const app = await headlessApp();
   const { PaintCache } = await import('../src/paintcache.js');
   const cache = new PaintCache(app, { verify: true });
@@ -394,7 +354,7 @@ test({ skip }, 'verify mode catches a key that misses an input', async () => {
   await app.close();
 });
 
-test({ skip }, 'verify mode is off unless asked for', async () => {
+test('verify mode is off unless asked for', async () => {
   const app = await headlessApp();
   const { PaintCache } = await import('../src/paintcache.js');
   const cache = new PaintCache(app);
@@ -439,61 +399,57 @@ test('an app that cannot make surfaces gets no cache, and no crash', async () =>
 
 // --- other implementors ----------------------------------------------------
 
-test(
-  { skip },
-  '<canvas cacheKey> is opt-in, and caches when opted in',
-  async () => {
-    const app = await headlessApp();
-    let draws = 0;
-    const onDraw = (ctx, { width, height }) => {
-      draws++;
-      ctx.fillStyle = '#00aa00';
-      ctx.fillRect(0, 0, width, height);
-    };
-    const cells = (props) =>
-      React.createElement(
-        'window',
-        { width: W, height: H, style: { backgroundColor: '#ffffff' } },
-        ...Array.from({ length: 4 }, (_, i) =>
-          React.createElement('canvas', {
-            key: i,
-            onDraw,
-            style: {
-              position: 'absolute',
-              left: i * 20,
-              top: 0,
-              width: 16,
-              height: 16,
-            },
-            ...props,
-          }),
-        ),
-      );
-
-    // without a key: every cell runs onDraw, every frame
-    const ctl = await mount(app, cells({}));
-    assert.equal(ctl.root._paintCache.entries.size, 0);
-    assert.equal(draws, 4);
-
-    await new Promise((resolve) =>
-      ReactX11.render(cells({ cacheKey: 'green:16x16' }), resolve, app),
+test('<canvas cacheKey> is opt-in, and caches when opted in', async () => {
+  const app = await headlessApp();
+  let draws = 0;
+  const onDraw = (ctx, { width, height }) => {
+    draws++;
+    ctx.fillStyle = '#00aa00';
+    ctx.fillRect(0, 0, width, height);
+  };
+  const cells = (props) =>
+    React.createElement(
+      'window',
+      { width: W, height: H, style: { backgroundColor: '#ffffff' } },
+      ...Array.from({ length: 4 }, (_, i) =>
+        React.createElement('canvas', {
+          key: i,
+          onDraw,
+          style: {
+            position: 'absolute',
+            left: i * 20,
+            top: 0,
+            width: 16,
+            height: 16,
+          },
+          ...props,
+        }),
+      ),
     );
-    ctl.frame();
-    await settle(app);
-    const cache = ctl.root._paintCache;
-    assert.equal(cache.entries.size, 1, 'four cells, one entry');
 
-    const drawsAfter = draws;
-    await repaint(app, ctl);
-    assert.equal(draws, drawsAfter, 'a cached repaint runs no onDraw at all');
+  // without a key: every cell runs onDraw, every frame
+  const ctl = await mount(app, cells({}));
+  assert.equal(ctl.root._paintCache.entries.size, 0);
+  assert.equal(draws, 4);
 
-    const px = await pixels(app, ctl.root);
-    assert.ok(near(px(8, 8), [0, 170, 0]), `and painted: got ${px(8, 8)}`);
-    await app.close();
-  },
-);
+  await new Promise((resolve) =>
+    ReactX11.render(cells({ cacheKey: 'green:16x16' }), resolve, app),
+  );
+  ctl.frame();
+  await settle(app);
+  const cache = ctl.root._paintCache;
+  assert.equal(cache.entries.size, 1, 'four cells, one entry');
 
-test({ skip }, 'the same formula twice is one <tex> entry', async () => {
+  const drawsAfter = draws;
+  await repaint(app, ctl);
+  assert.equal(draws, drawsAfter, 'a cached repaint runs no onDraw at all');
+
+  const px = await pixels(app, ctl.root);
+  assert.ok(near(px(8, 8), [0, 170, 0]), `and painted: got ${px(8, 8)}`);
+  await app.close();
+});
+
+test('the same formula twice is one <tex> entry', async () => {
   const app = await headlessApp();
   const formula = (props) =>
     React.createElement(

--- a/test/paint-cache.test.js
+++ b/test/paint-cache.test.js
@@ -1,0 +1,521 @@
+// The <svg> paint cache (issue #149): same drawing, one rendered copy.
+//
+// End-to-end, against node-x11's in-process X server, which implements Render
+// compositing for real — so "it drew the right thing" is a pixel assertion and
+// "it drew it from the cache" is a stats assertion, and both have to hold.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import React from 'react';
+import ReactX11 from '../src/index.js';
+
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient, StaticFontSource } from 'ntk';
+
+import { paintCacheSupported } from '../src/paintcache.js';
+
+// The cache needs ntk's Surface, which lands in a later ntk than package.json
+// pins; without it the renderer paints live and everything below is vacuous.
+// Skipped with a reason rather than quietly passing — a green run that tested
+// nothing is worse than a red one.
+const skip = paintCacheSupported()
+  ? false
+  : 'needs ntk with Surface (sidorares/ntk#157) — the cache is inert without it';
+
+const require = createRequire(import.meta.url);
+const fontDir = join(
+  dirname(require.resolve('katex/package.json')),
+  'dist',
+  'fonts',
+);
+
+const W = 200;
+const H = 200;
+
+async function headlessApp() {
+  const server = xserver.createServer({ width: 640, height: 480 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const fontSource = new StaticFontSource();
+  fontSource.add(readFileSync(join(fontDir, 'KaTeX_Main-Regular.ttf')), {
+    family: 'Test Main',
+  });
+  fontSource.alias('sans-serif', 'Test Main');
+  return createClient({ stream: clientEnd, fontSource });
+}
+
+const settle = (app) =>
+  new Promise((resolve, reject) =>
+    app.X.GetInputFocus((err) => (err ? reject(err) : resolve())),
+  );
+
+/** Mount a tree and return the root node plus a frame pump. */
+async function mount(app, element) {
+  const instance = await new Promise((resolve) =>
+    ReactX11.render(element, resolve, app),
+  );
+  const root = instance._reactX11Node;
+  const frame = () => {
+    root._scheduled = false;
+    root.flush();
+  };
+  frame();
+  await settle(app);
+  return { root, frame };
+}
+
+/** Force a full repaint, the way an expose or a theme change does. */
+async function repaint(app, ctl) {
+  ctl.root.invalidate(true, null, 'expose');
+  ctl.frame();
+  await settle(app);
+}
+
+async function pixels(app, root) {
+  const ctx = root._ctx;
+  const image = await new Promise((resolve, reject) =>
+    ctx.getImageData(0, 0, W, H, (err, data) =>
+      err ? reject(err) : resolve(data),
+    ),
+  );
+  return (x, y) => {
+    const i = (y * W + x) * 4;
+    return [image.data[i], image.data[i + 1], image.data[i + 2]];
+  };
+}
+
+const near = (rgb, want, tol = 24) =>
+  rgb.every((c, i) => Math.abs(c - want[i]) <= tol);
+
+// A filled square, so a pixel in the middle of a cell is unambiguously the
+// drawing's colour rather than an antialiased edge.
+const SQUARE = (paint) =>
+  `<svg viewBox="0 0 10 10"><rect width="10" height="10" fill="${paint}"/></svg>`;
+
+const TWO_COLOUR =
+  '<svg viewBox="0 0 10 10">' +
+  '<rect width="10" height="5" fill="#ff0000"/>' +
+  '<rect y="5" width="10" height="5" fill="#0000ff"/></svg>';
+
+/** `count` cells of one drawing, laid out in a row. */
+function wall(source, count, extra = {}) {
+  return React.createElement(
+    'window',
+    { width: W, height: H, style: { backgroundColor: '#ffffff' } },
+    ...Array.from({ length: count }, (_, i) =>
+      React.createElement('svg', {
+        key: i,
+        source,
+        style: {
+          position: 'absolute',
+          left: i * 20,
+          top: 0,
+          width: 16,
+          height: 16,
+        },
+        ...extra,
+      }),
+    ),
+  );
+}
+
+test({ skip }, 'identical drawings share one rendered copy', async () => {
+  const app = await headlessApp();
+  const ctl = await mount(app, wall(SQUARE('#00aa00'), 5));
+  const cache = ctl.root._paintCache;
+
+  assert.ok(cache, 'the cache exists on an app that can make surfaces');
+  assert.equal(cache.entries.size, 1, 'five cells, one entry');
+  assert.equal(cache.stats.renders, 1, 'rendered once');
+
+  // ...and every cell still shows the drawing
+  const px = await pixels(app, ctl.root);
+  for (let i = 0; i < 5; i++) {
+    assert.ok(
+      near(px(i * 20 + 8, 8), [0, 170, 0]),
+      `cell ${i} painted: got ${px(i * 20 + 8, 8)}`,
+    );
+  }
+  await app.close();
+});
+
+test({ skip }, 'a repaint of unchanged content is all hits', async () => {
+  const app = await headlessApp();
+  const ctl = await mount(app, wall(SQUARE('#00aa00'), 5));
+  const cache = ctl.root._paintCache;
+  const rendersAfterMount = cache.stats.renders;
+
+  const hitsBefore = cache.stats.hits;
+  await repaint(app, ctl);
+
+  assert.equal(cache.stats.renders, rendersAfterMount, 'nothing re-rendered');
+  assert.equal(cache.stats.hits - hitsBefore, 5, 'five cells, five hits');
+
+  const px = await pixels(app, ctl.root);
+  assert.ok(near(px(8, 8), [0, 170, 0]), `still painted: got ${px(8, 8)}`);
+  await app.close();
+});
+
+test({ skip }, 'a drawing painted once is never cached', async () => {
+  // the "seen twice" gate: a node painted once and never again is a pure loss
+  const app = await headlessApp();
+  const ctl = await mount(app, wall(SQUARE('#00aa00'), 1));
+  assert.equal(ctl.root._paintCache.entries.size, 0);
+
+  const px = await pixels(app, ctl.root);
+  assert.ok(near(px(8, 8), [0, 170, 0]), 'and it still painted live');
+  await app.close();
+});
+
+test(
+  { skip },
+  'a different document is a different entry, not a stale one',
+  async () => {
+    const app = await headlessApp();
+    const ctl = await mount(app, wall(SQUARE('#00aa00'), 4));
+    const cache = ctl.root._paintCache;
+    assert.equal(cache.entries.size, 1);
+
+    await new Promise((resolve) =>
+      ReactX11.render(wall(SQUARE('#0000ff'), 4), resolve, app),
+    );
+    ctl.frame();
+    await settle(app);
+
+    assert.equal(cache.entries.size, 2, 'the old entry is not reused');
+    const px = await pixels(app, ctl.root);
+    assert.ok(near(px(8, 8), [0, 0, 255]), `repainted blue: got ${px(8, 8)}`);
+    await app.close();
+  },
+);
+
+test(
+  { skip },
+  'a monochrome drawing recolours without re-rendering',
+  async () => {
+    // the point of caching coverage rather than colour: one entry serves every
+    // colour the UI asks for, so a hover or a theme flip is a composite
+    const coloured = (colour) =>
+      React.createElement(
+        'window',
+        { width: W, height: H, style: { backgroundColor: '#ffffff' } },
+        ...Array.from({ length: 4 }, (_, i) =>
+          React.createElement('svg', {
+            key: i,
+            source: SQUARE('currentColor'),
+            style: {
+              position: 'absolute',
+              left: i * 20,
+              top: 0,
+              width: 16,
+              height: 16,
+              color: colour,
+            },
+          }),
+        ),
+      );
+
+    const app = await headlessApp();
+    const ctl = await mount(app, coloured('#ff0000'));
+    const cache = ctl.root._paintCache;
+    const entries = cache.entries.size;
+    const renders = cache.stats.renders;
+    let px = await pixels(app, ctl.root);
+    assert.ok(near(px(8, 8), [255, 0, 0]), `red first: got ${px(8, 8)}`);
+
+    await new Promise((resolve) =>
+      ReactX11.render(coloured('#0000ff'), resolve, app),
+    );
+    ctl.frame();
+    await settle(app);
+
+    assert.equal(
+      cache.entries.size,
+      entries,
+      'no new entry for the new colour',
+    );
+    assert.equal(cache.stats.renders, renders, 'and nothing re-rendered');
+    px = await pixels(app, ctl.root);
+    assert.ok(near(px(8, 8), [0, 0, 255]), `now blue: got ${px(8, 8)}`);
+    await app.close();
+  },
+);
+
+test(
+  { skip },
+  'a multi-colour drawing bakes its colours and keeps them',
+  async () => {
+    const app = await headlessApp();
+    const ctl = await mount(app, wall(TWO_COLOUR, 4));
+    const cache = ctl.root._paintCache;
+    assert.equal(cache.entries.size, 1);
+
+    const px = await pixels(app, ctl.root);
+    assert.ok(near(px(8, 3), [255, 0, 0]), `top half red: got ${px(8, 3)}`);
+    assert.ok(
+      near(px(8, 13), [0, 0, 255]),
+      `bottom half blue: got ${px(8, 13)}`,
+    );
+
+    await repaint(app, ctl);
+    const after = await pixels(app, ctl.root);
+    assert.ok(
+      near(after(8, 3), [255, 0, 0]),
+      'still red after a cached repaint',
+    );
+    assert.ok(near(after(8, 13), [0, 0, 255]), 'still blue');
+    await app.close();
+  },
+);
+
+test(
+  { skip },
+  'a drawing too big to be worth caching paints live',
+  async () => {
+    const app = await headlessApp();
+    const big = {
+      position: 'absolute',
+      left: 0,
+      top: 0,
+      width: 400,
+      height: 400,
+    };
+    const ctl = await mount(
+      app,
+      React.createElement(
+        'window',
+        { width: W, height: H },
+        ...Array.from({ length: 3 }, (_, i) =>
+          React.createElement('svg', {
+            key: i,
+            source: SQUARE('#00aa00'),
+            style: big,
+          }),
+        ),
+      ),
+    );
+    const cache = ctl.root._paintCache;
+    assert.equal(cache.entries.size, 0, '400x400 is past the per-item cap');
+    assert.ok(cache.stats.tooBig > 0, 'and it says so');
+    await app.close();
+  },
+);
+
+// --- verify mode -----------------------------------------------------------
+//
+// A key that fails to name something the paint reads is the one way this
+// design produces a *wrong* pixel rather than a slow frame, and it is the
+// failure that is hardest to spot by looking. So the mechanism that catches it
+// gets tested against a node that really does lie.
+
+/** A node implementing the protocol, whose drawing can be changed underneath
+ * a fixed key — exactly the mistake an implementor makes. */
+function lyingNode(colours) {
+  let call = 0;
+  return {
+    kind: 'liar',
+    live: 0,
+    paintCachePlan: () => ({
+      key: 'liar|16x16', // never mentions the colour
+      x: 0,
+      y: 0,
+      width: 16,
+      height: 16,
+      format: 'argb32',
+      tint: null,
+    }),
+    paintCached(ctx, box) {
+      ctx.fillStyle = colours[Math.min(call++, colours.length - 1)];
+      ctx.fillRect(box.x, box.y, box.width, box.height);
+    },
+    _paintContent() {
+      this.live++;
+    },
+  };
+}
+
+async function drive(cache, node, ctx, times) {
+  for (let i = 0; i < times; i++) {
+    cache.beginFrame();
+    cache.paint(node, ctx);
+    cache.endFrame();
+  }
+}
+
+test(
+  { skip },
+  'verify mode says nothing when the key tells the truth',
+  async () => {
+    const app = await headlessApp();
+    const { PaintCache } = await import('../src/paintcache.js');
+    const cache = new PaintCache(app, { verify: true });
+    const ctx = app
+      .createPixmap({ width: 32, height: 32, depth: 32 })
+      .getContext('2d');
+
+    const errors = [];
+    const real = console.error;
+    console.error = (...a) => errors.push(a.join(' '));
+    try {
+      // one colour forever: the drawing really is a function of the key
+      await drive(cache, lyingNode(['#00aa00']), ctx, 4);
+    } finally {
+      console.error = real;
+    }
+    assert.equal(cache.stats.hits, 2, 'gate, render, then two hits');
+    assert.deepEqual(errors, [], 'and no complaint');
+    await app.close();
+  },
+);
+
+test({ skip }, 'verify mode catches a key that misses an input', async () => {
+  const app = await headlessApp();
+  const { PaintCache } = await import('../src/paintcache.js');
+  const cache = new PaintCache(app, { verify: true });
+  const ctx = app
+    .createPixmap({ width: 32, height: 32, depth: 32 })
+    .getContext('2d');
+
+  const errors = [];
+  const real = console.error;
+  console.error = (...a) => errors.push(a.join(' '));
+  try {
+    // the third paint draws a different colour under the same key
+    await drive(cache, lyingNode(['#00aa00', '#00aa00', '#ff0000']), ctx, 4);
+  } finally {
+    console.error = real;
+  }
+
+  assert.ok(errors.length > 0, 'the lie is reported');
+  assert.match(errors[0], /does not cover the paint/);
+  assert.match(errors[0], /liar\|16x16/, 'and it names the key');
+  await app.close();
+});
+
+test({ skip }, 'verify mode is off unless asked for', async () => {
+  const app = await headlessApp();
+  const { PaintCache } = await import('../src/paintcache.js');
+  const cache = new PaintCache(app);
+  const ctx = app
+    .createPixmap({ width: 32, height: 32, depth: 32 })
+    .getContext('2d');
+
+  const errors = [];
+  const real = console.error;
+  console.error = (...a) => errors.push(a.join(' '));
+  try {
+    await drive(cache, lyingNode(['#00aa00', '#00aa00', '#ff0000']), ctx, 4);
+  } finally {
+    console.error = real;
+  }
+  // the same lie, unreported — which is why the mode exists
+  assert.deepEqual(errors, []);
+  await app.close();
+});
+
+test('the kill switch turns the whole thing off', async () => {
+  // Stale pixels are the failure this cannot debug its way out of, so there
+  // has to be a way to take it out of the picture — same as NO_SCROLL_BLIT.
+  process.env.REACT_X11_NO_PAINT_CACHE = '1';
+  try {
+    // a fresh module instance, so the flag is read again at load
+    const { paintCacheFor } = await import('../src/paintcache.js?killswitch');
+    const app = await headlessApp();
+    assert.equal(paintCacheFor(app), null);
+    await app.close();
+  } finally {
+    delete process.env.REACT_X11_NO_PAINT_CACHE;
+  }
+});
+
+test('an app that cannot make surfaces gets no cache, and no crash', async () => {
+  // the headless mock in the smoke tests has no Render extension
+  const { paintCacheFor } = await import('../src/paintcache.js');
+  assert.equal(paintCacheFor({ display: {} }), null);
+  assert.equal(paintCacheFor(null), null);
+});
+
+// --- other implementors ----------------------------------------------------
+
+test(
+  { skip },
+  '<canvas cacheKey> is opt-in, and caches when opted in',
+  async () => {
+    const app = await headlessApp();
+    let draws = 0;
+    const onDraw = (ctx, { width, height }) => {
+      draws++;
+      ctx.fillStyle = '#00aa00';
+      ctx.fillRect(0, 0, width, height);
+    };
+    const cells = (props) =>
+      React.createElement(
+        'window',
+        { width: W, height: H, style: { backgroundColor: '#ffffff' } },
+        ...Array.from({ length: 4 }, (_, i) =>
+          React.createElement('canvas', {
+            key: i,
+            onDraw,
+            style: {
+              position: 'absolute',
+              left: i * 20,
+              top: 0,
+              width: 16,
+              height: 16,
+            },
+            ...props,
+          }),
+        ),
+      );
+
+    // without a key: every cell runs onDraw, every frame
+    const ctl = await mount(app, cells({}));
+    assert.equal(ctl.root._paintCache.entries.size, 0);
+    assert.equal(draws, 4);
+
+    await new Promise((resolve) =>
+      ReactX11.render(cells({ cacheKey: 'green:16x16' }), resolve, app),
+    );
+    ctl.frame();
+    await settle(app);
+    const cache = ctl.root._paintCache;
+    assert.equal(cache.entries.size, 1, 'four cells, one entry');
+
+    const drawsAfter = draws;
+    await repaint(app, ctl);
+    assert.equal(draws, drawsAfter, 'a cached repaint runs no onDraw at all');
+
+    const px = await pixels(app, ctl.root);
+    assert.ok(near(px(8, 8), [0, 170, 0]), `and painted: got ${px(8, 8)}`);
+    await app.close();
+  },
+);
+
+test({ skip }, 'the same formula twice is one <tex> entry', async () => {
+  const app = await headlessApp();
+  const formula = (props) =>
+    React.createElement(
+      'window',
+      { width: W, height: H, style: { backgroundColor: '#ffffff' } },
+      ...Array.from({ length: 3 }, (_, i) =>
+        React.createElement('tex', {
+          key: i,
+          source: 'x^2',
+          style: { position: 'absolute', left: 4, top: i * 40 },
+          ...props,
+        }),
+      ),
+    );
+  const ctl = await mount(app, formula({}));
+  const cache = ctl.root._paintCache;
+  // TexBox memoizes its *layout* per node, so without this each of the three
+  // rasterized itself on every frame
+  assert.equal(cache.entries.size, 1, 'three copies, one rendered');
+
+  const renders = cache.stats.renders;
+  await repaint(app, ctl);
+  assert.equal(cache.stats.renders, renders, 'and a repaint re-renders none');
+  await app.close();
+});


### PR DESCRIPTION
Closes #149. Steps 3 and 4 of the staging there.

> **Unblocked.** ntk 5.3.0 ships `Surface`, a8 contexts, the `drawImage` duck-type and the rectangular-clip fast path, so the pin has moved and this is ready. Rebased onto `master` now that #156 has merged.

## The numbers

`SvgView.draw` re-walked the parsed document on every repaint: `Path2D` geometry, reflatten, restroke, then a composite **per subpath**. From the protocol bench:

| scenario | requests | bytes out | composites |
| --- | ---: | ---: | ---: |
| 100 unchanged icons, full repaint | 1082 → **107** | 194KB → **3.6KB** | 501 → **101** |
| 10 unchanged icons in a damaged row | 183 → **42** | 11.8KB → **1.0KB** | 115 → **11** |

101 composites for 100 icons is the shape to look for: one blit each, plus the window.

## Keyed by content, not by node

Per-node ownership would make 400 cells of one icon into 400 identical surfaces. Keying on *what is drawn* collapses them to one entry per distinct drawing — and it removes invalidation entirely, since a changed prop yields a different key and there is never a stale entry to find.

The key is built in `_ensureView`, which already runs once per content change, so per frame it costs a `Map.get` and nothing else.

## Colour stays out of the key where it can

A drawing that commits to a single colour is kept as an **a8 coverage surface** and painted through the current fill colour. Hover, `:disabled` and a theme flip then all reuse one entry, at a quarter of the storage — the trick the glyph cache already runs on text. Multi-colour drawings bake their colours, which is right: those colours belong to the drawing rather than to the UI.

The other half of that is `<svg>` honouring `currentColor` at all, which it now does:

```jsx
<svg source={icons.gauge}
     style={{ width: 20, height: 20, color: '$fg', ':hover': { color: '$accent' } }} />
```

That was already expressible — `color` is in `STATE_PROPS` and `paintPropsChanged` handles it — it just did nothing. Now the hover is one composite.

## Self-limiting on purpose

X gives no back-pressure, and the first sign of overspending is `BadAlloc` on `CreatePixmap`, delivered async with no useful attribution. So: an 8MB byte budget with LRU eviction that never takes an entry drawn this frame, a per-item area cap so one big illustration cannot evict the useful set, and a **seen-twice gate**, since a node painted once and never again is a pure loss under a cache.

## The seam

An internal protocol on `Node` — `paintCachePlan()` and `paintCached(ctx, box)` — which the base class does not implement, so nothing is cached until a node opts in and no other element changes behaviour.

- **`<svg>`** and **`<tex>`** implement it. Note what content-keying adds for `<tex>`: `_boxKey` memoized the *layout* per node, so a document showing one formula twice laid it out twice and rasterized it twice every frame.
- **`<canvas>`** takes an explicit `cacheKey` prop instead. It is already origin-relative, so it needs no `paintCached` — but `onDraw` is an opaque closure whose identity changes every render, so only the author can say what it depends on.

It is also the seam a public custom-element API would expose — and #158 landed `registerElement()` while this was in review, so that is now testable rather than aspirational. It needs **no registry support at all**: the protocol is on `Node`, `registerElement` takes a `Node` subclass, so a third-party element implements the two methods and is cached like a built-in. There is a test with a registered `<swatch>` whose four instances share one rendered copy and whose `paintCached` is not called at all on a cached repaint, and `docs/extending.md` documents it where a third party will look.

## Guardrails

A stale pixel is the one bug this design can have, and the hardest to see:

- `REACT_X11_NO_PAINT_CACHE=1` turns it off, matching the `NO_SCROLL_BLIT` precedent.
- `REACT_X11_PAINT_CACHE=verify` re-renders every hit and compares a **digest of the drawing calls** against the one recorded when the entry was made. A key that fails to name an input then fails loudly instead of showing stale pixels — client-side, no pixel readback, no round trip. There is a test that builds a node which really does lie, and asserts the complaint.
- `REACT_X11_DEBUG_PAINT_CACHE=1` prints entries, bytes and hit/miss/render/eviction counts per frame.
- The cache stands aside under any non-identity transform, and every error path falls back to painting live — so the worst it can do is not fire.

## Testing

356 pass, 14 new, all end-to-end against the in-process X server: pixels for "it drew the right thing", cache stats for "it drew it from the cache", and both have to hold. The recolour test asserts that a red icon becomes a blue one *with no new entry and no re-render*.

### What the version bump brought with it

`getImageData` in 5.3.0 speaks straight RGBA, and both pixel readers here still un-swizzled it — eight integration tests failed as pixel timeouts naming nothing, comparing a red-blue transposition against the colour they wanted. That fix was parked on a separate branch while the pin was still 5.2.0, since it is incompatible with it; it is now the second commit, where it belongs.

The 14 cache tests previously **skipped with a reason** on 5.2.0, since without `Surface` the cache is inert and asserting on it would be vacuous. They now run: 366 pass, none skipped. The runtime feature check stays — it is what makes an older ntk degrade to painting live rather than crashing.

The bench baseline is saved with the cache **live**, the same choice the scroll blit made: `--check` only fails on an increase, so a change that quietly stopped the cache firing would sail past a fallback baseline and land squarely on this one. It is now measured against the released package rather than a hand-swapped lib — one request less than the figures above, otherwise identical.
