### PR TITLE
feat(elements): another process's window, in the layout — <foreign>

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,8 +10,9 @@ react-like ergonomics on top of [ntk](https://github.com/sidorares/ntk) /
 implementations of the X11 protocol, no native bridge.
 
 Architecture (see NEXT_STEPS.md for the full rationale): only `<window>`,
-`<popup>` and `<glarea>` map to real X11 windows (`<glarea>` because GLX
-needs its own visual); everything else is a retained
+`<popup>`, `<glarea>` and `<foreign>` map to real X11 windows (`<glarea>`
+because GLX needs its own visual, `<foreign>` because the window is another
+process's); everything else is a retained
 lightweight node — one yoga-layout node each — painted into the owning
 window's double-buffered 2d context on ntk's frame clock, with synthetic
 capture/bubble events dispatched via front-to-back hit testing. X11
@@ -36,6 +37,19 @@ no override-redirect staging (issue #4).
   GLX visual (ntk's `chooseGLXConfig`), positioned by the parent's yoga
   rect, drawing `onDraw` frames on its own frame clock. First step of
   docs/glx.md.
+- `src/foreignnodes.js` — `<foreign>`: another process's window, embedded.
+  A second `drawn: false` node, over ntk's `XEmbedSocket` (docs/embedding.md).
+  Two things here are not obvious and are commented at length. **Teardown is
+  synchronous** — `WindowNode` destroys its own X window in the same turn, and
+  `DestroyWindow` takes every inferior with it, so a release that waits for a
+  round trip releases a window that is already gone; the client is reparented
+  to the root and dropped from the save set before the container goes, and
+  **never destroyed**. And **no focus proxy**: the classic XEmbed embedder
+  gives the X focus to an InputOnly window that forwards keys, which here
+  would read as the toplevel losing focus and would put every key past the
+  React tree before any handler saw it. The X focus stays on our window and
+  forwarding happens in `defaultKeyDown`/`defaultKeyUp`, which is what makes
+  the rule "app chords first, everything else forwards" mechanical.
 - `src/scene3d.js` — the 3D scene tree inside a `<glarea>`: `<mesh>`,
   `<group>`, geometry/material nodes and the renderer that compiles each
   geometry into a server-side **display list** (a frame is matrices +

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -434,13 +434,13 @@ tear-free. So:
 **Real X window (own `Window` object) — only when the server gives us
 something we cannot do client-side:**
 
-| Element                                        | Why it needs a real window                                                                                                     |
-| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `<window>` (top-level)                         | WM interaction: title, decorations, close protocol, resize events                                                              |
-| `<popup>` / menus / tooltips / combo dropdowns | Must escape the parent window's bounds; needs `overrideRedirect` (or EWMH window types) — **blocked on the ntk attribute bug** |
-| `<glarea>`                                     | GLX needs its own visual/drawable; can't share the XRender pipeline                                                            |
-| `<foreign windowId={…}>`                       | Embedding external clients (XEMBED-ish); ntk's `createWindow({id})` foreign-window adoption already supports the wrapper side  |
-| (later) video / shm surfaces                   | Different presentation path                                                                                                    |
+| Element                                        | Why it needs a real window                                                                                                                                               |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `<window>` (top-level)                         | WM interaction: title, decorations, close protocol, resize events                                                                                                        |
+| `<popup>` / menus / tooltips / combo dropdowns | Must escape the parent window's bounds; needs `overrideRedirect` (or EWMH window types) — **blocked on the ntk attribute bug**                                           |
+| `<glarea>`                                     | GLX needs its own visual/drawable; can't share the XRender pipeline                                                                                                      |
+| `<foreign windowId={…}>`                       | Embedding external clients — **done** (issue #269, docs/embedding.md): XEmbed over ntk's `XEmbedSocket`, plus the plain-reparent path `xterm -into` and `mpv --wid` need |
+| (later) video / shm surfaces                   | Different presentation path                                                                                                                                              |
 
 Server-side wins we keep at this granularity: per-window expose coalescing,
 frame pacing/fencing, input masks — all already in ntk.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,8 @@
 
 - [elements.md](elements.md) — the host elements: `<window>`, `<popup>`,
   `<box>`, `<text>`, `<textinput>`, `<textarea>`, `<image>`, `<canvas>`,
-  and the rich-content wrappers `<markdown>`, `<html>`, `<svg>`, `<tex>`,
-  their props and refs.
+  `<foreign>`, and the rich-content wrappers `<markdown>`, `<html>`,
+  `<svg>`, `<tex>`, their props and refs.
 - [styling.md](styling.md) — the `style` prop: layout and paint properties,
   `:hover`/`:focus`/`:active`/`:disabled` blocks, transitions, theme tokens,
   window size queries, `createStyles`.
@@ -48,6 +48,10 @@
 - [extending.md](extending.md) — `registerElement()` and the subpath
   exports: adding a host element from outside the package, the node
   contract, and the two definition fields that fail far from their cause.
+- [embedding.md](embedding.md) — `<foreign>`: another application's window
+  inside yours. XEmbed and the plain-reparent path most clients actually
+  want, why unmount hands the window back rather than destroying it, and
+  the rule that keeps an app's chords from being swallowed by the client.
 - [testing.md](testing.md) — `react-x11/test`: render, query, drive and
   assert on real pixels, against a real X server in your test process. No
   display, no xvfb.

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -1,8 +1,10 @@
 # Elements
 
-Only `<window>`, `<popup>` and `<glarea>` are backed by real X11 windows,
-created top-down in React's commit phase so every `CreateWindow` names its
-actual parent. Everything else is a retained lightweight node — one
+Only `<window>`, `<popup>`, `<glarea>` and `<foreign>` are backed by real
+X11 windows, created top-down in React's commit phase so every
+`CreateWindow` names its actual parent — and, for `<foreign>`, so that no
+`ReparentWindow` is ever issued from a render React might discard.
+Everything else is a retained lightweight node — one
 [yoga-layout](https://www.yogalayout.dev/) node each — painted into the
 owning window's double-buffered 2d context on ntk's frame clock.
 
@@ -1153,6 +1155,60 @@ sibling `<popup>`. Pointer events over the surface go to its own window;
 `onDraw` is the raw escape hatch; for a scene, put 3D elements inside
 (below) and let the renderer drive the GL. See `examples/gl.jsx` for the
 raw form, `examples/three.jsx` for the declarative one.
+
+---
+
+## `<foreign>`
+
+Another process's top-level X window, laid out as an element — a terminal
+pane, a video surface, a docked tray icon. The second element that owns a
+real X window without painting into its parent, and the only one that makes
+a react-x11 app a _host_ rather than a drawer of its own pixels. Needs ntk
+≥ 7.4.0.
+
+```jsx
+<foreign
+  windowId={terminal.windowId}
+  style={{ flexGrow: 1, backgroundColor: '#101014' }}
+  onEmbedded={({ xembed }) => setMode(xembed ? 'xembed' : 'reparented')}
+  onClientGone={() => respawn()}
+/>
+```
+
+- `windowId` — the window to embed. Changing it hands the old client back
+  before the new one is taken. **Omit it** to adopt whatever is put inside
+  this node instead, which is what `xterm -into WID` and `mpv --wid=WID`
+  need.
+- `onReady({ windowId })` — this node's own container id, offered before
+  anything is embedded, so a program can be spawned into it.
+- `onEmbedded({ id, xembed, version })` — a client is in. `xembed: false`
+  is a client that set no `_XEMBED_INFO` and got plain reparenting, which
+  is the common case rather than the fallback.
+- `onClientGone()` — destroyed, or reparented away by someone else.
+- `onRequestFocus()` — the client asked for the focus. It is then given
+  through the focus manager, so the rest of the tree observes it normally.
+- `onError(err)` — the embed failed. Without a handler, a console warning.
+- `focusable` — default `true`, like `<textinput>`.
+- `backgroundColor` in the `style` is what shows in the rect with no client
+  in it: the container window's background, painted by the server.
+
+**Unmount reparents the client back to the root and drops it from the save
+set. It never destroys it** — a React tree changing shape is not a reason
+for another application to lose its window.
+
+Layout treats it as a leaf, and its X window follows that rect; every change
+also sends the client the synthetic ICCCM 4.1.5 `ConfigureNotify` with
+root-relative coordinates. Stacking is `<glarea>`'s: the child window sits
+above everything drawn in the parent, so 2D content cannot overlap it — an
+overlay belongs in a sibling `<popup>` — and pointer events over it are the
+client's. `<foreign>` takes no children.
+
+Keyboard focus is where this element has a rule of its own: **while a
+`<foreign>` holds focus, the application's handlers see every key first and
+anything they do not consume with `preventDefault()` is forwarded to the
+client.** That, the XEmbed focus messages, the tab chain crossing the
+boundary and the one case the rule cannot cover are all in
+[embedding.md](embedding.md).
 
 ---
 

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -80,6 +80,30 @@ destroyed.
 `onClientGone` fires when the client is destroyed by its own process, or
 reparented away by someone else. Nothing further is sent to a dead id.
 
+### Letting go really means letting go
+
+A released client is a top-level window again, and **a running window manager
+will manage it** — frame it, put it in the taskbar, place it wherever its
+policy says. That is the right outcome for an unmount (`examples/foreign.jsx`
+is built on it: detach the pane and the terminal is simply a terminal window
+on the desktop), and it is a trap for one thing:
+
+> **Do not hand a client from one `<foreign>` to another by unmounting the
+> first and mounting the second with the same `windowId`.**
+
+The window is parked at the root for the moment in between, which is long
+enough to be offered to the window manager. The WM's `ReparentWindow` into a
+frame of its own then arrives _after_ the second pane has taken the client,
+undoes it, and the second pane reports `onClientGone` — for a client that is
+alive and now framed on the desktop. It is a race with another process, so it
+does not always happen, which is worse than if it always did.
+
+Change `windowId` on **one** node instead. That path releases and re-embeds
+in order and is tested; the client is only ever at the root while nothing
+else wants it. (Re-embedding a window the WM has already framed also works —
+the reparent pulls it out and the WM unmanages it — the hazard is only the
+moment right after a release.)
+
 ## Layout and stacking
 
 The rect comes from yoga like any other child, and every change moves the
@@ -192,8 +216,9 @@ server rather than trusting reported geometry — the same problem
 
 ## Example
 
-`examples/foreign.jsx` spawns a program into a pane and shows the release
-path — run it with a program of your choice:
+`examples/foreign.jsx` spawns a program into a pane and then lets go of it,
+which is the whole element in one click: the pane disappears and the terminal
+is still there, framed by the window manager, as if it had started on its own.
 
 ```sh
 npm run examples:foreign            # xterm, if you have it

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -1,0 +1,215 @@
+# Embedding other applications: `<foreign>`
+
+Everything else react-x11 draws, it draws itself. `<foreign>` is the one
+element that shows somebody else's pixels: another process's top-level X
+window, reparented into yours and laid out like any other child.
+
+```jsx
+<foreign
+  windowId={terminal.windowId}
+  style={{ flexGrow: 1, backgroundColor: '#101014' }}
+  onEmbedded={({ xembed }) => setMode(xembed ? 'xembed' : 'reparented')}
+  onClientGone={() => respawn()}
+/>
+```
+
+That is a terminal pane, a video surface, a docked tray icon and a
+control-panel applet — four things an application cannot draw for itself and
+has no business reimplementing.
+
+The protocol underneath is [XEmbed](http://specifications.freedesktop.org/xembed/0.5/),
+implemented in ntk (`XEmbedSocket`, ntk ≥ 7.4.0). This page is the React half:
+what the element does, what it promises about a window it does not own, and
+what it does with the keyboard.
+
+## Two ways in
+
+**You have a window id.** Pass it as `windowId`. The client is added to the
+save set, reparented into the node's own X window, sized to the node's rect
+and told where it is.
+
+**You are about to start the program.** Then there is no id yet — a program
+like `xterm -into WID` or `mpv --wid=WID` has to be _given_ a window before it
+makes one. Leave `windowId` out, and the node adopts whatever turns up inside
+it; `onReady` hands you the id to spawn into:
+
+```jsx
+<foreign
+  style={{ flexGrow: 1 }}
+  onReady={({ windowId }) => spawn('xterm', ['-into', String(windowId)])}
+  onClientGone={() => close(paneId)}
+/>
+```
+
+`onReady` fires as soon as the node has an X window, which is before anything
+is in it — that is the point.
+
+## Most clients do not speak XEmbed
+
+`xterm -into`, `mpv --wid`, VLC and Wine set no `_XEMBED_INFO` and want plain
+reparenting. A missing property is not an error and not a fallback: it is the
+ordinary case, and it is what makes a terminal pane work at all. `onEmbedded`
+reports which happened:
+
+```jsx
+onEmbedded={({ id, xembed, version }) => { … }}
+```
+
+`xembed: false` means plain reparenting — the client was mapped immediately
+and no `_XEMBED` messages will pass. `xembed: true` means the client answered,
+`version` is the protocol version both sides settled on, and from then on the
+client is mapped and unmapped as its own `XEMBED_MAPPED` bit asks.
+
+## The window is not yours
+
+Unmounting a `<foreign>` **reparents the client back to the root window and
+drops it from the save set. It never destroys it.** A React tree changing
+shape is not a reason for another application to lose its window, and the
+first test in `test/foreign.test.js` is there to keep it that way.
+
+The same holds for `windowId` changing: the client that is leaving is handed
+back before the new one is taken.
+
+What this costs is an ordering rule, and it is the one thing worth knowing
+about the implementation: the reparent is issued **synchronously** during
+teardown, because `WindowNode` destroys its own X window in the same turn and
+`DestroyWindow` takes every inferior with it. The save set does not cover
+that — X processes it when a _connection_ closes, not when a window is
+destroyed.
+
+`onClientGone` fires when the client is destroyed by its own process, or
+reparented away by someone else. Nothing further is sent to a dead id.
+
+## Layout and stacking
+
+The rect comes from yoga like any other child, and every change moves the
+client and sends it the synthetic ICCCM 4.1.5 `ConfigureNotify` — root-relative
+coordinates, which is the question a client actually asks and which its own
+`ConfigureNotify` (relative to the container it now sits in) cannot answer.
+
+Two consequences of it being a real X window, both shared with
+[`<glarea>`](elements.md#glarea):
+
+- **Nothing drawn can overlap it.** A child X window is stacked above
+  everything painted in its parent. An overlay — a HUD, a "reconnecting…"
+  banner — belongs in a sibling `<popup>`. `<foreign>` takes no children and
+  says so rather than laying out something that could never be seen.
+- **Pointer events over it are the client's.** They never reach react-x11's
+  hit testing, which is exactly right for a terminal or a video surface.
+
+`backgroundColor` in the `style` is what shows in the rect before a client
+arrives and after one leaves — it is the container window's background, painted
+by the server. There is no separate prop for it, so the name is the one used
+everywhere else.
+
+## Focus, and who gets the keys
+
+X gives the input focus to one window. XEmbed's answer is that the embedder
+holds the real focus and gives the client a _logical_ one by message, and the
+classic implementation of that is a **focus proxy**: an invisible InputOnly
+window that takes the X focus and forwards keystrokes into the client with
+`SendEvent`.
+
+**react-x11 does not use a proxy**, and the reason matters if you are reading
+the code expecting one:
+
+- A proxy inside our own toplevel means the toplevel sees `FocusOut` the moment
+  the client is focused. react-x11 reads that as the window losing focus —
+  carets stop blinking, `<window onBlur>` fires — and the element would be told
+  to blur the client it had just focused.
+- A key that reaches a proxy has already gone past every handler in the React
+  tree, so an application chord could never be checked first.
+
+So the X focus stays on your window, and the rule is:
+
+> While a `<foreign>` holds focus, the application's handlers see every key
+> first. Anything they do not consume is forwarded to the client.
+
+`preventDefault()` is how they consume it — the same word, and the same
+ordering, that lets a `<textinput>` keep Tab as an indent key:
+
+```jsx
+<window
+  onKeyDown={(ev) => {
+    if (ev.ctrlKey && ev.keysym === XK_t) {
+      ev.preventDefault(); // the app's chord; the terminal never sees it
+      newTab();
+    }
+  }}
+>
+  <foreign windowId={id} style={{ flexGrow: 1 }} />
+</window>
+```
+
+Everything else about focus is the ordinary focus manager:
+
+| what happens                                 | what the client is told                                                                                                                      |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| the node takes focus by click or `focus()`   | `XEMBED_WINDOW_ACTIVATE`, then `XEMBED_FOCUS_IN` detail `CURRENT`                                                                            |
+| Tab into it                                  | `FOCUS_IN` detail `FIRST` — focus your first widget                                                                                          |
+| Shift+Tab into it                            | `FOCUS_IN` detail `LAST`                                                                                                                     |
+| focus leaves, or the window deactivates      | `FOCUS_OUT`, then `WINDOW_DEACTIVATE`                                                                                                        |
+| the client sends `XEMBED_REQUEST_FOCUS`      | the node is focused _through the focus manager_, so `:focus`, `:focus-within`, the previous node's `onBlur` and the AT-SPI bridge all see it |
+| the client sends `FOCUS_NEXT` / `FOCUS_PREV` | focus moves to the next/previous react-x11 focusable — Tab crosses the boundary as if it were one application                                |
+
+A `<foreign>` is focusable by default, like a `<textinput>`. `focusable={false}`
+opts out, which is what a video surface wants.
+
+Tab is _forwarded_ rather than acted on: an XEmbed client has a tab chain of its
+own and says so with `FOCUS_NEXT` when it runs off the end of it. A client that
+speaks no XEmbed — a terminal — keeps Tab for good, which is what a terminal is
+for; click elsewhere to leave.
+
+### The one gap
+
+X delivers a key to the deepest descendant of the focus window that contains the
+pointer. So while the pointer is _over_ the embedded client, the client receives
+keys directly and no handler of yours runs — application chords do not work
+there. They work everywhere else in the window, which is the trade a focus proxy
+would make in the other direction.
+
+## Reparenting window managers
+
+A `<foreign>` inside a toplevel that the window manager has reparented into a
+frame is offset by that frame, and the root-relative coordinates in the
+synthetic `ConfigureNotify` have to account for it. react-x11 tracks the
+toplevel's screen origin from `ReparentNotify`/`ConfigureNotify` and asks the
+server rather than trusting reported geometry — the same problem
+`src/components/anchor.js` solves for popup placement.
+
+## Props
+
+| prop             |                                                                                                                               |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `windowId`       | the X window to embed. Changing it hands the old client back first. Omit it to adopt whatever is put inside the node instead. |
+| `onReady`        | `({ windowId })` — the node's own container id, offered before anything is embedded, to spawn a program into                  |
+| `onEmbedded`     | `({ id, xembed, version })` — a client is in                                                                                  |
+| `onClientGone`   | destroyed, or reparented away by someone else                                                                                 |
+| `onRequestFocus` | the client asked for the focus (it is then given through the focus manager)                                                   |
+| `onError`        | the embed failed — no such window, or it went away mid-handshake. Without a handler, a console warning.                       |
+| `focusable`      | default `true`; takes part in the focus manager and the tab chain                                                             |
+| `style`          | layout as usual; `backgroundColor` is what shows with no client in                                                            |
+
+## Example
+
+`examples/foreign.jsx` spawns a program into a pane and shows the release
+path — run it with a program of your choice:
+
+```sh
+npm run examples:foreign            # xterm, if you have it
+FOREIGN_CMD="mpv --wid=%WID% video.mp4" npm run examples:foreign
+```
+
+## What is not here yet
+
+- **`<TrayHost>`** — owning the `_NET_SYSTEM_TRAY_S<screen>` manager selection
+  and rendering a `<foreign>` per docked icon, which is what makes a react-x11
+  panel a real desktop shell. The system tray is XEmbed's biggest surviving
+  consumer.
+- **The plug side** — a react-x11 root that renders _into_ someone else's
+  socket, for shipping as a tray icon or a panel applet. Lower value and
+  deliberately last: GTK4 removed `GtkPlug` and Qt dropped `QX11Embed*` after
+  Qt4, so the population of hosts willing to embed us is shrinking while the
+  population of clients we can host is not.
+
+Both are tracked in [issue #269](https://github.com/sidorares/react-x11/issues/269).

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -301,15 +301,16 @@ how the element is built — which is what `<textinput onKeyDown>` has always
 been able to do, and is the reason to implement behaviour here rather than in
 a React component wrapping the element.
 
-| method                   | when                                                                                                                         |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
-| `defaultKeyDown(ev)`     | a key, delivered to the focused node. `ev.keysym` is the `XK_*` constant; `codepoint >= 0x20` is the test for "this is text" |
-| `defaultMouseDown(ev)`   | a press. Place a caret, grab a handle; `ev.capturePointer()` to keep the rest of the gesture                                 |
-| `defaultMouseDrag(ev)`   | motion while _this_ element holds the press — including outside its box, which `onMouseMove` does not give you               |
-| `defaultMouseUp(ev)`     | that press was released                                                                                                      |
-| `defaultContextMenu(ev)` | right-click, after the press: open your own menu. Separate so suppressing it keeps the caret placement                       |
-| `defaultFocus()`         | this element became the focused node (or its window got the X focus back): start the caret blinking                          |
-| `defaultBlur()`          | focus left, or the window lost it: stop it                                                                                   |
+| method                   | when                                                                                                                                                                                                                        |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `defaultKeyDown(ev)`     | a key, delivered to the focused node. `ev.keysym` is the `XK_*` constant; `codepoint >= 0x20` is the test for "this is text"                                                                                                |
+| `defaultKeyUp(ev)`       | that key was released. Rare — nothing in core needs it — and there for an element that answers the whole keystroke rather than the press, such as `<foreign>` forwarding into an embedded client                            |
+| `defaultMouseDown(ev)`   | a press. Place a caret, grab a handle; `ev.capturePointer()` to keep the rest of the gesture                                                                                                                                |
+| `defaultMouseDrag(ev)`   | motion while _this_ element holds the press — including outside its box, which `onMouseMove` does not give you                                                                                                              |
+| `defaultMouseUp(ev)`     | that press was released                                                                                                                                                                                                     |
+| `defaultContextMenu(ev)` | right-click, after the press: open your own menu. Separate so suppressing it keeps the caret placement                                                                                                                      |
+| `defaultFocus(info)`     | this element became the focused node (or its window got the X focus back): start the caret blinking. `info` is `{ reason, backwards }` — `'key'` with a direction is a Tab, which is the only thing that has ever needed it |
+| `defaultBlur()`          | focus left, or the window lost it: stop it                                                                                                                                                                                  |
 
 ```js
 import { Node, CARET_BLINK_MS } from 'react-x11/node';
@@ -453,12 +454,29 @@ rather than a reason to opt out.
 
 `drawn: false` is for a node backed by its own child X window rather than
 painted into its parent — a GL surface, an XEMBED socket, a video overlay.
-`GlAreaNode` (`src/glnodes.js`) is the worked example: it holds no paint
-code, and the owning `WindowNode` realizes it in the commit phase
-(`_realizeGlAreas`) so the child window names its real parent from the
-start. Read those two together before writing a third one; the ordering
-constraint — no X calls in the render phase, because the render phase is
-discardable — is the part that is easy to get wrong.
+There are two worked examples, and they are worth reading in this order.
+
+`GlAreaNode` (`src/glnodes.js`) is the simple one: it holds no paint code,
+and the owning `WindowNode` realizes it in the commit phase
+(`_realizeChildWindows`) so the child window names its real parent from the
+start. The ordering constraint — no X calls in the render phase, because the
+render phase is discardable — is the part that is easy to get wrong.
+
+`ForeignNode` (`src/foreignnodes.js`) is the same shape with the stakes
+raised, and it is the one to read if your element touches a resource you did
+not create. Three things it has to do that a GL surface does not:
+
+- **Nothing in the render phase, for a sharper reason.** A `CreateWindow`
+  from a discarded render leaks a server resource; a `ReparentWindow` from
+  one has moved another application's window for real.
+- **Teardown is synchronous.** `WindowNode.destroySubtree` destroys its own
+  X window in the same turn your node's does, and `DestroyWindow` takes every
+  inferior with it — so a release that waits for a round trip releases a
+  window that no longer exists. Compute what you would have asked for; the
+  requests are ordered on the connection, which is what makes "hand it back,
+  _then_ destroy the container" a guarantee.
+- **Give it back, do not destroy it.** The element's own test file asserts
+  that first, because it is the failure this shape is most able to cause.
 
 ## The subpath exports
 

--- a/examples/foreign.jsx
+++ b/examples/foreign.jsx
@@ -1,0 +1,173 @@
+// <foreign>: another application's window, inside this one.
+//
+// A pane that spawns a program into itself and shows what happened to it.
+// Two paths in one demo, because they are the two ways an embed ever starts:
+//
+//   - **adopt** (no `windowId`): the pane's own X window id is handed to the
+//     program on its command line, and whatever it puts inside is taken.
+//     `xterm -into WID` and `mpv --wid=WID` work this way, and so does
+//     anything else that has to be *given* a window before it makes one.
+//   - **embed** (`windowId={id}`): a window that already exists — one found
+//     by a window manager, a picker, or a previous pane letting go of it.
+//     Closing the pane here re-embeds the same client in the other slot,
+//     which is the whole point: the window is not ours, and it survives.
+//
+// Run with: npm run examples:foreign     (needs an X server and a program
+//                                         that accepts a window id)
+//
+//   FOREIGN_CMD="mpv --wid=%WID% clip.mp4" npm run examples:foreign
+//
+// `%WID%` is replaced with the pane's window id; the default is
+// `xterm -into %WID%`, which is the one most systems have.
+import { spawn } from 'node:child_process';
+import React, { useCallback, useRef, useState } from 'react';
+
+import { Button } from '../src/components/index.js';
+import { createRoot } from '../src/index.js';
+import { ctrlChordLetter } from '../src/keysyms.js';
+
+const COMMAND = process.env.FOREIGN_CMD ?? 'xterm -into %WID%';
+
+/** The command, with `%WID%` filled in. Naive splitting on purpose — this is
+ *  a demo, and a real app would take argv rather than a string. */
+function commandFor(windowId) {
+  const [program, ...args] = COMMAND.split(/\s+/).map((token) =>
+    token.replaceAll('%WID%', String(windowId)),
+  );
+  return { program, args };
+}
+
+/**
+ * A pane that starts a program into itself.
+ *
+ * `onReady` is what makes this possible: it carries the pane's own X window
+ * id, and it fires before anything is embedded — which has to be true,
+ * because the program cannot be started without it.
+ */
+function SpawningPane({ onStatus, onWindow }) {
+  const started = useRef(false);
+
+  const start = useCallback(
+    ({ windowId }) => {
+      // onReady fires again if the socket is rebuilt; the program is not
+      if (started.current) return;
+      started.current = true;
+      const { program, args } = commandFor(windowId);
+      onStatus(`starting ${program}…`);
+      const child = spawn(program, args, { stdio: 'ignore' });
+      child.on('error', (err) =>
+        onStatus(`could not start ${program}: ${err.message}`),
+      );
+      child.on('exit', (code) => onStatus(`${program} exited (${code})`));
+    },
+    [onStatus],
+  );
+
+  return (
+    <foreign
+      style={{ flexGrow: 1, backgroundColor: '#101014' }}
+      onReady={start}
+      onEmbedded={({ id, xembed, version }) => {
+        onWindow(id);
+        onStatus(
+          xembed
+            ? `embedded ${id} — speaks XEmbed v${version}`
+            : `embedded ${id} — plain reparenting, no _XEMBED_INFO`,
+        );
+      }}
+      onClientGone={() => {
+        onWindow(null);
+        onStatus('the client went away');
+      }}
+      onRequestFocus={() => onStatus('the client asked for the focus')}
+      onError={(err) => onStatus(`embed failed: ${err.message}`)}
+    />
+  );
+}
+
+function App() {
+  const [status, setStatus] = useState(`waiting — ${COMMAND}`);
+  // the id the pane is holding, so the second pane can take it over
+  const [windowId, setWindowId] = useState(null);
+  const [moved, setMoved] = useState(false);
+
+  return (
+    <window
+      width={720}
+      height={520}
+      title="react-x11 — <foreign>"
+      // The chord rule, made visible. A `<foreign>` forwards the keys it is
+      // given, and `preventDefault()` here is what keeps one — the same word,
+      // and the same ordering, that lets a `<textinput>` keep Tab.
+      onKeyDown={(ev) => {
+        if (ev.ctrlKey && ctrlChordLetter(ev) === 0x6b /* k */) {
+          ev.preventDefault();
+          setStatus(`Ctrl+K stayed here (${new Date().toLocaleTimeString()})`);
+        }
+      }}
+    >
+      <box
+        style={{
+          flexGrow: 1,
+          padding: 12,
+          gap: 10,
+          backgroundColor: '$background',
+        }}
+      >
+        <box style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+          <text style={{ fontSize: 13, flexGrow: 1 }}>{status}</text>
+          <Button disabled={!windowId} onPress={() => setMoved((m) => !m)}>
+            {moved ? 'Move back' : 'Move to the other pane'}
+          </Button>
+        </box>
+
+        {/*
+          The same client, in one pane or the other. Unmounting the pane it
+          is in hands the window back to the root rather than destroying it,
+          which is what lets the other pane pick it up by id — and what would
+          happen to a real application if this app simply quit.
+        */}
+        {moved && windowId ? (
+          <box style={{ flexDirection: 'row', flexGrow: 1, gap: 10 }}>
+            <box
+              style={{
+                flexGrow: 1,
+                borderWidth: 1,
+                borderColor: '$border',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <text style={{ fontSize: 12, color: '$dim' }}>empty</text>
+            </box>
+            <foreign
+              windowId={windowId}
+              style={{ flexGrow: 1, backgroundColor: '#101014' }}
+              onEmbedded={({ id }) =>
+                setStatus(`re-embedded ${id} on the right`)
+              }
+              onClientGone={() => {
+                setWindowId(null);
+                setStatus('the client went away');
+              }}
+            />
+          </box>
+        ) : (
+          <SpawningPane onStatus={setStatus} onWindow={setWindowId} />
+        )}
+
+        <text style={{ fontSize: 11, color: '$dim' }}>
+          Keys go to the app first: Ctrl+K is taken here and never reaches the
+          client. Everything else is forwarded — click the pane and type.
+        </text>
+      </box>
+    </window>
+  );
+}
+
+export default App;
+
+if (!process.env.REACT_X11_NO_AUTORUN) {
+  const root = await createRoot();
+  root.render(<App />);
+}

--- a/examples/foreign.jsx
+++ b/examples/foreign.jsx
@@ -1,16 +1,19 @@
 // <foreign>: another application's window, inside this one.
 //
-// A pane that spawns a program into itself and shows what happened to it.
-// Two paths in one demo, because they are the two ways an embed ever starts:
+// A pane that spawns a program into itself, lets go of it, and takes it back.
+// Both ways an embed ever starts are in here:
 //
 //   - **adopt** (no `windowId`): the pane's own X window id is handed to the
 //     program on its command line, and whatever it puts inside is taken.
 //     `xterm -into WID` and `mpv --wid=WID` work this way, and so does
 //     anything else that has to be *given* a window before it makes one.
-//   - **embed** (`windowId={id}`): a window that already exists — one found
-//     by a window manager, a picker, or a previous pane letting go of it.
-//     Closing the pane here re-embeds the same client in the other slot,
-//     which is the whole point: the window is not ours, and it survives.
+//   - **embed** (`windowId={id}`): a window that already exists — found by a
+//     window manager, a picker, or a previous run.
+//
+// **Detach** is the part worth watching. It unmounts the pane, and the
+// terminal does not disappear: it becomes an ordinary application window on
+// the desktop, frame and all, because it was never this app's to destroy.
+// That is the whole promise of the element, visible in one click.
 //
 // Run with: npm run examples:foreign     (needs an X server and a program
 //                                         that accepts a window id)
@@ -44,7 +47,7 @@ function commandFor(windowId) {
  * id, and it fires before anything is embedded — which has to be true,
  * because the program cannot be started without it.
  */
-function SpawningPane({ onStatus, onWindow }) {
+function SpawningPane({ onStatus }) {
   const started = useRef(false);
 
   const start = useCallback(
@@ -67,18 +70,14 @@ function SpawningPane({ onStatus, onWindow }) {
     <foreign
       style={{ flexGrow: 1, backgroundColor: '#101014' }}
       onReady={start}
-      onEmbedded={({ id, xembed, version }) => {
-        onWindow(id);
+      onEmbedded={({ id, xembed, version }) =>
         onStatus(
           xembed
             ? `embedded ${id} — speaks XEmbed v${version}`
             : `embedded ${id} — plain reparenting, no _XEMBED_INFO`,
-        );
-      }}
-      onClientGone={() => {
-        onWindow(null);
-        onStatus('the client went away');
-      }}
+        )
+      }
+      onClientGone={() => onStatus('the client went away')}
       onRequestFocus={() => onStatus('the client asked for the focus')}
       onError={(err) => onStatus(`embed failed: ${err.message}`)}
     />
@@ -87,9 +86,7 @@ function SpawningPane({ onStatus, onWindow }) {
 
 function App() {
   const [status, setStatus] = useState(`waiting — ${COMMAND}`);
-  // the id the pane is holding, so the second pane can take it over
-  const [windowId, setWindowId] = useState(null);
-  const [moved, setMoved] = useState(false);
+  const [attached, setAttached] = useState(true);
 
   return (
     <window
@@ -116,44 +113,35 @@ function App() {
       >
         <box style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
           <text style={{ fontSize: 13, flexGrow: 1 }}>{status}</text>
-          <Button disabled={!windowId} onPress={() => setMoved((m) => !m)}>
-            {moved ? 'Move back' : 'Move to the other pane'}
+          <Button
+            disabled={!attached}
+            onPress={() => {
+              setAttached(false);
+              setStatus('detached — it is a window of its own now');
+            }}
+          >
+            Detach
           </Button>
         </box>
 
-        {/*
-          The same client, in one pane or the other. Unmounting the pane it
-          is in hands the window back to the root rather than destroying it,
-          which is what lets the other pane pick it up by id — and what would
-          happen to a real application if this app simply quit.
-        */}
-        {moved && windowId ? (
-          <box style={{ flexDirection: 'row', flexGrow: 1, gap: 10 }}>
-            <box
-              style={{
-                flexGrow: 1,
-                borderWidth: 1,
-                borderColor: '$border',
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
-            >
-              <text style={{ fontSize: 12, color: '$dim' }}>empty</text>
-            </box>
-            <foreign
-              windowId={windowId}
-              style={{ flexGrow: 1, backgroundColor: '#101014' }}
-              onEmbedded={({ id }) =>
-                setStatus(`re-embedded ${id} on the right`)
-              }
-              onClientGone={() => {
-                setWindowId(null);
-                setStatus('the client went away');
-              }}
-            />
-          </box>
+        {attached ? (
+          <SpawningPane onStatus={setStatus} />
         ) : (
-          <SpawningPane onStatus={setStatus} onWindow={setWindowId} />
+          <box
+            style={{
+              flexGrow: 1,
+              borderWidth: 1,
+              borderColor: '$border',
+              alignItems: 'center',
+              justifyContent: 'center',
+              padding: 20,
+            }}
+          >
+            <text style={{ fontSize: 12, color: '$dim', textAlign: 'center' }}>
+              The pane is gone and the terminal is still running — look for it
+              on the desktop, with a window manager frame of its own.
+            </text>
+          </box>
         )}
 
         <text style={{ fontSize: 11, color: '$dim' }}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^7.3.3",
+        "ntk": "^7.4.0",
         "react-reconciler": "^0.33.0"
       },
       "devDependencies": {
@@ -4034,9 +4034,9 @@
       }
     },
     "node_modules/ntk": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-7.3.3.tgz",
-      "integrity": "sha512-TLzqdEo8NkNkgN8+pPSbyQu8r0Yx6X4L/SHZDu0hRNTuJZuyoyeTdVHY30afnSfpsZWlPRX+l42Svl2LAXir+Q==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-7.4.0.tgz",
+      "integrity": "sha512-P6FeT5ZzCwk332vB+CXFBKcn79Z1CGp+IBZA7zzvG05LkEvM+WG0EJTDYWMEJR8KKeW++Xsh27h4oxkc3ijauA==",
       "license": "MIT",
       "dependencies": {
         "bidi-js": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "examples:icons": "tsx examples/icons.jsx",
     "examples:raster-gate": "tsx examples/raster-gate.jsx",
     "examples:stress": "tsx examples/stress/index.jsx",
+    "examples:foreign": "tsx examples/foreign.jsx",
     "examples:gl": "tsx examples/gl.jsx",
     "examples:three": "tsx examples/three.jsx",
     "examples:shader": "tsx examples/shader.jsx",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^7.3.3",
+    "ntk": "^7.4.0",
     "react-reconciler": "^0.33.0"
   },
   "optionalDependencies": {

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -45,6 +45,7 @@ import { beginStartup } from './startup.js';
 import { beginCompositing, endCompositing } from './compositing.js';
 import { beginScreens, endScreens } from './screens.js';
 import { watchAppearance } from './appearance.js';
+import { ForeignNode } from './foreignnodes.js';
 import { GlAreaNode } from './glnodes.js';
 import { directGLFailure, hasDirectGL } from './glbackend.js';
 import { createRegisteredNode, registeredElements } from './registry.js';
@@ -95,6 +96,7 @@ export const HOST_TYPES = [
   'svg',
   'tex',
   'glarea',
+  'foreign',
 ];
 
 const HostConfig = {
@@ -292,6 +294,14 @@ const HostConfig = {
         break;
       case 'glarea':
         node = new GlAreaNode(props, rootContainer);
+        break;
+      case 'foreign':
+        // No X11 calls here either, and for a sharper reason than
+        // `<window>`'s: the window this element embeds belongs to another
+        // process, and a reparent issued from a render React then discards
+        // has moved it for real. WindowNode.realize does it in the commit
+        // phase (`_realizeChildWindows`).
+        node = new ForeignNode(props, rootContainer);
         break;
       default: {
         // Third-party elements (issue #125). Built-ins stay a switch —

--- a/src/a11y.js
+++ b/src/a11y.js
@@ -98,6 +98,9 @@ export const ATSPI_ROLE = Object.freeze({
   PARAGRAPH: 73,
   APPLICATION: 75,
   AUTOCOMPLETE: 76,
+  // another toolkit's widget hierarchy inside ours — AT-SPI's own word for
+  // what `<foreign>` holds. The AT walks into the client's tree, not ours.
+  EMBEDDED: 78,
   ENTRY: 79,
   CAPTION: 81,
   DOCUMENT_FRAME: 82,
@@ -308,6 +311,7 @@ const KIND_ROLES = {
   tex: ATSPI_ROLE.MATH,
   svg: ATSPI_ROLE.IMAGE,
   glarea: ATSPI_ROLE.CANVAS,
+  foreign: ATSPI_ROLE.EMBEDDED,
 };
 
 /** The kind → web-role-name table `roleOf()` in the test queries also

--- a/src/events.js
+++ b/src/events.js
@@ -652,7 +652,16 @@ export class EventManager {
             ? String.fromCodePoint(native.codepoint)
             : undefined,
       });
-      if (name !== 'KeyDown' || ev.defaultPrevented) return;
+      if (ev.defaultPrevented) return;
+      // A release has no traversal after it, but it does have a default
+      // action: an element that answers the whole keystroke rather than the
+      // press — one forwarding into an embedded client (`<foreign>`) — needs
+      // the other half of the pair, or the client sees a key that never
+      // comes up.
+      if (name !== 'KeyDown') {
+        target.defaultKeyUp?.(ev);
+        return;
+      }
       // The element's own behaviour first, focus traversal after it — Tab is
       // an ordinary defaultable key rather than one the focus manager eats on
       // the way past. Cycling first meant an editor could only keep Tab as an
@@ -680,10 +689,16 @@ export class EventManager {
    * Everything else — Tab, an arrow inside a widget, `autoFocus`, a modal
    * handing focus back as it closes, `node.focus()` from an application —
    * lights one, because none of those tell the user where focus went.
+   *
+   * `backwards` is only meaningful for `reason: 'key'`, and only one element
+   * has ever needed it: XEmbed distinguishes a Tab arriving forwards from a
+   * back-Tab, because that is what tells an embedded client whether to focus
+   * its first widget or its last (`<foreign>`, src/foreignnodes.js). It
+   * reaches the node through `defaultFocus({ reason, backwards })`.
    */
-  focus(node, reason = 'script') {
+  focus(node, reason = 'script', backwards = false) {
     const manager = this.focusManager;
-    if (manager !== this) return manager.focus(node, reason);
+    if (manager !== this) return manager.focus(node, reason, backwards);
     if (node === this.focused) return;
     const old = this.focused;
     this._previousFocus = old;
@@ -708,7 +723,7 @@ export class EventManager {
       node.setStyleState(':focus', true);
       node.setStyleState(':focus-visible', reason !== 'pointer');
       this._scrollIntoView(node);
-      if (this.windowFocused) node.defaultFocus?.();
+      if (this.windowFocused) node.defaultFocus?.({ reason, backwards });
       node.props.onFocus?.(this._makeEvent('focus', null, node));
       node.root?.invalidate(false, node, 'focus');
     }
@@ -856,7 +871,7 @@ export class EventManager {
     const index = list.indexOf(this.focused);
     if (index === -1) {
       // nothing focused, or focus sits outside the current scope: Tab enters
-      this.focus(backwards ? list[list.length - 1] : list[0], 'key');
+      this.focus(backwards ? list[list.length - 1] : list[0], 'key', backwards);
       return;
     }
     this.focus(
@@ -864,6 +879,7 @@ export class EventManager {
         ? list[(index || list.length) - 1]
         : list[(index + 1) % list.length],
       'key',
+      backwards,
     );
   }
 

--- a/src/foreignnodes.js
+++ b/src/foreignnodes.js
@@ -1,0 +1,499 @@
+// <foreign>: another process's window, inside ours.
+//
+// The second element that owns a real X window without painting into its
+// parent (NEXT_STEPS §4, after `<glarea>`), and the only one that makes a
+// react-x11 app a *host* rather than a drawer of its own pixels: a terminal
+// pane, a video surface, a docked tray icon.
+//
+// The protocol is ntk's (`XEmbedSocket`, sidorares/ntk#246) — the save-set,
+// the reparent, `_XEMBED_INFO`, the `_XEMBED` messages, the synthetic ICCCM
+// 4.1.5 ConfigureNotify. What is left here is the part that has to be
+// React-shaped, and it is three things:
+//
+//  1. **When the X calls happen.** `createInstance` runs in the render
+//     phase, which React may discard — and a ReparentWindow issued from a
+//     render that is then thrown away has moved somebody else's window for
+//     real. So this node holds no socket until the owning `WindowNode`
+//     realizes it in the commit phase, exactly as `<glarea>` is realized
+//     (`_realizeChildWindows`, nodes.js).
+//
+//  2. **Where the rect comes from.** Yoga, like any other child. Every
+//     change is a ConfigureWindow on the client plus the synthetic
+//     ConfigureNotify with root-relative coordinates, which is the geometry
+//     question a client actually asks.
+//
+//  3. **Whose focus it is.** react-x11 has a focus manager, a tab order and
+//     `preventDefault`; XEmbed has activation, logical focus and
+//     FOCUS_NEXT/PREV. This file is the mapping — see "Focus" below.
+//
+// Unmount hands the client back: reparented to the root, dropped from the
+// save set, **never destroyed**. Destroying somebody else's window because a
+// React tree changed is the failure mode this element is most able to cause,
+// and `test/foreign.test.js` asserts against it first.
+import { XEMBED, XEmbedSocket } from 'ntk';
+
+import { isFocusable } from './a11y.js';
+import { inputTime } from './inputtime.js';
+import { Node, pixelFor } from './nodes.js';
+
+const px = (v) => Math.max(1, Math.round(v || 0));
+
+/**
+ * `<foreign>` — another client's top-level window, laid out as an element.
+ *
+ * ```jsx
+ * <foreign
+ *   windowId={id}
+ *   style={{ flexGrow: 1, backgroundColor: '#101014' }}
+ *   onEmbedded={({ xembed }) => setMode(xembed ? 'xembed' : 'reparented')}
+ *   onClientGone={() => respawn()}
+ * />
+ * ```
+ *
+ * With no `windowId` the node instead **adopts** whatever is put inside it,
+ * and hands out the id to put it in through `onReady` — which is the shape
+ * `xterm -into WID` and `mpv --wid=WID` need, since the program has to be
+ * given a window before it has one of its own.
+ *
+ * Like `<glarea>`, the child X window sits above everything drawn in the
+ * parent, so 2D content cannot overlap it — a HUD belongs in a sibling
+ * `<popup>`.
+ *
+ * ### Focus
+ *
+ * The classic embedder answers XEmbed focus with a *focus proxy*: an
+ * InputOnly window that takes the real X input focus and forwards
+ * keystrokes to the client with SendEvent. This one does not, deliberately.
+ * Two reasons, and they point the same way:
+ *
+ *  - A proxy inside our own toplevel means the toplevel sees FocusOut
+ *    (detail Inferior) the moment the client is focused, and react-x11 reads
+ *    that as the window losing focus — the caret stops blinking, `<window
+ *    onBlur>` fires, and this node is told to blur the client it just
+ *    focused.
+ *  - A key that reaches the proxy has already gone past every handler in the
+ *    React tree, so an application chord cannot be checked first. That is
+ *    the one rule this element has to keep: **while a `<foreign>` holds
+ *    focus, the app's handlers see the key first and everything they do not
+ *    consume is forwarded**. `preventDefault()` is how they consume it, the
+ *    same word that stops a `<textinput>` from eating Tab.
+ *
+ * So the X focus stays on our own window, the logical focus is a message
+ * (`XEMBED_FOCUS_IN`), and forwarding happens in `defaultKeyDown`/
+ * `defaultKeyUp` — after dispatch, which is what "the app sees it first"
+ * means mechanically.
+ *
+ * The one thing this cannot cover: X delivers a key to the deepest
+ * descendant of the focus window that contains the pointer, so while the
+ * pointer is *over* the embedded client the client receives keys directly
+ * and no handler of ours runs. Chords work everywhere else in the window,
+ * which is the trade a proxy would make in reverse.
+ */
+export class ForeignNode extends Node {
+  constructor(props, app) {
+    super('foreign', props, app);
+    /** ntk's XEmbedSocket, from the commit phase onwards */
+    this.socket = null;
+    /** `{ id, xembed, version }` while a client is in, else null */
+    this.client = null;
+    /** the error that stopped an embed, if one did */
+    this.error = null;
+    /** geometry last sent to the X windows */
+    this.rect = null;
+    // an embedded client is a control the user can Tab to, like a
+    // <textinput> — `focusable={false}` opts out (a video surface, say)
+    this.focusableByDefault = true;
+    // whether an XEMBED_FOCUS_IN is outstanding, so the matching FOCUS_OUT
+    // is sent once and only after one
+    this._focusSent = false;
+    this._backgroundPixel = null;
+  }
+
+  get isForeign() {
+    return true;
+  }
+
+  _setRoot(root) {
+    super._setRoot(root);
+    // a <foreign> mounted into a live tree realizes here; one mounted with
+    // the window is picked up by WindowNode.realize
+    if (root?.window) this.realize();
+  }
+
+  /**
+   * Create the container X window and start embedding. Called from the
+   * commit phase and from `_setRoot`, both of which are past the point
+   * where React can discard the work.
+   */
+  realize() {
+    if (this.socket || this.destroyed) return;
+    const parent = this.root?.window;
+    if (!parent || typeof this.app?.createWindow !== 'function') return;
+    const rect = this._geometry();
+    this.rect = rect;
+    const socket = new XEmbedSocket(parent, {
+      ...rect,
+      // react-x11 has a focus manager; a socket that answered
+      // XEMBED_REQUEST_FOCUS by itself would move focus behind its back and
+      // the rest of the tree would never hear about it
+      focusOnRequest: false,
+    });
+    this.socket = socket;
+    socket.window._reactX11Node = this;
+    this._applyBackground();
+    socket.on('embedded', (info) => this._onEmbedded(info));
+    socket.on('gone', () => this._onGone());
+    socket.on('requestFocus', () => this._onRequestFocus());
+    socket.on('focusNext', () => this._moveFocus(false));
+    socket.on('focusPrev', () => this._moveFocus(true));
+    this._start(this.props.windowId);
+    // after `_start`, which maps the container itself — both paths do,
+    // because a client cannot be viewable inside an unmapped one
+    this._syncMapped();
+  }
+
+  /**
+   * Embed `windowId`, or — with none — wait for something to put a window
+   * inside the container and take that.
+   *
+   * The token guards the async edge: a `windowId` that changes while an
+   * embed is in flight must not have the stale one report success, and a
+   * node that unmounted must not report anything at all.
+   */
+  _start(windowId) {
+    const socket = this.socket;
+    if (!socket) return;
+    const token = (this._token = {});
+    this.error = null;
+    const started = windowId ? socket.embed(windowId) : socket.adopt();
+    started.catch((err) => {
+      if (this._token !== token || this.destroyed) return;
+      this.error = err;
+      if (this.props.onError) this.props.onError(err);
+      else console.warn(`react-x11: <foreign> could not embed: ${err.message}`);
+    });
+    // The container id is what a program is *given* — `xterm -into ID` — so
+    // it has to be reachable before there is anything in it, and it is the
+    // only way the adopt path can ever start.
+    this.props.onReady?.({ windowId: socket.window.id, node: this });
+  }
+
+  _onEmbedded(info) {
+    if (this.destroyed) return;
+    this.client = { id: info.id, xembed: info.xembed, version: info.version };
+    this._syncMapped();
+    // A client that arrives while this node already has focus has missed the
+    // activation and the focus-in that went out before it was there — a
+    // terminal spawned into a focused pane, which is the ordinary case.
+    const manager = this._focusManager();
+    if (manager?.focused === this && manager.windowFocused) this.defaultFocus();
+    this.props.onEmbedded?.({ ...this.client, node: this });
+  }
+
+  _onGone() {
+    if (this.destroyed) return;
+    this.client = null;
+    this._focusSent = false;
+    this.props.onClientGone?.({ node: this });
+  }
+
+  /**
+   * `XEMBED_REQUEST_FOCUS`: the client says the user clicked it. Routed
+   * through the focus manager rather than answered here, so `:focus`,
+   * `:focus-within`, `onBlur` on whatever had focus and the AT-SPI bridge
+   * all observe it the way they observe any other focus change.
+   */
+  _onRequestFocus() {
+    if (this.destroyed) return;
+    this.props.onRequestFocus?.({ node: this });
+    if (isFocusable(this)) this.focus();
+  }
+
+  /**
+   * `XEMBED_FOCUS_NEXT`/`_PREV`: the client ran off the end of its own tab
+   * chain. Continuing into ours is what makes Tab feel like one application
+   * instead of two.
+   */
+  _moveFocus(backwards) {
+    if (this.destroyed) return;
+    const manager = this._focusManager();
+    // Only from focus we gave it. A client asking to be tabbed out of when
+    // it does not hold the focus would move focus somewhere the user is not
+    // looking, and the message is stale by definition.
+    if (manager?.focused !== this) return;
+    manager._cycleFocus(backwards);
+  }
+
+  // --- focus ---------------------------------------------------------
+
+  /**
+   * This node has the focus *and* the toplevel has the X focus — which is
+   * exactly when EventManager calls this. Both halves of the XEmbed
+   * handshake go out: the window is active, and the client has the logical
+   * focus.
+   *
+   * `detail` is the direction Tab arrived from, which is what tells the
+   * client whether to focus its first widget or its last; a click or a
+   * `focus()` call leaves the client's own focus where it was.
+   */
+  defaultFocus(info) {
+    const socket = this.socket;
+    if (!socket || !this.client) return;
+    const time = inputTime(this.app);
+    socket.activate(true, { time });
+    const detail =
+      info?.reason === 'key'
+        ? info.backwards
+          ? XEMBED.FOCUS_LAST
+          : XEMBED.FOCUS_FIRST
+        : XEMBED.FOCUS_CURRENT;
+    // `socket.focusIn()` would create the focus proxy — see the class
+    // comment for why this element sends the message and keeps the X focus
+    socket.send(XEMBED.FOCUS_IN, detail, 0, 0, { time });
+    this._focusSent = true;
+  }
+
+  /** Focus left, or the toplevel stopped being the active window. */
+  defaultBlur() {
+    const socket = this.socket;
+    if (!socket) return;
+    const time = inputTime(this.app);
+    if (this._focusSent) {
+      socket.send(XEMBED.FOCUS_OUT, 0, 0, 0, { time });
+      this._focusSent = false;
+    }
+    socket.activate(false, { time });
+  }
+
+  defaultKeyDown(ev) {
+    this._forwardKey(ev);
+  }
+
+  defaultKeyUp(ev) {
+    this._forwardKey(ev);
+  }
+
+  /**
+   * The key, re-addressed to the client.
+   *
+   * Reached only after the whole React tree has had the event and left it
+   * undefaulted, so an application chord bound above this node has already
+   * won. Consuming it here in turn is what stops the focus cycle from also
+   * running: Tab belongs to the client, which has its own chain and says so
+   * with FOCUS_NEXT when it reaches the end of it.
+   */
+  _forwardKey(ev) {
+    const client = this.socket?.client;
+    const native = ev.nativeEvent;
+    if (!client || client._destroyed || !native?.type) return;
+    const X = this.app?.X;
+    if (!X) return;
+    try {
+      X.SendEvent(client.id, 0, 0, {
+        ...native,
+        wid: client.id,
+        child: 0,
+        // window-relative coordinates do not survive the move; the client's
+        // origin is this node's rect (root coordinates are unaffected)
+        x: (native.x ?? 0) - Math.round(this.abs.x),
+        y: (native.y ?? 0) - Math.round(this.abs.y),
+      });
+    } catch {
+      // the connection is going away; there is nothing to forward to
+    }
+    ev.preventDefault();
+  }
+
+  // --- layout --------------------------------------------------------
+
+  _geometry() {
+    return {
+      x: Math.round(this.abs.x),
+      y: Math.round(this.abs.y),
+      width: px(this.abs.width),
+      height: px(this.abs.height),
+    };
+  }
+
+  absolutize(originX, originY) {
+    super.absolutize(originX, originY);
+    this._syncGeometry();
+  }
+
+  _syncGeometry() {
+    const socket = this.socket;
+    if (!socket) return;
+    const rect = this._geometry();
+    const prev = this.rect;
+    if (
+      prev &&
+      prev.x === rect.x &&
+      prev.y === rect.y &&
+      prev.width === rect.width &&
+      prev.height === rect.height
+    ) {
+      return;
+    }
+    this.rect = rect;
+    // moves the container, resizes the client with it and sends the
+    // synthetic ConfigureNotify with root-relative coordinates (ICCCM 4.1.5)
+    socket.resize(rect).catch(() => {});
+  }
+
+  // --- props ---------------------------------------------------------
+
+  applyProps(newProps, oldProps) {
+    const before = oldProps ?? this.props;
+    super.applyProps(newProps, oldProps);
+    if (!this.socket) return;
+    if (newProps.windowId !== before.windowId) this._reembed(before.windowId);
+    this._applyBackground();
+  }
+
+  /**
+   * `windowId` changed. The old client is handed back before the new one is
+   * taken: a socket holds one client, and the window that is leaving is
+   * still somebody else's to keep.
+   */
+  _reembed(previousId) {
+    const socket = this.socket;
+    const next = this.props.windowId;
+    // Switching between "embed this id" and "adopt whatever turns up" is a
+    // different socket, not a different client: a pending adopt() has no
+    // cancel, and would otherwise take a window out from under the id that
+    // replaced it.
+    if (!previousId !== !next) {
+      this._teardown();
+      this.realize();
+      return;
+    }
+    this._token = {};
+    this.client = null;
+    this._focusSent = false;
+    socket
+      .release()
+      .then(() => {
+        if (this.destroyed || this.socket !== socket) return;
+        this._start(next);
+      })
+      .catch(() => {});
+  }
+
+  /**
+   * What shows in the rect before a client arrives and after one leaves.
+   *
+   * It is the container window's `backgroundPixel` — the server paints it,
+   * because this element draws nothing itself. Read from the ordinary
+   * `backgroundColor` style rather than a prop of its own: a second name for
+   * the one colour it does show would leave `backgroundColor` as a style
+   * property that silently does nothing beside it.
+   */
+  _applyBackground() {
+    const wnd = this.socket?.window;
+    if (typeof wnd?.setBackgroundPixel !== 'function') return;
+    const pixel = pixelFor(this.style.backgroundColor);
+    if (pixel === null || pixel === this._backgroundPixel) return;
+    this._backgroundPixel = pixel;
+    wnd.setBackgroundPixel(pixel);
+  }
+
+  setHidden(hidden) {
+    super.setHidden(hidden);
+    this._syncMapped();
+  }
+
+  /** The container follows `hidden`; the client follows the container,
+   * because an inferior of an unmapped window is not viewable however
+   * mapped it is itself. */
+  _syncMapped() {
+    const wnd = this.socket?.window;
+    if (!wnd) return;
+    if (this.hidden) wnd.unmap?.();
+    else wnd.map?.();
+  }
+
+  // the client's window covers this rect: nothing to paint into the
+  // parent's 2d context, and pointer events over it are the client's
+  paint() {}
+
+  /**
+   * Children would be drawn *under* another client's window and never seen —
+   * the same stacking rule `<glarea>` has, with no scene graph to make an
+   * exception for. Said here rather than swallowed, because an overlay is a
+   * reasonable thing to want and a sibling `<popup>` is how to have one.
+   */
+  insertBefore(child, beforeChild) {
+    throw new Error(
+      `react-x11: <foreign> takes no children — <${child.kind}> would be ` +
+        "drawn under the embedded client's X window and never seen. Put an " +
+        'overlay in a sibling <popup>.',
+    );
+  }
+
+  // --- teardown ------------------------------------------------------
+
+  destroySubtree() {
+    if (this.destroyed) return;
+    super.destroySubtree();
+    this._teardown();
+  }
+
+  /**
+   * Give the client back, and drop the container — both **synchronously**,
+   * which is the whole reason this is not `socket.destroy()`.
+   *
+   * `XEmbedSocket.release()` asks the server where the container is before
+   * it reparents, and `destroy()` awaits that before dropping the container
+   * window. Neither wait is affordable here: `WindowNode.destroySubtree`
+   * destroys the toplevel in the same synchronous turn as this runs, and
+   * DestroyWindow takes every inferior with it — so an awaited release
+   * reparents a client that has already been destroyed along with the window
+   * it was sitting in. The save set does not cover it either: X processes
+   * that when a *connection* closes, not when a window is destroyed.
+   *
+   * So the position is computed rather than asked for (the toplevel's screen
+   * origin plus this node's rect, both already known), and the three
+   * requests go out in the order that matters — hand the client back, then
+   * destroy what it was inside. Requests on one connection are ordered, so
+   * "then" is a guarantee rather than a hope.
+   */
+  _teardown() {
+    const socket = this.socket;
+    if (!socket) return;
+    this.socket = null;
+    this._token = {};
+    this.client = null;
+    this._focusSent = false;
+    this._backgroundPixel = null;
+    socket.removeAllListeners();
+
+    const client = socket.client;
+    // …and the socket must not act on it again: `client` is the field it
+    // publishes, and null means "nothing embedded", which is now true
+    socket.client = null;
+    try {
+      if (client && !client._destroyed) {
+        const origin = this.root?.window?._screenOrigin ?? { x: 0, y: 0 };
+        const rect = this.rect ?? this._geometry();
+        // stop selecting events on a window that is no longer ours, so the
+        // ReparentNotify below does not come back to us as `gone`
+        client.eventMask = 0;
+        this.app.X.ChangeWindowAttributes(
+          client.id,
+          { eventMask: 0 },
+          () => {},
+        );
+        client.reparentTo(
+          this.app.rootWindow(),
+          origin.x + rect.x,
+          origin.y + rect.y,
+        );
+        client.removeFromSaveSet();
+      }
+      socket.window.destroy();
+    } catch {
+      // the connection is closing: the client goes back to the root through
+      // the save set, which is exactly what it is for
+    }
+  }
+}

--- a/src/foreignnodes.js
+++ b/src/foreignnodes.js
@@ -175,7 +175,20 @@ export class ForeignNode extends Node {
     // The container id is what a program is *given* — `xterm -into ID` — so
     // it has to be reachable before there is anything in it, and it is the
     // only way the adopt path can ever start.
-    this.props.onReady?.({ windowId: socket.window.id, node: this });
+    //
+    // On a microtask, because this runs in the **commit phase**: a handler
+    // that sets state — which is what "start the program and show its
+    // status" is — would be setting it on a component React has not finished
+    // mounting, and React says so. The microtask lands after the whole
+    // synchronous commit and still before any reply from the server, which
+    // is the only ordering the caller can observe.
+    const onReady = this.props.onReady;
+    if (onReady) {
+      queueMicrotask(() => {
+        if (this._token !== token || this.destroyed) return;
+        onReady({ windowId: socket.window.id, node: this });
+      });
+    }
   }
 
   _onEmbedded(info) {

--- a/src/host.js
+++ b/src/host.js
@@ -24,6 +24,7 @@ const BUILT_IN = Object.freeze([
   'svg',
   'tex',
   'glarea',
+  'foreign',
 ]);
 
 /** The built-in element names. A copy: the vocabulary grows through

--- a/src/node.d.ts
+++ b/src/node.d.ts
@@ -254,5 +254,7 @@ export declare class TextInputNode extends Node {}
 export declare class TextAreaNode extends TextInputNode {}
 export declare class WindowNode extends Node {}
 export declare class PopupNode extends WindowNode {}
-/** The precedent for an element owning a real child X window. */
+/** The precedents for an element owning a real child X window — a surface of
+ * its own, and one holding somebody else's window. */
 export declare class GlAreaNode extends Node {}
+export declare class ForeignNode extends Node {}

--- a/src/node.js
+++ b/src/node.js
@@ -35,7 +35,10 @@ export {
   PopupNode,
 } from './nodes.js';
 
-// The precedent for an element that owns a real child X window rather than
-// painting into its parent's: registered with `drawn: false`, realized by
-// the owning WindowNode. docs/extending.md walks through it.
+// The two precedents for an element that owns a real child X window rather
+// than painting into its parent's: registered with `drawn: false`, realized
+// by the owning WindowNode. docs/extending.md walks through them —
+// `GlAreaNode` for a surface of one's own, `ForeignNode` for one that holds
+// somebody else's window and therefore must never destroy it.
 export { GlAreaNode } from './glnodes.js';
+export { ForeignNode } from './foreignnodes.js';

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -473,7 +473,7 @@ export function flushWindowRestacks() {
  * uses. Alpha is dropped: this is the *window background attribute*, a single
  * opaque pixel the server repeats, not something composited.
  */
-function pixelFor(color) {
+export function pixelFor(color) {
   const rgba = cssColorStraight(color);
   if (!rgba) return null;
   const [r, g, b] = rgba;
@@ -5598,8 +5598,9 @@ export class WindowNode extends Scrollable(Node) {
       }
     }
     this._restackWindowChildren();
-    // <glarea>s mounted before the window existed own a child X window too
-    this._realizeGlAreas(this);
+    // <glarea>s and <foreign>s mounted before the window existed own a
+    // child X window too
+    this._realizeChildWindows(this);
     // Before the map, deliberately. EWMH 7.7 gives an unmapped window a
     // different mechanism — it *declares* its initial state by writing the
     // property, where a mapped one has to *ask* the window manager — and
@@ -5916,12 +5917,20 @@ export class WindowNode extends Scrollable(Node) {
     for (const cb of [...this._windowFocusListeners]) cb(focused);
   }
 
-  /** Walk the drawn subtree and give every <glarea> its child X window. */
-  _realizeGlAreas(node) {
+  /**
+   * Walk the drawn subtree and give every element that owns a real child X
+   * window one — `<glarea>` and `<foreign>`.
+   *
+   * Here rather than in `createInstance` because the render phase is
+   * discardable: a CreateWindow from a render React throws away leaks a
+   * server resource, and a ReparentWindow from one has moved another
+   * client's window for real (docs/extending.md).
+   */
+  _realizeChildWindows(node) {
     for (const child of node.children) {
       if (child.isWindow) continue;
-      if (child.isGlArea) child.realize();
-      else this._realizeGlAreas(child);
+      if (child.isGlArea || child.isForeign) child.realize();
+      else this._realizeChildWindows(child);
     }
   }
 

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -1,7 +1,7 @@
 /**
- * The host elements. Only `<window>`, `<popup>` and `<glarea>` are real X11
- * windows; everything else is a retained node laid out by yoga and painted
- * into the owning window. See docs/elements.md.
+ * The host elements. Only `<window>`, `<popup>`, `<glarea>` and `<foreign>`
+ * are real X11 windows; everything else is a retained node laid out by yoga
+ * and painted into the owning window. See docs/elements.md.
  */
 
 import type { Ref, ReactNode, Key } from 'react';
@@ -584,6 +584,43 @@ export interface GlAreaProps extends DrawnProps<DrawnNode> {
   onPointerMissed?: (ev: MouseEvent<DrawnNode>) => void;
 }
 
+// --- embedding -------------------------------------------------------------
+
+/** What arrived, and how. `xembed: false` is a client that set no
+ * `_XEMBED_INFO` and got plain reparenting — the common case. */
+export interface EmbeddedInfo {
+  /** the client's X window id */
+  id: number;
+  /** whether the client speaks the XEmbed protocol */
+  xembed: boolean;
+  /** the protocol version in use, or 0 */
+  version: number;
+  node: DrawnNode;
+}
+
+export interface ForeignProps extends DrawnProps<DrawnNode> {
+  /**
+   * The X window to embed. Changing it hands the old client back before the
+   * new one is taken. Omit it to instead **adopt** whatever is put inside
+   * this node, which is what `xterm -into WID` and `mpv --wid=WID` need —
+   * `onReady` is where that id comes from.
+   */
+  windowId?: number;
+  /** The container window's id, offered as soon as it exists, so a program
+   * can be spawned into it. Fires before there is anything embedded. */
+  onReady?: (info: { windowId: number; node: DrawnNode }) => void;
+  /** A client is in. */
+  onEmbedded?: (info: EmbeddedInfo) => void;
+  /** Destroyed, or reparented away by someone else. */
+  onClientGone?: (info: { node: DrawnNode }) => void;
+  /** `XEMBED_REQUEST_FOCUS`: the client wants the focus. It is given through
+   * the focus manager unless a handler prevents it by focusing elsewhere. */
+  onRequestFocus?: (info: { node: DrawnNode }) => void;
+  /** The embed failed — no such window, or it went away mid-handshake.
+   * Without a handler the failure is a console warning. */
+  onError?: (err: Error) => void;
+}
+
 // --- 3D scene --------------------------------------------------------------
 
 export type Vec3 = [number, number, number];
@@ -857,6 +894,7 @@ export interface ReactX11Elements {
   svg: SvgProps;
   tex: TexProps;
   glarea: GlAreaProps;
+  foreign: ForeignProps;
 
   group: GroupProps;
   mesh: MeshProps;

--- a/test/element-props.test.js
+++ b/test/element-props.test.js
@@ -31,6 +31,7 @@ import {
 import { MarkdownNode, HtmlNode, SvgNode, TexNode } from '../src/richnodes.js';
 import { DefaultTheme } from '../src/palette.js';
 import { GlAreaNode } from '../src/glnodes.js';
+import { ForeignNode } from '../src/foreignnodes.js';
 import { isStyleProp } from '../src/styles.js';
 import { createMockApp } from './helpers/mock-app.js';
 
@@ -53,6 +54,7 @@ const BUILD = {
   svg: (app, props) => new SvgNode(props, app),
   tex: (app, props) => new TexNode(props, app),
   glarea: (app, props) => new GlAreaNode(props, app),
+  foreign: (app, props) => new ForeignNode(props, app),
 };
 
 // A spread of the style vocabulary: one from each family, plus every name an

--- a/test/foreign.test.js
+++ b/test/foreign.test.js
@@ -1,0 +1,740 @@
+// <foreign>: hosting another client's window.
+//
+// Two connections to node-x11's in-process X server — one renders the React
+// tree, the other plays the application being embedded — because every claim
+// worth making here is about a window we do not own. Whether it was
+// reparented, whether it is still alive after an unmount, where the server
+// thinks it is: a mock can only report the calls we chose to make, and the
+// bug this element is most able to cause is destroying somebody else's
+// window, which shows up as the window being *gone*, not as a call.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import React from 'react';
+import xserver from 'x11/lib/xserver/index.js';
+import { XEMBED, createClient, StaticFontSource } from 'ntk';
+
+import { createRoot } from '../src/index.js';
+import { act } from '../src/testing/index.js';
+
+const h = React.createElement;
+
+async function headlessPair() {
+  const server = xserver.createServer({ width: 640, height: 480 });
+  const connect = async (onXError) => {
+    const [serverEnd, clientEnd] = xserver.createStreamPair();
+    server.addClientStream(serverEnd);
+    return createClient({
+      stream: clientEnd,
+      fontSource: new StaticFontSource(),
+      onXError,
+    });
+  };
+  const xErrors = [];
+  return {
+    server,
+    xErrors,
+    app: await connect((err) => xErrors.push(err)),
+    other: await connect(() => {}),
+  };
+}
+
+const render = (element, x11Root) =>
+  new Promise((resolve) => x11Root.render(element, resolve));
+
+const settle = (app) =>
+  new Promise((resolve) => app.X.GetInputFocus(() => setImmediate(resolve)));
+
+/**
+ * Drain until `predicate` holds. Embedding is a chain of awaited replies, so
+ * a fixed number of settles is a guess — and layout lands on ntk's frame
+ * clock, which is a *timer* behind a server fence rather than a reply, so
+ * round trips alone can spin without ever letting a frame run.
+ */
+async function until(app, predicate, what) {
+  for (let i = 0; i < 200; i++) {
+    if (predicate()) return;
+    await settle(app);
+    await new Promise((resolve) => setTimeout(resolve, 1));
+  }
+  assert.fail(`timed out waiting for ${what}`);
+}
+
+const queryTree = (app, wid) =>
+  new Promise((resolve, reject) =>
+    app.X.QueryTree(wid, (err, tree) => (err ? reject(err) : resolve(tree))),
+  );
+
+const geometry = (app, wid) =>
+  new Promise((resolve, reject) =>
+    app.X.GetGeometry(wid, (err, g) => (err ? reject(err) : resolve(g))),
+  );
+
+/** Does the server still have this window? The whole point of the release
+ *  path — a client we handed back has to still exist. */
+const alive = (app, wid) =>
+  new Promise((resolve) => app.X.GetGeometry(wid, (err) => resolve(!err)));
+
+/** Unmount before closing: an app that drops its connection mid-frame
+ *  leaves work in flight, which surfaces as noise from the next test. */
+async function teardown(x11Root, app, other) {
+  await x11Root.unmount().catch(() => {});
+  await settle(app);
+  await app.close();
+  await other.close();
+}
+
+/** A window belonging to the *other* connection, ready to be embedded. */
+function foreignWindow(other, { xembed = false } = {}) {
+  const wnd = other.createWindow({ x: 0, y: 0, width: 100, height: 60 });
+  if (xembed) {
+    // `_XEMBED_INFO` is what tells the socket the client speaks the
+    // protocol; without it the socket reparents and maps, which is what
+    // xterm -into and mpv --wid get.
+    wnd.setProperty('_XEMBED_INFO', [XEMBED.VERSION, XEMBED.MAPPED], {
+      type: '_XEMBED_INFO',
+      format: 32,
+    });
+  }
+  return wnd;
+}
+
+/** The <foreign> node under a rendered window instance. */
+function foreignNode(instance) {
+  const walk = (node) => {
+    if (node.kind === 'foreign') return node;
+    for (const child of node.children ?? []) {
+      const found = walk(child);
+      if (found) return found;
+    }
+    return null;
+  };
+  const node = walk(instance._reactX11Node);
+  assert.ok(node, 'the tree has a <foreign> node');
+  return node;
+}
+
+test('<foreign> reparents the client into its own window, and never from render', async () => {
+  const { app, other, xErrors } = await headlessPair();
+  const x11Root = await createRoot({ app });
+  try {
+    const client = foreignWindow(other);
+    await settle(other);
+
+    const embedded = [];
+    const instance = await render(
+      h(
+        'window',
+        { width: 320, height: 240 },
+        h('box', { style: { padding: 20, flexGrow: 1 } }, [
+          h('foreign', {
+            key: 'f',
+            windowId: client.id,
+            style: { flexGrow: 1 },
+            onEmbedded: (info) => embedded.push(info),
+          }),
+        ]),
+      ),
+      x11Root,
+    );
+
+    const node = foreignNode(instance);
+    await until(app, () => embedded.length > 0, 'the client to be embedded');
+
+    // the client is a child of the socket's container window, which is a
+    // child of the <window> — one reparent, into the node's own window
+    const tree = await queryTree(app, node.socket.window.id);
+    assert.deepEqual(tree.children, [client.id]);
+
+    // yoga sized it: 320x240 window, 20px padding all round
+    const geo = await geometry(app, client.id);
+    assert.deepEqual(
+      { width: geo.width, height: geo.height },
+      { width: 280, height: 200 },
+    );
+    assert.deepEqual(node.rect, { x: 20, y: 20, width: 280, height: 200 });
+
+    // no `_XEMBED_INFO` on the client: the plain-reparent path, which is
+    // what almost everything embeddable actually wants
+    assert.deepEqual(embedded[0].id, client.id);
+    assert.equal(embedded[0].xembed, false);
+    assert.equal(xErrors.length, 0, xErrors.map((e) => e.message).join(', '));
+
+    await x11Root.unmount();
+    await settle(app);
+  } finally {
+    await teardown(x11Root, app, other);
+  }
+});
+
+test('a discarded render issues no X calls against the client', async () => {
+  const { app, other } = await headlessPair();
+  // mounting this tree throws on purpose; onUncaughtError is the channel for
+  // it, and keeps the default (which sets process.exitCode) out of the way
+  const x11Root = await createRoot({ app, onUncaughtError: () => {} });
+  try {
+    const client = foreignWindow(other);
+    await settle(other);
+    const before = (await queryTree(other, client.id)).parent;
+
+    // A component that throws after its <foreign> child has been created:
+    // React discards the whole render, so nothing it built may have touched
+    // the server. This is the case the commit-phase rule exists for — a
+    // ReparentWindow from a discarded render has moved the window for real.
+    const Boom = () => {
+      throw new Error('discarded');
+    };
+    // the request itself, not just its effect: a ReparentWindow that happened
+    // to be a no-op here would still be one issued from a discarded render
+    const reparents = [];
+    const realReparent = app.X.ReparentWindow.bind(app.X);
+    app.X.ReparentWindow = (...args) => {
+      reparents.push(args);
+      return realReparent(...args);
+    };
+    const failed = render(
+      h('window', { width: 320, height: 240 }, [
+        h('foreign', { key: 'f', windowId: client.id, style: { flexGrow: 1 } }),
+        h(Boom, { key: 'b' }),
+      ]),
+      x11Root,
+    ).then(
+      () => null,
+      (err) => err,
+    );
+    await failed;
+    await settle(app);
+    await settle(other);
+
+    assert.deepEqual(reparents, [], 'no ReparentWindow was issued at all');
+    assert.equal(
+      (await queryTree(other, client.id)).parent,
+      before,
+      'the client is still where it was',
+    );
+    assert.ok(await alive(other, client.id), 'and still exists');
+  } finally {
+    await teardown(x11Root, app, other);
+  }
+});
+
+test('unmount hands the client back to the root instead of destroying it', async () => {
+  const { app, other, xErrors } = await headlessPair();
+  const x11Root = await createRoot({ app });
+  try {
+    const client = foreignWindow(other);
+    await settle(other);
+    const root = other.display.screen[0].root;
+
+    const embedded = [];
+    await render(
+      h(
+        'window',
+        { width: 320, height: 240 },
+        h('foreign', {
+          windowId: client.id,
+          style: { flexGrow: 1 },
+          onEmbedded: (info) => embedded.push(info),
+        }),
+      ),
+      x11Root,
+    );
+    await until(app, () => embedded.length > 0, 'the client to be embedded');
+
+    await x11Root.unmount();
+    await settle(app);
+    await settle(other);
+
+    assert.ok(
+      await alive(other, client.id),
+      'the client survives the unmount — it is not ours to destroy',
+    );
+    assert.equal(
+      (await queryTree(other, client.id)).parent,
+      root,
+      'and is a top-level window again',
+    );
+    assert.equal(xErrors.length, 0, xErrors.map((e) => e.message).join(', '));
+  } finally {
+    await teardown(x11Root, app, other);
+  }
+});
+
+test('a layout change moves the client and tells it where it is', async () => {
+  const { app, other } = await headlessPair();
+  const x11Root = await createRoot({ app });
+  try {
+    const client = foreignWindow(other);
+    // the synthetic ConfigureNotify (ICCCM 4.1.5) is the only way a client
+    // inside somebody else's window learns its position on screen
+    const configures = [];
+    client.on('resize', (ev) => configures.push(ev));
+    await client.selectInput(1 << 17); // StructureNotify
+    await settle(other);
+
+    const embedded = [];
+    const tree = (padding) =>
+      h(
+        'window',
+        { width: 320, height: 240 },
+        h(
+          'box',
+          { style: { padding, flexGrow: 1 } },
+          h('foreign', {
+            windowId: client.id,
+            style: { flexGrow: 1 },
+            onEmbedded: (info) => embedded.push(info),
+          }),
+        ),
+      );
+
+    const instance = await render(tree(20), x11Root);
+    const node = foreignNode(instance);
+    await until(app, () => embedded.length > 0, 'the client to be embedded');
+    await until(
+      other,
+      () => configures.length > 0,
+      'the first ConfigureNotify',
+    );
+
+    await render(tree(40), x11Root);
+    await until(app, () => node.rect.x === 40, 'the layout change');
+    await settle(app);
+
+    const geo = await geometry(app, client.id);
+    assert.deepEqual(
+      { width: geo.width, height: geo.height },
+      { width: 240, height: 160 },
+    );
+
+    // Root-relative, which is the whole point: the client is a child of the
+    // container and its *real* ConfigureNotify puts it at 0,0 inside it, so
+    // an event carrying the position on screen can only be the synthetic
+    // one. The origin is asked for rather than assumed — nothing here says
+    // where a window manager would have put the toplevel.
+    const origin = node.root.window._screenOrigin ?? { x: 0, y: 0 };
+    const expected = {
+      x: origin.x + 40,
+      y: origin.y + 40,
+      width: 240,
+      height: 160,
+    };
+    await until(
+      other,
+      () =>
+        configures.some(
+          (c) =>
+            c.x === expected.x &&
+            c.y === expected.y &&
+            c.width === expected.width &&
+            c.height === expected.height,
+        ),
+      `a ConfigureNotify carrying ${JSON.stringify(expected)}; saw ${JSON.stringify(configures.map((c) => [c.x, c.y, c.width, c.height]))}`,
+    );
+  } finally {
+    await teardown(x11Root, app, other);
+  }
+});
+
+test('changing windowId releases the old client before embedding the new one', async () => {
+  const { app, other, xErrors } = await headlessPair();
+  const x11Root = await createRoot({ app });
+  try {
+    const first = foreignWindow(other);
+    const second = foreignWindow(other);
+    await settle(other);
+    const root = other.display.screen[0].root;
+
+    const embedded = [];
+    const tree = (windowId) =>
+      h(
+        'window',
+        { width: 320, height: 240 },
+        h('foreign', {
+          windowId,
+          style: { flexGrow: 1 },
+          onEmbedded: (info) => embedded.push(info),
+        }),
+      );
+
+    const instance = await render(tree(first.id), x11Root);
+    const node = foreignNode(instance);
+    await until(app, () => embedded.length > 0, 'the first client');
+
+    await render(tree(second.id), x11Root);
+    await until(app, () => embedded.length > 1, 'the second client');
+    await settle(other);
+
+    assert.deepEqual(
+      embedded.map((e) => e.id),
+      [first.id, second.id],
+    );
+    assert.equal(
+      (await queryTree(other, first.id)).parent,
+      root,
+      'the client that left is a top-level window again',
+    );
+    assert.deepEqual(
+      (await queryTree(app, node.socket.window.id)).children,
+      [second.id],
+      'and the socket holds exactly the new one',
+    );
+    assert.ok(await alive(other, first.id));
+    assert.equal(xErrors.length, 0, xErrors.map((e) => e.message).join(', '));
+
+    await x11Root.unmount();
+    await settle(app);
+  } finally {
+    await teardown(x11Root, app, other);
+  }
+});
+
+test('a client destroyed out from under us reports gone, once', async () => {
+  const { app, other, xErrors } = await headlessPair();
+  const x11Root = await createRoot({ app });
+  try {
+    const client = foreignWindow(other);
+    await settle(other);
+
+    const embedded = [];
+    const gone = [];
+    const instance = await render(
+      h(
+        'window',
+        { width: 320, height: 240 },
+        h('foreign', {
+          windowId: client.id,
+          style: { flexGrow: 1 },
+          onEmbedded: (info) => embedded.push(info),
+          onClientGone: () => gone.push(1),
+        }),
+      ),
+      x11Root,
+    );
+    const node = foreignNode(instance);
+    await until(app, () => embedded.length > 0, 'the client to be embedded');
+
+    client.destroy();
+    await until(app, () => gone.length > 0, 'the client to go');
+    await settle(app);
+    assert.equal(gone.length, 1);
+    assert.equal(node.client, null);
+
+    // and nothing further is issued against the dead id
+    await x11Root.unmount();
+    await settle(app);
+    assert.equal(xErrors.length, 0, xErrors.map((e) => e.message).join(', '));
+  } finally {
+    await teardown(x11Root, app, other);
+  }
+});
+
+test('an XEmbed client is told it was embedded, and follows XEMBED_MAPPED', async () => {
+  const { app, other } = await headlessPair();
+  const x11Root = await createRoot({ app });
+  try {
+    const client = foreignWindow(other, { xembed: true });
+    const messages = [];
+    client.on('message', (ev) => messages.push(ev));
+    await client.selectInput(1 << 17); // StructureNotify
+    await settle(other);
+    const xembedAtom = await client.atom('_XEMBED');
+
+    const embedded = [];
+    await render(
+      h(
+        'window',
+        { width: 320, height: 240 },
+        h('foreign', {
+          windowId: client.id,
+          style: { flexGrow: 1 },
+          onEmbedded: (info) => embedded.push(info),
+        }),
+      ),
+      x11Root,
+    );
+    await until(app, () => embedded.length > 0, 'the client to be embedded');
+    await until(other, () => messages.length > 0, 'XEMBED_EMBEDDED_NOTIFY');
+
+    assert.equal(embedded[0].xembed, true, 'the client speaks the protocol');
+    const notify = messages.find((m) => m.message_type === xembedAtom);
+    assert.ok(notify, '_XEMBED message received');
+    assert.equal(notify.data[1], XEMBED.EMBEDDED_NOTIFY);
+  } finally {
+    await teardown(x11Root, app, other);
+  }
+});
+
+test('focus: activation and focus-in go out in that order, and Tab carries its direction', async () => {
+  const { app, other } = await headlessPair();
+  const x11Root = await createRoot({ app });
+  try {
+    const client = foreignWindow(other, { xembed: true });
+    const messages = [];
+    client.on('message', (ev) => messages.push(ev));
+    await settle(other);
+    const xembedAtom = await client.atom('_XEMBED');
+    const opcodes = () =>
+      messages
+        .filter((m) => m.message_type === xembedAtom)
+        .map((m) => m.data[1]);
+
+    const embedded = [];
+    const instance = await render(
+      h('window', { width: 320, height: 240 }, [
+        h('box', { key: 't', focusable: true, style: { height: 10 } }),
+        h('foreign', {
+          key: 'f',
+          windowId: client.id,
+          style: { flexGrow: 1 },
+          onEmbedded: (info) => embedded.push(info),
+        }),
+      ]),
+      x11Root,
+    );
+    const node = foreignNode(instance);
+    await until(app, () => embedded.length > 0, 'the client to be embedded');
+    await until(
+      other,
+      () => opcodes().includes(XEMBED.EMBEDDED_NOTIFY),
+      'the notify',
+    );
+
+    // the window has to hold the X focus for a node's focus to be real
+    node.root.events.windowFocused = true;
+    node.focus();
+    await until(other, () => opcodes().includes(XEMBED.FOCUS_IN), 'FOCUS_IN');
+
+    const sent = opcodes();
+    assert.ok(
+      sent.indexOf(XEMBED.WINDOW_ACTIVATE) < sent.indexOf(XEMBED.FOCUS_IN),
+      `activate before focus-in, got ${sent.join(',')}`,
+    );
+    const focusIn = messages
+      .filter((m) => m.message_type === xembedAtom)
+      .find((m) => m.data[1] === XEMBED.FOCUS_IN);
+    assert.equal(
+      focusIn.data[2],
+      XEMBED.FOCUS_CURRENT,
+      'a focus() call does not disturb the client’s own focus',
+    );
+
+    // a back-Tab into the node asks it to focus its *last* widget
+    node.root.events.focus(null);
+    await settle(other);
+    node.root.events._cycleFocus(true);
+    await until(
+      other,
+      () =>
+        messages
+          .filter((m) => m.message_type === xembedAtom)
+          .some(
+            (m) =>
+              m.data[1] === XEMBED.FOCUS_IN && m.data[2] === XEMBED.FOCUS_LAST,
+          ),
+      'FOCUS_IN with detail LAST',
+    );
+    assert.equal(node.focused, true);
+  } finally {
+    await teardown(x11Root, app, other);
+  }
+});
+
+test('XEMBED_REQUEST_FOCUS goes through the focus manager; FOCUS_NEXT leaves through it', async () => {
+  const { app, other } = await headlessPair();
+  const x11Root = await createRoot({ app });
+  try {
+    const client = foreignWindow(other, { xembed: true });
+    await settle(other);
+
+    const embedded = [];
+    const requested = [];
+    const instance = await render(
+      h('window', { width: 320, height: 240 }, [
+        h('foreign', {
+          key: 'f',
+          windowId: client.id,
+          style: { flexGrow: 1 },
+          onEmbedded: (info) => embedded.push(info),
+          onRequestFocus: () => requested.push(1),
+        }),
+        h('box', { key: 't', focusable: true, style: { height: 10 } }),
+      ]),
+      x11Root,
+    );
+    const node = foreignNode(instance);
+    await until(app, () => embedded.length > 0, 'the client to be embedded');
+    node.root.events.windowFocused = true;
+
+    // The client talks back to the socket window, addressed to it in both
+    // senses — delivered there and *about* it, which is what the spec says
+    // and what the routing needs (events reach a window by the id in them).
+    const socket = other.createWindow({ id: node.socket.window.id });
+    await socket.sendClientMessage('_XEMBED', [
+      0,
+      XEMBED.REQUEST_FOCUS,
+      0,
+      0,
+      0,
+    ]);
+    await until(app, () => requested.length > 0, 'the focus request');
+    assert.equal(node.focused, true, 'the focus manager moved focus here');
+
+    // …and the client running off the end of its own tab chain continues
+    // into ours, rather than stopping at the socket
+    await socket.sendClientMessage('_XEMBED', [0, XEMBED.FOCUS_NEXT, 0, 0, 0]);
+    await until(app, () => !node.focused, 'focus to move on');
+    assert.equal(
+      node.root.events.focusManager.focused.kind,
+      'box',
+      'the next react-x11 focusable has it',
+    );
+  } finally {
+    await teardown(x11Root, app, other);
+  }
+});
+
+test('keys reach the app first and are forwarded only if it does not consume them', async () => {
+  const { app, other } = await headlessPair();
+  const x11Root = await createRoot({ app });
+  try {
+    const client = foreignWindow(other);
+    await settle(other);
+
+    const embedded = [];
+    const seen = [];
+    const instance = await render(
+      h(
+        'window',
+        {
+          width: 320,
+          height: 240,
+          // an application chord, bound above the pane the way a real one is
+          onKeyDown: (ev) => {
+            seen.push(ev.keysym);
+            if (ev.ctrlKey) ev.preventDefault();
+          },
+        },
+        h('foreign', {
+          windowId: client.id,
+          style: { flexGrow: 1 },
+          onEmbedded: (info) => embedded.push(info),
+        }),
+      ),
+      x11Root,
+    );
+    const node = foreignNode(instance);
+    await until(app, () => embedded.length > 0, 'the client to be embedded');
+    node.root.events.windowFocused = true;
+    node.focus();
+
+    const sends = [];
+    const realSendEvent = app.X.SendEvent.bind(app.X);
+    app.X.SendEvent = (destination, propagate, mask, ev, cb) => {
+      sends.push({ destination, ev });
+      return realSendEvent(destination, propagate, mask, ev, cb);
+    };
+
+    const key = (buttons) => ({
+      type: 2,
+      name: 'KeyPress',
+      seq: 1,
+      keycode: 38,
+      time: 100,
+      root: other.display.screen[0].root,
+      wid: node.root.window.id,
+      child: 0,
+      rootx: 5,
+      rooty: 5,
+      x: 5,
+      y: 5,
+      buttons,
+      sameScreen: 1,
+    });
+
+    node.root.window.emit('keydown', key(0));
+    await settle(app);
+    assert.equal(seen.length, 1, 'the app saw the key');
+    assert.equal(
+      sends.filter((s) => s.destination === client.id).length,
+      1,
+      'and it was forwarded, re-addressed to the client',
+    );
+    assert.equal(sends.at(-1).ev.wid, client.id);
+
+    // Ctrl held: the app consumed it, so nothing is forwarded. This is the
+    // rule that makes a chord bound by the application beat the client.
+    node.root.window.emit('keydown', key(4));
+    await settle(app);
+    assert.equal(seen.length, 2);
+    assert.equal(
+      sends.filter((s) => s.destination === client.id).length,
+      1,
+      'the consumed chord was not forwarded',
+    );
+  } finally {
+    await teardown(x11Root, app, other);
+  }
+});
+
+test('<foreign> adopts a window put inside it, and hands out the id to put it in', async () => {
+  const { app, other } = await headlessPair();
+  const x11Root = await createRoot({ app });
+  try {
+    const ready = [];
+    const embedded = [];
+    await render(
+      h(
+        'window',
+        { width: 320, height: 240 },
+        h('foreign', {
+          style: { flexGrow: 1 },
+          onReady: (info) => ready.push(info),
+          onEmbedded: (info) => embedded.push(info),
+        }),
+      ),
+      x11Root,
+    );
+    assert.equal(ready.length, 1, 'the container id is offered immediately');
+    await settle(app);
+
+    // what `xterm -into ID` does: create a window as a child of the id it
+    // was given, rather than a top-level someone reparents
+    const client = other.createWindow({
+      parent: { id: ready[0].windowId, app: other, X: other.X },
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+    });
+    await settle(other);
+    await until(app, () => embedded.length > 0, 'the adopted client');
+    assert.equal(embedded[0].id, client.id);
+    assert.equal(embedded[0].xembed, false);
+  } finally {
+    await teardown(x11Root, app, other);
+  }
+});
+
+test('<foreign> takes no children', async () => {
+  const { app, other } = await headlessPair();
+  const x11Root = await createRoot({ app, onUncaughtError: () => {} });
+  try {
+    // act() is what rethrows a mount error; a bare render() swallows it
+    const err = await act(() =>
+      x11Root.render(
+        h(
+          'window',
+          { width: 320, height: 240 },
+          h('foreign', { windowId: 1 }, h('box', {})),
+        ),
+      ),
+    ).then(
+      () => null,
+      (e) => e,
+    );
+    assert.match(String(err), /<foreign> takes no children/);
+  } finally {
+    await teardown(x11Root, app, other);
+  }
+});

--- a/test/foreign.test.js
+++ b/test/foreign.test.js
@@ -695,7 +695,9 @@ test('<foreign> adopts a window put inside it, and hands out the id to put it in
       ),
       x11Root,
     );
-    assert.equal(ready.length, 1, 'the container id is offered immediately');
+    // on a microtask, not inside the commit — a handler that sets state must
+    // not be setting it on a component React has not finished mounting
+    await until(app, () => ready.length === 1, 'the container id');
     await settle(app);
 
     // what `xterm -into ID` does: create a window as a child of the id it

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -415,6 +415,36 @@ function RawGl() {
   );
 }
 
+function Embedded({ id }: { id: number }) {
+  return (
+    <foreign
+      windowId={id}
+      style={{ flexGrow: 1, backgroundColor: '#101014' }}
+      focusable
+      onEmbedded={({ id: wid, xembed, version }) => {
+        const _id: number = wid;
+        const _mode: boolean = xembed;
+        const _v: number = version;
+      }}
+      onClientGone={() => {}}
+      onRequestFocus={() => {}}
+      onError={(err) => void err.message}
+    />
+  );
+}
+
+function Adopting() {
+  // no windowId: the container's id is what a program is spawned into
+  return (
+    <foreign
+      style={{ flexGrow: 1 }}
+      onReady={({ windowId }) => {
+        const _id: number = windowId;
+      }}
+    />
+  );
+}
+
 // --- components ------------------------------------------------------------
 
 function Themed() {


### PR DESCRIPTION
Closes #269 (phases 1–3).

`<foreign windowId={…}>` has been a row in `NEXT_STEPS.md` §4 and a sentence in `docs/extending.md` since they were written. This implements it over ntk 7.4.0's `XEmbedSocket` (sidorares/ntk#246), which is published, so nothing here is a draft.

```jsx
<foreign
  windowId={terminal.windowId}
  style={{ flexGrow: 1, backgroundColor: '#101014' }}
  onEmbedded={({ xembed }) => setMode(xembed ? 'xembed' : 'reparented')}
  onClientGone={() => respawn()}
/>
```

## What it is

A `drawn: false` node — the second one, after `<glarea>` — holding an `XEmbedSocket`, laid out by yoga and realized by the owning `WindowNode` in the commit phase. ntk owns the protocol; what is here is the part that has to be React-shaped, and that is three things.

**1. When the X calls happen.** `createInstance` does nothing: a `CreateWindow` from a discarded render leaks a server resource, and a `ReparentWindow` from one has moved another application's window for real. `_realizeGlAreas` became `_realizeChildWindows` and now covers both elements.

**2. Where the rect comes from.** Yoga, like any other child; every change is a `ConfigureWindow` plus the synthetic ICCCM 4.1.5 `ConfigureNotify` with root-relative coordinates.

**3. Whose focus it is.** See below.

Omitting `windowId` puts the node in **adopt** mode and `onReady` hands out the container id — which is what `xterm -into WID` and `mpv --wid=WID` need, since the program has to be *given* a window before it has one. Most embeddable clients set no `_XEMBED_INFO` and get plain reparenting; `onEmbedded({ xembed })` reports which happened, and the plain path is the ordinary case rather than a fallback.

## The window is not ours

Unmount reparents the client back to the root and drops it from the save set. **It is never destroyed.** That is the first test in the file, and it needed one non-obvious thing: the reparent is issued **synchronously**, because `WindowNode.destroySubtree` destroys its own X window in the same turn and `DestroyWindow` takes every inferior with it — so `XEmbedSocket.release()`'s round trip would release a window that had already died with the container it was in. The save set does not cover that; X processes it when a *connection* closes.

## Focus, and the chord rule

The classic embedder gives the X focus to an InputOnly **focus proxy** that forwards keys. This one deliberately does not, for two reasons that point the same way: a proxy inside our own toplevel reads as the toplevel losing focus (carets stop, `<window onBlur>` fires, and the element is told to blur the client it just focused), and a key that reaches a proxy has already gone past every handler in the React tree.

So the X focus stays on our window, forwarding happens in `defaultKeyDown`/`defaultKeyUp`, and the rule the issue asked for is mechanical rather than aspirational:

> While a `<foreign>` holds focus, the app's handlers see every key first. Anything they do not consume with `preventDefault()` is forwarded.

The rest is the ordinary focus manager: activate + focus-in in that order, `FIRST`/`LAST` for a Tab arriving forwards or backwards, `XEMBED_REQUEST_FOCUS` routed *through* the manager so `:focus`, `:focus-within`, the previous node's `onBlur` and the AT-SPI bridge all observe it, and `FOCUS_NEXT`/`PREV` continuing into our tab chain. The one case it cannot cover — X delivers a key to the deepest descendant under the pointer, so chords are lost while the pointer is *over* the client — is documented rather than papered over.

## Verified against a real display, not only headlessly

`test/foreign.test.js` runs two connections to node-x11's in-process server, one rendering and one playing the application being embedded, because every claim here is about a window we do not own. 12 tests, each mutation-checked.

But the in-process server sends no `ReparentNotify`, and running `examples/foreign.jsx` against XQuartz found something the headless suite could not: **a client parked at the root is offered to the window manager**, whose reparent into a frame arrives *after* a second `<foreign>` has taken it and undoes it. So the example no longer demonstrates a pane-to-pane handoff — it demonstrates letting go, which is the honest and more valuable claim — and the hazard is written down in `docs/embedding.md`. A test that asserted otherwise was deleted rather than kept: it could only ever have passed.

`xterm` embedded in a react-x11 pane, and the same terminal after Detach — still running, now a desktop window with a frame of its own:

<table><tr><td width="50%"><img src="https://github.com/user-attachments/assets/74dabeef-b8a8-4237-aef1-7ae24fb3056d" /><br><sub>embedded in the pane</sub></td><td width="50%"><img src="https://github.com/user-attachments/assets/2ad51600-ab02-4ac1-b33b-b50fe7cf70d7"/><br><sub>after Detach — same terminal, its own window</sub></td></tr></table>

## Also here

- `defaultKeyUp` joins the default-action vocabulary (nothing in core needs it; an element that answers a whole keystroke does).
- `EventManager.focus(node, reason, backwards)` carries the Tab direction to `defaultFocus({ reason, backwards })` — XEmbed is the only thing that has ever needed it.
- `foreign` → AT-SPI `ROLE_EMBEDDED`, which is that role's whole purpose.
- ntk bumped to `^7.4.0`, lockfile regenerated.
- `docs/embedding.md`, an `<foreign>` section in `docs/elements.md`, a second worked example in `docs/extending.md` (a child-window element whose resource belongs to someone else), types + type test, and the `NEXT_STEPS.md` row.

## Not in this PR

Phases 4 and 5 of #269, both named as later there and both left for follow-ups: `<TrayHost>` (the `_NET_SYSTEM_TRAY_S<screen>` manager selection — XEmbed's biggest surviving consumer, and what makes a react-x11 panel a real shell) and the plug side (`createRoot({ embedInto })`). `docs/embedding.md` ends by saying so.

Rendered by this branch at 4dcd756 against XQuartz, `npm run examples:foreign`.
