### PR TITLE
fix(debug): REACT_X11_NO_SCROLL_BLIT answers only to 1

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -105,13 +105,14 @@ Full repaints are the renderer's main performance bug class (see
 them. Expected full repaints exist too — a resize, the first frame after a
 mount, ntk invalidating its backing store — and their reasons say so.
 
-## `REACT_X11_NO_SCROLL_BLIT`
+## `REACT_X11_NO_SCROLL_BLIT=1`
 
 Disables the scroll-blit fast path (a pure scroll `CopyArea`s the
 surviving band and repaints only the exposed strip), so a scroll frame
 repaints its whole viewport again. For measuring the blit against the
 plain path on the same build, and as first aid if a scroll ever
-misrenders. Read once at startup, like the switches above.
+misrenders. Read once at startup, like the switches above, and like them
+it answers only to `1` — any other value leaves the blit on.
 
 ## The paint cache — `REACT_X11_NO_PAINT_CACHE`, `REACT_X11_PAINT_CACHE=verify`
 

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -156,8 +156,11 @@ const SCROLL_BLIT_MIN_AREA = 48 * 1024;
 
 // Escape hatch, read once like the other switches: for measuring the blit
 // against the plain path on the same build, and as first aid if a scroll
-// ever misrenders in the field.
-const NO_SCROLL_BLIT = Boolean(process.env.REACT_X11_NO_SCROLL_BLIT);
+// ever misrenders in the field. `=== '1'` like REACT_X11_NO_PAINT_CACHE —
+// a truthy check would read NO_SCROLL_BLIT=0 as "disable the blit", and a
+// stale export like that is exactly the kind of thing a cross-machine
+// performance comparison trips over.
+const NO_SCROLL_BLIT = process.env.REACT_X11_NO_SCROLL_BLIT === '1';
 
 // If less than this fraction of the viewport survives the shift, the
 // exposed strip is most of a repaint anyway.


### PR DESCRIPTION
The switch was truthy-checked (`Boolean(process.env.REACT_X11_NO_SCROLL_BLIT)`), so `REACT_X11_NO_SCROLL_BLIT=0` — an export that reads as "blit enabled" — silently disabled the scroll fast path everywhere the shell inherited it. The paint-cache switches already compare against `'1'`; now this one does too, and the docs say so.

Found while chasing a cross-machine performance comparison (mac vs Ubuntu VM), which is exactly the situation where a stale export like this poisons the numbers on one side only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)