### PR TITLE
example(raster-gate): svg gauge and a height slider, and the cache rule they exposed

### DIFF
--- a/examples/raster-gate.jsx
+++ b/examples/raster-gate.jsx
@@ -39,6 +39,21 @@
 // masks and the like reach XRender directly — which is worth knowing before
 // concluding the gate alone can eliminate the fallback path.
 //
+// ## The gauge, twice
+//
+// `routeRaster` is handed a drawing's bounding box and edge count, so the
+// two things that decide its answer are how big a drawing is and how many
+// edges it carries. The gauge cells put both on the header:
+//
+//   gauge height       scales the arc, moving `area` — the left-hand side of
+//                      *both* comparisons — across the thresholds
+//   use svg for gauge  draws the identical arc as a parsed <svg> document
+//                      instead of imperative <canvas onDraw> calls
+//
+// SvgView draws through the same 2d context `onDraw` calls directly, so the
+// gate sees the same shapes either way and the switch isolates what the
+// frontend itself costs.
+//
 // Run with: npm run examples:raster-gate  (needs an X server / DISPLAY)
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 
@@ -84,35 +99,103 @@ const NTK_DEFAULT = { maxArea: 64 * 64, bytesPerEdge: 150, maxBytes: 1 << 20 };
 
 // --- the wall --------------------------------------------------------------
 
-/** A gauge: one stroked arc plus a needle. Strokes flatten into many edges
- * over a small area, which is precisely the shape `bytesPerEdge` arbitrates
- * — a rounded rectangle is 14-79 trapezoids, this is hundreds. */
-function Gauge({ value }) {
+// One stroked arc plus a needle. Strokes flatten into many edges over a
+// small area, which is precisely the shape `bytesPerEdge` arbitrates — a
+// rounded rectangle is 14-79 trapezoids, this is hundreds.
+
+const GAUGE_TRACK = '#dfe6e9';
+const GAUGE_VALUE = '#0984e3';
+const GAUGE_NEEDLE = '#2d3436';
+
+/** The gauge keeps the proportions of the 54x34 it started at, so the height
+ * slider grows the *drawing*: `r` below is bounded by half the width, so a
+ * gauge that grew in one axis only would stop getting bigger the moment
+ * height passed width and would then just slide down a taller box. */
+const GAUGE_ASPECT = 54 / 34;
+
+const gaugeWidth = (height) => Math.round(height * GAUGE_ASPECT);
+
+/** Arc centre, radius and needle angle. Shared by both frontends on purpose:
+ * the switch is a comparison of two *descriptions* only if the geometry each
+ * one describes is the same. */
+function gaugeGeometry(width, height, value) {
+  const cx = width / 2;
+  const cy = height - 4;
+  return { cx, cy, r: Math.min(cx, cy) - 3, angle: Math.PI * (1 + value) };
+}
+
+/** The gauge as imperative 2d calls: three strokes, three trips through the
+ * gate, nothing cached (`<canvas>` caching is opt-in via `cacheKey`). */
+function GaugeCanvas({ value, height }) {
   return (
     <canvas
-      style={{ width: 54, height: 34 }}
-      onDraw={(ctx, { width, height }) => {
-        const cx = width / 2;
-        const cy = height - 4;
-        const r = Math.min(cx, cy) - 3;
+      style={{ width: gaugeWidth(height), height }}
+      onDraw={(ctx, info) => {
+        const { cx, cy, r, angle } = gaugeGeometry(
+          info.width,
+          info.height,
+          value,
+        );
         ctx.lineWidth = 5;
-        ctx.strokeStyle = '#dfe6e9';
+        ctx.strokeStyle = GAUGE_TRACK;
         ctx.beginPath();
         ctx.arc(cx, cy, r, Math.PI, 2 * Math.PI);
         ctx.stroke();
-        ctx.strokeStyle = '#0984e3';
+        ctx.strokeStyle = GAUGE_VALUE;
         ctx.beginPath();
-        ctx.arc(cx, cy, r, Math.PI, Math.PI * (1 + value));
+        ctx.arc(cx, cy, r, Math.PI, angle);
         ctx.stroke();
-        const a = Math.PI * (1 + value);
-        ctx.strokeStyle = '#2d3436';
+        ctx.strokeStyle = GAUGE_NEEDLE;
         ctx.lineWidth = 2;
         ctx.beginPath();
         ctx.moveTo(cx, cy);
-        ctx.lineTo(cx + Math.cos(a) * r * 0.8, cy + Math.sin(a) * r * 0.8);
+        ctx.lineTo(
+          cx + Math.cos(angle) * r * 0.8,
+          cy + Math.sin(angle) * r * 0.8,
+        );
         ctx.stroke();
       }}
     />
+  );
+}
+
+/**
+ * The same gauge as a document. `<svg>` children are real nodes, serialized
+ * into the DOM ntk's SvgView parses; `viewBox` matching the style box makes
+ * the scale exactly 1, so this reaches the gate as the same three shapes.
+ *
+ * One thing the canvas gauge gets for free and this one has to earn: `<svg>`
+ * *is* paint-cached, keyed by the document text (`paintCachePlan` in
+ * src/richnodes.js), so a gauge whose value repeated would be composited
+ * from a pixmap with the gate never consulted — the same trap the churn
+ * switch exists to avoid. Coordinates go in at full float precision for that
+ * reason: rounding them to something a human would want to read is exactly
+ * what would let two frames share a key.
+ */
+function GaugeSvg({ value, height }) {
+  const width = gaugeWidth(height);
+  const { cx, cy, r, angle } = gaugeGeometry(width, height, value);
+  // sweep-flag 1 from the left end: in y-down space that is the upper arc
+  const arc = (to) =>
+    `M${cx - r} ${cy}A${r} ${r} 0 0 1 ${cx + Math.cos(to) * r} ${cy + Math.sin(to) * r}`;
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} style={{ width, height }}>
+      <path
+        d={arc(2 * Math.PI)}
+        fill="none"
+        stroke={GAUGE_TRACK}
+        strokeWidth={5}
+      />
+      <path d={arc(angle)} fill="none" stroke={GAUGE_VALUE} strokeWidth={5} />
+      <line
+        x1={cx}
+        y1={cy}
+        x2={cx + Math.cos(angle) * r * 0.8}
+        y2={cy + Math.sin(angle) * r * 0.8}
+        stroke={GAUGE_NEEDLE}
+        strokeWidth={2}
+      />
+    </svg>
   );
 }
 
@@ -123,8 +206,9 @@ function Gauge({ value }) {
  * caches painted content by key (src/paintcache.js), and a static wall would
  * be composites of cached pixmaps with the gate never consulted at all.
  */
-function Cell({ index, value }) {
+function Cell({ index, value, gaugeHeight, gaugeSvg }) {
   const kind = index % 4;
+  const Gauge = gaugeSvg ? GaugeSvg : GaugeCanvas;
   return (
     <box
       style={{
@@ -138,7 +222,7 @@ function Cell({ index, value }) {
       }}
     >
       <text style={{ fontSize: 11, color: '#7f8c8d' }}>{`#${index}`}</text>
-      {kind === 0 && <Gauge value={value} />}
+      {kind === 0 && <Gauge value={value} height={gaugeHeight} />}
       {kind === 1 && (
         <Slider value={Math.round(value * 100)} min={0} max={100} />
       )}
@@ -158,13 +242,19 @@ function Cell({ index, value }) {
   );
 }
 
-function Wall({ count, phase }) {
+function Wall({ count, phase, gaugeHeight, gaugeSvg }) {
   const cells = [];
   for (let i = 0; i < count; i++) {
     // A per-cell offset so the wall is never uniform: every cell is a
     // different drawing, which is also a different paint-cache key.
     cells.push(
-      <Cell key={i} index={i} value={(Math.sin(phase + i * 0.4) + 1) / 2} />,
+      <Cell
+        key={i}
+        index={i}
+        value={(Math.sin(phase + i * 0.4) + 1) / 2}
+        gaugeHeight={gaugeHeight}
+        gaugeSvg={gaugeSvg}
+      />,
     );
   }
   return (
@@ -287,6 +377,8 @@ function App() {
   const [vectorText, setVectorText] = useState(true);
   const [churn, setChurn] = useState(true);
   const [count, setCount] = useState(48);
+  const [gaugeHeight, setGaugeHeight] = useState(34); // the original 54x34
+  const [gaugeSvg, setGaugeSvg] = useState(false);
   const phase = useChurn(churn, windowRef);
   const stats = useFrameStats();
 
@@ -331,6 +423,19 @@ function App() {
       height={780}
       title="react-x11 — rasterization gate"
       style={{ backgroundColor: '#f5f6fa' }}
+      // Without this the WM's close button takes the window away and leaves
+      // the process running: `useFrameStats` holds a 250ms interval, which
+      // is enough to keep node's event loop alive on its own. Opting into
+      // WM_DELETE_WINDOW is what gives the example somewhere to exit from.
+      //
+      // It says so on the way out, because a silent exit here is
+      // indistinguishable from a crash — and under an unhelpful policy this
+      // example runs slowly enough that a window manager offering to
+      // force-quit it is a real thing that happens.
+      onCloseRequest={() => {
+        console.log('raster-gate: WM asked the window to close — exiting');
+        process.exit(0);
+      }}
     >
       <box style={{ padding: 12, gap: 10 }}>
         <text style={{ fontSize: 18, color: '#2d3436' }}>
@@ -364,6 +469,33 @@ function App() {
               style={{ width: 130 }}
             />
             <text style={{ color: '#2d3436', fontSize: 12 }}>{`${count}`}</text>
+          </Field>
+        </box>
+
+        {/* The gauge cells, which are the drawing the gate has the most to
+            say about. Height is shown as the box it produces, because that
+            product is what `routeRaster` compares against `maxArea`. */}
+        <box style={{ flexDirection: 'row', gap: 20, alignItems: 'center' }}>
+          <Field label="gauge height">
+            <Slider
+              value={gaugeHeight}
+              min={20}
+              max={80}
+              step={2}
+              onChange={(ev) => setGaugeHeight(ev.value)}
+              style={{ width: 180 }}
+            />
+            <text style={{ color: '#2d3436', fontSize: 12 }}>
+              {`${gaugeWidth(gaugeHeight)}×${gaugeHeight} = ${
+                gaugeWidth(gaugeHeight) * gaugeHeight
+              }px`}
+            </text>
+          </Field>
+          <Field label="use svg for gauge">
+            <Switch
+              checked={gaugeSvg}
+              onChange={(ev) => setGaugeSvg(ev.value)}
+            />
           </Field>
         </box>
 
@@ -404,7 +536,12 @@ function App() {
       </box>
 
       <scrollview style={{ flexGrow: 1 }}>
-        <Wall count={count} phase={phase} />
+        <Wall
+          count={count}
+          phase={phase}
+          gaugeHeight={gaugeHeight}
+          gaugeSvg={gaugeSvg}
+        />
       </scrollview>
     </window>
   );

--- a/src/richnodes.js
+++ b/src/richnodes.js
@@ -291,6 +291,11 @@ export class SvgNode extends Node {
     super('svg', props, app);
     this.view = null;
     this._stale = true;
+    /** Bumped every time the document is rebuilt, and sampled at paint time,
+     * so `paintCachePlan` can tell an animated document from a settled one.
+     * See the note there. */
+    this._docRevision = 0;
+    this._paintedRevision = -1;
     this.yoga.setMeasureFunc(
       intrinsicMeasure(() => {
         const view = this._ensureView();
@@ -312,6 +317,7 @@ export class SvgNode extends Node {
   _ensureView() {
     if (!this._stale) return this.view;
     this._stale = false;
+    this._docRevision++;
     this.view = null;
     this._docKey = null;
     try {
@@ -395,10 +401,34 @@ export class SvgNode extends Node {
    * a wall of icons is four extra requests each. The cost is that a cached
    * drawing sits on the pixel grid where a live one could straddle it, which
    * for icon-sized content is not visible.
+   *
+   * ## Animated documents opt themselves out
+   *
+   * A document that was rebuilt since this node's last paint is being
+   * animated, and caching it is a pure loss: the entry is written, composited
+   * once at most, and never matched again. The cache has a "seen twice" gate
+   * for exactly this, but content keying defeats it here — a wall of the same
+   * animated drawing at different phases produces documents that recur across
+   * *nodes* by coincidence, which is enough sightings to pass the gate and
+   * never enough to pay it back. Measured on a wall of 30 animated gauges:
+   * 450 of 1076 distinct documents recurred, 12% of lookups hit, and each
+   * miss-that-cached bought a CreatePixmap plus a second rasterization of a
+   * drawing that had already been painted live. On a server where offscreen
+   * rasterization is a software fallback that doubled the frame's fence.
+   *
+   * So the revision has to match the one this node last painted. A node that
+   * has never painted has nothing to compare and stays speculative, exactly
+   * as before — the "seen twice" gate is still the thing deciding, so a wall
+   * of identical icons fills on its first frame from its own sibling cells.
+   * Only a document that then *changes* opts out, which is the signal that it
+   * was never going to be matched again.
    */
   paintCachePlan() {
     const view = this._ensureView();
     if (!view || !this._docKey) return null;
+    const painted = this._paintedRevision;
+    this._paintedRevision = this._docRevision;
+    if (painted >= 0 && painted !== this._docRevision) return null;
     const content = this.contentBox();
     const width = Math.round(content.width);
     const height = Math.round(content.height);

--- a/test/paint-cache.test.js
+++ b/test/paint-cache.test.js
@@ -161,6 +161,64 @@ test('a drawing painted once is never cached', async () => {
   await app.close();
 });
 
+// Cell `i` at frame `f` draws tone `(f + i) % 5`, so every drawing recurs on
+// the next frame one cell to the left. That cross-node recurrence is what an
+// animated wall produces, and it is enough sightings to satisfy the "seen
+// twice" gate — which is why the gate alone does not keep animation out.
+const TONES = ['#00aa00', '#0000ff', '#ff0000', '#aa00aa', '#00aaaa'];
+const wave = (frame, count) =>
+  React.createElement(
+    'window',
+    { width: W, height: H, style: { backgroundColor: '#ffffff' } },
+    ...Array.from({ length: count }, (_, i) =>
+      React.createElement('svg', {
+        key: i,
+        source: SQUARE(TONES[(frame + i) % TONES.length]),
+        style: {
+          position: 'absolute',
+          left: i * 20,
+          top: 0,
+          width: 16,
+          height: 16,
+        },
+      }),
+    ),
+  );
+
+test('an animated document is never cached, however often it recurs', async () => {
+  const app = await headlessApp();
+  const ctl = await mount(app, wave(0, 4));
+  const cache = ctl.root._paintCache;
+
+  const FRAMES = 8;
+  for (let f = 1; f <= FRAMES; f++) {
+    await new Promise((resolve) =>
+      ctl.root._x11Root.render(wave(f, 4), resolve),
+    );
+    ctl.frame();
+    await settle(app);
+  }
+
+  assert.equal(
+    cache.stats.renders,
+    0,
+    'a document that changed since its own last paint is not worth a surface',
+  );
+  assert.equal(cache.entries.size, 0, 'so nothing accumulates');
+
+  // and every cell still shows the frame it was last rendered with
+  const px = await pixels(app, ctl.root);
+  for (let i = 0; i < 4; i++) {
+    const want = TONES[(FRAMES + i) % TONES.length];
+    const rgb = [1, 3, 5].map((o) => parseInt(want.slice(o, o + 2), 16));
+    assert.ok(
+      near(px(i * 20 + 8, 8), rgb),
+      `cell ${i}: got ${px(i * 20 + 8, 8)}`,
+    );
+  }
+  await app.close();
+});
+
 test('a different document is a different entry, not a stale one', async () => {
   const app = await headlessApp();
   const ctl = await mount(app, wall(SQUARE('#00aa00'), 4));
@@ -173,9 +231,15 @@ test('a different document is a different entry, not a stale one', async () => {
   ctl.frame();
   await settle(app);
 
-  assert.equal(cache.entries.size, 2, 'the old entry is not reused');
+  // A document that just changed paints live for one frame — see the
+  // animation note in paintCachePlan — so what matters on this frame is the
+  // pixels: blue, not the green entry reused.
   const px = await pixels(app, ctl.root);
   assert.ok(near(px(8, 8), [0, 0, 255]), `repainted blue: got ${px(8, 8)}`);
+
+  // and once it has settled it earns an entry of its own, beside the green
+  await repaint(app, ctl);
+  assert.equal(cache.entries.size, 2, 'the old entry is not reused');
   await app.close();
 });
 


### PR DESCRIPTION
Two new knobs on the rasterization-gate example, and the renderer fix the second one turned up.

The example changes came first; the cache rule is here because the svg gauge was unusably slow without it and the cause was not in the example. They are separate commits, and the fix stands on its own.

## The example

**Gauge height slider** (20–80px). `routeRaster` is handed a drawing's bounding box and edge count, so the slider moves `area` — the left-hand side of *both* threshold comparisons — across the thresholds. Width follows height at the gauge's original 54:34 proportions: `r` is bounded by half the width, so a gauge growing in one axis only would stop getting bigger the moment height passed width and would then just slide down a taller box. The readout shows the box the slider produces, because that product is what `maxArea` sees.

**"use svg for gauge" switch.** The same arc and needle as a parsed `<svg>` document instead of imperative `<canvas onDraw>` calls. Both frontends share one `gaugeGeometry()` helper and the `viewBox` matches the style box, so the scale is exactly 1 and the gate sees the same three shapes either way — the switch isolates what the frontend costs rather than comparing two different drawings.

**`onCloseRequest`.** The window had none, so the WM's close button took the window away and left the process running — the stats sampler's 250ms interval keeps node's event loop alive by itself. Verified by sending a real `WM_DELETE_WINDOW` under Xvfb: before, the window did not even advertise the protocol and the process was still alive 15s later; after, it exits. It logs on the way out, because a silent exit is indistinguishable from a crash.

## The cache rule

Turning the svg switch on made the wall much slower, and the cause was the paint cache rather than anything about SVG rasterization.

`<svg>` is cached automatically, keyed by the serialized document (`<canvas>` is opt-in via `cacheKey`, which the gauge does not set). The "seen twice" gate is meant to keep one-shot drawings out — but a wall of the *same* animated drawing at different phases defeats it, because the documents recur across *nodes* by coincidence. That is enough sightings to pass the gate and never enough to pay it back.

Measured on 30 animated gauges: **450 of 1076 distinct documents recurred, 12% of lookups hit**, and every miss-that-cached bought a `CreatePixmap` plus a second rasterization of a drawing already painted live.

On a glamor-class server — where offscreen rasterization is the software fallback this whole example exists to measure — that showed up as:

| gauge | fps | server fence | surfaces |
|---|---|---|---|
| canvas | 2–3 | 310–505ms, flat | 0 |
| svg, before | 1–2 | 500 → **890ms**, climbing | 450 |
| svg, after | 2–3 | 262–428ms, flat | **0** |

The degradation tracked the entry count exactly, and disabling the cache for `<svg>` reproduced the "after" column before any fix existed.

`paintCachePlan` now returns null when the document was rebuilt since that node's own last paint. A node that has never painted has nothing to compare and stays speculative, exactly as before, so the gate is still what decides for static content and a wall of identical icons still fills on its first frame from its sibling cells. Only a document that then *changes* opts out.

Worth noting this is invisible on a software X server: on Xvfb the two gauges were identical — 40fps both, same request counts. The cost only appears where offscreen rasterization is expensive.

## Tests

New: `an animated document is never cached, however often it recurs` — reproduces the cross-node recurrence deterministically (cell *i* at frame *f* draws what cell *i−1* drew at *f+1*) and fails without the fix.

Moved rather than broken: `a different document is a different entry` asserted the new entry appeared on the same frame as the change. It now appears one frame later, since that first changed frame paints live. Its real guarantee — blue pixels, not the green entry reused — still holds and is asserted first.

486 tests pass; lint, format and typecheck clean.

## Not covered here

The example was also reported to die after a few seconds with svg on. I could not reproduce it across five runs on a real glamor display (120s with svg on from startup, 90s instrumented, 60s sweeping the height slider, 90s with cells maxed, 30s verifying the fix). No OOM in `dmesg`/`journalctl`, node RSS flat. The `onCloseRequest` logging above is partly there to rule out the one path that could have ended the process without printing anything.