### PR TITLE
feat!: retire the legacy render()/unmountComponentAtNode() pair

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,8 @@ no override-redirect staging (issue #4).
 
 ## Layout
 
-- `src/index.js` — public entry (`render`, `createRoot`,
-  `unmountComponentAtNode`).
+- `src/index.js` — public entry (`createRoot`; the legacy
+  `render`/`unmountComponentAtNode` pair was retired in #114).
 - `src/Reconciler.js` — react-reconciler host config + render entry points.
   Written against react-reconciler 0.33 (React 19). If you upgrade
   react-reconciler, expect host config contract changes; the smoke test is

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@
 ## Entry points
 
 ```js
-import { createRoot, render, unmountComponentAtNode, Select } from 'react-x11';
+import { createRoot, Select } from 'react-x11';
 ```
 
 ### `await createRoot(options?)` → `{ app, render(element), unmount() }`
@@ -106,12 +106,9 @@ pixmap, glyph set and font is invalidated with the connection. Tear the
 root down and build a new one; nothing survives, and react-x11 promises
 nothing more than telling you it happened.
 
-### `render(element, callback?, container?)`
-
-Legacy entry point. Without `container` it connects first and returns a
-promise. Mounts/updates are flushed synchronously
-(`updateContainerSync` + `flushSyncWork`); painting happens a frame later
-on ntk's frame clock.
+`root.render(element, callback?)` flushes the mount or update synchronously
+(`updateContainerSync` + `flushSyncWork`); painting happens a frame later on
+ntk's frame clock.
 
 ## Environment variables
 

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -439,10 +439,10 @@ without an install. If it passes, the fastest real check is a render:
 
 ```jsx
 // probe.jsx — needs a display: run under $DISPLAY, or `xvfb-run -a`
-import ReactX11 from 'react-x11';
+import { createRoot } from 'react-x11';
 import { TheThing } from 'the-package';
 
-await ReactX11.render(
+(await createRoot()).render(
   <window width={300} height={200} title="probe">
     <box style={{ flexGrow: 1 }}>
       <TheThing />

--- a/docs/ecosystem/data-fetching.md
+++ b/docs/ecosystem/data-fetching.md
@@ -62,7 +62,7 @@ export const windowFocusProps = {
 
 ```jsx
 import React from 'react';
-import ReactX11 from 'react-x11';
+import { createRoot } from 'react-x11';
 import {
   QueryClient,
   QueryClientProvider,
@@ -80,7 +80,7 @@ function Weather() {
   return <text>{status === 'pending' ? 'loading…' : data}</text>;
 }
 
-ReactX11.render(
+(await createRoot()).render(
   <window width={360} height={120} title="weather" {...windowFocusProps}>
     <QueryClientProvider client={client}>
       <Weather />
@@ -132,7 +132,7 @@ so hang it off `<window onFocus>`:
 
 ```jsx
 import React from 'react';
-import ReactX11 from 'react-x11';
+import { createRoot } from 'react-x11';
 import useSWR, { mutate } from 'swr';
 
 const fetcher = (url) => fetch(url).then((r) => r.text());
@@ -142,7 +142,7 @@ function Weather() {
   return <text>{data ?? 'loading…'}</text>;
 }
 
-ReactX11.render(
+(await createRoot()).render(
   // the adapter is this one prop: revalidate everything on window focus
   <window
     width={360}

--- a/docs/ecosystem/dev-tooling.md
+++ b/docs/ecosystem/dev-tooling.md
@@ -95,10 +95,10 @@ mounted window survive reloads, and only app modules re-execute.
 ```js
 // Minimal hot entry for an app (mirrors examples/tasks-hot.jsx):
 import { performReactRefresh } from './examples/hmr-refresh.js'; // FIRST import
-import ReactX11 from 'react-x11'; // safe now: the global hook is patched
+import { createRoot } from 'react-x11'; // safe now: the global hook is patched
 import { App } from './app-ui.jsx'; // hot: lives in the reloadable graph
 
-ReactX11.render(<App />);
+(await createRoot()).render(<App />);
 import.meta.hot?.accept('./app-ui.jsx', () => {
   performReactRefresh();
 });
@@ -208,7 +208,7 @@ under a custom renderer.
 ```jsx
 import React from 'react';
 import whyDidYouRender from '@welldone-software/why-did-you-render';
-import ReactX11 from 'react-x11';
+import { createRoot } from 'react-x11';
 
 whyDidYouRender(React); // before anything renders
 
@@ -224,7 +224,7 @@ const App = () => (
   </window>
 );
 
-ReactX11.render(<App />);
+(await createRoot()).render(<App />);
 // terminal: "Label … props.user: different objects that are equal by value."
 ```
 

--- a/docs/ecosystem/routing.md
+++ b/docs/ecosystem/routing.md
@@ -23,7 +23,7 @@ non-browser one, so there is no adapter to write.
 
 ```jsx
 import React from 'react';
-import ReactX11 from 'react-x11';
+import { createRoot } from 'react-x11';
 import { Router, Route, Switch } from 'wouter';
 import { memoryLocation } from 'wouter/memory-location';
 
@@ -60,7 +60,7 @@ const App = () => (
   </window>
 );
 
-ReactX11.render(<App />);
+(await createRoot()).render(<App />);
 ```
 
 - **Always mount the memory hook at the top.** A `<Route>` outside a
@@ -90,7 +90,7 @@ entry points, and the browser entry points are exactly what fails.
 
 ```jsx
 import React from 'react';
-import ReactX11 from 'react-x11';
+import { createRoot } from 'react-x11';
 import {
   MemoryRouter,
   Routes,
@@ -116,7 +116,7 @@ function About() {
   return <text>{`about page (${loc.pathname})`}</text>;
 }
 
-ReactX11.render(
+(await createRoot()).render(
   <window width={300} height={200} title="routed">
     <box style={{ flexGrow: 1 }}>
       <MemoryRouter initialEntries={['/']}>

--- a/docs/ecosystem/state.md
+++ b/docs/ecosystem/state.md
@@ -21,7 +21,7 @@ default recommendation for app state: zero DOM, zero adapter.
 
 ```jsx
 import React from 'react';
-import ReactX11 from 'react-x11';
+import { createRoot } from 'react-x11';
 import { create } from 'zustand';
 
 const useStore = create((set) => ({
@@ -40,7 +40,7 @@ function App() {
   );
 }
 
-ReactX11.render(<App />);
+(await createRoot()).render(<App />);
 ```
 
 Because the store is module-level rather than tree-level, several windows
@@ -67,7 +67,7 @@ background work call `store.set(...)`. One store shared by several
 
 ```jsx
 import React from 'react';
-import ReactX11 from 'react-x11';
+import { createRoot } from 'react-x11';
 import { atom, createStore, Provider, useAtomValue } from 'jotai';
 
 const countAtom = atom(0);
@@ -83,7 +83,7 @@ function App() {
   );
 }
 
-ReactX11.render(
+(await createRoot()).render(
   <Provider store={store}>
     <App />
   </Provider>,
@@ -111,7 +111,7 @@ imperatively.
 
 ```jsx
 import React from 'react';
-import ReactX11 from 'react-x11';
+import { createRoot } from 'react-x11';
 import { proxy, useSnapshot } from 'valtio';
 
 const state = proxy({ n: 0, log: [] });
@@ -133,7 +133,7 @@ function App() {
   );
 }
 
-ReactX11.render(<App />);
+(await createRoot()).render(<App />);
 ```
 
 - Valtio 2 no longer deep-clones snapshots the way v1 did in dev; read the
@@ -157,7 +157,7 @@ level can outlive any single `<window>` and drive several of them.
 
 ```jsx
 import React from 'react';
-import ReactX11 from 'react-x11';
+import { createRoot } from 'react-x11';
 import { createMachine, createActor } from 'xstate';
 import { useSelector } from '@xstate/react';
 
@@ -185,7 +185,7 @@ function App() {
   );
 }
 
-ReactX11.render(<App />);
+(await createRoot()).render(<App />);
 ```
 
 - `useMachine(machine)` inside a component works too and gives you a
@@ -207,7 +207,7 @@ middleware included.
 
 ```jsx
 import React from 'react';
-import ReactX11 from 'react-x11';
+import { createRoot } from 'react-x11';
 import { configureStore, createSlice } from '@reduxjs/toolkit';
 import { Provider, useSelector, useDispatch } from 'react-redux';
 
@@ -232,7 +232,7 @@ function Counter() {
   );
 }
 
-ReactX11.render(
+(await createRoot()).render(
   <Provider store={store}>
     <window width={220} height={120} title="redux">
       <Counter />
@@ -268,7 +268,7 @@ as zustand middleware (`zustand/middleware/immer`).
 
 ```jsx
 import React from 'react';
-import ReactX11 from 'react-x11';
+import { createRoot } from 'react-x11';
 import { produce } from 'immer';
 
 function App() {
@@ -295,7 +295,7 @@ function App() {
   );
 }
 
-ReactX11.render(<App />);
+(await createRoot()).render(<App />);
 ```
 
 Nothing to adapt. Useful directly with `useState`/`useReducer` for the
@@ -327,7 +327,7 @@ re-render the tree.
 // prerequisite: npm install react-dom  (satisfies mobx-react-lite's import;
 // react-x11 does not render through it)
 import React from 'react';
-import ReactX11 from 'react-x11';
+import { createRoot } from 'react-x11';
 import { makeAutoObservable, runInAction } from 'mobx';
 import { observer } from 'mobx-react-lite';
 
@@ -350,7 +350,7 @@ const App = observer(function App() {
   );
 });
 
-ReactX11.render(<App />);
+(await createRoot()).render(<App />);
 ```
 
 - Without react-dom the app fails at import time, not render time; the error

--- a/docs/ecosystem/testing.md
+++ b/docs/ecosystem/testing.md
@@ -22,22 +22,24 @@ needs to hold the pieces directly.
 ```jsx
 // helpers/harness.jsx
 import React from 'react';
-import ReactX11 from 'react-x11';
-import { createClient } from 'ntk';
+import { createRoot } from 'react-x11';
 import xserver from 'x11/lib/xserver/index.js';
 
-export async function createHeadlessApp() {
+export async function createHeadlessRoot() {
   const server = xserver.createServer({ width: 640, height: 480 });
   const [serverEnd, clientEnd] = xserver.createStreamPair();
   server.addClientStream(serverEnd);
-  return await createClient({ stream: clientEnd });
+  // `stream` reaches a server that is not on the other end of $DISPLAY,
+  // which is the whole trick; the root owns the connection and closes it
+  // on unmount.
+  return await createRoot({ stream: clientEnd });
 }
 
-/** ReactX11.render's callback hands back the ntk window instance. */
-export const render = (element, app) =>
-  new Promise((resolve) =>
-    ReactX11.render(element, (wnd) => resolve(wnd), app),
-  );
+/** The render callback hands back the ntk window instance. `root.render`
+ * is synchronous, so this stays a plain helper — only obtaining the root
+ * is async, and that happens once. */
+export const render = (root, element) =>
+  new Promise((resolve) => root.render(element, (wnd) => resolve(wnd)));
 
 export const tick = () => new Promise((r) => setImmediate(r));
 ```
@@ -45,15 +47,15 @@ export const tick = () => new Promise((r) => setImmediate(r));
 ```jsx
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { createHeadlessApp, render, tick } from './helpers/harness.jsx';
+import { createHeadlessRoot, render, tick } from './helpers/harness.jsx';
 
 test('paints a box', async () => {
-  const app = await createHeadlessApp();
+  const root = await createHeadlessRoot();
   const wnd = await render(
+    root,
     <window width={320} height={240} title="probe">
       <box style={{ flexGrow: 1, backgroundColor: '#204080' }} />
     </window>,
-    app,
   );
   await tick(); // layout runs on the frame clock, after the commit
 
@@ -66,7 +68,7 @@ test('paints a box', async () => {
     height: 240,
   });
 
-  ReactX11.unmountComponentAtNode(app);
+  await root.unmount();
 });
 ```
 
@@ -97,10 +99,9 @@ export function textOf(node) {
 
 If you want to run without any X server at all — faster, and enough for most
 component tests — write a small mock ntk app that records canvas operations
-instead of painting them, and pass it as the third argument to
-`ReactX11.render`. That is what the renderer's unit tests do; there is no
-mock published in the package, so it is yours to write and yours to keep
-minimal.
+instead of painting them, and hand it to `createRoot({ app })`. That is what
+the renderer's unit tests do; there is no mock published in the package, so
+it is yours to write and yours to keep minimal.
 
 ## Driving events {#driving-events}
 
@@ -112,13 +113,13 @@ actions.
 
 ```jsx
 test('a synthetic click reaches the handler', async () => {
-  const app = await createHeadlessApp();
+  const root = await createHeadlessRoot();
   let clicks = 0;
   const wnd = await render(
+    root,
     <window width={200} height={100}>
       <box style={{ flexGrow: 1 }} onClick={() => (clicks += 1)} />
     </window>,
-    app,
   );
   await tick();
 
@@ -127,7 +128,7 @@ test('a synthetic click reaches the handler', async () => {
   await tick();
 
   assert.equal(clicks, 1);
-  ReactX11.unmountComponentAtNode(app);
+  await root.unmount();
 });
 ```
 
@@ -329,13 +330,13 @@ await fc.assert(
     fc.array(node, { maxLength: 4 }),
     fc.array(node, { maxLength: 4 }),
     async (a, b) => {
-      const app1 = await createHeadlessApp();
-      const w1 = await render(win(a), app1);
+      const root1 = await createHeadlessRoot();
+      const w1 = await render(root1, win(a));
       await tick();
-      await render(win(b), app1); // update path
+      await render(root1, win(b)); // update path
       await tick();
-      const app2 = await createHeadlessApp();
-      const w2 = await render(win(b), app2); // fresh-mount path
+      const root2 = await createHeadlessRoot();
+      const w2 = await render(root2, win(b)); // fresh-mount path
       await tick();
       assert.deepStrictEqual(snap(w1._reactX11Node), snap(w2._reactX11Node));
     },
@@ -387,12 +388,12 @@ test('toast auto-dismisses', async () => {
     toFake: ['setTimeout', 'clearTimeout', 'Date'],
   });
   try {
-    const app = await createHeadlessApp();
+    const root = await createHeadlessRoot();
     const wnd = await render(
+      root,
       <window width={100} height={50}>
         <Toast />
       </window>,
-      app,
     );
     await tick(); // mount + passive effect
     clock.tick(1000); // fires the timeout synchronously

--- a/scripts/bench/protocol.js
+++ b/scripts/bench/protocol.js
@@ -26,7 +26,7 @@ import { createClient, StaticFontSource } from 'ntk';
 import { compositePixels, countStream } from './xcount.js';
 
 process.env.REACT_X11_NO_AUTORUN = '1';
-const ReactX11 = (await import('../../src/index.js')).default;
+const { createRoot } = await import('../../src/index.js');
 
 const require = createRequire(import.meta.url);
 const fontDir = join(
@@ -65,9 +65,10 @@ const settle = (app) =>
  * an interaction rather than a mount. */
 async function measure(name, fn) {
   const { app, stats } = await connect();
+  const x11Root = await createRoot({ app });
   await settle(app);
   if (typeof fn !== 'function') {
-    await fn.prepare(app);
+    await fn.prepare(app, x11Root);
     await settle(app);
     fn = fn.run;
   }
@@ -88,7 +89,7 @@ async function measure(name, fn) {
   };
   process.on('uncaughtException', onUncaught);
   try {
-    await fn(app);
+    await fn(app, x11Root);
   } catch (err) {
     failure ??= err;
   } finally {
@@ -216,9 +217,9 @@ function iconWall(count, size = 20) {
 
 /** Mount a tree, settle it, and hand back the root node plus a frame pump.
  * The mount is what `prepare` pays for, so `run` measures only repaints. */
-async function mounted(app, element) {
+async function mounted(x11Root, element) {
   const instance = await new Promise((resolve) =>
-    ReactX11.render(element, resolve, app),
+    x11Root.render(element, resolve),
   );
   const root = instance._reactX11Node;
   const frame = () => {
@@ -232,14 +233,14 @@ async function mounted(app, element) {
 const SCENARIOS = [
   [
     'text: paragraph, no clip',
-    async (app) => {
+    async (app, x11Root) => {
       const ctx = pixmapCtx(app);
       paragraphLayout(app).draw(ctx, 5, 5);
     },
   ],
   [
     'text: paragraph, inside a rect clip',
-    async (app) => {
+    async (app, x11Root) => {
       const ctx = pixmapCtx(app);
       const layout = paragraphLayout(app);
       ctx.save();
@@ -257,7 +258,7 @@ const SCENARIOS = [
     // to allocate a full-surface a8 pixmap, rasterize into it and Composite
     // the whole surface *per clip*, so this scenario is where that shows up.
     'clips: 40 nested rect clips with text',
-    async (app) => {
+    async (app, x11Root) => {
       const ctx = pixmapCtx(app);
       const layout = paragraphLayout(app);
       ctx.save();
@@ -277,7 +278,7 @@ const SCENARIOS = [
   ],
   [
     'shapes: 50 filled rounded boxes',
-    async (app) => {
+    async (app, x11Root) => {
       const ctx = pixmapCtx(app);
       for (let i = 0; i < 50; i++) {
         ctx.fillStyle = i % 2 ? '#2980b9' : '#dfe6e9';
@@ -295,9 +296,9 @@ const SCENARIOS = [
   ],
   [
     'mount: window with 40 boxes and labels',
-    async (app) => {
+    async (app, x11Root) => {
       await new Promise((resolve) =>
-        ReactX11.render(
+        x11Root.render(
           React.createElement(
             'window',
             { width: W, height: H, style: { backgroundColor: '#f5f6fa' } },
@@ -326,7 +327,6 @@ const SCENARIOS = [
             ),
           ),
           resolve,
-          app,
         ),
       );
       await new Promise((r) => setImmediate(r));
@@ -350,9 +350,9 @@ const SCENARIOS = [
         root.flush();
       };
       return {
-        prepare: async (app) => {
+        prepare: async (app, x11Root) => {
           const instance = await new Promise((resolve) =>
-            ReactX11.render(
+            x11Root.render(
               React.createElement(
                 'window',
                 { width: W, height: H, style: { backgroundColor: '#f5f6fa' } },
@@ -382,7 +382,6 @@ const SCENARIOS = [
                 ),
               ),
               resolve,
-              app,
             ),
           );
           root = instance._reactX11Node;
@@ -413,8 +412,8 @@ const SCENARIOS = [
     (() => {
       let ctl;
       return {
-        prepare: async (app) => {
-          ctl = await mounted(app, iconWall(100));
+        prepare: async (app, x11Root) => {
+          ctl = await mounted(x11Root, iconWall(100));
         },
         run: async (app) => {
           // what an expose or a theme change does: unbounded damage
@@ -434,8 +433,8 @@ const SCENARIOS = [
     (() => {
       let ctl;
       return {
-        prepare: async (app) => {
-          ctl = await mounted(app, iconWall(100));
+        prepare: async (app, x11Root) => {
+          ctl = await mounted(x11Root, iconWall(100));
         },
         run: async (app) => {
           // a paint-only change on an ancestor: damage is that node's bounds,

--- a/scripts/check-stress.jsx
+++ b/scripts/check-stress.jsx
@@ -30,7 +30,7 @@ import xserver from 'x11/lib/xserver/index.js';
 import { createClient, StaticFontSource } from 'ntk';
 
 process.env.REACT_X11_NO_AUTORUN = '1';
-const ReactX11 = (await import('../src/index.js')).default;
+const { createRoot } = await import('../src/index.js');
 const App = (await import('../examples/stress/index.jsx')).default;
 const { watchFrames } = await import('../examples/stress/perf.js');
 
@@ -89,6 +89,7 @@ const server = xserver.createServer({ width: W, height: H });
 const [serverEnd, clientEnd] = xserver.createStreamPair();
 server.addClientStream(serverEnd);
 const app = await createClient({ stream: clientEnd, fontSource: fontSource() });
+const x11Root = await createRoot({ app });
 
 const created = [];
 const createWindow = app.createWindow.bind(app);
@@ -99,7 +100,7 @@ app.createWindow = (attributes) => {
 };
 
 const wnd = await new Promise((resolve) =>
-  ReactX11.render(<App width={W} height={H} />, () => resolve(created[0]), app),
+  x11Root.render(<App width={W} height={H} />, () => resolve(created[0])),
 );
 await sleep(400);
 const root = wnd._reactX11Node;

--- a/scripts/screenshots-framed.jsx
+++ b/scripts/screenshots-framed.jsx
@@ -22,7 +22,7 @@ import { dirname, join } from 'node:path';
 import React from 'react';
 
 process.env.REACT_X11_NO_AUTORUN = '1';
-const ReactX11 = (await import('../src/index.js')).default;
+const { createRoot } = await import('../src/index.js');
 
 const outDir =
   process.env.SHOT_DIR ??
@@ -140,6 +140,7 @@ if (!process.env.DISPLAY) {
 // trips are still in flight can hang (see AGENTS.md), and reconnecting per
 // scene is slower for no benefit.
 const app = await createClient();
+const x11Root = await createRoot({ app });
 const created = [];
 const origCreate = app.createWindow.bind(app);
 app.createWindow = (attrs) => {
@@ -157,7 +158,7 @@ for (const name of scenes) {
   created.length = 0;
 
   await new Promise((resolve) =>
-    ReactX11.render(React.createElement(App), resolve, app),
+    x11Root.render(React.createElement(App), resolve),
   );
   await sleep(400); // map + WM reparent + first paint
 
@@ -174,7 +175,7 @@ for (const name of scenes) {
         : '(NO frame — no reparenting WM running?)'),
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
   await settle();
   await sleep(150);
 }

--- a/scripts/screenshots.jsx
+++ b/scripts/screenshots.jsx
@@ -40,7 +40,7 @@ import xserver from 'x11/lib/xserver/index.js';
 import { createClient, StaticFontSource } from 'ntk';
 
 process.env.REACT_X11_NO_AUTORUN = '1';
-const ReactX11 = (await import('../src/index.js')).default;
+const { createRoot } = await import('../src/index.js');
 const { editMenuGeometry } = await import('../src/editmenu.js');
 const Dashboard = (await import('../examples/dashboard.jsx')).default;
 const Tasks = (await import('../examples/tasks.jsx')).default;
@@ -153,9 +153,9 @@ async function makeApp() {
   return app;
 }
 
-const render = (element, app) =>
+const render = (element, x11Root) =>
   new Promise((resolve) =>
-    ReactX11.render(element, () => resolve(app.created[0]), app),
+    x11Root.render(element, () => resolve(x11Root.app.created[0])),
   );
 
 /** Depth-first search over the retained node tree of a realized window. */
@@ -262,9 +262,10 @@ async function shotOver(wnd, popup, x, y, name) {
 
 async function scene(fn) {
   const app = await makeApp();
+  const x11Root = await createRoot({ app });
   try {
-    await fn(app);
-    ReactX11.unmountComponentAtNode(app);
+    await fn(app, x11Root);
+    await x11Root.unmount();
   } finally {
     await app.close();
   }
@@ -272,8 +273,8 @@ async function scene(fn) {
 
 // --- scenes ----------------------------------------------------------------
 
-await scene(async (app) => {
-  const wnd = await render(React.createElement(Dashboard), app);
+await scene(async (app, x11Root) => {
+  const wnd = await render(React.createElement(Dashboard), x11Root);
   await sleep(100);
   const plus = labeled(wnd, '+1');
   clickNode(wnd, plus);
@@ -283,8 +284,8 @@ await scene(async (app) => {
   await shot(wnd, 'dashboard');
 });
 
-await scene(async (app) => {
-  const wnd = await render(React.createElement(Tasks), app);
+await scene(async (app, x11Root) => {
+  const wnd = await render(React.createElement(Tasks), x11Root);
   await sleep(100);
   const input = findNode(wnd._reactX11Node, (n) => n.kind === 'textinput');
   clickNode(wnd, input);
@@ -292,8 +293,8 @@ await scene(async (app) => {
   await shot(wnd, 'tasks');
 });
 
-await scene(async (app) => {
-  const wnd = await render(React.createElement(Form), app);
+await scene(async (app, x11Root) => {
+  const wnd = await render(React.createElement(Form), x11Root);
   await sleep(100);
   const input = findNode(wnd._reactX11Node, (n) => n.kind === 'textinput');
   clickNode(wnd, input);
@@ -323,7 +324,7 @@ await scene(async (app) => {
   await shot(reopened, 'select-menu');
 });
 
-await scene(async (app) => {
+await scene(async (app, x11Root) => {
   const wnd = await render(
     <window width={420} height={260} style={{ backgroundColor: '#f5f6fa' }}>
       <box style={{ flexGrow: 1, padding: 16, gap: 12 }}>
@@ -364,7 +365,7 @@ await scene(async (app) => {
         </box>
       </box>
     </window>,
-    app,
+    x11Root,
   );
   await sleep(100);
   // click right after "Hello," so the caret shows mid-text
@@ -376,7 +377,7 @@ await scene(async (app) => {
 
 // The built-in edit menu, over the field it belongs to — the point being
 // that the selection survives the right-click and the menu acts on it.
-await scene(async (app) => {
+await scene(async (app, x11Root) => {
   const wnd = await render(
     <window width={420} height={230} style={{ backgroundColor: '#f5f6fa' }}>
       <box style={{ flexGrow: 1, padding: 16, gap: 10 }}>
@@ -396,7 +397,7 @@ await scene(async (app) => {
         />
       </box>
     </window>,
-    app,
+    x11Root,
   );
   await sleep(100);
   const input = findNode(wnd._reactX11Node, (n) => n.kind === 'textinput');

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -552,9 +552,6 @@ function loadIntegrations() {
   return integrations;
 }
 
-const roots = new Map();
-let cachedNtkApp = null;
-
 /**
  * Open a connection this process owns. The wrapper is here for one reason:
  * to say what is wrong when there is no server, which is the first thing
@@ -571,13 +568,6 @@ async function connect(options) {
         err.message,
     );
   }
-}
-
-async function connectApp() {
-  if (cachedNtkApp) return cachedNtkApp;
-  cachedNtkApp = await connect({});
-  registerApp(cachedNtkApp);
-  return cachedNtkApp;
 }
 
 /** An ntk App, told apart from an options bag by what only an App has. */
@@ -614,53 +604,6 @@ function watchConnection(app, onDisconnect, deliberate) {
   app.X.on('error', (err) => {
     if (err?.majorOpcode === undefined) fire('error', err);
   });
-}
-
-function renderIntoContainer(element, container, callback) {
-  let root = roots.get(container);
-  if (!root) {
-    root = Renderer.createContainer(
-      container,
-      ConcurrentRoot,
-      null,
-      false,
-      null,
-      '',
-      (error) => console.error('react-x11: uncaught error', error),
-      (error) => console.error('react-x11: caught error', error),
-      (error) => console.error('react-x11: recoverable error', error),
-      null,
-    );
-    roots.set(container, root);
-  }
-
-  Renderer.updateContainerSync(element, root, null, () => {
-    const publicInstance = Renderer.getPublicRootInstance(root);
-    if (callback) {
-      callback(publicInstance, container);
-    }
-  });
-  Renderer.flushSyncWork();
-}
-
-/**
- * Legacy entry point. Without a container it connects to the X server
- * (returns a promise in that case).
- */
-export function render(element, callback, container) {
-  const pending = loadIntegrations();
-  if (!container) {
-    return Promise.resolve(pending)
-      .then(connectApp)
-      .then((app) => renderIntoContainer(element, app, callback));
-  }
-  // synchronous unless an integration has to be installed first
-  if (pending) {
-    return pending.then(() =>
-      renderIntoContainer(element, container, callback),
-    );
-  }
-  return renderIntoContainer(element, container, callback);
 }
 
 /**
@@ -747,14 +690,4 @@ export async function createRoot(options = {}) {
       }
     },
   };
-}
-
-export function unmountComponentAtNode(container) {
-  const root = roots.get(container);
-  if (root) {
-    Renderer.updateContainerSync(null, root, null, () => {
-      roots.delete(container);
-    });
-    Renderer.flushSyncWork();
-  }
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -107,29 +107,11 @@ export interface Root {
  */
 export function createRoot(options?: RootOptions): Promise<Root>;
 
-/**
- * Legacy entry point. Without a container it connects to the X server and
- * resolves once mounted; with one it mounts synchronously.
- */
-export function render(
-  element: ReactNode,
-  callback?: () => void,
-): Promise<void>;
-export function render(
-  element: ReactNode,
-  callback: (() => void) | undefined,
-  container: NtkApp,
-): void;
-
-export function unmountComponentAtNode(container: NtkApp): void;
-
 /** The react-reconciler instance. Escape hatch; not a stable API. */
 export const Renderer: any;
 
 declare const ReactX11: {
-  render: typeof render;
   createRoot: typeof createRoot;
-  unmountComponentAtNode: typeof unmountComponentAtNode;
 };
 export default ReactX11;
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,4 @@
-export {
-  render,
-  createRoot,
-  unmountComponentAtNode,
-  Renderer,
-} from './Reconciler.js';
+export { createRoot, Renderer } from './Reconciler.js';
 export { createStyles, flattenStyle } from './styles.js';
 export { windowIdOf, useWindowId } from './windowid.js';
 export {
@@ -31,6 +26,6 @@ export {
   Canvas3D,
 } from './components/index.js';
 
-import { render, createRoot, unmountComponentAtNode } from './Reconciler.js';
+import { createRoot } from './Reconciler.js';
 
-export default { render, createRoot, unmountComponentAtNode };
+export default { createRoot };

--- a/test/click-to-component.test.js
+++ b/test/click-to-component.test.js
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import React from 'react';
-import ReactX11 from '../src/index.js';
+import { createRoot } from '../src/index.js';
 import xserver from 'x11/lib/xserver/index.js';
 import { createClient, StaticFontSource } from 'ntk';
 
@@ -45,15 +45,15 @@ test('Alt+Click resolves the fiber to its JSX call site and logs it', async () =
   clickToComponent.install();
 
   const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
   const instance = await new Promise((resolve) => {
-    ReactX11.render(
+    x11Root.render(
       React.createElement(
         'window',
         { width: 200, height: 200 },
         React.createElement(Leaf),
       ),
       (i) => resolve(i),
-      app,
     );
   });
 

--- a/test/create-root.test.js
+++ b/test/create-root.test.js
@@ -172,3 +172,39 @@ test('error handlers belong to the root, not the module', async () => {
   assert.deepStrictEqual(caught, ['boom']);
   await root.unmount();
 });
+
+test('the legacy render()/unmountComponentAtNode() pair is gone', async () => {
+  // Retired with the module-level connection cache they depended on (#114).
+  // Asserted rather than assumed: they were the reason two roots could
+  // share one fiber tree, and a re-export added back by reflex would bring
+  // the sharing back with it.
+  const mod = await import('../src/index.js');
+  assert.strictEqual(mod.render, undefined);
+  assert.strictEqual(mod.unmountComponentAtNode, undefined);
+  assert.deepStrictEqual(Object.keys(mod.default), ['createRoot']);
+});
+
+test('a root that borrows a connection can outlive another root on it', async () => {
+  // What the shared cache made impossible: `roots` was keyed by the
+  // connection, so a second root on one app was the *same* fiber root and
+  // unmounting either took down both trees.
+  const app = createMockApp();
+  const a = await createRoot({ app });
+  const b = await createRoot({ app });
+  a.render(win('a'));
+  b.render(win('b'));
+  await tick();
+  assert.strictEqual(app.windows.length, 2, 'two independent trees');
+
+  const [first, second] = app.windows;
+  await a.unmount();
+  await tick();
+  assert.ok(
+    first.calls.some(([name]) => name === 'destroy'),
+    "unmounting the first root destroyed the first root's window",
+  );
+  assert.ok(
+    !second.calls.some(([name]) => name === 'destroy'),
+    'and left the second tree standing on the same connection',
+  );
+});

--- a/test/debug-paint.test.js
+++ b/test/debug-paint.test.js
@@ -5,19 +5,18 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
 import React from 'react';
-import ReactX11 from '../src/index.js';
+import { createRoot } from '../src/index.js';
 import { setDebugPaint } from '../src/nodes.js';
 import { createMockApp } from './helpers/mock-app.js';
 
 const h = React.createElement;
 const tick = () => new Promise((resolve) => setImmediate(resolve));
 
-function mount(children, windowProps = {}) {
+async function mount(children, windowProps = {}) {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     h('window', { width: 200, height: 100, ...windowProps }, children),
-    null,
-    app,
   );
   return { app, wnd: app.windows[0], root: app.windows[0]._reactX11Node };
 }
@@ -41,7 +40,7 @@ test('flashing strokes each damage rect, in a colour that rotates', async (t) =>
   setDebugPaint('1');
   t.after(() => setDebugPaint(''));
   const ref = React.createRef();
-  const { wnd } = mount(hoverBox(ref));
+  const { wnd } = await mount(hoverBox(ref));
   await tick(); // mount frame paints (and flashes) once
   wnd.ctx.ops.length = 0;
 
@@ -64,7 +63,7 @@ test('flashing strokes each damage rect, in a colour that rotates', async (t) =>
 
 test('flashing is off (and free) by default', async () => {
   const ref = React.createRef();
-  const { wnd } = mount(hoverBox(ref));
+  const { wnd } = await mount(hoverBox(ref));
   await tick();
   wnd.ctx.ops.length = 0;
   ref.current.setStyleState(':hover', true);
@@ -82,7 +81,7 @@ test('=full warns on a full-window repaint, naming reason and origin', async (t)
   console.warn = (...args) => warnings.push(args.join(' '));
   t.after(() => (console.warn = original));
 
-  const { root } = mount(h('box', { style: { flexGrow: 1 } }));
+  const { root } = await mount(h('box', { style: { flexGrow: 1 } }));
   await tick(); // the mount frame is legitimately full — and says why
   assert.ok(
     warnings.some(
@@ -116,7 +115,7 @@ test('a bounded frame does not warn under =full', async (t) => {
   t.after(() => (console.warn = original));
 
   const ref = React.createRef();
-  mount(
+  await mount(
     h('box', {
       ref,
       style: { width: 80, height: 40, backgroundColor: '#111111' },
@@ -131,7 +130,7 @@ test('a bounded frame does not warn under =full', async (t) => {
 
 test('a frame collects reasons and clears them for the next one', async () => {
   const ref = React.createRef();
-  const { root } = mount(
+  const { root } = await mount(
     h(
       'scrollview',
       { ref, style: { flexGrow: 1 } },
@@ -157,7 +156,7 @@ test('an unknown reason warns in DEV instead of vanishing silently', async (t) =
   const original = console.warn;
   console.warn = (...args) => warnings.push(args.join(' '));
   t.after(() => (console.warn = original));
-  const { root } = mount(h('box', { style: { flexGrow: 1 } }));
+  const { root } = await mount(h('box', { style: { flexGrow: 1 } }));
   await tick();
   root.invalidate(false, null, 'tyop');
   assert.ok(warnings.some((w) => w.includes('unknown reason')));

--- a/test/dirty-rect.test.js
+++ b/test/dirty-rect.test.js
@@ -22,7 +22,7 @@ import React from 'react';
 import xserver from 'x11/lib/xserver/index.js';
 import { createClient, StaticFontSource } from 'ntk';
 
-import ReactX11 from '../src/index.js';
+import { createRoot } from '../src/index.js';
 
 const require = createRequire(import.meta.url);
 const fontDir = join(
@@ -66,8 +66,8 @@ const settled = (app) =>
  * `<window>` but the node itself for everything else, and a node knows its
  * `root`.
  */
-async function mount(app, element) {
-  await new Promise((resolve) => ReactX11.render(element, resolve, app));
+async function mount(x11Root, element) {
+  await new Promise((resolve) => x11Root.render(element, resolve));
   await new Promise((r) => setImmediate(r));
 }
 
@@ -140,9 +140,10 @@ function rowsElement(refs) {
 
 test('a hover state repaints only that row, with identical pixels', async () => {
   const app = await headlessApp();
+  const x11Root = await createRoot({ app });
   try {
     const refs = Array.from({ length: 8 }, () => React.createRef());
-    await mount(app, rowsElement(refs));
+    await mount(x11Root, rowsElement(refs));
     const row = refs[4].current;
     const root = row.root;
 
@@ -177,9 +178,10 @@ test('a hover state repaints only that row, with identical pixels', async () => 
 
 test('two rows far apart are painted as two rects, not the box around them', async () => {
   const app = await headlessApp();
+  const x11Root = await createRoot({ app });
   try {
     const refs = Array.from({ length: 8 }, () => React.createRef());
-    await mount(app, rowsElement(refs));
+    await mount(x11Root, rowsElement(refs));
     const root = refs[0].current.root;
 
     const { damage, rects, diff } = await paintBothWays(app, root, () => {
@@ -213,11 +215,12 @@ test('two rows far apart are painted as two rects, not the box around them', asy
 
 test('the rows between two far-apart changes are not painted', async () => {
   const app = await headlessApp();
+  const x11Root = await createRoot({ app });
   try {
     // The pixel comparisons cannot show this: repainting a row that did not
     // change produces the same pixels, just at a cost. So count the paints.
     const refs = Array.from({ length: 8 }, () => React.createRef());
-    await mount(app, rowsElement(refs));
+    await mount(x11Root, rowsElement(refs));
     const root = refs[0].current.root;
 
     const painted = new Set();
@@ -247,9 +250,10 @@ test('the rows between two far-apart changes are not painted', async () => {
 
 test('two rows near each other collapse into one rect', async () => {
   const app = await headlessApp();
+  const x11Root = await createRoot({ app });
   try {
     const refs = Array.from({ length: 8 }, () => React.createRef());
-    await mount(app, rowsElement(refs));
+    await mount(x11Root, rowsElement(refs));
     const root = refs[0].current.root;
 
     // Adjacent rows: two rects of ~20px separated by a 3px gap describe 40px
@@ -272,12 +276,13 @@ test('two rows near each other collapse into one rect', async () => {
 
 test('overlapping claims are merged, so no node is painted twice', async () => {
   const app = await headlessApp();
+  const x11Root = await createRoot({ app });
   try {
     // Two rects sharing area would put a node in the overlap through two
     // passes. That is invisible for opaque drawing and wrong for anything
     // translucent, which would blend over itself — so they have to merge.
     const refs = Array.from({ length: 8 }, () => React.createRef());
-    await mount(app, rowsElement(refs));
+    await mount(x11Root, rowsElement(refs));
     const root = refs[0].current.root;
 
     root.invalidate(false, { x: 20, y: 20, width: 60, height: 60 });
@@ -294,9 +299,10 @@ test('overlapping claims are merged, so no node is painted twice', async () => {
 
 test('the number of rects stays capped, however many rows change', async () => {
   const app = await headlessApp();
+  const x11Root = await createRoot({ app });
   try {
     const refs = Array.from({ length: 8 }, () => React.createRef());
-    await mount(app, rowsElement(refs));
+    await mount(x11Root, rowsElement(refs));
     const root = refs[0].current.root;
 
     // every other row: more separate regions than the cap allows
@@ -316,9 +322,10 @@ test('the number of rects stays capped, however many rows change', async () => {
 
 test('a claim covering the window gives up the bound entirely', async () => {
   const app = await headlessApp();
+  const x11Root = await createRoot({ app });
   try {
     const refs = Array.from({ length: 8 }, () => React.createRef());
-    await mount(app, rowsElement(refs));
+    await mount(x11Root, rowsElement(refs));
     const root = refs[0].current.root;
 
     const { damage, rects, diff } = await paintBothWays(app, root, () => {
@@ -336,10 +343,11 @@ test('a claim covering the window gives up the bound entirely', async () => {
 
 test('a caret repaint is bounded to the field it blinks in', async () => {
   const app = await headlessApp();
+  const x11Root = await createRoot({ app });
   try {
     const fieldRef = React.createRef();
     await mount(
-      app,
+      x11Root,
       React.createElement(
         'window',
         { width: W, height: H, style: { backgroundColor: '#f5f6fa' } },
@@ -380,6 +388,7 @@ test('a caret repaint is bounded to the field it blinks in', async () => {
 
 test('a subtree is culled by its whole extent, not its own rect', async () => {
   const app = await headlessApp();
+  const x11Root = await createRoot({ app });
   try {
     // `host` is a 10x10 box at the top of the window whose absolutely
     // positioned child is drawn 120px lower, over `target`. Hovering
@@ -390,7 +399,7 @@ test('a subtree is culled by its whole extent, not its own rect', async () => {
     const hostRef = React.createRef();
     const targetRef = React.createRef();
     await mount(
-      app,
+      x11Root,
       React.createElement(
         'window',
         { width: W, height: H, style: { backgroundColor: '#f5f6fa' } },
@@ -470,9 +479,10 @@ test('a subtree is culled by its whole extent, not its own rect', async () => {
 
 test('a layout change is never painted partially', async () => {
   const app = await headlessApp();
+  const x11Root = await createRoot({ app });
   try {
     const refs = Array.from({ length: 8 }, () => React.createRef());
-    await mount(app, rowsElement(refs));
+    await mount(x11Root, rowsElement(refs));
     const row = refs[3].current;
     const root = row.root;
 
@@ -501,7 +511,7 @@ test('a layout change is never painted partially', async () => {
 // change contributes none.
 
 /** Mount `body(state)` under a component and return a state setter. */
-async function mountStateful(app, body) {
+async function mountStateful(x11Root, body) {
   const ref = React.createRef();
   let setState;
   function App() {
@@ -518,7 +528,7 @@ async function mountStateful(app, body) {
     );
   }
   await new Promise((resolve) =>
-    ReactX11.render(React.createElement(App), resolve, app),
+    x11Root.render(React.createElement(App), resolve),
   );
   await new Promise((r) => setImmediate(r));
   return { root: ref.current.root, setState: (v) => setState(v) };
@@ -526,10 +536,11 @@ async function mountStateful(app, body) {
 
 test('a React update bounds the repaint to the row that changed', async () => {
   const app = await headlessApp();
+  const x11Root = await createRoot({ app });
   try {
     // styles built inline every render, the way an app really writes them:
     // all eight rows get a fresh style object, only one differs in value
-    const { root, setState } = await mountStateful(app, (state) =>
+    const { root, setState } = await mountStateful(x11Root, (state) =>
       Array.from({ length: 8 }, (_, i) =>
         React.createElement(
           'box',
@@ -581,6 +592,7 @@ test('a React update bounds the repaint to the row that changed', async () => {
 
 test('a non-style prop the node paints from still damages it', async () => {
   const app = await headlessApp();
+  const x11Root = await createRoot({ app });
   try {
     // Two things change in ONE commit: a row's colour, which bounds the
     // damage to a thin strip, and the field's `placeholder`, which is a prop
@@ -625,7 +637,7 @@ test('a non-style prop the node paints from still damages it', async () => {
       );
     }
     await new Promise((resolve) =>
-      ReactX11.render(React.createElement(App), resolve, app),
+      x11Root.render(React.createElement(App), resolve),
     );
     await new Promise((r) => setImmediate(r));
 
@@ -717,6 +729,7 @@ async function framesDuring(root, app, act, { rounds = 6, delay = 0 } = {}) {
 
 test('a commit that changes nothing visible paints no frame at all', async () => {
   const app = await headlessApp();
+  const x11Root = await createRoot({ app });
   try {
     // The state reaches no prop at all, so the re-render produces exactly the
     // tree already on screen — new element objects, so React really does walk
@@ -724,7 +737,7 @@ test('a commit that changes nothing visible paints no frame at all', async () =>
     // (State carried on *any* prop would not do: props are compared by
     // identity, so a changed one is a real claim, which is deliberate — that
     // is where a subclass's content lives.)
-    const { root, setState } = await mountStateful(app, () =>
+    const { root, setState } = await mountStateful(x11Root, () =>
       Array.from({ length: 6 }, (_, i) =>
         React.createElement(
           'box',
@@ -752,13 +765,14 @@ test('a commit that changes nothing visible paints no frame at all', async () =>
 
 test('a canvas whose onDraw changed repaints the canvas, not the window', async () => {
   const app = await headlessApp();
+  const x11Root = await createRoot({ app });
   try {
     // onDraw matches /^on[A-Z]/, so the base class skips it as an event
     // handler and CanvasNode is the only thing that notices. It used to claim
     // damage unbounded, which made every re-render of a component that draws
     // through <canvas> — a Checkbox tick, a Select chevron — repaint the whole
     // window.
-    const { root, setState } = await mountStateful(app, (state) => [
+    const { root, setState } = await mountStateful(x11Root, (state) => [
       React.createElement('box', {
         key: 'filler',
         style: { height: ROW_H, backgroundColor: '#dfe6e9' },
@@ -790,13 +804,14 @@ test('a canvas whose onDraw changed repaints the canvas, not the window', async 
 
 test('an animated transition stays bounded, including its last frame', async () => {
   const app = await headlessApp();
+  const x11Root = await createRoot({ app });
   try {
     // An absolutely-positioned thumb sliding on `left` is the Switch's
     // arrangement. Every frame of it used to repaint the whole window — and so
     // did the frame the animation *landed* on, because the node was dropped
     // from the animating set before anything claimed its region.
     const TRACK = { width: 36, height: 20 };
-    const { root, setState } = await mountStateful(app, (state) =>
+    const { root, setState } = await mountStateful(x11Root, (state) =>
       React.createElement(
         'box',
         {
@@ -851,6 +866,7 @@ test('an animated transition stays bounded, including its last frame', async () 
 
 test('mounting a child inside a fixed-size box repaints only that box', async () => {
   const app = await headlessApp();
+  const x11Root = await createRoot({ app });
   try {
     // A `Checkbox`'s tick and a `Radio`'s dot are children that mount and
     // unmount, and a child list change is a layout change — which with no
@@ -858,7 +874,7 @@ test('mounting a child inside a fixed-size box repaints only that box', async ()
     // the reflow cannot move anything outside it, so the damage is that
     // subtree before the mutation unioned with the same subtree after layout.
     const WELL = 16;
-    const { root, setState } = await mountStateful(app, (state) => [
+    const { root, setState } = await mountStateful(x11Root, (state) => [
       React.createElement('box', {
         key: 'filler',
         style: { height: ROW_H, backgroundColor: '#dfe6e9' },
@@ -908,12 +924,13 @@ test('mounting a child inside a fixed-size box repaints only that box', async ()
 
 test('a child mounting in an auto-sized box still repaints in full', async () => {
   const app = await headlessApp();
+  const x11Root = await createRoot({ app });
   try {
     // The counterpart, and the reason the rule checks *both* axes: a box with
     // no pinned height grows when a child appears, which moves its siblings —
     // so there is nothing safe to bound the repaint to. If this came back
     // bounded, the test above would prove nothing about the pinned case.
-    const { root, setState } = await mountStateful(app, (state) => [
+    const { root, setState } = await mountStateful(x11Root, (state) => [
       React.createElement(
         'box',
         { key: 'auto', style: { backgroundColor: '#ffffff' } },

--- a/test/discrete-latency.test.js
+++ b/test/discrete-latency.test.js
@@ -17,7 +17,7 @@ import React from 'react';
 import xserver from 'x11/lib/xserver/index.js';
 import { createClient } from 'ntk';
 
-import ReactX11 from '../src/index.js';
+import { createRoot } from '../src/index.js';
 import { createMockApp } from './helpers/mock-app.js';
 import { hooks } from '../src/trace-registry.js';
 
@@ -48,11 +48,8 @@ const PRESSABLE = {
 
 test('a press paints its :active flip in the same event-loop turn', async () => {
   const app = createMockApp();
-  ReactX11.render(
-    h('window', { width: 200, height: 100 }, h('box', PRESSABLE)),
-    null,
-    app,
-  );
+  const x11Root = await createRoot({ app });
+  x11Root.render(h('window', { width: 200, height: 100 }, h('box', PRESSABLE)));
   await tick();
   const wnd = app.windows[0];
   const passes = countPaints();
@@ -70,11 +67,12 @@ test('a press paints its :active flip in the same event-loop turn', async () => 
     'and what it painted is the pressed background',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('a click that sets React state is still exactly one paint', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   let renders = 0;
   const Host = () => {
     const [on, setOn] = React.useState(false);
@@ -92,7 +90,7 @@ test('a click that sets React state is still exactly one paint', async () => {
       }),
     );
   };
-  ReactX11.render(h(Host), null, app);
+  x11Root.render(h(Host));
   await tick();
   const wnd = app.windows[0];
   const passes = countPaints();
@@ -109,19 +107,18 @@ test('a click that sets React state is still exactly one paint', async () => {
   await tick();
   assert.strictEqual(passes.length, 1, 'and the scheduled frame is a no-op');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('a click-placed caret reaches the wire with the press', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     h(
       'window',
       { width: 200, height: 100 },
       h('textinput', { value: 'hello', style: { width: 120, height: 24 } }),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -130,12 +127,13 @@ test('a click-placed caret reaches the wire with the press', async () => {
   wnd.emit('mousedown', { x: 20, y: 10, keycode: 1 });
   assert.strictEqual(passes.length, 1, 'focus ring and caret painted at once');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('motion still coalesces to one paint per frame', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     h(
       'window',
       { width: 200, height: 100 },
@@ -148,8 +146,6 @@ test('motion still coalesces to one paint per frame', async () => {
         },
       }),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -163,12 +159,13 @@ test('motion still coalesces to one paint per frame', async () => {
   await tick();
   assert.strictEqual(passes.length, 1, 'the whole burst is one paint');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('a wheel burst inside one round trip paints twice, not ten times', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     h(
       'window',
       { width: 200, height: 200 },
@@ -183,8 +180,6 @@ test('a wheel burst inside one round trip paints twice, not ten times', async ()
         ),
       ),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -206,16 +201,13 @@ test('a wheel burst inside one round trip paints twice, not ten times', async ()
   await tick();
   assert.strictEqual(passes.length, 2, 'the other nine caught up in one frame');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('a window whose fence is outstanding waits for its scheduled frame', async () => {
   const app = createMockApp();
-  ReactX11.render(
-    h('window', { width: 200, height: 100 }, h('box', PRESSABLE)),
-    null,
-    app,
-  );
+  const x11Root = await createRoot({ app });
+  x11Root.render(h('window', { width: 200, height: 100 }, h('box', PRESSABLE)));
   await tick();
   const wnd = app.windows[0];
   const passes = countPaints();
@@ -228,12 +220,13 @@ test('a window whose fence is outstanding waits for its scheduled frame', async 
   await tick();
   assert.strictEqual(passes.length, 1, 'the scheduled frame still ran it');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('a transition in flight survives being ticked off-cadence', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     h(
       'window',
       { width: 200, height: 100 },
@@ -249,8 +242,6 @@ test('a transition in flight survives being ticked off-cadence', async () => {
         },
       }),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -291,7 +282,7 @@ test('a transition in flight survives being ticked off-cadence', async () => {
     'landing on the pressed colour',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 // --- against the real thing --------------------------------------------
@@ -320,6 +311,7 @@ const buttonPress = (keycode) => ({ type: 4, x: 100, y: 100, keycode });
 
 test('real ntk: the press paints, and the present shuts the gate behind it', async (t) => {
   const { server, app } = await xserverApp();
+  const x11Root = await createRoot({ app });
   t.after(async () => {
     await app.close?.();
     server.close?.();
@@ -328,7 +320,7 @@ test('real ntk: the press paints, and the present shuts the gate behind it', asy
   // the render callback hands back the root child's public instance, which
   // for a <window> is the live ntk window
   let wnd = null;
-  ReactX11.render(
+  x11Root.render(
     h(
       'window',
       { width: 200, height: 200 },
@@ -346,7 +338,6 @@ test('real ntk: the press paints, and the present shuts the gate behind it', asy
     (instance) => {
       wnd = instance;
     },
-    app,
   );
   await tick();
   await roundTrip(app);
@@ -381,16 +372,13 @@ test('real ntk: the press paints, and the present shuts the gate behind it', asy
   }
   assert.strictEqual(passes.length, 2, 'one catch-up frame for the rest');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('an ntk without the fence accessor keeps the scheduled path', async () => {
   const app = createMockApp();
-  ReactX11.render(
-    h('window', { width: 200, height: 100 }, h('box', PRESSABLE)),
-    null,
-    app,
-  );
+  const x11Root = await createRoot({ app });
+  x11Root.render(h('window', { width: 200, height: 100 }, h('box', PRESSABLE)));
   await tick();
   const wnd = app.windows[0];
   const passes = countPaints();
@@ -403,5 +391,5 @@ test('an ntk without the fence accessor keeps the scheduled path', async () => {
   await tick();
   assert.strictEqual(passes.length, 1);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });

--- a/test/glarea.test.js
+++ b/test/glarea.test.js
@@ -11,7 +11,7 @@ import React from 'react';
 import xserver from 'x11/lib/xserver/index.js';
 import { createClient, StaticFontSource } from 'ntk';
 
-import ReactX11 from '../src/index.js';
+import { createRoot } from '../src/index.js';
 
 const require = createRequire(import.meta.url);
 const { createGlxExtension, RecordingBackend } = require('x11/browser/glx');
@@ -40,8 +40,8 @@ async function createGlApp() {
   return { app, backend, xErrors };
 }
 
-const render = (element, app) =>
-  new Promise((resolve) => ReactX11.render(element, resolve, app));
+const render = (element, x11Root) =>
+  new Promise((resolve) => x11Root.render(element, resolve));
 
 const settle = async (app, roundTrips = 3) => {
   for (let i = 0; i < roundTrips; i++) {
@@ -71,6 +71,7 @@ const getAttributes = (app, wid) =>
 
 test('<glarea> gets a GL child window and draws a frame', async () => {
   const { app, backend, xErrors } = await createGlApp();
+  const x11Root = await createRoot({ app });
   try {
     const drawn = [];
     const instance = await render(
@@ -92,7 +93,7 @@ test('<glarea> gets a GL child window and draws a frame', async () => {
           }),
         ]),
       ),
-      app,
+      x11Root,
     );
 
     await waitFor(() => drawn.length > 0, 'the first frame');
@@ -153,7 +154,7 @@ test('<glarea> gets a GL child window and draws a frame', async () => {
     );
     assert.equal(xErrors.length, 0, xErrors.map((e) => e.message).join(', '));
 
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
     await settle(app);
   } finally {
     await app.close();
@@ -162,6 +163,7 @@ test('<glarea> gets a GL child window and draws a frame', async () => {
 
 test('<glarea> follows layout changes and redraws once per change', async () => {
   const { app, backend, xErrors } = await createGlApp();
+  const x11Root = await createRoot({ app });
   try {
     const frames = [];
     const tree = (padding) =>
@@ -177,12 +179,12 @@ test('<glarea> follows layout changes and redraws once per change', async () => 
         ]),
       );
 
-    const instance = await render(tree(10), app);
+    const instance = await render(tree(10), x11Root);
     await waitFor(() => frames.length > 0, 'the first frame');
     assert.deepEqual(frames.at(-1), [300, 220]);
 
     backend.calls.length = 0;
-    await render(tree(40), app);
+    await render(tree(40), x11Root);
     await waitFor(
       () => frames.some(([w]) => w === 240),
       'a frame at the new size',
@@ -210,7 +212,7 @@ test('<glarea> follows layout changes and redraws once per change', async () => 
     assert.equal(frames.length, before, 'no frames without a change');
     assert.equal(xErrors.length, 0, xErrors.map((e) => e.message).join(', '));
 
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
     await settle(app);
   } finally {
     await app.close();

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -4,7 +4,7 @@ import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import React from 'react';
-import ReactX11 from '../src/index.js';
+import { createRoot } from '../src/index.js';
 import { anchorRect } from '../src/components/anchor.js';
 
 // End-to-end test: react-x11 -> real ntk client -> node-x11's pure-JS
@@ -34,9 +34,9 @@ async function createHeadlessApp() {
   return { server, app };
 }
 
-function render(element, app) {
+function render(element, x11Root) {
   return new Promise((resolve) => {
-    ReactX11.render(element, (instance) => resolve(instance), app);
+    x11Root.render(element, (instance) => resolve(instance));
   });
 }
 
@@ -84,6 +84,7 @@ async function waitForPixel(ctx, w, h, x, y, want, what) {
 
 test('renders a window tree into an in-process X server', async () => {
   const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
   try {
     const instance = await render(
       React.createElement(
@@ -91,7 +92,7 @@ test('renders a window tree into an in-process X server', async () => {
         { width: 300, height: 200, title: 'integration' },
         React.createElement('window', { width: 50, height: 50, x: 10, y: 10 }),
       ),
-      app,
+      x11Root,
     );
 
     assert.ok(instance, 'render callback should receive the root instance');
@@ -104,10 +105,10 @@ test('renders a window tree into an in-process X server', async () => {
         { width: 320, height: 240, title: 'integration-updated' },
         React.createElement('window', { width: 50, height: 50, x: 10, y: 10 }),
       ),
-      app,
+      x11Root,
     );
 
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
     await settle(app);
   } finally {
     await app.close();
@@ -116,6 +117,7 @@ test('renders a window tree into an in-process X server', async () => {
 
 test('child windows stack bottom-to-top in JSX order on the server', async () => {
   const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
   try {
     const refs = { a: React.createRef(), b: React.createRef() };
     // Two child windows on the same spot. The check is QueryTree, not
@@ -141,7 +143,7 @@ test('child windows stack bottom-to-top in JSX order on the server', async () =>
         ),
       );
 
-    const parent = await render(ui(['a', 'b']), app);
+    const parent = await render(ui(['a', 'b']), x11Root);
     const queryTree = (id) =>
       new Promise((resolve, reject) =>
         app.X.QueryTree(id, (err, tree) => (err ? reject(err) : resolve(tree))),
@@ -154,14 +156,14 @@ test('child windows stack bottom-to-top in JSX order on the server', async () =>
       'the later sibling starts on top',
     );
 
-    await render(ui(['b', 'a']), app);
+    await render(ui(['b', 'a']), x11Root);
     assert.deepStrictEqual(
       (await queryTree(parent.id)).children,
       [refs.b.current.id, refs.a.current.id],
       'reordering the JSX restacks the real windows',
     );
 
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
     await settle(app);
   } finally {
     await app.close();
@@ -170,6 +172,7 @@ test('child windows stack bottom-to-top in JSX order on the server', async () =>
 
 test('paints a flex box tree and reflows on update', async () => {
   const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
   try {
     const ui = (leftColor) =>
       React.createElement(
@@ -187,17 +190,17 @@ test('paints a flex box tree and reflows on update', async () => {
         ),
       );
 
-    const wnd = await render(ui('red'), app);
+    const wnd = await render(ui('red'), x11Root);
     const ctx = wnd.getContext('2d');
 
     await waitForPixel(ctx, 160, 120, 40, 60, [255, 0, 0], 'left half red');
     await waitForPixel(ctx, 160, 120, 120, 60, [0, 0, 255], 'right half blue');
 
     // state-driven repaint
-    await render(ui('green'), app);
+    await render(ui('green'), x11Root);
     await waitForPixel(ctx, 160, 120, 40, 60, [0, 128, 0], 'left half green');
 
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
   } finally {
     await app.close();
   }
@@ -205,6 +208,7 @@ test('paints a flex box tree and reflows on update', async () => {
 
 test('scrollview scrolls content (pixel-verified)', async () => {
   const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
   try {
     const ref = React.createRef();
     const wnd = await render(
@@ -222,7 +226,7 @@ test('scrollview scrolls content (pixel-verified)', async () => {
           }),
         ),
       ),
-      app,
+      x11Root,
     );
     const ctx = wnd.getContext('2d');
 
@@ -230,7 +234,7 @@ test('scrollview scrolls content (pixel-verified)', async () => {
     ref.current.scrollTo(100);
     await waitForPixel(ctx, 100, 100, 40, 50, [0, 255, 0], 'scrolled: green');
 
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
   } finally {
     await app.close();
   }
@@ -238,6 +242,7 @@ test('scrollview scrolls content (pixel-verified)', async () => {
 
 test('popup is override-redirect on the server and paints', async () => {
   const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
   try {
     const ref = React.createRef();
     await render(
@@ -256,7 +261,7 @@ test('popup is override-redirect on the server and paints', async () => {
           ),
         ),
       ),
-      app,
+      x11Root,
     );
 
     const popupWindow = ref.current;
@@ -276,7 +281,7 @@ test('popup is override-redirect on the server and paints', async () => {
     const ctx = popupWindow.getContext('2d');
     await waitForPixel(ctx, 60, 40, 30, 20, [255, 0, 0], 'popup content red');
 
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
     await settle(app);
   } finally {
     await app.close();
@@ -285,6 +290,7 @@ test('popup is override-redirect on the server and paints', async () => {
 
 test('a popup anchors to the window even once a WM has reframed it', async () => {
   const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
   try {
     const ref = React.createRef();
     const wnd = await render(
@@ -296,7 +302,7 @@ test('a popup anchors to the window even once a WM has reframed it', async () =>
           style: { marginTop: 30, marginLeft: 20, width: 80, height: 20 },
         }),
       ),
-      app,
+      x11Root,
     );
     await settle(app);
 
@@ -329,7 +335,7 @@ test('a popup anchors to the window even once a WM has reframed it', async () =>
       'the origin came from the server, not from ConfigureNotify',
     );
 
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
     await settle(app);
   } finally {
     await app.close();
@@ -338,6 +344,7 @@ test('a popup anchors to the window even once a WM has reframed it', async () =>
 
 test('textinput renders its value through the ntk text stack', async () => {
   const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
   try {
     const wnd = await render(
       React.createElement(
@@ -348,7 +355,7 @@ test('textinput renders its value through the ntk text stack', async () => {
           style: { fontSize: 24, flexGrow: 1, backgroundColor: 'white' },
         }),
       ),
-      app,
+      x11Root,
     );
     const ctx = wnd.getContext('2d');
 
@@ -369,7 +376,7 @@ test('textinput renders its value through the ntk text stack', async () => {
       await new Promise((resolve) => setTimeout(resolve, 25));
     }
 
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
   } finally {
     await app.close();
   }
@@ -377,6 +384,7 @@ test('textinput renders its value through the ntk text stack', async () => {
 
 test('an unfocused field shows the start of its value, not the caret', async () => {
   const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
   try {
     // The caret starts at the *end* of the value, and the paint used to chase
     // it whether or not the field had ever been focused — so a field holding
@@ -402,7 +410,7 @@ test('an unfocused field shows the start of its value, not the caret', async () 
           style: { width: 120, fontSize: 13 },
         }),
       ),
-      app,
+      x11Root,
     );
 
     // paint at least once: the offsets are settled during _paintContent
@@ -430,7 +438,7 @@ test('an unfocused field shows the start of its value, not the caret', async () 
       'an unfocused textarea shows its first lines',
     );
 
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
   } finally {
     await app.close();
   }
@@ -438,6 +446,7 @@ test('an unfocused field shows the start of its value, not the caret', async () 
 
 test('textinput caret advances past trailing spaces', async () => {
   const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
   try {
     const ref = React.createRef();
     await render(
@@ -450,7 +459,7 @@ test('textinput caret advances past trailing spaces', async () => {
           style: { flexGrow: 1 },
         }),
       ),
-      app,
+      x11Root,
     );
     const input = ref.current;
 
@@ -474,7 +483,7 @@ test('textinput caret advances past trailing spaces', async () => {
       `synthetic advance tracks shaping (${w5} vs ${full})`,
     );
 
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
     await settle(app);
   } finally {
     await app.close();
@@ -483,6 +492,7 @@ test('textinput caret advances past trailing spaces', async () => {
 
 test('renders <text> through the ntk text stack', async () => {
   const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
   try {
     const wnd = await render(
       React.createElement(
@@ -494,7 +504,7 @@ test('renders <text> through the ntk text stack', async () => {
           'Hello',
         ),
       ),
-      app,
+      x11Root,
     );
     const ctx = wnd.getContext('2d');
 
@@ -518,7 +528,7 @@ test('renders <text> through the ntk text stack', async () => {
       await new Promise((resolve) => setTimeout(resolve, 25));
     }
 
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
   } finally {
     await app.close();
   }
@@ -547,6 +557,7 @@ const isDark = ([r, g, b]) => r < 128 && g < 128 && b < 128;
 
 test('centered text is vertically balanced (half-leading)', async () => {
   const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
   try {
     const wnd = await render(
       React.createElement(
@@ -568,7 +579,7 @@ test('centered text is vertically balanced (half-leading)', async () => {
           ),
         ),
       ),
-      app,
+      x11Root,
     );
     const ctx = wnd.getContext('2d');
     await waitForInk(
@@ -605,7 +616,7 @@ test('centered text is vertically balanced (half-leading)', async () => {
         `off by ${offset}px`,
     );
 
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
   } finally {
     await app.close();
   }
@@ -613,6 +624,7 @@ test('centered text is vertically balanced (half-leading)', async () => {
 
 test('rich content scrolled out of a scrollview leaves no ink behind', async () => {
   const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
   try {
     // a math fence: KaTeX draws glyph runs and vector shapes of its own,
     // which used to bypass the 2d clip and paint over whatever was above
@@ -633,7 +645,7 @@ test('rich content scrolled out of a scrollview leaves no ink behind', async () 
           ),
         ),
       ),
-      app,
+      x11Root,
     );
     const ctx = wnd.getContext('2d');
     const node = wnd._reactX11Node;
@@ -670,7 +682,7 @@ test('rich content scrolled out of a scrollview leaves no ink behind', async () 
       );
     }
 
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
     await settle(app);
   } finally {
     await app.close();
@@ -679,6 +691,7 @@ test('rich content scrolled out of a scrollview leaves no ink behind', async () 
 
 test('<markdown> survives a document being typed down to nothing', async () => {
   const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
   try {
     let setText;
     const Host = () => {
@@ -694,7 +707,7 @@ test('<markdown> survives a document being typed down to nothing', async () => {
         ),
       );
     };
-    await render(React.createElement(Host), app);
+    await render(React.createElement(Host), x11Root);
 
     // a live preview goes through these states on the way to empty, and a
     // blank block lays out with no spans at all — which used to throw
@@ -705,7 +718,7 @@ test('<markdown> survives a document being typed down to nothing', async () => {
     }
     await settle(app);
 
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
     await settle(app);
   } finally {
     await app.close();
@@ -714,6 +727,7 @@ test('<markdown> survives a document being typed down to nothing', async () => {
 
 test('<markdown> renders through MarkdownView and dispatches onLink', async () => {
   const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
   try {
     const clicked = [];
     const wnd = await render(
@@ -725,7 +739,7 @@ test('<markdown> renders through MarkdownView and dispatches onLink', async () =
           onLink: (href) => clicked.push(href),
         }),
       ),
-      app,
+      x11Root,
     );
     const ctx = wnd.getContext('2d');
 
@@ -754,7 +768,7 @@ test('<markdown> renders through MarkdownView and dispatches onLink', async () =
     wnd.emit('mouseup', { x: lx, y: ly, keycode: 1 });
     assert.deepStrictEqual(clicked, ['https://example.com/']);
 
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
   } finally {
     await app.close();
   }
@@ -762,6 +776,7 @@ test('<markdown> renders through MarkdownView and dispatches onLink', async () =
 
 test('<html> renders styled boxes through HtmlView', async () => {
   const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
   try {
     const wnd = await render(
       React.createElement(
@@ -772,11 +787,11 @@ test('<html> renders styled boxes through HtmlView', async () => {
             '<div style="width: 80px; height: 40px; background: #0000ff; margin: 0"></div>',
         }),
       ),
-      app,
+      x11Root,
     );
     const ctx = wnd.getContext('2d');
     await waitForPixel(ctx, 200, 120, 20, 20, [0, 0, 255], 'html div blue');
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
   } finally {
     await app.close();
   }
@@ -784,6 +799,7 @@ test('<html> renders styled boxes through HtmlView', async () => {
 
 test('<svg> scales its viewBox into the content box', async () => {
   const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
   try {
     const wnd = await render(
       React.createElement(
@@ -795,12 +811,12 @@ test('<svg> scales its viewBox into the content box', async () => {
           style: { width: 60, height: 60 },
         }),
       ),
-      app,
+      x11Root,
     );
     const ctx = wnd.getContext('2d');
     await waitForPixel(ctx, 100, 100, 30, 30, [255, 0, 0], 'svg rect red');
     await waitForPixel(ctx, 100, 100, 80, 80, [255, 255, 255], 'outside white');
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
   } finally {
     await app.close();
   }
@@ -808,6 +824,7 @@ test('<svg> scales its viewBox into the content box', async () => {
 
 test('<tex> lays out and draws a formula', async () => {
   const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
   try {
     const wnd = await render(
       React.createElement(
@@ -819,7 +836,7 @@ test('<tex> lays out and draws a formula', async () => {
           displayMode: true,
         }),
       ),
-      app,
+      x11Root,
     );
     const ctx = wnd.getContext('2d');
     await waitForInk(
@@ -831,7 +848,7 @@ test('<tex> lays out and draws a formula', async () => {
       15,
       'tex formula ink',
     );
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
   } finally {
     await app.close();
   }
@@ -839,6 +856,7 @@ test('<tex> lays out and draws a formula', async () => {
 
 test('<html> repaints when async content arrives (ntk onInvalidate)', async () => {
   const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
   try {
     // an <img> decodes off the render pass, so the first paint has nothing to
     // draw there; HtmlView then fires onInvalidate, which is the only thing
@@ -856,11 +874,11 @@ test('<html> repaints when async content arrives (ntk onInvalidate)', async () =
           source: `<div style="margin:0;padding:0"><img width="40" height="40" src="${svg}"></div>`,
         }),
       ),
-      app,
+      x11Root,
     );
     const ctx = wnd.getContext('2d');
     await waitForPixel(ctx, 200, 120, 20, 20, [0, 0, 255], 'html svg img blue');
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
   } finally {
     await app.close();
   }
@@ -868,6 +886,7 @@ test('<html> repaints when async content arrives (ntk onInvalidate)', async () =
 
 test('<svg> JSX children render and update declaratively', async () => {
   const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
   try {
     const ui = (fill) =>
       React.createElement(
@@ -886,12 +905,12 @@ test('<svg> JSX children render and update declaratively', async () => {
         ),
       );
 
-    const wnd = await render(ui('#ff0000'), app);
+    const wnd = await render(ui('#ff0000'), x11Root);
     const ctx = wnd.getContext('2d');
     await waitForPixel(ctx, 100, 100, 30, 30, [255, 0, 0], 'children rect red');
 
     // prop update on the SVG child re-renders the drawing
-    await render(ui('#00ff00'), app);
+    await render(ui('#00ff00'), x11Root);
     await waitForPixel(
       ctx,
       100,
@@ -902,7 +921,7 @@ test('<svg> JSX children render and update declaratively', async () => {
       'children rect green',
     );
 
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
   } finally {
     await app.close();
   }
@@ -910,6 +929,7 @@ test('<svg> JSX children render and update declaratively', async () => {
 
 test('<markdown> accepts its content as a string child', async () => {
   const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
   try {
     const wnd = await render(
       React.createElement(
@@ -917,7 +937,7 @@ test('<markdown> accepts its content as a string child', async () => {
         { width: 300, height: 100, style: { backgroundColor: 'white' } },
         React.createElement('markdown', null, '# From a child string'),
       ),
-      app,
+      x11Root,
     );
     const ctx = wnd.getContext('2d');
     await waitForInk(
@@ -929,7 +949,7 @@ test('<markdown> accepts its content as a string child', async () => {
       20,
       'child-string markdown heading ink',
     );
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
   } finally {
     await app.close();
   }
@@ -937,6 +957,7 @@ test('<markdown> accepts its content as a string child', async () => {
 
 test('<textarea> edits multi-line text with line-aware caret movement', async () => {
   const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
   try {
     const ref = React.createRef();
     const wnd = await render(
@@ -949,7 +970,7 @@ test('<textarea> edits multi-line text with line-aware caret movement', async ()
           style: { flexGrow: 1, backgroundColor: 'white' },
         }),
       ),
-      app,
+      x11Root,
     );
     const ta = ref.current;
     await new Promise((resolve) => setTimeout(resolve, 100));
@@ -1001,7 +1022,7 @@ test('<textarea> edits multi-line text with line-aware caret movement', async ()
     );
     assert.ok(wrapped.lines.length > 1, 'TextLayout wraps at maxWidth');
 
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
     await settle(app);
   } finally {
     await app.close();
@@ -1010,6 +1031,7 @@ test('<textarea> edits multi-line text with line-aware caret movement', async ()
 
 test('window hints reach the X server as real properties', async () => {
   const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
   try {
     // the render callback resolves to the live ntk window (getPublicInstance)
     const wnd = await render(
@@ -1020,7 +1042,7 @@ test('window hints reach the X server as real properties', async () => {
         wmClass: ['react-x11', 'React-X11'],
         windowType: 'dialog',
       }),
-      app,
+      x11Root,
     );
     await settle(app, 6); // deferred InternAtom -> ChangeProperty chains
 
@@ -1061,7 +1083,7 @@ test('window hints reach the X server as real properties', async () => {
     const type = await getProp(typeAtom);
     assert.strictEqual(type.data.readUInt32LE(0), dialog);
 
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
     await settle(app);
   } finally {
     await app.close();
@@ -1070,6 +1092,7 @@ test('window hints reach the X server as real properties', async () => {
 
 test('overflow: hidden still clips a child that really does overflow', async () => {
   const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
   try {
     // A clip that clips nothing is skipped, because each one costs a
     // server-side mask rebuild and a table sets `overflow: hidden` on every
@@ -1099,7 +1122,7 @@ test('overflow: hidden still clips a child that really does overflow', async () 
           }),
         ),
       ),
-      app,
+      x11Root,
     );
     const ctx = wnd.getContext('2d');
     const root = wnd._reactX11Node;
@@ -1126,7 +1149,7 @@ test('overflow: hidden still clips a child that really does overflow', async () 
       );
     }
 
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
   } finally {
     await app.close();
   }

--- a/test/pointer3d.test.js
+++ b/test/pointer3d.test.js
@@ -10,7 +10,7 @@ import React from 'react';
 import xserver from 'x11/lib/xserver/index.js';
 import { createClient, StaticFontSource } from 'ntk';
 
-import ReactX11, { Canvas3D } from '../src/index.js';
+import { createRoot, Canvas3D } from '../src/index.js';
 
 const require = createRequire(import.meta.url);
 const { createGlxExtension, RecordingBackend } = require('x11/browser/glx');
@@ -35,8 +35,8 @@ async function createGlApp() {
   return { app };
 }
 
-const render = (element, app) =>
-  new Promise((resolve) => ReactX11.render(element, resolve, app));
+const render = (element, x11Root) =>
+  new Promise((resolve) => x11Root.render(element, resolve));
 
 const settle = async (app, roundTrips = 2) => {
   for (let i = 0; i < roundTrips; i++) {
@@ -65,20 +65,20 @@ function findSurface(node) {
 }
 
 /** Mount a scene and draw one frame, so picking has a camera to work with. */
-async function mount(app, scene, size = { width: 400, height: 300 }) {
+async function mount(x11Root, scene, size = { width: 400, height: 300 }) {
   const instance = await render(
     h(
       'window',
       size,
       h(Canvas3D, { style: { flexGrow: 1 }, ...scene.canvas }, scene.children),
     ),
-    app,
+    x11Root,
   );
   const surface = findSurface(instance._reactX11Node);
   await waitFor(() => surface.gl?.contextTag > 0, 'the GL context');
   surface.requestFrame = () => {};
   surface._drawFrame();
-  await settle(app);
+  await settle(x11Root.app);
   return surface;
 }
 
@@ -96,10 +96,11 @@ const CUBE = (props = {}) =>
 
 test('a click on a mesh hits it, and a click past it misses', async () => {
   const { app } = await createGlApp();
+  const x11Root = await createRoot({ app });
   try {
     const clicks = [];
     const missed = [];
-    const surface = await mount(app, {
+    const surface = await mount(x11Root, {
       canvas: {
         camera: { position: [0, 0, 6] },
         onPointerMissed: () => missed.push(true),
@@ -133,9 +134,10 @@ test('a click on a mesh hits it, and a click past it misses', async () => {
 
 test('hover enters and leaves as the pointer crosses a mesh', async () => {
   const { app } = await createGlApp();
+  const x11Root = await createRoot({ app });
   try {
     const log = [];
-    const surface = await mount(app, {
+    const surface = await mount(x11Root, {
       canvas: { camera: { position: [0, 0, 6] } },
       children: CUBE({
         onPointerOver: () => log.push('over'),
@@ -157,10 +159,11 @@ test('hover enters and leaves as the pointer crosses a mesh', async () => {
 
 test('the nearest mesh wins, and events bubble to the group', async () => {
   const { app } = await createGlApp();
+  const x11Root = await createRoot({ app });
   try {
     const hits = [];
     const groupClicks = [];
-    const surface = await mount(app, {
+    const surface = await mount(x11Root, {
       canvas: { camera: { position: [0, 0, 10] } },
       children: h(
         'group',
@@ -188,9 +191,10 @@ test('the nearest mesh wins, and events bubble to the group', async () => {
 
 test('stopPropagation keeps an event off the ancestors', async () => {
   const { app } = await createGlApp();
+  const x11Root = await createRoot({ app });
   try {
     const seen = [];
-    const surface = await mount(app, {
+    const surface = await mount(x11Root, {
       canvas: { camera: { position: [0, 0, 6] } },
       children: h(
         'group',
@@ -214,13 +218,14 @@ test('stopPropagation keeps an event off the ancestors', async () => {
 
 test('a transform moves what the ray hits', async () => {
   const { app } = await createGlApp();
+  const x11Root = await createRoot({ app });
   try {
     const hits = [];
     const scene = (x) => ({
       canvas: { camera: { position: [0, 0, 6] } },
       children: CUBE({ position: [x, 0, 0], onClick: () => hits.push(x) }),
     });
-    const surface = await mount(app, scene(0));
+    const surface = await mount(x11Root, scene(0));
 
     pointer(surface, 'mousedown', 200, 150);
     pointer(surface, 'mouseup', 200, 150);
@@ -237,7 +242,7 @@ test('a transform moves what the ray hits', async () => {
           CUBE({ position: [-6, 0, 0], onClick: () => hits.push(-6) }),
         ),
       ),
-      app,
+      x11Root,
     );
     surface._drawFrame();
     await settle(app);
@@ -252,8 +257,9 @@ test('a transform moves what the ray hits', async () => {
 
 test('X pointer events are only selected when the scene listens', async () => {
   const { app } = await createGlApp();
+  const x11Root = await createRoot({ app });
   try {
-    const quiet = await mount(app, {
+    const quiet = await mount(x11Root, {
       canvas: {},
       children: CUBE(),
     });
@@ -263,7 +269,7 @@ test('X pointer events are only selected when the scene listens', async () => {
       'no handlers: no motion events asked for',
     );
 
-    const listening = await mount(app, {
+    const listening = await mount(x11Root, {
       canvas: {},
       children: CUBE({ onClick: () => {} }),
     });

--- a/test/scene3d.test.js
+++ b/test/scene3d.test.js
@@ -13,7 +13,7 @@ import React from 'react';
 import xserver from 'x11/lib/xserver/index.js';
 import { createClient, StaticFontSource } from 'ntk';
 
-import ReactX11, { Canvas3D } from '../src/index.js';
+import { createRoot, Canvas3D } from '../src/index.js';
 
 const require = createRequire(import.meta.url);
 const { createGlxExtension, RecordingBackend } = require('x11/browser/glx');
@@ -103,8 +103,8 @@ async function createGlApp() {
   return { app, backend, xErrors, tap: tapRequests(clientEnd) };
 }
 
-const render = (element, app) =>
-  new Promise((resolve) => ReactX11.render(element, resolve, app));
+const render = (element, x11Root) =>
+  new Promise((resolve) => x11Root.render(element, resolve));
 
 const settle = async (app, roundTrips = 3) => {
   for (let i = 0; i < roundTrips; i++) {
@@ -163,6 +163,7 @@ async function drawFrame(surface, app, tap) {
 
 test('a mesh compiles once, then every frame is one CallList', async () => {
   const { app, tap, xErrors } = await createGlApp();
+  const x11Root = await createRoot({ app });
   try {
     const scene = (rotation) =>
       h(
@@ -180,7 +181,7 @@ test('a mesh compiles once, then every frame is one CallList', async () => {
         ),
       );
 
-    const instance = await render(scene([0, 0, 0]), app);
+    const instance = await render(scene([0, 0, 0]), x11Root);
     const surface = findSurface(instance._reactX11Node);
     await waitFor(() => surface.gl?.contextTag > 0, 'the GL context');
     takeFrameControl(surface);
@@ -196,7 +197,7 @@ test('a mesh compiles once, then every frame is one CallList', async () => {
 
     // a transform change re-sends matrices, never geometry
     tap.reset();
-    await render(scene([0, 0.4, 0]), app);
+    await render(scene([0, 0.4, 0]), x11Root);
     await drawFrame(surface, app, tap);
 
     const moved = tap.glx(app.display.GLX.majorOpcode);
@@ -209,7 +210,7 @@ test('a mesh compiles once, then every frame is one CallList', async () => {
     );
     assert.equal(xErrors.length, 0, xErrors.map((e) => e.message).join(', '));
 
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
     await settle(app);
   } finally {
     await app.close();
@@ -218,6 +219,7 @@ test('a mesh compiles once, then every frame is one CallList', async () => {
 
 test('per-frame cost does not grow with triangle count', async () => {
   const { app, tap } = await createGlApp();
+  const x11Root = await createRoot({ app });
   try {
     const instance = await render(
       h(
@@ -234,7 +236,7 @@ test('per-frame cost does not grow with triangle count', async () => {
           ),
         ),
       ),
-      app,
+      x11Root,
     );
     const surface = findSurface(instance._reactX11Node);
     await waitFor(() => surface.gl?.contextTag > 0, 'the GL context');
@@ -264,6 +266,7 @@ test('per-frame cost does not grow with triangle count', async () => {
 
 test('changing geometry args recompiles that list once', async () => {
   const { app, tap } = await createGlApp();
+  const x11Root = await createRoot({ app });
   try {
     const scene = (size) =>
       h(
@@ -281,14 +284,14 @@ test('changing geometry args recompiles that list once', async () => {
         ),
       );
 
-    const instance = await render(scene(1), app);
+    const instance = await render(scene(1), x11Root);
     const surface = findSurface(instance._reactX11Node);
     await waitFor(() => surface.gl?.contextTag > 0, 'the GL context');
     takeFrameControl(surface);
     await drawFrame(surface, app, tap);
 
     tap.reset();
-    await render(scene(2), app);
+    await render(scene(2), x11Root);
     await drawFrame(surface, app, tap);
     const resized = tap.glx(app.display.GLX.majorOpcode);
     assert.equal(resized.requests(GLX_NEW_LIST), 1, 'exactly one recompile');
@@ -306,6 +309,7 @@ test('changing geometry args recompiles that list once', async () => {
 
 test('groups nest transforms and each material switches state once', async () => {
   const { app, tap } = await createGlApp();
+  const x11Root = await createRoot({ app });
   try {
     const instance = await render(
       h(
@@ -332,7 +336,7 @@ test('groups nest transforms and each material switches state once', async () =>
           ),
         ),
       ),
-      app,
+      x11Root,
     );
     const surface = findSurface(instance._reactX11Node);
     await waitFor(() => surface.gl?.contextTag > 0, 'the GL context');
@@ -355,6 +359,13 @@ test('groups nest transforms and each material switches state once', async () =>
 test('unsupported r3f elements fail with the protocol reason', async () => {
   const { app } = await createGlApp();
   const errors = [];
+  // mounting this tree throws on purpose: `onUncaughtError` is the channel
+  // for it, and it keeps the default (which sets process.exitCode) out of a
+  // test that is asserting on the message
+  const x11Root = await createRoot({
+    app,
+    onUncaughtError: (err) => errors.push(String(err?.message ?? err)),
+  });
   const consoleError = console.error;
   console.error = (...args) => errors.push(args.join(' '));
   try {
@@ -364,7 +375,7 @@ test('unsupported r3f elements fail with the protocol reason', async () => {
         { width: 100, height: 100 },
         h(Canvas3D, {}, h('mesh', {}, h('shaderMaterial', {}))),
       ),
-      app,
+      x11Root,
     ).catch(() => {});
     assert.match(
       errors.join('\n'),
@@ -380,12 +391,19 @@ test('unsupported r3f elements fail with the protocol reason', async () => {
 test('3D elements outside a <glarea> say where they belong', async () => {
   const { app } = await createGlApp();
   const errors = [];
+  // mounting this tree throws on purpose: `onUncaughtError` is the channel
+  // for it, and it keeps the default (which sets process.exitCode) out of a
+  // test that is asserting on the message
+  const x11Root = await createRoot({
+    app,
+    onUncaughtError: (err) => errors.push(String(err?.message ?? err)),
+  });
   const consoleError = console.error;
   console.error = (...args) => errors.push(args.join(' '));
   try {
     await render(
       h('window', { width: 100, height: 100 }, h('mesh', {})),
-      app,
+      x11Root,
     ).catch(() => {});
     assert.match(errors.join('\n'), /<mesh> is a 3D element.*<glarea>/s);
   } finally {
@@ -396,6 +414,7 @@ test('3D elements outside a <glarea> say where they belong', async () => {
 
 test('lights drive the lit materials, and ambient needs no unit of its own', async () => {
   const { app, backend, tap } = await createGlApp();
+  const x11Root = await createRoot({ app });
   try {
     const instance = await render(
       h(
@@ -414,7 +433,7 @@ test('lights drive the lit materials, and ambient needs no unit of its own', asy
           ),
         ),
       ),
-      app,
+      x11Root,
     );
     const surface = findSurface(instance._reactX11Node);
     await waitFor(() => surface.gl?.contextTag > 0, 'the GL context');
@@ -465,6 +484,7 @@ test('lights drive the lit materials, and ambient needs no unit of its own', asy
 
 test('a lit material with no lights falls back to flat colour', async () => {
   const { app, backend, tap } = await createGlApp();
+  const x11Root = await createRoot({ app });
   try {
     const instance = await render(
       h(
@@ -481,7 +501,7 @@ test('a lit material with no lights falls back to flat colour', async () => {
           ),
         ),
       ),
-      app,
+      x11Root,
     );
     const surface = findSurface(instance._reactX11Node);
     await waitFor(() => surface.gl?.contextTag > 0, 'the GL context');
@@ -505,6 +525,7 @@ test('a lit material with no lights falls back to flat colour', async () => {
 
 test('a texture is uploaded once and only rebound afterwards', async () => {
   const { app, backend, tap } = await createGlApp();
+  const x11Root = await createRoot({ app });
   try {
     // a 2x2 RGBA checker, the shape ntk's Image has
     const map = {
@@ -530,7 +551,7 @@ test('a texture is uploaded once and only rebound afterwards', async () => {
         ),
       );
 
-    const instance = await render(scene('white'), app);
+    const instance = await render(scene('white'), x11Root);
     const surface = findSurface(instance._reactX11Node);
     await waitFor(() => surface.gl?.contextTag > 0, 'the GL context');
     takeFrameControl(surface);
@@ -552,7 +573,7 @@ test('a texture is uploaded once and only rebound afterwards', async () => {
 
     // a material change re-sends state, never the pixels
     backend.calls.length = 0;
-    await render(scene('tomato'), app);
+    await render(scene('tomato'), x11Root);
     await drawFrame(surface, app, tap);
     const second = frameCalls(backend);
     assert.equal(
@@ -571,6 +592,7 @@ test('a texture is uploaded once and only rebound afterwards', async () => {
 
 test('a material without a map turns texturing off', async () => {
   const { app, backend, tap } = await createGlApp();
+  const x11Root = await createRoot({ app });
   try {
     const instance = await render(
       h(
@@ -587,7 +609,7 @@ test('a material without a map turns texturing off', async () => {
           ),
         ),
       ),
-      app,
+      x11Root,
     );
     const surface = findSurface(instance._reactX11Node);
     await waitFor(() => surface.gl?.contextTag > 0, 'the GL context');

--- a/test/scroll-blit.test.js
+++ b/test/scroll-blit.test.js
@@ -8,7 +8,7 @@ import { readFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import React from 'react';
-import ReactX11 from '../src/index.js';
+import { createRoot } from '../src/index.js';
 import { createMockApp } from './helpers/mock-app.js';
 
 import xserver from 'x11/lib/xserver/index.js';
@@ -19,10 +19,15 @@ const tick = () => new Promise((resolve) => setImmediate(resolve));
 
 // 20 rows of 40px in a 400x400 window: content 800, plenty to scroll, and
 // a viewport comfortably above the worth-it area gate.
-function mount({ windowProps = {}, scrollProps = {}, extra = null } = {}) {
+async function mount({
+  windowProps = {},
+  scrollProps = {},
+  extra = null,
+} = {}) {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const ref = React.createRef();
-  ReactX11.render(
+  x11Root.render(
     h(
       'window',
       { width: 400, height: 400, ...windowProps },
@@ -42,8 +47,6 @@ function mount({ windowProps = {}, scrollProps = {}, extra = null } = {}) {
       ),
       extra,
     ),
-    null,
-    app,
   );
   const wnd = app.windows[0];
   return { app, wnd, root: wnd._reactX11Node, ref };
@@ -52,7 +55,7 @@ function mount({ windowProps = {}, scrollProps = {}, extra = null } = {}) {
 const blits = (wnd) => wnd.calls.filter(([name]) => name === 'scrollRegion');
 
 test('a pure scroll blits the viewport and claims only the strip and thumb', async () => {
-  const { wnd, root, ref } = mount();
+  const { wnd, root, ref } = await mount();
   await tick();
   wnd.calls.length = 0;
 
@@ -78,7 +81,7 @@ test('a pure scroll blits the viewport and claims only the strip and thumb', asy
 });
 
 test('scrolling back up exposes a strip at the top', async () => {
-  const { wnd, root, ref } = mount();
+  const { wnd, root, ref } = await mount();
   await tick();
   ref.current.scrollTo(96);
   await tick();
@@ -95,7 +98,7 @@ test('scrolling back up exposes a strip at the top', async () => {
 });
 
 test('several scrollTo calls in one frame blit once, by the net delta', async () => {
-  const { wnd, ref } = mount();
+  const { wnd, ref } = await mount();
   await tick();
   wnd.calls.length = 0;
   ref.current.scrollBy(48);
@@ -108,7 +111,7 @@ test('several scrollTo calls in one frame blit once, by the net delta', async ()
 });
 
 test('other damage inside the viewport keeps the full repaint', async () => {
-  const { wnd, root, ref } = mount();
+  const { wnd, root, ref } = await mount();
   await tick();
   const row = root.children[0].children[2];
   wnd.calls.length = 0;
@@ -120,7 +123,7 @@ test('other damage inside the viewport keeps the full repaint', async () => {
 });
 
 test('a fractional target keeps the full repaint', async () => {
-  const { wnd, ref } = mount();
+  const { wnd, ref } = await mount();
   await tick();
   wnd.calls.length = 0;
   ref.current.scrollTo(48.5);
@@ -130,8 +133,9 @@ test('a fractional target keeps the full repaint', async () => {
 
 test('a small viewport is not worth the bookkeeping', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const ref = React.createRef();
-  ReactX11.render(
+  x11Root.render(
     h(
       'window',
       { width: 200, height: 100 },
@@ -143,8 +147,6 @@ test('a small viewport is not worth the bookkeeping', async () => {
         ),
       ),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -155,7 +157,7 @@ test('a small viewport is not worth the bookkeeping', async () => {
 });
 
 test('a page-sized jump repaints instead of blitting a sliver', async () => {
-  const { wnd, ref } = mount();
+  const { wnd, ref } = await mount();
   await tick();
   wnd.calls.length = 0;
   ref.current.scrollTo(240); // 60% of the viewport: less than half survives
@@ -164,7 +166,7 @@ test('a page-sized jump repaints instead of blitting a sliver', async () => {
 });
 
 test('a border on the scrollview keeps the full repaint', async () => {
-  const { wnd, ref } = mount({
+  const { wnd, ref } = await mount({
     scrollProps: {
       style: { flexGrow: 1, borderWidth: 2, borderColor: '#333333' },
     },
@@ -177,7 +179,7 @@ test('a border on the scrollview keeps the full repaint', async () => {
 });
 
 test('an overlapping sibling above the viewport keeps the full repaint', async () => {
-  const { wnd, ref } = mount({
+  const { wnd, ref } = await mount({
     extra: h('box', {
       style: {
         position: 'absolute',
@@ -197,7 +199,7 @@ test('an overlapping sibling above the viewport keeps the full repaint', async (
 });
 
 test('an ntk without scrollRegion gets the old behavior untouched', async () => {
-  const { wnd, root, ref } = mount();
+  const { wnd, root, ref } = await mount();
   await tick();
   delete wnd.scrollRegion;
   wnd.calls.length = 0;
@@ -210,7 +212,7 @@ test('an ntk without scrollRegion gets the old behavior untouched', async () => 
 });
 
 test('a refused blit falls back to the full repaint', async () => {
-  const { wnd, root, ref } = mount();
+  const { wnd, root, ref } = await mount();
   await tick();
   wnd.scrollRegion = () => false; // e.g. ntk with no valid backing store
   ref.current.scrollTo(48);
@@ -219,7 +221,7 @@ test('a refused blit falls back to the full repaint', async () => {
 });
 
 test('the scrolled thumb is repainted at both its old and new place', async () => {
-  const { wnd, root, ref } = mount();
+  const { wnd, root, ref } = await mount();
   await tick();
   // start mid-list, so the dragged copy of the old thumb stays on screen
   ref.current.scrollTo(96);
@@ -289,10 +291,11 @@ const readPixels = (ctx, w, h) =>
 
 test('a blitted scroll is byte-identical to the repaint it replaced', async (t) => {
   const app = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
   try {
     const ref = React.createRef();
     const instance = await new Promise((resolve) =>
-      ReactX11.render(
+      x11Root.render(
         h(
           'window',
           { width: 400, height: 300, style: { backgroundColor: '#f5f6fa' } },
@@ -321,7 +324,6 @@ test('a blitted scroll is byte-identical to the repaint it replaced', async (t) 
           ),
         ),
         resolve,
-        app,
       ),
     );
     if (typeof instance.scrollRegion !== 'function') {
@@ -360,7 +362,7 @@ test('a blitted scroll is byte-identical to the repaint it replaced', async (t) 
       'blitted pixels differ from a full repaint of the same state',
     );
   } finally {
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
     await app.close();
   }
 });

--- a/test/scrollbar.test.js
+++ b/test/scrollbar.test.js
@@ -4,17 +4,18 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
 import React from 'react';
-import ReactX11 from '../src/index.js';
+import { createRoot } from '../src/index.js';
 import { createMockApp } from './helpers/mock-app.js';
 
 const h = React.createElement;
 const tick = () => new Promise((resolve) => setImmediate(resolve));
 
 // 10 rows of 40 in a 100-tall viewport: 400 of content, 300 of scroll range
-function mount() {
+async function mount() {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const ref = React.createRef();
-  ReactX11.render(
+  x11Root.render(
     h(
       'window',
       { width: 200, height: 100 },
@@ -26,8 +27,6 @@ function mount() {
         ),
       ),
     ),
-    null,
-    app,
   );
   return { app, wnd: app.windows[0] };
 }
@@ -41,7 +40,8 @@ const drag = (wnd, from, to) => {
 };
 
 test('dragging the thumb scrolls in proportion to the pointer', async () => {
-  const { app, wnd } = mount();
+  const { app, wnd } = await mount();
+  const x11Root = await createRoot({ app });
   await tick();
   const sv = scroller(app);
   const bar = sv._scrollbar();
@@ -68,11 +68,12 @@ test('dragging the thumb scrolls in proportion to the pointer', async () => {
   assert.strictEqual(sv.scrollY, bar.range);
 
   wnd.emit('mouseup', { x: bar.x + 2, y: 10_000, keycode: 1 });
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('the drag keeps its grip on the thumb, without jumping', async () => {
-  const { app, wnd } = mount();
+  const { app, wnd } = await mount();
+  const x11Root = await createRoot({ app });
   await tick();
   const sv = scroller(app);
   const bar = sv._scrollbar();
@@ -87,11 +88,12 @@ test('the drag keeps its grip on the thumb, without jumping', async () => {
   assert.strictEqual(sv.scrollY, 0, 'grabbing the thumb does not move it');
   wnd.emit('mouseup', { x: bar.x + 2, y: bar.thumbStart, keycode: 1 });
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('a press on the track pages towards the pointer', async () => {
-  const { app, wnd } = mount();
+  const { app, wnd } = await mount();
+  const x11Root = await createRoot({ app });
   await tick();
   const sv = scroller(app);
   const bar = sv._scrollbar();
@@ -107,13 +109,14 @@ test('a press on the track pages towards the pointer', async () => {
   wnd.emit('mousedown', { x: bar.x + 2, y: bar.trackStart + 1, keycode: 1 });
   assert.strictEqual(sv.scrollY, 0, 'and back up again');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('the bar takes the press even with content painted under it', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const clicks = [];
-  ReactX11.render(
+  x11Root.render(
     h(
       'window',
       { width: 200, height: 100 },
@@ -129,8 +132,6 @@ test('the bar takes the press even with content painted under it', async () => {
         ),
       ),
     ),
-    null,
-    app,
   );
   await tick();
   const sv = scroller(app);
@@ -147,19 +148,18 @@ test('the bar takes the press even with content painted under it', async () => {
   drag(app.windows[0], { x: 10, y: 10 }, { x: 10, y: 10 });
   assert.deepStrictEqual(clicks, [0]);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('a <textarea> bar drag scrolls it, and never moves the caret', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     h(
       'window',
       { width: 200, height: 80 },
       h('textarea', { value: 'many lines', style: { flexGrow: 1 } }),
     ),
-    null,
-    app,
   );
   await tick();
 
@@ -207,17 +207,18 @@ test('a <textarea> bar drag scrolls it, and never moves the caret', async () => 
   area._defaultMouseDown({ x: content.x + 5, y: content.y + 5, detail: 1 });
   assert.ok(placed, 'a press away from the bar still places the caret');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 // --- horizontal ------------------------------------------------------------
 
 /** A row of fixed-width cells: wider than the viewport, and unable to
  * shrink, which is what a table of columns looks like. */
-function mountWide() {
+async function mountWide() {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const ref = React.createRef();
-  ReactX11.render(
+  x11Root.render(
     h(
       'window',
       { width: 200, height: 100 },
@@ -236,14 +237,13 @@ function mountWide() {
         ),
       ),
     ),
-    null,
-    app,
   );
   return { app, wnd: app.windows[0], ref };
 }
 
 test('content wider than the viewport scrolls sideways', async () => {
-  const { app, wnd } = mountWide();
+  const { app, wnd } = await mountWide();
+  const x11Root = await createRoot({ app });
   await tick();
   const sv = scroller(app);
 
@@ -268,11 +268,12 @@ test('content wider than the viewport scrolls sideways', async () => {
   );
   wnd.emit('mouseup', { x: 0, y: 0, keycode: 1 });
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('a sideways scroll moves the content, not just the number', async () => {
-  const { app, ref } = mountWide();
+  const { app, ref } = await mountWide();
+  const x11Root = await createRoot({ app });
   await tick();
   const sv = scroller(app);
   const firstCell = sv.children[0].children[0];
@@ -286,11 +287,12 @@ test('a sideways scroll moves the content, not just the number', async () => {
     'children are laid out shifted by the scroll',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('scrollTo takes a number for y, or an object for either axis', async () => {
-  const { app, ref } = mountWide();
+  const { app, ref } = await mountWide();
+  const x11Root = await createRoot({ app });
   await tick();
   const sv = scroller(app);
 
@@ -304,11 +306,12 @@ test('scrollTo takes a number for y, or an object for either axis', async () => 
   await tick();
   assert.strictEqual(sv.scrollX, 350);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('the horizontal wheel scrolls sideways, and Shift+wheel does too', async () => {
-  const { app, wnd } = mountWide();
+  const { app, wnd } = await mountWide();
+  const x11Root = await createRoot({ app });
   await tick();
   const sv = scroller(app);
 
@@ -324,11 +327,12 @@ test('the horizontal wheel scrolls sideways, and Shift+wheel does too', async ()
   assert.ok(sv.scrollX > after, 'Shift turned a vertical wheel sideways');
   assert.strictEqual(sv.scrollY, 0, 'and did not scroll down as well');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('scrollIntoView brings a node in from either side', async () => {
-  const { app, ref } = mountWide();
+  const { app, ref } = await mountWide();
+  const x11Root = await createRoot({ app });
   await tick();
   const sv = scroller(app);
   const last = sv.children[0].children[5];
@@ -341,12 +345,13 @@ test('scrollIntoView brings a node in from either side', async () => {
   await tick();
   assert.strictEqual(sv.scrollX, 0, 'and back left again');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('with both bars showing, neither runs into the other corner', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     h(
       'window',
       { width: 200, height: 100 },
@@ -361,8 +366,6 @@ test('with both bars showing, neither runs into the other corner', async () => {
         ),
       ),
     ),
-    null,
-    app,
   );
   await tick();
   const sv = scroller(app);
@@ -379,5 +382,5 @@ test('with both bars showing, neither runs into the other corner', async () => {
     'and so does the horizontal one',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });

--- a/test/size-queries.test.js
+++ b/test/size-queries.test.js
@@ -3,7 +3,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
 import React from 'react';
-import ReactX11 from '../src/index.js';
+import { createRoot } from '../src/index.js';
 import { createStyles } from '../src/styles.js';
 import { createMockApp } from './helpers/mock-app.js';
 
@@ -19,9 +19,10 @@ const responsive = createStyles({
   },
 });
 
-function mount(width) {
+async function mount(width) {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     h(
       'window',
       { width, height: 300 },
@@ -32,28 +33,29 @@ function mount(width) {
         h('box', { key: 'b', style: { width: 10, height: 10 } }),
       ),
     ),
-    null,
-    app,
   );
   return app;
 }
 
 test('a size query matches against the window it is laid out in', async () => {
-  const narrow = mount(400);
+  const narrow = await mount(400);
+  const x11Root_narrow = await createRoot({ app: narrow });
   await tick();
   assert.strictEqual(nodeOf(narrow).children[0].style.flexDirection, 'column');
   assert.strictEqual(nodeOf(narrow).children[0].style.gap, 4);
-  ReactX11.unmountComponentAtNode(narrow);
+  await x11Root_narrow.unmount();
 
-  const wide = mount(800);
+  const wide = await mount(800);
+  const x11Root_wide = await createRoot({ app: wide });
   await tick();
   assert.strictEqual(nodeOf(wide).children[0].style.flexDirection, 'row');
   assert.strictEqual(nodeOf(wide).children[0].style.gap, 16);
-  ReactX11.unmountComponentAtNode(wide);
+  await x11Root_wide.unmount();
 });
 
 test('resizing the window re-evaluates, and relays out', async () => {
-  const app = mount(400);
+  const app = await mount(400);
+  const x11Root = await createRoot({ app });
   await tick();
   const box = nodeOf(app).children[0];
   assert.strictEqual(box.style.flexDirection, 'column');
@@ -82,10 +84,10 @@ test('resizing the window re-evaluates, and relays out', async () => {
     'stacked again, with the narrow gap',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
-test('size queries may carry layout properties, unlike state blocks', () => {
+test('size queries may carry layout properties, unlike state blocks', async () => {
   // the rule: a pointer state must never reflow the tree, but a size query
   // is only re-evaluated inside a layout pass the resize already required
   createStyles({ a: { '@width >= 600': { padding: 20, flexGrow: 2 } } });
@@ -95,7 +97,7 @@ test('size queries may carry layout properties, unlike state blocks', () => {
   );
 });
 
-test('a bad query is an error that shows the shape', () => {
+test('a bad query is an error that shows the shape', async () => {
   assert.throws(
     () => createStyles({ a: { '@width => 600': {} } }),
     /bad size query "@width => 600"/,
@@ -108,7 +110,8 @@ test('a bad query is an error that shows the shape', () => {
 
 test('a state block inside the matched size still wins', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     h(
       'window',
       { width: 800, height: 300 },
@@ -121,8 +124,6 @@ test('a state block inside the matched size still wins', async () => {
         focusable: true,
       }),
     ),
-    null,
-    app,
   );
   await tick();
   const box = nodeOf(app).children[0];
@@ -135,13 +136,14 @@ test('a state block inside the matched size still wins', async () => {
     'state blocks fold in after the size, so hover wins',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('a node mounted after a resize matches the size the window is now', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const render = (extra) =>
-    ReactX11.render(
+    x11Root.render(
       h(
         'window',
         { width: 800, height: 300 },
@@ -151,8 +153,6 @@ test('a node mounted after a resize matches the size the window is now', async (
           ...(extra ? [h('box', { style: responsive.bar })] : []),
         ),
       ),
-      null,
-      app,
     );
 
   render(false);
@@ -167,12 +167,13 @@ test('a node mounted after a resize matches the size the window is now', async (
     'it did not miss the query just because it arrived late',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('a query that hides a node takes it out of the paint too', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     h(
       'window',
       { width: 400, height: 200 },
@@ -190,8 +191,6 @@ test('a query that hides a node takes it out of the paint too', async () => {
         }),
       ),
     ),
-    null,
-    app,
   );
   await tick();
 
@@ -206,5 +205,5 @@ test('a query that hides a node takes it out of the paint too', async () => {
   );
   assert.strictEqual(hidden.hitTest(5, 5), null, 'and takes no pointer input');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
 import React from 'react';
-import ReactX11 from '../src/index.js';
+import { createRoot } from '../src/index.js';
 
 const tick = () => new Promise((resolve) => setImmediate(resolve));
 
@@ -22,15 +22,16 @@ const XK = {
   Left: 0xff51,
 };
 
-test('renders a top-level window with a child window', () => {
+test('renders a top-level window with a child window', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const element = React.createElement(
     'window',
     { width: 300, height: 200, title: 'main' },
     React.createElement('window', { width: 50, height: 50, x: 10, y: 10 }),
   );
 
-  ReactX11.render(element, null, app);
+  x11Root.render(element);
 
   assert.strictEqual(app.windows.length, 2);
   // Windows are created top-down: the parent window first, then children
@@ -56,7 +57,7 @@ test('renders a top-level window with a child window', () => {
   );
   assert.strictEqual(child.mapped, true, 'child should be mapped');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 // Replay the recorded ConfigureWindow requests over the stack X gives a
@@ -72,8 +73,9 @@ function serverStack(app, createdIds) {
   return stack;
 }
 
-test('child windows stack in JSX order, and a reorder restacks them', () => {
+test('child windows stack in JSX order, and a reorder restacks them', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const App = ({ order }) =>
     React.createElement(
       'window',
@@ -88,11 +90,7 @@ test('child windows stack in JSX order, and a reorder restacks them', () => {
       ),
     );
 
-  ReactX11.render(
-    React.createElement(App, { order: ['a', 'b', 'c'] }),
-    null,
-    app,
-  );
+  x11Root.render(React.createElement(App, { order: ['a', 'b', 'c'] }));
   const [, a, b, c] = app.windows;
   assert.deepStrictEqual(
     [a.title, b.title, c.title],
@@ -105,11 +103,7 @@ test('child windows stack in JSX order, and a reorder restacks them', () => {
     'mount order already stacks right — X puts each new window on top',
   );
 
-  ReactX11.render(
-    React.createElement(App, { order: ['c', 'a', 'b'] }),
-    null,
-    app,
-  );
+  x11Root.render(React.createElement(App, { order: ['c', 'a', 'b'] }));
   const root = app.windows[0]._reactX11Node;
   assert.deepStrictEqual(
     root.children.map((child) => child.props.title),
@@ -132,13 +126,14 @@ test('child windows stack in JSX order, and a reorder restacks them', () => {
     'one pass per commit: n-1 requests, not one per moved child',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
-test('zIndex raises a child window above its later siblings', () => {
+test('zIndex raises a child window above its later siblings', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const render = (zIndex) =>
-    ReactX11.render(
+    x11Root.render(
       React.createElement(
         'window',
         { width: 300, height: 200 },
@@ -156,8 +151,6 @@ test('zIndex raises a child window above its later siblings', () => {
           height: 50,
         }),
       ),
-      null,
-      app,
     );
 
   render(0);
@@ -171,13 +164,14 @@ test('zIndex raises a child window above its later siblings', () => {
     'the higher zIndex ends up on top even though it comes first in JSX',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
-test('zIndex on a popup is inert — it is a child of the screen root', () => {
+test('zIndex on a popup is inert — it is a child of the screen root', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const render = (zIndex) =>
-    ReactX11.render(
+    x11Root.render(
       React.createElement(
         'window',
         { width: 300, height: 200 },
@@ -193,19 +187,18 @@ test('zIndex on a popup is inert — it is a child of the screen root', () => {
           }),
         ),
       ),
-      null,
-      app,
     );
 
   render(0);
   render(2); // must not try to restack the <box> the popup is written under
   assert.deepStrictEqual(app.configureCalls, []);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
-test('reordering keyed drawn children moves them instead of duplicating', () => {
+test('reordering keyed drawn children moves them instead of duplicating', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const App = ({ order }) =>
     React.createElement(
       'window',
@@ -218,19 +211,11 @@ test('reordering keyed drawn children moves them instead of duplicating', () => 
       ),
     );
 
-  ReactX11.render(
-    React.createElement(App, { order: ['red', 'green', 'blue'] }),
-    null,
-    app,
-  );
+  x11Root.render(React.createElement(App, { order: ['red', 'green', 'blue'] }));
   const root = app.windows[0]._reactX11Node;
   const green = root.children[1];
 
-  ReactX11.render(
-    React.createElement(App, { order: ['blue', 'red', 'green'] }),
-    null,
-    app,
-  );
+  x11Root.render(React.createElement(App, { order: ['blue', 'red', 'green'] }));
 
   assert.deepStrictEqual(
     root.children.map((child) => child.style.backgroundColor),
@@ -247,13 +232,14 @@ test('reordering keyed drawn children moves them instead of duplicating', () => 
   // has a parent aborts the wasm module
   assert.strictEqual(root.yoga.getChildCount(), 3);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
-test('applies prop updates to the window', () => {
+test('applies prop updates to the window', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const render = (props) =>
-    ReactX11.render(React.createElement('window', props), null, app);
+    x11Root.render(React.createElement('window', props));
 
   render({ width: 300, height: 200, title: 'before', x: 0, y: 0 });
   const wnd = app.windows[0];
@@ -265,13 +251,14 @@ test('applies prop updates to the window', () => {
   assert.deepStrictEqual([wnd.width, wnd.height], [400, 250]);
   assert.deepStrictEqual([wnd.x, wnd.y], [20, 30]);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
-test('adds a child to an already-mounted window top-down', () => {
+test('adds a child to an already-mounted window top-down', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const render = (withChild) =>
-    ReactX11.render(
+    x11Root.render(
       React.createElement(
         'window',
         { width: 300, height: 200 },
@@ -279,8 +266,6 @@ test('adds a child to an already-mounted window top-down', () => {
           ? React.createElement('window', { width: 10, height: 10 })
           : null,
       ),
-      null,
-      app,
     );
 
   render(false);
@@ -298,13 +283,14 @@ test('adds a child to an already-mounted window top-down', () => {
   assert.strictEqual(child.mapped, true);
   assert.ok(!child.calls.some(([name]) => name === 'reparentTo'));
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
-test('destroys windows that are removed', () => {
+test('destroys windows that are removed', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const render = (withChild) =>
-    ReactX11.render(
+    x11Root.render(
       React.createElement(
         'window',
         { width: 300, height: 200 },
@@ -312,8 +298,6 @@ test('destroys windows that are removed', () => {
           ? React.createElement('window', { width: 10, height: 10 })
           : null,
       ),
-      null,
-      app,
     );
 
   render(true);
@@ -327,41 +311,36 @@ test('destroys windows that are removed', () => {
     'removed child window should be destroyed',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
-test('unmounting destroys the top-level window', () => {
+test('unmounting destroys the top-level window', async () => {
   const app = createMockApp();
-  ReactX11.render(
-    React.createElement('window', { width: 100, height: 100 }),
-    null,
-    app,
-  );
+  const x11Root = await createRoot({ app });
+  x11Root.render(React.createElement('window', { width: 100, height: 100 }));
   const wnd = app.windows[0];
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
   assert.strictEqual(wnd.destroyed, true);
 });
 
-test('function components and state-driven rendering work', () => {
+test('function components and state-driven rendering work', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   function App({ title }) {
     return React.createElement('window', { width: 100, height: 100, title });
   }
 
-  ReactX11.render(
-    React.createElement(App, { title: 'fn component' }),
-    null,
-    app,
-  );
+  x11Root.render(React.createElement(App, { title: 'fn component' }));
   assert.strictEqual(app.windows[0].attributes.title, 'fn component');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('lays out a flex box tree with yoga and paints it', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     React.createElement(
       'window',
       { width: 200, height: 100 },
@@ -376,8 +355,6 @@ test('lays out a flex box tree with yoga and paints it', async () => {
         }),
       ),
     ),
-    null,
-    app,
   );
   await tick();
 
@@ -394,13 +371,14 @@ test('lays out a flex box tree with yoga and paints it', async () => {
   assert.deepStrictEqual(fills.at(-2), ['fillRect', 0, 0, 100, 100, 'red']);
   assert.deepStrictEqual(fills.at(-1), ['fillRect', 100, 0, 100, 100, 'blue']);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('updates reflow the tree', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const render = (direction) =>
-    ReactX11.render(
+    x11Root.render(
       React.createElement(
         'window',
         { width: 200, height: 100 },
@@ -411,8 +389,6 @@ test('updates reflow the tree', async () => {
           React.createElement('box', { style: { flexGrow: 1 } }),
         ),
       ),
-      null,
-      app,
     );
 
   render('row');
@@ -427,13 +403,14 @@ test('updates reflow the tree', async () => {
     [0, 50],
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('dispatches synthetic clicks, hover and focus events', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const log = [];
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 200, height: 100 },
@@ -457,8 +434,6 @@ test('dispatches synthetic clicks, hover and focus events', async () => {
         React.createElement('box', { style: { flexGrow: 1 } }),
       ),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -478,13 +453,14 @@ test('dispatches synthetic clicks, hover and focus events', async () => {
     'outer',
   ]);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('zIndex controls hit testing order', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const log = [];
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 100, height: 100 },
@@ -510,8 +486,6 @@ test('zIndex controls hit testing order', async () => {
         },
       }),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -519,13 +493,14 @@ test('zIndex controls hit testing order', async () => {
   wnd.emit('mouseup', { x: 50, y: 50, keycode: 1 });
 
   assert.deepStrictEqual(log, ['top']);
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('scrollview scrolls, clamps and offsets hit testing', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const clicks = [];
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 100, height: 100 },
@@ -541,8 +516,6 @@ test('scrollview scrolls, clamps and offsets hit testing', async () => {
         ),
       ),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -567,11 +540,12 @@ test('scrollview scrolls, clamps and offsets hit testing', async () => {
   wnd.emit('mouseup', { x: 50, y: 10, keycode: 1 });
   assert.deepStrictEqual(clicks, [1]);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('a shrinking window shrinks the scrollview, not the footer out of view', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const Host = ({ height }) =>
     React.createElement(
       'window',
@@ -594,7 +568,7 @@ test('a shrinking window shrinks the scrollview, not the footer out of view', as
       ),
     );
 
-  ReactX11.render(React.createElement(Host, { height: 400 }), null, app);
+  x11Root.render(React.createElement(Host, { height: 400 }));
   await tick();
   const wnd = app.windows[0];
   const root = wnd._reactX11Node;
@@ -628,12 +602,13 @@ test('a shrinking window shrinks the scrollview, not the footer out of view', as
     'and its content now overflows, so it scrolls',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('scrollview scrollIntoView scrolls the minimum amount', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     React.createElement(
       'window',
       { width: 100, height: 100 },
@@ -645,8 +620,6 @@ test('scrollview scrollIntoView scrolls the minimum amount', async () => {
         ),
       ),
     ),
-    null,
-    app,
   );
   await tick();
   const sv = app.windows[0]._reactX11Node.children[0];
@@ -671,16 +644,15 @@ test('scrollview scrollIntoView scrolls the minimum amount', async () => {
   await tick();
   assert.strictEqual(sv.scrollY, 0);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
-test('window manager hints pass through at creation and on update', () => {
+test('window manager hints pass through at creation and on update', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const render = (props) =>
-    ReactX11.render(
+    x11Root.render(
       React.createElement('window', { width: 200, height: 100, ...props }),
-      null,
-      app,
     );
 
   // creation goes through ntk's Window constructor as creation attributes
@@ -745,13 +717,14 @@ test('window manager hints pass through at creation and on update', () => {
     "dropping alwaysOnTop removes 'above'",
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
-test('popup mounts as an override-redirect window and unmounts cleanly', () => {
+test('popup mounts as an override-redirect window and unmounts cleanly', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const render = (open) =>
-    ReactX11.render(
+    x11Root.render(
       React.createElement(
         'window',
         { width: 200, height: 100 },
@@ -768,8 +741,6 @@ test('popup mounts as an override-redirect window and unmounts cleanly', () => {
             : null,
         ),
       ),
-      null,
-      app,
     );
 
   render(false);
@@ -789,12 +760,13 @@ test('popup mounts as an override-redirect window and unmounts cleanly', () => {
   render(false);
   assert.strictEqual(popup.destroyed, true);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('cursor prop follows hover (feature-detected setCursor)', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     React.createElement(
       'window',
       { width: 200, height: 100 },
@@ -807,8 +779,6 @@ test('cursor prop follows hover (feature-detected setCursor)', async () => {
         React.createElement('box', { style: { flexGrow: 1 } }),
       ),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -819,14 +789,15 @@ test('cursor prop follows hover (feature-detected setCursor)', async () => {
   wnd.emit('mousemove', { x: 150, y: 10 });
   assert.strictEqual(wnd.cursor, null, 'leaving the node restores the cursor');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('textinput: typing, backspace, arrows, submit (uncontrolled)', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const changes = [];
   let submitted = null;
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 200, height: 50 },
@@ -837,8 +808,6 @@ test('textinput: typing, backspace, arrows, submit (uncontrolled)', async () => 
         style: { flexGrow: 1 },
       }),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -865,14 +834,15 @@ test('textinput: typing, backspace, arrows, submit (uncontrolled)', async () => 
   pressKey(app, wnd, { keysym: XK.Return });
   assert.strictEqual(submitted, 'oh');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('textinput: controlled value does not change until props do', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const changes = [];
   const render = (value) =>
-    ReactX11.render(
+    x11Root.render(
       React.createElement(
         'window',
         { width: 200, height: 50 },
@@ -882,8 +852,6 @@ test('textinput: controlled value does not change until props do', async () => {
           style: { flexGrow: 1 },
         }),
       ),
-      null,
-      app,
     );
   render('abc');
   await tick();
@@ -900,7 +868,7 @@ test('textinput: controlled value does not change until props do', async () => {
   render('abcx');
   assert.strictEqual(input.value, 'abcx');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 // issue #115: onChange/onSubmit hand over a synthetic event like every other
@@ -908,6 +876,7 @@ test('textinput: controlled value does not change until props do', async () => {
 // tutorial's controlled input read — is the value the edit produced.
 test('textinput: onChange gets a synthetic event carrying value and name', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const events = [];
   // `ev.target` is the live node, so what it reports has to be sampled while
   // the handler runs — that is the moment form libraries read it
@@ -916,7 +885,7 @@ test('textinput: onChange gets a synthetic event carrying value and name', async
     events.push(ev);
     seen.push({ value: ev.target.value, name: ev.target.name });
   };
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 200, height: 50 },
@@ -930,8 +899,6 @@ test('textinput: onChange gets a synthetic event carrying value and name', async
         style: { flexGrow: 1 },
       }),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -970,7 +937,7 @@ test('textinput: onChange gets a synthetic event carrying value and name', async
   assert.deepStrictEqual(seen[1], { value: 'ab', name: 'email' });
   assert.ok(submit.nativeEvent, 'submit carries the key event it came from');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 // react-hook-form's register() hands the field ref back and writes through
@@ -978,8 +945,9 @@ test('textinput: onChange gets a synthetic event carrying value and name', async
 // that a TypeError during commit, which took the whole render down.
 test('textinput: node.value is writable, the way a DOM input is', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const changes = [];
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 200, height: 50 },
@@ -989,8 +957,6 @@ test('textinput: node.value is writable, the way a DOM input is', async () => {
         style: { flexGrow: 1 },
       }),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -1006,13 +972,14 @@ test('textinput: node.value is writable, the way a DOM input is', async () => {
   assert.strictEqual(input.undo(), true);
   assert.strictEqual(input.value, 'written');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('textarea: Ctrl+Enter submits with the same event shape', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   let submitted = null;
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 200, height: 90 },
@@ -1023,8 +990,6 @@ test('textarea: Ctrl+Enter submits with the same event shape', async () => {
         style: { flexGrow: 1 },
       }),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -1037,18 +1002,19 @@ test('textarea: Ctrl+Enter submits with the same event shape', async () => {
   assert.strictEqual(submitted.name, 'body');
   assert.strictEqual(submitted.target.name, 'body');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 // a throwing handler must not leave the control reporting a value it never
 // took — `_pendingValue` is restored in a finally
 test('textinput: a throwing onChange does not strand the pending value', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const errors = [];
   const console_error = console.error;
   console.error = (...args) => errors.push(args);
   try {
-    ReactX11.render(
+    x11Root.render(
       React.createElement(
         'window',
         { width: 200, height: 50 },
@@ -1060,8 +1026,6 @@ test('textinput: a throwing onChange does not strand the pending value', async (
           style: { flexGrow: 1 },
         }),
       ),
-      null,
-      app,
     );
     await tick();
     const wnd = app.windows[0];
@@ -1075,7 +1039,7 @@ test('textinput: a throwing onChange does not strand the pending value', async (
       1,
       'the throw is reported, not swallowed',
     );
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
   } finally {
     console.error = console_error;
     process.exitCode = 0;
@@ -1084,6 +1048,7 @@ test('textinput: a throwing onChange does not strand the pending value', async (
 
 test('textinput: clipboard shortcuts and middle-click PRIMARY paste', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   app.clipboard = {
     writes: [],
     write(text, opts) {
@@ -1096,7 +1061,7 @@ test('textinput: clipboard shortcuts and middle-click PRIMARY paste', async () =
       );
     },
   };
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 200, height: 50 },
@@ -1105,8 +1070,6 @@ test('textinput: clipboard shortcuts and middle-click PRIMARY paste', async () =
         style: { flexGrow: 1 },
       }),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -1129,12 +1092,13 @@ test('textinput: clipboard shortcuts and middle-click PRIMARY paste', async () =
   await tick();
   assert.strictEqual(input.value, 'clip!primary!');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('dashed borders emit setLineDash when the context supports it', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     React.createElement(
       'window',
       { width: 100, height: 100 },
@@ -1147,19 +1111,18 @@ test('dashed borders emit setLineDash when the context supports it', async () =>
         },
       }),
     ),
-    null,
-    app,
   );
   await tick();
   const dashOps = app.windows[0].ctx.ops.filter(([op]) => op === 'setLineDash');
   assert.deepStrictEqual(dashOps[0], ['setLineDash', [6, 4]]);
   assert.deepStrictEqual(dashOps.at(-1), ['setLineDash', []]);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('textinput: double-click selects word, triple-click selects all', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   app.clipboard = {
     writes: [],
     write(text, opts) {
@@ -1170,7 +1133,7 @@ test('textinput: double-click selects word, triple-click selects all', async () 
       return Promise.resolve('');
     },
   };
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 200, height: 50 },
@@ -1179,8 +1142,6 @@ test('textinput: double-click selects word, triple-click selects all', async () 
         style: { flexGrow: 1 },
       }),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -1199,14 +1160,15 @@ test('textinput: double-click selects word, triple-click selects all', async () 
   clickAt(10, 10); // detail 3 → select all
   assert.deepStrictEqual(input._selection(), [0, 11]);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('Select opens a popup menu, picks an option, closes on Escape', async () => {
   const { Select } = await import('../src/index.js');
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const picks = [];
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 240, height: 120 },
@@ -1221,8 +1183,6 @@ test('Select opens a popup menu, picks an option, closes on Escape', async () =>
         }),
       ),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -1269,7 +1229,7 @@ test('Select opens a popup menu, picks an option, closes on Escape', async () =>
   await tick();
   assert.strictEqual(app.windows[2].destroyed, true);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('Select: arrow keys move the active option, Enter picks it', async () => {
@@ -1281,8 +1241,9 @@ test('Select: arrow keys move the active option, Enter picks it', async () => {
   const HOVER_BG = '#2980b9';
 
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const picks = [];
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 240, height: 120 },
@@ -1297,8 +1258,6 @@ test('Select: arrow keys move the active option, Enter picks it', async () => {
         }),
       ),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -1373,7 +1332,7 @@ test('Select: arrow keys move the active option, Enter picks it', async () => {
   assert.strictEqual(app.windows[2].destroyed, true);
   assert.deepStrictEqual(picks, ['blue'], 'Escape does not pick');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('Select: an overlong menu scrolls the active option into view', async () => {
@@ -1384,7 +1343,8 @@ test('Select: an overlong menu scrolls the active option into view', async () =>
   const options = Array.from({ length: 12 }, (_, i) => `option-${i}`);
 
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     React.createElement(
       'window',
       { width: 300, height: 120 },
@@ -1398,8 +1358,6 @@ test('Select: an overlong menu scrolls the active option into view', async () =>
         }),
       ),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -1468,7 +1426,7 @@ test('Select: an overlong menu scrolls the active option into view', async () =>
     4 + options.length * ITEM_HEIGHT - scroller.abs.height,
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 // The menu used to take the trigger's width, and the trigger is only ever as
@@ -1484,7 +1442,8 @@ test('Select: the menu fits its longest option, not the selected one', async () 
 
   const openWith = async (selected) => {
     const app = createMockApp();
-    ReactX11.render(
+    const x11Root = await createRoot({ app });
+    x11Root.render(
       React.createElement(
         'window',
         { width: 400, height: 200 },
@@ -1498,8 +1457,6 @@ test('Select: the menu fits its longest option, not the selected one', async () 
           }),
         ),
       ),
-      null,
-      app,
     );
     await tick();
     const wnd = app.windows[0];
@@ -1518,10 +1475,10 @@ test('Select: the menu fits its longest option, not the selected one', async () 
     wnd.emit('mousedown', { x, y, keycode: 1 });
     wnd.emit('mouseup', { x, y, keycode: 1 });
     await tick();
-    return { app, trigger, popup: app.windows[1] };
+    return { app, x11Root, trigger, popup: app.windows[1] };
   };
 
-  const { app, trigger, popup } = await openWith('S');
+  const { x11Root, trigger, popup } = await openWith('S');
   assert.ok(
     popup.attributes.width > trigger.abs.width,
     `menu (${popup.attributes.width}) should outgrow the trigger (${trigger.abs.width})`,
@@ -1536,7 +1493,7 @@ test('Select: the menu fits its longest option, not the selected one', async () 
     popup.attributes.width >= Math.ceil(longest) + 10,
     `menu (${popup.attributes.width}) should fit the longest label (${Math.ceil(longest)})`,
   );
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 
   // and it does not depend on which option is selected: the widest one is
   // measured bold, the way Option paints it, so that case is the wider one
@@ -1545,13 +1502,14 @@ test('Select: the menu fits its longest option, not the selected one', async () 
     withLongSelected.popup.attributes.width >= popup.attributes.width,
     'selecting the longest option must not shrink the menu',
   );
-  ReactX11.unmountComponentAtNode(withLongSelected.app);
+  await withLongSelected.x11Root.unmount();
 });
 
 test('Select: the menu is never narrower than the trigger', async () => {
   const { Select } = await import('../src/index.js');
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     React.createElement(
       'window',
       { width: 400, height: 200 },
@@ -1565,8 +1523,6 @@ test('Select: the menu is never narrower than the trigger', async () => {
         }),
       ),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -1591,12 +1547,13 @@ test('Select: the menu is never narrower than the trigger', async () => {
     trigger.abs.width,
     'two one-letter options still open a menu the width of the trigger',
   );
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
-test('text spans collect nested styles', () => {
+test('text spans collect nested styles', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     React.createElement(
       'window',
       { width: 100, height: 100 },
@@ -1611,8 +1568,6 @@ test('text spans collect nested styles', () => {
         ),
       ),
     ),
-    null,
-    app,
   );
 
   const textNode = app.windows[0]._reactX11Node.children[0];
@@ -1636,7 +1591,7 @@ test('text spans collect nested styles', () => {
     ['world', 'bold', 'red'],
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('DevTools agent highlight tints the hovered node', async () => {
@@ -1644,7 +1599,8 @@ test('DevTools agent highlight tints the hovered node', async () => {
   const { attachHighlightAgent } =
     await import('../src/DevToolsIntegration.js');
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     React.createElement(
       'window',
       { width: 200, height: 100 },
@@ -1657,8 +1613,6 @@ test('DevTools agent highlight tints the hovered node', async () => {
         }),
       ),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -1705,11 +1659,12 @@ test('DevTools agent highlight tints the hovered node', async () => {
     'highlight cleared on hide',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('rich content elements mount, update and unmount headlessly', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const ui = (md) =>
     React.createElement(
       'window',
@@ -1727,15 +1682,15 @@ test('rich content elements mount, update and unmount headlessly', async () => {
       React.createElement('tex', { size: 20 }, 'x^2'),
     );
 
-  ReactX11.render(ui('# One'), null, app);
+  x11Root.render(ui('# One'));
   await tick(); // paint flush: no fonts on the mock app, must not throw
   const [wnd] = app.windows;
   assert.ok(wnd.mapped, 'window mounted with rich content children');
 
-  ReactX11.render(ui('# Two'), null, app);
+  x11Root.render(ui('# Two'));
   await tick();
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
   assert.ok(wnd.destroyed, 'clean unmount');
 });
 
@@ -1759,8 +1714,9 @@ const clickNode = (wnd, node) => {
 test('Button fires onPress via click and Space; disabled is inert', async () => {
   const { Button } = await import('../src/index.js');
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const presses = [];
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 300, height: 200 },
@@ -1785,8 +1741,6 @@ test('Button fires onPress via click and Space; disabled is inert', async () => 
         }),
       ),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -1817,12 +1771,13 @@ test('Button fires onPress via click and Space; disabled is inert', async () => 
   })(wnd._reactX11Node);
   clickNode(wnd, disabledText.parent);
   assert.deepStrictEqual(presses, ['go', 'go']);
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('Checkbox and Switch toggle through onChange', async () => {
   const { Checkbox, Switch } = await import('../src/index.js');
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const log = [];
   function Wrapper() {
     const [checked, setChecked] = React.useState(false);
@@ -1852,14 +1807,12 @@ test('Checkbox and Switch toggle through onChange', async () => {
       }),
     );
   }
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 300, height: 200 },
       React.createElement(Wrapper),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -1876,7 +1829,7 @@ test('Checkbox and Switch toggle through onChange', async () => {
     ['check', false],
     ['switch', true],
   ]);
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 // One signature across the library: the value widgets hand `onChange` a
@@ -1886,6 +1839,7 @@ test('value widgets pass a named change event to onChange', async () => {
   const { Checkbox, RadioGroup, Radio, Slider } =
     await import('../src/index.js');
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const events = [];
   function Wrapper() {
     const [checked, setChecked] = React.useState(false);
@@ -1928,14 +1882,12 @@ test('value widgets pass a named change event to onChange', async () => {
       }),
     );
   }
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 300, height: 240 },
       React.createElement(Wrapper),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -1970,7 +1922,7 @@ test('value widgets pass a named change event to onChange', async () => {
     assert.strictEqual(typeof ev, 'object');
     assert.strictEqual(ev.type, 'change');
   }
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 // The contract that matters, stated as the thing a user actually writes.
@@ -1979,6 +1931,7 @@ test('value widgets pass a named change event to onChange', async () => {
 test('a one-parameter handler is handed the event, not the value', async () => {
   const { Checkbox } = await import('../src/index.js');
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const seen = [];
   // exactly the shape of formik's handleChange: one parameter, destructures
   // the field out of `.target`
@@ -1995,26 +1948,25 @@ test('a one-parameter handler is handed the event, not the value', async () => {
       },
     });
   }
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 200, height: 100 },
       React.createElement(Wrapper),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
   clickNode(wnd, findAllFocusable(wnd._reactX11Node)[0]);
   await tick();
   assert.deepStrictEqual(seen, [['agree', 'checkbox', true]]);
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('RadioGroup: click selects, arrow keys move selection (wrapping)', async () => {
   const { Radio, RadioGroup } = await import('../src/index.js');
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const picks = [];
   function Wrapper() {
     const [value, setValue] = React.useState('a');
@@ -2032,14 +1984,12 @@ test('RadioGroup: click selects, arrow keys move selection (wrapping)', async ()
       React.createElement(Radio, { value: 'c' }, 'C'),
     );
   }
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 300, height: 200 },
       React.createElement(Wrapper),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -2055,13 +2005,14 @@ test('RadioGroup: click selects, arrow keys move selection (wrapping)', async ()
   pressKey(app, wnd, { keysym: 0xff52 }); // Up wraps back -> C
   await tick();
   assert.deepStrictEqual(picks, ['b', 'c', 'a', 'c']);
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('ProgressBar fill width follows value', async () => {
   const { ProgressBar } = await import('../src/index.js');
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     React.createElement(
       'window',
       { width: 300, height: 100 },
@@ -2071,8 +2022,6 @@ test('ProgressBar fill width follows value', async () => {
         React.createElement(ProgressBar, { value: 0.5, style: { width: 200 } }),
       ),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -2092,7 +2041,7 @@ test('ProgressBar fill width follows value', async () => {
     Math.abs(fill.abs.width - 100) <= 1,
     `fill should be ~half the track, got ${fill.abs.width}`,
   );
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 // issue #130 -------------------------------------------------------------
@@ -2103,6 +2052,7 @@ test('ProgressBar fill width follows value', async () => {
 // is still null. That is the case a multi-window app is made of.
 test('transientFor resolves a ref that attaches after the window realized', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const main = React.createRef();
   const App = () =>
     React.createElement(
@@ -2115,7 +2065,7 @@ test('transientFor resolves a ref that attaches after the window realized', asyn
         transientFor: main,
       }),
     );
-  ReactX11.render(React.createElement(App), null, app);
+  x11Root.render(React.createElement(App));
   const [owner, transient] = app.windows;
   // realize() ran with main.current still null, so nothing could be written
   assert.strictEqual(transient.transientFor, undefined);
@@ -2132,14 +2082,15 @@ test('transientFor resolves a ref that attaches after the window realized', asyn
     false,
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('transientFor takes an XID, a drawn-node ref, and null to clear', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const anchor = React.createRef();
   const render = (transientFor) =>
-    ReactX11.render(
+    x11Root.render(
       React.createElement(
         'window',
         { width: 300, height: 200 },
@@ -2150,8 +2101,6 @@ test('transientFor takes an XID, a drawn-node ref, and null to clear', async () 
           transientFor,
         }),
       ),
-      null,
-      app,
     );
 
   render(4242);
@@ -2172,10 +2121,9 @@ test('transientFor takes an XID, a drawn-node ref, and null to clear', async () 
 
   // and a window that never set one does not spend a DeleteProperty saying so
   const fresh = createMockApp();
-  ReactX11.render(
+  const x11Root_fresh = await createRoot({ app: fresh });
+  x11Root_fresh.render(
     React.createElement('window', { width: 100, height: 100 }),
-    null,
-    fresh,
   );
   await tick();
   assert.strictEqual(
@@ -2183,13 +2131,14 @@ test('transientFor takes an XID, a drawn-node ref, and null to clear', async () 
     false,
   );
 
-  ReactX11.unmountComponentAtNode(app);
-  ReactX11.unmountComponentAtNode(fresh);
+  await x11Root.unmount();
+  await x11Root_fresh.unmount();
 });
 
 test('a <popup> can opt out of override-redirect and be WM-managed', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     React.createElement(
       'window',
       { width: 300, height: 200 },
@@ -2208,8 +2157,6 @@ test('a <popup> can opt out of override-redirect and be WM-managed', async () =>
         windowType: 'dialog',
       }),
     ),
-    null,
-    app,
   );
   await tick();
   const [, menu, dialog] = app.windows;
@@ -2222,22 +2169,21 @@ test('a <popup> can opt out of override-redirect and be WM-managed', async () =>
   assert.strictEqual(dialog.attributes.overrideRedirect, false);
   assert.strictEqual(dialog.attributes.windowType, 'dialog');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('windowIdOf resolves windows, drawn nodes, refs and raw ids', async () => {
   const { windowIdOf } = await import('../src/index.js');
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const windowRef = React.createRef();
   const boxRef = React.createRef();
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { ref: windowRef, width: 300, height: 200 },
       React.createElement('box', { ref: boxRef }),
     ),
-    null,
-    app,
   );
   await tick();
   const id = app.windows[0].id;
@@ -2260,11 +2206,12 @@ test('windowIdOf resolves windows, drawn nodes, refs and raw ids', async () => {
     `x11:${id.toString(16)}`,
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('multiple root windows share one tree; onCloseRequest handles WM close', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const events = [];
   function Wrapper() {
     const [open, setOpen] = React.useState(true);
@@ -2289,7 +2236,7 @@ test('multiple root windows share one tree; onCloseRequest handles WM close', as
         }),
     );
   }
-  ReactX11.render(React.createElement(Wrapper), null, app);
+  x11Root.render(React.createElement(Wrapper));
   await tick();
   assert.strictEqual(app.windows.length, 2, 'two real top-level windows');
   const sat = app.windows[1];
@@ -2314,12 +2261,13 @@ test('multiple root windows share one tree; onCloseRequest handles WM close', as
   await tick();
   assert.deepStrictEqual(events, ['sat-close']);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('Slider: drag keeps tracking after the pointer leaves the widget', async () => {
   const { Slider } = await import('../src/index.js');
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const seen = [];
   const Host = () => {
     const [v, setV] = React.useState(0);
@@ -2341,7 +2289,7 @@ test('Slider: drag keeps tracking after the pointer leaves the widget', async ()
       ),
     );
   };
-  ReactX11.render(React.createElement(Host), null, app);
+  x11Root.render(React.createElement(Host));
   await tick();
 
   const wnd = app.windows[0];
@@ -2402,12 +2350,13 @@ test('Slider: drag keeps tracking after the pointer leaves the widget', async ()
   await tick();
   assert.strictEqual(seen.at(-1), afterRelease, 'no tracking after release');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('Slider: keyboard steps, Home/End and PageUp/Down', async () => {
   const { Slider } = await import('../src/index.js');
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   let current = 50;
   const Host = () => {
     const [v, setV] = React.useState(50);
@@ -2429,7 +2378,7 @@ test('Slider: keyboard steps, Home/End and PageUp/Down', async () => {
       ),
     );
   };
-  ReactX11.render(React.createElement(Host), null, app);
+  x11Root.render(React.createElement(Host));
   await tick();
 
   const wnd = app.windows[0];
@@ -2468,7 +2417,7 @@ test('Slider: keyboard steps, Home/End and PageUp/Down', async () => {
   await press(0xff56); // PageDown
   assert.strictEqual(current, 0);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('Slider: thumb stays within the track at both extremes', async () => {
@@ -2487,7 +2436,8 @@ test('Slider: thumb stays within the track at both extremes', async () => {
     [100, 'flush right'],
   ]) {
     const app = createMockApp();
-    ReactX11.render(
+    const x11Root = await createRoot({ app });
+    x11Root.render(
       React.createElement(
         'window',
         { width: 400, height: 100 },
@@ -2502,8 +2452,6 @@ test('Slider: thumb stays within the track at both extremes', async () => {
           }),
         ),
       ),
-      null,
-      app,
     );
     await tick();
     const track = findTrack(app.windows[0]._reactX11Node);
@@ -2524,7 +2472,7 @@ test('Slider: thumb stays within the track at both extremes', async () => {
         'midpoint value centres the thumb',
       );
     }
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
   }
 });
 
@@ -2617,8 +2565,9 @@ test('anchorRect places, flips at a screen edge and clamps', async () => {
 
 test('window focus: the focused node keeps focus but stops looking active', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const events = [];
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       {
@@ -2632,8 +2581,6 @@ test('window focus: the focused node keeps focus but stops looking active', asyn
         style: { width: 120, height: 24 },
       }),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -2662,14 +2609,15 @@ test('window focus: the focused node keeps focus but stops looking active', asyn
   );
   assert.deepStrictEqual(events, ['window:blur', 'window:focus']);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('focus(): ref API, autoFocus, and blur', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const seen = [];
   const ref = React.createRef();
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 200, height: 100 },
@@ -2687,8 +2635,6 @@ test('focus(): ref API, autoFocus, and blur', async () => {
         style: { width: 40, height: 20 },
       }),
     ),
-    null,
-    app,
   );
   await tick();
 
@@ -2702,12 +2648,13 @@ test('focus(): ref API, autoFocus, and blur', async () => {
   assert.strictEqual(ref.current.focused, false);
   assert.deepStrictEqual(seen, ['b:focus', 'a:focus', 'a:blur']);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('Tab into a scrollview scrolls the focused node into view', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     React.createElement(
       'window',
       { width: 200, height: 100 },
@@ -2723,8 +2670,6 @@ test('Tab into a scrollview scrolls the focused node into view', async () => {
         ),
       ),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -2737,11 +2682,12 @@ test('Tab into a scrollview scrolls the focused node into view', async () => {
   await tick();
   assert.ok(scroll.scrollY > 0, `scrolled to reveal it (${scroll.scrollY})`);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('tabIndex orders Tab traversal; -1 focuses but never tabs', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const box = (tabIndex, extra) =>
     React.createElement('box', {
       key: String(tabIndex),
@@ -2751,7 +2697,7 @@ test('tabIndex orders Tab traversal; -1 focuses but never tabs', async () => {
       style: { width: 100, height: 20 },
     });
   const refs = { plain: null, two: null, one: null, skip: null };
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 200, height: 200 },
@@ -2760,8 +2706,6 @@ test('tabIndex orders Tab traversal; -1 focuses but never tabs', async () => {
       box(1, { ref: (n) => (refs.one = n) }),
       box(-1, { ref: (n) => (refs.skip = n) }),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -2791,14 +2735,15 @@ test('tabIndex orders Tab traversal; -1 focuses but never tabs', async () => {
   skip.focus();
   assert.strictEqual(skip.focused, true, 'focus() works on it too');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('<popup> shares the owner window focus, so keys reach into it', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const seen = [];
   let inner = null;
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 300, height: 200, onKeyDown: () => seen.push('window') },
@@ -2814,8 +2759,6 @@ test('<popup> shares the owner window focus, so keys reach into it', async () =>
         }),
       ),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -2843,11 +2786,12 @@ test('<popup> shares the owner window focus, so keys reach into it', async () =>
   pressKey(app, wnd, { codepoint: 0x78 });
   assert.deepStrictEqual(seen, ['box', 'window']);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('<popup trapFocus> traps Tab and restores focus when it closes', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const refs = { trigger: null, other: null, first: null, second: null };
   const App = ({ open }) =>
     React.createElement(
@@ -2881,13 +2825,13 @@ test('<popup trapFocus> traps Tab and restores focus when it closes', async () =
         ),
     );
 
-  ReactX11.render(React.createElement(App, { open: false }), null, app);
+  x11Root.render(React.createElement(App, { open: false }));
   await tick();
   const wnd = app.windows[0];
   refs.trigger.focus();
   assert.strictEqual(refs.trigger.focused, true, 'the trigger has focus');
 
-  ReactX11.render(React.createElement(App, { open: true }), null, app);
+  x11Root.render(React.createElement(App, { open: true }));
   await tick();
   assert.strictEqual(refs.first.focused, true, 'the modal took focus');
 
@@ -2908,7 +2852,7 @@ test('<popup trapFocus> traps Tab and restores focus when it closes', async () =
   assert.strictEqual(refs.trigger.focused, false, 'the press was inert');
   assert.strictEqual(refs.first.focused, true, 'focus stayed in the modal');
 
-  ReactX11.render(React.createElement(App, { open: false }), null, app);
+  x11Root.render(React.createElement(App, { open: false }));
   await tick();
   assert.strictEqual(
     refs.trigger.focused,
@@ -2916,12 +2860,13 @@ test('<popup trapFocus> traps Tab and restores focus when it closes', async () =
     'closing the modal handed focus back to the trigger',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('Dialog: modal popup, Escape closes it, focus goes back', async () => {
   const { Dialog, Button } = await import('../src/index.js');
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const closed = [];
   let trigger = null;
   let input = null;
@@ -2949,13 +2894,13 @@ test('Dialog: modal popup, Escape closes it, focus goes back', async () => {
       ),
     );
 
-  ReactX11.render(React.createElement(App, { open: false }), null, app);
+  x11Root.render(React.createElement(App, { open: false }));
   await tick();
   const wnd = app.windows[0];
   assert.strictEqual(app.windows.length, 1, 'no popup while closed');
   trigger.focus();
 
-  ReactX11.render(React.createElement(App, { open: true }), null, app);
+  x11Root.render(React.createElement(App, { open: true }));
   await tick();
   const dialog = app.windows[1];
   assert.ok(dialog, 'the dialog is a popup window');
@@ -2977,7 +2922,7 @@ test('Dialog: modal popup, Escape closes it, focus goes back', async () => {
   await tick();
   assert.deepStrictEqual(closed, ['close'], 'Escape asked to close');
 
-  ReactX11.render(React.createElement(App, { open: false }), null, app);
+  x11Root.render(React.createElement(App, { open: false }));
   await tick();
   assert.strictEqual(dialog.destroyed, true, 'popup gone');
   assert.strictEqual(
@@ -2986,13 +2931,14 @@ test('Dialog: modal popup, Escape closes it, focus goes back', async () => {
     'and focus returned to what opened it',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('Dialog: with nothing to autoFocus, the surface takes focus', async () => {
   const { Dialog } = await import('../src/index.js');
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     React.createElement(
       'window',
       { width: 400, height: 300 },
@@ -3002,8 +2948,6 @@ test('Dialog: with nothing to autoFocus, the surface takes focus', async () => {
         'Nothing focusable in here.',
       ),
     ),
-    null,
-    app,
   );
   await tick();
   const dialog = app.windows[1];
@@ -3020,13 +2964,14 @@ test('Dialog: with nothing to autoFocus, the surface takes focus', async () => {
     'but it is not a stop in the tab order',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('context menu: a press outside — the window frame — dismisses it', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const picked = [];
-  await openNested(app, picked);
+  await openNested(x11Root, picked);
   const menu = app.windows[1];
 
   // the root level asks for a pointer grab; that is what makes the press
@@ -3041,13 +2986,14 @@ test('context menu: a press outside — the window frame — dismisses it', asyn
   assert.strictEqual(menu.destroyed, true, 'menu closed');
   assert.deepStrictEqual(picked, [], 'and nothing was selected');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('a press inside the menu is a normal click, not a dismissal', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const picked = [];
-  await openNested(app, picked);
+  await openNested(x11Root, picked);
   const menu = app.windows[1];
   const row = rowsOf(app, 1)[0];
 
@@ -3065,12 +3011,13 @@ test('a press inside the menu is a normal click, not a dismissal', async () => {
   await tick();
   assert.deepStrictEqual(picked, ['New'], 'the row was selected');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('Slider keeps its width as the value changes (no drag feedback loop)', async () => {
   const { Slider } = await import('../src/index.js');
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   let setValue;
   const Host = () => {
     const [v, setV] = React.useState(0);
@@ -3100,7 +3047,7 @@ test('Slider keeps its width as the value changes (no drag feedback loop)', asyn
     );
   };
 
-  ReactX11.render(React.createElement(Host), null, app);
+  x11Root.render(React.createElement(Host));
   await tick();
   const row = app.windows[0]._reactX11Node.children[0];
   const slider = row.children[1];
@@ -3121,12 +3068,13 @@ test('Slider keeps its width as the value changes (no drag feedback loop)', asyn
     `width is stable across the range, got ${widths.join(', ')}`,
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('ProgressBar does not widen the box it sits in', async () => {
   const { ProgressBar } = await import('../src/index.js');
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const Card = ({ progress }) =>
     React.createElement(
       'box',
@@ -3134,7 +3082,7 @@ test('ProgressBar does not widen the box it sits in', async () => {
       React.createElement(ProgressBar, { value: progress }),
     );
 
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 300, height: 120 },
@@ -3145,8 +3093,6 @@ test('ProgressBar does not widen the box it sits in', async () => {
         React.createElement(Card, { key: 'b', progress: 0.9 }),
       ),
     ),
-    null,
-    app,
   );
   await tick();
 
@@ -3168,13 +3114,14 @@ test('ProgressBar does not widen the box it sits in', async () => {
     `fill is 90% of the track, got ${fill.abs.width}/${track.abs.width}`,
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('Tooltip shows after the delay in a popup and hides on leave', async () => {
   const { Tooltip, Button } = await import('../src/index.js');
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     React.createElement(
       'window',
       { width: 300, height: 120 },
@@ -3188,8 +3135,6 @@ test('Tooltip shows after the delay in a popup and hides on leave', async () => 
         ),
       ),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -3220,13 +3165,14 @@ test('Tooltip shows after the delay in a popup and hides on leave', async () => 
   await tick();
   assert.strictEqual(tip.destroyed, true, 'popup destroyed on mouse leave');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('Tooltip stays up when the pointer moves toward it, and is reachable', async () => {
   const { Tooltip, Button } = await import('../src/index.js');
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     React.createElement(
       'window',
       { width: 300, height: 160 },
@@ -3240,8 +3186,6 @@ test('Tooltip stays up when the pointer moves toward it, and is reachable', asyn
         ),
       ),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -3288,13 +3232,14 @@ test('Tooltip stays up when the pointer moves toward it, and is reachable', asyn
   await tick();
   assert.strictEqual(tip.destroyed, true, 'gone once the pointer leaves');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('Tooltip does not show if the pointer leaves before the delay', async () => {
   const { Tooltip, Button } = await import('../src/index.js');
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     React.createElement(
       'window',
       { width: 300, height: 120 },
@@ -3308,8 +3253,6 @@ test('Tooltip does not show if the pointer leaves before the delay', async () =>
         ),
       ),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -3327,7 +3270,7 @@ test('Tooltip does not show if the pointer leaves before the delay', async () =>
   await tick();
   assert.strictEqual(app.windows.length, 1, 'the pending timer was cancelled');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 const MENU_ITEMS = (picked) => [
@@ -3348,8 +3291,9 @@ function activeMenuIndex(app) {
 test('ContextMenu opens at the pointer and skips separators/disabled', async () => {
   const { ContextMenu } = await import('../src/index.js');
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const picked = [];
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 300, height: 200 },
@@ -3359,8 +3303,6 @@ test('ContextMenu opens at the pointer and skips separators/disabled', async () 
         React.createElement('box', { style: { flexGrow: 1 } }),
       ),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -3426,14 +3368,15 @@ test('ContextMenu opens at the pointer and skips separators/disabled', async () 
   assert.deepStrictEqual(picked, ['Cut']);
   assert.strictEqual(app.windows[1].destroyed, true, 'closes after selecting');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('ContextMenu: Escape closes without selecting; disabled items are inert', async () => {
   const { ContextMenu } = await import('../src/index.js');
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const picked = [];
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 300, height: 200 },
@@ -3443,8 +3386,6 @@ test('ContextMenu: Escape closes without selecting; disabled items are inert', a
         React.createElement('box', { style: { flexGrow: 1 } }),
       ),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -3476,14 +3417,15 @@ test('ContextMenu: Escape closes without selecting; disabled items are inert', a
   assert.strictEqual(menu.destroyed, true);
   assert.deepStrictEqual(picked, []);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('ContextMenu: clicking an enabled row selects it and closes', async () => {
   const { ContextMenu } = await import('../src/index.js');
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const picked = [];
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 300, height: 200 },
@@ -3493,8 +3435,6 @@ test('ContextMenu: clicking an enabled row selects it and closes', async () => {
         React.createElement('box', { style: { flexGrow: 1 } }),
       ),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -3514,12 +3454,13 @@ test('ContextMenu: clicking an enabled row selects it and closes', async () => {
   assert.deepStrictEqual(picked, ['Copy']);
   assert.strictEqual(menu.destroyed, true, 'closes after selecting');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('MenuBar opens menus, switches on hover and walks with Left/Right', async () => {
   const { MenuBar } = await import('../src/index.js');
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const picked = [];
   const menus = [
     {
@@ -3534,14 +3475,12 @@ test('MenuBar opens menus, switches on hover and walks with Left/Right', async (
       items: [{ label: 'Undo', onSelect: () => picked.push('Undo') }],
     },
   ];
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 320, height: 200 },
       React.createElement(MenuBar, { menus }),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -3591,12 +3530,13 @@ test('MenuBar opens menus, switches on hover and walks with Left/Right', async (
   assert.deepStrictEqual(picked, ['New']);
   assert.strictEqual(fileMenu.destroyed, true, 'closes after selecting');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('backgroundColor/borderColor "transparent" paints nothing (and does not throw)', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     React.createElement(
       'window',
       { width: 100, height: 60 },
@@ -3612,8 +3552,6 @@ test('backgroundColor/borderColor "transparent" paints nothing (and does not thr
         style: { flexGrow: 1, backgroundColor: '#ff0000' },
       }),
     ),
-    null,
-    app,
   );
   await tick();
   const ops = app.windows[0].ctx.ops;
@@ -3627,7 +3565,7 @@ test('backgroundColor/borderColor "transparent" paints nothing (and does not thr
     'no transparent stroke was issued',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 const NESTED_ITEMS = (picked) => [
@@ -3650,9 +3588,9 @@ const rowsOf = (app, index) =>
 const activeIn = (app, index) =>
   rowsOf(app, index).findIndex((r) => r.style.backgroundColor === '#2980b9');
 
-async function openNested(app, picked) {
+async function openNested(x11Root, picked) {
   const { ContextMenu } = await import('../src/index.js');
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 320, height: 220 },
@@ -3662,11 +3600,9 @@ async function openNested(app, picked) {
         React.createElement('box', { style: { flexGrow: 1 } }),
       ),
     ),
-    null,
-    app,
   );
   await tick();
-  const wnd = app.windows[0];
+  const wnd = x11Root.app.windows[0];
   wnd.emit('mousedown', { x: 20, y: 20, keycode: 3, rootx: 200, rooty: 120 });
   // a popup lays out one tick after it is created: without this second
   // tick its rows still have zero rects and pointer assertions are vacuous
@@ -3677,8 +3613,9 @@ async function openNested(app, picked) {
 
 test('submenu: Right opens it, Left leaves, Escape closes one level', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const picked = [];
-  const wnd = await openNested(app, picked);
+  const wnd = await openNested(x11Root, picked);
   assert.strictEqual(app.windows.length, 2, 'root menu open');
 
   // move onto Export (index 1)
@@ -3733,13 +3670,14 @@ test('submenu: Right opens it, Left leaves, Escape closes one level', async () =
   assert.strictEqual(app.windows[1].destroyed, true, 'root closed');
   assert.deepStrictEqual(picked, []);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('submenu: selecting a nested item closes every level', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const picked = [];
-  const wnd = await openNested(app, picked);
+  const wnd = await openNested(x11Root, picked);
 
   pressKey(app, wnd, { keysym: 0xff54 }); // New
   await tick();
@@ -3755,13 +3693,14 @@ test('submenu: selecting a nested item closes every level', async () => {
   assert.strictEqual(app.windows[1].destroyed, true, 'root closed');
   assert.strictEqual(app.windows[2].destroyed, true, 'submenu closed');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('submenu: hovering a parent row opens it with nothing selected inside', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const picked = [];
-  await openNested(app, picked);
+  await openNested(x11Root, picked);
   const menu = app.windows[1];
   const exportRow = rowsOf(app, 1)[1];
 
@@ -3785,13 +3724,14 @@ test('submenu: hovering a parent row opens it with nothing selected inside', asy
   assert.strictEqual(app.windows[2].destroyed, true, 'submenu closed');
   assert.strictEqual(activeIn(app, 1), 2, 'Quit active');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('submenu: a diagonal path toward it keeps it open (safe polygon)', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const picked = [];
-  await openNested(app, picked);
+  await openNested(x11Root, picked);
   const menu = app.windows[1];
   const rows = rowsOf(app, 1);
   const exportRow = rows[1];
@@ -3844,13 +3784,14 @@ test('submenu: a diagonal path toward it keeps it open (safe polygon)', async ()
   assert.strictEqual(app.windows[2].destroyed, true, 'submenu closed');
   assert.strictEqual(activeIn(app, 1), 2, 'Quit active');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('submenu: a pointer that stops inside the safe polygon still switches', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const picked = [];
-  await openNested(app, picked);
+  await openNested(x11Root, picked);
   const menu = app.windows[1];
   const rows = rowsOf(app, 1);
   const exportRow = rows[1];
@@ -3889,7 +3830,7 @@ test('submenu: a pointer that stops inside the safe polygon still switches', asy
   for (let i = 0; i < 4; i++) await tick();
   assert.strictEqual(activeIn(app, 1), 2, 'Quit active once the delay lapses');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 const typeChar = (app, wnd, ch) =>
@@ -3898,6 +3839,7 @@ const typeChar = (app, wnd, ch) =>
 test('Select: type-ahead jumps, refines and cycles', async () => {
   const { Select } = await import('../src/index.js');
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const options = ['apple', 'banana', 'blueberry', 'cherry'];
   let current = null;
   const Host = () => {
@@ -3918,7 +3860,7 @@ test('Select: type-ahead jumps, refines and cycles', async () => {
       ),
     );
   };
-  ReactX11.render(React.createElement(Host), null, app);
+  x11Root.render(React.createElement(Host));
   await tick();
   const wnd = app.windows[0];
   const findFocusable = (n) =>
@@ -3980,13 +3922,14 @@ test('Select: type-ahead jumps, refines and cycles', async () => {
   await tick();
   assert.strictEqual(activeIndex(), 2, 'bb cycles to blueberry');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('menu type-ahead moves the active row and skips disabled entries', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const picked = [];
-  const wnd = await openNested(app, picked); // New / Export / Quit
+  const wnd = await openNested(x11Root, picked); // New / Export / Quit
 
   typeChar(app, wnd, 'q');
   await tick();
@@ -4002,13 +3945,14 @@ test('menu type-ahead moves the active row and skips disabled entries', async ()
   await tick();
   assert.strictEqual(activeIn(app, 1), 1, 'e -> Export');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('menu type-ahead applies to the deepest open submenu', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const picked = [];
-  const wnd = await openNested(app, picked);
+  const wnd = await openNested(x11Root, picked);
 
   // into Export's submenu: PNG / --- / SVG / PDF(disabled)
   pressKey(app, wnd, { keysym: 0xff54 });
@@ -4032,13 +3976,14 @@ test('menu type-ahead applies to the deepest open submenu', async () => {
   await tick();
   assert.strictEqual(activeIn(app, 2), 0, 'p -> PNG, never the disabled PDF');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('textinput: Ctrl+arrow moves by word, Ctrl+Backspace/Delete removes one', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const changes = [];
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 300, height: 80 },
@@ -4047,8 +3992,6 @@ test('textinput: Ctrl+arrow moves by word, Ctrl+Backspace/Delete removes one', a
         onChange: (ev) => changes.push(ev.target.value),
       }),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -4078,19 +4021,18 @@ test('textinput: Ctrl+arrow moves by word, Ctrl+Backspace/Delete removes one', a
   await tick();
   assert.strictEqual(changes.at(-1), 'foo-bar baz_qux end'.replace('bar ', ''));
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('textinput: shift+click extends the selection from the anchor', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     React.createElement(
       'window',
       { width: 300, height: 80 },
       React.createElement('textinput', { defaultValue: 'hello world' }),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -4116,7 +4058,7 @@ test('textinput: shift+click extends the selection from the anchor', async () =>
     'anchor kept, caret moved to the shift+clicked index',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 // --- undo/redo -------------------------------------------------------------
@@ -4124,14 +4066,13 @@ test('textinput: shift+click extends the selection from the anchor', async () =>
 // Mounts a focused <textinput> and returns helpers for driving it.
 async function mountInput(props = {}) {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     React.createElement(
       'window',
       { width: 300, height: 80 },
       React.createElement('textinput', props),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -4150,7 +4091,7 @@ async function mountInput(props = {}) {
       }
     },
     key: (keysym, buttons = 0) => pressKey(app, wnd, { keysym, buttons }),
-    unmount: () => ReactX11.unmountComponentAtNode(app),
+    unmount: () => x11Root.unmount(),
   };
 }
 
@@ -4269,9 +4210,10 @@ test('textinput: a paste is its own undo step', async () => {
 
 test('textinput: undo in controlled mode reports through onChange', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const changes = [];
   const render = (value) =>
-    ReactX11.render(
+    x11Root.render(
       React.createElement(
         'window',
         { width: 300, height: 80 },
@@ -4283,8 +4225,6 @@ test('textinput: undo in controlled mode reports through onChange', async () => 
           },
         }),
       ),
-      null,
-      app,
     );
   render('');
   await tick();
@@ -4308,20 +4248,19 @@ test('textinput: undo in controlled mode reports through onChange', async () => 
   pressKey(app, wnd, { keysym: XK_z, buttons: CTRL | SHIFT });
   assert.strictEqual(input.value, 'hi');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('textinput: a value changed from outside becomes its own undo step', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const render = (value) =>
-    ReactX11.render(
+    x11Root.render(
       React.createElement(
         'window',
         { width: 300, height: 80 },
         React.createElement('textinput', { value }),
       ),
-      null,
-      app,
     );
   render('typed');
   await tick();
@@ -4335,19 +4274,18 @@ test('textinput: a value changed from outside becomes its own undo step', async 
   assert.strictEqual(input.undo(), true, 'undo asks for the pre-reset value');
   assert.strictEqual(input._historyValue, 'typed');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('textarea: undo restores across lines, Enter is its own step', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     React.createElement(
       'window',
       { width: 300, height: 200 },
       React.createElement('textarea', { defaultValue: '', rows: 4 }),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -4369,7 +4307,7 @@ test('textarea: undo restores across lines, Enter is its own step', async () => 
   pressKey(app, wnd, { keysym: XK_z, buttons: CTRL });
   assert.strictEqual(area.value, '');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 // --- right-click / the built-in edit menu ----------------------------------
@@ -4377,6 +4315,7 @@ test('textarea: undo restores across lines, Enter is its own step', async () => 
 // A focused <textinput> with everything selected, plus a working clipboard.
 async function mountSelected(props = {}) {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const writes = [];
   app.clipboard = {
     write(text, opts) {
@@ -4385,7 +4324,7 @@ async function mountSelected(props = {}) {
     },
     read: () => Promise.resolve('pasted'),
   };
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 300, height: 80 },
@@ -4394,8 +4333,6 @@ async function mountSelected(props = {}) {
         ...props,
       }),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -4411,6 +4348,7 @@ const rightClick = (wnd, x = 40, y = 10) =>
 
 test('textinput: right-click keeps the selection it lands inside', async () => {
   const { app, wnd, input } = await mountSelected();
+  const x11Root = await createRoot({ app });
   assert.deepStrictEqual(input._selection(), [0, 11]);
 
   rightClick(wnd);
@@ -4426,11 +4364,12 @@ test('textinput: right-click keeps the selection it lands inside', async () => {
     'still painted while the menu holds the keyboard',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('textinput: right-click outside the selection moves the caret', async () => {
   const { app, wnd, input } = await mountSelected();
+  const x11Root = await createRoot({ app });
   input._indexAtPoint = () => 3; // stub: headless text measures 0x0
   input._caret = 6;
   input._anchor = 8; // a selection of [6, 8] — the click at 3 is outside it
@@ -4438,11 +4377,12 @@ test('textinput: right-click outside the selection moves the caret', async () =>
   rightClick(wnd);
   assert.deepStrictEqual(input._selection(), [3, 3], 'caret follows the click');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('textinput: right-click opens a menu whose rows match the state', async () => {
   const { app, wnd, input } = await mountSelected();
+  const x11Root = await createRoot({ app });
   const before = app.windows.length;
 
   rightClick(wnd);
@@ -4464,11 +4404,12 @@ test('textinput: right-click opens a menu whose rows match the state', async () 
     selectAll: false, // everything is already selected
   });
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('textinput: choosing Copy closes the menu and copies', async () => {
   const { app, wnd, input, writes } = await mountSelected();
+  const x11Root = await createRoot({ app });
   rightClick(wnd);
 
   input._chooseEditMenu('copy');
@@ -4477,11 +4418,12 @@ test('textinput: choosing Copy closes the menu and copies', async () => {
   assert.deepStrictEqual(input._selection(), [0, 11], 'selection survives');
   assert.strictEqual(input._focused, true, 'focus comes back to the field');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('textinput: Cut through the menu is one undoable step', async () => {
   const { app, wnd, input } = await mountSelected();
+  const x11Root = await createRoot({ app });
   rightClick(wnd);
   input._chooseEditMenu('cut');
 
@@ -4490,11 +4432,12 @@ test('textinput: Cut through the menu is one undoable step', async () => {
   input.undo();
   assert.strictEqual(input.value, 'hello world', 'one undo brings it back');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('textinput: Escape closes the menu, leaving the text alone', async () => {
   const { app, wnd, input } = await mountSelected();
+  const x11Root = await createRoot({ app });
   rightClick(wnd);
   const popup = input._editMenu;
   const canvas = popup.children[0];
@@ -4504,11 +4447,12 @@ test('textinput: Escape closes the menu, leaving the text alone', async () => {
   assert.strictEqual(input.value, 'hello world');
   assert.strictEqual(input._focused, true);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('textinput: arrows walk the menu, skipping disabled rows', async () => {
   const { app, wnd, input } = await mountSelected();
+  const x11Root = await createRoot({ app });
   rightClick(wnd);
   const canvas = input._editMenu.children[0];
   const items = input._editMenuItems();
@@ -4521,7 +4465,7 @@ test('textinput: arrows walk the menu, skipping disabled rows', async () => {
   assert.strictEqual(input.value, '', 'and the row it chose was Cut');
   assert.strictEqual(items[3].id, 'cut');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('textinput: onContextMenu fires, and preventDefault suppresses the menu', async () => {
@@ -4532,6 +4476,7 @@ test('textinput: onContextMenu fires, and preventDefault suppresses the menu', a
       ev.preventDefault();
     },
   });
+  const x11Root = await createRoot({ app });
 
   rightClick(wnd);
   assert.deepStrictEqual(seen, [3], 'the handler ran');
@@ -4541,11 +4486,12 @@ test('textinput: onContextMenu fires, and preventDefault suppresses the menu', a
     'and the built-in menu stayed shut',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('textinput: contextMenu={false} opts out of the built-in menu', async () => {
   const { app, wnd, input } = await mountSelected({ contextMenu: false });
+  const x11Root = await createRoot({ app });
   rightClick(wnd);
   assert.strictEqual(input._editMenu, null);
   assert.deepStrictEqual(
@@ -4554,18 +4500,19 @@ test('textinput: contextMenu={false} opts out of the built-in menu', async () =>
     'opting out still must not eat the selection',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('textinput: a press outside dismisses the menu', async () => {
   const { app, wnd, input } = await mountSelected();
+  const x11Root = await createRoot({ app });
   rightClick(wnd);
   const popup = input._editMenu;
 
   popup.props.onDismiss({});
   assert.strictEqual(input._editMenu, null);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('ContextMenu around a textinput replaces the built-in menu', async () => {
@@ -4575,7 +4522,8 @@ test('ContextMenu around a textinput replaces the built-in menu', async () => {
       ? node
       : node.children.reduce((f, c) => f ?? findKind(c, kind), null);
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     React.createElement(
       'window',
       { width: 300, height: 120 },
@@ -4588,8 +4536,6 @@ test('ContextMenu around a textinput replaces the built-in menu', async () => {
         React.createElement('textinput', { defaultValue: 'hello' }),
       ),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -4611,19 +4557,18 @@ test('ContextMenu around a textinput replaces the built-in menu', async () => {
     'exactly one popup, not two stacked on each other',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('textarea: right-click gets the same menu', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     React.createElement(
       'window',
       { width: 300, height: 200 },
       React.createElement('textarea', { defaultValue: 'a\nb', rows: 3 }),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -4636,12 +4581,13 @@ test('textarea: right-click gets the same menu', async () => {
   area._chooseEditMenu('selectAll');
   assert.deepStrictEqual(area._selection(), [0, 3]);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('textarea: PageDown/PageUp move by a viewport of lines', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     React.createElement(
       'window',
       { width: 300, height: 200 },
@@ -4652,8 +4598,6 @@ test('textarea: PageDown/PageUp move by a viewport of lines', async () => {
         rows: 4,
       }),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -4708,19 +4652,18 @@ test('textarea: PageDown/PageUp move by a viewport of lines', async () => {
   pressKey(app, wnd, { keysym: 0xff55 });
   assert.strictEqual(area._selection()[0], 0);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('textarea: draws a scrollbar thumb only when the text overflows', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     React.createElement(
       'window',
       { width: 300, height: 200 },
       React.createElement('textarea', { defaultValue: 'x', rows: 3 }),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -4760,14 +4703,15 @@ test('textarea: draws a scrollbar thumb only when the text overflows', async () 
   );
   assert.ok(ty >= content.y - 0.01, 'thumb starts at or below the top');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('Select: PageDown/PageUp move by a menu viewport, clamped at the ends', async () => {
   const { Select } = await import('../src/index.js');
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const options = Array.from({ length: 40 }, (_, i) => `option-${i}`);
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 300, height: 120 },
@@ -4781,8 +4725,6 @@ test('Select: PageDown/PageUp move by a menu viewport, clamped at the ends', asy
         }),
       ),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -4850,12 +4792,13 @@ test('Select: PageDown/PageUp move by a menu viewport, clamped at the ends', asy
   }
   assert.strictEqual(active(), 0, 'clamps at the first option');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('menu: PageDown/PageUp land on a selectable row, never a separator', async () => {
   const { ContextMenu } = await import('../src/index.js');
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const picked = [];
   // 12 rows where the row a page-stride away (index 10) is a separator, so
   // a naive jump would land on something unselectable
@@ -4864,7 +4807,7 @@ test('menu: PageDown/PageUp land on a selectable row, never a separator', async 
       ? { separator: true }
       : { label: `entry-${i}`, onSelect: () => picked.push(i) },
   );
-  ReactX11.render(
+  x11Root.render(
     React.createElement(
       'window',
       { width: 320, height: 220 },
@@ -4874,8 +4817,6 @@ test('menu: PageDown/PageUp land on a selectable row, never a separator', async 
         React.createElement('box', { style: { flexGrow: 1 } }),
       ),
     ),
-    null,
-    app,
   );
   await tick();
   const wnd = app.windows[0];
@@ -4913,7 +4854,7 @@ test('menu: PageDown/PageUp land on a selectable row, never a separator', async 
   await tick();
   assert.strictEqual(active(), 0, 'and clamps at the first entry');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('injectIntoDevTools registers the renderer metadata from the host config', async () => {
@@ -4969,10 +4910,9 @@ test('window states are declared before the map, so a window can open fullscreen
   // property; a mapped one has to *ask* the WM. Only the first can open
   // already fullscreen instead of flashing at the normal size first.
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     React.createElement('window', { width: 100, height: 80, fullscreen: true }),
-    null,
-    app,
   );
   await tick();
 
@@ -4985,12 +4925,13 @@ test('window states are declared before the map, so a window can open fullscreen
   );
   assert.deepStrictEqual(stateCalls(wnd), [['fullscreen', 'add']]);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('states, fullscreen and alwaysOnTop union rather than compete', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     React.createElement('window', {
       width: 100,
       height: 80,
@@ -4998,8 +4939,6 @@ test('states, fullscreen and alwaysOnTop union rather than compete', async () =>
       fullscreen: true,
       alwaysOnTop: true,
     }),
-    null,
-    app,
   );
   await tick();
 
@@ -5017,16 +4956,15 @@ test('states, fullscreen and alwaysOnTop union rather than compete', async () =>
     assert.strictEqual(typeof name, 'string', 'one state per message');
   }
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('a state change sends only the difference, and only when props change', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const render = (states) =>
-    ReactX11.render(
+    x11Root.render(
       React.createElement('window', { width: 100, height: 80, states }),
-      null,
-      app,
     );
   render(['fullscreen', 'skip_taskbar']);
   await tick();
@@ -5056,21 +4994,20 @@ test('a state change sends only the difference, and only when props change', asy
     'only the difference, in both directions',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('onStatesChange reports what the window manager actually did', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const seen = [];
-  ReactX11.render(
+  x11Root.render(
     React.createElement('window', {
       width: 100,
       height: 80,
       fullscreen: true,
       onStatesChange: (states) => seen.push(states),
     }),
-    null,
-    app,
   );
   await tick();
 
@@ -5086,16 +5023,15 @@ test('onStatesChange reports what the window manager actually did', async () => 
   await tick();
   assert.deepStrictEqual(stateCalls(wnd), [], 'the WM is not fought');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('decorations={false} writes _MOTIF_WM_HINTS with its own type atom', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const render = (decorations) =>
-    ReactX11.render(
+    x11Root.render(
       React.createElement('window', { width: 100, height: 80, decorations }),
-      null,
-      app,
     );
   render(false);
   await tick();
@@ -5119,5 +5055,5 @@ test('decorations={false} writes _MOTIF_WM_HINTS with its own type atom', async 
   const back = wnd.calls.find(([name]) => name === 'setProperty');
   assert.deepStrictEqual(back[2], [2, 0, 1, 0, 0], 'decorations back on');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });

--- a/test/style.test.js
+++ b/test/style.test.js
@@ -4,7 +4,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
 import React from 'react';
-import ReactX11, { ThemeProvider, useTheme } from '../src/index.js';
+import { createRoot, ThemeProvider, useTheme } from '../src/index.js';
 import { createStyles, flattenStyle, resolveTokens } from '../src/styles.js';
 import { createMockApp, pressButton, moveMouse } from './helpers/mock-app.js';
 
@@ -13,7 +13,7 @@ const tick = () => new Promise((resolve) => setImmediate(resolve));
 
 const nodeOf = (app, index = 0) => app.windows[index]._reactX11Node;
 
-test('flattenStyle: arrays flatten left-to-right, falsy entries skipped', () => {
+test('flattenStyle: arrays flatten left-to-right, falsy entries skipped', async () => {
   const base = { padding: 4, backgroundColor: 'red' };
   assert.strictEqual(flattenStyle(base), base, 'a lone object is not copied');
   assert.deepStrictEqual(
@@ -31,7 +31,7 @@ test('flattenStyle: arrays flatten left-to-right, falsy entries skipped', () => 
   );
 });
 
-test('createStyles rejects unknown properties and layout in state blocks', () => {
+test('createStyles rejects unknown properties and layout in state blocks', async () => {
   assert.throws(
     () => createStyles({ a: { paddin: 4 } }),
     /unknown style property "paddin" in styles\.a/,
@@ -51,14 +51,13 @@ test('createStyles rejects unknown properties and layout in state blocks', () =>
 
 test('style drives layout and paint; props stay semantic', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     h(
       'window',
       { width: 200, height: 100, title: 'main' },
       h('box', { style: { flexGrow: 1, backgroundColor: '#123456' } }),
     ),
-    null,
-    app,
   );
   await tick();
 
@@ -75,21 +74,20 @@ test('style drives layout and paint; props stay semantic', async () => {
     'the background painted',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
-test('a hoisted style is skipped by identity on re-render', () => {
+test('a hoisted style is skipped by identity on re-render', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const s = createStyles({ box: { flexGrow: 1, backgroundColor: 'red' } });
   const render = (title) =>
-    ReactX11.render(
+    x11Root.render(
       h(
         'window',
         { width: 200, height: 100, title },
         h('box', { style: s.box }),
       ),
-      null,
-      app,
     );
 
   render('a');
@@ -98,11 +96,12 @@ test('a hoisted style is skipped by identity on re-render', () => {
   render('b');
   assert.strictEqual(box.style, first, 'same object, no re-application');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test(':hover resolves in the renderer — a repaint, not a React render', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   let renders = 0;
   function Target() {
     renders++;
@@ -115,11 +114,7 @@ test(':hover resolves in the renderer — a repaint, not a React render', async 
       },
     });
   }
-  ReactX11.render(
-    h('window', { width: 100, height: 100 }, h(Target)),
-    null,
-    app,
-  );
+  x11Root.render(h('window', { width: 100, height: 100 }, h(Target)));
   await tick();
 
   const wnd = app.windows[0];
@@ -139,12 +134,13 @@ test(':hover resolves in the renderer — a repaint, not a React render', async 
     'the component never re-rendered for a visual-only state change',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test(':hover applies up the ancestor chain, like CSS', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     h(
       'window',
       { width: 100, height: 100 },
@@ -154,8 +150,6 @@ test(':hover applies up the ancestor chain, like CSS', async () => {
         h('box', { style: { width: 20, height: 20 } }),
       ),
     ),
-    null,
-    app,
   );
   await tick();
 
@@ -167,11 +161,12 @@ test(':hover applies up the ancestor chain, like CSS', async () => {
     'hovering a child hovers its ancestors',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test(':active follows the press, :disabled wins over :hover', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const style = {
     width: 40,
     height: 40,
@@ -181,14 +176,12 @@ test(':active follows the press, :disabled wins over :hover', async () => {
     ':disabled': { backgroundColor: 'grey' },
   };
   const render = (disabled) =>
-    ReactX11.render(
+    x11Root.render(
       h(
         'window',
         { width: 100, height: 100 },
         h('box', { style, disabled, focusable: true }),
       ),
-      null,
-      app,
     );
 
   render(false);
@@ -211,12 +204,13 @@ test(':active follows the press, :disabled wins over :hover', async () => {
     ':disabled beats everything below it',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('<window>: width/height are the X window, style is the root box', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     h('window', {
       width: 300,
       height: 200,
@@ -224,8 +218,6 @@ test('<window>: width/height are the X window, style is the root box', async () 
       minHeight: 80,
       style: { padding: 10, backgroundColor: 'white' },
     }),
-    null,
-    app,
   );
   await tick();
 
@@ -244,25 +236,24 @@ test('<window>: width/height are the X window, style is the root box', async () 
   );
   assert.strictEqual(root.style.padding, 10);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('a style-only <window> can still size its root box with style', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     h(
       'window',
       { width: 300, height: 200, style: { flexDirection: 'row' } },
       h('box', { style: { width: 50, height: 20, backgroundColor: 'red' } }),
     ),
-    null,
-    app,
   );
   await tick();
   const box = nodeOf(app).children[0];
   assert.strictEqual(box.abs.width, 50);
   assert.strictEqual(box.abs.height, 20);
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('REACT_X11_STYLE_ONLY: a flat style prop is an error that names the fix', async () => {
@@ -382,7 +373,8 @@ test('a transition eases a colour instead of snapping to it', async () => {
   setAnimationClock(() => clock);
   try {
     const app = createMockApp();
-    ReactX11.render(
+    const x11Root = await createRoot({ app });
+    x11Root.render(
       h(
         'window',
         { width: 100, height: 100 },
@@ -396,8 +388,6 @@ test('a transition eases a colour instead of snapping to it', async () => {
           },
         }),
       ),
-      null,
-      app,
     );
     await tick();
 
@@ -441,7 +431,8 @@ test('a transition after an idle spell still runs', async () => {
   setAnimationClock(() => clock);
   try {
     const app = createMockApp();
-    ReactX11.render(
+    const x11Root = await createRoot({ app });
+    x11Root.render(
       h(
         'window',
         { width: 100, height: 100 },
@@ -455,8 +446,6 @@ test('a transition after an idle spell still runs', async () => {
           },
         }),
       ),
-      null,
-      app,
     );
     await tick();
     const window = nodeOf(app);
@@ -491,7 +480,8 @@ test('an interrupted transition reverses from where it got to', async () => {
   setAnimationClock(() => clock);
   try {
     const app = createMockApp();
-    ReactX11.render(
+    const x11Root = await createRoot({ app });
+    x11Root.render(
       h(
         'window',
         { width: 100, height: 100 },
@@ -505,8 +495,6 @@ test('an interrupted transition reverses from where it got to', async () => {
           },
         }),
       ),
-      null,
-      app,
     );
     await tick();
     const root = nodeOf(app);
@@ -537,6 +525,7 @@ test('transitions cover layout too, and relayout as they run', async () => {
   setAnimationClock(() => clock);
   try {
     const app = createMockApp();
+    const x11Root = await createRoot({ app });
     const ui = (left) =>
       h(
         'window',
@@ -551,13 +540,13 @@ test('transitions cover layout too, and relayout as they run', async () => {
           },
         }),
       );
-    ReactX11.render(ui(0), null, app);
+    x11Root.render(ui(0));
     await tick();
     const root = nodeOf(app);
     const box = root.children[0];
     assert.strictEqual(box.abs.x, 0);
 
-    ReactX11.render(ui(100), null, app);
+    x11Root.render(ui(100));
     clock = 50;
     root._advanceAnimations(clock);
     root.flush();
@@ -581,6 +570,7 @@ test('a transition started by a prop change schedules its own frames', async () 
   setAnimationClock(() => clock);
   try {
     const app = createMockApp();
+    const x11Root = await createRoot({ app });
     const ui = (backgroundColor) =>
       h(
         'window',
@@ -589,7 +579,7 @@ test('a transition started by a prop change schedules its own frames', async () 
           style: { flexGrow: 1, backgroundColor, transition: 200 },
         }),
       );
-    ReactX11.render(ui('#000000'), null, app);
+    x11Root.render(ui('#000000'));
     await tick();
     const root = nodeOf(app);
     const box = root.children[0];
@@ -601,7 +591,7 @@ test('a transition started by a prop change schedules its own frames', async () 
     // displayed frame of a transition equals the previous style — so the
     // transition must schedule its first frame itself, or it only runs
     // when something else happens to dirty the window.
-    ReactX11.render(ui('#ffffff'), null, app);
+    x11Root.render(ui('#ffffff'));
 
     clock = 1100; // half way
     await tick();
@@ -640,7 +630,8 @@ test('a transition started by a prop change schedules its own frames', async () 
 
 test('a property with no midpoint snaps rather than animating', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     h(
       'window',
       { width: 100, height: 100 },
@@ -652,26 +643,22 @@ test('a property with no midpoint snaps rather than animating', async () => {
         },
       }),
     ),
-    null,
-    app,
   );
   await tick();
   const root = nodeOf(app);
-  ReactX11.render(
+  x11Root.render(
     h(
       'window',
       { width: 100, height: 100 },
       h('box', { style: { flexDirection: 'column', transition: 100 } }),
     ),
-    null,
-    app,
   );
   assert.strictEqual(
     root.children[0].style.flexDirection,
     'column',
     'an enum has no midpoint: it takes effect at once',
   );
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('Switch: the thumb slides between the ends instead of snapping', async () => {
@@ -681,15 +668,14 @@ test('Switch: the thumb slides between the ends instead of snapping', async () =
   setAnimationClock(() => clock);
   try {
     const app = createMockApp();
+    const x11Root = await createRoot({ app });
     const render = (checked) =>
-      ReactX11.render(
+      x11Root.render(
         h(
           'window',
           { width: 100, height: 60 },
           h(Switch, { checked, onChange: () => {} }),
         ),
-        null,
-        app,
       );
 
     render(false);
@@ -726,10 +712,11 @@ const THEME = {
 
 test('a hoisted style resolves $tokens against the nearest theme', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const s = createStyles({
     card: { backgroundColor: '$panel', padding: '$gutter', flexGrow: 1 },
   });
-  ReactX11.render(
+  x11Root.render(
     h(
       'window',
       { width: 100, height: 100, theme: THEME },
@@ -739,8 +726,6 @@ test('a hoisted style resolves $tokens against the nearest theme', async () => {
         h('text', { style: { color: '$ink' } }, 'hi'),
       ),
     ),
-    null,
-    app,
   );
   await tick();
 
@@ -754,12 +739,13 @@ test('a hoisted style resolves $tokens against the nearest theme', async () => {
     'the resolved padding reached yoga',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('a nested theme merges over the outer one', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     h(
       'window',
       { width: 100, height: 100, theme: THEME },
@@ -769,8 +755,6 @@ test('a nested theme merges over the outer one', async () => {
         h('text', { style: { color: '$ink' } }, 'hi'),
       ),
     ),
-    null,
-    app,
   );
   await tick();
 
@@ -782,14 +766,15 @@ test('a nested theme merges over the outer one', async () => {
     'and the rest of the outer palette still applies',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('changing the theme restyles the subtree', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const s = createStyles({ card: { backgroundColor: '$panel', flexGrow: 1 } });
   const render = (theme) =>
-    ReactX11.render(
+    x11Root.render(
       h(
         'window',
         { width: 100, height: 100, theme },
@@ -799,8 +784,6 @@ test('changing the theme restyles the subtree', async () => {
           h('text', { style: { color: '$ink' } }, 'x'),
         ),
       ),
-      null,
-      app,
     );
 
   render(THEME);
@@ -813,12 +796,13 @@ test('changing the theme restyles the subtree', async () => {
   assert.strictEqual(box.style.backgroundColor, '#1e272e');
   assert.strictEqual(box.children[0].style.color, '#f5f6fa', 'deep nodes too');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('a popup inherits the theme of where it is written, not its window', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     h(
       'window',
       { width: 200, height: 200, theme: THEME },
@@ -832,8 +816,6 @@ test('a popup inherits the theme of where it is written, not its window', async 
         ),
       ),
     ),
-    null,
-    app,
   );
   await tick();
 
@@ -844,23 +826,28 @@ test('a popup inherits the theme of where it is written, not its window', async 
     'a menu follows the UI that opened it, across the window boundary',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('an unknown token is an error naming what the theme has', async () => {
   const app = createMockApp();
   const errors = [];
+  // The tree throws on purpose. `onUncaughtError` is the channel for that —
+  // the default one logs *and* sets process.exitCode, which is right for an
+  // app and wrong for a test asserting on the message.
+  const x11Root = await createRoot({
+    app,
+    onUncaughtError: (err) => errors.push(String(err?.message ?? err)),
+  });
   const orig = console.error;
   console.error = (...a) => errors.push(a.join(' '));
   try {
-    ReactX11.render(
+    x11Root.render(
       h(
         'window',
         { width: 100, height: 100, theme: THEME },
         h('box', { style: { backgroundColor: '$pannel' } }),
       ),
-      null,
-      app,
     );
     await tick();
   } finally {
@@ -870,7 +857,7 @@ test('an unknown token is an error naming what the theme has', async () => {
   assert.match(errors.join('\n'), /theme has panel, ink, gutter, accent/);
 });
 
-test('tokens keep the identity fast path: same style, same theme, same object', () => {
+test('tokens keep the identity fast path: same style, same theme, same object', async () => {
   const s = createStyles({ card: { backgroundColor: '$panel' } });
   const a = resolveTokens(s.card, THEME);
   const b = resolveTokens(s.card, THEME);
@@ -880,9 +867,10 @@ test('tokens keep the identity fast path: same style, same theme, same object', 
 
 test('a token change invalidates cached text, not just the style object', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const s = createStyles({ title: { fontSize: 20, color: '$ink' } });
   const render = (theme) =>
-    ReactX11.render(
+    x11Root.render(
       h(
         'window',
         { width: 200, height: 80, theme },
@@ -892,8 +880,6 @@ test('a token change invalidates cached text, not just the style object', async 
           h('text', { style: s.title }, 'Dashboard'),
         ),
       ),
-      null,
-      app,
     );
 
   render(THEME);
@@ -914,7 +900,7 @@ test('a token change invalidates cached text, not just the style object', async 
     'the memoised text layout was dropped, so the repaint uses the new colour',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 // --- ThemeProvider ---------------------------------------------------------
@@ -926,20 +912,19 @@ test('a token change invalidates cached text, not just the style object', async 
 
 test('ThemeProvider feeds both channels: useTheme and $token read one palette', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const s = createStyles({ card: { backgroundColor: '$accent', flexGrow: 1 } });
   let fromContext;
   const Probe = () => {
     fromContext = useTheme();
     return h('box', { style: s.card });
   };
-  ReactX11.render(
+  x11Root.render(
     h(
       'window',
       { width: 100, height: 100 },
       h(ThemeProvider, { value: { accent: '#ff0000' } }, h(Probe)),
     ),
-    null,
-    app,
   );
   await tick();
 
@@ -961,17 +946,18 @@ test('ThemeProvider feeds both channels: useTheme and $token read one palette', 
     'both channels carry the same object, so the resolution cache holds',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('a nested ThemeProvider merges over the outer one, as a nested theme prop does', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   let inner;
   const Probe = () => {
     inner = useTheme();
     return h('box', { style: { backgroundColor: '$accent', flexGrow: 1 } });
   };
-  ReactX11.render(
+  x11Root.render(
     h(
       'window',
       { width: 100, height: 100 },
@@ -981,8 +967,6 @@ test('a nested ThemeProvider merges over the outer one, as a nested theme prop d
         h(ThemeProvider, { value: { accent: '#333333' } }, h(Probe)),
       ),
     ),
-    null,
-    app,
   );
   await tick();
 
@@ -991,14 +975,15 @@ test('a nested ThemeProvider merges over the outer one, as a nested theme prop d
   const box = nodeOf(app).children[0].children[0].children[0];
   assert.strictEqual(box.style.backgroundColor, '#333333', 'tokens agree');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('a ThemeProvider above a <window> plants the palette on the window', async () => {
   // a <window> may not sit inside a box, so the provider cannot wrap one —
   // it puts the prop on the window instead of coming between them
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     h(
       ThemeProvider,
       { value: { accent: '#abcdef' } },
@@ -1008,8 +993,6 @@ test('a ThemeProvider above a <window> plants the palette on the window', async 
         h('box', { style: { backgroundColor: '$accent', flexGrow: 1 } }),
       ),
     ),
-    null,
-    app,
   );
   await tick();
 
@@ -1017,17 +1000,18 @@ test('a ThemeProvider above a <window> plants the palette on the window', async 
   assert.strictEqual(win.kind, 'window', 'no box came between them');
   assert.strictEqual(win.children[0].style.backgroundColor, '#abcdef');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('a $token with no theme anywhere is reported once, not silently dropped', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const warnings = [];
   const orig = console.warn;
   console.warn = (...a) => warnings.push(a.join(' '));
   try {
     const render = (color) =>
-      ReactX11.render(
+      x11Root.render(
         h(
           'window',
           { width: 100, height: 100 },
@@ -1035,8 +1019,6 @@ test('a $token with no theme anywhere is reported once, not silently dropped', a
             style: { backgroundColor: '$panel', color, flexGrow: 1 },
           }),
         ),
-        null,
-        app,
       );
     render('red');
     await tick();
@@ -1050,18 +1032,19 @@ test('a $token with no theme anywhere is reported once, not silently dropped', a
   assert.match(warnings[0], /<box> uses \$panel but no theme is in force/);
   assert.match(warnings[0], /ThemeProvider/, 'it names the fix');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('a popup written under a theme does not trip the no-theme warning', async () => {
   // a <popup> is its own root from birth and only learns where it was
   // written when it attaches, so the check has to wait for the commit
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const warnings = [];
   const orig = console.warn;
   console.warn = (...a) => warnings.push(a.join(' '));
   try {
-    ReactX11.render(
+    x11Root.render(
       h(
         'window',
         { width: 200, height: 200, theme: THEME },
@@ -1071,8 +1054,6 @@ test('a popup written under a theme does not trip the no-theme warning', async (
           h('box', { style: { backgroundColor: '$panel', flexGrow: 1 } }),
         ),
       ),
-      null,
-      app,
     );
     await tick();
   } finally {
@@ -1080,5 +1061,5 @@ test('a popup written under a theme does not trip the no-theme warning', async (
   }
   assert.deepStrictEqual(warnings, []);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });

--- a/test/table.test.js
+++ b/test/table.test.js
@@ -3,7 +3,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
 import React from 'react';
-import ReactX11, { Table } from '../src/index.js';
+import { createRoot, Table } from '../src/index.js';
 import { createMockApp } from './helpers/mock-app.js';
 
 const h = React.createElement;
@@ -56,34 +56,35 @@ const makeRows = (n) =>
     size: (i * 37) % 1000,
   }));
 
-function mount(props, rowCount = 8, height = 200) {
+async function mount(props, rowCount = 8, height = 200) {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     h(
       'window',
       { width: 300, height },
       h(Table, { columns: COLUMNS, rows: makeRows(rowCount), ...props }),
     ),
-    null,
-    app,
   );
   return app;
 }
 
 test('renders a header and the rows under it', async () => {
-  const app = mount({}, 3);
+  const app = await mount({}, 3);
+  const x11Root = await createRoot({ app });
   await settle();
   const shown = texts(app);
   assert.ok(shown.includes('Name') && shown.includes('Size'), 'header labels');
   assert.ok(shown.includes('file-0000.js'));
   assert.ok(shown.includes('file-0002.js'));
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('only the rows in view are built', async () => {
   // 10k rows in a 200px window: about eight fit, plus the overscan
-  const app = mount({}, 10_000);
+  const app = await mount({}, 10_000);
+  const x11Root = await createRoot({ app });
   await settle();
 
   const built = texts(app).filter((t) => t.endsWith('.js')).length;
@@ -94,23 +95,22 @@ test('only the rows in view are built', async () => {
   );
   assert.ok(texts(app).includes('file-0000.js'), 'starting at the top');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
-test('the first render, before anything is measured, is still bounded', () => {
+test('the first render, before anything is measured, is still bounded', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   // no awaits: this is the tree as the very first commit leaves it, before
   // layout has run and onViewport could have said how tall the viewport is.
   // Rendering "all of them" here put 130,000 nodes in the tree and froze the
   // window for the best part of a second.
-  ReactX11.render(
+  x11Root.render(
     h(
       'window',
       { width: 300, height: 200 },
       h(Table, { columns: COLUMNS, rows: makeRows(10_000) }),
     ),
-    null,
-    app,
   );
 
   let nodes = 0;
@@ -121,11 +121,12 @@ test('the first render, before anything is measured, is still bounded', () => {
   walk(root(app));
   assert.ok(nodes < 1000, `first commit built ${nodes} nodes for 10,000 rows`);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('the scrollbar still measures the whole list', async () => {
-  const app = mount({}, 10_000);
+  const app = await mount({}, 10_000);
+  const x11Root = await createRoot({ app });
   await settle();
   const body = find(root(app), (n) => n.kind === 'scrollview');
 
@@ -135,11 +136,12 @@ test('the scrollbar still measures the whole list', async () => {
     'the spacers stand in for the rows that were not built',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('scrolling swaps which rows exist', async () => {
-  const app = mount({}, 10_000);
+  const app = await mount({}, 10_000);
+  const x11Root = await createRoot({ app });
   await settle();
   const body = find(root(app), (n) => n.kind === 'scrollview');
 
@@ -150,12 +152,13 @@ test('scrolling swaps which rows exist', async () => {
   assert.ok(shown.includes('file-0500.js'), 'the rows at that offset exist');
   assert.ok(!shown.includes('file-0000.js'), 'and the ones at the top do not');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('clicking a header sorts, and clicking again reverses', async () => {
   const changes = [];
-  const app = mount({ onSortChange: (next) => changes.push(next) }, 4);
+  const app = await mount({ onSortChange: (next) => changes.push(next) }, 4);
+  const x11Root = await createRoot({ app });
   await settle();
 
   const header = find(
@@ -193,15 +196,16 @@ test('clicking a header sorts, and clicking again reverses', async () => {
     'descending',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('Up/Down move the selection, Home/End jump to the ends', async () => {
   const picked = [];
-  const app = mount(
+  const app = await mount(
     { onSelect: (id) => picked.push(id), defaultSelected: 0 },
     50,
   );
+  const x11Root = await createRoot({ app });
   await settle();
   focusTable(app);
 
@@ -217,11 +221,12 @@ test('Up/Down move the selection, Home/End jump to the ends', async () => {
   await settle();
   assert.strictEqual(picked.at(-1), 0);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('the selection is kept on screen, even when it is not built yet', async () => {
-  const app = mount({ defaultSelected: 0 }, 10_000);
+  const app = await mount({ defaultSelected: 0 }, 10_000);
+  const x11Root = await createRoot({ app });
   await settle();
   const body = find(root(app), (n) => n.kind === 'scrollview');
   focusTable(app);
@@ -235,12 +240,16 @@ test('the selection is kept on screen, even when it is not built yet', async () 
   );
   assert.ok(texts(app).includes('file-9999.js'), 'and that row now exists');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('dragging a header grip resizes that column', async () => {
   const resized = [];
-  const app = mount({ onColumnResize: (id, w) => resized.push([id, w]) }, 4);
+  const app = await mount(
+    { onColumnResize: (id, w) => resized.push([id, w]) },
+    4,
+  );
+  const x11Root = await createRoot({ app });
   await settle();
 
   const grip = find(root(app), (n) => n.style.cursor === 'col-resize');
@@ -257,11 +266,12 @@ test('dragging a header grip resizes that column', async () => {
   assert.strictEqual(cell.abs.width, 180, 'the body column followed');
 
   app.windows[0].emit('mouseup', { x: grip.abs.x + 62, y, keycode: 1 });
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('the header scrolls sideways with the body but not down', async () => {
-  const app = mount({}, 40, 120);
+  const app = await mount({}, 40, 120);
+  const x11Root = await createRoot({ app });
   await settle();
   const body = find(root(app), (n) => n.kind === 'scrollview');
   const header = find(
@@ -274,12 +284,16 @@ test('the header scrolls sideways with the body but not down', async () => {
   await settle();
   assert.strictEqual(header.abs.y, headerY, 'it stayed put vertically');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('clicking a row selects it', async () => {
   const picked = [];
-  const app = mount({ onSelect: (id, row) => picked.push([id, row.name]) }, 6);
+  const app = await mount(
+    { onSelect: (id, row) => picked.push([id, row.name]) },
+    6,
+  );
+  const x11Root = await createRoot({ app });
   await settle();
 
   const cell = find(
@@ -294,5 +308,5 @@ test('clicking a row selects it', async () => {
 
   assert.deepStrictEqual(picked, [[3, 'file-0003.js']]);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });

--- a/test/tabs-splitpane.test.js
+++ b/test/tabs-splitpane.test.js
@@ -3,7 +3,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
 import React from 'react';
-import ReactX11, { SplitPane, Tabs } from '../src/index.js';
+import { createRoot, SplitPane, Tabs } from '../src/index.js';
 import { createMockApp } from './helpers/mock-app.js';
 
 const h = React.createElement;
@@ -58,16 +58,15 @@ const ITEMS = [
   { id: 'three', label: 'Three', content: h('text', null, 'third panel') },
 ];
 
-function mountTabs(props) {
+async function mountTabs(props) {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     h(
       'window',
       { width: 300, height: 200 },
       h(Tabs, { items: ITEMS, ...props }),
     ),
-    null,
-    app,
   );
   return app;
 }
@@ -79,7 +78,8 @@ const panelText = (app) =>
   )?.props.children;
 
 test('Tabs shows one panel, and clicking a tab switches it', async () => {
-  const app = mountTabs();
+  const app = await mountTabs();
+  const x11Root = await createRoot({ app });
   await tick();
   assert.strictEqual(panelText(app), 'first panel', 'the first enabled tab');
 
@@ -87,12 +87,13 @@ test('Tabs shows one panel, and clicking a tab switches it', async () => {
   await tick();
   assert.strictEqual(panelText(app), 'third panel');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('arrows move and wrap, skipping disabled tabs', async () => {
   const changes = [];
-  const app = mountTabs({ onChange: (id) => changes.push(id) });
+  const app = await mountTabs({ onChange: (id) => changes.push(id) });
+  const x11Root = await createRoot({ app });
   await tick();
   const wnd = app.windows[0];
   labelled(root(app), 'One').focus();
@@ -117,22 +118,24 @@ test('arrows move and wrap, skipping disabled tabs', async () => {
   await tick();
   assert.strictEqual(changes.at(-1), 'one');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('a disabled tab is not focusable and cannot be selected', async () => {
-  const app = mountTabs();
+  const app = await mountTabs();
+  const x11Root = await createRoot({ app });
   await tick();
   const two = labelled(root(app), 'Two');
   assert.strictEqual(two.props.focusable, false);
   click(app.windows[0], two);
   await tick();
   assert.strictEqual(panelText(app), 'first panel', 'the click did nothing');
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('manual mode moves focus without selecting until Enter', async () => {
-  const app = mountTabs({ manual: true });
+  const app = await mountTabs({ manual: true });
+  const x11Root = await createRoot({ app });
   await tick();
   const wnd = app.windows[0];
   labelled(root(app), 'One').focus();
@@ -149,11 +152,12 @@ test('manual mode moves focus without selecting until Enter', async () => {
   await tick();
   assert.strictEqual(panelText(app), 'third panel', 'Enter commits it');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('vertical Tabs use Up/Down instead', async () => {
-  const app = mountTabs({ orientation: 'vertical' });
+  const app = await mountTabs({ orientation: 'vertical' });
+  const x11Root = await createRoot({ app });
   await tick();
   const wnd = app.windows[0];
   labelled(root(app), 'One').focus();
@@ -165,13 +169,14 @@ test('vertical Tabs use Up/Down instead', async () => {
   await tick();
   assert.strictEqual(panelText(app), 'third panel');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('content given as a function is only built while selected', async () => {
   let built = 0;
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     h(
       'window',
       { width: 300, height: 200 },
@@ -189,8 +194,6 @@ test('content given as a function is only built while selected', async () => {
         ],
       }),
     ),
-    null,
-    app,
   );
   await tick();
   assert.strictEqual(built, 0, 'the hidden panel was never built');
@@ -199,14 +202,15 @@ test('content given as a function is only built while selected', async () => {
   await tick();
   assert.ok(built > 0, 'and is built once shown');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 // --- SplitPane -------------------------------------------------------------
 
-function mountSplit(props) {
+async function mountSplit(props) {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     h(
       'window',
       { width: 400, height: 200 },
@@ -217,8 +221,6 @@ function mountSplit(props) {
         h('box', { style: { flexGrow: 1, backgroundColor: 'blue' } }),
       ),
     ),
-    null,
-    app,
   );
   return app;
 }
@@ -227,14 +229,15 @@ const divider = (app) =>
   find(root(app), (n) => /resize$/.test(n.style.cursor ?? ''));
 
 test('SplitPane sizes the first pane and gives the rest to the second', async () => {
-  const app = mountSplit();
+  const app = await mountSplit();
+  const x11Root = await createRoot({ app });
   await tick();
   const [first, , second] = root(app).children[0].children;
   assert.strictEqual(first.abs.width, 100);
   assert.strictEqual(second.abs.width, 400 - 100 - 6, 'the divider takes 6');
   assert.strictEqual(first.abs.height, 200, 'panes fill across the other axis');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('the second pane does not grow to fit content wider than it', async () => {
@@ -245,7 +248,8 @@ test('the second pane does not grow to fit content wider than it', async () => {
   // invisible in the empty-pane test above: with no content there is no
   // natural width for the basis to pick up.
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     h(
       'window',
       { width: 400, height: 200 },
@@ -264,8 +268,6 @@ test('the second pane does not grow to fit content wider than it', async () => {
         ),
       ),
     ),
-    null,
-    app,
   );
   await tick();
 
@@ -291,16 +293,17 @@ test('the second pane does not grow to fit content wider than it', async () => {
     );
   }
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('dragging the divider resizes, and clamps at both minimums', async () => {
   const sizes = [];
-  const app = mountSplit({
+  const app = await mountSplit({
     onResize: (n) => sizes.push(n),
     min: 50,
     minSecond: 80,
   });
+  const x11Root = await createRoot({ app });
   await tick();
   const wnd = app.windows[0];
   const d = divider(app);
@@ -330,11 +333,12 @@ test('dragging the divider resizes, and clamps at both minimums', async () => {
   );
   wnd.emit('mouseup', { x: 395, y: 100, keycode: 1 });
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('the divider takes the grab point with it, without jumping', async () => {
-  const app = mountSplit();
+  const app = await mountSplit();
+  const x11Root = await createRoot({ app });
   await tick();
   const wnd = app.windows[0];
   const d = divider(app);
@@ -350,11 +354,12 @@ test('the divider takes the grab point with it, without jumping', async () => {
   );
   wnd.emit('mouseup', { x: d.abs.x + 5, y: 100, keycode: 1 });
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('the divider is focusable and moves with the arrow keys', async () => {
-  const app = mountSplit();
+  const app = await mountSplit();
+  const x11Root = await createRoot({ app });
   await tick();
   const wnd = app.windows[0];
   divider(app).focus();
@@ -375,16 +380,17 @@ test('the divider is focusable and moves with the arrow keys', async () => {
   await settle();
   assert.strictEqual(root(app).children[0].children[0].abs.width, 40, 'to min');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('a column split divides the other way', async () => {
-  const app = mountSplit({ direction: 'column', defaultSize: 60 });
+  const app = await mountSplit({ direction: 'column', defaultSize: 60 });
+  const x11Root = await createRoot({ app });
   await tick();
   const [first, d, second] = root(app).children[0].children;
   assert.strictEqual(first.abs.height, 60);
   assert.strictEqual(second.abs.height, 200 - 60 - 6);
   assert.strictEqual(d.style.cursor, 'row-resize');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });

--- a/test/trace.test.js
+++ b/test/trace.test.js
@@ -10,7 +10,7 @@ import { tmpdir } from 'node:os';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import React from 'react';
-import ReactX11 from '../src/index.js';
+import { createRoot } from '../src/index.js';
 import { startTrace, startEnvTrace } from '../src/debug.js';
 import { createMockApp } from './helpers/mock-app.js';
 
@@ -49,9 +49,9 @@ const settle = (app, roundTrips = 1) =>
     Promise.resolve(),
   );
 
-function render(element, app) {
+function render(element, x11Root) {
   return new Promise((resolve) => {
-    ReactX11.render(element, (instance) => resolve(instance), app);
+    x11Root.render(element, (instance) => resolve(instance));
   });
 }
 
@@ -83,6 +83,7 @@ test('counts framed requests and decodes their names exactly', async () => {
 
 test('a rendered tree shows up as named core and Render requests', async () => {
   const app = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
   try {
     await settle(app);
     const trace = startTrace({ app });
@@ -94,7 +95,7 @@ test('a rendered tree shows up as named core and Render requests', async () => {
           style: { width: 80, height: 40, backgroundColor: '#e74c3c' },
         }),
       ),
-      app,
+      x11Root,
     );
     await settle(app, 3);
     const stats = trace.stop();
@@ -111,13 +112,14 @@ test('a rendered tree shows up as named core and Render requests', async () => {
     );
     assert.ok(stats.bytesIn > 0);
   } finally {
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
     await app.close();
   }
 });
 
 test('chrome sink writes a valid trace with commits, frames and requests', async () => {
   const app = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
   const path = join(mkdtempSync(join(tmpdir(), 'rx11-trace-')), 'trace.json');
   try {
     await settle(app);
@@ -130,7 +132,7 @@ test('chrome sink writes a valid trace with commits, frames and requests', async
           style: { width: 80, height: 40, backgroundColor: '#27ae60' },
         }),
       ),
-      app,
+      x11Root,
     );
     // run the scheduled frame deterministically (see AGENTS.md on the
     // stalled frame clock under synthetic input)
@@ -154,7 +156,7 @@ test('chrome sink writes a valid trace with commits, frames and requests', async
       'the first frame is the mount',
     );
   } finally {
-    ReactX11.unmountComponentAtNode(app);
+    await x11Root.unmount();
     await app.close();
   }
 });

--- a/test/tree.test.js
+++ b/test/tree.test.js
@@ -3,7 +3,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
 import React from 'react';
-import ReactX11, { Tree } from '../src/index.js';
+import { createRoot, Tree } from '../src/index.js';
 import { createMockApp } from './helpers/mock-app.js';
 import { TYPE_AHEAD_TIMEOUT } from '../src/components/typeahead.js';
 
@@ -82,30 +82,31 @@ const ITEMS = [
   { id: 'locked', label: 'locked.bin', disabled: true },
 ];
 
-function mount(props) {
+async function mount(props) {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     h(
       'window',
       { width: 260, height: 200 },
       h(Tree, { items: ITEMS, ...props }),
     ),
-    null,
-    app,
   );
   return app;
 }
 
 test('only the roots show until a branch is expanded', async () => {
-  const app = mount();
+  const app = await mount();
+  const x11Root = await createRoot({ app });
   await settle();
   assert.deepStrictEqual(labels(app), ['src', 'README.md', 'locked.bin']);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('defaultExpanded opens branches, nested ones included', async () => {
-  const app = mount({ defaultExpanded: ['src', 'components'] });
+  const app = await mount({ defaultExpanded: ['src', 'components'] });
+  const x11Root = await createRoot({ app });
   await settle();
   assert.deepStrictEqual(labels(app), [
     'src',
@@ -117,12 +118,13 @@ test('defaultExpanded opens branches, nested ones included', async () => {
     'locked.bin',
   ]);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('clicking the twisty expands without selecting the row', async () => {
   const picked = [];
-  const app = mount({ onSelect: (id) => picked.push(id) });
+  const app = await mount({ onSelect: (id) => picked.push(id) });
+  const x11Root = await createRoot({ app });
   await settle();
 
   const row = rowFor(app, 'src');
@@ -132,27 +134,29 @@ test('clicking the twisty expands without selecting the row', async () => {
   assert.ok(labels(app).includes('nodes.js'), 'the branch opened');
   assert.deepStrictEqual(picked, [], 'and the selection did not move');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('clicking the label selects the row', async () => {
   const picked = [];
-  const app = mount({ onSelect: (id) => picked.push(id) });
+  const app = await mount({ onSelect: (id) => picked.push(id) });
+  const x11Root = await createRoot({ app });
   await settle();
 
   click(app, rowFor(app, 'README.md'));
   await settle();
   assert.deepStrictEqual(picked, ['readme']);
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('Right opens a branch, then walks into it; Left closes, then walks out', async () => {
   const picked = [];
-  const app = mount({
+  const app = await mount({
     defaultSelected: 'src',
     onSelect: (id) => picked.push(id),
   });
+  const x11Root = await createRoot({ app });
   await settle();
   rowFor(app, 'src').focus();
 
@@ -177,16 +181,17 @@ test('Right opens a branch, then walks into it; Left closes, then walks out', as
   await settle();
   assert.ok(!labels(app).includes('nodes.js'), 'and Left again collapses it');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('Up/Down walk the visible rows and skip disabled ones', async () => {
   const picked = [];
-  const app = mount({
+  const app = await mount({
     defaultExpanded: ['src'],
     defaultSelected: 'src',
     onSelect: (id) => picked.push(id),
   });
+  const x11Root = await createRoot({ app });
   await settle();
   rowFor(app, 'src').focus();
 
@@ -208,16 +213,17 @@ test('Up/Down walk the visible rows and skip disabled ones', async () => {
   await settle();
   assert.strictEqual(picked.at(-1), 'src');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('type-ahead jumps to a row by prefix', async () => {
   const picked = [];
-  const app = mount({
+  const app = await mount({
     defaultExpanded: ['src', 'components'],
     defaultSelected: 'src',
     onSelect: (id) => picked.push(id),
   });
+  const x11Root = await createRoot({ app });
   await settle();
   rowFor(app, 'src').focus();
 
@@ -237,15 +243,16 @@ test('type-ahead jumps to a row by prefix', async () => {
   await settle();
   assert.strictEqual(picked.at(-1), 'readme');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('Enter toggles a branch and reports the activation', async () => {
   const activated = [];
-  const app = mount({
+  const app = await mount({
     defaultSelected: 'src',
     onActivate: (id) => activated.push(id),
   });
+  const x11Root = await createRoot({ app });
   await settle();
   rowFor(app, 'src').focus();
 
@@ -258,14 +265,15 @@ test('Enter toggles a branch and reports the activation', async () => {
   await settle();
   assert.ok(!labels(app).includes('nodes.js'), 'and Enter again closed it');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('controlled expansion reports changes and follows the prop', async () => {
   const app = createMockApp();
+  const x11Root = await createRoot({ app });
   const changes = [];
   const render = (open) =>
-    ReactX11.render(
+    x11Root.render(
       h(
         'window',
         { width: 260, height: 200 },
@@ -275,8 +283,6 @@ test('controlled expansion reports changes and follows the prop', async () => {
           onExpandedChange: (next) => changes.push(next),
         }),
       ),
-      null,
-      app,
     );
 
   render([]);
@@ -293,19 +299,18 @@ test('controlled expansion reports changes and follows the prop', async () => {
   await settle();
   assert.ok(labels(app).includes('nodes.js'), 'the prop opens it');
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });
 
 test('a branch with no children still shows a twisty', async () => {
   const app = createMockApp();
-  ReactX11.render(
+  const x11Root = await createRoot({ app });
+  x11Root.render(
     h(
       'window',
       { width: 260, height: 200 },
       h(Tree, { items: [{ id: 'empty', label: 'empty', children: [] }] }),
     ),
-    null,
-    app,
   );
   await settle();
 
@@ -317,5 +322,5 @@ test('a branch with no children still shows a twisty', async () => {
     'the twisty is drawn even with an empty children array',
   );
 
-  ReactX11.unmountComponentAtNode(app);
+  await x11Root.unmount();
 });

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -21,7 +21,6 @@ import {
   ProgressBar,
   Radio,
   RadioGroup,
-  render,
   Select,
   Slider,
   SplitPane,
@@ -31,7 +30,6 @@ import {
   ThemeProvider,
   Tooltip,
   Tree,
-  unmountComponentAtNode,
   useAnchor,
   useTheme,
   useWindowId,
@@ -471,11 +469,11 @@ async function main() {
   const borrowing = await createRoot({ app: root.app });
   await borrowing.unmount();
 
-  await render(<Scene />);
-  render(<RawGl />, undefined, root.app);
-  render(<Popup />, () => {}, root.app);
-  render(<Events />, () => {}, root.app);
-  unmountComponentAtNode(root.app);
+  root.render(<Scene />);
+  root.render(<RawGl />);
+  root.render(<Popup />, () => {});
+  root.render(<Events />);
+  await root.unmount();
 
   // react-x11/debug — the protocol tracer
   const trace = startTrace({ sink: 'chrome', path: '/tmp/t.json' });

--- a/website/scripts/check-bundle.mjs
+++ b/website/scripts/check-bundle.mjs
@@ -39,7 +39,6 @@ const rx = await import(pathToFileURL(bundle));
 
 // --- shape -----------------------------------------------------------------
 assert.strictEqual(typeof rx.reactX11.createRoot, 'function', 'createRoot');
-assert.strictEqual(typeof rx.reactX11.render, 'function', 'render');
 assert.strictEqual(typeof rx.reactX11.createStyles, 'function', 'createStyles');
 assert.strictEqual(typeof rx.reactX11.Button, 'function', 'Button');
 assert.strictEqual(typeof rx.reactX11.Canvas3D, 'function', 'Canvas3D');


### PR DESCRIPTION
Closes #114. The API half already shipped: the options bag, one connection per root, an `unmount` that closes what it opened, and `onDisconnect`. This is the remaining half: deleting the legacy pair and the module-level connection cache behind it.

**BREAKING**: `render(element, callback, container)` and `unmountComponentAtNode(container)` are gone.

```js
// before
ReactX11.render(<App />, null, app);
ReactX11.unmountComponentAtNode(app);

// after
const root = await createRoot({ app });
root.render(<App />);
await root.unmount();
```

## Why it goes together

`cachedNtkApp` was the reason the issue exists: `connectApp()` memoised one connection, `roots` was keyed by the container, so a second `createRoot()` resolved the *same* app and got the *same* fiber root — the second `render()` silently replaced the first tree. `createRoot` already fixed that for its own callers, but the cache had to stay alive for legacy `render()`. Deleting the pair deletes the cache, and one-connection-per-root becomes the only shape there is.

## The migration was not the cascade it looked like

Worth recording, because a previous attempt was reverted as unsafe: **`root.render()` is synchronous.** Only *obtaining* the root is async, and a root is obtained once per app. So `await createRoot({ app })` hoists to where the app is created, and every local `const render = (x) => …` helper stays synchronous — no viral `await`, and no risk of a missed one leaving a test asserting on stale state.

Five test helpers genuinely did have to become async — the ones that *create* the app themselves, such as `mount` and `mountTabs`. That cascade is shallow and loud — each returns an object the caller destructures, so a missed `await` throws on the next line rather than passing vacuously.

Helpers that render now take the root rather than the app; where one also needed the connection it reads `root.app`, which `createRoot` already exposes.

## One behaviour change worth reviewing

`test/style.test.js` and `test/scene3d.test.js` mount throwing trees on purpose and previously asserted on captured `console.error`. Under `createRoot` the *default* `onUncaughtError` also sets `process.exitCode` — deliberate, so a GUI whose tree threw does not lie to CI — which made those files fail at the file level with every named test passing. They now pass their own `onUncaughtError`, which is what the option is for and gives that channel its first coverage.

## Scope

- **Library**: `renderIntoContainer`, `render`, `unmountComponentAtNode`, `roots`, `cachedNtkApp` and `connectApp` deleted from `src/Reconciler.js`; exports dropped from `src/index.js` and `src/index.d.ts`.
- **Tests**: ~181 call sites across 18 files. Two new tests in `test/create-root.test.js` pin the retirement — the exports are gone, and two roots on one borrowed connection are independent (the thing the shared cache made impossible).
- **Scripts**: `bench/protocol.js`, `screenshots.jsx`, `screenshots-framed.jsx`, `check-stress.jsx`. All run: `npm run bench` produces its table, `npm run screenshots` regenerates byte-identical output (except `tasks.png`, which drifts on unmodified `master` too — pre-existing rasterizer nondeterminism, left alone), `npm run stress:check` passes.
- **Docs**: `docs/README.md` entry-point section; the `ReactX11.render(<App />)` snippets across `ecosystem.md` and six `ecosystem/*` pages; `ecosystem/testing.md`'s hand-rolled harness rewritten around `createRoot({ stream })` — which also makes it a better example, since the root now owns and closes the connection. `AGENTS.md` layout note.

`npm test` 354 pass · lint clean · `npm run typecheck` with the type tests updated · `npm run docs:build` and the website `npm test` green.

Not screenshot-eligible: no pixel changes.


BREAKING CHANGE: render and unmountComponentAtNode are removed. Build a root with createRoot, then call render on it and await its unmount.
