### PR TITLE
feat(examples): a variable-font lab, built from whatever axes a file has

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -16,33 +16,34 @@ tests can import them without opening a window.
 
 Roughly in the order worth reading them:
 
-|                                            |                                                                                                                        |
-| ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------- |
-| [`simple.jsx`](simple.jsx)                 | hello world: flex layout and text, no pixel math. `npm run examples:simple`                                            |
-| [`simple-nojsx.js`](simple-nojsx.js)       | the same thing in plain node with `React.createElement` — no build step at all                                         |
-| [`xeyes.jsx`](xeyes.jsx)                   | the `<canvas>` escape hatch: custom drawing plus hooks for state and polling                                           |
-| [`dashboard.jsx`](dashboard.jsx)           | context for theming, `useState`/`useEffect`/`useMemo`, a custom hook, hover and focus states                           |
-| [`tasks.jsx`](tasks.jsx)                   | `useReducer`, dispatch through context, list rendering, `<scrollview>`, keyboard throughout                            |
-| [`form.jsx`](form.jsx)                     | `<textinput>`, `Select`, `RadioGroup`, `Slider`, `Checkbox`, and a modal `Dialog`                                      |
-| [`rules.jsx`](rules.jsx)                   | a WHEN/THEN rule builder: a recursive tree that edits itself, with drag-to-reorder and `<svg>` icons                   |
-| [`widgets.jsx`](widgets.jsx)               | the gallery: every standard component in one window, with a live `<markdown>` preview                                  |
-| [`react-features.jsx`](react-features.jsx) | React itself: priority, `<Suspense>`, `useOptimistic`, `<Activity>`, and where an error boundary goes                  |
-| [`menu.jsx`](menu.jsx)                     | `MenuBar` and `ContextMenu` over real `<popup>` windows that flip at screen edges — File → Open… is a real file dialog |
-| [`tooltips.jsx`](tooltips.jsx)             | hints that are text and hints that are components, `direction="auto"`, and the arrow an ARGB popup can have            |
-| [`theming.jsx`](theming.jsx)               | the style engine end to end: three themes in light and dark, switched at runtime                                       |
-| [`appearance.jsx`](appearance.jsx)         | follows the desktop's light/dark, accent, contrast and reduced motion — change your theme while it runs                |
-| [`richtext.jsx`](richtext.jsx)             | `<markdown>` with highlighted and math fences, a live `<tex>` formula, JSX `<svg>`, `<image>`                          |
-| [`windows.jsx`](windows.jsx)               | many top-level windows from one React tree, sharing state, closing via `onCloseRequest`                                |
-| [`app.jsx`](app.jsx)                       | the showcase: `SplitPane` + `Tabs` hosting `form`, `widgets` and `tasks` as panels                                     |
-| [`gl.jsx`](gl.jsx)                         | raw GL in a `<glarea>`, compiled to a server-side display list                                                         |
-| [`three.jsx`](three.jsx)                   | a react-three-fiber-shaped `<Canvas3D>` scene: meshes, lights, textures                                                |
-| [`icons.jsx`](icons.jsx)                   | 400 icon-sized `<svg>`s that reflow and scroll, with a cached-glyph control — a paint benchmark                        |
-| [`dnd-source.jsx`](dnd-source.jsx)         | **drag out of the app** (XDND) + in-app drags with live payloads, a `<popup>` drag preview                             |
-| [`dnd-target.jsx`](dnd-target.jsx)         | drop zones: `dropAccept` groups, parsed `e.files`, custom MIME types, `useDropTarget` state                            |
-| [`raster-gate.jsx`](raster-gate.jsx)       | a wall of live controls with ntk's local/server rasterization routing on a switch (ntk#177)                            |
-| [`dbus.jsx`](dbus.jsx)                     | a D-Bus explorer: `useSessionBus()`/`useSystemBus()`, a `Tree` of live introspection, a detail pane                    |
-| [`stress/`](stress/index.jsx)              | **the big one**: six panels to poke at by hand, with a frame log — see below                                           |
-| [`wm.jsx`](wm.jsx)                         | **a reparenting window manager** — see below                                                                           |
+|                                            |                                                                                                                                                               |
+| ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`simple.jsx`](simple.jsx)                 | hello world: flex layout and text, no pixel math. `npm run examples:simple`                                                                                   |
+| [`simple-nojsx.js`](simple-nojsx.js)       | the same thing in plain node with `React.createElement` — no build step at all                                                                                |
+| [`xeyes.jsx`](xeyes.jsx)                   | the `<canvas>` escape hatch: custom drawing plus hooks for state and polling                                                                                  |
+| [`dashboard.jsx`](dashboard.jsx)           | context for theming, `useState`/`useEffect`/`useMemo`, a custom hook, hover and focus states                                                                  |
+| [`tasks.jsx`](tasks.jsx)                   | `useReducer`, dispatch through context, list rendering, `<scrollview>`, keyboard throughout                                                                   |
+| [`form.jsx`](form.jsx)                     | `<textinput>`, `Select`, `RadioGroup`, `Slider`, `Checkbox`, and a modal `Dialog`                                                                             |
+| [`rules.jsx`](rules.jsx)                   | a WHEN/THEN rule builder: a recursive tree that edits itself, with drag-to-reorder and `<svg>` icons                                                          |
+| [`widgets.jsx`](widgets.jsx)               | the gallery: every standard component in one window, with a live `<markdown>` preview                                                                         |
+| [`react-features.jsx`](react-features.jsx) | React itself: priority, `<Suspense>`, `useOptimistic`, `<Activity>`, and where an error boundary goes                                                         |
+| [`menu.jsx`](menu.jsx)                     | `MenuBar` and `ContextMenu` over real `<popup>` windows that flip at screen edges — File → Open… is a real file dialog                                        |
+| [`tooltips.jsx`](tooltips.jsx)             | hints that are text and hints that are components, `direction="auto"`, and the arrow an ARGB popup can have                                                   |
+| [`theming.jsx`](theming.jsx)               | the style engine end to end: three themes in light and dark, switched at runtime                                                                              |
+| [`appearance.jsx`](appearance.jsx)         | follows the desktop's light/dark, accent, contrast and reduced motion — change your theme while it runs                                                       |
+| [`richtext.jsx`](richtext.jsx)             | `<markdown>` with highlighted and math fences, a live `<tex>` formula, JSX `<svg>`, `<image>`                                                                 |
+| [`variable-fonts.jsx`](variable-fonts.jsx) | pick a font file and get a control per axis it actually has — sliders, a `Switch` for a binary axis, the named instances, and the `<text>` that would draw it |
+| [`windows.jsx`](windows.jsx)               | many top-level windows from one React tree, sharing state, closing via `onCloseRequest`                                                                       |
+| [`app.jsx`](app.jsx)                       | the showcase: `SplitPane` + `Tabs` hosting `form`, `widgets` and `tasks` as panels                                                                            |
+| [`gl.jsx`](gl.jsx)                         | raw GL in a `<glarea>`, compiled to a server-side display list                                                                                                |
+| [`three.jsx`](three.jsx)                   | a react-three-fiber-shaped `<Canvas3D>` scene: meshes, lights, textures                                                                                       |
+| [`icons.jsx`](icons.jsx)                   | 400 icon-sized `<svg>`s that reflow and scroll, with a cached-glyph control — a paint benchmark                                                               |
+| [`dnd-source.jsx`](dnd-source.jsx)         | **drag out of the app** (XDND) + in-app drags with live payloads, a `<popup>` drag preview                                                                    |
+| [`dnd-target.jsx`](dnd-target.jsx)         | drop zones: `dropAccept` groups, parsed `e.files`, custom MIME types, `useDropTarget` state                                                                   |
+| [`raster-gate.jsx`](raster-gate.jsx)       | a wall of live controls with ntk's local/server rasterization routing on a switch (ntk#177)                                                                   |
+| [`dbus.jsx`](dbus.jsx)                     | a D-Bus explorer: `useSessionBus()`/`useSystemBus()`, a `Tree` of live introspection, a detail pane                                                           |
+| [`stress/`](stress/index.jsx)              | **the big one**: six panels to poke at by hand, with a frame log — see below                                                                                  |
+| [`wm.jsx`](wm.jsx)                         | **a reparenting window manager** — see below                                                                                                                  |
 
 `app.jsx` is where a new control should get demonstrated: it imports the
 panel each of `form`, `widgets` and `tasks` exports, so adding a widget

--- a/examples/variable-fonts.jsx
+++ b/examples/variable-fonts.jsx
@@ -1,0 +1,429 @@
+// A variable-font lab: pick a font file, and the app builds a control per
+// axis the file actually has — read off the font, not configured here.
+//
+//   Select font…  ->  useFileDialog()      the desktop's own dialog
+//   app.fonts.load(path)                   register it at runtime
+//   font.variationAxes                     { wght: {name, min, default, max} }
+//   font.fk.namedVariations                the designer's chosen points
+//
+// A slider per continuous axis, a Switch for a binary one, a readout for an
+// axis pinned to a single value, and a Select for the named instances. The
+// panel at the bottom prints the `<text>` that would draw what you are
+// looking at — the point being that `wght` comes out as `fontWeight`, since
+// that is the axis react-x11 already drives, and everything else goes in
+// `fontVariationSettings`.
+//
+// Needs a variable font to be interesting. Most systems have one:
+//   /usr/share/fonts/truetype/ubuntu/Ubuntu[wdth,wght].ttf   (wdth + wght)
+// Pick a .ttf/.otf rather than a .woff2 — fontkit cannot instantiate an axis
+// out of a compressed font, and the app says so when you try.
+//
+// Run with: npm run examples:variable-fonts  (needs an X server / DISPLAY)
+import React, { useCallback, useMemo, useState } from 'react';
+import { Font } from 'ntk';
+
+import {
+  Button,
+  Select,
+  Slider,
+  Switch,
+  createRoot,
+  createStyles,
+  useApp,
+  useFileDialog,
+} from '../src/index.js';
+
+// Every distinct coordinate is a font in its own right — its own glyphs, its
+// own server-side glyphset — so the control is stepped rather than the font
+// quantized (which is ntk's advice, and the reason it does not do it for
+// you). A coarse grid on a wide axis, a fine one on a narrow one.
+function stepFor(axis) {
+  const range = axis.max - axis.min;
+  if (range > 400) return 10;
+  if (range > 40) return 5;
+  if (range > 4) return 1;
+  return 0.1;
+}
+
+/** An axis of 0..1 is the `ital` convention: a switch, not a slider. */
+const isBinary = (axis) => axis.min === 0 && axis.max === 1;
+
+/** Axis order: the ones people reach for first, then whatever else exists. */
+const AXIS_ORDER = ['wght', 'wdth', 'opsz', 'slnt', 'ital', 'GRAD'];
+const byFamiliarity = (a, b) => {
+  const ia = AXIS_ORDER.indexOf(a);
+  const ib = AXIS_ORDER.indexOf(b);
+  return (ia === -1 ? 99 : ia) - (ib === -1 ? 99 : ib) || a.localeCompare(b);
+};
+
+const s = createStyles({
+  window: { backgroundColor: '$background' },
+  page: { flexGrow: 1, padding: 20, gap: 18 },
+  header: { flexDirection: 'row', alignItems: 'center', gap: 14 },
+  title: { fontSize: 16, fontWeight: 600, color: '$text' },
+  spacer: { flexGrow: 1 },
+  dim: { fontSize: 12, color: '$dim' },
+  card: {
+    backgroundColor: '$surfaceHover',
+    borderWidth: 1,
+    borderColor: '$border',
+    borderRadius: 6,
+    padding: 16,
+    gap: 12,
+  },
+  sample: { minHeight: 90, justifyContent: 'center' },
+  row: { flexDirection: 'row', alignItems: 'center', gap: 12 },
+  axisName: { width: 150 },
+  axisTag: { fontSize: 13, color: '$text', fontWeight: 500 },
+  axisLabel: { fontSize: 11, color: '$dim' },
+  value: { width: 58, fontSize: 13, color: '$text' },
+  range: { width: 96, fontSize: 11, color: '$dim' },
+  code: {
+    backgroundColor: '$background',
+    borderWidth: 1,
+    borderColor: '$border',
+    borderRadius: 6,
+    padding: 14,
+  },
+  codeText: { fontFamily: 'monospace', fontSize: 12, lineHeight: 1.5 },
+  warn: { fontSize: 12, color: '#c0392b', lineHeight: 1.45 },
+  empty: { gap: 8, paddingTop: 40, alignItems: 'center' },
+});
+
+// ---------------------------------------------------------------------------
+// Loading
+// ---------------------------------------------------------------------------
+
+/**
+ * What the app knows about a picked file. `axes` is read straight off the
+ * font — this is the whole of "what can I move?", and a static face answers
+ * with `{}` rather than with an error.
+ */
+function inspect(path, family) {
+  const font = Font.loadSync(path);
+  const axes = font.variationAxes;
+  const named = font.fk.namedVariations ?? {};
+  let instancing = null; // an error message, when the axes cannot be cut
+  const first = Object.keys(axes)[0];
+  if (first) {
+    try {
+      // a variable .woff2 parses and reports axes and then cannot be
+      // instantiated; better to find out here than at the first keystroke
+      font.variation({ [first]: axes[first].max });
+    } catch (err) {
+      instancing = err.message;
+    }
+  }
+  return {
+    path,
+    family,
+    file: path.split('/').pop(),
+    name: font.familyName ?? '(unnamed)',
+    axes,
+    named: Object.keys(named).length ? named : null,
+    namedCoords: named,
+    instancing,
+  };
+}
+
+let loaded = 0; // unique family counter, so picks never collide
+
+const defaults = (axes) =>
+  Object.fromEntries(Object.entries(axes).map(([tag, a]) => [tag, a.default]));
+
+// ---------------------------------------------------------------------------
+// The code panel
+// ---------------------------------------------------------------------------
+
+const num = (v) =>
+  Number.isInteger(v) ? String(v) : String(Number(v.toFixed(2)));
+
+/**
+ * The `<text>` that would draw what is on screen.
+ *
+ * `wght` is deliberately not in `fontVariationSettings`: `fontWeight` drives
+ * that axis, which is the thing worth teaching — an app with a variable font
+ * and one weight prop needs nothing else.
+ */
+function snippetFor({ font, size, values, sample }) {
+  // The family printed is the font's own, not the private alias this app
+  // registers it under — the snippet is meant to be read and copied, and a
+  // `picked-3` in it would be a lie about how the font got there. The line
+  // above it is how it got there.
+  const family = font.label;
+  const lines = [
+    `// app.fonts.load('${font.file}', { family: '${family}' })`,
+    '<text',
+    '  style={{',
+  ];
+  lines.push(`    fontFamily: '${family}',`);
+  lines.push(`    fontSize: ${num(size)},`);
+  if (font.axes.wght) lines.push(`    fontWeight: ${num(values.wght)},`);
+  const others = Object.keys(font.axes)
+    .filter((tag) => tag !== 'wght')
+    .sort(byFamiliarity);
+  if (others.length) {
+    const pairs = others.map((tag) => `${tag}: ${num(values[tag])}`).join(', ');
+    lines.push(`    fontVariationSettings: { ${pairs} },`);
+  }
+  lines.push('  }}', '>', `  ${sample}`, '</text>');
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Controls
+// ---------------------------------------------------------------------------
+
+function AxisRow({ tag, axis, value, onChange }) {
+  const fixed = axis.min === axis.max;
+  return (
+    <box style={s.row}>
+      <box style={s.axisName}>
+        <text style={s.axisTag}>
+          {tag}
+          {tag === 'wght' ? ' → fontWeight' : ''}
+        </text>
+        <text style={s.axisLabel}>{axis.name ?? tag}</text>
+      </box>
+      <text style={s.value}>{num(value)}</text>
+      <text style={s.range}>
+        {fixed ? 'fixed' : `${num(axis.min)}–${num(axis.max)}`}
+      </text>
+      {fixed ? (
+        <text style={s.dim}>this face pins the axis</text>
+      ) : isBinary(axis) ? (
+        <Switch
+          checked={value >= 0.5}
+          onChange={(ev) => onChange(ev.value ? 1 : 0)}
+        />
+      ) : (
+        <Slider
+          value={value}
+          min={axis.min}
+          max={axis.max}
+          step={stepFor(axis)}
+          onChange={(ev) => onChange(ev.value)}
+          style={{ flexGrow: 1, minWidth: 120 }}
+        />
+      )}
+    </box>
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+function Lab({ initialFont = null }) {
+  const app = useApp();
+  const { openFile } = useFileDialog();
+  const [font, setFont] = useState(null);
+  const [error, setError] = useState(null);
+  const [values, setValues] = useState({});
+  const [size, setSize] = useState(64);
+  const [sample, setSample] = useState('Handgloves');
+  const [picked, setPicked] = useState(null); // the named instance, if any
+
+  /** Register a file with the running app and read its axes off it. */
+  const load = useCallback(
+    (path) => {
+      try {
+        // a fresh family per pick, so a second font never resolves to the
+        // first: `fonts.load` registers by family, and two files claiming
+        // "Ubuntu" would otherwise be one family with two faces
+        const family = `picked-${++loaded}`;
+        const info = inspect(path, family);
+        app.fonts.load(path, { family });
+        setFont({ ...info, name: family, label: info.name });
+        setValues(defaults(info.axes));
+        setPicked(null);
+        setError(null);
+      } catch (err) {
+        setFont(null);
+        setError(err.message);
+      }
+    },
+    [app],
+  );
+
+  // a path on the command line preloads, so the app can be pointed straight
+  // at a face: `npm run examples:variable-fonts -- /path/to/Font.ttf`
+  const [booted, setBooted] = useState(false);
+  if (initialFont && !booted) {
+    setBooted(true);
+    load(initialFont);
+  }
+
+  const pick = useCallback(async () => {
+    const files = await openFile({
+      title: 'Select a font',
+      filters: [
+        { name: 'Fonts', extensions: ['ttf', 'otf', 'ttc', 'woff', 'woff2'] },
+      ],
+    });
+    if (!files?.length) return; // cancelled — an outcome, not an error
+    load(files[0]);
+  }, [openFile, load]);
+
+  const tags = useMemo(
+    () => Object.keys(font?.axes ?? {}).sort(byFamiliarity),
+    [font],
+  );
+
+  // `wght` is spent on fontWeight; everything else is fontVariationSettings
+  const variations = useMemo(() => {
+    const out = {};
+    for (const tag of tags) if (tag !== 'wght') out[tag] = values[tag];
+    return Object.keys(out).length ? out : undefined;
+  }, [tags, values]);
+
+  const setAxis = (tag, value) => {
+    setValues((v) => ({ ...v, [tag]: value }));
+    setPicked(null); // it is no longer that named instance
+  };
+
+  const applyNamed = (name) => {
+    setPicked(name);
+    const coords = font.namedCoords[name];
+    if (coords) setValues((v) => ({ ...v, ...coords }));
+  };
+
+  return (
+    <window
+      title="react-x11 — variable fonts"
+      width={860}
+      height={760}
+      style={s.window}
+    >
+      <scrollview style={{ flexGrow: 1 }}>
+        <box style={s.page}>
+          <box style={s.header}>
+            <text style={s.title}>Variable font lab</text>
+            <box style={s.spacer} />
+            {font && (
+              <text style={s.dim}>
+                {font.label} · {font.file}
+              </text>
+            )}
+            <Button label="Select font…" primary onPress={pick} />
+          </box>
+
+          {error && <text style={s.warn}>{error}</text>}
+
+          {!font && !error && (
+            <box style={s.empty}>
+              <text style={{ fontSize: 14, color: '$text' }}>
+                Pick a font file to see its axes.
+              </text>
+              <text style={s.dim}>
+                A variable .ttf has them; a static face reports none. On most
+                Linux boxes:
+                /usr/share/fonts/truetype/ubuntu/Ubuntu[wdth,wght].ttf
+              </text>
+            </box>
+          )}
+
+          {font && (
+            <>
+              <box style={[s.card, s.sample]}>
+                <text
+                  style={{
+                    fontFamily: font.name,
+                    fontSize: size,
+                    fontWeight: font.axes.wght ? values.wght : undefined,
+                    fontVariationSettings: variations,
+                    color: '$text',
+                  }}
+                >
+                  {sample}
+                </text>
+              </box>
+
+              {font.instancing && <text style={s.warn}>{font.instancing}</text>}
+
+              <box style={s.card}>
+                <box style={s.row}>
+                  <box style={s.axisName}>
+                    <text style={s.axisTag}>sample</text>
+                    <text style={s.axisLabel}>type to change it</text>
+                  </box>
+                  <textinput
+                    value={sample}
+                    onChange={(ev) => setSample(ev.value)}
+                    style={{ flexGrow: 1 }}
+                  />
+                </box>
+
+                <box style={s.row}>
+                  <box style={s.axisName}>
+                    <text style={s.axisTag}>size → fontSize</text>
+                    <text style={s.axisLabel}>not an axis; px</text>
+                  </box>
+                  <text style={s.value}>{size}</text>
+                  <text style={s.range}>8–200</text>
+                  <Slider
+                    value={size}
+                    min={8}
+                    max={200}
+                    step={2}
+                    onChange={(ev) => setSize(ev.value)}
+                    style={{ flexGrow: 1, minWidth: 120 }}
+                  />
+                </box>
+
+                {tags.length === 0 && (
+                  <text style={s.dim}>
+                    This face has no variation axes — `font.variationAxes` is
+                    empty, so there is nothing to move.
+                  </text>
+                )}
+
+                {tags.map((tag) => (
+                  <AxisRow
+                    key={tag}
+                    tag={tag}
+                    axis={font.axes[tag]}
+                    value={values[tag]}
+                    onChange={(v) => setAxis(tag, v)}
+                  />
+                ))}
+
+                {font.named && (
+                  <box style={s.row}>
+                    <box style={s.axisName}>
+                      <text style={s.axisTag}>named instances</text>
+                      <text style={s.axisLabel}>
+                        the designer&apos;s own points
+                      </text>
+                    </box>
+                    <Select
+                      style={{ width: 220 }}
+                      value={picked}
+                      placeholder={`${Object.keys(font.named).length} to choose from…`}
+                      options={Object.keys(font.named)}
+                      onChange={(ev) => applyNamed(ev.value)}
+                    />
+                  </box>
+                )}
+              </box>
+
+              <box style={s.card}>
+                <text style={s.dim}>the same text, in react-x11</text>
+                <box style={s.code}>
+                  <text style={s.codeText}>
+                    {snippetFor({ font, size, values, sample })}
+                  </text>
+                </box>
+              </box>
+            </>
+          )}
+        </box>
+      </scrollview>
+    </window>
+  );
+}
+
+export default Lab;
+
+if (!process.env.REACT_X11_NO_AUTORUN) {
+  const root = await createRoot();
+  root.render(<Lab initialFont={process.argv[2] ?? null} />);
+}

--- a/examples/variable-fonts.jsx
+++ b/examples/variable-fonts.jsx
@@ -7,7 +7,7 @@
 //   font.fk.namedVariations                the designer's chosen points
 //
 // A slider per continuous axis, a Switch for a binary one, a readout for an
-// axis pinned to a single value, and a Select for the named instances. The
+// axis pinned to a single value, and radios for the named instances. The
 // panel at the bottom prints the `<text>` that would draw what you are
 // looking at — the point being that `wght` comes out as `fontWeight`, since
 // that is the axis react-x11 already drives, and everything else goes in
@@ -24,7 +24,8 @@ import { Font } from 'ntk';
 
 import {
   Button,
-  Select,
+  Radio,
+  RadioGroup,
   Slider,
   Switch,
   createRoot,
@@ -268,6 +269,8 @@ function Lab({ initialFont = null }) {
     [font],
   );
 
+  const namedNames = useMemo(() => Object.keys(font?.named ?? {}), [font]);
+
   // `wght` is spent on fontWeight; everything else is fontVariationSettings
   const variations = useMemo(() => {
     const out = {};
@@ -394,13 +397,26 @@ function Lab({ initialFont = null }) {
                         the designer&apos;s own points
                       </text>
                     </box>
-                    <Select
-                      style={{ width: 220 }}
+                    {/* Radios rather than a dropdown: these are the one
+                        genuinely discrete thing about a variable font, and
+                        seeing all of them at once — with the coordinates
+                        they stand for — is the point. A menu would hide
+                        both behind a click. */}
+                    <RadioGroup
                       value={picked}
-                      placeholder={`${Object.keys(font.named).length} to choose from…`}
-                      options={Object.keys(font.named)}
                       onChange={(ev) => applyNamed(ev.value)}
-                    />
+                      style={{
+                        flexDirection: 'row',
+                        flexWrap: 'wrap',
+                        gap: 10,
+                        flexGrow: 1,
+                        flexShrink: 1,
+                      }}
+                    >
+                      {namedNames.map((name) => (
+                        <Radio key={name} value={name} label={name} />
+                      ))}
+                    </RadioGroup>
                   </box>
                 )}
               </box>

--- a/examples/variable-fonts.jsx
+++ b/examples/variable-fonts.jsx
@@ -7,11 +7,15 @@
 //   font.fk.namedVariations                the designer's chosen points
 //
 // A slider per continuous axis, a Switch for a binary one, a readout for an
-// axis pinned to a single value, and radios for the named instances. The
+// axis pinned to a single value, and a Select for the named instances. The
 // panel at the bottom prints the `<text>` that would draw what you are
 // looking at — the point being that `wght` comes out as `fontWeight`, since
 // that is the axis react-x11 already drives, and everything else goes in
 // `fontVariationSettings`.
+//
+// There is also a switch for ntk's *text policy*, which is not about
+// variable fonts at all but is the other thing this window is good for
+// looking at closely. See TEXT_POLICY below.
 //
 // Needs a variable font to be interesting. Most systems have one:
 //   /usr/share/fonts/truetype/ubuntu/Ubuntu[wdth,wght].ttf   (wdth + wght)
@@ -24,8 +28,7 @@ import { Font } from 'ntk';
 
 import {
   Button,
-  Radio,
-  RadioGroup,
+  Select,
   Slider,
   Switch,
   createRoot,
@@ -48,6 +51,28 @@ function stepFor(axis) {
 
 /** An axis of 0..1 is the `ital` convention: a switch, not a slider. */
 const isBinary = (axis) => axis.min === 0 && axis.max === 1;
+
+/**
+ * ntk routes each (face, size) to one of two glyph paths, and `textPolicy`
+ * is where the thresholds live:
+ *
+ * - **bitmap** — glyphs rasterize once, upload to a server-side glyphset and
+ *   composite by id. Cheap to draw repeatedly, and glyph origins are
+ *   **rounded to whole pixels**, because a cached bitmap can only land on
+ *   one.
+ * - **vector** — outlines are flattened at the exact size, trapezoidated and
+ *   composited through a scratch mask, every draw. Nothing is cached, and
+ *   positions are deliberately *not* rounded.
+ *
+ * Forcing everything to the vector path is how you see subpixel glyph
+ * positioning: at a fractional size, or with a fractional origin, the
+ * bitmap path snaps and the vector path does not. It costs a rasterization
+ * per draw, which is the trade the thresholds exist to make for you.
+ */
+const TEXT_POLICY = {
+  bitmap: undefined, // ntk's defaults: bitmapMax 128, vectorFrom 256
+  vector: { bitmapMax: 0, vectorFrom: 0 },
+};
 
 /** Axis order: the ones people reach for first, then whatever else exists. */
 const AXIS_ORDER = ['wght', 'wdth', 'opsz', 'slnt', 'ital', 'GRAD'];
@@ -222,6 +247,14 @@ function Lab({ initialFont = null }) {
   const [size, setSize] = useState(64);
   const [sample, setSample] = useState('Handgloves');
   const [picked, setPicked] = useState(null); // the named instance, if any
+  const [vectorText, setVectorText] = useState(false);
+
+  // `textPolicy` is read at *draw* time, not at render time, so setting it
+  // changes nothing on its own — the frame already on screen was composited
+  // by whichever path was in force when it was drawn. Remounting the sample
+  // (`key` below) is the honest way to ask for it again from React, with no
+  // reach into renderer internals.
+  app.textPolicy = vectorText ? TEXT_POLICY.vector : TEXT_POLICY.bitmap;
 
   /** Register a file with the running app and read its axes off it. */
   const load = useCallback(
@@ -328,6 +361,7 @@ function Lab({ initialFont = null }) {
             <>
               <box style={[s.card, s.sample]}>
                 <text
+                  key={vectorText ? 'vector' : 'bitmap'}
                   style={{
                     fontFamily: font.name,
                     fontSize: size,
@@ -360,16 +394,40 @@ function Lab({ initialFont = null }) {
                     <text style={s.axisTag}>size → fontSize</text>
                     <text style={s.axisLabel}>not an axis; px</text>
                   </box>
-                  <text style={s.value}>{size}</text>
+                  <text style={s.value}>{num(size)}</text>
                   <text style={s.range}>8–200</text>
+                  {/* half-pixel steps, because a fractional size is what
+                      makes the two glyph paths differ: the bitmap path
+                      rounds each origin to a whole pixel, the vector path
+                      does not */}
                   <Slider
                     value={size}
                     min={8}
                     max={200}
-                    step={2}
+                    step={0.5}
                     onChange={(ev) => setSize(ev.value)}
                     style={{ flexGrow: 1, minWidth: 120 }}
                   />
+                </box>
+
+                <box style={s.row}>
+                  <box style={s.axisName}>
+                    <text style={s.axisTag}>glyph path</text>
+                    <text style={s.axisLabel}>app.textPolicy</text>
+                  </box>
+                  <text style={s.value}>{vectorText ? 'vector' : 'auto'}</text>
+                  <text style={s.range}>
+                    {vectorText ? 'subpixel' : 'pixel-snapped'}
+                  </text>
+                  <Switch
+                    checked={vectorText}
+                    onChange={(ev) => setVectorText(ev.value)}
+                  />
+                  <text style={s.dim}>
+                    {vectorText
+                      ? '{ bitmapMax: 0, vectorFrom: 0 } — outlines every draw, origins unrounded'
+                      : 'ntk defaults — cached glyph bitmaps, origins rounded to whole pixels'}
+                  </text>
                 </box>
 
                 {tags.length === 0 && (
@@ -397,26 +455,13 @@ function Lab({ initialFont = null }) {
                         the designer&apos;s own points
                       </text>
                     </box>
-                    {/* Radios rather than a dropdown: these are the one
-                        genuinely discrete thing about a variable font, and
-                        seeing all of them at once — with the coordinates
-                        they stand for — is the point. A menu would hide
-                        both behind a click. */}
-                    <RadioGroup
+                    <Select
+                      style={{ width: 240 }}
                       value={picked}
+                      placeholder={`${namedNames.length} to choose from…`}
+                      options={namedNames}
                       onChange={(ev) => applyNamed(ev.value)}
-                      style={{
-                        flexDirection: 'row',
-                        flexWrap: 'wrap',
-                        gap: 10,
-                        flexGrow: 1,
-                        flexShrink: 1,
-                      }}
-                    >
-                      {namedNames.map((name) => (
-                        <Radio key={name} value={name} label={name} />
-                      ))}
-                    </RadioGroup>
+                    />
                   </box>
                 )}
               </box>

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "examples:tasks": "tsx examples/tasks.jsx",
     "examples:tasks:hot": "node --enable-source-maps --import ./examples/hmr-register.mjs examples/tasks-hot.jsx",
     "examples:menu": "tsx examples/menu.jsx",
+    "examples:variable-fonts": "tsx examples/variable-fonts.jsx",
     "examples:tooltips": "tsx examples/tooltips.jsx",
     "examples:clipboard": "tsx examples/clipboard.jsx",
     "examples:dbus": "tsx examples/dbus.jsx",


### PR DESCRIPTION
Pick a font file; the app reads its design space off the font and builds a control per axis. Nothing about any particular typeface is configured — `font.variationAxes` is the whole of "what can I move?", and a static face answers `{}` rather than with an error.

```
Select font…             useFileDialog(), the desktop's own dialog
app.fonts.load(path)     register it at runtime, under a private family
font.variationAxes       { wght: { name, min, default, max } }
font.fk.namedVariations  the designer's own points in that space
```

## The controls come from the file

| what the font says | control |
| --- | --- |
| a continuous axis (`wght` 100–800) | `Slider`, stepped by range |
| an axis of 0..1 (the `ital` convention) | `Switch` |
| `min === max` — the face pins it | a readout, no control |
| named instances | radios, all of them visible |

Axis sliders are stepped by range because the *control* is the thing to quantize: every distinct coordinate is a font in its own right, with its own glyphs and its own server-side glyphset. That is ntk's advice and the reason it does not quantize for you.

Named instances get radios rather than a dropdown. They are the one genuinely discrete thing about a variable font — the points the designer named, which used to ship as separate files — and putting them beside the axis controls is the point: clicking "Condensed Bold" visibly drops `wght` to 700 and `wdth` to 75, so the named point and the coordinates it stands for are on screen together. A menu hid exactly that.

## The panel underneath

It prints the `<text>` that would draw what you are looking at, live:

```jsx
// app.fonts.load('Ubuntu[wdth,wght].ttf', { family: 'Ubuntu' })
<text
  style={{
    fontFamily: 'Ubuntu',
    fontSize: 64,
    fontWeight: 700,
    fontVariationSettings: { wdth: 75 },
  }}
>
  Handgloves
</text>
```

`wght` comes out as `fontWeight` and never inside `fontVariationSettings` — that is the thing worth teaching, since an app with a variable font and a weight prop needs nothing else. The family printed is the font's own rather than the private `picked-1` alias the app registers it under, with the `fonts.load` line above it so the snippet is honest about how the font got there.

## Two failure modes on purpose

- **A static face** says it has no axes, and drops `fontVariationSettings` from the snippet entirely.
- **A variable `.woff2`** parses, reports its axes, renders at the axis default, and shows ntk's instancing error — which is exactly where someone hits it, and the message names the fix (ship the `.ttf`).

## Notes

A path on the command line preloads, which is also how it is screenshot:

```
npm run examples:variable-fonts -- /usr/share/fonts/truetype/ubuntu/Ubuntu[wdth,wght].ttf
```

Each pick registers under a fresh private family, because `fonts.load` registers by family name and two files both claiming "Ubuntu" would otherwise become one family with two faces.

`npm test`: 660/660. The `examples/README.md` diff looks large but is one added row plus prettier realigning the table — `git diff -w` is 2 insertions, 1 deletion.
