### PR TITLE
feat(extending): the box and the type an element draws in — contentBox and resolvedTextStyle

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -100,6 +100,10 @@ And what you read:
   lays out reads this, never `props`.**
 - `this.abs` — position and size within the owning window, valid after
   layout.
+- `this.contentBox()` — `abs` inset by the border and the padding: where the
+  content goes, and where every built-in draws.
+- `this.resolvedTextStyle()` — the text style this node resolves to, ready to
+  hand to `app.fonts.layout` (below).
 - `this.root` — the owning `<window>` node; `this.app` — the ntk connection.
 - `this.theme` — the nearest theme at or above this node.
 
@@ -115,6 +119,53 @@ And to take the keyboard focus: `this.focus()` moves it here as a click
 would and hands the node back, `this.blur()` gives it up, `this.focused` and
 `this.focusWithin` answer where it is. They claim their own damage — a
 focused control repaints itself, and its ring, without being asked.
+
+### Text of your own
+
+An element that draws text — a badge, a code editor, a terminal — shapes it
+through ntk's font manager, and the two things it needs to do that are the
+two accessors above:
+
+```js
+class BadgeNode extends Node {
+  paint(ctx) {
+    super.paint(ctx); // background, border, clip
+    const fonts = this.app?.fonts;
+    if (!fonts) return; // headless: no font manager, nothing to shape with
+    const box = this.contentBox();
+    const layout = fonts.layout(
+      String(this.props.label ?? ''),
+      this.resolvedTextStyle(),
+      { maxWidth: box.width || undefined },
+    );
+    layout.draw(ctx, box.x, box.y);
+  }
+}
+```
+
+**`contentBox()` is not `abs` minus `style.padding`.** The insets come off
+the layout, which is where `padding: '10%'`, the per-side overrides and the
+border widths have already been resolved against this frame's size — so the
+box an element computes from the style bag agrees with the one `<text>` uses
+only by luck, and stops agreeing the next time the vocabulary grows another
+edge — the per-side border widths were the last one to arrive.
+
+**`resolvedTextStyle()` is what makes the type of an app reach your
+element.** It is the node's own font properties over what the palette says
+text with none of its own is set in, in the shape `fonts.layout` wants
+(`family`, not `fontFamily`; `variations`, not `fontVariationSettings`). An
+element that reads `this.style.fontFamily` instead is one that a
+`<ThemeProvider value={{ fontFamily: 'Inter' }}>` does not reach — every
+built-in label changes face and yours does not, which is a bug an app author
+can only work around by growing a `fontFamily` prop on your element and
+threading it in. Ask, and the element inherits exactly what a `<text>`
+sibling inherits.
+
+Both are read at paint time, not cached: the palette can change under a
+mounted tree ([styling.md](styling.md)), and the box changes with every
+layout. If the text is also what _sizes_ the element, shape it in
+`measureContent` as well — `<text>` memoizes its layout per max-width for
+exactly that reason.
 
 ### A size of your own
 

--- a/src/node.d.ts
+++ b/src/node.d.ts
@@ -7,7 +7,12 @@
  * contract in prose.
  */
 import type { Rect, NtkApp } from './types/nodes.js';
-import type { Style } from './types/style.js';
+import type {
+  FontStyle,
+  FontWeight,
+  Style,
+  TextRendering,
+} from './types/style.js';
 import type { KeyboardEvent, MouseEvent } from './types/events.js';
 
 /** ntk's 2d context. Typed loosely — it is ntk's API, not ours. */
@@ -33,6 +38,24 @@ export interface MeasureConstraints {
 export interface MeasuredSize {
   width: number;
   height: number;
+}
+
+/**
+ * A resolved text style — the base style `app.fonts.layout` takes, which is
+ * ntk's vocabulary rather than the style vocabulary: `family` for
+ * `fontFamily`, `variations` for `fontVariationSettings`.
+ */
+export interface TextStyle {
+  /** A CSS-style family list, as `fontFamily` is written. */
+  family: string;
+  size: number;
+  weight: FontWeight;
+  style: FontStyle;
+  /** A variable font's axes, `{ wght: 460 }` — undefined unless a style or
+   * the cascade above it named one. */
+  variations: Record<string, number> | undefined;
+  textRendering: TextRendering | undefined;
+  color: string;
 }
 
 /**
@@ -78,6 +101,16 @@ export declare class Node {
   readonly destroyed: boolean;
   /** Position and size within the owning window, valid after layout. */
   readonly abs: Rect;
+  /** `abs` inset by the border and the padding — where the content goes,
+   * and where every built-in draws. The insets come off the layout, which
+   * is where percentages and the per-side overrides have already been
+   * resolved, so this is not arithmetic to redo from `style`. */
+  contentBox(): Rect;
+  /** The text style this node resolves to, in the shape `app.fonts.layout`
+   * takes: the style's font properties over what the palette says text
+   * with none of its own is set in. An element that draws text inherits
+   * exactly what `<text>` inherits by asking. */
+  resolvedTextStyle(): TextStyle;
   /** The flattened `style` prop with the active state blocks overlaid.
    * Everything that paints or lays out reads this, never `props`. */
   readonly style: Style;

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -2249,7 +2249,24 @@ export class Node {
     return Boolean(a11yFocusable(this));
   }
 
+  /**
+   * The rectangle this node's **content** goes in — `abs` inset by the
+   * border and the padding, in the owning window's coordinates. Every text
+   * element in core paints inside it, and so should anything a registered
+   * element draws that the padding is meant to hold off.
+   *
+   * Public (docs/extending.md) because the arithmetic is not reproducible
+   * from `this.style`: the insets come off the yoga node, which is where
+   * percentages, the per-side overrides and the border widths have already
+   * been resolved against this frame's size. An element deriving them from
+   * the style bag instead re-implements a resolution order it cannot see,
+   * and silently disagrees with `<text>` the day the vocabulary grows
+   * another edge — the per-side border widths (#262) were the last one.
+   */
   contentBox() {
+    // A node with no yoga node (`{ yoga: false }`) has no resolved insets,
+    // so its box is its content box.
+    if (!this.yoga) return { ...this.abs };
     const padL =
       this.yoga.getComputedPadding(Yoga.EDGE_LEFT) +
       this.yoga.getComputedBorder(Yoga.EDGE_LEFT);
@@ -2268,6 +2285,27 @@ export class Node {
       width: Math.max(0, this.abs.width - padL - padR),
       height: Math.max(0, this.abs.height - padT - padB),
     };
+  }
+
+  /**
+   * The text style this node resolves to, in the shape `app.fonts.layout`
+   * takes as its base: `{ family, size, weight, style, variations,
+   * textRendering, color }`. `<text>`, `<textinput>` and the document views
+   * draw with exactly this, and an element that draws text of its own is
+   * asking the same question they are.
+   *
+   * Two things are folded in that `this.style` does not carry. The palette
+   * is under it — `text`, `fontFamily` and `fontSize` are the ink, the face
+   * and the size of everything that named none of its own (styling.md) — so
+   * an element reading its own style alone is one whose app can say
+   * `<ThemeProvider value={{ fontFamily: 'Inter' }}>` and watch it reach
+   * every built-in label and stop at this one. And the bag is spelled ntk's
+   * way rather than the style vocabulary's (`family`, not `fontFamily`;
+   * `variations`, not `fontVariationSettings`), which is a mapping worth
+   * having in one place instead of vendored per element.
+   */
+  resolvedTextStyle() {
+    return textStyleFrom(this.style, this.inheritedTextStyle);
   }
 
   paint(ctx) {
@@ -2768,9 +2806,8 @@ export class TextNode extends Node {
     const key = String(maxWidth);
     let layout = this._layouts.get(key);
     if (!layout) {
-      const inherited = this.inheritedTextStyle;
-      const spans = this.collectSpans(inherited, []);
-      const base = textStyleFrom(this.style, inherited);
+      const spans = this.collectSpans(this.inheritedTextStyle, []);
+      const base = this.resolvedTextStyle();
       layout = fonts.layout(spans, base, {
         maxWidth: Number.isFinite(maxWidth) ? maxWidth : undefined,
         align: this.style.textAlign,
@@ -2803,7 +2840,7 @@ export class TextNode extends Node {
     if (this.style.textBoxTrim !== 'cap-alphabetic') return null;
     const lines = layout?.lines;
     if (!lines?.length) return null;
-    const base = textStyleFrom(this.style, this.inheritedTextStyle);
+    const base = this.resolvedTextStyle();
     const font = this.app?.fonts?.match?.(base.family, {
       weight: base.weight,
       style: base.style,
@@ -3784,24 +3821,20 @@ export class TextInputNode extends Node {
     return Array.from(this.value);
   }
 
-  _textStyle() {
-    return textStyleFrom(this.style, this.inheritedTextStyle);
-  }
-
   _layoutOf(text) {
     const fonts = this.app?.fonts;
     if (!fonts) return null;
-    const style = this._textStyle();
+    const style = this.resolvedTextStyle();
     return fonts.layout(text, style);
   }
 
   _lineHeight() {
     const layout = this._layoutOf('Mg');
     if (layout) return layout.height;
-    // No fonts to measure with. `_textStyle()` rather than the style prop
-    // alone, so the guess is made at the size this field inherits — the
+    // No fonts to measure with. `resolvedTextStyle()` rather than the style
+    // prop alone, so the guess is made at the size this field inherits — the
     // palette's — and not at 14 whatever the theme said.
-    return this._textStyle().size * 1.4;
+    return this.resolvedTextStyle().size * 1.4;
   }
 
   /**
@@ -3837,7 +3870,7 @@ export class TextInputNode extends Node {
   }
 
   _capBand() {
-    const style = this._textStyle();
+    const style = this.resolvedTextStyle();
     const cap = this.app?.fonts
       ?.match?.(style.family, { weight: style.weight, style: style.style })
       ?.metrics?.(style.size)?.capHeight;
@@ -3852,7 +3885,7 @@ export class TextInputNode extends Node {
     const fonts = this.app?.fonts;
     if (!fonts) return null;
     const text = this.value;
-    const s = this._textStyle();
+    const s = this.resolvedTextStyle();
     const key = `${text}|${s.family}|${s.size}|${s.weight}|${s.style}`;
     if (this._valueLayoutKey !== key) {
       this._valueLayoutKey = key;
@@ -4489,7 +4522,7 @@ export class TextInputNode extends Node {
     );
     const { x, y } = this._editMenuOrigin(ev, geometry);
     const colors = editMenuColors(this.theme);
-    const style = this._textStyle();
+    const style = this.resolvedTextStyle();
     const state = { active: -1 };
 
     const canvas = new CanvasNode(
@@ -4639,7 +4672,7 @@ export class TextInputNode extends Node {
     const content = this.contentBox();
     if (content.width <= 0 || content.height <= 0) return;
 
-    const style = this._textStyle();
+    const style = this.resolvedTextStyle();
     const text = this.value;
     const isEmpty = text.length === 0;
     const shown = isEmpty ? (this.props.placeholder ?? '') : text;
@@ -4832,7 +4865,7 @@ export class TextAreaNode extends TextInputNode {
     const text = this.value;
     const isEmpty = text.length === 0;
     const shown = isEmpty ? (this.props.placeholder ?? '') : text;
-    const s = this._textStyle();
+    const s = this.resolvedTextStyle();
     const color = isEmpty
       ? (this.props.placeholderColor ?? this.theme.dim)
       : s.color;
@@ -5031,7 +5064,7 @@ export class TextAreaNode extends TextInputNode {
     layout.draw(ctx, originX, originY);
 
     if (this._focused && this._caretOn && a === b) {
-      ctx.fillStyle = this.props.caretColor ?? this._textStyle().color;
+      ctx.fillStyle = this.props.caretColor ?? this.resolvedTextStyle().color;
       ctx.fillRect(originX + pos.x, originY + pos.y, 1.5, pos.height);
     }
     // inside the clip, so the thumb is bounded by the content box

--- a/test/node-accessors.test.js
+++ b/test/node-accessors.test.js
@@ -1,0 +1,318 @@
+// The two accessors a drawing element reads: `contentBox()` and
+// `resolvedTextStyle()` (#254).
+//
+// Both were internal, and both were therefore re-derived by hand outside
+// this package — the padding out of `this.style` with a `parseFloat` and a
+// hope, the font out of `this.style.fontFamily` with the palette missing
+// from under it. Neither hand-rolled version can be right: the insets are
+// resolved by yoga against this frame's size (percentages, per-side
+// overrides, the border), and the text style is the *cascade's* answer, not
+// the style bag's.
+//
+// So the tests come in two halves. The headless ones pin what the accessors
+// answer, including the cases the hand-rolled arithmetic gets wrong. The
+// pixel one is the acceptance criterion in the issue: a registered element
+// that draws with them is, pixel for pixel, a `<text>` sibling.
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import React from 'react';
+
+import { registerElement, unregisterElement } from '../src/host.js';
+import { Node } from '../src/node.js';
+import { renderX11, cleanup } from '../src/testing/index.js';
+
+const h = React.createElement;
+
+const require = createRequire(import.meta.url);
+const FONTS = {
+  // The only face in this server. The theme below names it explicitly, so
+  // an element that failed to inherit would fall back to `sans-serif` — and
+  // to 14 pixels of it, which is what the pixels are asked about.
+  'Test Main': join(
+    dirname(require.resolve('katex/package.json')),
+    'dist',
+    'fonts',
+    'KaTeX_Main-Regular.ttf',
+  ),
+};
+
+/**
+ * A third-party element that draws a line of text, written the way the docs
+ * say to: nothing in it names `this.yoga`, an underscore, or a font
+ * property of its own.
+ */
+class BadgeNode extends Node {
+  constructor(props, app) {
+    super('badge', props, app);
+    this.painted = null;
+  }
+
+  paint(ctx) {
+    super.paint(ctx); // background, border, clip
+    const fonts = this.app?.fonts;
+    if (!fonts) return; // headless: no font manager to shape with
+    const box = this.contentBox();
+    const style = this.resolvedTextStyle();
+    this.painted = { box, style };
+    const layout = fonts.layout(String(this.props.label ?? ''), style, {
+      maxWidth: box.width || undefined,
+    });
+    // `<text>` centres the line box in the same rectangle. Matching that is
+    // what makes the two renders comparable pixel for pixel; the styling
+    // and the box are what the test is actually about.
+    const last = layout.lines?.[layout.lines.length - 1];
+    const halfLeading = last
+      ? Math.max(0, (layout.height - (last.baseline + last.descent)) / 2)
+      : 0;
+    layout.draw(ctx, box.x, box.y + halfLeading);
+  }
+}
+
+const registered = new Set();
+function register(type, definition) {
+  registerElement(type, definition);
+  registered.add(type);
+}
+
+afterEach(async () => {
+  await cleanup();
+  for (const type of registered) unregisterElement(type);
+  registered.clear();
+});
+
+const badge = (props) => h('badge', { label: 'Handgloves', ...props });
+
+const found = (node, kind) =>
+  node.kind === kind
+    ? node
+    : (node.children.map((c) => found(c, kind)).find(Boolean) ?? null);
+
+/** Mount into the mock connection: layout, no server, no fonts. */
+const mount = (windowProps, ...children) =>
+  renderX11(h('window', { title: 'accessors', ...windowProps }, ...children), {
+    backend: 'mock',
+  });
+
+// --- contentBox --------------------------------------------------------------
+
+test('the content box is the border box inset by border and padding', async () => {
+  register('badge', { create: (p, a) => new BadgeNode(p, a) });
+  const { windowNode } = await mount(
+    { width: 300, height: 100 },
+    badge({ style: { width: 200, height: 60, padding: 8, borderWidth: 2 } }),
+  );
+  const node = found(windowNode, 'badge');
+  assert.deepStrictEqual(node.contentBox(), {
+    x: node.abs.x + 10,
+    y: node.abs.y + 10,
+    width: 200 - 20,
+    height: 60 - 20,
+  });
+});
+
+test('per-side padding and per-side borders inset their own side', async () => {
+  register('badge', { create: (p, a) => new BadgeNode(p, a) });
+  const { windowNode } = await mount(
+    { width: 300, height: 100 },
+    badge({
+      style: {
+        width: 200,
+        height: 60,
+        padding: 4,
+        paddingLeft: 20,
+        borderWidth: 1,
+        borderBottomWidth: 5,
+      },
+    }),
+  );
+  const node = found(windowNode, 'badge');
+  const box = node.contentBox();
+  assert.deepStrictEqual(
+    [box.x - node.abs.x, box.y - node.abs.y, box.width, box.height],
+    [21, 5, 200 - 21 - 5, 60 - 5 - 9],
+    'left is its own padding plus its own border; the bottom border is 5',
+  );
+});
+
+// The case that makes this an accessor rather than a snippet to copy: there
+// is no number in the style bag to read here. The percentage is resolved by
+// layout, against the containing block, at the size this frame came out at.
+test('percentage padding is resolved, not parsed', async () => {
+  register('badge', { create: (p, a) => new BadgeNode(p, a) });
+  const { windowNode } = await mount(
+    { width: 300, height: 100 },
+    badge({ style: { width: 200, height: 60, padding: '10%' } }),
+  );
+  const node = found(windowNode, 'badge');
+  const box = node.contentBox();
+  const inset = box.x - node.abs.x;
+  assert.ok(inset > 0, `a percentage resolved to ${inset}`);
+  assert.deepStrictEqual(
+    [box.width, box.height],
+    [200 - inset * 2, 60 - inset * 2],
+    'and the same inset came off all four edges',
+  );
+});
+
+test('a node with nothing to inset by has its own box', async () => {
+  register('badge', { create: (p, a) => new BadgeNode(p, a) });
+  const { windowNode } = await mount(
+    { width: 300, height: 100 },
+    badge({ style: { width: 200, height: 60 } }),
+  );
+  const node = found(windowNode, 'badge');
+  assert.deepStrictEqual(node.contentBox(), { ...node.abs });
+});
+
+// --- resolvedTextStyle -------------------------------------------------------
+
+test('the palette is under it, exactly as it is under <text>', async () => {
+  register('badge', { create: (p, a) => new BadgeNode(p, a) });
+  const { windowNode } = await mount(
+    {
+      width: 300,
+      height: 100,
+      theme: { fontFamily: 'Inter', fontSize: 22, text: '#c0392b' },
+    },
+    badge(),
+    h('text', null, 'Handgloves'),
+  );
+  const node = found(windowNode, 'badge');
+  const text = found(windowNode, 'text');
+  assert.deepStrictEqual(node.resolvedTextStyle(), text.resolvedTextStyle());
+  assert.deepStrictEqual(node.resolvedTextStyle(), {
+    family: 'Inter',
+    size: 22,
+    weight: 'normal',
+    style: 'normal',
+    variations: undefined,
+    textRendering: undefined,
+    color: '#c0392b',
+  });
+});
+
+test("the element's own style wins over what it inherits", async () => {
+  register('badge', { create: (p, a) => new BadgeNode(p, a) });
+  const { windowNode } = await mount(
+    { width: 300, height: 100, theme: { fontFamily: 'Inter', fontSize: 22 } },
+    badge({
+      style: {
+        fontSize: 30,
+        fontWeight: 'bold',
+        fontStyle: 'italic',
+        color: '#123456',
+        fontVariationSettings: { wght: 460 },
+      },
+    }),
+  );
+  const style = found(windowNode, 'badge').resolvedTextStyle();
+  assert.deepStrictEqual(style, {
+    family: 'Inter', // nothing said otherwise: still the palette's
+    size: 30,
+    weight: 'bold',
+    style: 'italic',
+    variations: { wght: 460 },
+    textRendering: undefined,
+    color: '#123456',
+  });
+});
+
+test('a `$token` reaches it, since it is the resolved style it reads', async () => {
+  register('badge', { create: (p, a) => new BadgeNode(p, a) });
+  const { windowNode } = await mount(
+    { width: 300, height: 100, theme: { monoFamily: 'Fira Code' } },
+    badge({ style: { fontFamily: '$monoFamily' } }),
+  );
+  assert.equal(
+    found(windowNode, 'badge').resolvedTextStyle().family,
+    'Fira Code',
+  );
+});
+
+test('a theme swap moves it, without the element hearing about it', async () => {
+  register('badge', { create: (p, a) => new BadgeNode(p, a) });
+  const tree = (theme) =>
+    h(
+      'window',
+      { title: 'accessors', width: 300, height: 100, theme },
+      badge(),
+    );
+  const { windowNode, rerender } = await renderX11(tree({ fontSize: 22 }), {
+    backend: 'mock',
+  });
+  assert.equal(found(windowNode, 'badge').resolvedTextStyle().size, 22);
+  await rerender(tree({ fontSize: 40 }));
+  assert.equal(found(windowNode, 'badge').resolvedTextStyle().size, 40);
+});
+
+// --- the acceptance criterion ------------------------------------------------
+
+const readPixels = (ctx, width, height) =>
+  new Promise((resolve, reject) =>
+    ctx.getImageData(0, 0, width, height, (err, image) =>
+      err ? reject(err) : resolve(image),
+    ),
+  );
+
+/** Pixels that differ between two reads of the same window, and the ink in
+ *  the first — a blank frame must not pass as a match. */
+const compare = (a, b) => {
+  let differing = 0;
+  let ink = 0;
+  for (let i = 0; i < a.data.length; i += 4) {
+    if (
+      a.data[i] !== b.data[i] ||
+      a.data[i + 1] !== b.data[i + 1] ||
+      a.data[i + 2] !== b.data[i + 2]
+    ) {
+      differing++;
+    }
+    if (a.data[i] < 200 || a.data[i + 1] < 200 || a.data[i + 2] < 200) ink++;
+  }
+  return { differing, ink };
+};
+
+// The issue in one test: an element that inherits its face, its size and
+// its ink from an ancestor draws what a `<text>` in its place would.
+test('a registered element renders identically to a <text> sibling', async () => {
+  register('badge', {
+    create: (p, a) => new BadgeNode(p, a),
+    semanticNames: ['label'],
+  });
+  const W = 300;
+  const H = 80;
+  const style = { width: W, height: H, padding: 12, borderWidth: 3 };
+  const window = (child) =>
+    h(
+      'window',
+      {
+        title: 'accessors',
+        width: W,
+        height: H,
+        theme: { fontFamily: 'Test Main', fontSize: 28, text: '#c0392b' },
+        style: { backgroundColor: '#ffffff' },
+      },
+      child,
+    );
+
+  const { ctx, rerender } = await renderX11(window(badge({ style })), {
+    fonts: FONTS,
+    wrap: false,
+    width: W,
+    height: H,
+  });
+  const drawn = await readPixels(ctx, W, H);
+
+  await rerender(window(h('text', { style }, 'Handgloves')));
+  const reference = await readPixels(ctx, W, H);
+
+  const { differing, ink } = compare(drawn, reference);
+  assert.ok(ink > 200, `the badge drew something: ${ink} inked pixels`);
+  assert.equal(
+    differing,
+    0,
+    `${differing} pixels differ from the <text> that replaced it`,
+  );
+});

--- a/test/types/extend.tsx
+++ b/test/types/extend.tsx
@@ -19,7 +19,8 @@ import {
   intrinsicSize,
   CARET_BLINK_MS,
 } from '../../src/node.js';
-import type { MeasureConstraints } from '../../src/node.js';
+import type { MeasureConstraints, TextStyle } from '../../src/node.js';
+import type { Rect } from '../../src/types/nodes.js';
 import { XK_ESCAPE, XK_TAB } from '../../src/keysyms.js';
 // the synthetic events, not the DOM's same-named globals
 import type { KeyboardEvent, MouseEvent } from '../../src/types/events.js';
@@ -78,6 +79,21 @@ class SparklineNode extends Node {
     // node collects, and `invalidate` is on every node, not just that one
     this.invalidate(false, this.abs, 'content');
     this.invalidate(false, this, 'content');
+  }
+
+  // The two accessors a drawing element reads (#254): where its content
+  // goes, and the text style the cascade resolved for it — the second in
+  // ntk's spelling, ready for `app.fonts.layout`.
+  label(): string {
+    const box: Rect = this.contentBox();
+    const type: TextStyle = this.resolvedTextStyle();
+    const _family: string = type.family;
+    const _size: number = type.size;
+    const _ink: string = type.color;
+    void box.width;
+    void _family;
+    void _size;
+    return _ink;
   }
 
   // The focus half of the same surface (#252): an element takes focus as a


### PR DESCRIPTION
Closes #254.

An element that draws could size itself since #265 and behave since #266, but it still could not draw *text* without re-deriving two things core keeps to itself — and re-deriving both of them wrong.

## `contentBox()`

Core's text elements paint inside `contentBox()`: `abs` inset by the border and the padding. A registered element got `this.abs` and `this.style` and did the arithmetic itself — `parseFloat` the padding, add the border, four edges, hoping the resolution order matched. It cannot match: the insets are resolved by yoga against the size this frame came out at, and for `padding: '10%'` there is no number in the style bag at all. Promoted to the public surface with the implementation unchanged, plus one guard so a node with no yoga node answers with its own box rather than throwing.

## `resolvedTextStyle()`

`app.fonts.layout` takes a base style in ntk's vocabulary (`family`, `variations`), and what belongs in it is the node's own font properties over **the palette's** — `text`, `fontFamily` and `fontSize` are the ink, the face and the size of everything that named none of its own. Both halves of that were internal (`textStyleFrom`, `inheritedTextStyle`), so an element outside the package vendored the shape and read only its own style.

The visible cost is the one the issue names: a `<ThemeProvider value={{ fontFamily: 'Inter' }}>` reaches every built-in label and stops at that element. `<CodeEditor>` and `<richtext>` in react-x11-components both work around it by growing font props of their own, which is the workaround multiplying rather than the fix.

`<text>`, `<textinput>` and `<textarea>` move onto the public name (`TextInputNode._textStyle` is deleted), so the seam a third party uses is the one core draws through rather than a private twin.

## Tests

`test/node-accessors.test.js`, nine tests in two halves:

- headless — the content box under `padding`/`borderWidth`, under per-side padding and per-side borders, and under `padding: '10%'` (the case with nothing to parse); the resolved style equal to a `<text>` sibling's, its own style winning over the palette, a `$token` reaching it, and a theme swap moving it with the element hearing nothing;
- pixels — the acceptance criterion. A registered element that draws with the two accessors, under a `<window theme={{ fontFamily, fontSize, text }}>`, is compared against the `<text>` that replaces it in the same box: 0 differing pixels out of 300×80. Mutating `resolvedTextStyle` to drop the inherited half fails it, along with three of the headless tests.

`test/types/extend.tsx` compiles both accessors and the exported `TextStyle`.

Full suite green apart from the pre-existing macOS `appearance.test.js` failures (the ladder answers `macos` on this machine), which fail identically on `master`. `npm run typecheck`, `npm run lint`, `npm run format:check` and the website build all clean.
