### PR TITLE
fix(text): re-measure when a text style prop changes

### DIFF
--- a/src/nodes.js
+++ b/src/nodes.js
@@ -2021,7 +2021,22 @@ export class TextNode extends Node {
   applyProps(newProps, oldProps) {
     const before = this.style;
     super.applyProps(newProps, oldProps);
-    if (textStyleChanged(this.style, before)) this._textContentChanged();
+    if (!textStyleChanged(this.style, before)) return;
+    this._textContentChanged();
+    // `super.applyProps` has already committed this frame, and it decided
+    // there was nothing to re-lay-out: none of `fontSize`, `fontWeight`,
+    // `fontFamily`, `fontStyle`, `lineHeight` or `textAlign` is a yoga
+    // property, so `applyLayoutStyle` saw nothing move, and none of them is
+    // a paint prop either, so the node contributed no damage. They are all
+    // inputs to the *measure function*, though — the dirty flag
+    // `_textContentChanged` just set is only read by a layout pass, and
+    // without asking for one the cleared layout is never rebuilt and the
+    // old glyphs stay on screen. A new string reaches the same conclusion
+    // through `TextChunkNode.setText`; this is that path for a new style.
+    let owner = this;
+    while (owner && !owner.yoga) owner = owner.parent;
+    if (owner) owner._invalidateLayout('text');
+    else this.root?.invalidate(true, null, 'text');
   }
 
   collectSpans(inherited, out) {

--- a/test/text-restyle.test.js
+++ b/test/text-restyle.test.js
@@ -1,0 +1,219 @@
+// Restyling text re-measures it.
+//
+// `fontSize`, `fontWeight`, `fontFamily`, `fontStyle`, `lineHeight` and
+// `textAlign` are the inputs to a `<text>`'s measure function, and none of
+// them is a yoga property or a paint property. So a commit that changes one
+// and nothing else reaches `applyProps` with nothing for `applyLayoutStyle`
+// to notice and nothing for `_paintChanged` to claim — the frame is already
+// decided by the time `TextNode.applyProps` marks the layout dirty. Ask for
+// no relayout there and the cleared layout is never rebuilt: React's state
+// is new, the node's props are new, the font manager hands back the right
+// face, and the old glyphs stay on the screen with nothing reporting an
+// error. Every test here changes exactly one of those properties and looks
+// at the pixels.
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { test } from 'node:test';
+import React from 'react';
+
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient, StaticFontSource } from 'ntk';
+
+import { createRoot } from '../src/index.js';
+
+const require = createRequire(import.meta.url);
+const fontDir = join(
+  dirname(require.resolve('katex/package.json')),
+  'dist',
+  'fonts',
+);
+
+const W = 240;
+const H = 120;
+
+// Three real faces of one family, so `fontWeight` and `fontStyle` have
+// somewhere to land: matching them is what the renderer is being asked to
+// redo, and a family with one face would pass this test without moving.
+async function headlessApp() {
+  const server = xserver.createServer({ width: 400, height: 400 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const fontSource = new StaticFontSource();
+  const add = (file, opts) =>
+    fontSource.add(readFileSync(join(fontDir, file)), {
+      family: 'Test Main',
+      ...opts,
+    });
+  add('KaTeX_Main-Regular.ttf', { weight: 400 });
+  add('KaTeX_Main-Bold.ttf', { weight: 700 });
+  add('KaTeX_Main-Italic.ttf', { style: 'italic' });
+  fontSource.alias('sans-serif', 'Test Main');
+  return createClient({ stream: clientEnd, fontSource });
+}
+
+const readPixels = (ctx, w, h) =>
+  new Promise((resolve, reject) =>
+    ctx.getImageData(0, 0, w, h, (err, data) =>
+      err ? reject(err) : resolve(data),
+    ),
+  );
+
+const settled = (app) =>
+  new Promise((resolve) => app.X.GetInputFocus(() => resolve()));
+
+/** How many pixels the text put ink in. */
+function ink(image) {
+  let n = 0;
+  for (let i = 0; i < image.data.length; i += 4) {
+    if (image.data[i] < 128) n++;
+  }
+  return n;
+}
+
+/**
+ * Render `element`, paint the frame it asked for, and read the window back.
+ * The second call onward is the one under test: it is an ordinary React
+ * update, which is how a restyle actually arrives.
+ */
+async function renderAndRead(app, x11Root, element, ref) {
+  await new Promise((resolve) => x11Root.render(element, resolve));
+  await new Promise((r) => setImmediate(r));
+  const node = ref.current;
+  node.root.flush();
+  await settled(app);
+  const ctx = (node.root._ctx ??= node.root.window.getContext('2d'));
+  return { image: await readPixels(ctx, W, H), node };
+}
+
+// `alignSelf: 'flex-start'` so the box is the measured text rather than the
+// window's width — which is what makes `abs.width` evidence that the
+// measure function ran again, and not just that something repainted.
+const label = (ref, style) =>
+  React.createElement(
+    'window',
+    { width: W, height: H, style: { backgroundColor: '#ffffff' } },
+    React.createElement(
+      'text',
+      { ref, style: { color: '#000000', alignSelf: 'flex-start', ...style } },
+      'Handgloves',
+    ),
+  );
+
+/**
+ * Restyle one `<text>` and report what moved: the ink on the screen and the
+ * width yoga measured it at.
+ */
+async function restyle(from, to) {
+  const app = await headlessApp();
+  const x11Root = await createRoot({ app });
+  try {
+    const ref = React.createRef();
+    const first = await renderAndRead(app, x11Root, label(ref, from), ref);
+    const before = { ink: ink(first.image), width: first.node.abs.width };
+    const second = await renderAndRead(app, x11Root, label(ref, to), ref);
+    return {
+      before,
+      after: { ink: ink(second.image), width: second.node.abs.width },
+    };
+  } finally {
+    await app.close();
+  }
+}
+
+test('a bigger fontSize re-measures and repaints', async () => {
+  const { before, after } = await restyle({ fontSize: 12 }, { fontSize: 28 });
+  assert.ok(
+    after.ink > before.ink * 1.5,
+    `28px should put down much more ink than 12px, got ${before.ink} -> ${after.ink}`,
+  );
+  assert.ok(
+    after.width > before.width,
+    `the measured box should grow, got ${before.width} -> ${after.width}`,
+  );
+});
+
+test('a smaller fontSize re-measures and repaints', async () => {
+  const { before, after } = await restyle({ fontSize: 28 }, { fontSize: 12 });
+  assert.ok(
+    after.ink < before.ink,
+    `12px should put down less ink than 28px, got ${before.ink} -> ${after.ink}`,
+  );
+  assert.ok(
+    after.width < before.width,
+    `the measured box should shrink, got ${before.width} -> ${after.width}`,
+  );
+});
+
+test('a new fontWeight picks up the bold face', async () => {
+  const { before, after } = await restyle(
+    { fontSize: 24, fontWeight: 400 },
+    { fontSize: 24, fontWeight: 700 },
+  );
+  assert.ok(
+    after.ink > before.ink,
+    `bold is heavier than regular, got ${before.ink} -> ${after.ink}`,
+  );
+});
+
+test('a new fontStyle picks up the italic face', async () => {
+  const { before, after } = await restyle(
+    { fontSize: 24, fontStyle: 'normal' },
+    { fontSize: 24, fontStyle: 'italic' },
+  );
+  assert.notEqual(
+    after.ink,
+    before.ink,
+    'the italic face draws different glyphs from the roman',
+  );
+});
+
+// The span has no yoga node of its own — the paragraph it belongs to owns
+// the measure function, so the invalidation has to walk up to it. Restyling
+// a span used to leave the paragraph laid out for the old style.
+test('restyling a nested span re-measures the paragraph', async () => {
+  const app = await headlessApp();
+  const x11Root = await createRoot({ app });
+  try {
+    const ref = React.createRef();
+    const paragraph = (spanStyle) =>
+      React.createElement(
+        'window',
+        { width: W, height: H, style: { backgroundColor: '#ffffff' } },
+        React.createElement(
+          'text',
+          {
+            ref,
+            style: {
+              fontSize: 12,
+              color: '#000000',
+              alignSelf: 'flex-start',
+            },
+          },
+          'plain ',
+          React.createElement('text', { style: spanStyle }, 'span'),
+        ),
+      );
+
+    const first = await renderAndRead(app, x11Root, paragraph({}), ref);
+    const before = { ink: ink(first.image), width: first.node.abs.width };
+    const second = await renderAndRead(
+      app,
+      x11Root,
+      paragraph({ fontSize: 30 }),
+      ref,
+    );
+
+    assert.ok(
+      ink(second.image) > before.ink,
+      `the span got bigger, got ${before.ink} -> ${ink(second.image)}`,
+    );
+    assert.ok(
+      second.node.abs.width > before.width,
+      `the paragraph re-wraps around it, got ${before.width} -> ${second.node.abs.width}`,
+    );
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
Changing `fontSize`, `fontWeight`, `fontFamily`, `fontStyle`, `lineHeight` or `textAlign` on a `<text>` — and nothing else — left the old glyphs on the screen. React's state was new, the node's props were new, the font manager handed back the right face, and the pixels never moved. Nothing reported an error.

## Why

None of those props is a yoga property or a paint property, and that is the whole bug.

`TextNode.applyProps` calls `super.applyProps` first, and that is where the frame gets decided: `applyLayoutStyle` compares the layout style (nothing moved), `_paintChanged` is asked whether anything drawn changed (it asks by value, and no text style prop is in `PAINT_PROPS`), and the root is invalidated on those two answers — `layoutChanged: false`, `NO_DAMAGE`.

Only then does `textStyleChanged` fire and `_textContentChanged()` clear `_layouts` and call `yoga.markDirty()`. That flag is read by a layout pass, and no layout pass was ever asked for. The cleared layout is never rebuilt, so the node keeps painting the line it was measured for.

`_themeChanged` already pairs `_textContentChanged()` with an explicit `invalidate(true, …)` for exactly this reason, and its comment says the invalidation "`TextNode.applyProps` would have done" happens there too — which turned out to be the assumption that was wrong.

## The fix

Ask for the layout pass, walking up to the node that owns the measure function so a restyled **span** re-measures the paragraph it belongs to (a span has no yoga node of its own). This is the path `TextChunkNode.setText` already takes for a new string; a new style now takes it too.

## Scope

Every text layout prop was affected, not just the exotic ones. Minimal repro with two ordinary DejaVu faces, counting ink in the window:

| change | before | after |
| --- | --- | --- |
| `fontWeight` 400 → 700 | 1331 px (unchanged) | 2362 px |
| `fontSize` 40 → 60 | 1331 px (unchanged) | 3075 px |

A responsive label that recomputes its own `fontSize`, a weight that follows a control, a family swapped at runtime — all of them silently did nothing.

## Tests

`test/text-restyle.test.js` — five cases over real faces (KaTeX Regular/Bold/Italic), each changing exactly one property and reading the window back: `fontSize` up, `fontSize` down, `fontWeight`, `fontStyle`, and a restyled span re-measuring its paragraph. They assert both the ink on the screen and the width yoga measured, so a repaint that skipped re-measurement would still fail.

All five fail on the parent commit and pass on this one.

`npm test` on this branch: 652/653. The one failure is `rounded-box-glyphs.test.js` — "an odd border width keeps the stroke on the polygon route" — which fails identically on a clean `master` (ntk 7.0.0 installed against a `^6.7.0` expectation) and is unrelated to this change.