### PR TITLE
feat(style)!: the layout mirrors — direction, logical edges, and an RTL widget set

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,14 @@ no override-redirect staging (issue #4).
   `npm run examples:urischeme` is the manual harness for the two dispatch paths
   a broker cannot fake.
 - `src/styles.js` — flat style props → yoga setters; paint prop
-  classification; text style resolution. Also the two prop sets the
+  classification; text style resolution. Also the **logical** edges
+  (`paddingStart`, `marginEnd`, `borderStartWidth`, `start`/`end`) and the
+  `direction` that decides what they mean: yoga resolves those for the
+  layout, and `Node.direction` (nodes.js) resolves the same rule a second
+  time for everything outside it — which side a scrollbar sits on, which
+  edge a logical border paints, the base level a paragraph of neutral
+  characters shapes at. The floor under it is the palette's `direction`,
+  seeded from the locale. Also the two prop sets the
   **inheritance** rule is written as: `INHERITED_TEXT_PROPS` (the ink, the
   face, the size — what travels down the tree) and `LOCAL_TEXT_PROPS` (what
   shapes a node's own box and therefore cannot arrive from above). Which

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -84,7 +84,7 @@ merged theme (`ThemeProvider`, `useTheme`) and a
   arrows/Home/End/PageUp/Down)
 - **Switch animation** — DONE via style transitions, not a per-widget
   requestAnimationFrame loop: the thumb is absolutely positioned and slides
-  on `left`, and the same `transition` declaration eases the track colour.
+  on `start`, and the same `transition` declaration eases the track colour.
   The frame loop runs only while something is unfinished
   ([docs/styling.md](docs/styling.md))
 - **Tooltip** — DONE: `useAnchor(ref)`/`anchorRect()` extracted from

--- a/docs/components.md
+++ b/docs/components.md
@@ -48,6 +48,7 @@ control are most of what separates one platform's controls from another's:
 | `radiusPopup` `radiusPopupItem` `radiusTooltip` | floating-surface shape         |
 | `fontSize` `paddingX` `paddingY`                | control size                   |
 | `fontFamily` `monoFamily`                       | the app's two faces            |
+| `direction`                                     | which way the app reads        |
 
 `fontFamily` and `fontSize` are the type this app sets, and text that names
 neither **takes them** — a `<text>`, a `<textinput>`, a widget's own label. So
@@ -69,6 +70,46 @@ preference and a fallback.
 that every code surface in an app — a listing, a log pane, a hex dump, all
 written by different components — can say `fontFamily: '$monoFamily'` and be
 set from one place.
+
+### Which way it reads
+
+`direction` is `'ltr'` or `'rtl'`, and it is **seeded from the locale**: an
+app started under an RTL locale is mirrored without being configured, the
+way a GTK or Qt one is. Set it here to mirror a whole UI from one place:
+
+```jsx
+<ThemeProvider value={{ direction: settings.rtl ? 'rtl' : 'ltr' }}>
+```
+
+The provider plants the matching `direction` style property in the node tree
+as it goes, so the **boxes** and the **widgets** mirror together. That is
+why this is the way to do it rather than a bare `<box style={{ direction:
+'rtl' }}>`: yoga mirrors boxes on its own, but which way an arrow key steps,
+which way a chevron points and which side a submenu opens on are widget
+decisions, read through `useDirection()`. Under a bare style property the
+layout mirrors and those do not.
+
+Most of the set needs no help — `Button`, `Checkbox`, `Radio`, `Switch` and
+`ProgressBar` are rows and flex ratios, and come out mirrored on their own.
+The rest each have one thing yoga could not answer:
+
+| widget                    | what mirrors                                        |
+| ------------------------- | --------------------------------------------------- |
+| `Slider`                  | the drag, and Left/Right (Up/Down do not)           |
+| `Tabs`                    | Left/Right walk the strip the way it is drawn       |
+| `Tree`                    | the indent, the twisty, and which arrow opens       |
+| `Table`                   | column resizing, the sort mark, the header's scroll |
+| `SplitPane`               | which pane is first, the drag and its arrows        |
+| `MenuBar` / `ContextMenu` | submenus open to the start side, and their arrows   |
+| `Calendar` / `DatePicker` | a week runs the other way, and so do Left/Right     |
+| `Select`, `PasswordInput` | the field's own insets follow the text              |
+
+`<textinput>` and `<textarea>` are the gap: they shape and draw bidi text
+correctly, but the field's own origin and caret scrolling are still
+left-to-right.
+
+See [styling.md](styling.md#direction-and-the-logical-edges) for the style
+property and the logical edges.
 
 `paddingY` is the space **you can see** — above the capitals and below the
 baseline — not the space plus whatever the font's ascent left over: every
@@ -1437,19 +1478,28 @@ const rect = measure({ placement: 'bottom', align: 'center', width, height });
 // -> { x, y, width, height, placement }
 ```
 
-| option            |                                                            |
-| ----------------- | ---------------------------------------------------------- |
-| `placement`       | `'bottom'` (default), `'top'`, `'left'`, `'right'`         |
-| `align`           | `'start'` (default), `'center'`, `'end'` on the cross axis |
-| `offset`          | gap from the anchor in px (default 2)                      |
-| `width`, `height` | size of the popup you are positioning                      |
-| `alignTo`         | node the alignment reads, when it is not the anchor        |
+| option            |                                                                        |
+| ----------------- | ---------------------------------------------------------------------- |
+| `placement`       | `'bottom'` (default), `'top'`, `'start'`, `'end'`, `'left'`, `'right'` |
+| `align`           | `'start'` (default), `'center'`, `'end'` on the cross axis             |
+| `offset`          | gap from the anchor in px (default 2)                                  |
+| `width`, `height` | size of the popup you are positioning                                  |
+| `alignTo`         | node the alignment reads, when it is not the anchor                    |
 
 `placement` is a **preference, not a promise**: a menu near the bottom of
 the screen flips above its trigger rather than opening off-screen, and the
 result is clamped into the screen either way. The side actually used comes
 back as `placement`. Where screen geometry is unavailable it places without
 clamping.
+
+`'start'` and `'end'` are the **logical** sides and are what a submenu
+wants: it opens away from the edge its parent's rows begin at, which is
+leftwards in a mirrored menu, and still flips at the screen edge from there.
+`'left'`/`'right'` stay physical. `align` mirrors the same way, but only
+when the popup is above or below its trigger — with one beside it the
+alignment axis is vertical, and nothing vertical mirrors. The direction is
+read off the anchoring node, so a menu inside a mirrored panel needs no
+argument.
 
 `alignTo` takes the two axes from **different nodes**: the placement edge
 from the anchor, the alignment from `alignTo`. A submenu is the case that

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -313,9 +313,9 @@ same screenshots far more than this route did.
 ## Invalidation reasons
 
 Every internal `invalidate()` call now names why it ran, from a small
-closed set: `props`, `style-state`, `theme`, `animation`, `scroll`,
-`text`, `content`, `measure`, `child-list`, `focus`, `caret`, `resize`,
-`mount`, `expose`, `highlight`. The frame's collected reasons are what
+closed set: `props`, `style-state`, `theme`, `direction`, `animation`,
+`scroll`, `text`, `content`, `measure`, `child-list`, `focus`, `caret`,
+`resize`, `mount`, `expose`, `highlight`, `capabilities`. The frame's collected reasons are what
 `REACT_X11_TRACE=requests` frame lines, the chrome trace's frame slices,
 the full-repaint warning and `examples/stress/perf.js` print. After a
 frame they are readable on the window node as `root._lastReasons`

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -762,6 +762,13 @@ around the labels in it
 `textAlign` and `lineHeight` do not: they shape the box the lines flow in,
 which belongs to the `<text>` that owns it.
 
+`start` and `end` are resolved against the box's own **direction**, not
+against the first strong character in the string — the box says which way it
+reads and the paragraph is laid out at that base level, so `"(12) files"` in
+an RTL panel punctuates as an RTL sentence and a `<text>` with no strong
+characters at all still lands on the right side.
+See [styling.md](styling.md#direction-and-the-logical-edges).
+
 ### Variable fonts
 
 _ntk ≥ 7.1.0._

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -104,6 +104,11 @@ And what you read:
   content goes, and where every built-in draws.
 - `this.resolvedTextStyle()` — the text style this node resolves to, ready to
   hand to `app.fonts.layout` (below).
+- `this.direction` — which way this node reads, resolved: `'ltr'` or
+  `'rtl'`, never `'inherit'`. Yoga has already mirrored the boxes, so this
+  is for what you draw _inside_ one — which side a mark sits on, which way
+  a chevron points, what a pointer coordinate means
+  ([styling.md](styling.md#direction-and-the-logical-edges)).
 - `this.root` — the owning `<window>` node; `this.app` — the ntk connection.
 - `this.theme` — the nearest theme at or above this node.
 

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -188,6 +188,80 @@ every ring under it at once — the renderer reads them from the nearest
 `theme` prop, so `<ThemeProvider>` covers the widgets and anything an
 application writes itself.
 
+## Direction, and the logical edges
+
+```jsx
+<box style={{ direction: 'rtl' }}>
+  <box style={{ flexDirection: 'row', paddingStart: 12, gap: 8 }}>…</box>
+</box>
+```
+
+`direction` is CSS's, `'ltr' | 'rtl' | 'inherit'`, and it inherits: setting
+it mirrors that subtree and nothing above it. Rows run the other way, `flex-start`
+is the right-hand end, and every logical edge below swaps sides with it.
+
+**The default comes from the locale.** An app started under
+`LANG=ar_EG.UTF-8` is mirrored with no configuration, because that is what
+GTK and Qt both do and because the alternative is an Arabic desktop where
+one application's panels are on the wrong side. Every locale that is not
+written right to left answers `'ltr'`, so an app that never thinks about
+this pays nothing. The palette carries it — `theme.direction` — so an app
+with a language menu switches the whole UI with the `<ThemeProvider>` swap
+it was already doing for colours:
+
+```jsx
+<ThemeProvider value={{ direction: settings.rtl ? 'rtl' : 'ltr' }}>
+```
+
+Prefer the provider over a bare `direction` style when the region contains
+**widgets**. Yoga mirrors boxes on its own, so most of the widget set needs
+nothing — a `<Checkbox>` is a row with a gap — but the decisions yoga cannot
+make (which way an arrow key steps, which way a chevron points, which side a
+submenu opens on) are read from the palette through `useDirection()`. A
+provider plants the matching style property in the tree as it goes, so both
+routes always agree under one.
+
+### The logical edges
+
+| logical                          | physical in LTR                | in RTL  |
+| -------------------------------- | ------------------------------ | ------- |
+| `start` / `end`                  | `left` / `right`               | swapped |
+| `marginStart` / `marginEnd`      | `marginLeft` / `marginRight`   | swapped |
+| `paddingStart` / `paddingEnd`    | `paddingLeft` / `paddingRight` | swapped |
+| `borderStartWidth` / `…EndWidth` | `borderLeftWidth` / `…Right…`  | swapped |
+| `borderStartColor` / `…EndColor` | `borderLeftColor` / `…Right…`  | swapped |
+
+**A logical edge wins over the physical one even in LTR**, the way CSS's
+`padding-inline-start` wins over `padding-left`. Yoga's full order is
+start/end, then the physical side, then `EDGE_HORIZONTAL`, then
+`EDGE_ALL` — the opposite way round from what the vertical shorthands
+suggest, which is why it is pinned in a test.
+
+Write layout in the logical pair and it is the same layout in both
+directions. Use the physical one when you mean the screen: a drop shadow, a
+resize handle in a fixed corner.
+
+### What does not mirror
+
+- **`<canvas>`** — the drawing is the application's, and `ctx` keeps its
+  top-left origin. An app that wants mirrored art reads `node.direction`
+  from the ref it already has.
+- **A `<window>`'s or `<popup>`'s explicit `x`/`y`** — screen coordinates.
+- **Vertical anything.** `top`/`bottom`, a column's order, a vertical
+  scrollbar's travel, Up/Down on every control.
+- **`<textinput>` and `<textarea>`.** They shape and draw bidi text
+  correctly — that is ntk's doing — but the field's own origin, caret
+  scrolling and selection geometry are still written left-to-right. Wrapping
+  one in an RTL box mirrors the box around it and not the field inside it.
+  Tracked separately.
+
+What **does**, besides the box tree: a vertical scrollbar moves to the left;
+horizontal scrolling counts from the right-hand edge, so `scrollX: 0` still
+means "at the beginning"; `textAlign: 'start'`/`'end'` resolve against the
+box's direction rather than against the first strong character; and a popup
+prefers the start side, so a submenu opens leftwards and still flips at the
+screen edge.
+
 ## Per-side borders
 
 ```jsx
@@ -200,7 +274,9 @@ application writes itself.
 
 A side width overrides the `borderWidth` shorthand exactly the way
 `paddingLeft` overrides `padding`, and a side colour
-(`borderTopColor`/`Right`/`Bottom`/`Left`) falls back to `borderColor`. The
+(`borderTopColor`/`Right`/`Bottom`/`Left`) falls back to `borderColor`.
+`borderStartWidth`/`borderStartColor` and their `End` counterparts are the
+[logical](#the-logical-edges) pair, and they win over the physical side. The
 widths are layout — yoga sees each edge, so the bar above insets content on
 the left only — and the colours are paint, legal in a state block like
 `borderColor` itself.

--- a/src/components/Calendar.js
+++ b/src/components/Calendar.js
@@ -4,7 +4,7 @@
 
 import React, { useImperativeHandle, useMemo, useState } from 'react';
 import { createStyles, tint } from '../styles.js';
-import { capTrim, useTheme } from './theme.js';
+import { capTrim, useDirection, useTheme } from './theme.js';
 import { Icon } from './Icon.js';
 import { changeEvent } from './change.js';
 import {
@@ -241,8 +241,11 @@ function DayCell({ day, state, theme, band, onPick, onHover, dayContent }) {
         style: [
           s.band,
           {
-            left: band.opensRight ? CELL_W / 2 : 0,
-            right: band.opensLeft ? CELL_W / 2 : 0,
+            // logical insets: the band runs along the row of days, and the
+            // row runs the way the text does — a mirrored month puts later
+            // days to the left
+            start: band.opensEnd ? CELL_W / 2 : 0,
+            end: band.opensStart ? CELL_W / 2 : 0,
             backgroundColor: tint(theme.accent, 0.18),
           },
         ],
@@ -357,6 +360,7 @@ export function Calendar({
   ...boxProps
 }) {
   const theme = useTheme();
+  const rtl = useDirection() === 'rtl';
   const minDay = toDay(min);
   const maxDay = toDay(max);
   const todayKey = today();
@@ -464,12 +468,16 @@ export function Calendar({
   /** Returns whether the key was the calendar's — a picker wrapping this one
    *  still owns Escape and Tab, and has no other way to tell. */
   const handleKey = (ev) => {
+    // A week is a `row`, so a mirrored month runs its days right to left and
+    // the key that steps to *tomorrow* is Left. Up and Down are a week either
+    // way — the grid only mirrors along one axis.
+    const nextDay = rtl ? -1 : 1;
     switch (ev.keysym) {
       case XK_LEFT:
-        moveFocus(-1);
+        moveFocus(-nextDay);
         return true;
       case XK_RIGHT:
-        moveFocus(1);
+        moveFocus(nextDay);
         return true;
       case XK_UP:
         moveFocus(-7);
@@ -582,7 +590,7 @@ export function Calendar({
             onPick: pick,
             onHover: pending ? setHovered : undefined,
             band: inBand
-              ? { opensRight: day === bandStart, opensLeft: day === bandEnd }
+              ? { opensEnd: day === bandStart, opensStart: day === bandEnd }
               : null,
             state: {
               blocked: isBlocked(day),

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -3,7 +3,13 @@
 // build-step-free for consumers.
 
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { capBand, capTrim, rowRadius, useTheme } from './theme.js';
+import {
+  capBand,
+  capTrim,
+  rowRadius,
+  useDirection,
+  useTheme,
+} from './theme.js';
 import { Icon, iconSize } from './Icon.js';
 import {
   DEFAULT_LABEL_SIZE,
@@ -308,6 +314,7 @@ function MenuRow({
   nodeRef,
 }) {
   const theme = useTheme();
+  const rtl = useDirection() === 'rtl';
   // only the live end of the trail takes the selection colour, and with it
   // the inverted label
   const active = state === 'active';
@@ -405,7 +412,9 @@ function MenuRow({
       ),
     submenu &&
       h(Icon, {
-        name: 'chevronRight',
+        // points the way the submenu opens, which is away from the edge the
+        // rows begin at
+        name: rtl ? 'chevronLeft' : 'chevronRight',
         // The capitals of the row, not the gutter's 16px column: a chevron
         // stands as tall as its box, so `MENU_ICON_SIZE` would put an arrow
         // beside the label taller than the label.
@@ -473,7 +482,9 @@ function MenuLevel({
     if (!node?.abs?.width) return;
     setChildRect(
       anchorRect(listRef.current ?? node, {
-        placement: 'right',
+        // the logical side: a submenu opens away from the edge its parent's
+        // rows begin at, and still flips at the screen edge from there
+        placement: 'end',
         // The edge comes from the list box, which fills the popup, and the
         // alignment from the row. Anchoring both to the row put the submenu
         // a border and a padding *inside* its parent's right edge, so the
@@ -634,10 +645,13 @@ function MenuLevel({
  *
  * Returns true when the key was consumed. Left and Right fall through when
  * there is no submenu to enter or leave, so `MenuBar` can walk the bar.
+ *
+ * `rtl` swaps the two horizontal keys, because they name what happens on the
+ * screen: a submenu that opens to the left is a submenu Left enters.
  */
 function handleMenuKey(
   ev,
-  { rootItems, path, setPath, select, close, typeAhead },
+  { rootItems, path, setPath, select, close, typeAhead, rtl = false },
 ) {
   const depth = path.length - 1;
   if (depth < 0) return false;
@@ -684,9 +698,9 @@ function handleMenuKey(
       );
       return true;
     }
-    case XK_RIGHT:
+    case rtl ? XK_LEFT : XK_RIGHT:
       return enterSubmenu();
-    case XK_LEFT:
+    case rtl ? XK_RIGHT : XK_LEFT:
       if (depth > 0) {
         setPath(path.slice(0, -1));
         return true;
@@ -731,6 +745,7 @@ export function ContextMenu({
   const [rect, setRect] = useState(null);
   const [path, setPath] = useState([]);
   const typeAhead = useTypeAhead();
+  const rtl = useDirection() === 'rtl';
 
   const close = () => {
     setRect(null);
@@ -794,6 +809,7 @@ export function ContextMenu({
           select,
           close,
           typeAhead,
+          rtl,
         });
       },
       onBlur: close,
@@ -837,6 +853,7 @@ export function MenuBar({
   ...boxProps
 }) {
   const theme = useTheme();
+  const rtl = useDirection() === 'rtl';
   const [openIndex, setOpenIndex] = useState(-1);
   const [rect, setRect] = useState(null);
   const [path, setPath] = useState([]);
@@ -1115,8 +1132,8 @@ export function MenuBar({
               }
               if (ev.codepoint === 32 || ev.keysym === XK_RETURN) {
                 openMenu(index);
-              } else if (ev.keysym === XK_LEFT) moveMenu(-1);
-              else if (ev.keysym === XK_RIGHT) moveMenu(1);
+              } else if (ev.keysym === XK_LEFT) moveMenu(rtl ? 1 : -1);
+              else if (ev.keysym === XK_RIGHT) moveMenu(rtl ? -1 : 1);
               return;
             }
             // the menu gets first refusal: Left leaves a submenu and Right
@@ -1129,10 +1146,13 @@ export function MenuBar({
               select,
               close,
               typeAhead,
+              rtl,
             });
             if (consumed) return;
-            if (ev.keysym === XK_LEFT) moveMenu(-1);
-            else if (ev.keysym === XK_RIGHT) moveMenu(1);
+            // the bar runs the way the titles do, so Left is the next title
+            // along in a mirrored bar
+            if (ev.keysym === XK_LEFT) moveMenu(rtl ? 1 : -1);
+            else if (ev.keysym === XK_RIGHT) moveMenu(rtl ? -1 : 1);
           },
           style: [
             {

--- a/src/components/PasswordInput.js
+++ b/src/components/PasswordInput.js
@@ -48,8 +48,10 @@ const s = createStyles({
     alignItems: 'center',
     gap: 6,
     padding: 8,
-    paddingLeft: 10,
-    paddingRight: 6,
+    // logical: the text's own inset, and the tighter one on the side the
+    // reveal button sits on, which is wherever the row ends
+    paddingStart: 10,
+    paddingEnd: 6,
   },
   slot: { flexGrow: 1, flexShrink: 1, minWidth: 0, justifyContent: 'center' },
   icon: {

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -66,14 +66,24 @@ export function Slider({
     if (next !== value) onChange?.(changeEvent('range', name, next));
   };
 
-  /** Pointer x -> value, using the track's laid-out rect. */
+  /**
+   * Pointer x -> value, using the track's laid-out rect.
+   *
+   * The direction is read off the **node** rather than the theme: it is the
+   * one the track was actually laid out in, which is what the pointer
+   * coordinate has to be measured against — a slider inside a `<box
+   * style={{ direction: 'rtl' }}>` mirrors without a provider anywhere.
+   */
   const valueAt = (ev) => {
     const node = trackRef.current;
     if (!node?.abs?.width) return value;
     // the thumb is centred on the value, so the usable travel is the track
     // minus one thumb width — otherwise min/max are unreachable at the ends
     const travel = Math.max(1, node.abs.width - SLIDER_THUMB);
-    const x = ev.x - node.abs.x - SLIDER_THUMB / 2;
+    const x =
+      node.direction === 'rtl'
+        ? node.abs.x + node.abs.width - ev.x - SLIDER_THUMB / 2
+        : ev.x - node.abs.x - SLIDER_THUMB / 2;
     return quantize(min + (Math.min(travel, Math.max(0, x)) / travel) * span);
   };
 
@@ -101,12 +111,22 @@ export function Slider({
         onMouseUp: () => setDragging(false),
         onKeyDown: (ev) => {
           const big = (step || 1) * 10;
+          // Left and Right name what the *thumb* should do on the screen, so
+          // in a mirrored slider Left is the one that raises the value —
+          // WAI-ARIA's rule for a horizontal slider, and the only one that
+          // matches what the hand sees. Up and Down never mirror, which is
+          // why they are not folded in with them.
+          const along = trackRef.current?.direction === 'rtl' ? -1 : 1;
           switch (ev.keysym) {
             case XK_LEFT:
+              emit(quantize(clamp(value - along * (step || 1))));
+              return;
+            case XK_RIGHT:
+              emit(quantize(clamp(value + along * (step || 1))));
+              return;
             case XK_DOWN:
               emit(quantize(clamp(value - (step || 1))));
               return;
-            case XK_RIGHT:
             case XK_UP:
               emit(quantize(clamp(value + (step || 1))));
               return;
@@ -188,12 +208,15 @@ export function Slider({
         style: { flexGrow: 1 - fraction, flexShrink: 0, flexBasis: 0 },
       }),
     ),
-    // thumb, centred on the value within the same travel the math uses
+    // thumb, centred on the value within the same travel the math uses.
+    // Logical inset and logical margin: the track's two flex ratios already
+    // mirror on their own — a `row` runs the other way under `direction:
+    // 'rtl'` — and these are what keep the thumb on top of the join.
     h('box', {
       style: {
         position: 'absolute',
-        left: `${fraction * 100}%`,
-        marginLeft: -SLIDER_THUMB * fraction,
+        start: `${fraction * 100}%`,
+        marginStart: -SLIDER_THUMB * fraction,
         width: SLIDER_THUMB,
         height: SLIDER_THUMB,
         borderRadius: SLIDER_THUMB / 2,

--- a/src/components/SplitPane.js
+++ b/src/components/SplitPane.js
@@ -4,7 +4,7 @@
 
 import React, { useRef, useState } from 'react';
 import { createStyles } from '../styles.js';
-import { useTheme } from './theme.js';
+import { useDirection, useTheme } from './theme.js';
 import { XK_DOWN, XK_END, XK_HOME, XK_LEFT, XK_RIGHT, XK_UP } from './keys.js';
 
 const h = React.createElement;
@@ -65,6 +65,7 @@ export function SplitPane({
   ...boxProps
 }) {
   const theme = useTheme();
+  const rtl = useDirection() === 'rtl';
   const [first, second] = React.Children.toArray(children);
   const [uncontrolled, setUncontrolled] = useState(defaultSize);
   const [dragging, setDragging] = useState(false);
@@ -92,12 +93,24 @@ export function SplitPane({
     onResize?.(clamped);
   };
 
+  /**
+   * How far along the split the pointer is, measured from the first pane's
+   * own edge — the top in a column, and in a row the side the panes start
+   * at, which is the right-hand one when the layout is mirrored. Everything
+   * else here is already a distance rather than a coordinate, so this is the
+   * only place the direction gets read.
+   */
+  const alongSplit = (ev, box) => {
+    if (vertical) return ev.y - box.y;
+    return rtl ? box.x + box.width - ev.x : ev.x - box.x;
+  };
+
   const dividerProps = {
     focusable: true,
     onMouseDown: (ev) => {
       const box = rootRef.current?.abs;
       // where in the divider it was taken, so it does not jump on press
-      grab.current = (vertical ? ev.y - box.y : ev.x - box.x) - sizeRef.current;
+      grab.current = alongSplit(ev, box) - sizeRef.current;
       ev.capturePointer();
       draggingRef.current = true;
       setDragging(true);
@@ -106,15 +119,18 @@ export function SplitPane({
       if (!draggingRef.current) return;
       const box = rootRef.current?.abs;
       if (!box) return;
-      commit((vertical ? ev.y - box.y : ev.x - box.x) - grab.current);
+      commit(alongSplit(ev, box) - grab.current);
     },
     onMouseUp: () => {
       draggingRef.current = false;
       setDragging(false);
     },
     onKeyDown: (ev) => {
-      const back = vertical ? XK_UP : XK_LEFT;
-      const forward = vertical ? XK_DOWN : XK_RIGHT;
+      // the key that *shrinks* the first pane is the one pointing back at
+      // its own edge, which swaps with the layout
+      const swap = !vertical && rtl;
+      const back = vertical ? XK_UP : swap ? XK_RIGHT : XK_LEFT;
+      const forward = vertical ? XK_DOWN : swap ? XK_LEFT : XK_RIGHT;
       switch (ev.keysym) {
         case back:
           commit(sizeRef.current - KEY_STEP);

--- a/src/components/Switch.js
+++ b/src/components/Switch.js
@@ -29,14 +29,16 @@ const s = createStyles({
     hitSlop: TRACK_SLOP,
     transition: { backgroundColor: 120 },
   },
-  // absolutely positioned so the thumb slides on `left`: `justifyContent`
-  // would flip it between the ends with nothing in between to animate
+  // absolutely positioned so the thumb slides on `start`: `justifyContent`
+  // would flip it between the ends with nothing in between to animate. The
+  // *logical* inset, so an off switch has its thumb on the side its label
+  // starts at and the slide runs the way the text does.
   thumb: {
     position: 'absolute',
     width: THUMB,
     height: THUMB,
     borderRadius: THUMB / 2,
-    transition: { left: 120 },
+    transition: { start: 120 },
   },
 });
 
@@ -61,7 +63,7 @@ const THUMB_ON = TRACK_WIDTH - THUMB - INSET;
  * node under the pointer, which is what lets the track answer a press that
  * landed on the thumb.
  *
- * The slide is a `transition` on `left`, so the animation is the renderer's
+ * The slide is a `transition` on `start`, so the animation is the renderer's
  * frame clock rather than a requestAnimationFrame loop written here — and
  * the same declaration animates the track colour with it. It runs on the
  * press tint too: 120ms of fade that *starts* on the press frame, which is
@@ -114,7 +116,7 @@ export function Switch({
       style: [
         s.thumb,
         {
-          left: checked ? THUMB_ON : THUMB_OFF,
+          start: checked ? THUMB_ON : THUMB_OFF,
           backgroundColor: theme.background,
         },
       ],

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -4,7 +4,7 @@
 
 import React, { useMemo, useRef, useState } from 'react';
 import { createStyles } from '../styles.js';
-import { capTrim, useTheme } from './theme.js';
+import { capTrim, useDirection, useTheme } from './theme.js';
 import { Icon } from './Icon.js';
 import {
   XK_DOWN,
@@ -54,10 +54,10 @@ const s = createStyles({
     flexDirection: 'row',
     alignItems: 'center',
     height: ROW_HEIGHT,
-    paddingLeft: 8,
-    // Matching the left inset, because the sort mark sits against this edge
-    // now — without it the chevron touches the rule between the columns.
-    paddingRight: 8,
+    paddingStart: 8,
+    // Matching the leading inset, because the sort mark sits against this
+    // edge now — without it the chevron touches the rule between the columns.
+    paddingEnd: 8,
     flexShrink: 0,
     cursor: 'pointer',
     transition: { backgroundColor: 80 },
@@ -85,7 +85,7 @@ const s = createStyles({
   cell: {
     height: ROW_HEIGHT,
     justifyContent: 'center',
-    paddingLeft: 8,
+    paddingStart: 8,
     flexShrink: 0,
     overflow: 'hidden',
   },
@@ -93,10 +93,10 @@ const s = createStyles({
   // would be sliced rather than shown — `textWrap` in styling.md
   cellText: { fontSize: 12, textWrap: 'nowrap' },
   spacer: { flexShrink: 0 },
-  // The mark is pushed right by a spacer, so this is the floor on the gap
-  // rather than the gap: it only does anything once a long caption has eaten
-  // the space between them.
-  sortMark: { marginLeft: 4 },
+  // The mark is pushed to the far end of the header by a spacer, so this is
+  // the floor on the gap rather than the gap: it only does anything once a
+  // long caption has eaten the space between them.
+  sortMark: { marginStart: 4 },
 });
 
 /** The sort chevron, matched to the capitals of the 12px header it follows —
@@ -154,6 +154,7 @@ export function Table({
   ...boxProps
 }) {
   const theme = useTheme();
+  const rtl = useDirection() === 'rtl';
   const [ownSort, setOwnSort] = useState(defaultSort ?? null);
   const [ownSelected, setOwnSelected] = useState(defaultSelected);
   const [widths, setWidths] = useState(() =>
@@ -276,7 +277,9 @@ export function Table({
     onMouseMove: (ev) => {
       const d = drag.current;
       if (!d) return;
-      resize(d.id, d.width + (ev.x - d.from));
+      // dragging the grip away from the column's own start edge widens it,
+      // and which way that is follows the layout
+      resize(d.id, d.width + (rtl ? d.from - ev.x : ev.x - d.from));
     },
     onMouseUp: () => {
       drag.current = null;
@@ -286,8 +289,10 @@ export function Table({
     // than no stop at all. Left/Right, the same pair `SplitPane`'s divider
     // takes; the table's own keys are Up/Down and never collide.
     onKeyDown: (ev) => {
-      if (ev.keysym === XK_LEFT) resize(column.id, columnWidth(column) - STEP);
-      else if (ev.keysym === XK_RIGHT)
+      const narrower = rtl ? XK_RIGHT : XK_LEFT;
+      const wider = rtl ? XK_LEFT : XK_RIGHT;
+      if (ev.keysym === narrower) resize(column.id, columnWidth(column) - STEP);
+      else if (ev.keysym === wider)
         resize(column.id, columnWidth(column) + STEP);
     },
   });
@@ -300,9 +305,12 @@ export function Table({
         style: [
           s.cell,
           { width: columnWidth(column) },
+          // `'right'` is what a numeric column asks for and what it means is
+          // "the end of the row" — a column of figures lines up on the edge
+          // the row finishes at, which is the left one in a mirrored table
           column.align === 'right' && {
             alignItems: 'flex-end',
-            paddingRight: 8,
+            paddingEnd: 8,
           },
         ],
       },
@@ -347,7 +355,9 @@ export function Table({
       { style: [s.headerClip, { backgroundColor: theme.surfaceHover }] },
       h(
         'box',
-        { style: [s.headerRow, { marginLeft: -scrollX, width: totalWidth }] },
+        // `marginStart`, so the header tracks the body's scroll in the
+        // direction the columns actually run
+        { style: [s.headerRow, { marginStart: -scrollX, width: totalWidth }] },
         columns.map((column, index) =>
           // The header cell and the grab band are **siblings**, not a cell
           // with a handle inside it. A click fires on the nearest common

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -4,7 +4,7 @@
 
 import React, { useRef, useState } from 'react';
 import { createStyles } from '../styles.js';
-import { labelContent, useTheme } from './theme.js';
+import { labelContent, useDirection, useTheme } from './theme.js';
 import {
   XK_DOWN,
   XK_END,
@@ -67,6 +67,7 @@ export function Tabs({
   ...boxProps
 }) {
   const theme = useTheme();
+  const rtl = useDirection() === 'rtl';
   const firstEnabled = items.find((item) => !item.disabled)?.id;
   const [uncontrolled, setUncontrolled] = useState(
     defaultValue ?? firstEnabled,
@@ -100,8 +101,12 @@ export function Tabs({
   };
 
   const onKeyDown = (ev) => {
-    const back = vertical ? XK_UP : XK_LEFT;
-    const forward = vertical ? XK_DOWN : XK_RIGHT;
+    // The arrows are visual, the list is logical: in a mirrored horizontal
+    // strip the *next* tab is the one to the left. A vertical strip never
+    // mirrors — Up is Up.
+    const swap = !vertical && rtl;
+    const back = vertical ? XK_UP : swap ? XK_RIGHT : XK_LEFT;
+    const forward = vertical ? XK_DOWN : swap ? XK_LEFT : XK_RIGHT;
     const current = items.findIndex(
       (item) => item.id === (focusedId ?? selected),
     );
@@ -131,8 +136,11 @@ export function Tabs({
   const content =
     typeof active?.content === 'function' ? active.content() : active?.content;
 
+  // A vertical strip's indicator rides the edge the rows *begin* at, so it
+  // is a logical inset; a horizontal one spans the tab and sits underneath
+  // it, where both edges are named and neither is a side.
   const indicatorStyle = vertical
-    ? { top: 0, bottom: 0, left: 0, width: INDICATOR }
+    ? { top: 0, bottom: 0, start: 0, width: INDICATOR }
     : { left: 0, right: 0, bottom: 0, height: INDICATOR };
 
   return h(

--- a/src/components/Tree.js
+++ b/src/components/Tree.js
@@ -4,7 +4,7 @@
 
 import React, { useMemo, useRef, useState } from 'react';
 import { createStyles } from '../styles.js';
-import { labelContent, useTheme } from './theme.js';
+import { labelContent, useDirection, useTheme } from './theme.js';
 import { Icon } from './Icon.js';
 import { typeAheadChar, useTypeAhead } from './typeahead.js';
 import {
@@ -35,7 +35,7 @@ const s = createStyles({
     flexDirection: 'row',
     alignItems: 'center',
     gap: 4,
-    paddingRight: 8,
+    paddingEnd: 8,
     cursor: 'pointer',
     transition: { backgroundColor: 80 },
   },
@@ -96,6 +96,7 @@ export function Tree({
   ...boxProps
 }) {
   const theme = useTheme();
+  const rtl = useDirection() === 'rtl';
   const [ownExpanded, setOwnExpanded] = useState(
     () => new Set(defaultExpanded),
   );
@@ -156,6 +157,12 @@ export function Tree({
       return null;
     };
     const row = rows[index];
+    // Deeper is the direction the indent grows in, which is the direction the
+    // text runs — so it is Left that opens a branch in a mirrored tree, and
+    // the two arrows swap wholesale rather than the tree growing a second
+    // pair of cases
+    const deeper = rtl ? XK_LEFT : XK_RIGHT;
+    const shallower = rtl ? XK_RIGHT : XK_LEFT;
     switch (ev.keysym) {
       case XK_UP:
         goTo(step(-1));
@@ -163,13 +170,13 @@ export function Tree({
       case XK_DOWN:
         goTo(step(1));
         return;
-      case XK_RIGHT:
+      case deeper:
         // open it, then walk into it — one key does both, in order
         if (row?.branch && !openRef.current.has(row.item.id)) {
           toggle(row.item.id, true);
         } else if (row?.branch) goTo(step(1));
         return;
-      case XK_LEFT:
+      case shallower:
         if (row?.branch && openRef.current.has(row.item.id)) {
           toggle(row.item.id, false);
         } else if (row?.parent) {
@@ -230,7 +237,9 @@ export function Tree({
           onClick: () => !item.disabled && goTo({ item, depth, branch }),
           style: [
             s.row,
-            { paddingLeft: 4 + depth * INDENT },
+            // the indent is what says "inside", so it is measured from the
+            // edge the row's label begins at
+            { paddingStart: 4 + depth * INDENT },
             {
               backgroundColor:
                 item.id === current ? theme.hoverBackground : 'transparent',
@@ -279,7 +288,11 @@ export function Tree({
           },
           branch &&
             h(Icon, {
-              name: openSet.has(item.id) ? 'chevronDown' : 'chevronRight',
+              name: openSet.has(item.id)
+                ? 'chevronDown'
+                : rtl
+                  ? 'chevronLeft'
+                  : 'chevronRight',
               size: TWISTY_SIZE,
               // dimmer than the label on an unselected row, and the row's own
               // ink once it is selected — where "the row's own ink" is what

--- a/src/components/anchor.js
+++ b/src/components/anchor.js
@@ -65,6 +65,20 @@ function windowOrigin(node) {
  * what is drawn **in** it: a submenu whose top edge is level with the row
  * that opened it has its first item a border and a padding lower down, and
  * the eye lines up the items, not the boxes.
+ *
+ * ## Which side is which
+ *
+ * `placement: 'start'` and `'end'` are the **logical** sides, and they are
+ * what a submenu wants: a menu opens away from the edge its rows begin at, so
+ * it goes out to the right in an LTR menu and out to the left in an RTL one.
+ * `'left'`/`'right'` stay available and stay physical, for the rare placement
+ * that really is about the screen. `align: 'start'`/`'end'` mirror the same
+ * way — but only when the popup is above or below its trigger, since with a
+ * popup beside it the alignment axis is vertical and nothing about a vertical
+ * axis mirrors.
+ *
+ * The direction comes from the anchoring node, so a menu inside a mirrored
+ * panel opens the mirrored way without its widget being told.
  */
 export function anchorRect(node, options = {}) {
   if (!node?.abs) return null;
@@ -76,7 +90,9 @@ export function anchorRect(node, options = {}) {
     width = node.abs.width,
     height = 0,
     alignTo,
+    direction = node.direction,
   } = options;
+  const rtl = direction === 'rtl';
 
   const origin = windowOrigin(node);
   const ax = origin.x + node.abs.x;
@@ -94,15 +110,36 @@ export function anchorRect(node, options = {}) {
   const sw = screen?.pixel_width;
   const sh = screen?.pixel_height;
 
-  const alignAlong = (start, size, extent) =>
-    alignOffset +
-    (align === 'center'
-      ? start + (size - extent) / 2
-      : align === 'end'
-        ? start + size - extent
-        : start);
+  // `mirrored` is only ever true on the horizontal axis: `alignAlong` serves
+  // both, and a vertically-aligned popup's `start` is the top in every
+  // direction there is.
+  const alignAlong = (start, size, extent, mirrored) => {
+    const at =
+      align === 'center'
+        ? 'center'
+        : (align === 'end') !== mirrored
+          ? 'end'
+          : 'start';
+    return (
+      alignOffset +
+      (at === 'center'
+        ? start + (size - extent) / 2
+        : at === 'end'
+          ? start + size - extent
+          : start)
+    );
+  };
 
-  let side = placement;
+  let side =
+    placement === 'start'
+      ? rtl
+        ? 'right'
+        : 'left'
+      : placement === 'end'
+        ? rtl
+          ? 'left'
+          : 'right'
+        : placement;
   let x;
   let y;
 
@@ -119,7 +156,7 @@ export function anchorRect(node, options = {}) {
       side = 'bottom';
     }
     y = side === 'bottom' ? below : above;
-    x = alignAlong(cx, cross.width, width);
+    x = alignAlong(cx, cross.width, width, rtl);
   } else {
     const after = ax + aw + offset;
     const before = ax - width - offset;
@@ -133,7 +170,7 @@ export function anchorRect(node, options = {}) {
       side = 'right';
     }
     x = side === 'right' ? after : before;
-    y = alignAlong(cy, cross.height, height);
+    y = alignAlong(cy, cross.height, height, false);
   }
 
   if (sw != null) x = Math.max(0, Math.min(x, sw - width));

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -2,7 +2,7 @@
 // modules here are grouped by widget, with the shared plumbing in
 // theme.js (palette + control props), anchor.js (popup geometry),
 // typeahead.js and keys.js.
-export { ThemeProvider, useTheme } from './theme.js';
+export { ThemeProvider, useDirection, useTheme } from './theme.js';
 export {
   anchorRect,
   centerRect,

--- a/src/components/theme.js
+++ b/src/components/theme.js
@@ -104,7 +104,18 @@ export function ThemeProvider({
       ),
     [outer, value, dark, wantsDark],
   );
-  const boxStyle = useMemo(() => (style ? [FILL, style] : FILL), [style]);
+  // A provider that **names** a direction plants it as a style too, so the
+  // node tree mirrors along with the widgets: `useTheme().direction` is what
+  // a `<Slider>` reads, and the `direction` style property is what yoga
+  // reads, and they have to be the same answer. Only when this provider named
+  // it — every provider publishes a *complete* palette, so planting
+  // `theme.direction` unconditionally would pin an inner provider's subtree
+  // back to LTR inside a `<box style={{ direction: 'rtl' }}>`.
+  const named = value?.direction ?? (wantsDark ? dark?.direction : undefined);
+  const boxStyle = useMemo(() => {
+    const base = named ? [FILL, { direction: named }] : [FILL];
+    return style ? [...base, style] : base.length === 1 ? FILL : base;
+  }, [style, named]);
   return h(
     ThemeContext.Provider,
     { value: theme },
@@ -151,6 +162,33 @@ export function useTheme() {
   const system = useAppearanceWhen(provided == null);
   if (provided) return provided;
   return system.colorScheme === 'dark' ? DarkTheme : DefaultTheme;
+}
+
+/**
+ * Which way the widgets here read — `'ltr'` or `'rtl'`.
+ *
+ * **What a widget mirrors is not what a box mirrors.** Yoga mirrors the boxes
+ * on its own from the `direction` style property, so most of the widget set
+ * needs nothing from this: a `<Checkbox>` is a `row` with a gap and a
+ * `<ProgressBar>` is two flex ratios, and both come out mirrored without a
+ * line of code. This is for the decisions yoga cannot make — which way an
+ * arrow key steps, which way a glyph points, which side a menu opens on.
+ *
+ * It comes from the palette because that is the channel a widget can read
+ * during its own render, and because an app with a language menu is already
+ * swapping a `<ThemeProvider>`. The provider plants the matching style
+ * property as it goes, so the boxes and the widgets under it mirror together.
+ *
+ * The one case the two can part company is a bare `<box style={{ direction:
+ * 'rtl' }}>` wrapped around widgets with no provider: the layout mirrors and
+ * a widget's own arithmetic does not. Use a `<ThemeProvider>` to mirror a
+ * region that contains widgets. Where a widget is measuring a **pointer**
+ * against a laid-out box it reads `node.direction` instead — the coordinate
+ * has to be interpreted in the direction the box was really laid out in, or a
+ * drag runs backwards.
+ */
+export function useDirection() {
+  return useTheme().direction === 'rtl' ? 'rtl' : 'ltr';
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,7 @@ export {
   Table,
   SplitPane,
   ThemeProvider,
+  useDirection,
   useTheme,
   Icon,
   icons,

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -32,6 +32,7 @@ import {
   DEFAULT_FOCUS_RING,
   resolveHitSlop,
   resolveBorderWidths,
+  resolveBorderColors,
   tint,
 } from './styles.js';
 import { cssColorStraight } from 'ntk';
@@ -188,6 +189,7 @@ const INVALIDATE_REASONS = new Set([
   'props', // a React commit changed what a node draws
   'style-state', // :hover/:focus/:active/:disabled restyle
   'theme', // a theme/token change restyled a subtree
+  'direction', // the reading direction moved: sides, glyph order, bar edge
   'animation', // a transition frame
   'scroll', // scrollTo/scrollBy/scrollIntoView, textarea/textinput panning
   'text', // text content, input value or caret editing
@@ -1070,6 +1072,10 @@ export class Node {
     // inherits. Undefined means "never asked", which is load-bearing — see
     // `_retext`
     this._resolvedText = undefined;
+    // `direction`'s cache, same contract as `_resolvedText`'s: undefined means
+    // "never asked", which is what lets `_redirectSubtree` stop at a node
+    // nothing below has resolved through
+    this._direction = undefined;
     // hot pointer-path caches (issue #188): the children in paint order,
     // re-verified against the live children on every read, and the
     // subtree's hit reach, invalidated through _clearHitBounds()
@@ -1215,6 +1221,12 @@ export class Node {
     if (!inThemeWalk && inheritedTextChanged(this.style, displayed)) {
       this._retextSubtree();
     }
+    // …and the same funnel is the only place a `direction` can arrive by. The
+    // *layout* half of it went to yoga through `applyLayoutStyle`; this is
+    // everything else that reads a side.
+    if (!inThemeWalk && displayed.direction !== this.style.direction) {
+      this._redirectSubtree();
+    }
     return this.style;
   }
 
@@ -1326,6 +1338,79 @@ export class Node {
     const own = this.props.theme;
     this._theme = own ? { ...inherited, ...own } : inherited;
     return this._theme;
+  }
+
+  /**
+   * Which way this node reads: `'ltr'` or `'rtl'`, never `'inherit'` — this
+   * is the *resolved* answer, which is what everything outside yoga needs.
+   *
+   * Yoga resolves the same question for the layout on its own, and does it
+   * inside WASM where nothing can read it back (the binding has no
+   * `getComputedDirection`). So it is resolved a second time here, over the
+   * same rule, for everything the box tree does not answer: which side a
+   * scrollbar sits on, which physical edge a `borderStartWidth` paints, which
+   * way a popup flips, and the base direction a paragraph of neutral
+   * characters resolves against.
+   *
+   * The rule, nearest first:
+   *
+   * 1. `direction` in this node's own style — CSS's property, and the one
+   *    thing that means "this subtree, whatever is around it".
+   * 2. otherwise the enclosing element's, which is what makes it inherit.
+   * 3. otherwise the palette's, which is seeded from the locale — so an app
+   *    started in an RTL locale is mirrored without being asked, and
+   *    `<ThemeProvider value={{ direction }}>` is how one with a language
+   *    menu says otherwise. The provider plants the matching style property
+   *    as it goes, so rule 1 is what actually carries a mid-tree swap and
+   *    this clause is only ever read at the top of the tree.
+   *
+   * Cached like `theme` and dropped by the same walk, since the two now move
+   * together.
+   */
+  get direction() {
+    if (this._direction !== undefined) return this._direction;
+    const own = this.style.direction;
+    return (this._direction =
+      own === 'ltr' || own === 'rtl'
+        ? own
+        : this.parent
+          ? this.parent.direction
+          : this.theme.direction === 'rtl'
+            ? 'rtl'
+            : 'ltr');
+  }
+
+  /**
+   * The resolved direction moved — because this node's style named a new one,
+   * or because the palette under the whole tree did. Everything below
+   * inherits it, so the caches go with it, and the walk stops where a
+   * subtree states a direction of its own: nothing under that node can have
+   * changed.
+   *
+   * A node that never resolved one has nothing cached below it either —
+   * `direction` fills every ancestor on the way up — which is the same
+   * early-out the text cascade takes.
+   */
+  _redirectSubtree() {
+    if (this._direction === undefined) return;
+    const before = this._direction;
+    this._direction = undefined;
+    if (this.direction === before) return;
+    this._directionMoved();
+    for (const child of this.children) child._redirectSubtree();
+  }
+
+  /**
+   * What a direction change costs this node. The default is a repaint: the
+   * *layout* has already been dealt with by yoga, which was told about the
+   * style property directly, so what is left here is everything painted from
+   * the resolved side — the scrollbar, a logical border, an icon.
+   *
+   * `TextNode` overrides it: a paragraph's base direction is part of how it
+   * is shaped, so its cached layouts have to go.
+   */
+  _directionMoved() {
+    this.root?.invalidate(false, this, 'direction');
   }
 
   /**
@@ -1465,6 +1550,11 @@ export class Node {
     inThemeWalk++;
     try {
       this._theme = undefined;
+      // The palette is the floor under the direction too, and this walk
+      // already visits every node — so the cache is dropped here rather than
+      // through `_redirectSubtree`, which would walk the same subtree again.
+      const wasDirection = this._direction;
+      this._direction = undefined;
       // A `<window>` with no `backgroundColor` of its own follows the palette,
       // and the server's copy of that colour has to follow with it — otherwise
       // the next resize fills the new area in the old scheme.
@@ -1486,6 +1576,9 @@ export class Node {
       // having: nothing else about the node changes, and a cached layout
       // carries the face it was shaped with.
       if (this._retext() !== 0) this.root?.invalidate(true, null, 'theme');
+      if (wasDirection !== undefined && this.direction !== wasDirection) {
+        this._directionMoved();
+      }
       for (const child of this.children) child._themeChanged();
     } finally {
       inThemeWalk--;
@@ -2446,14 +2539,11 @@ export class Node {
   }
 
   _paintBorder(ctx) {
-    const { borderColor, borderRadius = 0 } = this.style;
-    const w = resolveBorderWidths(this.style);
-    const colors = {
-      top: this.style.borderTopColor ?? borderColor,
-      right: this.style.borderRightColor ?? borderColor,
-      bottom: this.style.borderBottomColor ?? borderColor,
-      left: this.style.borderLeftColor ?? borderColor,
-    };
+    const { borderRadius = 0 } = this.style;
+    // Both through the node's resolved direction: a `borderStartWidth` lays
+    // out on one side and has to paint on the same one.
+    const w = resolveBorderWidths(this.style, this.direction);
+    const colors = resolveBorderColors(this.style, this.direction);
     const uniform =
       w.top === w.right &&
       w.top === w.bottom &&
@@ -2791,6 +2881,20 @@ export class TextNode extends Node {
     this._layouts.clear();
   }
 
+  /**
+   * The base direction is an input to shaping, not just to painting: it sets
+   * the level every neutral character resolves against and the edge
+   * `textAlign: 'start'` means. So a paragraph whose direction moved is a
+   * paragraph that has to be laid out again, at the same cost as a font
+   * change.
+   */
+  _directionMoved() {
+    this._textContentChanged();
+    const owner = this._textBoxOwner();
+    if (owner) owner._invalidateLayout('direction');
+    else this.root?.invalidate(true, null, 'direction');
+  }
+
   /** The node that owns the box this text flows in. A span has none of its
    * own, so its geometry — and its damage — belong to the nearest ancestor
    * with a yoga node. */
@@ -2905,6 +3009,16 @@ export class TextNode extends Node {
         maxWidth: Number.isFinite(maxWidth) ? maxWidth : undefined,
         align: this.style.textAlign,
         lineHeight: this.style.lineHeight,
+        // The paragraph's **base** direction, which is not the same question
+        // as which script the characters are in. UAX#9 resolves a run of
+        // neutrals — `"(1) 12:30"`, a filename, a lone bracket — against the
+        // paragraph level, and the first-strong-character rule is only what
+        // to do when nobody said. So handing the box's direction down is what
+        // makes an Arabic paragraph parenthesise and punctuate correctly, and
+        // it is also what `textAlign: 'start'` resolves against: ntk aligns
+        // `start`/`end` to the base level, so a `<text>` with no strong
+        // characters at all lands on the right side of an RTL box.
+        direction: this.direction,
       });
       if (this._layouts.size > 32) this._layouts.clear();
       this._layouts.set(key, layout);
@@ -3034,6 +3148,12 @@ const EMPTY_SCROLLBARS = Object.freeze([]);
  * `viewport`/`content`/`scroll` are along the axis; `across`/`crossSize`
  * place the bar on the other one. `shorten` keeps the two bars out of each
  * other's corner when both are showing.
+ *
+ * `direction` mirrors both of those. A vertical bar sits on the **left** in
+ * an RTL viewport — every desktop does this, and it is not decoration: the
+ * bar belongs on the edge the eye finishes a line at. And a horizontal bar's
+ * thumb starts at the right, because `scroll` is measured from the start of
+ * the content and the start of RTL content is its right-hand edge.
  */
 function scrollbarGeometry({
   axis = 'y',
@@ -3045,17 +3165,26 @@ function scrollbarGeometry({
   scroll,
   inset = 0,
   shorten = 0,
+  direction = 'ltr',
 }) {
   const length = viewport - shorten;
   if (length <= 0 || !(content > viewport)) return null;
+  const rtl = direction === 'rtl';
   const thumbLength = Math.max(
     SCROLLBAR_MIN_THUMB,
     (length * length) / content,
   );
   const range = content - viewport;
   const travel = Math.max(0, length - thumbLength);
-  const thumbStart = start + (range > 0 ? (scroll / range) * travel : 0);
-  const crossStart = crossStart0 + crossSize - SCROLLBAR_WIDTH - inset;
+  const offset = range > 0 ? (scroll / range) * travel : 0;
+  // a vertical bar always fills from the top; only the horizontal one runs
+  // the way the text does
+  const thumbStart =
+    rtl && axis === 'x' ? start + travel - offset : start + offset;
+  const crossStart =
+    rtl && axis === 'y'
+      ? crossStart0 + inset
+      : crossStart0 + crossSize - SCROLLBAR_WIDTH - inset;
   return {
     axis,
     trackStart: start,
@@ -3065,6 +3194,10 @@ function scrollbarGeometry({
     crossStart,
     range,
     travel,
+    // does a larger `scroll` move the thumb *towards* trackStart? The one
+    // place the mirroring is written down, so the drag and the track-page
+    // below read it rather than asking about the direction again
+    reversed: rtl && axis === 'x',
     // the thumb as a rect, for painting
     x: axis === 'x' ? thumbStart : crossStart,
     y: axis === 'x' ? crossStart : thumbStart,
@@ -3192,15 +3325,24 @@ export const Scrollable = (Base) =>
         }
         return;
       }
-      const { right, bottom } = this._measureContent();
+      const rtl = this.direction === 'rtl';
+      const { start, bottom } = this._measureContent();
       this.contentHeight =
         bottom + this.yoga.getComputedPadding(Yoga.EDGE_BOTTOM);
-      this.contentWidth = right + this.yoga.getComputedPadding(Yoga.EDGE_RIGHT);
+      this.contentWidth =
+        start +
+        this.yoga.getComputedPadding(rtl ? Yoga.EDGE_LEFT : Yoga.EDGE_RIGHT);
       this._resolveScrollIntoView();
       this.scrollY = clampScroll(this.scrollY, this._maxScroll('y'));
       this.scrollX = clampScroll(this.scrollX, this._maxScroll('x'));
       this._reportViewport();
-      const ox = originX - this.scrollX;
+      // `scrollX` is how far the content has moved **from its start**, which
+      // is the right-hand edge in RTL — so scrolling shifts the children the
+      // other way. Keeping it a distance rather than a coordinate is what
+      // makes `scrollTo({x: 0})` mean "back to the beginning" in both
+      // directions, and keeps every clamp, every max and the blit's arithmetic
+      // in one sign.
+      const ox = rtl ? originX + this.scrollX : originX - this.scrollX;
       const oy = originY - this.scrollY;
       // The layout diff and a scroll would double-report each other: a scroll
       // is a uniform shift of everything below this viewport, already claimed
@@ -3280,22 +3422,30 @@ export const Scrollable = (Base) =>
      *
      * Anything that clips its own children ends the walk: their overflow is
      * that node's business, not ours.
+     *
+     * `start` is how far the content reaches from the edge it *starts* at,
+     * which is the right-hand one under `direction: 'rtl'` — yoga lays an
+     * overflowing RTL row out at negative offsets, so the reach that matters
+     * there is how far left of zero it got, not how far right.
      */
     _measureContent() {
-      let right = 0;
+      const rtl = this.direction === 'rtl';
+      const width = this.yoga.getComputedWidth();
+      let start = 0;
       let bottom = 0;
       const walk = (node, dx, dy) => {
         for (const child of node.children) {
           if (child.isWindow || !child.yoga || child.hidden) continue;
           const x = dx + child.yoga.getComputedLeft();
           const y = dy + child.yoga.getComputedTop();
-          right = Math.max(right, x + child.yoga.getComputedWidth());
+          const w = child.yoga.getComputedWidth();
+          start = Math.max(start, rtl ? width - x : x + w);
           bottom = Math.max(bottom, y + child.yoga.getComputedHeight());
           if (!child.clipsChildren()) walk(child, x, y);
         }
       };
       walk(this, 0, 0);
-      return { right, bottom };
+      return { start, bottom };
     }
 
     /**
@@ -3412,15 +3562,21 @@ export const Scrollable = (Base) =>
       // arrows and Page keys to whatever else would answer them
       if (!this.focusableByDefault) return undefined;
       const page = Math.max(1, this.abs.height - SCROLL_KEY_PAGE_OVERLAP);
+      // Left and Right are the directions on the *screen*, and `scrollX` runs
+      // from the start of the content — so which of them moves it forward
+      // depends on which way the content runs. Home/End and the Page keys
+      // need no such rule: they already name the logical ends.
+      const forward =
+        this.direction === 'rtl' ? -SCROLL_KEY_STEP : SCROLL_KEY_STEP;
       switch (ev.keysym) {
         case XK_DOWN:
           return this.scrollBy({ y: SCROLL_KEY_STEP });
         case XK_UP:
           return this.scrollBy({ y: -SCROLL_KEY_STEP });
         case XK_RIGHT:
-          return this.scrollBy({ x: SCROLL_KEY_STEP });
+          return this.scrollBy({ x: forward });
         case XK_LEFT:
-          return this.scrollBy({ x: -SCROLL_KEY_STEP });
+          return this.scrollBy({ x: -forward });
         case XK_PAGE_DOWN:
           return this.scrollBy({ y: page });
         case XK_PAGE_UP:
@@ -3468,15 +3624,23 @@ export const Scrollable = (Base) =>
         if (!n.parent) return;
       }
       const bottom = top + target.yoga.getComputedHeight();
-      const rightEdge = left + target.yoga.getComputedWidth();
+      // Horizontally the two edges are measured from the content's **start**,
+      // the same units `scrollX` is in — so under RTL the target's near edge
+      // is its right one and both are counted back from the viewport's width.
+      const w = target.yoga.getComputedWidth();
+      const near =
+        this.direction === 'rtl'
+          ? this.yoga.getComputedWidth() - left - w
+          : left;
+      const far = near + w;
       if (bottom > this.scrollY + this.abs.height) {
         this.scrollY = bottom - this.abs.height;
       }
       if (top < this.scrollY) this.scrollY = top;
-      if (rightEdge > this.scrollX + this.abs.width) {
-        this.scrollX = rightEdge - this.abs.width;
+      if (far > this.scrollX + this.abs.width) {
+        this.scrollX = far - this.abs.width;
       }
-      if (left < this.scrollX) this.scrollX = left;
+      if (near < this.scrollX) this.scrollX = near;
     }
 
     paint(ctx) {
@@ -3512,6 +3676,7 @@ export const Scrollable = (Base) =>
         scroll: horizontal ? this.scrollX : this.scrollY,
         inset: 2,
         shorten: other ? SCROLLBAR_WIDTH + 2 : 0,
+        direction: this.direction,
       });
     }
 
@@ -3545,9 +3710,11 @@ export const Scrollable = (Base) =>
           ev.capturePointer();
           return;
         }
-        // a press on the track pages towards it, like PageUp/PageDown
+        // a press on the track pages towards it, like PageUp/PageDown — and
+        // "towards it" is a visual direction, so it flips with the bar
         const page = bar.axis === 'x' ? this.abs.width : this.abs.height;
-        const delta = at < bar.thumbStart ? -page : page;
+        const back = at < bar.thumbStart ? !bar.reversed : bar.reversed;
+        const delta = back ? -page : page;
         this.scrollBy(bar.axis === 'x' ? { x: delta } : { y: delta });
         return;
       }
@@ -3558,7 +3725,8 @@ export const Scrollable = (Base) =>
       const bar = this._scrollbar(this._barGrab.axis);
       if (!bar || bar.travel <= 0) return;
       const at = along(bar, ev.x, ev.y) - this._barGrab.offset - bar.trackStart;
-      const to = (at / bar.travel) * bar.range;
+      const from = bar.reversed ? bar.travel - at : at;
+      const to = (from / bar.travel) * bar.range;
       this.scrollTo(bar.axis === 'x' ? { x: to } : { y: to });
     }
 
@@ -5261,14 +5429,39 @@ export class WindowNode extends Scrollable(Node) {
    * way, so the floor is measured at the width the window will actually
    * have and re-sent as that changes.
    */
+  /**
+   * The direction to lay this window's tree out in, as yoga spells it.
+   *
+   * `calculateLayout`'s third argument is the direction the *owner* imposes,
+   * and a window has no owner — so the root reads its own resolved value and
+   * hands it down. A `direction` on a `<box>` inside is then yoga's business
+   * rather than ours: it carries the property on its own node and everything
+   * under it inherits from there.
+   */
+  get _rootDirection() {
+    return this.direction === 'rtl' ? Yoga.DIRECTION_RTL : Yoga.DIRECTION_LTR;
+  }
+
+  /**
+   * The root's direction is an argument to `calculateLayout` rather than a
+   * property on a yoga node, so nothing in the box tree is dirty when it
+   * moves and the layout pass has to be asked for. That is only reachable
+   * from the palette — a `direction` written in the window's own style goes
+   * through `applyLayoutStyle`, which dirties the node the ordinary way.
+   */
+  _directionMoved() {
+    this.invalidate(true, null, 'direction');
+  }
+
   _measureMinimum(axis, forWidth) {
     const yoga = this.yoga;
+    const dir = this._rootDirection;
     // The root carries whatever size the last pass pinned on it, and an
     // available size means nothing to a root that has one of its own.
     yoga.setWidth(undefined);
     yoga.setHeight(undefined);
     if (axis === 'width') {
-      yoga.calculateLayout(0, undefined, Yoga.DIRECTION_LTR);
+      yoga.calculateLayout(0, undefined, dir);
       return Math.ceil(contentSpan(this, axis));
     }
     // Height takes two passes. The first is the tree at its real width with
@@ -5277,10 +5470,10 @@ export class WindowNode extends Scrollable(Node) {
     // width, and no leaf can give any of it back. The second is the one
     // that collapses, and it squashes a leaf that a `row` stretches: those
     // are the ones the map above puts back.
-    yoga.calculateLayout(forWidth, undefined, Yoga.DIRECTION_LTR);
+    yoga.calculateLayout(forWidth, undefined, dir);
     const intrinsic = new Map();
     captureLeafHeights(this, intrinsic);
-    yoga.calculateLayout(forWidth, 0, Yoga.DIRECTION_LTR);
+    yoga.calculateLayout(forWidth, 0, dir);
     return Math.ceil(contentSpan(this, axis, intrinsic));
   }
 
@@ -5388,6 +5581,7 @@ export class WindowNode extends Scrollable(Node) {
       return { width: props.width, height: props.height, hints };
     }
 
+    const dir = this._rootDirection;
     const measure = () => {
       // The root carries whatever size the last flush() pinned on it — and
       // whatever the floor pass below cleared — so this is re-stated per
@@ -5397,11 +5591,7 @@ export class WindowNode extends Scrollable(Node) {
       yoga.setHeight(needH ? undefined : props.height);
       let naturalW;
       if (needW) {
-        yoga.calculateLayout(
-          undefined,
-          needH ? undefined : props.height,
-          Yoga.DIRECTION_LTR,
-        );
+        yoga.calculateLayout(undefined, needH ? undefined : props.height, dir);
         naturalW = clampExtent(yoga.getComputedWidth(), undefined, availW);
       }
       const width = autoW ? clampExtent(naturalW, minW, availW) : props.width;
@@ -5409,11 +5599,7 @@ export class WindowNode extends Scrollable(Node) {
       // is the layout the window is about to be created at, so leaving the
       // tree holding the max-content one would hand `flush()` a stale
       // arrangement.
-      yoga.calculateLayout(
-        width,
-        needH ? undefined : props.height,
-        Yoga.DIRECTION_LTR,
-      );
+      yoga.calculateLayout(width, needH ? undefined : props.height, dir);
       const naturalH = needH
         ? clampExtent(yoga.getComputedHeight(), undefined, availH)
         : undefined;
@@ -6676,7 +6862,7 @@ export class WindowNode extends Scrollable(Node) {
       this._resolveSizeQueries(width, height);
       this.yoga.setWidth(width);
       this.yoga.setHeight(height);
-      this.yoga.calculateLayout(width, height, Yoga.DIRECTION_LTR);
+      this.yoga.calculateLayout(width, height, this._rootDirection);
       this.abs = { x: 0, y: 0, width, height };
       // the root's rect is written here, not through _assignAbs, so its
       // cached hit reach is dropped here too (children bubble their own)
@@ -6820,7 +7006,7 @@ export class WindowNode extends Scrollable(Node) {
     if (layoutMoved) return;
     // children clip to the border box, so a border ring or rounded corner
     // would be shifted like content — any painted side counts
-    const blitBorder = resolveBorderWidths(node.style);
+    const blitBorder = resolveBorderWidths(node.style, node.direction);
     if (
       blitBorder.top > 0 ||
       blitBorder.right > 0 ||
@@ -6969,7 +7155,10 @@ export class WindowNode extends Scrollable(Node) {
           // on the path down: its solid background under the viewport is
           // translation-invariant, its border ring and corners are not.
           // The widest side is conservative for a non-uniform border
-          const bw = resolveBorderWidths(child.style ?? EMPTY_STYLE);
+          const bw = resolveBorderWidths(
+            child.style ?? EMPTY_STYLE,
+            child.direction,
+          );
           const inset = Math.max(
             bw.top,
             bw.right,

--- a/src/palette.js
+++ b/src/palette.js
@@ -16,6 +16,76 @@ import { appearanceSnapshot } from './appearance.js';
 import { stepBeyond } from './styles.js';
 
 /**
+ * The language subtags written right-to-left — CLDR's set, by the language
+ * rather than by the script, because a locale name is what an environment
+ * actually carries. Arabic and its neighbours, Hebrew, Persian and Dari,
+ * Pashto, Urdu, Sindhi, Kashmiri, Uyghur, Yiddish, Sorani Kurdish, Dhivehi,
+ * Syriac, N'Ko, and Adlam-written Fulah.
+ */
+const RTL_LANGUAGES = new Set([
+  'ae',
+  'ar',
+  'arc',
+  'bcc',
+  'bqi',
+  'ckb',
+  'dv',
+  'fa',
+  'ff',
+  'glk',
+  'he',
+  'iw',
+  'khw',
+  'ks',
+  'ku',
+  'mzn',
+  'nqo',
+  'pnb',
+  'prs',
+  'ps',
+  'sd',
+  'syr',
+  'ug',
+  'ur',
+  'yi',
+]);
+
+/**
+ * Which way this desktop reads, from the environment's locale.
+ *
+ * **This is the default, and it is a default rather than a setting on
+ * purpose.** An app started under `LANG=ar_EG.UTF-8` is an Arabic app, and
+ * the person who started it should not have to have been given a language
+ * menu before the panels are on the right side. It is what GTK and Qt both
+ * do — GTK asks the translation of `"default:LTR"`, Qt asks the system
+ * locale — and it costs an app that never thinks about this exactly nothing,
+ * because every locale not in the set above answers `'ltr'`.
+ *
+ * The overrides, nearest first: a `direction` style property on any node
+ * mirrors that subtree, and `<ThemeProvider value={{ direction }}>` mirrors
+ * everything under it *including the widgets*, which is the one an app with a
+ * language menu wants — see docs/styling.md.
+ *
+ * There is no environment in the playground bundle, which runs this in a
+ * browser — hence the guard rather than a bare `process.env`. A page has no
+ * locale to read either way; what it has is whatever the app writes.
+ *
+ * Read once, at load: a locale does not change under a running process, and
+ * this is on the path that resolves the palette for every node.
+ */
+export function localeDirection(env = ENV) {
+  const locale = env.LC_ALL || env.LC_MESSAGES || env.LANG || '';
+  // `ar_EG.UTF-8`, `he-IL`, `fa`, or `C`/`POSIX` — the language is whatever
+  // comes before the territory, and the separator is either spelling
+  const language = locale.split(/[._@-]/)[0].toLowerCase();
+  return RTL_LANGUAGES.has(language) ? 'rtl' : 'ltr';
+}
+
+const ENV = typeof process === 'undefined' ? {} : (process.env ?? {});
+
+const LOCALE_DIRECTION = localeDirection();
+
+/**
  * The palette every widget reads, and the shape of the controls with it.
  * A theme overrides what it cares about and inherits the rest, so the
  * defaults here are the look the widgets have always had.
@@ -91,6 +161,17 @@ export const DefaultTheme = {
   // ntk's `fonts.match` splits the list itself.
   fontFamily: 'sans-serif',
   monoFamily: 'monospace',
+  // Which way this app reads — `'ltr'` or `'rtl'`, seeded from the locale.
+  //
+  // In the palette rather than in a context of its own because both consumers
+  // are already here: the widgets read it through `useTheme()` to decide which
+  // way a slider travels or which side a submenu opens on, and the node tree
+  // reads it as the floor under the `direction` style property. An app with a
+  // language menu therefore switches the whole UI, layout and widgets
+  // together, with the `<ThemeProvider>` swap it was already doing for
+  // colours — and a `<ThemeProvider>` that names it plants the matching style
+  // in the tree, so the two routes cannot disagree.
+  direction: LOCALE_DIRECTION,
   paddingX: 16,
   // Measured from the **letters**, not from the font's line box: widget
   // labels are trimmed to the capitals down to the baseline, so this is the

--- a/src/styles.js
+++ b/src/styles.js
@@ -57,6 +57,18 @@ const OVERFLOW = {
   scroll: Yoga.OVERFLOW_SCROLL,
 };
 
+/**
+ * CSS's `direction`. `'inherit'` is yoga's own default and the value every
+ * node keeps having, so writing it is the same as leaving it out — it is
+ * spelled anyway because "take it from the box around me" is a thing a style
+ * has to be able to say back after saying `'rtl'`.
+ */
+const DIRECTION = {
+  ltr: Yoga.DIRECTION_LTR,
+  rtl: Yoga.DIRECTION_RTL,
+  inherit: Yoga.DIRECTION_INHERIT,
+};
+
 const pick = (map, value, name) => {
   if (value === undefined) return undefined;
   if (!(value in map)) {
@@ -98,6 +110,12 @@ const LAYOUT_APPLIERS = {
     n.setPositionType(
       pick(POSITION, v, 'position') ?? Yoga.POSITION_TYPE_RELATIVE,
     ),
+  // Which way the boxes under this one run. Everything else in this file is
+  // physical; this is the one property that decides what "start" means, and
+  // yoga inherits it down its own tree — so a `<box>` that sets it mirrors
+  // that subtree and nothing above it.
+  direction: (n, v) =>
+    n.setDirection(pick(DIRECTION, v, 'direction') ?? Yoga.DIRECTION_INHERIT),
   top: (n, v) => n.setPosition(Yoga.EDGE_TOP, v),
   right: (n, v) => n.setPosition(Yoga.EDGE_RIGHT, v),
   bottom: (n, v) => n.setPosition(Yoga.EDGE_BOTTOM, v),
@@ -112,6 +130,23 @@ const LAYOUT_APPLIERS = {
   paddingRight: (n, v) => n.setPadding(Yoga.EDGE_RIGHT, v),
   paddingBottom: (n, v) => n.setPadding(Yoga.EDGE_BOTTOM, v),
   paddingLeft: (n, v) => n.setPadding(Yoga.EDGE_LEFT, v),
+  // The **logical** edges — the side the text starts on and the side it ends
+  // on, whichever those turn out to be. A stylesheet written in these is the
+  // same stylesheet in both directions, which is the whole reason `direction`
+  // is worth having: a physical `paddingLeft` under `direction: 'rtl'` is a
+  // gutter on the wrong side of the text it was meant to indent.
+  //
+  // Yoga's edge precedence is start/end over the physical side over
+  // `EDGE_HORIZONTAL` over `EDGE_ALL` — so `paddingStart` beats `paddingLeft`
+  // even in LTR where the two name the same edge, the way CSS's
+  // `padding-inline-start` beats `padding-left`. Pinned in a test rather than
+  // trusted, since it is the opposite of what the vertical shorthands do.
+  start: (n, v) => n.setPosition(Yoga.EDGE_START, v),
+  end: (n, v) => n.setPosition(Yoga.EDGE_END, v),
+  marginStart: (n, v) => n.setMargin(Yoga.EDGE_START, v),
+  marginEnd: (n, v) => n.setMargin(Yoga.EDGE_END, v),
+  paddingStart: (n, v) => n.setPadding(Yoga.EDGE_START, v),
+  paddingEnd: (n, v) => n.setPadding(Yoga.EDGE_END, v),
   gap: (n, v) => n.setGap(Yoga.GUTTER_ALL, v ?? 0),
   rowGap: (n, v) => n.setGap(Yoga.GUTTER_ROW, v ?? 0),
   columnGap: (n, v) => n.setGap(Yoga.GUTTER_COLUMN, v ?? 0),
@@ -128,6 +163,8 @@ const LAYOUT_APPLIERS = {
   borderRightWidth: (n, v) => n.setBorder(Yoga.EDGE_RIGHT, v),
   borderBottomWidth: (n, v) => n.setBorder(Yoga.EDGE_BOTTOM, v),
   borderLeftWidth: (n, v) => n.setBorder(Yoga.EDGE_LEFT, v),
+  borderStartWidth: (n, v) => n.setBorder(Yoga.EDGE_START, v),
+  borderEndWidth: (n, v) => n.setBorder(Yoga.EDGE_END, v),
 };
 
 // Props that only affect painting, not geometry.
@@ -144,6 +181,8 @@ const PAINT_PROPS = new Set([
   'borderRightColor',
   'borderBottomColor',
   'borderLeftColor',
+  'borderStartColor',
+  'borderEndColor',
   'borderRadius',
   'zIndex',
   'outlineWidth',
@@ -581,6 +620,7 @@ export function hasStateStyles(style) {
 const NOT_ANIMATABLE = new Set([
   'transition',
   'zIndex',
+  'direction',
   'flexDirection',
   'justifyContent',
   'alignItems',
@@ -920,19 +960,57 @@ export const DEFAULT_FOCUS_RING = {
  * has to name what it grows.
  */
 /**
- * Per-side border widths, resolved the way padding resolves: the side
- * property overrides the `borderWidth` shorthand. This is the paint-side
- * reading of the same rule yoga applies on the layout side (EDGE_TOP wins
- * over EDGE_ALL), kept in one place so the two cannot disagree.
+ * Which physical side each logical edge lands on. The one function that knows
+ * what `start` means, so a widget or a paint path never has to spell the
+ * conditional out again.
  */
-export function resolveBorderWidths(style) {
+export const physicalSides = (direction) =>
+  direction === 'rtl'
+    ? { start: 'right', end: 'left' }
+    : { start: 'left', end: 'right' };
+
+/**
+ * Per-side border widths, resolved the way padding resolves: the side
+ * property overrides the `borderWidth` shorthand, and a **logical** side
+ * overrides the physical one — `borderStartWidth` beats `borderLeftWidth` in
+ * LTR, the way `border-inline-start-width` beats `border-left-width` in CSS.
+ * This is the paint-side reading of the rule yoga applies on the layout side
+ * (EDGE_START over EDGE_LEFT over EDGE_ALL), kept in one place so the two
+ * cannot disagree — a border that lays out one width and paints another is a
+ * gap along the edge of the box.
+ *
+ * `direction` is the resolved direction of the node being painted, so this is
+ * also where a `borderStartWidth` crosses to the other side of the box.
+ */
+export function resolveBorderWidths(style, direction) {
   const all = style.borderWidth ?? 0;
-  return {
+  const { start, end } = physicalSides(direction);
+  const sides = {
     top: style.borderTopWidth ?? all,
     right: style.borderRightWidth ?? all,
     bottom: style.borderBottomWidth ?? all,
     left: style.borderLeftWidth ?? all,
   };
+  if (style.borderStartWidth !== undefined)
+    sides[start] = style.borderStartWidth;
+  if (style.borderEndWidth !== undefined) sides[end] = style.borderEndWidth;
+  return sides;
+}
+
+/** …and the same rule for the colours those widths are stroked in. */
+export function resolveBorderColors(style, direction) {
+  const all = style.borderColor;
+  const { start, end } = physicalSides(direction);
+  const sides = {
+    top: style.borderTopColor ?? all,
+    right: style.borderRightColor ?? all,
+    bottom: style.borderBottomColor ?? all,
+    left: style.borderLeftColor ?? all,
+  };
+  if (style.borderStartColor !== undefined)
+    sides[start] = style.borderStartColor;
+  if (style.borderEndColor !== undefined) sides[end] = style.borderEndColor;
+  return sides;
 }
 
 export function resolveHitSlop(value) {

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -79,6 +79,14 @@ export interface Theme {
    * read by anything unstyled; it is there so `fontFamily: '$monoFamily'`
    * says "this app's mono face" in one place. */
   monoFamily: string;
+  /**
+   * Which way this app reads. Seeded from the environment's locale, so an app
+   * started under an RTL locale is mirrored without being asked; set it to
+   * mirror a whole UI from one place — the provider plants the matching
+   * `direction` style property in the tree, so the boxes and the widgets
+   * follow it together.
+   */
+  direction: 'ltr' | 'rtl';
   paddingX: number;
   paddingY: number;
 }
@@ -139,6 +147,13 @@ export interface ThemeTokens extends Theme {
 /** The palette in force: merged over the defaults and over any outer
  * provider, and the same object `$token` resolution sees. */
 export function useTheme(): ThemeTokens;
+
+/**
+ * Which way the widgets here read. Yoga mirrors the boxes on its own from the
+ * `direction` style property, so this is for what it cannot decide: which way
+ * an arrow key steps, which way a glyph points, which side a menu opens on.
+ */
+export function useDirection(): 'ltr' | 'rtl';
 
 /** Props a widget passes through to the `<box>` it renders. */
 type WidgetProps = Omit<BoxProps, 'children' | 'style' | 'ref'>;

--- a/src/types/nodes.d.ts
+++ b/src/types/nodes.d.ts
@@ -30,6 +30,16 @@ export interface DrawnNode {
   readonly focused: boolean;
   /** Whether focus is on this node or inside it — CSS `:focus-within`. */
   readonly focusWithin: boolean;
+  /**
+   * Which way this node reads, resolved — `'ltr'` or `'rtl'`, never
+   * `'inherit'`. The `direction` style property here or on the nearest
+   * element above, and the palette's under all of them.
+   *
+   * What a widget measuring a pointer against a laid-out box has to ask: a
+   * coordinate means the opposite thing in the two directions, so a drag
+   * reads this rather than the theme.
+   */
+  readonly direction: 'ltr' | 'rtl';
   /** Whether `node` is this node or a descendant of it (DOM `contains`). */
   contains(node: DrawnNode | null): boolean;
   getClientRects(): Rect[];

--- a/src/types/style.d.ts
+++ b/src/types/style.d.ts
@@ -71,6 +71,16 @@ export type Cursor =
   | 'none'
   | (string & {});
 
+/**
+ * Which way the boxes under this one run — CSS's `direction`.
+ *
+ * `'inherit'` is the default and means "whatever is around me"; the floor
+ * under the whole tree is the palette's `direction`, which is seeded from the
+ * locale. Setting it mirrors this subtree: rows run the other way, and every
+ * `*Start`/`*End` edge below swaps sides with it.
+ */
+export type Direction = 'ltr' | 'rtl' | 'inherit';
+
 /** Everything yoga lays out. */
 export interface LayoutStyle {
   width?: Dimension;
@@ -103,6 +113,18 @@ export interface LayoutStyle {
   paddingRight?: Length;
   paddingBottom?: Length;
   paddingLeft?: Length;
+  /**
+   * The **logical** horizontal edges: the side the text starts at and the
+   * side it ends at, whichever those are under the direction in force. They
+   * override their physical counterparts even in LTR, the way CSS's
+   * `padding-inline-start` overrides `padding-left`.
+   */
+  start?: Length;
+  end?: Length;
+  marginStart?: Dimension;
+  marginEnd?: Dimension;
+  paddingStart?: Length;
+  paddingEnd?: Length;
   gap?: number;
   rowGap?: number;
   columnGap?: number;
@@ -117,6 +139,10 @@ export interface LayoutStyle {
   borderRightWidth?: number;
   borderBottomWidth?: number;
   borderLeftWidth?: number;
+  /** The logical sides, which win over the physical ones. */
+  borderStartWidth?: number;
+  borderEndWidth?: number;
+  direction?: Direction;
 }
 
 /**
@@ -134,6 +160,9 @@ export interface PaintStyle {
   borderRightColor?: Color;
   borderBottomColor?: Color;
   borderLeftColor?: Color;
+  /** …and the logical sides, matching `borderStartWidth`/`borderEndWidth`. */
+  borderStartColor?: Color;
+  borderEndColor?: Color;
   /** Rounds the background, the border and the child clip. Requires uniform
    *  borders — same width and colour on all four sides; a non-uniform border
    *  paints square and ignores the radius. */

--- a/test/rtl.test.js
+++ b/test/rtl.test.js
@@ -1,0 +1,575 @@
+// RTL (issue #271): the layout mirrors, and it mirrors *whole*.
+//
+// The half-mirrored state is the one this exists to make impossible — boxes
+// that flow the other way with every padding still on the physically-left
+// side reads as a bug in a way that no support at all does not. So the two
+// halves are tested together: the direction that reaches yoga, and the
+// logical edges a stylesheet written for both directions is spelled in.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import {
+  createRoot,
+  Slider,
+  SplitPane,
+  Tabs,
+  ThemeProvider,
+} from '../src/index.js';
+import { anchorRect } from '../src/components/anchor.js';
+import { localeDirection } from '../src/palette.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+const settle = async () => {
+  await tick();
+  await tick();
+};
+const rootOf = (app) => app.windows[0]._reactX11Node;
+
+const XK = { LEFT: 0xff51, RIGHT: 0xff53 };
+
+function press(app, wnd, keysym) {
+  const keycode = (keysym % 248) + 8;
+  app.X.keycode2keysyms[keycode] = [keysym];
+  wnd.emit('keydown', { keycode, codepoint: 0, buttons: 0 });
+}
+
+const find = (node, pred) =>
+  pred(node)
+    ? node
+    : node.children.reduce(
+        (a, c) => a || (c.isWindow ? null : find(c, pred)),
+        null,
+      );
+
+async function mount(element) {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(element);
+  await settle();
+  return { app, root: rootOf(app), x11Root };
+}
+
+const window300 = (style, ...children) =>
+  h('window', { width: 300, height: 120, style }, ...children);
+
+// --- the direction itself ---------------------------------------------------
+
+test('a row of boxes lays out right-to-left under direction: rtl', async () => {
+  const row = (direction) =>
+    window300(
+      { direction },
+      h(
+        'box',
+        { style: { flexDirection: 'row' } },
+        h('box', { style: { width: 40, height: 20 } }),
+        h('box', { style: { width: 40, height: 20 } }),
+        h('box', { style: { width: 40, height: 20 } }),
+      ),
+    );
+
+  const ltr = await mount(row('ltr'));
+  const xs = (r) =>
+    find(r, (n) => n.style.flexDirection === 'row').children.map(
+      (c) => c.abs.x,
+    );
+  assert.deepStrictEqual(xs(ltr.root), [0, 40, 80], 'ltr is unchanged');
+
+  const rtl = await mount(row('rtl'));
+  assert.deepStrictEqual(
+    xs(rtl.root),
+    [260, 220, 180],
+    'the first child is against the right edge and the row runs left',
+  );
+});
+
+test('direction on an inner box mirrors that subtree only', async () => {
+  const { root } = await mount(
+    window300(
+      undefined,
+      h(
+        'box',
+        { style: { flexDirection: 'row' } },
+        h('box', { style: { width: 40, height: 20 } }),
+        h(
+          'box',
+          {
+            style: {
+              direction: 'rtl',
+              flexDirection: 'row',
+              width: 200,
+              height: 20,
+            },
+          },
+          h('box', { style: { width: 30, height: 20 } }),
+          h('box', { style: { width: 30, height: 20 } }),
+        ),
+      ),
+    ),
+  );
+  const outer = root.children[0];
+  assert.strictEqual(outer.direction, 'ltr', 'the outer row is untouched');
+  assert.strictEqual(outer.children[0].abs.x, 0, 'and lays out from the left');
+  const inner = outer.children[1];
+  assert.strictEqual(inner.direction, 'rtl');
+  assert.strictEqual(inner.abs.x, 40, 'the mirrored box itself does not move');
+  assert.deepStrictEqual(
+    inner.children.map((c) => c.abs.x),
+    [210, 180],
+    'only what is inside it runs the other way',
+  );
+});
+
+test('the resolved direction inherits, and a node states its own', async () => {
+  const { root } = await mount(
+    window300(
+      { direction: 'rtl' },
+      h(
+        'box',
+        { style: { direction: 'ltr' } },
+        h('box', { style: { height: 4 } }),
+      ),
+    ),
+  );
+  assert.strictEqual(root.direction, 'rtl');
+  assert.strictEqual(root.children[0].direction, 'ltr', 'the node states it');
+  assert.strictEqual(
+    root.children[0].children[0].direction,
+    'ltr',
+    'and everything below takes it from there',
+  );
+});
+
+// --- logical edges ----------------------------------------------------------
+
+test('paddingStart resolves to the leading edge, and beats paddingLeft', async () => {
+  // Yoga's edge precedence is start/end over the physical side over
+  // EDGE_HORIZONTAL over EDGE_ALL — the *opposite* way round from what the
+  // vertical shorthands suggest, and the whole reason a stylesheet can be
+  // written in logical edges and still carry a physical override for one
+  // case. Pinned rather than assumed.
+  const padded = (direction) =>
+    window300(
+      { direction },
+      h(
+        'box',
+        { style: { paddingStart: 20, paddingLeft: 9, paddingRight: 9 } },
+        h('box', { style: { height: 10 } }),
+      ),
+    );
+
+  const ltr = await mount(padded('ltr'));
+  assert.strictEqual(
+    ltr.root.children[0].children[0].abs.x,
+    20,
+    'in ltr the start is the left edge, and paddingStart wins there',
+  );
+
+  const rtl = await mount(padded('rtl'));
+  const inner = rtl.root.children[0].children[0];
+  assert.strictEqual(
+    inner.abs.x,
+    9,
+    'in rtl the left inset is the physical paddingLeft that is left over',
+  );
+  assert.strictEqual(
+    inner.abs.x + inner.abs.width,
+    300 - 20,
+    'and the 20 has moved to the right edge',
+  );
+});
+
+test('marginStart and a start inset mirror with the direction', async () => {
+  const shifted = (direction) =>
+    window300(
+      { direction },
+      h('box', {
+        style: {
+          position: 'absolute',
+          start: 10,
+          marginStart: 5,
+          width: 40,
+          height: 20,
+        },
+      }),
+    );
+  const ltr = await mount(shifted('ltr'));
+  assert.strictEqual(ltr.root.children[0].abs.x, 15);
+  const rtl = await mount(shifted('rtl'));
+  assert.strictEqual(
+    rtl.root.children[0].abs.x,
+    300 - 15 - 40,
+    'both are measured from the right edge instead',
+  );
+});
+
+test('borderStartWidth insets the content on the leading side', async () => {
+  const bordered = (direction) =>
+    window300(
+      { direction },
+      h(
+        'box',
+        { style: { borderStartWidth: 6, borderColor: '#c0392b' } },
+        h('box', { style: { flexGrow: 1, height: 10 } }),
+      ),
+    );
+  const ltr = await mount(bordered('ltr'));
+  assert.strictEqual(ltr.root.children[0].children[0].abs.x, 6);
+  const rtl = await mount(bordered('rtl'));
+  const inner = rtl.root.children[0].children[0];
+  assert.strictEqual(inner.abs.x, 0, 'nothing on the left');
+  assert.strictEqual(
+    inner.abs.x + inner.abs.width,
+    300 - 6,
+    'the bar is on the right, and it is layout rather than an overlay',
+  );
+});
+
+// --- what reads the resolved direction --------------------------------------
+
+test('a scrolling box puts its vertical scrollbar on the left in rtl', async () => {
+  const scroller = (direction) =>
+    window300(
+      { direction },
+      h(
+        'box',
+        { style: { overflow: 'scroll', width: 100, height: 50 } },
+        h('box', { style: { height: 400 } }),
+      ),
+    );
+
+  const ltr = await mount(scroller('ltr'));
+  const ltrBar = ltr.root.children[0]._scrollbar('y');
+  assert.ok(ltrBar, 'there is something to scroll');
+  assert.ok(ltrBar.crossStart > 80, 'ltr: against the right edge');
+
+  const rtl = await mount(scroller('rtl'));
+  const box = rtl.root.children[0];
+  const bar = box._scrollbar('y');
+  assert.strictEqual(
+    bar.crossStart,
+    box.abs.x + 2,
+    'rtl: against the left edge, at the same inset',
+  );
+});
+
+test('rtl horizontal scrolling counts from the right-hand edge', async () => {
+  const { root } = await mount(
+    window300(
+      { direction: 'rtl' },
+      h(
+        'box',
+        {
+          style: {
+            overflow: 'scroll',
+            flexDirection: 'row',
+            width: 100,
+            height: 50,
+          },
+        },
+        h('box', { style: { width: 160, height: 20, flexShrink: 0 } }),
+      ),
+    ),
+  );
+  const box = root.children[0];
+  const child = box.children[0];
+  assert.strictEqual(
+    box.contentWidth,
+    160,
+    'the content reach is 160 either way',
+  );
+  assert.strictEqual(
+    child.abs.x + child.abs.width,
+    box.abs.x + box.abs.width,
+    'scrollX 0 means "at the start", which is the right-hand edge',
+  );
+
+  box.scrollTo({ x: 60 });
+  await settle();
+  assert.strictEqual(
+    child.abs.x + child.abs.width,
+    box.abs.x + box.abs.width + 60,
+    'scrolling forward drags the content to the right, out past the start',
+  );
+
+  const bar = box._scrollbar('x');
+  assert.ok(bar.reversed, 'and its thumb runs the other way down the track');
+});
+
+// --- widgets ----------------------------------------------------------------
+
+test('Slider mirrors its thumb, its drag and its arrow keys', async () => {
+  const { app, root } = await mount(
+    window300(
+      { direction: 'rtl' },
+      h(Slider, { value: 0, min: 0, max: 100, onChange: () => {} }),
+    ),
+  );
+  const track = root.children[0];
+  const thumb = track.children[1];
+  assert.strictEqual(
+    thumb.abs.x + thumb.abs.width,
+    track.abs.x + track.abs.width,
+    'at value 0 the thumb is at the right-hand end',
+  );
+
+  // the keys: Left is the one that raises the value in a mirrored slider.
+  // Held at 50 rather than at an end, so neither step is swallowed by the
+  // clamp and the two are each other's mirror.
+  const changes = [];
+  const { root: keyed, app: keyApp } = await mount(
+    window300(
+      { direction: 'rtl' },
+      h(Slider, {
+        value: 50,
+        min: 0,
+        max: 100,
+        step: 5,
+        onChange: (ev) => changes.push(ev.value),
+      }),
+    ),
+  );
+  keyed.children[0].focus();
+  press(keyApp, keyApp.windows[0], XK.LEFT);
+  press(keyApp, keyApp.windows[0], XK.RIGHT);
+  assert.deepStrictEqual(
+    changes,
+    [55, 45],
+    'Left raises and Right lowers when the track runs the other way',
+  );
+  void app;
+});
+
+test('Tabs walk the strip in the direction it is drawn', async () => {
+  const picked = [];
+  const { app, root } = await mount(
+    window300(
+      { direction: 'rtl' },
+      h(ThemeProvider, {
+        value: { direction: 'rtl' },
+        children: h(Tabs, {
+          items: [
+            { id: 'a', label: 'A' },
+            { id: 'b', label: 'B' },
+          ],
+          value: 'a',
+          onChange: (id) => picked.push(id),
+        }),
+      }),
+    ),
+  );
+  const strip = find(root, (n) => n.props.role === 'tablist');
+  strip.children[0].focus();
+  press(app, app.windows[0], XK.LEFT);
+  assert.deepStrictEqual(picked, ['b'], 'Left is the next tab along');
+});
+
+test('SplitPane reads a drag from the edge its first pane starts at', async () => {
+  const sizes = [];
+  const { root } = await mount(
+    window300(
+      { direction: 'rtl' },
+      h(ThemeProvider, {
+        value: { direction: 'rtl' },
+        children: h(SplitPane, {
+          defaultSize: 100,
+          onResize: (n) => sizes.push(n),
+          children: [h('box', { key: 'a' }), h('box', { key: 'b' })],
+        }),
+      }),
+    ),
+  );
+  const divider = find(root, (n) => n.props.role === 'separator');
+  assert.ok(divider, 'the divider is there');
+  const box = find(
+    root,
+    (n) => n.props.role === undefined && n.children.length === 3,
+  )?.abs;
+  // press in the middle of the divider, then drag 40px towards the *left*,
+  // which in a mirrored split is 40px more for the first pane
+  const at = (x) => ({
+    x,
+    y: divider.abs.y + divider.abs.height / 2,
+    button: 1,
+    capturePointer() {},
+  });
+  divider.props.onMouseDown(at(divider.abs.x + divider.abs.width / 2));
+  divider.props.onMouseMove(at(divider.abs.x + divider.abs.width / 2 - 40));
+  assert.deepStrictEqual(sizes, [140], 'dragging left grows the first pane');
+  void box;
+});
+
+// --- popups -----------------------------------------------------------------
+
+test('a submenu opens to the start side, and flips at the screen edge', () => {
+  // a node standing in for a laid-out menu row, with a screen to clamp into
+  const node = (direction, x) => ({
+    direction,
+    abs: { x, y: 40, width: 120, height: 24 },
+    root: { window: { x: 0, y: 0 } },
+    app: { display: { screen: [{ pixel_width: 800, pixel_height: 600 }] } },
+  });
+
+  const ltr = anchorRect(node('ltr', 100), {
+    placement: 'end',
+    width: 150,
+    height: 100,
+  });
+  assert.strictEqual(ltr.placement, 'right', 'ltr: out to the right');
+  assert.strictEqual(ltr.x, 100 + 120 + 2);
+
+  const rtl = anchorRect(node('rtl', 400), {
+    placement: 'end',
+    width: 150,
+    height: 100,
+  });
+  assert.strictEqual(rtl.placement, 'left', 'rtl: out to the left');
+  assert.strictEqual(rtl.x, 400 - 150 - 2);
+
+  // …and the flip still happens when the preferred side has no room
+  const squeezed = anchorRect(node('rtl', 10), {
+    placement: 'end',
+    width: 150,
+    height: 100,
+  });
+  assert.strictEqual(squeezed.placement, 'right', 'no room on the left');
+});
+
+test('align: start is the right-hand edge under rtl', () => {
+  const node = {
+    direction: 'rtl',
+    abs: { x: 100, y: 40, width: 200, height: 24 },
+    root: { window: { x: 0, y: 0 } },
+    app: { display: { screen: [{ pixel_width: 800, pixel_height: 600 }] } },
+  };
+  const rect = anchorRect(node, { placement: 'bottom', width: 80, height: 50 });
+  assert.strictEqual(
+    rect.x,
+    100 + 200 - 80,
+    'the popup lines up with the trigger’s start, which is its right edge',
+  );
+});
+
+// --- where the root direction comes from ------------------------------------
+
+test('the palette is the floor, and a provider that names one plants it', async () => {
+  const { root } = await mount(
+    h(
+      'window',
+      { width: 300, height: 120, theme: { direction: 'rtl' } },
+      h(
+        'box',
+        { style: { flexDirection: 'row' } },
+        h('box', { style: { width: 40, height: 20 } }),
+      ),
+    ),
+  );
+  assert.strictEqual(root.direction, 'rtl', 'a theme prop reaches the root');
+  assert.strictEqual(
+    root.children[0].children[0].abs.x,
+    260,
+    'and the root hands it to calculateLayout, so the tree mirrors',
+  );
+});
+
+test('ThemeProvider mirrors the boxes under it as well as the widgets', async () => {
+  const { root } = await mount(
+    window300(
+      undefined,
+      h(ThemeProvider, {
+        value: { direction: 'rtl' },
+        children: h(
+          'box',
+          { style: { flexDirection: 'row' } },
+          h('box', { style: { width: 40, height: 20 } }),
+        ),
+      }),
+    ),
+  );
+  const planted = root.children[0];
+  assert.strictEqual(
+    planted.direction,
+    'rtl',
+    'the provider plants the style, not only the palette',
+  );
+  assert.strictEqual(planted.children[0].children[0].abs.x, 260);
+});
+
+test('the locale seeds the default', () => {
+  assert.strictEqual(localeDirection({ LANG: 'en_GB.UTF-8' }), 'ltr');
+  assert.strictEqual(localeDirection({ LANG: 'C' }), 'ltr');
+  assert.strictEqual(localeDirection({}), 'ltr', 'no locale at all is ltr');
+  assert.strictEqual(localeDirection({ LANG: 'ar_EG.UTF-8' }), 'rtl');
+  assert.strictEqual(localeDirection({ LANG: 'he-IL' }), 'rtl');
+  assert.strictEqual(localeDirection({ LANG: 'fa' }), 'rtl');
+  assert.strictEqual(
+    localeDirection({ LC_ALL: 'ur_PK.UTF-8', LANG: 'en_US.UTF-8' }),
+    'rtl',
+    'LC_ALL outranks LANG',
+  );
+  assert.strictEqual(
+    localeDirection({ LC_MESSAGES: 'he_IL', LANG: 'en_US' }),
+    'rtl',
+    '…and LC_MESSAGES outranks LANG too — it is the one that picks the words',
+  );
+});
+
+// --- paint ------------------------------------------------------------------
+
+test('a logical border paints on the side it laid out on', async () => {
+  // The layout half is asserted above; this is the other one. The two are
+  // resolved by the same function for exactly this reason — a border that
+  // reserves space on one side and strokes the other is a gap along the edge
+  // of the box, which no amount of layout testing would find.
+  const seen = [];
+  const { root } = await mount(
+    window300(
+      { direction: 'rtl' },
+      h('box', {
+        style: {
+          borderStartWidth: 4,
+          borderStartColor: '#c0392b',
+          borderEndColor: '#27ae60',
+          width: 100,
+          height: 40,
+        },
+      }),
+    ),
+  );
+  const box = root.children[0];
+  box._paintBorderSides = (ctx, w, colors) => seen.push({ w, colors });
+  box._paintBorder({});
+  assert.strictEqual(seen.length, 1, 'a one-sided border is not uniform');
+  assert.strictEqual(seen[0].w.right, 4, 'the width went to the right side');
+  assert.strictEqual(seen[0].w.left, 0);
+  assert.strictEqual(seen[0].colors.right, '#c0392b', 'and so did its colour');
+  assert.strictEqual(seen[0].colors.left, '#27ae60', 'the end colour is left');
+});
+
+test('a text node hands its base direction to the shaper', async () => {
+  const asked = [];
+  const app = createMockApp();
+  app.fonts = {
+    layout: (spans, base, options) => {
+      asked.push(options);
+      return { width: 10, height: 10, lines: [], draw() {} };
+    },
+  };
+  const x11Root = await createRoot({ app });
+  x11Root.render(
+    h(
+      'window',
+      { width: 300, height: 120, style: { direction: 'rtl' } },
+      h('text', { style: { textAlign: 'start' } }, 'שלום'),
+    ),
+  );
+  await settle();
+  assert.ok(asked.length > 0, 'the text was laid out');
+  assert.strictEqual(
+    asked[0].direction,
+    'rtl',
+    'UAX#9 resolves neutrals against the paragraph level, so the box has to ' +
+      'say what it is — and `textAlign: start` is resolved from it too',
+  );
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -68,6 +68,7 @@ import {
   Tooltip,
   Tree,
   useAnchor,
+  useDirection,
   useTheme,
   useTopLevelWindow,
   useWindowId,
@@ -129,6 +130,20 @@ const s = createStyles({
     ':hover': { borderLeftColor: '$accent' },
   },
   rule: { borderWidth: 1, borderBottomWidth: 0, borderTopColor: '#ddd' },
+  // issue #271: the logical edges and the direction that decides what they
+  // mean. `direction` is layout, so it is not legal in a state block; the
+  // logical border *colours* are paint, like the physical ones.
+  mirrored: {
+    direction: 'rtl',
+    paddingStart: 12,
+    paddingEnd: 4,
+    marginStart: 8,
+    marginEnd: 0,
+    start: 0,
+    borderStartWidth: 3,
+    borderStartColor: '$accent',
+    ':hover': { borderEndColor: '$border' },
+  },
   // the text cascade: `color` on a container is how the labels inside it are
   // dimmed, and `:focus-within` is how the row follows the field in it
   field: {
@@ -162,6 +177,12 @@ createStyles({ bad: { ':focus-visible': { hitSlop: 4 } } });
 // @ts-expect-error — a side width is layout, so it may not go in a state block
 createStyles({ bad: { ':hover': { borderLeftWidth: 3 } } });
 
+// @ts-expect-error — 'rtol' is not a direction
+createStyles({ bad: { direction: 'rtol' } });
+
+// @ts-expect-error — direction is layout, so it may not go in a state block
+createStyles({ bad: { ':hover': { direction: 'rtl' } } });
+
 // --- elements --------------------------------------------------------------
 
 function Elements() {
@@ -177,6 +198,9 @@ function Elements() {
   const _kind: string | undefined = boxRef.current?.kind;
   const _focused: boolean | undefined = boxRef.current?.focused;
   const _within: boolean | undefined = boxRef.current?.focusWithin;
+  // issue #271: the resolved direction, which is what a widget measuring a
+  // pointer against this box has to read
+  const _dir: 'ltr' | 'rtl' | undefined = boxRef.current?.direction;
   const _holds = () => boxRef.current?.contains(inputRef.current);
   // focus() hands the node back, so an imperative handle can forward it
   const _refocus = () => inputRef.current?.blur().focus();
@@ -427,6 +451,10 @@ function Themed() {
   const _face: string = theme.fontFamily;
   const _mono: string = theme.monoFamily;
   const _size: number = theme.fontSize;
+  // issue #271: the direction the palette carries, and the hook the widget
+  // set reads it through
+  const _themeDir: 'ltr' | 'rtl' = theme.direction;
+  const _dir: 'ltr' | 'rtl' = useDirection();
   // issue #252: a component that reads a token by a name it was handed —
   // a code palette, a `$token` it is resolving itself — indexes the palette
   // instead of casting it. Unknown names are `unknown`, so they narrow.

--- a/website/scripts/check-demos.mjs
+++ b/website/scripts/check-demos.mjs
@@ -144,6 +144,7 @@ const exercises = {
   layout: (server) => click(server, 0x1c4e80), // toggle direction
   styling: (server) => click(server, 0x2980b9), // switch theme
   'size-queries': (server) => click(server, 0x2980b9), // resize the window
+  rtl: (server) => click(server, 0x2980b9), // flip the panel's direction
   widgets: (server) => click(server, 0x0a84ff), // the primary "Mute" button
   events: (server) => click(server, 0x2980b9), // the inner box
   dates: (server) => click(server, 0x2980b9), // the primary Clear button

--- a/website/src/demos/index.js
+++ b/website/src/demos/index.js
@@ -2,6 +2,7 @@ import counter from './counter.js';
 import layout from './layout.js';
 import styling from './styling.js';
 import sizeQueries from './size-queries.js';
+import rtl from './rtl.js';
 import widgets from './widgets.js';
 import events from './events.js';
 import dates from './dates.js';
@@ -23,6 +24,7 @@ const demos = [
   layout,
   styling,
   sizeQueries,
+  rtl,
   widgets,
   events,
   dates,

--- a/website/src/demos/rtl.js
+++ b/website/src/demos/rtl.js
@@ -1,0 +1,83 @@
+export default {
+  id: 'rtl',
+  title: 'Right to left',
+  description:
+    'One <ThemeProvider value={{ direction }}> mirrors the whole panel — ' +
+    'rows run the other way, every logical edge swaps sides, the ' +
+    "scrollbar moves to the left, and the widgets' own arithmetic follows: " +
+    'the slider travels the other way and its arrow keys swap with it. The ' +
+    'default comes from the locale, so an app started under LANG=ar_EG is ' +
+    'already like this. Click the button.',
+  code: `import React, { useState } from 'react';
+import {
+  createRoot, createStyles, ThemeProvider, Slider, Checkbox, Switch,
+} from 'react-x11';
+
+const s = createStyles({
+  root: { flexGrow: 1, padding: 14, gap: 10, backgroundColor: '#f4f6f8' },
+  button: {
+    alignSelf: 'flex-start',
+    paddingLeft: 14, paddingRight: 14, paddingTop: 7, paddingBottom: 7,
+    backgroundColor: '#2980b9', borderRadius: 6, cursor: 'pointer',
+    ':hover': { backgroundColor: '#1f6693' },
+  },
+  card: {
+    backgroundColor: '#ffffff', borderRadius: 8, padding: 12, gap: 10,
+    borderWidth: 1, borderColor: '#d8dee4',
+  },
+  // The whole point: written in logical edges, this is one stylesheet for
+  // both directions. A borderStartWidth is the bar on the side the text
+  // begins at — the left in ltr, the right in rtl — and it is layout, so
+  // the label is inset by it either way.
+  quote: {
+    borderStartWidth: 3,
+    borderStartColor: '#2980b9',
+    paddingStart: 10,
+    marginStart: 2,
+  },
+  // …and the indent of a tree row means "inside", not "to the right"
+  row: { flexDirection: 'row', alignItems: 'center', gap: 6, height: 20 },
+  list: { height: 78, overflow: 'scroll', backgroundColor: '#ffffff',
+          borderRadius: 8, borderWidth: 1, borderColor: '#d8dee4' },
+});
+
+function App() {
+  const [rtl, setRtl] = useState(false);
+  const [volume, setVolume] = useState(30);
+
+  return (
+    <window x={20} y={30} width={420} height={330} title="direction" style={s.root}>
+      <box style={s.button} onClick={() => setRtl(!rtl)}>
+        <text style={{ color: '#ffffff', fontSize: 13 }}>
+          {rtl ? 'switch to ltr' : 'switch to rtl'}
+        </text>
+      </box>
+
+      <ThemeProvider value={{ direction: rtl ? 'rtl' : 'ltr' }}>
+        <box style={s.card}>
+          <text style={s.quote}>A bar on the side the text begins at.</text>
+
+          <Checkbox checked onChange={() => {}}>The well leads its label</Checkbox>
+          <Switch checked={rtl} onChange={() => setRtl(!rtl)} />
+          <Slider value={volume} onChange={(ev) => setVolume(ev.value)} />
+          <text style={{ fontSize: 12, color: '#7b8794' }}>
+            volume {volume}
+          </text>
+        </box>
+
+        <box style={s.list}>
+          {[0, 1, 2, 1, 0, 2, 1].map((depth, i) => (
+            <box key={i} style={[s.row, { paddingStart: 8 + depth * 16 }]}>
+              <text style={{ fontSize: 12 }}>{'item ' + (i + 1)}</text>
+            </box>
+          ))}
+        </box>
+      </ThemeProvider>
+    </window>
+  );
+}
+
+const root = await createRoot();
+root.render(<App />);
+`,
+};


### PR DESCRIPTION
Closes #271.

ntk shapes bidi text correctly today, so Arabic and Hebrew **drew** right while every box around them stayed left-to-right. Both halves of the issue land together here, because either alone is the half-mirrored state the issue warns about.

## The direction

`direction: 'ltr' | 'rtl' | 'inherit'` is a style property and it inherits. The six hardcoded `Yoga.DIRECTION_LTR` arguments to `calculateLayout` now take the window's resolved value.

`Node.direction` resolves the same rule a second time outside yoga — the binding has no `getComputedDirection`, so there is nothing to read back — for everything the box tree does not answer: which side a scrollbar sits on, which physical edge a `borderStartWidth` paints, which way a popup flips, and the **base paragraph direction** handed to ntk's text layout. That last one answers one of the issue's open questions: ntk does take a base direction, and it resolves `align: 'start'`/`'end'` against the paragraph level — so `textAlign: 'start'` is now right for a string with no strong characters, and a run of neutrals punctuates as the box it is in rather than as its first letter.

## The logical edges

`start`/`end`, `marginStart`/`marginEnd`, `paddingStart`/`paddingEnd`, `borderStartWidth`/`borderEndWidth`, plus `borderStartColor`/`borderEndColor` so the paint side resolves the logical edge the same way the layout side does.

One correction to the issue: yoga's precedence is **start/end over the physical side** over `EDGE_HORIZONTAL` over `EDGE_ALL` — `paddingStart` *wins* over `paddingLeft` rather than losing to it, matching CSS's `padding-inline-start`. It is the opposite way round from what the vertical shorthands suggest, so there is a test on it rather than a comment.

## Where the root direction comes from

The issue's main open question, answered with all three candidates layered so there is one rule:

1. `direction` in a node's own style — mirrors that subtree.
2. otherwise the enclosing element's.
3. otherwise the palette's `direction`, **seeded from the locale**.

The locale default is what GTK and Qt both do, and it is the "default that serves the main customer out of the box": an app started under `LANG=ar_EG.UTF-8` is mirrored without being asked. Every non-RTL locale answers `'ltr'`, so an app that never thinks about this pays nothing.

`<ThemeProvider value={{ direction }}>` is the seam an app with a language menu wants, and it plants the matching style property in the node tree as it goes — so the boxes and the widgets can never disagree under one. That is the documented way to mirror a region containing widgets; a bare `direction` style mirrors the layout, and a widget's own arithmetic (which way an arrow key steps, which way a chevron points) reads `useDirection()`.

## The widget audit

Most of the set needed nothing — a `Checkbox` is a row with a gap, a `ProgressBar` is two flex ratios, and both mirror on their own. What yoga could not answer:

| widget | what changed |
| --- | --- |
| `Slider` | the thumb rides `start`, the drag reads the node's direction, Left/Right swap (Up/Down do not) |
| `Switch` | the thumb slides on `start` |
| `Tabs` | Left/Right walk the strip the way it is drawn; a vertical indicator rides `start` |
| `Tree` | `paddingStart` indent, the twisty points the other way, and which arrow opens |
| `Table` | column resize drag and keys, the sort mark, the header's scroll sync |
| `SplitPane` | the drag is measured from the first pane's own edge, and its arrows swap |
| `MenuBar` / `ContextMenu` | submenus ask for `placement: 'end'`, chevrons follow, Left/Right swap |
| `Calendar` / `DatePicker` | a week runs the other way, the range band uses logical insets |
| `Select` / `PasswordInput` | asymmetric field insets became logical |

`anchorRect` grew logical `placement: 'start' | 'end'`; `align` mirrors too, but only when the popup is above or below its trigger, since a vertical alignment axis has no direction.

## Scrolling

A vertical scrollbar moves to the left. Horizontal scrolling counts from the right-hand edge — the content reach is measured from the start edge, `scrollX: 0` still means "at the beginning", the thumb runs the other way down its track, and the track-page and drag arithmetic follow it.

## Known gap, stated rather than discovered later

`<textinput>` and `<textarea>` shape and draw bidi text correctly (that is ntk's doing) but the field's own origin, caret scrolling and selection geometry are still written left-to-right. Wrapping one in an RTL box mirrors the box and not the field. It is its own project and it is called out in `docs/styling.md`.

## Verification

- `test/rtl.test.js` — 18 tests covering the issue's list plus the theme/locale routes. Mutation-checked: reverting the root direction argument, the scrollbar side, the RTL content measure and each logical-edge applier each fails the tests that name them.
- `npm test` 1060 pass / 6 fail, the 6 being pre-existing `appearance.test.js` failures on this macOS host (identical on `master`).
- `npm run lint`, `npm run typecheck`, and `website && npm test` (13 demos green, including a new `rtl` one) and `website && npm run build`.

## The picture

Same tree, same stylesheet, `direction` flipped. The bar written as `borderStartWidth` is on the side the text begins at; the checkbox well leads its label; the switch thumb is at the end it was; the slider fills from the other side; the tree indents inward.

Rendered from this branch at 2e2cf10 with `scripts/capture.js` against the in-process X server.



![rtl](https://github.com/user-attachments/assets/a3d38cce-4c7d-498d-8712-26d954663805)
