### PR TITLE
feat(dnd): scroll a scrollview when a drag rests near its edge

### DIFF
--- a/docs/architecture/drag-and-drop.md
+++ b/docs/architecture/drag-and-drop.md
@@ -806,7 +806,12 @@ and the app-facing API is complete. Phase 3 changes no application code.
 19. A `react-dnd` backend (separate package) over the seam from §5.
 20. Auto-scroll on drag near a `<scrollview>` edge — a default action in the
     router, the same shape as the existing wheel default
-    ([events.js:294](../../src/events.js)).
+    ([events.js:294](../../src/events.js)). _Done._ It hangs off
+    `_overAt`, so both transports get it from one implementation, and the
+    step re-routes rather than re-measuring. The one thing the sketch did
+    not anticipate: the step must **not** answer with an `XdndStatus`. A
+    status is the reply to a position, and the source has sent none — so
+    the fresh answer waits for the next real position instead.
 
 ---
 

--- a/docs/drag-and-drop.md
+++ b/docs/drag-and-drop.md
@@ -205,6 +205,29 @@ exactly the distinction it exists to draw:
 <box {...dropProps} style={[s.zone, isOver && (isAccepted ? s.yes : s.no)]} />
 ```
 
+### Scrolling while dragging
+
+A drag that rests near the top or bottom edge of a `<scrollview>` scrolls
+it, so a drop target below the fold can be reached without letting go.
+Nothing opts in: it applies to any `<scrollview>` a drag passes over,
+from this application or another one.
+
+The viewport it scrolls is the nearest one enclosing the pointer — the
+same one the wheel would scroll, found the same way. `<textarea>` is
+deliberately excluded: nothing can be dropped into one, so scrolling it
+during a drag would only move text out of reach.
+
+Two consequences worth knowing:
+
+- **The content moves under a stationary pointer**, so `onDragEnter`,
+  `onDragLeave` and `onDragOver` keep firing while it scrolls, and
+  `:drag-over` follows. That is the point — the node under the pointer
+  really is changing.
+- **Do not `e.freeze()` a zone inside a scrollview.** Freezing tells the
+  source to stop sending positions, and for a drag from another
+  application those positions are what start the scrolling in the first
+  place.
+
 ### `useDropTarget`
 
 When the _render_ has to change — a hint label, a disabled sibling — the
@@ -442,6 +465,7 @@ that if you need the pattern. See [testing.md](testing.md).
 | drag threshold                     | 4px                                                    |
 | `onDrop` reply watchdog            | 10 s                                                   |
 | wait for the target's confirmation | 5 s                                                    |
+| auto-scroll edge band              | 24px, stepping every 30 ms, up to 14px a step          |
 | XDND protocol version              | 5 (the current one; older sources are negotiated down) |
 | requires                           | ntk ≥ 5.4.0                                            |
 
@@ -455,7 +479,6 @@ Not supported, deliberately or not yet:
   choice of actions is understood — `e.action` reports `'ask'` and the
   request is echoed back — but nothing pops a Copy/Move/Link menu, so
   answer it with a concrete `e.accept('copy')` if you handle it at all.
-- **Auto-scrolling** a `<scrollview>` when a drag hovers near its edge.
 - **`react-dnd`** and other DOM drag libraries — see
   [ecosystem.md](ecosystem.md).
 

--- a/src/dnd.js
+++ b/src/dnd.js
@@ -34,6 +34,13 @@ export const XDND_VERSION = 5;
  * application's drag gesture. */
 const DROP_TIMEOUT = 10_000;
 
+// Edge auto-scroll. How near a viewport's edge the pointer has to be for
+// the drag to start scrolling it, how often a step goes out, and the
+// fastest one step can be.
+const AUTOSCROLL_EDGE = 24;
+const AUTOSCROLL_INTERVAL = 30;
+const AUTOSCROLL_STEP = 14;
+
 const ATOM_NAMES = [
   'XdndAware',
   'XdndSelection',
@@ -244,6 +251,56 @@ function decodeData(data, target) {
   return data.toString(target === 'STRING' ? 'latin1' : 'utf8');
 }
 
+/**
+ * The viewport a drag over `path` scrolls: the nearest enclosing one,
+ * found by walking out from the hit node the same way the wheel's default
+ * action does ([events.js](./events.js)). Stopping at the first rather
+ * than chaining to an outer viewport is that default's behaviour too, so
+ * the two gestures agree about which viewport a point belongs to.
+ *
+ * `<textarea>` scrolls under the wheel but not under a drag: nothing can
+ * be dropped into one, so scrolling it would move text the drag cannot
+ * reach.
+ */
+function scrollerIn(path) {
+  for (let i = path.length - 1; i >= 0; i--) {
+    if (path[i].kind === 'scrollview') return path[i];
+  }
+  return null;
+}
+
+/**
+ * Pixels to scroll per step for a pointer at `x, y` over `rect`, or null
+ * when it is not near enough to an edge to scroll at all.
+ *
+ * The rate ramps with depth into the band rather than being constant: a
+ * drag crossing a long list crawls at a constant slow rate, and one
+ * nudging the next row into view overshoots at a constant fast one. Each
+ * axis takes the nearer of its two edges, so a viewport shorter than two
+ * bands still scrolls one way rather than fighting itself.
+ */
+function edgeVelocity(rect, x, y) {
+  const inside =
+    x >= rect.x &&
+    x <= rect.x + rect.width &&
+    y >= rect.y &&
+    y <= rect.y + rect.height;
+  if (!inside) return null;
+  const ramp = (distance) =>
+    distance >= AUTOSCROLL_EDGE
+      ? 0
+      : Math.ceil(
+          (1 - Math.max(0, distance) / AUTOSCROLL_EDGE) * AUTOSCROLL_STEP,
+        );
+  const top = y - rect.y;
+  const bottom = rect.y + rect.height - y;
+  const left = x - rect.x;
+  const right = rect.x + rect.width - x;
+  const dy = top < bottom ? -ramp(top) : ramp(bottom);
+  const dx = left < right ? -ramp(left) : ramp(right);
+  return dx === 0 && dy === 0 ? null : { dx, dy };
+}
+
 // ---------------------------------------------------------------------------
 // The per-top-level session.
 // ---------------------------------------------------------------------------
@@ -267,6 +324,7 @@ export class DropSession {
   }
 
   _reset() {
+    this._stopAutoScroll();
     this.sourceWid = 0;
     this.version = 0;
     this.types = [];
@@ -400,6 +458,7 @@ export class DropSession {
     }
     this.accepted = accepted;
     this.lastPoint = { windowNode, x, y, rootX, rootY, time };
+    this._updateAutoScroll(path, x, y);
 
     const answer = {
       accept: Boolean(accepted),
@@ -672,6 +731,71 @@ export class DropSession {
     }
   }
 
+  // -- edge auto-scroll ----------------------------------------------------
+  //
+  // A drop target below the fold is otherwise unreachable: the pointer is
+  // already at the bottom of the list, and a source that sees no motion
+  // sends no more positions. So the timer, not the next position, is what
+  // advances the drag — which is also why the suppression rectangle
+  // (`e.freeze()`) is opt-in and off by default.
+
+  /**
+   * Aim the auto-scroll at whatever the pointer is over now, or stop it.
+   * Called from every position update, so the velocity tracks the pointer
+   * without the timer having to re-measure anything.
+   */
+  _updateAutoScroll(path, x, y) {
+    const node = scrollerIn(path);
+    const velocity = node?.abs ? edgeVelocity(node.abs, x, y) : null;
+    if (!velocity) return this._stopAutoScroll();
+    this._autoScroll = { node, ...velocity };
+    // already stepping: the line above is the whole update
+    if (this._autoScrollTimer) return;
+    this._autoScrollTimer = setInterval(
+      () => this._autoScrollStep(),
+      AUTOSCROLL_INTERVAL,
+    );
+    // a drag must never be the reason a process cannot exit
+    this._autoScrollTimer.unref?.();
+  }
+
+  _stopAutoScroll() {
+    if (this._autoScrollTimer) clearInterval(this._autoScrollTimer);
+    this._autoScrollTimer = null;
+    this._autoScroll = null;
+  }
+
+  /**
+   * One step. Re-routing after it is the point of the whole feature: the
+   * content moved under a stationary pointer, so which node is hovered —
+   * and whether it accepts — can differ from one step to the next.
+   *
+   * Nothing is sent to the source. An `XdndStatus` is the answer to an
+   * `XdndPosition`, and an unsolicited one is not in the protocol; the next
+   * real position carries the fresh answer instead.
+   */
+  _autoScrollStep() {
+    const state = this._autoScroll;
+    const point = this.lastPoint;
+    if (!state || !point || state.node.destroyed) return this._stopAutoScroll();
+    const { node, dx, dy } = state;
+    // Nothing may escape a timer callback: there is no caller to catch it,
+    // so a throw here would take the process down rather than end a drag.
+    // The tree can be torn down between steps — a handler on the way past
+    // is free to unmount whatever this was scrolling.
+    try {
+      const before = `${node.scrollX},${node.scrollY}`;
+      node.scrollBy({ x: dx, y: dy });
+      // at the limit: no movement, so nothing under the pointer changed and
+      // there is nothing to re-route. The timer stays armed — the content
+      // can still grow, and the pointer is still in the band.
+      if (`${node.scrollX},${node.scrollY}` === before) return;
+      this._overAt(point.rootX, point.rootY, point.time);
+    } catch {
+      this._stopAutoScroll();
+    }
+  }
+
   /** Enter/leave diffing over the drag path — the hover algorithm, with
    * `:drag-over` in place of `:hover`. Non-bubbling, like the DOM's. */
   _updateDragPath(newPath, native) {
@@ -713,6 +837,8 @@ export class DropSession {
   }
 
   _clearPath() {
+    // every way a drag ends — leave, drop, reset — comes through here
+    this._stopAutoScroll();
     const native = this.lastPoint
       ? {
           x: this.lastPoint.x,

--- a/test/dnd-source.test.js
+++ b/test/dnd-source.test.js
@@ -265,6 +265,118 @@ test('preventDefault in onDragStart cancels: the gesture stays a click', async (
   await x11Root.unmount();
 });
 
+// --- edge auto-scroll -------------------------------------------------------
+//
+// Driven from the in-app transport because the mechanism is transport
+// agnostic: both halves route through DropSession._overAt, and the timer is
+// what advances a drag whose pointer has stopped moving.
+
+/** Render a draggable row above a short scrollview of drop targets, and
+ * hand back the pieces a test needs to poke at. */
+async function renderScrollList(app) {
+  const rows = Array.from({ length: 40 }, (_, i) =>
+    h('box', {
+      key: i,
+      dropAccept: ['text'],
+      onDrop: () => {},
+      style: { height: 20 },
+    }),
+  );
+  const x11Root = await renderMock(
+    app,
+    h(
+      'window',
+      { width: 200, height: 200 },
+      h('box', {
+        draggable: true,
+        dragData: { 'text/plain': 'row' },
+        style: { height: 20 },
+      }),
+      h('scrollview', { style: { height: 100 } }, ...rows),
+    ),
+  );
+  const wnd = app.windows[0];
+  const windowNode = wnd._reactX11Node;
+  const scroller = windowNode.children.find((n) => n.kind === 'scrollview');
+  return { x11Root, wnd, windowNode, scroller };
+}
+
+/** Wait for `predicate`, letting real timers run — the auto-scroll interval
+ * is what is under test, so it is not mocked away. */
+async function waitFor(predicate, what, ms = 1000) {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.fail(`timed out waiting for ${what}`);
+}
+
+test('a drag resting near a scrollview edge scrolls it, and stops when it leaves', async () => {
+  const app = createMockApp();
+  const { x11Root, wnd, scroller } = await renderScrollList(app);
+  assert.equal(scroller.scrollY, 0, 'starts unscrolled');
+  assert.ok(scroller.contentHeight > scroller.abs.height, 'content overflows');
+
+  // start the drag on the row above the list, then park the pointer just
+  // inside the viewport's bottom edge and stop moving
+  down(wnd, 10, 10);
+  move(wnd, 16, 10); // past the 4px threshold
+  move(wnd, 100, 115); // viewport is y 20..120, so this is in the band
+  await waitFor(() => scroller.scrollY > 0, 'the list to scroll down');
+
+  // out of the band: the same stillness now scrolls nothing
+  move(wnd, 100, 70);
+  await new Promise((resolve) => setTimeout(resolve, 60));
+  const parked = scroller.scrollY;
+  await new Promise((resolve) => setTimeout(resolve, 90));
+  assert.equal(scroller.scrollY, parked, 'no drift once out of the band');
+
+  // and the top edge scrolls the other way
+  move(wnd, 100, 26);
+  await waitFor(() => scroller.scrollY < parked, 'the list to scroll back up');
+
+  up(wnd, 100, 26);
+  await tick();
+  await x11Root.unmount();
+});
+
+test('auto-scroll stops at the end of the drag, and holds no timer open', async () => {
+  const app = createMockApp();
+  const { x11Root, wnd, windowNode, scroller } = await renderScrollList(app);
+  down(wnd, 10, 10);
+  move(wnd, 16, 10);
+  move(wnd, 100, 115);
+  await waitFor(() => scroller.scrollY > 0, 'the list to scroll');
+  assert.ok(windowNode._dnd._autoScrollTimer, 'stepping while the drag is on');
+
+  up(wnd, 100, 115);
+  await tick();
+  assert.equal(
+    windowNode._dnd._autoScrollTimer,
+    null,
+    'the drop cleared the timer',
+  );
+  const settled = scroller.scrollY;
+  await new Promise((resolve) => setTimeout(resolve, 90));
+  assert.equal(scroller.scrollY, settled, 'and nothing scrolls after the drop');
+  await x11Root.unmount();
+});
+
+test('a drag in the middle of a scrollview does not scroll it', async () => {
+  const app = createMockApp();
+  const { x11Root, wnd, windowNode, scroller } = await renderScrollList(app);
+  down(wnd, 10, 10);
+  move(wnd, 16, 10);
+  move(wnd, 100, 70); // dead centre of a 100px viewport
+  await new Promise((resolve) => setTimeout(resolve, 120));
+  assert.equal(scroller.scrollY, 0, 'still at the top');
+  assert.equal(windowNode._dnd._autoScrollTimer, null, 'no timer armed');
+  up(wnd, 100, 70);
+  await tick();
+  await x11Root.unmount();
+});
+
 // --- the external transport (XDND out) --------------------------------------
 
 const SCREEN = { width: 800, height: 600 };

--- a/test/dnd.test.js
+++ b/test/dnd.test.js
@@ -258,6 +258,73 @@ test('top-level windows advertise XdndAware = 5; child windows do not', async ()
   }
 });
 
+test('a foreign drag resting near a scrollview edge scrolls it, silently', async () => {
+  // The timer scrolls and re-routes, but sends nothing: an XdndStatus is the
+  // answer to an XdndPosition, and an unsolicited one is not in the
+  // protocol. The source hears the new answer on its next real position.
+  const { app, srcApp } = await headlessPair();
+  const x11Root = await createRoot({ app });
+  try {
+    const rows = Array.from({ length: 40 }, (_, i) =>
+      React.createElement('box', {
+        key: i,
+        dropAccept: ['files'],
+        onDrop: () => {},
+        style: { height: 20 },
+      }),
+    );
+    const instance = await render(
+      React.createElement(
+        'window',
+        { width: 300, height: 200 },
+        React.createElement('scrollview', { style: { height: 100 } }, ...rows),
+      ),
+      x11Root,
+    );
+    const scroller = instance._reactX11Node.children.find(
+      (n) => n.kind === 'scrollview',
+    );
+    const src = new FakeSource(srcApp);
+    await src.init({ 'text/uri-list': 'file:///tmp/x\r\n' });
+    await settle(app);
+    await settle(app);
+    assert.ok(
+      scroller.contentHeight > scroller.abs.height,
+      'content overflows',
+    );
+
+    await src.enter(instance.id, ['text/uri-list']);
+    // one position, parked inside the viewport's bottom edge band
+    src.position(instance.id, 150, 95);
+    await until(
+      srcApp,
+      () => src.statuses().length > 0,
+      'the first XdndStatus',
+    );
+
+    for (let i = 0; i < 200 && scroller.scrollY === 0; i++) {
+      await settle(app);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    assert.ok(scroller.scrollY > 0, 'the list scrolled with no further motion');
+    assert.equal(
+      src.statuses().length,
+      1,
+      'still exactly one status: one position was sent, one was answered',
+    );
+
+    src.leave(instance.id);
+    await settle(app);
+    const stopped = scroller.scrollY;
+    await new Promise((resolve) => setTimeout(resolve, 90));
+    assert.equal(scroller.scrollY, stopped, 'the leave stopped the scrolling');
+    await x11Root.unmount();
+  } finally {
+    await app.close();
+    await srcApp.close();
+  }
+});
+
 test('zero drop targets: one refusal with a whole-window suppression rect', async () => {
   const { app, srcApp } = await headlessPair();
   const x11Root = await createRoot({ app });


### PR DESCRIPTION
Item 20 of [#126](https://github.com/sidorares/react-x11/issues/126)'s Phase 4.

A drop target below the fold was unreachable. The pointer is already at the
bottom of the list, and a source that sees no motion sends no more
positions — so nothing advanced the drag. The timer, not the next position,
is what moves it now.

```jsx
// nothing opts in; this list scrolls when a drag rests near its edge
<scrollview style={{ height: 200 }}>
  {rows.map((r) => (
    <box key={r.id} dropAccept={['text']} onDrop={...} />
  ))}
</scrollview>
```

## How it fits

It hangs off `DropSession._overAt`, which both transports already funnel
through, so a drag from this application and one from another get the same
behaviour from one implementation. The viewport it scrolls is the nearest one
enclosing the pointer — the same one the wheel would scroll, found by the same
walk out from the hit node.

Three decisions worth reviewing:

- **The rate ramps with depth into the 24px band** rather than being constant.
  A constant slow rate makes crossing a long list crawl; a constant fast one
  overshoots when you are nudging the next row into view. Each axis takes the
  nearer of its two edges, so a viewport shorter than two bands still scrolls
  one way rather than fighting itself.
- **`<textarea>` is excluded**, though it scrolls under the wheel. Nothing can
  be dropped into one, so scrolling it during a drag would only move text the
  drag cannot reach. Easy to add later if that changes.
- **The step sends no `XdndStatus`** — the one thing the architecture doc's
  sketch did not anticipate. A status is the reply to a position and the
  source has sent none, so an unsolicited one is out of protocol; the fresh
  answer waits for the next real position. The step *does* re-route, because
  content moving under a stationary pointer changes which node is hovered, so
  enter/leave and `:drag-over` keep up.

## Tests

Four, 391 pass. Three drive the in-app gesture over the mock app — scrolls at
the edge, stops when the pointer leaves the band, never starts in the middle,
and the timer is gone after the drop. The fourth is hermetic against the fake
XDND source, and its real assertion is the protocol one: after a single
`XdndPosition` parked in the band, the list scrolls with no further motion and
**exactly one** `XdndStatus` has gone out.

All four were mutation-checked — dropping the `_updateAutoScroll` call fails
three of them, and dropping the `_stopAutoScroll` teardown fails the fourth.

## Notes

- A window with **no** drop targets never auto-scrolls a foreign drag: the
  zero-target suppression fast path answers before `_overAt` runs. That is the
  right answer (nothing to reach by scrolling) and it costs nothing.
- Nothing escapes the timer callback. There is no caller to catch a throw
  there, and a handler on the way past is free to unmount whatever was being
  scrolled.

Docs: a "Scrolling while dragging" section in the reference page, the band and
step sizes in its defaults table, the "not supported" bullet removed, and the
Phase 4 checklist item in the architecture doc marked done with the
`XdndStatus` caveat recorded.

Phase 4 after this: the `XdndActionAsk` menu, and the `react-dnd` backend.
