### PR TITLE
feat: registerElement() and the subpath exports a third-party element needs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,9 @@
 - [typescript.md](typescript.md) — the bundled types: one tsconfig option,
   why JSX comes from `react-x11/jsx-runtime` rather than an augmentation,
   and how the declarations are kept from drifting.
+- [extending.md](extending.md) — `registerElement()` and the subpath
+  exports: adding a host element from outside the package, the node
+  contract, and the two definition fields that fail far from their cause.
 - [testing.md](testing.md) — `react-x11/test`: render, query, drive and
   assert on real pixels, against a real X server in your test process. No
   display, no xvfb.

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,0 +1,159 @@
+# Extending the element vocabulary
+
+`<box>`, `<text>`, `<glarea>` and the rest are built in, but the list is not
+closed. `registerElement()` adds an element from outside the package — a
+`<sparkline>`, a tray icon, an XEMBED `<foreign>` — so a sibling package can
+ship one without forking react-x11 and without the core growing.
+
+```js
+import { registerElement } from 'react-x11/host';
+import { Node } from 'react-x11/node';
+
+class SparklineNode extends Node {
+  constructor(props, app) {
+    super('sparkline', props, app); // the kind must be the element name
+  }
+
+  paint(ctx) {
+    super.paint(ctx); // background, border, clip
+    const { x, y, width, height } = this.abs;
+    const data = this.props.data ?? [];
+    const max = Math.max(1, ...data);
+    ctx.beginPath();
+    data.forEach((value, i) => {
+      const px = x + (width * i) / Math.max(1, data.length - 1);
+      const py = y + height - (height * value) / max;
+      i === 0 ? ctx.moveTo(px, py) : ctx.lineTo(px, py);
+    });
+    ctx.strokeStyle = this.props.color ?? '#000';
+    ctx.stroke();
+  }
+}
+
+registerElement('sparkline', {
+  create: (props, app) => new SparklineNode(props, app),
+  semanticNames: ['data', 'color'],
+});
+```
+
+```jsx
+<sparkline
+  data={[1, 4, 2, 8]}
+  color="#c0392b"
+  style={{ width: 120, height: 40 }}
+/>
+```
+
+Register before you render. The registry is consulted when an element is
+first created, so a late registration only affects trees mounted after it.
+
+## The definition
+
+| field                         |                                                                                                                                       |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `create(props, app, hostCtx)` | builds the node. `app` is the ntk connection — the second argument every built-in node constructor takes. Must return a `Node`.       |
+| `drawn`                       | default `true`: lays out with yoga and paints into the owning window. `false` for a node that owns a real child X window (see below). |
+| `semanticNames`               | prop names this element owns even though they are also style names                                                                    |
+| `childrenAllowed`             | default `true`; `false` rejects children by name instead of laying out something that never paints                                    |
+| `override`                    | replace an existing registration. Off by default — two packages claiming one name is a conflict worth hearing about                   |
+
+Two of these exist because getting them wrong fails a long way from the
+cause, so they are worth understanding rather than copying:
+
+**`drawn` decides whether your element paints at all.** `paintOrder()`
+filters children on the set of drawn kinds; a node missing from it lays out
+correctly, reports a sensible `abs` rect, and never appears on screen, with
+no error anywhere. `registerElement` puts you in that set unless you opt out.
+
+**`semanticNames` is the difference between DEV and production.** react-x11
+throws in development on `<box width={10} />`, because `width` is a style
+property written flat — a real mistake with an unhelpful failure otherwise.
+An element whose own vocabulary overlaps the style vocabulary (`width`,
+`color`, `fontSize`) therefore has to say so, or it throws on its own props
+in development and works in production. `<window width>` is the built-in
+precedent: on a `<window>` it is the X window's width and never style.
+
+`react-x11/style`'s `isStyleProp(name)` is how to check whether a name you
+are about to use needs declaring.
+
+## The node contract
+
+`Node` already implements the whole reconciler-facing surface, so an element
+that only draws needs a constructor and a `paint`. What you may override:
+
+| method                         | when                                                                                              |
+| ------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `paint(ctx)`                   | draw. Call `super.paint(ctx)` first for background, border and clip, then draw inside `this.abs`. |
+| `applyProps(next, prev)`       | props changed. Call `super.applyProps(next, prev)`; invalidate if you cache anything derived.     |
+| `hitTest(x, y)`                | non-rectangular hit areas. The default walks children in reverse paint order.                     |
+| `insertBefore` / `removeChild` | only if children mean something structural to you                                                 |
+| `destroySubtree()`             | release anything you allocated (pixmaps, fonts, timers). Call `super.destroySubtree()`.           |
+
+And what you read:
+
+- `this.props` — the current props, replaced wholesale on update.
+- `this.style` — the flattened `style` prop with the active `:hover` /
+  `:focus` / `:active` / `:disabled` blocks overlaid, and `$token`
+  references already resolved against the theme. **Everything that paints or
+  lays out reads this, never `props`.**
+- `this.abs` — position and size within the owning window, valid after
+  layout.
+- `this.root` — the owning `<window>` node; `this.app` — the ntk connection.
+- `this.theme` — the nearest theme at or above this node.
+
+To ask for a repaint: `this.root?.invalidate(layout, rect, reason)`. Pass a
+`rect` when you know what changed — an invalidation with no bound repaints
+the whole window, which is this renderer's main performance bug class (see
+[debugging.md](debugging.md)). `reason` joins the closed set the diagnostics
+print.
+
+### Elements that own a real X window
+
+`drawn: false` is for a node backed by its own child X window rather than
+painted into its parent — a GL surface, an XEMBED socket, a video overlay.
+`GlAreaNode` (`src/glnodes.js`) is the worked example: it holds no paint
+code, and the owning `WindowNode` realizes it in the commit phase
+(`_realizeGlAreas`) so the child window names its real parent from the
+start. Read those two together before writing a third one; the ordering
+constraint — no X calls in the render phase, because the render phase is
+discardable — is the part that is easy to get wrong.
+
+## The subpath exports
+
+| subpath             |                                                                                                          |
+| ------------------- | -------------------------------------------------------------------------------------------------------- |
+| `react-x11/host`    | `registerElement`, `unregisterElement`, `registeredElements`, `hostTypes`, `knownElements`, `drawnKinds` |
+| `react-x11/node`    | `Node` and the built-in node classes                                                                     |
+| `react-x11/style`   | `createStyles`, `flattenStyle`, `isStyleProp`, `resolveTokens`, the rest of the vocabulary               |
+| `react-x11/ntk`     | ntk itself, re-exported                                                                                  |
+| `react-x11/keysyms` | the `XK_*` constants                                                                                     |
+
+**Reach ntk through `react-x11/ntk`, not a second dependency.** Two copies
+of ntk in one process means two Yoga instances and two font caches, and a
+node built against one cannot be painted by the other — a failure that
+looks like a layout bug rather than a dependency bug.
+
+## Typing
+
+The element also has to be declared to JSX, which is module augmentation —
+the same mechanism [typescript.md](typescript.md) describes:
+
+```ts
+import type { Style } from 'react-x11/style';
+
+declare module 'react-x11/jsx-runtime' {
+  namespace JSX {
+    interface IntrinsicElements {
+      sparkline: {
+        data: number[];
+        color?: string;
+        style?: Style;
+        ref?: React.Ref<unknown>;
+      };
+    }
+  }
+}
+```
+
+`test/types/extend.tsx` in this repo compiles exactly that, so the story
+stays true as the declarations move.

--- a/package.json
+++ b/package.json
@@ -99,6 +99,22 @@
       "types": "./src/debug.d.ts",
       "default": "./src/debug.js"
     },
+    "./host": {
+      "types": "./src/host.d.ts",
+      "default": "./src/host.js"
+    },
+    "./node": {
+      "types": "./src/node.d.ts",
+      "default": "./src/node.js"
+    },
+    "./style": {
+      "types": "./src/style.d.ts",
+      "default": "./src/style.js"
+    },
+    "./ntk": {
+      "types": "./src/ntk.d.ts",
+      "default": "./src/ntk.js"
+    },
     "./test": {
       "types": "./src/testing/index.d.ts",
       "default": "./src/testing/index.js"

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -39,6 +39,7 @@ import {
   hooks as traceHooks,
 } from './trace-registry.js';
 import { GlAreaNode } from './glnodes.js';
+import { createRegisteredNode, registeredElements } from './registry.js';
 import { SCENE_KINDS, UNSUPPORTED_KINDS, createSceneNode } from './scene3d.js';
 import {
   MarkdownNode,
@@ -283,18 +284,37 @@ const HostConfig = {
       case 'glarea':
         node = new GlAreaNode(props, rootContainer);
         break;
-      default:
+      default: {
+        // Third-party elements (issue #125). Built-ins stay a switch —
+        // they are code, not data — and the registry is consulted only
+        // once the switch has run out, so it costs nothing on the way in.
+        const registered = createRegisteredNode(
+          type,
+          props,
+          rootContainer,
+          hostContext,
+        );
+        if (registered) {
+          registered._reactFiber = internalHandle;
+          return registered;
+        }
         if (SCENE_KINDS.has(type) || UNSUPPORTED_KINDS[type]) {
           throw new Error(
             `react-x11: <${type}> is a 3D element and only works inside ` +
               '<glarea> (or the <Canvas3D> component).',
           );
         }
+        const custom = registeredElements();
         throw new Error(
           `react-x11: unknown element type <${type}>. Supported: ` +
             HOST_TYPES.map((t) => `<${t}>`).join(', ') +
-            '.',
+            (custom.length > 0
+              ? `; registered: ${custom.map((t) => `<${t}>`).join(', ')}`
+              : '') +
+            '. Third-party elements are added with registerElement() from ' +
+            'react-x11/host (docs/extending.md).',
         );
+      }
     }
     node._reactFiber = internalHandle;
     return node;

--- a/src/host.d.ts
+++ b/src/host.d.ts
@@ -1,0 +1,76 @@
+/**
+ * `react-x11/host` — add a host element from outside the package.
+ *
+ * The element also has to be declared to JSX, which is module augmentation
+ * against `react-x11/jsx-runtime` (see docs/typescript.md and
+ * docs/extending.md):
+ *
+ * ```ts
+ * declare module 'react-x11/jsx-runtime' {
+ *   namespace JSX {
+ *     interface IntrinsicElements {
+ *       sparkline: { data: number[]; stroke?: string; style?: Style };
+ *     }
+ *   }
+ * }
+ * ```
+ */
+import type { Node } from './node.js';
+import type { NtkApp } from './types/nodes.js';
+
+export interface HostContext {
+  isInsideText: boolean;
+  isInsideSvg: boolean;
+  isInsideRichText: boolean;
+  isInside3d: boolean;
+}
+
+export interface ElementDefinition {
+  /**
+   * Build the node. `app` is the ntk connection the tree renders through —
+   * the second argument every built-in node constructor takes. Must return
+   * a `Node` whose `kind` is the registered element name.
+   */
+  create(
+    props: Record<string, unknown>,
+    app: NtkApp,
+    hostContext: HostContext,
+  ): Node;
+  /**
+   * Lays out with yoga and paints into the owning window (default true).
+   * `false` is for a node owning a real child X window instead — see
+   * `GlAreaNode`.
+   */
+  drawn?: boolean;
+  /**
+   * Prop names this element owns even though they are also style names, so
+   * `<sparkline stroke="red">` is not reported as a flat style prop in
+   * development.
+   */
+  semanticNames?: string[];
+  /** Reject children, naming this element, instead of laying out something
+   * that will never paint. Default true. */
+  childrenAllowed?: boolean;
+  /** Replace an existing registration. Off by default. */
+  override?: boolean;
+}
+
+export function registerElement(
+  type: string,
+  definition: ElementDefinition,
+): void;
+
+/** Undo a registration; true if there was one. */
+export function unregisterElement(type: string): boolean;
+
+/** Registered element names, in registration order. */
+export function registeredElements(): string[];
+
+/** The built-in element names (a copy). */
+export function hostTypes(): string[];
+
+/** Every element name currently known, built-in and registered. */
+export function knownElements(): string[];
+
+/** Kinds that lay out with yoga and paint into the owning window (a copy). */
+export function drawnKinds(): string[];

--- a/src/host.js
+++ b/src/host.js
@@ -1,0 +1,45 @@
+// `react-x11/host` — the seam a package that is not react-x11 uses to add
+// a host element. See docs/extending.md for the node contract; this file is
+// only the entry point.
+export {
+  registerElement,
+  unregisterElement,
+  registeredElements,
+} from './registry.js';
+
+import { DRAWN_KINDS as DRAWN } from './nodes.js';
+import { registeredElements } from './registry.js';
+
+const BUILT_IN = Object.freeze([
+  'window',
+  'popup',
+  'box',
+  'text',
+  'image',
+  'canvas',
+  'scrollview',
+  'textinput',
+  'textarea',
+  'markdown',
+  'html',
+  'svg',
+  'tex',
+  'glarea',
+]);
+
+/** The built-in element names. A copy: the vocabulary grows through
+ * `registerElement`, never by mutating this. */
+export function hostTypes() {
+  return [...BUILT_IN];
+}
+
+/** Every element name currently known, built-in and registered. */
+export function knownElements() {
+  return [...BUILT_IN, ...registeredElements()];
+}
+
+/** Kinds that lay out with yoga and paint into the owning window. A copy —
+ * to add one, register the element with `drawn: true`. */
+export function drawnKinds() {
+  return [...DRAWN];
+}

--- a/src/node.d.ts
+++ b/src/node.d.ts
@@ -1,0 +1,80 @@
+/**
+ * `react-x11/node` — the base class a registered element subclasses.
+ *
+ * Typed as the surface a subclass legitimately uses. It is deliberately
+ * narrower than the runtime class: everything underscore-prefixed is
+ * internal and may change in a patch release. docs/extending.md is the
+ * contract in prose.
+ */
+import type { Rect, NtkApp } from './types/nodes.js';
+import type { Style } from './types/style.js';
+
+/** ntk's 2d context. Typed loosely — it is ntk's API, not ours. */
+export type Context2D = unknown;
+
+export declare class Node {
+  constructor(
+    kind: string,
+    props: Record<string, unknown>,
+    app: NtkApp,
+    options?: { yoga?: boolean },
+  );
+
+  /** Element name. Must equal the name it was registered under. */
+  readonly kind: string;
+  /** The current props. Replaced wholesale by `applyProps`. */
+  readonly props: Record<string, unknown>;
+  /** The ntk connection this tree renders through. */
+  readonly app: NtkApp;
+  readonly parent: Node | null;
+  readonly children: Node[];
+  /** The owning `<window>` node, once attached. */
+  readonly root: Node | null;
+  readonly destroyed: boolean;
+  /** Position and size within the owning window, valid after layout. */
+  readonly abs: Rect;
+  /** The flattened `style` prop with the active state blocks overlaid.
+   * Everything that paints or lays out reads this, never `props`. */
+  readonly style: Style;
+  /** The nearest `theme` at or above this node. */
+  readonly theme: Record<string, unknown> | null;
+  /** Style names this element owns as its own semantics. Registered
+   * elements declare these to `registerElement` instead of overriding. */
+  readonly semanticNames: ReadonlySet<string>;
+
+  /** Draw. A subclass calls `super.paint(ctx)` first, for the background,
+   * border and clip, then draws inside `this.abs`. */
+  paint(ctx: Context2D): void;
+  /** Props changed. A subclass calls `super.applyProps(next, prev)`. */
+  applyProps(
+    nextProps: Record<string, unknown>,
+    prevProps: Record<string, unknown>,
+  ): void;
+  /** The deepest node containing the point, or null. */
+  hitTest(x: number, y: number): Node | null;
+  containsPoint(x: number, y: number): boolean;
+  /** Drawn, visible children in paint order. */
+  paintOrder(): Node[];
+  insertBefore(child: Node, beforeChild: Node | null): void;
+  removeChild(child: Node): void;
+  destroySubtree(): void;
+  /** Ask the owning window to repaint. `reason` joins the closed set the
+   * diagnostics print (docs/debugging.md). */
+  invalidate(layout?: boolean, rect?: Rect | null, reason?: string): void;
+  getClientRects(): Rect[];
+}
+
+export declare class BoxNode extends Node {
+  constructor(props: Record<string, unknown>, app: NtkApp);
+}
+
+export declare class TextNode extends Node {}
+export declare class ImageNode extends Node {}
+export declare class CanvasNode extends Node {}
+export declare class ScrollViewNode extends Node {}
+export declare class TextInputNode extends Node {}
+export declare class TextAreaNode extends TextInputNode {}
+export declare class WindowNode extends Node {}
+export declare class PopupNode extends WindowNode {}
+/** The precedent for an element owning a real child X window. */
+export declare class GlAreaNode extends Node {}

--- a/src/node.js
+++ b/src/node.js
@@ -1,0 +1,26 @@
+// `react-x11/node` — the base class a registered element subclasses, plus
+// the built-in nodes worth extending or reading as worked examples.
+//
+// The contract a subclass has to keep is written down in docs/extending.md.
+// The short version: `Node` already implements the whole reconciler-facing
+// surface (`insertBefore`, `removeChild`, `applyProps`, `destroySubtree`,
+// layout, hit testing, and a `paint` that draws background, border and
+// clip), so an element that only draws needs a constructor that names its
+// kind and a `paint` that calls `super.paint(ctx)` first.
+export {
+  Node,
+  BoxNode,
+  TextNode,
+  ImageNode,
+  CanvasNode,
+  ScrollViewNode,
+  TextInputNode,
+  TextAreaNode,
+  WindowNode,
+  PopupNode,
+} from './nodes.js';
+
+// The precedent for an element that owns a real child X window rather than
+// painting into its parent's: registered with `drawn: false`, realized by
+// the owning WindowNode. docs/extending.md walks through it.
+export { GlAreaNode } from './glnodes.js';

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -40,7 +40,14 @@ import {
   paintEditMenu,
 } from './editmenu.js';
 
-const DRAWN_KINDS = new Set([
+/**
+ * Kinds that lay out with yoga and paint into the owning window —
+ * `paintOrder` filters on this, so a kind missing from it lays out and
+ * never paints. Mutable because `registerElement` (registry.js) adds to it;
+ * that direction, rather than nodes.js importing the registry, is what
+ * keeps the two files acyclic.
+ */
+export const DRAWN_KINDS = new Set([
   'box',
   'text',
   'image',
@@ -53,6 +60,11 @@ const DRAWN_KINDS = new Set([
   'svg',
   'tex',
 ]);
+
+/** kind -> style names a registered element claims as its own semantics.
+ * Filled by registry.js; read by `Node.semanticNames`, so a registered
+ * element gets the exemption without subclassing the getter. */
+export const CUSTOM_SEMANTIC_NAMES = new Map();
 
 // X ConfigureWindow stack-mode: Below places the window directly under the
 // named sibling (X11 protocol, ConfigureWindow).
@@ -697,9 +709,11 @@ export class Node {
     }
   }
 
-  /** Style names this element claims as its own semantics (see WindowNode). */
+  /** Style names this element claims as its own semantics (see WindowNode).
+   * Registered elements declare theirs to `registerElement`, so the common
+   * case needs no subclass. */
   get semanticNames() {
-    return NO_SEMANTIC_NAMES;
+    return CUSTOM_SEMANTIC_NAMES.get(this.kind) ?? NO_SEMANTIC_NAMES;
   }
 
   /**
@@ -827,6 +841,16 @@ export class Node {
       throw new Error(
         `react-x11: <window> cannot be nested inside <${this.kind}>; ` +
           'windows may only appear at the root or inside another <window>.',
+      );
+    }
+    // A registered element that declared childrenAllowed: false says so
+    // here, rather than laying out a child that will never paint. The flag
+    // is set on the instance by the registry, so this stays one property
+    // read and nodes.js keeps not importing it.
+    if (this._childrenAllowed === false) {
+      throw new Error(
+        `react-x11: <${this.kind}> takes no children (registered with ` +
+          `childrenAllowed: false), but <${child.kind}> is inside it.`,
       );
     }
     // captured before the child joins, so it covers the arrangement that is

--- a/src/ntk.d.ts
+++ b/src/ntk.d.ts
@@ -1,0 +1,24 @@
+/**
+ * `react-x11/ntk` — the toolkit underneath, re-exported so an extension
+ * package does not declare a second, independently-versioned `ntk`
+ * dependency. Two copies in a process means two Yoga instances and two font
+ * caches, and a node built against one cannot be painted by the other.
+ *
+ * ntk ships no types of its own, so these are deliberately loose rather
+ * than a hand-written mirror that would drift out of date silently. The
+ * named exports are the ones an extension actually reaches for; anything
+ * else ntk has is still there at runtime.
+ */
+export const createClient: (
+  options?: Record<string, unknown>,
+) => Promise<unknown>;
+export const StaticFontSource: new (...args: unknown[]) => unknown;
+export const FontconfigFontSource: new (...args: unknown[]) => unknown;
+export const Clipboard: new (...args: unknown[]) => unknown;
+export const Path2D: new (...args: unknown[]) => unknown;
+export const Image: new (...args: unknown[]) => unknown;
+export const Pixmap: new (...args: unknown[]) => unknown;
+export const Yoga: Record<string, unknown>;
+
+declare const ntk: Record<string, unknown>;
+export default ntk;

--- a/src/ntk.js
+++ b/src/ntk.js
@@ -1,0 +1,11 @@
+// `react-x11/ntk` — the toolkit underneath, re-exported.
+//
+// A package that adds an element draws with ntk's 2d context, may need a
+// `Path2D`, an `Image`, a `Pixmap` or a `FontSource`, and an application
+// embedding react-x11 may want `createClient` to build the connection it
+// then passes as `createRoot({ app })`. Reaching those through here rather
+// than declaring a second `ntk` dependency is what keeps one copy in the
+// process: two copies mean two Yoga instances and two font caches, and a
+// node built against one cannot be painted by the other.
+export * from 'ntk';
+export { default } from 'ntk';

--- a/src/registry.js
+++ b/src/registry.js
@@ -1,0 +1,173 @@
+// The element registry: how a package that is not react-x11 adds a host
+// element (issue #125).
+//
+// The vocabulary used to be a closed `switch` with a throwing default, so a
+// `<sparkline>`, a tray icon or an XEMBED `<foreign>` meant forking. It is
+// now that switch plus this table, consulted by `createInstance` before it
+// gives up — the built-ins stay a switch because they are not data, and a
+// registered element is data.
+//
+// Two things the table carries besides the constructor, both because
+// getting them wrong fails somewhere far away:
+//
+// - **`drawn`** puts the kind in `DRAWN_KINDS`, which is what `paintOrder`
+//   filters on. A node missing from it lays out and never paints, with no
+//   error anywhere — the single most confusing way for a custom element to
+//   fail.
+// - **`semanticNames`** exempts the element's own prop names from the DEV
+//   assertion that catches `<box width={10}>` (a style property written
+//   flat). Without it an element whose vocabulary overlaps the style
+//   vocabulary — `width`, `stroke`, `opacity` — throws on its own props in
+//   development and works in production, which is the worst shape a bug
+//   can have.
+import { DRAWN_KINDS, CUSTOM_SEMANTIC_NAMES, Node } from './nodes.js';
+
+/** kind -> definition. Insertion-ordered, which is the order errors list. */
+const registry = new Map();
+
+const RESERVED = new Set(['textchunk', 'svgchild']);
+
+function assertNode(node, type) {
+  if (!(node instanceof Node)) {
+    throw new Error(
+      `react-x11: the create() registered for <${type}> returned ` +
+        `${node === undefined ? 'undefined' : typeof node} — it must return ` +
+        'a Node (import { Node } from "react-x11/node").',
+    );
+  }
+  if (node.kind !== type) {
+    throw new Error(
+      `react-x11: the create() registered for <${type}> returned a node of ` +
+        `kind "${node.kind}". The kind is what paint order, queries and the ` +
+        'DEV style assertion match on, so it has to be the element name.',
+    );
+  }
+  return node;
+}
+
+/**
+ * Teach react-x11 a new element.
+ *
+ * ```js
+ * import { registerElement } from 'react-x11/host';
+ * import { Node } from 'react-x11/node';
+ *
+ * class SparklineNode extends Node {
+ *   constructor(props, app) {
+ *     super('sparkline', props, app);
+ *   }
+ *   paint(ctx) {
+ *     super.paint(ctx);          // background, border, clip
+ *     // ...draw this.props.data inside this.abs
+ *   }
+ * }
+ *
+ * registerElement('sparkline', {
+ *   create: (props, app) => new SparklineNode(props, app),
+ *   drawn: true,
+ *   semanticNames: ['data', 'stroke'],
+ * });
+ * ```
+ *
+ * @param {string} type element name, as written in JSX
+ * @param {object} definition
+ * @param {(props, app, hostContext) => Node} definition.create builds the
+ *   node. `app` is the ntk connection the tree renders through — the second
+ *   argument every built-in node constructor takes.
+ * @param {boolean} [definition.drawn=true] lays out with yoga and paints
+ *   into the owning window. `false` is for a node that owns a real child X
+ *   window instead (`GlAreaNode` is the worked example).
+ * @param {string[]} [definition.semanticNames] prop names this element owns
+ *   even though they are also style names.
+ * @param {boolean} [definition.childrenAllowed=true] reject children in DEV
+ *   with a message naming the element, rather than laying out something
+ *   that cannot paint.
+ * @param {boolean} [definition.override=false] replace an existing
+ *   registration. Off by default: two packages claiming one name is a
+ *   conflict to be told about, not resolved silently.
+ */
+export function registerElement(type, definition) {
+  if (typeof type !== 'string' || type === '') {
+    throw new Error('react-x11: registerElement needs an element name.');
+  }
+  if (!/^[a-z][a-z0-9-]*$/.test(type)) {
+    // Capitalised names are components to JSX, never host elements, so
+    // `registerElement('Sparkline')` would register something unreachable.
+    throw new Error(
+      `react-x11: "${type}" cannot be an element name — JSX only treats ` +
+        'lowercase names as host elements. Use "sparkline", not "Sparkline".',
+    );
+  }
+  if (RESERVED.has(type)) {
+    throw new Error(
+      `react-x11: <${type}> is internal to react-x11 and cannot be ` +
+        'registered.',
+    );
+  }
+  if (!definition || typeof definition.create !== 'function') {
+    throw new Error(
+      `react-x11: registerElement("${type}") needs a create(props, app) ` +
+        'function that returns a Node.',
+    );
+  }
+  if (registry.has(type) && !definition.override) {
+    throw new Error(
+      `react-x11: <${type}> is already registered. Pass { override: true } ` +
+        'if replacing it is deliberate — two packages claiming one element ' +
+        'name is usually not.',
+    );
+  }
+
+  const {
+    create,
+    drawn = true,
+    semanticNames = [],
+    childrenAllowed = true,
+  } = definition;
+
+  registry.set(type, { create, drawn, childrenAllowed });
+
+  // paintOrder() filters on this set, so a drawn element has to join it or
+  // it lays out and never paints
+  if (drawn) DRAWN_KINDS.add(type);
+  else DRAWN_KINDS.delete(type);
+
+  if (semanticNames.length > 0) {
+    CUSTOM_SEMANTIC_NAMES.set(type, new Set(semanticNames));
+  } else {
+    CUSTOM_SEMANTIC_NAMES.delete(type);
+  }
+}
+
+/** Undo a registration. Mostly for tests, which must not leak an element
+ * into the next file's expectations. */
+export function unregisterElement(type) {
+  DRAWN_KINDS.delete(type);
+  CUSTOM_SEMANTIC_NAMES.delete(type);
+  return registry.delete(type);
+}
+
+/** The definition for a registered element, or undefined. */
+export function elementDefinition(type) {
+  return registry.get(type);
+}
+
+/** Registered element names, in registration order. */
+export function registeredElements() {
+  return [...registry.keys()];
+}
+
+/**
+ * Build a registered element's node, or undefined if the name is not one.
+ * Called from `createInstance`'s default branch, so an unregistered name
+ * still produces the built-in "unknown element" error.
+ */
+export function createRegisteredNode(type, props, app, hostContext) {
+  const definition = registry.get(type);
+  if (!definition) return undefined;
+  const node = assertNode(definition.create(props, app, hostContext), type);
+  // read by Node.insertBefore — carried on the instance so nodes.js needs
+  // no import from here
+  if (!definition.childrenAllowed) node._childrenAllowed = false;
+  return node;
+}

--- a/src/style.d.ts
+++ b/src/style.d.ts
@@ -1,0 +1,62 @@
+/**
+ * `react-x11/style` — the style vocabulary, for code outside the package
+ * that has to speak it: a registered element asking whether a prop name is
+ * style, resolving `$token` references against a theme, or flattening the
+ * array/object `style` shape the built-ins accept.
+ */
+import type { Style, StyleProperties } from './types/style.js';
+
+export type { Style, StyleProperties };
+
+/** Freeze a stylesheet object, the `StyleSheet.create` of this renderer. */
+export function createStyles<T extends Record<string, Style>>(sheet: T): T;
+
+/** Collapse an array/nested `style` prop into one object. */
+export function flattenStyle(
+  style: Style | Style[] | null | undefined,
+): StyleProperties;
+
+/** Is this prop name part of the style vocabulary? The question a
+ * registered element asks before treating a prop as its own semantics. */
+export function isStyleProp(name: string): boolean;
+export function isLayoutProp(name: string): boolean;
+export function isPaintProp(name: string): boolean;
+export function isAnimatableProp(name: string): boolean;
+
+/** Overlay the `:hover` / `:focus` / `:active` / `:disabled` blocks that
+ * the given states select. */
+export function resolveStyleStates(
+  style: StyleProperties,
+  states: Record<string, boolean>,
+): StyleProperties;
+export function hasStateStyles(style: StyleProperties): boolean;
+
+/** Does this style reference any `$token`? */
+export function styleUsesTokens(style: StyleProperties): boolean;
+export function tokenNames(
+  style: StyleProperties,
+  out?: Set<string>,
+): Set<string>;
+/** Replace `$token` references with values from the theme. */
+export function resolveTokens(
+  style: StyleProperties,
+  theme: Record<string, unknown> | null | undefined,
+  where?: string,
+  strict?: boolean,
+): StyleProperties;
+
+export function styleHasSizeQueries(style: StyleProperties): boolean;
+export function resolveSizeQueries(
+  style: StyleProperties,
+  size: { width: number; height: number },
+): StyleProperties;
+
+export function interpolate(from: unknown, to: unknown, t: number): unknown;
+export function transitionFor(
+  style: StyleProperties,
+  prop: string,
+): { duration: number; delay?: number } | null;
+export function ease(t: number): number;
+
+export const EMPTY_STYLE: Readonly<StyleProperties>;
+export const STATE_KEYS: readonly string[];

--- a/src/style.js
+++ b/src/style.js
@@ -1,0 +1,25 @@
+// `react-x11/style` — the style vocabulary, for code that has to speak it
+// from outside the package: a registered element deciding whether a prop
+// name is style (`isStyleProp`), resolving `$token` references against a
+// theme, or flattening the same array/object `style` prop shape the
+// built-ins take.
+export {
+  createStyles,
+  flattenStyle,
+  isStyleProp,
+  isLayoutProp,
+  isPaintProp,
+  isAnimatableProp,
+  resolveStyleStates,
+  hasStateStyles,
+  styleUsesTokens,
+  tokenNames,
+  resolveTokens,
+  styleHasSizeQueries,
+  resolveSizeQueries,
+  interpolate,
+  transitionFor,
+  ease,
+  EMPTY_STYLE,
+  STATE_KEYS,
+} from './styles.js';

--- a/test/register-element.test.js
+++ b/test/register-element.test.js
@@ -1,0 +1,255 @@
+// registerElement() and the subpath exports third parties need (#125).
+// Everything here imports through the published subpaths, because the point
+// of the issue is that a package outside react-x11 can do this — a test
+// reaching into src/ would prove nothing.
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+
+import {
+  registerElement,
+  unregisterElement,
+  registeredElements,
+  hostTypes,
+  knownElements,
+  drawnKinds,
+} from '../src/host.js';
+import { Node } from '../src/node.js';
+import { isStyleProp, flattenStyle } from '../src/style.js';
+import { renderX11, cleanup, screen } from '../src/testing/index.js';
+
+const h = React.createElement;
+
+/**
+ * Assert that mounting throws, without React's report of the escaping error
+ * on stderr — several tests here fail on purpose, and the message under
+ * test is the one thrown, not the one React logs about it. Same shape as
+ * the console capture in handler-errors.test.js.
+ */
+async function rejectsQuietly(fn, expected) {
+  const origError = console.error;
+  console.error = () => {};
+  try {
+    await assert.rejects(fn, expected);
+  } finally {
+    console.error = origError;
+  }
+}
+
+/** A minimal third-party element: draws a polyline from `data`, and owns
+ * `color` — a name the style vocabulary also has, which is exactly the
+ * case that needs `semanticNames`. */
+class SparklineNode extends Node {
+  constructor(props, app) {
+    super('sparkline', props, app);
+    this.painted = 0;
+  }
+
+  paint(ctx) {
+    super.paint(ctx);
+    this.painted++;
+    this.lastData = this.props.data;
+    ctx.save?.();
+    ctx.beginPath?.();
+    const { x, y, width, height } = this.abs;
+    const data = this.props.data ?? [];
+    const max = Math.max(1, ...data);
+    data.forEach((value, i) => {
+      const px = x + (width * i) / Math.max(1, data.length - 1);
+      const py = y + height - (height * value) / max;
+      if (i === 0) ctx.moveTo?.(px, py);
+      else ctx.lineTo?.(px, py);
+    });
+    ctx.strokeStyle = this.props.color ?? '#000';
+    ctx.stroke?.();
+    ctx.restore?.();
+  }
+}
+
+const registered = new Set();
+function register(type, definition) {
+  registerElement(type, definition);
+  registered.add(type);
+}
+
+afterEach(async () => {
+  await cleanup();
+  for (const type of registered) unregisterElement(type);
+  registered.clear();
+});
+
+test('a registered element mounts, lays out and paints', async () => {
+  register('sparkline', {
+    create: (props, app) => new SparklineNode(props, app),
+    semanticNames: ['data', 'color'],
+  });
+
+  await renderX11(
+    h('sparkline', {
+      data: [1, 4, 2, 8],
+      color: '#c0392b',
+      style: { width: 120, height: 40, margin: 10 },
+    }),
+    { backend: 'mock' },
+  );
+
+  const node = screen.all((n) => n.kind === 'sparkline')[0];
+  assert.ok(node, 'the element is in the retained tree');
+  // yoga laid it out — the proof it joined DRAWN_KINDS rather than being
+  // silently skipped by paintOrder
+  assert.strictEqual(node.abs.width, 120);
+  assert.strictEqual(node.abs.height, 40);
+  assert.strictEqual(node.abs.x, 10);
+  assert.ok(node.painted > 0, 'paint() ran');
+  assert.deepStrictEqual(node.lastData, [1, 4, 2, 8]);
+});
+
+test('semanticNames exempts the element vocabulary from the DEV style assertion', async () => {
+  // `color` is a style property, so without semanticNames this throws in
+  // development and works in production — the dev/prod split #125 calls out
+  assert.strictEqual(isStyleProp('color'), true, 'precondition');
+
+  register('sparkline', {
+    create: (props, app) => new SparklineNode(props, app),
+    semanticNames: ['data', 'color'],
+  });
+  await renderX11(h('sparkline', { data: [1], color: 'red' }), {
+    backend: 'mock',
+  });
+  screen.all((n) => n.kind === 'sparkline');
+
+  // and an element that did NOT declare it still gets the assertion
+  register('bare', { create: (props, app) => new Node('bare', props, app) });
+  await rejectsQuietly(
+    () => renderX11(h('bare', { color: 'red' }), { backend: 'mock' }),
+    /<bare color=…> is a style property/,
+  );
+});
+
+test('props update through the normal commit path', async () => {
+  register('sparkline', {
+    create: (props, app) => new SparklineNode(props, app),
+    semanticNames: ['data', 'color'],
+  });
+  const { rerender } = await renderX11(
+    h('sparkline', { data: [1, 2], style: { width: 50, height: 20 } }),
+    { backend: 'mock' },
+  );
+  const node = screen.all((n) => n.kind === 'sparkline')[0];
+  const before = node.painted;
+
+  await rerender(
+    h('sparkline', { data: [3, 4, 5], style: { width: 50, height: 20 } }),
+  );
+  assert.deepStrictEqual(node.props.data, [3, 4, 5]);
+  assert.ok(node.painted > before, 'the update repainted');
+});
+
+test('drawn: false keeps the element out of paint order', async () => {
+  class OffscreenNode extends Node {
+    constructor(props, app) {
+      super('offscreen', props, app);
+    }
+  }
+  register('offscreen', {
+    create: (props, app) => new OffscreenNode(props, app),
+    drawn: false,
+  });
+
+  assert.ok(!drawnKinds().includes('offscreen'));
+  await renderX11(h('box', { style: { flexGrow: 1 } }, h('offscreen', null)), {
+    backend: 'mock',
+  });
+  const box = screen.all((n) => n.kind === 'box')[0];
+  assert.ok(
+    !box.paintOrder().some((n) => n.kind === 'offscreen'),
+    'not painted by its parent',
+  );
+});
+
+test('childrenAllowed: false says so instead of laying out a child', async () => {
+  register('leafonly', {
+    create: (props, app) => new Node('leafonly', props, app),
+    childrenAllowed: false,
+  });
+  await rejectsQuietly(
+    () => renderX11(h('leafonly', null, h('box', null)), { backend: 'mock' }),
+    /<leafonly> takes no children[\s\S]*<box> is inside it/,
+  );
+});
+
+test('the registry refuses names that could not work, and silent clashes', () => {
+  assert.throws(
+    () => registerElement('Sparkline', { create: () => null }),
+    /JSX only treats lowercase names as host elements/,
+  );
+  assert.throws(
+    () => registerElement('textchunk', { create: () => null }),
+    /internal to react-x11/,
+  );
+  assert.throws(
+    () => registerElement('thing', {}),
+    /needs a create\(props, app\) function/,
+  );
+
+  register('dup', { create: (p, a) => new Node('dup', p, a) });
+  assert.throws(
+    () => registerElement('dup', { create: (p, a) => new Node('dup', p, a) }),
+    /already registered[\s\S]*override: true/,
+  );
+  // deliberate replacement is allowed
+  registerElement('dup', {
+    create: (p, a) => new Node('dup', p, a),
+    override: true,
+  });
+});
+
+test('a create() that returns the wrong thing is caught at the source', async () => {
+  register('wrong', { create: () => ({ kind: 'wrong' }) });
+  await rejectsQuietly(
+    () => renderX11(h('wrong', null), { backend: 'mock' }),
+    /must return a Node/,
+  );
+
+  register('mislabelled', {
+    create: (p, a) => new Node('somethingelse', p, a),
+  });
+  await rejectsQuietly(
+    () => renderX11(h('mislabelled', null), { backend: 'mock' }),
+    /returned a node of kind "somethingelse"/,
+  );
+});
+
+test('an unknown element still errors, and now points at the registry', async () => {
+  register('sparkline', { create: (p, a) => new SparklineNode(p, a) });
+  await rejectsQuietly(
+    () => renderX11(h('nosuchthing', null), { backend: 'mock' }),
+    /unknown element type <nosuchthing>[\s\S]*registered: <sparkline>[\s\S]*registerElement\(\) from react-x11\/host/,
+  );
+});
+
+test('the introspection helpers are copies, not the live sets', () => {
+  const before = hostTypes();
+  before.push('nonsense');
+  assert.ok(!hostTypes().includes('nonsense'), 'hostTypes() copies');
+
+  register('sparkline', { create: (p, a) => new SparklineNode(p, a) });
+  assert.deepStrictEqual(registeredElements(), ['sparkline']);
+  assert.ok(knownElements().includes('box'), 'built-ins');
+  assert.ok(knownElements().includes('sparkline'), 'and registered ones');
+  assert.ok(drawnKinds().includes('sparkline'), 'drawn by default');
+
+  unregisterElement('sparkline');
+  registered.delete('sparkline');
+  assert.deepStrictEqual(registeredElements(), []);
+  assert.ok(!drawnKinds().includes('sparkline'), 'and it leaves DRAWN_KINDS');
+});
+
+test('react-x11/style is enough to speak the vocabulary from outside', () => {
+  assert.strictEqual(isStyleProp('backgroundColor'), true);
+  assert.strictEqual(isStyleProp('title'), false);
+  assert.deepStrictEqual(flattenStyle([{ width: 1 }, { height: 2 }]), {
+    width: 1,
+    height: 2,
+  });
+});

--- a/test/types/extend.tsx
+++ b/test/types/extend.tsx
@@ -1,0 +1,95 @@
+/**
+ * Type tests for the extension surface (#125). Not run — compiled. The
+ * point of the file is that the module-augmentation story in
+ * docs/typescript.md and docs/extending.md stays true: a third party can
+ * declare its own element to JSX and get it type-checked.
+ */
+import React from 'react';
+import {
+  registerElement,
+  unregisterElement,
+  registeredElements,
+  hostTypes,
+  knownElements,
+  drawnKinds,
+} from '../../src/host.js';
+import { Node, BoxNode } from '../../src/node.js';
+import {
+  isStyleProp,
+  flattenStyle,
+  createStyles,
+  resolveTokens,
+} from '../../src/style.js';
+import type { Style } from '../../src/style.js';
+
+// The element, declared to JSX exactly as docs/extending.md shows.
+declare module '../../src/jsx-runtime.js' {
+  namespace JSX {
+    interface IntrinsicElements {
+      sparkline: {
+        data: number[];
+        color?: string;
+        style?: Style;
+      };
+    }
+  }
+}
+
+class SparklineNode extends Node {
+  constructor(props: Record<string, unknown>, app: never) {
+    super('sparkline', props, app);
+  }
+
+  paint(ctx: unknown): void {
+    super.paint(ctx);
+    // the subclass surface docs/extending.md promises
+    const _rect: number = this.abs.width;
+    const _kind: string = this.kind;
+    const _destroyed: boolean = this.destroyed;
+    void this.style;
+    void this.theme;
+    void this.props.data;
+    void this.app;
+    this.invalidate(false, this.abs, 'content');
+  }
+}
+
+registerElement('sparkline', {
+  create: (props, app) => new SparklineNode(props, app as never),
+  drawn: true,
+  semanticNames: ['data', 'color'],
+  childrenAllowed: false,
+});
+
+// the minimum: a create() and nothing else
+registerElement('minimal', {
+  create: (props, app) => new BoxNode(props, app),
+});
+
+const _removed: boolean = unregisterElement('minimal');
+const _registered: string[] = registeredElements();
+const _built: string[] = hostTypes();
+const _known: string[] = knownElements();
+const _drawn: string[] = drawnKinds();
+
+// the style vocabulary, from outside
+const _isStyle: boolean = isStyleProp('color');
+const _flat = flattenStyle([{ width: 10 }, { height: 20 }]);
+const _w: number | string | undefined = _flat.width;
+const styles = createStyles({ chart: { width: 120, height: 40 } });
+void resolveTokens(styles.chart, { accent: '#c0392b' });
+
+function Chart() {
+  return (
+    <box style={styles.chart}>
+      <sparkline data={[1, 4, 2, 8]} color="#c0392b" style={{ flexGrow: 1 }} />
+    </box>
+  );
+}
+
+// @ts-expect-error — `data` is required on <sparkline>
+const _missingData = <sparkline color="red" />;
+// @ts-expect-error — a create() is not optional
+registerElement('broken', { drawn: true });
+
+export default Chart;

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -180,6 +180,7 @@ const ORDER = [
   'components.md',
   'events.md',
   'typescript.md',
+  'extending.md',
   'testing.md',
   'remote.md',
   'security.md',


### PR DESCRIPTION
Closes #125.

`createInstance`'s `switch` keeps the built-ins — they are code, not data — and its default branch now consults a registry before giving up. The built-in path is unchanged and pays nothing.

```js
import { registerElement } from 'react-x11/host';
import { Node } from 'react-x11/node';

class SparklineNode extends Node {
  constructor(props, app) { super('sparkline', props, app); }
  paint(ctx) { super.paint(ctx); /* draw this.props.data inside this.abs */ }
}

registerElement('sparkline', {
  create: (props, app) => new SparklineNode(props, app),
  semanticNames: ['data', 'color'],
});
```

## The definition, and why it carries more than `create`

The two non-obvious fields are the ones the issue predicted would bite:

- **`drawn`** (default true) joins `DRAWN_KINDS`, which is what `paintOrder()` filters on. A kind missing from it lays out correctly, reports a sensible `abs`, and never appears on screen — **with no error anywhere**. That is the single most confusing way for a custom element to fail, so it is a default rather than a step to remember. `drawn: false` is the `GlAreaNode` shape: a node owning a real child X window.
- **`semanticNames`** exempts the element's own prop names from the DEV assertion that catches `<box width={10} />`. Without it, an element whose vocabulary overlaps the style vocabulary (`width`, `color`, `fontSize`) **throws in development and works in production** — the dev/prod split the issue calls out. `<window width>` is the built-in precedent.

Also `childrenAllowed: false` (rejects children by name rather than laying out something that cannot paint) and `override` (off by default — two packages claiming one name is a conflict worth hearing about).

`create()`'s return value is validated at the source: not a `Node`, or a `kind` that isn't the registered name, and you get a message naming the element instead of a failure in the commit phase.

## Subpath exports

| subpath | contents |
| --- | --- |
| `react-x11/host` | `registerElement`, `unregisterElement`, `registeredElements`, `hostTypes`, `knownElements`, `drawnKinds` |
| `react-x11/node` | `Node` plus the built-in node classes |
| `react-x11/style` | `createStyles`, `flattenStyle`, `isStyleProp`, `resolveTokens`, … |
| `react-x11/ntk` | ntk itself, re-exported |

`react-x11/keysyms` already existed. The introspection helpers return copies — the vocabulary grows through `registerElement`, not by mutating an exported array.

**`react-x11/ntk` matters more than it looks.** An extension that declares its own `ntk` dependency can end up with a second copy in the process: two Yoga instances and two font caches, and a node built against one cannot be painted by the other — which presents as a layout bug, not a dependency bug.

## Implementation notes for review

- `nodes.js` now exports `DRAWN_KINDS` and a `CUSTOM_SEMANTIC_NAMES` map, and `registry.js` writes into both. That direction — rather than `nodes.js` importing the registry — is what keeps the two files acyclic; `Node.semanticNames` reads the map, so a registered element gets the exemption **without** subclassing the getter.
- `childrenAllowed: false` is carried as a flag on the node instance, checked by `Node.insertBefore`. One property read on a hot path, and `nodes.js` still needs no import from the registry.
- The unknown-element error now lists registered names alongside the built-ins and points at `registerElement`/docs.

## Docs and tests

- **`docs/extending.md`** (new, linked from the docs index and slotted into the website sidebar after `typescript.md`): the definition fields, the node contract written down (`paint`/`applyProps`/`hitTest`/`destroySubtree`, what to read, how to invalidate with a bound), the own-an-X-window pattern with `GlAreaNode` as the worked example, the subpath table, and the JSX module augmentation.
- **`test/register-element.test.js`** — 10 tests, all importing through the published subpaths (a test reaching into `src/` would prove nothing): mounts/lays out/paints, `semanticNames` exempting `color` *and* the assertion still firing for an element that didn't declare it, prop updates through the commit path, `drawn: false` staying out of paint order, `childrenAllowed`, name validation and clash detection, bad `create()` returns, the unknown-element message, and copy-not-live-set introspection.
- **`test/types/extend.tsx`** — compiles the module-augmentation story from the docs, including two `@ts-expect-error` cases, so it stays true as the declarations move.

`npm test` 352 pass · lint clean · `npm run typecheck` · `npm run docs:build` green.

Not screenshot-eligible: no pixel changes.
