### PR TITLE
feat(popups)!: a popup at the caret, sized by its own rows — anchor and at

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,10 +62,20 @@ no override-redirect staging (issue #4).
   function, `draw(ctx, x, y)` paints, `onInvalidate` (ntk ≥ 3.4.0)
   reflows on async content (HtmlView images and SVGs; MarkdownView is
   synchronous).
+- `src/anchor.js` — where a `<popup>` goes: `anchorRect` and the screen
+  area it flips and clamps against. Core rather than widget code because
+  **both** callers need it and only one is a widget — a `<popup anchor>`
+  with an `'auto'` size learns how big it is inside `realize()`, after the
+  content is measured and before `CreateWindow`, which is past the last
+  moment React could have handed it a position (issue #255). So the window
+  places itself from the same functions the widgets call, and the two agree
+  by construction. `at` anchors to a rect _inside_ a node — a caret — and
+  is node-relative so that everything which moves the node keeps it true.
 - `src/components/` — the widget set, plain React over the host
   primitives (no reconciler support needed). One module per widget, with
   the shared plumbing in `theme.js` (palette, `useTheme`, `useControl`),
-  `anchor.js` (popup placement + label measurement), `typeahead.js` and
+  `anchor.js` (the React half of the above: `useAnchor`,
+  `useAnchorTracking`, label measurement), `typeahead.js` and
   `keys.js`. `index.js` re-exports the public names.
 - `src/menuitem.js`, `src/dbusmenu.js`, `src/globalmenu.js` — the global
   menu (#112). `menuitem.js` is the item vocabulary, which is

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -1185,13 +1185,10 @@ Shipping both without distinguishing them double-scales everything.
   `src/components/anchor.js` already does, with a comment explaining why.
   Anchoring, drag-and-drop, accessibility and IME candidate placement all
   want this.
-- **`AnchorOptions` is wrong in four places** (#120). It declares
-  `{ placement, gap, width, height, flip }`; `anchor.js` destructures
-  `{ placement, align, offset, width, height }`. `gap` and `flip` are
-  inert, `align` is undeclared, and `anchorRect()` returns `null` for a
-  node with no `.abs` while the type says `Rect`. Fix the implementation
-  where the declaration is right and the declaration where the
-  implementation is right.
+- **`AnchorOptions` is wrong in four places** (#120) — DONE (#255): the
+  declaration was the wrong one. `gap` and `flip` never existed; the options
+  are the ones `anchorRect` actually destructures, `at` among them, and the
+  return type says `null` for a node with no `.abs`, which is what it does.
 - **`<window onResize|onExpose|onCloseRequest>` forward the raw ntk event**
   while the types declare `SyntheticEvent<NtkWindow>`. Wrap them, since
   every other handler in the system receives a synthetic event.

--- a/docs/components.md
+++ b/docs/components.md
@@ -1483,6 +1483,7 @@ const rect = measure({ placement: 'bottom', align: 'center', width, height });
 | `placement`       | `'bottom'` (default), `'top'`, `'start'`, `'end'`, `'left'`, `'right'` |
 | `align`           | `'start'` (default), `'center'`, `'end'` on the cross axis             |
 | `offset`          | gap from the anchor in px (default 2)                                  |
+| `at`              | a rect **inside** the node to anchor to instead — a caret, a cell      |
 | `width`, `height` | size of the popup you are positioning                                  |
 | `alignTo`         | node the alignment reads, when it is not the anchor                    |
 
@@ -1506,6 +1507,52 @@ from the anchor, the alignment from `alignTo`. A submenu is the case that
 needs it — it belongs against the outer edge of the menu it comes out of,
 but level with the row that opened it, and that row is inset by the menu's
 border and padding. Both nodes have to be in the same window.
+
+### `at` — anchoring to part of a node
+
+`at` is a rect in the **anchor node's own coordinates**, and it becomes the
+anchor: the side that flips, the edge that aligns, the gap `offset` leaves,
+the rect tracking keeps in view. A caret is the case it exists for — a
+moving point inside one element — and a table cell, a chart datapoint or a
+highlighted span are the same shape.
+
+```jsx
+const measure = useAnchor(editorRef);
+const rect = measure({
+  at: { x: caretX, y: lineTop, width: 1, height: lineHeight },
+  placement: 'bottom',
+  width: 240,
+  height: rows * 22,
+});
+```
+
+`width` and `height` are optional (`{x, y}` alone is a point), and `width`
+on the popup then defaults to the sub-rect's rather than the node's.
+
+Node-relative rather than screen-relative on purpose: the offset stays true
+through everything that moves the node, so `useAnchorTracking` follows a
+caret with no extra work — and its out-of-view test becomes the caret's,
+which is what you want, since an editor's own lines scroll away long before
+the editor does.
+
+**A popup that has to measure itself first anchors from the other side.**
+Rows sized to their labels, a menu as wide as its widest item: the size is
+not known until the popup's content is laid out, and by then React has
+already rendered. `<popup anchor={{ to: ref, at }}>` hands the placement to
+the popup, which does it in the one place the size is known —
+[elements.md](elements.md#anchor--a-popup-that-places-itself).
+
+### `anchorArea(node)`
+
+The rect a popup anchored to `node` may be placed in: the usable part of the
+monitor that node is on — per-monitor, `_NET_WORKAREA` taken off it, the
+same answer [`<window width="auto">`](elements.md#natural-size) is capped
+by. `null` where there is no display to ask.
+
+What needs it is a surface sizing itself: a menu measured to its longest
+label is never usefully wider than the screen it opens on, and `anchorRect`
+can slide a popup back from an edge but nothing rescues one that does not
+fit. `Select` and `ContextMenu` both cap themselves this way.
 
 ## `useDropTarget(options)` / `useDragSource(options)`
 

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -563,18 +563,97 @@ An override-redirect top-level window at **screen coordinates** — the
 window manager ignores it (no decorations, no focus stealing): menus,
 tooltips, dropdowns. May appear anywhere in the JSX tree (its position in
 the tree does not affect its position on screen); it is its own paint and
-event root. Anchor with `ev.nativeEvent.rootx/rooty` (pointer in screen
-coordinates) or a ref's `abs` rect plus the owner window's `x`/`y`.
-Same props as `<window>`; conditional rendering controls its lifetime.
+event root. Give it an `anchor` and it places itself against a node
+([below](#anchor--a-popup-that-places-itself)); `x`/`y` are there for the
+placements that are nobody's node — `ev.nativeEvent.rootx/rooty`, the
+pointer in screen coordinates. Same props as `<window>` — **including
+[natural size](#natural-size)**, which is what a menu sized by its own rows
+is — and conditional rendering controls its lifetime.
 
 | prop               |                                                                                                                |
 | ------------------ | -------------------------------------------------------------------------------------------------------------- |
+| `anchor`           | place against a node, or a rect inside one, at whatever size the content turns out to be (below)               |
 | `grab`             | hold a pointer grab while the popup is up — how menus behave on X (below)                                      |
 | `transparent`      | 32-bit ARGB visual: rounded corners and translucency ([above](#transparent--rounded-corners-and-translucency)) |
 | `onDismiss`        | a press landed outside the popup: close it                                                                     |
 | `trapFocus`        | own a focus scope: a modal (see [events.md](events.md#focus-scopes-modals))                                    |
 | `overrideRedirect` | `false` makes it a WM-managed window instead — a real dialog (below)                                           |
 | `dragPreview`      | this popup is a drag preview following the pointer, never a drop target — [drag-and-drop.md](drag-and-drop.md) |
+
+### `anchor` — a popup that places itself
+
+```jsx
+function Completions({ editorRef, caret, matches, onPick }) {
+  if (!matches.length) return null;
+  return (
+    <popup
+      anchor={{ to: editorRef, at: caret, placement: 'bottom' }}
+      maxHeight={220}
+    >
+      <box
+        style={{ overflow: 'scroll', padding: 4, backgroundColor: '$surface' }}
+      >
+        {matches.map((m) => (
+          <box key={m.label} onClick={() => onPick(m)} style={{ padding: 6 }}>
+            <text>{m.label}</text>
+          </box>
+        ))}
+      </box>
+    </popup>
+  );
+}
+```
+
+That is the whole completion list: **at the caret**, as wide as its widest
+label, no taller than 220 and scrolling past that, flipped above the line
+when it is near the bottom of the screen. Nothing in it measures a font,
+states a size, or names a position — `caret` is a rect the editor already
+knows, in its own coordinates.
+
+`anchor` takes [`anchorRect`'s options](components.md#useanchorref--anchorrectnode-options)
+— `placement`, `align`, `offset`, `alignOffset`, `alignTo`, `at` — plus `to`,
+the node (or a ref to one) it hangs off. `x`/`y` are ignored while it is set.
+
+**Why the popup and not the application.** A `<popup>` with no `width` is
+sized from its content like any other window, and that size is settled
+_inside_ `realize()` — after the content is measured, before `CreateWindow`.
+Which side the popup flips to and how far it is pulled back from a screen
+edge are both functions of that size, so the earliest anyone can work out the
+position is the moment after the measurement — which is already too late for
+React to have passed one in. Doing it here keeps the rule the natural size
+established: the window is **born** the right size in the right place, rather
+than mapped somewhere provisional and corrected a frame later.
+
+Afterwards it keeps up with everything that can move either half — the
+anchor's own layout, an ancestor of it scrolling, the owner window being
+dragged by the window manager, its own content growing a row.
+
+`at` is a rect **inside** the node, in the node's own coordinates:
+
+```js
+const caret = { x: caretX, y: lineTop, width: 1, height: lineHeight };
+```
+
+Everything reads it — the side that flips, the edge that aligns, the gap
+`offset` leaves — so a popup at a caret behaves like one hung off a small
+widget that happens to be there. `width`/`height` may be left out, and
+`{x, y}` alone is a point.
+
+A popup whose anchor is a ref that has not attached yet — one written
+_above_ its own trigger in the JSX — waits for it rather than opening in the
+corner of the screen. That is one frame, and it is the same rule as the one
+below: an anchored popup is on screen only while there is something for it
+to point at.
+
+**When the anchor scrolls out of view the popup unmaps** and comes back,
+where it belongs — and holding its `grab` again, since X drops a pointer
+grab whose window stops being viewable — when the anchor does. A popup is a real X window rather
+than an element its ancestors clip, so a caret that has scrolled out of the
+editor leaves a list floating over a document it no longer points into —
+and there is no position that fixes that. Whether it should _close_ instead
+is React state and therefore the application's: do the placement yourself
+with [`useAnchorTracking`](components.md#useanchorref--anchorrectnode-options)
+and its `onOutOfView`.
 
 A popup never receives the X input focus, but nodes inside it can hold the
 **owner window's** focus and receive keys — with `trapFocus` and `autoFocus`

--- a/src/anchor.js
+++ b/src/anchor.js
@@ -1,0 +1,302 @@
+// Popup geometry: where to put a `<popup>` that hangs off something else.
+//
+// Core rather than `src/components/`, because two callers need it and only
+// one of them is a widget. A widget that knows its own size measures the
+// rect itself and passes it as `x`/`y` (`useAnchor`, `useAnchorTracking` —
+// `src/components/anchor.js`, which re-exports everything here). A `<popup>`
+// that sizes itself from its content cannot: its size is settled inside
+// `realize()`, between the measurement and `CreateWindow`, which is after
+// the last moment React could have computed a position for it. So the
+// window places *itself* from the same functions (`WindowNode._followAnchor`,
+// nodes.js), and the two paths agree because they are the same code.
+
+import { availableArea } from './screens.js';
+
+/**
+ * A node's laid-out rect in **screen** coordinates: the owner window's
+ * position plus the node's own box.
+ *
+ * `_screenOrigin` is what the server says the window is at; `x`/`y` are
+ * frame-relative under a reparenting window manager and are only a fallback
+ * (the headless mock has no server to ask).
+ *
+ * Exported because a popup sometimes has to know where its *trigger* is and
+ * not only where to put itself — a tooltip's arrow points at the middle of
+ * the thing it annotates, which stops being the middle of the tooltip as
+ * soon as a screen edge slides one of them.
+ */
+export function screenRect(node) {
+  if (!node?.abs) return null;
+  const origin = windowOrigin(node);
+  return {
+    x: origin.x + node.abs.x,
+    y: origin.y + node.abs.y,
+    width: node.abs.width,
+    height: node.abs.height,
+  };
+}
+
+/** Where the node's owner window is on the screen. */
+function windowOrigin(node) {
+  const win = node?.root?.window;
+  return win?._screenOrigin ?? { x: win?.x ?? 0, y: win?.y ?? 0 };
+}
+
+/**
+ * The rect within a node that a popup is anchored to, in the node's own
+ * coordinates — a caret, a table cell, a chart datapoint, the span under a
+ * text-range tooltip. `width`/`height` default to 0, so `{x, y}` alone is a
+ * point.
+ *
+ * Node-relative rather than screen-relative because the caller measures it
+ * against its own content, and because it then survives everything that
+ * moves the node: the window being dragged, an ancestor scrolling, the
+ * node's own layout shifting. That is what lets `useAnchorTracking` follow a
+ * caret with no extra work — it re-reads the options and the node, and the
+ * offset between them is still true.
+ */
+export function subRect(node, at) {
+  if (!node?.abs) return null;
+  if (!at) return node.abs;
+  return {
+    x: node.abs.x + (at.x ?? 0),
+    y: node.abs.y + (at.y ?? 0),
+    width: at.width ?? 0,
+    height: at.height ?? 0,
+  };
+}
+
+/**
+ * Has the thing this popup points at scrolled out of view? The check paint
+ * culling uses (`Node._offscreen`), asked about the sub-rect rather than
+ * about the node: an editor scrolls its own text, so the caret leaves the
+ * viewport a long time before the editor does.
+ *
+ * A degenerate rect counts as its own thinnest visible version — a caret is
+ * a line with no width and a `{x, y}` anchor is a point with neither, and
+ * having no area is not the same as being off screen.
+ */
+export function anchorOffscreen(node, at) {
+  const rect = subRect(node, at);
+  if (!rect || typeof node._offscreen !== 'function') return false;
+  return node._offscreen({
+    x: rect.x,
+    y: rect.y,
+    width: Math.max(rect.width, 1),
+    height: Math.max(rect.height, 1),
+  });
+}
+
+/**
+ * The area a popup anchored to this node may be placed in: the usable part
+ * of the monitor the node is on.
+ *
+ * The same answer `<window width="auto">` is capped by (`src/screens.js`) —
+ * per-monitor, minus the panels — rather than `screen.pixel_width`, which is
+ * the whole virtual desktop. On a two-head setup that difference is the
+ * difference between a menu flipping at the edge of the monitor it is on and
+ * a menu that only flips at the far edge of the *other* monitor, having
+ * opened halfway across the seam. `null` where there is nothing to ask,
+ * which is the headless mock and a server with no Xinerama and no screen:
+ * placement then neither flips nor clamps.
+ */
+export function anchorArea(node) {
+  const app = node?.app;
+  if (!app) return null;
+  const at = screenRect(node);
+  return availableArea(app, at ? { x: at.x, y: at.y } : null);
+}
+
+/**
+ * Where to put a `<popup>` anchored to a drawn node, in **screen**
+ * coordinates: the owner window's position plus the node's laid-out rect.
+ *
+ * `placement` is a preference, not a promise — a menu near the bottom of
+ * the screen flips above its trigger rather than opening off-screen, and
+ * the result is clamped into the screen either way. The chosen side comes
+ * back as `placement` so the caller can style accordingly.
+ *
+ * `at` anchors to a rect **inside** the node instead of to the node itself
+ * (see `subRect`): the caret in an editor, a cell in a table, a point on a
+ * chart. Everything else then reads that rect — the side it flips on, the
+ * edge it aligns to, the gap `offset` leaves — so a popup anchored to a
+ * caret behaves exactly like one anchored to a small widget that happens to
+ * be there.
+ *
+ * `alignTo` takes the two axes from **different** nodes: the placement edge
+ * from `node`, the alignment from `alignTo`. A submenu is the case that
+ * needs it — it belongs against the outer edge of the menu it comes out of,
+ * but lined up with the row that spawned it, and that row is inset by the
+ * menu's border and padding. Anchoring both to the row opens the submenu
+ * *over* its parent by exactly that inset. Both nodes must be in the same
+ * window, which is what lets one origin serve both.
+ *
+ * `alignOffset` shifts the result along the *alignment* axis, where `offset`
+ * moves it along the placement one — and it is applied before the clamp, so
+ * a popup nudged towards a screen edge is still brought back from it. What
+ * needs it is the difference between lining up a **surface** and lining up
+ * what is drawn **in** it: a submenu whose top edge is level with the row
+ * that opened it has its first item a border and a padding lower down, and
+ * the eye lines up the items, not the boxes.
+ *
+ * ## Which side is which
+ *
+ * `placement: 'start'` and `'end'` are the **logical** sides, and they are
+ * what a submenu wants: a menu opens away from the edge its rows begin at, so
+ * it goes out to the right in an LTR menu and out to the left in an RTL one.
+ * `'left'`/`'right'` stay available and stay physical, for the rare placement
+ * that really is about the screen. `align: 'start'`/`'end'` mirror the same
+ * way — but only when the popup is above or below its trigger, since with a
+ * popup beside it the alignment axis is vertical and nothing about a vertical
+ * axis mirrors.
+ *
+ * The direction comes from the anchoring node, so a menu inside a mirrored
+ * panel opens the mirrored way without its widget being told.
+ */
+export function anchorRect(node, options = {}) {
+  if (!node?.abs) return null;
+  const {
+    placement = 'bottom',
+    align = 'start',
+    alignOffset = 0,
+    offset = 2,
+    at,
+    alignTo,
+    direction = node.direction,
+  } = options;
+  const rtl = direction === 'rtl';
+
+  // The anchor is the sub-rect where there is one, all the way through:
+  // the side that flips, the edge that aligns, and — since a popup with no
+  // size of its own is as wide as the thing it hangs off — the default
+  // width.
+  const anchor = subRect(node, at);
+  const { width = anchor.width, height = 0 } = options;
+
+  const origin = windowOrigin(node);
+  const ax = origin.x + anchor.x;
+  const ay = origin.y + anchor.y;
+  const aw = anchor.width;
+  const ah = anchor.height;
+  // the rect the *alignment* reads, which is the anchor's own unless the
+  // caller split the two axes — one origin serves both, since both nodes are
+  // in the same window
+  const cross = alignTo ? (subRect(alignTo) ?? anchor) : anchor;
+  const cx = origin.x + cross.x;
+  const cy = origin.y + cross.y;
+
+  const area = anchorArea(node);
+  const left = area?.x ?? 0;
+  const top = area?.y ?? 0;
+  const right = area ? area.x + area.width : null;
+  const bottom = area ? area.y + area.height : null;
+
+  // `mirrored` is only ever true on the horizontal axis: `alignAlong` serves
+  // both, and a vertically-aligned popup's `start` is the top in every
+  // direction there is.
+  const alignAlong = (start, size, extent, mirrored) => {
+    const edge =
+      align === 'center'
+        ? 'center'
+        : (align === 'end') !== mirrored
+          ? 'end'
+          : 'start';
+    return (
+      alignOffset +
+      (edge === 'center'
+        ? start + (size - extent) / 2
+        : edge === 'end'
+          ? start + size - extent
+          : start)
+    );
+  };
+
+  let side =
+    placement === 'start'
+      ? rtl
+        ? 'right'
+        : 'left'
+      : placement === 'end'
+        ? rtl
+          ? 'left'
+          : 'right'
+        : placement;
+  let x;
+  let y;
+
+  if (side === 'bottom' || side === 'top') {
+    const below = ay + ah + offset;
+    const above = ay - height - offset;
+    if (
+      side === 'bottom' &&
+      bottom != null &&
+      below + height > bottom &&
+      above >= top
+    ) {
+      side = 'top';
+    } else if (
+      side === 'top' &&
+      above < top &&
+      (bottom == null || below + height <= bottom)
+    ) {
+      side = 'bottom';
+    }
+    y = side === 'bottom' ? below : above;
+    x = alignAlong(cx, cross.width, width, rtl);
+  } else {
+    const after = ax + aw + offset;
+    const before = ax - width - offset;
+    if (
+      side === 'right' &&
+      right != null &&
+      after + width > right &&
+      before >= left
+    ) {
+      side = 'left';
+    } else if (
+      side === 'left' &&
+      before < left &&
+      (right == null || after + width <= right)
+    ) {
+      side = 'right';
+    }
+    x = side === 'right' ? after : before;
+    y = alignAlong(cy, cross.height, height, false);
+  }
+
+  if (right != null) x = Math.max(left, Math.min(x, right - width));
+  if (bottom != null && height) y = Math.max(top, Math.min(y, bottom - height));
+
+  return { x: Math.round(x), y: Math.round(y), width, height, placement: side };
+}
+
+/**
+ * Where to put a `<popup>` of this size **centred over the owner window**,
+ * in screen coordinates, clamped into the screen. A dialog is anchored to
+ * the window rather than to a widget, which is the one placement
+ * `anchorRect` cannot express.
+ */
+export function centerRect(node, { width, height }) {
+  if (!node) return null;
+  const win = node.root?.window;
+  const ww = win?.width ?? width;
+  const wh = win?.height ?? height;
+  // `_screenOrigin` for the same reason `anchorRect` uses it: `x`/`y` come
+  // from ConfigureNotify, and under a reparenting window manager those can be
+  // relative to the *frame* rather than the root — which would centre the
+  // dialog off by the size of the decoration. The server's own answer is
+  // right whatever the WM did. (quartz-wm happens to report root-relative
+  // coordinates, so the two agree there; that is not something to rely on.)
+  // The raw coordinates stay as the fallback, since the headless mock has no
+  // server to ask.
+  const origin = win?._screenOrigin ?? { x: win?.x ?? 0, y: win?.y ?? 0 };
+  let x = origin.x + (ww - width) / 2;
+  let y = origin.y + (wh - height) / 2;
+
+  const area = anchorArea(node);
+  if (area) {
+    x = Math.max(area.x, Math.min(x, area.x + area.width - width));
+    y = Math.max(area.y, Math.min(y, area.y + area.height - height));
+  }
+  return { x: Math.round(x), y: Math.round(y), width, height };
+}

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -13,11 +13,11 @@ import {
 import { Icon, iconSize } from './Icon.js';
 import {
   DEFAULT_LABEL_SIZE,
+  anchorArea,
   anchorRect,
   measureLabel,
   movingToward,
   SAFE_HOVER_DELAY,
-  screenOf,
   screenPoint,
   useAnchorTracking,
   useDismissOnWindowBlur,
@@ -767,14 +767,16 @@ export function ContextMenu({
     if (!node || !items.length) return;
     const width = menuListWidth(node, items, fontSize);
     const height = menuListHeight(items, fontSize);
-    const screen = screenOf(node);
+    const area = anchorArea(node);
     // anchored at the pointer rather than at a widget: clamp by hand, since
     // there is no anchor rect to flip around
     const x = ev.nativeEvent?.rootx ?? ev.x;
     const y = ev.nativeEvent?.rooty ?? ev.y;
     setRect({
-      x: screen ? Math.max(0, Math.min(x, screen.pixel_width - width)) : x,
-      y: screen ? Math.max(0, Math.min(y, screen.pixel_height - height)) : y,
+      x: area ? Math.max(area.x, Math.min(x, area.x + area.width - width)) : x,
+      y: area
+        ? Math.max(area.y, Math.min(y, area.y + area.height - height))
+        : y,
       width,
       height,
     });

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -7,8 +7,8 @@ import { capBand, capTrim, rowRadius, useTheme } from './theme.js';
 import { Icon } from './Icon.js';
 import { changeEvent } from './change.js';
 import {
+  anchorArea,
   measureLabel,
-  screenOf,
   useAnchor,
   useAnchorTracking,
   useDismissOnWindowBlur,
@@ -95,8 +95,8 @@ function menuWidth(node, options, value, scrolls, fontSize) {
     ITEM_PAD_RIGHT +
     (scrolls ? SCROLLBAR_WIDTH : 0);
   const width = Math.max(node.abs.width, Math.ceil(widest) + chrome);
-  const screen = screenOf(node);
-  return screen ? Math.min(width, screen.pixel_width) : width;
+  const area = anchorArea(node);
+  return area ? Math.min(width, area.width) : width;
 }
 
 function Option({

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -14,10 +14,10 @@ import { interpolate } from '../styles.js';
 import { capTrim, ThemeProvider, useTheme } from './theme.js';
 import {
   DEFAULT_LABEL_SIZE,
+  anchorArea,
   measureLabel,
   movingToward,
   SAFE_HOVER_DELAY,
-  screenOf,
   screenPoint,
   screenRect,
   useAnchor,
@@ -131,23 +131,24 @@ function dismissOthers(app, self) {
  * The side to hang a hint off when the caller has not named one.
  *
  * Measured against the **screen**, not the owner window: a popup is a real
- * X window, so the room a tooltip has is the room the display has. The
- * first side it fits on wins, in the order above, and if it fits nowhere
- * the roomiest side does — there the placement is going to be clamped
- * whatever we pick, and the most room is the least clamping.
+ * X window, so the room a tooltip has is the room the display has — the
+ * usable part of the monitor the trigger is on (`anchorArea`). The first
+ * side it fits on wins, in the order above, and if it fits nowhere the
+ * roomiest side does — there the placement is going to be clamped whatever
+ * we pick, and the most room is the least clamping.
  *
- * With no screen geometry to read (the headless mock) this is `'top'`,
- * which is where a tooltip went before there was anything to ask.
+ * With no display to ask at all this is `'top'`, which is where a tooltip
+ * went before there was anything to ask.
  */
 function autoDirection(node, size) {
   const trigger = screenRect(node);
-  const screen = screenOf(node);
-  if (!trigger || !screen) return 'top';
+  const area = anchorArea(node);
+  if (!trigger || !area) return 'top';
   const room = {
-    top: trigger.y,
-    bottom: screen.pixel_height - (trigger.y + trigger.height),
-    left: trigger.x,
-    right: screen.pixel_width - (trigger.x + trigger.width),
+    top: trigger.y - area.y,
+    bottom: area.y + area.height - (trigger.y + trigger.height),
+    left: trigger.x - area.x,
+    right: area.x + area.width - (trigger.x + trigger.width),
   };
   const needed = (side) =>
     (side === 'top' || side === 'bottom' ? size.height : size.width) +

--- a/src/components/anchor.js
+++ b/src/components/anchor.js
@@ -1,214 +1,22 @@
-// Popup geometry: where to put a <popup> anchored to a drawn node, and
-// how big to make it around a measured label.
+// Popup geometry, the React half: the hooks a widget hangs a `<popup>` off
+// a node with, and the measurement a menu sizes itself around.
+//
+// The placement math itself is core (`src/anchor.js`), because a `<popup>`
+// that sizes itself from its content places itself from the same functions
+// — see the note there.
 
 import { useCallback, useEffect, useRef } from 'react';
 
-/** The X screen the node's window lives on, if reachable (the smoke-test
- *  mock app has no screen geometry — callers must cope with null). */
-export function screenOf(node) {
-  const app = node?.app;
-  const screen = (app?.display ?? app?.X?.display)?.screen?.[0];
-  return screen?.pixel_width ? screen : null;
-}
+export {
+  anchorArea,
+  anchorOffscreen,
+  anchorRect,
+  centerRect,
+  screenRect,
+  subRect,
+} from '../anchor.js';
 
-/**
- * A node's laid-out rect in **screen** coordinates: the owner window's
- * position plus the node's own box.
- *
- * `_screenOrigin` is what the server says the window is at; `x`/`y` are
- * frame-relative under a reparenting window manager and are only a fallback
- * (the headless mock has no server to ask).
- *
- * Exported because a popup sometimes has to know where its *trigger* is and
- * not only where to put itself — a tooltip's arrow points at the middle of
- * the thing it annotates, which stops being the middle of the tooltip as
- * soon as a screen edge slides one of them.
- */
-export function screenRect(node) {
-  if (!node?.abs) return null;
-  const origin = windowOrigin(node);
-  return {
-    x: origin.x + node.abs.x,
-    y: origin.y + node.abs.y,
-    width: node.abs.width,
-    height: node.abs.height,
-  };
-}
-
-/** Where the node's owner window is on the screen. */
-function windowOrigin(node) {
-  const win = node?.root?.window;
-  return win?._screenOrigin ?? { x: win?.x ?? 0, y: win?.y ?? 0 };
-}
-
-/**
- * Where to put a `<popup>` anchored to a drawn node, in **screen**
- * coordinates: the owner window's position plus the node's laid-out rect.
- *
- * `placement` is a preference, not a promise — a menu near the bottom of
- * the screen flips above its trigger rather than opening off-screen, and
- * the result is clamped into the screen either way. The chosen side comes
- * back as `placement` so the caller can style accordingly.
- *
- * `alignTo` takes the two axes from **different** nodes: the placement edge
- * from `node`, the alignment from `alignTo`. A submenu is the case that
- * needs it — it belongs against the outer edge of the menu it comes out of,
- * but lined up with the row that spawned it, and that row is inset by the
- * menu's border and padding. Anchoring both to the row opens the submenu
- * *over* its parent by exactly that inset. Both nodes must be in the same
- * window, which is what lets one origin serve both.
- *
- * `alignOffset` shifts the result along the *alignment* axis, where `offset`
- * moves it along the placement one — and it is applied before the clamp, so
- * a popup nudged towards a screen edge is still brought back from it. What
- * needs it is the difference between lining up a **surface** and lining up
- * what is drawn **in** it: a submenu whose top edge is level with the row
- * that opened it has its first item a border and a padding lower down, and
- * the eye lines up the items, not the boxes.
- *
- * ## Which side is which
- *
- * `placement: 'start'` and `'end'` are the **logical** sides, and they are
- * what a submenu wants: a menu opens away from the edge its rows begin at, so
- * it goes out to the right in an LTR menu and out to the left in an RTL one.
- * `'left'`/`'right'` stay available and stay physical, for the rare placement
- * that really is about the screen. `align: 'start'`/`'end'` mirror the same
- * way — but only when the popup is above or below its trigger, since with a
- * popup beside it the alignment axis is vertical and nothing about a vertical
- * axis mirrors.
- *
- * The direction comes from the anchoring node, so a menu inside a mirrored
- * panel opens the mirrored way without its widget being told.
- */
-export function anchorRect(node, options = {}) {
-  if (!node?.abs) return null;
-  const {
-    placement = 'bottom',
-    align = 'start',
-    alignOffset = 0,
-    offset = 2,
-    width = node.abs.width,
-    height = 0,
-    alignTo,
-    direction = node.direction,
-  } = options;
-  const rtl = direction === 'rtl';
-
-  const origin = windowOrigin(node);
-  const ax = origin.x + node.abs.x;
-  const ay = origin.y + node.abs.y;
-  const aw = node.abs.width;
-  const ah = node.abs.height;
-  // the rect the *alignment* reads, which is `node`'s own unless the caller
-  // split the two axes — one origin serves both, since both nodes are in the
-  // same window
-  const cross = alignTo?.abs ?? node.abs;
-  const cx = origin.x + cross.x;
-  const cy = origin.y + cross.y;
-
-  const screen = screenOf(node);
-  const sw = screen?.pixel_width;
-  const sh = screen?.pixel_height;
-
-  // `mirrored` is only ever true on the horizontal axis: `alignAlong` serves
-  // both, and a vertically-aligned popup's `start` is the top in every
-  // direction there is.
-  const alignAlong = (start, size, extent, mirrored) => {
-    const at =
-      align === 'center'
-        ? 'center'
-        : (align === 'end') !== mirrored
-          ? 'end'
-          : 'start';
-    return (
-      alignOffset +
-      (at === 'center'
-        ? start + (size - extent) / 2
-        : at === 'end'
-          ? start + size - extent
-          : start)
-    );
-  };
-
-  let side =
-    placement === 'start'
-      ? rtl
-        ? 'right'
-        : 'left'
-      : placement === 'end'
-        ? rtl
-          ? 'left'
-          : 'right'
-        : placement;
-  let x;
-  let y;
-
-  if (side === 'bottom' || side === 'top') {
-    const below = ay + ah + offset;
-    const above = ay - height - offset;
-    if (side === 'bottom' && sh != null && below + height > sh && above >= 0) {
-      side = 'top';
-    } else if (
-      side === 'top' &&
-      above < 0 &&
-      (sh == null || below + height <= sh)
-    ) {
-      side = 'bottom';
-    }
-    y = side === 'bottom' ? below : above;
-    x = alignAlong(cx, cross.width, width, rtl);
-  } else {
-    const after = ax + aw + offset;
-    const before = ax - width - offset;
-    if (side === 'right' && sw != null && after + width > sw && before >= 0) {
-      side = 'left';
-    } else if (
-      side === 'left' &&
-      before < 0 &&
-      (sw == null || after + width <= sw)
-    ) {
-      side = 'right';
-    }
-    x = side === 'right' ? after : before;
-    y = alignAlong(cy, cross.height, height, false);
-  }
-
-  if (sw != null) x = Math.max(0, Math.min(x, sw - width));
-  if (sh != null && height) y = Math.max(0, Math.min(y, sh - height));
-
-  return { x: Math.round(x), y: Math.round(y), width, height, placement: side };
-}
-
-/**
- * Where to put a `<popup>` of this size **centred over the owner window**,
- * in screen coordinates, clamped into the screen. A dialog is anchored to
- * the window rather than to a widget, which is the one placement
- * `anchorRect` cannot express.
- */
-export function centerRect(node, { width, height }) {
-  if (!node) return null;
-  const win = node.root?.window;
-  const ww = win?.width ?? width;
-  const wh = win?.height ?? height;
-  // `_screenOrigin` for the same reason `anchorRect` uses it: `x`/`y` come
-  // from ConfigureNotify, and under a reparenting window manager those can be
-  // relative to the *frame* rather than the root — which would centre the
-  // dialog off by the size of the decoration. The server's own answer is
-  // right whatever the WM did. (quartz-wm happens to report root-relative
-  // coordinates, so the two agree there; that is not something to rely on.)
-  // The raw coordinates stay as the fallback, since the headless mock has no
-  // server to ask.
-  const origin = win?._screenOrigin ?? { x: win?.x ?? 0, y: win?.y ?? 0 };
-  let x = origin.x + (ww - width) / 2;
-  let y = origin.y + (wh - height) / 2;
-
-  const screen = screenOf(node);
-  if (screen) {
-    x = Math.max(0, Math.min(x, screen.pixel_width - width));
-    y = Math.max(0, Math.min(y, screen.pixel_height - height));
-  }
-  return { x: Math.round(x), y: Math.round(y), width, height };
-}
+import { anchorOffscreen, anchorRect } from '../anchor.js';
 
 /**
  * useAnchor(ref) — stable `measure(options)` returning `anchorRect` for the
@@ -261,6 +69,12 @@ function sameAnchorRect(a, b) {
  * the caller's call — and does not resume until re-opened. With no
  * `onOutOfView` this just stops updating rather than snapping to a rect
  * that no longer means anything.
+ *
+ * With an `at` in the options that test is about **the sub-rect**, not the
+ * node: an editor scrolls its own text, so the caret leaves the viewport
+ * long before the editor does, and a completion popup that waited for the
+ * whole editor to scroll away would hang over the middle of a document it
+ * had stopped pointing into.
  */
 export function useAnchorTracking(
   ref,
@@ -292,12 +106,14 @@ export function useAnchorTracking(
     return root.onAnchorChange(() => {
       if (!activeRef.current) return;
       const node = ref.current;
-      if (node?._offscreen?.()) {
+      // the options before the view test, because `at` is in them: what has
+      // to still be visible is the rect the popup points at
+      const options = getOptionsRef.current();
+      if (!options) return;
+      if (anchorOffscreen(node, options.at)) {
         onOutOfViewRef.current?.();
         return;
       }
-      const options = getOptionsRef.current();
-      if (!options) return;
       const next = measure(options);
       if (!next) return;
       setRect((prev) => (sameAnchorRect(prev, next) ? prev : next));

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -4,6 +4,7 @@
 // typeahead.js and keys.js.
 export { ThemeProvider, useDirection, useTheme } from './theme.js';
 export {
+  anchorArea,
   anchorRect,
   centerRect,
   screenRect,

--- a/src/index.js
+++ b/src/index.js
@@ -64,6 +64,7 @@ export {
   ContextMenu,
   useAnchor,
   useAnchorTracking,
+  anchorArea,
   anchorRect,
   centerRect,
   screenRect,

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -53,6 +53,7 @@ import {
   watchCompositing,
 } from './compositing.js';
 import { availableArea } from './screens.js';
+import { anchorOffscreen, anchorRect } from './anchor.js';
 import { baseTheme } from './palette.js';
 import { callHandler } from './errors.js';
 import {
@@ -880,9 +881,10 @@ function contentSpan(node, axis, intrinsic) {
  * closure forever. Handlers are read from current props at dispatch time
  * instead, so they can never go stale. `children` is the tree's,
  * `transientFor` holds a React ref that only the commit phase can resolve
- * (WindowNode._applyTransientFor), and `transparent` names a visual that has
- * to be looked up on the connection (WindowNode._argbAttributes) rather than
- * a value ntk takes.
+ * (WindowNode._applyTransientFor), `anchor` is a position `realize()` works
+ * out from the size it just measured (WindowNode._anchorPlacement), and
+ * `transparent` names a visual that has to be looked up on the connection
+ * (WindowNode._argbAttributes) rather than a value ntk takes.
  */
 export function windowAttributes(props) {
   const attributes = {};
@@ -890,6 +892,7 @@ export function windowAttributes(props) {
   for (const key of Object.keys(props)) {
     if (key === 'children' || key === 'style' || isEventProp(key)) continue;
     if (key === 'transientFor' || key === 'transparent') continue;
+    if (key === 'anchor') continue;
     if ((key === 'width' || key === 'height') && isAutoSize(props[key])) {
       continue;
     }
@@ -2772,11 +2775,17 @@ export class Node {
    * them) for the server to then discard. Checking the window alone missed
    * that: a node can sit well inside the window and still be entirely past
    * a scrolling ancestor whose own bounds are the real limit.
+   *
+   * `rect` asks the same question about part of the node instead — window
+   * coordinates, the node's own rect by default. What wants it is anchoring
+   * (`src/anchor.js`): a popup pointed at a caret has to know when *the
+   * caret* has scrolled out of the editor, which happens many screens before
+   * the editor itself goes anywhere.
    */
-  _offscreen() {
+  _offscreen(rect = this.abs) {
     const window = this.root?.abs;
     if (!window) return false;
-    const { x, y, width, height } = this.abs;
+    const { x, y, width, height } = rect;
     if (
       x + width <= 0 ||
       y + height <= 0 ||
@@ -2786,7 +2795,7 @@ export class Node {
       return true;
     }
     for (let n = this.parent; n && n !== this.root; n = n.parent) {
-      if (n.clipsChildren() && !rectsOverlap(this.abs, n.abs)) return true;
+      if (n.clipsChildren() && !rectsOverlap(rect, n.abs)) return true;
     }
     return false;
   }
@@ -5926,6 +5935,130 @@ export class WindowNode extends Scrollable(Node) {
     } else {
       wnd.resize?.(next.width, next.height);
     }
+    // A window that grew is a window whose *placement* moved with it, and
+    // the anchored ones have to be told: a completion list that gains a row
+    // near the bottom of the screen is one that now flips above the caret.
+    // From `next` rather than from the window, which is still the size the
+    // server last confirmed.
+    this._followAnchor({ width: next.width, height: next.height });
+  }
+
+  // --- anchoring ----------------------------------------------------------
+  //
+  // A `<popup anchor={{to: ref, …}}>` works out its own position, because it
+  // is the only thing that can: with `width="auto"` the size is settled
+  // inside `realize()`, between `_measure()` and `CreateWindow`, which is
+  // after the last moment React could have computed a rect for it — and the
+  // placement *needs* the size, since which side it flips to and how far it
+  // is pulled back from an edge are both functions of how big it is.
+  //
+  // So the same order the natural size already established: measure, place,
+  // create. The popup is born the right size **and** in the right place,
+  // rather than mapped somewhere provisional and corrected a frame later.
+  // A widget that knows its own size has no such problem and stays on
+  // `useAnchor` / `useAnchorTracking`; both call the same functions
+  // (src/anchor.js), so the two agree by construction.
+
+  /** A `to`/`alignTo` in an `anchor` prop: a ref, or the node itself. */
+  _anchorTarget(target) {
+    if (target == null || typeof target !== 'object') return null;
+    const node = target.abs ? target : target.current;
+    return node?.abs ? node : null;
+  }
+
+  /** Where this window goes at `size`, or null when there is nothing to
+   *  anchor to yet — a ref whose node has not been laid out. */
+  _anchorPlacement(size) {
+    const anchor = this.props.anchor;
+    const node = this._anchorTarget(anchor?.to);
+    if (!node) return null;
+    return anchorRect(node, {
+      ...anchor,
+      alignTo: this._anchorTarget(anchor.alignTo) ?? undefined,
+      width: size.width,
+      height: size.height,
+    });
+  }
+
+  /**
+   * Keep an anchored window over the thing it points at: the trigger's own
+   * layout moving, an ancestor of it scrolling, the owner window being
+   * dragged, or this window's content changing size under it.
+   *
+   * The first three arrive through the *owner* window's `onAnchorChange`
+   * (`_watchAnchor`) — the same signal `useAnchorTracking` reads, since it
+   * is the same set of things that can move a trigger. The fourth is
+   * `_refit`, which knows the new size before the server does.
+   *
+   * **Out of view is not a position.** A popup is a real X window, not a
+   * web element its ancestors clip, so a caret that has scrolled out of the
+   * editor leaves a completion list floating over a document it no longer
+   * points into. There is no placement that fixes that, so the window is
+   * unmapped for as long as the anchor is gone and mapped again where it
+   * belongs when it comes back — the one answer the renderer can give on
+   * its own, since whether the popup should *close* is React state and
+   * therefore the application's. (An app that would rather close it keeps
+   * `useAnchorTracking`'s `onOutOfView`, which is exactly that seam.)
+   */
+  _followAnchor(size = this._requestedSize) {
+    if (this.destroyed || !this.window || !this.props.anchor) return;
+    const node = this._anchorTarget(this.props.anchor.to);
+    // A ref that has not attached yet counts as gone, and for the same
+    // reason: there is nowhere for the popup to be. Refs attach in the
+    // commit phase a popup realizes in, so one written *above* its own
+    // trigger in the JSX gets a frame of this — and waiting it out is
+    // better than a frame in the corner of the screen.
+    const lost = !node || anchorOffscreen(node, this.props.anchor.at);
+    if (lost !== Boolean(this._anchorLost)) {
+      this._anchorLost = lost;
+      // The grab goes with it and comes back with it. X releases a pointer
+      // grab whose window stops being viewable, so a menu that hid and
+      // reappeared would be one no press outside could dismiss — the
+      // `onDismiss` that reads as "click anywhere to close" would simply
+      // stop happening.
+      if (lost) {
+        if (this.props.grab) this.window.ungrabPointer?.();
+        this.window.unmap?.();
+      } else {
+        this._mapNow();
+        if (this.props.grab) this.window.grabPointer?.({}, () => {});
+      }
+    }
+    if (lost || !size) return;
+    const rect = this._anchorPlacement(size);
+    if (!rect) return;
+    if (this._placedAt?.x === rect.x && this._placedAt?.y === rect.y) return;
+    this._placedAt = { x: rect.x, y: rect.y };
+    if (typeof this.window.setState === 'function') {
+      this.window.setState({ x: rect.x, y: rect.y });
+    } else {
+      this.window.move?.(rect.x, rect.y);
+    }
+  }
+
+  /**
+   * Subscribe to whatever can move the anchor. On the **owner's** window,
+   * not on this one: what moves is the trigger, and this window's own
+   * layout passes say nothing about where it sits on screen.
+   */
+  _watchAnchor() {
+    this._unwatchAnchor();
+    if (!this.props.anchor) return;
+    // The anchor's own window where the ref has attached, and the window
+    // this popup was *written into* otherwise — which is the same one in
+    // every case that matters, and is what makes an unattached ref a
+    // one-frame wait rather than a popup nothing ever notifies again. The
+    // notification is only ever a prompt to re-measure, so subscribing to a
+    // window the anchor turns out not to be in costs a no-op.
+    const root =
+      this._anchorTarget(this.props.anchor.to)?.root ?? this.parent?.root;
+    if (!root?.onAnchorChange || root === this) return;
+    this._anchorWatch = root.onAnchorChange(() => this._followAnchor());
+  }
+
+  _unwatchAnchor() {
+    this._anchorWatch?.();
+    this._anchorWatch = null;
   }
 
   /** Create the real X11 window (commit phase only). Children windows are
@@ -5944,6 +6077,15 @@ export class WindowNode extends Scrollable(Node) {
     attributes.width = natural.width;
     attributes.height = natural.height;
     this._requestedSize = { width: natural.width, height: natural.height };
+    // And straight after it, for the same reason: the placement is a
+    // function of the size, so this is the first moment it can be worked
+    // out — and the last one before the window exists at a position.
+    const placed = this._anchorPlacement(natural);
+    if (placed) {
+      attributes.x = placed.x;
+      attributes.y = placed.y;
+      this._placedAt = { x: placed.x, y: placed.y };
+    }
     // A bound the content decides is a number by now, and the window manager
     // reads `WM_NORMAL_HINTS` when it frames the window — so it goes in with
     // the creation attributes rather than chasing the map with a second
@@ -6030,6 +6172,16 @@ export class WindowNode extends Scrollable(Node) {
     // only — a later `<window>` is not the launch (src/startup.js).
     this._topLevel = !parentWindow && !this.isPopup;
     if (this._topLevel) this.app._reactX11Startup?.decorate(wnd);
+    // Before the map for the same reason the properties above are: a popup
+    // whose anchor is already out of view — an editor scrolled between the
+    // keystroke that opened the completion list and the commit that
+    // realized it — should never be on screen at all, rather than appear
+    // and vanish.
+    if (this.props.anchor) {
+      this._watchAnchor();
+      const node = this._anchorTarget(this.props.anchor.to);
+      this._anchorLost = !node || anchorOffscreen(node, this.props.anchor.at);
+    }
     // Queued rather than mapped, when there is a commit to queue behind:
     // React hides a subtree only once it has inserted it (beginWindowMaps).
     if (inCommit) pendingMaps.add(this);
@@ -6050,6 +6202,9 @@ export class WindowNode extends Scrollable(Node) {
    */
   _mapNow() {
     if (this.destroyed || !this.window || this.hidden) return;
+    // An anchor that is not on screen is a popup that has nowhere to be
+    // (`_followAnchor`); it maps from there, when the anchor comes back.
+    if (this._anchorLost) return;
     this.window.map?.();
     if (this._topLevel) this.app._reactX11Startup?.mapped(this.window);
   }
@@ -6728,6 +6883,11 @@ export class WindowNode extends Scrollable(Node) {
     clearPendingFrame(this);
     this._unwatchCompositing?.();
     this._unwatchCompositing = null;
+    // Before the owner's next layout pass, which is this same commit: a
+    // popup that has gone still holds a subscription to the window it was
+    // anchored to, and answering that notification would configure a dead
+    // window.
+    this._unwatchAnchor();
     // out of the drag registries before the window goes: a drag routed to
     // a dead window would translate against a null _screenOrigin
     forgetTopLevel(this);
@@ -6798,8 +6958,14 @@ export class WindowNode extends Scrollable(Node) {
     const sizeChanged =
       canonicalSize(newProps.width) !== canonicalSize(before.width) ||
       canonicalSize(newProps.height) !== canonicalSize(before.height);
-    const geometryChanged =
-      sizeChanged || newProps.x !== before.x || newProps.y !== before.y;
+    // An anchored window's position is the anchor's business, not the
+    // app's: `x`/`y` are ignored while `anchor` is set (`_followAnchor`
+    // sends the moves), so a commit that changed nothing else is not a
+    // configure back to a stale prop.
+    const anchored = Boolean(newProps.anchor);
+    const movedByProps =
+      !anchored && (newProps.x !== before.x || newProps.y !== before.y);
+    const geometryChanged = sizeChanged || movedByProps;
     // A size that became a number is the app taking the size over, which is
     // exactly the state `_userSized` names — and one that became `'auto'` is
     // the app handing it back, so the window fits its content again on the
@@ -6820,8 +6986,8 @@ export class WindowNode extends Scrollable(Node) {
     if (geometryChanged) {
       if (typeof wnd.setState === 'function') {
         wnd.setState({
-          x: newProps.x,
-          y: newProps.y,
+          x: anchored ? undefined : newProps.x,
+          y: anchored ? undefined : newProps.y,
           // `'auto'` is not a geometry ntk can be given: an axis the app has
           // handed back is left alone here and resolved by `_refit()` on the
           // layout this same commit is about to schedule.
@@ -6836,10 +7002,27 @@ export class WindowNode extends Scrollable(Node) {
         ) {
           wnd.resize?.(newProps.width, newProps.height);
         }
-        if (newProps.x !== before.x || newProps.y !== before.y) {
+        if (movedByProps) {
           wnd.move?.(newProps.x, newProps.y);
         }
       }
+    }
+
+    // Re-read every commit: the options object is rebuilt by every render,
+    // and a moving `at` — a caret — is the whole point of one. Only the
+    // *subscription* is conditional, because only the node it hangs off can
+    // make it stale.
+    if (newProps.anchor?.to !== before.anchor?.to) this._watchAnchor();
+    if (anchored) {
+      this._followAnchor();
+    } else if (before.anchor) {
+      this._placedAt = null;
+      // A popup that gives up its anchor gives up being hidden by one: it
+      // is an ordinary `x`/`y` popup from here, and the configure above
+      // has already put it where the app asked.
+      const wasLost = this._anchorLost;
+      this._anchorLost = false;
+      if (wasLost) this._mapNow();
     }
 
     const layoutChanged =

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -767,10 +767,20 @@ export const Canvas3D: ComponentType<Canvas3DProps>;
 
 // --- anchoring helpers -----------------------------------------------------
 
+/**
+ * The side a popup is asked for. `'start'`/`'end'` are the **logical** ones
+ * and mirror with the anchor's direction, which is what a submenu wants;
+ * `'left'`/`'right'` stay physical.
+ */
+export type AnchorPlacement = Placement | 'start' | 'end';
+
 export interface AnchorOptions {
-  placement?: Placement;
-  /** Gap between the anchor and the popup, in px. */
-  gap?: number;
+  /** Preferred side, flipped at a screen edge (default `'bottom'`). */
+  placement?: AnchorPlacement;
+  /** Which edges line up on the cross axis (default `'start'`). */
+  align?: 'start' | 'center' | 'end';
+  /** Gap from the anchor along the placement axis, in px (default 2). */
+  offset?: number;
   /**
    * Shift along the *alignment* axis, applied before the popup is clamped
    * into the screen. For lining up what is drawn in a surface rather than
@@ -778,23 +788,52 @@ export interface AnchorOptions {
    * first item a border and a padding lower, and the eye lines up the items.
    */
   alignOffset?: number;
+  /**
+   * Anchor to a rect **inside** the node, in the node's own coordinates:
+   * a caret, a table cell, a chart datapoint. Everything reads it — the
+   * side that flips, the edge that aligns, the gap `offset` leaves — so a
+   * popup at a caret behaves like one at a small widget that happens to be
+   * there. `width`/`height` default to 0, so `{x, y}` alone is a point.
+   */
+  at?: { x: number; y: number; width?: number; height?: number };
+  /** The size of the popup being placed. `width` defaults to the anchor's. */
   width?: number;
   height?: number;
-  /** Flip to the opposite side when there is no room (default true). */
-  flip?: boolean;
+  /** Take the alignment from this node instead — a submenu lines up with
+   *  the row that opened it while hanging off the menu's outer edge. */
+  alignTo?: DrawnNode | null;
+  /** Overrides the direction read off the anchoring node. */
+  direction?: 'ltr' | 'rtl';
+}
+
+/** An anchored rect, and the side it actually ended up on. */
+export interface AnchorRect extends Rect {
+  placement: Placement;
 }
 
 /**
  * Where to put a `<popup>` relative to a node, in screen coordinates,
- * flipped at screen edges.
+ * flipped at screen edges. `null` for a node that has not been laid out.
  */
-export function anchorRect(node: DrawnNode, options?: AnchorOptions): Rect;
+export function anchorRect(
+  node: DrawnNode | null,
+  options?: AnchorOptions,
+): AnchorRect | null;
 
 /** Centre a popup of this size on the node's screen. */
 export function centerRect(
   node: DrawnNode,
   size: { width: number; height: number },
 ): Rect;
+
+/**
+ * The area a popup anchored to this node may be placed in: the usable part
+ * of the monitor it is on — per-monitor, minus the panels, the same answer
+ * `<window width="auto">` is capped by. What a widget sizing its own surface
+ * needs (a menu is never wider than the screen it opens on). `null` where
+ * there is no display to ask, which includes the headless mock.
+ */
+export function anchorArea(node: DrawnNode | null): Rect | null;
 
 /**
  * A node's laid-out rect in screen coordinates — where a popup's *trigger*
@@ -808,7 +847,7 @@ export function screenRect(node: DrawnNode): Rect | null;
 /** `anchorRect` bound to a ref, recomputed on demand. */
 export function useAnchor(
   ref: RefObject<DrawnNode | null>,
-): (options?: AnchorOptions) => Rect | null;
+): (options?: AnchorOptions) => AnchorRect | null;
 
 /**
  * Keeps an `anchorRect` live for as long as `active`, instead of measuring
@@ -823,12 +862,16 @@ export function useAnchor(
  * the popup there — a popup is a real window, not a web element clipped by
  * its ancestors, so following a trigger that is no longer visible would
  * leave it pointing at nothing. Typically `onOutOfView` closes the popup.
+ * With an `at` in the options that test is about the sub-rect: a caret
+ * leaves the viewport long before the editor around it does.
  */
 export function useAnchorTracking(
   ref: RefObject<DrawnNode | null>,
   active: boolean,
-  getOptions: () => AnchorOptions,
-  setRect: (next: Rect | null | ((prev: Rect | null) => Rect | null)) => void,
+  getOptions: () => AnchorOptions | null | undefined,
+  setRect: (
+    next: AnchorRect | null | ((prev: AnchorRect | null) => AnchorRect | null),
+  ) => void,
   onOutOfView?: () => void,
 ): void;
 

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -4,7 +4,7 @@
  * and painted into the owning window. See docs/elements.md.
  */
 
-import type { Ref, ReactNode, Key } from 'react';
+import type { Ref, RefObject, ReactNode, Key } from 'react';
 import type { Color, Cursor, StyleProp } from './style.js';
 import type {
   DrawnNode,
@@ -12,6 +12,7 @@ import type {
   ScrollableNode,
   TextInputNode,
 } from './nodes.js';
+import type { AnchorOptions } from './components.js';
 import type {
   ChangeEvent,
   EventHandlers,
@@ -405,6 +406,40 @@ export interface PopupProps extends WindowProps {
   overrideRedirect?: boolean;
   /** A press landed outside the popup: close it. */
   onDismiss?: (ev: MouseEvent<DrawnNode>) => void;
+  /**
+   * Hang this popup off a node — `anchorRect`'s options plus the node to
+   * measure, and the popup works out its own position from them, ignoring
+   * `x`/`y`.
+   *
+   * What this does that computing a rect in the application cannot: a popup
+   * with an `'auto'` size only knows how big it is *inside* `realize()`,
+   * after the content is measured and before `CreateWindow` — and which side
+   * it flips to and how far it is pulled back from a screen edge are both
+   * functions of that size. So an anchored popup is born the right size in
+   * the right place, and keeps up afterwards with everything that can move
+   * either: the anchor's own layout, an ancestor scrolling, the owner window
+   * being dragged, its own content growing.
+   *
+   * `at` names a rect **inside** the node — a caret, a table cell — so a
+   * completion list follows the line being typed on rather than the editor.
+   * When the anchor scrolls out of view the popup unmaps until it comes
+   * back, since there is no position that points at something invisible;
+   * an app that would rather *close* it does the placement itself with
+   * {@link useAnchorTracking} and its `onOutOfView`.
+   */
+  anchor?: PopupAnchor;
+}
+
+/** A node to anchor to: a ref (the usual — refs attach after the commit
+ *  that renders them) or the node itself. */
+export type AnchorTarget = DrawnNode | RefObject<DrawnNode | null> | null;
+
+export interface PopupAnchor extends Omit<AnchorOptions, 'alignTo'> {
+  /** The node this popup hangs off. */
+  to: AnchorTarget;
+  /** Takes the alignment axis from another node — see
+   *  {@link AnchorOptions.alignTo}. */
+  alignTo?: AnchorTarget;
 }
 
 // --- drawn elements --------------------------------------------------------

--- a/test/popup-anchor.test.js
+++ b/test/popup-anchor.test.js
@@ -1,0 +1,554 @@
+// Anchoring to something smaller than a node, and to a popup whose size is
+// its content's.
+//
+// The case both halves come from is a completion list: a `<popup>` that must
+// open **at the caret** — a moving point inside one element — sized to the
+// rows it happens to have. Neither half is expressible by measuring a node
+// and passing a rect (issue #255): the caret is not the editor, and a popup
+// whose width comes from its labels has no size at the moment React would
+// have to compute a position from one.
+//
+// Headless, so there are no fonts and text measures 0x0 (see AGENTS.md): the
+// rows here are sized boxes. The mock's monitor is 1280x800.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+
+import { createRoot } from '../src/index.js';
+import { anchorRect, useAnchor, useAnchorTracking } from '../src/index.js';
+import { createMockApp } from './helpers/mock-app.js';
+import { setScreensForTests } from '../src/screens.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+/** Poll until `fn()` is truthy, or fail after `ms`. */
+async function waitFor(fn, what, ms = 1000) {
+  const deadline = Date.now() + ms;
+  while (Date.now() < deadline) {
+    if (fn()) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.fail(`timed out waiting for ${what}`);
+}
+
+async function renderMock(app, element) {
+  const x11Root = await createRoot({ app });
+  await new Promise((resolve) => x11Root.render(element, resolve));
+  await tick();
+  await tick();
+  return x11Root;
+}
+
+// --- the geometry ----------------------------------------------------------
+
+/** A stand-in node: a laid-out rect, an owner window, and a monitor. */
+function fakeNode(abs, { win = { x: 100, y: 50 }, monitor } = {}) {
+  const app = {};
+  setScreensForTests(app, {
+    monitors: [{ x: 0, y: 0, width: 1000, height: 800, ...monitor }],
+  });
+  return { abs, root: { window: win }, app };
+}
+
+test('`at` anchors to a rect inside the node, in the node’s coordinates', () => {
+  const editor = fakeNode({ x: 10, y: 20, width: 400, height: 300 });
+  // a caret 40 across and 3 lines down the editor's own content
+  const caret = { x: 40, y: 48, width: 1, height: 16 };
+
+  const at = anchorRect(editor, { at: caret, width: 200, height: 100 });
+  assert.deepStrictEqual(
+    [at.x, at.y],
+    [100 + 10 + 40, 50 + 20 + 48 + 16 + 2],
+    'the owner window, the node, then the caret — and the gap under it',
+  );
+
+  // and without it the whole node is the anchor, which is the popup opening
+  // under the bottom of the editor instead of under the line being typed on
+  const whole = anchorRect(editor, { width: 200, height: 100 });
+  assert.deepStrictEqual([whole.x, whole.y], [100 + 10, 50 + 20 + 300 + 2]);
+});
+
+test('a sub-rect flips and clamps as if it were the node', () => {
+  // an editor filling the screen, with the caret near the bottom of it: what
+  // has to flip is the popup at *the caret*, and the editor's own bottom edge
+  // is nowhere near — anchoring to the node cannot see this at all.
+  const editor = fakeNode(
+    { x: 0, y: 0, width: 1000, height: 780 },
+    { win: { x: 0, y: 0 } },
+  );
+  const size = { width: 200, height: 120 };
+
+  const mid = anchorRect(editor, {
+    at: { x: 20, y: 600, width: 1, height: 16 },
+    ...size,
+  });
+  assert.strictEqual(mid.placement, 'bottom', 'still room under the caret');
+  assert.strictEqual(mid.y, 600 + 16 + 2);
+
+  const low = anchorRect(editor, {
+    at: { x: 20, y: 700, width: 1, height: 16 },
+    ...size,
+  });
+  assert.strictEqual(low.placement, 'top', 'no room under the caret');
+  assert.strictEqual(low.y, 700 - 120 - 2, 'sits above the caret');
+
+  // and the right edge is met by the caret, not by the editor
+  const wide = anchorRect(editor, {
+    at: { x: 950, y: 10, width: 1, height: 16 },
+    ...size,
+  });
+  assert.strictEqual(wide.x, 1000 - 200, 'pulled back onto the screen');
+});
+
+test('an `at` with no size is a point, and is what `width` then defaults to', () => {
+  const node = fakeNode(
+    { x: 0, y: 0, width: 400, height: 300 },
+    {
+      win: { x: 0, y: 0 },
+    },
+  );
+  const point = anchorRect(node, { at: { x: 30, y: 40 }, height: 50 });
+  assert.deepStrictEqual(
+    [point.x, point.y, point.width],
+    [30, 40 + 0 + 2, 0],
+    'zero-sized: the gap is measured from the point itself',
+  );
+});
+
+test('`align` reads the sub-rect too', () => {
+  const node = fakeNode(
+    { x: 0, y: 0, width: 400, height: 300 },
+    {
+      win: { x: 0, y: 0 },
+    },
+  );
+  const cell = { x: 100, y: 20, width: 80, height: 24 };
+  const centred = anchorRect(node, {
+    at: cell,
+    align: 'center',
+    width: 40,
+    height: 30,
+  });
+  assert.strictEqual(centred.x, 100 + (80 - 40) / 2, 'centred on the cell');
+});
+
+// --- tracking a caret ------------------------------------------------------
+
+/**
+ * The shape the completion popup takes at the widget layer: a rect measured
+ * once on open and tracked after, with `at` naming the caret.
+ */
+function CaretPopup({ editorRef, caret, popupRef, onClose }) {
+  const measure = useAnchor(editorRef);
+  const [rect, setRect] = React.useState(null);
+  const getOptions = () => ({ at: caret, width: 120, height: 60 });
+
+  React.useLayoutEffect(() => {
+    const next = measure(getOptions());
+    if (next) setRect(next);
+  }, [caret.x, caret.y]);
+
+  useAnchorTracking(editorRef, true, getOptions, setRect, onClose);
+
+  return (
+    rect &&
+    h('popup', {
+      ref: popupRef,
+      x: rect.x,
+      y: rect.y,
+      width: rect.width,
+      height: rect.height,
+    })
+  );
+}
+
+test('tracking follows a caret that moves inside a still node', async () => {
+  const app = createMockApp();
+  const editorRef = React.createRef();
+  const popupRef = React.createRef();
+
+  const Scene = ({ caret }) =>
+    h(
+      'window',
+      { width: 300, height: 200 },
+      h('box', { ref: editorRef, style: { margin: 10, flexGrow: 1 } }),
+      h(CaretPopup, { editorRef, caret, popupRef }),
+    );
+
+  const x11Root = await renderMock(
+    app,
+    h(Scene, { caret: { x: 20, y: 30, width: 1, height: 16 } }),
+  );
+  assert.deepStrictEqual(
+    [popupRef.current.x, popupRef.current.y],
+    [10 + 20, 10 + 30 + 16 + 2],
+    'the caret inside the editor, not the editor',
+  );
+
+  // typing moves the caret; nothing about the node's layout changed
+  await new Promise((resolve) =>
+    x11Root.render(
+      h(Scene, { caret: { x: 64, y: 46, width: 1, height: 16 } }),
+      resolve,
+    ),
+  );
+  await tick();
+  assert.deepStrictEqual(
+    [popupRef.current.x, popupRef.current.y],
+    [10 + 64, 10 + 46 + 16 + 2],
+    'the popup followed it',
+  );
+
+  await x11Root.unmount();
+});
+
+test('out of view is the caret’s, not the node’s', async () => {
+  const app = createMockApp();
+  const editorRef = React.createRef();
+  const popupRef = React.createRef();
+  const closed = { current: 0 };
+
+  // a scrolling viewport with a tall document in it: the document node stays
+  // firmly on screen while its own lines scroll away underneath
+  const Scene = ({ caret }) =>
+    h(
+      'window',
+      { width: 300, height: 200 },
+      h(
+        'box',
+        { style: { overflow: 'scroll', height: 100 } },
+        h('box', { ref: editorRef, style: { height: 600 } }),
+      ),
+      h(CaretPopup, {
+        editorRef,
+        caret,
+        popupRef,
+        onClose: () => closed.current++,
+      }),
+    );
+
+  const caret = { x: 20, y: 30, width: 1, height: 16 };
+  const x11Root = await renderMock(app, h(Scene, { caret }));
+  const scroller = app.windows[0]._reactX11Node.children.find((n) =>
+    n.isScroller?.(),
+  );
+  assert.ok(scroller, 'scroll box mounted');
+  assert.strictEqual(closed.current, 0, 'the caret is in view to start with');
+
+  // the document is 600 tall in a 100 viewport, so this leaves the *node*
+  // very much on screen — and the caret's line 200px above the viewport
+  scroller.scrollTo({ y: 260 });
+
+  await waitFor(
+    () => closed.current > 0,
+    'the popup being told its caret had gone',
+  );
+
+  await x11Root.unmount();
+});
+
+// --- a popup that sizes itself ---------------------------------------------
+
+/** The whole completion-popup pattern: anchored at a caret, sized by its
+ *  rows, capped, with no measurement in the application at all. */
+function Completions({ editorRef, caret, rows, popupRef, maxHeight = 200 }) {
+  return h(
+    'popup',
+    {
+      ref: popupRef,
+      anchor: { to: editorRef, at: caret, placement: 'bottom' },
+      grab: true,
+      maxHeight,
+    },
+    h(
+      'box',
+      { style: { overflow: 'scroll', padding: 4 } },
+      ...rows.map((label, i) =>
+        h('box', { key: label, style: { width: 40 + i * 30, height: 20 } }),
+      ),
+    ),
+  );
+}
+
+/** A scene whose popup only opens on the second render, which is what an
+ *  application does: the trigger is laid out by the time it is anchored to. */
+function completionScene(app, { editorStyle } = {}) {
+  const editorRef = React.createRef();
+  const popupRef = React.createRef();
+  const Scene = ({ open, caret, rows = ['a'], maxHeight }) =>
+    h(
+      'window',
+      { width: 400, height: 300 },
+      h('box', {
+        ref: editorRef,
+        style: { margin: 20, flexGrow: 1, ...editorStyle },
+      }),
+      open && h(Completions, { editorRef, caret, rows, popupRef, maxHeight }),
+    );
+  return { editorRef, popupRef, Scene };
+}
+
+test('an anchored popup is born at its content’s size, in the right place', async () => {
+  const app = createMockApp();
+  const { Scene } = completionScene(app);
+  const caret = { x: 30, y: 40, width: 1, height: 16 };
+
+  const x11Root = await renderMock(app, h(Scene, { open: false, caret }));
+  assert.strictEqual(app.windows.length, 1, 'no popup yet');
+
+  await new Promise((resolve) =>
+    x11Root.render(h(Scene, { open: true, caret, rows: ['a', 'b'] }), resolve),
+  );
+  await tick();
+
+  const popup = app.windows[1];
+  // 4 + max(40, 70) + 4 across, 4 + 20 + 20 + 4 down: the content's own size
+  assert.deepStrictEqual([popup.width, popup.height], [78, 48]);
+  // the editor is at (20, 20) in the window, the caret 30 across and 40 down
+  // it, and the popup a 2px gap under the caret's line
+  assert.deepStrictEqual(
+    [popup.x, popup.y],
+    [20 + 30, 20 + 40 + 16 + 2],
+    'placed from the size it had just measured',
+  );
+  assert.deepStrictEqual(
+    popup.calls.filter(([op]) => op === 'move'),
+    [],
+    'born there rather than moved there — nothing to see flash',
+  );
+
+  await x11Root.unmount();
+});
+
+test('growing content re-places an anchored popup', async () => {
+  const app = createMockApp();
+  const { popupRef, Scene } = completionScene(app);
+  // a short screen, and a caret low on it: two rows fit under the caret and
+  // six do not — which is a fact about the popup's own size, so nothing
+  // outside the popup could have decided it.
+  setScreensForTests(app, {
+    monitors: [{ x: 0, y: 0, width: 1280, height: 300 }],
+  });
+  const caret = { x: 10, y: 200, width: 1, height: 16 };
+
+  const x11Root = await renderMock(
+    app,
+    h(Scene, { open: true, caret, rows: ['a', 'b'] }),
+  );
+  assert.strictEqual(popupRef.current.height, 4 + 2 * 20 + 4);
+  assert.strictEqual(popupRef.current.y, 20 + 200 + 16 + 2, 'below the caret');
+
+  await new Promise((resolve) =>
+    x11Root.render(
+      h(Scene, { open: true, caret, rows: ['a', 'b', 'c', 'd', 'e', 'f'] }),
+      resolve,
+    ),
+  );
+  await waitFor(
+    () => popupRef.current.height === 4 + 6 * 20 + 4,
+    `the popup growing to its rows (got ${popupRef.current.height})`,
+  );
+  assert.strictEqual(
+    popupRef.current.y,
+    20 + 200 - (4 + 6 * 20 + 4) - 2,
+    'and flipping above the caret, which only its own size could decide',
+  );
+
+  await x11Root.unmount();
+});
+
+test('maxHeight caps the content, and the rows scroll inside the cap', async () => {
+  const app = createMockApp();
+  const { popupRef, Scene } = completionScene(app);
+  const caret = { x: 10, y: 20, width: 1, height: 16 };
+
+  const x11Root = await renderMock(
+    app,
+    h(Scene, {
+      open: true,
+      caret,
+      maxHeight: 60,
+      rows: ['a', 'b', 'c', 'd', 'e', 'f'],
+    }),
+  );
+  assert.strictEqual(popupRef.current.height, 60, 'capped');
+  assert.strictEqual(popupRef.current.y, 20 + 20 + 16 + 2, 'and still below');
+  // the width is still the content's: a cap on one axis is not a cap on the
+  // other, and `overflow: 'scroll'` shrinking to a bound it was not given
+  // would be a menu narrower than its own labels
+  assert.strictEqual(popupRef.current.width, 4 + 190 + 4);
+
+  const list = popupRef.current._reactX11Node.children[0];
+  assert.ok(list.isScroller?.(), 'the rows are in a scrolling box');
+  assert.ok(
+    list.contentHeight > list.abs.height,
+    `the overflow is the scroll (${list.contentHeight} in ${list.abs.height})`,
+  );
+
+  await x11Root.unmount();
+});
+
+test('an anchored popup follows the node it hangs off', async () => {
+  const app = createMockApp();
+  const editorRef = React.createRef();
+  const popupRef = React.createRef();
+  const caret = { x: 10, y: 10, width: 1, height: 16 };
+
+  const Scene = ({ spacer }) =>
+    h(
+      'window',
+      { width: 300, height: 300 },
+      h('box', { style: { height: spacer } }),
+      h('box', { ref: editorRef, style: { width: 200, height: 100 } }),
+      h(Completions, { editorRef, caret, rows: ['a'], popupRef }),
+    );
+
+  const x11Root = await renderMock(app, h(Scene, { spacer: 0 }));
+  const before = popupRef.current.y;
+
+  await new Promise((resolve) =>
+    x11Root.render(h(Scene, { spacer: 40 }), resolve),
+  );
+  await waitFor(
+    () => popupRef.current.y === before + 40,
+    `the popup following the editor down (got ${popupRef.current.y})`,
+  );
+
+  await x11Root.unmount();
+});
+
+test('an anchored popup unmaps while its anchor is out of view', async () => {
+  const app = createMockApp();
+  const editorRef = React.createRef();
+  const popupRef = React.createRef();
+  const caret = { x: 10, y: 30, width: 1, height: 16 };
+
+  const Scene = () =>
+    h(
+      'window',
+      { width: 300, height: 200 },
+      h(
+        'box',
+        { style: { overflow: 'scroll', height: 100 } },
+        h('box', { ref: editorRef, style: { height: 600 } }),
+      ),
+      h(Completions, { editorRef, caret, rows: ['a'], popupRef }),
+    );
+
+  const x11Root = await renderMock(app, h(Scene));
+  const scroller = app.windows[0]._reactX11Node.children.find((n) =>
+    n.isScroller?.(),
+  );
+  assert.strictEqual(popupRef.current.mapped, true, 'up to start with');
+
+  scroller.scrollTo({ y: 260 });
+  await waitFor(
+    () => popupRef.current.mapped === false,
+    'the popup going away with the line it points at',
+  );
+  assert.strictEqual(popupRef.current.grabbed, false, 'and letting go');
+
+  scroller.scrollTo({ y: 0 });
+  await waitFor(
+    () => popupRef.current.mapped === true,
+    'and coming back when it returns',
+  );
+  assert.strictEqual(
+    popupRef.current.grabbed,
+    true,
+    're-grabbed: X drops a grab whose window stops being viewable',
+  );
+  assert.strictEqual(
+    popupRef.current.y,
+    30 + 16 + 2,
+    'back where it belongs, not where it was',
+  );
+
+  await x11Root.unmount();
+});
+
+test('a popup whose anchor has not attached yet waits rather than flashing', async () => {
+  const app = createMockApp();
+  const editorRef = React.createRef();
+  const popupRef = React.createRef();
+
+  // the popup is written **above** its own trigger, so the ref is still
+  // empty in the commit phase the popup realizes in
+  const Scene = () =>
+    h(
+      'window',
+      { width: 300, height: 200 },
+      h(Completions, {
+        editorRef,
+        caret: { x: 10, y: 10, width: 1, height: 16 },
+        rows: ['a'],
+        popupRef,
+      }),
+      h('box', {
+        ref: editorRef,
+        style: { margin: 30, width: 100, height: 40 },
+      }),
+    );
+
+  const app11Root = await createRoot({ app });
+  await new Promise((resolve) => app11Root.render(h(Scene), resolve));
+  const popup = app.windows[1];
+  assert.strictEqual(
+    popup.mapped,
+    false,
+    'not on screen while there is nothing to point at',
+  );
+
+  await tick();
+  await tick();
+  assert.strictEqual(popup.mapped, true, 'and up once the ref has attached');
+  assert.deepStrictEqual(
+    [popup.x, popup.y],
+    [30 + 10, 30 + 10 + 16 + 2],
+    'in the right place the first time it is seen',
+  );
+
+  await app11Root.unmount();
+});
+
+test('an anchored popup ignores x/y props', async () => {
+  const app = createMockApp();
+  const editorRef = React.createRef();
+  const popupRef = React.createRef();
+
+  const Scene = ({ x }) =>
+    h(
+      'window',
+      { width: 300, height: 200 },
+      h('box', {
+        ref: editorRef,
+        style: { margin: 10, width: 100, height: 40 },
+      }),
+      h(
+        'popup',
+        {
+          ref: popupRef,
+          x,
+          y: 900,
+          width: 50,
+          height: 20,
+          anchor: { to: editorRef },
+        },
+        h('box', { style: { flexGrow: 1 } }),
+      ),
+    );
+
+  const x11Root = await renderMock(app, h(Scene, { x: 700 }));
+  assert.deepStrictEqual(
+    [popupRef.current.x, popupRef.current.y],
+    [10, 10 + 40 + 2],
+    'the anchor decides, not the props',
+  );
+
+  await new Promise((resolve) => x11Root.render(h(Scene, { x: 42 }), resolve));
+  await tick();
+  assert.strictEqual(popupRef.current.x, 10, 'and keeps deciding');
+
+  await x11Root.unmount();
+});

--- a/test/popup-chrome.test.js
+++ b/test/popup-chrome.test.js
@@ -11,6 +11,7 @@ import React from 'react';
 import { createRoot, MenuBar, Select, Tooltip } from '../src/index.js';
 import { resolveTheme } from '../src/components/theme.js';
 import { setCompositingForTests } from '../src/compositing.js';
+import { setScreensForTests } from '../src/screens.js';
 import { createMockApp, moveMouse, pressButton } from './helpers/mock-app.js';
 
 const h = React.createElement;
@@ -316,9 +317,10 @@ async function showTip(
 ) {
   const app = createMockApp();
   setCompositingForTests(app, composited);
-  // the mock models no screen geometry, and `anchorRect` reads that as "no
-  // edge to flip at" — a test about which side a hint takes has to say
-  if (screen) Object.assign(app.X.display.screen[0], screen);
+  // the mock's monitor is a roomy 1280x800, and which side a hint takes is a
+  // question about how much room there is — a test about that has to say
+  if (screen)
+    setScreensForTests(app, { monitors: [{ x: 0, y: 0, ...screen }] });
   const x11Root = await createRoot({ app });
   x11Root.render(
     h(
@@ -344,7 +346,7 @@ async function showTip(
   return { app, x11Root, wnd, wrapper, tip: app.windows[1] };
 }
 
-const ROOMY = { pixel_width: 900, pixel_height: 700 };
+const ROOMY = { width: 900, height: 700 };
 
 test('a tooltip is a rounded bubble with an arrow, and no border', async () => {
   const { x11Root, tip } = await showTip({}, { screen: ROOMY });
@@ -439,7 +441,7 @@ test('direction="auto" changes axis when neither top nor bottom fits', async () 
   // moves a popup to an axis it was not asked for.
   const { x11Root, tip } = await showTip(
     {},
-    { screen: { pixel_width: 900, pixel_height: 96 }, pad: 36 },
+    { screen: { width: 900, height: 96 }, pad: 36 },
   );
   const [bubble, arrow] = tip._reactX11Node.children;
 

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -2591,16 +2591,17 @@ test('Slider: thumb stays within the track at both extremes', async () => {
 
 test('anchorRect places, flips at a screen edge and clamps', async () => {
   const { anchorRect } = await import('../src/index.js');
-  // a stand-in node: laid-out rect, owner window position, screen size
-  const node = (
-    abs,
-    win = { x: 100, y: 50 },
-    screen = { pixel_width: 1000, pixel_height: 800 },
-  ) => ({
-    abs,
-    root: { window: win },
-    app: { display: { screen: [screen] } },
-  });
+  const { setScreensForTests } = await import('../src/screens.js');
+  // a stand-in node: laid-out rect, owner window position, and the monitor
+  // it is on — which is what placement flips and clamps against
+  // (`anchorArea`), the same answer an auto-sized window is capped by
+  const node = (abs, win = { x: 100, y: 50 }, screen = [1000, 800]) => {
+    const app = {};
+    setScreensForTests(app, {
+      monitors: [{ x: 0, y: 0, width: screen[0], height: screen[1] }],
+    });
+    return { abs, root: { window: win }, app };
+  };
 
   // default: below the anchor, left edges aligned, in screen coordinates
   const below = anchorRect(node({ x: 10, y: 20, width: 160, height: 30 }), {
@@ -2621,11 +2622,7 @@ test('anchorRect places, flips at a screen edge and clamps', async () => {
 
   // ... but only if there is room above; otherwise it stays below
   const noRoomEither = anchorRect(
-    node(
-      { x: 10, y: 10, width: 160, height: 30 },
-      { x: 0, y: 0 },
-      { pixel_width: 1000, pixel_height: 60 },
-    ),
+    node({ x: 10, y: 10, width: 160, height: 30 }, { x: 0, y: 0 }, [1000, 60]),
     { height: 100 },
   );
   assert.strictEqual(noRoomEither.placement, 'bottom');

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -372,6 +372,34 @@ function Popup() {
   );
 }
 
+// issue #255: a popup that hangs off a node — or off a rect inside one —
+// and sizes itself from its content, so it never states a position at all
+function AnchoredPopup() {
+  const editor = useRef<DrawnNode>(null);
+  const [caret, setCaret] = useState({ x: 0, y: 0, width: 1, height: 16 });
+  return (
+    <window title="editor">
+      <box ref={editor} onClick={() => setCaret({ ...caret, x: caret.x + 7 })} />
+      <popup
+        anchor={{ to: editor, at: caret, placement: 'bottom', align: 'start' }}
+        maxHeight={220}
+      >
+        <box />
+      </popup>
+      {/* the node itself is a target too, and so is the alignment's */}
+      <popup anchor={{ to: editor.current, alignTo: editor, offset: 6 }}>
+        <box />
+      </popup>
+    </window>
+  );
+}
+
+// @ts-expect-error — `at` is a rect, not a pair of screen coordinates
+const _badAt = <popup anchor={{ to: null, at: { left: 1, top: 2 } }} />;
+
+// @ts-expect-error — the anchor has to name what it hangs off
+const _noTarget = <popup anchor={{ placement: 'bottom' }} />;
+
 // issue #130: transientFor takes a ref to a window, a ref to a drawn node, a
 // raw XID or 'root'; a <popup> can opt out of override-redirect to become a
 // WM-managed dialog
@@ -536,7 +564,20 @@ function Widgets() {
     <ThemeProvider value={{ accent: '#2980b9', radius: 6 }} style={s.row}>
       <Themed />
       <box ref={anchorRef} style={s.row}>
-        <Button primary onPress={() => void anchor()}>
+        <Button
+          primary
+          onPress={() => {
+            // the placement options, including a rect inside the node
+            const rect = anchor({
+              placement: 'start',
+              align: 'center',
+              offset: 4,
+              at: { x: 12, y: 4, height: 16 },
+              width: 180,
+            });
+            if (rect) void (rect.placement === 'left');
+          }}
+        >
           press
         </Button>
         <Button label="labelled" disabled />
@@ -821,6 +862,7 @@ async function main() {
   root.render(<Scene />);
   root.render(<RawGl />);
   root.render(<Popup />, () => {});
+  root.render(<AnchoredPopup />);
   root.render(<Events />);
   await root.unmount();
 

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -379,7 +379,10 @@ function AnchoredPopup() {
   const [caret, setCaret] = useState({ x: 0, y: 0, width: 1, height: 16 });
   return (
     <window title="editor">
-      <box ref={editor} onClick={() => setCaret({ ...caret, x: caret.x + 7 })} />
+      <box
+        ref={editor}
+        onClick={() => setCaret({ ...caret, x: caret.x + 7 })}
+      />
       <popup
         anchor={{ to: editor, at: caret, placement: 'bottom', align: 'start' }}
         maxHeight={220}

--- a/website/scripts/check-demos.mjs
+++ b/website/scripts/check-demos.mjs
@@ -170,6 +170,8 @@ const exercises = {
     server.injectButton(3, true);
     server.injectButton(3, false);
   },
+  // a cell in the grid: opens a <popup anchor> at that cell's own rect
+  anchored: (server) => click(server, 0xeef4fb),
 };
 
 // The GLX emulator only has a WebGL backend, so <glarea> cannot draw

--- a/website/src/demos/anchored.js
+++ b/website/src/demos/anchored.js
@@ -1,0 +1,114 @@
+export default {
+  id: 'anchored',
+  title: 'A popup at a point inside a node',
+  description:
+    'A <popup> can hang off a rect *inside* an element — a caret, a cell, a ' +
+    'datapoint — and size itself from its own content. The popup works out ' +
+    'its own position, because with no width given it only learns how big ' +
+    'it is between measuring the content and creating the window: too late ' +
+    'for React to have passed a rect in, and exactly when the flip at a ' +
+    'screen edge needs one. Click a cell.',
+  code: `import React, { useRef, useState } from 'react';
+import { createRoot, createStyles } from 'react-x11';
+
+const COLS = 4;
+const CELL = { width: 92, height: 46 };
+const PAD = 12;
+
+const READINGS = [
+  { name: 'Oslo', note: 'a light frost, and clear' },
+  { name: 'Lisbon', note: 'warm' },
+  { name: 'Reykjavík', note: 'sleet, easing off by the afternoon' },
+  { name: 'Cairo', note: 'hot' },
+  { name: 'Bergen', note: 'rain' },
+  { name: 'Tromsø', note: 'snow, and no light to speak of until ten' },
+  { name: 'Nice', note: 'clear' },
+  { name: 'Porto', note: 'a wind off the sea all day' },
+];
+
+const s = createStyles({
+  root: { flexGrow: 1, padding: 16, gap: 12, backgroundColor: '#f4f6f8' },
+  hint: { fontSize: 12, color: '#7b8794' },
+  grid: {
+    flexDirection: 'row', flexWrap: 'wrap',
+    padding: PAD, gap: 0,
+    alignSelf: 'flex-start',
+    backgroundColor: '#ffffff',
+    borderWidth: 1, borderColor: '#d8dee4', borderRadius: 8,
+  },
+  cell: {
+    width: CELL.width - 2, height: CELL.height - 2,
+    margin: 1,
+    alignItems: 'center', justifyContent: 'center',
+    backgroundColor: '#eef4fb', borderRadius: 4,
+    cursor: 'pointer',
+    ':hover': { backgroundColor: '#dbe7f5' },
+  },
+  cellOpen: { backgroundColor: '#2980b9' },
+  cellLabel: { fontSize: 13, color: '#1f2933' },
+  cellLabelOpen: { color: '#ffffff' },
+  card: {
+    padding: 10, gap: 4,
+    backgroundColor: '#1f2933', borderRadius: 6,
+  },
+  cardTitle: { fontSize: 13, color: '#ffffff' },
+  cardNote: { fontSize: 12, color: '#c7ccd4' },
+});
+
+function App() {
+  const gridRef = useRef(null);
+  const [open, setOpen] = useState(null);
+
+  // the rect of one cell, in the grid's own coordinates — which is all \`at\`
+  // ever wants, and what makes it survive the grid moving or scrolling
+  const cellRect = (i) => ({
+    x: PAD + (i % COLS) * CELL.width,
+    y: PAD + Math.floor(i / COLS) * CELL.height,
+    ...CELL,
+  });
+
+  return (
+    <window x={30} y={30} width={560} height={320} title="anchored popups">
+      <box style={s.root}>
+        <text style={s.hint}>Click a cell: the card opens under that cell,
+          not under the grid, and is as wide as the sentence in it.</text>
+        <box ref={gridRef} style={s.grid}>
+          {READINGS.map((r, i) => (
+            <box
+              key={r.name}
+              style={[s.cell, open === i && s.cellOpen]}
+              onClick={() => setOpen(i)}
+            >
+              <text style={[s.cellLabel, open === i && s.cellLabelOpen]}>
+                {r.name}
+              </text>
+            </box>
+          ))}
+        </box>
+      </box>
+
+      {open !== null && (
+        <popup
+          anchor={{
+            to: gridRef,
+            at: cellRect(open),
+            placement: 'bottom',
+            align: 'center',
+          }}
+          maxWidth={260}
+          grab
+          onDismiss={() => setOpen(null)}
+        >
+          <box style={s.card}>
+            <text style={s.cardTitle}>{READINGS[open].name}</text>
+            <text style={s.cardNote}>{READINGS[open].note}</text>
+          </box>
+        </popup>
+      )}
+    </window>
+  );
+}
+
+createRoot().then((root) => root.render(<App />));
+`,
+};

--- a/website/src/demos/index.js
+++ b/website/src/demos/index.js
@@ -10,6 +10,7 @@ import password from './password.js';
 import tasks from './tasks.js';
 import canvas from './canvas.js';
 import menu from './menu.js';
+import anchored from './anchored.js';
 import three from './three.js';
 
 // Ordered list shown in the playground picker. Each entry:
@@ -32,6 +33,7 @@ const demos = [
   tasks,
   canvas,
   menu,
+  anchored,
   three,
 ];
 


### PR DESCRIPTION
Closes #255.

A completion list is a popup that has to open at a point **inside** one
element and be as wide as the labels it happens to be showing. Both halves
were just outside what anchoring could say, and the gap recurs for every
popup pointed at something smaller than a node — a table cell, a chart
datapoint, the span under a text-range tooltip.

![anchor-below](https://github.com/user-attachments/assets/8bc90111-024e-432c-ab65-0d049181dae9)

## `at` — a rect inside the node

`anchorRect(node, { at })` takes a rect in the node's **own coordinates** and
anchors to that instead of to the node's bounds. Everything downstream reads
it: the side that flips at a screen edge, the edge alignment lines up on, the
gap `offset` leaves, and the rect `useAnchorTracking` keeps in view — which
matters most, because an editor scrolls its own text and the caret leaves the
viewport many screens before the editor does.

Node-relative rather than screen-relative, so the offset survives everything
that moves the node: the window being dragged, an ancestor scrolling, the
node's own layout shifting. `{x, y}` alone is a point.

## `<popup anchor>` — the popup places itself

A popup with no `width` was already sized from its content like any other
window. What it could not do was be *placed*: that size is settled inside
`realize()`, after the content is measured and before `CreateWindow`, and
which side the popup flips to and how far it is pulled back from an edge are
both functions of it — so the first moment the position can be worked out is
already past the last moment React could have passed one in. An app was left
measuring its own labels through `app.fonts` and flipping on a window-relative
guess, because screen geometry was not public either.

So `anchor` takes `anchorRect`'s options plus `to`, and the window works the
position out where the size is known, in the order the natural size already
established: measure, place, create. It is born the right size in the right
place rather than mapped somewhere provisional and corrected a frame later.
Afterwards it follows the anchor's layout, an ancestor scrolling, the owner
window being dragged, and its own content growing a row.

The whole completion list, with no measurement in the application at all:

    <popup anchor={{ to: editorRef, at: caret, placement: 'bottom' }} maxHeight={220}>
      <box style={{ overflow: 'scroll', padding: 4 }}>
        {matches.map((m) => <Row key={m.label} match={m} />)}
      </box>
    </popup>

Below the caret where it fits, above it where it does not — and that is a
fact about the popup's own size, so nothing outside the popup could have
decided it:

![anchor-flipped](https://github.com/user-attachments/assets/cbbd1735-3a1e-4834-a32b-d5cf3cf145ca)

**Out of view is not a position**, so an anchored popup unmaps while its
anchor is gone and comes back where it belongs, with its pointer grab
re-taken (X drops a grab whose window stops being viewable). A ref that has
not attached yet counts the same way, which is what makes a popup written
above its own trigger in the JSX one frame late instead of one frame in the
corner of the screen. Whether it should *close* instead is React state and so
the application's — `useAnchorTracking`'s `onOutOfView` is that seam, and is
unchanged.

## Along the way

The placement math moves to `src/anchor.js`, out of `src/components/`,
because both callers are now on it and only one of them is a widget. They are
the same functions, so a hand-placed popup and a self-placed one cannot
drift.

- Placement flips and clamps against **the usable part of the monitor the
  anchor is on** — Xinerama's per-monitor rect minus `_NET_WORKAREA`, the
  same answer an auto-sized window is capped by — instead of
  `screen.pixel_width`, which is the whole virtual desktop. A menu on a
  two-head desktop used to flip only at the far edge of the *other* monitor.
  `anchorArea(node)` is that rect, now exported: what a surface sizing itself
  needs.
- `AnchorOptions` declared `gap` and `flip`, which never existed, and omitted
  `align`, `offset`, `alignOffset`, `alignTo` and `direction`, which do —
  NEXT_STEPS #120's "wrong in four places". The declaration was the wrong one.

## Checks

`npm test` (13 new cases in `test/popup-anchor.test.js`, each mutation-checked
against the implementation it pins), `npm run lint`, `npm run typecheck`, and
the website's three gates including a new playground demo. The screenshots
above are rendered by this branch's own code against node-x11's in-process X
server.

**BREAKING CHANGE:** `AnchorOptions.gap` and `AnchorOptions.flip` are gone
from the declarations. Neither was ever read — `offset` is the gap, and the
flip is unconditional — so nothing behaves differently, but TypeScript now
says so. Popup placement is bounded by the monitor's work area rather than by
the whole virtual screen, which moves menus and tooltips near a panel or a
monitor seam.

