### PR TITLE
feat(a11y): AT-SPI in core — screen readers see the tree

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -905,11 +905,13 @@ The right-click edit menu for the text controls is done too (#90,
 `src/editmenu.js`), which closed **#88** — including its second half, where
 right-click used to collapse the selection.
 
-Next: a generic Popover, a file open/save dialog, and the AT-SPI
-accessibility work (NEXT_STEPS §11.3), which the focus work has unblocked.
-Open GitHub issues, both real: **#85** keyboard layout switching is ignored
-(non-Latin layouts always type Latin), **#86** `sans-serif` resolves to a
-CJK font on macOS.
+The AT-SPI accessibility work is done and in core (NEXT_STEPS §11.3,
+[docs/accessibility.md](docs/accessibility.md)): standard `role`/`aria-*`
+props on every element, `src/a11y.js` (the model) + `src/atspi.js` (the
+bridge), Orca-verified. Next: a generic Popover and a file open/save
+dialog. Open GitHub issues, both real: **#85** keyboard layout switching
+is ignored (non-Latin layouts always type Latin), **#86** `sans-serif`
+resolves to a CJK font on macOS.
 
 ## Pull requests
 

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -933,6 +933,13 @@ where it follows the research below and where it deliberately does not:
   Orca speaks the widget gallery — "Press me — button", "check box
   checked", "horizontal slider, 80 percent" — and can press, adjust and
   type into it over the bus.
+- **The testing story ships with it.** `renderX11({ a11y: true })` returns
+  the assistive-technology spy — the same hook feed the bridge consumes,
+  observed in-process with no bus, so an app asserts focus order, keyboard
+  cycling, "nothing nameless" and announced state changes synchronously
+  (`test/a11y-spy.test.js` is the copyable set). `npm run a11y:probe` is
+  the same idea against a live desktop: the AT side of the wire in
+  dbus-native, sharing the spy's `utteranceOf` model.
 - **Deferred, recorded in the docs page**: relations (needs an id
   registry), the Selection and Table container interfaces, key-event
   forwarding via DeviceEventController, soft-wrap line granularity in

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -22,9 +22,13 @@
 > **Plan (next session):**
 >
 > 1. Decide on **2.0.0** and merge #69.
-> 2. **§11 accessibility (AT-SPI)** is next and now unblocked: it depended on
->    window-level focus, which shipped. §11.3 scopes it out; a
->    `@react-x11/a11y` sibling package is the likely shape.
+> 2. **§11 accessibility (AT-SPI) — DONE, and in core rather than the
+>    sibling package this line used to predict.** Orca reads the widget
+>    gallery: roles, names, states, live text editing, AT-driven activation
+>    and value changes. Standard `role`/`aria-*` props on every element,
+>    `src/a11y.js` (the model) + `src/atspi.js` (the bridge) on the D-Bus
+>    layer that was already here, off silently wherever there is no bus.
+>    See [docs/accessibility.md](docs/accessibility.md) and §11.3.
 > 3. The two oldest open issues, both real and both mine to fix: **#86**
 >    (`sans-serif` resolves to a CJK font on macOS) and **#85** (keyboard
 >    layout switching ignored — needs the Linux group bits _and_ XQuartz's
@@ -737,14 +741,15 @@ menus/tooltips.
   and the siblings that do get split out live in this repo as npm
   workspaces.** The widgets are plain React over the primitives with no
   extra dependency, so splitting them buys nothing and costs a
-  peer-version matrix. The packages that genuinely want to be separate are
-  the ones with dependencies core must not take — `@react-x11/desktop`
-  (D-Bus: portals, notifications, tray, global menu, #129) and
-  `@react-x11/a11y` (AT-SPI, §11.3) — and each of those in its own
-  repository turns every change into another land-release-bump chain on
-  top of the node-x11 → ntk → here one that already exists. Workspaces
-  with release-please's manifest mode, versioned in lockstep, keeps it to
-  one release.
+  peer-version matrix. The one package that still wants to be separate is
+  `@react-x11/desktop` (D-Bus: portals, notifications, tray, global menu,
+  #129) — and in its own repository every change becomes another
+  land-release-bump chain on top of the node-x11 → ntk → here one that
+  already exists. Workspaces with release-please's manifest mode,
+  versioned in lockstep, keeps it to one release. (`@react-x11/a11y` used
+  to be the second name on this list; AT-SPI shipped in core instead —
+  §11.3 records why, and the D-Bus floor it rides on is core's own
+  optionalDependency, so the dependency argument no longer applied.)
 - Where do the rich-content formats belong — ntk, here, or their own module?
   Analysed in [RICH_CONTENT.md](RICH_CONTENT.md); the decision and the staged
   plan live in [sidorares/ntk#106](https://github.com/sidorares/ntk/issues/106).
@@ -889,9 +894,53 @@ The gaps, roughly in the order they bite:
    it into view even though `scrollIntoView(node)` exists.
 6. **Focus is not restored** when a popup closes; menus do it by hand.
 
-### 11.3 Accessibility — what the target actually is
+### 11.3 Accessibility — DONE, in core
 
-Research, not a plan yet. Conclusion first: **being a pure-JS X11 client
+Shipped: a full AT-SPI2 bridge inside react-x11 itself —
+[docs/accessibility.md](docs/accessibility.md) is the reference. The shape,
+where it follows the research below and where it deliberately does not:
+
+- **In core, not `@react-x11/a11y`.** The dependency argument for a sibling
+  package dissolved when the D-Bus layer landed in core as an
+  `optionalDependency` (docs/dbus.md): the bridge rides the same
+  `dbus-native`, is dynamically imported only when a root exists, and adds
+  nothing to the install closure. A sibling package would have bought a
+  peer-version matrix and a "why is my app not accessible" FAQ entry
+  (answer: you did not install the extra package), and an accessibility
+  layer that is opt-in is an accessibility failure.
+- **The prop shape is the web's, not React Native's.** The research below
+  recommended `accessibilityRole`/`accessibilityState`; by the time the
+  bridge landed, RN 0.71+ itself had adopted `role`/`aria-*`, and the
+  widgets here had been carrying web-style `role` strings for months. So:
+  `role`, `aria-label`, `aria-checked`, `aria-valuenow`, … on every host
+  element, plus `onAccessibilityAction` for AT-driven value writes and
+  `announce()` for live-region-style messages.
+- **No mirror.** `src/a11y.js` computes roles/names/states as pure
+  functions over the retained tree (unit-testable with no bus);
+  `src/atspi.js` answers D-Bus calls from the live tree and keeps only a
+  per-exported-node snapshot to diff precise events from. Renderer hot
+  paths pay one nullable hook slot each, trace-registry style.
+- **The ladder is small**: dbus-native installed → session bus →
+  `org.a11y.Bus.GetAddress` → connect + `Embed`. Every rung fails into a
+  silent, costless off (ssh, CI, macOS/Windows X servers). `NO_AT_BRIDGE`
+  is honoured (and set by `react-x11/test`, so suites do not parade
+  phantom apps through a live screen reader); `AT_SPI_BUS_ADDRESS` is the
+  test seam; `REACT_X11_A11Y=1` makes the climb explain itself.
+- **Coverage**: Accessible/Component/Action/Value/Text/EditableText +
+  Cache and the event streams (focus, state-changed, text-changed with
+  real diffs, children-changed, window activate, announcements). Verified
+  hermetically against an in-process bus (`test/atspi.test.js`), and live:
+  Orca speaks the widget gallery — "Press me — button", "check box
+  checked", "horizontal slider, 80 percent" — and can press, adjust and
+  type into it over the bus.
+- **Deferred, recorded in the docs page**: relations (needs an id
+  registry), the Selection and Table container interfaces, key-event
+  forwarding via DeviceEventController, soft-wrap line granularity in
+  `<textarea>`.
+
+The original research follows.
+
+Conclusion first: **being a pure-JS X11 client
 does not block accessibility**, because Linux a11y does not go over the X
 protocol at all.
 
@@ -950,11 +999,12 @@ not acting on it:
   targets against WCAG 2.2 SC 2.5.8's 24, and both now answer over 24
   without a pixel of the drawing or the layout moving.
 
-What is still missing locally, and is the natural next step here rather than
-in a sibling package: **`accessibilityRole` and friends as props**. The
-widgets already carry a `role` prop that nothing reads; §11.3's RN-shaped
-vocabulary would give the AT-SPI bridge a tree to mirror instead of one to
-infer.
+What this section called "the natural next step" — role props something
+actually reads — is done as part of §11.3: the widgets' `role` strings
+turned out to be the right vocabulary (the web's), the `aria-*` props
+joined them, and the AT-SPI bridge mirrors the tree they describe. The
+test queries' `roleOf` now answers from the same model, so tests select by
+exactly what a screen reader hears.
 
 ## 12. Before 2.0.0 freezes the API
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,14 @@
   `SplitPane`, `Canvas3D`, and the `useAnchor` popup placement hook.
 - [events.md](events.md) — the synthetic event system: dispatch phases,
   event object shape, focus, cursors, default actions.
+- [accessibility.md](accessibility.md) — screen readers see react-x11 apps:
+  the built-in AT-SPI2 bridge, the standard `role`/`aria-*` props on every
+  element, what the defaults already say, what each widget announces,
+  `announce()`, driving controls from assistive technology, the no-bus
+  compatibility ladder, and how to test all of it without a desktop. The
+  design record behind it — no mirror tree, the event pipeline, what was
+  rejected — is
+  [architecture/accessibility.md](architecture/accessibility.md).
 - [react-features.md](react-features.md) — what your React knowledge buys
   you here and where a DOM habit breaks: `useLayoutEffect` vs `useEffect`,
   measuring a node without `getBoundingClientRect()`, what a `ref` hands

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -251,8 +251,42 @@ with a stub `Embed`, and walk your app with real D-Bus calls —
 names, states as pure functions over the tree) needs no bus at all
 (`test/a11y.test.js`).
 
-Against a real desktop, the AT side of the stack is scriptable through the
-same library Orca uses:
+### Seeing it without learning a screen reader
+
+`npm run a11y:probe` is the client side of AT-SPI — the side Orca is on —
+with no GNOME libraries and nothing to configure:
+
+```bash
+npm run a11y:probe                       # what is on the accessibility bus
+npm run a11y:probe -- widgets            # dump that app's accessible tree
+npm run a11y:probe -- widgets --watch    # follow its events as you click
+npm run a11y:probe -- widgets --watch --speak   # ...said out loud
+npm run a11y:probe -- nautilus           # someone else's toolkit, for comparison
+```
+
+It talks to whatever is on the bus, so pointing it at a GTK app and at
+yours is the sharpest check available: if the shapes match, a screen reader
+will treat them the same. The `say:` lines it prints are a **toy** model —
+what Orca really utters is Orca's own policy — but they make a missing
+accessible name audible instead of merely absent, which is the failure that
+matters most and is easiest to miss.
+
+### With a real screen reader
+
+```bash
+orca --replace --debug-file=/tmp/orca.log     # then Tab through your app
+grep "SPEECH OUTPUT" /tmp/orca.log
+```
+
+The debug log is the ground truth, and it is easier to read than listening.
+For audio, speech-dispatcher does the talking (`spd-say hello` tests it on
+its own). Orca's own toggle is `gsettings set
+org.gnome.desktop.a11y.applications screen-reader-enabled true`; the GUI
+inspector, if you want one, is `accerciser`.
+
+### Scripting the AT side
+
+The AT stack is also scriptable through the same library Orca uses:
 
 ```python
 import gi; gi.require_version('Atspi', '2.0')

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -244,12 +244,62 @@ whatever the tree says. The seams, in increasing order of involvement:
 
 ## Testing and verifying
 
-The bridge is testable without a desktop: point `AT_SPI_BUS_ADDRESS` at an
-in-process bus (dbus-native's broker), own `org.a11y.atspi.Registry` on it
-with a stub `Embed`, and walk your app with real D-Bus calls —
-`test/atspi.test.js` is the worked example, and the model half (roles,
-names, states as pure functions over the tree) needs no bus at all
-(`test/a11y.test.js`).
+### Asserting what a screen reader would hear
+
+`renderX11(element, { a11y: true })` hands back `at`, an in-process
+assistive-technology spy: the same semantic feed the AT-SPI bridge serves
+to Orca, observed before it becomes D-Bus — so it is synchronous, needs no
+bus, and runs everywhere the test suite runs (the mock backend, Node 20,
+macOS included). Input stays real: `userEvent.tab()` is a Tab through the
+in-process X server's focus machinery, not a shortcut around it.
+
+```js
+import { renderX11, userEvent, cleanup, XK_SPACE } from 'react-x11/test';
+
+const { at } = await renderX11(<Preferences />, { a11y: true });
+
+await userEvent.tab();
+assert.equal(at.focused().utterance, 'Save, button');
+
+await userEvent.tab();
+await userEvent.key(XK_SPACE);
+assert.ok(at.since().some((e) => e.type === 'state' && e.state === 'checked'));
+```
+
+Every entry is a precise fact (`{ type, state, on, node, … }`) plus a
+one-line `summary`; `at.transcript()` is the summaries, made for
+`deepEqual`. `at.focused()` and `at.focusables()` describe nodes the way an
+AT would — name, role, states, and an `utterance` string following the
+model documented on this page (name, role, the states worth speaking, a
+value as a percentage). The utterance is deliberately **this library's
+model, not an imitation of Orca**, whose wording is presentation policy;
+what it buys you is that a control nobody named renders as
+`"(no accessible name)"` instead of passing because no assertion happened
+to mention its name.
+
+Four tests worth copying into any application — each one a check a sighted
+test author cannot make by looking (`test/a11y-spy.test.js` is the worked
+example of all four):
+
+- **Focus order** — tab through, `deepEqual` the focus summaries.
+- **No keyboard trap** — `at.focusables().length` + 1 Tabs lands back on
+  the first stop, and Shift+Tab wraps the other way.
+- **Nothing nameless** — for each of `at.focusables()`, assert the
+  utterance is not `"(no accessible name)"`. The highest value per line in
+  this document.
+- **State changes are announced** — press Space on a checkbox, assert a
+  `checked` state entry arrived; a widget that repaints without one is the
+  most common accessibility regression there is.
+
+### Testing the bridge itself
+
+The wire half is testable without a desktop too: point
+`AT_SPI_BUS_ADDRESS` at an in-process bus (dbus-native's broker), own
+`org.a11y.atspi.Registry` on it with a stub `Embed`, and walk your app with
+real D-Bus calls — `test/atspi.test.js` is the worked example, and the
+model half (roles, names, states as pure functions over the tree) needs no
+bus at all (`test/a11y.test.js`). Applications rarely need this layer; it
+is how react-x11 proves the transport.
 
 ### Seeing it without learning a screen reader
 

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,0 +1,285 @@
+# Accessibility
+
+react-x11 applications are visible to screen readers. The renderer carries a
+built-in [AT-SPI2](https://gitlab.gnome.org/GNOME/at-spi2-core) bridge — the
+same interface GTK and Qt applications register themselves through — so Orca
+reads a react-x11 window the way it reads any other: roles, names, states,
+focus, live text editing, and the actions to drive controls without a
+pointer.
+
+It is on by default and costs nothing to have: with no accessibility bus on
+the machine the bridge never comes up, and the render path pays one property
+read per event for the hooks it would have filled.
+
+```jsx
+<box role="button" aria-label="Close" onClick={close} focusable>
+  <text>×</text>
+</box>
+```
+
+That is the entire API for most code. `role` and `aria-*` are the web's
+names, accepted on every host element — the same vocabulary react-dom takes
+and React Native adopted — so a component library that sets them is
+accessible here with no react-x11-specific knowledge, and the built-in
+widgets (`Button`, `Checkbox`, `Select`, `Menu`, `Tabs`, `Tree`, …) already
+carry them.
+
+> This page is the reference. The design record — why there is no mirror
+> tree, why the vocabulary is the web's rather than React Native's, why
+> discovery dials its own socket, what was rejected and what is deferred —
+> is [architecture/accessibility.md](architecture/accessibility.md).
+
+## What a screen reader hears without any props
+
+Accessibility is not opt-in; the defaults are chosen so an unlabelled tree
+is _boring_ to a screen reader rather than broken:
+
+| element                 | reads as                                                    |
+| ----------------------- | ----------------------------------------------------------- |
+| `<window>`              | frame, named by `title`                                     |
+| `<popup>`               | window (give the content a `role` — `menu`, `dialog`, …)    |
+| `<box>`                 | filler — skipped silently, like GTK's own layout boxes      |
+| `<text>`                | label, reading its content                                  |
+| `<textinput>`           | entry: editable, single-line, caret and selection live      |
+| `<textarea>`            | entry: editable, multi-line                                 |
+| `<image>` / `<svg>`     | image, named by `alt`                                       |
+| `<scrollview>`          | scroll pane (and a tab stop when it can scroll — see below) |
+| `<canvas>` / `<glarea>` | drawing area / canvas — name them if they carry meaning     |
+| `<markdown>` / `<html>` | document                                                    |
+
+Focus, enabled/disabled, checked, selected, expanded and the rest are read
+from the same live state the widgets draw from — the `focusable` rule, the
+`disabled` prop, the `aria-*` props — so what the screen reader says cannot
+drift from what the screen shows.
+
+## The props
+
+All of these are accepted on every host element and are inert (and
+harmless) when no assistive technology is listening.
+
+| prop                                                        | AT-SPI meaning                                       |
+| ----------------------------------------------------------- | ---------------------------------------------------- |
+| `role`                                                      | what the element _is_ (ARIA role names; table below) |
+| `aria-label`                                                | the accessible name, over every other source         |
+| `aria-description`                                          | supplementary description                            |
+| `aria-hidden`                                               | remove this subtree from the accessible tree         |
+| `aria-checked` (`true`/`false`/`'mixed'`)                   | CHECKABLE + CHECKED / INDETERMINATE                  |
+| `aria-selected`                                             | SELECTABLE + SELECTED                                |
+| `aria-expanded`                                             | EXPANDABLE + EXPANDED / COLLAPSED                    |
+| `aria-pressed`                                              | PRESSED (toggle buttons)                             |
+| `aria-busy`, `aria-modal`, `aria-required`, `aria-readonly` | the states of the same names                         |
+| `aria-haspopup`                                             | HAS_POPUP (`'menu'`, `'listbox'`, `'dialog'`, …)     |
+| `aria-orientation`                                          | HORIZONTAL / VERTICAL                                |
+| `aria-valuenow` / `-valuemin` / `-valuemax` / `-valuetext`  | the Value interface (sliders, progress)              |
+| `aria-level`, `aria-posinset`, `aria-setsize`               | "level 2", "3 of 7" — headings, trees, lists         |
+| `aria-keyshortcuts`                                         | the shortcut announced with the item ("Ctrl+N")      |
+| `onAccessibilityAction`                                     | the AT drove the control (below)                     |
+
+Roles: `alert alertdialog article banner blockquote button caption cell
+checkbox columnheader combobox comment complementary contentinfo dialog
+document form grid gridcell group heading img link list listbox listitem log
+main marquee math menu menubar menuitem menuitemcheckbox menuitemradio meter
+navigation note option paragraph progressbar radio radiogroup region row
+rowheader scrollbar search searchbox separator slider spinbutton status
+switch tab table tablist tabpanel term textbox timer toolbar tooltip tree
+treegrid treeitem window`, plus `none`/`presentation` to erase a wrapper
+from the accessible tree while keeping its children. An unknown role warns
+in development and falls back to the element default — a typo must not
+silently turn a button into a filler, and it must not crash either.
+
+Two deliberate absences. There is no `aria-disabled`: `disabled` is already
+a host prop with real behaviour (it blocks focus and drives `:disabled`
+style blocks), and a parallel prop that only _said_ disabled would let the
+two disagree. And there is no `aria-labelledby`/`aria-describedby`: there
+are no element ids to point them at — use `aria-label`, or lean on
+name-from-contents.
+
+### Names
+
+The accessible name resolves in order: `aria-label` → what the element
+itself carries (a window's `title`, an image's `alt`, an input's
+`placeholder` — the fallback the web engines also use) → for roles whose
+contents are their label (buttons, checkboxes, menu items, tabs, links,
+options, tree items, …), the visible text inside. So
+`<Button>Save</Button>` is named "Save" with nobody writing a label, and
+`announce`-worthy custom controls need one prop, not three.
+
+### AT-driven controls
+
+Activation needs no wiring at all: every element whose role promises it
+(button, checkbox, menu item, tab, …) or that has an `onClick` exposes an
+AT-SPI `activate` action, and the bridge performs it by dispatching a
+synthetic click through the normal event path — capture, bubble, default
+actions, the discrete-priority commit — so Orca pressing a button is
+indistinguishable from a finger.
+
+(Under the hood the activation is a full press gesture — mousedown, mouseup,
+click — because several controls act on the press: `Select` and `MenuBar`
+drop their menus on it, the way real menus do.)
+
+The one thing that does need a handler is a _value_ write — Orca adjusting
+a slider through the Value interface. The handler receives one argument:
+
+```ts
+{ action: 'setValue', value: number }
+```
+
+(`action` is a string so the shape can grow; `'setValue'` is the only
+action delivered today — activation never arrives here, it goes through the
+event system above.) Wire it into the same state setter as the pointer and
+the keyboard:
+
+```jsx
+<box
+  role="slider"
+  aria-valuenow={value}
+  aria-valuemin={0}
+  aria-valuemax={100}
+  onAccessibilityAction={({ action, value }) => {
+    if (action === 'setValue') setValue(clamp(value));
+  }}
+/>
+```
+
+`Slider` already does exactly this.
+
+### Announcements
+
+```js
+import { announce } from 'react-x11';
+
+announce('Form saved');
+announce('Connection lost', { assertive: true });
+```
+
+The explicit counterpart of an ARIA live region: say something through the
+screen reader without moving focus. Returns `true` when a bridge was live
+to carry it; `false` means nobody is listening and a visible fallback may
+be warranted. (Orca ≥ 45 speaks these; there is no `aria-live` region
+tracking — an explicit call is smaller, and it cannot fire on renders you
+did not mean.)
+
+## What the built-in widgets announce
+
+Every widget in [components.md](components.md) is wired; none of them need
+anything from you beyond their ordinary props. What a screen reader hears:
+
+| widget                    | reads as                                                                                                                                                  |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Button`                  | button, named by its label; disabled buttons say so                                                                                                       |
+| `Checkbox`                | check box, checked/unchecked, named by its label                                                                                                          |
+| `Radio` / `RadioGroup`    | radio buttons with the selected one checked                                                                                                               |
+| `Switch`                  | switch, on/off — **give it an `aria-label`**, it has no visible label of its own                                                                          |
+| `Slider`                  | horizontal slider with value and range; Orca can adjust it                                                                                                |
+| `ProgressBar`             | progress bar; the value reads as a percentage of its range                                                                                                |
+| `Select`                  | combo box named by the current choice, expanded/collapsed; its menu is a listbox of options, each "n of m" and the current one selected                   |
+| `MenuBar` / `ContextMenu` | menu bar and menus; items carry their shortcut ("Ctrl+N") as the standard `keyshortcuts` attribute, checkmarks as checked, submenus as expandable         |
+| `Tooltip`                 | tooltip                                                                                                                                                   |
+| `Dialog`                  | modal dialog, named by its title                                                                                                                          |
+| `Tabs`                    | tab list with orientation; each tab selected or not; the panel is a tab panel                                                                             |
+| `Tree`                    | tree of tree items with level, expanded/collapsed and selection                                                                                           |
+| `Table`                   | table with column headers and rows ("n of m", selected). Virtualization means only rendered rows exist in the tree — the same rows a sighted user can see |
+| `SplitPane`               | the divider is a separator with orientation and position — the ARIA window-splitter pattern                                                               |
+| `Calendar` / `DatePicker` | combo box opening a grid of date cells, each named by its date and marked selected; the month buttons are labelled                                        |
+
+## Text controls
+
+`<textinput>` and `<textarea>` implement the AT-SPI `Text` and
+`EditableText` interfaces in full working order: character count, reading
+by character/word/line, caret position (offsets are code points, on both
+sides), selections, per-character screen rectangles for magnifiers and
+caret tracking, and edits — a screen reader can read, navigate, select,
+and type. Every edit and caret move emits the precise
+`text-changed`/`text-caret-moved` deltas Orca narrates from.
+
+One honest limit: "line" granularity follows hard newlines, not the soft
+wraps of a `<textarea>`'s layout. Orca still reads everything; a
+line-by-line walk of one long wrapped paragraph is one stop, not several.
+
+## The compatibility ladder
+
+`createRoot()` starts one climb per process, off the critical path:
+
+1. is `dbus-native` installed? (it is an optionalDependency; Node < 22.12
+   skips it)
+2. is there a session bus?
+3. does `org.a11y.Bus` answer `GetAddress`? (this also starts the a11y bus
+   launcher on desktops where it is not running yet)
+4. connect, export the tree, `Embed` with the AT-SPI registry.
+
+Every "no" is a normal, **silent** off: ssh sessions, CI, containers, bare
+`startx`, macOS and Windows X servers — react-x11's own flagship
+configurations — simply have no accessibility stack, and an app must not
+log, slow down or grow a mode because of it. The bridge holds no
+event-loop reference either, so a process that is done exits; the registry
+sees the name drop and forgets the app.
+
+Environment switches, in priority order:
+
+- `REACT_X11_A11Y=0` — off. Any other value forces the climb **and makes
+  it loud**: each rung prints why it stopped, which is the answer to "why
+  does Orca not see my app".
+- `AT_SPI_BUS_ADDRESS` — skip discovery and connect here. The seam
+  sandboxes use, and the one the hermetic tests use.
+- `NO_AT_BRIDGE=1` — off; the ecosystem-wide switch every toolkit honours.
+  `react-x11/test` sets it, so a test run on a desktop does not parade
+  phantom applications through a running screen reader.
+
+A dead accessibility bus is not redialled — the same contract as
+[dbus.md](dbus.md): the app simply stops being accessible until restarted.
+
+## For component libraries
+
+There is nothing to integrate against. Set the standard props on the host
+elements you render, exactly as the built-in widgets do; the bridge mirrors
+whatever the tree says. The seams, in increasing order of involvement:
+
+- `role` + `aria-*` on any element — the whole story for almost everything.
+- `disabled`, `focusable`, `tabIndex` — already doubling as the ENABLED and
+  FOCUSABLE states; nothing separate to maintain.
+- `onAccessibilityAction` — when an AT can _set_ something on your control.
+- A [registered element](extending.md) is a host element like any other:
+  its instances take all of the above, and a class that should default to a
+  role can set `props.role` in its constructor.
+
+## Testing and verifying
+
+The bridge is testable without a desktop: point `AT_SPI_BUS_ADDRESS` at an
+in-process bus (dbus-native's broker), own `org.a11y.atspi.Registry` on it
+with a stub `Embed`, and walk your app with real D-Bus calls —
+`test/atspi.test.js` is the worked example, and the model half (roles,
+names, states as pure functions over the tree) needs no bus at all
+(`test/a11y.test.js`).
+
+Against a real desktop, the AT side of the stack is scriptable through the
+same library Orca uses:
+
+```python
+import gi; gi.require_version('Atspi', '2.0')
+from gi.repository import Atspi
+desktop = Atspi.get_desktop(0)
+apps = [desktop.get_child_at_index(i) for i in range(desktop.get_child_count())]
+app = next(a for a in apps if a and a.get_name() == 'myapp')
+# walk it, read roles/names/states, do_action(0), set values…
+```
+
+Accerciser gives the same view interactively, and running `orca` while
+Tab-walking your app is the ground truth. Under `react-x11/test`,
+remember, the bridge is off by default (`NO_AT_BRIDGE`) so tests stay
+deterministic.
+
+## What is deliberately not there (yet)
+
+- **Relations** (`aria-labelledby`, label-for) — needs an id registry;
+  `aria-label` and name-from-contents cover the widgets.
+- **The Selection interface** on containers — Orca reads per-item
+  SELECTED states and selection is driven through actions and focus, so
+  this is polish, not a gap in coverage.
+- **The Table interface** — `Table` exposes honest `table`/`row`/`cell`
+  roles with positions, but not the row/column navigation calls; note that
+  virtualization means only rendered rows exist in the accessible tree,
+  which is also all a sighted user can see.
+- **Key-event forwarding** (`DeviceEventController.NotifyListenersSync`) —
+  Orca's per-keystroke echo of _keys themselves_; typed characters already
+  arrive through text-changed events.
+- **Soft-wrap line granularity** in `<textarea>`, per above.

--- a/docs/architecture/accessibility.md
+++ b/docs/architecture/accessibility.md
@@ -280,11 +280,23 @@ exactly as the GTK bridge does.
 
 ## 9. Testing
 
-Three layers, each catching what the one below cannot:
+Four layers, each catching what the one below cannot:
 
 1. **Model** (`test/a11y.test.js`) — no bus: roles, names, states,
    projection, widget wiring, over the mock app.
-2. **Hermetic bridge** (`test/atspi.test.js`) — dbus-native's
+2. **The spy** (`src/testing/a11y.js`, `test/a11y-spy.test.js`, and the
+   layer applications are meant to use via `renderX11({ a11y: true })`) —
+   the hook slots are the seam the bridge itself consumes, so a spy
+   filling the same slots observes the same contract with no transport:
+   synchronous, bus-free, Node-20-and-macOS-safe. It reuses the bridge's
+   own snapshot-and-diff idea in miniature, and it doubles as a renderer
+   regression net — a chokepoint that stops calling its hook fails these
+   tests exactly as it would silence Orca. The utterance strings it (and
+   `scripts/a11y-probe.mjs`) produce come from one shared `utteranceOf`,
+   deliberately documented as react-x11's model rather than an imitation
+   of Orca's wording, which is presentation policy that shifts between
+   releases.
+3. **Hermetic bridge** (`test/atspi.test.js`) — dbus-native's
    `createBroker()` is a real in-process message bus (routing, names, match
    rules); a stub client owns `org.a11y.atspi.Registry` and answers
    `Embed`; `AT_SPI_BUS_ADDRESS` points the bridge at it, so everything
@@ -293,13 +305,20 @@ Three layers, each catching what the one below cannot:
    wire-level facts: struct shapes, state bits, text-diff offsets, the
    press gesture, cache items. Skips itself on Node 20 where the transport
    legitimately is not installed.
-3. **Live** — not automated, but scripted and repeatable: python3
-   `gi.repository.Atspi` is libatspi, Orca's own client stack, so
+4. **Live** — not automated, but scripted and repeatable:
+   `scripts/a11y-probe.mjs` is the AT side of the wire in dbus-native
+   (tree dumps, an event tail, `--speak` through speech-dispatcher), and
+   python3 `gi.repository.Atspi` is libatspi, Orca's own client stack —
    `get_desktop(0)` → find the app → walk/`do_action`/`set_current_value`
-   exercises the real registry, and `orca --debug-file=…` grepped for
-   `SPEECH OUTPUT` is ground truth. That run is what confirmed the whole
-   chain: "Press me — button", "check box checked", "horizontal slider —
-   80 percent", menus opening from AT activation with their rows readable.
+   exercises the real registry, with `orca --debug-file=…` grepped for
+   `SPEECH OUTPUT` as ground truth. Those runs confirmed the whole chain
+   ("Press me — button", "check box checked", "horizontal slider — 80
+   percent", menus opening from AT activation) — and found a real bug on
+   first contact: `GetRoleName` answered the ARIA vocabulary while
+   `GetRole` answered the AT-SPI number. Invisible to libatspi, which
+   derives role names locally from the number and never asks — exactly
+   the class of defect only a second, independent client exposes, and the
+   argument for the probe existing at all.
 
 ## 10. Alternatives rejected, for the record
 

--- a/docs/architecture/accessibility.md
+++ b/docs/architecture/accessibility.md
@@ -1,0 +1,353 @@
+# Accessibility: an AT-SPI2 bridge with no mirror, and where it lives
+
+Design record for the accessibility layer that shipped in core — the _why_
+behind [accessibility.md](../accessibility.md), which is the reference for
+what the API is. Written as built, not as proposed: the alternatives below
+were live options at the time and the reasons they lost are the useful part.
+
+_Checked at react-x11 `a937436` (master, 2026-08-07), **ntk 7.2.0**,
+`dbus-native` 0.15.1, against at-spi2-core 2.60.4 (the installed
+introspection data) and at-spi2-core's `xml/` interface definitions (the
+wire spec). Verified live against this desktop's registry with libatspi
+(python3 `gi.repository.Atspi`) and with Orca's own speech log. File:line
+references drift with the code._
+
+---
+
+## 0. TL;DR
+
+- **Linux accessibility is D-Bus, not X.** An app exposes a tree of objects
+  implementing `org.a11y.atspi.*` on a dedicated _accessibility bus_ and
+  registers with the AT-SPI registry daemon; Orca walks that. Being a
+  pure-JS X11 client blocks nothing.
+- **Two modules.** `src/a11y.js` is the model: pure functions from the
+  retained node tree to roles/names/states, plus null hook slots the
+  renderer polls (the trace-registry pattern — one property read per event
+  when off). `src/atspi.js` is the bridge: D-Bus plumbing, dynamically
+  imported once per process when a root exists. The model is unit-testable
+  with no bus anywhere; the bridge is testable against an in-process bus.
+- **No mirror tree.** Every AT call is answered from the live node tree at
+  the moment it arrives. The only per-node bridge state is the object path,
+  the exported interface list, and a snapshot of what the bus was last
+  _told_ — kept solely to turn "something changed" into the precise AT-SPI
+  event diff.
+- **The vocabulary is the web's** (`role`, `aria-*`), not React Native's
+  `accessibilityRole` family that NEXT_STEPS §11.3 originally recommended.
+  RN itself adopted the ARIA names in 0.71, and the widgets here had been
+  carrying web role strings for months. Role→AT-SPI mappings follow what
+  Chromium and Firefox send on Linux, so Orca sees from a react-x11 app
+  what it sees from a browser.
+- **In core, not `@react-x11/a11y`.** The dependency argument for a sibling
+  package dissolved when D-Bus landed in core as an `optionalDependency`;
+  what remained was a peer-version matrix and an opt-in accessibility
+  layer, which is an accessibility failure.
+- **Off is free and silent.** A four-rung ladder (transport → session bus →
+  `GetAddress` → connect+`Embed`), every rung failing into "off" with no
+  log and no mode; the bridge's socket is `unref()`d so it never holds the
+  process open. Discovery dials a **private, short-lived connection** —
+  deliberately not the shared `sessionBus()` — see §7.
+
+## 1. The constraints that shaped it
+
+Three personas had veto power:
+
+1. **The machine with no accessibility stack** — ssh -X, CI, containers,
+   macOS/XQuartz, bare `startx`. react-x11's flagship configurations. The
+   layer must cost them nothing: no import weight, no connection attempts
+   that log, no event-loop hold, no new mode. This is the same rule
+   [dbus.md](../dbus.md) established: "no bus" is a first-class
+   configuration.
+2. **The screen-reader user on a desktop.** For them the tree has to be
+   _correct_, not merely present: states that match the pixels, focus
+   events at the moment focus moves, text deltas as they type, and controls
+   that can actually be driven. Half an implementation — a tree with stale
+   states — is worse than none, because the user cannot tell which half to
+   trust.
+3. **The component-library author targeting react-x11.** They must not need
+   a react-x11-specific integration. Standard props on host elements had to
+   be the entire seam.
+
+And one engineering constraint: the renderer's hot paths (focus moves,
+every `applyProps`, every text repaint) get touched. The cost of
+accessibility being _off_ had to be one nullable property read per site,
+which is the same bar `trace-registry.js` set for the protocol tracer.
+
+## 2. Where accessibility actually happens
+
+The at-spi2-core `xml/` directory is the wire spec, and the shape is:
+
+- A **separate bus**, not the session bus. `org.a11y.Bus.GetAddress` on the
+  session bus answers its address (activating `at-spi-bus-launcher` on
+  demand); `AT_SPI_BUS_ADDRESS` overrides.
+- The app exports objects at `/org/a11y/atspi/accessible/<id>` implementing
+  `Accessible` (tree + role + states) and per-capability interfaces:
+  `Component` (geometry, hit test, focus), `Action`, `Value`,
+  `Text`/`EditableText`. The app root at `…/accessible/root` adds
+  `Application` and calls `org.a11y.atspi.Socket.Embed` on the registry,
+  which replies with the desktop ref the root reports as its `Parent`.
+- ATs bulk-load through `org.a11y.atspi.Cache.GetItems` (one struct per
+  node) and then track **signals**: `org.a11y.atspi.Event.Object.*`
+  (`StateChanged`, `ChildrenChanged`, `TextChanged`, `TextCaretMoved`,
+  `PropertyChange`, `Announcement`, …) and `Event.Window.*`
+  (`Activate`/`Deactivate`/`Create`/`Destroy`), all with the same
+  `siiva{sv}` body. Orca's model of the app is built almost entirely from
+  these; getting their _details_ right (state nicks like `"focused"`,
+  insert/delete offsets in code points) is most of the work.
+- Toolkit-less apps are expected to drive this themselves rather than
+  inherit it from GTK. That is what `src/atspi.js` is.
+
+Enum values (roles, states, relations) were generated from the installed
+`gi.repository.Atspi` — the very tables Orca reads — and are append-only
+upstream, so they are pasted into `a11y.js` as frozen data with the
+regeneration one-liner in a comment, not fetched or computed.
+
+## 3. The two-module split, and the hook-slot seam
+
+```
+nodes.js / events.js / Reconciler.js          (hot paths)
+        │  a11yHooks.focus?.(…)  — null when off
+        ▼
+src/a11y.js       the model: role/name/states/tree-projection as pure
+                  functions; the hook slots; startA11y() gate
+        │  dynamic import, once, when a root exists and the gate passes
+        ▼
+src/atspi.js      the bridge: bus dial, Embed, per-node export, the
+                  event queue/flush, the interface implementations
+```
+
+The precedent is `trace-registry.js`: an always-imported module whose whole
+idle cost is null slots, with the heavy half behind a dynamic import. Two
+consequences fall out of the split being _exactly at the D-Bus line_:
+
+- Everything semantically interesting — what role a node has, what its name
+  resolves to, which states are set, what the accessible tree looks like
+  after pruning — is computable and testable with **no bus in the
+  process** (`test/a11y.test.js`). The bridge test then only has to prove
+  plumbing, not semantics.
+- The bridge can be rewritten (Wayland's a11y future, a different
+  transport) without touching the model or the renderer wiring.
+
+The renderer chokepoints wired to slots: `insertBefore`/`removeChild`
+(tree), `applyProps` (props), `TextChunkNode.setText` (label content),
+`TextInputNode._repaint` (value/caret/selection — every edit path funnels
+through it), `EventManager.focus` (the one place focus moves),
+`_onWindowFocus` (WM focus), `appendChildToContainer`/
+`removeChildFromContainer` (toplevels), `resetAfterCommit` (flush). Focus
+and focusability deserve a note: the focusable rule used to exist twice
+(`EventManager._isFocusable` and `Node._focusableForRing`); it now lives
+once in `a11y.js` and both call it, so the keyboard, the focus ring and the
+FOCUSABLE state cannot disagree by construction.
+
+## 4. No mirror
+
+The obvious design — GTK's, historically — is a shadow "accessible object"
+per widget, kept in sync. The whole class of bugs that produces (stale
+name, stale index, remove-before-add races) comes from the mirror being a
+second copy of the truth.
+
+Here there is no copy. `GetChildren` walks the live `node.children` through
+the projection (§5) at call time; `GetState` recomputes from live props and
+live focus; `GetExtents` reads `node.abs` and the window's live
+`_screenOrigin`. An answer cannot be stale because nothing is cached to go
+stale.
+
+What _is_ kept per exported node — `{ id, ifaces, snapshot }` — exists for
+one reason: **events are diffs, and a diff needs a "before".** The snapshot
+holds the last name/description/states/value/text the bus was told.
+`syncNode()` recomputes, XORs the two u32 state words, and emits one
+`StateChanged` per flipped bit with its enum nick; `_diffText` runs a
+common-prefix/suffix diff over the code-point arrays and emits the
+`delete`+`insert` pair with exact offsets. This is also what makes the
+wiring correct without per-prop plumbing: _any_ prop change queues the
+node, and whatever actually changed is what gets emitted.
+
+Object **export is lazy**: a node is exported the first time a ref to it is
+handed out (`refFor`), which transitively means "the first time an AT could
+possibly call back on it". Per (node, interface) the impl object is
+`{ __proto__: sharedProto, b: bridge, n: node }` — the prototypes hold all
+behaviour, dbus-native reads properties through the chain, and the per-node
+cost is a couple of two-field objects. Signals are emitted through raw
+`bus.sendSignal` rather than dbus-native's EventEmitter hook-up, so impls
+need no emitter machinery. On detach, the subtree is walked, each exported
+node unexported with a `Cache.RemoveAccessible`, and the parent gets one
+`ChildrenChanged remove` — but only if the AT had ever seen the child;
+what the bus was never told about, it does not need to hear removed.
+
+## 5. The tree projection
+
+The accessible tree is the node tree through three rules:
+
+- **Pruned subtrees**: `aria-hidden`, the internal content kinds
+  (`textchunk`, `svgchild`), `<text>` spans (the outer `<text>` speaks for
+  the run), and everything under `<glarea>` (scene nodes have no
+  rectangles). Gone entirely.
+- **Erased nodes**: `role="none"`/`"presentation"` — the node vanishes and
+  its children take its place, ARIA's semantics. This is what keeps a
+  styling wrapper from adding a filler level around every widget.
+- **Defaults**: `<box>` is FILLER — the role GTK gives its own layout
+  containers and screen readers step over silently — so an unlabelled tree
+  is _boring_ rather than noisy. Everything with real semantics defaults to
+  them (window→FRAME, text→LABEL, textinput→ENTRY, image→IMAGE, …).
+
+Two structural notes. `<popup>`s stay **nested**: a popup's `parent` is the
+JSX node it was written under, so a menu appears inside the widget that
+opened it — GTK4 does the same with popovers, and it preserves context that
+promoting popups to application children would lose. Screen coordinates
+still resolve correctly because extents go through the _owning window's_
+`_screenOrigin`, and the popup is its own window. And name-from-contents
+(button/menuitem/tab/… with no `aria-label`) concatenates the subtree's
+chunk text — which is why `MenuRow` sets `aria-label` explicitly: without
+it the shortcut column and the submenu arrow would read into the name
+("New Ctrl+N ▸").
+
+## 6. Events: queue, collapse, flush
+
+Hook calls do not emit; they queue. The flush runs at `resetAfterCommit`
+(so a commit's worth of mutations is one batch) and, for changes that
+happen outside commits — pointer-driven focus, typing into an uncontrolled
+input — on a `queueMicrotask` fallback. Collapse rules:
+
+- **Removals first**, so a node that left and rejoined in one batch reads
+  as its add, never as a stale remove.
+- **Attaches collapse to the topmost node** per subtree: the AT gets one
+  `ChildrenChanged add` + `Cache.AddAccessible` and descends on its own.
+  The initial bottom-up construction of a tree costs _nothing_ — a detached
+  subtree is not "live" (§3's `_live` walk) until its top joins a mounted
+  toplevel, so React building a window queues zero events until the
+  container mount, which then announces exactly one child.
+- Focus emits `StateChanged focused` on both ends **plus** the legacy
+  `Event.Focus.Focus` on the gaining node, because that is what the GTK
+  bridge emits and older ATs still listen for the pair.
+
+## 7. The ladder, and why discovery dials its own socket
+
+`startA11y()` (called from `createRoot`, never awaited): gate →
+`import('./atspi.js')` → transport → session-bus address → `GetAddress` →
+connect → export root + `Cache` → `Embed` → install hooks → walk
+already-mounted toplevels (via `trace-registry.onApp`). Every failure is a
+silent off; `REACT_X11_A11Y=1` makes each rung print why it stopped, which
+is the entire debugging story for "Orca doesn't see my app".
+
+The one non-obvious decision: **the `GetAddress` probe uses a private
+connection, opened and closed inside the call, not the shared
+`sessionBus()`**. The shared machinery is process-global state, and the
+climb is an unowned background task — the combination raced this repo's own
+test harness, which swaps `DBUS_SESSION_BUS_ADDRESS` to a per-test broker
+and hard-resets the shared state between cases; an in-flight climb from an
+earlier test corrupted a later test's portal reads. The fix is not "be
+careful", it is _no shared state_: a probe that owns its socket cannot
+interfere with anyone, and as a bonus the shared session connection is no
+longer dialled (and kept warm) as the side effect of a probe on machines
+where nothing else wants D-Bus.
+
+Related hygiene, borrowed from the ecosystem: `NO_AT_BRIDGE` is honoured —
+it is what at-spi2-atk checks and what GTK's own test suite sets — and
+`react-x11/test` sets it, so a suite running on a developer's desktop does
+not parade hundreds of phantom applications through a live screen reader.
+Priority order: `REACT_X11_A11Y` (explicit, either way) →
+`AT_SPI_BUS_ADDRESS` (an address is intent — it is also the hermetic test
+seam) → `NO_AT_BRIDGE` → on.
+
+The bridge holds no event-loop reference (`stream.unref()`): it is a
+passenger, not cargo, and a process with no other work exits — the
+registry sees the name drop, which is AT-SPI's own liveness model. A dead
+accessibility bus is not redialled, the same no-resurrection contract as
+`bus.js`; the registry _restarting_ is survivable though — the bridge
+watches `NameOwnerChanged` on `org.a11y.atspi.Registry` and re-embeds,
+exactly as the GTK bridge does.
+
+## 8. AT-driven input goes through the front door
+
+- **Activation** (`Action.DoAction("activate")`) dispatches a synthetic
+  **full press gesture** — MouseDown, MouseUp, Click — through
+  `EventManager.dispatch` at discrete priority with the frame flush, so an
+  AT press is indistinguishable from a finger: capture/bubble order,
+  `:active` styling, the commit, the paint. The full gesture rather than a
+  bare Click was a live-testing find: `Select` and `MenuBar` open their
+  menus **on the press**, as real menus do, and a Click-only activation
+  silently did nothing on exactly those controls. Coordinate-driven
+  _default_ actions (caret placement, drag arming) are deliberately not
+  invoked — a synthesized centre point is not a place the user chose.
+- **Value writes** (`Value.CurrentValue` set) route to the node's
+  `onAccessibilityAction({ action: 'setValue', value })`, wrapped in
+  `callHandler` so a throwing handler cannot unwind into dbus-native's
+  message dispatch. `Slider` wires it into the same clamp/quantize/emit as
+  the pointer and the keyboard — one state path, three input routes.
+- **Edits** (`EditableText`) go through `TextInputNode._commit`, the same
+  single mutation point typing uses, so `onChange` fires and undo history
+  records — an AT edit _is_ a user edit. Offsets need no conversion
+  anywhere: AT-SPI counts code points, and `_chars()`/`_caret` already do.
+
+## 9. Testing
+
+Three layers, each catching what the one below cannot:
+
+1. **Model** (`test/a11y.test.js`) — no bus: roles, names, states,
+   projection, widget wiring, over the mock app.
+2. **Hermetic bridge** (`test/atspi.test.js`) — dbus-native's
+   `createBroker()` is a real in-process message bus (routing, names, match
+   rules); a stub client owns `org.a11y.atspi.Registry` and answers
+   `Embed`; `AT_SPI_BUS_ADDRESS` points the bridge at it, so everything
+   from the address onward is the production path. A second client plays
+   the screen reader with raw `invoke` calls and a signal tap, asserting
+   wire-level facts: struct shapes, state bits, text-diff offsets, the
+   press gesture, cache items. Skips itself on Node 20 where the transport
+   legitimately is not installed.
+3. **Live** — not automated, but scripted and repeatable: python3
+   `gi.repository.Atspi` is libatspi, Orca's own client stack, so
+   `get_desktop(0)` → find the app → walk/`do_action`/`set_current_value`
+   exercises the real registry, and `orca --debug-file=…` grepped for
+   `SPEECH OUTPUT` is ground truth. That run is what confirmed the whole
+   chain: "Press me — button", "check box checked", "horizontal slider —
+   80 percent", menus opening from AT activation with their rows readable.
+
+## 10. Alternatives rejected, for the record
+
+- **A sibling `@react-x11/a11y` package** (the original §11.3 sketch).
+  Made sense when D-Bus was going to be an external dependency; once
+  `dbus-native` became core's own optionalDependency the split bought a
+  version matrix and an opt-in accessibility story, and "install another
+  package to be accessible" is the wrong default in a way no engineering
+  argument offsets.
+- **The RN prop vocabulary** (`accessibilityRole`, `accessibilityState`).
+  Overtaken by RN itself (0.71 added the ARIA names); and the widgets'
+  existing `role` strings — written before anything read them — were
+  already the web's.
+- **A mirror/shadow accessible tree.** §4; the sync-bug class it invites
+  is the thing GTK4's rewrite spent years digging out of.
+- **Gating on `org.a11y.Status.IsEnabled`** (Qt's behaviour) rather than
+  connecting whenever the bus exists (GTK's). One more mode, one more
+  property watch, to save a tree that is only maintained when something
+  queries it anyway. GTK's answer is smaller.
+- **Per-node dbus-native interface exports with EventEmitter signal
+  hook-up.** dbus-native wraps `emit` per exported object; with thousands
+  of nodes that is machinery nobody asked for. Raw `sendSignal` plus
+  prototype-shared impls keeps per-node cost to two small objects.
+- **`aria-live` region tracking.** The DOM needs it because content
+  changes are the only signal; here `announce()` is explicit, cannot fire
+  on renders you did not mean, and maps onto the modern
+  `Event.Object.Announcement` Orca ≥ 45 speaks.
+
+## 11. Deferred, and what each needs
+
+| gap                                                                | what it waits on                                                                                                                            |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| relations (`aria-labelledby`, label-for)                           | an element-id registry; `aria-label` + name-from-contents cover the widgets                                                                 |
+| `Selection` interface on containers                                | per-item SELECTED states + actions already carry selection; this is polish                                                                  |
+| `Table` interface (row/col navigation calls)                       | honest `table`/`row`/`cell` roles + posinset shipped; the interface matters most with virtualization, where only rendered rows exist at all |
+| key-event forwarding (`DeviceEventController.NotifyListenersSync`) | per-keystroke echo of keys themselves; typed characters already arrive as text-changed events                                               |
+| soft-wrap line granularity in `<textarea>`                         | ntk layout lines are available (`caretPosition(...).line`); the work is boundary bookkeeping in the Text impl                               |
+| `GetApplicationBusAddress` peer-to-peer mode                       | niche; empty string is a valid "no"                                                                                                         |
+
+## 12. Sources
+
+- at-spi2-core `xml/` — the D-Bus interface definitions (fetched from the
+  GNOME repo at implementation time; `Accessible.xml`, `Cache.xml`,
+  `Socket.xml`, `Event.xml`, `Text.xml`, …).
+- `gi.repository.Atspi` 2.60.4 on this machine — enum values, and the
+  client stack used for live verification.
+- The GTK (at-spi2-atk / GTK4) and Qt (`atspiadaptor`) bridges, and
+  Chromium's `ax_platform_node_auralinux` — prior art for role mappings,
+  event pairs, `NO_AT_BRIDGE`, and registry-restart handling.
+- Orca — both as the consumer whose event diet defines "enough", and
+  directly: its debug speech log is the acceptance test.

--- a/docs/components.md
+++ b/docs/components.md
@@ -19,6 +19,11 @@ with it). Everything else is forwarded to the host box. See
 Widget components are plain React built on the host elements — no
 reconciler support involved. They live in the package root export.
 
+All of them are screen-reader ready: roles, names, states and AT-driven
+control come built in, and an `aria-label` (or a label child) is the only
+thing a widget can need from you — [accessibility.md](accessibility.md)
+lists what each one announces.
+
 ## Theming
 
 **Widgets follow the desktop with nothing declared** — dark on a dark desktop,

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -90,6 +90,12 @@ stay inside it, focus is restored when it unmounts), `disabled` (never
 focusable, and the trigger for a `:disabled` style block), and the event
 handlers listed in [events.md](events.md).
 
+Every element also takes `role` and the `aria-*` props — the web's
+accessibility vocabulary, read by the built-in AT-SPI bridge so screen
+readers see the tree. They are inert where no assistive technology is
+listening, and the defaults already say something sensible for every
+element: [accessibility.md](accessibility.md).
+
 Drag and drop is two more prop families on the same elements —
 `dropAccept` + `onDrop` to accept a drop, `draggable` + `dragData` to start
 a drag — and works with other X11 applications as well as inside the app.
@@ -840,9 +846,10 @@ scrolls too).
 
 ## `<image>`
 
-| prop  |                                     |
-| ----- | ----------------------------------- |
-| `src` | file path (PNG/JPEG, decoded in JS) |
+| prop  |                                                                                        |
+| ----- | -------------------------------------------------------------------------------------- |
+| `src` | file path (PNG/JPEG, decoded in JS)                                                    |
+| `alt` | the accessible name — what a screen reader says ([accessibility.md](accessibility.md)) |
 
 Sized by style — `style={{ width, height }}`, never flat props, since both
 are style names. With only one of the two set the other follows the natural

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -91,14 +91,22 @@ getByPlaceholder('Your name');
 - A miss prints the tree it searched, rather than leaving you with
   `undefined is not an object`.
 
-**About roles.** There is no accessibility tree yet (NEXT_STEPS §11.3), so
-`roleOf` is the honest subset: an explicit `role` prop if there is one, else
-the element kind — `textinput` and `textarea` report `textbox`, `popup`
-reports `dialog`. The widgets set their own: `Button` is `button`,
-`Checkbox` `checkbox`, `Switch` `switch`, `Radio` `radio`, `RadioGroup`
-`radiogroup`, `Select` `combobox` (its options `option`), `Slider` `slider`,
-`ProgressBar` `progressbar`. When AT-SPI lands, these are the names it will
-publish.
+**About roles.** `roleOf` answers from the same model the AT-SPI bridge
+publishes ([accessibility.md](accessibility.md)): an explicit `role` prop
+if there is one, else the element's own semantics — `textinput` and
+`textarea` report `textbox`, `window` and `popup` `window`, `image` `img`,
+`text` `text`; kinds with no accessibility meaning (`box`, `canvas`)
+answer their kind. The widgets name themselves — `Button` is `button`,
+`Checkbox` `checkbox`, `Switch` `switch`, `Radio` `radio`, `Select`
+`combobox` (its options `option`), `Slider` `slider`, `Tabs` `tablist`/
+`tab`/`tabpanel`, `Tree` `tree`/`treeitem`, `Dialog` `dialog` — so what a
+test selects by is exactly what a screen reader hears.
+
+**And the bridge itself.** Importing `react-x11/test` sets `NO_AT_BRIDGE`,
+so a test run on a desktop never registers phantom applications with the
+live screen-reader registry. Tests that exercise the bridge deliberately
+point `AT_SPI_BUS_ADDRESS` at an in-process bus instead — see
+[accessibility.md](accessibility.md#testing-and-verifying).
 
 ## Components
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -227,6 +227,31 @@ payload by reference. A drop from _another application_ needs a second X
 connection playing the foreign source — see
 [drag-and-drop.md](drag-and-drop.md).
 
+## What a screen reader would hear
+
+`renderX11(element, { a11y: true })` adds `at` to the result: the
+assistive-technology spy, an in-process log of the same semantic feed the
+AT-SPI bridge serves to Orca — focus, state changes, text edits,
+announcements — observed at the hook seam, before any D-Bus. Synchronous,
+bus-free, and it runs wherever the suite runs.
+
+```js
+const { at } = await renderX11(<App />, { a11y: true });
+await userEvent.tab();
+assert.equal(at.focused().utterance, 'Save, button');
+await userEvent.key(XK_SPACE);
+assert.ok(at.since().some((e) => e.type === 'state' && e.state === 'checked'));
+```
+
+`at.events()` / `at.since()` are precise facts, `at.transcript()` the
+one-line summaries, `at.focusables()` every keyboard stop in Tab order with
+its utterance — a nameless control reads `"(no accessible name)"`, which
+turns the most-missed accessibility bug into a one-line audit. The four
+canonical tests (focus order, keyboard trap, nothing nameless, states
+announced) live in `test/a11y-spy.test.js`, written to be copied; the model
+behind the wording is [accessibility.md](accessibility.md)'s own, not an
+imitation of Orca's.
+
 ## `act`, and the three clocks
 
 `act(fn)` flushes everything between a state update and a pixel. There are

--- a/examples/widgets.jsx
+++ b/examples/widgets.jsx
@@ -85,7 +85,13 @@ export function WidgetsPanel() {
       </Row>
 
       <Row label="Switch">
-        <Switch checked={notify} onChange={(ev) => setNotify(ev.value)} />
+        {/* the label beside it is a sibling, not a name a screen reader
+            can find — a control with no text of its own needs one */}
+        <Switch
+          aria-label="Notifications"
+          checked={notify}
+          onChange={(ev) => setNotify(ev.value)}
+        />
         <text style={{ color: '$text' }}>
           {notify ? 'notifications on' : 'off'}
         </text>
@@ -93,6 +99,7 @@ export function WidgetsPanel() {
 
       <Row label="Slider">
         <Slider
+          aria-label="Volume"
           value={volume}
           min={0}
           max={100}
@@ -105,7 +112,7 @@ export function WidgetsPanel() {
 
       <Row label="Progress">
         <box style={{ flexGrow: 1 }}>
-          <ProgressBar value={progress} />
+          <ProgressBar aria-label="Download" value={progress} />
         </box>
         <text
           style={{ color: '$dim' }}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "examples:clipboard": "tsx examples/clipboard.jsx",
     "examples:dbus": "tsx examples/dbus.jsx",
     "filedialog:probe": "node scripts/filedialog-probe.mjs",
+    "a11y:probe": "node scripts/a11y-probe.mjs",
     "examples:form": "tsx examples/form.jsx",
     "examples:rules": "tsx examples/rules.jsx",
     "examples:richtext": "tsx examples/richtext.jsx",

--- a/scripts/a11y-probe.mjs
+++ b/scripts/a11y-probe.mjs
@@ -1,0 +1,369 @@
+#!/usr/bin/env node
+// A screen reader, minus the screen reader.
+//
+// This is the *client* side of AT-SPI — the side Orca is on — in about two
+// hundred lines of D-Bus. It exists for two reasons:
+//
+//  1. **You do not have to learn Orca to see whether your app is
+//     accessible.** Point this at a running app and it prints the tree an
+//     assistive technology sees, or follows the events one would react to,
+//     or (with `--speak`) says them out loud through speech-dispatcher.
+//  2. It is the honest measure of what our bridge emits. Nothing here
+//     imports react-x11's renderer; it talks to whatever is on the
+//     accessibility bus, so it reads a GTK or Qt app exactly as well and
+//     you can compare the two side by side. That comparison is the whole
+//     test: if `nautilus` and your app print the same *shapes*, a screen
+//     reader will treat them the same way.
+//
+//   node scripts/a11y-probe.mjs                     # what is on the bus
+//   node scripts/a11y-probe.mjs widgets             # dump that app's tree
+//   node scripts/a11y-probe.mjs widgets --watch     # follow its events
+//   node scripts/a11y-probe.mjs widgets --watch --speak   # ...out loud
+//   node scripts/a11y-probe.mjs nautilus            # someone else's toolkit
+//
+// **The `say:` lines are a toy, and mean it.** What Orca actually utters is
+// Orca's policy — verbosity settings, locale, punctuation level, its own
+// per-role scripts — and it changes between releases. This file models the
+// bit everyone agrees on (name, role, the states that changed) so that a
+// missing accessible name is *audible* rather than merely absent from a
+// table. Treat a `say:` line as "there is enough here to say something",
+// never as "Orca will say this".
+//
+// See docs/accessibility.md; the design record is
+// docs/architecture/accessibility.md.
+
+import { execFile } from 'node:child_process';
+import { ATSPI_STATE, ATSPI_STATE_NICK } from '../src/a11y.js';
+
+const REGISTRY = 'org.a11y.atspi.Registry';
+const ROOT = '/org/a11y/atspi/accessible/root';
+const ACCESSIBLE = 'org.a11y.atspi.Accessible';
+const VALUE = 'org.a11y.atspi.Value';
+const PROPERTIES = 'org.freedesktop.DBus.Properties';
+
+const argv = process.argv.slice(2);
+const has = (flag) => argv.includes(flag);
+const target = argv.find((a) => !a.startsWith('-'));
+const watch = has('--watch');
+const speak = has('--speak');
+const depthLimit = Number(
+  argv[argv.indexOf('--depth') + 1] ?? (watch ? 0 : 40),
+);
+
+// --- the bus ----------------------------------------------------------------
+
+/** Wait for a fresh dbus-native client to finish handshake + Hello. */
+async function connected(bus) {
+  await new Promise((resolve, reject) => {
+    bus.connection.once('connect', resolve);
+    bus.connection.once('error', reject);
+  });
+  await bus.listNames();
+  return bus;
+}
+
+/**
+ * The accessibility bus is not the session bus: ask `org.a11y.Bus` where it
+ * is, which also starts the launcher on a desktop where nothing has needed
+ * it yet. Exactly the rung `src/atspi.js` climbs.
+ */
+async function accessibilityBus(dbus) {
+  if (process.env.AT_SPI_BUS_ADDRESS) {
+    return connected(
+      dbus.createClient({ busAddress: process.env.AT_SPI_BUS_ADDRESS }),
+    );
+  }
+  const session = await connected(dbus.createClient({}));
+  let address;
+  try {
+    address = await session.invoke({
+      destination: 'org.a11y.Bus',
+      path: '/org/a11y/bus',
+      interface: 'org.a11y.Bus',
+      member: 'GetAddress',
+    });
+  } finally {
+    session.connection.end();
+  }
+  if (!address) throw new Error('org.a11y.Bus answered no address');
+  return connected(dbus.createClient({ busAddress: address }));
+}
+
+// --- reading an accessible --------------------------------------------------
+
+const STATE_OF = new Map(Object.entries(ATSPI_STATE).map(([k, v]) => [v, k]));
+
+/** The state nicks set on a node, from the two uint32s the wire carries. */
+function stateNames([lo = 0, hi = 0]) {
+  const out = [];
+  for (const bit of STATE_OF.keys()) {
+    const on = bit < 32 ? lo & (1 << bit) : hi & (1 << (bit - 32));
+    if (on) out.push(ATSPI_STATE_NICK[bit]);
+  }
+  return out;
+}
+
+/** A remote accessible, as a handful of calls. `ref` is the `(so)` pair
+ * every AT-SPI reply hands you: a bus name and an object path. */
+function accessible(bus, [dest, path]) {
+  const call = (iface, member, signature, body) =>
+    bus.invoke({
+      destination: dest,
+      path,
+      interface: iface,
+      member,
+      signature,
+      body,
+    });
+  const prop = (iface, name) =>
+    call(PROPERTIES, 'Get', 'ss', [iface, name]).then((v) =>
+      Array.isArray(v) ? (v[1]?.[0] ?? v[1]) : v,
+    );
+  return {
+    ref: [dest, path],
+    dest,
+    path,
+    call,
+    name: () => prop(ACCESSIBLE, 'Name'),
+    roleName: () => call(ACCESSIBLE, 'GetRoleName'),
+    states: () => call(ACCESSIBLE, 'GetState').then(stateNames),
+    children: () => call(ACCESSIBLE, 'GetChildren'),
+    interfaces: () => call(ACCESSIBLE, 'GetInterfaces'),
+    value: () => prop(VALUE, 'CurrentValue'),
+    valueMax: () => prop(VALUE, 'MaximumValue'),
+  };
+}
+
+/** Everything on the bus: the registry's root lists one child per app. */
+async function applications(bus) {
+  const refs = await accessible(bus, [REGISTRY, ROOT]).children();
+  return Promise.all(
+    refs.map(async (ref) => {
+      const a = accessible(bus, ref);
+      return { ...a, label: await a.name().catch(() => '?') };
+    }),
+  );
+}
+
+// --- the toy utterance model ------------------------------------------------
+
+/** States worth saying, and how. Everything else stays quiet — a screen
+ * reader that read out every flag would be unusable, which is the first
+ * thing you notice writing one. */
+const SPOKEN_STATES = [
+  ['checked', 'checked'],
+  ['indeterminate', 'partially checked'],
+  ['pressed', 'pressed'],
+  ['expanded', 'expanded'],
+  ['collapsed', 'collapsed'],
+  ['selected', 'selected'],
+  ['editable', null],
+  ['sensitive', null],
+];
+
+async function utterance(node) {
+  const [name, role, states] = await Promise.all([
+    node.name().catch(() => ''),
+    node.roleName().catch(() => ''),
+    node.states().catch(() => []),
+  ]);
+  const words = [];
+  if (name) words.push(name);
+  if (role && role !== 'filler') words.push(role);
+  if (!states.includes('sensitive')) words.push('unavailable');
+  for (const [state, said] of SPOKEN_STATES) {
+    if (said && states.includes(state)) words.push(said);
+  }
+  const ifaces = await node.interfaces().catch(() => []);
+  if (ifaces.includes(VALUE)) {
+    const [now, max] = await Promise.all([
+      node.value().catch(() => null),
+      node.valueMax().catch(() => null),
+    ]);
+    if (typeof now === 'number') {
+      words.push(
+        max ? `${Math.round((now / max) * 100)} percent` : String(now),
+      );
+    }
+  }
+  // A control with nothing but a role is the bug this line exists to make
+  // loud: "button" on its own is what a blind user gets, and it is useless.
+  return words.length ? words.join(', ') : '(no accessible name)';
+}
+
+let speaking = Promise.resolve();
+function say(text) {
+  if (!speak) return;
+  // queued through speech-dispatcher, the same daemon Orca speaks through
+  speaking = speaking.then(
+    () =>
+      new Promise((resolve) => execFile('spd-say', ['--wait', text], resolve)),
+  );
+}
+
+// --- the tree ---------------------------------------------------------------
+
+async function dump(node, depth = 0, budget = { left: 400 }) {
+  if (depth > depthLimit || budget.left-- <= 0) return;
+  const [name, role, states] = await Promise.all([
+    node.name().catch(() => ''),
+    node.roleName().catch(() => '?'),
+    node.states().catch(() => []),
+  ]);
+  const interesting = states.filter((s) =>
+    [
+      'focusable',
+      'focused',
+      'checked',
+      'selected',
+      'expanded',
+      'editable',
+      'modal',
+    ].includes(s),
+  );
+  console.log(
+    '  '.repeat(depth) +
+      `${role}${name ? ` "${name}"` : ''}` +
+      (interesting.length ? ` [${interesting.join(',')}]` : ''),
+  );
+  const kids = await node.children().catch(() => []);
+  for (const ref of kids) await dump(accessible(bus, ref), depth + 1, budget);
+}
+
+// --- events -----------------------------------------------------------------
+
+const WATCHED = [
+  'org.a11y.atspi.Event.Object',
+  'org.a11y.atspi.Event.Window',
+  'org.a11y.atspi.Event.Focus',
+];
+
+async function follow(bus, app) {
+  for (const iface of WATCHED) {
+    await bus.addMatch(
+      `type='signal',interface='${iface}',sender='${app.dest}'`,
+    );
+  }
+  // Some toolkits only emit once the registry says somebody is listening.
+  // Ours emits unconditionally, so this is best-effort — and the reason the
+  // probe works against GTK apps too.
+  for (const event of [
+    'object:state-changed',
+    'object:text-changed',
+    'focus:',
+  ]) {
+    await bus
+      .invoke({
+        destination: REGISTRY,
+        path: '/org/a11y/atspi/registry',
+        interface: 'org.a11y.atspi.Registry',
+        member: 'RegisterEvent',
+        signature: 'sas',
+        body: [event, []],
+      })
+      .catch(() => {});
+  }
+
+  console.log(
+    `\nwatching "${app.label}" — interact with the window (^C to stop)\n`,
+  );
+
+  bus.connection.on('message', async (msg) => {
+    if (msg.type !== 4 || msg.sender !== app.dest) return;
+    const member = msg.member;
+    const [detail, d1, , any] = msg.body ?? [];
+    const node = accessible(bus, [msg.sender, msg.path]);
+    const plain = (v) => (Array.isArray(v) ? (v[1]?.[0] ?? v[1]) : v);
+
+    if (member === 'StateChanged' && detail === 'focused' && d1 === 1) {
+      const text = await utterance(node);
+      console.log(`focus      ${text}`);
+      say(text);
+      return;
+    }
+    if (member === 'StateChanged' && detail !== 'focused') {
+      // a state a screen reader would re-announce on the focused control
+      if (['checked', 'expanded', 'selected', 'pressed'].includes(detail)) {
+        const word = d1 === 1 ? detail : `not ${detail}`;
+        console.log(`state      ${word}`);
+        say(word);
+      }
+      return;
+    }
+    if (member === 'TextChanged') {
+      const text = String(plain(any) ?? '');
+      console.log(`text       ${detail} ${JSON.stringify(text)} @${d1}`);
+      // an inserted character is what a screen reader echoes as you type
+      if (detail === 'insert' && text.length <= 2) say(text);
+      return;
+    }
+    if (member === 'TextCaretMoved') {
+      console.log(`caret      ${d1}`);
+      return;
+    }
+    if (member === 'Announcement') {
+      const text = String(plain(any) ?? '');
+      console.log(`announce   ${text}`);
+      say(text);
+      return;
+    }
+    if (member === 'ChildrenChanged') {
+      console.log(`tree       ${detail} at ${d1}`);
+      return;
+    }
+    if (member === 'Activate' || member === 'Deactivate') {
+      console.log(`window     ${member.toLowerCase()}`);
+      return;
+    }
+    if (member === 'PropertyChange') {
+      console.log(`property   ${detail} = ${JSON.stringify(plain(any))}`);
+    }
+  });
+}
+
+// --- main -------------------------------------------------------------------
+
+let bus;
+try {
+  const dbus = (await import('dbus-native')).default;
+  bus = await accessibilityBus(dbus);
+} catch (err) {
+  console.error(
+    'no accessibility bus here:',
+    err?.message ?? err,
+    '\n\nOn a desktop, enable it once with:\n' +
+      '  gsettings set org.gnome.desktop.interface toolkit-accessibility true\n' +
+      'On Node < 22.12, dbus-native is not installed: npm i dbus-native',
+  );
+  process.exit(1);
+}
+
+const apps = await applications(bus);
+
+if (!target) {
+  console.log('applications on the accessibility bus:\n');
+  for (const app of apps) console.log(`  ${app.label}`);
+  console.log(
+    '\npass one of those names to dump its tree, --watch to follow it.',
+  );
+  process.exit(0);
+}
+
+const app =
+  apps.find((a) => a.label === target) ??
+  apps.find((a) => a.label?.includes(target));
+if (!app) {
+  console.error(
+    `no application named "${target}" on the bus. Present: ${apps
+      .map((a) => a.label)
+      .join(', ')}`,
+  );
+  process.exit(1);
+}
+
+if (watch) {
+  await follow(bus, app);
+} else {
+  await dump(app);
+  process.exit(0);
+}

--- a/scripts/a11y-probe.mjs
+++ b/scripts/a11y-probe.mjs
@@ -21,19 +21,22 @@
 //   node scripts/a11y-probe.mjs widgets --watch --speak   # ...out loud
 //   node scripts/a11y-probe.mjs nautilus            # someone else's toolkit
 //
-// **The `say:` lines are a toy, and mean it.** What Orca actually utters is
+// **The `say:` lines are a model, not Orca.** What Orca actually utters is
 // Orca's policy — verbosity settings, locale, punctuation level, its own
-// per-role scripts — and it changes between releases. This file models the
-// bit everyone agrees on (name, role, the states that changed) so that a
-// missing accessible name is *audible* rather than merely absent from a
-// table. Treat a `say:` line as "there is enough here to say something",
-// never as "Orca will say this".
+// per-role scripts — and it changes between releases. The lines here follow
+// react-x11's own documented utterance model (`utteranceOf`, shared with
+// the `renderX11({ a11y: true })` test spy, which is what makes a probe
+// session and a test suite agree on wording) so that a missing accessible
+// name is *audible* rather than merely absent from a table. Treat a `say:`
+// line as "there is enough here to say something", never as "Orca will say
+// this".
 //
 // See docs/accessibility.md; the design record is
 // docs/architecture/accessibility.md.
 
 import { execFile } from 'node:child_process';
 import { ATSPI_STATE, ATSPI_STATE_NICK } from '../src/a11y.js';
+import { utteranceOf } from '../src/testing/a11y.js';
 
 const REGISTRY = 'org.a11y.atspi.Registry';
 const ROOT = '/org/a11y/atspi/accessible/root';
@@ -145,50 +148,27 @@ async function applications(bus) {
   );
 }
 
-// --- the toy utterance model ------------------------------------------------
+// --- the utterance, over the wire -------------------------------------------
 
-/** States worth saying, and how. Everything else stays quiet — a screen
- * reader that read out every flag would be unusable, which is the first
- * thing you notice writing one. */
-const SPOKEN_STATES = [
-  ['checked', 'checked'],
-  ['indeterminate', 'partially checked'],
-  ['pressed', 'pressed'],
-  ['expanded', 'expanded'],
-  ['collapsed', 'collapsed'],
-  ['selected', 'selected'],
-  ['editable', null],
-  ['sensitive', null],
-];
-
+/** Gather a remote accessible's parts and hand them to the shared model —
+ * the same `utteranceOf` the test spy uses on live nodes, fed here from
+ * real D-Bus replies so the two can never drift apart. */
 async function utterance(node) {
-  const [name, role, states] = await Promise.all([
+  const [name, role, states, ifaces] = await Promise.all([
     node.name().catch(() => ''),
     node.roleName().catch(() => ''),
     node.states().catch(() => []),
+    node.interfaces().catch(() => []),
   ]);
-  const words = [];
-  if (name) words.push(name);
-  if (role && role !== 'filler') words.push(role);
-  if (!states.includes('sensitive')) words.push('unavailable');
-  for (const [state, said] of SPOKEN_STATES) {
-    if (said && states.includes(state)) words.push(said);
-  }
-  const ifaces = await node.interfaces().catch(() => []);
+  let value = null;
   if (ifaces.includes(VALUE)) {
     const [now, max] = await Promise.all([
       node.value().catch(() => null),
       node.valueMax().catch(() => null),
     ]);
-    if (typeof now === 'number') {
-      words.push(
-        max ? `${Math.round((now / max) * 100)} percent` : String(now),
-      );
-    }
+    if (typeof now === 'number') value = { now, min: 0, max: max ?? 0 };
   }
-  // A control with nothing but a role is the bug this line exists to make
-  // loud: "button" on its own is what a blind user gets, and it is useless.
-  return words.length ? words.join(', ') : '(no accessible name)';
+  return utteranceOf({ name, role, states, value });
 }
 
 let speaking = Promise.resolve();

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -39,6 +39,7 @@ import {
   unregisterApp,
   hooks as traceHooks,
 } from './trace-registry.js';
+import { hooks as a11yHooks, startA11y } from './a11y.js';
 import { beginStartup } from './startup.js';
 import { beginCompositing, endCompositing } from './compositing.js';
 import { beginScreens, endScreens } from './screens.js';
@@ -166,6 +167,8 @@ const HostConfig = {
   resetAfterCommit() {
     flushWindowRestacks();
     traceHooks.commitEnd?.();
+    // the AT-SPI bridge flushes its queued tree/state diffs per commit
+    a11yHooks.commit?.();
   },
 
   createInstance(type, props, rootContainer, hostContext, internalHandle) {
@@ -355,6 +358,7 @@ const HostConfig = {
     // null — the container keeps the list instead. Same answer as before:
     // the first top-level node the tree put here.
     (container._rootChildren ??= []).push(child);
+    a11yHooks.rootMounted?.(child);
   },
 
   insertBefore(parentInstance, child, beforeChild) {
@@ -373,6 +377,8 @@ const HostConfig = {
     const roots = container._rootChildren;
     const at = roots ? roots.indexOf(child) : -1;
     if (at !== -1) roots.splice(at, 1);
+    // before the destroy, while the subtree is still walkable
+    a11yHooks.rootUnmounted?.(child);
     child.destroySubtree();
   },
 
@@ -657,6 +663,12 @@ export async function createRoot(options = {}) {
   // borrowed or owned, this is now a connection the renderer draws through,
   // which is what a REACT_X11_TRACE / startTrace() session follows
   registerApp(app);
+
+  // Climb toward the accessibility bus, once per process and off the
+  // critical path — every rung that fails is a normal, silent "off"
+  // (docs/accessibility.md). Deliberately not awaited: a root must not
+  // wait on a bus that is not there.
+  startA11y();
 
   // Before anything renders: the launch id has to be on the first toplevel
   // before it maps, and the environment variable has to be consumed whether

--- a/src/a11y.js
+++ b/src/a11y.js
@@ -1,0 +1,784 @@
+// The accessibility model: standard `role` / `aria-*` props resolved against
+// the retained node tree, plus the hook slots the renderer polls.
+//
+// This file is the cheap half. It is imported unconditionally by nodes.js,
+// events.js and Reconciler.js, so it must cost nothing when accessibility is
+// off: no D-Bus, no node builtins, no side effects — the hot paths pay one
+// property read per hook (`hooks.focus?.(…)`), exactly the trace-registry
+// pattern. The expensive half — the AT-SPI2 bridge that mirrors this model
+// onto the accessibility bus — lives in atspi.js and is only imported once a
+// root exists (and never with REACT_X11_A11Y=0).
+//
+// ## The vocabulary is the web's, deliberately
+//
+// `role` takes ARIA role names ('button', 'checkbox', 'tablist', …) and the
+// states are `aria-*` props (`aria-checked`, `aria-expanded`,
+// `aria-valuenow`, …) — the same names react-dom accepts and React Native
+// adopted in 0.71. NEXT_STEPS §11.3 originally suggested the older RN
+// vocabulary (`accessibilityRole`, `accessibilityState`); the widgets were
+// then built carrying web-style `role` strings years before anything read
+// them, which settled the question: the standard names are the ones this
+// codebase already speaks. A component library that sets `role="option"` and
+// `aria-selected` on a `<box>` is accessible here with no react-x11-specific
+// knowledge at all.
+//
+// What there is NOT: `aria-labelledby`/`aria-describedby` (no id registry to
+// resolve them against — `aria-label` and name-from-contents cover the
+// widgets; relations are a later addition), `aria-live` regions (announce()
+// is the explicit version), and no `aria-disabled` — `disabled` is already a
+// host prop with real behaviour (it blocks focus), and a parallel prop that
+// only *said* disabled would let the two disagree.
+//
+// ## Roles and states are AT-SPI's, numerically
+//
+// The tables below are the AT-SPI2 enums, generated from the installed
+// introspection data (at-spi2-core 2.60.4, gi.repository.Atspi — the same
+// tables Orca reads) and checked against at-spi2-core's xml/. They are
+// append-only upstream, so the numbers are stable forever; regenerate with:
+//
+//   python3 -c "import gi; gi.require_version('Atspi','2.0'); \
+//     from gi.repository import Atspi; \
+//     print({k: int(getattr(Atspi.Role, k)) for k in dir(Atspi.Role) if not k.startswith('_')})"
+
+/** AT-SPI role numbers (AtspiRole). */
+export const ATSPI_ROLE = Object.freeze({
+  INVALID: 0,
+  ALERT: 2,
+  CANVAS: 6,
+  CHECK_BOX: 7,
+  CHECK_MENU_ITEM: 8,
+  COLUMN_HEADER: 10,
+  COMBO_BOX: 11,
+  DIAL: 15,
+  DIALOG: 16,
+  DRAWING_AREA: 18,
+  FILE_CHOOSER: 19,
+  FILLER: 20,
+  FRAME: 23,
+  ICON: 26,
+  IMAGE: 27,
+  LABEL: 29,
+  LIST: 31,
+  LIST_ITEM: 32,
+  MENU: 33,
+  MENU_BAR: 34,
+  MENU_ITEM: 35,
+  PAGE_TAB: 37,
+  PAGE_TAB_LIST: 38,
+  PANEL: 39,
+  PASSWORD_TEXT: 40,
+  POPUP_MENU: 41,
+  PROGRESS_BAR: 42,
+  BUTTON: 43,
+  RADIO_BUTTON: 44,
+  RADIO_MENU_ITEM: 45,
+  ROW_HEADER: 47,
+  SCROLL_BAR: 48,
+  SCROLL_PANE: 49,
+  SEPARATOR: 50,
+  SLIDER: 51,
+  SPIN_BUTTON: 52,
+  SPLIT_PANE: 53,
+  STATUS_BAR: 54,
+  TABLE: 55,
+  TABLE_CELL: 56,
+  TABLE_COLUMN_HEADER: 57,
+  TABLE_ROW_HEADER: 58,
+  TEXT: 61,
+  TOGGLE_BUTTON: 62,
+  TOOL_BAR: 63,
+  TOOL_TIP: 64,
+  TREE: 65,
+  TREE_TABLE: 66,
+  UNKNOWN: 67,
+  VIEWPORT: 68,
+  WINDOW: 69,
+  HEADER: 71,
+  FOOTER: 72,
+  PARAGRAPH: 73,
+  APPLICATION: 75,
+  AUTOCOMPLETE: 76,
+  ENTRY: 79,
+  CAPTION: 81,
+  DOCUMENT_FRAME: 82,
+  HEADING: 83,
+  SECTION: 85,
+  FORM: 87,
+  LINK: 88,
+  TABLE_ROW: 90,
+  TREE_ITEM: 91,
+  DOCUMENT_TEXT: 94,
+  DOCUMENT_WEB: 95,
+  COMMENT: 97,
+  LIST_BOX: 98,
+  GROUPING: 99,
+  NOTIFICATION: 101,
+  INFO_BAR: 102,
+  LEVEL_BAR: 103,
+  BLOCK_QUOTE: 105,
+  ARTICLE: 109,
+  LANDMARK: 110,
+  LOG: 111,
+  MARQUEE: 112,
+  MATH: 113,
+  RATING: 114,
+  TIMER: 115,
+  STATIC: 116,
+  DESCRIPTION_LIST: 121,
+  DESCRIPTION_TERM: 122,
+  DESCRIPTION_VALUE: 123,
+  SWITCH: 130,
+});
+
+/** AT-SPI state numbers (AtspiStateType). A state set is a 64-bit field
+ * carried as two uint32s. */
+export const ATSPI_STATE = Object.freeze({
+  ACTIVE: 1,
+  BUSY: 3,
+  CHECKED: 4,
+  COLLAPSED: 5,
+  DEFUNCT: 6,
+  EDITABLE: 7,
+  ENABLED: 8,
+  EXPANDABLE: 9,
+  EXPANDED: 10,
+  FOCUSABLE: 11,
+  FOCUSED: 12,
+  HORIZONTAL: 14,
+  MODAL: 16,
+  MULTI_LINE: 17,
+  PRESSED: 20,
+  RESIZABLE: 21,
+  SELECTABLE: 22,
+  SELECTED: 23,
+  SENSITIVE: 24,
+  SHOWING: 25,
+  SINGLE_LINE: 26,
+  VERTICAL: 29,
+  VISIBLE: 30,
+  INDETERMINATE: 32,
+  REQUIRED: 33,
+  CHECKABLE: 41,
+  HAS_POPUP: 42,
+  READ_ONLY: 43,
+});
+
+/**
+ * The state-changed event's detail string for each state: the GLib enum
+ * nick, which is the constant name lowercased with dashes. Orca matches on
+ * these ("object:state-changed:focused").
+ */
+export const ATSPI_STATE_NICK = Object.freeze(
+  Object.fromEntries(
+    Object.entries(ATSPI_STATE).map(([name, bit]) => [
+      bit,
+      name.toLowerCase().replaceAll('_', '-'),
+    ]),
+  ),
+);
+
+/**
+ * ARIA role name → AT-SPI role. The mapping follows what the web engines
+ * send to AT-SPI on Linux (Chromium's ax_platform_node_auralinux, Firefox's
+ * nsRoleMap), so Orca sees from a react-x11 app exactly what it sees from a
+ * browser. Roles with no AT-SPI counterpart borrow the engines' choices
+ * ('option' → LIST_ITEM, 'meter' → LEVEL_BAR).
+ */
+const ROLE_TO_ATSPI = new Map(
+  Object.entries({
+    alert: ATSPI_ROLE.ALERT,
+    alertdialog: ATSPI_ROLE.DIALOG,
+    article: ATSPI_ROLE.ARTICLE,
+    banner: ATSPI_ROLE.LANDMARK,
+    blockquote: ATSPI_ROLE.BLOCK_QUOTE,
+    button: ATSPI_ROLE.BUTTON,
+    caption: ATSPI_ROLE.CAPTION,
+    cell: ATSPI_ROLE.TABLE_CELL,
+    checkbox: ATSPI_ROLE.CHECK_BOX,
+    columnheader: ATSPI_ROLE.COLUMN_HEADER,
+    combobox: ATSPI_ROLE.COMBO_BOX,
+    comment: ATSPI_ROLE.COMMENT,
+    complementary: ATSPI_ROLE.LANDMARK,
+    contentinfo: ATSPI_ROLE.LANDMARK,
+    dialog: ATSPI_ROLE.DIALOG,
+    document: ATSPI_ROLE.DOCUMENT_FRAME,
+    form: ATSPI_ROLE.FORM,
+    grid: ATSPI_ROLE.TABLE,
+    gridcell: ATSPI_ROLE.TABLE_CELL,
+    group: ATSPI_ROLE.GROUPING,
+    heading: ATSPI_ROLE.HEADING,
+    img: ATSPI_ROLE.IMAGE,
+    link: ATSPI_ROLE.LINK,
+    list: ATSPI_ROLE.LIST,
+    listbox: ATSPI_ROLE.LIST_BOX,
+    listitem: ATSPI_ROLE.LIST_ITEM,
+    log: ATSPI_ROLE.LOG,
+    main: ATSPI_ROLE.LANDMARK,
+    marquee: ATSPI_ROLE.MARQUEE,
+    math: ATSPI_ROLE.MATH,
+    menu: ATSPI_ROLE.MENU,
+    menubar: ATSPI_ROLE.MENU_BAR,
+    menuitem: ATSPI_ROLE.MENU_ITEM,
+    menuitemcheckbox: ATSPI_ROLE.CHECK_MENU_ITEM,
+    menuitemradio: ATSPI_ROLE.RADIO_MENU_ITEM,
+    meter: ATSPI_ROLE.LEVEL_BAR,
+    navigation: ATSPI_ROLE.LANDMARK,
+    note: ATSPI_ROLE.COMMENT,
+    option: ATSPI_ROLE.LIST_ITEM,
+    paragraph: ATSPI_ROLE.PARAGRAPH,
+    progressbar: ATSPI_ROLE.PROGRESS_BAR,
+    radio: ATSPI_ROLE.RADIO_BUTTON,
+    radiogroup: ATSPI_ROLE.PANEL,
+    region: ATSPI_ROLE.LANDMARK,
+    row: ATSPI_ROLE.TABLE_ROW,
+    rowheader: ATSPI_ROLE.ROW_HEADER,
+    scrollbar: ATSPI_ROLE.SCROLL_BAR,
+    search: ATSPI_ROLE.LANDMARK,
+    searchbox: ATSPI_ROLE.ENTRY,
+    separator: ATSPI_ROLE.SEPARATOR,
+    slider: ATSPI_ROLE.SLIDER,
+    spinbutton: ATSPI_ROLE.SPIN_BUTTON,
+    status: ATSPI_ROLE.STATUS_BAR,
+    switch: ATSPI_ROLE.SWITCH,
+    tab: ATSPI_ROLE.PAGE_TAB,
+    table: ATSPI_ROLE.TABLE,
+    tablist: ATSPI_ROLE.PAGE_TAB_LIST,
+    tabpanel: ATSPI_ROLE.PANEL,
+    term: ATSPI_ROLE.DESCRIPTION_TERM,
+    textbox: ATSPI_ROLE.ENTRY,
+    timer: ATSPI_ROLE.TIMER,
+    toolbar: ATSPI_ROLE.TOOL_BAR,
+    tooltip: ATSPI_ROLE.TOOL_TIP,
+    tree: ATSPI_ROLE.TREE,
+    treegrid: ATSPI_ROLE.TREE_TABLE,
+    treeitem: ATSPI_ROLE.TREE_ITEM,
+    window: ATSPI_ROLE.WINDOW,
+  }),
+);
+
+/** The web role names this renderer understands. Exported for the DEV
+ * warning's message and for tests. */
+export const KNOWN_ROLES = Object.freeze([
+  ...ROLE_TO_ATSPI.keys(),
+  'none',
+  'presentation',
+]);
+
+/**
+ * What an element is when nothing says otherwise. `<box>` is FILLER — the
+ * role GTK gives its own layout containers, which screen readers know to
+ * step over silently — so an unlabelled tree is *boring* to a screen reader
+ * rather than noisy. Everything with real semantics gets them here, so an
+ * app that never writes a `role` still reads: windows are frames, text is a
+ * label, an input is an entry.
+ */
+const KIND_ROLES = {
+  window: ATSPI_ROLE.FRAME,
+  popup: ATSPI_ROLE.WINDOW,
+  box: ATSPI_ROLE.FILLER,
+  text: ATSPI_ROLE.LABEL,
+  image: ATSPI_ROLE.IMAGE,
+  canvas: ATSPI_ROLE.DRAWING_AREA,
+  scrollview: ATSPI_ROLE.SCROLL_PANE,
+  textinput: ATSPI_ROLE.ENTRY,
+  textarea: ATSPI_ROLE.ENTRY,
+  markdown: ATSPI_ROLE.DOCUMENT_TEXT,
+  html: ATSPI_ROLE.DOCUMENT_WEB,
+  tex: ATSPI_ROLE.MATH,
+  svg: ATSPI_ROLE.IMAGE,
+  glarea: ATSPI_ROLE.CANVAS,
+};
+
+/** The kind → web-role-name table `roleOf()` in the test queries also
+ * reads, kept here so the queries and the bridge cannot disagree. */
+export const KIND_ROLE_NAMES = Object.freeze({
+  window: 'window',
+  popup: 'window',
+  text: 'text',
+  image: 'img',
+  canvas: 'canvas',
+  scrollview: 'scrollable',
+  textinput: 'textbox',
+  textarea: 'textbox',
+});
+
+/**
+ * Roles whose accessible name comes from their contents when no
+ * `aria-label` names them — ARIA's name-from-content set, which is how
+ * `<Button>OK</Button>` gets the name "OK" from the `<text>` inside it.
+ */
+const NAME_FROM_CONTENTS = new Set([
+  'button',
+  'cell',
+  'checkbox',
+  'columnheader',
+  'combobox',
+  'gridcell',
+  'heading',
+  'link',
+  'listitem',
+  'menuitem',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'option',
+  'radio',
+  'row',
+  'rowheader',
+  'switch',
+  'tab',
+  'tooltip',
+  'treeitem',
+]);
+
+/** Roles that promise activation, so the bridge exposes an AT-SPI action
+ * for them even when the click handler lives on an ancestor. */
+const ACTIVATABLE_ROLES = new Set([
+  'button',
+  'checkbox',
+  'combobox',
+  'link',
+  'menuitem',
+  'menuitemcheckbox',
+  'menuitemradio',
+  'option',
+  'radio',
+  'switch',
+  'tab',
+  'treeitem',
+]);
+
+/** Kinds that are internal structure, never accessibility objects: chunks
+ * and spans are the *content* of their `<text>`, SVG children belong to
+ * their `<svg>`'s raster. */
+const INTERNAL_KINDS = new Set(['textchunk', 'svgchild']);
+
+// --------------------------------------------------------------------------
+// The tree projection
+// --------------------------------------------------------------------------
+
+/** The web role name in force on a node: the `role` prop, else the kind's
+ * default name (only the kinds with real semantics have one). */
+export function roleNameOf(node) {
+  const role = node.props?.role;
+  if (typeof role === 'string' && role !== '') return role;
+  return KIND_ROLE_NAMES[node.kind] ?? null;
+}
+
+/** The AT-SPI role number for a node. An unknown `role` string falls back
+ * to the kind default rather than to nothing — a typo should not turn a
+ * button into a filler silently, but it must not crash either; the DEV
+ * check below is what reports it. */
+export function a11yRole(node) {
+  const role = node.props?.role;
+  if (typeof role === 'string') {
+    const mapped = ROLE_TO_ATSPI.get(role);
+    if (mapped !== undefined) return mapped;
+  }
+  return KIND_ROLES[node.kind] ?? ATSPI_ROLE.UNKNOWN;
+}
+
+/** `role="none"`/`"presentation"`: the node is layout, its children are
+ * not. It disappears from the accessible tree and its children take its
+ * place — ARIA's semantics, and what keeps a wrapper `<box>` from adding a
+ * level of "filler" around every widget that needs one for styling. */
+export function a11yErased(node) {
+  const role = node.props?.role;
+  return role === 'none' || role === 'presentation';
+}
+
+/** Whole-subtree removal: `aria-hidden`, the internal content kinds, and
+ * `<text>` spans (the outer `<text>` speaks for the whole run). */
+export function a11yPruned(node) {
+  if (node.props?.['aria-hidden'] === true) return true;
+  if (INTERNAL_KINDS.has(node.kind)) return true;
+  if (node.kind === 'text' && node.isSpan) return true;
+  return false;
+}
+
+/**
+ * A node's children as assistive technology sees them: pruned subtrees
+ * gone, erased nodes replaced by their children. `<glarea>` children are 3D
+ * scene nodes with their own vocabulary and no rectangles — a glarea is a
+ * leaf up here.
+ */
+export function a11yChildren(node) {
+  if (node.kind === 'glarea') return [];
+  const out = [];
+  for (const child of node.children ?? []) {
+    if (child.destroyed || a11yPruned(child)) continue;
+    if (a11yErased(child)) out.push(...a11yChildren(child));
+    else out.push(child);
+  }
+  return out;
+}
+
+/** The accessible parent: the nearest ancestor that is itself in the
+ * accessible tree (skipping erased wrappers). Null for a toplevel window —
+ * the bridge parents those on the application. */
+export function a11yParent(node) {
+  for (let p = node.parent; p; p = p.parent) {
+    if (!a11yErased(p) && !a11yPruned(p)) return p;
+  }
+  return null;
+}
+
+/** Index of `node` among its accessible siblings, -1 when detached. */
+export function a11yIndexIn(parent, node) {
+  return a11yChildren(parent).indexOf(node);
+}
+
+// --------------------------------------------------------------------------
+// Name, description, states, value
+// --------------------------------------------------------------------------
+
+/** Visible text of a subtree, for name-from-contents: every chunk under the
+ * node, in tree order, hidden branches skipped. */
+export function subtreeText(node) {
+  const parts = [];
+  const walk = (n) => {
+    if (n.props?.['aria-hidden'] === true || n.hidden) return;
+    if (n.kind === 'textchunk' && typeof n.text === 'string') {
+      parts.push(n.text);
+      return;
+    }
+    // do not read a nested widget's editable content as its parent's label
+    if (n.kind === 'textinput' || n.kind === 'textarea') return;
+    for (const child of n.children ?? []) {
+      if (!child.isWindow) walk(child);
+    }
+  };
+  walk(node);
+  return parts.join(' ').replace(/\s+/g, ' ').trim();
+}
+
+/**
+ * The accessible name, by the ARIA precedence that fits what exists here:
+ * `aria-label` above everything; then what the element itself carries (a
+ * window's `title`, an image's `alt`, an input's `placeholder` as the
+ * fallback the web engines also use); then contents, for the roles whose
+ * contents are their label.
+ */
+export function a11yName(node) {
+  const label = node.props?.['aria-label'];
+  if (typeof label === 'string' && label !== '') return label;
+  if (node.isWindow) return node.props?.title ?? '';
+  if (node.kind === 'image' || node.kind === 'svg') {
+    return node.props?.alt ?? '';
+  }
+  if (node.kind === 'textinput' || node.kind === 'textarea') {
+    return node.props?.placeholder ?? '';
+  }
+  const role = roleNameOf(node);
+  if (role !== null && NAME_FROM_CONTENTS.has(role)) return subtreeText(node);
+  if (node.kind === 'text') return subtreeText(node);
+  return '';
+}
+
+export function a11yDescription(node) {
+  const description = node.props?.['aria-description'];
+  return typeof description === 'string' ? description : '';
+}
+
+/**
+ * Whether the event manager would let this node take focus — the same rule
+ * as `EventManager._isFocusable`, which now delegates here so the answer
+ * the keyboard gives and the answer the screen reader hears cannot drift.
+ */
+export function isFocusable(node) {
+  if (node.props.disabled) return false;
+  return (
+    node.props.focusable ??
+    (node.props.tabIndex != null ? true : (node.focusableByDefault ?? false))
+  );
+}
+
+const bit = (states, state) => {
+  if (state < 32) states[0] |= 1 << state;
+  else states[1] |= 1 << (state - 32);
+};
+
+/** True when the node and every ancestor up to its window is neither
+ * `hidden` nor `display: 'none'`. */
+function effectivelyVisible(node) {
+  for (let n = node; n; n = n.parent) {
+    if (n.destroyed || n.hidden || n.style?.display === 'none') return false;
+    if (n.isWindow) break;
+  }
+  return true;
+}
+
+/**
+ * The AT-SPI state set, as the two uint32s the wire carries. Everything is
+ * derived — from the props, the kind, and the same live state the widgets
+ * draw from — so it cannot disagree with the screen.
+ */
+export function a11yStates(node) {
+  const states = [0, 0];
+  const props = node.props ?? {};
+  const S = ATSPI_STATE;
+  if (node.destroyed) {
+    bit(states, S.DEFUNCT);
+    return states;
+  }
+  const role = roleNameOf(node);
+
+  if (!props.disabled) {
+    bit(states, S.ENABLED);
+    bit(states, S.SENSITIVE);
+  }
+  if (isFocusable(node)) bit(states, S.FOCUSABLE);
+  const manager = node._focusManager?.();
+  if (manager?.focused === node) bit(states, S.FOCUSED);
+
+  if (effectivelyVisible(node)) {
+    bit(states, S.VISIBLE);
+    // SHOWING additionally wants the pixels to be reachable: the owning
+    // window has to actually exist on the server
+    const owner = node.isWindow ? node : node.root;
+    if (owner?.window) bit(states, S.SHOWING);
+  }
+
+  const checked = props['aria-checked'];
+  if (
+    checked != null ||
+    role === 'checkbox' ||
+    role === 'radio' ||
+    role === 'switch' ||
+    role === 'menuitemcheckbox' ||
+    role === 'menuitemradio'
+  ) {
+    bit(states, S.CHECKABLE);
+  }
+  if (checked === true || checked === 'true') bit(states, S.CHECKED);
+  if (checked === 'mixed') bit(states, S.INDETERMINATE);
+
+  const pressed = props['aria-pressed'];
+  if (pressed === true || pressed === 'true') bit(states, S.PRESSED);
+
+  const expanded = props['aria-expanded'];
+  if (expanded != null) {
+    bit(states, S.EXPANDABLE);
+    if (expanded === true || expanded === 'true') bit(states, S.EXPANDED);
+    else bit(states, S.COLLAPSED);
+  }
+
+  const selected = props['aria-selected'];
+  if (selected != null) bit(states, S.SELECTABLE);
+  if (selected === true || selected === 'true') bit(states, S.SELECTED);
+
+  if (props['aria-busy'] === true) bit(states, S.BUSY);
+  if (props['aria-required'] === true) bit(states, S.REQUIRED);
+  if (props['aria-haspopup']) bit(states, S.HAS_POPUP);
+  if (props['aria-modal'] === true || (role === 'dialog' && props.trapFocus)) {
+    bit(states, S.MODAL);
+  }
+
+  const orientation = props['aria-orientation'];
+  if (orientation === 'horizontal') bit(states, S.HORIZONTAL);
+  if (orientation === 'vertical') bit(states, S.VERTICAL);
+
+  const readOnly = props['aria-readonly'] === true;
+  if (readOnly) bit(states, S.READ_ONLY);
+  if (node.kind === 'textinput' || node.kind === 'textarea') {
+    bit(states, node.kind === 'textarea' ? S.MULTI_LINE : S.SINGLE_LINE);
+    if (!props.disabled && !readOnly) bit(states, S.EDITABLE);
+  }
+
+  if (node.isWindow) {
+    if (node.props?.resizable !== false && !node.isPopup) {
+      bit(states, S.RESIZABLE);
+    }
+    if (node.events?.windowFocused && node.window) bit(states, S.ACTIVE);
+  }
+
+  return states;
+}
+
+/**
+ * The AT-SPI value triple for anything that declares `aria-valuenow` —
+ * which is how a slider or progress bar built out of boxes gets a real
+ * Value interface. Null when the node has none.
+ */
+export function a11yValue(node) {
+  const now = node.props?.['aria-valuenow'];
+  if (typeof now !== 'number' || Number.isNaN(now)) return null;
+  const min = numberOr(node.props['aria-valuemin'], 0);
+  const max = numberOr(node.props['aria-valuemax'], 100);
+  const text = node.props['aria-valuetext'];
+  return {
+    now,
+    min,
+    max,
+    text: typeof text === 'string' ? text : '',
+  };
+}
+
+function numberOr(value, fallback) {
+  return typeof value === 'number' && !Number.isNaN(value) ? value : fallback;
+}
+
+/** Object attributes (`Accessible.GetAttributes`): the ARIA leftovers that
+ * are neither role nor state. Orca reads `level` for "level 2", and
+ * `posinset`/`setsize` for "3 of 7". */
+export function a11yAttributes(node) {
+  const attrs = [];
+  const props = node.props ?? {};
+  const role = props.role;
+  if (typeof role === 'string' && role !== '') attrs.push(['xml-roles', role]);
+  const level = props['aria-level'];
+  if (typeof level === 'number') attrs.push(['level', String(level)]);
+  const posinset = props['aria-posinset'];
+  if (typeof posinset === 'number') attrs.push(['posinset', String(posinset)]);
+  const setsize = props['aria-setsize'];
+  if (typeof setsize === 'number') attrs.push(['setsize', String(setsize)]);
+  const shortcuts = props['aria-keyshortcuts'];
+  if (typeof shortcuts === 'string' && shortcuts !== '') {
+    // the core-aam mapping ARIA gives it; Orca announces it with the item
+    attrs.push(['keyshortcuts', shortcuts]);
+  }
+  return attrs;
+}
+
+/** Whether the bridge should offer an "activate" action: an explicit
+ * handler, or a role that promises one (widgets often keep the handler on
+ * an ancestor of the role-carrying node — activation is dispatched through
+ * the tree, so the promise still holds). */
+export function a11yActivatable(node) {
+  if (typeof node.props?.onClick === 'function') return true;
+  const role = roleNameOf(node);
+  return role !== null && ACTIVATABLE_ROLES.has(role);
+}
+
+// --------------------------------------------------------------------------
+// DEV validation
+// --------------------------------------------------------------------------
+
+const warned = new Set();
+
+/**
+ * Report an unknown `role` once per name, in development only. Unknown
+ * `aria-*` props are deliberately not swept: the set grows with ARIA and a
+ * warning list that lags the spec teaches people to stop trusting it.
+ */
+export function devCheckA11yProps(node) {
+  const role = node.props?.role;
+  if (role == null) return;
+  if (typeof role !== 'string' || ROLE_TO_ATSPI.has(role)) return;
+  if (role === 'none' || role === 'presentation') return;
+  if (warned.has(role)) return;
+  warned.add(role);
+  console.warn(
+    `react-x11: unknown role "${role}" on <${node.kind}> — it will read as ` +
+      `the element default. Known roles: ${KNOWN_ROLES.join(', ')}.`,
+  );
+}
+
+// --------------------------------------------------------------------------
+// The hook slots, and turning the bridge on
+// --------------------------------------------------------------------------
+
+/**
+ * Slots the renderer's hot paths poll, all null until the AT-SPI bridge is
+ * live — the cost of accessibility being off is one property read per
+ * event, same design as trace-registry. atspi.js fills them; nothing else
+ * may.
+ *
+ *  - `rootMounted(windowNode)` / `rootUnmounted(windowNode)` — a toplevel
+ *    `<window>` entered or left a container.
+ *  - `attached(parent, child)` — a node joined a live tree (also popups).
+ *  - `detach(parent, child)` — about to leave; called while still wired.
+ *  - `propsChanged(node)` — after applyProps landed new props.
+ *  - `textContent(node)` — a text chunk's string changed.
+ *  - `textState(node)` — a text control's value/caret/selection may have
+ *    moved (funnelled through `_repaint`, which every edit path calls).
+ *  - `focus(previous, next)` — the owning manager moved focus.
+ *  - `windowFocus(windowNode, focused)` — the WM moved input focus.
+ *  - `commit()` — a React commit finished (resetAfterCommit).
+ *  - `announce(text, opts)` — announce() below, when a bridge is live.
+ */
+export const hooks = {
+  rootMounted: null,
+  rootUnmounted: null,
+  attached: null,
+  detach: null,
+  propsChanged: null,
+  textContent: null,
+  textState: null,
+  focus: null,
+  windowFocus: null,
+  commit: null,
+  announce: null,
+};
+
+let startPromise = null;
+
+/**
+ * Whether to climb toward the accessibility bus at all, resolved from two
+ * environment variables:
+ *
+ *  - `REACT_X11_A11Y` — this renderer's own switch. `0` is off; any other
+ *    value is an explicit "on" that also makes the climb loud, and wins
+ *    over `NO_AT_BRIDGE`.
+ *  - `NO_AT_BRIDGE` — the ecosystem's switch, honoured because it already
+ *    means "do not register with AT-SPI" to every toolkit (at-spi2-atk
+ *    checks it, GTK's own test suite sets it). react-x11's test harness
+ *    sets it too, so a test run on a desktop does not parade phantom
+ *    applications through the live screen reader.
+ *
+ * An explicit `AT_SPI_BUS_ADDRESS` is intent — whoever set it wants a
+ * bridge on that bus — so it overrides `NO_AT_BRIDGE`; the hermetic bridge
+ * tests are exactly this case.
+ */
+function a11yEnabled() {
+  const own = process.env.REACT_X11_A11Y;
+  if (own === '0') return false;
+  if (own) return true;
+  if (process.env.AT_SPI_BUS_ADDRESS) return true;
+  const noBridge = process.env.NO_AT_BRIDGE;
+  if (noBridge && noBridge !== '0') return false;
+  return true;
+}
+
+/**
+ * Kick off the AT-SPI bridge, once per process. Called from `createRoot()`
+ * and deliberately not awaited there: the ladder this climbs — transport
+ * installed? session bus? accessibility bus? — ends in "no" on most
+ * machines this renderer targets (ssh, CI, macOS/Windows X servers, bare
+ * startx), and every "no" is a normal, silent outcome that must cost the
+ * app nothing. See docs/accessibility.md for the ladder.
+ *
+ * `REACT_X11_A11Y=0` (or the ecosystem's `NO_AT_BRIDGE=1`) skips even the
+ * import; `REACT_X11_A11Y=1` makes the climb *loud* — each rung says why
+ * it stopped — which is the debugging story for "why does Orca not see my
+ * app".
+ */
+export function startA11y() {
+  if (startPromise) return startPromise;
+  if (!a11yEnabled()) {
+    startPromise = Promise.resolve(null);
+    return startPromise;
+  }
+  startPromise = import('./atspi.js')
+    .then((atspi) => atspi.start())
+    .catch((err) => {
+      if (process.env.REACT_X11_A11Y) {
+        console.warn('react-x11: accessibility bridge failed to start:', err);
+      }
+      return null;
+    });
+  return startPromise;
+}
+
+/**
+ * Say something through the screen reader without moving focus — the
+ * explicit counterpart of an ARIA live region ("saved", "3 results",
+ * "connection lost"). Returns true when a bridge was there to carry it;
+ * false means nobody is listening (no accessibility bus, or it has not
+ * connected yet) and the app may want a visible fallback.
+ *
+ *   announce('Form saved');
+ *   announce('Connection lost', { assertive: true });
+ */
+export function announce(text, opts) {
+  return hooks.announce?.(String(text), opts) ?? false;
+}

--- a/src/a11y.js
+++ b/src/a11y.js
@@ -178,6 +178,28 @@ export const ATSPI_STATE_NICK = Object.freeze(
 );
 
 /**
+ * The AT-SPI role *name* for each role number — the constant lowercased
+ * with spaces ("check box", "page tab list"), which is what
+ * `atspi_role_get_name` produces and therefore what every AT means by a
+ * role name.
+ *
+ * This is deliberately **not** the ARIA role the app wrote. libatspi
+ * derives role names locally from the number, so a bridge that answered
+ * `GetRoleName` with its own vocabulary would be inconsistent with its own
+ * `GetRole` and nobody would notice until an AT asked over the wire. The
+ * app's ARIA role travels as the `xml-roles` attribute instead, which is
+ * where Chromium and Firefox put it and where Orca looks for it.
+ */
+export const ATSPI_ROLE_NICK = Object.freeze(
+  Object.fromEntries(
+    Object.entries(ATSPI_ROLE).map(([name, role]) => [
+      role,
+      name.toLowerCase().replaceAll('_', ' '),
+    ]),
+  ),
+);
+
+/**
  * ARIA role name → AT-SPI role. The mapping follows what the web engines
  * send to AT-SPI on Linux (Chromium's ax_platform_node_auralinux, Firefox's
  * nsRoleMap), so Orca sees from a react-x11 app exactly what it sees from a

--- a/src/a11y.js
+++ b/src/a11y.js
@@ -672,6 +672,63 @@ export function a11yActivatable(node) {
 }
 
 // --------------------------------------------------------------------------
+// Text state — shared by the AT-SPI bridge's Text interface and the test
+// spy, because both answer the same question: what would an assistive
+// technology read out of this control right now?
+// --------------------------------------------------------------------------
+
+/** Kinds whose value is editable text with a caret. */
+export const isTextControl = (node) =>
+  node.kind === 'textinput' || node.kind === 'textarea';
+
+/** Kinds that expose the AT-SPI Text interface at all — the editable
+ * controls plus `<text>` labels, which are readable but caret-less. */
+export const hasTextInterface = (node) =>
+  isTextControl(node) || node.kind === 'text';
+
+/**
+ * The code points and caret/selection of anything with a Text interface —
+ * offsets in AT-SPI are code points, which is also exactly what
+ * TextInputNode's `_chars()`/`_caret` already count.
+ */
+export function textStateOf(node) {
+  if (isTextControl(node)) {
+    return {
+      chars: node._chars(),
+      caret: node._caret ?? 0,
+      selection: node._selection?.() ?? [0, 0],
+    };
+  }
+  const spans = node.collectSpans?.(node.inheritedTextStyle, []) ?? [];
+  const chars = Array.from(spans.map((s) => s.text).join(''));
+  return { chars, caret: 0, selection: [0, 0] };
+}
+
+/** Common-prefix/suffix diff of two code-point arrays →
+ * `{ offset, removed, inserted }`, the exact shape AT-SPI text-changed
+ * events want. Null when equal. */
+export function diffChars(before, after) {
+  const bn = before.length;
+  const an = after.length;
+  let prefix = 0;
+  const max = Math.min(bn, an);
+  while (prefix < max && before[prefix] === after[prefix]) prefix++;
+  let suffix = 0;
+  while (
+    suffix < max - prefix &&
+    before[bn - 1 - suffix] === after[an - 1 - suffix]
+  ) {
+    suffix++;
+  }
+  if (prefix === bn && prefix === an) return null;
+  return {
+    offset: prefix,
+    removed: before.slice(prefix, bn - suffix),
+    inserted: after.slice(prefix, an - suffix),
+  };
+}
+
+// --------------------------------------------------------------------------
 // DEV validation
 // --------------------------------------------------------------------------
 

--- a/src/atspi.js
+++ b/src/atspi.js
@@ -38,8 +38,8 @@ import {
   ATSPI_ROLE,
   ATSPI_STATE,
   ATSPI_STATE_NICK,
+  ATSPI_ROLE_NICK,
   a11yRole,
-  roleNameOf,
   a11yErased,
   a11yPruned,
   a11yChildren,
@@ -426,11 +426,17 @@ const AccessibleImpl = {
   GetRole() {
     return a11yRole(this.n);
   },
+  // The AT-SPI role name, not the ARIA one the app wrote — see
+  // ATSPI_ROLE_NICK. The ARIA role is reported through `xml-roles` in
+  // GetAttributes, as the browsers do.
   GetRoleName() {
-    return roleNameOf(this.n) ?? this.n.kind;
+    return ATSPI_ROLE_NICK[a11yRole(this.n)] ?? 'unknown';
   },
   GetLocalizedRoleName() {
-    return roleNameOf(this.n) ?? this.n.kind;
+    // No localisation here: answering the untranslated name is what a
+    // toolkit with no message catalogue should do, and libatspi falls back
+    // to its own translations anyway.
+    return ATSPI_ROLE_NICK[a11yRole(this.n)] ?? 'unknown';
   },
   GetState() {
     return a11yStates(this.n);

--- a/src/atspi.js
+++ b/src/atspi.js
@@ -1,0 +1,1795 @@
+// The AT-SPI2 bridge: the accessible tree, live on the accessibility bus.
+//
+// Linux accessibility does not go over the X protocol at all. An application
+// exposes a tree of objects on a separate D-Bus instance — the *accessibility
+// bus* — implementing the org.a11y.atspi.* interfaces (at-spi2-core's xml/ is
+// the wire spec), and registers itself with the AT-SPI registry daemon.
+// Assistive technology (Orca, Accerciser, magnifiers) walks that tree and
+// listens for its signals. Toolkit-less applications are expected to drive
+// this themselves rather than inherit it from GTK — which is exactly what
+// this file is.
+//
+// ## No mirror
+//
+// There is no shadow tree to keep in sync. Every method call is answered
+// from the live node tree through the model in a11y.js (`a11yChildren`,
+// `a11yStates`, `node.abs`, …), so the answer cannot be stale. The bridge
+// keeps only three things per exported node: its object path, which
+// interfaces it was exported with, and the last name/states/text it *told*
+// the bus about — the snapshot that turns "something changed" from the
+// renderer's hooks into the precise AT-SPI event diff.
+//
+// ## The ladder (docs/accessibility.md)
+//
+// start() climbs: transport installed → session bus → org.a11y.Bus knows an
+// address → connect → Embed with the registry. Every rung ends in a silent
+// "off" on machines with no accessibility stack — ssh, CI, containers,
+// macOS/Windows X servers — and the renderer's hook slots stay null, so the
+// app pays one property read per event for a bridge that is not there.
+// AT_SPI_BUS_ADDRESS overrides the discovery, which is also the test seam.
+//
+// Like the rest of the D-Bus layer, a dead accessibility bus is not
+// resurrected: the slots are cleared and the app simply stops being
+// accessible until restarted, the same contract bus.js documents.
+
+import { addressFor, loadTransport } from './bus.js';
+import {
+  hooks,
+  ATSPI_ROLE,
+  ATSPI_STATE,
+  ATSPI_STATE_NICK,
+  a11yRole,
+  roleNameOf,
+  a11yErased,
+  a11yPruned,
+  a11yChildren,
+  a11yParent,
+  a11yIndexIn,
+  a11yName,
+  a11yDescription,
+  a11yStates,
+  a11yValue,
+  a11yAttributes,
+  a11yActivatable,
+} from './a11y.js';
+import { onApp } from './trace-registry.js';
+import { discrete } from './events.js';
+import { callHandler } from './errors.js';
+
+const ROOT_PATH = '/org/a11y/atspi/accessible/root';
+const NODE_PATH = '/org/a11y/atspi/accessible/';
+const NULL_PATH = '/org/a11y/atspi/null';
+const CACHE_PATH = '/org/a11y/atspi/cache';
+const REGISTRY_NAME = 'org.a11y.atspi.Registry';
+
+const IFACE = {
+  ACCESSIBLE: 'org.a11y.atspi.Accessible',
+  APPLICATION: 'org.a11y.atspi.Application',
+  COMPONENT: 'org.a11y.atspi.Component',
+  ACTION: 'org.a11y.atspi.Action',
+  VALUE: 'org.a11y.atspi.Value',
+  TEXT: 'org.a11y.atspi.Text',
+  EDITABLE_TEXT: 'org.a11y.atspi.EditableText',
+  SOCKET: 'org.a11y.atspi.Socket',
+  CACHE: 'org.a11y.atspi.Cache',
+  EVENT_OBJECT: 'org.a11y.atspi.Event.Object',
+  EVENT_WINDOW: 'org.a11y.atspi.Event.Window',
+  EVENT_FOCUS: 'org.a11y.atspi.Event.Focus',
+};
+
+// AtspiCoordType / AtspiComponentLayer, from the same enums as a11y.js's
+// tables.
+const COORD_SCREEN = 0;
+const COORD_WINDOW = 1;
+const COORD_PARENT = 2;
+const LAYER_WIDGET = 3;
+const LAYER_POPUP = 5;
+const LAYER_WINDOW = 7;
+
+/** The version at-spi2-core reports for current releases; ATs use it only
+ * to gate features far newer than anything here. */
+const ATSPI_VERSION = '2.1';
+
+const EVENT_SIGNATURE = 'siiva{sv}';
+const CACHE_ITEM_SIGNATURE = '((so)(so)(so)iiassusau)';
+
+// --------------------------------------------------------------------------
+// Interface descriptors (dbus-native shape). Signatures are copied from
+// at-spi2-core's xml/, which is the authoritative wire spec.
+// --------------------------------------------------------------------------
+
+const readOnly = (type) => ({ type, access: 'read' });
+
+const ACCESSIBLE_DESC = {
+  name: IFACE.ACCESSIBLE,
+  methods: {
+    GetChildAtIndex: ['i', '(so)'],
+    GetChildren: ['', 'a(so)'],
+    GetIndexInParent: ['', 'i'],
+    GetRelationSet: ['', 'a(ua(so))'],
+    GetRole: ['', 'u'],
+    GetRoleName: ['', 's'],
+    GetLocalizedRoleName: ['', 's'],
+    GetState: ['', 'au'],
+    GetAttributes: ['', 'a{ss}'],
+    GetApplication: ['', '(so)'],
+    GetInterfaces: ['', 'as'],
+  },
+  properties: {
+    Name: readOnly('s'),
+    Description: readOnly('s'),
+    Parent: readOnly('(so)'),
+    ChildCount: readOnly('i'),
+    Locale: readOnly('s'),
+    AccessibleId: readOnly('s'),
+  },
+};
+
+const APPLICATION_DESC = {
+  name: IFACE.APPLICATION,
+  methods: {
+    GetLocale: ['u', 's'],
+    GetApplicationBusAddress: ['', 's'],
+  },
+  properties: {
+    ToolkitName: readOnly('s'),
+    Version: readOnly('s'),
+    AtspiVersion: readOnly('s'),
+    Id: 'i',
+  },
+};
+
+const SOCKET_DESC = {
+  name: IFACE.SOCKET,
+  methods: {
+    Embedded: ['s', ''],
+    Unembed: ['(so)', ''],
+  },
+};
+
+const COMPONENT_DESC = {
+  name: IFACE.COMPONENT,
+  methods: {
+    Contains: ['iiu', 'b'],
+    GetAccessibleAtPoint: ['iiu', '(so)'],
+    GetExtents: ['u', '(iiii)'],
+    GetPosition: ['u', 'ii'],
+    GetSize: ['', 'ii'],
+    GetLayer: ['', 'u'],
+    GrabFocus: ['', 'b'],
+    GetAlpha: ['', 'd'],
+    ScrollTo: ['u', 'b'],
+    ScrollToPoint: ['uii', 'b'],
+  },
+};
+
+const ACTION_DESC = {
+  name: IFACE.ACTION,
+  methods: {
+    GetDescription: ['i', 's'],
+    GetName: ['i', 's'],
+    GetLocalizedName: ['i', 's'],
+    GetKeyBinding: ['i', 's'],
+    GetActions: ['', 'a(sss)'],
+    DoAction: ['i', 'b'],
+  },
+  properties: { NActions: readOnly('i') },
+};
+
+const VALUE_DESC = {
+  name: IFACE.VALUE,
+  properties: {
+    MinimumValue: readOnly('d'),
+    MaximumValue: readOnly('d'),
+    MinimumIncrement: readOnly('d'),
+    CurrentValue: 'd',
+    Text: readOnly('s'),
+  },
+};
+
+const TEXT_DESC = {
+  name: IFACE.TEXT,
+  methods: {
+    GetText: ['ii', 's'],
+    GetStringAtOffset: ['iu', 'sii'],
+    GetTextAtOffset: ['iu', 'sii'],
+    GetTextBeforeOffset: ['iu', 'sii'],
+    GetTextAfterOffset: ['iu', 'sii'],
+    GetCharacterAtOffset: ['i', 'i'],
+    SetCaretOffset: ['i', 'b'],
+    GetAttributes: ['i', 'a{ss}ii'],
+    GetDefaultAttributes: ['', 'a{ss}'],
+    GetAttributeValue: ['is', 's'],
+    GetCharacterExtents: ['iu', 'iiii'],
+    GetRangeExtents: ['iiu', 'iiii'],
+    GetOffsetAtPoint: ['iiu', 'i'],
+    GetNSelections: ['', 'i'],
+    GetSelection: ['i', 'ii'],
+    AddSelection: ['ii', 'b'],
+    RemoveSelection: ['i', 'b'],
+    SetSelection: ['iii', 'b'],
+  },
+  properties: {
+    CharacterCount: readOnly('i'),
+    CaretOffset: readOnly('i'),
+  },
+};
+
+const EDITABLE_TEXT_DESC = {
+  name: IFACE.EDITABLE_TEXT,
+  methods: {
+    SetTextContents: ['s', 'b'],
+    InsertText: ['isi', 'b'],
+    CopyText: ['ii', ''],
+    CutText: ['ii', 'b'],
+    DeleteText: ['ii', 'b'],
+    PasteText: ['i', 'b'],
+  },
+};
+
+const CACHE_DESC = {
+  name: IFACE.CACHE,
+  methods: {
+    GetItems: ['', `a${CACHE_ITEM_SIGNATURE}`],
+  },
+  signals: {
+    AddAccessible: [CACHE_ITEM_SIGNATURE, 'nodeAdded'],
+    RemoveAccessible: ['(so)', 'nodeRemoved'],
+  },
+};
+
+// --------------------------------------------------------------------------
+// Helpers over the node tree
+// --------------------------------------------------------------------------
+
+const isTextControl = (node) =>
+  node.kind === 'textinput' || node.kind === 'textarea';
+const hasTextInterface = (node) => isTextControl(node) || node.kind === 'text';
+
+/** The code points and caret/selection of anything with a Text interface —
+ * offsets in AT-SPI are code points, which is also exactly what
+ * TextInputNode's `_chars()`/`_caret` already count. */
+function textStateOf(node) {
+  if (isTextControl(node)) {
+    return {
+      chars: node._chars(),
+      caret: node._caret ?? 0,
+      selection: node._selection?.() ?? [0, 0],
+    };
+  }
+  const spans = node.collectSpans?.(node.inheritedTextStyle, []) ?? [];
+  const chars = Array.from(spans.map((s) => s.text).join(''));
+  return { chars, caret: 0, selection: [0, 0] };
+}
+
+function clampOffset(offset, length) {
+  return Math.max(0, Math.min(offset | 0, length));
+}
+
+const isWordChar = (ch) => /\S/.test(ch);
+
+/** [start, end) of the word containing (or after) `offset`. */
+function wordRange(chars, offset) {
+  const n = chars.length;
+  let i = clampOffset(offset, n);
+  if (i >= n) i = n - 1;
+  if (i < 0) return [0, 0];
+  if (!isWordChar(chars[i])) {
+    // between words: the range is the whitespace run, as GTK reports it
+    let s = i;
+    while (s > 0 && !isWordChar(chars[s - 1])) s--;
+    let e = i;
+    while (e < n && !isWordChar(chars[e])) e++;
+    return [s, e];
+  }
+  let s = i;
+  while (s > 0 && isWordChar(chars[s - 1])) s--;
+  let e = i;
+  while (e < n && isWordChar(chars[e])) e++;
+  return [s, e];
+}
+
+/** Hard-line ranges [start, end) with the newline included in its line —
+ * what GtkTextView reports for LINE_START. Soft wraps are not lines here;
+ * see docs/accessibility.md. */
+function lineRanges(chars) {
+  const ranges = [];
+  let start = 0;
+  for (let i = 0; i < chars.length; i++) {
+    if (chars[i] === '\n') {
+      ranges.push([start, i + 1]);
+      start = i + 1;
+    }
+  }
+  ranges.push([start, chars.length]);
+  return ranges;
+}
+
+function lineRangeAt(chars, offset) {
+  const ranges = lineRanges(chars);
+  for (const range of ranges) {
+    if (offset < range[1]) return range;
+  }
+  return ranges[ranges.length - 1];
+}
+
+/**
+ * A granular range around `offset`. `granularity` follows AtspiTextGranularity
+ * (0 char, 1 word, 2 sentence, 3 line, 4 paragraph); the legacy
+ * AtspiTextBoundaryType values GetTextAtOffset carries are translated by the
+ * caller. Sentences and paragraphs answer as lines — hard lines are the only
+ * paragraph structure a `<textarea>` has.
+ */
+function granularRange(chars, offset, granularity) {
+  const n = chars.length;
+  const at = clampOffset(offset, n);
+  switch (granularity) {
+    case 0:
+      return at >= n ? [n, n] : [at, at + 1];
+    case 1:
+      return wordRange(chars, at);
+    default:
+      return lineRangeAt(chars, at);
+  }
+}
+
+/** Legacy AtspiTextBoundaryType → granularity (start/end variants collapse:
+ * the range is the same, only legacy iteration order differed). */
+function boundaryToGranularity(type) {
+  if (type === 0) return 0; // CHAR
+  if (type === 1 || type === 2) return 1; // WORD_START / WORD_END
+  return 3; // SENTENCE_* and LINE_* answer as lines
+}
+
+/** Common-prefix/suffix diff of two code-point arrays →
+ * `{ offset, removed, inserted }`, the exact shape AT-SPI text-changed
+ * events want. Null when equal. */
+function diffChars(before, after) {
+  const bn = before.length;
+  const an = after.length;
+  let prefix = 0;
+  const max = Math.min(bn, an);
+  while (prefix < max && before[prefix] === after[prefix]) prefix++;
+  let suffix = 0;
+  while (
+    suffix < max - prefix &&
+    before[bn - 1 - suffix] === after[an - 1 - suffix]
+  ) {
+    suffix++;
+  }
+  if (prefix === bn && prefix === an) return null;
+  return {
+    offset: prefix,
+    removed: before.slice(prefix, bn - suffix),
+    inserted: after.slice(prefix, an - suffix),
+  };
+}
+
+/** The best guess at what the desktop calls this program. */
+function programName() {
+  const scriptPath = process.argv?.[1];
+  if (typeof scriptPath === 'string' && scriptPath !== '') {
+    const base = scriptPath.split(/[\\/]/).pop();
+    if (base) return base.replace(/\.[cm]?jsx?$/, '');
+  }
+  return process.title || 'node';
+}
+
+function localeString() {
+  return (
+    process.env.LC_ALL || process.env.LC_MESSAGES || process.env.LANG || 'C'
+  );
+}
+
+// --------------------------------------------------------------------------
+// Per-interface implementation prototypes. One tiny `{ b, n }` object per
+// (node, interface) is created at export time; everything else lives here.
+// dbus-native reads properties straight off the object (prototype getters
+// included) and calls methods with the message appended, which none of
+// these need — the node is bound at export.
+// --------------------------------------------------------------------------
+
+const AccessibleImpl = {
+  get Name() {
+    return a11yName(this.n);
+  },
+  get Description() {
+    return a11yDescription(this.n);
+  },
+  get Parent() {
+    return this.b.parentRef(this.n);
+  },
+  get ChildCount() {
+    return a11yChildren(this.n).length;
+  },
+  get Locale() {
+    return localeString();
+  },
+  get AccessibleId() {
+    return '';
+  },
+  GetChildAtIndex(index) {
+    const child = a11yChildren(this.n)[index];
+    return child ? this.b.refFor(child) : this.b.nullRef();
+  },
+  GetChildren() {
+    return a11yChildren(this.n).map((child) => this.b.refFor(child));
+  },
+  GetIndexInParent() {
+    const parent = a11yParent(this.n);
+    if (!parent) return this.b.toplevels.indexOf(this.n);
+    return a11yIndexIn(parent, this.n);
+  },
+  GetRelationSet() {
+    return [];
+  },
+  GetRole() {
+    return a11yRole(this.n);
+  },
+  GetRoleName() {
+    return roleNameOf(this.n) ?? this.n.kind;
+  },
+  GetLocalizedRoleName() {
+    return roleNameOf(this.n) ?? this.n.kind;
+  },
+  GetState() {
+    return a11yStates(this.n);
+  },
+  GetAttributes() {
+    return a11yAttributes(this.n);
+  },
+  GetApplication() {
+    return this.b.rootRef();
+  },
+  GetInterfaces() {
+    return this.b.interfacesOf(this.n);
+  },
+};
+
+const ComponentImpl = {
+  Contains(x, y) {
+    const r = this.b.extentsOf(this.n, COORD_SCREEN);
+    return x >= r[0] && y >= r[1] && x < r[0] + r[2] && y < r[1] + r[3];
+  },
+  GetAccessibleAtPoint(x, y, coordType) {
+    const node = this.n;
+    const win = node.isWindow ? node : node.root;
+    if (!win) return this.b.nullRef();
+    let wx = x;
+    let wy = y;
+    if (coordType !== COORD_WINDOW) {
+      const origin = this.b.screenOriginOf(win);
+      wx -= origin.x;
+      wy -= origin.y;
+    }
+    let hit = win.hitTest?.(wx, wy) ?? null;
+    while (hit && (a11yErased(hit) || a11yPruned(hit))) hit = hit.parent;
+    return hit ? this.b.refFor(hit) : this.b.nullRef();
+  },
+  GetExtents(coordType) {
+    return this.b.extentsOf(this.n, coordType);
+  },
+  GetPosition(coordType) {
+    const r = this.b.extentsOf(this.n, coordType);
+    return [r[0], r[1]];
+  },
+  GetSize() {
+    const r = this.b.extentsOf(this.n, COORD_WINDOW);
+    return [r[2], r[3]];
+  },
+  GetLayer() {
+    if (this.n.isPopup) return LAYER_POPUP;
+    if (this.n.isWindow) return LAYER_WINDOW;
+    return LAYER_WIDGET;
+  },
+  GrabFocus() {
+    if (typeof this.n.focus !== 'function') return false;
+    this.n.focus();
+    return true;
+  },
+  GetAlpha() {
+    return 1.0;
+  },
+  ScrollTo() {
+    for (let p = this.n.parent; p; p = p.parent) {
+      if (typeof p.scrollIntoView === 'function') {
+        p.scrollIntoView(this.n);
+        return true;
+      }
+    }
+    return false;
+  },
+  ScrollToPoint() {
+    return false;
+  },
+};
+
+const ACTIVATE = 'activate';
+
+const ActionImpl = {
+  get NActions() {
+    return 1;
+  },
+  GetName(index) {
+    return index === 0 ? ACTIVATE : '';
+  },
+  GetLocalizedName(index) {
+    return index === 0 ? ACTIVATE : '';
+  },
+  GetDescription() {
+    return '';
+  },
+  GetKeyBinding() {
+    return '';
+  },
+  GetActions() {
+    return [[ACTIVATE, '', '']];
+  },
+  DoAction(index) {
+    if (index !== 0) return false;
+    return this.b.activate(this.n);
+  },
+};
+
+const ValueImpl = {
+  get MinimumValue() {
+    return a11yValue(this.n)?.min ?? 0;
+  },
+  get MaximumValue() {
+    return a11yValue(this.n)?.max ?? 0;
+  },
+  get MinimumIncrement() {
+    return 0;
+  },
+  get CurrentValue() {
+    return a11yValue(this.n)?.now ?? 0;
+  },
+  /** An AT writing the value — Orca adjusting a slider. Routed to the
+   * component through `onAccessibilityAction`, the seam a widget wires its
+   * own state setter into. */
+  set CurrentValue(next) {
+    const node = this.n;
+    const handler = node.props?.onAccessibilityAction;
+    if (typeof handler !== 'function') return;
+    callHandler(node, 'onAccessibilityAction', handler, {
+      action: 'setValue',
+      value: Number(next),
+    });
+  },
+  get Text() {
+    return a11yValue(this.n)?.text ?? '';
+  },
+};
+
+const TextImpl = {
+  get CharacterCount() {
+    return textStateOf(this.n).chars.length;
+  },
+  get CaretOffset() {
+    return textStateOf(this.n).caret;
+  },
+  GetText(start, end) {
+    const { chars } = textStateOf(this.n);
+    const s = clampOffset(start, chars.length);
+    const e = end < 0 ? chars.length : clampOffset(end, chars.length);
+    return chars.slice(s, e).join('');
+  },
+  GetStringAtOffset(offset, granularity) {
+    const { chars } = textStateOf(this.n);
+    const [s, e] = granularRange(chars, offset, granularity);
+    return [chars.slice(s, e).join(''), s, e];
+  },
+  GetTextAtOffset(offset, type) {
+    return TextImpl.GetStringAtOffset.call(
+      this,
+      offset,
+      boundaryToGranularity(type),
+    );
+  },
+  GetTextBeforeOffset(offset, type) {
+    const { chars } = textStateOf(this.n);
+    const granularity = boundaryToGranularity(type);
+    const [s] = granularRange(chars, offset, granularity);
+    if (s <= 0) return ['', 0, 0];
+    const [ps, pe] = granularRange(chars, s - 1, granularity);
+    return [chars.slice(ps, pe).join(''), ps, pe];
+  },
+  GetTextAfterOffset(offset, type) {
+    const { chars } = textStateOf(this.n);
+    const granularity = boundaryToGranularity(type);
+    const [, e] = granularRange(chars, offset, granularity);
+    if (e >= chars.length) return ['', chars.length, chars.length];
+    const [ns, ne] = granularRange(chars, e, granularity);
+    return [chars.slice(ns, ne).join(''), ns, ne];
+  },
+  GetCharacterAtOffset(offset) {
+    const { chars } = textStateOf(this.n);
+    if (offset < 0 || offset >= chars.length) return 0;
+    return chars[offset].codePointAt(0);
+  },
+  SetCaretOffset(offset) {
+    const node = this.n;
+    if (typeof node._moveCaret !== 'function') return false;
+    const { chars } = textStateOf(node);
+    node._moveCaret(clampOffset(offset, chars.length), false);
+    return true;
+  },
+  GetAttributes() {
+    const { chars } = textStateOf(this.n);
+    return [[], 0, chars.length];
+  },
+  GetDefaultAttributes() {
+    return [];
+  },
+  GetAttributeValue() {
+    return '';
+  },
+  GetCharacterExtents(offset, coordType) {
+    return this.b.characterExtents(this.n, offset, coordType);
+  },
+  GetRangeExtents(start, end, coordType) {
+    const a = this.b.characterExtents(this.n, start, coordType);
+    const z = this.b.characterExtents(
+      this.n,
+      Math.max(start, end - 1),
+      coordType,
+    );
+    const x = Math.min(a[0], z[0]);
+    const y = Math.min(a[1], z[1]);
+    return [
+      x,
+      y,
+      Math.max(a[0] + a[2], z[0] + z[2]) - x,
+      Math.max(a[1] + a[3], z[1] + z[3]) - y,
+    ];
+  },
+  GetOffsetAtPoint(x, y, coordType) {
+    return this.b.offsetAtPoint(this.n, x, y, coordType);
+  },
+  GetNSelections() {
+    const [s, e] = textStateOf(this.n).selection;
+    return s !== e ? 1 : 0;
+  },
+  GetSelection(index) {
+    if (index !== 0) return [0, 0];
+    return textStateOf(this.n).selection;
+  },
+  AddSelection(start, end) {
+    return this.b.setTextSelection(this.n, start, end);
+  },
+  SetSelection(index, start, end) {
+    if (index !== 0) return false;
+    return this.b.setTextSelection(this.n, start, end);
+  },
+  RemoveSelection(index) {
+    if (index !== 0) return false;
+    const node = this.n;
+    if (typeof node._moveCaret !== 'function') return false;
+    node._moveCaret(node._caret ?? 0, false);
+    return true;
+  },
+};
+
+const EditableTextImpl = {
+  SetTextContents(newContents) {
+    return this.b.editText(this.n, () => {
+      const chars = Array.from(String(newContents));
+      this.n._commit(chars, chars.length);
+    });
+  },
+  InsertText(position, text, length) {
+    return this.b.editText(this.n, () => {
+      const node = this.n;
+      const chars = node._chars();
+      const insert = Array.from(String(text)).slice(
+        0,
+        length < 0 ? undefined : length,
+      );
+      const at = clampOffset(position, chars.length);
+      chars.splice(at, 0, ...insert);
+      node._commit(chars, at + insert.length);
+    });
+  },
+  DeleteText(start, end) {
+    return this.b.editText(this.n, () => {
+      const node = this.n;
+      const chars = node._chars();
+      const s = clampOffset(Math.min(start, end), chars.length);
+      const e = clampOffset(Math.max(start, end), chars.length);
+      chars.splice(s, e - s);
+      node._commit(chars, s);
+    });
+  },
+  CopyText(start, end) {
+    this.b.copyTextRange(this.n, start, end);
+    return null;
+  },
+  CutText(start, end) {
+    this.b.copyTextRange(this.n, start, end);
+    return EditableTextImpl.DeleteText.call(this, start, end);
+  },
+  PasteText(position) {
+    const node = this.n;
+    if (!this.b.editable(node)) return false;
+    if (typeof node._pasteFrom !== 'function') return false;
+    const { chars } = textStateOf(node);
+    node._moveCaret?.(clampOffset(position, chars.length), false);
+    node._pasteFrom('CLIPBOARD');
+    return true;
+  },
+};
+
+// --------------------------------------------------------------------------
+// The bridge
+// --------------------------------------------------------------------------
+
+class AtspiBridge {
+  constructor(bus, toolkitVersion) {
+    this.bus = bus;
+    this.toolkitVersion = toolkitVersion;
+    this.dead = false;
+    /** @type {Map<object, {id: number, ifaces: string[], snapshot: object}>} */
+    this.exported = new Map();
+    this.nextId = 1;
+    /** Toplevel `<window>` nodes across every root, in mount order — the
+     * application's accessible children. */
+    this.toplevels = [];
+    this.desktop = [REGISTRY_NAME, ROOT_PATH];
+    this.appId = -1;
+    this._unsubscribes = [];
+    // batched renderer notifications, flushed per commit / microtask
+    this._pending = {
+      attach: new Set(),
+      remove: [],
+      props: new Set(),
+      text: new Set(),
+      focus: [],
+      window: [],
+    };
+    this._flushScheduled = false;
+  }
+
+  // ---- refs and export -------------------------------------------------
+
+  nullRef() {
+    return [this.bus.name, NULL_PATH];
+  }
+
+  rootRef() {
+    return [this.bus.name, ROOT_PATH];
+  }
+
+  pathOf(node) {
+    const entry = this.exported.get(node);
+    return entry ? NODE_PATH + entry.id : NULL_PATH;
+  }
+
+  /** The ref for a node, exporting it on the way if the bus has never seen
+   * it. Everything that hands a node to the bus goes through here, so an AT
+   * can call back on any ref it was ever given. */
+  refFor(node) {
+    this.ensureExported(node);
+    return [this.bus.name, this.pathOf(node)];
+  }
+
+  parentRef(node) {
+    const parent = a11yParent(node);
+    return parent ? this.refFor(parent) : this.rootRef();
+  }
+
+  interfacesOf(node) {
+    return this.exported.get(node)?.ifaces ?? this._ifaceSetFor(node);
+  }
+
+  _ifaceSetFor(node) {
+    const ifaces = [IFACE.ACCESSIBLE, IFACE.COMPONENT];
+    if (a11yActivatable(node)) ifaces.push(IFACE.ACTION);
+    if (a11yValue(node) !== null) ifaces.push(IFACE.VALUE);
+    if (hasTextInterface(node)) ifaces.push(IFACE.TEXT);
+    if (isTextControl(node)) ifaces.push(IFACE.EDITABLE_TEXT);
+    return ifaces;
+  }
+
+  _implFor(proto, node) {
+    return { __proto__: proto, b: this, n: node };
+  }
+
+  _descriptorFor(name) {
+    switch (name) {
+      case IFACE.ACCESSIBLE:
+        return [ACCESSIBLE_DESC, AccessibleImpl];
+      case IFACE.COMPONENT:
+        return [COMPONENT_DESC, ComponentImpl];
+      case IFACE.ACTION:
+        return [ACTION_DESC, ActionImpl];
+      case IFACE.VALUE:
+        return [VALUE_DESC, ValueImpl];
+      case IFACE.TEXT:
+        return [TEXT_DESC, TextImpl];
+      case IFACE.EDITABLE_TEXT:
+        return [EDITABLE_TEXT_DESC, EditableTextImpl];
+      default:
+        return null;
+    }
+  }
+
+  ensureExported(node) {
+    if (this.dead || this.exported.has(node)) return;
+    const id = this.nextId++;
+    const ifaces = this._ifaceSetFor(node);
+    const path = NODE_PATH + id;
+    const entry = { id, ifaces, snapshot: null };
+    // registered before the interfaces export, so a getter that recurses
+    // through refFor (Parent, GetChildren) sees the entry and terminates
+    this.exported.set(node, entry);
+    for (const name of ifaces) {
+      const [desc, proto] = this._descriptorFor(name);
+      this.bus.exportInterface(this._implFor(proto, node), path, desc);
+    }
+    entry.snapshot = this._snapshot(node);
+  }
+
+  _unexport(node) {
+    const entry = this.exported.get(node);
+    if (!entry) return;
+    this.exported.delete(node);
+    const path = NODE_PATH + entry.id;
+    this.emitCacheRemove([this.bus.name, path]);
+    this.bus.unexportInterface(path);
+  }
+
+  _snapshot(node) {
+    const snapshot = {
+      name: a11yName(node),
+      description: a11yDescription(node),
+      states: a11yStates(node),
+      value: a11yValue(node)?.now ?? null,
+      ifaces: this.exported.get(node)?.ifaces ?? [],
+      text: null,
+    };
+    if (hasTextInterface(node)) {
+      const { chars, caret, selection } = textStateOf(node);
+      snapshot.text = { chars, caret, selection };
+    }
+    return snapshot;
+  }
+
+  // ---- geometry --------------------------------------------------------
+
+  screenOriginOf(win) {
+    const wnd = win?.window;
+    if (!wnd) return { x: 0, y: 0 };
+    return wnd._screenOrigin ?? { x: wnd.x ?? 0, y: wnd.y ?? 0 };
+  }
+
+  /** [x, y, width, height] in the asked-for coordinate system. A window is
+   * its whole surface; a drawn node is its layout rect. */
+  extentsOf(node, coordType) {
+    let rect;
+    const win = node.isWindow ? node : node.root;
+    if (node.isWindow) {
+      const wnd = node.window;
+      rect = { x: 0, y: 0, width: wnd?.width ?? 0, height: wnd?.height ?? 0 };
+    } else {
+      rect = node.abs ?? { x: 0, y: 0, width: 0, height: 0 };
+    }
+    let { x, y } = rect;
+    if (coordType === COORD_SCREEN) {
+      const origin = this.screenOriginOf(win);
+      x += origin.x;
+      y += origin.y;
+    } else if (coordType === COORD_PARENT && !node.isWindow) {
+      const parent = a11yParent(node);
+      if (parent && !parent.isWindow && parent.abs) {
+        x -= parent.abs.x;
+        y -= parent.abs.y;
+      }
+    }
+    return [x, y, rect.width, rect.height];
+  }
+
+  /** Where the text control paints its characters: the content box, minus
+   * the horizontal scroll a long value has been dragged by. */
+  _textOrigin(node) {
+    const content = node.contentBox?.() ?? node.abs;
+    return {
+      x: content.x - (node._scrollX ?? 0),
+      y: content.y - (node._scrollY ?? 0),
+    };
+  }
+
+  characterExtents(node, offset, coordType) {
+    const layout = node._valueLayout?.();
+    if (!layout || typeof layout.caretPosition !== 'function') {
+      return this.extentsOf(node, coordType);
+    }
+    const { chars } = textStateOf(node);
+    const at = clampOffset(offset, chars.length);
+    const pos = layout.caretPosition(at);
+    const next = layout.caretPosition(Math.min(at + 1, chars.length));
+    const origin = this._textOrigin(node);
+    let x = origin.x + pos.x;
+    let y = origin.y + pos.y;
+    const width = next.line === pos.line && next.x > pos.x ? next.x - pos.x : 0;
+    if (coordType === COORD_SCREEN) {
+      const screen = this.screenOriginOf(node.isWindow ? node : node.root);
+      x += screen.x;
+      y += screen.y;
+    }
+    return [
+      Math.round(x),
+      Math.round(y),
+      Math.round(width),
+      Math.round(pos.height),
+    ];
+  }
+
+  offsetAtPoint(node, x, y, coordType) {
+    const layout = node._valueLayout?.();
+    if (!layout || typeof layout.indexAt !== 'function') return -1;
+    let wx = x;
+    let wy = y;
+    if (coordType === COORD_SCREEN) {
+      const screen = this.screenOriginOf(node.isWindow ? node : node.root);
+      wx -= screen.x;
+      wy -= screen.y;
+    }
+    const origin = this._textOrigin(node);
+    return layout.indexAt(wx - origin.x, wy - origin.y);
+  }
+
+  // ---- AT-initiated behaviour -----------------------------------------
+
+  /** DoAction("activate"): a synthetic click through the same dispatch a
+   * real press uses — capture, bubble, default actions, discrete-priority
+   * commit and paint — so an AT's activation is indistinguishable from the
+   * user's. */
+  activate(node) {
+    const manager = node.root?.events;
+    if (!manager || node.destroyed) return false;
+    const abs = node.abs ?? { x: 0, y: 0, width: 0, height: 0 };
+    const native = {
+      x: Math.round(abs.x + abs.width / 2),
+      y: Math.round(abs.y + abs.height / 2),
+      buttons: 0,
+      keycode: 1,
+    };
+    // The whole press gesture, not just the click: several controls act on
+    // the *press* — `Select` and `MenuBar` drop their menus on mousedown,
+    // the way real menus do — and an AT activation has to reach those too.
+    // Handlers only; the coordinate-driven defaults (caret placement, drag
+    // arming) stay out, because a synthesized centre point is not a place
+    // the user chose.
+    discrete(() => {
+      manager.dispatch('MouseDown', node, native, { button: 1, detail: 1 });
+      if (!node.destroyed) {
+        manager.dispatch('MouseUp', node, native, { button: 1 });
+      }
+      if (!node.destroyed) {
+        manager.dispatch('Click', node, native, { button: 1, detail: 1 });
+      }
+    })(native);
+    return true;
+  }
+
+  editable(node) {
+    if (!isTextControl(node) || node.destroyed) return false;
+    if (node.props?.disabled || node.props?.['aria-readonly'] === true) {
+      return false;
+    }
+    return true;
+  }
+
+  editText(node, edit) {
+    if (!this.editable(node)) return false;
+    if (typeof node._commit !== 'function') return false;
+    edit();
+    return true;
+  }
+
+  setTextSelection(node, start, end) {
+    if (!isTextControl(node) || node.destroyed) return false;
+    const { chars } = textStateOf(node);
+    node._anchor = clampOffset(start, chars.length);
+    node._caret = clampOffset(end, chars.length);
+    node._repaint?.();
+    return true;
+  }
+
+  copyTextRange(node, start, end) {
+    if (!isTextControl(node) || node.destroyed) return;
+    if (typeof node._copySelection !== 'function') return;
+    const caret = node._caret;
+    const anchor = node._anchor;
+    const { chars } = textStateOf(node);
+    node._anchor = clampOffset(Math.min(start, end), chars.length);
+    node._caret = clampOffset(Math.max(start, end), chars.length);
+    try {
+      node._copySelection('CLIPBOARD');
+    } finally {
+      node._caret = caret;
+      node._anchor = anchor;
+    }
+  }
+
+  // ---- signals ---------------------------------------------------------
+
+  _signal(path, iface, member, detail, detail1, detail2, anyData) {
+    if (this.dead) return;
+    try {
+      this.bus.sendSignal(path, iface, member, EVENT_SIGNATURE, [
+        detail,
+        detail1 | 0,
+        detail2 | 0,
+        anyData ?? ['i', 0],
+        [],
+      ]);
+    } catch {
+      // a marshalling failure on one event must not take down dispatch;
+      // the tree itself stays queryable
+    }
+  }
+
+  emitObject(node, member, detail = '', d1 = 0, d2 = 0, anyData = null) {
+    this._signal(
+      this.pathOf(node),
+      IFACE.EVENT_OBJECT,
+      member,
+      detail,
+      d1,
+      d2,
+      anyData,
+    );
+  }
+
+  emitWindow(node, member) {
+    this._signal(this.pathOf(node), IFACE.EVENT_WINDOW, member, '', 0, 0, [
+      's',
+      a11yName(node),
+    ]);
+  }
+
+  emitStateChanged(node, stateBit, on) {
+    const nick = ATSPI_STATE_NICK[stateBit];
+    if (!nick) return;
+    this.emitObject(node, 'StateChanged', nick, on ? 1 : 0, 0, ['i', 0]);
+  }
+
+  _cacheItemFor(node) {
+    return [
+      this.refFor(node),
+      this.rootRef(),
+      this.parentRef(node),
+      AccessibleImpl.GetIndexInParent.call({ b: this, n: node }),
+      a11yChildren(node).length,
+      this.interfacesOf(node),
+      a11yName(node),
+      a11yRole(node),
+      a11yDescription(node),
+      a11yStates(node),
+    ];
+  }
+
+  emitCacheAdd(node) {
+    if (this.dead) return;
+    try {
+      this.bus.sendSignal(
+        CACHE_PATH,
+        IFACE.CACHE,
+        'AddAccessible',
+        CACHE_ITEM_SIGNATURE,
+        [this._cacheItemFor(node)],
+      );
+    } catch {
+      // as _signal
+    }
+  }
+
+  emitCacheRemove(ref) {
+    if (this.dead) return;
+    try {
+      this.bus.sendSignal(CACHE_PATH, IFACE.CACHE, 'RemoveAccessible', '(so)', [
+        ref,
+      ]);
+    } catch {
+      // as _signal
+    }
+  }
+
+  // ---- the queue -------------------------------------------------------
+
+  _schedule() {
+    if (this._flushScheduled || this.dead) return;
+    this._flushScheduled = true;
+    queueMicrotask(() => this.flush());
+  }
+
+  /** Is this node under a toplevel the bridge is presenting? Detached
+   * subtrees under construction are not, which is what keeps the initial
+   * bottom-up build of a tree from queueing one event per node. */
+  _live(node) {
+    let n = node;
+    while (n) {
+      if (!n.parent) return this.toplevels.includes(n);
+      n = n.parent;
+    }
+    return false;
+  }
+
+  queueAttach(node) {
+    this._pending.attach.add(node);
+    this._schedule();
+  }
+
+  queueRemove(parent, child, index) {
+    this._pending.remove.push({ parent, child, index });
+    this._schedule();
+  }
+
+  queueProps(node) {
+    this._pending.props.add(node);
+    this._schedule();
+  }
+
+  queueText(node) {
+    this._pending.text.add(node);
+    this._schedule();
+  }
+
+  queueFocus(previous, next) {
+    this._pending.focus.push({ previous, next });
+    this._schedule();
+  }
+
+  queueWindowFocus(win, focused) {
+    this._pending.window.push({ win, focused });
+    this._schedule();
+  }
+
+  flush() {
+    if (this.dead) return;
+    this._flushScheduled = false;
+    const p = this._pending;
+    if (
+      p.attach.size === 0 &&
+      p.remove.length === 0 &&
+      p.props.size === 0 &&
+      p.text.size === 0 &&
+      p.focus.length === 0 &&
+      p.window.length === 0
+    ) {
+      return;
+    }
+    this._pending = {
+      attach: new Set(),
+      remove: [],
+      props: new Set(),
+      text: new Set(),
+      focus: [],
+      window: [],
+    };
+
+    // Removals first: a node that left and came back in one batch reads as
+    // its add, never as a stale remove.
+    for (const { parent, child, index } of p.remove) {
+      const stillIn =
+        parent === null
+          ? this.toplevels.includes(child)
+          : child.parent === parent;
+      if (stillIn) continue;
+      const wasExported = this.exported.has(child);
+      const childPath = this.pathOf(child);
+      const childRef = [this.bus.name, childPath];
+      // unexport the whole subtree the AT may hold refs into; each exported
+      // node also tells the client caches it is gone
+      const walk = (n) => {
+        for (const c of n.children ?? []) walk(c);
+        this._unexport(n);
+      };
+      walk(child);
+      // Whatever the AT never saw, it does not need to hear about.
+      if (!wasExported) continue;
+      if (child.isWindow && !child.parent) {
+        this._signal(childPath, IFACE.EVENT_WINDOW, 'Destroy', '', 0, 0, [
+          's',
+          '',
+        ]);
+      }
+      if (parent === null || this.exported.has(parent)) {
+        this._signal(
+          parent === null ? ROOT_PATH : this.pathOf(parent),
+          IFACE.EVENT_OBJECT,
+          'ChildrenChanged',
+          'remove',
+          index,
+          0,
+          ['(so)', childRef],
+        );
+      }
+    }
+
+    // Attaches, collapsed to the topmost node per subtree: the AT descends
+    // from there on its own.
+    for (const node of p.attach) {
+      if (node.destroyed || !this._live(node)) continue;
+      let covered = false;
+      for (let a = node.parent; a; a = a.parent) {
+        if (p.attach.has(a)) {
+          covered = true;
+          break;
+        }
+      }
+      if (covered) continue;
+      const wasExported = this.exported.has(node);
+      const parent = a11yParent(node);
+      const index = parent
+        ? a11yIndexIn(parent, node)
+        : this.toplevels.indexOf(node);
+      if (!wasExported) this.emitCacheAdd(node);
+      this._signal(
+        parent ? this.pathOf(parent) : ROOT_PATH,
+        IFACE.EVENT_OBJECT,
+        'ChildrenChanged',
+        'add',
+        index,
+        0,
+        ['(so)', this.refFor(node)],
+      );
+      if (node.isWindow && !node.parent) this.emitWindow(node, 'Create');
+    }
+
+    for (const node of p.props) this.syncNode(node);
+    for (const node of p.text) this.syncText(node);
+
+    for (const { previous, next } of p.focus) {
+      if (previous && this.exported.has(previous) && !previous.destroyed) {
+        this.emitStateChanged(previous, ATSPI_STATE.FOCUSED, false);
+        this._refreshSnapshotStates(previous);
+      }
+      if (next && !next.destroyed && this._live(next)) {
+        this.ensureExported(next);
+        this.emitStateChanged(next, ATSPI_STATE.FOCUSED, true);
+        this._signal(this.pathOf(next), IFACE.EVENT_FOCUS, 'Focus', '', 0, 0, [
+          'i',
+          0,
+        ]);
+        this._refreshSnapshotStates(next);
+      }
+    }
+
+    const lastWindow = new Map();
+    for (const { win, focused } of p.window) lastWindow.set(win, focused);
+    for (const [win, focused] of lastWindow) {
+      if (win.destroyed || !this.exported.has(win)) continue;
+      this.emitWindow(win, focused ? 'Activate' : 'Deactivate');
+      this.emitStateChanged(win, ATSPI_STATE.ACTIVE, focused);
+      this._refreshSnapshotStates(win);
+    }
+  }
+
+  _refreshSnapshotStates(node) {
+    const entry = this.exported.get(node);
+    if (entry?.snapshot) entry.snapshot.states = a11yStates(node);
+  }
+
+  /** Recompute what the bus was last told about a node and emit the exact
+   * difference. Every "some prop changed" notification lands here, which is
+   * what makes the wiring correct without per-prop plumbing. */
+  syncNode(node) {
+    const entry = this.exported.get(node);
+    if (!entry || node.destroyed) return;
+    const before = entry.snapshot;
+    // interface set can change (a value appearing, a handler added)
+    const wanted = this._ifaceSetFor(node);
+    if (wanted.join() !== entry.ifaces.join()) {
+      const path = NODE_PATH + entry.id;
+      for (const name of entry.ifaces) {
+        if (!wanted.includes(name)) this.bus.unexportInterface(path, name);
+      }
+      for (const name of wanted) {
+        if (!entry.ifaces.includes(name)) {
+          const [desc, proto] = this._descriptorFor(name);
+          this.bus.exportInterface(this._implFor(proto, node), path, desc);
+        }
+      }
+      entry.ifaces = wanted;
+    }
+    const now = this._snapshot(node);
+    now.ifaces = entry.ifaces;
+    entry.snapshot = now;
+    if (now.name !== before.name) {
+      this.emitObject(node, 'PropertyChange', 'accessible-name', 0, 0, [
+        's',
+        now.name,
+      ]);
+    }
+    if (now.description !== before.description) {
+      this.emitObject(node, 'PropertyChange', 'accessible-description', 0, 0, [
+        's',
+        now.description,
+      ]);
+    }
+    if (now.value !== before.value && now.value !== null) {
+      this.emitObject(node, 'PropertyChange', 'accessible-value', 0, 0, [
+        'd',
+        now.value,
+      ]);
+    }
+    for (const half of [0, 1]) {
+      let changed = (before.states[half] ^ now.states[half]) >>> 0;
+      while (changed !== 0) {
+        const low = changed & -changed;
+        const stateBit = 31 - Math.clz32(low) + half * 32;
+        this.emitStateChanged(node, stateBit, Boolean(now.states[half] & low));
+        changed = (changed ^ low) >>> 0;
+      }
+    }
+    if (before.text && now.text) this._diffText(node, before.text, now.text);
+  }
+
+  syncText(node) {
+    const entry = this.exported.get(node);
+    if (!entry || node.destroyed || !entry.snapshot?.text) return;
+    const before = entry.snapshot.text;
+    const now = textStateOf(node);
+    entry.snapshot.text = now;
+    this._diffText(node, before, now);
+  }
+
+  _diffText(node, before, now) {
+    const diff = diffChars(before.chars, now.chars);
+    if (diff) {
+      if (diff.removed.length > 0) {
+        this.emitObject(
+          node,
+          'TextChanged',
+          'delete',
+          diff.offset,
+          diff.removed.length,
+          ['s', diff.removed.join('')],
+        );
+      }
+      if (diff.inserted.length > 0) {
+        this.emitObject(
+          node,
+          'TextChanged',
+          'insert',
+          diff.offset,
+          diff.inserted.length,
+          ['s', diff.inserted.join('')],
+        );
+      }
+    }
+    if (now.caret !== before.caret) {
+      this.emitObject(node, 'TextCaretMoved', '', now.caret, 0, ['i', 0]);
+    }
+    const selectionChanged =
+      now.selection[0] !== before.selection[0] ||
+      now.selection[1] !== before.selection[1];
+    if (selectionChanged) {
+      this.emitObject(node, 'TextSelectionChanged', '', 0, 0, ['i', 0]);
+    }
+  }
+
+  // ---- the application root -------------------------------------------
+
+  exportRoot() {
+    const bridge = this;
+    const rootAccessible = {
+      get Name() {
+        return programName();
+      },
+      get Description() {
+        return '';
+      },
+      get Parent() {
+        return bridge.desktop;
+      },
+      get ChildCount() {
+        return bridge.toplevels.length;
+      },
+      get Locale() {
+        return localeString();
+      },
+      get AccessibleId() {
+        return '';
+      },
+      GetChildAtIndex(index) {
+        const win = bridge.toplevels[index];
+        return win ? bridge.refFor(win) : bridge.nullRef();
+      },
+      GetChildren() {
+        return bridge.toplevels.map((win) => bridge.refFor(win));
+      },
+      GetIndexInParent() {
+        return -1;
+      },
+      GetRelationSet() {
+        return [];
+      },
+      GetRole() {
+        return ATSPI_ROLE.APPLICATION;
+      },
+      GetRoleName() {
+        return 'application';
+      },
+      GetLocalizedRoleName() {
+        return 'application';
+      },
+      GetState() {
+        return [0, 0];
+      },
+      GetAttributes() {
+        return [['toolkit', 'react-x11']];
+      },
+      GetApplication() {
+        return bridge.rootRef();
+      },
+      GetInterfaces() {
+        return [IFACE.ACCESSIBLE, IFACE.APPLICATION, IFACE.SOCKET];
+      },
+    };
+    const application = {
+      ToolkitName: 'react-x11',
+      get Version() {
+        return bridge.toolkitVersion;
+      },
+      AtspiVersion: ATSPI_VERSION,
+      get Id() {
+        return bridge.appId;
+      },
+      set Id(value) {
+        bridge.appId = value | 0;
+      },
+      GetLocale() {
+        return localeString();
+      },
+      GetApplicationBusAddress() {
+        return '';
+      },
+    };
+    const socket = {
+      Embedded() {
+        return null;
+      },
+      Unembed() {
+        return null;
+      },
+    };
+    const cache = {
+      GetItems() {
+        const items = [bridge._rootCacheItem(rootAccessible)];
+        const walk = (node) => {
+          items.push(bridge._cacheItemFor(node));
+          for (const child of a11yChildren(node)) walk(child);
+        };
+        for (const win of bridge.toplevels) walk(win);
+        return items;
+      },
+    };
+    this.bus.exportInterface(rootAccessible, ROOT_PATH, ACCESSIBLE_DESC);
+    this.bus.exportInterface(application, ROOT_PATH, APPLICATION_DESC);
+    this.bus.exportInterface(socket, ROOT_PATH, SOCKET_DESC);
+    this.bus.exportInterface(cache, CACHE_PATH, CACHE_DESC);
+  }
+
+  /** The cache item for the application root itself, which is not a node. */
+  _rootCacheItem(rootAccessible) {
+    return [
+      this.rootRef(),
+      this.rootRef(),
+      this.desktop,
+      -1,
+      this.toplevels.length,
+      rootAccessible.GetInterfaces(),
+      rootAccessible.Name,
+      ATSPI_ROLE.APPLICATION,
+      '',
+      [0, 0],
+    ];
+  }
+
+  // ---- registration ----------------------------------------------------
+
+  async embed() {
+    const reply = await this.bus.invoke({
+      destination: REGISTRY_NAME,
+      path: ROOT_PATH,
+      interface: IFACE.SOCKET,
+      member: 'Embed',
+      signature: '(so)',
+      body: [[this.bus.name, ROOT_PATH]],
+    });
+    if (Array.isArray(reply) && reply.length === 2) this.desktop = reply;
+  }
+
+  /** The registry restarting is survivable: watch its name and re-embed
+   * under the new owner, exactly as the GTK bridge does. */
+  async watchRegistry() {
+    const rule =
+      "type='signal',sender='org.freedesktop.DBus'," +
+      "interface='org.freedesktop.DBus',member='NameOwnerChanged'," +
+      `arg0='${REGISTRY_NAME}'`;
+    await this.bus.addMatch(rule);
+    const key = this.bus.mangle(
+      '/org/freedesktop/DBus',
+      'org.freedesktop.DBus',
+      'NameOwnerChanged',
+    );
+    this.bus.signals.on(key, (body) => {
+      const newOwner = body?.[2];
+      if (newOwner) this.embed().catch(() => {});
+    });
+  }
+
+  // ---- wiring into the renderer ---------------------------------------
+
+  install() {
+    hooks.rootMounted = (win) => {
+      if (this.toplevels.includes(win)) return;
+      this.toplevels.push(win);
+      this.queueAttach(win);
+    };
+    hooks.rootUnmounted = (win) => {
+      const index = this.toplevels.indexOf(win);
+      if (index === -1) return;
+      this.toplevels.splice(index, 1);
+      this.queueRemove(null, win, index);
+    };
+    hooks.attached = (parent, child) => {
+      if (!this._live(parent)) return;
+      this.queueAttach(child);
+    };
+    hooks.detach = (parent, child) => {
+      if (!this.exported.has(child) && !this._live(parent)) return;
+      this.queueRemove(parent, child, a11yIndexIn(parent, child));
+    };
+    hooks.propsChanged = (node) => {
+      if (this.exported.has(node)) this.queueProps(node);
+    };
+    hooks.textContent = (chunk) => {
+      let text = chunk.parent;
+      while (text && text.kind === 'text' && text.isSpan) text = text.parent;
+      if (!text) return;
+      if (this.exported.has(text)) this.queueText(text);
+      // labels feed names-from-contents anywhere above them
+      for (let a = text; a; a = a11yParent(a)) {
+        if (this.exported.has(a)) this.queueProps(a);
+        if (a.isWindow) break;
+      }
+    };
+    hooks.textState = (node) => {
+      if (this.exported.has(node)) this.queueText(node);
+    };
+    hooks.focus = (previous, next) => {
+      this.queueFocus(previous, next);
+    };
+    hooks.windowFocus = (win, focused) => {
+      this.queueWindowFocus(win, focused);
+    };
+    hooks.commit = () => this.flush();
+    hooks.announce = (text, opts) => {
+      // spoken from the active window, which is the context the user is in
+      const target =
+        this.toplevels.find((win) => win.events?.windowFocused) ??
+        this.toplevels[0] ??
+        null;
+      if (target) this.ensureExported(target);
+      this._signal(
+        target ? this.pathOf(target) : ROOT_PATH,
+        IFACE.EVENT_OBJECT,
+        'Announcement',
+        '',
+        opts?.assertive ? 2 : 1, // AtspiLive: 1 polite, 2 assertive
+        0,
+        ['s', String(text)],
+      );
+      return true;
+    };
+
+    // toplevels that mounted before the bridge finished connecting
+    this._unsubscribes.push(
+      onApp((app) => {
+        for (const win of app._rootChildren ?? []) {
+          hooks.rootMounted(win);
+        }
+      }),
+    );
+  }
+
+  bury() {
+    if (this.dead) return;
+    this.dead = true;
+    for (const key of Object.keys(hooks)) hooks[key] = null;
+    for (const unsubscribe of this._unsubscribes) unsubscribe();
+    this._unsubscribes = [];
+  }
+}
+
+// --------------------------------------------------------------------------
+// The ladder
+// --------------------------------------------------------------------------
+
+let bridge = null;
+
+/** Wait for a fresh dbus-native client to finish its handshake and its
+ * Hello, or throw with the reason it could not. */
+async function connected(bus) {
+  await new Promise((resolve, reject) => {
+    const conn = bus.connection;
+    const cleanup = () => {
+      conn.removeListener('connect', onConnect);
+      conn.removeListener('error', onError);
+      conn.removeListener('close', onClose);
+    };
+    const onConnect = () => {
+      cleanup();
+      resolve();
+    };
+    const onError = (err) => {
+      cleanup();
+      reject(err);
+    };
+    const onClose = () => {
+      cleanup();
+      reject(new Error('the bus closed during the handshake'));
+    };
+    conn.once('connect', onConnect);
+    conn.on('error', onError);
+    conn.once('close', onClose);
+  });
+  // one round trip so bus.name (the Hello reply) is settled
+  await bus.listNames();
+  if (bus.name == null) {
+    throw new Error('the peer answered but never assigned a unique name');
+  }
+}
+
+/**
+ * Ask the session bus where the accessibility bus is. `org.a11y.Bus` is
+ * D-Bus-activatable, so this also starts the launcher on desktops where it
+ * is not already running.
+ *
+ * Deliberately **not** the shared `sessionBus()` connection. Discovery is
+ * one call at process startup; riding the shared machinery would leave the
+ * warm shared socket open as the side effect of a probe, and would race
+ * anything that swaps `DBUS_SESSION_BUS_ADDRESS` and resets the shared
+ * state under an in-flight climb — which is exactly what a test harness
+ * (this repo's own included) does between cases. A private connection,
+ * closed before this returns, cannot interfere with anyone.
+ */
+async function accessibilityBusAddress(dbus) {
+  if (process.env.AT_SPI_BUS_ADDRESS) return process.env.AT_SPI_BUS_ADDRESS;
+  const busAddress = addressFor('session');
+  if (!busAddress && process.platform !== 'darwin') return null;
+  let sbus = null;
+  try {
+    sbus = dbus.createClient({ busAddress });
+    await connected(sbus);
+    const address = await sbus.invoke({
+      destination: 'org.a11y.Bus',
+      path: '/org/a11y/bus',
+      interface: 'org.a11y.Bus',
+      member: 'GetAddress',
+    });
+    return typeof address === 'string' && address !== '' ? address : null;
+  } catch {
+    return null;
+  } finally {
+    if (sbus) {
+      silenceAndEnd(sbus);
+    }
+  }
+}
+
+function silenceAndEnd(abus) {
+  try {
+    abus.connection.removeAllListeners('error');
+    abus.connection.on('error', () => {});
+    abus.connection.end?.();
+  } catch {
+    // it was never usable; nothing to say
+  }
+}
+
+/**
+ * Climb the ladder and return the live bridge, or null. Called once per
+ * process through `startA11y()`; every rung that fails reports why when
+ * REACT_X11_A11Y is set and stays silent otherwise — "no accessibility
+ * stack here" is a normal configuration, not an error.
+ */
+export async function start() {
+  if (bridge) return bridge.dead ? null : bridge;
+  const loud = Boolean(process.env.REACT_X11_A11Y);
+  const off = (why, cause) => {
+    if (loud) {
+      console.warn(
+        `react-x11: accessibility off — ${why}` +
+          (cause ? ` (${cause.message ?? cause})` : ''),
+      );
+    }
+    return null;
+  };
+
+  let dbus;
+  try {
+    dbus = await loadTransport();
+  } catch (cause) {
+    return off('dbus-native is not installed (npm i dbus-native)', cause);
+  }
+
+  const address = await accessibilityBusAddress(dbus);
+  if (!address) {
+    return off(
+      'no accessibility bus (no session bus, or no at-spi on this desktop)',
+    );
+  }
+
+  let abus;
+  try {
+    abus = dbus.createClient({ busAddress: address });
+  } catch (cause) {
+    return off(`could not parse the accessibility bus address`, cause);
+  }
+
+  try {
+    await connected(abus);
+  } catch (cause) {
+    silenceAndEnd(abus);
+    return off('could not connect to the accessibility bus', cause);
+  }
+
+  // Never hold the process open: the bridge is a passenger, not cargo. If
+  // the app has no other work, exiting is correct and the registry sees the
+  // name drop.
+  abus.connection.stream?.unref?.();
+
+  let version = '0.0.0';
+  try {
+    const { createRequire } = await import('node:module');
+    version = createRequire(import.meta.url)('../package.json').version;
+  } catch {
+    // bundled; the toolkit version is cosmetic
+  }
+
+  const b = new AtspiBridge(abus, version);
+  abus.connection.on('error', () => b.bury());
+  abus.connection.once('close', () => b.bury());
+
+  b.exportRoot();
+  try {
+    await b.embed();
+  } catch (cause) {
+    // A bus with no registry is unusual but not fatal: the watch below
+    // embeds the moment one appears.
+    if (loud) {
+      console.warn(
+        'react-x11: accessibility registry not reachable yet:',
+        cause?.message ?? cause,
+      );
+    }
+  }
+  b.watchRegistry().catch(() => {});
+  b.install();
+  bridge = b;
+  if (loud) {
+    console.warn(
+      `react-x11: accessibility bridge live on ${abus.name} (${address})`,
+    );
+  }
+  return b;
+}
+
+/** Test seam: tear the bridge down and forget it, so the next start() can
+ * climb the ladder again against a different bus. */
+export async function _stopForTests() {
+  if (!bridge) return;
+  const b = bridge;
+  bridge = null;
+  b.bury();
+  try {
+    await b.bus.close();
+  } catch {
+    // already gone
+  }
+}

--- a/src/atspi.js
+++ b/src/atspi.js
@@ -51,6 +51,10 @@ import {
   a11yValue,
   a11yAttributes,
   a11yActivatable,
+  isTextControl,
+  hasTextInterface,
+  textStateOf,
+  diffChars,
 } from './a11y.js';
 import { onApp } from './trace-registry.js';
 import { discrete } from './events.js';
@@ -239,28 +243,9 @@ const CACHE_DESC = {
 };
 
 // --------------------------------------------------------------------------
-// Helpers over the node tree
+// Helpers over the node tree. `textStateOf`/`diffChars` live in a11y.js —
+// they answer "what would an AT read here", which the test spy asks too.
 // --------------------------------------------------------------------------
-
-const isTextControl = (node) =>
-  node.kind === 'textinput' || node.kind === 'textarea';
-const hasTextInterface = (node) => isTextControl(node) || node.kind === 'text';
-
-/** The code points and caret/selection of anything with a Text interface —
- * offsets in AT-SPI are code points, which is also exactly what
- * TextInputNode's `_chars()`/`_caret` already count. */
-function textStateOf(node) {
-  if (isTextControl(node)) {
-    return {
-      chars: node._chars(),
-      caret: node._caret ?? 0,
-      selection: node._selection?.() ?? [0, 0],
-    };
-  }
-  const spans = node.collectSpans?.(node.inheritedTextStyle, []) ?? [];
-  const chars = Array.from(spans.map((s) => s.text).join(''));
-  return { chars, caret: 0, selection: [0, 0] };
-}
 
 function clampOffset(offset, length) {
   return Math.max(0, Math.min(offset | 0, length));
@@ -339,30 +324,6 @@ function boundaryToGranularity(type) {
   if (type === 0) return 0; // CHAR
   if (type === 1 || type === 2) return 1; // WORD_START / WORD_END
   return 3; // SENTENCE_* and LINE_* answer as lines
-}
-
-/** Common-prefix/suffix diff of two code-point arrays →
- * `{ offset, removed, inserted }`, the exact shape AT-SPI text-changed
- * events want. Null when equal. */
-function diffChars(before, after) {
-  const bn = before.length;
-  const an = after.length;
-  let prefix = 0;
-  const max = Math.min(bn, an);
-  while (prefix < max && before[prefix] === after[prefix]) prefix++;
-  let suffix = 0;
-  while (
-    suffix < max - prefix &&
-    before[bn - 1 - suffix] === after[an - 1 - suffix]
-  ) {
-    suffix++;
-  }
-  if (prefix === bn && prefix === an) return null;
-  return {
-    offset: prefix,
-    removed: before.slice(prefix, bn - suffix),
-    inserted: after.slice(prefix, an - suffix),
-  };
 }
 
 /** The best guess at what the desktop calls this program. */

--- a/src/bus.js
+++ b/src/bus.js
@@ -134,8 +134,12 @@ export async function loadTransport() {
  * Deliberately no `busAddress` parameter on the public API: a per-call
  * address is incoherent under sharing. Two callers, two addresses, one
  * socket — which would win? Tests use this same seam.
+ *
+ * Not public, but exported for atspi.js, whose one-shot discovery probe
+ * dials its own short-lived connection rather than the shared one — see
+ * the note in `accessibilityBusAddress`.
  */
-function addressFor(kind) {
+export function addressFor(kind) {
   if (kind === 'system') {
     return (
       process.env.DBUS_SYSTEM_BUS_ADDRESS ||

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -194,6 +194,8 @@ function NavButton({ direction, disabled, onPress, theme }) {
     'box',
     {
       role: 'button',
+      'aria-label': direction < 0 ? 'Previous month' : 'Next month',
+      disabled: disabled || undefined,
       onClick: disabled ? undefined : onPress,
       style: [
         s.nav,
@@ -222,7 +224,13 @@ function DayCell({ day, state, theme, band, onPick, onHover, dayContent }) {
 
   return h(
     'box',
-    { role: 'gridcell', style: s.cell },
+    {
+      role: 'gridcell',
+      'aria-label': day,
+      'aria-selected': selected,
+      disabled: blocked || undefined,
+      style: s.cell,
+    },
     // Behind the pill and out of flow, so an end of the range keeps its own
     // fill while the band still runs out of it towards the next day. Half a
     // cell at each end is what joins one pill to the next without drawing

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -62,6 +62,7 @@ export function Checkbox({
     {
       theme,
       role: 'checkbox',
+      'aria-checked': checked,
       ...props,
       ...boxProps,
       style: [

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -184,6 +184,9 @@ export function DatePicker({
     {
       theme,
       role: 'combobox',
+      'aria-expanded': Boolean(open),
+      'aria-haspopup': 'dialog',
+      disabled: disabled || undefined,
       ref: triggerRef,
       focusable: !disabled,
       onMouseDown: disabled ? undefined : toggle,

--- a/src/components/Dialog.js
+++ b/src/components/Dialog.js
@@ -143,6 +143,9 @@ export function Dialog({
           'box',
           {
             ref: surface,
+            role: 'dialog',
+            'aria-modal': true,
+            'aria-label': typeof title === 'string' ? title : undefined,
             tabIndex: -1,
             ...boxProps,
             style: [

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -177,6 +177,7 @@ function MenuRow({
       'box',
       {
         theme,
+        role: 'separator',
         style: { height: MENU_SEPARATOR_HEIGHT, justifyContent: 'center' },
       },
       h('box', { style: { height: 1, backgroundColor: theme.border } }),
@@ -187,6 +188,16 @@ function MenuRow({
   return h(
     'box',
     {
+      role: item.checked !== undefined ? 'menuitemcheckbox' : 'menuitem',
+      // the label alone: without it, name-from-contents would read the
+      // shortcut and the submenu arrow into the name ("New Ctrl+N")
+      'aria-label': typeof item.label === 'string' ? item.label : undefined,
+      'aria-keyshortcuts':
+        typeof item.shortcut === 'string' ? item.shortcut : undefined,
+      'aria-checked': item.checked !== undefined ? item.checked : undefined,
+      'aria-haspopup': hasSubmenu ? 'menu' : undefined,
+      'aria-expanded': hasSubmenu ? state === 'path' : undefined,
+      disabled: dim || undefined,
       ref: nodeRef,
       onMouseEnter: dim ? undefined : onHover,
       onMouseMove: dim ? undefined : onMove,
@@ -428,6 +439,7 @@ function MenuLevel({
       'box',
       {
         ref: listRef,
+        role: 'menu',
         style: {
           flexGrow: 1,
           flexShrink: 1,
@@ -779,6 +791,7 @@ export function MenuBar({
     'box',
     {
       theme,
+      role: 'menubar',
       ...boxProps,
       style: [
         {
@@ -799,6 +812,9 @@ export function MenuBar({
         'box',
         {
           key: menu.label,
+          role: 'menuitem',
+          'aria-haspopup': 'menu',
+          'aria-expanded': openIndex === index,
           ref: (node) => {
             refs.current[index] = node;
           },

--- a/src/components/ProgressBar.js
+++ b/src/components/ProgressBar.js
@@ -31,6 +31,9 @@ export function ProgressBar({
     {
       theme,
       role: 'progressbar',
+      'aria-valuenow': clamped,
+      'aria-valuemin': 0,
+      'aria-valuemax': 1,
       ...boxProps,
       style: [
         {

--- a/src/components/Radio.js
+++ b/src/components/Radio.js
@@ -92,6 +92,7 @@ export function Radio({ value, children, label, disabled = false }) {
     {
       theme,
       role: 'radio',
+      'aria-checked': selected,
       ...props,
       style: [
         controlStyle,

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -90,7 +90,16 @@ function menuWidth(node, options, value, scrolls) {
   return screen ? Math.min(width, screen.pixel_width) : width;
 }
 
-function Option({ option, selected, active, onPick, onHover, nodeRef }) {
+function Option({
+  option,
+  selected,
+  active,
+  onPick,
+  onHover,
+  nodeRef,
+  posinset,
+  setsize,
+}) {
   const theme = useTheme();
   // one highlight, shared by pointer and keyboard: hovering moves the
   // active index rather than tracking a second, competing state
@@ -99,6 +108,9 @@ function Option({ option, selected, active, onPick, onHover, nodeRef }) {
     {
       theme,
       role: 'option',
+      'aria-selected': selected,
+      'aria-posinset': posinset,
+      'aria-setsize': setsize,
       ref: nodeRef,
       onMouseEnter: () => onHover?.(),
       onClick: () => onPick(option),
@@ -288,6 +300,8 @@ export function Select({
     {
       theme,
       role: 'combobox',
+      'aria-expanded': open,
+      'aria-haspopup': 'listbox',
       ref: triggerRef,
       focusable: true,
       onMouseDown: toggle,
@@ -385,6 +399,7 @@ export function Select({
             'scrollview',
             {
               ref: scrollRef,
+              role: 'listbox',
               // Not a tab stop, and not a focus target for a press either.
               // A scrollview becomes focusable the moment its content
               // overflows, so a menu long enough to scroll would take focus
@@ -402,6 +417,8 @@ export function Select({
                 option,
                 selected: option.value === value,
                 active: index === activeIndex,
+                posinset: index + 1,
+                setsize: normalized.length,
                 nodeRef: index === activeIndex ? activeRef : undefined,
                 onHover: () => setActiveIndex(index),
                 onPick: pick,

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -78,9 +78,16 @@ export function Slider({
   };
 
   const controlProps = disabled
-    ? {}
+    ? { disabled: true }
     : {
         focusable: true,
+        // the AT-SPI Value interface writes land here (Orca adjusting the
+        // slider): same clamp/quantize/emit as every other input route
+        onAccessibilityAction: ({ action, value: next }) => {
+          if (action === 'setValue' && typeof next === 'number') {
+            emit(quantize(clamp(next)));
+          }
+        },
         onFocus: () => setFocused(true),
         onBlur: () => setFocused(false),
         onMouseDown: (ev) => {
@@ -126,6 +133,10 @@ export function Slider({
     {
       theme,
       role: 'slider',
+      'aria-valuenow': clamp(value),
+      'aria-valuemin': min,
+      'aria-valuemax': max,
+      'aria-orientation': 'horizontal',
       ref: trackRef,
       ...controlProps,
       ...boxProps,

--- a/src/components/SplitPane.js
+++ b/src/components/SplitPane.js
@@ -156,6 +156,12 @@ export function SplitPane({
     h(
       'box',
       {
+        // the ARIA window-splitter pattern: a separator whose value is the
+        // primary pane's size
+        role: 'separator',
+        'aria-orientation': vertical ? 'vertical' : 'horizontal',
+        'aria-valuenow': current,
+        'aria-valuemin': min,
         ...dividerProps,
         style: [
           s.divider,

--- a/src/components/Switch.js
+++ b/src/components/Switch.js
@@ -86,6 +86,7 @@ export function Switch({
     {
       theme,
       role: 'switch',
+      'aria-checked': checked,
       ...control.props,
       ...boxProps,
       style: [

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -276,6 +276,10 @@ export function Table({
     'box',
     {
       theme,
+      // The grid role, with the honest caveat that virtualization keeps
+      // only the rendered rows in the accessible tree — the same rows a
+      // sighted user can see. `aria-label` via boxProps names the table.
+      role: 'table',
       // the *table* takes focus, not the row: a virtualized row is
       // unmounted as soon as it scrolls out, and focus would go with it
       focusable: true,
@@ -296,6 +300,7 @@ export function Table({
             'box',
             {
               key: column.id,
+              role: 'columnheader',
               style: [s.header, { width: columnWidth(column) }],
               focusable: true,
               onClick: () => toggleSort(column),
@@ -356,11 +361,15 @@ export function Table({
         { style: [s.rows, { width: totalWidth }] },
         first > 0 &&
           h('box', { style: [s.spacer, { height: first * rowHeight }] }),
-        slice.map((row) =>
+        slice.map((row, sliceIndex) =>
           h(
             'box',
             {
               key: row.id,
+              role: 'row',
+              'aria-selected': row.id === current,
+              'aria-posinset': first + sliceIndex + 1,
+              'aria-setsize': sorted.length,
               style: [
                 s.row,
                 { height: rowHeight },

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -145,6 +145,8 @@ export function Tabs({
     h(
       'box',
       {
+        role: 'tablist',
+        'aria-orientation': orientation,
         style: [s.strip, { flexDirection: vertical ? 'column' : 'row' }],
         onKeyDown,
       },
@@ -153,6 +155,8 @@ export function Tabs({
           'box',
           {
             key: item.id,
+            role: 'tab',
+            'aria-selected': item.id === selected,
             ref: (node) => {
               if (node) tabRefs.current.set(item.id, node);
               else tabRefs.current.delete(item.id);
@@ -202,6 +206,6 @@ export function Tabs({
         ),
       ),
     ),
-    h('box', { style: s.panel }, content ?? null),
+    h('box', { role: 'tabpanel', style: s.panel }, content ?? null),
   );
 }

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -444,6 +444,7 @@ export function Tooltip({
       h(
         'box',
         {
+          role: 'tooltip',
           onMouseEnter: cancel,
           onMouseLeave: hide,
           style: {

--- a/src/components/Tree.js
+++ b/src/components/Tree.js
@@ -201,6 +201,7 @@ export function Tree({
     'scrollview',
     {
       theme,
+      role: 'tree',
       ref: scroller,
       ...boxProps,
       style: [s.root, style],
@@ -211,6 +212,10 @@ export function Tree({
         'box',
         {
           key: item.id,
+          role: 'treeitem',
+          'aria-level': depth + 1,
+          'aria-selected': item.id === current,
+          'aria-expanded': branch ? openSet.has(item.id) : undefined,
           ref: (node) => {
             if (node) rowRefs.current.set(item.id, node);
             else rowRefs.current.delete(item.id);

--- a/src/components/theme.js
+++ b/src/components/theme.js
@@ -187,7 +187,10 @@ export function useControl(disabled, onActivate, { styled = false } = {}) {
     },
   };
   const props = disabled
-    ? {}
+    ? // the node still has to *say* it is disabled: `:disabled` style
+      // blocks, the focus rule and the AT-SPI ENABLED state all read the
+      // prop off the node, not off the widget's closure
+      { disabled: true }
     : styled
       ? activation
       : {

--- a/src/events.js
+++ b/src/events.js
@@ -12,6 +12,7 @@ import { flushPendingFrames } from './frames.js';
 import { callHandler } from './errors.js';
 import { armDrag } from './dnd.js';
 import { noteInputTime } from './inputtime.js';
+import { hooks as a11yHooks, isFocusable } from './a11y.js';
 
 const XK_TAB = 0xff09;
 const WHEEL_BUTTONS = { 4: [0, -48], 5: [0, 48], 6: [-48, 0], 7: [48, 0] };
@@ -236,6 +237,7 @@ export class EventManager {
     // of this one having focus — a menu, a dropdown — which the focused node
     // keeping its focus would otherwise never tell (`WindowNode`, nodes.js)
     this.node._notifyWindowFocus?.(focused);
+    a11yHooks.windowFocus?.(this.node, focused);
     runWithPriority(DiscreteEventPriority, () => {
       const prop = focused ? 'onFocus' : 'onBlur';
       this.node.props[prop]?.(
@@ -497,13 +499,11 @@ export class EventManager {
 
   /** Focusable: `focusable`, an explicit `tabIndex` (including a negative
    * one, focusable but not tabbable), or a kind that is focusable by default
-   * (`<textinput>`). `focusable={false}` and `disabled` opt back out. */
+   * (`<textinput>`). `focusable={false}` and `disabled` opt back out. The
+   * rule itself lives in a11y.js, shared with the focus ring and the
+   * AT-SPI FOCUSABLE state. */
   _isFocusable(node) {
-    if (node.props.disabled) return false;
-    return (
-      node.props.focusable ??
-      (node.props.tabIndex != null ? true : (node.focusableByDefault ?? false))
-    );
+    return isFocusable(node);
   }
 
   _onMouseOut(native) {
@@ -680,6 +680,7 @@ export class EventManager {
       node.props.onFocus?.(this._makeEvent('focus', null, node));
       node.root?.invalidate(false, node, 'focus');
     }
+    a11yHooks.focus?.(old, node);
   }
 
   /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -259,6 +259,14 @@ export interface Root {
  */
 export function createRoot(options?: RootOptions): Promise<Root>;
 
+/**
+ * Say something through the screen reader without moving focus — the
+ * explicit counterpart of an ARIA live region ("saved", "3 results").
+ * Returns `true` when an AT-SPI bridge was live to carry it; `false` means
+ * nobody was listening and a visible fallback may be warranted.
+ */
+export function announce(text: string, opts?: { assertive?: boolean }): boolean;
+
 /** The react-reconciler instance. Escape hatch; not a stable API. */
 export const Renderer: any;
 

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ export { launchTimestamp, notifyStartupComplete } from './startup.js';
 export { parseUriList } from './transfer.js';
 export { useApp, useClipboard, useSupports } from './appcontext.js';
 export { BusUnavailableError, closeBus, sessionBus, systemBus } from './bus.js';
+export { announce } from './a11y.js';
 export { useSessionBus, useSystemBus } from './bushooks.js';
 export {
   NoPortalError,

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -50,6 +50,11 @@ import {
 import { availableArea } from './screens.js';
 import { baseTheme } from './palette.js';
 import { callHandler } from './errors.js';
+import {
+  hooks as a11yHooks,
+  isFocusable as a11yFocusable,
+  devCheckA11yProps,
+} from './a11y.js';
 import { windowIdOf } from './windowid.js';
 import { paintCacheFor } from './paintcache.js';
 import { hooks as traceHooks } from './trace-registry.js';
@@ -791,6 +796,7 @@ export class Node {
     if (this.yoga) {
       applyLayoutStyle(this.yoga, this.style);
     }
+    if (DEV) devCheckA11yProps(this);
   }
 
   /**
@@ -1145,6 +1151,7 @@ export class Node {
       this._spliceChild(child, beforeChild);
       child.parent = this;
       if (this.theme || child.props.theme) child._themeChanged();
+      a11yHooks.attached?.(this, child);
       return;
     }
     if (child.isWindow) {
@@ -1183,6 +1190,7 @@ export class Node {
     if (this.theme || child.props.theme) child._themeChanged();
     this._textContentChanged();
     this._childListChanged(before);
+    a11yHooks.attached?.(this, child);
   }
 
   /**
@@ -1211,6 +1219,9 @@ export class Node {
   removeChild(child) {
     const index = this.children.indexOf(child);
     if (index === -1) return;
+    // told while the child is still wired, so the bridge can compute the
+    // index the AT will see the removal at
+    a11yHooks.detach?.(this, child);
     // captured while the child is still attached, so it covers the rect the
     // child is about to stop occupying
     const before = this.paintBounds();
@@ -1287,6 +1298,8 @@ export class Node {
         'props',
       );
     }
+    if (DEV) devCheckA11yProps(this);
+    a11yHooks.propsChanged?.(this);
   }
 
   /**
@@ -1774,15 +1787,12 @@ export class Node {
     return outline ? outline.width + Math.max(0, outline.offset) : 0;
   }
 
-  /** Would a keyboard focus land here? Mirrors `EventManager._isFocusable`;
-   * kept as its own method because the ring is decided during paint, where
-   * the event manager is not in hand. */
+  /** Would a keyboard focus land here? The one rule lives in a11y.js —
+   * `EventManager._isFocusable` and the AT-SPI FOCUSABLE state read the
+   * same function, so the ring, the keyboard and the screen reader cannot
+   * disagree. */
   _focusableForRing() {
-    if (this.props.disabled) return false;
-    return Boolean(
-      this.props.focusable ??
-      (this.props.tabIndex != null ? true : (this.focusableByDefault ?? false)),
-    );
+    return Boolean(a11yFocusable(this));
   }
 
   contentBox() {
@@ -2085,6 +2095,7 @@ export class TextChunkNode extends Node {
   setText(text) {
     this.text = String(text);
     this.parent?._textContentChanged();
+    a11yHooks.textContent?.(this);
     // the chunk has no geometry of its own — the ancestor that owns a yoga
     // node is the box that rewraps, and its before/after rects are the
     // bound on what a new string can repaint
@@ -3192,6 +3203,8 @@ export class TextInputNode extends Node {
   _repaint() {
     this._caretOn = true;
     this.root?.invalidate(false, this, 'text');
+    // every edit, caret move and selection change funnels through here
+    a11yHooks.textState?.(this);
   }
 
   /**

--- a/src/testing/a11y.js
+++ b/src/testing/a11y.js
@@ -1,0 +1,445 @@
+// The assistive-technology spy: what a screen reader would be told, as an
+// in-process event log — no D-Bus, no bus, no async gap between the app
+// changing and the assertion seeing it.
+//
+// ## Why this exists next to the real bridge
+//
+// The AT-SPI bridge (src/atspi.js) consumes the renderer through a set of
+// hook slots (src/a11y.js) and a pure semantic model. Everything an AT
+// learns — focus moved, a state flipped, text changed, an announcement —
+// crosses those hooks before it ever becomes D-Bus. So a spy that fills
+// the same slots observes the same contract with none of the transport:
+// it runs on the mock backend, on Node 20 where dbus-native is not
+// installed, on macOS, and it is synchronous where the wire is not. The
+// bridge's own wire behaviour is covered separately (test/atspi.test.js,
+// against an in-process message bus); an application's tests should not
+// pay D-Bus latency to check their own labels.
+//
+// Because the slots are the seam, the spy also keeps the renderer honest:
+// a regression that stops a hook firing fails these tests exactly as it
+// would silence a real screen reader.
+//
+// ## Two layers per entry
+//
+// Every log entry is a precise fact (`{ type: 'state', state: 'checked',
+// on: true, node }`) plus a `summary` string ("state: checked"). Assert on
+// the facts when exactness matters; assert on `transcript()` when the
+// question is "what would a user have been told" — which is also the form
+// that catches the omission tree-shaped assertions structurally miss: a
+// control nobody named renders as "(no accessible name)" instead of
+// passing because no assertion mentioned its name.
+//
+// The utterances follow react-x11's **own documented model** (name, role,
+// the states worth speaking, a value as a percentage) — deliberately not
+// an imitation of Orca, whose wording is presentation policy that shifts
+// between releases and verbosity settings. See docs/accessibility.md.
+//
+// ```js
+// const { at, getByRole } = await renderX11(h(App), { a11y: true });
+// await userEvent.tab();
+// assert.equal(at.focused().utterance, 'Save, button');
+// await userEvent.key(XK_space);
+// assert.ok(at.since().some((e) => e.type === 'state' && e.state === 'checked'));
+// ```
+
+import {
+  hooks,
+  ATSPI_ROLE_NICK,
+  ATSPI_STATE,
+  ATSPI_STATE_NICK,
+  a11yRole,
+  a11yName,
+  a11yStates,
+  a11yValue,
+  a11yParent,
+  hasTextInterface,
+  textStateOf,
+  diffChars,
+} from '../a11y.js';
+
+/** The states a screen reader would speak, in speaking order, with the
+ * words this library's model uses for them. Everything else stays quiet —
+ * a reader that voiced every flag would be unusable. */
+const SPOKEN_STATES = [
+  ['checked', 'checked'],
+  ['indeterminate', 'partially checked'],
+  ['pressed', 'pressed'],
+  ['expanded', 'expanded'],
+  ['collapsed', 'collapsed'],
+  ['selected', 'selected'],
+];
+
+/**
+ * One utterance from its parts — the shared formatter behind the spy, and
+ * behind `scripts/a11y-probe.mjs`, which feeds it values read over real
+ * D-Bus so the two can never drift apart.
+ *
+ * @param {object} parts
+ * @param {string} parts.name the accessible name ('' when there is none)
+ * @param {string} [parts.role] the AT-SPI role name ("check box", "entry")
+ * @param {string[]} [parts.states] state nicks ("checked", "sensitive", …)
+ * @param {{now: number, min?: number, max?: number} | null} [parts.value]
+ * @returns {string} e.g. `"Volume, slider, 30 percent"`, or
+ *   `"(no accessible name)"` when there is nothing to say — which is the
+ *   defect this string exists to make loud.
+ */
+export function utteranceOf({ name, role, states = [], value = null }) {
+  const words = [];
+  if (name) words.push(name);
+  if (role && role !== 'filler') words.push(role);
+  // an empty states array means "not told", not "insensitive"
+  if (states.length > 0 && !states.includes('sensitive')) {
+    words.push('unavailable');
+  }
+  for (const [state, said] of SPOKEN_STATES) {
+    if (states.includes(state)) words.push(said);
+  }
+  if (value && typeof value.now === 'number') {
+    const span = (value.max ?? 0) - (value.min ?? 0);
+    words.push(
+      span > 0
+        ? `${Math.round(((value.now - (value.min ?? 0)) / span) * 100)} percent`
+        : String(value.now),
+    );
+  }
+  return words.length ? words.join(', ') : '(no accessible name)';
+}
+
+/** The set state nicks of a node, from the model's two uint32s. */
+function stateNicksOf(node) {
+  const [lo, hi] = a11yStates(node);
+  const out = [];
+  for (const bit of Object.values(ATSPI_STATE)) {
+    const on = bit < 32 ? lo & (1 << bit) : hi & (1 << (bit - 32));
+    if (on) out.push(ATSPI_STATE_NICK[bit]);
+  }
+  return out;
+}
+
+/** The utterance for a live node, through the same model the bridge
+ * serves. */
+export function nodeUtterance(node) {
+  return utteranceOf({
+    name: a11yName(node),
+    role: ATSPI_ROLE_NICK[a11yRole(node)],
+    states: stateNicksOf(node),
+    value: a11yValue(node),
+  });
+}
+
+/** Internal kinds that are content, not accessibility objects — the same
+ * exclusion the tree projection makes. */
+const CONTENT_KINDS = new Set(['textchunk', 'svgchild']);
+
+export class A11ySpy {
+  constructor() {
+    /** Every entry, oldest first. Each has `type`, `summary`, and usually
+     * `node`; see the handlers below for the shapes. */
+    this.log = [];
+    this._sinceIndex = 0;
+    this._snapshots = new WeakMap();
+    this._toplevels = [];
+    this._installed = null;
+  }
+
+  // ---- lifecycle -------------------------------------------------------
+
+  install() {
+    if (this._installed) return this;
+    const occupied = Object.entries(hooks)
+      .filter(([, slot]) => slot !== null)
+      .map(([name]) => name);
+    if (occupied.length > 0) {
+      throw new Error(
+        'react-x11/test: the a11y hook slots are already taken ' +
+          `(${occupied.join(', ')}) — the AT-SPI bridge is live in this ` +
+          'process. The spy and the bridge observe through the same seam, ' +
+          'so run spy tests without AT_SPI_BUS_ADDRESS/REACT_X11_A11Y=1 ' +
+          '(react-x11/test sets NO_AT_BRIDGE for exactly this reason).',
+      );
+    }
+    const spy = this;
+    const installed = {
+      rootMounted(win) {
+        if (!spy._toplevels.includes(win)) spy._toplevels.push(win);
+        spy._snapshotTree(win);
+      },
+      rootUnmounted(win) {
+        const at = spy._toplevels.indexOf(win);
+        if (at !== -1) spy._toplevels.splice(at, 1);
+      },
+      attached(parent, child) {
+        if (spy._live(parent)) spy._snapshotTree(child);
+      },
+      detach: null,
+      propsChanged(node) {
+        spy._diffNode(node);
+      },
+      textContent(chunk) {
+        // the chunk's string is the content of its <text>, whose name — and
+        // the name of any contents-named ancestor — may just have changed
+        let text = chunk.parent;
+        while (text && text.kind === 'text' && text.isSpan) text = text.parent;
+        if (!text) return;
+        for (let n = text; n; n = a11yParent(n)) {
+          spy._diffNode(n);
+          if (n.isWindow) break;
+        }
+      },
+      textState(node) {
+        spy._diffNode(node);
+      },
+      focus(previous, next) {
+        // re-snapshot both ends so the FOCUSED bit never double-reports
+        // through a later props diff
+        if (previous && !previous.destroyed) spy._resnapshot(previous);
+        if (next && !next.destroyed) {
+          spy._resnapshot(next);
+          const utterance = nodeUtterance(next);
+          spy._push({
+            type: 'focus',
+            node: next,
+            utterance,
+            summary: `focus: ${utterance}`,
+          });
+        } else {
+          spy._push({ type: 'blur', node: previous ?? null, summary: 'blur' });
+        }
+      },
+      windowFocus(win, focused) {
+        spy._resnapshot(win);
+        spy._push({
+          type: 'window',
+          node: win,
+          focused,
+          summary: `window: ${focused ? 'active' : 'inactive'}`,
+        });
+      },
+      commit: null,
+      announce(text, opts) {
+        spy._push({
+          type: 'announce',
+          text: String(text),
+          assertive: Boolean(opts?.assertive),
+          summary: `announce: ${text}`,
+        });
+        // an announcement the test observed *was* delivered
+        return true;
+      },
+    };
+    for (const [name, fn] of Object.entries(installed)) hooks[name] = fn;
+    this._installed = installed;
+    return this;
+  }
+
+  /** Put the slots back. Idempotent, and careful not to evict somebody
+   * else's handlers if the test already replaced them. */
+  uninstall() {
+    if (!this._installed) return;
+    for (const [name, fn] of Object.entries(this._installed)) {
+      if (hooks[name] === fn) hooks[name] = null;
+    }
+    this._installed = null;
+  }
+
+  // ---- the log ---------------------------------------------------------
+
+  /** Everything recorded so far, oldest first. */
+  events() {
+    return [...this.log];
+  }
+
+  /** The `summary` line of every entry — the "what was the user told"
+   * view, made for `assert.deepEqual`. */
+  transcript() {
+    return this.log.map((entry) => entry.summary);
+  }
+
+  /** Entries recorded since the previous `since()` (or `clear()`), so a
+   * test reads one interaction's worth at a time. */
+  since() {
+    const fresh = this.log.slice(this._sinceIndex);
+    this._sinceIndex = this.log.length;
+    return fresh;
+  }
+
+  clear() {
+    this.log.length = 0;
+    this._sinceIndex = 0;
+  }
+
+  // ---- live queries ----------------------------------------------------
+
+  /** The focused node as an AT would describe it, or null. With several
+   * roots, the window that actually holds the X focus wins. */
+  focused() {
+    const win =
+      this._toplevels.find((w) => w.events?.windowFocused) ??
+      this._toplevels[0];
+    const manager = win?.events?.focusManager ?? win?.events;
+    const node = manager?.focused ?? null;
+    if (!node || node.destroyed) return null;
+    return this._describe(node);
+  }
+
+  /**
+   * Every node the keyboard can reach, in Tab order — the same sequential
+   * order the event manager cycles, focus scopes included. The one-line
+   * audit this powers:
+   *
+   * ```js
+   * for (const stop of at.focusables()) {
+   *   assert.notEqual(stop.utterance, '(no accessible name)');
+   * }
+   * ```
+   */
+  focusables() {
+    const out = [];
+    for (const win of this._toplevels) {
+      const manager = win.events;
+      if (!manager?._tabbables) continue;
+      for (const node of manager._tabbables()) out.push(this._describe(node));
+    }
+    return out;
+  }
+
+  _describe(node) {
+    return {
+      node,
+      name: a11yName(node),
+      role: ATSPI_ROLE_NICK[a11yRole(node)],
+      states: stateNicksOf(node),
+      utterance: nodeUtterance(node),
+    };
+  }
+
+  // ---- snapshots and diffing ------------------------------------------
+
+  _push(entry) {
+    this.log.push(entry);
+  }
+
+  _live(node) {
+    let n = node;
+    while (n?.parent) n = n.parent;
+    return n ? this._toplevels.includes(n) : false;
+  }
+
+  _snap(node) {
+    return {
+      states: a11yStates(node),
+      name: a11yName(node),
+      value: a11yValue(node)?.now ?? null,
+      text: hasTextInterface(node) ? textStateOf(node) : null,
+    };
+  }
+
+  _resnapshot(node) {
+    this._snapshots.set(node, this._snap(node));
+  }
+
+  _snapshotTree(node) {
+    if (node.destroyed || CONTENT_KINDS.has(node.kind)) return;
+    if (!this._snapshots.has(node)) this._resnapshot(node);
+    for (const child of node.children ?? []) this._snapshotTree(child);
+  }
+
+  /**
+   * Recompute what an AT knows about a node and log the exact difference —
+   * the same snapshot-and-diff the bridge turns into D-Bus events, so any
+   * prop change produces the right entries with no per-prop wiring. A node
+   * seen for the first time only takes a baseline: a mount is not a
+   * change.
+   */
+  _diffNode(node) {
+    if (node.destroyed || CONTENT_KINDS.has(node.kind)) return;
+    const before = this._snapshots.get(node);
+    const now = this._snap(node);
+    this._snapshots.set(node, now);
+    if (!before) return;
+
+    if (now.name !== before.name) {
+      this._push({
+        type: 'name',
+        node,
+        name: now.name,
+        summary: `name: ${now.name}`,
+      });
+    }
+    if (now.value !== before.value && now.value !== null) {
+      this._push({
+        type: 'value',
+        node,
+        value: now.value,
+        summary: `value: ${now.value}`,
+      });
+    }
+    for (const half of [0, 1]) {
+      let changed = (before.states[half] ^ now.states[half]) >>> 0;
+      while (changed !== 0) {
+        const low = changed & -changed;
+        const bit = 31 - Math.clz32(low) + half * 32;
+        const on = Boolean(now.states[half] & low);
+        const nick = ATSPI_STATE_NICK[bit];
+        this._push({
+          type: 'state',
+          node,
+          state: nick,
+          on,
+          summary: `state: ${on ? '' : 'not '}${nick}`,
+        });
+        changed = (changed ^ low) >>> 0;
+      }
+    }
+    if (before.text && now.text) {
+      const diff = diffChars(before.text.chars, now.text.chars);
+      if (diff && diff.removed.length > 0) {
+        this._push({
+          type: 'text-delete',
+          node,
+          text: diff.removed.join(''),
+          offset: diff.offset,
+          summary: `delete: ${JSON.stringify(diff.removed.join(''))}`,
+        });
+      }
+      if (diff && diff.inserted.length > 0) {
+        this._push({
+          type: 'text-insert',
+          node,
+          text: diff.inserted.join(''),
+          offset: diff.offset,
+          summary: `insert: ${JSON.stringify(diff.inserted.join(''))}`,
+        });
+      }
+      if (!diff && now.text.caret !== before.text.caret) {
+        // a caret move without an edit — arrows, Home/End, a click
+        this._push({
+          type: 'caret',
+          node,
+          offset: now.text.caret,
+          summary: `caret: ${now.text.caret}`,
+        });
+      }
+      const [s0, e0] = before.text.selection;
+      const [s1, e1] = now.text.selection;
+      if ((s0 !== s1 || e0 !== e1) && s1 !== e1) {
+        this._push({
+          type: 'selection',
+          node,
+          start: s1,
+          end: e1,
+          summary: `selection: ${s1}..${e1}`,
+        });
+      }
+    }
+  }
+}
+
+/**
+ * Install a fresh spy on the a11y hook slots and return it. Prefer
+ * `renderX11(element, { a11y: true })`, which installs before the mount —
+ * so the initial tree is baselined — and uninstalls in `cleanup()`.
+ */
+export function installA11ySpy() {
+  return new A11ySpy().install();
+}

--- a/src/testing/harness.js
+++ b/src/testing/harness.js
@@ -140,6 +140,7 @@ export async function renderX11(element, options = {}) {
     wrap = element?.type !== 'window',
     title = 'react-x11 test',
     colorScheme = 'light',
+    a11y = false,
     ...rootOptions
   } = options;
 
@@ -170,6 +171,17 @@ export async function renderX11(element, options = {}) {
   );
 
   const root = await createRoot({ app, ...rootOptions });
+
+  // Installed **before** the mount, so the initial tree is baselined and
+  // the first render is not reported as a wall of changes — and after
+  // everything that can fail without an entry to hang the teardown on.
+  // `cleanup()` takes it down with the render it belongs to.
+  let at = null;
+  if (a11y) {
+    const { installA11ySpy } = await import('./a11y.js');
+    at = installA11ySpy();
+  }
+
   const tree = wrap
     ? React.createElement('window', { width, height, title }, element)
     : element;
@@ -181,6 +193,7 @@ export async function renderX11(element, options = {}) {
     ownsApp: !options.app,
     unmounted: false,
     windowNode: null,
+    at,
   };
   mounted.add(entry);
 
@@ -235,6 +248,9 @@ export async function renderX11(element, options = {}) {
     get ctx() {
       return windowNode?.window?.getContext?.('2d') ?? null;
     },
+    /** The assistive-technology spy, when `a11y: true` asked for one —
+     * what a screen reader would have been told (docs/accessibility.md). */
+    at,
     /** Re-render into the same root, then settle. */
     rerender: (next) =>
       act(() => {
@@ -326,6 +342,8 @@ async function unmountEntry(entry) {
   if (entry.unmounted) return;
   entry.unmounted = true;
   mounted.delete(entry);
+  // before the unmount, so the teardown's own hook traffic is not recorded
+  entry.at?.uninstall();
   try {
     entry.root.unmount?.();
   } catch {

--- a/src/testing/harness.js
+++ b/src/testing/harness.js
@@ -12,6 +12,14 @@ import { createRoot } from '../Reconciler.js';
 import { setAnimationClock } from '../nodes.js';
 import { setAppearanceForTests } from '../appearance.js';
 
+// A test process must not register with the desktop's live AT-SPI registry —
+// a suite on a developer desktop would otherwise parade hundreds of phantom
+// applications through a running screen reader. NO_AT_BRIDGE is the
+// ecosystem-wide way to say so (GTK's own test suite sets it); `??=` so an
+// explicit environment still wins, and an explicit AT_SPI_BUS_ADDRESS (the
+// hermetic bridge tests) overrides it inside startA11y anyway.
+process.env.NO_AT_BRIDGE ??= '1';
+
 // x11 and pngjs arrive through ntk rather than as direct dependencies, so
 // they are imported lazily: an app that never runs a pixel test should not
 // pay for them, and a hoisting layout that hides them should say so clearly

--- a/src/testing/index.d.ts
+++ b/src/testing/index.d.ts
@@ -59,6 +59,84 @@ export interface RenderX11Options {
   title?: string;
   /** Render into a connection you already have. */
   app?: NtkApp;
+  /**
+   * Install the assistive-technology spy before the mount and hand it back
+   * as `at`: an in-process log of everything a screen reader would have
+   * been told — focus, state changes, text edits, announcements — with no
+   * D-Bus anywhere. See docs/accessibility.md.
+   */
+  a11y?: boolean;
+}
+
+/** One recorded assistive-technology fact, plus its one-line `summary`. */
+export interface A11ySpyEvent {
+  type:
+    | 'focus'
+    | 'blur'
+    | 'state'
+    | 'name'
+    | 'value'
+    | 'text-insert'
+    | 'text-delete'
+    | 'caret'
+    | 'selection'
+    | 'announce'
+    | 'window';
+  /** The transcript line — `"focus: Save, button"`, `"state: checked"`. */
+  summary: string;
+  node?: DrawnNode | null;
+  /** For `focus`. */
+  utterance?: string;
+  /** For `state`: the AT-SPI state nick, and whether it turned on. */
+  state?: string;
+  on?: boolean;
+  /** For `name` / `announce` / `text-*`. */
+  name?: string;
+  text?: string;
+  assertive?: boolean;
+  /** For `value`. */
+  value?: number;
+  /** For `text-*` / `caret`. */
+  offset?: number;
+  /** For `selection`. */
+  start?: number;
+  end?: number;
+  /** For `window`. */
+  focused?: boolean;
+}
+
+/** A focusable (or focused) node as an AT would describe it. */
+export interface A11yDescription {
+  node: DrawnNode;
+  name: string;
+  /** The AT-SPI role name — `"check box"`, `"entry"`. */
+  role: string;
+  /** The set state nicks — `"focusable"`, `"checked"`, `"sensitive"`, … */
+  states: string[];
+  /** `"(no accessible name)"` when there is nothing to say. */
+  utterance: string;
+}
+
+/**
+ * The in-process assistive-technology spy: the same semantic feed the
+ * AT-SPI bridge serves, observed at the hook seam with no bus. Assert on
+ * `events()`/`since()` for exact facts, on `transcript()` for "what would
+ * a user have been told".
+ */
+export interface A11ySpy {
+  /** Every entry recorded so far, oldest first. */
+  events(): A11ySpyEvent[];
+  /** Entries since the previous `since()` (or `clear()`). */
+  since(): A11ySpyEvent[];
+  /** The `summary` of every entry — made for `assert.deepEqual`. */
+  transcript(): string[];
+  clear(): void;
+  /** The focused node as an AT would describe it, or null. */
+  focused(): A11yDescription | null;
+  /** Every keyboard-reachable node, in Tab order, focus scopes included. */
+  focusables(): A11yDescription[];
+  /** Put the hook slots back; `cleanup()` does this for you. */
+  uninstall(): void;
 }
 
 export interface Queries {
@@ -161,9 +239,27 @@ export interface RenderX11Result extends Queries {
   window: NtkWindow | null;
   /** The window's 2d context, which is what pixel assertions read. */
   readonly ctx: TestContext2D;
+  /** The assistive-technology spy, when `a11y: true` asked for one. */
+  at: A11ySpy | null;
   rerender(element: ReactNode): Promise<void>;
   unmount(): Promise<void>;
 }
+
+/** Install a spy outside `renderX11` — install **before** rendering, and
+ * uninstall yourself. Prefer `renderX11(el, { a11y: true })`. */
+export function installA11ySpy(): A11ySpy;
+
+/** The utterance for a live node, through the shared model. */
+export function nodeUtterance(node: DrawnNode): string;
+
+/** The utterance formatter itself, for callers that gathered the parts
+ * elsewhere (scripts/a11y-probe.mjs reads them over real D-Bus). */
+export function utteranceOf(parts: {
+  name: string;
+  role?: string;
+  states?: string[];
+  value?: { now: number; min?: number; max?: number } | null;
+}): string;
 
 /**
  * Mount a tree against a real in-process X server and return a handle plus

--- a/src/testing/index.js
+++ b/src/testing/index.js
@@ -37,6 +37,7 @@ export {
 } from './harness.js';
 
 export { within, textOf, roleOf } from './queries.js';
+export { installA11ySpy, nodeUtterance, utteranceOf } from './a11y.js';
 export { inspect, ownerChainOf, sourceOf } from './components.js';
 export {
   fireEvent,

--- a/src/testing/mock-app.js
+++ b/src/testing/mock-app.js
@@ -7,6 +7,10 @@ import { setAppearanceForTests } from '../appearance.js';
 import { setCompositingForTests } from '../compositing.js';
 import { setScreensForTests } from '../screens.js';
 
+// As in harness.js: a mock-app test must not register with a live AT-SPI
+// registry on the machine running it.
+process.env.NO_AT_BRIDGE ??= '1';
+
 // ntk 5 loads the layout engine's WebAssembly in createClient() rather than
 // at import time — that is what keeps top-level await out of the bundle, and
 // so lets an app ship as a single executable (see docs/packaging.md). A mock

--- a/src/testing/queries.js
+++ b/src/testing/queries.js
@@ -15,6 +15,7 @@
 //   findBy*   getBy*, retried until it appears or the timeout expires
 
 import { queryAllByComponent, componentInventory } from './components.js';
+import { roleNameOf } from '../a11y.js';
 
 const DEFAULT_TIMEOUT = 1000;
 
@@ -55,31 +56,14 @@ function matches(actual, expected, exact) {
 }
 
 /**
- * The role a node reports. There is no accessibility tree yet (NEXT_STEPS
- * §11.3), so this is the honest subset: the host element kind, plus an
- * explicit `role` prop, which is how a widget names itself until AT-SPI
- * lands. `Button` and friends set it.
+ * The role a node reports: the `role` prop, else the same kind → role-name
+ * table the AT-SPI bridge reads (src/a11y.js), so what a test selects by
+ * and what a screen reader hears cannot drift apart. Kinds with no
+ * accessibility default (`box`, `canvas`, …) answer their kind, which is
+ * what queries were written against.
  */
 export function roleOf(node) {
-  if (node.props?.role) return String(node.props.role);
-  switch (node.kind) {
-    case 'textinput':
-      return 'textbox';
-    case 'textarea':
-      return 'textbox';
-    case 'window':
-      return 'window';
-    case 'popup':
-      return 'dialog';
-    case 'scrollview':
-      return 'scrollable';
-    case 'image':
-      return 'img';
-    case 'text':
-      return 'text';
-    default:
-      return node.kind;
-  }
+  return roleNameOf(node) ?? node.kind;
 }
 
 function describe(node) {

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -41,12 +41,143 @@ export interface InteractionProps {
    * when it unmounts. This is what makes a modal.
    */
   trapFocus?: boolean;
-  /** Never focusable, and the trigger for a `:disabled` style block. */
+  /** Never focusable, and the trigger for a `:disabled` style block. Also
+   * clears the AT-SPI ENABLED/SENSITIVE states. */
   disabled?: boolean;
 }
 
+/**
+ * The ARIA role vocabulary the AT-SPI bridge maps (src/a11y.js). An
+ * unknown string falls back to the element default and warns in DEV; the
+ * open union keeps forward compatibility.
+ */
+export type A11yRole =
+  | 'alert'
+  | 'alertdialog'
+  | 'article'
+  | 'banner'
+  | 'blockquote'
+  | 'button'
+  | 'caption'
+  | 'cell'
+  | 'checkbox'
+  | 'columnheader'
+  | 'combobox'
+  | 'comment'
+  | 'complementary'
+  | 'contentinfo'
+  | 'dialog'
+  | 'document'
+  | 'form'
+  | 'grid'
+  | 'gridcell'
+  | 'group'
+  | 'heading'
+  | 'img'
+  | 'link'
+  | 'list'
+  | 'listbox'
+  | 'listitem'
+  | 'log'
+  | 'main'
+  | 'marquee'
+  | 'math'
+  | 'menu'
+  | 'menubar'
+  | 'menuitem'
+  | 'menuitemcheckbox'
+  | 'menuitemradio'
+  | 'meter'
+  | 'navigation'
+  | 'none'
+  | 'note'
+  | 'option'
+  | 'paragraph'
+  | 'presentation'
+  | 'progressbar'
+  | 'radio'
+  | 'radiogroup'
+  | 'region'
+  | 'row'
+  | 'rowheader'
+  | 'scrollbar'
+  | 'search'
+  | 'searchbox'
+  | 'separator'
+  | 'slider'
+  | 'spinbutton'
+  | 'status'
+  | 'switch'
+  | 'tab'
+  | 'table'
+  | 'tablist'
+  | 'tabpanel'
+  | 'term'
+  | 'textbox'
+  | 'timer'
+  | 'toolbar'
+  | 'tooltip'
+  | 'tree'
+  | 'treegrid'
+  | 'treeitem'
+  | 'window'
+  | (string & {});
+
+/** An action assistive technology asked the app to perform. */
+export interface A11yActionEvent {
+  action: 'setValue';
+  /** For `setValue`: the value the AT wants (AT-SPI `Value.CurrentValue`). */
+  value?: number;
+}
+
+/**
+ * Accessibility, in the web's vocabulary — the same `role` / `aria-*`
+ * names react-dom accepts. Read by the AT-SPI bridge (docs/accessibility.md);
+ * inert (and harmless) where there is no accessibility bus. Every host
+ * element takes these, which is the whole seam a component library needs.
+ */
+export interface A11yProps {
+  /** What this element *is* to a screen reader. */
+  role?: A11yRole;
+  /** The accessible name, above every other name source. */
+  'aria-label'?: string;
+  /** Supplementary description (AT-SPI `Description`). */
+  'aria-description'?: string;
+  /** Remove this subtree from the accessible tree entirely. */
+  'aria-hidden'?: boolean;
+  'aria-checked'?: boolean | 'mixed';
+  'aria-selected'?: boolean;
+  'aria-expanded'?: boolean;
+  'aria-pressed'?: boolean | 'mixed';
+  'aria-busy'?: boolean;
+  'aria-modal'?: boolean;
+  'aria-readonly'?: boolean;
+  'aria-required'?: boolean;
+  /** Truthy exposes HAS_POPUP; the string names what opens. */
+  'aria-haspopup'?: boolean | 'menu' | 'listbox' | 'dialog' | 'grid' | 'tree';
+  'aria-orientation'?: 'horizontal' | 'vertical';
+  /** Present ⇒ the element exposes the AT-SPI Value interface. */
+  'aria-valuenow'?: number;
+  'aria-valuemin'?: number;
+  'aria-valuemax'?: number;
+  'aria-valuetext'?: string;
+  /** Outline level, for `role="heading"` and tree items. */
+  'aria-level'?: number;
+  'aria-posinset'?: number;
+  'aria-setsize'?: number;
+  /** The shortcut that triggers this ("Ctrl+N"), announced with the item. */
+  'aria-keyshortcuts'?: string;
+  /**
+   * Assistive technology drove the control — Orca setting a slider's value
+   * through the AT-SPI Value interface. Wire it to the same state setter
+   * as the pointer and the keyboard. Activation needs no handler here: the
+   * bridge dispatches a synthetic click through the normal event path.
+   */
+  onAccessibilityAction?: (ev: A11yActionEvent) => void;
+}
+
 export interface DrawnProps<T = DrawnNode>
-  extends CommonProps, InteractionProps, EventHandlers<T> {
+  extends CommonProps, InteractionProps, A11yProps, EventHandlers<T> {
   ref?: Ref<T>;
 }
 
@@ -88,6 +219,7 @@ export interface WindowProps
   extends
     CommonProps,
     InteractionProps,
+    A11yProps,
     EventHandlers<DrawnNode>,
     SizeHintProps {
   ref?: Ref<NtkWindow>;
@@ -313,6 +445,8 @@ export interface TextAreaProps extends TextInputProps {
 export interface ImageProps extends DrawnProps<DrawnNode> {
   /** File path; PNG or JPEG, decoded in JS. */
   src: string;
+  /** The accessible name — what a screen reader says for this image. */
+  alt?: string;
 }
 // Size is `style={{ width, height }}`, like every other element: `width`
 // and `height` are style names, so they are not declared here.

--- a/test/a11y-spy.test.js
+++ b/test/a11y-spy.test.js
@@ -1,0 +1,211 @@
+// The assistive-technology spy (`renderX11(..., { a11y: true })`): screen-
+// reader-shaped assertions with no bus anywhere. Input is real — injected
+// through the in-process X server, so Tab is the event manager's Tab and a
+// press is a press — and the observations are the same hook feed the AT-SPI
+// bridge serves to Orca, cut off before D-Bus.
+//
+// The four tests at the top are the canonical ones — the checks a sighted
+// test author cannot make by looking and a unit test cannot express:
+// focus order, no keyboard trap, nothing nameless, state changes announced.
+// They are written to be stolen into applications wholesale.
+import { after, beforeEach, test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+
+import { Button, Checkbox, Slider, Switch, announce } from '../src/index.js';
+import {
+  cleanup,
+  renderX11,
+  userEvent,
+  utteranceOf,
+  XK_RIGHT,
+  XK_SPACE,
+} from '../src/testing/index.js';
+import { hooks } from '../src/a11y.js';
+
+const h = React.createElement;
+const { useState } = React;
+
+/** A settings pane with one of everything the keyboard reaches. */
+function App({ onSave = () => {} } = {}) {
+  const [agreed, setAgreed] = useState(true);
+  const [notify, setNotify] = useState(false);
+  const [volume, setVolume] = useState(30);
+  return h(
+    'box',
+    { style: { padding: 12, gap: 8 } },
+    h('text', null, 'Preferences'),
+    h(Button, { onPress: onSave }, 'Save'),
+    h(
+      Checkbox,
+      { checked: agreed, onChange: (ev) => setAgreed(ev.value) },
+      'Enable telemetry',
+    ),
+    h(Switch, {
+      'aria-label': 'Notifications',
+      checked: notify,
+      onChange: (ev) => setNotify(ev.value),
+    }),
+    h(Slider, {
+      'aria-label': 'Volume',
+      value: volume,
+      min: 0,
+      max: 100,
+      step: 1,
+      onChange: (ev) => setVolume(ev.value),
+      style: { width: 160 },
+    }),
+    h('textinput', { placeholder: 'Name' }),
+  );
+}
+
+beforeEach(() => cleanup());
+after(() => cleanup());
+
+// ---------------------------------------------------------------------------
+// The canonical four
+// ---------------------------------------------------------------------------
+
+test('focus order: tabbing tells the story in the right order', async () => {
+  const { at } = await renderX11(h(App), { a11y: true });
+  for (let i = 0; i < 5; i++) await userEvent.tab();
+  const heard = at
+    .events()
+    .filter((e) => e.type === 'focus')
+    .map((e) => e.summary);
+  assert.deepEqual(heard, [
+    'focus: Save, button',
+    'focus: Enable telemetry, check box, checked',
+    'focus: Notifications, switch',
+    'focus: Volume, slider, 30 percent',
+    'focus: Name, entry',
+  ]);
+});
+
+test('no keyboard trap: Tab cycles, in both directions', async () => {
+  const { at } = await renderX11(h(App), { a11y: true });
+  const stops = at.focusables();
+  assert.equal(stops.length, 5);
+  // n+1 presses land back on the first stop — nothing swallowed the cycle
+  for (let i = 0; i <= stops.length; i++) await userEvent.tab();
+  assert.equal(at.focused().node, stops[0].node);
+  // and backwards wraps to the last
+  await userEvent.tab({ shift: true });
+  assert.equal(at.focused().node, stops[stops.length - 1].node);
+});
+
+test('nothing the keyboard reaches is nameless', async () => {
+  const { at } = await renderX11(h(App), { a11y: true });
+  for (const stop of at.focusables()) {
+    assert.notEqual(
+      stop.utterance,
+      '(no accessible name)',
+      `a blind user reaching this <${stop.node.kind}> would be told nothing`,
+    );
+    assert.notEqual(stop.name, '', `unnamed ${stop.role}`);
+  }
+});
+
+test('a state change is announced, not just repainted', async () => {
+  const { at } = await renderX11(h(App), { a11y: true });
+  await userEvent.tab();
+  await userEvent.tab(); // the checkbox, checked
+  at.since();
+  await userEvent.key(XK_SPACE);
+  const heard = at.since();
+  assert.ok(
+    heard.some((e) => e.type === 'state' && e.state === 'checked' && !e.on),
+    `expected a checked→off state change, heard: ${heard.map((e) => e.summary).join(' | ')}`,
+  );
+  // …and back
+  await userEvent.key(XK_SPACE);
+  assert.ok(
+    at.since().some((e) => e.type === 'state' && e.state === 'checked' && e.on),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// The rest of the feed
+// ---------------------------------------------------------------------------
+
+test('adjusting a slider announces its value', async () => {
+  const { at } = await renderX11(h(App), { a11y: true });
+  // Tab, not click: a press on the track is a jump-to-position gesture and
+  // would move the value before the arrow key does
+  for (let i = 0; i < 4; i++) await userEvent.tab();
+  assert.equal(at.focused().role, 'slider');
+  at.since();
+  await userEvent.key(XK_RIGHT);
+  const heard = at.since();
+  assert.ok(
+    heard.some((e) => e.type === 'value' && e.value === 31),
+    `expected value: 31, heard: ${heard.map((e) => e.summary).join(' | ')}`,
+  );
+  assert.equal(at.focused().utterance, 'Volume, slider, 31 percent');
+});
+
+test('typing echoes through text-changed, character by character', async () => {
+  const { at, getByRole } = await renderX11(h(App), { a11y: true });
+  const input = getByRole('textbox');
+  await userEvent.type(input, 'hi');
+  const inserts = at
+    .events()
+    .filter((e) => e.type === 'text-insert')
+    .map((e) => e.text);
+  assert.deepEqual(inserts, ['h', 'i']);
+  // the name is still the placeholder — a value is not a name
+  assert.equal(at.focused().utterance, 'Name, entry');
+});
+
+test('announce() is observable, and reports delivery', async () => {
+  const { at } = await renderX11(h(App), { a11y: true });
+  assert.equal(announce('Saved', { assertive: true }), true);
+  const heard = at.since().filter((e) => e.type === 'announce');
+  assert.deepEqual(
+    heard.map((e) => e.summary),
+    ['announce: Saved'],
+  );
+  assert.equal(heard[0].assertive, true);
+});
+
+test('the audit catches what it exists to catch', async () => {
+  // a focusable box nobody named: exactly the control the nameless check
+  // is for — prove the utterance flags it rather than passing politely
+  const { at } = await renderX11(
+    h('box', { focusable: true, style: { width: 40, height: 40 } }),
+    { a11y: true },
+  );
+  const [stop] = at.focusables();
+  assert.equal(stop.utterance, '(no accessible name)');
+});
+
+test('the spy uninstalls with its render', async () => {
+  const { at } = await renderX11(h(App), { a11y: true });
+  assert.equal(typeof hooks.focus, 'function');
+  await cleanup();
+  assert.equal(hooks.focus, null);
+  assert.equal(hooks.announce, null);
+  // the log survives teardown for post-mortem assertions
+  assert.ok(Array.isArray(at.events()));
+  assert.equal(announce('nobody is listening'), false);
+});
+
+test('utteranceOf is the documented model, exactly', () => {
+  assert.equal(
+    utteranceOf({
+      name: 'Volume',
+      role: 'slider',
+      states: ['sensitive', 'focusable'],
+      value: { now: 30, min: 0, max: 100 },
+    }),
+    'Volume, slider, 30 percent',
+  );
+  assert.equal(
+    utteranceOf({ name: 'Save', role: 'button', states: ['focusable'] }),
+    'Save, button, unavailable',
+  );
+  assert.equal(
+    utteranceOf({ name: '', role: 'filler' }),
+    '(no accessible name)',
+  );
+});

--- a/test/a11y.test.js
+++ b/test/a11y.test.js
@@ -1,0 +1,317 @@
+// The accessibility model, with no bus anywhere: roles, names, states and
+// the tree projection are pure functions over the retained node tree
+// (src/a11y.js), so they are tested the way the style resolver is — build a
+// tree on the mock app, ask, compare. The AT-SPI bridge that serves this
+// model over D-Bus is test/atspi.test.js; everything asserted here holds
+// whether or not that bridge ever connects.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+
+import {
+  createRoot,
+  Button,
+  Checkbox,
+  Slider,
+  Tabs,
+  announce,
+} from '../src/index.js';
+import {
+  ATSPI_ROLE,
+  ATSPI_STATE,
+  a11yRole,
+  roleNameOf,
+  a11yChildren,
+  a11yParent,
+  a11yIndexIn,
+  a11yName,
+  a11yStates,
+  a11yValue,
+  a11yAttributes,
+  a11yActivatable,
+  hooks,
+  isFocusable,
+} from '../src/a11y.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+const settle = async () => {
+  await tick();
+  await tick();
+};
+
+const mount = async (element, { width = 300, height = 200, title } = {}) => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(h('window', { width, height, title }, element));
+  await settle();
+  const wnd = app.windows[0];
+  return { app, wnd, root: wnd._reactX11Node, x11Root };
+};
+
+const find = (node, pred) =>
+  pred(node)
+    ? node
+    : node.children.reduce(
+        (a, c) => a || (c.isWindow ? null : find(c, pred)),
+        null,
+      );
+
+const byRole = (root, role) => find(root, (n) => n.props?.role === role);
+
+const hasState = (states, bit) =>
+  bit < 32
+    ? Boolean(states[0] & (1 << bit))
+    : Boolean(states[1] & (1 << (bit - 32)));
+
+// ---------------------------------------------------------------------------
+
+test('kind defaults: an unlabelled tree is boring, not wrong', async () => {
+  const { root } = await mount(
+    h(
+      'box',
+      null,
+      h('text', null, 'plain words'),
+      h('textinput', { defaultValue: 'x' }),
+      h('scrollview', null, h('box')),
+    ),
+  );
+  assert.equal(a11yRole(root), ATSPI_ROLE.FRAME);
+  const box = find(root, (n) => n.kind === 'box');
+  assert.equal(a11yRole(box), ATSPI_ROLE.FILLER);
+  assert.equal(
+    a11yRole(find(root, (n) => n.kind === 'text')),
+    ATSPI_ROLE.LABEL,
+  );
+  assert.equal(
+    a11yRole(find(root, (n) => n.kind === 'textinput')),
+    ATSPI_ROLE.ENTRY,
+  );
+  assert.equal(
+    a11yRole(find(root, (n) => n.kind === 'scrollview')),
+    ATSPI_ROLE.SCROLL_PANE,
+  );
+});
+
+test('the role prop maps to AT-SPI, and an unknown one falls back', async () => {
+  const { root } = await mount(
+    h(
+      'box',
+      null,
+      h('box', { role: 'button' }),
+      h('box', { role: 'switch' }),
+      h('box', { role: 'no-such-role' }),
+    ),
+  );
+  assert.equal(a11yRole(byRole(root, 'button')), ATSPI_ROLE.BUTTON);
+  assert.equal(a11yRole(byRole(root, 'switch')), ATSPI_ROLE.SWITCH);
+  // unknown: reads as the element default rather than vanishing
+  assert.equal(a11yRole(byRole(root, 'no-such-role')), ATSPI_ROLE.FILLER);
+  assert.equal(roleNameOf(byRole(root, 'button')), 'button');
+});
+
+test('the projection: hidden subtrees gone, presentation erased, text opaque', async () => {
+  const { root } = await mount(
+    h(
+      'box',
+      null,
+      h('box', { 'aria-hidden': true }, h('box', { role: 'button' })),
+      h(
+        'box',
+        { role: 'none' },
+        h('box', { role: 'checkbox' }),
+        h('box', { role: 'radio' }),
+      ),
+      h('text', null, 'one ', h('text', null, 'run')),
+    ),
+  );
+  const outer = root.children[0];
+  const projected = a11yChildren(outer);
+  // aria-hidden subtree contributes nothing; the presentation box is
+  // replaced by its two children; the text is one leaf despite its spans
+  assert.deepEqual(
+    projected.map((n) => roleNameOf(n) ?? n.kind),
+    ['checkbox', 'radio', 'text'],
+  );
+  const checkbox = projected[0];
+  // the erased wrapper is skipped walking up too
+  assert.equal(a11yParent(checkbox), outer);
+  assert.equal(a11yIndexIn(outer, checkbox), 0);
+  const text = projected[2];
+  assert.equal(a11yChildren(text).length, 0);
+});
+
+test('names: aria-label, then what the element carries, then contents', async () => {
+  const { root } = await mount(
+    h(
+      'box',
+      null,
+      h('box', { role: 'button', 'aria-label': 'Close' }, h('text', null, 'X')),
+      h(
+        'box',
+        { role: 'button' },
+        h('text', null, 'Save ', h('text', null, 'now')),
+      ),
+      h('textinput', { placeholder: 'Search…' }),
+      h('image', { src: '/dev/null/nothing.png', alt: 'A chart' }),
+    ),
+    { title: 'Named' },
+  );
+  assert.equal(a11yName(root), 'Named');
+  const [labelled, contents] = [
+    byRole(root, 'button'),
+    find(root, (n) => n.props?.role === 'button' && !n.props['aria-label']),
+  ];
+  assert.equal(a11yName(labelled), 'Close');
+  assert.equal(a11yName(contents), 'Save now');
+  assert.equal(a11yName(find(root, (n) => n.kind === 'textinput')), 'Search…');
+  assert.equal(a11yName(find(root, (n) => n.kind === 'image')), 'A chart');
+});
+
+test('states derive from the same facts the widgets draw from', async () => {
+  const { root } = await mount(
+    h(
+      'box',
+      null,
+      h('box', { role: 'checkbox', 'aria-checked': true, focusable: true }),
+      h('box', { role: 'checkbox', 'aria-checked': 'mixed' }),
+      h('box', { role: 'button', disabled: true }),
+      h('textarea', { defaultValue: 'a\nb' }),
+      h('box', { role: 'tab', 'aria-selected': true }),
+      h('box', {
+        role: 'menuitem',
+        'aria-haspopup': 'menu',
+        'aria-expanded': false,
+      }),
+    ),
+  );
+  const S = ATSPI_STATE;
+
+  const checked = byRole(root, 'checkbox');
+  let s = a11yStates(checked);
+  for (const bit of [
+    S.CHECKABLE,
+    S.CHECKED,
+    S.ENABLED,
+    S.SENSITIVE,
+    S.FOCUSABLE,
+    S.VISIBLE,
+    S.SHOWING,
+  ]) {
+    assert.ok(hasState(s, bit), `expected state ${bit}`);
+  }
+
+  const mixed = find(root, (n) => n.props?.['aria-checked'] === 'mixed');
+  s = a11yStates(mixed);
+  assert.ok(hasState(s, S.INDETERMINATE));
+  assert.ok(!hasState(s, S.CHECKED));
+
+  const disabled = byRole(root, 'button');
+  s = a11yStates(disabled);
+  assert.ok(!hasState(s, S.ENABLED));
+  assert.ok(!hasState(s, S.SENSITIVE));
+  assert.ok(!hasState(s, S.FOCUSABLE));
+  assert.ok(!isFocusable(disabled));
+
+  const area = find(root, (n) => n.kind === 'textarea');
+  s = a11yStates(area);
+  assert.ok(hasState(s, S.MULTI_LINE));
+  assert.ok(hasState(s, S.EDITABLE));
+  assert.ok(hasState(s, S.FOCUSABLE), 'textarea is focusable by default');
+
+  s = a11yStates(byRole(root, 'tab'));
+  assert.ok(hasState(s, S.SELECTABLE));
+  assert.ok(hasState(s, S.SELECTED));
+
+  const item = byRole(root, 'menuitem');
+  s = a11yStates(item);
+  assert.ok(hasState(s, S.HAS_POPUP));
+  assert.ok(hasState(s, S.EXPANDABLE));
+  assert.ok(!hasState(s, S.EXPANDED));
+  assert.ok(hasState(s, S.COLLAPSED));
+});
+
+test('focus is one fact: the manager, the ring and the state agree', async () => {
+  const { root } = await mount(h('textinput', { defaultValue: '' }));
+  const input = find(root, (n) => n.kind === 'textinput');
+  assert.ok(!hasState(a11yStates(input), ATSPI_STATE.FOCUSED));
+  input.focus();
+  assert.ok(hasState(a11yStates(input), ATSPI_STATE.FOCUSED));
+  assert.equal(root.events.focused, input);
+});
+
+test('aria-valuenow is the Value interface, and widgets carry it', async () => {
+  const changes = [];
+  const { root } = await mount(
+    h(
+      'box',
+      null,
+      h(Slider, {
+        value: 30,
+        min: 0,
+        max: 50,
+        onChange: (ev) => changes.push(ev.value),
+      }),
+      h(Checkbox, { checked: true, onChange: () => {} }, 'Ticked'),
+      h(Button, { onPress: () => {} }, 'Go'),
+    ),
+  );
+  const slider = byRole(root, 'slider');
+  assert.deepEqual(a11yValue(slider), { now: 30, min: 0, max: 50, text: '' });
+  assert.ok(a11yActivatable(byRole(root, 'button')));
+
+  // the AT-side write route a widget wires through onAccessibilityAction
+  slider.props.onAccessibilityAction({ action: 'setValue', value: 12 });
+  assert.deepEqual(changes, [12]);
+
+  const checkbox = byRole(root, 'checkbox');
+  assert.ok(hasState(a11yStates(checkbox), ATSPI_STATE.CHECKED));
+  assert.equal(a11yName(checkbox), 'Ticked');
+});
+
+test('widget wiring: Tabs speak the tab pattern', async () => {
+  const { root } = await mount(
+    h(Tabs, {
+      items: [
+        { id: 'a', label: 'First', content: h('text', null, 'A') },
+        { id: 'b', label: 'Second', content: h('text', null, 'B') },
+      ],
+    }),
+  );
+  const tablist = byRole(root, 'tablist');
+  assert.ok(tablist, 'the strip carries role=tablist');
+  const tabs = a11yChildren(tablist).filter((n) => n.props?.role === 'tab');
+  assert.equal(tabs.length, 2);
+  assert.equal(a11yName(tabs[0]), 'First');
+  assert.ok(hasState(a11yStates(tabs[0]), ATSPI_STATE.SELECTED));
+  assert.ok(!hasState(a11yStates(tabs[1]), ATSPI_STATE.SELECTED));
+  assert.ok(byRole(root, 'tabpanel'));
+});
+
+test('attributes carry the ordinal leftovers', async () => {
+  const { root } = await mount(
+    h('box', {
+      role: 'treeitem',
+      'aria-level': 2,
+      'aria-posinset': 3,
+      'aria-setsize': 7,
+    }),
+  );
+  const item = byRole(root, 'treeitem');
+  assert.deepEqual(a11yAttributes(item), [
+    ['xml-roles', 'treeitem'],
+    ['level', '2'],
+    ['posinset', '3'],
+    ['setsize', '7'],
+  ]);
+});
+
+test('with no bridge, the hooks stay null and announce says so', async () => {
+  await mount(h('box', { role: 'button' }, h('text', null, 'Quiet')));
+  // NO_AT_BRIDGE is set by the test harness, so the climb never started
+  for (const [name, slot] of Object.entries(hooks)) {
+    assert.equal(slot, null, `hook ${name} must stay unset`);
+  }
+  assert.equal(announce('nobody is listening'), false);
+});

--- a/test/atspi.test.js
+++ b/test/atspi.test.js
@@ -1,0 +1,537 @@
+// The AT-SPI bridge, end to end, with no desktop: an in-process message bus
+// (dbus-native's broker), a stub registry owning org.a11y.atspi.Registry,
+// and a test client playing the screen reader — connecting, walking the
+// tree with real Accessible/Component/Text calls, driving the app through
+// Action and EditableText, and collecting the signals Orca would.
+//
+// AT_SPI_BUS_ADDRESS pointed at the broker is the same seam a sandboxed
+// desktop uses, so the bridge under test runs the exact code a real session
+// runs from the GetAddress reply onward; only the discovery rung is skipped.
+import { after, before, describe, test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+
+import {
+  transportAvailable,
+  startBroker,
+  stopBroker,
+  until,
+} from './helpers/with-bus.js';
+
+const haveTransport = await transportAvailable();
+const needsBroker = haveTransport
+  ? {}
+  : { skip: 'dbus-native is not installed (expected on Node < 22.12)' };
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+const settle = async () => {
+  await tick();
+  await tick();
+};
+
+const ROOT_PATH = '/org/a11y/atspi/accessible/root';
+const CACHE_PATH = '/org/a11y/atspi/cache';
+const ACCESSIBLE = 'org.a11y.atspi.Accessible';
+const COMPONENT = 'org.a11y.atspi.Component';
+const ACTION = 'org.a11y.atspi.Action';
+const TEXT = 'org.a11y.atspi.Text';
+const EDITABLE = 'org.a11y.atspi.EditableText';
+const VALUE = 'org.a11y.atspi.Value';
+const PROPERTIES = 'org.freedesktop.DBus.Properties';
+
+const ROLE = { APPLICATION: 75, FRAME: 23, BUTTON: 43, ENTRY: 79, LABEL: 29 };
+const STATE = { CHECKED: 4, ENABLED: 8, FOCUSABLE: 11, FOCUSED: 12 };
+const hasState = ([lo, hi], bit) =>
+  bit < 32 ? Boolean(lo & (1 << bit)) : Boolean(hi & (1 << (bit - 32)));
+
+describe('the AT-SPI bridge', { concurrency: 1, ...needsBroker }, () => {
+  let dbus;
+  let broker;
+  let registry; // the stub at-spi2-registryd
+  let at; // the test client playing the screen reader
+  let signals; // every signal `at` overhears, raw
+  const embeds = [];
+
+  /** A connected dbus-native client on the broker, name settled. */
+  async function client() {
+    const bus = dbus.createClient({ busAddress: broker.addressString });
+    await new Promise((resolve, reject) => {
+      bus.connection.once('connect', resolve);
+      bus.connection.once('error', reject);
+    });
+    await bus.listNames();
+    return bus;
+  }
+
+  const call = (dest, path, iface, member, signature = '', body = []) =>
+    at.invoke({
+      destination: dest,
+      path,
+      interface: iface,
+      member,
+      signature,
+      body,
+    });
+
+  const getProp = async (dest, path, iface, name) => {
+    const variant = await call(dest, path, PROPERTIES, 'Get', 'ss', [
+      iface,
+      name,
+    ]);
+    return dbus.variantValue(variant);
+  };
+
+  const eventsNamed = (member) => signals.filter((s) => s.member === member);
+
+  before(async () => {
+    dbus = (await import('dbus-native')).default;
+    broker = await startBroker();
+    // the stub registry: owns the well-known name, answers Socket.Embed
+    // with a desktop ref, exactly what at-spi2-registryd would
+    registry = await client();
+    await registry.requestName('org.a11y.atspi.Registry', 0);
+    registry.exportInterface(
+      {
+        Embed(plug) {
+          embeds.push(plug);
+          return ['org.a11y.atspi.Registry', ROOT_PATH];
+        },
+        Unembed() {
+          return null;
+        },
+      },
+      ROOT_PATH,
+      {
+        name: 'org.a11y.atspi.Socket',
+        methods: { Embed: ['(so)', '(so)'], Unembed: ['(so)', ''] },
+      },
+    );
+    // the "screen reader": subscribes to everything and keeps the raw feed
+    at = await client();
+    signals = [];
+    await at.addMatch("type='signal'");
+    at.connection.on('message', (msg) => {
+      if (msg.type === 4 /* signal */) signals.push(msg);
+    });
+    process.env.AT_SPI_BUS_ADDRESS = broker.addressString;
+  });
+
+  after(async () => {
+    delete process.env.AT_SPI_BUS_ADDRESS;
+    const { _stopForTests } = await import('../src/atspi.js');
+    await _stopForTests();
+    for (const bus of [registry, at]) {
+      try {
+        await bus.close();
+      } catch {
+        // the broker may already be gone
+      }
+    }
+    await stopBroker(broker);
+  });
+
+  // shared across the tests below, in order — one app, one bridge, the way
+  // one process has one
+  let app;
+  let x11Root;
+  let appBus; // the app's unique name on the a11y bus
+  let framePath;
+  let pressed = 0;
+  const paths = {};
+
+  test('climbs the ladder, embeds, and exposes the application', async () => {
+    const { createRoot } = await import('../src/index.js');
+    const { createMockApp } = await import('./helpers/mock-app.js');
+    const { startA11y } = await import('../src/a11y.js');
+
+    app = createMockApp();
+    x11Root = await createRoot({ app });
+    x11Root.render(
+      h(
+        'window',
+        { title: 'Bridge Test', width: 320, height: 200 },
+        h(
+          'box',
+          { role: 'button', focusable: true, onClick: () => pressed++ },
+          h('text', null, 'Save'),
+        ),
+        h('textinput', { defaultValue: 'hello' }),
+      ),
+    );
+    await settle();
+
+    const bridge = await startA11y();
+    assert.ok(bridge, 'the bridge came up against the broker');
+    await until(() => embeds.length === 1, 'the Embed handshake');
+    // the plug ref names the app's unique name and its root path
+    assert.equal(embeds[0][1], ROOT_PATH);
+    appBus = embeds[0][0];
+
+    assert.equal(
+      await call(appBus, ROOT_PATH, ACCESSIBLE, 'GetRole'),
+      ROLE.APPLICATION,
+    );
+    assert.equal(
+      await getProp(
+        appBus,
+        ROOT_PATH,
+        'org.a11y.atspi.Application',
+        'ToolkitName',
+      ),
+      'react-x11',
+    );
+    // the desktop ref the registry answered with is the root's parent
+    assert.deepEqual(await getProp(appBus, ROOT_PATH, ACCESSIBLE, 'Parent'), [
+      'org.a11y.atspi.Registry',
+      ROOT_PATH,
+    ]);
+  });
+
+  test('the frame and its subtree read correctly over the wire', async () => {
+    const children = await call(appBus, ROOT_PATH, ACCESSIBLE, 'GetChildren');
+    assert.equal(children.length, 1, 'one toplevel window');
+    assert.equal(children[0][0], appBus);
+    framePath = children[0][1];
+
+    assert.equal(
+      await call(appBus, framePath, ACCESSIBLE, 'GetRole'),
+      ROLE.FRAME,
+    );
+    assert.equal(
+      await getProp(appBus, framePath, ACCESSIBLE, 'Name'),
+      'Bridge Test',
+    );
+
+    const frameChildren = await call(
+      appBus,
+      framePath,
+      ACCESSIBLE,
+      'GetChildren',
+    );
+    assert.equal(frameChildren.length, 2, 'the button and the input');
+    paths.button = frameChildren[0][1];
+    paths.input = frameChildren[1][1];
+
+    assert.equal(
+      await call(appBus, paths.button, ACCESSIBLE, 'GetRole'),
+      ROLE.BUTTON,
+    );
+    assert.equal(
+      await getProp(appBus, paths.button, ACCESSIBLE, 'Name'),
+      'Save',
+      'name from contents',
+    );
+    assert.equal(
+      await call(appBus, paths.button, ACCESSIBLE, 'GetIndexInParent'),
+      0,
+    );
+    const states = await call(appBus, paths.button, ACCESSIBLE, 'GetState');
+    assert.ok(hasState(states, STATE.ENABLED));
+    assert.ok(hasState(states, STATE.FOCUSABLE));
+    assert.ok(!hasState(states, STATE.FOCUSED));
+
+    // the label under the button is a LABEL leaf
+    const inside = await call(appBus, paths.button, ACCESSIBLE, 'GetChildren');
+    assert.equal(inside.length, 1);
+    assert.equal(
+      await call(appBus, inside[0][1], ACCESSIBLE, 'GetRole'),
+      ROLE.LABEL,
+    );
+
+    // Component answers rectangles once layout ran
+    const extents = await call(
+      appBus,
+      paths.button,
+      COMPONENT,
+      'GetExtents',
+      'u',
+      [1],
+    );
+    assert.equal(extents.length, 4);
+    assert.ok(extents[2] > 0, 'the button has laid-out width');
+  });
+
+  test('Cache.GetItems is the whole tree in one call', async () => {
+    const items = await call(
+      appBus,
+      CACHE_PATH,
+      'org.a11y.atspi.Cache',
+      'GetItems',
+    );
+    const roles = items.map((item) => item[7]);
+    assert.ok(roles.includes(ROLE.APPLICATION));
+    assert.ok(roles.includes(ROLE.FRAME));
+    assert.ok(roles.includes(ROLE.BUTTON));
+    const buttonItem = items.find((item) => item[7] === ROLE.BUTTON);
+    assert.equal(buttonItem[0][1], paths.button, 'refs are stable');
+    assert.equal(buttonItem[2][1], framePath, 'parent ref points at the frame');
+    assert.equal(buttonItem[6], 'Save');
+  });
+
+  test('DoAction("activate") is a real press gesture', async () => {
+    const actions = await call(appBus, paths.button, ACTION, 'GetActions');
+    assert.deepEqual(actions, [['activate', '', '']]);
+    assert.equal(
+      await call(appBus, paths.button, ACTION, 'DoAction', 'i', [0]),
+      true,
+    );
+    await until(() => pressed === 1, 'the onClick handler');
+
+    // Controls that act on the *press* — Select and MenuBar drop their
+    // menus on mousedown — must hear an AT activation too.
+    let pressedDown = 0;
+    x11Root.render(
+      h(
+        'window',
+        { title: 'Bridge Test', width: 320, height: 200 },
+        h(
+          'box',
+          { role: 'button', focusable: true, onClick: () => pressed++ },
+          h('text', null, 'Save'),
+        ),
+        h('textinput', { defaultValue: 'hello' }),
+        h('box', {
+          role: 'button',
+          'aria-label': 'Open menu',
+          onMouseDown: () => pressedDown++,
+        }),
+      ),
+    );
+    await settle();
+    const kids = await call(appBus, framePath, ACCESSIBLE, 'GetChildren');
+    await call(appBus, kids[2][1], ACTION, 'DoAction', 'i', [0]);
+    await until(() => pressedDown === 1, 'the onMouseDown handler');
+
+    // restore the tree the following tests were written against
+    x11Root.render(
+      h(
+        'window',
+        { title: 'Bridge Test', width: 320, height: 200 },
+        h(
+          'box',
+          { role: 'button', focusable: true, onClick: () => pressed++ },
+          h('text', null, 'Save'),
+        ),
+        h('textinput', { defaultValue: 'hello' }),
+      ),
+    );
+    await settle();
+  });
+
+  test('focus lands as state-changed:focused plus the legacy Focus', async () => {
+    signals.length = 0;
+    assert.equal(await call(appBus, paths.input, COMPONENT, 'GrabFocus'), true);
+    await until(
+      () =>
+        eventsNamed('StateChanged').some(
+          (s) =>
+            s.body[0] === 'focused' &&
+            s.body[1] === 1 &&
+            s.path === paths.input,
+        ),
+      'the focused state change',
+    );
+    assert.ok(
+      eventsNamed('Focus').some((s) => s.path === paths.input),
+      'the legacy Focus event went with it',
+    );
+    const states = await call(appBus, paths.input, ACCESSIBLE, 'GetState');
+    assert.ok(hasState(states, STATE.FOCUSED));
+  });
+
+  test('the Text interface reads what the input holds', async () => {
+    assert.equal(await getProp(appBus, paths.input, TEXT, 'CharacterCount'), 5);
+    assert.equal(
+      await call(appBus, paths.input, TEXT, 'GetText', 'ii', [0, -1]),
+      'hello',
+    );
+    const [word, start, end] = await call(
+      appBus,
+      paths.input,
+      TEXT,
+      'GetStringAtOffset',
+      'iu',
+      [1, 1],
+    );
+    assert.deepEqual([word, start, end], ['hello', 0, 5]);
+    assert.equal(
+      await call(appBus, paths.input, TEXT, 'SetCaretOffset', 'i', [2]),
+      true,
+    );
+    assert.equal(await getProp(appBus, paths.input, TEXT, 'CaretOffset'), 2);
+  });
+
+  test('an edit through EditableText emits the text-changed diff', async () => {
+    signals.length = 0;
+    assert.equal(
+      await call(appBus, paths.input, EDITABLE, 'SetTextContents', 's', [
+        'help me',
+      ]),
+      true,
+    );
+    // 'hello' -> 'help me': common prefix 'hel', delete 'lo', insert 'p me'
+    await until(
+      () => eventsNamed('TextChanged').length >= 2,
+      'both halves of the diff',
+    );
+    const changes = eventsNamed('TextChanged').map((s) => ({
+      kind: s.body[0],
+      offset: s.body[1],
+      length: s.body[2],
+      text: dbus.variantValue(s.body[3]),
+    }));
+    assert.deepEqual(changes, [
+      { kind: 'delete', offset: 3, length: 2, text: 'lo' },
+      { kind: 'insert', offset: 3, length: 4, text: 'p me' },
+    ]);
+    assert.equal(
+      await call(appBus, paths.input, TEXT, 'GetText', 'ii', [0, -1]),
+      'help me',
+    );
+  });
+
+  test('typing into the focused control reaches the AT as a diff', async () => {
+    signals.length = 0;
+    const wnd = app.windows[0];
+    const input = wnd._reactX11Node.children[1];
+    assert.equal(input.kind, 'textinput');
+    input._insert('!');
+    await until(
+      () =>
+        eventsNamed('TextChanged').some(
+          (s) => s.body[0] === 'insert' && dbus.variantValue(s.body[3]) === '!',
+        ),
+      'the keystroke diff',
+    );
+    await until(
+      () => eventsNamed('TextCaretMoved').length > 0,
+      'the caret move that went with it',
+    );
+  });
+
+  test('a state prop change becomes one precise state-changed event', async () => {
+    // reach the checkbox in a fresh render: props flow through commitUpdate
+    x11Root.render(
+      h(
+        'window',
+        { title: 'Bridge Test', width: 320, height: 200 },
+        h(
+          'box',
+          { role: 'button', focusable: true, onClick: () => pressed++ },
+          h('text', null, 'Save'),
+        ),
+        h('textinput', { defaultValue: 'hello' }),
+        h('box', { role: 'checkbox', 'aria-checked': false }),
+      ),
+    );
+    await settle();
+    await until(
+      () => eventsNamed('ChildrenChanged').some((s) => s.body[0] === 'add'),
+      'the checkbox joining the tree',
+    );
+    const frameChildren = await call(
+      appBus,
+      framePath,
+      ACCESSIBLE,
+      'GetChildren',
+    );
+    paths.checkbox = frameChildren[2][1];
+    let states = await call(appBus, paths.checkbox, ACCESSIBLE, 'GetState');
+    assert.ok(!hasState(states, STATE.CHECKED));
+
+    signals.length = 0;
+    x11Root.render(
+      h(
+        'window',
+        { title: 'Bridge Test', width: 320, height: 200 },
+        h(
+          'box',
+          { role: 'button', focusable: true, onClick: () => pressed++ },
+          h('text', null, 'Save'),
+        ),
+        h('textinput', { defaultValue: 'hello' }),
+        h('box', { role: 'checkbox', 'aria-checked': true }),
+      ),
+    );
+    await settle();
+    await until(
+      () =>
+        eventsNamed('StateChanged').some(
+          (s) =>
+            s.body[0] === 'checked' &&
+            s.body[1] === 1 &&
+            s.path === paths.checkbox,
+        ),
+      'the checked state change',
+    );
+    states = await call(appBus, paths.checkbox, ACCESSIBLE, 'GetState');
+    assert.ok(hasState(states, STATE.CHECKED));
+  });
+
+  test('aria-valuenow is a live Value interface', async () => {
+    x11Root.render(
+      h(
+        'window',
+        { title: 'Bridge Test', width: 320, height: 200 },
+        h('box', {
+          role: 'slider',
+          'aria-valuenow': 40,
+          'aria-valuemin': 0,
+          'aria-valuemax': 100,
+          onAccessibilityAction: (ev) => {
+            paths.lastAction = ev;
+          },
+        }),
+      ),
+    );
+    await settle();
+    const frameChildren = await call(
+      appBus,
+      framePath,
+      ACCESSIBLE,
+      'GetChildren',
+    );
+    const sliderPath = frameChildren[0][1];
+    assert.equal(await getProp(appBus, sliderPath, VALUE, 'CurrentValue'), 40);
+    assert.equal(await getProp(appBus, sliderPath, VALUE, 'MaximumValue'), 100);
+    // the AT writes the value; the widget's handler hears a setValue action
+    await call(appBus, sliderPath, PROPERTIES, 'Set', 'ssv', [
+      VALUE,
+      'CurrentValue',
+      ['d', 25],
+    ]);
+    await until(() => paths.lastAction?.action === 'setValue', 'the action');
+    assert.equal(paths.lastAction.value, 25);
+  });
+
+  test('announce() reaches the bus as an Announcement', async () => {
+    const { announce } = await import('../src/index.js');
+    signals.length = 0;
+    assert.equal(announce('saved', { assertive: true }), true);
+    await until(() => eventsNamed('Announcement').length === 1, 'the event');
+    const [detail, politeness, , text] = eventsNamed('Announcement')[0].body;
+    assert.equal(detail, '');
+    assert.equal(politeness, 2);
+    assert.equal(dbus.variantValue(text), 'saved');
+  });
+
+  test('unmounting removes the tree and tells the cache', async () => {
+    signals.length = 0;
+    x11Root.render(null);
+    await settle();
+    await until(
+      () => eventsNamed('RemoveAccessible').length > 0,
+      'the cache removals',
+    );
+    await until(
+      () =>
+        eventsNamed('ChildrenChanged').some(
+          (s) => s.body[0] === 'remove' && s.path === ROOT_PATH,
+        ),
+      'the application losing its child',
+    );
+    const children = await call(appBus, ROOT_PATH, ACCESSIBLE, 'GetChildren');
+    assert.equal(children.length, 0);
+  });
+});

--- a/test/atspi.test.js
+++ b/test/atspi.test.js
@@ -217,6 +217,28 @@ describe('the AT-SPI bridge', { concurrency: 1, ...needsBroker }, () => {
       await call(appBus, paths.button, ACCESSIBLE, 'GetRole'),
       ROLE.BUTTON,
     );
+    // GetRoleName is the AT-SPI name, not the ARIA one the app wrote:
+    // libatspi derives role names locally from the number, so a bridge
+    // answering its own vocabulary here is inconsistent with its own
+    // GetRole and nothing notices until an AT asks over the wire (which is
+    // how this was found — scripts/a11y-probe.mjs does ask).
+    assert.equal(
+      await call(appBus, paths.button, ACCESSIBLE, 'GetRoleName'),
+      'button',
+    );
+    assert.equal(
+      await call(appBus, framePath, ACCESSIBLE, 'GetRoleName'),
+      'frame',
+    );
+    // …and the ARIA role travels as an attribute, where the browsers put it.
+    // `a{ss}` reads back as pairs or as a plain object depending on the
+    // connection's value shapes, so normalise rather than pin one.
+    const attrs = await call(appBus, paths.button, ACCESSIBLE, 'GetAttributes');
+    const entries = Array.isArray(attrs) ? attrs : Object.entries(attrs);
+    assert.deepEqual(
+      entries.find(([k]) => k === 'xml-roles'),
+      ['xml-roles', 'button'],
+    );
     assert.equal(
       await getProp(appBus, paths.button, ACCESSIBLE, 'Name'),
       'Save',

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -179,6 +179,7 @@ const ORDER = [
   'styling.md',
   'components.md',
   'events.md',
+  'accessibility.md',
   'react-features.md',
   'drag-and-drop.md',
   'clipboard.md',


### PR DESCRIPTION
Screen readers see react-x11 apps. Every host element now takes the web's `role` / `aria-*` props, and a built-in AT-SPI2 bridge — the same interface GTK and Qt register through — exposes the live node tree on the accessibility bus: roles, names, states, focus, text editing with precise deltas, and the actions for assistive technology to drive controls back. NEXT_STEPS §11.3, landed in core rather than the `@react-x11/a11y` sibling package it originally sketched (§11.3 now records why).

```jsx
<box role="button" aria-label="Close" onClick={close} focusable>
  <text>×</text>
</box>
```

That is the whole API for most code — and most code needs even less, because the defaults already speak: windows are frames named by `title`, `<text>` is a label, `<textinput>` is a live editable entry, `<box>` is a filler screen readers step over silently. All the widgets are wired (`Button` through `Calendar`/`DatePicker`), `announce()` covers the live-region case, and `onAccessibilityAction` is the one handler a value-bearing control needs (Orca adjusting a `Slider` goes through the same clamp/quantize/emit as the pointer and the keyboard).

## Shape

- **`src/a11y.js` — the model.** Roles/names/states as pure functions over the retained tree, plus null hook slots the renderer's hot paths poll (the trace-registry pattern: accessibility off costs one property read per event). The focusable rule now lives here once — `EventManager._isFocusable`, the focus ring and the AT-SPI FOCUSABLE state all read the same function.
- **`src/atspi.js` — the bridge**, dynamically imported once per process. **No mirror tree**: every AT call is answered from the live node tree at call time; the only per-node state is the object path, the interface list, and a snapshot of what the bus was last *told* — kept to turn "something changed" into exact event diffs (state bits XOR'd to `StateChanged` nicks, text through a common-prefix/suffix diff to `insert`/`delete` with code-point offsets).
- **The ladder**: dbus-native (optionalDependency, already here) → session bus → `org.a11y.Bus.GetAddress` → connect + `Embed`. Every rung fails into a silent, costless off — ssh, CI, containers, macOS/Windows X servers stay exactly as they were. The bridge's socket is unref'd, so it never holds a process open. `REACT_X11_A11Y=1` makes the climb explain each rung; `NO_AT_BRIDGE` (the ecosystem switch) is honoured and set by `react-x11/test`, so suites on a desktop don't parade phantom apps through a running screen reader; `AT_SPI_BUS_ADDRESS` skips discovery and is the hermetic test seam.

Two decisions found the hard way, both recorded in the design doc:

- **Discovery dials a private, short-lived connection**, not the shared `sessionBus()`. An unowned background climb riding process-global bus state races anything that swaps `DBUS_SESSION_BUS_ADDRESS` and resets between cases — which this repo's own test harness does, and which corrupted `appearance.test.js` until the probe got its own socket.
- **AT activation is a full press gesture** (mousedown → mouseup → click through the normal dispatch, discrete priority, frame flush). A bare Click silently did nothing on exactly the controls a real menu bar is made of — `Select` and `MenuBar` open **on the press**, as menus do. Found by driving the live menu example over the bus; pinned by a test.

## Verification

726/726 tests (22 new), lint/typecheck/format clean. Nothing here is visible on screen, so in place of screenshots: transcripts produced by this PR's code running on a real desktop.

`test/atspi.test.js` is end-to-end with no desktop — dbus-native's broker is a real in-process message bus, a stub client owns `org.a11y.atspi.Registry`, and a second client plays the screen reader with raw calls: the Embed handshake, tree walking, `Cache.GetItems`, state bits, the press gesture, text-changed offsets, Value writes, announcements, teardown. `test/a11y.test.js` covers the model with no bus at all.

Live, against this desktop's real registry, via libatspi (the stack Orca uses):

```
application 'widgets' — toolkit react-x11
  frame 'widgets' [showing]
      button 'Press me' [focusable,showing]
      check box 'I agree to nothing in particular' [focusable,checked,showing]
      radio button 'Vanilla' [focusable,checked,showing]
      switch '' [focusable,showing]
      slider '' [focusable,showing]
      combo box 'fast' [focusable,showing]
      entry 'Type here…' [focusable,editable,showing]
```

Driving it AT-side: `do_action(0)` pressed the button and the counter label re-read `0×` → `1×`; `set_current_value(80)` moved the slider through `onAccessibilityAction`; `EditableText.set_text_contents` typed into the entry (caret followed); `grab_focus` focused it. Menu example: activating "File" on the menu bar over the bus dropped the real menu — EXPANDED flipped, and the popup appeared in the tree as `menu` with rows `'New'` (`keyshortcuts='Ctrl+N'`), separators and all.

And Orca itself (`orca --debug-file`), walking focus through the gallery:

```
SPEECH OUTPUT: 'widgets'
SPEECH OUTPUT: 'Press me'
SPEECH OUTPUT: 'button.'
SPEECH OUTPUT: 'I agree to nothing in particular'
SPEECH OUTPUT: 'check box checked.'
SPEECH OUTPUT: 'off switch.'
SPEECH OUTPUT: 'horizontal slider'
SPEECH OUTPUT: '80'
SPEECH OUTPUT: '80 percent.'
```

## Docs

- [docs/accessibility.md](https://github.com/sidorares/react-x11/blob/a11y-atspi/docs/accessibility.md) — the reference: props, roles, defaults, per-widget announcements, `announce()`, the ladder, testing recipes.
- [docs/architecture/accessibility.md](https://github.com/sidorares/react-x11/blob/a11y-atspi/docs/architecture/accessibility.md) — the design record: why no mirror, why the web vocabulary rather than the RN names, the event pipeline, rejected alternatives, deferred work (relations, Selection/Table interfaces, key-event forwarding, soft-wrap line granularity).
- NEXT_STEPS §11.3 rewritten as done; §10's package-split answer corrected; `roleOf` in the test queries now answers from the same model, so what a test selects by is what a screen reader hears.
