### PR TITLE
feat(style): per-side borders — borderLeftWidth and friends

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -52,6 +52,13 @@ A box with `overflow: 'scroll'` applies exactly that to itself by default.
   `'rgba(0,0,0,.5)'`, `'red'`)
 - `borderWidth`, `borderColor`, `borderRadius`, `borderStyle`
   (`'solid'` default, `'dashed'`)
+- per-side borders: `borderTopWidth`/`Right`/`Bottom`/`Left` override
+  `borderWidth` the way `paddingLeft` overrides `padding`, and
+  `borderTopColor`/… fall back to `borderColor`. A blockquote's bar is
+  `borderLeftWidth: 3` on the quote box, not a 3px sibling; a table rule is
+  `borderBottomWidth: 1` on the row. `borderRadius` requires uniform
+  borders — a non-uniform border paints square
+  ([styling.md](styling.md#per-side-borders))
 - `zIndex` — paint/hit order among siblings (stable sort)
 - `outlineWidth`, `outlineColor`, `outlineOffset` — the focus ring, painted
   outside the border box and invisible to yoga, so it never moves what it

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -128,7 +128,8 @@ that. `:dragging` is set on the source node for the duration of a drag.
 See [drag-and-drop.md](drag-and-drop.md).
 
 **State blocks may only set paint properties** (`backgroundColor`,
-`borderColor`, `borderRadius`, `zIndex`, `outlineWidth`, `outlineColor`,
+`borderColor` and the per-side `borderTopColor`/…, `borderRadius`, `zIndex`,
+`outlineWidth`, `outlineColor`,
 `outlineOffset`, `color`) — enforced at declaration
 time by `createStyles`. A `:hover` that could set `padding` would reflow the
 tree on pointer move: jitter, and the end of the "hover is a repaint" property
@@ -160,6 +161,40 @@ A theme sets `focusRing`, `focusRingWidth` and `focusRingOffset` to restyle
 every ring under it at once — the renderer reads them from the nearest
 `theme` prop, so `<ThemeProvider>` covers the widgets and anything an
 application writes itself.
+
+## Per-side borders
+
+```jsx
+<box
+  style={{ borderLeftWidth: 3, borderLeftColor: '$border', paddingLeft: 10 }}
+>
+  {children} {/* a blockquote bar, no extra node */}
+</box>
+```
+
+A side width overrides the `borderWidth` shorthand exactly the way
+`paddingLeft` overrides `padding`, and a side colour
+(`borderTopColor`/`Right`/`Bottom`/`Left`) falls back to `borderColor`. The
+widths are layout — yoga sees each edge, so the bar above insets content on
+the left only — and the colours are paint, legal in a state block like
+`borderColor` itself.
+
+This is what a rule or an accent edge should be built from: a blockquote's
+bar, a table's row separators (`borderBottomWidth: 1` on each row), a tab's
+underline. Composing the same line out of 1px `<box>`es works but pays a
+node per row into layout and paint, and scatters what is really one style
+value ("the table's border colour") across the tree.
+
+Two edges of the v1 shape:
+
+- **`borderRadius` requires uniform borders** — same width and colour on
+  all four sides. A non-uniform border paints square, ignores the radius,
+  and says so once in development; bars and rules are square, so this costs
+  nothing real.
+- Corners between two painted sides of different colours are square and
+  deterministic: top and bottom span the box's full width, left and right
+  run between them. CSS mitres that corner diagonally; nothing built from
+  bars and rules can tell the difference.
 
 ## Measuring text to its letters
 

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -29,6 +29,7 @@ import {
   resolveQueries,
   DEFAULT_FOCUS_RING,
   resolveHitSlop,
+  resolveBorderWidths,
   tint,
 } from './styles.js';
 import { cssColorStraight } from 'ntk';
@@ -521,6 +522,9 @@ const DEV = process.env.NODE_ENV !== 'production';
 
 // Connections already told they have no 32-bit visual (`_argbAttributes`).
 const warnedNoArgb = new WeakSet();
+
+// `borderRadius` on a non-uniform border warned about once (`_paintBorderSides`).
+let warnedSideRadius = false;
 
 // Frame timestamps for transitions. Indirected so tests can drive the clock
 // instead of sleeping through real animations.
@@ -2158,8 +2162,27 @@ export class Node {
   }
 
   _paintBorder(ctx) {
-    const { borderWidth = 0, borderColor, borderRadius = 0 } = this.style;
-    if (!(borderWidth > 0) || !isPaintedColor(borderColor)) return;
+    const { borderColor, borderRadius = 0 } = this.style;
+    const w = resolveBorderWidths(this.style);
+    const colors = {
+      top: this.style.borderTopColor ?? borderColor,
+      right: this.style.borderRightColor ?? borderColor,
+      bottom: this.style.borderBottomColor ?? borderColor,
+      left: this.style.borderLeftColor ?? borderColor,
+    };
+    const uniform =
+      w.top === w.right &&
+      w.top === w.bottom &&
+      w.top === w.left &&
+      colors.top === colors.right &&
+      colors.top === colors.bottom &&
+      colors.top === colors.left;
+    if (!uniform) {
+      this._paintBorderSides(ctx, w, colors);
+      return;
+    }
+    const borderWidth = w.top;
+    if (!(borderWidth > 0) || !isPaintedColor(colors.top)) return;
     // dashed borders need ntk >= 3.2.0 (setLineDash); solid fallback below
     const dashed =
       this.style.borderStyle === 'dashed' &&
@@ -2167,7 +2190,7 @@ export class Node {
     if (dashed) {
       ctx.setLineDash([borderWidth * 2 + 2, borderWidth + 2]);
     }
-    ctx.strokeStyle = borderColor;
+    ctx.strokeStyle = colors.top;
     ctx.lineWidth = borderWidth;
     // stroke centered on the box edge inset by half the border width
     const inset = borderWidth / 2;
@@ -2192,6 +2215,68 @@ export class Node {
     if (dashed) {
       ctx.setLineDash([]);
     }
+  }
+
+  /**
+   * Non-uniform borders: four independent strokes, square corners. The join
+   * rule is CSS-adjacent and deterministic — top and bottom span the full
+   * width of the box, left and right run between them — which every square
+   * case (bars, rules, accent edges) never notices, because it only has one
+   * painted side to begin with.
+   *
+   * `borderRadius` requires uniform borders in v1: a rounded corner between
+   * two sides of different width or colour has no honest square answer, so
+   * the radius is ignored here and DEV says so once rather than bending the
+   * strokes halfway.
+   */
+  _paintBorderSides(ctx, w, colors) {
+    if (DEV && (this.style.borderRadius ?? 0) > 0 && !warnedSideRadius) {
+      warnedSideRadius = true;
+      console.warn(
+        'react-x11: borderRadius needs uniform borders — same width and ' +
+          'colour on all four sides. This border is painted square. Round ' +
+          'the corners with a uniform border, or drop the radius.',
+      );
+    }
+    const dashable = typeof ctx.setLineDash === 'function';
+    const dashed = this.style.borderStyle === 'dashed' && dashable;
+    const { x, y, width, height } = this.abs;
+    const side = (sw, color, x1, y1, x2, y2) => {
+      if (!(sw > 0) || !isPaintedColor(color)) return;
+      if (dashed) ctx.setLineDash([sw * 2 + 2, sw + 2]);
+      ctx.strokeStyle = color;
+      ctx.lineWidth = sw;
+      ctx.beginPath();
+      ctx.moveTo(x1, y1);
+      ctx.lineTo(x2, y2);
+      ctx.stroke();
+    };
+    side(w.top, colors.top, x, y + w.top / 2, x + width, y + w.top / 2);
+    side(
+      w.bottom,
+      colors.bottom,
+      x,
+      y + height - w.bottom / 2,
+      x + width,
+      y + height - w.bottom / 2,
+    );
+    side(
+      w.left,
+      colors.left,
+      x + w.left / 2,
+      y + w.top,
+      x + w.left / 2,
+      y + height - w.bottom,
+    );
+    side(
+      w.right,
+      colors.right,
+      x + width - w.right / 2,
+      y + w.top,
+      x + width - w.right / 2,
+      y + height - w.bottom,
+    );
+    if (dashed) ctx.setLineDash([]);
   }
 
   _paintContent(ctx) {}
@@ -6439,8 +6524,17 @@ export class WindowNode extends Scrollable(Node) {
     // pixels into place the repaint no longer covers
     if (layoutMoved) return;
     // children clip to the border box, so a border ring or rounded corner
-    // would be shifted like content
-    if (node.style.borderWidth > 0 || node.style.borderRadius > 0) return;
+    // would be shifted like content — any painted side counts
+    const blitBorder = resolveBorderWidths(node.style);
+    if (
+      blitBorder.top > 0 ||
+      blitBorder.right > 0 ||
+      blitBorder.bottom > 0 ||
+      blitBorder.left > 0 ||
+      node.style.borderRadius > 0
+    ) {
+      return;
+    }
     const vp = node.abs;
     // fractional geometry or offsets change every pixel; only a whole-pixel
     // shift is a copy
@@ -6578,9 +6672,14 @@ export class WindowNode extends Scrollable(Node) {
         if (child.style?.display === 'none') continue;
         if (ancestors.has(child)) {
           // on the path down: its solid background under the viewport is
-          // translation-invariant, its border ring and corners are not
+          // translation-invariant, its border ring and corners are not.
+          // The widest side is conservative for a non-uniform border
+          const bw = resolveBorderWidths(child.style ?? EMPTY_STYLE);
           const inset = Math.max(
-            child.style?.borderWidth ?? 0,
+            bw.top,
+            bw.right,
+            bw.bottom,
+            bw.left,
             child.style?.borderRadius ?? 0,
           );
           if (inset > 0 && !rectContains(insetRect(child.abs, inset), vp)) {

--- a/src/styles.js
+++ b/src/styles.js
@@ -121,6 +121,13 @@ const LAYOUT_APPLIERS = {
   overflow: (n, v) =>
     n.setOverflow(pick(OVERFLOW, v, 'overflow') ?? Yoga.OVERFLOW_VISIBLE),
   borderWidth: (n, v) => n.setBorder(Yoga.EDGE_ALL, v ?? 0),
+  // per-side widths resolve the way padding does: the side overrides the
+  // shorthand, and yoga's own edge precedence (EDGE_TOP over EDGE_ALL) is
+  // what implements the override
+  borderTopWidth: (n, v) => n.setBorder(Yoga.EDGE_TOP, v),
+  borderRightWidth: (n, v) => n.setBorder(Yoga.EDGE_RIGHT, v),
+  borderBottomWidth: (n, v) => n.setBorder(Yoga.EDGE_BOTTOM, v),
+  borderLeftWidth: (n, v) => n.setBorder(Yoga.EDGE_LEFT, v),
 };
 
 // Props that only affect painting, not geometry.
@@ -133,6 +140,10 @@ const LAYOUT_APPLIERS = {
 const PAINT_PROPS = new Set([
   'backgroundColor',
   'borderColor',
+  'borderTopColor',
+  'borderRightColor',
+  'borderBottomColor',
+  'borderLeftColor',
   'borderRadius',
   'zIndex',
   'outlineWidth',
@@ -779,6 +790,22 @@ export const DEFAULT_FOCUS_RING = {
  * or null when there is none. Sides left out are 0, so the object form only
  * has to name what it grows.
  */
+/**
+ * Per-side border widths, resolved the way padding resolves: the side
+ * property overrides the `borderWidth` shorthand. This is the paint-side
+ * reading of the same rule yoga applies on the layout side (EDGE_TOP wins
+ * over EDGE_ALL), kept in one place so the two cannot disagree.
+ */
+export function resolveBorderWidths(style) {
+  const all = style.borderWidth ?? 0;
+  return {
+    top: style.borderTopWidth ?? all,
+    right: style.borderRightWidth ?? all,
+    bottom: style.borderBottomWidth ?? all,
+    left: style.borderLeftWidth ?? all,
+  };
+}
+
 export function resolveHitSlop(value) {
   if (value == null) return null;
   if (typeof value === 'number') {

--- a/src/types/style.d.ts
+++ b/src/types/style.d.ts
@@ -110,6 +110,13 @@ export interface LayoutStyle {
   display?: Display;
   overflow?: Overflow;
   borderWidth?: number;
+  /** Per-side widths override `borderWidth` the way `paddingTop` overrides
+   *  `padding`. Layout properties: yoga sees each edge, so a 3px left bar
+   *  insets content on the left only. */
+  borderTopWidth?: number;
+  borderRightWidth?: number;
+  borderBottomWidth?: number;
+  borderLeftWidth?: number;
 }
 
 /**
@@ -121,6 +128,15 @@ export interface LayoutStyle {
 export interface PaintStyle {
   backgroundColor?: Color;
   borderColor?: Color;
+  /** Per-side colours fall back to `borderColor`. Paint properties, legal in
+   *  state blocks like it. */
+  borderTopColor?: Color;
+  borderRightColor?: Color;
+  borderBottomColor?: Color;
+  borderLeftColor?: Color;
+  /** Rounds the background, the border and the child clip. Requires uniform
+   *  borders — same width and colour on all four sides; a non-uniform border
+   *  paints square and ignores the radius. */
   borderRadius?: number;
   zIndex?: number;
   /**

--- a/test/element-props.test.js
+++ b/test/element-props.test.js
@@ -80,6 +80,8 @@ const STYLE_NAMES = [
   'borderColor',
   'borderRadius',
   'borderWidth',
+  'borderLeftWidth',
+  'borderTopColor',
   'borderStyle',
   'zIndex',
   'color',

--- a/test/per-side-borders.test.js
+++ b/test/per-side-borders.test.js
@@ -1,0 +1,241 @@
+// Per-side borders (issue #262): borderLeftWidth and friends resolve the
+// way padding resolves — the side overrides the shorthand — with the widths
+// going to yoga per edge and the colours falling back to `borderColor`.
+//
+// The acceptance criteria, verified as pixels against node-x11's in-process
+// X server:
+//
+//   * `borderLeftWidth: 3` draws a left bar with no extra nodes, and the
+//     content is inset on the left only — the bar is layout, not an overlay;
+//   * a uniform `borderWidth` behaves exactly as before: four equal
+//     per-side widths resolve onto the same single-stroke path and come out
+//     byte-identical to the shorthand.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import { createRoot } from '../src/index.js';
+
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient } from 'ntk';
+
+const W = 240;
+const H = 180;
+
+async function headlessApp() {
+  const server = xserver.createServer({ width: 640, height: 480 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  return createClient({ stream: clientEnd });
+}
+
+const settle = (app) =>
+  new Promise((resolve, reject) =>
+    app.X.GetInputFocus((err) => (err ? reject(err) : resolve())),
+  );
+
+async function mount(app, element) {
+  const x11Root = await createRoot({ app });
+  const instance = await new Promise((resolve) =>
+    x11Root.render(element, resolve),
+  );
+  const root = instance._reactX11Node;
+  root._scheduled = false;
+  root.flush();
+  await settle(app);
+  return root;
+}
+
+/** The whole window as raw image bytes (BGRA), for exact comparisons. */
+async function image(root) {
+  const ctx = root._ctx;
+  const data = await new Promise((resolve, reject) =>
+    ctx.getImageData(0, 0, W, H, (err, d) => (err ? reject(err) : resolve(d))),
+  );
+  return Buffer.from(data.data);
+}
+
+/** One pixel as [r, g, b]. */
+const px = (img, x, y) => {
+  const i = (y * W + x) * 4;
+  return [img[i], img[i + 1], img[i + 2]];
+};
+
+const RED = [192, 57, 43]; // '#c0392b'
+const BLACK = [0, 0, 0];
+const GREEN = [39, 174, 96]; // '#27ae60'
+
+const e = React.createElement;
+
+// One box at fixed integer geometry, so every assertion below is an exact
+// pixel at a coordinate worked out by hand.
+const BOX = { x: 20, y: 20, w: 100, h: 46 };
+
+function single(style, children) {
+  return e(
+    'window',
+    { width: W, height: H, style: { backgroundColor: '#e9edf2' } },
+    e(
+      'box',
+      {
+        style: {
+          position: 'absolute',
+          left: BOX.x,
+          top: BOX.y,
+          width: BOX.w,
+          height: BOX.h,
+          ...style,
+        },
+      },
+      children,
+    ),
+  );
+}
+
+// A child that fills the content box, so where the green starts *is* where
+// yoga put the content edge.
+const filler = e('box', {
+  style: { flexGrow: 1, backgroundColor: '#27ae60' },
+});
+
+test('borderLeftWidth: 3 draws a left bar and insets content on the left only', async () => {
+  const app = await headlessApp();
+  const root = await mount(
+    app,
+    single({ borderLeftWidth: 3, borderLeftColor: '#c0392b' }, filler),
+  );
+  const img = await image(root);
+
+  const midY = BOX.y + Math.floor(BOX.h / 2);
+  // the bar: 3px, flush with the box's left edge, full height
+  assert.deepStrictEqual(px(img, BOX.x, BOX.y), RED, 'bar reaches the top');
+  assert.deepStrictEqual(px(img, BOX.x + 1, midY), RED, 'bar at mid height');
+  assert.deepStrictEqual(
+    px(img, BOX.x + 2, BOX.y + BOX.h - 1),
+    RED,
+    'bar reaches the bottom',
+  );
+  // content starts right after it — the 3px came out of yoga, not paint
+  assert.deepStrictEqual(
+    px(img, BOX.x + 3, midY),
+    GREEN,
+    'content is inset by exactly the bar',
+  );
+  // and the other three edges got neither border nor inset
+  assert.deepStrictEqual(px(img, BOX.x + BOX.w - 1, midY), GREEN, 'right');
+  assert.deepStrictEqual(px(img, BOX.x + 50, BOX.y), GREEN, 'top');
+  assert.deepStrictEqual(
+    px(img, BOX.x + 50, BOX.y + BOX.h - 1),
+    GREEN,
+    'bottom',
+  );
+});
+
+test('four equal per-side widths are byte-identical to the uniform shorthand', async () => {
+  const shorthand = await mount(
+    await headlessApp(),
+    single({ borderWidth: 2, borderColor: '#c0392b' }),
+  );
+  const perSide = await mount(
+    await headlessApp(),
+    single({
+      borderTopWidth: 2,
+      borderRightWidth: 2,
+      borderBottomWidth: 2,
+      borderLeftWidth: 2,
+      borderColor: '#c0392b',
+    }),
+  );
+  const a = await image(shorthand);
+  const b = await image(perSide);
+  assert.ok(
+    a.equals(b),
+    'equal sides must resolve onto the same uniform stroke path',
+  );
+});
+
+test('a side colour falls back to borderColor and overrides it per side', async () => {
+  const app = await headlessApp();
+  const root = await mount(
+    app,
+    single({
+      borderWidth: 1,
+      borderColor: '#000000',
+      borderTopColor: '#c0392b',
+    }),
+  );
+  const img = await image(root);
+
+  const midY = BOX.y + Math.floor(BOX.h / 2);
+  const midX = BOX.x + Math.floor(BOX.w / 2);
+  assert.deepStrictEqual(px(img, midX, BOX.y), RED, 'top uses its own colour');
+  assert.deepStrictEqual(px(img, BOX.x, midY), BLACK, 'left falls back');
+  assert.deepStrictEqual(
+    px(img, BOX.x + BOX.w - 1, midY),
+    BLACK,
+    'right falls back',
+  );
+  assert.deepStrictEqual(
+    px(img, midX, BOX.y + BOX.h - 1),
+    BLACK,
+    'bottom falls back',
+  );
+  // the deterministic corner rule: top and bottom span the box's full width
+  assert.deepStrictEqual(px(img, BOX.x, BOX.y), RED, 'top owns its corners');
+});
+
+test('a side width overrides the shorthand the way paddingLeft overrides padding', async () => {
+  const app = await headlessApp();
+  const root = await mount(
+    app,
+    single(
+      { borderWidth: 1, borderColor: '#000000', borderLeftWidth: 5 },
+      filler,
+    ),
+  );
+  const img = await image(root);
+
+  const midY = BOX.y + Math.floor(BOX.h / 2);
+  assert.deepStrictEqual(px(img, BOX.x + 4, midY), BLACK, 'left is 5px wide');
+  assert.deepStrictEqual(
+    px(img, BOX.x + 5, midY),
+    GREEN,
+    'content starts after the 5px',
+  );
+  assert.deepStrictEqual(
+    px(img, BOX.x + BOX.w - 1, midY),
+    BLACK,
+    'right keeps the shorthand 1px',
+  );
+  assert.deepStrictEqual(
+    px(img, BOX.x + BOX.w - 2, midY),
+    GREEN,
+    'and only 1px of it',
+  );
+});
+
+test('borderRadius on a non-uniform border paints square and warns once', async () => {
+  const warnings = [];
+  const realWarn = console.warn;
+  console.warn = (...args) => warnings.push(args.join(' '));
+  try {
+    const app = await headlessApp();
+    const root = await mount(
+      app,
+      single({
+        borderRadius: 8,
+        borderLeftWidth: 3,
+        borderLeftColor: '#c0392b',
+      }),
+    );
+    const img = await image(root);
+    // square: the bar still owns its top-left corner pixel, which a rounded
+    // stroke would have vacated
+    assert.deepStrictEqual(px(img, BOX.x, BOX.y), RED);
+    const radiusWarnings = warnings.filter((w) =>
+      /borderRadius needs uniform borders/.test(w),
+    );
+    assert.strictEqual(radiusWarnings.length, 1, 'said so, and said so once');
+  } finally {
+    console.warn = realWarn;
+  }
+});

--- a/test/style.test.js
+++ b/test/style.test.js
@@ -48,6 +48,13 @@ test('createStyles rejects unknown properties and layout in state blocks', async
   );
   // paint properties are fine
   createStyles({ a: { ':hover': { backgroundColor: 'red', color: 'blue' } } });
+  // per-side border colours are paint too; the widths are layout (#262)
+  createStyles({ a: { ':hover': { borderLeftColor: 'red' } } });
+  assert.throws(
+    () => createStyles({ a: { ':hover': { borderLeftWidth: 3 } } }),
+    /"borderLeftWidth" is not allowed inside ":hover"/,
+    'a side width reflows, so it is refused like padding',
+  );
 });
 
 test('style drives layout and paint; props stay semantic', async () => {

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -120,6 +120,15 @@ const s = createStyles({
   },
   target: { hitSlop: 4 },
   perSide: { hitSlop: { top: 4, bottom: 4 } },
+  // issue #262: per-side borders — a side width overrides the shorthand the
+  // way paddingLeft overrides padding; a side colour is paint, so it may
+  // change in a state block
+  quote: {
+    borderLeftWidth: 3,
+    borderLeftColor: '$border',
+    ':hover': { borderLeftColor: '$accent' },
+  },
+  rule: { borderWidth: 1, borderBottomWidth: 0, borderTopColor: '#ddd' },
 });
 
 // arrays, falsy entries, nesting
@@ -138,6 +147,9 @@ createStyles({ bad: { colour: 'red' } });
 
 // @ts-expect-error — hit slop is not paint, so it cannot go in a state block
 createStyles({ bad: { ':focus-visible': { hitSlop: 4 } } });
+
+// @ts-expect-error — a side width is layout, so it may not go in a state block
+createStyles({ bad: { ':hover': { borderLeftWidth: 3 } } });
 
 // --- elements --------------------------------------------------------------
 


### PR DESCRIPTION
Closes #262.

Per-side border style properties, CSS names, resolved the way padding already resolves per side:

- `borderTopWidth` / `borderRightWidth` / `borderBottomWidth` / `borderLeftWidth` — a side width overrides the `borderWidth` shorthand, and each width goes to yoga per edge (`setBorder(EDGE_TOP, …)` over `EDGE_ALL`), so a 3px left bar insets content on the left only. Layout properties, like `borderWidth` itself.
- `borderTopColor` / … — fall back to `borderColor`. Paint properties, so they are legal in state blocks (`':hover': { borderLeftColor: … }`) and animatable, exactly like `borderColor`.

## What this replaces

A blockquote's bar was a 3px `<box>` beside the content column; a 50-row table paid 50 separator boxes into layout and paint; a themed "table border colour" was scattered across dozens of nodes. Each of those is now one style value on the node that means it.

## Paint

- **Uniform borders take exactly the old path** — same single stroke, same `roundRect` fast path, same dash pattern. Four equal per-side widths resolve onto it too, and the test asserts the shorthand and per-side spellings come out byte-identical.
- **Non-uniform borders are four independent strokes**, square corners, with a deterministic join rule: top and bottom span the box's full width, left and right run between them. `borderStyle: 'dashed'` works per side.
- **`borderRadius` requires uniform borders in v1** (as proposed in the issue): a non-uniform border paints square, ignores the radius, and warns once in development. Bars and rules are square, so this covers every motivating case.

The scroll-blit safety checks that previously read `style.borderWidth` now resolve all four sides, so a viewport with only a left bar is still (correctly) excluded from wholesale pixel moves.

## Acceptance criteria from the issue

- ✅ `style={{ borderLeftWidth: 3, borderLeftColor: '$border' }}` draws a left bar with no extra nodes (pixel-asserted against node-x11's in-process server, including the layout inset being left-only)
- ✅ uniform `borderWidth` behaves exactly as today (byte-identical image assertion; `rounded-box-glyphs` parity suite untouched and passing)

New tests were mutation-checked: all 5 fail against master's `src/`.

## Screenshot

Rendered by this PR's code at `5dc1c1ea215ed3d073159d2bb0792bbec0fdc74b` (in-process X server → `getImageData` → pngjs):

![per-side-borders](https://github.com/user-attachments/assets/44723c1e-144f-43fb-a663-bdb505b00760)

