### PR TITLE
fix(dnd): an async onDrop that rejects is reported, not fatal

### DIFF
--- a/docs/drag-and-drop.md
+++ b/docs/drag-and-drop.md
@@ -207,6 +207,26 @@ application the reply is not sent until the handler settles, so a menu can
 decide it. In-app drags do not wait, so only a synchronous answer reaches
 `onDragEnd`.
 
+### When the handler fails
+
+A handler that throws — or returns a promise that rejects — did not store
+what it was given, so **the drop is refused**, exactly as if it had called
+`e.reject()`, and the failure is reported the way every handler throw is
+([events.md](events.md#when-a-handler-throws)): the handler name, the
+element, and the component that rendered it.
+
+Refusing is the part worth knowing about. A `move` source deletes its own
+copy on the strength of being told the drop was taken, so a failed import
+that reported success is how a file goes missing. A later handler on the
+path can still `accept()`; the refusal is the failed one's answer, not the
+whole dispatch's.
+
+An `async` failure is reported when the promise rejects. For a drop from
+another application that is before the protocol reply goes out, so the
+source hears about it. In-app it is after `onDragEnd` has already fired,
+for the same reason nothing else in that path waits — which is why it is
+reported rather than only returned.
+
 ### Sources that ask
 
 A file manager dragging between two filesystems often does not know

--- a/docs/events.md
+++ b/docs/events.md
@@ -63,6 +63,11 @@ react-x11: onClick on <box> in Panel threw. It ran from an X event rather
 than a render, so no error boundary could catch it; dispatch continues.
 ```
 
+`onDrop` is the one handler that may be `async`, and a promise it rejects
+with arrives here too — same message, same channel — rather than becoming an
+unhandled rejection, which node exits on. It also refuses the drop; see
+[drag-and-drop.md](drag-and-drop.md#the-drop).
+
 `createRoot({ onUncaughtError })` takes it over completely, which is the
 point of it being overridable: for a kiosk, crashing loudly is correct.
 

--- a/src/dnd.js
+++ b/src/dnd.js
@@ -526,7 +526,11 @@ export class DropSession {
     // in a drop handler means one thing across both. In-app handlers are
     // dispatched synchronously and not awaited, so only a synchronous
     // answer reaches `onDragEnd` — an async one is too late, exactly as it
-    // is for the rest of the in-app drop path.
+    // is for the rest of the in-app drop path. Not awaited is not the same
+    // as not observed, though: `_dispatchDrop` attaches to whatever a
+    // handler returns even with no `pending` array to collect it, because
+    // an unobserved rejection here is a dead process rather than a late
+    // answer (#203).
     const outcome = { accept: true, action, freeze: false };
     discrete(() => {
       runWithPriority(DiscreteEventPriority, () => {
@@ -546,7 +550,7 @@ export class DropSession {
           outcome,
         );
         Object.assign(drop, extras);
-        this._dispatchDrop(point.windowNode, targetNode, drop, []);
+        this._dispatchDrop(point.windowNode, targetNode, drop);
         this._clearPath();
       });
     })();
@@ -602,6 +606,9 @@ export class DropSession {
       // getData available for retries of other types
     }
 
+    // What XdndFinished waits for. `_dispatchDrop` fills it with promises
+    // whose rejections it has already turned into a reported, refused drop,
+    // so nothing here rejects and `finish` is reached either way.
     const pending = [];
     // What the handler settles on. `accept`/`reject` mean something
     // different at drop time than during a hover — "I took it, doing this"
@@ -731,9 +738,18 @@ export class DropSession {
     }
   }
 
-  /** onDrop dispatch that keeps the handlers' returned promises — the
-   * XdndFinished watchdog needs them, and events.dispatch discards return
-   * values. Same capture → target → bubble walk. */
+  /** onDrop dispatch that observes the handlers' returned promises, and
+   * hands them to a caller that has to *wait* for them —
+   * `events.dispatch` does neither. Same capture → target → bubble walk.
+   *
+   * Observing and waiting are separate, and only the waiting is optional:
+   * `_onDrop` passes `pending` because XdndFinished cannot go out until the
+   * handlers settle, `localDrop` passes nothing because nothing in-app
+   * waits (its `onDragEnd` follows immediately, by design). Observing is
+   * unconditional — an `async onDrop` that throws is a failed drop, and a
+   * failed drop nobody attached to is an unhandled rejection, which under
+   * node's default `--unhandled-rejections=throw` kills the application
+   * (#203). */
   _dispatchDrop(windowNode, targetNode, ev, pending) {
     const events = windowNode.events;
     const nodePath = events._path(targetNode);
@@ -741,9 +757,18 @@ export class DropSession {
       ev.currentTarget = events._public(n);
       try {
         const result = handler(ev);
-        if (result && typeof result.then === 'function') pending.push(result);
+        if (result && typeof result.then === 'function') {
+          // settled first, pushed second: `pending?.push(result.then(…))`
+          // would short-circuit the whole expression when there is no
+          // `pending`, which is the bug this is here to prevent.
+          const settled = result.then(
+            () => {},
+            (error) => this._dropFailed(ev, n, name, error),
+          );
+          pending?.push(settled);
+        }
       } catch (error) {
-        reportHandlerError(n, name, error);
+        this._dropFailed(ev, n, name, error);
       }
     };
     for (const n of nodePath) {
@@ -758,6 +783,21 @@ export class DropSession {
         if (ev.propagationStopped) return;
       }
     }
+  }
+
+  /** A drop handler that failed, whichever way it failed.
+   *
+   * Both halves matter. It is **reported** on the same channel as every
+   * other handler throw, so an `async onDrop` that rejects is as loud as a
+   * synchronous one rather than silent (or, before #203, fatal). And it
+   * **refuses the drop**: the handler did not store what it was given, and
+   * XdndFinished's accepted bit is what a `move` source deletes its own
+   * copy on — reporting success after the handler threw is how a failed
+   * drop turns into lost data. A later handler that succeeds may still
+   * accept, exactly as one may today. */
+  _dropFailed(ev, node, name, error) {
+    ev.reject();
+    reportHandlerError(node, name, error);
   }
 
   // -- edge auto-scroll ----------------------------------------------------

--- a/test/dnd-source.test.js
+++ b/test/dnd-source.test.js
@@ -265,6 +265,122 @@ test('preventDefault in onDragStart cancels: the gesture stays a click', async (
   await x11Root.unmount();
 });
 
+// --- a drop handler that fails ----------------------------------------------
+//
+// The in-app transport awaits nothing, which is a decision about the
+// *answer* (`onDragEnd` cannot wait for a promise it already ran past) and
+// not a licence to drop the promise on the floor. Unobserved, a rejected
+// async `onDrop` is an unhandled rejection, and node has thrown on those
+// since 15 — the package floor is >= 20.19, so it takes the application
+// down. Issue #203.
+
+/** Capture console.error, process.exitCode and any unhandled rejection
+ * around a body — the last one is the failure under test, so it is watched
+ * rather than left to kill the run. */
+async function watched(body) {
+  const errors = [];
+  const rejections = [];
+  const origError = console.error;
+  const origCode = process.exitCode;
+  const onRejection = (reason) => rejections.push(reason);
+  console.error = (...a) => errors.push(a.map(String).join(' '));
+  process.on('unhandledRejection', onRejection);
+  try {
+    await body();
+    // an unhandled rejection is reported after the microtask queue drains,
+    // so give it a macrotask to arrive in
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  } finally {
+    process.off('unhandledRejection', onRejection);
+    console.error = origError;
+    process.exitCode = origCode;
+  }
+  return { errors, rejections };
+}
+
+/** A draggable box and a dropzone that fails the way the test asks for. */
+function failingDrop(onDrop, log) {
+  return h(
+    'window',
+    { width: 400, height: 200 },
+    h('box', {
+      draggable: true,
+      dragData: { 'text/plain': 'payload' },
+      onDragEnd: (e) => log.push(['dragend', e.action, e.dropped]),
+      style: { position: 'absolute', left: 0, top: 0, width: 100, height: 100 },
+    }),
+    h('box', {
+      dropAccept: ['text'],
+      onDrop,
+      style: {
+        position: 'absolute',
+        left: 200,
+        top: 0,
+        width: 150,
+        height: 150,
+      },
+    }),
+  );
+}
+
+test('an async in-app onDrop that rejects is reported, not fatal', async () => {
+  const app = createMockApp();
+  const log = [];
+  const x11Root = await renderMock(
+    app,
+    failingDrop(async () => {
+      throw new Error('the write failed');
+    }, log),
+  );
+  const wnd = app.windows[0];
+
+  const { errors, rejections } = await watched(async () => {
+    down(wnd, 50, 50);
+    move(wnd, 60, 50); // past the threshold
+    move(wnd, 250, 60); // over the dropzone
+    up(wnd, 250, 60);
+    await tick();
+    await tick();
+  });
+
+  assert.deepEqual(rejections, [], 'nothing was left for node to throw on');
+  assert.match(errors.join('\n'), /onDrop on <box>/, 'names what failed');
+  assert.match(errors.join('\n'), /the write failed/, 'and carries the error');
+  assert.ok(
+    log.some((l) => l[0] === 'dragend'),
+    'the gesture still ended cleanly',
+  );
+  await x11Root.unmount();
+});
+
+test('a synchronous in-app onDrop throw refuses the drop', async () => {
+  const app = createMockApp();
+  const log = [];
+  const x11Root = await renderMock(
+    app,
+    failingDrop(() => {
+      throw new Error('boom');
+    }, log),
+  );
+  const wnd = app.windows[0];
+
+  const { errors } = await watched(async () => {
+    down(wnd, 50, 50);
+    move(wnd, 60, 50);
+    move(wnd, 250, 60);
+    up(wnd, 250, 60);
+    await tick();
+  });
+
+  assert.match(errors.join('\n'), /boom/, 'reported');
+  assert.deepEqual(
+    log,
+    [['dragend', null, false]],
+    'a handler that threw did not take the drop, and onDragEnd says so',
+  );
+  await x11Root.unmount();
+});
+
 // --- edge auto-scroll -------------------------------------------------------
 //
 // Driven from the in-app transport because the mechanism is transport

--- a/test/dnd.test.js
+++ b/test/dnd.test.js
@@ -647,6 +647,62 @@ test('a drop handler can refuse at the last moment, and a plain drag asks for no
   }
 });
 
+test('a drop handler that rejects is reported, and the source is told it failed', async () => {
+  // An `async onDrop` that throws did not store what it was given. The
+  // rejection has to be observed (node throws on unhandled ones, #203),
+  // reported like any other handler throw, and — since XdndFinished's
+  // accepted bit is what a `move` source deletes its own copy on — it must
+  // not report success.
+  const { app, srcApp } = await headlessPair();
+  const x11Root = await createRoot({ app });
+  const errors = [];
+  const origError = console.error;
+  const origCode = process.exitCode;
+  const rejections = [];
+  const onRejection = (reason) => rejections.push(reason);
+  console.error = (...a) => errors.push(a.map(String).join(' '));
+  process.on('unhandledRejection', onRejection);
+  try {
+    const instance = await render(
+      React.createElement(
+        'window',
+        { width: 300, height: 200 },
+        React.createElement('box', {
+          dropAccept: ['files'],
+          onDrop: async () => {
+            throw new Error('the import failed');
+          },
+          style: { flexGrow: 1 },
+        }),
+      ),
+      x11Root,
+    );
+    const src = new FakeSource(srcApp);
+    await src.init({ 'text/uri-list': 'file:///tmp/x\r\n' });
+    await settle(app);
+
+    await src.enter(instance.id, ['text/uri-list']);
+    src.position(instance.id, 150, 100, { action: 'XdndActionMove' });
+    await until(srcApp, () => src.statuses().length > 0, 'an XdndStatus');
+    src.drop(instance.id);
+    await until(srcApp, () => src.finished().length > 0, 'XdndFinished');
+
+    assert.deepEqual(rejections, [], 'nothing was left for node to throw on');
+    assert.match(errors.join('\n'), /onDrop on <box>/, 'names what failed');
+    assert.match(errors.join('\n'), /the import failed/, 'carries the error');
+    const fin = src.finished()[0].data;
+    assert.equal(fin[1] & 1, 0, 'the source is not told the move succeeded');
+    assert.equal(fin[2], 0, 'and no action is claimed');
+    await x11Root.unmount();
+  } finally {
+    process.off('unhandledRejection', onRejection);
+    console.error = origError;
+    process.exitCode = origCode;
+    await app.close();
+    await srcApp.close();
+  }
+});
+
 test('more than three types: the offer is read from XdndTypeList', async () => {
   const { app, srcApp } = await headlessPair();
   const x11Root = await createRoot({ app });


### PR DESCRIPTION
Closes #203.

## The bug

`_dispatchDrop` collected handler-returned promises into whatever array it was handed, and one of the two call sites handed it a throwaway:

- **external (XDND)** — `_onDrop` passes a real array and consumes it (`Promise.allSettled(pending).then(finish)`), so a rejection was at least *attached to*;
- **in-app** — `localDrop` passed `[]`, which nothing ever touched again. A rejected `async onDrop` was a genuine unhandled rejection, and `package.json` requires node `>= 20.19`, where `--unhandled-rejections=throw` is the default. Same handler, same event: safely ignored from a file manager, **exit code 1** from a drag that started in the app itself.

## The fix

**Observing the promise is `_dispatchDrop`'s own job now, and unconditional.** The `pending` array means "someone *waits* for these" — XdndFinished cannot go out before the handlers settle — not "someone observes these", so `localDrop` passes nothing and still cannot leak a rejection. No call site can forget again, because there is nothing left to forget.

**A failed handler refuses the drop, whichever way it failed.** The external path was not blameless: `finish` never inspected the settled results, so a rejected `onDrop` still reported `accept` in XdndFinished. That bit is what a **`move`** source deletes its own copy on — a failed import that reports success is how a file goes missing. Both a throw and a rejection now report through `reportHandlerError` (naming the handler, the element and the component, as every other handler throw does) and refuse the drop. A later handler on the path can still `accept()`; the refusal is the failed handler's answer, not the whole dispatch's.

One deliberate non-change: the design note at `src/dnd.js` — in-app handlers "are dispatched synchronously and not awaited, so only a synchronous answer reaches `onDragEnd`" — stands. Not awaiting the promise was always fine; dropping it on the floor was not. So an in-app async failure is *reported* rather than returned, and the docs say so.

## Tests

Three, each verified to fail without the source change:

| test | without the fix |
| --- | --- |
| `an async in-app onDrop that rejects is reported, not fatal` | `failureType: 'unhandledRejection'` — the crash, reproduced |
| `a synchronous in-app onDrop throw refuses the drop` | `onDragEnd` reported `dropped: true` after the handler threw |
| `a drop handler that rejects is reported, and the source is told it failed` (external, wire-level) | nothing logged at all, and `XdndFinished` claimed the move succeeded |

The first two run against the mock app; the third drives the real XDND wire through the two-connection `FakeSource` harness and reads the `XdndFinished` bytes back. Full suite: 937 passing, plus lint, typecheck and prettier.

## Docs

`docs/drag-and-drop.md` gains a **When the handler fails** section under "The drop", and `docs/events.md`'s "When a handler throws" now says where an `async onDrop`'s rejection lands. No API or type change — `onDrop` was already declared `=> void | Promise<void>`.
