### PR TITLE
feat(extending)!: pixels that scroll — the wheel chain as public protocol

### DIFF
--- a/docs/drag-and-drop.md
+++ b/docs/drag-and-drop.md
@@ -283,10 +283,13 @@ it, so a drop target below the fold can be reached without letting go.
 Nothing opts in: it applies to any scroll container a drag passes over,
 from this application or another one.
 
-The viewport it scrolls is the nearest one enclosing the pointer — the
-same one the wheel would scroll, found the same way. `<textarea>` is
+The viewport it scrolls is the nearest scroll _container_ enclosing the
+pointer, walked out the same way the wheel walks. Something that scrolls
+pixels of its own without being a container — `<textarea>` and anything else
+that answers `canScroll` alone
+([extending.md](extending.md#scrolling-content-you-painted)) — is
 deliberately excluded: nothing can be dropped into one, so scrolling it
-during a drag would only move text out of reach.
+during a drag would only move content out of reach.
 
 Two consequences worth knowing:
 

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -707,6 +707,10 @@ box you do not scroll.
 `scrollTo(y)` takes a number for the vertical axis; `scrollTo({x, y})` moves
 either, leaving alone whichever you omit. `scrollBy` matches.
 `scrollIntoView(node)` scrolls the minimum amount on both axes.
+`canScroll(dx, dy)` answers whether there is room to move on the axis a delta
+names — what the wheel asks each node on its way out, and the one method an
+element of your own implements to be asked it too
+([extending.md](extending.md#scrolling-content-you-painted)).
 
 Horizontal content comes from children that will not shrink — a row of
 fixed-width cells, say. The extent is measured **through the subtree**, the
@@ -987,6 +991,10 @@ word-wraps at the content width, Enter inserts a newline (Ctrl+Enter fires
 Home/End go to the start/end of the visual (wrapped) line, selection spans
 lines, and the view scrolls vertically to follow the caret (mouse wheel
 scrolls too).
+
+The wheel reaches it through the same chain a `<box overflow="scroll">` is
+in, so a field whose text fits passes the gesture out to the pane or the
+window behind it rather than swallowing it.
 
 | prop            |                                                   |
 | --------------- | ------------------------------------------------- |

--- a/docs/events.md
+++ b/docs/events.md
@@ -18,7 +18,11 @@ events dispatched over the drawn node tree with DOM-like semantics.
 Step 4 is a documented seam, not a privilege of the built-in elements: an
 element added with `registerElement` implements the same `defaultKeyDown` /
 `defaultMouseDown` / … methods and gets the same ordering
-([extending.md](extending.md#behaviour-of-your-own)).
+([extending.md](extending.md#behaviour-of-your-own)). The wheel's default
+action is the same story in a different shape — it walks out from the target
+asking each node `canScroll(deltaX, deltaY)`, so an element that scrolls
+content it painted joins the chain by answering
+([extending.md](extending.md#scrolling-content-you-painted)).
 
 `ev.stopPropagation()` stops the walk. Handlers always read from current
 props — they can never go stale.

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -81,15 +81,16 @@ are about to use needs declaring.
 `Node` already implements the whole reconciler-facing surface, so an element
 that only draws needs a constructor and a `paint`. What you may override:
 
-| method                         | when                                                                                                |
-| ------------------------------ | --------------------------------------------------------------------------------------------------- |
-| `paint(ctx)`                   | draw. Call `super.paint(ctx)` first for background, border and clip, then draw inside `this.abs`.   |
-| `applyProps(next, prev)`       | props changed. Call `super.applyProps(next, prev)`; invalidate if you cache anything derived.       |
-| `measureContent(constraints)`  | your content has a size of its own (below). Leaves only — an element that measures has no children. |
-| `default*(ev)`                 | the element's own behaviour for a key, a press or focus (below) — what makes it _interactive_.      |
-| `hitTest(x, y)`                | non-rectangular hit areas. The default walks children in reverse paint order.                       |
-| `insertBefore` / `removeChild` | only if children mean something structural to you                                                   |
-| `destroySubtree()`             | release anything you allocated (pixmaps, fonts, timers). Call `super.destroySubtree()`.             |
+| method                         | when                                                                                                         |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------ |
+| `paint(ctx)`                   | draw. Call `super.paint(ctx)` first for background, border and clip, then draw inside `this.abs`.            |
+| `paintContent(ctx)`            | draw _between_ the background and the children — where the built-ins draw, and what a scroller needs (below) |
+| `applyProps(next, prev)`       | props changed. Call `super.applyProps(next, prev)`; invalidate if you cache anything derived.                |
+| `measureContent(constraints)`  | your content has a size of its own (below). Leaves only — an element that measures has no children.          |
+| `default*(ev)`                 | the element's own behaviour for a key, a press or focus (below) — what makes it _interactive_.               |
+| `hitTest(x, y)`                | non-rectangular hit areas. The default walks children in reverse paint order.                                |
+| `insertBefore` / `removeChild` | only if children mean something structural to you                                                            |
+| `destroySubtree()`             | release anything you allocated (pixmaps, fonts, timers). Call `super.destroySubtree()`.                      |
 
 And what you read:
 
@@ -397,6 +398,114 @@ exported so that two carets on one screen are in step rather than a few tens
 of milliseconds apart. Stop the timer in `defaultBlur` _and_ in
 `destroySubtree`: a node that unmounts while focused is forgotten rather than
 blurred, so `defaultBlur` is not guaranteed to run.
+
+### Scrolling content you painted
+
+A `<box overflow="scroll">` scrolls **children**: layout knows where they
+are, so the extent, the bars, the clamping and the wheel all follow from the
+tree. An editor, a terminal or a canvas-backed table has no children — its
+content is pixels it draws — and it still has a scroll position, an extent
+and a wheel gesture to answer. Two methods make it a member of the same
+machinery instead of an exception to it (issue #253):
+
+| method                   |                                                                                                     |
+| ------------------------ | --------------------------------------------------------------------------------------------------- |
+| `canScroll(dx, dy)`      | is there room to move on the axis this delta names? The wheel asks before it scrolls you            |
+| `scrollBy(by)`           | `scrollBy(dy)` or `scrollBy({x, y})` — move by that much                                            |
+| `measureScrollContent()` | `Scrollable` only: `{ width, height }`, how far the content reaches. The default walks the children |
+
+**The wheel's default action is those first two and nothing else.** It walks
+out from the node the pointer hit, asks each one `canScroll(deltaX, deltaY)`,
+and the first that says yes gets `scrollBy` — up to the `<window>`, where the
+walk stops. So an element joins the chain by answering two questions, and it
+**chains** by answering the first of them honestly: say no when there is
+nothing left to move and the wheel goes to the pane or the window behind you,
+which is what a browser does and what a user flicking through a long page
+expects. `<textarea>` is the worked example in core — it scrolls wrapped text
+it painted, and since it answers `canScroll` off that text, a short one hands
+the gesture outward rather than swallowing it.
+
+Answer `canScroll` from the **extent, not the position**: a viewport already
+scrolled to its bottom should keep the rest of a flick rather than pass it
+to whatever is behind it.
+
+#### The mixin, for everything else
+
+`canScroll` + `scrollBy` buys the wheel. `Scrollable(Node)` buys the rest —
+the offsets, `scrollTo`/`scrollBy`/`scrollIntoView`, the drawn scrollbars and
+their drags, the scroll keys (arrows, Page, Home/End, Space), the tab stop
+and the AT-SPI scroll-pane role — and all of it reads one number pair:
+
+```js
+import { Node, Scrollable } from 'react-x11/node';
+
+const LINE = 16;
+
+class EditorNode extends Scrollable(Node) {
+  constructor(props, app) {
+    super('codeeditor', props, app);
+  }
+
+  // scrolling is what this element *is*, rather than something an app opts
+  // into with a style; the default answers `overflow: 'scroll'`
+  isScroller() {
+    return true;
+  }
+
+  // …and the one thing only this element knows: how far the drawing goes
+  measureScrollContent() {
+    return {
+      width: this.longestLineWidth(),
+      height: LINE * this.lines.length,
+    };
+  }
+
+  paintContent(ctx) {
+    const box = this.contentBox();
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(box.x, box.y, box.width, box.height);
+    ctx.clip();
+    this.drawLines(ctx, box.x - this.scrollX, box.y - this.scrollY);
+    ctx.restore();
+  }
+}
+```
+
+Three things about that, each of which is a bug if you get it the other way
+round:
+
+**Draw in `paintContent`, not in `paint`.** `paint` draws the background,
+then `paintContent`, then the children, the border, and — for a
+`Scrollable` — the scrollbars last. An element that draws after
+`super.paint(ctx)` returns therefore paints _over its own thumb_.
+`paintContent` is the seam every built-in that draws uses, and it is where a
+drawing belongs whether it scrolls or not.
+
+**Offset the drawing yourself, and clip it.** A `<box>`'s children are moved
+by the scroll during layout; nobody moves pixels. `contentBox()` is the
+viewport to clip to and `scrollX`/`scrollY` are what to subtract — they are
+already clamped to the extent you reported, so there is nothing to bound
+again. `scrollX` is a distance from the edge the content _starts_ at, which
+is the right-hand one under `direction: 'rtl'`
+([styling.md](styling.md#direction-and-the-logical-edges)) — and the `width` you report is that
+same reach, so an element that draws in its own reading direction never has
+to ask which one it is in.
+
+**Do not assign `focusableByDefault`.** `Scrollable` answers it — a pane with
+somewhere to go is a tab stop, one that fits is not — and assigning over the
+getter throws. Override the getter if your element is focusable for a reason
+of its own.
+
+`measureScrollContent` is called once per layout pass, from `absolutize`, so
+it may read layout geometry, but it must not paint or invalidate. It has to
+return finite numbers: a `NaN` extent would otherwise become a `NaN` offset
+and a subtree laid out at `NaN`, so returning anything else throws naming the
+element, exactly as `measureContent` does.
+
+When the drawing changes its own extent — a line was typed, rows arrived —
+say so the way any other layout change is said, with
+`this.invalidate(true, this, 'scroll')`; the next pass asks again.
 
 ### Drawing once instead of every frame
 

--- a/src/dnd.js
+++ b/src/dnd.js
@@ -194,16 +194,15 @@ function actionAtom(atoms, name) {
  * skipping the same ones, so the two gestures agree about which viewport a
  * point belongs to.
  *
- * `<textarea>` scrolls under the wheel but not under a drag: nothing can
- * be dropped into one, so scrolling it would move text the drag cannot
- * reach.
+ * A scroll *container* — `isScroller()` — rather than anything the wheel
+ * would scroll: `<textarea>` and its kind answer `canScroll` because they
+ * pan their own pixels, but nothing can be dropped into one, so scrolling
+ * it here would move text the drag cannot reach.
  */
 function scrollerIn(path) {
   for (let i = path.length - 1; i >= 0; i--) {
     const n = path[i];
-    if (n.isScroller?.() && (n._maxScroll('x') > 0 || n._maxScroll('y') > 0)) {
-      return n;
-    }
+    if (n.isScroller?.() && n.canScroll(1, 1)) return n;
   }
   return null;
 }

--- a/src/events.js
+++ b/src/events.js
@@ -356,19 +356,20 @@ export class EventManager {
           deltaY: dy,
         });
         if (!ev.defaultPrevented) {
-          // Default action: scroll the nearest enclosing scroll container
-          // that has somewhere to go on this axis. Chaining past one that
+          // Default action: the nearest node out from the target that says it
+          // has somewhere to go on this axis scrolls. Chaining past one that
           // fits its own content is what a browser does, and it matters now
           // that any `<box>` can be a scroll container — a pane that happens
           // to fit must not swallow the wheel the window would have answered.
           // The `<window>` is the last candidate, then the walk stops.
+          //
+          // Two methods and no kinds: `<textarea>` scrolls pixels it painted
+          // rather than children it laid out, and so does a registered
+          // element that draws its own content, and neither of them should
+          // have to be named here to be reachable (issue #253).
           for (let n = target; n; n = n.parent) {
-            if (n.isScroller?.() && n._canScroll(ev.deltaX, ev.deltaY)) {
+            if (n.canScroll?.(ev.deltaX, ev.deltaY)) {
               n.scrollBy({ x: ev.deltaX, y: ev.deltaY });
-              break;
-            }
-            if (n.kind === 'textarea') {
-              n.scrollBy(ev.deltaY); // one axis only: it wraps
               break;
             }
             if (n === this.node) break;

--- a/src/node.d.ts
+++ b/src/node.d.ts
@@ -227,6 +227,10 @@ export declare class Node {
  * Scrolling as a mixin: `class Pane extends Scrollable(Node)` gives a
  * registered element the same `overflow: 'scroll'` behaviour `<box>` and
  * `<window>` have — wheel, keys, bars, and the AT-SPI scroll-pane role.
+ *
+ * An element whose content is **painted rather than laid out** overrides
+ * `measureScrollContent`; everything else follows from the numbers it
+ * returns. See docs/extending.md.
  */
 export declare function Scrollable<T extends typeof Node>(
   Base: T,
@@ -239,6 +243,13 @@ export declare function Scrollable<T extends typeof Node>(
     isScroller(): boolean;
     scrollTo(to: number | { x?: number; y?: number }): void;
     scrollBy(by: number | { x?: number; y?: number }): void;
+    /** Chain membership: has this node room to move on the axis the delta
+     * names? The wheel asks it before scrolling this node rather than the
+     * next one out. */
+    canScroll(dx: number, dy: number): boolean;
+    /** How far the content reaches. The default walks the children;
+     * override it when the content is pixels this element paints. */
+    measureScrollContent(): { width: number; height: number };
     scrollIntoView(node: Node): void;
   };
 };

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -2469,7 +2469,7 @@ export class Node {
     // lookup for the privilege.
     const cache = this.paintCachePlan && this.root?._paintCache;
     if (cache) cache.paint(this, ctx);
-    else this._paintContent(ctx);
+    else this.paintContent(ctx);
     this._paintChildren(ctx);
     this._paintBorder(ctx);
     // last, and outside the border box: a ring drawn under the border would
@@ -2653,7 +2653,14 @@ export class Node {
     if (dashed) ctx.setLineDash([]);
   }
 
-  _paintContent(ctx) {}
+  /**
+   * What this element draws of its own, between its background and its
+   * children — where every built-in that draws anything draws it, and the
+   * seam an element that draws over its own scroll offset needs, since the
+   * scrollbars go on after the children and `paint` returning is too late
+   * to be underneath them.
+   */
+  paintContent(ctx) {}
 
   /**
    * The paint-cache protocol (issue #149). A node implements both methods or
@@ -3063,7 +3070,7 @@ export class TextNode extends Node {
     };
   }
 
-  _paintContent(ctx) {
+  paintContent(ctx) {
     const content = this.contentBox();
     const layout = this._layoutFor(this._wrapWidth(content.width || Infinity));
     if (!layout) return;
@@ -3114,7 +3121,7 @@ export class ImageNode extends Node {
     }
   }
 
-  _paintContent(ctx) {
+  paintContent(ctx) {
     if (!this.image) return;
     const content = this.contentBox();
     ctx.drawImage(
@@ -3326,12 +3333,20 @@ export const Scrollable = (Base) =>
         return;
       }
       const rtl = this.direction === 'rtl';
-      const { start, bottom } = this._measureContent();
-      this.contentHeight =
-        bottom + this.yoga.getComputedPadding(Yoga.EDGE_BOTTOM);
-      this.contentWidth =
-        start +
-        this.yoga.getComputedPadding(rtl ? Yoga.EDGE_LEFT : Yoga.EDGE_RIGHT);
+      const size = this.measureScrollContent();
+      if (!Number.isFinite(size?.width) || !Number.isFinite(size?.height)) {
+        // A NaN here does not throw on its own: it becomes a NaN max scroll,
+        // a NaN offset, and every child laid out at NaN — a whole tree gone
+        // with nothing naming the element that did it.
+        throw new Error(
+          `react-x11: <${this.kind}>.measureScrollContent() must return ` +
+            '{ width, height } as finite numbers; it returned ' +
+            `${describeSize(size)}. Return { width: 0, height: 0 } for ` +
+            'content that has not arrived yet.',
+        );
+      }
+      this.contentWidth = size.width;
+      this.contentHeight = size.height;
       this._resolveScrollIntoView();
       this.scrollY = clampScroll(this.scrollY, this._maxScroll('y'));
       this.scrollX = clampScroll(this.scrollX, this._maxScroll('x'));
@@ -3413,22 +3428,35 @@ export const Scrollable = (Base) =>
     }
 
     /**
-     * How far the content actually reaches, measured through the subtree
-     * rather than off the direct children. A row that stretches to the
-     * viewport while its own cells overflow it — a table, in other words —
-     * reports the viewport width at the top level and says nothing about the
-     * cells, so a shallow measurement would find nothing to scroll. This is
-     * what `scrollWidth`/`scrollHeight` mean in a browser.
+     * How far the content reaches — `scrollWidth`/`scrollHeight`, and what
+     * everything below scrolls against: the maxima, the bars, the keys.
      *
-     * Anything that clips its own children ends the walk: their overflow is
-     * that node's business, not ours.
+     * The default measures the **children**, through the subtree rather than
+     * off the direct ones. A row that stretches to the viewport while its own
+     * cells overflow it — a table, in other words — reports the viewport
+     * width at the top level and says nothing about the cells, so a shallow
+     * measurement would find nothing to scroll. Anything that clips its own
+     * children ends the walk: their overflow is that node's business.
      *
-     * `start` is how far the content reaches from the edge it *starts* at,
+     * `width` is how far the content reaches from the edge it *starts* at,
      * which is the right-hand one under `direction: 'rtl'` — yoga lays an
      * overflowing RTL row out at negative offsets, so the reach that matters
-     * there is how far left of zero it got, not how far right.
+     * there is how far left of zero it got, not how far right. An element
+     * measuring its own drawing answers the same question and never has to
+     * ask which direction it is in.
+     *
+     * **Override it when the content is pixels rather than nodes.** An
+     * element that paints its own content — an editor drawing lines of text,
+     * a terminal, a canvas-backed table — has no children to walk, so the
+     * default measures 0 and the viewport clamps to nothing however far the
+     * drawing actually goes. Answering here is the whole of joining in: the
+     * wheel, the scrollbars, the scroll keys and the AT-SPI scroll pane all
+     * read the numbers this returns (docs/extending.md).
+     *
+     * Called once per layout pass, from `absolutize`, so it may read yoga
+     * geometry but must not invalidate or paint.
      */
-    _measureContent() {
+    measureScrollContent() {
       const rtl = this.direction === 'rtl';
       const width = this.yoga.getComputedWidth();
       let start = 0;
@@ -3445,7 +3473,15 @@ export const Scrollable = (Base) =>
         }
       };
       walk(this, 0, 0);
-      return { start, bottom };
+      // the end padding is part of the content box a browser scrolls to, and
+      // it is the one part of it yoga has already resolved for us — on the
+      // left in RTL, since that is the end there
+      return {
+        width:
+          start +
+          this.yoga.getComputedPadding(rtl ? Yoga.EDGE_LEFT : Yoga.EDGE_RIGHT),
+        height: bottom + this.yoga.getComputedPadding(Yoga.EDGE_BOTTOM),
+      };
     }
 
     /**
@@ -3513,11 +3549,16 @@ export const Scrollable = (Base) =>
     }
 
     /**
-     * Is there room to move on the axis this delta names? What the wheel's
-     * default action chains on: a scroll container that fits its content
-     * hands the gesture to the next one out, the way a browser does.
+     * Is there room to move on the axis this delta names? The first half of
+     * the wheel's chain protocol (`canScroll` then `scrollBy`, see
+     * docs/extending.md): a scroll container that fits its content answers
+     * no and hands the gesture to the next one out, the way a browser does.
+     *
+     * Position is deliberately not part of the answer — a viewport scrolled
+     * to its bottom still owns the wheel, rather than passing the rest of a
+     * flick to whatever is behind it.
      */
-    _canScroll(dx, dy) {
+    canScroll(dx, dy) {
       if (dx && this._maxScroll('x') > 0) return true;
       if (dy && this._maxScroll('y') > 0) return true;
       return false;
@@ -3791,7 +3832,7 @@ export class CanvasNode extends Node {
     ctx.strokeStyle = color;
   }
 
-  _paintContent(ctx) {
+  paintContent(ctx) {
     const onDraw = this.props.onDraw;
     if (typeof onDraw !== 'function') return;
     ctx.save();
@@ -4935,7 +4976,7 @@ export class TextInputNode extends Node {
     }
   }
 
-  _paintContent(ctx) {
+  paintContent(ctx) {
     const fonts = this.app?.fonts;
     if (!fonts) return;
     const content = this.contentBox();
@@ -5162,11 +5203,33 @@ export class TextAreaNode extends TextInputNode {
     return layout.indexAt(ev.x - content.x, ev.y - content.y + this._scrollY);
   }
 
-  scrollBy(dy) {
+  /** How far the wrapped text reaches past the viewport. The measurement a
+   * `Scrollable` takes off its children, taken off the layout that is
+   * actually painted — which is what makes a self-painting element a member
+   * of the scroll protocol rather than a special case in it. */
+  _maxScrollY() {
     const layout = this._valueLayout();
-    const content = this.contentBox();
-    const max = layout ? Math.max(0, layout.height - content.height) : 0;
-    const next = Math.min(Math.max(0, this._scrollY + dy), max);
+    if (!layout) return 0;
+    return Math.max(0, layout.height - this.contentBox().height);
+  }
+
+  /**
+   * The chain protocol's first half (issue #253). Vertical only — the text
+   * wraps, so there is never anything to the right — and false when the
+   * value fits, which is what lets the wheel chain outward to the pane or
+   * the window behind a short field instead of dying on it.
+   */
+  canScroll(dx, dy) {
+    return Boolean(dy) && this._maxScrollY() > 0;
+  }
+
+  /** `scrollBy(dy)`, or `scrollBy({x, y})` — the shape `Scrollable` takes,
+   * so the wheel's default action calls every scroller the same way. `x` is
+   * accepted and ignored: wrapped text has no horizontal extent. */
+  scrollBy(by) {
+    const dy = typeof by === 'number' ? by : (by?.y ?? 0);
+    if (!dy) return;
+    const next = Math.min(Math.max(0, this._scrollY + dy), this._maxScrollY());
     if (next === this._scrollY) return;
     this._scrollY = next;
     // an inner scroll moves pixels only inside the field's own clip
@@ -5268,7 +5331,7 @@ export class TextAreaNode extends TextInputNode {
     });
   }
 
-  _paintContent(ctx) {
+  paintContent(ctx) {
     const layout = this._valueLayout();
     if (!layout) return;
     const content = this.contentBox();

--- a/src/paintcache.js
+++ b/src/paintcache.js
@@ -189,11 +189,11 @@ export class PaintCache {
    */
   paint(node, ctx) {
     const plan = node.paintCachePlan(ctx);
-    if (!plan || !isDeviceSpace(ctx)) return node._paintContent(ctx);
+    if (!plan || !isDeviceSpace(ctx)) return node.paintContent(ctx);
 
     if (plan.width * plan.height > MAX_ITEM_PIXELS) {
       this.stats.tooBig++;
-      return node._paintContent(ctx);
+      return node.paintContent(ctx);
     }
 
     const hit = this.entries.get(plan.key);
@@ -212,12 +212,12 @@ export class PaintCache {
     if (seen < 2) {
       if (this.pending.size >= MAX_PENDING) this.pending.clear();
       this.pending.set(plan.key, seen);
-      return node._paintContent(ctx);
+      return node.paintContent(ctx);
     }
     this.pending.delete(plan.key);
 
     const entry = this._render(node, plan);
-    if (!entry) return node._paintContent(ctx);
+    if (!entry) return node.paintContent(ctx);
     this.entries.set(plan.key, entry);
     this.bytes += entry.bytes;
     this.inUse.add(entry);

--- a/src/richnodes.js
+++ b/src/richnodes.js
@@ -113,7 +113,7 @@ class DocumentViewNode extends Node {
     }
   }
 
-  _paintContent(ctx) {
+  paintContent(ctx) {
     const view = this._ensureView();
     if (!view) return;
     const content = this.contentBox();
@@ -367,7 +367,7 @@ export class SvgNode extends Node {
     this._textContentChanged();
   }
 
-  _paintContent(ctx) {
+  paintContent(ctx) {
     const view = this._ensureView();
     if (!view) return;
     const content = this.contentBox();
@@ -391,7 +391,7 @@ export class SvgNode extends Node {
   }
 
   /**
-   * Cache plan (see `Node._paintContent` for the protocol).
+   * Cache plan (see `Node.paintContent` for the protocol).
    *
    * The key is the document, the size it is drawn at, and the device scale.
    * Everything else that could change the pixels is either handled at blit
@@ -493,7 +493,7 @@ const texColor = (node) => node.resolvedTextStyle().color;
  *
  * The ink colour is `style={{ color }}`, not a prop — `color` is a style
  * name, so a `color` prop threw in development and only worked in
- * production (issue #118). `_paintContent` and `paintCachePlan` already
+ * production (issue #118). `paintContent` and `paintCachePlan` already
  * read it off the style; the prop reached nothing but layoutTex.
  */
 export class TexNode extends Node {
@@ -552,7 +552,7 @@ export class TexNode extends Node {
     }
   }
 
-  _paintContent(ctx) {
+  paintContent(ctx) {
     const box = this._ensureBox();
     // TexBox.draw issues raw XRender requests through ctx.window.app —
     // it needs a real ntk 2d context (headless mock contexts skip)

--- a/src/types/nodes.d.ts
+++ b/src/types/nodes.d.ts
@@ -64,6 +64,12 @@ export interface ScrollableNode extends DrawnNode {
   scrollTo(to: number | ScrollTarget): void;
   scrollBy(by: number | ScrollTarget): void;
   /**
+   * Is there room to move on the axis a delta names? What the wheel's
+   * default action asks before it scrolls this node instead of the next one
+   * out — see [extending.md](../../docs/extending.md).
+   */
+  canScroll(dx: number, dy: number): boolean;
+  /**
    * Scroll the minimum amount on both axes that makes a descendant fully
    * visible. Safe to call right after that node mounts — the request is
    * resolved on the next layout pass, when it has geometry.

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -415,7 +415,7 @@ test('an unfocused field shows the start of its value, not the caret', async () 
       x11Root,
     );
 
-    // paint at least once: the offsets are settled during _paintContent
+    // paint at least once: the offsets are settled during paintContent
     const root = wnd._reactX11Node;
     for (let i = 0; i < 4; i++) {
       await new Promise((r) => setImmediate(r));

--- a/test/paint-cache.test.js
+++ b/test/paint-cache.test.js
@@ -360,7 +360,7 @@ function lyingNode(colours) {
       ctx.fillStyle = colours[Math.min(call++, colours.length - 1)];
       ctx.fillRect(box.x, box.y, box.width, box.height);
     },
-    _paintContent() {
+    paintContent() {
       this.live++;
     },
   };

--- a/test/scroll-protocol.test.js
+++ b/test/scroll-protocol.test.js
@@ -1,0 +1,382 @@
+// The scroll chain as a documented protocol (#253): an element that scrolls
+// pixels it painted — an editor, a terminal, a canvas-backed table, and
+// core's own `<textarea>` — joins the wheel's default action on public API
+// instead of being named by kind inside it.
+//
+// Two ways in, both exercised here: `Scrollable(Node)` with
+// `measureScrollContent()` overridden, which brings the bars, the keys and
+// the scroll-pane role with it; and `canScroll` + `scrollBy` implemented
+// directly, which is the whole of chain membership.
+//
+// Everything registers its element through `react-x11/host` and imports from
+// `react-x11/node`, because the point is that a package outside react-x11
+// can do this — a test reaching into src/nodes.js would prove nothing about
+// the published surface.
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import React from 'react';
+
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient, StaticFontSource } from 'ntk';
+
+import { createRoot } from '../src/index.js';
+import { registerElement, unregisterElement } from '../src/host.js';
+import { Node, Scrollable } from '../src/node.js';
+import { a11yRole, ATSPI_ROLE } from '../src/a11y.js';
+import { XK_PAGE_DOWN } from '../src/keysyms.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+// X delivers wheel notches as button presses: 4 up, 5 down, 6/7 horizontal.
+const wheel = (wnd, x, y, button = 5) =>
+  wnd.emit('mousedown', { x, y, keycode: button });
+
+function pressKey(app, wnd, keysym) {
+  const keycode = (keysym % 248) + 8;
+  app.X.keycode2keysyms[keycode] = [keysym];
+  wnd.emit('keydown', { keycode, keysym, codepoint: 0, buttons: 0 });
+}
+
+/**
+ * A miniature code editor: `lines` of painted text, no child nodes at all.
+ * The content extent is a fact about the drawing, which is exactly what
+ * `measureScrollContent` is for.
+ */
+const LINE = 16;
+
+class EditorNode extends Scrollable(Node) {
+  constructor(props, app) {
+    super('miniedit', props, app);
+    // no `this.focusableByDefault = true` here: the mixin answers that one
+    // itself, off whether there is anything to scroll
+    this.painted = [];
+  }
+
+  /** Scrolling is what this element *is*, rather than a style an app opts
+   * into — the same call `<box>` answers off `overflow`. */
+  isScroller() {
+    return true;
+  }
+
+  measureScrollContent() {
+    return {
+      width: 40 * (this.props.columns ?? 1),
+      height: LINE * (this.props.lines ?? 0),
+    };
+  }
+
+  paintContent(ctx) {
+    // under the scrollbars, over the background — and offset by the scroll
+    // this element owns, since it has no children for absolutize to move
+    this.painted.push({ x: this.scrollX, y: this.scrollY });
+    void ctx;
+  }
+}
+
+/** The other half of the protocol on its own: no mixin, two methods. */
+class TerminalNode extends Node {
+  constructor(props, app) {
+    super('miniterm', props, app);
+    this.scrolled = 0;
+  }
+
+  _max() {
+    return Math.max(0, LINE * (this.props.lines ?? 0) - this.abs.height);
+  }
+
+  canScroll(dx, dy) {
+    return Boolean(dy) && this._max() > 0;
+  }
+
+  scrollBy(by) {
+    const dy = typeof by === 'number' ? by : (by?.y ?? 0);
+    this.scrolled = Math.min(Math.max(0, this.scrolled + dy), this._max());
+  }
+}
+
+const registered = new Set();
+function register(type, definition) {
+  registerElement(type, { override: true, ...definition });
+  registered.add(type);
+}
+
+afterEach(() => {
+  for (const type of registered) unregisterElement(type);
+  registered.clear();
+});
+
+async function mount(children, windowProps = {}) {
+  register('miniedit', {
+    create: (p, app) => new EditorNode(p, app),
+    childrenAllowed: false,
+    semanticNames: ['lines', 'columns'],
+  });
+  register('miniterm', {
+    create: (p, app) => new TerminalNode(p, app),
+    childrenAllowed: false,
+    semanticNames: ['lines'],
+  });
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(
+    h('window', { width: 200, height: 100, ...windowProps }, children),
+  );
+  await tick();
+  const wnd = app.windows[0];
+  wnd.flushFrame?.();
+  await tick();
+  return { app, root, wnd, node: wnd._reactX11Node };
+}
+
+// --- a self-painting element in the chain -----------------------------------
+
+test('a painted element scrolls on the wheel with no prop handler', async () => {
+  const ref = React.createRef();
+  const { wnd } = await mount(
+    h('miniedit', { ref, lines: 40, style: { width: 200, height: 100 } }),
+  );
+  const editor = ref.current;
+
+  assert.equal(editor.contentHeight, 40 * LINE, 'the override was asked');
+  assert.ok(editor.canScroll(0, 1), 'and it has somewhere to go');
+
+  wheel(wnd, 50, 50);
+  await tick();
+  assert.equal(editor.scrollY, 48, 'one notch, through the default action');
+
+  wnd.flushFrame?.();
+  await tick();
+  assert.ok(
+    editor.painted.some((p) => p.y === 48),
+    'and the element painted at the offset it was scrolled to',
+  );
+});
+
+test('the two methods on their own are enough to join the chain', async () => {
+  const ref = React.createRef();
+  const { wnd } = await mount(
+    h('miniterm', { ref, lines: 40, style: { width: 200, height: 100 } }),
+  );
+  wheel(wnd, 50, 50);
+  await tick();
+  assert.equal(ref.current.scrolled, 48);
+});
+
+test('an app handler still gets the wheel first, and can veto it', async () => {
+  const ref = React.createRef();
+  const seen = [];
+  const { wnd } = await mount(
+    h('miniedit', {
+      ref,
+      lines: 40,
+      onWheel: (ev) => {
+        seen.push(ev.deltaY);
+        ev.preventDefault();
+      },
+      style: { width: 200, height: 100 },
+    }),
+  );
+  wheel(wnd, 50, 50);
+  await tick();
+  assert.deepEqual(seen, [48], 'the handler ran');
+  assert.equal(ref.current.scrollY, 0, 'preventDefault kept the default off');
+});
+
+// --- chaining ---------------------------------------------------------------
+
+/** The editor over a tall sibling, so the window always has somewhere to go
+ * and only the editor's own content decides who takes the wheel. */
+const nested = (ref, lines) => [
+  h('miniedit', {
+    key: 'edit',
+    ref,
+    lines,
+    style: { width: 200, height: 60, flexShrink: 0 },
+  }),
+  h('box', { key: 'tail', style: { height: 400, flexShrink: 0 } }),
+];
+
+test('a painted element with nothing to scroll passes the wheel outward', async () => {
+  const ref = React.createRef();
+  const { wnd, node } = await mount(nested(ref, 2), {
+    style: { overflow: 'scroll' },
+  });
+  assert.equal(ref.current.canScroll(0, 1), false, 'two lines fit');
+
+  wheel(wnd, 50, 20); // over the editor
+  await tick();
+  assert.equal(ref.current.scrollY, 0);
+  assert.equal(node.scrollY, 48, 'the window answered it instead');
+});
+
+test('…and keeps it while it has somewhere to go', async () => {
+  const ref = React.createRef();
+  const { wnd, node } = await mount(nested(ref, 40), {
+    style: { overflow: 'scroll' },
+  });
+  wheel(wnd, 50, 20);
+  await tick();
+  assert.equal(ref.current.scrollY, 48);
+  assert.equal(node.scrollY, 0, 'the window did not also move');
+});
+
+// --- what the mixin brings with it ------------------------------------------
+
+test('painted content gets the bars, the keys and the scroll-pane role', async () => {
+  const ref = React.createRef();
+  const { app, wnd } = await mount(
+    h('miniedit', { ref, lines: 40, style: { width: 200, height: 100 } }),
+  );
+  const editor = ref.current;
+
+  const bar = editor._scrollbar('y');
+  assert.ok(bar, 'a vertical bar');
+  assert.ok(
+    bar.thumbLength < bar.trackLength,
+    'a thumb sized from the painted extent',
+  );
+
+  assert.equal(editor.focusableByDefault, true, 'a tab stop, being scrollable');
+  assert.equal(a11yRole(editor), ATSPI_ROLE.SCROLL_PANE);
+
+  editor.focus();
+  await tick();
+  pressKey(app, wnd, XK_PAGE_DOWN);
+  await tick();
+  assert.ok(editor.scrollY > 0, 'PageDown paged the painted content');
+});
+
+test('a horizontal extent it reports is one the wheel can reach', async () => {
+  const ref = React.createRef();
+  const { wnd } = await mount(
+    h('miniedit', {
+      ref,
+      lines: 1,
+      columns: 20,
+      style: { width: 200, height: 100 },
+    }),
+  );
+  assert.equal(ref.current.canScroll(0, 1), false, 'nothing vertical');
+  wheel(wnd, 50, 50, 7); // X button 7 is a wheel-right
+  await tick();
+  assert.ok(ref.current.scrollX > 0);
+});
+
+test('a nonsense measurement names the element instead of spreading NaNs', async () => {
+  const ref = React.createRef();
+  const { node, root } = await mount(
+    h('miniedit', { ref, lines: 40, style: { width: 200, height: 100 } }),
+  );
+  const honest = ref.current.measureScrollContent;
+  // A NaN content extent does not throw on its own: it becomes a NaN max
+  // scroll, a NaN offset and a subtree laid out at NaN, with nothing saying
+  // which element produced it.
+  ref.current.measureScrollContent = () => ({ width: 0, height: undefined });
+  ref.current.invalidate(true, ref.current, 'scroll');
+  assert.throws(
+    () => node.flush(),
+    /<miniedit>\.measureScrollContent\(\) must return \{ width, height \}/,
+  );
+
+  // …and the frame the throw abandoned is still queued: put the honest
+  // measurement back before it runs, or it takes the process with it.
+  ref.current.measureScrollContent = honest;
+  await root.unmount();
+});
+
+// --- core's own self-painting scroller --------------------------------------
+//
+// `<textarea>` was the `kind === 'textarea'` branch in the wheel's default
+// action, which is what said the protocol was missing a member. It is a
+// member now, and these two tests are the halves of that: it takes the
+// wheel through `canScroll`/`scrollBy`, and it lets go of it when there is
+// nothing left to take — which the old branch never did.
+
+/** A real (in-process) X server, because a textarea's scroll extent comes
+ * out of shaped text and the mock connection has no fonts. */
+async function headlessApp() {
+  const require = createRequire(import.meta.url);
+  const fontDir = join(
+    dirname(require.resolve('katex/package.json')),
+    'dist',
+    'fonts',
+  );
+  const server = xserver.createServer({ width: 400, height: 400 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const fontSource = new StaticFontSource();
+  fontSource.add(readFileSync(join(fontDir, 'KaTeX_Main-Regular.ttf')), {
+    family: 'Test Main',
+  });
+  fontSource.alias('sans-serif', 'Test Main');
+  return createClient({ stream: clientEnd, fontSource });
+}
+
+test('the wheel scrolls a <textarea> with no branch naming it', async () => {
+  const app = await headlessApp();
+  const root = await createRoot({ app });
+  try {
+    const ref = React.createRef();
+    root.render(
+      h(
+        'window',
+        { width: 240, height: 200 },
+        h('textarea', {
+          ref,
+          rows: 3,
+          defaultValue: Array.from({ length: 30 }, (_, i) => `line ${i}`).join(
+            '\n',
+          ),
+        }),
+      ),
+    );
+    await tick();
+    const wnd = app.windows?.[0] ?? ref.current.root.window;
+    ref.current.root.flush();
+
+    assert.equal(ref.current.canScroll(0, 48), true, 'it says so itself');
+    assert.equal(ref.current.canScroll(48, 0), false, 'and only vertically');
+
+    wheel(wnd, 20, 20);
+    await tick();
+    assert.ok(ref.current._scrollY > 0, 'the wheel reached it');
+  } finally {
+    await root.unmount();
+    await app.close();
+  }
+});
+
+test('a <textarea> whose text fits hands the wheel to the pane behind it', async () => {
+  const app = await headlessApp();
+  const root = await createRoot({ app });
+  try {
+    const ref = React.createRef();
+    const area = React.createRef();
+    root.render(
+      h(
+        'window',
+        { width: 240, height: 120, style: { overflow: 'scroll' } },
+        h('textarea', { ref: area, rows: 3, defaultValue: 'one line' }),
+        h('box', { ref, style: { height: 400, flexShrink: 0 } }),
+      ),
+    );
+    await tick();
+    const node = area.current.root;
+    node.flush();
+    const wnd = app.windows?.[0] ?? node.window;
+
+    assert.equal(area.current.canScroll(0, 48), false, 'one line fits');
+    wheel(wnd, 20, 20); // over the field
+    await tick();
+    assert.equal(area.current._scrollY, 0);
+    assert.equal(node.scrollY, 48, 'the window answered it instead');
+  } finally {
+    await root.unmount();
+    await app.close();
+  }
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -202,6 +202,8 @@ function Elements() {
   // pointer against this box has to read
   const _dir: 'ltr' | 'rtl' | undefined = boxRef.current?.direction;
   const _holds = () => boxRef.current?.contains(inputRef.current);
+  // issue #253: the question the wheel asks a scroller on its way out
+  const _room: boolean | undefined = scrollRef.current?.canScroll(0, 48);
   // focus() hands the node back, so an imperative handle can forward it
   const _refocus = () => inputRef.current?.blur().focus();
   // @ts-expect-error — the element name is `kind`; no node has a `type`

--- a/test/types/extend.tsx
+++ b/test/types/extend.tsx
@@ -16,6 +16,7 @@ import {
 import {
   Node,
   BoxNode,
+  Scrollable,
   intrinsicSize,
   CARET_BLINK_MS,
 } from '../../src/node.js';
@@ -208,6 +209,60 @@ class EditorNode extends Node {
 
 registerElement('codeeditor', {
   create: (props, app) => new EditorNode(props, app as never),
+});
+
+// An element that scrolls pixels it painted (#253). The mixin brings the
+// offsets, the bars and the keys; the override is the one number pair only
+// this element knows.
+class TerminalNode extends Scrollable(Node) {
+  private rows: string[] = [];
+
+  constructor(props: Record<string, unknown>, app: never) {
+    super('miniterm', props, app);
+  }
+
+  isScroller(): boolean {
+    return true;
+  }
+
+  measureScrollContent(): { width: number; height: number } {
+    return { width: 400, height: this.rows.length * 16 };
+  }
+
+  paintContent(_ctx: unknown): void {
+    // the offsets the mixin clamped, subtracted by the drawing itself
+    const _x: number = this.scrollX;
+    const _y: number = this.scrollY;
+    void _x;
+    void _y;
+  }
+}
+
+// …and the chain on its own: two methods, no mixin, the shape the wheel's
+// default action calls.
+class TickerNode extends Node {
+  private at = 0;
+
+  constructor(props: Record<string, unknown>, app: never) {
+    super('miniticker', props, app);
+  }
+
+  canScroll(_dx: number, dy: number): boolean {
+    return Boolean(dy) && this.at < 400;
+  }
+
+  scrollBy(by: number | { x?: number; y?: number }): void {
+    this.at += typeof by === 'number' ? by : (by.y ?? 0);
+  }
+}
+
+registerElement('miniterm', {
+  create: (props, app) => new TerminalNode(props, app as never),
+  childrenAllowed: false,
+});
+registerElement('miniticker', {
+  create: (props, app) => new TickerNode(props, app as never),
+  childrenAllowed: false,
 });
 
 registerElement('gauge', {


### PR DESCRIPTION
The wheel's default action walked out from the target looking for a scroll
container, and had one line in it naming `<textarea>` by kind. That branch
was the tell: `<textarea>` scrolls content it paints rather than children it
lays out, it could not join the chain the boxes were in, and neither could
anything a sibling package might write — a code editor, a terminal, a
canvas-backed table — because the question the chain asked was `_canScroll`,
underscored and therefore nobody's to answer.

The chain is now two public methods and no kinds:

    canScroll(dx, dy)   is there room to move on the axis this delta names?
    scrollBy(by)        move by that much

The walk asks each node out from the target and the first that says yes gets
the notch. `<textarea>` answers both, so the `kind === 'textarea'` branch is
gone — and with it a small bug it carried: the branch always broke the walk,
so a field whose text fitted swallowed the wheel the window would have
answered. It chains now, like everything else.

For the mixin, `Scrollable` gains `measureScrollContent()`. The extent used
to be a private child walk, which measures 0 for an element whose content is
a drawing — so a self-painting scroller clamped to nothing however far the
drawing went. Overriding it is the whole of joining in: the maxima, the
bars, the scroll keys, `scrollIntoView` and the AT-SPI scroll-pane role all
read the two numbers it returns. A non-finite answer throws naming the
element, as `measureContent` does, rather than laying a subtree out at NaN.

`Node._paintContent` is public as `paintContent(ctx)` in the same pass,
because a scroller needs it: `paint` draws background, content, children,
border, and — for a `Scrollable` — the bars last, so an element drawing
after `super.paint(ctx)` returns paints over its own thumb. It is where
every built-in that draws already draws.

Drag auto-scroll keeps the exclusion it always had, now stated in the
vocabulary that exists for it: it takes scroll *containers* — the nodes
that answer `isScroller` — and not everything that answers `canScroll`,
because nothing can be dropped into a `<textarea>` and scrolling one during
a drag moves content out of reach.

BREAKING CHANGE: `_canScroll(dx, dy)` is now `canScroll(dx, dy)` and
`Node._paintContent(ctx)` is now `paintContent(ctx)`. A `Scrollable`'s
content extent comes from `measureScrollContent()`, which returns
`{ width, height }` including the end padding, where the private
`_measureContent()` it replaces returned `{ right, bottom }` without it.

Closes #253
