### PR TITLE
feat(windows): a bound the content decides — minWidth="auto" and friends

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -183,6 +183,69 @@ a window manager answers with a size of its own, the window is theirs and
 stops re-fitting. Setting `width` to a number is the app doing the same
 thing, and setting it back to `'auto'` hands it back.
 
+### A floor the content decides
+
+`minWidth`/`minHeight` also take `'auto'`: **the smallest size the content
+can be drawn at**, measured from the tree and handed to the window manager,
+which is what stops the user dragging the window below it.
+
+```jsx
+<window minWidth="auto" minHeight="auto">   {/* never smaller than my content */}
+<window width={900} minWidth="auto" />      {/* my opening size, the content's floor */}
+```
+
+This is what Qt and GTK both do, and in both it is the default rather than
+something you ask for: a Qt layout's `minimumSize()` becomes the window's
+via `QLayout::SetDefaultConstraint`, and GTK writes the widget tree's
+minimum into the WM geometry hints. Here it is opt-in, because a renderer
+whose layout is CSS has no floor unless one is asked for — CSS lets content
+overflow.
+
+**How the floor is measured**: the tree is laid out with _no room at all_,
+and the floor is how far it still reached. What each node contributes is
+whatever its own style lets it shrink to, which makes the interesting part
+what _doesn't_ count:
+
+| the node                                               | contributes       |
+| ------------------------------------------------------ | ----------------- |
+| a rigid box (`flexShrink` is 0 by default — see above) | its whole size    |
+| a wrapping row                                         | its widest item   |
+| text                                                   | its longest word  |
+| `overflow: 'scroll'` / `'hidden'`                      | nothing           |
+| `flexShrink: 1`, or a `minWidth: 0` of its own         | what it shrank to |
+
+The last two rows are the escape hatch, and they are the same one CSS,
+Qt and GTK all spell — `min-width: 0`, `QScrollArea`, `min-content-width`.
+A node that was told it may shrink is taken at its word and its contents
+stop counting, so a window around a scrolling pane is floored by everything
+_except_ that pane. Naming a number (`minWidth: 240` on the box) is an
+answer too, and stops the measurement there.
+
+`maxWidth`/`maxHeight` take `'auto'` as well, and it means the other half of
+the pair: **the size the content wanted** — the natural size above, not the
+floor. `'auto'` reads as "ask the content", and the content's answer to _how
+big_ is not its answer to _how small_. On a tree where nothing can shrink
+the two are the same number, which is what makes `minWidth="auto"
+maxWidth="auto"` the fixed-size dialog — the same thing `resizable={false}`
+says more briefly.
+
+Three things worth knowing:
+
+- **A floor is a request.** mutter, kwin and xfwm enforce it at the drag; a
+  tiling window manager may size the window however it likes. It stops the
+  user, it does not relieve the app of clipping gracefully — and the
+  renderer will not fight a window manager that ignores it.
+- **`minHeight="auto"` is measured for the width the window has**, and
+  re-sent as that changes. A minimum height is a height _for a width_ — a
+  paragraph is tallest at its narrowest — and `WM_NORMAL_HINTS` holds two
+  independent numbers with no way to say so. (GTK answers the same question
+  at its minimum _width_, which is a taller floor than a wide window needs.)
+- **The floor outlives the size.** An `'auto'` size stops tracking once the
+  user takes the window over; an `'auto'` bound does not, because stopping
+  them going too far is the whole job. It is measured on every frame that
+  lays out — one extra layout pass per axis asked for — and written only on
+  the frames it actually moves.
+
 Three things worth knowing before reaching for it:
 
 - A scroll container reports its **content** height, not a viewport height,
@@ -257,7 +320,11 @@ are free, so no `sizeHints` object is needed.
 ```jsx
 <window width={400} height={300} resizable={false} windowType="dialog" />
 <window width={400} height={300} minWidth={320} minHeight={200} />
+<window width={400} height={300} minWidth="auto" /> {/* measured — see above */}
 ```
+
+The four bounds also take `'auto'`, which asks the content instead of naming
+a number: [a floor the content decides](#a-floor-the-content-decides).
 
 On a `<window>` these names are the window's, not yoga's: `width`/`height`
 are the real geometry the user can drag, and `minWidth`/`maxHeight` are what

--- a/examples/tasks.jsx
+++ b/examples/tasks.jsx
@@ -3,7 +3,9 @@
 // a scrolling <box>, Buttons for the filters — with keyboard interaction
 // throughout (Tab moves focus, Space/Enter toggles). Type a task and press
 // Enter or click Add; Ctrl+C/V and middle-click PRIMARY paste work in the
-// input. Run with: npm run examples:tasks  (needs an X server / DISPLAY)
+// input. The window also refuses to be resized smaller than its own content
+// (`minWidth="auto"`, at the bottom of this file) — drag an edge and see.
+// Run with: npm run examples:tasks  (needs an X server / DISPLAY)
 // — or hot-reloadable with: npm run examples:tasks:hot  (edit this file
 // while it runs; see tasks-hot.jsx)
 import React, { useContext, useMemo, useReducer, useState } from 'react';
@@ -157,7 +159,7 @@ export function TasksPanel() {
 
         <text style={{ color: '$dim' }}>
           {String(remaining)} remaining — click or Tab + Space to toggle, wheel
-          to scroll
+          to scroll, drag an edge to meet the floor
         </text>
       </box>
     </DispatchContext.Provider>
@@ -166,9 +168,17 @@ export function TasksPanel() {
 
 function App() {
   return (
+    // `minWidth`/`minHeight` of `'auto'` is the smallest size this content
+    // can be drawn at, handed to the window manager — try dragging an edge
+    // and it stops where the filter buttons stop fitting. The task list is
+    // the part that gives: `overflow: 'scroll'` means it can be any size, so
+    // it contributes nothing to the floor and everything around it does.
+    // The window still *opens* at 420x400; a floor is not a size.
     <window
       width={420}
       height={400}
+      minWidth="auto"
+      minHeight="auto"
       title="tasks"
       style={{ backgroundColor: '$surfaceHover' }}
     >

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -619,6 +619,19 @@ function clampExtent(value, min, max) {
 }
 
 /**
+ * A bound measured from the content, held inside the space there is. Unlike
+ * a size it may legitimately be 0 — a window whose every part can give has
+ * no floor to speak of — and a bound the window cannot satisfy is worse than
+ * none: a `minWidth` past the screen is a window that cannot be put on it.
+ */
+function clampBound(value, max) {
+  return Math.max(
+    0,
+    Math.min(Math.ceil(value), max ?? Infinity, MAX_WINDOW_EXTENT),
+  );
+}
+
+/**
  * Where a `transientFor` owner sits on screen, for picking the monitor a
  * dialog should be sized against. Accepts everything `windowIdOf` does — a
  * window ref, a node, a drawn node's ref — and answers null for a raw XID,
@@ -652,6 +665,24 @@ export const WINDOW_HINT_PROPS = [
   'maxAspect',
   'gravity',
 ];
+
+/**
+ * The bounds that can be spelled `'auto'` — asked of the content rather than
+ * named as a number. The increments and the aspect ratios cannot: there is
+ * no content answer to what a resize step is.
+ */
+export const CONTENT_BOUND_PROPS = [
+  'minWidth',
+  'minHeight',
+  'maxWidth',
+  'maxHeight',
+];
+
+/** A bound that asks the content instead of naming a number. */
+const isContentBound = (value) => value === 'auto';
+
+/** A bound as a number, or nothing where it is the content's to answer. */
+const numericBound = (value) => (isContentBound(value) ? undefined : value);
 
 /**
  * A `<window width>`/`<height>` that is not a number: sized from its own
@@ -696,6 +727,112 @@ function assertWindowSize(props, kind) {
         'means. See docs/elements.md, "Natural size".',
     );
   }
+  for (const bound of CONTENT_BOUND_PROPS) {
+    const value = props[bound];
+    if (value === undefined || value === 'auto') continue;
+    if (typeof value === 'number' && Number.isFinite(value) && value >= 0) {
+      continue;
+    }
+    throw new Error(
+      `react-x11: <${kind} ${bound}={${JSON.stringify(value)}}> — a window ` +
+        `bound is a number of pixels or 'auto' (measured from the content), ` +
+        'and leaving it out means no bound at all. ' +
+        'See docs/elements.md, "A floor the content decides".',
+    );
+  }
+}
+
+/**
+ * Whether this node's laid-out size is already the answer for `axis`, so
+ * that what is inside it stops counting towards a floor.
+ *
+ * The question only arises because the layout being read was run with no
+ * room in it: a node whose size came from its container rather than from
+ * itself came out at nothing, and nothing is not a measurement. So the test
+ * is *who decided this size* —
+ *
+ * - it clips, so what overflows it is not something to make room for. CSS
+ *   says the same in `min-width: auto` computing to `0` on anything whose
+ *   overflow is not `visible`, and it is the escape hatch Qt spells
+ *   `QScrollArea` and GTK spells `min-content-width`;
+ * - the author named a size, a floor or a ceiling on this axis. All three
+ *   are answers, `minWidth: 0` — "I can be any size" — included;
+ * - it was told it may shrink, on the axis its container lays out along.
+ *   `flexShrink` is the opt-in, and it means nothing on the other axis.
+ *
+ * Anything else was sized by its parent — a stretched cross-axis child is
+ * the usual one — and has to be looked inside.
+ */
+function boundsItsOwnContent(node, axis, axisIsMain) {
+  const style = node.style;
+  if (style.overflow === 'scroll' || style.overflow === 'hidden') return true;
+  const [size, min, max] =
+    axis === 'width'
+      ? [style.width, style.minWidth, style.maxWidth]
+      : [style.height, style.minHeight, style.maxHeight];
+  if (
+    typeof size === 'number' ||
+    typeof min === 'number' ||
+    typeof max === 'number'
+  ) {
+    return true;
+  }
+  return axisIsMain && (style.flexShrink ?? 0) > 0;
+}
+
+/**
+ * How far this node's content actually reaches along one axis, in its own
+ * coordinate space — the reading of a layout the root was given no room for,
+ * where `getComputedWidth()` says nothing (a root offered 0 is clamped to 0)
+ * but the children still sit where their own styles put them.
+ *
+ * A **span** rather than a rightmost edge, because a `center` or
+ * `space-around` row given less room than it needs overflows *both* sides —
+ * exactly as CSS says it should — and its first child's edge lands at a
+ * negative offset. The padding and border are added back on both sides
+ * because the span is measured between the children, inside them.
+ *
+ * Out-of-flow children are skipped, as they are in CSS: an absolutely
+ * positioned node contributes nothing to what contains it, and a
+ * `display: 'none'` one is not there at all.
+ */
+function contentSpan(node, axis) {
+  const yoga = node.yoga;
+  const horizontal = axis === 'width';
+  const own = horizontal ? yoga.getComputedWidth() : yoga.getComputedHeight();
+  const [startEdge, endEdge] = horizontal
+    ? [Yoga.EDGE_LEFT, Yoga.EDGE_RIGHT]
+    : [Yoga.EDGE_TOP, Yoga.EDGE_BOTTOM];
+  const direction = node.style.flexDirection ?? 'column';
+  const rowFirst = direction === 'row' || direction === 'row-reverse';
+  const axisIsMain = rowFirst === horizontal;
+  let start = Infinity;
+  let end = -Infinity;
+  for (const child of node.children) {
+    // the same set that joins the flex tree: a nested <window> is laid out
+    // by itself, and a <text> span has no box of its own
+    if (!child.yoga || child.isWindow) continue;
+    if (child.style.position === 'absolute') continue;
+    if (child.style.display === 'none') continue;
+    const at = horizontal
+      ? child.yoga.getComputedLeft()
+      : child.yoga.getComputedTop();
+    let extent = horizontal
+      ? child.yoga.getComputedWidth()
+      : child.yoga.getComputedHeight();
+    if (!boundsItsOwnContent(child, axis, axisIsMain)) {
+      extent = Math.max(extent, contentSpan(child, axis));
+    }
+    start = Math.min(start, at);
+    end = Math.max(end, at + extent);
+  }
+  if (start === Infinity) return own;
+  const edges =
+    yoga.getComputedPadding(startEdge) +
+    yoga.getComputedPadding(endEdge) +
+    yoga.getComputedBorder(startEdge) +
+    yoga.getComputedBorder(endEdge);
+  return Math.max(own, end - start + edges);
 }
 
 /**
@@ -727,7 +864,9 @@ export function windowAttributes(props) {
       continue;
     }
     if (WINDOW_HINT_PROPS.includes(key)) {
-      hints[key] = props[key];
+      // An `'auto'` bound is not a number ntk can be given; `realize()`
+      // measures it and merges the answer in before CreateWindow.
+      if (!isContentBound(props[key])) hints[key] = props[key];
       continue;
     }
     attributes[key] = props[key];
@@ -4644,11 +4783,60 @@ export class WindowNode extends Scrollable(Node) {
     // the only thing that ever does is the user dragging an edge.
     this._requestedSize = null;
     this._userSized = false;
+    // the last `WM_NORMAL_HINTS` struct written and the size it was written
+    // at, so that a bound measured every frame is only *sent* on the frames
+    // it moves (see _sendSizeHints for why the size is part of it)
+    this._sentHints = null;
+    this._sentHintsAt = null;
   }
 
   /**
-   * The size this window's content wants, for whichever of `width`/`height`
-   * is `'auto'` — CSS shrink-to-fit, then height-for-width.
+   * The smallest size this window's content can be drawn at: GTK's
+   * `minimum` to the `natural` below, and what an `'auto'` `minWidth` or
+   * `minHeight` resolves to.
+   *
+   * One layout pass **with no space on offer at all**, which is the whole
+   * trick — yoga answers it with every node at the smallest size its own
+   * style allows. Nothing shrinks unless the author said it may (yoga
+   * defaults `flexShrink` to 0, and `overflow: 'scroll'` sets it to 1 along
+   * with `minWidth: 0`), text measures at its longest word, and a wrapping
+   * row wraps at every item. `contentSpan` then reads how far that reached.
+   *
+   * What it deliberately does *not* do is second-guess that layout. A node
+   * that shrank was told it may shrink, so it contributes what it shrank to
+   * and its content stops counting — CSS's `min-width: 0`, Qt's
+   * `QScrollArea`, GTK's `min-content-width`. All three spell the same
+   * escape hatch, and a scroll container gets it here for free.
+   *
+   * `forWidth` is the width the height is measured for, and there has to be
+   * one: a paragraph's minimum height is a height *for a width*. GTK asks
+   * for its minimum height at its minimum width, which for a paragraph is
+   * the width it is tallest at — an honest answer to a question nobody
+   * asked, since the window is not at its minimum width. `WM_NORMAL_HINTS`
+   * holds two independent numbers and cannot express the dependency either
+   * way, so the floor is measured at the width the window will actually
+   * have and re-sent as that changes.
+   */
+  _measureMinimum(axis, forWidth) {
+    const yoga = this.yoga;
+    // The root carries whatever size the last pass pinned on it, and an
+    // available size means nothing to a root that has one of its own.
+    yoga.setWidth(undefined);
+    yoga.setHeight(undefined);
+    if (axis === 'width') {
+      yoga.calculateLayout(0, undefined, Yoga.DIRECTION_LTR);
+    } else {
+      yoga.calculateLayout(forWidth, 0, Yoga.DIRECTION_LTR);
+    }
+    return Math.ceil(contentSpan(this, axis));
+  }
+
+  /**
+   * What the content has to say about this window's size: the size it wants
+   * for whichever of `width`/`height` is `'auto'`, and the numbers an
+   * `'auto'` bound resolves to.
+   *
+   * The **natural** size is CSS shrink-to-fit, then height-for-width:
    *
    * 1. Lay the tree out with **no available width**, which is what yoga's
    *    `undefined` means: every measure function is asked in
@@ -4666,13 +4854,24 @@ export class WindowNode extends Scrollable(Node) {
    * overflows. A window cannot be wider than the screen, so the clamp wins
    * and the content is cut instead.
    *
+   * The two answers are the pair Qt and GTK both hand their toplevels —
+   * `sizeHint()`/`minimumSizeHint()`, `gtk_widget_measure`'s
+   * `(minimum, natural)` — which is why `'auto'` reads as the natural size
+   * on a cap and as the minimum on a floor: it means "ask the content",
+   * and the content's answer to *how big* is not its answer to *how small*.
+   *
    * Runs before `CreateWindow`, so it must not need one: text measures
    * through `app.fonts`, which is the connection's, and the clamp was
    * resolved during `createRoot`. That is the whole point — the window is
    * *created* at its natural size rather than resized into it after mapping,
    * so nothing is ever on screen at the wrong size.
+   *
+   * Leaves the tree laid out at a size that is nobody's arrangement, so it
+   * may only be called on a frame that goes on to lay out — `realize()`,
+   * which invalidates, and `_refit()`, which `flush()` only calls when it
+   * owes a layout pass anyway.
    */
-  _measureNatural() {
+  _measure() {
     const props = this.props;
     const autoW = isAutoSize(props.width);
     const autoH = isAutoSize(props.height);
@@ -4680,53 +4879,93 @@ export class WindowNode extends Scrollable(Node) {
     // Where the window will open, for picking a monitor: next to its owner
     // where it has one, and wherever the WM puts it otherwise.
     const area = availableArea(this.app, screenOriginOf(props.transientFor));
+    // An `'auto'` cap never bounds the pass that resolves it: `maxWidth`
+    // there *is* the natural width, so letting it in would be the answer
+    // bounding the question.
     const limit = (max, screen) =>
-      Math.min(max ?? Infinity, screen ?? Infinity, MAX_WINDOW_EXTENT);
+      Math.min(
+        numericBound(max) ?? Infinity,
+        screen ?? Infinity,
+        MAX_WINDOW_EXTENT,
+      );
     const availW = limit(props.maxWidth, area?.width);
     const availH = limit(props.maxHeight, area?.height);
+    const hints = {};
     if (!yoga) {
       // Only reachable on a torn-down window, and a size still has to be a
       // size: fall back to the space on offer rather than handing `'auto'`
-      // through to CreateWindow.
+      // through to CreateWindow. Nothing left to measure a bound against.
       return {
         width: autoW
-          ? clampExtent(availW, props.minWidth, availW)
+          ? clampExtent(availW, numericBound(props.minWidth), availW)
           : props.width,
         height: autoH
-          ? clampExtent(availH, props.minHeight, availH)
+          ? clampExtent(availH, numericBound(props.minHeight), availH)
           : props.height,
+        hints,
       };
     }
-    if (!autoW && !autoH) return { width: props.width, height: props.height };
 
-    // The root carries whatever size the last flush() pinned on it; clearing
-    // an axis is what makes yoga measure it rather than fill it.
-    yoga.setWidth(autoW ? undefined : props.width);
-    yoga.setHeight(autoH ? undefined : props.height);
+    // A numeric floor applies to the natural size as it always has; an
+    // `'auto'` one is measured below. The height's needs a width to be
+    // measured for, and it can never exceed the natural height anyway —
+    // same width, every node at or below the size it settled at — so
+    // nothing is lost by clamping the height without it.
+    const minH = numericBound(props.minHeight);
+
+    // Also run for an axis that is not `'auto'` but whose cap is: a
+    // `maxWidth="auto"` on a window with a `width` still has to find out
+    // what the content wanted.
+    const needW = autoW || isContentBound(props.maxWidth);
+    const needH = autoH || isContentBound(props.maxHeight);
+    if (!needW && !needH) {
+      // Both sizes are the app's, so there is nothing to measure but the
+      // bounds — and nothing re-resolves `@width` blocks here: the styles
+      // are the ones the window's real size resolved on the last frame,
+      // which is the size the floors are wanted for.
+      if (isContentBound(props.minWidth)) {
+        hints.minWidth = clampBound(this._measureMinimum('width'), availW);
+      }
+      this._finishHeightFloor(
+        hints,
+        props,
+        this.window?.width ?? props.width,
+        availH,
+      );
+      return { width: props.width, height: props.height, hints };
+    }
 
     const measure = () => {
-      let width = props.width;
-      if (autoW) {
+      // The root carries whatever size the last flush() pinned on it — and
+      // whatever the floor pass below cleared — so this is re-stated per
+      // call rather than hoisted: clearing an axis is what makes yoga
+      // measure it rather than fill it.
+      yoga.setWidth(needW ? undefined : props.width);
+      yoga.setHeight(needH ? undefined : props.height);
+      let naturalW;
+      if (needW) {
         yoga.calculateLayout(
           undefined,
-          autoH ? undefined : props.height,
+          needH ? undefined : props.height,
           Yoga.DIRECTION_LTR,
         );
-        width = clampExtent(yoga.getComputedWidth(), props.minWidth, availW);
+        naturalW = clampExtent(yoga.getComputedWidth(), undefined, availW);
       }
+      const width = autoW ? clampExtent(naturalW, minW, availW) : props.width;
       // The height-for-width pass. Run even when only the width is auto: it
       // is the layout the window is about to be created at, so leaving the
       // tree holding the max-content one would hand `flush()` a stale
       // arrangement.
       yoga.calculateLayout(
         width,
-        autoH ? undefined : props.height,
+        needH ? undefined : props.height,
         Yoga.DIRECTION_LTR,
       );
-      const height = autoH
-        ? clampExtent(yoga.getComputedHeight(), props.minHeight, availH)
-        : props.height;
-      return { width, height };
+      const naturalH = needH
+        ? clampExtent(yoga.getComputedHeight(), undefined, availH)
+        : undefined;
+      const height = autoH ? clampExtent(naturalH, minH, availH) : props.height;
+      return { width, height, naturalW, naturalH };
     };
 
     // `@width`/`@height` blocks and an auto size are mutually circular: the
@@ -4741,9 +4980,49 @@ export class WindowNode extends Scrollable(Node) {
       autoW ? availW : props.width,
       autoH ? availH : props.height,
     );
+
+    // The width floor, measured against the styles the pass below starts
+    // from and before it, because it is what the natural width is clamped
+    // into. Bounded by the same space the size is: a floor wider than the
+    // screen is a window that cannot be put on it, and a floor past
+    // `maxWidth` is a `WM_NORMAL_HINTS` that contradicts itself.
+    const minW = isContentBound(props.minWidth)
+      ? (hints.minWidth = clampBound(this._measureMinimum('width'), availW))
+      : props.minWidth;
+
     let size = measure();
     if (this._resolveSizeQueries(size.width, size.height)) size = measure();
-    return size;
+
+    // A cap the content decides is its natural size, never below a floor
+    // that was named as a number: `WM_NORMAL_HINTS` with a min above its own
+    // max is a struct no window manager can honour.
+    if (isContentBound(props.maxWidth)) {
+      hints.maxWidth = Math.max(size.naturalW, minW ?? 0);
+    }
+    if (isContentBound(props.maxHeight)) {
+      hints.maxHeight = Math.max(size.naturalH, minH ?? 0);
+    }
+    // Last, because it is a height *for a width*: the width the window is
+    // about to have where the width is still ours to choose, and the one it
+    // has where it is not.
+    const forWidth =
+      autoW && !this._userSized
+        ? size.width
+        : (this.window?.width ?? size.width);
+    this._finishHeightFloor(hints, props, forWidth, availH);
+    return { width: size.width, height: size.height, hints };
+  }
+
+  /** The `minHeight="auto"` floor, measured for the width just settled. */
+  _finishHeightFloor(hints, props, forWidth, availH) {
+    if (!isContentBound(props.minHeight)) return;
+    hints.minHeight = clampBound(
+      this._measureMinimum('height', forWidth),
+      availH,
+    );
+    if (isContentBound(props.maxHeight)) {
+      hints.maxHeight = Math.max(hints.maxHeight ?? 0, hints.minHeight);
+    }
   }
 
   /**
@@ -4762,14 +5041,29 @@ export class WindowNode extends Scrollable(Node) {
    * The result is applied through the window rather than through props: an
    * auto size is not something React said, so nothing about it should read
    * as a prop change or wait for one.
+   *
+   * A **bound** the content decides is not covered by that rule and outlives
+   * it: `minWidth="auto"` still means the same thing after the user has
+   * taken the size over — it is what stops them taking it *too far* — and it
+   * means it on a window with a `width` of its own, which never tracked
+   * anything. So the floor is re-measured on every frame that lays out, and
+   * the size only while it is still the window's to choose.
    */
   _refit() {
-    if (this._userSized || this.destroyed) return;
-    if (!isAutoSize(this.props.width) && !isAutoSize(this.props.height)) return;
+    if (this.destroyed) return;
     const wnd = this.window;
     if (!wnd) return;
+    const props = this.props;
+    const tracking =
+      !this._userSized && (isAutoSize(props.width) || isAutoSize(props.height));
+    const bounded = CONTENT_BOUND_PROPS.some((key) =>
+      isContentBound(props[key]),
+    );
+    if (!tracking && !bounded) return;
     const asked = this._requestedSize;
-    const next = this._measureNatural();
+    const next = this._measure();
+    this._sendSizeHints(props, next.hints);
+    if (!tracking) return;
     if (asked && next.width === asked.width && next.height === asked.height) {
       return;
     }
@@ -4801,10 +5095,18 @@ export class WindowNode extends Scrollable(Node) {
     // Before CreateWindow, so an auto-sized window is *born* the right size.
     // Doing it after would mean a window mapped at 800x800 and corrected a
     // frame later, which is the jump this exists to avoid.
-    const natural = this._measureNatural();
+    const natural = this._measure();
     attributes.width = natural.width;
     attributes.height = natural.height;
     this._requestedSize = { width: natural.width, height: natural.height };
+    // A bound the content decides is a number by now, and the window manager
+    // reads `WM_NORMAL_HINTS` when it frames the window — so it goes in with
+    // the creation attributes rather than chasing the map with a second
+    // property write.
+    if (Object.keys(natural.hints).length > 0) {
+      this._sentHints = this._hintsToSend(this.props, natural.hints);
+      attributes.sizeHints = this._sentHints;
+    }
     // **What the server paints into newly exposed area.** A resize enlarges
     // the window before the app can possibly have drawn the new part, and X
     // fills it with this attribute in the meantime — so without one, growing
@@ -5186,10 +5488,16 @@ export class WindowNode extends Scrollable(Node) {
       next.resizable !== prev.resizable ||
       !shallowEqual(hints, this._sizeHints(prev))
     ) {
-      wnd.setSizeHints?.({
-        ...hints,
-        ...(next.resizable === false && { resizable: false }),
-      });
+      if (CONTENT_BOUND_PROPS.some((key) => isContentBound(next[key]))) {
+        // A bound this commit cannot resolve: `'auto'` is a measurement, and
+        // measuring leaves the tree laid out at a size that is nobody's
+        // arrangement. Asking for the layout this frame owes anyway is what
+        // makes it safe — `flush()` measures, sends the hints and lays the
+        // tree back out, in that order.
+        this.invalidate(true, null, 'props');
+      } else {
+        this._sendSizeHints(next);
+      }
     }
     if (!shallowEqual(next.wmClass, prev.wmClass) && next.wmClass) {
       const c = next.wmClass;
@@ -5283,13 +5591,64 @@ export class WindowNode extends Scrollable(Node) {
     wnd.setTransientFor(id);
   }
 
-  /** The WM size hints among these props. */
+  /** The WM size hints among these props, as the author wrote them. */
   _sizeHints(props) {
     const hints = {};
     for (const key of WINDOW_HINT_PROPS) {
       if (props[key] !== undefined) hints[key] = props[key];
     }
     return hints;
+  }
+
+  /**
+   * The whole `WM_NORMAL_HINTS` struct to write: what the author named, with
+   * every `'auto'` replaced by the number `_measure()` resolved for it.
+   *
+   * Whole, because `setSizeHints` writes the property outright and carries
+   * nothing over from the last call — a floor sent on its own would drop the
+   * `widthInc` beside it. A bound left unresolved (a torn-down window with
+   * nothing to measure) is dropped rather than sent: `'auto'` reaches the
+   * wire as a CARD32 of 0, which is a floor of nothing dressed up as a
+   * declaration.
+   */
+  _hintsToSend(props, resolved) {
+    const hints = { ...this._sizeHints(props), ...resolved };
+    for (const key of CONTENT_BOUND_PROPS) {
+      if (isContentBound(hints[key])) delete hints[key];
+    }
+    if (props.resizable === false) hints.resizable = false;
+    return hints;
+  }
+
+  /**
+   * Write the hints, if they are not the ones already written.
+   *
+   * Diffed against what actually went out rather than against props: a
+   * content-measured bound is recomputed on every frame that lays out, and
+   * most frames move nothing. Without the check, a window with
+   * `minWidth="auto"` would spend a `ChangeProperty` per frame restating a
+   * number the window manager already has.
+   *
+   * `resizable: false` is the one hint whose meaning is not in its keys — it
+   * pins min and max to the size the window has *at the call* — so the size
+   * is part of what is compared, and a window that pins itself and then
+   * grows re-pins at the size it grew to.
+   */
+  _sendSizeHints(props = this.props, resolved = null) {
+    const wnd = this.window;
+    if (!wnd || typeof wnd.setSizeHints !== 'function') return;
+    const hints = this._hintsToSend(props, resolved);
+    if (Object.keys(hints).length === 0) return;
+    const at = `${wnd.width}x${wnd.height}`;
+    if (
+      shallowEqual(hints, this._sentHints) &&
+      (hints.resizable !== false || at === this._sentHintsAt)
+    ) {
+      return;
+    }
+    this._sentHints = hints;
+    this._sentHintsAt = at;
+    wnd.setSizeHints(hints);
   }
 
   get semanticNames() {

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -743,6 +743,27 @@ function assertWindowSize(props, kind) {
 }
 
 /**
+ * Record how tall every leaf in this subtree currently is, keyed by node.
+ *
+ * A leaf's height at a given width is not something it can give: a
+ * paragraph wrapped to 300px is as tall as it is. But `align-items` defaults
+ * to `stretch`, so a leaf inside a `row` takes the row's height — and in a
+ * pass run with no height on offer the row came out at nothing, taking its
+ * leaves down with it. A container in that position is recovered by looking
+ * inside it; a leaf has nothing inside, which is what this is for.
+ */
+function captureLeafHeights(node, out) {
+  let leaf = true;
+  for (const child of node.children) {
+    if (!child.yoga || child.isWindow) continue;
+    if (child.style.display === 'none') continue;
+    if (child.style.position !== 'absolute') leaf = false;
+    captureLeafHeights(child, out);
+  }
+  if (leaf) out.set(node, node.yoga.getComputedHeight());
+}
+
+/**
  * Whether this node's laid-out size is already the answer for `axis`, so
  * that what is inside it stops counting towards a floor.
  *
@@ -795,8 +816,13 @@ function boundsItsOwnContent(node, axis, axisIsMain) {
  * Out-of-flow children are skipped, as they are in CSS: an absolutely
  * positioned node contributes nothing to what contains it, and a
  * `display: 'none'` one is not there at all.
+ *
+ * `intrinsic` carries what the leaves measured to before the pass being read
+ * squashed them — see `_measureMinimum`, which is the only caller that needs
+ * it. A container that came out at nothing is recovered by looking inside
+ * it; a leaf has nothing inside, so it has to be remembered.
  */
-function contentSpan(node, axis) {
+function contentSpan(node, axis, intrinsic) {
   const yoga = node.yoga;
   const horizontal = axis === 'width';
   const own = horizontal ? yoga.getComputedWidth() : yoga.getComputedHeight();
@@ -808,25 +834,50 @@ function contentSpan(node, axis) {
   const axisIsMain = rowFirst === horizontal;
   let start = Infinity;
   let end = -Infinity;
+  // What the children after this one were laid out too early by. A node the
+  // pass squashed is one its siblings were packed in behind, so recovering
+  // its extent without moving them along would lose exactly what was
+  // recovered — the span would come out the same as before.
+  let shift = 0;
   for (const child of node.children) {
     // the same set that joins the flex tree: a nested <window> is laid out
     // by itself, and a <text> span has no box of its own
     if (!child.yoga || child.isWindow) continue;
     if (child.style.position === 'absolute') continue;
     if (child.style.display === 'none') continue;
-    const at = horizontal
-      ? child.yoga.getComputedLeft()
-      : child.yoga.getComputedTop();
-    let extent = horizontal
+    const at =
+      (horizontal
+        ? child.yoga.getComputedLeft()
+        : child.yoga.getComputedTop()) + shift;
+    const laidOut = horizontal
       ? child.yoga.getComputedWidth()
       : child.yoga.getComputedHeight();
+    let extent = laidOut;
     if (!boundsItsOwnContent(child, axis, axisIsMain)) {
-      extent = Math.max(extent, contentSpan(child, axis));
+      extent = Math.max(extent, contentSpan(child, axis, intrinsic));
     }
+    // Only along the axis the children are packed on: on the other one they
+    // all start from the same edge, so nothing follows anything.
+    if (axisIsMain) shift += extent - laidOut;
     start = Math.min(start, at);
     end = Math.max(end, at + extent);
   }
-  if (start === Infinity) return own;
+  if (start === Infinity) {
+    // A leaf: nothing inside to look at, and what the pass did to it may
+    // have been a stretch rather than a measurement. So it is asked again —
+    // across, for the size its content cannot go below, which for a
+    // paragraph is its longest word; down, for what it measured before the
+    // collapse, since a height at a settled width is not a leaf's to give.
+    const measured = horizontal
+      ? node._measureFn?.(
+          0,
+          Yoga.MEASURE_MODE_AT_MOST,
+          undefined,
+          Yoga.MEASURE_MODE_UNDEFINED,
+        )?.width
+      : intrinsic?.get(node);
+    return Math.max(own, measured ?? 0);
+  }
   const edges =
     yoga.getComputedPadding(startEdge) +
     yoga.getComputedPadding(endEdge) +
@@ -1317,6 +1368,23 @@ export class Node {
 
   _joinsYoga(child) {
     return Boolean(this.yoga && child.yoga && !child.isWindow);
+  }
+
+  /**
+   * Give this node's box a measure function, keeping a reference that can be
+   * asked again later.
+   *
+   * A leaf's content is recorded nowhere but in its measure function, and
+   * the size yoga keeps for it is not always what that function said:
+   * `align-items` defaults to `stretch`, so in a pass run with no room on
+   * offer — which is how a content floor is measured, see `contentSpan` —
+   * the cross size a leaf ends up at is the container's, not its own. A
+   * container in that position is recovered by looking inside it. A leaf
+   * has nothing inside, so it is asked again instead.
+   */
+  _setMeasureFunc(measure) {
+    this._measureFn = measure;
+    this.yoga.setMeasureFunc(measure);
   }
 
   appendChild(child) {
@@ -2310,7 +2378,7 @@ export class TextNode extends Node {
     this.isSpan = span;
     this._layouts = new Map();
     if (this.yoga) {
-      this.yoga.setMeasureFunc((width, widthMode) => {
+      this._setMeasureFunc((width, widthMode) => {
         const maxWidth =
           widthMode === Yoga.MEASURE_MODE_UNDEFINED ? Infinity : width;
         const layout = this._layoutFor(this._wrapWidth(maxWidth));
@@ -2536,7 +2604,7 @@ export class ImageNode extends Node {
     super('image', props, app);
     this.image = null;
     this._loadToken = 0;
-    this.yoga.setMeasureFunc(
+    this._setMeasureFunc(
       intrinsicMeasure(() => ({
         width: this.image?.width ?? 0,
         height: this.image?.height ?? 0,
@@ -3358,7 +3426,7 @@ export class TextInputNode extends Node {
     this._undoRun = null;
     // the open built-in edit menu, if any (see _openEditMenu)
     this._editMenu = null;
-    this.yoga.setMeasureFunc((width, widthMode) => {
+    this._setMeasureFunc((width, widthMode) => {
       const preferred = 150;
       const w =
         widthMode === Yoga.MEASURE_MODE_UNDEFINED
@@ -4488,7 +4556,7 @@ export class TextAreaNode extends TextInputNode {
     super(props, app, 'textarea');
     this._scrollY = 0;
     this._goalX = null;
-    this.yoga.setMeasureFunc((width, widthMode) => {
+    this._setMeasureFunc((width, widthMode) => {
       const preferred = 220;
       const w =
         widthMode === Yoga.MEASURE_MODE_UNDEFINED
@@ -4825,10 +4893,19 @@ export class WindowNode extends Scrollable(Node) {
     yoga.setHeight(undefined);
     if (axis === 'width') {
       yoga.calculateLayout(0, undefined, Yoga.DIRECTION_LTR);
-    } else {
-      yoga.calculateLayout(forWidth, 0, Yoga.DIRECTION_LTR);
+      return Math.ceil(contentSpan(this, axis));
     }
-    return Math.ceil(contentSpan(this, axis));
+    // Height takes two passes. The first is the tree at its real width with
+    // no bound on the height, which is where every leaf reports the height
+    // it actually needs there — a wrapped paragraph's is settled by the
+    // width, and no leaf can give any of it back. The second is the one
+    // that collapses, and it squashes a leaf that a `row` stretches: those
+    // are the ones the map above puts back.
+    yoga.calculateLayout(forWidth, undefined, Yoga.DIRECTION_LTR);
+    const intrinsic = new Map();
+    captureLeafHeights(this, intrinsic);
+    yoga.calculateLayout(forWidth, 0, Yoga.DIRECTION_LTR);
+    return Math.ceil(contentSpan(this, axis, intrinsic));
   }
 
   /**

--- a/src/richnodes.js
+++ b/src/richnodes.js
@@ -42,7 +42,7 @@ class DocumentViewNode extends Node {
     super(kind, props, app);
     this.view = null;
     this._laidOutWidth = -1;
-    this.yoga.setMeasureFunc((width, widthMode) => {
+    this._setMeasureFunc((width, widthMode) => {
       const view = this._ensureView();
       if (!view) return { width: 0, height: 0 };
       const unconstrained =
@@ -296,7 +296,7 @@ export class SvgNode extends Node {
      * See the note there. */
     this._docRevision = 0;
     this._paintedRevision = -1;
-    this.yoga.setMeasureFunc(
+    this._setMeasureFunc(
       intrinsicMeasure(() => {
         const view = this._ensureView();
         return {
@@ -492,7 +492,7 @@ export class TexNode extends Node {
     super('tex', props, app);
     this.box = null;
     this._boxKey = null;
-    this.yoga.setMeasureFunc(() => {
+    this._setMeasureFunc(() => {
       const box = this._ensureBox();
       if (!box) return { width: 0, height: 0 };
       return { width: Math.ceil(box.width), height: Math.ceil(box.height) };

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -183,12 +183,18 @@ export interface DrawnProps<T = DrawnNode>
 
 // --- windows ---------------------------------------------------------------
 
-/** ICCCM `WM_NORMAL_HINTS` — what the window manager will let the user do. */
+/**
+ * ICCCM `WM_NORMAL_HINTS` — what the window manager will let the user do.
+ *
+ * The four bounds also take `'auto'`, which asks the content: on a floor
+ * that is the smallest size it can be drawn at, and on a cap the size it
+ * wanted. Both are re-measured as the content changes.
+ */
 export interface SizeHintProps {
-  minWidth?: number;
-  minHeight?: number;
-  maxWidth?: number;
-  maxHeight?: number;
+  minWidth?: number | 'auto';
+  minHeight?: number | 'auto';
+  maxWidth?: number | 'auto';
+  maxHeight?: number | 'auto';
   widthInc?: number;
   heightInc?: number;
   baseWidth?: number;

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1533,3 +1533,66 @@ test('a window with no size fits its text, and wraps to fit the screen', async (
     await app.close();
   }
 });
+
+test('a content floor is measured through real glyphs and read back', async () => {
+  // The two claims about `minWidth="auto"` that need a font to make, read
+  // back off the server as the window manager would see them.
+  const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
+  try {
+    const wnd = await render(
+      React.createElement(
+        'window',
+        { title: 'floor', minWidth: 'auto', minHeight: 'auto' },
+        React.createElement(
+          'text',
+          { style: { fontSize: 20 } },
+          'wrap me somewhere sensible',
+        ),
+      ),
+      x11Root,
+    );
+    await settle(app);
+    const hints = await wnd.getSizeHints();
+
+    // A paragraph's floor is the width of its longest word: it may be made
+    // much narrower than the line it opened as without a word being cut.
+    assert.ok(
+      hints.minWidth > 0 && hints.minWidth < wnd.width / 2,
+      `a floor well under the unwrapped line (got ${hints.minWidth} of ${wnd.width})`,
+    );
+    assert.ok(
+      hints.minHeight >= wnd.height,
+      'and at that width the same text is at least as tall',
+    );
+
+    // A leaf inside a `row` is stretched to the row's height, and the pass
+    // that measures the floor gives the row no height to stretch to — so a
+    // squashed measure function is what this asserts is *not* believed.
+    const stacked = await render(
+      React.createElement(
+        'window',
+        { key: 'stacked', title: 'stacked', minHeight: 'auto', width: 400 },
+        React.createElement(
+          'box',
+          { style: { flexDirection: 'row', gap: 8 } },
+          React.createElement('text', { style: { fontSize: 20 } }, 'All'),
+          React.createElement('text', { style: { fontSize: 20 } }, 'Done'),
+        ),
+        React.createElement('box', { style: { width: 40, height: 30 } }),
+      ),
+      x11Root,
+    );
+    await settle(app);
+    const stackedHints = await stacked.getSizeHints();
+    // Nothing here can give, so the floor is the whole natural height —
+    // the row of text included, and the 30-tall box after it not shifted
+    // up into the space the row would have vacated.
+    assert.strictEqual(stackedHints.minHeight, stacked.height);
+    assert.ok(stackedHints.minHeight > 30, 'the row of text was counted');
+
+    await x11Root.unmount();
+  } finally {
+    await app.close();
+  }
+});

--- a/test/window-min-size.test.js
+++ b/test/window-min-size.test.js
@@ -457,3 +457,33 @@ test('a window that pins itself re-pins at the size it grew to', async () => {
   assert.ok(pinnedAt.length > 0, 'the pin was re-sent after the window grew');
   await root.unmount();
 });
+
+test('a row of containers is floored by the sum of what they hold', async () => {
+  // The pass that measures the floor offers nothing, so a container with no
+  // size of its own comes out at nothing and the ones after it are packed
+  // in behind it. Recovering what each holds without moving the rest along
+  // would measure the two boxes below as if they overlapped.
+  const { wnd, root } = await mount(
+    h(
+      'window',
+      { minWidth: 'auto' },
+      h(
+        'box',
+        { style: { flexDirection: 'row', gap: 10 } },
+        h(
+          'box',
+          { key: 'a', style: { padding: 4 } },
+          box({ width: 90, height: 20 }, 'inner'),
+        ),
+        h(
+          'box',
+          { key: 'b', style: { padding: 4 } },
+          box({ width: 70, height: 20 }, 'inner'),
+        ),
+      ),
+    ),
+  );
+  // (90 + 8) + 10 + (70 + 8)
+  assert.strictEqual(hintsOf(wnd).minWidth, 186);
+  await root.unmount();
+});

--- a/test/window-min-size.test.js
+++ b/test/window-min-size.test.js
@@ -1,0 +1,459 @@
+// A `<window>` bound the *content* decides: `minWidth="auto"` and friends.
+//
+// The floor is measured by laying the tree out with no room at all and
+// reading how far it still reached — so what a node contributes is whatever
+// its own style lets it shrink to, and a node that was told it may shrink
+// (`flexShrink`, `overflow: 'scroll'`) contributes nothing. That is the
+// escape hatch Qt spells `QScrollArea` and GTK spells `min-content-width`,
+// and most of what is asserted here is which side of it a node falls on.
+//
+// Headless, so there are no fonts and text measures 0x0 (see AGENTS.md): the
+// content is sized boxes throughout, and the height-for-width case is built
+// out of `flexWrap` rather than out of a wrapping paragraph.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import { createRoot } from '../src/index.js';
+import { createMockApp } from './helpers/mock-app.js';
+import { setScreensForTests } from '../src/screens.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+async function mount(element, { screens } = {}) {
+  const app = createMockApp();
+  if (screens !== undefined) setScreensForTests(app, screens);
+  const root = await createRoot({ app });
+  root.render(element);
+  await tick();
+  return { app, root, wnd: app.windows[0] };
+}
+
+const box = (style, key) => h('box', { key, style });
+
+/** The hints the window was created with, or the last ones written to it. */
+const hintsOf = (wnd) => {
+  const sent = wnd.calls.filter(([name]) => name === 'setSizeHints');
+  return sent.length ? sent[sent.length - 1][1] : wnd.attributes.sizeHints;
+};
+
+/** A window whose content is a row of rigid boxes, floored by that row. */
+const rigidRow = (props, widths = [120, 90]) =>
+  h(
+    'window',
+    { title: 'floor', minWidth: 'auto', ...props },
+    h(
+      'box',
+      { style: { flexDirection: 'row' } },
+      ...widths.map((w, i) => box({ width: w, height: 40 }, i)),
+    ),
+  );
+
+// --- what the floor is ------------------------------------------------------
+
+test('minWidth="auto" is the width the content cannot go below', async () => {
+  const { wnd, root } = await mount(rigidRow());
+  assert.strictEqual(hintsOf(wnd).minWidth, 210);
+  await root.unmount();
+});
+
+test('the floor counts the padding and border around the content', async () => {
+  const { wnd, root } = await mount(
+    h(
+      'window',
+      { minWidth: 'auto', style: { padding: 10, borderWidth: 2 } },
+      box({ width: 100, height: 20 }),
+    ),
+  );
+  assert.strictEqual(hintsOf(wnd).minWidth, 124);
+  await root.unmount();
+});
+
+test('a row that overflows both ways is still measured whole', async () => {
+  // With less room than it needs, a centered row overflows to the left as
+  // well as the right — CSS says so — and its first child's edge lands at a
+  // negative offset. Read as a rightmost edge the floor would be half the
+  // truth; read as a span it is the whole row.
+  const { wnd, root } = await mount(
+    h(
+      'window',
+      { minWidth: 'auto' },
+      h(
+        'box',
+        { style: { flexDirection: 'row', justifyContent: 'center' } },
+        box({ width: 120, height: 20 }, 'a'),
+        box({ width: 120, height: 20 }, 'b'),
+      ),
+    ),
+  );
+  assert.strictEqual(hintsOf(wnd).minWidth, 240);
+  await root.unmount();
+});
+
+test('the gap between items is part of the floor', async () => {
+  const { wnd, root } = await mount(
+    h(
+      'window',
+      { minWidth: 'auto' },
+      h(
+        'box',
+        { style: { flexDirection: 'row', gap: 8 } },
+        box({ width: 100, height: 20 }, 'a'),
+        box({ width: 100, height: 20 }, 'b'),
+      ),
+    ),
+  );
+  assert.strictEqual(hintsOf(wnd).minWidth, 208);
+  await root.unmount();
+});
+
+test('a column is floored by its widest row, not by their sum', async () => {
+  const { wnd, root } = await mount(
+    h(
+      'window',
+      { minWidth: 'auto' },
+      box({ width: 100, height: 20 }, 'a'),
+      box({ width: 300, height: 20 }, 'b'),
+      box({ width: 80, height: 20 }, 'c'),
+    ),
+  );
+  assert.strictEqual(hintsOf(wnd).minWidth, 300);
+  await root.unmount();
+});
+
+// --- what does not floor it -------------------------------------------------
+
+test('a scroll container contributes nothing to the floor', async () => {
+  // The escape hatch, and it costs the author nothing to reach: `overflow:
+  // 'scroll'` already resolves to `minWidth: 0, flexShrink: 1`, so the pass
+  // that measures the floor finds a pane that can give everything. What is
+  // left is the rigid sidebar beside it.
+  const { wnd, root } = await mount(
+    h(
+      'window',
+      { minWidth: 'auto', width: 900, height: 400 },
+      h(
+        'box',
+        { style: { flexDirection: 'row' } },
+        box({ width: 160, height: 40, flexShrink: 0 }, 'sidebar'),
+        h(
+          'box',
+          { key: 'pane', style: { overflow: 'scroll', flexGrow: 1 } },
+          box({ width: 2000, height: 40 }, 'wide'),
+        ),
+      ),
+    ),
+  );
+  assert.strictEqual(hintsOf(wnd).minWidth, 160);
+  await root.unmount();
+});
+
+test('a box told it may shrink is taken at its word', async () => {
+  const { wnd, root } = await mount(
+    h(
+      'window',
+      { minWidth: 'auto', width: 600, height: 200 },
+      h(
+        'box',
+        { style: { flexDirection: 'row' } },
+        h(
+          'box',
+          { key: 'giving', style: { flexShrink: 1 } },
+          box({ width: 400, height: 20 }, 'inside'),
+        ),
+        box({ width: 100, height: 20, flexShrink: 0 }, 'rigid'),
+      ),
+    ),
+  );
+  assert.strictEqual(hintsOf(wnd).minWidth, 100);
+  await root.unmount();
+});
+
+test('an absolutely positioned node does not floor its container', async () => {
+  const { wnd, root } = await mount(
+    h(
+      'window',
+      { minWidth: 'auto' },
+      box({ width: 120, height: 20 }, 'flow'),
+      box({ position: 'absolute', width: 900, height: 20 }, 'badge'),
+    ),
+  );
+  assert.strictEqual(hintsOf(wnd).minWidth, 120);
+  await root.unmount();
+});
+
+// --- the bounds around the bound --------------------------------------------
+
+test('the floor is capped at the space the window can have', async () => {
+  // A floor past the screen is a window that cannot be put on it.
+  const { wnd, root } = await mount(
+    h('window', { minWidth: 'auto' }, box({ width: 5000, height: 40 })),
+    { screens: { monitors: [{ x: 0, y: 0, width: 1280, height: 800 }] } },
+  );
+  assert.strictEqual(hintsOf(wnd).minWidth, 1280);
+  await root.unmount();
+});
+
+test('a floor never comes out above a maxWidth beside it', async () => {
+  const { wnd, root } = await mount(
+    h(
+      'window',
+      { minWidth: 'auto', maxWidth: 300 },
+      box({ width: 800, height: 40 }),
+    ),
+  );
+  const hints = hintsOf(wnd);
+  assert.strictEqual(hints.minWidth, 300, 'clamped, not contradictory');
+  assert.ok(hints.minWidth <= hints.maxWidth);
+  await root.unmount();
+});
+
+test('maxWidth="auto" is the size the content wanted', async () => {
+  // The other half of the pair: `'auto'` means "ask the content", and the
+  // content's answer to *how big* is its natural size, not its minimum.
+  const { wnd, root } = await mount(
+    h(
+      'window',
+      { width: 400, height: 200, maxWidth: 'auto' },
+      h(
+        'box',
+        { style: { flexDirection: 'row' } },
+        box({ width: 260, height: 20, flexShrink: 1 }, 'a'),
+        box({ width: 100, height: 20, flexShrink: 0 }, 'b'),
+      ),
+    ),
+  );
+  assert.strictEqual(hintsOf(wnd).maxWidth, 360, 'unshrunk, unwrapped');
+  await root.unmount();
+});
+
+test('a rigid window pinned both ways is its natural size, once', async () => {
+  // Where nothing can give, the minimum and the natural size are the same
+  // number — which is what makes `minWidth="auto" maxWidth="auto"` the
+  // fixed-size dialog on such a tree, the same thing `resizable={false}`
+  // says a shorter way.
+  const { wnd, root } = await mount(
+    rigidRow({ maxWidth: 'auto', minWidth: 'auto' }),
+  );
+  const hints = hintsOf(wnd);
+  assert.strictEqual(hints.minWidth, 210);
+  assert.strictEqual(hints.maxWidth, 210);
+  assert.strictEqual(wnd.width, 210, 'and the window opened there');
+  await root.unmount();
+});
+
+test('minHeight="auto" is measured for the width the window has', async () => {
+  // Height-for-width, and the reason the floor cannot be one number: three
+  // 100-wide chips are one row at 320 and two rows at 250, so the height
+  // the window must not go below depends on the width it is at.
+  const chips = (width) =>
+    h(
+      'window',
+      { width, minHeight: 'auto' },
+      h(
+        'box',
+        { style: { flexDirection: 'row', flexWrap: 'wrap' } },
+        box({ width: 100, height: 30 }, 'a'),
+        box({ width: 100, height: 30 }, 'b'),
+        box({ width: 100, height: 30 }, 'c'),
+      ),
+    );
+  const wide = await mount(chips(320));
+  assert.strictEqual(hintsOf(wide.wnd).minHeight, 30, 'one row at 320');
+  await wide.root.unmount();
+
+  const narrow = await mount(chips(250));
+  assert.strictEqual(hintsOf(narrow.wnd).minHeight, 60, 'two rows at 250');
+  await narrow.root.unmount();
+});
+
+// --- when it is written -----------------------------------------------------
+
+test('the floor is in place before the window is mapped', async () => {
+  // Same rule the natural size follows: the window manager reads
+  // WM_NORMAL_HINTS when it frames the window, so a floor that arrives after
+  // the map is a floor the frame was not built with.
+  const { wnd, root } = await mount(rigidRow());
+  assert.strictEqual(wnd.attributes.sizeHints.minWidth, 210, 'at CreateWindow');
+  assert.deepStrictEqual(
+    wnd.calls.filter(([name]) => name === 'setSizeHints'),
+    [],
+    'and not re-sent behind the map',
+  );
+  await root.unmount();
+});
+
+test("'auto' never reaches the wire", async () => {
+  // It is a measurement, not a value: as a CARD32 it is 0, which is a floor
+  // of nothing wearing the flag that says one was declared.
+  const { wnd, root } = await mount(
+    rigidRow({ minHeight: 'auto', maxWidth: 'auto', maxHeight: 'auto' }),
+  );
+  for (const [key, value] of Object.entries(hintsOf(wnd))) {
+    assert.strictEqual(typeof value, 'number', `${key} is a number`);
+  }
+  await root.unmount();
+});
+
+function Rows({ n, ...props }) {
+  return h(
+    'window',
+    { title: 'rows', minWidth: 'auto', minHeight: 'auto', ...props },
+    ...Array.from({ length: n }, (_, i) =>
+      box({ width: 100 + i * 10, height: 30 }, i),
+    ),
+  );
+}
+
+test('the floor follows the content', async () => {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(h(Rows, { n: 2 }));
+  await tick();
+  const wnd = app.windows[0];
+  assert.strictEqual(hintsOf(wnd).minHeight, 60);
+
+  root.render(h(Rows, { n: 5 }));
+  await tick();
+  assert.strictEqual(hintsOf(wnd).minHeight, 150, 'three more rows');
+  assert.strictEqual(hintsOf(wnd).minWidth, 140, 'and the widest of them');
+  await root.unmount();
+});
+
+test('a floor that did not move is not sent again', async () => {
+  // Measured every frame that lays out; written only when it changes. A
+  // ChangeProperty per frame restating a number the window manager already
+  // has is the cost this has to not have.
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(h(Rows, { n: 2 }));
+  await tick();
+  const wnd = app.windows[0];
+  const before = wnd.calls.filter(([name]) => name === 'setSizeHints').length;
+
+  root.render(h(Rows, { n: 2, title: 'renamed' }));
+  await tick();
+  wnd.flushFrame?.();
+  await tick();
+  assert.strictEqual(
+    wnd.calls.filter(([name]) => name === 'setSizeHints').length,
+    before,
+  );
+  await root.unmount();
+});
+
+test('the floor outlives the user taking the size over', async () => {
+  // The size stops tracking once the user drags an edge; the floor is what
+  // stops them dragging it too far, so it goes on being measured.
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(h(Rows, { n: 2 }));
+  await tick();
+  const wnd = app.windows[0];
+
+  wnd.width = 400;
+  wnd.height = 400;
+  wnd.emit('resize', { width: 400, height: 400, resized: true, moved: false });
+  await tick();
+
+  root.render(h(Rows, { n: 6 }));
+  await tick();
+  assert.strictEqual(wnd.width, 400, 'the size the user chose stands');
+  assert.strictEqual(hintsOf(wnd).minHeight, 180, 'the floor kept up');
+  await root.unmount();
+});
+
+test('a window that never tracked its size still gets a floor', async () => {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(h(Rows, { n: 2, width: 500, height: 500 }));
+  await tick();
+  const wnd = app.windows[0];
+  assert.strictEqual(wnd.height, 500, 'the app said so');
+  assert.strictEqual(hintsOf(wnd).minHeight, 60, 'the content said so');
+
+  root.render(h(Rows, { n: 4, width: 500, height: 500 }));
+  await tick();
+  assert.strictEqual(hintsOf(wnd).minHeight, 120);
+  await root.unmount();
+});
+
+test('handing a bound over to the content measures it', async () => {
+  // A bound that becomes `'auto'` changes no layout by itself, so the commit
+  // has to ask for the frame that resolves it.
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(h(Rows, { n: 3, minWidth: 40 }));
+  await tick();
+  const wnd = app.windows[0];
+  assert.strictEqual(hintsOf(wnd).minWidth, 40);
+
+  root.render(h(Rows, { n: 3, minWidth: 'auto' }));
+  await tick();
+  assert.strictEqual(hintsOf(wnd).minWidth, 120, 'measured from the content');
+
+  root.render(h(Rows, { n: 3, minWidth: 40 }));
+  await tick();
+  assert.strictEqual(hintsOf(wnd).minWidth, 40, 'and handed back');
+  await root.unmount();
+});
+
+test('the other hints survive a floor being re-sent', async () => {
+  // `setSizeHints` writes the whole struct and carries nothing over, so a
+  // floor sent on its own would drop the increment beside it.
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(h(Rows, { n: 2, widthInc: 8, gravity: 1 }));
+  await tick();
+  const wnd = app.windows[0];
+
+  root.render(h(Rows, { n: 4, widthInc: 8, gravity: 1 }));
+  await tick();
+  const hints = hintsOf(wnd);
+  assert.strictEqual(hints.minHeight, 120, 'the floor moved');
+  assert.strictEqual(hints.widthInc, 8, 'and took the rest with it');
+  assert.strictEqual(hints.gravity, 1);
+  await root.unmount();
+});
+
+test('a bound that is neither a number nor auto says what to write', async () => {
+  const app = createMockApp();
+  const errors = [];
+  const root = await createRoot({
+    app,
+    onUncaughtError: (e) => errors.push(e),
+  });
+  root.render(h('window', { minWidth: 'min-content' }));
+  await tick();
+  assert.strictEqual(errors.length, 1);
+  assert.match(errors[0].message, /minWidth=\{"min-content"\}/);
+  assert.match(errors[0].message, /a number of pixels or 'auto'/);
+  await root.unmount();
+});
+
+test('a window that pins itself re-pins at the size it grew to', async () => {
+  // `resizable={false}` pins min and max to the size the window has when the
+  // hints are written, so the same struct means a different thing once the
+  // content has moved — the one hint that cannot be diffed on its keys.
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(h(Rows, { n: 2, resizable: false }));
+  await tick();
+  const wnd = app.windows[0];
+  const pinnedAt = [];
+  const record = () => {
+    for (const [name, hints] of wnd.calls) {
+      if (name === 'setSizeHints' && hints.resizable === false) {
+        pinnedAt.push(wnd.height);
+      }
+    }
+  };
+
+  root.render(h(Rows, { n: 5, resizable: false }));
+  await tick();
+  wnd.flushFrame?.();
+  await tick();
+  record();
+  assert.ok(pinnedAt.length > 0, 'the pin was re-sent after the window grew');
+  await root.unmount();
+});


### PR DESCRIPTION
`<window minWidth="auto">` is **the smallest size the content can be drawn at**, measured from the tree and written into `WM_NORMAL_HINTS` — which is what stops the user dragging the window below it. `minHeight`, `maxWidth` and `maxHeight` take it too.

```jsx
<window minWidth="auto" minHeight="auto">   {/* never smaller than my content */}
<window width={900} minWidth="auto" />      {/* my opening size, the content's floor */}
```

### Prior art

Qt and GTK both do this, and in both it is the **default** rather than something you ask for: a Qt layout's `minimumSize()` becomes the window's via `QLayout::SetDefaultConstraint`, and GTK writes the widget tree's minimum into the WM geometry hints (`gtk_window_compute_hints` → `GDK_HINT_MIN_SIZE`). It is opt-in here, because a renderer whose layout is CSS has no floor unless one is asked for — CSS lets content overflow.

### How the floor is measured

One layout pass with **no room on offer at all**, read as how far the tree still reached. `getComputedWidth()` is no use there — a root offered 0 is clamped to 0 — and it is read as a *span* rather than a rightmost edge, because a centered row given less room than it needs overflows both sides and its first child lands at a negative offset.

Every node then contributes whatever its own style lets it shrink to, which makes the escape hatch fall out of styles already in the tree:

| the node | contributes |
| --- | --- |
| a rigid box (`flexShrink` is 0 by default) | its whole size |
| a wrapping row | its widest item |
| text | its longest word |
| `overflow: 'scroll'` / `'hidden'` | nothing |
| `flexShrink: 1`, or a `minWidth: 0` of its own | what it shrank to |

The last two rows are the same escape hatch CSS, Qt and GTK all spell — `min-width: 0`, `QScrollArea`, `min-content-width`. A window around a scrolling pane is floored by everything *except* that pane, and `resolveScrollContainer` already puts `flexShrink: 1, minWidth: 0` on one, so it costs the author nothing.

`'auto'` on a **cap** is the other half of the pair — the natural size, GTK's `natural` to this `minimum`. It means "ask the content", and the content's answer to *how big* is not its answer to *how small*. On a tree where nothing can shrink the two are the same number, which is what makes `minWidth="auto" maxWidth="auto"` the fixed-size dialog.

### Two rules bounds do not share with an `'auto'` size

- They **outlive the user taking the window over** — stopping them going too far is the whole job — and they apply to a window with a size of its own, which never tracked anything. So `_refit()` re-measures on every frame that lays out and writes only on the frames the numbers move.
- `minHeight="auto"` is measured **for the width the window has**, not for its minimum width. A minimum height is a height for a width, `WM_NORMAL_HINTS` holds two independent numbers with no way to say so, and GTK's answer (the minimum at the minimum width) is a taller floor than a wide window needs.

### Verified

23 new tests in `test/window-min-size.test.js`; full suite green apart from three failures that pre-date this branch (`ntk floor`, `textinput`, `<tex>` — font-dependent on my box).

Also checked end to end against the live X server, reading the property back with `xprop`:

- a window whose content is two rigid boxes and a 1200-wide scroll pane opens at 1564 wide and reports `minimum size: 364 by 84` — the rigid boxes, the gaps and the padding, with the scroll pane contributing nothing;
- a **fixed** 700x300 window with `minWidth="auto" minHeight="auto"` reports `140 by 60`, and `260 by 150` once three more rows are added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)