### PR TITLE
feat(clipboard): grey Paste when there is nothing to paste

### DIFF
--- a/docs/clipboard.md
+++ b/docs/clipboard.md
@@ -120,6 +120,10 @@ useEffect(() => {
 }, [clipboard]);
 ```
 
+The built-in edit menu on `<textinput>`/`<textarea>` already does this for
+its Paste row — see [elements.md](elements.md#the-right-click-menu). This is
+the same mechanism, for your own menus.
+
 `watch()` is a server-side subscription, not a poll — it costs nothing until
 something changes. `owner === 0` means nothing is on the clipboard, which is
 the case a Paste menu item wants. It rejects on a server without XFixes;

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -467,7 +467,7 @@ that is how react-hook-form's `register()` resets a field through its ref.
 Interactions: click/drag selection, double-click word select, triple-click
 select all, Backspace/Delete, arrows (+Shift extends), Home/End, Ctrl+A,
 Ctrl+C/X/V on CLIPBOARD, middle-click paste from PRIMARY, selections own
-PRIMARY (X11 conventions), **Ctrl+Z / Ctrl+Shift+Z** (Ctrl+Y too) to undo
+PRIMARY (X11 conventions, select-all included), **Ctrl+Z / Ctrl+Shift+Z** (Ctrl+Y too) to undo
 and redo, and a **right-click menu**. Focusable by default; shows the text
 cursor. `ev.preventDefault()` in your `onKeyDown`/`onMouseDown` suppresses
 the built-in editing behavior. To copy or paste from anywhere else — a
@@ -482,6 +482,14 @@ wiring, the way a browser gives `<input>` one — each row live only when it
 would do something, and every row running the same code the keyboard
 shortcut does. Right-clicking **inside** a selection keeps it (the menu is
 about to act on it); outside one, the caret moves there first.
+
+**Paste** is greyed when nothing owns the CLIPBOARD selection. The field
+subscribes to selection changes the first time its menu opens rather than
+asking on the way in — asking would mean a round trip against whatever
+foreign client owns the clipboard, and a wait if that client is wedged, at
+exactly the moment a menu should already be on screen. So the very first
+menu of a session still shows Paste enabled; every one after it knows. On
+a server without XFixes it stays enabled, which is where it started.
 
 Arrows walk the rows, skipping the disabled ones, Enter chooses, Escape or
 a press anywhere outside closes. The selection stays visibly highlighted

--- a/examples/clipboard.jsx
+++ b/examples/clipboard.jsx
@@ -1,0 +1,247 @@
+// A clipboard inspector — and the manual interop harness for the type
+// vocabulary.
+//
+//   npm run examples:clipboard      # needs an X server / DISPLAY
+//
+// The left column copies; the right column shows what is on the clipboard
+// right now and pastes it back. Point it at real applications: copy in
+// GTK's gedit, in a terminal, in Firefox, or select files in Nautilus and
+// press Ctrl+C, and watch which type names actually arrive. That list is
+// the whole reason `read('text')` and `read('files')` take groups rather
+// than exact names — see docs/clipboard.md.
+//
+// Things worth trying:
+//   - Copy from a terminal: usually STRING only, no UTF8_STRING.
+//   - Copy from a GTK app: text/plain;charset=utf-8 first, which is the
+//     flavour readText() cannot ask for and read('text') finds.
+//   - Copy a link in Firefox: text/x-moz-url, which is in the `uris` group
+//     rather than `text` — deliberately, since it is UTF-16 and carries a
+//     title on a second line.
+//   - Copy files in a file manager: text/uri-list, parsed by readFiles().
+//   - Then copy *from* here and paste into those applications: the HTML
+//     button offers text/html and text/plain at once, so a rich editor and
+//     a terminal each take what they understand.
+import React, { useCallback, useEffect, useState } from 'react';
+
+import { createRoot, createStyles, useClipboard } from '../src/index.js';
+
+const s = createStyles({
+  root: { flexDirection: 'row', padding: 12, gap: 12, flexGrow: 1 },
+  // minWidth 0 or the long button labels set a min-content width the
+  // column will not shrink below, and the right half runs off the window
+  left: { flexDirection: 'column', gap: 8, width: 190 },
+  col: { flexDirection: 'column', gap: 8, flexGrow: 1, minWidth: 0 },
+  panel: {
+    flexDirection: 'column',
+    gap: 6,
+    padding: 10,
+    backgroundColor: '#ffffff',
+    borderColor: '#dfe6e9',
+    borderWidth: 1,
+    borderRadius: 6,
+    flexGrow: 1,
+    minWidth: 0,
+  },
+  heading: { color: '#2d3436', fontSize: 13 },
+  dim: { color: '#7f8c8d', fontSize: 11 },
+  button: {
+    padding: 6,
+    backgroundColor: '#f5f6fa',
+    borderColor: '#b2bec3',
+    borderWidth: 1,
+    borderRadius: 4,
+    color: '#2d3436',
+    ':hover': { backgroundColor: '#e8eaf0' },
+  },
+  mono: { color: '#2d3436', fontSize: 11 },
+  empty: { color: '#b2bec3', fontSize: 11 },
+});
+
+function Button({ label, onClick }) {
+  return (
+    <box style={s.button} onMouseUp={onClick}>
+      <text style={s.heading}>{label}</text>
+    </box>
+  );
+}
+
+/** A 1x1 red PNG, so the image button has something real to offer. */
+const RED_DOT = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==',
+  'base64',
+);
+
+function App() {
+  const clipboard = useClipboard();
+  const [offered, setOffered] = useState([]);
+  const [pasted, setPasted] = useState(null);
+  // one line, and short: an unbounded string here sets a min-content width
+  // the whole column is then sized to, and the panel runs off the window
+  const [note, setNoteRaw] = useState('nothing yet');
+  const setNote = useCallback(
+    (text) => setNoteRaw(String(text).slice(0, 58)),
+    [],
+  );
+
+  const refresh = useCallback(async () => {
+    try {
+      setOffered(await clipboard.targets());
+    } catch (err) {
+      setNote(`targets() failed: ${err.message}`);
+    }
+  }, [clipboard]);
+
+  // The list follows the clipboard rather than being polled: watch() is a
+  // server-side subscription, so this costs nothing until something copies.
+  useEffect(() => {
+    let stop;
+    let live = true;
+    clipboard
+      .watch(() => refresh())
+      .then((fn) => {
+        if (live) stop = fn;
+        else fn();
+      })
+      .catch((err) => setNote(`watch() unavailable: ${err.message}`));
+    refresh();
+    return () => {
+      live = false;
+      stop?.();
+    };
+  }, [clipboard, refresh]);
+
+  const copy = (data, label) => async () => {
+    try {
+      await clipboard.write(data);
+      setNote(`copied ${label}`);
+    } catch (err) {
+      setNote(`copy failed: ${err.message}`);
+    }
+  };
+
+  const paste = (label, run) => async () => {
+    try {
+      const value = await run();
+      setPasted({ label, value });
+      setNote(`pasted as ${label}`);
+    } catch (err) {
+      setPasted(null);
+      setNote(`${label} failed: ${err.message}`);
+    }
+  };
+
+  return (
+    <box style={s.root}>
+      <box style={s.left}>
+        <box style={s.panel}>
+          <text style={s.heading}>Copy</text>
+          <Button
+            label="plain text"
+            onClick={copy('Hello, κόσμε! — from react-x11', 'plain text')}
+          />
+          <Button
+            label="html + plain text"
+            onClick={copy(
+              {
+                'text/html': '<b>Hello</b> from <i>react-x11</i>',
+                'text/plain': 'Hello from react-x11',
+              },
+              'two flavours',
+            )}
+          />
+          <Button
+            label="a png"
+            onClick={copy({ 'image/png': RED_DOT }, 'image/png')}
+          />
+          <Button
+            label="this file, as a file list"
+            onClick={copy(
+              {
+                'text/uri-list': `file://${process.cwd()}/examples/clipboard.jsx\r\n`,
+              },
+              'text/uri-list',
+            )}
+          />
+          <Button
+            label="clear it"
+            onClick={async () => {
+              await clipboard.clear();
+              setNote('cleared');
+            }}
+          />
+        </box>
+      </box>
+
+      <box style={s.col}>
+        <box style={s.panel}>
+          <text style={s.heading}>On the clipboard now</text>
+          {offered.length === 0 ? (
+            <text style={s.empty}>nothing, or nobody owns CLIPBOARD</text>
+          ) : (
+            offered.map((t) => (
+              <text key={t} style={s.mono}>
+                {t}
+              </text>
+            ))
+          )}
+          <Button label="refresh" onClick={refresh} />
+        </box>
+
+        <box style={s.panel}>
+          <text style={s.heading}>Paste</text>
+          <Button
+            label="read('text')"
+            onClick={paste('text', () => clipboard.read('text'))}
+          />
+          <Button
+            label="readText()"
+            onClick={paste('readText', () => clipboard.readText())}
+          />
+          <Button
+            label="readFiles()"
+            onClick={paste('files', async () =>
+              (await clipboard.readFiles())
+                .map((f) => f.path ?? f.uri)
+                .join('\n'),
+            )}
+          />
+          <Button
+            label="read('image/png')"
+            onClick={paste('png', async () => {
+              const bytes = await clipboard.read('image/png');
+              return bytes ? `${bytes.length} bytes` : null;
+            })}
+          />
+          <text style={s.dim}>{note}</text>
+          <text style={s.mono}>
+            {pasted === null
+              ? ''
+              : pasted.value === null
+                ? `${pasted.label}: (nothing of that kind)`
+                : String(pasted.value).slice(0, 400)}
+          </text>
+        </box>
+      </box>
+    </box>
+  );
+}
+
+function Inspector() {
+  return (
+    <window
+      width={720}
+      height={420}
+      title="react-x11 — clipboard"
+      style={{ backgroundColor: '#f5f6fa' }}
+    >
+      <App />
+    </window>
+  );
+}
+
+export default Inspector;
+
+if (!process.env.REACT_X11_NO_AUTORUN) {
+  const root = await createRoot();
+  root.render(<Inspector />);
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "examples:tasks": "tsx examples/tasks.jsx",
     "examples:tasks:hot": "node --enable-source-maps --import ./examples/hmr-register.mjs examples/tasks-hot.jsx",
     "examples:menu": "tsx examples/menu.jsx",
+    "examples:clipboard": "tsx examples/clipboard.jsx",
     "examples:form": "tsx examples/form.jsx",
     "examples:richtext": "tsx examples/richtext.jsx",
     "examples:widgets": "tsx examples/widgets.jsx",

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -42,6 +42,7 @@ import { paintCacheFor } from './paintcache.js';
 import { hooks as traceHooks } from './trace-registry.js';
 import { runWithPriority, DiscreteEventPriority } from './priority.js';
 import { inputTime } from './inputtime.js';
+import { armPasteState, canPaste } from './pastestate.js';
 import {
   editMenuColors,
   editMenuGeometry,
@@ -2687,10 +2688,7 @@ export class TextInputNode extends Node {
     if (ev.ctrlKey) {
       const letter = ctrlChordLetter(ev);
       if (letter === 0x61 /* a */) {
-        this._anchor = 0;
-        this._caret = this._chars().length;
-        this._breakUndoRun();
-        this._repaint();
+        this._selectAll();
       } else if (letter === 0x63 /* c */) {
         this._copySelection();
       } else if (letter === 0x78 /* x */) {
@@ -2818,6 +2816,18 @@ export class TextInputNode extends Node {
     this._repaint();
   }
 
+  /** Select everything, and take PRIMARY with it. Both ways in — Ctrl+A and
+   * the menu row — come through here: every other selection gesture owns
+   * PRIMARY, and GTK and Qt both do it for select-all too, so a middle-click
+   * paste after Ctrl+A pastes what is on screen rather than whatever was
+   * selected before it. */
+  _selectAll() {
+    this._anchor = 0;
+    this._caret = this._chars().length;
+    this._breakUndoRun();
+    this._ownSelection();
+  }
+
   _ownSelection() {
     this._repaint();
     if (this._caret !== this._anchor) this._copySelection('PRIMARY');
@@ -2873,9 +2883,9 @@ export class TextInputNode extends Node {
         id: 'paste',
         label: 'Paste',
         shortcut: 'Ctrl+V',
-        // whether CLIPBOARD holds anything is an async round trip, so the
-        // row stays live whenever there is a clipboard to ask
-        enabled: Boolean(this._clipboardApi()),
+        // greyed only when the server has told us the selection is unowned
+        // (pastestate.js). Never a round trip on the way to opening a menu.
+        enabled: Boolean(this._clipboardApi()) && canPaste(this.app),
       },
       { separator: true },
       {
@@ -2898,12 +2908,7 @@ export class TextInputNode extends Node {
       this._copySelection();
       if (a !== b) this._deleteRange(a, b);
     } else if (id === 'paste') this._pasteFrom();
-    else if (id === 'selectAll') {
-      this._anchor = 0;
-      this._caret = this._chars().length;
-      this._breakUndoRun();
-      this._repaint();
-    }
+    else if (id === 'selectAll') this._selectAll();
   }
 
   _defaultContextMenu(ev) {
@@ -2935,6 +2940,11 @@ export class TextInputNode extends Node {
 
   _openEditMenu(ev) {
     this._closeEditMenu();
+    // From here on the menu knows whether there is anything to paste. This
+    // first open still shows the row enabled — the answer arrives after it
+    // is drawn — which is the pre-tracking behaviour, and correct far more
+    // often than not.
+    armPasteState(this.app, this._clipboardApi());
     const items = this._editMenuItems();
     const geometry = editMenuGeometry(
       items,

--- a/src/pastestate.js
+++ b/src/pastestate.js
@@ -1,0 +1,66 @@
+// Is there anything to paste? — kept per app, so a menu can answer without
+// a round trip.
+//
+// The honest answer needs the server, and asking for it costs a full
+// conversion against whatever foreign client owns the selection — plus a
+// two second wait when that client is wedged. A menu cannot pay that while
+// it is opening, which is why the built-in edit menu shipped with Paste
+// always enabled.
+//
+// XFixes turns it around: the server says when the selection changes hands,
+// and the answer is a boolean already in hand by the time a menu opens. One
+// registration per app, armed the first time anything asks.
+//
+// Deliberately only "is it owned", not "does it hold text". Refining it
+// would mean a TARGETS round trip per change, which reintroduces the cost
+// this exists to avoid; an owner offering nothing a text field can take is
+// rare enough to leave the row enabled and let the paste do nothing.
+
+const states = new WeakMap();
+
+/**
+ * Start tracking `app`'s CLIPBOARD, once. Safe to call on every menu open —
+ * the second call and the ten thousandth do nothing.
+ */
+export function armPasteState(app, clipboard) {
+  if (!app || !clipboard || states.has(app)) return;
+  // A clipboard without these is an older ntk, or a stand-in someone
+  // supplied. Tracking is the enhancement, not the feature: skip it and
+  // leave the row enabled rather than throwing on the way into a menu.
+  if (
+    typeof clipboard.watch !== 'function' ||
+    typeof clipboard.targets !== 'function'
+  ) {
+    return;
+  }
+  // Unknown means "yes": until the server has said otherwise, behave the way
+  // this did before there was any tracking at all.
+  const state = { owned: true, live: false };
+  states.set(app, state);
+
+  clipboard
+    .watch('CLIPBOARD', (ev) => {
+      state.live = true;
+      state.owned = ev.owner !== 0;
+    })
+    .catch(() => {
+      // No XFixes on this server. Nothing to fall back to that is worth the
+      // latency, so the row stays enabled — which is where it started.
+    });
+
+  // `watch` reports *changes*, so it says nothing about the selection that
+  // was already there when we armed. One question, once per app, off the
+  // menu's path entirely.
+  clipboard
+    .targets({ selection: 'CLIPBOARD' })
+    .then((offered) => {
+      // a change may have overtaken this round trip; it is the fresher answer
+      if (!state.live) state.owned = offered.length > 0;
+    })
+    .catch(() => {});
+}
+
+/** Whether a Paste row should be live. True when nothing is known yet. */
+export function canPaste(app) {
+  return states.get(app)?.owned ?? true;
+}

--- a/test/clipboard.test.js
+++ b/test/clipboard.test.js
@@ -268,3 +268,81 @@ test('watch() reports the clipboard going empty', async () => {
   assert.deepEqual(seen, [1, 0], 'unwatch stops the callbacks');
   await x11Root.unmount();
 });
+
+// --- the edit menu's Paste row ----------------------------------------------
+
+/** A focused `<textinput>` on the mock app, whose clipboard is the working
+ * one — so the Paste row is answering about real ownership. */
+async function mountInput() {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(
+    h(
+      'window',
+      { width: 300, height: 80 },
+      h('textinput', { defaultValue: 'hello' }),
+    ),
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const input = wnd._reactX11Node.children[0];
+  return { app, wnd, input, x11Root };
+}
+
+const pasteRow = (input) =>
+  input._editMenuItems().find((r) => r.id === 'paste');
+
+test('Paste greys out once the server says the clipboard is empty', async () => {
+  const { app, wnd, input, x11Root } = await mountInput();
+  const open = () => wnd.emit('mousedown', { x: 40, y: 10, keycode: 3 });
+
+  // nothing known yet: the row is live, which is where it started
+  assert.equal(pasteRow(input).enabled, true, 'optimistic before tracking');
+
+  open(); // arms the watch
+  await tick();
+  input._closeEditMenu();
+  await tick();
+  assert.equal(
+    pasteRow(input).enabled,
+    false,
+    'seeded from the server: nothing owns CLIPBOARD',
+  );
+
+  await app.clipboard.write('now there is something');
+  assert.equal(pasteRow(input).enabled, true, 'the watch woke it up');
+
+  await app.clipboard.clear();
+  assert.equal(pasteRow(input).enabled, false, 'and put it back');
+  await x11Root.unmount();
+});
+
+test('one watch per app, however many times a menu opens', async () => {
+  const { app, wnd, input, x11Root } = await mountInput();
+  for (let i = 0; i < 5; i++) {
+    wnd.emit('mousedown', { x: 40, y: 10, keycode: 3 });
+    await tick();
+    input._closeEditMenu();
+    await tick();
+  }
+  assert.equal(
+    app.clipboard._watchers.get('CLIPBOARD')?.length,
+    1,
+    'armed once, not once per open',
+  );
+  await x11Root.unmount();
+});
+
+test('a clipboard that cannot be watched leaves Paste alone', async () => {
+  // an older ntk, or a stand-in: tracking is the enhancement, not the
+  // feature, so the row stays live rather than the menu throwing
+  const { app, wnd, input, x11Root } = await mountInput();
+  app.clipboard = {
+    write: () => Promise.resolve(),
+    read: () => Promise.resolve('x'),
+  };
+  wnd.emit('mousedown', { x: 40, y: 10, keycode: 3 });
+  await tick();
+  assert.equal(pasteRow(input).enabled, true);
+  await x11Root.unmount();
+});

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -4457,6 +4457,28 @@ async function mountSelected(props = {}) {
   return { app, wnd, input, writes };
 }
 
+test('textinput: select-all owns PRIMARY, both ways in', async () => {
+  // Every other selection gesture already did; GTK and Qt do it for
+  // select-all too, so a middle-click paste right after Ctrl+A pastes what
+  // is on screen rather than whatever was selected before it.
+  const { writes } = await mountSelected(); // its last act is Ctrl+A
+  assert.deepStrictEqual(
+    writes.at(-1),
+    ['hello world', 'PRIMARY'],
+    'Ctrl+A published the selection',
+  );
+
+  const { input, writes: menuWrites } = await mountSelected();
+  menuWrites.length = 0;
+  input._runEditAction('selectAll');
+  assert.deepStrictEqual(input._selection(), [0, 11]);
+  assert.deepStrictEqual(
+    menuWrites.at(-1),
+    ['hello world', 'PRIMARY'],
+    'the menu row published it too',
+  );
+});
+
 const rightClick = (wnd, x = 40, y = 10) =>
   wnd.emit('mousedown', { x, y, keycode: 3 });
 


### PR DESCRIPTION
The last three items on [#164](https://github.com/sidorares/react-x11/issues/164),
after #167's timestamps and #171's API. **Closes it.**

![paste-greyed](https://github.com/user-attachments/assets/e5342856-5599-48fd-93fe-c5add91c99ed)

Text selected, Cut and Copy live, **Paste greyed** — because nothing owns
CLIPBOARD. Rendered by this PR's own code through the in-process X server.

## §3 — Paste greying

The menu shipped with the row always live, and a comment admitting why:
asking whether CLIPBOARD holds anything is a conversion round trip against
whatever foreign client owns it, plus a two-second wait when that client is
wedged, at exactly the moment a menu should already be on screen.

XFixes turns the question around — the server says when the selection changes
hands, so the answer is a boolean already in hand when the menu opens.
`src/pastestate.js` keeps it, one registration per app, armed the first time
a menu opens.

**Two things the plan in #164 did not account for**, both worth reviewing:

- **`watch()` reports _changes_.** Arming it says nothing about the selection
  that was already there, so it needs a one-time seed — one `targets()` call,
  off the menu's path. Without it the row would have been wrong until someone
  else copied.
- **A clipboard without `watch`/`targets` must not throw into a menu open.**
  An older ntk or a stand-in hits that; four existing suites install exactly
  such a fake, which is how I found it. Tracking is the enhancement, not the
  feature, so it is skipped and the row stays enabled.

Still deliberately only *is it owned*, not *does it hold text* — refining that
means a `TARGETS` round trip per change, which is the cost this exists to
avoid. The stage-2 refinement stays unbuilt until someone reports pasting a
non-text clipboard as confusing.

## §7 — select-all owns PRIMARY

Every other selection gesture did. `Ctrl+A` and the menu row set anchor and
caret directly and skipped it, so a middle-click paste right after Ctrl+A
pasted whatever had been selected *before*. Both now route through one
`_selectAll`. GTK and Qt both do this.

Not a consequence of ntk 5.3 — a conformance gap the audit happened to
surface, which is why it was held out of the earlier PRs.

## §6 — the inspector

![inspector](https://github.com/user-attachments/assets/101b92fa-f603-4adc-85f5-d110b21cec62)

`examples/clipboard.jsx`: copy plain text, HTML + plain text, a PNG, a
uri-list; watch the offered type names update live over `watch()`; paste each
way back. The type list in that shot is real — written by a second ntk client
and read back through `targets()`.

It is also the **manual interop harness** the vocabulary needs. Point it at
gedit, a terminal, Firefox and a file manager and the group table stops being
a claim: a terminal offers `STRING` only, a GTK app leads with
`text/plain;charset=utf-8`, Firefox gives you `text/x-moz-url`. The note in
the shot reading "no XFixes extension" is the in-process server being honest
— it has none, and the example degrades to its refresh button.

Two layout findings from making it render, both commented in the file: an
unbounded status string sets a min-content width the flex column will not
shrink below (so the note is capped), and the columns need `minWidth: 0`.

## Tests

Five new, 408 pass. All mutation-checked — removing the greying fails one,
removing the PRIMARY ownership fails another. The Paste tests use the mock
app's clipboard from #171 rather than a stub, so they exercise real ownership
transitions: seeded empty, a write wakes the row, a clear puts it back.


