### PR TITLE
feat(style)!: the ink and the face travel down the tree — text inheritance, and :focus-within

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,10 +83,16 @@ no override-redirect staging (issue #4).
   `npm run examples:urischeme` is the manual harness for the two dispatch paths
   a broker cannot fake.
 - `src/styles.js` — flat style props → yoga setters; paint prop
-  classification; text style resolution.
+  classification; text style resolution. Also the two prop sets the
+  **inheritance** rule is written as: `INHERITED_TEXT_PROPS` (the ink, the
+  face, the size — what travels down the tree) and `LOCAL_TEXT_PROPS` (what
+  shapes a node's own box and therefore cannot arrive from above). Which
+  side a text property is on decides who has to react when it moves, so a
+  new one goes in exactly one of them.
 - `src/events.js` — `EventManager`: ntk window events → synthetic events
   (click synthesis, hover enter/leave diffing, wheel from X buttons 4-7,
-  focus/Tab).
+  focus/Tab). Three ancestor-chain diffs live here and share one shape —
+  `:hover`, `:active` over the press chain, and `:focus-within`.
 - `src/priority.js` — shared React update-priority state (discrete vs
   continuous events).
 - `src/DevToolsIntegration.js` — opt-in React DevTools bridge
@@ -517,13 +523,16 @@ Two things came out of that and are worth keeping:
   catches it — regenerate on the base first and diff, since the rasterizer
   shifts edges on its own.
 
-Two things follow that every call site has to know, because there is **no
-cascade**: an icon does not inherit `color` or `fontSize` from an ancestor
-box, and `:hover` marks the ancestor chain rather than the children, so a
-glyph inside a highlighted row is handed its ink in React. (If a real
-`color`/`fontSize` cascade lands, those become defaults inheritance fills in
-and nothing about the set changes — but until then, passing the colour is
-not boilerplate to be cleaned up. It is the only thing that works.)
+**The ink comes from the cascade; the size does not.** `color` is an
+inherited property (docs/styling.md), and a `mono` drawing reads exactly what
+a `<text>` beside it would — so an icon in a row that dims itself dims with
+it, and a `:hover` block that sets `color` on the row reaches the glyph the
+same way it reaches the label. Nothing is handed over at the call site, and
+an `<Icon color=…>` now means "this mark is not the colour of the text
+around it" rather than "someone remembered". `size` stays out of it on
+purpose: a glyph has no baseline and no ascent, so it derives from the
+palette's `fontSize` rather than from whatever text is nearby, which keeps a
+chevron the same size in a row that shrank its label.
 
 Not a font, and the reasoning is on record so it is not re-derived: ntk's
 FontManager does take font bytes, and glyphs composite through a solid source

--- a/docs/components.md
+++ b/docs/components.md
@@ -216,30 +216,31 @@ The **drawings are not themable** for the same reason: the geometry is the
 widget set's vocabulary, and an application that wants a different chevron
 wants an icon library. Colour and size are yours; the shape is not.
 
-### Colour and size do not cascade — pass them
+### Colour inherits; size does not
 
-This renderer has no cascade: `style` precedence is written at the call site
-([styling.md](styling.md)), and `color` or `fontSize` on an ancestor `<box>`
-reaches nothing below it. An icon is a sibling element rather than a span, so
-it is outside `<text>`'s span inheritance too. Two consequences:
+`color` travels down the tree
+([styling.md](styling.md#inheritance-the-ink-the-face-and-the-size)), so an
+icon takes the ink of whatever it is written inside and needs nothing said
+at the call site:
 
-- **Colour.** `color` defaults to the palette's `text`, because `theme` _is_
-  inherited — it is the one channel that walks the tree. But a row painting
-  its label in `theme.hoverText` has to hand its icon the same ink:
+```jsx
+<box style={{ color: theme.dim, ':hover': { color: theme.accent } }}>
+  <text>Open recent</text>
+  <Icon name="chevronRight" />
+</box>
+```
 
-  ```jsx
-  <Icon name="chevronRight" color={active ? theme.hoverText : theme.dim} />
-  ```
+That covers the hover case too. `:hover` marks the row, `color` is
+inherited, and the label and the icon both follow — which is why `Tree`'s
+twisty and `ContextMenu`'s submenu chevron carry no colour of their own any
+more. The `color` prop is for saying something the surrounding text does
+not: a destructive action's mark, or a check drawn on an accent fill.
 
-- **`:hover`.** State selectors resolve per node against the _ancestor_
-  chain, so hovering a row lights the row up and leaves its children alone.
-  An icon that has to follow a hover follows it through React state, the way
-  `Tree`'s twisty and `ContextMenu`'s submenu chevron do.
-
-Both of those describe the model as it stands today rather than a settled
-verdict — a real `color`/`fontSize` cascade is an open question. If it
-lands, `color` and `size` become defaults that inheritance fills in instead
-of things every call site repeats, and nothing about the set changes.
+**`size` does not inherit, and is deliberately not `fontSize`.** A glyph is
+a drawing rather than a letter — no baseline to sit on, no ascent to be
+measured against — so it takes its default from the palette's `fontSize` and
+stays put when a label beside it shrinks. Pass `size` for the one icon that
+has to be bigger.
 
 ### What it costs to draw one
 

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -747,12 +747,20 @@ run list so wrapping spans the whole content.
 
 | prop                                                |                                                        |
 | --------------------------------------------------- | ------------------------------------------------------ |
-| `color`                                             | text color (inherited by spans)                        |
+| `color`                                             | text color — inherited (see below)                     |
 | `fontSize`, `fontFamily`, `fontWeight`, `fontStyle` | ntk font style (fontconfig lookup + fallback)          |
 | `fontVariationSettings`                             | a variable font's axes — see below                     |
 | `textRendering`                                     | which glyph path to draw with — see below              |
 | `textAlign`                                         | `left`, `right`, `center`, `start`, `end` (bidi-aware) |
 | `lineHeight`                                        | multiplier over the natural font line height           |
+
+The first four rows and `fontVariationSettings` and `textRendering`
+**inherit** — from a nested span's point of view that has always been true,
+and it is equally true across a `<box>`, so a caption block is written once
+around the labels in it
+([styling.md](styling.md#inheritance-the-ink-the-face-and-the-size)).
+`textAlign` and `lineHeight` do not: they shape the box the lines flow in,
+which belongs to the `<text>` that owns it.
 
 ### Variable fonts
 
@@ -1043,7 +1051,10 @@ their props, so the renderer can build the key itself.
 
 `mono` is a promise about the drawing: **everything it paints is one colour,
 and it is not the drawing's to choose.** `onDraw` then names no colour at all
-— `fillStyle` and `strokeStyle` arrive preset from `style.color`:
+— `fillStyle` and `strokeStyle` arrive preset from the node's resolved
+`color`, which is its own if it named one and otherwise the ink it inherits
+([styling.md](styling.md#inheritance-the-ink-the-face-and-the-size)), so a
+mark inside a dimmed or hovered row follows it with nothing said:
 
 ```jsx
 const chevron = (ctx, { width: w, height: h }) => {
@@ -1415,8 +1426,12 @@ on the `<svg>` element itself.
 | `viewBox` | coordinate system (children form) |
 
 **`currentColor` and recolouring.** `fill="currentColor"` and
-`stroke="currentColor"` resolve to the node's `color` style, so one icon
-serves every state the UI puts it in:
+`stroke="currentColor"` resolve the way the word does in CSS: the node's own
+`color` if it named one, otherwise the ink it inherits, and under that the
+palette's `text`
+([styling.md](styling.md#inheritance-the-ink-the-face-and-the-size)). So one
+drawing serves every state the UI puts it in, and an unstyled one is
+readable on a dark desktop rather than black on it:
 
 ```jsx
 <svg

--- a/docs/events.md
+++ b/docs/events.md
@@ -161,7 +161,10 @@ default, and so is a scroll container with somewhere to scroll), `autoFocus`
 takes it at mount, and every drawn node has
 `focus()` / `blur()` / `focused` on its ref — plus `focusWithin`, which is
 true while focus is on the node **or inside it**, the question a modal asks
-before taking focus itself. `focus()` hands the node back, so a component
+before taking focus itself. To _draw_ that rather than read it, there is a
+`':focus-within'` style block
+([styling.md](styling.md#inline-pseudo-states)), which is what a row
+containing a field wants. `focus()` hands the node back, so a component
 can forward it straight out of an imperative handle. Focusing a node inside a
 scroll container scrolls it into view. Mousedown focuses the nearest
 focusable ancestor of the hit node; Tab / Shift+Tab cycle through focusable

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -151,21 +151,30 @@ only by luck, and stops agreeing the next time the vocabulary grows another
 edge — the per-side border widths were the last one to arrive.
 
 **`resolvedTextStyle()` is what makes the type of an app reach your
-element.** It is the node's own font properties over what the palette says
-text with none of its own is set in, in the shape `fonts.layout` wants
-(`family`, not `fontFamily`; `variations`, not `fontVariationSettings`). An
-element that reads `this.style.fontFamily` instead is one that a
-`<ThemeProvider value={{ fontFamily: 'Inter' }}>` does not reach — every
-built-in label changes face and yours does not, which is a bug an app author
-can only work around by growing a `fontFamily` prop on your element and
-threading it in. Ask, and the element inherits exactly what a `<text>`
-sibling inherits.
+element.** It is the node's own font properties over what it **inherits**
+from the elements around it, and under that what the palette says text with
+none of its own is set in — in the shape `fonts.layout` wants (`family`, not
+`fontFamily`; `variations`, not `fontVariationSettings`). An element that
+reads `this.style.fontFamily` instead is one that a
+`<ThemeProvider value={{ fontFamily: 'Inter' }}>` does not reach, and one
+that a `<box style={{ color: theme.dim }}>` around it does not dim — bugs an
+app author can only work around by growing props on your element and
+threading them in. Ask, and the element inherits exactly what a `<text>`
+sibling inherits, including a `:hover` block on the row it sits in
+([styling.md](styling.md#inheritance-the-ink-the-face-and-the-size)).
 
-Both are read at paint time, not cached: the palette can change under a
-mounted tree ([styling.md](styling.md)), and the box changes with every
-layout. If the text is also what _sizes_ the element, shape it in
-`measureContent` as well — `<text>` memoizes its layout per max-width for
-exactly that reason.
+Both are read at paint time. `contentBox()` is computed each call, since the
+box changes with every layout; `resolvedTextStyle()` is memoised and dropped
+by everything that can move it — a style change, a state block, an
+animation tick, a theme swap, an element above it changing its own type — so
+reading it per frame costs a property lookup and never goes stale. If the
+text is also what _sizes_ the element, shape it in `measureContent` as well;
+`<text>` memoizes its layout per max-width for exactly that reason. An
+element that keeps a cache of its own keyed on the type — a shaped run, a
+rasterized label — should drop it in **`_textStyleMoved(cost)`**, which is
+called with `2` when a glyph can have moved and `1` when only the ink or the
+glyph rounding did. The default re-measures on the first and repaints on the
+second, which is right for most elements.
 
 ### A size of your own
 

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -16,12 +16,19 @@ One namespace per kind of thing, and no name in both:
   (`position`, `material`) — those are object properties, not CSS.
 
 `style` takes an object or a nested array, flattened left-to-right with
-falsy entries skipped. That is what replaces the cascade: precedence is
-written at the call site instead of resolved by specificity.
+falsy entries skipped. That is what replaces the **selector** cascade:
+precedence is written at the call site instead of resolved by specificity.
 
 ```jsx
 <box style={[s.card, isWide && s.wide, { backgroundColor: theme.panel }]} />
 ```
+
+Inheritance is a different thing and it does happen — see
+[Inheritance](#inheritance-the-ink-the-face-and-the-size) below. The two are
+easy to conflate because CSS ships them together: what is gone here is
+_matching a rule against a tree_; what remains is a handful of properties
+that travel down it, which is the part that makes a theme, a caption block
+or a dimmed row expressible at all.
 
 ## What it fixes on `<window>`
 
@@ -65,18 +72,19 @@ The thing inline CSS cannot do, and the reason people keep a stylesheet:
 />
 ```
 
-`:hover`, `:focus`, `:focus-visible`, `:active`, `:disabled`, `:drag-over`,
-`:dragging`.
+`:hover`, `:focus-within`, `:focus`, `:focus-visible`, `:active`,
+`:disabled`, `:drag-over`, `:dragging`.
 These are **node states, not selectors** — each is something the node itself
-already knows, so resolving them needs no cascade, no specificity and no
-tree walk. The event manager already tracks the hover path and the focused
-node; a state change now recomputes one node's style and repaints. **No
-React render.**
+already knows, so resolving them needs no specificity and no matching. The
+event manager already tracks the hover path, the press chain and the focused
+node; a state change recomputes one node's style and repaints. **No React
+render.**
 
-Precedence is fixed and low-to-high: `:hover` → `:focus` → `:focus-visible`
-→ `:active` → `:disabled` → `:drag-over` → `:dragging`, merged per property,
-so a disabled control never looks hovered, and a drag in progress outranks
-all of the pointer and focus states.
+Precedence is fixed and low-to-high: `:hover` → `:focus-within` → `:focus` →
+`:focus-visible` → `:active` → `:disabled` → `:drag-over` → `:dragging`,
+merged per property, so a disabled control never looks hovered, a node that
+is itself focused can say something narrower than one that merely contains
+focus, and a drag in progress outranks all of the pointer and focus states.
 Because the hover _path_ is the ancestor chain, hovering a child lights up an
 ancestor's `:hover` block, exactly like CSS.
 
@@ -119,6 +127,24 @@ CSS grew the distinction: the user knows where they clicked, and a ring on
 every click is noise, where a ring on Tab is the only cue a keyboard user
 has. Put focus rings in `:focus-visible` and colour changes that are welcome
 either way in `:focus`.
+
+`:focus-within` is focus on this node **or inside it** — CSS's, and the
+answer to "the row should light up while the field in it is being typed
+into", which is the one thing a node's own states cannot say. It is diffed
+over the focused node's ancestor chain, the same walk `:hover` uses, and a
+`<popup>` counts as inside the node it hangs off in the JSX tree, so a
+`Select` with its menu open still reads as focused.
+
+```jsx
+<box
+  style={{
+    borderColor: theme.border,
+    ':focus-within': { borderColor: theme.borderFocus },
+  }}
+>
+  <textinput value={value} onChange={setValue} />
+</box>
+```
 
 The last two belong to drag and drop. `:drag-over` follows the pointer
 during a drag on exactly the same ancestor-path rule as `:hover` — and,
@@ -288,6 +314,70 @@ to do with. Default `'wrap'`.
 
 `<Table>` sets it on every cell and header for that reason.
 
+## Inheritance: the ink, the face and the size
+
+Seven properties travel down the tree, and they are the ones CSS calls
+inherited:
+
+| property                |                                            |
+| ----------------------- | ------------------------------------------ |
+| `color`                 | the ink                                    |
+| `fontFamily`            | the face                                   |
+| `fontSize`              | the size                                   |
+| `fontWeight`            |                                            |
+| `fontStyle`             |                                            |
+| `fontVariationSettings` | a variable font's remaining axes           |
+| `textRendering`         | how glyph origins are rounded at draw time |
+
+So a block of quiet type is a `<box>` and not a decision repeated at every
+label inside it:
+
+```jsx
+<box style={{ color: theme.dim, fontSize: 12 }}>
+  <text>Last modified</text>
+  <text>{row.modified}</text>
+  <Icon name="clock" />
+</box>
+```
+
+A style property on the node itself still wins, the way a property always
+wins over what a node inherits — and under the outermost element is the
+palette, so text that names none of this is set in the theme's `text`,
+`fontFamily` and `fontSize` ([theme tokens](#theme-tokens) below).
+
+It reaches everything that draws with type, not just `<text>`: a
+`<textinput>`, a `<canvas mono>` (which is what an `<Icon>` is), an `<svg>`
+resolving `fill="currentColor"`, a `<tex>` formula, and any custom element
+that asks `node.resolvedTextStyle()`
+([extending.md](extending.md#text-of-your-own)). A nested `<text>` span is
+the same mechanism seen from closer up.
+
+**A `:hover` block that sets `color` therefore reaches the labels inside.**
+That is how CSS behaves and it is why there is no "group hover" here to
+learn: `:hover` marks the row, `color` is inherited, and the row's label and
+its icon follow.
+
+```jsx
+<box style={{ color: theme.text, ':hover': { color: theme.accent } }}>
+  <text>Open recent</text>
+  <Icon name="chevronRight" />
+</box>
+```
+
+Nothing about that costs a layout pass. A state block may only set paint
+properties and `color` (see above), so the only inherited property a pointer
+can ever move is the ink — which drops the memoised text layouts under it
+and repaints, with no re-measuring and no reflow. A `fontSize` change
+_does_ re-measure, and it can only come from a React commit, a size query or
+a theme.
+
+What does **not** inherit: `textAlign`, `lineHeight`, `textWrap` and
+`textBoxTrim`. CSS inherits the first two; here they are read by the node
+that owns the **box** the text flows in, and a box is not something a
+descendant has. `<Icon>`'s `size` does not inherit either — a glyph is a
+drawing rather than a letter, so it takes its default from the palette's
+`fontSize` and stays put when a label around it shrinks.
+
 ## `createStyles`
 
 Identity is the point — a hoisted style object lets `applyProps` skip the
@@ -355,7 +445,9 @@ well.
 Three of them are read with no `$` anywhere, because they are what text falls
 back to rather than something a style asked for: **`text`, `fontFamily` and
 `fontSize` are the ink, the face and the size of every `<text>` that names
-none of its own** ([components.md](components.md#theming)). That is what makes
+none of its own** ([components.md](components.md#theming)). They are the floor
+under [inheritance](#inheritance-the-ink-the-face-and-the-size) — what a node
+resolves to when no element above it named one either — which is what makes
 `<ThemeProvider value={{ fontFamily: 'Inter' }}>` a sentence an app says once.
 A style property still wins over it, the way a style property always wins over
 what a node inherits:
@@ -537,6 +629,17 @@ can be looked at without stopping the compositor for the whole session. See
 
 - **`':hover'`, not `_hover`.** The CSS spelling costs a pair of quotes and
   buys transfer from every other styling system.
+- **Inherited properties, no relational selectors.** `color` and the font
+  properties travel down the tree; nothing matches a rule against it. So
+  there is no `:hover > child`, no sibling combinator and no Tailwind-style
+  `group`. Each of those exists to move a value across the tree, and
+  inheritance already does it in the one direction that is cheap: a parent's
+  `:hover` reaches its children because `color` is inherited, and a child's
+  hover reaches its parents because the hover path is the ancestor chain.
+  What is left over — a **sibling** reacting to a sibling — stays in React,
+  where `useControl` already returns `hover`/`focused`/`pressed` as state
+  ([components.md](components.md#basic-controls)). `<Checkbox>` does exactly
+  that, because its well is a sibling of the label the press lands on.
 
 ## Elements that are not styled
 

--- a/src/a11y.js
+++ b/src/a11y.js
@@ -709,7 +709,7 @@ export function textStateOf(node) {
       selection: node._selection?.() ?? [0, 0],
     };
   }
-  const spans = node.collectSpans?.(node.inheritedTextStyle, []) ?? [];
+  const spans = node.collectSpans?.([]) ?? [];
   const chars = Array.from(spans.map((s) => s.text).join(''));
   return { chars, caret: 0, selection: [0, 0] };
 }

--- a/src/components/Icon.js
+++ b/src/components/Icon.js
@@ -265,30 +265,21 @@ export const iconSize = (fontSize) => Math.round(fontSize * 0.85);
  * <Icon name="check" size={10} color={theme.accentText} />
  * ```
  *
- * ## Colour and size do not cascade — pass them
+ * ## Colour inherits; size does not
  *
- * There is no cascade in this renderer: `style` precedence is written at the
- * call site (docs/styling.md), and a `color` or `fontSize` on an ancestor
- * `<box>` reaches nothing below it. So an icon inside a highlighted row does
- * **not** pick the row's ink up by itself, and neither does one inside a
- * `<text>` — it is a sibling element, not a span.
+ * `color` travels down the tree, so an icon inside a row that dims itself
+ * dims with it, and a `:hover` block that sets `color` on the row reaches
+ * the icon exactly as it reaches the row's label — the ink is an inherited
+ * property, and the state block changes it on the row (docs/styling.md).
+ * The `color` prop here is for saying something the surrounding text does
+ * not: a destructive action's mark, a check drawn on an accent fill.
  *
- * Two consequences worth knowing before reaching for one:
- *
- *  - `color` defaults to the palette's `text`, which *does* reach here,
- *    because `theme` is the one channel that walks the tree. A row that
- *    paints its label in `theme.hoverText` has to hand the icon the same
- *    colour explicitly — which is what every call site in core does, and
- *    what Menu's `icon({ color, size })` contract has always done.
- *  - `:hover` is resolved per node against the *ancestor* chain, so a
- *    hovered row lights up but its child icon does not. An icon that has to
- *    follow a hover follows it through React state, not through a style
- *    block.
- *
- * (Both of those are the current model rather than a settled verdict: a real
- * `color`/`fontSize` cascade is a live question, and if it lands, `color`
- * and `size` here become defaults that inheritance fills in rather than
- * things every call site repeats. Nothing in the set's shape would change.)
+ * **`size` does not inherit** and is deliberately not `fontSize`. A glyph is
+ * a drawing rather than a letter — it has no baseline to sit on and no
+ * ascent to be measured against — so it takes its default from the palette's
+ * `fontSize` (`iconSize`) rather than from whatever text happens to be
+ * around it, which keeps a chevron the same size in a row that shrank its
+ * label. Pass `size` for the one icon that has to be bigger.
  *
  * Everything else is a `<canvas>`: `style` merges last, and the rest of the
  * props go straight through, so a clickable icon is `<Icon onClick focusable/>`.
@@ -326,8 +317,12 @@ export function Icon({
     onDraw: draw,
     'aria-hidden': ariaHidden,
     ...canvasProps,
+    // No `color` unless the call site named one: leaving it off the style is
+    // what lets it inherit, where `color: theme.text` would pin every icon to
+    // the palette and undo the row it sits in.
     style: [
-      { width: px, height: px, flexShrink: 0, color: color ?? theme.text },
+      { width: px, height: px, flexShrink: 0 },
+      color ? { color } : null,
       style,
     ],
   });

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -270,11 +270,13 @@ function toggleMark(item) {
  */
 function gutterMark(item, { color, fontSize }) {
   const toggle = toggleMark(item);
-  if (toggle) return h(Icon, { name: toggle, size: MENU_ICON_SIZE, color });
+  // no `color` on the built-ins: the row names its ink and both of these
+  // inherit it, which is also what keeps them in step with `:active`
+  if (toggle) return h(Icon, { name: toggle, size: MENU_ICON_SIZE });
   const { icon } = item;
   if (icon == null) return null;
   if (typeof icon === 'string' || typeof icon === 'number') {
-    return h('text', { style: { color, fontSize } }, String(icon));
+    return h('text', { style: { fontSize } }, String(icon));
   }
   return typeof icon === 'function'
     ? icon({ color, size: MENU_ICON_SIZE })
@@ -323,6 +325,7 @@ function MenuRow({
   const dim = !isEnabled(item);
   const submenu = hasSubmenu(item);
   const accelerator = formatShortcut(item.shortcut);
+  const rowInk = dim ? theme.dim : active ? theme.hoverText : theme.text;
   if (process.env.NODE_ENV !== 'production') checkShortcut(item);
   return h(
     'box',
@@ -371,6 +374,10 @@ function MenuRow({
           : state === 'path'
             ? theme.surfaceActive
             : 'transparent',
+        // The row's ink, said once for the mark, the label, the accelerator
+        // and the submenu chevron — four elements that used to repeat this
+        // ternary and could each be forgotten separately.
+        color: rowInk,
         // the item is already highlighted by the time it can be pressed, so
         // the press is a further step down rather than a first one — without
         // it the command runs on the release out of a picture that never
@@ -383,37 +390,17 @@ function MenuRow({
     h(
       'box',
       { style: { width: MENU_GUTTER - MENU_ITEM_PAD, alignItems: 'center' } },
-      gutterMark(item, {
-        color: dim ? theme.dim : active ? theme.hoverText : theme.text,
-        fontSize,
-      }),
+      gutterMark(item, { color: rowInk, fontSize }),
     ),
-    h(
-      'text',
-      {
-        style: [
-          capTrim,
-          {
-            color: dim ? theme.dim : active ? theme.hoverText : theme.text,
-            fontSize: fontSize,
-          },
-        ],
-      },
-      item.label,
-    ),
+    h('text', { style: [capTrim, { fontSize }] }, item.label),
     h('box', { style: { flexGrow: 1 } }),
+    // The accelerator and the chevron are quieter than the label at rest and
+    // rise with the row when it is chosen — so on an active row they say
+    // nothing and take what the row set.
     accelerator &&
       h(
         'text',
-        {
-          style: [
-            capTrim,
-            {
-              color: dim ? theme.dim : active ? theme.hoverText : theme.dim,
-              fontSize: fontSize,
-            },
-          ],
-        },
+        { style: [capTrim, { fontSize }, !active && { color: theme.dim }] },
         accelerator,
       ),
     submenu &&
@@ -423,7 +410,7 @@ function MenuRow({
         // stands as tall as its box, so `MENU_ICON_SIZE` would put an arrow
         // beside the label taller than the label.
         size: capBand(fontSize),
-        color: dim ? theme.dim : active ? theme.hoverText : theme.dim,
+        style: !active && { color: theme.dim },
       }),
   );
 }
@@ -1187,6 +1174,8 @@ export function MenuBar({
               // keyboard user who cannot see where they are is exactly the
               // reader the ring exists for.
               outlineWidth: openIndex === index ? 0 : undefined,
+              // said once for whichever of the two the title turns out to be
+              color: barState === 'active' ? theme.hoverText : theme.text,
             },
             // Only while this menu is shut, as in `Select`: an open one is
             // already showing the answer, and a state block would outrank
@@ -1208,21 +1197,8 @@ export function MenuBar({
               // `icon`s. One drawing, every font, both colour schemes.
               name: 'moreVertical',
               size: iconSize(fontSize),
-              color: barState === 'active' ? theme.hoverText : theme.text,
             })
-          : h(
-              'text',
-              {
-                style: [
-                  capTrim,
-                  {
-                    color: barState === 'active' ? theme.hoverText : theme.text,
-                    fontSize: fontSize,
-                  },
-                ],
-              },
-              menu.label,
-            ),
+          : h('text', { style: [capTrim, { fontSize }] }, menu.label),
       );
     }),
     openIndex >= 0 &&

--- a/src/components/Tree.js
+++ b/src/components/Tree.js
@@ -234,6 +234,15 @@ export function Tree({
             {
               backgroundColor:
                 item.id === current ? theme.hoverBackground : 'transparent',
+              // The row's ink, said once. `color` inherits, so the label and
+              // the twisty both take it — a twisty that had to be handed the
+              // colour separately used to be the thing that stayed grey
+              // inside a highlighted row.
+              color: item.disabled
+                ? theme.dim
+                : item.id === current
+                  ? theme.hoverText
+                  : theme.text,
             },
             !item.disabled && {
               ':hover': {
@@ -272,20 +281,13 @@ export function Tree({
             h(Icon, {
               name: openSet.has(item.id) ? 'chevronDown' : 'chevronRight',
               size: TWISTY_SIZE,
-              // The row's ink, handed over: `:hover` marks the row and its
-              // ancestors, not its children, and colour does not cascade —
-              // so a twisty that did not take this would stay grey inside a
-              // highlighted row.
-              color: item.id === current ? theme.hoverText : theme.dim,
+              // dimmer than the label on an unselected row, and the row's own
+              // ink once it is selected — where "the row's own ink" is what
+              // inheritance gives it, with nothing said here
+              style: item.id === current ? null : { color: theme.dim },
             }),
         ),
-        labelContent(item.label, {
-          color: item.disabled
-            ? theme.dim
-            : item.id === current
-              ? theme.hoverText
-              : theme.text,
-        }),
+        labelContent(item.label),
       ),
     ),
   );

--- a/src/events.js
+++ b/src/events.js
@@ -140,6 +140,8 @@ export class EventManager {
     this._downDefaulted = false;
     this.capturedNode = null;
     this.focused = null;
+    // the focused node and its ancestors, which is what draws `:focus-within`
+    this.focusWithinPath = [];
     // what had focus before `focused`, so a focus scope opened by something
     // that focuses itself still knows where to hand focus back
     this._previousFocus = null;
@@ -710,7 +712,35 @@ export class EventManager {
       node.props.onFocus?.(this._makeEvent('focus', null, node));
       node.root?.invalidate(false, node, 'focus');
     }
+    this._updateFocusWithin(node);
     a11yHooks.focus?.(old, node);
+  }
+
+  /**
+   * Flip `:focus-within` over the focused node's ancestor chain, diffed the
+   * way hover and the press chain are.
+   *
+   * It is the answer to "this row should light up while the field inside it
+   * has focus", which is otherwise the one thing a state block cannot say —
+   * the field is a descendant, and the row has no state of its own to react
+   * to. Nothing relational is added by it: the chain is a walk up `parent`,
+   * the same one `Node.focusWithin` already reports, and a `<popup>` counts
+   * as inside the node it hangs off in the JSX tree, so a `Select` with its
+   * menu open still reads as focused.
+   */
+  _updateFocusWithin(node) {
+    const path = [];
+    for (let n = node; n; n = n.parent) path.push(n);
+    path.reverse();
+    const old = this.focusWithinPath;
+    const common = sharedPrefix(old, path);
+    for (let i = old.length - 1; i >= common; i--) {
+      if (!old[i].destroyed) old[i].setStyleState(':focus-within', false);
+    }
+    for (let i = common; i < path.length; i++) {
+      path[i].setStyleState(':focus-within', true);
+    }
+    this.focusWithinPath = path;
   }
 
   /**
@@ -848,5 +878,8 @@ export class EventManager {
     manager.popScope(node);
     if (manager.focused === node) manager.focused = null;
     if (manager._previousFocus === node) manager._previousFocus = null;
+    // the ancestors above a departing node keep `:focus-within` until focus
+    // actually moves, which is right — what must not survive is the node
+    manager.focusWithinPath = manager.focusWithinPath.filter((n) => n !== node);
   }
 }

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -8,8 +8,10 @@ import {
   paintPropsChanged,
   textStyleFrom,
   DEFAULT_TEXT_STYLE,
-  TEXT_LAYOUT_PROPS,
-  TEXT_PAINT_PROPS,
+  inheritedTextChanged,
+  localTextStyleChanged,
+  resolvedTextDelta,
+  TEXT_REMEASURE,
   flattenStyle,
   validateStyle,
   resolveStyleStates,
@@ -527,6 +529,16 @@ const warnedNoArgb = new WeakSet();
 // `borderRadius` on a non-uniform border warned about once (`_paintBorderSides`).
 let warnedSideRadius = false;
 
+/**
+ * Depth of the `_themeChanged` walk in progress, if any.
+ *
+ * That walk already visits every node in the subtree and re-resolves each
+ * one, so a style swap it performs on the way down must not kick off a
+ * second walk of the nodes it is about to reach anyway. Without the guard a
+ * theme change over a tree of token-using nodes is quadratic in its depth.
+ */
+let inThemeWalk = 0;
+
 // Frame timestamps for transitions. Indirected so tests can drive the clock
 // instead of sleeping through real animations.
 let now = () => Date.now();
@@ -541,46 +553,6 @@ export function setAnimationClock(fn) {
 let debugPaint = process.env.REACT_X11_DEBUG_PAINT || '';
 export function setDebugPaint(mode) {
   debugPaint = mode || '';
-}
-
-/**
- * Every text layout prop is a scalar and compares by value, except the one
- * that is a bag of axis coordinates. `fontVariationSettings` is written as
- * an object literal in a render, so a fresh one arrives on every commit and
- * `!==` would call it a change every time — re-shaping the paragraph and
- * re-rasterizing its glyphs to arrive at the same pixels. Small and flat, so
- * comparing it is cheaper than believing it.
- */
-function axesEqual(a, b) {
-  if (a === b) return true;
-  if (!a || !b) return false;
-  const keys = Object.keys(a);
-  if (keys.length !== Object.keys(b).length) return false;
-  for (const key of keys) {
-    if (a[key] !== b[key]) return false;
-  }
-  return true;
-}
-
-/** Did anything that only changes how the text is *drawn* change? */
-function textPaintStyleChanged(style, before) {
-  if (style === before) return false;
-  for (const key of TEXT_PAINT_PROPS) {
-    if (style[key] !== before[key]) return true;
-  }
-  return false;
-}
-
-/** Did anything the text stack measures or paints with change? */
-function textStyleChanged(style, before) {
-  if (style === before) return false;
-  if (style.color !== before.color) return true;
-  for (const key of TEXT_LAYOUT_PROPS) {
-    if (key === 'fontVariationSettings') {
-      if (!axesEqual(style[key], before[key])) return true;
-    } else if (style[key] !== before[key]) return true;
-  }
-  return false;
 }
 
 /**
@@ -1085,6 +1057,7 @@ export class Node {
     // node states that style blocks can react to, owned by EventManager
     this.states = {
       ':hover': false,
+      ':focus-within': false,
       ':focus': false,
       ':focus-visible': false,
       ':active': false,
@@ -1093,6 +1066,10 @@ export class Node {
     };
     // in-flight transitions: prop -> {from, to, start, duration}
     this._anim = null;
+    // `resolvedTextStyle()`'s cache: this node's own text style over what it
+    // inherits. Undefined means "never asked", which is load-bearing — see
+    // `_retext`
+    this._resolvedText = undefined;
     // hot pointer-path caches (issue #188): the children in paint order,
     // re-verified against the live children on every read, and the
     // subtree's hit reach, invalidated through _clearHitBounds()
@@ -1231,6 +1208,13 @@ export class Node {
     if (displayed.overflow !== this.style.overflow) {
       this._overflowChanged?.(displayed.overflow);
     }
+    // The same funnel is what keeps the text cascade honest: every route a
+    // new style arrives by — a commit, a `:hover`, a size query, a token —
+    // comes through here, so this is the one place that has to notice the
+    // ink or the face moving and push it into the subtree.
+    if (!inThemeWalk && inheritedTextChanged(this.style, displayed)) {
+      this._retextSubtree();
+    }
     return this.style;
   }
 
@@ -1263,6 +1247,11 @@ export class Node {
       // the author asked for that by transitioning one (docs/styling.md)
       if (this.root) this.root.needsLayout = true;
     }
+    // A tick writes `this.style` without going through `_retarget`, so it
+    // owes the cascade the same notice — and it is the only thing that owes
+    // it *per frame*: a transitioned `color` is a new ink every frame, for
+    // this node and for everything inheriting from it.
+    if (inheritedTextChanged(this.style, before)) this._retextSubtree();
     return this._anim.size > 0;
   }
 
@@ -1340,26 +1329,30 @@ export class Node {
   }
 
   /**
-   * The text style a node inherits when nothing named one — **the palette's**,
-   * not a set of constants.
+   * The text style this node inherits — **the enclosing element's**, and at
+   * the top of the tree the palette's.
    *
-   * The ink first: a `<text>` or a `<textinput>` that never mentions a colour
+   * The ink, the face and the size travel down the tree the way they do in
+   * CSS: `<box style={{ color: theme.dim, fontSize: 12 }}>` is how a caption
+   * block, a disabled row or a code panel is written, and it is what makes
+   * `color` on a row reach the row's label without the row handing it over.
+   * Only the properties in `INHERITED_TEXT_PROPS` travel; a style property on
+   * the node itself still wins, the way it always has.
+   *
+   * Under the last element is the palette, and that floor is not a set of
+   * constants either. The ink first: a `<text>` that never mentions a colour
    * has to be readable on the surface it is drawn on, and that surface
    * follows the desktop now. Black on `#1e2228` is invisible, which is the
-   * whole bug.
+   * whole bug. The face and the size for the same reason one step out — a
+   * theme names `fontFamily` and `fontSize` because it is describing the type
+   * this app sets, and the only way that can be true is if the text nobody
+   * styled follows them.
    *
-   * The face and the size for the same reason one step out. A theme names
-   * `fontFamily` and `fontSize` because it is describing the type this app
-   * sets, and the only way that can be true is if the text nobody styled
-   * follows them — otherwise `fontSize` is a token that moves the menu
-   * corners derived from it and not one letter, and `fontFamily` is a token
-   * with no reader at all.
-   *
-   * Cached per node so the object identity is stable while the palette is —
-   * the layouts below are keyed on style and a fresh base each call would
-   * miss the cache every time.
+   * A detached node has no parent yet and so resolves against the floor;
+   * `insertBefore` re-resolves the subtree against the real one.
    */
   get inheritedTextStyle() {
+    if (this.parent) return this.parent.resolvedTextStyle();
     const theme = this.theme;
     const color = theme.text;
     // A palette can reach a node as a bare `theme` **prop** rather than a
@@ -1372,6 +1365,57 @@ export class Node {
       this._textBase = { ...DEFAULT_TEXT_STYLE, color, family, size };
     }
     return this._textBase;
+  }
+
+  /**
+   * Re-resolve this node's text style and pay for what moved.
+   *
+   * The cache is dropped rather than patched, and the *values* decide what
+   * happens next: a node that names its own `color` and face absorbs an
+   * ancestor's change entirely, which is what lets `_retextSubtree` stop
+   * walking there. Returns the cost so it can.
+   *
+   * A node with no cached resolution has never been asked, and neither has
+   * anything below it — `inheritedTextStyle` fills every ancestor on the way
+   * up, so an empty cache here proves an empty cache in the whole subtree.
+   * That is the early-out that keeps a hover on one row from touching a
+   * window's worth of nodes.
+   */
+  _retext() {
+    const before = this._resolvedText;
+    if (before === undefined) return 0;
+    this._resolvedText = undefined;
+    const cost = resolvedTextDelta(before, this.resolvedTextStyle());
+    if (cost !== 0) this._textStyleMoved(cost);
+    return cost;
+  }
+
+  /** …and everything under it, stopping wherever the answer did not change. */
+  _retextSubtree() {
+    if (this._retext() === 0) return;
+    for (const child of this.children) child._retextSubtree();
+  }
+
+  /**
+   * This node's resolved text style moved — because its own style did, or
+   * because an ancestor's did and it inherited the change.
+   *
+   * `TEXT_REMEASURE` means a glyph can have moved and the box has to be
+   * measured again; `TEXT_REPAINT` means only the ink or the glyph rounding
+   * did, so the cached layout still has to go — the value rides on the spans
+   * inside it — but nothing reflows. Keeping those apart is the whole reason
+   * a `:hover { color }` costs a repaint rather than a layout pass.
+   *
+   * The default serves any element that draws text: re-measure if it has a
+   * size of its own, repaint otherwise. Elements that draw no text override
+   * it away.
+   */
+  _textStyleMoved(cost) {
+    if (cost === TEXT_REMEASURE && this._measureFn) {
+      this.invalidateMeasure('text');
+    } else {
+      this.root?.invalidate(false, this, 'text');
+    }
   }
 
   /**
@@ -1402,8 +1446,11 @@ export class Node {
   _sizeQueriesChanged() {
     if (!(this._queried || this._supportsQueried) || this.destroyed) return;
     const before = this.style;
+    // a query block may name `fontSize`, and `_syncStyle` → `_retarget` is
+    // what pushes that into the subtree; only the node-local text props are
+    // left to notice here
     this._syncStyle(this.props);
-    if (textStyleChanged(this.style, before)) this._textContentChanged();
+    if (localTextStyleChanged(this.style, before)) this._textContentChanged();
     if (this.yoga && this.style !== before) {
       applyLayoutStyle(this.yoga, this.style, before);
     }
@@ -1412,35 +1459,37 @@ export class Node {
   /** The theme above or on this node changed: drop the caches and restyle
    * the subtree, since a token can appear at any depth. */
   _themeChanged() {
-    // The base this node's unstyled text was last shaped against, by
-    // identity: `inheritedTextStyle` only builds a new one when a value it
-    // reads actually moved, so `!==` afterwards is exact.
-    const wasType = this._textBase;
-    this._theme = undefined;
-    // A `<window>` with no `backgroundColor` of its own follows the palette,
-    // and the server's copy of that colour has to follow with it — otherwise
-    // the next resize fills the new area in the old scheme.
-    if (this.isWindow) this._syncWindowBackground();
-    // The inherited ink, face and size are in no style object, so
-    // `_usesTokens` does not see them move — but a cached layout carries the
-    // colour *and the font* it was shaped with, and would keep painting them.
-    // A theme swap that only changes `fontFamily` is the case that made this
-    // worth widening: nothing else about the node changes, so nothing else
-    // would have dropped the layout.
-    if (wasType !== undefined && this.inheritedTextStyle !== wasType) {
-      this._textContentChanged();
-      this.root?.invalidate(true, null, 'theme');
+    // This walk visits every node itself, so the per-node re-resolution below
+    // is enough — a style swap it causes must not start a second walk of the
+    // same subtree from halfway down.
+    inThemeWalk++;
+    try {
+      this._theme = undefined;
+      // A `<window>` with no `backgroundColor` of its own follows the palette,
+      // and the server's copy of that colour has to follow with it — otherwise
+      // the next resize fills the new area in the old scheme.
+      if (this.isWindow) this._syncWindowBackground();
+      if (this._usesTokens) {
+        const before = this.style;
+        this._syncStyle(this.props);
+        // a token change reaches the node without React re-rendering it, so
+        // the invalidation a commit would have done has to happen here too
+        if (localTextStyleChanged(this.style, before)) {
+          this._textContentChanged();
+        }
+        this.root?.invalidate(true, null, 'theme');
+      }
+      // The palette is the floor under the cascade, so a theme swap moves the
+      // resolved style of every node that named none of its own — and none of
+      // that is in a style object, so nothing above would have noticed. A
+      // swap that only changes `fontFamily` is the case that made this worth
+      // having: nothing else about the node changes, and a cached layout
+      // carries the face it was shaped with.
+      if (this._retext() !== 0) this.root?.invalidate(true, null, 'theme');
+      for (const child of this.children) child._themeChanged();
+    } finally {
+      inThemeWalk--;
     }
-    if (this._usesTokens) {
-      const before = this.style;
-      this._syncStyle(this.props);
-      // a token change reaches the node without React re-rendering it, so
-      // the invalidation TextNode.applyProps would have done has to happen
-      // here too — otherwise the cached layout keeps painting the old colour
-      if (textStyleChanged(this.style, before)) this._textContentChanged();
-      this.root?.invalidate(true, null, 'theme');
-    }
-    for (const child of this.children) child._themeChanged();
   }
 
   /**
@@ -2303,9 +2352,18 @@ export class Node {
    * way rather than the style vocabulary's (`family`, not `fontFamily`;
    * `variations`, not `fontVariationSettings`), which is a mapping worth
    * having in one place instead of vendored per element.
+   *
+   * **Cached**, and the cache is the cascade's spine: asking here fills every
+   * ancestor's on the way up, which is what lets an invalidation walk stop at
+   * a node that never resolved (`_retext`). Everything that can move the
+   * answer drops it — a style swap (`_retarget`), an animation tick, a theme
+   * change, an attach — so an element may keep reading it at paint time.
    */
   resolvedTextStyle() {
-    return textStyleFrom(this.style, this.inheritedTextStyle);
+    return (this._resolvedText ??= textStyleFrom(
+      this.style,
+      this.inheritedTextStyle,
+    ));
   }
 
   paint(ctx) {
@@ -2733,38 +2791,73 @@ export class TextNode extends Node {
     this._layouts.clear();
   }
 
+  /** The node that owns the box this text flows in. A span has none of its
+   * own, so its geometry — and its damage — belong to the nearest ancestor
+   * with a yoga node. */
+  _textBoxOwner() {
+    let owner = this;
+    while (owner && !owner.yoga) owner = owner.parent;
+    return owner;
+  }
+
+  /**
+   * The type this text is set in moved, from its own style or from an
+   * ancestor's. The two costs differ by a layout pass.
+   *
+   * A re-measure has to *ask* for one. None of `fontSize`, `fontWeight`,
+   * `fontFamily` or `fontStyle` is a yoga property, so `applyLayoutStyle`
+   * sees nothing move, and none is a paint prop either, so the node
+   * contributes no damage — the frame is already decided by the time the
+   * layout is dropped. They are all inputs to the *measure function*, and the
+   * dirty flag `_textContentChanged` sets is only read by a layout pass:
+   * without asking for one the cleared layout is never rebuilt and the old
+   * glyphs stay on screen with nothing reporting an error.
+   */
+  _textStyleMoved(cost) {
+    const owner = this._textBoxOwner();
+    if (cost === TEXT_REMEASURE) {
+      this._textContentChanged();
+      if (owner) owner._invalidateLayout('text');
+      else this.root?.invalidate(true, null, 'text');
+      return;
+    }
+    // Only the ink or the glyph rounding. Both ride on the spans inside the
+    // cached layout, so it still has to go — but the box cannot have moved,
+    // and `false` here is the whole point: this is the path a `:hover`
+    // arrives by, once per pointer move, and a transitioned colour by, once
+    // per frame.
+    this._textPaintChanged();
+    this.root?.invalidate(false, owner ?? NO_DAMAGE, 'text');
+  }
+
   applyProps(newProps, oldProps) {
     const before = this.style;
     super.applyProps(newProps, oldProps);
-    if (!textStyleChanged(this.style, before)) {
-      if (!textPaintStyleChanged(this.style, before)) return;
-      this._textPaintChanged();
-      // damage belongs to the node that owns the box; a span has none of its
-      // own. `false` is the whole point of this branch — no layout pass.
-      let owner = this;
-      while (owner && !owner.yoga) owner = owner.parent;
-      this.root?.invalidate(false, owner ?? NO_DAMAGE, 'text');
-      return;
-    }
+    // The inherited half of the text style — the face, the size, the ink —
+    // travels through `_retarget` and lands in `_textStyleMoved`, whichever
+    // route it arrived by. What is left here is what only this node's own box
+    // cares about: how its lines are aligned, how tall they are, whether they
+    // wrap at all.
+    if (!localTextStyleChanged(this.style, before)) return;
     this._textContentChanged();
-    // `super.applyProps` has already committed this frame, and it decided
-    // there was nothing to re-lay-out: none of `fontSize`, `fontWeight`,
-    // `fontFamily`, `fontStyle`, `lineHeight` or `textAlign` is a yoga
-    // property, so `applyLayoutStyle` saw nothing move, and none of them is
-    // a paint prop either, so the node contributed no damage. They are all
-    // inputs to the *measure function*, though — the dirty flag
-    // `_textContentChanged` just set is only read by a layout pass, and
-    // without asking for one the cleared layout is never rebuilt and the
-    // old glyphs stay on screen. A new string reaches the same conclusion
-    // through `TextChunkNode.setText`; this is that path for a new style.
-    let owner = this;
-    while (owner && !owner.yoga) owner = owner.parent;
+    const owner = this._textBoxOwner();
     if (owner) owner._invalidateLayout('text');
     else this.root?.invalidate(true, null, 'text');
   }
 
-  collectSpans(inherited, out) {
-    const style = textStyleFrom(this.style, inherited);
+  /**
+   * The paragraph as a flat run list: one entry per chunk of text, carrying
+   * the style resolved where that chunk is written.
+   *
+   * A nested `<text>` is a span, and it inherits from the `<text>` around it
+   * by the same mechanism a `<text>` inherits from the `<box>` around it —
+   * `resolvedTextStyle()` walks the parents either way, so a span needs no
+   * inheritance rule of its own. It also has to *ask*, rather than be handed
+   * the answer: filling the cache here is what makes `:hover` on a span work,
+   * since an unresolved node is one `_retext` skips.
+   */
+  collectSpans(out) {
+    const style = this.resolvedTextStyle();
     for (const child of this.children) {
       if (child.kind === 'textchunk') {
         out.push({
@@ -2778,7 +2871,7 @@ export class TextNode extends Node {
           color: style.color,
         });
       } else if (child.kind === 'text') {
-        child.collectSpans(style, out);
+        child.collectSpans(out);
       }
     }
     return out;
@@ -2806,7 +2899,7 @@ export class TextNode extends Node {
     const key = String(maxWidth);
     let layout = this._layouts.get(key);
     if (!layout) {
-      const spans = this.collectSpans(this.inheritedTextStyle, []);
+      const spans = this.collectSpans([]);
       const base = this.resolvedTextStyle();
       layout = fonts.layout(spans, base, {
         maxWidth: Number.isFinite(maxWidth) ? maxWidth : undefined,
@@ -3482,6 +3575,13 @@ export class BoxNode extends Scrollable(Node) {
   constructor(props, app) {
     super('box', props, app);
   }
+
+  /** A box draws a fill and a border and no text at all, so a new ink or a
+   * new face costs it nothing — it is only ever the *source* of one. The
+   * nodes inside it claim their own damage as the walk reaches them, which
+   * keeps hovering a long list bounded to the labels rather than to the
+   * list. */
+  _textStyleMoved() {}
 }
 
 /** Escape hatch: a retained node whose content is painted by props.onDraw. */
@@ -3506,12 +3606,14 @@ export class CanvasNode extends Node {
   }
 
   /**
-   * The ink a `mono` drawing is painted in: the node's own `color`, falling
-   * back to the palette's, exactly as `<text>` and `<svg>` resolve theirs.
-   * There is no cascade from an ancestor `<box>` — see the note on `mono`.
+   * The ink a `mono` drawing is painted in: the node's own `color`, then what
+   * it inherits, then the palette's — exactly as `<text>` and `<svg>` resolve
+   * theirs, because it is literally the same resolution. An `<Icon>` in a
+   * row that dims itself dims with it, with nothing handed over at the call
+   * site.
    */
   _monoColor() {
-    return this.style.color ?? this.theme.text;
+    return this.resolvedTextStyle().color;
   }
 
   /** Preset the ink a `mono` drawing inherits, so `onDraw` never names a
@@ -4652,11 +4754,10 @@ export class TextInputNode extends Node {
     this._caret = Math.min(this._caret, len);
     this._anchor = Math.min(this._anchor, len);
     this._noteExternalValue();
-    let metricsChanged = false;
-    for (const key of TEXT_LAYOUT_PROPS) {
-      if (this.style[key] !== beforeStyle[key]) metricsChanged = true;
-    }
-    if (metricsChanged) {
+    // The face and the size arrive through `_textStyleMoved`, whether they
+    // came from this commit or from an ancestor; what is left here is the
+    // node-local half of the text vocabulary.
+    if (localTextStyleChanged(this.style, beforeStyle)) {
       this.invalidateMeasure('props');
     } else if (newProps.value !== before.value) {
       // painting clips to the content box and the measure function reads
@@ -5625,6 +5726,10 @@ export class WindowNode extends Scrollable(Node) {
   _windowBackground() {
     return this.style.backgroundColor || this.theme.background;
   }
+
+  /** Like a `<box>`: a window fills and never letters, so it is the top of
+   * the cascade rather than a reader of it. */
+  _textStyleMoved() {}
 
   /**
    * Keep the server's idea of the background in step with ours. Called when

--- a/src/richnodes.js
+++ b/src/richnodes.js
@@ -6,7 +6,7 @@
 import { MarkdownView, HtmlView, SvgView, layoutTex } from 'ntk';
 
 import { Node, intrinsicSize } from './nodes.js';
-import { isLayoutProp, isPaintProp, DEFAULT_TEXT_STYLE } from './styles.js';
+import { isLayoutProp, isPaintProp } from './styles.js';
 
 /** Joined text of string children (react-markdown style), or null when the
  * element has none — then the `source` prop is the content. */
@@ -78,6 +78,11 @@ class DocumentViewNode extends Node {
     if (this.view) this._setSource(this.view);
     this._contentInvalidated();
   }
+
+  /** A document sets its own type — headings, code, body, all decided by the
+   * widget's `theme` prop — so the enclosing element's ink and face are not
+   * something it reads, and a change in them costs it nothing. */
+  _textStyleMoved() {}
 
   _layoutAt(width) {
     if (this._laidOutWidth !== width) {
@@ -372,9 +377,17 @@ export class SvgNode extends Node {
     });
   }
 
-  /** What `fill="currentColor"` resolves to here. */
+  /**
+   * What `fill="currentColor"` resolves to here.
+   *
+   * The node's own `color`, then what it inherits, then the palette's — the
+   * same resolution `<text>` and `<canvas mono>` use, and it has to be, or
+   * `currentColor` means something different depending on which element is
+   * drawing. It used to stop at a hardcoded black, which is invisible on a
+   * dark desktop and does not follow a `<box style={{ color }}>` either.
+   */
   _currentColor() {
-    return this.style.color ?? DEFAULT_TEXT_STYLE.color;
+    return this.resolvedTextStyle().color;
   }
 
   /**
@@ -465,13 +478,13 @@ export class SvgNode extends Node {
 }
 
 /**
- * A formula's ink, which is the palette's text colour unless the style names
- * one. It used to be a fixed `#222222` — a shade darker than the prose around
- * it, so a formula read as a figure. That cannot survive a palette that
- * follows the desktop: `#222222` on a dark background is invisible, and
+ * A formula's ink, which is the ink of the text around it unless the style
+ * names one. It used to be a fixed `#222222` — a shade darker than the prose
+ * beside it, so a formula read as a figure. That cannot survive a palette
+ * that follows the desktop: `#222222` on a dark background is invisible, and
  * stepping past `text` to keep the contrast lands on black on a light one.
  */
-const texColor = (node) => node.style.color ?? node.theme.text;
+const texColor = (node) => node.resolvedTextStyle().color;
 
 /**
  * <tex source displayMode size>: a KaTeX formula via ntk layoutTex.

--- a/src/styles.js
+++ b/src/styles.js
@@ -187,6 +187,112 @@ export const TEXT_LAYOUT_PROPS = new Set([
  */
 export const TEXT_PAINT_PROPS = new Set(['textRendering']);
 
+/**
+ * The text properties that **inherit** — the ones a node hands down to
+ * everything drawing text inside it, so `<box style={{ color: theme.dim }}>`
+ * dims the labels under it the way it would in CSS.
+ *
+ * This is CSS's inherited set narrowed to what a *descendant* can act on: the
+ * face, the size, the ink and the glyph rounding. `textAlign`, `lineHeight`,
+ * `textWrap` and `textBoxTrim` stay out even though CSS inherits the first
+ * two — here they are read by the node that owns the **box** the text flows
+ * in, and a box is not something a descendant has. A `<box>` that wants its
+ * children aligned says so in the styles it gives them.
+ */
+export const INHERITED_TEXT_PROPS = new Set([
+  'fontFamily',
+  'fontSize',
+  'fontWeight',
+  'fontStyle',
+  'fontVariationSettings',
+  'textRendering',
+  'color',
+]);
+
+/**
+ * The text props that do **not** inherit — `TEXT_LAYOUT_PROPS` minus
+ * `INHERITED_TEXT_PROPS`. They shape the box a node's own text flows in, so
+ * no cascade can bring one in from above and the node that owns them is the
+ * only one that has to react.
+ */
+export const LOCAL_TEXT_PROPS = new Set(
+  [...TEXT_LAYOUT_PROPS].filter((key) => !INHERITED_TEXT_PROPS.has(key)),
+);
+
+/** Did anything that shapes this node's own text box change? */
+export function localTextStyleChanged(style, before) {
+  if (style === before) return false;
+  for (const key of LOCAL_TEXT_PROPS) {
+    if (style[key] !== before[key]) return true;
+  }
+  return false;
+}
+
+/** Did anything a descendant inherits change between two style bags? The
+ * gate on re-resolving a subtree, so a commit that moved `padding` walks
+ * nothing. */
+export function inheritedTextChanged(style, before) {
+  if (style === before) return false;
+  for (const key of INHERITED_TEXT_PROPS) {
+    if (key === 'fontVariationSettings') {
+      if (!axesEqual(style[key], before[key])) return true;
+    } else if (style[key] !== before[key]) return true;
+  }
+  return false;
+}
+
+/** What a change in resolved text style costs the node that draws with it:
+ * a glyph may have moved. */
+export const TEXT_REMEASURE = 2;
+/** …or only the ink or the rounding did, so the box cannot have changed. */
+export const TEXT_REPAINT = 1;
+
+/**
+ * Compare two **resolved** text styles (`textStyleFrom`'s shape, which is
+ * ntk's) and price the difference.
+ *
+ * The split is what keeps a colour cascade off the layout path: `color` and
+ * `textRendering` ride on the spans inside a cached layout, so the layout
+ * still has to go — but neither moves a glyph, so nothing needs measuring
+ * again. Conflating the two is why `:hover { color }` used to be able to
+ * cost a full layout pass per pointer move.
+ */
+export function resolvedTextDelta(a, b) {
+  if (a === b) return 0;
+  if (
+    a.family !== b.family ||
+    a.size !== b.size ||
+    a.weight !== b.weight ||
+    a.style !== b.style ||
+    !axesEqual(a.variations, b.variations)
+  ) {
+    return TEXT_REMEASURE;
+  }
+  if (a.color !== b.color || a.textRendering !== b.textRendering) {
+    return TEXT_REPAINT;
+  }
+  return 0;
+}
+
+/**
+ * Every text layout prop is a scalar and compares by value, except the one
+ * that is a bag of axis coordinates. `fontVariationSettings` is written as
+ * an object literal in a render, so a fresh one arrives on every commit and
+ * `!==` would call it a change every time — re-shaping the paragraph and
+ * re-rasterizing its glyphs to arrive at the same pixels. Small and flat, so
+ * comparing it is cheaper than believing it.
+ */
+export function axesEqual(a, b) {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  const keys = Object.keys(a);
+  if (keys.length !== Object.keys(b).length) return false;
+  for (const key of keys) {
+    if (a[key] !== b[key]) return false;
+  }
+  return true;
+}
+
 export const isLayoutProp = (name) =>
   Object.prototype.hasOwnProperty.call(LAYOUT_APPLIERS, name);
 export const isPaintProp = (name) => PAINT_PROPS.has(name);
@@ -195,12 +301,25 @@ export const isEventProp = (name) => /^on[A-Z]/.test(name);
 /**
  * State blocks, lowest precedence first. These are *node* states, not
  * selectors: each one is something the node itself knows about, so
- * resolving them needs no cascade, no specificity and no tree walk.
- * Anything relational (`:hover > child`, `:focus-within`, `:nth-child`)
- * stays in React, where composition already answers it.
+ * resolving them needs no specificity and no matching. Anything relational
+ * — `:hover > child`, a sibling selector, `:nth-child` — stays in React,
+ * where composition already answers it.
+ *
+ * The two that read as relational are not. `:hover` and `:active` mark the
+ * whole ancestor chain because the node the pointer actually landed on is
+ * whatever the control happens to be built out of, and `:focus-within` is
+ * the same fact about the focus path — each of them is still "something
+ * true of this node", diffed over a path the event manager has already
+ * computed. What a child does about an ancestor's state is inheritance
+ * rather than a selector: a `:hover` block that sets `color` reaches the
+ * labels inside, the way it does in CSS.
  */
 export const STATE_KEYS = [
   ':hover',
+  // Focus is on this node or inside it — CSS's `:focus-within`. Below
+  // `:focus` on purpose: it is the broader fact, so a node that is itself
+  // focused should be able to say something narrower and win.
+  ':focus-within',
   ':focus',
   // Focus that came from the keyboard rather than from a press — CSS's
   // `:focus-visible`, and for the same reason: a ring on every click is

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -209,8 +209,9 @@ export interface IconProps extends Omit<CanvasProps, 'onDraw' | 'cacheKey'> {
    * way. Default: a shade under the palette's `fontSize`.
    */
   size?: number;
-  /** Default: the palette's `text`. Colour does not cascade — a widget that
-   *  paints its label in another ink hands the icon the same one. */
+  /** Default: the ink of the element around it, and under that the palette's
+   *  `text` — `color` inherits, so an icon in a row that dims itself dims
+   *  with it. Pass this only to say something the surrounding text does not. */
   color?: Color;
   style?: StyleProp;
 }

--- a/src/types/style.d.ts
+++ b/src/types/style.d.ts
@@ -241,6 +241,11 @@ export type SizeQuery = `@${'width' | 'height'} ${string}`;
 export interface StyleBlocks {
   transition?: Transition;
   ':hover'?: StateStyle;
+  /** Set while focus is on this node **or inside it** — CSS's
+   * `:focus-within`, and the way a row highlights while the field in it is
+   * being typed into. Lower precedence than `:focus`, which is the narrower
+   * statement. */
+  ':focus-within'?: StateStyle;
   ':focus'?: StateStyle;
   /** Focus that arrived from the keyboard rather than from a press — CSS's
    * `:focus-visible`. This is where a focus ring belongs: a ring on every
@@ -265,8 +270,10 @@ export type Style = StyleProperties &
 
 /**
  * What a `style` prop accepts: an object, or a nested array of them with
- * falsy entries skipped and later entries winning. This is what replaces
- * the cascade — precedence is written at the call site.
+ * falsy entries skipped and later entries winning. This is what replaces the
+ * *selector* cascade — precedence is written at the call site rather than
+ * resolved by specificity. Inheritance is a separate thing and does happen:
+ * the ink, the face and the size travel down the tree (`INHERITED_TEXT_PROPS`).
  */
 export type StyleProp = Style | false | null | undefined | readonly StyleProp[];
 

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -1680,16 +1680,9 @@ test('text spans collect nested styles', async () => {
   );
 
   const textNode = app.windows[0]._reactX11Node.children[0];
-  const spans = textNode.collectSpans(
-    {
-      family: 'sans-serif',
-      size: 14,
-      weight: 'normal',
-      style: 'normal',
-      color: 'black',
-    },
-    [],
-  );
+  // no base to hand over: a span inherits from the <text> around it through
+  // the same cascade a <text> inherits from the <box> around it
+  const spans = textNode.collectSpans([]);
   assert.strictEqual(spans.length, 2);
   assert.deepStrictEqual(
     [spans[0].text, spans[0].size, spans[0].color],

--- a/test/style.test.js
+++ b/test/style.test.js
@@ -215,6 +215,80 @@ test(':active follows the press, :disabled wins over :hover', async () => {
   await x11Root.unmount();
 });
 
+test(':focus-within lights the ancestors of whatever has focus', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const field = React.createRef();
+  x11Root.render(
+    h(
+      'window',
+      { width: 200, height: 100 },
+      h(
+        'box',
+        {
+          style: {
+            backgroundColor: 'white',
+            ':focus-within': { backgroundColor: 'yellow' },
+            // narrower than the row's, and only true of the field itself
+            ':focus': { backgroundColor: 'green' },
+          },
+        },
+        h('textinput', { ref: field, style: { height: 20 } }),
+      ),
+    ),
+  );
+  await tick();
+  const row = nodeOf(app).children[0];
+  assert.strictEqual(row.style.backgroundColor, 'white');
+
+  field.current.focus();
+  assert.strictEqual(
+    row.style.backgroundColor,
+    'yellow',
+    'the row follows focus landing inside it',
+  );
+  assert.strictEqual(
+    field.current.style.backgroundColor,
+    undefined,
+    'and the field is not styled by the row',
+  );
+
+  field.current.blur();
+  assert.strictEqual(row.style.backgroundColor, 'white', 'and gives it back');
+
+  await x11Root.unmount();
+});
+
+test(':focus is narrower than :focus-within, so it wins', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const box = React.createRef();
+  x11Root.render(
+    h(
+      'window',
+      { width: 200, height: 100 },
+      h('box', {
+        ref: box,
+        focusable: true,
+        style: {
+          backgroundColor: 'white',
+          ':focus-within': { backgroundColor: 'yellow' },
+          ':focus': { backgroundColor: 'green' },
+        },
+      }),
+    ),
+  );
+  await tick();
+  box.current.focus();
+  assert.strictEqual(
+    box.current.style.backgroundColor,
+    'green',
+    'a node with focus is also within itself, and the narrower block wins',
+  );
+
+  await x11Root.unmount();
+});
+
 test('<window>: width/height are the X window, style is the root box', async () => {
   const app = createMockApp();
   const x11Root = await createRoot({ app });
@@ -899,6 +973,12 @@ test('a token change invalidates cached text, not just the style object', async 
   render(THEME);
   await tick();
   const text = nodeOf(app).children[0].children[0];
+  // What a paint would do, and the reason the invalidation walk is allowed to
+  // stop at a node that has never resolved: the only thing that fills
+  // `_layouts` is `_layoutFor`, which asks for the resolved text style first.
+  // The mock app has no font manager, so `_layoutFor` bails before it gets
+  // there and the two halves have to be staged by hand.
+  text.resolvedTextStyle();
   text._layouts.set('stale', { width: 1, height: 1 });
 
   // the <text> element's own props do not change — only the theme above it —

--- a/test/text-cascade.test.js
+++ b/test/text-cascade.test.js
@@ -1,0 +1,389 @@
+// The text cascade: the ink, the face and the size travel down the tree.
+//
+// Three things are verified here as pixels, against node-x11's in-process X
+// server and a real font, because every one of them is a bug that survives
+// every assertion about styles and layout — the resolved style is right, the
+// node is damaged, a frame is painted, and the glyphs on the screen are the
+// old ones.
+//
+//   * a `:hover` (or `:focus`, or `:active`) block that sets `color` on a
+//     `<text>` repaints it. The memoised `TextLayout` carries the span
+//     colours it was built with, and `setStyleState` used to swap the style
+//     without dropping it;
+//   * a `transition` on a `color` reaches the new ink. Same cause, through
+//     the animation tick, and worse — it never arrived at all, not even at
+//     the end of the transition;
+//   * `color` and `fontSize` on an enclosing element reach the text inside
+//     it, and a `:hover` on a row therefore reaches the row's label, which
+//     is what CSS does and what makes `group-hover` unnecessary.
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { test } from 'node:test';
+import React from 'react';
+
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient, StaticFontSource } from 'ntk';
+
+import { createRoot } from '../src/index.js';
+import { setAnimationClock } from '../src/nodes.js';
+
+const require = createRequire(import.meta.url);
+const fontDir = join(
+  dirname(require.resolve('katex/package.json')),
+  'dist',
+  'fonts',
+);
+
+const W = 240;
+const H = 120;
+
+async function headlessApp() {
+  const server = xserver.createServer({ width: 400, height: 400 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const fontSource = new StaticFontSource();
+  const add = (file, opts) =>
+    fontSource.add(readFileSync(join(fontDir, file)), {
+      family: 'Test Main',
+      ...opts,
+    });
+  add('KaTeX_Main-Regular.ttf', { weight: 400 });
+  add('KaTeX_Main-Bold.ttf', { weight: 700 });
+  fontSource.alias('sans-serif', 'Test Main');
+  return createClient({ stream: clientEnd, fontSource });
+}
+
+const settled = (app) =>
+  new Promise((resolve, reject) =>
+    app.X.GetInputFocus((err) => (err ? reject(err) : resolve())),
+  );
+
+/**
+ * How many pixels of each ink the window holds. `getImageData` speaks RGBA
+ * (ntk >= 5.3), and the two inks are picked far enough apart that antialiased
+ * edges land in neither bucket.
+ */
+function inks(image) {
+  let red = 0;
+  let black = 0;
+  for (let i = 0; i < image.data.length; i += 4) {
+    const [r, g, b] = [image.data[i], image.data[i + 1], image.data[i + 2]];
+    if (r > 150 && g < 90 && b < 90) red++;
+    else if (r < 90 && g < 90 && b < 90) black++;
+  }
+  return { red, black };
+}
+
+/** Mount, paint the frame it asked for, and hand back a reader. */
+async function mount(app, element) {
+  const x11Root = await createRoot({ app });
+  const instance = await new Promise((resolve) =>
+    x11Root.render(element, resolve),
+  );
+  const root = instance._reactX11Node;
+  const ctx = (root._ctx ??= root.window.getContext('2d'));
+  const read = async () => {
+    root._scheduled = false;
+    root.flush();
+    await settled(app);
+    return inks(
+      await new Promise((resolve, reject) =>
+        ctx.getImageData(0, 0, W, H, (err, d) =>
+          err ? reject(err) : resolve(d),
+        ),
+      ),
+    );
+  };
+  return {
+    root,
+    read,
+    render: (el) => new Promise((r) => x11Root.render(el, r)),
+  };
+}
+
+const h = React.createElement;
+
+/** A window with one `<text>`, wrapped in whatever `wrap` builds. */
+const scene = (textStyle, boxStyle, refs = {}) =>
+  h(
+    'window',
+    { width: W, height: H, style: { backgroundColor: '#ffffff' } },
+    h(
+      'box',
+      { ref: refs.box, style: { alignSelf: 'flex-start', ...boxStyle } },
+      h(
+        'text',
+        { ref: refs.text, style: { fontSize: 24, ...textStyle } },
+        'Handgloves',
+      ),
+    ),
+  );
+
+const RED = '#ff0000';
+const BLACK = '#000000';
+
+test(':hover { color } on a <text> repaints it in the new ink', async () => {
+  const app = await headlessApp();
+  try {
+    const refs = { text: React.createRef() };
+    const { read } = await mount(
+      app,
+      scene({ color: BLACK, ':hover': { color: RED } }, null, refs),
+    );
+    const resting = await read();
+    assert.ok(resting.black > 200 && resting.red === 0, 'resting is black');
+
+    refs.text.current.setStyleState(':hover', true);
+    const hovered = await read();
+    assert.ok(
+      hovered.red > 200 && hovered.black === 0,
+      `hovering should repaint the glyphs red, got ${JSON.stringify(hovered)}`,
+    );
+
+    refs.text.current.setStyleState(':hover', false);
+    const left = await read();
+    assert.ok(
+      left.black > 200 && left.red === 0,
+      `leaving should put it back, got ${JSON.stringify(left)}`,
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test('a state block that only changes the ink does not reflow', async () => {
+  const app = await headlessApp();
+  try {
+    const refs = { text: React.createRef() };
+    const { read } = await mount(
+      app,
+      scene({ color: BLACK, ':hover': { color: RED } }, null, refs),
+    );
+    await read();
+    const text = refs.text.current;
+    const before = { ...text.abs };
+    // the box is the measured text (`alignSelf: 'flex-start'`), so a width
+    // that survives is evidence the measure function was not re-run — the
+    // whole reason `color` is priced apart from the face and the size
+    let measures = 0;
+    const measureContent = text.measureContent.bind(text);
+    text.measureContent = (c) => {
+      measures++;
+      return measureContent(c);
+    };
+    text.setStyleState(':hover', true);
+    await read();
+    assert.strictEqual(measures, 0, 'a new ink must not re-measure the text');
+    assert.deepStrictEqual({ ...text.abs }, before, 'and must not move it');
+  } finally {
+    await app.close();
+  }
+});
+
+test('a transitioned colour reaches the new ink', async () => {
+  const app = await headlessApp();
+  let clock = 1000;
+  setAnimationClock(() => clock);
+  try {
+    const { read, render } = await mount(
+      app,
+      scene({ color: BLACK, transition: 100 }),
+    );
+    assert.ok((await read()).black > 200);
+
+    await render(scene({ color: RED, transition: 100 }));
+    clock += 1000; // well past the end of the transition
+    const after = await read();
+    assert.ok(
+      after.red > 200 && after.black === 0,
+      `the transition should land on red, got ${JSON.stringify(after)}`,
+    );
+  } finally {
+    setAnimationClock(() => Date.now());
+    await app.close();
+  }
+});
+
+test('color on an enclosing <box> reaches the text inside it', async () => {
+  const app = await headlessApp();
+  try {
+    const { read, render } = await mount(app, scene(null, { color: BLACK }));
+    assert.ok((await read()).black > 200, 'the box names the ink');
+
+    await render(scene(null, { color: RED }));
+    const after = await read();
+    assert.ok(
+      after.red > 200 && after.black === 0,
+      `changing the box's colour should restyle the label, got ${JSON.stringify(after)}`,
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test("a node's own colour wins over what it inherits", async () => {
+  const app = await headlessApp();
+  try {
+    const { read } = await mount(app, scene({ color: BLACK }, { color: RED }));
+    const shown = await read();
+    assert.ok(
+      shown.black > 200 && shown.red === 0,
+      `the <text> named black, so black it is, got ${JSON.stringify(shown)}`,
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test(':hover on a row reaches the label inside it', async () => {
+  const app = await headlessApp();
+  try {
+    const refs = { box: React.createRef() };
+    const { read } = await mount(
+      app,
+      scene(null, { color: BLACK, ':hover': { color: RED } }, refs),
+    );
+    assert.ok((await read()).black > 200);
+
+    // exactly what the event manager does: `:hover` marks the ancestor chain,
+    // and what the child does about it is inheritance rather than a selector
+    refs.box.current.setStyleState(':hover', true);
+    const hovered = await read();
+    assert.ok(
+      hovered.red > 200 && hovered.black === 0,
+      `hovering the row should light its label, got ${JSON.stringify(hovered)}`,
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test('a descendant that names its own ink absorbs an ancestor change', async () => {
+  const app = await headlessApp();
+  try {
+    const refs = { box: React.createRef(), text: React.createRef() };
+    const { read } = await mount(
+      app,
+      scene({ color: BLACK }, { ':hover': { color: RED } }, refs),
+    );
+    await read();
+    // the walk stops at the node whose answer did not change, so nothing
+    // under it is re-resolved and nothing under it is damaged
+    let dropped = 0;
+    const text = refs.text.current;
+    const paintChanged = text._textPaintChanged.bind(text);
+    text._textPaintChanged = () => {
+      dropped++;
+      paintChanged();
+    };
+    refs.box.current.setStyleState(':hover', true);
+    const hovered = await read();
+    assert.strictEqual(dropped, 0, 'the label resolves to the same ink');
+    assert.ok(hovered.black > 200 && hovered.red === 0);
+  } finally {
+    await app.close();
+  }
+});
+
+test('fontSize on an enclosing <box> re-measures the text inside it', async () => {
+  const app = await headlessApp();
+  try {
+    const refs = { text: React.createRef() };
+    const wide = h(
+      'window',
+      { width: W, height: H, style: { backgroundColor: '#ffffff' } },
+      h(
+        'box',
+        { style: { alignSelf: 'flex-start', fontSize: 12 } },
+        h('text', { ref: refs.text, style: { color: BLACK } }, 'Handgloves'),
+      ),
+    );
+    const { read, render } = await mount(app, wide);
+    const small = await read();
+    const smallWidth = refs.text.current.abs.width;
+
+    await render(
+      h(
+        'window',
+        { width: W, height: H, style: { backgroundColor: '#ffffff' } },
+        h(
+          'box',
+          { style: { alignSelf: 'flex-start', fontSize: 28 } },
+          h('text', { ref: refs.text, style: { color: BLACK } }, 'Handgloves'),
+        ),
+      ),
+    );
+    const big = await read();
+    assert.ok(
+      big.black > small.black * 1.5,
+      `28px should put down much more ink than 12px, got ${small.black} -> ${big.black}`,
+    );
+    assert.ok(
+      refs.text.current.abs.width > smallWidth,
+      `and the measured box should grow, got ${smallWidth} -> ${refs.text.current.abs.width}`,
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test('a <canvas mono> takes the ink of the element around it', async () => {
+  const app = await headlessApp();
+  try {
+    const draw = (ctx, { width, height }) => {
+      ctx.fillRect(0, 0, width, height);
+    };
+    const swatch = (color) =>
+      h(
+        'window',
+        { width: W, height: H, style: { backgroundColor: '#ffffff' } },
+        h(
+          'box',
+          { style: { color } },
+          h('canvas', {
+            mono: true,
+            onDraw: draw,
+            style: { width: 40, height: 40 },
+          }),
+        ),
+      );
+    const { read, render } = await mount(app, swatch(BLACK));
+    assert.ok((await read()).black > 1000, 'the swatch takes the box ink');
+    await render(swatch(RED));
+    const after = await read();
+    assert.ok(
+      after.red > 1000 && after.black === 0,
+      `an <Icon> in a row follows the row, got ${JSON.stringify(after)}`,
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test('an unstyled <text> still falls back to the palette', async () => {
+  const app = await headlessApp();
+  try {
+    const { read } = await mount(
+      app,
+      h(
+        'window',
+        {
+          width: W,
+          height: H,
+          theme: { text: RED },
+          style: { backgroundColor: '#ffffff' },
+        },
+        h('text', { style: { fontSize: 24 } }, 'Handgloves'),
+      ),
+    );
+    const shown = await read();
+    assert.ok(
+      shown.red > 200 && shown.black === 0,
+      `the floor under the cascade is the palette, got ${JSON.stringify(shown)}`,
+    );
+  } finally {
+    await app.close();
+  }
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -129,7 +129,18 @@ const s = createStyles({
     ':hover': { borderLeftColor: '$accent' },
   },
   rule: { borderWidth: 1, borderBottomWidth: 0, borderTopColor: '#ddd' },
+  // the text cascade: `color` on a container is how the labels inside it are
+  // dimmed, and `:focus-within` is how the row follows the field in it
+  field: {
+    color: '$text',
+    fontSize: 13,
+    ':focus-within': { borderColor: '$borderFocus' },
+    ':hover': { color: '$accent' },
+  },
 });
+
+// @ts-expect-error — the size a container sets is layout, state blocks are not
+createStyles({ bad: { ':focus-within': { fontSize: 12 } } });
 
 // arrays, falsy entries, nesting
 const composed: StyleProp = [s.root, false, null, [s.row, { padding: 4 }]];

--- a/website/src/demos/styling.js
+++ b/website/src/demos/styling.js
@@ -4,8 +4,10 @@ export default {
   description:
     'Inline styles with :hover / :focus / :active blocks that resolve in the ' +
     'renderer — a pointer move repaints one node and never renders React. ' +
-    'Plus theme tokens ($name, resolved against the nearest theme above the ' +
-    'node) and transitions, which lerp on the window frame clock.',
+    'Plus inherited type (color and the font properties travel down the ' +
+    'tree, so a :hover on a row reaches its labels), theme tokens ($name, ' +
+    'resolved against the nearest theme above the node) and transitions, ' +
+    'which lerp on the window frame clock.',
   code: `import React, { useState } from 'react';
 import { createRoot, createStyles } from 'react-x11';
 
@@ -48,6 +50,18 @@ const s = createStyles({
   },
   buttonText: { color: '$accentText', fontSize: 13 },
   swatch: { width: 34, height: 34, borderRadius: 17, transition: 200 },
+  // color and the font properties inherit, so this row sets the type of
+  // everything written inside it — including on hover, which is why there
+  // is no "group hover" to learn
+  row: {
+    flexDirection: 'row',
+    gap: 8,
+    padding: 6,
+    borderRadius: 6,
+    color: '$muted',
+    transition: 140,
+    ':hover': { color: '$accent', backgroundColor: '$panel' },
+  },
 });
 
 function App() {
@@ -73,6 +87,19 @@ function App() {
           The border colour comes from a ':hover' block. No React render
           happens: the event manager already knows the hover path, so the
           renderer recomputes this node's style and repaints it.
+        </text>
+      </box>
+
+      <box style={s.card}>
+        <text style={s.title}>Type travels down</text>
+        <box style={s.row}>
+          <text style={{ fontSize: 13 }}>Open recent</text>
+          <box style={{ flexGrow: 1 }} />
+          <text style={{ fontSize: 13 }}>Ctrl+R</text>
+        </box>
+        <text style={s.body}>
+          Neither label names a colour. The row does, in its own style and in
+          its ':hover' block, and 'color' is inherited — so both follow it.
         </text>
       </box>
 


### PR DESCRIPTION
Seven text properties now inherit — `color`, `fontFamily`, `fontSize`, `fontWeight`, `fontStyle`, `fontVariationSettings`, `textRendering` — so a caption block is a `<box>` and not a decision repeated at every label inside it. A style property on the node still wins, and the palette is still the floor under everything; what changes is that there is now something between the two.

Three paint bugs found while investigating turned out to sit on the same seam and are fixed here too. `:focus-within` lands as the last state block.

## Why inheritance rather than a selector

`:hover` marks the ancestor chain, so a hovered row could always restyle *itself* and never its label. The usual answers to that are a relational selector or Tailwind's `group`. The answer in CSS is that `color` is inherited and the question never comes up — and it does not come up here now either:

```jsx
<box style={{ color: theme.dim, ':hover': { color: theme.accent } }}>
  <text>Open recent</text>
  <box style={{ flexGrow: 1 }} />
  <text>Ctrl+R</text>
  <Icon name="chevronRight" />
</box>
```

Nothing in that row below the outer `<box>` names a colour. The middle row is hovered in both shots; only the middle row was told anything.

| before (`95c2531`) | after (`0d4a286`) |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/2e19d91b-1598-4baf-8bec-b6e841931614" width="300"> | <img src="https://github.com/user-attachments/assets/f53c0bcd-d11b-4845-8719-c25d23cb26f8" width="300"> |
| the label, the accelerator and the chevron ignore the row | all three follow it |

**And it costs no layout pass.** A state block may only set paint properties and `color`, so the only inherited property a pointer can ever move is the ink — which drops the memoised text layouts under it and repaints, with nothing re-measured. ntk keys its shaping cache without the colour, so the rebuild is line-breaking rather than re-shaping. A `fontSize` change *does* re-measure, and it can only arrive from a commit, a size query or a theme. `npm run bench -- --check` reports no regressions.

## Three bugs, one cause

A `<text>`'s `TextLayout` is memoised with the span colours baked in, and only `TextNode.applyProps` ever dropped it. Every one of these is the kind that survives every assertion about styles, damage and layout — the resolved style is right, the node is damaged, a frame is painted, and the old glyphs are still on the screen. All three are pinned as pixel tests in `test/text-cascade.test.js`.

- **A state block that set `color` on a `<text>` was a silent no-op.** `setStyleState` swapped the style and never dropped the layout, so `:hover`, `:focus`, `:active`, `:drag-over` and `:dragging` all did nothing to text. `:disabled` was fine — it rides a commit.
- **A `transition` on a `<text>`'s colour never arrived at all**, not even at the end of the transition. Same cause, through the animation tick. `docs/styling.md` promised colours lerp.
- **`<svg fill="currentColor">` fell back to a hardcoded black** rather than the palette's text colour — invisible on a dark desktop — while `<tex>` two functions away and `<canvas mono>` both used the palette. All three resolve through one accessor now.

The fix is a repaint, not a re-measure: `color` and `textRendering` ride on the spans inside a cached layout, so it has to go, but neither moves a glyph. Conflating the two is what would have made a hover cost a layout pass.

## `:focus-within`

The row that lights up while the field inside it is being typed into — the one thing a node's own states could not say. It is a diff over the focused node's ancestor chain, the same walk `:hover` and the press chain already use and the third caller of it, so no new machinery. It sits below `:focus` in precedence, which is the narrower statement.

```jsx
<box style={{ borderColor: theme.border, ':focus-within': { borderColor: theme.borderFocus } }}>
  <textinput value={value} onChange={setValue} />
</box>
```

## What stays out

Sibling and group selectors, now on the record in `docs/styling.md`'s Decided section. Each exists to move a value across the tree, and inheritance already does it in the two directions that are cheap: a parent's `:hover` reaches its children because `color` is inherited, and a child's hover reaches its parents because the hover path *is* the ancestor chain. What is left over — a sibling reacting to a sibling — stays in React, where `useControl` already returns `hover`/`focused`/`pressed` as state. `<Checkbox>` does exactly that, because its well is a sibling of the label the press lands on.

## How it works

- `Node.inheritedTextStyle` reads the parent's `resolvedTextStyle()` instead of only the theme. `resolvedTextStyle()` is memoised, and asking fills every ancestor's cache on the way up — so an empty cache proves an empty cache in the whole subtree, which is the early-out that keeps a hover on one row from walking a window.
- `_retarget` is the single funnel every style swap already went through, so it is where a moved ink is noticed and pushed down. The walk stops at any node whose own resolution did not change: a label that names its own colour absorbs an ancestor's change for everything below it too.
- `INHERITED_TEXT_PROPS` and `LOCAL_TEXT_PROPS` split the text vocabulary by who has to react. `textAlign`, `lineHeight`, `textWrap` and `textBoxTrim` are local — they shape the box the lines flow in, which a descendant does not have.
- `_textStyleMoved(cost)` is the seam a custom element overrides to drop a cache of its own. It also completes the `resolvedTextStyle()` half of #254: an element that asks now inherits a `<box style={{ color }}>` and a `:hover` on the row it sits in, not just the palette.

## Call sites

`Tree`'s twisty, `ContextMenu`'s chevron and `MenuBar`'s titles stop being handed their ink, and `<Icon>` stops pinning `color` to the palette so it can inherit at all. `<Icon size>` deliberately still does not inherit and is still not `fontSize`: a glyph has no baseline and no ascent, so it derives from the palette and stays put when a label beside it shrinks.

`npm run screenshots` output is byte-identical to master's, regenerated on the same machine — the widget refactor computes the same colours by a shorter route.

## Breaking

`color` and the font properties now reach descendants. A `<box style={{ color }}>` that previously affected nothing below it now sets the ink of every label inside it, and an `<Icon>` with no `color` follows the element around it rather than the palette.

## Checks

`npm test` (1042 pass; the six `appearance.test.js` failures are pre-existing on `95c2531` and macOS-only — the appearance ladder finds the system appearance before XSETTINGS), `npm run lint`, `npm run typecheck`, `npm run bench -- --check`, and `website && npm test && npm run build`.

Screenshots were rendered headlessly into node-x11's in-process X server through `scripts/capture.js`, once per SHA on the same machine, from the snippet above.
