### PR TITLE
fix(paint): cull off-screen paint past a clipping ancestor, not just the window

### DIFF
--- a/src/nodes.js
+++ b/src/nodes.js
@@ -1829,23 +1829,39 @@ export class Node {
   }
 
   /**
-   * Entirely outside the window, so there is nothing to draw. Worth doing
-   * for its own sake, but it is also a correctness fix: X's render traps
-   * are 16.16 fixed point, so a coordinate past ±32767 overflows the
+   * Entirely outside the window, or entirely outside some nearer ancestor
+   * that clips its children — either way there is nothing to draw. Worth
+   * doing for its own sake, but it is also a correctness fix: X's render
+   * traps are 16.16 fixed point, so a coordinate past ±32767 overflows the
    * request. A scrolled list is exactly how you get there — the frame
    * between a scroll and the re-render that follows it can hold rows
    * ninety thousand pixels above the viewport.
+   *
+   * The ancestor walk matters on its own (issue #211): a `<scrollview>`'s
+   * own box is often much smaller than the window around it, and its
+   * `ctx.clip()` in `_paintChildren` only keeps the *pixels* off the visible
+   * surface — every child below the fold still ran its full paint (canvas
+   * `onDraw`, text/tex layout, the XRender/PutImage requests that go with
+   * them) for the server to then discard. Checking the window alone missed
+   * that: a node can sit well inside the window and still be entirely past
+   * a `<scrollview>` ancestor whose own bounds are the real limit.
    */
   _offscreen() {
     const window = this.root?.abs;
     if (!window) return false;
     const { x, y, width, height } = this.abs;
-    return (
+    if (
       x + width <= 0 ||
       y + height <= 0 ||
       x >= window.width ||
       y >= window.height
-    );
+    ) {
+      return true;
+    }
+    for (let n = this.parent; n && n !== this.root; n = n.parent) {
+      if (n.clipsChildren() && !rectsOverlap(this.abs, n.abs)) return true;
+    }
+    return false;
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #211.

`_offscreen()` (`src/nodes.js`) only checked a node's bounds against the
whole window, so a `<scrollview>` whose own box is smaller than the window
around it — sibling content above/below/beside it, or just a shorter layout
region — did nothing to stop off-screen children from running full paint
work (canvas `onDraw`, text/tex layout, the XRender/PutImage requests that
go with them) every time they were invalidated. The scrollview's own
`ctx.clip()` only discarded the pixels server-side, after the work was
already computed and sent — the same anti-pattern `_outsideDamage()`'s own
docstring already names for a different case.

`_offscreen()` now also walks the parent chain and culls a node past any
`clipsChildren()` ancestor's own bounds, the same way `_hitBounds()` already
stops its reach at one.

## Evidence

Isolated the variable with a small benchmark: window bounds held constant
and tall, only the `<scrollview>`'s own box pinned small (~4 cells visible
throughout), varying only the total off-screen cell count:

| count | before | after |
|---|---|---|
| 12  | 1.9ms | 1.9ms |
| 48  | 7.6ms | 2.1ms |
| 96  | 8.8ms | 1.9ms |
| 192 | 9.3ms | 2.0ms |

Paint cost is now flat regardless of total content — it tracks what's
visible, not what merely sits inside the window.

Also captured real pixels before/after a scroll (60 colored cells,
scrolled to `y: 900`) to confirm the fix doesn't cull anything actually
visible — content renders correctly with intact colors, borders and text
at both positions.

## Test plan

- [x] `node --test` — 533/533 pass, no regressions (scroll-blit, scrollbar
      and paint-cache suites exercise this code path directly)
- [x] Isolating benchmark shows paint cost now tracks visible content, not
      total content
- [x] Pixel capture before/after scrolling confirms visible content still
      renders correctly