### PR TITLE
feat(theme)!: the palette carries the type — fontFamily and monoFamily

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -47,6 +47,28 @@ control are most of what separates one platform's controls from another's:
 | `radius` `radiusSmall` `borderWidth`            | control shape                  |
 | `radiusPopup` `radiusPopupItem` `radiusTooltip` | floating-surface shape         |
 | `fontSize` `paddingX` `paddingY`                | control size                   |
+| `fontFamily` `monoFamily`                       | the app's two faces            |
+
+`fontFamily` and `fontSize` are the type this app sets, and text that names
+neither **takes them** — a `<text>`, a `<textinput>`, a widget's own label. So
+`<ThemeProvider value={{ fontFamily: 'Inter', fontSize: 16 }}>` is where an app
+says what it is set in, once, rather than on every label, and a `Select`'s rows
+grow with it because a row is its label with even space all round. A `fontSize`
+or `fontFamily` in a style still wins, the way a style property always wins
+over what a node inherits.
+
+The widgets that take a size of their own keep taking it: `MenuBar` and
+`ContextMenu` have a `fontSize` prop because they measure their labels before
+they have anywhere to measure them in, and `Table` has `rowHeight` because
+every row has to be the same height for it to skip the ones off screen.
+
+Both are CSS-style family lists — `'"JetBrains Mono", monospace'` names a
+preference and a fallback.
+
+`monoFamily` is the second face, and nothing unstyled reads it: it is there so
+that every code surface in an app — a listing, a log pane, a hex dump, all
+written by different components — can say `fontFamily: '$monoFamily'` and be
+set from one place.
 
 `paddingY` is the space **you can see** — above the capitals and below the
 baseline — not the space plus whatever the font's ascent left over: every

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -352,6 +352,27 @@ paints (`style={[s.card, { backgroundColor: theme.panel }]}`).
 Tokens are not colour-only; `padding: '$gutter'` resolves a number just as
 well.
 
+Three of them are read with no `$` anywhere, because they are what text falls
+back to rather than something a style asked for: **`text`, `fontFamily` and
+`fontSize` are the ink, the face and the size of every `<text>` that names
+none of its own** ([components.md](components.md#theming)). That is what makes
+`<ThemeProvider value={{ fontFamily: 'Inter' }}>` a sentence an app says once.
+A style property still wins over it, the way a style property always wins over
+what a node inherits:
+
+```jsx
+<window theme={{ fontFamily: 'Inter', fontSize: 16 }}>
+  <text>Inter at 16</text>
+  <text style={{ fontFamily: '$monoFamily' }}>the palette's mono face, 16</text>
+  <text style={{ fontSize: 24 }}>Inter at 24</text>
+</window>
+```
+
+`monoFamily` has no such fallback — nothing is monospace unless it says so, and
+that is what the `$` above is for. It is a token so that the code surfaces of
+an app, which are written by components that never meet, can be set from one
+place.
+
 A `theme` prop anywhere scopes its subtree, and an inner one merges over the
 outer, so a panel can restate a colour or two without repeating a palette.
 Popups resolve through their place in the **tree**, not their window, so a

--- a/examples/dbus.jsx
+++ b/examples/dbus.jsx
@@ -98,7 +98,11 @@ const C = {
 // rounder corners than the default 4. Colours are deliberately absent.
 const THEME = { radius: 5 };
 
-const MONO = 'monospace';
+// The palette's mono face rather than the literal: every code surface in
+// this app — the chips, the pane titles, the value dumps — is one token, so
+// a desktop or an app that has a better monospace than the default sets it
+// in one place.
+const MONO = '$monoFamily';
 
 // react-x11 has `borderWidth` for the whole box and no per-edge borders, so a
 // rule is a one-pixel box rather than a border — which is also cheaper: a

--- a/src/components/PasswordInput.js
+++ b/src/components/PasswordInput.js
@@ -3,7 +3,7 @@
 // build-step-free for consumers.
 
 import React, { useEffect, useRef, useState } from 'react';
-import { DEFAULT_TEXT_STYLE, createStyles } from '../styles.js';
+import { createStyles } from '../styles.js';
 import { useClipboard } from '../appcontext.js';
 import { windowIdOf } from '../windowid.js';
 import { useTheme } from './theme.js';
@@ -178,7 +178,10 @@ export function PasswordInput({
   const length = chars(text).length;
   const showing = revealed === undefined ? ownRevealed : revealed;
 
-  const size = DEFAULT_TEXT_STYLE.size;
+  // The palette's size, not a constant: the dots are drawn to stand in for
+  // the characters the field would have shown, and the field shows them at
+  // the size it inherits.
+  const size = theme.fontSize;
   const unit = measureLabel(fieldRef.current, REFERENCE_GLYPH, { size });
   const lineHeight = Math.ceil(unit.height || size * 1.4);
 

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -13,7 +13,6 @@ import {
   useAnchorTracking,
   useDismissOnWindowBlur,
 } from './anchor.js';
-import { DEFAULT_TEXT_STYLE } from '../styles.js';
 import { typeAheadChar, useTypeAhead } from './typeahead.js';
 import {
   XK_DOWN,
@@ -39,13 +38,12 @@ const ITEM_PAD_RIGHT = ITEM_PAD;
 // A row is its label with even space all round — the same number left and
 // right as above and below, measured to the letters rather than to the
 // font's line box (`capTrim`). The menus derive their rows the same way.
-const ITEM_HEIGHT = capBand(DEFAULT_TEXT_STYLE.size) + ITEM_PAD * 2;
-// The chevron is exactly as tall as the capitals it stands beside, and for
-// a reason a form depends on: a field, a dropdown and a button in one row
-// have to be one height, and they only are if the tallest thing in each is
-// measured the same way. A glyph taller than the cap band makes the
-// dropdown alone two pixels taller than everything next to it.
-const CHEVRON = capBand(DEFAULT_TEXT_STYLE.size);
+//
+// A function of the palette's text size and not of a constant: the labels in
+// these rows are unstyled `<text>`, which *inherits* that size, so a row
+// sized against 14 under a theme that set 18 is a row its own label does not
+// fit in.
+const itemHeight = (fontSize) => capBand(fontSize) + ITEM_PAD * 2;
 // The scrolling pane's own padding, and so the inset between the edge
 // and an option — which is what makes the highlight read as a pill on the
 // menu rather than a band across it, and what the pill's own corner radius
@@ -73,20 +71,20 @@ function normalizeOption(option) {
  * current value — left every longer label to wrap inside a fixed 28px row and
  * overlap the option under it.
  *
- * Labels are measured at the size they are painted: a `<text>` resolves its
- * style against `DEFAULT_TEXT_STYLE` rather than inheriting from the boxes
- * around it, so the option rows are 14px whatever the trigger is set to. The
- * selected one is measured bold, which is how `Option` draws it.
+ * Labels are measured at the size they are painted: a `<text>` that names no
+ * size of its own takes the palette's, so this is `theme.fontSize` and not
+ * the size of whatever is in the trigger. The selected one is measured bold,
+ * which is how `Option` draws it.
  *
  * The result is never narrower than the trigger it hangs off, and never wider
  * than the screen it has to open on — `anchorRect` can slide a popup left to
  * fit, but nothing can rescue one that is wider than the display.
  */
-function menuWidth(node, options, value, scrolls) {
+function menuWidth(node, options, value, scrolls, fontSize) {
   let widest = 0;
   for (const option of options) {
     const { width } = measureLabel(node, option.label, {
-      size: DEFAULT_TEXT_STYLE.size,
+      size: fontSize,
       weight: option.value === value ? 'bold' : 'normal',
     });
     if (width > widest) widest = width;
@@ -126,7 +124,7 @@ function Option({
       onMouseEnter: () => onHover?.(),
       onClick: () => onPick(option),
       style: {
-        height: ITEM_HEIGHT,
+        height: itemHeight(theme.fontSize),
         justifyContent: 'center',
         paddingLeft: ITEM_PAD_LEFT,
         paddingRight: ITEM_PAD_RIGHT,
@@ -201,7 +199,10 @@ export function Select({
 
   const normalized = options.map(normalizeOption);
   const current = normalized.find((o) => o.value === value);
-  const contentHeight = normalized.length * ITEM_HEIGHT + MENU_PAD * 2;
+  // Rows are sized from the palette's text size, because that is the size
+  // the labels inside them come out at.
+  const rowHeight = itemHeight(theme.fontSize);
+  const contentHeight = normalized.length * rowHeight + MENU_PAD * 2;
   const menuHeight = Math.min(contentHeight, MAX_MENU_HEIGHT);
   const scrolls = contentHeight > MAX_MENU_HEIGHT;
 
@@ -211,7 +212,13 @@ export function Select({
   const menuAnchorOptions = () => ({
     placement: 'bottom',
     height: menuHeight + 2,
-    width: menuWidth(triggerRef.current, normalized, value, scrolls),
+    width: menuWidth(
+      triggerRef.current,
+      normalized,
+      value,
+      scrolls,
+      theme.fontSize,
+    ),
   });
 
   const close = () => setOpen(false);
@@ -274,7 +281,7 @@ export function Select({
         // a page is what the menu shows at once, so paging lines up with
         // what the user can see rather than an arbitrary count
         if (!open || !count) return;
-        const page = Math.max(1, Math.floor(MAX_MENU_HEIGHT / ITEM_HEIGHT));
+        const page = Math.max(1, Math.floor(MAX_MENU_HEIGHT / rowHeight));
         const dir = ev.keysym === XK_PAGE_DOWN ? 1 : -1;
         const from = activeIndex < 0 ? 0 : activeIndex;
         setActiveIndex(Math.min(count - 1, Math.max(0, from + dir * page)));
@@ -368,7 +375,16 @@ export function Select({
       current ? current.label : placeholder,
     ),
     h('box', { style: { flexGrow: 1 } }),
-    h(Icon, { name: 'chevronDown', size: CHEVRON, color: theme.dim }),
+    // The chevron is exactly as tall as the capitals it stands beside, and
+    // for a reason a form depends on: a field, a dropdown and a button in one
+    // row have to be one height, and they only are if the tallest thing in
+    // each is measured the same way. A glyph taller than the cap band makes
+    // the dropdown alone two pixels taller than everything next to it.
+    h(Icon, {
+      name: 'chevronDown',
+      size: capBand(theme.fontSize),
+      color: theme.dim,
+    }),
     open &&
       anchor &&
       h(

--- a/src/components/anchor.js
+++ b/src/components/anchor.js
@@ -306,7 +306,12 @@ export function measureLabel(node, text, style) {
     return { width: String(text).length * size * 0.55, height: size * 1.4 };
   }
   const layout = fonts.layout(String(text), {
-    family: style?.family ?? 'sans-serif',
+    // The face **this node inherits**, not the literal `sans-serif`: the
+    // labels these popups are sized around name no family of their own, so
+    // the one they are drawn in is the palette's. Measuring in a different
+    // face is measuring the wrong label — a menu sized in sans-serif for a
+    // row that paints in a wider mono is a menu whose own options wrap.
+    family: style?.family ?? node?.inheritedTextStyle?.family ?? 'sans-serif',
     size,
     weight: style?.weight ?? 'normal',
     // dropping this would measure a different face from the one drawn, and

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -1267,21 +1267,36 @@ export class Node {
   }
 
   /**
-   * The text style a node inherits when nothing named one.
+   * The text style a node inherits when nothing named one — **the palette's**,
+   * not a set of constants.
    *
-   * The ink is the **palette's**, not a fixed black: a `<text>` or a
-   * `<textinput>` that never mentions a colour has to be readable on the
-   * surface it is drawn on, and that surface follows the desktop now. Black
-   * on `#1e2228` is invisible, which is the whole bug.
+   * The ink first: a `<text>` or a `<textinput>` that never mentions a colour
+   * has to be readable on the surface it is drawn on, and that surface
+   * follows the desktop now. Black on `#1e2228` is invisible, which is the
+   * whole bug.
+   *
+   * The face and the size for the same reason one step out. A theme names
+   * `fontFamily` and `fontSize` because it is describing the type this app
+   * sets, and the only way that can be true is if the text nobody styled
+   * follows them — otherwise `fontSize` is a token that moves the menu
+   * corners derived from it and not one letter, and `fontFamily` is a token
+   * with no reader at all.
    *
    * Cached per node so the object identity is stable while the palette is —
    * the layouts below are keyed on style and a fresh base each call would
    * miss the cache every time.
    */
   get inheritedTextStyle() {
-    const color = this.theme.text;
-    if (this._textBase?.color !== color) {
-      this._textBase = { ...DEFAULT_TEXT_STYLE, color };
+    const theme = this.theme;
+    const color = theme.text;
+    // A palette can reach a node as a bare `theme` **prop** rather than a
+    // resolved one — `<box theme={{ text: 'red' }}>` merges and derives
+    // nothing (styling.md) — so neither of these is guaranteed to be there.
+    const family = theme.fontFamily ?? DEFAULT_TEXT_STYLE.family;
+    const size = theme.fontSize ?? DEFAULT_TEXT_STYLE.size;
+    const base = this._textBase;
+    if (base?.color !== color || base.family !== family || base.size !== size) {
+      this._textBase = { ...DEFAULT_TEXT_STYLE, color, family, size };
     }
     return this._textBase;
   }
@@ -1324,16 +1339,22 @@ export class Node {
   /** The theme above or on this node changed: drop the caches and restyle
    * the subtree, since a token can appear at any depth. */
   _themeChanged() {
-    const wasInk = this._theme?.text;
+    // The base this node's unstyled text was last shaped against, by
+    // identity: `inheritedTextStyle` only builds a new one when a value it
+    // reads actually moved, so `!==` afterwards is exact.
+    const wasType = this._textBase;
     this._theme = undefined;
     // A `<window>` with no `backgroundColor` of its own follows the palette,
     // and the server's copy of that colour has to follow with it — otherwise
     // the next resize fills the new area in the old scheme.
     if (this.isWindow) this._syncWindowBackground();
-    // The inherited ink is not in any style object, so `_usesTokens` does not
-    // see it move — but a cached layout carries the colour it was shaped
-    // with, and would keep painting the old one.
-    if (wasInk !== undefined && wasInk !== this.theme.text) {
+    // The inherited ink, face and size are in no style object, so
+    // `_usesTokens` does not see them move — but a cached layout carries the
+    // colour *and the font* it was shaped with, and would keep painting them.
+    // A theme swap that only changes `fontFamily` is the case that made this
+    // worth widening: nothing else about the node changes, so nothing else
+    // would have dropped the layout.
+    if (wasType !== undefined && this.inheritedTextStyle !== wasType) {
       this._textContentChanged();
       this.root?.invalidate(true, null, 'theme');
     }
@@ -3642,7 +3663,10 @@ export class TextInputNode extends Node {
   _lineHeight() {
     const layout = this._layoutOf('Mg');
     if (layout) return layout.height;
-    return (this.style.fontSize ?? DEFAULT_TEXT_STYLE.size) * 1.4;
+    // No fonts to measure with. `_textStyle()` rather than the style prop
+    // alone, so the guess is made at the size this field inherits — the
+    // palette's — and not at 14 whatever the theme said.
+    return this._textStyle().size * 1.4;
   }
 
   /**

--- a/src/palette.js
+++ b/src/palette.js
@@ -78,6 +78,19 @@ export const DefaultTheme = {
   radiusTooltip: 4,
   borderWidth: 1,
   fontSize: 14,
+  // The two faces an app has. `fontFamily` is what a `<text>` inherits where
+  // nothing named one, so "this app is Inter" is a sentence said once here
+  // rather than on every label; `monoFamily` is the one every code surface
+  // reaches for — a `<Code>`, a log pane, a hex dump — and the reason it is a
+  // token at all is that those are written by *different* components, which
+  // would otherwise each grow their own prop for it and have to be set one by
+  // one.
+  //
+  // CSS-style family lists, the same as the `fontFamily` style property:
+  // `'"JetBrains Mono", monospace'` names a preference and a fallback, and
+  // ntk's `fonts.match` splits the list itself.
+  fontFamily: 'sans-serif',
+  monoFamily: 'monospace',
   paddingX: 16,
   // Measured from the **letters**, not from the font's line box: widget
   // labels are trimmed to the capitals down to the baseline, so this is the

--- a/src/styles.js
+++ b/src/styles.js
@@ -755,6 +755,16 @@ export function textStyleFrom(props, inherited) {
   };
 }
 
+/**
+ * The floor under `Node.inheritedTextStyle`, which is what text actually
+ * reads: the ink, the face and the size all come from the palette in force,
+ * and these are only what is left when there is no palette at all — a node
+ * that has not been attached yet, or a bare `theme` prop naming neither.
+ *
+ * `family`, `size` and `color` therefore mirror `DefaultTheme.fontFamily`,
+ * `.fontSize` and `.text`; the rest have no token because no theme has ever
+ * wanted to set the weight of every label in an app at once.
+ */
 export const DEFAULT_TEXT_STYLE = {
   family: 'sans-serif',
   size: 14,

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -69,7 +69,16 @@ export interface Theme {
   /** A tooltip bubble — the smallest floating surface there is. */
   radiusTooltip: number;
   borderWidth: number;
+  /** The size unstyled text comes out at, and what the popup radii are
+   * derived from. */
   fontSize: number;
+  /** The UI face, as a CSS-style family list. What a `<text>` that names no
+   * `fontFamily` inherits. */
+  fontFamily: string;
+  /** The face code surfaces use — a `<Code>`, a log pane, a hex dump. Not
+   * read by anything unstyled; it is there so `fontFamily: '$monoFamily'`
+   * says "this app's mono face" in one place. */
+  monoFamily: string;
   paddingX: number;
   paddingY: number;
 }

--- a/test/theme-type.test.js
+++ b/test/theme-type.test.js
@@ -1,0 +1,337 @@
+// The palette's **type**: the face and the size text takes when nothing
+// styled it.
+//
+// A theme has always carried `fontSize`, and until now almost nothing read
+// it — the popup radii were derived from it and the icons were sized by it,
+// and not one letter came out any different, because a `<text>` that named
+// no size fell back to a module constant. `fontFamily` did not exist at all,
+// so "this app is Inter" was a sentence that had to be said on every label.
+//
+// Both are read through `Node.inheritedTextStyle` now, alongside the ink,
+// and that is what these tests are about — plus the thing that half of it
+// silently: a theme swap does not re-render anything. The `<text>` element's
+// props are identical across it, so nothing marks its measured layout
+// dirty, and a cached layout carries the face and size it was *shaped* with.
+// Two of these tests are pixels for that reason.
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { test } from 'node:test';
+import React from 'react';
+
+import xserver from 'x11/lib/xserver/index.js';
+import { StaticFontSource, createClient } from 'ntk';
+
+import { createRoot, Select, ThemeProvider } from '../src/index.js';
+import { capBand } from '../src/components/theme.js';
+import { measureLabel } from '../src/components/anchor.js';
+import { DefaultTheme } from '../src/palette.js';
+import { createStyles, resolveTokens } from '../src/styles.js';
+import { createMockApp, pressButton } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+const nodeOf = (app, index = 0) => app.windows[index]._reactX11Node;
+
+// --- the tokens -------------------------------------------------------------
+
+test('the palette names both faces, and they are what text already had', () => {
+  assert.equal(DefaultTheme.fontFamily, 'sans-serif');
+  assert.equal(DefaultTheme.monoFamily, 'monospace');
+});
+
+test('$monoFamily is a token like any other', () => {
+  const s = createStyles({ code: { fontFamily: '$monoFamily', fontSize: 12 } });
+  const theme = { ...DefaultTheme, monoFamily: '"JetBrains Mono", monospace' };
+  assert.equal(
+    resolveTokens(s.code, theme).fontFamily,
+    '"JetBrains Mono", monospace',
+  );
+  // which is the whole point of it being a token: the style is hoisted, so
+  // the component that wrote it never saw the palette
+  assert.equal(resolveTokens(s.code, DefaultTheme).fontFamily, 'monospace');
+});
+
+// --- what an unstyled <text> inherits ---------------------------------------
+
+async function inheritedUnder(theme) {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(
+    h(
+      ThemeProvider,
+      { value: theme },
+      h('window', { width: 200, height: 100 }, h('text', null, 'Handgloves')),
+    ),
+  );
+  await tick();
+  await tick();
+  const find = (node) =>
+    node.kind === 'text'
+      ? node
+      : node.children.reduce((hit, child) => hit ?? find(child), null);
+  const text = find(nodeOf(app));
+  const inherited = text.parent.inheritedTextStyle;
+  await x11Root.unmount();
+  return inherited;
+}
+
+test('a <text> that styles nothing takes the palette’s face, size and ink', async () => {
+  const inherited = await inheritedUnder({
+    fontFamily: '"Test Mono", monospace',
+    fontSize: 22,
+    text: '#ff0000',
+  });
+  assert.equal(inherited.family, '"Test Mono", monospace');
+  assert.equal(inherited.size, 22);
+  assert.equal(inherited.color, '#ff0000');
+});
+
+test('a palette that names neither leaves text where it was', async () => {
+  const inherited = await inheritedUnder({ text: '#123456' });
+  assert.equal(inherited.family, 'sans-serif');
+  assert.equal(inherited.size, 14);
+});
+
+test('a bare theme prop derives nothing, so the type falls back', async () => {
+  // `<box theme={…}>` merges and computes nothing (styling.md) — a palette
+  // reaching a node that way can be missing either token entirely, and text
+  // under it still has to have a face and a size.
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(
+    h(
+      'window',
+      { width: 200, height: 100, theme: { text: '#00ff00' } },
+      h('text', null, 'Handgloves'),
+    ),
+  );
+  await tick();
+  const inherited = nodeOf(app).inheritedTextStyle;
+  assert.equal(inherited.family, 'sans-serif');
+  assert.equal(inherited.size, 14);
+  assert.equal(inherited.color, '#00ff00', 'what it did name still lands');
+  await x11Root.unmount();
+});
+
+test('the style property still wins over the palette', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(
+    h(
+      ThemeProvider,
+      { value: { fontFamily: 'Test Mono', fontSize: 22 } },
+      h(
+        'window',
+        { width: 200, height: 100 },
+        h('text', { style: { fontFamily: 'Test Main', fontSize: 9 } }, 'Hand'),
+      ),
+    ),
+  );
+  await tick();
+  await tick();
+  const text = nodeOf(app).children[0];
+  assert.equal(text.style.fontFamily, 'Test Main');
+  assert.equal(text.style.fontSize, 9);
+  await x11Root.unmount();
+});
+
+// --- the swap has to re-measure ---------------------------------------------
+//
+// Pixels, because this is the half that has no other witness: the element's
+// own props do not change across a theme swap, so nothing re-renders the
+// `<text>` and the memoised layout would otherwise survive with the old face
+// baked into it.
+
+const W = 240;
+const H = 120;
+
+const require = createRequire(import.meta.url);
+const fontDir = join(
+  dirname(require.resolve('katex/package.json')),
+  'dist',
+  'fonts',
+);
+
+// Two families with visibly different advances: a proportional serif and a
+// typewriter face. A theme that swaps between them has to move the ink.
+async function headlessApp() {
+  const server = xserver.createServer({ width: 400, height: 400 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const fontSource = new StaticFontSource();
+  fontSource.add(readFileSync(join(fontDir, 'KaTeX_Main-Regular.ttf')), {
+    family: 'Test Main',
+  });
+  fontSource.add(readFileSync(join(fontDir, 'KaTeX_Typewriter-Regular.ttf')), {
+    family: 'Test Mono',
+  });
+  fontSource.alias('sans-serif', 'Test Main');
+  fontSource.alias('monospace', 'Test Mono');
+  return createClient({ stream: clientEnd, fontSource });
+}
+
+const readPixels = (ctx, w, h) =>
+  new Promise((resolve, reject) =>
+    ctx.getImageData(0, 0, w, h, (err, data) =>
+      err ? reject(err) : resolve(data),
+    ),
+  );
+
+const settled = (app) =>
+  new Promise((resolve) => app.X.GetInputFocus(() => resolve()));
+
+/** How many pixels the text put ink in. */
+function ink(image) {
+  let n = 0;
+  for (let i = 0; i < image.data.length; i += 4) {
+    if (image.data[i] < 128) n++;
+  }
+  return n;
+}
+
+// `alignSelf: 'flex-start'` so the box is the measured text and not the
+// window's width — which is what makes `abs.width` evidence that the measure
+// function ran again rather than that something merely repainted. The
+// `<text>` names no face and no size: the palette is the only thing saying
+// what it is.
+const label = (ref, theme) =>
+  h(
+    'window',
+    { width: W, height: H, theme, style: { backgroundColor: '#ffffff' } },
+    h(
+      'text',
+      { ref, style: { color: '#000000', alignSelf: 'flex-start' } },
+      'Handgloves',
+    ),
+  );
+
+async function renderAndRead(app, x11Root, element, ref) {
+  await new Promise((resolve) => x11Root.render(element, resolve));
+  await new Promise((r) => setImmediate(r));
+  const node = ref.current;
+  node.root.flush();
+  await settled(app);
+  const ctx = (node.root._ctx ??= node.root.window.getContext('2d'));
+  return { image: await readPixels(ctx, W, H), node };
+}
+
+/** Swap the palette over an unchanged `<text>` and report what moved. */
+async function reTheme(from, to) {
+  const app = await headlessApp();
+  const x11Root = await createRoot({ app });
+  try {
+    const ref = React.createRef();
+    const first = await renderAndRead(app, x11Root, label(ref, from), ref);
+    const before = { ink: ink(first.image), width: first.node.abs.width };
+    const second = await renderAndRead(app, x11Root, label(ref, to), ref);
+    return {
+      before,
+      after: { ink: ink(second.image), width: second.node.abs.width },
+    };
+  } finally {
+    await app.close();
+  }
+}
+
+test('a palette that only moves the size re-measures and repaints', async () => {
+  const { before, after } = await reTheme(
+    { ...DefaultTheme, fontSize: 12 },
+    { ...DefaultTheme, fontSize: 28 },
+  );
+  assert.ok(
+    after.ink > before.ink * 1.5,
+    `28px should put down much more ink than 12px, got ${before.ink} -> ${after.ink}`,
+  );
+  assert.ok(
+    after.width > before.width,
+    `the measured box should grow, got ${before.width} -> ${after.width}`,
+  );
+});
+
+test('a palette that only moves the face re-measures and repaints', async () => {
+  const { before, after } = await reTheme(
+    { ...DefaultTheme, fontSize: 24, fontFamily: 'Test Main' },
+    { ...DefaultTheme, fontSize: 24, fontFamily: 'Test Mono' },
+  );
+  assert.notEqual(
+    after.width,
+    before.width,
+    `the typewriter face measures differently from the serif, got ` +
+      `${before.width} -> ${after.width}`,
+  );
+  assert.notEqual(
+    after.ink,
+    before.ink,
+    'and the glyphs on the screen are the new face’s',
+  );
+});
+
+// --- the widgets that had 14 written into their geometry ---------------------
+
+test('a popup is measured in the face its label will be drawn in', () => {
+  // The bug this pins showed up as a `Select` whose own options wrapped: the
+  // rows painted in the palette's monospace and the menu was sized in
+  // `sans-serif`, which is narrower, so the width was short by the
+  // difference. Every popup here measures a label that names no family.
+  const asked = [];
+  const node = {
+    app: {
+      fonts: {
+        layout: (text, style) => (asked.push(style), { width: 10, height: 10 }),
+      },
+    },
+    inheritedTextStyle: { family: '"JetBrains Mono", monospace', size: 20 },
+  };
+  measureLabel(node, 'three', { size: 20 });
+  assert.equal(asked[0].family, '"JetBrains Mono", monospace');
+
+  // an explicit family still wins — a caller that knows better says so
+  measureLabel(node, 'three', { size: 20, family: 'Inter' });
+  assert.equal(asked[1].family, 'Inter');
+});
+
+test('a Select’s rows are sized from the palette, not from 14', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(
+    h(
+      ThemeProvider,
+      { value: { fontSize: 22 } },
+      h(
+        'window',
+        { width: 300, height: 200 },
+        h(
+          'box',
+          { style: { flexGrow: 1, padding: 10 } },
+          h(Select, { options: ['one', 'two', 'three'], value: 'one' }),
+        ),
+      ),
+    ),
+  );
+  await tick();
+  await tick();
+
+  const wnd = app.windows[0];
+  const trigger = wnd._reactX11Node.children[0].children[0].children[0];
+  pressButton(wnd, trigger.abs.x + 4, trigger.abs.y + 4);
+  await tick();
+  await tick();
+
+  const sheet = app.windows[1]._reactX11Node.children[0];
+  const rows = sheet.children[0].children;
+  // ITEM_PAD is 10 either side of the cap band — the row is its label with
+  // even space all round, and the label is now 22px because it inherits.
+  assert.equal(
+    rows[0].style.height,
+    capBand(22) + 20,
+    'the row grew with the type it holds',
+  );
+  assert.ok(
+    rows[0].style.height > capBand(14) + 20,
+    'which is to say it is not the 14px row any more',
+  );
+
+  await x11Root.unmount();
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -399,10 +399,16 @@ function Themed() {
   const theme = useTheme();
   const _radius: number = theme.radius;
   const _focus: string = theme.borderFocus;
+  // the type the palette sets: what unstyled text takes, and the face code
+  // surfaces ask for by name
+  const _face: string = theme.fontFamily;
+  const _mono: string = theme.monoFamily;
+  const _size: number = theme.fontSize;
   return (
     <box
       style={{
         backgroundColor: theme.accent,
+        fontFamily: theme.monoFamily,
         ':hover': { backgroundColor: theme.accentHover },
         // the pressed step: derived from the hover unless a palette names it
         ':active': { backgroundColor: theme.accentActive },


### PR DESCRIPTION
Closes #261.

`DefaultTheme` has carried `fontSize` all along and almost nothing read it: the popup radii were derived from it and the icons were sized by it, and not one letter of text came out any different, because a `<text>` that named no size fell back to a module constant. `fontFamily` did not exist at all, so "this app is Inter" was a sentence that had to be said on every label — and the components that render code had each grown a `monoFamily` prop of their own, because there was no token to read.

Two tokens, and one accessor that makes all three real: `Node.inheritedTextStyle` already took the ink from the palette, for the reason that black on `#1e2228` is invisible. It takes the face and the size from it now as well. A style property still wins, the way it always has.

```jsx
<ThemeProvider value={{ fontFamily: 'Inter', monoFamily: '"JetBrains Mono", monospace' }}>
  <text>Inter</text>
  <text style={{ fontFamily: '$monoFamily' }}>JetBrains Mono</text>
</ThemeProvider>
```

## The same palette, before and after

Both rendered by this PR's own harness — the identical scene under `theme={{ fontFamily: 'UI Mono', fontSize: 20 }}`, with nothing in it styling either one. On `master` the palette says both and neither is read; here the text, the field, the button's label and the `Select`'s rows all take them.

**master @ f95c24b**

![before](https://github.com/user-attachments/assets/349c5c1a-b81e-4587-ae4f-1689622b5519)

**this branch @ 0ba4880**

![after](https://github.com/user-attachments/assets/dd5d14a6-da34-4fde-a490-7ee192bcdc10)

## Three things it dragged in

Each is a place that held a constant where the palette is now the answer, and the last two are why the screenshots above are worth having.

- **`_themeChanged` dropped a memoised text layout only when the ink moved.** A theme swap re-renders nothing — the `<text>` element's props are identical across it — so a palette that changed only the face left every cached layout painting the old font, with nothing reporting an error. It compares the whole inherited base now, by identity. The two pixel tests in `theme-type.test.js` are for this: with everything else in place and only the old ink-only comparison restored, they are the only two that fail.
- **`Select` had 14 written into its row height, its chevron and the width it measures its menu at.** Its option labels inherit, so a row sized against 14 under a theme that set 18 is a row its own label does not fit in. `PasswordInput` sized its dots the same way.
- **`measureLabel` measured every popup's label in `sans-serif`** while the label itself is drawn in whatever the palette says. Its own comment already warned that measuring a different face from the one drawn sizes the popup wrong; a face in the palette is what made that reachable, and the first render of the screenshot above had a `Select` wrapping its own options. It measures in the face the node inherits now, which fixes `Menu`, `Tooltip` and `Select` together.

## Breaking

Text that names no `fontSize` takes the palette's rather than a constant 14, so an app whose theme sets `fontSize` gets the size it asked for in every unstyled `<text>`, `<textinput>` and widget label. With the default palette nothing moves — `fontFamily`/`fontSize` default to exactly the constants they replace, and `docs/img` is unchanged.

`MenuBar`, `ContextMenu` and `Table` are deliberately unaffected: they take an explicit `fontSize` or `rowHeight` because they size themselves before there is anywhere to measure in. Worth a follow-up — their `DEFAULT_LABEL_SIZE = 13` is the same class of constant, but changing it moves the default menu geometry and would need `docs/img` regenerated.

## Not in scope

#258 is the rest of the token-vocabulary discussion — the status family and the `surface` naming. This is the slice of it with no naming controversy.

## Tests

Ten in `test/theme-type.test.js`; six of them fail with the source reverted, and the three that don't are the fallback and style-wins directions, which are supposed to hold either way. Two are pixels on a headless X server with two real families registered. `lint`, `typecheck` and `format:check` clean; the full suite has the same six pre-existing `appearance.test.js` failures as `master` on macOS and no others.

