### PR TITLE
fix(components): a menu bar item is the same pill as the row it opens

### DIFF
--- a/examples/menu.jsx
+++ b/examples/menu.jsx
@@ -9,6 +9,11 @@
 // Right opens a submenu and Left leaves it, Enter picks, Escape closes one
 // level at a time.
 //
+// **Extremes → Large menu items** is the stress switch: ticking it puts
+// twenty pull-downs on a 520px bar and thirty rows in the File menu, which is
+// how the bar behaves when it is wider than its window and how a menu behaves
+// when it is taller than the screen it is anchored on.
+//
 // **On a desktop with a global menu the bar is not here at all** — it is in
 // the panel, and the app said nothing to make that happen. `menus` is a plain
 // data array in dbusmenu's own vocabulary, so the same array that draws the
@@ -103,9 +108,19 @@ const ICONS = {
   ),
 };
 
+// The extremes, on a switch (the first bar menu's "Large menu items"): a bar
+// of twenty pull-downs on a 520px window, and a menu of thirty rows on a
+// screen that has no room for it. Neither is a shape an example would
+// otherwise reach, and both are shapes a real application arrives at by
+// accident — a bar that has to survive being wider than its window, a menu
+// that has to survive being taller than the display it is anchored on.
+const LARGE_BAR = 20;
+const LARGE_ITEMS = 30;
+
 function App() {
   const [last, setLast] = useState('(none)');
   const [wrap, setWrap] = useState(true);
+  const [large, setLarge] = useState(false);
   // Only so this example can *say* which way it went. An app needs none of
   // it: `<MenuBar menus={menus} />` is the whole integration, and the bar
   // moves to the panel or stays here without the app being told.
@@ -303,6 +318,59 @@ function App() {
     },
   ];
 
+  // The switch, and the first thing on the bar. `toggleType` is what puts a
+  // row in the check column — `'checkmark'` draws the system check, where
+  // `'radio'` would draw a dot — and `toggleState` is dbusmenu's three-state
+  // one rather than a boolean: 0 keeps the column and draws nothing, which is
+  // what stops a menu of toggles from shuffling sideways as they are ticked.
+  const extremes = {
+    label: 'Extremes',
+    items: [
+      {
+        label: 'Large menu items',
+        toggleType: 'checkmark',
+        toggleState: large ? 1 : 0,
+        onSelect: () => {
+          setLarge((v) => !v);
+          setLast('Large menu items');
+        },
+      },
+    ],
+  };
+
+  // Filler, so that what is extreme about the extremes is the *count*: the
+  // same rows with the same handlers, just a great many of them.
+  const filler = (count, name) =>
+    Array.from({ length: count }, (_, i) => ({
+      label: `${name} ${i + 1}`,
+      onSelect: note(`${name} ${i + 1}`),
+    }));
+
+  // Padded rather than replaced, in both directions: File keeps its own rows
+  // and grows to thirty, the bar keeps File/Edit/View and grows to twenty. A
+  // stress mode that threw the real menus away would be testing the filler.
+  const [file, ...rest] = menus;
+  const bar = !large
+    ? [extremes, ...menus]
+    : [
+        extremes,
+        {
+          ...file,
+          items: [
+            ...file.items,
+            ...filler(Math.max(0, LARGE_ITEMS - file.items.length), 'Item'),
+          ],
+        },
+        ...rest,
+        ...Array.from(
+          { length: Math.max(0, LARGE_BAR - (menus.length + 1)) },
+          (_, i) => ({
+            label: `Menu ${i + 1}`,
+            items: filler(3, `Menu ${i + 1} item`),
+          }),
+        ),
+      ];
+
   const contextItems = [
     {
       label: 'Cut',
@@ -344,7 +412,7 @@ function App() {
       style={{ backgroundColor: '$surfaceHover' }}
     >
       <box style={{ flexGrow: 1 }}>
-        <MenuBar menus={menus} onGlobalMenuChange={setInPanel} />
+        <MenuBar menus={bar} onGlobalMenuChange={setInPanel} />
         <ContextMenu
           items={contextItems}
           style={{
@@ -364,6 +432,14 @@ function App() {
           </text>
           <text style={{ color: '$dim' }}>
             wrap lines: {wrap ? 'on' : 'off'}
+          </text>
+          <text style={{ color: '$dim' }}>
+            Extremes → Large menu items:{' '}
+            <text style={{ color: '$accent' }}>
+              {large
+                ? `on — ${bar.length} menus on the bar, ${LARGE_ITEMS} rows in File`
+                : 'off'}
+            </text>
           </text>
           <text style={{ color: '$dim' }}>
             File → Open/Save runs a real dialog, on this machine's{' '}

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -76,6 +76,20 @@ const BAR_INSET = 3;
 // the gap between two pills, split between them
 const BAR_GAP = 1;
 
+// A bar item wears the same pill as a row in the menu it opens, so it takes
+// the row's padding rather than numbers of its own: a title packed tighter
+// than its own first row is the tell that the two were measured separately.
+// Vertically that is `MENU_ITEM_PAD` exactly — same padding, same `capTrim`
+// text — which makes the pill `menuRowHeight` tall, and the bar that much
+// taller for it.
+//
+// Horizontally it takes a little more. A row's label is not `MENU_ITEM_PAD`
+// from the pill's edge but a whole `MENU_GUTTER` in, past the check column,
+// so matching the row's padding here would read as the cramped one: on a
+// strip the pills sit shoulder to shoulder, with nothing but that padding
+// between one label and the next.
+const BAR_ITEM_PAD_X = MENU_ITEM_PAD + 4;
+
 // The horizontal gap between a menu and the submenu it opens, measured from
 // the parent popup's outer edge — so `0` is flush against it, a positive
 // value leaves the desktop showing between the two, and a negative one
@@ -1001,8 +1015,8 @@ export function MenuBar({
           style: [
             {
               cursor: 'pointer',
-              paddingLeft: 10,
-              paddingRight: 10,
+              paddingLeft: BAR_ITEM_PAD_X,
+              paddingRight: BAR_ITEM_PAD_X,
               // The same pill the rows inside the menu wear, at the same
               // radius: the bar item and the first row of the menu it opens
               // are one gesture, and a square title over rounded rows reads
@@ -1010,15 +1024,16 @@ export function MenuBar({
               //
               // The margin is what a radius needs to be seen — a rounded
               // rect flush against the strip's own edges reads as a cut
-              // corner rather than a pill — and it comes out of the padding
-              // rather than being added to it, so the bar is the height it
-              // always was.
+              // corner rather than a pill. It sits *outside* the padding, so
+              // the bar is a menu row plus its two insets tall: the item and
+              // the row below it are then the same pill in the same size,
+              // which is the whole point of giving the bar one.
               marginTop: BAR_INSET,
               marginBottom: BAR_INSET,
               marginLeft: BAR_GAP,
               marginRight: BAR_GAP,
-              paddingTop: 6 - BAR_INSET,
-              paddingBottom: 6 - BAR_INSET,
+              paddingTop: MENU_ITEM_PAD,
+              paddingBottom: MENU_ITEM_PAD,
               borderRadius: rowRadius(theme, MENU_BORDER, MENU_PAD),
               backgroundColor:
                 barState === 'active'


### PR DESCRIPTION
A menu bar item wore its own padding — 10px horizontal, 3px vertical — while
a row inside the menu it opens takes `MENU_ITEM_PAD` all round, measured to
the cap band. So the two pills never matched: a 15px title over a 25px first
row, tight enough that the bar read as a different widget from the menu
hanging off it.

## What changed

`src/components/Menu.js`, the bar item's style:

- **Vertical**: `paddingTop/Bottom: MENU_ITEM_PAD` — the same padding around
  the same `capTrim` text as a row, so the pill is exactly `menuRowHeight`.
  The `BAR_INSET` margin now sits *outside* that instead of being taken out
  of it, so the bar is a menu row plus its two insets: **21px → 31px**.
- **Horizontal**: a new `BAR_ITEM_PAD_X = MENU_ITEM_PAD + 4`, replacing the
  bare `10`. A row's label is not `MENU_ITEM_PAD` from the pill's edge but a
  whole `MENU_GUTTER` in, past the check column — so matching the row's
  padding outright would be the cramped choice on a strip where the pills sit
  shoulder to shoulder.

Both are now derived from the row's own constant rather than hard-coded, in
the spirit of `menuRowHeight`.

## Before / after

`examples/menu.jsx` with the Edit menu open, rendered headlessly by this
branch's own code — node-x11's in-process X server, real events, pixels read
back through `scripts/capture.js`. The measured geometry:

| | bar item | first row | bar |
|---|---|---|---|
| before | 43 × **15** | 130 × **25** | 21 |
| after | 47 × **25** | 130 × **25** | 31 |

**Before**

![before](https://github.com/user-attachments/assets/e247d820-cffc-427f-8533-a846bb45dbc7)

**After**

![after](https://github.com/user-attachments/assets/37298b87-36f6-437c-ae94-36790ad25e6b)

## For the reviewer

- **Every application's menu bar is 10px taller.** No prop guards this — it
  is a change of the default, on purpose, since the whole point is that the
  bar and its menu agree. Shout if you would rather it were opt-in.
- Nothing in the repo pins the old metrics: no committed screenshot contains
  a menu bar, and no doc quotes the numbers.
- Prettier and eslint clean. The MenuBar-touching suites pass — anchor-
  tracking, popup-chrome, a11y, smoke, atspi, globalmenu, 182 tests. Full
  suite is 944/950, with the same 6 `test/icons.test.js` failures present on
  unmodified `master` here (the "ntk floor" coverage-under-clip tests),
  unrelated to this change.



---

## Also here: a stress switch in the menu example

`examples/menu.jsx` only ever showed menus of a comfortable size, which is the
one shape a menu bar never has to survive. The first bar menu is now
**Extremes**, holding a checkbox item — `toggleType: 'checkmark'`, so it draws
the system check in the gutter — and ticking it takes the bar to **20**
pull-downs and the File menu to **30** rows.

![large-toggle](https://github.com/user-attachments/assets/6358f94a-3924-46a1-a338-1c71d574ae1b)

Both are padded rather than replaced: File keeps its own rows and the bar
keeps File/Edit/View, so what the switch changes is the count. A stress mode
that threw the real menus away would be testing the filler.

**20 menus on a 520px bar** — the row overflows and clips at the window edge.
The bar lays all twenty out (the last one starts at x=1325), so the sixteen
past "Menu 4" are unreachable with the pointer; Left/Right still walk onto
them, which then opens a menu anchored off-window.

![large-bar](https://github.com/user-attachments/assets/9ec0c1c9-6757-4dcd-b052-ad907a86f6b6)

**30 rows on a 600px screen** — the popup measures 724px tall, is pinned to
y=0 and runs off the bottom. Menus size to their content rather than
scrolling, on purpose (`MENU_PAGE_ROWS` in `Menu.js` says as much), so this is
the shape of that decision rather than a regression this branch introduced.

![large-file-menu](https://github.com/user-attachments/assets/04d9fb2b-3901-4157-bda2-9848736032c4)

Neither is fixed here — the switch exists so the shapes are one click away
rather than a thing you have to construct. `chore(examples)` because examples
are not in the published `files`, so this half is not a release.

