### PR TITLE
feat(text): textRendering, and it does not reflow

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -551,6 +551,7 @@ run list so wrapping spans the whole content.
 | `color`                                             | text color (inherited by spans)                        |
 | `fontSize`, `fontFamily`, `fontWeight`, `fontStyle` | ntk font style (fontconfig lookup + fallback)          |
 | `fontVariationSettings`                             | a variable font's axes — see below                     |
+| `textRendering`                                     | which glyph path to draw with — see below              |
 | `textAlign`                                         | `left`, `right`, `center`, `start`, `end` (bidi-aware) |
 | `lineHeight`                                        | multiplier over the natural font line height           |
 
@@ -590,6 +591,45 @@ really will ask for hundreds of distinct faces as it is dragged — step the
 control, not the font. See ntk's `docs/fonts.md` for the whole picture,
 including why a variable `.woff2` cannot be instantiated and you want the
 `.ttf`.
+
+### `textRendering`
+
+_ntk ≥ 7.2.0._ CSS's property, picking which glyph path draws the text.
+
+| value                |                                                           |
+| -------------------- | --------------------------------------------------------- |
+| `auto` (default)     | ntk decides from the size — right for UI text             |
+| `geometricPrecision` | glyph origins exactly where shaping asked; nothing cached |
+| `optimizeSpeed`      | ntk's cached glyph bitmaps, at any size                   |
+| `optimizeLegibility` | accepted, means `auto` — there is no hinting to turn on   |
+
+```jsx
+<text style={{ fontSize: 96, textRendering: 'geometricPrecision' }}>
+  Serious by default.
+</text>
+```
+
+**Why display text wants it.** On the cached path a glyph's advance is baked
+into the server-side glyphset as a whole number, because a cached bitmap can
+only land on a whole pixel. Animate a variable font's `wght` and the true
+advances move by hundredths of a pixel — hundredths that accumulate along
+the line until one glyph crosses a rounding boundary and jumps a whole pixel
+on its own while its neighbours stand still. `geometricPrecision` puts every
+glyph where shaping asked, so the line slides instead of stepping.
+
+It inherits into spans and a span may override it, so a headline and the
+body text under it can take different paths in one paragraph.
+
+**It never reflows.** Only draw-time rounding differs; ntk's layout measures
+byte-identically for every value, down to per-run offsets. Changing it drops
+the cached layout — the value rides on the spans inside it — and repaints,
+without marking anything dirty for yoga. So it is safe to flip on a state
+change without the tree moving.
+
+The cost is real: the precise path rasterizes outlines on every draw and
+caches nothing. That is the right trade for text being animated and the
+wrong one for a paragraph that never changes, which is why `auto` is the
+default rather than the other way round.
 
 ## `<textinput>`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^7.1.0",
+        "ntk": "^7.2.0",
         "react-reconciler": "^0.33.0"
       },
       "devDependencies": {
@@ -4034,9 +4034,9 @@
       }
     },
     "node_modules/ntk": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-7.1.0.tgz",
-      "integrity": "sha512-fx9e2SUVI5WBnr3+SplynrapQxc5l78LQSefvtDOLs1aMKrDwqiksj27no30BP6A/yrnoSiwuRSsyJeAzrGpRg==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-7.2.0.tgz",
+      "integrity": "sha512-vVd0zh87s8vmmtm+M/nDwpXOevqSb1lexttQmC8fc5/+sPIV9LHeMewgLd/EnDEODA8ZumK80qbyk5zuvlLmDw==",
       "dependencies": {
         "bidi-js": "^1.0.3",
         "canvas-fontstyle": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^7.1.0",
+    "ntk": "^7.2.0",
     "react-reconciler": "^0.33.0"
   },
   "optionalDependencies": {

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -9,6 +9,7 @@ import {
   textStyleFrom,
   DEFAULT_TEXT_STYLE,
   TEXT_LAYOUT_PROPS,
+  TEXT_PAINT_PROPS,
   flattenStyle,
   validateStyle,
   resolveStyleStates,
@@ -502,6 +503,15 @@ function axesEqual(a, b) {
     if (a[key] !== b[key]) return false;
   }
   return true;
+}
+
+/** Did anything that only changes how the text is *drawn* change? */
+function textPaintStyleChanged(style, before) {
+  if (style === before) return false;
+  for (const key of TEXT_PAINT_PROPS) {
+    if (style[key] !== before[key]) return true;
+  }
+  return false;
 }
 
 /** Did anything the text stack measures or paints with change? */
@@ -2039,10 +2049,37 @@ export class TextNode extends Node {
     if (this.yoga) this.yoga.markDirty();
   }
 
+  /**
+   * The cached layout is stale, but the box it reported cannot have moved.
+   *
+   * `textRendering` rides on the spans inside a layout, so a cached one keeps
+   * answering with the old value and has to go — but it decides only how
+   * glyph origins are rounded at draw time, and ntk's layout measures
+   * byte-identically whichever way it is set. So the layout is dropped
+   * without marking yoga dirty: the next paint calls `_layoutFor` and
+   * rebuilds it, and nothing reflows on the way.
+   */
+  _textPaintChanged() {
+    if (this.isSpan) {
+      this.parent?._textPaintChanged();
+      return;
+    }
+    this._layouts.clear();
+  }
+
   applyProps(newProps, oldProps) {
     const before = this.style;
     super.applyProps(newProps, oldProps);
-    if (!textStyleChanged(this.style, before)) return;
+    if (!textStyleChanged(this.style, before)) {
+      if (!textPaintStyleChanged(this.style, before)) return;
+      this._textPaintChanged();
+      // damage belongs to the node that owns the box; a span has none of its
+      // own. `false` is the whole point of this branch — no layout pass.
+      let owner = this;
+      while (owner && !owner.yoga) owner = owner.parent;
+      this.root?.invalidate(false, owner ?? NO_DAMAGE, 'text');
+      return;
+    }
     this._textContentChanged();
     // `super.applyProps` has already committed this frame, and it decided
     // there was nothing to re-lay-out: none of `fontSize`, `fontWeight`,
@@ -2071,6 +2108,7 @@ export class TextNode extends Node {
           weight: style.weight,
           style: style.style,
           variations: style.variations,
+          textRendering: style.textRendering,
           color: style.color,
         });
       } else if (child.kind === 'text') {

--- a/src/styles.js
+++ b/src/styles.js
@@ -157,6 +157,21 @@ export const TEXT_LAYOUT_PROPS = new Set([
   'textBoxTrim',
 ]);
 
+/**
+ * Text style props that change how the text is **drawn** and provably not
+ * where any of it lands. They still invalidate the cached layout — the value
+ * rides on the spans inside it — but never the box, so changing one repaints
+ * without reflowing.
+ *
+ * `textRendering` is CSS's, and picks the glyph path: `geometricPrecision`
+ * puts glyph origins exactly where shaping asked, `optimizeSpeed` keeps them
+ * on ntk's cached-bitmap path, `auto` lets size decide. Only rounding at
+ * draw time differs — ntk's layout answers byte-identically for all three,
+ * down to per-run offsets — which is what makes it safe to keep out of the
+ * measurement set.
+ */
+export const TEXT_PAINT_PROPS = new Set(['textRendering']);
+
 export const isLayoutProp = (name) =>
   Object.prototype.hasOwnProperty.call(LAYOUT_APPLIERS, name);
 export const isPaintProp = (name) => PAINT_PROPS.has(name);
@@ -193,6 +208,7 @@ const STYLE_PROPS = new Set([
   ...Object.keys(LAYOUT_APPLIERS),
   ...PAINT_PROPS,
   ...TEXT_LAYOUT_PROPS,
+  ...TEXT_PAINT_PROPS,
   'color',
   'borderStyle',
   'transition',
@@ -679,6 +695,7 @@ export function textStyleFrom(props, inherited) {
     // ntk's name for it is `variations`; the prop is spelled after the CSS
     // property, like every other name in this vocabulary
     variations: props.fontVariationSettings ?? inherited.variations,
+    textRendering: props.textRendering ?? inherited.textRendering,
     color: props.color ?? inherited.color,
   };
 }
@@ -689,6 +706,7 @@ export const DEFAULT_TEXT_STYLE = {
   weight: 'normal',
   style: 'normal',
   variations: undefined,
+  textRendering: undefined,
   color: 'black',
 };
 

--- a/src/types/style.d.ts
+++ b/src/types/style.d.ts
@@ -149,6 +149,9 @@ export interface PaintStyle {
  */
 export type TextBoxTrim = 'none' | 'cap-alphabetic';
 
+export type TextRendering =
+  'auto' | 'optimizeSpeed' | 'optimizeLegibility' | 'geometricPrecision';
+
 /** Text properties. All affect measurement except `color`. */
 export interface TextStyle {
   color?: Color;
@@ -161,6 +164,13 @@ export interface TextStyle {
    *  rest. Axes the font does not have are ignored and values clamp to each
    *  axis's range. Compared by value, so an object literal is fine. */
   fontVariationSettings?: Record<string, number>;
+  /** CSS's `text-rendering`, picking the glyph path (ntk >= 7.2.0).
+   *  `'geometricPrecision'` puts glyph origins exactly where shaping asked —
+   *  what display text and animated variable fonts want, since cached glyphs
+   *  can only land on whole pixels. `'optimizeSpeed'` keeps the cached path
+   *  at any size. `'auto'` (default) lets size decide. Changing it repaints
+   *  without reflowing: it cannot move anything. */
+  textRendering?: TextRendering;
   textAlign?: TextAlign;
   lineHeight?: number;
   /** Default `'none'`. Applies to `<text>`; the editable controls keep their

--- a/test/text-rendering.test.js
+++ b/test/text-rendering.test.js
@@ -1,0 +1,271 @@
+// `textRendering` — which glyph path a `<text>` takes.
+//
+// ntk decides that from size by default, which is a good guess for UI text
+// and a bad one for a headline whose weight is under a slider: on the cached
+// path glyph origins round to whole pixels, so as advances drift by
+// hundredths one glyph eventually jumps a whole pixel by itself. This is how
+// a `<text>` says which it wants.
+//
+// react-x11's share is the same two halves as `fontVariationSettings` —
+// carrying it onto the paragraph *and* onto nested spans — plus one thing
+// that property did not have: it must **not** reflow. Only draw-time
+// rounding differs, and ntk's layout measures byte-identically for every
+// value, so a change here is a repaint and nothing more.
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test } from 'node:test';
+import React from 'react';
+
+import xserver from 'x11/lib/xserver/index.js';
+import { StaticFontSource, createClient } from 'ntk';
+
+import { createRoot } from '../src/index.js';
+import { DEFAULT_TEXT_STYLE, textStyleFrom } from '../src/styles.js';
+
+const require = createRequire(import.meta.url);
+const katexFonts = join(
+  dirname(require.resolve('katex/package.json')),
+  'dist',
+  'fonts',
+);
+const VF = join(
+  dirname(fileURLToPath(import.meta.url)),
+  'fixtures',
+  'MonelogicsSubset[wght].ttf',
+);
+
+const W = 300;
+const H = 140;
+const SAMPLE = 'Handgloves';
+
+// --- the seam ---------------------------------------------------------------
+
+test('the prop reaches the style ntk resolves a run with', () => {
+  const style = textStyleFrom(
+    { fontSize: 20, textRendering: 'geometricPrecision' },
+    DEFAULT_TEXT_STYLE,
+  );
+  assert.equal(style.textRendering, 'geometricPrecision');
+});
+
+test('it inherits into spans, and a span may override it', () => {
+  const paragraph = textStyleFrom(
+    { textRendering: 'geometricPrecision' },
+    DEFAULT_TEXT_STYLE,
+  );
+  assert.equal(
+    textStyleFrom({}, paragraph).textRendering,
+    'geometricPrecision',
+  );
+  assert.equal(
+    textStyleFrom({ textRendering: 'optimizeSpeed' }, paragraph).textRendering,
+    'optimizeSpeed',
+  );
+});
+
+test('nothing is carried when nothing was asked for', () => {
+  assert.equal(
+    textStyleFrom({ fontSize: 12 }, DEFAULT_TEXT_STYLE).textRendering,
+    undefined,
+  );
+});
+
+// --- pixels -----------------------------------------------------------------
+
+function app() {
+  const server = xserver.createServer({ width: 400, height: 400 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const fontSource = new StaticFontSource();
+  fontSource.add(readFileSync(VF), { family: 'Test VF' });
+  fontSource.add(readFileSync(join(katexFonts, 'KaTeX_Main-Regular.ttf')), {
+    family: 'Static',
+  });
+  fontSource.alias('sans-serif', 'test vf');
+  return createClient({ stream: clientEnd, fontSource });
+}
+
+const settled = (a) => new Promise((r) => a.X.GetInputFocus(() => r()));
+const readPixels = (ctx) =>
+  new Promise((resolve, reject) =>
+    ctx.getImageData(0, 0, W, H, (err, d) => (err ? reject(err) : resolve(d))),
+  );
+
+/** coverage-weighted ink centroid — where the text actually sits */
+function centroid(image) {
+  let sum = 0;
+  let weighted = 0;
+  for (let y = 0; y < H; y++) {
+    for (let x = 0; x < W; x++) {
+      const c = 255 - image.data[(y * W + x) * 4];
+      if (c > 8) {
+        sum += c;
+        weighted += c * x;
+      }
+    }
+  }
+  return sum ? weighted / sum : 0;
+}
+
+// Yoga hands `<text>` a whole-pixel origin, so the difference reachable from
+// here is the one that matters anyway: *advances*. The cached path bakes an
+// integer advance into each glyph, so ten glyphs of "Handgloves" accumulate
+// ten roundings; the precise path puts each where shaping asked.
+const label = (ref, textRendering, left = 20) =>
+  React.createElement(
+    'window',
+    { width: W, height: H, style: { backgroundColor: '#ffffff' } },
+    React.createElement(
+      'box',
+      { style: { paddingLeft: left, alignItems: 'flex-start' } },
+      React.createElement(
+        'text',
+        {
+          ref,
+          style: {
+            fontFamily: 'Test VF',
+            fontSize: 30,
+            color: '#000000',
+            alignSelf: 'flex-start',
+            textRendering,
+          },
+        },
+        SAMPLE,
+      ),
+    ),
+  );
+
+async function renderAndRead(a, root, element, ref) {
+  await new Promise((resolve) => root.render(element, resolve));
+  await new Promise((r) => setImmediate(r));
+  const node = ref.current;
+  node.root.flush();
+  await settled(a);
+  const ctx = (node.root._ctx ??= node.root.window.getContext('2d'));
+  return { image: await readPixels(ctx), node, width: node.abs.width };
+}
+
+test('geometricPrecision reaches ntk and places glyphs differently', async () => {
+  const a = await app();
+  const client = await createRoot({ app: a });
+  try {
+    const ref = React.createRef();
+    // 30px: the size thresholds would put this on the cached path
+    const auto = await renderAndRead(a, client, label(ref, 'auto'), ref);
+    const fine = await renderAndRead(
+      a,
+      client,
+      label(ref, 'geometricPrecision'),
+      ref,
+    );
+    const speed = await renderAndRead(
+      a,
+      client,
+      label(ref, 'optimizeSpeed'),
+      ref,
+    );
+
+    assert.notEqual(
+      centroid(fine.image).toFixed(3),
+      centroid(auto.image).toFixed(3),
+      'unrounded advances put the ink somewhere the rounded ones cannot',
+    );
+    assert.equal(
+      centroid(speed.image).toFixed(3),
+      centroid(auto.image).toFixed(3),
+      'optimizeSpeed is what auto already chose at this size',
+    );
+  } finally {
+    await a.close();
+  }
+});
+
+test('changing it repaints and does not reflow', async () => {
+  const a = await app();
+  const client = await createRoot({ app: a });
+  try {
+    const ref = React.createRef();
+    const first = await renderAndRead(a, client, label(ref, 'auto', 20), ref);
+    const node = ref.current;
+
+    // the measure function is the reflow: count the times yoga asks for one
+    let measured = 0;
+    const dirty = node.yoga.markDirty.bind(node.yoga);
+    node.yoga.markDirty = () => {
+      measured++;
+      dirty();
+    };
+    let layoutsCleared = 0;
+    const clear = node._layouts.clear.bind(node._layouts);
+    node._layouts.clear = () => {
+      layoutsCleared++;
+      clear();
+    };
+
+    const second = await renderAndRead(
+      a,
+      client,
+      label(ref, 'geometricPrecision', 20),
+      ref,
+    );
+
+    assert.equal(measured, 0, 'a draw-only property must not dirty the layout');
+    assert.equal(layoutsCleared, 1, 'but the cached layout still has to go');
+    assert.equal(second.width, first.width, 'and the box cannot have moved');
+  } finally {
+    await a.close();
+  }
+});
+
+test('a nested span carries its own value', async () => {
+  const a = await app();
+  const client = await createRoot({ app: a });
+  try {
+    const ref = React.createRef();
+    const paragraph = (spanRendering, left) =>
+      React.createElement(
+        'window',
+        { width: W, height: H, style: { backgroundColor: '#ffffff' } },
+        React.createElement(
+          'box',
+          { style: { paddingLeft: left, alignItems: 'flex-start' } },
+          React.createElement(
+            'text',
+            {
+              ref,
+              style: {
+                fontFamily: 'Test VF',
+                fontSize: 30,
+                color: '#000000',
+                alignSelf: 'flex-start',
+              },
+            },
+            React.createElement(
+              'text',
+              { style: { textRendering: spanRendering } },
+              SAMPLE,
+            ),
+          ),
+        ),
+      );
+
+    const plain = await renderAndRead(a, client, paragraph('auto', 20), ref);
+    const precise = await renderAndRead(
+      a,
+      client,
+      paragraph('geometricPrecision', 20),
+      ref,
+    );
+
+    assert.notEqual(
+      centroid(precise.image).toFixed(3),
+      centroid(plain.image).toFixed(3),
+      'a span that asks for precision gets it — collectSpans has to carry it',
+    );
+  } finally {
+    await a.close();
+  }
+});


### PR DESCRIPTION
ntk 7.2.0 lets a run name its own glyph path. This is the style prop, and the dependency bump that brings it in.

```jsx
<text style={{ fontSize: 96, textRendering: 'geometricPrecision' }}>
  Serious by default.
</text>
```

| value | |
| --- | --- |
| `auto` (default) | ntk decides from size — right for UI text |
| `geometricPrecision` | glyph origins exactly where shaping asked; nothing cached |
| `optimizeSpeed` | ntk's cached glyph bitmaps, at any size |
| `optimizeLegibility` | accepted, means `auto` — no hinting to turn on |

On the cached path a glyph's advance is baked into the server-side glyphset as a **whole number**, because a cached bitmap can only land on a whole pixel. Animate a variable font's `wght` and the true advances move by hundredths of a pixel — hundredths that accumulate along the line until one glyph crosses a rounding boundary and jumps a whole pixel on its own while its neighbours stand still.

## The interesting half: it does not reflow

This is the first text style prop for which that is true, and it is worth being explicit about why it is safe.

Only draw-time rounding differs between the values. Asked for the same paragraph three times, once per value, ntk's layout answers **byte-identically**:

```
auto    width/height: 296.2560 91.0800
precise width/height: 296.2560 91.0800
speed   width/height: 296.2560 91.0800

layout identical (auto vs geometricPrecision): true   (width, height, line
layout identical (auto vs optimizeSpeed):      true    count, per-run offsets)
```

So `textRendering` is deliberately **not** in `TEXT_LAYOUT_PROPS`. It gets its own set (`TEXT_PAINT_PROPS`) and its own invalidation path: the cached layout is dropped — the value rides on the spans inside it, and a stale layout would keep painting the old one — but yoga is never marked dirty, and the next paint rebuilds it. A `<text>` can flip this on a state change with nothing in the tree moving.

There is a test that pins exactly that: it counts `markDirty` calls across the change and asserts **zero**, asserts the layout cache was dropped **once**, and asserts the measured box is unchanged.

## The rest is the shape `fontVariationSettings` established

Including the half that broke last time. `collectSpans` names the fields it copies one at a time, so a prop can reach a top-level `<text>` correctly and still vanish on a nested one. Test 6 fails on exactly that missing line — verified by deleting it.

## Tests

Six cases. Three are plumbing (the prop reaching the ntk style, span inheritance and override, absence). Three are pixels:

- `geometricPrecision` at 30px places glyphs differently from `auto`, while `optimizeSpeed` matches `auto` — i.e. the value reaches ntk and means what it says
- changing it repaints without reflowing (the `markDirty` count above)
- a nested span carries its own value

One note on how the pixel tests work, since it surprised me: I first tried to prove this with a fractional *origin*, which is the cleanest demonstration at the ntk level. It does not survive the trip through react-x11 — yoga hands `<text>` a whole-pixel origin, so the origin-rounding half is not reachable from a style at all. What is reachable, and what the reported symptom actually is, is **advance** rounding accumulating across a run. The tests measure that.

`npm test`: 669/669.
