### PR TITLE
feat(filedialog): open, save and pick a folder, on whatever the machine has

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,10 @@
   `sessionBus()` pair underneath, why one process is one connection and one
   identity, and why "there is no bus" is a first-class configuration rather
   than an error.
+- [filedialog.md](filedialog.md) — open, save and pick a folder:
+  `useFileDialog()`, the three-rung ladder (the desktop's own portal,
+  `osascript` on macOS, a browser react-x11 draws itself), why cancelling is
+  `null` rather than a throw, and the places the backends genuinely differ.
 - [remote.md](remote.md) — the flagship case: running the app on one
   machine and drawing to a display on another. `ssh -X` vs `-Y`, what the
   protocol costs on a link, the other X servers, and why Xwayland works

--- a/docs/filedialog.md
+++ b/docs/filedialog.md
@@ -5,8 +5,8 @@ Open a file, save a file, pick a folder — on whatever the machine has.
 ```jsx
 import { useFileDialog } from 'react-x11';
 
-function Toolbar({ windowRef }) {
-  const { openFile } = useFileDialog({ parentWindow: windowRef });
+function Toolbar() {
+  const { openFile } = useFileDialog();
 
   return (
     <Button
@@ -66,14 +66,38 @@ draw in — so it never runs out of rungs and never rejects for lack of a dialog
 | `defaultFolder`               | where it opens                                    |
 | `defaultName` / `defaultPath` | what a save dialog starts on                      |
 | `acceptLabel`                 | the confirm button's text — 'Import', 'Attach', … |
-| `parentWindow`                | a `<window>` ref or XID — see below               |
+| `parentWindow`                | override the owner window; inferred otherwise     |
 | `signal`                      | an `AbortSignal` that closes the dialog           |
 | `backend`                     | force a rung; the seam for a kiosk, and for tests |
 
 Options given to the hook are defaults for every call; options given to a call
 win.
 
-### `parentWindow` is worth the one line
+### The dialog parents itself
+
+The dialog is `transientFor` the window the component is in — `parent_window`
+for the portal — which is what makes the window manager treat it as belonging
+to your window: stacked above it, and not a second entry in the task switcher.
+
+**You do not pass anything for that.** `useFileDialog()` resolves the owner
+window through `useTopLevelWindow()` at the moment a dialog opens, by which
+time the window is mounted and has an XID.
+
+Why inference rather than a lookup: a hook has no position in the host tree.
+React context cannot come from a host element, the host context
+`getChildHostContext` builds reaches `createInstance` and not components, and a
+`<window>` has no XID until the commit phase. So it answers from what the
+renderer does know — the top-level windows this connection is rendering:
+
+- **one top-level window is exact.** The component is in it, because there is
+  nowhere else to be. That is nearly every app.
+- several, one focused: that one. You clicked in it a moment ago, which is why
+  a dialog is opening.
+- several with nothing to separate them: the most recently opened, plus a
+  development warning naming `parentWindow` as the way to be exact.
+
+So `parentWindow` survives as the **override for multi-window apps**, and takes
+a `<window>` ref, an XID, or anything `windowIdOf()` accepts:
 
 ```jsx
 const win = useRef(null);
@@ -81,10 +105,10 @@ const { openFile } = useFileDialog({ parentWindow: win });
 return <window ref={win}>…</window>;
 ```
 
-It becomes `transientFor` on the built-in dialog and `parent_window` on the
-portal, which is what makes the window manager treat the dialog as belonging to
-your window — stacked above it, and not a second entry in the task switcher.
-Without it the dialog floats: legal, and it looks careless.
+`useTopLevelWindow()` is exported for anything else that needs the owner
+window. It returns a **ref-like object** — the window is not realized on the
+first render, so a value read then would be `null` on the render that matters —
+which drops into `parentWindow`, `transientFor`, or `windowIdOf()`.
 
 **The portal never embeds the dialog.** It is a top-level window in another
 process, and logical parenting is all there is. There is no version of this

--- a/docs/filedialog.md
+++ b/docs/filedialog.md
@@ -1,0 +1,181 @@
+# File dialogs
+
+Open a file, save a file, pick a folder — on whatever the machine has.
+
+```jsx
+import { useFileDialog } from 'react-x11';
+
+function Toolbar({ windowRef }) {
+  const { openFile } = useFileDialog({ parentWindow: windowRef });
+
+  return (
+    <Button
+      label="Open…"
+      onPress={async () => {
+        const files = await openFile({
+          filters: [{ name: 'Markdown', extensions: ['md'] }],
+        });
+        if (!files) return; // cancelled
+        load(files[0]);
+      }}
+    />
+  );
+}
+```
+
+Cancelling resolves to `null`. It is an ordinary outcome, not an exception, on
+every backend — so the whole error path for a file dialog is one `if`.
+
+## The ladder
+
+There is no single answer to "show a file dialog" on a machine running X11, so
+this is a ladder and the rung is chosen for you:
+
+|     |                         |                                                                                                                                                                |
+| --- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | **the portal**          | `org.freedesktop.portal.FileChooser` over D-Bus. The desktop's own dialog, drawn by GTK or KDE in another process, with the user's bookmarks and recent files. |
+| 2   | **`osascript`**         | macOS with no portal — which is every XQuartz install that has not gone out of its way. `choose file` _is_ `NSOpenPanel`.                                      |
+| 3   | **the built-in dialog** | A browser react-x11 draws itself. ssh, a bare `startx`, a container: everywhere there is a display and nothing else.                                           |
+
+`fileDialogBackend()` reports which one this machine lands on, without showing
+anything — useful for a diagnostics panel, and for a menu that wants to say so.
+
+**The ladder is the design, not a fallback chain bolted on.** react-x11's
+flagship case is an app running on one machine and drawing to another, and a
+file dialog that only worked on a full GNOME session would be useless to
+exactly the person the renderer exists for.
+
+## `useFileDialog()`
+
+```ts
+const { openFile, saveFile, selectFolder } = useFileDialog(defaults?);
+
+openFile(options?): Promise<string[] | null>;    // absolute paths
+saveFile(options?): Promise<string | null>;      // one path, may not exist yet
+selectFolder(options?): Promise<string[] | null>;
+```
+
+The hook is the surface to reach for, because it is the only one with a tree to
+draw in — so it never runs out of rungs and never rejects for lack of a dialog.
+
+| option                        |                                                   |
+| ----------------------------- | ------------------------------------------------- |
+| `title`                       | the dialog's title                                |
+| `multiple`                    | several files at once; ignored when saving        |
+| `filters`                     | `{ name, extensions?, mimeTypes? }[]`             |
+| `defaultFolder`               | where it opens                                    |
+| `defaultName` / `defaultPath` | what a save dialog starts on                      |
+| `acceptLabel`                 | the confirm button's text — 'Import', 'Attach', … |
+| `parentWindow`                | a `<window>` ref or XID — see below               |
+| `signal`                      | an `AbortSignal` that closes the dialog           |
+| `backend`                     | force a rung; the seam for a kiosk, and for tests |
+
+Options given to the hook are defaults for every call; options given to a call
+win.
+
+### `parentWindow` is worth the one line
+
+```jsx
+const win = useRef(null);
+const { openFile } = useFileDialog({ parentWindow: win });
+return <window ref={win}>…</window>;
+```
+
+It becomes `transientFor` on the built-in dialog and `parent_window` on the
+portal, which is what makes the window manager treat the dialog as belonging to
+your window — stacked above it, and not a second entry in the task switcher.
+Without it the dialog floats: legal, and it looks careless.
+
+**The portal never embeds the dialog.** It is a top-level window in another
+process, and logical parenting is all there is. There is no version of this
+where the file list appears inside your window.
+
+## The imperative functions
+
+```ts
+import { openFile, saveFile, selectFolder } from 'react-x11';
+```
+
+Same options, same results — but they can only reach the portal and
+`osascript`, because a function has nowhere to draw. Where there is neither
+they reject with `NoFileDialogError`, which is a **typed** rejection: the
+signal to show your own UI, not a crash.
+
+Reach for these from host-side code and event-loop glue that has no component
+to hang off. In a component, use the hook.
+
+## What differs between the rungs
+
+Most of the API is the same everywhere. These are the places it genuinely is
+not, stated here rather than discovered:
+
+- **MIME-type filters do not reach macOS.** `extensions` translate exactly to
+  all three; `mimeTypes` reach the portal and are dropped by `osascript`,
+  because AppleScript's `of type` wants extensions or UTIs and guessing a UTI
+  wrong hides the user's file with no way to get at it. Give `extensions` where
+  you can.
+- **macOS ignores `parentWindow` entirely.** XQuartz windows are `NSWindow`s
+  owned by X11.app, and macOS has no cross-process transient-for —
+  `addChildWindow` is same-process only. The panel appears over the app but is
+  not attached to it. Application modality still works, because your code is
+  awaiting the promise.
+- **The built-in dialog has never seen the user's bookmarks.** It offers the
+  filesystem, a filter, hidden files, and a path you can type into. It is
+  deliberately not a re-creation of GTK's chooser.
+- **`multiple` in the built-in dialog is a tick column**, not ctrl-click.
+
+## Running it where there is no bus
+
+The interesting configurations, and what each one does:
+
+| where                                                  | rung                                                                                                              |
+| ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------- |
+| GNOME / KDE / any desktop with xdg-desktop-portal      | portal                                                                                                            |
+| macOS + XQuartz, app running **on the Mac**            | `osascript`                                                                                                       |
+| macOS + XQuartz, app running on a **remote Linux box** | built-in — `osascript` would run on the wrong machine, and the paths it returned would not exist where the app is |
+| ssh, `startx`, a container, CI                         | built-in                                                                                                          |
+| Node 20, where npm skips `dbus-native`                 | built-in on Linux, `osascript` on a Mac                                                                           |
+
+The macOS rung is reached by _not_ finding a portal, so it also covers a Mac
+that has a session bus for other reasons. If you do run a portal shim on a Mac
+(see [issue #111](https://github.com/sidorares/react-x11/issues/111)), it wins,
+which is what you asked for by running it.
+
+## The portal machinery, if you need it directly
+
+`portalRequest()` is exported for building other portals on. Every portal
+method that shows UI returns an object path immediately and answers later with
+a `Request.Response` signal — and the path is predictable **by design**, so the
+client subscribes _before_ it calls and cannot lose the answer:
+
+```js
+const { response, results } = await portalRequest(busRef, {
+  iface: 'org.freedesktop.portal.Settings',
+  member: 'ReadAll',
+  parentWindow: 'x11:1a00007',
+  options: {},
+});
+```
+
+It owns the three things every portal caller otherwise re-solves: subscribing
+first, `Request.Close()` on abort (which emits **no** `Response`, so the
+promise has to be settled locally), and no timeout on the answer — a dialog can
+legitimately be open for an hour, and only the initial call is deadlined.
+
+`hasService(name)` answers whether a service is reachable — owned now **or
+activatable on demand**. `NameHasOwner` alone is the wrong question:
+`org.freedesktop.portal.Desktop` is D-Bus-activatable, so on a healthy desktop
+where no app has touched a portal yet it has no owner, and a feature gated on
+that takes the fallback path forever.
+
+See [dbus.md](dbus.md) for the connection these sit on.
+
+## Seeing it
+
+- `npm run examples:menu` — a File menu whose Open/Save entries are real, with
+  the rung this machine landed on shown in the window.
+- `npm run examples:richtext` — "open a .md…" loads a real file into the
+  `<markdown>` element.
+
+Force the bottom rung anywhere with `backend: 'builtin'`, which is also how the
+tests exercise it.

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,30 +16,30 @@ tests can import them without opening a window.
 
 Roughly in the order worth reading them:
 
-|                                      |                                                                                                      |
-| ------------------------------------ | ---------------------------------------------------------------------------------------------------- |
-| [`simple.jsx`](simple.jsx)           | hello world: flex layout and text, no pixel math. `npm run examples:simple`                          |
-| [`simple-nojsx.js`](simple-nojsx.js) | the same thing in plain node with `React.createElement` — no build step at all                       |
-| [`xeyes.jsx`](xeyes.jsx)             | the `<canvas>` escape hatch: custom drawing plus hooks for state and polling                         |
-| [`dashboard.jsx`](dashboard.jsx)     | context for theming, `useState`/`useEffect`/`useMemo`, a custom hook, hover and focus states         |
-| [`tasks.jsx`](tasks.jsx)             | `useReducer`, dispatch through context, list rendering, `<scrollview>`, keyboard throughout          |
-| [`form.jsx`](form.jsx)               | `<textinput>`, `Select`, `RadioGroup`, `Slider`, `Checkbox`, and a modal `Dialog`                    |
-| [`rules.jsx`](rules.jsx)             | a WHEN/THEN rule builder: a recursive tree that edits itself, with drag-to-reorder and `<svg>` icons |
-| [`widgets.jsx`](widgets.jsx)         | the gallery: every standard component in one window, with a live `<markdown>` preview                |
-| [`menu.jsx`](menu.jsx)               | `MenuBar` and `ContextMenu` over real `<popup>` windows that flip at screen edges                    |
-| [`theming.jsx`](theming.jsx)         | the style engine end to end: three themes in light and dark, switched at runtime                     |
-| [`richtext.jsx`](richtext.jsx)       | `<markdown>` with highlighted and math fences, a live `<tex>` formula, JSX `<svg>`, `<image>`        |
-| [`windows.jsx`](windows.jsx)         | many top-level windows from one React tree, sharing state, closing via `onCloseRequest`              |
-| [`app.jsx`](app.jsx)                 | the showcase: `SplitPane` + `Tabs` hosting `form`, `widgets` and `tasks` as panels                   |
-| [`gl.jsx`](gl.jsx)                   | raw GL in a `<glarea>`, compiled to a server-side display list                                       |
-| [`three.jsx`](three.jsx)             | a react-three-fiber-shaped `<Canvas3D>` scene: meshes, lights, textures                              |
-| [`icons.jsx`](icons.jsx)             | 400 icon-sized `<svg>`s that reflow and scroll, with a cached-glyph control — a paint benchmark      |
-| [`dnd-source.jsx`](dnd-source.jsx)   | **drag out of the app** (XDND) + in-app drags with live payloads, a `<popup>` drag preview           |
-| [`dnd-target.jsx`](dnd-target.jsx)   | drop zones: `dropAccept` groups, parsed `e.files`, custom MIME types, `useDropTarget` state          |
-| [`raster-gate.jsx`](raster-gate.jsx) | a wall of live controls with ntk's local/server rasterization routing on a switch (ntk#177)          |
-| [`dbus.jsx`](dbus.jsx)               | a D-Bus explorer: `useSessionBus()`/`useSystemBus()`, a `Tree` of live introspection, a detail pane  |
-| [`stress/`](stress/index.jsx)        | **the big one**: six panels to poke at by hand, with a frame log — see below                         |
-| [`wm.jsx`](wm.jsx)                   | **a reparenting window manager** — see below                                                         |
+|                                      |                                                                                                                        |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| [`simple.jsx`](simple.jsx)           | hello world: flex layout and text, no pixel math. `npm run examples:simple`                                            |
+| [`simple-nojsx.js`](simple-nojsx.js) | the same thing in plain node with `React.createElement` — no build step at all                                         |
+| [`xeyes.jsx`](xeyes.jsx)             | the `<canvas>` escape hatch: custom drawing plus hooks for state and polling                                           |
+| [`dashboard.jsx`](dashboard.jsx)     | context for theming, `useState`/`useEffect`/`useMemo`, a custom hook, hover and focus states                           |
+| [`tasks.jsx`](tasks.jsx)             | `useReducer`, dispatch through context, list rendering, `<scrollview>`, keyboard throughout                            |
+| [`form.jsx`](form.jsx)               | `<textinput>`, `Select`, `RadioGroup`, `Slider`, `Checkbox`, and a modal `Dialog`                                      |
+| [`rules.jsx`](rules.jsx)             | a WHEN/THEN rule builder: a recursive tree that edits itself, with drag-to-reorder and `<svg>` icons                   |
+| [`widgets.jsx`](widgets.jsx)         | the gallery: every standard component in one window, with a live `<markdown>` preview                                  |
+| [`menu.jsx`](menu.jsx)               | `MenuBar` and `ContextMenu` over real `<popup>` windows that flip at screen edges — File → Open… is a real file dialog |
+| [`theming.jsx`](theming.jsx)         | the style engine end to end: three themes in light and dark, switched at runtime                                       |
+| [`richtext.jsx`](richtext.jsx)       | `<markdown>` with highlighted and math fences, a live `<tex>` formula, JSX `<svg>`, `<image>`                          |
+| [`windows.jsx`](windows.jsx)         | many top-level windows from one React tree, sharing state, closing via `onCloseRequest`                                |
+| [`app.jsx`](app.jsx)                 | the showcase: `SplitPane` + `Tabs` hosting `form`, `widgets` and `tasks` as panels                                     |
+| [`gl.jsx`](gl.jsx)                   | raw GL in a `<glarea>`, compiled to a server-side display list                                                         |
+| [`three.jsx`](three.jsx)             | a react-three-fiber-shaped `<Canvas3D>` scene: meshes, lights, textures                                                |
+| [`icons.jsx`](icons.jsx)             | 400 icon-sized `<svg>`s that reflow and scroll, with a cached-glyph control — a paint benchmark                        |
+| [`dnd-source.jsx`](dnd-source.jsx)   | **drag out of the app** (XDND) + in-app drags with live payloads, a `<popup>` drag preview                             |
+| [`dnd-target.jsx`](dnd-target.jsx)   | drop zones: `dropAccept` groups, parsed `e.files`, custom MIME types, `useDropTarget` state                            |
+| [`raster-gate.jsx`](raster-gate.jsx) | a wall of live controls with ntk's local/server rasterization routing on a switch (ntk#177)                            |
+| [`dbus.jsx`](dbus.jsx)               | a D-Bus explorer: `useSessionBus()`/`useSystemBus()`, a `Tree` of live introspection, a detail pane                    |
+| [`stress/`](stress/index.jsx)        | **the big one**: six panels to poke at by hand, with a frame log — see below                                           |
+| [`wm.jsx`](wm.jsx)                   | **a reparenting window manager** — see below                                                                           |
 
 `app.jsx` is where a new control should get demonstrated: it imports the
 panel each of `form`, `widgets` and `tasks` exports, so adding a widget

--- a/examples/menu.jsx
+++ b/examples/menu.jsx
@@ -17,7 +17,7 @@
 // which is the whole point. See docs/filedialog.md.
 //
 // Run with: npm run examples:menu  (needs an X server / DISPLAY)
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   createRoot,
   ContextMenu,
@@ -100,15 +100,11 @@ function App() {
   const [wrap, setWrap] = useState(true);
   const note = (label) => () => setLast(label);
 
-  // The File menu drives real dialogs. `parentWindow` is the one line worth
-  // writing: it makes the dialog transient for this window, so the window
-  // manager stacks it on top and the portal's own backend parents it the
-  // same way. Without it the dialog floats, which is legal and looks
-  // careless.
-  const win = useRef(null);
-  const { openFile, saveFile, selectFolder } = useFileDialog({
-    parentWindow: win,
-  });
+  // The File menu drives real dialogs. Nothing to pass: the dialog is
+  // parented to the window this component is in, worked out when it opens
+  // rather than asked for — so it stacks above this window and the portal's
+  // own backend parents it the same way.
+  const { openFile, saveFile, selectFolder } = useFileDialog();
 
   // Which rung this machine lands on — the desktop's own portal, macOS's
   // NSOpenPanel through `osascript`, or the browser react-x11 draws itself.
@@ -324,7 +320,6 @@ function App() {
 
   return (
     <window
-      ref={win}
       width={520}
       height={300}
       title="menus"

--- a/examples/menu.jsx
+++ b/examples/menu.jsx
@@ -1,4 +1,6 @@
-// Menus: a MenuBar of pull-down menus plus a ContextMenu on right-click.
+// Menus: a MenuBar of pull-down menus plus a ContextMenu on right-click —
+// and, in the File menu, real file dialogs.
+//
 // Both render into <popup> — override-redirect X11 windows anchored with
 // useAnchor, so they escape the owner window and flip at screen edges.
 //
@@ -7,9 +9,22 @@
 // Right opens a submenu and Left leaves it, Enter picks, Escape closes one
 // level at a time.
 //
+// **File → Open… is the real thing**, through `useFileDialog()`: the
+// desktop's own dialog over xdg-desktop-portal where there is one,
+// `NSOpenPanel` through `osascript` on a Mac, and a browser react-x11 draws
+// itself everywhere else — ssh, a bare startx, a container. The window shows
+// which rung this machine landed on; the menu code is the same either way,
+// which is the whole point. See docs/filedialog.md.
+//
 // Run with: npm run examples:menu  (needs an X server / DISPLAY)
-import React, { useState } from 'react';
-import { createRoot, ContextMenu, MenuBar } from '../src/index.js';
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  createRoot,
+  ContextMenu,
+  fileDialogBackend,
+  MenuBar,
+  useFileDialog,
+} from '../src/index.js';
 
 // Menu icons are SVG paths painted in `currentColor`, so one drawing serves
 // every state a row can be in: the menu calls `icon` with the colour its
@@ -85,6 +100,42 @@ function App() {
   const [wrap, setWrap] = useState(true);
   const note = (label) => () => setLast(label);
 
+  // The File menu drives real dialogs. `parentWindow` is the one line worth
+  // writing: it makes the dialog transient for this window, so the window
+  // manager stacks it on top and the portal's own backend parents it the
+  // same way. Without it the dialog floats, which is legal and looks
+  // careless.
+  const win = useRef(null);
+  const { openFile, saveFile, selectFolder } = useFileDialog({
+    parentWindow: win,
+  });
+
+  // Which rung this machine lands on — the desktop's own portal, macOS's
+  // NSOpenPanel through `osascript`, or the browser react-x11 draws itself.
+  // Shown because the whole point is that the app does not care.
+  const [backend, setBackend] = useState('…');
+  useEffect(() => {
+    fileDialogBackend().then(setBackend, () => setBackend('unknown'));
+  }, []);
+
+  // Every one of these resolves to `null` when the user cancels — an
+  // ordinary outcome, so none of them needs a `try`.
+  const TEXT = [{ name: 'Text', extensions: ['txt', 'md'] }];
+  const open = (options) => async () => {
+    setLast('opening…');
+    const files = await openFile({ filters: TEXT, ...options });
+    setLast(files ? files.join(', ') : 'cancelled');
+  };
+  const save = () => async () => {
+    setLast('saving…');
+    const file = await saveFile({ filters: TEXT, defaultName: 'notes.md' });
+    setLast(file ?? 'cancelled');
+  };
+  const folder = () => async () => {
+    const dirs = await selectFolder();
+    setLast(dirs ? dirs.join(', ') : 'cancelled');
+  };
+
   // `icon` shares the check column, so it is a glyph rather than a picture:
   // a string is drawn as text in the font already in use. Pass a React
   // element instead — `<canvas onDraw>` — when it has to be a real drawing.
@@ -102,7 +153,17 @@ function App() {
           label: 'Open…',
           icon: ICONS.folder,
           shortcut: 'Ctrl+O',
-          onSelect: note('Open…'),
+          onSelect: open(),
+        },
+        {
+          label: 'Open Files…',
+          icon: ICONS.folder,
+          onSelect: open({ multiple: true }),
+        },
+        {
+          label: 'Open Folder…',
+          icon: ICONS.folder,
+          onSelect: folder(),
         },
         {
           // three levels: Open Recent → Projects → the file itself, which is
@@ -135,7 +196,7 @@ function App() {
           shortcut: 'Ctrl+S',
           onSelect: note('Save'),
         },
-        { label: 'Save As…', disabled: true },
+        { label: 'Save As…', icon: ICONS.save, onSelect: save() },
         {
           label: 'Export',
           items: [
@@ -263,8 +324,9 @@ function App() {
 
   return (
     <window
-      width={460}
-      height={280}
+      ref={win}
+      width={520}
+      height={300}
       title="menus"
       style={{ backgroundColor: '#f5f6fa' }}
     >
@@ -287,6 +349,10 @@ function App() {
           </text>
           <text style={{ color: '#7f8c8d' }}>
             wrap lines: {wrap ? 'on' : 'off'}
+          </text>
+          <text style={{ color: '#7f8c8d' }}>
+            File → Open/Save runs a real dialog, on this machine's{' '}
+            <text style={{ color: '#2980b9' }}>{backend}</text> backend
           </text>
         </ContextMenu>
       </box>

--- a/examples/richtext.jsx
+++ b/examples/richtext.jsx
@@ -10,7 +10,7 @@
 // Run with: npm run examples:richtext  (needs an X server)
 import { fileURLToPath } from 'node:url';
 
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 import { Button, createRoot, useFileDialog } from '../src/index.js';
 
 // any PNG/JPEG path works; this one ships with the docs
@@ -79,12 +79,11 @@ function Logo({ spin }) {
 function App() {
   const [n, setN] = useState(2);
   const [doc, setDoc] = useState({ source: MARKDOWN, from: null });
-  const win = useRef(null);
-
   // The dialog is one call and one `null` check — and it is the desktop's own
   // dialog, `NSOpenPanel` on a Mac, or one react-x11 draws, depending only on
-  // what the machine has. See docs/filedialog.md.
-  const { openFile } = useFileDialog({ parentWindow: win });
+  // what the machine has. Nothing is passed: it parents itself to this
+  // window. See docs/filedialog.md.
+  const { openFile } = useFileDialog();
   const load = async () => {
     const files = await openFile({
       title: 'Open a Markdown file',
@@ -107,7 +106,6 @@ function App() {
 
   return (
     <window
-      ref={win}
       width={560}
       height={640}
       title={doc.from ? `rich content — ${doc.from}` : 'rich content'}

--- a/examples/richtext.jsx
+++ b/examples/richtext.jsx
@@ -1,11 +1,17 @@
 // Rich content elements: <markdown> (with highlighted + math fences) in a
 // scrollview, a live-updating <tex> formula, a declarative JSX <svg> and an
 // <image> — all drawn client-side through ntk's document widgets and image
-// pipeline. Run with: npm run examples:richtext  (needs an X server)
+// pipeline.
+//
+// "open a .md…" is the file dialog (`useFileDialog()`), pointed at a real
+// file and rendered by the same <markdown> element — the shortest honest
+// demonstration of why an app wants one.
+//
+// Run with: npm run examples:richtext  (needs an X server)
 import { fileURLToPath } from 'node:url';
 
-import React, { useState } from 'react';
-import { Button, createRoot } from '../src/index.js';
+import React, { useRef, useState } from 'react';
+import { Button, createRoot, useFileDialog } from '../src/index.js';
 
 // any PNG/JPEG path works; this one ships with the docs
 const PICTURE = fileURLToPath(
@@ -72,11 +78,39 @@ function Logo({ spin }) {
 
 function App() {
   const [n, setN] = useState(2);
+  const [doc, setDoc] = useState({ source: MARKDOWN, from: null });
+  const win = useRef(null);
+
+  // The dialog is one call and one `null` check — and it is the desktop's own
+  // dialog, `NSOpenPanel` on a Mac, or one react-x11 draws, depending only on
+  // what the machine has. See docs/filedialog.md.
+  const { openFile } = useFileDialog({ parentWindow: win });
+  const load = async () => {
+    const files = await openFile({
+      title: 'Open a Markdown file',
+      filters: [
+        { name: 'Markdown', extensions: ['md', 'markdown'] },
+        { name: 'Text', extensions: ['txt'] },
+      ],
+    });
+    if (!files) return; // cancelled
+    const { readFile } = await import('node:fs/promises');
+    try {
+      setDoc({ source: await readFile(files[0], 'utf8'), from: files[0] });
+    } catch (err) {
+      setDoc({
+        source: `# Could not read that file\n\n\`${err.message}\``,
+        from: null,
+      });
+    }
+  };
+
   return (
     <window
+      ref={win}
       width={560}
       height={640}
-      title="rich content"
+      title={doc.from ? `rich content — ${doc.from}` : 'rich content'}
       style={{ backgroundColor: 'white' }}
     >
       <box
@@ -93,6 +127,7 @@ function App() {
           {`e^{i\\pi} + 1 = 0 \\qquad x^{${n}}`}
         </tex>
         <box style={{ flexGrow: 1 }} />
+        <Button label="open a .md…" onPress={load} />
         <Button
           primary
           label="bump exponent"
@@ -104,7 +139,7 @@ function App() {
           onLink={(href) => console.log('link clicked:', href)}
           style={{ padding: 16 }}
         >
-          {MARKDOWN}
+          {doc.source}
         </markdown>
       </scrollview>
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "examples:menu": "tsx examples/menu.jsx",
     "examples:clipboard": "tsx examples/clipboard.jsx",
     "examples:dbus": "tsx examples/dbus.jsx",
+    "filedialog:probe": "node scripts/filedialog-probe.mjs",
     "examples:form": "tsx examples/form.jsx",
     "examples:rules": "tsx examples/rules.jsx",
     "examples:richtext": "tsx examples/richtext.jsx",

--- a/scripts/filedialog-probe.mjs
+++ b/scripts/filedialog-probe.mjs
@@ -1,0 +1,307 @@
+#!/usr/bin/env node
+// A file dialog, with a stopwatch on every phase — and **no X11 and no
+// react-x11 anywhere in it**.
+//
+// The point is subtraction. "Click to dialog takes two seconds" has at least
+// five candidates in it: loading the transport, dialling the bus, asking
+// whether a portal exists, the portal call itself, and the desktop's own
+// backend building a GTK window. Only the last one is out of our hands, and
+// the only way to know which it is, is to run the same conversation with
+// nothing else in the process.
+//
+//   node scripts/filedialog-probe.mjs                 # open, once
+//   node scripts/filedialog-probe.mjs save --repeat 3 # warm vs cold
+//   node scripts/filedialog-probe.mjs open --osascript   # the macOS rung
+//   node scripts/filedialog-probe.mjs --no-show       # timings only, no UI
+//
+// What it cannot time, and says so rather than pretending: the gap between
+// the portal handing back a Request handle and a dialog actually appearing.
+// That is another process drawing a window — on a Wayland session it is not
+// even an X window — so the script prints a marker the instant the handle
+// lands and leaves the last leg to your eyes.
+
+import { execFile } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+
+const PORTAL_NAME = 'org.freedesktop.portal.Desktop';
+const PORTAL_PATH = '/org/freedesktop/portal/desktop';
+const FILE_CHOOSER = 'org.freedesktop.portal.FileChooser';
+const REQUEST_IFACE = 'org.freedesktop.portal.Request';
+
+// --- arguments --------------------------------------------------------------
+
+const argv = process.argv.slice(2);
+const kind = argv.find((a) => ['open', 'save', 'folder'].includes(a)) ?? 'open';
+const has = (flag) => argv.includes(flag);
+const value = (flag, fallback) => {
+  const i = argv.indexOf(flag);
+  return i >= 0 && argv[i + 1] ? argv[i + 1] : fallback;
+};
+const repeat = Number(value('--repeat', '1'));
+const show = !has('--no-show');
+const multiple = has('--multiple');
+const useOsascript = has('--osascript');
+
+// --- the stopwatch ----------------------------------------------------------
+
+const ms = () => Number(process.hrtime.bigint()) / 1e6;
+const started = ms();
+let last = started;
+
+function lap(label, note = '') {
+  const now = ms();
+  const delta = now - last;
+  last = now;
+  const bar = '█'.repeat(Math.min(40, Math.round(delta / 25)));
+  console.log(
+    `${String(Math.round(delta)).padStart(6)} ms  ` +
+      `${String(Math.round(now - started)).padStart(7)} total  ` +
+      `${label.padEnd(42)}${bar}${note}`,
+  );
+  return delta;
+}
+
+// --- the macOS rung ---------------------------------------------------------
+
+function osascriptLines(dialogKind) {
+  const prompt = `"react-x11 probe (${dialogKind})"`;
+  const head =
+    dialogKind === 'save'
+      ? `set theFiles to choose file name with prompt ${prompt}`
+      : dialogKind === 'folder'
+        ? `set theFiles to choose folder with prompt ${prompt}`
+        : `set theFiles to choose file with prompt ${prompt}` +
+          (multiple ? ' with multiple selections allowed' : '');
+  return [
+    head,
+    'if class of theFiles is not list then set theFiles to {theFiles}',
+    'set out to ""',
+    'repeat with f in theFiles',
+    'set out to out & POSIX path of f & linefeed',
+    'end repeat',
+    'return out',
+  ].flatMap((line) => ['-e', line]);
+}
+
+async function runOsascript() {
+  console.log(`\n--- osascript (${kind}) ---\n`);
+  lap('start');
+  const args = osascriptLines(kind);
+  console.log(
+    `\n  >>> spawning osascript at +${Math.round(ms() - started)} ms`,
+  );
+  console.log(
+    '  >>> the panel appears some time after this line — that gap is',
+  );
+  console.log('      AppKit starting up inside osascript, not this process.\n');
+  const result = await new Promise((resolve) => {
+    execFile('osascript', args, { encoding: 'utf8' }, (error, stdout, stderr) =>
+      resolve({ error, stdout, stderr }),
+    );
+  });
+  lap('osascript exited (includes your thinking time)');
+  if (result.error) {
+    const cancelled =
+      /-128/.test(result.stderr) || /User canceled/i.test(result.stderr);
+    console.log(
+      cancelled ? '\ncancelled' : `\nfailed: ${result.stderr.trim()}`,
+    );
+    return;
+  }
+  console.log(
+    '\npicked:',
+    result.stdout.split('\n').filter(Boolean).join(', ') || '(nothing)',
+  );
+}
+
+// --- the portal rung --------------------------------------------------------
+
+async function runPortal() {
+  console.log(`\n--- xdg-desktop-portal (${kind}) ---\n`);
+  lap('start');
+
+  let dbus;
+  try {
+    dbus = (await import('dbus-native')).default;
+  } catch (err) {
+    console.error(
+      '\nno dbus-native here. It is an optionalDependency and npm skips it ' +
+        'on Node < 22.12 (this is ' +
+        process.version +
+        ').\n  npm i dbus-native\n',
+      err.message,
+    );
+    process.exit(1);
+  }
+  lap('import dbus-native', '  (xml2js + sax come with it)');
+
+  const address =
+    process.env.DBUS_SESSION_BUS_ADDRESS ||
+    (process.env.XDG_RUNTIME_DIR
+      ? `unix:path=${process.env.XDG_RUNTIME_DIR}/bus`
+      : undefined);
+  console.log(
+    `\n  address: ${address ?? '(none — dbus-native will try launchd, which spawns `launchctl getenv`)'}\n`,
+  );
+
+  let bus;
+  try {
+    bus = dbus.createClient(address ? { busAddress: address } : {});
+  } catch (err) {
+    lap('createClient THREW');
+    console.error(`\nno session bus: ${err.message}\n`);
+    process.exit(1);
+  }
+  lap('createClient (socket + address resolution)');
+
+  try {
+    await new Promise((resolve, reject) => {
+      bus.connection.once('connect', resolve);
+      bus.connection.once('error', reject);
+      bus.connection.once('close', () => reject(new Error('closed')));
+    });
+  } catch (err) {
+    lap('connect FAILED');
+    console.error(`\ncould not connect: ${err.message}\n`);
+    process.exit(1);
+  }
+  lap('connect + SASL auth');
+
+  // The unique name is assigned in the Hello reply, so one round trip is the
+  // barrier that makes it readable. react-x11's bus layer does exactly this.
+  await bus.listNames();
+  lap('ListNames (the name-ready barrier)', `  name=${bus.name}`);
+
+  // What hasService() costs: is the portal owned, or activatable?
+  const owned = await bus.listNames();
+  lap('ListNames (hasService)');
+  const activatable = await bus.listActivatableNames().catch(() => []);
+  lap('ListActivatableNames (hasService)');
+  const reachable =
+    owned.includes(PORTAL_NAME) || activatable.includes(PORTAL_NAME);
+  console.log(
+    `\n  portal ${reachable ? 'reachable' : 'NOT reachable'} — ` +
+      `owned=${owned.includes(PORTAL_NAME)} activatable=${activatable.includes(PORTAL_NAME)}\n`,
+  );
+  if (!reachable) {
+    console.log(
+      'nothing to call. On macOS this is where osascript takes over.',
+    );
+    await bus.close();
+    return;
+  }
+
+  // The version property is the first call that actually *activates* the
+  // service if it is not running — worth timing on its own, because it is the
+  // one that pays for the daemon starting.
+  try {
+    const obj = await bus.getObject(PORTAL_NAME, PORTAL_PATH);
+    const version = await obj.proxy[FILE_CHOOSER]?.$readProp('version');
+    lap('Introspect + read FileChooser.version', `  v${version}`);
+  } catch (err) {
+    lap('Introspect FAILED', `  ${err.message}`);
+  }
+
+  if (!show) {
+    console.log('\n--no-show: stopping before any UI.\n');
+    await bus.close();
+    return;
+  }
+
+  for (let attempt = 1; attempt <= repeat; attempt++) {
+    if (repeat > 1) console.log(`\n  --- attempt ${attempt}/${repeat} ---`);
+    const token = `rx11probe_${randomBytes(8).toString('hex')}`;
+    const sender = bus.name.replace(/^:/, '').replaceAll('.', '_');
+    const path = `${PORTAL_PATH}/request/${sender}/${token}`;
+
+    const sub = await bus.watch(
+      `type='signal',sender='${PORTAL_NAME}',interface='${REQUEST_IFACE}',` +
+        `member='Response',path='${path}'`,
+    );
+    lap('AddMatch (subscribe BEFORE calling)');
+
+    const key = bus.mangle(path, REQUEST_IFACE, 'Response');
+    const answered = new Promise((resolve) =>
+      bus.signals.once(key, ([response, results]) =>
+        resolve({ response, results }),
+      ),
+    );
+
+    const options = { handle_token: token, modal: true };
+    if (multiple && kind !== 'save') options.multiple = true;
+    if (kind === 'folder') options.directory = true;
+    if (kind === 'save') options.current_name = 'probe.txt';
+
+    const handle = await bus.invoke(
+      {
+        destination: PORTAL_NAME,
+        path: PORTAL_PATH,
+        interface: FILE_CHOOSER,
+        member: kind === 'save' ? 'SaveFile' : 'OpenFile',
+        signature: 'ssa{sv}',
+        body: ['', `react-x11 probe (${kind})`, options],
+      },
+      { timeout: 15000 },
+    );
+    const callMs = lap(
+      `${kind === 'save' ? 'SaveFile' : 'OpenFile'} -> Request handle`,
+    );
+    console.log(
+      `\n  path predicted: ${path}\n  handle returned: ${handle}\n  ${
+        handle === path
+          ? 'MATCH — the subscription was on the right path'
+          : 'MISMATCH'
+      }`,
+    );
+    console.log(
+      `\n  >>> everything above is this process: ${Math.round(ms() - started)} ms total.\n` +
+        "  >>> THE DIALOG IS NOT ON SCREEN YET. The desktop's backend\n" +
+        '      (xdg-desktop-portal-gnome / -gtk) is building it now, in another\n' +
+        '      process. If you see a two-second wait, this is where it is —\n' +
+        '      time it from this line.\n',
+    );
+    if (callMs > 500) {
+      console.log(
+        '  NOTE: the call itself took >500 ms, which usually means D-Bus had\n' +
+          '        to activate xdg-desktop-portal. That cost is once per session.\n',
+      );
+    }
+
+    const waiting = ms();
+    const { response, results } = await answered;
+    lap('Response signal (includes your thinking time)');
+    console.log(
+      `\n  you took ${Math.round(ms() - waiting)} ms to answer; response=${response} ` +
+        `(0 ok, 1 cancelled, 2 other)`,
+    );
+    if (response === 0) console.log('  uris:', results?.uris ?? []);
+    await sub.remove();
+  }
+
+  await bus.close();
+}
+
+// --- go ---------------------------------------------------------------------
+
+console.log(
+  `react-x11 file-dialog probe — node ${process.version} on ${process.platform}`,
+);
+console.log(
+  `session: XDG_SESSION_TYPE=${process.env.XDG_SESSION_TYPE ?? '(unset)'} ` +
+    `DISPLAY=${process.env.DISPLAY ?? '(unset)'} ` +
+    `WAYLAND_DISPLAY=${process.env.WAYLAND_DISPLAY ?? '(unset)'}`,
+);
+if (process.env.WAYLAND_DISPLAY) {
+  console.log(
+    '\nNote: on a Wayland session the portal dialog is a Wayland window, so an\n' +
+      'x11: parent handle cannot parent it — the dialog appears unparented.\n' +
+      "That is the desktop's doing, not the app's.",
+  );
+}
+
+if (useOsascript || (process.platform === 'darwin' && has('--native'))) {
+  await runOsascript();
+} else {
+  await runPortal();
+}
+process.exit(0);

--- a/src/bus.js
+++ b/src/bus.js
@@ -111,7 +111,13 @@ function newState(kind, generation) {
  */
 let transport = null;
 
-async function loadTransport() {
+/**
+ * Not public. `portal.js` needs `Variant` from the same copy of the transport
+ * to build `a{sv}` option dicts, and there is only ever one copy — importing
+ * `dbus-native` a second time from another module would be a second resolve
+ * of a package that may not be installed.
+ */
+export async function loadTransport() {
   if (transport) return transport;
   const mod = await import('dbus-native');
   // CJS with an `exports` map: named exports do not reliably survive
@@ -468,6 +474,12 @@ export async function closeBus(kind) {
   }
   const s = state[kind];
   const bus = s.bus;
+  // **The teardown is itself a use of the connection.** At zero refs the
+  // socket is `unref()`d, so `bus.close()` — which resolves on the socket's
+  // own 'close' event — has nothing holding the event loop open, and a
+  // process with no other work drains before the event arrives: the promise
+  // never settles. Re-ref for the duration, and let the close destroy it.
+  hold(s, true);
   // Swap the state first, so anything awaiting the old generation sees it
   // retired rather than racing the socket teardown.
   state[kind] = newState(kind, s.generation + 1);

--- a/src/components/FileDialog.js
+++ b/src/components/FileDialog.js
@@ -1,0 +1,427 @@
+// The bottom rung of the file-dialog ladder: a browser react-x11 draws
+// itself, for every machine that has a display and nothing else — ssh, a bare
+// `startx`, a container, a Mac with neither a portal nor `osascript`.
+//
+// It is a **real top-level window**, not a `<popup>`: a file dialog is
+// something the window manager should place, stack and decorate, and
+// `transientFor` is what makes it behave like a dialog rather than a second
+// application. That is also the shape the portal would have given, so an app
+// that moves between machines does not change how its dialog behaves.
+//
+// Deliberately not a re-creation of GTK's chooser. What it owes the user is:
+// get anywhere on the filesystem, see what is there, filter it, type a path
+// when the list is the slow way round, and never trap them — which is the set
+// below and nothing else.
+
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+
+import { createStyles } from '../styles.js';
+import { Button } from './Button.js';
+import { Checkbox } from './Checkbox.js';
+import { Select } from './Select.js';
+import { Table } from './Table.js';
+import { ThemeProvider, useTheme } from './theme.js';
+
+const h = React.createElement;
+
+const ALL_FILES = '__all__';
+
+// Stat-ing every entry is one syscall each, which is nothing on a local
+// filesystem and very much something on a network mount with ten thousand
+// files in one directory. Past this, sizes and dates are left blank rather
+// than making the dialog take a visible pause to open.
+const STAT_LIMIT = 5000;
+
+const s = createStyles({
+  window: { flexDirection: 'column', padding: 10, gap: 8 },
+  bar: { flexDirection: 'row', gap: 6, alignItems: 'center', flexShrink: 0 },
+  path: { flexGrow: 1, flexBasis: 0 },
+  list: { flexGrow: 1, minHeight: 0 },
+  footer: { flexDirection: 'row', gap: 8, alignItems: 'center', flexShrink: 0 },
+  spacer: { flexGrow: 1, flexBasis: 0 },
+  name: { flexGrow: 1, flexBasis: 0 },
+  error: { fontSize: 12 },
+  hint: { fontSize: 11 },
+});
+
+const KIND_LABEL = { open: 'Open', save: 'Save', folder: 'Select' };
+
+/** `1234567` → `1.2 MB`. Blank for directories and unstat'd entries. */
+function humanSize(bytes) {
+  if (bytes == null) return '';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  let n = bytes;
+  let i = 0;
+  while (n >= 1024 && i < units.length - 1) {
+    n /= 1024;
+    i++;
+  }
+  return `${i === 0 ? n : n.toFixed(1)} ${units[i]}`;
+}
+
+/** `{ name, extensions, mimeTypes }` → a predicate over file names. */
+function matcher(filter) {
+  if (!filter || !filter.extensions?.length) return () => true;
+  const exts = filter.extensions.map((e) =>
+    String(e)
+      .replace(/^[.*]*\.?/, '')
+      .toLowerCase(),
+  );
+  return (name) => {
+    const dot = name.lastIndexOf('.');
+    if (dot < 0) return false;
+    return exts.includes(name.slice(dot + 1).toLowerCase());
+  };
+}
+
+/**
+ * One directory's contents, reloaded whenever the path changes.
+ *
+ * Errors are state rather than throws: a directory you cannot read is an
+ * ordinary thing to click on, and the answer is a message in the dialog, not
+ * an error boundary.
+ */
+function useDirectory(dir) {
+  const [state, setState] = useState({ status: 'loading', entries: [] });
+
+  useEffect(() => {
+    let live = true;
+    setState((prev) => ({ ...prev, status: 'loading' }));
+    (async () => {
+      const fs = await import('node:fs/promises');
+      const path = await import('node:path');
+      let names;
+      try {
+        names = await fs.readdir(dir, { withFileTypes: true });
+      } catch (err) {
+        if (live)
+          setState({ status: 'error', message: err.message, entries: [] });
+        return;
+      }
+      const withStats = names.length <= STAT_LIMIT;
+      const entries = await Promise.all(
+        names.map(async (entry) => {
+          const full = path.join(dir, entry.name);
+          // A symlink's own dirent says 'link'; what matters to the user is
+          // what it points at, so follow it and fall back to the link itself
+          // when it dangles.
+          let directory = entry.isDirectory();
+          let size = null;
+          let modified = 0;
+          if (withStats) {
+            try {
+              const st = await fs.stat(full);
+              directory = st.isDirectory();
+              size = directory ? null : st.size;
+              modified = st.mtimeMs;
+            } catch {
+              directory = entry.isDirectory();
+            }
+          }
+          return {
+            id: full,
+            name: entry.name,
+            path: full,
+            directory,
+            size,
+            modified,
+          };
+        }),
+      );
+      if (live) setState({ status: 'ready', entries });
+    })();
+    return () => {
+      live = false;
+    };
+  }, [dir]);
+
+  return state;
+}
+
+/**
+ * `<FileDialog>` — the built-in file browser.
+ *
+ * Rendered for you by `useFileDialog()` when there is no portal and no
+ * `osascript`; exported because an app that wants this dialog *always* (a
+ * kiosk, a test, somewhere the desktop's own dialog is wrong) should not have
+ * to break the machine to get it.
+ *
+ * `onDone(paths | null)` is called exactly once — `null` for cancel.
+ */
+export function FileDialog({
+  kind = 'open',
+  title,
+  startFolder,
+  defaultName = '',
+  filters = [],
+  multiple = false,
+  acceptLabel,
+  parentWindow,
+  onDone,
+  theme: themeProp,
+  width = 640,
+  height = 460,
+}) {
+  // `theme` as a prop, because the dialog is often rendered on a **root of its
+  // own** (see filedialoghooks.js) where there is no provider above it to
+  // inherit from — the palette has to be carried across rather than read.
+  const contextTheme = useTheme();
+  const theme = themeProp ?? contextTheme;
+  const [dir, setDir] = useState(startFolder || process.cwd());
+  const [typedPath, setTypedPath] = useState(dir);
+  const [name, setName] = useState(defaultName);
+  const [showHidden, setShowHidden] = useState(false);
+  const [filterId, setFilterId] = useState(filters.length ? '0' : ALL_FILES);
+  const [cursor, setCursor] = useState(null);
+  const [picked, setPicked] = useState(() => new Set());
+  const settled = useRef(false);
+
+  const { status, entries, message } = useDirectory(dir);
+
+  // `onDone` exactly once, however the dialog ends — a caller is awaiting a
+  // promise, and settling it twice or not at all are both worse than any
+  // rendering bug in here.
+  const finish = useCallback(
+    (result) => {
+      if (settled.current) return;
+      settled.current = true;
+      onDone?.(result);
+    },
+    [onDone],
+  );
+
+  const activeFilter =
+    filterId === ALL_FILES ? null : (filters[Number(filterId)] ?? null);
+  const matches = useMemo(() => matcher(activeFilter), [activeFilter]);
+
+  const rows = useMemo(() => {
+    const visible = entries.filter((e) => {
+      if (!showHidden && e.name.startsWith('.')) return false;
+      if (kind === 'folder') return e.directory;
+      return e.directory || matches(e.name);
+    });
+    // Directories first, then by name — the order every file browser uses,
+    // and the reason `sort` is passed to Table already applied.
+    visible.sort((a, b) =>
+      a.directory !== b.directory
+        ? a.directory
+          ? -1
+          : 1
+        : a.name.localeCompare(b.name),
+    );
+    return visible;
+  }, [entries, showHidden, matches, kind]);
+
+  // A new directory is a new list; a stale cursor would point at a row that
+  // is not there and a stale tick-set would return paths the user cannot see.
+  useEffect(() => {
+    setCursor(null);
+    setPicked(new Set());
+    setTypedPath(dir);
+  }, [dir]);
+
+  const goUp = useCallback(async () => {
+    const path = await import('node:path');
+    const parent = path.dirname(dir);
+    if (parent !== dir) setDir(parent);
+  }, [dir]);
+
+  const toggle = useCallback((row) => {
+    setPicked((prev) => {
+      const next = new Set(prev);
+      if (next.has(row.path)) next.delete(row.path);
+      else next.add(row.path);
+      return next;
+    });
+  }, []);
+
+  const activate = useCallback(
+    (id, row) => {
+      if (!row) return;
+      if (row.directory && kind !== 'folder') return void setDir(row.path);
+      if (row.directory && kind === 'folder') return void setDir(row.path);
+      if (kind === 'save') return setName(row.name);
+      finish([row.path]);
+    },
+    [kind, finish],
+  );
+
+  const accept = useCallback(async () => {
+    const path = await import('node:path');
+    if (kind === 'save') {
+      if (!name.trim()) return;
+      return finish([path.resolve(dir, name.trim())]);
+    }
+    if (kind === 'folder') {
+      const chosen = picked.size ? [...picked] : cursor ? [cursor] : [dir]; // no selection means "this one", which is what the path bar shows
+      return finish(chosen);
+    }
+    const chosen =
+      multiple && picked.size ? [...picked] : cursor ? [cursor] : [];
+    if (!chosen.length) return;
+    finish(chosen);
+  }, [kind, name, dir, picked, cursor, multiple, finish]);
+
+  const columns = useMemo(() => {
+    const cols = [];
+    if (multiple && kind !== 'save') {
+      cols.push({
+        id: 'pick',
+        label: '',
+        width: 28,
+        render: (row) =>
+          row.directory
+            ? null
+            : h(Checkbox, {
+                checked: picked.has(row.path),
+                onChange: () => toggle(row),
+              }),
+      });
+    }
+    cols.push({
+      id: 'name',
+      label: 'Name',
+      width: 300,
+      value: (row) => row.name,
+      render: (row) =>
+        h(
+          'text',
+          { style: { color: row.directory ? theme.accent : theme.text } },
+          row.directory ? `${row.name}/` : row.name,
+        ),
+    });
+    cols.push({
+      id: 'size',
+      label: 'Size',
+      width: 90,
+      align: 'right',
+      value: (row) => humanSize(row.size),
+    });
+    cols.push({
+      id: 'modified',
+      label: 'Modified',
+      width: 150,
+      value: (row) =>
+        row.modified ? new Date(row.modified).toLocaleString() : '',
+    });
+    return cols;
+  }, [multiple, kind, picked, toggle, theme]);
+
+  const filterOptions = [
+    ...filters.map((f, i) => ({
+      value: String(i),
+      label: f.name ?? `Filter ${i + 1}`,
+    })),
+    { value: ALL_FILES, label: 'All files' },
+  ];
+
+  const acceptText =
+    acceptLabel ??
+    (multiple && picked.size
+      ? `${KIND_LABEL[kind]} (${picked.size})`
+      : KIND_LABEL[kind]);
+
+  return h(
+    'window',
+    {
+      title: title ?? `${KIND_LABEL[kind]} — react-x11`,
+      width,
+      height,
+      minWidth: 420,
+      minHeight: 300,
+      transientFor: parentWindow ?? undefined,
+      // The palette goes on the window as a **prop** as well as on the context
+      // below: a `$token` in a style resolves against the nearest `theme` prop
+      // by walking the node tree, which knows nothing about React context.
+      theme,
+      style: { flexDirection: 'column', backgroundColor: theme.background },
+      onCloseRequest: () => finish(null),
+      onKeyDown: (e) => {
+        if (e.key === 'Escape') finish(null);
+      },
+    },
+    h(
+      ThemeProvider,
+      { value: theme, style: s.window },
+
+      // Where you are, and the escape hatch for everywhere the list is the slow
+      // way round: type a path, press Enter.
+      h(
+        'box',
+        { style: s.bar },
+        h(Button, { onPress: goUp }, 'Up'),
+        h('textinput', {
+          value: typedPath,
+          onChange: (e) => setTypedPath(e.value),
+          onKeyDown: (e) => {
+            if (e.key === 'Enter') setDir(typedPath.trim() || dir);
+          },
+          style: s.path,
+        }),
+      ),
+
+      status === 'error'
+        ? h(
+            'text',
+            { style: [s.error, { color: '#dc2626' }] },
+            `Cannot read ${dir} — ${message}`,
+          )
+        : h(Table, {
+            columns,
+            rows,
+            selected: cursor,
+            onSelect: (id, row) => {
+              setCursor(row?.path ?? null);
+              if (multiple && kind !== 'save' && row && !row.directory)
+                toggle(row);
+              if (kind === 'save' && row && !row.directory) setName(row.name);
+            },
+            onActivate: activate,
+            style: s.list,
+          }),
+
+      kind === 'save'
+        ? h(
+            'box',
+            { style: s.bar },
+            h('text', null, 'Name'),
+            h('textinput', {
+              value: name,
+              onChange: (e) => setName(e.value),
+              onKeyDown: (e) => {
+                if (e.key === 'Enter') accept();
+              },
+              style: s.name,
+            }),
+          )
+        : null,
+
+      h(
+        'box',
+        { style: s.footer },
+        h(Checkbox, {
+          checked: showHidden,
+          onChange: (e) => setShowHidden(Boolean(e.value)),
+          label: 'Show hidden',
+        }),
+        filters.length
+          ? h(Select, {
+              options: filterOptions,
+              value: filterId,
+              onChange: (e) => setFilterId(e.value),
+              style: { width: 180 },
+            })
+          : null,
+        h('box', { style: s.spacer }),
+        h(Button, { onPress: () => finish(null) }, 'Cancel'),
+        h(Button, { primary: true, onPress: accept }, acceptText),
+      ),
+    ),
+  );
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -7,6 +7,7 @@ export { anchorRect, centerRect, useAnchor } from './anchor.js';
 export { useDropTarget, useDragSource } from './dnd.js';
 export { Button } from './Button.js';
 export { Dialog } from './Dialog.js';
+export { FileDialog } from './FileDialog.js';
 export { Checkbox } from './Checkbox.js';
 export { Radio, RadioGroup } from './Radio.js';
 export { Switch } from './Switch.js';

--- a/src/filedialog.js
+++ b/src/filedialog.js
@@ -1,0 +1,375 @@
+// Open, save, and pick a folder — through whatever this machine actually has.
+//
+// There is no one answer, so this is a ladder, tried in order:
+//
+//   1. **the portal** — `org.freedesktop.portal.FileChooser` over D-Bus. The
+//      real desktop dialog, with the user's bookmarks and recent files, drawn
+//      by GTK or KDE in another process. What a Linux desktop should get.
+//   2. **`osascript`** — macOS with no portal, which is every XQuartz install
+//      that has not gone out of its way. `choose file` is `NSOpenPanel`, so
+//      the user gets the dialog they know.
+//   3. **the built-in dialog** — a file browser drawn by react-x11 itself.
+//      Reached over ssh, under a bare `startx`, in a container: everywhere
+//      there is a display and nothing else. See `components/FileDialog.js`;
+//      it needs a React tree, so `useFileDialog()` has it and the bare
+//      functions here do not.
+//
+// The ladder is the whole design. A file dialog that only works on a full
+// GNOME session would be useless to the person running this over ssh from a
+// laptop, which is the case react-x11 exists for.
+//
+// ## What each rung cannot do
+//
+// - **The portal never embeds.** The dialog is a top-level window in another
+//   process; all you get is logical parenting, through `parent_window`. That
+//   is `transientFor` by another name, and it is why these calls want a window
+//   to point at.
+// - **macOS has no cross-process transient-for at all.** XQuartz windows are
+//   `NSWindow`s owned by X11.app, and `addChildWindow` is same-process only.
+//   So the panel appears over the app but is not attached to it. Application
+//   modality still works, because the caller is awaiting the promise.
+// - **The built-in dialog is ours**, so it is the only rung that can be
+//   modal-and-parented properly — and the only one that has never seen the
+//   user's bookmarks.
+
+import {
+  NoPortalError,
+  PORTAL_NAME,
+  PortalCancelledError,
+  RESPONSE_CANCELLED,
+  RESPONSE_OK,
+  hasService,
+  parentWindowHandle,
+  pathBytes,
+  portalRequest,
+  variant,
+} from './portal.js';
+import { sessionBus } from './bus.js';
+import { windowIdOf } from './windowid.js';
+
+const FILE_CHOOSER = 'org.freedesktop.portal.FileChooser';
+
+/**
+ * Nothing on this machine can show a file dialog, and nothing here can draw
+ * one either.
+ *
+ * Only the bare functions throw this — `useFileDialog()` has a tree to draw
+ * in, so it never runs out of rungs. It is a **typed** rejection because it is
+ * a fallback signal, not a crash: a caller that has its own UI branches on it.
+ */
+export class NoFileDialogError extends Error {
+  constructor(cause) {
+    super(
+      'react-x11: no file dialog is available — there is no ' +
+        'xdg-desktop-portal on the bus, and this is not macOS. Use ' +
+        'useFileDialog() instead, which draws one, or supply `backend`.',
+      { cause },
+    );
+    this.name = 'NoFileDialogError';
+  }
+}
+
+export { PortalCancelledError };
+
+// --------------------------------------------------------------------------
+// Options, in one shape, translated per backend
+// --------------------------------------------------------------------------
+
+/**
+ * `[{ name: 'Images', extensions: ['png', 'jpg'] }]` → the portal's
+ * `a(sa(us))`: a list of (label, [(type, pattern)]) where type 0 is a glob and
+ * 1 is a MIME type.
+ *
+ * Extensions are turned into globs here rather than asking callers for
+ * `*.png`, because every other file-dialog API in the world takes extensions
+ * and the glob is a portal implementation detail.
+ */
+function portalFilters(filters) {
+  return filters.map((f) => [
+    f.name ?? '',
+    [
+      ...(f.extensions ?? []).map((ext) => [
+        0,
+        `*.${String(ext).replace(/^[.*]*\.?/, '')}`,
+      ]),
+      ...(f.mimeTypes ?? []).map((type) => [1, type]),
+    ],
+  ]);
+}
+
+async function portalOptions(opts, { save, directory }) {
+  const options = {};
+  if (opts.acceptLabel) options.accept_label = opts.acceptLabel;
+  if (opts.multiple && !save) options.multiple = true;
+  if (directory) options.directory = true;
+  if (opts.modal !== false) options.modal = true;
+  if (opts.filters?.length) {
+    options.filters = await variant('a(sa(us))', portalFilters(opts.filters));
+  }
+  // Paths are NUL-terminated byte arrays here, not strings. A string marshals
+  // as `s` and the backend ignores it without saying so.
+  if (opts.defaultFolder)
+    options.current_folder = pathBytes(opts.defaultFolder);
+  if (save && opts.defaultName) options.current_name = opts.defaultName;
+  if (save && opts.defaultPath)
+    options.current_file = pathBytes(opts.defaultPath);
+  return options;
+}
+
+/** `file:///a/b%20c` → `/a/b c`. Anything not a file: URI is dropped. */
+async function urisToPaths(uris) {
+  const { fileURLToPath } = await import('node:url');
+  const out = [];
+  for (const uri of uris ?? []) {
+    if (typeof uri !== 'string') continue;
+    try {
+      if (uri.startsWith('file://')) out.push(fileURLToPath(uri));
+      else if (uri.startsWith('/')) out.push(uri);
+    } catch {
+      // a URI we cannot turn into a path is not one the caller can open
+    }
+  }
+  return out;
+}
+
+// --------------------------------------------------------------------------
+// Rung 1: the portal
+// --------------------------------------------------------------------------
+
+async function portalDialog(kind, opts, ref) {
+  const member = kind === 'save' ? 'SaveFile' : 'OpenFile';
+  const { response, results } = await portalRequest(ref, {
+    iface: FILE_CHOOSER,
+    member,
+    parentWindow: parentWindowHandle(windowIdOf(opts.parentWindow)),
+    title: opts.title ?? defaultTitle(kind),
+    options: await portalOptions(opts, {
+      save: kind === 'save',
+      directory: kind === 'folder',
+    }),
+    signal: opts.signal,
+  });
+  if (response !== RESPONSE_OK) throw new PortalCancelledError(response);
+  return urisToPaths(results?.uris);
+}
+
+// --------------------------------------------------------------------------
+// Rung 2: osascript, on macOS
+// --------------------------------------------------------------------------
+
+/** AppleScript string literal. */
+const as = (s) => `"${String(s).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+
+/**
+ * The AppleScript for one dialog, as `-e` lines.
+ *
+ * Every branch normalises to newline-separated POSIX paths, so the caller
+ * parses one shape. `choose file` hands back an alias and `choose file name` a
+ * file reference that need not exist yet; `POSIX path of` works on both.
+ */
+export function osascriptLines(kind, opts = {}) {
+  const title = opts.title ?? defaultTitle(kind);
+  const parts = [];
+
+  if (kind === 'save') {
+    parts.push(`set theFiles to choose file name with prompt ${as(title)}`);
+    if (opts.defaultName) parts.push(`default name ${as(opts.defaultName)}`);
+    if (opts.defaultFolder) {
+      parts.push(`default location POSIX file ${as(opts.defaultFolder)}`);
+    }
+  } else if (kind === 'folder') {
+    parts.push(`set theFiles to choose folder with prompt ${as(title)}`);
+    if (opts.defaultFolder) {
+      parts.push(`default location POSIX file ${as(opts.defaultFolder)}`);
+    }
+    // `with …` flags go last: AppleScript is tolerant about the order of
+    // labelled parameters and conventional about this one, and the failure
+    // mode of getting it wrong is a syntax error at the far end of a pipe
+    // where nobody is looking.
+    if (opts.multiple) parts.push('with multiple selections allowed');
+  } else {
+    parts.push(`set theFiles to choose file with prompt ${as(title)}`);
+    // Extensions map exactly; MIME types do not, and guessing a UTI wrong
+    // hides the user's file with no way to get at it. So MIME-only filters
+    // mean no type restriction here rather than the wrong one — noted in
+    // docs/filedialog.md as the one place the backends genuinely differ.
+    const extensions = (opts.filters ?? [])
+      .flatMap((f) => f.extensions ?? [])
+      .map((e) => String(e).replace(/^[.*]*\.?/, ''))
+      .filter(Boolean);
+    if (extensions.length) {
+      parts.push(`of type {${[...new Set(extensions)].map(as).join(', ')}}`);
+    }
+    if (opts.defaultFolder) {
+      parts.push(`default location POSIX file ${as(opts.defaultFolder)}`);
+    }
+    if (opts.multiple) parts.push('with multiple selections allowed');
+  }
+
+  return [
+    parts.join(' '),
+    'if class of theFiles is not list then set theFiles to {theFiles}',
+    'set out to ""',
+    'repeat with f in theFiles',
+    'set out to out & POSIX path of f & linefeed',
+    'end repeat',
+    'return out',
+  ].flatMap((line) => ['-e', line]);
+}
+
+async function osascriptDialog(kind, opts) {
+  const { execFile } = await import('node:child_process');
+  const args = osascriptLines(kind, opts);
+  return new Promise((resolve, reject) => {
+    const child = execFile(
+      'osascript',
+      args,
+      { encoding: 'utf8' },
+      (error, stdout, stderr) => {
+        if (error) {
+          if (error.code === 'ENOENT') {
+            return reject(new NoFileDialogError(error));
+          }
+          // AppleScript reports a cancel as -128, which is an ordinary
+          // outcome and must not read as a failure.
+          if (/-128/.test(stderr) || /User canceled/i.test(stderr)) {
+            return reject(new PortalCancelledError(RESPONSE_CANCELLED));
+          }
+          return reject(
+            new Error(
+              `react-x11: the macOS file dialog failed — ${stderr.trim() || error.message}`,
+              { cause: error },
+            ),
+          );
+        }
+        resolve(
+          stdout
+            .split('\n')
+            .map((line) => line.trim())
+            .filter(Boolean),
+        );
+      },
+    );
+    // An abort has to reach the panel; killing osascript closes it.
+    opts.signal?.addEventListener('abort', () => child.kill(), { once: true });
+  });
+}
+
+// --------------------------------------------------------------------------
+// Choosing a rung
+// --------------------------------------------------------------------------
+
+function defaultTitle(kind) {
+  return kind === 'save'
+    ? 'Save file'
+    : kind === 'folder'
+      ? 'Select folder'
+      : 'Open file';
+}
+
+/**
+ * Which rung this machine lands on, without showing anything.
+ *
+ * Useful for a menu that wants to say "Open…" versus "Open (built-in)…", and
+ * for the tests. It acquires a bus ref and releases it, so it is cheap to call
+ * but not free — cache it if it is on a render path.
+ *
+ * @returns {Promise<'portal'|'osascript'|'builtin'>}
+ */
+export async function fileDialogBackend() {
+  const ref = await sessionBus();
+  if (ref) {
+    try {
+      if (await hasService(PORTAL_NAME, ref)) return 'portal';
+    } finally {
+      await ref.release();
+    }
+  }
+  if (process.platform === 'darwin') return 'osascript';
+  return 'builtin';
+}
+
+/**
+ * Run one dialog on the best rung that is not the built-in one.
+ *
+ * Split out so `useFileDialog()` can try exactly this and fall through to its
+ * own dialog, without duplicating the ladder or the option translation.
+ */
+export async function runNativeDialog(kind, opts = {}) {
+  if (opts.backend === 'builtin') throw new NoFileDialogError();
+
+  const wantPortal = !opts.backend || opts.backend === 'portal';
+  if (wantPortal) {
+    const ref = await sessionBus();
+    if (ref) {
+      try {
+        if (await hasService(PORTAL_NAME, ref)) {
+          return await portalDialog(kind, opts, ref);
+        }
+      } finally {
+        await ref.release();
+      }
+    }
+    if (opts.backend === 'portal') {
+      throw new NoPortalError('no xdg-desktop-portal on the session bus');
+    }
+  }
+
+  const wantOsascript = !opts.backend || opts.backend === 'osascript';
+  if (wantOsascript && (process.platform === 'darwin' || opts.backend)) {
+    return await osascriptDialog(kind, opts);
+  }
+
+  throw new NoFileDialogError();
+}
+
+/**
+ * Ask for one or more existing files.
+ *
+ * ```js
+ * const files = await openFile({ multiple: true, filters: [
+ *   { name: 'Images', extensions: ['png', 'jpg'] },
+ * ]});
+ * if (!files) return;              // cancelled
+ * ```
+ *
+ * Resolves to **absolute paths**, or `null` when the user cancelled —
+ * cancelling is an ordinary outcome and should not need a `try`. Rejects with
+ * {@link NoFileDialogError} when there is no portal and no `osascript`, which
+ * is the signal to draw your own; {@link useFileDialog} does that for you.
+ *
+ * @returns {Promise<string[] | null>}
+ */
+export function openFile(options) {
+  return cancellable('open', options);
+}
+
+/**
+ * Ask where to write a file. Resolves to one **absolute path** — which need
+ * not exist yet — or `null` when the user cancelled.
+ *
+ * @returns {Promise<string | null>}
+ */
+export async function saveFile(options) {
+  const paths = await cancellable('save', options);
+  return paths ? (paths[0] ?? null) : null;
+}
+
+/**
+ * Ask for a directory. Resolves to absolute paths, or `null` when cancelled.
+ *
+ * @returns {Promise<string[] | null>}
+ */
+export function selectFolder(options) {
+  return cancellable('folder', options);
+}
+
+/** Cancellation is an answer, not an error. Everything else propagates. */
+async function cancellable(kind, options = {}) {
+  try {
+    return await runNativeDialog(kind, options);
+  } catch (err) {
+    if (err instanceof PortalCancelledError) return null;
+    throw err;
+  }
+}

--- a/src/filedialoghooks.js
+++ b/src/filedialoghooks.js
@@ -1,0 +1,126 @@
+// `useFileDialog()` — the file dialog with the bottom rung attached.
+//
+// The bare `openFile()` in `filedialog.js` can reach the portal and
+// `osascript`, and rejects with `NoFileDialogError` when there is neither,
+// because a function has nowhere to draw. A component does: this hook mounts
+// the built-in browser on the connection the tree is already using, so the
+// ladder never runs out and an app never needs a `catch` that renders a
+// second dialog of its own.
+//
+// ## Why a second root rather than an element to render
+//
+// The obvious alternative is `const { open, dialog } = useFileDialog()` with
+// `{dialog}` rendered somewhere — which is a documentation step for every app
+// author, forever, and one that fails silently when forgotten: `open()` would
+// resolve to nothing with no clue why.
+//
+// A file dialog is a **top-level window** on every other rung, so it is one
+// here too: `createRoot({ app })` borrows the tree's own X connection (it
+// never closes a borrowed one) and renders a real, window-manager-placed,
+// `transientFor` dialog. Nothing to render, nothing to forget, and the same
+// window on all three rungs.
+
+import { useCallback, useMemo } from 'react';
+import React from 'react';
+
+import { FileDialog } from './components/FileDialog.js';
+import { useTheme } from './components/theme.js';
+import { NoFileDialogError, runNativeDialog } from './filedialog.js';
+import { PortalCancelledError } from './portal.js';
+import { useApp } from './appcontext.js';
+import { createRoot } from './Reconciler.js';
+import { windowIdOf } from './windowid.js';
+
+/**
+ * Show the built-in dialog on its own root, and resolve with what the user
+ * chose. The root is torn down before the promise settles, so a caller that
+ * opens a second dialog in the `.then()` never has two on screen.
+ */
+async function showBuiltin(app, theme, props) {
+  const root = await createRoot({ app });
+  try {
+    return await new Promise((resolve) => {
+      // `<FileDialog>` renders a `<window>`, and a window may only be a root
+      // child or nested in another window — so the palette travels as a prop
+      // and the dialog installs the provider *inside* its own window. Wrapping
+      // it here in `<ThemeProvider>` would put a `<box>` between the root and
+      // the window, which throws.
+      root.render(
+        React.createElement(FileDialog, { ...props, theme, onDone: resolve }),
+      );
+    });
+  } finally {
+    await root.unmount();
+  }
+}
+
+/**
+ * File dialogs, on the best rung this machine has.
+ *
+ * ```jsx
+ * const { openFile, saveFile } = useFileDialog({ parentWindow: windowRef });
+ *
+ * <MenuBar onSelect={async (id) => {
+ *   if (id === 'open') {
+ *     const files = await openFile({ filters: [{ name: 'Text', extensions: ['txt', 'md'] }] });
+ *     if (files) load(files[0]);       // null means the user cancelled
+ *   }
+ * }} />
+ * ```
+ *
+ * `parentWindow` — a `<window>` ref or a raw XID — is what makes the dialog
+ * behave like a dialog: `transientFor` for the built-in one, `parent_window`
+ * for the portal. It is optional and worth the one line; without it the
+ * dialog floats unparented, which is legal and looks careless.
+ *
+ * Every call resolves to `null` when the user cancels. That is an ordinary
+ * outcome, not an exception, on all three rungs.
+ */
+export function useFileDialog(defaults = {}) {
+  const app = useApp();
+  const theme = useTheme();
+
+  const run = useCallback(
+    async (kind, options = {}) => {
+      const opts = { ...defaults, ...options };
+      try {
+        return await runNativeDialog(kind, opts);
+      } catch (err) {
+        if (err instanceof PortalCancelledError) return null;
+        if (!(err instanceof NoFileDialogError)) throw err;
+        // The bottom rung. Reached over ssh, under startx, in a container —
+        // and on any machine whose portal went away between calls.
+        return showBuiltin(app, theme, {
+          kind,
+          title: opts.title,
+          startFolder: opts.defaultFolder,
+          defaultName: opts.defaultName,
+          filters: opts.filters ?? [],
+          multiple: !!opts.multiple && kind !== 'save',
+          acceptLabel: opts.acceptLabel,
+          parentWindow: windowIdOf(opts.parentWindow) ?? undefined,
+        });
+      }
+    },
+    // `defaults` is deliberately not a dependency: an app writes it inline, so
+    // a new object every render would rebuild these callbacks every render and
+    // defeat the memo below. It is read through the closure at call time,
+    // which is when its values are actually wanted.
+    [app, theme],
+  );
+
+  return useMemo(
+    () => ({
+      /** @returns {Promise<string[] | null>} absolute paths, or null if cancelled */
+      openFile: (options) => run('open', options),
+      /** @returns {Promise<string | null>} one absolute path, or null if cancelled */
+      saveFile: async (options) => {
+        const paths = await run('save', options);
+        return paths ? (paths[0] ?? null) : null;
+      },
+      /** @returns {Promise<string[] | null>} absolute paths, or null if cancelled */
+      selectFolder: (options) => run('folder', options),
+    }),
+    [run],
+  );
+}

--- a/src/filedialoghooks.js
+++ b/src/filedialoghooks.js
@@ -29,7 +29,7 @@ import { NoFileDialogError, runNativeDialog } from './filedialog.js';
 import { PortalCancelledError } from './portal.js';
 import { useApp } from './appcontext.js';
 import { createRoot } from './Reconciler.js';
-import { windowIdOf } from './windowid.js';
+import { useTopLevelWindow, windowIdOf } from './windowid.js';
 
 /**
  * Show the built-in dialog on its own root, and resolve with what the user
@@ -58,7 +58,7 @@ async function showBuiltin(app, theme, props) {
  * File dialogs, on the best rung this machine has.
  *
  * ```jsx
- * const { openFile, saveFile } = useFileDialog({ parentWindow: windowRef });
+ * const { openFile, saveFile } = useFileDialog();
  *
  * <MenuBar onSelect={async (id) => {
  *   if (id === 'open') {
@@ -68,10 +68,11 @@ async function showBuiltin(app, theme, props) {
  * }} />
  * ```
  *
- * `parentWindow` — a `<window>` ref or a raw XID — is what makes the dialog
- * behave like a dialog: `transientFor` for the built-in one, `parent_window`
- * for the portal. It is optional and worth the one line; without it the
- * dialog floats unparented, which is legal and looks careless.
+ * **No arguments needed.** The dialog is parented to the window this
+ * component is in — `transientFor` for the built-in one, `parent_window` for
+ * the portal — worked out at the moment it opens rather than asked for.
+ * `parentWindow` remains as the override for a tree with several top-level
+ * windows, where inference has to guess and says so.
  *
  * Every call resolves to `null` when the user cancels. That is an ordinary
  * outcome, not an exception, on all three rungs.
@@ -79,10 +80,15 @@ async function showBuiltin(app, theme, props) {
 export function useFileDialog(defaults = {}) {
   const app = useApp();
   const theme = useTheme();
+  // The window this component is in, resolved when a dialog actually opens —
+  // by which time it is mounted and has an XID. So a parented dialog costs
+  // the app nothing, and `parentWindow` is left as the override for a tree
+  // with several top-level windows. See `useTopLevelWindow`.
+  const owner = useTopLevelWindow();
 
   const run = useCallback(
     async (kind, options = {}) => {
-      const opts = { ...defaults, ...options };
+      const opts = { parentWindow: owner, ...defaults, ...options };
       try {
         return await runNativeDialog(kind, opts);
       } catch (err) {
@@ -106,7 +112,7 @@ export function useFileDialog(defaults = {}) {
     // a new object every render would rebuild these callbacks every render and
     // defeat the memo below. It is read through the closure at call time,
     // which is when its values are actually wanted.
-    [app, theme],
+    [app, theme, owner],
   );
 
   return useMemo(

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,6 +17,7 @@ export * from './types/nodes.js';
 export * from './types/elements.js';
 export * from './types/components.js';
 export * from './types/dbus.js';
+export * from './types/filedialog.js';
 
 /**
  * The XID of the X11 window a ref points at, or `null` if there is not one

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 export { createRoot, Renderer } from './Reconciler.js';
 export { createStyles, flattenStyle } from './styles.js';
-export { windowIdOf, useWindowId } from './windowid.js';
+export { windowIdOf, useWindowId, useTopLevelWindow } from './windowid.js';
 export { launchTimestamp, notifyStartupComplete } from './startup.js';
 export { parseUriList } from './transfer.js';
 export { useApp, useClipboard, useSupports } from './appcontext.js';

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,20 @@ export { useApp, useClipboard, useSupports } from './appcontext.js';
 export { BusUnavailableError, closeBus, sessionBus, systemBus } from './bus.js';
 export { useSessionBus, useSystemBus } from './bushooks.js';
 export {
+  NoPortalError,
+  PortalCancelledError,
+  hasService,
+  portalRequest,
+} from './portal.js';
+export {
+  NoFileDialogError,
+  fileDialogBackend,
+  openFile,
+  saveFile,
+  selectFolder,
+} from './filedialog.js';
+export { useFileDialog } from './filedialoghooks.js';
+export {
   useDropTarget,
   useDragSource,
   Select,

--- a/src/portal.js
+++ b/src/portal.js
@@ -1,0 +1,300 @@
+// xdg-desktop-portal: the shared machinery every portal-backed feature needs,
+// and nothing user-visible.
+//
+// A portal is a D-Bus API, not a widget. An app asks "the desktop" to run a
+// dialog *in another process* and hand back the answer — which is how a
+// sandboxed app gets a file picker it is not allowed to draw, and how a Qt app
+// on GNOME gets a GTK dialog with your bookmarks in it.
+//
+// ## The one thing that is easy to get wrong
+//
+// Every portal method that shows UI has the same shape: it returns an object
+// path **immediately** and answers later with a
+// `org.freedesktop.portal.Request.Response` signal. Subscribe after the call
+// returns and you can lose the answer — the dialog can be dismissed before
+// your match rule is in place.
+//
+// So the path is predictable *by design*. From the upstream
+// `org.freedesktop.portal.Request.xml`:
+//
+// > Since version 0.9 of xdg-desktop-portal, the handle will be of the form
+// > `/org/freedesktop/portal/desktop/request/SENDER/TOKEN` where SENDER is the
+// > callers unique name, with the initial ':' removed and all '.' replaced by
+// > '_' […] This change was made to let applications subscribe to the Response
+// > signal before making the initial portal call, thereby avoiding a race
+// > condition.
+//
+// `portalRequest()` is that subscribe-then-call, written once, so every portal
+// added later is a method name and an options dict rather than a race to
+// re-solve.
+
+import { loadTransport, sessionBus } from './bus.js';
+
+export const PORTAL_NAME = 'org.freedesktop.portal.Desktop';
+export const PORTAL_PATH = '/org/freedesktop/portal/desktop';
+const REQUEST_IFACE = 'org.freedesktop.portal.Request';
+
+/** The portal answered; `response` is what it means. */
+export const RESPONSE_OK = 0;
+export const RESPONSE_CANCELLED = 1;
+export const RESPONSE_ENDED = 2;
+
+/**
+ * There is no portal here — no bus, no service, or a version too old for what
+ * was asked. A **typed** rejection rather than a crash: it is the signal that
+ * a caller should fall back to something it can draw itself, which is exactly
+ * what the file dialog does.
+ */
+export class NoPortalError extends Error {
+  constructor(message, cause) {
+    super(`react-x11: ${message}`, { cause });
+    this.name = 'NoPortalError';
+  }
+}
+
+/** The user closed the dialog, or the desktop ended the request some other way. */
+export class PortalCancelledError extends Error {
+  constructor(response = RESPONSE_CANCELLED) {
+    super(
+      response === RESPONSE_CANCELLED
+        ? 'react-x11: the portal dialog was cancelled'
+        : 'react-x11: the portal request ended without an answer',
+    );
+    this.name = 'PortalCancelledError';
+    /** 1 when the user cancelled, 2 when it ended some other way. */
+    this.response = response;
+  }
+}
+
+/**
+ * `':1.42'` → `'1_42'`.
+ *
+ * The transform is three characters of code and the whole reason the Request
+ * race is avoidable, so it is named and tested rather than inlined.
+ */
+export const senderPath = (uniqueName) =>
+  uniqueName.replace(/^:/, '').replaceAll('.', '_');
+
+/**
+ * A token that is a legal object-path element and not guessable — the XML asks
+ * for "a per-library prefix combined with a random number", so: ours plus
+ * eight random bytes.
+ */
+async function newToken() {
+  const { randomBytes } = await import('node:crypto');
+  return `rx11_${randomBytes(8).toString('hex')}`;
+}
+
+// --------------------------------------------------------------------------
+// hasService
+// --------------------------------------------------------------------------
+
+/**
+ * Cache per bus generation. `NameOwnerChanged` would invalidate it precisely;
+ * a portal appearing mid-session is rare enough that the cheap version — cache
+ * only the *positive* answer — is the honest trade. A false negative that
+ * cached would be the bug (a feature disabled for the life of the process),
+ * and this cannot produce one.
+ */
+const reachable = new Map();
+
+/**
+ * Is `name` reachable — owned right now, **or activatable on demand**?
+ *
+ * `NameHasOwner` alone is the wrong question and gets this wrong on a healthy
+ * desktop. `org.freedesktop.portal.Desktop` ships a D-Bus service file:
+ *
+ *     [D-BUS Service]
+ *     Name=org.freedesktop.portal.Desktop
+ *     Exec=…/xdg-desktop-portal
+ *
+ * so on a GNOME session where no app has touched a portal yet the name has no
+ * owner and would answer *false* — and a feature gated on it takes the
+ * fallback path forever, on a machine where the portal works perfectly.
+ */
+export async function hasService(name, busRef) {
+  if (reachable.get(name)) return true;
+  const ref = busRef ?? (await sessionBus());
+  if (!ref) return false;
+  try {
+    const [owned, activatable] = await Promise.all([
+      ref.bus.listNames(),
+      ref.bus.listActivatableNames().catch(() => []),
+    ]);
+    const found = owned.includes(name) || activatable.includes(name);
+    if (found) reachable.set(name, true);
+    return found;
+  } catch {
+    return false;
+  } finally {
+    if (!busRef) await ref.release();
+  }
+}
+
+/** Test seam, not public: forget what was learned about the bus. */
+export function _resetServiceCache() {
+  reachable.clear();
+}
+
+// --------------------------------------------------------------------------
+// The Request helper
+// --------------------------------------------------------------------------
+
+/**
+ * Call a portal method that answers through a `Request`, with the
+ * subscription already in place before the call goes out.
+ *
+ * ```js
+ * const { response, results } = await portalRequest(ref, {
+ *   iface: 'org.freedesktop.portal.FileChooser',
+ *   member: 'OpenFile',
+ *   parentWindow: 'x11:1a00007',
+ *   title: 'Open',
+ *   options: { multiple: true },
+ * });
+ * ```
+ *
+ * Three things it owns, so that no caller reimplements them:
+ *
+ * - **Cancellation.** An `AbortSignal` calls `Request.Close()` on the same
+ *   path. Per the XML that means **no `Response` is emitted**, so the promise
+ *   has to be settled here rather than left waiting for one.
+ * - **Deadlines.** There is deliberately **no timeout on the answer** — a
+ *   dialog can legitimately be open for an hour, which is the whole reason
+ *   portals are request-shaped instead of plain calls. Only the initial method
+ *   call gets a short one: a portal that does not hand back a handle in a few
+ *   seconds is not there.
+ * - **A pre-0.9 portal** that returns an unpredictable path. Cheap insurance:
+ *   re-subscribe on whatever came back.
+ *
+ * @param {{ bus: any, uniqueName: string }} busRef
+ * @returns {Promise<{ response: number, results: object }>}
+ */
+export async function portalRequest(
+  busRef,
+  { iface, member, parentWindow = '', title = '', options = {}, signal },
+) {
+  const { bus, uniqueName } = busRef;
+  const token = await newToken();
+  const path = `${PORTAL_PATH}/request/${senderPath(uniqueName)}/${token}`;
+
+  if (signal?.aborted) throw signal.reason ?? new PortalCancelledError();
+
+  const subscribe = async (requestPath) => {
+    const sub = await bus.watch(
+      `type='signal',sender='${PORTAL_NAME}',` +
+        `interface='${REQUEST_IFACE}',member='Response',path='${requestPath}'`,
+    );
+    const key = bus.mangle(requestPath, REQUEST_IFACE, 'Response');
+    return { sub, key };
+  };
+
+  // Subscribe FIRST. Everything else in this function is bookkeeping around
+  // the fact that this line comes before the invoke.
+  let { sub, key } = await subscribe(path);
+  const answered = new Promise((resolve) => {
+    // `bus.signals` emits the signal's argument array.
+    bus.signals.once(key, ([response, results]) =>
+      resolve({ response, results: results ?? {} }),
+    );
+  });
+
+  const closeRequest = (requestPath) =>
+    bus
+      .invoke({
+        destination: PORTAL_NAME,
+        path: requestPath,
+        interface: REQUEST_IFACE,
+        member: 'Close',
+        signature: '',
+        body: [],
+      })
+      .catch(() => {
+        // The request may already be gone — that is the outcome we wanted.
+      });
+
+  let onAbort;
+  try {
+    let handle;
+    try {
+      handle = await bus.invoke(
+        {
+          destination: PORTAL_NAME,
+          path: PORTAL_PATH,
+          interface: iface,
+          member,
+          signature: 'ssa{sv}',
+          body: [parentWindow, title, { ...options, handle_token: token }],
+        },
+        { timeout: 10_000 },
+      );
+    } catch (cause) {
+      throw new NoPortalError(`${iface}.${member} did not answer`, cause);
+    }
+
+    // Pre-0.9 portals chose their own path. Re-subscribe on the real one; the
+    // first subscription stays until the finally below, which is cheaper than
+    // getting the ordering wrong.
+    if (typeof handle === 'string' && handle !== path) {
+      const moved = await subscribe(handle);
+      bus.signals.once(moved.key, ([response, results]) => {
+        bus.signals.emit(key, [response, results]);
+      });
+      sub = { remove: () => Promise.all([sub.remove(), moved.sub.remove()]) };
+    }
+
+    if (signal) {
+      onAbort = () => closeRequest(handle ?? path);
+      signal.addEventListener('abort', onAbort, { once: true });
+      // `Close()` produces no Response, so the abort has to settle the race
+      // itself rather than wait for one that will never arrive.
+      const aborted = new Promise((_, reject) => {
+        signal.addEventListener(
+          'abort',
+          () => reject(signal.reason ?? new PortalCancelledError()),
+          { once: true },
+        );
+      });
+      return await Promise.race([answered, aborted]);
+    }
+
+    return await answered;
+  } finally {
+    if (onAbort) signal.removeEventListener('abort', onAbort);
+    await sub.remove().catch(() => {});
+  }
+}
+
+/**
+ * A `parent_window` handle for the portal, or `''` when there is no window to
+ * name — which is legal and just means the dialog floats.
+ *
+ * Lowercase hex, no `0x`. Both shipping backends tolerate a prefix, which is
+ * precisely why it is easy to get wrong and never notice; Qt's parser answers
+ * 0 on failure with no error path, so a third backend would silently give an
+ * unparented, non-modal dialog rather than throw.
+ */
+export function parentWindowHandle(xid) {
+  return typeof xid === 'number' && xid > 0 ? `x11:${xid.toString(16)}` : '';
+}
+
+/**
+ * `Variant`, from the one copy of the transport the bus layer loaded.
+ *
+ * Needed for the option types inference cannot produce — `a(sa(us))` for
+ * filters, `u` where a plain number would marshal as `i`.
+ */
+export async function variant(signature, value) {
+  const dbus = await loadTransport();
+  return new dbus.Variant(signature, value);
+}
+
+/**
+ * A NUL-terminated byte array, which is how the FileChooser portal spells a
+ * path in its options (`current_folder`, `current_file`). A plain string there
+ * marshals as `s` and the backend ignores it — silently, which is the failure
+ * mode worth writing a helper to avoid.
+ */
+export function pathBytes(value) {
+  return Buffer.from(`${value}\0`, 'utf8');
+}

--- a/src/types/filedialog.d.ts
+++ b/src/types/filedialog.d.ts
@@ -1,0 +1,221 @@
+/**
+ * The file dialog and the portal machinery under it. See docs/filedialog.md.
+ */
+
+import type { ReactNode, RefObject } from 'react';
+import type { MessageBus } from './dbus.js';
+import type { DrawnNode, NtkWindow } from './nodes.js';
+
+/**
+ * The shape of `AbortSignal` this uses.
+ *
+ * Named structurally rather than reaching for the global: these declarations
+ * compile with `types: []` and no `DOM` lib — adding `DOM` to get one name
+ * would also make `<div>` legal JSX, which owning the element namespace exists
+ * to prevent. A real `AbortSignal` satisfies this.
+ */
+export interface AbortSignalLike {
+  readonly aborted: boolean;
+  readonly reason?: unknown;
+  addEventListener(
+    type: 'abort',
+    listener: () => void,
+    options?: { once?: boolean },
+  ): void;
+  removeEventListener(type: 'abort', listener: () => void): void;
+}
+
+/** Which rung of the ladder answered — or would. */
+export type FileDialogBackend = 'portal' | 'osascript' | 'builtin';
+
+/**
+ * One entry in a dialog's type filter.
+ *
+ * Give `extensions` where you can: they translate to every backend. MIME types
+ * reach the portal exactly and macOS not at all — see docs/filedialog.md.
+ */
+export interface FileFilter {
+  name: string;
+  /** `['png', 'jpg']` — with or without the leading dot. */
+  extensions?: string[];
+  /** `['image/png']`. Portal only. */
+  mimeTypes?: string[];
+}
+
+/** Anything a `<window>`/`<popup>` ref or XID can be given as. */
+export type WindowTarget =
+  | NtkWindow
+  | DrawnNode
+  | RefObject<NtkWindow | DrawnNode | null>
+  | number
+  | null;
+
+export interface FileDialogOptions {
+  title?: string;
+  /** Several files at once. Ignored when saving — that is always one file. */
+  multiple?: boolean;
+  filters?: FileFilter[];
+  /** Where the dialog opens. */
+  defaultFolder?: string;
+  /** The name a save dialog starts with. */
+  defaultName?: string;
+  /** The file a save dialog starts on, replacing `defaultName`. */
+  defaultPath?: string;
+  /** The confirm button's text — 'Import', 'Attach', … */
+  acceptLabel?: string;
+  /**
+   * The window the dialog belongs to. `transientFor` for the built-in dialog,
+   * `parent_window` for the portal; macOS has no cross-process equivalent and
+   * ignores it. Worth the one line — without it the dialog floats.
+   */
+  parentWindow?: WindowTarget;
+  /** Abort the dialog. Closes the portal request or kills `osascript`. */
+  signal?: AbortSignalLike;
+  /**
+   * Force a rung instead of taking the best available one. The seam for a
+   * kiosk that must never show the desktop's dialog, and for tests.
+   */
+  backend?: FileDialogBackend;
+  /** `false` lets the portal dialog be non-modal. Default `true`. */
+  modal?: boolean;
+}
+
+/**
+ * Nothing on this machine can show a file dialog, and the caller cannot draw
+ * one either. A **typed** rejection, so it reads as "fall back to your own UI"
+ * rather than as a crash — {@link useFileDialog} never throws it, because it
+ * has a tree to draw in.
+ */
+export declare class NoFileDialogError extends Error {
+  readonly name: 'NoFileDialogError';
+  readonly cause?: unknown;
+}
+
+/** There is no portal here — no bus, no service, or a version too old. */
+export declare class NoPortalError extends Error {
+  readonly name: 'NoPortalError';
+  readonly cause?: unknown;
+}
+
+/** The user dismissed the dialog. Surfaced as `null`, not thrown, by the
+ * functions below; exported for code driving {@link portalRequest} directly. */
+export declare class PortalCancelledError extends Error {
+  readonly name: 'PortalCancelledError';
+  /** 1 when the user cancelled, 2 when it ended some other way. */
+  readonly response: number;
+}
+
+/**
+ * Which rung this machine lands on, without showing anything.
+ *
+ * Acquires a bus reference and releases it, so it is cheap but not free —
+ * cache it rather than calling it on a render path.
+ */
+export declare function fileDialogBackend(): Promise<FileDialogBackend>;
+
+/**
+ * Ask for existing files. Resolves to absolute paths, or `null` when the user
+ * cancelled.
+ *
+ * Rejects with {@link NoFileDialogError} where there is no portal and no
+ * `osascript`; {@link useFileDialog} draws its own dialog instead.
+ */
+export declare function openFile(
+  options?: FileDialogOptions,
+): Promise<string[] | null>;
+
+/** Ask where to write a file. One absolute path, which need not exist yet. */
+export declare function saveFile(
+  options?: FileDialogOptions,
+): Promise<string | null>;
+
+/** Ask for directories. Absolute paths, or `null` when cancelled. */
+export declare function selectFolder(
+  options?: FileDialogOptions,
+): Promise<string[] | null>;
+
+export interface FileDialogs {
+  openFile(options?: FileDialogOptions): Promise<string[] | null>;
+  saveFile(options?: FileDialogOptions): Promise<string | null>;
+  selectFolder(options?: FileDialogOptions): Promise<string[] | null>;
+}
+
+/**
+ * File dialogs that never run out of rungs: the desktop's own where there is
+ * one, `osascript` on macOS, and a browser react-x11 draws itself everywhere
+ * else. Cancelling resolves to `null` on all three.
+ *
+ * ```tsx
+ * const { openFile } = useFileDialog({ parentWindow: windowRef });
+ * const files = await openFile({ filters: [{ name: 'Text', extensions: ['txt'] }] });
+ * if (files) load(files[0]);
+ * ```
+ */
+export declare function useFileDialog(
+  defaults?: FileDialogOptions,
+): FileDialogs;
+
+export interface FileDialogProps {
+  kind?: 'open' | 'save' | 'folder';
+  title?: string;
+  startFolder?: string;
+  defaultName?: string;
+  filters?: FileFilter[];
+  multiple?: boolean;
+  acceptLabel?: string;
+  /** An XID. Resolved for you when this is rendered by `useFileDialog()`. */
+  parentWindow?: number;
+  /** Called exactly once: the chosen paths, or `null` for cancel. */
+  onDone?: (paths: string[] | null) => void;
+  /** The palette, for when this is rendered on a root with no provider. */
+  theme?: Record<string, unknown>;
+  width?: number;
+  height?: number;
+}
+
+/**
+ * The built-in file browser, as a component. `useFileDialog()` renders this
+ * for you; reach for it directly only when this dialog is the one you want
+ * regardless of what the desktop offers.
+ */
+export declare function FileDialog(props: FileDialogProps): ReactNode;
+
+// ---------------------------------------------------------------------------
+// The portal floor
+// ---------------------------------------------------------------------------
+
+/**
+ * Is `name` reachable — owned now, **or activatable on demand**?
+ *
+ * `NameHasOwner` is the wrong question: `org.freedesktop.portal.Desktop` is
+ * D-Bus-activatable, so on a healthy desktop where no app has touched a portal
+ * yet it has no owner, and a feature gated on that takes the fallback path
+ * forever.
+ */
+export declare function hasService(
+  name: string,
+  busRef?: { bus: MessageBus; uniqueName: string },
+): Promise<boolean>;
+
+export interface PortalRequestOptions {
+  iface: string;
+  member: string;
+  /** `'x11:1a00007'`, or `''` for none. */
+  parentWindow?: string;
+  title?: string;
+  options?: Record<string, unknown>;
+  signal?: AbortSignalLike;
+}
+
+/**
+ * Call a portal method that answers through a `Request`, with the
+ * subscription in place **before** the call goes out — which is the whole
+ * reason this exists rather than each portal doing it slightly wrong.
+ *
+ * There is deliberately no timeout on the answer: a dialog can be open for an
+ * hour. Only the initial call is deadlined.
+ */
+export declare function portalRequest(
+  busRef: { bus: MessageBus; uniqueName: string },
+  options: PortalRequestOptions,
+): Promise<{ response: number; results: Record<string, unknown> }>;

--- a/src/types/filedialog.d.ts
+++ b/src/types/filedialog.d.ts
@@ -141,6 +141,23 @@ export interface FileDialogs {
 }
 
 /**
+ * The window this component is in, resolved when it is read rather than at
+ * render time — a `<window>` has no XID until the commit phase.
+ *
+ * Returns a **ref-like object**, so it drops into anything that already takes
+ * a ref (`parentWindow`, `transientFor`) and `windowIdOf()` resolves it.
+ * `useFileDialog()` uses it for you; reach for it directly when something
+ * else needs the owner window.
+ *
+ * Exact when the tree has one top-level window, which is nearly every app.
+ * With several it prefers the focused one and warns in development when it
+ * has to guess — see docs/filedialog.md.
+ */
+export declare function useTopLevelWindow(): {
+  readonly current: NtkWindow | DrawnNode | null;
+};
+
+/**
  * File dialogs that never run out of rungs: the desktop's own where there is
  * one, `osascript` on macOS, and a browser react-x11 draws itself everywhere
  * else. Cancelling resolves to `null` on all three.

--- a/src/windowid.js
+++ b/src/windowid.js
@@ -5,7 +5,9 @@
 // once: `transientFor` resolves its prop through this, and the
 // xdg-desktop-portal work needs it to build a `parent_window` handle.
 
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
+
+import { useAppOrNull } from './appcontext.js';
 
 /**
  * The XID of the X11 window a ref points at, or `null` if there is not one
@@ -57,4 +59,89 @@ export function windowIdOf(target) {
  */
 export function useWindowId(ref) {
   return useCallback(() => windowIdOf(ref), [ref]);
+}
+
+/**
+ * The top-level windows this connection is currently rendering, in the order
+ * they were added.
+ *
+ * `createContainer(app, …)` passes the app as the container, so
+ * `appendChildToContainer` records every top-level node on the app itself —
+ * which makes "what windows does this tree have" answerable without the app
+ * author wiring anything. Popups are excluded: a `<popup>` is
+ * override-redirect and never what a dialog should be transient for.
+ */
+function topLevelWindows(app) {
+  if (!app) return [];
+  return (app._rootChildren ?? []).filter(
+    (node) => node?.isWindow && !node.isPopup && node.window?.id,
+  );
+}
+
+let warnedAboutAmbiguity = false;
+
+/**
+ * The window a component belongs to, resolved when it is read.
+ *
+ * ```js
+ * const owner = useTopLevelWindow();
+ * // …later, in a handler, when everything is mounted:
+ * const id = windowIdOf(owner);
+ * ```
+ *
+ * **Why this is inference and not a lookup.** A hook has no position in the
+ * host tree: React context cannot come from a host element, the host context
+ * `getChildHostContext` builds reaches `createInstance` and not components,
+ * and a `<window>` has no XID at all until the commit phase. Everything else
+ * in this file walks *up from a node* — which is why the alternative is
+ * `useRef` on the window and a line of wiring in every app that wants a
+ * parented dialog.
+ *
+ * So it answers from what the renderer does know, at read time, when the tree
+ * is mounted and realized:
+ *
+ * - **one top-level window — the overwhelmingly common case — is exact.** The
+ *   component is in that window, because there is nowhere else to be.
+ * - several, and one of them holds the X input focus: that one. You clicked
+ *   in it a moment ago, which is why a dialog is opening.
+ * - several with nothing to separate them: the most recently opened, and a
+ *   development warning naming `parentWindow` as the way to be exact. A
+ *   guess that says it is guessing beats a guess that does not.
+ *
+ * Returns a **ref-like object** rather than a number: the window is not
+ * realized on the first render, so a value read then would be `null` on the
+ * render that matters. It drops into anything that already takes a ref —
+ * `parentWindow`, `transientFor` — and `windowIdOf()` resolves it.
+ */
+export function useTopLevelWindow() {
+  const app = useAppOrNull();
+  return useMemo(
+    () => ({
+      get current() {
+        const windows = topLevelWindows(app);
+        if (windows.length <= 1) return windows[0] ?? null;
+
+        const focused = windows.filter((w) => w.events?.windowFocused);
+        if (focused.length === 1) return focused[0];
+
+        // Nothing separates them. `windowFocused` also defaults to true on an
+        // ntk too old to report focus changes, so "all of them" is the same
+        // answer as "none of them" and both land here.
+        if (process.env.NODE_ENV !== 'production' && !warnedAboutAmbiguity) {
+          warnedAboutAmbiguity = true;
+          console.warn(
+            `react-x11: this tree has ${windows.length} top-level windows and ` +
+              'none of them is uniquely focused, so the owner window is a ' +
+              'guess (the most recently opened). Pass the window explicitly ' +
+              'to be exact:\n' +
+              '  const win = useRef(null);\n' +
+              '  const { openFile } = useFileDialog({ parentWindow: win });\n' +
+              '  return <window ref={win}>…</window>;',
+          );
+        }
+        return windows[windows.length - 1];
+      },
+    }),
+    [app],
+  );
 }

--- a/test/bus.test.js
+++ b/test/bus.test.js
@@ -398,6 +398,34 @@ describe('against a broker', { ...needsBroker }, () => {
     }
   });
 
+  test('closeBus at zero refs settles instead of draining the loop', async () => {
+    // The teardown is a use of the connection. At zero refs the socket is
+    // `unref()`d, so `bus.close()` — which resolves on the socket's own
+    // 'close' event — had nothing holding the loop open, and a process with no
+    // other work drained before the event arrived: the promise never settled
+    // and the process exited silently, mid-close. A child with nothing else
+    // pending is the only place that is observable.
+    const broker = await startBroker();
+    try {
+      const { code, stdout, stderr } = await runScript(
+        `
+        import { sessionBus, closeBus } from './src/bus.js';
+        const ref = await sessionBus();
+        await ref.release();
+        await closeBus('session');
+        console.log('closed');
+        `,
+        { DBUS_SESSION_BUS_ADDRESS: broker.address() },
+        [],
+        5000,
+      );
+      assert.equal(code, 0, stderr);
+      assert.match(stdout, /closed/, 'closeBus() resolved');
+    } finally {
+      await stopBroker(broker);
+    }
+  });
+
   test('generation on death: old refs stay harmless, a new one connects', async () => {
     const socket = await reservedSocket();
     let broker = await startBroker({ socket });

--- a/test/filedialog.test.js
+++ b/test/filedialog.test.js
@@ -30,6 +30,8 @@ import {
 } from '../src/filedialog.js';
 import { _resetBusState, closeBus, sessionBus } from '../src/bus.js';
 import { FileDialog } from '../src/components/FileDialog.js';
+import { useFileDialog } from '../src/filedialoghooks.js';
+import { useTopLevelWindow, windowIdOf } from '../src/windowid.js';
 import {
   act,
   cleanup,
@@ -480,6 +482,124 @@ describe('the built-in dialog', () => {
     fireEvent.click(screen.getByText('Select'));
     await settle();
     assert.deepEqual(done, [dir]);
+  });
+});
+
+describe('the owner window', () => {
+  afterEach(cleanup);
+
+  test('one top-level window is exact, with nothing passed', async () => {
+    let owner;
+    function Probe() {
+      owner = useTopLevelWindow();
+      return React.createElement('text', null, 'hi');
+    }
+    const view = await renderX11(
+      React.createElement(
+        'window',
+        { width: 200, height: 120 },
+        React.createElement(Probe),
+      ),
+      { wrap: false, fonts: FONTS },
+    );
+    await settle();
+    // Read through `windowIdOf`, which is how every consumer reaches it.
+    assert.equal(windowIdOf(owner), view.windowNode.window.id);
+  });
+
+  test('it resolves on read, not on render', async () => {
+    // The first render happens before the window is realized, so a hook that
+    // captured a value then would hand back null on the render that matters.
+    const seen = [];
+    function Probe() {
+      const owner = useTopLevelWindow();
+      seen.push(windowIdOf(owner));
+      return React.createElement('text', null, 'hi');
+    }
+    await renderX11(
+      React.createElement(
+        'window',
+        { width: 200, height: 120 },
+        React.createElement(Probe),
+      ),
+      { wrap: false, fonts: FONTS },
+    );
+    await settle();
+    assert.equal(seen[0], null, 'null during the first render, as expected');
+    // …and the same object answers correctly once there is a window.
+    assert.equal(seen.length >= 1, true);
+  });
+
+  test('a popup is never the owner', async () => {
+    let owner;
+    function Probe() {
+      owner = useTopLevelWindow();
+      return React.createElement(
+        'box',
+        null,
+        React.createElement(
+          'popup',
+          { width: 60, height: 40, x: 10, y: 10 },
+          React.createElement('text', null, 'pop'),
+        ),
+      );
+    }
+    const view = await renderX11(
+      React.createElement(
+        'window',
+        { width: 200, height: 120 },
+        React.createElement(Probe),
+      ),
+      { wrap: false, fonts: FONTS },
+    );
+    await settle();
+    // A <popup> is override-redirect; a dialog transient for one would be
+    // parented to something the window manager does not manage.
+    assert.equal(windowIdOf(owner), view.windowNode.window.id);
+  });
+
+  test('the dialog is parented with no ref and no options at all', async () => {
+    let open;
+    function Probe() {
+      const dialogs = useFileDialog({ backend: 'builtin' });
+      open = () => dialogs.openFile({ defaultFolder: os.tmpdir() });
+      return React.createElement('text', null, 'hi');
+    }
+    const view = await renderX11(
+      React.createElement(
+        'window',
+        { width: 200, height: 120 },
+        React.createElement(Probe),
+      ),
+      { wrap: false, fonts: FONTS },
+    );
+    await settle();
+
+    const created = [];
+    const makeWindow = view.app.createWindow.bind(view.app);
+    view.app.createWindow = (attrs) => {
+      const w = makeWindow(attrs);
+      created.push(w);
+      return w;
+    };
+
+    await act(async () => {
+      open().catch(() => {});
+      await new Promise((r) => setTimeout(r, 300));
+    });
+    assert.equal(created.length, 1, 'the built-in dialog opened');
+
+    const X = view.app.X;
+    const atom = await new Promise((res, rej) =>
+      X.InternAtom(false, 'WM_TRANSIENT_FOR', (e, a) => (e ? rej(e) : res(a))),
+    );
+    const prop = await new Promise((res, rej) =>
+      X.GetProperty(0, created[0].id, atom, 0, 0, 10, (e, p) =>
+        e ? rej(e) : res(p),
+      ),
+    );
+    assert.ok(prop?.data?.length >= 4, 'WM_TRANSIENT_FOR is set');
+    assert.equal(prop.data.readUInt32LE(0), view.windowNode.window.id);
   });
 });
 

--- a/test/filedialog.test.js
+++ b/test/filedialog.test.js
@@ -1,0 +1,557 @@
+// The file dialog (issue #111) and the portal machinery under it (#129).
+//
+// Three rungs, and the tests are organised by which one is being exercised:
+// the portal against a fake one on the broker, `osascript` by the script it
+// builds (it cannot run here), and the built-in browser as an ordinary
+// component. The fourth group is the ladder itself — which rung gets picked,
+// and what happens when there is none.
+import { test, describe, afterEach } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import os from 'node:os';
+import path from 'node:path';
+import React from 'react';
+
+import {
+  NoPortalError,
+  _resetServiceCache,
+  hasService,
+  parentWindowHandle,
+  senderPath,
+} from '../src/portal.js';
+import {
+  NoFileDialogError,
+  fileDialogBackend,
+  openFile,
+  osascriptLines,
+  saveFile,
+  selectFolder,
+} from '../src/filedialog.js';
+import { _resetBusState, closeBus, sessionBus } from '../src/bus.js';
+import { FileDialog } from '../src/components/FileDialog.js';
+import {
+  act,
+  cleanup,
+  fireEvent,
+  renderX11,
+  screen,
+} from '../src/testing/index.js';
+import { fakePortal } from './helpers/fake-portal.js';
+import { transportAvailable, until, withBus } from './helpers/with-bus.js';
+
+const haveTransport = await transportAvailable();
+const needsBroker = haveTransport
+  ? {}
+  : { skip: 'dbus-native is not installed (expected on Node < 22.12)' };
+
+afterEach(() => {
+  _resetServiceCache();
+});
+
+/** A directory with a known shape, for the built-in browser. */
+async function fixture() {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'rx11-files-'));
+  await fs.mkdir(path.join(dir, 'sub'));
+  await fs.writeFile(path.join(dir, 'a.txt'), 'hello');
+  await fs.writeFile(path.join(dir, 'b.md'), 'x');
+  await fs.writeFile(path.join(dir, 'photo.png'), 'y');
+  await fs.writeFile(path.join(dir, '.hidden'), 'z');
+  return dir;
+}
+
+// The dialog is measured, laid out and clicked, so it needs a real font — but
+// not a *particular* one, and not fontconfig, which answers differently on
+// every machine and not at all in a container. KaTeX's face ships with ntk's
+// own dependency tree, which is what `test/integration.test.js` uses for the
+// same reason.
+const require = createRequire(import.meta.url);
+const FONTS = {
+  'sans-serif': path.join(
+    path.dirname(require.resolve('katex/package.json')),
+    'dist',
+    'fonts',
+    'KaTeX_Main-Regular.ttf',
+  ),
+};
+
+// ---------------------------------------------------------------------------
+
+describe('the Request path', () => {
+  // The transform is three characters of code and the entire reason the race
+  // is avoidable, so it is pinned rather than trusted.
+  test('a unique name becomes a request path element', () => {
+    assert.equal(senderPath(':1.42'), '1_42');
+    assert.equal(senderPath(':1.2.3'), '1_2_3');
+    assert.equal(senderPath('1_42'), '1_42');
+  });
+
+  test('parent_window is lowercase hex with no 0x', () => {
+    assert.equal(parentWindowHandle(0x1a00007), 'x11:1a00007');
+    // No window is legal — the dialog just floats. Qt's parser answers 0 on a
+    // malformed handle with no error path, so an empty string is the only
+    // honest way to say "none".
+    assert.equal(parentWindowHandle(null), '');
+    assert.equal(parentWindowHandle(0), '');
+  });
+});
+
+describe('the portal', { ...needsBroker }, () => {
+  test('subscribes before it calls, and gets the answer', async () => {
+    await withBus(async (address) => {
+      const portal = await fakePortal(address, {
+        OpenFile: () => ({
+          response: 0,
+          results: { uris: ['file:///tmp/one.txt', 'file:///tmp/two%20b.txt'] },
+        }),
+      });
+      try {
+        const files = await openFile({ title: 'Pick' });
+        assert.deepEqual(files, ['/tmp/one.txt', '/tmp/two b.txt']);
+        assert.equal(portal.calls.length, 1);
+        // The client's own token, and therefore the path it subscribed to,
+        // reached the portal — which is what makes the path predictable.
+        assert.match(
+          portal.calls[0].options.handle_token,
+          /^rx11_[0-9a-f]{16}$/,
+        );
+        assert.equal(
+          portal.calls[0].path,
+          `/org/freedesktop/portal/desktop/request/${senderPath(
+            await currentUniqueName(),
+          )}/${portal.calls[0].options.handle_token}`,
+        );
+      } finally {
+        await portal.stop();
+      }
+    });
+  });
+
+  test('a cancelled response resolves to null, not a throw', async () => {
+    await withBus(async (address) => {
+      const portal = await fakePortal(address, {
+        OpenFile: () => ({ response: 1, results: {} }),
+      });
+      try {
+        assert.equal(await openFile(), null);
+      } finally {
+        await portal.stop();
+      }
+    });
+  });
+
+  test('options are translated: filters, multiple, folders, names', async () => {
+    await withBus(async (address) => {
+      const portal = await fakePortal(address, {
+        OpenFile: () => ({ response: 1, results: {} }),
+        SaveFile: () => ({ response: 1, results: {} }),
+      });
+      try {
+        await openFile({
+          multiple: true,
+          acceptLabel: 'Choose',
+          defaultFolder: '/tmp/start',
+          filters: [
+            { name: 'Text', extensions: ['.txt', 'md'] },
+            { name: 'Images', mimeTypes: ['image/png'] },
+          ],
+        });
+        const open = portal.calls[0].options;
+        assert.equal(open.multiple, true);
+        assert.equal(open.accept_label, 'Choose');
+        // A path is a NUL-terminated byte array here. A plain string marshals
+        // as `s` and every backend ignores it, silently.
+        assert.ok(Buffer.isBuffer(open.current_folder));
+        assert.equal(open.current_folder.toString(), '/tmp/start\0');
+        // `a(sa(us))`: (label, [(type, pattern)]), type 0 glob and 1 MIME.
+        assert.deepEqual(open.filters, [
+          [
+            'Text',
+            [
+              [0, '*.txt'],
+              [0, '*.md'],
+            ],
+          ],
+          ['Images', [[1, 'image/png']]],
+        ]);
+
+        await saveFile({ defaultName: 'notes.md', multiple: true });
+        const save = portal.calls[1].options;
+        assert.equal(save.current_name, 'notes.md');
+        // Saving is one file; `multiple` is meaningless and must not go out.
+        assert.equal(save.multiple, undefined);
+      } finally {
+        await portal.stop();
+      }
+    });
+  });
+
+  test('the parent window travels as an x11: handle', async () => {
+    await withBus(async (address) => {
+      const portal = await fakePortal(address, {
+        OpenFile: () => ({ response: 1, results: {} }),
+      });
+      try {
+        await openFile({ parentWindow: 0x1a00007 });
+        assert.equal(portal.calls[0].parentWindow, 'x11:1a00007');
+      } finally {
+        await portal.stop();
+      }
+    });
+  });
+
+  test('abort closes the request rather than walking away', async () => {
+    await withBus(async (address) => {
+      // Never answers: the only way out is Close(), which emits no Response —
+      // so a client that merely stopped waiting would leave a dialog on the
+      // user's screen with nobody listening.
+      const portal = await fakePortal(address, {
+        OpenFile: () => ({ silent: true }),
+      });
+      try {
+        const ac = new AbortController();
+        const pending = openFile({ signal: ac.signal });
+        await until(() => portal.calls.length === 1, 'the call to arrive');
+        ac.abort();
+        await assert.rejects(pending, /aborted/i);
+        await until(
+          () => portal.closed.length === 1,
+          'the portal to see Close()',
+        );
+        assert.equal(portal.closed[0], portal.calls[0].path);
+      } finally {
+        await portal.stop();
+      }
+    });
+  });
+
+  test('selectFolder asks for a directory', async () => {
+    await withBus(async (address) => {
+      const portal = await fakePortal(address, {
+        OpenFile: () => ({
+          response: 0,
+          results: { uris: ['file:///tmp/dir'] },
+        }),
+      });
+      try {
+        assert.deepEqual(await selectFolder(), ['/tmp/dir']);
+        assert.equal(portal.calls[0].member, 'OpenFile');
+        assert.equal(portal.calls[0].options.directory, true);
+      } finally {
+        await portal.stop();
+      }
+    });
+  });
+
+  test('a portal that never answers the call is not a portal', async () => {
+    await withBus(async (address) => {
+      // The name is owned but nothing is exported at the object path, so the
+      // method call errors — which must read as "no portal", not as a crash.
+      const dbus = (await import('dbus-native')).default;
+      const squatter = dbus.createClient({ busAddress: address });
+      await new Promise((r) => squatter.connection.once('connect', r));
+      await squatter.requestName('org.freedesktop.portal.Desktop', 0);
+      try {
+        await assert.rejects(
+          () => openFile({ backend: 'portal' }),
+          (err) => err instanceof NoPortalError,
+        );
+      } finally {
+        await squatter.close();
+      }
+    });
+  });
+});
+
+/** The unique name of the shared session bus, for path assertions. */
+async function currentUniqueName() {
+  const ref = await sessionBus();
+  const name = ref.uniqueName;
+  await ref.release();
+  return name;
+}
+
+describe('hasService', { ...needsBroker }, () => {
+  test('true for a name that is owned, false for one that is not', async () => {
+    await withBus(async (address) => {
+      assert.equal(await hasService('org.freedesktop.portal.Desktop'), false);
+      const portal = await fakePortal(address);
+      try {
+        _resetServiceCache();
+        assert.equal(await hasService('org.freedesktop.portal.Desktop'), true);
+        assert.equal(await hasService('org.example.Nothing'), false);
+      } finally {
+        await portal.stop();
+      }
+    });
+  });
+
+  // The activation branch — the reason this is not NameHasOwner — cannot be
+  // covered here: the broker has no service activation, so an activatable
+  // name that nothing owns yet does not exist to be found. Stated so a green
+  // suite is not read as covering it.
+  test('only the positive answer is cached, so a portal that appears is found', async () => {
+    await withBus(async (address) => {
+      assert.equal(await hasService('org.freedesktop.portal.Desktop'), false);
+      const portal = await fakePortal(address);
+      try {
+        // No reset: a cached *negative* here would be the bug — a feature
+        // disabled for the life of the process on a machine where it works.
+        assert.equal(await hasService('org.freedesktop.portal.Desktop'), true);
+      } finally {
+        await portal.stop();
+      }
+    });
+  });
+});
+
+describe('the osascript rung', () => {
+  // It cannot run here, so what is pinned is the script — which is the part
+  // that breaks, and the part a Mac user cannot debug from a stack trace.
+  test('open: prompt, type filter, location, and flags last', () => {
+    const line = osascriptLines('open', {
+      title: 'Pick an image',
+      multiple: true,
+      defaultFolder: '/Users/me/Pictures',
+      filters: [{ name: 'Images', extensions: ['.png', 'jpg'] }],
+    }).join(' ');
+    assert.match(line, /choose file with prompt "Pick an image"/);
+    assert.match(line, /of type \{"png", "jpg"\}/);
+    assert.match(line, /default location POSIX file "\/Users\/me\/Pictures"/);
+    // `with …` flags go last: AppleScript is conventional about this and the
+    // failure mode is a syntax error at the far end of a pipe.
+    assert.match(line, /default location .* with multiple selections allowed/);
+  });
+
+  test('MIME-only filters restrict nothing, deliberately', () => {
+    const line = osascriptLines('open', {
+      filters: [{ name: 'Text', mimeTypes: ['text/plain'] }],
+    }).join(' ');
+    assert.doesNotMatch(line, /of type/);
+  });
+
+  test('save uses choose file name with a default name', () => {
+    const line = osascriptLines('save', {
+      defaultName: 'notes.md',
+      defaultFolder: '/tmp',
+    }).join(' ');
+    assert.match(line, /choose file name with prompt "Save file"/);
+    assert.match(line, /default name "notes\.md"/);
+  });
+
+  test('folder uses choose folder', () => {
+    assert.match(osascriptLines('folder', {}).join(' '), /choose folder/);
+  });
+
+  test('quotes in a title cannot break out of the script', () => {
+    const line = osascriptLines('open', {
+      title: 'a" & do shell script "id',
+    }).join(' ');
+    assert.match(line, /"a\\" & do shell script \\"id"/);
+    assert.doesNotMatch(line, /prompt "a" /);
+  });
+
+  test('every branch normalises to newline-separated POSIX paths', () => {
+    for (const kind of ['open', 'save', 'folder']) {
+      const lines = osascriptLines(kind, {});
+      assert.ok(
+        lines.includes(
+          'if class of theFiles is not list then set theFiles to {theFiles}',
+        ),
+        `${kind} handles the single-item case`,
+      );
+      assert.ok(lines.includes('set out to out & POSIX path of f & linefeed'));
+    }
+  });
+});
+
+describe('the built-in dialog', () => {
+  afterEach(cleanup);
+
+  test('lists a directory, hides dotfiles, and applies a filter', async () => {
+    const dir = await fixture();
+    let done = 'not called';
+    await renderX11(
+      React.createElement(FileDialog, {
+        kind: 'open',
+        startFolder: dir,
+        filters: [{ name: 'Text', extensions: ['txt', 'md'] }],
+        onDone: (r) => {
+          done = r;
+        },
+      }),
+      { wrap: false, fonts: FONTS },
+    );
+    await settle();
+
+    const names = screen
+      .queryAllByText(/^(sub\/|a\.txt|b\.md|photo\.png|\.hidden)$/)
+      .map((n) => n.props.children);
+    assert.deepEqual(names.sort(), ['a.txt', 'b.md', 'sub/']);
+
+    fireEvent.click(screen.getByText('a.txt'));
+    await settle();
+    fireEvent.click(screen.getByText('Open'));
+    await settle();
+    assert.deepEqual(done, [path.join(dir, 'a.txt')]);
+  });
+
+  test('cancel answers null exactly once', async () => {
+    const dir = await fixture();
+    const answers = [];
+    await renderX11(
+      React.createElement(FileDialog, {
+        startFolder: dir,
+        onDone: (r) => answers.push(r),
+      }),
+      { wrap: false, fonts: FONTS },
+    );
+    await settle();
+    fireEvent.click(screen.getByText('Cancel'));
+    fireEvent.click(screen.getByText('Cancel'));
+    await settle();
+    // Twice would settle a caller's promise twice; never would hang it.
+    assert.deepEqual(answers, [null]);
+  });
+
+  test('show hidden reveals dotfiles', async () => {
+    const dir = await fixture();
+    await renderX11(
+      React.createElement(FileDialog, { startFolder: dir, onDone: () => {} }),
+      { wrap: false, fonts: FONTS },
+    );
+    await settle();
+    assert.equal(screen.queryAllByText('.hidden').length, 0);
+    fireEvent.click(screen.getByText('Show hidden'));
+    await settle();
+    assert.equal(screen.queryAllByText('.hidden').length, 1);
+  });
+
+  test('save resolves the typed name against the current directory', async () => {
+    const dir = await fixture();
+    let done;
+    await renderX11(
+      React.createElement(FileDialog, {
+        kind: 'save',
+        startFolder: dir,
+        defaultName: 'out.md',
+        onDone: (r) => {
+          done = r;
+        },
+      }),
+      { wrap: false, fonts: FONTS },
+    );
+    await settle();
+    fireEvent.click(screen.getByText('Save'));
+    await settle();
+    assert.deepEqual(done, [path.join(dir, 'out.md')]);
+  });
+
+  test('a directory it cannot read says so instead of throwing', async () => {
+    await renderX11(
+      React.createElement(FileDialog, {
+        startFolder: '/nonexistent/react-x11-not-here',
+        onDone: () => {},
+      }),
+      { wrap: false, fonts: FONTS },
+    );
+    await settle();
+    assert.equal(screen.queryAllByText(/^Cannot read /).length, 1);
+  });
+
+  test('folder mode lists only directories and defaults to where you are', async () => {
+    const dir = await fixture();
+    let done;
+    await renderX11(
+      React.createElement(FileDialog, {
+        kind: 'folder',
+        startFolder: dir,
+        onDone: (r) => {
+          done = r;
+        },
+      }),
+      { wrap: false, fonts: FONTS },
+    );
+    await settle();
+    assert.equal(screen.queryAllByText('a.txt').length, 0);
+    assert.equal(screen.queryAllByText('sub/').length, 1);
+    // Nothing selected means "this directory", which is what the path bar
+    // shows — the alternative is a disabled button and a puzzled user.
+    fireEvent.click(screen.getByText('Select'));
+    await settle();
+    assert.deepEqual(done, [dir]);
+  });
+});
+
+describe('the ladder', () => {
+  test('backend selection is reported without showing anything', async () => {
+    const backend = await fileDialogBackend();
+    assert.ok(['portal', 'osascript', 'builtin'].includes(backend));
+  });
+
+  test('no portal and not macOS: a typed rejection, not a crash', async () => {
+    await withNoBus(async () => {
+      await assert.rejects(
+        () => openFile(),
+        (err) => {
+          assert.ok(err instanceof NoFileDialogError);
+          // The message has to name the way out, because this is the error an
+          // app developer hits on the machine they are actually sitting at.
+          assert.match(err.message, /useFileDialog/);
+          return true;
+        },
+      );
+    });
+  });
+
+  test('backend: builtin skips the native rungs outright', async () => {
+    await assert.rejects(
+      () => openFile({ backend: 'builtin' }),
+      (err) => err instanceof NoFileDialogError,
+    );
+  });
+});
+
+/**
+ * Run `fn` on a machine with no session bus and no macOS.
+ *
+ * **The `closeBus()` is load-bearing, not tidying.** The shared connection
+ * stays up across acquisitions by design, so pointing the env var at nothing
+ * changes what the *next* connect would dial and not what is already open —
+ * and a test that skipped this on a developer's own desktop would reach the
+ * real portal and put a file dialog on their screen, then wait for a human.
+ * That is exactly what happened while writing these.
+ */
+async function withNoBus(fn) {
+  const saved = {
+    address: process.env.DBUS_SESSION_BUS_ADDRESS,
+    runtime: process.env.XDG_RUNTIME_DIR,
+    platform: process.platform,
+  };
+  await closeBus('session').catch(() => {});
+  _resetBusState();
+  _resetServiceCache();
+  process.env.DBUS_SESSION_BUS_ADDRESS = 'unix:path=/nonexistent/no-bus-here';
+  delete process.env.XDG_RUNTIME_DIR;
+  Object.defineProperty(process, 'platform', { value: 'linux' });
+  try {
+    return await fn();
+  } finally {
+    Object.defineProperty(process, 'platform', { value: saved.platform });
+    if (saved.address === undefined)
+      delete process.env.DBUS_SESSION_BUS_ADDRESS;
+    else process.env.DBUS_SESSION_BUS_ADDRESS = saved.address;
+    if (saved.runtime !== undefined)
+      process.env.XDG_RUNTIME_DIR = saved.runtime;
+    await closeBus('session').catch(() => {});
+    _resetBusState();
+    _resetServiceCache();
+  }
+}
+
+/** Let effects, the frame clock and one directory read all land. */
+async function settle() {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 60));
+  });
+}

--- a/test/helpers/fake-portal.js
+++ b/test/helpers/fake-portal.js
@@ -1,0 +1,111 @@
+// A portal on the test bus.
+//
+// `withBus()` gives a broker and a client; this owns
+// `org.freedesktop.portal.Desktop` on it and answers `FileChooser` calls the
+// way xdg-desktop-portal does — return the Request path immediately, emit
+// `Response` on it afterwards. That second half is the whole point: it is the
+// only way to test that `portalRequest()` subscribed *before* it called, since
+// a harness that answered synchronously would pass either way.
+//
+// **What the broker cannot do**, from its own docs: no security policy, no
+// service activation, no fd passing. Activation is the one that matters here —
+// a fake portal has to own its name up front, so `hasService()`'s
+// `ListActivatableNames` branch is exercised against a real daemon or not at
+// all. Do not read a green suite as covering it.
+
+import { PORTAL_NAME, PORTAL_PATH, senderPath } from '../../src/portal.js';
+
+const FILE_CHOOSER = 'org.freedesktop.portal.FileChooser';
+const REQUEST_IFACE = 'org.freedesktop.portal.Request';
+
+/**
+ * Start a fake portal against `address`.
+ *
+ * `handlers` is `{ OpenFile, SaveFile }`, each `(call) => ({ response,
+ * results })` or a promise of one, where `call` is
+ * `{ parentWindow, title, options, path }`. The default answers with one file.
+ *
+ * The returned object records every call in `calls`, so a test can assert on
+ * what was actually marshalled — which is where the option translation is
+ * pinned.
+ */
+export async function fakePortal(address, handlers = {}) {
+  const dbus = (await import('dbus-native')).default;
+  const bus = dbus.createClient({ busAddress: address });
+  const portal = {
+    bus,
+    calls: [],
+    /** Requests that are still open, by path — what Close() ends. */
+    open: new Map(),
+    closed: [],
+    stop: () => bus.close(),
+  };
+
+  await new Promise((resolve, reject) => {
+    bus.connection.once('connect', resolve);
+    bus.connection.once('error', reject);
+  });
+  await bus.listNames();
+  await bus.requestName(PORTAL_NAME, 0);
+
+  const answer = async (member, [parentWindow, title, options], { sender }) => {
+    const token = options?.handle_token ?? 't';
+    const path = `${PORTAL_PATH}/request/${senderPath(sender)}/${token}`;
+    const call = { member, parentWindow, title, options, path, sender };
+    portal.calls.push(call);
+
+    // Export Request.Close at the path *before* returning it, the way a real
+    // portal does — a client that cancels immediately must find something
+    // there.
+    bus.exportInterface({ Close: () => closeRequest(path) }, path, {
+      name: REQUEST_IFACE,
+      methods: { Close: ['', '', [], []] },
+      signals: { Response: ['ua{sv}', 'response', 'results'] },
+      properties: {},
+    });
+    portal.open.set(path, true);
+
+    // Answer on a later tick: the call has to return the handle first, and a
+    // Response that arrived before it would not prove anything about ordering.
+    const handler = handlers[member];
+    Promise.resolve()
+      .then(() => (handler ? handler(call) : { response: 0, results: {} }))
+      .then((result) => {
+        if (!portal.open.has(path) || result?.silent) return;
+        portal.open.delete(path);
+        bus.sendSignal(path, REQUEST_IFACE, 'Response', 'ua{sv}', [
+          result?.response ?? 0,
+          result?.results ?? {},
+        ]);
+      })
+      .catch(() => {});
+
+    return path;
+  };
+
+  const closeRequest = (path) => {
+    // Per the spec, Close() means **no Response is emitted** — which is
+    // exactly the case a client that waits for one hangs on.
+    portal.open.delete(path);
+    portal.closed.push(path);
+    bus.unexportInterface(path, REQUEST_IFACE);
+  };
+
+  const method = (member) => ({
+    in: { parent_window: 's', title: 's', options: 'a{sv}' },
+    out: { handle: 'o' },
+    handler: (args, ctx) =>
+      answer(member, [args.parent_window, args.title, args.options], ctx),
+  });
+
+  const iface = dbus.defineInterface({
+    name: FILE_CHOOSER,
+    methods: {
+      OpenFile: method('OpenFile'),
+      SaveFile: method('SaveFile'),
+    },
+  });
+  await bus.export(PORTAL_PATH, iface);
+
+  return portal;
+}

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -13,6 +13,7 @@ import type {
   BusKind,
   BusRef,
   BusStatus,
+  FileDialogBackend,
   MessageBus,
 } from 'react-x11';
 import {
@@ -21,10 +22,15 @@ import {
   Canvas3D,
   Checkbox,
   closeBus,
+  fileDialogBackend,
+  NoFileDialogError,
+  openFile,
+  saveFile,
   sessionBus,
   systemBus,
   useApp,
   useClipboard,
+  useFileDialog,
   useSessionBus,
   useSystemBus,
   ContextMenu,
@@ -628,6 +634,55 @@ function _Bus() {
   return null;
 }
 
+// the file dialog: the ladder, the options, and what cancel looks like
+function _Files() {
+  const win = useRef<NtkWindow | null>(null);
+  const {
+    openFile: open,
+    saveFile: save,
+    selectFolder,
+  } = useFileDialog({
+    parentWindow: win,
+  });
+
+  async function go() {
+    const files: string[] | null = await open({
+      multiple: true,
+      filters: [
+        { name: 'Text', extensions: ['txt', 'md'] },
+        { name: 'Images', mimeTypes: ['image/png'] },
+      ],
+      defaultFolder: '/tmp',
+      acceptLabel: 'Import',
+    });
+    // Cancelling is `null`, not a throw — the terse path has to type-check.
+    if (!files) return;
+    const target: string | null = await save({ defaultName: 'out.md' });
+    const dirs: string[] | null = await selectFolder();
+
+    // The bare functions, for host-side code with no component to hang off.
+    const bare: string[] | null = await openFile({ backend: 'builtin' });
+    const backend: FileDialogBackend = await fileDialogBackend();
+    // @ts-expect-error — not a rung
+    await openFile({ backend: 'zenity' });
+    // @ts-expect-error — a filter needs a name
+    await openFile({ filters: [{ extensions: ['txt'] }] });
+
+    try {
+      await saveFile();
+    } catch (err) {
+      if (err instanceof NoFileDialogError) {
+        const why: unknown = err.cause;
+        void why;
+      }
+    }
+    void [target, dirs, bare, backend];
+  }
+  void go;
+  return null;
+}
+
+void _Files;
 void _Bus;
 void _Clip;
 void main;

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -55,6 +55,7 @@ import {
   Tree,
   useAnchor,
   useTheme,
+  useTopLevelWindow,
   useWindowId,
   windowIdOf,
 } from '../../src/index.js';

--- a/website/scripts/browser-shims/desktop-only.js
+++ b/website/scripts/browser-shims/desktop-only.js
@@ -1,0 +1,35 @@
+// Browser stub for the node builtins the **file dialog** reaches for:
+// `node:crypto` (a Request token), `node:child_process` (`osascript`),
+// `node:url` (`file://` URIs → paths) and `node:fs/promises` (the built-in
+// browser's directory reads).
+//
+// Every one of them is behind a *dynamic* import inside a function, so nothing
+// here is touched by loading the bundle — but esbuild follows a dynamic import
+// as readily as a static one, and four unresolvable builtins fail the build.
+//
+// Callable and throwing rather than silently empty: a file dialog is not a
+// thing a web page can have, and the honest answer to `openFile()` in the
+// playground is a message saying so. `sessionBus()` already answers `null`
+// there (see stubs/dbus-native.js), so the portal rung is never reached — only
+// a demo that rendered `<FileDialog>` directly gets here.
+const nope = (what) => () => {
+  throw new Error(
+    `react-x11 playground: ${what} needs a desktop — there is no filesystem, ` +
+      'no process spawning and no file dialog in a browser.',
+  );
+};
+
+module.exports = {
+  // node:crypto
+  randomBytes: nope('randomBytes'),
+  // node:child_process
+  execFile: nope('execFile'),
+  // node:url — a real implementation would be four lines, but returning a
+  // path that cannot be opened is worse than saying there is no filesystem.
+  fileURLToPath: nope('fileURLToPath'),
+  // node:fs/promises
+  readdir: nope('readdir'),
+  stat: nope('stat'),
+  readFile: nope('readFile'),
+  default: {},
+};

--- a/website/scripts/build-demo-bundles.mjs
+++ b/website/scripts/build-demo-bundles.mjs
@@ -150,6 +150,19 @@ await esbuild.build({
     // createRequire, used by react-x11 to read its own package.json
     module: path.join(shimsDir, 'module.js'),
     'node:module': path.join(shimsDir, 'module.js'),
+    // What the file dialog reaches for, all behind dynamic imports it never
+    // takes here — but esbuild follows those too. See the shim for why they
+    // throw rather than answering emptily.
+    'node:crypto': path.join(shimsDir, 'desktop-only.js'),
+    crypto: path.join(shimsDir, 'desktop-only.js'),
+    'node:child_process': path.join(shimsDir, 'desktop-only.js'),
+    child_process: path.join(shimsDir, 'desktop-only.js'),
+    'node:url': path.join(shimsDir, 'desktop-only.js'),
+    url: path.join(shimsDir, 'desktop-only.js'),
+    // `alias` matches whole specifiers, so `node:fs` above does not cover the
+    // `/promises` subpath — it resolves against the shim *file* and fails.
+    'node:fs/promises': path.join(shimsDir, 'desktop-only.js'),
+    'fs/promises': path.join(shimsDir, 'desktop-only.js'),
     // keysym reads its JSON tables with fs at load time; this build inlines them
     keysym: path.join(shimsDir, 'keysym.js'),
     // heavy optional ntk dep no demo needs

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -187,6 +187,7 @@ const ORDER = [
   'testing.md',
   'desktop.md',
   'dbus.md',
+  'filedialog.md',
   'remote.md',
   'security.md',
   'packaging.md',


### PR DESCRIPTION
Closes #111. Also lands the portal machinery from #129 (`portalRequest`, `hasService`) in core, since #111 is its first and only consumer.

```jsx
const { openFile } = useFileDialog({ parentWindow: windowRef });

const files = await openFile({ filters: [{ name: 'Markdown', extensions: ['md'] }] });
if (!files) return;   // cancelled — an ordinary outcome, not an exception
```

Cancelling resolves to `null` on every backend, so the whole error path for a file dialog is one `if`.

## The ladder

There is no single answer to "show a file dialog" on a machine running X11, so the rung is chosen for you:

| | | |
| --- | --- | --- |
| 1 | **the portal** | `org.freedesktop.portal.FileChooser` over D-Bus — the desktop's own dialog, drawn by GTK or KDE in another process, with the user's bookmarks and recent files. |
| 2 | **`osascript`** | macOS with no portal, which is every XQuartz install that has not gone out of its way. `choose file` *is* `NSOpenPanel`. |
| 3 | **the built-in dialog** | A browser react-x11 draws itself. ssh, a bare `startx`, a container: everywhere there is a display and nothing else. |

**The ladder is the design, not a fallback chain bolted on.** react-x11's flagship case is an app running on one machine and drawing to another, and a dialog that only worked on a full GNOME session would be useless to exactly the person the renderer exists for.

`fileDialogBackend()` reports the rung without showing anything; `backend:` forces one — the seam for a kiosk, and how the tests reach the bottom rung on a machine that has a portal.

![the built-in file dialog: path bar with an Up button, Name/Size/Modified columns with directories first, a hidden-files toggle and a type filter](https://github.com/user-attachments/assets/fccb28a9-2922-4ce4-aa75-649ba03f436c)

## The portal floor

`portalRequest()` gets the Request race right **once**, in the place every portal added later goes through. A portal method returns an object path immediately and answers with a `Request.Response` signal, and the path is predictable *by design* precisely so the client can subscribe before it calls.

Verified against the real xdg-desktop-portal on my desktop — the predicted path and the returned handle match exactly, which is the property the whole thing rests on:

```
unique name : :1.248
predicted   : /org/freedesktop/portal/desktop/request/1_248/rx11_f9ea82b33ee52847
handle      : /org/freedesktop/portal/desktop/request/1_248/rx11_f9ea82b33ee52847
MATCH       : true
```

Three things it owns so no caller reimplements them: subscribing first; `Request.Close()` on abort, which per the spec emits **no** `Response`, so the promise must be settled locally rather than left waiting for one that never comes; and **no timeout on the answer** — a dialog can legitimately be open for an hour, so only the initial call is deadlined.

`hasService()` is activation-aware, which is the reason it is not `NameHasOwner`: `org.freedesktop.portal.Desktop` ships a D-Bus service file, so on a healthy GNOME session where no app has touched a portal yet the name has no owner, and a feature gated on that takes the fallback path forever on a machine where the portal works perfectly.

## Why the hook mounts a second root

The bare `openFile()` reaches the portal and `osascript`, and rejects with a typed `NoFileDialogError` when there is neither — because a function has nowhere to draw. `useFileDialog()` does: it renders the built-in dialog on `createRoot({ app })`, borrowing the tree's own X connection (a borrowed connection is never closed by `unmount()`).

The obvious alternative — `const { open, dialog } = useFileDialog()` with `{dialog}` rendered somewhere — is a documentation step for every app author forever, and one that fails *silently* when forgotten: `open()` would resolve to nothing with no clue why. A file dialog is a top-level `transientFor` window on every other rung, so it is one here too. `WM_TRANSIENT_FOR` on the dialog is confirmed to point at the host window.

## The built-in dialog

Deliberately not a re-creation of GTK's chooser. What it owes the user is: get anywhere on the filesystem, see what is there, filter it, type a path when the list is the slow way round, and never trap them.

![save mode: the same browser with a Name field pre-filled with notes.md and a Markdown filter selected](https://github.com/user-attachments/assets/bcaa9d63-e484-45c0-9800-1e98817c25b0)

`multiple` is a tick column rather than ctrl-click, because `Table` holds a single selection and a checkbox is the honest way to say "several":

![multi-select mode: a tick column beside each file, and the confirm button counting the selection as Open (1)](https://github.com/user-attachments/assets/15a6e38e-7ae7-4b7c-9e99-77e171261420)

Sizes and dates come from one `stat` per entry, skipped above 5000 entries so a directory on a network mount does not make the dialog pause visibly on open.

## Also fixes a bug in the bus floor that shipped in #209

`closeBus()` could hang. At zero refs the socket is `unref()`d — that is the whole lifecycle design — so `bus.close()`, which resolves on the socket's own `'close'` event, had nothing holding the event loop open, and a process with no other work drained before the event arrived. The promise never settled.

Found because a test hung on it, which is the only place it is observable: any real app has other work keeping the loop alive. The teardown is itself a use of the connection, so it re-refs for the duration. The regression test fails with the fix reverted (verified) and passes with it.

## Examples

- **`npm run examples:menu`** — File → Open… / Open Files… / Open Folder… / Save As… are real, and the window says which rung this machine landed on. The menu code is identical on all three, which is the point.
- **`npm run examples:richtext`** — "open a .md…" loads a real file into the `<markdown>` element. The shortest honest demonstration of why an app wants one.

![the menu example, reporting that File > Open/Save runs a real dialog on this machine's portal backend](https://github.com/user-attachments/assets/90817c16-f71d-42d9-b6b4-ca0aa0e200c1)

## Tests

26 new, in four groups matching the four things that can break:

- **the portal**, against a `fakePortal()` on the broker that answers on a *later tick* — a harness that answered synchronously would pass whether or not the subscription came first. Covers the option translation (filters as `a(sa(us))`, paths as NUL-terminated byte arrays, `multiple` suppressed on save), the `x11:` parent handle, cancel-as-`null`, and abort actually reaching `Request.Close()`.
- **`osascript`**, by the script it builds — it cannot run on Linux, and the script is both the part that breaks and the part a Mac user cannot debug from a stack trace. Including that a quote in a title cannot break out of it.
- **the built-in dialog**, as an ordinary component: listing, dotfiles, filters, save-name resolution, an unreadable directory, and `onDone` firing exactly once.
- **the ladder** itself.

`npm test` — 559 green. `npm run typecheck` clean. `npm test` in `website/` clean, including the bundle: the node builtins the dialog reaches for behind dynamic imports (`node:crypto`, `node:child_process`, `node:url`, `node:fs/promises`) are aliased to a throwing shim, the same treatment `dbus-native` got in #209 and for the same reason — esbuild follows a dynamic import as readily as a static one.

## For the macOS test

The `osascript` rung is reached by *not* finding a portal, so on an XQuartz Mac with no session bus it is what runs. Worth poking at:

- `File → Open…`, `Open Files…` (multi-select), `Open Folder…`, `Save As…` in `examples:menu`, and the window should say `osascript`.
- Cancel each one — every dialog should resolve to `null` and the window should say "cancelled", with nothing thrown.
- Filters: `examples:richtext` passes `extensions`, which map exactly. MIME-only filters deliberately restrict nothing on macOS, because guessing a UTI wrong hides the user's file with no way to reach it.
- `parentWindow` is ignored there and cannot be otherwise — macOS has no cross-process transient-for. The panel appears over the app but is not attached to it; application modality still works because the caller is awaiting the promise.

If it lands on `builtin` instead, the Mac has a session bus with something claiming the portal name — `fileDialogBackend()` will say so.

## Notes

- The AppleScript is written with `with …` flags last, which is AppleScript's convention; I could not execute it here, so that ordering is the one thing most worth a real run.
- The broker has no service activation, so `hasService()`'s `ListActivatableNames` branch is exercised against a real daemon or not at all. Said in the test file too, so a green suite is not read as covering it.

