### PR TITLE
feat(dnd): hand a drop the choices an asking source is offering

### DIFF
--- a/docs/architecture/drag-and-drop.md
+++ b/docs/architecture/drag-and-drop.md
@@ -802,7 +802,15 @@ and the app-facing API is complete. Phase 3 changes no application code.
 ### Phase 4 — ecosystem and polish
 
 18. `XdndActionAsk` → `ContextMenu` from `XdndActionList` /
-    `XdndActionDescription`.
+    `XdndActionDescription`. _Done, but not as sketched._ The two
+    properties are read and handed to the app as `e.actions` /
+    `e.actionDescriptions`, and `onDrop` settles the answer with
+    `e.accept(action)`; the menu itself stays in application code. A
+    built-in one would have to hold `XdndFinished` open for as long as it
+    was on screen, and §9's first hazard is that a slow drop freezes the
+    source application — so how long to make someone wait is the app's
+    call, not the toolkit's. Reading the properties lazily, only when a
+    position actually asks, keeps the two round trips off every other drag.
 19. A `react-dnd` backend (separate package) over the seam from §5.
 20. Auto-scroll on drag near a `<scrollview>` edge — a default action in the
     router, the same shape as the existing wheel default

--- a/docs/drag-and-drop.md
+++ b/docs/drag-and-drop.md
@@ -123,11 +123,15 @@ Every drag event carries:
 | `types`                    | `string[]` — the offered payload type names                                    |
 | `has(type)`                | group-aware membership test: `e.has('files')`                                  |
 | `action`                   | `'copy' \| 'move' \| 'link' \| 'ask' \| 'private'` — what the source asked for |
+| `actions`                  | the choices an `'ask'` source will accept; empty otherwise                     |
+| `actionDescriptions`       | its own words for them, positionally matched, `null` where it gave none        |
 | `source`                   | `'internal'` (this app) or `'external'` (another application)                  |
 | `screenX` / `screenY`      | pointer position in root coordinates                                           |
 | `x`/`y`, `localX`/`localY` | window and target-relative coordinates, as on any event                        |
 
-plus, in `onDragOver` only, three ways to answer:
+plus three ways to answer. `e.freeze()` is `onDragOver` only; `e.accept()`
+and `e.reject()` also work in `onDrop`, where they settle what the drop did
+rather than whether it would be taken (see [The drop](#the-drop)):
 
 - `e.accept(action?)` — take the drop, optionally forcing the action
   (`e.accept('move')`);
@@ -185,6 +189,51 @@ There is deliberately **no `e.dataTransfer`**. X selection transfer is
 asynchronous and the DOM's `getData()` is synchronous; a lookalike
 returning a promise would stringify to `"[object Promise]"` in template
 literals with no error anywhere. The different name is the warning.
+
+`onDrop` can also settle what the drop _did_, which is what the source is
+told afterwards:
+
+- **`e.accept('move')`** — report a different action from the one that was
+  negotiated while hovering. This is how a source that asks gets its
+  answer.
+- **`e.reject()`** — having looked at the payload, refuse it after all.
+  The source is told the drop was not taken, so a "move" leaves the
+  original where it was.
+
+Both may be called late from an `async` handler: for a drag from another
+application the reply is not sent until the handler settles, so a menu can
+decide it. In-app drags do not wait, so only a synchronous answer reaches
+`onDragEnd`.
+
+### Sources that ask
+
+A file manager dragging between two filesystems often does not know
+whether you meant copy or move, so it asks: `e.action` is `'ask'`, and the
+choices it will accept come with the event.
+
+```jsx
+onDrop={async (e) => {
+  if (e.action !== 'ask') return void save(e.files, e.action);
+  // e.actions            -> ['copy', 'move', 'link']
+  // e.actionDescriptions -> ['Copy here', 'Move here', null]
+  const chosen = await myMenu(e.actions, e.actionDescriptions);
+  if (!chosen) return void e.reject();
+  save(e.files, chosen);
+  e.accept(chosen);
+}}
+```
+
+`actionDescriptions` is positional and the source's own wording — a `null`
+means it offered that action without describing it, so use your own label.
+Both arrays are empty for every other kind of drag, so they can be read
+without guarding, and nothing is read off the source's window unless a
+position actually asks.
+
+The menu is yours to draw. A built-in one would have to hold the protocol
+reply open for as long as it stayed up, and that reply is the only thing
+keeping the other application's drag cursor from freezing — so the choice
+of how long to make someone wait belongs to the app, not the toolkit.
+`ContextMenu` is the obvious thing to build it from.
 
 ### `:drag-over`
 
@@ -475,10 +524,10 @@ Not supported, deliberately or not yet:
   AWT applications speak only that and will not interoperate.
 - **XdndDirectSave (XDS)** — "drag out of the app to save a file into the
   file manager". A separate protocol layered on XDND.
-- **A menu for `XdndActionAsk`.** A source asking the target to offer a
-  choice of actions is understood — `e.action` reports `'ask'` and the
-  request is echoed back — but nothing pops a Copy/Move/Link menu, so
-  answer it with a concrete `e.accept('copy')` if you handle it at all.
+- **A built-in menu for `XdndActionAsk`.** The choices are handed to you —
+  see [Sources that ask](#sources-that-ask) — but the menu itself is yours
+  to draw. A built-in one would have to hold the reply while it was open,
+  and the reply is what keeps another application's drag from freezing.
 - **`react-dnd`** and other DOM drag libraries — see
   [ecosystem.md](ecosystem.md).
 

--- a/src/dnd.js
+++ b/src/dnd.js
@@ -57,6 +57,9 @@ const ATOM_NAMES = [
   'XdndActionLink',
   'XdndActionAsk',
   'XdndActionPrivate',
+  // read off the source's window when it asks the target to choose
+  'XdndActionList',
+  'XdndActionDescription',
 ];
 
 // per-connection atom table: X -> { atoms|null, promise, names: Map }
@@ -329,6 +332,8 @@ export class DropSession {
     this.version = 0;
     this.types = [];
     this.path = [];
+    // what an `ask` source offered, read once per drag (see _readAskOffer)
+    this._askOffer = null;
     this.accepted = null;
     this.acceptedAction = 'copy';
     this.requestedAction = 'copy';
@@ -406,7 +411,60 @@ export class DropSession {
     });
   }
 
-  _onPosition(ev, atoms) {
+  /**
+   * What a source offering `ask` is offering, read from its window: the
+   * actions as `XdndActionList` (type ATOM) and, beside it, the source's
+   * own words for them as `XdndActionDescription` — a run of NUL-separated
+   * strings, one per action, positionally matched.
+   *
+   * Read once per drag, and only when a position actually asks, because
+   * the two round trips buy nothing for the copy/move/link sources that
+   * are the overwhelming majority.
+   */
+  async _readAskOffer(sourceWid) {
+    if (this._askOffer) return this._askOffer;
+    const dnd = dndAtomsOf(this.X);
+    const [list, describedBytes] = await Promise.all([
+      this._readAtomList(sourceWid, dnd.XdndActionList),
+      this._readBytes(sourceWid, dnd.XdndActionDescription),
+    ]);
+    const actions = (await Promise.all(list.map((a) => atomName(this.X, a))))
+      .map((name) => ACTION_NAMES[name])
+      .filter(Boolean);
+    // trailing NUL is conventional, so drop the empty tail it leaves
+    const described = describedBytes.toString('utf8').split('\0');
+    if (described.at(-1) === '') described.pop();
+    this._askOffer = {
+      actions,
+      // positional: a source that describes none, or describes fewer than
+      // it offers, leaves the rest to us to name
+      descriptions: actions.map((name, i) => described[i] ?? null),
+    };
+    return this._askOffer;
+  }
+
+  _readAtomList(wid, atom) {
+    return new Promise((resolve) => {
+      this.X.GetProperty(0, wid, atom, 0, 0, 0x1000, (err, prop) => {
+        if (err || !prop?.data?.length) return resolve([]);
+        const atoms = [];
+        for (let o = 0; o + 4 <= prop.data.length; o += 4) {
+          atoms.push(prop.data.readUInt32LE(o));
+        }
+        resolve(atoms);
+      });
+    });
+  }
+
+  _readBytes(wid, atom) {
+    return new Promise((resolve) => {
+      this.X.GetProperty(0, wid, atom, 0, 0, 0x1000, (err, prop) =>
+        resolve(err || !prop?.data ? Buffer.alloc(0) : prop.data),
+      );
+    });
+  }
+
+  async _onPosition(ev, atoms) {
     if (ev.data[0] >>> 0 !== this.sourceWid) return;
     const packed = ev.data[2] >>> 0;
     const rootX = packed >>> 16;
@@ -421,6 +479,15 @@ export class DropSession {
     if (this.node._dndTargetCount() === 0) {
       this._sendStatus(atoms, { accept: false, rect: this._windowRect() });
       return;
+    }
+
+    // `ask` means the source wants the user asked which action to perform,
+    // so the choices have to be in hand before a handler is called. Only
+    // this branch pays for them, and only once per drag.
+    if (this.requestedAction === 'ask' && !this._askOffer) {
+      await this._readAskOffer(this.sourceWid);
+      // a leave or a new drag may have overtaken the round trips
+      if (ev.data[0] >>> 0 !== this.sourceWid) return;
     }
 
     const answer = this._overAt(rootX, rootY, time);
@@ -519,6 +586,12 @@ export class DropSession {
       this.localLeave();
       return { handled: false, action: null };
     }
+    // the same outcome object the wire transport uses, so `e.accept('move')`
+    // in a drop handler means one thing across both. In-app handlers are
+    // dispatched synchronously and not awaited, so only a synchronous
+    // answer reaches `onDragEnd` — an async one is too late, exactly as it
+    // is for the rest of the in-app drop path.
+    const outcome = { accept: true, action, freeze: false };
     discrete(() => {
       runWithPriority(DiscreteEventPriority, () => {
         const targetNode = this._dropTarget(point) ?? accepted;
@@ -534,7 +607,7 @@ export class DropSession {
             buttons: 0,
           },
           targetNode,
-          null,
+          outcome,
         );
         Object.assign(drop, extras);
         this._dispatchDrop(point.windowNode, targetNode, drop, []);
@@ -544,7 +617,10 @@ export class DropSession {
     this.accepted = null;
     this.lastPoint = null;
     this._source = 'external';
-    return { handled: true, action };
+    return {
+      handled: outcome.accept,
+      action: outcome.accept ? outcome.action : null,
+    };
   }
 
   _onLeave(ev) {
@@ -591,6 +667,13 @@ export class DropSession {
     }
 
     const pending = [];
+    // What the handler settles on. `accept`/`reject` mean something
+    // different at drop time than during a hover — "I took it, doing this"
+    // rather than "I would take it" — and this is what XdndFinished
+    // reports. An `ask` source is the reason it can be changed at all: the
+    // point of asking is that the answer is not known until now, and a
+    // handler that puts a menu up settles it later still.
+    const outcome = { accept: true, action, freeze: false };
     discrete(() => {
       runWithPriority(DiscreteEventPriority, () => {
         const targetNode = this._dropTarget(point) ?? accepted;
@@ -606,7 +689,7 @@ export class DropSession {
             buttons: 0,
           },
           targetNode,
-          null,
+          outcome,
         );
         drop.files = files;
         drop.text = text;
@@ -625,7 +708,12 @@ export class DropSession {
       if (finished) return;
       finished = true;
       clearTimeout(timer);
-      this._sendFinished(atoms, sourceWid, version, { accepted: true, action });
+      // read now, not captured: an async handler settles the outcome
+      // between the dispatch above and this call
+      this._sendFinished(atoms, sourceWid, version, {
+        accepted: outcome.accept,
+        action: outcome.action,
+      });
       // only clear session state if no new drag has entered meanwhile
       if (this.sourceWid === sourceWid) this._reset();
     };
@@ -663,6 +751,11 @@ export class DropSession {
       types,
       has: (want) => typeMatches(types, want),
       action: this.requestedAction,
+      // Only an `ask` source fills these: the actions it will accept, and
+      // its own words for them, positionally matched (null where it gave
+      // none). Empty otherwise, so a handler can read them unguarded.
+      actions: this._askOffer?.actions ?? [],
+      actionDescriptions: this._askOffer?.descriptions ?? [],
       source: this._source,
       screenX: native.rootx,
       screenY: native.rooty,

--- a/src/types/events.d.ts
+++ b/src/types/events.d.ts
@@ -96,15 +96,25 @@ export interface DragEvent<T = DrawnNode> extends SyntheticEvent<T> {
   types: string[];
   /** Alias-aware membership test: a concrete type or a semantic group. */
   has(type: string): boolean;
-  /** The action the source asked for. */
+  /** The action the source asked for. `'ask'` means it wants the user
+   * offered a choice — see `actions`. */
   action: DropAction;
+  /** The actions an `'ask'` source will accept, in the order it listed
+   * them. Empty for every other action, which is all but a few file
+   * managers. */
+  actions: Array<'copy' | 'move' | 'link'>;
+  /** The source's own words for `actions`, positionally matched, with
+   * `null` where it offered none. Empty when `actions` is. */
+  actionDescriptions: Array<string | null>;
   /** Where the drag came from: another application, or this one. */
   source: 'internal' | 'external';
   /** Pointer position in screen (root) coordinates. */
   screenX: number;
   screenY: number;
   /** Override the declarative `dropAccept` answer for this position
-   * (`onDragOver` only; elsewhere these are inert). */
+   * (`onDragOver`), or settle what the drop actually did (`onDrop`, where
+   * `accept` picks the action reported to the source and `reject` tells it
+   * the drop was not taken after all). Inert elsewhere. */
   accept(action?: 'copy' | 'move' | 'link'): void;
   reject(): void;
   /** Opt into the XdndStatus suppression rectangle for this node's rect:

--- a/test/dnd.test.js
+++ b/test/dnd.test.js
@@ -80,6 +80,8 @@ class FakeSource {
       'XdndTypeList',
       'XdndActionCopy',
       'XdndActionMove',
+      'XdndActionLink',
+      'XdndActionAsk',
     ];
     this.atoms = {};
     await Promise.all(
@@ -97,6 +99,26 @@ class FakeSource {
     if (payload) {
       await this.app.clipboard.write(payload, { selection: 'XdndSelection' });
     }
+  }
+
+  /** What a source that asks publishes on its own window: the actions it
+   * will accept, and its own words for them, NUL-separated. */
+  async offerAsk(actions, descriptions) {
+    await this.wnd.setProperty(
+      'XdndActionList',
+      actions.map((a) => this.atoms[a]),
+      { type: 'ATOM' },
+    );
+    const prop = await this.typeAtom('XdndActionDescription');
+    const text = descriptions.length ? `${descriptions.join('\0')}\0` : '';
+    this.X.ChangeProperty(
+      0,
+      this.wnd.id,
+      prop,
+      this.X.atoms.STRING,
+      8,
+      Buffer.from(text, 'utf8'),
+    );
   }
 
   async typeAtom(name) {
@@ -509,6 +531,110 @@ test('drop: uri-list arrives parsed, XdndFinished confirms with the action', asy
       [...new Set(converted.map((c) => c.time))],
       [43],
       "every conversion used XdndDrop's timestamp",
+    );
+    await x11Root.unmount();
+  } finally {
+    await app.close();
+    await srcApp.close();
+  }
+});
+
+test('a source that asks: the choices reach the handler, and its answer reaches XdndFinished', async () => {
+  const { app, srcApp } = await headlessPair();
+  const x11Root = await createRoot({ app });
+  try {
+    const drops = [];
+    const instance = await render(
+      React.createElement(
+        'window',
+        { width: 300, height: 200 },
+        React.createElement('box', {
+          dropAccept: ['files'],
+          onDrop: (e) => {
+            drops.push({
+              action: e.action,
+              actions: e.actions,
+              descriptions: e.actionDescriptions,
+            });
+            // what a menu built from those choices would come back with
+            e.accept('move');
+          },
+          style: { flexGrow: 1 },
+        }),
+      ),
+      x11Root,
+    );
+    const src = new FakeSource(srcApp);
+    await src.init({ 'text/uri-list': 'file:///tmp/x\r\n' });
+    // Link is offered but left undescribed, so the gap is positional
+    await src.offerAsk(
+      ['XdndActionCopy', 'XdndActionMove', 'XdndActionLink'],
+      ['Copy here', 'Move here'],
+    );
+    await settle(app);
+
+    await src.enter(instance.id, ['text/uri-list']);
+    src.position(instance.id, 150, 100, { action: 'XdndActionAsk' });
+    await until(srcApp, () => src.statuses().length > 0, 'an XdndStatus');
+
+    src.drop(instance.id);
+    await until(srcApp, () => src.finished().length > 0, 'XdndFinished');
+
+    assert.equal(drops.length, 1);
+    assert.equal(drops[0].action, 'ask', 'the source asked');
+    assert.deepEqual(drops[0].actions, ['copy', 'move', 'link']);
+    assert.deepEqual(drops[0].descriptions, ['Copy here', 'Move here', null]);
+
+    const fin = src.finished()[0].data;
+    assert.equal(fin[1] & 1, 1, 'accepted');
+    assert.equal(
+      fin[2],
+      src.atoms.XdndActionMove,
+      "the handler's choice is what the source is told",
+    );
+    await x11Root.unmount();
+  } finally {
+    await app.close();
+    await srcApp.close();
+  }
+});
+
+test('a drop handler can refuse at the last moment, and a plain drag asks for nothing', async () => {
+  const { app, srcApp } = await headlessPair();
+  const x11Root = await createRoot({ app });
+  try {
+    let seen = null;
+    const instance = await render(
+      React.createElement(
+        'window',
+        { width: 300, height: 200 },
+        React.createElement('box', {
+          dropAccept: ['files'],
+          onDrop: (e) => {
+            seen = { actions: e.actions, descriptions: e.actionDescriptions };
+            e.reject(); // decided against it after looking at the payload
+          },
+          style: { flexGrow: 1 },
+        }),
+      ),
+      x11Root,
+    );
+    const src = new FakeSource(srcApp);
+    await src.init({ 'text/uri-list': 'file:///tmp/x\r\n' });
+    await settle(app);
+
+    await src.enter(instance.id, ['text/uri-list']);
+    src.position(instance.id, 150, 100); // a plain copy, no asking
+    await until(srcApp, () => src.statuses().length > 0, 'an XdndStatus');
+    src.drop(instance.id);
+    await until(srcApp, () => src.finished().length > 0, 'XdndFinished');
+
+    // nothing was asked, so nothing was read off the source window
+    assert.deepEqual(seen, { actions: [], descriptions: [] });
+    assert.equal(
+      src.finished()[0].data[1] & 1,
+      0,
+      'the refusal reaches the source',
     );
     await x11Root.unmount();
   } finally {


### PR DESCRIPTION
Item 18 of [#126](https://github.com/sidorares/react-x11/issues/126)'s Phase 4
— though **not in the shape the checklist sketched**, and the difference is
the part worth reviewing.

A file manager dragging between two filesystems does not know whether you
meant copy or move, so it asks: `XdndActionAsk`, with the actions it will
accept published on its own window as `XdndActionList`, and its own words for
them as `XdndActionDescription`. react-x11 spoke the atom but read neither
property, so a handler had nothing to offer anyone and no way to answer.

```jsx
onDrop={async (e) => {
  if (e.action !== 'ask') return void save(e.files, e.action);
  // e.actions            -> ['copy', 'move', 'link']
  // e.actionDescriptions -> ['Copy here', 'Move here', null]
  const chosen = await myMenu(e.actions, e.actionDescriptions);
  if (!chosen) return void e.reject();
  save(e.files, chosen);
  e.accept(chosen);
}}
```

## Why the menu is not built in

The checklist said `XdndActionAsk` → a `ContextMenu` built from those two
properties. Building it would mean holding `XdndFinished` open for as long as
the menu stayed on screen — and the architecture doc's **first** listed hazard
is that a slow drop freezes the source application. The menu is exactly a
"slow drop": it waits for a human.

So the toolkit reads the properties, hands over the choices, and lets the app
decide how long to make someone wait. That is a decision to overturn if you
disagree — the plumbing is the same either way, and a built-in menu could be
added on top without changing this API. The rationale is recorded next to the
checklist item in the architecture doc, and the reference page points at
`ContextMenu` for building one.

## Answering

`onDrop` now honours the two answers it previously ignored:

- **`e.accept('move')`** — picks what `XdndFinished` reports.
- **`e.reject()`** — tells the source the drop was not taken after all, so a
  `move` source leaves its original where it was.

The outcome is read when the reply goes out rather than captured before the
dispatch, so an `async` handler that puts a menu up settles it late and still
in time. In-app drops are not awaited (unchanged), so only a synchronous
answer reaches `onDragEnd` there.

## Costs

Nothing is read off the source's window unless a position actually asks, and
then once per drag — so the two round trips stay off the copy/move/link drags
that are almost all of them. Both arrays are empty rather than absent
otherwise, so handlers can read them unguarded.

## Tests

Two hermetic tests over the fake XDND source, 389 pass. The first offers three
actions but describes only two, pinning that the descriptions are positional
and the gap is `null` rather than a shifted label; it then answers with
`e.accept('move')` and asserts the *source* is told `XdndActionMove`. The
second is a plain non-asking drag that reads nothing off the source window and
refuses at the last moment.

Both were mutation-checked: ignoring the outcome object fails both, and
withholding the choices fails the first.

## Notes

- Split off [#169](https://github.com/sidorares/react-x11/pull/169) (auto-scroll,
  the other Phase 4 item) so the two review independently. #169 has since
  merged and this branch is **rebased on top of it** — the two touched
  `_reset` and the same docs list, both resolved, and the auto-scroll and ask
  tests now run together.
- Phase 4 after this: the `react-dnd` backend, which is a packaging decision
  as much as a code one — there is a working spike but it adds a dependency
  and the design doc calls for a separate package.
