### PR TITLE
feat(extending): behaviour the element decides — default actions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -994,8 +994,9 @@ source of truth for what's next). Done: phase 0 (ntk 3.1.0), phase 1 (drawn laye
 phase 2 (events, scrolling), phase 3's `<popup>` and `<textinput>`
 (on ntk 3.2.0: clipboard, cursors, setLineDash), and the layout debug
 overlay (`REACT_X11_DEBUG_LAYOUT=1`). Element default actions (textinput
-editing, wheel scrolling) run via `_default*` hooks on nodes AFTER user
-prop handlers, skipped on `preventDefault()`. The window-manager example
+editing, wheel scrolling, Tab traversal) run via the `default*` methods on
+nodes AFTER user prop handlers, skipped on `preventDefault()` — a documented
+seam a registered element implements too (#251, docs/extending.md). The window-manager example
 (issue #3) is done — on ntk 3.9.0 and node-x11 3.2.0, which grew the
 substructure-redirect support it needed. Also done since: the widget set
 including `Select`, `Menu`/`MenuBar`/`ContextMenu`, `Tabs`, `Tree`,

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -120,7 +120,7 @@ merged theme (`ThemeProvider`, `useTheme`) and a
   (#90, issue #88): `src/editmenu.js` builds it from the node's own
   capabilities, and the selection-collapse half of that issue went with it —
   a right-click inside a selection keeps it, only one outside moves the
-  caret (`_defaultMouseDown`), which is what GTK and Qt do. Still missing:
+  caret (`defaultMouseDown`), which is what GTK and Qt do. Still missing:
   a generic Popover, and a file open/save dialog
 - **Horizontal scrolling — DONE.** A scroll container scrolls on both axes:
   `scrollX`/`contentWidth`, a second draggable bar, `scrollTo({x, y})`,

--- a/docs/events.md
+++ b/docs/events.md
@@ -12,8 +12,13 @@ events dispatched over the drawn node tree with DOM-like semantics.
    the target.
 3. **Target + bubble phase**: `on<Event>` handlers from the target up.
 4. **Default action**: the element's built-in behavior (textinput editing,
-   wheel scrolling) — skipped if any handler called
+   wheel scrolling, then Tab traversal) — skipped if any handler called
    `ev.preventDefault()`.
+
+Step 4 is a documented seam, not a privilege of the built-in elements: an
+element added with `registerElement` implements the same `defaultKeyDown` /
+`defaultMouseDown` / … methods and gets the same ordering
+([extending.md](extending.md#behaviour-of-your-own)).
 
 `ev.stopPropagation()` stops the walk. Handlers always read from current
 props — they can never go stale.
@@ -102,18 +107,18 @@ const root = await createRoot({
 
 ## Handlers
 
-| handler                                     | notes                                                                                   |
-| ------------------------------------------- | --------------------------------------------------------------------------------------- |
-| `onClick`                                   | fires on the nearest common ancestor of press & release; `detail` counts multi-clicks   |
-| `onMouseDown` / `onMouseUp` / `onMouseMove` | move is coalesced to once per frame by ntk                                              |
-| `onMouseEnter` / `onMouseLeave`             | do not propagate; synthesized by hover-path diffing                                     |
-| `onWheel`                                   | X buttons 4–7; default action scrolls the nearest scroll container with somewhere to go |
-| `onContextMenu`                             | right-click (button 3), after `onMouseDown`; default action opens the element's menu    |
-| `onKeyDown` / `onKeyUp`                     | delivered to the focused node (or the window); Tab cycles focus in `tabIndex` order     |
-| `onFocus` / `onBlur`                        | focus follows mousedown (nearest `focusable` ancestor) and Tab traversal                |
-| `onDragEnter` / `onDragLeave`               | do not propagate; drag-path diffing, the same shape as the hover pair above             |
-| `onDragOver` / `onDrop`                     | on a drop target; `onDrop` may be async — [drag-and-drop.md](drag-and-drop.md)          |
-| `onDragStart` / `onDrag` / `onDragEnd`      | on a `draggable` node; the press is a click until it moves 4px                          |
+| handler                                     | notes                                                                                      |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `onClick`                                   | fires on the nearest common ancestor of press & release; `detail` counts multi-clicks      |
+| `onMouseDown` / `onMouseUp` / `onMouseMove` | move is coalesced to once per frame by ntk                                                 |
+| `onMouseEnter` / `onMouseLeave`             | do not propagate; synthesized by hover-path diffing                                        |
+| `onWheel`                                   | X buttons 4–7; default action scrolls the nearest scroll container with somewhere to go    |
+| `onContextMenu`                             | right-click (button 3), after `onMouseDown`; default action opens the element's menu       |
+| `onKeyDown` / `onKeyUp`                     | delivered to the focused node (or the window); Tab cycles focus unless the element took it |
+| `onFocus` / `onBlur`                        | focus follows mousedown (nearest `focusable` ancestor) and Tab traversal                   |
+| `onDragEnter` / `onDragLeave`               | do not propagate; drag-path diffing, the same shape as the hover pair above                |
+| `onDragOver` / `onDrop`                     | on a drop target; `onDrop` may be async — [drag-and-drop.md](drag-and-drop.md)             |
+| `onDragStart` / `onDrag` / `onDragEnd`      | on a `draggable` node; the press is a click until it moves 4px                             |
 
 ## Pointer capture
 
@@ -177,6 +182,13 @@ the order.
 <box focusable />      {/* then tree order */}
 <box tabIndex={-1} />  {/* clickable, never tabbed to */}
 ```
+
+Traversal is a **default action** like any other, and it runs last: an
+`onKeyDown` that calls `preventDefault()` on Tab keeps it, and so does an
+element whose own `defaultKeyDown` consumes it — an editor indenting with
+Tab. An element that does owes the keyboard user a way out of it, which is
+the Escape-arms-one-Tab convention in
+[extending.md](extending.md#behaviour-of-your-own).
 
 ### Focus scopes (modals)
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -86,6 +86,7 @@ that only draws needs a constructor and a `paint`. What you may override:
 | `paint(ctx)`                   | draw. Call `super.paint(ctx)` first for background, border and clip, then draw inside `this.abs`.   |
 | `applyProps(next, prev)`       | props changed. Call `super.applyProps(next, prev)`; invalidate if you cache anything derived.       |
 | `measureContent(constraints)`  | your content has a size of its own (below). Leaves only — an element that measures has no children. |
+| `default*(ev)`                 | the element's own behaviour for a key, a press or focus (below) — what makes it _interactive_.      |
 | `hitTest(x, y)`                | non-rectangular hit areas. The default walks children in reverse paint order.                       |
 | `insertBefore` / `removeChild` | only if children mean something structural to you                                                   |
 | `destroySubtree()`             | release anything you allocated (pixmaps, fonts, timers). Call `super.destroySubtree()`.             |
@@ -215,6 +216,115 @@ class ThumbNode extends Node {
 It shrinks to the width on offer with the height following, and scales the
 width from a style height when only that axis is fixed — which is what an
 `<img>` does, and is the whole of `<image>`'s own measurement.
+
+### Behaviour of your own
+
+An element that _does_ something — an editor, a terminal, a table with cell
+editing, a tree with type-ahead — implements the **default actions**. They are
+the same seam `<textinput>`'s editing runs on, and the ordering is the whole
+point:
+
+1. the application's `onKeyDown` / `onMouseDown` / … handlers, capture then
+   bubble;
+2. **if none of them called `ev.preventDefault()`**, the element's `default*`
+   method.
+
+So an app can veto the behaviour, or run something before it, without knowing
+how the element is built — which is what `<textinput onKeyDown>` has always
+been able to do, and is the reason to implement behaviour here rather than in
+a React component wrapping the element.
+
+| method                   | when                                                                                                                         |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
+| `defaultKeyDown(ev)`     | a key, delivered to the focused node. `ev.keysym` is the `XK_*` constant; `codepoint >= 0x20` is the test for "this is text" |
+| `defaultMouseDown(ev)`   | a press. Place a caret, grab a handle; `ev.capturePointer()` to keep the rest of the gesture                                 |
+| `defaultMouseDrag(ev)`   | motion while _this_ element holds the press — including outside its box, which `onMouseMove` does not give you               |
+| `defaultMouseUp(ev)`     | that press was released                                                                                                      |
+| `defaultContextMenu(ev)` | right-click, after the press: open your own menu. Separate so suppressing it keeps the caret placement                       |
+| `defaultFocus()`         | this element became the focused node (or its window got the X focus back): start the caret blinking                          |
+| `defaultBlur()`          | focus left, or the window lost it: stop it                                                                                   |
+
+```js
+import { Node, CARET_BLINK_MS } from 'react-x11/node';
+import { XK_TAB, XK_ESCAPE } from 'react-x11/keysyms';
+
+class EditorNode extends Node {
+  constructor(props, app) {
+    super('codeeditor', props, app);
+    // without this nothing focuses it, and no key ever arrives
+    this.focusableByDefault = true;
+    this.defaultCursor = 'text';
+  }
+
+  defaultKeyDown(ev) {
+    if (ev.keysym === XK_ESCAPE) {
+      // the way out: the next Tab leaves, so the element is never a trap
+      this._tabEscapes = true;
+      return;
+    }
+    if (ev.keysym === XK_TAB) {
+      if (this._tabEscapes) {
+        this._tabEscapes = false; // one Tab, then it indents again
+        return; // …and this one belongs to focus traversal
+      }
+      this.indent(ev.shiftKey ? -1 : 1);
+      ev.preventDefault(); // this one is mine
+      return;
+    }
+    this._tabEscapes = false;
+    if (ev.codepoint >= 0x20) this.insert(ev.key);
+  }
+
+  defaultFocus() {
+    this._caretOn = true;
+    this._blink = setInterval(() => {
+      this._caretOn = !this._caretOn;
+      this.root?.invalidate(false, this, 'caret');
+    }, CARET_BLINK_MS);
+    this._blink.unref?.();
+  }
+
+  defaultBlur() {
+    clearInterval(this._blink);
+    this._blink = null;
+    this._caretOn = false;
+  }
+}
+```
+
+Four details worth having in writing:
+
+**A gesture is vetoed once, at its press.** `defaultMouseDrag` and
+`defaultMouseUp` are the continuation of the press `defaultMouseDown` got, so
+a handler that prevented the press means none of the three run — an element
+never hears about motion it has no press behind, and does not need a
+`dragging` flag of its own to discover that.
+
+**Focus is a prerequisite, not a consequence.** Keys are delivered to the
+focused node, and nothing focuses an element that has not said it can be:
+`focusableByDefault = true` makes it a tab stop and a press target the way
+`<textinput>` is one, and an application's `focusable={false}` or `tabIndex`
+still overrides it ([events.md](events.md#focus)).
+
+**Tab is an ordinary key here.** It reaches `defaultKeyDown` before focus
+traversal sees it, so an element can keep it — an editor indenting with Tab
+does not need a wrapping component to get it, which is what the ordering used
+to force. Consuming it means calling `ev.preventDefault()` from the default
+action: what that prevents is the default action _after_ this one, which for
+Tab is the focus cycle.
+
+An element that eats Tab has taken the keyboard user's only way out of it, so
+it owes them another. The convention, above and worth converging on: **Escape
+arms one pass-through Tab.** Escape on its own does nothing visible, the next
+Tab leaves, and the one after that indents again — the same bargain a code
+editor on the web makes, and the reason a screen-reader user is not stuck in
+your element.
+
+**A caret blinks at `CARET_BLINK_MS`.** It is the cadence `<textinput>` uses,
+exported so that two carets on one screen are in step rather than a few tens
+of milliseconds apart. Stop the timer in `defaultBlur` _and_ in
+`destroySubtree`: a node that unmounts while focused is forgotten rather than
+blurred, so `defaultBlur` is not guaranteed to run.
 
 ### Drawing once instead of every frame
 

--- a/src/events.js
+++ b/src/events.js
@@ -135,6 +135,9 @@ export class EventManager {
     // — the second shrinks and grows again as the pointer leaves and returns
     this.downPath = [];
     this.pressPath = [];
+    // whether the press's default action ran, which is what the drag and the
+    // release that continue the same gesture follow
+    this._downDefaulted = false;
     this.capturedNode = null;
     this.focused = null;
     // what had focus before `focused`, so a focus scope opened by something
@@ -230,8 +233,8 @@ export class EventManager {
     this.windowFocused = focused;
     const node = this.focused;
     if (node && !node.destroyed) {
-      if (focused) node._defaultFocus?.();
-      else node._defaultBlur?.();
+      if (focused) node.defaultFocus?.();
+      else node.defaultBlur?.();
     }
     // …and the things that keep a window of their own open on the strength
     // of this one having focus — a menu, a dropdown — which the focused node
@@ -385,8 +388,15 @@ export class EventManager {
         },
         this.downPath,
       );
-      if (!ev.defaultPrevented) {
-        target._defaultMouseDown?.(ev);
+      // A gesture is vetoed at its press, once: the drag and the release
+      // that continue it are the same gesture, so an element whose
+      // `defaultMouseDown` never ran does not then get told about motion it
+      // has no press behind. `<textinput>` guarded that itself with a
+      // `_dragging` flag; a registered element should not have to rediscover
+      // the need for one (issue #251).
+      this._downDefaulted = !ev.defaultPrevented;
+      if (this._downDefaulted) {
+        target.defaultMouseDown?.(ev);
       }
       // a left press on (or inside) a `draggable` arms a drag; below the
       // threshold the gesture is still a click (src/dnd.js)
@@ -402,7 +412,7 @@ export class EventManager {
           button: native.keycode,
         });
         if (!menuEv.defaultPrevented) {
-          target?._defaultContextMenu?.(menuEv);
+          target?.defaultContextMenu?.(menuEv);
         }
       }
     });
@@ -435,8 +445,8 @@ export class EventManager {
       // capture ends with the gesture, like implicit DOM pointer capture
       this.capturedNode = null;
       this._clearPress();
-      if (this.downNode && !this.downNode.destroyed) {
-        this.downNode._defaultMouseUp?.(ev);
+      if (this._downDefaulted && this.downNode && !this.downNode.destroyed) {
+        this.downNode.defaultMouseUp?.(ev);
       }
       if (this.downNode) {
         // click fires on the nearest common ancestor of press and release
@@ -475,9 +485,10 @@ export class EventManager {
       if (this.downNode && !captured)
         this._setPressed(this._pressedAlong(path));
       const ev = this.dispatch('MouseMove', target, native, undefined, path);
-      // drags deliver to the pressed node even when the pointer leaves it
-      if (this.downNode && !this.downNode.destroyed) {
-        this.downNode._defaultMouseDrag?.(ev);
+      // drags deliver to the pressed node even when the pointer leaves it —
+      // unless the press that started them was vetoed, see `_downDefaulted`
+      if (this._downDefaulted && this.downNode && !this.downNode.destroyed) {
+        this.downNode.defaultMouseDrag?.(ev);
       }
     });
   }
@@ -639,12 +650,21 @@ export class EventManager {
             ? String.fromCodePoint(native.codepoint)
             : undefined,
       });
-      if (name === 'KeyDown' && keysym === XK_TAB && !ev.defaultPrevented) {
+      if (name !== 'KeyDown' || ev.defaultPrevented) return;
+      // The element's own behaviour first, focus traversal after it — Tab is
+      // an ordinary defaultable key rather than one the focus manager eats on
+      // the way past. Cycling first meant an editor could only keep Tab as an
+      // indent key through a *user-level* handler, which is a wiring an
+      // element cannot ship with itself (issue #251).
+      //
+      // A default action that consumed the key says so by calling
+      // `preventDefault()` — the same word, one layer down: what it prevents
+      // now is the default action left after it, which for Tab is the focus
+      // cycle. Nothing in core consumes Tab, so `<textinput>` and friends
+      // still hand it straight to traversal.
+      target.defaultKeyDown?.(ev);
+      if (keysym === XK_TAB && !ev.defaultPrevented) {
         this._cycleFocus(Boolean(native.buttons & 1));
-        return;
-      }
-      if (name === 'KeyDown' && !ev.defaultPrevented) {
-        target._defaultKeyDown?.(ev);
       }
     });
   }
@@ -674,7 +694,7 @@ export class EventManager {
       old.root?.invalidate(false, old, 'focus');
       old.setStyleState(':focus', false);
       old.setStyleState(':focus-visible', false);
-      old._defaultBlur?.();
+      old.defaultBlur?.();
       old.props.onBlur?.(this._makeEvent('blur', null, old));
       // it may be in another window than the new focus — owner window ↔ its
       // popup — and the caret it was drawing has to go too
@@ -686,7 +706,7 @@ export class EventManager {
       node.setStyleState(':focus', true);
       node.setStyleState(':focus-visible', reason !== 'pointer');
       this._scrollIntoView(node);
-      if (this.windowFocused) node._defaultFocus?.();
+      if (this.windowFocused) node.defaultFocus?.();
       node.props.onFocus?.(this._makeEvent('focus', null, node));
       node.root?.invalidate(false, node, 'focus');
     }

--- a/src/node.d.ts
+++ b/src/node.d.ts
@@ -8,6 +8,7 @@
  */
 import type { Rect, NtkApp } from './types/nodes.js';
 import type { Style } from './types/style.js';
+import type { KeyboardEvent, MouseEvent } from './types/events.js';
 
 /** ntk's 2d context. Typed loosely — it is ntk's API, not ours. */
 export type Context2D = unknown;
@@ -48,6 +49,13 @@ export declare function intrinsicSize(
   natural: MeasuredSize,
   constraints: MeasureConstraints,
 ): MeasuredSize;
+
+/**
+ * How long a caret stays in each of its two states, in milliseconds — what
+ * `<textinput>` blinks at. An element that draws its own caret uses this
+ * rather than a number of its own, so two carets on one screen are in step.
+ */
+export declare const CARET_BLINK_MS: number;
 
 export declare class Node {
   constructor(
@@ -100,6 +108,48 @@ export declare class Node {
    * arrived — so the next layout has to ask again. `reason` joins the closed
    * set the diagnostics print. */
   invalidateMeasure(reason?: string): void;
+  /**
+   * The element's own behaviour for a key, run **after** the application's
+   * `onKeyDown` handlers and not at all if one of them called
+   * `preventDefault()` — the ordering that lets an app veto or extend an
+   * interactive element without knowing how it is built.
+   *
+   * Tab arrives here like any other key. Consuming it — an editor that
+   * indents — means calling `ev.preventDefault()`, which suppresses the
+   * default action left after this one: the focus cycle. An element that
+   * takes Tab owes the user a way back out; see docs/extending.md.
+   */
+  defaultKeyDown?(ev: KeyboardEvent): void;
+  /** The element's own behaviour for a press, after `onMouseDown` handlers:
+   * placing a caret, grabbing a scrollbar thumb, arming a drag. */
+  defaultMouseDown?(ev: MouseEvent): void;
+  /** Pointer motion while this element holds the press — it keeps receiving
+   * these wherever the pointer goes, as `onMouseMove` does not. */
+  defaultMouseDrag?(ev: MouseEvent): void;
+  /** The press this element received has been released. */
+  defaultMouseUp?(ev: MouseEvent): void;
+  /** Right-click, after `onContextMenu` handlers: open the element's own
+   * menu. Separate from the press so suppressing the menu does not also
+   * give up the caret placement `defaultMouseDown` did. */
+  defaultContextMenu?(ev: MouseEvent): void;
+  /** This element became the focused node, or its window regained the X
+   * focus while it was: start a caret blinking, arm an IME. No event —
+   * focus is a state, and `onFocus` is where the app hears about it. */
+  defaultFocus?(): void;
+  /** Focus left, or the window lost it: stop whatever `defaultFocus`
+   * started. A node that unmounts while focused is *forgotten* rather than
+   * blurred, so anything with a lifetime — a blink timer — is released in
+   * `destroySubtree` as well, the way `<textinput>` does. */
+  defaultBlur?(): void;
+  /** Whether this element is a tab stop and a focus target with nothing in
+   * the props saying so — `<textinput>` is, a `<box>` with something to
+   * scroll is. `focusable`/`tabIndex` props override it either way. An
+   * element with default actions for keys has to set this, or nothing will
+   * ever focus it. */
+  focusableByDefault?: boolean;
+  /** The cursor to show over this element when nothing in the style says
+   * otherwise — `'text'` for something editable. A `cursor` style wins. */
+  defaultCursor?: string;
   /** Props changed. A subclass calls `super.applyProps(next, prev)`. */
   applyProps(
     nextProps: Record<string, unknown>,

--- a/src/node.js
+++ b/src/node.js
@@ -8,7 +8,11 @@
 // clip), so an element that only draws needs a constructor that names its
 // kind and a `paint` that calls `super.paint(ctx)` first. An element whose
 // *size* comes from its content adds `measureContent`, and says when that
-// answer moves with `invalidateMeasure`.
+// answer moves with `invalidateMeasure`. An element that *behaves* — one
+// that edits, drags a caret or answers chords — adds the `default*` methods:
+// they run after the application's own handlers and not at all if one of
+// those called `preventDefault`, which is the ordering that makes an
+// interactive element composable rather than something to work around.
 export {
   Node,
   // `class MyPane extends Scrollable(Node)` — the same mixin <box> and
@@ -18,6 +22,9 @@ export {
   // The `measureContent` body of an element whose content has a size of its
   // own and an aspect ratio to keep — what <image> and <svg> answer with.
   intrinsicSize,
+  // The cadence a caret blinks at, so an element that draws one is in step
+  // with `<textinput>` rather than a few tens of milliseconds beside it.
+  CARET_BLINK_MS,
   BoxNode,
   TextNode,
   ImageNode,

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -3261,7 +3261,7 @@ export const Scrollable = (Base) =>
      * Runs after the application's own `onKeyDown`, and not at all if that
      * called `preventDefault` — the same contract `<textinput>` editing has.
      */
-    _defaultKeyDown(ev) {
+    defaultKeyDown(ev) {
       // nothing to scroll, nothing to swallow: a plain box must leave the
       // arrows and Page keys to whatever else would answer them
       if (!this.focusableByDefault) return undefined;
@@ -3388,7 +3388,7 @@ export const Scrollable = (Base) =>
       return super.hitTest(x, y);
     }
 
-    _defaultMouseDown(ev) {
+    defaultMouseDown(ev) {
       for (const bar of this._scrollbars()) {
         const hit = scrollbarHit(bar, ev.x, ev.y);
         if (!hit) continue;
@@ -3407,7 +3407,7 @@ export const Scrollable = (Base) =>
       }
     }
 
-    _defaultMouseDrag(ev) {
+    defaultMouseDrag(ev) {
       if (this._barGrab == null) return;
       const bar = this._scrollbar(this._barGrab.axis);
       if (!bar || bar.travel <= 0) return;
@@ -3416,7 +3416,7 @@ export const Scrollable = (Base) =>
       this.scrollTo(bar.axis === 'x' ? { x: to } : { y: to });
     }
 
-    _defaultMouseUp() {
+    defaultMouseUp() {
       this._barGrab = null;
     }
   };
@@ -3602,6 +3602,18 @@ const SCROLL_KEY_PAGE_OVERLAP = 24;
 /** Undo entries kept per input. Snapshots of a single field are small; the
  * cap is what stops a long-lived form from growing without bound. */
 const UNDO_LIMIT = 200;
+
+/**
+ * How long a caret stays in each of its two states, in milliseconds. GTK,
+ * Qt and Windows all land within a few tens of milliseconds of this, and a
+ * blink that is out of step with the rest of the desktop is noticed even
+ * when the number cannot be named.
+ *
+ * Exported from `react-x11/node` because an element that edits text draws
+ * its own caret and would otherwise hardcode a second cadence — two carets
+ * on one screen blinking against each other (issue #251).
+ */
+export const CARET_BLINK_MS = 530;
 
 /**
  * <textinput>: single-line editable text. Caret/selection via ntk TextLayout
@@ -4105,7 +4117,7 @@ export class TextInputNode extends Node {
    * an input event at all, and a value pushed from a parent has no X event
    * behind it — those report `nativeEvent: null`, which is the truth.
    */
-  _defaultKeyDown(ev) {
+  defaultKeyDown(ev) {
     const previous = this._keyNative;
     this._keyNative = ev.nativeEvent ?? null;
     try {
@@ -4248,7 +4260,7 @@ export class TextInputNode extends Node {
     return i;
   }
 
-  _defaultMouseDown(ev) {
+  defaultMouseDown(ev) {
     // wherever the caret lands, editing resumes as a new undo entry
     this._breakUndoRun();
     if (ev.button === 3) {
@@ -4327,13 +4339,13 @@ export class TextInputNode extends Node {
     return this._focused || Boolean(this._editMenu);
   }
 
-  _defaultMouseDrag(ev) {
+  defaultMouseDrag(ev) {
     if (!this._dragging) return;
     this._caret = this._indexAtPoint(ev);
     this._repaint();
   }
 
-  _defaultMouseUp() {
+  defaultMouseUp() {
     if (!this._dragging) return;
     this._dragging = false;
     if (this._caret !== this._anchor) this._copySelection('PRIMARY');
@@ -4420,7 +4432,7 @@ export class TextInputNode extends Node {
     else if (id === 'selectAll') this._selectAll();
   }
 
-  _defaultContextMenu(ev) {
+  defaultContextMenu(ev) {
     if (this.props.contextMenu === false) return;
     this._openEditMenu(ev);
   }
@@ -4549,7 +4561,7 @@ export class TextInputNode extends Node {
     if (!this.destroyed) this._focusManager()?.focus(this, 'pointer');
   }
 
-  _defaultFocus() {
+  defaultFocus() {
     this._focused = true;
     this._caretOn = true;
     this._blinkTimer = setInterval(() => {
@@ -4557,12 +4569,12 @@ export class TextInputNode extends Node {
       // twice a second, forever, for as long as a field has focus: the one
       // repaint that most wants to cost only the field it happens in
       this.root?.invalidate(false, this, 'caret');
-    }, 530);
+    }, CARET_BLINK_MS);
     this._blinkTimer.unref?.();
     this.root?.invalidate(false, this, 'focus');
   }
 
-  _defaultBlur() {
+  defaultBlur() {
     this._focused = false;
     this._caretOn = false;
     // coming back to a field later is a new edit, not more of the old one
@@ -4728,10 +4740,10 @@ export class TextAreaNode extends TextInputNode {
    * thumb would drop the caret into whatever text sits behind it and start
    * a selection drag.
    */
-  _defaultMouseDown(ev) {
+  defaultMouseDown(ev) {
     const bar = this._scrollbar();
     const hit = scrollbarHit(bar, ev.x, ev.y);
-    if (!hit) return super._defaultMouseDown(ev);
+    if (!hit) return super.defaultMouseDown(ev);
     if (hit === 'thumb') {
       this._barGrab = ev.y - bar.thumbStart;
       ev.capturePointer();
@@ -4741,8 +4753,8 @@ export class TextAreaNode extends TextInputNode {
     this._scrollTo(this._scrollY + (ev.y < bar.thumbStart ? -page : page), bar);
   }
 
-  _defaultMouseDrag(ev) {
-    if (this._barGrab == null) return super._defaultMouseDrag(ev);
+  defaultMouseDrag(ev) {
+    if (this._barGrab == null) return super.defaultMouseDrag(ev);
     const bar = this._scrollbar();
     if (!bar || bar.travel <= 0) return;
     this._scrollTo(
@@ -4751,12 +4763,12 @@ export class TextAreaNode extends TextInputNode {
     );
   }
 
-  _defaultMouseUp(ev) {
+  defaultMouseUp(ev) {
     if (this._barGrab != null) {
       this._barGrab = null;
       return;
     }
-    super._defaultMouseUp(ev);
+    super.defaultMouseUp(ev);
   }
 
   _scrollTo(y, bar) {

--- a/src/richnodes.js
+++ b/src/richnodes.js
@@ -119,12 +119,12 @@ class DocumentViewNode extends Node {
     ctx.rect(this.abs.x, this.abs.y, this.abs.width, this.abs.height);
     ctx.clip();
     // links recorded by draw() are in window coordinates, so linkAt can
-    // take synthetic-event coordinates directly (_defaultMouseDown)
+    // take synthetic-event coordinates directly (defaultMouseDown)
     view.draw(ctx, content.x, content.y);
     ctx.restore();
   }
 
-  _defaultMouseDown(ev) {
+  defaultMouseDown(ev) {
     if (ev.button !== 1 || !this.view || !this.props.onLink) return;
     const hit = this.view.linkAt(ev.x, ev.y);
     if (!hit) return;

--- a/test/default-actions.test.js
+++ b/test/default-actions.test.js
@@ -1,0 +1,375 @@
+// Default actions as a documented seam (#251): an element that *behaves* —
+// an editor, a terminal, a table with cell editing — implements the same
+// `default*` methods `<textinput>`'s editing runs on, and gets the same
+// ordering: the application's handlers first, the element's behaviour after,
+// `preventDefault` in between.
+//
+// Everything here registers its element through `react-x11/host` and imports
+// `Node` from `react-x11/node`, because the point of the issue is that a
+// package outside react-x11 can do this. A test reaching into src/nodes.js
+// would prove nothing about the published surface.
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+
+import { createRoot } from '../src/index.js';
+import { registerElement, unregisterElement } from '../src/host.js';
+import { Node, CARET_BLINK_MS } from '../src/node.js';
+import { XK_TAB, XK_ESCAPE, XK_LEFT } from '../src/keysyms.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+/** Simulate an ntk keydown: bind the keysym to a synthetic keycode and emit
+ * the raw event shape the EventManager consumes. */
+function pressKey(app, wnd, keysym, { codepoint, buttons = 0 } = {}) {
+  const keycode = ((keysym ?? codepoint) % 248) + 8;
+  app.X.keycode2keysyms[keycode] = [keysym ?? codepoint];
+  wnd.emit('keydown', { keycode, keysym, codepoint, buttons });
+}
+
+/**
+ * The element under test: a miniature editor. It records what it was asked
+ * to do rather than doing it, so a test can assert on the order of the two
+ * layers rather than on pixels.
+ */
+class EditorNode extends Node {
+  constructor(props, app) {
+    super('miniedit', props, app);
+    this.focusableByDefault = true;
+    this.defaultCursor = 'text';
+    this.log = [];
+    this.tabEscapes = false;
+    this.blinks = 0;
+  }
+
+  defaultKeyDown(ev) {
+    this.log.push(`key:${ev.keysym}`);
+    if (ev.keysym === XK_ESCAPE) {
+      // the documented way out: the next Tab leaves
+      this.tabEscapes = true;
+      return;
+    }
+    if (ev.keysym === XK_TAB) {
+      if (this.tabEscapes) {
+        this.tabEscapes = false; // one Tab, then it indents again
+        return; // …and this one belongs to focus traversal
+      }
+      this.log.push('indent');
+      ev.preventDefault(); // …but this one is mine
+      return;
+    }
+    this.tabEscapes = false;
+  }
+
+  defaultMouseDown(ev) {
+    this.log.push('down');
+    ev.capturePointer();
+  }
+
+  defaultMouseDrag(ev) {
+    this.log.push(`drag:${ev.x}`);
+  }
+
+  defaultMouseUp() {
+    this.log.push('up');
+  }
+
+  defaultContextMenu() {
+    this.log.push('menu');
+  }
+
+  defaultFocus() {
+    this.log.push('focus');
+    this.blinkTimer = setInterval(() => {
+      this.blinks++;
+      this.root?.invalidate(false, this, 'caret');
+    }, CARET_BLINK_MS);
+    this.blinkTimer.unref?.();
+  }
+
+  defaultBlur() {
+    this.log.push('blur');
+    clearInterval(this.blinkTimer);
+    this.blinkTimer = null;
+  }
+
+  destroySubtree() {
+    // a node that unmounts while focused is forgotten, not blurred
+    clearInterval(this.blinkTimer);
+    this.blinkTimer = null;
+    super.destroySubtree();
+  }
+}
+
+const registered = new Set();
+function register(type, definition) {
+  registerElement(type, definition);
+  registered.add(type);
+}
+
+afterEach(() => {
+  for (const type of registered) unregisterElement(type);
+  registered.clear();
+});
+
+/** Mount `<miniedit>` (plus whatever else the test asked for) and hand back
+ * the pieces every test here pokes at. */
+async function mount({ props = {}, extra = null } = {}) {
+  register('miniedit', {
+    create: (p, app) => new EditorNode(p, app),
+    childrenAllowed: false,
+    // a test that mounts twice re-registers the same class; the conflict the
+    // flag is really for is two packages, not two roots
+    override: true,
+  });
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(
+    h(
+      'window',
+      { width: 300, height: 200 },
+      h('miniedit', { style: { width: 200, height: 100 }, ...props }),
+      extra,
+    ),
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const windowNode = wnd._reactX11Node;
+  const find = (node, pred) =>
+    pred(node)
+      ? node
+      : node.children.reduce((a, c) => a || find(c, pred), null);
+  return {
+    app,
+    root,
+    wnd,
+    windowNode,
+    editor: find(windowNode, (n) => n.kind === 'miniedit'),
+    find,
+  };
+}
+
+test('a registered element gets keys after the app handler, and can be vetoed', async () => {
+  const seen = [];
+  const { app, wnd, editor } = await mount({
+    props: {
+      onKeyDown: (ev) => {
+        seen.push(ev.keysym);
+        if (ev.keysym === XK_LEFT) ev.preventDefault();
+      },
+    },
+  });
+
+  // focus it the way a user would — a press
+  wnd.emit('mousedown', { x: 10, y: 10, keycode: 1 });
+  wnd.emit('mouseup', { x: 10, y: 10, keycode: 1 });
+  await tick();
+  assert.strictEqual(editor.focused, true, 'focusableByDefault took focus');
+
+  pressKey(app, wnd, XK_ESCAPE);
+  assert.deepStrictEqual(seen, [XK_ESCAPE], 'the app handler ran');
+  assert.ok(
+    editor.log.includes(`key:${XK_ESCAPE}`),
+    'and the element behaviour after it',
+  );
+
+  editor.log.length = 0;
+  pressKey(app, wnd, XK_LEFT);
+  assert.deepStrictEqual(seen, [XK_ESCAPE, XK_LEFT]);
+  assert.deepStrictEqual(
+    editor.log,
+    [],
+    'preventDefault in the app handler skips the default action',
+  );
+});
+
+test('Tab reaches the element, and consuming it keeps focus', async () => {
+  const { app, wnd, editor, find, windowNode } = await mount({
+    extra: h('box', { focusable: true, style: { width: 10, height: 10 } }),
+  });
+  const other = find(windowNode, (n) => n.kind === 'box' && n.props.focusable);
+
+  editor.focus();
+  await tick();
+  assert.strictEqual(editor.focused, true);
+
+  pressKey(app, wnd, XK_TAB);
+  await tick();
+  assert.ok(editor.log.includes('indent'), 'Tab arrived as an ordinary key');
+  assert.strictEqual(
+    editor.focused,
+    true,
+    'preventDefault kept it from the focus cycle',
+  );
+  assert.strictEqual(other.focused, false);
+});
+
+test('Escape arms one pass-through Tab, and only one', async () => {
+  const { app, wnd, editor, find, windowNode } = await mount({
+    extra: h('box', { focusable: true, style: { width: 10, height: 10 } }),
+  });
+  const other = find(windowNode, (n) => n.kind === 'box' && n.props.focusable);
+
+  editor.focus();
+  await tick();
+  pressKey(app, wnd, XK_ESCAPE);
+  pressKey(app, wnd, XK_TAB);
+  await tick();
+  assert.strictEqual(other.focused, true, 'the armed Tab left the element');
+  assert.ok(!editor.log.includes('indent'), 'and did not indent');
+
+  // …and the element has it back: Tab in from the other node, then Tab again
+  editor.focus();
+  await tick();
+  editor.log.length = 0;
+  pressKey(app, wnd, XK_TAB);
+  await tick();
+  assert.ok(editor.log.includes('indent'), 'the escape was for one Tab only');
+  assert.strictEqual(editor.focused, true);
+});
+
+test('a key handler that prevents default keeps Tab too', async () => {
+  // the app's veto is above the element's: it stops both the element
+  // behaviour and the focus cycle, which is what it did before #251
+  const { app, wnd, editor, find, windowNode } = await mount({
+    props: { onKeyDown: (ev) => ev.preventDefault() },
+    extra: h('box', { focusable: true, style: { width: 10, height: 10 } }),
+  });
+  const other = find(windowNode, (n) => n.kind === 'box' && n.props.focusable);
+
+  editor.focus();
+  await tick();
+  pressKey(app, wnd, XK_TAB);
+  await tick();
+  assert.deepStrictEqual(editor.log, ['focus'], 'no default action ran');
+  assert.strictEqual(other.focused, false, 'and no traversal either');
+});
+
+test('an element with no default action for Tab still hands it to traversal', async () => {
+  register('inert', { create: (p, app) => new Node('inert', p, app) });
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(
+    h(
+      'window',
+      { width: 300, height: 200 },
+      h('inert', { focusable: true, style: { width: 50, height: 50 } }),
+      h('box', { focusable: true, style: { width: 10, height: 10 } }),
+    ),
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const windowNode = wnd._reactX11Node;
+  const [inert, box] = [
+    windowNode.children.find((n) => n.kind === 'inert'),
+    windowNode.children.find((n) => n.kind === 'box'),
+  ];
+  inert.focus();
+  await tick();
+  pressKey(app, wnd, XK_TAB);
+  await tick();
+  assert.strictEqual(box.focused, true);
+});
+
+test('press, drag past the element and release all reach it', async () => {
+  const seen = [];
+  const { wnd, editor } = await mount({
+    props: { onMouseDown: () => seen.push('handler') },
+  });
+
+  wnd.emit('mousedown', { x: 10, y: 10, keycode: 1 });
+  // the drag leaves the element's box entirely — `onMouseMove` would go to
+  // whatever is under the pointer, the default action follows the press
+  wnd.emit('mousemove', { x: 260, y: 150 });
+  wnd.emit('mouseup', { x: 260, y: 150, keycode: 1 });
+  await tick();
+
+  assert.deepStrictEqual(seen, ['handler']);
+  assert.deepStrictEqual(
+    editor.log.filter((entry) => entry !== 'focus'),
+    ['down', 'drag:260', 'up'],
+  );
+});
+
+test('preventDefault on the press skips the element behaviour', async () => {
+  const { wnd, editor } = await mount({
+    props: { onMouseDown: (ev) => ev.preventDefault() },
+  });
+  wnd.emit('mousedown', { x: 10, y: 10, keycode: 1 });
+  wnd.emit('mousemove', { x: 20, y: 10 });
+  await tick();
+  assert.ok(!editor.log.includes('down'));
+  // the drag hooks follow the press, and there was no press to follow
+  assert.ok(!editor.log.some((entry) => entry.startsWith('drag')));
+});
+
+test('the context menu is its own default action', async () => {
+  const { wnd, editor } = await mount({
+    props: { onContextMenu: (ev) => ev.preventDefault() },
+  });
+  wnd.emit('mousedown', { x: 10, y: 10, keycode: 3 });
+  await tick();
+  assert.ok(editor.log.includes('down'), 'the press still placed the caret');
+  assert.ok(
+    !editor.log.includes('menu'),
+    'while the menu the handler suppressed did not open',
+  );
+
+  editor.log.length = 0;
+  const plain = await mount();
+  plain.wnd.emit('mousedown', { x: 10, y: 10, keycode: 3 });
+  await tick();
+  assert.ok(plain.editor.log.includes('menu'), 'and opens with no handler');
+});
+
+test('focus and blur bracket the element behaviour, including the window losing focus', async () => {
+  const { wnd, editor, find, windowNode } = await mount({
+    extra: h('box', { focusable: true, style: { width: 10, height: 10 } }),
+  });
+  const other = find(windowNode, (n) => n.kind === 'box' && n.props.focusable);
+
+  editor.focus();
+  await tick();
+  assert.deepStrictEqual(editor.log, ['focus']);
+  assert.ok(editor.blinkTimer, 'the blink is running');
+
+  // the window manager gives the keyboard to another window: the node keeps
+  // focus, its caret does not keep blinking
+  wnd.emit('blur', {});
+  await tick();
+  assert.deepStrictEqual(editor.log, ['focus', 'blur']);
+  assert.strictEqual(editor.blinkTimer, null);
+  assert.strictEqual(editor.focused, true, 'still the focused node');
+
+  wnd.emit('focus', {});
+  await tick();
+  assert.deepStrictEqual(editor.log, ['focus', 'blur', 'focus']);
+
+  other.focus();
+  await tick();
+  assert.deepStrictEqual(editor.log, ['focus', 'blur', 'focus', 'blur']);
+  assert.strictEqual(editor.blinkTimer, null, 'nothing left ticking');
+});
+
+test('CARET_BLINK_MS is the cadence <textinput> blinks at', async () => {
+  assert.ok(
+    Number.isFinite(CARET_BLINK_MS) && CARET_BLINK_MS > 0,
+    'a usable interval',
+  );
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(h('window', { width: 200, height: 100 }, h('textinput', null)));
+  await tick();
+  const wnd = app.windows[0];
+  const input = wnd._reactX11Node.children.find((n) => n.kind === 'textinput');
+  input.focus();
+  await tick();
+  // the built-in caret and an element's own caret have to agree, so the
+  // number is one export rather than two copies
+  const interval =
+    input._blinkTimer?._idleTimeout ?? input._blinkTimer?._repeat;
+  assert.strictEqual(interval, CARET_BLINK_MS);
+  input.blur();
+});

--- a/test/overflow-scroll.test.js
+++ b/test/overflow-scroll.test.js
@@ -245,6 +245,6 @@ test('a plain box does not swallow the keys a scroll pane answers', async () => 
   );
   // XK_Down. A scroll pane consumes it; a box with nothing to scroll must
   // leave it for whatever else would answer.
-  assert.equal(ref.current._defaultKeyDown({ keysym: 0xff54 }), undefined);
+  assert.equal(ref.current.defaultKeyDown({ keysym: 0xff54 }), undefined);
   assert.equal(ref.current.scrollY, 0);
 });

--- a/test/scrollbar.test.js
+++ b/test/scrollbar.test.js
@@ -177,12 +177,12 @@ test('a <textarea> bar drag scrolls it, and never moves the caret', async () => 
   assert.ok(bar, 'text taller than the box gets a thumb');
   const caretBefore = area._caret;
 
-  area._defaultMouseDown({
+  area.defaultMouseDown({
     x: bar.x + 2,
     y: bar.thumbStart + 2,
     capturePointer() {},
   });
-  area._defaultMouseDrag({
+  area.defaultMouseDrag({
     x: bar.x + 2,
     y: bar.thumbStart + 2 + bar.travel / 2,
   });
@@ -192,9 +192,9 @@ test('a <textarea> bar drag scrolls it, and never moves the caret', async () => 
     `half the travel is half the range, got ${area._scrollY}`,
   );
 
-  area._defaultMouseDrag({ x: bar.x + 2, y: 10_000 });
+  area.defaultMouseDrag({ x: bar.x + 2, y: 10_000 });
   assert.strictEqual(area._scrollY, bar.range, 'and clamps at the end');
-  area._defaultMouseUp({});
+  area.defaultMouseUp({});
 
   // a press in the text still reaches the caret logic
   area._scrollY = 0;
@@ -204,7 +204,7 @@ test('a <textarea> bar drag scrolls it, and never moves the caret', async () => 
     placed = true;
     return 3;
   };
-  area._defaultMouseDown({ x: content.x + 5, y: content.y + 5, detail: 1 });
+  area.defaultMouseDown({ x: content.x + 5, y: content.y + 5, detail: 1 });
   assert.ok(placed, 'a press away from the bar still places the caret');
 
   await x11Root.unmount();

--- a/test/types/extend.tsx
+++ b/test/types/extend.tsx
@@ -13,8 +13,16 @@ import {
   knownElements,
   drawnKinds,
 } from '../../src/host.js';
-import { Node, BoxNode, intrinsicSize } from '../../src/node.js';
+import {
+  Node,
+  BoxNode,
+  intrinsicSize,
+  CARET_BLINK_MS,
+} from '../../src/node.js';
 import type { MeasureConstraints } from '../../src/node.js';
+import { XK_ESCAPE, XK_TAB } from '../../src/keysyms.js';
+// the synthetic events, not the DOM's same-named globals
+import type { KeyboardEvent, MouseEvent } from '../../src/types/events.js';
 import {
   isStyleProp,
   flattenStyle,
@@ -38,6 +46,13 @@ declare module '../../src/jsx-runtime.js' {
       };
       thumb: {
         style?: Style;
+      };
+      codeeditor: {
+        value?: string;
+        style?: Style;
+        // a third party declares the handlers it composes with, and gets the
+        // synthetic event rather than the DOM's same-named one
+        onKeyDown?: (ev: KeyboardEvent) => void;
       };
     }
   }
@@ -106,6 +121,59 @@ class ThumbNode extends Node {
   }
 }
 
+// An element with behaviour of its own (#251): the default actions run after
+// the app's handlers, and Tab is an ordinary key it may keep.
+class EditorNode extends Node {
+  private caretOn = false;
+  private tabEscapes = false;
+
+  constructor(props: Record<string, unknown>, app: never) {
+    super('codeeditor', props, app);
+    this.focusableByDefault = true;
+    this.defaultCursor = 'text';
+  }
+
+  defaultKeyDown(ev: KeyboardEvent): void {
+    if (ev.keysym === XK_ESCAPE) {
+      this.tabEscapes = true;
+      return;
+    }
+    if (ev.keysym === XK_TAB && !this.tabEscapes) {
+      ev.preventDefault(); // mine: the focus cycle does not get this one
+      return;
+    }
+    this.tabEscapes = false;
+    const _typed: string = ev.key;
+    void _typed;
+  }
+
+  defaultMouseDown(ev: MouseEvent): void {
+    ev.capturePointer();
+    const _button: number = ev.button;
+    void _button;
+  }
+
+  defaultMouseDrag(_ev: MouseEvent): void {}
+
+  defaultMouseUp(_ev: MouseEvent): void {}
+
+  defaultFocus(): void {
+    // the timer is node's; what this pins is the cadence it runs at
+    const _every: number = CARET_BLINK_MS;
+    this.caretOn = true;
+    this.invalidate(false, this.abs, 'caret');
+  }
+
+  defaultBlur(): void {
+    this.caretOn = false;
+    this.invalidate(false, this.abs, 'caret');
+  }
+}
+
+registerElement('codeeditor', {
+  create: (props, app) => new EditorNode(props, app as never),
+});
+
 registerElement('gauge', {
   create: (props, app) => new GaugeNode(props, app as never),
   semanticNames: ['ticks'],
@@ -138,6 +206,8 @@ function Chart() {
       <sparkline data={[1, 4, 2, 8]} color="#c0392b" style={{ flexGrow: 1 }} />
       <gauge ticks={6} />
       <thumb />
+      {/* an app handler and the element's own behaviour, composed */}
+      <codeeditor value="const x = 1" onKeyDown={(ev) => void ev.keysym} />
     </box>
   );
 }


### PR DESCRIPTION
A registered element could draw, and since #265 size itself, but it could not
*behave*. Core's own interactive elements get their behaviour from the
EventManager's default-action hooks — the application's handlers first, then,
if nothing called `preventDefault()`, the element's own — and every one of
those hooks was underscore-internal, so a third party either bet on internals
or rebuilt the ordering by hand in a React component wrapping the element.
That wrapper works, and it costs: a bare `<codeeditor>` in JSX is inert where
`<textinput>` is not, and every future interactive element (terminal, table
with cell editing, tree with type-ahead) re-implements the same wiring
slightly differently.

This is option **A** from the issue: bless the seam that already exists.

## The seam

`defaultKeyDown`, `defaultMouseDown`, `defaultMouseDrag`, `defaultMouseUp`,
`defaultContextMenu`, `defaultFocus` and `defaultBlur` are methods on `Node`,
called by the EventManager on any target it reaches. `<textinput>`,
`<textarea>`, the `Scrollable` mixin and the document views move onto the
public names, so the built-ins run through the documented seam rather than a
private twin of it.

## Tab

Tab becomes an ordinary defaultable key. The focus manager used to consume it
on the way past (`_onKey` returned after `_cycleFocus`), which meant an editor
could keep Tab as an indent key only through a *user-level* handler — a wiring
an element cannot ship with itself. Focus traversal now runs **after** the
element's default action, and an element that consumed Tab says so by calling
`preventDefault()` from it: what that prevents is the default action left
after it, which for Tab is the focus cycle.

Nothing in core consumes Tab, so every existing tab order is unchanged.
`docs/extending.md` writes down the convention that keeps such an element from
being a keyboard trap — **Escape arms one pass-through Tab** — because
elements converging on different escapes is worse than any one of them.

## Two riders

- **A gesture is vetoed once, at its press.** An element whose
  `defaultMouseDown` never ran no longer hears the drag and release that
  continue the same gesture. `<textinput>` was guarding that with a `_dragging`
  flag of its own; a registered element should not have to rediscover the need
  for one.
- **`CARET_BLINK_MS`** is exported from `react-x11/node` and is what
  `<textinput>` blinks at, so an element that draws its own caret is in step
  with the built-in fields rather than a few tens of milliseconds beside them.

## Acceptance criteria

- [x] a registered element implements key/mouse/focus behaviour that runs
      after app handlers and respects `preventDefault`, on documented API
- [x] the Tab interplay is specified — ordering change *and* the escape
      convention
- [x] `docs/extending.md` gains the hooks in its override table (a new
      "Behaviour of your own" section); `test/types/extend.tsx` compiles a
      `<codeeditor>` using them
- [x] `<textinput>`'s own behaviour runs through the same documented seam

## Testing

- `test/default-actions.test.js` — 10 cases through the published subpaths
  (`react-x11/host`, `react-x11/node`): handler-then-default ordering and the
  veto, Tab consumed and Tab passed through, the escape arming exactly one
  Tab, press/drag/release past the element's box, the context menu as its own
  default action, focus and blur across a window focus change, and the caret
  cadence. Mutation-checked: with the ordering change reverted, exactly the
  three behavioural cases fail.
- `npm test` 1020/1026 — the six failures are the pre-existing appearance and
  icons ones on this host, identical on an unmodified tree.
- `npm run lint`, `npm run typecheck`, prettier, and `website`'s build plus
  its three check scripts all green.

Closes #251
