### PR TITLE
fix(windows): don't map a <window> the same commit hides

### DIFF
--- a/docs/react-features.md
+++ b/docs/react-features.md
@@ -42,7 +42,7 @@ What differs is anything the DOM used to define for you:
 | `useTransition`, `startTransition`, `useDeferredValue`                     | work, and really do stay responsive                                        |
 | `useLayoutEffect` vs `useEffect`                                           | the difference is real — one paint versus two                              |
 | `<Suspense>`                                                               | works; read [Suspense and Activity](#suspense-and-activity) for `<window>` |
-| `<Activity>`                                                               | works for drawn nodes; known bug around a toplevel `<window>`              |
+| `<Activity>`                                                               | works; `mode="hidden"` around a `<window>` unmaps it                       |
 | Error boundaries                                                           | work — but **where you put one** decides if the window survives            |
 | `<StrictMode>`                                                             | safe to use; effects are not double-invoked on the first mount             |
 | `useId`                                                                    | works; there is very little here to use it for                             |
@@ -227,8 +227,12 @@ lost. Prefer suspending _inside_ a window over suspending the window itself.
 `import()` gets inlined — you keep lazy _evaluation_ but get no code
 splitting; see [packaging.md](packaging.md).
 
-`<Activity>` works for drawn content. Around a toplevel `<window>` it
-currently has a bug — see [Known gaps](#known-gaps).
+`<Activity>` works, and `mode="hidden"` around a toplevel `<window>` reads
+the same way `<Suspense>` does: the window is unmapped, and one mounted
+hidden is never mapped at all — it is created, laid out and kept, but the
+window manager only ever hears about it on the reveal. The same caveat
+applies: what the user did to the window before it was hidden is the window
+manager's to remember, and it may not.
 
 **Testing Suspense**: a promise that settles outside `act()` is not always
 picked up by an `await act()`, because React throttles the commit when a
@@ -372,9 +376,6 @@ unaffected and work normally.
 
 Open bugs where a React feature does not yet mean here what it should:
 
-- [#201](https://github.com/sidorares/react-x11/issues/201) — `<Activity
-mode="hidden">` around a toplevel `<window>` leaves the window **visible**
-  when a window manager is running.
 - [#202](https://github.com/sidorares/react-x11/issues/202) — hiding a
   subtree with `<Suspense>` or `<Activity>` does not move focus out of it, so
   a focused control keeps receiving keystrokes while invisible.

--- a/examples/react-features.jsx
+++ b/examples/react-features.jsx
@@ -740,8 +740,9 @@ export function ActivityPanel() {
 
       <box style={s.spacer} />
       <text style={s.hint}>
-        Around a toplevel {'<window>'} this is issue #201 and does not work yet:
-        the window stays on screen when a window manager is running.
+        Around a toplevel {'<window>'} the same switch unmaps the window — one
+        mounted hidden is never mapped at all, so the window manager first hears
+        about it on the reveal.
       </text>
     </box>
   );

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -27,6 +27,8 @@ import {
   TextInputNode,
   TextAreaNode,
   appearanceChanged,
+  beginWindowMaps,
+  flushWindowMaps,
   flushWindowRestacks,
   windowAttributes,
 } from './nodes.js';
@@ -162,6 +164,10 @@ const HostConfig = {
   },
 
   prepareForCommit() {
+    // …so that a <window> realized during the mutation phase waits to be
+    // mapped until React has finished hiding whatever it hides (nodes.js,
+    // beginWindowMaps)
+    beginWindowMaps();
     traceHooks.commitStart?.();
     return null;
   },
@@ -170,6 +176,9 @@ const HostConfig = {
   // one pass instead of one per insertBefore.
   resetAfterCommit() {
     flushWindowRestacks();
+    // after the restacking, so a subtree of windows arrives on screen in its
+    // final order rather than shuffling once it is up
+    flushWindowMaps();
     traceHooks.commitEnd?.();
     // the AT-SPI bridge flushes its queued tree/state diffs per commit
     a11yHooks.commit?.();

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -104,6 +104,51 @@ const STACK_BELOW = 1;
 // in progress; drained by flushWindowRestacks from resetAfterCommit.
 const pendingRestack = new Set();
 
+// Windows realized during the commit in progress, waiting to be mapped;
+// drained by flushWindowMaps from resetAfterCommit. See beginWindowMaps.
+const pendingMaps = new Set();
+let inCommit = false;
+
+/**
+ * A window maps at the *end* of the commit that realized it, not when
+ * `realize()` runs.
+ *
+ * React inserts a host instance before it hides it: `hideInstance` runs
+ * after the whole mutation phase, so a `<window>` born inside a hidden
+ * `<Activity>` — or inside a `<Suspense>` that suspends on its first render
+ * — used to be mapped and unmapped back to back. That pair is only safe
+ * when nothing redirects the map. Under a window manager holding
+ * SubstructureRedirect on the root the MapWindow is **not performed**: the
+ * server turns it into a MapRequest and leaves the window unmapped, so the
+ * UnmapWindow that follows lands on an already-unmapped window and is
+ * discarded. The window manager then services its MapRequest and the
+ * "hidden" window is on screen for good (issue #201).
+ *
+ * Deferring costs nothing — `resetAfterCommit` runs inside the same
+ * synchronous `render()` — and it means the map is decided at the one
+ * moment when whether the window is hidden is already known.
+ *
+ * Outside a commit (a `<popup>` realized from `commitMount`, which runs in
+ * the layout phase, or one built imperatively like the text controls' edit
+ * menu) there is no such phase to wait for, and no hiding on the way
+ * either: those map immediately.
+ */
+export function beginWindowMaps() {
+  // A commit that never reached `resetAfterCommit` left its queue behind,
+  // and a window that is owed a map had better get one late rather than
+  // never — that failure mode is an application with no windows in it.
+  flushWindowMaps();
+  inCommit = true;
+}
+
+/** Map every window this commit realized and did not then hide. */
+export function flushWindowMaps() {
+  inCommit = false;
+  const nodes = [...pendingMaps];
+  pendingMaps.clear();
+  for (const node of nodes) node._mapNow();
+}
+
 // --- damage -------------------------------------------------------------
 //
 // A frame either repaints the whole window or a bounded region of it. The
@@ -4561,6 +4606,9 @@ export class WindowNode extends Scrollable(Node) {
     this.root = this;
     this.attributes = attributes;
     this.window = null;
+    // whether this is the tree's own top-level window rather than a nested
+    // one or a popup — decided by realize(), read when it maps
+    this._topLevel = false;
     // set by realize() only once the ARGB visual is actually there, so the
     // paint path never assumes an alpha channel the window does not have
     this._transparent = false;
@@ -4818,17 +4866,30 @@ export class WindowNode extends Scrollable(Node) {
     // everything above it: EWMH's guarantee about `_NET_WM_USER_TIME` is
     // about the window's state at the moment it is mapped. First toplevel
     // only — a later `<window>` is not the launch (src/startup.js).
-    if (!parentWindow && !this.isPopup) {
-      this.app._reactX11Startup?.decorate(wnd);
-    }
-    wnd.map?.();
-    if (!parentWindow && !this.isPopup) {
-      this.app._reactX11Startup?.mapped(wnd);
-    }
+    this._topLevel = !parentWindow && !this.isPopup;
+    if (this._topLevel) this.app._reactX11Startup?.decorate(wnd);
+    // Queued rather than mapped, when there is a commit to queue behind:
+    // React hides a subtree only once it has inserted it (beginWindowMaps).
+    if (inCommit) pendingMaps.add(this);
+    else this._mapNow();
     // ask before anything can be anchored to it, so the first popup is
     // placed as well as the second
     this._refreshScreenOrigin();
     this.invalidate(true, null, 'mount');
+  }
+
+  /**
+   * Put the window on screen, unless this commit went on to hide it.
+   *
+   * The only caller that maps a window for the first time is
+   * `flushWindowMaps` (or `realize` itself outside a commit); `setHidden`
+   * comes back through here so that a window born hidden and revealed later
+   * still ends the startup sequence on its real first map.
+   */
+  _mapNow() {
+    if (this.destroyed || !this.window || this.hidden) return;
+    this.window.map?.();
+    if (this._topLevel) this.app._reactX11Startup?.mapped(this.window);
   }
 
   /**
@@ -5638,9 +5699,22 @@ export class WindowNode extends Scrollable(Node) {
     for (const claim of claims) this.invalidate(false, claim, 'animation');
   }
 
+  /**
+   * A window is hidden by unmapping it, not by yoga's `display: none`: it is
+   * its own layout root, so collapsing it would throw away the arrangement
+   * it comes back to — and there is no parent flex line for it to leave.
+   * The flag is still recorded, because it is what tells a map that has not
+   * gone out yet not to bother.
+   */
   setHidden(hidden) {
+    this.hidden = hidden;
+    // A map still queued for the end of this commit reads `hidden` when it
+    // runs, so there is nothing to send here — and an unmap sent now would
+    // do nothing anyway, the server not having mapped the window yet
+    // (issue #201).
+    if (pendingMaps.has(this)) return;
     if (hidden) this.window?.unmap?.();
-    else this.window?.map?.();
+    else this._mapNow();
   }
 
   /**

--- a/test/offscreen.test.js
+++ b/test/offscreen.test.js
@@ -1,0 +1,191 @@
+// `<Activity mode="hidden">` and a `<Suspense>` boundary showing its
+// fallback hide a subtree through the reconciler's `hideInstance`, which
+// React calls *after* it has inserted that subtree. For a toplevel
+// `<window>` that used to mean a MapWindow and an UnmapWindow back to back
+// in one commit — a pair that is only safe when nothing redirects the map
+// (issue #201).
+//
+// So the configuration that matters is the one with a window manager on the
+// other end, and node-x11's in-process server can hold substructure redirect
+// (x11 >= 3.2.0), the same setup test/wm.test.js uses: two connections to
+// one server, one of them playing the window manager.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient, StaticFontSource } from 'ntk';
+
+import { createRoot } from '../src/index.js';
+
+const SCREEN = { width: 800, height: 600 };
+const IS_UNMAPPED = 0;
+const IS_VIEWABLE = 2;
+
+async function headlessPair() {
+  const server = xserver.createServer(SCREEN);
+  const connect = async () => {
+    const [serverEnd, clientEnd] = xserver.createStreamPair();
+    server.addClientStream(serverEnd);
+    return createClient({
+      stream: clientEnd,
+      fontSource: new StaticFontSource(),
+    });
+  };
+  return { server, wmApp: await connect(), clientApp: await connect() };
+}
+
+const settle = (app) =>
+  new Promise((resolve) => app.X.GetInputFocus(() => setImmediate(resolve)));
+
+/**
+ * The smallest thing that counts as a window manager: hold
+ * SubstructureRedirect on the root and honour the MapRequests that arrive
+ * because of it. That redirect is the whole story — it is what turns a
+ * client's MapWindow into a request somebody else services later.
+ */
+async function startWM(app) {
+  const { X } = app;
+  const root = X.display.screen[0].root;
+  const seen = { mapRequests: 0 };
+  await new Promise((resolve, reject) =>
+    X.ChangeWindowAttributes(
+      root,
+      {
+        eventMask:
+          X.eventMask.SubstructureRedirect | X.eventMask.SubstructureNotify,
+      },
+      (err) => (err ? reject(err) : resolve()),
+    ),
+  );
+  X.on('event', (ev) => {
+    if (ev.name !== 'MapRequest') return;
+    seen.mapRequests++;
+    X.MapWindow(ev.wid);
+  });
+  await settle(app);
+  return seen;
+}
+
+const rootChildren = (app) =>
+  new Promise((resolve, reject) =>
+    app.X.QueryTree(app.X.display.screen[0].root, (err, tree) =>
+      err ? reject(err) : resolve(tree.children),
+    ),
+  );
+
+const mapStateOf = (app, wid) =>
+  new Promise((resolve, reject) =>
+    app.X.GetWindowAttributes(wid, (err, attrs) =>
+      err ? reject(err) : resolve(attrs.mapState),
+    ),
+  );
+
+/**
+ * React first, then both connections. A hidden `<Activity>` mounts its
+ * children at a deferred lane, so the commit under test is not the one
+ * `render()` returns from — `act` is what drains it.
+ */
+async function flush(apps, fn) {
+  const previous = globalThis.IS_REACT_ACT_ENVIRONMENT;
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  try {
+    await React.act(async () => {
+      await fn?.();
+    });
+    for (let round = 0; round < 3; round++) {
+      await React.act(async () => {
+        for (const app of apps) await settle(app);
+      });
+    }
+  } finally {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = previous;
+  }
+}
+
+const activity = (mode) =>
+  React.createElement(
+    React.Activity,
+    { mode },
+    React.createElement(
+      'window',
+      { width: 200, height: 120, title: 'activity' },
+      React.createElement('box', {
+        style: { width: 50, height: 20, backgroundColor: '#f00' },
+      }),
+    ),
+  );
+
+/** Mount a hidden `<Activity>` around a toplevel `<window>`, with or
+ * without a window manager, and hand back the pieces to assert on. */
+async function mountHidden({ wm }) {
+  const { wmApp, clientApp } = await headlessPair();
+  const seen = wm ? await startWM(wmApp) : { mapRequests: 0 };
+  const root = await createRoot({ app: clientApp });
+  const apps = [clientApp, wmApp];
+
+  await flush(apps, () => {
+    root.render(activity('hidden'));
+  });
+
+  const wid = (await rootChildren(clientApp)).at(-1) ?? null;
+  assert.ok(wid != null, 'the <window> was created');
+
+  const done = async () => {
+    await root.unmount();
+    await wmApp.close();
+    await clientApp.close();
+  };
+  return { root, apps, clientApp, wid, seen, done };
+}
+
+test('a <window> hidden by <Activity> is never mapped, with no window manager', async () => {
+  const { clientApp, wid, seen, done } = await mountHidden({ wm: false });
+
+  assert.equal(await mapStateOf(clientApp, wid), IS_UNMAPPED);
+  assert.equal(seen.mapRequests, 0);
+
+  await done();
+});
+
+test('a <window> hidden by <Activity> is never mapped under a window manager', async () => {
+  const { clientApp, wid, seen, done } = await mountHidden({ wm: true });
+
+  // The regression: the map used to go out during the commit and come back
+  // as a MapRequest, so the window manager mapped the window for good — the
+  // UnmapWindow that followed had already been discarded, having landed on
+  // a window the server had not mapped.
+  assert.equal(seen.mapRequests, 0, 'nothing was ever asked to be mapped');
+  assert.equal(
+    await mapStateOf(clientApp, wid),
+    IS_UNMAPPED,
+    'the hidden window is not on screen',
+  );
+
+  await done();
+});
+
+test('revealing the <Activity> maps the window, and hiding it again unmaps it', async () => {
+  const { root, apps, clientApp, wid, seen, done } = await mountHidden({
+    wm: true,
+  });
+
+  // its own premise: nothing has been mapped yet, so the count below is
+  // this reveal's and not the mount's
+  assert.equal(seen.mapRequests, 0);
+
+  await flush(apps, () => {
+    root.render(activity('visible'));
+  });
+  assert.equal(seen.mapRequests, 1, 'now it asks');
+  assert.equal(await mapStateOf(clientApp, wid), IS_VIEWABLE);
+
+  // and the ordinary path back: unmapping a window the server really has
+  // mapped is never redirected, so this half always worked
+  await flush(apps, () => {
+    root.render(activity('hidden'));
+  });
+  assert.equal(await mapStateOf(clientApp, wid), IS_UNMAPPED);
+
+  await done();
+});


### PR DESCRIPTION
Fixes #201.

## The bug

`<Activity mode="hidden">` around a toplevel `<window>` produced a **mapped, visible** window as soon as a window manager was present. Without a WM it behaved correctly.

`WindowNode.realize()` sent `MapWindow` and `hideInstance` → `WindowNode.setHidden` sent `UnmapWindow` back to back in one commit — React inserts a host instance before it hides it, since the hide loop runs after the whole mutation phase (`commitMutationEffectsOnFiber`, case 22: `recursivelyTraverseMutationEffects` first, then the hide walk).

That ordering is only safe when nothing redirects the map. Under a WM holding `SubstructureRedirect` on the root, the `MapWindow` is **not performed** — the server emits `MapRequest` and leaves the window unmapped — so the `UnmapWindow` that follows lands on an already-unmapped window and is silently discarded. The WM then services its `MapRequest` and maps the window for good.

## The fix

The map waits for the **end of the commit** and reads `hidden` when it runs.

- `realize()` queues the window instead of mapping it (`pendingMaps`), and `resetAfterCommit` drains the queue — right beside `flushWindowRestacks`, which already exists for the same "once per commit" reason. It runs inside the same synchronous `render()`, so nothing observable is delayed, and a subtree still arrives on screen in its final stacking order.
- Outside a commit — a `<popup>` realized from `commitMount` (the layout phase, after `resetAfterCommit`), or one built imperatively like the text controls' edit menu — there is no phase to wait for and no hiding on the way, so those map immediately as before.
- `WindowNode.setHidden` now records `hidden`. That is what lets a queued map skip itself, and it makes the flag truthful for `_scopeRoot`/`_focusables`/a11y, which already ask.
- Nothing at all goes on the wire for a window mounted hidden: it is created, laid out and kept, but never mapped. The WM first hears about it on the reveal. A window born hidden therefore ends the **startup-notification** sequence on its real first map (`setHidden(false)` routes through the same `_mapNow()`), rather than never.

Unmapping is never redirected, so the reveal → hide path was already correct and stays so.

## Verification

`test/offscreen.test.js` — two connections to node-x11's in-process X server, one playing the window manager (selects `SubstructureRedirect|SubstructureNotify`, honours `MapRequest`), the same shape as the issue's repro and as `test/wm.test.js`:

| | before | after |
| --- | --- | --- |
| MapRequests the WM saw | 1 | **0** |
| `mapState` of the "hidden" window | `2 IsViewable` | **`0 IsUnmapped`** |

The middle test fails on master and passes here; the other two pin the premises (the no-WM path, and that reveal → hide still maps and unmaps).

`npm test` 937/937, lint, typecheck, `npm run bench -- --check` (no regressions) and `website/ npm test` all green.

No screenshots: nothing about this changes how anything is painted — the whole diff is which X requests go out and when.
