### PR TITLE
perf(paint): bound layout damage to what moved

### DIFF
--- a/scripts/bench/baseline.json
+++ b/scripts/bench/baseline.json
@@ -80,11 +80,11 @@
     "compositePixels": 25020
   },
   "update: 5 absolute box moves (layout)": {
-    "requests": 27,
-    "bytesOut": 572,
+    "requests": 58,
+    "bytesOut": 1156,
     "bytesIn": 384,
     "replies": 12,
     "composites": 10,
-    "compositePixels": 812000
+    "compositePixels": 31320
   }
 }

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -113,6 +113,15 @@ const NO_DAMAGE = Symbol('no-damage');
 // against it.
 const DAMAGE_SLOP = 1;
 
+// While a bounded frame's layout pass runs, every node whose absolute rect
+// comes out different reports its old and new rects here (each already
+// inflated by that node's own paint reach) — which is what lets a layout
+// change stay a handful of rects instead of degrading the frame to
+// FULL_DAMAGE. Module state rather than a parameter because absolutize is
+// a hot recursive walk with overrides in three classes; null outside the
+// pass, and always restored through `finally`.
+let layoutDiffSink = null;
+
 // What an invalidate() may name as its reason — a small closed set, so the
 // frame log, the tracer and the full-repaint warning can print "why" next
 // to "where". A typo'd reason would silently vanish from every report, so
@@ -186,6 +195,16 @@ function insetRect(rect, by) {
     width: rect.width - 2 * by,
     height: rect.height - 2 * by,
   };
+}
+
+/** The overlap of two rects, or null when they have none. */
+function intersectRects(a, b) {
+  const x = Math.max(a.x, b.x);
+  const y = Math.max(a.y, b.y);
+  const right = Math.min(a.x + a.width, b.x + b.width);
+  const bottom = Math.min(a.y + a.height, b.y + b.height);
+  if (right <= x || bottom <= y) return null;
+  return { x, y, width: right - x, height: bottom - y };
 }
 
 /** The full track strip a scrollbar occupies (thumb travel included), with
@@ -899,39 +918,21 @@ export class Node {
   }
 
   /**
-   * True when this node's own box cannot change size, so a reflow of its
-   * children cannot move anything outside it. Both axes have to be pinned: a
-   * node with an explicit width but an auto height still grows downwards when
-   * a child appears, which moves its siblings.
-   */
-  _sizePinned() {
-    return (
-      typeof this.style?.width === 'number' &&
-      typeof this.style?.height === 'number'
-    );
-  }
-
-  /**
    * A child was inserted or removed. `before` is this node's paint bounds from
    * *before* the mutation, which the caller has to capture while the departing
    * child is still attached.
    *
-   * A child list change is a layout change, and a layout change with no bound
-   * repaints the window — which is what made toggling a `Checkbox` or a
-   * `Radio` cost a full repaint: the tick and the dot are children that mount
-   * and unmount. But when this node's own size is pinned, the reflow is
-   * confined to its subtree, so the damage is that subtree before the mutation
-   * unioned with the same subtree after layout. The second half is not
-   * measurable yet — an inserted child has no rect until layout runs — so the
-   * node is queued for the root to re-measure once it has.
+   * The damage is this subtree before the mutation unioned with the same
+   * subtree after layout. The second half is not measurable yet — an
+   * inserted child has no rect until layout runs — so the node is queued
+   * for the root to re-measure once it has. Siblings the reflow displaces
+   * outside this subtree (this node growing taller, say) claim themselves
+   * through the layout diff in flush(), which is what lets this claim stay
+   * bounded without requiring the node's own size to be pinned.
    */
   _childListChanged(before) {
     const root = this.root;
     if (!root) return;
-    if (!this._sizePinned()) {
-      root.invalidate(true, null, 'child-list');
-      return;
-    }
     root.invalidate(true, before, 'child-list');
     root._reflowed.add(this);
   }
@@ -1000,19 +1001,21 @@ export class Node {
     }
     // This is how every React update arrives, so it is where partial
     // painting pays for itself. `applyLayoutStyle` has just told us whether
-    // anything can have *moved*: if not, this node's own region bounds what
-    // changed — a new colour, a new label, a different border. And if
-    // nothing it draws changed at all, it contributes no damage, which is
-    // what keeps a commit from widening the region to every node it touched.
-    this.root?.invalidate(
-      layoutChanged,
-      layoutChanged
-        ? null
-        : this._paintChanged(newProps, prev, style, prevStyle)
-          ? this
-          : NO_DAMAGE,
-      'props',
-    );
+    // anything can have *moved*: if so, this subtree's before/after rects
+    // plus the layout diff bound the frame; if not, this node's own region
+    // bounds what changed — a new colour, a new label, a different border.
+    // And if nothing it draws changed at all, it contributes no damage,
+    // which is what keeps a commit from widening the region to every node
+    // it touched.
+    if (layoutChanged) {
+      this._invalidateLayout('props');
+    } else {
+      this.root?.invalidate(
+        false,
+        this._paintChanged(newProps, prev, style, prevStyle) ? this : NO_DAMAGE,
+        'props',
+      );
+    }
   }
 
   /**
@@ -1048,6 +1051,9 @@ export class Node {
   }
 
   setHidden(hidden) {
+    // claimed before the yoga flip so the bound covers the arrangement
+    // being vacated; the reveal is the after-layout re-claim
+    this._invalidateLayout('props');
     this.hidden = hidden;
     if (this.yoga) {
       this.yoga.setDisplay(
@@ -1056,7 +1062,6 @@ export class Node {
           : Yoga.DISPLAY_FLEX,
       );
     }
-    this.root?.invalidate(true, null, 'props');
   }
 
   /**
@@ -1219,15 +1224,58 @@ export class Node {
 
   absolutize(originX, originY) {
     if (!this.yoga) return;
-    this.abs = {
-      x: originX + this.yoga.getComputedLeft(),
-      y: originY + this.yoga.getComputedTop(),
-      width: this.yoga.getComputedWidth(),
-      height: this.yoga.getComputedHeight(),
-    };
+    this._assignAbs(
+      originX + this.yoga.getComputedLeft(),
+      originY + this.yoga.getComputedTop(),
+      this.yoga.getComputedWidth(),
+      this.yoga.getComputedHeight(),
+    );
     for (const child of this.children) {
       if (!child.isWindow) child.absolutize(this.abs.x, this.abs.y);
     }
+  }
+
+  /**
+   * absolutize's write to `abs`, funneled through one place so a bounded
+   * frame's layout diff sees every node the pass actually moved or resized.
+   * The old and new rects are claimed separately (not their union box —
+   * a node crossing the window would drag everything between them along),
+   * each grown by this node's own paint reach. A rect that was or became
+   * zero-area claims nothing: there were, or will be, no pixels there.
+   */
+  _assignAbs(x, y, width, height) {
+    const old = this.abs;
+    this.abs = { x, y, width, height };
+    if (
+      layoutDiffSink &&
+      (old.x !== x ||
+        old.y !== y ||
+        old.width !== width ||
+        old.height !== height)
+    ) {
+      const grow = this._outlineExtent() + DAMAGE_SLOP;
+      if (old.width > 0 && old.height > 0) {
+        layoutDiffSink(insetRect(old, -grow));
+      }
+      if (width > 0 && height > 0) {
+        layoutDiffSink(insetRect(this.abs, -grow));
+      }
+    }
+  }
+
+  /**
+   * A layout-affecting change confined to this node: claim the subtree as
+   * it stands now, and queue it for a second claim once layout has run —
+   * the same before/after protocol `_childListChanged` uses. Anything
+   * *else* the reflow displaces claims itself through the layout diff in
+   * `flush()`, so the frame stays bounded instead of collapsing to
+   * FULL_DAMAGE the way a bare `invalidate(true, null)` would.
+   */
+  _invalidateLayout(reason) {
+    const root = this.root;
+    if (!root) return;
+    root.invalidate(true, this.paintBounds(), reason);
+    root._reflowed.add(this);
   }
 
   /**
@@ -1631,7 +1679,13 @@ export class TextChunkNode extends Node {
   setText(text) {
     this.text = String(text);
     this.parent?._textContentChanged();
-    this.root?.invalidate(true, null, 'text');
+    // the chunk has no geometry of its own — the ancestor that owns a yoga
+    // node is the box that rewraps, and its before/after rects are the
+    // bound on what a new string can repaint
+    let owner = this.parent;
+    while (owner && !owner.yoga) owner = owner.parent;
+    if (owner) owner._invalidateLayout('text');
+    else this.root?.invalidate(true, null, 'text');
   }
 
   _textContentChanged() {
@@ -1790,7 +1844,7 @@ export class ImageNode extends Node {
       this.image = image;
       if (this.yoga) {
         this.yoga.markDirty?.();
-        this.root?.invalidate(true, null, 'content');
+        this._invalidateLayout('content');
       }
     } catch (err) {
       console.error(`react-x11: failed to load image ${src}:`, err.message);
@@ -1954,12 +2008,12 @@ export class ScrollViewNode extends Node {
 
   absolutize(originX, originY) {
     if (!this.yoga) return;
-    this.abs = {
-      x: originX + this.yoga.getComputedLeft(),
-      y: originY + this.yoga.getComputedTop(),
-      width: this.yoga.getComputedWidth(),
-      height: this.yoga.getComputedHeight(),
-    };
+    this._assignAbs(
+      originX + this.yoga.getComputedLeft(),
+      originY + this.yoga.getComputedTop(),
+      this.yoga.getComputedWidth(),
+      this.yoga.getComputedHeight(),
+    );
     const { right, bottom } = this._measureContent();
     this.contentHeight =
       bottom + this.yoga.getComputedPadding(Yoga.EDGE_BOTTOM);
@@ -1968,10 +2022,41 @@ export class ScrollViewNode extends Node {
     this.scrollY = Math.min(Math.max(0, this.scrollY), this._maxScroll('y'));
     this.scrollX = Math.min(Math.max(0, this.scrollX), this._maxScroll('x'));
     this._reportViewport();
-    for (const child of this.children) {
-      if (!child.isWindow) {
-        child.absolutize(this.abs.x - this.scrollX, this.abs.y - this.scrollY);
+    const ox = this.abs.x - this.scrollX;
+    const oy = this.abs.y - this.scrollY;
+    // The layout diff and a scroll would double-report each other: a scroll
+    // is a uniform shift of everything below this viewport, already claimed
+    // as the viewport itself (or narrowed to the exposed strip by the blit),
+    // and per-child old/new claims would re-widen the very frame the blit
+    // narrows. So when the children's origin moved, the walk below runs
+    // with the diff off. When it did not move, a child that moved did so by
+    // real layout — claim it, but clipped to the viewport: ink below the
+    // fold never reaches the surface, and an unclipped claim would repaint
+    // whatever unrelated UI sits under this node's off-viewport extent.
+    const shifted =
+      this._childOrigin &&
+      (this._childOrigin.x !== ox || this._childOrigin.y !== oy);
+    this._childOrigin = { x: ox, y: oy };
+    const outer = layoutDiffSink;
+    if (outer) {
+      if (shifted) {
+        layoutDiffSink = null;
+      } else {
+        const vp = insetRect(this.abs, -DAMAGE_SLOP);
+        layoutDiffSink = (rect) => {
+          const clipped = intersectRects(rect, vp);
+          if (clipped) outer(clipped);
+        };
       }
+    }
+    try {
+      for (const child of this.children) {
+        if (!child.isWindow) {
+          child.absolutize(ox, oy);
+        }
+      }
+    } finally {
+      layoutDiffSink = outer;
     }
   }
 
@@ -2163,7 +2248,9 @@ export class ScrollViewNode extends Node {
   scrollIntoView(node) {
     if (!node) return;
     this._scrollIntoViewTarget = node;
-    this.root?.invalidate(true, null, 'scroll');
+    // whatever the resolved scroll moves is inside this clipped viewport,
+    // so the viewport's own before/after rects bound the frame
+    this._invalidateLayout('scroll');
   }
 
   _resolveScrollIntoView() {
@@ -3312,7 +3399,7 @@ export class TextInputNode extends Node {
     }
     if (metricsChanged) {
       this.yoga.markDirty();
-      this.root?.invalidate(true, null, 'props');
+      this._invalidateLayout('props');
     } else if (newProps.value !== before.value) {
       this.root?.invalidate(false, null, 'text');
     }
@@ -3498,7 +3585,7 @@ export class TextAreaNode extends TextInputNode {
     super.applyProps(newProps, oldProps);
     if (newProps.rows !== before.rows) {
       this.yoga.markDirty();
-      this.root?.invalidate(true, null, 'props');
+      this._invalidateLayout('props');
     }
   }
 
@@ -4469,14 +4556,30 @@ export class WindowNode extends Node {
     this._advanceAnimations(now());
     const width = this.window.width ?? this.props.width ?? 0;
     const height = this.window.height ?? this.props.height ?? 0;
+    let layoutMoved = false;
     if (this.needsLayout) {
       this._resolveSizeQueries(width, height);
       this.yoga.setWidth(width);
       this.yoga.setHeight(height);
       this.yoga.calculateLayout(width, height, Yoga.DIRECTION_LTR);
       this.abs = { x: 0, y: 0, width, height };
-      for (const child of this.children) {
-        if (!child.isWindow) child.absolutize(0, 0);
+      // A bounded frame watches the walk: whatever this pass actually moved
+      // claims its old and new rects through the sink, and the frame stays
+      // a few rects instead of the whole window. An unbounded frame skips
+      // the bookkeeping — it repaints everything anyway.
+      if (this._damage !== FULL_DAMAGE) {
+        layoutDiffSink = (rect) => {
+          if (this._damage === FULL_DAMAGE) return;
+          layoutMoved = true;
+          this._damage = addDamageRect(this._damage, rect);
+        };
+      }
+      try {
+        for (const child of this.children) {
+          if (!child.isWindow) child.absolutize(0, 0);
+        }
+      } finally {
+        layoutDiffSink = null;
       }
       this.needsLayout = false;
       this.needsPaint = true;
@@ -4498,7 +4601,7 @@ export class WindowNode extends Node {
     // after layout (the claims above included), before the damage is taken:
     // a frame that turns out to be a pure scroll blits the surviving band
     // and narrows its claim to the exposed strip
-    this._applyScrollBlits(width, height);
+    this._applyScrollBlits(width, height, layoutMoved);
     if (!this.needsPaint) return;
     this.needsPaint = false;
     const damage = this._takeDamage(width, height);
@@ -4568,7 +4671,7 @@ export class WindowNode extends Node {
    * has always been the behavior. The fast path can therefore cost
    * correctness nothing: the worst mistake it can make is not firing.
    */
-  _applyScrollBlits(width, height) {
+  _applyScrollBlits(width, height, layoutMoved = false) {
     const pending = this._pendingScrolls;
     if (!pending?.size) return;
     const nodes = [...pending];
@@ -4588,6 +4691,10 @@ export class WindowNode extends Node {
       return;
     }
     if (!Array.isArray(this._damage)) return; // unbounded frame already
+    // the layout diff claimed real movement this pass — the frame is not a
+    // pure scroll, and a blit under rearranged content would shift stale
+    // pixels into place the repaint no longer covers
+    if (layoutMoved) return;
     // children clip to the border box, so a border ring or rounded corner
     // would be shifted like content
     if (node.style.borderWidth > 0 || node.style.borderRadius > 0) return;

--- a/src/richnodes.js
+++ b/src/richnodes.js
@@ -72,7 +72,7 @@ class DocumentViewNode extends Node {
     if (this.destroyed) return;
     this._laidOutWidth = -1;
     this.yoga?.markDirty();
-    this.root?.invalidate(true, null, 'content');
+    this._invalidateLayout('content');
   }
 
   _source() {
@@ -306,7 +306,7 @@ export class SvgNode extends Node {
   _textContentChanged() {
     this._stale = true;
     this.yoga?.markDirty();
-    this.root?.invalidate(true, null, 'props');
+    this._invalidateLayout('props');
   }
 
   _ensureView() {
@@ -468,7 +468,7 @@ export class TexNode extends Node {
   _textContentChanged() {
     this._boxKey = null;
     this.yoga?.markDirty();
-    this.root?.invalidate(true, null, 'text');
+    this._invalidateLayout('text');
   }
 
   _ensureBox() {
@@ -504,7 +504,7 @@ export class TexNode extends Node {
       newProps.displayMode !== before.displayMode
     ) {
       this.yoga.markDirty();
-      this.root?.invalidate(true, null, 'props');
+      this._invalidateLayout('props');
     }
   }
 

--- a/test/dirty-rect.test.js
+++ b/test/dirty-rect.test.js
@@ -477,7 +477,7 @@ test('a subtree is culled by its whole extent, not its own rect', async () => {
   }
 });
 
-test('a layout change is never painted partially', async () => {
+test('a layout change is bounded to what moved, pixel-exact', async () => {
   const app = await headlessApp();
   const x11Root = await createRoot({ app });
   try {
@@ -486,8 +486,9 @@ test('a layout change is never painted partially', async () => {
     const row = refs[3].current;
     const root = row.root;
 
-    // a height change moves every row below it, so the region the changed
-    // node covers says nothing about where stale pixels are
+    // a height change moves every row below it: the changed row claims its
+    // before/after subtree, and each displaced sibling claims its own old
+    // and new rects through the layout diff — the rows above never repaint
     const { damage, diff } = await paintBothWays(app, root, () => {
       row.applyProps(
         { ...row.props, style: { ...HOISTED[3], height: 40 } },
@@ -495,8 +496,23 @@ test('a layout change is never painted partially', async () => {
       );
     });
 
-    assert.equal(damage, null, 'a layout change repaints the whole window');
     assert.equal(diff, 0, `${diff} pixels differ from a full repaint`);
+    assert.ok(damage, 'a bounded layout change must not repaint the window');
+    const row2Bottom = 6 + 2 * (ROW_H + 3) + ROW_H; // unmoved rows above
+    assert.ok(
+      damage.y >= row2Bottom,
+      `damage starts at y=${damage.y}, repainting the unmoved rows above ` +
+        `(row 2 ends at ${row2Bottom})`,
+    );
+    // both arrangements of the shifted rows: old row 7 ends at 171, and
+    // after row 3 grows by 22 every later row sits 22 lower, so the grown
+    // layout's row 7 ends at 193 — the bound must reach the deeper one
+    const lastRowNewBottom = 6 + 7 * (ROW_H + 3) + ROW_H + (40 - ROW_H);
+    assert.ok(
+      damage.y + damage.height >= lastRowNewBottom,
+      `damage ends at ${damage.y + damage.height}, short of the shifted ` +
+        `rows (row 7 now ends at ${lastRowNewBottom})`,
+    );
   } finally {
     await app.close();
   }
@@ -922,14 +938,14 @@ test('mounting a child inside a fixed-size box repaints only that box', async ()
   }
 });
 
-test('a child mounting in an auto-sized box still repaints in full', async () => {
+test('a child mounting in an auto-sized box stays bounded', async () => {
   const app = await headlessApp();
   const x11Root = await createRoot({ app });
   try {
-    // The counterpart, and the reason the rule checks *both* axes: a box with
-    // no pinned height grows when a child appears, which moves its siblings —
-    // so there is nothing safe to bound the repaint to. If this came back
-    // bounded, the test above would prove nothing about the pinned case.
+    // A box with no pinned height grows when a child appears, which moves
+    // its siblings — the box's own before/after claim cannot bound that,
+    // but the displaced sibling claims itself through the layout diff, so
+    // the frame stays the growth region instead of the whole window.
     const { root, setState } = await mountStateful(x11Root, (state) => [
       React.createElement(
         'box',
@@ -949,10 +965,114 @@ test('a child mounting in an auto-sized box still repaints in full', async () =>
 
     const regions = await framesDuring(root, app, () => setState(1));
     assert.strictEqual(regions.length, 1, 'one repaint');
-    assert.strictEqual(
-      regions[0],
-      null,
-      'an unpinned box grows, moving its siblings, so the frame is unbounded',
+    const damage = regions[0];
+    assert.ok(damage, 'the growth must not repaint the whole window');
+    // the grown box plus the sibling it pushed down, in both arrangements:
+    // everything ends well inside the top quarter of the window
+    assert.ok(
+      damage.y + damage.height >= 45 && damage.y + damage.height <= 50,
+      `damage ends at ${damage.y + damage.height}, expected the pushed ` +
+        'sibling to bound it near 46',
+    );
+    // and the bounded frame left exactly the pixels a full repaint would
+    const ctx = (root._ctx ??= root.window.getContext('2d'));
+    const settle = () =>
+      new Promise((resolve) => app.X.GetInputFocus(() => resolve()));
+    const partial = await readPixels(ctx, W, H);
+    root.needsPaint = true;
+    root._damage = null;
+    root.flush();
+    await settle();
+    const full = await readPixels(ctx, W, H);
+    const diff = differences(partial, full);
+    assert.equal(diff, 0, `${diff} pixels differ from a full repaint`);
+  } finally {
+    await app.close();
+  }
+});
+
+/** Read pixels twice — after the bounded frame, and after forcing a full
+ * repaint of the same tree — and return the damage box plus the diff. */
+async function reactPaintBothWays(app, root, act) {
+  const regions = await framesDuring(root, app, act);
+  const ctx = (root._ctx ??= root.window.getContext('2d'));
+  const settle = () =>
+    new Promise((resolve) => app.X.GetInputFocus(() => resolve()));
+  const partial = await readPixels(ctx, W, H);
+  root.needsPaint = true;
+  root._damage = null;
+  root.flush();
+  await settle();
+  const full = await readPixels(ctx, W, H);
+  return { regions, diff: differences(partial, full) };
+}
+
+test('an absolutely-positioned box moving stays a strip, pixel-exact', async () => {
+  const app = await headlessApp();
+  const x11Root = await createRoot({ app });
+  try {
+    // The animation case the bench pins (`update: 5 absolute box moves`):
+    // `left` changes, layout runs, and the frame must be the box's old and
+    // new rects — not the window. The damage box spans both positions
+    // horizontally, so the vertical extent is what proves the bound.
+    const { root, setState } = await mountStateful(x11Root, (state) =>
+      React.createElement('box', {
+        key: 'float',
+        style: {
+          position: 'absolute',
+          left: 20 + state * 120,
+          top: 40,
+          width: 50,
+          height: 50,
+          backgroundColor: '#0984e3',
+        },
+      }),
+    );
+    const { regions, diff } = await reactPaintBothWays(app, root, () =>
+      setState(1),
+    );
+    assert.equal(diff, 0, `${diff} pixels differ from a full repaint`);
+    assert.strictEqual(regions.length, 1, 'one repaint');
+    const damage = regions[0];
+    assert.ok(damage, 'a moved absolute box must not repaint the window');
+    assert.ok(
+      damage.height <= 50 + 2 * SLOP + 2,
+      `damage is ${damage.height}px tall for a 50px box`,
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test('a text change repaints the text line, pixel-exact', async () => {
+  const app = await headlessApp();
+  const x11Root = await createRoot({ app });
+  try {
+    // The ticking-label case: a new string rewraps inside the <text> box,
+    // whose before/after claim bounds the frame. The block below it must
+    // not repaint — its rect is unchanged, so the layout diff stays quiet.
+    const { root, setState } = await mountStateful(x11Root, (state) => [
+      React.createElement(
+        'text',
+        { key: 't', style: { fontSize: 12 } },
+        `tick ${state}`,
+      ),
+      React.createElement('box', {
+        key: 'b',
+        style: { height: ROW_H, backgroundColor: '#e6e9ef', marginTop: 60 },
+      }),
+    ]);
+    const { regions, diff } = await reactPaintBothWays(app, root, () =>
+      setState(1),
+    );
+    assert.equal(diff, 0, `${diff} pixels differ from a full repaint`);
+    assert.strictEqual(regions.length, 1, 'one repaint');
+    const damage = regions[0];
+    assert.ok(damage, 'a text change must not repaint the window');
+    assert.ok(
+      damage.y + damage.height < 60,
+      `damage reaches y=${damage.y + damage.height}, into the unmoved ` +
+        'block that starts 60px down',
     );
   } finally {
     await app.close();


### PR DESCRIPTION
Closes #186.

## What

A layout change no longer degrades the frame to FULL WINDOW. Two mechanisms compose:

1. **The initiating node claims its subtree before and after the layout pass** — the `_childListChanged` before/`_reflowed`-after protocol, extracted as `_invalidateLayout()` and adopted by every in-window layout site: `Node.applyProps`, text chunks, `<image>`/markdown/html/svg/tex content loads, `setHidden`, `scrollIntoView`, textinput/textarea metrics.
2. **Whatever else the reflow displaces claims itself**: on bounded frames, the `absolutize` walk reports each node whose rect actually changed (old and new rects claimed separately, grown by the node's own paint reach — outline + slop). Unbounded frames skip the bookkeeping entirely.

Scrollviews get the careful treatment: a shifted child origin (a scroll) turns the diff off below the viewport — the viewport claim/blit strip already covers it, and per-child claims would re-widen what the blit just narrowed. An unshifted origin keeps claims on, clipped to the viewport. Any frame where the diff claimed movement skips the scroll blit (not a pure scroll). `_sizePinned` is gone: displaced siblings claim themselves now, so child-list changes in auto-sized boxes stay bounded too.

## Measured

| | before | after |
|---|---|---|
| bench `update: 5 absolute box moves (layout)` | 812,000 px | **31,320 px** (level with the paint-only flip) |
| live 60Hz box move (glamor/virgl, Compiz) | 475/475 frames FULL WINDOW | **1/289** (the mount), ~11.6kpx/frame |
| live ticking label | 477/477 FULL | **1/359**, ~23.1kpx/frame |
| bench `scroll: 10 notches over 500 rows` | 418 req / 0.65 Mpx | unchanged to the byte |

## Verification

- 465 tests pass. The two tests that asserted the old contract ("a layout change repaints the whole window") now assert bounded + **pixel-exact against a forced full repaint**, with geometric bounds (rows above the change must not repaint; the claim must reach the deepest shifted row in both arrangements).
- Two new React-driven tests: absolute-position move stays a box-height strip; a text change stays above an unmoved sibling. Both pixel-exact.
- `stress:check` damage assertions (one cell / scattered / every cell) pass with output identical to master. (Its intermittent exit-0 hang is pre-existing — sidorares/node-x11#264.)
- `bench --check` green except the pre-existing mount drift (89→108, tracked separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)