### PR TITLE
feat(components): a menu bar too narrow for its titles grows a chevron

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -995,9 +995,22 @@ not taken over yet: the pointer is still on the row that opened it, so that
 row stays lit — which is why a menu bar item stays coloured until you touch
 a row in the menu it opened, and goes quiet then.
 
-The bar item wears the same pill as the rows, at `radiusPopupItem`, inset
-into the bar by a few pixels taken out of its own padding so the bar is the
-height it always was.
+The bar item wears the same pill as the rows, at `radiusPopupItem` — the same
+padding around the same capitals, so a title and the first row of the menu it
+opens are one shape in one size, inset into the bar by a few pixels of margin
+that sit outside that padding.
+
+**Titles that do not fit.** A bar narrower than its menus paints as many as
+fit and moves the rest behind a chevron at the end of it — the system set's
+`moreVertical`, drawn rather than a `»`, so it is a mark and not a font's
+opinion of one. The chevron is an ordinary bar entry whose items are the
+menus that were cut, so each row opens the menu it stands for as a submenu,
+and it is a real stop for Left/Right: **the keyboard walks exactly what is
+painted**, never a title laid out past the window's edge. Widen the window
+and the titles come back one at a time. The bar measures itself, so the
+first frame of a new bar always shows everything and the cut lands on the
+next — and none of this happens on a desktop whose panel has taken the menu,
+where there is no bar of ours to overflow.
 
 **Icons.** `icon` fills the 16px column left of the label — the same column
 a `toggleType` mark uses, so an item that is both checked and iconned shows

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -4,7 +4,7 @@
 
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { capBand, capTrim, rowRadius, useTheme } from './theme.js';
-import { Icon } from './Icon.js';
+import { Icon, iconSize } from './Icon.js';
 import {
   DEFAULT_LABEL_SIZE,
   anchorRect,
@@ -90,6 +90,18 @@ const BAR_GAP = 1;
 // between one label and the next.
 const BAR_ITEM_PAD_X = MENU_ITEM_PAD + 4;
 
+// The bar entry that stands for the titles that did not fit. A symbol rather
+// than a `label`, because it is the one entry on the bar the application did
+// not write: everything else about it — its popup, its rows, its keys — is
+// the ordinary machinery, and a marker no menu object can collide with is
+// what keeps it that way.
+const OVERFLOW = Symbol('menubar overflow');
+const isOverflow = (menu) => Boolean(menu?.[OVERFLOW]);
+// A title is keyed by its label; the chevron has none, and a NUL is the one
+// key no label can equal — so a menu actually called "More" keeps its
+// identity across a resize instead of trading places with the chevron.
+const OVERFLOW_KEY = '\0menubar-overflow';
+
 // The horizontal gap between a menu and the submenu it opens, measured from
 // the parent popup's outer edge — so `0` is flush against it, a positive
 // value leaves the desktop showing between the two, and a negative one
@@ -140,6 +152,52 @@ function menuListWidth(node, items, fontSize) {
       MENU_ITEM_PAD +
       2,
   );
+}
+
+/**
+ * How much of the bar one title takes, margins included — the same
+ * arithmetic the bar itself is laid out with, written next to
+ * `menuListWidth` so the two cannot drift.
+ */
+function barItemWidth(node, label, fontSize) {
+  const text = measureLabel(node, label ?? '', { size: fontSize }).width;
+  return Math.ceil(text) + (BAR_ITEM_PAD_X + BAR_GAP) * 2;
+}
+
+/** The same, for the chevron: an icon box where a title has its label. */
+const barOverflowWidth = (fontSize) =>
+  iconSize(fontSize) + (BAR_ITEM_PAD_X + BAR_GAP) * 2;
+
+/**
+ * How many titles the bar can paint, and therefore where it is cut. The rest
+ * go to the chevron.
+ *
+ * Two passes rather than Qt's one. Qt reserves the extension button's width
+ * unconditionally, which spends it on every bar including the ones that
+ * never overflow; asking first whether everything fits costs one extra sum
+ * and gives the common case its full width back. It cannot oscillate — the
+ * second pass only ever runs on a bar already known not to fit, and the
+ * chevron is narrower than the title it displaces — which is the trap this
+ * shape is usually avoided for.
+ *
+ * A title that is *partly* visible does not count as visible: half a word is
+ * not a menu you can find, and the pointer cannot reach the half that is
+ * off-window anyway.
+ */
+function barCut(node, menus, fontSize, width) {
+  const widths = menus.map((menu) => barItemWidth(node, menu.label, fontSize));
+  const inner = width - (BAR_INSET - BAR_GAP) * 2;
+  const total = widths.reduce((sum, w) => sum + w, 0);
+  if (total <= inner) return menus.length;
+  const room = inner - barOverflowWidth(fontSize);
+  let used = 0;
+  let count = 0;
+  for (const w of widths) {
+    if (used + w > room) break;
+    used += w;
+    count++;
+  }
+  return count;
 }
 
 /** Next selectable index in `dir`, wrapping, skipping separators/disabled. */
@@ -811,6 +869,36 @@ export function MenuBar({
   const bar = useMemo(() => visibleItems(menus), [menus]);
   const delegated = useGlobalMenu(menus, { onSelect, enabled: globalMenu });
 
+  // What the bar turned out to be, which is the one thing here that cannot
+  // be worked out in a render: layout runs on the frame clock, after the
+  // commit that mounted the box, so `onViewport` is the supported way to
+  // hear about a size (docs/react-features.md) — and it is what makes the
+  // box a scroll container, which is also what clips a bar mid-cut.
+  //
+  // `0` means "not measured yet", and an unmeasured bar shows everything:
+  // that is what every bar did before this, and it is right for every bar
+  // that fits. The window narrower than its titles is one frame late, not
+  // wrong.
+  const barRef = useRef(null);
+  const [barWidth, setBarWidth] = useState(0);
+  const [fits, setFits] = useState(-1);
+  useEffect(() => {
+    if (!barWidth || !barRef.current) return;
+    setFits(barCut(barRef.current, bar, fontSize, barWidth));
+  }, [bar, fontSize, barWidth]);
+
+  // The bar as it is actually drawn: the titles that fit, then the chevron
+  // standing for the rest. Everything downstream — the open index, the
+  // anchor, Left/Right, the popup — reads this rather than `menus`, which
+  // is the whole of what keeps the keyboard on what the eye can see.
+  const entries = useMemo(() => {
+    if (fits < 0 || fits >= bar.length) return bar;
+    return [
+      ...bar.slice(0, fits),
+      { [OVERFLOW]: true, items: bar.slice(fits) },
+    ];
+  }, [bar, fits]);
+
   // The one thing about this an app cannot find out for itself: calling
   // `useGlobalMenu` a second time would export the menu twice, on two paths,
   // with the second registration displacing the first. So the answer is
@@ -823,7 +911,7 @@ export function MenuBar({
     notifyDelegation.current?.(delegated);
   }, [delegated]);
 
-  const items = openIndex >= 0 ? (bar[openIndex]?.items ?? []) : [];
+  const items = openIndex >= 0 ? (entries[openIndex]?.items ?? []) : [];
 
   const close = () => {
     openRef.current = -1;
@@ -839,6 +927,16 @@ export function MenuBar({
     if (delegated) close();
   }, [delegated]);
 
+  // Narrowing the window while a menu is down can take the item it hangs
+  // off the bar. Anchor tracking follows a trigger that *moves*; one that
+  // stopped existing leaves the popup where it was, hanging under nothing
+  // and still holding its grab, so it is shut here instead. Reopening the
+  // same menu from the chevron is one click, and guessing which of the two
+  // the user meant is worse than either.
+  useEffect(() => {
+    if (openIndex >= entries.length) close();
+  }, [entries.length, openIndex]);
+
   /**
    * `reason` is the gesture that opened the menu, and it decides the ring.
    * A menu opened with the pointer already tells you where you are — the
@@ -849,7 +947,7 @@ export function MenuBar({
    */
   const openMenu = (index, reason = 'key') => {
     const node = refs.current[index];
-    const menu = bar[index];
+    const menu = entries[index];
     if (!node || !hasSubmenu(menu)) return;
     const width = menuListWidth(node, menu.items, fontSize);
     const height = menuListHeight(menu.items, fontSize);
@@ -895,7 +993,7 @@ export function MenuBar({
     openIndex >= 0,
     () => {
       const node = refs.current[openRef.current];
-      const menu = bar[openRef.current];
+      const menu = entries[openRef.current];
       if (!node || !hasSubmenu(menu)) return null;
       return {
         placement: 'bottom',
@@ -919,8 +1017,8 @@ export function MenuBar({
   };
 
   const moveMenu = (dir) => {
-    if (!bar.length) return;
-    const n = bar.length;
+    if (!entries.length) return;
+    const n = entries.length;
     openMenu((openIndex + dir + n) % n);
   };
 
@@ -935,7 +1033,22 @@ export function MenuBar({
     {
       theme,
       role: 'menubar',
+      ref: barRef,
+      scrollbar: false,
       ...boxProps,
+      // Layout is the only thing that knows how wide the bar came out, and
+      // it says so here. Width alone: `contentWidth` changes as the cut is
+      // applied, and storing that would be reacting to our own answer.
+      //
+      // After the spread and chained rather than before it and overridable:
+      // an application is welcome to watch its own menu bar resize, and a
+      // handler of its own taking this one's place would quietly leave the
+      // bar unable to measure itself — a prop that turns a feature off by
+      // accident.
+      onViewport: (v) => {
+        setBarWidth(v.width);
+        boxProps.onViewport?.(v);
+      },
       style: [
         {
           flexDirection: 'row',
@@ -943,21 +1056,43 @@ export function MenuBar({
           backgroundColor: theme.surfaceHover,
           paddingLeft: BAR_INSET - BAR_GAP,
           paddingRight: BAR_INSET - BAR_GAP,
+          // `scroll` is what makes a box report its viewport, and the clip
+          // that comes with it is wanted in its own right: it is what holds
+          // the one frame before the first measurement — and any bar whose
+          // own titles cannot be cut down far enough — inside the window
+          // instead of letting it run off the edge. Nothing is ever left to
+          // scroll to once the cut lands, so the bar answers no keys and
+          // takes no wheel (docs/elements.md).
+          overflow: 'scroll',
+          // A scroll container brings `flexShrink: 1`; a menu bar is not a
+          // thing that gives up height when the window is short.
+          flexShrink: 0,
         },
         style,
       ],
     },
-    bar.map((menu, index) => {
+    entries.map((menu, index) => {
       // The bar is the first level of the same trail: while its menu is open
       // with nothing chosen in it the item is the selection, and the moment a
       // row down there takes over it goes quiet — the same handover, drawn
       // the same way, one level up (`rowState`).
       const barState = rowState(index, openIndex, (path[0] ?? -1) >= 0);
+      const overflow = isOverflow(menu);
       return h(
         'box',
         {
-          key: menu.label,
+          key: overflow ? OVERFLOW_KEY : menu.label,
           role: 'menuitem',
+          // The glyph is decoration — `<Icon>` is `aria-hidden` by default —
+          // so the chevron is the one bar item with nothing to read out, and
+          // it says how many titles are behind it because "more" without a
+          // number is the question rather than the answer. The hidden menus
+          // themselves are simply not in the tree: AT-SPI has no notion of
+          // "laid out past the edge", and the fix for reaching them is the
+          // same for a screen reader as for a pointer — this item.
+          'aria-label': overflow
+            ? `More menus (${menu.items.length})`
+            : undefined,
           'aria-haspopup': 'menu',
           'aria-expanded': openIndex === index,
           ref: (node) => {
@@ -1063,19 +1198,31 @@ export function MenuBar({
             },
           ],
         },
-        h(
-          'text',
-          {
-            style: [
-              capTrim,
+        overflow
+          ? h(Icon, {
+              // The set's own overflow mark, rather than the `»` Qt and
+              // Firefox draw or the `⋯` a modern toolbar does: both are text
+              // glyphs, and a text glyph is only as good as the font it
+              // lands in — tofu on a machine without it, which is the exact
+              // warning docs/components.md gives applications about string
+              // `icon`s. One drawing, every font, both colour schemes.
+              name: 'moreVertical',
+              size: iconSize(fontSize),
+              color: barState === 'active' ? theme.hoverText : theme.text,
+            })
+          : h(
+              'text',
               {
-                color: barState === 'active' ? theme.hoverText : theme.text,
-                fontSize: fontSize,
+                style: [
+                  capTrim,
+                  {
+                    color: barState === 'active' ? theme.hoverText : theme.text,
+                    fontSize: fontSize,
+                  },
+                ],
               },
-            ],
-          },
-          menu.label,
-        ),
+              menu.label,
+            ),
       );
     }),
     openIndex >= 0 &&

--- a/test/menubar-overflow.test.js
+++ b/test/menubar-overflow.test.js
@@ -1,0 +1,257 @@
+// A menu bar narrower than its titles: what is painted, what moves into the
+// chevron, and what the keyboard is allowed to reach.
+//
+// Before this, the titles that did not fit were laid out past the window's
+// edge — never painted, unreachable by pointer, and still in the keyboard's
+// cycle, so walking the bar opened a menu anchored to an item nobody could
+// see (#241). The rule these tests hold to is that the bar's cycle and the
+// bar's paint are the same list.
+//
+// Widths here are the mock's own: with no font stack, `measureLabel` falls
+// back to `length * size * 0.55`, which is what makes an expected split
+// something a test can state rather than approximate.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+
+import { createRoot, MenuBar } from '../src/index.js';
+import { createMockApp, pressButton } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+/**
+ * Long enough for the measurement to come back round.
+ *
+ * The bar cannot know its own width during the render that mounts it:
+ * layout runs on the frame clock after that commit, `onViewport` is
+ * deferred out of the layout pass itself, and the cut it feeds is a state
+ * change that renders again. Three hops, so this waits rather than counting
+ * them.
+ */
+async function settle() {
+  for (let i = 0; i < 10; i++) await tick();
+}
+
+const TITLES = [
+  'File',
+  'Edit',
+  'Selection',
+  'View',
+  'Go',
+  'Run',
+  'Terminal',
+  'Window',
+  'Help',
+];
+const MENUS = TITLES.map((label) => ({
+  label,
+  items: [{ label: `${label} one` }, { label: `${label} two` }],
+}));
+
+const findNode = (node, pred) => {
+  if (pred(node)) return node;
+  for (const child of node.children ?? []) {
+    if (child.isWindow) continue;
+    const found = findNode(child, pred);
+    if (found) return found;
+  }
+  return null;
+};
+
+const textOf = (node) => {
+  const chunk = findNode(node, (n) => n.kind === 'textchunk');
+  return chunk?.text ?? null;
+};
+
+/** The chevron draws a system icon and no text — that is how it is spotted. */
+const isChevron = (node) =>
+  Boolean(
+    findNode(
+      node,
+      (n) => n.kind === 'canvas' && n.props?.cacheKey === 'moreVertical',
+    ),
+  );
+
+const barOf = (wnd) => wnd._reactX11Node.children[0];
+
+/** What the bar actually paints, with the chevron as `'…'`. */
+const painted = (wnd) =>
+  barOf(wnd).children.map((item) => (isChevron(item) ? '…' : textOf(item)));
+
+/** The rows of the popup that is currently open. */
+const rowsOf = (app) => {
+  const popup = app.windows.at(-1);
+  const list = popup?._reactX11Node.children[0];
+  return (list?.children ?? []).map(textOf);
+};
+
+async function mount(width, menus = MENUS) {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(
+    h(
+      'window',
+      { width, height: 200 },
+      // `globalMenu: false` because this is a test about the bar we draw: on
+      // a machine running a panel that takes application menus, `MenuBar`
+      // would correctly render nothing at all.
+      h(MenuBar, { menus, fontSize: 13, globalMenu: false }),
+    ),
+  );
+  await settle();
+  return { app, x11Root, wnd: app.windows[0] };
+}
+
+/** Click a bar item by its painted index. */
+async function clickItem(wnd, index) {
+  const item = barOf(wnd).children[index];
+  pressButton(wnd, item.abs.x + 4, item.abs.y + 4);
+  await settle();
+}
+
+function press(app, wnd, keysym) {
+  const keycode = (keysym % 248) + 8;
+  app.X.keycode2keysyms[keycode] = [keysym];
+  wnd.emit('keydown', { keycode, buttons: 0 });
+}
+
+const XK_LEFT = 0xff51;
+const XK_RIGHT = 0xff53;
+
+test('a bar too narrow paints what fits and pockets the rest', async () => {
+  const { app, x11Root, wnd } = await mount(300);
+
+  assert.deepEqual(
+    painted(wnd),
+    ['File', 'Edit', 'Selection', 'View', '…'],
+    'the four that fit, then the chevron',
+  );
+
+  // and the pocket holds exactly the ones that went missing, in order
+  await clickItem(wnd, 4);
+  assert.deepEqual(rowsOf(app), ['Go', 'Run', 'Terminal', 'Window', 'Help']);
+
+  await x11Root.unmount();
+});
+
+test('a bar wide enough for its titles has no chevron at all', async () => {
+  const { x11Root, wnd } = await mount(900);
+  assert.deepEqual(painted(wnd), TITLES, 'all nine, nothing pocketed');
+  await x11Root.unmount();
+});
+
+test('the chevron opens the hidden menu as a submenu of its own', async () => {
+  const { app, x11Root, wnd } = await mount(300);
+
+  await clickItem(wnd, 4);
+  const popup = app.windows.at(-1);
+  const rows = popup._reactX11Node.children[0].children;
+  const terminal = rows[2];
+  assert.equal(textOf(terminal), 'Terminal');
+  assert.equal(
+    terminal.props['aria-haspopup'],
+    'menu',
+    'a hidden menu is a row that opens its own menu, not a leaf',
+  );
+
+  await x11Root.unmount();
+});
+
+test('Left/Right walk the painted titles and the chevron, and nothing else', async () => {
+  const { app, x11Root, wnd } = await mount(300);
+
+  await clickItem(wnd, 0);
+  assert.deepEqual(rowsOf(app), ['File one', 'File two']);
+
+  // four steps right: Edit, Selection, View, then the chevron — which is the
+  // last stop rather than `Go`, the first title that is not painted
+  for (const expected of [
+    ['Edit one', 'Edit two'],
+    ['Selection one', 'Selection two'],
+    ['View one', 'View two'],
+    ['Go', 'Run', 'Terminal', 'Window', 'Help'],
+  ]) {
+    press(app, wnd, XK_RIGHT);
+    await settle();
+    assert.deepEqual(rowsOf(app), expected);
+  }
+
+  // and one more wraps to the first title, not into the hidden ones
+  press(app, wnd, XK_RIGHT);
+  await settle();
+  assert.deepEqual(rowsOf(app), ['File one', 'File two']);
+
+  // the same backwards: Left off the first title lands on the chevron
+  press(app, wnd, XK_LEFT);
+  await settle();
+  assert.deepEqual(rowsOf(app), ['Go', 'Run', 'Terminal', 'Window', 'Help']);
+
+  await x11Root.unmount();
+});
+
+test('widening the window puts a title back on the bar', async () => {
+  const { x11Root, wnd } = await mount(300);
+  assert.deepEqual(painted(wnd).at(-1), '…');
+
+  wnd.width = 900;
+  wnd.emit('resize', { width: 900, height: 200 });
+  await settle();
+  assert.deepEqual(painted(wnd), TITLES, 'all of them, chevron gone');
+
+  // and back: the cut is recomputed from the width, not accumulated
+  wnd.width = 300;
+  wnd.emit('resize', { width: 300, height: 200 });
+  await settle();
+  assert.deepEqual(painted(wnd), ['File', 'Edit', 'Selection', 'View', '…']);
+
+  await x11Root.unmount();
+});
+
+test('a single title that does not fit still leaves a usable bar', async () => {
+  const { app, x11Root, wnd } = await mount(60);
+
+  assert.deepEqual(painted(wnd), ['…'], 'the bar is one button');
+
+  await clickItem(wnd, 0);
+  assert.deepEqual(rowsOf(app), TITLES, 'and it holds everything');
+
+  await x11Root.unmount();
+});
+
+test('the chevron says how many menus are behind it', async () => {
+  const { x11Root, wnd } = await mount(300);
+
+  const chevron = barOf(wnd).children.at(-1);
+  assert.equal(chevron.props.role, 'menuitem');
+  assert.equal(chevron.props['aria-haspopup'], 'menu');
+  assert.equal(chevron.props['aria-label'], 'More menus (5)');
+
+  // the hidden titles are not in the tree at all: AT-SPI has no notion of
+  // "laid out past the edge", so a menu item nobody can reach would be a
+  // lie told to a screen reader rather than a fallback
+  for (const hidden of ['Go', 'Run', 'Terminal', 'Window', 'Help']) {
+    assert.equal(
+      findNode(barOf(wnd), (n) => n.kind === 'textchunk' && n.text === hidden),
+      null,
+      `${hidden} is pocketed, not merely unpainted`,
+    );
+  }
+
+  await x11Root.unmount();
+});
+
+test('the menus prop is never rewritten by the cut', async () => {
+  const menus = MENUS.map((menu) => ({ ...menu }));
+  const before = JSON.stringify(menus);
+  const { x11Root, wnd } = await mount(300, menus);
+
+  assert.deepEqual(painted(wnd).at(-1), '…', 'it did overflow');
+  assert.equal(
+    JSON.stringify(menus),
+    before,
+    'what the panel would export is the array the app passed, untouched',
+  );
+
+  await x11Root.unmount();
+});


### PR DESCRIPTION
Closes #241.

A window narrower than its menu bar used to lay the titles that did not fit
**past the window's edge** — never painted, out of the pointer's reach, and
still in the keyboard's cycle. Right from the last visible title opened a menu
anchored to an item nobody could see, which `anchorRect` then clamped back
on-screen under an unrelated title. Every bar until now happened to fit, so
nothing had ever asked.

The bar now measures itself and cuts: what fits stays a title, the rest go
behind a chevron at the end of the strip.

## The shape

The chevron is an **ordinary bar entry whose `items` are the menus that were
cut**. That is what keeps the diff small — `MenuRow` already opens a submenu
for any item with `items`, so the row machinery, the safe-polygon hover and
the whole key handler come for free, and each pocketed menu is a row that
opens the menu it stands for.

Following Qt (`QMenuBarPrivate::updateGeometries`), as the issue argues: only
the hidden menus are listed, the leftmost titles are the ones that stay, and
nothing is ellipsised. Two differences, both deliberate:

- **Two passes, not one.** Qt reserves the extension button's width
  unconditionally; this asks first whether everything fits, so a bar that fits
  is never charged for a chevron it does not show. It cannot oscillate — the
  second pass only runs on a bar already known not to fit, and the chevron is
  narrower than the title it displaces.
- **The mark is `moreVertical` from the system icon set** (#242), not the `»`
  the issue floated. A text glyph is only as good as the font it lands in,
  which is the exact warning `docs/components.md` gives applications about
  string `icon`s. One drawing, every font, both colour schemes.

Everything downstream — the open index, the anchor, Left/Right — reads the cut
list rather than `menus`, which is the whole of what puts the keyboard on what
the eye can see. The hidden titles leave the accessibility tree rather than
lingering as menu items nobody can reach; the chevron carries
`aria-label="More menus (5)"`, because "more" without a number is the question
rather than the answer.

Measuring is `onViewport` on the bar box, as the issue suggested — which also
makes it a scroll container, and that clip is wanted in its own right: it is
what holds the one pre-measurement frame (and any bar whose titles cannot be
cut down far enough) inside the window instead of letting it run off the edge.
The first frame of any bar shows everything, as it always did, and the cut
lands on the next.

`delegated` is untouched: where a panel has taken the menu, `MenuBar` still
returns `null` before any of this and the dbusmenu export is the array the
application passed, unmodified (there is a test for exactly that).

## What it looks like

`examples/menu.jsx` with **Extremes → Large menu items** ticked — twenty
pull-downs on a 520px bar, which is the case that used to lay sixteen of them
off-window. Rendered headlessly by this branch's own code.

![overflow-bar](https://github.com/user-attachments/assets/e7a47bab-8f64-4dae-bc2c-0085ec6502ff)

The chevron's menu is the menus that were cut, in order:

![overflow-menu](https://github.com/user-attachments/assets/fc25aaf2-af29-43a5-ad90-2a7a1f506e61)

…and each row opens the menu it stands for, as a submenu:

![overflow-submenu](https://github.com/user-attachments/assets/23a0269a-e0d4-4863-862c-72d2e4dd49fe)

## Tests

`test/menubar-overflow.test.js`, eight of them, covering the issue's list:
the split and what the pocket holds, the chevron's rows being real submenu
parents, Left/Right walking the painted titles **and stopping at the chevron**
(with the wrap in both directions), widening the window putting titles back,
a single title too wide leaving a one-button bar, the ARIA naming plus the
hidden titles being absent from the tree, and the `menus` prop never being
rewritten.

Mutation-checked: with `src/components/Menu.js` reverted, 7 of the 8 fail
(the eighth is the control — a bar wide enough for its titles, which must
pass either way).

## Checks

- `npm run lint`, `format:check`, `typecheck` clean.
- MenuBar-adjacent suites (popup-chrome, a11y, atspi, globalmenu, smoke,
  anchor-tracking) plus the new file: 185 tests, all passing.
- Full suite 952/958. The 6 failures are `test/appearance.test.js` probing
  this machine's real desktop and fail identically on unmodified `master`
  here.
- `website && npm run build` passes on a fresh install (node 22), so the docs
  link/anchor check is happy with the new `MenuBar` section.

## One thing to look at

The bar box gains `overflow: 'scroll'` (with `scrollbar={false}` and an
explicit `flexShrink: 0`, since a scroll container would otherwise bring
`flexShrink: 1` and a menu bar should not give up height). That is the price
of `onViewport` — there is no viewport callback for a plain box. Once the cut
lands there is never anything to scroll to, so per `docs/elements.md` the bar
is not a tab stop, answers no keys and takes no wheel. If you would rather not
pay it, the alternative is a layout-time notification for non-scrollers, which
is a bigger change than this issue.

