### PR TITLE
feat(desktop): myapp:// links open the app that is already running

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,20 @@ no override-redirect staging (issue #4).
   tidying up after a dead panel launches a new registrar nobody reads.
   `scripts/globalmenu-host.mjs` is a panel in a terminal; there is no
   installable dbusmenu client to test against otherwise.
+- `src/application.js`, `src/activate.js`, `src/apphooks.js` — custom URI
+  schemes and single instances (#173). `application.js` is the bus half and
+  **imports neither react nor X11**, so the seam it would be extracted along
+  stays visible; what keeps it here is that `RequestName` has to land on the
+  same connection as the menu and the portals, or the desktop sees two
+  half-applications. Two traps live there: the object path is _derived_ from
+  the app id with dashes becoming underscores (get it wrong and the launch
+  reaches a path nobody serves, which looks like nothing happening), and the
+  interface is **exported before `RequestName`**, because the daemon delivers
+  the queued activating call the instant the name is owned. `activate.js` is
+  the raise, and it is the part users judge the feature by — `_NET_ACTIVE_WINDOW`
+  with a wrong timestamp is refused by the WM while every layer reports success.
+  `npm run examples:urischeme` is the manual harness for the two dispatch paths
+  a broker cannot fake.
 - `src/styles.js` — flat style props → yoga setters; paint prop
   classification; text style resolution.
 - `src/events.js` — `EventManager`: ntk window events → synthetic events

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -1313,6 +1313,15 @@ startupWmClass })`, with the icon PNGs generated from a React component
 through the offscreen renderer (#124) so the app icon, `_NET_WM_ICON` and
 the launcher icon all come from one source.
 
+The generator now has a second customer and therefore a second reason to
+exist: custom URI schemes (#173) need `MimeType=x-scheme-handler/…`,
+`DBusActivatable=true` and a `StartupWMClass` that matches the window's
+`wmClass` prop, and [docs/uri-schemes.md](docs/uri-schemes.md) currently ships
+that as a snippet to paste. It stays prose deliberately — a library that writes
+into `~/.local/share` on import is a surprise, and it cannot work for a
+system-installed or Flatpak app — so whatever this becomes must be a command
+the **app author** runs, never something that happens implicitly.
+
 Finally, a CI `bundle` job that runs the esbuild build and executes the
 result against Xvfb. It is the only way the two blockers stay fixed; both
 were introduced silently by transitive dependencies and neither was noticed

--- a/README.md
+++ b/README.md
@@ -206,6 +206,18 @@ the array that serialises. `npm run globalmenu:host` is a panel in a terminal,
 for seeing it work on a desktop that has none. See
 [docs/globalmenu.md](docs/globalmenu.md).
 
+**`myapp://` links open the app that is already running.**
+`registerApplication({ appId, schemes })` before `createRoot()` owns the app's
+name on the bus, exports `org.freedesktop.Application`, and — on the half of
+all desktops where `xdg-open` ignores D-Bus activation and spawns a second copy
+with the URI in `argv` — forwards it to the first copy and tells that copy to
+exit. `useAppOpen()` receives the link, buffered and replayed if it arrived
+before the tree mounted, and `activateWindow()` brings the window forward with
+the launch's own timestamp, without which a window manager declines and the
+taskbar entry just blinks. The OAuth redirect this is for has an easier answer
+that needs none of it, and the page says so first. See
+[docs/uri-schemes.md](docs/uri-schemes.md).
+
 **Drag and drop** works with the rest of the desktop: `<box dropAccept={['files']}
 onDrop={…}>` takes a file dragged out of Nautilus, and `<box draggable dragData={…}>`
 can be dropped into a file manager or an editor. Drags that stay inside the

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,12 @@
   `sessionBus()` pair underneath, why one process is one connection and one
   identity, and why "there is no bus" is a first-class configuration rather
   than an error.
+- [uri-schemes.md](uri-schemes.md) — being the app a `myapp://…` link opens:
+  `registerApplication()` and the two dispatch paths a real desktop uses (only
+  one of which is D-Bus), why a second copy of the app has to forward and
+  exit, `useAppOpen()`, and the timestamp without which the window does not
+  actually come forward. Also: why a loopback port is the better answer for a
+  login, and the `.desktop` half that is an install step rather than code.
 - [filedialog.md](filedialog.md) — open, save and pick a folder:
   `useFileDialog()`, the three-rung ladder (the desktop's own portal,
   `osascript` on macOS, a browser react-x11 draws itself), why cancelling is

--- a/docs/dbus.md
+++ b/docs/dbus.md
@@ -204,6 +204,14 @@ ref.bus.exportInterface(impl, '/org/example/MyApp', description);
 Holding the ref is not bookkeeping — it is the event-loop hold above. Release
 it and nothing keeps the process running.
 
+The one service react-x11 exports for you is `org.freedesktop.Application`, so
+that a `myapp://…` link opens the app that is already running —
+[uri-schemes.md](uri-schemes.md). It is on this connection for exactly the
+reason above: a separately-dialled one would own the app's name under a
+different unique name than the one the global menu registers under and the one
+portals build Request paths from, and the desktop's model of "this
+application" would come apart.
+
 ## Installing, and Node 20
 
 ```json

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -11,6 +11,13 @@ menus in its panel, `MenuBar` hands the menu over and stops drawing. Same
 default shape as startup notification: on with no configuration, and one
 switch to turn it off.
 
+Everything on this page is the app talking _outwards_. The one thing that
+comes the other way — the desktop handing the app a `myapp://…` link to open,
+and the single-instance question that goes with it — is
+[uri-schemes.md](uri-schemes.md). It shares the launch timestamp described
+below: `ctx.timestamp` there is the same `_TIME` suffix `launchTimestamp()`
+parses here, and for the same reason.
+
 ## Startup notification
 
 When a launcher spawns an app it opens a **startup sequence** — that is what

--- a/docs/uri-schemes.md
+++ b/docs/uri-schemes.md
@@ -1,0 +1,337 @@
+# Custom URI schemes and single instances
+
+Being the app that `com.example.myapp://…` opens: a link clicked in a browser,
+a chat message or a launcher reaches the **already-running** app, and its
+window comes to the front.
+
+The flow this exists for is logging in through the browser. The app opens the
+system browser, the provider redirects to
+`com.example.myapp://auth?code=…`, the desktop routes that URI back, and the
+app finishes the login without asking anyone to paste anything.
+
+## Read this first: for a login, you probably want a loopback port
+
+RFC 8252 §7.3 has a second answer that needs none of the machinery below —
+redirect to `http://127.0.0.1:<port>/cb` and listen on it:
+
+```js
+import { createServer } from 'node:http';
+
+const server = createServer((req, res) => {
+  const url = new URL(req.url, 'http://127.0.0.1');
+  res.end('You can close this tab.');
+  finishLogin(url.searchParams.get('code'));
+});
+server.listen(0); // "Authorization servers MUST allow any port" — RFC 8252 §7.3
+const port = server.address().port;
+```
+
+No desktop registration, no D-Bus, no install step, and it works on XQuartz,
+in a container and over ssh in ways a scheme handler does not. **For an OAuth
+flow, make this the default and reach for the rest of this page only when you
+cannot.**
+
+Custom schemes still earn their place three ways: providers that only accept a
+registered private-use scheme; deep links that are not logins at all
+(`myapp://project/42` out of a chat message, a document opened from a
+launcher); and the fact that owning a name on the bus is the same machinery
+the [global menu](globalmenu.md) and a tray icon need anyway.
+
+## Four things have to be true
+
+|                  |                                                            | where                   |
+| ---------------- | ---------------------------------------------------------- | ----------------------- |
+| **Registration** | a `.desktop` entry claiming `x-scheme-handler/…`           | an install step         |
+| **Dispatch**     | the URI reaching the running process                       | `registerApplication()` |
+| **Delivery**     | `org.freedesktop.Application.Open`, answered before the UI | `useAppOpen()`          |
+| **The raise**    | `_NET_ACTIVE_WINDOW`, with the right timestamp             | `activateWindow()`      |
+
+The last one is the one that decides whether a user calls the feature working;
+see [the raise is the part that fails](#the-raise-is-the-part-that-fails).
+
+## The code
+
+```js
+import { createRoot, registerApplication } from 'react-x11';
+
+const app = await registerApplication({
+  appId: 'com.example.myapp',
+  schemes: ['com.example.myapp'],
+});
+if (app?.role === 'secondary') process.exit(0); // we do not exit for you
+
+const root = await createRoot();
+root.render(<App />);
+```
+
+```jsx
+import { activateWindow, useAppOpen } from 'react-x11';
+
+function App() {
+  const win = useRef(null);
+  useAppOpen((uris, ctx) => {
+    activateWindow(win, { timestamp: ctx.timestamp });
+    const code = new URL(uris[0]).searchParams.get('code');
+    finishLogin(code);
+  });
+  return <window ref={win}>…</window>;
+}
+```
+
+That is the whole runtime half. What follows is why each line is shaped the
+way it is.
+
+### `registerApplication()`
+
+```ts
+function registerApplication(options: {
+  appId: string;
+  schemes?: string[];
+  onOpen?: (uris: string[], ctx: LaunchContext) => void;
+  onActivate?: (ctx: LaunchContext) => void;
+  onAction?: (name: string, params: unknown[], ctx: LaunchContext) => void;
+  argv?: string[];
+}): Promise<AppRegistration | null>;
+
+interface AppRegistration {
+  readonly role: 'primary' | 'secondary';
+  readonly appId: string;
+  readonly objectPath: string;
+  release(): Promise<void>;
+}
+```
+
+**Call it before `createRoot()`.** On the D-Bus path the bus _started this
+process_ because someone called `Open`, and that call is outstanding while the
+app boots — registering from inside a component answers it with an
+unknown-method error, and the launch is lost.
+
+**`appId` is not a free parameter.** The desktop entry spec ties three things
+to one string: the well-known bus name, the `.desktop` file's basename, and —
+by RFC 8252 §7.1 — the URI scheme. The object path follows from it too, and is
+derived rather than passed: dots become slashes, a slash goes on the front,
+and **a dash becomes an underscore**. `com.example.my-app` is served at
+`/com/example/my_app`; get that wrong and the desktop calls a path you do not
+serve, which looks exactly like nothing happening.
+
+**`null` means there is no session bus** — ssh, a bare `startx`, a container,
+CI, Node 20 without the transport. The app runs as an ordinary single-window
+program. A URI that arrived in `argv` is still delivered to `useAppOpen`: a
+cold-start deep link needs no bus, only a second instance does.
+
+**A malformed `appId` or an unusable scheme throws**, and that is not a hole in
+[the never-throws rule](dbus.md#the-rule-everything-else-is-subordinate-to):
+`null` means "this machine has no bus", and using it for a typo would hide the
+typo on every box without one.
+
+### Two dispatch paths, and why `role` exists
+
+The desktop entry spec makes D-Bus activation sound like the whole story.
+`DBusActivatable=true`, and implementations _should_ ignore `Exec` and send a
+D-Bus message instead. _Should_ — and the most common opener does not.
+
+- **GIO honours it.** `g_app_info_launch_default_for_uri` calls `Open` on the
+  app's well-known name. `gio open`, and most of GNOME, take this path.
+- **`xdg-open`'s generic fallback does not.** It resolves the handler with
+  `xdg-mime query default`, reads the `Exec` key and runs it;
+  `DBusActivatable` is never read on that branch. Chromium shells out to
+  `xdg-open`, and `xdg-open` takes the generic branch on every desktop it
+  cannot identify — which is every WM-only session, react-x11's own persona.
+
+So on half of all desktops **a second copy of your app is spawned with the URI
+in `argv`**, and it has to hand that URI to the first copy and exit. An app
+that only exports the interface opens a second window every time.
+`registerApplication` does both halves, which is why it answers a role:
+
+| `role`        |                                                                    |
+| ------------- | ------------------------------------------------------------------ |
+| `'primary'`   | this process owns the name and will receive `Open`                 |
+| `'secondary'` | another instance owns it; this launch was forwarded — **exit now** |
+
+It does not call `process.exit()` for you. Exiting is an application decision
+and a library that takes it is a library that surprises somebody.
+
+A second launch with **no** URI forwards `Activate` rather than an empty
+`Open`: "the user started the app again" and "the user clicked a link" are
+different events, and an app that cannot tell them apart cannot answer the
+first one properly.
+
+### Delivery: buffered, and replayed
+
+`Open` is answered on the turn it arrives — never when the UI is ready. The
+URIs are buffered and replayed to the **first handler that attaches**, so an
+app whose React tree mounts a second later loses nothing, and an app whose
+first frame is slow does not creep towards the caller's 25-second timeout.
+
+Replay happens once. A second subscriber does not get the same login again.
+
+```ts
+function useAppOpen(
+  handler: (uris: string[], ctx: LaunchContext) => void,
+): void;
+function useAppActivate(handler: (ctx: LaunchContext) => void): void;
+
+// the same two, for code that has no component to hang off
+function onAppOpen(handler): () => void;
+function onAppActivate(handler): () => void;
+
+interface LaunchContext {
+  readonly platformData: Readonly<Record<string, unknown>>;
+  readonly timestamp: number | null;
+  readonly startupId: string | null;
+  readonly activationToken: string | null;
+}
+```
+
+There is **nothing to wrap** — no provider, no prop drilling. An application
+has one identity on the desktop, so the registration is process-global and a
+component library can call these hooks.
+
+`schemes` filters what arrives: a URI whose scheme you did not register is
+dropped before your handler sees it. `file:` is always allowed alongside them,
+because `Open` is also how a file manager says "open this document with you"
+and declaring a custom scheme must not stop your app opening its own files.
+Declaring no schemes at all filters nothing.
+
+### The raise is the part that fails
+
+```ts
+function activateWindow(
+  target?: NtkWindow | DrawnNode | RefObject<…> | number | null,
+  options?: { timestamp?: number | null; source?: 1 | 2 },
+): boolean;
+```
+
+Sends `_NET_ACTIVE_WINDOW` to the root window: source indication, timestamp,
+and this app's currently active toplevel. `target` is anything
+[`windowIdOf()`](elements.md) accepts, or nothing — in which case this app's
+only top-level window is used, its focused one when it has several.
+
+**The timestamp is the whole feature.** Per the startup-notification protocol
+the digits after `_TIME` in a startup id are the X timestamp of the user action
+that triggered the launch, and that timestamp is what a window manager's
+focus-stealing prevention weighs before letting a window come forward. Get it
+wrong and nothing reports an error: the user finishes logging in, the browser
+redirects, your app receives the code correctly, the WM declines, and the
+taskbar entry blinks. Every layer says it worked.
+
+| `timestamp`     |                                                                                                               |
+| --------------- | ------------------------------------------------------------------------------------------------------------- |
+| omitted         | the last input this app saw — EWMH's own definition of the field                                              |
+| `ctx.timestamp` | **what a deep link should pass**: the click in the browser is the user action, not whatever this app last saw |
+| `null`          | `CurrentTime`; legal, and most window managers will decline it                                                |
+
+The return value is whether the request was **issued**, not whether it worked.
+EWMH is explicit that the window manager may refuse and set
+`_NET_WM_STATE_DEMANDS_ATTENTION` instead — that is the blinking taskbar entry,
+it is the WM's call, and no client can tell the difference from here.
+
+## Registration: the half that is not runtime code
+
+react-x11 does **not** write into `~/.local/share` for you. A library that
+edits a user's data directory on import is the kind of thing that surprises
+people, and it cannot work for a system-installed or Flatpak app anyway. Ship
+these from your installer, your package, or a one-line setup command your users
+run.
+
+`~/.local/share/applications/com.example.myapp.desktop` — the basename is tied
+to the bus name by the spec:
+
+```ini
+[Desktop Entry]
+Type=Application
+Name=My App
+Exec=my-app %u
+Icon=com.example.myapp
+DBusActivatable=true
+StartupWMClass=com.example.myapp
+MimeType=x-scheme-handler/com.example.myapp;
+```
+
+`StartupWMClass` must match the `wmClass` prop on your `<window>`, or the
+window manager cannot match the window that appears to the launch that asked
+for it.
+
+Then tell the MIME database it changed:
+
+```bash
+update-desktop-database ~/.local/share/applications
+```
+
+And, so that the bus can _start_ the app when it is not running,
+`~/.local/share/dbus-1/services/com.example.myapp.service`:
+
+```ini
+[D-BUS Service]
+Name=com.example.myapp
+Exec=/usr/bin/my-app
+```
+
+### Checking it by hand
+
+Neither branch below is reachable from `npm test` — the in-process broker has
+no service activation and no security policy — so this is the pass that covers
+them:
+
+```bash
+gio open com.example.myapp://test              # path A: D-Bus activation
+```
+
+```bash
+env -u XDG_CURRENT_DESKTOP xdg-open com.example.myapp://test   # path B: Exec %u
+```
+
+Run each twice: once with the app closed (it should start and handle the link)
+and once with it running (it should come to the front, and no second window
+should appear). `REACT_X11_DEBUG_URI=1` narrates what this module decided —
+with every URI's query and fragment stripped, so the output is safe to paste
+into an issue.
+
+## Security
+
+The URI is attacker-controlled input from an unauthenticated local caller.
+
+- **Scheme squatting is unfixable and expected.** Nothing in the MIME database
+  enforces uniqueness; the last handler to register wins. RFC 8252 §7.1 says as
+  much, which is why §6 requires PKCE for public native clients — **use it**,
+  and do not treat receiving a code as proof of anything. The reverse-domain
+  naming rule is the other half of the mitigation, and it is why `appId` is
+  validated the way it is.
+- **`Open` is callable by any peer on the session bus.** It is not an
+  authenticated entry point. The bus is a per-user socket, not an authorization
+  check. Validate what you receive, and never turn a URI's path into a
+  filesystem path.
+- **`platform_data` is spoofable.** A hostile local process can fabricate a
+  `desktop-startup-id` and make your app raise itself. Same uid, so it is focus
+  theft rather than data loss — but treat `ctx.timestamp` as a hint, not a
+  credential.
+- **On the `xdg-open` path the URI lands in `argv`**, so a code is briefly
+  visible in `/proc/<pid>/cmdline` to processes of the same user. One more
+  reason to point login flows at loopback first; the D-Bus path does not have
+  this property.
+- **Never log the URI.** react-x11 does not: everything on
+  `REACT_X11_DEBUG_URI` goes through a redaction that drops the query, the
+  fragment and any userinfo. Hold your own logging to the same rule — the code
+  is _in_ the URI.
+
+## Over ssh
+
+Both mechanisms only work when the browser runs on the **same host as the
+app**. A URL pasted into your laptop's browser reaches neither a loopback port
+nor a scheme handler on the server you are `ssh -X`'d into. That is not fixable
+here; it is the shape of the problem.
+
+## Deliberately not here
+
+- **`ActivateAction` beyond a correct reply.** Desktop actions (jump-list
+  entries) want a design alongside the global menu. The method answers properly
+  today, and `onAction` is there if you want it — a stub that _errors_ would
+  make a shell conclude the app is broken rather than that the action is
+  unhandled.
+- **Writing `.desktop` files.** See above. A generator belongs with the
+  packaging work ([packaging.md](packaging.md)), not on an import.
+- **A full OAuth client.** This is the transport for a redirect, not a PKCE
+  implementation or a token store.
+- **`http`/`https` handling.** Being the default browser is not this.
+- **Wayland's `xdg-activation` token.** `platform_data.activation-token` is
+  read and exposed on `ctx`, and ignored. There is no Wayland here.

--- a/examples/urischeme.jsx
+++ b/examples/urischeme.jsx
@@ -1,0 +1,149 @@
+// Deep links: the manual harness for `com.example.myapp://…`.
+//
+//   npm run examples:urischeme      # needs an X server / DISPLAY
+//
+// The two branches that matter here are the two a broker cannot fake — a
+// launch that *starts* the process through D-Bus activation, and the
+// `.desktop`/MIME route that `xdg-open` takes — so this is what covers them.
+// The window prints the install snippet it needs and then narrates every
+// launch it receives.
+//
+// The pass, once the two files below exist:
+//
+//   gio open com.example.myapp://test                            # path A
+//   env -u XDG_CURRENT_DESKTOP xdg-open com.example.myapp://test # path B
+//
+// Run each twice — with this closed, and with it running. Closed, it should
+// start and show the link. Running, the link should appear in *this* window
+// and the window should come to the front, with no second copy anywhere.
+//
+// See docs/uri-schemes.md.
+import React, { useRef, useState } from 'react';
+
+import {
+  activateWindow,
+  createRoot,
+  createStyles,
+  registerApplication,
+  useAppActivate,
+  useAppOpen,
+} from '../src/index.js';
+
+const APP_ID = 'com.example.myapp';
+
+const s = createStyles({
+  root: { flexDirection: 'column', padding: 14, gap: 10, flexGrow: 1 },
+  heading: { color: '$text', fontSize: 14 },
+  dim: { color: '$dim', fontSize: 11 },
+  panel: {
+    flexDirection: 'column',
+    gap: 4,
+    padding: 10,
+    backgroundColor: '$background',
+    borderColor: '$track',
+    borderWidth: 1,
+    borderRadius: 6,
+    flexGrow: 1,
+  },
+  line: { color: '$text', fontSize: 11 },
+  empty: { color: '$border', fontSize: 11 },
+});
+
+let registration = null;
+
+// Registration happens **before** createRoot, and before anything renders: on
+// the D-Bus path the bus started this process because someone called `Open`,
+// and that call is outstanding while we boot. Skipped when this file is only
+// being imported, since owning a name on the session bus is not something an
+// import should do.
+if (!process.env.REACT_X11_NO_AUTORUN) {
+  registration = await registerApplication({
+    appId: APP_ID,
+    schemes: [APP_ID],
+  });
+  if (registration?.role === 'secondary') {
+    // The link went to the copy that is already running. Nothing to draw.
+    console.log(`${APP_ID} is already running — link forwarded.`);
+    process.exit(0);
+  }
+}
+
+const INSTALL = [
+  `~/.local/share/applications/${APP_ID}.desktop:`,
+  '  [Desktop Entry]',
+  '  Type=Application',
+  '  Name=react-x11 deep links',
+  // Whatever command actually starts this — an absolute path, since a
+  // launcher has your shell's PATH and not your terminal's.
+  '  Exec=/path/to/npx tsx /path/to/examples/urischeme.jsx %u',
+  '  DBusActivatable=true',
+  `  StartupWMClass=${APP_ID}`,
+  `  MimeType=x-scheme-handler/${APP_ID};`,
+  '',
+  '  update-desktop-database ~/.local/share/applications',
+];
+
+function App() {
+  const win = useRef(null);
+  const [log, setLog] = useState([]);
+  const note = (text) => setLog((all) => [...all, text].slice(-12));
+
+  useAppOpen((uris, ctx) => {
+    note(`Open  ${uris.join(' ')}   (t=${ctx.timestamp ?? 'none'})`);
+    // The timestamp is the whole feature: with the launch's own, the window
+    // manager lets the window come forward. With none, it may decline and
+    // blink the taskbar entry instead.
+    activateWindow(win, { timestamp: ctx.timestamp });
+  });
+
+  useAppActivate((ctx) => {
+    note(`Activate   (t=${ctx.timestamp ?? 'none'})`);
+    activateWindow(win, { timestamp: ctx.timestamp });
+  });
+
+  return (
+    <window
+      ref={win}
+      width={680}
+      height={420}
+      wmClass={APP_ID}
+      title="react-x11 — deep links"
+      style={{ backgroundColor: '$surfaceHover' }}
+    >
+      <box style={s.root}>
+        <text style={s.heading}>
+          {registration
+            ? `owning ${APP_ID} at ${registration.objectPath}`
+            : 'no session bus — argv links only, and no single instance'}
+        </text>
+        <box style={s.panel}>
+          {log.length === 0 ? (
+            <text style={s.empty}>
+              nothing yet — open {APP_ID}://test from another terminal
+            </text>
+          ) : (
+            log.map((line, i) => (
+              <text key={i} style={s.line}>
+                {line}
+              </text>
+            ))
+          )}
+        </box>
+        <box style={s.panel}>
+          {INSTALL.map((line, i) => (
+            <text key={i} style={s.dim}>
+              {line || ' '}
+            </text>
+          ))}
+        </box>
+      </box>
+    </window>
+  );
+}
+
+export default App;
+
+if (!process.env.REACT_X11_NO_AUTORUN) {
+  const root = await createRoot();
+  root.render(<App />);
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "examples:tooltips": "tsx examples/tooltips.jsx",
     "examples:clipboard": "tsx examples/clipboard.jsx",
     "examples:dbus": "tsx examples/dbus.jsx",
+    "examples:urischeme": "tsx examples/urischeme.jsx",
     "filedialog:probe": "node scripts/filedialog-probe.mjs",
     "a11y:probe": "node scripts/a11y-probe.mjs",
     "globalmenu:host": "node scripts/globalmenu-host.mjs",

--- a/src/activate.js
+++ b/src/activate.js
@@ -1,0 +1,168 @@
+// The raise: asking the window manager to bring one of this app's windows to
+// the front, with the timestamp that makes the request legitimate.
+//
+// This is the half of the deep-link story that decides whether a user calls
+// the feature working. The failure mode is not an exception — it is that the
+// user finishes logging in, the browser redirects, the app receives the code
+// correctly, sends `_NET_ACTIVE_WINDOW` with `CurrentTime` because nobody
+// parsed the launch timestamp, the WM's focus-stealing prevention declines,
+// and the taskbar entry blinks. Every layer reports success.
+//
+// So the timestamp is a first-class parameter here rather than an
+// implementation detail, and its default is the value EWMH itself names:
+//
+// > `data.l[1]` — "Client's last user activity timestamp … at the time of the
+// > request"
+//
+// which is exactly what `inputtime.js` already stashes off the event stream.
+// A launch context has something better — the timestamp of the click in the
+// *browser* that redirected here — and that is what a caller passes in.
+//
+// EWMH is explicit that the window manager may refuse, and that its fallback
+// is `_NET_WM_STATE_DEMANDS_ATTENTION`. That is its call, so this reports what
+// was **sent**, never what happened.
+//
+// See docs/uri-schemes.md. Issue #173.
+
+import { inputTime } from './inputtime.js';
+import { liveApps } from './trace-registry.js';
+import { topLevelWindows, windowIdOf } from './windowid.js';
+
+const ACTIVE_WINDOW = '_NET_ACTIVE_WINDOW';
+
+/** `1` is an application asking; `2` is a pager, which we are not. */
+const SOURCE_APPLICATION = 1;
+
+let warnedAboutAmbiguity = false;
+
+/** A ref object → what it holds. Anything else passes through. */
+function deref(target) {
+  if (target && typeof target === 'object' && 'current' in target) {
+    return target.isWindow ? target : target.current;
+  }
+  return target;
+}
+
+/**
+ * The ntk window behind a node, a ref or an ntk window. Recognised by having
+ * both an id and a connection, which is the pair this file needs anyway.
+ */
+function ntkWindowOf(node) {
+  if (!node || typeof node !== 'object') return null;
+  if (typeof node.id === 'number' && node.X) return node;
+  if (node.window?.X) return node.window;
+  if (node.root?.window?.X) return node.root.window;
+  return null;
+}
+
+/**
+ * The connection to send through, when the caller named a window that does not
+ * carry one — a raw XID, or nothing at all.
+ *
+ * One process usually has exactly one. Several is legal (a root per display,
+ * and a borrowed connection stays registered after its root unmounts), so the
+ * tie-break is which of them currently has a window: raising is about a window
+ * on screen, and a connection with none cannot be the one meant. Still
+ * ambiguous after that is a real `null` — an XID means nothing without the
+ * server that issued it.
+ */
+function soleApp() {
+  const apps = liveApps();
+  if (apps.length <= 1) return apps[0] ?? null;
+  const showing = apps.filter((app) => topLevelWindows(app).length > 0);
+  return showing.length === 1 ? showing[0] : null;
+}
+
+/**
+ * Which of this app's windows to raise when the caller did not say.
+ *
+ * The same inference `useTopLevelWindow()` makes, for the same reason: one
+ * top-level window is exact, and the focused one is right when there are
+ * several, because it is the window the user was last in.
+ */
+function inferWindow(app) {
+  const windows = topLevelWindows(app);
+  if (windows.length <= 1) return windows[0] ?? null;
+  const focused = windows.filter((w) => w.events?.windowFocused);
+  if (focused.length === 1) return focused[0];
+  if (process.env.NODE_ENV !== 'production' && !warnedAboutAmbiguity) {
+    warnedAboutAmbiguity = true;
+    console.warn(
+      `react-x11: activateWindow() with no window to raise, and this tree ` +
+        `has ${windows.length} top-level windows with none uniquely ` +
+        'focused — raising the most recently opened. Name the window to be ' +
+        'exact:\n' +
+        '  const win = useRef(null);\n' +
+        '  activateWindow(win, { timestamp });\n' +
+        '  return <window ref={win}>…</window>;',
+    );
+  }
+  return windows[windows.length - 1];
+}
+
+/** This app's currently active toplevel, for EWMH's `data.l[2]`. */
+function currentActive(app) {
+  const focused = topLevelWindows(app).filter((w) => w.events?.windowFocused);
+  return focused.length === 1 ? (windowIdOf(focused[0]) ?? 0) : 0;
+}
+
+/**
+ * Ask the window manager to raise and focus a window.
+ *
+ * ```jsx
+ * useAppOpen((uris, ctx) => {
+ *   activateWindow(win, { timestamp: ctx.timestamp });
+ *   route(uris[0]);
+ * });
+ * ```
+ *
+ * `target` is anything {@link windowIdOf} accepts — a `<window>` ref, a ref to
+ * any node inside it, a live ntk window, a raw XID — or nothing, in which case
+ * this app's only top-level window is used (its focused one, when it has
+ * several).
+ *
+ * `timestamp` is the X server time of the user action being answered.
+ * **Getting this wrong is the whole failure mode of the feature**, so:
+ *
+ * - omitted — the last input this app saw, which is EWMH's own definition of
+ *   the field;
+ * - a number — the launch context's timestamp, which is what a deep link
+ *   should pass: the click in the browser is the user action, not whatever
+ *   this app last saw;
+ * - `null` — `CurrentTime`. Legal, and most window managers will decline it.
+ *
+ * Returns whether the request was **issued**: `false` means there was no
+ * window or no connection to send it through. `true` is not a promise that the
+ * window came forward — EWMH lets the WM refuse and set
+ * `_NET_WM_STATE_DEMANDS_ATTENTION` instead, which is the blinking taskbar
+ * entry, and no client can tell the difference from here.
+ */
+export function activateWindow(target, { timestamp, source } = {}) {
+  const node = deref(target);
+  const wnd = ntkWindowOf(node);
+  const app = node?.app ?? node?.root?.app ?? wnd?.app ?? soleApp();
+
+  const chosen = wnd ?? (windowIdOf(node) === null ? inferWindow(app) : null);
+  const xid = windowIdOf(chosen) ?? windowIdOf(node);
+  const X = ntkWindowOf(chosen)?.X ?? wnd?.X ?? app?.X;
+  const root = X?.display?.screen?.[0]?.root;
+
+  if (!xid || !root || !X.SendClientMessage || !X.InternAtom) return false;
+
+  const when =
+    timestamp === undefined ? (inputTime(app) ?? 0) : (timestamp ?? 0);
+
+  X.InternAtom(false, ACTIVE_WINDOW, (err, atom) => {
+    if (err || !atom) return;
+    // The message goes to the **root** and is *about* our window, which is why
+    // both are arguments. The default event mask is
+    // SubstructureRedirect|SubstructureNotify — what EWMH requires for
+    // messages sent to the root — so it is deliberately not passed.
+    X.SendClientMessage(root, xid, atom, 32, [
+      source ?? SOURCE_APPLICATION,
+      when >>> 0,
+      currentActive(app),
+    ]);
+  });
+  return true;
+}

--- a/src/apphooks.js
+++ b/src/apphooks.js
@@ -1,0 +1,73 @@
+// The two inbound events, as rendering code sees them.
+//
+// Thin on purpose. `application.js` owns the bus, the buffer and the replay;
+// this is the lid that lets a component take a deep link without the app
+// author threading a callback down from the module scope where
+// `registerApplication()` had to be called.
+//
+// There is **nothing to wrap** — the registration is process-global, because
+// an application has one identity on the desktop — so these work in any tree,
+// including a component library's.
+
+import { useEffect, useRef } from 'react';
+
+import { onAppActivate, onAppOpen } from './application.js';
+
+/**
+ * Subscribe without re-subscribing when the handler identity changes.
+ *
+ * The subscription must be installed **once**, on mount: a launch that arrived
+ * before anything was listening is replayed to the first handler that
+ * attaches, and re-subscribing on every render would keep re-arming a drain
+ * that has already happened while doing nothing useful. The handler itself is
+ * read at call time, so a link that arrives three minutes from now runs the
+ * closure from the current render rather than the mounting one.
+ */
+function useLaunchSubscription(subscribe, handler) {
+  const live = useRef(handler);
+  live.current = handler;
+  useEffect(() => subscribe((...args) => live.current?.(...args)), [subscribe]);
+}
+
+/**
+ * The desktop handed this app URIs to open — a `myapp://` link clicked
+ * somewhere else, or a document opened from a file manager.
+ *
+ * ```jsx
+ * function App() {
+ *   const win = useRef(null);
+ *   useAppOpen((uris, ctx) => {
+ *     activateWindow(win, { timestamp: ctx.timestamp });
+ *     const code = new URL(uris[0]).searchParams.get('code');
+ *     finishLogin(code);
+ *   });
+ *   return <window ref={win}>…</window>;
+ * }
+ * ```
+ *
+ * Fires for links that arrived **before the tree mounted** too, which is the
+ * normal case when the bus started this process to deliver one: they are
+ * buffered and replayed to the first handler that attaches.
+ *
+ * `uris` is attacker-controlled input from an unauthenticated local peer —
+ * `Open` is callable by anything on the session bus. Validate before acting,
+ * and never treat a URI's path as a filesystem path. See docs/uri-schemes.md.
+ */
+export function useAppOpen(handler) {
+  useLaunchSubscription(onAppOpen, handler);
+}
+
+/**
+ * The desktop asked this app to come forward with nothing to open — the user
+ * launched it again from the panel while it was already running.
+ *
+ * ```jsx
+ * useAppActivate((ctx) => activateWindow(win, { timestamp: ctx.timestamp }));
+ * ```
+ *
+ * Nothing is raised for you: an app that answers a second launch by opening a
+ * new document should not have to undo a raise first.
+ */
+export function useAppActivate(handler) {
+  useLaunchSubscription(onAppActivate, handler);
+}

--- a/src/application.js
+++ b/src/application.js
@@ -1,0 +1,748 @@
+// `org.freedesktop.Application`: being the app that a `myapp://…` link opens.
+//
+// The concrete flow this exists for: the app opens the system browser for an
+// OAuth login, the provider redirects to `com.example.myapp://auth?code=…`,
+// the desktop routes that URI back to the **already-running** app, and the
+// app's window comes to the front with the code in hand.
+//
+// Four things have to be true and this module owns two of them — dispatch and
+// delivery. Registration (a `.desktop` file claiming
+// `x-scheme-handler/com.example.myapp`) is an install step rather than runtime
+// code and is documented, not executed; the raise is `activate.js`, because it
+// needs an X connection and a window id and this file deliberately has
+// neither.
+//
+// ## Two dispatch paths, and why an app must survive both
+//
+// The desktop entry spec makes D-Bus activation sound like the whole story —
+// `DBusActivatable=true` and implementations "should ignore the `Exec` key".
+// *Should*, and the most common opener does not.
+//
+// - **GIO honours it.** `g_desktop_app_info_launch_uris_with_dbus` calls
+//   `Open`/`Activate` on the app's well-known name with a `platform_data`
+//   dict. `gio open`, and most of GNOME, take this path.
+// - **`xdg-open`'s generic fallback does not.** Its
+//   `open_generic_xdg_x_scheme_handler` resolves the handler with `xdg-mime
+//   query default`, reads the `Exec` key and runs it — `DBusActivatable` is
+//   never read on that path. Chromium shells out to `xdg-open`, and `xdg-open`
+//   takes the generic branch on every desktop it cannot identify, which is
+//   every WM-only session: react-x11's own persona.
+//
+// So **a second copy of the app gets spawned with the URI in `argv`, and it
+// has to hand that URI to the first copy and exit.** An app that only exports
+// the interface opens a second window on half of all desktops. Both halves are
+// `registerApplication()`, which is why it answers `role` rather than a
+// boolean.
+//
+// ## The launch call arrives before the UI exists
+//
+// On the D-Bus path the bus *starts the process* because someone called
+// `Open()`, and that call is outstanding while the app boots. Two consequences
+// shape the code below:
+//
+// - registration happens **before `createRoot`**, not inside a component, or
+//   the launching call is answered with an unknown-method error;
+// - the reply must not wait for the UI. `Open` is answered on the turn it
+//   arrives, the URIs are buffered, and they replay to the first handler that
+//   attaches. "Reply when the window is ready" is a design that gets slower
+//   until it breaks.
+//
+// ## What this file may not import
+//
+// No `react`, no X11. The bus half of this feature is genuinely orthogonal —
+// it would work for any Node GUI toolkit — and it is written to that seam so
+// that extracting it later is a move rather than a rewrite. What keeps it
+// *here* for now is the connection: `RequestName` lands on one socket, and the
+// app's name, its global menu and its portal Request paths have to be the same
+// identity on the same connection (see docs/dbus.md).
+//
+// See docs/uri-schemes.md. Issue #173.
+
+import { loadTransport, sessionBus } from './bus.js';
+import { parseLaunchTime } from './startup.js';
+
+/** The standard interface a D-Bus-activatable application exports. */
+export const APPLICATION_IFACE = 'org.freedesktop.Application';
+
+/**
+ * `RequestName` flags and replies, from the D-Bus specification.
+ *
+ * `DO_NOT_QUEUE` is what makes single-instance detection one round trip: with
+ * it, "somebody else has this name" comes back as a reply code instead of
+ * silently parking us in a queue behind them.
+ */
+const DO_NOT_QUEUE = 0x4;
+const PRIMARY_OWNER = 1;
+const EXISTS = 3;
+const ALREADY_OWNER = 4;
+
+/**
+ * How long the *other* instance gets to accept a forwarded URI.
+ *
+ * Short and explicit, because dbus-native's default is 25 s and its reply
+ * timer is not unref'd — a process whose only remaining job is to exit would
+ * otherwise sit there for half a minute looking hung.
+ */
+const FORWARD_TIMEOUT = 5000;
+
+/**
+ * Schemes an app may not claim through this API.
+ *
+ * Being the default browser or the default file handler is a different feature
+ * with a different threat model, and neither is what a deep link is for. The
+ * list is short on purpose: `mailto:` or `ftp:` are things an app might
+ * legitimately *be*, and refusing them would be this module inventing policy.
+ */
+const RESERVED_SCHEMES = new Set(['http', 'https', 'file']);
+
+/** RFC 3986: `ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )`. */
+const SCHEME_RE = /^[A-Za-z][A-Za-z0-9+.-]*$/;
+
+/** A D-Bus well-known bus name: two or more dot-separated elements. */
+const BUS_NAME_RE = /^[A-Za-z_-][A-Za-z0-9_-]*(\.[A-Za-z_-][A-Za-z0-9_-]*)+$/;
+
+/** Anything that starts like an absolute URI. */
+const HAS_SCHEME_RE = /^([A-Za-z][A-Za-z0-9+.-]*):/;
+
+// --------------------------------------------------------------------------
+// Derivations and validation
+// --------------------------------------------------------------------------
+
+/**
+ * The object path the spec says an app id has, which is not a choice:
+ *
+ * > Starting with the well-known D-Bus name of the application, change all
+ * > dots to slashes, prefix a slash, and if a dash is found, convert it to an
+ * > underscore.
+ *
+ * `org.example.FooViewer` → `/org/example/FooViewer`;
+ * `com.example.my-app` → `/com/example/my_app`. The dash rule is the one
+ * everybody misses, and it fails as "the desktop launched us and then nothing
+ * happened" rather than as an error — a dash is legal in a bus name and
+ * illegal in an object path, so the call goes to a path we do not serve.
+ */
+export function objectPathForAppId(appId) {
+  return `/${appId}`.replaceAll('.', '/').replaceAll('-', '_');
+}
+
+/**
+ * `appId` is three things at once and the spec ties them together: the
+ * well-known bus name, the `.desktop` file's basename, and — by convention and
+ * by RFC 8252 §7.1 — the URI scheme. So it is checked as the strictest of
+ * them, a bus name.
+ *
+ * This **throws**, and that is not a hole in the never-rejects rule: a
+ * malformed app id is a mistake in the source, not a fact about the machine.
+ * Answering `null` would hide it on every box without a session bus and
+ * surface it only on the developer's, which is the worst place for a bug to
+ * be discovered.
+ */
+function checkAppId(appId) {
+  if (typeof appId !== 'string' || !BUS_NAME_RE.test(appId)) {
+    throw new Error(
+      `react-x11: registerApplication({ appId: ${JSON.stringify(appId)} }) — ` +
+        'the app id is the well-known D-Bus name, the .desktop file name and ' +
+        'the URI scheme all at once, so it must be a valid bus name: two or ' +
+        'more dot-separated elements of [A-Za-z_-][A-Za-z0-9_-]*, e.g. ' +
+        '"com.example.myapp".',
+    );
+  }
+  if (appId.length > 255) {
+    throw new Error(
+      `react-x11: registerApplication — the app id is ${appId.length} ` +
+        'characters; D-Bus caps a bus name at 255.',
+    );
+  }
+  return appId;
+}
+
+/** Same contract as {@link checkAppId}: a bad scheme is a source mistake. */
+function checkSchemes(schemes) {
+  if (schemes === undefined) return null;
+  if (!Array.isArray(schemes)) {
+    throw new Error(
+      'react-x11: registerApplication({ schemes }) — expected an array of ' +
+        'scheme names, e.g. ["com.example.myapp"].',
+    );
+  }
+  for (const scheme of schemes) {
+    if (typeof scheme !== 'string' || !SCHEME_RE.test(scheme)) {
+      throw new Error(
+        `react-x11: registerApplication — ${JSON.stringify(scheme)} is not a ` +
+          'scheme name. RFC 3986 wants a letter followed by letters, digits, ' +
+          '"+", "-" or "." — and no colon.',
+      );
+    }
+    if (RESERVED_SCHEMES.has(scheme.toLowerCase())) {
+      throw new Error(
+        `react-x11: registerApplication — "${scheme}" cannot be registered ` +
+          'here. Being the default browser or file handler is a different ' +
+          'feature; a deep link wants a scheme derived from a domain you ' +
+          'control, written in reverse (RFC 8252 §7.1), e.g. ' +
+          '"com.example.myapp".',
+      );
+    }
+  }
+  return schemes.map((scheme) => scheme.toLowerCase());
+}
+
+/**
+ * The scheme of a URI, lowercased, or `null` when the string is not one.
+ *
+ * Deliberately not `new URL()`: this runs on attacker-supplied input from an
+ * unauthenticated local peer, and a parser that throws on some inputs is a
+ * parser every caller has to wrap.
+ */
+export function schemeOf(uri) {
+  if (typeof uri !== 'string') return null;
+  const match = HAS_SCHEME_RE.exec(uri);
+  return match ? match[1].toLowerCase() : null;
+}
+
+/**
+ * The URIs of `list` this app answers for.
+ *
+ * `file:` is always allowed, whatever `schemes` says. `Open` is not only the
+ * deep-link entry point — it is also how a file manager says "open this
+ * document with you", and an app that declared a custom scheme must not
+ * thereby stop opening its own files. An app that declares no schemes at all
+ * gets everything, which is the honest reading of "it has not told us what it
+ * answers for".
+ */
+export function acceptUris(list, schemes) {
+  const uris = (Array.isArray(list) ? list : []).filter(
+    (uri) => typeof uri === 'string' && schemeOf(uri) !== null,
+  );
+  if (!schemes) return uris;
+  const allowed = new Set([...schemes, 'file']);
+  return uris.filter((uri) => {
+    if (allowed.has(schemeOf(uri))) return true;
+    debug(`ignoring ${redactUri(uri)}: not a scheme this app registered`);
+    return false;
+  });
+}
+
+/**
+ * A URI with everything secret taken out of it: no query, no fragment, no
+ * userinfo.
+ *
+ * The whole point of this feature is that an authorization code arrives inside
+ * a URI, so **the URI must never be logged whole** — not by us, and the docs
+ * say not by the app either. What is left identifies the link well enough to
+ * debug a routing problem.
+ */
+export function redactUri(uri) {
+  const text = String(uri);
+  const cut = text.search(/[?#]/);
+  const head = cut < 0 ? text : `${text.slice(0, cut)}…`;
+  // `scheme://user:password@host/…` — the credential is in the authority, and
+  // it survives stripping the query.
+  return head.replace(/(:\/\/)[^/@]*@/, '$1…@');
+}
+
+/**
+ * The debug channel for this module, off unless asked for.
+ *
+ * Its own switch rather than a general one, because *this* output is the one
+ * that has to be safe to paste into an issue: everything that goes through it
+ * has already been through {@link redactUri}.
+ */
+function debug(message) {
+  if (process.env.REACT_X11_DEBUG_URI === '1') {
+    console.error(`react-x11: ${message}`);
+  }
+}
+
+// --------------------------------------------------------------------------
+// platform_data
+// --------------------------------------------------------------------------
+
+/**
+ * Whatever the wire produced for an `a{sv}`, as a plain object.
+ *
+ * dbus-native's defaults already hand back exactly that, so this is normally
+ * one `Object.entries` pass. It tolerates the other shapes because
+ * `setValueShapes()` is process-global and app policy (docs/dbus.md): an app
+ * that flips it for its own service must not silently break the launch path.
+ */
+function plainDict(value) {
+  const out = Object.create(null);
+  if (!value || typeof value !== 'object') return out;
+  const entries = Array.isArray(value)
+    ? value.filter((e) => Array.isArray(e) && e.length >= 2)
+    : Object.entries(value);
+  for (const [key, raw] of entries) out[String(key)] = plainValue(raw);
+  return out;
+}
+
+/** A variant in any of the three shapes dbus-native can produce, unwrapped. */
+function plainValue(value) {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    // `new Variant(signature, value)`
+    if ('signature' in value && 'value' in value) return value.value;
+    return value;
+  }
+  // the classic `[signatureTree, [value]]` pair
+  if (Array.isArray(value) && value.length === 2 && Array.isArray(value[1])) {
+    return value[1].length === 1 ? value[1][0] : value[1];
+  }
+  return value;
+}
+
+/**
+ * The launch context a handler is given.
+ *
+ * **Everything on it is untrusted.** `Open` is callable by any peer on the
+ * session bus — it is a per-user socket, not an authorization check — so a
+ * hostile local process can fabricate a `desktop-startup-id` and make the app
+ * raise itself. That is focus theft rather than data loss, and it is the
+ * reason the timestamp is documented as a hint rather than a credential.
+ */
+function launchContext(platformData) {
+  const data = plainDict(platformData);
+  const startupId =
+    typeof data['desktop-startup-id'] === 'string'
+      ? data['desktop-startup-id']
+      : null;
+  const token =
+    typeof data['activation-token'] === 'string'
+      ? data['activation-token']
+      : null;
+  return Object.freeze({
+    platformData: Object.freeze(data),
+    // The `_TIME` suffix of the startup id is the X timestamp of the user
+    // action that triggered the launch — the same parse startup notification
+    // does, and the value the window manager weighs before letting a window
+    // come forward.
+    timestamp: parseLaunchTime(startupId),
+    startupId,
+    /** Read, exposed, and ignored: there is no Wayland here. */
+    activationToken: token,
+  });
+}
+
+/** The environment's version of the same thing, for a command-line launch. */
+function environmentContext() {
+  const data = {};
+  // Read, never deleted. `beginStartup()` consumes DESKTOP_STARTUP_ID for the
+  // startup sequence and must still find it — registration runs first.
+  if (process.env.DESKTOP_STARTUP_ID) {
+    data['desktop-startup-id'] = process.env.DESKTOP_STARTUP_ID;
+  }
+  if (process.env.XDG_ACTIVATION_TOKEN) {
+    data['activation-token'] = process.env.XDG_ACTIVATION_TOKEN;
+  }
+  return launchContext(data);
+}
+
+// --------------------------------------------------------------------------
+// Handlers, and the buffer in front of them
+// --------------------------------------------------------------------------
+
+/**
+ * One registration per process, because an application has one identity on the
+ * desktop. Module state rather than a context, for the same reason
+ * `launchTimestamp()` is: `useAppOpen()` has to reach it from inside a tree
+ * that was mounted after the launch it is asking about.
+ */
+let current = null;
+
+const openHandlers = new Set();
+const activateHandlers = new Set();
+
+/**
+ * Calls that arrived before anything was listening.
+ *
+ * Drained by the **first** handler to attach and then gone — replaying to
+ * every later subscriber would deliver one login twice.
+ */
+let buffered = [];
+
+/**
+ * Run app code detached from the D-Bus reply.
+ *
+ * Two things this buys, both of which are the difference between a working
+ * launch and a mysterious one: the reply goes out on the turn the call
+ * arrived, however long the handler takes; and a handler that throws stays the
+ * app's problem instead of becoming an error reply to a desktop that has no
+ * idea what to do with it.
+ */
+function dispatch(fn) {
+  queueMicrotask(() => {
+    try {
+      fn();
+    } catch (err) {
+      // Not swallowed: an app whose deep-link handler throws would otherwise
+      // see nothing at all, and there is no React boundary above a D-Bus call.
+      console.error('react-x11: a handler for an app launch threw', err);
+    }
+  });
+}
+
+function deliver(event) {
+  const handlers = event.kind === 'open' ? openHandlers : activateHandlers;
+  if (handlers.size === 0) {
+    buffered.push(event);
+    return;
+  }
+  for (const handler of [...handlers]) {
+    dispatch(() =>
+      event.kind === 'open'
+        ? handler(event.uris, event.ctx)
+        : handler(event.ctx),
+    );
+  }
+}
+
+function drainTo(kind, handler) {
+  if (buffered.length === 0) return;
+  const mine = buffered.filter((event) => event.kind === kind);
+  if (mine.length === 0) return;
+  buffered = buffered.filter((event) => event.kind !== kind);
+  for (const event of mine) {
+    dispatch(() =>
+      kind === 'open' ? handler(event.uris, event.ctx) : handler(event.ctx),
+    );
+  }
+}
+
+/**
+ * Be told when the desktop hands this app URIs to open.
+ *
+ * ```js
+ * const stop = onAppOpen((uris, ctx) => {
+ *   activateWindow(null, { timestamp: ctx.timestamp });
+ *   route(uris[0]);
+ * });
+ * ```
+ *
+ * Anything that arrived before the first handler attached is replayed to it,
+ * so an app whose React tree mounts a second after the launch loses nothing.
+ * Safe to call with no registration and no bus — it simply never fires.
+ */
+export function onAppOpen(handler) {
+  if (typeof handler !== 'function') return () => {};
+  openHandlers.add(handler);
+  drainTo('open', handler);
+  return () => openHandlers.delete(handler);
+}
+
+/**
+ * Be told when the desktop asks this app to come forward with nothing to open
+ * — a second launch from the panel, or `gio launch` on a running app.
+ *
+ * The handler is what raises the window; nothing is raised for you, because
+ * this module has no X connection and an app that wants to answer differently
+ * (a new document, say) should not have to undo a raise first.
+ */
+export function onAppActivate(handler) {
+  if (typeof handler !== 'function') return () => {};
+  activateHandlers.add(handler);
+  drainTo('activate', handler);
+  return () => activateHandlers.delete(handler);
+}
+
+// --------------------------------------------------------------------------
+// The exported interface
+// --------------------------------------------------------------------------
+
+/**
+ * `org.freedesktop.Application`, as the desktop entry spec defines it.
+ *
+ * All three methods answer with nothing and answer immediately. `Open`'s
+ * `uris` are filtered before the app sees them; `ActivateAction` is a
+ * deliberate stub — the desktop-actions half wants a design alongside the
+ * global menu — but it is a stub that *replies correctly*, which is the
+ * difference between an unimplemented action and a shell that thinks the app
+ * is broken.
+ */
+function defineApplication(dbus, { schemes, onAction }) {
+  return dbus.defineInterface({
+    name: APPLICATION_IFACE,
+    methods: {
+      Activate: {
+        in: { platform_data: 'a{sv}' },
+        out: {},
+        handler: ({ platform_data: platformData }) => {
+          deliver({ kind: 'activate', ctx: launchContext(platformData) });
+        },
+      },
+      Open: {
+        in: { uris: 'as', platform_data: 'a{sv}' },
+        out: {},
+        handler: ({ uris, platform_data: platformData }) => {
+          const accepted = acceptUris(uris, schemes);
+          debug(
+            `Open(${accepted.map(redactUri).join(', ')}) from the session bus`,
+          );
+          deliver({
+            kind: 'open',
+            uris: accepted,
+            ctx: launchContext(platformData),
+          });
+        },
+      },
+      ActivateAction: {
+        in: {
+          action_name: 's',
+          parameter: 'av',
+          platform_data: 'a{sv}',
+        },
+        out: {},
+        handler: ({
+          action_name: name,
+          parameter,
+          platform_data: platformData,
+        }) => {
+          if (!onAction) return;
+          const ctx = launchContext(platformData);
+          dispatch(() => onAction(name, parameter ?? [], ctx));
+        },
+      },
+    },
+  });
+}
+
+// --------------------------------------------------------------------------
+// Registration
+// --------------------------------------------------------------------------
+
+/**
+ * Own this app's name on the session bus, export
+ * `org.freedesktop.Application` on it, and answer whether this process is the
+ * app or a second copy of it.
+ *
+ * ```js
+ * const app = await registerApplication({
+ *   appId: 'com.example.myapp',
+ *   schemes: ['com.example.myapp'],
+ * });
+ * if (app?.role === 'secondary') process.exit(0);   // we do not exit for you
+ * const root = await createRoot();
+ * ```
+ *
+ * **Call it before `createRoot`.** On the D-Bus path the bus started this
+ * process *because* someone called `Open`, and that call is outstanding while
+ * the app boots; registering from inside a component answers it with an
+ * unknown-method error.
+ *
+ * `null` means there is no session bus — ssh, a bare `startx`, a container,
+ * CI, Node 20 without the transport. The app runs as an ordinary
+ * single-window program, and a URI that arrived in `argv` is still delivered
+ * to {@link onAppOpen}: a cold-start deep link does not need a bus, only a
+ * second one does.
+ *
+ * It never rejects for anything about the machine. It does throw for a
+ * malformed `appId` or an unusable `scheme`, which are mistakes in the source
+ * — see {@link checkAppId}.
+ */
+export async function registerApplication(options = {}) {
+  const { onOpen, onActivate, onAction } = options;
+  const appId = checkAppId(options.appId);
+  const schemes = checkSchemes(options.schemes);
+  const objectPath = objectPathForAppId(appId);
+
+  if (current) {
+    // An app has one identity; two registrations would be two RequestNames and
+    // two exports on the same path, with the second silently replacing the
+    // first. The same id answers the existing registration and **ignores the
+    // rest of the options** — a double call cannot corrupt anything, and a
+    // second set of handlers belongs on `onAppOpen()` where adding one is what
+    // the function is for.
+    if (current.appId === appId) return current;
+    throw new Error(
+      `react-x11: registerApplication("${appId}") — this process is already ` +
+        `registered as "${current.appId}". An application has one identity ` +
+        'on the bus; release() the first registration to change it.',
+    );
+  }
+
+  if (typeof onOpen === 'function') onAppOpen(onOpen);
+  if (typeof onActivate === 'function') onAppActivate(onActivate);
+
+  // The URIs this launch carried on the command line, before any of the bus
+  // work: they are equally real whether we turn out to be the first copy of
+  // the app or the second, and whether or not there is a bus at all.
+  const argv = Array.isArray(options.argv)
+    ? options.argv
+    : process.argv.slice(2);
+  const uris = acceptUris(argv, schemes);
+
+  const ref = await sessionBus();
+  if (!ref) {
+    // No bus is a first-class configuration, not a degraded one. This process
+    // is the app because it is the only one that can be.
+    if (uris.length > 0) {
+      debug(`no session bus; delivering ${uris.length} URI(s) from argv`);
+      deliver({ kind: 'open', uris, ctx: environmentContext() });
+    }
+    return null;
+  }
+
+  let dbus;
+  try {
+    dbus = await loadTransport();
+  } catch {
+    // Unreachable in practice — `sessionBus()` already loaded it — but this
+    // module must not be the one thing that turns a missing optional
+    // dependency into a crash.
+    await ref.release();
+    return null;
+  }
+
+  const iface = defineApplication(dbus, { schemes, onAction });
+
+  // **Export before requesting the name.** The daemon queues the activating
+  // `Open` call against the well-known name and delivers it the instant we own
+  // it; an object exported one await later is an object that did not exist
+  // when the launch arrived, and the launcher gets UnknownMethod. Exporting
+  // first costs nothing if we turn out to be the second copy — nobody can
+  // route to us under a name we do not hold.
+  let registration;
+  try {
+    registration = await ref.bus.export(objectPath, iface);
+  } catch (cause) {
+    // The path is derived from an id that has already been validated, so this
+    // is a transport-level failure rather than a caller error — and a caller
+    // whose deep links do not work must still get an app that runs.
+    debug(`exporting ${objectPath} failed: ${cause?.message ?? cause}`);
+    await ref.release();
+    return null;
+  }
+
+  let reply;
+  try {
+    reply = await ref.bus.requestName(appId, DO_NOT_QUEUE);
+  } catch (cause) {
+    debug(`RequestName(${appId}) failed: ${cause?.message ?? cause}`);
+    await registration.remove().catch(() => {});
+    await ref.release();
+    return null;
+  }
+
+  const primary = reply === PRIMARY_OWNER || reply === ALREADY_OWNER;
+
+  if (!primary) {
+    // The first copy of the app is running; hand it what we were launched with
+    // and become nothing. `DO_NOT_QUEUE` is what makes this one round trip:
+    // without it the daemon parks us behind the owner and answers 2 instead,
+    // which is a state with no useful behaviour attached to it.
+    debug(
+      reply === EXISTS
+        ? `${appId} is owned by another instance`
+        : `RequestName(${appId}) answered ${reply}; not the primary owner`,
+    );
+    await registration.remove().catch(() => {});
+    await forward(ref, dbus, { appId, objectPath, uris });
+    await ref.release();
+    const secondary = {
+      role: 'secondary',
+      appId,
+      objectPath,
+      async release() {},
+    };
+    secondary[Symbol.asyncDispose] = () => secondary.release();
+    return secondary;
+  }
+
+  if (uris.length > 0) {
+    // Launched from the command line *with* a link — `xdg-open`'s path, and
+    // the cold start of the D-Bus one. Same delivery as a bus call, so an app
+    // handles one code path instead of two.
+    debug(`launched with ${uris.length} URI(s) in argv`);
+    deliver({ kind: 'open', uris, ctx: environmentContext() });
+  }
+
+  let released = false;
+  const primaryRegistration = {
+    role: 'primary',
+    appId,
+    objectPath,
+    /**
+     * Give the name back and stop serving. Rare: a registration normally lives
+     * as long as the process, and the bus ref it holds is what keeps the
+     * process alive while there is a name to answer for.
+     *
+     * Idempotent on its own flag rather than on `current`, so that a test seam
+     * that forgot the registration cannot turn this into a no-op that leaks
+     * the bus ref — a held ref is a `ref()`d socket and a process that never
+     * exits.
+     */
+    async release() {
+      if (released) return;
+      released = true;
+      if (current === primaryRegistration) current = null;
+      await ref.bus.releaseName(appId).catch(() => {});
+      await registration?.remove().catch(() => {});
+      registration = null;
+      await ref.release();
+    },
+  };
+  primaryRegistration[Symbol.asyncDispose] = () =>
+    primaryRegistration.release();
+  current = primaryRegistration;
+  return primaryRegistration;
+}
+
+/**
+ * Hand this launch to the copy of the app that owns the name.
+ *
+ * `Open` when there is something to open, `Activate` when there is not —
+ * "the user started the app again" and "the user clicked a link" are different
+ * events, and an app that treats a second launch as an empty `Open` cannot
+ * tell them apart.
+ *
+ * **Auto-start is deliberately left on here**, which is the opposite of the
+ * rule `globalmenu.js` follows. There, starting the service we are talking to
+ * would be actively harmful; here, the owner exiting between our `RequestName`
+ * and this call is exactly the case where launching a fresh instance to handle
+ * the URI is the right outcome rather than a bug.
+ */
+async function forward(ref, dbus, { appId, objectPath, uris }) {
+  const platformData = {};
+  for (const [key, value] of Object.entries(
+    environmentContext().platformData,
+  )) {
+    platformData[key] = new dbus.Variant('s', String(value));
+  }
+  const call =
+    uris.length > 0
+      ? { member: 'Open', signature: 'asa{sv}', body: [uris, platformData] }
+      : { member: 'Activate', signature: 'a{sv}', body: [platformData] };
+  debug(
+    `another instance owns ${appId}; forwarding ${call.member}` +
+      (uris.length ? ` (${uris.map(redactUri).join(', ')})` : ''),
+  );
+  try {
+    await ref.bus.invoke(
+      {
+        destination: appId,
+        path: objectPath,
+        interface: APPLICATION_IFACE,
+        member: call.member,
+        signature: call.signature,
+        body: call.body,
+      },
+      { timeout: FORWARD_TIMEOUT },
+    );
+  } catch (cause) {
+    // The owner died in the window between the two calls, or refuses the
+    // interface. Nothing left to try: we do not own the name, so we cannot
+    // serve the link either. Reported rather than thrown — the caller's job is
+    // still to exit.
+    debug(`forwarding to ${appId} failed: ${cause?.message ?? cause}`);
+  }
+}
+
+/** This process's registration, or `null`. Not public; the docs use `role`. */
+export function currentRegistration() {
+  return current;
+}
+
+/** Test seam, not public: forget every handler, buffer and registration. */
+export function _resetApplicationState() {
+  current = null;
+  openHandlers.clear();
+  activateHandlers.clear();
+  buffered = [];
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -18,6 +18,7 @@ export * from './types/elements.js';
 export * from './types/components.js';
 export * from './types/globalmenu.js';
 export * from './types/dbus.js';
+export * from './types/application.js';
 export * from './types/filedialog.js';
 export * from './types/appearance.js';
 

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,13 @@ export { createRoot, Renderer } from './Reconciler.js';
 export { createStyles, flattenStyle } from './styles.js';
 export { windowIdOf, useWindowId, useTopLevelWindow } from './windowid.js';
 export { launchTimestamp, notifyStartupComplete } from './startup.js';
+export { activateWindow } from './activate.js';
+export {
+  onAppActivate,
+  onAppOpen,
+  registerApplication,
+} from './application.js';
+export { useAppActivate, useAppOpen } from './apphooks.js';
 export { parseUriList } from './transfer.js';
 export { useApp, useClipboard, useSupports } from './appcontext.js';
 export { BusUnavailableError, closeBus, sessionBus, systemBus } from './bus.js';

--- a/src/trace-registry.js
+++ b/src/trace-registry.js
@@ -23,6 +23,18 @@ export function unregisterApp(app) {
 }
 
 /**
+ * The connections the renderer currently draws through.
+ *
+ * A snapshot, in registration order. `activate.js` uses it to answer "which
+ * server issued this XID" when a caller names a window by number and nothing
+ * else — one process usually has exactly one connection, and when it has
+ * several a bare XID is genuinely ambiguous.
+ */
+export function liveApps() {
+  return [...apps];
+}
+
+/**
  * Call `fn` for every current connection and every future one, until the
  * returned function is called. This is how a trace with no explicit `app`
  * follows the renderer: `createRoot()` may not have connected yet when the

--- a/src/types/application.d.ts
+++ b/src/types/application.d.ts
@@ -1,0 +1,173 @@
+/**
+ * Custom URI schemes and single-instance launches:
+ * `registerApplication()`, `useAppOpen()` and the raise an inbound link
+ * needs. See docs/uri-schemes.md.
+ */
+
+import type { DrawnNode, NtkWindow } from './nodes.js';
+import type { RefObject } from 'react';
+
+/**
+ * What the desktop said about the launch this handler is answering.
+ *
+ * **Every field is untrusted.** `org.freedesktop.Application.Open` is callable
+ * by any peer on the session bus — a per-user socket, not an authorization
+ * check — so a hostile local process can fabricate all of it. The timestamp in
+ * particular is a hint, not a credential: the worst it buys an attacker is
+ * making this app steal its own focus.
+ */
+export interface LaunchContext {
+  /** `platform_data` as received, with variants unwrapped. */
+  readonly platformData: Readonly<Record<string, unknown>>;
+  /**
+   * The X server timestamp of the user action behind the launch, from the
+   * `_TIME` suffix of `desktop-startup-id`, or `null`.
+   *
+   * This is the value {@link activateWindow} wants. `null` is a real answer —
+   * a launch from a shell has no timestamp — and `0` is not a substitute for
+   * it: EWMH gives zero its own meaning.
+   */
+  readonly timestamp: number | null;
+  /** `desktop-startup-id`, unparsed, or `null`. */
+  readonly startupId: string | null;
+  /** `activation-token`. Read and exposed; there is no Wayland here. */
+  readonly activationToken: string | null;
+}
+
+export interface ApplicationOptions {
+  /**
+   * The well-known D-Bus name, the `.desktop` file's basename and the URI
+   * scheme, all at once — the desktop entry spec ties them together. A
+   * malformed one throws: it is a mistake in the source, not a fact about the
+   * machine.
+   */
+  appId: string;
+  /**
+   * The schemes this app answers for. Used to filter what a second instance
+   * forwards and what an inbound `Open` delivers; `file:` is always allowed
+   * alongside them, and omitting this filters nothing.
+   *
+   * `http`, `https` and `file` are refused — being the default browser or file
+   * handler is a different feature. RFC 8252 §7.1 wants a scheme derived from
+   * a domain you control, written in reverse.
+   */
+  schemes?: string[];
+  /** Same as subscribing with {@link onAppOpen}, before anything can arrive. */
+  onOpen?: (uris: string[], ctx: LaunchContext) => void;
+  onActivate?: (ctx: LaunchContext) => void;
+  /**
+   * A desktop action was invoked (`ActivateAction`). Without a handler the
+   * method is a no-op that still replies correctly, which is the difference
+   * between an unimplemented action and an app the shell thinks is broken.
+   */
+  onAction?: (name: string, params: unknown[], ctx: LaunchContext) => void;
+  /**
+   * The launch arguments to look for URIs in. Defaults to
+   * `process.argv.slice(2)`, which is where `Exec=my-app %u` puts them.
+   */
+  argv?: string[];
+}
+
+export interface AppRegistration {
+  /**
+   * `'primary'` — this process owns the name and will receive `Open`.
+   *
+   * `'secondary'` — another instance owns it, this launch's URIs have been
+   * forwarded to it, and the caller should exit. **The library does not exit
+   * for you.**
+   */
+  readonly role: 'primary' | 'secondary';
+  readonly appId: string;
+  /** Derived from `appId`, never passed in — exposed because the dash rule is
+   *  easy to get wrong and fails silently. */
+  readonly objectPath: string;
+  /** Give the name back and stop serving. Idempotent. */
+  release(): Promise<void>;
+  [Symbol.asyncDispose](): Promise<void>;
+}
+
+/**
+ * Own this app's name on the session bus and export
+ * `org.freedesktop.Application` on it.
+ *
+ * ```js
+ * const app = await registerApplication({
+ *   appId: 'com.example.myapp',
+ *   schemes: ['com.example.myapp'],
+ * });
+ * if (app?.role === 'secondary') process.exit(0);
+ * const root = await createRoot();
+ * ```
+ *
+ * **Call it before `createRoot`.** On the D-Bus path the bus started this
+ * process *because* someone called `Open`, and that call is outstanding while
+ * the app boots.
+ *
+ * `null` means there is no session bus — ssh, a bare `startx`, a container,
+ * CI, Node 20 without the transport. The app runs as an ordinary single-window
+ * program, and a URI that arrived in `argv` still reaches {@link onAppOpen}.
+ * It never rejects for anything about the machine; a malformed `appId` or an
+ * unusable scheme throws.
+ */
+export declare function registerApplication(
+  options: ApplicationOptions,
+): Promise<AppRegistration | null>;
+
+/**
+ * The desktop handed this app URIs to open. Returns an unsubscribe function.
+ * Anything that arrived before the first handler attached is replayed to it.
+ */
+export declare function onAppOpen(
+  handler: (uris: string[], ctx: LaunchContext) => void,
+): () => void;
+
+/** The desktop asked this app to come forward with nothing to open. */
+export declare function onAppActivate(
+  handler: (ctx: LaunchContext) => void,
+): () => void;
+
+/** {@link onAppOpen} as rendering code sees it. Nothing to wrap. */
+export declare function useAppOpen(
+  handler: (uris: string[], ctx: LaunchContext) => void,
+): void;
+
+/** {@link onAppActivate} as rendering code sees it. */
+export declare function useAppActivate(
+  handler: (ctx: LaunchContext) => void,
+): void;
+
+export interface ActivateWindowOptions {
+  /**
+   * The X server time of the user action being answered.
+   *
+   * Omitted, the last input this app saw is used — EWMH's own definition of
+   * the field. A deep link should pass `ctx.timestamp` instead: the click in
+   * the browser is the user action, not whatever this app last saw. `null`
+   * sends `CurrentTime`, which most window managers will decline.
+   */
+  timestamp?: number | null;
+  /** EWMH source indication: `1` an application (default), `2` a pager. */
+  source?: 1 | 2;
+}
+
+/**
+ * Ask the window manager to raise and focus a window.
+ *
+ * `target` is anything {@link windowIdOf} accepts, or nothing — in which case
+ * this app's only top-level window is used (its focused one, when it has
+ * several).
+ *
+ * Returns whether the request was **issued**. `true` is not a promise that the
+ * window came forward: EWMH lets the window manager refuse and set
+ * `_NET_WM_STATE_DEMANDS_ATTENTION` instead, and no client can tell the
+ * difference from here.
+ */
+export declare function activateWindow(
+  target?:
+    | NtkWindow
+    | DrawnNode
+    | RefObject<NtkWindow | DrawnNode | null>
+    | number
+    | null,
+  options?: ActivateWindowOptions,
+): boolean;

--- a/src/windowid.js
+++ b/src/windowid.js
@@ -70,8 +70,12 @@ export function useWindowId(ref) {
  * which makes "what windows does this tree have" answerable without the app
  * author wiring anything. Popups are excluded: a `<popup>` is
  * override-redirect and never what a dialog should be transient for.
+ *
+ * Not public: `useTopLevelWindow()` is the shape a component wants.
+ * `activate.js` needs the list itself, to pick the window a raise with no
+ * argument goes to.
  */
-function topLevelWindows(app) {
+export function topLevelWindows(app) {
   if (!app) return [];
   return (app._rootChildren ?? []).filter(
     (node) => node?.isWindow && !node.isPopup && node.window?.id,

--- a/test/application.test.js
+++ b/test/application.test.js
@@ -1,0 +1,546 @@
+// Custom URI schemes (issue #173): being the app a `myapp://…` link opens.
+//
+// Three halves, and they fail in different ways, so they are tested apart:
+//
+// - the **derivations** — an object path with a dash in it, a scheme that is
+//   not ours to claim — which fail silently on a real desktop as "the launcher
+//   started us and then nothing happened";
+// - the **dispatch**, against a real broker: owning the name, answering `Open`
+//   before any UI exists, and a second copy of the app handing over what it
+//   was launched with;
+// - the **raise**, which is the part a user judges the feature by, and which
+//   reports success at every layer while doing nothing if the timestamp is
+//   wrong.
+//
+// Two branches this harness deliberately cannot reach, stated rather than
+// faked: the broker has no service activation and no security policy, so
+// *bus-started* activation and the `.desktop`/MIME registration end to end are
+// manual QA on a real session. The script for that is in docs/uri-schemes.md.
+
+import assert from 'node:assert';
+import { afterEach, describe, test } from 'node:test';
+import React from 'react';
+
+import { _resetBusState, busRefs } from '../src/bus.js';
+import { activateWindow, createRoot, useAppOpen } from '../src/index.js';
+import {
+  _resetApplicationState,
+  acceptUris,
+  objectPathForAppId,
+  onAppActivate,
+  onAppOpen,
+  redactUri,
+  registerApplication,
+} from '../src/application.js';
+import { createMockApp } from './helpers/mock-app.js';
+import { fakeApplication, fakeLauncher } from './helpers/fake-launcher.js';
+import { transportAvailable, until, withBus } from './helpers/with-bus.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+const haveTransport = await transportAvailable();
+const needsBroker = haveTransport
+  ? {}
+  : { skip: 'dbus-native is not installed (expected on Node < 22.12)' };
+
+const APP_ID = 'com.example.myapp';
+const LINK = `${APP_ID}://auth?code=SECRET`;
+
+afterEach(() => _resetApplicationState());
+
+// --------------------------------------------------------------------------
+// The derivations
+// --------------------------------------------------------------------------
+
+describe('the app id is three things at once', () => {
+  test('the object path is derived, including the dash rule', () => {
+    assert.equal(
+      objectPathForAppId('org.example.FooViewer'),
+      '/org/example/FooViewer',
+    );
+    // The one everybody misses: a dash is legal in a bus name and illegal in
+    // an object path, so an app that got this wrong would be called at a path
+    // it does not serve — and see nothing at all.
+    assert.equal(
+      objectPathForAppId('com.example.my-app'),
+      '/com/example/my_app',
+    );
+    assert.equal(
+      objectPathForAppId('com.example.a-b.c-d'),
+      '/com/example/a_b/c_d',
+    );
+  });
+
+  test('a malformed app id throws rather than answering null', async () => {
+    // Not the never-rejects rule: `null` means "no bus here", and using it for
+    // a typo would hide the typo on every machine without a session bus.
+    for (const appId of ['myapp', '', '.com.example', 'com.example.', 42]) {
+      await assert.rejects(
+        () => registerApplication({ appId }),
+        /valid bus name|app id/,
+        `${JSON.stringify(appId)} is not an app id`,
+      );
+    }
+  });
+
+  test('http, https and file are refused; a private scheme is not', async () => {
+    for (const scheme of ['http', 'https', 'file', 'HTTPS']) {
+      await assert.rejects(
+        () => registerApplication({ appId: APP_ID, schemes: [scheme] }),
+        /cannot be registered here/,
+      );
+    }
+    for (const scheme of ['1nvalid', 'has space', 'has:colon', '']) {
+      await assert.rejects(
+        () => registerApplication({ appId: APP_ID, schemes: [scheme] }),
+        /not a scheme name/,
+      );
+    }
+  });
+});
+
+describe('what an app answers for', () => {
+  test('a declared scheme filters, and file: is always allowed', () => {
+    const uris = [
+      LINK,
+      'com.evil.other://take-over',
+      'file:///home/u/notes.md',
+      'not a uri',
+    ];
+    assert.deepEqual(acceptUris(uris, [APP_ID]), [
+      LINK,
+      'file:///home/u/notes.md',
+    ]);
+    // No declaration is not the same as an empty one: an app that never said
+    // what it answers for gets everything that is a URI at all.
+    assert.deepEqual(acceptUris(uris, null), uris.slice(0, 3));
+  });
+
+  test('a URI is never repeated whole — query, fragment and userinfo go', () => {
+    assert.equal(redactUri(LINK), `${APP_ID}://auth…`);
+    assert.equal(redactUri('myapp://cb#token=SECRET'), 'myapp://cb…');
+    assert.equal(
+      redactUri('myapp://user:hunter2@host/path'),
+      'myapp://…@host/path',
+    );
+    assert.equal(redactUri('myapp://project/42'), 'myapp://project/42');
+  });
+});
+
+// --------------------------------------------------------------------------
+// Dispatch and delivery
+// --------------------------------------------------------------------------
+
+describe('against a broker', { concurrency: 1, ...needsBroker }, () => {
+  test('the first copy of the app owns the name and is introspectable', async () => {
+    await withBus(async (address) => {
+      const app = await registerApplication({ appId: APP_ID });
+      assert.equal(app.role, 'primary');
+      assert.equal(app.objectPath, '/com/example/myapp');
+
+      const desktop = await fakeLauncher(address);
+      const names = await desktop.bus.listNames();
+      assert.ok(names.includes(APP_ID), 'the well-known name is ours');
+      const xml = await desktop.introspect(APP_ID);
+      assert.match(xml, /interface name="org.freedesktop.Application"/);
+      assert.match(xml, /method name="Open"/);
+      assert.match(xml, /method name="ActivateAction"/);
+
+      await desktop.stop();
+      await app.release();
+      await until(() => busRefs('session') === 0, 'the app to release the bus');
+    });
+  });
+
+  test('Open reaches a handler that attached after the call', async () => {
+    await withBus(async (address) => {
+      const app = await registerApplication({
+        appId: APP_ID,
+        schemes: [APP_ID],
+      });
+      const desktop = await fakeLauncher(address);
+
+      // Nothing is listening yet — the shape of a bus-started launch, where
+      // the call is what boots the process and React is a second away.
+      await desktop.open(APP_ID, [LINK], {
+        'desktop-startup-id': 'launcher/app.desktop/1-0_TIME12345',
+      });
+
+      const seen = [];
+      onAppOpen((uris, ctx) => seen.push({ uris, ctx }));
+      await until(() => seen.length === 1, 'the buffered link to replay');
+
+      assert.deepEqual(seen[0].uris, [LINK]);
+      // The whole point of the id: this is the timestamp the window manager
+      // weighs before letting a window come forward.
+      assert.equal(seen[0].ctx.timestamp, 12345);
+      assert.equal(seen[0].ctx.startupId, 'launcher/app.desktop/1-0_TIME12345');
+
+      // Drained by the first handler and gone: a second subscriber must not
+      // replay one login twice.
+      const later = [];
+      onAppOpen((uris) => later.push(uris));
+      await tick();
+      assert.deepEqual(later, []);
+
+      await desktop.stop();
+      await app.release();
+    });
+  });
+
+  test('Open takes none, one or many URIs, and answers promptly', async () => {
+    await withBus(async (address) => {
+      const app = await registerApplication({ appId: APP_ID });
+      const seen = [];
+      onAppOpen((uris) => seen.push(uris));
+      const desktop = await fakeLauncher(address);
+
+      const many = [`${APP_ID}://a`, `${APP_ID}://b`, `${APP_ID}://c`];
+      await desktop.open(APP_ID, []);
+      await desktop.open(APP_ID, [LINK]);
+      await desktop.open(APP_ID, many);
+      await until(() => seen.length === 3, 'three Open calls to arrive');
+      assert.deepEqual(seen, [[], [LINK], many]);
+
+      await desktop.stop();
+      await app.release();
+    });
+  });
+
+  test('a missing or malformed _TIME is null, never a throw', async () => {
+    await withBus(async (address) => {
+      const app = await registerApplication({ appId: APP_ID });
+      const seen = [];
+      onAppOpen((uris, ctx) => seen.push(ctx.timestamp));
+      const desktop = await fakeLauncher(address);
+
+      await desktop.open(APP_ID, [LINK], { 'desktop-startup-id': 'no-time' });
+      await desktop.open(APP_ID, [LINK], {
+        'desktop-startup-id': 'x_TIMEnotanumber',
+      });
+      await desktop.open(APP_ID, [LINK]);
+      await until(() => seen.length === 3, 'three launches to arrive');
+      assert.deepEqual(seen, [null, null, null]);
+
+      await desktop.stop();
+      await app.release();
+    });
+  });
+
+  test('Activate is its own event, not an Open with nothing in it', async () => {
+    await withBus(async (address) => {
+      const app = await registerApplication({ appId: APP_ID });
+      const opens = [];
+      const activations = [];
+      onAppOpen((uris) => opens.push(uris));
+      onAppActivate((ctx) => activations.push(ctx));
+      const desktop = await fakeLauncher(address);
+
+      await desktop.activate(APP_ID, {
+        'desktop-startup-id': 'panel_TIME77',
+        'activation-token': 'tok',
+      });
+      await until(() => activations.length === 1, 'the activation to arrive');
+      assert.deepEqual(opens, []);
+      assert.equal(activations[0].timestamp, 77);
+      assert.equal(activations[0].activationToken, 'tok');
+
+      await desktop.stop();
+      await app.release();
+    });
+  });
+
+  test('ActivateAction replies correctly, handler or not', async () => {
+    await withBus(async (address) => {
+      const desktop = await fakeLauncher(address);
+      // A stub that errors is worse than one that does nothing: the shell
+      // concludes the app is broken rather than that the action is unhandled.
+      const bare = await registerApplication({ appId: APP_ID });
+      await desktop.activateAction(APP_ID, 'new-window');
+      await bare.release();
+      _resetApplicationState();
+
+      const seen = [];
+      const app = await registerApplication({
+        appId: APP_ID,
+        onAction: (name, params) => seen.push([name, params]),
+      });
+      await desktop.activateAction(APP_ID, 'new-window');
+      await until(() => seen.length === 1, 'the action to reach the handler');
+      assert.equal(seen[0][0], 'new-window');
+
+      await desktop.stop();
+      await app.release();
+    });
+  });
+
+  test('a second copy hands over its argv and becomes nothing', async () => {
+    await withBus(async (address) => {
+      // The `xdg-open` path: the desktop spawned `my-app com.example.myapp://…`
+      // while a copy was already running. Owning the name from a separate
+      // connection is the only faithful way to be that first copy.
+      const first = await fakeApplication(address, APP_ID);
+      assert.equal(first.nameReply, 1, 'the fake really owns the name');
+
+      const second = await registerApplication({
+        appId: APP_ID,
+        schemes: [APP_ID],
+        argv: ['--frobnicate', LINK, 'com.evil.other://nope'],
+      });
+
+      assert.equal(second.role, 'secondary');
+      await until(() => first.opened.length === 1, 'the URI to be forwarded');
+      // Only the URI, and only the scheme this app registered: forwarding an
+      // arbitrary command line to another process would be a different and
+      // much worse feature.
+      assert.deepEqual(first.opened[0].uris, [LINK]);
+
+      // And it holds nothing: the caller's next line is process.exit(0).
+      await until(
+        () => busRefs('session') === 0,
+        'the second copy to release the bus',
+      );
+
+      await first.stop();
+    });
+  });
+
+  test('a second launch with no link asks the first one to come forward', async () => {
+    await withBus(async (address) => {
+      const first = await fakeApplication(address, APP_ID);
+      const second = await registerApplication({
+        appId: APP_ID,
+        schemes: [APP_ID],
+        argv: [],
+      });
+      assert.equal(second.role, 'secondary');
+      await until(() => first.activated.length === 1, 'an Activate to arrive');
+      assert.deepEqual(first.opened, [], 'not an empty Open');
+      await first.stop();
+    });
+  });
+
+  test('the launch carried in argv reaches the first copy too', async () => {
+    await withBus(async () => {
+      // A cold start through `xdg-open` with nothing else running: this
+      // process is the app *and* the URI is in its argv. Without this the deep
+      // link that started the app is the one link it never sees.
+      const seen = [];
+      onAppOpen((uris) => seen.push(uris));
+      const app = await registerApplication({
+        appId: APP_ID,
+        schemes: [APP_ID],
+        argv: [LINK],
+      });
+      assert.equal(app.role, 'primary');
+      await until(() => seen.length === 1, 'the argv link to be delivered');
+      assert.deepEqual(seen[0], [LINK]);
+      await app.release();
+    });
+  });
+
+  test('two identities in one process is a mistake, and says so', async () => {
+    await withBus(async () => {
+      const app = await registerApplication({ appId: APP_ID });
+      await assert.rejects(
+        () => registerApplication({ appId: 'com.example.other' }),
+        /already registered as "com.example.myapp"/,
+      );
+      await app.release();
+    });
+  });
+
+  test('debug output never carries the secret in a link', async () => {
+    await withBus(async (address) => {
+      const saved = process.env.REACT_X11_DEBUG_URI;
+      process.env.REACT_X11_DEBUG_URI = '1';
+      const written = [];
+      const realError = console.error;
+      console.error = (...args) => written.push(args.join(' '));
+      try {
+        const app = await registerApplication({
+          appId: APP_ID,
+          schemes: [APP_ID],
+        });
+        const desktop = await fakeLauncher(address);
+        await desktop.open(APP_ID, [LINK, 'com.evil.other://take-over']);
+        await tick();
+        await desktop.stop();
+        await app.release();
+      } finally {
+        console.error = realError;
+        if (saved === undefined) delete process.env.REACT_X11_DEBUG_URI;
+        else process.env.REACT_X11_DEBUG_URI = saved;
+      }
+      const all = written.join('\n');
+      assert.ok(all.length > 0, 'the switch produced something to check');
+      assert.ok(!all.includes('SECRET'), `leaked a code:\n${all}`);
+      assert.ok(all.includes(`${APP_ID}://auth`), 'still identifies the link');
+    });
+  });
+});
+
+// --------------------------------------------------------------------------
+// No bus
+// --------------------------------------------------------------------------
+
+/** Run `fn` where `sessionBus()` can only answer `null`. */
+async function withoutBus(fn) {
+  const saved = {
+    addr: process.env.DBUS_SESSION_BUS_ADDRESS,
+    runtime: process.env.XDG_RUNTIME_DIR,
+    platform: process.platform,
+  };
+  delete process.env.DBUS_SESSION_BUS_ADDRESS;
+  delete process.env.XDG_RUNTIME_DIR;
+  // darwin has launchd to fall back to, so there is always an address there.
+  Object.defineProperty(process, 'platform', { value: 'linux' });
+  try {
+    await fn();
+  } finally {
+    Object.defineProperty(process, 'platform', { value: saved.platform });
+    if (saved.addr !== undefined)
+      process.env.DBUS_SESSION_BUS_ADDRESS = saved.addr;
+    if (saved.runtime !== undefined)
+      process.env.XDG_RUNTIME_DIR = saved.runtime;
+    _resetBusState();
+  }
+}
+
+describe('with no session bus', () => {
+  test('registering answers null and an app still renders', async () => {
+    await withoutBus(async () => {
+      // ssh, a bare startx, a container, CI, Node 20 without the transport.
+      assert.equal(await registerApplication({ appId: APP_ID }), null);
+
+      const app = createMockApp();
+      const root = await createRoot({ app });
+      root.render(h('window', { width: 100, height: 50 }, h('box', null)));
+      await tick();
+      assert.equal(app.windows.length, 1, 'the tree mounted anyway');
+      await root.unmount();
+    });
+  });
+
+  test('a cold-start link in argv is delivered without a bus at all', async () => {
+    await withoutBus(async () => {
+      const seen = [];
+      onAppOpen((uris) => seen.push(uris));
+      assert.equal(
+        await registerApplication({
+          appId: APP_ID,
+          schemes: [APP_ID],
+          argv: [LINK],
+        }),
+        null,
+      );
+      await until(() => seen.length === 1, 'the argv link to be delivered');
+      assert.deepEqual(seen[0], [LINK]);
+    });
+  });
+});
+
+// --------------------------------------------------------------------------
+// The raise
+// --------------------------------------------------------------------------
+
+describe('activateWindow', () => {
+  const mount = async (element) => {
+    const app = createMockApp();
+    const root = await createRoot({ app });
+    root.render(element ?? h('window', { width: 200, height: 100 }));
+    await tick();
+    return { app, root };
+  };
+
+  /** The `_NET_ACTIVE_WINDOW` messages this connection sent. */
+  const raises = (app) =>
+    app.clientMessages.filter(
+      (m) => m.type === app._atoms.get('_NET_ACTIVE_WINDOW'),
+    );
+
+  test('goes to the root, about our window, with the timestamp given', async () => {
+    const { app, root } = await mount();
+    const wnd = app.windows[0];
+
+    assert.equal(activateWindow(wnd, { timestamp: 12345 }), true);
+    await tick();
+
+    const [message] = raises(app);
+    assert.ok(message, 'a _NET_ACTIVE_WINDOW went out');
+    // EWMH sends this to the **root**, about the client window — getting the
+    // two the wrong way round is silent and total.
+    assert.equal(message.destination, app.X.display.screen[0].root);
+    assert.equal(message.wid, wnd.id);
+    assert.equal(message.format, 32);
+    assert.equal(message.data[0], 1, 'source indication: an application');
+    assert.equal(message.data[1], 12345);
+    await root.unmount();
+  });
+
+  test('null means CurrentTime, which is the honest zero', async () => {
+    const { app, root } = await mount();
+    activateWindow(app.windows[0], { timestamp: null });
+    await tick();
+    assert.equal(raises(app)[0].data[1], 0);
+    await root.unmount();
+  });
+
+  test('with no window named, the app’s only toplevel is the answer', async () => {
+    const { app, root } = await mount();
+    assert.equal(activateWindow(), true);
+    await tick();
+    assert.equal(raises(app)[0].wid, app.windows[0].id);
+    await root.unmount();
+  });
+
+  test('nothing to raise is false rather than a throw', async () => {
+    const app = createMockApp();
+    const root = await createRoot({ app });
+    // Mounted, but nothing rendered: there is no window, and an app that calls
+    // this from a launch handler before its first frame must not crash.
+    assert.equal(activateWindow(), false);
+    assert.equal(activateWindow(null, { timestamp: 1 }), false);
+    await root.unmount();
+  });
+
+  test('a component raises its own window from a buffered link', async () => {
+    // The shape the docs show, end to end: a launch that arrived before the
+    // tree existed replays into `useAppOpen`, and the handler raises the
+    // window that render produced — with the launch's own timestamp, which is
+    // the only number a window manager will accept as a reason.
+    const received = [];
+
+    function App() {
+      const win = React.useRef(null);
+      useAppOpen((uris, ctx) => {
+        received.push(uris);
+        activateWindow(win, { timestamp: ctx.timestamp });
+      });
+      return h('window', { ref: win, width: 200, height: 100 });
+    }
+
+    await withoutBus(async () => {
+      process.env.DESKTOP_STARTUP_ID = 'launcher/app.desktop/1-0_TIME4242';
+      try {
+        await registerApplication({
+          appId: APP_ID,
+          schemes: [APP_ID],
+          argv: [LINK],
+        });
+      } finally {
+        delete process.env.DESKTOP_STARTUP_ID;
+      }
+
+      const { app, root } = await mount(h(App));
+      await until(() => received.length === 1, 'the link to reach the tree');
+      assert.deepEqual(received[0], [LINK]);
+
+      await until(() => raises(app).length === 1, 'the window to be raised');
+      assert.equal(raises(app)[0].wid, app.windows[0].id);
+      assert.equal(raises(app)[0].data[1], 4242, 'the launch timestamp');
+      await root.unmount();
+    });
+  });
+});

--- a/test/helpers/fake-launcher.js
+++ b/test/helpers/fake-launcher.js
@@ -1,0 +1,147 @@
+// The other side of `org.freedesktop.Application`, twice over.
+//
+// `fakeLauncher()` is the desktop: `gio open` and everything else on GLib's
+// `g_app_info_launch_default_for_uri`, which calls `Open`/`Activate` on the
+// app's well-known name with a `platform_data` dict.
+//
+// `fakeApplication()` is the *first copy of the app* — the one already running
+// when `xdg-open` spawns a second. That case cannot be built out of two
+// `registerApplication()` calls in one process: a registration is per-process
+// because an identity is, and a second call on the same connection would get
+// `ALREADY_OWNER` rather than `EXISTS`. A separate connection owning the name
+// is the only faithful way to be the other instance.
+//
+// **What the broker cannot do**, from its own docs: no security policy and no
+// service activation. So the launch that *starts* the process — the bus
+// calling `Open` on a name it activates from a `.service` file — is not
+// reachable here and is manual QA on a real session; see docs/uri-schemes.md.
+
+import {
+  APPLICATION_IFACE,
+  objectPathForAppId,
+} from '../../src/application.js';
+
+async function client(address) {
+  const dbus = (await import('dbus-native')).default;
+  const bus = dbus.createClient({ busAddress: address });
+  await new Promise((resolve, reject) => {
+    bus.connection.once('connect', resolve);
+    bus.connection.once('error', reject);
+  });
+  await bus.listNames();
+  return { dbus, bus };
+}
+
+/** `{ 'desktop-startup-id': 'x_TIME9' }` → the `a{sv}` the wire wants. */
+function platformData(dbus, values) {
+  const out = {};
+  for (const [key, value] of Object.entries(values ?? {})) {
+    out[key] = new dbus.Variant('s', String(value));
+  }
+  return out;
+}
+
+/**
+ * A desktop that can open links with an app.
+ *
+ * ```js
+ * const desktop = await fakeLauncher(address);
+ * await desktop.open('com.example.myapp', ['com.example.myapp://auth?code=1'], {
+ *   'desktop-startup-id': 'launcher/app/1-0_TIME9876',
+ * });
+ * ```
+ */
+export async function fakeLauncher(address) {
+  const { dbus, bus } = await client(address);
+
+  const call = (appId, member, signature, body) =>
+    bus.invoke({
+      destination: appId,
+      path: objectPathForAppId(appId),
+      interface: APPLICATION_IFACE,
+      member,
+      signature,
+      body,
+      timeout: 4000,
+    });
+
+  return {
+    bus,
+    open: (appId, uris, data) =>
+      call(appId, 'Open', 'asa{sv}', [uris, platformData(dbus, data)]),
+    activate: (appId, data) =>
+      call(appId, 'Activate', 'a{sv}', [platformData(dbus, data)]),
+    activateAction: (appId, name, params = [], data) =>
+      call(appId, 'ActivateAction', 'sava{sv}', [
+        name,
+        params,
+        platformData(dbus, data),
+      ]),
+    introspect: (appId) =>
+      bus.invoke({
+        destination: appId,
+        path: objectPathForAppId(appId),
+        interface: 'org.freedesktop.DBus.Introspectable',
+        member: 'Introspect',
+        signature: '',
+        body: [],
+        timeout: 4000,
+      }),
+    stop: () => bus.close(),
+  };
+}
+
+/**
+ * An instance of the app that is already running: it owns the name and records
+ * what gets forwarded to it.
+ *
+ * ```js
+ * const first = await fakeApplication(address, 'com.example.myapp');
+ * const second = await registerApplication({ appId: 'com.example.myapp', argv });
+ * assert.equal(second.role, 'secondary');
+ * assert.deepEqual(first.opened[0].uris, argv);
+ * ```
+ */
+export async function fakeApplication(address, appId) {
+  const { dbus, bus } = await client(address);
+
+  /** `{ uris, platformData }` per `Open`, in order. */
+  const opened = [];
+  /** `{ platformData }` per `Activate`. */
+  const activated = [];
+
+  const iface = dbus.defineInterface({
+    name: APPLICATION_IFACE,
+    methods: {
+      Activate: {
+        in: { platform_data: 'a{sv}' },
+        out: {},
+        handler: ({ platform_data: data }) => {
+          activated.push({ platformData: data ?? {} });
+        },
+      },
+      Open: {
+        in: { uris: 'as', platform_data: 'a{sv}' },
+        out: {},
+        handler: ({ uris, platform_data: data }) => {
+          opened.push({ uris: uris ?? [], platformData: data ?? {} });
+        },
+      },
+    },
+  });
+
+  const registration = await bus.export(objectPathForAppId(appId), iface);
+  const reply = await bus.requestName(appId, 0);
+
+  return {
+    bus,
+    opened,
+    activated,
+    /** 1 when this fake really is the owner — a test's own premise. */
+    nameReply: reply,
+    async stop() {
+      await registration.remove().catch(() => {});
+      await bus.close();
+    },
+  };
+}

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -22,9 +22,14 @@ import {
   BusUnavailableError,
   Calendar,
   Canvas3D,
+  activateWindow,
   Checkbox,
   closeBus,
   fileDialogBackend,
+  onAppOpen,
+  registerApplication,
+  useAppActivate,
+  useAppOpen,
   NoFileDialogError,
   openFile,
   saveFile,
@@ -707,6 +712,52 @@ function _GlobalMenu() {
   return <MenuBar menus={menus} globalMenu={false} />;
 }
 
+// custom URI schemes: registration, the two inbound events, and the raise
+function _DeepLinks() {
+  const win = useRef<NtkWindow | null>(null);
+
+  useAppOpen((uris, ctx) => {
+    const first: string = uris[0];
+    // `null` is a real answer, and it is what activateWindow takes
+    const when: number | null = ctx.timestamp;
+    const raw: unknown = ctx.platformData['desktop-startup-id'];
+    activateWindow(win, { timestamp: when });
+    void [first, raw, ctx.startupId, ctx.activationToken];
+  });
+  useAppActivate(
+    (ctx) => void activateWindow(win, { timestamp: ctx.timestamp }),
+  );
+
+  async function go() {
+    const app = await registerApplication({
+      appId: 'com.example.myapp',
+      schemes: ['com.example.myapp'],
+      onOpen: (uris) => void uris,
+      onAction: (name, params) => void [name, params],
+    });
+    // null until it is checked — there may be no session bus
+    if (app?.role === 'secondary') return;
+    const path: string | undefined = app?.objectPath;
+    await app?.release();
+
+    // @ts-expect-error — role is a closed set
+    void (app?.role === 'tertiary');
+    // @ts-expect-error — appId is required
+    await registerApplication({ schemes: ['com.example.myapp'] });
+
+    const stop = onAppOpen(() => {});
+    stop();
+
+    const issued: boolean = activateWindow();
+    activateWindow(0x1a00007, { timestamp: null, source: 2 });
+    // @ts-expect-error — EWMH names two source indications
+    activateWindow(win, { source: 3 });
+    void [path, issued];
+  }
+  void go;
+  return null;
+}
+
 // the bus floor: the hooks, the imperative pair, and the `required` overload
 function _Bus() {
   const session: BusHandle = useSessionBus();
@@ -798,6 +849,7 @@ function _Files() {
 
 void _Files;
 void _Bus;
+void _DeepLinks;
 void _Clip;
 void main;
 void grow;

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -189,6 +189,7 @@ const ORDER = [
   'desktop.md',
   'dbus.md',
   'globalmenu.md',
+  'uri-schemes.md',
   'filedialog.md',
   'appearance.md',
   'remote.md',


### PR DESCRIPTION
Closes #173.

A react-x11 app could not be the target of `myapp://…`. This is the runtime half of that — `org.freedesktop.Application` on the shared session connection, single-instance forwarding, and the raise an OAuth redirect actually needs.

## What landed

| | |
|---|---|
| `src/application.js` | the bus half: name ownership, the exported interface, buffering, argv forwarding. **Imports neither react nor X11.** |
| `src/activate.js` | `activateWindow()` — `_NET_ACTIVE_WINDOW` with a timestamp that works |
| `src/apphooks.js` | `useAppOpen()` / `useAppActivate()` |
| `docs/uri-schemes.md` | the page, including the `.desktop` half that is an install step |
| `examples/urischeme.jsx` | `npm run examples:urischeme` — the manual harness for the two paths a broker cannot fake |

```js
const app = await registerApplication({
  appId: 'com.example.myapp',
  schemes: ['com.example.myapp'],
});
if (app?.role === 'secondary') process.exit(0);   // the library does not exit for you
const root = await createRoot();
```

```jsx
useAppOpen((uris, ctx) => {
  activateWindow(win, { timestamp: ctx.timestamp });
  finishLogin(new URL(uris[0]).searchParams.get('code'));
});
```

## The three decisions worth reviewing

**`role`, not a boolean.** Both dispatch paths happen in the field: GIO honours `DBusActivatable` and calls `Open`, while `xdg-open`'s generic branch never reads the key and spawns a second copy with the URI in `argv` — which is every WM-only session, react-x11's own persona. A `'secondary'` forwards its argv URIs and its caller exits. A second launch with *no* URI forwards `Activate` rather than an empty `Open`, because those are different events.

**Export before `RequestName`.** The daemon delivers the queued activating call the instant the name is owned, so an object exported one `await` later gets `UnknownMethod` and the launch is lost. Same family of trap as the derived object path, where a dash must become an underscore.

**The timestamp is the feature.** `_NET_ACTIVE_WINDOW` with `CurrentTime` is declined by focus-stealing prevention, the taskbar entry blinks, and every layer reports success. So it is a first-class parameter, its default is EWMH's own definition of the field (this app's last input), and `activateWindow` returns whether the request was *issued* — never whether it worked, which no client can know.

## Deviations from the issue, called out

- **`useAppActivate` as well as `useAppOpen`.** The issue scopes the hook layer to `useAppOpen` only, but a second launch asking the app to come forward is the flagship single-instance case and it has no React-side answer otherwise. Two thin hooks over one subscription is not the "wider hooks layer" that note was guarding against.
- **Argument errors throw; only the environment answers `null`.** The issue's sketch says "never rejects", and test 7 wants bad schemes "refused at registration" — which `null` cannot express, since it already means "no bus". So a malformed `appId` or an unusable scheme throws and is documented as doing so.
- **`activateWindow` returns `boolean`, not `void`** — "was this even issued", the same shape `announce()` already has.
- **A cold-start link in `argv` is delivered to the primary too**, and with no bus at all. Otherwise the deep link that *started* the app is the one link it never sees.
- **`file:` always passes the scheme filter.** `Open` is also how a file manager says "open this document with you"; declaring a custom scheme must not stop an app opening its own files.
- **No `.desktop` generator.** The issue says it need not pick today; docs carry the snippet and NEXT_STEPS now records the second reason it should exist and the constraint it must respect (never implicit).

## Testing

23 new tests: path derivation including the dash rule, primary/secondary against a real broker, buffer-and-replay drained exactly once, `Open` arities, timestamp parse (`_TIME12345` / absent / malformed), scheme refusal, no-bus, redaction, and the raise — where it is sent, what `null` means, and a component raising its own window from a buffered link.

Full suite green (838), lint, `format:check` and `typecheck` clean; `test/types/api.tsx` grew a `_DeepLinks` case with three `@ts-expect-error`s.

**Two branches this cannot cover, stated rather than faked:** the in-process broker has no service activation and no security policy, so a *bus-started* launch and the `.desktop`/MIME route end to end are manual QA. The recipe is in the docs page and `examples/urischeme.jsx` is built for it.

`website/` deps are not installed here, so `docs:test` was not run — the only website change is one entry in `sync-docs.mjs`'s `ORDER`, and `node scripts/sync-docs.mjs` was run to confirm the page lands at position 16, after globalmenu.

No visual change, so no screenshots.
