### PR TITLE
fix(elements): size <image> and <svg> by style, ink <tex> by style

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -24,8 +24,8 @@ blocks and `createStyles`.
 Numbers are pixels, strings like `'50%'` / `'auto'` pass through to yoga.
 
 - **Size**: `width`, `height`, `minWidth`, `minHeight`, `maxWidth`,
-  `maxHeight`, `aspectRatio`. `<image>` keeps its aspect ratio when only one
-  of `width`/`height` is given
+  `maxHeight`, `aspectRatio`. `<image>` and `<svg>` keep their aspect ratio
+  when only one of `width`/`height` is given
 - **Flex**: `flexDirection` (`row`, `column`, `row-reverse`,
   `column-reverse`), `justifyContent` (`flex-start`, `center`, `flex-end`,
   `space-between`, `space-around`, `space-evenly`), `alignItems`,
@@ -539,8 +539,14 @@ scrolls too).
 | ----- | ----------------------------------- |
 | `src` | file path (PNG/JPEG, decoded in JS) |
 
-Sized by style, or measured from the natural size (aspect-preserving
-shrink-to-width) when `width`/`height` are not both given.
+Sized by style — `style={{ width, height }}`, never flat props, since both
+are style names. With only one of the two set the other follows the natural
+aspect ratio; with neither, the image measures at its natural size, shrunk
+to the width on offer.
+
+```jsx
+<image src={photo} style={{ height: 64 }} /> // width follows the aspect ratio
+```
 
 ## `<canvas>`
 
@@ -816,9 +822,10 @@ ntk `HtmlView`: its own CSS cascade (document `<style>`s plus the
 ### `<svg>`
 
 ntk `SvgView` (static SVG via Path2D — paths, shapes, gradients,
-transforms, basic text). Sized like `<image>`: natural `viewBox` size,
-aspect-preserving shrink-to-width, or explicit `width`/`height` (the
-drawing scales to the content box).
+transforms, basic text). Sized like `<image>`, and by the same style
+properties: natural `viewBox` size, aspect-preserving when the style sets
+only one of `style={{ width, height }}`, and scaled into the content box
+when it sets both.
 
 Content is **JSX children, like SVG in React DOM** — SVG elements are
 declarative children with camelCase props (`strokeWidth`, `fillRule`;
@@ -876,6 +883,8 @@ wrapping), drawn as server-side glyphs/rects.
 | children      | TeX source (string), or use `source`    |
 | `source`      | TeX source                              |
 | `size`        | base font size (the formula em), px     |
-| `color`       | ink color (default `#222222`)           |
 | `displayMode` | KaTeX display mode (default `false`)    |
 | `katex`       | extra KaTeX options (macros, strict, …) |
+
+The ink colour is `style={{ color }}` (default `#222222`), like `<text>` —
+`color` is a style name, so it is not a prop here.

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -67,7 +67,10 @@ try {
   // bundled, or installed somewhere without the manifest beside us
 }
 
-const HOST_TYPES = [
+// The vocabulary, in the order the unknown-element error lists it. Exported
+// so a test can sweep every element rather than a list of them that was
+// true once (test/element-props.test.js).
+export const HOST_TYPES = [
   'window',
   'popup',
   'box',

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -1580,38 +1580,60 @@ export class TextNode extends Node {
   }
 }
 
+/**
+ * The measure function the intrinsically-sized elements share — the ones
+ * with a natural width and height that scale together (`<image>`, `<svg>`).
+ * `natural()` returns that size; it is called per measure because it
+ * arrives late (a decoded file, a parsed document).
+ *
+ * **Which dimensions the style fixed is something yoga already knows**, and
+ * says in the measure modes: `EXACTLY` on an axis means the style made it
+ * definite. Working it out a second time by reading style back would be
+ * duplication; working it out by reading *props* was issue #118 — `width`
+ * is a style name, so `<image width={40}>` throws in development and only
+ * ever reached this branch in production.
+ *
+ * - Both fixed: yoga skips the measure function outright, so there is no
+ *   fixed-size case to write here.
+ * - Height fixed alone: scale the width with it, the way an `<img>` with
+ *   only a height set does, rather than stretching to the container.
+ * - Otherwise: natural size, shrunk to the width on offer, height
+ *   following the aspect ratio.
+ */
+export function intrinsicMeasure(natural) {
+  return (width, widthMode, height, heightMode) => {
+    const { width: natW, height: natH } = natural();
+    if (
+      heightMode === Yoga.MEASURE_MODE_EXACTLY &&
+      widthMode !== Yoga.MEASURE_MODE_EXACTLY &&
+      natH > 0
+    ) {
+      return { width: (height * natW) / natH, height };
+    }
+    let w = natW;
+    if (
+      widthMode !== Yoga.MEASURE_MODE_UNDEFINED &&
+      Number.isFinite(width) &&
+      width < w
+    ) {
+      w = width;
+    }
+    return { width: w, height: natW > 0 ? (w * natH) / natW : natH };
+  };
+}
+
 export class ImageNode extends Node {
   constructor(props, app) {
     super('image', props, app);
     this.image = null;
     this._loadToken = 0;
-    this._configureMeasure();
+    this.yoga.setMeasureFunc(
+      intrinsicMeasure(() => ({
+        width: this.image?.width ?? 0,
+        height: this.image?.height ?? 0,
+      })),
+    );
     this._load(props.src);
-  }
-
-  _configureMeasure() {
-    const fixed = this.props.width != null && this.props.height != null;
-    if (fixed) {
-      this.yoga.unsetMeasureFunc();
-      return;
-    }
-    this.yoga.setMeasureFunc((width, widthMode, height, heightMode) => {
-      const natW = this.image?.width ?? 0;
-      const natH = this.image?.height ?? 0;
-      // a height alone should scale the width with it, the way an <img>
-      // with only a height set does — not stretch to the container
-      if (
-        this.props.width == null &&
-        this.props.height != null &&
-        heightMode !== Yoga.MEASURE_MODE_UNDEFINED &&
-        natH > 0
-      ) {
-        return { width: (height * natW) / natH, height };
-      }
-      let w = natW;
-      if (widthMode !== Yoga.MEASURE_MODE_UNDEFINED && width < w) w = width;
-      return { width: w, height: natW > 0 ? (w * natH) / natW : natH };
-    });
   }
 
   async _load(src) {
@@ -1634,7 +1656,6 @@ export class ImageNode extends Node {
   applyProps(newProps, oldProps) {
     const before = oldProps ?? this.props;
     super.applyProps(newProps, oldProps);
-    this._configureMeasure();
     if (newProps.src !== before.src) {
       this.image = null;
       this._load(newProps.src);

--- a/src/richnodes.js
+++ b/src/richnodes.js
@@ -5,7 +5,7 @@
 // through the widget's `onInvalidate` hook (ntk >= 3.4.0).
 import { MarkdownView, HtmlView, SvgView, layoutTex } from 'ntk';
 
-import { Node } from './nodes.js';
+import { Node, intrinsicMeasure } from './nodes.js';
 import {
   Yoga,
   isLayoutProp,
@@ -283,23 +283,29 @@ export class SvgChildNode extends Node {
  * <svg>: ntk SvgView. Content is either JSX children (React-DOM style —
  * <svg viewBox="0 0 24 24"><circle cx={12} … />; children win when both
  * are present) or a `source` markup string. Sized like <image>: natural
- * (viewBox) size, kept to its aspect ratio when only the width is
- * constrained; scales to the content box.
+ * (viewBox) size, kept to its aspect ratio when the style constrains only
+ * one axis; scales to the content box.
  */
 export class SvgNode extends Node {
   constructor(props, app) {
     super('svg', props, app);
     this.view = null;
     this._stale = true;
-    this._configureMeasure();
+    this.yoga.setMeasureFunc(
+      intrinsicMeasure(() => {
+        const view = this._ensureView();
+        return {
+          width: view?.naturalWidth ?? 0,
+          height: view?.naturalHeight ?? 0,
+        };
+      }),
+    );
   }
 
   /** Any change to the svg subtree (props, children, text) lands here. */
   _textContentChanged() {
     this._stale = true;
-    // markDirty is only legal on nodes with a measure function (it is
-    // unset when width and height are both fixed)
-    if (this._hasMeasure) this.yoga?.markDirty();
+    this.yoga?.markDirty();
     this.root?.invalidate(true, null, 'props');
   }
 
@@ -347,32 +353,8 @@ export class SvgNode extends Node {
     return this.view;
   }
 
-  _configureMeasure() {
-    if (this.props.width != null && this.props.height != null) {
-      if (this._hasMeasure) this.yoga.unsetMeasureFunc();
-      this._hasMeasure = false;
-      return;
-    }
-    this._hasMeasure = true;
-    this.yoga.setMeasureFunc((width, widthMode) => {
-      const view = this._ensureView();
-      const natW = view?.naturalWidth ?? 0;
-      const natH = view?.naturalHeight ?? 0;
-      let w = natW;
-      if (
-        widthMode !== Yoga.MEASURE_MODE_UNDEFINED &&
-        Number.isFinite(width) &&
-        width < w
-      ) {
-        w = width;
-      }
-      return { width: w, height: natW > 0 ? (w * natH) / natW : natH };
-    });
-  }
-
   applyProps(newProps, oldProps) {
     super.applyProps(newProps, oldProps);
-    this._configureMeasure();
     // attributes live in props (children form) or in `source`; either way
     // the SvgView is cheap to rebuild on the next measure/paint
     this._textContentChanged();
@@ -456,10 +438,19 @@ export class SvgNode extends Node {
   }
 }
 
+// Darker than the default text ink: a formula reads as a figure, not as a
+// run of prose.
+const DEFAULT_TEX_COLOR = '#222222';
+
 /**
- * <tex source displayMode size color>: a KaTeX formula via ntk layoutTex.
+ * <tex source displayMode size>: a KaTeX formula via ntk layoutTex.
  * Layout is synchronous and headless; the box has an intrinsic size (no
  * wrapping). Invalid TeX renders nothing and logs once.
+ *
+ * The ink colour is `style={{ color }}`, not a prop — `color` is a style
+ * name, so a `color` prop threw in development and only worked in
+ * production (issue #118). `_paintContent` and `paintCachePlan` already
+ * read it off the style; the prop reached nothing but layoutTex.
  */
 export class TexNode extends Node {
   constructor(props, app) {
@@ -481,7 +472,8 @@ export class TexNode extends Node {
   }
 
   _ensureBox() {
-    const { size, color, displayMode, katex } = this.props;
+    const { size, displayMode, katex } = this.props;
+    const color = this.style.color ?? DEFAULT_TEX_COLOR;
     const source = stringChildrenOf(this) ?? this.props.source;
     if (!source) return null;
     const key = `${source}|${size}|${color}|${displayMode}`;
@@ -504,10 +496,11 @@ export class TexNode extends Node {
   applyProps(newProps, oldProps) {
     const before = oldProps ?? this.props;
     super.applyProps(newProps, oldProps);
+    // A colour change is not in here: it cannot move the box, and the
+    // repaint it does need is already claimed for it as a paint style.
     if (
       newProps.source !== before.source ||
       newProps.size !== before.size ||
-      newProps.color !== before.color ||
       newProps.displayMode !== before.displayMode
     ) {
       this.yoga.markDirty();
@@ -521,7 +514,7 @@ export class TexNode extends Node {
     // it needs a real ntk 2d context (headless mock contexts skip)
     if (!box || !ctx.window?.app?.display) return;
     const content = this.contentBox();
-    ctx.fillStyle = this.style.color ?? '#222222';
+    ctx.fillStyle = this.style.color ?? DEFAULT_TEX_COLOR;
     box.draw(ctx, content.x, content.y);
   }
 
@@ -537,7 +530,9 @@ export class TexNode extends Node {
    * The colour is in the key rather than tinted, because a TexBox draws
    * through glyph and trapezoid composites whose colour is the context's
    * fill at draw time; rendering it as coverage would need the box to promise
-   * it never sets a colour of its own, which it does not.
+   * it never sets a colour of its own, which it does not. `_boxKey` carries
+   * it — the colour is a style value, and that is where `_ensureBox` reads
+   * it from.
    */
   paintCachePlan() {
     const box = this._ensureBox();
@@ -547,7 +542,7 @@ export class TexNode extends Node {
     const height = Math.ceil(content.height);
     if (width <= 0 || height <= 0) return null;
     return {
-      key: `tex|${width}x${height}@1|${this.style.color ?? ''}|${this._boxKey}`,
+      key: `tex|${width}x${height}@1|${this._boxKey}`,
       x: Math.round(content.x),
       y: Math.round(content.y),
       width,
@@ -560,7 +555,7 @@ export class TexNode extends Node {
   paintCached(ctx, box) {
     const laid = this._ensureBox();
     if (!laid || !ctx.window?.app?.display) return;
-    ctx.fillStyle = this.style.color ?? '#222222';
+    ctx.fillStyle = this.style.color ?? DEFAULT_TEX_COLOR;
     laid.draw(ctx, box.x, box.y);
   }
 }

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -267,6 +267,8 @@ export interface ImageProps extends DrawnProps<DrawnNode> {
   /** File path; PNG or JPEG, decoded in JS. */
   src: string;
 }
+// Size is `style={{ width, height }}`, like every other element: `width`
+// and `height` are style names, so they are not declared here.
 
 /** What `onDraw` is told about the node it is painting. */
 export interface DrawInfo {
@@ -321,11 +323,12 @@ export interface SvgProps extends DrawnProps<DrawnNode> {
   viewBox?: string;
 }
 
+// The ink colour is `style={{ color }}`: `color` is a style name, so it is
+// not a prop here.
 export interface TexProps extends DrawnProps<DrawnNode> {
   source?: string;
   /** Base font size — the formula's em, in px. */
   size?: number;
-  color?: Color;
 }
 
 // --- GL --------------------------------------------------------------------

--- a/test/element-props.test.js
+++ b/test/element-props.test.js
@@ -1,0 +1,321 @@
+// Element props against the style vocabulary. The house rule is that a name
+// is either style or an element's own semantics and never both, which is
+// what keeps `<window width>` unambiguous — and the DEV assertion that
+// enforces it (`assertNoFlatStyleProps`) is the only thing standing between
+// a developer and a silently-dropped prop.
+//
+// Issue #118: three elements read `this.props.width` / `this.props.height` /
+// `this.props.color` without claiming those names, so the branch was
+// unreachable in development (it threw) and reachable in production (it
+// worked) — the same JSX crashing in dev and rendering in prod. The sweep
+// below is what would have caught it for free: construct every element with
+// every style name flat, and check the outcome against what the element
+// says it claims.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import React from 'react';
+
+import { createRoot } from '../src/index.js';
+import { HOST_TYPES } from '../src/Reconciler.js';
+import {
+  BoxNode,
+  ScrollViewNode,
+  TextNode,
+  TextInputNode,
+  TextAreaNode,
+  ImageNode,
+  CanvasNode,
+  WindowNode,
+  PopupNode,
+} from '../src/nodes.js';
+import { MarkdownNode, HtmlNode, SvgNode, TexNode } from '../src/richnodes.js';
+import { GlAreaNode } from '../src/glnodes.js';
+import { isStyleProp } from '../src/styles.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+// One constructor per host element. Window nodes take (app, attributes,
+// props); drawn nodes take (props, app).
+const BUILD = {
+  window: (app, props) => new WindowNode(app, {}, props),
+  popup: (app, props) => new PopupNode(app, {}, props),
+  box: (app, props) => new BoxNode(props, app),
+  scrollview: (app, props) => new ScrollViewNode(props, app),
+  text: (app, props) => new TextNode(props, app, { span: false }),
+  textinput: (app, props) => new TextInputNode(props, app),
+  textarea: (app, props) => new TextAreaNode(props, app),
+  image: (app, props) => new ImageNode(props, app),
+  canvas: (app, props) => new CanvasNode(props, app),
+  markdown: (app, props) => new MarkdownNode(props, app),
+  html: (app, props) => new HtmlNode(props, app),
+  svg: (app, props) => new SvgNode(props, app),
+  tex: (app, props) => new TexNode(props, app),
+  glarea: (app, props) => new GlAreaNode(props, app),
+};
+
+// A spread of the style vocabulary: one from each family, plus every name an
+// element has actually wanted for itself. Checked against `isStyleProp`
+// below, so a name that stops being style fails here rather than quietly
+// testing nothing.
+const STYLE_NAMES = [
+  'width',
+  'height',
+  'minWidth',
+  'minHeight',
+  'maxWidth',
+  'maxHeight',
+  'aspectRatio',
+  'flexGrow',
+  'position',
+  'top',
+  'left',
+  'margin',
+  'padding',
+  'gap',
+  'display',
+  'overflow',
+  'backgroundColor',
+  'borderColor',
+  'borderRadius',
+  'borderWidth',
+  'borderStyle',
+  'zIndex',
+  'color',
+  'fontSize',
+  'fontFamily',
+  'textAlign',
+  'lineHeight',
+  'cursor',
+  'pointerEvents',
+  'transition',
+];
+
+// A `<popup>` is a WindowNode, so it reports itself as `window` — its
+// geometry props are the X window's for the same reason.
+const WINDOW_LIKE = new Set(['window', 'popup']);
+
+test('the element list here is the whole element list', () => {
+  // HOST_TYPES is what the reconciler's switch and the unknown-element error
+  // are both built from, so a new element has to be added to BUILD too —
+  // which is what makes the sweep below a net rather than a snapshot of what
+  // existed the day it was written.
+  assert.deepStrictEqual(
+    HOST_TYPES.filter((kind) => !BUILD[kind]),
+    [],
+    'every host element needs a line in BUILD',
+  );
+  assert.deepStrictEqual(
+    Object.keys(BUILD).filter((kind) => !HOST_TYPES.includes(kind)),
+    [],
+    'and BUILD has no elements of its own',
+  );
+});
+
+test('a style name is style on every element that does not claim it', () => {
+  const app = createMockApp();
+  for (const kind of HOST_TYPES) {
+    const build = BUILD[kind];
+    const node = build(app, {});
+    const semantic = node.semanticNames;
+    for (const name of STYLE_NAMES) {
+      assert.ok(isStyleProp(name), `${name} is a style property`);
+      const attempt = () => build(app, { [name]: 1 });
+      if (semantic.has(name)) {
+        // claimed: it is this element's own vocabulary and must go through
+        assert.doesNotThrow(attempt, `<${kind} ${name}> is semantic`);
+      } else {
+        assert.throws(
+          attempt,
+          new RegExp(`<${node.kind} ${name}=…> is a style property`),
+          `<${kind} ${name}> should say to pass it in style`,
+        );
+      }
+    }
+  }
+});
+
+// The declarations are the list of props an element documents, so they are
+// the other half of the check: a declared prop that is also a style name has
+// to be one the element claims, or writing it throws in development and
+// works in production. `<tex color>` was declared, read, and claimed by
+// nobody — the exact shape.
+function declaredProps() {
+  const src = readFileSync(
+    new URL('../src/types/elements.d.ts', import.meta.url),
+    'utf8',
+  );
+  const interfaces = new Map();
+  for (const m of src.matchAll(
+    /export interface (\w+)([^{]*)\{([\s\S]*?)\n\}/g,
+  )) {
+    interfaces.set(m[1], {
+      extends: [...m[2].matchAll(/\b([A-Z]\w*Props)\b/g)].map((x) => x[1]),
+      own: [
+        ...m[3].matchAll(/^ {2}(?:readonly )?([A-Za-z_]\w*)\??\s*[:(]/gm),
+      ].map((x) => x[1]),
+    });
+  }
+  const all = (name, seen = new Set()) => {
+    if (seen.has(name) || !interfaces.has(name)) return [];
+    seen.add(name);
+    const face = interfaces.get(name);
+    return face.own.concat(...face.extends.map((p) => all(p, seen)));
+  };
+  const byKind = new Map();
+  const map = src.match(
+    /export interface ReactX11Elements \{([\s\S]*?)\n\}/,
+  )[1];
+  for (const m of map.matchAll(/^ {2}([a-zA-Z]\w*): (\w+);/gm)) {
+    byKind.set(m[1], all(m[2]));
+  }
+  return byKind;
+}
+
+test('a declared prop that is also a style name is one the element claims', () => {
+  const app = createMockApp();
+  const declared = declaredProps();
+  assert.ok(
+    declared.get('window')?.includes('width'),
+    'the declarations parsed at all',
+  );
+  for (const kind of HOST_TYPES) {
+    const semantic = BUILD[kind](app, {}).semanticNames;
+    const unclaimed = (declared.get(kind) ?? [])
+      .filter(isStyleProp)
+      .filter((name) => !semantic.has(name));
+    assert.deepStrictEqual(
+      unclaimed,
+      [],
+      `<${kind}> declares ${unclaimed.join(', ')}, which JSX cannot pass flat`,
+    );
+  }
+});
+
+test('only the window elements claim style names as their own props', () => {
+  // Issue #118 had two possible resolutions, and this pins the one taken:
+  // `<image>`, `<svg>` and `<tex>` are sized and coloured by style like
+  // everything else, rather than growing `semanticNames` of their own. A
+  // window is the exception because its `width` is the X window's, which
+  // yoga has no say in.
+  const app = createMockApp();
+  for (const kind of HOST_TYPES) {
+    const claimed = [...BUILD[kind](app, {}).semanticNames].filter(isStyleProp);
+    if (WINDOW_LIKE.has(kind)) {
+      assert.deepStrictEqual(
+        claimed.sort(),
+        ['height', 'maxHeight', 'maxWidth', 'minHeight', 'minWidth', 'width'],
+        `<${kind}> owns its geometry and the hints that constrain it`,
+      );
+    } else {
+      assert.deepStrictEqual(claimed, [], `<${kind}> claims no style name`);
+    }
+  }
+});
+
+// --- what the style now drives ---------------------------------------------
+//
+// Sizing used to be read off props, so with the props unreachable the
+// aspect-ratio behaviour documented for `<image>` never ran at all. It runs
+// off the measure modes now, which is yoga answering the same question.
+
+const laidOut = async (element) => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(h('window', { width: 200, height: 200 }, element));
+  await tick();
+  return app.windows[0]._reactX11Node.children[0];
+};
+
+// The decode is async and wants a real file; the natural size is all the
+// measure function reads, so hand it over the way `_load` does.
+const decoded = async (node, image) => {
+  node.image = image;
+  node.yoga.markDirty();
+  node.root.invalidate(true, null, 'content');
+  await tick();
+  return node;
+};
+
+test('<image> takes its aspect ratio from a style height', async () => {
+  const node = await laidOut(
+    h('image', { style: { height: 20, alignSelf: 'flex-start' } }),
+  );
+  await decoded(node, { width: 200, height: 50 });
+  assert.deepStrictEqual(
+    [node.abs.width, node.abs.height],
+    [80, 20],
+    'a 4:1 image 20 tall is 80 wide, not stretched to the window',
+  );
+});
+
+test('<image> shrinks to the width on offer, keeping its ratio', async () => {
+  const node = await laidOut(
+    h('image', { style: { alignSelf: 'flex-start' } }),
+  );
+  await decoded(node, { width: 400, height: 100 });
+  assert.deepStrictEqual(
+    [node.abs.width, node.abs.height],
+    [200, 50],
+    'a 400x100 image in a 200-wide window is 200x50',
+  );
+});
+
+test('<svg> is sized like <image>, off the same style names', async () => {
+  const source =
+    '<svg viewBox="0 0 40 10"><rect width="40" height="10"/></svg>';
+  const natural = await laidOut(
+    h('svg', { source, style: { alignSelf: 'flex-start' } }),
+  );
+  assert.deepStrictEqual(
+    [natural.abs.width, natural.abs.height],
+    [40, 10],
+    'the viewBox is the natural size',
+  );
+
+  const byHeight = await laidOut(
+    h('svg', { source, style: { height: 20, alignSelf: 'flex-start' } }),
+  );
+  assert.deepStrictEqual(
+    [byHeight.abs.width, byHeight.abs.height],
+    [80, 20],
+    'a style height scales the width with it',
+  );
+
+  const both = await laidOut(
+    h('svg', { source, style: { width: 30, height: 30 } }),
+  );
+  assert.deepStrictEqual(
+    [both.abs.width, both.abs.height],
+    [30, 30],
+    'both set wins outright — the drawing scales into the box',
+  );
+});
+
+test('<svg> content still reflows when both dimensions are fixed', async () => {
+  // The measure function used to be unset in this case, which made
+  // `markDirty()` illegal and cost the node its own bookkeeping flag.
+  const node = await laidOut(
+    h('svg', {
+      source: '<svg viewBox="0 0 10 10"><rect width="10" height="10"/></svg>',
+      style: { width: 24, height: 24 },
+    }),
+  );
+  assert.doesNotThrow(() => node._textContentChanged());
+  node.root._scheduled = false;
+  node.root.flush();
+  assert.deepStrictEqual([node.abs.width, node.abs.height], [24, 24]);
+});
+
+test('<tex> takes its ink colour from the style', () => {
+  const app = createMockApp();
+  const node = new TexNode({ source: 'x^2', size: 12 }, app);
+  node._syncStyle({ source: 'x^2', style: { color: '#ff0000' } });
+  node._ensureBox();
+  assert.match(node._boxKey, /#ff0000/, 'the layout is keyed on the style');
+  const plain = new TexNode({ source: 'x^2', size: 12 }, app);
+  plain._ensureBox();
+  assert.match(plain._boxKey, /#222222/, 'and defaults without one');
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -182,7 +182,7 @@ function Elements() {
       <markdown source="# hi" onLink={(href) => void href.length} />
       <html source="<p>hi</p>" stylesheet="p { margin: 0 }" />
       <svg source="<svg/>" />
-      <tex source="e^{i\\pi}" size={18} color="#222" />
+      <tex source="e^{i\\pi}" size={18} style={{ color: '#222' }} />
     </window>
   );
 }
@@ -222,6 +222,14 @@ const _div = <div />;
 const _img = <img />;
 // @ts-expect-error — <box> has no 'className'
 const _classy = <box className="nope" />;
+// Size is style everywhere except <window>, so the elements that measure
+// themselves do not get to take it flat either (issue #118).
+// @ts-expect-error — <image> is sized by style, not by a width prop
+const _sized = <image src="./logo.png" width={40} />;
+// @ts-expect-error — nor is <svg>
+const _svg = <svg source="<svg/>" height={40} />;
+// @ts-expect-error — <tex> ink colour is style={{ color }}
+const _inked = <tex source="x^2" color="#222" />;
 
 // --- popups ----------------------------------------------------------------
 


### PR DESCRIPTION
Closes #118.

`ImageNode` and `SvgNode` configured their yoga measure function off `this.props.width` and `this.props.height`; `TexNode` laid its formula out in `this.props.color`. All three are style names, so the DEV assertion that keeps style out of flat props threw on exactly those props — the branches were unreachable in development and reachable only in production, where they silently worked. The same JSX crashed in dev and rendered in prod.

## Which resolution

The issue offered two. This is **A**, the one consistent with the rule at `src/nodes.js` that no element has a name meaning both style and semantics: `<box width>` is style, so `<image width>` is too. Nothing grows `semanticNames`; `<window>` stays the only element that owns a style name, because its `width` is the X window's and yoga has no say in it.

The aspect-ratio behaviour the issue expected to lose survives, because yoga already knows which axes the style made definite and says so in the measure modes. `MEASURE_MODE_EXACTLY` on an axis **is** "the style fixed this", so reading the style back would be the same question answered twice. Both dimensions exactly means yoga skips the measure function entirely, so there is no fixed-size case left to write — `_configureMeasure` goes away, and with it the flag `SvgNode` kept to remember whether its measure function was currently set.

## What visibly changes

The documented behaviour now runs for the first time. An `<image>` or `<svg>` given only a style height scales its width with it instead of stretching to whatever the row offered. `examples/richtext.jsx` is the case in the tree — a 1000x870 photo, `style={{ height: 64 }}`, drawn 536x64 before and 74x64 now, which is what the comment written above it always claimed.

Rendered by this branch, before on top:

![image-aspect](https://github.com/user-attachments/assets/26c24598-e9bd-497a-9b86-bd0a311b36ab)

`<svg>` gains the same behaviour, which it did not have in either direction before: a style height used to leave it at its natural width and squash the drawing. Every `<svg>` in `examples/` and `website/src/demos/` sets both axes, so nothing there moves.

`<tex>` takes its ink from `style.color`. `_paintContent` and `paintCachePlan` were reading it there already; the prop reached nothing but the KaTeX layout call, and only in production.

## The net

`test/element-props.test.js`, which is the test the issue asked for:

- every element constructed with every style name passed flat, and the outcome checked against what that element claims — so a future element whose vocabulary overlaps the style vocabulary is caught by construction;
- the same check driven from `src/types/elements.d.ts`, since a declared prop is what a developer will write. That half is what would have caught `<tex color>`, which was declared, read, and claimed by nobody;
- a pin on the resolution above, so switching to option B is a deliberate edit to a test rather than a quiet one;
- and the sizing itself, in both directions plus the shrink-to-width default.

Reverting `src/nodes.js` and `src/richnodes.js` fails three of them; reverting only the declarations fails the fourth.

`HOST_TYPES` is exported from `src/Reconciler.js` so the sweep runs over the real element list rather than a copy of it that was true once.

## Checks

`npm test` 417 passing, `npm run lint`, `npm run typecheck`, and `npm test` in `website/` — bundle, all 10 demos, share links.

