### PR TITLE
feat(window): size a window from its content when it is not given one

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -810,6 +810,21 @@ onDraw>`, `value`, `placeholder`. `children` and event handlers are
   strips `width`/`height` before feeding props to yoga and sizes the root
   yoga node from the _actual_ window size in `flush()` (the user may have
   resized the window).
+- **A `<window>` size may be `'auto'`, and leaving it out means `'auto'`** —
+  sized from its content, capped at the monitor's work area
+  (`src/screens.js`, read once during `createRoot` so the answer is
+  synchronous later). `WindowNode._measureNatural()` runs **before
+  `CreateWindow`**, which is the whole point: the window is born the right
+  size rather than resized into it after mapping. Two things about it are
+  easy to undo by accident. The **second layout pass is not redundant** —
+  the first has no available width so nothing wraps, and a height taken from
+  it cuts wrapped text off; and ntk must **never see the keyword**, so
+  `windowAttributes` drops an auto axis and `realize()` writes the resolved
+  number back. Afterwards `_refit()` keeps an auto window on its content
+  until `_userSized` — a ConfigureNotify that does not match
+  `_requestedSize`, i.e. the user dragging an edge or a WM overriding —
+  hands the size over for good. `_requestedSize` has to name **both** axes on
+  every configure, since the echo does.
 - Windows cannot be nested inside `<box>` (throws); raw strings are only
   legal inside `<text>` (throws otherwise).
 - **Never test an unreleased ntk by symlinking the checkout into

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -102,25 +102,94 @@ mount: [drag-and-drop.md](drag-and-drop.md).
 
 A real X11 window; the flex, paint and event root for its subtree.
 
-| prop                        |                                                                                       |
-| --------------------------- | ------------------------------------------------------------------------------------- |
-| `title`                     | window title (UTF-8, via `WM_NAME` + `_NET_WM_NAME`)                                  |
-| `width`, `height`, `x`, `y` | window geometry (window state, not yoga style — the user may resize)                  |
-| `backgroundColor`           | full-window clear color (default white)                                               |
-| `onResize(ev)`              | ConfigureNotify — the tree reflows automatically. Fires for **moves** too (see below) |
-| `onExpose(ev)`              | after a repaint was required                                                          |
-| `onCloseRequest(ev)`        | WM close button (opts into `WM_DELETE_WINDOW`)                                        |
-| `states`                    | EWMH `_NET_WM_STATE` — controlled, see below                                          |
-| `fullscreen`, `alwaysOnTop` | boolean sugar for two of those states                                                 |
-| `decorations`               | `false` asks the WM for no titlebar or border                                         |
-| `transparent`               | 32-bit ARGB visual — rounded, translucent windows (below)                             |
-| `transientFor`              | ICCCM `WM_TRANSIENT_FOR` — the window this one belongs to (below)                     |
-| `onStatesChange(states)`    | what the window manager actually did                                                  |
-| `theme`                     | palette that `$token` style values resolve against, for this subtree                  |
+| prop                        |                                                                                                                                               |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `title`                     | window title (UTF-8, via `WM_NAME` + `_NET_WM_NAME`)                                                                                          |
+| `width`, `height`, `x`, `y` | window geometry (window state, not yoga style — the user may resize). A size is pixels or `'auto'`, and leaving it out means `'auto'` (below) |
+| `backgroundColor`           | full-window clear color (default white)                                                                                                       |
+| `onResize(ev)`              | ConfigureNotify — the tree reflows automatically. Fires for **moves** too (see below)                                                         |
+| `onExpose(ev)`              | after a repaint was required                                                                                                                  |
+| `onCloseRequest(ev)`        | WM close button (opts into `WM_DELETE_WINDOW`)                                                                                                |
+| `states`                    | EWMH `_NET_WM_STATE` — controlled, see below                                                                                                  |
+| `fullscreen`, `alwaysOnTop` | boolean sugar for two of those states                                                                                                         |
+| `decorations`               | `false` asks the WM for no titlebar or border                                                                                                 |
+| `transparent`               | 32-bit ARGB visual — rounded, translucent windows (below)                                                                                     |
+| `transientFor`              | ICCCM `WM_TRANSIENT_FOR` — the window this one belongs to (below)                                                                             |
+| `onStatesChange(states)`    | what the window manager actually did                                                                                                          |
+| `theme`                     | palette that `$token` style values resolve against, for this subtree                                                                          |
 
 Windows may be nested inside other windows (real X11 child windows).
 **Ref**: the live ntk `Window` — `getContext('2d')`,
 `requestAnimationFrame`, `setCursor`, the whole ntk API.
+
+### Natural size
+
+A window with no `width`/`height` is **sized from its content and capped at
+the screen**. `'auto'` says the same thing out loud, and the two axes are
+independent:
+
+```jsx
+<window title="prefs" />                               {/* natural, both ways */}
+<window width={600} height="auto" />                   {/* height follows the content */}
+<window width="auto" maxWidth={720} minHeight={200} /> {/* auto within your own bounds */}
+```
+
+This is CSS's `width: auto`, read the way CSS reads it for a box whose
+containing block is the viewport but which is not in flow — a float, an
+abspos, an inline-block: **shrink-to-fit**. A top-level window has no
+container to stretch into, and stretching into the screen is what
+`fullscreen` means.
+
+The size is worked out **before `CreateWindow`**, so the window is created
+the right size rather than resized into it after mapping. Nothing is ever on
+screen at the wrong size, and there is no jump to watch for.
+
+**How it is measured**, which is worth knowing because the second step is
+where the surprises are:
+
+1. The tree is laid out with no available width, so nothing wraps and the
+   root reports its **max-content** width.
+2. That is clamped into `[minWidth, min(maxWidth, the screen)]` — the same
+   size-hint props the window manager enforces also bound the auto size,
+   exactly as `min-width`/`max-width` bound `width: auto` in CSS. Where the
+   two disagree, `minWidth` wins, which is CSS's order too.
+3. The tree is laid out **again at that width**, and the height comes from
+   there. A paragraph that had to wrap is taller than step 1 said.
+
+Where this parts company with CSS: shrink-to-fit is
+`min(max(min-content, available), max-content)`, and that `max(…)` means a
+CSS box never shrinks below its min-content size even when it overflows. A
+window cannot be wider than the screen, so the cap wins and the content is
+cut instead.
+
+**The cap** is the usable area of the monitor the window will open on:
+Xinerama's per-monitor rects — so a window on a two-head desktop is bounded
+by one screen and not by both — with `_NET_WORKAREA` taken off it per axis,
+so a panel is not space to grow into. Both are read once while `createRoot()`
+connects. On a server with neither, the cap is the screen; with no display to
+ask at all — the headless mock — there is no cap. The window manager's frame
+is _not_ modelled, so a window that reaches the cap is a titlebar taller than
+the work area and the WM will trim it.
+
+**Afterwards, auto keeps up with the content until something else sets the
+size.** Add a row and the window grows; the moment the user drags an edge, or
+a window manager answers with a size of its own, the window is theirs and
+stops re-fitting. Setting `width` to a number is the app doing the same
+thing, and setting it back to `'auto'` hands it back.
+
+Three things worth knowing before reaching for it:
+
+- A `<scrollview>` reports its **content** height, not a viewport height, so
+  an auto window around a long list opens as tall as the screen. Give the
+  window a `height`, or the scrollview a `maxHeight`, if the scrolling is
+  meant to happen inside a smaller window.
+- With no available width nothing wraps (and yoga defaults `flexShrink` to
+  0 — see [styling.md](styling.md)), so an auto width is the **unwrapped**
+  row. That makes the width font-dependent: the same window is wider under a
+  wide UI face than under a narrow one.
+- Measuring costs an extra layout pass per frame that lays out, for as long
+  as the window is still tracking. A window with both sizes given pays
+  nothing.
 
 ### `onResize` fires for moves
 
@@ -186,7 +255,14 @@ are free, so no `sizeHints` object is needed.
 
 On a `<window>` these names are the window's, not yoga's: `width`/`height`
 are the real geometry the user can drag, and `minWidth`/`maxHeight` are what
-the WM enforces. A window's _contents_ are laid out by its `style`.
+the WM enforces. A window's _contents_ are laid out by its `style`. The size
+hints do double duty on an auto-sized window, where they also bound the
+natural size (above) — so `resizable={false}` pins the window at whatever its
+content measured, which is the fixed-size dialog:
+
+```jsx
+<window resizable={false} windowType="dialog" />
+```
 
 ### `transientFor` — a window that belongs to another
 

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -41,6 +41,7 @@ import {
 } from './trace-registry.js';
 import { beginStartup } from './startup.js';
 import { beginCompositing, endCompositing } from './compositing.js';
+import { beginScreens, endScreens } from './screens.js';
 import { watchAppearance } from './appearance.js';
 import { GlAreaNode } from './glnodes.js';
 import { createRegisteredNode, registeredElements } from './registry.js';
@@ -668,6 +669,14 @@ export async function createRoot(options = {}) {
   // correct itself visibly. One round trip, on a path that is already async.
   await beginCompositing(app);
 
+  // Awaited for the same reason, and it is the same shape of question: a
+  // `<window>` with no size given is sized from its content and capped at the
+  // screen, and the cap has to be a *synchronous* answer because the size is
+  // resolved before CreateWindow. One round trip for the monitor layout and
+  // one for the work area, on a path that is already async, and after this
+  // no window ever has to wait to know how big it is allowed to be.
+  await beginScreens(app);
+
   // The desktop switching between light and dark reaches the widgets through
   // React — `useTheme()` subscribes — but the other theme route is the node
   // tree, which React does not re-render. This is that half: drop the cached
@@ -707,6 +716,7 @@ export async function createRoot(options = {}) {
       if (rest.onUncaughtError) setErrorHandler(app, null);
       stopAppearance();
       endCompositing(app);
+      endScreens(app);
       if (owned) {
         unregisterApp(app);
         await app.close();

--- a/src/components/Dialog.js
+++ b/src/components/Dialog.js
@@ -52,8 +52,13 @@ const DEFAULT_HEIGHT = 170;
  * belongs to the `states` work; it means nothing without the
  * `WM_TRANSIENT_FOR` this now sets, which is why that had to come first.
  *
- * A `<popup>` is a real X window and needs its size up front, hence explicit
- * `width`/`height` rather than sizing to content.
+ * `width`/`height` are explicit rather than sized to content, and now only
+ * because of where the dialog is *placed*: `centeredRect` needs the size to
+ * work out the offset that centres it over its owner, and that is computed
+ * during the render that opens the popup, before anything has been laid out.
+ * The popup itself could size to its content — see "Natural size" in
+ * docs/elements.md — so this is the anchor math's constraint, not the X
+ * window's.
  */
 export function Dialog({
   open,

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -241,10 +241,12 @@ function paintArrow(ctx, { width, height }, side, color) {
  * is given, so that nothing that named a side has to change.)
  *
  * `label` is usually a string, and then the popup is sized from the
- * **measured** text: a `<popup>` is a real X window and needs its size up
- * front rather than after layout. It can equally be an element — a swatch
- * and a hex code, a shortcut in its own type, a whole card — and then the
- * caller says how big with `width`/`height`, for the same reason. The
+ * **measured** text — not because a `<popup>` cannot size itself (it can,
+ * see "Natural size" in docs/elements.md) but because `anchorRect` needs the
+ * size to decide which side of the trigger the hint fits on, and that is
+ * decided during the render that opens it. It can equally be an element — a
+ * swatch and a hex code, a shortcut in its own type, a whole card — and then
+ * the caller says how big with `width`/`height`, for the same reason. The
  * element fills the bubble and draws its own padding; a string gets the
  * bubble's.
  *

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -46,6 +46,7 @@ import {
   transparencyDisabled,
   watchCompositing,
 } from './compositing.js';
+import { availableArea } from './screens.js';
 import { baseTheme } from './palette.js';
 import { callHandler } from './errors.js';
 import { windowIdOf } from './windowid.js';
@@ -517,6 +518,43 @@ function assertNoFlatStyleProps(props, kind, semantic) {
 // style, and there is no element where a name means both.
 const NO_SEMANTIC_NAMES = new Set();
 
+// X window geometry is CARD16 and coordinates are INT16, so a window wider
+// than this cannot be positioned or damaged coherently even where the server
+// accepts it. Nothing sized from content should get near it; it is the
+// backstop for a measure function that answered Infinity.
+const MAX_WINDOW_EXTENT = 32767;
+
+/** One axis of an auto size, bounded the way CSS bounds `width: auto`. */
+function clampExtent(value, min, max) {
+  const v = Math.ceil(Number.isFinite(value) ? value : 0);
+  // CSS's resolution order: the max bound applies first and the min wins
+  // over it, so `minWidth` beats `maxWidth` where an app sets both and they
+  // disagree.
+  const bounded = Math.max(min ?? 0, Math.min(v, max ?? Infinity));
+  // A zero-dimension window is a BadValue outright, so a `<window>` with
+  // nothing in it is 1x1 rather than a protocol error.
+  return Math.max(1, Math.min(bounded, MAX_WINDOW_EXTENT));
+}
+
+/**
+ * Where a `transientFor` owner sits on screen, for picking the monitor a
+ * dialog should be sized against. Accepts everything `windowIdOf` does — a
+ * window ref, a node, a drawn node's ref — and answers null for a raw XID,
+ * which carries no geometry with it.
+ */
+function screenOriginOf(target) {
+  if (target == null || typeof target !== 'object') return null;
+  if ('current' in target && !target.isWindow) {
+    return screenOriginOf(target.current);
+  }
+  return (
+    target._screenOrigin ??
+    target.window?._screenOrigin ??
+    target.root?.window?._screenOrigin ??
+    null
+  );
+}
+
 // Everything a <window> owns: the real geometry, and the WM size hints that
 // constrain it. On a <window> these are never style.
 export const WINDOW_HINT_PROPS = [
@@ -534,10 +572,57 @@ export const WINDOW_HINT_PROPS = [
 ];
 
 /**
+ * A `<window width>`/`<height>` that is not a number: sized from its own
+ * content instead. CSS's initial value for `width`, and the same meaning —
+ * for a box whose containing block is the viewport but which is not in flow
+ * (a float, an abspos, an inline-block) `auto` is shrink-to-fit, and a
+ * top-level window is exactly that shape. It has no container to stretch
+ * into; stretching into the screen is what `fullscreen` means.
+ *
+ * Omitting the prop is the same thing, which is why this is a `??` rather
+ * than an `===`: leaving a size out cannot sensibly mean "some number
+ * somebody picked", and it used to mean ntk's 800x800.
+ */
+export const isAutoSize = (value) => (value ?? 'auto') === 'auto';
+
+/** A size prop reduced to what it means, so the two spellings of auto — the
+ *  keyword and the missing prop — compare equal. */
+const canonicalSize = (value) => (isAutoSize(value) ? 'auto' : value);
+
+/**
+ * A `<window>` size is a number of pixels or `'auto'`, and nothing else.
+ *
+ * Worth its own error because the near misses all come from CSS and all look
+ * reasonable: `'100%'` has no containing block to be a percentage of,
+ * `'fit-content'` is what `'auto'` already means here, and `'600px'` is the
+ * unit X11 works in anyway. Left to itself each of them reaches ntk as a
+ * string and comes back as a `BadValue` on CreateWindow with a sequence
+ * number and nothing else — an X protocol error for what is a typo in JSX.
+ */
+function assertWindowSize(props, kind) {
+  if (!DEV) return;
+  for (const axis of ['width', 'height']) {
+    const value = props[axis];
+    if (value === undefined || value === 'auto') continue;
+    if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+      continue;
+    }
+    throw new Error(
+      `react-x11: <${kind} ${axis}={${JSON.stringify(value)}}> — a window ` +
+        `size is a number of pixels or 'auto' (sized to its content, ` +
+        `capped at the screen), which is also what leaving ${axis} out ` +
+        'means. See docs/elements.md, "Natural size".',
+    );
+  }
+}
+
+/**
  * ntk's Window constructor takes every creation attribute up front. The
- * user-facing shape and ntk's differ in two places: size hints are flat
- * props here and a `sizeHints` object there, and the window background is
- * a style property here and a creation attribute there.
+ * user-facing shape and ntk's differ in three places: size hints are flat
+ * props here and a `sizeHints` object there, the window background is a
+ * style property here and a creation attribute there, and an `'auto'`
+ * width or height is resolved to a number by `realize()` — ntk is handed
+ * pixels or nothing, never the keyword.
  *
  * Event props never travel this way. ntk reads `onKeyDown` & co. off its
  * creation args and registers them as raw listeners (events_map.toSnake),
@@ -556,6 +641,9 @@ export function windowAttributes(props) {
   for (const key of Object.keys(props)) {
     if (key === 'children' || key === 'style' || isEventProp(key)) continue;
     if (key === 'transientFor' || key === 'transparent') continue;
+    if ((key === 'width' || key === 'height') && isAutoSize(props[key])) {
+      continue;
+    }
     if (WINDOW_HINT_PROPS.includes(key)) {
       hints[key] = props[key];
       continue;
@@ -4131,6 +4219,7 @@ export class TextAreaNode extends TextInputNode {
 export class WindowNode extends Node {
   constructor(app, attributes, props) {
     super('window', props, app, { yoga: true });
+    assertWindowSize(props, this.kind);
     this.root = this;
     this.attributes = attributes;
     this.window = null;
@@ -4163,6 +4252,155 @@ export class WindowNode extends Node {
     // Node._childListChanged)
     this._reflowed = new Set();
     this.querySize = null;
+    // The geometry we last asked the server for, and whether anything else
+    // has since decided otherwise. Together they are the rule for `'auto'`:
+    // it keeps up with the content until someone takes the size over, and
+    // the only thing that ever does is the user dragging an edge.
+    this._requestedSize = null;
+    this._userSized = false;
+  }
+
+  /**
+   * The size this window's content wants, for whichever of `width`/`height`
+   * is `'auto'` — CSS shrink-to-fit, then height-for-width.
+   *
+   * 1. Lay the tree out with **no available width**, which is what yoga's
+   *    `undefined` means: every measure function is asked in
+   *    `MEASURE_MODE_UNDEFINED`, text does not wrap, and the root reports
+   *    its max-content width.
+   * 2. Clamp that into `[minWidth, min(maxWidth, the screen)]`.
+   * 3. **Lay out again at the clamped width.** This is the pass that
+   *    matters and the one it is tempting to skip: a paragraph that had to
+   *    wrap at the clamped width is taller than the max-content pass said,
+   *    and a window sized from that first height would cut its own text off.
+   *
+   * Where CSS and X part ways: shrink-to-fit is
+   * `min(max(min-content, available), max-content)`, and that `max(...)`
+   * means a CSS box never goes below its min-content size even when it
+   * overflows. A window cannot be wider than the screen, so the clamp wins
+   * and the content is cut instead.
+   *
+   * Runs before `CreateWindow`, so it must not need one: text measures
+   * through `app.fonts`, which is the connection's, and the clamp was
+   * resolved during `createRoot`. That is the whole point — the window is
+   * *created* at its natural size rather than resized into it after mapping,
+   * so nothing is ever on screen at the wrong size.
+   */
+  _measureNatural() {
+    const props = this.props;
+    const autoW = isAutoSize(props.width);
+    const autoH = isAutoSize(props.height);
+    const yoga = this.yoga;
+    // Where the window will open, for picking a monitor: next to its owner
+    // where it has one, and wherever the WM puts it otherwise.
+    const area = availableArea(this.app, screenOriginOf(props.transientFor));
+    const limit = (max, screen) =>
+      Math.min(max ?? Infinity, screen ?? Infinity, MAX_WINDOW_EXTENT);
+    const availW = limit(props.maxWidth, area?.width);
+    const availH = limit(props.maxHeight, area?.height);
+    if (!yoga) {
+      // Only reachable on a torn-down window, and a size still has to be a
+      // size: fall back to the space on offer rather than handing `'auto'`
+      // through to CreateWindow.
+      return {
+        width: autoW
+          ? clampExtent(availW, props.minWidth, availW)
+          : props.width,
+        height: autoH
+          ? clampExtent(availH, props.minHeight, availH)
+          : props.height,
+      };
+    }
+    if (!autoW && !autoH) return { width: props.width, height: props.height };
+
+    // The root carries whatever size the last flush() pinned on it; clearing
+    // an axis is what makes yoga measure it rather than fill it.
+    yoga.setWidth(autoW ? undefined : props.width);
+    yoga.setHeight(autoH ? undefined : props.height);
+
+    const measure = () => {
+      let width = props.width;
+      if (autoW) {
+        yoga.calculateLayout(
+          undefined,
+          autoH ? undefined : props.height,
+          Yoga.DIRECTION_LTR,
+        );
+        width = clampExtent(yoga.getComputedWidth(), props.minWidth, availW);
+      }
+      // The height-for-width pass. Run even when only the width is auto: it
+      // is the layout the window is about to be created at, so leaving the
+      // tree holding the max-content one would hand `flush()` a stale
+      // arrangement.
+      yoga.calculateLayout(
+        width,
+        autoH ? undefined : props.height,
+        Yoga.DIRECTION_LTR,
+      );
+      const height = autoH
+        ? clampExtent(yoga.getComputedHeight(), props.minHeight, availH)
+        : props.height;
+      return { width, height };
+    };
+
+    // `@width`/`@height` blocks and an auto size are mutually circular: the
+    // query wants a size the measurement has not produced yet. Broken the way
+    // CSS breaks the same cycle for container queries — measure against the
+    // space on offer, then re-resolve against the answer, and measure once
+    // more if that moved anything. **Once**: a second look settles the common
+    // case (a block that turns on below the width the content would have
+    // taken) and a third would only be chasing a layout that oscillates,
+    // which no size can satisfy.
+    this._resolveSizeQueries(
+      autoW ? availW : props.width,
+      autoH ? availH : props.height,
+    );
+    let size = measure();
+    if (this._resolveSizeQueries(size.width, size.height)) size = measure();
+    return size;
+  }
+
+  /**
+   * Keep an `'auto'` window the size of its content while it still owns its
+   * own size. Called from `flush()` on any frame that lays out, which is
+   * every frame where the natural size could have moved.
+   *
+   * One rule covers both kinds of window, which is why it is a rule and not
+   * two behaviours: **auto tracks the content until something else sets the
+   * size.** A `<window>` grows as rows are added to it and stops the moment
+   * the user drags an edge — GTK's behaviour, and right for the same reason:
+   * the size is the app's opinion until it is the user's. Nothing can ever
+   * take a `<popup>`'s size over — it is override-redirect and has no
+   * resize handles — so a menu tracks its items for good.
+   *
+   * The result is applied through the window rather than through props: an
+   * auto size is not something React said, so nothing about it should read
+   * as a prop change or wait for one.
+   */
+  _refit() {
+    if (this._userSized || this.destroyed) return;
+    if (!isAutoSize(this.props.width) && !isAutoSize(this.props.height)) return;
+    const wnd = this.window;
+    if (!wnd) return;
+    const asked = this._requestedSize;
+    const next = this._measureNatural();
+    if (asked && next.width === asked.width && next.height === asked.height) {
+      return;
+    }
+    this._requestedSize = { width: next.width, height: next.height };
+    // Asked for, not assumed. `window.width` stays what the server last said
+    // until the ConfigureNotify lands, and this frame lays out against that
+    // — the echo brings `needsLayout` and an unbounded repaint with it (see
+    // the 'resize' listener), which is the same one-frame settle a
+    // controlled `width` prop change has always had. Writing the new size
+    // onto the window here would be worse than the wait: ntk allocates the
+    // backing pixmap from the resize event, so a frame painted at a size the
+    // pixmap has not reached yet is a frame clipped to the old one.
+    if (typeof wnd.setState === 'function') {
+      wnd.setState({ width: next.width, height: next.height });
+    } else {
+      wnd.resize?.(next.width, next.height);
+    }
   }
 
   /** Create the real X11 window (commit phase only). Children windows are
@@ -4174,6 +4412,13 @@ export class WindowNode extends Node {
     if (parentWindow) {
       attributes.parent = parentWindow;
     }
+    // Before CreateWindow, so an auto-sized window is *born* the right size.
+    // Doing it after would mean a window mapped at 800x800 and corrected a
+    // frame later, which is the jump this exists to avoid.
+    const natural = this._measureNatural();
+    attributes.width = natural.width;
+    attributes.height = natural.height;
+    this._requestedSize = { width: natural.width, height: natural.height };
     // **What the server paints into newly exposed area.** A resize enlarges
     // the window before the app can possibly have drawn the new part, and X
     // fills it with this attribute in the meantime — so without one, growing
@@ -4671,6 +4916,21 @@ export class WindowNode extends Node {
         this.needsLayout = true;
         this.invalidate(true, null, 'resize');
       }
+      // The end of an `'auto'` window's authority over its own size. A
+      // ConfigureNotify that does not match what we last asked for is
+      // somebody else's decision — the user dragging an edge, or a window
+      // manager applying a policy of its own — and from here on the window
+      // is theirs. Growing it back under a user who has just made it smaller
+      // is the one behaviour worse than not fitting the content.
+      //
+      // Checked against `_requestedSize` rather than ntk's `ev.resized`
+      // because our own configures come back as echoes, and every one of
+      // them would otherwise read as the user taking over on the first
+      // re-fit.
+      const asked = this._requestedSize;
+      if (asked && (ev.width !== asked.width || ev.height !== asked.height)) {
+        this._userSized = true;
+      }
       // Where the window sits on screen decides where popups anchored to it
       // belong — and finding that out is a server round trip
       // (TranslateCoordinates), so it is worth not making one per frame of a
@@ -4855,6 +5115,7 @@ export class WindowNode extends Node {
 
   applyProps(newProps, oldProps) {
     const before = oldProps ?? this.props;
+    assertWindowSize(newProps, this.kind);
     const beforeStyle = this.style;
     const themeChanged = newProps.theme !== before.theme;
     this.props = newProps;
@@ -4901,22 +5162,47 @@ export class WindowNode extends Node {
     // only a size change re-lays-out — the window's own coordinate space is
     // untouched by where the window sits on screen, so a pointer-tracking
     // popup does not repaint itself per motion.
+    // Compared after normalising, so that an app switching between an
+    // omitted size and a spelled-out `'auto'` — the same request written two
+    // ways — is not a change and does not reset the state below.
     const sizeChanged =
-      newProps.width !== before.width || newProps.height !== before.height;
+      canonicalSize(newProps.width) !== canonicalSize(before.width) ||
+      canonicalSize(newProps.height) !== canonicalSize(before.height);
     const geometryChanged =
       sizeChanged || newProps.x !== before.x || newProps.y !== before.y;
+    // A size that became a number is the app taking the size over, which is
+    // exactly the state `_userSized` names — and one that became `'auto'` is
+    // the app handing it back, so the window fits its content again on the
+    // next layout even if the user had resized it before.
+    //
+    // The record moves with it, and an axis still on `'auto'` records the
+    // size the window *has*, because that is the one this configure is not
+    // about to change. Without that the echo of a one-axis configure would
+    // disagree with the record on the other axis and read as somebody else
+    // setting the size — locking the window on the app's own update.
+    if (sizeChanged) {
+      this._userSized = false;
+      this._requestedSize = {
+        width: isAutoSize(newProps.width) ? wnd.width : newProps.width,
+        height: isAutoSize(newProps.height) ? wnd.height : newProps.height,
+      };
+    }
     if (geometryChanged) {
       if (typeof wnd.setState === 'function') {
         wnd.setState({
           x: newProps.x,
           y: newProps.y,
-          width: newProps.width,
-          height: newProps.height,
+          // `'auto'` is not a geometry ntk can be given: an axis the app has
+          // handed back is left alone here and resolved by `_refit()` on the
+          // layout this same commit is about to schedule.
+          width: isAutoSize(newProps.width) ? undefined : newProps.width,
+          height: isAutoSize(newProps.height) ? undefined : newProps.height,
         });
       } else {
         if (
-          newProps.width !== before.width ||
-          newProps.height !== before.height
+          sizeChanged &&
+          !isAutoSize(newProps.width) &&
+          !isAutoSize(newProps.height)
         ) {
           wnd.resize?.(newProps.width, newProps.height);
         }
@@ -4955,16 +5241,20 @@ export class WindowNode extends Node {
   _resolveSizeQueries(width, height) {
     if (this._sizeQueryNodes.size === 0) {
       this.querySize = this.querySize ?? { width, height };
-      return;
+      return false;
     }
     if (this.querySize?.width === width && this.querySize?.height === height) {
-      return;
+      return false;
     }
     this.querySize = { width, height };
     for (const node of [...this._sizeQueryNodes]) {
       if (node.destroyed) this._sizeQueryNodes.delete(node);
       else node._sizeQueriesChanged();
     }
+    // Whether the layout may have moved under this, which is what an
+    // auto-sizing pass needs to know: it resolves these against a size it is
+    // still working out, and has to look again if the answer changed.
+    return true;
   }
 
   /** A node in this window started a transition. */
@@ -5146,8 +5436,9 @@ export class WindowNode extends Node {
       this._applyTransientFor(this._pendingTransientFor);
     }
     this._advanceAnimations(now());
-    const width = this.window.width ?? this.props.width ?? 0;
-    const height = this.window.height ?? this.props.height ?? 0;
+    if (this.needsLayout) this._refit();
+    const width = this.window.width ?? this._requestedSize?.width ?? 0;
+    const height = this.window.height ?? this._requestedSize?.height ?? 0;
     let layoutMoved = false;
     // captured before the branch clears it: whether *this* flush ran a
     // layout pass is what decides whether an anchored popup needs a look,

--- a/src/screens.js
+++ b/src/screens.js
@@ -1,0 +1,298 @@
+/**
+ * How big is a window allowed to get before anyone has asked for a size?
+ *
+ * `<window width="auto">` is sized from its content, and the one thing that
+ * bound cannot be is "as large as the content wants" — a paragraph with no
+ * line breaks in it is a window several metres wide. So the natural size is
+ * clamped, and the honest clamp is *the usable area of the monitor the
+ * window will open on*.
+ *
+ * Three tiers, because none of them is available everywhere:
+ *
+ * 1. **A monitor rect.** `screen.pixel_width` is the whole virtual desktop,
+ *    so on a two-head setup it would let an auto window span both monitors —
+ *    which nobody wants and no toolkit does. Xinerama's `QueryScreens`
+ *    answers with one rect per monitor in a single round trip, and every X
+ *    server that speaks RandR emulates it, so this is the cheap universal
+ *    way to ask.
+ * 2. **`_NET_WORKAREA`**, which is the desktop minus the panels and docks
+ *    that reserved space with `_NET_WM_STRUT`. It is defined over the whole
+ *    virtual screen rather than per monitor (an EWMH weakness), so it is
+ *    taken as a *per-axis* bound on top of the monitor rect rather than as a
+ *    rect in its own right: on one head that is exactly the work area, and
+ *    on several it still takes a top or bottom panel off the height.
+ * 3. **The screen**, which every server has.
+ *
+ * And a fourth answer, `null`, meaning "no clamp at all" — the headless mock
+ * has no display to ask, and a test window that measures 4000px wide is more
+ * useful than one silently cut to a screen that does not exist.
+ *
+ * Asked once per connection during `createRoot`, which is already async, so
+ * by the time any window realizes the answer is known *synchronously* — the
+ * natural size has to be resolved before `CreateWindow`, and there is no
+ * round trip available at that point.
+ *
+ * What this deliberately does not model is the **window manager's frame**. A
+ * window sized to exactly the work-area height is taller than that once it
+ * has a titlebar, and the WM will shrink or shove it. EWMH's answer is
+ * `_NET_REQUEST_FRAME_EXTENTS`, which a client sends *before* mapping and
+ * the WM replies to by writing `_NET_FRAME_EXTENTS` — but that is a round
+ * trip in the middle of a synchronous `realize()`, and plenty of window
+ * managers never answer it. Letting the WM have the last word costs a
+ * clamped-to-the-edge window one correction it would have made anyway.
+ */
+
+const sessions = new WeakMap();
+
+const PROPERTY_NOTIFY = 28;
+const PROPERTY_CHANGE_MASK = 4194304; // x11.eventMask.PropertyChange
+const WORKAREA_PROPERTY = '_NET_WORKAREA';
+
+/**
+ * What a connection knows about its outputs. `monitors` is null until
+ * Xinerama has answered (or for good, where it never does); `workArea` is
+ * null until the desktop has published one. Both are advisory — `available()`
+ * degrades through them in order and always has the screen to fall back on.
+ */
+class ScreenSession {
+  constructor(app) {
+    this.app = app;
+    this.monitors = null;
+    this.workArea = null;
+    this.stopped = false;
+    this._workAreaAtom = null;
+  }
+
+  stop() {
+    this.stopped = true;
+  }
+
+  /** The screen's own size — the tier everything falls back to. */
+  get screenRect() {
+    const screen = (this.app?.display ?? this.app?.X?.display)?.screen?.[0];
+    if (!screen?.pixel_width) return null;
+    return {
+      x: 0,
+      y: 0,
+      width: screen.pixel_width,
+      height: screen.pixel_height,
+    };
+  }
+}
+
+/** The monitor a point is on, or the largest one when it is on none (a
+ *  window whose owner the WM has not placed yet, or coordinates from a
+ *  screen layout that has since changed). */
+function monitorAt(monitors, point) {
+  if (!monitors?.length) return null;
+  if (point) {
+    for (const m of monitors) {
+      if (
+        point.x >= m.x &&
+        point.x < m.x + m.width &&
+        point.y >= m.y &&
+        point.y < m.y + m.height
+      ) {
+        return m;
+      }
+    }
+  }
+  let best = monitors[0];
+  for (const m of monitors) {
+    if (m.width * m.height > best.width * best.height) best = m;
+  }
+  return best;
+}
+
+/**
+ * The rect an auto-sized window may grow into, or `null` where there is
+ * nothing to ask. `near` is a screen-coordinate point the window will open
+ * next to — a `transientFor` owner's origin, in practice — and picks the
+ * monitor when there are several.
+ */
+export function availableArea(app, near = null) {
+  const session = sessions.get(app);
+  const screen = session?.screenRect ?? null;
+  if (!session) return screen;
+  const monitor = monitorAt(session.monitors, near) ?? screen;
+  if (!monitor) return null;
+  const work = session.workArea;
+  if (!work) return monitor;
+  // Per axis, not as a rect: `_NET_WORKAREA` spans the whole virtual screen,
+  // so intersecting it with a monitor would only ever give the monitor back
+  // on a multi-head desktop. Its *extent* is still the useful part.
+  return {
+    x: monitor.x,
+    y: monitor.y,
+    width: Math.min(monitor.width, work.width),
+    height: Math.min(monitor.height, work.height),
+  };
+}
+
+/**
+ * Start reading the screen layout on `app`. Resolves once the first answer
+ * is in, so `createRoot` can await it and every window realized afterwards
+ * sizes against a settled value.
+ *
+ * Never rejects. A server with no Xinerama, a desktop with no work area, an
+ * ntk too old to reach the raw connection and a headless mock all degrade to
+ * the next tier down and stop there.
+ */
+export async function beginScreens(app) {
+  let session = sessions.get(app);
+  if (session) return session;
+  session = new ScreenSession(app);
+  sessions.set(app, session);
+
+  const X = app?.X;
+  if (!X || typeof X.GetProperty !== 'function') return session; // mock app
+
+  try {
+    session.monitors = await queryMonitors(app);
+    session._workAreaAtom = await internAtom(X, WORKAREA_PROPERTY);
+    session.workArea = await readWorkArea(session);
+    watchLayout(session);
+  } catch {
+    // every failure here means "one tier less to work with", which is what
+    // the nulls already say
+  }
+  return session;
+}
+
+/**
+ * Both of these change while an app runs — a monitor is plugged in, a panel
+ * is added or auto-hidden — and both announce themselves on the root window,
+ * so one `PropertyChange` selection covers them. A window already on screen
+ * keeps its size; this is for whatever opens next.
+ *
+ * RandR's own `ScreenChangeNotify` would be the direct signal for the first
+ * one, but it needs the extension selected and an event mask on top of this,
+ * and the WM republishes `_NET_WORKAREA` on a layout change anyway.
+ */
+function watchLayout(session) {
+  const X = session.app.X;
+  const root = X.display?.screen?.[0]?.root;
+  if (root == null) return;
+  // PropertyChange on a window we do not own. Legal and shared — every
+  // panel-aware application on the desktop selects this same event.
+  X.ChangeWindowAttributes(root, { eventMask: PROPERTY_CHANGE_MASK }, () => {});
+  X.on('event', (ev) => {
+    if (session.stopped) return;
+    if (ev.type !== PROPERTY_NOTIFY || ev.wid !== root) return;
+    if (ev.atom !== session._workAreaAtom) return;
+    Promise.all([queryMonitors(session.app), readWorkArea(session)]).then(
+      ([monitors, workArea]) => {
+        if (session.stopped) return;
+        if (monitors) session.monitors = monitors;
+        session.workArea = workArea;
+      },
+      () => {},
+    );
+  });
+}
+
+/** One rect per monitor, or null where the server has no Xinerama — and null
+ *  for the single fake screen a server with the extension present but
+ *  inactive reports, which carries no more than `screenRect` already does. */
+function queryMonitors(app) {
+  return new Promise((resolve) => {
+    try {
+      app.X.require('xinerama', (err, ext) => {
+        if (err || !ext?.QueryScreens) return resolve(null);
+        ext.QueryScreens((screensError, screens) =>
+          resolve(
+            screensError || !screens?.length
+              ? null
+              : screens.map((s) => ({
+                  x: s.x,
+                  y: s.y,
+                  width: s.width,
+                  height: s.height,
+                })),
+          ),
+        );
+      });
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
+/**
+ * `_NET_WORKAREA` is four CARDINALs per desktop — x, y, width, height — and
+ * the current desktop's is the one that matters. Reading only the first is
+ * the common approximation and it is wrong on a desktop that reserves space
+ * differently per workspace, so `_NET_CURRENT_DESKTOP` picks the entry.
+ */
+async function readWorkArea(session) {
+  const X = session.app.X;
+  const root = X.display?.screen?.[0]?.root;
+  if (root == null || session._workAreaAtom == null) return null;
+  const prop = await getProperty(X, root, session._workAreaAtom);
+  const data = prop?.data;
+  if (!data || data.length < 16) return null;
+  const desktops = Math.floor(data.length / 16);
+  const current = Math.min(await currentDesktop(session), desktops - 1);
+  const off = Math.max(0, current) * 16;
+  const width = data.readUInt32LE(off + 8);
+  const height = data.readUInt32LE(off + 12);
+  if (!(width > 0 && height > 0)) return null;
+  return {
+    x: data.readInt32LE(off),
+    y: data.readInt32LE(off + 4),
+    width,
+    height,
+  };
+}
+
+async function currentDesktop(session) {
+  const X = session.app.X;
+  const root = X.display?.screen?.[0]?.root;
+  try {
+    const atom = await internAtom(X, '_NET_CURRENT_DESKTOP');
+    const prop = await getProperty(X, root, atom);
+    return prop?.data?.length >= 4 ? prop.data.readUInt32LE(0) : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function internAtom(X, name) {
+  return new Promise((resolve, reject) =>
+    X.InternAtom(false, name, (err, atom) =>
+      err ? reject(err) : resolve(atom),
+    ),
+  );
+}
+
+function getProperty(X, wid, atom) {
+  return new Promise((resolve) =>
+    X.GetProperty(0, wid, atom, 0, 0, 0x1fffffff, (err, prop) =>
+      resolve(err ? null : prop),
+    ),
+  );
+}
+
+/** Tear down with the root that started it. */
+export function endScreens(app) {
+  const session = sessions.get(app);
+  if (!session) return;
+  session.stop();
+  sessions.delete(app);
+}
+
+/**
+ * Test seam: state a screen layout without an X server, the way
+ * `setCompositingForTests` states a compositor. `null` for either argument
+ * leaves that tier unknown, which is how the fallbacks are exercised.
+ */
+export function setScreensForTests(app, { monitors = null, workArea = null }) {
+  let session = sessions.get(app);
+  if (!session) {
+    session = new ScreenSession(app);
+    sessions.set(app, session);
+  }
+  session.monitors = monitors;
+  session.workArea = workArea;
+  return session;
+}

--- a/src/testing/mock-app.js
+++ b/src/testing/mock-app.js
@@ -5,6 +5,7 @@ import { loadLayout } from 'ntk';
 
 import { setAppearanceForTests } from '../appearance.js';
 import { setCompositingForTests } from '../compositing.js';
+import { setScreensForTests } from '../screens.js';
 
 // ntk 5 loads the layout engine's WebAssembly in createClient() rather than
 // at import time — that is what keeps top-level await out of the bundle, and
@@ -349,6 +350,16 @@ export function createMockApp() {
   // light palette. `setAppearanceForTests({ colorScheme: 'dark' })` is the
   // other half of the matrix.
   setAppearanceForTests({});
+  // And a monitor, for the third reason of the same kind: a `<window>` with
+  // no size is sized from its content and capped at the screen, and a mock
+  // with no screen to cap against would let a headless test grow a window to
+  // a size no desktop would ever have given it. One 1280x800 output, which
+  // is a modest laptop — big enough not to be in the way of a test that is
+  // about something else, small enough that a test about the cap can reach
+  // it. `setScreensForTests(app, {})` takes it away again.
+  setScreensForTests(app, {
+    monitors: [{ x: 0, y: 0, width: 1280, height: 800 }],
+  });
   return app;
 }
 

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -93,9 +93,17 @@ export interface WindowProps
   ref?: Ref<NtkWindow>;
   /** Window title (UTF-8, via `WM_NAME` + `_NET_WM_NAME`). */
   title?: string;
-  /** Window geometry — window state, not yoga style: the user may resize. */
-  width?: number;
-  height?: number;
+  /**
+   * Window geometry — window state, not yoga style: the user may resize.
+   *
+   * `'auto'`, which is also what leaving the prop out means, sizes the
+   * window from its content and caps it at the screen — CSS's `width: auto`
+   * for a box that shrinks to fit. The two axes are independent, so
+   * `width={600}` with no `height` gives a window whose height follows its
+   * content at that width.
+   */
+  width?: number | 'auto';
+  height?: number | 'auto';
   x?: number;
   y?: number;
   /** Palette that `$token` style values resolve against, for this subtree. */

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1272,3 +1272,62 @@ test('textBoxTrim: cap-alphabetic centres a label on its capitals', async () => 
     await app.close();
   }
 });
+
+test('a window with no size fits its text, and wraps to fit the screen', async () => {
+  // The claim the mock-app tests cannot make: an auto size measured through
+  // real glyph metrics, and the height-for-width pass that a wrapping
+  // paragraph is the whole reason for.
+  const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
+  try {
+    const label = 'Fit me';
+    const wnd = await render(
+      React.createElement(
+        'window',
+        { title: 'natural' },
+        React.createElement(
+          'text',
+          { style: { padding: 10, fontSize: 20 } },
+          label,
+        ),
+      ),
+      x11Root,
+    );
+    await settle(app);
+
+    const node = wnd._reactX11Node;
+    const text = node.children[0];
+    // the window is the text's own box, padding included — no screen
+    // involved, since the label is nowhere near 640 wide
+    assert.strictEqual(wnd.width, Math.ceil(text.abs.width));
+    assert.strictEqual(wnd.height, Math.ceil(text.abs.height));
+    assert.ok(wnd.width > 20 && wnd.height > 20, 'the glyphs were measured');
+    assert.ok(wnd.width < 640, 'and it did not need the whole screen');
+
+    // A paragraph with no line breaks in it: max-content is far wider than
+    // the 640x480 server, so the width clamps and the height has to come
+    // from a second pass at the clamped width. A window sized from the
+    // max-content height would be one line tall and cut off every line
+    // after the first.
+    const long = `${label} `.repeat(200);
+    const wide = await render(
+      React.createElement(
+        'window',
+        { key: 'wide', title: 'wrapped' },
+        React.createElement('text', { style: { fontSize: 20 } }, long),
+      ),
+      x11Root,
+    );
+    await settle(app);
+    assert.strictEqual(wide.width, 640, 'capped at the screen');
+    assert.ok(
+      wide.height > 40,
+      `wrapped text is more than one line tall (got ${wide.height})`,
+    );
+    assert.ok(wide.height <= 480, 'and still no taller than the screen');
+
+    await x11Root.unmount();
+  } finally {
+    await app.close();
+  }
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -267,6 +267,16 @@ const _svg = <svg source="<svg/>" height={40} />;
 // @ts-expect-error — <tex> ink colour is style={{ color }}
 const _inked = <tex source="x^2" color="#222" />;
 
+// A <window> size is pixels or 'auto', and leaving it out is the same
+// request as 'auto' — the two axes are independent.
+const _natural = <window title="natural" />;
+const _autoBoth = <window width="auto" height="auto" />;
+const _heightForWidth = <window width={600} height="auto" maxHeight={800} />;
+// @ts-expect-error — 'fit-content' is what 'auto' already means here
+const _fitContent = <window width="fit-content" />;
+// @ts-expect-error — there is no containing block to be a percentage of
+const _percent = <window height="100%" />;
+
 // --- popups ----------------------------------------------------------------
 
 function Popup() {

--- a/test/window-autosize.test.js
+++ b/test/window-autosize.test.js
@@ -1,0 +1,364 @@
+// `<window>` sizing itself from its content — CSS's `width: auto`, which is
+// also what leaving the prop out means.
+//
+// Headless, so there are no fonts and text measures 0x0 (see AGENTS.md): the
+// content here is sized boxes, and the height-for-width case is built out of
+// `flexWrap` rather than out of a wrapping paragraph. `test/integration.test.js`
+// is where the same thing is asserted against real glyphs.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import { createRoot } from '../src/index.js';
+import { createMockApp } from './helpers/mock-app.js';
+import { setScreensForTests } from '../src/screens.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+/** Render one tree and hand back the mock window it created. */
+async function mount(element, { screens } = {}) {
+  const app = createMockApp();
+  if (screens !== undefined) setScreensForTests(app, screens);
+  const root = await createRoot({ app });
+  root.render(element);
+  await tick();
+  return { app, root, wnd: app.windows[0] };
+}
+
+const box = (style, key) => h('box', { key, style });
+
+test('a window with no size is as big as its content', async () => {
+  const { wnd, root } = await mount(
+    h(
+      'window',
+      { title: 'natural' },
+      h(
+        'box',
+        { style: { padding: 10, flexDirection: 'row', gap: 8 } },
+        box({ width: 120, height: 40 }, 'a'),
+        box({ width: 300, height: 80 }, 'b'),
+      ),
+    ),
+  );
+  // 10 + 120 + 8 + 300 + 10 across, 10 + 80 + 10 down
+  assert.strictEqual(wnd.width, 448);
+  assert.strictEqual(wnd.height, 100);
+  await root.unmount();
+});
+
+test("width='auto' is the same request as leaving width out", async () => {
+  const content = box({ width: 210, height: 90 }, 'only');
+  const omitted = await mount(h('window', null, content));
+  const spelled = await mount(
+    h('window', { width: 'auto', height: 'auto' }, content),
+  );
+  assert.deepStrictEqual(
+    [omitted.wnd.width, omitted.wnd.height],
+    [spelled.wnd.width, spelled.wnd.height],
+  );
+  assert.strictEqual(spelled.wnd.width, 210);
+  await omitted.root.unmount();
+  await spelled.root.unmount();
+});
+
+test('the size is settled before the window is mapped', async () => {
+  // The whole point of measuring in realize() rather than after the first
+  // layout: the window is *created* at its natural size, so nothing is ever
+  // on screen at the wrong one. A resize before or after the map would both
+  // be a visible jump.
+  const { wnd, root } = await mount(
+    h('window', null, box({ width: 240, height: 160 })),
+  );
+  assert.strictEqual(wnd.attributes.width, 240, 'sized at CreateWindow');
+  assert.strictEqual(wnd.attributes.height, 160);
+  assert.deepStrictEqual(
+    wnd.calls.filter(([name]) => name === 'resize'),
+    [],
+    'and never resized into place afterwards',
+  );
+  assert.ok(
+    wnd.calls.some(([name]) => name === 'map'),
+    'the window really did map',
+  );
+  await root.unmount();
+});
+
+test('a window is never bigger than the monitor it opens on', async () => {
+  const { wnd, root } = await mount(
+    h('window', null, box({ width: 5000, height: 5000 })),
+    { screens: { monitors: [{ x: 0, y: 0, width: 400, height: 300 }] } },
+  );
+  assert.strictEqual(wnd.width, 400);
+  assert.strictEqual(wnd.height, 300);
+  await root.unmount();
+});
+
+test('the work area takes a panel off the monitor', async () => {
+  const { wnd, root } = await mount(
+    h('window', null, box({ width: 5000, height: 5000 })),
+    {
+      screens: {
+        monitors: [{ x: 0, y: 0, width: 1280, height: 800 }],
+        workArea: { x: 0, y: 28, width: 1280, height: 744 },
+      },
+    },
+  );
+  assert.strictEqual(wnd.width, 1280);
+  assert.strictEqual(wnd.height, 744, 'the panel is not space to grow into');
+  await root.unmount();
+});
+
+test('with several monitors, a dialog is sized against its owner’s', async () => {
+  const app = createMockApp();
+  setScreensForTests(app, {
+    monitors: [
+      { x: 0, y: 0, width: 1920, height: 1080 },
+      { x: 1920, y: 0, width: 800, height: 600 },
+    ],
+  });
+  const root = await createRoot({ app });
+  const owner = { current: null };
+  root.render(
+    h(
+      'window',
+      { ref: owner, width: 300, height: 200 },
+      h('popup', {
+        transientFor: owner,
+        overrideRedirect: false,
+        children: box({ width: 4000, height: 4000 }),
+      }),
+    ),
+  );
+  await tick();
+  // the owner is on the small right-hand monitor
+  app.windows[0]._screenOrigin = { x: 2000, y: 100 };
+  const dialog = app.windows[1];
+  dialog._reactX11Node._refit();
+  assert.strictEqual(dialog.width, 800, 'the monitor it will open on');
+  assert.strictEqual(dialog.height, 600);
+  await root.unmount();
+});
+
+test('with no screen to ask, nothing is capped', async () => {
+  const { wnd, root } = await mount(
+    h('window', null, box({ width: 4000, height: 40 })),
+    { screens: {} },
+  );
+  assert.strictEqual(wnd.width, 4000);
+  await root.unmount();
+});
+
+test('minWidth and maxHeight bound the natural size, min winning', async () => {
+  const { wnd, root } = await mount(
+    h(
+      'window',
+      { maxWidth: 200, minWidth: 260, minHeight: 500, maxHeight: 600 },
+      box({ width: 900, height: 20 }),
+    ),
+  );
+  // CSS's order: max applies, then min wins over it
+  assert.strictEqual(wnd.width, 260);
+  assert.strictEqual(wnd.height, 500);
+  await root.unmount();
+});
+
+test('a fixed width with an auto height is height-for-width', async () => {
+  // Three 100-wide chips wrapping in a 250-wide window is two rows, not one
+  // — the height has to come from a layout run at the width the window will
+  // actually be, which is the pass it is tempting to skip.
+  const { wnd, root } = await mount(
+    h(
+      'window',
+      { width: 250 },
+      h(
+        'box',
+        { style: { flexDirection: 'row', flexWrap: 'wrap' } },
+        box({ width: 100, height: 30 }, 'a'),
+        box({ width: 100, height: 30 }, 'b'),
+        box({ width: 100, height: 30 }, 'c'),
+      ),
+    ),
+  );
+  assert.strictEqual(wnd.width, 250, 'the width was the app’s to say');
+  assert.strictEqual(wnd.height, 60, 'two rows, measured at 250');
+  await root.unmount();
+});
+
+test('an empty window is 1x1 rather than a BadValue', async () => {
+  const { wnd, root } = await mount(h('window', { title: 'nothing' }));
+  assert.strictEqual(wnd.width, 1);
+  assert.strictEqual(wnd.height, 1);
+  await root.unmount();
+});
+
+test('an explicit size is passed through untouched', async () => {
+  const { wnd, root } = await mount(
+    h('window', { width: 640, height: 480 }, box({ width: 20, height: 20 })),
+  );
+  assert.strictEqual(wnd.width, 640);
+  assert.strictEqual(wnd.height, 480);
+  await root.unmount();
+});
+
+test('a size that is neither a number nor auto says what to write', async () => {
+  const app = createMockApp();
+  const errors = [];
+  const root = await createRoot({
+    app,
+    onUncaughtError: (e) => errors.push(e),
+  });
+  root.render(h('window', { width: '100%' }));
+  await tick();
+  assert.strictEqual(errors.length, 1);
+  assert.match(errors[0].message, /width=\{"100%"\}/);
+  assert.match(errors[0].message, /a number of pixels or 'auto'/);
+  await root.unmount();
+});
+
+// --- keeping up with the content -------------------------------------------
+
+function Rows({ n, ...props }) {
+  return h(
+    'window',
+    { title: 'rows', ...props },
+    ...Array.from({ length: n }, (_, i) => box({ width: 100, height: 30 }, i)),
+  );
+}
+
+test('an auto window grows with its content', async () => {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(h(Rows, { n: 2 }));
+  await tick();
+  const wnd = app.windows[0];
+  assert.strictEqual(wnd.height, 60);
+
+  root.render(h(Rows, { n: 5 }));
+  await tick();
+  assert.strictEqual(wnd.height, 150, 'three more rows, three more times 30');
+  await root.unmount();
+});
+
+test('…until the user resizes it, and then it is theirs', async () => {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(h(Rows, { n: 2 }));
+  await tick();
+  const wnd = app.windows[0];
+
+  // what a resize drag delivers: a ConfigureNotify for a size we never asked
+  // for
+  wnd.width = 400;
+  wnd.height = 400;
+  wnd.emit('resize', { width: 400, height: 400, resized: true, moved: false });
+  await tick();
+
+  root.render(h(Rows, { n: 8 }));
+  await tick();
+  assert.strictEqual(wnd.width, 400, 'the size the user chose stands');
+  assert.strictEqual(wnd.height, 400);
+  await root.unmount();
+});
+
+test('a window manager that overrides the size keeps it', async () => {
+  // Same rule from the other side: a tiling WM answers the natural size with
+  // one of its own, and re-asking every frame would be a fight it wins.
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(h(Rows, { n: 2 }));
+  await tick();
+  const wnd = app.windows[0];
+  wnd.width = 960;
+  wnd.height = 540;
+  wnd.emit('resize', { width: 960, height: 540, resized: true, moved: false });
+  await tick();
+
+  root.render(h(Rows, { n: 6 }));
+  await tick();
+  assert.strictEqual(wnd.height, 540);
+  await root.unmount();
+});
+
+test('the echo of our own configure is not the user taking over', async () => {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(h(Rows, { n: 2 }));
+  await tick();
+  const wnd = app.windows[0];
+  // the server confirming the size we asked for
+  wnd.emit('resize', { width: 100, height: 60, resized: true, moved: false });
+  await tick();
+
+  root.render(h(Rows, { n: 4 }));
+  await tick();
+  assert.strictEqual(wnd.height, 120, 'still tracking');
+  await root.unmount();
+});
+
+test('handing the size back to auto starts it fitting again', async () => {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(h(Rows, { n: 2, width: 500, height: 500 }));
+  await tick();
+  const wnd = app.windows[0];
+  assert.strictEqual(wnd.height, 500);
+
+  root.render(h(Rows, { n: 2 }));
+  await tick();
+  assert.strictEqual(wnd.height, 60, 'back to the content');
+  await root.unmount();
+});
+
+test('a size query is answered against the size the window ends up', async () => {
+  // The circular case: the block only applies below 600, and whether it does
+  // decides how wide the content is. One extra look settles it.
+  const { wnd, root } = await mount(
+    h(
+      'window',
+      null,
+      h(
+        'box',
+        {
+          style: {
+            flexDirection: 'row',
+            '@width >= 600': { flexDirection: 'column' },
+          },
+        },
+        box({ width: 120, height: 40 }, 'a'),
+        box({ width: 120, height: 40 }, 'b'),
+      ),
+    ),
+  );
+  assert.strictEqual(wnd.width, 240, 'a row: 240 wide, which is under 600');
+  assert.strictEqual(wnd.height, 40);
+  await root.unmount();
+});
+
+test('an app changing one axis does not lock the other', async () => {
+  // A one-axis configure comes back as a ConfigureNotify covering *both*, so
+  // the record of what was asked for has to cover both too — otherwise the
+  // app's own update reads as somebody else setting the size, and the auto
+  // axis stops tracking on the first `width` change.
+  //
+  // The order is the point, and it is the real one: on a live connection the
+  // configure goes out during the commit and the echo can land before the
+  // frame that would have re-measured. So the echo is delivered here between
+  // the render and the flush, not after both.
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(h(Rows, { n: 2, width: 300 }));
+  await tick();
+  const wnd = app.windows[0];
+  assert.strictEqual(wnd.height, 60, 'the auto axis fitted its two rows');
+
+  root.render(h(Rows, { n: 2, width: 420 }));
+  wnd.width = 420;
+  wnd.emit('resize', { width: 420, height: 60, resized: true, moved: false });
+  await tick();
+
+  root.render(h(Rows, { n: 5, width: 420 }));
+  await tick();
+  assert.strictEqual(wnd.width, 420, 'the width is still the app’s');
+  assert.strictEqual(wnd.height, 150, 'and the height is still tracking');
+  await root.unmount();
+});


### PR DESCRIPTION
A `<window>` with no `width`/`height` opened at ntk's 800x800 — a placeholder, not a decision, and nothing to do with what was in it. Now it is **sized from its content and capped at the screen**. `'auto'` says the same thing out loud, and the two axes are independent:

```jsx
<window title="prefs" />                               {/* natural, capped at the screen */}
<window width={600} height="auto" />                   {/* height follows the content */}
<window width="auto" maxWidth={720} minHeight={200} /> {/* auto within your own bounds */}
```

This is CSS's `width: auto`, read the way CSS reads it for a box whose containing block is the viewport but which is not in flow — a float, an abspos, an inline-block: **shrink-to-fit**. A top-level window has no container to stretch into, and stretching into the screen is what `fullscreen` means.

<!-- drag in: auto-1.png -->
<!-- drag in: auto-2.png -->

_The same window on a real server with a real WM: created at 383x163, then 433x247 after three rows were added. `GetGeometry` confirms both._

## It lands before CreateWindow

That was the part worth getting right — the window is *born* the right size rather than mapped at one size and corrected a frame later, so there is no jump to watch for.

It can be, because by the time `appendChildToContainer` realizes the tree, React has completed the whole subtree bottom-up, every node has its yoga node with layout style applied from its constructor, and text measures through `app.fonts` — the connection's, not the window's. None of it needs a window to exist.

`test/window-autosize.test.js` asserts this directly: `attributes.width` is the measured size, and no `resize` ever appears in the call log.

## How it is measured

`WindowNode._measureNatural()` is CSS shrink-to-fit followed by height-for-width:

1. Lay out with **no available width** — yoga's `undefined`, so every measure function is asked in `MEASURE_MODE_UNDEFINED`, nothing wraps, and the root reports its **max-content** width.
2. Clamp into `[minWidth, min(maxWidth, screen)]`. The size hints the WM already enforces bound the auto size too, exactly as `min-width`/`max-width` bound `width: auto` in CSS — and `minWidth` wins over `maxWidth`, which is CSS's order.
3. **Lay out again at that width** for the height.

Step 3 is the one it is tempting to skip. A paragraph that had to wrap is taller than step 1 said, and a window sized from that height cuts its own text off. `test/integration.test.js` pins it against real glyph metrics on the in-process server: a 200-repetition paragraph clamps to the 640px screen and comes back many lines tall.

Where this parts company with CSS: shrink-to-fit is `min(max(min-content, available), max-content)`, and that `max(…)` means a CSS box never shrinks below min-content even when it overflows. A window cannot be wider than the screen, so the cap wins and the content is cut instead.

## The cap

`src/screens.js`, three tiers because none is available everywhere:

1. **Xinerama's per-monitor rects** — `screen.pixel_width` is the whole virtual desktop, so on two heads it would let an auto window span both. `QueryScreens` is one round trip and every RandR server emulates it.
2. **`_NET_WORKAREA`**, taken off per axis rather than intersected as a rect: it spans the whole virtual screen (an EWMH weakness), so its *extent* is the useful part. A panel is not space to grow into.
3. **The screen**, which every server has. And `null` — no cap at all — for the headless mock.

Read once during `createRoot`, `await`ed beside `beginCompositing` and for the same reason already written down there: the answer has to be known *synchronously* when `realize()` asks, because there is no round trip available at that point.

**Not modelled: the WM frame.** A window sized to exactly the work-area height is a titlebar taller than that. `_NET_REQUEST_FRAME_EXTENTS` is the pre-map mechanism designed for this, but it is a round trip inside a synchronous `realize()` and plenty of window managers never answer it. Letting the WM have the last word costs a clamped-to-the-edge window one correction it would have made anyway.

## Afterwards

One rule, and it is one rule rather than two behaviours: **auto tracks the content until something else sets the size.**

A `<window>` grows as rows are added and stops the moment the user drags an edge — GTK's behaviour, and right for the same reason: the size is the app's opinion until it is the user's. A window manager answering with a size of its own counts too, so a tiling WM is not fought. Nothing can ever take a `<popup>`'s size over, so a popup tracks for good.

The state is `_requestedSize` + `_userSized`, compared against the ConfigureNotify rather than ntk's `ev.resized` — our own configures echo back, and every one would otherwise read as the user taking over on the first re-fit.

One bug found and fixed on the way, worth naming because it is the non-obvious part: **a one-axis configure echoes back covering both axes**, so `_requestedSize` has to record both. Recording only the axis that changed made the app's own `width` update disagree with the record on the other axis, read as somebody else setting the size, and lock the auto axis. The regression test for it fails with the fix reverted — checked, because the first version of the test did not.

## Verification

- 677 tests green; 19 new in `test/window-autosize.test.js`, one new in `test/integration.test.js` against real glyphs on the in-process X server
- `npm run typecheck`, `npm run lint`, `npm run format:check` clean; `elements.d.ts` takes `number | 'auto'` with cases in `test/types/api.tsx`, including `@ts-expect-error` for `'fit-content'` and `'100%'`
- `npm run bench -- --check`: no regressions — a window given both sizes never measures
- On a real display: `_NET_WORKAREA` correctly takes 32px of panel off a 2014x1187 screen, and the screenshots above are server-confirmed geometry

## Not in this PR

**The widget half.** `Menu`, `Tooltip`, `Dialog` and `Select` still hand-measure their popups, because `useAnchor` takes the size from the caller to decide placement and flipping, and that is computed during the render that opens the popup. The comments in `Dialog.js` and `Tooltip.js` that said a `<popup>` *cannot* size to content are corrected here — that is no longer why they take `width`/`height`.

## Breaking

Omitting `width`/`height` no longer means 800x800. Pass the numbers to keep a fixed size. Every example and demo in the repo already does, so nothing there moves.
