### PR TITLE
feat(extending): a size the element decides — measureContent + invalidateMeasure

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -314,8 +314,8 @@ same screenshots far more than this route did.
 
 Every internal `invalidate()` call now names why it ran, from a small
 closed set: `props`, `style-state`, `theme`, `animation`, `scroll`,
-`text`, `content`, `child-list`, `focus`, `caret`, `resize`, `mount`,
-`expose`, `highlight`. The frame's collected reasons are what
+`text`, `content`, `measure`, `child-list`, `focus`, `caret`, `resize`,
+`mount`, `expose`, `highlight`. The frame's collected reasons are what
 `REACT_X11_TRACE=requests` frame lines, the chrome trace's frame slices,
 the full-repaint warning and `examples/stress/perf.js` print. After a
 frame they are readable on the window node as `root._lastReasons`

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -221,6 +221,10 @@ what _doesn't_ count:
 | `overflow: 'scroll'` / `'hidden'`                      | nothing           |
 | `flexShrink: 1`, or a `minWidth: 0` of its own         | what it shrank to |
 
+A registered element contributes whatever its `measureContent` answers when
+asked for the smallest size it can be drawn at — see
+[extending.md](extending.md#a-size-of-your-own).
+
 The last two rows are the escape hatch, and they are the same one CSS,
 Qt and GTK all spell — `min-width: 0`, `QScrollArea`, `min-content-width`.
 A node that was told it may shrink is taken at its word and its contents

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -81,13 +81,14 @@ are about to use needs declaring.
 `Node` already implements the whole reconciler-facing surface, so an element
 that only draws needs a constructor and a `paint`. What you may override:
 
-| method                         | when                                                                                              |
-| ------------------------------ | ------------------------------------------------------------------------------------------------- |
-| `paint(ctx)`                   | draw. Call `super.paint(ctx)` first for background, border and clip, then draw inside `this.abs`. |
-| `applyProps(next, prev)`       | props changed. Call `super.applyProps(next, prev)`; invalidate if you cache anything derived.     |
-| `hitTest(x, y)`                | non-rectangular hit areas. The default walks children in reverse paint order.                     |
-| `insertBefore` / `removeChild` | only if children mean something structural to you                                                 |
-| `destroySubtree()`             | release anything you allocated (pixmaps, fonts, timers). Call `super.destroySubtree()`.           |
+| method                         | when                                                                                                |
+| ------------------------------ | --------------------------------------------------------------------------------------------------- |
+| `paint(ctx)`                   | draw. Call `super.paint(ctx)` first for background, border and clip, then draw inside `this.abs`.   |
+| `applyProps(next, prev)`       | props changed. Call `super.applyProps(next, prev)`; invalidate if you cache anything derived.       |
+| `measureContent(constraints)`  | your content has a size of its own (below). Leaves only — an element that measures has no children. |
+| `hitTest(x, y)`                | non-rectangular hit areas. The default walks children in reverse paint order.                       |
+| `insertBefore` / `removeChild` | only if children mean something structural to you                                                   |
+| `destroySubtree()`             | release anything you allocated (pixmaps, fonts, timers). Call `super.destroySubtree()`.             |
 
 And what you read:
 
@@ -106,6 +107,114 @@ To ask for a repaint: `this.root?.invalidate(layout, rect, reason)`. Pass a
 the whole window, which is this renderer's main performance bug class (see
 [debugging.md](debugging.md)). `reason` joins the closed set the diagnostics
 print.
+
+### A size of your own
+
+`<box>` is as big as its style and its children say; a gauge, a chart, a
+terminal or an editor is as big as its _content_ says. An element with a size
+of its own implements **`measureContent`**, and layout asks it whenever the
+size on an axis is the element's to give:
+
+```js
+const TICK = 30;
+
+class GaugeNode extends Node {
+  measureContent({ width }) {
+    const ticks = Math.max(1, Number(this.props.ticks ?? 4));
+    // never wider than the offer, never narrower than one tick
+    return { width: Math.max(TICK, Math.min(ticks * TICK, width)), height: 24 };
+  }
+
+  applyProps(next, prev) {
+    const before = prev ?? this.props;
+    super.applyProps(next, prev);
+    // the measurement reads `ticks`, so a new one has to be taken
+    if (next.ticks !== before.ticks) this.invalidateMeasure();
+  }
+}
+```
+
+`<gauge ticks={6} />` is then 180×24 with nothing in the style saying so, the
+way `<textarea rows={6}>` is six lines tall.
+
+It has to be a **method on the class**: the base `Node` constructor is what
+wires it to layout, so an element that assigns it in its own constructor is
+too late and never gets asked. `invalidateMeasure()` says so in development.
+
+#### What it is asked
+
+The argument is `{ width, height, widthMode, heightMode }`. Each mode says
+what the number beside it means, and an unbounded axis arrives as `Infinity`
+rather than as a sentinel — so `Math.min(preferred, width)` is the right
+answer in all three, and the mode is there for the cases where it is not:
+
+| asked with       | the element answers                                                                                                            |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `unconstrained`  | its natural size — nothing bounds this axis (`<textarea>`: its preferred width, `rows` tall)                                   |
+| `at-most`        | its natural size, clamped into the offer                                                                                       |
+| `at-most` with 0 | **the smallest it can be drawn at** — an editor: a character or two of one line; something that scrolls inside: honestly small |
+| `exactly`        | the style decided this axis; hand the number back and answer for the other one                                                 |
+
+The `at-most 0` row is the one worth reading twice, because something else
+asks it: `<window minWidth="auto">` measures the smallest size its content
+can be drawn at by laying the tree out with **no room at all** and asking
+every leaf directly ([elements.md](elements.md#a-floor-the-content-decides)).
+An element that answers 0 there is saying it can be squeezed to nothing, and
+the window's floor comes out without it.
+
+`at-most` is what is _available_, not a cap that will be enforced: an element
+may answer larger and it will be laid out at what it asked for, overflowing
+whatever contains it. That is how `<text textWrap="nowrap">` works, and it is
+the honest answer for content that genuinely does not reflow — a code block
+that scrolls sideways rather than wrapping.
+
+#### What it must not do
+
+`measureContent` is a **question about a hypothetical**, asked several times
+per layout and at sizes nothing will ever be drawn at. So:
+
+- **do not read `this.abs`** — it is the result of the layout doing the
+  asking, and last frame's answer at that;
+- **do not paint, invalidate, or set state.** Cache derived work if it is
+  expensive (`<text>` memoizes its shaped layout per width), but keep the
+  answer a pure function of the content and the constraints;
+- **answer with finite numbers.** Content that has not arrived yet is
+  `{ width: 0, height: 0 }`, not `undefined` — anything else throws naming
+  the element, because a `NaN` would otherwise spread silently through every
+  ancestor's rect.
+
+An element that measures itself **cannot have children**: layout sizes it
+from the measure function and gives its children no say, so rendering one
+inside it is an error naming both elements.
+
+#### Saying the answer moved
+
+Layout caches what an element measured to. `invalidateMeasure(reason?)` is
+how the element says that cache is stale — a prop the measurement read
+changed, data arrived, a font loaded — and the next frame asks again. Nothing
+does this for you: only the element knows which of its inputs the measurement
+reads. `reason` joins the closed set the diagnostics print
+([debugging.md](debugging.md#invalidation-reasons)); the default is
+`'measure'`.
+
+#### Content with an aspect ratio
+
+The `<image>`/`<svg>` shape — a natural size to keep the proportions of — is
+one call:
+
+```js
+import { Node, intrinsicSize } from 'react-x11/node';
+
+class ThumbNode extends Node {
+  measureContent(constraints) {
+    return intrinsicSize(this.decoded ?? { width: 0, height: 0 }, constraints);
+  }
+}
+```
+
+It shrinks to the width on offer with the height following, and scales the
+width from a style height when only that axis is fixed — which is what an
+`<img>` does, and is the whole of `<image>`'s own measurement.
 
 ### Drawing once instead of every frame
 
@@ -179,7 +288,7 @@ discardable — is the part that is easy to get wrong.
 | subpath             |                                                                                                          |
 | ------------------- | -------------------------------------------------------------------------------------------------------- |
 | `react-x11/host`    | `registerElement`, `unregisterElement`, `registeredElements`, `hostTypes`, `knownElements`, `drawnKinds` |
-| `react-x11/node`    | `Node` and the built-in node classes                                                                     |
+| `react-x11/node`    | `Node`, the built-in node classes, `Scrollable`, `intrinsicSize`                                         |
 | `react-x11/style`   | `createStyles`, `flattenStyle`, `isStyleProp`, `resolveTokens`, the rest of the vocabulary               |
 | `react-x11/ntk`     | ntk itself, re-exported                                                                                  |
 | `react-x11/keysyms` | the `XK_*` constants                                                                                     |

--- a/src/node.d.ts
+++ b/src/node.d.ts
@@ -12,6 +12,43 @@ import type { Style } from './types/style.js';
 /** ntk's 2d context. Typed loosely — it is ntk's API, not ours. */
 export type Context2D = unknown;
 
+/** How an axis is bounded when layout asks an element for its size.
+ * `'exactly'` — the style decided this axis; `'at-most'` — that many pixels
+ * are on offer; `'unconstrained'` — nothing bounds it. */
+export type MeasureMode = 'exactly' | 'at-most' | 'unconstrained';
+
+/** The question `measureContent` answers. */
+export interface MeasureConstraints {
+  /** Pixels on offer across, per `widthMode`. `Infinity` when unbounded, so
+   * `Math.min(preferred, width)` is right in every mode. */
+  width: number;
+  /** Pixels on offer down, per `heightMode`. `Infinity` when unbounded. */
+  height: number;
+  widthMode: MeasureMode;
+  heightMode: MeasureMode;
+}
+
+/** What `measureContent` answers with. */
+export interface MeasuredSize {
+  width: number;
+  height: number;
+}
+
+/**
+ * The `measureContent` body for content with a natural size and an aspect
+ * ratio to keep — `<image>` and `<svg>` are written on it:
+ *
+ * ```js
+ * measureContent(constraints) {
+ *   return intrinsicSize({ width: 320, height: 200 }, constraints);
+ * }
+ * ```
+ */
+export declare function intrinsicSize(
+  natural: MeasuredSize,
+  constraints: MeasureConstraints,
+): MeasuredSize;
+
 export declare class Node {
   constructor(
     kind: string,
@@ -45,6 +82,24 @@ export declare class Node {
   /** Draw. A subclass calls `super.paint(ctx)` first, for the background,
    * border and clip, then draws inside `this.abs`. */
   paint(ctx: Context2D): void;
+  /**
+   * Implemented by an element whose size comes from its content — a gauge, a
+   * chart, a terminal, an editor. Called during layout whenever the box's
+   * size is the element's to give, and by the content-floor pass behind
+   * `minWidth: 'auto'` with `{ width: 0, widthMode: 'at-most' }`, whose
+   * answer is the smallest size the content can be drawn at.
+   *
+   * Must be a **method on the class**: the base constructor is what wires it
+   * to layout. An element that implements it may not have children, and it
+   * has to answer from what it can read at any time (props, loaded data) —
+   * never from `this.abs`, which is the result of the layout doing the
+   * asking. Call `invalidateMeasure()` when the answer would change.
+   */
+  measureContent?(constraints: MeasureConstraints): MeasuredSize;
+  /** The inputs to `measureContent` changed — a prop it reads, data that
+   * arrived — so the next layout has to ask again. `reason` joins the closed
+   * set the diagnostics print. */
+  invalidateMeasure(reason?: string): void;
   /** Props changed. A subclass calls `super.applyProps(next, prev)`. */
   applyProps(
     nextProps: Record<string, unknown>,

--- a/src/node.js
+++ b/src/node.js
@@ -6,13 +6,18 @@
 // surface (`insertBefore`, `removeChild`, `applyProps`, `destroySubtree`,
 // layout, hit testing, and a `paint` that draws background, border and
 // clip), so an element that only draws needs a constructor that names its
-// kind and a `paint` that calls `super.paint(ctx)` first.
+// kind and a `paint` that calls `super.paint(ctx)` first. An element whose
+// *size* comes from its content adds `measureContent`, and says when that
+// answer moves with `invalidateMeasure`.
 export {
   Node,
   // `class MyPane extends Scrollable(Node)` — the same mixin <box> and
   // <window> use, so a registered element can honour `overflow: 'scroll'`
   // with the wheel, the keys, the bars and the a11y role already wired.
   Scrollable,
+  // The `measureContent` body of an element whose content has a size of its
+  // own and an aspect ratio to keep — what <image> and <svg> answer with.
+  intrinsicSize,
   BoxNode,
   TextNode,
   ImageNode,

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -190,6 +190,7 @@ const INVALIDATE_REASONS = new Set([
   'scroll', // scrollTo/scrollBy/scrollIntoView, textarea/textinput panning
   'text', // text content, input value or caret editing
   'content', // async content arrived (image decode, rich-content reflow)
+  'measure', // an element said its own size changed (invalidateMeasure)
   'child-list', // children were added, removed or reordered
   'focus', // focus moved: ring/caret handover between nodes
   'caret', // the caret blink timer
@@ -987,6 +988,72 @@ const WINDOW_SEMANTIC_NAMES = new Set([
   ...WINDOW_HINT_PROPS,
 ]);
 
+/**
+ * Yoga's measure modes, in words. Indexed by the integer yoga hands a
+ * measure function, so `MEASURE_MODES[widthMode]` is the name.
+ *
+ * The names are the public vocabulary (`measureContent`) and the integers
+ * are not: an element that wrote `widthMode === 0` would be pinned to
+ * yoga's ABI through us, which is exactly what the seam exists to stop.
+ */
+const MEASURE_MODES = [];
+MEASURE_MODES[Yoga.MEASURE_MODE_UNDEFINED] = 'unconstrained';
+MEASURE_MODES[Yoga.MEASURE_MODE_EXACTLY] = 'exactly';
+MEASURE_MODES[Yoga.MEASURE_MODE_AT_MOST] = 'at-most';
+
+/**
+ * The pixels on offer on one axis, as a number an element can do arithmetic
+ * with. Yoga says "no bound" with a null, so `Math.min(preferred, width)`
+ * would answer 0 to the one question where the honest answer is `preferred`;
+ * `Infinity` is what "no bound" means in that expression, and it makes the
+ * mode something an element consults only when it has a reason to.
+ */
+function measureOffer(value, mode) {
+  return mode === Yoga.MEASURE_MODE_UNDEFINED || !Number.isFinite(value)
+    ? Infinity
+    : value;
+}
+
+/** What a measure function answered, for the error that rejects it. */
+function describeSize(size) {
+  if (size === null || typeof size !== 'object') return String(size);
+  return `{ width: ${size.width}, height: ${size.height} }`;
+}
+
+/**
+ * Fit a natural size into what layout offered — the shape `<image>`, `<svg>`
+ * and any other element whose content has a size of its own and an aspect
+ * ratio to keep.
+ *
+ * **Which axes the style fixed is something layout already knows**, and says
+ * in the measure modes: `'exactly'` on an axis means the style made it
+ * definite. Working it out a second time by reading style back would be
+ * duplication; working it out by reading *props* was issue #118 — `width` is
+ * a style name, so `<image width={40}>` throws in development and only ever
+ * reached that branch in production.
+ *
+ * - Both fixed: layout skips the measure entirely, so there is no
+ *   fixed-size case to write here.
+ * - Height fixed alone: scale the width with it, the way an `<img>` with
+ *   only a height set does, rather than stretching to the container.
+ * - Otherwise: natural size, shrunk to the width on offer, height following
+ *   the aspect ratio.
+ *
+ * @param {{width: number, height: number}} natural the content's own size
+ * @param {MeasureConstraints} constraints the argument of `measureContent`
+ */
+export function intrinsicSize(
+  natural,
+  { width, height, widthMode, heightMode },
+) {
+  const { width: natW, height: natH } = natural;
+  if (heightMode === 'exactly' && widthMode !== 'exactly' && natH > 0) {
+    return { width: (height * natW) / natH, height };
+  }
+  const w = width < natW ? width : natW;
+  return { width: w, height: natW > 0 ? (w * natH) / natW : natH };
+}
+
 /** Equality for props that may be a scalar, an array or a plain object
  *  (window hints are all three shapes), so an unchanged inline object
  *  literal does not re-send the property every render. */
@@ -1035,6 +1102,12 @@ export class Node {
     this.yoga = yoga ? Yoga.Node.create() : null;
     if (this.yoga) {
       applyLayoutStyle(this.yoga, this.style);
+      // An element with a size of its own says so by implementing
+      // `measureContent`, and the base class is what wires it to layout —
+      // so a third-party element reaches everything that asks a leaf for its
+      // size, including the content floor `minWidth: 'auto'` is measured
+      // with (#248), without knowing either of them exists.
+      if (typeof this.measureContent === 'function') this._useMeasureContent();
     }
     if (DEV) devCheckA11yProps(this);
   }
@@ -1391,6 +1464,67 @@ export class Node {
     this.yoga.setMeasureFunc(measure);
   }
 
+  /**
+   * Hand `measureContent` to layout, translated: the modes arrive as words,
+   * an axis with no bound arrives as `Infinity` rather than as yoga's null,
+   * and what comes back is checked before it can turn a whole tree into
+   * NaNs. Called by the constructor, so an element only writes the method.
+   */
+  _useMeasureContent() {
+    this._setMeasureFunc((width, widthMode, height, heightMode) => {
+      const size = this.measureContent({
+        width: measureOffer(width, widthMode),
+        height: measureOffer(height, heightMode),
+        widthMode: MEASURE_MODES[widthMode],
+        heightMode: MEASURE_MODES[heightMode],
+      });
+      if (!Number.isFinite(size?.width) || !Number.isFinite(size?.height)) {
+        // Left to itself this is a destructuring TypeError from inside
+        // yoga's wrapper, or — worse, because it does not throw at all — a
+        // NaN that spreads through every ancestor's rect.
+        throw new Error(
+          `react-x11: <${this.kind}>.measureContent() must return ` +
+            '{ width, height } as finite numbers; it returned ' +
+            `${describeSize(size)}. Return { width: 0, height: 0 } for ` +
+            'content that has not arrived yet.',
+        );
+      }
+      return size;
+    });
+  }
+
+  /**
+   * The inputs to `measureContent` changed — a prop it reads, data that
+   * loaded — so the next layout has to ask again instead of reusing the
+   * answer it cached.
+   *
+   * `reason` joins the closed set the diagnostics print (docs/debugging.md);
+   * the default says the measurement itself moved.
+   */
+  invalidateMeasure(reason = 'measure') {
+    // Nothing to re-ask, and both halves matter: layout aborts the process
+    // on a node that never had a measure function, and a destroyed node's
+    // box has already been freed under it.
+    if (this.destroyed || !this._measureFn) {
+      // Said once, in development: an element that asks for a re-measure and
+      // silently gets none looks broken rather than degraded, and there is
+      // nothing in the frame to pull on.
+      if (DEV && !this.destroyed && !this._measureNagged) {
+        this._measureNagged = true;
+        console.warn(
+          `react-x11: <${this.kind}>.invalidateMeasure() has nothing to ` +
+            're-measure — this element implements no measureContent(). ' +
+            'Note it has to be a method on the class: assigning it in the ' +
+            'constructor is too late, since the base Node constructor is ' +
+            'what wires it to layout.',
+        );
+      }
+      return;
+    }
+    this.yoga.markDirty();
+    this._invalidateLayout(reason);
+  }
+
   appendChild(child) {
     this.insertBefore(child, null);
   }
@@ -1434,6 +1568,23 @@ export class Node {
       throw new Error(
         `react-x11: <${this.kind}> takes no children (registered with ` +
           `childrenAllowed: false), but <${child.kind}> is inside it.`,
+      );
+    }
+    // A node's size comes from its measure function or from its children,
+    // never both — and yoga does not merely refuse the second one, it aborts
+    // the WebAssembly module, which takes the process down naming nothing
+    // the developer wrote. The built-ins reach it too: `<text>`, `<markdown>`
+    // and friends are turned away earlier by `createInstance`, which knows
+    // what their content is, but `<image>`, `<textinput>` and `<textarea>`
+    // arrive here.
+    if (this._measureFn && this._joinsYoga(child)) {
+      throw new Error(
+        `react-x11: <${this.kind}> measures its own content, so it cannot ` +
+          `contain <${child.kind}> — layout sizes such an element from its ` +
+          `measure function and gives its children no say. Render <${child.kind}> ` +
+          `beside it rather than inside it; or, if <${this.kind}> is meant to ` +
+          'arrange children, remove its measureContent() and let flexbox size ' +
+          'it from what is inside it.',
       );
     }
     // captured before the child joins, so it covers the arrangement that is
@@ -2462,22 +2613,22 @@ export class TextNode extends Node {
     super('text', props, app, { yoga: !span });
     this.isSpan = span;
     this._layouts = new Map();
-    if (this.yoga) {
-      this._setMeasureFunc((width, widthMode) => {
-        const maxWidth =
-          widthMode === Yoga.MEASURE_MODE_UNDEFINED ? Infinity : width;
-        const layout = this._layoutFor(this._wrapWidth(maxWidth));
-        if (!layout) return { width: 0, height: 0 };
-        const trim = this._trim(layout);
-        return {
-          width: Math.ceil(layout.width),
-          height: Math.max(
-            0,
-            Math.ceil(layout.height) - (trim ? trim.top + trim.bottom : 0),
-          ),
-        };
-      });
-    }
+  }
+
+  /** Height for a width: the paragraph shaped into whatever is on offer.
+   * The offer is `Infinity` when nothing bounds it, which is also what
+   * `textWrap: 'nowrap'` asks for, so neither needs a mode. */
+  measureContent({ width }) {
+    const layout = this._layoutFor(this._wrapWidth(width));
+    if (!layout) return { width: 0, height: 0 };
+    const trim = this._trim(layout);
+    return {
+      width: Math.ceil(layout.width),
+      height: Math.max(
+        0,
+        Math.ceil(layout.height) - (trim ? trim.top + trim.bottom : 0),
+      ),
+    };
   }
 
   _textContentChanged() {
@@ -2642,60 +2793,21 @@ export class TextNode extends Node {
   }
 }
 
-/**
- * The measure function the intrinsically-sized elements share — the ones
- * with a natural width and height that scale together (`<image>`, `<svg>`).
- * `natural()` returns that size; it is called per measure because it
- * arrives late (a decoded file, a parsed document).
- *
- * **Which dimensions the style fixed is something yoga already knows**, and
- * says in the measure modes: `EXACTLY` on an axis means the style made it
- * definite. Working it out a second time by reading style back would be
- * duplication; working it out by reading *props* was issue #118 — `width`
- * is a style name, so `<image width={40}>` throws in development and only
- * ever reached this branch in production.
- *
- * - Both fixed: yoga skips the measure function outright, so there is no
- *   fixed-size case to write here.
- * - Height fixed alone: scale the width with it, the way an `<img>` with
- *   only a height set does, rather than stretching to the container.
- * - Otherwise: natural size, shrunk to the width on offer, height
- *   following the aspect ratio.
- */
-export function intrinsicMeasure(natural) {
-  return (width, widthMode, height, heightMode) => {
-    const { width: natW, height: natH } = natural();
-    if (
-      heightMode === Yoga.MEASURE_MODE_EXACTLY &&
-      widthMode !== Yoga.MEASURE_MODE_EXACTLY &&
-      natH > 0
-    ) {
-      return { width: (height * natW) / natH, height };
-    }
-    let w = natW;
-    if (
-      widthMode !== Yoga.MEASURE_MODE_UNDEFINED &&
-      Number.isFinite(width) &&
-      width < w
-    ) {
-      w = width;
-    }
-    return { width: w, height: natW > 0 ? (w * natH) / natW : natH };
-  };
-}
-
 export class ImageNode extends Node {
   constructor(props, app) {
     super('image', props, app);
     this.image = null;
     this._loadToken = 0;
-    this._setMeasureFunc(
-      intrinsicMeasure(() => ({
-        width: this.image?.width ?? 0,
-        height: this.image?.height ?? 0,
-      })),
-    );
     this._load(props.src);
+  }
+
+  /** The decoded size, kept to its aspect ratio. Read per measure rather
+   * than once, because it arrives late. */
+  measureContent(constraints) {
+    return intrinsicSize(
+      { width: this.image?.width ?? 0, height: this.image?.height ?? 0 },
+      constraints,
+    );
   }
 
   async _load(src) {
@@ -2706,10 +2818,7 @@ export class ImageNode extends Node {
       const image = await loadImage(src);
       if (token !== this._loadToken || this.destroyed) return;
       this.image = image;
-      if (this.yoga) {
-        this.yoga.markDirty?.();
-        this._invalidateLayout('content');
-      }
+      this.invalidateMeasure('content');
     } catch (err) {
       console.error(`react-x11: failed to load image ${src}:`, err.message);
     }
@@ -3511,17 +3620,15 @@ export class TextInputNode extends Node {
     this._undoRun = null;
     // the open built-in edit menu, if any (see _openEditMenu)
     this._editMenu = null;
-    this._setMeasureFunc((width, widthMode) => {
-      const preferred = 150;
-      const w =
-        widthMode === Yoga.MEASURE_MODE_UNDEFINED
-          ? preferred
-          : Math.min(preferred, width);
-      // Not rounded here: a trimmed `<text>` hands yoga the raw cap band too,
-      // and rounding one of them and not the other is a pixel of difference
-      // between a field and the button beside it.
-      return { width: w, height: this._capBand() };
-    });
+  }
+
+  /** A preferred width, capped to whatever is on offer — `Infinity` when
+   * nothing is, which is what makes the `Math.min` the whole rule. */
+  measureContent({ width }) {
+    // Not rounded here: a trimmed `<text>` hands layout the raw cap band
+    // too, and rounding one of them and not the other is a pixel of
+    // difference between a field and the button beside it.
+    return { width: Math.min(150, width), height: this._capBand() };
   }
 
   get value() {
@@ -4465,8 +4572,7 @@ export class TextInputNode extends Node {
       if (this.style[key] !== beforeStyle[key]) metricsChanged = true;
     }
     if (metricsChanged) {
-      this.yoga.markDirty();
-      this._invalidateLayout('props');
+      this.invalidateMeasure('props');
     } else if (newProps.value !== before.value) {
       // painting clips to the content box and the measure function reads
       // only font metrics, so a value change is confined to the field —
@@ -4641,15 +4747,17 @@ export class TextAreaNode extends TextInputNode {
     super(props, app, 'textarea');
     this._scrollY = 0;
     this._goalX = null;
-    this._setMeasureFunc((width, widthMode) => {
-      const preferred = 220;
-      const w =
-        widthMode === Yoga.MEASURE_MODE_UNDEFINED
-          ? preferred
-          : Math.min(preferred, width);
-      const rows = Math.max(1, this.props.rows ?? 3);
-      return { width: w, height: Math.ceil(this._lineHeight() * rows) };
-    });
+  }
+
+  /** Wider than a single-line field, and `rows` lines tall — a height that
+   * comes from a prop rather than from the style, which is what makes
+   * `invalidateMeasure` necessary below. */
+  measureContent({ width }) {
+    const rows = Math.max(1, this.props.rows ?? 3);
+    return {
+      width: Math.min(220, width),
+      height: Math.ceil(this._lineHeight() * rows),
+    };
   }
 
   /** Multi-line: preserve newlines (normalize CRLF). */
@@ -4690,10 +4798,7 @@ export class TextAreaNode extends TextInputNode {
   applyProps(newProps, oldProps) {
     const before = oldProps ?? this.props;
     super.applyProps(newProps, oldProps);
-    if (newProps.rows !== before.rows) {
-      this.yoga.markDirty();
-      this._invalidateLayout('props');
-    }
+    if (newProps.rows !== before.rows) this.invalidateMeasure('props');
   }
 
   _indexAtPoint(ev) {

--- a/src/richnodes.js
+++ b/src/richnodes.js
@@ -5,13 +5,8 @@
 // through the widget's `onInvalidate` hook (ntk >= 3.4.0).
 import { MarkdownView, HtmlView, SvgView, layoutTex } from 'ntk';
 
-import { Node, intrinsicMeasure } from './nodes.js';
-import {
-  Yoga,
-  isLayoutProp,
-  isPaintProp,
-  DEFAULT_TEXT_STYLE,
-} from './styles.js';
+import { Node, intrinsicSize } from './nodes.js';
+import { isLayoutProp, isPaintProp, DEFAULT_TEXT_STYLE } from './styles.js';
 
 /** Joined text of string children (react-markdown style), or null when the
  * element has none — then the `source` prop is the content. */
@@ -42,17 +37,17 @@ class DocumentViewNode extends Node {
     super(kind, props, app);
     this.view = null;
     this._laidOutWidth = -1;
-    this._setMeasureFunc((width, widthMode) => {
-      const view = this._ensureView();
-      if (!view) return { width: 0, height: 0 };
-      const unconstrained =
-        widthMode === Yoga.MEASURE_MODE_UNDEFINED ||
-        !Number.isFinite(width) ||
-        width <= 0;
-      const w = Math.max(1, Math.ceil(unconstrained ? PREFERRED_WIDTH : width));
-      const height = this._layoutAt(w);
-      return { width: w, height: Math.ceil(height) };
-    });
+  }
+
+  /** Height for a width, through the document widget's own layout. A flowed
+   * document has no natural width, so an unbounded offer gets a readable
+   * one rather than one long line. */
+  measureContent({ width }) {
+    const view = this._ensureView();
+    if (!view) return { width: 0, height: 0 };
+    const bounded = Number.isFinite(width) && width > 0;
+    const w = Math.max(1, Math.ceil(bounded ? width : PREFERRED_WIDTH));
+    return { width: w, height: Math.ceil(this._layoutAt(w)) };
   }
 
   _ensureView() {
@@ -71,8 +66,7 @@ class DocumentViewNode extends Node {
   _contentInvalidated() {
     if (this.destroyed) return;
     this._laidOutWidth = -1;
-    this.yoga?.markDirty();
-    this._invalidateLayout('content');
+    this.invalidateMeasure('content');
   }
 
   _source() {
@@ -296,22 +290,24 @@ export class SvgNode extends Node {
      * See the note there. */
     this._docRevision = 0;
     this._paintedRevision = -1;
-    this._setMeasureFunc(
-      intrinsicMeasure(() => {
-        const view = this._ensureView();
-        return {
-          width: view?.naturalWidth ?? 0,
-          height: view?.naturalHeight ?? 0,
-        };
-      }),
+  }
+
+  /** The viewBox is the natural size; `<image>`'s rules do the rest. */
+  measureContent(constraints) {
+    const view = this._ensureView();
+    return intrinsicSize(
+      {
+        width: view?.naturalWidth ?? 0,
+        height: view?.naturalHeight ?? 0,
+      },
+      constraints,
     );
   }
 
   /** Any change to the svg subtree (props, children, text) lands here. */
   _textContentChanged() {
     this._stale = true;
-    this.yoga?.markDirty();
-    this._invalidateLayout('props');
+    this.invalidateMeasure('props');
   }
 
   _ensureView() {
@@ -492,18 +488,19 @@ export class TexNode extends Node {
     super('tex', props, app);
     this.box = null;
     this._boxKey = null;
-    this._setMeasureFunc(() => {
-      const box = this._ensureBox();
-      if (!box) return { width: 0, height: 0 };
-      return { width: Math.ceil(box.width), height: Math.ceil(box.height) };
-    });
+  }
+
+  /** A formula does not wrap: one size, whatever is on offer. */
+  measureContent() {
+    const box = this._ensureBox();
+    if (!box) return { width: 0, height: 0 };
+    return { width: Math.ceil(box.width), height: Math.ceil(box.height) };
   }
 
   /** Formula text changed via string children. */
   _textContentChanged() {
     this._boxKey = null;
-    this.yoga?.markDirty();
-    this._invalidateLayout('text');
+    this.invalidateMeasure('text');
   }
 
   _ensureBox() {
@@ -538,8 +535,7 @@ export class TexNode extends Node {
       newProps.size !== before.size ||
       newProps.displayMode !== before.displayMode
     ) {
-      this.yoga.markDirty();
-      this._invalidateLayout('props');
+      this.invalidateMeasure('props');
     }
   }
 

--- a/test/measure-content.test.js
+++ b/test/measure-content.test.js
@@ -1,0 +1,392 @@
+// A size the element itself decides: `measureContent` + `invalidateMeasure`
+// (#250).
+//
+// The element under test is written the way a third-party one would be —
+// everything it uses comes from the published subpaths, and nothing in it
+// names `this.yoga`, a yoga constant or an underscore. That is the whole
+// point of the issue: before this, an element with an intrinsic size had to
+// reach past the public surface for `setMeasureFunc`, and one that did was
+// invisible to the content floor `minWidth: 'auto'` is measured with (#248).
+//
+// Headless, so there are no fonts (see AGENTS.md): the gauge below measures
+// out of arithmetic rather than out of text.
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+
+import { registerElement, unregisterElement } from '../src/host.js';
+import { Node, intrinsicSize } from '../src/node.js';
+import { renderX11, cleanup } from '../src/testing/index.js';
+
+const h = React.createElement;
+
+/** One tick of the gauge, and the smallest width it can be drawn at. */
+const TICK = 30;
+
+/**
+ * A dial: `ticks` marks at `TICK` pixels each, 24 tall, and never narrower
+ * than a single tick however little room is on offer — the three answers the
+ * mode table in docs/extending.md asks for.
+ */
+class GaugeNode extends Node {
+  constructor(props, app) {
+    super('gauge', props, app);
+    this.measured = 0;
+  }
+
+  measureContent({ width }) {
+    this.measured++;
+    const ticks = Math.max(1, Number(this.props.ticks ?? 4));
+    return {
+      width: Math.max(TICK, Math.min(ticks * TICK, width)),
+      height: 24,
+    };
+  }
+
+  applyProps(next, prev) {
+    const before = prev ?? this.props;
+    super.applyProps(next, prev);
+    if (next.ticks !== before.ticks) this.invalidateMeasure();
+  }
+}
+
+const registered = new Set();
+function register(type, definition) {
+  registerElement(type, definition);
+  registered.add(type);
+}
+
+afterEach(async () => {
+  await cleanup();
+  for (const type of registered) unregisterElement(type);
+  registered.clear();
+});
+
+/** Mount a `<window>` of our own, into the mock connection. */
+const mount = (props, ...children) =>
+  renderX11(h('window', { title: 'measure', ...props }, ...children), {
+    backend: 'mock',
+  });
+
+/** A gauge that is measured rather than stretched: `stretch` is the default
+ * cross-axis alignment, and it overrides what a leaf measured to. */
+const gauge = (props) =>
+  h('gauge', {
+    ticks: 4,
+    ...props,
+    style: { alignSelf: 'flex-start', ...props?.style },
+  });
+
+const found = (node, kind) =>
+  node.kind === kind
+    ? node
+    : (node.children.map((c) => found(c, kind)).find(Boolean) ?? null);
+
+/** The hints the window was created with, or the last ones written to it. */
+const hintsOf = (wnd) => {
+  const sent = wnd.calls.filter(([name]) => name === 'setSizeHints');
+  return sent.length ? sent[sent.length - 1][1] : wnd.attributes.sizeHints;
+};
+
+/**
+ * Assert a mount throws, without React's report of the escaping error on
+ * stderr — the message under test is the one thrown, not the one React logs
+ * about it. Same shape as the console capture in register-element.test.js.
+ */
+async function rejectsQuietly(fn, expected) {
+  const origError = console.error;
+  console.error = () => {};
+  try {
+    await assert.rejects(fn, expected);
+  } finally {
+    console.error = origError;
+  }
+}
+
+// --- the three questions layout asks ----------------------------------------
+
+test('unconstrained: the element answers with its natural size', async () => {
+  register('gauge', {
+    create: (props, app) => new GaugeNode(props, app),
+    semanticNames: ['ticks'],
+  });
+  // An `'auto'` window is sized by laying its content out with no available
+  // width at all, which is where the unconstrained mode is reached from
+  // JSX — and it is the case a `Math.min` against yoga's own "no bound"
+  // would answer 0 to.
+  const { windowNode, window: wnd } = await mount(
+    { width: 'auto', height: 'auto' },
+    gauge(),
+  );
+  assert.deepStrictEqual(
+    [
+      found(windowNode, 'gauge').abs.width,
+      found(windowNode, 'gauge').abs.height,
+    ],
+    [4 * TICK, 24],
+    'four ticks wide, its own height',
+  );
+  assert.strictEqual(
+    wnd.attributes.width,
+    4 * TICK,
+    'and the window was created around it',
+  );
+});
+
+test('at-most: the natural size is clamped into the offer', async () => {
+  register('gauge', { create: (p, a) => new GaugeNode(p, a) });
+  const { windowNode } = await mount(
+    { width: 200, height: 120 },
+    gauge({ ticks: 12 }),
+  );
+  assert.strictEqual(
+    found(windowNode, 'gauge').abs.width,
+    200,
+    '12 ticks want 360; the window has 200',
+  );
+});
+
+test('exactly: the style decided that axis, the element answers the other', async () => {
+  register('gauge', { create: (p, a) => new GaugeNode(p, a) });
+  const { windowNode } = await mount(
+    { width: 200, height: 120 },
+    gauge({ style: { width: 90 } }),
+  );
+  const dial = found(windowNode, 'gauge');
+  assert.deepStrictEqual(
+    [dial.abs.width, dial.abs.height],
+    [90, 24],
+    "the width is the style's, the height is still the element's",
+  );
+});
+
+test('an answer larger than the offer overflows rather than being clamped', async () => {
+  // `at-most` is what is available, not a cap the renderer enforces — which
+  // is what content that does not reflow needs: `<text textWrap="nowrap">`
+  // runs off the edge, and so does a code block that scrolls sideways.
+  class RigidNode extends Node {
+    constructor(props, app) {
+      super('rigid', props, app);
+    }
+
+    measureContent() {
+      return { width: 500, height: 20 };
+    }
+  }
+  register('rigid', { create: (p, a) => new RigidNode(p, a) });
+  const { windowNode } = await mount(
+    { width: 200, height: 120 },
+    h('rigid', { style: { alignSelf: 'flex-start' } }),
+  );
+  assert.strictEqual(found(windowNode, 'rigid').abs.width, 500);
+});
+
+// --- saying the answer moved ------------------------------------------------
+
+test('invalidateMeasure() is what makes the next frame ask again', async () => {
+  register('gauge', { create: (p, a) => new GaugeNode(p, a) });
+  const { windowNode, rerender } = await mount(
+    { width: 400, height: 120 },
+    gauge(),
+  );
+  const dial = found(windowNode, 'gauge');
+  assert.strictEqual(dial.abs.width, 4 * TICK);
+
+  await rerender(
+    h(
+      'window',
+      { title: 'measure', width: 400, height: 120 },
+      gauge({ ticks: 7 }),
+    ),
+  );
+  assert.strictEqual(
+    dial.abs.width,
+    7 * TICK,
+    'the measurement reads `ticks`, so a new one has to be taken',
+  );
+});
+
+test('a measurement nobody invalidated is reused, cache and all', async () => {
+  // The other half of the contract, and the reason `invalidateMeasure` is
+  // not something the renderer can do on the element's behalf: it cannot
+  // know which props the measurement read.
+  class Frozen extends GaugeNode {
+    applyProps(next, prev) {
+      Node.prototype.applyProps.call(this, next, prev);
+    }
+  }
+  register('gauge', { create: (p, a) => new Frozen(p, a) });
+  const { windowNode, rerender } = await mount(
+    { width: 400, height: 120 },
+    gauge(),
+  );
+  const dial = found(windowNode, 'gauge');
+  await rerender(
+    h(
+      'window',
+      { title: 'measure', width: 400, height: 120 },
+      gauge({ ticks: 7 }),
+    ),
+  );
+  assert.strictEqual(dial.props.ticks, 7, 'the prop did arrive');
+  assert.strictEqual(dial.abs.width, 4 * TICK, 'the size did not');
+});
+
+// --- the content floor (#248) ----------------------------------------------
+
+// **Stretched on purpose**, which is the case the seam exists for: the floor
+// is measured by laying the tree out with no room at all, and a leaf with the
+// default `align-items: stretch` comes out of that pass at its container's
+// size — nothing. So the size it *would* have drawn at is recorded nowhere
+// but in its measure function, and the pass has to ask it again directly.
+// An element whose measure function went in through raw `yoga.setMeasureFunc`
+// is not there to ask, and these come out 0.
+const stretchedGauge = (props) => h('gauge', { ticks: 4, ...props });
+
+test('a measured element is what floors a minWidth="auto" window', async () => {
+  register('gauge', { create: (p, a) => new GaugeNode(p, a) });
+  const { window: wnd, windowNode } = await mount(
+    { width: 400, height: 120, minWidth: 'auto' },
+    stretchedGauge(),
+  );
+  assert.strictEqual(
+    found(windowNode, 'gauge').abs.width,
+    400,
+    'precondition: stretched, so its own width is nowhere in the layout',
+  );
+  assert.strictEqual(hintsOf(wnd).minWidth, TICK);
+});
+
+test('the floor carries the padding that surrounds the content', async () => {
+  register('gauge', { create: (p, a) => new GaugeNode(p, a) });
+  const { window: wnd } = await mount(
+    { width: 400, height: 120, minWidth: 'auto', style: { padding: 12 } },
+    stretchedGauge(),
+  );
+  assert.strictEqual(hintsOf(wnd).minWidth, TICK + 24);
+});
+
+test('minHeight="auto" reaches the same element down the other axis', async () => {
+  register('gauge', { create: (p, a) => new GaugeNode(p, a) });
+  const { window: wnd } = await mount(
+    { width: 400, height: 120, minHeight: 'auto' },
+    stretchedGauge(),
+  );
+  assert.strictEqual(hintsOf(wnd).minHeight, 24);
+});
+
+// --- the intrinsic-size recipe ----------------------------------------------
+
+test('intrinsicSize keeps an aspect ratio the way <image> does', async () => {
+  class ThumbNode extends Node {
+    constructor(props, app) {
+      super('thumb', props, app);
+    }
+
+    measureContent(constraints) {
+      return intrinsicSize({ width: 400, height: 100 }, constraints);
+    }
+  }
+  register('thumb', { create: (p, a) => new ThumbNode(p, a) });
+
+  const { windowNode } = await mount(
+    { width: 200, height: 200 },
+    h('thumb', { key: 'shrunk', style: { alignSelf: 'flex-start' } }),
+    h('thumb', {
+      key: 'tall',
+      style: { height: 20, alignSelf: 'flex-start' },
+    }),
+  );
+  const [shrunk, tall] = windowNode.children.filter((c) => c.kind === 'thumb');
+  assert.deepStrictEqual(
+    [shrunk.abs.width, shrunk.abs.height],
+    [200, 50],
+    '4:1 shrunk into a 200-wide window',
+  );
+  assert.deepStrictEqual(
+    [tall.abs.width, tall.abs.height],
+    [80, 20],
+    'a style height scales the width with it',
+  );
+});
+
+// --- the two mistakes the seam can be made ----------------------------------
+
+test('an element that measures itself cannot also arrange children', async () => {
+  register('gauge', { create: (p, a) => new GaugeNode(p, a) });
+  // Left to yoga this is an abort of the WebAssembly module — the process
+  // dies naming nothing the developer wrote — so the check is worth its
+  // property read.
+  await rejectsQuietly(
+    () =>
+      mount(
+        { width: 200, height: 120 },
+        h('gauge', { ticks: 2 }, h('box', { style: { width: 5 } })),
+      ),
+    /<gauge> measures its own content, so it cannot contain <box>/,
+  );
+});
+
+test('a measurement that is not a size says so, naming the element', async () => {
+  class BrokenNode extends Node {
+    constructor(props, app) {
+      super('broken', props, app);
+    }
+
+    measureContent() {
+      return { width: 10 };
+    }
+  }
+  register('broken', { create: (p, a) => new BrokenNode(p, a) });
+  await rejectsQuietly(
+    () => mount({ width: 'auto', height: 'auto' }, h('broken', {})),
+    /<broken>\.measureContent\(\) must return \{ width, height \} as finite numbers; it returned \{ width: 10, height: undefined \}/,
+  );
+});
+
+test('invalidateMeasure() on an element that measures nothing says so', async () => {
+  // The trap it exists for: `measureContent` assigned in the constructor
+  // rather than written as a method. The base constructor is what wires it,
+  // so the element measures nothing and every invalidation is a no-op —
+  // which looks like a broken element rather than a mis-declared one.
+  class LateNode extends Node {
+    constructor(props, app) {
+      super('late', props, app);
+      this.measureContent = () => ({ width: 40, height: 40 });
+    }
+  }
+  register('late', { create: (p, a) => new LateNode(p, a) });
+  const said = [];
+  const origWarn = console.warn;
+  console.warn = (...args) => said.push(args.join(' '));
+  try {
+    const { windowNode } = await mount(
+      { width: 200, height: 120 },
+      h('late', { style: { alignSelf: 'flex-start' } }),
+    );
+    const node = found(windowNode, 'late');
+    assert.strictEqual(node.abs.width, 0, 'never asked, so it has no size');
+    node.invalidateMeasure();
+    node.invalidateMeasure();
+  } finally {
+    console.warn = origWarn;
+  }
+  assert.strictEqual(said.length, 1, 'once, not once per call');
+  assert.match(said[0], /<late>\.invalidateMeasure\(\) has nothing to/);
+  assert.match(said[0], /method on the class/);
+});
+
+test('the built-ins that measure are held to it too', async () => {
+  // Not a new restriction — yoga has always aborted on this — but the error
+  // now names both elements instead of killing the process. `<text>`,
+  // `<markdown>` and `<tex>` are turned away earlier still, by the
+  // reconciler, which knows what their content is supposed to be.
+  await rejectsQuietly(
+    () =>
+      mount(
+        { width: 200, height: 120 },
+        h('textarea', {}, h('box', { style: { width: 5 } })),
+      ),
+    /<textarea> measures its own content, so it cannot contain <box>/,
+  );
+});

--- a/test/types/extend.tsx
+++ b/test/types/extend.tsx
@@ -13,7 +13,8 @@ import {
   knownElements,
   drawnKinds,
 } from '../../src/host.js';
-import { Node, BoxNode } from '../../src/node.js';
+import { Node, BoxNode, intrinsicSize } from '../../src/node.js';
+import type { MeasureConstraints } from '../../src/node.js';
 import {
   isStyleProp,
   flattenStyle,
@@ -29,6 +30,13 @@ declare module '../../src/jsx-runtime.js' {
       sparkline: {
         data: number[];
         color?: string;
+        style?: Style;
+      };
+      gauge: {
+        ticks?: number;
+        style?: Style;
+      };
+      thumb: {
         style?: Style;
       };
     }
@@ -61,6 +69,51 @@ registerElement('sparkline', {
   childrenAllowed: false,
 });
 
+// An element with a size of its own (#250): the modes are words, the offer is
+// a number, and nothing here names yoga.
+class GaugeNode extends Node {
+  constructor(props: Record<string, unknown>, app: never) {
+    super('gauge', props, app);
+  }
+
+  measureContent({ width, widthMode }: MeasureConstraints): {
+    width: number;
+    height: number;
+  } {
+    const ticks = Number(this.props.ticks ?? 4);
+    const _mode: 'exactly' | 'at-most' | 'unconstrained' = widthMode;
+    return { width: Math.min(ticks * 30, width), height: 24 };
+  }
+
+  applyProps(
+    next: Record<string, unknown>,
+    prev: Record<string, unknown>,
+  ): void {
+    const before = prev ?? this.props;
+    super.applyProps(next, prev);
+    if (next.ticks !== before.ticks) this.invalidateMeasure();
+  }
+}
+
+// …and the aspect-ratio recipe, which is `<image>`'s own measurement.
+class ThumbNode extends Node {
+  constructor(props: Record<string, unknown>, app: never) {
+    super('thumb', props, app);
+  }
+
+  measureContent(constraints: MeasureConstraints) {
+    return intrinsicSize({ width: 400, height: 100 }, constraints);
+  }
+}
+
+registerElement('gauge', {
+  create: (props, app) => new GaugeNode(props, app as never),
+  semanticNames: ['ticks'],
+});
+registerElement('thumb', {
+  create: (props, app) => new ThumbNode(props, app as never),
+});
+
 // the minimum: a create() and nothing else
 registerElement('minimal', {
   create: (props, app) => new BoxNode(props, app),
@@ -83,6 +136,8 @@ function Chart() {
   return (
     <box style={styles.chart}>
       <sparkline data={[1, 4, 2, 8]} color="#c0392b" style={{ flexGrow: 1 }} />
+      <gauge ticks={6} />
+      <thumb />
     </box>
   );
 }


### PR DESCRIPTION
Closes #250.

An element whose size comes from its content — a gauge, a chart, a terminal, the `<CodeEditor>` and `<richtext>` the issue came out of — had no public way to say so. `<textinput>` does it through `this.yoga.setMeasureFunc`, and `yoga` is deliberately absent from `react-x11/node`'s surface, so a third party reached past it three times for one feature: the measure function, yoga's `MEASURE_MODE_*` integers, and `markDirty()`.

Since #248 that stopped being merely untidy. The content floor behind `minWidth="auto"` re-asks a leaf **directly** through `_measureFn`, because a computed size after the squash pass is a stretch result rather than a measurement — so an element wired the raw way is invisible to it, and the window's floor comes out wrong around it. Two consumers of a leaf's measure function, and only core wired to both.

## The seam

```js
import { Node, intrinsicSize } from 'react-x11/node';

class GaugeNode extends Node {
  measureContent({ width }) {
    const ticks = Math.max(1, Number(this.props.ticks ?? 4));
    return { width: Math.max(30, Math.min(ticks * 30, width)), height: 24 };
  }

  applyProps(next, prev) {
    const before = prev ?? this.props;
    super.applyProps(next, prev);
    if (next.ticks !== before.ticks) this.invalidateMeasure();
  }
}
```

- **The modes are words** — `'exactly' | 'at-most' | 'unconstrained'` — so yoga's ABI stays private and `widthMode === 0` dies. No yoga enum appears in any public signature.
- **An unbounded axis arrives as `Infinity`**, not as a sentinel, which makes `Math.min(preferred, width)` the right answer in all three modes. `<textinput>`'s measurement is now that one expression.
- **The base constructor wires it through `_setMeasureFunc`**, so a registered element contributes to `minWidth`/`minHeight: "auto"` with no further work — the #248 half.
- **`invalidateMeasure(reason?)`** replaces the `markDirty()` cast: `markDirty` plus the bounded layout invalidation `TextAreaNode.applyProps` already did by hand, guarded on `destroyed` and on there being a measure function at all — `markDirty` on a node without one aborts the process.

The contract is documented in [docs/extending.md](https://github.com/sidorares/react-x11/blob/claude/react-x11-issue-250-296d7a/docs/extending.md#a-size-of-your-own): what each mode means, what `at-most 0` is for, that an answer larger than the offer overflows rather than being clamped — the `<richtext wrap={false}>` case from the issue thread — and that the measurement must stay a pure function of the content and the constraints.

## Core migrates onto it

`<text>`, `<image>`, `<textinput>`, `<textarea>`, `<markdown>`/`<html>`, `<svg>` and `<tex>` all measure through `measureContent` now. That is what keeps the seam honest, and it removes an ordering hazard: a built-in's constructor calling `_setMeasureFunc` would otherwise clobber a subclass's `measureContent`. `intrinsicMeasure` becomes `intrinsicSize(natural, constraints)` and is exported from `react-x11/node`, so the aspect-ratio case is reachable rather than copied.

## Two aborts become errors

- A measured element with children used to take down the WebAssembly module — `Aborted()`, naming nothing the developer wrote. `<image>`, `<textinput>` and `<textarea>` all reached it; now the error names both elements and says what to do.
- A measure that answers with anything but two finite numbers used to surface as a destructuring TypeError from inside yoga's wrapper, or — worse — as a NaN spreading through every ancestor's rect. Now it names the element and what came back.

## Not a compatibility break

Raw `this.yoga.setMeasureFunc` keeps working exactly as before, and keeps being invisible to the content floor. That is the reason to move rather than a reason to keep a shim.

## Verification

- `npm test` — 1000 pass, 6 fail, all six pre-existing on master and unrelated: `test/appearance.test.js` reads this Mac's real appearance instead of the mocked XSETTINGS ladder.
- New `test/measure-content.test.js` — 14 cases, written entirely against the published subpaths, nothing in the element naming `this.yoga` or an underscore: the three modes, `at-most 0` flooring a `minWidth="auto"` window's `WM_NORMAL_HINTS`, `minHeight="auto"`, an answer that overflows the offer, `invalidateMeasure` and the frame that reuses a measurement nobody invalidated, `intrinsicSize`'s aspect ratio, and the three errors. Mutation-checked: bypassing `_setMeasureFunc` fails the floor cases, a no-op `invalidateMeasure` and a raw offer instead of `Infinity` each fail their own.
- `npm run lint`, `npm run typecheck` — clean. `test/types/extend.tsx` compiles an element using `measureContent`, `invalidateMeasure`, `MeasureConstraints` and `intrinsicSize`; deleting the declaration fails the build.
- `npm run bench -- --check` — no regressions.
- `website && npm test && npm run build` — green, which is what validates the new cross-page anchors.
- **No screenshots**, because nothing about this is detectable by eye: `npm run screenshots` on master and on this branch produces byte-identical PNGs across all nine, which is the evidence that migrating every measure function in the tree changed no layout. Two committed PNGs already drift from what today's renderer produces on master; regenerating them is not this PR's business.
