### PR TITLE
perf(paint): bound the invalidate sites that already know their rect (#187)

### DIFF
--- a/src/nodes.js
+++ b/src/nodes.js
@@ -3401,7 +3401,10 @@ export class TextInputNode extends Node {
       this.yoga.markDirty();
       this._invalidateLayout('props');
     } else if (newProps.value !== before.value) {
-      this.root?.invalidate(false, null, 'text');
+      // painting clips to the content box and the measure function reads
+      // only font metrics, so a value change is confined to the field —
+      // the same claim applyProps makes for any paint-only prop
+      this.root?.invalidate(false, this, 'text');
     }
   }
 
@@ -3527,7 +3530,8 @@ export class TextAreaNode extends TextInputNode {
     const next = Math.min(Math.max(0, y), bar.range);
     if (next === this._scrollY) return;
     this._scrollY = next;
-    this.root?.invalidate(false, null, 'scroll');
+    // an inner scroll moves pixels only inside the field's own clip
+    this.root?.invalidate(false, this, 'scroll');
   }
 
   constructor(props, app) {
@@ -3603,7 +3607,8 @@ export class TextAreaNode extends TextInputNode {
     const next = Math.min(Math.max(0, this._scrollY + dy), max);
     if (next === this._scrollY) return;
     this._scrollY = next;
-    this.root?.invalidate(false, null, 'scroll');
+    // an inner scroll moves pixels only inside the field's own clip
+    this.root?.invalidate(false, this, 'scroll');
   }
 
   /** Visual lines that fit in the viewport — one Page keypress worth. */
@@ -4861,7 +4866,12 @@ export class WindowNode extends Node {
       // The clip is belt to the culling's braces: it bounds the server-side
       // mask work for whatever *does* paint, and it contains any node that
       // inks slightly outside its own rect. Rectangular clips take ntk's
-      // server-side fast path, so this is cheap.
+      // server-side fast path, so this is cheap. The unbounded pass stays
+      // unclipped on purpose: a clip would only re-report what ntk already
+      // does — its fallback present is clamped to min(window, backing)
+      // (ntk >= 5.3, window.js _presentNow) — at two SetPictureClipRectangles
+      // per composite, which the protocol bench prices at +207 requests for
+      // a hundred-icon full repaint.
       ctx.save();
       ctx.beginPath();
       ctx.rect(damage.x, damage.y, damage.width, damage.height);
@@ -4969,8 +4979,22 @@ export class WindowNode extends Node {
   /** DevTools hover highlight: tint a node's rect on the next paint. */
   setHighlight(node) {
     if (this._highlight === node) return;
+    const prev = this._highlight;
     this._highlight = node;
-    this.invalidate(false, null, 'highlight');
+    // The tint leaves one rect and lands on another, and both are already
+    // known, so the claim is their union rather than the window. A side
+    // with no laid-out rect tints (or tinted) the whole window — the same
+    // fallback _paintRegion paints — so only that case stays unbounded.
+    const rects = [];
+    for (const n of [prev, node]) {
+      if (!n) continue;
+      if (!n.abs?.width) {
+        this.invalidate(false, null, 'highlight');
+        return;
+      }
+      rects.push(n.abs);
+    }
+    for (const rect of rects) this.invalidate(false, rect, 'highlight');
   }
 
   /** REACT_X11_DEBUG_LAYOUT=1: outline every drawn node, color by depth. */

--- a/test/dirty-rect.test.js
+++ b/test/dirty-rect.test.js
@@ -1078,3 +1078,155 @@ test('a text change repaints the text line, pixel-exact', async () => {
     await app.close();
   }
 });
+
+test('a controlled value change repaints the field, pixel-exact', async () => {
+  const app = await headlessApp();
+  const x11Root = await createRoot({ app });
+  try {
+    // Typing into a controlled <textinput>: the parent re-renders with a new
+    // `value`, metrics unchanged. The field clips its own painting, so the
+    // frame is the field — not the window (issue #187).
+    const { root, setState } = await mountStateful(x11Root, (state) => [
+      ...HOISTED.slice(0, 4).map((style, i) =>
+        React.createElement('box', { key: `r${i}`, style }),
+      ),
+      React.createElement('textinput', {
+        key: 'field',
+        value: state ? 'hello world' : 'hello',
+        onChange: () => {},
+        style: { height: 22, backgroundColor: '#ffffff' },
+      }),
+    ]);
+    const { regions, diff } = await reactPaintBothWays(app, root, () =>
+      setState(1),
+    );
+    assert.equal(diff, 0, `${diff} pixels differ from a full repaint`);
+    assert.strictEqual(regions.length, 1, 'one repaint');
+    const damage = regions[0];
+    assert.ok(damage, 'a value change must not repaint the window');
+    assert.ok(
+      damage.height <= 22 + 2 * SLOP + 2,
+      `expected the field's height, got ${damage.height}`,
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test('a textarea inner scroll repaints the field, pixel-exact', async () => {
+  const app = await headlessApp();
+  const x11Root = await createRoot({ app });
+  try {
+    const taRef = React.createRef();
+    await mount(
+      x11Root,
+      React.createElement(
+        'window',
+        { width: W, height: H, style: { backgroundColor: '#f5f6fa' } },
+        React.createElement('box', { style: { flexGrow: 1, padding: 6 } }, [
+          ...HOISTED.slice(0, 2).map((style, i) =>
+            React.createElement('box', { key: `r${i}`, style }),
+          ),
+          React.createElement('textarea', {
+            key: 'ta',
+            ref: taRef,
+            defaultValue: Array.from(
+              { length: 12 },
+              (_, i) => `line ${i}`,
+            ).join('\n'),
+            style: { backgroundColor: '#ffffff' },
+          }),
+        ]),
+      ),
+    );
+    const ta = taRef.current;
+    const root = ta.root;
+    const taHeight = ta.abs.height;
+
+    // the wheel path — pixels move only inside the field's own clip
+    const { damage, diff } = await paintBothWays(app, root, () =>
+      ta.scrollBy(12),
+    );
+    assert.ok(ta._scrollY > 0, 'the textarea actually scrolled');
+    assert.ok(damage, 'an inner scroll must not repaint the window');
+    assert.ok(
+      damage.height <= taHeight + 2 * SLOP + 2,
+      `expected the field's height, got ${damage.height}`,
+    );
+    assert.equal(diff, 0, `${diff} pixels differ from a full repaint`);
+  } finally {
+    await app.close();
+  }
+});
+
+test('the DevTools highlight claims its rects, not the window', async () => {
+  const app = await headlessApp();
+  const x11Root = await createRoot({ app });
+  try {
+    const aRef = React.createRef();
+    const bRef = React.createRef();
+    await mount(
+      x11Root,
+      React.createElement(
+        'window',
+        { width: W, height: H, style: { backgroundColor: '#f5f6fa' } },
+        React.createElement(
+          'box',
+          { style: { flexGrow: 1, padding: 6, gap: 3 } },
+          [
+            React.createElement('box', {
+              key: 'a',
+              ref: aRef,
+              style: rowStyle(0),
+            }),
+            ...HOISTED.slice(1, 4).map((style, i) =>
+              React.createElement('box', { key: `r${i}`, style }),
+            ),
+            React.createElement('box', {
+              key: 'b',
+              ref: bRef,
+              style: rowStyle(4),
+            }),
+          ],
+        ),
+      ),
+    );
+    const a = aRef.current;
+    const b = bRef.current;
+    const root = a.root;
+
+    // appear: the tint lands on one row
+    const on = await paintBothWays(app, root, () => root.setHighlight(a));
+    assert.ok(on.damage, 'highlighting a node must not repaint the window');
+    assert.ok(
+      on.damage.height <= ROW_H + 2,
+      `expected the row's height, got ${on.damage.height}`,
+    );
+    assert.equal(on.diff, 0, `${on.diff} pixels differ from a full repaint`);
+
+    // move: the old rect and the new one, not the rows between them
+    const move = await paintBothWays(app, root, () => root.setHighlight(b));
+    assert.ok(move.damage, 'moving the highlight must not repaint the window');
+    assert.strictEqual(
+      move.rects.length,
+      2,
+      'old and new rects stay two claims, not the box around them',
+    );
+    assert.equal(
+      move.diff,
+      0,
+      `${move.diff} pixels differ from a full repaint`,
+    );
+
+    // clear: the tinted rect repaints, nothing else
+    const off = await paintBothWays(app, root, () => root.setHighlight(null));
+    assert.ok(off.damage, 'clearing the highlight must not repaint the window');
+    assert.ok(
+      off.damage.height <= ROW_H + 2,
+      `expected the row's height, got ${off.damage.height}`,
+    );
+    assert.equal(off.diff, 0, `${off.diff} pixels differ from a full repaint`);
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
Closes #187.

## What

Three `invalidate` call sites claimed `null` (unbounded) damage where the rect was already in hand, each degrading its whole frame to FULL WINDOW:

- **DevTools highlight** (`setHighlight`): the claim is now the outgoing node's rect plus the incoming node's rect — two claims, not the box between them, so moving the hover between rows far apart repaints two rows and nothing in between. It falls back to unbounded only when a side has no laid-out rect, which is exactly the case where `_paintRegion` tints the whole window.
- **`<textinput>` controlled value change** (`applyProps`, metrics unchanged): claims `this`, the same bound `Node.applyProps` names for any paint-only prop. Painting clips to the content box and the measure function reads only font metrics, so the field contains everything a value change can touch.
- **`<textarea>` inner scrolls** (`_scrollTo`, `scrollBy` — thumb drag, track page, wheel): same claim, same reasoning. Not named by the issue's bullets, but the same class in the same file with the same obvious bound.

## The other two bullets

- **Child-list changes**: already done, past what the issue asked. #191 made `_childListChanged`'s claim unconditionally bounded (before/after subtree rects plus the layout diff); the `_sizePinned` gate the issue wanted relaxed no longer exists.
- **Clipping the unbounded paint pass**: implemented, measured, and deliberately backed out. The hazard the bullet names — the fallback present blitting backing-store-size, exceeding the window — does not exist against any ntk this repo has pinned: `_presentNow` clamps the fallback to min(window, backing), verified in the 5.3.0 tarball and in the 6.0.1 this repo now installs (the pin at filing time was already `^5.4.0`). With the blit already window-bounded, the clip would only re-report known bounds, at two `SetPictureClipRectangles` per composite. The protocol bench prices that:

  | scenario | requests | composites / Mpx |
  |---|---|---|
  | `svg: 100 unchanged icons, full repaint` | 106 → 313 | unchanged |
  | `mount: window with 40 boxes and labels` | 100 → 146 | unchanged |

  Pure protocol chatter with zero pixel-work change, by the same metric AGENTS.md uses to price clips. `_paintRegion` now carries a comment saying why the unbounded pass stays unclipped, so the idea doesn't get re-tried without this context.

## Verification

- Three new tests in `test/dirty-rect.test.js`, one per bounded path, each asserting the damage bound *and* pixel equality against a forced full repaint (the file's invariant). The highlight test covers appear, move (two rects, `SPLIT_SAVING` not collapsing them), and clear. All three fail against the previous claims (`actual: null` on the bound assertion) and pass with the fix.
- Full suite: 468 pass. `npm run bench -- --check`: no regressions against the baseline.
- `REACT_X11_DEBUG_PAINT=full` no longer warns for DevTools hover, controlled typing, or textarea scrolling; the remaining full-window reasons (`mount`, `resize`, `theme`) are the genuinely unbounded ones.
