### PR TITLE
chore: unblock the dev-dependency bump, and hold eslint 10 until its plugin lands

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,23 @@ updates:
     groups:
       dev-dependencies:
         dependency-type: development
+    ignore:
+      # eslint 10 cannot be installed here: eslint-plugin-react caps its peer
+      # at `^9.7` (7.37.5 is the newest release, and the `next` tag is an
+      # older prerelease), so `npm ci` fails with ERESOLVE before any job
+      # gets to run — which is what made every check on #182 red. Dropping
+      # the plugin is not the way out either: `react/jsx-uses-react` and
+      # `react/jsx-uses-vars` are what stop `no-unused-vars` flagging
+      # `React` and every JSX-referenced identifier, 30 errors' worth.
+      #
+      # Lift this once jsx-eslint/eslint-plugin-react#3977 ships. Nothing
+      # else here is in the way: eslint 10's new recommended rules
+      # (preserve-caught-error, no-useless-assignment) already pass.
+      - dependency-name: eslint
+        update-types: ['version-update:semver-major']
+      # released in lockstep with eslint, so holding one holds both
+      - dependency-name: '@eslint/js'
+        update-types: ['version-update:semver-major']
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -553,6 +553,7 @@ async function connect(options) {
       'react-x11: could not connect to the X server. Is an X server running ' +
         `and DISPLAY set (DISPLAY=${display})? Original error: ` +
         err.message,
+      { cause: err },
     );
   }
 }

--- a/src/testing/components.js
+++ b/src/testing/components.js
@@ -182,6 +182,7 @@ function rendererInterface() {
             'in-process, which needs the react-devtools-core package — ' +
             'add it to your devDependencies. Original error: ' +
             err.message,
+          { cause: err },
         );
       }
       const api = mod.default?.initialize ? mod.default : mod;

--- a/src/testing/harness.js
+++ b/src/testing/harness.js
@@ -24,6 +24,7 @@ async function optional(specifier, why) {
         `inside ntk's dependency tree, so this usually means a package ` +
         `manager that does not hoist — add "${specifier.split('/')[0]}" to ` +
         `your own devDependencies.\n${err.message}`,
+      { cause: err },
     );
   }
 }

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -68,7 +68,9 @@ const isNear = (rgb, want, tol = 40) =>
 
 async function waitForPixel(ctx, w, h, x, y, want, what) {
   const deadline = Date.now() + 3000;
-  let last = null;
+  // no initializer: the loop below always assigns before anything reads it,
+  // and eslint 10's no-useless-assignment flags the dead `= null`
+  let last;
   for (;;) {
     const image = await readPixels(ctx, w, h);
     last = px(image, w, x, y);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,6 @@
     "skipLibCheck": false,
     "types": [],
     "forceConsistentCasingInFileNames": true,
-    "baseUrl": ".",
     "paths": {
       "react-x11": ["./src/index.d.ts"],
       "react-x11/jsx-runtime": ["./src/jsx-runtime.d.ts"],


### PR DESCRIPTION
Makes the dev-dependency bump in #182 landable, and holds back the one part of it that cannot land yet.

## Why every check on #182 was red

All five jobs failed in 6–12 seconds, at `npm ci`, before a single test ran:

```
npm error code ERESOLVE
npm error peer eslint@"^3 || ... || ^9.7" from eslint-plugin-react@7.37.5
npm error Conflicting peer dependency: eslint@9.39.5
```

The bump asks for eslint 10.8.0; `eslint-plugin-react` caps its peer at `^9.7`. Dependabot resolved its lockfile with a tolerant resolver, and plain `npm ci` refuses the tree.

**That part is upstream's.** 7.37.5 is the newest published release and the `next` tag is `7.8.0-rc.0` — *older*, not a fix ([jsx-eslint/eslint-plugin-react#3977](https://github.com/jsx-eslint/eslint-plugin-react/issues/3977) is open). Dropping the plugin is not the escape either: `react/jsx-uses-react` and `react/jsx-uses-vars` are what stop `no-unused-vars` flagging `React` and every JSX-referenced identifier — I removed it to check, and eslint 10 then reported **30** extra errors.

So `.github/dependabot.yml` now holds `eslint` and `@eslint/js` at their majors, with the reason and the upstream issue written next to it. One comment to delete when the plugin ships v10 support.

## Two more failures were hiding behind it

Neither could be seen while `npm ci` was failing. I installed with `--legacy-peer-deps` and ran the jobs CI never reached:

**eslint 10 adds two rules to `js.configs.recommended`** — 4 errors:

- `preserve-caught-error` ×3 — [src/Reconciler.js](src/Reconciler.js), [src/testing/components.js](src/testing/components.js), [src/testing/harness.js](src/testing/harness.js). All three catch an error, then throw a new one that inlines `err.message` but drops the error itself. They now pass `{ cause: err }`, which is what the rule is for and keeps the original stack — the message text is unchanged.
- `no-useless-assignment` ×1 — a dead `= null` initializer in [test/integration.test.js](test/integration.test.js), where the loop always assigns before anything reads.

**TypeScript 7 removed `baseUrl`** (`TS5102`), breaking `npm run typecheck`. It was redundant already: all four `paths` entries are `./`-relative, and those resolve against the tsconfig's own directory without it.

## Verified both ways round

| | eslint 9.39.5 / TS 5.9.3 (today) | eslint 10.8.0 / TS 7.0.2 (the bump) |
|---|---|---|
| `npm ci` | ✅ | n/a — held |
| lint | ✅ | ✅ |
| typecheck | ✅ | ✅ |
| prettier | ✅ | ✅ |
| tests | ✅ 482 | ✅ 482 |

Nothing here waits on the hold being lifted; when it is, the repo is already clean under eslint 10.

I also simulated the PR dependabot will regenerate — `globals` 17 and `typescript` 7 with eslint held — on top of this branch: `npm ci` succeeds (the exact step that failed), lint and typecheck clean, 482 tests pass. That is the state #182 could not reach.

`package.json` and `package-lock.json` are deliberately untouched: the bumps themselves are dependabot's to make.
