### PR TITLE
feat(debug): report the frame fence, and a live-server frame bench

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -36,8 +36,13 @@ REACT_X11_TRACE=summary npm run examples:dashboard
   stderr when the process exits.
 - `requests` — one stderr line per request as it is sent
   (`x11 → Render.FillRectangles 36B`), plus one line per painted frame
-  (`frame 412: 320x24@8,40 reasons=style-state`). X errors are decoded and
-  name the failing request.
+  (`frame 412: 320x24@8,40 reasons=style-state fence=0.4ms`). X errors are
+  decoded and name the failing request. `fence` is ntk's measured server
+  round trip after the previous frame — how long the server took to drain
+  what that frame drew. Client work and server work separate here: a paint
+  that builds in 0.3ms against a fence of 20ms is a server-side problem
+  (software-fallback RENDER ops, a virtualized GPU), not a renderer one.
+  `npm run bench:frames` reports the same split as a summary.
 - `chrome:/tmp/trace.json` — [Chrome Trace Event
   JSON](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU),
   written at exit. Open it in Perfetto or `about:tracing`: React commits

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "screenshots": "tsx scripts/screenshots.jsx",
     "screenshots:framed": "tsx scripts/screenshots-framed.jsx",
     "bench": "tsx scripts/bench/protocol.js",
+    "bench:frames": "tsx scripts/bench/frames.js",
     "docs:dev": "npm --prefix website start",
     "docs:build": "npm --prefix website run build",
     "docs:test": "npm --prefix website test"

--- a/scripts/bench/frames.js
+++ b/scripts/bench/frames.js
@@ -1,0 +1,136 @@
+// Live-server frame benchmark: what does a 60Hz animation actually cost on
+// *this* X server?
+//
+//   npm run bench:frames                    # move a rounded box for 8s
+//   npm run bench:frames -- color           # paint-only change (no layout)
+//   npm run bench:frames -- text            # a re-laid-out label
+//   npm run bench:frames -- move 8 --square # same box, no borderRadius
+//
+// The protocol bench (protocol.js) counts requests against an in-process
+// server, so it is deterministic — and blind to how long a real server
+// takes to execute them. This one renders against $DISPLAY and reports the
+// two numbers that separate client cost from server cost:
+//
+//   paint    how long the client spent building each frame's requests
+//   fence    ntk's measured GetInputFocus round trip after each frame —
+//            how long the server took to drain them
+//
+// A healthy local server holds the fence well under a millisecond. A fence
+// that dwarfs paint is a server-side bottleneck: RENDER ops falling back to
+// software (glamor has no AddTraps acceleration — every rounded rectangle
+// pays it), a virtualized GPU, a compositor recomposite per blit. Run
+// `move` against `move --square` to see exactly what one rounded corner
+// mask costs on your setup; on glamor/virgl it has been measured at 10-40x
+// the fence of the square run.
+//
+// The damage columns catch the other regression class: `color` must stay
+// rect-bounded (~the box's own area), while `move`/`text` currently degrade
+// to FULL WINDOW because a layout pass claims unbounded damage.
+import { readFileSync, unlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import React from 'react';
+
+process.env.REACT_X11_NO_AUTORUN = '1';
+const { createRoot } = await import('../../src/index.js');
+const { startTrace } = await import('../../src/debug.js');
+
+const args = process.argv.slice(2).filter((a) => !a.startsWith('--'));
+const MODE = args[0] ?? 'move';
+const SECONDS = Number(args[1] ?? 8);
+const SQUARE = process.argv.includes('--square');
+if (!['move', 'color', 'text'].includes(MODE)) {
+  console.error(`unknown mode ${JSON.stringify(MODE)} — move | color | text`);
+  process.exit(1);
+}
+
+const e = React.createElement;
+const W = 800;
+const H = 600;
+
+function App({ tick }) {
+  const left = MODE === 'move' ? Math.round(340 + 300 * Math.sin(tick / 20)) : 340;
+  const color = MODE === 'color' ? (tick % 2 ? '#3498db' : '#e74c3c') : '#3498db';
+  const label = MODE === 'text' ? `tick ${tick}` : 'tick';
+  return e(
+    'window',
+    { width: W, height: H, title: 'bench:frames', style: { backgroundColor: '#f4f4f4' } },
+    e(
+      'box',
+      { style: { flexGrow: 1, padding: 16, gap: 12 } },
+      e('text', { style: { fontSize: 20, color: '#222' } }, label),
+      e('box', {
+        style: {
+          position: 'absolute',
+          left,
+          top: 80,
+          width: 100,
+          height: 100,
+          backgroundColor: color,
+          borderRadius: SQUARE ? 0 : 8,
+        },
+      }),
+      e(
+        'text',
+        { style: { color: '#7f8c8d', marginTop: 200 } },
+        'static text below the animation to give the frame some weight',
+      ),
+    ),
+  );
+}
+
+const tracePath = join(tmpdir(), `react-x11-frames-${process.pid}.json`);
+const trace = startTrace({ sink: 'chrome', path: tracePath });
+const root = await createRoot();
+
+let tick = 0;
+root.render(e(App, { tick }));
+await new Promise((r) => setTimeout(r, 500)); // mount and settle
+
+const t0 = performance.now();
+const timer = setInterval(() => {
+  tick += 1;
+  root.render(e(App, { tick }));
+}, 16);
+await new Promise((r) => setTimeout(r, SECONDS * 1000));
+clearInterval(timer);
+const elapsed = (performance.now() - t0) / 1000;
+
+const stats = trace.stop();
+const events = JSON.parse(readFileSync(tracePath, 'utf8')).traceEvents;
+unlinkSync(tracePath);
+
+const frames = events.filter((ev) => ev.name === 'frame');
+const paint = frames.map((f) => f.dur / 1000).sort((a, b) => a - b);
+const fence = frames
+  .map((f) => f.args?.fenceMs)
+  .filter((v) => typeof v === 'number')
+  .sort((a, b) => a - b);
+const full = frames.filter((f) => f.args?.full).length;
+const areas = frames
+  .filter((f) => !f.args?.full)
+  .map((f) => f.args.area)
+  .sort((a, b) => a - b);
+
+const avg = (a) => (a.length ? a.reduce((s, v) => s + v, 0) / a.length : null);
+const q = (a, p) =>
+  a.length ? a[Math.min(a.length - 1, Math.floor(p * a.length))] : null;
+const ms = (v) => (v == null ? '   -' : v.toFixed(2).padStart(6));
+
+console.log(
+  `${MODE}${SQUARE ? ' (square)' : ''}: ${frames.length} frames in ${elapsed.toFixed(1)}s` +
+    ` = ${(frames.length / elapsed).toFixed(1)} fps (${tick} ticks issued)`,
+);
+console.log(
+  `  damage   ${full} FULL WINDOW, ${areas.length} bounded` +
+    (areas.length ? ` (avg ${Math.round(avg(areas) / 1000)}kpx)` : ''),
+);
+console.log(
+  `           min    avg    p95    max   (ms)\n` +
+    `  paint  ${ms(paint[0])} ${ms(avg(paint))} ${ms(q(paint, 0.95))} ${ms(paint[paint.length - 1])}\n` +
+    `  fence  ${ms(fence[0])} ${ms(avg(fence))} ${ms(q(fence, 0.95))} ${ms(fence[fence.length - 1])}`,
+);
+console.log(
+  `  wire     ${stats.requests} requests, ${(stats.bytesOut / 1024).toFixed(0)}KB out, ${stats.replies} replies`,
+);
+process.exit(0);

--- a/scripts/bench/frames.js
+++ b/scripts/bench/frames.js
@@ -49,12 +49,19 @@ const W = 800;
 const H = 600;
 
 function App({ tick }) {
-  const left = MODE === 'move' ? Math.round(340 + 300 * Math.sin(tick / 20)) : 340;
-  const color = MODE === 'color' ? (tick % 2 ? '#3498db' : '#e74c3c') : '#3498db';
+  const left =
+    MODE === 'move' ? Math.round(340 + 300 * Math.sin(tick / 20)) : 340;
+  const color =
+    MODE === 'color' ? (tick % 2 ? '#3498db' : '#e74c3c') : '#3498db';
   const label = MODE === 'text' ? `tick ${tick}` : 'tick';
   return e(
     'window',
-    { width: W, height: H, title: 'bench:frames', style: { backgroundColor: '#f4f4f4' } },
+    {
+      width: W,
+      height: H,
+      title: 'bench:frames',
+      style: { backgroundColor: '#f4f4f4' },
+    },
     e(
       'box',
       { style: { flexGrow: 1, padding: 16, gap: 12 } },

--- a/src/debug.js
+++ b/src/debug.js
@@ -323,7 +323,7 @@ function createSession({ sink, path }) {
       }
     },
 
-    frame({ rects, reasons, start, end }) {
+    frame({ rects, reasons, start, end, fence }) {
       frames += 1;
       const full = !rects;
       const area = full
@@ -334,7 +334,14 @@ function createSession({ sink, path }) {
           ? 'FULL WINDOW'
           : rects.map((r) => `${r.width}x${r.height}@${r.x},${r.y}`).join(' ');
         const why = reasons?.length ? ` reasons=${reasons.join('+')}` : '';
-        line(`frame ${frames}: ${where}${why}`);
+        // the previous frame's measured server drain: on a healthy local
+        // server it sits well under a millisecond, and a fence that grows
+        // with window area is the signature of a server-side bottleneck
+        // (software-fallback RENDER ops, a virtualized GPU) that client
+        // timings cannot show
+        const wait =
+          typeof fence === 'number' ? ` fence=${fence.toFixed(1)}ms` : '';
+        line(`frame ${frames}: ${where}${why}${wait}`);
       }
       record({
         name: 'frame',
@@ -349,6 +356,7 @@ function createSession({ sink, path }) {
           rects: rects?.length ?? 0,
           area,
           reasons: reasons ?? [],
+          fenceMs: typeof fence === 'number' ? +fence.toFixed(2) : undefined,
         },
       });
     },

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -4526,6 +4526,11 @@ export class WindowNode extends Node {
         reasons: this._lastReasons,
         start: started,
         end: performance.now(),
+        // ntk's last measured frame fence (GetInputFocus round trip after a
+        // frame's requests): how long the server took to drain them. Client
+        // work and server drain separate cleanly in a trace only when both
+        // are in it — a slow virtualized GPU shows up here, not in `end`.
+        fence: this.window.frameLatency,
       });
     }
     // A frame that actually painted, which is the moment the app is up


### PR DESCRIPTION
## What

The trace always showed client-side timings, and the client is almost never the problem: on a glamor-on-virgl VM a frame that took 0.3ms to build took the server 4–30ms to drain, and nothing in the diagnostics said so.

ntk already measures exactly that number after every frame (`wnd.frameLatency` — the GetInputFocus fence round trip). Now it rides along on the frame hook:

- `REACT_X11_TRACE=requests` frame lines gain `fence=NN.Nms`
- the chrome trace's frame slices gain `args.fenceMs`
- `npm run bench:frames` reports the split as a summary against the real `$DISPLAY`: paint vs fence percentiles, damage shape (FULL WINDOW vs bounded + avg damaged area), achieved fps, for a 60Hz box animation in three flavours (`move` / `color` / `text`, plus `--square`)

## Why the fence matters

`paint` is client work; `fence` is server drain. They separate cleanly only when both are visible:

```
color: 202 frames in 4.0s = 50.5 fps (240 ticks issued)
  damage   2 FULL WINDOW, 200 bounded (avg 10kpx)
           min    avg    p95    max   (ms)
  paint    0.09   0.35   0.54  21.12
  fence    2.44  13.31  32.64  34.10
```

That is a real run on Xorg/glamor/virgl under Compiz — the renderer builds frames in microseconds and the server takes 13ms to chew them. Running `bench:frames move` against `bench:frames move --square` isolates what a single rounded-corner `AddTraps` mask costs per frame on the server at hand: measured 0.4ms → 4.5ms avg fence (p95 0.7ms → 17ms) on glamor/virgl, and near-free on software servers. That asymmetry is the whole "fast under XQuartz, slow in the VM" story in two commands.

459 tests pass, typecheck + lint clean. The fence field is absent (not 0) on servers/mocks with no frame clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)