### PR TITLE
feat(events)!: the accent and the letter are one character — dead keys, Compose, and a preedit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,16 @@ no override-redirect staging (issue #4).
   (click synthesis, hover enter/leave diffing, wheel from X buttons 4-7,
   focus/Tab). Three ancestor-chain diffs live here and share one shape —
   `:hover`, `:active` over the press chain, and `:focus-within`.
+- `src/compose.js` — dead keys and the Compose key (#272): the sequence
+  table and the state machine `EventManager` runs between an application's
+  `onKeyDown` and the element's `defaultKeyDown`. The dead-key half is
+  **Unicode's composition rather than a table of ours** — `dead_acute` is
+  U+0301 and the rest is `normalize('NFC')` — which is what makes it 30
+  entries instead of X's 6000 and correct for scripts nobody listed. Only
+  what Unicode has no rule for is written down: `ø`, the currency signs, and
+  the `Multi_key` symbols. `probe`/`apply` are separate on purpose, since
+  the key event is dispatched to the application before the composer may
+  eat it.
 - `src/priority.js` — shared React update-priority state (discrete vs
   continuous events).
 - `src/DevToolsIntegration.js` — opt-in React DevTools bridge

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -901,7 +901,8 @@ without firing `onChange`, the way assigning to a DOM input's `value` does —
 that is how react-hook-form's `register()` resets a field through its ref.
 
 Interactions: click/drag selection, double-click word select, triple-click
-select all, Backspace/Delete, arrows (+Shift extends), Home/End, Ctrl+A,
+select all, **dead keys and Compose**
+([events.md](events.md#composition)), Backspace/Delete, arrows (+Shift extends), Home/End, Ctrl+A,
 Ctrl+C/X/V on CLIPBOARD, middle-click paste from PRIMARY, selections own
 PRIMARY (X11 conventions, select-all included), **Ctrl+Z / Ctrl+Shift+Z** (Ctrl+Y too) to undo
 and redo, and a **right-click menu**. Focusable by default; shows the text
@@ -964,6 +965,10 @@ Home/End, a click, focus leaving the field), and around edits that are
 their own step whatever surrounds them: a paste, a cut, a replaced
 selection, Ctrl+Backspace, and a `<textarea>` newline. Undo restores the
 selection and puts the caret back where the undone edit started.
+
+A composed character is one entry, not one per keystroke: the accent a dead
+key is holding is not in the value until it commits, so Ctrl+Z after
+`dead_acute` `e` steps over `é` rather than into it.
 
 Undo is a stack of snapshots of the states the control has shown, capped
 at 200. A **controlled** `value` reports the restored text through

--- a/docs/events.md
+++ b/docs/events.md
@@ -98,7 +98,8 @@ const root = await createRoot({
   capturePointer(), releasePointer(),   // see Pointer capture below
   // mouse: button, detail (DOM-style click count: 2 = double, 3 = triple)
   // wheel: deltaX, deltaY
-  // keyboard: keycode, keysym, codepoint, key
+  // keyboard: keycode, keysym, codepoint, key, composing
+  // composition: data
 }
 ```
 
@@ -120,18 +121,111 @@ onKeyDown={(ev) => {
 
 ## Handlers
 
-| handler                                     | notes                                                                                      |
-| ------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `onClick`                                   | fires on the nearest common ancestor of press & release; `detail` counts multi-clicks      |
-| `onMouseDown` / `onMouseUp` / `onMouseMove` | move is coalesced to once per frame by ntk                                                 |
-| `onMouseEnter` / `onMouseLeave`             | do not propagate; synthesized by hover-path diffing                                        |
-| `onWheel`                                   | X buttons 4–7; default action scrolls the nearest scroll container with somewhere to go    |
-| `onContextMenu`                             | right-click (button 3), after `onMouseDown`; default action opens the element's menu       |
-| `onKeyDown` / `onKeyUp`                     | delivered to the focused node (or the window); Tab cycles focus unless the element took it |
-| `onFocus` / `onBlur`                        | focus follows mousedown (nearest `focusable` ancestor) and Tab traversal                   |
-| `onDragEnter` / `onDragLeave`               | do not propagate; drag-path diffing, the same shape as the hover pair above                |
-| `onDragOver` / `onDrop`                     | on a drop target; `onDrop` may be async — [drag-and-drop.md](drag-and-drop.md)             |
-| `onDragStart` / `onDrag` / `onDragEnd`      | on a `draggable` node; the press is a click until it moves 4px                             |
+| handler                                                           | notes                                                                                      |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `onClick`                                                         | fires on the nearest common ancestor of press & release; `detail` counts multi-clicks      |
+| `onMouseDown` / `onMouseUp` / `onMouseMove`                       | move is coalesced to once per frame by ntk                                                 |
+| `onMouseEnter` / `onMouseLeave`                                   | do not propagate; synthesized by hover-path diffing                                        |
+| `onWheel`                                                         | X buttons 4–7; default action scrolls the nearest scroll container with somewhere to go    |
+| `onContextMenu`                                                   | right-click (button 3), after `onMouseDown`; default action opens the element's menu       |
+| `onKeyDown` / `onKeyUp`                                           | delivered to the focused node (or the window); Tab cycles focus unless the element took it |
+| `onCompositionStart` / `onCompositionUpdate` / `onCompositionEnd` | text still being typed — a dead key, a Compose sequence; see below                         |
+| `onFocus` / `onBlur`                                              | focus follows mousedown (nearest `focusable` ancestor) and Tab traversal                   |
+| `onDragEnter` / `onDragLeave`                                     | do not propagate; drag-path diffing, the same shape as the hover pair above                |
+| `onDragOver` / `onDrop`                                           | on a drop target; `onDrop` may be async — [drag-and-drop.md](drag-and-drop.md)             |
+| `onDragStart` / `onDrag` / `onDragEnd`                            | on a `draggable` node; the press is a click until it moves 4px                             |
+
+## Composition: dead keys and Compose {#composition}
+
+`é` is not a key. On a French, German or us-intl layout it is `dead_acute`
+then `e`, and a dead key is a keysym with **no code point at all** — so a
+renderer that types from `ev.codepoint` types the letter and drops the
+accent. That is most accented input in Europe, and it is invisible to anyone
+testing on a US layout (issue #272).
+
+A composition is text the user is still typing. It shows at the caret,
+underlined, and it is not the value until it commits:
+
+```
+dead_acute        →  the field shows ´ (underlined). value unchanged.
+e                 →  the field shows é. value is now …é, one undo step.
+```
+
+Everything about it is on by default and needs no configuration:
+
+| you press                          | you get                                           |
+| ---------------------------------- | ------------------------------------------------- |
+| `dead_acute` `e`                   | `é` — and any base letter, in any script          |
+| `dead_circumflex` `dead_acute` `e` | `ế` — dead keys stack                             |
+| `dead_acute` space                 | `´` — the accent on its own                       |
+| `dead_acute` `q`                   | `´q` — no such character, so nothing is swallowed |
+| Compose `o` `c`                    | `©`                                               |
+| Compose `'` `e` (or `e` `'`)       | `é`                                               |
+| Compose `-` `-` `-`                | `—`                                               |
+| Escape mid-sequence                | nothing typed, and the accent goes away           |
+
+The dead keys are Unicode's own composition rather than a table somebody
+maintains, so `dead_breve` + `и` is `й` and `dead_acute` + `α` is `ά`
+without anyone having written those down. What is written down is the part
+Unicode has no rule for: `dead_stroke` + `o` is `ø`, and the `Multi_key`
+symbol sequences, which are conventions rather than compositions.
+
+### Handling it yourself
+
+The three events mirror the DOM's. `data` is empty on the start, the text
+showing at the caret on each update, and the **committed text** at the end —
+empty when the sequence was abandoned.
+
+```jsx
+<textinput
+  onCompositionUpdate={(ev) => setStatus(`composing ${ev.data}`)}
+  onCompositionEnd={(ev) => setStatus('')}
+/>
+```
+
+**A key an open composition took carries no text of its own.** `ev.key` and
+`ev.codepoint` are `undefined` on it and `ev.composing` is true, because its
+text arrives on the composition event instead — an application that types
+from `onKeyDown` would otherwise insert `o`, `c` and then `©`. The keysym is
+still there, so a chord still matches.
+
+The order is **application chords → composition → the element → focus
+traversal**: an `onKeyDown` that calls `preventDefault()` keeps its key and
+the composer never sees it, and a key the composer does take never reaches
+the element's `defaultKeyDown` — so a dead key cannot also fire an
+accelerator, and a Compose sequence containing `z` cannot undo halfway
+through.
+
+A composition is abandoned, never half-committed, when focus leaves, when the
+window loses the keyboard, or when a press puts the caret somewhere else.
+
+### Changing the table
+
+```js
+import { XK_MULTI_KEY } from 'react-x11/keysyms';
+
+const root = await createRoot({
+  compose: {
+    // this machine's Compose file, which is how a personal ~/.XCompose is
+    // picked up — usually absent on macOS, where nothing is lost
+    file: 'system',
+    sequences: [[[XK_MULTI_KEY, 'l', 'd'], '🦆']],
+  },
+});
+```
+
+`compose: 'system'` is the whole file shorthand, `compose: false` turns
+composition off for an app that does its own, and later definitions win over
+earlier ones — which is what makes a Compose file an override of the
+built-ins rather than an addition beside them. Parsing is X's own format;
+`include` directives are ignored, and a line naming keysyms outside ASCII
+and the dead-key block (`<Greek_alpha>`, `<Cyrillic_a>`) is skipped rather
+than guessed at.
+
+**What this is not is an input method.** There is no preedit arriving from
+another process and no candidate list, so CJK still needs XIM or an
+IBus/Fcitx client — issue #272 tracks it. The events above are the surface it
+will arrive on.
 
 ## Pointer capture
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -301,15 +301,16 @@ how the element is built — which is what `<textinput onKeyDown>` has always
 been able to do, and is the reason to implement behaviour here rather than in
 a React component wrapping the element.
 
-| method                   | when                                                                                                                         |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| `defaultKeyDown(ev)`     | a key, delivered to the focused node. `ev.keysym` is the `XK_*` constant; `codepoint >= 0x20` is the test for "this is text" |
-| `defaultMouseDown(ev)`   | a press. Place a caret, grab a handle; `ev.capturePointer()` to keep the rest of the gesture                                 |
-| `defaultMouseDrag(ev)`   | motion while _this_ element holds the press — including outside its box, which `onMouseMove` does not give you               |
-| `defaultMouseUp(ev)`     | that press was released                                                                                                      |
-| `defaultContextMenu(ev)` | right-click, after the press: open your own menu. Separate so suppressing it keeps the caret placement                       |
-| `defaultFocus()`         | this element became the focused node (or its window got the X focus back): start the caret blinking                          |
-| `defaultBlur()`          | focus left, or the window lost it: stop it                                                                                   |
+| method                   | when                                                                                                                                  |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `defaultKeyDown(ev)`     | a key, delivered to the focused node. `ev.keysym` is the `XK_*` constant; `codepoint >= 0x20` is the test for "this is text"          |
+| `defaultComposition(ev)` | text still being typed — a dead key, a Compose sequence. `ev.type` is the phase, `ev.data` what to show, or at the end what to insert |
+| `defaultMouseDown(ev)`   | a press. Place a caret, grab a handle; `ev.capturePointer()` to keep the rest of the gesture                                          |
+| `defaultMouseDrag(ev)`   | motion while _this_ element holds the press — including outside its box, which `onMouseMove` does not give you                        |
+| `defaultMouseUp(ev)`     | that press was released                                                                                                               |
+| `defaultContextMenu(ev)` | right-click, after the press: open your own menu. Separate so suppressing it keeps the caret placement                                |
+| `defaultFocus()`         | this element became the focused node (or its window got the X focus back): start the caret blinking                                   |
+| `defaultBlur()`          | focus left, or the window lost it: stop it                                                                                            |
 
 ```js
 import { Node, CARET_BLINK_MS } from 'react-x11/node';
@@ -386,6 +387,32 @@ arms one pass-through Tab.** Escape on its own does nothing visible, the next
 Tab leaves, and the one after that indents again — the same bargain a code
 editor on the web makes, and the reason a screen-reader user is not stuck in
 your element.
+
+**An element that types text implements `defaultComposition` too.** `é` is
+a dead key and then a letter, and the keys that make it never reach
+`defaultKeyDown` — so an element that only implements the key path types the
+letter and drops the accent, which is the bug
+[events.md](events.md#composition) describes. Three phases, and the third
+is the only one that inserts anything:
+
+```js
+defaultComposition(ev) {
+  if (ev.type === 'compositionEnd') {
+    this.preedit = '';
+    if (ev.data) this.insert(ev.data);   // one edit, one undo entry
+  } else {
+    this.preedit = ev.data;              // draw it at the caret, underlined
+  }
+  this.root?.invalidate(false, this, 'text');
+}
+```
+
+The preedit is deliberately not part of your value: it never reaches
+`onChange` or the undo history, a controlled value rewritten mid-composition
+cannot corrupt it, and abandoning it — Escape, focus leaving — is dropping a
+string rather than undoing an edit. Not implementing it at all is a
+supported position for an element that holds no text; the composition then
+simply goes nowhere.
 
 **A caret blinks at `CARET_BLINK_MS`.** It is the cadence `<textinput>` uses,
 exported so that two carets on one screen are in step rather than a few tens

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -189,6 +189,7 @@ await userEvent.hover(node);
 await userEvent.type(input, 'héllo\n'); // \n is Return
 await userEvent.tab({ shift: true });
 await userEvent.key(XK_ESCAPE); // react-x11/keysyms
+await userEvent.key(XK_DEAD_ACUTE); // then type 'e' for é — events.md#composition
 await userEvent.wheel(list, { deltaY: 3 });
 await userEvent.clickOutside(); // dismisses a menu — see below
 ```

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -42,6 +42,7 @@ import {
 } from './trace-registry.js';
 import { hooks as a11yHooks, startA11y } from './a11y.js';
 import { beginStartup } from './startup.js';
+import { beginCompose } from './compose.js';
 import { beginCompositing, endCompositing } from './compositing.js';
 import { beginScreens, endScreens } from './screens.js';
 import { watchAppearance } from './appearance.js';
@@ -714,6 +715,12 @@ export async function createRoot(options = {}) {
   // before it maps, and the environment variable has to be consumed whether
   // or not this app ends up using it (src/startup.js).
   beginStartup(app, rest.startupNotification);
+
+  // Which dead-key and Compose sequences this root types (src/compose.js).
+  // Synchronous and normally free: the built-in table is built once per
+  // process, and only `compose: 'system'` or a file of your own reads
+  // anything from disk.
+  beginCompose(app, rest.compose);
 
   // Awaited, and this is the only place it can be: whether a compositor is
   // running decides what a `transparent` window paints, and a window that

--- a/src/compose.js
+++ b/src/compose.js
@@ -1,0 +1,868 @@
+// Composition: dead keys and the Compose key, client-side.
+//
+// A key event carries one keysym and at most one code point, so the path
+// from `EventManager._onKey` to `TextInputNode._insert` could only ever type
+// what one key produces. That is enough for a US layout and for nothing
+// else: `é` on a French, German or us-intl layout is `dead_acute` then `e`,
+// and `dead_acute` is a keysym with no code point at all — it used to arrive
+// and be dropped, so the accent vanished and the letter came out bare
+// (issue #272).
+//
+// This is the state that was missing between those two points. It is
+// entirely client-side: no X extension, no input-method process, no
+// protocol. `XK_dead_*` and `XK_Multi_key` are ordinary keysyms that already
+// arrive; what turns a *sequence* of them into a character is a table and a
+// small machine in front of the insert.
+//
+// ## The table is Unicode's, not ours
+//
+// The obvious implementation is X's `Compose` file: six thousand lines
+// mapping keysym sequences to strings. Bundling it would be 300 kB of data
+// for the Latin coverage alone, and it would still be a snapshot of one
+// machine's locale.
+//
+// A dead key *is* a combining mark, so the composition is the one Unicode
+// already specifies: `dead_acute` is U+0301, and `dead_acute` + `e` is
+// `'é'.normalize('NFC')`. That is 30 entries instead of 6000, it
+// covers every base letter in every script — Cyrillic, Greek, Vietnamese
+// with two stacked marks — and it cannot drift, because the data is the
+// runtime's. Only the sequences Unicode has no canonical composition for
+// need naming by hand: `dead_stroke` + `o` is `ø`, whose decomposition
+// Unicode deliberately does not define, and the `Multi_key` symbol
+// sequences (`Compose o c` is `©`), which are conventions rather than
+// characters.
+//
+// ## Default, and the seam
+//
+// The built-in table is what an app gets with no configuration, and it is
+// chosen to cover what a Latin-script keyboard can type: every dead key on
+// every common layout, plus the punctuation and symbol sequences people
+// actually reach for. The seam is `createRoot({ compose })` — `'system'`
+// adds the machine's own Compose file (which is what picks up a personal
+// `~/.XCompose`), `{ sequences }` adds or overrides individual ones, and
+// `false` turns the whole thing off for an app that means to do its own.
+//
+// What this does *not* do is an input method: there is no preedit coming
+// from another process, no candidate window, and therefore no CJK. That is
+// XIM or an IBus/Fcitx D-Bus client, and it is the next tier of #272 — but
+// it lands on this machinery rather than beside it, because the preedit
+// buffer and the composition events it needs are the ones below.
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import {
+  charOf,
+  keysymOf,
+  isDeadKeysym,
+  XK_MULTI_KEY,
+  XK_ESCAPE,
+  XK_BACKSPACE,
+  XK_SPACE,
+  XK_DEAD_GRAVE,
+  XK_DEAD_ACUTE,
+  XK_DEAD_CIRCUMFLEX,
+  XK_DEAD_TILDE,
+  XK_DEAD_MACRON,
+  XK_DEAD_BREVE,
+  XK_DEAD_ABOVEDOT,
+  XK_DEAD_DIAERESIS,
+  XK_DEAD_ABOVERING,
+  XK_DEAD_DOUBLEACUTE,
+  XK_DEAD_CARON,
+  XK_DEAD_CEDILLA,
+  XK_DEAD_OGONEK,
+  XK_DEAD_IOTA,
+  XK_DEAD_VOICED_SOUND,
+  XK_DEAD_SEMIVOICED_SOUND,
+  XK_DEAD_BELOWDOT,
+  XK_DEAD_HOOK,
+  XK_DEAD_HORN,
+  XK_DEAD_STROKE,
+  XK_DEAD_ABOVECOMMA,
+  XK_DEAD_ABOVEREVERSEDCOMMA,
+  XK_DEAD_DOUBLEGRAVE,
+  XK_DEAD_BELOWRING,
+  XK_DEAD_BELOWMACRON,
+  XK_DEAD_BELOWCIRCUMFLEX,
+  XK_DEAD_BELOWTILDE,
+  XK_DEAD_BELOWBREVE,
+  XK_DEAD_BELOWDIAERESIS,
+  XK_DEAD_INVERTEDBREVE,
+  XK_DEAD_BELOWCOMMA,
+  XK_DEAD_CURRENCY,
+} from './keysyms.js';
+
+/**
+ * The combining mark each dead key applies. This is the whole dead-key
+ * table: everything else about `dead_acute` + `e` follows from Unicode
+ * normalisation.
+ */
+const MARKS = {
+  [XK_DEAD_GRAVE]: '̀',
+  [XK_DEAD_ACUTE]: '́',
+  [XK_DEAD_CIRCUMFLEX]: '̂',
+  [XK_DEAD_TILDE]: '̃',
+  [XK_DEAD_MACRON]: '̄',
+  [XK_DEAD_BREVE]: '̆',
+  [XK_DEAD_ABOVEDOT]: '̇',
+  [XK_DEAD_DIAERESIS]: '̈',
+  [XK_DEAD_HOOK]: '̉',
+  [XK_DEAD_ABOVERING]: '̊',
+  [XK_DEAD_DOUBLEACUTE]: '̋',
+  [XK_DEAD_CARON]: '̌',
+  [XK_DEAD_DOUBLEGRAVE]: '̏',
+  [XK_DEAD_INVERTEDBREVE]: '̑',
+  [XK_DEAD_ABOVECOMMA]: '̓',
+  [XK_DEAD_ABOVEREVERSEDCOMMA]: '̔',
+  [XK_DEAD_HORN]: '̛',
+  [XK_DEAD_BELOWDOT]: '̣',
+  [XK_DEAD_BELOWDIAERESIS]: '̤',
+  [XK_DEAD_BELOWRING]: '̥',
+  [XK_DEAD_BELOWCOMMA]: '̦',
+  [XK_DEAD_CEDILLA]: '̧',
+  [XK_DEAD_OGONEK]: '̨',
+  [XK_DEAD_BELOWCIRCUMFLEX]: '̭',
+  [XK_DEAD_BELOWBREVE]: '̮',
+  [XK_DEAD_BELOWTILDE]: '̰',
+  [XK_DEAD_BELOWMACRON]: '̱',
+  [XK_DEAD_STROKE]: '̸',
+  [XK_DEAD_IOTA]: 'ͅ',
+  [XK_DEAD_VOICED_SOUND]: '゙',
+  [XK_DEAD_SEMIVOICED_SOUND]: '゚',
+};
+
+/**
+ * What a dead key shows while it is pending, and what it types on its own —
+ * `dead_acute` then space is `´`, which is how the accent character itself
+ * is typed on a layout that has no separate key for it.
+ *
+ * A mark with no spacing form of its own falls back to the mark on a space,
+ * which renders as the mark: not beautiful in every font, but it is the
+ * accent, which is what the user needs to see.
+ */
+const SPACING = {
+  [XK_DEAD_GRAVE]: '`',
+  [XK_DEAD_ACUTE]: '´',
+  [XK_DEAD_CIRCUMFLEX]: '^',
+  [XK_DEAD_TILDE]: '~',
+  [XK_DEAD_MACRON]: '¯',
+  [XK_DEAD_BREVE]: '˘',
+  [XK_DEAD_ABOVEDOT]: '˙',
+  [XK_DEAD_DIAERESIS]: '¨',
+  [XK_DEAD_ABOVERING]: '°',
+  [XK_DEAD_DOUBLEACUTE]: '˝',
+  [XK_DEAD_CARON]: 'ˇ',
+  [XK_DEAD_CEDILLA]: '¸',
+  [XK_DEAD_OGONEK]: '˛',
+  [XK_DEAD_STROKE]: '/',
+  [XK_DEAD_CURRENCY]: '¤',
+};
+
+/**
+ * The pairs Unicode will not compose, because the character has no
+ * canonical decomposition: a stroke through a letter is a different letter,
+ * not a decorated one, and a currency sign is not a decorated letter at all.
+ * Small and closed, which is the test for what belongs here.
+ */
+const UNCOMPOSED = {
+  [XK_DEAD_STROKE]: {
+    o: 'ø',
+    O: 'Ø',
+    d: 'đ',
+    D: 'Đ',
+    l: 'ł',
+    L: 'Ł',
+    t: 'ŧ',
+    T: 'Ŧ',
+    h: 'ħ',
+    H: 'Ħ',
+    b: 'ƀ',
+    B: 'Ƀ',
+    g: 'ǥ',
+    G: 'Ǥ',
+    i: 'ɨ',
+    I: 'Ɨ',
+  },
+  [XK_DEAD_CURRENCY]: {
+    e: '€',
+    E: '€',
+    l: '£',
+    L: '£',
+    y: '¥',
+    Y: '¥',
+    c: '¢',
+    C: '¢',
+    r: '₹',
+    R: '₹',
+    w: '₩',
+    W: '₩',
+    f: '₣',
+    F: '₣',
+    d: '$',
+    D: '$',
+  },
+};
+
+/**
+ * A character that names an accent when it follows `Multi_key`. This is
+ * what makes `Compose ' e` type `é` without a table entry per letter: the
+ * quote resolves to `dead_acute` and the ordinary dead-key path takes it
+ * from there, in either order (`Compose e '` too, which is how half the
+ * standard Compose file is written).
+ */
+const ACCENTS = {
+  "'": XK_DEAD_ACUTE,
+  '`': XK_DEAD_GRAVE,
+  '^': XK_DEAD_CIRCUMFLEX,
+  '~': XK_DEAD_TILDE,
+  '"': XK_DEAD_DIAERESIS,
+  ',': XK_DEAD_CEDILLA,
+  ';': XK_DEAD_OGONEK,
+  _: XK_DEAD_MACRON,
+  '.': XK_DEAD_ABOVEDOT,
+  '/': XK_DEAD_STROKE,
+  o: XK_DEAD_ABOVERING,
+  v: XK_DEAD_CARON,
+  U: XK_DEAD_BREVE,
+};
+
+/**
+ * The `Multi_key` sequences, keyed by the characters that follow it. These
+ * are the ones that are conventions rather than compositions — no rule
+ * derives `©` from `o` and `c` — so they are named, and the list is the
+ * part of X's Compose file people actually press. Anything reachable
+ * through an accent (`Compose ' e`) is deliberately absent: `ACCENTS`
+ * covers those by rule.
+ */
+const SYMBOLS = {
+  oc: '©',
+  oC: '©',
+  Oc: '©',
+  OC: '©',
+  or: '®',
+  oR: '®',
+  Or: '®',
+  OR: '®',
+  tm: '™',
+  TM: '™',
+  '+-': '±',
+  xx: '×',
+  ':-': '÷',
+  '-:': '÷',
+  oo: '°',
+  '..': '…',
+  '--.': '–',
+  '---': '—',
+  '<<': '«',
+  '>>': '»',
+  '"<': '“',
+  '<"': '“',
+  '">': '”',
+  '>"': '”',
+  "'<": '‘',
+  "<'": '‘',
+  "'>": '’',
+  ">'": '’',
+  '??': '¿',
+  '!!': '¡',
+  ss: 'ß',
+  SS: 'ẞ',
+  ae: 'æ',
+  AE: 'Æ',
+  oe: 'œ',
+  OE: 'Œ',
+  12: '½',
+  13: '⅓',
+  14: '¼',
+  34: '¾',
+  '=e': '€',
+  '=E': '€',
+  '=l': '£',
+  '=L': '£',
+  '=y': '¥',
+  '=Y': '¥',
+  '=r': '₹',
+  '=R': '₹',
+  '=w': '₩',
+  '=W': '₩',
+  'c/': '¢',
+  '/c': '¢',
+  '->': '→',
+  '<-': '←',
+  '<=': '≤',
+  '>=': '≥',
+  '%o': '‰',
+  '/u': 'µ',
+  mu: 'µ',
+  '.=': '•',
+  so: '§',
+  'p!': '¶',
+  'P!': '¶',
+  '+z': '†',
+};
+
+/**
+ * What the Compose key itself shows while a sequence is open.
+ *
+ * Not nothing: pressing Compose and seeing the field sit there is the
+ * "answer the input, not the outcome" failure (AGENTS.md) in its purest
+ * form — the key did something, and the only evidence is that the next
+ * two keys will behave strangely.
+ */
+const COMPOSE_MARK = '·';
+
+/** A sequence trie: keysym arrays in, `{ text, prefix }` out. */
+class ComposeTable {
+  constructor() {
+    this.root = { children: new Map(), text: undefined };
+  }
+
+  /** Later definitions win, which is what makes a Compose file an override
+   * of the built-ins rather than an addition beside them. */
+  add(keysyms, text) {
+    let node = this.root;
+    for (const k of keysyms) {
+      let next = node.children.get(k);
+      if (!next) {
+        next = { children: new Map(), text: undefined };
+        node.children.set(k, next);
+      }
+      node = next;
+    }
+    node.text = text;
+  }
+
+  lookup(keysyms) {
+    let node = this.root;
+    for (const k of keysyms) {
+      node = node.children.get(k);
+      if (!node) return { text: undefined, prefix: false };
+    }
+    return { text: node.text, prefix: node.children.size > 0 };
+  }
+}
+
+let builtinTable = null;
+
+/** The table every app gets without asking. Built once, lazily. */
+export function builtinCompose() {
+  if (builtinTable) return builtinTable;
+  const table = new ComposeTable();
+  for (const [seq, text] of Object.entries(SYMBOLS)) {
+    table.add([XK_MULTI_KEY, ...Array.from(seq, keysymOf)], text);
+  }
+  builtinTable = table;
+  return table;
+}
+
+// --- Compose files ---------------------------------------------------------
+
+/**
+ * X keysym names for the ASCII range, which is what a Compose file's input
+ * side is written in. Generated rather than listed: the letters and digits
+ * name themselves, and only the punctuation has names to remember.
+ */
+const ASCII_NAMES = (() => {
+  const names = new Map();
+  const punctuation = {
+    0x20: 'space',
+    0x21: 'exclam',
+    0x22: 'quotedbl',
+    0x23: 'numbersign',
+    0x24: 'dollar',
+    0x25: 'percent',
+    0x26: 'ampersand',
+    0x27: 'apostrophe',
+    0x28: 'parenleft',
+    0x29: 'parenright',
+    0x2a: 'asterisk',
+    0x2b: 'plus',
+    0x2c: 'comma',
+    0x2d: 'minus',
+    0x2e: 'period',
+    0x2f: 'slash',
+    0x3a: 'colon',
+    0x3b: 'semicolon',
+    0x3c: 'less',
+    0x3d: 'equal',
+    0x3e: 'greater',
+    0x3f: 'question',
+    0x40: 'at',
+    0x5b: 'bracketleft',
+    0x5c: 'backslash',
+    0x5d: 'bracketright',
+    0x5e: 'asciicircum',
+    0x5f: 'underscore',
+    0x60: 'grave',
+    0x7b: 'braceleft',
+    0x7c: 'bar',
+    0x7d: 'braceright',
+    0x7e: 'asciitilde',
+  };
+  for (const [code, name] of Object.entries(punctuation)) {
+    names.set(name, Number(code));
+  }
+  for (let c = 0x30; c <= 0x39; c++) names.set(String.fromCharCode(c), c);
+  for (let c = 0x41; c <= 0x5a; c++) names.set(String.fromCharCode(c), c);
+  for (let c = 0x61; c <= 0x7a; c++) names.set(String.fromCharCode(c), c);
+  return names;
+})();
+
+const DEAD_NAMES = new Map([
+  ['Multi_key', XK_MULTI_KEY],
+  ['dead_grave', XK_DEAD_GRAVE],
+  ['dead_acute', XK_DEAD_ACUTE],
+  ['dead_circumflex', XK_DEAD_CIRCUMFLEX],
+  ['dead_tilde', XK_DEAD_TILDE],
+  ['dead_macron', XK_DEAD_MACRON],
+  ['dead_breve', XK_DEAD_BREVE],
+  ['dead_abovedot', XK_DEAD_ABOVEDOT],
+  ['dead_diaeresis', XK_DEAD_DIAERESIS],
+  ['dead_abovering', XK_DEAD_ABOVERING],
+  ['dead_doubleacute', XK_DEAD_DOUBLEACUTE],
+  ['dead_caron', XK_DEAD_CARON],
+  ['dead_cedilla', XK_DEAD_CEDILLA],
+  ['dead_ogonek', XK_DEAD_OGONEK],
+  ['dead_iota', XK_DEAD_IOTA],
+  ['dead_voiced_sound', XK_DEAD_VOICED_SOUND],
+  ['dead_semivoiced_sound', XK_DEAD_SEMIVOICED_SOUND],
+  ['dead_belowdot', XK_DEAD_BELOWDOT],
+  ['dead_hook', XK_DEAD_HOOK],
+  ['dead_horn', XK_DEAD_HORN],
+  ['dead_stroke', XK_DEAD_STROKE],
+  ['dead_abovecomma', XK_DEAD_ABOVECOMMA],
+  ['dead_psili', XK_DEAD_ABOVECOMMA],
+  ['dead_abovereversedcomma', XK_DEAD_ABOVEREVERSEDCOMMA],
+  ['dead_dasia', XK_DEAD_ABOVEREVERSEDCOMMA],
+  ['dead_doublegrave', XK_DEAD_DOUBLEGRAVE],
+  ['dead_belowring', XK_DEAD_BELOWRING],
+  ['dead_belowmacron', XK_DEAD_BELOWMACRON],
+  ['dead_belowcircumflex', XK_DEAD_BELOWCIRCUMFLEX],
+  ['dead_belowtilde', XK_DEAD_BELOWTILDE],
+  ['dead_belowbreve', XK_DEAD_BELOWBREVE],
+  ['dead_belowdiaeresis', XK_DEAD_BELOWDIAERESIS],
+  ['dead_invertedbreve', XK_DEAD_INVERTEDBREVE],
+  ['dead_belowcomma', XK_DEAD_BELOWCOMMA],
+  ['dead_currency', XK_DEAD_CURRENCY],
+]);
+
+/** `<name>` → keysym, or undefined for a name outside what we can resolve. */
+function keysymNamed(name) {
+  const dead = DEAD_NAMES.get(name);
+  if (dead !== undefined) return dead;
+  const ascii = ASCII_NAMES.get(name);
+  if (ascii !== undefined) return ascii;
+  // the two escape hatches X's own format has for everything unnamed
+  if (/^U[0-9A-Fa-f]{4,6}$/.test(name)) {
+    return keysymOf(String.fromCodePoint(parseInt(name.slice(1), 16)));
+  }
+  if (/^0x[0-9A-Fa-f]+$/.test(name)) return Number(name);
+  return undefined;
+}
+
+const LINE =
+  /^\s*((?:<[A-Za-z_0-9]+>\s*)+):\s*(?:"((?:[^"\\]|\\.)*)"|([A-Za-z_0-9]+))/;
+
+function unescape(text) {
+  return text.replace(/\\(x[0-9A-Fa-f]{2}|[0-7]{1,3}|.)/g, (_, esc) => {
+    if (esc[0] === 'x') return String.fromCharCode(parseInt(esc.slice(1), 16));
+    if (/^[0-7]+$/.test(esc)) return String.fromCharCode(parseInt(esc, 8));
+    return { n: '\n', t: '\t', r: '\r' }[esc] ?? esc;
+  });
+}
+
+/**
+ * Parse X's Compose format — the one in `/usr/share/X11/locale/<locale>/Compose`
+ * and in `~/.XCompose`:
+ *
+ * ```
+ * <Multi_key> <o> <c>   : "©"   copyright
+ * <dead_acute> <e>      : "é"   eacute
+ * ```
+ *
+ * Returns the sequences it understood and a count of the lines it did not.
+ * Two things it does not do, both stated rather than silently absorbed:
+ * `include` directives are ignored (the system file's first line includes
+ * the locale's, so a bare `~/.XCompose` may parse to almost nothing), and a
+ * line whose input side names a keysym outside ASCII and the dead-key block
+ * — `<Greek_alpha>`, `<Cyrillic_a>` — is skipped, because resolving those
+ * names needs a table this package does not carry.
+ */
+export function parseCompose(text) {
+  const sequences = [];
+  let skipped = 0;
+  for (const line of String(text).split('\n')) {
+    if (!line.trim() || line.trim().startsWith('#')) continue;
+    const match = LINE.exec(line);
+    if (!match) {
+      if (!/^\s*include\b/.test(line)) skipped++;
+      continue;
+    }
+    const [, lhs, quoted, named] = match;
+    const keysyms = [];
+    let ok = true;
+    for (const [, name] of lhs.matchAll(/<([A-Za-z_0-9]+)>/g)) {
+      const keysym = keysymNamed(name);
+      if (keysym === undefined) {
+        ok = false;
+        break;
+      }
+      keysyms.push(keysym);
+    }
+    // the right-hand side may be a string, a keysym name, or both; the
+    // string wins, and a bare name is the character that keysym types
+    const result =
+      quoted !== undefined ? unescape(quoted) : charOf(keysymNamed(named) ?? 0);
+    if (!ok || !result) {
+      skipped++;
+      continue;
+    }
+    sequences.push([keysyms, result]);
+  }
+  return { sequences, skipped };
+}
+
+/**
+ * The Compose file this machine would use, or `null` when there is none —
+ * which is the normal answer on macOS, where XQuartz ships no locale tree.
+ *
+ * The search is Xlib's: `$XCOMPOSEFILE`, then a personal `~/.XCompose`,
+ * then the locale's file under the X11 tree.
+ */
+export function systemComposeFile() {
+  const candidates = [];
+  if (process.env.XCOMPOSEFILE) candidates.push(process.env.XCOMPOSEFILE);
+  const home = process.env.HOME || homedir();
+  if (home) candidates.push(join(home, '.XCompose'));
+  const locale =
+    process.env.LC_ALL || process.env.LC_CTYPE || process.env.LANG || '';
+  const name = locale.split(':')[0] || 'en_US.UTF-8';
+  for (const dir of ['/usr/share/X11/locale', '/opt/X11/share/X11/locale']) {
+    candidates.push(join(dir, name, 'Compose'));
+    candidates.push(join(dir, 'en_US.UTF-8', 'Compose'));
+  }
+  for (const path of candidates) {
+    try {
+      readFileSync(path);
+      return path;
+    } catch {
+      // not there, or not readable: try the next rung
+    }
+  }
+  return null;
+}
+
+/**
+ * Build the table a root composes with.
+ *
+ * `option` is `createRoot`'s `compose`:
+ * `undefined` — the built-ins; `false` — no composition at all;
+ * `'system'` — the built-ins plus this machine's Compose file;
+ * `{ file, sequences }` — the built-ins plus a file and/or explicit
+ * sequences, each overriding what came before it.
+ */
+export function composeTable(option) {
+  if (option === false) return null;
+  const settings =
+    option === 'system'
+      ? { file: 'system' }
+      : typeof option === 'object' && option !== null
+        ? option
+        : {};
+  const base = builtinCompose();
+  if (!settings.file && !settings.sequences) return base;
+
+  // a copy, so one root's Compose file is not every root's
+  const extended = new ComposeTable();
+  copyInto(extended, base.root, []);
+
+  if (settings.file) {
+    const path =
+      settings.file === 'system' ? systemComposeFile() : settings.file;
+    if (path) {
+      let text = null;
+      try {
+        text = readFileSync(path, 'utf8');
+      } catch (err) {
+        // Named explicitly and not there is a mistake worth hearing about;
+        // 'system' finding nothing is Tuesday on macOS and says nothing.
+        if (settings.file !== 'system') {
+          console.warn(
+            `react-x11: could not read the Compose file ${path} ` +
+              `(${err?.code ?? err?.message}). Composition falls back to the ` +
+              'built-in sequences; pass compose: false to turn it off.',
+          );
+        }
+      }
+      if (text) {
+        for (const [keysyms, result] of parseCompose(text).sequences) {
+          extended.add(keysyms, result);
+        }
+      }
+    }
+  }
+  for (const [keysyms, result] of settings.sequences ?? []) {
+    extended.add(
+      Array.from(keysyms, (k) => (typeof k === 'string' ? keysymOf(k) : k)),
+      result,
+    );
+  }
+  return extended;
+}
+
+function copyInto(table, node, path) {
+  if (node.text !== undefined) table.add(path, node.text);
+  for (const [keysym, child] of node.children) {
+    copyInto(table, child, [...path, keysym]);
+  }
+}
+
+/**
+ * Install a root's table on its connection, the way the other per-root
+ * settings ride the app object. Returns it so a caller can tell composition
+ * off from composition on.
+ */
+export function beginCompose(app, option) {
+  const table = composeTable(option);
+  if (app) app._reactX11Compose = table;
+  return table;
+}
+
+/** The table a window composes with: its root's, or the built-ins for an
+ * app that never went through `createRoot` (a unit test, a mock). */
+export function composeTableFor(app) {
+  const table = app?._reactX11Compose;
+  return table === undefined ? builtinCompose() : table;
+}
+
+// --- the machine -----------------------------------------------------------
+
+// Modifier keysyms, plus the two group/level switches. A sequence has to
+// survive them: reaching an uppercase letter means pressing Shift, and
+// AltGr is how half of Europe reaches a dead key in the first place.
+const MODIFIER_LOW = 0xffe1;
+const MODIFIER_HIGH = 0xffee;
+const XK_MODE_SWITCH = 0xff7e;
+const XK_ISO_LEVEL3_SHIFT = 0xfe03;
+const XK_ISO_LEVEL5_SHIFT = 0xfe11;
+
+function isModifier(keysym) {
+  return (
+    (keysym >= MODIFIER_LOW && keysym <= MODIFIER_HIGH) ||
+    keysym === XK_MODE_SWITCH ||
+    keysym === XK_ISO_LEVEL3_SHIFT ||
+    keysym === XK_ISO_LEVEL5_SHIFT
+  );
+}
+
+/** The character a pending keysym stands for. `Multi_key` is the one that
+ * differs between the two readers: it *shows* as a mark, and it *types*
+ * nothing, because `·` is a note about the keyboard rather than something
+ * anybody pressed a key to say. */
+function markOf(keysym) {
+  return SPACING[keysym] ?? MARKS[keysym] ?? charOf(keysym);
+}
+
+/** What an open sequence shows in the preedit. */
+function preeditOf(keys) {
+  return keys
+    .map((k) => (k === XK_MULTI_KEY ? COMPOSE_MARK : markOf(k)))
+    .join('');
+}
+
+/** What an open sequence types when it turns out not to be one. */
+function typedOf(keys) {
+  return keys.map((k) => (k === XK_MULTI_KEY ? '' : markOf(k))).join('');
+}
+
+/** The dead key a pending keysym stands for, if any — a `dead_*` keysym is
+ * itself, and a character after `Multi_key` may name one. */
+function deadOf(keysym, viaMulti) {
+  if (isDeadKeysym(keysym)) return keysym;
+  if (!viaMulti) return undefined;
+  return ACCENTS[charOf(keysym)];
+}
+
+/** Apply dead keys to a base keysym, or undefined if they do not compose. */
+function applyDead(deads, base) {
+  if (base === XK_SPACE) {
+    // the accent on its own, which is how `´` is typed at all on a layout
+    // whose only acute is a dead key
+    return deads.map((d) => SPACING[d] ?? MARKS[d] ?? '').join('');
+  }
+  const char = charOf(base);
+  if (!char) return undefined;
+  if (deads.length === 1) {
+    const named = UNCOMPOSED[deads[0]]?.[char];
+    if (named) return named;
+  }
+  let text = char;
+  for (const dead of deads) {
+    const mark = MARKS[dead];
+    if (!mark) return undefined;
+    text += mark;
+  }
+  const composed = text.normalize('NFC');
+  // A sequence that stays decomposed is one Unicode has no character for:
+  // `dead_acute` + `q` normalises to `q` + U+0301 and is not a `q́` anybody
+  // meant to type. Two code points out means no.
+  return Array.from(composed).length === 1 ? composed : undefined;
+}
+
+/**
+ * Everything the algorithmic path can make of a sequence — the dead-key
+ * table, in both the orders the Compose file writes them.
+ */
+function derive(keys) {
+  const viaMulti = keys[0] === XK_MULTI_KEY;
+  const body = viaMulti ? keys.slice(1) : keys;
+  if (body.length < 2) return undefined;
+  const direct = inOrder(body, viaMulti);
+  if (direct !== undefined) return direct;
+  // `Compose e '` as well as `Compose ' e`: the standard file spells the
+  // common ones both ways round, and a user who learned one is not going to
+  // be told the other is the real one.
+  if (viaMulti && body.length === 2) return inOrder([body[1], body[0]], true);
+  return undefined;
+}
+
+/** Every key but the last read as a dead key, applied to the last. */
+function inOrder(body, viaMulti) {
+  const deads = [];
+  for (const keysym of body.slice(0, -1)) {
+    const dead = deadOf(keysym, viaMulti);
+    if (dead === undefined) return undefined;
+    deads.push(dead);
+  }
+  return applyDead(deads, body[body.length - 1]);
+}
+
+/**
+ * The composition state machine for one keyboard focus.
+ *
+ * `probe` is pure and `apply` is what commits the transition, deliberately:
+ * the key event is dispatched to the application *before* the composer eats
+ * it, so an `onKeyDown` that calls `preventDefault()` gets to keep its
+ * chord — and it can only do that if asking what would happen has not
+ * already changed anything.
+ */
+export class Composer {
+  constructor(table = builtinCompose()) {
+    this.table = table;
+    this.keys = [];
+  }
+
+  get composing() {
+    return this.keys.length > 0;
+  }
+
+  get preedit() {
+    return preeditOf(this.keys);
+  }
+
+  reset() {
+    this.keys = [];
+  }
+
+  /**
+   * What this keysym would do, without doing it.
+   *
+   * @returns {{keys: number[], consumed: boolean,
+   *   preedit: string|null, text: string|null}}
+   *   `consumed` is whether the key belongs to the composition rather than
+   *   to the application, `preedit` is what to show (null for "this key is
+   *   nothing to do with composition"), and `text` is what to insert.
+   */
+  probe(keysym) {
+    const idle = {
+      keys: this.keys,
+      consumed: false,
+      preedit: null,
+      text: null,
+    };
+    if (keysym == null || isModifier(keysym)) return idle;
+
+    if (!this.composing) {
+      if (keysym === XK_MULTI_KEY || isDeadKeysym(keysym)) {
+        return this._pending([keysym]);
+      }
+      return idle;
+    }
+
+    // Escape abandons the sequence: nothing typed, and the accent that was
+    // showing goes away. The one gesture every composing user needs and the
+    // only one that cannot be a fallback, since Escape has no character.
+    if (keysym === XK_ESCAPE) {
+      return { keys: [], consumed: true, preedit: '', text: null };
+    }
+    // Backspace un-presses the last key of the sequence, the way it undoes
+    // anything else half-typed.
+    if (keysym === XK_BACKSPACE) {
+      return this._pending(this.keys.slice(0, -1));
+    }
+
+    const candidate = [...this.keys, keysym];
+    const hit = this.table.lookup(candidate);
+    if (hit.text !== undefined) return this._commit(hit.text);
+    const derived = derive(candidate);
+    // A table entry that is also a prefix (`Compose - -` before
+    // `Compose - - -`) commits the shorter one, because there is nothing to
+    // wait for: X's own tables do not nest that way.
+    if (derived !== undefined) return this._commit(derived);
+    if (hit.prefix) return this._pending(candidate);
+    // A dead key on a dead key stacks — Vietnamese `ế` is circumflex then
+    // acute then `e` — except for the same one twice, which every layout
+    // uses to type the accent itself.
+    if (isDeadKeysym(keysym)) {
+      if (keysym === this.keys[this.keys.length - 1]) {
+        return this._commit(markOf(keysym));
+      }
+      return this._pending(candidate);
+    }
+    // The key straight after Compose always waits for one more, whatever the
+    // table says. That is what makes `Compose e '` work as well as
+    // `Compose ' e`: the standard file spells the common accents both ways
+    // round, and the letter-first order cannot be recognised until the
+    // accent after it has arrived.
+    if (
+      this.keys.length === 1 &&
+      this.keys[0] === XK_MULTI_KEY &&
+      charOf(keysym)
+    ) {
+      return this._pending(candidate);
+    }
+
+    // No sequence, so the keys are typed as they came: X's rule for a failed
+    // composition is that nothing is swallowed. A key with no character of
+    // its own — an arrow, Return — hands the accent over and then takes its
+    // normal turn, which is why `consumed` is false while `text` is not null.
+    const accent = typedOf(this.keys);
+    const char = charOf(keysym);
+    if (!char) {
+      return { keys: [], consumed: false, preedit: '', text: accent };
+    }
+    return this._commit(accent + char);
+  }
+
+  _pending(keys) {
+    if (keys.length === 0) {
+      return { keys, consumed: true, preedit: '', text: null };
+    }
+    return { keys, consumed: true, preedit: preeditOf(keys), text: null };
+  }
+
+  _commit(text) {
+    return { keys: [], consumed: true, preedit: '', text };
+  }
+
+  /** Commit a `probe` result. */
+  apply(result) {
+    this.keys = result.keys;
+    return result;
+  }
+
+  /** Probe and apply in one step — what a test or a non-event caller wants. */
+  feed(keysym) {
+    return this.apply(this.probe(keysym));
+  }
+}

--- a/src/events.js
+++ b/src/events.js
@@ -13,6 +13,7 @@ import { callHandler } from './errors.js';
 import { armDrag } from './dnd.js';
 import { noteInputTime } from './inputtime.js';
 import { hooks as a11yHooks, isFocusable } from './a11y.js';
+import { Composer, composeTableFor } from './compose.js';
 
 const XK_TAB = 0xff09;
 const WHEEL_BUTTONS = { 4: [0, -48], 5: [0, 48], 6: [-48, 0], 7: [48, 0] };
@@ -149,6 +150,9 @@ export class EventManager {
     this.scopes = [];
     // resolved lazily for popups: the manager that owns focus (focusManager)
     this._focusOwner = null;
+    // the dead-key/Compose state machine, built on the first key (undefined
+    // until then, null when the app turned composition off)
+    this._composerInstance = undefined;
     // whether the X server sends keys to this window at all. Assume yes
     // until told otherwise: ntk < 3.7 never reports focus changes, and a
     // toolkit that believed it was unfocused would blink no caret at all.
@@ -233,6 +237,9 @@ export class EventManager {
   _onWindowFocus(focused, native) {
     if (this.windowFocused === focused) return;
     this.windowFocused = focused;
+    // a half-typed accent does not wait for the user to come back: the keys
+    // that would finish it are going somewhere else now
+    if (!focused) this._endComposition(native);
     const node = this.focused;
     if (node && !node.destroyed) {
       if (focused) node.defaultFocus?.();
@@ -378,6 +385,8 @@ export class EventManager {
       }
       this.downNode = target;
       this.downPath = target ? this._path(target) : [];
+      // the caret is about to move, and the accent was aimed at where it was
+      this._endComposition(native);
       this._setPressed(this.downPath);
       this._focusFromPress(target);
       const ev = this.dispatch(
@@ -628,6 +637,72 @@ export class EventManager {
     }
   }
 
+  /**
+   * The composition state machine for this keyboard focus, or null when the
+   * app turned composition off. On the focus manager, because a composition
+   * belongs to *the* keyboard: a `<popup>` shares the owner window's focus,
+   * and a half-typed accent has to survive a dropdown opening under it.
+   *
+   * Built lazily from the root's table (`createRoot({ compose })`), which is
+   * also why an app object that never went through `createRoot` — a mock, a
+   * unit test — still composes: `composeTableFor` falls back to the
+   * built-ins rather than to nothing.
+   */
+  _composer() {
+    const manager = this.focusManager;
+    if (manager !== this) return manager._composer();
+    if (this._composerInstance === undefined) {
+      const table = composeTableFor(this.node.app);
+      this._composerInstance = table ? new Composer(table) : null;
+    }
+    return this._composerInstance;
+  }
+
+  /**
+   * One composition event, defaultable like any other: the application's
+   * `onCompositionStart` / `onCompositionUpdate` / `onCompositionEnd` first,
+   * then the element's own `defaultComposition` unless one of them called
+   * `preventDefault()`. Same seam, same order as `defaultKeyDown`.
+   */
+  _composition(phase, target, data, native) {
+    const ev = this.dispatch('Composition' + phase, target, native, { data });
+    if (!ev.defaultPrevented) target.defaultComposition?.(ev);
+    return ev;
+  }
+
+  /** Run a composer step that has already been probed, as the events an
+   * element and an application see. */
+  _compose(composer, step, target, native) {
+    const was = composer.composing;
+    composer.apply(step);
+    if (!was) this._composition('Start', target, '', native);
+    if (composer.composing) {
+      this._composition('Update', target, step.preedit, native);
+    } else {
+      this._composition('End', target, step.text ?? '', native);
+    }
+  }
+
+  /**
+   * Abandon an open composition, discarding what it had so far.
+   *
+   * Focus moving, the window losing the keyboard, a press putting the caret
+   * somewhere else: in all three the accent was aimed at a place the user
+   * has left, and committing it there would put a character where nobody
+   * was looking. The element hears an `End` with no data, which is what
+   * clears its preedit.
+   */
+  _endComposition(native = null) {
+    const manager = this.focusManager;
+    if (manager !== this) return manager._endComposition(native);
+    const composer = this._composerInstance;
+    if (!composer?.composing) return;
+    composer.reset();
+    const focused = this.focused;
+    const target = focused && !focused.destroyed ? focused : this.node;
+    this._composition('End', target, '', native);
+  }
+
   _onKey(name, native) {
     runWithPriority(DiscreteEventPriority, () => {
       const wnd = this.node.window;
@@ -643,16 +718,43 @@ export class EventManager {
       // shared with the popup (see focusManager), key delivery follows it
       const focused = this.focusManager.focused;
       const target = focused && !focused.destroyed ? focused : this.node;
+      // Composition reads the keysym the key *typed*, not the base one:
+      // a dead key is routinely a shifted or AltGr level of a key whose
+      // level 1 is an ordinary character, and `baseKeysym` is that
+      // character. Shortcuts want the base — the reason it is on the event
+      // at all — and composition wants what was actually produced.
+      const composer = name === 'KeyDown' ? this._composer() : null;
+      const step = composer?.probe(native.keysym ?? keysym) ?? null;
+      const composing = Boolean(step?.consumed);
       const ev = this.dispatch(name, target, native, {
         keycode: native.keycode,
         keysym,
-        codepoint: native.codepoint,
+        // A key the composition is going to take types nothing on its own:
+        // its text arrives on the composition event instead. Reporting the
+        // code point as well is what would make `Compose o c` insert `oc©`
+        // in any application that types from `onKeyDown` — the renderer's
+        // own elements included.
+        codepoint: composing ? undefined : native.codepoint,
         key:
-          native.codepoint && native.codepoint >= 0x20
+          !composing && native.codepoint && native.codepoint >= 0x20
             ? String.fromCodePoint(native.codepoint)
             : undefined,
+        composing,
       });
       if (name !== 'KeyDown' || ev.defaultPrevented) return;
+      // App chords, then composition, then the element, then focus
+      // traversal. Composition sits above the element so that a dead key
+      // cannot also trigger an editing action, and below the application so
+      // that an `onKeyDown` chord still wins — `preventDefault()` above
+      // returned already, with the composer's state untouched, which is why
+      // `probe` and `apply` are separate.
+      if (step && (step.consumed || step.text != null)) {
+        this._compose(composer, step, target, native);
+        // A key that ended a sequence without belonging to it — an arrow
+        // after a pending accent — has committed the accent and now takes
+        // its ordinary turn.
+        if (step.consumed) return;
+      }
       // The element's own behaviour first, focus traversal after it — Tab is
       // an ordinary defaultable key rather than one the focus manager eats on
       // the way past. Cycling first meant an editor could only keep Tab as an
@@ -685,6 +787,9 @@ export class EventManager {
     const manager = this.focusManager;
     if (manager !== this) return manager.focus(node, reason);
     if (node === this.focused) return;
+    // before `focused` moves, so the element that was collecting the
+    // sequence is the one told to drop it
+    this._endComposition();
     const old = this.focused;
     this._previousFocus = old;
     this.focused = node;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -247,6 +247,32 @@ export interface RootOptions {
    * counts as up, and docs/desktop.md.
    */
   startupNotification?: boolean | string | StartupNotificationOptions;
+  /**
+   * Dead keys and the Compose key — what `dead_acute` then `e` types, and
+   * what `Compose o c` does (docs/events.md).
+   *
+   * The default is a built-in table: every dead key composed through
+   * Unicode, so it covers every base letter in every script, plus the
+   * `Multi_key` symbol sequences. It needs no configuration and reads
+   * nothing from disk.
+   *
+   * - `'system'` adds this machine's Compose file — `$XCOMPOSEFILE`, a
+   *   personal `~/.XCompose`, or the locale's file under
+   *   `/usr/share/X11/locale`. There is usually none on macOS.
+   * - `{ file }` adds one you name, `{ sequences }` adds or overrides
+   *   individual ones; later definitions win.
+   * - `false` turns composition off, for an app doing its own.
+   */
+  compose?: false | 'system' | ComposeOptions;
+}
+
+export interface ComposeOptions {
+  /** A Compose file to load on top of the built-ins, or `'system'` to look
+   * for this machine's. */
+  file?: string | 'system';
+  /** Sequences to add or override: `[[keysyms], text]`, where a keysym may
+   * be given as a character. */
+  sequences?: Array<[Array<number | string>, string]>;
 }
 
 export interface StartupNotificationOptions {

--- a/src/keysyms.d.ts
+++ b/src/keysyms.d.ts
@@ -52,6 +52,52 @@ export const XK_KP_ENTER: 0xff8d;
 export const XK_MENU: 0xff67;
 export const XK_SPACE: 0x0020;
 
+/**
+ * The Compose key. It types nothing on its own: it opens a sequence that
+ * the next keys finish — `Compose o c` is `©`. See
+ * [docs/events.md](events.md#composition).
+ */
+export const XK_MULTI_KEY: 0xff20;
+
+// The dead keys. Each waits for the character it decorates, so `dead_acute`
+// then `e` is `é`; on its own — followed by a space, or pressed twice — it
+// types the accent.
+export const XK_DEAD_GRAVE: 0xfe50;
+export const XK_DEAD_ACUTE: 0xfe51;
+export const XK_DEAD_CIRCUMFLEX: 0xfe52;
+export const XK_DEAD_TILDE: 0xfe53;
+export const XK_DEAD_MACRON: 0xfe54;
+export const XK_DEAD_BREVE: 0xfe55;
+export const XK_DEAD_ABOVEDOT: 0xfe56;
+export const XK_DEAD_DIAERESIS: 0xfe57;
+export const XK_DEAD_ABOVERING: 0xfe58;
+export const XK_DEAD_DOUBLEACUTE: 0xfe59;
+export const XK_DEAD_CARON: 0xfe5a;
+export const XK_DEAD_CEDILLA: 0xfe5b;
+export const XK_DEAD_OGONEK: 0xfe5c;
+export const XK_DEAD_IOTA: 0xfe5d;
+export const XK_DEAD_VOICED_SOUND: 0xfe5e;
+export const XK_DEAD_SEMIVOICED_SOUND: 0xfe5f;
+export const XK_DEAD_BELOWDOT: 0xfe60;
+export const XK_DEAD_HOOK: 0xfe61;
+export const XK_DEAD_HORN: 0xfe62;
+export const XK_DEAD_STROKE: 0xfe63;
+export const XK_DEAD_ABOVECOMMA: 0xfe64;
+export const XK_DEAD_ABOVEREVERSEDCOMMA: 0xfe65;
+export const XK_DEAD_DOUBLEGRAVE: 0xfe66;
+export const XK_DEAD_BELOWRING: 0xfe67;
+export const XK_DEAD_BELOWMACRON: 0xfe68;
+export const XK_DEAD_BELOWCIRCUMFLEX: 0xfe69;
+export const XK_DEAD_BELOWTILDE: 0xfe6a;
+export const XK_DEAD_BELOWBREVE: 0xfe6b;
+export const XK_DEAD_BELOWDIAERESIS: 0xfe6c;
+export const XK_DEAD_INVERTEDBREVE: 0xfe6d;
+export const XK_DEAD_BELOWCOMMA: 0xfe6e;
+export const XK_DEAD_CURRENCY: 0xfe6f;
+
+/** Whether a keysym is one of the `XK_dead_*` block. */
+export function isDeadKeysym(keysym: number): boolean;
+
 export const XK_SHIFT_L: 0xffe1;
 export const XK_SHIFT_R: 0xffe2;
 export const XK_CONTROL_L: 0xffe3;

--- a/src/keysyms.js
+++ b/src/keysyms.js
@@ -52,6 +52,59 @@ export const XK_KP_ENTER = 0xff8d;
 export const XK_MENU = 0xff67;
 export const XK_SPACE = 0x0020;
 
+// --- composition -----------------------------------------------------------
+//
+// The keys that type nothing on their own. A dead key waits for the letter
+// it decorates (`dead_acute` then `e` is `é`) and `Multi_key` — the Compose
+// key — opens a sequence of them. They are ordinary keysyms that arrive on
+// ordinary key events; what turns a run of them into a character is the
+// state machine in `src/compose.js`, and `charOf` deliberately answers `''`
+// for every one of them because on their own they produce no text.
+//
+// The whole `dead_*` block is here rather than the handful most layouts
+// use: the names are the vocabulary an application matches on, and half a
+// block is a table nobody can trust.
+
+export const XK_MULTI_KEY = 0xff20;
+
+export const XK_DEAD_GRAVE = 0xfe50;
+export const XK_DEAD_ACUTE = 0xfe51;
+export const XK_DEAD_CIRCUMFLEX = 0xfe52;
+export const XK_DEAD_TILDE = 0xfe53;
+export const XK_DEAD_MACRON = 0xfe54;
+export const XK_DEAD_BREVE = 0xfe55;
+export const XK_DEAD_ABOVEDOT = 0xfe56;
+export const XK_DEAD_DIAERESIS = 0xfe57;
+export const XK_DEAD_ABOVERING = 0xfe58;
+export const XK_DEAD_DOUBLEACUTE = 0xfe59;
+export const XK_DEAD_CARON = 0xfe5a;
+export const XK_DEAD_CEDILLA = 0xfe5b;
+export const XK_DEAD_OGONEK = 0xfe5c;
+export const XK_DEAD_IOTA = 0xfe5d;
+export const XK_DEAD_VOICED_SOUND = 0xfe5e;
+export const XK_DEAD_SEMIVOICED_SOUND = 0xfe5f;
+export const XK_DEAD_BELOWDOT = 0xfe60;
+export const XK_DEAD_HOOK = 0xfe61;
+export const XK_DEAD_HORN = 0xfe62;
+export const XK_DEAD_STROKE = 0xfe63;
+export const XK_DEAD_ABOVECOMMA = 0xfe64;
+export const XK_DEAD_ABOVEREVERSEDCOMMA = 0xfe65;
+export const XK_DEAD_DOUBLEGRAVE = 0xfe66;
+export const XK_DEAD_BELOWRING = 0xfe67;
+export const XK_DEAD_BELOWMACRON = 0xfe68;
+export const XK_DEAD_BELOWCIRCUMFLEX = 0xfe69;
+export const XK_DEAD_BELOWTILDE = 0xfe6a;
+export const XK_DEAD_BELOWBREVE = 0xfe6b;
+export const XK_DEAD_BELOWDIAERESIS = 0xfe6c;
+export const XK_DEAD_INVERTEDBREVE = 0xfe6d;
+export const XK_DEAD_BELOWCOMMA = 0xfe6e;
+export const XK_DEAD_CURRENCY = 0xfe6f;
+
+/** Whether a keysym is one of the `XK_dead_*` block. */
+export function isDeadKeysym(keysym) {
+  return keysym >= XK_DEAD_GRAVE && keysym <= XK_DEAD_CURRENCY;
+}
+
 // --- modifiers -------------------------------------------------------------
 
 export const XK_SHIFT_L = 0xffe1;

--- a/src/node.d.ts
+++ b/src/node.d.ts
@@ -13,7 +13,11 @@ import type {
   Style,
   TextRendering,
 } from './types/style.js';
-import type { KeyboardEvent, MouseEvent } from './types/events.js';
+import type {
+  CompositionEvent,
+  KeyboardEvent,
+  MouseEvent,
+} from './types/events.js';
 
 /** ntk's 2d context. Typed loosely — it is ntk's API, not ours. */
 export type Context2D = unknown;
@@ -153,6 +157,17 @@ export declare class Node {
    * takes Tab owes the user a way back out; see docs/extending.md.
    */
   defaultKeyDown?(ev: KeyboardEvent): void;
+  /**
+   * Text the user is still typing: a dead key waiting for its letter, or a
+   * Compose sequence half entered. `ev.type` is `compositionStart`,
+   * `compositionUpdate` or `compositionEnd`, and `ev.data` is what to show
+   * — or, at the end, the text that was committed.
+   *
+   * An element that implements this shows the preedit at its caret and
+   * inserts only what the end carries; the keys that made it never reach
+   * `defaultKeyDown`. See docs/extending.md.
+   */
+  defaultComposition?(ev: CompositionEvent): void;
   /** The element's own behaviour for a press, after `onMouseDown` handlers:
    * placing a caret, grabbing a scrollbar thumb, arming a drag. */
   defaultMouseDown?(ev: MouseEvent): void;

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -3806,6 +3806,11 @@ export class TextInputNode extends Node {
     this._historyIndex = 0;
     this._historyValue = this.value;
     this._undoRun = null;
+    // the uncommitted composition: what a pending dead key or an open
+    // Compose sequence is showing, and where it sits in the value. Never
+    // part of `value`, and never in the history — see `defaultComposition`
+    this._preedit = '';
+    this._preeditAt = 0;
     // the open built-in edit menu, if any (see _openEditMenu)
     this._editMenu = null;
   }
@@ -3923,6 +3928,97 @@ export class TextInputNode extends Node {
     return Array.from(this.value);
   }
 
+  // --- composition ---------------------------------------------------------
+  //
+  // A composition is text the user is still typing: a dead key that has not
+  // met its letter yet, or a Compose sequence half entered (src/compose.js).
+  // It is shown at the caret and underlined, and it is deliberately *not*
+  // the value:
+  //
+  // - `value`, `onChange` and the undo history never see it, so a commit is
+  //   one entry rather than one per keystroke, and Ctrl+Z after `dead_acute`
+  //   + `e` steps over `é` rather than into it;
+  // - a **controlled** field whose parent rewrites `value` mid-composition
+  //   cannot corrupt the buffer, because the buffer is not in the value.
+  //   That is the classic web bug, and it is structurally absent here;
+  // - abandoning it — Escape, focus leaving, a press elsewhere — is
+  //   dropping a string, not undoing an edit.
+  //
+  // The one thing it does change is the *displayed* string, which is what
+  // `_displayValue` is: everything measuring or hit-testing goes through
+  // that, and `_displayIndex` is the door between the two index spaces.
+
+  /** Where the composition sits in the value — clamped, because a
+   * controlled parent may have replaced the value under it. */
+  _preeditStart() {
+    return Math.min(this._preeditAt, this._chars().length);
+  }
+
+  /** The string the field draws — the value with any composition spliced in
+   * where it will land. */
+  _displayValue() {
+    if (!this._preedit) return this.value;
+    const chars = this._chars();
+    const at = this._preeditStart();
+    return (
+      chars.slice(0, at).join('') + this._preedit + chars.slice(at).join('')
+    );
+  }
+
+  /** A value index in the displayed string. The caret is at the composition
+   * while it is open, so it maps to the *end* of the preedit — which is
+   * where the next keystroke of the sequence appears. */
+  _displayIndex(index) {
+    if (!this._preedit) return index;
+    return index >= this._preeditStart()
+      ? index + Array.from(this._preedit).length
+      : index;
+  }
+
+  /** The inverse, for indices that come back out of a layout. A hit inside
+   * the preedit answers where the preedit starts: the composition is one
+   * thing, not a run of characters to put a caret between. */
+  _valueIndex(index) {
+    if (!this._preedit) return index;
+    const start = this._preeditStart();
+    if (index <= start) return index;
+    return Math.max(start, index - Array.from(this._preedit).length);
+  }
+
+  _setPreedit(text) {
+    if (text === this._preedit) return;
+    if (!this._preedit) this._preeditAt = this._selection()[0];
+    this._preedit = text;
+    this._repaint();
+  }
+
+  /**
+   * The composition default action, after `onCompositionStart` /
+   * `onCompositionUpdate` / `onCompositionEnd` have had their say.
+   *
+   * `compositionEnd` carries the text the sequence produced — empty when it
+   * was abandoned — and inserting it is an ordinary edit, so it replaces the
+   * selection, respects `maxLength`, fires `onChange` and joins the undo run
+   * the surrounding typing is in. `é` undoes like the letter it is.
+   */
+  defaultComposition(ev) {
+    if (ev.type !== 'compositionEnd') {
+      this._setPreedit(ev.data);
+      return;
+    }
+    this._setPreedit('');
+    if (!ev.data) return;
+    // the same bookkeeping `defaultKeyDown` does, so the `onChange` this
+    // produces carries the keystroke that committed the sequence
+    const previous = this._keyNative;
+    this._keyNative = ev.nativeEvent ?? null;
+    try {
+      this._insert(ev.data, 'type');
+    } finally {
+      this._keyNative = previous;
+    }
+  }
+
   _layoutOf(text) {
     const fonts = this.app?.fonts;
     if (!fonts) return null;
@@ -3986,7 +4082,7 @@ export class TextInputNode extends Node {
   _valueLayout() {
     const fonts = this.app?.fonts;
     if (!fonts) return null;
-    const text = this.value;
+    const text = this._displayValue();
     const s = this.resolvedTextStyle();
     const key = `${text}|${s.family}|${s.size}|${s.weight}|${s.style}`;
     if (this._valueLayoutKey !== key) {
@@ -3996,11 +4092,17 @@ export class TextInputNode extends Node {
     return this._valueLayoutCache;
   }
 
-  /** Visual caret x for a logical code-point index. */
+  /** Visual caret x for a logical code-point index **in the value**. */
   _prefixWidth(count) {
+    return this._prefixWidthAt(this._displayIndex(count));
+  }
+
+  /** The same, for an index in the displayed string — which is the value
+   * unless a composition is showing. */
+  _prefixWidthAt(index) {
     const layout = this._valueLayout();
     if (!layout) return 0;
-    return layout.caretPosition(count).x;
+    return layout.caretPosition(index).x;
   }
 
   _selection() {
@@ -4369,7 +4471,7 @@ export class TextInputNode extends Node {
     const layout = this._valueLayout();
     if (!layout) return this._chars().length;
     const content = this.contentBox();
-    return layout.indexAt(x - content.x + this._scrollX, 0);
+    return this._valueIndex(layout.indexAt(x - content.x + this._scrollX, 0));
   }
 
   /** Click-to-caret for a mouse event (textarea also uses ev.y). */
@@ -4728,6 +4830,10 @@ export class TextInputNode extends Node {
   defaultBlur() {
     this._focused = false;
     this._caretOn = false;
+    // the EventManager ends an open composition before focus moves, so this
+    // is the belt to that braces: a field that lost focus by some other
+    // route must not keep drawing an accent nobody can finish
+    this._preedit = '';
     // coming back to a field later is a new edit, not more of the old one
     this._breakUndoRun();
     clearInterval(this._blinkTimer);
@@ -4774,7 +4880,7 @@ export class TextInputNode extends Node {
     if (content.width <= 0 || content.height <= 0) return;
 
     const style = this.resolvedTextStyle();
-    const text = this.value;
+    const text = this._displayValue();
     const isEmpty = text.length === 0;
     const shown = isEmpty ? (this.props.placeholder ?? '') : text;
     const color = isEmpty
@@ -4867,12 +4973,45 @@ export class TextInputNode extends Node {
     }
 
     layout.draw(ctx, originX, textY);
+    this._paintPreedit(ctx, originX, textY, style);
 
     if (this._focused && this._caretOn && a === b) {
       ctx.fillStyle = this.props.caretColor ?? style.color;
       ctx.fillRect(originX + caretX, markY, 1.5, markHeight);
     }
     ctx.restore();
+  }
+
+  /**
+   * Underline the composition. The convention every toolkit shares, and the
+   * reason it is worth having: the accent showing at the caret is text the
+   * user has not typed yet, and nothing else about it says so — it is in the
+   * field's own ink, in the field's own font, where the next character will
+   * be. The line is what makes it provisional.
+   */
+  _paintPreedit(ctx, originX, originY, style) {
+    if (!this._preedit) return;
+    const layout = this._valueLayout();
+    if (!layout?.lines?.length) return;
+    const start = this._preeditStart();
+    const from = layout.caretPosition(start);
+    const to = layout.caretPosition(start + Array.from(this._preedit).length);
+    ctx.fillStyle = style.color;
+    // a line loop rather than one rectangle, because `<textarea>` shares
+    // this and a composition at a wrap point is two spans
+    for (let li = from.line; li <= to.line; li++) {
+      const line = layout.lines[li];
+      if (!line) break;
+      const x0 = li === from.line ? from.x : line.x;
+      const x1 = li === to.line ? to.x : line.x + line.width;
+      if (x1 <= x0) continue;
+      ctx.fillRect(
+        originX + x0,
+        originY + line.y + line.ascent + 1,
+        x1 - x0,
+        1,
+      );
+    }
   }
 }
 
@@ -4963,7 +5102,7 @@ export class TextAreaNode extends TextInputNode {
   _valueLayout() {
     const fonts = this.app?.fonts;
     if (!fonts) return null;
-    const text = this.value;
+    const text = this._displayValue();
     const isEmpty = text.length === 0;
     const shown = isEmpty ? (this.props.placeholder ?? '') : text;
     const s = this.resolvedTextStyle();
@@ -4991,7 +5130,9 @@ export class TextAreaNode extends TextInputNode {
     const layout = this._valueLayout();
     if (!layout) return this._chars().length;
     const content = this.contentBox();
-    return layout.indexAt(ev.x - content.x, ev.y - content.y + this._scrollY);
+    return this._valueIndex(
+      layout.indexAt(ev.x - content.x, ev.y - content.y + this._scrollY),
+    );
   }
 
   scrollBy(dy) {
@@ -5105,7 +5246,7 @@ export class TextAreaNode extends TextInputNode {
     if (!layout) return;
     const content = this.contentBox();
     if (content.width <= 0 || content.height <= 0) return;
-    const isEmpty = this.value.length === 0;
+    const isEmpty = this._displayValue().length === 0;
 
     // Keep the caret line inside the viewport, and only while focused — the
     // caret starts at the end of the value, so chasing it unconditionally
@@ -5113,7 +5254,7 @@ export class TextAreaNode extends TextInputNode {
     // <textinput> this does not reset the offset when focus leaves: a
     // textarea scrolls on the wheel and has a scrollbar, so where an
     // unfocused one is scrolled to is the reader's business.
-    const pos = layout.caretPosition(this._caret);
+    const pos = layout.caretPosition(this._displayIndex(this._caret));
     if (this._focused) {
       if (pos.y + pos.height - this._scrollY > content.height) {
         this._scrollY = pos.y + pos.height - content.height;
@@ -5137,8 +5278,8 @@ export class TextAreaNode extends TextInputNode {
 
     const [a, b] = this._selection();
     if (this._showsSelection() && a !== b && !isEmpty) {
-      const posA = layout.caretPosition(a);
-      const posB = layout.caretPosition(b);
+      const posA = layout.caretPosition(this._displayIndex(a));
+      const posB = layout.caretPosition(this._displayIndex(b));
       // A **translucent** accent rather than an opaque light blue. The ink
       // on top is `style.color`, which this fill does not control, so an
       // opaque highlight has to be picked to contrast with it — and no one
@@ -5163,6 +5304,7 @@ export class TextAreaNode extends TextInputNode {
     }
 
     layout.draw(ctx, originX, originY);
+    this._paintPreedit(ctx, originX, originY, this.resolvedTextStyle());
 
     if (this._focused && this._caretOn && a === b) {
       ctx.fillStyle = this.props.caretColor ?? this.resolvedTextStyle().color;

--- a/src/types/events.d.ts
+++ b/src/types/events.d.ts
@@ -70,10 +70,26 @@ export interface KeyboardEvent<T = DrawnNode> extends SyntheticEvent<T> {
   keycode: number;
   /** X keysym (`XK_*`), or undefined if the map has no entry. */
   keysym?: number;
-  /** Unicode code point, 0 when the key produces no character. */
-  codepoint: number;
-  /** The character the key produced, `''` for non-printing keys. */
-  key: string;
+  /** Unicode code point, undefined when the key produces no character —
+   * which includes every key a composition took (see `composing`). */
+  codepoint?: number;
+  /** The character the key produced, undefined for non-printing keys and
+   * for keys a composition took. */
+  key?: string;
+  /** Whether this key belongs to an open composition — a dead key, or a key
+   * of a Compose sequence. Its text arrives on the composition events
+   * instead, so a handler that types from `onKeyDown` should skip it. */
+  composing: boolean;
+}
+
+/**
+ * A composition — text the user is still typing. `onCompositionStart` has
+ * no data, `onCompositionUpdate` carries what is showing at the caret, and
+ * `onCompositionEnd` carries the text that was committed (empty when the
+ * sequence was abandoned).
+ */
+export interface CompositionEvent<T = DrawnNode> extends SyntheticEvent<T> {
+  data: string;
 }
 
 export interface FocusEvent<T = DrawnNode> extends SyntheticEvent<T> {}
@@ -290,6 +306,20 @@ export interface KeyboardHandlers<T = DrawnNode> {
   onKeyDownCapture?: (ev: KeyboardEvent<T>) => void;
   onKeyUp?: (ev: KeyboardEvent<T>) => void;
   onKeyUpCapture?: (ev: KeyboardEvent<T>) => void;
+  /**
+   * A composition opened — a dead key was pressed, or the Compose key was.
+   * `preventDefault()` on any of the three stops the element acting on it,
+   * which for `<textinput>` means showing or committing the text.
+   */
+  onCompositionStart?: (ev: CompositionEvent<T>) => void;
+  onCompositionStartCapture?: (ev: CompositionEvent<T>) => void;
+  /** The composition changed: `data` is what is showing at the caret. */
+  onCompositionUpdate?: (ev: CompositionEvent<T>) => void;
+  onCompositionUpdateCapture?: (ev: CompositionEvent<T>) => void;
+  /** The composition finished: `data` is the text it produced, empty if it
+   * was abandoned. */
+  onCompositionEnd?: (ev: CompositionEvent<T>) => void;
+  onCompositionEndCapture?: (ev: CompositionEvent<T>) => void;
 }
 
 export interface FocusHandlers<T = DrawnNode> {

--- a/test/compose.test.js
+++ b/test/compose.test.js
@@ -1,0 +1,547 @@
+// Composition (#272): dead keys and the Compose key, from the state machine
+// up to a character landing in a `<textinput>` with one undo entry behind it.
+//
+// The unit half drives `Composer` directly, because that is where the rules
+// live — X's fallback, the stacking, the abandon. The rest goes through the
+// event pipeline, since the whole bug being fixed was a *missing state*
+// between an X key event and an insert, and only the pipeline has both ends.
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import React from 'react';
+
+import { createRoot } from '../src/index.js';
+import { registerElement, unregisterElement } from '../src/host.js';
+import { Node } from '../src/node.js';
+import {
+  Composer,
+  composeTable,
+  parseCompose,
+  builtinCompose,
+} from '../src/compose.js';
+import {
+  keysymOf,
+  XK_MULTI_KEY,
+  XK_DEAD_ACUTE,
+  XK_DEAD_BREVE,
+  XK_DEAD_CIRCUMFLEX,
+  XK_DEAD_DIAERESIS,
+  XK_DEAD_STROKE,
+  XK_ESCAPE,
+  XK_LEFT,
+  XK_SHIFT_L,
+  XK_SPACE,
+  isDeadKeysym,
+} from '../src/keysyms.js';
+import {
+  renderX11,
+  cleanup,
+  act,
+  screen,
+  userEvent,
+  countPixels,
+} from '../src/testing/index.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+const require = createRequire(import.meta.url);
+const FONTS = {
+  'sans-serif': path.join(
+    path.dirname(require.resolve('katex/package.json')),
+    'dist',
+    'fonts',
+    'KaTeX_Main-Regular.ttf',
+  ),
+};
+
+/** Feed a whole sequence, returning what each key produced. */
+function sequence(keys, table) {
+  const composer = new Composer(table);
+  return keys.map((key) =>
+    composer.feed(typeof key === 'string' ? keysymOf(key) : key),
+  );
+}
+
+/** What a sequence typed, in order — the empty string for a key that only
+ * moved the machine along. */
+const typed = (keys, table) =>
+  sequence(keys, table)
+    .map((r) => r.text ?? '')
+    .join('');
+
+// --- the machine -----------------------------------------------------------
+
+test('a dead key composes with the letter after it', () => {
+  const steps = sequence([XK_DEAD_ACUTE, 'e']);
+  // the accent shows while it waits: pressing it has to say something
+  assert.equal(steps[0].preedit, '´');
+  assert.equal(steps[0].text, null);
+  assert.equal(steps[0].consumed, true);
+  assert.equal(steps[1].text, 'é');
+  assert.equal(steps[1].preedit, '');
+  assert.equal(typed([XK_DEAD_DIAERESIS, 'o']), 'ö');
+  assert.equal(typed([XK_DEAD_CIRCUMFLEX, 'a']), 'â');
+});
+
+test('every base letter, not a table of the ones somebody listed', () => {
+  // Unicode's composition, so scripts nobody wrote an entry for work too
+  assert.equal(typed([XK_DEAD_BREVE, 'и']), 'й');
+  assert.equal(typed([XK_DEAD_ACUTE, 'α']), 'ά');
+  assert.equal(typed([XK_DEAD_DIAERESIS, 'y']), 'ÿ');
+  // …and a mark on a letter Unicode has no single character for is not a
+  // character: it falls back rather than leaving a combining mark loose
+  assert.equal(typed([XK_DEAD_ACUTE, 'и']), '´и');
+});
+
+test('a sequence that composes nothing types what was pressed', () => {
+  // X's rule: a failed composition swallows nothing
+  assert.equal(typed([XK_DEAD_ACUTE, 'q']), '´q');
+  assert.equal(typed([XK_MULTI_KEY, 'z', 'q']), 'zq');
+});
+
+test('a dead key and a space is the accent itself', () => {
+  assert.equal(typed([XK_DEAD_ACUTE, XK_SPACE]), '´');
+  // …and so is pressing it twice, which is how most layouts spell it
+  assert.equal(typed([XK_DEAD_ACUTE, XK_DEAD_ACUTE]), '´');
+});
+
+test('dead keys stack', () => {
+  const steps = sequence([XK_DEAD_CIRCUMFLEX, XK_DEAD_ACUTE, 'e']);
+  assert.equal(steps[1].preedit, '^´');
+  assert.equal(steps[2].text, 'ế');
+});
+
+test('the pairs Unicode will not compose are named by hand', () => {
+  assert.equal(typed([XK_DEAD_STROKE, 'o']), 'ø');
+  assert.equal(typed([XK_DEAD_STROKE, 'd']), 'đ');
+});
+
+test('Multi_key sequences, in both the orders the Compose file spells', () => {
+  assert.equal(typed([XK_MULTI_KEY, 'o', 'c']), '©');
+  assert.equal(typed([XK_MULTI_KEY, 'T', 'M']), '™');
+  assert.equal(typed([XK_MULTI_KEY, '-', '-', '-']), '—');
+  assert.equal(typed([XK_MULTI_KEY, '=', 'e']), '€');
+  assert.equal(typed([XK_MULTI_KEY, "'", 'e']), 'é');
+  assert.equal(typed([XK_MULTI_KEY, 'e', "'"]), 'é');
+  assert.equal(typed([XK_MULTI_KEY, ',', 'c']), 'ç');
+  assert.equal(typed([XK_MULTI_KEY, 'o', 'a']), 'å');
+});
+
+test('the Compose key shows a mark of its own while it waits', () => {
+  const steps = sequence([XK_MULTI_KEY, 'o']);
+  assert.equal(steps[0].preedit, '·');
+  assert.equal(steps[1].preedit, '·o');
+  // …and that mark is never typed: it is a note about the keyboard
+  assert.equal(typed([XK_MULTI_KEY, 'z', 'z']), 'zz');
+});
+
+test('Escape abandons the sequence, typing nothing', () => {
+  const steps = sequence([XK_DEAD_ACUTE, XK_ESCAPE]);
+  assert.equal(steps[1].consumed, true);
+  assert.equal(steps[1].text, null);
+  assert.equal(steps[1].preedit, '');
+});
+
+test('Backspace un-presses the last key of the sequence', () => {
+  const composer = new Composer();
+  composer.feed(XK_MULTI_KEY);
+  composer.feed(keysymOf('o'));
+  assert.equal(composer.preedit, '·o');
+  composer.feed(0xff08 /* BackSpace */);
+  assert.equal(composer.preedit, '·');
+  composer.feed(0xff08);
+  assert.equal(composer.composing, false);
+});
+
+test('a modifier does not break a sequence', () => {
+  // reaching a capital means pressing Shift, and pressing Shift is a key
+  const steps = sequence([XK_DEAD_ACUTE, XK_SHIFT_L, 'E']);
+  assert.equal(steps[1].consumed, false);
+  assert.equal(steps[1].preedit, null);
+  assert.equal(steps[2].text, 'É');
+});
+
+test('a key with no character of its own gets its turn back', () => {
+  // an arrow after a pending accent: the accent is typed, and the arrow is
+  // still an arrow — `consumed` false is what hands it on
+  const steps = sequence([XK_DEAD_ACUTE, XK_LEFT]);
+  assert.equal(steps[1].consumed, false);
+  assert.equal(steps[1].text, '´');
+});
+
+test('probing does not move the machine', () => {
+  const composer = new Composer();
+  composer.feed(XK_DEAD_ACUTE);
+  const first = composer.probe(keysymOf('e'));
+  const second = composer.probe(keysymOf('e'));
+  assert.equal(first.text, 'é');
+  assert.deepEqual(first, second);
+  assert.equal(composer.preedit, '´');
+});
+
+test('keys outside composition are none of its business', () => {
+  const steps = sequence(['a', 'b']);
+  assert.ok(steps.every((s) => !s.consumed && s.text === null));
+});
+
+test('isDeadKeysym covers the block and nothing else', () => {
+  assert.equal(isDeadKeysym(XK_DEAD_ACUTE), true);
+  assert.equal(isDeadKeysym(XK_MULTI_KEY), false);
+  assert.equal(isDeadKeysym(keysymOf('a')), false);
+});
+
+// --- the table and its seam ------------------------------------------------
+
+test('an app can add sequences of its own', () => {
+  const table = composeTable({
+    sequences: [
+      [[XK_MULTI_KEY, keysymOf('l'), keysymOf('d')], '🦆'],
+      // and override a built-in, which is what a Compose file mostly does
+      [[XK_MULTI_KEY, keysymOf('o'), keysymOf('c')], 'CC'],
+    ],
+  });
+  assert.equal(typed([XK_MULTI_KEY, 'l', 'd'], table), '🦆');
+  assert.equal(typed([XK_MULTI_KEY, 'o', 'c'], table), 'CC');
+  // the built-ins are still there beside them, and untouched for everyone else
+  assert.equal(typed([XK_MULTI_KEY, 'T', 'M'], table), '™');
+  assert.equal(typed([XK_MULTI_KEY, 'o', 'c'], builtinCompose()), '©');
+});
+
+test('compose: false is composition off, not an empty table', () => {
+  assert.equal(composeTable(false), null);
+});
+
+test('parses X Compose files', () => {
+  const { sequences, skipped } = parseCompose(`
+# a comment
+<Multi_key> <x> <y>          : "zz"   somename
+<dead_acute> <e>             : "é"    eacute
+<Multi_key> <numbersign>     : "#"
+<Multi_key> <q> <q>          : "\\""
+include "%L"
+<Greek_alpha> <a>            : "aa"
+`);
+  const table = composeTable({ sequences });
+  assert.equal(typed([XK_MULTI_KEY, 'x', 'y'], table), 'zz');
+  assert.equal(typed([XK_MULTI_KEY, 'q', 'q'], table), '"');
+  // a line naming keysyms outside ASCII and the dead block is counted, not
+  // guessed at
+  assert.equal(skipped, 1);
+});
+
+test('a Compose file overrides the built-in it collides with', () => {
+  const { sequences } = parseCompose('<Multi_key> <o> <c> : "(c)"\n');
+  const table = composeTable({ sequences });
+  assert.equal(typed([XK_MULTI_KEY, 'o', 'c'], table), '(c)');
+});
+
+// --- through the event pipeline --------------------------------------------
+
+const MOD = { Shift: 1, Control: 4 };
+
+/** One keydown, as ntk decorates it. */
+function press(app, keysym, { codepoint, ctrl = false } = {}) {
+  const keycode = ((keysym ?? codepoint) % 248) + 8;
+  app.X.keycode2keysyms[keycode] = [keysym ?? codepoint];
+  app.windows[0].emit('keydown', {
+    keycode,
+    keysym,
+    codepoint,
+    buttons: ctrl ? MOD.Control : 0,
+  });
+}
+
+const typeKey = (app, char) =>
+  press(app, keysymOf(char), { codepoint: char.codePointAt(0) });
+
+const treeOf = (app) => app.windows[0]._reactX11Node;
+
+function find(node, pred) {
+  if (pred(node)) return node;
+  for (const child of node.children) {
+    const hit = find(child, pred);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+async function mountInput(props = {}, options = {}) {
+  const app = createMockApp();
+  const root = await createRoot({ app, ...options });
+  root.render(h('window', { width: 300, height: 200 }, h('textinput', props)));
+  await tick();
+  const input = find(treeOf(app), (n) => n.kind === 'textinput');
+  input.focus();
+  return { app, root, input };
+}
+
+test('a dead key sequence types one character into a <textinput>', async () => {
+  const { app, input } = await mountInput({ defaultValue: '' });
+  press(app, XK_DEAD_ACUTE);
+  assert.equal(input.value, '', 'the dead key types nothing on its own');
+  typeKey(app, 'e');
+  assert.equal(input.value, 'é');
+});
+
+test('a composed character is one undo entry', async () => {
+  const { app, input } = await mountInput({ defaultValue: '' });
+  press(app, XK_DEAD_ACUTE);
+  typeKey(app, 'e');
+  assert.equal(input.value, 'é');
+  input.undo();
+  assert.equal(input.value, '', 'undo steps over the character, not into it');
+  assert.equal(input.canUndo, false);
+});
+
+test('the preedit shows, and is not the value', async () => {
+  const { app, input } = await mountInput({ defaultValue: 'ab' });
+  press(app, XK_DEAD_ACUTE);
+  assert.equal(input.value, 'ab');
+  assert.equal(input._preedit, '´');
+  assert.equal(input._displayValue(), 'ab´', 'drawn at the caret');
+  typeKey(app, 'e');
+  assert.equal(input._preedit, '');
+  assert.equal(input.value, 'abé');
+});
+
+test('Escape abandons a composition without reaching the element', async () => {
+  const escapes = [];
+  const { app, input } = await mountInput({
+    defaultValue: 'x',
+    onKeyDown: (ev) => {
+      if (ev.keysym === XK_ESCAPE) escapes.push(ev.composing);
+    },
+  });
+  press(app, XK_DEAD_ACUTE);
+  press(app, XK_ESCAPE);
+  assert.equal(input.value, 'x');
+  assert.equal(input._preedit, '');
+  // the application still hears the key — it is the composer that ate it,
+  // and `composing` is how a handler tells this Escape from a dismissal
+  assert.deepEqual(escapes, [true]);
+});
+
+test('a composing key carries no text of its own', async () => {
+  const seen = [];
+  const { app } = await mountInput({
+    defaultValue: '',
+    onKeyDown: (ev) => seen.push([ev.composing, ev.key, ev.codepoint]),
+  });
+  press(app, XK_MULTI_KEY);
+  typeKey(app, 'o');
+  typeKey(app, 'c');
+  // every key of the sequence: composing, and with no `key`/`codepoint` —
+  // an app that types from onKeyDown would otherwise insert `oc` and then ©
+  assert.deepEqual(seen, [
+    [true, undefined, undefined],
+    [true, undefined, undefined],
+    [true, undefined, undefined],
+  ]);
+});
+
+test('an application chord still wins over composition', async () => {
+  const { app, input } = await mountInput({
+    defaultValue: '',
+    onKeyDown: (ev) => {
+      if (ev.keysym === XK_DEAD_ACUTE) ev.preventDefault();
+    },
+  });
+  press(app, XK_DEAD_ACUTE);
+  assert.equal(input._preedit, '', 'the composer never saw it');
+  // …and the state machine is where it was, so the next key is ordinary text
+  typeKey(app, 'e');
+  assert.equal(input.value, 'e');
+});
+
+test('composition events arrive in the DOM order', async () => {
+  const events = [];
+  const record = (ev) => events.push([ev.type, ev.data]);
+  const { app } = await mountInput({
+    defaultValue: '',
+    onCompositionStart: record,
+    onCompositionUpdate: record,
+    onCompositionEnd: record,
+  });
+  press(app, XK_DEAD_ACUTE);
+  typeKey(app, 'e');
+  assert.deepEqual(events, [
+    ['compositionStart', ''],
+    ['compositionUpdate', '´'],
+    ['compositionEnd', 'é'],
+  ]);
+});
+
+test('preventing the end event keeps the text out', async () => {
+  const { app, input } = await mountInput({
+    defaultValue: '',
+    onCompositionEnd: (ev) => ev.preventDefault(),
+  });
+  press(app, XK_DEAD_ACUTE);
+  typeKey(app, 'e');
+  assert.equal(input.value, '');
+});
+
+test('a controlled value rewritten mid-composition does not corrupt it', async () => {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  let setValue;
+  function Form() {
+    const [value, set] = React.useState('a');
+    setValue = set;
+    return h('textinput', { value, onChange: (ev) => set(ev.value) });
+  }
+  root.render(h('window', { width: 300, height: 200 }, h(Form)));
+  await tick();
+  const input = find(treeOf(app), (n) => n.kind === 'textinput');
+  input.focus();
+
+  press(app, XK_DEAD_ACUTE);
+  // The parent rewrites the value while the accent is pending — the classic
+  // controlled-input-during-composition bug. The preedit is not in the
+  // value, so there is nothing here to corrupt: the accent survives, and it
+  // commits at the caret, which is exactly where an ordinary keystroke
+  // would have gone (the caret was at 1 and a shorter value only clamps it).
+  await act(() => setValue('xyz'));
+  assert.equal(input._preedit, '´');
+  typeKey(app, 'e');
+  await tick();
+  assert.equal(input.value, 'xéyz');
+});
+
+test('focus leaving discards the composition', async () => {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(
+    h(
+      'window',
+      { width: 300, height: 200 },
+      h('textinput', { defaultValue: '' }),
+      h('textinput', { defaultValue: '' }),
+    ),
+  );
+  await tick();
+  const window = treeOf(app);
+  const inputs = [];
+  find(window, (n) => {
+    if (n.kind === 'textinput') inputs.push(n);
+    return false;
+  });
+  inputs[0].focus();
+  press(app, XK_DEAD_ACUTE);
+  assert.equal(inputs[0]._preedit, '´');
+  inputs[1].focus();
+  assert.equal(inputs[0]._preedit, '', 'the accent went with the focus');
+  assert.equal(inputs[0].value, '');
+  typeKey(app, 'e');
+  assert.equal(inputs[1].value, 'e', 'and did not follow it either');
+});
+
+// --- the seam a registered element sees ------------------------------------
+
+const registered = new Set();
+afterEach(() => {
+  for (const type of registered) unregisterElement(type);
+  registered.clear();
+});
+
+class EditorNode extends Node {
+  constructor(props, app) {
+    super('composeedit', props, app);
+    this.focusableByDefault = true;
+    this.log = [];
+  }
+
+  defaultKeyDown(ev) {
+    this.log.push(`key:${ev.keysym}`);
+  }
+
+  defaultComposition(ev) {
+    this.log.push(`${ev.type}:${ev.data}`);
+  }
+}
+
+test('a composing key never reaches the element default action', async () => {
+  registerElement('composeedit', {
+    create: (p, app) => new EditorNode(p, app),
+    childrenAllowed: false,
+    override: true,
+  });
+  registered.add('composeedit');
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(
+    h(
+      'window',
+      { width: 300, height: 200 },
+      h('composeedit', { autoFocus: true }),
+    ),
+  );
+  await tick();
+  const editor = find(treeOf(app), (n) => n.kind === 'composeedit');
+  editor.focus();
+  editor.log.length = 0;
+
+  press(app, XK_MULTI_KEY);
+  typeKey(app, 'o');
+  typeKey(app, 'c');
+  assert.deepEqual(editor.log, [
+    'compositionStart:',
+    'compositionUpdate:·',
+    'compositionUpdate:·o',
+    'compositionEnd:©',
+  ]);
+
+  // and an ordinary key still is one
+  typeKey(app, 'z');
+  assert.deepEqual(editor.log.slice(-1), [`key:${keysymOf('z')}`]);
+});
+
+// --- pixels ----------------------------------------------------------------
+
+test('the composition is underlined, and the underline goes on commit', async () => {
+  const { ctx } = await renderX11(
+    h('textinput', {
+      autoFocus: true,
+      defaultValue: '',
+      style: {
+        width: 160,
+        height: 30,
+        color: '#000000',
+        backgroundColor: '#ffffff',
+        fontSize: 20,
+      },
+    }),
+    { fonts: FONTS, wrap: true },
+  );
+  const field = screen.getByRole('textbox');
+  const box = field.getClientRects()[0];
+  const region = {
+    x: Math.round(box.x),
+    y: Math.round(box.y),
+    width: Math.round(box.width),
+    height: Math.round(box.height),
+  };
+  const ink = () => countPixels(ctx, region, '#000000', 40);
+
+  const empty = await ink();
+  await userEvent.key(0xfe57 /* dead_diaeresis */, { target: field });
+  const composing = await ink();
+  assert.ok(
+    composing > empty,
+    `a pending accent draws something (${empty} → ${composing})`,
+  );
+
+  await userEvent.type(field, 'o', { skipClick: true });
+  assert.equal(field.value, 'ö');
+  const committed = await ink();
+  // the character it composed is drawn, and the underline under it is not:
+  // `ö` is wider than nothing but it has lost the line the preedit had
+  assert.ok(committed > empty, 'the composed character is drawn');
+  assert.ok(
+    committed < composing + Math.round(box.width * 0.2),
+    'the underline is gone',
+  );
+  await cleanup();
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -8,6 +8,7 @@
  */
 import React, { useRef, useState } from 'react';
 import { startTrace } from 'react-x11/debug';
+import { XK_MULTI_KEY, isDeadKeysym } from 'react-x11/keysyms';
 import type {
   BusHandle,
   CalendarHandle,
@@ -76,6 +77,7 @@ import {
 import type {
   ChangeEvent,
   DrawnNode,
+  CompositionEvent,
   KeyboardEvent,
   MouseEvent,
   NtkWindow,
@@ -291,6 +293,14 @@ function Events() {
         void ev.key;
         void ev.codepoint;
         void ev.shiftKey;
+        // a key an open composition took types nothing of its own
+        if (ev.composing) return;
+      }}
+      onCompositionStart={(ev: CompositionEvent) => void ev.data}
+      onCompositionUpdate={(ev: CompositionEvent) => void ev.data}
+      onCompositionEnd={(ev: CompositionEvent) => {
+        void ev.data;
+        ev.preventDefault();
       }}
       onMouseEnter={() => {}}
       onFocus={() => {}}
@@ -728,6 +738,25 @@ async function main() {
 
   // @ts-expect-error — completeOn is a closed set
   await createRoot({ startupNotification: { completeOn: 'someday' } });
+
+  // composition: the built-in table by default, and four ways to say
+  // otherwise
+  const composes: boolean = isDeadKeysym(0xfe51);
+  void composes;
+  const noCompose = await createRoot({ compose: false });
+  await noCompose.unmount();
+  const systemCompose = await createRoot({ compose: 'system' });
+  await systemCompose.unmount();
+  const ownCompose = await createRoot({
+    compose: {
+      file: '/usr/share/X11/locale/en_US.UTF-8/Compose',
+      sequences: [[[XK_MULTI_KEY, 'l', 'd'], '\u{1F986}']],
+    },
+  });
+  await ownCompose.unmount();
+
+  // @ts-expect-error — compose takes a table, not a boolean either way
+  await createRoot({ compose: true });
 
   root.render(<Scene />);
   root.render(<RawGl />);

--- a/test/types/extend.tsx
+++ b/test/types/extend.tsx
@@ -23,7 +23,11 @@ import type { MeasureConstraints, TextStyle } from '../../src/node.js';
 import type { Rect } from '../../src/types/nodes.js';
 import { XK_ESCAPE, XK_TAB } from '../../src/keysyms.js';
 // the synthetic events, not the DOM's same-named globals
-import type { KeyboardEvent, MouseEvent } from '../../src/types/events.js';
+import type {
+  CompositionEvent,
+  KeyboardEvent,
+  MouseEvent,
+} from '../../src/types/events.js';
 import {
   isStyleProp,
   flattenStyle,
@@ -179,8 +183,15 @@ class EditorNode extends Node {
       return;
     }
     this.tabEscapes = false;
-    const _typed: string = ev.key;
+    // `key` is absent for a key that types nothing — a function key, and
+    // every key an open composition took
+    const _typed: string | undefined = ev.key;
     void _typed;
+  }
+
+  defaultComposition(ev: CompositionEvent): void {
+    const _data: string = ev.data;
+    void _data;
   }
 
   defaultMouseDown(ev: MouseEvent): void {

--- a/website/scripts/browser-shims/fs.js
+++ b/website/scripts/browser-shims/fs.js
@@ -1,6 +1,9 @@
-// Browser stub for node's `fs`. Two callers: x11's lib/auth.js (reading
-// ~/.Xauthority, and custom transports skip auth entirely) and react-x11's
-// remembered system appearance. Keep the shape callable so any stray call
+// Browser stub for node's `fs`. Three callers: x11's lib/auth.js (reading
+// ~/.Xauthority, and custom transports skip auth entirely), react-x11's
+// remembered system appearance, and the Compose file `compose: 'system'`
+// looks for — which finds none here, so composition falls back to its
+// built-in table, which is the whole table a browser was ever going to get.
+// Keep the shape callable so any stray call
 // fails softly through the normal error path — both of those already treat a
 // throw as "no cached value", which in a browser is the truth.
 const noFilesystem = (what) => {


### PR DESCRIPTION
Closes the first tier of #272 — dead keys and Compose, client-side.

## The bug

`é` is not a key. On a French, German or us-intl layout it is `dead_acute`
then `e`, and a dead key is a keysym with **no code point at all** — so the
path from `EventManager._onKey` to `TextInputNode._insert`, one keypress and
one code point with no state between them, typed the letter and dropped the
accent. `grep -c 'dead_\|Multi_key' src/keysyms.js` was 0: the dead key did
not have a name here.

## What it does now

![compose](https://github.com/user-attachments/assets/5af18f34-5c19-4c4d-b6d6-eec2ad518904)

Rendered by this branch's own code, headlessly, through the real event
pipeline: a pending `dead_acute` showing underlined at the caret, the `é` it
commits to, and the same for `Compose o c`.

| you press | you get |
| --- | --- |
| `dead_acute` `e` | `é` — and any base letter, in any script |
| `dead_circumflex` `dead_acute` `e` | `ế` — dead keys stack |
| `dead_acute` space, or twice | `´` |
| `dead_acute` `q` | `´q` — X's rule: a failed sequence swallows nothing |
| Compose `o` `c` | `©` |
| Compose `'` `e`, or `e` `'` | `é` |
| Escape mid-sequence | nothing typed, the accent goes away |

## The table is Unicode's, not ours

The obvious implementation is X's Compose file: six thousand lines, 300 kB
for the Latin coverage alone, and still a snapshot of one machine's locale.

A dead key *is* a combining mark, so the composition is the one Unicode
already specifies — `dead_acute` is U+0301 and the rest is
`normalize('NFC')`. Thirty entries instead of six thousand, correct for `й`,
`ά` and Vietnamese `ế` without anyone having listed them, and it cannot
drift, because the data is the runtime's. Only what Unicode has no rule for
is written down by hand: `ø` and the other struck letters, the currency
signs, and the `Multi_key` symbol sequences, which are conventions rather
than compositions.

## Where the seam goes

`app chords → composition → element default action → focus traversal`, which
is what #272 asked for. `probe` and `apply` are separate on the state machine
for exactly this reason: the key event is dispatched to the application
first, so an `onKeyDown` that calls `preventDefault()` keeps its chord and
the composer's state is untouched. A key the composer *does* take never
reaches `defaultKeyDown` — so a dead key cannot also fire an accelerator, and
a Compose sequence containing `z` cannot undo halfway through — and it
carries no `key`/`codepoint` of its own, with `ev.composing` true instead,
or every app that types from `onKeyDown` would insert `o`, `c` and then `©`.

## Preedit, and why it is not the value

`<textinput>`/`<textarea>` draw the composition at the caret, underlined,
and keep it out of `value`, `onChange` and the undo history. That is not
tidiness:

- a composed character is **one undo entry**, so Ctrl+Z steps over `é`
  rather than into it;
- a **controlled** field whose parent rewrites `value` mid-composition
  cannot corrupt the buffer, because the buffer is not in the value — the
  classic web bug, structurally absent;
- abandoning it on Escape, focus loss or a press elsewhere is dropping a
  string, not undoing an edit.

`onCompositionStart` / `onCompositionUpdate` / `onCompositionEnd` are the
application's view, and `defaultComposition` is the seam a registered element
implements — same preventDefault ordering as every other default action.

## Default, and a way out

The built-in table needs no configuration and reads nothing from disk.
`createRoot({ compose })` takes `'system'` for this machine's Compose file,
which is how a personal `~/.XCompose` is picked up and which finds nothing on
macOS without complaining, a `file` or `sequences` of your own — later
definitions win — or `false` to turn composition off. Parsing is X's own
format; `include` is ignored and a line naming keysyms outside ASCII and the
dead-key block is counted rather than guessed at. Against the real
`en_US.UTF-8/Compose` here: 2930 of 5195 sequences, 11 ms.

## Merged with `<foreign>`

#277 landed while this was open, and the two meet on the key path: a
`<foreign>` forwards the raw key event to an embedded client that runs its
own input method. Composing on this side would swallow the dead key on its
way there and hand back a character with nowhere to go, so composition does
not run for an element that says `composes = false` — which `<foreign>` now
does. That is the whole interaction, and there is a test for it.

## Not an input method

No preedit from another process, no candidate list, so **CJK still needs
XIM or an IBus/Fcitx client**, and the AT-SPI bridge does not yet distinguish
a preedit from a commit. #272 stays open for those tiers — they land on the
composition events above rather than beside them.

## Tests

`test/compose.test.js`, 31 cases: the machine's rules as units, the pipeline
end to end through the mock app — one undo entry, the preedit staying out of
the value, the chord precedence, a controlled value rewritten
mid-composition, focus leaving — the `defaultComposition` seam through a
registered element, and a pixel test on the in-process X server that the
composition is underlined and the underline is gone after it commits.

`npm test` 1073 pass; the 6 failures are `appearance.test.js` and fail the
same way on master on this machine. `npm run lint`, `npm run typecheck`, the
website build and `npm --prefix website test` are green.


