### PR TITLE
fix(anchor): keep an open popup tracking its trigger

### DIFF
--- a/examples/rules.jsx
+++ b/examples/rules.jsx
@@ -731,8 +731,9 @@ function TokenField({ options, values, onChange }) {
 
   const height = Math.min(options.length * 28 + 8, 232);
   const anchorOptions = () => ({ placement: 'bottom', height: height + 2 });
+  const close = () => setOpen(false);
   const toggle = () => {
-    if (open) return setOpen(false);
+    if (open) return close();
     const rect = measure(anchorOptions());
     if (!rect) return;
     setAnchor(rect);
@@ -742,8 +743,10 @@ function TokenField({ options, values, onChange }) {
   // keeps the popup under the field for as long as it is open: a scrolled
   // ancestor, the field's own layout moving it (a neighbouring field
   // wrapping to a second line), or the owner window being nudged by the
-  // window manager or a script would otherwise leave it hanging in place
-  useAnchorTracking(ref, open, anchorOptions, setAnchor);
+  // window manager or a script would otherwise leave it hanging in place.
+  // If the field itself scrolls out of view, the popup closes rather than
+  // following it there.
+  useAnchorTracking(ref, open, anchorOptions, setAnchor, close);
 
   const set = (next) => onChange(options.filter((o) => next.includes(o)));
 

--- a/examples/rules.jsx
+++ b/examples/rules.jsx
@@ -35,6 +35,7 @@ import {
   Select,
   ThemeProvider,
   useAnchor,
+  useAnchorTracking,
 } from '../src/index.js';
 
 // --- palette ---------------------------------------------------------------
@@ -729,13 +730,20 @@ function TokenField({ options, values, onChange }) {
   const measure = useAnchor(ref);
 
   const height = Math.min(options.length * 28 + 8, 232);
+  const anchorOptions = () => ({ placement: 'bottom', height: height + 2 });
   const toggle = () => {
     if (open) return setOpen(false);
-    const rect = measure({ placement: 'bottom', height: height + 2 });
+    const rect = measure(anchorOptions());
     if (!rect) return;
     setAnchor(rect);
     setOpen(true);
   };
+
+  // keeps the popup under the field for as long as it is open: a scrolled
+  // ancestor, the field's own layout moving it (a neighbouring field
+  // wrapping to a second line), or the owner window being nudged by the
+  // window manager or a script would otherwise leave it hanging in place
+  useAnchorTracking(ref, open, anchorOptions, setAnchor);
 
   const set = (next) => onChange(options.filter((o) => next.includes(o)));
 

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -2,7 +2,7 @@
 // support needed. Plain createElement (no JSX) so the library stays
 // build-step-free for consumers.
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { useTheme } from './theme.js';
 import {
   DEFAULT_LABEL_SIZE,
@@ -12,6 +12,7 @@ import {
   SAFE_HOVER_DELAY,
   screenOf,
   screenPoint,
+  useAnchorTracking,
 } from './anchor.js';
 import { typeAheadChar, useTypeAhead } from './typeahead.js';
 import {
@@ -643,6 +644,36 @@ export function MenuBar({
     // pointer grab while you try.
     node.root?.events?.focus?.(node, reason);
   };
+
+  // keeps the pulled-down menu under its bar item for as long as it is
+  // open: a scrolled ancestor, the item's own layout moving it, or the
+  // owner window being nudged by the window manager or a script would
+  // otherwise leave it stranded. `openRef` (not `openIndex`) both because
+  // it is already the live index a handler mid-call reads, and because a
+  // stable ref keeps `activeTriggerRef`'s identity fixed across renders.
+  const activeTriggerRef = useMemo(
+    () => ({
+      get current() {
+        return refs.current[openRef.current] ?? null;
+      },
+    }),
+    [],
+  );
+  useAnchorTracking(
+    activeTriggerRef,
+    openIndex >= 0,
+    () => {
+      const node = refs.current[openRef.current];
+      const menu = menus[openRef.current];
+      if (!node || !menu?.items?.length) return null;
+      return {
+        placement: 'bottom',
+        width: menuListWidth(node, menu.items, fontSize),
+        height: menuListHeight(menu.items),
+      };
+    },
+    setRect,
+  );
 
   const select = (item) => {
     close();

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -650,7 +650,9 @@ export function MenuBar({
   // owner window being nudged by the window manager or a script would
   // otherwise leave it stranded. `openRef` (not `openIndex`) both because
   // it is already the live index a handler mid-call reads, and because a
-  // stable ref keeps `activeTriggerRef`'s identity fixed across renders.
+  // stable ref keeps `activeTriggerRef`'s identity fixed across renders. If
+  // the bar item itself scrolls out of view, the menu closes rather than
+  // following it there.
   const activeTriggerRef = useMemo(
     () => ({
       get current() {
@@ -673,6 +675,7 @@ export function MenuBar({
       };
     },
     setRect,
+    close,
   );
 
   const select = (item) => {

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -5,7 +5,12 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useTheme } from './theme.js';
 import { changeEvent } from './change.js';
-import { measureLabel, screenOf, useAnchor } from './anchor.js';
+import {
+  measureLabel,
+  screenOf,
+  useAnchor,
+  useAnchorTracking,
+} from './anchor.js';
 import { DEFAULT_TEXT_STYLE } from '../styles.js';
 import { typeAheadChar, useTypeAhead } from './typeahead.js';
 import {
@@ -158,18 +163,20 @@ export function Select({
   const menuHeight = Math.min(contentHeight, MAX_MENU_HEIGHT);
   const scrolls = contentHeight > MAX_MENU_HEIGHT;
 
+  // shared anchoring: also flips the menu above the trigger when there is
+  // no room below, and slides it left when the menu is wider than the
+  // trigger and would otherwise open off the right edge
+  const menuAnchorOptions = () => ({
+    placement: 'bottom',
+    height: menuHeight + 2,
+    width: menuWidth(triggerRef.current, normalized, value, scrolls),
+  });
+
   const close = () => setOpen(false);
   const openMenu = () => {
     const node = triggerRef.current;
     if (!node) return;
-    // shared anchoring: also flips the menu above the trigger when there is
-    // no room below, and slides it left when the menu is wider than the
-    // trigger and would otherwise open off the right edge
-    const rect = measureAnchor({
-      placement: 'bottom',
-      height: menuHeight + 2,
-      width: menuWidth(node, normalized, value, scrolls),
-    });
+    const rect = measureAnchor(menuAnchorOptions());
     if (!rect) return;
     setAnchor(rect);
     const selected = normalized.findIndex((o) => o.value === value);
@@ -177,6 +184,12 @@ export function Select({
     setOpen(true);
   };
   const toggle = () => (open ? close() : openMenu());
+
+  // keeps the menu under the trigger for as long as it is open: a scrolled
+  // ancestor, the trigger's own layout moving it (a neighbouring field
+  // wrapping to a second line), or the owner window being nudged by the
+  // window manager or a script would otherwise leave it hanging in place
+  useAnchorTracking(triggerRef, open, menuAnchorOptions, setAnchor);
 
   const emit = (next) => onChange?.(changeEvent('select-one', name, next));
 

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -188,8 +188,12 @@ export function Select({
   // keeps the menu under the trigger for as long as it is open: a scrolled
   // ancestor, the trigger's own layout moving it (a neighbouring field
   // wrapping to a second line), or the owner window being nudged by the
-  // window manager or a script would otherwise leave it hanging in place
-  useAnchorTracking(triggerRef, open, menuAnchorOptions, setAnchor);
+  // window manager or a script would otherwise leave it hanging in place.
+  // If the trigger itself scrolls out of view, the menu closes instead of
+  // following it there — a popup is a real window, not something clipped
+  // by the trigger's ancestors, so it would otherwise hang over content it
+  // no longer points at.
+  useAnchorTracking(triggerRef, open, menuAnchorOptions, setAnchor, close);
 
   const emit = (next) => onChange?.(changeEvent('select-one', name, next));
 

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -11,6 +11,7 @@ import {
   SAFE_HOVER_DELAY,
   screenPoint,
   useAnchor,
+  useAnchorTracking,
 } from './anchor.js';
 
 const h = React.createElement;
@@ -80,15 +81,27 @@ export function Tooltip({
   // a pending timer must not outlive the component
   useEffect(() => cancel, []);
 
-  const show = () => {
+  const tooltipAnchorOptions = () => {
     const node = ref.current;
-    if (!node || !label) return;
+    if (!node || !label) return null;
     const text = measureLabel(node, label, { size: fontSize });
     const width = Math.ceil(text.width) + TOOLTIP_PADDING_X * 2 + 2;
     const height = Math.ceil(text.height) + TOOLTIP_PADDING_Y * 2 + 2;
-    const next = measureAnchor({ placement, align: 'center', width, height });
+    return { placement, align: 'center', width, height };
+  };
+
+  const show = () => {
+    const options = tooltipAnchorOptions();
+    if (!options) return;
+    const next = measureAnchor(options);
     if (next) setRect(next);
   };
+
+  // keeps the tooltip pinned to its trigger for as long as it is shown: a
+  // scrolled ancestor, the trigger's own layout moving it, or the owner
+  // window being nudged by the window manager or a script would otherwise
+  // leave it pointing at empty space
+  useAnchorTracking(ref, Boolean(rect), tooltipAnchorOptions, setRect);
 
   const onMouseEnter = () => {
     cancel();

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -100,8 +100,11 @@ export function Tooltip({
   // keeps the tooltip pinned to its trigger for as long as it is shown: a
   // scrolled ancestor, the trigger's own layout moving it, or the owner
   // window being nudged by the window manager or a script would otherwise
-  // leave it pointing at empty space
-  useAnchorTracking(ref, Boolean(rect), tooltipAnchorOptions, setRect);
+  // leave it pointing at empty space. If the trigger scrolls out of view
+  // entirely, the tooltip hides instead of following it there — unlike a
+  // web tooltip it is a real window and can drift past the edge of the
+  // document it annotates, which reads as a stray popup rather than a hint.
+  useAnchorTracking(ref, Boolean(rect), tooltipAnchorOptions, setRect, hide);
 
   const onMouseEnter = () => {
     cancel();

--- a/src/components/anchor.js
+++ b/src/components/anchor.js
@@ -159,13 +159,13 @@ function sameAnchorRect(a, b) {
 }
 
 /**
- * useAnchorTracking(ref, active, getOptions, setRect) — keeps a popup's
- * `anchorRect` live for as long as `active`, instead of the one-shot measure
- * every caller used to take at open time. A trigger inside a scrolled
- * viewport, one whose own layout moves it (a neighbouring field wrapping to
- * a second line), or an owner window nudged by the window manager or a
- * script all leave a popup that was only ever measured once hanging over
- * stale ground.
+ * useAnchorTracking(ref, active, getOptions, setRect, onOutOfView) — keeps a
+ * popup's `anchorRect` live for as long as `active`, instead of the one-shot
+ * measure every caller used to take at open time. A trigger inside a
+ * scrolled viewport, one whose own layout moves it (a neighbouring field
+ * wrapping to a second line), or an owner window nudged by the window
+ * manager or a script all leave a popup that was only ever measured once
+ * hanging over stale ground.
  *
  * Subscribes to the anchoring node's owner window (`WindowNode.onAnchorChange`,
  * `nodes.js`) rather than polling: that fires exactly on the events which
@@ -176,17 +176,41 @@ function sameAnchorRect(a, b) {
  * ref not being ready yet, say). `setRect` only runs when the measured rect
  * actually differs, so it will not re-render (or re-`ConfigureWindow` the
  * popup) for a change that turned out not to move anything.
+ *
+ * A popup is a real X window, not a web element clipped by its ancestors'
+ * overflow — following a trigger that has scrolled out of view would leave
+ * it floating over content it no longer belongs to, detached from anything
+ * the user can see it points at. So once the trigger is entirely past a
+ * clipping ancestor's own bounds or past the owner window itself
+ * (`Node._offscreen()`, the same check paint culling uses), tracking calls
+ * `onOutOfView` instead of measuring — closing the popup, or hiding it, is
+ * the caller's call — and does not resume until re-opened. With no
+ * `onOutOfView` this just stops updating rather than snapping to a rect
+ * that no longer means anything.
  */
-export function useAnchorTracking(ref, active, getOptions, setRect) {
+export function useAnchorTracking(
+  ref,
+  active,
+  getOptions,
+  setRect,
+  onOutOfView,
+) {
   const measure = useAnchor(ref);
   const getOptionsRef = useRef(getOptions);
   getOptionsRef.current = getOptions;
+  const onOutOfViewRef = useRef(onOutOfView);
+  onOutOfViewRef.current = onOutOfView;
 
   useEffect(() => {
     if (!active) return undefined;
     const root = ref.current?.root;
     if (!root?.onAnchorChange) return undefined;
     return root.onAnchorChange(() => {
+      const node = ref.current;
+      if (node?._offscreen?.()) {
+        onOutOfViewRef.current?.();
+        return;
+      }
       const options = getOptionsRef.current();
       if (!options) return;
       const next = measure(options);

--- a/src/components/anchor.js
+++ b/src/components/anchor.js
@@ -1,7 +1,7 @@
 // Popup geometry: where to put a <popup> anchored to a drawn node, and
 // how big to make it around a measured label.
 
-import { useCallback } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 /** The X screen the node's window lives on, if reachable (the smoke-test
  *  mock app has no screen geometry — callers must cope with null). */
@@ -143,6 +143,57 @@ export function centerRect(node, { width, height }) {
  */
 export function useAnchor(ref) {
   return useCallback((options) => anchorRect(ref.current, options), [ref]);
+}
+
+function sameAnchorRect(a, b) {
+  return (
+    a === b ||
+    (a != null &&
+      b != null &&
+      a.x === b.x &&
+      a.y === b.y &&
+      a.width === b.width &&
+      a.height === b.height &&
+      a.placement === b.placement)
+  );
+}
+
+/**
+ * useAnchorTracking(ref, active, getOptions, setRect) — keeps a popup's
+ * `anchorRect` live for as long as `active`, instead of the one-shot measure
+ * every caller used to take at open time. A trigger inside a scrolled
+ * viewport, one whose own layout moves it (a neighbouring field wrapping to
+ * a second line), or an owner window nudged by the window manager or a
+ * script all leave a popup that was only ever measured once hanging over
+ * stale ground.
+ *
+ * Subscribes to the anchoring node's owner window (`WindowNode.onAnchorChange`,
+ * `nodes.js`) rather than polling: that fires exactly on the events which
+ * can actually move the rect — a layout pass and a fresh `_screenOrigin` —
+ * so a still trigger costs nothing and a moved one is caught the same frame.
+ * `getOptions` is read fresh through a ref on every notification, so callers
+ * do not need to memoize it; returning a falsy value skips that tick (the
+ * ref not being ready yet, say). `setRect` only runs when the measured rect
+ * actually differs, so it will not re-render (or re-`ConfigureWindow` the
+ * popup) for a change that turned out not to move anything.
+ */
+export function useAnchorTracking(ref, active, getOptions, setRect) {
+  const measure = useAnchor(ref);
+  const getOptionsRef = useRef(getOptions);
+  getOptionsRef.current = getOptions;
+
+  useEffect(() => {
+    if (!active) return undefined;
+    const root = ref.current?.root;
+    if (!root?.onAnchorChange) return undefined;
+    return root.onAnchorChange(() => {
+      const options = getOptionsRef.current();
+      if (!options) return;
+      const next = measure(options);
+      if (!next) return;
+      setRect((prev) => (sameAnchorRect(prev, next) ? prev : next));
+    });
+  }, [active, ref, measure, setRect]);
 }
 
 /** Measured size of a single-line label, for sizing a popup around it.

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -3,7 +3,12 @@
 // theme.js (palette + control props), anchor.js (popup geometry),
 // typeahead.js and keys.js.
 export { ThemeProvider, useTheme } from './theme.js';
-export { anchorRect, centerRect, useAnchor } from './anchor.js';
+export {
+  anchorRect,
+  centerRect,
+  useAnchor,
+  useAnchorTracking,
+} from './anchor.js';
 export { useDropTarget, useDragSource } from './dnd.js';
 export { Button } from './Button.js';
 export { Dialog } from './Dialog.js';

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ export {
   MenuBar,
   ContextMenu,
   useAnchor,
+  useAnchorTracking,
   anchorRect,
   centerRect,
   Canvas3D,

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -4326,7 +4326,32 @@ export class WindowNode extends Node {
     X.TranslateCoordinates(wnd.id, root, 0, 0, (err, res) => {
       if (err || this.destroyed || !this.window) return;
       this.window._screenOrigin = { x: res.destX, y: res.destY };
+      this._notifyAnchorChange();
     });
+  }
+
+  /**
+   * Subscribe to "something this window's popups might be anchored to just
+   * moved" — a real layout pass (a trigger's own position changing: text
+   * wrapping, a sibling growing, an ancestor scrollview scrolling — scroll
+   * offset is applied during absolutize, so it is a layout change too) or a
+   * fresh `_screenOrigin` (the window manager or a script moving this window).
+   * Returns an unsubscribe function.
+   *
+   * Event-driven off the same signals `flush()` and `_refreshScreenOrigin()`
+   * already track internally, rather than a polling loop: costs nothing
+   * between real changes, and `useAnchor`'s tracking hook (`anchor.js`) is
+   * what turns this into a popup that follows its trigger instead of hanging
+   * over stale ground once opened.
+   */
+  onAnchorChange(cb) {
+    (this._anchorListeners ??= new Set()).add(cb);
+    return () => this._anchorListeners?.delete(cb);
+  }
+
+  _notifyAnchorChange() {
+    if (!this._anchorListeners?.size) return;
+    for (const cb of this._anchorListeners) cb();
   }
 
   /** Walk the drawn subtree and give every <glarea> its child X window. */
@@ -4962,6 +4987,10 @@ export class WindowNode extends Node {
     const width = this.window.width ?? this.props.width ?? 0;
     const height = this.window.height ?? this.props.height ?? 0;
     let layoutMoved = false;
+    // captured before the branch clears it: whether *this* flush ran a
+    // layout pass is what decides whether an anchored popup needs a look,
+    // not the flag's post-pass value
+    const layoutRan = this.needsLayout;
     if (this.needsLayout) {
       this._resolveSizeQueries(width, height);
       this.yoga.setWidth(width);
@@ -5006,6 +5035,8 @@ export class WindowNode extends Node {
     } else if (this._reflowed.size) {
       this._reflowed.clear();
     }
+    // any node this pass laid out may be what an open popup is anchored to
+    if (layoutRan) this._notifyAnchorChange();
     // after layout (the claims above included), before the damage is taken:
     // a frame that turns out to be a pure scroll blits the surviving band
     // and narrows its claim to the exposed strip

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -436,6 +436,21 @@ export function useAnchor(
   ref: RefObject<DrawnNode | null>,
 ): (options?: AnchorOptions) => Rect | null;
 
+/**
+ * Keeps an `anchorRect` live for as long as `active`, instead of measuring
+ * once at open time: a scrolled ancestor, the node's own layout moving it,
+ * or the owner window being repositioned by the WM or a script each call
+ * `setRect` again with the new rect. `getOptions` is read fresh on every
+ * change, so it need not be memoized. `setRect` is only called when the
+ * measured rect actually differs from the previous one.
+ */
+export function useAnchorTracking(
+  ref: RefObject<DrawnNode | null>,
+  active: boolean,
+  getOptions: () => AnchorOptions,
+  setRect: (next: Rect | null | ((prev: Rect | null) => Rect | null)) => void,
+): void;
+
 // --- drag and drop ---------------------------------------------------------
 
 export interface UseDropTargetOptions {

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -443,12 +443,19 @@ export function useAnchor(
  * `setRect` again with the new rect. `getOptions` is read fresh on every
  * change, so it need not be memoized. `setRect` is only called when the
  * measured rect actually differs from the previous one.
+ *
+ * If the anchor node scrolls (or is laid out) entirely past a clipping
+ * ancestor or the owner window, `onOutOfView` is called instead of moving
+ * the popup there — a popup is a real window, not a web element clipped by
+ * its ancestors, so following a trigger that is no longer visible would
+ * leave it pointing at nothing. Typically `onOutOfView` closes the popup.
  */
 export function useAnchorTracking(
   ref: RefObject<DrawnNode | null>,
   active: boolean,
   getOptions: () => AnchorOptions,
   setRect: (next: Rect | null | ((prev: Rect | null) => Rect | null)) => void,
+  onOutOfView?: () => void,
 ): void;
 
 // --- drag and drop ---------------------------------------------------------

--- a/test/anchor-tracking.test.js
+++ b/test/anchor-tracking.test.js
@@ -155,7 +155,11 @@ test('a tracked popup follows a scrolled ancestor, while the trigger stays visib
     () => popupRef.current.y === before.y - 30,
     `the popup following the scroll (got ${popupRef.current.y}, want ${before.y - 30})`,
   );
-  assert.strictEqual(popupRef.current.x, before.x, 'x unaffected by a vertical scroll');
+  assert.strictEqual(
+    popupRef.current.x,
+    before.x,
+    'x unaffected by a vertical scroll',
+  );
 
   await x11Root.unmount();
 });
@@ -221,7 +225,11 @@ test("a tracked popup follows the trigger's own layout moving under it", async (
     () => popupRef.current.y === before.y + 40,
     `the popup following the trigger down (got ${popupRef.current.y}, want ${before.y + 40})`,
   );
-  assert.strictEqual(popupRef.current.x, before.x, 'x unaffected by a vertical reflow');
+  assert.strictEqual(
+    popupRef.current.x,
+    before.x,
+    'x unaffected by a vertical reflow',
+  );
 
   await x11Root.unmount();
 });
@@ -286,7 +294,10 @@ test('a tracked popup follows the owner window when it moves', async () => {
     await settle(app);
 
     const before = { x: popupRef.current.x, y: popupRef.current.y };
-    assert.ok(before.x > 0 || before.y > 0, 'the popup measured somewhere real');
+    assert.ok(
+      before.x > 0 || before.y > 0,
+      'the popup measured somewhere real',
+    );
 
     app.X.ConfigureWindow(wnd.id, { x: 90, y: 55 });
     await waitFor(() => wnd.x === 90, 'the move ConfigureNotify');

--- a/test/anchor-tracking.test.js
+++ b/test/anchor-tracking.test.js
@@ -1,0 +1,233 @@
+// A popup anchored to a trigger used to be measured once, at the moment it
+// opened, and never again: a scrolled ancestor, a trigger whose own layout
+// moved it (a neighbouring field wrapping to a second line), or an owner
+// window nudged by the window manager or a script all left it hanging over
+// stale ground. `useAnchorTracking` (anchor.js) and the `onAnchorChange`
+// subscription it reads (`WindowNode`, nodes.js) are the fix.
+//
+// These tests exercise the shared mechanism directly with a minimal tracked
+// popup, rather than through any one widget — Select, Tooltip, MenuBar and
+// rules.jsx's TokenField all sit on top of the same two functions.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import React from 'react';
+
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient, StaticFontSource } from 'ntk';
+
+import { createRoot } from '../src/index.js';
+import { useAnchor, useAnchorTracking } from '../src/components/anchor.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+/** Poll until `fn()` is truthy, or fail after `ms`. */
+async function waitFor(fn, what, ms = 1000) {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    if (fn()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.fail(`timed out waiting for ${what}`);
+}
+
+/**
+ * A trigger-anchored `<popup>` that stays live for as long as `open`: the
+ * exact shape `Select`, `Tooltip` and `MenuBar` all follow — measure once on
+ * open (so opening is instant, no extra frame of latency) and keep tracking
+ * after (so it catches up whatever moves next).
+ */
+function TrackedPopup({ open, triggerRef, popupRef, width = 60, height = 30 }) {
+  const measure = useAnchor(triggerRef);
+  const [rect, setRect] = React.useState(null);
+  const getOptions = () => ({ placement: 'bottom', width, height });
+
+  React.useLayoutEffect(() => {
+    if (!open) {
+      setRect(null);
+      return;
+    }
+    const next = measure(getOptions());
+    if (next) setRect(next);
+    // deliberately just `open`: `getOptions` is read fresh, not a dependency
+  }, [open]);
+
+  useAnchorTracking(triggerRef, open, getOptions, setRect);
+
+  return (
+    rect &&
+    h('popup', {
+      ref: popupRef,
+      x: rect.x,
+      y: rect.y,
+      width: rect.width,
+      height: rect.height,
+    })
+  );
+}
+
+async function renderMock(app, element) {
+  const x11Root = await createRoot({ app });
+  await new Promise((resolve) => x11Root.render(element, resolve));
+  // layout runs on the frame after the commit
+  await tick();
+  await tick();
+  return x11Root;
+}
+
+test('a tracked popup follows a scrolled ancestor', async () => {
+  const app = createMockApp();
+  const triggerRef = React.createRef();
+  const popupRef = React.createRef();
+  const rows = Array.from({ length: 20 }, (_, i) =>
+    h('box', { key: i, style: { height: 20 } }),
+  );
+
+  const x11Root = await renderMock(
+    app,
+    h(
+      'window',
+      { width: 200, height: 150 },
+      h(
+        'scrollview',
+        { style: { height: 100 } },
+        ...rows,
+        h('box', { ref: triggerRef, style: { width: 80, height: 20 } }),
+      ),
+      h(TrackedPopup, { open: true, triggerRef, popupRef }),
+    ),
+  );
+
+  const wnd = app.windows[0];
+  const windowNode = wnd._reactX11Node;
+  const scroller = windowNode.children.find((n) => n.kind === 'scrollview');
+  assert.ok(scroller, 'scrollview mounted');
+  assert.ok(scroller.contentHeight > scroller.abs.height, 'content overflows');
+
+  const before = { x: popupRef.current.x, y: popupRef.current.y };
+  scroller.scrollTo({ y: 100 });
+
+  await waitFor(
+    () => popupRef.current.y === before.y - 100,
+    `the popup following the scroll (got ${popupRef.current.y}, want ${before.y - 100})`,
+  );
+  assert.strictEqual(popupRef.current.x, before.x, 'x unaffected by a vertical scroll');
+
+  await x11Root.unmount();
+});
+
+test("a tracked popup follows the trigger's own layout moving under it", async () => {
+  const app = createMockApp();
+  const triggerRef = React.createRef();
+  const popupRef = React.createRef();
+
+  const Scene = ({ spacerHeight }) =>
+    h(
+      'window',
+      { width: 200, height: 200 },
+      // stands in for a neighbouring field wrapping to a second line: it
+      // grows, and everything below it — the trigger included — moves down
+      h('box', { style: { height: spacerHeight } }),
+      h('box', { ref: triggerRef, style: { width: 80, height: 20 } }),
+      h(TrackedPopup, { open: true, triggerRef, popupRef }),
+    );
+
+  const x11Root = await renderMock(app, h(Scene, { spacerHeight: 0 }));
+  const before = { x: popupRef.current.x, y: popupRef.current.y };
+
+  await new Promise((resolve) =>
+    x11Root.render(h(Scene, { spacerHeight: 40 }), resolve),
+  );
+
+  await waitFor(
+    () => popupRef.current.y === before.y + 40,
+    `the popup following the trigger down (got ${popupRef.current.y}, want ${before.y + 40})`,
+  );
+  assert.strictEqual(popupRef.current.x, before.x, 'x unaffected by a vertical reflow');
+
+  await x11Root.unmount();
+});
+
+// --- owner window moved by the WM or a script -------------------------------
+// Needs a real (in-process) X connection: `_screenOrigin` only refreshes off
+// a genuine TranslateCoordinates round trip, which the mock app has no
+// server to answer (see anchor.js's screenOf/`_screenOrigin` comments).
+
+const require = createRequire(import.meta.url);
+const fontDir = join(
+  dirname(require.resolve('katex/package.json')),
+  'dist',
+  'fonts',
+);
+
+async function createHeadlessApp() {
+  const server = xserver.createServer({ width: 640, height: 480 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const fontSource = new StaticFontSource();
+  fontSource.add(readFileSync(join(fontDir, 'KaTeX_Main-Regular.ttf')), {
+    family: 'Test Main',
+  });
+  fontSource.alias('sans-serif', 'Test Main');
+  const app = await createClient({ stream: clientEnd, fontSource });
+  return { server, app };
+}
+
+function render(element, x11Root) {
+  return new Promise((resolve) => {
+    x11Root.render(element, resolve);
+  });
+}
+
+async function settle(app, roundTrips = 3) {
+  for (let i = 0; i < roundTrips; i++) {
+    await new Promise((resolve, reject) =>
+      app.X.GetInputFocus((err) => (err ? reject(err) : resolve())),
+    );
+  }
+}
+
+test('a tracked popup follows the owner window when it moves', async () => {
+  const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
+  try {
+    const triggerRef = React.createRef();
+    const popupRef = React.createRef();
+    const wnd = await render(
+      h(
+        'window',
+        { width: 200, height: 120, x: 0, y: 0 },
+        h('box', {
+          ref: triggerRef,
+          style: { marginTop: 30, marginLeft: 20, width: 80, height: 20 },
+        }),
+        h(TrackedPopup, { open: true, triggerRef, popupRef }),
+      ),
+      x11Root,
+    );
+    await settle(app);
+
+    const before = { x: popupRef.current.x, y: popupRef.current.y };
+    assert.ok(before.x > 0 || before.y > 0, 'the popup measured somewhere real');
+
+    app.X.ConfigureWindow(wnd.id, { x: 90, y: 55 });
+    await waitFor(() => wnd.x === 90, 'the move ConfigureNotify');
+    await waitFor(
+      () =>
+        popupRef.current.x === before.x + 90 &&
+        popupRef.current.y === before.y + 55,
+      `the popup following the window move ` +
+        `(got ${popupRef.current.x},${popupRef.current.y}, ` +
+        `want ${before.x + 90},${before.y + 55})`,
+    );
+
+    await x11Root.unmount();
+    await settle(app);
+  } finally {
+    await app.close();
+  }
+});

--- a/test/anchor-tracking.test.js
+++ b/test/anchor-tracking.test.js
@@ -39,9 +39,17 @@ async function waitFor(fn, what, ms = 1000) {
  * A trigger-anchored `<popup>` that stays live for as long as `open`: the
  * exact shape `Select`, `Tooltip` and `MenuBar` all follow — measure once on
  * open (so opening is instant, no extra frame of latency) and keep tracking
- * after (so it catches up whatever moves next).
+ * after (so it catches up whatever moves next). `onClose` is called instead
+ * of tracking once the trigger scrolls entirely out of view.
  */
-function TrackedPopup({ open, triggerRef, popupRef, width = 60, height = 30 }) {
+function TrackedPopup({
+  open,
+  onClose,
+  triggerRef,
+  popupRef,
+  width = 60,
+  height = 30,
+}) {
   const measure = useAnchor(triggerRef);
   const [rect, setRect] = React.useState(null);
   const getOptions = () => ({ placement: 'bottom', width, height });
@@ -56,7 +64,7 @@ function TrackedPopup({ open, triggerRef, popupRef, width = 60, height = 30 }) {
     // deliberately just `open`: `getOptions` is read fresh, not a dependency
   }, [open]);
 
-  useAnchorTracking(triggerRef, open, getOptions, setRect);
+  useAnchorTracking(triggerRef, open, getOptions, setRect, onClose);
 
   return (
     rect &&
@@ -79,15 +87,34 @@ async function renderMock(app, element) {
   return x11Root;
 }
 
-test('a tracked popup follows a scrolled ancestor', async () => {
-  const app = createMockApp();
-  const triggerRef = React.createRef();
-  const popupRef = React.createRef();
-  const rows = Array.from({ length: 20 }, (_, i) =>
-    h('box', { key: i, style: { height: 20 } }),
-  );
+/**
+ * `TrackedPopup` wrapped in its own `open` state, the way `Select` and the
+ * others actually behave — `onClose` (an out-of-view notification, same as
+ * Escape or a press outside) really shuts it, rather than a test only
+ * observing that the callback fired.
+ */
+function Harness({ triggerRef, popupRef, closedRef }) {
+  const [open, setOpen] = React.useState(true);
+  const close = () => {
+    if (closedRef) closedRef.current++;
+    setOpen(false);
+  };
+  return h(TrackedPopup, { open, onClose: close, triggerRef, popupRef });
+}
 
-  const x11Root = await renderMock(
+// Layout shared by both scroll tests: a couple of short rows, then the
+// trigger (visible in the scrollview's own 100px viewport at scrollY 0),
+// then enough rows after it that the view has 160px left to scroll through
+// — some of that keeps the trigger visible and moved, the rest scrolls it
+// entirely past the scrollview's own bottom edge.
+function renderScrolledTrigger(app, popup) {
+  const rowsBefore = Array.from({ length: 2 }, (_, i) =>
+    h('box', { key: `before-${i}`, style: { height: 20 } }),
+  );
+  const rowsAfter = Array.from({ length: 10 }, (_, i) =>
+    h('box', { key: `after-${i}`, style: { height: 20 } }),
+  );
+  return renderMock(
     app,
     h(
       'window',
@@ -95,12 +122,23 @@ test('a tracked popup follows a scrolled ancestor', async () => {
       h(
         'scrollview',
         { style: { height: 100 } },
-        ...rows,
-        h('box', { ref: triggerRef, style: { width: 80, height: 20 } }),
+        ...rowsBefore,
+        h('box', { ref: popup.triggerRef, style: { width: 80, height: 20 } }),
+        ...rowsAfter,
       ),
-      h(TrackedPopup, { open: true, triggerRef, popupRef }),
+      popup.element,
     ),
   );
+}
+
+test('a tracked popup follows a scrolled ancestor, while the trigger stays visible', async () => {
+  const app = createMockApp();
+  const triggerRef = React.createRef();
+  const popupRef = React.createRef();
+  const x11Root = await renderScrolledTrigger(app, {
+    triggerRef,
+    element: h(TrackedPopup, { open: true, triggerRef, popupRef }),
+  });
 
   const wnd = app.windows[0];
   const windowNode = wnd._reactX11Node;
@@ -109,13 +147,49 @@ test('a tracked popup follows a scrolled ancestor', async () => {
   assert.ok(scroller.contentHeight > scroller.abs.height, 'content overflows');
 
   const before = { x: popupRef.current.x, y: popupRef.current.y };
-  scroller.scrollTo({ y: 100 });
+  // the trigger sits at content y 40..60, so this leaves it at 10..30 —
+  // still inside the scrollview's [0, 100) viewport
+  scroller.scrollTo({ y: 30 });
 
   await waitFor(
-    () => popupRef.current.y === before.y - 100,
-    `the popup following the scroll (got ${popupRef.current.y}, want ${before.y - 100})`,
+    () => popupRef.current.y === before.y - 30,
+    `the popup following the scroll (got ${popupRef.current.y}, want ${before.y - 30})`,
   );
   assert.strictEqual(popupRef.current.x, before.x, 'x unaffected by a vertical scroll');
+
+  await x11Root.unmount();
+});
+
+test('a tracked popup closes once its trigger scrolls entirely out of view', async () => {
+  const app = createMockApp();
+  const triggerRef = React.createRef();
+  const popupRef = React.createRef();
+  const closedRef = { current: 0 };
+  const x11Root = await renderScrolledTrigger(app, {
+    triggerRef,
+    element: h(Harness, { triggerRef, popupRef, closedRef }),
+  });
+
+  const wnd = app.windows[0];
+  const scroller = wnd._reactX11Node.children.find(
+    (n) => n.kind === 'scrollview',
+  );
+  assert.ok(popupRef.current, 'the popup opened');
+
+  // the trigger sits at content y 40..60; scrolling past 60 puts it entirely
+  // above the scrollview's own viewport, not merely moved within it
+  scroller.scrollTo({ y: 90 });
+
+  await waitFor(
+    () => closedRef.current > 0,
+    'onClose firing once the trigger left view',
+  );
+  await tick();
+  assert.strictEqual(
+    popupRef.current,
+    null,
+    'the popup unmounted rather than following the trigger off-view',
+  );
 
   await x11Root.unmount();
 });


### PR DESCRIPTION
## Problem

A popup anchored to a trigger — `Select`'s dropdown, `MenuBar`'s pulldown, `Tooltip`, `rules.jsx`'s `TokenField` — measured `anchorRect` exactly once, at the moment it opened, and never again. Three ways that goes stale while the popup is still up:

- the viewport scrolls (a mouse wheel over an ancestor `<scrollview>`) — the trigger moves, the popup does not
- the trigger's own layout changes (e.g. a neighbouring field wrapping to a second line and pushing everything below it down) — same story
- the owner window is moved by the window manager or a script — the popup detaches entirely

## Fix

`WindowNode` (`nodes.js`) gains an `onAnchorChange` subscription, fired:
- after a real layout pass in `flush()` — this covers scroll too, since scroll offset is applied during `absolutize()`, so a scroll is a layout change
- after `_refreshScreenOrigin()` gets a fresh `TranslateCoordinates` answer — the window-moved case

`useAnchorTracking` (`anchor.js`) subscribes to it and keeps a popup's rect live for as long as it's open. It's event-driven off signals the reconciler already tracks, not a polling loop — costs nothing between real changes, and only calls `setRect` when the measured rect actually differs, so a still trigger causes no re-render or `ConfigureWindow` call.

`Select`, `MenuBar`, `Tooltip` and `rules.jsx`'s `TokenField` now call it alongside their existing one-shot measure on open, so opening stays instant (no extra frame of latency) and tracking catches up whatever moves after. `MenuBar`'s submenu cascade already recomputes off its parent's `rect.x`/`rect.y`, so it follows for free once the root anchor is live.

`useAnchorTracking` is exported publicly (same surface as `useAnchor`) for anyone building their own anchored popup, like `TokenField` does.

## Closing when the anchor leaves the viewport

A `<popup>` is a real X window, not a web element clipped by its ancestors' `overflow` — so unlike a browser tooltip/dropdown, it can happily keep floating in place even once the trigger it's anchored to has scrolled entirely out of view, or off the owner window. That reads as a stray, detached popup rather than a hint pointing at something.

`useAnchorTracking` takes a 5th, optional `onOutOfView` callback. On each tracking tick it first checks `Node._offscreen()` — the same "entirely past a clipping ancestor's own bounds, or past the window" check paint culling uses (#212) — and if the trigger is now off-view, calls `onOutOfView` instead of moving the popup there. `Select`, `MenuBar`, `Tooltip` and `TokenField` all pass their existing close/hide function.

## Screenshot

Same scenario both times, rendered by this PR's own code against a real in-process X server: a window with a red trigger and a popup (blue) anchored below it, moved by script after opening — the same thing a WM drag does.

**Before** — the popup stays at its old screen position, detached from the trigger:

![before-fix](https://github.com/user-attachments/assets/960f44c1-c6b8-4a00-904f-b2f319ee95a6)

**After** — the popup follows the window and stays put under the trigger:

![after-fix](https://github.com/user-attachments/assets/f367c0a9-7164-4889-87ba-8c852173686c)

## Test plan

- [x] `test/anchor-tracking.test.js` exercises the shared mechanism directly (not through any one widget): a tracked popup follows a scrolled ancestor while the trigger stays visible, follows the trigger's own layout moving under it, follows the owner window moving (real in-process X server, since that path needs an actual `TranslateCoordinates` round trip), and closes once the trigger scrolls entirely out of its scrollview's viewport
- [x] Verified each new test actually fails against the pre-fix behavior (temporarily neutered the relevant check and confirmed each one fails on its own, then restored)
- [x] `npm test` — 567 passing, no regressions
- [x] `npm run lint` and `npm run typecheck` clean on touched files