### PR TITLE
feat(dnd): drag sources — in-app drags and XDND out, with a two-process example pair

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -306,11 +306,91 @@ const { dropProps, isOver, isAccepted } = useDropTarget({
 return <box {...dropProps} style={isOver ? s.zoneHot : s.zone} />;
 ```
 
+### Drag sources
+
+`draggable` makes a node a drag source; `dragData` is the offer, keyed by
+payload type name:
+
+```jsx
+<box
+  draggable
+  dragData={{
+    'text/uri-list': () => toUriList(item), // a thunk: resolved lazily
+    'text/plain': item.path,
+    'application/x-myapp-item': item, // a live object
+  }}
+  dragActions={['copy', 'move']}
+  onDragEnd={(e) => {
+    if (e.action === 'move') remove(item.id);
+  }}
+  style={{ ':dragging': { opacity: 0.4 } }}
+/>
+```
+
+One drag session, two transports, and handlers cannot tell them apart
+without asking (`e.source`):
+
+- **Inside the app** (over any of its windows, including other
+  `<window>`s and `<popup>`s) the drag is local: no X traffic at all, and
+  a drop hands values over **by reference** — `e.items['application/x-myapp-item']`
+  is the object itself, never serialised.
+- **Leaving the app's windows** promotes the drag to XDND: `dragData` is
+  published on `XdndSelection` (thunks resolve now — a drag that ends in
+  the wastebasket never builds its payload; live objects are
+  JSON-serialised for the wire), the target under the pointer is found by
+  descending from the root, and any XDND application — a file manager, an
+  editor, another react-x11 process — can accept the drop. Coming back
+  over the app demotes it again.
+
+The gesture is DOM-shaped: a press on a `draggable` is still a click
+until it moves ~4px; `onDragStart` fires at the threshold
+(`preventDefault()` cancels the drag); `onDrag` tracks every motion with
+`screenX/screenY` and `accepted`; `onDragEnd` reports `{ action,
+dropped }` — `action` is null when the drag ended nowhere. A completed
+drag suppresses the click, and `:dragging` styles the source while it
+lasts.
+
+There is deliberately no `dragPreview` prop rendering a bitmap — the
+preview is a live React tree. `useDragSource` packages the pattern:
+
+```jsx
+const { dragProps, isDragging, position } = useDragSource({
+  data: { 'text/plain': label },
+  onDragEnd: (e) => {
+    /* … */
+  },
+});
+return (
+  <>
+    <box {...dragProps} />
+    {isDragging && (
+      <popup dragPreview x={position.x + 12} y={position.y + 12}>
+        <Chip label={label} />
+      </popup>
+    )}
+  </>
+);
+```
+
+The `dragPreview` prop on the `<popup>` matters: it tells the drag router
+the window under the pointer is the preview itself, not a drop target.
+
+The two runnable halves live in
+[`examples/dnd-source.jsx`](../examples/dnd-source.jsx) and
+[`examples/dnd-target.jsx`](../examples/dnd-target.jsx) — run them in two
+terminals and drag between the processes.
+
 Notes for protocol watchers: `XdndAware` (version 5) is written on every
 top-level window unconditionally at realize time; a window with no drop
 targets mounted answers a drag with one refusal covering the whole
 window, so an app that never uses DnD costs one property and nothing per
-drag. macOS/XQuartz cannot deliver Finder drags into X11 applications
+drag. On the source side, the foreign target is re-resolved per motion
+frame (2–4 round trips against a local server; the drag-start window
+cache for remote X is future work), the mid-drag cursor rides
+`ChangeActivePointerGrab` over the implicit button grab, and
+`XdndFinished` is awaited with a 5 s timeout so a dead target cannot wedge
+the gesture. macOS/XQuartz cannot deliver Finder drags into X11
+applications
 ([XQuartz#173](https://github.com/XQuartz/XQuartz/issues/173)) — test
 against another X client there; on Linux, XWayland bridges XDND both
 ways.

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,6 +33,8 @@ Roughly in the order worth reading them:
 | [`gl.jsx`](gl.jsx)                   | raw GL in a `<glarea>`, compiled to a server-side display list                                  |
 | [`three.jsx`](three.jsx)             | a react-three-fiber-shaped `<Canvas3D>` scene: meshes, lights, textures                         |
 | [`icons.jsx`](icons.jsx)             | 400 icon-sized `<svg>`s that reflow and scroll, with a cached-glyph control — a paint benchmark |
+| [`dnd-source.jsx`](dnd-source.jsx)   | **drag out of the app** (XDND) + in-app drags with live payloads, a `<popup>` drag preview      |
+| [`dnd-target.jsx`](dnd-target.jsx)   | drop zones: `dropAccept` groups, parsed `e.files`, custom MIME types, `useDropTarget` state     |
 | [`stress/`](stress/index.jsx)        | **the big one**: six panels to poke at by hand, with a frame log — see below                    |
 | [`wm.jsx`](wm.jsx)                   | **a reparenting window manager** — see below                                                    |
 

--- a/examples/dnd-source.jsx
+++ b/examples/dnd-source.jsx
@@ -1,0 +1,156 @@
+// Drag-and-drop, the source side. Run this together with the target half in
+// a second terminal and drag between the two processes over XDND:
+//
+//   npm run examples:dnd-target     # terminal 1
+//   npm run examples:dnd-source    # terminal 2  (needs an X server / DISPLAY)
+//
+// Three things are demonstrated here:
+//   - the "file shelf": draggable cards whose dragData offers text/uri-list
+//     (as a lazy thunk — resolved only if the drag actually leaves this
+//     process), text/plain, and a custom application/x-react-x11-demo type
+//     carrying JSON. Drop them on the target app, a file manager, an
+//     editor, a terminal — anything XDND.
+//   - in-app drags: the same cards drop onto the tray at the bottom of this
+//     window; the payload arrives live (`e.items`, by reference, no
+//     serialisation), and 'move' removes the card from the shelf.
+//   - useDragSource: `isDragging` + `position` drive a live drag preview in
+//     a `<popup dragPreview>` following the pointer — a React tree, not a
+//     bitmap — and a `:dragging` style block dims the source card.
+import React, { useState } from 'react';
+import { createRoot, createStyles, useDragSource } from '../src/index.js';
+
+const FILES = [
+  { id: 'notes', name: 'notes.md', path: '/tmp/react-x11-demo/notes.md' },
+  { id: 'photo', name: 'photo.png', path: '/tmp/react-x11-demo/photo.png' },
+  { id: 'data', name: 'data.csv', path: '/tmp/react-x11-demo/data.csv' },
+];
+
+const toUri = (path) => `file://${encodeURI(path)}`;
+
+function Card({ file, onMoved }) {
+  const { dragProps, isDragging, position } = useDragSource({
+    data: {
+      // a thunk: never called unless the drag is promoted to XDND
+      'text/uri-list': () => `${toUri(file.path)}\r\n`,
+      'text/plain': file.path,
+      // live for in-app drops; JSON.stringify'd automatically for the wire
+      'application/x-react-x11-demo': file,
+    },
+    actions: ['copy', 'move'],
+    onDragEnd: (e) => {
+      if (e.action === 'move') onMoved(file.id);
+    },
+  });
+  return (
+    <>
+      <box {...dragProps} style={s.card}>
+        <text style={s.cardTitle}>{file.name}</text>
+        <text style={s.cardPath}>{file.path}</text>
+      </box>
+      {isDragging && (
+        <popup
+          dragPreview
+          x={position.x + 14}
+          y={position.y + 14}
+          width={180}
+          height={34}
+        >
+          <box style={[s.preview, !position.accepted && s.previewNo]}>
+            <text style={s.previewText}>
+              {position.accepted ? '📄 ' : '🚫 '}
+              {file.name}
+            </text>
+          </box>
+        </popup>
+      )}
+    </>
+  );
+}
+
+function App() {
+  const [shelf, setShelf] = useState(FILES);
+  const [tray, setTray] = useState([]);
+  return (
+    <window width={360} height={430} title="DnD source — drag out of me">
+      <box style={s.root}>
+        <text style={s.heading}>File shelf</text>
+        <text style={s.hint}>
+          Drag a card onto the target app (or any XDND application). Drop it on
+          the tray below for an in-app move.
+        </text>
+        {shelf.map((file) => (
+          <Card
+            key={file.id}
+            file={file}
+            onMoved={(id) =>
+              setShelf((list) => list.filter((f) => f.id !== id))
+            }
+          />
+        ))}
+        <box style={{ flexGrow: 1 }} />
+        <box
+          dropAccept={['application/x-react-x11-demo']}
+          onDragOver={(e) => e.accept('move')}
+          onDrop={(e) => {
+            // internal transport: the object arrives by reference
+            const file = e.items['application/x-react-x11-demo'];
+            setTray((list) => [...list, file.name]);
+          }}
+          style={s.tray}
+        >
+          <text style={s.trayLabel}>
+            {tray.length === 0
+              ? 'in-app tray — drop here to move'
+              : `moved here: ${tray.join(', ')}`}
+          </text>
+        </box>
+      </box>
+    </window>
+  );
+}
+
+const s = createStyles({
+  root: { flexGrow: 1, padding: 14, gap: 8, backgroundColor: '#f7f6f2' },
+  heading: { fontSize: 18, color: '#333' },
+  hint: { fontSize: 11, color: '#888' },
+  card: {
+    padding: 10,
+    gap: 2,
+    backgroundColor: 'white',
+    borderWidth: 1,
+    borderColor: '#d8d4cc',
+    borderRadius: 6,
+    ':hover': { borderColor: '#8a857b' },
+    ':dragging': { backgroundColor: '#eceae4', borderColor: '#c4beb2' },
+  },
+  cardTitle: { fontSize: 14, color: '#222' },
+  cardPath: { fontSize: 10, color: '#999' },
+  preview: {
+    flexGrow: 1,
+    justifyContent: 'center',
+    paddingLeft: 10,
+    backgroundColor: '#fffef8',
+    borderWidth: 1,
+    borderColor: '#b9b29f',
+    borderRadius: 5,
+  },
+  previewNo: { borderColor: '#cc6659' },
+  previewText: { fontSize: 12, color: '#444' },
+  tray: {
+    minHeight: 56,
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderWidth: 2,
+    borderColor: '#c9c3b6',
+    borderRadius: 8,
+    ':drag-over': { borderColor: '#7a9c59', backgroundColor: '#f0f4e8' },
+  },
+  trayLabel: { fontSize: 12, color: '#777' },
+});
+
+export default App;
+
+if (!process.env.REACT_X11_NO_AUTORUN) {
+  const root = await createRoot();
+  root.render(<App />);
+}

--- a/examples/dnd-target.jsx
+++ b/examples/dnd-target.jsx
@@ -1,0 +1,138 @@
+// Drag-and-drop, the target side. Run alongside the source half:
+//
+//   npm run examples:dnd-target     # terminal 1
+//   npm run examples:dnd-source    # terminal 2  (needs an X server / DISPLAY)
+//
+// …then drag cards from the source window into the zones here — or drag
+// files from a file manager, text from an editor, a link from a browser:
+// each zone shows a different side of the drop API.
+//
+//   - "files only": dropAccept={['files']} — the semantic group matches
+//     text/uri-list however the source spells it; e.files arrives parsed
+//     (URIs percent-decoded, local paths extracted).
+//   - "any text": dropAccept={['text']} catches the whole flavour zoo
+//     (text/plain;charset=utf-8, UTF8_STRING, STRING…); e.text is the best
+//     offered flavour.
+//   - "demo objects": an exact custom MIME name plus `await e.getData()` —
+//     JSON over the wire from another process, the live object by
+//     reference (`e.items`) when dragged within one.
+//
+// Highlighting needs no state: the `:drag-over` style block does it. The
+// files zone uses `useDropTarget` instead, to show `isOver`/`isAccepted`
+// driving the render.
+import React, { useState } from 'react';
+import { createRoot, createStyles, useDropTarget } from '../src/index.js';
+
+function FilesZone({ onLog }) {
+  const { dropProps, isOver, isAccepted } = useDropTarget({
+    accept: ['files'],
+    onDrop: (e) => {
+      for (const f of e.files) onLog(`file: ${f.path ?? f.uri}`);
+    },
+  });
+  return (
+    <box
+      {...dropProps}
+      style={[s.zone, isOver && (isAccepted ? s.zoneYes : s.zoneNo)]}
+    >
+      <text style={s.zoneTitle}>files only</text>
+      <text style={s.zoneHint}>
+        {isOver
+          ? isAccepted
+            ? 'drop them!'
+            : 'not a file drag'
+          : "dropAccept={['files']} — e.files, parsed"}
+      </text>
+    </box>
+  );
+}
+
+function App() {
+  const [log, setLog] = useState([]);
+  const push = (line) =>
+    setLog((l) => [
+      ...l.slice(-7),
+      `${new Date().toLocaleTimeString()}  ${line}`,
+    ]);
+  return (
+    <window width={380} height={470} title="DnD target — drop on me">
+      <box style={s.root}>
+        <FilesZone onLog={push} />
+
+        <box
+          dropAccept={['text']}
+          onDrop={(e) => push(`text: ${JSON.stringify(e.text ?? '')}`)}
+          style={s.zone}
+        >
+          <text style={s.zoneTitle}>any text</text>
+          <text style={s.zoneHint}>
+            dropAccept={"{['text']}"} — utf-8, STRING, charset variants alike
+          </text>
+        </box>
+
+        <box
+          dropAccept={['application/x-react-x11-demo']}
+          onDragOver={(e) => e.accept('move')}
+          onDrop={async (e) => {
+            // in-app: the live object; cross-process: JSON bytes
+            const live = e.items?.['application/x-react-x11-demo'];
+            if (live) return push(`demo object (live): ${live.name}`);
+            const raw = await e.getData('application/x-react-x11-demo');
+            const parsed = JSON.parse(String(raw));
+            push(`demo object (wire): ${parsed.name}`);
+          }}
+          style={s.zone}
+        >
+          <text style={s.zoneTitle}>demo objects</text>
+          <text style={s.zoneHint}>
+            a custom MIME type — accepts the source example's cards, asks for
+            'move'
+          </text>
+        </box>
+
+        <box style={s.log}>
+          <text style={s.logTitle}>drops</text>
+          {log.length === 0 && <text style={s.logLine}>nothing yet…</text>}
+          {log.map((line, i) => (
+            <text key={i} style={s.logLine}>
+              {line}
+            </text>
+          ))}
+        </box>
+      </box>
+    </window>
+  );
+}
+
+const s = createStyles({
+  root: { flexGrow: 1, padding: 14, gap: 10, backgroundColor: '#f2f5f7' },
+  zone: {
+    padding: 12,
+    gap: 3,
+    borderWidth: 2,
+    borderColor: '#c2ccd4',
+    borderRadius: 8,
+    backgroundColor: 'white',
+    ':drag-over': { borderColor: '#4a7fb5', backgroundColor: '#eaf1f8' },
+  },
+  zoneYes: { borderColor: '#4a7fb5', backgroundColor: '#eaf1f8' },
+  zoneNo: { borderColor: '#c25b4e', backgroundColor: '#f8eeec' },
+  zoneTitle: { fontSize: 14, color: '#28313a' },
+  zoneHint: { fontSize: 10, color: '#8a949c' },
+  log: {
+    flexGrow: 1,
+    padding: 10,
+    gap: 2,
+    borderRadius: 8,
+    backgroundColor: '#28313a',
+  },
+  logTitle: { fontSize: 11, color: '#8fa3b5' },
+  logLine: { fontSize: 11, color: '#d5dde4' },
+});
+
+export default App;
+
+if (!process.env.REACT_X11_NO_AUTORUN) {
+  const root = await createRoot();
+  root.render(<App />);
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     "examples:three": "tsx examples/three.jsx",
     "examples:windows": "tsx examples/windows.jsx",
     "examples:wm": "tsx examples/wm.jsx",
+    "examples:dnd-source": "tsx examples/dnd-source.jsx",
+    "examples:dnd-target": "tsx examples/dnd-target.jsx",
     "stress:check": "tsx scripts/check-stress.jsx",
     "screenshots": "tsx scripts/screenshots.jsx",
     "screenshots:framed": "tsx scripts/screenshots-framed.jsx",

--- a/src/components/dnd.js
+++ b/src/components/dnd.js
@@ -48,3 +48,56 @@ export function useDropTarget(options = {}) {
     isAccepted: Boolean(drag?.accepted),
   };
 }
+
+/**
+ * useDragSource — the source-side twin. Spread `dragProps` on the node to
+ * drag; the hook adds render state (`isDragging`, the pointer `position` in
+ * screen coordinates) so a component can dim itself, show a hint, or render
+ * a drag preview. The preview is deliberately userland — a `<popup
+ * dragPreview>` following `position` is a live React tree, which is more
+ * than a DOM `setDragImage` bitmap ever was; the `dragPreview` prop is what
+ * keeps the router from seeing the popup as the window under the pointer.
+ *
+ *   const { dragProps, isDragging, position } = useDragSource({
+ *     data: {
+ *       'text/uri-list': () => toUriList(item),   // thunk: resolved lazily
+ *       'application/x-myapp-item': item,         // live for in-app drops
+ *     },
+ *     actions: ['copy', 'move'],
+ *     onDragEnd: (e) => { if (e.action === 'move') remove(item.id); },
+ *   });
+ *   return (
+ *     <>
+ *       <box {...dragProps} style={{ ':dragging': { opacity: 0.4 } }} />
+ *       {isDragging && (
+ *         <popup dragPreview x={position.x + 12} y={position.y + 12}>
+ *           <Chip label={item.name} />
+ *         </popup>
+ *       )}
+ *     </>
+ *   );
+ */
+export function useDragSource(options = {}) {
+  const { data, actions, onDragStart, onDrag, onDragEnd } = options;
+  const [drag, setDrag] = useState(null);
+  const dragProps = {
+    draggable: true,
+    dragData: data,
+    dragActions: actions,
+    onDragStart: (ev) => {
+      onDragStart?.(ev);
+      if (!ev.defaultPrevented) {
+        setDrag({ x: ev.screenX, y: ev.screenY, accepted: false });
+      }
+    },
+    onDrag: (ev) => {
+      setDrag({ x: ev.screenX, y: ev.screenY, accepted: ev.accepted });
+      onDrag?.(ev);
+    },
+    onDragEnd: (ev) => {
+      setDrag(null);
+      onDragEnd?.(ev);
+    },
+  };
+  return { dragProps, isDragging: drag != null, position: drag };
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -4,7 +4,7 @@
 // typeahead.js and keys.js.
 export { ThemeProvider, useTheme } from './theme.js';
 export { anchorRect, centerRect, useAnchor } from './anchor.js';
-export { useDropTarget } from './dnd.js';
+export { useDropTarget, useDragSource } from './dnd.js';
 export { Button } from './Button.js';
 export { Dialog } from './Dialog.js';
 export { Checkbox } from './Checkbox.js';

--- a/src/dnd.js
+++ b/src/dnd.js
@@ -275,6 +275,10 @@ export class DropSession {
     this.acceptedAction = 'copy';
     this.requestedAction = 'copy';
     this.lastPoint = null;
+    // which transport is feeding this session: 'external' (XDND wire) or
+    // 'internal' (a DragSession in this process). Carried onto every drag
+    // event as `e.source`.
+    this._source = 'external';
   }
 
   /** Entry point, from the window's 'message' listener. */
@@ -361,6 +365,23 @@ export class DropSession {
       return;
     }
 
+    const answer = this._overAt(rootX, rootY, time);
+    this._sendStatus(atoms, {
+      accept: answer.accept,
+      action: answer.action,
+      rect:
+        answer.freeze && this.accepted ? this._nodeRect(this.accepted) : null,
+    });
+  }
+
+  /**
+   * One position update, whichever transport delivered it: route the root
+   * point, hit-test, find the accepting node from `dropAccept` data, diff
+   * the drag path (enter/leave + `:drag-over`), and give `onDragOver` its
+   * synchronous chance to override. Returns the answer — XDND sends it as
+   * XdndStatus, an internal DragSession reads it directly.
+   */
+  _overAt(rootX, rootY, time) {
     const { windowNode, x, y } = this._routePoint(rootX, rootY);
     const target = windowNode.hitTest(x, y) ?? windowNode;
     const path = windowNode.events._path(target);
@@ -399,11 +420,72 @@ export class DropSession {
       this._dispatchOver(windowNode, path, over);
     });
     this.acceptedAction = answer.action;
-    this._sendStatus(atoms, {
-      accept: answer.accept,
-      action: answer.action,
-      rect: answer.freeze && accepted ? this._nodeRect(accepted) : null,
-    });
+    return answer;
+  }
+
+  // -- the internal transport (a DragSession in this process) --------------
+  //
+  // Same session, same path diffing, same handlers — no wire. `e.source`
+  // says 'internal', `e.items` carries live values, and the answer goes
+  // back as a return value instead of an XdndStatus.
+
+  localOver(rootX, rootY, offer, time) {
+    this._source = 'internal';
+    this.sourceWid = 0;
+    this.types = offer.types;
+    this.requestedAction = offer.action;
+    const answer = this._overAt(rootX, rootY, time);
+    return { accepted: answer.accept, action: answer.action };
+  }
+
+  localLeave() {
+    if (this._source !== 'internal') return;
+    discrete(() => this._clearPath())();
+    this.accepted = null;
+    this.lastPoint = null;
+    this._source = 'external';
+  }
+
+  /** The internal drop: dispatch with the live extras a DragSession built
+   * (`items`, prefetched `files`/`text`, a local `getData`). Synchronous
+   * from the caller's point of view — `onDragEnd` follows immediately,
+   * like the DOM's dragend after drop. */
+  localDrop(offer, extras, time) {
+    this._source = 'internal';
+    this.types = offer.types;
+    const point = this.lastPoint;
+    const accepted = this.accepted;
+    const action = this.acceptedAction;
+    if (!accepted || accepted.destroyed || !point) {
+      this.localLeave();
+      return { handled: false, action: null };
+    }
+    discrete(() => {
+      runWithPriority(DiscreteEventPriority, () => {
+        const targetNode = this._dropTarget(point) ?? accepted;
+        const drop = this._makeDragEvent(
+          point.windowNode,
+          'drop',
+          {
+            x: point.x,
+            y: point.y,
+            rootx: point.rootX,
+            rooty: point.rootY,
+            time,
+            buttons: 0,
+          },
+          targetNode,
+          null,
+        );
+        Object.assign(drop, extras);
+        this._dispatchDrop(point.windowNode, targetNode, drop, []);
+        this._clearPath();
+      });
+    })();
+    this.accepted = null;
+    this.lastPoint = null;
+    this._source = 'external';
+    return { handled: true, action };
   }
 
   _onLeave(ev) {
@@ -520,7 +602,7 @@ export class DropSession {
       types,
       has: (want) => typeMatches(types, want),
       action: this.requestedAction,
-      source: 'external',
+      source: this._source,
       screenX: native.rootx,
       screenY: native.rooty,
       accept: (action) => {
@@ -770,6 +852,665 @@ export class DropSession {
       this.X.SendClientMessage(destWid, destWid, typeAtom, 32, data, 0);
     } catch {
       // the source died mid-drag; its ClientMessages stop arriving too
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The drag source.
+//
+// One drag session, two transports (docs/architecture/drag-and-drop.md §6.3):
+// while the pointer is over this process's own windows the drag is local —
+// no wire, live JS payloads, the DropSession above delivering to the same
+// handlers with `e.source === 'internal'`. The moment it leaves them, the
+// session promotes to XDND: the payload is published on XdndSelection
+// through ntk's clipboard, the foreign target is found by descending from
+// the root, and Enter/Position/Leave/Drop go out. Handlers cannot tell the
+// transports apart except by asking.
+// ---------------------------------------------------------------------------
+
+/** DOM-ish drag threshold: a press is a click until it moves this far. */
+const DRAG_THRESHOLD = 4;
+/** How long to wait for a target's XdndFinished before ending the drag
+ * anyway — the mirror of the drop side's watchdog. */
+const FINISH_TIMEOUT = 5_000;
+/** ButtonPress | ButtonRelease | PointerMotion: what the active grab must
+ * keep selecting when the cursor is swapped mid-drag. */
+const GRAB_EVENT_MASK = 4 | 8 | 64;
+
+export function hasDragProps(props) {
+  return Boolean(props?.draggable);
+}
+
+// Realized top-level WindowNodes per app: "is this root point over one of
+// our windows" is the internal/external transport switch, and the same set
+// answers internal cross-window routing.
+const appTopLevels = new WeakMap();
+
+export function registerTopLevel(windowNode) {
+  const app = windowNode.app;
+  let set = appTopLevels.get(app);
+  if (!set) appTopLevels.set(app, (set = new Set()));
+  set.add(windowNode);
+}
+
+export function forgetTopLevel(windowNode) {
+  appTopLevels.get(windowNode.app)?.delete(windowNode);
+}
+
+/** The top-level under a root point. Popups sit above plain windows and a
+ * later realization above an earlier one — a heuristic, since the server
+ * owns top-level stacking; good enough for drags. A `<popup dragPreview>`
+ * follows the pointer by design and must never be the thing under it. */
+function topLevelAt(app, rootX, rootY) {
+  const set = appTopLevels.get(app);
+  if (!set) return null;
+  let hit = null;
+  for (const node of set) {
+    if (node.destroyed || !node.window || node.props.dragPreview) continue;
+    const wnd = node.window;
+    const origin = wnd._screenOrigin ?? { x: wnd.x ?? 0, y: wnd.y ?? 0 };
+    if (
+      rootX >= origin.x &&
+      rootY >= origin.y &&
+      rootX < origin.x + (wnd.width ?? 0) &&
+      rootY < origin.y + (wnd.height ?? 0)
+    ) {
+      if (!hit || node.isPopup || !hit.isPopup) hit = node;
+    }
+  }
+  return hit;
+}
+
+/** Called on every button-1 press (events.js): the nearest draggable
+ * ancestor of the hit node arms the window's DragSession, or nothing
+ * happens at all. */
+export function armDrag(windowNode, target, native) {
+  let source = null;
+  for (
+    let n = target;
+    n;
+    n = n === windowNode ? null : (n.parent ?? windowNode)
+  ) {
+    if (hasDragProps(n.props) && !n.props.disabled) {
+      source = n;
+      break;
+    }
+    if (n === windowNode) break;
+  }
+  if (!source) return null;
+  const session = (windowNode._dragSession ??= new DragSession(windowNode));
+  session.arm(source, native);
+  return session;
+}
+
+const isBinaryData = (v) =>
+  Buffer.isBuffer(v) || ArrayBuffer.isView(v) || v instanceof ArrayBuffer;
+
+function internAtom(X, name) {
+  return new Promise((resolve, reject) =>
+    X.InternAtom(false, name, (err, atom) =>
+      err ? reject(err) : resolve(atom),
+    ),
+  );
+}
+
+export class DragSession {
+  constructor(windowNode) {
+    this.node = windowNode;
+    this.app = windowNode.app;
+    this.X = windowNode.app.X;
+    this._reset();
+  }
+
+  _reset() {
+    this.phase = 'idle'; // 'idle' | 'armed' | 'dragging'
+    this.source = null;
+    this.press = null;
+    this.types = [];
+    this.actions = ['copy'];
+    this.currentAction = 'copy';
+    this.accepted = false;
+    this.localSession = null;
+    this._data = null;
+    this._resolved = null;
+    this._published = false;
+    this._typeAtoms = null;
+    this._atoms = null;
+    this._cursor = null;
+    this.ext = null;
+  }
+
+  /** The pressed node (or an ancestor) is draggable: remember where, and
+   * wait for the threshold. Below it, the gesture is still a click. */
+  arm(source, native) {
+    this._reset();
+    this.phase = 'armed';
+    this.source = source;
+    this.press = {
+      x: native.x,
+      y: native.y,
+      rootx: native.rootx ?? native.x,
+      rooty: native.rooty ?? native.y,
+      time: (native.time ?? 0) >>> 0,
+    };
+  }
+
+  cancel() {
+    if (this.phase === 'dragging') {
+      this.source?.setStyleState?.(':dragging', false);
+      this.localSession?.localLeave();
+    }
+    this._reset();
+  }
+
+  /** A node leaving the tree mid-gesture: abort rather than dangle. */
+  forget(node) {
+    if (this.source === node) this.cancel();
+  }
+
+  /** Every mousemove while armed or dragging. Returns true when the drag
+   * consumed the motion — the caller then skips hover and mousemove. */
+  motion(native) {
+    if (this.phase === 'armed') {
+      const moved =
+        Math.abs(native.x - this.press.x) + Math.abs(native.y - this.press.y);
+      if (moved < DRAG_THRESHOLD) return false;
+      if (!this._start(native)) return false;
+    }
+    if (this.phase !== 'dragging') return false;
+    this._feed(native);
+    return true;
+  }
+
+  _start(native) {
+    const source = this.source;
+    if (!source || source.destroyed) {
+      this._reset();
+      return false;
+    }
+    this._data = source.props.dragData ?? {};
+    this.types = Object.keys(this._data);
+    const actions = source.props.dragActions;
+    this.actions =
+      Array.isArray(actions) && actions.length > 0 ? actions : ['copy'];
+    this.currentAction = this.actions[0];
+    this._resolved = new Map();
+    const ev = this.node.events.dispatch('DragStart', source, native, {
+      types: this.types,
+      action: this.currentAction,
+      source: 'internal',
+      screenX: native.rootx ?? native.x,
+      screenY: native.rooty ?? native.y,
+    });
+    if (ev.defaultPrevented) {
+      this._reset();
+      return false;
+    }
+    this.phase = 'dragging';
+    source.setStyleState(':dragging', true);
+    this._setCursor('grab');
+    return true;
+  }
+
+  /** dragData values resolve once per drag: thunks are called on first
+   * use — at delivery for an internal drop, at promotion for an external
+   * one — and never at mousedown. */
+  _resolve(type) {
+    if (!this._resolved.has(type)) {
+      const value = this._data[type];
+      this._resolved.set(type, typeof value === 'function' ? value() : value);
+    }
+    return this._resolved.get(type);
+  }
+
+  _offer() {
+    return {
+      types: this.types,
+      action: this.actions[0],
+      source: 'internal',
+    };
+  }
+
+  /** What an internal drop event carries beyond the external one: the live
+   * values themselves, plus the same prefetched `files`/`text` shape so a
+   * handler cannot tell the transports apart unless it asks. */
+  _dropExtras() {
+    const items = {};
+    for (const t of this.types) items[t] = this._resolve(t);
+    let files = [];
+    const uriType = this.types.find((t) => TYPE_GROUPS.files.includes(t));
+    if (uriType) {
+      const v = this._resolve(uriType);
+      if (typeof v === 'string') files = parseUriList(v);
+    }
+    let text;
+    const best = TEXT_TARGETS.find((t) => this.types.includes(t));
+    if (best) {
+      const v = this._resolve(best);
+      if (typeof v === 'string') text = v;
+    }
+    const getData = (type) => {
+      const group = TYPE_GROUPS[type];
+      const concrete = group
+        ? (this.types.find((t) => group.includes(t)) ?? type)
+        : type;
+      return Promise.resolve(this._resolve(concrete));
+    };
+    return { items, files, text, getData };
+  }
+
+  _feed(native) {
+    const rootX = native.rootx ?? native.x;
+    const rootY = native.rooty ?? native.y;
+    const over = topLevelAt(this.app, rootX, rootY);
+    if (over?._dnd) {
+      // internal: deliver through the window's own DropSession
+      if (this.ext?.current) this._extLeave();
+      if (this.localSession && this.localSession !== over._dnd) {
+        this.localSession.localLeave();
+      }
+      this.localSession = over._dnd;
+      const result = this.localSession.localOver(
+        rootX,
+        rootY,
+        this._offer(),
+        (native.time ?? 0) >>> 0,
+      );
+      this.accepted = result.accepted;
+      if (result.accepted) this.currentAction = result.action;
+      this._setCursor(result.accepted ? 'grab' : 'not-allowed');
+    } else {
+      // external: over a foreign window (or nothing)
+      if (this.localSession) {
+        this.localSession.localLeave();
+        this.localSession = null;
+        this.accepted = false;
+      }
+      this._extMotion(rootX, rootY, (native.time ?? 0) >>> 0);
+    }
+    const source = this.source;
+    if (source && !source.destroyed && source.props.onDrag) {
+      callHandler(
+        source,
+        'onDrag',
+        source.props.onDrag,
+        this.node.events._makeEvent('drag', native, source, {
+          types: this.types,
+          action: this.currentAction,
+          source: this.localSession ? 'internal' : 'external',
+          accepted: this.accepted,
+          screenX: rootX,
+          screenY: rootY,
+        }),
+      );
+    }
+  }
+
+  /** Button release. Returns true when a drag ran (the caller suppresses
+   * mouseup/click, like the DOM after a drag gesture). */
+  release(native) {
+    if (this.phase !== 'dragging') {
+      this._reset();
+      return false;
+    }
+    const source = this.source;
+    source?.setStyleState?.(':dragging', false);
+    if (this.localSession) {
+      let outcome = { handled: false, action: null };
+      if (this.accepted) {
+        outcome = this.localSession.localDrop(
+          this._offer(),
+          this._dropExtras(),
+          (native.time ?? 0) >>> 0,
+        );
+      } else {
+        this.localSession.localLeave();
+      }
+      this._end(
+        native,
+        outcome.handled ? outcome.action : null,
+        outcome.handled,
+      );
+    } else if (this.ext?.current && this.accepted) {
+      this._extDrop(native); // async: onDragEnd follows XdndFinished
+    } else {
+      if (this.ext?.current) this._extLeave();
+      this._end(native, null, false);
+    }
+    return true;
+  }
+
+  _end(native, action, dropped) {
+    const source = this.source;
+    if (this._published) this._disown();
+    if (source && !source.destroyed) {
+      this.node.events.dispatch('DragEnd', source, native, {
+        types: this.types,
+        action,
+        dropped,
+        source: 'internal',
+        screenX: native.rootx ?? native.x ?? 0,
+        screenY: native.rooty ?? native.y ?? 0,
+      });
+    }
+    this._reset();
+  }
+
+  /** Swap the active grab's cursor (X ChangeActivePointerGrab works on the
+   * implicit button grab too). Core-font approximations — see the doc's
+   * XCursor caveat; the mask must keep selecting motion and release or the
+   * gesture goes silent. */
+  _setCursor(name) {
+    if (name === this._cursor) return;
+    const X = this.X;
+    if (typeof X.ChangeActivePointerGrab !== 'function') return;
+    const cursors = this.app.cursors;
+    if (!cursors?.get) return;
+    try {
+      X.ChangeActivePointerGrab(cursors.get(name), 0, GRAB_EVENT_MASK);
+      this._cursor = name;
+    } catch {
+      // no cursor feedback is a cosmetic failure, never a functional one
+    }
+  }
+
+  // -- the external transport (XDND out) -----------------------------------
+
+  /** First motion outside our windows: publish the payload. Thunks resolve
+   * now; live objects are JSON-serialised for the wire (internal drops got
+   * them by reference). ntk's clipboard owns XdndSelection and serves the
+   * conversions, INCR included. */
+  async _publish() {
+    if (this._published) return;
+    this._published = true;
+    this._atoms = await dndAtoms(this.X);
+    this._typeAtoms = await Promise.all(
+      this.types.map((t) => internAtom(this.X, t)),
+    );
+    const map = {};
+    for (const t of this.types) {
+      let v = this._resolve(t);
+      if (typeof v !== 'string' && !isBinaryData(v)) v = JSON.stringify(v);
+      map[t] = v;
+    }
+    const clipboard = this.app.clipboard;
+    if (clipboard && this.types.length > 0) {
+      await clipboard.write(map, {
+        selection: 'XdndSelection',
+        ...(this.press.time ? { time: this.press.time } : {}),
+      });
+    }
+    if (
+      this._typeAtoms.length > 3 &&
+      typeof this.node.window?.setProperty === 'function'
+    ) {
+      await this.node.window.setProperty('XdndTypeList', this._typeAtoms, {
+        type: 'ATOM',
+      });
+    }
+  }
+
+  /** Positions are serialized behind the publish and the async target
+   * descent; only the newest queued point is ever resolved, so a motion
+   * burst costs one descent, not one per event. */
+  _extMotion(rootX, rootY, time) {
+    const ext = (this.ext ??= {
+      current: null,
+      queue: null,
+      busy: false,
+      suppress: null,
+      finish: null,
+    });
+    ext.queue = { rootX, rootY, time };
+    if (ext.busy) return;
+    ext.busy = true;
+    (async () => {
+      try {
+        await this._publish();
+        while (this.ext?.queue && this.phase === 'dragging') {
+          const point = this.ext.queue;
+          this.ext.queue = null;
+          await this._extStep(point);
+        }
+      } catch {
+        // connection teardown mid-drag
+      } finally {
+        if (this.ext) this.ext.busy = false;
+      }
+    })();
+  }
+
+  async _extStep({ rootX, rootY, time }) {
+    const atoms = this._atoms;
+    const found = await this._findTarget(rootX, rootY);
+    const ext = this.ext;
+    if (!ext || this.phase !== 'dragging') return;
+    const current = ext.current;
+    if ((found?.wid ?? 0) !== (current?.wid ?? 0)) {
+      if (current) {
+        this._sendTo(current.sendWid, atoms.XdndLeave, [
+          this.node.window.id,
+          0,
+          0,
+          0,
+          0,
+        ]);
+      }
+      ext.current = found;
+      ext.suppress = null;
+      this.accepted = false;
+      this._setCursor('not-allowed');
+      if (found) {
+        const flags =
+          ((XDND_VERSION << 24) | (this.types.length > 3 ? 1 : 0)) >>> 0;
+        const t = this._typeAtoms ?? [];
+        this._sendTo(found.sendWid, atoms.XdndEnter, [
+          this.node.window.id,
+          flags,
+          t[0] ?? 0,
+          t[1] ?? 0,
+          t[2] ?? 0,
+        ]);
+      }
+    }
+    if (!ext.current) return;
+    const s = ext.suppress;
+    if (
+      s &&
+      rootX >= s.x &&
+      rootY >= s.y &&
+      rootX < s.x + s.width &&
+      rootY < s.y + s.height
+    ) {
+      return; // the target asked for silence inside this rectangle
+    }
+    this._sendTo(ext.current.sendWid, atoms.XdndPosition, [
+      this.node.window.id,
+      0,
+      (((rootX & 0xffff) << 16) | (rootY & 0xffff)) >>> 0,
+      time >>> 0,
+      actionAtom(atoms, this.actions[0]),
+    ]);
+  }
+
+  /**
+   * The XDND target under a root point: descend the window tree with
+   * TranslateCoordinates, checking XdndAware at each level (since v3 it is
+   * on the top-level client window, which under a reparenting WM sits a
+   * level or two below the frame). XdndProxy redirects the sends. Per
+   * motion and uncached — 2–4 round trips, fine locally; the drag-start
+   * window cache from the design doc is the remote-X follow-up.
+   */
+  async _findTarget(rootX, rootY) {
+    const root = this.X.display?.screen?.[0]?.root;
+    if (root == null) return null;
+    let wid = root;
+    for (let depth = 0; depth < 16; depth++) {
+      const child = await this._translate(root, wid, rootX, rootY);
+      if (!child) return null;
+      if (this._isOurs(child)) return null;
+      const aware = await this._readAware(child);
+      if (aware) {
+        return {
+          wid: child,
+          sendWid: aware.proxy || child,
+          version: Math.min(XDND_VERSION, aware.version),
+        };
+      }
+      wid = child;
+    }
+    return null;
+  }
+
+  _translate(srcWid, dstWid, x, y) {
+    return new Promise((resolve) => {
+      this.X.TranslateCoordinates(srcWid, dstWid, x, y, (err, res) =>
+        resolve(err ? 0 : (res?.child ?? 0)),
+      );
+    });
+  }
+
+  _isOurs(wid) {
+    const set = appTopLevels.get(this.app);
+    if (!set) return false;
+    for (const node of set) {
+      if (node.window?.id === wid) return true;
+    }
+    return false;
+  }
+
+  _readAware(wid) {
+    const atoms = this._atoms;
+    const read = (atom) =>
+      new Promise((resolve) => {
+        this.X.GetProperty(0, wid, atom, 0, 0, 4, (err, prop) =>
+          resolve(
+            err || !prop?.data || prop.data.length < 4 ? null : prop.data,
+          ),
+        );
+      });
+    return Promise.all([read(atoms.XdndAware), read(atoms.XdndProxy)]).then(
+      ([aware, proxy]) =>
+        aware
+          ? {
+              version: aware.readUInt32LE(0),
+              proxy: proxy ? proxy.readUInt32LE(0) : 0,
+            }
+          : null,
+    );
+  }
+
+  /** XdndStatus / XdndFinished sent back by the foreign target, routed here
+   * from the source window's 'message' listener. */
+  handleMessage(ev) {
+    if (ev.format !== 32) return;
+    const atoms = dndAtomsOf(this.X);
+    if (!atoms) return; // cannot be ours: we intern before we publish
+    if (ev.message_type === atoms.XdndStatus) this._onStatus(ev, atoms);
+    else if (ev.message_type === atoms.XdndFinished) this._onFinished(ev);
+  }
+
+  _onStatus(ev, atoms) {
+    const ext = this.ext;
+    if (!ext?.current || ev.data[0] >>> 0 !== ext.current.wid) return;
+    const accept = Boolean(ev.data[1] & 1);
+    this.accepted = accept;
+    if (accept) this.currentAction = actionName(atoms, ev.data[4] >>> 0);
+    const wantInside = Boolean(ev.data[1] & 2);
+    const rw = ev.data[3] >>> 16;
+    const rh = ev.data[3] & 0xffff;
+    ext.suppress =
+      wantInside || (rw === 0 && rh === 0)
+        ? null
+        : {
+            x: ev.data[2] >>> 16,
+            y: ev.data[2] & 0xffff,
+            width: rw,
+            height: rh,
+          };
+    this._setCursor(accept ? 'grab' : 'not-allowed');
+  }
+
+  _onFinished(ev) {
+    const ext = this.ext;
+    if (ext?.finish) {
+      const finish = ext.finish;
+      ext.finish = null;
+      finish({
+        accepted: Boolean(ev.data[1] & 1),
+        actionAtom: ev.data[2] >>> 0,
+      });
+    }
+  }
+
+  _extLeave() {
+    const ext = this.ext;
+    if (!ext?.current || !this._atoms) return;
+    this._sendTo(ext.current.sendWid, this._atoms.XdndLeave, [
+      this.node.window.id,
+      0,
+      0,
+      0,
+      0,
+    ]);
+    ext.current = null;
+    ext.suppress = null;
+    this.accepted = false;
+  }
+
+  _extDrop(native) {
+    const ext = this.ext;
+    const atoms = this._atoms;
+    const target = ext.current;
+    this._sendTo(target.sendWid, atoms.XdndDrop, [
+      this.node.window.id,
+      0,
+      (native.time ?? 0) >>> 0,
+      0,
+      0,
+    ]);
+    let done = false;
+    const finish = (result) => {
+      if (done) return;
+      done = true;
+      clearTimeout(timer);
+      if (this.ext) this.ext.finish = null;
+      // pre-v5 XdndFinished carries no verdict: treat silence and old
+      // versions as "done, with the action the status negotiated"
+      const rejected = result != null && result.accepted === false;
+      const action =
+        result?.accepted && target.version >= 5 && result.actionAtom
+          ? actionName(atoms, result.actionAtom)
+          : this.currentAction;
+      this._end(native, rejected ? null : action, !rejected);
+    };
+    const timer = setTimeout(() => finish(null), FINISH_TIMEOUT);
+    timer.unref?.();
+    if (target.version >= 2) ext.finish = finish;
+    else finish(null);
+  }
+
+  /** Give XdndSelection up at drag end. Ownership is otherwise held until
+   * someone else drags — harmless, except that a stale offer answered long
+   * after XdndFinished is exactly what the spec warns about. */
+  _disown() {
+    internAtom(this.X, 'XdndSelection')
+      .then((sel) => {
+        try {
+          this.X.SetSelectionOwner(0, sel, 0);
+        } catch {
+          // teardown
+        }
+      })
+      .catch(() => {});
+  }
+
+  _sendTo(destWid, typeAtom, data) {
+    try {
+      this.X.SendClientMessage(destWid, destWid, typeAtom, 32, data, 0);
+    } catch {
+      // the target died mid-drag
     }
   }
 }

--- a/src/events.js
+++ b/src/events.js
@@ -10,6 +10,7 @@ import {
 } from './priority.js';
 import { flushPendingFrames } from './frames.js';
 import { callHandler } from './errors.js';
+import { armDrag } from './dnd.js';
 
 const XK_TAB = 0xff09;
 const WHEEL_BUTTONS = { 4: [0, -48], 5: [0, 48], 6: [-48, 0], 7: [48, 0] };
@@ -74,6 +75,8 @@ export class EventManager {
     // toolkit that believed it was unfocused would blink no caret at all.
     this.windowFocused = true;
     this._lastClick = { time: 0, x: 0, y: 0, detail: 0 };
+    // the window's DragSession while a press has armed it (src/dnd.js)
+    this._dragArmed = null;
   }
 
   /**
@@ -317,6 +320,11 @@ export class EventManager {
       if (!ev.defaultPrevented) {
         target._defaultMouseDown?.(ev);
       }
+      // a left press on (or inside) a `draggable` arms a drag; below the
+      // threshold the gesture is still a click (src/dnd.js)
+      if (native.keycode === 1 && !ev.defaultPrevented) {
+        this._dragArmed = armDrag(this.node, target, native);
+      }
       // Right-click is two events, as in the DOM: mousedown, then a
       // separate contextmenu whose default action opens the element's own
       // menu. Handlers that only want to suppress the menu can do it
@@ -335,6 +343,20 @@ export class EventManager {
   _onMouseUp(native) {
     if (WHEEL_BUTTONS[native.keycode]) return; // wheel release
     runWithPriority(DiscreteEventPriority, () => {
+      // a completed drag ends the gesture: no mouseup, no click — as in
+      // the DOM, where dragend replaces them
+      const drag = this._dragArmed;
+      if (drag) {
+        this._dragArmed = null;
+        if (drag.release(native)) {
+          if (this.downNode && !this.downNode.destroyed) {
+            this.downNode.setStyleState(':active', false);
+          }
+          this.downNode = null;
+          this.capturedNode = null;
+          return;
+        }
+      }
       const captured = this._captured();
       const target = captured ?? this._hit(native);
       const ev = this.dispatch('MouseUp', target, native, {
@@ -367,6 +389,10 @@ export class EventManager {
 
   _onMouseMove(native) {
     runWithPriority(ContinuousEventPriority, () => {
+      // an active drag owns the pointer: drag-path diffing replaces hover,
+      // onDrag replaces mousemove. Below the threshold this falls through.
+      const drag = this._dragArmed;
+      if (drag && drag.motion(native)) return;
       const captured = this._captured();
       const target = captured ?? this._hit(native);
       // while captured, hover stays put: dragging a slider must not light
@@ -651,6 +677,7 @@ export class EventManager {
   forget(node) {
     if (this.downNode === node) this.downNode = null;
     if (this.capturedNode === node) this.capturedNode = null;
+    this.node._dragSession?.forget(node);
     this.hoverPath = this.hoverPath.filter((n) => n !== node);
     const manager = this.focusManager;
     // a scope closing restores focus, so pop before the focus reference goes

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ export { windowIdOf, useWindowId } from './windowid.js';
 export { parseUriList } from './dnd.js';
 export {
   useDropTarget,
+  useDragSource,
   Select,
   Tabs,
   Tree,

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -27,7 +27,14 @@ import {
   resolveSizeQueries,
 } from './styles.js';
 import { EventManager, discrete } from './events.js';
-import { DropSession, dndAtoms, hasDropProps, XDND_VERSION } from './dnd.js';
+import {
+  DropSession,
+  dndAtoms,
+  forgetTopLevel,
+  hasDropProps,
+  registerTopLevel,
+  XDND_VERSION,
+} from './dnd.js';
 import { addPendingFrame, clearPendingFrame } from './frames.js';
 import { callHandler } from './errors.js';
 import { windowIdOf } from './windowid.js';
@@ -550,6 +557,7 @@ export class Node {
       ':focus': false,
       ':active': false,
       ':drag-over': false,
+      ':dragging': false,
     };
     // in-flight transitions: prop -> {from, to, start, duration}
     this._anim = null;
@@ -3522,11 +3530,17 @@ export class WindowNode extends Node {
       return; // mock app, or an ntk too old to write raw properties
     }
     this._dnd = new DropSession(this);
+    registerTopLevel(this);
     void dndAtoms(X).catch(() => {});
     wnd
       .setProperty('XdndAware', [XDND_VERSION], { type: 'ATOM' })
       .catch(() => {});
-    wnd.on('message', (ev) => this._dnd.handleMessage(ev));
+    wnd.on('message', (ev) => {
+      this._dnd.handleMessage(ev);
+      // a drag *out* of this window gets its XdndStatus/XdndFinished back
+      // on the same channel
+      this._dragSession?.handleMessage(ev);
+    });
   }
 
   /** Nodes with drop props register with their root; the count gates the
@@ -3878,6 +3892,10 @@ export class WindowNode extends Node {
     if (this.destroyed) return;
     this.destroyed = true;
     clearPendingFrame(this);
+    // out of the drag registries before the window goes: a drag routed to
+    // a dead window would translate against a null _screenOrigin
+    forgetTopLevel(this);
+    this._dragSession?.cancel();
     for (const child of this.children) child.destroySubtree();
     if (this.window && typeof this.window.destroy === 'function') {
       this.window.destroy();

--- a/src/styles.js
+++ b/src/styles.js
@@ -159,6 +159,7 @@ export const STATE_KEYS = [
   ':active',
   ':disabled',
   ':drag-over',
+  ':dragging',
 ];
 
 // What a state block may change. Deliberately paint-only: a state block that

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -8,7 +8,10 @@ import type { Color, StyleProp } from './style.js';
 import type { BoxProps, GlAreaProps, Vec3 } from './elements.js';
 import type { DrawnNode, Rect } from './nodes.js';
 import type {
+  DragEndEvent,
   DragEvent,
+  DragSourceEvent,
+  DragSourceProps,
   DropAccept,
   DropEvent,
   DropTargetProps,
@@ -408,4 +411,26 @@ export function useDropTarget(options?: UseDropTargetOptions): {
   dropProps: DropTargetProps;
   isOver: boolean;
   isAccepted: boolean;
+};
+
+export interface UseDragSourceOptions {
+  /** Maps to the `dragData` host prop. */
+  data?: DragSourceProps['dragData'];
+  /** Maps to `dragActions`. */
+  actions?: Array<'copy' | 'move' | 'link'>;
+  onDragStart?: (ev: DragSourceEvent) => void;
+  onDrag?: (ev: DragSourceEvent) => void;
+  onDragEnd?: (ev: DragEndEvent) => void;
+}
+
+/**
+ * The source-side convenience: spread `dragProps` on the node to drag.
+ * `position` (screen coordinates, non-null while dragging) is what a
+ * `<popup dragPreview>` follows — the drag preview is a live React tree,
+ * not a bitmap.
+ */
+export function useDragSource(options?: UseDragSourceOptions): {
+  dragProps: DragSourceProps;
+  isDragging: boolean;
+  position: { x: number; y: number; accepted: boolean } | null;
 };

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -144,6 +144,12 @@ export interface WindowProps
    * simply decorates the window.
    */
   decorations?: boolean;
+  /**
+   * Mark this window as a drag preview: the drag router never treats it as
+   * the window under the pointer, so a `<popup dragPreview>` can follow the
+   * pointer without swallowing its own drag. See `useDragSource`.
+   */
+  dragPreview?: boolean;
   /** ConfigureNotify — the tree reflows on its own. */
   onResize?: (ev: SyntheticEvent<NtkWindow>) => void;
   onExpose?: (ev: SyntheticEvent<NtkWindow>) => void;

--- a/src/types/events.d.ts
+++ b/src/types/events.d.ts
@@ -130,6 +130,56 @@ export interface DropEvent<T = DrawnNode> extends DragEvent<T> {
   files: Array<{ uri: string; path?: string }>;
   /** The best offered text flavour, when there was one. */
   text?: string;
+  /** Internal drags only: the dragData values by type name, live — no
+   * serialisation happened. Absent for drops from other applications. */
+  items?: Record<string, unknown>;
+}
+
+/** A drag *source*'s events (`onDragStart` / `onDrag` / `onDragEnd`).
+ * `source` and `accepted` describe the transport and the current target's
+ * answer; `screenX/screenY` are where the pointer is, in root coordinates
+ * — what a preview `<popup>` follows. */
+export interface DragSourceEvent<T = DrawnNode> extends SyntheticEvent<T> {
+  types: string[];
+  action: DropAction;
+  source: 'internal' | 'external';
+  screenX: number;
+  screenY: number;
+  /** Whether whatever is under the pointer currently accepts the drop. */
+  accepted?: boolean;
+}
+
+/** `onDragEnd`: `action` is what the drop performed, or null when the drag
+ * ended nowhere (or was rejected). */
+export interface DragEndEvent<T = DrawnNode> extends Omit<
+  DragSourceEvent<T>,
+  'action'
+> {
+  action: DropAction | null;
+  dropped: boolean;
+}
+
+/**
+ * The props that make a node draggable. `dragData` maps payload type names
+ * to values: strings and bytes are served as-is, thunks are resolved
+ * lazily (at delivery for an in-app drop, at promotion for an external
+ * one), and any other live value reaches in-app drops by reference
+ * (`e.items`) but is JSON-serialised for the wire.
+ */
+export interface DragSourceProps<T = DrawnNode> {
+  draggable?: boolean;
+  dragData?: Record<
+    string,
+    string | Uint8Array | (() => string | Uint8Array | unknown) | unknown
+  >;
+  /** Offered actions, preferred first. Defaults to `['copy']`. */
+  dragActions?: Array<'copy' | 'move' | 'link'>;
+  /** Fires past the drag threshold; `preventDefault()` cancels the drag
+   * (the gesture continues as plain mouse events). */
+  onDragStart?: (ev: DragSourceEvent<T>) => void;
+  /** Per motion while dragging — the source-side mirror of onDragOver. */
+  onDrag?: (ev: DragSourceEvent<T>) => void;
+  onDragEnd?: (ev: DragEndEvent<T>) => void;
 }
 
 /** The props that make a node a drop target. Any drawn element and
@@ -242,4 +292,5 @@ export interface EventHandlers<T = DrawnNode>
     PointerHandlers<T>,
     KeyboardHandlers<T>,
     FocusHandlers<T>,
-    DropTargetProps<T> {}
+    DropTargetProps<T>,
+    DragSourceProps<T> {}

--- a/test/dnd-source.test.js
+++ b/test/dnd-source.test.js
@@ -1,0 +1,615 @@
+// The drag source, both transports.
+//
+// In-app drags run against the mock app: the whole local transport —
+// threshold, DragStart cancellation, :dragging/:drag-over, live e.items,
+// click suppression — needs no X server at all. The external half runs
+// against node-x11's in-process JS server with a *fake XDND target* on a
+// second connection: it advertises XdndAware, receives the real
+// Enter/Position/Drop ClientMessages, converts the selection through ntk's
+// clipboard, and answers Status/Finished — wire bytes, not internals.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient, StaticFontSource } from 'ntk';
+
+import { createRoot } from '../src/index.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+// ntk events as the mock (and a real server) would deliver them; rootx
+// defaults to window-relative because the mock's windows sit at 0,0
+const down = (wnd, x, y, extra) =>
+  wnd.emit('mousedown', {
+    x,
+    y,
+    rootx: x,
+    rooty: y,
+    keycode: 1,
+    buttons: 0,
+    time: 100,
+    ...extra,
+  });
+const move = (wnd, x, y, extra) =>
+  wnd.emit('mousemove', {
+    x,
+    y,
+    rootx: x,
+    rooty: y,
+    buttons: 256,
+    time: 101,
+    ...extra,
+  });
+const up = (wnd, x, y, extra) =>
+  wnd.emit('mouseup', {
+    x,
+    y,
+    rootx: x,
+    rooty: y,
+    keycode: 1,
+    buttons: 0,
+    time: 102,
+    ...extra,
+  });
+
+async function renderMock(app, element) {
+  const x11Root = await createRoot({ app });
+  await new Promise((resolve) => x11Root.render(element, resolve));
+  // layout runs on the frame after the commit; events before it hit nothing
+  await tick();
+  await tick();
+  return x11Root;
+}
+
+// --- the in-app transport ---------------------------------------------------
+
+test('below the threshold a draggable is still a click', async () => {
+  const app = createMockApp();
+  const log = [];
+  const x11Root = await renderMock(
+    app,
+    h(
+      'window',
+      { width: 300, height: 200 },
+      h('box', {
+        draggable: true,
+        dragData: { 'text/plain': 'hi' },
+        onDragStart: () => log.push('dragstart'),
+        onClick: () => log.push('click'),
+        style: { width: 100, height: 100 },
+      }),
+    ),
+  );
+  const wnd = app.windows[0];
+  down(wnd, 10, 10);
+  move(wnd, 12, 11); // 3px: under the threshold
+  up(wnd, 12, 11);
+  await tick();
+  assert.deepEqual(log, ['click'], 'no drag, and the click still fires');
+  await x11Root.unmount();
+});
+
+test('an in-app drag: threshold, :dragging, live items, click suppression', async () => {
+  const app = createMockApp();
+  const log = [];
+  const rowPayload = { id: 42, label: 'live' };
+  const sourceRef = React.createRef();
+  const targetRef = React.createRef();
+  const x11Root = await renderMock(
+    app,
+    h(
+      'window',
+      { width: 400, height: 200 },
+      h('box', {
+        ref: sourceRef,
+        draggable: true,
+        dragData: {
+          'application/x-demo-row': rowPayload,
+          'text/uri-list': () => 'file:///tmp/a%20b.txt\r\n',
+          'text/plain': 'plain fallback',
+        },
+        dragActions: ['move', 'copy'],
+        onDragStart: (e) => log.push(['dragstart', e.types.length, e.source]),
+        onDragEnd: (e) => log.push(['dragend', e.action, e.dropped]),
+        onClick: () => log.push(['click']),
+        style: {
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          width: 100,
+          height: 100,
+        },
+      }),
+      h('box', {
+        ref: targetRef,
+        dropAccept: ['application/x-demo-row'],
+        onDragEnter: (e) => log.push(['enter', e.source]),
+        onDragOver: (e) => e.accept('move'),
+        onDrop: (e) =>
+          log.push([
+            'drop',
+            e.items['application/x-demo-row'],
+            e.files,
+            e.text,
+          ]),
+        style: {
+          position: 'absolute',
+          left: 200,
+          top: 0,
+          width: 150,
+          height: 150,
+        },
+      }),
+    ),
+  );
+  const wnd = app.windows[0];
+
+  down(wnd, 50, 50);
+  move(wnd, 60, 50); // past the threshold: the drag starts
+  await tick();
+  assert.deepEqual(log[0], ['dragstart', 3, 'internal']);
+  assert.equal(sourceRef.current.states[':dragging'], true);
+
+  move(wnd, 250, 60); // over the dropzone
+  await tick();
+  assert.deepEqual(log[1], ['enter', 'internal']);
+  assert.equal(targetRef.current.states[':drag-over'], true);
+
+  up(wnd, 250, 60);
+  await tick();
+  const dropEntry = log.find((l) => l[0] === 'drop');
+  assert.ok(dropEntry, 'the drop dispatched');
+  assert.equal(
+    dropEntry[1],
+    rowPayload,
+    'e.items carries the value by reference',
+  );
+  assert.deepEqual(
+    dropEntry[2],
+    [{ uri: 'file:///tmp/a%20b.txt', path: '/tmp/a b.txt' }],
+    'the uri-list thunk resolved and parsed, same shape as an external drop',
+  );
+  assert.equal(dropEntry[3], 'plain fallback', 'e.text from the text flavour');
+  assert.deepEqual(
+    log.at(-1),
+    ['dragend', 'move', true],
+    'onDragOver accept(move) won',
+  );
+  assert.equal(sourceRef.current.states[':dragging'], false);
+  assert.equal(targetRef.current.states[':drag-over'], false);
+  assert.ok(
+    !log.some((l) => l[0] === 'click'),
+    'a completed drag is not a click',
+  );
+  await x11Root.unmount();
+});
+
+test('a drag released over nothing ends with action null; mismatched accept rejects', async () => {
+  const app = createMockApp();
+  const log = [];
+  const x11Root = await renderMock(
+    app,
+    h(
+      'window',
+      { width: 400, height: 200 },
+      h('box', {
+        draggable: true,
+        dragData: { 'text/plain': 'x' },
+        onDragEnd: (e) => log.push(['dragend', e.action, e.dropped]),
+        style: {
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          width: 100,
+          height: 100,
+        },
+      }),
+      h('box', {
+        dropAccept: ['image/png'], // never matches text/plain
+        onDrop: () => log.push(['drop']),
+        style: {
+          position: 'absolute',
+          left: 200,
+          top: 0,
+          width: 150,
+          height: 150,
+        },
+      }),
+    ),
+  );
+  const wnd = app.windows[0];
+  down(wnd, 50, 50);
+  move(wnd, 70, 50);
+  move(wnd, 250, 60); // over the rejecting zone
+  up(wnd, 250, 60);
+  await tick();
+  assert.deepEqual(log, [['dragend', null, false]], 'no drop, no action');
+  await x11Root.unmount();
+});
+
+test('preventDefault in onDragStart cancels: the gesture stays a click', async () => {
+  const app = createMockApp();
+  const log = [];
+  const x11Root = await renderMock(
+    app,
+    h(
+      'window',
+      { width: 300, height: 200 },
+      h('box', {
+        draggable: true,
+        dragData: { 'text/plain': 'x' },
+        onDragStart: (e) => {
+          log.push('dragstart');
+          e.preventDefault();
+        },
+        onDrag: () => log.push('drag'),
+        onClick: () => log.push('click'),
+        style: { width: 100, height: 100 },
+      }),
+    ),
+  );
+  const wnd = app.windows[0];
+  down(wnd, 10, 10);
+  move(wnd, 40, 40);
+  move(wnd, 60, 60);
+  up(wnd, 60, 60);
+  await tick();
+  assert.deepEqual(
+    log,
+    ['dragstart', 'click'],
+    'cancelled: no onDrag, click intact',
+  );
+  await x11Root.unmount();
+});
+
+// --- the external transport (XDND out) --------------------------------------
+
+const SCREEN = { width: 800, height: 600 };
+
+async function headlessPair() {
+  const server = xserver.createServer(SCREEN);
+  const connect = async (onXError) => {
+    const [serverEnd, clientEnd] = xserver.createStreamPair();
+    server.addClientStream(serverEnd);
+    return createClient({
+      stream: clientEnd,
+      fontSource: new StaticFontSource(),
+      ...(onXError ? { onXError } : {}),
+    });
+  };
+  // our app swallows X errors: cursor-font glyph loads on the bare JS
+  // server are best-effort
+  return { server, app: await connect(() => {}), targetApp: await connect() };
+}
+
+const settle = (app) =>
+  new Promise((resolve) => app.X.GetInputFocus(() => setImmediate(resolve)));
+
+/** Drain round trips on every involved connection until `predicate` holds —
+ * a drag is a conversation, and both sides need the event loop. */
+async function until(apps, predicate, what) {
+  const list = Array.isArray(apps) ? apps : [apps];
+  for (let i = 0; i < 300; i++) {
+    if (predicate()) return;
+    for (const app of list) await settle(app);
+  }
+  assert.fail(`timed out waiting for ${what}`);
+}
+
+/** The other application: one window, XdndAware, answering the real
+ * protocol from the target side. */
+class FakeTarget {
+  constructor(app, { x, y, width, height, accept = true }) {
+    this.app = app;
+    this.X = app.X;
+    this.accept = accept;
+    this.received = [];
+    this.wnd = app.createWindow({ x, y, width, height });
+    this.wnd.map?.();
+  }
+
+  async init() {
+    const names = [
+      'XdndAware',
+      'XdndEnter',
+      'XdndPosition',
+      'XdndStatus',
+      'XdndLeave',
+      'XdndDrop',
+      'XdndFinished',
+      'XdndActionCopy',
+      'XdndActionMove',
+    ];
+    this.atoms = {};
+    await Promise.all(
+      names.map(
+        (name) =>
+          new Promise((resolve, reject) =>
+            this.X.InternAtom(false, name, (err, atom) => {
+              if (err) return reject(err);
+              this.atoms[name] = atom;
+              resolve();
+            }),
+          ),
+      ),
+    );
+    await this.wnd.setProperty('XdndAware', [5], { type: 'ATOM' });
+    this.X.on('event', (ev) => {
+      if (ev.type !== 33) return;
+      this.received.push(ev);
+      if (ev.message_type === this.atoms.XdndPosition) {
+        // accept (or refuse) with the requested action, no suppression
+        const source = ev.data[0];
+        this.X.SendClientMessage(
+          source,
+          source,
+          this.atoms.XdndStatus,
+          32,
+          [
+            this.wnd.id,
+            this.accept ? 1 | 2 : 0,
+            0,
+            0,
+            this.accept ? ev.data[4] : 0,
+          ],
+          0,
+        );
+      }
+      if (ev.message_type === this.atoms.XdndDrop) {
+        const source = ev.data[0];
+        // convert the selection like a real target, then confirm v5-style
+        this.app.clipboard
+          .read({ selection: 'XdndSelection', target: 'text/uri-list' })
+          .then((data) => {
+            this.converted = String(data);
+          })
+          .catch((err) => {
+            this.convertError = err;
+          })
+          .then(() => {
+            this.X.SendClientMessage(
+              source,
+              source,
+              this.atoms.XdndFinished,
+              32,
+              [this.wnd.id, 1, this.atoms.XdndActionCopy, 0, 0],
+              0,
+            );
+          });
+      }
+    });
+  }
+
+  ofType(name) {
+    return this.received.filter((ev) => ev.message_type === this.atoms[name]);
+  }
+}
+
+test('a drag out of the app speaks XDND: Enter, Position, Drop, Finished', async () => {
+  const { app, targetApp } = await headlessPair();
+  const x11Root = await createRoot({ app });
+  try {
+    const log = [];
+    let dragged;
+    const instance = await new Promise((resolve) =>
+      x11Root.render(
+        h(
+          'window',
+          { width: 300, height: 200 },
+          h('box', {
+            draggable: true,
+            dragData: {
+              'text/uri-list': () => {
+                dragged = true;
+                return 'file:///tmp/dragged.txt\r\n';
+              },
+              'text/plain': '/tmp/dragged.txt',
+            },
+            onDrag: (e) => log.push(['drag', e.source, e.accepted]),
+            onDragEnd: (e) => log.push(['dragend', e.action, e.dropped]),
+            style: { width: 100, height: 100 },
+          }),
+        ),
+        resolve,
+      ),
+    );
+    const target = new FakeTarget(targetApp, {
+      x: 400,
+      y: 0,
+      width: 150,
+      height: 150,
+    });
+    await target.init();
+    await settle(app);
+    await settle(app); // XdndAware + _screenOrigin land
+
+    const wnd = instance; // the ntk window (render hands back the public instance)
+    wnd.emit('mousedown', {
+      x: 50,
+      y: 50,
+      rootx: 50,
+      rooty: 50,
+      keycode: 1,
+      buttons: 0,
+      time: 10,
+    });
+    wnd.emit('mousemove', {
+      x: 70,
+      y: 50,
+      rootx: 70,
+      rooty: 50,
+      buttons: 256,
+      time: 11,
+    });
+    assert.equal(dragged, undefined, 'thunks are not resolved at drag start');
+
+    // leave our window (300 wide) for the fake target at x=400
+    wnd.emit('mousemove', {
+      x: 450,
+      y: 60,
+      rootx: 450,
+      rooty: 60,
+      buttons: 256,
+      time: 12,
+    });
+    await until(
+      [app, targetApp],
+      () => target.ofType('XdndEnter').length > 0,
+      'XdndEnter',
+    );
+    const enter = target.ofType('XdndEnter')[0];
+    assert.equal(enter.data[1] >>> 24, 5, 'version 5, two types inline');
+    assert.equal(enter.data[1] & 1, 0, 'no XdndTypeList needed for two types');
+    assert.equal(dragged, true, 'promotion resolved the thunk for publication');
+
+    await until(
+      [app, targetApp],
+      () => target.ofType('XdndPosition').length > 0,
+      'XdndPosition',
+    );
+    const pos = target.ofType('XdndPosition')[0];
+    assert.equal(pos.data[2] >>> 16, 450, 'root x');
+    assert.equal(pos.data[2] & 0xffff, 60, 'root y');
+
+    // the accepting XdndStatus surfaces on the *next* motion's onDrag —
+    // keep the pointer twitching, as a real drag would
+    await until(
+      [app, targetApp],
+      () => {
+        wnd.emit('mousemove', {
+          x: 451,
+          y: 60,
+          rootx: 451,
+          rooty: 60,
+          buttons: 256,
+          time: 12,
+        });
+        return log.some((l) => l[0] === 'drag' && l[2] === true);
+      },
+      'accepted status reaching onDrag',
+    );
+
+    wnd.emit('mouseup', {
+      x: 451,
+      y: 60,
+      rootx: 451,
+      rooty: 60,
+      keycode: 1,
+      buttons: 0,
+      time: 13,
+    });
+    await until(
+      [app, targetApp],
+      () => target.ofType('XdndDrop').length > 0,
+      'XdndDrop',
+    );
+    await until(
+      [app, targetApp],
+      () => target.converted != null || target.convertError,
+      'the conversion',
+    );
+    assert.equal(target.convertError, undefined, 'the selection converted');
+    assert.equal(target.converted, 'file:///tmp/dragged.txt\r\n');
+
+    await until(
+      [app, targetApp],
+      () => log.some((l) => l[0] === 'dragend'),
+      'onDragEnd',
+    );
+    assert.deepEqual(log.at(-1), ['dragend', 'copy', true]);
+    await x11Root.unmount();
+  } finally {
+    await app.close();
+    await targetApp.close();
+  }
+});
+
+test('a refusing target: Leave on release, dragend with no action', async () => {
+  const { app, targetApp } = await headlessPair();
+  const x11Root = await createRoot({ app });
+  try {
+    const log = [];
+    const instance = await new Promise((resolve) =>
+      x11Root.render(
+        h(
+          'window',
+          { width: 300, height: 200 },
+          h('box', {
+            draggable: true,
+            dragData: { 'text/plain': 'nope' },
+            onDragEnd: (e) => log.push(['dragend', e.action, e.dropped]),
+            style: { width: 100, height: 100 },
+          }),
+        ),
+        resolve,
+      ),
+    );
+    const target = new FakeTarget(targetApp, {
+      x: 400,
+      y: 0,
+      width: 150,
+      height: 150,
+      accept: false,
+    });
+    await target.init();
+    await settle(app);
+    await settle(app);
+
+    instance.emit('mousedown', {
+      x: 50,
+      y: 50,
+      rootx: 50,
+      rooty: 50,
+      keycode: 1,
+      buttons: 0,
+      time: 10,
+    });
+    instance.emit('mousemove', {
+      x: 70,
+      y: 50,
+      rootx: 70,
+      rooty: 50,
+      buttons: 256,
+      time: 11,
+    });
+    instance.emit('mousemove', {
+      x: 450,
+      y: 60,
+      rootx: 450,
+      rooty: 60,
+      buttons: 256,
+      time: 12,
+    });
+    await until(
+      [app, targetApp],
+      () => target.ofType('XdndPosition').length > 0,
+      'a position',
+    );
+    await settle(app); // let the refusing status arrive back
+
+    instance.emit('mouseup', {
+      x: 450,
+      y: 60,
+      rootx: 450,
+      rooty: 60,
+      keycode: 1,
+      buttons: 0,
+      time: 13,
+    });
+    await until([app, targetApp], () => log.length > 0, 'onDragEnd');
+    assert.deepEqual(log, [['dragend', null, false]]);
+    await until(
+      [app, targetApp],
+      () => target.ofType('XdndLeave').length > 0,
+      'the refused target getting its XdndLeave',
+    );
+    assert.equal(target.ofType('XdndDrop').length, 0, 'and never a drop');
+    await x11Root.unmount();
+  } finally {
+    await app.close();
+    await targetApp.close();
+  }
+});


### PR DESCRIPTION
Phases 2+3 of #126: react-x11 nodes become **drag sources** — in-app drags with live payloads, and full XDND out to any other X11 application. With #162's drop target this completes both sides of the protocol. Includes the two-process example pair.

## One session, two transports

A press on a `draggable` node becomes a drag past a 4px threshold (below it, still a click; a completed drag suppresses the click, as in the DOM).

- **Inside the app** (any of its windows/popups): the drag is local — zero wire traffic, delivery through the same `DropSession` path-diffing the target half uses, and `e.items` hands the `dragData` values over **by reference**. Reorderable lists and kanban never serialise anything.
- **Leaving the app's windows** promotes to XDND: `dragData` publishes on `XdndSelection` via ntk 5.3's clipboard (INCR included) — thunks resolve only now, so a drag that ends in the wastebasket never builds its payload; live objects JSON-serialise for the wire. The target is found by descending from the root (`XdndAware` checked per level, `XdndProxy` honoured, our own windows and the preview skipped); Enter/Position/Leave/Drop go out, Status/Finished come back, and the suppression rectangle is respected. Re-entering our windows demotes back to local. Handlers can't tell the transports apart except via `e.source`.

## API

```jsx
<box
  draggable
  dragData={{
    'text/uri-list': () => toUriList(item),   // thunk — resolved lazily
    'application/x-myapp-item': item,          // live object
  }}
  dragActions={['copy', 'move']}
  onDragEnd={(e) => { if (e.action === 'move') remove(item.id); }}
  style={{ ':dragging': { opacity: 0.4 } }}
/>
```

`onDragStart` (cancellable) / `onDrag` (`screenX/Y`, `accepted`) / `onDragEnd` (`{ action | null, dropped }`); `:dragging` style state; mid-drag cursor via `ChangeActivePointerGrab` over the implicit button grab (core-font approximations — the XCursor theme caveat from the design doc stands). `XdndFinished` is awaited with a 5 s timeout so a dead target can't wedge the gesture, and `XdndSelection` is disowned at drag end per the spec's stale-data warning.

`useDragSource` packages render state — `isDragging` + pointer `position` — and the **drag preview is a live React tree**: a `<popup dragPreview>` following `position`, not a `setDragImage` bitmap. The `dragPreview` window prop keeps the router from treating the preview as the window under the pointer.

Internal drops receive the same shape as external ones (`e.files` parsed, `e.text`, `getData`) plus `e.items` — a handler written for one transport works on the other.

## The example pair (two processes)

- [`examples/dnd-source.jsx`](https://github.com/sidorares/react-x11/blob/feat/xdnd-source/examples/dnd-source.jsx) — a draggable file shelf (`text/uri-list` thunk + `text/plain` + custom JSON type), an in-app tray demonstrating live-payload 'move', the preview popup, `:dragging`/`:drag-over` styling.
- [`examples/dnd-target.jsx`](https://github.com/sidorares/react-x11/blob/feat/xdnd-source/examples/dnd-target.jsx) — three zones: `dropAccept={['files']}` with `useDropTarget`'s `isOver`/`isAccepted`, the `['text']` flavour zoo, and a custom MIME type read with `await e.getData()` (live object in-app, JSON over the wire cross-process), plus a drop log.

`npm run examples:dnd-target` and `npm run examples:dnd-source` in two terminals; they also interop with file managers/editors/browsers (Linux/XWayland; on XQuartz test X-client↔X-client — Finder does not bridge, XQuartz/XQuartz#173).

Verified hermetically before shipping: both example apps rendered against the in-process JS server on one screen, an in-app tray move, **and a cross-process XDND drop of the custom JSON type between the two apps** (target logged `demo object (wire): data.csv`).

## Tests (+6, 383 total)

- **Mock app, no server**: threshold (a 3px wiggle stays a click), `onDragStart` `preventDefault` cancellation, `:dragging`/`:drag-over` flips, live `e.items` identity, uri-list thunk parsed to the same `e.files` shape as external drops, click suppression, `dragend` with `action: null` over a rejecting zone.
- **JS server, fake XdndAware target on a second connection**: Enter carries version 5 + inline types, Position packs root coords, thunks resolve at promotion (asserted un-resolved at drag start), the accepting Status reaches `onDrag`, Drop → the fake target converts the selection through ntk's clipboard and gets the exact payload, Finished → `onDragEnd { action: 'copy', dropped: true }`; the refusal path gets `XdndLeave` and never a Drop.

## Notes

- Per-motion target descent is 2–4 round trips (fine locally; the drag-start window cache from the design doc is the remote-X follow-up, noted in docs).
- One test-harness discovery folded in: on the mock app, events emitted straight after the render callback land before layout — `renderMock` settles two ticks first.
- Docs: `docs/events.md` gains the "Drag sources" section; `examples/README.md` rows; typecheck/lint/prettier/383 tests/website build all green.

Part of #126 — ticks Phases 2 and 3. Remaining: Phase 4 (XdndActionAsk menu, scrollview edge auto-scroll, the react-dnd backend package).
