### PR TITLE
feat(events)!: the scroll is the distance the device measured — XI2 wheel deltas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,9 +111,11 @@ no override-redirect staging (issue #4).
   side a text property is on decides who has to react when it moves, so a
   new one goes in exactly one of them.
 - `src/events.js` — `EventManager`: ntk window events → synthetic events
-  (click synthesis, hover enter/leave diffing, wheel from X buttons 4-7,
-  focus/Tab). Three ancestor-chain diffs live here and share one shape —
-  `:hover`, `:active` over the press chain, and `:focus-within`.
+  (click synthesis, hover enter/leave diffing, the wheel — ntk's `wheel`
+  event, XI2 valuators where the server has them and buttons 4-7 where it
+  does not, converted from notches to pixels here (#273) — focus/Tab).
+  Three ancestor-chain diffs live here and share one shape — `:hover`,
+  `:active` over the press chain, and `:focus-within`.
 - `src/compose.js` — dead keys and the Compose key (#272): the sequence
   table and the state machine `EventManager` runs between an application's
   `onKeyDown` and the element's `defaultKeyDown`. The dead-key half is

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -721,9 +721,14 @@ while its own cells overflow it still reports something to scroll. Anything
 that clips its own children ends that measurement, since their overflow
 belongs to them.
 
-X sends buttons 6 and 7 for a horizontal wheel; **Shift + vertical wheel**
-scrolls sideways too, for mice and touchpads that have none. When both bars
+A device with a horizontal axis scrolls sideways with it; **Shift + vertical
+wheel** does too, for the mice and touchpads that have none. When both bars
 show, each stops short of the other's corner.
+
+The distance is the device's, not a constant: where the server has XI2 a
+touchpad's scroll arrives as the fraction of a notch it measured, so a pane
+moves by a few pixels rather than by 48 at a time. A wheel notch is still 48
+pixels, and so is an arrow key ([events.md](events.md#wheel)).
 
 `onViewport` fires from **layout**, not from scrolling, so it arrives for a
 list nobody has scrolled yet. That is what a virtualized list needs before

--- a/docs/events.md
+++ b/docs/events.md
@@ -40,18 +40,21 @@ unwound — the default action, your handlers and React's update all in one
 pass, never a half-updated frame followed by a second one.
 
 Discrete means everything ntk does not coalesce: `mouseDown`/`mouseUp`,
-`keyDown`/`keyUp`, the wheel, focus and blur, and the window manager's close
-request.
+`keyDown`/`keyUp`, focus and blur, and the window manager's close request.
 
-**Motion stays on the frame clock.** `mouseMove`, and the hover
+**Motion and the wheel stay on the frame clock.** `mouseMove`, and the hover
 enter/leave work it drives, are the opposite case — the pointer reports at
 device rate and only the newest position matters — so they coalesce to at
-most one repaint per frame, as before.
+most one repaint per frame. A scroll is the same case for a different reason:
+a touchpad reports one dozens of times a frame, and nobody can see those
+frames apart. What makes the wait free is that ntk coalesces a scroll by
+_adding it up_ rather than keeping the newest, so a frame's event carries the
+whole distance and the pacing costs a paint, never a pixel.
 
 Bursts of discrete input stay bounded by the same mechanism. While the
 server has not acknowledged the last frame, the response goes back to the
-paced path: spin a wheel and the first notch paints immediately while the
-rest fold into one catch-up frame. Update instantly, then catch up.
+paced path: click twice quickly and the first press paints immediately while
+the second folds into one catch-up frame. Update instantly, then catch up.
 
 This needs ntk 5.2.0 or newer, which publishes the `frameInFlight()` gate
 the decision is made with. On an older ntk everything still works; the
@@ -101,7 +104,7 @@ const root = await createRoot({
   preventDefault(), stopPropagation(),
   capturePointer(), releasePointer(),   // see Pointer capture below
   // mouse: button, detail (DOM-style click count: 2 = double, 3 = triple)
-  // wheel: deltaX, deltaY
+  // wheel: deltaX, deltaY (pixels), smooth
   // keyboard: keycode, keysym, codepoint, key, composing
   // composition: data
 }
@@ -125,19 +128,63 @@ onKeyDown={(ev) => {
 
 ## Handlers
 
-| handler                                                           | notes                                                                                      |
-| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
-| `onClick`                                                         | fires on the nearest common ancestor of press & release; `detail` counts multi-clicks      |
-| `onMouseDown` / `onMouseUp` / `onMouseMove`                       | move is coalesced to once per frame by ntk                                                 |
-| `onMouseEnter` / `onMouseLeave`                                   | do not propagate; synthesized by hover-path diffing                                        |
-| `onWheel`                                                         | X buttons 4–7; default action scrolls the nearest scroll container with somewhere to go    |
-| `onContextMenu`                                                   | right-click (button 3), after `onMouseDown`; default action opens the element's menu       |
-| `onKeyDown` / `onKeyUp`                                           | delivered to the focused node (or the window); Tab cycles focus unless the element took it |
-| `onCompositionStart` / `onCompositionUpdate` / `onCompositionEnd` | text still being typed — a dead key, a Compose sequence; see below                         |
-| `onFocus` / `onBlur`                                              | focus follows mousedown (nearest `focusable` ancestor) and Tab traversal                   |
-| `onDragEnter` / `onDragLeave`                                     | do not propagate; drag-path diffing, the same shape as the hover pair above                |
-| `onDragOver` / `onDrop`                                           | on a drop target; `onDrop` may be async — [drag-and-drop.md](drag-and-drop.md)             |
-| `onDragStart` / `onDrag` / `onDragEnd`                            | on a `draggable` node; the press is a click until it moves 4px                             |
+| handler                                                           | notes                                                                                                                   |
+| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `onClick`                                                         | fires on the nearest common ancestor of press & release; `detail` counts multi-clicks                                   |
+| `onMouseDown` / `onMouseUp` / `onMouseMove`                       | move is coalesced to once per frame by ntk                                                                              |
+| `onMouseEnter` / `onMouseLeave`                                   | do not propagate; synthesized by hover-path diffing                                                                     |
+| `onWheel`                                                         | pixels, from the device or from X buttons 4–7; default action scrolls the nearest scroll container with somewhere to go |
+| `onContextMenu`                                                   | right-click (button 3), after `onMouseDown`; default action opens the element's menu                                    |
+| `onKeyDown` / `onKeyUp`                                           | delivered to the focused node (or the window); Tab cycles focus unless the element took it                              |
+| `onCompositionStart` / `onCompositionUpdate` / `onCompositionEnd` | text still being typed — a dead key, a Compose sequence; see below                                                      |
+| `onFocus` / `onBlur`                                              | focus follows mousedown (nearest `focusable` ancestor) and Tab traversal                                                |
+| `onDragEnter` / `onDragLeave`                                     | do not propagate; drag-path diffing, the same shape as the hover pair above                                             |
+| `onDragOver` / `onDrop`                                           | on a drop target; `onDrop` may be async — [drag-and-drop.md](drag-and-drop.md)                                          |
+| `onDragStart` / `onDrag` / `onDragEnd`                            | on a `draggable` node; the press is a click until it moves 4px                                                          |
+
+## The wheel {#wheel}
+
+`ev.deltaX` / `ev.deltaY` are **pixels**, positive down and right, and one
+notch of a wheel is 48 of them — the step an arrow key takes, so the two
+input routes move a list by the same amount.
+
+Where the server has XI2, those pixels are the distance the device actually
+measured. The core protocol has no wheel at all: a scroll arrives as a click
+of button 4/5/6/7, and a click carries no magnitude, which is why every
+scroll used to be exactly one notch. XI2 carries the same gesture as the
+device's own _scroll valuators_, so a touchpad's two-finger scroll reports
+the fractions of a notch it really was, and `deltaY` is `14.5` rather than
+`48` twice a second.
+
+```jsx
+<box
+  style={{ overflow: 'scroll' }}
+  onWheel={(ev) => {
+    ev.deltaY; // pixels — fractional from a touchpad
+    ev.smooth; // whether the device can report a fraction at all
+  }}
+/>
+```
+
+`ev.smooth` says which kind of device this was, not whether this particular
+delta happened to be fractional: `true` means the valuators are flowing and
+the next event may be a third of a notch, `false` means the emulated button,
+which can only ever say one. It is the flag to branch on for anything that
+wants to animate a scroll — a whole notch is worth easing towards, a stream
+of measured pixels is not.
+
+**Nothing is opted into.** A `<window>` selects XI2 when it is created and
+falls back to the wheel buttons where the server has none, so a handler
+written against `deltaY` works on both and the difference is the value.
+`<window xi2={false}>` opts out. A `<popup>` is on the buttons deliberately —
+it holds a pointer grab, and a core grab delivers core events — so a scroll
+inside an open menu moves a notch at a time. Needs ntk >= 7.5.0.
+
+Shift turns a vertical scroll sideways for a device with only one axis (the
+convention every toolkit follows); a device that reports its own horizontal
+axis keeps what it reported. The default action is the scroll chain — see
+[extending.md](extending.md#scrolling-content-you-painted) for how anything
+joins it.
 
 ## Composition: dead keys and Compose {#composition}
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -463,6 +463,15 @@ Answer `canScroll` from the **extent, not the position**: a viewport already
 scrolled to its bottom should keep the rest of a flick rather than pass it
 to whatever is behind it.
 
+Both deltas are **whole pixels**, and stay whole however the scroll was
+measured. A touchpad on a server with XI2 reports fractions of a notch and
+`ev.deltaY` carries them ([events.md](events.md#wheel)), but the default
+action spends only the whole part and carries the rest to the next event —
+because a fractional scroll offset is one the server-side blit cannot shift,
+and a smooth gesture that repainted every frame would cost more than it
+looks. So an element joining the chain never has to think about sub-pixels,
+and a slow scroll still moves: a pixel at a time.
+
 #### The mixin, for everything else
 
 `canScroll` + `scrollBy` buys the wheel. `Scrollable(Node)` buys the rest —

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -190,7 +190,8 @@ await userEvent.type(input, 'héllo\n'); // \n is Return
 await userEvent.tab({ shift: true });
 await userEvent.key(XK_ESCAPE); // react-x11/keysyms
 await userEvent.key(XK_DEAD_ACUTE); // then type 'e' for é — events.md#composition
-await userEvent.wheel(list, { deltaY: 3 });
+await userEvent.wheel(list, { deltaY: 3 }); // three notches, as buttons 4-7
+await userEvent.wheel(list, { deltaY: 0.25, smooth: true }); // a touchpad
 await userEvent.clickOutside(); // dismisses a menu — see below
 ```
 
@@ -209,6 +210,13 @@ exercised rather than simulated. Deciding which window gets the keyboard is a
 window manager's job and there is no window manager, so `renderX11` plays the
 part with one `SetInputFocus` at mount — otherwise keys would go to whatever
 the pointer happened to be over, which is a rule nobody should have to learn.
+
+**A smooth scroll is the one exception**, and says so. Whole notches go
+through the server as the button presses X really uses, but a touchpad's
+fraction of a notch is XI2, and the in-process server has no XInput — there
+are no valuators to inject. `{ smooth: true }` therefore delivers the `wheel`
+event ntk would have derived from them, straight to the window. Everything
+above it is still the real path: the dispatch, the chain, the default action.
 
 **Typing works for text the layout does not have.** `userEvent.type(input,
 'héllo')` binds a spare keycode for `é` on both the server's keymap and the

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^7.4.0",
+        "ntk": "^7.5.0",
         "react-reconciler": "^0.33.0"
       },
       "devDependencies": {
@@ -4034,9 +4034,9 @@
       }
     },
     "node_modules/ntk": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-7.4.0.tgz",
-      "integrity": "sha512-P6FeT5ZzCwk332vB+CXFBKcn79Z1CGp+IBZA7zzvG05LkEvM+WG0EJTDYWMEJR8KKeW++Xsh27h4oxkc3ijauA==",
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-7.5.0.tgz",
+      "integrity": "sha512-R0GYBAQd/xYcVo5ng6uzNDfLPxIcF+U4+cCupY1f6ynF64IAW1KwBIucFClUNZJPc6ZIZekIhcEKQFr/gnQZZw==",
       "license": "MIT",
       "dependencies": {
         "bidi-js": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^7.4.0",
+    "ntk": "^7.5.0",
     "react-reconciler": "^0.33.0"
   },
   "optionalDependencies": {

--- a/src/events.js
+++ b/src/events.js
@@ -1,6 +1,6 @@
 // Synthetic event system: ntk window events → capture/target/bubble dispatch
 // over the drawn node tree, with hit testing, click synthesis, hover
-// enter/leave, wheel mapping (X buttons 4-7) and focus/Tab traversal.
+// enter/leave, the wheel and focus/Tab traversal.
 // Handlers always read from current props, so updates never go stale.
 import {
   runWithPriority,
@@ -16,7 +16,27 @@ import { hooks as a11yHooks, isFocusable } from './a11y.js';
 import { Composer, composeTableFor } from './compose.js';
 
 const XK_TAB = 0xff09;
-const WHEEL_BUTTONS = { 4: [0, -48], 5: [0, 48], 6: [-48, 0], 7: [48, 0] };
+// The core protocol has no wheel: it is a click of button 4/5 (vertical) or
+// 6/7 (horizontal). ntk derives its `wheel` event from those presses — or,
+// where the connection has XI2, from the scroll valuators that carry the real
+// distance — so the presses themselves are noise on the button path, the way
+// a wheel release always was.
+const WHEEL_BUTTONS = new Set([4, 5, 6, 7]);
+/**
+ * How far one notch of the wheel scrolls, in pixels.
+ *
+ * ntk reports a scroll in **notches**: a mouse wheel's click, or the fraction
+ * of one a touchpad measured, `increment` being what the device says makes a
+ * whole one. That is the only unit a device agrees on — how far a notch
+ * *travels* is a toolkit's decision, and this is ours. Everything downstream
+ * of the dispatch is in pixels (`canScroll`/`scrollBy` take them, so does
+ * every registered element that answers the wheel), so the conversion happens
+ * here, once, and `deltaX`/`deltaY` mean pixels wherever they are read.
+ *
+ * The same step an arrow key takes (`SCROLL_KEY_STEP`, nodes.js), so a notch
+ * and an arrow press move a list by the same amount.
+ */
+export const WHEEL_NOTCH_PX = 48;
 const RIGHT_BUTTON = 3;
 // X11 KeyButMask bit for Mod1 (Alt on virtually every layout), same bitmask
 // `shiftKey`/`ctrlKey` above already read `buttons` from.
@@ -103,9 +123,9 @@ export function setClickToComponentHandler(fn) {
  * Wrap an ntk event callback for a *discrete* event — one whose response is
  * a single visual state, so there is nothing a frame's wait could coalesce
  * it with. That is everything ntk does not coalesce: mousedown/mouseup,
- * keydown/keyup, the wheel (X delivers notches as button 4-7 presses),
- * focus/blur and WM messages. Motion, and the hover diffing it drives, are
- * the opposite case and stay on the paced frame.
+ * keydown/keyup, focus/blur and WM messages. Motion and the wheel are the
+ * opposite case and stay on the paced frame — the hover diffing motion
+ * drives, and a scroll whose distance ntk sums over the frame.
  *
  * The response is painted once the *whole* dispatch has unwound — default
  * actions, React's discrete-priority commit, and every invalidation the two
@@ -158,6 +178,10 @@ export class EventManager {
     // toolkit that believed it was unfocused would blink no caret at all.
     this.windowFocused = true;
     this._lastClick = { time: 0, x: 0, y: 0, detail: 0 };
+    // the sub-pixel part of a smooth scroll the default action has not spent
+    // yet — see `_onWheel`, which moves whole pixels so the scroll blit stays
+    // available
+    this._wheelOwed = { x: 0, y: 0 };
     // the window's DragSession while a press has armed it (src/dnd.js)
     this._dragArmed = null;
   }
@@ -218,6 +242,13 @@ export class EventManager {
       );
     onDiscrete('mousedown', (ev) => this._onMouseDown(ev));
     onDiscrete('mouseup', (ev) => this._onMouseUp(ev));
+    // ntk's own event, derived from the wheel buttons or from XI2's scroll
+    // valuators (ntk >= 7.5.0) — one shape whichever the connection turned
+    // out to have. Paced rather than discrete because ntk coalesces it, and
+    // it coalesces by *adding up*: a touchpad reports a scroll dozens of
+    // times a frame, and the frame's event carries the sum of them rather
+    // than the last one, so pacing costs distance nothing.
+    wnd.on('wheel', (ev) => this._onWheel(ev));
     wnd.on('mousemove', (ev) => this._onMouseMove(ev));
     wnd.on('mouseout', (ev) => this._onMouseOut(ev));
     onDiscrete('keydown', (ev) => this._onKey('KeyDown', ev));
@@ -330,60 +361,114 @@ export class EventManager {
     );
   }
 
+  /**
+   * Answer an input the grab brought in from outside the window with the
+   * dismissal it is, and say so. Both the press and the wheel end here: a
+   * menu is anchored to something, and scrolling that something away is as
+   * much "I am doing something else now" as clicking beside it.
+   */
+  _dismissOutside(native) {
+    if (!this._pressOutside(native)) return false;
+    runWithPriority(DiscreteEventPriority, () => {
+      const onDismiss = this.node.props.onDismiss;
+      if (onDismiss) {
+        callHandler(
+          this.node,
+          'onDismiss',
+          onDismiss,
+          this._makeEvent('dismiss', native, this.node),
+        );
+      }
+    });
+    return true;
+  }
+
+  /**
+   * A scroll: ntk's `wheel`, in notches, whatever measured it.
+   *
+   * On a connection with XI2 that is the scroll valuators of the device the
+   * user actually touched, so a touchpad's two-finger scroll arrives as the
+   * fractions of a notch it really was — and arrives at all, where the
+   * emulated button 4/5 it also sends could only ever say "one notch, again".
+   * Everywhere else it is that button, worth exactly one notch, which is the
+   * most a press can carry. Neither is named below: the difference is the
+   * value of `deltaY`, and `ev.smooth` for a handler that wants to know
+   * whether the device it is reading can do better than whole notches.
+   *
+   * Continuous priority, as in the DOM: a scroll is a stream of states on the
+   * way somewhere rather than one, and React must be free to interrupt the
+   * render it started for the notch before.
+   */
+  _onWheel(native) {
+    // A scroll somewhere else is an interaction somewhere else: the pointer
+    // grab an open menu holds brings it here, and the menu is anchored to
+    // content that is about to move out from under it. Same answer the press
+    // outside gets, and for the same reason (`_pressOutside`).
+    if (this._dismissOutside(native)) return;
+    runWithPriority(ContinuousEventPriority, () => {
+      const target = this._hit(native);
+      // Shift turns a vertical wheel sideways — the convention for the mouse
+      // and the touchpad that have no horizontal axis. Read off the delta
+      // rather than off the source: a plain wheel mouse on an XI2 connection
+      // reports through the valuators too, and it still has only one axis.
+      const sideways = Boolean(native.buttons & 1) && !native.deltaX;
+      const notchX = sideways ? native.deltaY : native.deltaX;
+      const notchY = sideways ? 0 : native.deltaY;
+      const ev = this.dispatch('Wheel', target, native, {
+        deltaX: notchX * WHEEL_NOTCH_PX,
+        deltaY: notchY * WHEEL_NOTCH_PX,
+        // whether the delta can be a fraction of a notch, not whether this
+        // one is: a touchpad that happens to have travelled exactly one
+        // notch this frame is still the device that can travel a third
+        smooth: Boolean(native.smooth),
+      });
+      if (ev.defaultPrevented) return;
+      // **The default action moves whole pixels and keeps the change.** A
+      // scroll offset that is not an integer costs the scroll blit — the
+      // server-side copy that makes a scroll cheap can only shift by whole
+      // pixels, so `_applyScrollBlits` (nodes.js) declines a fractional one
+      // and repaints the viewport instead. A touchpad reporting a third of a
+      // notch would therefore turn every frame of the smoothest gesture the
+      // renderer has into a full repaint, which is the opposite of the
+      // trade. The fraction is not dropped, it is carried to the next event,
+      // so a slow scroll still moves — it moves a pixel at a time.
+      const owedX = this._wheelOwed.x + ev.deltaX;
+      const owedY = this._wheelOwed.y + ev.deltaY;
+      const dx = Math.trunc(owedX);
+      const dy = Math.trunc(owedY);
+      this._wheelOwed = { x: owedX - dx, y: owedY - dy };
+      if (dx === 0 && dy === 0) return;
+      // The nearest node out from the target that says it has somewhere to
+      // go on this axis scrolls. Chaining past one that fits its own content
+      // is what a browser does, and it matters now that any `<box>` can be a
+      // scroll container — a pane that happens to fit must not swallow the
+      // wheel the window would have answered. The `<window>` is the last
+      // candidate, then the walk stops.
+      //
+      // Two methods and no kinds: `<textarea>` scrolls pixels it painted
+      // rather than children it laid out, and so does a registered
+      // element that draws its own content, and neither of them should
+      // have to be named here to be reachable (issue #253).
+      for (let n = target; n; n = n.parent) {
+        if (n.canScroll?.(dx, dy)) {
+          n.scrollBy({ x: dx, y: dy });
+          break;
+        }
+        if (n === this.node) break;
+      }
+    });
+  }
+
   _onMouseDown(native) {
+    // the wheel arrived as `wheel`, with a distance the press cannot carry
+    if (WHEEL_BUTTONS.has(native.keycode)) return;
     if (clickToComponentHandler && Boolean(native.buttons & MOD1_MASK)) {
       clickToComponentHandler(this._hit(native), native);
       return;
     }
-    if (this._pressOutside(native)) {
-      runWithPriority(DiscreteEventPriority, () => {
-        const onDismiss = this.node.props.onDismiss;
-        if (onDismiss) {
-          callHandler(
-            this.node,
-            'onDismiss',
-            onDismiss,
-            this._makeEvent('dismiss', native, this.node),
-          );
-        }
-      });
-      return;
-    }
+    if (this._dismissOutside(native)) return;
     runWithPriority(DiscreteEventPriority, () => {
-      const wheel = WHEEL_BUTTONS[native.keycode];
       const target = this._hit(native);
-      if (wheel) {
-        const shift = Boolean(native.buttons & 1);
-        // X sends buttons 6/7 for a horizontal wheel; Shift+vertical is the
-        // convention for mice and touchpads that have none
-        const [dx, dy] =
-          shift && wheel[0] === 0 ? [wheel[1], 0] : [wheel[0], wheel[1]];
-        const ev = this.dispatch('Wheel', target, native, {
-          deltaX: dx,
-          deltaY: dy,
-        });
-        if (!ev.defaultPrevented) {
-          // Default action: the nearest node out from the target that says it
-          // has somewhere to go on this axis scrolls. Chaining past one that
-          // fits its own content is what a browser does, and it matters now
-          // that any `<box>` can be a scroll container — a pane that happens
-          // to fit must not swallow the wheel the window would have answered.
-          // The `<window>` is the last candidate, then the walk stops.
-          //
-          // Two methods and no kinds: `<textarea>` scrolls pixels it painted
-          // rather than children it laid out, and so does a registered
-          // element that draws its own content, and neither of them should
-          // have to be named here to be reachable (issue #253).
-          for (let n = target; n; n = n.parent) {
-            if (n.canScroll?.(ev.deltaX, ev.deltaY)) {
-              n.scrollBy({ x: ev.deltaX, y: ev.deltaY });
-              break;
-            }
-            if (n === this.node) break;
-          }
-        }
-        return;
-      }
       this.downNode = target;
       this.downPath = target ? this._path(target) : [];
       // the caret is about to move, and the accent was aimed at where it was
@@ -431,7 +516,7 @@ export class EventManager {
   }
 
   _onMouseUp(native) {
-    if (WHEEL_BUTTONS[native.keycode]) return; // wheel release
+    if (WHEEL_BUTTONS.has(native.keycode)) return; // wheel release
     runWithPriority(DiscreteEventPriority, () => {
       // a completed drag ends the gesture: no mouseup, no click — as in
       // the DOM, where dragend replaces them

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -36,7 +36,7 @@ import {
   tint,
 } from './styles.js';
 import { cssColorStraight } from 'ntk';
-import { EventManager, discrete } from './events.js';
+import { EventManager, discrete, WHEEL_NOTCH_PX } from './events.js';
 import {
   DropSession,
   dndAtoms,
@@ -3956,9 +3956,10 @@ const XK_DELETE = 0xffff;
 const XK_ESCAPE = 0xff1b;
 const XK_SPACE = 0x0020;
 
-// An arrow key scrolls by a wheel notch — the same 48px `WHEEL_BUTTONS`
-// moves in events.js, so the two input routes agree about what one step is.
-const SCROLL_KEY_STEP = 48;
+// An arrow key scrolls by a wheel notch — literally the one events.js
+// converts a notch into, so the two input routes agree about what one step
+// is however far a notch turns out to be.
+const SCROLL_KEY_STEP = WHEEL_NOTCH_PX;
 // A page keeps a sliver of the previous one on screen, so the eye has
 // somewhere to land. Toolkits all keep a line or two; this is about that.
 const SCROLL_KEY_PAGE_OVERLAP = 24;
@@ -5968,6 +5969,20 @@ export class WindowNode extends Scrollable(Node) {
     // with 0 — transparent black — when the ARGB visual is really there.
     if (this.props.transparent)
       Object.assign(attributes, this._argbAttributes());
+    // **Smooth scrolling, where the server can.** XI2 carries a scroll as
+    // the device's own valuators, so a touchpad's two-finger scroll arrives
+    // as the fractions of a notch it was rather than as the whole clicks of
+    // button 4/5 the server emulates for clients that cannot read them. ntk
+    // translates the device events back into the core-shaped ones the rest
+    // of this file reads, and falls back to those buttons where there is no
+    // XI2, so this is the whole cost of it here (issue #273).
+    //
+    // Not on a `<popup>`, which is the window that holds a pointer grab: a
+    // core grab delivers core events, and ntk drops the emulated wheel
+    // buttons on a window whose valuators are flowing — a menu that had
+    // selected XI2 would be a menu the wheel could not reach while it was
+    // grabbing. Notch-at-a-time inside an open menu, smooth everywhere else.
+    attributes.xi2 ??= !this.isPopup;
     const wnd = this.app.createWindow(attributes);
     this.window = wnd;
     // Now that the visual is known: settle the capabilities, re-resolve any

--- a/src/testing/events.js
+++ b/src/testing/events.js
@@ -185,11 +185,39 @@ export const fireEvent = {
   },
 
   /**
-   * A wheel notch. X has no wheel: it is buttons 4/5 (vertical) and 6/7
-   * (horizontal), which is what the renderer maps back into deltas.
+   * A scroll, in **notches** — one click of a wheel, which the renderer
+   * turns into the 48 pixels a notch is worth. The core protocol has no
+   * wheel, so a whole notch is injected as the press of button 4/5
+   * (vertical) or 6/7 (horizontal) it really is.
+   *
+   * `{ smooth: true }` is a touchpad instead, and takes fractions:
+   * `fireEvent.wheel(list, { deltaY: 0.25, smooth: true })` is a quarter of
+   * a notch. That one does **not** go through the server — the in-process X
+   * server has no XInput extension, so there are no valuators to inject —
+   * and is delivered as the `wheel` event ntk would have derived from them.
+   * The only thing in this module that skips the server, and it skips it
+   * because nothing below the toolkit can express the gesture.
    */
-  wheel(node, { deltaY = 1, deltaX = 0, ...options } = {}) {
+  wheel(node, { deltaY = 1, deltaX = 0, smooth = false, ...options } = {}) {
     const { x, y, server } = screenPointOf(node, options);
+    if (smooth) {
+      const wnd = rootWindow(node).window;
+      const origin = wnd._screenOrigin ?? { x: wnd.x ?? 0, y: wnd.y ?? 0 };
+      wnd.emit('wheel', {
+        name: 'wheel',
+        x: x - origin.x,
+        y: y - origin.y,
+        rootx: x,
+        rooty: y,
+        buttons: maskOf(options.modifiers),
+        deltaX,
+        deltaY,
+        deltaMode: 'line',
+        smooth: true,
+        source: 'valuator',
+      });
+      return;
+    }
     server.injectPointerMove(x, y);
     const button = deltaX ? (deltaX > 0 ? 7 : 6) : deltaY > 0 ? 5 : 4;
     const notches = Math.max(1, Math.abs(deltaX || deltaY));

--- a/src/testing/index.d.ts
+++ b/src/testing/index.d.ts
@@ -395,9 +395,15 @@ export const fireEvent: {
   click(node: DrawnNode, options?: PointerOptions): void;
   doubleClick(node: DrawnNode, options?: PointerOptions): void;
   contextMenu(node: DrawnNode, options?: PointerOptions): void;
+  /** A scroll in notches; `smooth` takes fractions of one, as a touchpad
+   *  measures them. */
   wheel(
     node: DrawnNode,
-    options?: PointerOptions & { deltaX?: number; deltaY?: number },
+    options?: PointerOptions & {
+      deltaX?: number;
+      deltaY?: number;
+      smooth?: boolean;
+    },
   ): void;
   key(keysym: number, options?: KeyOptions): void;
   char(char: string, options?: KeyOptions): void;
@@ -414,9 +420,15 @@ export const userEvent: {
   doubleClick(node: DrawnNode, options?: PointerOptions): Promise<void>;
   hover(node: DrawnNode, options?: PointerOptions): Promise<void>;
   unhover(node: DrawnNode, options?: PointerOptions): Promise<void>;
+  /** A scroll in notches; `smooth` takes fractions of one, as a touchpad
+   *  measures them. */
   wheel(
     node: DrawnNode,
-    options?: PointerOptions & { deltaX?: number; deltaY?: number },
+    options?: PointerOptions & {
+      deltaX?: number;
+      deltaY?: number;
+      smooth?: boolean;
+    },
   ): Promise<void>;
   /** Click to focus, then send each character as a real key. */
   type(
@@ -528,4 +540,16 @@ export function pressButton(
   x: number,
   y: number,
   options?: { press?: boolean; release?: boolean },
+): void;
+/** A scroll at a point, in notches — ntk's `wheel` event. */
+export function spinWheel(
+  window: unknown,
+  x: number,
+  y: number,
+  options?: {
+    deltaX?: number;
+    deltaY?: number;
+    smooth?: boolean;
+    buttons?: number;
+  },
 ): void;

--- a/src/testing/index.js
+++ b/src/testing/index.js
@@ -54,7 +54,12 @@ export {
   toRgb,
   toPNG,
 } from './pixels.js';
-export { createMockApp, moveMouse, pressButton } from './mock-app.js';
+export {
+  createMockApp,
+  moveMouse,
+  pressButton,
+  spinWheel,
+} from './mock-app.js';
 export * from '../keysyms.js';
 
 /**

--- a/src/testing/mock-app.js
+++ b/src/testing/mock-app.js
@@ -388,3 +388,35 @@ export function pressButton(wnd, x, y, { press = true, release = true } = {}) {
   if (press) wnd.emit('mousedown', { x, y, keycode: 1 });
   if (release) wnd.emit('mouseup', { x, y, keycode: 1 });
 }
+
+/**
+ * A scroll at a point, in **notches** — ntk's `wheel` event, which is what
+ * the renderer reads whether the connection had XI2 or only the wheel
+ * buttons behind it.
+ *
+ * A notch is one click of a wheel, and a fraction of one is what a touchpad
+ * measures, so `{ deltaY: 0.25, smooth: true }` is a quarter of a notch from
+ * a device that can do that — the case the emulated buttons cannot express
+ * and a test of smooth scrolling is about. `buttons` takes the X modifier
+ * mask, for the Shift that turns a vertical wheel sideways.
+ */
+export function spinWheel(
+  wnd,
+  x,
+  y,
+  { deltaX = 0, deltaY = 1, smooth = false, buttons = 0 } = {},
+) {
+  wnd.emit('wheel', {
+    name: 'wheel',
+    x,
+    y,
+    rootx: x,
+    rooty: y,
+    buttons,
+    deltaX,
+    deltaY,
+    deltaMode: 'line',
+    smooth,
+    source: smooth ? 'valuator' : 'button',
+  });
+}

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -327,6 +327,19 @@ export interface WindowProps
    */
   transparent?: boolean;
   /**
+   * Read the pointer through XI2, which is what makes scrolling smooth: the
+   * device's own scroll valuators instead of the whole notches the server
+   * emulates as button 4/5 presses, so a touchpad reports the fractions of a
+   * notch it measured. On by default, and ignored where the server has no
+   * XI2 — the wheel buttons answer as they always did. `false` opts out.
+   *
+   * A `<popup>` is the exception and defaults to `false`: it holds a pointer
+   * grab, a core grab delivers core events, and a window whose valuators are
+   * flowing has its emulated wheel buttons dropped. Set at creation. Needs
+   * ntk >= 7.5.0.
+   */
+  xi2?: boolean;
+  /**
    * Mark this window as a drag preview: the drag router never treats it as
    * the window under the pointer, so a `<popup dragPreview>` can follow the
    * pointer without swallowing its own drag. See `useDragSource`.

--- a/src/types/events.d.ts
+++ b/src/types/events.d.ts
@@ -61,8 +61,16 @@ export interface MouseEvent<T = DrawnNode> extends SyntheticEvent<T> {
 }
 
 export interface WheelEvent<T = DrawnNode> extends SyntheticEvent<T> {
+  /** Pixels, positive right — one notch of the wheel is 48 of them. */
   deltaX: number;
+  /** Pixels, positive down. Fractions of a notch where `smooth`. */
   deltaY: number;
+  /**
+   * Whether the device measured this scroll rather than clicked it: XI2's
+   * scroll valuators (a touchpad, a high-resolution wheel) can report a
+   * fraction of a notch, the emulated buttons 4-7 can only ever say one.
+   */
+  smooth: boolean;
 }
 
 export interface KeyboardEvent<T = DrawnNode> extends SyntheticEvent<T> {

--- a/test/discrete-latency.test.js
+++ b/test/discrete-latency.test.js
@@ -18,7 +18,7 @@ import xserver from 'x11/lib/xserver/index.js';
 import { createClient } from 'ntk';
 
 import { createRoot } from '../src/index.js';
-import { createMockApp } from './helpers/mock-app.js';
+import { createMockApp, spinWheel } from './helpers/mock-app.js';
 import { hooks } from '../src/trace-registry.js';
 
 const h = React.createElement;
@@ -162,7 +162,7 @@ test('motion still coalesces to one paint per frame', async () => {
   await x11Root.unmount();
 });
 
-test('a wheel burst inside one round trip paints twice, not ten times', async () => {
+test('a wheel burst is one paint, and no notch is lost in it', async () => {
   const app = createMockApp();
   const x11Root = await createRoot({ app });
   x11Root.render(
@@ -183,23 +183,22 @@ test('a wheel burst inside one round trip paints twice, not ten times', async ()
   );
   await tick();
   const wnd = app.windows[0];
+  const box = wnd._reactX11Node.children[0];
   const passes = countPaints();
 
-  // Model the fence: the first paint of a frame sends one, and it stays
-  // unanswered for the rest of this turn. That is the gate that turns a
-  // burst into "paint the first notch, coalesce the rest".
-  wnd.frameInFlight = () => passes.length > 0;
+  // The wheel is the one input that is *not* on the discrete path, because
+  // it is the one ntk coalesces: a touchpad reports a scroll dozens of times
+  // a frame and nobody can see the difference between those frames. What
+  // makes that free is that the coalescing adds up — ntk hands over the sum
+  // of the frame's deltas — so the pacing costs a paint, never a distance.
+  // (A real connection delivers one summed event; ten arriving separately,
+  // as here, is the harder case and lands in the same place.)
+  for (let i = 0; i < 10; i++) spinWheel(wnd, 100, 100, { deltaY: 1 });
+  assert.strictEqual(passes.length, 0, 'no paint per notch');
 
-  // X delivers wheel notches as presses of buttons 4-7, and a spun wheel
-  // sends many per round trip
-  for (let i = 0; i < 10; i++) {
-    wnd.emit('mousedown', { x: 100, y: 100, keycode: 5 });
-  }
-  assert.strictEqual(passes.length, 1, 'the first notch painted immediately');
-
-  wnd.frameInFlight = () => false; // the server caught up
   await tick();
-  assert.strictEqual(passes.length, 2, 'the other nine caught up in one frame');
+  assert.strictEqual(passes.length, 1, 'the whole burst is one paint');
+  assert.strictEqual(box.scrollY, 480, 'and all ten notches are in it');
 
   await x11Root.unmount();
 });
@@ -305,9 +304,33 @@ async function xserverApp() {
 const roundTrip = (app) =>
   new Promise((resolve) => app.X.GetInputFocus(() => resolve()));
 
-// X ButtonPress, as it arrives on ntk's raw event stream — button 5 is a
-// wheel notch down
+// A core input event as it arrives on ntk's raw stream: ButtonPress is 4,
+// and buttons 4-7 are what a wheel is in the core protocol.
 const buttonPress = (keycode) => ({ type: 4, x: 100, y: 100, keycode });
+const buttonRelease = (keycode) => ({ type: 5, x: 100, y: 100, keycode });
+
+/** The scene both real-ntk tests use: a scroll pane taller than its window,
+ *  with a pressable at the top so a press has something to darken. */
+function scrollScene(x11Root, onWindow) {
+  x11Root.render(
+    h(
+      'window',
+      { width: 200, height: 200 },
+      h('box', PRESSABLE),
+      h(
+        'box',
+        { style: { overflow: 'scroll', flexGrow: 1 } },
+        ...Array.from({ length: 20 }, (_, i) =>
+          h('box', {
+            key: i,
+            style: { height: 40, flexShrink: 0, backgroundColor: '#eef1f5' },
+          }),
+        ),
+      ),
+    ),
+    onWindow,
+  );
+}
 
 test('real ntk: the press paints, and the present shuts the gate behind it', async (t) => {
   const { server, app } = await xserverApp();
@@ -320,25 +343,9 @@ test('real ntk: the press paints, and the present shuts the gate behind it', asy
   // the render callback hands back the root child's public instance, which
   // for a <window> is the live ntk window
   let wnd = null;
-  x11Root.render(
-    h(
-      'window',
-      { width: 200, height: 200 },
-      h(
-        'box',
-        { style: { overflow: 'scroll', flexGrow: 1 } },
-        ...Array.from({ length: 20 }, (_, i) =>
-          h('box', {
-            key: i,
-            style: { height: 40, flexShrink: 0, backgroundColor: '#eef1f5' },
-          }),
-        ),
-      ),
-    ),
-    (instance) => {
-      wnd = instance;
-    },
-  );
+  scrollScene(x11Root, (instance) => {
+    wnd = instance;
+  });
   await tick();
   await roundTrip(app);
   await tick();
@@ -353,9 +360,63 @@ test('real ntk: the press paints, and the present shuts the gate behind it', asy
   assert.strictEqual(wnd.frameInFlight(), false, 'the server is caught up');
 
   const passes = countPaints();
-  // ten notches of a spun wheel, all inside one round trip
-  for (let i = 0; i < 10; i++) wnd.emit('event', buttonPress(5));
+  // a press on the pressable, and the release that ends it — two discrete
+  // events, each with one visual answer of its own
+  wnd.emit('event', { type: 4, x: 10, y: 10, keycode: 1 });
 
+  assert.strictEqual(passes.length, 1, 'the press painted, from its handler');
+  assert.strictEqual(
+    wnd.frameInFlight(),
+    true,
+    'presenting it armed the fence, which is what paces what follows',
+  );
+
+  // The release's answer rides the paced frame, because the fence the press
+  // armed is still outstanding: update instantly, then catch up.
+  wnd.emit('event', { type: 5, x: 10, y: 10, keycode: 1 });
+  assert.strictEqual(passes.length, 1, 'the fence held the release');
+
+  const deadline = Date.now() + 2000;
+  while (passes.length < 2 && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  assert.strictEqual(passes.length, 2, 'one catch-up frame for the rest');
+
+  await x11Root.unmount();
+});
+
+test('real ntk: a spun wheel paints twice, not ten times, and loses no notch', async (t) => {
+  const { server, app } = await xserverApp();
+  const x11Root = await createRoot({ app });
+  t.after(async () => {
+    await app.close?.();
+    server.close?.();
+  });
+
+  let wnd = null;
+  scrollScene(x11Root, (instance) => {
+    wnd = instance;
+  });
+  await tick();
+  await roundTrip(app);
+  await tick();
+  await roundTrip(app);
+  const pane = wnd._reactX11Node.children[1];
+
+  const passes = countPaints();
+  // Ten notches of a spun wheel, all inside one round trip. This server has
+  // no XI2, so they arrive the way they always did — as presses of button 5,
+  // each with its release — and ntk turns them into its own `wheel`.
+  for (let i = 0; i < 10; i++) {
+    wnd.emit('event', buttonPress(5));
+    wnd.emit('event', buttonRelease(5));
+  }
+  // Still one paint for the first notch and not ten for the burst, though
+  // neither number is the wheel's doing any more: the press behind it is a
+  // discrete event, and the flush that ends *its* dispatch pays off the
+  // scroll the wheel just did. On a connection with XI2 there is no press —
+  // the wheel arrives inside ntk's frame, which paints before it ends, so
+  // the first notch is on screen just as fast by the other route.
   assert.strictEqual(passes.length, 1, 'the first notch painted, alone');
   assert.strictEqual(
     wnd.frameInFlight(),
@@ -363,14 +424,12 @@ test('real ntk: the press paints, and the present shuts the gate behind it', asy
     'presenting it armed the fence, which is what held the other nine',
   );
 
-  // The catch-up rides the paced frame, so it waits on the fence *and* the
-  // frame interval — which is exactly the point: the nine notches nobody
-  // needed to see individually cost one frame between them.
   const deadline = Date.now() + 2000;
   while (passes.length < 2 && Date.now() < deadline) {
     await new Promise((resolve) => setTimeout(resolve, 5));
   }
   assert.strictEqual(passes.length, 2, 'one catch-up frame for the rest');
+  assert.strictEqual(pane.scrollY, 480, 'and every notch is in the distance');
 
   await x11Root.unmount();
 });

--- a/test/helpers/mock-app.js
+++ b/test/helpers/mock-app.js
@@ -5,4 +5,5 @@ export {
   createMockApp,
   moveMouse,
   pressButton,
+  spinWheel,
 } from '../../src/testing/mock-app.js';

--- a/test/overflow-scroll.test.js
+++ b/test/overflow-scroll.test.js
@@ -11,7 +11,7 @@ import assert from 'node:assert';
 import React from 'react';
 import { createRoot } from '../src/index.js';
 import { a11yRole, ATSPI_ROLE } from '../src/a11y.js';
-import { createMockApp } from './helpers/mock-app.js';
+import { createMockApp, spinWheel } from './helpers/mock-app.js';
 
 const h = React.createElement;
 const tick = () => new Promise((resolve) => setImmediate(resolve));
@@ -36,9 +36,9 @@ const rows = (n = 10, height = 40) =>
     h('box', { key: i, style: { height, flexShrink: 0 } }),
   );
 
-// X delivers wheel notches as button presses: 4 up, 5 down, 6/7 horizontal.
-const wheel = (wnd, x, y, button = 5) =>
-  wnd.emit('mousedown', { x, y, keycode: button });
+// ntk delivers a scroll as `wheel`, in notches — positive down and right,
+// whether the connection measured it with XI2 or counted button 4-7 presses.
+const wheel = (wnd, x, y, delta) => spinWheel(wnd, x, y, delta);
 
 // --- the gate ---------------------------------------------------------------
 

--- a/test/scroll-protocol.test.js
+++ b/test/scroll-protocol.test.js
@@ -27,14 +27,14 @@ import { registerElement, unregisterElement } from '../src/host.js';
 import { Node, Scrollable } from '../src/node.js';
 import { a11yRole, ATSPI_ROLE } from '../src/a11y.js';
 import { XK_PAGE_DOWN } from '../src/keysyms.js';
-import { createMockApp } from './helpers/mock-app.js';
+import { createMockApp, spinWheel } from './helpers/mock-app.js';
 
 const h = React.createElement;
 const tick = () => new Promise((resolve) => setImmediate(resolve));
 
-// X delivers wheel notches as button presses: 4 up, 5 down, 6/7 horizontal.
-const wheel = (wnd, x, y, button = 5) =>
-  wnd.emit('mousedown', { x, y, keycode: button });
+// ntk delivers a scroll as `wheel`, in notches — positive down and right,
+// whether the connection measured it with XI2 or counted button 4-7 presses.
+const wheel = (wnd, x, y, delta) => spinWheel(wnd, x, y, delta);
 
 function pressKey(app, wnd, keysym) {
   const keycode = (keysym % 248) + 8;
@@ -262,7 +262,7 @@ test('a horizontal extent it reports is one the wheel can reach', async () => {
     }),
   );
   assert.equal(ref.current.canScroll(0, 1), false, 'nothing vertical');
-  wheel(wnd, 50, 50, 7); // X button 7 is a wheel-right
+  wheel(wnd, 50, 50, { deltaX: 1, deltaY: 0 }); // a notch to the right
   await tick();
   assert.ok(ref.current.scrollX > 0);
 });

--- a/test/scrollbar.test.js
+++ b/test/scrollbar.test.js
@@ -5,7 +5,7 @@ import { test } from 'node:test';
 import assert from 'node:assert';
 import React from 'react';
 import { createRoot } from '../src/index.js';
-import { createMockApp } from './helpers/mock-app.js';
+import { createMockApp, spinWheel } from './helpers/mock-app.js';
 
 const h = React.createElement;
 const tick = () => new Promise((resolve) => setImmediate(resolve));
@@ -315,14 +315,14 @@ test('the horizontal wheel scrolls sideways, and Shift+wheel does too', async ()
   await tick();
   const sv = scroller(app);
 
-  // X button 7 is a wheel-right
-  wnd.emit('mousedown', { x: 50, y: 50, keycode: 7 });
+  // a notch to the right — X button 7, or a horizontal scroll axis
+  spinWheel(wnd, 50, 50, { deltaX: 1, deltaY: 0 });
   await tick();
   assert.ok(sv.scrollX > 0, `wheel-right scrolled to ${sv.scrollX}`);
 
   const after = sv.scrollX;
   // Shift + wheel-down, for mice with no horizontal wheel (buttons bit 1)
-  wnd.emit('mousedown', { x: 50, y: 50, keycode: 5, buttons: 1 });
+  spinWheel(wnd, 50, 50, { deltaY: 1, buttons: 1 });
   await tick();
   assert.ok(sv.scrollX > after, 'Shift turned a vertical wheel sideways');
   assert.strictEqual(sv.scrollY, 0, 'and did not scroll down as well');

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -5,7 +5,7 @@ import { createRoot } from '../src/index.js';
 
 const tick = () => new Promise((resolve) => setImmediate(resolve));
 
-import { createMockApp } from './helpers/mock-app.js';
+import { createMockApp, spinWheel } from './helpers/mock-app.js';
 
 // Simulate an ntk keydown: registers the keysym for a synthetic keycode and
 // emits the raw event shape the EventManager consumes.
@@ -529,8 +529,8 @@ test('a scroll box scrolls, clamps and offsets hit testing', async () => {
   assert.strictEqual(sv.contentHeight, 180);
   assert.strictEqual(sv.children[1].abs.y, 60);
 
-  // wheel down (X button 5) scrolls by default
-  wnd.emit('mousedown', { x: 50, y: 50, keycode: 5 });
+  // a notch down scrolls by default
+  spinWheel(wnd, 50, 50, { deltaY: 1 });
   await tick();
   assert.strictEqual(sv.scrollY, 48);
   assert.strictEqual(sv.children[1].abs.y, 12);

--- a/test/smooth-scroll.test.js
+++ b/test/smooth-scroll.test.js
@@ -1,0 +1,273 @@
+// Issue #273: the scroll distance is the one the device measured.
+//
+// Every scroll used to be 48 pixels, because the only thing a core X client
+// can see of a wheel is a press of button 4/5/6/7 — and a press carries no
+// magnitude. ntk 7.5 reads the device's scroll valuators through XI2 where
+// the server has it and falls back to those buttons where it does not, and
+// reports either as a `wheel` event in notches. What is tested here is the
+// renderer's half: that a notch becomes pixels once, that a fraction of one
+// survives the trip, and that the emulated press behind a notch is not
+// counted a second time.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import { createRoot } from '../src/index.js';
+import { createMockApp, spinWheel } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+/** 20 rows of 40 in a 200-tall window: 800 of content, 600 to scroll. */
+const rows = (n = 20) =>
+  Array.from({ length: n }, (_, i) =>
+    h('box', { key: i, style: { height: 40, flexShrink: 0 } }),
+  );
+
+async function mount(children, windowProps = {}) {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(
+    h(
+      'window',
+      { width: 200, height: 200, ...windowProps },
+      h('box', { style: { overflow: 'scroll', flexGrow: 1 } }, ...children),
+    ),
+  );
+  await tick();
+  const wnd = app.windows[0];
+  wnd.flushFrame?.();
+  await tick();
+  return {
+    app,
+    wnd,
+    node: wnd._reactX11Node,
+    pane: wnd._reactX11Node.children[0],
+  };
+}
+
+// --- the distance -----------------------------------------------------------
+
+test('a whole notch is the step an arrow key takes', async () => {
+  const { wnd, pane } = await mount(rows());
+  spinWheel(wnd, 100, 100, { deltaY: 1 });
+  await tick();
+  assert.strictEqual(pane.scrollY, 48, 'one notch, one step');
+});
+
+test('a fraction of a notch scrolls a fraction of the step', async () => {
+  const { wnd, pane } = await mount(rows());
+  // what a touchpad measures: a quarter of the distance the device calls a
+  // notch. The emulated button behind it could only ever have said "one".
+  spinWheel(wnd, 100, 100, { deltaY: 0.25, smooth: true });
+  await tick();
+  assert.strictEqual(pane.scrollY, 12);
+});
+
+test('sub-notch deltas add up instead of rounding away', async () => {
+  const { wnd, pane } = await mount(rows());
+  for (let i = 0; i < 8; i++) {
+    spinWheel(wnd, 100, 100, { deltaY: 0.125, smooth: true });
+  }
+  await tick();
+  assert.strictEqual(pane.scrollY, 48, 'eight eighths are a notch');
+});
+
+test('the offset stays a whole number, and the fraction is not lost', async () => {
+  const { wnd, pane } = await mount(rows());
+  // 0.3 of a notch is 14.4 pixels: the scroll blit can only shift whole
+  // ones, so the offset takes 14 and the renderer owes 0.4 — three of them
+  // are 43.2 pixels asked for and 43 delivered, not 42.
+  for (let i = 0; i < 3; i++) {
+    spinWheel(wnd, 100, 100, { deltaY: 0.3, smooth: true });
+    await tick();
+    assert.ok(
+      Number.isInteger(pane.scrollY),
+      `offset ${pane.scrollY} is a whole pixel`,
+    );
+  }
+  assert.strictEqual(pane.scrollY, 43);
+});
+
+test('a scroll too small to move a pixel still moves one eventually', async () => {
+  const { wnd, pane } = await mount(rows());
+  // a fiftieth of a notch is under a pixel; ten of them are not
+  for (let i = 0; i < 9; i++) {
+    spinWheel(wnd, 100, 100, { deltaY: 0.02, smooth: true });
+  }
+  await tick();
+  assert.strictEqual(
+    pane.scrollY,
+    8,
+    'the change adds up rather than dropping',
+  );
+});
+
+test('a scroll up is negative, and clamps at the top like any other', async () => {
+  const { wnd, pane } = await mount(rows());
+  spinWheel(wnd, 100, 100, { deltaY: 4 });
+  await tick();
+  assert.strictEqual(pane.scrollY, 192);
+
+  spinWheel(wnd, 100, 100, { deltaY: -1.5, smooth: true });
+  await tick();
+  assert.strictEqual(pane.scrollY, 120, 'a notch and a half back up');
+});
+
+// --- what the handler sees --------------------------------------------------
+
+test('deltas reach a handler in pixels, with the device behind them named', async () => {
+  const seen = [];
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(
+    h(
+      'window',
+      { width: 200, height: 200, onWheel: (ev) => seen.push(ev) },
+      h('box', { style: { overflow: 'scroll', flexGrow: 1 } }, ...rows()),
+    ),
+  );
+  await tick();
+  const wnd = app.windows[0];
+
+  spinWheel(wnd, 100, 100, { deltaY: 0.5, smooth: true });
+  spinWheel(wnd, 100, 100, { deltaY: 1 });
+  await tick();
+
+  assert.strictEqual(seen.length, 2);
+  assert.strictEqual(seen[0].deltaY, 24, 'half a notch of 48');
+  assert.strictEqual(seen[0].deltaX, 0);
+  assert.strictEqual(
+    seen[0].smooth,
+    true,
+    'a device that can measure a fraction says so',
+  );
+  assert.strictEqual(seen[1].deltaY, 48);
+  assert.strictEqual(
+    seen[1].smooth,
+    false,
+    'and the emulated button admits it cannot',
+  );
+
+  await x11Root.unmount();
+});
+
+test('preventDefault still stops the scroll it would have done', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(
+    h(
+      'window',
+      { width: 200, height: 200, onWheel: (ev) => ev.preventDefault() },
+      h('box', { style: { overflow: 'scroll', flexGrow: 1 } }, ...rows()),
+    ),
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const pane = wnd._reactX11Node.children[0];
+
+  spinWheel(wnd, 100, 100, { deltaY: 0.75, smooth: true });
+  await tick();
+  assert.strictEqual(pane.scrollY, 0);
+
+  await x11Root.unmount();
+});
+
+// --- the press behind the notch ---------------------------------------------
+
+test('the emulated wheel button scrolls nothing on its own', async () => {
+  const presses = [];
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(
+    h(
+      'window',
+      { width: 200, height: 200, onMouseDown: (ev) => presses.push(ev) },
+      h('box', { style: { overflow: 'scroll', flexGrow: 1 } }, ...rows()),
+    ),
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const pane = wnd._reactX11Node.children[0];
+
+  // A core connection sends both halves of the same notch: ntk's `wheel`,
+  // and the button press it was derived from. Counting the press too would
+  // scroll twice as far as the user asked for.
+  spinWheel(wnd, 100, 100, { deltaY: 1 });
+  for (const keycode of [4, 5, 6, 7]) {
+    wnd.emit('mousedown', { x: 100, y: 100, keycode });
+    wnd.emit('mouseup', { x: 100, y: 100, keycode });
+  }
+  await tick();
+
+  assert.strictEqual(pane.scrollY, 48, 'the notch, once');
+  assert.deepStrictEqual(presses, [], 'and no mouseDown for a wheel button');
+
+  await x11Root.unmount();
+});
+
+// --- the axis ---------------------------------------------------------------
+
+test('Shift turns a one-axis wheel sideways, whatever measured it', async () => {
+  const { wnd, pane } = await mount(
+    [
+      h('box', {
+        key: 'wide',
+        style: { width: 800, height: 40, flexShrink: 0 },
+      }),
+    ],
+    {},
+  );
+  // buttons bit 0 is Shift in the X modifier mask
+  spinWheel(wnd, 100, 100, { deltaY: 1, buttons: 1 });
+  await tick();
+  assert.strictEqual(pane.scrollX, 48, 'the vertical notch went sideways');
+  assert.strictEqual(pane.scrollY, 0);
+
+  // …and a touchpad, which has an axis of its own, keeps the one it reported
+  spinWheel(wnd, 100, 100, {
+    deltaX: 0.5,
+    deltaY: 0.25,
+    smooth: true,
+    buttons: 1,
+  });
+  await tick();
+  assert.strictEqual(pane.scrollX, 72, 'half a notch right, as reported');
+});
+
+// --- selecting it -----------------------------------------------------------
+
+test('a window asks for XI2; a popup, which grabs, does not', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(
+    h(
+      'window',
+      { width: 200, height: 200 },
+      h('popup', { width: 80, height: 40, x: 10, y: 10 }),
+    ),
+  );
+  await tick();
+
+  const [window, popup] = app.windows;
+  assert.strictEqual(
+    window.attributes.xi2,
+    true,
+    'the window scrolls smoothly',
+  );
+  assert.strictEqual(
+    popup.attributes.xi2,
+    false,
+    'a grabbing menu stays on the wheel buttons the grab delivers',
+  );
+
+  await x11Root.unmount();
+});
+
+test('a window can turn it down', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(h('window', { width: 200, height: 200, xi2: false }));
+  await tick();
+  assert.strictEqual(app.windows[0].attributes.xi2, false);
+  await x11Root.unmount();
+});

--- a/test/test-entry.test.js
+++ b/test/test-entry.test.js
@@ -467,3 +467,34 @@ test('a drag and drop gesture is drivable through the published surface', async 
   );
   assert.deepStrictEqual(log.at(-1), ['end', 'copy', true]);
 });
+
+test('the wheel is drivable both ways: notches, and a touchpad', async () => {
+  const deltas = [];
+  const { windowNode } = await renderX11(
+    h(
+      'box',
+      {
+        style: { overflow: 'scroll', flexGrow: 1 },
+        onWheel: (ev) => deltas.push([ev.deltaY, ev.smooth]),
+      },
+      ...Array.from({ length: 20 }, (_, i) =>
+        h('box', { key: i, style: { height: 40, flexShrink: 0 } }),
+      ),
+    ),
+    { fonts, width: 200, height: 200 },
+  );
+  const pane = windowNode.children[0];
+
+  // whole notches go through the server as the button presses X has
+  await userEvent.wheel(pane, { deltaY: 2 });
+  assert.deepStrictEqual(deltas, [
+    [48, false],
+    [48, false],
+  ]);
+  assert.strictEqual(pane.scrollY, 96);
+
+  // and a touchpad reports a fraction of one, which no button could
+  await userEvent.wheel(pane, { deltaY: 0.5, smooth: true });
+  assert.deepStrictEqual(deltas.at(-1), [24, true]);
+  assert.strictEqual(pane.scrollY, 120);
+});


### PR DESCRIPTION
Closes #273.

Every scroll in a react-x11 app was 48 pixels. The core protocol has no
wheel — a scroll is a click of button 4, 5, 6 or 7, and a click carries no
magnitude — so the renderer turned each press into a fixed step. A
touchpad's two-finger scroll reached the server as valuators and was thrown
away, because we read only the emulated clicks the server sends alongside
them for clients that cannot.

ntk 7.5.0 reads them (sidorares/ntk#250): it selects XI2 per window, keeps
the per-device scroll-axis bookkeeping a valuator delta needs, drops the
emulated press once the valuators are flowing, and reports either source as
one `wheel` event in notches. This is the renderer's half.

![smooth-scroll](https://github.com/user-attachments/assets/7a9d4a65-fd46-4dea-8c4d-ba63da03259c)

The same list, the same code, the same event — the left pane scrolled by the
smallest gesture the wheel buttons can express, the right by the smallest a
touchpad can. Rendered by this branch, headless, through the published
`fireEvent.wheel`.

## What changed

- **The wheel comes off ntk's `wheel` event** instead of `mousedown` on
  buttons 4-7, which are now ignored the way a wheel release always was.
  Counting both would scroll twice as far as the user asked for.
- **Notches become pixels in one place.** `WHEEL_NOTCH_PX` is 48, which is
  also `SCROLL_KEY_STEP`, so a notch and an arrow key move a list by the
  same amount — and `deltaX`/`deltaY` mean pixels wherever they are read.
  `canScroll`/`scrollBy` and every element that answered the wheel before
  are unchanged.
- **`ev.smooth`** says whether the device behind this delta can report a
  fraction of a notch at all, rather than whether this one happened to be
  fractional. That is the flag to branch on for anything that wants to
  animate a scroll: a notch is worth easing towards, a stream of measured
  pixels is not.
- **A `<window>` selects XI2 at creation**, and falls back where the server
  has none, so nothing is opted into. `xi2={false}` opts out.
- **A `<popup>` does not**, deliberately. It holds a pointer grab; a core
  grab delivers core events; and ntk drops the emulated wheel buttons on a
  window whose valuators are flowing. A menu that had selected XI2 would be
  a menu the wheel could not reach while it was grabbing. Notch-at-a-time
  inside an open menu, smooth everywhere else.

## Two decisions worth the review

**Pixels, not a `deltaMode`.** The issue proposed the DOM's pair — pixels
from XI2, lines from the buttons, and a mode field to tell them apart. ntk
landed on one unit for both, notches, because a notch is what the device
itself defines and how far it travels is the toolkit's call. So the mode has
nothing to select: the conversion happens once in the dispatcher and
everything downstream stays in the pixels it was already written for. A
delta that means one thing in one place and another somewhere else is the
thing worth avoiding here, not the missing field.

**Whole pixels down the chain, with the fraction carried.** A scroll offset
that is not an integer is one `_applyScrollBlits` declines — the server-side
copy that makes a scroll cheap can only shift by whole pixels. Letting
sub-pixels through would have turned the smoothest gesture the renderer has
into a full viewport repaint per frame, which is the opposite of the trade.
The default action therefore spends the whole part and owes the rest to the
next event, so a slow scroll still moves: a pixel at a time. An element
joining the chain never sees a fraction; a handler reading `ev.deltaY` still
sees the true value.

**The wheel left the discrete path**, because it is now something ntk
coalesces — and coalesces by adding up, so a frame's event carries the whole
distance and the pacing costs a paint, never a pixel. The first notch is on
screen just as fast either way: on a core connection the press behind it is
still discrete and its flush pays off the scroll; on an XI2 one the event
arrives inside the frame that paints it. `test/discrete-latency.test.js`
pins both, the second against a real ntk over an in-process server.

## Tests

- `test/smooth-scroll.test.js` — the new file: a notch is a step, a quarter
  of one is a quarter of a step, eighths add up, the offset stays whole
  while the fraction is not lost, a scroll under a pixel still eventually
  moves one, the emulated press scrolls nothing on its own, Shift turns a
  one-axis device sideways and leaves a two-axis one alone, and who selects
  XI2.
- `test/test-entry.test.js` — the same gesture through the published test
  surface, both ways.
- `test/discrete-latency.test.js` — a burst is one paint and loses no notch,
  on the mock and against real ntk.
- The suites that drove the wheel by emitting button presses now emit the
  `wheel` event ntk delivers, through a shared `spinWheel` helper.

Full suite green apart from six pre-existing `test/appearance.test.js`
failures on master, which need a session bus. Lint, typecheck and the docs
site build are clean.

## Checked against a real server

XQuartz, through this branch: XI2 negotiates, the pointer's scroll classes
are found (`increment: -1`, an inverted axis, which ntk divides through),
and motion arrives translated — `nativeEvent.xi2` true, window coordinates
the dispatch hit-tests correctly. XQuartz advertises no XTEST, so the notch
itself cannot be injected there; the button path is covered end to end
against node-x11's in-process server instead.

