### PR TITLE
feat(clipboard): useClipboard(), over the vocabulary drag and drop already had

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,10 @@
   (`e.files`, `e.getData`, live `e.items`), `dragData` and lazy payloads,
   the `useDropTarget`/`useDragSource` hooks, drag previews, what GTK and
   Firefox actually offer, and how to drive a drag in a test.
+- [clipboard.md](clipboard.md) — copy and paste beyond the built-in text
+  controls: `useClipboard()`, the CLIPBOARD/PRIMARY split, offering several
+  flavours of one payload, the `text`/`files`/`uris` groups shared with drag
+  and drop, `watch()`, and why a copy carries a timestamp.
 - [typescript.md](typescript.md) — the bundled types: one tsconfig option,
   why JSX comes from `react-x11/jsx-runtime` rather than an augmentation,
   and how the declarations are kept from drifting.

--- a/docs/clipboard.md
+++ b/docs/clipboard.md
@@ -1,0 +1,162 @@
+# Clipboard
+
+```jsx
+import { useClipboard } from 'react-x11';
+
+function Editor({ value }) {
+  const clipboard = useClipboard();
+  return (
+    <box
+      onKeyDown={(e) => {
+        if (e.ctrlKey && e.key === 'c') clipboard.writeText(value);
+      }}
+    />
+  );
+}
+```
+
+`<textinput>` and `<textarea>` already do all of this for you — Ctrl+C/X/V,
+middle-click paste, select-to-own. This page is for everything else: a
+canvas that copies an image, a list that pastes files, a document view with
+its own Copy item.
+
+## Two clipboards
+
+X has no clipboard buffer. "Copy" means owning a **selection** — a named
+thing the server tracks — and answering conversion requests from whoever
+pastes. There are two in everyday use, and they are independent:
+
+| selection   | filled by                                  | pasted with          |
+| ----------- | ------------------------------------------ | -------------------- |
+| `CLIPBOARD` | an explicit Copy or Cut                    | Ctrl+V, an Edit menu |
+| `PRIMARY`   | _selecting text at all_, with no Copy step | middle click         |
+
+Every call below takes `{ selection }` and defaults to `CLIPBOARD`. The
+X11-native behaviour is to write `PRIMARY` whenever your selection changes,
+which is what the built-in text controls do.
+
+Two consequences worth knowing, because neither matches a browser:
+
+- **The data lives in this process.** Nothing is stored by the server, so
+  when the app exits the clipboard goes with it — normal X behaviour, and
+  the reason desktops run clipboard managers. Nothing negotiates with one
+  yet.
+- **Someone else copying takes it away.** Ownership is exclusive; there is
+  no "clipboard history" to fall back on.
+
+## `useClipboard()`
+
+Returns the clipboard for the connection this tree renders onto. Stable, so
+it is safe in a dependency array. Everything on it returns a promise.
+
+### Writing
+
+```js
+await clipboard.writeText('hello');
+await clipboard.write({
+  'text/html': '<b>hello</b>',
+  'text/plain': 'hello',
+  'image/png': pngBytes,
+});
+```
+
+`write()` takes a map of **type name to payload** — strings are encoded
+UTF-8, `Buffer`s and typed arrays are served as they are. Offering several
+flavours of the same thing is the point: a rich-text editor takes the HTML,
+a terminal takes the plain text, and each asks for what it understands.
+There is no size limit worth naming; large payloads transfer incrementally.
+
+`clear()` gives the selection back, so nothing is served for it any more.
+
+### Reading
+
+```js
+const text = await clipboard.read('text'); //  'hello'  | null
+const files = await clipboard.readFiles(); //  [{ uri, path? }]
+const png = await clipboard.read('image/png'); //  Uint8Array | null
+const offered = await clipboard.targets(); //  ['text/html', …]
+```
+
+**`read(type)` is the one to reach for.** It accepts a concrete type name or
+a **group**, resolves it against what the owner actually offers, and decodes
+text-ish types to a string. It answers `null` when the owner has nothing of
+that kind, because "is there an image on the clipboard?" is a question, not
+an error.
+
+The groups exist because the same payload arrives under different names
+depending on who copied it, and exact-match filtering silently misses most
+of the desktop:
+
+| group     | matches                                                                                                    |
+| --------- | ---------------------------------------------------------------------------------------------------------- |
+| `'text'`  | `text/plain;charset=utf-8`, `UTF8_STRING`, `text/plain`, `STRING`, `TEXT`, `COMPOUND_TEXT` (in that order) |
+| `'files'` | `text/uri-list`, `application/x-kde4-urilist`, `x-special/gnome-copied-files`                              |
+| `'uris'`  | `text/uri-list`, `text/x-moz-url`, `_NETSCAPE_URL`                                                         |
+
+This is the same table [drag and drop](drag-and-drop.md) uses, and
+deliberately so: the flavours a file manager offers on a drop are the ones
+it offers on a copy. Groups do not overlap — a Firefox link is
+`text/x-moz-url`, which is in `uris`, not `text`.
+
+`readFiles()` is `read('files')` with the RFC 2483 parsing applied: CRLF
+separators, `#` comment lines, percent-decoding. `path` is present only for
+genuinely local `file:` URIs — a remote `file://otherhost/…` gets a `uri`
+and no `path` rather than a path that does not exist here.
+
+`readText()` is the plain-text shortcut and asks only for `UTF8_STRING` then
+`STRING`. It **rejects** when there is no owner or the owner offers neither,
+where `read('text')` returns `null` and walks the whole preference list. If
+you are not sure which you want, use `read('text')`.
+
+### Knowing when it changes
+
+```js
+useEffect(() => {
+  let stop;
+  clipboard
+    .watch((ev) => setCanPaste(ev.owner !== 0))
+    .then((fn) => (stop = fn));
+  return () => stop?.();
+}, [clipboard]);
+```
+
+`watch()` is a server-side subscription, not a poll — it costs nothing until
+something changes. `owner === 0` means nothing is on the clipboard, which is
+the case a Paste menu item wants. It rejects on a server without XFixes;
+every X server since about 2004 has it.
+
+## Timestamps
+
+X arbitrates between two clients copying at the same moment by **timestamp**,
+and ICCCM is explicit that the right one is the event that caused the copy —
+never "now". You do not have to pass one: react-x11 remembers the last input
+event on the connection and uses it, so a copy from a Ctrl+C handler is
+stamped with that keystroke. Pass `{ time }` if you have a better answer.
+
+This is also why a `write()` can fail: if another client copied with a newer
+timestamp, the server refuses ours, and the promise rejects rather than
+pretending.
+
+## Reaching ntk directly
+
+`useClipboard()` is a thin layer over ntk's `app.clipboard` and adds only the
+vocabulary, the timestamps and the React access. Anything it does not cover
+is one step away:
+
+```js
+const app = useApp();
+await app.clipboard.write(data, { selection: 'MY_SELECTION', time });
+```
+
+`app` is the whole ntk connection — `app.fonts`, `app.cursors`, `app.X` for
+raw protocol. See ntk's own clipboard documentation for the ICCCM details.
+
+## Limits
+
+- **No clipboard-manager handoff** (`SAVE_TARGETS`), so the data really does
+  vanish when the app exits.
+- **`STRING` is latin-1 by definition**, so codepoints above U+00FF are lossy
+  in that target. Modern requestors ask for `UTF8_STRING`, which is not — and
+  a bare `writeText()` offers both.
+- **No image decoding.** `read('image/png')` hands back the bytes; turning
+  them into something drawable is yours.

--- a/docs/drag-and-drop.md
+++ b/docs/drag-and-drop.md
@@ -54,7 +54,9 @@ What the node will take. Four shapes:
 
 The three groups exist because the same payload arrives under different
 names depending on who is dragging, and exact-match filtering silently
-misses most of the desktop:
+misses most of the desktop. The clipboard uses the same table, on purpose —
+what a file manager offers on a drop is what it offers on a copy, so
+[`clipboard.read('files')`](clipboard.md#reading) resolves it the same way:
 
 | group     | matches                                                                                                    |
 | --------- | ---------------------------------------------------------------------------------------------------------- |

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -470,7 +470,8 @@ Ctrl+C/X/V on CLIPBOARD, middle-click paste from PRIMARY, selections own
 PRIMARY (X11 conventions), **Ctrl+Z / Ctrl+Shift+Z** (Ctrl+Y too) to undo
 and redo, and a **right-click menu**. Focusable by default; shows the text
 cursor. `ev.preventDefault()` in your `onKeyDown`/`onMouseDown` suppresses
-the built-in editing behavior.
+the built-in editing behavior. To copy or paste from anywhere else — a
+canvas, a list, your own menu item — see [clipboard.md](clipboard.md).
 
 ### The right-click menu
 

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -33,6 +33,7 @@ import {
 } from './nodes.js';
 import { flattenStyle } from './styles.js';
 import { hasDropProps } from './dnd.js';
+import { AppProvider } from './appcontext.js';
 import { defaultRootHandlers, setErrorHandler } from './errors.js';
 import {
   registerApp,
@@ -379,6 +380,12 @@ const HostConfig = {
       // screen root.
       child.realize(null);
     }
+    // React's getPublicRootInstance answers from the root fiber's first
+    // child, and only when that child is a host component. `render()` wraps
+    // the tree in a context provider, which is not one, so it would answer
+    // null — the container keeps the list instead. Same answer as before:
+    // the first top-level node the tree put here.
+    (container._rootChildren ??= []).push(child);
   },
 
   insertBefore(parentInstance, child, beforeChild) {
@@ -394,6 +401,9 @@ const HostConfig = {
   },
 
   removeChildFromContainer(container, child) {
+    const roots = container._rootChildren;
+    const at = roots ? roots.indexOf(child) : -1;
+    if (at !== -1) roots.splice(at, 1);
     child.destroySubtree();
   },
 
@@ -681,8 +691,22 @@ export async function createRoot(options = {}) {
   return {
     app,
     render(element, callback) {
-      Renderer.updateContainerSync(element, container, null, () => {
-        callback?.(Renderer.getPublicRootInstance(container), app);
+      // The provider wraps rather than replaces: it renders no host node, so
+      // `getPublicRootInstance` still hands back the tree's own root and
+      // nothing downstream can tell it is there. `null` unmounts, and must
+      // stay null rather than become a provider around nothing.
+      // The provider renders no host node, so it changes nothing about
+      // what is drawn — but it does sit between the root fiber and the
+      // tree, which is why the public instance comes from the container's
+      // own record rather than from getPublicRootInstance. `null` unmounts,
+      // and has to stay null rather than become a provider around nothing.
+      const tree =
+        element == null
+          ? element
+          : React.createElement(AppProvider, { value: app }, element);
+      Renderer.updateContainerSync(tree, container, null, () => {
+        const rootNode = app._rootChildren?.[0] ?? null;
+        callback?.(rootNode && HostConfig.getPublicInstance(rootNode), app);
       });
       Renderer.flushSyncWork();
     },

--- a/src/appcontext.js
+++ b/src/appcontext.js
@@ -1,0 +1,56 @@
+// Reaching the X connection from a component.
+//
+// `createRoot()` hands the app back to whoever called it, which is fine for
+// an entry point and useless three components down — and a component
+// library has no route to it at all without prop-drilling. So `render()`
+// wraps the tree in a provider and `useApp()` reads it.
+//
+// Context rather than the ref walk `useWindowId`/`useAnchor` use: those
+// answer *per-node* questions, and the ref is the question. The connection
+// is app-scoped, so demanding a host ref to find it would be busywork with
+// no information in it. A module-level global would be simpler still and
+// wrong — one process can drive several roots on several connections, which
+// the test suite does routinely.
+
+import { createContext, useContext, useMemo } from 'react';
+
+import { createClipboard } from './clipboard.js';
+
+const AppContext = createContext(null);
+
+/** Wraps the rendered element; not exported to applications. */
+export const AppProvider = AppContext.Provider;
+
+/**
+ * The ntk connection this tree is rendering onto.
+ *
+ * Everything ntk exposes hangs off it — `app.fonts`, `app.cursors`,
+ * `app.X` for raw protocol — so this is the escape hatch as much as it is
+ * an API. Throws outside a react-x11 tree rather than returning null,
+ * because every caller would have had to check.
+ */
+export function useApp() {
+  const app = useContext(AppContext);
+  if (!app) {
+    throw new Error(
+      'react-x11: useApp() must be called inside a tree rendered by createRoot()',
+    );
+  }
+  return app;
+}
+
+/**
+ * The clipboard, scoped to this tree's connection.
+ *
+ * ```jsx
+ * const clipboard = useClipboard();
+ * await clipboard.writeText(selection);        // stamped with the keystroke
+ * const files = await clipboard.readFiles();   // parsed, or []
+ * ```
+ *
+ * Stable for as long as the app is, so it is safe in a dependency array.
+ */
+export function useClipboard() {
+  const app = useApp();
+  return useMemo(() => createClipboard(app), [app]);
+}

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -1,0 +1,121 @@
+// The clipboard an application sees.
+//
+// ntk's `app.clipboard` is the ICCCM selection machinery: it owns
+// selections, answers conversions, and speaks INCR. This is the layer above
+// it, and it adds exactly three things, none of which belong upstream:
+//
+//   1. the type vocabulary (transfer.js) — so `read('text')` finds GTK's
+//      UTF8_STRING and `readFiles()` parses a file manager's uri-list,
+//      instead of every app rediscovering the same table;
+//   2. an ICCCM timestamp by default (inputtime.js), so a copy is stamped
+//      with the keystroke that caused it rather than with "now";
+//   3. a way in from React (useClipboard), since a component has no route
+//      to the connection.
+//
+// Everything on the wire is still ntk's. `root.app.clipboard` remains the
+// documented escape hatch for anything this does not cover.
+
+import { inputTime } from './inputtime.js';
+import { decodeData, parseUriList, resolveType } from './transfer.js';
+
+/** Ask the owner what it has, so a group name can be resolved against a
+ * real offer rather than guessed at one failed conversion per guess. */
+async function offeredTypes(clipboard, options) {
+  try {
+    return await clipboard.targets(options);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * The object `useClipboard()` hands back. One per app — it holds no state
+ * of its own, so making a second is harmless.
+ */
+export function createClipboard(app) {
+  const raw = () => {
+    const c = app?.clipboard;
+    if (!c) throw new Error('react-x11: this app has no clipboard');
+    return c;
+  };
+  // every call takes the same three, and every one of them has a default
+  // worth not repeating
+  const opts = ({ selection = 'CLIPBOARD', timeout, time } = {}) => ({
+    selection,
+    ...(timeout === undefined ? {} : { timeout }),
+    time: time === undefined ? inputTime(app) : time,
+  });
+
+  return {
+    /** Take a selection and serve `data` — a string, or a map of type name
+     * to string/bytes for offering several flavours of one thing. */
+    write(data, options) {
+      return raw().write(data, opts(options));
+    },
+
+    /** Shorthand for the common case; offered as UTF8_STRING and STRING. */
+    writeText(text, options) {
+      return raw().write(String(text), opts(options));
+    },
+
+    /** Give the selection back, so nothing is served for it any more. */
+    clear(selection = 'CLIPBOARD') {
+      return raw().clear(selection);
+    },
+
+    /** What the current owner can convert to. `[]` when nothing owns it. */
+    targets(options) {
+      return raw().targets(opts(options));
+    },
+
+    /** The plain text of a selection, ntk's UTF8_STRING → STRING walk.
+     * `read('text')` is the interop-hardened version of this. */
+    readText(options) {
+      return raw().read(opts(options));
+    },
+
+    /**
+     * One type, decoded: a concrete name (`'image/png'`) or a group
+     * (`'text'`, `'files'`, `'uris'`) resolved against what the owner
+     * actually offers. Text-ish types come back as a string, everything
+     * else as bytes. `null` when the owner has nothing of that kind —
+     * which is a question, not an error, unlike `readText()` on an empty
+     * clipboard.
+     */
+    async read(type, options) {
+      const o = opts(options);
+      const offered = await offeredTypes(raw(), o);
+      const target = resolveType(type, offered);
+      if (!offered.includes(target)) return null;
+      const data = await raw().read({ ...o, target });
+      return typeof data === 'string' ? data : decodeData(data, target);
+    },
+
+    /**
+     * Files copied in a file manager, parsed (RFC 2483). `[]` when the
+     * clipboard holds no file flavour, so a paste handler can call it
+     * without asking first.
+     */
+    async readFiles(options) {
+      const list = await this.read('files', options);
+      return typeof list === 'string' ? parseUriList(list) : [];
+    },
+
+    /**
+     * Call `handler` whenever the selection changes hands — an XFixes
+     * subscription, not a poll. `ev.owner === 0` means nothing is on the
+     * clipboard, which is the case an edit menu wants.
+     *
+     * Rejects on a server without XFixes; every X server since about 2004
+     * has it, so treat that as "this server is unusual" rather than as a
+     * path to code around.
+     */
+    watch(selectionOrHandler, maybeHandler) {
+      const [selection, handler] =
+        typeof selectionOrHandler === 'function'
+          ? ['CLIPBOARD', selectionOrHandler]
+          : [selectionOrHandler, maybeHandler];
+      return raw().watch(selection, handler);
+    },
+  };
+}

--- a/src/dnd.js
+++ b/src/dnd.js
@@ -26,6 +26,14 @@ import {
 } from './priority.js';
 import { callHandler, reportHandlerError } from './errors.js';
 import { discrete } from './events.js';
+import {
+  TEXT_TARGETS,
+  TYPE_GROUPS,
+  decodeData,
+  parseUriList,
+  resolveType,
+  typeMatches,
+} from './transfer.js';
 
 export const XDND_VERSION = 5;
 
@@ -117,47 +125,7 @@ function atomName(X, atom) {
   return p;
 }
 
-// ---------------------------------------------------------------------------
-// The type vocabulary.
-//
-// The same logical payload arrives under different names depending on who is
-// dragging: files are text/uri-list (plus desktop-specific variants), GTK
-// text is text/plain;charset=utf-8 / UTF8_STRING / STRING / COMPOUND_TEXT,
-// Firefox links are UTF-16 text/x-moz-url, Chromium's are _NETSCAPE_URL.
-// String equality on 'text/plain' misses GTK text entirely — normalising
-// this once, here, is the interop feature.
-// ---------------------------------------------------------------------------
-
-/** Best-first text flavours, for `e.text` and the 'text' group. */
-const TEXT_TARGETS = [
-  'text/plain;charset=utf-8',
-  'UTF8_STRING',
-  'text/plain',
-  'STRING',
-  'TEXT',
-  'COMPOUND_TEXT',
-];
-
-const TYPE_GROUPS = {
-  files: [
-    'text/uri-list',
-    'application/x-kde4-urilist',
-    'x-special/gnome-copied-files',
-  ],
-  uris: ['text/uri-list', 'text/x-moz-url', '_NETSCAPE_URL'],
-  text: TEXT_TARGETS,
-};
-
-/** Does the offered type list satisfy one accept entry — a semantic group
- * ('files' | 'uris' | 'text') or a concrete type name? MIME names compare
- * case-insensitively; X atom names like UTF8_STRING are exact. */
-export function typeMatches(offered, want) {
-  const group = TYPE_GROUPS[want];
-  if (group) return group.some((t) => offered.includes(t));
-  if (offered.includes(want)) return true;
-  const lower = String(want).toLowerCase();
-  return offered.some((t) => t.toLowerCase() === lower);
-}
+export { parseUriList, typeMatches };
 
 /**
  * Does a node's `dropAccept` accept this offer? `dropAccept` is a type
@@ -170,34 +138,6 @@ export function matchAccept(accept, offered) {
   if (typeof accept === 'function') return Boolean(accept(offered));
   const list = Array.isArray(accept) ? accept : [accept];
   return list.some((want) => typeMatches(offered, want));
-}
-
-/**
- * Parse a `text/uri-list` payload (RFC 2483): CRLF-separated, `#` lines are
- * comments, URIs are percent-encoded. `path` is present only for `file:`
- * URIs that are actually local — a remote `file://host/...` has no local
- * path and must not pretend to.
- */
-export function parseUriList(text) {
-  const files = [];
-  for (const line of String(text).split(/\r?\n/)) {
-    const uri = line.trim();
-    if (!uri || uri.startsWith('#')) continue;
-    const entry = { uri };
-    try {
-      const url = new URL(uri);
-      if (
-        url.protocol === 'file:' &&
-        (url.hostname === '' || url.hostname === 'localhost')
-      ) {
-        entry.path = decodeURIComponent(url.pathname);
-      }
-    } catch {
-      // not a parseable URI — keep the raw line, claim no path
-    }
-    files.push(entry);
-  }
-  return files;
 }
 
 /** The props that make a node a drop target (and register it, see
@@ -247,13 +187,6 @@ function actionAtom(atoms, name) {
 
 /** Decode selection bytes for a text-ish target; anything else stays a
  * Buffer. STRING is defined as latin-1; everything textual else is UTF-8. */
-function decodeData(data, target) {
-  const textish =
-    TEXT_TARGETS.includes(target) || /^text\//i.test(String(target));
-  if (!textish) return data;
-  return data.toString(target === 'STRING' ? 'latin1' : 'utf8');
-}
-
 /**
  * The viewport a drag over `path` scrolls: the nearest enclosing one,
  * found by walking out from the hit node the same way the wheel's default
@@ -968,9 +901,7 @@ export class DropSession {
   /** `getData('files')` and friends: resolve a semantic group to the first
    * concretely offered member. */
   _resolveType(type) {
-    const group = TYPE_GROUPS[type];
-    if (!group) return type;
-    return group.find((t) => this.types.includes(t)) ?? type;
+    return resolveType(type, this.types);
   }
 
   // -- geometry ------------------------------------------------------------
@@ -1315,13 +1246,8 @@ export class DragSession {
       const v = this._resolve(best);
       if (typeof v === 'string') text = v;
     }
-    const getData = (type) => {
-      const group = TYPE_GROUPS[type];
-      const concrete = group
-        ? (this.types.find((t) => group.includes(t)) ?? type)
-        : type;
-      return Promise.resolve(this._resolve(concrete));
-    };
+    const getData = (type) =>
+      Promise.resolve(this._resolve(resolveType(type, this.types)));
     return { items, files, text, getData };
   }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -57,6 +57,75 @@ export function parseUriList(
   text: string | Uint8Array,
 ): Array<{ uri: string; path?: string }>;
 
+/** A semantic group, or any concrete type name the owner offers. */
+export type TransferType = 'text' | 'files' | 'uris' | (string & {});
+
+export interface ClipboardOptions {
+  /** Selection atom name; `'CLIPBOARD'` by default, `'PRIMARY'` for the
+   * middle-click buffer. Any name works. */
+  selection?: string;
+  /** ms to wait for the owner at each protocol step. */
+  timeout?: number;
+  /** The server timestamp of the event behind this (ICCCM 2.1 / 2.4).
+   * Defaults to the last input event seen on this connection, which is
+   * almost always what you want. */
+  time?: number;
+}
+
+export interface SelectionChange {
+  selection: string;
+  /** Window now owning it, or `0` when nothing does — the case an edit
+   * menu wants. */
+  owner: number;
+  timestamp?: number;
+  selectionTimestamp?: number;
+  reason?: 'new-owner' | 'destroyed' | 'closed';
+}
+
+/** What `useClipboard()` returns. See docs/clipboard.md. */
+export interface Clipboard {
+  /** Offer several flavours of one thing: type name to string or bytes. */
+  write(
+    data: string | Record<string, string | Uint8Array>,
+    options?: ClipboardOptions,
+  ): Promise<void>;
+  writeText(text: string, options?: ClipboardOptions): Promise<void>;
+  /** Stop owning the selection, so nothing is served for it any more. */
+  clear(selection?: string): Promise<void>;
+  /** What the current owner can convert to; `[]` when nothing owns it. */
+  targets(options?: ClipboardOptions): Promise<string[]>;
+  /** Plain text, via the owner's `UTF8_STRING`/`STRING` targets. Rejects
+   * when there is no owner or it offers neither — `read('text')` is the
+   * interop-hardened version. */
+  readText(options?: ClipboardOptions): Promise<string>;
+  /** One type, decoded, or `null` when the owner has nothing of that kind.
+   * Text-ish types resolve to a string, anything else to bytes. */
+  read(
+    type: TransferType,
+    options?: ClipboardOptions,
+  ): Promise<string | Uint8Array | null>;
+  /** Files copied in a file manager, parsed; `[]` when there are none. */
+  readFiles(
+    options?: ClipboardOptions,
+  ): Promise<Array<{ uri: string; path?: string }>>;
+  /** Called whenever the selection changes hands. Resolves to an
+   * unsubscribe function. Rejects on a server without XFixes. */
+  watch(handler: (change: SelectionChange) => void): Promise<() => void>;
+  watch(
+    selection: string,
+    handler: (change: SelectionChange) => void,
+  ): Promise<() => void>;
+}
+
+/**
+ * The ntk connection this tree renders onto — `app.fonts`, `app.cursors`,
+ * `app.X` and the rest. Throws outside a tree rendered by `createRoot()`.
+ */
+export function useApp(): unknown;
+
+/** The clipboard, scoped to this tree's connection. */
+export function useClipboard(): Clipboard;
+
 /** What React reports alongside an error it caught. */
 export interface ErrorInfo {
   componentStack?: string;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
 export { createRoot, Renderer } from './Reconciler.js';
 export { createStyles, flattenStyle } from './styles.js';
 export { windowIdOf, useWindowId } from './windowid.js';
-export { parseUriList } from './dnd.js';
+export { parseUriList } from './transfer.js';
+export { useApp, useClipboard } from './appcontext.js';
 export {
   useDropTarget,
   useDragSource,

--- a/src/testing/mock-app.js
+++ b/src/testing/mock-app.js
@@ -42,6 +42,77 @@ export function createMockApp() {
       app.closed++;
       return Promise.resolve();
     },
+    // A clipboard that behaves like ntk's without a server: selections are
+    // owned in this process, so a write is visible to the next read. Enough
+    // for anything that copies or pastes — the ICCCM machinery itself is
+    // tested against the real thing in test/clipboard.test.js.
+    clipboard: {
+      /** every write, in order: `{ data, selection, time }` */
+      writes: [],
+      /** selection name -> the target map currently owned */
+      owned: new Map(),
+      _watchers: new Map(),
+      write(data, { selection = 'CLIPBOARD', time } = {}) {
+        app.clipboard.writes.push({ data, selection, time });
+        const map =
+          typeof data === 'string'
+            ? { UTF8_STRING: data, STRING: data }
+            : { ...data };
+        app.clipboard.owned.set(selection, map);
+        for (const fn of app.clipboard._watchers.get(selection) ?? []) {
+          fn({ selection, owner: 1, reason: 'new-owner' });
+        }
+        return Promise.resolve();
+      },
+      clear(selection = 'CLIPBOARD') {
+        app.clipboard.owned.delete(selection);
+        for (const fn of app.clipboard._watchers.get(selection) ?? []) {
+          fn({ selection, owner: 0, reason: 'new-owner' });
+        }
+        return Promise.resolve();
+      },
+      targets({ selection = 'CLIPBOARD' } = {}) {
+        return Promise.resolve([
+          ...Object.keys(app.clipboard.owned.get(selection) ?? {}),
+        ]);
+      },
+      read({ selection = 'CLIPBOARD', target } = {}) {
+        const map = app.clipboard.owned.get(selection);
+        if (!map) {
+          return Promise.reject(
+            new Error(
+              `clipboard: nothing to paste — ${selection} has no owner`,
+            ),
+          );
+        }
+        if (target === undefined) {
+          const text = map.UTF8_STRING ?? map.STRING;
+          return text === undefined
+            ? Promise.reject(
+                new Error('clipboard: owner refused both text targets'),
+              )
+            : Promise.resolve(text);
+        }
+        if (!(target in map)) {
+          return Promise.reject(
+            new Error(`clipboard: owner cannot convert to ${target}`),
+          );
+        }
+        const value = map[target];
+        return Promise.resolve(
+          typeof value === 'string' ? Buffer.from(value, 'utf8') : value,
+        );
+      },
+      watch(selection, handler) {
+        const list = app.clipboard._watchers.get(selection) ?? [];
+        list.push(handler);
+        app.clipboard._watchers.set(selection, list);
+        return Promise.resolve(() => {
+          const at = list.indexOf(handler);
+          if (at !== -1) list.splice(at, 1);
+        });
+      },
+    },
     windows: [],
     createWindow(attributes) {
       const handlers = {};

--- a/src/transfer.js
+++ b/src/transfer.js
@@ -1,0 +1,93 @@
+// The type vocabulary, shared by the clipboard and drag and drop.
+//
+// The same logical payload arrives under different names depending on who
+// sent it: files are text/uri-list (plus desktop-specific variants), GTK
+// text is text/plain;charset=utf-8 / UTF8_STRING / STRING / COMPOUND_TEXT,
+// Firefox links are UTF-16 text/x-moz-url, Chromium's are _NETSCAPE_URL.
+// String equality on 'text/plain' misses GTK text entirely — normalising
+// this once is the interop feature.
+//
+// It lives here rather than in dnd.js because a paste and a drop face the
+// identical soup: the X selection a file manager offers on CLIPBOARD is the
+// one it offers on XdndSelection. One vocabulary, two gestures — the same
+// split GTK draws with GdkContentFormats and Qt with QMimeData.
+
+/** Best-first text flavours, for `e.text` and the 'text' group. */
+export const TEXT_TARGETS = [
+  'text/plain;charset=utf-8',
+  'UTF8_STRING',
+  'text/plain',
+  'STRING',
+  'TEXT',
+  'COMPOUND_TEXT',
+];
+
+export const TYPE_GROUPS = {
+  files: [
+    'text/uri-list',
+    'application/x-kde4-urilist',
+    'x-special/gnome-copied-files',
+  ],
+  uris: ['text/uri-list', 'text/x-moz-url', '_NETSCAPE_URL'],
+  text: TEXT_TARGETS,
+};
+
+/** Does the offered type list satisfy one accept entry — a semantic group
+ * ('files' | 'uris' | 'text') or a concrete type name? MIME names compare
+ * case-insensitively; X atom names like UTF8_STRING are exact. */
+export function typeMatches(offered, want) {
+  const group = TYPE_GROUPS[want];
+  if (group) return group.some((t) => offered.includes(t));
+  if (offered.includes(want)) return true;
+  const lower = String(want).toLowerCase();
+  return offered.some((t) => t.toLowerCase() === lower);
+}
+
+/**
+ * A group name resolved against what is actually on offer: the first
+ * member of the group the owner can convert to, in the group's own
+ * preference order. A concrete type is returned unchanged, so callers can
+ * pass either without asking which they have.
+ */
+export function resolveType(type, offered) {
+  const group = TYPE_GROUPS[type];
+  if (!group) return type;
+  return group.find((t) => offered.includes(t)) ?? type;
+}
+
+/** Bytes from a selection, decoded when the target says they are text.
+ * STRING is latin-1 by definition; everything else text-ish is UTF-8. */
+export function decodeData(data, target) {
+  const textish =
+    TEXT_TARGETS.includes(target) || /^text\//i.test(String(target));
+  if (!textish) return data;
+  return data.toString(target === 'STRING' ? 'latin1' : 'utf8');
+}
+
+/**
+ * Parse a `text/uri-list` payload (RFC 2483): CRLF-separated, `#` lines are
+ * comments, URIs are percent-encoded. `path` is present only for `file:`
+ * URIs that are actually local — a remote `file://host/...` has no local
+ * path and must not pretend to.
+ */
+export function parseUriList(text) {
+  const files = [];
+  for (const line of String(text).split(/\r?\n/)) {
+    const uri = line.trim();
+    if (!uri || uri.startsWith('#')) continue;
+    const entry = { uri };
+    try {
+      const url = new URL(uri);
+      if (
+        url.protocol === 'file:' &&
+        (url.hostname === '' || url.hostname === 'localhost')
+      ) {
+        entry.path = decodeURIComponent(url.pathname);
+      }
+    } catch {
+      // not a parseable URI — keep the raw line, claim no path
+    }
+    files.push(entry);
+  }
+  return files;
+}

--- a/test/clipboard.test.js
+++ b/test/clipboard.test.js
@@ -1,0 +1,270 @@
+// The userland clipboard, against a real ICCCM peer.
+//
+// Two ntk clients on node-x11's in-process X server, the pattern from
+// test/dnd.test.js: one owns selections through ntk's clipboard, the other
+// reads them through `useClipboard()`'s facade. What is asserted is the
+// layer react-x11 adds — the type vocabulary and the timestamps — not the
+// selection machinery underneath, which is ntk's and tested there.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient, StaticFontSource } from 'ntk';
+
+import { createRoot, useApp, useClipboard } from '../src/index.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+async function headlessPair() {
+  const server = xserver.createServer({ width: 320, height: 240 });
+  const connect = async () => {
+    const [serverEnd, clientEnd] = xserver.createStreamPair();
+    server.addClientStream(serverEnd);
+    return createClient({
+      stream: clientEnd,
+      fontSource: new StaticFontSource(),
+    });
+  };
+  return { app: await connect(), peer: await connect() };
+}
+
+/** The facade, without a React tree in the way. `useClipboard` is a
+ * `useMemo` over exactly this. */
+async function clipboardOf(app) {
+  const { createClipboard } = await import('../src/clipboard.js');
+  return createClipboard(app);
+}
+
+// --- the vocabulary ---------------------------------------------------------
+
+test("read('text') finds a flavour readText() cannot", async () => {
+  const { app, peer } = await headlessPair();
+  try {
+    // A GTK-ish owner that offers only the modern MIME name. ntk's own
+    // read() asks UTF8_STRING and then STRING, so it has nothing to ask
+    // for — which is exactly the gap the group walk exists to close.
+    await peer.clipboard.write({ 'text/plain;charset=utf-8': 'κόσμε' });
+    const clipboard = await clipboardOf(app);
+
+    await assert.rejects(
+      () => clipboard.readText(),
+      /refused|cannot convert|no owner/,
+      'the plain text path has no target to ask for',
+    );
+    assert.equal(await clipboard.read('text'), 'κόσμε');
+  } finally {
+    await app.close();
+    await peer.close();
+  }
+});
+
+test("read('text') prefers the best flavour when several are offered", async () => {
+  const { app, peer } = await headlessPair();
+  try {
+    await peer.clipboard.write({
+      'text/plain;charset=utf-8': 'best',
+      'text/plain': 'worse',
+      STRING: 'worst',
+    });
+    const clipboard = await clipboardOf(app);
+    assert.equal(await clipboard.read('text'), 'best');
+  } finally {
+    await app.close();
+    await peer.close();
+  }
+});
+
+test('readFiles() parses what a file manager copies, and is [] otherwise', async () => {
+  const { app, peer } = await headlessPair();
+  try {
+    const clipboard = await clipboardOf(app);
+    await peer.clipboard.write({
+      'text/uri-list':
+        'file:///home/u/My%20Doc.pdf\r\n# a comment\r\nfile://otherhost/x\r\n',
+    });
+    assert.deepEqual(await clipboard.readFiles(), [
+      { uri: 'file:///home/u/My%20Doc.pdf', path: '/home/u/My Doc.pdf' },
+      { uri: 'file://otherhost/x' }, // remote: no local path
+    ]);
+
+    await peer.clipboard.write('just text');
+    assert.deepEqual(
+      await clipboard.readFiles(),
+      [],
+      'no file flavour is an empty list, not a throw',
+    );
+  } finally {
+    await app.close();
+    await peer.close();
+  }
+});
+
+test('read() answers null for a type the owner does not have', async () => {
+  const { app, peer } = await headlessPair();
+  try {
+    await peer.clipboard.write('text only');
+    const clipboard = await clipboardOf(app);
+    assert.equal(await clipboard.read('image/png'), null);
+  } finally {
+    await app.close();
+    await peer.close();
+  }
+});
+
+test('write() offers several flavours of one thing; clear() gives it back', async () => {
+  const { app, peer } = await headlessPair();
+  try {
+    const clipboard = await clipboardOf(app);
+    await clipboard.write({
+      'text/html': '<b>hi</b>',
+      'text/plain': 'hi',
+    });
+    const offered = await peer.clipboard.targets();
+    for (const t of ['text/html', 'text/plain']) {
+      assert.ok(offered.includes(t), `${t} offered, got ${offered.join(', ')}`);
+    }
+    assert.equal(
+      (await peer.clipboard.read({ target: 'text/html' })).toString('utf8'),
+      '<b>hi</b>',
+    );
+
+    await clipboard.clear();
+    assert.deepEqual(await peer.clipboard.targets(), []);
+  } finally {
+    await app.close();
+    await peer.close();
+  }
+});
+
+test('PRIMARY is a separate selection, reachable through the same calls', async () => {
+  const { app, peer } = await headlessPair();
+  try {
+    const clipboard = await clipboardOf(app);
+    await clipboard.writeText('for ctrl-v');
+    await clipboard.writeText('for middle click', { selection: 'PRIMARY' });
+    assert.equal(await peer.clipboard.read(), 'for ctrl-v');
+    assert.equal(
+      await peer.clipboard.read({ selection: 'PRIMARY' }),
+      'for middle click',
+    );
+  } finally {
+    await app.close();
+    await peer.close();
+  }
+});
+
+// --- the React surface ------------------------------------------------------
+
+test('useClipboard() reaches the app the tree renders onto', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  let clipboard = null;
+  function Copier() {
+    clipboard = useClipboard();
+    return h('box', { style: { width: 10, height: 10 } });
+  }
+  x11Root.render(h('window', { width: 100, height: 100 }, h(Copier)));
+  await tick();
+
+  assert.ok(clipboard, 'the hook resolved');
+  await clipboard.writeText('from a component');
+  assert.deepEqual(app.clipboard.writes.at(-1).data, 'from a component');
+  assert.equal(await clipboard.read('text'), 'from a component');
+  await x11Root.unmount();
+});
+
+test('useApp() hands back the connection, and says so when there is none', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  let seen = null;
+  function Probe() {
+    seen = useApp();
+    return null;
+  }
+  x11Root.render(h('window', { width: 100, height: 100 }, h(Probe)));
+  await tick();
+  assert.equal(seen, app, 'the same app createRoot was given');
+  await x11Root.unmount();
+});
+
+test('useApp() explains itself when the tree has no provider above it', async () => {
+  // Reached by rendering react-x11 components under another renderer, which
+  // is why it is an error with a sentence in it rather than a null. Driven
+  // through the provider directly: `createRoot` always installs one, so
+  // there is no way to get here through the public entry point.
+  const { AppProvider } = await import('../src/appcontext.js');
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const errors = [];
+  function Probe() {
+    try {
+      useApp();
+    } catch (err) {
+      errors.push(err.message);
+    }
+    return null;
+  }
+  x11Root.render(
+    h(
+      'window',
+      { width: 100, height: 100 },
+      h(AppProvider, { value: null }, h(Probe)),
+    ),
+  );
+  await tick();
+  assert.match(errors[0] ?? '', /inside a tree rendered by createRoot/);
+  await x11Root.unmount();
+});
+
+test('a copy carries the timestamp of the keystroke behind it', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  let clipboard = null;
+  function Copier() {
+    clipboard = useClipboard();
+    return h('box', { style: { width: 50, height: 50 } });
+  }
+  x11Root.render(h('window', { width: 100, height: 100 }, h(Copier)));
+  await tick();
+  await tick();
+
+  const wnd = app.windows[0];
+  wnd.emit('keydown', { keycode: 40, codepoint: 0x63, buttons: 4, time: 4242 });
+  await clipboard.writeText('copied');
+  assert.equal(
+    app.clipboard.writes.at(-1).time,
+    4242,
+    'ICCCM 2.1: the event that caused the copy, not "now"',
+  );
+
+  // an explicit time still wins — a caller with a better one is believed
+  await clipboard.writeText('again', { time: 7 });
+  assert.equal(app.clipboard.writes.at(-1).time, 7);
+  await x11Root.unmount();
+});
+
+test('watch() reports the clipboard going empty', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  let clipboard = null;
+  function Probe() {
+    clipboard = useClipboard();
+    return null;
+  }
+  x11Root.render(h('window', { width: 100, height: 100 }, h(Probe)));
+  await tick();
+
+  const seen = [];
+  const unwatch = await clipboard.watch((ev) => seen.push(ev.owner));
+  await clipboard.writeText('something');
+  await clipboard.clear();
+  assert.deepEqual(seen, [1, 0], 'owned, then unowned');
+
+  unwatch();
+  await clipboard.writeText('after');
+  assert.deepEqual(seen, [1, 0], 'unwatch stops the callbacks');
+  await x11Root.unmount();
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -12,6 +12,8 @@ import {
   Button,
   Canvas3D,
   Checkbox,
+  useApp,
+  useClipboard,
   ContextMenu,
   createRoot,
   createStyles,
@@ -487,6 +489,35 @@ async function main() {
   void [n, perOpcode, one.stats.errors, one.stop()];
 }
 
+// the clipboard facade: groups, options, and the two read contracts
+function _Clip() {
+  const app = useApp();
+  const clipboard = useClipboard();
+  async function go() {
+    await clipboard.writeText('hi');
+    await clipboard.write({ 'text/html': '<b>hi</b>', 'text/plain': 'hi' });
+    await clipboard.writeText('sel', { selection: 'PRIMARY', time: 12 });
+    const text: string = await clipboard.readText();
+    const rich: string | Uint8Array | null = await clipboard.read('text');
+    const png = await clipboard.read('image/png', { timeout: 500 });
+    const files = await clipboard.readFiles();
+    const first: string | undefined = files[0]?.path;
+    const offered: string[] = await clipboard.targets();
+    const stop = await clipboard.watch((ev) => {
+      const empty: boolean = ev.owner === 0;
+      void empty;
+    });
+    const stop2 = await clipboard.watch('PRIMARY', () => {});
+    stop();
+    stop2();
+    await clipboard.clear('PRIMARY');
+    void [app, text, rich, png, first, offered];
+  }
+  void go;
+  return null;
+}
+
+void _Clip;
 void main;
 void grow;
 void _div;

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -180,6 +180,7 @@ const ORDER = [
   'components.md',
   'events.md',
   'drag-and-drop.md',
+  'clipboard.md',
   'typescript.md',
   'extending.md',
   'testing.md',


### PR DESCRIPTION
Second slice of [#164](https://github.com/sidorares/react-x11/issues/164),
after the timestamps in #167. §2 and §5 of the plan there.

Copy and paste worked in `<textinput>`/`<textarea>` and nowhere else. An app
that wanted to copy an image, paste files, or put a Copy item in its own menu
had `root.app.clipboard` — undocumented, untyped, unreachable from a
component, and raw enough that every app would have rediscovered the same
interop table.

```jsx
const clipboard = useClipboard();

await clipboard.write({ 'text/html': html, 'text/plain': text });
const files = await clipboard.readFiles(); // [{ uri, path? }], or []
const png = await clipboard.read('image/png'); // bytes, or null
```

## `src/transfer.js` — one vocabulary, two gestures

The text flavour order, the `files`/`uris`/`text` groups, the uri-list parser
and the byte decoder move out of `dnd.js` **unchanged**. They moved because a
paste faces the identical soup a drop does — what a file manager offers on
`XdndSelection` is what it offers on `CLIPBOARD` — and one copy of that table
is the entire interop argument. `dnd.js` imports it and re-exports the two
names it used to own, so nothing outside changes; all 21 DnD tests pass
untouched. GTK splits the same way with `GdkContentFormats`, Qt with
`QMimeData`.

## The two read paths are deliberately different

| | asks for | when there is none |
| --- | --- | --- |
| `readText()` | `UTF8_STRING`, then `STRING` (ntk's own walk) | rejects |
| `read('text')` | the whole preference list | `null` |

Not academic: **an owner offering only `text/plain;charset=utf-8` — what a
GTK app does — is invisible to the first and found by the second.** There is
a test that pins exactly that, against a real ICCCM peer rather than a mock.
`read()` answers `null` rather than throwing because "is there an image on
the clipboard?" is a question, not an error.

Timestamps default to `src/inputtime.js`, so a copy is stamped with the
keystroke behind it without the caller doing anything; an explicit `{ time }`
still wins.

## `useApp()`, and one consequence

The connection is what a component could not reach, so `render()` now wraps
the tree in a provider. Context rather than the ref walk `useWindowId` and
`useAnchor` use: those answer *per-node* questions where the ref is the
question, and the connection is app-scoped. A module global would be simpler
and wrong — one process can drive several roots on several connections, which
the test suite does routinely.

**The wrapper broke `render()`'s callback and the fix is worth a look.**
React's `getPublicRootInstance` answers from the root fiber's first child and
only when that child is a host component, so a provider in between makes it
`null`. The container now records what was appended and the callback answers
from that — the same value as before. The click-to-component tests caught
this, which is the argument for it being covered.

## Tests

Eleven new, 404 pass. Six drive the facade against a **second ntk client over
the in-process X server**, which is where the interop claims are checked; five
cover the React surface on the mock app.

Both of the facade's reasons to exist were mutation-checked: dropping the
group resolution fails four tests, dropping the ambient timestamp fails one.
One test I wrote and then rewrote — the `useApp()` throw was originally
satisfied by React's own "Invalid hook call", so it never reached my code; it
now drives the provider directly with a `null` value.

The mock app also grows a working clipboard (selections owned in-process, so
a write is visible to the next read) — four suites had been hand-rolling a
fake each.

## Docs

`docs/clipboard.md`, placed next to `drag-and-drop.md` in the sidebar because
they share the table, and cross-linked from both plus `elements.md`.

## Still open on #164

§3 `watch()`-driven Paste greying in the edit menu, §6 the inspector example,
and §7 the PRIMARY-on-select-all conformance nits. Kept out to keep this one
idea.
