### PR TITLE
feat(components): a password field that scribbles instead of counting

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,9 @@ Widget **components** (plain React on top of the primitives, themable via
 `ThemeProvider`): `Button`, `Checkbox`, `Radio`/`RadioGroup`, `Switch`,
 `Slider`, `ProgressBar`, `Select`, `Tooltip`, `MenuBar`/`ContextMenu`,
 `Calendar`/`DatePicker` — one date or a range, with days blockable and a
-seam for drawing into the cells — `Dialog` — a modal built on
+seam for drawing into the cells — `PasswordInput`, whose mask is a scribble
+that moves on every keystroke rather than a countable row of bullets —
+`Dialog` — a modal built on
 `<popup trapFocus>`, which traps Tab and restores focus when it closes —
 plus the two containers an application window is built from: `Tabs`, `Tree`
 and `SplitPane`. See
@@ -259,6 +261,7 @@ npm run examples:menu          # right-click context menu via <popup>
 npm run examples:transparent   # rounded translucent <popup transparent>
 npm run examples:form          # <textinput> + Select dropdowns
 npm run examples:datepicker    # Calendar/DatePicker: ranges, blocked days, events
+npm run examples:password      # PasswordInput: the scribble mask, and a custom one
 npm run examples:gl            # raw GL in a <glarea> (display-list cube)
 npm run examples:three         # <Canvas3D> scene: meshes, lights, textures
 npm run examples:wm            # a reparenting window manager (see below)

--- a/docs/components.md
+++ b/docs/components.md
@@ -528,14 +528,27 @@ does not: **this hides a glance, not a recording.** Someone watching the
 field grow keystroke by keystroke still counts the keystrokes, and a long
 password still sits in a visibly different bracket from a short one.
 
-### What it does not do
+### Two states, and what holds across both
 
-Editing is smaller than `<textinput>`'s, because a scribble has nowhere to
-put a caret: type, Backspace, Ctrl+Backspace / Ctrl+U / Delete to clear,
-Ctrl+V or Shift+Insert to paste, Enter to submit. No caret, no selection, no
-undo history — a rewindable secret is not a feature — and **no copy**:
-Ctrl+C and Ctrl+X do nothing, and the field never takes the PRIMARY
-selection, so a middle click in another window cannot spend it.
+**Masked**, editing is smaller than `<textinput>`'s, because a scribble has
+nowhere to put a caret: type, Backspace, Ctrl+Backspace / Ctrl+U / Delete to
+clear, Ctrl+V or Shift+Insert to paste, Enter to submit. No caret, no
+selection, no undo history — a rewindable secret is not a feature.
+
+**Revealed**, it is an ordinary text input, because that is what it looks
+like and anything else would be a trap. A real `<textinput>` takes the mask's
+place: caret, selection, arrow keys, a click into the middle of the word,
+undo, the edit menu. Focus follows the swap in both directions, and the
+reveal ends when the keyboard leaves the widget — not when it moves between
+the field and the input inside it.
+
+What holds in **both** states is that nothing leaves by a selection. Ctrl+C
+and Ctrl+X do nothing, the revealed input carries
+[`sensitive`](elements.md#sensitive) so its menu has no Cut or Copy, and
+neither state ever takes PRIMARY, so a middle click in another window cannot
+spend it. The line is between what is on screen and what is on the clipboard:
+the first stops being visible when the field is hidden, the second is
+readable by every client on the display until something else takes it.
 
 While the value is masked it is **never laid out and never drawn**: the mask
 is measured from one reference character, so the secret does not enter ntk's

--- a/docs/components.md
+++ b/docs/components.md
@@ -467,6 +467,103 @@ whole purpose is to be looked at gains nothing by waiting out the length of
 the click. It closes on the pick — on the _second_ end of a range — on Escape,
 on a second press of the trigger, and when the window loses focus.
 
+## `PasswordInput`
+
+A masked field whose mask is a **scribble**, not a row of bullets.
+
+```jsx
+<PasswordInput
+  value={secret}
+  onChange={(ev) => setSecret(ev.value)}
+  onSubmit={() => signIn()}
+/>
+```
+
+| prop                          |                                        |
+| ----------------------------- | -------------------------------------- |
+| `value` / `defaultValue`      | the secret; controlled with `onChange` |
+| `onChange(ev)`                | `ev.value` is the new value            |
+| `onSubmit(value)`             | Enter                                  |
+| `placeholder`                 | shown while empty (`'Password'`)       |
+| `revealable`                  | show the eye at all, default `true`    |
+| `revealed` / `onRevealChange` | drive the reveal yourself              |
+| `maxLength`                   | in code points                         |
+| `drawMask(ctx, info)`         | draw the mask yourself                 |
+| `disabled`                    | not focusable, not editable            |
+
+### Why a scribble
+
+Bullets answer the wrong question. They report **how many characters** have
+been typed — countably, from across the room — and they report almost nothing
+about the keystroke that just landed, because one more identical dot at the
+end of a row of identical dots is the least visible change a field could
+make. The feedback is weakest exactly where a password field needs it, and
+strongest exactly where it should not be.
+
+So the mask is a single stroke through points chosen by a generator seeded
+from the window id and a hash of the value. Every keystroke reseeds it, so
+**the whole curve moves on every character** — feedback you cannot miss — and
+nothing in the shape is per-character: the number of control points is fixed,
+so there is no wiggle to count.
+
+What does grow is the width, because a mask that did not would say nothing
+about progress. Each position contributes an advance drawn from a **second,
+window-seeded** stream, so the width only ever grows as you type, never
+twitches when a character is replaced, and is not a clean multiple of
+anything a glance could divide.
+
+The honest limit, since a mask that oversells itself is worse than one that
+does not: **this hides a glance, not a recording.** Someone watching the
+field grow keystroke by keystroke still counts the keystrokes, and a long
+password still sits in a visibly different bracket from a short one.
+
+### What it does not do
+
+Editing is smaller than `<textinput>`'s, because a scribble has nowhere to
+put a caret: type, Backspace, Ctrl+Backspace / Ctrl+U / Delete to clear,
+Ctrl+V or Shift+Insert to paste, Enter to submit. No caret, no selection, no
+undo history — a rewindable secret is not a feature — and **no copy**:
+Ctrl+C and Ctrl+X do nothing, and the field never takes the PRIMARY
+selection, so a middle click in another window cannot spend it.
+
+While the value is masked it is **never laid out and never drawn**: the mask
+is measured from one reference character, so the secret does not enter ntk's
+shaping cache and its glyphs never reach the X server. Revealing it costs
+what revealing it costs. The eye is a pointer affordance and not a tab stop,
+as GTK's peek icon is; `revealed` + `onRevealChange` put the toggle wherever
+your keyboard can reach it.
+
+Caps Lock is reported while it is on, from the modifier state on the keys as
+they arrive — the mistake that a masked field otherwise lets you make four
+times before telling you.
+
+### Drawing your own mask
+
+`drawMask(ctx, info)` replaces the scribble entirely; `info` is
+`{ width, height, seed, color, length }`, where `width` is the mask width the
+field worked out and `seed` is the value-and-window seed. The scribble itself
+is `strokeScribble` in `src/components/scribble.js`, which is worth reading
+before replacing it — the reasoning for each number is there.
+
+```jsx
+<PasswordInput
+  drawMask={(ctx, { width, height, color }) => {
+    ctx.fillStyle = color;
+    ctx.fillRect(0, height / 2 - 1, width, 2);
+  }}
+/>
+```
+
+### Password managers
+
+Paste and typing are the two seams that reach a field on this desktop, and
+both work here: XTEST auto-type arrives as ordinary key events, and Ctrl+V
+takes a secret from the clipboard with control characters stripped so a
+manager's trailing newline stays out of it. Which manager does what, what the
+window title has to do with it, and the seams that are _not_ a field —
+Secret Service, the sandbox portal, AT-SPI — are in
+[desktop.md](desktop.md#password-fields-and-password-managers).
+
 ## `Slider`
 
 A draggable value control.

--- a/docs/components.md
+++ b/docs/components.md
@@ -503,8 +503,19 @@ strongest exactly where it should not be.
 So the mask is a single stroke through points chosen by a generator seeded
 from the window id and a hash of the value. Every keystroke reseeds it, so
 **the whole curve moves on every character** — feedback you cannot miss — and
-nothing in the shape is per-character: the number of control points is fixed,
-so there is no wiggle to count.
+nothing in the shape is per-character: the pen visits a number of points taken
+from the mask's _width_, where a character is worth about half a point, so no
+part of the stroke can be matched to anything typed.
+
+It is a **scribble rather than a waveform**, and that is a decision rather
+than a look. A stroke whose `x` only ever increases is the plot of a
+function, and the eye reads it as one — value against position, meaning in
+the peaks — however wild the `y` is. So the points are laid out one per
+column, which is what makes the stroke cover the width it was given, and then
+visited **out of order**: the pen doubles back, crosses what it has already
+drawn, and leaves loops. The shuffle is local rather than global, because in
+a box seventeen pixels tall a jump right across it is a long shallow scratch,
+and a maskful of those is not a scribble either.
 
 What does grow is the width, because a mask that did not would say nothing
 about progress. Each position contributes an advance drawn from a **second,

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -1,7 +1,9 @@
 # Desktop integration
 
 What an app has to tell the desktop about itself, beyond drawing. Today that
-is startup notification; it is on by default and there is nothing to call.
+is startup notification, which is on by default and has nothing to call, and
+what a password field has to do to be reachable by the desktop's password
+managers.
 
 ## Startup notification
 
@@ -139,3 +141,107 @@ it. On X11 that is the pre-existing no-isolation story rather than a new
 exposure — see [security.md](security.md) — but it is the reason the
 messages carry the id the launcher gave us and nothing invented, and the
 reason the variable's value is never logged.
+
+## Password fields and password managers
+
+There is **no password-field protocol on the Linux desktop.** No toolkit
+publishes "this is a password field, fill it", and no manager asks. What
+exists instead are four seams, none of which a widget can opt into by
+declaring itself — they are things an application either supports or does
+not. `PasswordInput` supports the two that reach a field, and this is what
+they turn out to be.
+
+### 1. Typing — XTEST auto-type, and the keymap race
+
+The mechanism nearly every desktop manager uses is **auto-type**: KeePassXC
+matches the focused window's **title** against its entries, then synthesises
+the keystrokes. Its X11 backend is the whole of the story — `SendKeyEvent()`
+sends `XTestFakeKeyEvent()`, and for a character the current layout cannot
+type, `RemapKeycode()` writes the keysym into a spare keycode with
+`XkbSetMap()` first, `XSync`ing before it types.
+
+For us that is good news and one hazard:
+
+- **A faked key is an ordinary key.** XTEST events are delivered by the
+  server through the normal event path, so `PasswordInput` — and every other
+  focusable node — cannot tell auto-type from a person, and nothing has to be
+  done to support it. An auto-type sequence of `{USERNAME}{TAB}{PASSWORD}
+{ENTER}` walks a react-x11 form because Tab moves focus and Enter reaches
+  `onSubmit`.
+- **The window needs a title worth matching.** Auto-type's default matching is
+  on the window title, so `<window title="…">` is the integration surface.
+  A window titled after the document with nothing identifying the app is one
+  a user cannot write an auto-type rule for; `wmClass` is worth setting too,
+  since a manager that grew a smarter matcher would read that.
+- **The keymap race is real.** ntk refetches the mapping when the server sends
+  `MappingNotify`, which is what makes a remapped keycode decode correctly —
+  but the refetch is a round trip, and a manager that remaps, syncs and types
+  immediately can land its key before the reply does. The window is small and
+  only affects characters outside the user's layout, but a password of ASCII
+  is not the case that fails. Nothing here can close it; the fix belongs where
+  the map lives.
+
+### 2. Pasting — the clipboard, and the hint that keeps it out of history
+
+The other path every manager offers is copy-to-clipboard, usually with a
+countdown before it clears. That is ordinary `CLIPBOARD` interop
+([clipboard.md](clipboard.md)); `PasswordInput` takes Ctrl+V and
+Shift+Insert, and strips control characters so a manager's trailing newline
+does not end up inside the secret.
+
+If your app ever puts a secret **on** the clipboard — this widget never does
+— offer `x-kde-passwordManagerHint` with the value `secret` beside the text.
+Klipper drops such an offer from its history, KDE Connect refuses to forward
+it, and `wl-clipboard` marks the state sensitive. It is a convention rather
+than a specification, and it is the only thing standing between a copied
+password and a clipboard manager's on-disk history:
+
+```js
+clipboard.write({ UTF8_STRING: secret, 'x-kde-passwordManagerHint': 'secret' });
+```
+
+`PasswordInput` also never takes the **PRIMARY** selection, which a
+`<textinput>` does on every selection: PRIMARY is pasted by a middle click in
+any window on the display, and a secret does not belong in a selection that
+can be spent by accident.
+
+### 3. Fetching it yourself — the Secret Service
+
+When the app has an account of its own to unlock, the seam is not a field at
+all: the **Secret Service** D-Bus API, `org.freedesktop.secrets`, which
+gnome-keyring, KWallet and KeePassXC all implement, and which `libsecret`
+speaks for C applications. react-x11 has no wrapper for it and does not need
+one — `useSessionBus()` reaches it directly ([dbus.md](dbus.md)) — and the
+shape is: search by attributes, unlock the collection if it is locked, read
+the secret back. An app that does this shows no password field on most
+launches, which is a better outcome than any field can offer.
+
+Inside a sandbox that name is not there. Flatpak's answer is
+`org.freedesktop.portal.Secret`, whose `RetrieveSecret` hands the app a
+per-application master secret down a pipe; libsecret switches to it
+automatically and encrypts a local store with it.
+
+### 4. Reading the field — AT-SPI, which we do not implement
+
+The accessibility bus is the only channel through which an outside program
+can see a field's _contents and role_ rather than guess at a window title:
+AT-SPI2 gives a password entry the role `password text`, which is how a
+screen reader knows to announce "bullet" instead of the character. Some
+automation leans on the same tree. react-x11 has no accessibility tree yet
+(NEXT_STEPS §11.3) — `role` is a prop the testing queries read and nothing
+else — so this seam is closed here for now, and worth reopening as one piece
+with the rest of AT-SPI rather than as a password-shaped hole in it.
+
+### What a field can still do wrong
+
+None of the above stops the field itself from leaking. What `PasswordInput`
+does about that, and what it cannot:
+
+- the masked value is **never laid out or drawn** — no glyphs of the secret
+  reach ntk's shaping cache or the X server, and the mask's width is measured
+  from one reference character;
+- there is **no copy, no selection, no undo history**;
+- the value is still a JavaScript string, and strings are immutable. It
+  cannot be zeroed, it lives until the garbage collector takes it, and every
+  intermediate value typed on the way lives alongside it. A design that needs
+  more than that needs the secret to never enter this process.

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -804,6 +804,23 @@ To replace it with your own, set `contextMenu={false}` and render a
 `ContextMenu` — `onContextMenu` still fires. To suppress it for one event,
 call `ev.preventDefault()` in an `onContextMenu` handler.
 
+### `sensitive`
+
+`<textinput sensitive>` is a field whose text **never reaches a selection**.
+Ctrl+C and the copy half of Ctrl+X do nothing, the menu offers neither Cut
+nor Copy — absent rows rather than greyed ones, because a greyed Copy over a
+password reads as a bug in the application — and selecting text does not take
+PRIMARY, so a middle click in another window cannot spend it. Everything else
+is untouched: the caret, the selection itself, the arrows, undo, and pasting
+_in_.
+
+The line it draws is between what is on screen and what is on the clipboard.
+The first stops being visible when the field is hidden or the window closes;
+the second is readable by every client on the display until something else
+takes the selection, and a clipboard manager will have written it down.
+`PasswordInput` sets it on the input it shows while the secret is revealed —
+see [components.md](components.md#passwordinput).
+
 **Ref**: the node, plus `value`, `undo()` / `redo()` and `canUndo` /
 `canRedo` — enough for a toolbar button beside the field.
 

--- a/examples/app.jsx
+++ b/examples/app.jsx
@@ -21,6 +21,7 @@ import {
 import { FormPanel } from './form.jsx';
 import { WidgetsPanel } from './widgets.jsx';
 import { DatesPanel } from './datepicker.jsx';
+import { PasswordPanel } from './password.jsx';
 import { TasksPanel } from './tasks.jsx';
 import { ThemingPanel } from './theming.jsx';
 
@@ -70,6 +71,7 @@ const SECTIONS = [
   { id: 'form', label: 'Form' },
   { id: 'widgets', label: 'Widgets' },
   { id: 'dates', label: 'Dates' },
+  { id: 'password', label: 'Password' },
   { id: 'tasks', label: 'Tasks' },
   { id: 'tree', label: 'Tree' },
   { id: 'table', label: 'Table' },
@@ -171,6 +173,7 @@ const PANELS = {
   form: () => <FormPanel />,
   widgets: () => <WidgetsPanel />,
   dates: () => <DatesPanel />,
+  password: () => <PasswordPanel />,
   tasks: () => <TasksPanel />,
   tree: () => <TreePanel />,
   table: () => <TablePanel />,

--- a/examples/password.jsx
+++ b/examples/password.jsx
@@ -1,0 +1,152 @@
+// A masked field whose mask is a scribble: type into it and watch the whole
+// curve move, rather than one more identical bullet appear at the end of a
+// row of identical bullets.
+//
+// The panel also shows what the mask is *for*: the same value drawn beside a
+// row of bullets, so the two can be compared at a glance, and a second field
+// with `drawMask` replaced to show the seam.
+// Run with: npm run examples:password  (needs an X server / DISPLAY)
+import React, { useState } from 'react';
+import {
+  Button,
+  PasswordInput,
+  Switch,
+  createRoot,
+  createStyles,
+} from '../src/index.js';
+
+const s = createStyles({
+  panel: { flexGrow: 1, padding: 16, gap: 14 },
+  heading: { fontSize: 20, color: '$text' },
+  hint: { fontSize: 11, color: '$dim' },
+  row: { flexDirection: 'row', alignItems: 'center', gap: 12 },
+  label: { color: '$dim', width: 110 },
+  value: { color: '$text' },
+  card: {
+    borderWidth: 1,
+    borderColor: '$border',
+    borderRadius: 6,
+    backgroundColor: '$background',
+    padding: 12,
+    gap: 10,
+  },
+  bullets: { fontSize: 14, color: '$text' },
+  form: { gap: 10, width: 320 },
+});
+
+/** What the scribble replaces, for comparison — the same secret, the way
+ *  every other toolkit would draw it. */
+function Bullets({ value }) {
+  return (
+    <text style={s.bullets}>{value ? '•'.repeat([...value].length) : ' '}</text>
+  );
+}
+
+/** The `drawMask` seam: a bar chart of the value's own bytes. Nothing here
+ *  is a good mask — it is here to show that the mask is replaceable. */
+function bars(ctx, { width, height, seed, color }) {
+  const count = 14;
+  const step = width / count;
+  ctx.fillStyle = color;
+  let n = seed >>> 0;
+  for (let i = 0; i < count && i * step < width; i++) {
+    n = (n * 1103515245 + 12345) >>> 0;
+    const h = 2 + ((n >>> 16) % Math.max(2, height - 2));
+    ctx.fillRect(i * step, height - h, Math.max(1, step - 2), h);
+  }
+}
+
+/** The panel, without a window round it, so examples/app.jsx can show it in
+ *  a tab. */
+export function PasswordPanel() {
+  const [secret, setSecret] = useState('');
+  const [second, setSecond] = useState('');
+  const [compare, setCompare] = useState(true);
+  const [submitted, setSubmitted] = useState(null);
+
+  return (
+    <box style={s.panel}>
+      <text style={s.heading}>Password</text>
+      <text style={s.hint}>
+        Type into the field. Every keystroke reseeds the curve, so the whole
+        mask moves; the width grows with what you have typed, but by an uneven
+        step, so it is not a ruler. Enter submits, Ctrl+U clears, Ctrl+V pastes,
+        and the eye reveals while you hold the field.
+      </text>
+
+      <box style={[s.card, s.form]}>
+        <PasswordInput
+          value={secret}
+          onChange={(ev) => setSecret(ev.value)}
+          onSubmit={(value) => setSubmitted(value.length)}
+          placeholder="Password"
+        />
+        {compare && (
+          <box style={s.row}>
+            <text style={s.label}>as bullets</text>
+            <Bullets value={secret} />
+          </box>
+        )}
+        <box style={s.row}>
+          <text style={s.label}>length</text>
+          <text style={s.value}>{String([...secret].length)}</text>
+        </box>
+        <box style={s.row}>
+          <Button primary onPress={() => setSubmitted([...secret].length)}>
+            Sign in
+          </Button>
+          <Button onPress={() => setSecret('')}>Clear</Button>
+          <text style={s.hint}>
+            {submitted == null
+              ? 'not submitted'
+              : `submitted ${submitted} chars`}
+          </text>
+        </box>
+      </box>
+
+      <box style={s.row}>
+        <Switch checked={compare} onChange={(ev) => setCompare(ev.value)} />
+        <text style={s.value}>Show the same value as bullets</text>
+      </box>
+
+      <box style={[s.card, s.form]}>
+        <text style={s.hint}>
+          The mask is a seam: `drawMask` replaces it entirely. This one draws
+          bars from the same seed.
+        </text>
+        <PasswordInput
+          value={second}
+          onChange={(ev) => setSecond(ev.value)}
+          drawMask={bars}
+          placeholder="Try this one too"
+        />
+      </box>
+
+      <text style={s.hint}>
+        The secret is never laid out or drawn while it is masked — the mask is
+        measured from one reference character — so its glyphs never reach the X
+        server. Revealing it costs what revealing it costs.
+      </text>
+    </box>
+  );
+}
+
+function App() {
+  return (
+    <window
+      width={520}
+      height={520}
+      title="password"
+      style={{ backgroundColor: '$surfaceHover' }}
+    >
+      <PasswordPanel />
+    </window>
+  );
+}
+
+export default App;
+
+if (!process.env.REACT_X11_NO_AUTORUN) {
+  const root = await createRoot();
+  root.render(<App />);
+}

--- a/examples/password.jsx
+++ b/examples/password.jsx
@@ -70,8 +70,10 @@ export function PasswordPanel() {
       <text style={s.hint}>
         Type into the field. Every keystroke reseeds the curve, so the whole
         mask moves; the width grows with what you have typed, but by an uneven
-        step, so it is not a ruler. Enter submits, Ctrl+U clears, Ctrl+V pastes,
-        and the eye reveals while you hold the field.
+        step, so it is not a ruler. Enter submits, Ctrl+U clears, Ctrl+V pastes.
+        Press the eye and the mask gives way to an ordinary text input — caret,
+        selection, arrows, click into the middle of a word — which hides itself
+        again when the keyboard leaves. Copy is off in both states.
       </text>
 
       <box style={[s.card, s.form]}>

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "examples:richtext": "tsx examples/richtext.jsx",
     "examples:widgets": "tsx examples/widgets.jsx",
     "examples:datepicker": "tsx examples/datepicker.jsx",
+    "examples:password": "tsx examples/password.jsx",
     "examples:react-features": "tsx examples/react-features.jsx",
     "examples:icons": "tsx examples/icons.jsx",
     "examples:raster-gate": "tsx examples/raster-gate.jsx",

--- a/src/components/PasswordInput.js
+++ b/src/components/PasswordInput.js
@@ -127,11 +127,15 @@ const chars = (text) => Array.from(text);
  *
  * Here one stroke is drawn through points from a generator seeded by the
  * window and the value, so **every keystroke redraws the whole curve** and
- * nothing in the shape is per-character. The width grows with what has been
- * typed — a mask that did not would say nothing about progress — by a
- * per-position advance from a *window*-seeded stream, so it is monotonic
- * without being a ruler. `scribble.js` carries the reasoning and the limits;
- * the headline limit is that this hides a glance, not a recording.
+ * nothing in the shape is per-character. It is a scribble rather than a wave
+ * on purpose: the pen visits its points out of order, so it doubles back,
+ * crosses what it has drawn and leaves loops, where a stroke whose `x` only
+ * increases would be read as the plot of a function. The width grows with
+ * what has been typed — a mask that did not would say nothing about progress
+ * — by a per-position advance from a *window*-seeded stream, so it is
+ * monotonic without being a ruler. `scribble.js` carries the reasoning and
+ * the limits; the headline limit is that this hides a glance, not a
+ * recording.
  *
  * **The secret is never laid out or drawn while it is masked.** The mask's
  * width comes from one reference character, so the password never enters

--- a/src/components/PasswordInput.js
+++ b/src/components/PasswordInput.js
@@ -2,7 +2,7 @@
 // support needed. Plain createElement (no JSX) so the library stays
 // build-step-free for consumers.
 
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { DEFAULT_TEXT_STYLE, createStyles } from '../styles.js';
 import { useClipboard } from '../appcontext.js';
 import { windowIdOf } from '../windowid.js';
@@ -142,13 +142,23 @@ const chars = (text) => Array.from(text);
  * ntk's shaping cache and its glyphs never reach the X server. Revealing it
  * costs exactly what revealing it costs.
  *
- * Editing is deliberately smaller than `<textinput>`'s, because a scribble
- * has nowhere to put a caret: type, Backspace, Ctrl+Backspace or Ctrl+U or
- * Delete to clear, Ctrl+V or Shift+Insert to paste, Enter for `onSubmit`.
- * There is no caret, no selection, no undo history — a rewindable secret is
- * not a feature — and **no copy**: Ctrl+C and Ctrl+X do nothing, and the
- * field never takes the PRIMARY selection, so a middle-click in another
- * application cannot spill it.
+ * **While it is masked** editing is smaller than `<textinput>`'s, because a
+ * scribble has nowhere to put a caret: type, Backspace, Ctrl+Backspace or
+ * Ctrl+U or Delete to clear, Ctrl+V or Shift+Insert to paste, Enter for
+ * `onSubmit`. No caret, no selection, no undo history — a rewindable secret
+ * is not a feature.
+ *
+ * **Revealed it is an ordinary text input**, because that is what it looks
+ * like and anything else would be a trap: a real `<textinput>` takes its
+ * place, with a caret, a selection, the arrow keys, a click into the middle
+ * of the word, undo and the edit menu. Focus follows the swap in both
+ * directions.
+ *
+ * What holds in both states is that **nothing leaves by a selection**:
+ * Ctrl+C and Ctrl+X do nothing, the revealed input carries `sensitive` so its
+ * menu has no Cut or Copy, and neither state ever takes PRIMARY — so a middle
+ * click in another application cannot spill the secret. What is on screen
+ * stops being on screen; what is on the clipboard does not.
  *
  * Those two exclusions are also the integration story, which is why they are
  * exactly this shape: **paste** is how every password manager on the desktop
@@ -178,11 +188,15 @@ export function PasswordInput({
 }) {
   const theme = useTheme();
   const fieldRef = useRef(null);
+  const inputRef = useRef(null);
+  const hideTimer = useRef(null);
   const clipboard = useClipboard();
   const [ownValue, setOwnValue] = useState(defaultValue ?? '');
   const [ownRevealed, setOwnRevealed] = useState(false);
   const [focused, setFocused] = useState(false);
   const [capsLock, setCapsLock] = useState(false);
+  const wasShowing = useRef(false);
+  const leaving = useRef(false);
 
   const text = String(value ?? ownValue ?? '');
   const length = chars(text).length;
@@ -211,6 +225,44 @@ export function PasswordInput({
     onRevealChange?.(on);
   };
 
+  // Revealing swaps the mask for a real <textinput>, so focus has to move
+  // with it — twice, and back again — while "hide it on the way out" must not
+  // fire for a move *within* the widget. The blur schedules the hide and any
+  // focus inside cancels it, which is the plain version of `:focus-within`
+  // for two nodes that know about each other.
+  const cancelHide = () => {
+    if (hideTimer.current == null) return;
+    clearTimeout(hideTimer.current);
+    hideTimer.current = null;
+  };
+  const scheduleHide = () => {
+    cancelHide();
+    hideTimer.current = setTimeout(() => {
+      hideTimer.current = null;
+      leaving.current = true;
+      reveal(false);
+      setCapsLock(false);
+    }, 0);
+  };
+  useEffect(() => cancelHide, []);
+  useEffect(() => {
+    if (showing) {
+      // the input is the keyboard from here, and it has just mounted
+      inputRef.current?.focus();
+    } else if (wasShowing.current && !leaving.current) {
+      // hidden while the widget still has the keyboard — the eye was pressed,
+      // or the app moved `revealed` — so the mask takes it back. Hidden
+      // *because* the keyboard left is the other case, and taking focus back
+      // there would drag it out of whatever the user had just moved to.
+      fieldRef.current?.focus();
+    }
+    wasShowing.current = showing;
+    leaving.current = false;
+    // `showing` alone: this is about the *swap*, not about anything the refs
+    // hold, and a dependency on them would move the focus again for a render
+    // that only changed the value.
+  }, [showing]);
+
   const paste = (selection) => {
     try {
       clipboard
@@ -227,7 +279,7 @@ export function PasswordInput({
   };
 
   const onKeyDown = (ev) => {
-    if (disabled) return;
+    if (disabled || showing) return;
     setCapsLock(Boolean(ev.nativeEvent?.buttons & MOD.Lock));
 
     if (ev.keysym === XK_RETURN || ev.keysym === XK_KP_ENTER) {
@@ -290,14 +342,21 @@ export function PasswordInput({
       ref: fieldRef,
       focusable: !disabled,
       onKeyDown: disabled ? undefined : onKeyDown,
-      onFocus: () => setFocused(true),
+      onFocus: () => {
+        cancelHide();
+        setFocused(true);
+        // The box stays focusable while revealed so that a press on the eye
+        // lands *inside* the widget rather than nowhere — but the input is
+        // the keyboard then, so hand it straight on.
+        if (showing) inputRef.current?.focus();
+      },
       onBlur: () => {
         setFocused(false);
         // A field nobody is in should not still be showing the secret: the
-        // reveal is for the moment you are looking at it, not a mode. The eye
-        // is not focusable, so this only fires on the way out of the widget.
-        reveal(false);
-        setCapsLock(false);
+        // reveal is for the moment you are looking at it, not a mode. A move
+        // to the revealed input is not leaving, which is what the deferred
+        // hide and its cancel are for.
+        scheduleHide();
       },
       ...boxProps,
       style: [
@@ -315,10 +374,45 @@ export function PasswordInput({
     h(
       'box',
       { style: [s.slot, { height: lineHeight }] },
-      length === 0
-        ? h('text', { style: { color: theme.dim } }, placeholder)
-        : showing
-          ? h('text', { style: { color: theme.text } }, text)
+      showing
+        ? // Revealed, the field is an ordinary text input and behaves like
+          // one: a caret, a selection, the arrow keys, a click into the
+          // middle of the word, undo, the edit menu. `sensitive` is the one
+          // thing it is not allowed — nothing here reaches a selection, in
+          // either direction out — because what is on screen stops being on
+          // screen and what is on the clipboard does not.
+          h('textinput', {
+            ref: inputRef,
+            sensitive: true,
+            value: text,
+            placeholder,
+            maxLength,
+            name,
+            onChange: (ev) => commit(ev.value),
+            onSubmit: () => onSubmit?.(text),
+            onFocus: () => {
+              cancelHide();
+              setFocused(true);
+            },
+            onBlur: () => {
+              setFocused(false);
+              scheduleHide();
+            },
+            style: {
+              flexGrow: 1,
+              minWidth: 0,
+              height: lineHeight,
+              backgroundColor: 'transparent',
+              // No ring of its own: the field around it already borders in
+              // `borderFocus` while the keyboard is inside, and a second ring
+              // an inch inside the first reads as two controls. It earns the
+              // opt-out because focus here is never ambiguous — the input only
+              // exists while it is the thing being typed into.
+              outlineWidth: 0,
+            },
+          })
+        : length === 0
+          ? h('text', { style: { color: theme.dim } }, placeholder)
           : h('canvas', {
               // `onDraw` is a plain prop compared by identity, so a fresh
               // closure each render is what repaints the mask — and it

--- a/src/components/PasswordInput.js
+++ b/src/components/PasswordInput.js
@@ -1,0 +1,354 @@
+// Widget components built purely on the host primitives — no reconciler
+// support needed. Plain createElement (no JSX) so the library stays
+// build-step-free for consumers.
+
+import React, { useRef, useState } from 'react';
+import { DEFAULT_TEXT_STYLE, createStyles } from '../styles.js';
+import { useClipboard } from '../appcontext.js';
+import { windowIdOf } from '../windowid.js';
+import { useTheme } from './theme.js';
+import { changeEvent } from './change.js';
+import { measureLabel } from './anchor.js';
+import { hash32, maskWidth, strokeScribble } from './scribble.js';
+import {
+  MOD,
+  XK_BACKSPACE,
+  XK_DELETE,
+  XK_INSERT,
+  XK_KP_ENTER,
+  XK_RETURN,
+  ctrlChordLetter,
+} from '../keysyms.js';
+
+const h = React.createElement;
+
+// The reference advance the mask's width is measured in: one character of
+// the field's own font, so a themed field keeps the mask in proportion —
+// and the *only* text this widget ever lays out while it is masked.
+const REFERENCE_GLYPH = 'n';
+const ICON = 18;
+
+// Ctrl chords this field answers, as keysym letters.
+const CTRL_U = 0x75;
+const CTRL_V = 0x76;
+
+// Control characters, which a paste has no business contributing: a manager's
+// clipboard entry often ends in a newline, and an auto-type sequence that
+// pastes and then submits would otherwise put that newline *in* the secret.
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHARS = /[\x00-\x1f\x7f]/g;
+
+const s = createStyles({
+  field: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    padding: 8,
+    paddingLeft: 10,
+    paddingRight: 6,
+  },
+  slot: { flexGrow: 1, flexShrink: 1, minWidth: 0, justifyContent: 'center' },
+  icon: {
+    width: ICON,
+    height: ICON,
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    cursor: 'pointer',
+    transition: { backgroundColor: 80 },
+  },
+  eye: { width: 16, height: 12 },
+  caps: { width: 12, height: 12, flexShrink: 0 },
+});
+
+/** An eye, and an eye with a line through it. Drawn rather than set in a
+ *  font: a glyph the machine has not got is a tofu box in a login form. */
+function EyeGlyph({ color, open }) {
+  return h('canvas', {
+    style: s.eye,
+    onDraw: (ctx, { width, height }) => {
+      const midY = height / 2;
+      ctx.strokeStyle = color;
+      ctx.lineWidth = 1.2;
+      ctx.beginPath();
+      ctx.moveTo(1, midY);
+      ctx.quadraticCurveTo(width / 2, -1, width - 1, midY);
+      ctx.quadraticCurveTo(width / 2, height + 1, 1, midY);
+      ctx.stroke();
+      ctx.beginPath();
+      ctx.arc(width / 2, midY, 2.2, 0, Math.PI * 2);
+      ctx.stroke();
+      if (!open) {
+        ctx.beginPath();
+        ctx.moveTo(2, height - 1);
+        ctx.lineTo(width - 2, 1);
+        ctx.stroke();
+      }
+    },
+  });
+}
+
+/** Caps Lock: an arrow standing on a bar, which is what the key is engraved
+ *  with wherever it is engraved at all. */
+function CapsGlyph({ color }) {
+  return h('canvas', {
+    style: s.caps,
+    onDraw: (ctx, { width, height }) => {
+      ctx.fillStyle = color;
+      ctx.beginPath();
+      ctx.moveTo(width / 2, 1);
+      ctx.lineTo(width - 1, height / 2);
+      ctx.lineTo(width * 0.72, height / 2);
+      ctx.lineTo(width * 0.72, height - 4);
+      ctx.lineTo(width * 0.28, height - 4);
+      ctx.lineTo(width * 0.28, height / 2);
+      ctx.lineTo(1, height / 2);
+      ctx.closePath();
+      ctx.fill();
+      ctx.fillRect(width * 0.28, height - 2.5, width * 0.44, 2);
+    },
+  });
+}
+
+/** Code points, not UTF-16 units: deleting half a surrogate pair is how a
+ *  password with an emoji in it becomes one nobody can retype. */
+const chars = (text) => Array.from(text);
+
+/**
+ * <PasswordInput value onChange …boxProps> — a masked field whose mask is a
+ * **scribble**, not a row of bullets.
+ *
+ *   <PasswordInput value={secret} onChange={(ev) => setSecret(ev.value)} />
+ *
+ * Bullets answer the wrong question. They report how many characters have
+ * been typed — countably, from across the room — and report almost nothing
+ * about the keystroke that just landed, one more identical dot at the end of
+ * a row of identical dots being the least visible change a field could make.
+ *
+ * Here one stroke is drawn through points from a generator seeded by the
+ * window and the value, so **every keystroke redraws the whole curve** and
+ * nothing in the shape is per-character. The width grows with what has been
+ * typed — a mask that did not would say nothing about progress — by a
+ * per-position advance from a *window*-seeded stream, so it is monotonic
+ * without being a ruler. `scribble.js` carries the reasoning and the limits;
+ * the headline limit is that this hides a glance, not a recording.
+ *
+ * **The secret is never laid out or drawn while it is masked.** The mask's
+ * width comes from one reference character, so the password never enters
+ * ntk's shaping cache and its glyphs never reach the X server. Revealing it
+ * costs exactly what revealing it costs.
+ *
+ * Editing is deliberately smaller than `<textinput>`'s, because a scribble
+ * has nowhere to put a caret: type, Backspace, Ctrl+Backspace or Ctrl+U or
+ * Delete to clear, Ctrl+V or Shift+Insert to paste, Enter for `onSubmit`.
+ * There is no caret, no selection, no undo history — a rewindable secret is
+ * not a feature — and **no copy**: Ctrl+C and Ctrl+X do nothing, and the
+ * field never takes the PRIMARY selection, so a middle-click in another
+ * application cannot spill it.
+ *
+ * Those two exclusions are also the integration story, which is why they are
+ * exactly this shape: **paste** is how every password manager on the desktop
+ * delivers a secret it did not type, and **typing** is the other half —
+ * XTEST auto-type arrives as ordinary key events and this field cannot tell
+ * it from a person. See docs/components.md.
+ *
+ * The eye is a pointer affordance and not a tab stop, as GTK's peek icon is.
+ * `revealed` + `onRevealChange` make it controlled, for an app that wants the
+ * toggle somewhere its keyboard can reach.
+ */
+export function PasswordInput({
+  value,
+  defaultValue,
+  onChange,
+  onSubmit,
+  name,
+  placeholder = 'Password',
+  revealable = true,
+  revealed,
+  onRevealChange,
+  maxLength,
+  drawMask,
+  disabled = false,
+  style,
+  ...boxProps
+}) {
+  const theme = useTheme();
+  const fieldRef = useRef(null);
+  const clipboard = useClipboard();
+  const [ownValue, setOwnValue] = useState(defaultValue ?? '');
+  const [ownRevealed, setOwnRevealed] = useState(false);
+  const [focused, setFocused] = useState(false);
+  const [capsLock, setCapsLock] = useState(false);
+
+  const text = String(value ?? ownValue ?? '');
+  const length = chars(text).length;
+  const showing = revealed === undefined ? ownRevealed : revealed;
+
+  const size = DEFAULT_TEXT_STYLE.size;
+  const unit = measureLabel(fieldRef.current, REFERENCE_GLYPH, { size });
+  const lineHeight = Math.ceil(unit.height || size * 1.4);
+
+  // The window is in the seed so the same password does not draw the same
+  // curve in two windows, or in this one tomorrow: an X id is not a secret,
+  // but it is not a constant either.
+  const windowSeed = hash32(`w${windowIdOf(fieldRef) ?? 0}`);
+  const shapeSeed = (windowSeed ^ hash32(text)) >>> 0;
+
+  const commit = (next) => {
+    const clipped =
+      maxLength == null ? next : chars(next).slice(0, maxLength).join('');
+    if (clipped === text) return;
+    if (value === undefined) setOwnValue(clipped);
+    onChange?.(changeEvent('password', name, clipped));
+  };
+
+  const reveal = (on) => {
+    if (revealed === undefined) setOwnRevealed(on);
+    onRevealChange?.(on);
+  };
+
+  const paste = (selection) => {
+    try {
+      clipboard
+        .readText({ selection })
+        // nothing owns the selection, or its owner refused text: a field that
+        // threw here would take the app down over an empty clipboard
+        .then(
+          (pasted) => commit(text + String(pasted).replace(CONTROL_CHARS, '')),
+          () => {},
+        );
+    } catch {
+      // no clipboard on this app object at all (a mock, an old ntk)
+    }
+  };
+
+  const onKeyDown = (ev) => {
+    if (disabled) return;
+    setCapsLock(Boolean(ev.nativeEvent?.buttons & MOD.Lock));
+
+    if (ev.keysym === XK_RETURN || ev.keysym === XK_KP_ENTER) {
+      onSubmit?.(text);
+      return;
+    }
+    if (ev.keysym === XK_BACKSPACE) {
+      // Ctrl+Backspace deletes a word everywhere else, and a password has no
+      // words — so it clears, which is what someone who has lost track of
+      // what is in there actually wants.
+      commit(ev.ctrlKey ? '' : chars(text).slice(0, -1).join(''));
+      return;
+    }
+    if (ev.keysym === XK_DELETE) {
+      commit('');
+      return;
+    }
+    if (ev.keysym === XK_INSERT) {
+      if (ev.shiftKey) paste('CLIPBOARD');
+      return;
+    }
+    if (ev.ctrlKey) {
+      const letter = ctrlChordLetter(ev);
+      // Ctrl+U clears the line, as readline and every pinentry on the desktop
+      // do; Ctrl+V pastes. Nothing for C, X or A — there is no selection to
+      // copy, and the secret does not leave by the clipboard.
+      if (letter === CTRL_U) commit('');
+      else if (letter === CTRL_V) paste('CLIPBOARD');
+      return;
+    }
+    // A printable character and only that: a control code is not text, and
+    // neither is a key that types nothing at all.
+    if (ev.codepoint != null && ev.codepoint >= 32 && ev.codepoint !== 127) {
+      commit(text + String.fromCodePoint(ev.codepoint));
+    }
+  };
+
+  const draw = (ctx, box) => {
+    const info = {
+      width: maskWidth(
+        length,
+        unit.width || size * 0.55,
+        windowSeed,
+        box.width,
+      ),
+      height: box.height,
+      seed: shapeSeed,
+      color: disabled ? theme.dim : theme.text,
+      length,
+    };
+    if (drawMask) drawMask(ctx, info);
+    else strokeScribble(ctx, info);
+  };
+
+  return h(
+    'box',
+    {
+      theme,
+      role: 'textbox',
+      ref: fieldRef,
+      focusable: !disabled,
+      onKeyDown: disabled ? undefined : onKeyDown,
+      onFocus: () => setFocused(true),
+      onBlur: () => {
+        setFocused(false);
+        // A field nobody is in should not still be showing the secret: the
+        // reveal is for the moment you are looking at it, not a mode. The eye
+        // is not focusable, so this only fires on the way out of the widget.
+        reveal(false);
+        setCapsLock(false);
+      },
+      ...boxProps,
+      style: [
+        s.field,
+        {
+          cursor: disabled ? 'default' : 'text',
+          borderWidth: theme.borderWidth,
+          borderRadius: theme.radius,
+          borderColor: focused ? theme.borderFocus : theme.border,
+          backgroundColor: disabled ? theme.surfaceHover : theme.background,
+        },
+        style,
+      ],
+    },
+    h(
+      'box',
+      { style: [s.slot, { height: lineHeight }] },
+      length === 0
+        ? h('text', { style: { color: theme.dim } }, placeholder)
+        : showing
+          ? h('text', { style: { color: theme.text } }, text)
+          : h('canvas', {
+              // `onDraw` is a plain prop compared by identity, so a fresh
+              // closure each render is what repaints the mask — and it
+              // repaints that one node, not the field around it.
+              onDraw: draw,
+              style: { flexGrow: 1, height: lineHeight },
+            }),
+    ),
+    capsLock && !showing && h(CapsGlyph, { color: theme.dim }),
+    revealable &&
+      !disabled &&
+      h(
+        'box',
+        {
+          role: 'button',
+          // Not a tab stop, and not a focus target for a press either: focus
+          // stays on the field, so leaving the widget is the only blur it
+          // ever sees — which is what makes "hide it again on the way out"
+          // mean what it says.
+          focusable: false,
+          onClick: () => reveal(!showing),
+          style: [
+            s.icon,
+            { borderRadius: theme.radiusSmall },
+            {
+              ':hover': { backgroundColor: theme.surfaceHover },
+              ':active': { backgroundColor: theme.surfaceActive },
+            },
+          ],
+        },
+        h(EyeGlyph, {
+          color: disabled ? theme.border : theme.dim,
+          open: !showing,
+        }),
+      ),
+  );
+}

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -14,6 +14,7 @@ export { useDropTarget, useDragSource } from './dnd.js';
 export { Button } from './Button.js';
 export { Calendar } from './Calendar.js';
 export { DatePicker } from './DatePicker.js';
+export { PasswordInput } from './PasswordInput.js';
 export { Dialog } from './Dialog.js';
 export { FileDialog } from './FileDialog.js';
 export { Checkbox } from './Checkbox.js';

--- a/src/components/scribble.js
+++ b/src/components/scribble.js
@@ -9,8 +9,16 @@
 // This inverts both. A stroke is drawn through points chosen by a generator
 // seeded from the window and the value, so **every keystroke redraws the
 // whole curve**: the feedback is the entire mask moving, not a mark
-// appearing. And nothing in the shape is per-character — a fixed number of
-// control points, whatever the length — so there is nothing to count.
+// appearing. And nothing in the shape is per-character — the pen visits a
+// number of points taken from the mask's *width*, where a character is worth
+// about half a point, so no part of the stroke can be matched to anything
+// that was typed.
+//
+// It is a scribble rather than a wave, and that is a decision rather than a
+// look: a stroke whose `x` only ever increases is the plot of a function, and
+// the eye reads it as one — value against position, meaning in the peaks —
+// however wild the `y` is. So the pen doubles back, crosses what it has
+// already drawn, and leaves loops. `scribblePoints` is where that happens.
 //
 // What does grow is the width, because a mask that did not grow would say
 // nothing about progress at all. It grows by a per-position advance drawn
@@ -55,9 +63,37 @@ export function seededRandom(seed) {
   };
 }
 
-/** How many control points a scribble is drawn through, whatever its length
- *  — a count that grew with the value would be a character count. */
-export const SCRIBBLE_POINTS = 7;
+/**
+ * How many points the pen visits, per pixel of mask.
+ *
+ * Deriving the count from the **width** rather than fixing it keeps the
+ * scrawl at one density: a fixed count stretches into a few long shallow
+ * strokes as the field fills, which both stops looking like a scribble and —
+ * since density would then fall with length — says as much about the length
+ * as the count would. Width is already on show; density does not have to be.
+ *
+ * The count is not per-character either way. At this rate a character is
+ * worth about half a point, so nothing in the stroke can be matched to
+ * anything that was typed.
+ */
+const PX_PER_POINT = 9;
+const MIN_POINTS = 7;
+
+/** How far apart, in pixels, the curve is sampled when it is drawn. */
+const SAMPLE_PX = 2;
+const MAX_POINTS = 30;
+
+/** How many points a mask this wide is drawn through. */
+export function scribblePointCount(width) {
+  return Math.max(
+    MIN_POINTS,
+    Math.min(MAX_POINTS, Math.round(width / PX_PER_POINT)),
+  );
+}
+
+/** How far the pen may jump out of order: the width of the window the
+ *  visiting order is shuffled inside. See `scribblePoints`. */
+export const SCRIBBLE_GROUP = 3;
 
 /** The narrowest and widest a character may push the mask, as a fraction of
  *  the reference advance. Wide enough that the steps do not read as a ruler,
@@ -91,73 +127,121 @@ export function maskWidth(length, unit, seed, max = Infinity) {
 }
 
 /**
- * The points the curve runs through, inside a `width` × `height` box.
+ * The points the pen visits, inside a `width` × `height` box.
  *
- * `x` marches across the box so the stroke reads left to right like writing,
- * with enough jitter that the columns are not a grid; `y` is free within the
- * box, which is what makes it a scribble rather than a wave.
+ * **Not in left-to-right order.** A stroke whose `x` only ever increases is a
+ * plot of a function — a waveform, a time series — and it reads as one however
+ * wild the `y` is: the eye follows it as "value against position" and starts
+ * looking for meaning in the peaks. A pen moved at random over a piece of
+ * paper does not do that. It doubles back, crosses what it has already drawn,
+ * and leaves loops.
+ *
+ * So the points are laid out in **columns** — one per column, which is what
+ * guarantees the stroke covers the width it was given rather than knotting
+ * itself in one corner — and then the *visiting order is shuffled*. The pen
+ * therefore starts somewhere in the middle, sweeps across, comes back, and
+ * crosses itself on the way.
  */
 export function scribblePoints({
   width,
   height,
   seed,
-  points = SCRIBBLE_POINTS,
+  points = scribblePointCount(width),
+  group = SCRIBBLE_GROUP,
   inset = 2,
 }) {
   const rnd = seededRandom(seed);
   const span = Math.max(1, height - inset * 2);
-  const drift = width / (points * 2);
-  // Which half the first point sits in; after that they alternate. Free `y`
-  // in the whole box reads as a gentle wave once the field is wide — seven
-  // points over two hundred pixels rarely happen to zigzag — and a mask that
-  // relaxes into a line as the password gets longer is saying something about
-  // the password. Alternating halves keeps the stroke oscillating at every
-  // width, with the randomness spent on *where* in the half it lands.
-  let high = rnd() < 0.5;
+  const usable = Math.max(1, width - inset * 2);
+  const column = usable / points;
   const out = [];
   for (let i = 0; i < points; i++) {
-    const t = points === 1 ? 0.5 : i / (points - 1);
-    const x = t * (width - inset * 2) + inset + (rnd() - 0.5) * drift;
-    const y = inset + (high ? rnd() * 0.42 : 0.58 + rnd() * 0.42) * span;
-    high = !high;
     out.push({
-      x: Math.min(width - inset, Math.max(inset, x)),
-      y,
+      // inside its own column, so no two points share a place and the whole
+      // width is used, but nowhere near the middle of it
+      x: inset + i * column + rnd() * column,
+      y: inset + rnd() * span,
     });
+  }
+  // Fisher-Yates within a sliding group rather than over the whole list. A
+  // full shuffle puts consecutive points a third of the width apart on
+  // average, and in a box this short every one of those moves is a long
+  // shallow sweep — the stroke ends up a bundle of near-horizontal scratches.
+  // Shuffling locally keeps the moves short, so the pen has room to go up and
+  // down between them, and it still doubles back and crosses itself.
+  for (let start = 0; start < out.length; start += group) {
+    const end = Math.min(out.length, start + group);
+    for (let i = end - 1; i > start; i--) {
+      const j = start + Math.floor(rnd() * (i - start + 1));
+      const swap = out[i];
+      out[i] = out[j];
+      out[j] = swap;
+    }
   }
   return out;
 }
 
 /**
- * Stroke the scribble for `seed` into a `width` × `height` box.
+ * The pen's path as a **dense polyline**, sampled off a Catmull-Rom spline
+ * through the points — a curve that passes through every one of them rather
+ * than being pulled towards it.
  *
- * Catmull-Rom through the points, converted to the cubic béziers the context
- * actually draws: a curve that passes *through* every point rather than
- * being pulled towards it, which is what keeps the stroke inside the box it
- * was given.
+ * Sampled here rather than handed to the context as béziers, which is what
+ * this did first. A mask is 17 pixels tall, its control points land within a
+ * pixel of each other constantly, and ntk's stroker answers a curve that
+ * small with the occasional spike: a stray tail shooting out of the field,
+ * several times the width of the mask. The same points drawn as line segments
+ * are exact at any size, and a curve sampled every couple of pixels is
+ * smooth long before anyone can see the difference. (The béziers themselves
+ * are fine — the shape is right when it is drawn eight times bigger — so this
+ * is a workaround for the stroker, not for the geometry.)
+ *
+ * Every sample is clamped into the box, so "the stroke stays in the field" is
+ * arithmetic rather than a hope.
  */
-export function strokeScribble(ctx, { width, height, seed, color, lineWidth }) {
-  if (!(width > 2) || !(height > 2)) return;
-  const pts = scribblePoints({ width, height, seed });
-  ctx.strokeStyle = color;
-  ctx.lineWidth = lineWidth ?? 1.5;
-  ctx.lineCap = 'round';
-  ctx.lineJoin = 'round';
-  ctx.beginPath();
-  ctx.moveTo(pts[0].x, pts[0].y);
+export function scribblePath(pts, { width, height, inset = 2 }) {
+  const clampX = (v) => Math.min(width, Math.max(0, v));
+  const clampY = (v) => Math.min(height - inset, Math.max(inset, v));
+  const out = [{ x: clampX(pts[0].x), y: clampY(pts[0].y) }];
   for (let i = 0; i < pts.length - 1; i++) {
     const p0 = pts[i - 1] ?? pts[i];
     const p1 = pts[i];
     const p2 = pts[i + 1];
     const p3 = pts[i + 2] ?? p2;
-    ctx.bezierCurveTo(
-      p1.x + (p2.x - p0.x) / 6,
-      p1.y + (p2.y - p0.y) / 6,
-      p2.x - (p3.x - p1.x) / 6,
-      p2.y - (p3.y - p1.y) / 6,
-      p2.x,
-      p2.y,
-    );
+    const span = Math.abs(p2.x - p1.x) + Math.abs(p2.y - p1.y);
+    const steps = Math.max(3, Math.min(14, Math.round(span / SAMPLE_PX)));
+    for (let step = 1; step <= steps; step++) {
+      const t = step / steps;
+      const t2 = t * t;
+      const t3 = t2 * t;
+      // Catmull-Rom basis, uniform parameterisation
+      const at = (a, b, c, d) =>
+        0.5 *
+        (2 * b +
+          (c - a) * t +
+          (2 * a - 5 * b + 4 * c - d) * t2 +
+          (3 * b - a - 3 * c + d) * t3);
+      out.push({
+        x: clampX(at(p0.x, p1.x, p2.x, p3.x)),
+        y: clampY(at(p0.y, p1.y, p2.y, p3.y)),
+      });
+    }
   }
+  return out;
+}
+
+/** Stroke the scribble for `seed` into a `width` × `height` box. */
+export function strokeScribble(ctx, { width, height, seed, color, lineWidth }) {
+  if (!(width > 2) || !(height > 2)) return;
+  const inset = 2;
+  const pts = scribblePoints({ width, height, seed, inset });
+  const path = scribblePath(pts, { width, height, inset });
+  ctx.strokeStyle = color;
+  ctx.lineWidth = lineWidth ?? 1.5;
+  ctx.lineCap = 'round';
+  ctx.lineJoin = 'round';
+  ctx.beginPath();
+  ctx.moveTo(path[0].x, path[0].y);
+  for (const point of path.slice(1)) ctx.lineTo(point.x, point.y);
   ctx.stroke();
 }

--- a/src/components/scribble.js
+++ b/src/components/scribble.js
@@ -1,0 +1,163 @@
+// The scribble a masked field is drawn with, and the arithmetic behind it.
+//
+// A row of bullets answers the wrong question. It says *how many characters
+// you have typed* — loudly, countably, from across the room — and it says
+// nothing at all about the keystroke that just landed, because one more
+// identical dot at the end of a row of identical dots is the least visible
+// change a field could make.
+//
+// This inverts both. A stroke is drawn through points chosen by a generator
+// seeded from the window and the value, so **every keystroke redraws the
+// whole curve**: the feedback is the entire mask moving, not a mark
+// appearing. And nothing in the shape is per-character — a fixed number of
+// control points, whatever the length — so there is nothing to count.
+//
+// What does grow is the width, because a mask that did not grow would say
+// nothing about progress at all. It grows by a per-position advance drawn
+// from a **window-seeded** stream rather than by a fixed step, so the width
+// is monotonic in the length (typing always widens it) without being a clean
+// multiple of anything (a glance does not give a character count). Those two
+// streams are deliberately separate: the shape reshuffles on every keystroke,
+// the width never does.
+//
+// The honest limits, since a mask that oversells itself is worse than one
+// that does not: an observer who watches the field grow keystroke by
+// keystroke still learns the length, and the width still puts a long password
+// in a different bracket from a short one. This hides a glance, not a
+// recording.
+
+/** FNV-1a over the UTF-16 units, which is all a seed needs to be. */
+export function hash32(text) {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < text.length; i++) {
+    h ^= text.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+/**
+ * mulberry32: a small, fast, well-distributed PRNG with a 32-bit state.
+ *
+ * The point is not statistical quality, it is that the sequence is a pure
+ * function of the seed — the same value in the same window draws the same
+ * scribble on every repaint, so a frame that redraws a damaged strip cannot
+ * come back with a different curve than the frame before it.
+ */
+export function seededRandom(seed) {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** How many control points a scribble is drawn through, whatever its length
+ *  — a count that grew with the value would be a character count. */
+export const SCRIBBLE_POINTS = 7;
+
+/** The narrowest and widest a character may push the mask, as a fraction of
+ *  the reference advance. Wide enough that the steps do not read as a ruler,
+ *  narrow enough that the mask still tracks what has been typed. */
+const MIN_ADVANCE = 0.55;
+const MAX_ADVANCE = 1.35;
+
+/**
+ * How wide the mask for a value of `length` characters is, in pixels.
+ *
+ * `unit` is the reference advance — one character of the field's own font —
+ * and `seed` is derived from the **window**, never from the value, which is
+ * what makes position 7 contribute the same width whatever is typed there.
+ * So the mask only ever grows as you type, and never twitches when a
+ * character is replaced.
+ */
+export function maskWidth(length, unit, seed, max = Infinity) {
+  if (length <= 0) return 0;
+  const rnd = seededRandom(seed);
+  let width = 0;
+  for (let i = 0; i < length; i++) {
+    const advance = unit * (MIN_ADVANCE + rnd() * (MAX_ADVANCE - MIN_ADVANCE));
+    width += advance;
+    // A field that has run out of room stops growing, the way a text input
+    // that has scrolled stops showing you where the end is — and the loop
+    // stops with it, so a pasted novel is not a hundred thousand rounds of a
+    // generator whose answer is already known.
+    if (width >= max) return max;
+  }
+  return width;
+}
+
+/**
+ * The points the curve runs through, inside a `width` × `height` box.
+ *
+ * `x` marches across the box so the stroke reads left to right like writing,
+ * with enough jitter that the columns are not a grid; `y` is free within the
+ * box, which is what makes it a scribble rather than a wave.
+ */
+export function scribblePoints({
+  width,
+  height,
+  seed,
+  points = SCRIBBLE_POINTS,
+  inset = 2,
+}) {
+  const rnd = seededRandom(seed);
+  const span = Math.max(1, height - inset * 2);
+  const drift = width / (points * 2);
+  // Which half the first point sits in; after that they alternate. Free `y`
+  // in the whole box reads as a gentle wave once the field is wide — seven
+  // points over two hundred pixels rarely happen to zigzag — and a mask that
+  // relaxes into a line as the password gets longer is saying something about
+  // the password. Alternating halves keeps the stroke oscillating at every
+  // width, with the randomness spent on *where* in the half it lands.
+  let high = rnd() < 0.5;
+  const out = [];
+  for (let i = 0; i < points; i++) {
+    const t = points === 1 ? 0.5 : i / (points - 1);
+    const x = t * (width - inset * 2) + inset + (rnd() - 0.5) * drift;
+    const y = inset + (high ? rnd() * 0.42 : 0.58 + rnd() * 0.42) * span;
+    high = !high;
+    out.push({
+      x: Math.min(width - inset, Math.max(inset, x)),
+      y,
+    });
+  }
+  return out;
+}
+
+/**
+ * Stroke the scribble for `seed` into a `width` × `height` box.
+ *
+ * Catmull-Rom through the points, converted to the cubic béziers the context
+ * actually draws: a curve that passes *through* every point rather than
+ * being pulled towards it, which is what keeps the stroke inside the box it
+ * was given.
+ */
+export function strokeScribble(ctx, { width, height, seed, color, lineWidth }) {
+  if (!(width > 2) || !(height > 2)) return;
+  const pts = scribblePoints({ width, height, seed });
+  ctx.strokeStyle = color;
+  ctx.lineWidth = lineWidth ?? 1.5;
+  ctx.lineCap = 'round';
+  ctx.lineJoin = 'round';
+  ctx.beginPath();
+  ctx.moveTo(pts[0].x, pts[0].y);
+  for (let i = 0; i < pts.length - 1; i++) {
+    const p0 = pts[i - 1] ?? pts[i];
+    const p1 = pts[i];
+    const p2 = pts[i + 1];
+    const p3 = pts[i + 2] ?? p2;
+    ctx.bezierCurveTo(
+      p1.x + (p2.x - p0.x) / 6,
+      p1.y + (p2.y - p0.y) / 6,
+      p2.x - (p3.x - p1.x) / 6,
+      p2.y - (p3.y - p1.y) / 6,
+      p2.x,
+      p2.y,
+    );
+  }
+  ctx.stroke();
+}

--- a/src/index.js
+++ b/src/index.js
@@ -35,6 +35,7 @@ export {
   Button,
   Calendar,
   DatePicker,
+  PasswordInput,
   Checkbox,
   Radio,
   RadioGroup,

--- a/src/keysyms.js
+++ b/src/keysyms.js
@@ -80,6 +80,22 @@ export const XK_F11 = 0xffc8;
 export const XK_F12 = 0xffc9;
 
 /**
+ * The letter of a Ctrl chord, independent of Shift. ntk derives `codepoint`
+ * from the *shifted* keysym, so Ctrl+Shift+Z arrives as `Z` while Ctrl+Z
+ * arrives as `z` — the keysym does not shift, so match on that and fall back
+ * to the codepoint when the keymap has not been read yet.
+ *
+ * Here rather than beside its first caller because both layers need it: the
+ * `<textinput>` node reads Ctrl+C/V/Z, and so does any widget that answers a
+ * chord of its own.
+ */
+export function ctrlChordLetter(ev) {
+  const code = ev.keysym ?? ev.codepoint;
+  if (code == null) return null;
+  return code >= 0x41 && code <= 0x5a ? code + 0x20 : code;
+}
+
+/**
  * The X11 modifier mask bits, as they arrive on `ev.nativeEvent.buttons`
  * and as `fireEvent` takes them. Bit 3 (Mod1) is Alt on virtually every
  * layout; the renderer reads Shift, Control and Mod1.

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -56,6 +56,7 @@ import { hooks as traceHooks } from './trace-registry.js';
 import { runWithPriority, DiscreteEventPriority } from './priority.js';
 import { inputTime } from './inputtime.js';
 import { armPasteState, canPaste } from './pastestate.js';
+import { ctrlChordLetter } from './keysyms.js';
 import {
   editMenuColors,
   editMenuGeometry,
@@ -2971,18 +2972,6 @@ const SCROLL_KEY_PAGE_OVERLAP = 24;
 /** Undo entries kept per input. Snapshots of a single field are small; the
  * cap is what stops a long-lived form from growing without bound. */
 const UNDO_LIMIT = 200;
-
-/**
- * The letter of a Ctrl chord, independent of Shift. ntk derives `codepoint`
- * from the *shifted* keysym, so Ctrl+Shift+Z arrives as `Z` while Ctrl+Z
- * arrives as `z` — the keysym does not shift, so match on that and fall
- * back to the codepoint when the keymap has not been read yet.
- */
-function ctrlChordLetter(ev) {
-  const code = ev.keysym ?? ev.codepoint;
-  if (code == null) return null;
-  return code >= 0x41 && code <= 0x5a ? code + 0x20 : code;
-}
 
 /**
  * <textinput>: single-line editable text. Caret/selection via ntk TextLayout

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -3367,7 +3367,22 @@ export class TextInputNode extends Node {
     return this.app?.clipboard ?? null;
   }
 
+  /**
+   * Put the selection on a selection — unless this input is `sensitive`.
+   *
+   * Every route out of the field funnels through here: Ctrl+C, the copy half
+   * of Ctrl+X, the right-click menu, and the select-to-own that hands PRIMARY
+   * to a middle click in some other application. One gate covers them all,
+   * which is the reason the field is the thing that knows it holds a secret
+   * rather than each of the six callers.
+   *
+   * The reason a *revealed* password field still refuses: what is on screen
+   * stops being on screen when the field is hidden again, and what is on the
+   * clipboard does not. Any client on the display can ask for it, and a
+   * clipboard manager will have written it down.
+   */
   _copySelection(selection = 'CLIPBOARD') {
+    if (this.props.sensitive) return;
     const text = this._selectedText();
     if (!text) return;
     this._clipboardApi()
@@ -3673,8 +3688,25 @@ export class TextInputNode extends Node {
         enabled: this.canRedo,
       },
       { separator: true },
-      { id: 'cut', label: 'Cut', shortcut: 'Ctrl+X', enabled: hasSelection },
-      { id: 'copy', label: 'Copy', shortcut: 'Ctrl+C', enabled: hasSelection },
+      // A `sensitive` field offers neither: they are not disabled rows, they
+      // are absent, because a greyed Copy over a password reads as a bug in
+      // the application rather than as a decision.
+      ...(this.props.sensitive
+        ? []
+        : [
+            {
+              id: 'cut',
+              label: 'Cut',
+              shortcut: 'Ctrl+X',
+              enabled: hasSelection,
+            },
+            {
+              id: 'copy',
+              label: 'Copy',
+              shortcut: 'Ctrl+C',
+              enabled: hasSelection,
+            },
+          ]),
       {
         id: 'paste',
         label: 'Paste',

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -275,6 +275,42 @@ export type DatePickerProps = (SingleCalendarProps | RangeCalendarProps) & {
 };
 export const DatePicker: ComponentType<DatePickerProps>;
 
+/** What a `drawMask` is told about the mask it is painting. */
+export interface PasswordMaskInfo {
+  /** How wide the mask should be — what the field worked out from the
+   * length, not the width of the box. */
+  width: number;
+  height: number;
+  /** Seeded from the window and a hash of the value, so it changes on every
+   * keystroke and repaints identically in between. */
+  seed: number;
+  color: Color;
+  length: number;
+}
+
+export interface PasswordInputProps extends WidgetProps, NamedWidget {
+  value?: string;
+  defaultValue?: string;
+  onChange?: (ev: WidgetChangeEvent<string>) => void;
+  /** Enter. */
+  onSubmit?: (value: string) => void;
+  placeholder?: string;
+  /** Show the reveal eye at all. Default `true`, as GTK's peek icon is. */
+  revealable?: boolean;
+  /** Drive the reveal yourself — for a toggle the keyboard can reach, the
+   * built-in eye being a pointer affordance. */
+  revealed?: boolean;
+  onRevealChange?: (revealed: boolean) => void;
+  /** In code points, not UTF-16 units. */
+  maxLength?: number;
+  /** Draw the mask instead of the scribble. `ctx` is ntk's canvas-like 2d
+   * context, translated to the mask's origin. */
+  drawMask?: (ctx: any, info: PasswordMaskInfo) => void;
+  disabled?: boolean;
+  style?: StyleProp;
+}
+export const PasswordInput: ComponentType<PasswordInputProps>;
+
 export interface CheckboxProps extends WidgetProps, NamedWidget {
   children?: ReactNode;
   label?: string;

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -303,6 +303,17 @@ export interface TextInputProps extends DrawnProps<TextInputNode> {
    * you replace it with your own rather than suppressing it per-event.
    */
   contextMenu?: false;
+  /**
+   * The text is a secret: **nothing here reaches a selection.** Ctrl+C and
+   * the copy half of Ctrl+X do nothing, the edit menu offers neither Cut nor
+   * Copy, and selecting text does not take PRIMARY — so a middle click in
+   * another window cannot spend it. Pasting *in*, editing, undo and the caret
+   * are untouched.
+   *
+   * What is on screen stops being on screen; what is on the clipboard does
+   * not. `PasswordInput` sets this on the input it shows while revealed.
+   */
+  sensitive?: boolean;
 }
 
 export interface TextAreaProps extends TextInputProps {

--- a/test/password.test.js
+++ b/test/password.test.js
@@ -1,0 +1,335 @@
+// PasswordInput: the editing model, what never leaves the widget, and the
+// scribble arithmetic the mask is drawn from.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import { PasswordInput, createRoot } from '../src/index.js';
+import { createMockApp } from './helpers/mock-app.js';
+import {
+  hash32,
+  maskWidth,
+  scribblePoints,
+  seededRandom,
+} from '../src/components/scribble.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+const settle = async () => {
+  await tick();
+  await tick();
+};
+
+const XK = {
+  BACKSPACE: 0xff08,
+  DELETE: 0xffff,
+  INSERT: 0xff63,
+  RETURN: 0xff0d,
+};
+const MOD = { Shift: 1, Lock: 2, Control: 4 };
+
+const treeOf = (app) => app.windows[0]._reactX11Node;
+
+function nodes(from, pred, out = []) {
+  if (pred(from)) out.push(from);
+  for (const child of from.children) nodes(child, pred, out);
+  return out;
+}
+
+const texts = (app) =>
+  nodes(treeOf(app), (n) => n.kind === 'text').map((n) =>
+    String(n.props.children),
+  );
+const canvases = (app) => nodes(treeOf(app), (n) => n.kind === 'canvas');
+const field = (app) =>
+  nodes(treeOf(app), (n) => n.props?.role === 'textbox')[0];
+
+/** Type one character, as the X server delivers it. */
+function type(app, char, { ctrl = false, shift = false, lock = false } = {}) {
+  const codepoint = char.codePointAt(0);
+  const keycode = (codepoint % 248) + 8;
+  app.X.keycode2keysyms[keycode] = [codepoint];
+  app.windows[0].emit('keydown', {
+    keycode,
+    codepoint,
+    buttons:
+      (ctrl ? MOD.Control : 0) |
+      (shift ? MOD.Shift : 0) |
+      (lock ? MOD.Lock : 0),
+  });
+}
+
+function press(app, keysym, { ctrl = false, shift = false } = {}) {
+  const keycode = (keysym % 248) + 8;
+  app.X.keycode2keysyms[keycode] = [keysym];
+  app.windows[0].emit('keydown', {
+    keycode,
+    buttons: (ctrl ? MOD.Control : 0) | (shift ? MOD.Shift : 0),
+  });
+}
+
+const click = (app, node) => {
+  const x = node.abs.x + node.abs.width / 2;
+  const y = node.abs.y + node.abs.height / 2;
+  app.windows[0].emit('mousedown', { x, y, keycode: 1 });
+  app.windows[0].emit('mouseup', { x, y, keycode: 1 });
+};
+
+async function mount(props) {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(
+    h(
+      'window',
+      { width: 320, height: 120 },
+      h(PasswordInput, { ...props, style: { width: 240 } }),
+    ),
+  );
+  await settle();
+  field(app).focus();
+  return { app, root };
+}
+
+test('typing reports the value and never draws the characters', async () => {
+  const seen = [];
+  const { app, root } = await mount({ onChange: (ev) => seen.push(ev.value) });
+
+  for (const ch of 'hunter2') type(app, ch);
+  await settle();
+
+  assert.strictEqual(seen.at(-1), 'hunter2');
+  assert.deepStrictEqual(
+    texts(app),
+    [],
+    'no <text> anywhere: not the secret, and not a placeholder either',
+  );
+  assert.strictEqual(canvases(app).length, 2, 'the mask, and the eye');
+
+  await root.unmount();
+});
+
+test('Backspace takes one, Ctrl+Backspace and Delete take the lot', async () => {
+  const seen = [];
+  const { app, root } = await mount({ onChange: (ev) => seen.push(ev.value) });
+
+  for (const ch of 'abc') type(app, ch);
+  press(app, XK.BACKSPACE);
+  await settle();
+  assert.strictEqual(seen.at(-1), 'ab');
+
+  press(app, XK.BACKSPACE, { ctrl: true });
+  await settle();
+  assert.strictEqual(seen.at(-1), '');
+
+  for (const ch of 'xy') type(app, ch);
+  press(app, XK.DELETE);
+  await settle();
+  assert.strictEqual(seen.at(-1), '');
+
+  await root.unmount();
+});
+
+test('a surrogate pair is one character, not two halves', async () => {
+  const seen = [];
+  const { app, root } = await mount({ onChange: (ev) => seen.push(ev.value) });
+
+  type(app, 'a');
+  type(app, '🔑');
+  await settle();
+  assert.strictEqual(seen.at(-1), 'a🔑');
+
+  press(app, XK.BACKSPACE);
+  await settle();
+  assert.strictEqual(seen.at(-1), 'a', 'the whole key went, not half of it');
+
+  await root.unmount();
+});
+
+test('the secret does not leave by the clipboard, and paste brings one in', async () => {
+  const seen = [];
+  const { app, root } = await mount({ onChange: (ev) => seen.push(ev.value) });
+
+  for (const ch of 'secret') type(app, ch);
+  type(app, 'c', { ctrl: true });
+  type(app, 'x', { ctrl: true });
+  type(app, 'a', { ctrl: true });
+  await settle();
+
+  assert.deepStrictEqual(
+    app.clipboard.writes,
+    [],
+    'nothing this field holds was ever offered to a selection',
+  );
+  assert.strictEqual(seen.at(-1), 'secret', 'and the chords typed no letters');
+
+  // what a password manager does: own the clipboard, then the app pastes
+  await app.clipboard.write('from-the-manager\n');
+  type(app, 'v', { ctrl: true });
+  await settle();
+  assert.strictEqual(
+    seen.at(-1),
+    'secretfrom-the-manager',
+    'pasted, with the manager’s trailing newline left out of the secret',
+  );
+
+  press(app, XK.INSERT, { shift: true });
+  await settle();
+  assert.strictEqual(seen.at(-1), 'secretfrom-the-managerfrom-the-manager');
+
+  await root.unmount();
+});
+
+test('Enter submits, and Ctrl+U clears the way a pinentry does', async () => {
+  const submitted = [];
+  const { app, root } = await mount({ onSubmit: (v) => submitted.push(v) });
+
+  for (const ch of 'pw') type(app, ch);
+  press(app, XK.RETURN);
+  await settle();
+  assert.deepStrictEqual(submitted, ['pw']);
+
+  type(app, 'u', { ctrl: true });
+  await settle();
+  assert.deepStrictEqual(
+    texts(app),
+    ['Password'],
+    'cleared, so the placeholder is back',
+  );
+  press(app, XK.RETURN);
+  await settle();
+  assert.deepStrictEqual(submitted, ['pw', ''], 'and it is empty again');
+
+  await root.unmount();
+});
+
+test('maxLength holds, and the placeholder shows only while empty', async () => {
+  const seen = [];
+  const { app, root } = await mount({
+    maxLength: 4,
+    placeholder: 'Passphrase',
+    onChange: (ev) => seen.push(ev.value),
+  });
+
+  assert.deepStrictEqual(texts(app), ['Passphrase']);
+  for (const ch of 'abcdefgh') type(app, ch);
+  await settle();
+  assert.strictEqual(seen.at(-1), 'abcd');
+  assert.deepStrictEqual(texts(app), [], 'the placeholder is gone');
+
+  await root.unmount();
+});
+
+test('the eye reveals the text, and blurring the field hides it again', async () => {
+  const { app, root } = await mount({ defaultValue: 'letmein' });
+
+  const eye = nodes(treeOf(app), (n) => n.props?.role === 'button')[0];
+  click(app, eye);
+  await settle();
+  assert.deepStrictEqual(texts(app), ['letmein'], 'revealed on the click');
+
+  field(app).blur();
+  await settle();
+  assert.deepStrictEqual(texts(app), [], 'and hidden on the way out');
+
+  await root.unmount();
+});
+
+test('Caps Lock is reported while it is on, and only while masked', async () => {
+  const { app, root } = await mount({});
+
+  type(app, 'a');
+  await settle();
+  assert.strictEqual(canvases(app).length, 2, 'no warning yet');
+
+  type(app, 'B', { lock: true });
+  await settle();
+  assert.strictEqual(canvases(app).length, 3, 'the caps indicator joined');
+
+  type(app, 'c');
+  await settle();
+  assert.strictEqual(canvases(app).length, 2, 'and left when the key came up');
+
+  await root.unmount();
+});
+
+test('drawMask replaces the scribble and hears the geometry', async () => {
+  const calls = [];
+  const { app, root } = await mount({
+    drawMask: (ctx, info) => {
+      calls.push(info);
+      ctx.fillRect(0, 0, info.width, info.height);
+    },
+  });
+
+  for (const ch of 'abcd') type(app, ch);
+  await settle();
+
+  const last = calls.at(-1);
+  assert.strictEqual(last.length, 4);
+  assert.ok(last.width > 0 && last.height > 0);
+  assert.ok(
+    calls.some((c) => c.seed !== last.seed),
+    'the seed moved as the value did',
+  );
+
+  await root.unmount();
+});
+
+test('the mask widens with every character and never with the value alone', () => {
+  const unit = 8;
+  const seed = hash32('w4242');
+  const widths = [0, 1, 2, 3, 4, 5].map((n) => maskWidth(n, unit, seed));
+
+  for (let i = 1; i < widths.length; i++) {
+    assert.ok(
+      widths[i] > widths[i - 1],
+      `${i} characters is wider than ${i - 1}`,
+    );
+  }
+  assert.strictEqual(
+    maskWidth(5, unit, seed),
+    widths[5],
+    'and the same length is the same width, whatever was typed',
+  );
+  // not a ruler: the steps differ from one another
+  const steps = widths.slice(1).map((w, i) => w - widths[i]);
+  assert.ok(
+    new Set(steps.map((s) => s.toFixed(3))).size > 1,
+    'the per-character steps are not all the same',
+  );
+  assert.strictEqual(maskWidth(500, unit, seed, 120), 120, 'and it is capped');
+});
+
+test('the scribble is a pure function of its seed, and stays in its box', () => {
+  const box = { width: 120, height: 18 };
+  const a = scribblePoints({ ...box, seed: 1234 });
+  const again = scribblePoints({ ...box, seed: 1234 });
+  const other = scribblePoints({ ...box, seed: 1235 });
+
+  assert.deepStrictEqual(a, again, 'a repaint draws the same curve');
+  assert.notDeepStrictEqual(a, other, 'a keystroke draws a different one');
+  assert.strictEqual(
+    a.length,
+    7,
+    'a fixed number of points, whatever is typed',
+  );
+  for (const p of a) {
+    assert.ok(p.x >= 0 && p.x <= box.width, `x ${p.x} inside the box`);
+    assert.ok(p.y >= 0 && p.y <= box.height, `y ${p.y} inside the box`);
+  }
+  // and x marches across it, so the stroke reads as writing rather than a
+  // tangle in one corner
+  assert.ok(a[6].x > a[0].x);
+});
+
+test('the generator is deterministic and spread over the unit interval', () => {
+  const first = Array.from({ length: 5 }, seededRandom(7));
+  assert.deepStrictEqual(
+    Array.from({ length: 5 }, seededRandom(7)),
+    first,
+    'same seed, same sequence',
+  );
+  const many = Array.from({ length: 2000 }, seededRandom(99));
+  assert.ok(Math.min(...many) >= 0 && Math.max(...many) < 1);
+  const mean = many.reduce((a, b) => a + b, 0) / many.length;
+  assert.ok(Math.abs(mean - 0.5) < 0.05, `mean ${mean} is near the middle`);
+});

--- a/test/password.test.js
+++ b/test/password.test.js
@@ -220,17 +220,58 @@ test('maxLength holds, and the placeholder shows only while empty', async () => 
   await root.unmount();
 });
 
-test('the eye reveals the text, and blurring the field hides it again', async () => {
+const inputs = (app) => nodes(treeOf(app), (n) => n.kind === 'textinput');
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+test('the eye swaps the mask for a real input, and leaving hides it again', async () => {
   const { app, root } = await mount({ defaultValue: 'letmein' });
 
   const eye = nodes(treeOf(app), (n) => n.props?.role === 'button')[0];
   click(app, eye);
   await settle();
-  assert.deepStrictEqual(texts(app), ['letmein'], 'revealed on the click');
 
-  field(app).blur();
+  const [input] = inputs(app);
+  assert.ok(input, 'revealed, the field is an ordinary <textinput>');
+  assert.strictEqual(input.value, 'letmein');
+  assert.strictEqual(canvases(app).length, 1, 'and the mask is gone: only the eye');
+
+  // …with everything a text input has, the caret included
+  input.focus();
+  input.setSelection?.(0, 3);
+  assert.strictEqual(typeof input._caret, 'number', 'it has a caret');
+
+  input.blur();
+  await sleep(5);
   await settle();
-  assert.deepStrictEqual(texts(app), [], 'and hidden on the way out');
+  assert.deepStrictEqual(inputs(app), [], 'hidden on the way out of the widget');
+  assert.deepStrictEqual(texts(app), [], 'and the secret is not drawn as text');
+
+  await root.unmount();
+});
+
+test('a revealed field still lets nothing out by a selection', async () => {
+  const { app, root } = await mount({ defaultValue: 'letmein' });
+
+  const eye = nodes(treeOf(app), (n) => n.props?.role === 'button')[0];
+  click(app, eye);
+  await settle();
+  const [input] = inputs(app);
+  input.focus();
+
+  // select everything and copy it, by the two routes a user has
+  type(app, 'a', { ctrl: true });
+  type(app, 'c', { ctrl: true });
+  type(app, 'x', { ctrl: true });
+  await settle();
+  assert.deepStrictEqual(
+    app.clipboard.writes,
+    [],
+    'neither Ctrl+C nor Ctrl+X put the secret on a selection, and Ctrl+A took no PRIMARY',
+  );
+
+  const menu = input._editMenuItems().map((item) => item.id);
+  assert.ok(!menu.includes('copy') && !menu.includes('cut'), 'nor does the menu');
+  assert.ok(menu.includes('paste'), 'but pasting in is still there');
 
   await root.unmount();
 });

--- a/test/password.test.js
+++ b/test/password.test.js
@@ -8,6 +8,8 @@ import { createMockApp } from './helpers/mock-app.js';
 import {
   hash32,
   maskWidth,
+  scribblePath,
+  scribblePointCount,
   scribblePoints,
   seededRandom,
 } from '../src/components/scribble.js';
@@ -307,18 +309,68 @@ test('the scribble is a pure function of its seed, and stays in its box', () => 
 
   assert.deepStrictEqual(a, again, 'a repaint draws the same curve');
   assert.notDeepStrictEqual(a, other, 'a keystroke draws a different one');
-  assert.strictEqual(
-    a.length,
-    7,
-    'a fixed number of points, whatever is typed',
-  );
   for (const p of a) {
     assert.ok(p.x >= 0 && p.x <= box.width, `x ${p.x} inside the box`);
     assert.ok(p.y >= 0 && p.y <= box.height, `y ${p.y} inside the box`);
   }
-  // and x marches across it, so the stroke reads as writing rather than a
-  // tangle in one corner
-  assert.ok(a[6].x > a[0].x);
+
+  const path = scribblePath(a, box);
+  assert.ok(
+    path.length > a.length * 2,
+    'sampled densely enough to look smooth',
+  );
+});
+
+test('the drawn path is clamped inside the box, not merely likely to be', () => {
+  // A spline through shuffled points overshoots on the sharp reversals — 78
+  // seeds in 200 do, in a box this short — and the stroke has width on top of
+  // that, so the ink would be shaved by the node's own clip. The clamp is what
+  // makes staying inside arithmetic rather than luck.
+  const box = { width: 160, height: 18 };
+  const inset = 2;
+  for (let seed = 0; seed < 200; seed++) {
+    for (const p of scribblePath(scribblePoints({ ...box, seed }), box)) {
+      assert.ok(p.x >= 0 && p.x <= box.width, `x ${p.x} (seed ${seed})`);
+      assert.ok(
+        p.y >= inset && p.y <= box.height - inset,
+        `y ${p.y} inside the inset box (seed ${seed})`,
+      );
+    }
+  }
+});
+
+test('the pen doubles back rather than plotting a function of x', () => {
+  const box = { width: 160, height: 18 };
+  let reversing = 0;
+  for (let seed = 0; seed < 40; seed++) {
+    const pts = scribblePoints({ ...box, seed });
+    const backwards = pts.filter((p, i) => i > 0 && p.x < pts[i - 1].x).length;
+    if (backwards >= 2) reversing++;
+    // whichever order it visits them in, it still covers the width it was
+    // given rather than knotting itself in one corner
+    const xs = pts.map((p) => p.x);
+    assert.ok(Math.min(...xs) < box.width * 0.2, 'reaches the left');
+    assert.ok(Math.max(...xs) > box.width * 0.8, 'and the right');
+  }
+  assert.ok(
+    reversing >= 38,
+    `${reversing}/40 seeds double back at least twice — a monotonic x would be a waveform`,
+  );
+});
+
+test('how many points there are follows the width, not what was typed', () => {
+  // same width, any seed: the same count. A count that moved with the value
+  // would be something to read the value off.
+  const counts = [1, 2, 3].map(
+    (seed) => scribblePoints({ width: 90, height: 18, seed }).length,
+  );
+  assert.deepStrictEqual(counts, [counts[0], counts[0], counts[0]]);
+  assert.ok(scribblePointCount(200) > scribblePointCount(60), 'denser masks');
+  assert.strictEqual(
+    scribblePointCount(4),
+    scribblePointCount(20),
+    'and a floor under it, so a two-character mask is still a scrawl',
+  );
 });
 
 test('the generator is deterministic and spread over the unit interval', () => {

--- a/test/password.test.js
+++ b/test/password.test.js
@@ -233,7 +233,11 @@ test('the eye swaps the mask for a real input, and leaving hides it again', asyn
   const [input] = inputs(app);
   assert.ok(input, 'revealed, the field is an ordinary <textinput>');
   assert.strictEqual(input.value, 'letmein');
-  assert.strictEqual(canvases(app).length, 1, 'and the mask is gone: only the eye');
+  assert.strictEqual(
+    canvases(app).length,
+    1,
+    'and the mask is gone: only the eye',
+  );
 
   // …with everything a text input has, the caret included
   input.focus();
@@ -243,7 +247,11 @@ test('the eye swaps the mask for a real input, and leaving hides it again', asyn
   input.blur();
   await sleep(5);
   await settle();
-  assert.deepStrictEqual(inputs(app), [], 'hidden on the way out of the widget');
+  assert.deepStrictEqual(
+    inputs(app),
+    [],
+    'hidden on the way out of the widget',
+  );
   assert.deepStrictEqual(texts(app), [], 'and the secret is not drawn as text');
 
   await root.unmount();
@@ -270,7 +278,10 @@ test('a revealed field still lets nothing out by a selection', async () => {
   );
 
   const menu = input._editMenuItems().map((item) => item.id);
-  assert.ok(!menu.includes('copy') && !menu.includes('cut'), 'nor does the menu');
+  assert.ok(
+    !menu.includes('copy') && !menu.includes('cut'),
+    'nor does the menu',
+  );
   assert.ok(menu.includes('paste'), 'but pasting in is still there');
 
   await root.unmount();

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -517,6 +517,7 @@ function Widgets() {
       />
       {/* @ts-expect-error the value is a string, not a number */}
       <PasswordInput value={42} />
+      <textinput sensitive value="s3cret" onChange={() => {}} />
 
       <Tabs
         items={[{ id: 'a', label: 'A', content: <box /> }]}

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -38,6 +38,7 @@ import {
   ContextMenu,
   createRoot,
   DatePicker,
+  PasswordInput,
   createStyles,
   Dialog,
   flattenStyle,
@@ -500,6 +501,22 @@ function Widgets() {
       />
       {/* @ts-expect-error a range value needs mode="range" */}
       <Calendar value={{ start: '2026-08-01', end: null }} />
+
+      <PasswordInput
+        name="password"
+        value=""
+        placeholder="Passphrase"
+        maxLength={64}
+        onChange={(ev) => void ev.value.length}
+        onSubmit={(secret) => void secret.length}
+        onRevealChange={(on) => void on}
+        drawMask={(ctx, { width, height, color }) => {
+          ctx.fillStyle = color;
+          ctx.fillRect(0, height / 2, width, 2);
+        }}
+      />
+      {/* @ts-expect-error the value is a string, not a number */}
+      <PasswordInput value={42} />
 
       <Tabs
         items={[{ id: 'a', label: 'A', content: <box /> }]}

--- a/website/scripts/check-demos.mjs
+++ b/website/scripts/check-demos.mjs
@@ -147,6 +147,10 @@ const exercises = {
   widgets: (server) => click(server, 0x0a84ff), // the primary "Mute" button
   events: (server) => click(server, 0x2980b9), // the inner box
   dates: (server) => click(server, 0x2980b9), // the primary Clear button
+  password(server) {
+    click(server, 0xeef4fb); // the field, which is the one thing painted in it
+    type(server, 'hunter2');
+  },
   tasks(server) {
     click(server, 0x27ae60); // the done task's checkbox
     // and the editor: click into the input, then type

--- a/website/src/demos/index.js
+++ b/website/src/demos/index.js
@@ -5,6 +5,7 @@ import sizeQueries from './size-queries.js';
 import widgets from './widgets.js';
 import events from './events.js';
 import dates from './dates.js';
+import password from './password.js';
 import tasks from './tasks.js';
 import canvas from './canvas.js';
 import menu from './menu.js';
@@ -25,6 +26,7 @@ const demos = [
   widgets,
   events,
   dates,
+  password,
   tasks,
   canvas,
   menu,

--- a/website/src/demos/password.js
+++ b/website/src/demos/password.js
@@ -1,0 +1,59 @@
+export default {
+  id: 'password',
+  title: 'A password field that scribbles',
+  description:
+    'Bullets report how many characters you have typed — countably, from ' +
+    'across the room — and say almost nothing about the keystroke that just ' +
+    'landed. PasswordInput draws one stroke through points seeded from the ' +
+    'window and the value, so every keystroke redraws the whole curve, and ' +
+    'nothing in the shape is per-character. Click the field and type.',
+  code: `import React, { useState } from 'react';
+import { createRoot, Button, PasswordInput } from 'react-x11';
+
+function App() {
+  const [secret, setSecret] = useState('');
+  const [signedIn, setSignedIn] = useState(false);
+
+  return (
+    <window x={30} y={30} width={460} height={300} title="sign in"
+            style={{ backgroundColor: '#f1f2f6' }}>
+      <box style={{ padding: 20, gap: 14 }}>
+        <text style={{ fontSize: 18 }}>Sign in</text>
+
+        <PasswordInput
+          value={secret}
+          onChange={(ev) => setSecret(ev.value)}
+          onSubmit={() => setSignedIn(true)}
+          placeholder="Password"
+          style={{ backgroundColor: '#eef4fb', width: 300 }}
+        />
+
+        <box style={{ flexDirection: 'row', gap: 10, alignItems: 'center' }}>
+          <text style={{ fontSize: 13, color: '#7f8c8d' }}>as bullets:</text>
+          <text style={{ fontSize: 13 }}>{'•'.repeat([...secret].length)}</text>
+        </box>
+
+        <box style={{ flexDirection: 'row', gap: 10, alignItems: 'center' }}>
+          <Button primary onPress={() => setSignedIn(true)}>Sign in</Button>
+          <Button onPress={() => { setSecret(''); setSignedIn(false); }}>
+            Clear
+          </Button>
+          <text style={{ fontSize: 12, color: '#7f8c8d' }}>
+            {signedIn ? [...secret].length + ' characters submitted' : ''}
+          </text>
+        </box>
+
+        <text style={{ fontSize: 11, color: '#7f8c8d' }}>
+          The width grows with what you type, by an uneven step — so it is
+          feedback, not a ruler. Ctrl+U clears, Ctrl+V pastes, the eye reveals
+          while you are in the field, and there is deliberately no copy.
+        </text>
+      </box>
+    </window>
+  );
+}
+
+const root = await createRoot();
+root.render(<App />);
+`,
+};


### PR DESCRIPTION
A masked field whose mask is a **scribble**, not a row of bullets.

![password-panel](https://github.com/user-attachments/assets/b1e32f1f-d997-49da-a5b8-adb0bb46d2f9)

`npm run examples:password`, or the **Password** tab of `npm run
examples:app`. There is a playground demo too. Both shots are rendered by
this branch's own code into node-x11's in-process X server.

## Why

Bullets answer the wrong question. They report **how many characters** have
been typed — countably, from across the room — and they report almost nothing
about the keystroke that just landed, because one more identical dot at the
end of a row of identical dots is the least visible change a field could
make. The feedback is weakest exactly where a password field needs it, and
strongest exactly where it should not be.

So: one stroke through points from a generator seeded by the **window id and
a hash of the value**. Every keystroke reseeds it, so the whole curve moves —
feedback you cannot miss — and nothing in the shape is per-character: the
number of points comes from the mask's *width*, where a character is worth
about half a point.

It is a **scribble rather than a waveform**, and that is a decision rather
than a look. A stroke whose `x` only ever increases is the plot of a
function, and the eye reads it as one — value against position, meaning in
the peaks — however wild the `y` is. So the points are laid out one per
column, which is what makes the stroke cover the width it was given, and then
visited **out of order**: the pen doubles back, crosses what it has already
drawn, and leaves loops.

![password-steps](https://github.com/user-attachments/assets/d4d5508e-e7ed-410c-8270-baa857e9caef)

What grows is the width, because a mask that did not would say nothing about
progress. Each position contributes an advance from a **second stream seeded
from the window only**, so the width is monotonic in the length (typing
always widens it), never twitches when a character is replaced, and is not a
clean multiple of anything a glance can divide.

Three decisions took a redraw each, and all three are in the module:

- **the shuffle is local**, a sliding window of three columns. A full shuffle
  puts consecutive points a third of the width apart on average, and in a box
  seventeen pixels tall every one of those moves is a long shallow scratch —
  a mask full of those is not a scribble either.
- **the point count follows the width.** A fixed count stretches into a few
  long strokes as the field fills, which stops looking like a scribble and,
  since density would then fall with length, says as much about the length as
  the count would. Width is already on show; density does not have to be.
- **the curve is drawn as a sampled polyline, not as béziers.** In a box this
  short the control points land within a pixel of each other constantly, and
  ntk's stroker answers a curve that small with the occasional spike — a
  stray tail several times the width of the mask, shooting out of the field.
  The same geometry is right when it is drawn eight times bigger, so this is
  a workaround for the stroker rather than for the shape — filed as
  sidorares/ntk#233, with a bisect: only at scale 1, only between two
  segments, spike length proportional to `lineWidth`, and `lineJoin` never
  reaches it. Sampling also puts every point through
  the clamp, so staying inside the field is arithmetic: 78 seeds in 200
  overshoot the inset box on the sharp reversals, and the stroke has width on
  top of that.

The limit, stated in the module and the docs rather than papered over: **this
hides a glance, not a recording.** Someone watching the field grow keystroke
by keystroke still counts the keystrokes.

## Two states

**Masked**, the value is never laid out and never drawn — the mask is measured
from one reference character, so the secret does not enter ntk's shaping cache
and its glyphs never reach the X server. Editing is smaller than
`<textinput>`'s, because a scribble has nowhere to put a caret: type,
Backspace, Ctrl+Backspace / Ctrl+U / Delete to clear, Ctrl+V or Shift+Insert
to paste, Enter to submit. No caret, no selection, no undo history — a
rewindable secret is not a feature.

**Revealed**, it is an ordinary text input, because that is what it looks like
and anything else would be a trap. A real `<textinput>` takes the mask's
place — caret, selection, arrows, a click into the middle of a word, undo, the
edit menu — and focus follows the swap both ways. The reveal ends when the
keyboard leaves the *widget*, not when it moves between the field and the
input inside it, which is what the deferred hide and its cancel are for.

![password-revealed](https://github.com/user-attachments/assets/e964182c-8748-4b18-9d00-894f23962ffd)

What holds in **both** states is that nothing leaves by a selection, and that
is a new element prop rather than a component trick: **`<textinput sensitive>`**.
Ctrl+C and the copy half of Ctrl+X do nothing, the edit menu offers neither
Cut nor Copy — absent rows rather than greyed ones, since a greyed Copy over a
password reads as a bug in the application — and a selection does not take
PRIMARY, so a middle click in another window cannot spend it. Pasting in,
editing, undo and the caret are untouched. Every route out funnels through
`_copySelection`, so one gate covers all six of them.

The line it draws is between what is on screen and what is on the clipboard:
the first stops being visible when the field is hidden, the second is readable
by every client on the display until something else takes the selection, and a
clipboard manager will have written it down.

`drawMask(ctx, info)` replaces the mask entirely (the example ships a second
field drawn as bars), `revealed`/`onRevealChange` move the reveal toggle
somewhere a keyboard can reach, and Caps Lock is reported from the modifier
state on the keys as they arrive.

## The other half: what password managers actually attach to

Asked for as part of this, and written up in
[docs/desktop.md](docs/desktop.md). The short version is that **there is no
password-field protocol on the Linux desktop** — no toolkit publishes "this
is a password field, fill it" and no manager asks. There are four seams:

1. **XTEST auto-type**, which is what nearly every manager uses. KeePassXC
   matches the focused window's *title*, then `XTestFakeKeyEvent()`s the
   keystrokes, remapping a spare keycode with `XkbSetMap()` first for any
   character the layout cannot type. Nothing is needed to support it — a
   faked key is an ordinary key — but two things follow: `<window title>` is
   the integration surface, and there is a **race**: ntk refetches the map on
   `MappingNotify`, and that refetch is a round trip that can land after the
   key does. Small window, only bites on characters outside the layout, and
   the fix belongs where the map lives.
2. **The clipboard.** Ordinary `CLIPBOARD` interop; this field takes Ctrl+V
   and Shift+Insert and strips control characters so a manager's trailing
   newline stays out of the secret. If an app ever puts a secret *on* the
   clipboard, the convention is an `x-kde-passwordManagerHint: secret` target
   beside the text — Klipper drops it from history, KDE Connect will not
   forward it, `wl-clipboard` marks the state sensitive.
3. **Secret Service** (`org.freedesktop.secrets`, or
   `org.freedesktop.portal.Secret` in a sandbox) — not a field seam at all,
   but the one that lets an app show no password field on most launches.
   `useSessionBus()` already reaches it.
4. **AT-SPI**, the only channel that exposes a field's role and contents to
   an outside program. react-x11 has no accessibility tree (NEXT_STEPS
   §11.3), so this one is closed here, and is worth reopening as one piece
   with the rest of AT-SPI rather than as a password-shaped hole in it.

## Testing

`test/password.test.js` — 16 cases: the editing model, surrogate pairs, that
nothing this field holds ever reaches a selection, that a paste arrives with
the manager's newline stripped, `maxLength`, the reveal swapping in a real input and hiding on the way out
of the widget, a revealed field still refusing every route to a selection, the Caps Lock indicator, the `drawMask` seam, and the scribble
arithmetic (width monotonic in length and stable across values, the pen
doubling back on 38 of 40 seeds while still covering the width, the point
count a function of the width alone, every sampled point inside the box, the
generator deterministic). Mutation-checked: letting Ctrl chords
fall through to the printable branch, dropping the paste cleaning, or making
the per-character advance uniform each fail the case that covers them.

`npm run typecheck` with new cases in `test/types/api.tsx`, and the website's
demo checks exercise the new playground demo by typing into it.

Six failures in `test/appearance.test.js` on this machine are pre-existing on
`origin/master` — macOS answers the appearance query before XSETTINGS can.

## Small refactor riding along

`ctrlChordLetter` moves from `nodes.js` to `keysyms.js`, where both the
renderer and the widgets can reach it, rather than being written twice.



