### PR TITLE
feat(dbus): lazy, shared, never-throwing `useSessionBus()` / `useSystemBus()`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,11 @@
   beyond drawing. Startup notification: why the launcher's busy cursor spins
   for 15 seconds without it, when an app counts as "started", and the seams
   for saying otherwise.
+- [dbus.md](dbus.md) — the bus every desktop-integration feature sits on:
+  `useSessionBus()` / `useSystemBus()` with nothing to wrap, the imperative
+  `sessionBus()` pair underneath, why one process is one connection and one
+  identity, and why "there is no bus" is a first-class configuration rather
+  than an error.
 - [remote.md](remote.md) — the flagship case: running the app on one
   machine and drawing to a display on another. `ssh -X` vs `-Y`, what the
   protocol costs on a link, the other X servers, and why Xwayland works

--- a/docs/dbus.md
+++ b/docs/dbus.md
@@ -1,0 +1,252 @@
+# D-Bus
+
+Everything the desktop wants from an app beyond drawing — a native file
+dialog, the light/dark preference, notifications, a global menu, a tray icon
+— is a D-Bus call. This page is the connection those features sit on, and
+nothing else: no service is spoken to here, and the only traffic this layer
+generates is its own handshake.
+
+```jsx
+import { useSessionBus } from 'react-x11';
+
+function ColourScheme() {
+  const { bus } = useSessionBus();
+  if (!bus) return null; // no bus here — nothing to read a preference from
+  // ...call org.freedesktop.portal.Settings through `bus`
+}
+```
+
+There is **nothing to wrap**. No provider, no prop drilling, no setup step
+for the app author — a component library can call this, which is the whole
+reason it is shaped this way.
+
+## The rule everything else is subordinate to
+
+**Nothing throws at import time, and nothing crashes an app running where
+there is no session bus.**
+
+Concretely, that has to hold on XQuartz, under a bare `startx`, in CI, in an
+ssh session on a headless server, in a container, and on Node 20 where the
+transport is not installed at all. The ssh case is not an edge case — it is
+react-x11's flagship persona. **"No bus" is a first-class configuration, not
+a degraded one.**
+
+So `sessionBus()` answers `null` rather than rejecting, and `useSessionBus()`
+reports `'unavailable'` rather than throwing, when:
+
+- `dbus-native` is not installed,
+- `$DBUS_SESSION_BUS_ADDRESS` is unset and there is no `$XDG_RUNTIME_DIR/bus`,
+- the connect fails, authentication fails, or the platform has no bus at all.
+
+## The hooks
+
+```ts
+function useSessionBus(): BusHandle;
+function useSystemBus(): BusHandle;
+
+interface BusHandle {
+  readonly bus: MessageBus | null; // null unless status === 'ready'
+  readonly uniqueName: string | null;
+  readonly status: 'connecting' | 'ready' | 'unavailable' | 'closed';
+  readonly cause?: BusUnavailableError; // set when status === 'unavailable'
+  retry(): void;
+}
+```
+
+| `status`        |                                                          |
+| --------------- | -------------------------------------------------------- |
+| `'connecting'`  | the handshake is in flight — and also the first render   |
+| `'ready'`       | `bus` and `uniqueName` are set                           |
+| `'unavailable'` | no daemon, socket or permission here; `cause` says which |
+| `'closed'`      | the connection died under you; `retry()` dials a new one |
+
+**The terse path is correct on its own.** `const { bus } = useSessionBus()`
+followed by `if (!bus) return fallback` is right, with no reference to
+`status`; if reading `status` were _required_ to avoid a bug the shape would
+be wrong. For a colour-scheme subscriber, `'connecting'` and `'unavailable'`
+render identically anyway. The states earn their keep in diagnostics ("why is
+my tray icon missing") and for an app that is itself a service.
+
+**"Idle" is not a fourth state.** The first render happens before the effect
+runs, so nothing has been attempted yet — calling that `'connecting'` is a
+small inaccuracy that becomes true within a tick, and an honest fourth state
+would give every consumer a branch that never needs different handling.
+
+**`'unavailable'` is a snapshot, not a verdict.** Failure is not cached: a
+session bus can appear later — `$XDG_RUNTIME_DIR/bus` exists the moment
+something starts one — and the next acquisition retries. Do not permanently
+disable a feature on seeing it. The name invites the opposite reading, which
+is why this paragraph exists.
+
+**`'closed'` does not auto-retry, deliberately.** Silently re-acquiring would
+hand you a fresh `bus` under the same variable and hide the unique-name change
+(see [the sharing contract](#the-sharing-contract)). A feature-level hook that
+knows how to rebuild its bus-side state can call `retry()`; a generic one
+cannot, so the decision is yours.
+
+## The imperative pair
+
+```ts
+function sessionBus(opts?: { required?: boolean }): Promise<BusRef | null>;
+function systemBus(opts?: { required?: boolean }): Promise<BusRef | null>;
+function closeBus(kind: 'session' | 'system'): Promise<void>;
+
+interface BusRef {
+  readonly bus: MessageBus; // the full dbus-native surface, shared
+  readonly uniqueName: string; // this connection's unique name, e.g. ':1.42'
+  release(): Promise<void>; // drop this consumer's reference; idempotent
+  [Symbol.asyncDispose](): Promise<void>;
+}
+```
+
+This is what the hooks are built on, and it is public for two reasons that are
+not "completeness":
+
+- **Host-side code has no component to hang off.** The plumbing that later
+  features add — a settings subscriber, a notification sender — is module code
+  and event-loop glue, some of which must run with no root mounted at all.
+- **A click handler wants to resolve at click time**, not at render time:
+
+  ```jsx
+  <Button
+    onClick={async () => {
+      await using ref = await sessionBus({ required: true });
+      await ref.bus.proxy(/* … */);
+    }}
+  />
+  ```
+
+`required: true` is the service-author escape hatch. `null` is right for
+feature-probing plumbing and hides _why_ from an app whose purpose is the bus,
+so `required` converts unavailability into a rejection carrying the cause. The
+default stays never-rejecting; the hooks use `required` internally purely to
+obtain the reason for `cause`.
+
+There is **no `busAddress` parameter**, deliberately: a per-call address is
+incoherent under sharing — two callers, two addresses, one socket, which
+would win? The address seam is D-Bus's own, `$DBUS_SESSION_BUS_ADDRESS`, plus
+an `$XDG_RUNTIME_DIR/bus` fallback until
+[dbus-native#389](https://github.com/sidorares/dbus-native/pull/389) lands.
+
+## One connection, on purpose
+
+`dbus-native`'s own `sessionBus()` is a constructor in disguise: every call
+opens a new socket with its own unique name. A menu, a tray and an app's own
+exported service would be three connections and three identities, and the
+desktop would see three half-applications.
+
+A D-Bus connection is **process** identity, so every consumer in the process
+shares one socket and one unique name. That is also why these hooks need no
+provider, where `useApp()` does: the X connection really is per-tree —
+`createRoot()` opens one per root and a process can drive several — but two
+roots on two X displays still share one session bus. Putting a process-global
+on a tree-scoped context would assert a relationship that does not exist.
+
+## Lifecycle: connect on first use, stay connected
+
+The ref count drives the socket's **event-loop hold**, not its existence:
+
+| refs | socket                | process exit                                              |
+| ---- | --------------------- | --------------------------------------------------------- |
+| `>0` | connected, `ref()`d   | held open — someone is using the bus                      |
+| `0`  | connected, `unref()`d | not held; the connection stays warm and costs one idle FD |
+
+Releasing the last ref does **not** close the connection. A file dialog that
+mounts on click and unmounts on dismiss would otherwise tear the connection
+down and rebuild it every time — and the real cost is not the handshake, it is
+that **every reconnect is a new unique name**, with the daemon forgetting
+match rules and well-known names along with the old connection. StrictMode's
+double-mount becomes two counter flips rather than a full connect/disconnect
+cycle.
+
+`closeBus(kind)` is the way out for an app that genuinely wants the connection
+gone. Rare, explicit, and never the automatic consequence of an unmount.
+
+## The sharing contract
+
+One connection with many consumers only works if the things one consumer can
+break for another are named:
+
+- **Never close a shared bus.** `release()` is the only lifecycle verb a ref
+  holder has. `ref.bus.close()` or `bus.connection.end()` tears the connection
+  out from under every other holder — libdbus makes closing a shared
+  connection a hard application error, and here it is a rule.
+- **react-x11 owns the connection's one `'error'` listener.** `dbus-native`
+  deliberately attaches none, because an unlistened `'error'` crashing the
+  process is the right contract for a caller-owned connection and the wrong
+  one for a shared one. Do not attach your own.
+- **A dead connection is not resurrected.** `dbus-native`'s reconnect stays
+  off: a new socket is a new unique name, and the daemon forgets names and
+  match rules with the old one. Refs on the dead connection fail their calls
+  with `ConnectionClosedError` and `release()` harmlessly; the next
+  `sessionBus()` dials fresh, and mounted hooks move to `'closed'`.
+- **App-global stays app-global.** Well-known names (`RequestName` has no
+  per-consumer refcount), exported object paths (re-exporting the same path
+  and interface replaces silently) and `setValueShapes()` (which flips reply
+  shapes for _every_ holder) are process-level resources. Owning them is app
+  policy; a `BusRef` does not scope them, and react-x11 will never call
+  `setValueShapes()` on the shared bus.
+
+## Being a service, not just a client
+
+An app that wants to _be_ on the bus gets the full `dbus-native` surface
+through `ref.bus`, on the **same connection and unique name** as react-x11's
+own plumbing — one socket, one identity on the desktop:
+
+```js
+const ref = await sessionBus({ required: true });
+await ref.bus.requestName('org.example.MyApp', 0);
+ref.bus.exportInterface(impl, '/org/example/MyApp', description);
+// hold the ref for as long as you serve: it is what keeps the process alive
+```
+
+Holding the ref is not bookkeeping — it is the event-loop hold above. Release
+it and nothing keeps the process running.
+
+## Installing, and Node 20
+
+```json
+"optionalDependencies": { "dbus-native": "^0.15.1" }
+```
+
+`dbus-native` declares `engines: ">=22.12.0"` where react-x11 declares
+`">=20.19"`, so **npm skips it on Node 20** and the install succeeds exactly
+as before. There is no compiler and no install script either way — `npm i
+react-x11` still needs no toolchain.
+
+On Node 20, `useSessionBus()` reports `'unavailable'` with a `cause` that says
+the transport is missing. That is the same code path an ssh session or a Mac
+without a bus already takes: **"no transport installed" collapses into "no bus
+here" rather than adding a mode.** To have it on Node 20 anyway, install it
+explicitly:
+
+```bash
+npm i dbus-native
+```
+
+The declarations never name `dbus-native`, so they type-check on an install
+where it is absent. `MessageBus` is a structural type covering the members
+documented here, with an index signature over the rest of the package's
+surface — code that wants `dbus-native`'s own checked types can import them
+directly and cast; it is the same object.
+
+## Known sharp edges
+
+- **The `Hello` window is the one crash this layer cannot absorb.** A daemon
+  that authenticates and then never answers `Hello` throws from inside
+  `dbus-native` where nothing can catch it, 25 s in, from a timer tick —
+  [dbus-native#393](https://github.com/sidorares/dbus-native/issues/393). Small
+  window, real bug, tracked upstream.
+- **Identical match rules are refcounted by the daemon, not by the client** —
+  [dbus-native#394](https://github.com/sidorares/dbus-native/issues/394).
+  Dormant here, since reconnect is off; recorded so that nobody enables
+  reconnect without reading it.
+
+## Seeing it
+
+`npm run examples:dbus` is a bus explorer: session and system side by side, a
+tree of names → object paths → interfaces built from live introspection, and a
+right-hand pane showing an object's methods, signals and property values. It
+is also the worked example of the degradation rule — run it with
+`DBUS_SESSION_BUS_ADDRESS` pointed at nothing and it renders the
+`'unavailable'` state rather than failing to start.

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,6 +37,7 @@ Roughly in the order worth reading them:
 | [`dnd-source.jsx`](dnd-source.jsx)   | **drag out of the app** (XDND) + in-app drags with live payloads, a `<popup>` drag preview           |
 | [`dnd-target.jsx`](dnd-target.jsx)   | drop zones: `dropAccept` groups, parsed `e.files`, custom MIME types, `useDropTarget` state          |
 | [`raster-gate.jsx`](raster-gate.jsx) | a wall of live controls with ntk's local/server rasterization routing on a switch (ntk#177)          |
+| [`dbus.jsx`](dbus.jsx)               | a D-Bus explorer: `useSessionBus()`/`useSystemBus()`, a `Tree` of live introspection, a detail pane  |
 | [`stress/`](stress/index.jsx)        | **the big one**: six panels to poke at by hand, with a frame log — see below                         |
 | [`wm.jsx`](wm.jsx)                   | **a reparenting window manager** — see below                                                         |
 

--- a/examples/dbus.jsx
+++ b/examples/dbus.jsx
@@ -1,0 +1,931 @@
+// A D-Bus explorer: both buses, a tree to walk them, and a pane of detail.
+//
+// This is the worked example for docs/dbus.md — the connection layer #163
+// added — and it is deliberately built the way a real desktop-integration
+// feature would be:
+//
+//   const { bus, status, cause, retry } = useSessionBus();
+//
+// No provider, nothing to wrap, and **no reason for this window to fail to
+// open when there is no bus**. Run it over ssh, in a container, under a bare
+// startx, or on Node 20 where npm skipped the optional `dbus-native`
+// dependency entirely, and the header renders the reason instead of the
+// process dying. That is the whole point of the layer: "there is no bus" is a
+// configuration, not an error.
+//
+//   DBUS_SESSION_BUS_ADDRESS=unix:path=/nope npm run examples:dbus
+//
+// ## What it shows
+//
+//   Session bus — :1.148           <- one connection, one identity, shared by
+//   System bus — :1.159               every consumer in this process
+//     org.a11y.Bus                 <- names, from ListNames
+//       /org/a11y/bus              <- objects, from Introspect, lazily
+//         org.a11y.Status          <- the interfaces on that object
+//
+// Selecting a row fills the right pane: a bus's address and status, a name's
+// owner and pid, an object's interfaces, an interface's methods, signals and
+// **live property values** (one GetAll, on demand).
+//
+// ## Four things that shaped the code
+//
+// **Introspection is a round trip per node**, so the tree loads lazily —
+// `children: []` is what makes an unexplored branch show a twisty before its
+// contents are known, and `onExpandedChange` is where the call goes. Every
+// expansion shows `loading…` on the frame the click landed on rather than
+// after the reply: answer the input, not the outcome.
+//
+// **Object paths are a namespace, not a hierarchy anyone arranged.** Reaching
+// `org.a11y.Bus`'s only object by hand means `/` → `/org` → `/org/a11y` →
+// `/org/a11y/bus`: three rows that say nothing. `compressPath` skips them.
+//
+// **A service can simply not answer.** `Introspect` on a name whose owner is
+// busy, or wedged, or does not implement Introspectable, hangs — so every call
+// here is raced against a deadline and a failure becomes a row you can read,
+// not a spinner forever.
+//
+// **Nothing here imports `dbus-native`.** Not the value formatter, not the
+// signature reader. An example that did would crash on exactly the install
+// this example exists to demonstrate.
+//
+// Run with: npm run examples:dbus  (needs an X server / DISPLAY)
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Button,
+  createRoot,
+  createStyles,
+  SplitPane,
+  ThemeProvider,
+  Tree,
+  useSessionBus,
+  useSystemBus,
+} from '../src/index.js';
+
+// --- palette ---------------------------------------------------------------
+
+const C = {
+  page: '#ffffff',
+  chrome: '#f7f7f8',
+  edge: '#e4e4e7',
+  text: '#18181b',
+  dim: '#71717a',
+  faint: '#a1a1aa',
+  accent: '#2563eb',
+  good: '#16a34a',
+  warn: '#b45309',
+  bad: '#dc2626',
+  mono: '#f4f4f5',
+};
+
+const THEME = {
+  background: C.page,
+  foreground: C.text,
+  border: C.edge,
+  dim: C.dim,
+  accent: C.accent,
+  accentText: '#ffffff',
+  surfaceHover: '#f1f5f9',
+  radius: 5,
+};
+
+const MONO = 'monospace';
+
+// react-x11 has `borderWidth` for the whole box and no per-edge borders, so a
+// rule is a one-pixel box rather than a border — which is also cheaper: a
+// border makes the box a bordered drawing, where this is one filled rect.
+const s = createStyles({
+  window: { flexDirection: 'column', backgroundColor: C.page },
+  rule: { height: 1, flexShrink: 0, backgroundColor: C.edge },
+  header: {
+    flexDirection: 'row',
+    gap: 10,
+    padding: 10,
+    backgroundColor: C.chrome,
+    flexWrap: 'wrap',
+    flexShrink: 0,
+  },
+  chip: {
+    flexDirection: 'column',
+    gap: 2,
+    paddingTop: 6,
+    paddingBottom: 6,
+    paddingLeft: 10,
+    paddingRight: 10,
+    borderWidth: 1,
+    borderColor: C.edge,
+    borderRadius: 6,
+    backgroundColor: C.page,
+    minWidth: 260,
+  },
+  chipTop: { flexDirection: 'row', alignItems: 'center', gap: 6 },
+  dot: { width: 8, height: 8, borderRadius: 4 },
+  chipName: { fontSize: 12, fontWeight: 'bold', color: C.text },
+  chipLine: { fontSize: 11, color: C.dim, fontFamily: MONO },
+  chipWhy: { fontSize: 11, color: C.warn },
+
+  sidebar: {
+    // `flexGrow: 1` is what gives the tree a height to fill. SplitPane wraps
+    // each child in a pane box that is sized on the main axis and stacks its
+    // own children in a column — so an auto-height sidebar leaves the tree,
+    // which only asks to grow, with nothing to grow into.
+    flexGrow: 1,
+    flexDirection: 'column',
+    backgroundColor: C.page,
+    minHeight: 0,
+  },
+  sidebarHead: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingLeft: 10,
+    paddingRight: 10,
+    paddingTop: 6,
+    paddingBottom: 6,
+    flexShrink: 0,
+  },
+  sidebarTitle: { fontSize: 11, color: C.dim, flexGrow: 1, flexBasis: 0 },
+
+  pane: { flexGrow: 1, padding: 14, flexDirection: 'column', gap: 12 },
+  paneKind: { fontSize: 10, color: C.faint },
+  paneTitle: { fontSize: 15, color: C.text, fontFamily: MONO },
+  section: { flexDirection: 'column', gap: 4 },
+  sectionTitle: { fontSize: 11, color: C.dim, fontWeight: 'bold' },
+  field: { flexDirection: 'row', gap: 8, alignItems: 'flex-start' },
+  fieldName: { width: 110, fontSize: 12, color: C.dim, flexShrink: 0 },
+  fieldValue: { fontSize: 12, color: C.text, flexGrow: 1, flexBasis: 0 },
+  member: {
+    flexDirection: 'row',
+    gap: 8,
+    alignItems: 'flex-start',
+    paddingTop: 2,
+    paddingBottom: 2,
+  },
+  memberName: {
+    fontSize: 12,
+    color: C.text,
+    fontFamily: MONO,
+    width: 200,
+    flexShrink: 0,
+  },
+  memberType: {
+    fontSize: 11,
+    color: C.dim,
+    fontFamily: MONO,
+    flexGrow: 1,
+    flexBasis: 0,
+  },
+  empty: { fontSize: 12, color: C.faint },
+  error: { fontSize: 12, color: C.bad },
+  hint: { fontSize: 11, color: C.faint },
+});
+
+// --- the node ids -----------------------------------------------------------
+//
+// The tree is keyed by strings so that expansion survives a reload of any
+// branch. `|` is the separator because D-Bus permits it nowhere: bus names are
+// `[A-Za-z0-9_.-]`, object paths `[A-Za-z0-9_/]`, interface names
+// `[A-Za-z0-9_.]`. Nothing has to be escaped, and nothing can collide.
+
+const idOf = (...parts) => parts.join('|');
+const partsOf = (id) => id.split('|');
+const kindOf = (id) => partsOf(id)[0];
+
+// --- talking to the bus -----------------------------------------------------
+
+/**
+ * Every call is raced against a deadline.
+ *
+ * A name whose owner is wedged, or which does not implement Introspectable at
+ * all, never answers — and a tree node that says `loading…` forever is worse
+ * than one that says what went wrong, because there is nothing to do about it
+ * and nothing to read.
+ */
+function withDeadline(promise, ms, what) {
+  let timer;
+  return Promise.race([
+    Promise.resolve(promise).finally(() => clearTimeout(timer)),
+    new Promise((_, reject) => {
+      timer = setTimeout(
+        () => reject(new Error(`${what} did not answer within ${ms}ms`)),
+        ms,
+      );
+    }),
+  ]);
+}
+
+/**
+ * Interfaces every object has. An object that declares only these is not an
+ * object anyone came to look at — it is a directory node that D-Bus happens
+ * to express as an object path.
+ */
+const SCAFFOLDING = new Set([
+  'org.freedesktop.DBus.Peer',
+  'org.freedesktop.DBus.Introspectable',
+  'org.freedesktop.DBus.Properties',
+  'org.freedesktop.DBus.ObjectManager',
+]);
+
+const joinPath = (base, node) => `${base === '/' ? '' : base}/${node}`;
+
+/** Child object paths of `path`, from one Introspect. */
+async function childPaths(bus, service, path) {
+  const obj = await withDeadline(
+    bus.getObject(service, path),
+    4000,
+    `Introspect ${service} ${path}`,
+  );
+  return (obj.nodes ?? []).map((node) => joinPath(path, node));
+}
+
+/**
+ * Skip the scaffolding.
+ *
+ * `org.freedesktop.Notifications` publishes one object, and reaching it means
+ * walking `/` → `/org` → `/org/freedesktop` → `/org/freedesktop/Notifications`
+ * — three rows that say nothing and three clicks that teach nothing. So the
+ * walk keeps descending while a node declares no interfaces of its own and
+ * has exactly one child, and the row shows where it landed. Every D-Bus
+ * browser does this; the paths are a namespace, not a hierarchy anybody
+ * arranged.
+ *
+ * Bounded, because the cost is one Introspect per level and a service is free
+ * to publish a very deep tree.
+ */
+async function compressPath(bus, service, path, budget = 8) {
+  let current = path;
+  for (let depth = 0; depth < budget; depth++) {
+    const obj = await withDeadline(
+      bus.getObject(service, current),
+      4000,
+      `Introspect ${service} ${current}`,
+    );
+    const own = Object.keys(obj.proxy ?? {}).filter((n) => !SCAFFOLDING.has(n));
+    const nodes = obj.nodes ?? [];
+    if (own.length || nodes.length !== 1) return current;
+    current = joinPath(current, nodes[0]);
+  }
+  return current;
+}
+
+/** The interfaces an object declares, with their members. */
+async function interfacesOf(bus, service, path) {
+  const obj = await withDeadline(
+    bus.getObject(service, path),
+    4000,
+    `Introspect ${service} ${path}`,
+  );
+  return Object.entries(obj.proxy ?? {}).map(([name, iface]) => ({
+    name,
+    methods: Object.entries(iface.$methods ?? {}).map(([m, signature]) => ({
+      name: m,
+      signature,
+    })),
+    // A signal is `[signature, ...argument names]`, so the head is the type
+    // and the tail is what the arguments are called.
+    signals: Object.entries(iface.$signals ?? {}).map(([m, decl]) => ({
+      name: m,
+      signature: Array.isArray(decl) ? decl[0] : '',
+      args: Array.isArray(decl) ? decl.slice(1) : [],
+    })),
+    properties: Object.entries(iface.$properties ?? {}).map(([p, decl]) => ({
+      name: p,
+      type: decl?.type ?? '?',
+      access: decl?.access ?? 'read',
+    })),
+  }));
+}
+
+/** Every readable property on one interface, in a single GetAll. */
+async function readProperties(bus, service, path, interfaceName) {
+  const obj = await withDeadline(
+    bus.getObject(service, path),
+    4000,
+    `Introspect ${service} ${path}`,
+  );
+  const iface = obj.proxy?.[interfaceName];
+  if (!iface?.$readAllProps) return {};
+  return withDeadline(
+    iface.$readAllProps(),
+    4000,
+    `GetAll on ${interfaceName}`,
+  );
+}
+
+/**
+ * A D-Bus value as one line of text.
+ *
+ * Written out rather than reached for from `dbus-native`'s `toPlain`, because
+ * this file must not import the transport — see the header. It covers what
+ * actually comes back: primitives, byte arrays, arrays, dict entries as
+ * `[key, value]` pairs, and both variant shapes (the classic
+ * `[signature, [value]]` pair and the `Variant` class).
+ */
+function formatValue(value, depth = 0) {
+  if (value === null || value === undefined) return '—';
+  if (depth > 4) return '…';
+  if (typeof value === 'string') return JSON.stringify(value);
+  if (typeof value === 'bigint') return `${value}n`;
+  if (typeof value !== 'object') return String(value);
+
+  if (value instanceof Uint8Array || Buffer.isBuffer?.(value)) {
+    const head = [...value.slice(0, 12)]
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join(' ');
+    return `<${value.length} bytes${value.length ? ` ${head}` : ''}${
+      value.length > 12 ? ' …' : ''
+    }>`;
+  }
+  // The forward-compatible variant: { signature, value }.
+  if (typeof value.signature === 'string' && 'value' in value) {
+    return formatValue(value.value, depth + 1);
+  }
+  if (Array.isArray(value)) {
+    // The classic variant, [[{type,child}…], [value]] — unwrap to the value.
+    if (
+      value.length === 2 &&
+      Array.isArray(value[0]) &&
+      Array.isArray(value[1]) &&
+      value[1].length === 1 &&
+      value[0][0] &&
+      typeof value[0][0] === 'object' &&
+      'type' in value[0][0]
+    ) {
+      return formatValue(value[1][0], depth + 1);
+    }
+    if (value.length === 0) return '[]';
+    const items = value
+      .slice(0, 8)
+      .map((v) => formatValue(v, depth + 1))
+      .join(', ');
+    return `[${items}${value.length > 8 ? `, … ${value.length} total` : ''}]`;
+  }
+  const entries = Object.entries(value).slice(0, 8);
+  if (!entries.length) return '{}';
+  return `{ ${entries
+    .map(([k, v]) => `${k}: ${formatValue(v, depth + 1)}`)
+    .join(', ')} }`;
+}
+
+// --- the tree ---------------------------------------------------------------
+
+const LOADING = (parent) => [
+  { id: idOf('loading', parent), label: 'loading…', disabled: true },
+];
+
+const failure = (parent, message) => [
+  { id: idOf('failed', parent), label: `⚠ ${message}`, disabled: true },
+];
+
+/**
+ * Children per node id, plus what is still in flight.
+ *
+ * Kept in one map rather than in the tree items themselves, so that a reload
+ * of one branch never rebuilds the array identity of its siblings — and so a
+ * failure can sit in the tree as a readable row.
+ */
+function useLoader(buses) {
+  const [loaded, setLoaded] = useState({});
+  const [pending, setPending] = useState({});
+
+  // A bus that goes away invalidates everything read over it. The alternative
+  // is a tree of paths that no longer resolve, which looks like data.
+  const generations = buses.map((b) => b.handle.uniqueName).join(',');
+  useEffect(() => {
+    setLoaded({});
+    setPending({});
+  }, [generations]);
+
+  const load = useCallback(
+    async (id, fetcher) => {
+      setPending((prev) => ({ ...prev, [id]: true }));
+      try {
+        const children = await fetcher();
+        setLoaded((prev) => ({ ...prev, [id]: children }));
+      } catch (err) {
+        setLoaded((prev) => ({ ...prev, [id]: { error: err.message } }));
+      } finally {
+        setPending((prev) => {
+          const next = { ...prev };
+          delete next[id];
+          return next;
+        });
+      }
+    },
+    [setLoaded, setPending],
+  );
+
+  return { loaded, pending, load, reset: () => setLoaded({}) };
+}
+
+/** The rows under a node, given what has been loaded for it. */
+function childrenFor(id, loaded, pending) {
+  if (pending[id]) return LOADING(id);
+  const entry = loaded[id];
+  if (!entry) return [];
+  if (entry.error) return failure(id, entry.error);
+  return entry;
+}
+
+// --- panes ------------------------------------------------------------------
+
+function Field({ name, children }) {
+  return (
+    <box style={s.field}>
+      <text style={s.fieldName}>{name}</text>
+      <text style={s.fieldValue}>{children}</text>
+    </box>
+  );
+}
+
+function Section({ title, empty, children, count }) {
+  return (
+    <box style={s.section}>
+      <text style={s.sectionTitle}>
+        {title}
+        {count === undefined ? '' : ` (${count})`}
+      </text>
+      {count === 0 ? <text style={s.empty}>{empty}</text> : children}
+    </box>
+  );
+}
+
+function BusPane({ bus }) {
+  const { handle, label, address } = bus;
+  return (
+    <box style={s.pane}>
+      <text style={s.paneKind}>CONNECTION</text>
+      <text style={s.paneTitle}>{label}</text>
+      <Field name="status">{handle.status}</Field>
+      <Field name="unique name">{handle.uniqueName ?? '—'}</Field>
+      <Field name="address">{address}</Field>
+      {handle.cause ? (
+        <Field name="why">{String(handle.cause.cause?.message ?? '')}</Field>
+      ) : null}
+      <text style={s.hint}>
+        {handle.status === 'ready'
+          ? 'One connection, shared by everything in this process — the tray, ' +
+            'the menu and an exported service would all be on this same ' +
+            'socket and this same unique name.'
+          : "'unavailable' is a snapshot, not a verdict: failure is not " +
+            'cached, so a bus that appears later is found on the next ' +
+            'acquisition.'}
+      </text>
+    </box>
+  );
+}
+
+function NamePane({ bus, service }) {
+  const [info, setInfo] = useState(null);
+  useEffect(() => {
+    let live = true;
+    setInfo(null);
+    const read = async () => {
+      const b = bus.handle.bus;
+      if (!b) return;
+      const get = async (fn) => {
+        try {
+          return await withDeadline(fn(), 3000, 'the bus');
+        } catch (err) {
+          return `⚠ ${err.message}`;
+        }
+      };
+      const owner = await get(() => b.getNameOwner(service));
+      const pid = await get(() => b.getConnectionUnixProcessId(service));
+      const uid = await get(() => b.getConnectionUnixUser(service));
+      if (live) setInfo({ owner, pid, uid });
+    };
+    read();
+    return () => {
+      live = false;
+    };
+  }, [bus.handle.bus, service]);
+
+  return (
+    <box style={s.pane}>
+      <text style={s.paneKind}>BUS NAME</text>
+      <text style={s.paneTitle}>{service}</text>
+      <Field name="owner">{String(info?.owner ?? '…')}</Field>
+      <Field name="pid">{String(info?.pid ?? '…')}</Field>
+      <Field name="uid">{String(info?.uid ?? '…')}</Field>
+      <text style={s.hint}>
+        Expand it in the tree to walk the object paths this name publishes.
+      </text>
+    </box>
+  );
+}
+
+function ObjectPane({ bus, service, path }) {
+  const [state, setState] = useState({ status: 'loading' });
+  useEffect(() => {
+    let live = true;
+    setState({ status: 'loading' });
+    const b = bus.handle.bus;
+    if (!b) return undefined;
+    interfacesOf(b, service, path).then(
+      (interfaces) => live && setState({ status: 'ok', interfaces }),
+      (err) => live && setState({ status: 'error', message: err.message }),
+    );
+    return () => {
+      live = false;
+    };
+  }, [bus.handle.bus, service, path]);
+
+  return (
+    <box style={s.pane}>
+      <text style={s.paneKind}>OBJECT</text>
+      <text style={s.paneTitle}>{path}</text>
+      <Field name="on">{service}</Field>
+      {state.status === 'loading' ? (
+        <text style={s.empty}>introspecting…</text>
+      ) : state.status === 'error' ? (
+        <text style={s.error}>⚠ {state.message}</text>
+      ) : (
+        <Section
+          title="Interfaces"
+          count={state.interfaces.length}
+          empty="none — this path is a container for the ones below it"
+        >
+          {state.interfaces.map((iface) => (
+            <box key={iface.name} style={s.member}>
+              <text style={s.memberName}>{iface.name}</text>
+              <text style={s.memberType}>
+                {`${iface.methods.length} methods · ${iface.signals.length} signals · ${iface.properties.length} properties`}
+              </text>
+            </box>
+          ))}
+        </Section>
+      )}
+    </box>
+  );
+}
+
+function InterfacePane({ bus, service, path, interfaceName }) {
+  const [state, setState] = useState({ status: 'loading' });
+  const [values, setValues] = useState(null);
+
+  useEffect(() => {
+    let live = true;
+    setState({ status: 'loading' });
+    setValues(null);
+    const b = bus.handle.bus;
+    if (!b) return undefined;
+    interfacesOf(b, service, path).then(
+      (interfaces) => {
+        if (!live) return;
+        const found = interfaces.find((i) => i.name === interfaceName);
+        setState(
+          found
+            ? { status: 'ok', iface: found }
+            : { status: 'error', message: 'the object no longer declares it' },
+        );
+      },
+      (err) => live && setState({ status: 'error', message: err.message }),
+    );
+    return () => {
+      live = false;
+    };
+  }, [bus.handle.bus, service, path, interfaceName]);
+
+  // Property values are a call, so they are asked for rather than assumed —
+  // reading them is observable to the service, and some of them are expensive.
+  const readValues = async () => {
+    setValues({ status: 'loading' });
+    try {
+      const props = await readProperties(
+        bus.handle.bus,
+        service,
+        path,
+        interfaceName,
+      );
+      setValues({ status: 'ok', props });
+    } catch (err) {
+      setValues({ status: 'error', message: err.message });
+    }
+  };
+
+  if (state.status !== 'ok') {
+    return (
+      <box style={s.pane}>
+        <text style={s.paneKind}>INTERFACE</text>
+        <text style={s.paneTitle}>{interfaceName}</text>
+        {state.status === 'loading' ? (
+          <text style={s.empty}>introspecting…</text>
+        ) : (
+          <text style={s.error}>⚠ {state.message}</text>
+        )}
+      </box>
+    );
+  }
+
+  const { iface } = state;
+  return (
+    <box style={s.pane}>
+      <text style={s.paneKind}>INTERFACE</text>
+      <text style={s.paneTitle}>{interfaceName}</text>
+      <Field name="on">{`${service} ${path}`}</Field>
+
+      <Section title="Methods" count={iface.methods.length} empty="none">
+        {iface.methods.map((m) => (
+          <box key={m.name} style={s.member}>
+            <text style={s.memberName}>{m.name}</text>
+            <text style={s.memberType}>
+              {m.signature ? `in: ${m.signature}` : 'no arguments'}
+            </text>
+          </box>
+        ))}
+      </Section>
+
+      <Section title="Signals" count={iface.signals.length} empty="none">
+        {iface.signals.map((sig) => (
+          <box key={sig.name} style={s.member}>
+            <text style={s.memberName}>{sig.name}</text>
+            <text style={s.memberType}>
+              {sig.args.length
+                ? `${sig.signature} (${sig.args.join(', ')})`
+                : sig.signature || '—'}
+            </text>
+          </box>
+        ))}
+      </Section>
+
+      <Section title="Properties" count={iface.properties.length} empty="none">
+        <box style={{ flexDirection: 'row', gap: 8, alignItems: 'center' }}>
+          <Button
+            onClick={readValues}
+            disabled={values?.status === 'loading'}
+            style={{ alignSelf: 'flex-start' }}
+          >
+            {values ? 'Re-read values' : 'Read values (GetAll)'}
+          </Button>
+          {values?.status === 'error' ? (
+            <text style={s.error}>⚠ {values.message}</text>
+          ) : null}
+        </box>
+        {iface.properties.map((p) => (
+          <box key={p.name} style={s.member}>
+            <text style={s.memberName}>{p.name}</text>
+            <text style={s.memberType}>
+              {`${p.type} · ${p.access}` +
+                (values?.status === 'ok'
+                  ? `  =  ${formatValue(values.props[p.name])}`
+                  : '')}
+            </text>
+          </box>
+        ))}
+      </Section>
+    </box>
+  );
+}
+
+function Placeholder() {
+  return (
+    <box style={s.pane}>
+      <text style={s.paneKind}>NOTHING SELECTED</text>
+      <text style={s.empty}>
+        Pick a row on the left. Expanding a name introspects it, which is a
+        round trip per node — so branches fill in as they open rather than all
+        at once.
+      </text>
+    </box>
+  );
+}
+
+// --- the header -------------------------------------------------------------
+
+function BusChip({ bus }) {
+  const { handle, label, address } = bus;
+  const colour =
+    handle.status === 'ready'
+      ? C.good
+      : handle.status === 'connecting'
+        ? C.warn
+        : C.bad;
+  return (
+    <box style={s.chip}>
+      <box style={s.chipTop}>
+        <box style={[s.dot, { backgroundColor: colour }]} />
+        <text style={s.chipName}>{label}</text>
+        <box style={{ flexGrow: 1 }} />
+        {handle.status === 'closed' || handle.status === 'unavailable' ? (
+          <Button onClick={handle.retry}>Retry</Button>
+        ) : null}
+      </box>
+      <text style={s.chipLine}>
+        {handle.status === 'ready' ? handle.uniqueName : handle.status}
+      </text>
+      <text style={s.chipLine}>{address}</text>
+      {handle.cause ? (
+        <text style={s.chipWhy}>
+          {String(handle.cause.cause?.message ?? '')}
+        </text>
+      ) : null}
+    </box>
+  );
+}
+
+// --- the app ----------------------------------------------------------------
+
+function App() {
+  const session = useSessionBus();
+  const system = useSystemBus();
+  const [showUnique, setShowUnique] = useState(false);
+  const [expanded, setExpanded] = useState([]);
+  const [selected, setSelected] = useState(null);
+
+  const buses = useMemo(
+    () => [
+      {
+        kind: 'session',
+        label: 'Session bus',
+        handle: session,
+        address:
+          process.env.DBUS_SESSION_BUS_ADDRESS ??
+          (process.env.XDG_RUNTIME_DIR
+            ? `unix:path=${process.env.XDG_RUNTIME_DIR}/bus`
+            : '(no address)'),
+      },
+      {
+        kind: 'system',
+        label: 'System bus',
+        handle: system,
+        address:
+          process.env.DBUS_SYSTEM_BUS_ADDRESS ??
+          'unix:path=/var/run/dbus/system_bus_socket',
+      },
+    ],
+    [session, system],
+  );
+
+  const byKind = useMemo(
+    () => Object.fromEntries(buses.map((b) => [b.kind, b])),
+    [buses],
+  );
+  const { loaded, pending, load } = useLoader(buses);
+
+  // Expanding is where every round trip is triggered. The tree hands back the
+  // whole open set, so the new id is whatever was not open before.
+  const onExpandedChange = (next) => {
+    const opened = next.filter((id) => !expanded.includes(id));
+    setExpanded(next);
+    for (const id of opened) {
+      if (loaded[id] || pending[id]) continue;
+      const parts = partsOf(id);
+      const bus = byKind[parts[1]];
+      const b = bus?.handle.bus;
+      if (!b) continue;
+      if (parts[0] === 'bus') {
+        load(id, async () => {
+          const names = await withDeadline(b.listNames(), 4000, 'ListNames');
+          return names
+            .filter((n) => showUnique || !n.startsWith(':'))
+            .sort()
+            .map((name) => ({
+              id: idOf('name', parts[1], name),
+              label: name,
+              children: [],
+            }));
+        });
+      } else if (parts[0] === 'name') {
+        // A name's tree starts at the first object worth looking at, which is
+        // rarely `/` — see compressPath.
+        load(id, async () => {
+          const root = await compressPath(b, parts[2], '/');
+          return [
+            {
+              id: idOf('path', parts[1], parts[2], root),
+              label: root,
+              children: [],
+            },
+          ];
+        });
+      } else if (parts[0] === 'path') {
+        load(id, async () => {
+          const [paths, interfaces] = await Promise.all([
+            childPaths(b, parts[2], parts[3]),
+            interfacesOf(b, parts[2], parts[3]),
+          ]);
+          const compressed = await Promise.all(
+            paths.map((p) => compressPath(b, parts[2], p)),
+          );
+          return [
+            ...interfaces.map((iface) => ({
+              id: idOf('iface', parts[1], parts[2], parts[3], iface.name),
+              label: iface.name,
+            })),
+            ...compressed.map((p) => ({
+              id: idOf('path', parts[1], parts[2], p),
+              label: p,
+              children: [],
+            })),
+          ];
+        });
+      }
+    }
+  };
+
+  const items = useMemo(
+    () =>
+      buses.map((bus) => {
+        const id = idOf('bus', bus.kind);
+        const ready = bus.handle.status === 'ready';
+        const decorate = (node) => ({
+          ...node,
+          children: Array.isArray(node.children)
+            ? childrenFor(node.id, loaded, pending).map(decorate)
+            : undefined,
+        });
+        return {
+          id,
+          label: `${bus.label}${ready ? ` — ${bus.handle.uniqueName}` : ` — ${bus.handle.status}`}`,
+          // A bus with no connection is still a branch, so the twisty is there
+          // the moment it comes back rather than after a re-render nobody
+          // triggers.
+          children: ready ? childrenFor(id, loaded, pending).map(decorate) : [],
+        };
+      }),
+    [buses, loaded, pending],
+  );
+
+  const detail = () => {
+    if (!selected) return <Placeholder />;
+    const parts = partsOf(selected);
+    const bus = byKind[parts[1]];
+    if (!bus) return <Placeholder />;
+    switch (kindOf(selected)) {
+      case 'bus':
+        return <BusPane bus={bus} />;
+      case 'name':
+        return <NamePane bus={bus} service={parts[2]} />;
+      case 'path':
+        return <ObjectPane bus={bus} service={parts[2]} path={parts[3]} />;
+      case 'iface':
+        return (
+          <InterfacePane
+            bus={bus}
+            service={parts[2]}
+            path={parts[3]}
+            interfaceName={parts[4]}
+          />
+        );
+      default:
+        return <Placeholder />;
+    }
+  };
+
+  return (
+    <window
+      title="react-x11 — D-Bus explorer"
+      width={1000}
+      height={660}
+      minWidth={640}
+      minHeight={420}
+      theme={THEME}
+      style={s.window}
+    >
+      <ThemeProvider value={THEME}>
+        <box style={s.header}>
+          {buses.map((bus) => (
+            <BusChip key={bus.kind} bus={bus} />
+          ))}
+        </box>
+        <box style={s.rule} />
+
+        <SplitPane direction="row" defaultSize={340} min={220} minSecond={320}>
+          <box style={s.sidebar}>
+            <box style={s.sidebarHead}>
+              <text style={s.sidebarTitle}>names → objects → interfaces</text>
+              <Button
+                onClick={() => {
+                  // Unique names double the list and are rarely what you are
+                  // looking for, so they are opt-in. Collapsing the buses is
+                  // what makes the next expansion re-read ListNames.
+                  setShowUnique((v) => !v);
+                  setExpanded([]);
+                }}
+              >
+                {showUnique ? 'Hide :1.x' : 'Show :1.x'}
+              </Button>
+            </box>
+            <box style={s.rule} />
+            <Tree
+              items={items}
+              expanded={expanded}
+              onExpandedChange={onExpandedChange}
+              selected={selected}
+              onSelect={setSelected}
+            />
+          </box>
+
+          <scrollview style={{ flexGrow: 1 }}>{detail()}</scrollview>
+        </SplitPane>
+      </ThemeProvider>
+    </window>
+  );
+}
+
+export default App;
+
+if (!process.env.REACT_X11_NO_AUTORUN) {
+  const root = await createRoot();
+  root.render(<App />);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,9 @@
       "engines": {
         "node": ">=20.19"
       },
+      "optionalDependencies": {
+        "dbus-native": "^0.15.1"
+      },
       "peerDependencies": {
         "react": "^19.0.0"
       }
@@ -2078,6 +2081,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dbus-native": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/dbus-native/-/dbus-native-0.15.1.tgz",
+      "integrity": "sha512-2Zdm+2eQuhmX08/Dyk3fltCqij5LGUwSx3Wj/ZN9IowlUw6eGfYZZXxkviUcN1iPOvWOQWUi74/nVnjZmg37vg==",
+      "optional": true,
+      "dependencies": {
+        "xml2js": "^0.6.2"
+      },
+      "bin": {
+        "dbus-native": "bin/dbus-native.js"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/debug": {
@@ -4631,6 +4649,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "optional": true,
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -5349,6 +5376,28 @@
       "integrity": "sha512-SYXE7H6ALT1HQ/CNoOxxLfwYb8QQU2jJpro9/R3jhYtmmNJWaNccEzkyLKnMbzLd/YV0WeMbU2qbTTqrft21tg==",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "optional": true,
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "examples:tasks:hot": "node --enable-source-maps --import ./examples/hmr-register.mjs examples/tasks-hot.jsx",
     "examples:menu": "tsx examples/menu.jsx",
     "examples:clipboard": "tsx examples/clipboard.jsx",
+    "examples:dbus": "tsx examples/dbus.jsx",
     "examples:form": "tsx examples/form.jsx",
     "examples:rules": "tsx examples/rules.jsx",
     "examples:richtext": "tsx examples/richtext.jsx",
@@ -64,6 +65,9 @@
   "dependencies": {
     "ntk": "^6.6.0",
     "react-reconciler": "^0.33.0"
+  },
+  "optionalDependencies": {
+    "dbus-native": "^0.15.1"
   },
   "peerDependencies": {
     "react": "^19.0.0"

--- a/src/bus.js
+++ b/src/bus.js
@@ -1,0 +1,520 @@
+// The D-Bus floor: one connection per bus, shared by everything in the
+// process, acquired lazily and never able to crash an app that has no bus.
+//
+// Everything the desktop wants from an app — a file dialog, the colour
+// scheme, notifications, a global menu, a tray icon — is a D-Bus call, and
+// each of those is a separate feature that will want a connection. This
+// module exists so that they all get the *same* one.
+//
+// ## Why not just call `dbus.sessionBus()`
+//
+// Because `dbus-native`'s `sessionBus()` is a constructor in disguise: every
+// call opens a new socket and gets its own unique name. Menu + tray + the
+// app's own exported service would be three connections and three identities,
+// and the desktop would see three half-applications. A D-Bus connection is
+// *process* identity, so sharing is the design, not an optimisation.
+//
+// And because it throws. `createStream` (dbus-native index.js:32-37) throws
+// `unknown bus address` synchronously when `DBUS_SESSION_BUS_ADDRESS` is
+// unset — which is every environment react-x11 was designed for: a bare
+// `startx`, a WM keybinding, an ssh session, a container, CI. That throw must
+// never reach an app.
+//
+// ## The rule
+//
+// **Nothing here throws at import time, and nothing here crashes an app
+// running where there is no session bus.** `sessionBus()` answers `null`; the
+// caller turns its feature off. `required: true` is the escape hatch for an
+// app whose whole purpose is the bus, and it is the only shape that rejects.
+//
+// ## Lifecycle: connect on first use, stay connected
+//
+// The ref count drives the socket's *event-loop hold*, not its existence:
+//
+//   refs > 0   connected, `ref()`d    — the process stays alive for it
+//   refs == 0  connected, `unref()`d  — warm, costs one idle FD, holds nothing
+//
+// Closing at zero refs would be wrong for the consumers this actually has. A
+// file dialog that mounts on click and unmounts on dismiss would tear the
+// connection down and rebuild it every time — and every rebuild is a *new
+// unique name*, with the daemon forgetting match rules and well-known names
+// along with the old one. `closeBus()` is the way out for an app that wants
+// the connection gone; it is never the automatic consequence of an unmount.
+
+/** @typedef {'session'|'system'} BusKind */
+
+const KINDS = ['session', 'system'];
+
+/**
+ * There is no bus to be had, and this is why.
+ *
+ * `cause` is the real reason — no address, `ECONNREFUSED`, an auth rejection,
+ * `dbus-native` not installed. Deliberately not a second failure taxonomy: a
+ * coarse enum layered on top would have to stay true across platforms, npm
+ * layouts and transport versions, and in practice the reason gets logged far
+ * more often than it gets branched on.
+ */
+export class BusUnavailableError extends Error {
+  /**
+   * @param {BusKind} kind
+   * @param {unknown} [cause]
+   */
+  constructor(kind, cause) {
+    super(
+      `react-x11: no ${kind} bus available` +
+        (cause instanceof Error ? ` (${cause.message})` : ''),
+      { cause },
+    );
+    this.name = 'BusUnavailableError';
+    /** @type {BusKind} which bus was asked for */
+    this.kind = kind;
+  }
+}
+
+/**
+ * Per-kind state. One entry, replaced wholesale on every generation — a dead
+ * connection is never resurrected, because a new socket is a new unique name
+ * and callers holding the old one are talking to nobody.
+ */
+const state = {
+  session: newState('session', 0),
+  system: newState('system', 0),
+};
+
+function newState(kind, generation) {
+  return {
+    kind,
+    /** Bumped per connection attempt; a ref remembers which one it belongs to. */
+    generation,
+    /** The in-flight connect, shared by concurrent acquisitions. */
+    connecting: null,
+    bus: null,
+    uniqueName: null,
+    /** Live refs on this generation. */
+    refs: 0,
+    /** Set when the connection died under us; the generation is retired. */
+    dead: false,
+  };
+}
+
+// --------------------------------------------------------------------------
+// The transport
+// --------------------------------------------------------------------------
+
+/**
+ * `dbus-native`, imported on the first acquisition and never at module load.
+ *
+ * It is an `optionalDependency`, so on Node 20 — where its own
+ * `engines: ">=22.12.0"` makes npm skip it — this import fails, and "no
+ * transport installed" collapses into the "no bus here" path rather than
+ * adding a mode.
+ */
+let transport = null;
+
+async function loadTransport() {
+  if (transport) return transport;
+  const mod = await import('dbus-native');
+  // CJS with an `exports` map: named exports do not reliably survive
+  // cjs-module-lexer, so take the default and destructure from it.
+  transport = mod.default ?? mod;
+  return transport;
+}
+
+/**
+ * The address seam is D-Bus's own — `DBUS_SESSION_BUS_ADDRESS` — plus the
+ * `$XDG_RUNTIME_DIR/bus` fallback `dbus-native` does not have yet
+ * (sidorares/dbus-native#389). Delete the fallback when that lands.
+ *
+ * Deliberately no `busAddress` parameter on the public API: a per-call
+ * address is incoherent under sharing. Two callers, two addresses, one
+ * socket — which would win? Tests use this same seam.
+ */
+function addressFor(kind) {
+  if (kind === 'system') {
+    return (
+      process.env.DBUS_SYSTEM_BUS_ADDRESS ||
+      'unix:path=/var/run/dbus/system_bus_socket'
+    );
+  }
+  if (process.env.DBUS_SESSION_BUS_ADDRESS) {
+    return process.env.DBUS_SESSION_BUS_ADDRESS;
+  }
+  // macOS advertises the session bus through launchd, which dbus-native
+  // already falls back to on its own. Leave it undefined and let it.
+  if (process.platform === 'darwin') return undefined;
+  const runtimeDir = process.env.XDG_RUNTIME_DIR;
+  return runtimeDir ? `unix:path=${runtimeDir}/bus` : undefined;
+}
+
+function noAddressError(kind) {
+  return new Error(
+    `react-x11: no ${kind} bus address. ` +
+      (kind === 'session'
+        ? '$DBUS_SESSION_BUS_ADDRESS is unset and $XDG_RUNTIME_DIR is not ' +
+          'set either, which is normal over ssh, under a bare startx and in ' +
+          'most containers.'
+        : '$DBUS_SYSTEM_BUS_ADDRESS is unset and there is no default.'),
+  );
+}
+
+function noTransportError(cause) {
+  return new Error(
+    'react-x11: the D-Bus transport is not installed. dbus-native is an ' +
+      'optional dependency and npm skips it on Node < 22.12 (this process ' +
+      `is ${process.version}). Install it explicitly — npm i dbus-native — ` +
+      'or run on Node >= 22.12.',
+    { cause },
+  );
+}
+
+// --------------------------------------------------------------------------
+// Connecting
+// --------------------------------------------------------------------------
+
+/** Swallow whatever a doomed connection has left to say. */
+function silence(bus) {
+  bus.connection.removeAllListeners('error');
+  bus.connection.on('error', () => {});
+}
+
+async function discard(bus) {
+  silence(bus);
+  try {
+    await bus.close();
+  } catch {
+    // Already gone. The cause we are on our way to reporting is the
+    // interesting one, not this.
+  }
+}
+
+/**
+ * One connect attempt: dial, wait for the handshake, wait for the unique
+ * name, and take ownership of the connection's `'error'` channel.
+ *
+ * Resolves with `{ bus, uniqueName }` or rejects with a `BusUnavailableError`
+ * carrying the real reason. Never resolves before `bus.name` is set.
+ */
+async function connect(kind, generation) {
+  const fail = (cause) => {
+    throw new BusUnavailableError(kind, cause);
+  };
+
+  let dbus;
+  try {
+    dbus = await loadTransport();
+  } catch (cause) {
+    return fail(noTransportError(cause));
+  }
+
+  const busAddress = addressFor(kind);
+  if (!busAddress && process.platform !== 'darwin') {
+    return fail(noAddressError(kind));
+  }
+
+  let bus;
+  try {
+    // Reconnection stays off, deliberately: a new socket is a new unique
+    // name, and the daemon forgets names and match rules along with the old
+    // one. The replacement is a new generation, which is explicit.
+    bus = dbus.createClient({ busAddress });
+  } catch (cause) {
+    // The synchronous throw this whole module exists to absorb.
+    return fail(cause);
+  }
+
+  const conn = bus.connection;
+
+  // **This layer owns the connection's one 'error' listener.** dbus-native
+  // deliberately attaches none — an unlistened 'error' crashes the process,
+  // which is the right contract for a caller-owned connection and the wrong
+  // one for a shared one. Consumers never attach their own.
+  let onConnect, onClose, onError;
+  try {
+    await new Promise((resolve, reject) => {
+      onConnect = () => resolve();
+      onClose = (cause) =>
+        reject(cause ?? new Error(`react-x11: the ${kind} bus closed`));
+      onError = (err) => reject(err);
+      conn.once('connect', onConnect);
+      conn.once('close', onClose);
+      conn.on('error', onError);
+    });
+  } catch (cause) {
+    await discard(bus);
+    return fail(cause);
+  } finally {
+    conn.removeListener('connect', onConnect);
+    conn.removeListener('close', onClose);
+    conn.removeListener('error', onError);
+  }
+
+  // Name-ready. `bus.name` is assigned in the Hello reply callback
+  // (dbus-native lib/bus.js:1002-1009), so it is *not* set when the
+  // constructor returns. One org.freedesktop.DBus round trip is an ordering
+  // barrier: replies arrive behind the Hello dbus-native sent first. Without
+  // it, the first consumer to derive state from the app's own identity — a
+  // portal Request path, say — races Hello and builds a path with
+  // `undefined` in it.
+  try {
+    await bus.listNames();
+  } catch (cause) {
+    await discard(bus);
+    return fail(cause);
+  }
+  if (bus.name == null) {
+    await discard(bus);
+    return fail(
+      new Error(
+        `react-x11: the ${kind} bus answered a call but never assigned a ` +
+          'unique name — the peer is not a message bus.',
+      ),
+    );
+  }
+
+  // Live. From here a failure is a *death* rather than a failed connect, so
+  // both channels retarget onto the generation.
+  conn.on('error', () => bury(kind, generation));
+  conn.once('close', () => bury(kind, generation));
+
+  return { bus, uniqueName: bus.name };
+}
+
+/**
+ * The connection died. Retire the generation rather than resurrecting it:
+ * refs on it fail their calls with the transport's `ConnectionClosedError`
+ * and `release()` harmlessly, mounted hooks move to `'closed'`, and the next
+ * acquisition dials a fresh socket with a fresh unique name.
+ */
+function bury(kind, generation) {
+  const s = state[kind];
+  if (s.generation !== generation || s.dead) return;
+  s.dead = true;
+  s.refs = 0;
+  s.connecting = null;
+  notify(kind);
+}
+
+// --------------------------------------------------------------------------
+// The event-loop hold
+// --------------------------------------------------------------------------
+
+/**
+ * `ref()`/`unref()` the live socket, so the ref count decides whether the
+ * connection *holds the process open* without deciding whether it exists.
+ *
+ * `bus.connection.stream` is a `net.Socket` on every path this module dials
+ * (dbus-native index.js:169, :30-31). It is reaching into an internal, hence
+ * the guards: a caller-supplied stream need not be a socket. A missing `ref`
+ * costs nothing worse than a process that exits a beat earlier than it should
+ * have, which the exit test would catch.
+ */
+function hold(s, held) {
+  const stream = s.bus?.connection?.stream;
+  if (!stream) return;
+  if (held) stream.ref?.();
+  else stream.unref?.();
+}
+
+// --------------------------------------------------------------------------
+// Acquisition
+// --------------------------------------------------------------------------
+
+/**
+ * @param {BusKind} kind
+ * @param {{ required?: boolean }} [opts]
+ * @returns {Promise<BusRefShape | null>}
+ */
+async function acquire(kind, opts = {}) {
+  let s = state[kind];
+
+  // A dead generation is retired: a fresh acquisition starts a new one rather
+  // than handing out a corpse.
+  if (s.dead) {
+    s = state[kind] = newState(kind, s.generation + 1);
+  }
+
+  if (!s.bus) {
+    // Concurrent acquisitions share one connect attempt.
+    if (!s.connecting) {
+      const generation = s.generation;
+      const attempt = connect(kind, generation).then((result) => {
+        // A `closeBus()` that landed mid-connect wins: drop what we dialled.
+        if (state[kind] !== s) {
+          discard(result.bus);
+          throw new BusUnavailableError(
+            kind,
+            new Error(`react-x11: the ${kind} bus was closed while connecting`),
+          );
+        }
+        s.bus = result.bus;
+        s.uniqueName = result.uniqueName;
+        // Nothing holds a ref yet, so the socket must not keep the process
+        // alive on its own.
+        hold(s, false);
+        notify(kind);
+        return result;
+      });
+      // **Failure is not cached.** A failed attempt answers its waiters and is
+      // forgotten: a session bus can genuinely appear later — the moment
+      // something creates $XDG_RUNTIME_DIR/bus — feature probes happen once
+      // per feature init so the retry costs nothing, and a transient failure
+      // must never become a process-lifetime false negative.
+      s.connecting = attempt;
+      attempt
+        .catch(() => {})
+        .then(() => {
+          if (s.connecting === attempt) s.connecting = null;
+        });
+    }
+    try {
+      await s.connecting;
+    } catch (cause) {
+      if (opts.required) throw cause;
+      return null;
+    }
+    // `closeBus()` can land between that resolving and this line.
+    if (state[kind] !== s || !s.bus) return acquire(kind, opts);
+  }
+
+  return makeRef(s);
+}
+
+/** @typedef {{ bus: any, uniqueName: string, release(): Promise<void> }} BusRefShape */
+
+function makeRef(s) {
+  const generation = s.generation;
+  // Captured, not read through the state: a ref's `bus` must stay the object
+  // it was handed even after the generation is retired, so that a call on it
+  // fails with ConnectionClosedError rather than on `null`.
+  const bus = s.bus;
+  const uniqueName = s.uniqueName;
+  let live = true;
+
+  // No `notify()` here or in `release()`: the ref count is not part of any
+  // status a watcher renders, and waking every mounted hook on every
+  // acquire/release would be render churn with nothing behind it.
+  if (s.refs++ === 0) hold(s, true);
+
+  const ref = {
+    bus,
+    uniqueName,
+    /**
+     * Drop this consumer's reference. Idempotent *per ref*, so `finally`
+     * blocks and `asyncDispose` compose without double-decrement bugs.
+     *
+     * It does not close anything. `release()` is the only lifecycle verb a
+     * ref holder has, deliberately: `ref.bus.close()` would tear the
+     * connection out from under the tray, the menu and the app's own service.
+     */
+    async release() {
+      if (!live) return;
+      live = false;
+      // A ref on a retired generation decrements nothing — `bury` and
+      // `closeBus` already zeroed the count, and this ref's slot went with it.
+      if (state[s.kind] !== s || s.generation !== generation || s.dead) return;
+      if (--s.refs === 0) hold(s, false);
+    },
+  };
+  ref[Symbol.asyncDispose] = () => ref.release();
+  return ref;
+}
+
+/**
+ * A shared session bus, or `null`.
+ *
+ * ```js
+ * const ref = await sessionBus();
+ * if (!ref) return;                    // no bus here; turn the feature off
+ * const player = await ref.bus.proxy('org.mpris.MediaPlayer2.vlc', '/org/mpris/MediaPlayer2');
+ * await ref.release();
+ * ```
+ *
+ * Never rejects — unless `required: true` asks it to, which converts
+ * unavailability into a `BusUnavailableError` carrying the reason. `null` is
+ * right for feature-probing plumbing, and hides *why* from an app whose whole
+ * purpose is the bus.
+ *
+ * @param {{ required?: boolean }} [opts]
+ */
+export function sessionBus(opts) {
+  return acquire('session', opts);
+}
+
+/**
+ * A shared system bus, or `null`. Hardware, networking, logind — read-mostly
+ * for an application. Same contract as {@link sessionBus}.
+ *
+ * @param {{ required?: boolean }} [opts]
+ */
+export function systemBus(opts) {
+  return acquire('system', opts);
+}
+
+/**
+ * Close the shared connection outright. Rare, explicit, never automatic.
+ *
+ * This is the app-level decision a consumer must not make for its siblings.
+ * Outstanding refs are retired with the generation: their calls fail with
+ * `ConnectionClosedError` and `release()` still succeeds.
+ *
+ * @param {BusKind} kind
+ */
+export async function closeBus(kind) {
+  if (!KINDS.includes(kind)) {
+    throw new Error(
+      `react-x11: closeBus(${JSON.stringify(kind)}) — expected ` +
+        `${KINDS.map((k) => JSON.stringify(k)).join(' or ')}.`,
+    );
+  }
+  const s = state[kind];
+  const bus = s.bus;
+  // Swap the state first, so anything awaiting the old generation sees it
+  // retired rather than racing the socket teardown.
+  state[kind] = newState(kind, s.generation + 1);
+  notify(kind);
+  if (!bus) return;
+  silence(bus);
+  await bus.close();
+}
+
+// --------------------------------------------------------------------------
+// Subscription, for the hooks
+// --------------------------------------------------------------------------
+
+const watchers = { session: new Set(), system: new Set() };
+
+/**
+ * Re-render when a bus's status changes. Not public: `useSessionBus()` is the
+ * public shape, and a consumer reaching for the imperative API does not want
+ * a store.
+ */
+export function watchBus(kind, onChange) {
+  watchers[kind].add(onChange);
+  return () => watchers[kind].delete(onChange);
+}
+
+function notify(kind) {
+  for (const fn of [...watchers[kind]]) fn();
+}
+
+/** Whether the generation a ref belongs to has been retired. Not public. */
+export function busGeneration(kind) {
+  return state[kind].generation;
+}
+
+/** Whether the live generation for `kind` has been buried. Not public. */
+export function busIsDead(kind) {
+  return state[kind].dead;
+}
+
+/**
+ * Test seam, not public: forget every connection without closing anything.
+ * `withBus()` hard-closes first and then calls this, so that no match rule or
+ * exported object survives into the next test.
+ */
+export function _resetBusState() {
+  for (const kind of KINDS) {
+    state[kind] = newState(kind, state[kind].generation + 1);
+    notify(kind);
+  }
+}

--- a/src/bushooks.js
+++ b/src/bushooks.js
@@ -1,0 +1,136 @@
+// `useSessionBus()` / `useSystemBus()` — the surface almost everyone uses.
+//
+// ## No provider, and why that is not the trick `useApp()` uses
+//
+// The requirement is the same: a component that talks to the desktop works in
+// any tree with *nothing for the app author to wrap*. `useApp()` gets there
+// with a provider `Reconciler.js` injects, because the X connection is
+// genuinely per-tree — `createRoot()` opens one per root and a process can
+// drive several.
+//
+// A D-Bus connection is **process** identity. Every consumer shares one socket
+// and one unique name on purpose, so that an app's exported service, its menu
+// and its tray are visibly one application. There is therefore nothing to
+// provide: these hooks read the module-global in `bus.js` and manage their own
+// acquire/release. Putting a process-global on a tree-scoped context would
+// assert a scoping relationship that does not exist — two roots on two X
+// displays share one session bus.
+//
+// ## The terse path has to be correct on its own
+//
+//     const { bus } = useSessionBus();
+//     if (!bus) return null;              // right, with no reference to status
+//
+// If reading `status` were *required* to avoid a bug, the shape would be
+// wrong. `status` and `cause` are there for the cases that need more —
+// diagnostics ("why is my tray icon missing") and the app-author persona —
+// not as a step every consumer has to remember.
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import {
+  busGeneration,
+  busIsDead,
+  sessionBus,
+  systemBus,
+  watchBus,
+} from './bus.js';
+
+/** @typedef {'connecting'|'ready'|'unavailable'|'closed'} BusStatus */
+
+const CONNECTING = { bus: null, uniqueName: null, status: 'connecting' };
+
+function useBus(kind, acquire) {
+  const [attempt, setAttempt] = useState(0);
+  // The attempt each answer belongs to, so a `retry()` shows 'connecting'
+  // immediately instead of leaving the stale answer up until the new dial
+  // settles — and without an extra render to reset it.
+  const [answer, setAnswer] = useState({ attempt: -1, handle: CONNECTING });
+
+  // The way back from `'closed'`. Deliberately not automatic: silently
+  // re-acquiring would hand the consumer a fresh `bus` under the same
+  // variable and hide the unique-name change that disabling reconnect exists
+  // to expose. A feature-level hook that knows how to rebuild its bus-side
+  // state can call this; a generic one cannot.
+  const retry = useCallback(() => setAttempt((n) => n + 1), []);
+
+  useEffect(() => {
+    let live = true;
+    let acquired = null;
+    let acquiredGeneration = null;
+    let unwatch = null;
+    const settle = (handle) => setAnswer({ attempt, handle });
+
+    // `required: true` purely to obtain the reason. The imperative default
+    // stays never-rejecting; the hook is that option's first consumer,
+    // converting the rejection into rendering state.
+    acquire({ required: true }).then(
+      (ref) => {
+        if (!live) return void ref.release();
+        acquired = ref;
+        acquiredGeneration = busGeneration(kind);
+        settle({
+          bus: ref.bus,
+          uniqueName: ref.uniqueName,
+          status: 'ready',
+        });
+        // The connection can die under a live ref. When it does the
+        // generation is retired, which is what distinguishes "the daemon went
+        // away" from "there was never a bus here".
+        unwatch = watchBus(kind, () => {
+          if (!live) return;
+          if (!busIsDead(kind) && busGeneration(kind) === acquiredGeneration) {
+            return;
+          }
+          settle({ bus: null, uniqueName: null, status: 'closed' });
+        });
+      },
+      (cause) => {
+        if (!live) return;
+        settle({ bus: null, uniqueName: null, status: 'unavailable', cause });
+      },
+    );
+
+    return () => {
+      live = false;
+      unwatch?.();
+      acquired?.release();
+    };
+  }, [kind, acquire, attempt]);
+
+  const handle = answer.attempt === attempt ? answer.handle : CONNECTING;
+  // Memoized so the handle is stable between renders and safe in a dependency
+  // array — a fresh object every render would restart any effect keyed on it.
+  return useMemo(() => ({ ...handle, retry }), [handle, retry]);
+}
+
+/**
+ * The session bus, as rendering state.
+ *
+ * ```jsx
+ * function ThemeWatcher() {
+ *   const { bus } = useSessionBus();
+ *   if (!bus) return null;          // no bus here: no desktop theme to read
+ *   ...
+ * }
+ * ```
+ *
+ * | `status`       |                                                        |
+ * | -------------- | ------------------------------------------------------ |
+ * | `'connecting'` | the handshake is in flight — also the first render     |
+ * | `'ready'`      | `bus` and `uniqueName` are set                         |
+ * | `'unavailable'` | no daemon, socket or permission here; `cause` says why |
+ * | `'closed'`     | the connection died; call `retry()` to dial a new one   |
+ *
+ * **`'unavailable'` is a snapshot, not a verdict.** Failure is not cached, so
+ * a session bus that appears later will be found — do not permanently disable
+ * a feature on seeing it.
+ */
+export function useSessionBus() {
+  return useBus('session', sessionBus);
+}
+
+/** The system bus, as rendering state. Same shape as {@link useSessionBus}. */
+export function useSystemBus() {
+  return useBus('system', systemBus);
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,6 +16,7 @@ export * from './types/events.js';
 export * from './types/nodes.js';
 export * from './types/elements.js';
 export * from './types/components.js';
+export * from './types/dbus.js';
 
 /**
  * The XID of the X11 window a ref points at, or `null` if there is not one

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,8 @@ export { windowIdOf, useWindowId } from './windowid.js';
 export { launchTimestamp, notifyStartupComplete } from './startup.js';
 export { parseUriList } from './transfer.js';
 export { useApp, useClipboard, useSupports } from './appcontext.js';
+export { BusUnavailableError, closeBus, sessionBus, systemBus } from './bus.js';
+export { useSessionBus, useSystemBus } from './bushooks.js';
 export {
   useDropTarget,
   useDragSource,

--- a/src/types/dbus.d.ts
+++ b/src/types/dbus.d.ts
@@ -1,0 +1,177 @@
+/**
+ * The D-Bus floor — `useSessionBus()`, `sessionBus()` and what they hand back.
+ * See docs/dbus.md.
+ */
+
+/** Which bus. Session is the user's; system is hardware, networking, logind. */
+export type BusKind = 'session' | 'system';
+
+/** What a {@link BusHandle} is doing. See {@link useSessionBus}. */
+export type BusStatus = 'connecting' | 'ready' | 'unavailable' | 'closed';
+
+/**
+ * The connection, as `dbus-native` presents it — **structurally**, so that
+ * these declarations type-check on an install where the package is not there.
+ *
+ * That is not a hypothetical: `dbus-native` is an `optionalDependency` and
+ * declares `engines: ">=22.12.0"`, so npm skips it on Node 20 and a
+ * `import type { MessageBus } from 'dbus-native'` here would fail to resolve
+ * for anyone type-checking with `skipLibCheck: false`. Nothing in react-x11's
+ * declarations names the package for that reason.
+ *
+ * The members below are the ones this layer documents. **The index signature
+ * is not a shrug** — the whole `dbus-native` surface is genuinely on this
+ * object and reaching for one of the rest is the supported thing to do. Code
+ * that wants the package's own checked types can import them on its side and
+ * cast; the object is the same object.
+ */
+export interface MessageBus {
+  /** This connection's unique name, once `Hello` has been answered. */
+  name?: string;
+  /** Signals, keyed by `mangle(path, interface, member)`. */
+  signals?: unknown;
+  /** The transport underneath. Reaching into it is not this layer's contract. */
+  connection?: unknown;
+
+  /** A remote object with its members resolved by introspection. */
+  proxy(service: string, path: string, options?: unknown): PromiseLike<any>;
+  getService(name: string): any;
+  getObject(service: string, path: string): PromiseLike<any>;
+  getInterface(
+    service: string,
+    path: string,
+    interfaceName: string,
+  ): PromiseLike<any>;
+  invoke(message: unknown, options?: unknown): PromiseLike<any>;
+
+  listNames(): PromiseLike<string[]>;
+  listActivatableNames(): PromiseLike<string[]>;
+  getNameOwner(name: string): PromiseLike<string>;
+  nameHasOwner(name: string): PromiseLike<boolean>;
+  requestName(name: string, flags: number): PromiseLike<number>;
+  releaseName(name: string): PromiseLike<number>;
+  addMatch(rule: string): PromiseLike<void>;
+  removeMatch(rule: string): PromiseLike<void>;
+  mangle(path: string, interfaceName?: string, member?: string): string;
+
+  /**
+   * **Do not call this on a shared bus.** It tears the connection out from
+   * under every other consumer — the tray, the menu, the app's own exported
+   * service. {@link closeBus} is the app-level decision; `release()` is the
+   * only lifecycle verb a ref holder has.
+   */
+  close(): Promise<void>;
+
+  [member: string]: any;
+}
+
+/**
+ * There is no bus to be had, and this is why.
+ *
+ * `cause` carries the real reason — no address, `ECONNREFUSED`, an auth
+ * rejection, the transport not being installed. There is deliberately no
+ * second failure taxonomy on top of it: an enum would have to stay true
+ * across platforms, npm layouts and `dbus-native` versions, and in practice
+ * the reason gets logged far more often than it gets branched on.
+ */
+export declare class BusUnavailableError extends Error {
+  constructor(kind: BusKind, cause?: unknown);
+  /** Which bus was asked for. */
+  readonly kind: BusKind;
+  readonly cause?: unknown;
+}
+
+/**
+ * One consumer's claim on the shared connection.
+ *
+ * `release()` drops the claim; it never closes anything. The connection stays
+ * up for the life of the process — see docs/dbus.md — because every reconnect
+ * is a new unique name, and a dialog that mounts and unmounts must not cost
+ * the app its identity on the desktop.
+ */
+export interface BusRef {
+  /** The full `dbus-native` surface, shared with every other ref. */
+  readonly bus: MessageBus;
+  /** This connection's unique name, e.g. `':1.42'`. Always a string. */
+  readonly uniqueName: string;
+  /** Drop this consumer's reference. Idempotent per ref. */
+  release(): Promise<void>;
+  [Symbol.asyncDispose](): Promise<void>;
+}
+
+export interface AcquireOptions {
+  /**
+   * Reject with a {@link BusUnavailableError} instead of answering `null`.
+   *
+   * The escape hatch for an app whose purpose *is* the bus: `null` is right
+   * for feature-probing plumbing and hides why from a service author. The
+   * default stays never-rejecting.
+   */
+  required?: boolean;
+}
+
+/**
+ * A shared session bus, or `null` when there is not one.
+ *
+ * ```js
+ * const ref = await sessionBus();
+ * if (!ref) return;                 // no bus here; turn the feature off
+ * const portal = await ref.bus.proxy('org.freedesktop.portal.Desktop', '/org/freedesktop/portal/desktop');
+ * await ref.release();
+ * ```
+ *
+ * Lazy — nothing is dialled until the first call — and shared: every consumer
+ * in the process gets the same socket and the same unique name, so the app's
+ * exported service, its menu and its tray are visibly one application.
+ */
+export declare function sessionBus(
+  options?: AcquireOptions & { required?: false },
+): Promise<BusRef | null>;
+export declare function sessionBus(
+  options: AcquireOptions & { required: true },
+): Promise<BusRef>;
+
+/** A shared system bus, or `null`. Same contract as {@link sessionBus}. */
+export declare function systemBus(
+  options?: AcquireOptions & { required?: false },
+): Promise<BusRef | null>;
+export declare function systemBus(
+  options: AcquireOptions & { required: true },
+): Promise<BusRef>;
+
+/**
+ * Close the shared connection outright. Rare, explicit, never automatic —
+ * and never something a consumer does on behalf of its siblings.
+ */
+export declare function closeBus(kind: BusKind): Promise<void>;
+
+/** What {@link useSessionBus} and {@link useSystemBus} return. */
+export interface BusHandle {
+  /** The connection, or `null` unless `status === 'ready'`. */
+  readonly bus: MessageBus | null;
+  readonly uniqueName: string | null;
+  readonly status: BusStatus;
+  /** Why there is no bus. Set when `status === 'unavailable'`. */
+  readonly cause?: BusUnavailableError;
+  /** Dial again after `'closed'`. Not automatic — see docs/dbus.md. */
+  retry(): void;
+}
+
+/**
+ * The session bus, as rendering state. Works in any tree with **nothing to
+ * wrap** — a D-Bus connection is process identity, so there is no provider
+ * and nothing for an app author to install.
+ *
+ * ```tsx
+ * const { bus } = useSessionBus();
+ * if (!bus) return null;            // correct on its own; status is for detail
+ * ```
+ *
+ * `'unavailable'` is a snapshot, not a verdict: failure is not cached, so a
+ * bus that appears later will be found. Do not permanently disable a feature
+ * on seeing it.
+ */
+export declare function useSessionBus(): BusHandle;
+
+/** The system bus, as rendering state. Same shape as {@link useSessionBus}. */
+export declare function useSystemBus(): BusHandle;

--- a/test/bus.test.js
+++ b/test/bus.test.js
@@ -1,0 +1,659 @@
+// The bus floor (issue #163): lazy, shared, ref-counted, name-ready, and
+// unable to crash an app that has no bus.
+//
+// Every behaviour the contract names is a test here rather than a comment in
+// src/bus.js, because the whole point of the layer is what it does in
+// environments the developer writing against it is not sitting in — an ssh
+// session, a container, CI, a Node 20 install with no transport at all.
+import { test, describe } from 'node:test';
+import assert from 'node:assert';
+import { execFile } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import React from 'react';
+
+import {
+  BusUnavailableError,
+  closeBus,
+  sessionBus,
+  systemBus,
+  _resetBusState,
+} from '../src/bus.js';
+import { useSessionBus } from '../src/bushooks.js';
+import { act, cleanup, renderX11 } from '../src/testing/index.js';
+import {
+  startBroker,
+  stopBroker,
+  transportAvailable,
+  until,
+  withBus,
+} from './helpers/with-bus.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repo = path.join(here, '..');
+
+// On Node 20 npm skips `dbus-native` (its own engines field is >=22.12), which
+// is the degradation this layer is designed around rather than a problem to
+// route around. The tests that need a real broker skip there; the ones that
+// assert the *absence* of a transport run everywhere.
+const haveTransport = await transportAvailable();
+const needsBroker = haveTransport
+  ? {}
+  : { skip: 'dbus-native is not installed (expected on Node < 22.12)' };
+
+function run(args, env = {}, timeout = 20000) {
+  return new Promise((resolve) => {
+    const child = execFile(
+      process.execPath,
+      args,
+      { cwd: repo, env: { ...process.env, ...env }, timeout },
+      (error, stdout, stderr) =>
+        resolve({ code: error?.code ?? 0, error, stdout, stderr }),
+    );
+    child.on('error', () => {});
+  });
+}
+
+/** Run a snippet of ESM in a child process, from the repo root. */
+function runScript(source, env = {}, nodeArgs = [], timeout) {
+  return run(
+    [...nodeArgs, '--input-type=module', '--eval', source],
+    env,
+    timeout,
+  );
+}
+
+/**
+ * Poll a rendering condition, flushing React's queue between attempts.
+ *
+ * An update scheduled from a promise callback is *queued* while an `act()`
+ * scope is open, so polling from inside one would never see it — each attempt
+ * has to be its own act. This is the difference between a hook test that
+ * passes and one that times out staring at the first render.
+ */
+async function untilRendered(predicate, message, timeout = 3000) {
+  const deadline = Date.now() + timeout;
+  for (;;) {
+    if (predicate()) return;
+    if (Date.now() > deadline)
+      throw new Error(`timed out waiting for ${message}`);
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 10));
+    });
+  }
+}
+
+/**
+ * A socket path nothing is listening on yet — the tests that need to start and
+ * stop a broker at a *fixed* address, which is what a daemon restart looks
+ * like from the client's side.
+ */
+async function reservedSocket() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'rx11-bus-'));
+  return path.join(dir, 'socket');
+}
+
+/** Point the session bus at `address` for the duration of `fn`. */
+async function withAddress(address, fn) {
+  const saved = process.env.DBUS_SESSION_BUS_ADDRESS;
+  process.env.DBUS_SESSION_BUS_ADDRESS = address;
+  try {
+    return await fn();
+  } finally {
+    if (saved === undefined) delete process.env.DBUS_SESSION_BUS_ADDRESS;
+    else process.env.DBUS_SESSION_BUS_ADDRESS = saved;
+    await closeBus('session').catch(() => {});
+    _resetBusState();
+  }
+}
+
+// ---------------------------------------------------------------------------
+
+describe('import safety', () => {
+  // The single most important rule in this layer: nothing throws at import
+  // time and nothing dials a socket. `--eval` runs from the repo root, with no
+  // DBUS_SESSION_BUS_ADDRESS and no XDG_RUNTIME_DIR — the ssh/CI/container
+  // configuration, which is react-x11's flagship persona rather than an edge
+  // case.
+  test('importing react-x11 with no bus loads no transport and exits 0', async () => {
+    // dbus-native is CJS, and the ESM loader evaluates a CJS package through
+    // the CJS loader — so `require.cache` is where a module that really was
+    // loaded shows up, whichever syntax reached it. Nothing else in the
+    // process touches it, so a single entry is proof.
+    const source = `
+      import './src/index.js';
+      const { createRequire } = await import('node:module');
+      const require = createRequire(process.cwd() + '/');
+      const cached = Object.keys(require.cache).filter((p) => p.includes('dbus-native'));
+      if (cached.length) {
+        console.error('dbus-native was loaded at import time: ' + cached[0]);
+        process.exit(3);
+      }
+      console.log('ok');
+    `;
+    const { code, stdout, stderr } = await runScript(source, {
+      DBUS_SESSION_BUS_ADDRESS: undefined,
+      XDG_RUNTIME_DIR: undefined,
+    });
+    assert.equal(code, 0, stderr);
+    assert.match(stdout, /ok/);
+  });
+
+  test('calling sessionBus() with no bus answers null rather than throwing', async () => {
+    const source = `
+      import { sessionBus, systemBus } from './src/bus.js';
+      const s = await sessionBus();
+      const y = await systemBus();
+      console.log(JSON.stringify({ session: s, system: y }));
+    `;
+    const { code, stdout, stderr } = await runScript(source, {
+      DBUS_SESSION_BUS_ADDRESS: undefined,
+      XDG_RUNTIME_DIR: undefined,
+      DBUS_SYSTEM_BUS_ADDRESS: 'unix:path=/nonexistent/react-x11-test-system',
+    });
+    assert.equal(code, 0, stderr);
+    assert.deepEqual(JSON.parse(stdout), { session: null, system: null });
+  });
+});
+
+describe('the transport is absent', () => {
+  // The Node 20 configuration, run on every Node: `dbus-native` fails to
+  // resolve, and "no transport installed" collapses into "no bus here" rather
+  // than adding a mode.
+  const loader = path.join(here, 'helpers', 'no-dbus.mjs');
+
+  test('sessionBus() is null and the cause says the transport is missing', async () => {
+    const source = `
+      import { sessionBus, BusUnavailableError } from './src/bus.js';
+      console.log(JSON.stringify({ ref: await sessionBus() }));
+      try {
+        await sessionBus({ required: true });
+        process.exit(4);
+      } catch (err) {
+        console.log(JSON.stringify({
+          name: err.constructor.name,
+          kind: err.kind,
+          cause: err.cause?.message ?? '',
+        }));
+      }
+    `;
+    const { code, stdout, stderr } = await runScript(source, {}, [
+      '--import',
+      loader,
+    ]);
+    assert.equal(code, 0, stderr);
+    const [absent, required] = stdout.trim().split('\n').map(JSON.parse);
+    assert.equal(absent.ref, null);
+    assert.equal(required.name, 'BusUnavailableError');
+    assert.equal(required.kind, 'session');
+    assert.match(required.cause, /transport is not installed/);
+    assert.match(required.cause, /npm i dbus-native/);
+  });
+
+  test('useSessionBus() reports unavailable with that cause', async () => {
+    const source = `
+      import React from 'react';
+      import { useSessionBus } from './src/bushooks.js';
+      import { act, cleanup, renderX11 } from './src/testing/index.js';
+
+      let seen = null;
+      function Probe() {
+        const handle = useSessionBus();
+        seen = handle;
+        return React.createElement('text', null, handle.status);
+      }
+      await renderX11(React.createElement(Probe), { backend: 'mock' });
+      await act(async () => { await new Promise((r) => setTimeout(r, 50)); });
+      console.log(JSON.stringify({
+        status: seen.status,
+        bus: seen.bus,
+        cause: seen.cause?.cause?.message ?? '',
+        retry: typeof seen.retry,
+      }));
+      await cleanup();
+    `;
+    const { code, stdout, stderr } = await runScript(source, {}, [
+      '--import',
+      loader,
+    ]);
+    assert.equal(code, 0, stderr);
+    const seen = JSON.parse(stdout.trim().split('\n').pop());
+    assert.equal(seen.status, 'unavailable');
+    assert.equal(seen.bus, null);
+    assert.equal(seen.retry, 'function');
+    assert.match(seen.cause, /transport is not installed/);
+  });
+});
+
+describe('never-throwing', { ...needsBroker }, () => {
+  test('a nonexistent socket answers null, and names ENOENT when required', async () => {
+    await withAddress(
+      'unix:path=/nonexistent/react-x11-no-such-bus',
+      async () => {
+        assert.equal(await sessionBus(), null);
+        await assert.rejects(
+          () => sessionBus({ required: true }),
+          (err) => {
+            assert.ok(err instanceof BusUnavailableError);
+            assert.equal(err.kind, 'session');
+            // The cause distinguishes this from "no address at all".
+            assert.equal(err.cause.code, 'ENOENT');
+            return true;
+          },
+        );
+      },
+    );
+  });
+
+  test('no address at all answers null, with a different cause', async () => {
+    const saved = {
+      addr: process.env.DBUS_SESSION_BUS_ADDRESS,
+      runtime: process.env.XDG_RUNTIME_DIR,
+      platform: process.platform,
+    };
+    delete process.env.DBUS_SESSION_BUS_ADDRESS;
+    delete process.env.XDG_RUNTIME_DIR;
+    // The no-address path is a Linux/BSD one: darwin has launchd to fall back
+    // to, so there is always an address to try there.
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    try {
+      assert.equal(await sessionBus(), null);
+      await assert.rejects(
+        () => sessionBus({ required: true }),
+        (err) => {
+          assert.ok(err instanceof BusUnavailableError);
+          assert.match(err.cause.message, /no session bus address/);
+          assert.equal(err.cause.code, undefined);
+          return true;
+        },
+      );
+    } finally {
+      Object.defineProperty(process, 'platform', { value: saved.platform });
+      if (saved.addr !== undefined)
+        process.env.DBUS_SESSION_BUS_ADDRESS = saved.addr;
+      if (saved.runtime !== undefined)
+        process.env.XDG_RUNTIME_DIR = saved.runtime;
+      _resetBusState();
+    }
+  });
+});
+
+describe('against a broker', { ...needsBroker }, () => {
+  test('lazy: the first acquisition is what dials', async () => {
+    await withBus(async (address, broker) => {
+      assert.equal(broker.liveClients, 0, 'importing dialled nothing');
+      const ref = await sessionBus();
+      assert.ok(ref, 'connected to the broker');
+      assert.equal(broker.liveClients, 1);
+      await ref.release();
+    });
+  });
+
+  test('name-ready: uniqueName is a string with no extra awaiting', async () => {
+    await withBus(async () => {
+      const ref = await sessionBus();
+      assert.match(ref.uniqueName, /^:/);
+      assert.equal(ref.uniqueName, ref.bus.name);
+      await ref.release();
+    });
+  });
+
+  test('shared: two acquisitions are one socket and one identity', async () => {
+    await withBus(async (address, broker) => {
+      const [a, b] = await Promise.all([sessionBus(), sessionBus()]);
+      assert.equal(broker.liveClients, 1, 'one client on the broker');
+      assert.equal(a.bus, b.bus);
+      assert.equal(a.uniqueName, b.uniqueName);
+      await a.release();
+      await b.release();
+    });
+  });
+
+  test('concurrent acquisitions share one connect attempt', async () => {
+    await withBus(async (address, broker) => {
+      const refs = await Promise.all(
+        Array.from({ length: 8 }, () => sessionBus()),
+      );
+      assert.equal(broker.liveClients, 1);
+      assert.equal(new Set(refs.map((r) => r.uniqueName)).size, 1);
+      await Promise.all(refs.map((r) => r.release()));
+    });
+  });
+
+  test('session and system are separate connections', async () => {
+    await withBus(async (address, broker) => {
+      process.env.DBUS_SYSTEM_BUS_ADDRESS = address;
+      const s = await sessionBus();
+      const y = await systemBus();
+      assert.equal(broker.liveClients, 2);
+      assert.notEqual(s.uniqueName, y.uniqueName);
+      await s.release();
+      await y.release();
+    });
+  });
+
+  test('no churn on release: the connection survives zero refs', async () => {
+    await withBus(async (address, broker) => {
+      const first = await sessionBus();
+      const name = first.uniqueName;
+      await first.release();
+      // The lifecycle decision, made falsifiable: closing at zero refs would
+      // show up here as a dropped client and a new unique name below.
+      assert.equal(broker.liveClients, 1, 'still connected at zero refs');
+      const second = await sessionBus();
+      assert.equal(second.uniqueName, name, 'same identity');
+      assert.equal(broker.liveClients, 1, 'no new client');
+      await second.release();
+    });
+  });
+
+  test('release() is idempotent per ref', async () => {
+    await withBus(async (address, broker) => {
+      const a = await sessionBus();
+      const b = await sessionBus();
+      await a.release();
+      await a.release();
+      await a.release();
+      // If the extra releases had decremented, the count would be at zero and
+      // b's would take it negative — which nothing would notice until an
+      // unref'd socket let the process exit under a live consumer.
+      assert.equal(broker.liveClients, 1);
+      await b.release();
+      assert.equal(broker.liveClients, 1);
+    });
+  });
+
+  test('asyncDispose releases', async () => {
+    await withBus(async () => {
+      let captured;
+      {
+        const ref = await sessionBus();
+        captured = ref;
+        await ref[Symbol.asyncDispose]();
+      }
+      // A second dispose is the same idempotent release.
+      await captured[Symbol.asyncDispose]();
+    });
+  });
+
+  test('retry is not cached: a bus that appears later is found', async () => {
+    // A failed attempt answers its waiters and is forgotten. A session bus can
+    // genuinely appear later — $XDG_RUNTIME_DIR/bus exists the moment
+    // something starts one — so a transient failure must never become a
+    // process-lifetime false negative.
+    const socket = await reservedSocket();
+    let broker = null;
+    try {
+      await withAddress(`unix:path=${socket}`, async () => {
+        assert.equal(await sessionBus(), null, 'nothing listening yet');
+        broker = await startBroker({ socket });
+        const ref = await sessionBus();
+        assert.ok(ref, 'the second attempt connects');
+        await ref.release();
+      });
+    } finally {
+      if (broker) await stopBroker(broker);
+    }
+  });
+
+  test('generation on death: old refs stay harmless, a new one connects', async () => {
+    const socket = await reservedSocket();
+    let broker = await startBroker({ socket });
+    try {
+      await withAddress(`unix:path=${socket}`, async () => {
+        const old = await sessionBus();
+        const oldName = old.uniqueName;
+
+        await stopBroker(broker);
+        await until(
+          () => old.bus.connection.stream.destroyed,
+          'the connection to notice the broker went away',
+        );
+
+        // A call on the dead ref fails rather than hanging for a reply that
+        // cannot arrive.
+        await assert.rejects(() => old.bus.listNames());
+        // ...and releasing it is still safe.
+        await old.release();
+
+        broker = await startBroker({ socket });
+        const fresh = await sessionBus();
+        assert.ok(fresh, 'a fresh acquisition dials a new socket');
+        // Identity is asserted on the connection rather than on the name: a
+        // broker that restarts also restarts its own `:1.N` counter, so the
+        // *name* would collide here for a reason that has nothing to do with
+        // this layer. The name change is pinned in the next test, against a
+        // broker that stays up.
+        assert.notEqual(fresh.bus, old.bus, 'a new connection object');
+        assert.match(oldName, /^:/);
+        await fresh.release();
+      });
+    } finally {
+      await stopBroker(broker);
+    }
+  });
+
+  test('a connection that dies under a live bus comes back as a new name', async () => {
+    // The reason reconnect stays off and a death retires the generation: the
+    // replacement is a different client as far as the bus is concerned, so
+    // anything holding the old unique name is talking to nobody.
+    await withBus(async (address, broker) => {
+      const old = await sessionBus();
+      const oldName = old.uniqueName;
+      old.bus.connection.stream.destroy();
+      await until(() => broker.liveClients === 0, 'the client to go away');
+
+      const fresh = await sessionBus();
+      assert.notEqual(fresh.uniqueName, oldName, 'a new socket is a new name');
+      assert.equal(broker.liveClients, 1);
+      // The old ref never becomes dangerous: its calls fail and it releases.
+      await assert.rejects(() => old.bus.listNames());
+      await old.release();
+      await fresh.release();
+    });
+  });
+
+  test('closeBus() drops the connection and a later acquisition redials', async () => {
+    await withBus(async (address, broker) => {
+      const first = await sessionBus();
+      const name = first.uniqueName;
+      await closeBus('session');
+      await until(
+        () => broker.liveClients === 0,
+        'the broker to see the client go',
+      );
+      // The retired ref releases without disturbing the new generation.
+      await first.release();
+      const second = await sessionBus();
+      assert.notEqual(second.uniqueName, name);
+      assert.equal(broker.liveClients, 1);
+      await second.release();
+    });
+  });
+
+  test('closeBus() rejects a kind that is not a bus', async () => {
+    await assert.rejects(
+      () => closeBus('sesion'),
+      /expected "session" or "system"/,
+    );
+  });
+});
+
+describe('the event-loop hold', { ...needsBroker }, () => {
+  // Both halves of the ref/unref rule, as process exit — which is the only
+  // place the difference is observable.
+  test('a process that releases exits; one that holds does not', async () => {
+    const broker = await startBroker();
+    try {
+      const address = broker.address();
+      const released = await runScript(
+        `
+        import { sessionBus } from './src/bus.js';
+        const ref = await sessionBus();
+        if (!ref) { console.error('no bus'); process.exit(5); }
+        await ref.release();
+        console.log('released');
+        `,
+        { DBUS_SESSION_BUS_ADDRESS: address },
+      );
+      assert.equal(released.code, 0, released.stderr);
+      assert.match(released.stdout, /released/);
+
+      // The same script without the release has nothing else keeping the loop
+      // alive — no timer, no listener — so if it is still running when the
+      // kill lands, it is the ref'd socket holding it. A serving app is this
+      // shape, which is why the hold is conditional on the count rather than
+      // an unconditional unref.
+      const held = await runScript(
+        `
+        import { sessionBus } from './src/bus.js';
+        const ref = await sessionBus();
+        if (!ref) { console.error('no bus'); process.exit(5); }
+        console.log('held');
+        `,
+        { DBUS_SESSION_BUS_ADDRESS: address },
+        [],
+        3000,
+      );
+      assert.match(held.stdout, /held/);
+      assert.ok(
+        held.error && (held.error.killed || held.error.signal),
+        'a held ref keeps the process alive until it is killed, got ' +
+          JSON.stringify({ code: held.code, stderr: held.stderr }),
+      );
+    } finally {
+      await stopBroker(broker);
+    }
+  });
+});
+
+describe('the hooks', { ...needsBroker }, () => {
+  test('mount reports connecting, then ready with a unique name', async () => {
+    await withBus(async () => {
+      const seen = [];
+      function Probe() {
+        const handle = useSessionBus();
+        seen.push(handle);
+        return React.createElement('text', null, handle.status);
+      }
+      const { unmount } = await renderX11(React.createElement(Probe), {
+        backend: 'mock',
+      });
+      assert.equal(seen[0].status, 'connecting');
+      assert.equal(seen[0].bus, null);
+      await untilRendered(
+        () => seen.at(-1).status === 'ready',
+        'the hook to reach ready',
+      );
+      const ready = seen.at(-1);
+      assert.equal(ready.status, 'ready');
+      assert.ok(ready.bus);
+      assert.match(ready.uniqueName, /^:/);
+      await unmount();
+      await cleanup();
+    });
+  });
+
+  test('the hook does not churn the connection', async () => {
+    await withBus(async (address, broker) => {
+      function Probe() {
+        const { status } = useSessionBus();
+        return React.createElement('text', null, status);
+      }
+      let name = null;
+      for (let i = 0; i < 4; i++) {
+        const { unmount } = await renderX11(React.createElement(Probe), {
+          backend: 'mock',
+        });
+        await untilRendered(
+          () => broker.liveClients === 1,
+          'a client on the broker',
+        );
+        const ref = await sessionBus();
+        name ??= ref.uniqueName;
+        // The React-level statement of "no churn on release": StrictMode's
+        // double-mount and a dialog that opens and closes are the same shape.
+        assert.equal(ref.uniqueName, name, 'same identity across mounts');
+        assert.equal(broker.liveClients, 1, 'one client throughout');
+        await ref.release();
+        await unmount();
+      }
+      await cleanup();
+      assert.equal(broker.liveClients, 1);
+    });
+  });
+
+  test('a dead connection moves the hook to closed, and retry() recovers', async () => {
+    const socket = await reservedSocket();
+    let broker = await startBroker({ socket });
+    try {
+      await withAddress(`unix:path=${socket}`, async () => {
+        const seen = [];
+        function Probe() {
+          const handle = useSessionBus();
+          seen.push(handle);
+          return React.createElement('text', null, handle.status);
+        }
+        const { unmount } = await renderX11(React.createElement(Probe), {
+          backend: 'mock',
+        });
+        await untilRendered(() => seen.at(-1).status === 'ready', 'ready');
+
+        await stopBroker(broker);
+        await untilRendered(() => seen.at(-1).status === 'closed', 'closed');
+        // Deliberately no auto-retry: a silent re-acquire would hand the
+        // consumer a fresh bus under the same variable and hide the
+        // unique-name change that disabling reconnect exists to expose.
+        assert.equal(seen.at(-1).bus, null);
+
+        broker = await startBroker({ socket });
+        const mark = seen.length;
+        await act(async () => {
+          seen.at(-1).retry();
+        });
+        await untilRendered(
+          () => seen.at(-1).status === 'ready',
+          'ready again',
+        );
+        // A retry goes back through 'connecting' rather than leaving the dead
+        // connection on screen until the new dial settles — asserted on the
+        // render sequence, since how fast the dial lands is not the point.
+        assert.equal(seen.slice(mark).map((h) => h.status)[0], 'connecting');
+        assert.match(seen.at(-1).uniqueName, /^:/);
+        await unmount();
+        await cleanup();
+      });
+    } finally {
+      await stopBroker(broker);
+    }
+  });
+
+  test('no bus at all reports unavailable with a cause, and stays retryable', async () => {
+    await withAddress(
+      'unix:path=/nonexistent/react-x11-no-such-bus',
+      async () => {
+        const seen = [];
+        function Probe() {
+          const handle = useSessionBus();
+          seen.push(handle);
+          return React.createElement('text', null, handle.status);
+        }
+        const { unmount } = await renderX11(React.createElement(Probe), {
+          backend: 'mock',
+        });
+        await untilRendered(
+          () => seen.at(-1).status === 'unavailable',
+          'unavailable',
+        );
+        const handle = seen.at(-1);
+        assert.equal(handle.bus, null);
+        assert.ok(handle.cause instanceof BusUnavailableError);
+        assert.equal(typeof handle.retry, 'function');
+        await unmount();
+        await cleanup();
+      },
+    );
+  });
+});

--- a/test/helpers/no-dbus-loader.mjs
+++ b/test/helpers/no-dbus-loader.mjs
@@ -1,0 +1,13 @@
+// The resolve hook behind no-dbus.mjs: `dbus-native` is not installed here.
+// Fails with the code and shape npm's own skip produces, so the code under
+// test takes exactly the branch it would take on Node 20.
+export async function resolve(specifier, context, next) {
+  if (specifier === 'dbus-native' || specifier.startsWith('dbus-native/')) {
+    const err = new Error(
+      `Cannot find package 'dbus-native' imported from ${context.parentURL}`,
+    );
+    err.code = 'ERR_MODULE_NOT_FOUND';
+    throw err;
+  }
+  return next(specifier, context);
+}

--- a/test/helpers/no-dbus.mjs
+++ b/test/helpers/no-dbus.mjs
@@ -1,0 +1,11 @@
+// Make `dbus-native` unresolvable in a child process, so the Node 20 install
+// — where npm skips the optional dependency because its own engines field is
+// `>=22.12.0` — can be tested on every Node rather than only on the one leg of
+// the matrix where it happens to be true.
+//
+// `module.register` rather than `module.registerHooks`: the async form has
+// been there since Node 20.6, and this has to run on the oldest supported
+// Node.
+import { register } from 'node:module';
+
+register('./no-dbus-loader.mjs', import.meta.url);

--- a/test/helpers/with-bus.js
+++ b/test/helpers/with-bus.js
@@ -1,0 +1,112 @@
+// A message bus for a test, in this process.
+//
+// `dbus-native`'s `createBroker()` is a real bus — name ownership,
+// org.freedesktop.DBus, routing — so nothing here needs dbus-daemon installed
+// or a session to be logged into. The harness starts one, points
+// `DBUS_SESSION_BUS_ADDRESS` at it, runs the test, and then unwinds
+// everything it caused, on pass and on fail alike.
+//
+// **The env var is the seam on purpose.** It is how D-Bus itself says "use
+// this bus", so the code under test carries no test-only injection path —
+// `src/bus.js` reads exactly what a real deployment reads.
+//
+// The hard close at the end follows from the lifecycle: draining refs no
+// longer closes the socket, so without it a connection would survive between
+// tests carrying match rules and exported objects. That is the harness
+// closing what the harness caused, not a seam into production code.
+
+import { _resetBusState, closeBus } from '../../src/bus.js';
+
+/**
+ * The transport, loaded on demand — this file is imported by a suite that has
+ * to *run* on Node 20, where `dbus-native` is legitimately not installed and a
+ * static import would fail before a single test could skip itself.
+ */
+export async function transportAvailable() {
+  try {
+    await import('dbus-native');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Start a broker, run `fn` against it, and clean up.
+ *
+ * ```js
+ * await withBus(async (address, broker) => {
+ *   const ref = await sessionBus();
+ *   assert.equal(broker.liveClients, 1);
+ * });
+ * ```
+ *
+ * `broker.liveClients` is maintained here rather than by the broker: how many
+ * sockets are open is the question most of these tests are actually asking,
+ * and counting it from the outside keeps the assertion honest.
+ *
+ * Only `DBUS_SESSION_BUS_ADDRESS` is pointed at the broker. A test that wants
+ * the system bus there too can assign `DBUS_SYSTEM_BUS_ADDRESS` inside `fn`;
+ * both are restored afterwards.
+ *
+ * @param {(address: string, broker: any) => Promise<void>} fn
+ */
+export async function withBus(fn) {
+  const broker = await startBroker();
+  const savedSession = process.env.DBUS_SESSION_BUS_ADDRESS;
+  const savedSystem = process.env.DBUS_SYSTEM_BUS_ADDRESS;
+  process.env.DBUS_SESSION_BUS_ADDRESS = broker.address();
+  try {
+    await fn(broker.address(), broker);
+  } finally {
+    restore('DBUS_SESSION_BUS_ADDRESS', savedSession);
+    restore('DBUS_SYSTEM_BUS_ADDRESS', savedSystem);
+    await closeBus('session').catch(() => {});
+    await closeBus('system').catch(() => {});
+    _resetBusState();
+    await stopBroker(broker);
+  }
+}
+
+function restore(name, value) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+/** A listening broker, with a live client count attached. */
+export async function startBroker(where) {
+  const dbus = (await import('dbus-native')).default;
+  const broker = dbus.createBroker();
+  broker.liveClients = 0;
+  broker.on('connection', () => broker.liveClients++);
+  broker.on('disconnect', () => broker.liveClients--);
+  // A client that dies rudely is a normal thing for these tests to cause;
+  // without a listener it would be an unhandled 'error' on an EventEmitter.
+  broker.on('clientError', () => {});
+  broker.on('error', () => {});
+  return new Promise((resolve, reject) => {
+    broker.listen(where, (err, address) => {
+      if (err) return reject(err);
+      broker.on('listening', () => {});
+      resolve(Object.assign(broker, { addressString: address }));
+    });
+  });
+}
+
+export function stopBroker(broker) {
+  return new Promise((resolve) => broker.close(resolve));
+}
+
+/**
+ * Wait for a condition, or fail with something more useful than a timeout.
+ * Bus state settles across ticks and socket events, not synchronously.
+ */
+export async function until(predicate, message, timeout = 2000) {
+  const deadline = Date.now() + timeout;
+  for (;;) {
+    if (await predicate()) return;
+    if (Date.now() > deadline)
+      throw new Error(`timed out waiting for ${message}`);
+    await new Promise((r) => setTimeout(r, 10));
+  }
+}

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -8,12 +8,25 @@
  */
 import React, { useRef, useState } from 'react';
 import { startTrace } from 'react-x11/debug';
+import type {
+  BusHandle,
+  BusKind,
+  BusRef,
+  BusStatus,
+  MessageBus,
+} from 'react-x11';
 import {
   Button,
+  BusUnavailableError,
   Canvas3D,
   Checkbox,
+  closeBus,
+  sessionBus,
+  systemBus,
   useApp,
   useClipboard,
+  useSessionBus,
+  useSystemBus,
   ContextMenu,
   createRoot,
   createStyles,
@@ -574,6 +587,48 @@ function _Clip() {
   return null;
 }
 
+// the bus floor: the hooks, the imperative pair, and the `required` overload
+function _Bus() {
+  const session: BusHandle = useSessionBus();
+  const system = useSystemBus();
+
+  // The terse path has to type-check on its own — no `status` in sight.
+  if (!session.bus) return null;
+
+  const status: BusStatus = session.status;
+  const name: string | null = session.uniqueName;
+  const why: BusUnavailableError | undefined = system.cause;
+  const kind: BusKind | undefined = why?.kind;
+  session.retry();
+
+  async function go() {
+    // The default answers null, so the null check is not optional.
+    const ref = await sessionBus();
+    if (ref) {
+      const bus: MessageBus = ref.bus;
+      const unique: string = ref.uniqueName;
+      const names: string[] = await bus.listNames();
+      // Anything else on the dbus-native surface stays reachable.
+      await bus.exportInterface({}, '/org/example', {});
+      await ref.release();
+      void [unique, names];
+    }
+    // @ts-expect-error — null until it is checked
+    (await systemBus()).release();
+
+    // `required` narrows away the null.
+    const required: BusRef = await sessionBus({ required: true });
+    await required[Symbol.asyncDispose]();
+
+    await closeBus('session');
+    // @ts-expect-error — not a bus
+    await closeBus('accessibility');
+  }
+  void go;
+  return null;
+}
+
+void _Bus;
 void _Clip;
 void main;
 void grow;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "ESNext.Disposable"],
     "jsx": "react-jsx",
     "jsxImportSource": "react-x11",
     "strict": true,

--- a/website/scripts/build-demo-bundles.mjs
+++ b/website/scripts/build-demo-bundles.mjs
@@ -154,6 +154,11 @@ await esbuild.build({
     keysym: path.join(shimsDir, 'keysym.js'),
     // heavy optional ntk dep no demo needs
     pngjs: path.join(stubsDir, 'pngjs.js'),
+    // The D-Bus transport: node-only, dynamically imported by src/bus.js, and
+    // six node builtins deep. The stub throws on import, which is the same
+    // answer a Node 20 install gives — see the file for why that is the right
+    // shape rather than an inert proxy.
+    'dbus-native': path.join(stubsDir, 'dbus-native.js'),
   },
 });
 

--- a/website/scripts/stubs/dbus-native.js
+++ b/website/scripts/stubs/dbus-native.js
@@ -1,0 +1,21 @@
+// Stand-in for the D-Bus transport, which is node-only by construction: it
+// dials a unix socket and reaches for `child_process`, `crypto`, `net` and
+// `stream`. `src/bus.js` imports it *dynamically*, inside the first
+// acquisition, so nothing in the browser bundle needs it — but esbuild
+// follows a dynamic import all the same, and pulling it in fails the build on
+// six node builtins that have no browser answer.
+//
+// Throwing from the module body rather than handing back an inert proxy is
+// deliberate: it is exactly what `await import('dbus-native')` does on a Node
+// 20 install, where npm skipped the optional dependency. `loadTransport()`
+// turns that rejection into a `BusUnavailableError` whose cause says the
+// transport is missing, `sessionBus()` answers `null`, and `useSessionBus()`
+// reports `'unavailable'`. So the playground is not a special case with a
+// stub bolted on — it is a genuine instance of the "there is no bus here"
+// configuration docs/dbus.md calls first-class, and a demo that calls the
+// hooks renders the same fallback it would over ssh.
+throw new Error(
+  'react-x11 playground: there is no D-Bus in a browser, so the transport ' +
+    'is not bundled. This is the same path a Node 20 install takes — ' +
+    'useSessionBus() reports "unavailable" and sessionBus() answers null.',
+);

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -186,6 +186,7 @@ const ORDER = [
   'extending.md',
   'testing.md',
   'desktop.md',
+  'dbus.md',
   'remote.md',
   'security.md',
   'packaging.md',


### PR DESCRIPTION
Closes #163.

Everything the desktop wants from an app beyond drawing — a native file dialog, the light/dark preference, notifications, a global menu, a tray icon — is a D-Bus call, and react-x11 had no bus. This adds one and stops there. No service is spoken to; the only traffic this layer generates is its own handshake.

```jsx
import { useSessionBus } from 'react-x11';

function ColourScheme() {
  const { bus } = useSessionBus();
  if (!bus) return null;   // no bus here — nothing to read a preference from
  // ...call org.freedesktop.portal.Settings through `bus`
}
```

**Nothing to wrap.** No provider, no prop drilling, no setup step for the app author — which is what makes a component library able to call it.

## The rule everything else is subordinate to

**Nothing throws at import time, and nothing crashes an app running where there is no session bus.** That has to hold on XQuartz, under a bare `startx`, in CI, in an ssh session, in a container, and on Node 20 where the transport is not installed at all. The ssh case is not an edge case — it is react-x11's flagship persona, so **"no bus" is a first-class configuration, not a degraded one**.

`dbus-native`'s `createStream` throws `unknown bus address` *synchronously* when `DBUS_SESSION_BUS_ADDRESS` is unset, which is most of those environments. `sessionBus()` absorbs it and answers `null`; `useSessionBus()` reports `'unavailable'` with the reason in `cause`.

Here is the same example with both buses pointed at nothing — it opens and explains itself rather than dying:

![the explorer with both buses pointed at nothing: red dots, 'unavailable', the ENOENT reason, and a Retry button](https://github.com/user-attachments/assets/1c12e23a-4db1-4b24-9148-cedeb887d44e)

## Packaging: one line

```json
"optionalDependencies": { "dbus-native": "^0.15.1" }
```

`dbus-native` declares `engines: ">=22.12.0"` where core declares `">=20.19"`, and npm already treats an engine-mismatched optional dependency as skippable. So a Node 20 user installs exactly as before and gets no D-Bus stack; `.github/workflows/ci.yml`'s `[20, 22, 24]` matrix is untouched and the Node 20 leg becomes the degradation test. **"No transport installed" collapses into "no bus here" rather than adding a mode.**

What it genuinely costs, stated plainly: every user on Node 22+ now downloads `dbus-native` and `xml2js`. One dependency with one dependency, no `gypfile` and no install script, so `npm i react-x11` still needs no compiler — but a Mac user's install is no longer free of Linux-shaped code.

## Design decisions worth the diff

- **One connection per bus, shared and ref-counted.** `dbus-native`'s own `sessionBus()` is a constructor in disguise — every call opens a socket with its own unique name, so a menu, a tray and an app's own exported service would be three half-applications as far as the desktop is concerned. A D-Bus connection is *process* identity. That is also why these hooks need no provider where `useApp()` does: the X connection really is per-tree, but two roots on two displays still share one session bus.
- **Connect on first use, stay connected.** The ref count drives the socket's **event-loop hold** (`ref()`/`unref()`), not its existence. Closing at zero refs would make a file dialog that mounts on click and unmounts on dismiss cost the app a *new unique name* every time, with the daemon forgetting match rules and well-known names along with the old connection. `closeBus()` is the explicit way out; it is never the automatic consequence of an unmount.
- **Name-ready.** `bus.name` is assigned in the `Hello` reply callback, so it is not set when the constructor returns. Acquisition awaits one `ListNames` round trip as an ordering barrier, so `uniqueName` is always a string — otherwise the first consumer to derive state from the app's own identity (#129's portal `Request` paths) computes a path with `undefined` in it.
- **A dead connection is not resurrected.** Reconnect stays off. The generation retires: old refs fail their calls with `ConnectionClosedError` and `release()` harmlessly, mounted hooks move to `'closed'`, and `retry()` is explicit — a silent re-acquire would hand you a fresh `bus` under the same variable and hide exactly the unique-name change that disabling reconnect exists to expose.
- **Failure is not cached.** A session bus can appear later, the moment something creates `$XDG_RUNTIME_DIR/bus`. `'unavailable'` is a snapshot, not a verdict, and the docs say so because the name invites the opposite reading.
- **This layer owns the connection's one `'error'` listener.** `dbus-native` deliberately attaches none — an unlistened `'error'` crashing the process is the right contract for a caller-owned connection and the wrong one for a shared one.

## Tests

`test/bus.test.js` — 24 tests over a `createBroker()`-backed harness (`test/helpers/with-bus.js`), so nothing needs `dbus-daemon` or a login session:

| | |
| --- | --- |
| import safety | a child process imports `react-x11` with no address and asserts `dbus-native` never reaches `require.cache` |
| lazy / shared | zero broker clients after import, one after the first acquisition, one across eight concurrent ones |
| no churn on release | release every ref — the broker still sees the connection, and re-acquiring gets the same unique name |
| the event-loop hold | a child that releases exits on its own; one that holds a ref does not. Both halves |
| name-ready | `uniqueName` matches `/^:/` with no extra awaiting by the caller |
| never-throwing | a dead socket and a missing address both answer `null`, with `required: true` distinguishing them by `cause` |
| transport absent | `dbus-native` forced unresolvable via a `module.register` hook — **runs on every Node**, so the Node 20 configuration is tested everywhere rather than only on that leg |
| retry-not-cached | a failed acquisition, then a broker started at that address, then one that connects |
| generation-on-death | stop the broker under live refs; their calls fail, `release()` still succeeds, a fresh acquisition dials a new socket |
| hook states | `'connecting'` → `'ready'`; `'unavailable'` with a cause; `'closed'` on a dead daemon and `retry()` recovering; and repeated mount/unmount leaving the broker with one client throughout |

`npm test` — 531/531. `npm run typecheck` — clean, **and clean with `node_modules/dbus-native` removed**, which is the Node 20 install. That is why `src/types/dbus.d.ts` vendors `MessageBus` structurally instead of importing it: this repo type-checks with `skipLibCheck: false`, so a hard `import type` from an uninstalled package would fail. The index signature over the rest of the surface keeps every `dbus-native` method reachable.

`tsconfig.json` gains `ESNext.Disposable` to `lib`, for `Symbol.asyncDispose` on `BusRef`.

## The example — `npm run examples:dbus`

Both buses in the header, a `Tree` of names → objects → interfaces built from live introspection, and a right-hand pane of detail. Names come from `ListNames`; objects and interfaces from `Introspect`, one round trip per node, loaded lazily on expansion with `loading…` on the frame the click landed on.

![the session bus expanded into its bus names, with the connection detail pane on the right](https://github.com/user-attachments/assets/80581be7-9cc4-495e-83b1-503f02b2b1e4)

Selecting an object lists its interfaces with member counts; selecting an interface shows methods with their input signatures, signals with argument names, and properties — whose **values** are read on demand with one `GetAll`, because reading them is observable to the service.

![an object's interfaces, with member counts per interface](https://github.com/user-attachments/assets/14fd1cbd-4a1c-4dca-a431-22b64f9f6849)
![an interface pane showing methods, signals and live property values read with one GetAll](https://github.com/user-attachments/assets/5dbf8551-0c45-451f-84f9-da53e53117a5)

Three things shaped that code: object paths are a namespace rather than a hierarchy anyone arranged, so `compressPath` skips the `/` → `/org` → `/org/a11y` scaffolding and shows where it lands; a service can simply not answer, so every call is raced against a deadline and a failure becomes a row you can read rather than a spinner forever; and **nothing in the example imports `dbus-native`** — not the value formatter, not the signature reader — because an example that did would crash on exactly the install it exists to demonstrate.

Screenshots are rendered by this PR's own code, against the real session and system buses, through `react-x11/test` and node-x11's in-process X server.

## Follow-ups this unblocks

#129 (portal floor) and, behind it, #111 (file dialog). Both are written against the withdrawn `@react-x11/desktop` import paths and want updating to `react-x11` now that this landed in core.

Two sharp edges are documented rather than fixed, both upstream: sidorares/dbus-native#393 (a daemon that authenticates and never answers `Hello` throws from a timer tick where nothing can catch it — the one crash this layer cannot absorb) and sidorares/dbus-native#394 (match-rule refcounting, dormant while reconnect is off).

