### PR TITLE
feat(a11y): the accent is not the character — a preedit a screen reader can tell from its commit

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -196,6 +196,38 @@ One honest limit: "line" granularity follows hard newlines, not the soft
 wraps of a `<textarea>`'s layout. Orca still reads everything; a
 line-by-line walk of one long wrapped paragraph is one stop, not several.
 
+### While a composition is open
+
+A dead key or a half-typed Compose sequence puts text on the screen that is
+in nobody's value yet ([events.md](events.md#composition)). The `Text`
+interface answers with **what is drawn**, that preedit included, and its
+offsets index that string — because every geometric answer beside it is
+read off the layout of the same string, and a magnifier tracking character
+3 has to land on the glyph a sighted user sees. `CaretOffset` is at the far
+end of the composition, where the next keystroke of the sequence appears.
+
+Which part of it is uncommitted is said twice, so a reader can act on
+either:
+
+- the preedit is its own **attribute run** — `underline: single`, the
+  registered AT-SPI attribute for what is literally drawn, plus
+  `composition: true`, which is this renderer's own because AT-SPI
+  registers nothing for a preedit;
+- its churn is **`:system`** text — `text-changed:insert:system` when the
+  accent appears, `delete:system` when it changes or is abandoned. That is
+  the suffix Gecko established for a change the user did not type, and it
+  is what lets a reader stay quiet through a composition.
+
+What the sequence **commits** is a plain `insert` of the finished
+character: `é` is what the user typed, and it is spoken, once, as one
+insertion — the same event an ordinary keystroke produces, which is also
+why it is one undo step and not two.
+
+Nothing here is announced through `announce()`. A live-region announcement
+on top of the text-changed feed would have a screen reader say the accent
+twice; an application that wants to narrate composition state can call
+`announce()` itself from `onCompositionUpdate`.
+
 ## The compatibility ladder
 
 `createRoot()` starts one climb per process, off the critical path:
@@ -367,3 +399,8 @@ deterministic.
   Orca's per-keystroke echo of _keys themselves_; typed characters already
   arrive through text-changed events.
 - **Soft-wrap line granularity** in `<textarea>`, per above.
+- **An input method** — dead keys and Compose are the whole composition
+  story today, so a script that needs a candidate window (any CJK) cannot
+  be typed at all, accessibly or otherwise. What an IME would report is
+  already here: the preedit is a text run and its own `:system` feed, so
+  the work left is the input method, not its accessibility.

--- a/docs/events.md
+++ b/docs/events.md
@@ -254,6 +254,11 @@ through.
 A composition is abandoned, never half-committed, when focus leaves, when the
 window loses the keyboard, or when a press puts the caret somewhere else.
 
+A screen reader is told the same story: the preedit is a text run of its
+own and its churn is marked as text the user did not type, so the accent is
+not read out and the character it commits is —
+[accessibility.md](accessibility.md#while-a-composition-is-open).
+
 ### Changing the table
 
 ```js

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -256,6 +256,12 @@ await userEvent.key(XK_SPACE);
 assert.ok(at.since().some((e) => e.type === 'state' && e.state === 'checked'));
 ```
 
+A composition is in there as itself: a dead key logs one `preedit` entry
+(`preedit: "´"`) and no insertion, and the letter that finishes it logs
+`preedit: cleared` and one `insert: "é"` — the same line the bridge draws
+with `:system`, which is how a test catches a screen reader that would echo
+a half-typed accent.
+
 `at.events()` / `at.since()` are precise facts, `at.transcript()` the
 one-line summaries, `at.focusables()` every keyboard stop in Tab order with
 its utterance — a nameless control reads `"(no accessible name)"`, which

--- a/src/a11y.js
+++ b/src/a11y.js
@@ -704,18 +704,55 @@ export const hasTextInterface = (node) =>
  * The code points and caret/selection of anything with a Text interface —
  * offsets in AT-SPI are code points, which is also exactly what
  * TextInputNode's `_chars()`/`_caret` already count.
+ *
+ * The string is the one the control **draws**, an open composition
+ * included, and the offsets are indices into it. That is not a detail of
+ * wording: every geometric answer the Text interface gives — the extents of
+ * character *n*, the offset under a point, where the caret is — is read off
+ * the layout of the displayed string (`_valueLayout`), so reporting the
+ * committed value while a preedit is showing would put a magnifier's
+ * highlight and a braille cursor a preedit's width to the left of the
+ * glyphs they are tracking.
+ *
+ * `preedit` is which part of it is uncommitted — `{ offset, length, text }`
+ * in the same code-point space, or null. It is what lets a reader tell a
+ * composition from the character it commits: the bridge marks the
+ * composition's own churn `:system` and leaves the commit a plain insert
+ * (see `_diffText` in atspi.js).
  */
 export function textStateOf(node) {
   if (isTextControl(node)) {
+    const shown = node._displayValue ? node._displayValue() : null;
+    const toDisplay = (index) => node._displayIndex?.(index) ?? index;
+    const [start, end] = node._selection?.() ?? [0, 0];
+    const preedit = node._preedit ?? '';
     return {
-      chars: node._chars(),
-      caret: node._caret ?? 0,
-      selection: node._selection?.() ?? [0, 0],
+      chars: shown === null ? node._chars() : Array.from(shown),
+      caret: toDisplay(node._caret ?? 0),
+      selection: [toDisplay(start), toDisplay(end)],
+      preedit: preedit
+        ? {
+            offset: node._preeditStart?.() ?? 0,
+            length: Array.from(preedit).length,
+            text: preedit,
+          }
+        : null,
     };
   }
   const spans = node.collectSpans?.([]) ?? [];
   const chars = Array.from(spans.map((s) => s.text).join(''));
-  return { chars, caret: 0, selection: [0, 0] };
+  return { chars, caret: 0, selection: [0, 0], preedit: null };
+}
+
+/**
+ * Whether a `[offset, offset + length)` code-point range lies inside the
+ * composition of a `textStateOf` state — the question that separates a
+ * preedit's own churn from an edit the user made.
+ */
+export function inPreedit(state, offset, length) {
+  const pre = state?.preedit;
+  if (!pre) return false;
+  return offset >= pre.offset && offset + length <= pre.offset + pre.length;
 }
 
 /** Common-prefix/suffix diff of two code-point arrays →

--- a/src/atspi.js
+++ b/src/atspi.js
@@ -54,6 +54,7 @@ import {
   isTextControl,
   hasTextInterface,
   textStateOf,
+  inPreedit,
   diffChars,
 } from './a11y.js';
 import { onApp } from './trace-registry.js';
@@ -249,6 +250,49 @@ const CACHE_DESC = {
 
 function clampOffset(offset, length) {
   return Math.max(0, Math.min(offset | 0, length));
+}
+
+/**
+ * The attribute run around an offset, `[attributes, start, end)`.
+ *
+ * A composition is drawn underlined and `underline` is the only registered
+ * AT-SPI attribute that says so, so that is what the preedit run carries.
+ * `composition` beside it is this renderer's own: AT-SPI registers nothing
+ * for a preedit, and an attribute a reader does not know is one it ignores,
+ * which is a better failure than a run claiming to be nothing special.
+ * Everything outside the composition is one unattributed run, bounded by
+ * the composition's edges so an AT walking runs finds them.
+ */
+function attributeRun(state, offset) {
+  const total = state.chars.length;
+  const at = clampOffset(offset, total);
+  const pre = state.preedit;
+  if (!pre) return [[], 0, total];
+  const start = pre.offset;
+  const end = pre.offset + pre.length;
+  if (at >= start && at < end) {
+    return [
+      [
+        ['underline', 'single'],
+        ['composition', 'true'],
+      ],
+      start,
+      end,
+    ];
+  }
+  return at < start ? [[], 0, start] : [[], end, total];
+}
+
+/**
+ * An offset an AT handed back, in the node's **value** space — what it was
+ * told is the displayed string, composition included. An offset inside the
+ * composition answers where the composition starts: a preedit is one thing,
+ * not a run of characters to put a caret between or edit around.
+ */
+function valueOffset(node, offset) {
+  const { chars } = textStateOf(node);
+  const at = clampOffset(offset, chars.length);
+  return node._valueIndex ? node._valueIndex(at) : at;
 }
 
 const isWordChar = (ch) => /\S/.test(ch);
@@ -580,18 +624,20 @@ const TextImpl = {
   SetCaretOffset(offset) {
     const node = this.n;
     if (typeof node._moveCaret !== 'function') return false;
-    const { chars } = textStateOf(node);
-    node._moveCaret(clampOffset(offset, chars.length), false);
+    node._moveCaret(valueOffset(node, offset), false);
     return true;
   },
-  GetAttributes() {
-    const { chars } = textStateOf(this.n);
-    return [[], 0, chars.length];
+  GetAttributes(offset) {
+    return attributeRun(textStateOf(this.n), offset);
   },
   GetDefaultAttributes() {
     return [];
   },
-  GetAttributeValue() {
+  GetAttributeValue(offset, name) {
+    const [attrs] = attributeRun(textStateOf(this.n), offset);
+    for (const [key, value] of attrs) {
+      if (key === name) return value;
+    }
     return '';
   },
   GetCharacterExtents(offset, coordType) {
@@ -650,12 +696,12 @@ const EditableTextImpl = {
   InsertText(position, text, length) {
     return this.b.editText(this.n, () => {
       const node = this.n;
+      const at = valueOffset(node, position);
       const chars = node._chars();
       const insert = Array.from(String(text)).slice(
         0,
         length < 0 ? undefined : length,
       );
-      const at = clampOffset(position, chars.length);
       chars.splice(at, 0, ...insert);
       node._commit(chars, at + insert.length);
     });
@@ -663,9 +709,11 @@ const EditableTextImpl = {
   DeleteText(start, end) {
     return this.b.editText(this.n, () => {
       const node = this.n;
+      const a = valueOffset(node, start);
+      const b = valueOffset(node, end);
       const chars = node._chars();
-      const s = clampOffset(Math.min(start, end), chars.length);
-      const e = clampOffset(Math.max(start, end), chars.length);
+      const s = Math.min(a, b);
+      const e = Math.max(a, b);
       chars.splice(s, e - s);
       node._commit(chars, s);
     });
@@ -682,8 +730,7 @@ const EditableTextImpl = {
     const node = this.n;
     if (!this.b.editable(node)) return false;
     if (typeof node._pasteFrom !== 'function') return false;
-    const { chars } = textStateOf(node);
-    node._moveCaret?.(clampOffset(position, chars.length), false);
+    node._moveCaret?.(valueOffset(node, position), false);
     node._pasteFrom('CLIPBOARD');
     return true;
   },
@@ -818,8 +865,8 @@ class AtspiBridge {
       text: null,
     };
     if (hasTextInterface(node)) {
-      const { chars, caret, selection } = textStateOf(node);
-      snapshot.text = { chars, caret, selection };
+      const { chars, caret, selection, preedit } = textStateOf(node);
+      snapshot.text = { chars, caret, selection, preedit };
     }
     return snapshot;
   }
@@ -959,9 +1006,8 @@ class AtspiBridge {
 
   setTextSelection(node, start, end) {
     if (!isTextControl(node) || node.destroyed) return false;
-    const { chars } = textStateOf(node);
-    node._anchor = clampOffset(start, chars.length);
-    node._caret = clampOffset(end, chars.length);
+    node._anchor = valueOffset(node, start);
+    node._caret = valueOffset(node, end);
     node._repaint?.();
     return true;
   }
@@ -971,9 +1017,10 @@ class AtspiBridge {
     if (typeof node._copySelection !== 'function') return;
     const caret = node._caret;
     const anchor = node._anchor;
-    const { chars } = textStateOf(node);
-    node._anchor = clampOffset(Math.min(start, end), chars.length);
-    node._caret = clampOffset(Math.max(start, end), chars.length);
+    const a = valueOffset(node, start);
+    const b = valueOffset(node, end);
+    node._anchor = Math.min(a, b);
+    node._caret = Math.max(a, b);
     try {
       node._copySelection('CLIPBOARD');
     } finally {
@@ -1306,24 +1353,40 @@ class AtspiBridge {
     this._diffText(node, before, now);
   }
 
+  /**
+   * The difference as AT-SPI events, with the composition's own churn
+   * marked `:system` — the detail suffix Gecko established for a change the
+   * user did not type, and which at-spi2-core's event dispatch already
+   * parses. A preedit appearing, growing or being abandoned is exactly
+   * that: nothing was typed, a decoration is on the screen.
+   *
+   * The **commit** stays a plain `insert`. `dead_acute` then `e` deletes
+   * the `´` — inside the old preedit, so `delete:system` — and inserts `é`,
+   * which is in no preedit and is what the user actually typed. A reader
+   * that suppresses system text says "é" and nothing else, which is the
+   * distinction this path exists to draw.
+   */
   _diffText(node, before, now) {
     const diff = diffChars(before.chars, now.chars);
     if (diff) {
       if (diff.removed.length > 0) {
+        // what it replaced belonged to the *previous* state's composition
+        const system = inPreedit(before, diff.offset, diff.removed.length);
         this.emitObject(
           node,
           'TextChanged',
-          'delete',
+          system ? 'delete:system' : 'delete',
           diff.offset,
           diff.removed.length,
           ['s', diff.removed.join('')],
         );
       }
       if (diff.inserted.length > 0) {
+        const system = inPreedit(now, diff.offset, diff.inserted.length);
         this.emitObject(
           node,
           'TextChanged',
-          'insert',
+          system ? 'insert:system' : 'insert',
           diff.offset,
           diff.inserted.length,
           ['s', diff.inserted.join('')],

--- a/src/testing/a11y.js
+++ b/src/testing/a11y.js
@@ -54,6 +54,7 @@ import {
   a11yParent,
   hasTextInterface,
   textStateOf,
+  inPreedit,
   diffChars,
 } from '../a11y.js';
 
@@ -393,7 +394,19 @@ export class A11ySpy {
     }
     if (before.text && now.text) {
       const diff = diffChars(before.text.chars, now.text.chars);
-      if (diff && diff.removed.length > 0) {
+      // A composition's own churn is not an edit. A preedit appearing,
+      // growing or being abandoned is one `preedit` entry rather than the
+      // insert and delete it technically is on screen — and what the
+      // sequence finally *commits* stays an ordinary insert, because that
+      // is the character the user typed. The bridge draws the same line
+      // with the `:system` detail suffix; this is the same rule, spoken.
+      const wasComposing = before.text.preedit?.text ?? '';
+      const isComposing = now.text.preedit?.text ?? '';
+      if (
+        diff &&
+        diff.removed.length > 0 &&
+        !inPreedit(before.text, diff.offset, diff.removed.length)
+      ) {
         this._push({
           type: 'text-delete',
           node,
@@ -402,7 +415,22 @@ export class A11ySpy {
           summary: `delete: ${JSON.stringify(diff.removed.join(''))}`,
         });
       }
-      if (diff && diff.inserted.length > 0) {
+      if (isComposing !== wasComposing) {
+        this._push({
+          type: 'preedit',
+          node,
+          text: isComposing,
+          offset: now.text.preedit?.offset ?? before.text.preedit?.offset ?? 0,
+          summary: isComposing
+            ? `preedit: ${JSON.stringify(isComposing)}`
+            : 'preedit: cleared',
+        });
+      }
+      if (
+        diff &&
+        diff.inserted.length > 0 &&
+        !inPreedit(now.text, diff.offset, diff.inserted.length)
+      ) {
         this._push({
           type: 'text-insert',
           node,

--- a/src/testing/index.d.ts
+++ b/src/testing/index.d.ts
@@ -78,6 +78,7 @@ export interface A11ySpyEvent {
     | 'value'
     | 'text-insert'
     | 'text-delete'
+    | 'preedit'
     | 'caret'
     | 'selection'
     | 'announce'
@@ -90,13 +91,15 @@ export interface A11ySpyEvent {
   /** For `state`: the AT-SPI state nick, and whether it turned on. */
   state?: string;
   on?: boolean;
-  /** For `name` / `announce` / `text-*`. */
+  /** For `name` / `announce` / `text-*` / `preedit` — on a `preedit` this
+   * is what the composition now shows, `''` when it was abandoned or has
+   * just committed. */
   name?: string;
   text?: string;
   assertive?: boolean;
   /** For `value`. */
   value?: number;
-  /** For `text-*` / `caret`. */
+  /** For `text-*` / `caret` / `preedit`. */
   offset?: number;
   /** For `selection`. */
   start?: number;

--- a/test/a11y-spy.test.js
+++ b/test/a11y-spy.test.js
@@ -18,6 +18,9 @@ import {
   renderX11,
   userEvent,
   utteranceOf,
+  keysymOf,
+  XK_DEAD_ACUTE,
+  XK_ESCAPE,
   XK_RIGHT,
   XK_SPACE,
 } from '../src/testing/index.js';
@@ -155,6 +158,48 @@ test('typing echoes through text-changed, character by character', async () => {
   assert.deepEqual(inserts, ['h', 'i']);
   // the name is still the placeholder — a value is not a name
   assert.equal(at.focused().utterance, 'Name, entry');
+});
+
+test('a composition is one preedit, then the character it commits', async () => {
+  const { at, getByRole } = await renderX11(h(App), { a11y: true });
+  const input = getByRole('textbox');
+  await userEvent.click(input);
+  at.since(); // the focus that put the caret there
+
+  // The dead key. Something is on the screen and nothing was typed, which
+  // is a distinction a reader has to be able to make: echoing `´` as an
+  // insertion is how a screen reader reads out characters the user never
+  // committed, and saying nothing at all is how it goes silent for anyone
+  // typing an accented language.
+  await userEvent.key(XK_DEAD_ACUTE, { target: input });
+  assert.deepEqual(
+    at.since().map((e) => e.summary),
+    ['preedit: "´"'],
+  );
+  assert.equal(input.value, '', 'the value is untouched while composing');
+
+  // The letter. One insert, of the character the sequence made.
+  await userEvent.key(keysymOf('e'), { target: input });
+  assert.deepEqual(
+    at.since().map((e) => e.summary),
+    ['preedit: cleared', 'insert: "é"'],
+  );
+  assert.equal(input.value, 'é');
+});
+
+test('an abandoned composition is a preedit that inserts nothing', async () => {
+  const { at, getByRole } = await renderX11(h(App), { a11y: true });
+  const input = getByRole('textbox');
+  await userEvent.click(input);
+  await userEvent.key(XK_DEAD_ACUTE, { target: input });
+  at.since();
+
+  await userEvent.key(XK_ESCAPE, { target: input });
+  assert.deepEqual(
+    at.since().map((e) => e.summary),
+    ['preedit: cleared'],
+  );
+  assert.equal(input.value, '');
 });
 
 test('announce() is observable, and reports delivery', async () => {

--- a/test/atspi.test.js
+++ b/test/atspi.test.js
@@ -432,6 +432,109 @@ describe('the AT-SPI bridge', { concurrency: 1, ...needsBroker }, () => {
     );
   });
 
+  test('a composition is system text; the character it commits is not', async () => {
+    const wnd = app.windows[0];
+    const input = wnd._reactX11Node.children[1];
+    // compose in the middle of the value, so a wrong index space shows up
+    // as a wrong offset rather than as the end of the string either way
+    await call(appBus, paths.input, TEXT, 'SetCaretOffset', 'i', [2]);
+    const before = await call(
+      appBus,
+      paths.input,
+      TEXT,
+      'GetText',
+      'ii',
+      [0, -1],
+    );
+    const chars = Array.from(before);
+    signals.length = 0;
+
+    // A dead key. The accent is on the screen and in nobody's value.
+    input.defaultComposition({ type: 'compositionUpdate', data: '´' });
+    await until(
+      () => eventsNamed('TextChanged').length >= 1,
+      'the preedit insert',
+    );
+    assert.deepEqual(
+      eventsNamed('TextChanged').map((s) => [
+        s.body[0],
+        s.body[1],
+        dbus.variantValue(s.body[3]),
+      ]),
+      [['insert:system', 2, '´']],
+      'a preedit is text the user did not type — Gecko\'s ":system" suffix',
+    );
+    assert.equal(input.value, chars.join(''), 'the value did not move');
+
+    // The Text interface answers with what is drawn: an AT tracking the
+    // caret or magnifying character 3 has to land on the glyphs, and the
+    // layout every extent is read from is the layout of *this* string.
+    const composed = [...chars.slice(0, 2), '´', ...chars.slice(2)].join('');
+    assert.equal(
+      await call(appBus, paths.input, TEXT, 'GetText', 'ii', [0, -1]),
+      composed,
+    );
+    assert.equal(
+      await getProp(appBus, paths.input, TEXT, 'CharacterCount'),
+      chars.length + 1,
+    );
+    // the caret is at the far end of the composition, where the next
+    // keystroke of the sequence will appear
+    assert.equal(await getProp(appBus, paths.input, TEXT, 'CaretOffset'), 3);
+
+    // …and which part of it is uncommitted is a text run, not a guess
+    assert.deepEqual(
+      await call(appBus, paths.input, TEXT, 'GetAttributes', 'i', [2]),
+      // `underline` is the registered AT-SPI attribute for what is drawn;
+      // `composition` is this renderer's own, because AT-SPI registers
+      // nothing for a preedit
+      [{ underline: 'single', composition: 'true' }, 2, 3],
+    );
+    assert.deepEqual(
+      await call(appBus, paths.input, TEXT, 'GetAttributes', 'i', [0]),
+      [{}, 0, 2],
+      'the committed text before it is one plain run, bounded by the preedit',
+    );
+    assert.equal(
+      await call(appBus, paths.input, TEXT, 'GetAttributeValue', 'is', [
+        2,
+        'underline',
+      ]),
+      'single',
+    );
+
+    // The commit. The accent leaving is still system text — nothing was
+    // deleted — but `é` is what the user typed, so it is a plain insert and
+    // a reader that suppresses system text still speaks it.
+    signals.length = 0;
+    input.defaultComposition({ type: 'compositionEnd', data: 'é' });
+    await until(
+      () =>
+        eventsNamed('TextChanged').some((s) => s.body[0].startsWith('insert')),
+      'the commit',
+    );
+    assert.deepEqual(
+      eventsNamed('TextChanged').map((s) => [
+        s.body[0],
+        s.body[1],
+        dbus.variantValue(s.body[3]),
+      ]),
+      [
+        ['delete:system', 2, '´'],
+        ['insert', 2, 'é'],
+      ],
+    );
+    assert.equal(
+      await call(appBus, paths.input, TEXT, 'GetText', 'ii', [0, -1]),
+      [...chars.slice(0, 2), 'é', ...chars.slice(2)].join(''),
+    );
+    assert.deepEqual(
+      await call(appBus, paths.input, TEXT, 'GetAttributes', 'i', [2]),
+      [{}, 0, chars.length + 1],
+      'nothing is composing any more',
+    );
+  });
+
   test('a state prop change becomes one precise state-changed event', async () => {
     // reach the checkbox in a fresh render: props flow through commitUpdate
     x11Root.render(


### PR DESCRIPTION
Tier 1 of #272 landed in #276 and put a composition on the screen. It stayed
invisible to everything downstream: `textStateOf` reported the value, so an
open preedit was not *wrong* to a screen reader, it was absent — which is
what the issue's remaining tier-2 item names.

Half of it was already a bug rather than a gap. `characterExtents` and
`offsetAtPoint` read `_valueLayout`, the layout of the **displayed** string,
while their offsets came from the committed value. With a preedit open, a
magnifier tracking character 3 was a preedit's width away from the glyph a
sighted user sees.

### What the Text interface says now

It answers with what is drawn, composition included, and says which part is
uncommitted twice over — so a reader can act on either:

| | |
| --- | --- |
| a **text run** | `underline: single`, the registered AT-SPI attribute for what is literally drawn, plus `composition: true`, this renderer's own because AT-SPI registers nothing for a preedit |
| **`:system`** text | `text-changed:insert:system` when the accent appears, `delete:system` when it changes or is abandoned |

`:system` is the detail suffix Gecko established for a change the user did
not type; at-spi2-core's own event dispatch already parses it.

What the sequence **commits** stays a plain `insert` — `é` is what the user
typed. A reader that suppresses system text stays quiet through the
composition and says the character once, which is the entire distinction the
issue asks for. `CaretOffset` sits at the far end of the composition, where
the next keystroke of the sequence appears.

Offsets an AT hands back are read in the space it was given them, so
`SetCaretOffset`, the selection calls and every `EditableText` edit map
through `_valueIndex`: a point inside a composition answers where the
composition starts, because a preedit is one thing, not a run of characters
to put a caret between.

### Two decisions worth recording

**Nothing is announced.** A live-region `announce()` on top of the
text-changed feed would have a screen reader say the accent twice. An app
that wants to narrate composition state can call `announce()` from
`onCompositionUpdate`; the renderer does not do it behind its back.

**The reported string is the displayed one, not the value.** The alternative
— keep reporting the value and describe the preedit out of band — leaves
every geometric answer beside it wrong, and puts a braille cursor on text
that is not where it is.

### Tests

- `test/atspi.test.js` — over the wire, on the in-process broker: the
  preedit arrives as `insert:system`, `GetText`/`CharacterCount`/`CaretOffset`
  describe the drawn string, `GetAttributes` bounds the composition run, and
  the commit is `delete:system` + a plain `insert`. Composed mid-string on
  purpose, so a wrong index space is a wrong offset rather than the end of
  the string either way.
- `test/a11y-spy.test.js` — real keys through the in-process server:
  `dead_acute` logs one `preedit` entry and no insertion, `e` logs
  `preedit: cleared` and one `insert: "é"`, and Escape abandons with neither.

All three fail against the previous implementation — checked by reverting
`textStateOf` to the committed value, and separately by dropping the
`:system` suffix.

Full suite: 1157 pass. The 6 failures in `appearance.test.js` /
`icons.test.js` are pre-existing on `master` on this macOS host — identical
counts with the branch stashed.

Nothing renders differently, so there is nothing to screenshot.

### What is still open on #272

Tier 3 — an input method, so still no CJK. XIM is a wire protocol and
belongs in ntk the way XEmbed does; the D-Bus route to IBus/Fcitx is the
cheaper candidate and is still unmeasured, which the issue asks be settled
before either is built. What an input method would *report* is now here
either way, so that work is the bus conversation and nothing else.

`docs/accessibility.md` gains the section, and its "deliberately not there
(yet)" list gains the input method.
