### PR TITLE
feat(components): a date picker — one date, a range, and days you can block

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,11 @@ and [docs/](docs/README.md) for the full API reference.
 Widget **components** (plain React on top of the primitives, themable via
 `ThemeProvider`): `Button`, `Checkbox`, `Radio`/`RadioGroup`, `Switch`,
 `Slider`, `ProgressBar`, `Select`, `Tooltip`, `MenuBar`/`ContextMenu`,
-`Dialog` — a modal built on `<popup trapFocus>`, which traps Tab and
-restores focus when it closes — plus the two containers an application
-window is built from: `Tabs`, `Tree` and `SplitPane`. See
+`Calendar`/`DatePicker` — one date or a range, with days blockable and a
+seam for drawing into the cells — `Dialog` — a modal built on
+`<popup trapFocus>`, which traps Tab and restores focus when it closes —
+plus the two containers an application window is built from: `Tabs`, `Tree`
+and `SplitPane`. See
 [docs/components.md](docs/components.md).
 
 **Drag and drop** works with the rest of the desktop: `<box dropAccept={['files']}
@@ -256,6 +258,7 @@ npm run examples:tasks         # useReducer, textinput, scrollview
 npm run examples:menu          # right-click context menu via <popup>
 npm run examples:transparent   # rounded translucent <popup transparent>
 npm run examples:form          # <textinput> + Select dropdowns
+npm run examples:datepicker    # Calendar/DatePicker: ranges, blocked days, events
 npm run examples:gl            # raw GL in a <glarea> (display-list cube)
 npm run examples:three         # <Canvas3D> scene: meshes, lights, textures
 npm run examples:wm            # a reparenting window manager (see below)

--- a/docs/components.md
+++ b/docs/components.md
@@ -339,6 +339,134 @@ single letter cycles through the options starting with it.
 while open, the chevron and the placeholder text are `dim`, and the menu
 highlight is `hoverBackground`/`hoverText`.
 
+## `Calendar` / `DatePicker`
+
+A month grid — one date or a range, with any day blockable. `Calendar` is the
+grid on its own; `DatePicker` hangs the same grid off a field, on a real
+`<popup>` window, and every calendar prop passes straight through it.
+
+```jsx
+<DatePicker value={day} onChange={(ev) => setDay(ev.value)} />
+
+<Calendar
+  mode="range"
+  value={stay}
+  onChange={(ev) => setStay(ev.value)}
+  min="2026-08-01"
+  isDateBlocked={(day) => booked.has(day)}
+/>
+```
+
+| prop                                      |                                                         |
+| ----------------------------------------- | ------------------------------------------------------- |
+| `mode`                                    | `'single'` (default) or `'range'`                       |
+| `value` / `defaultValue`                  | a day, or `{ start, end }` in range mode                |
+| `onChange(ev)`                            | `ev.value` is the new selection                         |
+| `min` / `max`                             | the bounds; days outside them are blocked               |
+| `isDateBlocked(day, parts)`               | everything the bounds cannot say                        |
+| `spanBlocked`                             | let a range run **across** blocked days                 |
+| `dayContent(day, state)`                  | drawn under the number — the seam for per-day marks     |
+| `month` / `defaultMonth`                  | visible month, `'2026-08'`; reported by `onMonthChange` |
+| `locale` / `weekStartsOn`                 | month and weekday names; which day a week starts on     |
+| `format(value)` _(DatePicker)_            | the trigger's label                                     |
+| `placeholder` / `disabled` _(DatePicker)_ | an empty field, and one that does not open              |
+
+### A day is a string
+
+`'2026-08-07'`, in and out — not a `Date`. A square on a wall calendar is not
+an instant: it has no time, no zone and no length that survives a DST
+boundary, so two `Date`s for "the 7th" are only equal if both were built the
+same way (`new Date(2026, 7, 7)` and `new Date('2026-08-07')` are eleven hours
+apart in Sydney, and neither is wrong). As a string, `a === b` is "the same
+day", `a < b` is "earlier", it is a `Set` key with no codec, and it is already
+the shape a calendar API answers in.
+
+A `Date` is accepted anywhere a day is taken and read as its **local**
+calendar day — the day you were looking at when you built it. Anything else
+throws, and so does a date that does not exist: `'2026-02-30'` is a typo, and
+sliding it quietly to March 2nd the way `new Date()` does is how a booking
+ends up a day out.
+
+### Blocking days
+
+`min`/`max` for the bounds, `isDateBlocked(day, parts)` for the rest. `parts`
+is `{ year, month, day, weekday, date }`, so the common cases do not parse the
+string back apart:
+
+```jsx
+<Calendar
+  min={today}
+  isDateBlocked={(day, { weekday }) =>
+    weekday === 0 || weekday === 6 || holidays.has(day)
+  }
+/>
+```
+
+A blocked day is dimmed, is not clickable, and cannot be reached by Enter —
+but the keyboard still **moves through** it, so a blocked week is not a wall
+the arrows cannot cross.
+
+**A range may not contain a blocked day.** The preview stops at the first one
+and an end past it is refused, because an app that blocked a date did not mean
+"unless it is in the middle", and a selection that quietly included it would
+have to be validated all over again on the way out. `spanBlocked` is the other
+reading — only the two ends must be free — for the holidays a stay is allowed
+to run across.
+
+### Picking a range
+
+The first click sets the start and reports `{ start, end: null }`; the second
+completes it. Reporting the half-picked state is what lets a controlled
+picker drive the whole interaction from its own value — there is no hidden
+"pending" state to get out of step with — and it is what a form shows while it
+waits for the other end. Clicking **before** the start re-anchors rather than
+selecting backwards, and the pointer previews the end it would land on.
+
+### Marking days
+
+`dayContent(day, state)` renders inside the cell, under the number, in a strip
+the grid reserves only when the prop is there. `state` is
+`{ selected, inRange, blocked, outside, today, focused, color }`, and `color`
+is what the number itself is being drawn in — a marker that follows it stays
+legible on the filled ends of a range.
+
+```jsx
+<Calendar
+  dayContent={(day, state) =>
+    events.has(day) && (
+      <box
+        style={{
+          width: 4,
+          height: 4,
+          borderRadius: 2,
+          backgroundColor: state.color,
+        }}
+      />
+    )
+  }
+/>
+```
+
+### Keyboard
+
+The grid is a **single tab stop**. Arrows move by a day and by a week,
+Home/End go to the ends of the week, PageUp/PageDown change month — with
+Shift, year — and Enter or Space takes the day under the cursor. Moving off
+the edge of the month turns the page, and so does clicking one of the
+neighbouring days the grid's corners are filled with.
+
+A `DatePicker` opens on Down, Up, Enter or Space, and its **trigger keeps the
+keyboard** while the calendar is up: a `<popup>` is override-redirect and
+never takes focus, so the trigger feeds the grid its keys through the
+`handleKey` on its ref and keeps Escape and Tab for itself. That ref is
+public — `useRef<CalendarHandle>` — for anything else that has to drive a
+calendar it does not focus.
+
+The calendar opens on the **press**, as `Select`'s menu does: a control whose
+whole purpose is to be looked at gains nothing by waiting out the length of
+the click. It closes on the pick — on the _second_ end of a range — on Escape,
+on a second press of the trigger, and when the window loses focus.
+
 ## `Slider`
 
 A draggable value control.

--- a/examples/app.jsx
+++ b/examples/app.jsx
@@ -20,6 +20,7 @@ import {
 } from '../src/index.js';
 import { FormPanel } from './form.jsx';
 import { WidgetsPanel } from './widgets.jsx';
+import { DatesPanel } from './datepicker.jsx';
 import { TasksPanel } from './tasks.jsx';
 import { ThemingPanel } from './theming.jsx';
 
@@ -68,6 +69,7 @@ const s = createStyles({
 const SECTIONS = [
   { id: 'form', label: 'Form' },
   { id: 'widgets', label: 'Widgets' },
+  { id: 'dates', label: 'Dates' },
   { id: 'tasks', label: 'Tasks' },
   { id: 'tree', label: 'Tree' },
   { id: 'table', label: 'Table' },
@@ -168,6 +170,7 @@ function TablePanel() {
 const PANELS = {
   form: () => <FormPanel />,
   widgets: () => <WidgetsPanel />,
+  dates: () => <DatesPanel />,
   tasks: () => <TasksPanel />,
   tree: () => <TreePanel />,
   table: () => <TablePanel />,

--- a/examples/datepicker.jsx
+++ b/examples/datepicker.jsx
@@ -1,0 +1,261 @@
+// Dates: `DatePicker` for one day and for a span, and the `Calendar` grid on
+// its own with a day's events drawn into it.
+//
+// Everything on the right-hand switches is live — block the weekends, let a
+// range span the days that are blocked, move the week's first day, change the
+// locale — so the behaviour can be poked at rather than read about.
+// Run with: npm run examples:datepicker  (needs an X server / DISPLAY)
+import React, { useState } from 'react';
+import {
+  Calendar,
+  DatePicker,
+  Select,
+  Switch,
+  createRoot,
+  createStyles,
+} from '../src/index.js';
+
+const s = createStyles({
+  panel: { flexGrow: 1, padding: 16, gap: 12 },
+  heading: { fontSize: 20, color: '$text' },
+  hint: { fontSize: 11, color: '$dim' },
+  row: { flexDirection: 'row', alignItems: 'center', gap: 12 },
+  label: { color: '$dim', width: 96 },
+  value: { color: '$text' },
+  columns: { flexDirection: 'row', gap: 16, flexGrow: 1, minHeight: 0 },
+  card: {
+    borderWidth: 1,
+    borderColor: '$border',
+    borderRadius: 6,
+    backgroundColor: '$background',
+    padding: 8,
+    gap: 8,
+  },
+  agenda: { flexGrow: 1, minWidth: 0, gap: 6, padding: 8 },
+  agendaDay: { fontSize: 15, color: '$text' },
+  event: { flexDirection: 'row', alignItems: 'center', gap: 8 },
+  eventTime: { fontSize: 12, color: '$dim', width: 46 },
+  eventTitle: { fontSize: 12, color: '$text' },
+  dot: { width: 5, height: 5, borderRadius: 3 },
+  switches: { gap: 8 },
+});
+
+// A day the way the widgets want one: 'YYYY-MM-DD', local, no time on it.
+const iso = (date) =>
+  `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(
+    date.getDate(),
+  ).padStart(2, '0')}`;
+
+const dayFromNow = (n) => {
+  const date = new Date();
+  date.setDate(date.getDate() + n);
+  return iso(date);
+};
+
+const TODAY = dayFromNow(0);
+
+// The overlay this control was designed to grow: a diary, keyed by day, drawn
+// into the grid through `dayContent`. Nothing about it is special-cased in the
+// widget — it is a callback returning boxes.
+const KIND_COLOR = { work: '#e67e22', personal: '#27ae60', travel: '#8e44ad' };
+
+const EVENTS = {
+  [dayFromNow(0)]: [
+    { time: '09:30', title: 'Standup', kind: 'work' },
+    { time: '14:00', title: 'Renderer review', kind: 'work' },
+  ],
+  [dayFromNow(1)]: [{ time: '19:00', title: 'Climbing', kind: 'personal' }],
+  [dayFromNow(3)]: [
+    { time: '08:05', title: 'Train to Berlin', kind: 'travel' },
+    { time: '11:00', title: 'X11 workshop', kind: 'work' },
+    { time: '20:30', title: 'Dinner with M', kind: 'personal' },
+  ],
+  [dayFromNow(6)]: [{ time: '10:00', title: 'Dentist', kind: 'personal' }],
+  [dayFromNow(9)]: [{ time: '17:45', title: 'Flight home', kind: 'travel' }],
+};
+
+// Days somebody else already has: these are blocked outright, and a range
+// cannot be drawn across them unless `spanBlocked` says otherwise.
+const BOOKED = new Set([dayFromNow(4), dayFromNow(5), dayFromNow(12)]);
+
+const LOCALES = [
+  { value: 'en-GB', label: 'en-GB' },
+  { value: 'en-US', label: 'en-US' },
+  { value: 'fr-FR', label: 'fr-FR' },
+  { value: 'de-DE', label: 'de-DE' },
+  { value: 'ja-JP', label: 'ja-JP' },
+];
+
+const WEEK_START = [
+  { value: 'locale', label: "the locale's" },
+  { value: '1', label: 'Monday' },
+  { value: '0', label: 'Sunday' },
+];
+
+function Dot({ color }) {
+  return <box style={[s.dot, { backgroundColor: color }]} />;
+}
+
+/** The agenda for whichever day is selected — the other half of an overlay:
+ *  the marks say *that* there is something, this says what. */
+function Agenda({ day }) {
+  const events = EVENTS[day] ?? [];
+  return (
+    <box style={[s.card, s.agenda]}>
+      <text style={s.agendaDay}>{day ?? 'no day selected'}</text>
+      {events.length === 0 && <text style={s.hint}>Nothing on.</text>}
+      {events.map((event) => (
+        <box key={event.time} style={s.event}>
+          <Dot color={KIND_COLOR[event.kind]} />
+          <text style={s.eventTime}>{event.time}</text>
+          <text style={s.eventTitle}>{event.title}</text>
+        </box>
+      ))}
+      {BOOKED.has(day) && <text style={s.hint}>Blocked — already taken.</text>}
+    </box>
+  );
+}
+
+/** The panel, without a window round it, so examples/app.jsx can show it in
+ *  a tab. */
+export function DatesPanel() {
+  const [day, setDay] = useState(TODAY);
+  const [stay, setStay] = useState({ start: null, end: null });
+  const [browsing, setBrowsing] = useState(TODAY);
+  const [noWeekends, setNoWeekends] = useState(false);
+  const [spanBlocked, setSpanBlocked] = useState(false);
+  const [locale, setLocale] = useState('en-GB');
+  const [weekStart, setWeekStart] = useState('locale');
+
+  const isDateBlocked = (date, { weekday }) =>
+    BOOKED.has(date) || (noWeekends && (weekday === 0 || weekday === 6));
+
+  const shared = {
+    locale,
+    weekStartsOn: weekStart === 'locale' ? undefined : Number(weekStart),
+    isDateBlocked,
+  };
+
+  const span = stay.start
+    ? `${stay.start} → ${stay.end ?? '…'}`
+    : 'nothing picked';
+
+  return (
+    <box style={s.panel}>
+      <text style={s.heading}>Dates</text>
+      <text style={s.hint}>
+        Arrows walk the grid, PageUp/PageDown change month (Shift: year), Enter
+        picks. Grey days are blocked — three are already booked, and the
+        switches below take the weekends out too.
+      </text>
+
+      <box style={s.row}>
+        <text style={s.label}>One date</text>
+        <DatePicker
+          {...shared}
+          value={day}
+          onChange={(ev) => setDay(ev.value)}
+          min={dayFromNow(-30)}
+          style={{ width: 190 }}
+        />
+        <text style={s.value}>{day ?? '—'}</text>
+      </box>
+
+      <box style={s.row}>
+        <text style={s.label}>A range</text>
+        <DatePicker
+          {...shared}
+          mode="range"
+          value={stay}
+          spanBlocked={spanBlocked}
+          onChange={(ev) => setStay(ev.value)}
+          style={{ width: 250 }}
+        />
+        <text style={s.value}>{span}</text>
+      </box>
+
+      <box style={s.columns}>
+        <box style={s.card}>
+          {/* the same grid the picker drops, inline — with the diary drawn
+              into it through `dayContent` */}
+          <Calendar
+            {...shared}
+            value={browsing}
+            onChange={(ev) => setBrowsing(ev.value)}
+            dayContent={(date, state) =>
+              (EVENTS[date] ?? [])
+                .slice(0, 3)
+                .map((event, i) => (
+                  <Dot
+                    key={i}
+                    color={
+                      state.selected ? state.color : KIND_COLOR[event.kind]
+                    }
+                  />
+                ))
+            }
+          />
+          <text style={s.hint}>Dots are events. Click a day to read them.</text>
+        </box>
+
+        <box style={{ flexGrow: 1, minWidth: 0, gap: 12 }}>
+          <Agenda day={browsing} />
+          <box style={[s.card, s.switches]}>
+            <box style={s.row}>
+              <Switch
+                checked={noWeekends}
+                onChange={(ev) => setNoWeekends(ev.value)}
+              />
+              <text style={s.value}>Block weekends</text>
+            </box>
+            <box style={s.row}>
+              <Switch
+                checked={spanBlocked}
+                onChange={(ev) => setSpanBlocked(ev.value)}
+              />
+              <text style={s.value}>A range may span blocked days</text>
+            </box>
+            <box style={s.row}>
+              <text style={s.label}>Locale</text>
+              <Select
+                options={LOCALES}
+                value={locale}
+                onChange={(ev) => setLocale(ev.value)}
+                style={{ width: 120 }}
+              />
+            </box>
+            <box style={s.row}>
+              <text style={s.label}>Week starts</text>
+              <Select
+                options={WEEK_START}
+                value={weekStart}
+                onChange={(ev) => setWeekStart(ev.value)}
+                style={{ width: 120 }}
+              />
+            </box>
+          </box>
+        </box>
+      </box>
+    </box>
+  );
+}
+
+function App() {
+  return (
+    <window
+      width={760}
+      height={620}
+      title="dates"
+      style={{ backgroundColor: '$surfaceHover' }}
+    >
+      <DatesPanel />
+    </window>
+  );
+}
+
+export default App;
+
+if (!process.env.REACT_X11_NO_AUTORUN) {
+  const root = await createRoot();
+  root.render(<App />);
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "examples:rules": "tsx examples/rules.jsx",
     "examples:richtext": "tsx examples/richtext.jsx",
     "examples:widgets": "tsx examples/widgets.jsx",
+    "examples:datepicker": "tsx examples/datepicker.jsx",
     "examples:react-features": "tsx examples/react-features.jsx",
     "examples:icons": "tsx examples/icons.jsx",
     "examples:raster-gate": "tsx examples/raster-gate.jsx",

--- a/scripts/screenshots.jsx
+++ b/scripts/screenshots.jsx
@@ -20,6 +20,12 @@ process.memoryUsage = () => ({
   heapUsed: 42 * 1024 * 1024,
   heapTotal: 64 * 1024 * 1024,
 });
+// Freezing `Date.now()` also freezes every `transition`: `nodes.js` drives
+// them off it, so an animation started by one of the scenes below stalls at
+// t=0 and photographs the colour a control was leaving rather than the one it
+// landed on. Harmless for these scenes, which capture at rest — but a new one
+// that clicks something with a transitioned colour needs a real clock for the
+// paint to be honest.
 const FROZEN_MS = Date.UTC(2026, 0, 1, 9, 41, 0);
 const RealDate = Date;
 globalThis.Date = class extends RealDate {

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -1,0 +1,581 @@
+// Widget components built purely on the host primitives — no reconciler
+// support needed. Plain createElement (no JSX) so the library stays
+// build-step-free for consumers.
+
+import React, { useImperativeHandle, useMemo, useState } from 'react';
+import { createStyles, tint } from '../styles.js';
+import { useTheme } from './theme.js';
+import { changeEvent } from './change.js';
+import {
+  XK_DOWN,
+  XK_END,
+  XK_HOME,
+  XK_LEFT,
+  XK_PAGE_DOWN,
+  XK_PAGE_UP,
+  XK_RETURN,
+  XK_RIGHT,
+  XK_UP,
+} from './keys.js';
+import {
+  addDays,
+  addMonths,
+  clampDay,
+  dayParts,
+  firstOfMonth,
+  formatMonth,
+  localeWeekStart,
+  monthGrid,
+  monthOf,
+  toDay,
+  toMonth,
+  today,
+  weekdayLabels,
+} from './dates.js';
+
+const h = React.createElement;
+
+// The grid's geometry. A cell is the square the pointer aims at and the band
+// runs through; the pill inside it is what gets filled, rounded and hovered,
+// which is what leaves the band visible on either side of a selected end.
+const CELL_W = 36;
+const CELL_H = 32;
+const PILL_W = 32;
+const PILL_H = 28;
+// Reserved under the number when `dayContent` is given — and only then, so a
+// plain calendar is not 6×8 pixels taller for a feature it is not using.
+const MARKER_H = 8;
+const NAV = 26;
+const PAD = 8;
+const GAP = 4;
+const WEEKDAY_H = 20;
+
+/**
+ * How big a `<Calendar>` lays out — exported because `DatePicker` has to size
+ * a real X window around one *before* it is laid out, and a popup that
+ * guesses is a popup that clips the last week of the month. Everything the
+ * sum reads is a constant above it, so the two cannot drift apart.
+ *
+ * Eight rows in the column (the header, the weekday names, six weeks), so
+ * seven gaps between them.
+ */
+export const CALENDAR_WIDTH = CELL_W * 7 + PAD * 2;
+export const CALENDAR_HEIGHT = PAD * 2 + NAV + WEEKDAY_H + CELL_H * 6 + GAP * 7;
+
+const s = createStyles({
+  root: { alignItems: 'flex-start', padding: PAD, gap: GAP },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    width: CELL_W * 7,
+    height: NAV,
+    flexShrink: 0,
+  },
+  title: { flexGrow: 1, textAlign: 'center', fontWeight: 'bold' },
+  nav: {
+    width: NAV,
+    height: NAV,
+    alignItems: 'center',
+    justifyContent: 'center',
+    cursor: 'pointer',
+    transition: { backgroundColor: 80 },
+  },
+  chevron: { width: 7, height: 12 },
+  week: { flexDirection: 'row', flexShrink: 0 },
+  weekdayCell: {
+    width: CELL_W,
+    height: WEEKDAY_H,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  weekdayLabel: { fontSize: 11 },
+  cell: {
+    width: CELL_W,
+    height: CELL_H,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  band: { position: 'absolute', top: 2, bottom: 2 },
+  pill: {
+    width: PILL_W,
+    height: PILL_H,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: 1,
+    // the 2px the pill gives up on each side of the cell are still part of
+    // its target, so the whole square is clickable and the gap between two
+    // days is not a dead strip
+    hitSlop: 2,
+    transition: { backgroundColor: 80 },
+  },
+  number: { fontSize: 13 },
+  markers: {
+    flexDirection: 'row',
+    height: MARKER_H,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 2,
+  },
+});
+
+const TRANSPARENT = 'transparent';
+
+/** The selection, with every day normalized — and with the two shapes told
+ *  apart loudly, since passing a range to a single-date calendar otherwise
+ *  shows up as an empty calendar rather than as the mistake it is. */
+function normalizeValue(mode, value) {
+  if (mode === 'range') {
+    if (value == null) return { start: null, end: null };
+    if (typeof value !== 'object' || value instanceof Date) {
+      throw new TypeError(
+        "react-x11: a range calendar's value is { start, end }, got " +
+          `${JSON.stringify(value)}. Drop mode="range" for a single date.`,
+      );
+    }
+    return { start: toDay(value.start), end: toDay(value.end) };
+  }
+  if (value != null && typeof value === 'object' && !(value instanceof Date)) {
+    throw new TypeError(
+      "react-x11: a single-date calendar's value is one day, got " +
+        `${JSON.stringify(value)}. Pass mode="range" to select a span.`,
+    );
+  }
+  return toDay(value);
+}
+
+/**
+ * The first blocked day after `start`, up to `last` — where a range that may
+ * not contain a blocked day has to stop.
+ *
+ * Scanned over the days the grid can show rather than per candidate end:
+ * nothing off the grid is clickable, and the keyboard's focus is always on it.
+ * With no half-picked start there is nothing to scan for.
+ */
+function firstBlockedAfter(start, last, blocked) {
+  if (!start) return null;
+  for (let d = addDays(start, 1); d <= last; d = addDays(d, 1)) {
+    if (blocked(d)) return d;
+  }
+  return null;
+}
+
+/** The day in `month` with the same day-of-month as `day`, or the last one
+ *  the month has — so paging from the 31st does not skip February. */
+function sameDayIn(month, day) {
+  const wanted = Number(day.slice(8));
+  const last = Number(addDays(firstOfMonth(addMonths(month, 1)), -1).slice(8));
+  return `${month}-${String(Math.min(wanted, last)).padStart(2, '0')}`;
+}
+
+function Chevron({ direction, color }) {
+  return h('canvas', {
+    style: s.chevron,
+    onDraw: (ctx, { width, height }) => {
+      const mid = height / 2;
+      ctx.strokeStyle = color;
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      if (direction === 'left') {
+        ctx.moveTo(width - 1, 1);
+        ctx.lineTo(1, mid);
+        ctx.lineTo(width - 1, height - 1);
+      } else {
+        ctx.moveTo(1, 1);
+        ctx.lineTo(width - 1, mid);
+        ctx.lineTo(1, height - 1);
+      }
+      ctx.stroke();
+    },
+  });
+}
+
+function NavButton({ direction, disabled, onPress, theme }) {
+  return h(
+    'box',
+    {
+      role: 'button',
+      onClick: disabled ? undefined : onPress,
+      style: [
+        s.nav,
+        {
+          borderRadius: theme.radius,
+          cursor: disabled ? 'default' : 'pointer',
+        },
+        !disabled && {
+          ':hover': { backgroundColor: theme.surfaceHover },
+          ':active': { backgroundColor: theme.surfaceActive },
+        },
+      ],
+    },
+    h(Chevron, { direction, color: disabled ? theme.border : theme.dim }),
+  );
+}
+
+function DayCell({ day, state, theme, band, onPick, onHover, dayContent }) {
+  const { blocked, outside, selected, focused } = state;
+  const color = selected
+    ? theme.accentText
+    : blocked || outside
+      ? theme.dim
+      : theme.text;
+  const markers = dayContent?.(day, { ...state, color });
+
+  return h(
+    'box',
+    { role: 'gridcell', style: s.cell },
+    // Behind the pill and out of flow, so an end of the range keeps its own
+    // fill while the band still runs out of it towards the next day. Half a
+    // cell at each end is what joins one pill to the next without drawing
+    // over either.
+    band &&
+      h('box', {
+        style: [
+          s.band,
+          {
+            left: band.opensRight ? CELL_W / 2 : 0,
+            right: band.opensLeft ? CELL_W / 2 : 0,
+            backgroundColor: tint(theme.accent, 0.18),
+          },
+        ],
+      }),
+    h(
+      'box',
+      {
+        onClick: blocked ? undefined : () => onPick(day),
+        onMouseEnter: onHover ? () => onHover(day) : undefined,
+        style: [
+          s.pill,
+          {
+            cursor: blocked ? 'default' : 'pointer',
+            borderRadius: theme.radius,
+            backgroundColor: selected ? theme.accent : TRANSPARENT,
+            // today keeps its outline whatever else is going on, and every
+            // other cell carries the same border in nothing — a border that
+            // appears would inset the number by a pixel as the day turns
+            borderColor: focused
+              ? theme.borderFocus
+              : state.today
+                ? theme.accent
+                : TRANSPARENT,
+          },
+          !blocked && {
+            ':hover': {
+              backgroundColor: selected
+                ? theme.accentHover
+                : theme.surfaceHover,
+            },
+            ':active': {
+              backgroundColor: selected
+                ? theme.accentActive
+                : theme.surfaceActive,
+            },
+          },
+        ],
+      },
+      h('text', { style: [s.number, { color }] }, String(Number(day.slice(8)))),
+      markers ? h('box', { style: s.markers }, markers) : null,
+    ),
+  );
+}
+
+/**
+ * <Calendar value onChange …/> — a month grid: one date, or a range, with any
+ * day blockable.
+ *
+ *   <Calendar value={day} onChange={(ev) => setDay(ev.value)} />
+ *   <Calendar mode="range" value={{ start, end }} onChange={…} />
+ *
+ * **A day is a `'YYYY-MM-DD'` string** in and out (a `Date` is accepted on the
+ * way in and read as its local calendar day). See `dates.js` for why: a square
+ * on a wall calendar is not an instant, and comparing two of them should not
+ * depend on which constructor built them.
+ *
+ * Blocking is `min`/`max` for the usual bounds and `isDateBlocked(day, parts)`
+ * for everything else — weekends, holidays, whatever the server said is taken.
+ * `parts` is `{ year, month, day, weekday, date }` so the common cases do not
+ * have to parse the string back apart.
+ *
+ * In `range` mode the first click sets the start and reports
+ * `{ start, end: null }`, the second completes it. Clicking before the start
+ * re-anchors rather than selecting backwards. **A range may not contain a
+ * blocked day**: the preview stops at the first one, because an app that
+ * blocked a date did not mean "unless it is in the middle", and a selection
+ * that quietly included it would have to be validated all over again on the
+ * way out. `spanBlocked` is the other reading — only the ends must be free —
+ * for holidays a booking is allowed to run across.
+ *
+ * `dayContent(day, state)` renders under the number, in a strip the grid
+ * reserves only when the prop is there. It is the seam for anything drawn per
+ * day — an event dot, a price, an availability count — and `state` carries
+ * `{ selected, inRange, blocked, outside, today, focused, color }` so a marker
+ * can stay legible on the filled ends of the range.
+ *
+ * The grid is a **single tab stop**. Arrows move a day at a time and a week at
+ * a time, Home/End go to the ends of the week, PageUp/PageDown change month
+ * (with Shift, year), Enter and Space select. Moving off the edge of the month
+ * turns the page.
+ *
+ * A calendar inside a popup does not hold the keyboard — the trigger does, on
+ * its behalf, because an override-redirect window never takes focus. That is
+ * what `focusable: false` plus `focusVisible: true` say together: someone else
+ * is feeding this grid its keys through the `handleKey` on its ref, and the
+ * day cursor still has to be drawn or the arrows move something invisible.
+ */
+export function Calendar({
+  mode = 'single',
+  value,
+  defaultValue,
+  onChange,
+  name,
+  month,
+  defaultMonth,
+  onMonthChange,
+  min,
+  max,
+  isDateBlocked,
+  spanBlocked = false,
+  dayContent,
+  locale,
+  weekStartsOn,
+  focusable = true,
+  focusVisible,
+  ref,
+  style,
+  ...boxProps
+}) {
+  const theme = useTheme();
+  const minDay = toDay(min);
+  const maxDay = toDay(max);
+  const todayKey = today();
+
+  const [ownValue, setOwnValue] = useState(() =>
+    normalizeValue(mode, defaultValue ?? null),
+  );
+  const selection =
+    value === undefined ? ownValue : normalizeValue(mode, value);
+  const anchor = mode === 'range' ? selection.start : selection;
+
+  const [ownMonth, setOwnMonth] = useState(
+    () =>
+      toMonth(defaultMonth) ??
+      monthOf(anchor ?? clampDay(todayKey, minDay, maxDay)),
+  );
+  const visibleMonth = month == null ? ownMonth : toMonth(month);
+
+  const [focusedDay, setFocusedDay] = useState(() =>
+    clampDay(anchor ?? todayKey, minDay, maxDay),
+  );
+  const [focused, setFocused] = useState(false);
+  // Only ever set while a range is half-picked, which is the only time the
+  // grid repaints on pointer movement: with nothing pending the highlight is
+  // a `:hover` block on one cell and React hears nothing about it.
+  const [hovered, setHovered] = useState(null);
+
+  const weekStart = weekStartsOn ?? localeWeekStart(locale);
+  const weeks = useMemo(
+    () => monthGrid(visibleMonth, weekStart),
+    [visibleMonth, weekStart],
+  );
+  const weekdays = useMemo(
+    () => weekdayLabels(locale, weekStart),
+    [locale, weekStart],
+  );
+
+  const isBlocked = (day) => {
+    if (minDay && day < minDay) return true;
+    if (maxDay && day > maxDay) return true;
+    return isDateBlocked ? Boolean(isDateBlocked(day, dayParts(day))) : false;
+  };
+
+  const pending =
+    mode === 'range' && Boolean(selection.start && !selection.end);
+
+  // The first blocked day after a half-picked start, which is where the range
+  // has to stop. Scanned once per render over the days the grid can actually
+  // show, rather than per candidate end: nothing outside the grid is clickable
+  // and the keyboard's focus is always on it.
+  const wall = firstBlockedAfter(
+    pending && !spanBlocked ? selection.start : null,
+    weeks[5][6],
+    isBlocked,
+  );
+
+  const canEndAt = (day) =>
+    pending &&
+    day >= selection.start &&
+    !isBlocked(day) &&
+    (!wall || day < wall);
+
+  const preview = pending && hovered && canEndAt(hovered) ? hovered : null;
+  const bandStart = mode === 'range' ? selection.start : null;
+  const bandEnd = mode === 'range' ? (selection.end ?? preview) : null;
+
+  const setMonth = (next) => {
+    if (month == null) setOwnMonth(next);
+    onMonthChange?.(next);
+  };
+
+  const commit = (next) => {
+    if (value === undefined) setOwnValue(next);
+    onChange?.(
+      changeEvent(mode === 'range' ? 'date-range' : 'date', name, next),
+    );
+  };
+
+  const show = (day) => {
+    setFocusedDay(day);
+    if (monthOf(day) !== visibleMonth) setMonth(monthOf(day));
+  };
+
+  const pick = (day) => {
+    if (isBlocked(day)) return;
+    if (mode === 'range') {
+      if (!pending || day < selection.start) commit({ start: day, end: null });
+      else if (canEndAt(day)) commit({ start: selection.start, end: day });
+      else return;
+    } else {
+      commit(day);
+    }
+    show(day);
+  };
+
+  const moveFocus = (delta) =>
+    show(clampDay(addDays(focusedDay, delta), minDay, maxDay));
+
+  const stepMonth = (delta) => {
+    const next = addMonths(visibleMonth, delta);
+    setMonth(next);
+    setFocusedDay(clampDay(sameDayIn(next, focusedDay), minDay, maxDay));
+  };
+
+  /** Returns whether the key was the calendar's — a picker wrapping this one
+   *  still owns Escape and Tab, and has no other way to tell. */
+  const handleKey = (ev) => {
+    switch (ev.keysym) {
+      case XK_LEFT:
+        moveFocus(-1);
+        return true;
+      case XK_RIGHT:
+        moveFocus(1);
+        return true;
+      case XK_UP:
+        moveFocus(-7);
+        return true;
+      case XK_DOWN:
+        moveFocus(7);
+        return true;
+      case XK_HOME:
+        moveFocus(-((dayParts(focusedDay).weekday - weekStart + 7) % 7));
+        return true;
+      case XK_END:
+        moveFocus(6 - ((dayParts(focusedDay).weekday - weekStart + 7) % 7));
+        return true;
+      case XK_PAGE_UP:
+        stepMonth(ev.shiftKey ? -12 : -1);
+        return true;
+      case XK_PAGE_DOWN:
+        stepMonth(ev.shiftKey ? 12 : 1);
+        return true;
+      case XK_RETURN:
+        pick(focusedDay);
+        return true;
+      default:
+        break;
+    }
+    if (ev.codepoint === 32) {
+      pick(focusedDay);
+      return true;
+    }
+    return false;
+  };
+
+  useImperativeHandle(ref, () => ({ handleKey }));
+
+  const canGoBack = !minDay || firstOfMonth(visibleMonth) > minDay;
+  const canGoOn = !maxDay || firstOfMonth(addMonths(visibleMonth, 1)) <= maxDay;
+
+  return h(
+    'box',
+    {
+      theme,
+      role: 'grid',
+      focusable,
+      onKeyDown: handleKey,
+      onFocus: () => setFocused(true),
+      onBlur: () => setFocused(false),
+      // the preview belongs to the pointer, and the pointer has left
+      onMouseLeave: pending ? () => setHovered(null) : undefined,
+      ...boxProps,
+      style: [s.root, style],
+    },
+    h(
+      'box',
+      { style: s.header },
+      h(NavButton, {
+        direction: 'left',
+        disabled: !canGoBack,
+        theme,
+        onPress: () => stepMonth(-1),
+      }),
+      h(
+        'text',
+        { style: [s.title, { color: theme.text, fontSize: theme.fontSize }] },
+        formatMonth(visibleMonth, locale),
+      ),
+      h(NavButton, {
+        direction: 'right',
+        disabled: !canGoOn,
+        theme,
+        onPress: () => stepMonth(1),
+      }),
+    ),
+    h(
+      'box',
+      { style: s.week },
+      weekdays.map((label, i) =>
+        h(
+          'box',
+          { key: i, style: s.weekdayCell },
+          h('text', { style: [s.weekdayLabel, { color: theme.dim }] }, label),
+        ),
+      ),
+    ),
+    weeks.map((days, w) =>
+      h(
+        'box',
+        { key: w, style: s.week },
+        days.map((day) => {
+          const inBand =
+            bandStart != null &&
+            bandEnd != null &&
+            bandStart !== bandEnd &&
+            day >= bandStart &&
+            day <= bandEnd;
+          return h(DayCell, {
+            key: day,
+            day,
+            theme,
+            dayContent,
+            onPick: pick,
+            onHover: pending ? setHovered : undefined,
+            band: inBand
+              ? { opensRight: day === bandStart, opensLeft: day === bandEnd }
+              : null,
+            state: {
+              blocked: isBlocked(day),
+              outside: monthOf(day) !== visibleMonth,
+              today: day === todayKey,
+              selected:
+                mode === 'range'
+                  ? day === selection.start || day === bandEnd
+                  : day === selection,
+              inRange: inBand,
+              preview: inBand && selection.end == null,
+              focused: (focusVisible ?? focused) && day === focusedDay,
+            },
+          });
+        }),
+      ),
+    ),
+  );
+}

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -1,0 +1,294 @@
+// Widget components built purely on the host primitives — no reconciler
+// support needed. Plain createElement (no JSX) so the library stays
+// build-step-free for consumers.
+
+import React, { useRef, useState } from 'react';
+import { createStyles } from '../styles.js';
+import { useTheme } from './theme.js';
+import {
+  useAnchor,
+  useAnchorTracking,
+  useDismissOnWindowBlur,
+} from './anchor.js';
+import { CALENDAR_HEIGHT, CALENDAR_WIDTH, Calendar } from './Calendar.js';
+import { formatDay, formatDayRange, toDay } from './dates.js';
+import { XK_DOWN, XK_ESCAPE, XK_RETURN, XK_UP } from './keys.js';
+
+const h = React.createElement;
+
+// A hairline round the sheet, as the menus and `Select` use: this border is
+// where the popup meets the desktop, not a control's outline, so a theme that
+// draws 2px borders on its buttons does not get a 2px frame here.
+const SHEET_BORDER = 1;
+
+const s = createStyles({
+  trigger: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    padding: 8,
+    paddingLeft: 10,
+    paddingRight: 10,
+    cursor: 'pointer',
+  },
+  label: { flexGrow: 1 },
+  icon: { width: 14, height: 14, flexShrink: 0 },
+  sheet: { flexGrow: 1, flexShrink: 1, borderWidth: SHEET_BORDER },
+});
+
+/** A wall calendar, 14×14: the page, its two hangers and the ruled week. */
+function CalendarGlyph({ color }) {
+  return h('canvas', {
+    style: s.icon,
+    onDraw: (ctx, { width, height }) => {
+      ctx.strokeStyle = color;
+      ctx.lineWidth = 1;
+      ctx.strokeRect(0.5, 2.5, width - 1, height - 3);
+      ctx.beginPath();
+      ctx.moveTo(0.5, 6.5);
+      ctx.lineTo(width - 0.5, 6.5);
+      ctx.moveTo(4.5, 0.5);
+      ctx.lineTo(4.5, 3.5);
+      ctx.moveTo(width - 4.5, 0.5);
+      ctx.lineTo(width - 4.5, 3.5);
+      ctx.stroke();
+    },
+  });
+}
+
+/** What the trigger says, when the app has not said it itself. */
+function defaultFormat(mode, value, locale) {
+  if (mode === 'range') {
+    const start = toDay(value?.start);
+    const end = toDay(value?.end);
+    if (!start) return null;
+    if (!end) return `${formatDay(start, locale)} → …`;
+    return formatDayRange(start, end, locale);
+  }
+  const day = toDay(value);
+  return day ? formatDay(day, locale) : null;
+}
+
+/**
+ * <DatePicker value onChange …boxProps> — a `<Calendar>` on a `<popup>`, hung
+ * off a field that shows the current date.
+ *
+ *   <DatePicker value={day} onChange={(ev) => setDay(ev.value)} />
+ *   <DatePicker mode="range" value={span} onChange={…} max="2026-12-31" />
+ *
+ * Every calendar prop passes straight through — `mode`, `min`/`max`,
+ * `isDateBlocked`, `spanBlocked`, `dayContent`, `locale`, `weekStartsOn` — and
+ * the value has the same shape here as there: a `'YYYY-MM-DD'` day, or
+ * `{ start, end }` in range mode.
+ *
+ * The calendar opens on the **press**, not the release, for the reason
+ * `Select`'s menu does: a control whose whole purpose is to be looked at has
+ * nothing to gain from waiting out the length of the click. It closes when the
+ * value is complete — the day in single mode, the second end of a range — on
+ * Escape, on a second press of the trigger, and when the window loses focus.
+ *
+ * The popup is override-redirect and never takes focus, so the **trigger keeps
+ * the keyboard** and hands the calendar its keys: Down/Up/Enter/Space open it,
+ * and once it is open everything the grid understands (arrows, Home/End,
+ * PageUp/PageDown, Enter, Space) goes there. Escape and Tab stay here, which
+ * is why `handleKey` reports whether it took the key.
+ *
+ * `format(value)` is the seam for the label: the default is the locale's
+ * medium date, and `Intl`'s own range format when there are two of them, which
+ * collapses the parts the ends share ("7 – 12 Aug 2026").
+ */
+export function DatePicker({
+  mode = 'single',
+  value,
+  defaultValue,
+  onChange,
+  name,
+  month,
+  defaultMonth,
+  onMonthChange,
+  min,
+  max,
+  isDateBlocked,
+  spanBlocked,
+  dayContent,
+  locale,
+  weekStartsOn,
+  format,
+  placeholder,
+  disabled = false,
+  style,
+  ...boxProps
+}) {
+  const theme = useTheme();
+  const [open, setOpen] = useState(false);
+  const [anchor, setAnchor] = useState(null);
+  const [focused, setFocused] = useState(false);
+  const [ownValue, setOwnValue] = useState(defaultValue ?? null);
+  const triggerRef = useRef(null);
+  const calendarRef = useRef(null);
+
+  const measureAnchor = useAnchor(triggerRef);
+  const current = value === undefined ? ownValue : value;
+
+  const width = CALENDAR_WIDTH + SHEET_BORDER * 2;
+  const height = CALENDAR_HEIGHT + SHEET_BORDER * 2;
+  const anchorOptions = () => ({ placement: 'bottom', width, height });
+
+  const close = () => setOpen(false);
+  const openCalendar = () => {
+    const rect = measureAnchor(anchorOptions());
+    if (!rect) return;
+    setAnchor(rect);
+    setOpen(true);
+  };
+  const toggle = () => (open ? close() : openCalendar());
+
+  // the same two the other popups take: keep the sheet under the trigger while
+  // anything moves it, and shut it when the window itself loses focus (the
+  // trigger keeps its focus, so its own onBlur never hears about that)
+  useAnchorTracking(triggerRef, open, anchorOptions, setAnchor, close);
+  useDismissOnWindowBlur(triggerRef, open, close);
+
+  const handleChange = (ev) => {
+    if (value === undefined) setOwnValue(ev.value);
+    onChange?.(ev);
+    // a half-picked range is the one selection that is not finished, and the
+    // calendar has to stay up for the other end of it
+    if (mode !== 'range' || ev.value?.end) close();
+  };
+
+  const onKeyDown = (ev) => {
+    if (ev.keysym === XK_ESCAPE) {
+      if (open) close();
+      return;
+    }
+    if (open && calendarRef.current?.handleKey(ev)) return;
+    if (
+      ev.keysym === XK_DOWN ||
+      ev.keysym === XK_UP ||
+      ev.keysym === XK_RETURN ||
+      ev.codepoint === 32
+    ) {
+      if (!open) openCalendar();
+    }
+  };
+
+  const label = format ? format(current) : defaultFormat(mode, current, locale);
+  const empty = label == null || label === '';
+  const text = empty
+    ? (placeholder ?? (mode === 'range' ? 'Pick dates…' : 'Pick a date…'))
+    : label;
+
+  return h(
+    'box',
+    {
+      theme,
+      role: 'combobox',
+      ref: triggerRef,
+      focusable: !disabled,
+      onMouseDown: disabled ? undefined : toggle,
+      onFocus: () => setFocused(true),
+      onBlur: () => {
+        setFocused(false);
+        close();
+      },
+      onKeyDown: disabled ? undefined : onKeyDown,
+      ...boxProps,
+      style: [
+        s.trigger,
+        {
+          cursor: disabled ? 'default' : 'pointer',
+          borderWidth: theme.borderWidth,
+          borderRadius: theme.radius,
+          borderColor: focused || open ? theme.borderFocus : theme.border,
+          backgroundColor: disabled ? theme.surfaceHover : theme.background,
+        },
+        // hover and press say "this opens", so they belong to the trigger
+        // while it is shut and are simply not declared once the calendar is
+        // down — a state block always outranks the base style, so the only
+        // way for the open look to win is for nothing to be competing
+        !disabled &&
+          !open && {
+            ':hover': { backgroundColor: theme.surfaceHover },
+            ':active': { backgroundColor: theme.surfaceActive },
+          },
+        style,
+      ],
+    },
+    h(
+      'text',
+      {
+        style: [
+          s.label,
+          { color: disabled ? theme.dim : empty ? theme.dim : theme.text },
+        ],
+      },
+      text,
+    ),
+    h(CalendarGlyph, { color: disabled ? theme.border : theme.dim }),
+    open &&
+      anchor &&
+      h(
+        'popup',
+        {
+          theme,
+          x: anchor.x,
+          y: anchor.y,
+          width,
+          height,
+          grab: true,
+          onDismiss: close,
+          // ARGB where the display has it, so the corners the sheet gives up
+          // are the desktop rather than a colour. The window paints nothing
+          // itself when it can be seen through — the box below is the whole
+          // of the sheet, and a square fill under it would put the corners
+          // straight back.
+          transparent: true,
+          style: {
+            backgroundColor: theme.background,
+            '@supports transparency': { backgroundColor: 'transparent' },
+          },
+        },
+        h(
+          'box',
+          {
+            style: [
+              s.sheet,
+              {
+                borderColor: theme.border,
+                backgroundColor: theme.background,
+                '@supports transparency': { borderRadius: theme.radiusPopup },
+              },
+            ],
+          },
+          h(Calendar, {
+            ref: calendarRef,
+            mode,
+            value: current,
+            onChange: handleChange,
+            name,
+            month,
+            defaultMonth,
+            onMonthChange,
+            min,
+            max,
+            isDateBlocked,
+            spanBlocked,
+            dayContent,
+            locale,
+            weekStartsOn,
+            // The trigger owns the keyboard: the popup is override-redirect
+            // and never takes focus, so a focusable grid inside it would take
+            // focus on the press instead — blurring the trigger, whose onBlur
+            // closes the sheet, unmounting the day under the pointer before
+            // the release could turn into a click.
+            focusable: false,
+            // …and because it does not hold the focus, it would not draw the
+            // day cursor either, leaving the arrow keys moving something
+            // invisible.
+            focusVisible: true,
+          }),
+        ),
+      ),
+  );
+}

--- a/src/components/dates.js
+++ b/src/components/dates.js
@@ -1,0 +1,256 @@
+// Calendar days, and the arithmetic the date widgets do on them.
+//
+// **A day here is a string, `'2026-08-07'`, not a `Date`.** A date picker
+// selects a square on a wall calendar, and that is not an instant: it has no
+// time, no zone, and no duration that survives a DST boundary. A `Date` is an
+// instant, so every comparison the widgets need — is this the selected day, is
+// it inside the range, is it blocked — would be a comparison of two timestamps
+// that are only equal if both were built the same way. `new Date(2026, 7, 7)`
+// and `new Date('2026-08-07')` are eleven hours apart in Sydney and neither is
+// wrong.
+//
+// A string has none of that: `a === b` is "the same day", `a < b` is "earlier"
+// (fixed-width fields, so lexical order *is* chronological order), it is a
+// `Map`/`Set` key without a codec, and it is what a calendar API hands back
+// over the wire in the first place — which is the shape the event overlay this
+// is designed for will arrive in.
+//
+// `Date` is still accepted everywhere a day is taken: `toDay()` converts one
+// using its **local** calendar day, because that is the day the user was
+// looking at when they built it.
+//
+// The arithmetic runs in UTC (`Date.UTC`, `getUTC*`) so that "add a day" is
+// always 86400 seconds and never 23 or 25 — the local-time trap that puts a
+// month grid an hour out on the last Sunday in October.
+
+const DAY_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+const MONTH_RE = /^(\d{4})-(\d{2})$/;
+
+/**
+ * A day key from a `'YYYY-MM-DD'` string, a `Date`, or `null`/`undefined`
+ * (which is "no day", and comes back as `null`).
+ *
+ * Throws on anything else, and on a string that is not a real date —
+ * `'2026-02-30'` is a typo, not a day, and silently sliding it to March 2nd
+ * the way `new Date()` does is how a booking ends up a day out. The message
+ * names what arrived, because the value in a props object is usually miles
+ * from the line that built it.
+ */
+export function toDay(value) {
+  if (value == null) return null;
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) {
+      throw new TypeError(
+        'react-x11: an Invalid Date was passed where a calendar day was expected.',
+      );
+    }
+    // its *local* calendar day: `new Date(2026, 7, 7)` is local midnight, and
+    // the day the developer wrote down is the one they meant
+    return key(value.getFullYear(), value.getMonth() + 1, value.getDate());
+  }
+  if (typeof value === 'string') {
+    const m = DAY_RE.exec(value);
+    if (!m) {
+      throw new TypeError(
+        `react-x11: expected a calendar day as 'YYYY-MM-DD' or a Date, got ${JSON.stringify(value)}.`,
+      );
+    }
+    const [, y, mo, d] = m;
+    // through a real Date and back: the fields on their own are well-formed
+    // for '2026-02-30' too, and only the calendar knows February ends earlier
+    const date = new Date(Date.UTC(Number(y), Number(mo) - 1, Number(d)));
+    const round = key(
+      date.getUTCFullYear(),
+      date.getUTCMonth() + 1,
+      date.getUTCDate(),
+    );
+    if (round !== value) {
+      throw new TypeError(
+        `react-x11: ${JSON.stringify(value)} is not a real calendar date.`,
+      );
+    }
+    return value;
+  }
+  throw new TypeError(
+    `react-x11: expected a calendar day as 'YYYY-MM-DD' or a Date, got ${typeof value}.`,
+  );
+}
+
+/** `'YYYY-MM'` from the same set of inputs, for the *visible month* props. */
+export function toMonth(value) {
+  if (value == null) return null;
+  if (typeof value === 'string' && MONTH_RE.test(value)) return value;
+  return monthOf(toDay(value));
+}
+
+function key(year, month, day) {
+  return `${pad(year, 4)}-${pad(month, 2)}-${pad(day, 2)}`;
+}
+
+function pad(n, width) {
+  return String(n).padStart(width, '0');
+}
+
+/** Today, on this machine, in local time — which is the day the user's wall
+ *  calendar is showing. */
+export function today() {
+  const now = new Date();
+  return key(now.getFullYear(), now.getMonth() + 1, now.getDate());
+}
+
+/** The day as a UTC-midnight `Date`, for `Intl` and for arithmetic. */
+export function dayDate(day) {
+  const [y, m, d] = day.split('-').map(Number);
+  return new Date(Date.UTC(y, m - 1, d));
+}
+
+/**
+ * `{ year, month, day, weekday, date }` — the parts a caller needs to decide
+ * something about a day without parsing the string itself. `weekday` is
+ * `0`-`6` from Sunday, as `Date#getDay()` counts, so blocking weekends is
+ * `weekday === 0 || weekday === 6`. `month` is 1-based, unlike `Date`'s.
+ */
+export function dayParts(day) {
+  const date = dayDate(day);
+  return {
+    year: date.getUTCFullYear(),
+    month: date.getUTCMonth() + 1,
+    day: date.getUTCDate(),
+    weekday: date.getUTCDay(),
+    date,
+  };
+}
+
+export function addDays(day, n) {
+  const date = dayDate(day);
+  date.setUTCDate(date.getUTCDate() + n);
+  return key(date.getUTCFullYear(), date.getUTCMonth() + 1, date.getUTCDate());
+}
+
+/** `'2026-08'` — the month a day is in. */
+export function monthOf(day) {
+  return day.slice(0, 7);
+}
+
+/** The first day of a `'YYYY-MM'`. */
+export function firstOfMonth(month) {
+  return `${month}-01`;
+}
+
+/**
+ * `n` months on from a `'YYYY-MM'`. Months, unlike days, are not all the same
+ * length, so this deliberately works on the month key and never on a day: the
+ * "same date next month" question (Jan 31 → Feb 31?) has no good answer and
+ * nothing here asks it.
+ */
+export function addMonths(month, n) {
+  const [y, m] = month.split('-').map(Number);
+  const total = y * 12 + (m - 1) + n;
+  return `${pad(Math.floor(total / 12), 4)}-${pad((total % 12) + 1, 2)}`;
+}
+
+/** `day` held inside `[min, max]`; either bound may be null. */
+export function clampDay(day, min, max) {
+  if (min && day < min) return min;
+  if (max && day > max) return max;
+  return day;
+}
+
+/**
+ * The grid a month is drawn on: **six weeks of seven days**, always, starting
+ * on `weekStartsOn` and running through whatever days of the neighbouring
+ * months it takes to fill the corners.
+ *
+ * Six rows even when five would do (and a 28-day February starting on the
+ * first day of the week needs only four) because the alternative is a picker
+ * whose popup changes height as you page through it, moving the very buttons
+ * the pointer is aiming at.
+ */
+export function monthGrid(month, weekStartsOn = 1) {
+  const first = firstOfMonth(month);
+  const lead = (dayParts(first).weekday - weekStartsOn + 7) % 7;
+  const start = addDays(first, -lead);
+  const weeks = [];
+  for (let w = 0; w < 6; w++) {
+    const days = [];
+    for (let d = 0; d < 7; d++) days.push(addDays(start, w * 7 + d));
+    weeks.push(days);
+  }
+  return weeks;
+}
+
+// Intl formatters are expensive to build and every cell in the grid wants the
+// same three, so they are made once per (locale, shape) and kept.
+const formatters = new Map();
+
+function formatter(locale, options) {
+  const id = `${locale ?? ''}|${JSON.stringify(options)}`;
+  let f = formatters.get(id);
+  if (!f) {
+    // everything here is a UTC-midnight Date, so the formatter has to read it
+    // in UTC or a negative offset prints the day before
+    f = new Intl.DateTimeFormat(locale, { ...options, timeZone: 'UTC' });
+    formatters.set(id, f);
+  }
+  return f;
+}
+
+/**
+ * Which day the week starts on for a locale: `0` Sunday … `6` Saturday.
+ *
+ * The runtime knows this — CLDR carries it — but only through
+ * `Intl.Locale#getWeekInfo`, which is recent enough that a small-ICU build or
+ * an older V8 has neither it nor the `weekInfo` property it was proposed as.
+ * So it is feature-detected, and what is left when it is missing is **Monday**:
+ * ISO 8601's answer, and the one most of the world uses.
+ */
+export function localeWeekStart(locale) {
+  try {
+    const info = new Intl.Locale(locale ?? undefined);
+    const week = info.getWeekInfo?.() ?? info.weekInfo;
+    // CLDR counts 1 Monday … 7 Sunday; JS counts 0 Sunday … 6 Saturday
+    if (week?.firstDay) return week.firstDay % 7;
+  } catch {
+    // an invalid locale tag: the caller's formatters will complain about it
+    // more usefully than a week-start fallback could
+  }
+  return 1;
+}
+
+/** `['Mon', 'Tue', …]` in the locale, rotated to start on `weekStartsOn`. */
+export function weekdayLabels(locale, weekStartsOn = 1) {
+  const f = formatter(locale, { weekday: 'short' });
+  // 2026-08-02 is a Sunday, so `+ weekday` lands on the day we want a name for
+  return Array.from({ length: 7 }, (_, i) =>
+    f.format(dayDate(addDays('2026-08-02', (weekStartsOn + i) % 7))),
+  );
+}
+
+/** `'August 2026'` in the locale. */
+export function formatMonth(month, locale) {
+  return formatter(locale, { month: 'long', year: 'numeric' }).format(
+    dayDate(firstOfMonth(month)),
+  );
+}
+
+/** `'7 Aug 2026'` in the locale — what a picker's trigger shows. */
+export function formatDay(day, locale, options) {
+  return formatter(locale, options ?? { dateStyle: 'medium' }).format(
+    dayDate(day),
+  );
+}
+
+/**
+ * `'7 – 12 Aug 2026'`: the locale's own way of writing a span, which collapses
+ * the parts the two ends share. `formatRange` is ES2021 and universal in the
+ * Node versions this package supports, but a small-ICU build can still throw,
+ * so a plain "a – b" is kept behind it.
+ */
+export function formatDayRange(start, end, locale, options) {
+  const f = formatter(locale, options ?? { dateStyle: 'medium' });
+  try {
+    return f.formatRange(dayDate(start), dayDate(end));
+  } catch {
+    return `${f.format(dayDate(start))} – ${f.format(dayDate(end))}`;
+  }
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -12,6 +12,8 @@ export {
 } from './anchor.js';
 export { useDropTarget, useDragSource } from './dnd.js';
 export { Button } from './Button.js';
+export { Calendar } from './Calendar.js';
+export { DatePicker } from './DatePicker.js';
 export { Dialog } from './Dialog.js';
 export { FileDialog } from './FileDialog.js';
 export { Checkbox } from './Checkbox.js';

--- a/src/index.js
+++ b/src/index.js
@@ -33,6 +33,8 @@ export {
   ThemeProvider,
   useTheme,
   Button,
+  Calendar,
+  DatePicker,
   Checkbox,
   Radio,
   RadioGroup,

--- a/src/testing/mock-app.js
+++ b/src/testing/mock-app.js
@@ -151,6 +151,13 @@ export function createMockApp() {
         fillRect(x, y, w, h) {
           ops.push(['fillRect', x, y, w, h, ctx.fillStyle]);
         },
+        // ntk's context has this beside `fillRect`, so an `onDraw` that
+        // outlines a box paints on a real server and used to crash on the
+        // mock — a missing method here is an app's headless test failing at
+        // something that works
+        strokeRect(x, y, w, h) {
+          ops.push(['strokeRect', x, y, w, h, ctx.strokeStyle, ctx.lineWidth]);
+        },
         beginPath() {},
         clearRect(x, y, w, h) {
           ops.push(['clearRect', x, y, w, h]);

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -3,7 +3,7 @@
  * `ThemeProvider`. See docs/components.md.
  */
 
-import type { ComponentType, ReactNode, RefObject } from 'react';
+import type { ComponentType, ReactNode, Ref, RefObject } from 'react';
 import type { ColorSchemePreference } from './appearance.js';
 import type { Color, StyleProp } from './style.js';
 import type { BoxProps, GlAreaProps, Vec3 } from './elements.js';
@@ -16,6 +16,7 @@ import type {
   DropAccept,
   DropEvent,
   DropTargetProps,
+  KeyboardEvent,
   MouseEvent,
 } from './events.js';
 
@@ -158,6 +159,121 @@ export interface ButtonProps extends WidgetProps {
   style?: StyleProp;
 }
 export const Button: ComponentType<ButtonProps>;
+
+/**
+ * A calendar day, `'2026-08-07'`. Not a `Date`: a square on a wall calendar
+ * has no time and no zone, and two of them compare equal only if both were
+ * built the same way. As a string, `===` is "the same day" and `<` is
+ * "earlier".
+ */
+export type CalendarDay = string;
+
+/** What a day prop takes: a day, or a `Date` read as its **local** day. */
+export type DayInput = CalendarDay | Date | null;
+
+/** A span. `end` is `null` while only one end has been picked. */
+export interface DateRange {
+  start: CalendarDay | null;
+  end: CalendarDay | null;
+}
+
+export interface DateRangeInput {
+  start?: DayInput;
+  end?: DayInput;
+}
+
+/** The day, taken apart — so `isDateBlocked` need not parse the string. */
+export interface DayParts {
+  year: number;
+  /** 1-based, unlike `Date`'s. */
+  month: number;
+  day: number;
+  /** `0` Sunday … `6` Saturday, as `Date#getDay()` counts. */
+  weekday: number;
+  /** The day as a UTC-midnight `Date`. */
+  date: Date;
+}
+
+/** What a cell is, when `dayContent` is asked what to draw in it. */
+export interface CalendarDayState {
+  blocked: boolean;
+  /** A day of the neighbouring month, filling a corner of the grid. */
+  outside: boolean;
+  today: boolean;
+  selected: boolean;
+  inRange: boolean;
+  /** Inside a range that is being previewed rather than picked. */
+  preview: boolean;
+  focused: boolean;
+  /** The colour the day's number is drawn in — a marker that follows it
+   * stays legible on the filled ends of a range. */
+  color: Color;
+}
+
+/** A `<Calendar>`'s imperative side, for a control that holds the keyboard on
+ * its behalf. `handleKey` reports whether the grid took the key. */
+export interface CalendarHandle {
+  handleKey: (ev: KeyboardEvent<DrawnNode>) => boolean;
+}
+
+interface CalendarCommonProps extends WidgetProps, NamedWidget {
+  /** Visible month, `'2026-08'`; controlled with `onMonthChange`. */
+  month?: string | null;
+  defaultMonth?: string | Date | null;
+  onMonthChange?: (month: string) => void;
+  min?: DayInput;
+  max?: DayInput;
+  /** Everything `min`/`max` cannot say — weekends, holidays, days the
+   * server reports as taken. */
+  isDateBlocked?: (day: CalendarDay, parts: DayParts) => boolean;
+  /** Let a range run across blocked days; only its ends must be free. */
+  spanBlocked?: boolean;
+  /** Drawn under the number, in a strip reserved only when this is given —
+   * the seam for event dots, prices, availability counts. */
+  dayContent?: (day: CalendarDay, state: CalendarDayState) => ReactNode;
+  /** BCP 47 tag for the month name, weekday names and the trigger's label.
+   * The system locale by default. */
+  locale?: string;
+  /** `0` Sunday … `6` Saturday. The locale's own answer by default, and
+   * Monday where the runtime does not know it. */
+  weekStartsOn?: number;
+  style?: StyleProp;
+}
+
+export interface SingleCalendarProps extends CalendarCommonProps {
+  mode?: 'single';
+  value?: DayInput;
+  defaultValue?: DayInput;
+  onChange?: (ev: WidgetChangeEvent<CalendarDay>) => void;
+}
+
+export interface RangeCalendarProps extends CalendarCommonProps {
+  mode: 'range';
+  value?: DateRangeInput | null;
+  defaultValue?: DateRangeInput | null;
+  onChange?: (ev: WidgetChangeEvent<DateRange>) => void;
+}
+
+export type CalendarProps = (SingleCalendarProps | RangeCalendarProps) & {
+  /** A tab stop by default. Off for a calendar whose keys come from
+   * elsewhere — a picker's trigger, which the popup cannot take focus
+   * from. */
+  focusable?: boolean;
+  /** Draw the day cursor even though this grid does not hold the focus,
+   * which is what that same case needs. */
+  focusVisible?: boolean;
+  ref?: Ref<CalendarHandle>;
+};
+export const Calendar: ComponentType<CalendarProps>;
+
+export type DatePickerProps = (SingleCalendarProps | RangeCalendarProps) & {
+  /** The trigger's label. The locale's medium date by default, and
+   * `Intl`'s own range format for two of them. */
+  format?: (value: unknown) => string | null | undefined;
+  placeholder?: string;
+  disabled?: boolean;
+};
+export const DatePicker: ComponentType<DatePickerProps>;
 
 export interface CheckboxProps extends WidgetProps, NamedWidget {
   children?: ReactNode;

--- a/test/calendar.test.js
+++ b/test/calendar.test.js
@@ -1,0 +1,401 @@
+// Calendar and DatePicker: picking a day, picking a span, and the days an
+// application has taken off the board.
+//
+// The grid is pinned to August 2026 throughout, which starts on a Saturday.
+// With the week starting on Monday that leaves five days of July in the first
+// row, so August's 1st is cell 5 and its Nth is cell N + 4 — worked out here
+// rather than read back out of `monthGrid`, so a broken grid cannot agree with
+// the test about where it put things.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import { Calendar, DatePicker, createRoot } from '../src/index.js';
+import { createMockApp } from './helpers/mock-app.js';
+import {
+  addDays,
+  formatDayRange,
+  monthGrid,
+  toDay,
+  weekdayLabels,
+} from '../src/components/dates.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+const settle = async () => {
+  await tick();
+  await tick();
+};
+
+const MONTH = '2026-08';
+/** Cell index of the Nth of August 2026 in a Monday-first grid. */
+const cellOf = (n) => n + 4;
+
+const XK = {
+  LEFT: 0xff51,
+  UP: 0xff52,
+  RIGHT: 0xff53,
+  DOWN: 0xff54,
+  PAGE_UP: 0xff55,
+  PAGE_DOWN: 0xff56,
+  RETURN: 0xff0d,
+};
+
+/** Every node under `from`, popups included — a `<popup>` is its own X window
+ *  but still a child in the tree, which is where the calendar a picker opens
+ *  lives. */
+function nodes(from, pred) {
+  const out = [];
+  const walk = (node) => {
+    if (!node) return;
+    if (pred(node)) out.push(node);
+    for (const child of node.children) walk(child);
+  };
+  walk(from);
+  return out;
+}
+
+const treeOf = (app) => app.windows[0]._reactX11Node;
+const cells = (app) => nodes(treeOf(app), (n) => n.props?.role === 'gridcell');
+const texts = (node) =>
+  nodes(node, (n) => n.kind === 'text').map((n) => String(n.props.children));
+const labelOf = (cell) => texts(cell)[0];
+
+function click(app, node) {
+  const window = node.root.window;
+  const x = node.abs.x + node.abs.width / 2;
+  const y = node.abs.y + node.abs.height / 2;
+  window.emit('mousedown', { x, y, keycode: 1 });
+  window.emit('mouseup', { x, y, keycode: 1 });
+}
+
+function hover(app, node) {
+  const window = node.root.window;
+  window.emit('mousemove', {
+    x: node.abs.x + node.abs.width / 2,
+    y: node.abs.y + node.abs.height / 2,
+    buttons: 0,
+  });
+}
+
+function press(app, keysym, { shift = false } = {}) {
+  const keycode = (keysym % 248) + 8;
+  app.X.keycode2keysyms[keycode] = [keysym];
+  app.windows[0].emit('keydown', { keycode, buttons: shift ? 1 : 0 });
+}
+
+async function mount(props, { component = Calendar } = {}) {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(
+    h(
+      'window',
+      { width: 420, height: 460 },
+      h(component, { defaultMonth: MONTH, locale: 'en-GB', ...props }),
+    ),
+  );
+  await settle();
+  return { app, root };
+}
+
+test('the grid is six weeks, Monday first, with the neighbouring days on it', async () => {
+  const { app, root } = await mount({});
+
+  const grid = cells(app);
+  assert.strictEqual(grid.length, 42, 'six weeks of seven days, always');
+  assert.strictEqual(labelOf(grid[0]), '27', 'the Monday before the 1st');
+  assert.strictEqual(labelOf(grid[cellOf(1)]), '1');
+  assert.strictEqual(labelOf(grid[cellOf(31)]), '31');
+  assert.strictEqual(labelOf(grid[41]), '6', 'and on into September');
+
+  await root.unmount();
+});
+
+test('clicking a day reports it as a YYYY-MM-DD string', async () => {
+  const picked = [];
+  const { app, root } = await mount({
+    onChange: (ev) => picked.push(ev.value),
+  });
+
+  click(app, cells(app)[cellOf(12)]);
+  await settle();
+  assert.deepStrictEqual(picked, ['2026-08-12']);
+
+  await root.unmount();
+});
+
+test('clicking a day of the next month turns the page with it', async () => {
+  const months = [];
+  const { app, root } = await mount({ onMonthChange: (m) => months.push(m) });
+
+  click(app, cells(app)[41]);
+  await settle();
+  assert.deepStrictEqual(months, ['2026-09']);
+  // September 2026 starts on a Tuesday, so a Monday-first grid opens on
+  // August the 31st and the 1st is the cell after it
+  assert.strictEqual(labelOf(cells(app)[0]), '31');
+  assert.strictEqual(labelOf(cells(app)[1]), '1', 'September the 1st');
+
+  await root.unmount();
+});
+
+test('a blocked day answers nothing, and so do the days past min/max', async () => {
+  const picked = [];
+  const { app, root } = await mount({
+    onChange: (ev) => picked.push(ev.value),
+    min: '2026-08-05',
+    max: '2026-08-20',
+    // every Saturday and Sunday
+    isDateBlocked: (_day, { weekday }) => weekday === 0 || weekday === 6,
+  });
+
+  click(app, cells(app)[cellOf(15)]); // a Saturday
+  click(app, cells(app)[cellOf(3)]); // before min
+  click(app, cells(app)[cellOf(25)]); // after max
+  await settle();
+  assert.deepStrictEqual(picked, [], 'none of the three was selectable');
+
+  click(app, cells(app)[cellOf(12)]);
+  await settle();
+  assert.deepStrictEqual(picked, ['2026-08-12'], 'and a free day still is');
+
+  await root.unmount();
+});
+
+test('a range takes two clicks, and reports the half-picked state in between', async () => {
+  const picked = [];
+  const { app, root } = await mount({
+    mode: 'range',
+    onChange: (ev) => picked.push(ev.value),
+  });
+
+  click(app, cells(app)[cellOf(10)]);
+  await settle();
+  click(app, cells(app)[cellOf(14)]);
+  await settle();
+
+  assert.deepStrictEqual(picked, [
+    { start: '2026-08-10', end: null },
+    { start: '2026-08-10', end: '2026-08-14' },
+  ]);
+
+  await root.unmount();
+});
+
+test('clicking before the start re-anchors the range instead of selecting backwards', async () => {
+  const picked = [];
+  const { app, root } = await mount({
+    mode: 'range',
+    onChange: (ev) => picked.push(ev.value),
+  });
+
+  click(app, cells(app)[cellOf(10)]);
+  await settle();
+  click(app, cells(app)[cellOf(4)]);
+  await settle();
+
+  assert.deepStrictEqual(picked.at(-1), { start: '2026-08-04', end: null });
+
+  await root.unmount();
+});
+
+test('a range stops at a blocked day, and spanBlocked lets it across', async () => {
+  const blockedWednesday = (day) => day === '2026-08-12';
+
+  const picked = [];
+  const { app, root } = await mount({
+    mode: 'range',
+    onChange: (ev) => picked.push(ev.value),
+    isDateBlocked: blockedWednesday,
+  });
+
+  click(app, cells(app)[cellOf(10)]);
+  await settle();
+  click(app, cells(app)[cellOf(14)]); // past the blocked day
+  await settle();
+  assert.deepStrictEqual(
+    picked.at(-1),
+    { start: '2026-08-10', end: null },
+    'the end past a blocked day was refused',
+  );
+
+  click(app, cells(app)[cellOf(11)]); // short of it
+  await settle();
+  assert.deepStrictEqual(picked.at(-1), {
+    start: '2026-08-10',
+    end: '2026-08-11',
+  });
+
+  await root.unmount();
+
+  const spanned = [];
+  const across = await mount({
+    mode: 'range',
+    spanBlocked: true,
+    onChange: (ev) => spanned.push(ev.value),
+    isDateBlocked: blockedWednesday,
+  });
+  click(across.app, cells(across.app)[cellOf(10)]);
+  await settle();
+  click(across.app, cells(across.app)[cellOf(14)]);
+  await settle();
+  assert.deepStrictEqual(spanned.at(-1), {
+    start: '2026-08-10',
+    end: '2026-08-14',
+  });
+
+  await across.root.unmount();
+});
+
+test('the pointer previews the other end of a half-picked range', async () => {
+  const { app, root } = await mount({ mode: 'range' });
+
+  click(app, cells(app)[cellOf(10)]);
+  await settle();
+  hover(app, cells(app)[cellOf(13)]);
+  await settle();
+
+  // the band is an extra box in the cells the range would cover, and in
+  // nothing else
+  const banded = (n) => cells(app)[n].children.length > 1;
+  assert.ok(banded(cellOf(11)), 'a day inside the preview is banded');
+  assert.ok(banded(cellOf(13)), 'and so is the end under the pointer');
+  assert.ok(!banded(cellOf(14)), 'but nothing past it');
+  assert.ok(!banded(cellOf(9)), 'and nothing before the start');
+
+  await root.unmount();
+});
+
+test('arrows move a day and a week, and Enter takes the one they land on', async () => {
+  const picked = [];
+  const { app, root } = await mount({
+    defaultValue: '2026-08-10',
+    onChange: (ev) => picked.push(ev.value),
+  });
+
+  treeOf(app).children[0].focus();
+  press(app, XK.RIGHT);
+  press(app, XK.DOWN);
+  await settle();
+  press(app, XK.RETURN);
+  await settle();
+  assert.deepStrictEqual(picked, ['2026-08-18'], 'one day on, then one week');
+
+  press(app, XK.LEFT);
+  press(app, XK.UP);
+  await settle();
+  press(app, XK.RETURN);
+  await settle();
+  assert.deepStrictEqual(picked.at(-1), '2026-08-10', 'and back again');
+
+  await root.unmount();
+});
+
+test('PageUp/PageDown change the month, with Shift the year', async () => {
+  const months = [];
+  const { app, root } = await mount({ onMonthChange: (m) => months.push(m) });
+
+  treeOf(app).children[0].focus();
+  press(app, XK.PAGE_DOWN);
+  await settle();
+  press(app, XK.PAGE_UP, { shift: true });
+  await settle();
+
+  assert.deepStrictEqual(months, ['2026-09', '2025-09']);
+
+  await root.unmount();
+});
+
+test('dayContent draws under the number, and hears what the day is', async () => {
+  const seen = new Map();
+  const { app, root } = await mount({
+    defaultValue: '2026-08-12',
+    dayContent: (day, state) => {
+      seen.set(day, state);
+      return day === '2026-08-12' ? h('text', null, '•') : null;
+    },
+  });
+
+  assert.strictEqual(seen.size, 42, 'asked once per cell on the grid');
+  assert.strictEqual(seen.get('2026-08-12').selected, true);
+  assert.strictEqual(seen.get('2026-07-27').outside, true);
+  assert.ok(
+    texts(cells(app)[cellOf(12)]).includes('•'),
+    'and what it returned is in the cell',
+  );
+
+  await root.unmount();
+});
+
+test('a DatePicker opens its calendar on the press and closes on the pick', async () => {
+  const picked = [];
+  const { app, root } = await mount(
+    { onChange: (ev) => picked.push(ev.value) },
+    { component: DatePicker },
+  );
+
+  const trigger = treeOf(app).children[0];
+  assert.strictEqual(cells(app).length, 0, 'nothing is open yet');
+
+  app.windows[0].emit('mousedown', {
+    x: trigger.abs.x + 4,
+    y: trigger.abs.y + 4,
+    keycode: 1,
+  });
+  await settle();
+  assert.strictEqual(cells(app).length, 42, 'the press alone opened it');
+
+  click(app, cells(app)[cellOf(12)]);
+  await settle();
+  assert.deepStrictEqual(picked, ['2026-08-12']);
+  assert.strictEqual(cells(app).length, 0, 'and picking closed it');
+
+  await root.unmount();
+});
+
+test('a range picker stays open until both ends are in', async () => {
+  const { app, root } = await mount(
+    { mode: 'range' },
+    { component: DatePicker },
+  );
+
+  const trigger = treeOf(app).children[0];
+  app.windows[0].emit('mousedown', {
+    x: trigger.abs.x + 4,
+    y: trigger.abs.y + 4,
+    keycode: 1,
+  });
+  await settle();
+
+  click(app, cells(app)[cellOf(10)]);
+  await settle();
+  assert.strictEqual(cells(app).length, 42, 'still up for the other end');
+
+  click(app, cells(app)[cellOf(14)]);
+  await settle();
+  assert.strictEqual(cells(app).length, 0);
+  assert.strictEqual(
+    texts(treeOf(app))[0],
+    formatDayRange('2026-08-10', '2026-08-14', 'en-GB'),
+    'and the trigger says so',
+  );
+
+  await root.unmount();
+});
+
+test('a day is a string, a Date is read as its local day, and rubbish throws', () => {
+  assert.strictEqual(toDay('2026-08-07'), '2026-08-07');
+  assert.strictEqual(toDay(new Date(2026, 7, 7)), '2026-08-07');
+  assert.strictEqual(toDay(null), null);
+  assert.throws(() => toDay('7/8/2026'), /YYYY-MM-DD/);
+  assert.throws(() => toDay('2026-02-30'), /not a real calendar date/);
+  assert.strictEqual(addDays('2026-02-28', 1), '2026-03-01');
+  assert.strictEqual(addDays('2024-02-28', 1), '2024-02-29', 'a leap year');
+});
+
+test('the week starts where the caller says, and the labels follow', () => {
+  const [first] = monthGrid(MONTH, 0);
+  assert.strictEqual(first[0], '2026-07-26', 'a Sunday-first grid');
+  assert.strictEqual(monthGrid(MONTH, 1)[0][0], '2026-07-27');
+  assert.deepStrictEqual(weekdayLabels('en-GB', 1).slice(0, 2), ['Mon', 'Tue']);
+  assert.strictEqual(weekdayLabels('en-GB', 0)[0], 'Sun');
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -10,6 +10,7 @@ import React, { useRef, useState } from 'react';
 import { startTrace } from 'react-x11/debug';
 import type {
   BusHandle,
+  CalendarHandle,
   BusKind,
   BusRef,
   BusStatus,
@@ -19,6 +20,7 @@ import type {
 import {
   Button,
   BusUnavailableError,
+  Calendar,
   Canvas3D,
   Checkbox,
   closeBus,
@@ -35,6 +37,7 @@ import {
   useSystemBus,
   ContextMenu,
   createRoot,
+  DatePicker,
   createStyles,
   Dialog,
   flattenStyle,
@@ -387,6 +390,7 @@ const _pressedPalette = (
 
 function Widgets() {
   const anchorRef = useRef<DrawnNode>(null);
+  const calendar = useRef<CalendarHandle>(null);
   const anchor = useAnchor(anchorRef);
   const [checked, setChecked] = useState(false);
 
@@ -448,6 +452,44 @@ function Widgets() {
         />
         <Select options={['plain', 'values']} />
       </box>
+
+      <Calendar
+        value="2026-08-07"
+        min={new Date()}
+        max="2026-12-31"
+        isDateBlocked={(day, parts) =>
+          day > '2026-09-01' && parts.weekday === 0
+        }
+        dayContent={(day, state) => (
+          <text style={{ color: state.color }}>{day}</text>
+        )}
+        onChange={(ev) => void ev.value.slice(0, 4)}
+      />
+      <Calendar
+        mode="range"
+        defaultValue={{ start: '2026-08-01', end: null }}
+        spanBlocked
+        weekStartsOn={0}
+        locale="en-GB"
+        onMonthChange={(month) => void month.length}
+        onChange={(ev) => void (ev.value.start ?? '').length}
+      />
+      <Calendar ref={calendar} focusable={false} focusVisible />
+      <DatePicker
+        name="when"
+        value={null}
+        placeholder="When?"
+        onChange={(ev) => void ev.value}
+      />
+      <DatePicker
+        mode="range"
+        value={{ start: '2026-08-01', end: '2026-08-04' }}
+        format={(value) => String(value)}
+        disabled
+        onChange={(ev) => void ev.value.end}
+      />
+      {/* @ts-expect-error a range value needs mode="range" */}
+      <Calendar value={{ start: '2026-08-01', end: null }} />
 
       <Tabs
         items={[{ id: 'a', label: 'A', content: <box /> }]}

--- a/website/scripts/check-demos.mjs
+++ b/website/scripts/check-demos.mjs
@@ -146,6 +146,7 @@ const exercises = {
   'size-queries': (server) => click(server, 0x2980b9), // resize the window
   widgets: (server) => click(server, 0x0a84ff), // the primary "Mute" button
   events: (server) => click(server, 0x2980b9), // the inner box
+  dates: (server) => click(server, 0x2980b9), // the primary Clear button
   tasks(server) {
     click(server, 0x27ae60); // the done task's checkbox
     // and the editor: click into the input, then type

--- a/website/src/demos/dates.js
+++ b/website/src/demos/dates.js
@@ -1,0 +1,96 @@
+export default {
+  id: 'dates',
+  title: 'Dates',
+  description:
+    'DatePicker drops a Calendar on a real popup window; the same grid runs ' +
+    'inline. A day is a "YYYY-MM-DD" string in and out, days can be blocked ' +
+    'outright, a range refuses to run across one, and dayContent draws ' +
+    'whatever you like under the number — here, the events for that day.',
+  code: `import React, { useState } from 'react';
+import { createRoot, Button, Calendar, DatePicker } from 'react-x11';
+
+// Everything a calendar takes is a day, and a day is a string. So a diary is
+// an object keyed by one, and "is there anything on?" is a lookup.
+const EVENTS = {
+  '2026-08-06': [{ time: '09:30', kind: 'work' }],
+  '2026-08-11': [{ time: '19:00', kind: 'personal' }],
+  '2026-08-13': [
+    { time: '08:05', kind: 'travel' },
+    { time: '11:00', kind: 'work' },
+  ],
+  '2026-08-20': [{ time: '10:00', kind: 'personal' }],
+};
+const KIND = { work: '#e67e22', personal: '#27ae60', travel: '#8e44ad' };
+
+// Days somebody else already has. A range may not be drawn across one.
+const BOOKED = new Set(['2026-08-17', '2026-08-18']);
+
+function App() {
+  const [day, setDay] = useState('2026-08-13');
+  const [stay, setStay] = useState({ start: null, end: null });
+
+  return (
+    <window x={30} y={30} width={560} height={430} title="dates"
+            style={{ backgroundColor: '#ffffff' }}>
+      <box style={{ padding: 14, gap: 12 }}>
+        <box style={{ flexDirection: 'row', gap: 10, alignItems: 'center' }}>
+          <DatePicker
+            mode="range"
+            value={stay}
+            defaultMonth="2026-08"
+            min="2026-08-01"
+            isDateBlocked={(d) => BOOKED.has(d)}
+            onChange={(ev) => setStay(ev.value)}
+            style={{ width: 230 }}
+          />
+          <Button primary onPress={() => setStay({ start: null, end: null })}>
+            Clear
+          </Button>
+        </box>
+
+        <box style={{ flexDirection: 'row', gap: 14 }}>
+          <Calendar
+            value={day}
+            defaultMonth="2026-08"
+            locale="en-GB"
+            onChange={(ev) => setDay(ev.value)}
+            dayContent={(d, state) =>
+              (EVENTS[d] || []).map((event, i) => (
+                <box
+                  key={i}
+                  style={{
+                    width: 5,
+                    height: 5,
+                    borderRadius: 3,
+                    backgroundColor: state.selected ? state.color : KIND[event.kind],
+                  }}
+                />
+              ))
+            }
+          />
+          <box style={{ gap: 6, flexGrow: 1 }}>
+            <text style={{ fontSize: 15 }}>{day}</text>
+            {(EVENTS[day] || []).map((event) => (
+              <text key={event.time} style={{ fontSize: 12, color: '#7f8c8d' }}>
+                {event.time} — {event.kind}
+              </text>
+            ))}
+            {!EVENTS[day] && (
+              <text style={{ fontSize: 12, color: '#7f8c8d' }}>Nothing on.</text>
+            )}
+            <text style={{ fontSize: 11, color: '#7f8c8d', marginTop: 8 }}>
+              Two days in the middle of the month are taken: a range stops
+              short of them. Arrows walk the grid, PageUp and PageDown change
+              month, Enter picks.
+            </text>
+          </box>
+        </box>
+      </box>
+    </window>
+  );
+}
+
+const root = await createRoot();
+root.render(<App />);
+`,
+};

--- a/website/src/demos/index.js
+++ b/website/src/demos/index.js
@@ -4,6 +4,7 @@ import styling from './styling.js';
 import sizeQueries from './size-queries.js';
 import widgets from './widgets.js';
 import events from './events.js';
+import dates from './dates.js';
 import tasks from './tasks.js';
 import canvas from './canvas.js';
 import menu from './menu.js';
@@ -23,6 +24,7 @@ const demos = [
   sizeQueries,
   widgets,
   events,
+  dates,
   tasks,
   canvas,
   menu,


### PR DESCRIPTION
`<Calendar>` is the month grid; `<DatePicker>` hangs the same grid off a field
on a real `<popup>` window. Single date, range, and any day blockable.

![calendar-panel](https://github.com/user-attachments/assets/363fa9b3-e987-40ee-9012-6f630eb0b158)

`examples/datepicker.jsx` — `npm run examples:datepicker`, or the **Dates** tab
of `npm run examples:app`. Both shots are rendered by this branch's own code
into node-x11's in-process X server.

## A day is a string

`'2026-08-07'` in and out, not a `Date`. A square on a wall calendar is not an
instant — no time, no zone, no length that survives a DST boundary — so two
`Date`s for "the 7th" are equal only if both were built the same way.
`new Date(2026, 7, 7)` and `new Date('2026-08-07')` are eleven hours apart in
Sydney and neither is wrong. As a string, `===` is "the same day", `<` is
"earlier", it is a `Set` key with no codec, and it is the shape a calendar API
already answers in — which matters for the overlay this is meant to grow.

A `Date` is accepted anywhere a day is taken and read as its **local** calendar
day. Anything else throws, and so does a date that does not exist: `'2026-02-30'`
is a typo, and sliding it quietly to March 2nd the way `new Date()` does is how
a booking ends up a day out.

## Blocking, and what a range does about it

`min`/`max` for the bounds, `isDateBlocked(day, parts)` for everything else —
`parts` is `{ year, month, day, weekday, date }`, so blocking weekends does not
have to parse the string back apart.

**A range may not contain a blocked day.** The preview stops at the first one
and an end past it is refused, because an app that blocked a date did not mean
"unless it is in the middle", and a selection that quietly included it would
have to be validated all over again on the way out. `spanBlocked` is the other
reading — only the two ends must be free — for the holidays a stay is allowed
to run across.

The first click reports `{ start, end: null }` and the second completes the
range, so a controlled picker drives the whole interaction from its own value
and there is no hidden pending state to get out of step with. Clicking before
the start re-anchors rather than selecting backwards, and the pointer previews
the end it would land on:

![range-preview](https://github.com/user-attachments/assets/c3fa8207-17f8-4171-a879-03a8cc1da74a)

## The seam for the next iteration

`dayContent(day, state)` renders inside the cell, under the number, in a strip
the grid reserves only when the prop is there. It is a callback returning
nodes — nothing about events is special-cased in the widget — and `state` is
`{ selected, inRange, blocked, outside, today, focused, color }`, where `color`
is what the number itself is being drawn in, so a marker stays legible on the
filled ends of a range. The example overlays a diary through it, dots by event
kind, and lists that day's events beside the grid.

## Keyboard

A single tab stop. Arrows by a day and by a week, Home/End along the week,
PageUp/PageDown by month and with Shift by year, Enter and Space pick. Blocked
days can be moved *through* but not onto. A calendar on a popup does not hold
the keyboard — the trigger does, feeding it keys through the `handleKey` on its
ref, because an override-redirect window never takes focus; that ref is public
for anything else that has to drive a calendar it cannot focus.

## Also in here

- `strokeRect` on the test mock's 2d context. ntk has it and the mock did not,
  so an app's headless test of a `<canvas onDraw>` that outlines a box crashed
  at something that works on a real server. Hit while drawing the picker's
  calendar glyph.
- A note on `scripts/screenshots.jsx`: its frozen `Date.now()` also freezes
  every transition, since `nodes.js` drives them off it — an animation started
  by a scene stalls at t=0 and photographs the colour a control was leaving
  rather than the one it landed on. Cost half an hour here as a phantom repaint
  bug; harmless for the committed shots, which capture at rest.

## Not in here

**Time of day.** The requirement list was date selection, ranges and blocked
days, and a time field is a different control with a different value — worth
adding as `<TimeField>` beside this, or as an `'2026-08-07T09:30'` extension of
the same string, rather than half-doing it inside the grid.

## Testing

`test/calendar.test.js` — 15 cases over the mock app: the shape of the grid,
picking, blocking, the two-click range and its refusal across a blocked day,
`spanBlocked`, the hover preview, the keyboard, `dayContent`, and the picker's
popup opening and closing. Mutation-checked: removing the blocked-day guards or
the range's wall makes the relevant case fail.

`npm run typecheck` with new cases in `test/types/api.tsx`, `docs/components.md`
has the reference section, and `website/src/demos/dates.js` is a playground demo
that the site's `check-demos` run exercises.

Six failures in `test/appearance.test.js` on this machine are pre-existing on
`origin/master` — macOS answers the appearance query before XSETTINGS can.

