### PR TITLE
fix(portal): an abort that beats the portal's reply is not lost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ jobs:
     # making progress holds a runner for six hours and uploads no log at all,
     # so there is nothing to read afterwards — which is exactly the case this
     # exists for. Well clear of a slow runner, nowhere near the default.
+    #
+    # It is the outer fence, not the first line: `--test-timeout` in the test
+    # script fails the individual test by name, which is the thing you actually
+    # want in the log. This only catches a hang no per-test deadline can see.
     timeout-minutes: 10
     strategy:
       fail-fast: false

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "src"
   ],
   "scripts": {
-    "test": "node --test",
+    "test": "node --test --test-timeout=60000",
     "typecheck": "tsc -p tsconfig.json",
     "lint": "eslint .",
     "format": "prettier --write .",

--- a/src/portal.js
+++ b/src/portal.js
@@ -158,7 +158,12 @@ export function _resetServiceCache() {
  *
  * - **Cancellation.** An `AbortSignal` calls `Request.Close()` on the same
  *   path. Per the XML that means **no `Response` is emitted**, so the promise
- *   has to be settled here rather than left waiting for one.
+ *   has to be settled here rather than left waiting for one. The listener goes
+ *   on **before the first await**, because `addEventListener('abort')` on a
+ *   signal that has already fired never runs: an abort that lands while
+ *   `AddMatch` or the initial call is still in flight would otherwise be
+ *   dropped, leaving a promise nothing can settle and a dialog on screen with
+ *   nobody listening — the exact leak this is here to prevent.
  * - **Deadlines.** There is deliberately **no timeout on the answer** — a
  *   dialog can legitimately be open for an hour, which is the whole reason
  *   portals are request-shaped instead of plain calls. Only the initial method
@@ -189,16 +194,6 @@ export async function portalRequest(
     return { sub, key };
   };
 
-  // Subscribe FIRST. Everything else in this function is bookkeeping around
-  // the fact that this line comes before the invoke.
-  let { sub, key } = await subscribe(path);
-  const answered = new Promise((resolve) => {
-    // `bus.signals` emits the signal's argument array.
-    bus.signals.once(key, ([response, results]) =>
-      resolve({ response, results: results ?? {} }),
-    );
-  });
-
   const closeRequest = (requestPath) =>
     bus
       .invoke({
@@ -213,11 +208,56 @@ export async function portalRequest(
         // The request may already be gone — that is the outcome we wanted.
       });
 
+  // The abort wiring, before anything that can suspend. `sent` is the guard on
+  // Close(): there is no request to close until the call has actually gone out,
+  // and the path the portal will answer on is the predictable one from here
+  // until a pre-0.9 portal says otherwise.
+  let sent = false;
+  let requestPath = path;
+  /** The path the abort actually closed, if it has fired. */
+  let closedPath = null;
   let onAbort;
+  let aborted;
+  if (signal) {
+    aborted = new Promise((_, reject) => {
+      onAbort = () => {
+        if (sent) {
+          closedPath = requestPath;
+          closeRequest(requestPath);
+        }
+        reject(signal.reason ?? new PortalCancelledError());
+      };
+      signal.addEventListener('abort', onAbort, { once: true });
+    });
+    // Nothing awaits `aborted` until the races below, and an abort can land
+    // before then. Mark it handled so a rejection in that window is not an
+    // unhandled one; the races still see it.
+    aborted.catch(() => {});
+  }
+
+  // Subscribe FIRST. Everything else in this function is bookkeeping around
+  // the fact that this line comes before the invoke. It is not raced against
+  // the abort: a match rule half-added is a match rule leaked, so let it
+  // finish and let the `finally` below take it away again.
+  let { sub, key } = await subscribe(path);
+  const answered = new Promise((resolve) => {
+    // `bus.signals` emits the signal's argument array.
+    bus.signals.once(key, ([response, results]) =>
+      resolve({ response, results: results ?? {} }),
+    );
+  });
+
   try {
-    let handle;
-    try {
-      handle = await bus.invoke(
+    // An abort during `AddMatch` above: nothing has been asked for yet, so
+    // there is nothing to Close — just leave, and let the `finally` unsubscribe.
+    if (signal?.aborted) throw signal.reason ?? new PortalCancelledError();
+
+    // `sent` flips *before* the await, not after: from the moment the call is
+    // on the wire the portal may already have a dialog up, and an abort in that
+    // window has to Close it even though no handle has come back yet.
+    sent = true;
+    const call = bus
+      .invoke(
         {
           destination: PORTAL_NAME,
           path: PORTAL_PATH,
@@ -227,15 +267,33 @@ export async function portalRequest(
           body: [parentWindow, title, { ...options, handle_token: token }],
         },
         { timeout: 10_000 },
+      )
+      // Settled either way, so that an abort winning the race below does not
+      // leave this one rejecting into nobody's hands.
+      .then(
+        (handle) => ({ handle }),
+        (cause) => ({ cause }),
       );
-    } catch (cause) {
+
+    // A pre-0.9 portal that picks its own path is the one case where an abort
+    // that beat the reply closed the wrong one — and which path it really was
+    // is not knowable until the handle arrives, quite possibly after this
+    // function has already rejected.
+    call.then(({ handle }) => {
+      if (closedPath && typeof handle === 'string' && handle !== closedPath) {
+        closeRequest(handle);
+      }
+    });
+
+    const { handle, cause } = await Promise.race([call, aborted ?? call]);
+    if (cause)
       throw new NoPortalError(`${iface}.${member} did not answer`, cause);
-    }
 
     // Pre-0.9 portals chose their own path. Re-subscribe on the real one; the
     // first subscription stays until the finally below, which is cheaper than
     // getting the ordering wrong.
     if (typeof handle === 'string' && handle !== path) {
+      requestPath = handle;
       const moved = await subscribe(handle);
       bus.signals.once(moved.key, ([response, results]) => {
         bus.signals.emit(key, [response, results]);
@@ -243,22 +301,9 @@ export async function portalRequest(
       sub = { remove: () => Promise.all([sub.remove(), moved.sub.remove()]) };
     }
 
-    if (signal) {
-      onAbort = () => closeRequest(handle ?? path);
-      signal.addEventListener('abort', onAbort, { once: true });
-      // `Close()` produces no Response, so the abort has to settle the race
-      // itself rather than wait for one that will never arrive.
-      const aborted = new Promise((_, reject) => {
-        signal.addEventListener(
-          'abort',
-          () => reject(signal.reason ?? new PortalCancelledError()),
-          { once: true },
-        );
-      });
-      return await Promise.race([answered, aborted]);
-    }
-
-    return await answered;
+    // `Close()` produces no Response, so the abort has to settle the race
+    // itself rather than wait for one that will never arrive.
+    return await Promise.race([answered, aborted ?? answered]);
   } finally {
     if (onAbort) signal.removeEventListener('abort', onAbort);
     await sub.remove().catch(() => {});

--- a/test/filedialog.test.js
+++ b/test/filedialog.test.js
@@ -227,6 +227,40 @@ describe('the portal', { ...needsBroker }, () => {
     });
   });
 
+  // The one above aborts as soon as the *portal* has recorded the call — which
+  // it does before its reply travels back, so on a loaded runner the abort can
+  // land while the client is still waiting for the handle. That used to be a
+  // hang rather than a failure: `addEventListener('abort')` on a signal that
+  // has already fired never runs, so the listener registered after the call
+  // returned was registered onto nothing, and a request with no Response
+  // coming waited for one forever. Here the reply is held on purpose, so the
+  // window is the whole test rather than a few microseconds of luck.
+  test('an abort that beats the portal reply is still an abort', async () => {
+    await withBus(async (address) => {
+      const portal = await fakePortal(
+        address,
+        { OpenFile: () => ({ silent: true }) },
+        { holdReply: 200 },
+      );
+      try {
+        const ac = new AbortController();
+        const pending = openFile({ signal: ac.signal });
+        await until(() => portal.calls.length === 1, 'the call to arrive');
+        ac.abort();
+        await assert.rejects(pending, /aborted/i);
+        // And the dialog the portal already has up is closed, which is the
+        // whole point of not simply walking away.
+        await until(
+          () => portal.closed.length === 1,
+          'the portal to see Close()',
+        );
+        assert.equal(portal.closed[0], portal.calls[0].path);
+      } finally {
+        await portal.stop();
+      }
+    });
+  });
+
   test('selectFolder asks for a directory', async () => {
     await withBus(async (address) => {
       const portal = await fakePortal(address, {

--- a/test/helpers/fake-portal.js
+++ b/test/helpers/fake-portal.js
@@ -28,8 +28,19 @@ const REQUEST_IFACE = 'org.freedesktop.portal.Request';
  * The returned object records every call in `calls`, so a test can assert on
  * what was actually marshalled — which is where the option translation is
  * pinned.
+ *
+ * `holdReply` delays the *reply to the method call* — not the Response signal —
+ * by that many milliseconds, while still recording the call and exporting
+ * `Request.Close` up front, exactly as a real portal does. It makes the window
+ * between "the portal has a dialog up" and "the client knows the handle"
+ * wide enough to test deliberately, instead of waiting for a loaded CI runner
+ * to land in it by accident.
  */
-export async function fakePortal(address, handlers = {}) {
+export async function fakePortal(
+  address,
+  handlers = {},
+  { holdReply = 0 } = {},
+) {
   const dbus = (await import('dbus-native')).default;
   const bus = dbus.createClient({ busAddress: address });
   const portal = {
@@ -67,8 +78,12 @@ export async function fakePortal(address, handlers = {}) {
 
     // Answer on a later tick: the call has to return the handle first, and a
     // Response that arrived before it would not prove anything about ordering.
+    // A held reply holds the Response behind it too, for the same reason.
+    const held = holdReply
+      ? new Promise((r) => setTimeout(r, holdReply))
+      : Promise.resolve();
     const handler = handlers[member];
-    Promise.resolve()
+    held
       .then(() => (handler ? handler(call) : { response: 0, results: {} }))
       .then((result) => {
         if (!portal.open.has(path) || result?.silent) return;
@@ -80,6 +95,7 @@ export async function fakePortal(address, handlers = {}) {
       })
       .catch(() => {});
 
+    await held;
     return path;
   };
 


### PR DESCRIPTION
Found while chasing the intermittent CI hang on #244 — `test (22)` sat there until the 10-minute job ceiling killed it, with no failing test named. It is not that PR's fault: `src/portal.js` and `test/filedialog.test.js` are byte-identical between #244 and master. The flake is pre-existing and #244 just lost the coin toss.

## The bug

`portalRequest()` registered its abort wiring *after* `await bus.invoke(...)` resolved:

```js
handle = await bus.invoke({ /* OpenFile */ }, { timeout: 10_000 });
...
signal.addEventListener('abort', onAbort, { once: true });   // too late
```

`addEventListener('abort')` on a signal that has **already fired** never runs. So an abort landing between the call going out and the handle coming back was dropped whole: the `aborted` promise never rejected, `Promise.race([answered, aborted])` went on waiting for a `Response` that `Close()` guarantees will never arrive, and no `Close()` was ever sent — the dialog stayed up on the user's screen with nobody listening, which is the exact leak the abort path exists to prevent.

## Why it hangs CI and not you

`abort closes the request rather than walking away` aborts as soon as `portal.calls.length === 1`, and the fake portal records the call *synchronously inside its handler* — before its reply travels back over the socket. On an idle machine that gap is sub-millisecond and `until()`'s 10 ms poll always steps over it. On a runner with three test files sharing a core, it lands in it.

Confirmed with a repro holding the portal's reply for 200 ms: `outcome: HUNG, Close() seen: 0` before, `rejected: AbortError, Close() seen: 1` after.

## The fix

- **`src/portal.js`** — the abort wiring goes up before the first await, keyed on a mutable `requestPath` rather than the handle. `sent` decides whether there is anything to `Close()` (an abort during `AddMatch` closes nothing, because nothing has been asked for yet), and `closedPath` covers the pre-0.9 portal that answers on a path of its own choosing, whose real handle can arrive after this function has already rejected. The initial call is raced against the abort, settled either way so a losing invoke does not reject into nobody's hands.
- **`test/helpers/fake-portal.js`** — a `holdReply` option that delays the reply to the method call while still recording it and exporting `Request.Close` up front, the way a real portal does.
- **`test/filedialog.test.js`** — a regression test on top of it, so the race is deliberate rather than one-in-N.
- **`package.json`** — `--test-timeout=60000`. This one took ten minutes and named nothing; the next hang of any kind fails as a named test in a minute. The job's `timeout-minutes: 10` stays as the outer fence, with a comment saying so.

## Verification

- The new test hangs against unfixed `portal.js` and passes against fixed — `--test-timeout` turns the hang into `'test timed out after 10000ms'` on the named test.
- Full suite before and after: 0 failures both. (23 cancellations in `appearance.test.js`, identical on both sides — pre-existing on macOS, unrelated, green on Linux.)
- `test/filedialog.test.js` 3/3 on each of Node 20, 22 and 24; `--test-timeout` verified present on all three.
- `lint`, `format:check` and `typecheck` clean.