### PR TITLE
perf(windows): only ask where the window is when it actually moved

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -102,24 +102,47 @@ mount: [drag-and-drop.md](drag-and-drop.md).
 
 A real X11 window; the flex, paint and event root for its subtree.
 
-| prop                        |                                                                      |
-| --------------------------- | -------------------------------------------------------------------- |
-| `title`                     | window title (UTF-8, via `WM_NAME` + `_NET_WM_NAME`)                 |
-| `width`, `height`, `x`, `y` | window geometry (window state, not yoga style — the user may resize) |
-| `backgroundColor`           | full-window clear color (default white)                              |
-| `onResize(ev)`              | ConfigureNotify — the tree reflows automatically                     |
-| `onExpose(ev)`              | after a repaint was required                                         |
-| `onCloseRequest(ev)`        | WM close button (opts into `WM_DELETE_WINDOW`)                       |
-| `states`                    | EWMH `_NET_WM_STATE` — controlled, see below                         |
-| `fullscreen`, `alwaysOnTop` | boolean sugar for two of those states                                |
-| `decorations`               | `false` asks the WM for no titlebar or border                        |
-| `transientFor`              | ICCCM `WM_TRANSIENT_FOR` — the window this one belongs to (below)    |
-| `onStatesChange(states)`    | what the window manager actually did                                 |
-| `theme`                     | palette that `$token` style values resolve against, for this subtree |
+| prop                        |                                                                                       |
+| --------------------------- | ------------------------------------------------------------------------------------- |
+| `title`                     | window title (UTF-8, via `WM_NAME` + `_NET_WM_NAME`)                                  |
+| `width`, `height`, `x`, `y` | window geometry (window state, not yoga style — the user may resize)                  |
+| `backgroundColor`           | full-window clear color (default white)                                               |
+| `onResize(ev)`              | ConfigureNotify — the tree reflows automatically. Fires for **moves** too (see below) |
+| `onExpose(ev)`              | after a repaint was required                                                          |
+| `onCloseRequest(ev)`        | WM close button (opts into `WM_DELETE_WINDOW`)                                        |
+| `states`                    | EWMH `_NET_WM_STATE` — controlled, see below                                          |
+| `fullscreen`, `alwaysOnTop` | boolean sugar for two of those states                                                 |
+| `decorations`               | `false` asks the WM for no titlebar or border                                         |
+| `transientFor`              | ICCCM `WM_TRANSIENT_FOR` — the window this one belongs to (below)                     |
+| `onStatesChange(states)`    | what the window manager actually did                                                  |
+| `theme`                     | palette that `$token` style values resolve against, for this subtree                  |
 
 Windows may be nested inside other windows (real X11 child windows).
 **Ref**: the live ntk `Window` — `getContext('2d')`,
 `requestAnimationFrame`, `setCursor`, the whole ntk API.
+
+### `onResize` fires for moves
+
+`onResize` is X's `ConfigureNotify`, which reports _any_ geometry change:
+under a window manager that moves windows opaquely, dragging one by its
+title bar delivers one per pointer step, all the same size. The renderer
+already discriminates — a move costs no layout and no repaint — but a
+handler of your own has to, or it does its work per step of a drag. The
+event says which it was:
+
+```jsx
+<window
+  onResize={(ev) => {
+    if (ev.resized) refit(ev.width, ev.height);
+    if (ev.moved) rememberPosition(ev.x, ev.y);
+  }}
+/>
+```
+
+`ev.previous` carries the geometry these are measured against. Note that
+`ev.x`/`ev.y` are frame-relative once a reparenting window manager has
+framed the window, so they are not screen coordinates — the renderer
+resolves the real origin itself for popup anchoring.
 
 ### Stacking
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^6.0.1",
+        "ntk": "^6.2.0",
         "react-reconciler": "^0.33.0"
       },
       "devDependencies": {
@@ -3676,9 +3676,10 @@
       }
     },
     "node_modules/ntk": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-6.0.1.tgz",
-      "integrity": "sha512-wwNYq2vC2+aYePEpzh52Nv5m/XS/JZjLUUEbtEJPycN5ct+w1dgfRjzgi4c1X/psyqJEbF7wMzxzbMMUShDL2Q==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-6.2.0.tgz",
+      "integrity": "sha512-GVNGA9tWGpJebdTOu7w7i+UOTh0ViQycC/JJ9GulazZR4xYz/yy8hqh3iZwqSmMuPveGdYmYUFiROtn0s/6CRA==",
+      "license": "MIT",
       "dependencies": {
         "bidi-js": "^1.0.3",
         "canvas-fontstyle": "^1.0.1",
@@ -3695,7 +3696,7 @@
         "parse-color": "^1.0.0",
         "pngjs": "^7.0.0",
         "postcss": "^8.5.23",
-        "x11": "^3.6.0",
+        "x11": "^3.7.0",
         "yoga-layout": "^3.2.1"
       },
       "engines": {
@@ -4983,9 +4984,9 @@
       }
     },
     "node_modules/x11": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/x11/-/x11-3.6.1.tgz",
-      "integrity": "sha512-VKGxNCszNa3UEjBJKJsqNPyVzac1ljPMMtTrwJNLIpwErEFl4/t9dFd8CvneZWDofEXiVnKVJi86kBrM98UawQ==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/x11/-/x11-3.7.1.tgz",
+      "integrity": "sha512-yYSkB5VXOAlbuqGa32AH5X4vHSBoUEWuQGjlG4rW/k2ViKfBgosijg4uFElmcr0uatvOYzx+8Cb7bT3GIvJp9Q==",
       "engines": {
         "node": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^6.0.1",
+    "ntk": "^6.2.0",
     "react-reconciler": "^0.33.0"
   },
   "peerDependencies": {

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -4235,17 +4235,38 @@ export class WindowNode extends Node {
     if (typeof wnd.on !== 'function') return;
     wnd.on('resize', (ev) => {
       // ConfigureNotify also fires for pure moves and reparents; only a real
-      // size change dirties layout or pixels (ntk guards its backing store
-      // the same way)
+      // size change dirties layout or pixels.
+      //
+      // Compared against the laid-out rect rather than ntk's `ev.resized`
+      // (which is "differs from the last delivered event"), because the two
+      // answer different questions and this is the one that matters here: a
+      // React-driven resize configures the window and lays out in the same
+      // commit, and the server's echo comes back a moment later saying the
+      // size changed — true, but already accounted for. `ev.resized` would
+      // relayout and fully repaint a second time for every controlled
+      // resize.
       if (ev.width !== this.abs.width || ev.height !== this.abs.height) {
         this.needsLayout = true;
         this.invalidate(true, null, 'resize');
       }
-      // a move or a reparent arrives the same way, and either changes where
-      // popups anchored to this window belong
-      this._refreshScreenOrigin();
+      // Where the window sits on screen decides where popups anchored to it
+      // belong — and finding that out is a server round trip
+      // (TranslateCoordinates), so it is worth not making one per frame of a
+      // resize drag that never moved the window. `ev.moved` is ntk >= 6.2
+      // (sidorares/ntk#184), which is the floor; the `?? true` is for a mock
+      // window or a deduped older copy, which then keep the unconditional
+      // refresh rather than losing the anchor.
+      if (ev.moved ?? true) this._refreshScreenOrigin();
       this.props.onResize?.(ev);
     });
+    // A reparent is the other way the origin moves: the window manager puts
+    // the window inside its frame, and ConfigureNotify coordinates become
+    // frame-relative from then on. It usually arrives with a ConfigureNotify
+    // whose coordinates changed, but "usually" is not a guarantee — a frame
+    // whose client offset happens to match the old root position reports no
+    // move at all. StructureNotify is already selected for 'resize', so
+    // listening costs nothing.
+    wnd.on('reparent', () => this._refreshScreenOrigin());
     // the frame clock emits 'draw' when the backing store content is invalid
     wnd.on('draw', () => {
       (this._frameReasons ??= new Set()).add('expose');

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -20,6 +20,7 @@ import type {
   SubmitEvent,
   SyntheticEvent,
   ViewportEvent,
+  WindowResizeEvent,
 } from './events.js';
 
 /** Props every element takes. */
@@ -150,8 +151,12 @@ export interface WindowProps
    * pointer without swallowing its own drag. See `useDragSource`.
    */
   dragPreview?: boolean;
-  /** ConfigureNotify — the tree reflows on its own. */
-  onResize?: (ev: SyntheticEvent<NtkWindow>) => void;
+  /**
+   * ConfigureNotify — the tree reflows on its own. Fires for moves and
+   * reparents too: check `ev.resized` / `ev.moved` before doing work of
+   * your own, or a window drag pays for it per pointer step.
+   */
+  onResize?: (ev: WindowResizeEvent) => void;
   onExpose?: (ev: SyntheticEvent<NtkWindow>) => void;
   /**
    * The states the window manager now has on the window. Subscribing is

--- a/src/types/events.d.ts
+++ b/src/types/events.d.ts
@@ -4,7 +4,7 @@
  * DOM. See docs/events.md.
  */
 
-import type { DrawnNode, TextInputNode } from './nodes.js';
+import type { DrawnNode, NtkWindow, TextInputNode } from './nodes.js';
 
 /** The raw ntk/X11 event a synthetic one was made from. */
 export interface NativeEvent {
@@ -304,3 +304,36 @@ export interface EventHandlers<T = DrawnNode>
     FocusHandlers<T>,
     DropTargetProps<T>,
     DragSourceProps<T> {}
+
+/**
+ * `<window onResize>`: X's ConfigureNotify, handed over as ntk's own event
+ * object rather than a synthetic one — there is no capture/bubble phase and
+ * nothing to `preventDefault`, because the window manager has already done
+ * the thing being reported.
+ *
+ * It fires for **moves and reparents** as much as for size changes; see
+ * docs/elements.md. `x`/`y` are relative to whatever the window's parent is,
+ * which is the window manager's frame once it has framed the window — not
+ * screen coordinates.
+ */
+export interface WindowResizeEvent {
+  /** X event type number (22, ConfigureNotify). */
+  type: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  /** The size differs from the last delivered event's. */
+  resized: boolean;
+  /** The position does. */
+  moved: boolean;
+  /**
+   * The geometry `moved`/`resized` are measured against, or null when none
+   * is known yet.
+   */
+  previous: { x: number; y: number; width: number; height: number } | null;
+  /** Every raw event merged into this one, oldest first. */
+  coalesced?: WindowResizeEvent[];
+  window: NtkWindow;
+  target: NtkWindow;
+}

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -128,7 +128,7 @@ function Elements() {
       onStatesChange={(states) => void states.includes('fullscreen')}
       style={s.root}
       onCloseRequest={() => {}}
-      onResize={(ev) => void ev.nativeEvent.rootx}
+      onResize={(ev) => void (ev.resized && ev.width + ev.height)}
     >
       <box
         ref={boxRef}

--- a/test/window-move.test.js
+++ b/test/window-move.test.js
@@ -144,3 +144,61 @@ test('a WM-driven resize still lays out and repaints', async () => {
     `the frame names its reason (got ${JSON.stringify(frames.map((f) => f.reasons))})`,
   );
 });
+
+// Where the window is on screen cannot be read off ConfigureNotify — a
+// reparenting WM makes those coordinates frame-relative — so it costs a
+// TranslateCoordinates round trip, and popups anchored to the window need
+// it. ntk's `ev.moved` (sidorares/ntk#184) says whether the position
+// changed at all, which is what keeps a resize drag from paying for one
+// per frame.
+let translates = 0;
+const countTranslates = () => {
+  const real = app.X.TranslateCoordinates.bind(app.X);
+  app.X.TranslateCoordinates = (...args) => {
+    translates++;
+    return real(...args);
+  };
+};
+countTranslates();
+
+test('a resize that did not move the window asks the server nothing', async () => {
+  await sleep(120);
+  translates = 0;
+  app.X.ConfigureWindow(node.window.id, { width: W + 120, height: H + 80 });
+  await waitFor(() => node.window.width === W + 120, 'the resize');
+  await sleep(120);
+  assert.strictEqual(
+    translates,
+    0,
+    'a pure resize must not re-ask where the window is',
+  );
+});
+
+test('a move still refreshes the screen origin', async () => {
+  await sleep(120);
+  translates = 0;
+  app.X.ConfigureWindow(node.window.id, { x: 33, y: 44 });
+  await waitFor(() => node.window.x === 33, 'the move');
+  await waitFor(() => translates > 0, 'the screen-origin refresh');
+  await waitFor(
+    () => node.window._screenOrigin?.x === 33,
+    'the origin the server answered with',
+  );
+});
+
+test('a reparent refreshes the screen origin on its own', async () => {
+  await sleep(120);
+  // stand in for a window manager framing the window: a parent at a known
+  // offset, which is exactly the case where ConfigureNotify coordinates
+  // stop meaning screen coordinates
+  const frame = app.X.AllocID();
+  app.X.CreateWindow(frame, app.X.display.screen[0].root, 70, 90, 400, 400);
+  app.X.MapWindow(frame);
+  translates = 0;
+  app.X.ReparentWindow(node.window.id, frame, 0, 0);
+  await waitFor(() => translates > 0, 'the reparent refresh');
+  await waitFor(
+    () => node.window._screenOrigin?.x === 70,
+    `the framed origin (got ${JSON.stringify(node.window._screenOrigin)})`,
+  );
+});


### PR DESCRIPTION
The react-x11 half of sidorares/ntk#184 (ntk PR: sidorares/ntk#193).

## What

`WindowNode` refreshed its cached screen origin on **every** ConfigureNotify — a `TranslateCoordinates` round trip per event, including all the ones that only changed the size. ntk 6.2 tags the event with what actually changed, so a resize drag stops paying for a round trip per frame:

```js
if (ev.moved ?? true) this._refreshScreenOrigin();
```

The floor moves to `^6.2.0` for it, lockfile regenerated. The `?? true` stays anyway — the same bargain `scrollRegion` makes — so a mock window or a deduped older copy keeps the unconditional refresh rather than losing the anchor.

## What deliberately did *not* change

The size guard stays a comparison against the laid-out rect rather than becoming `ev.resized`. They compare against different baselines and only one is right here — `ev.resized` means "differs from the last delivered event", but a React-driven resize configures the window and lays out in the same commit, so the server's echo arrives saying the size changed (true, and already accounted for). Swapping it in would relayout and fully repaint a second time for every controlled resize. There is now a comment saying so, since the guard looks redundant next to the new flag.

## A pre-existing hole this exposed

Gating the refresh on `ev.moved` raised the question of what happens on a reparent — and the answer turned out to be that it was already broken. `ReparentWindow` delivers **only** `ReparentNotify`; no ConfigureNotify at all (verified against the in-process server). So a bare reparent never refreshed the screen origin, and a popup anchored to a window the WM had just framed was placed against a stale one.

Real window managers hide this by sending the ICCCM synthetic ConfigureNotify that follows a frame, which is why nobody hit it. `WindowNode` now listens for `reparent` as well — `StructureNotify` is already selected for `resize`, so the subscription costs nothing.

## Types

`onResize` was typed `SyntheticEvent<NtkWindow>`, promising `localX`, `preventDefault()`, `capturePointer()` — none of which exist on what the handler is actually given, which is ntk's raw ConfigureNotify. The type test read an `ev.nativeEvent.rootx` that is `undefined` at runtime. Both now use a `WindowResizeEvent` that describes what really arrives, including the new flags — declared required, which the `^6.2.0` floor makes true — and the warning that `ev.x`/`ev.y` are frame-relative, not screen coordinates.

`docs/elements.md` gains the same note for `<window onResize>` — it fires for moves, check the flags before doing work of your own.

## Verification

Three new cases in `test/window-move.test.js`, the file that already owns "a move is not a resize":

- a resize that did not move the window makes **no** `TranslateCoordinates` call
- a move still refreshes, and the origin matches what the server answered
- a reparent refreshes on its own

Mutation-checked: restoring the unconditional refresh fails the first; dropping the `reparent` listener fails the third; and with both reverted — i.e. master's behaviour — the reparent test fails too, which is what identifies it as a pre-existing bug rather than fallout from the gate.

Verified against the **published ntk 6.2.0**, on a clean `npm install` — not the hand-copied branch build the draft was tested with. Full suite 482 pass, `npm run bench -- --check` clean, typecheck, lint and format clean.

Rebased onto master (post-#194).
