### PR TITLE
feat(types)!: declarations that match the runtime — focus, kind, chords, invalidate

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -138,6 +138,13 @@ function Panel() {
 }
 ```
 
+It is a bag of tokens, and indexes like one: a component that resolves a name
+it was handed rather than one it wrote — a code block reading its own colour
+map, a renderer resolving `$token` itself — writes `theme[name]` with no cast.
+The named tokens keep their types, anything else is `unknown` and narrows.
+What a provider _accepts_ stays closed (`Partial<Theme>`), because a typo in a
+palette has nowhere else to be caught.
+
 The palette reaches the tree on a `<box>` the provider renders, styled
 `{ flexGrow: 1 }` so an app-level provider fills its parent; pass `style` to
 change that (`style={{ flexGrow: 0 }}` around a single control). A `<window>`

--- a/docs/events.md
+++ b/docs/events.md
@@ -100,6 +100,19 @@ const root = await createRoot({
 `nativeEvent.rootx/rooty` are screen coordinates — useful for anchoring a
 `<popup>` at the pointer.
 
+**A Ctrl chord is read from the keysym, not the code point.** `codepoint`
+comes from the _shifted_ keysym, so Ctrl+Shift+Z arrives as `Z` and Ctrl+Z as
+`z`; a handler that compares code points misses half of its own shortcut.
+`ctrlChordLetter(ev)` from `react-x11/keysyms` answers with the lowercase
+keysym either way — it is what `<textinput>` reads Ctrl+C/V/Z with, and it is
+exported because any widget with a chord of its own needs the same rule:
+
+```js
+onKeyDown={(ev) => {
+  if (ev.ctrlKey && ctrlChordLetter(ev) === keysymOf('d')) duplicateLine();
+}}
+```
+
 ## Handlers
 
 | handler                                     | notes                                                                                   |
@@ -141,7 +154,10 @@ light up every widget the pointer crosses.
 `focusable` opts a node into focus (`<textinput>` is focusable by
 default, and so is a scroll container with somewhere to scroll), `autoFocus`
 takes it at mount, and every drawn node has
-`focus()` / `blur()` / `focused` on its ref. Focusing a node inside a
+`focus()` / `blur()` / `focused` on its ref — plus `focusWithin`, which is
+true while focus is on the node **or inside it**, the question a modal asks
+before taking focus itself. `focus()` hands the node back, so a component
+can forward it straight out of an imperative handle. Focusing a node inside a
 scroll container scrolls it into view. Mousedown focuses the nearest
 focusable ancestor of the hit node; Tab / Shift+Tab cycle through focusable
 nodes in tree order. Keyboard

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -102,11 +102,18 @@ And what you read:
 - `this.root` — the owning `<window>` node; `this.app` — the ntk connection.
 - `this.theme` — the nearest theme at or above this node.
 
-To ask for a repaint: `this.root?.invalidate(layout, rect, reason)`. Pass a
-`rect` when you know what changed — an invalidation with no bound repaints
-the whole window, which is this renderer's main performance bug class (see
-[debugging.md](debugging.md)). `reason` joins the closed set the diagnostics
-print.
+To ask for a repaint: `this.invalidate(layout, damage, reason)`. Pass the
+damage — `this` is usually it, or a rect when you know a tighter one. An
+invalidation with no bound repaints the whole window, which is this
+renderer's main performance bug class (see [debugging.md](debugging.md)).
+`reason` joins the closed set the diagnostics print. Damage is collected on
+the window node and `invalidate` on any node forwards there, so an element
+that is not attached yet invalidates nothing rather than throwing.
+
+And to take the keyboard focus: `this.focus()` moves it here as a click
+would and hands the node back, `this.blur()` gives it up, `this.focused` and
+`this.focusWithin` answer where it is. They claim their own damage — a
+focused control repaints itself, and its ring, without being asked.
 
 ### A size of your own
 
@@ -291,7 +298,7 @@ discardable — is the part that is easy to get wrong.
 | `react-x11/node`    | `Node`, the built-in node classes, `Scrollable`, `intrinsicSize`                                         |
 | `react-x11/style`   | `createStyles`, `flattenStyle`, `isStyleProp`, `resolveTokens`, the rest of the vocabulary               |
 | `react-x11/ntk`     | ntk itself, re-exported                                                                                  |
-| `react-x11/keysyms` | the `XK_*` constants                                                                                     |
+| `react-x11/keysyms` | the `XK_*` constants, `keysymOf`, `charOf`, `MOD`, `ctrlChordLetter`                                     |
 
 **Reach ntk through `react-x11/ntk`, not a second dependency.** Two copies
 of ntk in one process means two Yoga instances and two font caches, and a

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -88,6 +88,10 @@ getByPlaceholder('Your name');
   included** — a `<popup>` is a child node of the window that opened it, so a
   menu or a dialog is queryable without any special casing.
 - `within(node)` scopes them to a subtree.
+- `all(predicate?)` is the escape hatch: every node under the root, in paint
+  order, matched on anything — `screen.all((n) => n.kind === 'gauge')`.
+  `node.kind` is the element name, which is how an element with no text and
+  no role of its own is still reachable.
 - A miss prints the tree it searched, rather than leaving you with
   `undefined is not an object`.
 

--- a/src/keysyms.d.ts
+++ b/src/keysyms.d.ts
@@ -12,6 +12,26 @@ export function keysymOf(char: string): number;
 /** The character a keysym produces, or `''` for a non-printing key. */
 export function charOf(keysym: number): string;
 
+/**
+ * The letter of a Ctrl chord, independent of Shift — the keysym for its
+ * lowercase form, so `keysymOf('z')` matches both Ctrl+Z and Ctrl+Shift+Z.
+ * Null when the event carries neither a keysym nor a codepoint.
+ *
+ * ntk derives `codepoint` from the *shifted* keysym, so a handler that
+ * compared code points would see `Z` for Ctrl+Shift+Z and miss the chord.
+ * Here rather than inside `<textinput>` because both layers need it: the
+ * built-in editors read Ctrl+C/V/Z, and so does any widget that answers a
+ * chord of its own.
+ *
+ * ```js
+ * if (ev.ctrlKey && ctrlChordLetter(ev) === keysymOf('d')) duplicateLine();
+ * ```
+ */
+export function ctrlChordLetter(ev: {
+  keysym?: number | null;
+  codepoint?: number | null;
+}): number | null;
+
 export const XK_BACKSPACE: 0xff08;
 export const XK_TAB: 0xff09;
 export const XK_RETURN: 0xff0d;

--- a/src/node.d.ts
+++ b/src/node.d.ts
@@ -105,6 +105,20 @@ export declare class Node {
     nextProps: Record<string, unknown>,
     prevProps: Record<string, unknown>,
   ): void;
+  /** Take the keyboard focus, as clicking this node would: focus moves
+   * here, `onBlur` fires on whatever had it, `onFocus` here. Also pulls the
+   * X input focus back to the window if the window manager gave it away.
+   * Returns this node, so an element can hand it out of a method. */
+  focus(): this;
+  /** Give up focus, leaving the window with nothing focused. */
+  blur(): this;
+  /** Whether this node has the owning window's focus. */
+  readonly focused: boolean;
+  /** Whether focus is on this node or inside it — CSS `:focus-within`. A
+   * `<popup>` counts as inside the node it hangs off in the JSX tree. */
+  readonly focusWithin: boolean;
+  /** Whether `node` is this node or a descendant of it (DOM `contains`). */
+  contains(node: Node | null): boolean;
   /** The deepest node containing the point, or null. */
   hitTest(x: number, y: number): Node | null;
   containsPoint(x: number, y: number): boolean;
@@ -113,9 +127,16 @@ export declare class Node {
   insertBefore(child: Node, beforeChild: Node | null): void;
   removeChild(child: Node): void;
   destroySubtree(): void;
-  /** Ask the owning window to repaint. `reason` joins the closed set the
+  /** Ask the owning window to repaint — every node has this; the window
+   * node is where it lands. `damage` is what changed: pass `this`, or a
+   * rect when you know a tighter one, because an invalidation with no bound
+   * repaints the whole window. `reason` joins the closed set the
    * diagnostics print (docs/debugging.md). */
-  invalidate(layout?: boolean, rect?: Rect | null, reason?: string): void;
+  invalidate(
+    layout?: boolean,
+    damage?: Node | Rect | null,
+    reason?: string,
+  ): void;
   getClientRects(): Rect[];
 }
 

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -2105,6 +2105,22 @@ export class Node {
   }
 
   /**
+   * Ask the owning window to repaint. The damage lives on the window node,
+   * which is the only node with a frame clock — this forwards there, so an
+   * element says `this.invalidate(false, this, 'props')` and never has to
+   * know that. Overridden by WindowNode, which *is* the collector.
+   *
+   * `damage` is the node or rect that changed. Passing one is the difference
+   * between repainting a control and repainting the window, and `this` is
+   * almost always the right answer (docs/extending.md). Before the node is
+   * attached there is no window and nothing on screen, so this is a no-op —
+   * the mount invalidates in full anyway.
+   */
+  invalidate(layoutChanged = false, damage = null, reason = null) {
+    this.root?.invalidate(layoutChanged, damage, reason);
+  }
+
+  /**
    * A layout-affecting change confined to this node: claim the subtree as
    * it stands now, and queue it for a second claim once layout has run —
    * the same before/after protocol `_childListChanged` uses. Anything

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -120,9 +120,25 @@ export interface ThemeProviderProps {
  */
 export const ThemeProvider: ComponentType<ThemeProviderProps>;
 
+/**
+ * The palette as a bag of tokens, which is what it is at runtime: a theme
+ * merges over whatever is above it and a `$name` in a style resolves against
+ * the result, so a component that reads tokens by name — a code block asking
+ * for `background`/`text`/`dim`, a renderer resolving a palette it was handed
+ * — can index it. The named tokens keep their types; anything else is
+ * `unknown` and has to be narrowed, which is the honest answer for a name
+ * only the caller knows.
+ *
+ * `<ThemeProvider value>` stays closed (`Partial<Theme>`) on purpose: a typo
+ * in a palette is a bug, and there is nowhere else to catch it.
+ */
+export interface ThemeTokens extends Theme {
+  readonly [token: string]: unknown;
+}
+
 /** The palette in force: merged over the defaults and over any outer
  * provider, and the same object `$token` resolution sees. */
-export function useTheme(): Theme;
+export function useTheme(): ThemeTokens;
 
 /** Props a widget passes through to the `<box>` it renders. */
 type WidgetProps = Omit<BoxProps, 'children' | 'style' | 'ref'>;

--- a/src/types/nodes.d.ts
+++ b/src/types/nodes.d.ts
@@ -14,15 +14,24 @@ export interface Rect {
 
 /** The retained node behind a drawn element. */
 export interface DrawnNode {
-  /** Element name — `'box'`, `'text'`, … */
-  readonly type: string;
+  /** Element name — `'box'`, `'text'`, and the name a registered element
+   * was registered under. What queries and paint order match on:
+   * `screen.all((n) => n.kind === 'gauge')`. */
+  readonly kind: string;
   /** Position and size within the owning window, valid after layout. */
   readonly abs: Rect;
   readonly parent: DrawnNode | null;
   readonly children: readonly DrawnNode[];
-  /** Take the keyboard focus, if this node is focusable. */
-  focus(): void;
-  blur(): void;
+  /** Take the keyboard focus, if this node is focusable. Returns the node,
+   * so a component can hand it straight out of an imperative handle. */
+  focus(): this;
+  blur(): this;
+  /** Whether this node has the owning window's focus. */
+  readonly focused: boolean;
+  /** Whether focus is on this node or inside it — CSS `:focus-within`. */
+  readonly focusWithin: boolean;
+  /** Whether `node` is this node or a descendant of it (DOM `contains`). */
+  contains(node: DrawnNode | null): boolean;
   getClientRects(): Rect[];
 }
 

--- a/test/register-element.test.js
+++ b/test/register-element.test.js
@@ -245,6 +245,53 @@ test('the introspection helpers are copies, not the live sets', () => {
   assert.ok(!drawnKinds().includes('sparkline'), 'and it leaves DRAWN_KINDS');
 });
 
+test('an element asks for its own repaint, bounded (#252)', async () => {
+  register('sparkline', {
+    create: (props, app) => new SparklineNode(props, app),
+    semanticNames: ['data', 'color'],
+  });
+  await renderX11(
+    h(
+      'box',
+      { style: { padding: 10, flexGrow: 1 } },
+      h('sparkline', { data: [1, 2], style: { width: 60, height: 20 } }),
+    ),
+    { backend: 'mock' },
+  );
+
+  const node = screen.all((n) => n.kind === 'sparkline')[0];
+  const root = node.root;
+  assert.notStrictEqual(root, node, 'the window node is where damage lands');
+
+  // what docs/extending.md tells an element to write: name yourself as the
+  // damage, and the frame is bounded by what you draw rather than the window
+  root.needsPaint = false;
+  root._damage = null;
+  node.invalidate(false, node, 'props');
+  assert.strictEqual(root.needsPaint, true, 'a frame is owed');
+  assert.deepStrictEqual(
+    root._damage,
+    [node.paintBounds()],
+    'bounded by the node that changed',
+  );
+
+  // and naming nothing is still the whole window, as it always was
+  root.needsPaint = false;
+  root._damage = null;
+  node.invalidate(true, null, 'props');
+  assert.strictEqual(root.needsLayout, true);
+  assert.strictEqual(
+    typeof root._damage,
+    'symbol',
+    'no bound is the whole window',
+  );
+
+  // before it is attached there is no window and nothing on screen
+  const orphan = new SparklineNode({ data: [] }, node.app);
+  assert.strictEqual(orphan.root, null);
+  assert.doesNotThrow(() => orphan.invalidate(false, orphan, 'props'));
+});
+
 test('react-x11/style is enough to speak the vocabulary from outside', () => {
   assert.strictEqual(isStyleProp('backgroundColor'), true);
   assert.strictEqual(isStyleProp('title'), false);

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -160,6 +160,18 @@ function Elements() {
   const inputRef = useRef<TextInputNode>(null);
   const [text, setText] = useState('');
 
+  // issue #252: what a ref hands back, without a cast. The element name is
+  // `kind` — the name the element was registered under, which is what paint
+  // order and the harness queries match on.
+  const _kind: string | undefined = boxRef.current?.kind;
+  const _focused: boolean | undefined = boxRef.current?.focused;
+  const _within: boolean | undefined = boxRef.current?.focusWithin;
+  const _holds = () => boxRef.current?.contains(inputRef.current);
+  // focus() hands the node back, so an imperative handle can forward it
+  const _refocus = () => inputRef.current?.blur().focus();
+  // @ts-expect-error — the element name is `kind`; no node has a `type`
+  const _noType = () => boxRef.current?.type;
+
   return (
     <window
       ref={winRef}
@@ -404,6 +416,12 @@ function Themed() {
   const _face: string = theme.fontFamily;
   const _mono: string = theme.monoFamily;
   const _size: number = theme.fontSize;
+  // issue #252: a component that reads a token by a name it was handed —
+  // a code palette, a `$token` it is resolving itself — indexes the palette
+  // instead of casting it. Unknown names are `unknown`, so they narrow.
+  const pick = (token: string): string =>
+    typeof theme[token] === 'string' ? (theme[token] as string) : theme.text;
+  void pick('dim');
   return (
     <box
       style={{

--- a/test/types/extend.tsx
+++ b/test/types/extend.tsx
@@ -22,6 +22,7 @@ import {
   resolveTokens,
 } from '../../src/style.js';
 import type { Style } from '../../src/style.js';
+import { ctrlChordLetter, keysymOf } from '../../src/keysyms.js';
 
 // The element, declared to JSX exactly as docs/extending.md shows.
 declare module '../../src/jsx-runtime.js' {
@@ -58,7 +59,26 @@ class SparklineNode extends Node {
     void this.theme;
     void this.props.data;
     void this.app;
+    // damage as a rect, and as the node itself — both are what the window
+    // node collects, and `invalidate` is on every node, not just that one
     this.invalidate(false, this.abs, 'content');
+    this.invalidate(false, this, 'content');
+  }
+
+  // The focus half of the same surface (#252): an element takes focus as a
+  // click would, and reads where focus is.
+  activate(): SparklineNode {
+    if (!this.focused && !this.focusWithin)
+      this.focus().invalidate(false, this);
+    void this.contains(this.parent);
+    return this.blur();
+  }
+
+  // A widget that answers a chord of its own reads the letter from keysyms
+  // rather than copying the Shift rule.
+  handleKey(ev: { keysym?: number; codepoint: number }): boolean {
+    const letter: number | null = ctrlChordLetter(ev);
+    return letter === keysymOf('d');
   }
 }
 

--- a/test/types/test-api.tsx
+++ b/test/types/test-api.tsx
@@ -76,6 +76,9 @@ async function suite() {
   void within(windowNode).queryAllByRole('option');
   const _text: string = textOf(input);
   const _role: string = roleOf(input);
+  // the escape hatch, matching on the element name (#252)
+  const _gauges = screen.all((n) => n.kind === 'gauge');
+  const _kind: string = input.kind;
   void windowNodesOf(windowNode).length;
 
   // events


### PR DESCRIPTION
Closes #252, including the two follow-ons from the `<Markdown>`/`<Code>` build in the issue comment. No behaviour changes anywhere except the one runtime addition below, which is the item the issue asked for by name.

### The five

- **`Node.focus` / `Node.blur` are declared.** They were implemented all along — `focused`, `focusWithin` and `contains` come with them, since they are the same family and each one currently costs a cast. `focus` returns the node, as the runtime always did, so a component can forward it straight out of an imperative handle.
- **`ctrlChordLetter` is declared** in `keysyms.d.ts`, and documented in `docs/events.md` beside the event object, where a widget author meets the shifted-codepoint problem for the first time. It had three vendored copies.
- **`DrawnNode.kind`** replaces `DrawnNode.type`. The declared name was fictional: no node has ever had a `type` property, so the field that queries and paint order actually match on was both undeclared and misnamed. This is the breaking half — TypeScript only, since nothing could have read it at runtime.
- **`Node.invalidate` is real on every node.** It forwards to the window node that collects the damage, so `this.invalidate` in an element does what the declaration has been promising while only `WindowNode` implemented it. The damage argument is widened to `Node | Rect`, which is what the runtime accepts and what an element should pass — naming yourself is the difference between repainting a control and repainting the window. `docs/extending.md` now says `this.invalidate` rather than reaching through `this.root`.
- **`useTheme` returns a token-indexed view.** A component that resolves a name it was handed indexes the palette instead of widening it through `unknown`. `ThemeProvider` still takes `Partial<Theme>`: a typo in a palette has nowhere else to be caught, and the `@ts-expect-error` case in the type tests that pins that still passes.

### Tests

- `test/register-element.test.js` gets the runtime case: an element invalidates itself, the window node ends up with damage bounded by that node, naming no damage is still the whole window, and a node with no root yet is a quiet no-op. Mutation-checked — with the new method removed it fails with `node.invalidate is not a function`.
- The declarations are covered where declarations are covered: `test/types/extend.tsx` for the element surface and the chord helper, `test/types/api.tsx` for the ref surface and the theme index, `test/types/test-api.tsx` for `kind` in a harness query. `api.tsx` also pins `type` as gone with a `@ts-expect-error`.

`npm test`, `npm run lint`, `npm run typecheck` and prettier are clean. The six `test/appearance.test.js` failures on this machine are pre-existing on master — macOS answers the appearance ladder before XSETTINGS gets a turn.
