### PR TITLE
fix(windows): keep event props out of ntk's creation attributes

### DIFF
--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -29,9 +29,8 @@ import {
   TextAreaNode,
   flushWindowRestacks,
   flushTokenChecks,
-  WINDOW_HINT_PROPS,
+  windowAttributes,
 } from './nodes.js';
-import { flattenStyle } from './styles.js';
 import { hasDropProps } from './dnd.js';
 import { AppProvider } from './appcontext.js';
 import { defaultRootHandlers, setErrorHandler } from './errors.js';
@@ -87,41 +86,6 @@ export const HOST_TYPES = [
   'tex',
   'glarea',
 ];
-
-const isEventProp = (name) => /^on[A-Z]/.test(name);
-
-// Props forwarded to ntk createWindow. Event handlers are dispatched by the
-// EventManager from current props (never registered at creation, so they
-// cannot go stale) and children are handled by the tree.
-/**
- * ntk's Window constructor takes every creation attribute up front. The
- * user-facing shape and ntk's differ in two places: size hints are flat
- * props here and a `sizeHints` object there, and the window background is
- * a style property here and a creation attribute there.
- */
-function windowAttributes(props) {
-  const attributes = {};
-  const hints = {};
-  for (const key of Object.keys(props)) {
-    if (key === 'children' || key === 'style' || isEventProp(key)) continue;
-    // resolved in the commit phase against a ref that has not attached yet
-    // at createInstance time — WindowNode._applyTransientFor
-    if (key === 'transientFor') continue;
-    if (WINDOW_HINT_PROPS.includes(key)) {
-      hints[key] = props[key];
-      continue;
-    }
-    attributes[key] = props[key];
-  }
-  if (Object.keys(hints).length > 0) attributes.sizeHints = hints;
-  if (props.style !== undefined) {
-    const style = flattenStyle(props.style);
-    if (style.backgroundColor !== undefined) {
-      attributes.backgroundColor = style.backgroundColor;
-    }
-  }
-  return attributes;
-}
 
 const HostConfig = {
   supportsMutation: true,

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -497,6 +497,43 @@ export const WINDOW_HINT_PROPS = [
   'maxAspect',
   'gravity',
 ];
+
+/**
+ * ntk's Window constructor takes every creation attribute up front. The
+ * user-facing shape and ntk's differ in two places: size hints are flat
+ * props here and a `sizeHints` object there, and the window background is
+ * a style property here and a creation attribute there.
+ *
+ * Event props never travel this way. ntk reads `onKeyDown` & co. off its
+ * creation args and registers them as raw listeners (events_map.toSnake),
+ * which would hand the application the native X event instead of the
+ * synthetic one the EventManager dispatches — and hold the first render's
+ * closure forever. Handlers are read from current props at dispatch time
+ * instead, so they can never go stale. `children` is the tree's, and
+ * `transientFor` holds a React ref that only the commit phase can resolve
+ * (WindowNode._applyTransientFor).
+ */
+export function windowAttributes(props) {
+  const attributes = {};
+  const hints = {};
+  for (const key of Object.keys(props)) {
+    if (key === 'children' || key === 'style' || isEventProp(key)) continue;
+    if (key === 'transientFor') continue;
+    if (WINDOW_HINT_PROPS.includes(key)) {
+      hints[key] = props[key];
+      continue;
+    }
+    attributes[key] = props[key];
+  }
+  if (Object.keys(hints).length > 0) attributes.sizeHints = hints;
+  if (props.style !== undefined) {
+    const style = flattenStyle(props.style);
+    if (style.backgroundColor !== undefined) {
+      attributes.backgroundColor = style.backgroundColor;
+    }
+  }
+  return attributes;
+}
 /**
  * The `_NET_WM_STATE` names these props ask for. `states` is the general
  * mechanism; `fullscreen` and `alwaysOnTop` are sugar for the two everyone
@@ -4446,12 +4483,13 @@ export class WindowNode extends Node {
     }
     const wnd = this.window;
     if (!wnd) {
-      // not realized yet: refresh creation attributes instead. `transientFor`
-      // is the one prop that must not travel this way — it holds a React ref
-      // until the commit phase resolves it, and ntk's hint handling reads a
-      // key by that name.
-      this.attributes = { ...this.attributes, ...newProps };
-      delete this.attributes.transientFor;
+      // Not realized yet: refresh creation attributes instead — through the
+      // same filter createInstance used, since these are the arguments ntk's
+      // constructor will see. Spreading raw props here was the bug behind
+      // `ev.preventDefault is not a function` in a <popup>'s onKeyDown: ntk
+      // registers any `onFoo` in its creation args as a raw listener, so the
+      // handler was called a second time with the native X event.
+      this.attributes = { ...this.attributes, ...windowAttributes(newProps) };
       return;
     }
 

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -3063,6 +3063,16 @@ test('Dialog: modal popup, Escape closes it, focus goes back', async () => {
     false,
     'the ref is resolved in the commit phase, never handed to ntk',
   );
+  // ntk's Window constructor registers any `onKeyDown`/`onFocus`/… it finds
+  // in its creation args as a raw listener (events_map.toSnake). A handler
+  // that got there would be called a second time with the native X event —
+  // no preventDefault, no target — so no event prop may reach the
+  // attributes, on creation or on the pre-realize update path.
+  assert.deepStrictEqual(
+    Object.keys(dialog.attributes).filter((k) => /^on[A-Z]/.test(k)),
+    [],
+    'event props are dispatched by the EventManager, never by ntk',
+  );
   assert.strictEqual(input.focused, true, 'autoFocus inside the dialog won');
 
   // Escape reaches the dialog by bubbling out of the focused node


### PR DESCRIPTION
## The bug

Escape in the stress example's Dialog takes the process down:

```
file:///home/andrey/react-x11/src/components/Dialog.js:98
      ev.preventDefault();
         ^
TypeError: ev.preventDefault is not a function
    at Window.onKeyDown (src/components/Dialog.js:98:10)
    at Window.emit (node:events:531:35)
    at Window.<anonymous> (node_modules/ntk/lib/window.js:537:12)
```

Note the frames: no `callHandler`, no dispatch — the component's handler was called straight off an ntk `emit`, with the native X event.

## Why

`WindowNode.applyProps` has a branch for props that change *before* the X window exists. It refreshes the creation attributes instead of talking to a window that is not there yet — and it spread the raw props in:

```js
this.attributes = { ...this.attributes, ...newProps };
```

ntk's `Window` constructor scans its creation args for `onKeyDown`, `onFocus` & co. (`lib/events_map.js`, `toSnake`) and registers each as a raw listener. So the handler ran twice: once from the `EventManager` with the synthetic event, and once from ntk with the native one, which has no `preventDefault`, no `target`, no bubbling. It also pinned the first render's closure for the window's lifetime, which is exactly what dispatching from current props exists to avoid.

A `<popup>` is what trips it: it realizes in `commitMount`, one props update later than a `<window>`, which realizes when it is appended and so never takes that branch.

## The fix

`createInstance` already had the right filter. This moves `windowAttributes()` from the Reconciler into `nodes.js` and runs the pre-realize update through it, so both paths agree on what ntk may see. The hand-written `delete this.attributes.transientFor` goes away — the shared filter drops it.

## Testing

Against a mock-app repro, the popup's creation attributes carried `onDismiss`, `onCloseRequest`, `onKeyDown` before the change and nothing after. The existing Dialog test now asserts no `on*` prop reaches them, on either path. Full suite passes (482 tests); lint clean for `src/` and `test/`.