### PR TITLE
feat(desktop): tell the launcher the app has started

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,48 @@ auto-repeat and neither ntk nor node-x11 implements XKB's
 series of taps and `:active` would strobe at the repeat rate. It needs the
 XKB extension upstream first.
 
+## Decide it, then leave a way out
+
+A feature ships with a **default that serves the main customer out of the
+box** — no configuration, no decision asked of someone who has not got the
+context to make it — and **a seam for everyone else**. Both halves, always:
+a default with no override strands the edge case, and an override with no
+default makes every app answer a question most of them do not have.
+
+The main customer is whoever will hit this most, not whoever is loudest in
+the issue. Work out what they would pick if they knew everything you know,
+make that the behaviour with no arguments, and write down why in the place
+the default lives.
+
+The seam is not ceremonial and it is not a boolean by reflex. Give it the
+shape of the real disagreement:
+
+- A **config value** when the answer is a fact about the app — an id, a
+  timeout, a name it is known by.
+- An **enumerated choice** when there are a few defensible answers and the
+  cost of a wrong one is only that it fits badly.
+  `startupNotification.completeOn` is `'paint' | 'map' | 'manual'` because
+  those are the three honest moments an app can call itself started.
+- A **hook** when the answer is code we cannot write — `notifyStartupComplete()`
+  exists for an app that is up only when it says so.
+- An **off switch** when a whole feature can be someone else's job. Every
+  feature core turns on for you needs one, because sooner or later an
+  embedder owns the thing we assumed was ours.
+
+Two failure modes to watch for, both of which read as thoughtfulness:
+
+- **A default that is only a guess with an escape hatch bolted on.** If the
+  documentation for the default is "or set this to the other thing", the
+  decision has not been made — it has been forwarded.
+- **A seam nobody can reach.** An override that needs internal state, or
+  fires before the app can install it, is not an override. If the honest
+  signal is internal — "the first flush that painted" — the seam has to be
+  in core, next to the signal, rather than approximated from outside.
+
+And a default that turns something _on_ still owes the same discipline as
+one that turns something off: state what it does, what it costs, and how to
+stop it, in one place — see docs/desktop.md for the worked example.
+
 ## Commands
 
 - `npm test` — node:test. **Headless: no X server needed.** Primary feedback

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,10 @@
 - [testing.md](testing.md) — `react-x11/test`: render, query, drive and
   assert on real pixels, against a real X server in your test process. No
   display, no xvfb.
+- [desktop.md](desktop.md) — what an app tells the desktop about itself
+  beyond drawing. Startup notification: why the launcher's busy cursor spins
+  for 15 seconds without it, when an app counts as "started", and the seams
+  for saying otherwise.
 - [remote.md](remote.md) — the flagship case: running the app on one
   machine and drawing to a display on another. `ssh -X` vs `-Y`, what the
   protocol costs on a link, the other X servers, and why Xwayland works

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -1,0 +1,141 @@
+# Desktop integration
+
+What an app has to tell the desktop about itself, beyond drawing. Today that
+is startup notification; it is on by default and there is nothing to call.
+
+## Startup notification
+
+When a launcher spawns an app it opens a **startup sequence** — that is what
+the busy cursor is — and closes it when the app says it is up. An app that
+never says so leaves the sequence running until the desktop gives up on it:
+mutter's `STARTUP_TIMEOUT_MS` is 15 seconds, long after the window is on
+screen and being clicked. The mutter source is blunt about what that looks
+like, in a comment on the constant itself: people assume the launch failed
+and start it again.
+
+Two other things ride on the same handshake:
+
+- **Focus.** `_NET_WM_USER_TIME` is the evidence focus-stealing prevention
+  weighs when deciding whether a new window may come to the front. With
+  none, a strict desktop opens the window behind whatever the user was
+  doing — correctly, from its point of view, since nothing said a user asked
+  for this.
+- **Placement.** The sequence records which workspace the launch happened
+  on. Without one the window goes wherever new windows go.
+
+react-x11 does all of it with no configuration:
+
+```jsx
+const root = await createRoot(); // that is the whole of it
+```
+
+`DESKTOP_STARTUP_ID` is read from the environment and **removed from it**.
+That is deliberate and it matters: the variable names one launch, so a child
+process that inherits it would claim a sequence that is not its own and end
+it early — the parent's cursor stops when the child starts. Every toolkit
+that gets this wrong produces that same bug.
+
+With no id in the environment — a terminal, CI, XQuartz — nothing is set and
+nothing is sent.
+
+### When is an app "started"?
+
+The default is **the first frame that actually painted**.
+
+GTK ends the sequence when the toplevel maps, and copying that here would be
+subtly wrong. This renderer does not paint on map: `invalidate()` schedules
+through the frame clock and the drawing lands in `flush()` a frame later. So
+a mapped window is an empty rectangle, and stopping the busy cursor there is
+compliant and dishonest — it says "ready" over a blank window.
+
+A suspense fallback counts as painted, and should. If the first frame is a
+spinner because the tree is waiting on data, that is exactly the right
+moment to stop the _system's_ spinner: the app is up and is telling the user
+what it is doing. There is no signal for "finished loading", and guessing at
+one is how this ends back at fifteen seconds.
+
+`completeOn` is there for apps the default does not suit:
+
+```jsx
+await createRoot({ startupNotification: { completeOn: 'map' } });
+```
+
+| `completeOn` |                                                         |
+| ------------ | ------------------------------------------------------- |
+| `'paint'`    | the first frame that drew (default)                     |
+| `'map'`      | the first toplevel mapping — earlier, and what GTK does |
+| `'manual'`   | nothing automatic; call `notifyStartupComplete()`       |
+
+`'map'` suits an app whose first frame is expensive enough that it would
+rather the cursor stopped before it. `'manual'` suits one that is not up
+until it says so — restoring a session behind a splash, say:
+
+```jsx
+import { notifyStartupComplete } from 'react-x11';
+
+await createRoot({ startupNotification: { completeOn: 'manual' } });
+await restoreSession();
+notifyStartupComplete(); // idempotent, and a no-op if there is no sequence
+```
+
+**A backstop ends the sequence regardless**, ten seconds after the window
+maps, whichever mode is in force. An app that never paints, or that forgets
+to call, cannot leave the cursor spinning — which would be this feature
+reproducing the bug it exists to fix. Ten is chosen to beat mutter's fifteen
+by a margin while being far longer than any honest first frame.
+
+### Turning it off, and supplying an id
+
+```jsx
+await createRoot({ startupNotification: false });
+await createRoot({ startupNotification: 'launcher/app/1-0_TIME9876' });
+```
+
+`false` is for an app that runs its own sequence, or an embedder that owns
+the toplevel. Note that opting out leaves `DESKTOP_STARTUP_ID` in the
+environment — if you are managing the sequence yourself, the id is yours to
+read and yours to clear.
+
+A string supplies the id for a launch where it did not arrive in the
+environment. A D-Bus-activated app gets it in `platform_data` instead.
+
+### `launchTimestamp()`
+
+```jsx
+import { launchTimestamp } from 'react-x11';
+
+const when = launchTimestamp(); // number | null
+```
+
+The X server timestamp of the user action that launched the app, parsed from
+the id's `_TIME` suffix. **`null` is a real answer**, not a failure: an app
+started from a shell has no launch timestamp and never will.
+
+It is the "when" that any later request to come forward is weighed against.
+Do not substitute `0` for a missing one — EWMH gives zero its own meaning,
+"do not focus this window when it maps".
+
+### On macOS
+
+quartz-wm implements none of this, so on XQuartz the messages go to a root
+window nobody is listening at and `_NET_WM_USER_TIME` is ignored. Harmless,
+and worth knowing before concluding from a Mac that the feature is broken.
+
+### What is deliberately not here
+
+- **The launcher half.** An app that spawns _another_ app should generate an
+  id, send `new:`, put `DESKTOP_STARTUP_ID` in the child's environment and
+  close the sequence itself. Same encoder, different persona.
+- **Ongoing `_NET_WM_USER_TIME` maintenance.** Setting it once at launch is
+  this. Keeping it current on every keypress is a separate design with a
+  real cost — EWMH is explicit that storing a frequently-changing property
+  on the toplevel wakes every client watching that window, which is what
+  `_NET_WM_USER_TIME_WINDOW` exists to avoid.
+
+### Security
+
+The id is broadcast to the root window, so every client on the display sees
+it. On X11 that is the pre-existing no-isolation story rather than a new
+exposure — see [security.md](security.md) — but it is the reason the
+messages carry the id the launcher gave us and nothing invented, and the
+reason the variable's value is never logged.

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -40,6 +40,7 @@ import {
   unregisterApp,
   hooks as traceHooks,
 } from './trace-registry.js';
+import { beginStartup } from './startup.js';
 import { GlAreaNode } from './glnodes.js';
 import { createRegisteredNode, registeredElements } from './registry.js';
 import { SCENE_KINDS, UNSUPPORTED_KINDS, createSceneNode } from './scene3d.js';
@@ -690,6 +691,11 @@ export async function createRoot(options = {}) {
   // borrowed or owned, this is now a connection the renderer draws through,
   // which is what a REACT_X11_TRACE / startTrace() session follows
   registerApp(app);
+
+  // Before anything renders: the launch id has to be on the first toplevel
+  // before it maps, and the environment variable has to be consumed whether
+  // or not this app ends up using it (src/startup.js).
+  beginStartup(app, rest.startupNotification);
 
   return {
     app,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -160,7 +160,62 @@ export interface RootOptions {
    * new one; nothing survives.
    */
   onDisconnect?: (reason: 'closed' | 'error', err?: Error) => void;
+  /**
+   * Startup notification (freedesktop), on by default. Reads
+   * `DESKTOP_STARTUP_ID`, sets `_NET_STARTUP_ID` and `_NET_WM_USER_TIME` on
+   * the first toplevel before it maps, and ends the launcher's startup
+   * sequence when the app is up — which stops the busy cursor and gives
+   * focus-stealing prevention the evidence it asks for.
+   *
+   * `false` turns it off entirely, for an app that runs its own sequence or
+   * an embedder that owns the toplevel. A string supplies the id for a
+   * launch where it did not arrive in the environment.
+   *
+   * See {@link StartupNotificationOptions.completeOn} for *when* the app
+   * counts as up, and docs/desktop.md.
+   */
+  startupNotification?: boolean | string | StartupNotificationOptions;
 }
+
+export interface StartupNotificationOptions {
+  /** The launch id, when it did not come from `DESKTOP_STARTUP_ID`. */
+  id?: string;
+  /**
+   * What counts as "started". Default `'paint'`.
+   *
+   * - `'paint'` — the first frame that actually drew. This renderer maps a
+   *   window and paints it a frame later, so the map is an empty rectangle;
+   *   ending there stops the busy cursor over a blank window.
+   * - `'map'` — the first toplevel mapping, which is what GTK does. Earlier,
+   *   and right for an app whose first frame is expensive enough that it
+   *   would rather the cursor stopped before it.
+   * - `'manual'` — nothing automatic; call {@link notifyStartupComplete}.
+   *   For an app that is not up until it says so, such as one restoring a
+   *   session behind a splash.
+   *
+   * A backstop timer ends the sequence regardless, so an app that never
+   * paints — or never calls — cannot leave the cursor spinning.
+   */
+  completeOn?: 'paint' | 'map' | 'manual';
+}
+
+/**
+ * The X server timestamp of the user action that launched this app, from
+ * the startup id, or `null` when there was none.
+ *
+ * `null` is a real answer rather than a failure: an app started from a
+ * shell has no launch timestamp and never will. It is the "when" that a
+ * legitimate request to come forward is weighed against, and `0` is not a
+ * substitute — EWMH gives zero its own meaning.
+ */
+export function launchTimestamp(): number | null;
+
+/**
+ * End the startup sequence now. Idempotent, and a no-op when there is none,
+ * so it may be called unconditionally. The seam behind
+ * `startupNotification: { completeOn: 'manual' }`.
+ */
+export function notifyStartupComplete(): void;
 
 /** A mounted tree, as returned by {@link createRoot}. */
 export interface Root {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 export { createRoot, Renderer } from './Reconciler.js';
 export { createStyles, flattenStyle } from './styles.js';
 export { windowIdOf, useWindowId } from './windowid.js';
+export { launchTimestamp, notifyStartupComplete } from './startup.js';
 export { parseUriList } from './transfer.js';
 export { useApp, useClipboard } from './appcontext.js';
 export {

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -3756,7 +3756,17 @@ export class WindowNode extends Node {
     // <window>s never advertise (XDND v3 puts XdndAware on top-levels
     // only); drags over them arrive here and are routed down in JS.
     if (!parentWindow) this._initDnd();
+    // The launch's own properties, and the same "before the map" rule as
+    // everything above it: EWMH's guarantee about `_NET_WM_USER_TIME` is
+    // about the window's state at the moment it is mapped. First toplevel
+    // only — a later `<window>` is not the launch (src/startup.js).
+    if (!parentWindow && !this.isPopup) {
+      this.app._reactX11Startup?.decorate(wnd);
+    }
     wnd.map?.();
+    if (!parentWindow && !this.isPopup) {
+      this.app._reactX11Startup?.mapped(wnd);
+    }
     // ask before anything can be anchored to it, so the first popup is
     // placed as well as the second
     this._refreshScreenOrigin();
@@ -4518,6 +4528,11 @@ export class WindowNode extends Node {
         end: performance.now(),
       });
     }
+    // A frame that actually painted, which is the moment the app is up
+    // (src/startup.js). One property read once the sequence is over — the
+    // session clears itself off the app — which is the same bargain the
+    // trace hook above makes with the frame loop.
+    this.app._reactX11Startup?.painted();
   }
 
   /**

--- a/src/startup.js
+++ b/src/startup.js
@@ -1,0 +1,302 @@
+// Startup notification (freedesktop): tell the desktop the app has finished
+// starting, and tell the window manager which user action started it.
+//
+// Two visible defects without it, for anyone who launches from a launcher
+// rather than a terminal. The launcher opens a startup sequence when it
+// spawns us and closes it when we say we are up; say nothing and it runs to
+// mutter's STARTUP_TIMEOUT_MS, which is 15 seconds of busy cursor over a
+// window the user is already clicking. And `_NET_WM_USER_TIME` is the
+// evidence focus-stealing prevention weighs when deciding whether a new
+// window may come forward; with none, a strict desktop opens us behind
+// whatever the user was doing.
+//
+// This is core rather than an integration package: it is X11 over the
+// connection the renderer already has, using calls already in ntk and
+// node-x11 — no dependency, no engines floor, nothing to opt into. It sits
+// next to `WM_DELETE_WINDOW` and `_NET_WM_PID` in kind.
+//
+// See docs/desktop.md. Issue #174.
+import { eventMask } from 'x11/lib/eventmask.js';
+
+/** mutter gives up at 15s. This is the backstop for an app that never
+ *  paints at all — early enough to beat that by a margin, late enough that
+ *  no honest first frame trips it. */
+const BACKSTOP_MS = 10_000;
+
+const BEGIN = '_NET_STARTUP_INFO_BEGIN';
+const CONTINUE = '_NET_STARTUP_INFO';
+/** The protocol's chunk size: format 8, 20 bytes per ClientMessage. */
+const CHUNK = 20;
+
+/**
+ * Take `DESKTOP_STARTUP_ID` out of the environment.
+ *
+ * **Deleted, not merely read.** The variable names exactly one launch, and
+ * a child process that inherits it claims a sequence that is not its own
+ * and ends it early — the parent's busy cursor stops when the child starts.
+ * Every toolkit that gets this wrong produces that same bug, which is why
+ * the read is destructive rather than tidy.
+ *
+ * Deliberately not memoized: the deletion is the memo, and a cache here
+ * would outlive the launch it belongs to.
+ */
+function consumeEnv() {
+  const found = process.env?.DESKTOP_STARTUP_ID || null;
+  if (process.env) delete process.env.DESKTOP_STARTUP_ID;
+  return found;
+}
+
+/** The id in force: whatever a root was given, else the environment's.
+ *  `undefined` until something has looked. */
+let currentId;
+
+/** The live session, if any. One per process, because one launch is. */
+let current = null;
+
+/**
+ * The X server timestamp of the user action that launched this app, from
+ * the `_TIME` suffix of the startup id, or `null`.
+ *
+ * `null` is a real answer rather than a failure: an app started from a
+ * shell has no launch timestamp and never will. Callers that want to raise
+ * a window use it as the "when", and `0` is not a substitute — EWMH gives
+ * zero its own meaning ("do not focus this on map").
+ */
+export function launchTimestamp() {
+  if (currentId === undefined) currentId = consumeEnv();
+  return parseLaunchTime(currentId);
+}
+
+/** `foo_TIME12345` → `12345`. Anything else, including a `_TIME` that is
+ *  not a number, is `null`. Never throws. */
+export function parseLaunchTime(id) {
+  if (typeof id !== 'string') return null;
+  const at = id.lastIndexOf('_TIME');
+  if (at < 0) return null;
+  const digits = id.slice(at + 5);
+  if (!/^\d+$/.test(digits)) return null;
+  const value = Number(digits);
+  return Number.isSafeInteger(value) ? value : null;
+}
+
+/**
+ * A value as the protocol's parser wants it. Always quoted, which is always
+ * legal and saves deciding; inside the quotes only `\` and `"` are escaped.
+ *
+ * Note what this is *not*: C escaping. The spec is explicit that `\n` here
+ * means the letter n, so a newline passes through as itself and must not be
+ * turned into a backslash and an n.
+ */
+function quote(value) {
+  return `"${String(value).replace(/[\\"]/g, (c) => `\\${c}`)}"`;
+}
+
+/** `remove: ID="foo"` — a message type and its key/value pairs. */
+export function encodeStartupMessage(type, fields) {
+  const pairs = Object.entries(fields)
+    .filter(([, v]) => v != null)
+    .map(([k, v]) => `${k}=${quote(v)}`);
+  return `${type}: ${pairs.join(' ')}`;
+}
+
+/**
+ * The message split into the ClientMessages that carry it: 20 bytes each,
+ * nul-terminated, zero-padded.
+ *
+ * The trailing nul is part of the message rather than padding, so a message
+ * whose bytes land on an exact multiple of 20 still needs the chunk after
+ * it — otherwise the last byte used is not a nul and a strict reader waits
+ * forever for the rest.
+ */
+export function messageChunks(text) {
+  const body = Buffer.from(text, 'utf8');
+  const bytes = Buffer.concat([body, Buffer.from([0])]);
+  const chunks = [];
+  for (let at = 0; at < bytes.length; at += CHUNK) {
+    const chunk = new Array(CHUNK).fill(0);
+    for (let i = 0; i < CHUNK && at + i < bytes.length; i++) {
+      chunk[i] = bytes[at + i];
+    }
+    chunks.push(chunk);
+  }
+  return chunks;
+}
+
+/**
+ * Resolve the `startupNotification` option into `{ id, completeOn }`, or
+ * `null` for opted out.
+ *
+ * `completeOn` defaults to `'paint'` — see `StartupSession.painted`.
+ */
+function settings(option) {
+  if (option === false) return null;
+  // Consumed either way, even when an explicit id wins: leaving it set
+  // would hand this launch's id to the next child process spawned.
+  const fromEnv = consumeEnv();
+  const given =
+    typeof option === 'string'
+      ? { id: option }
+      : option && typeof option === 'object'
+        ? option
+        : {};
+  return { id: given.id ?? fromEnv, completeOn: given.completeOn ?? 'paint' };
+}
+
+class StartupSession {
+  constructor(app, { id, completeOn }) {
+    this.app = app;
+    this.id = id;
+    this.completeOn = completeOn;
+    this.time = parseLaunchTime(id);
+    this.done = false;
+    this.timer = null;
+  }
+
+  /**
+   * `_NET_STARTUP_ID` and `_NET_WM_USER_TIME` on the first toplevel, and
+   * **before it maps**: EWMH's guarantee is about the state of the window at
+   * the moment it is mapped, so setting them afterwards is too late and
+   * looks identical in a log.
+   */
+  decorate(wnd) {
+    if (this.claimed || !this.id) return;
+    this.claimed = wnd;
+    wnd.setProperty?.('_NET_STARTUP_ID', this.id);
+    if (this.time !== null) {
+      wnd.setProperty?.('_NET_WM_USER_TIME', [this.time], {
+        type: 'CARDINAL',
+        format: 32,
+      });
+    }
+    // Intern now rather than at the moment of completion. Both are round
+    // trips, and the whole point of this feature is that the second one
+    // happens the instant the app is up — spending it here, while the first
+    // frame is still being built, costs nothing anybody can see.
+    this._primeAtoms(wnd);
+  }
+
+  _primeAtoms(wnd) {
+    const X = wnd.X;
+    if (!X?.InternAtom) return;
+    const atom = (name) =>
+      new Promise((resolve, reject) =>
+        X.InternAtom(false, name, (err, id) =>
+          err ? reject(err) : resolve(id),
+        ),
+      );
+    this.atomsReady = Promise.all([atom(BEGIN), atom(CONTINUE)])
+      .then((ids) => {
+        this.atoms = ids;
+      })
+      .catch(() => {
+        // A display that cannot intern an atom has worse problems than a
+        // busy cursor, and the launcher's own timeout still covers this.
+      });
+  }
+
+  /** The first toplevel is up. Arms the backstop; completes now if that is
+   *  what this app asked for. */
+  mapped(wnd) {
+    if (this.done || !this.id || this.claimed !== wnd) return;
+    if (this.completeOn === 'map') return this.complete();
+    // Whichever comes first. An app that never paints — headless, a throw in
+    // the first render, a window mounted hidden — must still end the
+    // sequence, or this reproduces the bug it exists to fix.
+    this.timer ??= setTimeout(() => this.complete(), BACKSTOP_MS);
+    this.timer.unref?.();
+  }
+
+  /**
+   * A flush actually painted — the default moment, and the one this
+   * renderer can name where a toolkit that paints on map cannot.
+   *
+   * Not the map: `invalidate()` schedules through the frame clock and the
+   * drawing happens in `flush()` a frame later, so a mapped window is an
+   * empty one. Ending the sequence there stops the busy cursor over a blank
+   * rectangle — compliant, and a worse answer than the timeout.
+   *
+   * Not "real" content either. If the first frame is a spinner because the
+   * tree is suspended, that is exactly the right moment to stop the
+   * *system's* spinner: the app is up and is telling the user what it is
+   * doing. There is no signal for "finished loading" and guessing at one is
+   * how this ends up back at fifteen seconds.
+   */
+  painted() {
+    if (this.completeOn === 'paint') this.complete();
+  }
+
+  /**
+   * Send `remove:` and stand down. Idempotent, because three things race to
+   * call it and the protocol should see exactly one.
+   */
+  complete() {
+    if (this.done) return;
+    this.done = true;
+    if (this.timer) clearTimeout(this.timer);
+    this.timer = null;
+    if (this.app._reactX11Startup === this) this.app._reactX11Startup = null;
+    const wnd = this.claimed;
+    if (!this.id || !wnd) return;
+    const text = encodeStartupMessage('remove', { ID: this.id });
+    // Normally the atoms landed while the first frame was being built, and
+    // this goes out in the same turn as the paint that triggered it. The
+    // fallback is for completing before they arrive, which is what
+    // `completeOn: 'map'` does on a cold connection.
+    if (this.atoms) send(wnd, this.atoms, text);
+    else this.atomsReady?.then(() => this.atoms && send(wnd, this.atoms, text));
+  }
+}
+
+/**
+ * Broadcast a startup message to the root window.
+ *
+ * Two things the transport gets wrong by default. The event mask has to be
+ * `PropertyChange` — `SendClientMessage` defaults to the substructure pair
+ * EWMH wants for root messages, and this protocol is not that. And the
+ * `window` field names a window the *sender* owns, while the destination is
+ * the root, which is why both are arguments.
+ */
+function send(wnd, [begin, cont], text) {
+  const X = wnd.X;
+  const root = X?.display?.screen?.[0]?.root;
+  if (!X?.SendClientMessage || !root) return;
+  messageChunks(text).forEach((chunk, i) => {
+    X.SendClientMessage(
+      root,
+      wnd.id,
+      i === 0 ? begin : cont,
+      8,
+      chunk,
+      eventMask.PropertyChange,
+    );
+  });
+}
+
+/**
+ * Begin a session for a root, or `null` when there is nothing to do — no
+ * id in the environment (a terminal, CI, XQuartz) or the app opted out.
+ * Nothing is sent and nothing is set in that case.
+ */
+export function beginStartup(app, option) {
+  const resolved = settings(option);
+  currentId = resolved?.id ?? null;
+  if (!resolved?.id) return null;
+  const session = new StartupSession(app, resolved);
+  app._reactX11Startup = session;
+  current = session;
+  return session;
+}
+
+/**
+ * End the startup sequence now. Idempotent, and a no-op when there is none,
+ * so an app may call it unconditionally.
+ *
+ * This is the seam behind `completeOn: 'manual'`, for an app that knows
+ * better than "the first frame" — one whose first frame is a splash it does
+ * not want to be judged by, or which is up only once a session is restored.
+ * No arguments, because a process has one launch however many roots it
+ * builds.
+ */
+export function notifyStartupComplete() {
+  current?.complete();
+}

--- a/src/testing/mock-app.js
+++ b/src/testing/mock-app.js
@@ -28,6 +28,19 @@ export function createMockApp() {
       ConfigureWindow(id, options) {
         app.configureCalls.push([id, options]);
       },
+      // Startup notification broadcasts through this (src/startup.js), and
+      // it is the only way to see the message: it goes to the root window,
+      // which the mock does not model as a window with properties.
+      SendClientMessage(destination, wid, type, format, data, eventMask) {
+        app.clientMessages.push({
+          destination,
+          wid,
+          type,
+          format,
+          data,
+          eventMask,
+        });
+      },
       on(event, fn) {
         (listeners[event] ??= []).push(fn);
       },
@@ -36,6 +49,7 @@ export function createMockApp() {
       },
     },
     configureCalls: [],
+    clientMessages: [],
     _atoms: new Map([['WM_DELETE_WINDOW', 999]]),
     closed: 0,
     close() {

--- a/test/startup-notification.test.js
+++ b/test/startup-notification.test.js
@@ -1,0 +1,365 @@
+// Startup notification (issue #174): the handshake that stops the
+// launcher's busy cursor and tells the window manager which user action
+// opened this window.
+//
+// The interesting decision is *when* an app counts as started. GTK says
+// "when the toplevel maps"; this renderer can say something better, because
+// it knows when a frame actually painted — a mapped window here is an empty
+// one, the drawing lands a frame later. So the default is the first flush
+// that painted, with `completeOn` for the apps that want the other answers.
+import { test, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+
+import {
+  createRoot,
+  launchTimestamp,
+  notifyStartupComplete,
+} from '../src/index.js';
+import {
+  encodeStartupMessage,
+  messageChunks,
+  parseLaunchTime,
+} from '../src/startup.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+const settle = async () => {
+  await tick();
+  await tick();
+};
+
+const ID = 'launcher/app.desktop/1234-0_TIME9876';
+
+let savedEnv;
+beforeEach(() => {
+  savedEnv = process.env.DESKTOP_STARTUP_ID;
+  delete process.env.DESKTOP_STARTUP_ID;
+});
+afterEach(() => {
+  if (savedEnv === undefined) delete process.env.DESKTOP_STARTUP_ID;
+  else process.env.DESKTOP_STARTUP_ID = savedEnv;
+});
+
+/** The messages, reassembled from their 20-byte fragments. */
+function messagesOf(app) {
+  const out = [];
+  let bytes = [];
+  for (const msg of app.clientMessages) {
+    if (msg.type === app._atoms.get('_NET_STARTUP_INFO_BEGIN')) bytes = [];
+    bytes.push(...msg.data);
+    const end = bytes.indexOf(0);
+    if (end >= 0) {
+      out.push(Buffer.from(bytes.slice(0, end)).toString('utf8'));
+      bytes = [];
+    }
+  }
+  return out;
+}
+
+const propertyCalls = (wnd) => wnd.calls.filter((c) => c[0] === 'setProperty');
+
+async function mount(options = {}, element) {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app, ...options });
+  x11Root.render(
+    element ?? h('window', { width: 200, height: 100 }, h('box', null)),
+  );
+  await settle();
+  return { app, x11Root, wnd: app.windows[0] };
+}
+
+// --- the pieces ---------------------------------------------------------
+
+test('an id carries the launch timestamp, or admits it has none', () => {
+  assert.strictEqual(parseLaunchTime('foo_TIME12345'), 12345);
+  assert.strictEqual(parseLaunchTime('foo'), null, 'no _TIME');
+  assert.strictEqual(parseLaunchTime('foo_TIMEnotanumber'), null);
+  assert.strictEqual(parseLaunchTime(''), null);
+  assert.strictEqual(parseLaunchTime(undefined), null, 'never throws');
+});
+
+test('values are quoted the way the protocol parses them, not the way C does', () => {
+  assert.strictEqual(
+    encodeStartupMessage('remove', { ID: 'plain' }),
+    'remove: ID="plain"',
+  );
+  assert.strictEqual(
+    encodeStartupMessage('new', { ID: 'a b', NAME: 'say "hi"' }),
+    'new: ID="a b" NAME="say \\"hi\\""',
+  );
+  assert.strictEqual(
+    encodeStartupMessage('new', { ID: 'back\\slash' }),
+    'new: ID="back\\\\slash"',
+    'a backslash is escaped',
+  );
+  // the spec is explicit that `\n` means the letter n, so a real newline
+  // stays a real newline rather than becoming an escape
+  assert.strictEqual(
+    encodeStartupMessage('new', { ID: 'a\nb' }),
+    'new: ID="a\nb"',
+  );
+  assert.strictEqual(
+    encodeStartupMessage('remove', { ID: 'x', NAME: undefined }),
+    'remove: ID="x"',
+    'absent fields are left out, not sent empty',
+  );
+});
+
+test('a message is fragmented into nul-terminated 20-byte chunks', () => {
+  const long = 'remove: ID="' + 'x'.repeat(60) + '"';
+  const chunks = messageChunks(long);
+  assert.ok(chunks.length > 1, 'long enough to need fragmenting');
+  for (const chunk of chunks) {
+    assert.strictEqual(chunk.length, 20, 'every fragment is 20 bytes');
+  }
+  const flat = chunks.flat();
+  const end = flat.indexOf(0);
+  assert.strictEqual(
+    Buffer.from(flat.slice(0, end)).toString('utf8'),
+    long,
+    'and they reassemble to what went in',
+  );
+  assert.ok(
+    flat.slice(0, end).every((b) => b !== 0),
+    'no intermediate byte is nul',
+  );
+
+  // a message whose bytes land on an exact multiple of 20 still needs the
+  // chunk carrying its terminator, or the last byte used is not a nul
+  const exact = 'a'.repeat(20);
+  assert.strictEqual(messageChunks(exact).length, 2);
+});
+
+// --- the handshake ------------------------------------------------------
+
+test('the id is set on the first toplevel, before it maps', async () => {
+  process.env.DESKTOP_STARTUP_ID = ID;
+  const { wnd, x11Root } = await mount();
+
+  const names = wnd.calls.map((c) => (c[0] === 'setProperty' ? c[1] : c[0]));
+  const mapAt = names.indexOf('map');
+  assert.ok(mapAt >= 0, 'it mapped');
+  assert.ok(
+    names.indexOf('_NET_STARTUP_ID') >= 0 &&
+      names.indexOf('_NET_STARTUP_ID') < mapAt,
+    `_NET_STARTUP_ID before the map, got ${names.join(',')}`,
+  );
+  assert.ok(
+    names.indexOf('_NET_WM_USER_TIME') >= 0 &&
+      names.indexOf('_NET_WM_USER_TIME') < mapAt,
+    'and _NET_WM_USER_TIME too — EWMH is about the state at map time',
+  );
+
+  const userTime = propertyCalls(wnd).find((c) => c[1] === '_NET_WM_USER_TIME');
+  assert.deepStrictEqual(userTime[2], [9876], 'the launch timestamp');
+  assert.strictEqual(userTime[3].type, 'CARDINAL');
+  assert.strictEqual(userTime[3].format, 32);
+
+  await x11Root.unmount();
+});
+
+test('the sequence ends on the first paint, and only once', async () => {
+  process.env.DESKTOP_STARTUP_ID = ID;
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(h('window', { width: 200, height: 100 }, h('box', null)));
+
+  // mapped, but the frame clock has not run: nothing sent yet
+  assert.strictEqual(
+    app.clientMessages.length,
+    0,
+    'a mapped window is an empty one — the map is not the moment',
+  );
+
+  await settle();
+  assert.deepStrictEqual(
+    messagesOf(app),
+    [`remove: ID="${ID}"`],
+    'the first frame that painted ended it',
+  );
+
+  // paint again; the sequence is over
+  app.windows[0]._reactX11Node.invalidate(true, null, 'test');
+  await settle();
+  assert.strictEqual(messagesOf(app).length, 1, 'not sent twice');
+
+  await x11Root.unmount();
+});
+
+test('the message goes to the root, from our window, on PropertyChange', async () => {
+  process.env.DESKTOP_STARTUP_ID = ID;
+  const { app, wnd, x11Root } = await mount();
+
+  const sent = app.clientMessages;
+  assert.ok(sent.length > 0, 'something was sent');
+  for (const msg of sent) {
+    assert.strictEqual(msg.destination, 1, 'to the root window');
+    assert.strictEqual(msg.wid, wnd.id, 'naming a window we own');
+    assert.strictEqual(msg.format, 8);
+    assert.strictEqual(msg.data.length, 20);
+    assert.strictEqual(
+      msg.eventMask,
+      0x00400000,
+      'PropertyChange, not the SendClientMessage default',
+    );
+  }
+  assert.strictEqual(
+    sent[0].type,
+    app._atoms.get('_NET_STARTUP_INFO_BEGIN'),
+    'the first fragment opens the message',
+  );
+
+  await x11Root.unmount();
+});
+
+test('the environment variable is consumed, not merely read', async () => {
+  process.env.DESKTOP_STARTUP_ID = ID;
+  const { x11Root } = await mount();
+  assert.strictEqual(
+    process.env.DESKTOP_STARTUP_ID,
+    undefined,
+    'a child process must not inherit a sequence that is not its own',
+  );
+  await x11Root.unmount();
+});
+
+test('launchTimestamp is the launch time, or null for a shell start', async () => {
+  process.env.DESKTOP_STARTUP_ID = ID;
+  const { x11Root } = await mount();
+  assert.strictEqual(launchTimestamp(), 9876);
+  await x11Root.unmount();
+
+  const bare = await mount();
+  assert.strictEqual(
+    launchTimestamp(),
+    null,
+    'no id is a real answer, not a failure',
+  );
+  await bare.x11Root.unmount();
+});
+
+test('no id means no properties and no traffic', async () => {
+  const { app, wnd, x11Root } = await mount();
+  assert.strictEqual(app.clientMessages.length, 0);
+  assert.deepStrictEqual(
+    propertyCalls(wnd).filter((c) => String(c[1]).startsWith('_NET_STARTUP')),
+    [],
+  );
+  await x11Root.unmount();
+});
+
+// --- the seams ----------------------------------------------------------
+
+test('startupNotification: false opts out entirely', async () => {
+  process.env.DESKTOP_STARTUP_ID = ID;
+  const { app, wnd, x11Root } = await mount({ startupNotification: false });
+  assert.strictEqual(app.clientMessages.length, 0, 'nothing sent');
+  assert.deepStrictEqual(
+    propertyCalls(wnd).filter((c) => String(c[1]).startsWith('_NET_STARTUP')),
+    [],
+    'and nothing set',
+  );
+  assert.strictEqual(
+    process.env.DESKTOP_STARTUP_ID,
+    ID,
+    'opting out leaves the variable alone: this app is not the launchee',
+  );
+  await x11Root.unmount();
+});
+
+test('an id can be supplied instead of inherited', async () => {
+  const { app, x11Root } = await mount({
+    startupNotification: 'given_TIME99',
+  });
+  assert.deepStrictEqual(messagesOf(app), ['remove: ID="given_TIME99"']);
+  assert.strictEqual(launchTimestamp(), 99);
+  await x11Root.unmount();
+});
+
+test("completeOn: 'map' ends it at the map, GTK-style", async () => {
+  process.env.DESKTOP_STARTUP_ID = ID;
+  const app = createMockApp();
+  const x11Root = await createRoot({
+    app,
+    startupNotification: { completeOn: 'map' },
+  });
+  x11Root.render(h('window', { width: 200, height: 100 }, h('box', null)));
+
+  // Take painting away *after* the map, so nothing can ever reach the
+  // default path. Whatever arrives now was sent by the map alone — which is
+  // the whole claim of this mode, and it is what an app wants when its
+  // first frame is expensive and it would rather the cursor stopped early.
+  const wnd = app.windows[0];
+  delete wnd.getContext;
+
+  await settle();
+  assert.deepStrictEqual(
+    messagesOf(app),
+    [`remove: ID="${ID}"`],
+    'sent from the map, with no paint anywhere in the run',
+  );
+  assert.strictEqual(wnd.ctx.ops.length, 0, 'and nothing painted, at all');
+
+  await x11Root.unmount();
+});
+
+test("completeOn: 'manual' waits for the app to say so", async () => {
+  process.env.DESKTOP_STARTUP_ID = ID;
+  const { app, x11Root } = await mount({
+    startupNotification: { completeOn: 'manual' },
+  });
+  assert.strictEqual(
+    app.clientMessages.length,
+    0,
+    'painting is not the signal here',
+  );
+
+  notifyStartupComplete();
+  await tick();
+  assert.deepStrictEqual(messagesOf(app), [`remove: ID="${ID}"`]);
+
+  notifyStartupComplete();
+  await tick();
+  assert.strictEqual(messagesOf(app).length, 1, 'idempotent');
+
+  await x11Root.unmount();
+});
+
+test('an app that never says it is up is still let go of', async (t) => {
+  // The case that would otherwise reproduce the bug this exists to fix: a
+  // sequence nobody closes runs to the launcher's own 15-second timeout.
+  // `manual` is the shape of it — a session that armed the backstop and
+  // then heard nothing — and mock timers stand in for the ten seconds.
+  t.mock.timers.enable({ apis: ['setTimeout'] });
+  process.env.DESKTOP_STARTUP_ID = ID;
+  const { app, x11Root } = await mount({
+    startupNotification: { completeOn: 'manual' },
+  });
+  assert.strictEqual(app.clientMessages.length, 0, 'nothing yet');
+
+  t.mock.timers.tick(10_000);
+  await tick();
+  assert.deepStrictEqual(
+    messagesOf(app),
+    [`remove: ID="${ID}"`],
+    'the backstop sent exactly one',
+  );
+
+  notifyStartupComplete();
+  await tick();
+  assert.strictEqual(messagesOf(app).length, 1, 'and it is over for good');
+
+  await x11Root.unmount();
+});
+
+test('the session takes itself off the app once it is over', async () => {
+  // the paint path reads `app._reactX11Startup` on every frame that draws;
+  // clearing it is what keeps that to one property read for the life of
+  // the process rather than a live call
+  process.env.DESKTOP_STARTUP_ID = ID;
+  const { app, x11Root } = await mount();
+  assert.strictEqual(app._reactX11Startup, null);
+  await x11Root.unmount();
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -19,7 +19,9 @@ import {
   createStyles,
   Dialog,
   flattenStyle,
+  launchTimestamp,
   MenuBar,
+  notifyStartupComplete,
   ProgressBar,
   Radio,
   RadioGroup,
@@ -507,6 +509,22 @@ async function main() {
   await other.unmount();
   const borrowing = await createRoot({ app: root.app });
   await borrowing.unmount();
+
+  // startup notification: on by default, three ways to say otherwise
+  const off = await createRoot({ startupNotification: false });
+  await off.unmount();
+  const withId = await createRoot({ startupNotification: 'x_TIME1' });
+  await withId.unmount();
+  const manual = await createRoot({
+    startupNotification: { id: 'x_TIME1', completeOn: 'manual' },
+  });
+  const when: number | null = launchTimestamp();
+  void when;
+  notifyStartupComplete();
+  await manual.unmount();
+
+  // @ts-expect-error — completeOn is a closed set
+  await createRoot({ startupNotification: { completeOn: 'someday' } });
 
   root.render(<Scene />);
   root.render(<RawGl />);

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -184,6 +184,7 @@ const ORDER = [
   'typescript.md',
   'extending.md',
   'testing.md',
+  'desktop.md',
   'remote.md',
   'security.md',
   'packaging.md',


### PR DESCRIPTION
Closes #174.

An app launched from a launcher rather than a terminal shows two defects,
neither of which errors. The busy cursor spins for **15 seconds** — the
launcher opens a startup sequence when it spawns us, we never close it, and
it runs to mutter's `STARTUP_TIMEOUT_MS`. And the first window may open
*behind* whatever the user was doing, because `_NET_WM_USER_TIME` is the
evidence focus-stealing prevention weighs and there was none.

So: read `DESKTOP_STARTUP_ID`, set `_NET_STARTUP_ID` and `_NET_WM_USER_TIME`
on the first toplevel **before it maps**, and end the sequence when the app
is up. The environment variable is deleted rather than merely read — it
names one launch, and a child process that inherits it ends a sequence that
is not its own.

## The part that was a design question

**When does an app count as "up"?** GTK says "when the toplevel maps", and
copying that here would be subtly wrong: this renderer does not paint on
map. `invalidate()` schedules through the frame clock and the drawing lands
in `flush()` a frame later, so a mapped window is an empty rectangle and
map-time completion stops the busy cursor over a blank one.

The default is **the first flush that actually painted** — a real moment in
this renderer rather than an approximation of one. It also turned out to be
cheap: that is the same moment `hooks.frame` already reports, so the signal
was a line, not a mechanism.

A suspense fallback counts as painted, deliberately. A first frame that is a
spinner is exactly when to stop the *system's* spinner — the app is up and
is telling the user what it is doing. There is no signal for "finished
loading" and guessing at one is how this ends back at fifteen seconds.

## Seams

A default with no way out strands the edge case, so:

| | |
| --- | --- |
| `completeOn: 'paint'` | the first frame that drew — **default** |
| `completeOn: 'map'` | the first toplevel mapping, GTK-style; for an app whose first frame is expensive enough that it would rather the cursor stopped before it |
| `completeOn: 'manual'` | `notifyStartupComplete()`; for an app that is up only when it says so |
| `startupNotification: '<id>'` | a launch that did not carry an id in the environment |
| `startupNotification: false` | an embedder that owns the toplevel, or an app running its own sequence |

**A backstop ends the sequence regardless**, ten seconds after the map,
whichever mode is in force. A feature that can leave the cursor spinning
would be the bug it exists to fix.

`launchTimestamp()` falls out of it — the value anything that ever
legitimately raises a window will need. `null` is a real answer, not a
failure: an app started from a shell has no launch timestamp and never will.

No new dependency, no engines change, nothing upstream to wait on. This is
X11 over the connection the renderer already has, which is why it is core
rather than `@react-x11/desktop`.

## AGENTS.md

Adds the policy this shape came from, at the maintainer's request: decide
the default for the main customer and leave a seam with the shape of the
real disagreement — a config value for a fact about the app, an enumerated
choice for a few defensible answers, a hook for code we cannot write, an
off switch for a job that can be someone else's. With the two failure modes
that read as thoughtfulness: a default that is only a guess with an escape
hatch bolted on, and a seam nobody can reach.

## Checks

- `npm test` — 459 pass, 15 of them new in `test/startup-notification.test.js`.
  Mutation-checked: completing on map instead of paint, reading the
  environment without deleting it, setting the properties after the map, and
  falling back to `SendClientMessage`'s default event mask each fail the
  test that covers them.
- The mock grew a `SendClientMessage` recorder, since the messages go to the
  root window and there was no way to see them.
- `npm run typecheck` (with `@ts-expect-error` pinning `completeOn` as a
  closed set), `npm run lint`, `website && npm test`, `npm run build` all clean.

## Not covered here

- **The launcher half** — an app that spawns another app. Same encoder,
  different persona; the issue scopes it out and so does this.
- **Ongoing `_NET_WM_USER_TIME` maintenance.** Setting it once at launch is
  this PR. Keeping it current on every keypress has a real cost EWMH is
  explicit about, and `_NET_WM_USER_TIME_WINDOW` exists because of it.
- **Verification against a real WM.** quartz-wm implements none of this, so
  a Mac cannot tell you whether it works. The protocol-level behaviour is
  tested; whether GNOME actually stops the cursor wants one manual launch.
