### PR TITLE
fix(windows): a move is not a resize

### DIFF
--- a/scripts/bench/baseline.json
+++ b/scripts/bench/baseline.json
@@ -62,5 +62,29 @@
     "replies": 4,
     "composites": 11,
     "compositePixels": 10292
+  },
+  "window: 10 pure moves": {
+    "requests": 43,
+    "bytesOut": 476,
+    "bytesIn": 1376,
+    "replies": 33,
+    "composites": 0,
+    "compositePixels": 0
+  },
+  "update: 5 color flips, no layout": {
+    "requests": 60,
+    "bytesOut": 1220,
+    "bytesIn": 384,
+    "replies": 12,
+    "composites": 10,
+    "compositePixels": 25020
+  },
+  "update: 5 absolute box moves (layout)": {
+    "requests": 27,
+    "bytesOut": 572,
+    "bytesIn": 384,
+    "replies": 12,
+    "composites": 10,
+    "compositePixels": 812000
   }
 }

--- a/scripts/bench/protocol.js
+++ b/scripts/bench/protocol.js
@@ -215,6 +215,52 @@ function iconWall(count, size = 20) {
   );
 }
 
+/** The mount scenario's tree: `count` striped rows with a label each. */
+function rowsWindow(count) {
+  return React.createElement(
+    'window',
+    { width: W, height: H, style: { backgroundColor: '#f5f6fa' } },
+    React.createElement(
+      'box',
+      { style: { flexGrow: 1, padding: 8, gap: 2 } },
+      Array.from({ length: count }, (_, i) =>
+        React.createElement(
+          'box',
+          {
+            key: i,
+            style: {
+              flexDirection: 'row',
+              gap: 6,
+              padding: 2,
+              backgroundColor: i % 2 ? '#ffffff' : '#eef1f5',
+            },
+          },
+          React.createElement('text', { style: { fontSize: 11 } }, `row ${i}`),
+        ),
+      ),
+    ),
+  );
+}
+
+/** One absolutely-positioned box on a plain background — the smallest tree
+ * where "what changed" and "what repainted" can drift apart. */
+function absBoxWindow(left, color) {
+  return React.createElement(
+    'window',
+    { width: W, height: H, style: { backgroundColor: '#f5f6fa' } },
+    React.createElement('box', {
+      style: {
+        position: 'absolute',
+        left,
+        top: 40,
+        width: 60,
+        height: 40,
+        backgroundColor: color,
+      },
+    }),
+  );
+}
+
 /** Mount a tree, settle it, and hand back the root node plus a frame pump.
  * The mount is what `prepare` pays for, so `run` measures only repaints. */
 async function mounted(x11Root, element) {
@@ -298,36 +344,7 @@ const SCENARIOS = [
     'mount: window with 40 boxes and labels',
     async (app, x11Root) => {
       await new Promise((resolve) =>
-        x11Root.render(
-          React.createElement(
-            'window',
-            { width: W, height: H, style: { backgroundColor: '#f5f6fa' } },
-            React.createElement(
-              'box',
-              { style: { flexGrow: 1, padding: 8, gap: 2 } },
-              Array.from({ length: 40 }, (_, i) =>
-                React.createElement(
-                  'box',
-                  {
-                    key: i,
-                    style: {
-                      flexDirection: 'row',
-                      gap: 6,
-                      padding: 2,
-                      backgroundColor: i % 2 ? '#ffffff' : '#eef1f5',
-                    },
-                  },
-                  React.createElement(
-                    'text',
-                    { style: { fontSize: 11 } },
-                    `row ${i}`,
-                  ),
-                ),
-              ),
-            ),
-          ),
-          resolve,
-        ),
+        x11Root.render(rowsWindow(40), resolve),
       );
       await new Promise((r) => setImmediate(r));
     },
@@ -445,6 +462,95 @@ const SCENARIOS = [
           }
           ctl.frame();
           await settle(app);
+        },
+      };
+    })(),
+  ],
+  [
+    // A drag under an opaque-move WM (Compiz, KWin, Mutter) is a stream of
+    // ConfigureNotify events that change only x/y. The window's own
+    // coordinate space is untouched, so the right cost is zero pixels —
+    // before the guard in WindowNode's 'resize' listener each step was a
+    // full relayout plus a FULL WINDOW repaint. compositePixels is the
+    // alarm here: it must stay 0.
+    'window: 10 pure moves',
+    (() => {
+      let ctl;
+      return {
+        prepare: async (app, x11Root) => {
+          ctl = await mounted(x11Root, rowsWindow(40));
+          // pace frames on the fence alone — deterministic under test, no
+          // 16ms wall-clock timer between the event and any (wrong) repaint
+          ctl.root.window.frameInterval = 0;
+        },
+        run: async (app) => {
+          for (let i = 0; i < 10; i++) {
+            app.X.ConfigureWindow(ctl.root.window.id, {
+              x: 20 + i * 7,
+              y: 30 + (i % 3) * 11,
+            });
+            // one round trip delivers the ConfigureNotify; two immediates
+            // let the paced frame run whatever it (wrongly) scheduled
+            await new Promise((resolve) => app.X.GetInputFocus(resolve));
+            await new Promise((resolve) => setImmediate(resolve));
+            await new Promise((resolve) => setImmediate(resolve));
+          }
+          ctl.frame();
+          await settle(app);
+        },
+      };
+    })(),
+  ],
+  [
+    // A paint-only change: the box flips color in place. The damage tracker
+    // bounds this to the box, so compositePixels stays near the box's own
+    // area — this is the partial-repaint contract the Damage panel of
+    // examples/stress demonstrates, pinned as a number.
+    'update: 5 color flips, no layout',
+    (() => {
+      let ctl;
+      return {
+        prepare: async (app, x11Root) => {
+          ctl = await mounted(x11Root, absBoxWindow(40, '#3498db'));
+        },
+        run: async (app, x11Root) => {
+          for (let i = 0; i < 5; i++) {
+            await new Promise((resolve) =>
+              x11Root.render(
+                absBoxWindow(40, i % 2 ? '#3498db' : '#e74c3c'),
+                resolve,
+              ),
+            );
+            ctl.frame();
+            await settle(app);
+          }
+        },
+      };
+    })(),
+  ],
+  [
+    // The same box moving instead: `left` changes, layout runs, and today
+    // any layout pass degrades the frame to FULL damage — the whole window
+    // per step instead of two box-sized rects (the old and new positions).
+    // Baselined as-is on purpose: this documents the known cost of
+    // unbounded layout damage, and the number here should DROP by an order
+    // of magnitude when bounded layout damage lands (--check only fails on
+    // increases, so an improvement sails through and can be re-saved).
+    'update: 5 absolute box moves (layout)',
+    (() => {
+      let ctl;
+      return {
+        prepare: async (app, x11Root) => {
+          ctl = await mounted(x11Root, absBoxWindow(40, '#3498db'));
+        },
+        run: async (app, x11Root) => {
+          for (let i = 0; i < 5; i++) {
+            await new Promise((resolve) =>
+              x11Root.render(absBoxWindow(40 + (i + 1) * 30, '#3498db'), resolve),
+            );
+            ctl.frame();
+            await settle(app);
+          }
         },
       };
     })(),

--- a/scripts/bench/protocol.js
+++ b/scripts/bench/protocol.js
@@ -343,9 +343,7 @@ const SCENARIOS = [
   [
     'mount: window with 40 boxes and labels',
     async (app, x11Root) => {
-      await new Promise((resolve) =>
-        x11Root.render(rowsWindow(40), resolve),
-      );
+      await new Promise((resolve) => x11Root.render(rowsWindow(40), resolve));
       await new Promise((r) => setImmediate(r));
     },
   ],
@@ -546,7 +544,10 @@ const SCENARIOS = [
         run: async (app, x11Root) => {
           for (let i = 0; i < 5; i++) {
             await new Promise((resolve) =>
-              x11Root.render(absBoxWindow(40 + (i + 1) * 30, '#3498db'), resolve),
+              x11Root.render(
+                absBoxWindow(40 + (i + 1) * 30, '#3498db'),
+                resolve,
+              ),
             );
             ctl.frame();
             await settle(app);

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -4001,8 +4001,13 @@ export class WindowNode extends Node {
     const wnd = this.window;
     if (typeof wnd.on !== 'function') return;
     wnd.on('resize', (ev) => {
-      this.needsLayout = true;
-      this.invalidate(true, null, 'resize');
+      // ConfigureNotify also fires for pure moves and reparents; only a real
+      // size change dirties layout or pixels (ntk guards its backing store
+      // the same way)
+      if (ev.width !== this.abs.width || ev.height !== this.abs.height) {
+        this.needsLayout = true;
+        this.invalidate(true, null, 'resize');
+      }
       // a move or a reparent arrives the same way, and either changes where
       // popups anchored to this window belong
       this._refreshScreenOrigin();
@@ -4210,11 +4215,14 @@ export class WindowNode extends Node {
       pendingRestack.add(this.parent);
     }
     this._applyWindowHints(newProps, before);
+    // Position and size part ways below: both are sent to the server, but
+    // only a size change re-lays-out — the window's own coordinate space is
+    // untouched by where the window sits on screen, so a pointer-tracking
+    // popup does not repaint itself per motion.
+    const sizeChanged =
+      newProps.width !== before.width || newProps.height !== before.height;
     const geometryChanged =
-      newProps.width !== before.width ||
-      newProps.height !== before.height ||
-      newProps.x !== before.x ||
-      newProps.y !== before.y;
+      sizeChanged || newProps.x !== before.x || newProps.y !== before.y;
     if (geometryChanged) {
       if (typeof wnd.setState === 'function') {
         wnd.setState({
@@ -4244,9 +4252,14 @@ export class WindowNode extends Node {
     // (React updates the parent whenever its child list is rebuilt), and
     // that must not widen the damage those children just recorded.
     const ownPaintChanged = paintPropsChanged(style, beforeStyle);
+    // A size change is unbounded — the window's old bounds do not cover the
+    // grown area. A style-driven relayout at the same size is bounded by the
+    // window itself (its paint covers all of it; NO_DAMAGE alongside a
+    // layout change would fall through invalidate's bounds bookkeeping with
+    // no rect at all). An x/y-only commit contributes nothing.
     this.invalidate(
-      layoutChanged || geometryChanged,
-      ownPaintChanged ? this : NO_DAMAGE,
+      layoutChanged || sizeChanged,
+      sizeChanged ? null : ownPaintChanged || layoutChanged ? this : NO_DAMAGE,
       'props',
     );
   }

--- a/test/window-move.test.js
+++ b/test/window-move.test.js
@@ -1,0 +1,146 @@
+// A window move is not a resize. The window manager reports both through
+// ConfigureNotify (ntk's 'resize' event), and a WM that moves windows
+// opaquely — Compiz, KWin, Mutter — sends one per pointer step of a drag.
+// The window's own coordinate space is untouched by where it sits on
+// screen, so a pure move must cost no layout and no paint: before the
+// guard in WindowNode's 'resize' listener, every drag step was a full
+// relayout plus a FULL WINDOW repaint (30 moves = 30 full frames, measured
+// against Compiz on glamor/virgl where each such frame is a GPU round
+// trip through the VM).
+//
+// The frame hook from trace-registry is the observer here because it is
+// the same signal REACT_X11_TRACE prints as "FULL WINDOW": a frame fires
+// it exactly when a flush painted, with the rects it painted. No frames
+// through the hook means no pixels touched — the assertion the fix is for.
+//
+// Test order matters: the React-driven cases run before the X-driven
+// resize, so React's idea of the window size stays in step with the
+// server's. (An X resize the app never rendered leaves the props stale,
+// and the next commit would legitimately configure the size back.)
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { after, test } from 'node:test';
+import React from 'react';
+
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient, StaticFontSource } from 'ntk';
+
+import { createRoot } from '../src/index.js';
+import { hooks } from '../src/trace-registry.js';
+
+const require = createRequire(import.meta.url);
+const fontDir = join(
+  dirname(require.resolve('katex/package.json')),
+  'dist',
+  'fonts',
+);
+
+const W = 240;
+const H = 200;
+
+async function headlessApp() {
+  const server = xserver.createServer({ width: 400, height: 400 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const fontSource = new StaticFontSource();
+  fontSource.add(readFileSync(join(fontDir, 'KaTeX_Main-Regular.ttf')), {
+    family: 'Test Main',
+  });
+  fontSource.alias('sans-serif', 'Test Main');
+  return createClient({ stream: clientEnd, fontSource });
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** Poll until `fn()` is truthy, or fail after `ms`. */
+async function waitFor(fn, what, ms = 1000) {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    if (fn()) return;
+    await sleep(10);
+  }
+  assert.fail(`timed out waiting for ${what}`);
+}
+
+const app = await headlessApp();
+const x11Root = await createRoot({ app });
+
+const frames = [];
+hooks.frame = (info) => frames.push(info);
+after(() => {
+  hooks.frame = null;
+  return app.close();
+});
+
+const element = (x, y, width = W, height = H) =>
+  React.createElement(
+    'window',
+    { x, y, width, height, style: { backgroundColor: '#f5f6fa' } },
+    React.createElement(
+      'box',
+      { style: { flexGrow: 1, padding: 8 } },
+      React.createElement('text', { style: { fontSize: 12 } }, 'hello'),
+    ),
+  );
+
+const instance = await new Promise((resolve) =>
+  x11Root.render(element(10, 10), resolve),
+);
+const node = instance._reactX11Node;
+node._scheduled = false;
+node.flush();
+// let the mount's own ConfigureNotify echo (same size as laid out) drain
+await sleep(120);
+frames.length = 0;
+
+test('a pure window move paints nothing', async () => {
+  app.X.ConfigureWindow(node.window.id, { x: 60, y: 40 });
+  // the event must actually arrive — otherwise this test passes vacuously
+  await waitFor(() => node.window.x === 60, 'the move ConfigureNotify');
+  await sleep(120); // two paced-frame intervals, room for a scheduled flush
+  assert.strictEqual(node.needsLayout, false, 'a move must not dirty layout');
+  assert.deepStrictEqual(
+    frames.map((f) => f.rects),
+    [],
+    'a move must not paint',
+  );
+});
+
+test('a React x/y-only prop change moves the window without painting', async () => {
+  frames.length = 0;
+  await new Promise((resolve) => x11Root.render(element(120, 90), resolve));
+  await waitFor(() => node.window.x === 120, 'the ConfigureWindow move');
+  await sleep(120);
+  assert.deepStrictEqual(
+    frames.map((f) => f.rects),
+    [],
+    'an x/y-only commit must not paint',
+  );
+});
+
+test('a React size prop change still repaints', async () => {
+  frames.length = 0;
+  await new Promise((resolve) =>
+    x11Root.render(element(120, 90, W + 40, H + 20), resolve),
+  );
+  await waitFor(() => frames.length > 0, 'the props-resize repaint');
+  await waitFor(
+    () => node.abs.width === W + 40,
+    'layout consuming the new width',
+  );
+});
+
+test('a WM-driven resize still lays out and repaints', async () => {
+  // drain the props-resize echo first so its frame is not counted here
+  await sleep(120);
+  frames.length = 0;
+  app.X.ConfigureWindow(node.window.id, { width: W + 100, height: H + 60 });
+  await waitFor(() => frames.length > 0, 'the resize repaint');
+  assert.strictEqual(node.abs.width, W + 100, 'layout consumed the new width');
+  assert.ok(
+    frames.some((f) => f.reasons?.includes('resize')),
+    `the frame names its reason (got ${JSON.stringify(frames.map((f) => f.reasons))})`,
+  );
+});


### PR DESCRIPTION
## What

Dragging a window produced a full relayout + `FULL WINDOW` repaint per pointer step. Two call sites treated position like size:

- `WindowNode`'s ntk `'resize'` listener ran `needsLayout = true; invalidate(true, null, 'resize')` on **every** ConfigureNotify — and ConfigureNotify fires for pure moves too (once per pointer step under an opaque-move WM like Compiz/KWin/Mutter). ntk already guards its own backing store against same-size events (`window.js:633`); the same guard now lives on the react-x11 side. Moves still refresh the screen origin (popup anchoring) and still reach `onResize`.
- The React-driven twin: an x/y-only `<window>` prop change claimed `layoutChanged` via `geometryChanged`, so a pointer-tracking popup repainted itself fully per motion. Position now moves the window and contributes no damage; a size change claims unbounded damage explicitly (the old `NO_DAMAGE`-next-to-`layoutChanged` combination fell through `invalidate`'s bounds bookkeeping and produced a `{x: NaN}` rect — no usable rect at all — leaving the echo ConfigureNotify to rescue the repaint).

## Measured

On Ubuntu/Unity (Compiz) with glamor-on-virgl, driving 30 synthetic moves through the WM (`ConfigureWindow` → SubstructureRedirect → synthetic ConfigureNotify, same stream as a real drag):

| | before | after |
|---|---|---|
| repaint frames | 30 × `FULL WINDOW reasons=resize` | **0** |
| per move | full relayout + repaint + `CreatePixmap`/`FreePixmap` churn + present blit | `TranslateCoordinates` + fence only |

Real resizes verified to still relayout and repaint (test + 10 synthetic resizes → 10 `resize` frames).

## Regression net

Three new protocol-bench scenarios (in-process server, deterministic):

| scenario | reqs | composites | Mpx |
|---|---|---|---|
| `window: 10 pure moves` | 43 | **0** | **0.00** |
| `update: 5 color flips, no layout` | 60 | 10 | 0.03 |
| `update: 5 absolute box moves (layout)` | 27 | 10 | 0.81 |

Reverting the guard explodes the pure-moves scenario to 463 requests / 210 composites / **2.98 Mpx** — far past `--check` tolerance, so this cannot quietly come back. The absolute-move scenario is baselined at its current full-window cost *on purpose*: it documents the unbounded-layout-damage inefficiency (any layout pass degrades the frame to FULL damage — 27× the pixels of the two box-sized rects actually needed); that number should drop when bounded layout damage lands, and `--check` only fails on increases.

Plus `test/window-move.test.js`: pure X move paints nothing, React x/y-only commit paints nothing, React size change and WM resize still repaint.

## Notes

- `npm run bench -- --check` still flags the pre-existing `mount` drift (89→108 requests on clean master, predates this branch — tracked separately). The new baseline entries were added without touching the existing ones.
- 463 tests pass (459 + 4 new), typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)