### PR TITLE
feat(popups): rounded menus, tooltips with arrows, and the tokens for both

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -387,6 +387,14 @@ ref, so it composes around any element. Hides immediately on leave and on
 mousedown — a tooltip lingering over the menu you just opened is the
 classic annoyance.
 
+**One at a time**, per connection: a hint belongs to where the pointer is,
+and there is one pointer. A trigger taking the hover dismisses whatever is
+showing straight away rather than at the end of its own delay, so two are
+never up together saying different things about the same place. This does
+not fight the safe-polygon grace that lets a hint with content in it be
+reached — a trigger underneath an open hint cannot be hovered, the popup
+being a window above it.
+
 `direction` is which side of the trigger it opens on. The default, `'auto'`,
 takes the first side the hint fits on, preferring above — measured against
 the **screen**, because a popup is a real X window and the screen is what
@@ -542,6 +550,14 @@ selection colour, shared with `Select`'s active option and `Table`'s current
 row, so one token moves every highlight in the app. Without a compositor
 both go square, which is what those pixels can honestly be.
 
+**One selection at a time.** With submenus open, only the deepest level
+wears the selection colour; the rows behind it are drawn in `surfaceActive`.
+They are still chosen — they are the way back — but two selection-coloured
+rows in two menus claim the same thing twice, and only one of them is where
+the keys are going. A submenu that is open with _nothing_ selected in it has
+not taken over yet: the pointer is still on the row that opened it, so that
+row stays lit.
+
 **Icons.** `icon` fills the 16px column left of the label — the same column
 the check mark uses, so an item that is both checked and iconned shows the
 check: the check is state, the icon is only identity. One column rather than
@@ -585,6 +601,12 @@ popup. It hangs off the **menu's** outer edge and lines up with the row that
 opened it — two different nodes, which is what `anchorRect`'s `alignTo` is
 for. Anchoring both to the row would put the submenu inside its parent by
 the menu's border and padding, and the two would overlap.
+
+Lined up on the **items**, not on the boxes: a submenu whose top edge is
+level with its parent row starts its first item a border and a padding
+lower, and what the eye lines up is the text. `anchorRect`'s `alignOffset`
+is the shift that pays for the submenu's own chrome, so the row you came
+from and the row you arrive at are on one line.
 
 **Keyboard.** Up/Down move the active item, **skipping separators and
 disabled entries** and wrapping; Home/End jump to the ends; Right opens a

--- a/docs/components.md
+++ b/docs/components.md
@@ -32,15 +32,16 @@ changes and everything else keeps following. It carries **shape as well as
 colour** — corner radius, border weight, text size and the padding inside a
 control are most of what separates one platform's controls from another's:
 
-| token                                      |                                |
-| ------------------------------------------ | ------------------------------ |
-| `background` `text` `dim` `border`         | the surface a control sits on  |
-| `accent` `accentHover` `accentText`        | primary buttons, checks, fills |
-| `hoverBackground` `hoverText`              | selected rows, menu highlights |
-| `surfaceHover` `track` `borderFocus`       | hover fills, tracks, focus     |
-| `accentActive` `surfaceActive` `dimActive` | the pressed step of each fill  |
-| `radius` `radiusSmall` `borderWidth`       | control shape                  |
-| `fontSize` `paddingX` `paddingY`           | control size                   |
+| token                                           |                                |
+| ----------------------------------------------- | ------------------------------ |
+| `background` `text` `dim` `border`              | the surface a control sits on  |
+| `accent` `accentHover` `accentText`             | primary buttons, checks, fills |
+| `hoverBackground` `hoverText`                   | selected rows, menu highlights |
+| `surfaceHover` `track` `borderFocus`            | hover fills, tracks, focus     |
+| `accentActive` `surfaceActive` `dimActive`      | the pressed step of each fill  |
+| `radius` `radiusSmall` `borderWidth`            | control shape                  |
+| `radiusPopup` `radiusPopupItem` `radiusTooltip` | floating-surface shape         |
+| `fontSize` `paddingX` `paddingY`                | control size                   |
 
 The `…Active` three are the colour a control takes **while it is held**, and
 a palette almost never sets them: each is derived from the step the palette's
@@ -48,6 +49,21 @@ own hover already makes — `accent` → `accentHover` → one more of the same 
 so it darkens a light theme and lightens a dark one. Set one explicitly and
 it wins. See [The press state](#the-press-state) for why every control has
 one.
+
+The `radius…` three that name a popup are derived too, and from the **text
+size** rather than from `radius`: a menu is a sheet laid over the window
+where a button is a control cut into it, and half the body size is the
+number desktops land near — 7px at a 14px body. The other two step in from
+there, because a rounded thing inside a rounded thing needs the tighter
+curve: `radiusPopupItem` is the highlight on a menu row, `radiusTooltip` the
+tooltip bubble. A palette that moves `fontSize` and names none of them gets
+all three in proportion; naming one pins it.
+
+They are only ever _seen_ where the display composites — a popup gives up
+its corners by not painting them, and with nothing blending them those
+pixels are black rather than the desktop, so the widgets ask the window
+(`'@supports transparency'`, [styling.md](styling.md)) and stay square
+where the answer is no.
 
 There are two consumers of a palette, and one provider feeds both. Widgets
 read it as React context through `useTheme()`; a `$token` in a style
@@ -358,18 +374,56 @@ import { Tooltip } from 'react-x11';
 </Tooltip>;
 ```
 
-| prop        |                                                    |
-| ----------- | -------------------------------------------------- |
-| `label`     | the hint text (nothing shows without it)           |
-| `placement` | `'top'` (default), `'bottom'`, `'left'`, `'right'` |
-| `delay`     | ms of hover before showing (default 500)           |
-| `fontSize`  | label size, also used to size the popup            |
+| prop              |                                                              |
+| ----------------- | ------------------------------------------------------------ |
+| `label`           | the hint: a string, or an element (nothing shows without it) |
+| `direction`       | `'auto'` (default), `'top'`, `'bottom'`, `'left'`, `'right'` |
+| `delay`           | ms of hover before showing (default 500)                     |
+| `fontSize`        | label size, also used to size the popup                      |
+| `width`, `height` | the bubble's size — required for an element `label`          |
 
 Wraps its children in a row box carrying the hover handlers and the anchor
 ref, so it composes around any element. Hides immediately on leave and on
 mousedown — a tooltip lingering over the menu you just opened is the
-classic annoyance. The popup is sized from the _measured_ label, because a
-`<popup>` is a real X window and needs its size before layout.
+classic annoyance.
+
+`direction` is which side of the trigger it opens on. The default, `'auto'`,
+takes the first side the hint fits on, preferring above — measured against
+the **screen**, because a popup is a real X window and the screen is what
+bounds it. A named side is a preference rather than a promise either way:
+it still flips to its opposite instead of opening off-screen. (`placement`
+is the older name for the same prop and still wins where it is given.)
+
+A **string** `label` is measured and the popup sized around it, because a
+`<popup>` is a real X window and needs its size before layout. An
+**element** is the same problem without a way to measure, so the caller
+gives `width`/`height` — and then gets the bubble to fill, with no padding
+imposed on it:
+
+```jsx
+<Tooltip
+  label={
+    <box style={{ flexGrow: 1, padding: 10, gap: 7 }}>
+      <text style={{ color: '#f5f6fa' }}>Scratch volume</text>
+      <ProgressBar value={used} />
+    </box>
+  }
+  width={200}
+  height={82}
+  direction="right"
+>
+  <box>…</box>
+</Tooltip>
+```
+
+Anything renders in there, widgets included — it is a real tree in a real
+window, not a rich-text label. `examples/tooltips.jsx` has both kinds.
+
+Where the display composites, the popup is an ARGB window: a bubble rounded
+at `radiusTooltip`, no border, and a small arrow pointing back at the middle
+of the trigger with everything neither covers left transparent. Without a
+compositor it is the square opaque rectangle it has always been and there is
+no arrow — those pixels would be black rather than empty.
 
 ## `Dialog`
 
@@ -478,6 +532,15 @@ import { MenuBar, ContextMenu } from 'react-x11';
 Item shape: `{ label, onSelect, shortcut, disabled, separator, checked,
 icon, items }`. Both take an `onSelect(item)` prop as well, fired after the
 item's own. A bar menu opens on the **press**, for the reason `Select` does.
+
+**The sheet.** Where the display composites, a menu is an ARGB window
+rounded at `radiusPopup` with a hairline border, and the highlight on a row
+is a pill: inset from the popup's edge by the list's own padding and rounded
+a step tighter (`radiusPopupItem`), so it reads as sitting _on_ the sheet
+rather than cutting across it. The fill is `hoverBackground` — the palette's
+selection colour, shared with `Select`'s active option and `Table`'s current
+row, so one token moves every highlight in the app. Without a compositor
+both go square, which is what those pixels can honestly be.
 
 **Icons.** `icon` fills the 16px column left of the label — the same column
 the check mark uses, so an item that is both checked and iconned shows the

--- a/docs/components.md
+++ b/docs/components.md
@@ -289,6 +289,12 @@ Behavior: the menu opens on the **press** — Space and Enter toggle it too;
 Escape, focus loss, or picking closes it; the option list scrolls when taller
 than 220px; the trigger participates in Tab traversal.
 
+The menu is the **same surface a menu is**: an ARGB popup rounded at
+`radiusPopup` with a hairline border where the display composites, and the
+active option is the same pill at `radiusPopupItem`, inset from the sheet's
+edge. A dropdown and a menu are one kind of thing, and two shapes for it
+would only say that the widgets were written at different times.
+
 Opening on the press rather than the release is deliberate, and it is the
 one control whose answer to a press is more than a colour: a dropdown exists
 to be looked at, so waiting for the button to come back up before showing it
@@ -312,6 +318,12 @@ scrolled into view.
 
 **PageUp/PageDown** move by a menu viewport (`MAX_MENU_HEIGHT / ITEM_HEIGHT`
 options), clamping at the ends rather than wrapping the way the arrows do.
+
+**Losing the window** closes it too. That is not the same event as the
+trigger's own blur: a window losing the window manager's focus leaves the
+node inside it focused and merely stops it looking active — so without this
+the menu would still be up over an application you have switched away from,
+holding the pointer grab it opened with. The menus do the same.
 
 **Type-ahead.** Typing letters jumps to the matching option: with the menu
 open it moves the highlight, and with it closed it changes the value
@@ -426,6 +438,16 @@ imposed on it:
 
 Anything renders in there, widgets included — it is a real tree in a real
 window, not a rich-text label. `examples/tooltips.jsx` has both kinds.
+
+**The palette inside the bubble is upside down.** A tooltip is drawn in the
+palette's ink so that it reads as a label over the desktop rather than as
+another panel of the app — so inside it, `$background` is the bubble and
+`$text` is the ink on it, published through a `ThemeProvider` so that
+`useTheme()` agrees. Write the content the way you would write anything
+else and it is legible in both schemes; hard-code a light text colour and
+it will be invisible on the light bubble a dark palette gives it. `dim` is
+derived for the same reason — the palette's own is a grey chosen against
+the app's background, not against this one.
 
 Where the display composites, the popup is an ARGB window: a bubble rounded
 at `radiusTooltip`, no border, and a small arrow pointing back at the middle
@@ -550,13 +572,19 @@ selection colour, shared with `Select`'s active option and `Table`'s current
 row, so one token moves every highlight in the app. Without a compositor
 both go square, which is what those pixels can honestly be.
 
-**One selection at a time.** With submenus open, only the deepest level
-wears the selection colour; the rows behind it are drawn in `surfaceActive`.
+**One selection at a time.** The bar item, the row under it and the row
+under that are one trail, and only its deepest level wears the selection
+colour; everything behind is drawn in `surfaceActive`.
 They are still chosen — they are the way back — but two selection-coloured
 rows in two menus claim the same thing twice, and only one of them is where
 the keys are going. A submenu that is open with _nothing_ selected in it has
 not taken over yet: the pointer is still on the row that opened it, so that
-row stays lit.
+row stays lit — which is why a menu bar item stays coloured until you touch
+a row in the menu it opened, and goes quiet then.
+
+The bar item wears the same pill as the rows, at `radiusPopupItem`, inset
+into the bar by a few pixels taken out of its own padding so the bar is the
+height it always was.
 
 **Icons.** `icon` fills the 16px column left of the label — the same column
 the check mark uses, so an item that is both checked and iconned shows the

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -119,6 +119,43 @@ plain path on the same build, and as first aid if a scroll ever
 misrenders. Read once at startup, like the switches above, and like them
 it answers only to `1` — any other value leaves the blit on.
 
+## `REACT_X11_NO_TRANSPARENCY=1`
+
+Makes every display answer the way one with no 32-bit visual does:
+[`transparent`](elements.md#transparent--rounded-corners-and-translucency)
+is ignored, windows are created on
+the ordinary visual, `'@supports transparency'`
+([styling.md](styling.md#capability-queries)) never matches, and
+`useSupports('transparency')` is false.
+
+```sh
+REACT_X11_NO_TRANSPARENCY=1 npm run examples:tooltips
+```
+
+It exists because the fallback design is otherwise unreachable on the
+machine you work on. Rounded menus, the tooltip's arrow and any
+`@supports` block of your own have a second look for displays that cannot
+composite — and the only way to see it used to be stopping the compositor,
+which takes every other window on the desktop with it. Both halves answer
+this switch at once, deliberately: a window that took the ARGB visual under
+a `useSupports` that said no would size a popup for chrome it then refused
+to draw.
+
+What it models is a display with **no 32-bit visual** — XQuartz, a plain
+remote server. The other degraded case, an ARGB window with _nothing
+compositing it_, is the one where a cleared corner comes out black rather
+than showing the desktop; that one needs a real session with the compositor
+off (or `setCompositingForTests`), since the visual has to be taken for the
+question to arise. Both render the same by design, which is the invariant
+worth checking.
+
+Like the switches above it answers only to `1`, so a stale
+`NO_TRANSPARENCY=0` cannot quietly mean the opposite of what it says.
+Unlike them it is read per call rather than once at startup — it is asked
+when a window is created and when a `@supports` block resolves, never on
+the frame path, and being live is what lets a test turn it on around a
+single mount.
+
 ## The paint cache — `REACT_X11_NO_PAINT_CACHE`, `REACT_X11_PAINT_CACHE=verify`
 
 `<svg>` and `<tex>` render their content once and composite the result on

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -378,6 +378,13 @@ const canBlend = useSupports('transparency');
 const margin = canBlend ? 26 : 0; // room for a client-drawn shadow
 ```
 
+To **look at the fallback** on a display that composites perfectly well,
+run with `REACT_X11_NO_TRANSPARENCY=1`: `transparent` is ignored, the window
+is created on the ordinary visual, and both the style block and
+`useSupports` answer false. Otherwise the only way to see the design you
+wrote for XQuartz is to stop the compositor, which takes the rest of your
+desktop with it. See [debugging.md](debugging.md).
+
 Toggling the `transparent` prop itself on a mounted window does nothing
 until it remounts (change its `key`) — again because the visual is fixed at
 creation. Requires **ntk ≥ 6.6.0**.

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -415,6 +415,11 @@ which answers the same question about the display.
 
 An unknown feature name is an error, like a malformed size query.
 
+Running with `REACT_X11_NO_TRANSPARENCY=1` makes the answer false on any
+display, so the base design — the one nobody tests, being the unusual case —
+can be looked at without stopping the compositor for the whole session. See
+[debugging.md](debugging.md#react_x11_no_transparency1).
+
 ## Decided
 
 - **`':hover'`, not `_hover`.** The CSS spelling costs a pair of quotes and

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,6 +27,7 @@ Roughly in the order worth reading them:
 | [`rules.jsx`](rules.jsx)             | a WHEN/THEN rule builder: a recursive tree that edits itself, with drag-to-reorder and `<svg>` icons                   |
 | [`widgets.jsx`](widgets.jsx)         | the gallery: every standard component in one window, with a live `<markdown>` preview                                  |
 | [`menu.jsx`](menu.jsx)               | `MenuBar` and `ContextMenu` over real `<popup>` windows that flip at screen edges — File → Open… is a real file dialog |
+| [`tooltips.jsx`](tooltips.jsx)       | hints that are text and hints that are components, `direction="auto"`, and the arrow an ARGB popup can have            |
 | [`theming.jsx`](theming.jsx)         | the style engine end to end: three themes in light and dark, switched at runtime                                       |
 | [`appearance.jsx`](appearance.jsx)   | follows the desktop's light/dark, accent, contrast and reduced motion — change your theme while it runs                |
 | [`richtext.jsx`](richtext.jsx)       | `<markdown>` with highlighted and math fences, a live `<tex>` formula, JSX `<svg>`, `<image>`                          |

--- a/examples/rules.jsx
+++ b/examples/rules.jsx
@@ -36,39 +36,49 @@ import {
   ThemeProvider,
   useAnchor,
   useAnchorTracking,
+  useTheme,
 } from '../src/index.js';
 
 // --- palette ---------------------------------------------------------------
+//
+// Two palettes, and the example says nothing about which is in force:
+// `<ThemeProvider value={LIGHT} dark={DARK}>` layers the dark one on when the
+// desktop is dark, so this follows the machine the way the widgets do.
+//
+// Four of the design's colours are the *standard* tokens — `text`, `dim`,
+// `border`, `background` — because that is what they are, and naming them
+// privately would mean a sheet whose ink and a `Select` whose ink were two
+// different decisions that happened to agree. What stays private is what the
+// design actually adds: the sheet under the rows, the bracket rail, the
+// true/false chips, the drop target.
+//
+// Everything reads them as `$tokens` rather than as values, which is what
+// lets the styles below stay hoisted at module level and still follow the
+// desktop — resolution walks the node tree, not React (docs/styling.md).
 
-const C = {
+const LIGHT = {
+  // the standard four, which the built-in widgets read too
+  background: '#ffffff',
+  text: '#18181b',
+  dim: '#71717a',
+  border: '#e4e4e7',
+  // this design's own
   page: '#ffffff',
   row: '#fafafa',
   rowLocked: '#f4f4f5',
-  card: '#ffffff',
+  faint: '#a1a1aa',
+  rail: '#d4d4d8',
   dropEdge: '#93c5fd',
   dropFill: '#eff6ff',
-  edge: '#e4e4e7',
-  rail: '#d4d4d8',
-  text: '#18181b',
-  dim: '#71717a',
-  faint: '#a1a1aa',
   trueBg: '#ecfdf3',
   trueText: '#067647',
   falseBg: '#fef3f2',
   falseText: '#b42318',
-};
-
-// The widget palette. Everything the built-in controls paint reads from
-// here, so the pills, their dropdowns and the ghost buttons stay one look.
-const UI = {
-  border: C.edge,
-  borderActive: C.faint,
-  background: C.card,
-  text: C.text,
-  dim: C.faint,
+  // the widget palette: a monochrome accent, because every coloured thing in
+  // this sheet means something and a blue button would be the odd one out
   hoverBackground: '#f4f4f5',
-  hoverText: C.text,
-  accent: C.text,
+  hoverText: '#18181b',
+  accent: '#18181b',
   accentHover: '#3f3f46',
   surfaceHover: '#f4f4f5',
   radius: 8,
@@ -78,10 +88,45 @@ const UI = {
   paddingY: 7,
 };
 
-// A second palette for the two dropdowns that read as labels rather than
-// as choices — the locked trigger's status and the branch selector. Only
-// the colours differ, so they are still real menus, just quiet ones.
-const UI_QUIET = { ...UI, text: C.faint, background: C.row };
+// The same design in the dark scheme rather than a second one: same shapes,
+// same roles, the greys walked the other way. Zinc, as the light palette is.
+const DARK = {
+  background: '#1f1f23',
+  text: '#f4f4f5',
+  dim: '#a1a1aa',
+  border: '#3f3f46',
+  page: '#18181b',
+  row: '#232327',
+  rowLocked: '#26262b',
+  faint: '#71717a',
+  rail: '#52525b',
+  dropEdge: '#3b82f6',
+  dropFill: '#1e293b',
+  trueBg: '#0c2f1e',
+  trueText: '#4ade80',
+  falseBg: '#3a1416',
+  falseText: '#fca5a5',
+  hoverBackground: '#2a2a30',
+  hoverText: '#f4f4f5',
+  accent: '#f4f4f5',
+  accentHover: '#d4d4d8',
+  // the accent is the ink here, so what goes *on* it is the page
+  accentText: '#18181b',
+  surfaceHover: '#2a2a30',
+};
+
+/**
+ * The palette for the two dropdowns that read as labels rather than as
+ * choices — the locked trigger's status, and the branch selector. Only the
+ * colours differ, so they are still real menus, just quiet ones.
+ *
+ * Derived from the palette in force rather than written out twice: it is the
+ * same two substitutions in either scheme.
+ */
+const quietPalette = (theme) => ({
+  text: theme.faint,
+  background: theme.row,
+});
 
 // --- the vocabulary --------------------------------------------------------
 
@@ -301,16 +346,21 @@ const LUCIDE = {
   strokeLinejoin: 'round',
 };
 
-function Icon({ children, color = C.faint, size = 16, style }) {
+// `currentColor` and the colour in the *style*, rather than a stroke per
+// shape: an SVG attribute takes a value, and a `$token` is only resolved in
+// the style channel — which is also where a colour has to be for the
+// renderer to cache the drawing as coverage and recolour it per node
+// (docs/elements.md).
+function Icon({ children, color = '$faint', size = 16, style }) {
   return (
     <svg
       viewBox="0 0 24 24"
-      style={[{ width: size, height: size, flexShrink: 0 }, style]}
+      style={[{ width: size, height: size, flexShrink: 0, color }, style]}
     >
       {React.Children.map(children, (child) =>
         React.cloneElement(child, {
           ...LUCIDE,
-          stroke: color,
+          stroke: 'currentColor',
           ...child.props,
         }),
       )}
@@ -413,7 +463,7 @@ const RAIL_X = 8.5; // the vertical line inside it, on a half pixel
 const JOIN_W = 38; // the And/Or pill, wide enough for either word
 
 const s = createStyles({
-  window: { backgroundColor: C.page },
+  window: { backgroundColor: '$page' },
   // the left padding is the bracket's gutter: a top-level list pulls itself
   // into it so its rows line up with the headers and the trigger above them
   page: { flexGrow: 1, padding: 28, paddingTop: 22, paddingLeft: 28 + RAIL },
@@ -446,13 +496,13 @@ const s = createStyles({
     alignItems: 'center',
     justifyContent: 'center',
     borderWidth: 1,
-    borderColor: C.edge,
+    borderColor: '$border',
     borderRadius: 11,
-    backgroundColor: C.card,
+    backgroundColor: '$background',
     cursor: 'pointer',
-    ':hover': { borderColor: C.faint },
+    ':hover': { borderColor: '$faint' },
   },
-  joinText: { fontSize: 12, color: C.dim },
+  joinText: { fontSize: 12, color: '$dim' },
 
   // the grey capsule a rule or an action lives in
   row: {
@@ -463,7 +513,7 @@ const s = createStyles({
     paddingLeft: 10,
     paddingRight: 10,
     borderRadius: 10,
-    backgroundColor: C.row,
+    backgroundColor: '$row',
     // carried by every row, painted on none of them: the lifted row turns it
     // on, and a border that only appears when held would make the row 2px
     // taller than the landing box standing in for it
@@ -472,7 +522,7 @@ const s = createStyles({
   },
   // the row while it is held: off the page rather than in it, which without
   // a shadow to cast is said with the fill and an edge the flow rows lack
-  rowLifted: { backgroundColor: C.card, borderColor: C.edge },
+  rowLifted: { backgroundColor: '$background', borderColor: '$border' },
   // the wrapping half of a row. `flexBasis: 0` because yoga defaults
   // flexShrink to 0: with `auto`, this takes its content's max-content width
   // as its base, cannot shrink back, and the fields never wrap at all
@@ -499,9 +549,9 @@ const s = createStyles({
   landing: {
     borderWidth: 2,
     borderStyle: 'dashed',
-    borderColor: C.dropEdge,
+    borderColor: '$dropEdge',
     borderRadius: 10,
-    backgroundColor: C.dropFill,
+    backgroundColor: '$dropFill',
   },
   rowLocked: {
     flexDirection: 'row',
@@ -511,10 +561,10 @@ const s = createStyles({
     paddingLeft: 12,
     paddingRight: 10,
     borderRadius: 10,
-    backgroundColor: C.rowLocked,
+    backgroundColor: '$rowLocked',
   },
-  word: { color: C.dim, fontSize: 14 },
-  lockedWord: { color: C.dim, fontSize: 14 },
+  word: { color: '$dim', fontSize: 14 },
+  lockedWord: { color: '$dim', fontSize: 14 },
 
   handle: {
     width: 20,
@@ -543,11 +593,11 @@ const s = createStyles({
     paddingLeft: 10,
     paddingRight: 10,
     fontSize: 14,
-    color: C.text,
+    color: '$text',
     borderWidth: 1,
-    borderColor: C.edge,
+    borderColor: '$border',
     borderRadius: 8,
-    backgroundColor: C.card,
+    backgroundColor: '$background',
   },
 
   // the multi-value field, and the removable chips in it
@@ -564,12 +614,12 @@ const s = createStyles({
     paddingLeft: 6,
     paddingRight: 6,
     borderWidth: 1,
-    borderColor: C.edge,
+    borderColor: '$border',
     borderRadius: 8,
-    backgroundColor: C.card,
+    backgroundColor: '$background',
     cursor: 'pointer',
   },
-  tokensOpen: { borderColor: C.faint },
+  tokensOpen: { borderColor: '$faint' },
   chip: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -578,11 +628,11 @@ const s = createStyles({
     paddingLeft: 8,
     paddingRight: 2,
     borderWidth: 1,
-    borderColor: C.edge,
+    borderColor: '$border',
     borderRadius: 6,
-    backgroundColor: C.card,
+    backgroundColor: '$background',
   },
-  chipText: { fontSize: 13, color: C.text },
+  chipText: { fontSize: 13, color: '$text' },
   chipClose: {
     width: 18,
     height: 18,
@@ -592,15 +642,15 @@ const s = createStyles({
     cursor: 'pointer',
     ':hover': { backgroundColor: '$surfaceActive' },
   },
-  placeholder: { fontSize: 13, color: C.faint, paddingLeft: 4 },
+  placeholder: { fontSize: 13, color: '$faint', paddingLeft: 4 },
 
   menu: {
     flexGrow: 1,
     flexShrink: 1,
     borderWidth: 1,
-    borderColor: C.edge,
+    borderColor: '$border',
     borderRadius: 8,
-    backgroundColor: C.card,
+    backgroundColor: '$background',
   },
   menuItem: {
     flexDirection: 'row',
@@ -613,20 +663,20 @@ const s = createStyles({
     cursor: 'pointer',
     ':hover': { backgroundColor: '$surfaceHover' },
   },
-  menuText: { fontSize: 13, color: C.text },
+  menuText: { fontSize: 13, color: '$text' },
 
   // the group card, and the buttons under every list
   card: {
     padding: 14,
     paddingBottom: 10,
     borderWidth: 1,
-    borderColor: C.edge,
+    borderColor: '$border',
     borderRadius: 12,
-    backgroundColor: C.card,
+    backgroundColor: '$background',
     gap: 10,
   },
   cardHead: { flexDirection: 'row', alignItems: 'center', gap: 8 },
-  cardTitle: { fontSize: 12, color: C.faint },
+  cardTitle: { fontSize: 12, color: '$faint' },
 
   buttons: { flexDirection: 'row', flexWrap: 'wrap', gap: 8, paddingTop: 4 },
   ghost: {
@@ -637,13 +687,13 @@ const s = createStyles({
     paddingLeft: 12,
     paddingRight: 14,
     borderWidth: 1,
-    borderColor: C.edge,
+    borderColor: '$border',
     borderRadius: 8,
-    backgroundColor: C.card,
+    backgroundColor: '$background',
     cursor: 'pointer',
-    ':hover': { backgroundColor: '$background', borderColor: C.faint },
+    ':hover': { backgroundColor: '$background', borderColor: '$faint' },
   },
-  ghostText: { fontSize: 14, color: C.text },
+  ghostText: { fontSize: 14, color: '$text' },
 
   // the two THEN branches
   branch: {
@@ -673,6 +723,7 @@ const valueOf = (ev) => (ev?.type === 'change' ? ev.value : ev);
 
 /** The pill every dropdown in a row is: `Select`, shaped to match. */
 function Pill({ quiet = false, style, onChange, ...props }) {
+  const theme = useTheme();
   const select = (
     <Select
       {...props}
@@ -690,9 +741,11 @@ function Pill({ quiet = false, style, onChange, ...props }) {
       ]}
     />
   );
-  // the quiet palette is scoped to the one control, not to the tree
+  // the quiet palette is scoped to the one control, not to the tree — and
+  // derived from the one in force rather than frozen, so it follows the
+  // desktop like everything else
   return quiet ? (
-    <ThemeProvider value={UI_QUIET}>{select}</ThemeProvider>
+    <ThemeProvider value={quietPalette(theme)}>{select}</ThemeProvider>
   ) : (
     select
   );
@@ -791,7 +844,7 @@ function TokenField({ options, values, onChange }) {
           // rectangle, exactly as it was before.
           transparent
           style={{
-            backgroundColor: C.card,
+            backgroundColor: '$background',
             '@supports transparency': { backgroundColor: 'transparent' },
           }}
         >
@@ -814,7 +867,7 @@ function TokenField({ options, values, onChange }) {
                     {/* the tick's slot is held whether or not it is on, so
                         the labels do not shuffle as values are picked */}
                     <box style={s.tick}>
-                      {on && <CheckIcon color={C.text} size={16} />}
+                      {on && <CheckIcon color={'$text'} size={16} />}
                     </box>
                     <Label style={s.menuText}>{option}</Label>
                   </box>
@@ -861,7 +914,9 @@ function Rail({ position, gapBelow, hidden = false, onElbow }) {
         onElbow?.(node.abs.y + cy);
         if (position === 'only') return;
         const r = 8;
-        ctx.strokeStyle = C.rail;
+        // a canvas paints with values, not tokens — `node.theme` is the
+        // same palette a `$rail` in a style would have resolved against
+        ctx.strokeStyle = node.theme?.rail ?? '#d4d4d8';
         ctx.lineWidth = 1;
         ctx.beginPath();
         if (position === 'first') {
@@ -1310,8 +1365,8 @@ function ListButtons({ onNodes, nodes, kind }) {
 function Branch({ tone, label }) {
   const colors =
     tone === 'yes'
-      ? { backgroundColor: C.trueBg, color: C.trueText }
-      : { backgroundColor: C.falseBg, color: C.falseText };
+      ? { backgroundColor: '$trueBg', color: '$trueText' }
+      : { backgroundColor: '$falseBg', color: '$falseText' };
   return (
     <box style={[s.branch, { backgroundColor: colors.backgroundColor }]}>
       <CheckIcon color={colors.color} size={14} />
@@ -1350,13 +1405,12 @@ export function RulesPanel() {
     });
   };
 
-  // the widget palette wraps the panel rather than the window, so the panel
-  // still looks like itself wherever it is dropped
+  // The palette wraps the panel rather than the window, so the panel still
+  // looks like itself wherever it is dropped — `App` puts a second provider
+  // above the window, which is the only way the *window's* own background
+  // can read a token this palette defines.
   return (
-    // This app styles everything from its own `C` palette, so it pins rather
-    // than half-following: layering a light design over a dark base is what
-    // produces a window of mixed light and dark controls.
-    <ThemeProvider value={UI} colorScheme="light">
+    <ThemeProvider value={LIGHT} dark={DARK}>
       <scrollview style={s.page}>
         <box style={s.sheet}>
           <Label style={s.section}>WHEN</Label>
@@ -1430,17 +1484,22 @@ export function RulesPanel() {
 }
 
 function App() {
+  // A provider above a `<window>` renders no box — it plants the palette on
+  // the window itself (a window may not sit inside a box), which is what
+  // lets the window's own `backgroundColor: '$page'` resolve.
   return (
-    <window
-      title="rules"
-      width={880}
-      height={820}
-      minWidth={560}
-      minHeight={360}
-      style={s.window}
-    >
-      <RulesPanel />
-    </window>
+    <ThemeProvider value={LIGHT} dark={DARK}>
+      <window
+        title="rules"
+        width={880}
+        height={820}
+        minWidth={560}
+        minHeight={360}
+        style={s.window}
+      >
+        <RulesPanel />
+      </window>
+    </ThemeProvider>
   );
 }
 

--- a/examples/tooltips.jsx
+++ b/examples/tooltips.jsx
@@ -28,9 +28,6 @@ import {
   useSupports,
 } from '../src/index.js';
 
-const INK = '#2d3436';
-const DIM = '#7f8c8d';
-
 const SWATCHES = [
   { name: 'Signal', hex: '#e74c3c', use: 'errors, destructive actions' },
   { name: 'Meadow', hex: '#27ae60', use: 'success, "saved" states' },
@@ -44,6 +41,12 @@ const SWATCHES = [
  * `flexGrow: 1` because the bubble hands an element the whole rectangle and
  * imposes no padding of its own — the card draws its own, which is the
  * point of passing one.
+ *
+ * The tokens are the **bubble's**, not the window's: a hint is drawn in the
+ * palette's ink, so inside it `$text` is the ink *on that surface* and
+ * `$background` is the surface. Written this way the card is legible in
+ * either scheme; hard-coding a light text colour would put it on the light
+ * bubble a dark desktop gives it, and disappear.
  */
 function SwatchCard({ swatch }) {
   return (
@@ -58,11 +61,11 @@ function SwatchCard({ swatch }) {
           }}
         />
         <box style={{ gap: 1 }}>
-          <text style={{ color: '#f5f6fa', fontSize: 13 }}>{swatch.name}</text>
-          <text style={{ color: '#b2bec3', fontSize: 11 }}>{swatch.hex}</text>
+          <text style={{ color: '$text', fontSize: 13 }}>{swatch.name}</text>
+          <text style={{ color: '$dim', fontSize: 11 }}>{swatch.hex}</text>
         </box>
       </box>
-      <text style={{ color: '#b2bec3', fontSize: 11 }}>{swatch.use}</text>
+      <text style={{ color: '$dim', fontSize: 11 }}>{swatch.use}</text>
     </box>
   );
 }
@@ -72,9 +75,9 @@ function SwatchCard({ swatch }) {
 function UsageCard({ used }) {
   return (
     <box style={{ flexGrow: 1, padding: 10, gap: 7, justifyContent: 'center' }}>
-      <text style={{ color: '#f5f6fa', fontSize: 13 }}>Scratch volume</text>
+      <text style={{ color: '$text', fontSize: 13 }}>Scratch volume</text>
       <ProgressBar value={used} />
-      <text style={{ color: '#b2bec3', fontSize: 11 }}>
+      <text style={{ color: '$dim', fontSize: 11 }}>
         {`${Math.round(used * 100)}% of 240 GB used`}
       </text>
     </box>
@@ -84,7 +87,7 @@ function UsageCard({ used }) {
 function Row({ label, children }) {
   return (
     <box style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
-      <text style={{ color: DIM, width: 92 }}>{label}</text>
+      <text style={{ color: '$dim', width: 92 }}>{label}</text>
       {children}
     </box>
   );
@@ -97,8 +100,8 @@ function Panel() {
   return (
     <box style={{ flexGrow: 1, padding: 18, gap: 16 }}>
       <box style={{ gap: 3 }}>
-        <text style={{ fontSize: 19, color: INK }}>Tooltips</text>
-        <text style={{ fontSize: 12, color: DIM }}>
+        <text style={{ fontSize: 19, color: '$text' }}>Tooltips</text>
+        <text style={{ fontSize: 12, color: '$dim' }}>
           {composited
             ? 'compositing: rounded, with an arrow'
             : 'no compositor: square and opaque, no arrow'}
@@ -141,7 +144,7 @@ function Panel() {
                 height: 34,
                 borderRadius: 6,
                 borderWidth: 1,
-                borderColor: '#dfe6e9',
+                borderColor: '$border',
                 backgroundColor: swatch.hex,
                 cursor: 'pointer',
               }}
@@ -169,13 +172,13 @@ function Panel() {
               paddingRight: 12,
               borderRadius: 6,
               borderWidth: 1,
-              borderColor: '#dfe6e9',
-              backgroundColor: 'white',
+              borderColor: '$border',
+              backgroundColor: '$background',
               cursor: 'pointer',
             }}
           >
-            <text style={{ color: INK }}>/scratch</text>
-            <text style={{ color: DIM, fontSize: 12 }}>
+            <text style={{ color: '$text' }}>/scratch</text>
+            <text style={{ color: '$dim', fontSize: 12 }}>
               {`${Math.round(used * 100)}%`}
             </text>
           </box>
@@ -183,7 +186,7 @@ function Panel() {
       </Row>
 
       <box style={{ flexGrow: 1 }} />
-      <text style={{ fontSize: 11, color: DIM }}>
+      <text style={{ fontSize: 11, color: '$dim' }}>
         Move the window against a screen edge to watch “auto” change its mind.
       </text>
     </box>
@@ -192,12 +195,9 @@ function Panel() {
 
 function App() {
   return (
-    <window
-      width={520}
-      height={330}
-      title="tooltips"
-      style={{ backgroundColor: '#f5f6fa' }}
-    >
+    // no `backgroundColor`: an unstyled window fills from the palette in
+    // force, so this follows the desktop between light and dark
+    <window width={520} height={330} title="tooltips">
       <Panel />
     </window>
   );

--- a/examples/tooltips.jsx
+++ b/examples/tooltips.jsx
@@ -1,0 +1,211 @@
+// Tooltips: the two kinds, and where they point.
+//
+// A `label` that is a **string** is measured and the popup is sized around
+// it — the common case, and the one that needs nothing from the caller. A
+// `label` that is an **element** gets the bubble to fill and a `width`/
+// `height` to fill it at, because a <popup> is a real X window: it needs its
+// size before React can lay anything out inside it. Anything renders in
+// there, widgets included — the last card below has a real <ProgressBar>.
+//
+// `direction` picks the side. The default, `"auto"`, takes the first side
+// the hint fits on measured against the *screen* (a popup is a real window,
+// so the screen is what bounds it) — drag this window to the top edge and
+// the hints that were opening above start opening below.
+//
+// Where a compositor is running the popups are ARGB windows: rounded
+// corners, and a small arrow pointing back at the trigger with the rest of
+// the window left transparent. Without one they degrade to the square
+// opaque rectangles they have always been — the strip below says which of
+// the two this display is getting.
+//
+// Run with: npm run examples:tooltips  (needs an X server / DISPLAY)
+import React, { useState } from 'react';
+import {
+  createRoot,
+  Button,
+  ProgressBar,
+  Tooltip,
+  useSupports,
+} from '../src/index.js';
+
+const INK = '#2d3436';
+const DIM = '#7f8c8d';
+
+const SWATCHES = [
+  { name: 'Signal', hex: '#e74c3c', use: 'errors, destructive actions' },
+  { name: 'Meadow', hex: '#27ae60', use: 'success, "saved" states' },
+  { name: 'Harbour', hex: '#2980b9', use: 'selection, links, focus' },
+];
+
+/**
+ * A tooltip that is a component rather than a line of text: a chip of the
+ * colour, its name and hex, and a note under them.
+ *
+ * `flexGrow: 1` because the bubble hands an element the whole rectangle and
+ * imposes no padding of its own — the card draws its own, which is the
+ * point of passing one.
+ */
+function SwatchCard({ swatch }) {
+  return (
+    <box style={{ flexGrow: 1, padding: 10, gap: 8 }}>
+      <box style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+        <box
+          style={{
+            width: 22,
+            height: 22,
+            borderRadius: 5,
+            backgroundColor: swatch.hex,
+          }}
+        />
+        <box style={{ gap: 1 }}>
+          <text style={{ color: '#f5f6fa', fontSize: 13 }}>{swatch.name}</text>
+          <text style={{ color: '#b2bec3', fontSize: 11 }}>{swatch.hex}</text>
+        </box>
+      </box>
+      <text style={{ color: '#b2bec3', fontSize: 11 }}>{swatch.use}</text>
+    </box>
+  );
+}
+
+/** And one with a live widget in it, to make the point that it is a real
+ *  tree and not a rich-text label. */
+function UsageCard({ used }) {
+  return (
+    <box style={{ flexGrow: 1, padding: 10, gap: 7, justifyContent: 'center' }}>
+      <text style={{ color: '#f5f6fa', fontSize: 13 }}>Scratch volume</text>
+      <ProgressBar value={used} />
+      <text style={{ color: '#b2bec3', fontSize: 11 }}>
+        {`${Math.round(used * 100)}% of 240 GB used`}
+      </text>
+    </box>
+  );
+}
+
+function Row({ label, children }) {
+  return (
+    <box style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+      <text style={{ color: DIM, width: 92 }}>{label}</text>
+      {children}
+    </box>
+  );
+}
+
+function Panel() {
+  const [used, setUsed] = useState(0.62);
+  const composited = useSupports('transparency');
+
+  return (
+    <box style={{ flexGrow: 1, padding: 18, gap: 16 }}>
+      <box style={{ gap: 3 }}>
+        <text style={{ fontSize: 19, color: INK }}>Tooltips</text>
+        <text style={{ fontSize: 12, color: DIM }}>
+          {composited
+            ? 'compositing: rounded, with an arrow'
+            : 'no compositor: square and opaque, no arrow'}
+        </text>
+      </box>
+
+      {/* A string label. Nothing to size, nothing to lay out — the popup is
+          measured from the text. */}
+      <Row label="Text">
+        <Tooltip label="Back to zero" delay={250}>
+          <Button onPress={() => setUsed(0)}>Reset</Button>
+        </Tooltip>
+        <Tooltip label="Fills the volume up" direction="bottom" delay={250}>
+          <Button onPress={() => setUsed((u) => Math.min(1, u + 0.12))}>
+            Fill
+          </Button>
+        </Tooltip>
+        <Tooltip
+          label="Hangs off the right, where there is room for it"
+          direction="right"
+          delay={250}
+        >
+          <Button>Right</Button>
+        </Tooltip>
+      </Row>
+
+      {/* An element label: the caller says how big, and fills it. */}
+      <Row label="Component">
+        {SWATCHES.map((swatch) => (
+          <Tooltip
+            key={swatch.hex}
+            label={<SwatchCard swatch={swatch} />}
+            width={190}
+            height={78}
+            delay={250}
+          >
+            <box
+              style={{
+                width: 54,
+                height: 34,
+                borderRadius: 6,
+                borderWidth: 1,
+                borderColor: '#dfe6e9',
+                backgroundColor: swatch.hex,
+                cursor: 'pointer',
+              }}
+            />
+          </Tooltip>
+        ))}
+      </Row>
+
+      <Row label="Widgets">
+        <Tooltip
+          label={<UsageCard used={used} />}
+          width={200}
+          height={82}
+          direction="right"
+          delay={250}
+        >
+          <box
+            style={{
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: 8,
+              paddingTop: 7,
+              paddingBottom: 7,
+              paddingLeft: 12,
+              paddingRight: 12,
+              borderRadius: 6,
+              borderWidth: 1,
+              borderColor: '#dfe6e9',
+              backgroundColor: 'white',
+              cursor: 'pointer',
+            }}
+          >
+            <text style={{ color: INK }}>/scratch</text>
+            <text style={{ color: DIM, fontSize: 12 }}>
+              {`${Math.round(used * 100)}%`}
+            </text>
+          </box>
+        </Tooltip>
+      </Row>
+
+      <box style={{ flexGrow: 1 }} />
+      <text style={{ fontSize: 11, color: DIM }}>
+        Move the window against a screen edge to watch “auto” change its mind.
+      </text>
+    </box>
+  );
+}
+
+function App() {
+  return (
+    <window
+      width={520}
+      height={330}
+      title="tooltips"
+      style={{ backgroundColor: '#f5f6fa' }}
+    >
+      <Panel />
+    </window>
+  );
+}
+
+export default App;
+
+if (!process.env.REACT_X11_NO_AUTORUN) {
+  const root = await createRoot();
+  root.render(<App />);
+}

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "examples:tasks": "tsx examples/tasks.jsx",
     "examples:tasks:hot": "node --enable-source-maps --import ./examples/hmr-register.mjs examples/tasks-hot.jsx",
     "examples:menu": "tsx examples/menu.jsx",
+    "examples:tooltips": "tsx examples/tooltips.jsx",
     "examples:clipboard": "tsx examples/clipboard.jsx",
     "examples:dbus": "tsx examples/dbus.jsx",
     "filedialog:probe": "node scripts/filedialog-probe.mjs",

--- a/src/appcontext.js
+++ b/src/appcontext.js
@@ -21,7 +21,11 @@ import {
 } from 'react';
 
 import { createClipboard } from './clipboard.js';
-import { compositingActive, watchCompositing } from './compositing.js';
+import {
+  argbVisual,
+  compositingActive,
+  watchCompositing,
+} from './compositing.js';
 
 const AppContext = createContext(null);
 
@@ -66,7 +70,9 @@ const SUPPORTS_FEATURES = new Set(['transparency']);
  *
  * `'transparency'` is true when the server has a 32-bit visual to draw on
  * *and* a compositor is running to blend it. It re-renders when a compositor
- * starts or stops.
+ * starts or stops. `REACT_X11_NO_TRANSPARENCY=1` answers false whatever the
+ * display can do, so the fallback design can be looked at without stopping
+ * the compositor for the whole session.
  *
  * The companion is the `'@supports transparency'` style block, and the two
  * answer deliberately different questions. This one is about the display, so
@@ -92,7 +98,7 @@ export function useSupports(feature) {
   // a boolean, so the snapshot is stable for a given state — returning the
   // visual object here would tear on every render
   const snapshot = useCallback(
-    () => compositingActive(app) && Boolean(app.findArgbVisual?.()),
+    () => compositingActive(app) && Boolean(argbVisual(app)),
     [app],
   );
   return useSyncExternalStore(subscribe, snapshot, snapshot);

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -131,9 +131,24 @@ function gutterMark(item, { color, fontSize }) {
     : icon;
 }
 
+/**
+ * How a row is drawn, which is three states and not two.
+ *
+ * `'active'` is the selection: this row is where the menus are being driven
+ * from. `'path'` is a row whose submenu has taken that over — it is still
+ * the way back to where you are, and it still has to look chosen, but two
+ * selection-coloured rows in two menus would be claiming the same thing
+ * twice. Every desktop resolves that the same way: the trail goes quiet and
+ * only the live end of it stays lit.
+ */
+function rowState(index, active, handedOn) {
+  if (index !== active) return undefined;
+  return handedOn ? 'path' : 'active';
+}
+
 function MenuRow({
   item,
-  active,
+  state,
   onHover,
   onMove,
   onSelect,
@@ -141,6 +156,9 @@ function MenuRow({
   nodeRef,
 }) {
   const theme = useTheme();
+  // only the live end of the trail takes the selection colour, and with it
+  // the inverted label
+  const active = state === 'active';
   if (item.separator) {
     return h(
       'box',
@@ -175,7 +193,11 @@ function MenuRow({
         // now that the row is rounded, repainting it per row would be a
         // coverage mask drawn to change nothing — with four corners it
         // deliberately leaves out.
-        backgroundColor: active ? theme.hoverBackground : 'transparent',
+        backgroundColor: active
+          ? theme.hoverBackground
+          : state === 'path'
+            ? theme.surfaceActive
+            : 'transparent',
         // the item is already highlighted by the time it can be pressed, so
         // the press is a further step down rather than a first one — without
         // it the command runs on the release out of a picture that never
@@ -257,6 +279,10 @@ function MenuLevel({
   const active = path[depth] ?? -1;
   const childItems = items[active]?.items;
   const childOpen = path.length > depth + 1 && childItems?.length > 0;
+  // Has this level's selection handed over to the one below it? A submenu
+  // opened with nothing selected in it yet has not: the pointer is still on
+  // the row that opened it, and that row is still where the keys go.
+  const handedOn = childOpen && (path[depth + 1] ?? -1) >= 0;
 
   const activeRowRef = useRef(null);
   const listRef = useRef(null);
@@ -281,6 +307,13 @@ function MenuLevel({
         // two menus overlapped by five pixels.
         alignTo: node,
         align: 'start',
+        // Lined up on the *items*, not on the boxes: the submenu's own
+        // border and padding come before its first row, so a popup whose
+        // top edge is level with the parent row opens that row's
+        // continuation six pixels lower than the row itself. Shifting by
+        // the inset puts the first item exactly beside the item it came
+        // out of, which is where the eye is already looking.
+        alignOffset: -(MENU_BORDER + MENU_PAD),
         offset: 0,
         width: menuListWidth(node, childItems, fontSize),
         height: menuListHeight(childItems),
@@ -396,7 +429,7 @@ function MenuLevel({
         h(MenuRow, {
           key: item.separator ? `sep-${index}` : (item.key ?? item.label),
           item,
-          active: index === active,
+          state: rowState(index, active, handedOn),
           fontSize,
           nodeRef: index === active ? activeRowRef : undefined,
           onHover: (ev) => hover(index, ev),

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -13,6 +13,7 @@ import {
   screenOf,
   screenPoint,
   useAnchorTracking,
+  useDismissOnWindowBlur,
 } from './anchor.js';
 import { typeAheadChar, useTypeAhead } from './typeahead.js';
 import {
@@ -47,6 +48,18 @@ const MENU_PAD = 5;
 // an edge where it meets the desktop behind it, and a theme that draws 2px
 // borders on its *controls* does not mean a 2px outline around every menu.
 const MENU_BORDER = 1;
+
+// How far a bar item's pill sits inside the bar, taken out of its padding so
+// the bar's height does not change.
+const BAR_INSET = 3;
+
+// The horizontal gap between a menu and the submenu it opens, measured from
+// the parent popup's outer edge — so `0` is flush against it, a positive
+// value leaves the desktop showing between the two, and a negative one
+// overlaps the parent the way the classic toolkits do. The pointer crosses
+// this gap on its way to the submenu and the safe polygon covers it either
+// way (`movingToward`), so this is a matter of taste rather than of reach.
+const SUBMENU_GAP = 0;
 
 const MENU_GUTTER = 24; // room for the check column
 // what a self-drawing icon gets to fill, inside that column's 16px
@@ -314,7 +327,7 @@ function MenuLevel({
         // the inset puts the first item exactly beside the item it came
         // out of, which is where the eye is already looking.
         alignOffset: -(MENU_BORDER + MENU_PAD),
-        offset: 0,
+        offset: SUBMENU_GAP,
         width: menuListWidth(node, childItems, fontSize),
         height: menuListHeight(childItems),
       }),
@@ -568,6 +581,11 @@ export function ContextMenu({
     onSelect?.(item);
   };
 
+  // the wrapper keeps the focus the right-click gave it, so `onBlur` below
+  // never fires when the *window* loses focus — and the menu is holding a
+  // pointer grab until something closes it
+  useDismissOnWindowBlur(ref, Boolean(rect), close);
+
   const openAt = (ev) => {
     const node = ref.current;
     if (!node || !items.length) return;
@@ -739,6 +757,11 @@ export function MenuBar({
     setRect,
     close,
   );
+  // and shut it when the whole window loses focus. The bar item keeps the
+  // focus it took, so its own `onBlur` never fires for this — and a menu
+  // left open over an application the user has switched away from is still
+  // holding the pointer grab it opened with.
+  useDismissOnWindowBlur(activeTriggerRef, openIndex >= 0, close);
 
   const select = (item) => {
     close();
@@ -766,8 +789,13 @@ export function MenuBar({
         style,
       ],
     },
-    menus.map((menu, index) =>
-      h(
+    menus.map((menu, index) => {
+      // The bar is the first level of the same trail: while its menu is open
+      // with nothing chosen in it the item is the selection, and the moment a
+      // row down there takes over it goes quiet — the same handover, drawn
+      // the same way, one level up (`rowState`).
+      const barState = rowState(index, openIndex, (path[0] ?? -1) >= 0);
+      return h(
         'box',
         {
           key: menu.label,
@@ -828,10 +856,29 @@ export function MenuBar({
               cursor: 'pointer',
               paddingLeft: 10,
               paddingRight: 10,
-              paddingTop: 6,
-              paddingBottom: 6,
+              // The same pill the rows inside the menu wear, at the same
+              // radius: the bar item and the first row of the menu it opens
+              // are one gesture, and a square title over rounded rows reads
+              // as two widgets that have not met.
+              //
+              // The margin is what a radius needs to be seen — a rounded
+              // rect flush against the strip's own edges reads as a cut
+              // corner rather than a pill — and it comes out of the padding
+              // rather than being added to it, so the bar is the height it
+              // always was.
+              marginTop: BAR_INSET,
+              marginBottom: BAR_INSET,
+              marginLeft: 1,
+              marginRight: 1,
+              paddingTop: 6 - BAR_INSET,
+              paddingBottom: 6 - BAR_INSET,
+              borderRadius: theme.radiusPopupItem,
               backgroundColor:
-                openIndex === index ? theme.hoverBackground : undefined,
+                barState === 'active'
+                  ? theme.hoverBackground
+                  : barState === 'path'
+                    ? theme.surfaceActive
+                    : undefined,
               // No ring while this item's menu is up. Walking the bar with
               // the arrow keys opens each menu as it arrives, so the item is
               // already inverted with a menu hanging off it — a ring on top
@@ -858,14 +905,14 @@ export function MenuBar({
           'text',
           {
             style: {
-              color: openIndex === index ? theme.hoverText : theme.text,
+              color: barState === 'active' ? theme.hoverText : theme.text,
               fontSize: fontSize,
             },
           },
           menu.label,
         ),
-      ),
-    ),
+      );
+    }),
     openIndex >= 0 &&
       rect &&
       path.length > 0 &&

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -36,7 +36,17 @@ const MENU_SEPARATOR_HEIGHT = 7;
 
 const MENU_MIN_WIDTH = 140;
 
-const MENU_PAD = 4;
+// The inset between the popup's edge and a row, which is what makes the
+// highlight read as a *pill on* the menu rather than a band across it — and
+// what keeps the first and last one clear of the sheet's rounded corners,
+// where a full-width highlight would show a square shoulder outside the
+// curve.
+const MENU_PAD = 5;
+
+// A hairline, not `theme.borderWidth`: this border is there to give the sheet
+// an edge where it meets the desktop behind it, and a theme that draws 2px
+// borders on its *controls* does not mean a 2px outline around every menu.
+const MENU_BORDER = 1;
 
 const MENU_GUTTER = 24; // room for the check column
 // what a self-drawing icon gets to fill, inside that column's 16px
@@ -56,7 +66,7 @@ function menuListHeight(items) {
       sum + (item.separator ? MENU_SEPARATOR_HEIGHT : MENU_ITEM_HEIGHT),
     0,
   );
-  return body + MENU_PAD * 2 + 2;
+  return body + (MENU_PAD + MENU_BORDER) * 2;
 }
 
 /** Widest label + shortcut, measured, so the popup can be sized up front. */
@@ -75,7 +85,7 @@ function menuListWidth(node, items, fontSize) {
   }
   return Math.max(
     MENU_MIN_WIDTH,
-    Math.ceil(widest) + MENU_GUTTER + MENU_PAD * 2 + 12,
+    Math.ceil(widest) + MENU_GUTTER + (MENU_PAD + MENU_BORDER) * 2 + 10,
   );
 }
 
@@ -157,7 +167,15 @@ function MenuRow({
         paddingLeft: 8,
         paddingRight: 8,
         cursor: dim ? undefined : 'pointer',
-        backgroundColor: active ? theme.hoverBackground : theme.background,
+        // A pill inside the sheet: the row is inset from the popup edge by
+        // the list's padding and rounded a step tighter than the menu, so
+        // the highlight sits *on* the menu instead of cutting across it.
+        borderRadius: theme.radiusPopupItem,
+        // Nothing at rest: the sheet under it is already that colour, and
+        // now that the row is rounded, repainting it per row would be a
+        // coverage mask drawn to change nothing — with four corners it
+        // deliberately leaves out.
+        backgroundColor: active ? theme.hoverBackground : 'transparent',
         // the item is already highlighted by the time it can be pressed, so
         // the press is a further step down rather than a first one — without
         // it the command runs on the release out of a picture that never
@@ -348,7 +366,17 @@ function MenuLevel({
       windowType: 'popup_menu',
       grab: depth === 0,
       onDismiss: depth === 0 ? onDismiss : undefined,
-      style: { backgroundColor: theme.background },
+      // ARGB where the display has it, so the corners the sheet gives up are
+      // the desktop rather than a colour. The window paints nothing itself
+      // when it can be seen through — the list box below is the whole of the
+      // menu, and a square fill under it would put the corners straight back.
+      // Without a compositor the window is the opaque rectangle it always
+      // was, and the list box's rounding is gated off to match.
+      transparent: true,
+      style: {
+        backgroundColor: theme.background,
+        '@supports transparency': { backgroundColor: 'transparent' },
+      },
     },
     h(
       'box',
@@ -358,9 +386,10 @@ function MenuLevel({
           flexGrow: 1,
           flexShrink: 1,
           padding: MENU_PAD,
-          borderWidth: 1,
+          borderWidth: MENU_BORDER,
           borderColor: theme.border,
           backgroundColor: theme.background,
+          '@supports transparency': { borderRadius: theme.radiusPopup },
         },
       },
       items.map((item, index) =>

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -10,6 +10,7 @@ import {
   screenOf,
   useAnchor,
   useAnchorTracking,
+  useDismissOnWindowBlur,
 } from './anchor.js';
 import { DEFAULT_TEXT_STYLE } from '../styles.js';
 import { typeAheadChar, useTypeAhead } from './typeahead.js';
@@ -35,7 +36,15 @@ const MAX_MENU_HEIGHT = 220;
 // is measuring for clips the very labels it exists to fit.
 const ITEM_PAD_LEFT = 10;
 const ITEM_PAD_RIGHT = 10;
-const MENU_PAD = 4; // the scrollview's own padding
+// The scrollview's own padding, and so the inset between the sheet's edge
+// and an option — which is what makes the highlight read as a pill on the
+// menu rather than a band across it. The same number the menus use
+// (`Menu.js`): a dropdown is the same kind of surface and there is no
+// reading in which it wants a different one.
+const MENU_PAD = 5;
+// A hairline, not `theme.borderWidth`: this border gives the sheet an edge
+// where it meets the desktop behind it, and a theme that draws 2px borders
+// on its *controls* does not mean a 2px outline around every popup.
 const MENU_BORDER = 1;
 // the scrollbar is drawn *over* the content rather than insetting it
 // (`nodes.js`, SCROLLBAR_WIDTH), so a menu that scrolls reserves the room
@@ -99,7 +108,14 @@ function Option({ option, selected, active, onPick, onHover, nodeRef }) {
         paddingLeft: ITEM_PAD_LEFT,
         paddingRight: ITEM_PAD_RIGHT,
         cursor: 'pointer',
-        backgroundColor: active ? theme.hoverBackground : theme.background,
+        // the menus' pill, for the same reason and at the same radius: an
+        // option list and a menu are one surface with rows in it, and two
+        // shapes for that would only say the widgets were written apart
+        borderRadius: theme.radiusPopupItem,
+        // nothing at rest — the sheet under it is already that colour, and a
+        // rounded fill of the same colour is a coverage mask drawn to change
+        // nothing, with four corners it deliberately leaves out
+        backgroundColor: active ? theme.hoverBackground : 'transparent',
       },
     },
     h(
@@ -194,6 +210,9 @@ export function Select({
   // by the trigger's ancestors, so it would otherwise hang over content it
   // no longer points at.
   useAnchorTracking(triggerRef, open, menuAnchorOptions, setAnchor, close);
+  // and shut it when the whole window loses focus: the trigger keeps the
+  // focus it has, so its own `onBlur` never fires for this
+  useDismissOnWindowBlur(triggerRef, open, close);
 
   const emit = (next) => onChange?.(changeEvent('select-one', name, next));
 
@@ -332,13 +351,23 @@ export function Select({
       h(
         'popup',
         {
+          theme,
           x: anchor.x,
           y: anchor.y,
           width: anchor.width,
           height: menuHeight + 2,
           grab: true,
           onDismiss: close,
-          style: { backgroundColor: theme.background },
+          // ARGB where the display has it, so the corners the sheet gives up
+          // are the desktop rather than a colour — as the menus are. The
+          // window paints nothing itself when it can be seen through: the
+          // box below is the whole of the dropdown, and a square fill under
+          // it would put the corners straight back.
+          transparent: true,
+          style: {
+            backgroundColor: theme.background,
+            '@supports transparency': { backgroundColor: 'transparent' },
+          },
         },
         h(
           'box',
@@ -349,6 +378,7 @@ export function Select({
               borderWidth: MENU_BORDER,
               borderColor: theme.border,
               backgroundColor: theme.background,
+              '@supports transparency': { borderRadius: theme.radiusPopup },
             },
           },
           h(

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -2,8 +2,8 @@
 // support needed. Plain createElement (no JSX) so the library stays
 // build-step-free for consumers.
 
-import React, { useEffect, useRef, useState } from 'react';
-import { useSupports } from '../appcontext.js';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useApp, useSupports } from '../appcontext.js';
 import { useTheme } from './theme.js';
 import {
   DEFAULT_LABEL_SIZE,
@@ -53,6 +53,33 @@ const AUTO_SIDES = ['top', 'bottom', 'right', 'left'];
 // `anchorRect`'s own 2px gap, and enough left over that the hint is not
 // jammed flush against the edge of the screen.
 const AUTO_MARGIN = 8;
+
+/**
+ * The one hint that is up, per connection.
+ *
+ * A tooltip belongs to where the pointer is, and there is one pointer — so
+ * two of them on screen at once is never a state anything meant to produce.
+ * It happens anyway without a rule like this, because each `Tooltip` only
+ * watches its own trigger: the safe-polygon grace that lets a hint with
+ * content in it be *reached* (docs/components.md) is exactly a window where
+ * one stays up while the pointer has already moved on, and moving on can
+ * mean arriving somewhere that shows another.
+ *
+ * So the trigger taking the hover dismisses whatever else is showing, and
+ * showing claims the slot. Keyed by connection, not module-global: one
+ * process can drive several roots on several displays, and each display has
+ * its own pointer. A WeakMap, so a closed connection takes its entry with
+ * it.
+ */
+const showing = new WeakMap();
+
+/** Hide the hint that is up, unless it is this one. */
+function dismissOthers(app, self) {
+  const current = showing.get(app);
+  if (!current || current === self) return;
+  showing.delete(app);
+  current();
+}
 
 /**
  * The side to hang a hint off when the caller has not named one.
@@ -194,6 +221,7 @@ export function Tooltip({
   ...boxProps
 }) {
   const theme = useTheme();
+  const app = useApp();
   const ref = useRef(null);
   const measureAnchor = useAnchor(ref);
   const [rect, setRect] = useState(null);
@@ -203,16 +231,21 @@ export function Tooltip({
   // question (`useSupports`) rather than the per-window style block.
   const composited = useSupports('transparency');
 
-  const cancel = () => {
+  // `cancel` and `hide` touch nothing but refs and a state setter, so they
+  // can hold still across renders — and `hide` has to: it is this tooltip's
+  // identity in the `showing` registry, and one that changed every render
+  // would leave the registry holding a stale closure.
+  const cancel = useCallback(() => {
     if (timer.current) {
       clearTimeout(timer.current);
       timer.current = null;
     }
-  };
-  const hide = () => {
+  }, []);
+  const hide = useCallback(() => {
     cancel();
+    if (showing.get(app) === hide) showing.delete(app);
     setRect(null);
-  };
+  }, [app, cancel]);
 
   // safe-polygon hover (docs/components.md): leaving the trigger *toward*
   // the tooltip keeps it up, so a tooltip with content in it can be
@@ -222,7 +255,7 @@ export function Tooltip({
     cancel();
     timer.current = setTimeout(() => {
       timer.current = null;
-      setRect(null);
+      hide();
     }, SAFE_HOVER_DELAY);
   };
   const onMouseMove = (ev) => {
@@ -233,8 +266,14 @@ export function Tooltip({
     else hide();
   };
 
-  // a pending timer must not outlive the component
-  useEffect(() => cancel, []);
+  // neither a pending timer nor a claim on the one visible hint may outlive
+  // the component
+  useEffect(() => {
+    return () => {
+      cancel();
+      if (showing.get(app) === hide) showing.delete(app);
+    };
+  }, [app, cancel, hide]);
 
   // The bubble, which is the popup minus whatever the arrow takes.
   const bubbleSize = (node) => {
@@ -276,7 +315,12 @@ export function Tooltip({
     const options = tooltipAnchorOptions();
     if (!options) return;
     const next = measureAnchor(options);
-    if (next) setRect(next);
+    if (!next) return;
+    // claim the slot at the moment there is something to see, so a hint
+    // that never made it past its delay never took anything away
+    dismissOthers(app, hide);
+    showing.set(app, hide);
+    setRect(next);
   };
 
   // keeps the tooltip pinned to its trigger for as long as it is shown: a
@@ -289,6 +333,15 @@ export function Tooltip({
   useAnchorTracking(ref, Boolean(rect), tooltipAnchorOptions, setRect, hide);
 
   const onMouseEnter = () => {
+    // The pointer has arrived somewhere else, so whatever is still up
+    // belongs to where it *was* — drop it now rather than at the end of
+    // this one's delay, which would leave two on screen for half a second
+    // saying different things about the same pointer.
+    //
+    // This does not fight the safe polygon. A trigger under an open hint
+    // cannot be hovered — the popup is a window above it — so reaching for
+    // a hint never crosses the trigger this would fire for.
+    dismissOthers(app, hide);
     cancel();
     timer.current = setTimeout(() => {
       timer.current = null;

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -2,9 +2,16 @@
 // support needed. Plain createElement (no JSX) so the library stays
 // build-step-free for consumers.
 
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useApp, useSupports } from '../appcontext.js';
-import { useTheme } from './theme.js';
+import { interpolate } from '../styles.js';
+import { ThemeProvider, useTheme } from './theme.js';
 import {
   DEFAULT_LABEL_SIZE,
   measureLabel,
@@ -53,6 +60,45 @@ const AUTO_SIDES = ['top', 'bottom', 'right', 'left'];
 // `anchorRect`'s own 2px gap, and enough left over that the hint is not
 // jammed flush against the edge of the screen.
 const AUTO_MARGIN = 8;
+
+/**
+ * The palette **inside** the bubble, which is the one outside it upside
+ * down: a tooltip is drawn in the palette's ink so that it reads as a label
+ * over the desktop rather than as another panel of the app, and that makes
+ * its surface `text` and its own ink `background`.
+ *
+ * Content has to be told, or it cannot be written once and stay legible in
+ * both schemes — a card that hard-codes light text is invisible on the light
+ * bubble a dark palette gives it, which is what a naive component label
+ * does. Published through `ThemeProvider`, so both routes agree: a `$token`
+ * in the content and a `useTheme()` in it describe the surface the content
+ * is actually on.
+ *
+ * `dim` is derived rather than swapped, because the palette's own is a mid
+ * grey chosen against the *app's* background. Mixing the bubble's ink
+ * towards its surface lands on the muted version of whichever ink this
+ * turned out to be.
+ */
+const MUTED = 0.38;
+const BORDERISH = 0.6;
+
+// The provider's box fills the bubble and centres what is in it, so a
+// string label still sits in the middle and an element with `flexGrow: 1`
+// still gets the whole rectangle.
+const BUBBLE_CONTENT = Object.freeze({
+  flexGrow: 1,
+  justifyContent: 'center',
+});
+
+function invertedSurface(theme) {
+  return {
+    background: theme.text,
+    text: theme.background,
+    dim: interpolate(theme.background, theme.text, MUTED) ?? theme.dim,
+    border:
+      interpolate(theme.background, theme.text, BORDERISH) ?? theme.border,
+  };
+}
 
 /**
  * The one hint that is up, per connection.
@@ -230,6 +276,9 @@ export function Tooltip({
   // exists — it is part of how big the window is — so this is the display
   // question (`useSupports`) rather than the per-window style block.
   const composited = useSupports('transparency');
+  // memoized for identity, not for the arithmetic: a fresh palette every
+  // render would re-resolve every `$token` under it
+  const surfacePalette = useMemo(() => invertedSurface(theme), [theme]);
 
   // `cancel` and `hide` touch nothing but refs and a state setter, so they
   // can hold still across renders — and `hide` has to: it is this tooltip's
@@ -415,9 +464,16 @@ export function Tooltip({
             '@supports transparency': { borderRadius: theme.radiusTooltip },
           },
         },
-        isText(label)
-          ? h('text', { style: { color: theme.background, fontSize } }, label)
-          : label,
+        // the content is on the inverted surface, and is given the palette
+        // that says so — both routes at once, which is what `ThemeProvider`
+        // is for. The filling box it plants keeps a string label centred.
+        h(
+          ThemeProvider,
+          { value: surfacePalette, style: BUBBLE_CONTENT },
+          isText(label)
+            ? h('text', { style: { color: '$text', fontSize } }, label)
+            : label,
+        ),
       ),
       arrow &&
         h('canvas', {

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -3,13 +3,16 @@
 // build-step-free for consumers.
 
 import React, { useEffect, useRef, useState } from 'react';
+import { useSupports } from '../appcontext.js';
 import { useTheme } from './theme.js';
 import {
   DEFAULT_LABEL_SIZE,
   measureLabel,
   movingToward,
   SAFE_HOVER_DELAY,
+  screenOf,
   screenPoint,
+  screenRect,
   useAnchor,
   useAnchorTracking,
 } from './anchor.js';
@@ -20,25 +23,173 @@ const TOOLTIP_PADDING_X = 8;
 
 const TOOLTIP_PADDING_Y = 4;
 
+// The arrow, across the bubble's edge and out from it. Small on purpose: it
+// is there to say *which* control the hint belongs to, and a big one starts
+// to look like a speech balloon.
+const ARROW_WIDTH = 12;
+const ARROW_DEPTH = 6;
+
+// The arrow's base sits this far *inside* the bubble. The two shapes are
+// painted separately and antialiased separately, so meeting them exactly on
+// the edge leaves a hairline of half-covered pixels between them.
+const ARROW_OVERLAP = 1;
+
+// What a `label` that is not text gets when the caller sizes nothing. A
+// popup is a real X window: it needs its size before anything inside it can
+// be laid out, so there is no measuring our way out of this one.
+const RICH_WIDTH = 220;
+const RICH_HEIGHT = 80;
+
+const isText = (label) =>
+  typeof label === 'string' || typeof label === 'number';
+
+// Which sides `direction="auto"` tries, in order. Above first, because a
+// hint above the thing it describes covers nothing you are about to click;
+// then below, then out to the sides, which is where a control near the top
+// or bottom of a screen has to put it.
+const AUTO_SIDES = ['top', 'bottom', 'right', 'left'];
+
+// Room the popup needs beyond its own size for a side to count as fitting:
+// `anchorRect`'s own 2px gap, and enough left over that the hint is not
+// jammed flush against the edge of the screen.
+const AUTO_MARGIN = 8;
+
 /**
- * <Tooltip label placement delay>…</Tooltip> — a hover hint in a `<popup>`,
+ * The side to hang a hint off when the caller has not named one.
+ *
+ * Measured against the **screen**, not the owner window: a popup is a real
+ * X window, so the room a tooltip has is the room the display has. The
+ * first side it fits on wins, in the order above, and if it fits nowhere
+ * the roomiest side does — there the placement is going to be clamped
+ * whatever we pick, and the most room is the least clamping.
+ *
+ * With no screen geometry to read (the headless mock) this is `'top'`,
+ * which is where a tooltip went before there was anything to ask.
+ */
+function autoDirection(node, size) {
+  const trigger = screenRect(node);
+  const screen = screenOf(node);
+  if (!trigger || !screen) return 'top';
+  const room = {
+    top: trigger.y,
+    bottom: screen.pixel_height - (trigger.y + trigger.height),
+    left: trigger.x,
+    right: screen.pixel_width - (trigger.x + trigger.width),
+  };
+  const needed = (side) =>
+    (side === 'top' || side === 'bottom' ? size.height : size.width) +
+    AUTO_MARGIN;
+  const fits = AUTO_SIDES.find((side) => room[side] >= needed(side));
+  if (fits) return fits;
+  return AUTO_SIDES.reduce((best, side) =>
+    room[side] > room[best] ? side : best,
+  );
+}
+
+/**
+ * Where the arrow goes **inside the popup window**, and which way it points.
+ *
+ * Along the bubble's edge it wants the middle of the trigger, not the middle
+ * of the bubble — the two are the same until a screen edge slides the popup
+ * and leaves the trigger where it was. Clamped so the triangle stays on the
+ * straight part of the edge: pushed into a rounded corner it would grow a
+ * notch where the two curves cross.
+ */
+function arrowPlacement(side, rect, trigger, radius) {
+  const vertical = side === 'top' || side === 'bottom';
+  const span = vertical ? rect.width : rect.height;
+  // the middle of the trigger, in the popup's own coordinates
+  const wanted = !trigger
+    ? span / 2
+    : vertical
+      ? trigger.x - rect.x + trigger.width / 2
+      : trigger.y - rect.y + trigger.height / 2;
+  const margin = radius + ARROW_WIDTH / 2 + 1;
+  const center = Math.round(Math.max(margin, Math.min(span - margin, wanted)));
+  // how far along the popup the bubble's outer edge is, on the axis the
+  // arrow sticks out along
+  const reach = (vertical ? rect.height : rect.width) - ARROW_DEPTH;
+
+  const across = center - ARROW_WIDTH / 2;
+  const out = reach - ARROW_OVERLAP;
+  const thick = ARROW_DEPTH + ARROW_OVERLAP;
+  if (side === 'top') {
+    return { left: across, top: out, width: ARROW_WIDTH, height: thick, side };
+  }
+  if (side === 'bottom') {
+    return { left: across, top: 0, width: ARROW_WIDTH, height: thick, side };
+  }
+  if (side === 'left') {
+    return { left: out, top: across, width: thick, height: ARROW_WIDTH, side };
+  }
+  return { left: 0, top: across, width: thick, height: ARROW_WIDTH, side };
+}
+
+/** The triangle itself, pointing away from the bubble it grows out of. */
+function paintArrow(ctx, { width, height }, side, color) {
+  ctx.fillStyle = color;
+  ctx.beginPath();
+  if (side === 'top') {
+    ctx.moveTo(0, 0);
+    ctx.lineTo(width, 0);
+    ctx.lineTo(width / 2, height);
+  } else if (side === 'bottom') {
+    ctx.moveTo(0, height);
+    ctx.lineTo(width, height);
+    ctx.lineTo(width / 2, 0);
+  } else if (side === 'left') {
+    ctx.moveTo(0, 0);
+    ctx.lineTo(0, height);
+    ctx.lineTo(width, height / 2);
+  } else {
+    ctx.moveTo(width, 0);
+    ctx.lineTo(width, height);
+    ctx.lineTo(0, height / 2);
+  }
+  ctx.closePath();
+  ctx.fill();
+}
+
+/**
+ * <Tooltip label direction delay>…</Tooltip> — a hover hint in a `<popup>`,
  * so it can extend past the owner window's bounds.
  *
  * Wraps its children in a row box that carries the hover handlers and the
  * anchor ref. Shows after `delay` ms of hover, hides immediately on leave
  * (and on mousedown — a tooltip lingering over a menu you just opened is
- * the classic annoyance). `placement` flips automatically near a screen
- * edge, via the same `useAnchor` math `Select` uses.
+ * the classic annoyance).
  *
- * The popup is sized from the measured label, since a `<popup>` is a real
- * X window and needs its size up front rather than after layout.
+ * `direction` is which side of the trigger it goes on, and it defaults to
+ * `'auto'`: the first side the hint fits on, preferring above. Naming one —
+ * `'top'`, `'bottom'`, `'left'`, `'right'` — is a preference rather than a
+ * promise either way, since a named side still flips to its opposite rather
+ * than opening off-screen, via the same `useAnchor` math `Select` uses.
+ * (`placement` is the older name for the same thing and still wins where it
+ * is given, so that nothing that named a side has to change.)
+ *
+ * `label` is usually a string, and then the popup is sized from the
+ * **measured** text: a `<popup>` is a real X window and needs its size up
+ * front rather than after layout. It can equally be an element — a swatch
+ * and a hex code, a shortcut in its own type, a whole card — and then the
+ * caller says how big with `width`/`height`, for the same reason. The
+ * element fills the bubble and draws its own padding; a string gets the
+ * bubble's.
+ *
+ * On a display that composites, the popup is a real ARGB window: a rounded
+ * bubble with a small arrow pointing back at the trigger, and everything the
+ * two do not cover left empty. Without a compositor it degrades to the
+ * square opaque rectangle it has always been — an arrow there would be a
+ * black triangle in a black notch, which is worse than no arrow.
  */
 export function Tooltip({
   label,
   children,
-  placement = 'top',
+  direction = 'auto',
+  placement,
   delay = 500,
   fontSize = DEFAULT_LABEL_SIZE,
+  width,
+  height,
   style,
   ...boxProps
 }) {
@@ -47,6 +198,10 @@ export function Tooltip({
   const measureAnchor = useAnchor(ref);
   const [rect, setRect] = useState(null);
   const timer = useRef(null);
+  // Whether there is an arrow at all has to be settled *before* the popup
+  // exists — it is part of how big the window is — so this is the display
+  // question (`useSupports`) rather than the per-window style block.
+  const composited = useSupports('transparency');
 
   const cancel = () => {
     if (timer.current) {
@@ -81,13 +236,40 @@ export function Tooltip({
   // a pending timer must not outlive the component
   useEffect(() => cancel, []);
 
+  // The bubble, which is the popup minus whatever the arrow takes.
+  const bubbleSize = (node) => {
+    if (!isText(label)) {
+      return { width: width ?? RICH_WIDTH, height: height ?? RICH_HEIGHT };
+    }
+    const text = measureLabel(node, label, { size: fontSize });
+    return {
+      width: width ?? Math.ceil(text.width) + TOOLTIP_PADDING_X * 2,
+      height: height ?? Math.ceil(text.height) + TOOLTIP_PADDING_Y * 2,
+    };
+  };
+
   const tooltipAnchorOptions = () => {
     const node = ref.current;
-    if (!node || !label) return null;
-    const text = measureLabel(node, label, { size: fontSize });
-    const width = Math.ceil(text.width) + TOOLTIP_PADDING_X * 2 + 2;
-    const height = Math.ceil(text.height) + TOOLTIP_PADDING_Y * 2 + 2;
-    return { placement, align: 'center', width, height };
+    // `!label` would have thrown away `0`, which is a hint like any other;
+    // an empty string is not one
+    if (!node || label == null || label === false || label === '') return null;
+    const bubble = bubbleSize(node);
+    const grow = composited ? ARROW_DEPTH : 0;
+    const want = placement ?? direction;
+    const side =
+      want === 'auto'
+        ? autoDirection(node, {
+            width: bubble.width + grow,
+            height: bubble.height + grow,
+          })
+        : want;
+    const vertical = side === 'top' || side === 'bottom';
+    return {
+      placement: side,
+      align: 'center',
+      width: bubble.width + (vertical ? 0 : grow),
+      height: bubble.height + (vertical ? grow : 0),
+    };
   };
 
   const show = () => {
@@ -114,6 +296,90 @@ export function Tooltip({
     }, delay);
   };
 
+  /**
+   * The popup, in two absolutely-positioned pieces: the bubble, and the
+   * arrow beside it. Absolute rather than a flex column, because the two are
+   * placed by the same arithmetic that decided how big the window is, and
+   * that arithmetic has to run before there is a window to lay anything out
+   * in. Whatever neither covers is the transparent margin the arrow needs to
+   * point through.
+   */
+  const surface = () => {
+    // the side `anchorRect` settled on, which is the one it was asked for
+    // unless a screen edge flipped it
+    const side = rect.placement ?? 'top';
+    const vertical = side === 'top' || side === 'bottom';
+    const arrow = composited
+      ? arrowPlacement(side, rect, screenRect(ref.current), theme.radiusTooltip)
+      : null;
+    const inset = arrow ? ARROW_DEPTH : 0;
+    const bubble = {
+      // the arrow is always on the side facing the trigger, so the bubble is
+      // pushed off that edge and fills the rest
+      left: side === 'right' ? inset : 0,
+      top: side === 'bottom' ? inset : 0,
+      width: rect.width - (vertical ? 0 : inset),
+      height: rect.height - (vertical ? inset : 0),
+    };
+
+    return h(
+      'popup',
+      {
+        theme,
+        x: rect.x,
+        y: rect.y,
+        width: rect.width,
+        height: rect.height,
+        windowType: 'tooltip',
+        transparent: true,
+        style: {
+          backgroundColor: theme.text,
+          '@supports transparency': { backgroundColor: 'transparent' },
+        },
+      },
+      h(
+        'box',
+        {
+          onMouseEnter: cancel,
+          onMouseLeave: hide,
+          style: {
+            position: 'absolute',
+            left: bubble.left,
+            top: bubble.top,
+            width: bubble.width,
+            height: bubble.height,
+            justifyContent: 'center',
+            backgroundColor: theme.text,
+            // No border. On a hint this small a 1px outline in a colour
+            // close to the fill is a smudge on the corners and nothing
+            // anywhere else; the arrow is what tells you where it belongs.
+            ...(isText(label)
+              ? {
+                  paddingLeft: TOOLTIP_PADDING_X,
+                  paddingRight: TOOLTIP_PADDING_X,
+                }
+              : null),
+            '@supports transparency': { borderRadius: theme.radiusTooltip },
+          },
+        },
+        isText(label)
+          ? h('text', { style: { color: theme.background, fontSize } }, label)
+          : label,
+      ),
+      arrow &&
+        h('canvas', {
+          style: {
+            position: 'absolute',
+            left: arrow.left,
+            top: arrow.top,
+            width: arrow.width,
+            height: arrow.height,
+          },
+          onDraw: (ctx, info) => paintArrow(ctx, info, arrow.side, theme.text),
+        }),
+    );
+  };
+
   return h(
     'box',
     {
@@ -127,40 +393,7 @@ export function Tooltip({
       style: [{ flexDirection: 'row', alignItems: 'center' }, style],
     },
     children,
-    rect &&
-      h(
-        'popup',
-        {
-          x: rect.x,
-          y: rect.y,
-          width: rect.width,
-          height: rect.height,
-          windowType: 'tooltip',
-          style: { backgroundColor: theme.text },
-        },
-        h(
-          'box',
-          {
-            onMouseEnter: cancel,
-            onMouseLeave: hide,
-            style: {
-              flexGrow: 1,
-              borderWidth: theme.borderWidth,
-              borderColor: theme.text,
-              borderRadius: theme.radiusSmall,
-              backgroundColor: theme.text,
-              justifyContent: 'center',
-              paddingLeft: TOOLTIP_PADDING_X,
-              paddingRight: TOOLTIP_PADDING_X,
-            },
-          },
-          h(
-            'text',
-            { style: { color: theme.background, fontSize: fontSize } },
-            label,
-          ),
-        ),
-      ),
+    rect && surface(),
   );
 }
 

--- a/src/components/anchor.js
+++ b/src/components/anchor.js
@@ -57,12 +57,21 @@ function windowOrigin(node) {
  * menu's border and padding. Anchoring both to the row opens the submenu
  * *over* its parent by exactly that inset. Both nodes must be in the same
  * window, which is what lets one origin serve both.
+ *
+ * `alignOffset` shifts the result along the *alignment* axis, where `offset`
+ * moves it along the placement one — and it is applied before the clamp, so
+ * a popup nudged towards a screen edge is still brought back from it. What
+ * needs it is the difference between lining up a **surface** and lining up
+ * what is drawn **in** it: a submenu whose top edge is level with the row
+ * that opened it has its first item a border and a padding lower down, and
+ * the eye lines up the items, not the boxes.
  */
 export function anchorRect(node, options = {}) {
   if (!node?.abs) return null;
   const {
     placement = 'bottom',
     align = 'start',
+    alignOffset = 0,
     offset = 2,
     width = node.abs.width,
     height = 0,
@@ -86,11 +95,12 @@ export function anchorRect(node, options = {}) {
   const sh = screen?.pixel_height;
 
   const alignAlong = (start, size, extent) =>
-    align === 'center'
+    alignOffset +
+    (align === 'center'
       ? start + (size - extent) / 2
       : align === 'end'
         ? start + size - extent
-        : start;
+        : start);
 
   let side = placement;
   let x;
@@ -227,12 +237,23 @@ export function useAnchorTracking(
   getOptionsRef.current = getOptions;
   const onOutOfViewRef = useRef(onOutOfView);
   onOutOfViewRef.current = onOutOfView;
+  // Read during render, and read again inside the notification, because the
+  // two do not happen in that order. Closing a popup sets its rect to null
+  // and the *commit* destroys its window — and destroying a window is a
+  // layout pass, which notifies from inside the commit, before React gets
+  // to the effect cleanup that would have unsubscribed. A subscription that
+  // only knew the `active` of the render it was made in would answer that
+  // notification by measuring a fresh rect for the popup just closed, and
+  // hand back a second window in place of the one that went away.
+  const activeRef = useRef(active);
+  activeRef.current = active;
 
   useEffect(() => {
     if (!active) return undefined;
     const root = ref.current?.root;
     if (!root?.onAnchorChange) return undefined;
     return root.onAnchorChange(() => {
+      if (!activeRef.current) return;
       const node = ref.current;
       if (node?._offscreen?.()) {
         onOutOfViewRef.current?.();

--- a/src/components/anchor.js
+++ b/src/components/anchor.js
@@ -268,6 +268,35 @@ export function useAnchorTracking(
   }, [active, ref, measure, setRect]);
 }
 
+/**
+ * useDismissOnWindowBlur(ref, active, onDismiss) — shut a popup when the
+ * **window** it belongs to loses focus.
+ *
+ * A node's `onBlur` does not fire for this, deliberately: a window losing
+ * focus leaves the node inside it focused and merely stops it looking
+ * active, so the trigger a menu closes on never hears anything. What is left
+ * is a menu still open over an application the user has switched away from
+ * — and, for the ones that grab, still holding the pointer grab that came
+ * with it, so the first click anywhere goes to dismissing it.
+ *
+ * The window manager's own focus, then, rather than anything in the tree:
+ * `WindowNode.onWindowFocusChange` (nodes.js), which the event manager
+ * notifies from the same place it suspends the caret.
+ */
+export function useDismissOnWindowBlur(ref, active, onDismiss) {
+  const onDismissRef = useRef(onDismiss);
+  onDismissRef.current = onDismiss;
+
+  useEffect(() => {
+    if (!active) return undefined;
+    const root = ref.current?.root;
+    if (!root?.onWindowFocusChange) return undefined;
+    return root.onWindowFocusChange((focused) => {
+      if (!focused) onDismissRef.current?.();
+    });
+  }, [active, ref]);
+}
+
 /** Measured size of a single-line label, for sizing a popup around it.
  *  Falls back to a rough estimate where no font stack is available. */
 export function measureLabel(node, text, style) {

--- a/src/components/anchor.js
+++ b/src/components/anchor.js
@@ -12,6 +12,36 @@ export function screenOf(node) {
 }
 
 /**
+ * A node's laid-out rect in **screen** coordinates: the owner window's
+ * position plus the node's own box.
+ *
+ * `_screenOrigin` is what the server says the window is at; `x`/`y` are
+ * frame-relative under a reparenting window manager and are only a fallback
+ * (the headless mock has no server to ask).
+ *
+ * Exported because a popup sometimes has to know where its *trigger* is and
+ * not only where to put itself — a tooltip's arrow points at the middle of
+ * the thing it annotates, which stops being the middle of the tooltip as
+ * soon as a screen edge slides one of them.
+ */
+export function screenRect(node) {
+  if (!node?.abs) return null;
+  const origin = windowOrigin(node);
+  return {
+    x: origin.x + node.abs.x,
+    y: origin.y + node.abs.y,
+    width: node.abs.width,
+    height: node.abs.height,
+  };
+}
+
+/** Where the node's owner window is on the screen. */
+function windowOrigin(node) {
+  const win = node?.root?.window;
+  return win?._screenOrigin ?? { x: win?.x ?? 0, y: win?.y ?? 0 };
+}
+
+/**
  * Where to put a `<popup>` anchored to a drawn node, in **screen**
  * coordinates: the owner window's position plus the node's laid-out rect.
  *
@@ -39,17 +69,14 @@ export function anchorRect(node, options = {}) {
     alignTo,
   } = options;
 
-  // `_screenOrigin` is what the server says; `x`/`y` are frame-relative
-  // under a reparenting WM and are only a fallback (the headless mock has
-  // no server to ask)
-  const win = node.root?.window;
-  const origin = win?._screenOrigin ?? { x: win?.x ?? 0, y: win?.y ?? 0 };
+  const origin = windowOrigin(node);
   const ax = origin.x + node.abs.x;
   const ay = origin.y + node.abs.y;
   const aw = node.abs.width;
   const ah = node.abs.height;
   // the rect the *alignment* reads, which is `node`'s own unless the caller
-  // split the two axes
+  // split the two axes — one origin serves both, since both nodes are in the
+  // same window
   const cross = alignTo?.abs ?? node.abs;
   const cx = origin.x + cross.x;
   const cy = origin.y + cross.y;

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -6,6 +6,7 @@ export { ThemeProvider, useTheme } from './theme.js';
 export {
   anchorRect,
   centerRect,
+  screenRect,
   useAnchor,
   useAnchorTracking,
 } from './anchor.js';

--- a/src/compositing.js
+++ b/src/compositing.js
@@ -166,6 +166,39 @@ export function compositingActive(app) {
   return sessions.get(app)?.supported === true;
 }
 
+/**
+ * Is transparency switched off for this process?
+ *
+ * `REACT_X11_NO_TRANSPARENCY=1` makes every display answer the way one with
+ * no 32-bit visual does: `transparent` is ignored, windows are created on
+ * the ordinary visual, and `'@supports transparency'` never matches. It is
+ * for looking at the fallback design on the machine you actually work on —
+ * the built-in menus and tooltips have two looks now, and the opaque one is
+ * otherwise reachable only by stopping the compositor for the whole session,
+ * which takes every other window on the desktop with it.
+ *
+ * `=== '1'` rather than a truthy test, like `REACT_X11_NO_PAINT_CACHE`: a
+ * stale `NO_TRANSPARENCY=0` left in a shell profile must not silently mean
+ * the opposite of what it says. Read per call rather than once at load, so
+ * a test can turn it on around one mount — and because the question it
+ * feeds is already one whose answer may change while an app runs.
+ */
+export function transparencyDisabled() {
+  return process.env.REACT_X11_NO_TRANSPARENCY === '1';
+}
+
+/**
+ * The 32-bit visual a transparent window would be created on, or null when
+ * this display has none — and null whatever it has when transparency is
+ * switched off. The one place that question is asked, so the switch cannot
+ * be half-applied: a window that took the visual but a `useSupports` that
+ * said no would size a tooltip for an arrow it then refused to draw.
+ */
+export function argbVisual(app) {
+  if (transparencyDisabled()) return null;
+  return app?.findArgbVisual?.() ?? null;
+}
+
 /** Subscribe to the answer changing. Returns an unsubscribe function. */
 export function watchCompositing(app, fn) {
   const session = sessions.get(app);

--- a/src/events.js
+++ b/src/events.js
@@ -232,6 +232,10 @@ export class EventManager {
       if (focused) node._defaultFocus?.();
       else node._defaultBlur?.();
     }
+    // …and the things that keep a window of their own open on the strength
+    // of this one having focus — a menu, a dropdown — which the focused node
+    // keeping its focus would otherwise never tell (`WindowNode`, nodes.js)
+    this.node._notifyWindowFocus?.(focused);
     runWithPriority(DiscreteEventPriority, () => {
       const prop = focused ? 'onFocus' : 'onBlur';
       this.node.props[prop]?.(

--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,7 @@ export {
   useAnchorTracking,
   anchorRect,
   centerRect,
+  screenRect,
   Canvas3D,
 } from './components/index.js';
 

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -40,7 +40,12 @@ import {
   XDND_VERSION,
 } from './dnd.js';
 import { addPendingFrame, clearPendingFrame } from './frames.js';
-import { compositingActive, watchCompositing } from './compositing.js';
+import {
+  argbVisual,
+  compositingActive,
+  transparencyDisabled,
+  watchCompositing,
+} from './compositing.js';
 import { baseTheme } from './palette.js';
 import { callHandler } from './errors.js';
 import { windowIdOf } from './windowid.js';
@@ -4345,19 +4350,29 @@ export class WindowNode extends Node {
   }
 
   _argbAttributes() {
-    const argb = this.app?.findArgbVisual?.();
+    const argb = argbVisual(this.app);
     if (!argb) {
-      // Once per connection. The answer is a property of the display and
-      // cannot change while it is open, and since the widgets ask for a
-      // transparent popup every time a menu or a tooltip opens, warning per
-      // window would turn one piece of news into a running commentary.
+      // Once per connection. The answer is a property of the display (or of
+      // an environment switch) and cannot change while it is open, and since
+      // the widgets ask for a transparent popup every time a menu or a
+      // tooltip opens, warning per window would turn one piece of news into
+      // a running commentary.
       if (DEV && this.app && !warnedNoArgb.has(this.app)) {
         warnedNoArgb.add(this.app);
-        console.warn(
-          'react-x11: <%s transparent> — no 32-bit TrueColor visual on this ' +
-            'display, falling back to an opaque window',
-          this.isPopup ? 'popup' : 'window',
-        );
+        const what = this.isPopup ? 'popup' : 'window';
+        if (transparencyDisabled()) {
+          console.warn(
+            'react-x11: REACT_X11_NO_TRANSPARENCY=1 — <%s transparent> ' +
+              'ignored, this run is opaque',
+            what,
+          );
+        } else {
+          console.warn(
+            'react-x11: <%s transparent> — no 32-bit TrueColor visual on ' +
+              'this display, falling back to an opaque window',
+            what,
+          );
+        }
       }
       return null;
     }

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -4492,6 +4492,27 @@ export class WindowNode extends Node {
     for (const cb of this._anchorListeners) cb();
   }
 
+  /**
+   * Subscribe to this window gaining or losing the **window manager's**
+   * focus. Returns an unsubscribe function.
+   *
+   * Deliberately not the same thing as a node's `onBlur`: a window losing
+   * focus does not blur the node inside it — the node keeps focus and stops
+   * looking active, which is what the DOM does with `document.activeElement`
+   * and what a caret coming back where you left it depends on. So nothing in
+   * the tree hears about it, and the things that must — a menu holding a
+   * pointer grab, most of all — have nowhere else to ask.
+   */
+  onWindowFocusChange(cb) {
+    (this._windowFocusListeners ??= new Set()).add(cb);
+    return () => this._windowFocusListeners?.delete(cb);
+  }
+
+  _notifyWindowFocus(focused) {
+    if (!this._windowFocusListeners?.size) return;
+    for (const cb of [...this._windowFocusListeners]) cb(focused);
+  }
+
   /** Walk the drawn subtree and give every <glarea> its child X window. */
   _realizeGlAreas(node) {
     for (const child of node.children) {

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -461,6 +461,9 @@ function isPaintedColor(color) {
 
 const DEV = process.env.NODE_ENV !== 'production';
 
+// Connections already told they have no 32-bit visual (`_argbAttributes`).
+const warnedNoArgb = new WeakSet();
+
 // Frame timestamps for transitions. Indirected so tests can drive the clock
 // instead of sleeping through real animations.
 let now = () => Date.now();
@@ -4344,7 +4347,12 @@ export class WindowNode extends Node {
   _argbAttributes() {
     const argb = this.app?.findArgbVisual?.();
     if (!argb) {
-      if (DEV) {
+      // Once per connection. The answer is a property of the display and
+      // cannot change while it is open, and since the widgets ask for a
+      // transparent popup every time a menu or a tooltip opens, warning per
+      // window would turn one piece of news into a running commentary.
+      if (DEV && this.app && !warnedNoArgb.has(this.app)) {
+        warnedNoArgb.add(this.app);
         console.warn(
           'react-x11: <%s transparent> — no 32-bit TrueColor visual on this ' +
             'display, falling back to an opaque window',

--- a/src/palette.js
+++ b/src/palette.js
@@ -62,6 +62,20 @@ export const DefaultTheme = {
   // shape
   radius: 4,
   radiusSmall: 3,
+  // Floating surfaces round on their own scale, and it is a wider one: a
+  // menu is a sheet of paper laid over the window, where a button is a
+  // control cut into it. Half the text size is the number every desktop
+  // lands near — 7px at a 14px body — and tying it to the type rather than
+  // to `radius` is what keeps a theme that only sets `fontSize` from
+  // getting a 20px menu with a 4px corner.
+  //
+  // The two inside it step down from there, because a rounded thing inside
+  // a rounded thing wants a *smaller* curve or the two read as concentric
+  // rings: the highlight on a menu row, and the tooltip bubble, which is
+  // the smallest floating surface there is and the one closest to text.
+  radiusPopup: 7,
+  radiusPopupItem: 5,
+  radiusTooltip: 4,
   borderWidth: 1,
   fontSize: 14,
   paddingX: 16,
@@ -76,9 +90,19 @@ const PRESSED_FROM = {
   dimActive: ['border', 'dim'],
 };
 
+// And the same for the floating-surface radii, which are a function of the
+// text they wrap: a palette that sets `fontSize` and nothing else still gets
+// menus in proportion to it.
+const RADIUS_FROM_FONT = {
+  radiusPopup: (size) => Math.round(size / 2),
+  radiusPopupItem: (size) => Math.max(0, Math.round(size / 2) - 2),
+  radiusTooltip: (size) => Math.max(0, Math.round(size / 2) - 3),
+};
+
 /**
  * Merge a partial palette, filling in the pressed step for any family whose
- * colours moved without it.
+ * colours moved without it — and the popup radii for a palette that moved
+ * the text size without them.
  *
  * The rule per token: an explicit value wins; otherwise, if this palette
  * touched either colour the step is measured between, it is re-derived; and
@@ -97,6 +121,11 @@ export function resolveTheme(value, base = DefaultTheme) {
     if (value[token] != null) continue;
     if (value[rest] == null && value[hover] == null) continue;
     merged[token] = stepBeyond(merged[rest], merged[hover]);
+  }
+  if (value.fontSize != null) {
+    for (const [token, from] of Object.entries(RADIUS_FROM_FONT)) {
+      if (value[token] == null) merged[token] = from(merged.fontSize);
+    }
   }
   return merged;
 }

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -458,6 +458,13 @@ export interface AnchorOptions {
   placement?: Placement;
   /** Gap between the anchor and the popup, in px. */
   gap?: number;
+  /**
+   * Shift along the *alignment* axis, applied before the popup is clamped
+   * into the screen. For lining up what is drawn in a surface rather than
+   * the surface itself: a submenu level with the row that opened it has its
+   * first item a border and a padding lower, and the eye lines up the items.
+   */
+  alignOffset?: number;
   width?: number;
   height?: number;
   /** Flip to the opposite side when there is no room (default true). */

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -52,6 +52,15 @@ export interface Theme {
   focusRingOffset: number;
   radius: number;
   radiusSmall: number;
+  /** A floating surface — a menu, a dropdown — which rounds on a wider
+   * scale than a control does: half the text size, and derived from
+   * `fontSize` for any palette that moves it without naming this. */
+  radiusPopup: number;
+  /** A row inside one, a step tighter so the highlight reads as a pill on
+   * the sheet rather than as a second edge just inside its own. */
+  radiusPopupItem: number;
+  /** A tooltip bubble — the smallest floating surface there is. */
+  radiusTooltip: number;
   borderWidth: number;
   fontSize: number;
   paddingX: number;
@@ -209,12 +218,30 @@ export const Slider: ComponentType<SliderProps>;
 export type Placement = 'top' | 'bottom' | 'left' | 'right';
 
 export interface TooltipProps extends WidgetProps {
-  label: string;
+  /**
+   * The hint. A string is measured and the popup sized around it; an
+   * element is given the bubble to fill and sized by {@link TooltipProps.width}
+   * / {@link TooltipProps.height}, since a `<popup>` is a real X window and
+   * needs its size before anything in it can be laid out.
+   */
+  label: ReactNode;
   children?: ReactNode;
+  /**
+   * Which side of the trigger to open on. `'auto'` (the default) takes the
+   * first side the hint fits on, preferring above; a named side is still a
+   * preference rather than a promise, since it flips to its opposite rather
+   * than opening off-screen.
+   */
+  direction?: Placement | 'auto';
+  /** The older name for {@link TooltipProps.direction}; wins where given. */
   placement?: Placement;
   /** ms before it appears (default 500). */
   delay?: number;
   fontSize?: number;
+  /** The bubble's size. Required for an element `label` (defaults to
+   * 220×80); for text it overrides the measured size. */
+  width?: number;
+  height?: number;
   style?: StyleProp;
 }
 export const Tooltip: ComponentType<TooltipProps>;
@@ -448,6 +475,15 @@ export function centerRect(
   node: DrawnNode,
   size: { width: number; height: number },
 ): Rect;
+
+/**
+ * A node's laid-out rect in screen coordinates — where a popup's *trigger*
+ * is, rather than where to put the popup. What a surface has to know when
+ * it points back at the thing it belongs to: a tooltip's arrow aims at the
+ * middle of the trigger, and that stops being the middle of the tooltip as
+ * soon as a screen edge slides one of the two.
+ */
+export function screenRect(node: DrawnNode): Rect | null;
 
 /** `anchorRect` bound to a ref, recomputed on demand. */
 export function useAnchor(

--- a/test/anchor-tracking.test.js
+++ b/test/anchor-tracking.test.js
@@ -20,7 +20,7 @@ import { createClient, StaticFontSource } from 'ntk';
 
 import { createRoot } from '../src/index.js';
 import { useAnchor, useAnchorTracking } from '../src/components/anchor.js';
-import { createMockApp } from './helpers/mock-app.js';
+import { createMockApp, moveMouse } from './helpers/mock-app.js';
 
 const h = React.createElement;
 const tick = () => new Promise((resolve) => setImmediate(resolve));
@@ -315,4 +315,67 @@ test('a tracked popup follows the owner window when it moves', async () => {
   } finally {
     await app.close();
   }
+});
+
+test('a popup that closes stays closed, even though closing is a layout pass', async () => {
+  // The shape every real caller has, `Tooltip` most literally: one piece of
+  // state is both the rect and whether there is a popup at all, and it is
+  // driven from pointer motion. So closing nulls the rect and destroys the
+  // window in one commit, the window's next frame lays out without it —
+  // and that layout pass notifies every anchor subscriber before React has
+  // flushed the effect cleanup that would have removed this one.
+  //
+  // A subscription that trusted the `active` of the render it was made in
+  // answers by measuring a fresh rect for the popup just closed, and the
+  // reconciler hands back a second window in place of the one that went
+  // away: a popup nothing can dismiss, because dismissing it is what brings
+  // it back. (Continuous priority is load-bearing here — React flushes a
+  // click synchronously, and the cleanup then wins the race by luck.)
+  const app = createMockApp();
+  const triggerRef = React.createRef();
+  const SIZE = { placement: 'bottom', width: 60, height: 30 };
+
+  function OnHover() {
+    const [rect, setRect] = React.useState(null);
+    const measure = useAnchor(triggerRef);
+    const hide = () => setRect(null);
+    useAnchorTracking(triggerRef, Boolean(rect), () => SIZE, setRect, hide);
+    return h(
+      'window',
+      { width: 200, height: 120 },
+      // the popup inside the box the trigger is in, as `Tooltip`'s is, so
+      // that dropping it is a change to that box's children
+      h(
+        'box',
+        {
+          ref: triggerRef,
+          onMouseEnter: () => setRect(measure(SIZE)),
+          onMouseLeave: hide,
+          style: { marginTop: 30, marginLeft: 20, width: 80, height: 20 },
+        },
+        rect && h('popup', { x: rect.x, y: rect.y, ...SIZE }),
+      ),
+    );
+  }
+
+  const x11Root = await renderMock(app, h(OnHover));
+  const wnd = app.windows[0];
+  const { x, y } = triggerRef.current.abs;
+
+  moveMouse(wnd, x + 2, y + 2);
+  await tick();
+  await tick();
+  assert.equal(app.windows.length, 2, 'the popup is up');
+
+  moveMouse(wnd, x + 2, y + 100); // off the trigger entirely
+  for (let i = 0; i < 5; i++) await tick();
+
+  assert.equal(app.windows[1].destroyed, true, 'the popup went away');
+  assert.equal(
+    app.windows.filter((w) => !w.destroyed).length,
+    1,
+    'and nothing took its place',
+  );
+
+  await x11Root.unmount();
 });

--- a/test/popup-chrome.test.js
+++ b/test/popup-chrome.test.js
@@ -285,6 +285,30 @@ test('direction="auto" changes axis when neither top nor bottom fits', async () 
   await x11Root.unmount();
 });
 
+test('REACT_X11_NO_TRANSPARENCY=1 gives the opaque design on a display that composites', async () => {
+  // the switch has to reach both halves at once: the window's style blocks,
+  // and the arrow, which is decided a step earlier because it is part of how
+  // big the window is
+  process.env.REACT_X11_NO_TRANSPARENCY = '1';
+  try {
+    const tip = await showTip({}, { screen: ROOMY });
+    assert.ok(!('depth' in tip.tip.attributes), 'no ARGB visual taken');
+    assert.equal(tip.tip._reactX11Node.children.length, 1, 'no arrow');
+    assert.equal(
+      tip.tip._reactX11Node.children[0].style.borderRadius,
+      undefined,
+    );
+    await tip.x11Root.unmount();
+
+    const { x11Root, menu, list } = await openMenu();
+    assert.equal(list.style.borderRadius, undefined, 'and a square menu');
+    assert.equal(menu._reactX11Node.style.backgroundColor, 'white');
+    await x11Root.unmount();
+  } finally {
+    delete process.env.REACT_X11_NO_TRANSPARENCY;
+  }
+});
+
 test('a named direction grows the popup along its own axis', async () => {
   const right = await showTip({ direction: 'right' }, { screen: ROOMY });
   const down = await showTip({ direction: 'bottom' }, { screen: ROOMY });

--- a/test/popup-chrome.test.js
+++ b/test/popup-chrome.test.js
@@ -55,7 +55,15 @@ test('the popup radii come from the text size, and an explicit one pins it', () 
 const MENUS = [
   {
     label: 'File',
-    items: [{ label: 'New' }, { separator: true }, { label: 'Quit' }],
+    items: [
+      { label: 'New' },
+      { separator: true },
+      {
+        label: 'Export',
+        items: [{ label: 'PNG' }, { label: 'SVG' }],
+      },
+      { label: 'Quit' },
+    ],
   },
 ];
 
@@ -78,6 +86,20 @@ async function openMenu({ composited = true } = {}) {
   await tick();
   const menu = app.windows[1];
   return { app, x11Root, wnd, menu, list: menu?._reactX11Node.children[0] };
+}
+
+/**
+ * Hover a row of an open menu popup (a mock window), by list index.
+ *
+ * Generous with ticks: a mousemove is scheduled at continuous priority
+ * rather than flushed, and opening a submenu is then a render, an effect
+ * that measures, and a second render to place what it measured.
+ */
+async function hoverRow(popup, index) {
+  const row = popup._reactX11Node.children[0].children[index];
+  moveMouse(popup, row.abs.x + 4, row.abs.y + 4);
+  for (let i = 0; i < 6; i++) await tick();
+  return row;
 }
 
 test('a menu is an ARGB window and the sheet inside it is rounded', async () => {
@@ -135,6 +157,58 @@ test('a menu row is a rounded pill, inset, and paints nothing at rest', async ()
     theme.hoverBackground,
     'the selection colour, shared with Select and Table',
   );
+
+  await x11Root.unmount();
+});
+
+test('a submenu lines its first item up with the row that opened it', async () => {
+  const { app, x11Root, menu } = await openMenu();
+  const parent = await hoverRow(menu, 2); // 'Export', which has a submenu
+
+  const sub = app.windows[2];
+  assert.ok(sub, 'the submenu opened');
+  const first = sub._reactX11Node.children[0].children[0];
+
+  // both in screen coordinates: the popup's own y plus the row's y in it
+  const parentTop = menu.y + parent.abs.y;
+  const firstTop = sub.y + first.abs.y;
+  assert.equal(
+    firstTop,
+    parentTop,
+    'the items line up, not the popup edges — the submenu sits a border and ' +
+      'a padding higher to pay for its own chrome',
+  );
+  assert.ok(sub.y < menu.y + parent.abs.y, 'which means the popup is higher');
+
+  await x11Root.unmount();
+});
+
+test('only the live end of the trail is selection-coloured', async () => {
+  const { app, x11Root, menu, list } = await openMenu();
+  const theme = list.theme;
+  await hoverRow(menu, 2); // 'Export' — its submenu opens with nothing chosen
+  const sub = app.windows[2];
+
+  // the pointer is still on the parent row, and so are the keys: it stays lit
+  assert.equal(
+    list.children[2].style.backgroundColor,
+    theme.hoverBackground,
+    'a submenu with nothing selected has not taken over',
+  );
+
+  await hoverRow(sub, 0); // into the submenu
+  assert.equal(
+    sub._reactX11Node.children[0].children[0].style.backgroundColor,
+    theme.hoverBackground,
+    'the row now driving the menus',
+  );
+  assert.equal(
+    list.children[2].style.backgroundColor,
+    theme.surfaceActive,
+    'and the row it came out of goes quiet rather than claiming it too',
+  );
+  // quiet, not unselected: it still has to read as the way back
+  assert.notEqual(list.children[2].style.backgroundColor, 'transparent');
 
   await x11Root.unmount();
 });
@@ -281,6 +355,51 @@ test('direction="auto" changes axis when neither top nor bottom fits', async () 
     0,
     'arrow on the left, pointing back at the trigger',
   );
+
+  await x11Root.unmount();
+});
+
+test('a second hint dismisses the first — there is only one pointer', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const trigger = (key) =>
+    h(
+      Tooltip,
+      { key, label: `hint ${key}`, delay: 10 },
+      h('box', { style: { width: 70, height: 24 } }),
+    );
+  x11Root.render(
+    h(
+      'window',
+      { width: 300, height: 200 },
+      h('box', { style: { flexGrow: 1, padding: 20, gap: 30 } }, [
+        trigger('a'),
+        trigger('b'),
+      ]),
+    ),
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const [first, second] = wnd._reactX11Node.children[0].children;
+
+  moveMouse(wnd, first.abs.x + 5, first.abs.y + 5);
+  await after(40);
+  await tick();
+  assert.equal(app.windows.length, 2, 'the first hint is up');
+  const one = app.windows[1];
+
+  // straight onto the other trigger: the pointer is somewhere else now, so
+  // the hint that belongs to where it was goes at once — not at the end of
+  // the second one's delay, which would show two at a time
+  moveMouse(wnd, second.abs.x + 5, second.abs.y + 5);
+  await tick();
+  await tick();
+  assert.equal(one.destroyed, true, 'the first is gone before the second');
+
+  await after(40);
+  await tick();
+  const up = app.windows.filter((w) => !w.destroyed && w !== wnd);
+  assert.equal(up.length, 1, 'and exactly one hint is showing');
 
   await x11Root.unmount();
 });

--- a/test/popup-chrome.test.js
+++ b/test/popup-chrome.test.js
@@ -1,0 +1,305 @@
+// The chrome of the floating surfaces: what a menu and a tooltip look like
+// on a display that composites, and what they fall back to on one that does
+// not. The shape is theme tokens (`radiusPopup` and the two that step in
+// from it), the rounding is gated on `@supports transparency` per window,
+// and the tooltip's arrow is gated on the *display* — it is part of how big
+// the window has to be, so it cannot wait for a style to resolve.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+
+import { createRoot, MenuBar, Tooltip } from '../src/index.js';
+import { resolveTheme } from '../src/components/theme.js';
+import { setCompositingForTests } from '../src/compositing.js';
+import { createMockApp, moveMouse, pressButton } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+const after = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+// the default palette's own numbers, for a 14px body
+const RADIUS_POPUP = 7;
+const RADIUS_ITEM = 5;
+const RADIUS_TOOLTIP = 4;
+const ARROW_DEPTH = 6;
+
+/** Ops of the kind `name` recorded on a mock window's context. */
+const opsOf = (wnd, name) => wnd.ctx.ops.filter(([op]) => op === name);
+
+// --- the tokens -------------------------------------------------------------
+
+test('the popup radii come from the text size, and an explicit one pins it', () => {
+  const base = resolveTheme({ accent: '#333' });
+  assert.equal(base.radiusPopup, RADIUS_POPUP, 'untouched by a colour change');
+  assert.equal(base.radiusPopupItem, RADIUS_ITEM);
+  assert.equal(base.radiusTooltip, RADIUS_TOOLTIP);
+
+  // a palette that moves the type and names no radius gets all three in
+  // proportion — half the font, and two steps in from there
+  const big = resolveTheme({ fontSize: 20 });
+  assert.deepEqual(
+    [big.radiusPopup, big.radiusPopupItem, big.radiusTooltip],
+    [10, 8, 7],
+  );
+
+  const pinned = resolveTheme({ fontSize: 20, radiusPopup: 0 });
+  assert.equal(pinned.radiusPopup, 0, 'named explicitly, so not derived');
+  assert.equal(pinned.radiusPopupItem, 8, 'the others still are');
+
+  const tight = resolveTheme({ fontSize: 4 });
+  assert.equal(tight.radiusTooltip, 0, 'never negative');
+});
+
+// --- menus ------------------------------------------------------------------
+
+const MENUS = [
+  {
+    label: 'File',
+    items: [{ label: 'New' }, { separator: true }, { label: 'Quit' }],
+  },
+];
+
+async function openMenu({ composited = true } = {}) {
+  const app = createMockApp();
+  setCompositingForTests(app, composited);
+  const x11Root = await createRoot({ app });
+  x11Root.render(
+    h(
+      'window',
+      { width: 300, height: 200 },
+      h(MenuBar, { menus: MENUS, fontSize: 13 }),
+    ),
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const item = wnd._reactX11Node.children[0].children[0];
+  pressButton(wnd, item.abs.x + 4, item.abs.y + 4);
+  await tick();
+  await tick();
+  const menu = app.windows[1];
+  return { app, x11Root, wnd, menu, list: menu?._reactX11Node.children[0] };
+}
+
+test('a menu is an ARGB window and the sheet inside it is rounded', async () => {
+  const { x11Root, menu, list } = await openMenu();
+
+  assert.equal(menu.attributes.depth, 32, 'asks for the 32-bit visual');
+  assert.equal(menu.attributes.windowType, 'popup_menu');
+  // the window paints nothing of its own: a square fill under a rounded
+  // sheet would put the corners straight back
+  assert.equal(menu._reactX11Node.style.backgroundColor, 'transparent');
+
+  assert.equal(list.style.borderRadius, RADIUS_POPUP);
+  assert.equal(list.style.borderWidth, 1, 'a hairline edge, not the theme’s');
+  assert.ok(
+    opsOf(menu, 'roundRect').some(([, , , , , r]) => r === RADIUS_POPUP),
+    'and it really paints a rounded rect',
+  );
+
+  await x11Root.unmount();
+});
+
+test('with nothing compositing, the same menu is square and opaque', async () => {
+  const { x11Root, menu, list } = await openMenu({ composited: false });
+
+  // the visual is still taken — a compositor can start later, and a window
+  // cannot change visual once created — but nothing rounds
+  assert.equal(menu.attributes.depth, 32);
+  assert.equal(list.style.borderRadius, undefined);
+  assert.equal(menu._reactX11Node.style.backgroundColor, 'white');
+  assert.equal(opsOf(menu, 'clearRect').length, 0, 'never erases to black');
+
+  await x11Root.unmount();
+});
+
+test('a menu row is a rounded pill, inset, and paints nothing at rest', async () => {
+  const { x11Root, menu, list } = await openMenu();
+  const theme = list.theme;
+  const [first] = list.children;
+
+  assert.equal(first.style.borderRadius, RADIUS_ITEM, 'tighter than the sheet');
+  assert.equal(first.style.backgroundColor, 'transparent', 'nothing at rest');
+  // inset from the popup by the list's padding on both sides, which is what
+  // makes it read as a pill on the sheet rather than a band across it
+  const inset = first.abs.x;
+  assert.ok(inset >= 5, `row inset by ${inset}px`);
+  assert.equal(first.abs.width, menu.width - inset * 2);
+  assert.ok(first.abs.width > menu.width - 16, 'but still nearly menu-wide');
+
+  // hovering it lights it up in the palette's selection colour
+  moveMouse(menu, first.abs.x + 4, first.abs.y + 4);
+  await tick();
+  await tick();
+  assert.equal(
+    list.children[0].style.backgroundColor,
+    theme.hoverBackground,
+    'the selection colour, shared with Select and Table',
+  );
+
+  await x11Root.unmount();
+});
+
+// --- tooltips ---------------------------------------------------------------
+
+async function showTip(
+  props = {},
+  { composited = true, screen, pad = 60 } = {},
+) {
+  const app = createMockApp();
+  setCompositingForTests(app, composited);
+  // the mock models no screen geometry, and `anchorRect` reads that as "no
+  // edge to flip at" — a test about which side a hint takes has to say
+  if (screen) Object.assign(app.X.display.screen[0], screen);
+  const x11Root = await createRoot({ app });
+  x11Root.render(
+    h(
+      'window',
+      { width: 300, height: 200 },
+      h(
+        'box',
+        { style: { flexGrow: 1, padding: pad } },
+        h(
+          Tooltip,
+          { label: 'Save the file', delay: 10, ...props },
+          h('box', { style: { width: 70, height: 24 } }),
+        ),
+      ),
+    ),
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const wrapper = wnd._reactX11Node.children[0].children[0];
+  moveMouse(wnd, wrapper.abs.x + 5, wrapper.abs.y + 5);
+  await after(40);
+  await tick();
+  return { app, x11Root, wnd, wrapper, tip: app.windows[1] };
+}
+
+const ROOMY = { pixel_width: 900, pixel_height: 700 };
+
+test('a tooltip is a rounded bubble with an arrow, and no border', async () => {
+  const { x11Root, tip } = await showTip({}, { screen: ROOMY });
+
+  assert.equal(tip.attributes.windowType, 'tooltip');
+  assert.equal(tip.attributes.depth, 32);
+  const [bubble, arrow] = tip._reactX11Node.children;
+  assert.equal(bubble.style.borderRadius, RADIUS_TOOLTIP);
+  assert.ok(!bubble.style.borderWidth, 'no border on a hint this small');
+
+  // the popup is the bubble plus the strip the arrow points through, and
+  // the bubble sits above it — `direction` resolved to 'top'
+  assert.equal(bubble.abs.height, tip.height - ARROW_DEPTH);
+  assert.equal(bubble.abs.width, tip.width);
+  assert.equal(bubble.abs.y, 0);
+  assert.ok(arrow, 'and there is an arrow');
+  assert.equal(arrow.abs.y + arrow.abs.height, tip.height);
+  // centred on the trigger, which with room on both sides is the middle of
+  // the bubble too — to within the half-pixel each rounds away
+  const off = arrow.abs.x + arrow.abs.width / 2 - tip.width / 2;
+  assert.ok(Math.abs(off) <= 1, `arrow off centre by ${off}px`);
+
+  // a filled triangle, not a rect
+  const ops = tip.ctx.ops.map(([op]) => op);
+  assert.ok(ops.includes('moveTo') && ops.includes('lineTo'));
+  assert.ok(ops.includes('closePath'));
+
+  await x11Root.unmount();
+});
+
+test('with nothing compositing, a tooltip is square and has no arrow', async () => {
+  const composited = await showTip();
+  const plain = await showTip({}, { composited: false });
+
+  assert.equal(plain.tip._reactX11Node.children.length, 1, 'bubble only');
+  assert.equal(
+    plain.tip._reactX11Node.children[0].style.borderRadius,
+    undefined,
+  );
+  assert.equal(
+    plain.tip.height,
+    composited.tip.height - ARROW_DEPTH,
+    'and the window is exactly the arrow shorter',
+  );
+  assert.equal(plain.tip.width, composited.tip.width);
+  assert.ok(
+    !plain.tip.ctx.ops.some(([op]) => op === 'moveTo'),
+    'nothing draws a triangle',
+  );
+
+  await composited.x11Root.unmount();
+  await plain.x11Root.unmount();
+});
+
+test('an element label fills a bubble the caller sized', async () => {
+  const { x11Root, tip } = await showTip({
+    label: h('box', { style: { flexGrow: 1 } }, h('text', null, 'rich')),
+    width: 180,
+    height: 90,
+  });
+
+  assert.equal(tip.width, 180);
+  assert.equal(tip.height, 90 + ARROW_DEPTH);
+  const [bubble] = tip._reactX11Node.children;
+  // no padding imposed on an element: it gets the whole rectangle and draws
+  // its own, which is the point of passing one
+  assert.equal(bubble.style.paddingLeft, undefined);
+  assert.equal(bubble.children[0].abs.width, 180);
+
+  await x11Root.unmount();
+});
+
+test('direction="auto" goes above where it fits, and below where it does not', async () => {
+  const roomy = await showTip({}, { screen: ROOMY });
+  const [above, aboveArrow] = roomy.tip._reactX11Node.children;
+  assert.equal(above.abs.y, 0, 'bubble on top…');
+  assert.equal(aboveArrow.abs.y + aboveArrow.abs.height, roomy.tip.height);
+
+  // the same hint on a trigger with nothing above it
+  const low = await showTip({}, { screen: ROOMY, pad: 8 });
+  const [bubble, arrow] = low.tip._reactX11Node.children;
+  assert.equal(bubble.abs.y, ARROW_DEPTH, 'bubble pushed down…');
+  assert.equal(arrow.abs.y, 0, '…and the arrow points up at the trigger');
+
+  await roomy.x11Root.unmount();
+  await low.x11Root.unmount();
+});
+
+test('direction="auto" changes axis when neither top nor bottom fits', async () => {
+  // a screen too short for the hint either side of the trigger. Only `auto`
+  // can answer this one: `anchorRect` flips top for bottom, but it never
+  // moves a popup to an axis it was not asked for.
+  const { x11Root, tip } = await showTip(
+    {},
+    { screen: { pixel_width: 900, pixel_height: 96 }, pad: 36 },
+  );
+  const [bubble, arrow] = tip._reactX11Node.children;
+
+  assert.equal(bubble.abs.width, tip.width - ARROW_DEPTH, 'gone sideways');
+  assert.equal(bubble.abs.x, ARROW_DEPTH);
+  assert.equal(
+    arrow.abs.x,
+    0,
+    'arrow on the left, pointing back at the trigger',
+  );
+
+  await x11Root.unmount();
+});
+
+test('a named direction grows the popup along its own axis', async () => {
+  const right = await showTip({ direction: 'right' }, { screen: ROOMY });
+  const down = await showTip({ direction: 'bottom' }, { screen: ROOMY });
+
+  // the arrow is horizontal on a horizontal placement: it takes width there
+  // and height here, and the bubble is the rest either way
+  const [rightBubble, rightArrow] = right.tip._reactX11Node.children;
+  assert.equal(rightBubble.abs.width, right.tip.width - ARROW_DEPTH);
+  assert.equal(rightBubble.abs.height, right.tip.height);
+  assert.equal(rightArrow.abs.x, 0, 'arrow on the edge facing the trigger');
+
+  const [downBubble] = down.tip._reactX11Node.children;
+  assert.equal(downBubble.abs.height, down.tip.height - ARROW_DEPTH);
+  assert.equal(right.tip.width, down.tip.width + ARROW_DEPTH);
+
+  await right.x11Root.unmount();
+  await down.x11Root.unmount();
+});

--- a/test/popup-chrome.test.js
+++ b/test/popup-chrome.test.js
@@ -8,7 +8,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import React from 'react';
 
-import { createRoot, MenuBar, Tooltip } from '../src/index.js';
+import { createRoot, MenuBar, Select, Tooltip } from '../src/index.js';
 import { resolveTheme } from '../src/components/theme.js';
 import { setCompositingForTests } from '../src/compositing.js';
 import { createMockApp, moveMouse, pressButton } from './helpers/mock-app.js';
@@ -183,6 +183,28 @@ test('a submenu lines its first item up with the row that opened it', async () =
   await x11Root.unmount();
 });
 
+test('the bar item is the first link in the trail', async () => {
+  const { x11Root, wnd, menu, list } = await openMenu();
+  const item = wnd._reactX11Node.children[0].children[0];
+  const theme = list.theme;
+
+  assert.equal(item.style.borderRadius, RADIUS_ITEM, 'the same pill');
+  assert.equal(
+    item.style.backgroundColor,
+    theme.hoverBackground,
+    'lit while its menu is open with nothing chosen in it',
+  );
+
+  await hoverRow(menu, 0);
+  assert.equal(
+    item.style.backgroundColor,
+    theme.surfaceActive,
+    'and quiet once a row down there takes the selection over',
+  );
+
+  await x11Root.unmount();
+});
+
 test('only the live end of the trail is selection-coloured', async () => {
   const { app, x11Root, menu, list } = await openMenu();
   const theme = list.theme;
@@ -209,6 +231,53 @@ test('only the live end of the trail is selection-coloured', async () => {
   );
   // quiet, not unselected: it still has to read as the way back
   assert.notEqual(list.children[2].style.backgroundColor, 'transparent');
+
+  await x11Root.unmount();
+});
+
+// --- dropdowns --------------------------------------------------------------
+
+test("a Select's menu is the same surface as a menu, and its options the same pill", async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(
+    h(
+      'window',
+      { width: 300, height: 200 },
+      h(
+        'box',
+        { style: { flexGrow: 1, padding: 10 } },
+        h(Select, { options: ['one', 'two', 'three'], value: 'one' }),
+      ),
+    ),
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const trigger = wnd._reactX11Node.children[0].children[0];
+  // opens on the press, as it always has
+  pressButton(wnd, trigger.abs.x + 4, trigger.abs.y + 4);
+  await tick();
+  await tick();
+
+  const menu = app.windows[1];
+  const sheet = menu._reactX11Node.children[0];
+  assert.equal(menu.attributes.depth, 32, 'ARGB, like a menu');
+  assert.equal(menu._reactX11Node.style.backgroundColor, 'transparent');
+  assert.equal(sheet.style.borderRadius, RADIUS_POPUP);
+  assert.equal(sheet.style.borderWidth, 1, 'the same hairline edge');
+
+  const rows = sheet.children[0].children; // through the scrollview
+  const theme = sheet.theme;
+  assert.equal(rows[0].style.borderRadius, RADIUS_ITEM);
+  assert.equal(
+    rows[0].style.backgroundColor,
+    theme.hoverBackground,
+    'the selected option opens active',
+  );
+  assert.equal(rows[1].style.backgroundColor, 'transparent', 'and the rest');
+  // inset from the sheet on both sides, so the pill sits on it
+  assert.ok(rows[0].abs.x >= 5, `option inset by ${rows[0].abs.x}px`);
+  assert.equal(rows[0].abs.width, menu.width - rows[0].abs.x * 2);
 
   await x11Root.unmount();
 });

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1443,6 +1443,9 @@ test('Select: an overlong menu scrolls the active option into view', async () =>
   const XK_DOWN = 0xff54;
   const XK_END = 0xff57;
   const ITEM_HEIGHT = 28;
+  // the scrollview's own padding, which the menu's chrome is measured from
+  // (`Select.js`, MENU_PAD — the same inset the menus use)
+  const MENU_PAD = 5;
   const options = Array.from({ length: 12 }, (_, i) => `option-${i}`);
 
   const app = createMockApp();
@@ -1512,7 +1515,7 @@ test('Select: an overlong menu scrolls the active option into view', async () =>
   assert.strictEqual(scroller.scrollY, 0);
 
   // arrowing down only scrolls once the active option leaves the viewport
-  const visible = Math.floor((scroller.abs.height - 4) / ITEM_HEIGHT);
+  const visible = Math.floor((scroller.abs.height - MENU_PAD) / ITEM_HEIGHT);
   for (let i = 0; i < visible - 1; i++) pressKey(app, wnd, { keysym: XK_DOWN });
   await settle();
   assert.strictEqual(scroller.scrollY, 0, 'still within the viewport');
@@ -1526,7 +1529,7 @@ test('Select: an overlong menu scrolls the active option into view', async () =>
   await settle();
   assert.strictEqual(
     scroller.scrollY,
-    4 + options.length * ITEM_HEIGHT - scroller.abs.height,
+    MENU_PAD + options.length * ITEM_HEIGHT - scroller.abs.height,
   );
 
   await x11Root.unmount();
@@ -3772,6 +3775,31 @@ test('MenuBar: an open menu is always dismissible', async () => {
       app.windows[1].destroyed,
       true,
       'Escape is not fussy about which item of the bar heard it',
+    );
+    await x11Root.unmount();
+  }
+
+  // the window losing the window manager's focus — alt-tab, a click in
+  // another application. Nothing in the tree hears that on its own: the bar
+  // item keeps the focus it took (a window blur leaves the focused node
+  // focused and merely stops it looking active), so without
+  // `useDismissOnWindowBlur` the menu stays up over an app the user has
+  // switched away from, still holding its pointer grab.
+  {
+    const { app, x11Root, wnd, buttons } = await mount();
+    openFile(wnd, buttons[0]);
+    await tick();
+    wnd.emit('blur', {});
+    await tick();
+    await tick();
+    assert.strictEqual(
+      app.windows[1].destroyed,
+      true,
+      'switching away closes it',
+    );
+    assert.ok(
+      wnd._reactX11Node.events.focused === buttons[0],
+      'and the bar item still holds focus, as a blurred window leaves it',
     );
     await x11Root.unmount();
   }

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -3947,6 +3947,11 @@ const rowsOf = (app, index) =>
   app.windows[index]._reactX11Node.children[0].children;
 const activeIn = (app, index) =>
   rowsOf(app, index).findIndex((r) => r.style.backgroundColor === '#2980b9');
+// A row whose submenu has taken the selection over is still the chosen one,
+// but only the deepest open level wears the selection colour — the trail
+// behind it goes quiet (`surfaceActive`).
+const pathIn = (app, index) =>
+  rowsOf(app, index).findIndex((r) => r.style.backgroundColor === '#e3e5ed');
 
 async function openNested(x11Root, picked) {
   const { ContextMenu } = await import('../src/index.js');
@@ -4328,7 +4333,7 @@ test('menu type-ahead applies to the deepest open submenu', async () => {
   typeChar(app, wnd, 's');
   await tick();
   assert.strictEqual(activeIn(app, 2), 2, 's -> SVG, inside the submenu');
-  assert.strictEqual(activeIn(app, 1), 1, 'parent row unchanged');
+  assert.strictEqual(pathIn(app, 1), 1, 'parent row unchanged, and quiet');
 
   // the disabled PDF is never matched
   await new Promise((r) => setTimeout(r, 800));

--- a/test/transparent.test.js
+++ b/test/transparent.test.js
@@ -437,3 +437,73 @@ test('an unknown @supports feature merges nothing rather than half-matching', as
     'red',
   );
 });
+
+// --- the switch -----------------------------------------------------------
+//
+// A desktop that composites has no other way to look at the opaque design:
+// stopping the compositor takes every other window on the screen with it.
+
+test('REACT_X11_NO_TRANSPARENCY=1 ignores the prop, on a display that could', async () => {
+  process.env.REACT_X11_NO_TRANSPARENCY = '1';
+  const ref = React.createRef();
+  try {
+    const app = createMockApp(); // composites, and has a 32-bit visual
+    const x11Root = await createRoot({ app });
+    x11Root.render(
+      h(
+        'window',
+        {
+          width: 200,
+          height: 100,
+          transparent: true,
+          style: { backgroundColor: '#101014', borderRadius: 14 },
+        },
+        h('box', { ref, style: CARD }),
+      ),
+    );
+    await tick();
+    const wnd = app.windows[0];
+
+    // created on the ordinary visual, exactly as on a display with none
+    assert.ok(!('depth' in wnd.attributes), 'no ARGB visual taken');
+    assert.strictEqual(wnd._reactX11Node._transparent, false);
+    assert.strictEqual(wnd._reactX11Node.transparencyEffective, false);
+    assert.ok(!wnd.ctx.ops.some(([op]) => op === 'clearRect'), 'never erases');
+    assert.ok(!wnd.ctx.ops.some(([op]) => op === 'roundRect'), 'square');
+    // and the style block that would have rounded it does not match
+    assert.strictEqual(ref.current.style.backgroundColor, '#1c1c22');
+    assert.strictEqual(ref.current.style.borderRadius, undefined);
+
+    await x11Root.unmount();
+  } finally {
+    delete process.env.REACT_X11_NO_TRANSPARENCY;
+  }
+});
+
+test('useSupports("transparency") answers the switch too', async () => {
+  // the two have to agree: a window that took the visual under a hook that
+  // said no would size a popup for chrome it then refused to draw
+  const seen = [];
+  function Probe() {
+    seen.push(useSupports('transparency'));
+    return null;
+  }
+  process.env.REACT_X11_NO_TRANSPARENCY = '1';
+  try {
+    const app = createMockApp();
+    const x11Root = await createRoot({ app });
+    x11Root.render(h('window', { width: 100, height: 60 }, h(Probe)));
+    await tick();
+    assert.strictEqual(seen.at(-1), false);
+    await x11Root.unmount();
+  } finally {
+    delete process.env.REACT_X11_NO_TRANSPARENCY;
+  }
+
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(h('window', { width: 100, height: 60 }, h(Probe)));
+  await tick();
+  assert.strictEqual(seen.at(-1), true, 'and true again with it unset');
+  await x11Root.unmount();
+});


### PR DESCRIPTION
Pixel polish for the built-in popups, on displays that composite — and an
honest fallback on the ones that do not.

## Shape is theme, not constants

Three tokens, derived from the **text size** rather than from `radius`: a
menu is a sheet laid over the window where a button is a control cut into
it, and the two do not want the same curve.

| token              | default | what it rounds              |
| ------------------ | ------- | --------------------------- |
| `radiusPopup`      | 7       | the menu sheet, at half the body size |
| `radiusPopupItem`  | 5       | the highlight on a row      |
| `radiusTooltip`    | 4       | the tooltip bubble          |

A palette that moves `fontSize` and names none of them gets all three in
proportion, the way the `…Active` colours already derive from the hover
step. Naming one pins it.

## Menus

- `<popup transparent>`: rounded sheet, hairline border, and the window
  paints nothing under it — a square fill would put the corners back.
- The row highlight is a **pill**: inset from the popup edge by the list's
  padding, rounded a step tighter, `hoverBackground` (the palette's
  selection colour, shared with `Select` and `Table`), nothing at rest.
- **Submenus line up on the items, not the boxes.** `anchorRect` grows an
  `alignOffset` — a shift along the alignment axis, applied before the
  clamp — and the submenu pays for its own border and padding with it, so
  the row you came from and the row you arrive at are on one line.
- **One selection at a time.** Only the deepest open level wears the
  selection colour; the trail behind it goes quiet (`surfaceActive`). A
  submenu open with *nothing* selected has not taken over yet, so the row
  that opened it stays lit.

## Tooltips

- No border, rounded at `radiusTooltip`, and a small arrow pointing back at
  the middle of the **trigger** — which stops being the middle of the bubble
  as soon as a screen edge slides one of them. Everything neither covers is
  left transparent.
- **`direction`**, defaulting to `'auto'`: the first side the hint fits on,
  measured against the screen, preferring above. Only `auto` can change
  axis — `anchorRect` flips top for bottom but never moves a popup to a side
  it was not asked for. `placement` still works and still wins.
- **`label` may be an element**, sized with `width`/`height` (a `<popup>` is
  a real X window and needs its size before layout). It fills the bubble and
  draws its own padding; anything renders in there, widgets included.
- **One hint at a time**, per connection: a trigger taking the hover
  dismisses whatever is showing, rather than waiting out its own delay.

## A bug underneath that last one

`useAnchorTracking` resurrected popups it had just closed. Closing nulls the
rect and destroys the window in one commit; the window's next frame lays out
without it and notifies every anchor subscriber — before React flushes the
effect cleanup that would have unsubscribed. The stale subscription answered
by measuring a fresh rect for the popup just closed, and the reconciler
handed back a second window in place of the one that went away.

Continuous priority is load-bearing: React flushes a click synchronously and
the cleanup then wins the race by luck, which is why it only showed up under
the pointer. **Select and MenuBar were exposed to it too**, so the regression
test drives the shared mechanism rather than any one widget.

## Degrading, and looking at the degraded design

Every bit of this is gated. The rounding is per window
(`'@supports transparency'`); the arrow is gated on the *display*
(`useSupports`), because it is part of how big the window has to be and
cannot wait for a style to resolve. With no compositor the popups are the
square opaque rectangles they have always been — those pixels would be
black, not the desktop.

`REACT_X11_NO_TRANSPARENCY=1` makes every display answer that way, so the
fallback can be looked at without stopping the compositor for the whole
session:

```sh
REACT_X11_NO_TRANSPARENCY=1 npm run examples:tooltips
```

One gate (`argbVisual()` in `compositing.js`) answers for both halves — a
window that took the ARGB visual under a `useSupports` that said no would
size a tooltip for an arrow it then refused to draw.

## Demo, docs, tests

`examples/tooltips.jsx` (`npm run examples:tooltips`) has a text hint, a
component hint, and one holding a live `<ProgressBar>`.

Docs: the token table and the `Tooltip`/menu sections in
`docs/components.md`, the switch in `docs/debugging.md`, cross-references in
`docs/elements.md` and `docs/styling.md`.

584 tests pass (19 new in `test/popup-chrome.test.js`, plus the tracking
regression and the switch), lint, typecheck and format clean. One existing
smoke test changed meaning rather than breaking: it asserted "parent row
unchanged" through the highlight colour, which is now the trail colour.

Verified on a composited Xwayland session throughout — menus, the row pill,
submenu alignment, the trail, both tooltip kinds and the opaque fallback all
read back from the popups' own ARGB backing stores.

🤖 Generated with [Claude Code](https://claude.ai/code)
