### PR TITLE
feat!: move to ntk 7, where the display sets the frame rate

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -36,12 +36,17 @@ REACT_X11_TRACE=summary npm run examples:dashboard
   stderr when the process exits.
 - `requests` — one stderr line per request as it is sent
   (`x11 → Render.FillRectangles 36B`), plus one line per painted frame
-  (`frame 412: 320x24@8,40 reasons=style-state fence=0.4ms`). X errors are
-  decoded and name the failing request. `fence` is ntk's measured server
-  round trip after the previous frame — how long the server took to drain
-  what that frame drew. Client work and server work separate here: a paint
-  that builds in 0.3ms against a fence of 20ms is a server-side problem
-  (software-fallback RENDER ops, a virtualized GPU), not a renderer one.
+  (`frame 412: 320x24@8,40 reasons=style-state landed=16.4ms`). X errors are
+  decoded and name the failing request. `landed` is ntk's `frameLatency`:
+  how long the previous frame took to be answered, which means different
+  things on the two frame clocks. On ntk >= 7 a window presents by default
+  and its frames end on the display, so this is time-to-display and reads
+  about **one refresh period** — 16ms on a 60Hz screen is the system
+  working. Client work and server work still separate here, but the question
+  to ask of a large number is which clock produced it: on `frameClock: 'fence'`
+  it is a server round trip, and a paint that builds in 0.3ms
+  against 20ms there _is_ a server-side problem (software-fallback RENDER
+  ops, a virtualized GPU) rather than a renderer one.
   `npm run bench:frames` reports the same split as a summary.
 - `chrome:/tmp/trace.json` — [Chrome Trace Event
   JSON](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU),
@@ -209,10 +214,14 @@ takes the route with no change to your code.
 What it is worth, measured on this repo's `bench:frames` cards mode against
 a glamor/virgl server — 48 cards, all recoloured every frame:
 
-|                          | fps  | paint   | fence   | wire/frame |
+|                          | fps  | paint   | landed  | wire/frame |
 | ------------------------ | ---- | ------- | ------- | ---------- |
 | `--border=2` (fast path) | 57.8 | 0.78 ms | 0.70 ms | 13 KB      |
 | `--border=2 --no-glyphs` | 3.8  | 7.53 ms | 287 ms  | 342 KB     |
+
+(measured on the fence clock, where the column is server drain — on the
+default vertical-blank clock the fast-path row would read about one refresh
+period instead, and the cliff would show in `fps` and `dropped`)
 
 A bail-out is a silent perf cliff — the box still renders, identically,
 just via the route above — so the counters matter more than usual.
@@ -240,16 +249,20 @@ histogram the route shows up directly: `Render.CompositeGlyphs8` and
 `misses` counts by reason. In rough order of how often they bite:
 
 - `fractional` — the box, or the stroke's band, is not on whole pixels.
-  **The one to know:** `_paintBorder` strokes the box inset by half the
-  border width, which puts the stroke's centre-line radius at
-  `borderRadius - borderWidth/2` — half-integer whenever the border width
-  is **odd**, and ntk requires an integer radius. So a 1px or 3px rounded
-  border keeps its corners on the polygon route while the background fill
-  underneath takes the fast one. On the 48-card wall that is 26x the wire
-  per frame (341 KB against 13 KB) and 5x the client paint. A 2px border
-  costs nothing extra and avoids it entirely; the fill is unaffected either
-  way. Fractional layout geometry lands here too — a box laid out on a
-  half-pixel bails even with an even border.
+  Usually **fractional layout geometry**: a box laid out on a half-pixel
+  bails whatever its border width is.
+
+  On ntk < 7 an _odd_ border width bailed too, and it was the one to know
+  about. `_paintBorder` strokes the box inset by half the border width,
+  putting the stroke's centre-line radius at `borderRadius - borderWidth/2`
+  — half-integer whenever the border is odd — and the stroke path wanted an
+  integer radius. A 1px or 3px rounded border therefore kept its corners on
+  the polygon route while the fill underneath took the fast one, which on
+  the 48-card wall was 26x the wire per frame (341 KB against 13 KB) and 5x
+  the client paint. ntk 7 takes those radii (sidorares/ntk#218), so a 1px
+  border is now as cheap as a 2px one and no border width needs choosing
+  around this.
+
 - `radius-cap` — the corner radius is over `shapePolicy.maxRadius` (64 by
   default; glyph-atlas behaviour past that is driver-specific). Also what
   the off switch reports.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -231,7 +231,8 @@ stays flaky on pixel assertions:
    overtake them and `act` would return before the pointer move had been
    dispatched at all, which looks exactly like a hover that does not work.
 3. **ntk's frame clock** — painting is scheduled through
-   `requestAnimationFrame`, paced behind a server fence. Synthetic input can
+   `requestAnimationFrame`, paced behind the display's vertical blank (or a
+   server round trip where there is no Present extension). Synthetic input can
    leave a frame scheduled and never run, so `act` runs the frame directly
    rather than waiting for it, then round-trips so the server has actually
    processed the drawing.

--- a/examples/stress/perf.js
+++ b/examples/stress/perf.js
@@ -138,11 +138,25 @@ export function watchFrames(root, { label = '', quiet = 0 } = {}) {
       if (frames === 0) return 'no frames painted';
       const bounded = frames - fullFrames;
       const pct = ((bounded / frames) * 100).toFixed(0);
-      return [
+      const line = [
         `${frames} frames, ${bounded} bounded (${pct}%), ${fullFrames} full`,
         `mean ${(totalArea / frames / 1000).toFixed(1)}kpx`,
         `mean ${(totalMs / frames).toFixed(2)}ms`,
-      ].join(' · ');
+      ];
+      // What the display made of them, where ntk >= 7 can say: the clock in
+      // effect, the refresh period it measured, and the vertical blanks that
+      // went past without a frame from us. `dropped` is the number to watch
+      // when chasing jank — it says the frame was late, which the ms column
+      // above can only hint at.
+      const wnd = root.window;
+      if (wnd?.frameClock) {
+        const refresh = wnd.refreshInterval
+          ? `${wnd.refreshInterval.toFixed(1)}ms (${(1000 / wnd.refreshInterval).toFixed(0)}Hz)`
+          : 'unmeasured';
+        line.push(`clock ${wnd.frameClock}, refresh ${refresh}`);
+        if (wnd.droppedFrames) line.push(`${wnd.droppedFrames} dropped`);
+      }
+      return line.join(' · ');
     },
     get frames() {
       return frames;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^6.7.0",
+        "ntk": "^7.0.0",
         "react-reconciler": "^0.33.0"
       },
       "devDependencies": {
@@ -4034,9 +4034,9 @@
       }
     },
     "node_modules/ntk": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-6.7.0.tgz",
-      "integrity": "sha512-cN3MBcyaY+OiQQEysIqbYJfzGScjdeRfyQ1bgRGB0eDsouTt8Pha4zLWg/H0D3Ws9GLSScKEwbNvMm3RMu1X0w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-7.0.0.tgz",
+      "integrity": "sha512-bSF/1w+sOwU5ALN5ix5wIiSYEVoXXntBSkDqpgaZrKESUuroy4eblCmn0XsJ6poQ8bpE8UrGOao86rPC1euwoA==",
       "dependencies": {
         "bidi-js": "^1.0.3",
         "canvas-fontstyle": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^6.7.0",
+    "ntk": "^7.0.0",
     "react-reconciler": "^0.33.0"
   },
   "optionalDependencies": {

--- a/scripts/bench/baseline.json
+++ b/scripts/bench/baseline.json
@@ -40,18 +40,18 @@
     "compositePixels": 160000
   },
   "shapes: 24 rounded bordered cards, 1px border": {
-    "requests": 82,
-    "bytesOut": 28140,
+    "requests": 107,
+    "bytesOut": 6776,
     "bytesIn": 32,
     "replies": 1,
     "composites": 1,
     "compositePixels": 160000
   },
   "mount: window with 40 boxes and labels": {
-    "requests": 101,
-    "bytesOut": 3928,
-    "bytesIn": 768,
-    "replies": 22,
+    "requests": 104,
+    "bytesOut": 3976,
+    "bytesIn": 864,
+    "replies": 25,
     "composites": 21,
     "compositePixels": 298240
   },

--- a/scripts/bench/frames.js
+++ b/scripts/bench/frames.js
@@ -13,16 +13,22 @@
 // two numbers that separate client cost from server cost:
 //
 //   paint    how long the client spent building each frame's requests
-//   fence    ntk's measured GetInputFocus round trip after each frame —
-//            how long the server took to drain them
+//   landed   how long the frame took to be answered — ntk's frameLatency,
+//            whose meaning follows the clock the window is on
 //
-// A healthy local server holds the fence well under a millisecond. A fence
-// that dwarfs paint is a server-side bottleneck: RENDER ops falling back to
-// software (glamor has no AddTraps acceleration — every rounded rectangle
-// pays it), a virtualized GPU, a compositor recomposite per blit. Run
-// `move` against `move --square` to see exactly what one rounded corner
-// mask costs on your setup; on glamor/virgl it has been measured at 10-40x
-// the fence of the square run.
+// On ntk >= 7 a window presents by default and its frames end on the
+// display, so `landed` is time-to-display and reads about one refresh
+// period: 16ms on a 60Hz screen is the system working, not a stall. What to
+// watch there is `fps` against the refresh rate, and `dropped`.
+//
+// On the fence clock (`frameClock: 'fence'`) it is a server round trip
+// instead, and a healthy local server holds it well under a millisecond;
+// one that dwarfs paint is a server-side bottleneck — RENDER ops falling
+// back to software (glamor has no AddTraps acceleration, so every rounded
+// rectangle pays it), a virtualized GPU, a compositor recomposite per blit.
+// That is the arm to use for server-cost questions: run `move` against
+// `move --square` to see what one rounded corner mask costs on your setup,
+// where on glamor/virgl it has been measured at 10-40x the square run.
 //
 // The damage columns catch the other regression class: `color` must stay
 // rect-bounded (~the box's own area), while `move`/`text` currently degrade
@@ -188,8 +194,8 @@ unlinkSync(tracePath);
 
 const frames = events.filter((ev) => ev.name === 'frame');
 const paint = frames.map((f) => f.dur / 1000).sort((a, b) => a - b);
-const fence = frames
-  .map((f) => f.args?.fenceMs)
+const landed = frames
+  .map((f) => f.args?.landedMs)
   .filter((v) => typeof v === 'number')
   .sort((a, b) => a - b);
 const full = frames.filter((f) => f.args?.full).length;
@@ -219,7 +225,7 @@ console.log(
 console.log(
   `           min    avg    p95    max   (ms)\n` +
     `  paint  ${ms(paint[0])} ${ms(avg(paint))} ${ms(q(paint, 0.95))} ${ms(paint[paint.length - 1])}\n` +
-    `  fence  ${ms(fence[0])} ${ms(avg(fence))} ${ms(q(fence, 0.95))} ${ms(fence[fence.length - 1])}`,
+    `  landed ${ms(landed[0])} ${ms(avg(landed))} ${ms(q(landed, 0.95))} ${ms(landed[landed.length - 1])}`,
 );
 // per frame, not per run: when a route change moves the frame rate by 10x,
 // the totals compare different numbers of frames and say nothing

--- a/scripts/bench/protocol.js
+++ b/scripts/bench/protocol.js
@@ -507,8 +507,12 @@ const SCENARIOS = [
       return {
         prepare: async (app, x11Root) => {
           ctl = await mounted(x11Root, rowsWindow(40));
-          // pace frames on the fence alone — deterministic under test, no
-          // 16ms wall-clock timer between the event and any (wrong) repaint
+          // Pace frames on the round trip alone — deterministic under test,
+          // with no wall-clock timer between the event and any (wrong)
+          // repaint. `frameClock: 'fence'` as well as the zero interval,
+          // since on ntk >= 7 the default clock waits for the display to
+          // report each frame, which the in-process server does not model.
+          ctl.root.window.frameClock = 'fence';
           ctl.root.window.frameInterval = 0;
         },
         run: async (app) => {

--- a/src/debug.js
+++ b/src/debug.js
@@ -399,7 +399,7 @@ function createSession({ sink, path }) {
       }
     },
 
-    frame({ rects, reasons, start, end, fence }) {
+    frame({ rects, reasons, start, end, landed }) {
       frames += 1;
       const full = !rects;
       const area = full
@@ -410,13 +410,17 @@ function createSession({ sink, path }) {
           ? 'FULL WINDOW'
           : rects.map((r) => `${r.width}x${r.height}@${r.x},${r.y}`).join(' ');
         const why = reasons?.length ? ` reasons=${reasons.join('+')}` : '';
-        // the previous frame's measured server drain: on a healthy local
-        // server it sits well under a millisecond, and a fence that grows
-        // with window area is the signature of a server-side bottleneck
-        // (software-fallback RENDER ops, a virtualized GPU) that client
-        // timings cannot show
+        // How long the previous frame took to be answered — ntk's
+        // `frameLatency`, whose meaning follows the clock it is on. On the
+        // vertical-blank clock (ntk >= 7, the default) it is time-to-display
+        // and reads about one refresh period, so a 16ms figure on a 60Hz
+        // screen is the system working. On the fence clock it is a server
+        // round trip and sits under a millisecond locally, where a figure
+        // that grows with window area is a server-side bottleneck —
+        // software-fallback RENDER ops, a virtualized GPU — that client
+        // timings cannot show. Either way it is paint-vs-everything-else.
         const wait =
-          typeof fence === 'number' ? ` fence=${fence.toFixed(1)}ms` : '';
+          typeof landed === 'number' ? ` landed=${landed.toFixed(1)}ms` : '';
         line(`frame ${frames}: ${where}${why}${wait}`);
       }
       record({
@@ -432,7 +436,7 @@ function createSession({ sink, path }) {
           rects: rects?.length ?? 0,
           area,
           reasons: reasons ?? [],
-          fenceMs: typeof fence === 'number' ? +fence.toFixed(2) : undefined,
+          landedMs: typeof landed === 'number' ? +landed.toFixed(2) : undefined,
         },
       });
     },

--- a/src/events.js
+++ b/src/events.js
@@ -115,7 +115,7 @@ export function setClickToComponentHandler(fn) {
  * ntk presents a window's dirty backing rects when its event handler
  * returns, so the blit goes out in the same event-loop turn as the press
  * that caused it. `flushPendingFrames` decides *whether* to paint now; see
- * frames.js for the fence gate that keeps a burst from painting ten times.
+ * frames.js for the frame gate that keeps a burst from painting ten times.
  */
 export function discrete(fn) {
   return (ev) => {

--- a/src/frames.js
+++ b/src/frames.js
@@ -37,16 +37,22 @@ export function clearPendingFrame(node) {
  *
  * Two things make that safe to do unconditionally at the call site:
  *
- *  - **The fence gate.** A window whose last frame is still unacknowledged
- *    keeps the frame it already scheduled. Painting it now would be work
- *    nobody sees: ntk defers the present until the ack, where it coalesces
- *    with the one already pending. This is what keeps a burst sane — spin a
- *    wheel and the first notch paints immediately, the rest fold into one
- *    catch-up frame. "Update instantly, then catch up", with the fence as
- *    the backpressure.
+ *  - **The frame gate.** A window whose last frame has not landed keeps the
+ *    frame it already scheduled. Painting it now would be work nobody sees:
+ *    ntk defers the present until the frame ends, where it coalesces with
+ *    the one already pending. This is what keeps a burst sane — spin a wheel
+ *    and the first notch paints immediately, the rest fold into one catch-up
+ *    frame. "Update instantly, then catch up", with the frame clock as the
+ *    backpressure.
+ *
+ *    On ntk >= 7 what ends a frame is the display: the server reports the
+ *    present it executed at a vertical blank, so the gate now means "the
+ *    display has not shown the last frame" rather than "the socket has not
+ *    acknowledged it". Same call, later and truer signal — and it is also
+ *    what keeps us off a backing pixmap the server is still copying from.
  *  - **Every window answers for itself.** The set is app-wide, so a click
  *    that dirtied both a menu and the window under it paints both, each
- *    gated on its own connection's fence.
+ *    gated on its own window's frame clock.
  *
  * A window whose scheduled frame this pays off keeps that scheduled
  * callback; it runs and finds `needsPaint` false, which is already a cheap
@@ -56,11 +62,10 @@ export function flushPendingFrames() {
   if (pending.size === 0) return;
   for (const node of [...pending]) {
     const wnd = node.window;
-    // ntk < 5.2.0 (sidorares/ntk#148) cannot say whether the server is
-    // caught up, and a missing
-    // answer is not a "no" — without the gate a burst would paint every
-    // event, so the paced frame stays the safe choice. Same for a headless
-    // mock window that models no frame clock at all.
+    // ntk < 5.2.0 (sidorares/ntk#148) cannot say whether the frame has
+    // landed, and a missing answer is not a "no" — without the gate a burst
+    // would paint every event, so the paced frame stays the safe choice.
+    // Same for a headless mock window that models no frame clock at all.
     if (typeof wnd?.frameInFlight !== 'function') continue;
     if (wnd.frameInFlight()) continue;
     node.flush();

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -5246,11 +5246,13 @@ export class WindowNode extends Node {
         reasons: this._lastReasons,
         start: started,
         end: performance.now(),
-        // ntk's last measured frame fence (GetInputFocus round trip after a
-        // frame's requests): how long the server took to drain them. Client
-        // work and server drain separate cleanly in a trace only when both
-        // are in it — a slow virtualized GPU shows up here, not in `end`.
-        fence: this.window.frameLatency,
+        // ntk's `frameLatency`: how long the previous frame took to be
+        // answered. On the vertical-blank clock that is time-to-display and
+        // reads about a refresh period; on the fence clock it is the server
+        // round trip that drained the frame's requests. Client work and
+        // server work separate cleanly in a trace only when both are in it —
+        // a slow virtualized GPU shows up here, not in `end`.
+        landed: this.window.frameLatency,
       });
     }
     // A frame that actually painted, which is the moment the app is up

--- a/test/rounded-box-glyphs.test.js
+++ b/test/rounded-box-glyphs.test.js
@@ -308,15 +308,15 @@ test('maxRadius: 0 turns the route off without changing what is drawn', async ()
   );
 });
 
-// The cliff this repo found on ntk 6.7.0, pinned so it cannot regress
-// silently — and so that relaxing it upstream fails here loudly rather than
-// passing unnoticed. `_paintBorder` strokes the box inset by half the
-// border width, which is right; the centre-line radius that follows from it
-// is `borderRadius - borderWidth/2`, half-integer whenever the border width
-// is odd, and ntk's stroke path requires an integer radius even though the
-// band it covers, `r ± bw/2`, lands on whole pixels either way.
-// See docs/debugging.md.
-test('an odd border width keeps the stroke on the polygon route', async () => {
+// The cliff this repo found on ntk 6.7.0, and which ntk 7 removed
+// (sidorares/ntk#218). `_paintBorder` strokes the box inset by half the
+// border width, so the centre-line radius is `borderRadius - borderWidth/2`,
+// half-integer whenever the border width is odd — which the stroke path used
+// to decline even though the band it covers, `r ± bw/2`, lands on whole
+// pixels either way. It now takes them, so a 1px border is as cheap as a 2px
+// one and this pins the *absence* of the cliff: an odd border reappearing in
+// the bail-out counts is the regression to catch. See docs/debugging.md.
+test('an odd border width is on the fast path, like an even one', async () => {
   const app = await headlessApp();
   const odd = await mount(
     app,
@@ -346,13 +346,13 @@ test('an odd border width keeps the stroke on the polygon route', async () => {
 
   assert.equal(
     oddStats.fractional ?? 0,
-    1,
-    'a 1px rounded border still bails as fractional',
+    0,
+    'a 1px rounded border no longer bails as fractional',
   );
   assert.equal(
     evenRoot._ctx.shapeStats.misses.fractional ?? 0,
     0,
-    'a 2px rounded border does not',
+    'and neither does a 2px one',
   );
 });
 


### PR DESCRIPTION
ntk 7 clocks a window's frames on the display instead of on a socket round
trip: a window presents by default, and the server reports each present it
executed at a vertical blank. Frames therefore run at the output's own rate
rather than at the 62.5fps a hardcoded 16ms interval implied, which is the
point of the bump — a 165Hz or 180Hz screen now gets 165 or 180 updates a
second when the frames fit.

BREAKING CHANGE: requires ntk >= 7. The rate a window runs at, the meaning
of `frameLatency`, and the traced `fenceMs` field all change with it.

The renderer needed no changes. `flushPendingFrames` already gates the
discrete-input fast path on `frameInFlight()`, which now answers "the
display has not shown the last frame" rather than "the socket has not
acknowledged it" — a later and truer signal for the same decision, and the
one that also keeps us off a backing pixmap the server is still copying
from. What needed changing is everything that explains or measures the old
mechanism, because against ntk 7 it quietly says the wrong thing.

**`fence` is now `landed`**, in the frame trace, the `requests` sink and the
`bench:frames` table. It is ntk's `frameLatency`, and on the vertical-blank
clock it measures time-to-display — about one refresh period. Measured here
it went from 1.11ms to 15.69ms on a ~63Hz server purely because of what it
now means, and the docs told you to read a number that size as a server-side
bottleneck. Anyone measuring a healthy ntk 7 system would have gone hunting
a software fallback that is not there. Both readings are documented now,
along with which clock produces which, and the fence clock is named as the
arm to use for server-cost questions.

**One round trip per frame is gone**, which is the part that matters on a
slow link. The vblank clock ends a frame on an event rather than on a reply,
so nothing waits for a `GetInputFocus`. In the protocol baseline that is
`update: 5 color flips` at 12 replies to 7, `scroll: 10 notches` at 22 to
17, and `svg: 100 unchanged icons` at 4 to 3 — on a 100ms link, five fewer
round trips is half a second off a scroll gesture.

**The rest of the baseline moved too**, and most of it is not this bump:
master pinned ntk ^6.6.0, so 6.7's corner-glyph fast path lands here as
well. `shapes: 50 filled rounded boxes` drops from 68216 to 6316 bytes with
composites from 51 to 1, which is that path rather than anything about
frames. What is this bump is `mount: window with 40 boxes and labels` at 3
more requests and 3 more replies, the cost of setting Present up per window.

**`bench:protocol` pins the fence clock explicitly.** It paces frames on the
round trip for determinism, and the in-process JS server models no display
for the default clock to wait on.

**The stress harness reports what the display made of the frames** — the
clock in effect, the refresh period ntk measured, and the vertical blanks
that went past without a frame from us. `dropped` is the number to watch
when chasing jank; the ms column can only hint at it.

Note for `perf/system-probe`, which is not in this branch: it carries
`test/rounded-box-glyphs.test.js` and a docs section pinning ntk 6.7's
odd-border cliff, where a 1px rounded border kept its corners on the polygon
route. ntk 7 removes that cliff, so the test fails and the advice to prefer
even border widths is obsolete. Both need the opposite assertion before that
branch meets this one.
