### PR TITLE
fix(clipboard): ICCCM timestamps on copy, paste, drop and drag-end release

### DIFF
--- a/docs/architecture/drag-and-drop.md
+++ b/docs/architecture/drag-and-drop.md
@@ -203,9 +203,11 @@ named mechanism, and the drag path got slightly cheaper.
    and the server routes to whoever owns it, wherever that is — and none of
    the reference implementations validate owner == source window. Verify in
    Phase 3; if a target does check, ntk needs a `window` option on `write()`.
-   Related: there is no disown API, so releasing `XdndSelection` at drag end
-   means `app.X.SetSelectionOwner(0, sel, time)` directly, or a small
-   `clipboard.clear(selection)` upstream.
+   Related: there was no disown API when this was written, so releasing
+   `XdndSelection` at drag end meant `app.X.SetSelectionOwner(0, sel, time)`
+   directly. **ntk 5.4.0 added `clipboard.clear(selection)`**
+   ([ntk#169](https://github.com/sidorares/ntk/issues/169)) and `_disown()`
+   uses it.
 
 #### Unchanged
 
@@ -725,10 +727,14 @@ need ([§0.1](#01-audit-against-ntk-530)).
 - **[ntk, optional]** `ChangeActivePointerGrab` wrapper for the mid-drag
   cursor swap — `grabPointer({ cursor: app.cursors.get(name) })` already
   covers grab time, and node-x11 exposes the request, so this is convenience.
-- **[ntk, optional]** `clipboard.clear(selection)` to disown `XdndSelection`
-  at drag end (otherwise `app.X.SetSelectionOwner(0, sel, time)` directly);
-  lazy payload getters on `write()` if eager serialisation at promotion turns
-  out to matter.
+- **[ntk, done in 5.4.0]** `clipboard.clear(selection)` to disown
+  `XdndSelection` at drag end
+  ([ntk#169](https://github.com/sidorares/ntk/issues/169)), and a `time`
+  option on `read()`/`targets()` so a drop converts with `XdndDrop`'s
+  timestamp rather than `CurrentTime`
+  ([ntk#168](https://github.com/sidorares/ntk/issues/168)). Both are wired
+  up. Still open: lazy payload getters on `write()`, if eager serialisation
+  at promotion turns out to matter.
 - **[decision]** `:drag-over` (and later `:dragging`) join `STATE_KEYS`.
 
 ### Phase 1 — drop target (closes #126)
@@ -832,12 +838,17 @@ Unusually strong here, and worth exploiting.
   descent (safe, because the grab makes us the only client searching).
 - **Timestamps.** Using `CurrentTime` for `ConvertSelection` mostly works and
   then fails against sources that validate — the worst failure profile there
-  is. Thread `XdndDrop`'s `l[2]` through.
+  is. Thread `XdndDrop`'s `l[2]` through. _Done:_ `read({ time })` landed in
+  ntk 5.4.0 and `_getData` passes the drop timestamp.
 - **Selection ownership outlives the drag.** ntk's `Clipboard` holds a
-  selection until someone else takes it, and has no disown API. An
-  `XdndSelection` still owned after the drag ends is mostly harmless, but a
-  stale offer answered after `XdndFinished` is the case the spec warns about
-  ("throw out extremely old data"); release it explicitly at drag end.
+  selection until someone else takes it. An `XdndSelection` still owned after
+  the drag ends is mostly harmless, but a stale offer answered after
+  `XdndFinished` is the case the spec warns about ("throw out extremely old
+  data"); release it explicitly at drag end. _Done:_ `_disown()` calls
+  `clipboard.clear('XdndSelection')` (ntk 5.4.0), which releases with the
+  acquisition timestamp — so a drag that already lost the selection to
+  another client leaves it alone, where `CurrentTime` would have taken it
+  back from them.
 - **Grabs versus `<popup>`.** Menus already take pointer grabs
   (`window.js:2017`). A drag beginning inside an open menu must not fight
   them; establish that the drag grab replaces the menu grab, and that closing

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^5.3.0",
+        "ntk": "^5.4.0",
         "react-reconciler": "^0.33.0"
       },
       "devDependencies": {
@@ -3676,9 +3676,9 @@
       }
     },
     "node_modules/ntk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-5.3.0.tgz",
-      "integrity": "sha512-jAnEhhcMfbvJ5sj3M2LDv4a17IhNl2q9HRFGj02zPskcKoaqeU1m1nOMXNK6mI0GDcKM4X52qHeLIOGtRYHLMA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-5.4.0.tgz",
+      "integrity": "sha512-OXb9GlTfuomOvkyu4kpPGgvfooJXHMctS9LaBbq/Dqe3/FmrDKBpn4dpoJGFBkeI2npREh6nMKyW7D5AukqKKQ==",
       "license": "MIT",
       "dependencies": {
         "bidi-js": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^5.3.0",
+    "ntk": "^5.4.0",
     "react-reconciler": "^0.33.0"
   },
   "peerDependencies": {

--- a/src/dnd.js
+++ b/src/dnd.js
@@ -519,12 +519,12 @@ export class DropSession {
     let text;
     try {
       if (typeMatches(this.types, 'files')) {
-        const raw = await this._getData('text/uri-list');
+        const raw = await this._getData('text/uri-list', time);
         text = String(raw);
         files = parseUriList(raw);
       } else {
         const best = TEXT_TARGETS.find((t) => this.types.includes(t));
-        if (best) text = await this._getData(best);
+        if (best) text = await this._getData(best, time);
       }
     } catch {
       // conversion refused or timed out; the handler still runs with
@@ -551,7 +551,9 @@ export class DropSession {
         );
         drop.files = files;
         drop.text = text;
-        drop.getData = (type) => this._getData(this._resolveType(type));
+        // `time` is captured, not read off the session: an async onDrop can
+        // still be holding getData after a later drag has reset us
+        drop.getData = (type) => this._getData(this._resolveType(type), time);
         this._dispatchDrop(point.windowNode, targetNode, drop, pending);
         this._clearPath();
       });
@@ -726,16 +728,20 @@ export class DropSession {
   // -- data ----------------------------------------------------------------
 
   /** One selection conversion, decoded for text-ish targets. ntk's
-   * clipboard drives ConvertSelection + INCR reassembly; note it converts
-   * with CurrentTime rather than the drop timestamp (`read` has no time
-   * option yet) — fine for every mainstream source, which serves whatever
-   * it currently offers. */
-  async _getData(target, _time) {
+   * clipboard drives ConvertSelection + INCR reassembly.
+   *
+   * `time` is the timestamp from `XdndDrop`'s `l[2]`, which the protocol
+   * says to convert with — never CurrentTime. Mainstream sources serve
+   * whatever they currently offer and would not notice, but one that
+   * validates the timestamp fails mysteriously, which is the worst failure
+   * profile there is. */
+  async _getData(target, time) {
     const clipboard = this.node.app.clipboard;
     if (!clipboard) throw new Error('react-x11: no clipboard on this app');
     const data = await clipboard.read({
       selection: 'XdndSelection',
       target,
+      time,
     });
     return typeof data === 'string' ? data : decodeData(data, target);
   }
@@ -1493,17 +1499,22 @@ export class DragSession {
 
   /** Give XdndSelection up at drag end. Ownership is otherwise held until
    * someone else drags — harmless, except that a stale offer answered long
-   * after XdndFinished is exactly what the spec warns about. */
+   * after XdndFinished is exactly what the spec warns about.
+   *
+   * `clipboard.clear()` rather than a raw `SetSelectionOwner` (ntk >= 5.4.0):
+   * it releases with the timestamp the selection was acquired with, as ICCCM
+   * 2.3.1 requires, so a drag that has already lost XdndSelection to another
+   * client leaves it alone — where CurrentTime would have taken it away from
+   * them. It also keeps ntk's own record of what it owns in step, instead of
+   * waiting for the SelectionClear to come back and say so. */
   _disown() {
-    internAtom(this.X, 'XdndSelection')
-      .then((sel) => {
-        try {
-          this.X.SetSelectionOwner(0, sel, 0);
-        } catch {
-          // teardown
-        }
-      })
-      .catch(() => {});
+    // Nothing here may throw: `_end` calls this before dispatching DragEnd,
+    // so a throw would cost the app the end of its own drag.
+    try {
+      this.app?.clipboard?.clear('XdndSelection')?.catch(() => {});
+    } catch {
+      // a connection already closing
+    }
   }
 
   _sendTo(destWid, typeAtom, data) {

--- a/src/events.js
+++ b/src/events.js
@@ -11,6 +11,7 @@ import {
 import { flushPendingFrames } from './frames.js';
 import { callHandler } from './errors.js';
 import { armDrag } from './dnd.js';
+import { noteInputTime } from './inputtime.js';
 
 const XK_TAB = 0xff09;
 const WHEEL_BUTTONS = { 4: [0, -48], 5: [0, 48], 6: [-48, 0], 7: [48, 0] };
@@ -121,7 +122,18 @@ export class EventManager {
     // leaves it to the paced frame. Which is which is not a judgement call:
     // it is ntk's coalesce table (lib/events_map.js), and motion is the
     // whole reason that table exists.
-    const onDiscrete = (name, fn) => wnd.on(name, discrete(fn));
+    // Every X input event carries a server timestamp, and the selection
+    // operations further down need one (inputtime.js). Noting it here, on
+    // the way past, is what keeps `write()`/`read()` from having to ask the
+    // server for the time they should already know.
+    const onDiscrete = (name, fn) =>
+      wnd.on(
+        name,
+        discrete((ev) => {
+          noteInputTime(this.node.app, name, ev);
+          return fn(ev);
+        }),
+      );
     onDiscrete('mousedown', (ev) => this._onMouseDown(ev));
     onDiscrete('mouseup', (ev) => this._onMouseUp(ev));
     wnd.on('mousemove', (ev) => this._onMouseMove(ev));

--- a/src/inputtime.js
+++ b/src/inputtime.js
@@ -1,0 +1,45 @@
+// The server timestamp of the last X input event, per app.
+//
+// X arbitrates between clients by timestamp, and every selection operation
+// wants one: taking a selection (ICCCM 2.1), converting one (ICCCM 2.4) and
+// giving one back (ICCCM 2.3.1) all say to use "the timestamp of the event
+// that caused this" and not CurrentTime. The only place that value exists is
+// the X event being dispatched, which is nowhere near the code that copies —
+// `_copySelection` is four frames down from the keystroke that triggered it.
+//
+// So it is stashed on the way past, the same trick GTK plays with
+// `gtk_get_current_event_time()`. Without it ntk asks the server for a
+// timestamp on every acquisition, which is a round trip per copy — and
+// select-to-own PRIMARY copies on every selection-extending keystroke.
+//
+// Keyed on the app rather than stored on it: one process can drive several
+// roots on several connections, and a timestamp is only meaningful against
+// the server clock that issued it.
+
+const lastInputTime = new WeakMap();
+
+// Motion is deliberately not tracked. Nothing converts or acquires a
+// selection from a motion event — a drag-select owns PRIMARY on the mouseup
+// that ends it, and a drag publishes on the mousedown that began it — so
+// tracking motion would add a write per motion event to buy nothing.
+const TRACKED = new Set(['mousedown', 'mouseup', 'keydown', 'keyup']);
+
+/** Remember the server time an input event carried, if it carried one. */
+export function noteInputTime(app, name, native) {
+  if (!app || !TRACKED.has(name)) return;
+  const time = native?.time;
+  if (typeof time === 'number') lastInputTime.set(app, time >>> 0);
+}
+
+/**
+ * The last input timestamp seen on this app's connection, or `undefined`
+ * when no input has arrived yet.
+ *
+ * `undefined` is passed straight through to ntk rather than replaced with a
+ * zero: `write()` turns it into a real server timestamp, and CurrentTime is
+ * what ICCCM 2.1 forbids. A caller with no event to name should get ntk's
+ * fallback, not a made-up number.
+ */
+export function inputTime(app) {
+  return app ? lastInputTime.get(app) : undefined;
+}

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -41,6 +41,7 @@ import { windowIdOf } from './windowid.js';
 import { paintCacheFor } from './paintcache.js';
 import { hooks as traceHooks } from './trace-registry.js';
 import { runWithPriority, DiscreteEventPriority } from './priority.js';
+import { inputTime } from './inputtime.js';
 import {
   editMenuColors,
   editMenuGeometry,
@@ -2180,7 +2181,7 @@ function ctrlChordLetter(ev) {
  * prefix measurement, editing via the EventManager default-action hooks
  * (user onKeyDown/onMouseDown handlers run first and can preventDefault).
  * Clipboard: Ctrl+C/X/V on CLIPBOARD, X11-style middle-click paste and
- * select-to-own on PRIMARY (needs ntk >= 3.2.0 app.clipboard; degrades
+ * select-to-own on PRIMARY (needs ntk >= 5.4.0 app.clipboard; degrades
  * gracefully without it). Controlled (`value` + `onChange`) or uncontrolled
  * (`defaultValue`). Caret indices are in code points, not UTF-16 units.
  */
@@ -2573,13 +2574,28 @@ export class TextInputNode extends Node {
     const text = this._selectedText();
     if (!text) return;
     this._clipboardApi()
-      ?.write(text, { selection })
-      .catch(() => {});
+      // ICCCM 2.1: the timestamp of the event that triggered the copy is
+      // what arbitrates a race with another app copying at the same moment.
+      // It also saves ntk a round trip asking the server for one, which on
+      // PRIMARY is a round trip per selection-extending keystroke.
+      ?.write(text, { selection, time: inputTime(this.app) })
+      .catch((err) => {
+        // Losing the race is now possible rather than theoretical: a real
+        // event timestamp can be older than another client's, where the
+        // server-time fallback never was. A cut that deleted the text
+        // without acquiring the selection should not be silent.
+        console.warn(
+          `react-x11: could not take the ${selection} selection: ${err.message}`,
+        );
+      });
   }
 
   _pasteFrom(selection = 'CLIPBOARD') {
     this._clipboardApi()
-      ?.read({ selection })
+      // ICCCM 2.4: convert with the timestamp of the event that asked for
+      // the paste, so an owner that has replaced its data since can tell
+      // which value was wanted (ntk >= 5.4.0)
+      ?.read({ selection, time: inputTime(this.app) })
       .then((text) => {
         if (!this.destroyed && text) this._insert(text);
       })

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -2584,8 +2584,12 @@ export class TextInputNode extends Node {
         // event timestamp can be older than another client's, where the
         // server-time fallback never was. A cut that deleted the text
         // without acquiring the selection should not be silent.
+        //
+        // `err?.message ?? err` because a throw in here would be an
+        // unhandled rejection, which ends the process — the exact failure
+        // errors.js exists to keep away from a GUI event path.
         console.warn(
-          `react-x11: could not take the ${selection} selection: ${err.message}`,
+          `react-x11: could not take the ${selection} selection: ${err?.message ?? err}`,
         );
       });
   }

--- a/test/dnd-source.test.js
+++ b/test/dnd-source.test.js
@@ -388,7 +388,7 @@ class FakeTarget {
   }
 }
 
-test('a drag out of the app speaks XDND: Enter, Position, Drop, Finished', async () => {
+test('a drag out of the app speaks XDND: Enter, Position, Drop, Finished, and gives the selection back', async () => {
   const { app, targetApp } = await headlessPair();
   const x11Root = await createRoot({ app });
   try {
@@ -520,6 +520,133 @@ test('a drag out of the app speaks XDND: Enter, Position, Drop, Finished', async
       'onDragEnd',
     );
     assert.deepEqual(log.at(-1), ['dragend', 'copy', true]);
+
+    // and the selection goes back. Holding XdndSelection past the drag is
+    // how a stale offer gets answered long after XdndFinished, which is
+    // what the spec means by "throw out extremely old data".
+    const sel = await new Promise((resolve, reject) =>
+      targetApp.X.InternAtom(false, 'XdndSelection', (err, a) =>
+        err ? reject(err) : resolve(a),
+      ),
+    );
+    const ownerOf = () =>
+      new Promise((resolve, reject) =>
+        targetApp.X.GetSelectionOwner(sel, (err, wid) =>
+          err ? reject(err) : resolve(wid),
+        ),
+      );
+    let owner = await ownerOf();
+    for (let i = 0; i < 50 && owner !== 0; i++) {
+      await settle(app);
+      await settle(targetApp);
+      owner = await ownerOf();
+    }
+    assert.equal(owner, 0, 'XdndSelection was given back at drag end');
+
+    await x11Root.unmount();
+  } finally {
+    await app.close();
+    await targetApp.close();
+  }
+});
+
+test('ending a drag does not take XdndSelection back from whoever owns it now', async () => {
+  // The release is addressed at the drag's own ownership, not at the
+  // selection generally: `clipboard.clear()` releases with the timestamp the
+  // selection was acquired with, and sends nothing at all once we are no
+  // longer the owner. A raw SetSelectionOwner(None, CurrentTime) would
+  // instead succeed here and quietly strip the new owner.
+  const { app, targetApp } = await headlessPair();
+  const x11Root = await createRoot({ app });
+  try {
+    const log = [];
+    const instance = await new Promise((resolve) =>
+      x11Root.render(
+        h(
+          'window',
+          { width: 300, height: 200 },
+          h('box', {
+            draggable: true,
+            dragData: { 'text/plain': 'ours' },
+            onDragEnd: () => log.push('dragend'),
+            style: { width: 100, height: 100 },
+          }),
+        ),
+        resolve,
+      ),
+    );
+    await settle(app);
+    await settle(app);
+
+    const sel = await new Promise((resolve, reject) =>
+      targetApp.X.InternAtom(false, 'XdndSelection', (err, a) =>
+        err ? reject(err) : resolve(a),
+      ),
+    );
+    const ownerOf = () =>
+      new Promise((resolve, reject) =>
+        targetApp.X.GetSelectionOwner(sel, (err, wid) =>
+          err ? reject(err) : resolve(wid),
+        ),
+      );
+
+    const wnd = instance;
+    wnd.emit('mousedown', {
+      x: 50,
+      y: 50,
+      rootx: 50,
+      rooty: 50,
+      keycode: 1,
+      buttons: 0,
+      time: 10,
+    });
+    wnd.emit('mousemove', {
+      x: 70,
+      y: 50,
+      rootx: 70,
+      rooty: 50,
+      buttons: 256,
+      time: 11,
+    });
+    // leave our 300-wide window: promotion publishes on XdndSelection
+    wnd.emit('mousemove', {
+      x: 450,
+      y: 60,
+      rootx: 450,
+      rooty: 60,
+      buttons: 256,
+      time: 12,
+    });
+    // `until` takes a sync predicate, and this one has to await a round
+    // trip, so poll it directly
+    let published = 0;
+    for (let i = 0; i < 300 && published === 0; i++) {
+      await settle(app);
+      await settle(targetApp);
+      published = await ownerOf();
+    }
+    assert.notEqual(published, 0, 'promotion published on XdndSelection');
+
+    // another client copies mid-drag, taking the selection from us
+    await targetApp.clipboard.write('theirs', { selection: 'XdndSelection' });
+    const theirs = await ownerOf();
+    assert.notEqual(theirs, 0, 'the other client owns it now');
+
+    wnd.emit('mouseup', {
+      x: 450,
+      y: 60,
+      rootx: 450,
+      rooty: 60,
+      keycode: 1,
+      buttons: 0,
+      time: 13,
+    });
+    await until([app, targetApp], () => log.includes('dragend'), 'onDragEnd');
+    for (let i = 0; i < 20; i++) {
+      await settle(app);
+      await settle(targetApp);
+    }
+    assert.equal(await ownerOf(), theirs, 'the new owner keeps the selection');
     await x11Root.unmount();
   } finally {
     await app.close();

--- a/test/dnd.test.js
+++ b/test/dnd.test.js
@@ -57,8 +57,14 @@ class FakeSource {
     this.X = app.X;
     this.wnd = app.createWindow({ width: 10, height: 10 });
     this.received = []; // ClientMessages sent back to us
+    // SelectionRequests ntk's clipboard answers on our behalf. Observing
+    // them is how the conversion timestamp is checked: XDND says a drop
+    // must convert with the timestamp from XdndDrop, never CurrentTime.
+    this.conversions = [];
     this.X.on('event', (ev) => {
       if (ev.type === 33) this.received.push(ev);
+      if (ev.type === 30)
+        this.conversions.push({ target: ev.target, time: ev.time });
     });
   }
 
@@ -424,6 +430,19 @@ test('drop: uri-list arrives parsed, XdndFinished confirms with the action', asy
     assert.equal(fin[0], instance.id, 'l[0] is the target window');
     assert.equal(fin[1] & 1, 1, 'v5: accepted bit set');
     assert.equal(fin[2], src.atoms.XdndActionCopy, 'v5: performed action');
+
+    // The conversion carried XdndDrop's timestamp, l[2] = 43, rather than
+    // CurrentTime. Mainstream sources serve whatever they hold and never
+    // notice; one that validates the timestamp refuses, and that is the
+    // failure this pins.
+    const uriList = await src.typeAtom('text/uri-list');
+    const converted = src.conversions.filter((c) => c.target === uriList);
+    assert.ok(converted.length > 0, 'the target converted text/uri-list');
+    assert.deepEqual(
+      [...new Set(converted.map((c) => c.time))],
+      [43],
+      "every conversion used XdndDrop's timestamp",
+    );
     await x11Root.unmount();
   } finally {
     await app.close();

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -9,10 +9,15 @@ import { createMockApp } from './helpers/mock-app.js';
 
 // Simulate an ntk keydown: registers the keysym for a synthetic keycode and
 // emits the raw event shape the EventManager consumes.
-function pressKey(app, wnd, { keysym, codepoint, buttons = 0 }) {
+function pressKey(app, wnd, { keysym, codepoint, buttons = 0, time }) {
   const keycode = ((keysym ?? codepoint) % 248) + 8;
   app.X.keycode2keysyms[keycode] = [keysym ?? codepoint];
-  wnd.emit('keydown', { keycode, codepoint, buttons });
+  wnd.emit('keydown', {
+    keycode,
+    codepoint,
+    buttons,
+    ...(time ? { time } : {}),
+  });
 }
 
 const XK = {
@@ -1091,6 +1096,104 @@ test('textinput: clipboard shortcuts and middle-click PRIMARY paste', async () =
   wnd.emit('mousedown', { x: 10, y: 10, keycode: 2 }); // middle click
   await tick();
   assert.strictEqual(input.value, 'clip!primary!');
+
+  await x11Root.unmount();
+});
+
+test('textinput: a copy and a paste carry the timestamp of the event behind them', async () => {
+  // X arbitrates selection ownership by timestamp, and the right one is the
+  // event that triggered the copy — not "whenever ntk's round trip asking
+  // the server for the time happened to finish"
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  app.clipboard = {
+    writes: [],
+    reads: [],
+    write(text, opts) {
+      this.writes.push({ text, selection: opts?.selection, time: opts?.time });
+      return Promise.resolve();
+    },
+    read(opts) {
+      this.reads.push({ selection: opts?.selection, time: opts?.time });
+      return Promise.resolve('pasted');
+    },
+  };
+  x11Root.render(
+    React.createElement(
+      'window',
+      { width: 200, height: 50 },
+      React.createElement('textinput', {
+        defaultValue: 'hello',
+        style: { flexGrow: 1 },
+      }),
+    ),
+  );
+  await tick();
+  const wnd = app.windows[0];
+
+  wnd.emit('mousedown', { x: 10, y: 10, keycode: 1, time: 900 });
+  wnd.emit('mouseup', { x: 10, y: 10, keycode: 1, time: 901 });
+
+  pressKey(app, wnd, { keysym: 0x61, codepoint: 0x61, buttons: 4, time: 1000 }); // ctrl+a
+  pressKey(app, wnd, { keysym: 0x63, codepoint: 0x63, buttons: 4, time: 1001 }); // ctrl+c
+  assert.strictEqual(
+    app.clipboard.writes.at(-1).time,
+    1001,
+    'the copy carries its own keystroke, not the select-all before it',
+  );
+
+  pressKey(app, wnd, { keysym: 0x76, codepoint: 0x76, buttons: 4, time: 1002 }); // ctrl+v
+  await tick();
+  assert.deepStrictEqual(app.clipboard.reads.at(-1), {
+    selection: 'CLIPBOARD',
+    time: 1002,
+  });
+
+  // middle-click paste is driven by the button event, so that is the stamp
+  wnd.emit('mousedown', { x: 10, y: 10, keycode: 2, time: 1003 });
+  await tick();
+  assert.deepStrictEqual(app.clipboard.reads.at(-1), {
+    selection: 'PRIMARY',
+    time: 1003,
+  });
+
+  await x11Root.unmount();
+});
+
+test('textinput: with no input seen yet, ntk is left to find its own timestamp', async () => {
+  // `undefined` rather than 0: CurrentTime is what ICCCM 2.1 forbids, and
+  // ntk's own fallback asks the server for a real one
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const writes = [];
+  app.clipboard = {
+    write(text, opts) {
+      writes.push(opts);
+      return Promise.resolve();
+    },
+    read: () => Promise.resolve(''),
+  };
+  x11Root.render(
+    React.createElement(
+      'window',
+      { width: 200, height: 50 },
+      React.createElement('textinput', {
+        defaultValue: 'hello',
+        style: { flexGrow: 1 },
+      }),
+    ),
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const input = wnd._reactX11Node.children[0];
+  input._anchor = 0;
+  input._caret = 5;
+  input._copySelection();
+  assert.strictEqual(writes.length, 1);
+  assert.ok(
+    !('time' in writes[0]) || writes[0].time === undefined,
+    'no invented timestamp',
+  );
 
   await x11Root.unmount();
 });


### PR DESCRIPTION
X arbitrates between clients by timestamp, and the right value is always
"the timestamp of the event that caused this". react-x11 was passing one in
exactly one place — the drag source's publish — and CurrentTime or nothing
everywhere else. ntk 5.4.0 shipped the last two pieces this needed
[sidorares/ntk#172](https://github.com/sidorares/ntk/pull/172), so the whole
set can be threaded through now.

First of the phases in #164.

## The ambient timestamp

`src/inputtime.js` keeps the server time of the last input event, per app —
the trick GTK plays with `gtk_get_current_event_time()`. The copy that needs
the value sits several frames below the keystroke that triggered it, so it is
stashed on the way past rather than threaded through ten signatures.

Motion is deliberately not tracked. Nothing acquires or converts a selection
from a motion event — a drag-select owns PRIMARY on the mouseup that ends it,
a drag publishes on the mousedown that began it — so tracking motion would
add a write per motion event to buy nothing. It is keyed on the app rather
than stored on it, because one process can drive several roots on several
connections and a timestamp only means something against the clock that
issued it.

## What now carries one

| | before | after |
| --- | --- | --- |
| `<textinput>` copy / cut | server-time round trip per copy | the keystroke or click behind it |
| `<textinput>` paste | CurrentTime | same |
| XDND drop conversion | CurrentTime | `XdndDrop`'s `l[2]`, as the protocol requires |
| drag-end release | CurrentTime | the timestamp the selection was acquired with |

The copy row is also a round trip removed: ntk asks the server for a
timestamp whenever it is not given one, and select-to-own PRIMARY copies on
**every selection-extending keystroke**.

The drop row was already decoded and passed to a parameter named `_time` that
could not use it — that is the comment #162 left behind, now resolved.

A caller with no input event yet passes `undefined` rather than `0`, so ntk
still finds a real timestamp for itself. CurrentTime is the thing ICCCM 2.1
forbids, and inventing a number would be worse than asking.

## Two behaviour changes worth calling out

**A failed copy is now reported.** With a real event timestamp, losing the
ownership race to another client becomes possible where the server-time
fallback always won it — it was stamped "whenever the round trip finished",
which is strictly newer than the event. A cut that deleted the text without
acquiring the clipboard should not be silent, so that path warns.

**`_disown()` fixes a real bug, not a style nit.** The old raw
`SetSelectionOwner(0, sel, 0)` released with CurrentTime, so a drag whose
`XdndSelection` had already been taken by another client mid-drag would strip
it back off them on mouseup. `clipboard.clear()` releases with the
acquisition timestamp as ICCCM 2.3.1 requires, and sends nothing at all once
we are no longer the owner.

## Tests

Three new tests and two existing ones extended; 386 pass, up from 383. All
three behaviours were mutation-checked, because the obvious assertion passes
against a plausible-looking wrong implementation in each case:

- Reverting the threaded timestamps fails the textinput test.
- Reverting `_getData` to CurrentTime fails the drop test — asserting that a
  drop converts *successfully* does not prove it converted with the right
  timestamp, so the fake source records the `time` on every SelectionRequest
  ntk answers for it.
- Reverting `_disown()` to the raw call fails the new clobber test. Note the
  other release test — "gives the selection back" — passes against the old
  code, which is exactly why the clobber test exists: releasing the selection
  at all does not prove the release was addressed correctly.

## Also

Corrects three claims in `docs/architecture/drag-and-drop.md` that 5.4.0
falsified: "there is no disown API" in two places, and the Phase 0 item
listing `clear()` as an optional upstream ask. The doc's own convention is to
correct the body rather than annotate it.

Not in this PR, still tracked in #164: the `src/transfer.js` extraction,
`useApp()`/`useClipboard()`, and `watch()`-driven Paste greying.
