### PR TITLE
fix(select): a menu long enough to scroll swallowed every click

### DIFF
--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -383,7 +383,19 @@ export function Select({
           },
           h(
             'scrollview',
-            { ref: scrollRef, style: { flexGrow: 1, padding: MENU_PAD } },
+            {
+              ref: scrollRef,
+              // Not a tab stop, and not a focus target for a press either.
+              // A scrollview becomes focusable the moment its content
+              // overflows, so a menu long enough to scroll would take focus
+              // on mousedown — blurring the trigger, whose onBlur closes the
+              // menu, which unmounts the row under the pointer before the
+              // release can turn into a click. The trigger owns the keyboard
+              // for a Select; this pane is scrolled by wheel and by the
+              // arrow keys the trigger already handles.
+              focusable: false,
+              style: { flexGrow: 1, padding: MENU_PAD },
+            },
             normalized.map((option, index) =>
               h(Option, {
                 key: String(option.value),

--- a/test/select-long-menu.test.js
+++ b/test/select-long-menu.test.js
@@ -1,0 +1,160 @@
+// A `Select` whose menu is long enough to scroll must still be clickable.
+//
+// It was not, and the mechanism is worth writing down because every step of
+// it is something a component is supposed to do:
+//
+//   1. a `<scrollview>` becomes focusable the moment its content overflows —
+//      that is what makes a pane of unfocusable content keyboard-reachable
+//   2. so a press inside a menu tall enough to scroll moves focus to the
+//      menu's own scrollview
+//   3. which blurs the trigger, back in the owner window
+//   4. whose `onBlur` closes the menu — correct, and how a click elsewhere
+//      dismisses it
+//   5. so React unmounts the row under the pointer during the *mousedown*
+//      commit, and the release has nothing left to pair with: `onClick` is
+//      the nearest common ancestor of press and release, and the press node
+//      is gone
+//
+// The result was a dropdown that opened, highlighted, scrolled and answered
+// the keyboard — and silently ignored every click. Only past the scroll
+// threshold, which is why it survived: the menus in the examples are short.
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { test } from 'node:test';
+import React from 'react';
+
+import xserver from 'x11/lib/xserver/index.js';
+import { StaticFontSource, createClient } from 'ntk';
+
+import { Select, createRoot } from '../src/index.js';
+
+const require = createRequire(import.meta.url);
+const fontDir = join(
+  dirname(require.resolve('katex/package.json')),
+  'dist',
+  'fonts',
+);
+
+// 28px an item, 220px of menu: seven fit, eight scroll.
+const FITS = 7;
+const SCROLLS = 8;
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function headlessApp() {
+  const server = xserver.createServer({ width: 500, height: 500 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const fontSource = new StaticFontSource();
+  fontSource.add(readFileSync(join(fontDir, 'KaTeX_Main-Regular.ttf')), {
+    family: 'Test Main',
+  });
+  fontSource.alias('sans-serif', 'Test Main');
+  return createClient({ stream: clientEnd, fontSource });
+}
+
+const find = (node, pred, out = []) => {
+  if (pred(node)) out.push(node);
+  for (const child of node.children)
+    if (!child.isWindow) find(child, pred, out);
+  return out;
+};
+
+const click = (wnd, node) => {
+  const x = node.abs.x + node.abs.width / 2;
+  const y = node.abs.y + node.abs.height / 2;
+  wnd.emit('mousedown', { x, y, keycode: 1 });
+  wnd.emit('mouseup', { x, y, keycode: 1 });
+};
+
+/**
+ * Open a Select of `count` options, click the first one, and report what
+ * `onChange` saw. That is the whole assertion: a successful pick closes the
+ * menu itself, so the menu being gone afterwards says nothing — only whether
+ * the press ever became a click does.
+ */
+async function pickFirstOption(count) {
+  const app = await headlessApp();
+  const root = await createRoot({ app });
+  try {
+    const popups = [];
+    const create = app.createWindow.bind(app);
+    app.createWindow = (attrs) => {
+      const wnd = create(attrs);
+      if (attrs?.overrideRedirect) popups.push(wnd);
+      return wnd;
+    };
+
+    const options = Array.from({ length: count }, (_, i) => `opt${i}`);
+    let picked = null;
+    function App() {
+      const [value, setValue] = React.useState(null);
+      return React.createElement(
+        'window',
+        { width: 500, height: 500 },
+        React.createElement(
+          'box',
+          { style: { padding: 20 } },
+          React.createElement(Select, {
+            style: { width: 200 },
+            value,
+            options,
+            placeholder: 'pick…',
+            onChange: (ev) => {
+              picked = ev.value;
+              setValue(ev.value);
+            },
+          }),
+        ),
+      );
+    }
+
+    const created = [];
+    const create2 = app.createWindow;
+    app.createWindow = (attrs) => {
+      const wnd = create2(attrs);
+      created.push(wnd);
+      return wnd;
+    };
+
+    await new Promise((resolve) =>
+      root.render(React.createElement(App), resolve),
+    );
+    await sleep(300);
+    const wnd = created[0];
+
+    const trigger = find(
+      wnd._reactX11Node,
+      (n) => n.props?.role === 'combobox',
+    )[0];
+    assert.ok(trigger, 'the trigger renders');
+    click(wnd, trigger);
+    await sleep(300);
+
+    const menu = popups.at(-1);
+    assert.ok(menu, 'the menu opens');
+    const rows = find(menu._reactX11Node, (n) => n.props?.role === 'option');
+    assert.equal(rows.length, count, 'every option is in the menu');
+
+    click(menu, rows[0]);
+    await sleep(300);
+    return picked;
+  } finally {
+    await app.close();
+  }
+}
+
+test('a menu that fits is clickable', async () => {
+  assert.equal(await pickFirstOption(FITS), 'opt0');
+});
+
+// The regression. One option more than fits, and every click was swallowed.
+test('a menu one option past the scroll threshold is clickable', async () => {
+  assert.equal(await pickFirstOption(SCROLLS), 'opt0');
+});
+
+test('a much longer menu is clickable', async () => {
+  assert.equal(await pickFirstOption(30), 'opt0');
+});


### PR DESCRIPTION
Eight options or more and a `Select` opened, highlighted on hover, scrolled, answered the keyboard — and ignored the mouse completely. Seven or fewer worked fine.

```
options= 6  popup=200x180  content ~180  click -> opt0
options= 7  popup=200x208  content ~208  click -> opt0
options= 8  popup=200x222  content ~236  click -> NOTHING
options= 9  popup=200x222  content ~264  click -> NOTHING
options=12  popup=200x222  content ~348  click -> NOTHING
```

The threshold is the menu overflowing `MAX_MENU_HEIGHT` (220px, at `ITEM_HEIGHT` 28 + padding). That is why it survived this long: every `Select` in the examples and screenshots is short. It turned up in a font-picker with twelve named instances in it.

## Why

Every step is a component doing exactly what it should.

1. A `<scrollview>` becomes focusable **the moment its content overflows** — that is what makes a pane of unfocusable content keyboard-reachable, and `focusableByDefault` is answered from the current layout.
2. So a press inside a menu tall enough to scroll now lands on a focusable node, and `_focusFromPress` moves focus to the menu's own scrollview.
3. That blurs the trigger, back in the owner window.
4. The trigger's `onBlur` closes the menu — also correct, and how a click elsewhere dismisses it.
5. React unmounts the row under the pointer during the **mousedown** commit. The release then has nothing to pair with: a click is dispatched on the nearest common ancestor of press and release, and `EventManager.forget` had already cleared the press node.

The menu shut itself before the click it was waiting for. Traced:

```
--- 12 options ---
   focus before: main= box[combobox]  popup= box[combobox]
   dispatch MouseDown -> text
   downNode CLEARED at:
        at EventManager.forget (events.js:805)
        at detachDeletedInstance (Reconciler.js:411)
        at detachFiberAfterEffects (react-reconciler.development.js:11746)
   focus after:  main= null  popup= null
   popup node destroyed: true
   dispatch MouseUp -> text          <- no Click
```

Against seven options the same trace keeps `downNode`, keeps focus on the trigger, and dispatches `Click`.

## The fix

The scrollview inside a menu should never have been a focus target. The trigger owns the keyboard for a `Select` — arrows move the highlight, Enter picks, Escape closes — and the pane is scrolled by the wheel and by those same arrows. `focusable: false` takes it out of the focus path and changes nothing else about it.

I considered fixing this further out — not moving focus on press into a popup, or having the trigger ignore a blur to its own menu — but both change behaviour for every popup to fix one component that is asking for something it does not want.

**Not shared elsewhere.** `MenuBar`/`ContextMenu` do not put their items in a scrollview, so they never cross the threshold. `Table` and `Tree` have scrollviews that *should* stay focusable — they are panes in the owner window, and being keyboard-reachable is the point.

## Tests

`test/select-long-menu.test.js` opens a menu, clicks its first option and asserts `onChange` fired, on both sides of the threshold:

- **7 options** — the control; passes with and without the fix
- **8 options** — one past it; fails on the parent commit
- **30 options** — well past it; fails on the parent commit

The obvious assertion "the menu is still open after the press" is deliberately not there: a *successful* pick closes the menu itself, so that says nothing either way. Whether the press became a click is the only real signal.

`npm test`: 663/663.
