### PR TITLE
feat(glarea): render something useful when the server has no GL

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -747,10 +747,59 @@ Takes every `<glarea>` prop (layout props, `clearColor`, `frameLoop`, `glx`,
 - `camera` — `{ position, target, up, fov, near, far }`, or
   `{ orthographic: true, zoom }`. Defaults to a perspective camera at
   `[0, 0, 5]` looking at the origin with a 50° vertical field of view.
+- `fallback` — what to show when this X server cannot give us a GL context.
 
 Animate by changing props from a `requestAnimationFrame` loop on the window
 ref (see `examples/three.jsx`) — a scene only redraws when something
 changes, unless `frameLoop="always"`.
+
+### When there is no GL
+
+Plan for it. Indirect GLX — the only kind that works over the wire, and so
+the only kind react-x11 can use — is **disabled by default** on Xorg ≥ 1.17
+and on Xwayland, which is most desktops. A `<Canvas3D>` there has nothing to
+draw with, and without a `fallback` it renders an empty box.
+
+```jsx
+<Canvas3D
+  style={{ flexGrow: 1 }}
+  fallback={(err) => <NoGL error={err} />}
+>
+```
+
+`fallback` takes an element or a function of the error, and is rendered in a
+`<box>` carrying the component's `style` — so it holds the same place in the
+layout the surface would have. It cannot be `children`: those are the scene
+graph. (Same reason `<Suspense fallback>` is a prop.)
+
+The error is classified, so branch on `code` rather than matching the
+message:
+
+| `err.code`              |                                                               |
+| ----------------------- | ------------------------------------------------------------- |
+| `GLX_INDIRECT_DISABLED` | server has GLX but refuses indirect contexts — the common one |
+| `GLX_NO_EXTENSION`      | server has no GLX at all                                      |
+| `GLX_NO_CONFIG`         | no visual matches the `glx` spec you asked for                |
+| `GLX_CONTEXT_FAILED`    | anything else in setup                                        |
+
+`err.hint` is a multi-line explanation of how to get a server that works,
+written to be printed as-is. The codes come from ntk and are also available
+as `GLXError` from `react-x11/ntk` if you would rather not spell them out.
+
+Setup failure is a property of the connection, not of one surface, so it is
+remembered per app: a second `<Canvas3D>` mounting after the first has found
+out renders its fallback on the first frame, with no round trip and no
+flash of empty box.
+
+To develop against a server that does have it:
+
+```bash
+Xwayland :5 +iglx & DISPLAY=:5 npm run examples:three
+```
+
+Be warned that on current Linux distros the indirect GL engine behind those
+contexts is frequently missing even with `+iglx` — contexts are created and
+nothing rasterizes. See [3D over indirect GLX](glx.md).
 
 ## `useAnchor(ref)` / `anchorRect(node, options)`
 

--- a/examples/three.jsx
+++ b/examples/three.jsx
@@ -52,6 +52,35 @@ function useSpin(running, windowRef) {
   return angle;
 }
 
+/**
+ * Shown in place of the surface when the X server cannot give us a GL
+ * context — which is the default on Xwayland and on Xorg without `+iglx`,
+ * so most people run this example and land here first. The error carries a
+ * `code` to branch on and a `hint` explaining how to get a server that works.
+ */
+function NoGL({ error }) {
+  const disabled = error.code === 'GLX_INDIRECT_DISABLED';
+  return (
+    <box
+      style={{
+        flexGrow: 1,
+        padding: 20,
+        gap: 10,
+        justifyContent: 'center',
+        backgroundColor: '#12161f',
+      }}
+    >
+      <text style={{ fontSize: 15, color: '#e8ecf1' }}>
+        {disabled ? 'This X server has no indirect GLX' : 'No GL surface'}
+      </text>
+      <text style={{ fontSize: 12, color: '#9aa7b4' }}>{error.message}</text>
+      {error.hint ? (
+        <text style={{ fontSize: 11, color: '#6f7d8c' }}>{error.hint}</text>
+      ) : null}
+    </box>
+  );
+}
+
 function App() {
   const windowRef = useRef(null);
   const [running, setRunning] = useState(true);
@@ -87,6 +116,7 @@ function App() {
           glx={{ DEPTH_SIZE: 24 }}
           camera={{ position: [0, 2.6, 8.5], target: [0, -0.2, 0], fov: 45 }}
           style={{ flexGrow: 1 }}
+          fallback={(err) => <NoGL error={err} />}
         >
           <ambientLight intensity={0.35} />
           <pointLight position={[5, 6, 6]} intensity={1} />

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^6.2.0",
+        "ntk": "^6.4.0",
         "react-reconciler": "^0.33.0"
       },
       "devDependencies": {
@@ -3676,10 +3676,9 @@
       }
     },
     "node_modules/ntk": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-6.2.0.tgz",
-      "integrity": "sha512-GVNGA9tWGpJebdTOu7w7i+UOTh0ViQycC/JJ9GulazZR4xYz/yy8hqh3iZwqSmMuPveGdYmYUFiROtn0s/6CRA==",
-      "license": "MIT",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-6.4.0.tgz",
+      "integrity": "sha512-ZlIAgiTlrmfZ4LPy+l8FbicLtmcJza+fet88cU3RDNAVMhfDJEf0P+EZ/g+cbEIH0zO1TLsU/7H+UwpDH3zmUg==",
       "dependencies": {
         "bidi-js": "^1.0.3",
         "canvas-fontstyle": "^1.0.1",
@@ -3696,7 +3695,7 @@
         "parse-color": "^1.0.0",
         "pngjs": "^7.0.0",
         "postcss": "^8.5.23",
-        "x11": "^3.7.0",
+        "x11": "^3.8.0",
         "yoga-layout": "^3.2.1"
       },
       "engines": {
@@ -4984,9 +4983,9 @@
       }
     },
     "node_modules/x11": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/x11/-/x11-3.7.1.tgz",
-      "integrity": "sha512-yYSkB5VXOAlbuqGa32AH5X4vHSBoUEWuQGjlG4rW/k2ViKfBgosijg4uFElmcr0uatvOYzx+8Cb7bT3GIvJp9Q==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/x11/-/x11-3.8.0.tgz",
+      "integrity": "sha512-SYXE7H6ALT1HQ/CNoOxxLfwYb8QQU2jJpro9/R3jhYtmmNJWaNccEzkyLKnMbzLd/YV0WeMbU2qbTTqrft21tg==",
       "engines": {
         "node": ">=18"
       }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^6.2.0",
+    "ntk": "^6.4.0",
     "react-reconciler": "^0.33.0"
   },
   "peerDependencies": {

--- a/src/appcontext.js
+++ b/src/appcontext.js
@@ -21,6 +21,12 @@ const AppContext = createContext(null);
 /** Wraps the rendered element; not exported to applications. */
 export const AppProvider = AppContext.Provider;
 
+/** `useApp()` without the throw, for components that can still render
+ * something useful outside a tree (see `<Canvas3D>`). Not public. */
+export function useAppOrNull() {
+  return useContext(AppContext);
+}
+
 /**
  * The ntk connection this tree is rendering onto.
  *

--- a/src/components/Canvas3D.js
+++ b/src/components/Canvas3D.js
@@ -1,4 +1,7 @@
-import { createElement as h } from 'react';
+import { createElement as h, useCallback, useState } from 'react';
+
+import { useAppOrNull } from '../appcontext.js';
+import { glxFailure } from '../glnodes.js';
 
 /**
  * `<Canvas3D>` — the react-three-fiber-shaped entry point to the 3D scene.
@@ -16,13 +19,57 @@ import { createElement as h } from 'react';
  *
  * Props are `<glarea>`'s (`style`, `clearColor`, `frameLoop`, `glx`,
  * `onCreated`, `onDraw`, `onError`) plus `camera`:
- * `{ position, target, up, fov, near, far, orthographic, zoom }`.
+ * `{ position, target, up, fov, near, far, orthographic, zoom }`, and
+ * `fallback` (below).
  *
  * The name is `Canvas3D`, not r3f's `Canvas`, because react-x11 already has
  * a `<canvas>` host element — the 2D `onDraw` escape hatch.
+ *
+ * ## When there is no GL
+ *
+ * Plenty of X servers cannot give us a GL context — indirect GLX is off by
+ * default on Xorg >= 1.17 and Xwayland, which is most desktops. `fallback`
+ * is what to show instead:
+ *
+ * ```jsx
+ * <Canvas3D fallback={(err) => <text>No 3D here: {err.message}</text>}>
+ * ```
+ *
+ * An element works too; a function receives the error, whose `code` is one
+ * of ntk's `GLXError` values (`GLX_INDIRECT_DISABLED` is the common one) and
+ * whose `hint` is a multi-line explanation of how to fix the server. Branch
+ * on the code, not on the message.
+ *
+ * The fallback is rendered in a `<box>` carrying this component's `style`,
+ * so it takes the same place in the layout the surface would have. Children
+ * are the scene graph and cannot double as the fallback — hence a prop, the
+ * same reason `<Suspense fallback>` is one.
+ *
+ * Without `fallback` the surface stays mounted, draws nothing, and the error
+ * goes to `onError` (or to the console, once).
  */
-export function Canvas3D({ children, style, ...props }) {
-  return h('glarea', { ...props, style }, children);
+export function Canvas3D({ children, style, fallback, onError, ...props }) {
+  const app = useAppOrNull();
+  // seeded from the connection: by the time a second <Canvas3D> mounts, the
+  // answer is usually already known, and seeding renders its fallback on the
+  // first frame rather than after a round trip
+  const [error, setError] = useState(() => glxFailure(app));
+  const handleError = useCallback(
+    (err) => {
+      setError(err);
+      onError?.(err);
+    },
+    [onError],
+  );
+
+  if (error && fallback !== undefined) {
+    return h(
+      'box',
+      { style },
+      typeof fallback === 'function' ? fallback(error) : fallback,
+    );
+  }
+  return h('glarea', { ...props, style, onError: handleError }, children);
 }
 
 export default Canvas3D;

--- a/src/glnodes.js
+++ b/src/glnodes.js
@@ -15,6 +15,24 @@ import { SceneRenderer } from './scene3d.js';
 // <glarea> in an app wants the same answer.
 const configCache = new WeakMap();
 
+// Whether GL setup has already been found impossible on this connection.
+// Every reason it fails — no GLX extension, indirect GLX disabled, no
+// matching visual — is a property of the X server, not of one surface, so
+// the first <glarea> to find out saves the rest from asking. `<Canvas3D
+// fallback>` reads it to render the fallback on the first frame instead of
+// showing an empty box for the round trip it would otherwise take.
+const glxFailures = new WeakMap();
+
+/** The error that made GL unavailable on `app`, or null if all is well (or
+ * not yet known). Carries ntk's `code` — see `GLXError`. */
+export function glxFailure(app) {
+  return (app && glxFailures.get(app)) || null;
+}
+
+function recordGlxFailure(app, err) {
+  if (app && err && !glxFailures.has(app)) glxFailures.set(app, err);
+}
+
 export function glxConfig(app, spec) {
   const key = JSON.stringify(spec ?? null);
   let perApp = configCache.get(app);
@@ -101,22 +119,53 @@ export class GlAreaNode extends Node {
     if (this.window || this.destroyed || this._realizing) return;
     const parent = this.root?.window;
     if (!parent || typeof this.app?.createWindow !== 'function') return;
+    // asked and answered — and whoever asked first already reported it
+    const known = glxFailure(this.app);
+    if (known) return this._failed(known, { reported: true });
     this._realizing = true;
     glxConfig(this.app, this.props.glx).then(
       (config) => {
         this._realizing = false;
         if (this.destroyed || this.window) return;
-        this._create(config, parent);
+        // getContext() throws rather than rejects when the display has no
+        // GLX at all, and a throw in here would escape as an unhandled
+        // rejection instead of reaching onError
+        try {
+          this._create(config, parent);
+        } catch (err) {
+          this._failed(err);
+        }
       },
       (err) => {
         this._realizing = false;
-        this.error = err;
-        this.props.onError?.(err);
-        if (!this.props.onError) {
-          console.warn(`react-x11: <glarea> has no GL surface: ${err.message}`);
-        }
+        this._failed(err);
       },
     );
+  }
+
+  /**
+   * GL is not available: report it once, and give up the X child window if
+   * one was created. It would otherwise sit over this rect as an unpainted
+   * hole, hiding whatever the fallback draws in its place.
+   *
+   * `reported` means ntk has already written the diagnosis to the console —
+   * it does that for a failed context, and its message is the better one.
+   */
+  _failed(err, { reported = false } = {}) {
+    this._realizing = false;
+    if (this.error) return;
+    this.error = err;
+    recordGlxFailure(this.app, err);
+    this.gl = null;
+    if (this.window) {
+      this.window.destroy?.();
+      this.window = null;
+      this.rect = null;
+    }
+    if (this.props.onError) this.props.onError(err);
+    else if (!reported) {
+      console.warn(`react-x11: <glarea> has no GL surface: ${err.message}`);
+    }
   }
 
   _create(config, parent) {
@@ -138,6 +187,13 @@ export class GlAreaNode extends Node {
     this.config = config;
     wnd._reactX11Node = this;
     this.gl = wnd.getContext('opengl', config);
+    // The context is only usable once MakeCurrent has answered, and that is
+    // where a server refusing indirect GLX says so (ntk gives the rejection
+    // an err.code — see GLXError). Nothing here awaits it: GL calls queue
+    // until the tag arrives, so this only has to catch the failure.
+    this.gl?.ready?.catch((err) => {
+      if (!this.destroyed) this._failed(err, { reported: true });
+    });
     wnd.on?.('expose', () => this.requestFrame());
     wnd.map?.();
     this.requestFrame();

--- a/src/ntk.d.ts
+++ b/src/ntk.d.ts
@@ -19,6 +19,13 @@ export const Path2D: new (...args: unknown[]) => unknown;
 export const Image: new (...args: unknown[]) => unknown;
 export const Pixmap: new (...args: unknown[]) => unknown;
 export const Yoga: Record<string, unknown>;
+/** `code` values on a failed GL setup — see `<Canvas3D fallback>`. */
+export const GLXError: {
+  NO_EXTENSION: 'GLX_NO_EXTENSION';
+  INDIRECT_DISABLED: 'GLX_INDIRECT_DISABLED';
+  NO_CONFIG: 'GLX_NO_CONFIG';
+  CONTEXT_FAILED: 'GLX_CONTEXT_FAILED';
+};
 
 declare const ntk: Record<string, unknown>;
 export default ntk;

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -387,6 +387,23 @@ export interface Canvas3DProps extends Omit<GlAreaProps, 'onDraw'> {
     target?: Vec3;
   };
   children?: ReactNode;
+  /**
+   * What to render when this X server cannot give us a GL context — an
+   * element, or a function of the error. `err.code` is one of ntk's
+   * `GLXError` values; `GLX_INDIRECT_DISABLED` is the usual one. Rendered
+   * inside a `<box>` with this component's `style`, so it keeps the
+   * surface's place in the layout.
+   */
+  fallback?: ReactNode | ((error: GlxSetupError) => ReactNode);
+}
+
+/** The error a failed GL setup reports (ntk classifies it). */
+export interface GlxSetupError extends Error {
+  /** `GLX_INDIRECT_DISABLED` | `GLX_NO_EXTENSION` | `GLX_NO_CONFIG` |
+   * `GLX_CONTEXT_FAILED` — branch on this, not on the message. */
+  code?: string;
+  /** Multi-line remedy, suitable for printing as-is. */
+  hint?: string;
 }
 export const Canvas3D: ComponentType<Canvas3DProps>;
 

--- a/test/glarea.test.js
+++ b/test/glarea.test.js
@@ -11,6 +11,7 @@ import React from 'react';
 import xserver from 'x11/lib/xserver/index.js';
 import { createClient, StaticFontSource } from 'ntk';
 
+import { Canvas3D } from '../src/components/index.js';
 import { createRoot } from '../src/index.js';
 
 const require = createRequire(import.meta.url);
@@ -18,7 +19,7 @@ const { createGlxExtension, RecordingBackend } = require('x11/browser/glx');
 
 const h = React.createElement;
 
-async function createGlApp() {
+async function createGlApp({ indirectContexts = true } = {}) {
   const server = xserver.createServer({ width: 640, height: 480 });
   const backend = new RecordingBackend();
   const surfaces = new Map();
@@ -26,6 +27,7 @@ async function createGlApp() {
     'GLX',
     createGlxExtension({
       backend,
+      indirectContexts,
       getDrawableSurface: (xid) => surfaces.get(xid) || null,
     }),
   );
@@ -211,6 +213,147 @@ test('<glarea> follows layout changes and redraws once per change', async () => 
     await settle(app, 6);
     assert.equal(frames.length, before, 'no frames without a change');
     assert.equal(xErrors.length, 0, xErrors.map((e) => e.message).join(', '));
+
+    await x11Root.unmount();
+    await settle(app);
+  } finally {
+    await app.close();
+  }
+});
+
+// A server with indirect GLX disabled is the common case, not an edge case:
+// it is the default on Xwayland and on Xorg without +iglx. The emulator's
+// indirectContexts:false reproduces it exactly — every query answers, and
+// CreateContext alone fails with BadValue 0.
+test('<Canvas3D fallback> renders instead of the surface when GL is refused', async () => {
+  const { app } = await createGlApp({ indirectContexts: false });
+  const x11Root = await createRoot({ app });
+  try {
+    const errors = [];
+    const instance = await render(
+      h(
+        'window',
+        { width: 320, height: 240 },
+        h(
+          Canvas3D,
+          {
+            style: { flexGrow: 1 },
+            fallback: (err) => {
+              errors.push(err);
+              // a box, not text: this suite's font source is empty
+              return h('box', { name: 'no-gl' });
+            },
+          },
+          h('mesh', null, h('boxGeometry', { args: [1, 1, 1] })),
+        ),
+      ),
+      x11Root,
+    );
+
+    await waitFor(() => errors.length > 0, 'the fallback to render');
+    await settle(app);
+
+    const err = errors[0];
+    assert.equal(
+      err.code,
+      'GLX_INDIRECT_DISABLED',
+      `classified by cause, got ${err.code}: ${err.message}`,
+    );
+    assert.match(err.message, /indirect GLX/);
+    assert.ok(err.hint, 'and carries the remedy for whoever wants to show it');
+
+    const node = instance._reactX11Node;
+    const [child] = node.children;
+    assert.equal(child.kind, 'box', 'the surface is gone, the fallback is up');
+    assert.equal(
+      child.children[0].props.name,
+      'no-gl',
+      'and it is what the fallback returned',
+    );
+
+    await x11Root.unmount();
+    await settle(app);
+  } finally {
+    await app.close();
+  }
+});
+
+test('a failed <glarea> leaves no X window over the fallback', async () => {
+  const { app } = await createGlApp({ indirectContexts: false });
+  const x11Root = await createRoot({ app });
+  try {
+    const errors = [];
+    const instance = await render(
+      h(
+        'window',
+        { width: 320, height: 240 },
+        h('glarea', { style: { flexGrow: 1 }, onError: (e) => errors.push(e) }),
+      ),
+      x11Root,
+    );
+
+    await waitFor(() => errors.length > 0, 'onError');
+    await settle(app);
+
+    const area = instance._reactX11Node.children[0];
+    assert.equal(area.kind, 'glarea');
+    assert.equal(area.error, errors[0], 'the node records why it has no GL');
+    assert.equal(area.gl, null, 'no context');
+    assert.equal(
+      area.window,
+      null,
+      'and no child window: an unpainted one would cover whatever replaces it',
+    );
+
+    await x11Root.unmount();
+    await settle(app);
+  } finally {
+    await app.close();
+  }
+});
+
+// Why the connection remembers: the reason GL is unavailable is a property
+// of the X server, so a second surface asking would get the same answer one
+// round trip later — and show an empty box until it arrived.
+test('a second <Canvas3D> shows its fallback on the first frame', async () => {
+  const { app } = await createGlApp({ indirectContexts: false });
+  const x11Root = await createRoot({ app });
+  try {
+    const first = [];
+    const commits = [];
+    const canvas = (log) =>
+      h(Canvas3D, {
+        style: { flexGrow: 1 },
+        fallback: (err) => {
+          log.push(err);
+          return h('box', { name: 'no-gl' });
+        },
+      });
+
+    await render(
+      h('window', { width: 320, height: 240 }, canvas(first)),
+      x11Root,
+    );
+    await waitFor(() => first.length > 0, 'the first surface to find out');
+    await settle(app);
+
+    // a second surface, mounted after the answer is known
+    const second = [];
+    let rendered = 0;
+    const Probe = () => {
+      rendered++;
+      commits.push(second.length);
+      return canvas(second);
+    };
+    await render(h('window', { width: 320, height: 240 }, h(Probe)), x11Root);
+
+    assert.ok(rendered > 0, 'the second tree rendered');
+    assert.equal(
+      second.length,
+      1,
+      'its fallback ran on the first commit, with no round trip in between',
+    );
+    assert.equal(second[0].code, 'GLX_INDIRECT_DISABLED');
 
     await x11Root.unmount();
     await settle(app);


### PR DESCRIPTION
Completes the three-repo chain that started with [node-x11#272](https://github.com/sidorares/node-x11/pull/272) (`CreateContext` can report why it failed) and [ntk#200](https://github.com/sidorares/ntk/pull/200) (classify that failure and explain it). Those turned three cryptic X errors into one diagnosis; this turns it into UI. Requires ntk >= 6.4.0.

## Why

Indirect GLX — the only kind that works over the wire, so the only kind we can use — is **disabled by default** on Xorg >= 1.17 and Xwayland. A `<Canvas3D>` on a normal Wayland desktop has nothing to draw with. That is the common case, not an edge case, and `examples/three.jsx` is most people's first encounter with it.

What they got was an empty box, plus a console warning naming the wrong cause.

## What

```jsx
<Canvas3D style={{ flexGrow: 1 }} fallback={(err) => <NoGL error={err} />}>
  <mesh>…</mesh>
</Canvas3D>
```

`fallback` takes an element or a function of the error, and renders inside a `<box>` carrying the component's `style` — so it holds the place in the layout the surface would have had. It can't be `children`: those are the scene graph. (Same reason `<Suspense fallback>` is a prop.)

The error is classified by ntk, so branch on the code rather than matching message text:

| `err.code` | |
| --- | --- |
| `GLX_INDIRECT_DISABLED` | server has GLX but refuses indirect contexts — the common one |
| `GLX_NO_EXTENSION` | server has no GLX at all |
| `GLX_NO_CONFIG` | no visual matches the `glx` spec |
| `GLX_CONTEXT_FAILED` | anything else in setup |

`err.hint` is a multi-line remedy written to be printed as-is.

## What had to change underneath

The prop is the small part. Three things stopped the error from arriving at all:

- **A rejected `gl.ready` went nowhere.** Only config-stage failures reached `onError`, and `GLX_INDIRECT_DISABLED` is not one of those — so the single most common failure had no route out of the node.
- **`getContext()` throws rather than rejects** when the display has no GLX, and that throw was inside a `.then` handler. It escaped as an unhandled rejection instead of reaching `onError`.
- **A failed surface kept its X child window**, which sat over the rect as an unpainted hole and would have covered whatever replaced it.

Also: failure is a property of the connection, not of one surface, so it is remembered per app. A second `<Canvas3D>` renders its fallback on the first commit — no round trip, no flash of empty box. And react-x11 no longer repeats a warning ntk has already printed in full.

## Testing

`test/glarea.test.js` — 5 passing, three of them new and hermetic, driven by the `indirectContexts: false` option node-x11's GLX emulator grew for exactly this. They assert the code and hint reach the fallback, that no X window is left over the fallback, and that the second surface's fallback runs on its first commit.

Verified end to end against a real XWayland session: the fallback receives `code: GLX_INDIRECT_DISABLED`, the one-line message, the hint, and `cause: Bad param value`. `examples/three.jsx` now ships a fallback panel, which is what most people running it will see.

## One known failure, not from this change

`test/discrete-latency.test.js:312` fails on this branch: a 10-notch wheel burst paints 10 times instead of 1. It comes from the ntk 6.2.0 -> 6.4.0 bump this PR needs, bisected — passes on 6.2.0, fails on 6.4.0 with this branch's source changes stashed.

ntk 6.3.0's Present work (sidorares/ntk#198) added a `frameInterval` timer gate to `Window._present()`; a deferred present no longer arms the fence, so the `frameInFlight()` gate in `src/frames.js:65` stays open for the whole burst. ntk's own doc comment on `frameInFlight()` describes that deferred-and-coalesced case as precisely when it should return `true`, so the fix likely belongs in ntk. Being handled separately — it is a different subsystem and shouldn't hold this up.