### PR TITLE
perf(events): stop allocating per node per event on the pointer path (#188)

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -28,6 +28,66 @@ function sharedPrefix(a, b) {
   return n;
 }
 
+// 'MouseDown' → 'mouseDown', memoized — the set of names is small and
+// closed, and dispatch runs at motion rate
+const TYPE_NAMES = Object.create(null);
+function eventType(name) {
+  return (TYPE_NAMES[name] ??= name[0].toLowerCase() + name.slice(1));
+}
+
+/**
+ * One synthetic event, methods on the prototype: they used to be built as
+ * four fresh closures on every event object, which at motion rate was
+ * steady allocation for the GC to chew on (issue #188). Handlers only ever
+ * call them as methods (`ev.capturePointer()`), the same contract DOM
+ * events have.
+ */
+class SyntheticEvent {
+  constructor(manager, type, native, target, extra) {
+    this._manager = manager;
+    this._targetNode = target;
+    this.type = type;
+    this.x = native?.x ?? 0;
+    this.y = native?.y ?? 0;
+    this.target = manager._public(target);
+    this.currentTarget = null;
+    this.nativeEvent = native;
+    // X11 modifier mask: bit 0 Shift, bit 2 Control. Carried on every
+    // event, not just keys — shift+click needs it too.
+    this.shiftKey = Boolean(native?.buttons & 1);
+    this.ctrlKey = Boolean(native?.buttons & 4);
+    this.defaultPrevented = false;
+    this.propagationStopped = false;
+    if (extra) Object.assign(this, extra);
+    if (target.abs) {
+      this.localX = this.x - target.abs.x;
+      this.localY = this.y - target.abs.y;
+    }
+  }
+
+  preventDefault() {
+    this.defaultPrevented = true;
+  }
+
+  stopPropagation() {
+    this.propagationStopped = true;
+  }
+
+  // Pointer capture, DOM-like: while captured, mousemove/mouseup go to the
+  // capturing node instead of whatever is under the pointer, so a drag
+  // keeps working past the widget's own bounds. Released automatically on
+  // mouseup and when the node unmounts.
+  capturePointer() {
+    this._manager.capturedNode = this._targetNode;
+  }
+
+  releasePointer() {
+    if (this._manager.capturedNode === this._targetNode) {
+      this._manager.capturedNode = null;
+    }
+  }
+}
+
 // Click-to-component hook (see ClickToComponent.js). At most one handler is
 // installed, gated by REACT_X11_CLICK_TO_COMPONENT — checked ahead of the
 // normal press handling so an Alt+Click never also starts a drag or moves
@@ -196,77 +256,43 @@ export class EventManager {
       n;
       n = n === this.node ? null : (n.parent ?? this.node)
     ) {
-      path.unshift(n);
+      path.push(n);
       if (n === this.node) break;
     }
-    return path;
+    return path.reverse();
   }
 
   _makeEvent(type, native, target, extra) {
-    const ev = {
-      type,
-      x: native?.x ?? 0,
-      y: native?.y ?? 0,
-      target: this._public(target),
-      currentTarget: null,
-      nativeEvent: native,
-      // X11 modifier mask: bit 0 Shift, bit 2 Control. Carried on every
-      // event, not just keys — shift+click needs it too.
-      shiftKey: Boolean(native?.buttons & 1),
-      ctrlKey: Boolean(native?.buttons & 4),
-      defaultPrevented: false,
-      propagationStopped: false,
-      preventDefault() {
-        ev.defaultPrevented = true;
-      },
-      stopPropagation() {
-        ev.propagationStopped = true;
-      },
-      // Pointer capture, DOM-like: while captured, mousemove/mouseup go to
-      // the capturing node instead of whatever is under the pointer, so a
-      // drag keeps working past the widget's own bounds. Released
-      // automatically on mouseup and when the node unmounts.
-      capturePointer: () => {
-        this.capturedNode = target;
-      },
-      releasePointer: () => {
-        if (this.capturedNode === target) this.capturedNode = null;
-      },
-      ...extra,
-    };
-    if (target.abs) {
-      ev.localX = ev.x - target.abs.x;
-      ev.localY = ev.y - target.abs.y;
-    }
-    return ev;
+    return new SyntheticEvent(this, type, native, target, extra);
   }
 
-  /** Capture → target → bubble along the ancestor path. Returns the event. */
-  dispatch(name, target, native, extra) {
-    const path = this._path(target);
-    const ev = this._makeEvent(
-      name[0].toLowerCase() + name.slice(1),
-      native,
-      target,
-      extra,
-    );
+  /**
+   * Capture → target → bubble along the ancestor path. A caller that
+   * already built the target's path for its own bookkeeping passes it in;
+   * everyone else lets the default build it. Returns the event.
+   */
+  dispatch(name, target, native, extra, path = this._path(target)) {
+    const ev = this._makeEvent(eventType(name), native, target, extra);
+    // the two handler keys are per dispatch, not per node visited
+    const bubbleKey = 'on' + name;
+    const captureKey = bubbleKey + 'Capture';
     // Each handler is called inside callHandler: a throw here has no React
     // on the stack to catch it, so bare it would unwind into ntk's socket
     // handler and take the process. Reported and stepped over instead —
     // one bad handler must not stop the ones after it, or the frame loop.
     for (const n of path) {
-      const handler = n.props[`on${name}Capture`];
+      const handler = n.props[captureKey];
       if (handler) {
         ev.currentTarget = this._public(n);
-        callHandler(n, `on${name}Capture`, handler, ev);
+        callHandler(n, captureKey, handler, ev);
         if (ev.propagationStopped) return ev;
       }
     }
     for (let i = path.length - 1; i >= 0; i--) {
-      const handler = path[i].props[`on${name}`];
+      const handler = path[i].props[bubbleKey];
       if (handler) {
         ev.currentTarget = this._public(path[i]);
-        callHandler(path[i], `on${name}`, handler, ev);
+        callHandler(path[i], bubbleKey, handler, ev);
         if (ev.propagationStopped) return ev;
       }
     }
@@ -338,10 +364,16 @@ export class EventManager {
       this.downPath = target ? this._path(target) : [];
       this._setPressed(this.downPath);
       this._focusFromPress(target);
-      const ev = this.dispatch('MouseDown', target, native, {
-        button: native.keycode,
-        detail: this._clickDetail(native),
-      });
+      const ev = this.dispatch(
+        'MouseDown',
+        target,
+        native,
+        {
+          button: native.keycode,
+          detail: this._clickDetail(native),
+        },
+        this.downPath,
+      );
       if (!ev.defaultPrevented) {
         target._defaultMouseDown?.(ev);
       }
@@ -426,7 +458,7 @@ export class EventManager {
       // captured control stays pressed wherever the pointer wandered off to
       if (this.downNode && !captured)
         this._setPressed(this._pressedAlong(path));
-      const ev = this.dispatch('MouseMove', target, native);
+      const ev = this.dispatch('MouseMove', target, native, undefined, path);
       // drags deliver to the pressed node even when the pointer leaves it
       if (this.downNode && !this.downNode.destroyed) {
         this.downNode._defaultMouseDrag?.(ev);
@@ -572,8 +604,14 @@ export class EventManager {
   _onKey(name, native) {
     runWithPriority(DiscreteEventPriority, () => {
       const wnd = this.node.window;
-      const syms = wnd.X?.keycode2keysyms?.[native.keycode];
-      const keysym = syms?.[0];
+      // ntk decodes the key on the way in (window.js decorates the event
+      // with keysym/baseKeysym/codepoint), so re-deriving it from the
+      // keymap here was redundant. `baseKeysym` — group 1, level 1 — is
+      // what shortcut comparisons want (XK_TAB even under Shift), which is
+      // exactly what the old level-0 read gave. The keymap lookup stays as
+      // the fallback for synthetic events that skip ntk's decoration.
+      const keysym =
+        native.baseKeysym ?? wnd.X?.keycode2keysyms?.[native.keycode]?.[0];
       // the focused node may live inside a <popup> of this window: focus is
       // shared with the popup (see focusManager), key delivery follows it
       const focused = this.focusManager.focused;
@@ -586,8 +624,6 @@ export class EventManager {
           native.codepoint && native.codepoint >= 0x20
             ? String.fromCodePoint(native.codepoint)
             : undefined,
-        shiftKey: Boolean(native.buttons & 1),
-        ctrlKey: Boolean(native.buttons & 4),
       });
       if (name === 'KeyDown' && keysym === XK_TAB && !ev.defaultPrevented) {
         this._cycleFocus(Boolean(native.buttons & 1));

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -588,6 +588,11 @@ export class Node {
     };
     // in-flight transitions: prop -> {from, to, start, duration}
     this._anim = null;
+    // hot pointer-path caches (issue #188): the children in paint order,
+    // re-verified against the live children on every read, and the
+    // subtree's hit reach, invalidated through _clearHitBounds()
+    this._paintOrderCache = null;
+    this._hitBoundsCache = null;
     this._syncStyle(props);
     this.yoga = yoga ? Yoga.Node.create() : null;
     if (this.yoga) {
@@ -682,6 +687,17 @@ export class Node {
     this.style = this._anim?.size
       ? { ...target, ...this._animatedValues() }
       : target;
+    // `hitSlop` feeds the cached hit reach and `overflow` decides where its
+    // invalidation walks stop, so a swap that changes either clears here —
+    // the one funnel every style path goes through. Animation ticks never
+    // change them: neither interpolates, so both land on the target value
+    // in this very swap, before any tick runs.
+    if (
+      displayed.hitSlop !== this.style.hitSlop ||
+      displayed.overflow !== this.style.overflow
+    ) {
+      this._clearHitBounds();
+    }
     return this.style;
   }
 
@@ -931,6 +947,9 @@ export class Node {
    * bounded without requiring the node's own size to be pinned.
    */
   _childListChanged(before) {
+    // belt for a subtree attached imperatively with its rect already laid
+    // out — nothing then re-runs _assignAbs to notice the reach grew
+    this._clearHitBounds();
     const root = this.root;
     if (!root) return;
     root.invalidate(true, before, 'child-list');
@@ -1120,25 +1139,71 @@ export class Node {
 
   /** Drawn, visible children in paint order (stable sort by zIndex). */
   paintOrder() {
+    // Hit testing asks at every node it visits and painting at every node
+    // it draws, so the filter-map-sort-map here was steady per-event
+    // allocation (issue #188). Cached — and verified against the live
+    // children on every read rather than invalidated: membership and
+    // z-keys are the same reads the filter always did, so a fresh cache
+    // costs no allocation and a stale one is impossible, whatever mutates
+    // children, styles, visibility or DRAWN_KINDS.
+    const cache = this._paintOrderCache;
+    if (cache && this._paintOrderFresh(cache)) return cache.order;
     // `display: 'none'` takes a node out of the layout, and it has to leave
     // the paint with it. They were separate before because the only way to
     // hide something was the `hidden` flag, which does both — until a size
     // query started setting `display` from a style block, and the hidden
     // node carried on painting at the position it no longer had.
-    const drawn = this.children.filter(
-      (c) =>
+    const drawn = [];
+    const z = [];
+    for (const c of this.children) {
+      if (
         DRAWN_KINDS.has(c.kind) &&
         c.yoga &&
         !c.hidden &&
-        c.style.display !== 'none',
-    );
-    return drawn
-      .map((node, i) => ({ node, i }))
-      .sort(
-        (a, b) =>
-          (a.node.style.zIndex ?? 0) - (b.node.style.zIndex ?? 0) || a.i - b.i,
-      )
-      .map((e) => e.node);
+        c.style.display !== 'none'
+      ) {
+        drawn.push(c);
+        z.push(c.style.zIndex ?? 0);
+      }
+    }
+    // document order already answers the usual no-zIndex case; the sort is
+    // only paid when some z actually disagrees with it
+    let order = drawn;
+    for (let i = 1; i < z.length; i++) {
+      if (z[i] < z[i - 1]) {
+        order = drawn
+          .map((node, j) => ({ node, z: z[j], j }))
+          .sort((a, b) => a.z - b.z || a.j - b.j)
+          .map((e) => e.node);
+        break;
+      }
+    }
+    this._paintOrderCache = { order, drawn, z };
+    return order;
+  }
+
+  /** Do the cached drawn children and their z-keys still match the tree? */
+  _paintOrderFresh({ drawn, z }) {
+    let j = 0;
+    for (const c of this.children) {
+      if (
+        !DRAWN_KINDS.has(c.kind) ||
+        !c.yoga ||
+        c.hidden ||
+        c.style.display === 'none'
+      ) {
+        continue;
+      }
+      if (
+        j >= drawn.length ||
+        drawn[j] !== c ||
+        z[j] !== (c.style.zIndex ?? 0)
+      ) {
+        return false;
+      }
+      j++;
+    }
+    return j === drawn.length;
   }
 
   clipsChildren() {
@@ -1199,6 +1264,67 @@ export class Node {
     ];
   }
 
+  /**
+   * The rect a hit anywhere in this subtree must fall inside: this node's
+   * rect grown by its own hitSlop, unioned with every child's reach —
+   * except under a clipping node, whose children can only be hit while the
+   * point is inside its rect (hitTest never descends from outside one).
+   *
+   * A conservative superset, and only ever that: hidden and
+   * pointerEvents-none subtrees are counted anyway, and nothing shrinks a
+   * cached bound before the next invalidation. A bound too big costs a
+   * walk; one too small would drop real input. Every change that can
+   * *grow* the true reach funnels through `_clearHitBounds`: `_assignAbs`
+   * for whatever layout moves (mounts, reveals and scrolls all change
+   * `abs`), `_retarget` for `hitSlop` and `overflow`, `_childListChanged`
+   * for a subtree attached with its rect already laid out, and `flush`
+   * for the root's own rect, which is written without `_assignAbs`.
+   */
+  _hitBounds() {
+    let b = this._hitBoundsCache;
+    if (b) return b;
+    const abs = this.abs;
+    const slop = resolveHitSlop(this.style.hitSlop);
+    let left = abs.x;
+    let top = abs.y;
+    let right = abs.x + abs.width;
+    let bottom = abs.y + abs.height;
+    if (slop) {
+      left -= slop.left;
+      top -= slop.top;
+      right += slop.right;
+      bottom += slop.bottom;
+    }
+    if (!this.clipsChildren()) {
+      for (const child of this.children) {
+        if (child.isWindow || !child.yoga) continue;
+        const cb = child._hitBounds();
+        if (cb.left < left) left = cb.left;
+        if (cb.top < top) top = cb.top;
+        if (cb.right > right) right = cb.right;
+        if (cb.bottom > bottom) bottom = cb.bottom;
+      }
+    }
+    b = { left, top, right, bottom };
+    this._hitBoundsCache = b;
+    return b;
+  }
+
+  /**
+   * This node's reach changed: drop the cached bounds here and up the
+   * chain of ancestors whose unions embed them. The walk stops at a
+   * clipping ancestor — its reach is its own rect, so nothing below it
+   * changes what it or anything above it reports — or at one already
+   * invalid, whose own clear walked the rest of the way up.
+   */
+  _clearHitBounds() {
+    this._hitBoundsCache = null;
+    for (let n = this.parent; n; n = n.parent) {
+      if (n.clipsChildren() || n._hitBoundsCache === null) return;
+      n._hitBoundsCache = null;
+    }
+  }
+
   /** Front-to-back hit test. Returns the deepest hit node or null. */
   hitTest(x, y) {
     if (
@@ -1206,6 +1332,13 @@ export class Node {
       this.style.display === 'none' ||
       this.style.pointerEvents === 'none'
     ) {
+      return null;
+    }
+    // nothing in this subtree reaches the point: skip it whole, children
+    // and all — this is what keeps a motion event from walking every node
+    // in the window (issue #188)
+    const b = this._hitBounds();
+    if (x < b.left || y < b.top || x >= b.right || y >= b.bottom) {
       return null;
     }
     const inside = this.containsPoint(x, y);
@@ -1245,14 +1378,19 @@ export class Node {
    */
   _assignAbs(x, y, width, height) {
     const old = this.abs;
-    this.abs = { x, y, width, height };
     if (
-      layoutDiffSink &&
-      (old.x !== x ||
-        old.y !== y ||
-        old.width !== width ||
-        old.height !== height)
+      old.x === x &&
+      old.y === y &&
+      old.width === width &&
+      old.height === height
     ) {
+      return;
+    }
+    this.abs = { x, y, width, height };
+    // moving or resizing changes where this subtree can be hit, and the
+    // cached unions all the way up with it
+    this._clearHitBounds();
+    if (layoutDiffSink) {
       const grow = this._outlineExtent() + DAMAGE_SLOP;
       if (old.width > 0 && old.height > 0) {
         layoutDiffSink(insetRect(old, -grow));
@@ -4563,6 +4701,9 @@ export class WindowNode extends Node {
       this.yoga.setHeight(height);
       this.yoga.calculateLayout(width, height, Yoga.DIRECTION_LTR);
       this.abs = { x: 0, y: 0, width, height };
+      // the root's rect is written here, not through _assignAbs, so its
+      // cached hit reach is dropped here too (children bubble their own)
+      this._hitBoundsCache = null;
       // A bounded frame watches the walk: whatever this pass actually moved
       // claims its old and new rects through the sink, and the frame stays
       // a few rects instead of the whole window. An unbounded frame skips

--- a/test/hit-test.test.js
+++ b/test/hit-test.test.js
@@ -1,0 +1,502 @@
+// The hot pointer path (issue #188): paint order is cached and re-verified
+// per read, and hitTest culls whole subtrees on cached hit bounds. The cache
+// rules these tests pin:
+//
+//  - the hit-bounds cache may only ever be a *superset* of the true reach,
+//    so every test here warms it first and then mutates — a missing
+//    invalidation shows up as a miss on input that should land;
+//  - the paint-order cache is verified against the live children on every
+//    read, so order, zIndex and visibility changes take effect on the very
+//    next event with no invalidation hook to forget.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import { createRoot } from '../src/index.js';
+
+import { createMockApp, moveMouse, pressButton } from './helpers/mock-app.js';
+
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+// A bare setState is default-priority work: React schedules the render a
+// few macrotasks out (observed: three), unlike the event-driven updates the
+// rest of the suite makes, which discrete dispatch flushes synchronously.
+const settle = async () => {
+  for (let i = 0; i < 6; i++) await tick();
+};
+
+/** Mount `body(state)` inside a fixed window; returns setState. */
+async function mountStateful(x11Root, body) {
+  let setState;
+  function App() {
+    const [state, set] = React.useState(0);
+    setState = set;
+    return React.createElement(
+      'window',
+      { width: 400, height: 400 },
+      body(state),
+    );
+  }
+  x11Root.render(React.createElement(App));
+  await tick();
+  return { setState: (v) => setState(v) };
+}
+
+test('hitSlop reaches outside every ancestor rect, through the culled walk', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  try {
+    const host = React.createRef();
+    const target = React.createRef();
+    await mountStateful(x11Root, () =>
+      // a 10x10 host whose absolutely-positioned child sits far outside it,
+      // with slop growing the child's target beyond its own rect: the cull
+      // must include both hops or the tap is dropped
+      React.createElement(
+        'box',
+        {
+          ref: host,
+          style: {
+            position: 'absolute',
+            left: 0,
+            top: 0,
+            width: 10,
+            height: 10,
+          },
+        },
+        React.createElement('box', {
+          ref: target,
+          style: {
+            position: 'absolute',
+            left: 100,
+            top: 100,
+            width: 30,
+            height: 30,
+            hitSlop: 8,
+          },
+        }),
+      ),
+    );
+    const root = host.current.root;
+
+    assert.ok(root.hitTest(105, 105) === target.current, 'inside the box');
+    assert.ok(
+      root.hitTest(95, 95) === target.current,
+      'inside the slop ring, outside the box and every ancestor rect',
+    );
+    assert.ok(
+      root.hitTest(300, 300) === root,
+      'far away resolves to the window itself',
+    );
+  } finally {
+    await x11Root.unmount();
+  }
+});
+
+test('a hitSlop that grows after the cache warmed still lands taps', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  try {
+    const target = React.createRef();
+    const { setState } = await mountStateful(x11Root, (state) =>
+      React.createElement('box', {
+        ref: target,
+        style: {
+          position: 'absolute',
+          left: 100,
+          top: 100,
+          width: 20,
+          height: 20,
+          hitSlop: state ? 12 : 0,
+        },
+      }),
+    );
+    const root = target.current.root;
+
+    // warm the cached bounds with the slopless style
+    assert.ok(root.hitTest(95, 95) === root, 'no slop yet');
+    setState(1);
+    await settle();
+    assert.ok(
+      root.hitTest(95, 95) === target.current,
+      'the grown slop is hittable on the next event',
+    );
+  } finally {
+    await x11Root.unmount();
+  }
+});
+
+test('a node layout moves away from warmed bounds and is hit at its new rect', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  try {
+    const box = React.createRef();
+    const { setState } = await mountStateful(x11Root, (state) =>
+      React.createElement('box', {
+        ref: box,
+        style: {
+          position: 'absolute',
+          left: state ? 140 : 20,
+          top: 40,
+          width: 40,
+          height: 40,
+        },
+      }),
+    );
+    const root = box.current.root;
+
+    assert.ok(root.hitTest(30, 50) === box.current, 'at the old rect');
+    setState(1);
+    await settle();
+    assert.ok(root.hitTest(150, 50) === box.current, 'at the new rect');
+    assert.ok(root.hitTest(30, 50) === root, 'the old rect is vacated');
+  } finally {
+    await x11Root.unmount();
+  }
+});
+
+test('scrolling re-aims the pointer at the row that moved under it', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  try {
+    const sv = React.createRef();
+    const rows = Array.from({ length: 10 }, () => React.createRef());
+    await mountStateful(x11Root, () =>
+      React.createElement(
+        'scrollview',
+        { ref: sv, style: { width: 200, height: 100 } },
+        rows.map((ref, i) =>
+          React.createElement('box', {
+            key: i,
+            ref,
+            style: { height: 40 },
+          }),
+        ),
+      ),
+    );
+    const root = sv.current.root;
+
+    assert.ok(root.hitTest(50, 50) === rows[1].current, 'row 1 at y=50');
+    sv.current.scrollBy({ x: 0, y: 80 });
+    await tick();
+    assert.ok(
+      root.hitTest(50, 50) === rows[3].current,
+      'after an 80px scroll the same point is row 3',
+    );
+  } finally {
+    await x11Root.unmount();
+  }
+});
+
+test('a keyed reorder flips which overlapping sibling is on top', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  try {
+    const a = React.createRef();
+    const b = React.createRef();
+    const overlap = {
+      position: 'absolute',
+      left: 0,
+      top: 0,
+      width: 50,
+      height: 50,
+    };
+    const { setState } = await mountStateful(x11Root, (state) => {
+      const A = React.createElement('box', {
+        key: 'a',
+        ref: a,
+        style: overlap,
+      });
+      const B = React.createElement('box', {
+        key: 'b',
+        ref: b,
+        style: overlap,
+      });
+      return state ? [B, A] : [A, B];
+    });
+    const root = a.current.root;
+
+    assert.ok(root.hitTest(10, 10) === b.current, 'later sibling wins');
+    setState(1);
+    await settle();
+    assert.ok(
+      root.hitTest(10, 10) === a.current,
+      'the reorder moved A later in document order, so A wins',
+    );
+  } finally {
+    await x11Root.unmount();
+  }
+});
+
+test('a zIndex change reorders hits on the very next event', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  try {
+    const a = React.createRef();
+    const b = React.createRef();
+    const { setState } = await mountStateful(x11Root, (state) => [
+      React.createElement('box', {
+        key: 'a',
+        ref: a,
+        style: {
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          width: 50,
+          height: 50,
+          zIndex: state ? 2 : 0,
+        },
+      }),
+      React.createElement('box', {
+        key: 'b',
+        ref: b,
+        style: { position: 'absolute', left: 0, top: 0, width: 50, height: 50 },
+      }),
+    ]);
+    const root = a.current.root;
+
+    assert.ok(root.hitTest(10, 10) === b.current, 'document order first');
+    setState(1);
+    await settle();
+    assert.ok(root.hitTest(10, 10) === a.current, 'zIndex 2 wins');
+    setState(0);
+    await settle();
+    assert.ok(root.hitTest(10, 10) === b.current, 'and back');
+  } finally {
+    await x11Root.unmount();
+  }
+});
+
+test('display: none removes a node from hits, and its lifting restores it', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  try {
+    const top = React.createRef();
+    const under = React.createRef();
+    const { setState } = await mountStateful(x11Root, (state) => [
+      React.createElement('box', {
+        key: 'under',
+        ref: under,
+        style: { position: 'absolute', left: 0, top: 0, width: 60, height: 60 },
+      }),
+      React.createElement('box', {
+        key: 'top',
+        ref: top,
+        style: {
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          width: 60,
+          height: 60,
+          display: state ? 'none' : 'flex',
+        },
+      }),
+    ]);
+    const root = top.current.root;
+
+    assert.ok(root.hitTest(10, 10) === top.current, 'top is hit first');
+    setState(1);
+    await settle();
+    assert.ok(
+      root.hitTest(10, 10) === under.current,
+      'display:none drops out of hit testing',
+    );
+    setState(0);
+    await settle();
+    assert.ok(root.hitTest(10, 10) === top.current, 'restored');
+  } finally {
+    await x11Root.unmount();
+  }
+});
+
+test('the cull skips subtrees the pointer is nowhere near', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  try {
+    const first = React.createRef();
+    // 20 rows of 10 leaves under a non-clipping container: 232 nodes
+    await mountStateful(x11Root, () =>
+      React.createElement(
+        'box',
+        { style: { flexGrow: 1 } },
+        Array.from({ length: 20 }, (_, r) =>
+          React.createElement(
+            'box',
+            { key: r, style: { height: 20, flexDirection: 'row' } },
+            Array.from({ length: 10 }, (_, c) =>
+              React.createElement('box', {
+                key: c,
+                ref: r === 0 && c === 0 ? first : undefined,
+                style: { width: 20 },
+              }),
+            ),
+          ),
+        ),
+      ),
+    );
+    const root = first.current.root;
+
+    // count hitTest entries by patching the prototype that owns it
+    let proto = first.current;
+    while (proto && !Object.hasOwn(proto, 'hitTest')) {
+      proto = Object.getPrototypeOf(proto);
+    }
+    const original = proto.hitTest;
+    let visits = 0;
+    proto.hitTest = function (x, y) {
+      visits++;
+      return original.call(this, x, y);
+    };
+    try {
+      assert.ok(root.hitTest(5, 5) === first.current, 'the leaf is hit');
+      // every sibling row is entered once and culled without touching its
+      // leaves: well under the 232 nodes a full walk visits
+      assert.ok(
+        visits <= 60,
+        `expected the bounds cull to skip far subtrees, visited ${visits}`,
+      );
+    } finally {
+      proto.hitTest = original;
+    }
+  } finally {
+    await x11Root.unmount();
+  }
+});
+
+test('dispatch runs capture then bubble with per-dispatch keys and one event', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  try {
+    const inner = React.createRef();
+    const calls = [];
+    let captureEv = null;
+    let bubbleEv = null;
+    function App() {
+      return React.createElement(
+        'window',
+        {
+          width: 400,
+          height: 400,
+          onMouseDownCapture: (ev) => {
+            captureEv = ev;
+            calls.push(['window capture', ev.currentTarget]);
+          },
+          onMouseDown: (ev) => calls.push(['window bubble', ev.currentTarget]),
+        },
+        React.createElement('box', {
+          ref: inner,
+          style: {
+            position: 'absolute',
+            left: 0,
+            top: 0,
+            width: 50,
+            height: 50,
+          },
+          onMouseDown: (ev) => {
+            bubbleEv = ev;
+            calls.push(['box bubble', ev.currentTarget]);
+          },
+        }),
+      );
+    }
+    x11Root.render(React.createElement(App));
+    await tick();
+    const wnd = app.windows[0];
+
+    pressButton(wnd, 10, 10, { release: false });
+    assert.deepStrictEqual(
+      calls.map(([name]) => name),
+      ['window capture', 'box bubble', 'window bubble'],
+    );
+    assert.ok(captureEv === bubbleEv, 'one event object end to end');
+    assert.ok(bubbleEv.target === inner.current, 'target is the box node');
+    assert.strictEqual(bubbleEv.type, 'mouseDown');
+    assert.strictEqual(bubbleEv.button, 1);
+    assert.strictEqual(bubbleEv.localX, 10);
+  } finally {
+    await x11Root.unmount();
+  }
+});
+
+test('capturePointer routes moves to the captor; releasePointer hands back', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  try {
+    const grabber = React.createRef();
+    const moves = [];
+    const otherMoves = [];
+    function App() {
+      return React.createElement('window', { width: 400, height: 400 }, [
+        React.createElement('box', {
+          key: 'grab',
+          ref: grabber,
+          style: {
+            position: 'absolute',
+            left: 0,
+            top: 0,
+            width: 50,
+            height: 50,
+          },
+          onMouseDown: (ev) => ev.capturePointer(),
+          onMouseMove: (ev) => {
+            moves.push(ev.x);
+            if (moves.length === 2) ev.releasePointer();
+          },
+        }),
+        React.createElement('box', {
+          key: 'other',
+          style: {
+            position: 'absolute',
+            left: 200,
+            top: 0,
+            width: 50,
+            height: 50,
+          },
+          onMouseMove: (ev) => otherMoves.push(ev.x),
+        }),
+      ]);
+    }
+    x11Root.render(React.createElement(App));
+    await tick();
+    const wnd = app.windows[0];
+
+    pressButton(wnd, 10, 10, { release: false });
+    moveMouse(wnd, 220, 10); // over 'other', but captured
+    moveMouse(wnd, 230, 10); // still captured; handler releases here
+    moveMouse(wnd, 240, 10); // released: goes to 'other'
+    assert.deepStrictEqual(
+      moves,
+      [220, 230],
+      'captured moves reach the captor',
+    );
+    assert.deepStrictEqual(otherMoves, [240], 'after release, hits rule again');
+  } finally {
+    await x11Root.unmount();
+  }
+});
+
+test('key events prefer ntk-decoded baseKeysym, fall back to the keymap', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  try {
+    const seen = [];
+    function App() {
+      return React.createElement('window', {
+        width: 400,
+        height: 400,
+        onKeyDown: (ev) => seen.push(ev.keysym),
+      });
+    }
+    x11Root.render(React.createElement(App));
+    await tick();
+    const wnd = app.windows[0];
+
+    // decorated event, the way ntk delivers keys: baseKeysym wins even when
+    // the raw keymap disagrees (a shifted key reports its level-0 sym there)
+    app.X.keycode2keysyms[30] = [0x71]; // 'q'
+    wnd.emit('keydown', { keycode: 30, baseKeysym: 0xff09, buttons: 0 });
+    // undecorated event, the way mocks and older ntk deliver them
+    wnd.emit('keydown', { keycode: 30, buttons: 0 });
+    assert.deepStrictEqual(seen, [0xff09, 0x71]);
+  } finally {
+    await x11Root.unmount();
+  }
+});


### PR DESCRIPTION
Closes #188.

## What

`hitTest` and `dispatch` sit under every pointer event and allocated all the way down. Both are now allocation-free in the steady state, and hit testing culls whole subtrees.

**`paintOrder()` is cached per node, verified instead of invalidated.** Hit testing asks at every node it visits and painting at every node it draws; each ask rebuilt four arrays plus a sort-comparator's wrapper objects. The cache is re-verified against the live children on every read — membership and z-keys are the same reads the old filter always did, so a fresh cache allocates nothing and a stale one is impossible by construction, whatever mutates children, styles, visibility, or `DRAWN_KINDS` (which `registerElement` extends at runtime). The sort itself is now only paid when some `zIndex` actually disagrees with document order, which the common all-default case never does. The issue proposed invalidation hooks on child-list/zIndex changes; verification gets the same win with no hook to forget, on reads that were already being made.

**`hitTest` culls on cached hit reach.** Each node carries its reach — own rect grown by `hitSlop`, unioned with children's reach, stopped at clipping nodes (whose children can only be hit from inside, so their reach is their own rect) — and a subtree whose reach excludes the point is skipped whole. The cached bound is a deliberate *superset*: hidden and `pointerEvents: 'none'` subtrees are counted anyway, shrinks leave it stale-big (costs a walk, never an input), and every change that can *grow* the true reach funnels through `_clearHitBounds`:

- `_assignAbs` — anything layout moves; mounts, reveals, and scroll offsets all change `abs`, so they ride this funnel for free;
- `_retarget` — `hitSlop` and `overflow` swaps, the one place every style path (props, state blocks, themes, transitions) assigns `this.style`; animation ticks can't change either, since neither interpolates;
- `_childListChanged` — belt for a subtree attached imperatively with its rect already laid out;
- `flush` — the root's own rect, which is written without `_assignAbs`.

The clear bubbles up only through ancestors whose unions embed the node, stopping at clipping ancestors and at already-cleared ones (whose own clear walked the rest of the way).

**`dispatch` stops allocating per delivery.** The two handler-key strings are built once per dispatch instead of once per node visited; the event type string is memoized; the synthetic event is a class with `preventDefault`/`stopPropagation`/`capturePointer`/`releasePointer` on the prototype instead of four fresh closures per event (nothing in the repo, examples, or docs ever detaches them — same contract as DOM events); `_path` builds with push+reverse instead of quadratic unshift; and `mousedown`/`mousemove` pass the path they already built for press/hover bookkeeping instead of dispatch rebuilding it.

**`_onKey` reuses ntk's decoded key.** ntk decorates key events with `keysym`/`baseKeysym`/`codepoint` on the way in; the manual `keycode2keysyms` lookup remains only as the fallback for undecorated synthetic events (mocks). `baseKeysym` is group 1 level 1 — the same thing the old level-0 read gave, and what shortcut comparisons want. The duplicated `shiftKey`/`ctrlKey` overrides were byte-identical to what the event constructor already computes, and are gone.

Also: `_assignAbs` no longer replaces the `abs` object when the rect is unchanged — one less object per unmoved node per layout pass, and `abs` identity is now stable unless the rect actually changes.

## Numbers

Mock-app micro-bench, 400-node tree (20 rows × 19 leaves + chrome), 50k iterations, node 26, two runs each within ±2%:

| metric | master | this PR |
|---|---|---|
| `hitTest` per call | 15.4 µs | 0.78 µs |
| full `mousemove` (hit + hover diff + dispatch) | 17.3 µs | 1.4 µs |
| minor GCs across the whole workload (`--trace-gc`) | 462 | 10 |

`npm run bench -- --check` (protocol/pixels): no regressions — these paths don't touch the wire, which is also why the win doesn't show there.

## Verification

- `test/hit-test.test.js` pins the cache rules: slop reach outside every ancestor rect, slop growth after the cache warmed, layout moves, scrolling, keyed reorders, zIndex flips, `display` flips, cull visit counts (≤60 entries where the full walk visits 232), capture/bubble order with one event object end to end, pointer capture hand-off, and keysym preference plus fallback.
- Mutation-checked hook by hook: removing the `_assignAbs` clear fails the move + scroll tests; removing the `_retarget` clear fails the slop-growth test; short-circuiting the paint-order verification fails the reorder + zIndex tests; removing the cull fails the visit-count test. Each failure is the test written for that hook.
- Full suite: 476 pass. Typecheck and lint clean.

The tests deliberately compare nodes with `assert.ok(a === b, msg)` rather than `assert.strictEqual` — a failing `strictEqual` on two retained-tree nodes spends ~20s serializing the cyclic tree into the assertion diff and wedges the file.
