### PR TITLE
feat(events)!: the protocol arrives at the window that speaks it — <window onClientMessage>

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,29 @@ no override-redirect staging (issue #4).
   does not, converted from notches to pixels here (#273) — focus/Tab).
   Three ancestor-chain diffs live here and share one shape — `:hover`,
   `:active` over the press chain, and `:focus-within`.
+- `src/clientmessage.js` — `<window onClientMessage>`: the element-scoped
+  seam for the protocols X layers on ClientMessage (EWMH, XEmbed, the system
+  tray), where the alternative was `X.on('event')` over the whole connection
+  — which is what `src/xsettings.js` still does internally, correctly, since
+  a settings daemon's window is nobody's element. Two decisions live there.
+  The type is handed over as the atom's **name**, so a handler is a `switch`
+  over strings rather than an atom table it had to intern first; and because
+  a protocol an application only _receives_ has never named its atoms, an
+  unknown one costs a `GetAtomName` — behind which **every message queues**.
+  That FIFO gate is not optional and `test/client-message.test.js` pins it:
+  the tray's balloon messages and XEmbed's opcodes reassemble by arrival
+  order alone, so a round trip that let a later message overtake an earlier
+  one would corrupt them undetectably. `preventDefault()` is the usual
+  default-action seam, and reaches XDND (`src/dnd.js`), which is the one
+  ClientMessage protocol core answers on the same stream.
+- `src/inputtime.js` — the two selection timestamps, both public since #18's
+  second gap: `lastInputTime(app)` is the last input event's server time,
+  stashed off the event stream because ICCCM wants "the timestamp of the
+  event that caused this" and the causing event is four frames above the code
+  that copies; `serverTime(app)` derives a fresh one for an acquisition no
+  user action caused. The failure they exist to prevent is silent —
+  `CurrentTime` is accepted by the server and leaves two clients racing for a
+  selection unorderable — so neither should ever be `?? 0`-ed at a call site.
 - `src/compose.js` — dead keys and the Compose key (#272): the sequence
   table and the state machine `EventManager` runs between an application's
   `onKeyDown` and the element's `defaultKeyDown`. The dead-key half is

--- a/docs/clipboard.md
+++ b/docs/clipboard.md
@@ -141,6 +141,41 @@ This is also why a `write()` can fail: if another client copied with a newer
 timestamp, the server refuses ours, and the promise rejects rather than
 pretending.
 
+### Owning a selection of your own
+
+The same rule governs every other selection — a system tray takes
+`_NET_SYSTEM_TRAY_S<screen>`, a clipboard manager takes `CLIPBOARD_MANAGER`,
+an input method takes `XIM_SERVERS` — and there the timestamp is yours to
+supply. Both of the values worth supplying are exported:
+
+```jsx
+import { lastInputTime, serverTime, useApp } from 'react-x11';
+
+const app = useApp();
+
+// the user did something, and ICCCM wants that event's own time
+const take = (wid, selection) =>
+  app.X.SetSelectionOwner(wid, selection, lastInputTime(app));
+
+// nothing did — a tray takes its selection when it starts
+const claim = async (wid, selection) =>
+  app.X.SetSelectionOwner(wid, selection, await serverTime(app));
+```
+
+`lastInputTime(app)` is free: it is the timestamp of the last input event
+this connection saw, which is what react-x11 already stamps copies with, and
+what EWMH calls `_NET_WM_USER_TIME`. It is `undefined` before any input has
+arrived.
+
+`serverTime(app)` is one round trip and always answers. Reach for it when
+there is no user action to name — and **do not** write `lastInputTime(app) ??
+0` instead. Zero is `CurrentTime`, which ICCCM 2.1 forbids for exactly the
+reason above: the server accepts it, two clients racing for one selection
+cannot be ordered by it, and the loser is never told it lost.
+
+`serverTime` resolves `0` if the server has not answered within five seconds.
+It never rejects and never hangs.
+
 ## Reaching ntk directly
 
 `useClipboard()` is a thin layer over ntk's `app.clipboard` and adds only the

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -131,6 +131,7 @@ A real X11 window; the flex, paint and event root for its subtree.
 | `transparent`               | 32-bit ARGB visual — rounded, translucent windows (below)                                                                                     |
 | `transientFor`              | ICCCM `WM_TRANSIENT_FOR` — the window this one belongs to (below)                                                                             |
 | `onStatesChange(states)`    | what the window manager actually did                                                                                                          |
+| `onClientMessage(ev)`       | a ClientMessage addressed to this window — EWMH, XEmbed, the tray (below)                                                                     |
 | `theme`                     | palette that `$token` style values resolve against, for this subtree                                                                          |
 
 Windows may be nested inside other windows (real X11 child windows).
@@ -444,6 +445,62 @@ the normal size first.
 
 `alwaysOnTop` falls back to Apple-WM window levels on XQuartz, where
 quartz-wm does not support `_NET_WM_STATE_ABOVE`.
+
+### `onClientMessage` — speaking a protocol of your own
+
+Nearly every convention layered over X11 is carried by ClientMessage: EWMH's
+requests to the window manager, XEmbed, the system tray, and whatever two
+copies of one application agree between themselves. `onClientMessage` is
+every one of them that was addressed to this window.
+
+```jsx
+<window
+  onClientMessage={(ev) => {
+    if (ev.messageType !== '_NET_SYSTEM_TRAY_OPCODE') return;
+    if (ev.data[1] === SYSTEM_TRAY_REQUEST_DOCK) dock(ev.data[2]);
+  }}
+/>
+```
+
+`ev.messageType` is the atom's **name**, which is the point: without it a
+handler has to intern its atoms first and compare numbers, and cannot say
+anything at all until those round trips have landed. `ev.atom` is the id it
+came in as, `ev.format` is 8, 16 or 32, and `ev.data` is the payload at that
+width — 5 values at 32, 10 at 16, 20 at 8.
+
+Nothing has to be armed. A ClientMessage reaches its window's owner whatever
+event mask that window selected, so a `<window>` without the prop pays
+nothing and one with it needs no other setup.
+
+Three things worth knowing:
+
+- **Messages arrive in the order they were sent.** The chunked protocols
+  depend on it — `_NET_SYSTEM_TRAY_BEGIN_MESSAGE` and the
+  `_NET_SYSTEM_TRAY_MESSAGE_DATA` pieces after it reassemble by arrival order
+  and nothing else. Naming a type this connection has never seen costs one
+  `GetAtomName`, and everything behind it waits rather than overtaking it.
+  `messageType` is therefore `null` only for an atom the **server** does not
+  know, which is a broken sender.
+- **It is scoped to the window the message names**, not to the connection —
+  that is the whole difference from `useApp().X.on('event')`, which sees
+  every event for every window and outlives the element. A message aimed at
+  another window, including the EWMH ones sent to the root, does not arrive
+  here; a window manager wants the raw stream for those
+  (`examples/wm-core.js`).
+- **`preventDefault()` stops react-x11 acting on the message itself**, which
+  today means XDND — for a window answering the drag protocol on its own
+  terms. It does not cover the WM close button; `onCloseRequest` is that
+  seam, and it opts into `WM_DELETE_WINDOW` as well as handling it.
+
+Sending is `useApp().X.SendClientMessage(destination, aboutWindow, atom,
+format, data, eventMask)`, or ntk's `window.sendClientMessage(name, data)`
+which interns the atom for you. Note the two window arguments: EWMH messages
+about a window are delivered to the **root**, and messages to another
+application's window pass an event mask of `0`.
+
+Selections are the other half of most of these protocols, and taking one
+needs a timestamp rather than `CurrentTime`:
+[`lastInputTime` and `serverTime`](clipboard.md#owning-a-selection-of-your-own).
 
 ### Kiosk
 

--- a/src/activate.js
+++ b/src/activate.js
@@ -24,7 +24,7 @@
 //
 // See docs/uri-schemes.md. Issue #173.
 
-import { inputTime } from './inputtime.js';
+import { lastInputTime } from './inputtime.js';
 import { liveApps } from './trace-registry.js';
 import { topLevelWindows, windowIdOf } from './windowid.js';
 
@@ -150,7 +150,7 @@ export function activateWindow(target, { timestamp, source } = {}) {
   if (!xid || !root || !X.SendClientMessage || !X.InternAtom) return false;
 
   const when =
-    timestamp === undefined ? (inputTime(app) ?? 0) : (timestamp ?? 0);
+    timestamp === undefined ? (lastInputTime(app) ?? 0) : (timestamp ?? 0);
 
   X.InternAtom(false, ACTIVE_WINDOW, (err, atom) => {
     if (err || !atom) return;

--- a/src/clientmessage.js
+++ b/src/clientmessage.js
@@ -1,0 +1,140 @@
+// ClientMessage, delivered to the element it was addressed to.
+//
+// ClientMessage is the carrier of every convention layered over the core
+// protocol: EWMH's requests to the window manager, ICCCM's WM_PROTOCOLS,
+// XEmbed, XDND, the system tray, and whatever two copies of one application
+// agree between themselves. react-x11 speaks a few of those itself — XDND in
+// `src/dnd.js`, WM_DELETE_WINDOW through ntk's `close` — and an application
+// that speaks one core does not had exactly one route: subscribe to
+// `X.on('event')`, which is every event on the connection for every window,
+// and filter. `src/xsettings.js` does that internally and it is the right
+// shape *there*, because a settings daemon's window is nobody's element. It
+// is the wrong shape to hand an application: it is not scoped to a window,
+// it does not go away when the window unmounts, and it is expressed in atom
+// ids rather than names.
+//
+// So `<window onClientMessage>` is the seam, and this is what fills it.
+//
+// ## The type is a name, and that costs a round trip once
+//
+// `message_type` is an atom, and an atom is a number that means nothing away
+// from the server that issued it. Comparing against one means interning it
+// first, which is asynchronous, so the obvious handler cannot be written as a
+// `switch` — it has to wait for an atom table to arrive before it can tell
+// one message from another, and that table is the boilerplate this seam
+// exists to delete.
+//
+// Most of the time the name is already there: node-x11 keeps a per-connection
+// id → name table filled from every InternAtom and GetAtomName reply, so an
+// atom this application has ever *named* — which is every atom in a protocol
+// it sends, advertises or owns anything for — resolves synchronously and the
+// message is dispatched in the turn it arrived in.
+//
+// A protocol this application only ever *receives* has no such moment, and
+// that case is the whole point of the feature: a tray host does not send
+// `_NET_SYSTEM_TRAY_OPCODE`, it is sent one. So an unknown atom is resolved
+// with `GetAtomName` — and **every message behind it waits**, which is the
+// part that is not optional. The protocols carried this way are chunked
+// (`_NET_SYSTEM_TRAY_BEGIN_MESSAGE` and the `_NET_SYSTEM_TRAY_MESSAGE_DATA`
+// pieces that reassemble by arrival order alone) or sequenced (XEmbed), so a
+// round trip that let a later message overtake an earlier one would corrupt
+// them in a way no handler could detect. The same FIFO gate `src/dnd.js`
+// runs its own messages through, for the same reason.
+//
+// The cost is one round trip per message *type* per connection — node-x11
+// caches the reply, so the second `_NET_SYSTEM_TRAY_OPCODE` is synchronous
+// like everything else. `messageType` is therefore null only for an atom the
+// server itself does not know, which is a broken sender rather than a case to
+// design around; `atom` carries the id regardless.
+
+/** X's event code for ClientMessage, for `ev.type`. */
+const CLIENT_MESSAGE = 33;
+
+/** Per-connection id → name lookups in flight or resolved, negatives kept:
+ * a sender repeating a bogus atom must not repeat the round trip. */
+const nameCaches = new WeakMap();
+
+/** The name of an atom, or a promise for it. Never rejects. */
+function atomName(X, id) {
+  const known = X?.atom_names?.[id];
+  if (known !== undefined) return known;
+  if (typeof X?.GetAtomName !== 'function') return null;
+  let cache = nameCaches.get(X);
+  if (!cache) nameCaches.set(X, (cache = new Map()));
+  const hit = cache.get(id);
+  if (hit) return hit;
+  const pending = new Promise((resolve) =>
+    X.GetAtomName(id, (err, name) => resolve(err ? null : name)),
+  );
+  cache.set(id, pending);
+  return pending;
+}
+
+/**
+ * The stream of ClientMessages for one window: names each message's type and
+ * hands it to `dispatch` in arrival order.
+ *
+ * `dispatch` is the caller's, so the priority and the paint stay with the
+ * other window events in nodes.js; what lives here is the naming and the
+ * ordering it has to preserve.
+ */
+export function createClientMessages(node, dispatch) {
+  let queued = 0;
+  let chain = Promise.resolve();
+
+  /**
+   * The event a handler receives. Not a `SyntheticEvent`: a ClientMessage is
+   * addressed to a *window*, so there is no node under it, nothing to hit
+   * test and no chain to bubble along. Same shape `onResize` has, for the
+   * same reason.
+   */
+  const build = (raw, messageType) => ({
+    type: CLIENT_MESSAGE,
+    messageType,
+    atom: raw.message_type,
+    format: raw.format,
+    data: raw.data,
+    window: node.window,
+    target: node.window,
+    nativeEvent: raw,
+    get defaultPrevented() {
+      return raw.defaultPrevented === true;
+    },
+    preventDefault() {
+      // Marked on the raw event, because what reads it is a second
+      // subscriber to the same ntk stream (`WindowNode._initDnd`) rather
+      // than a later step of this dispatch.
+      raw.defaultPrevented = true;
+    },
+  });
+
+  return {
+    /** Take one raw ntk `'message'` event. */
+    handle(raw) {
+      const name = atomName(node.app?.X, raw.message_type);
+      const settled = name === null || typeof name === 'string';
+      if (queued === 0 && settled) {
+        dispatch(build(raw, name));
+        return;
+      }
+      queued++;
+      chain = chain
+        .then(() => name)
+        .then((resolved) => dispatch(build(raw, resolved)))
+        .catch(() => {}) // a handler throw is already reported by callHandler
+        .then(() => {
+          queued--;
+        });
+    },
+
+    /**
+     * `null` when every message so far has been dispatched, so a default
+     * action can run in the same turn its message arrived in; otherwise the
+     * promise after which it has been — which is what lets `preventDefault()`
+     * still reach XDND on the one message whose type had to be named first.
+     */
+    pending() {
+      return queued === 0 ? null : chain;
+    },
+  };
+}

--- a/src/clipboard.js
+++ b/src/clipboard.js
@@ -15,7 +15,7 @@
 // Everything on the wire is still ntk's. `root.app.clipboard` remains the
 // documented escape hatch for anything this does not cover.
 
-import { inputTime } from './inputtime.js';
+import { lastInputTime } from './inputtime.js';
 import { decodeData, parseUriList, resolveType } from './transfer.js';
 
 /** Ask the owner what it has, so a group name can be resolved against a
@@ -43,7 +43,7 @@ export function createClipboard(app) {
   const opts = ({ selection = 'CLIPBOARD', timeout, time } = {}) => ({
     selection,
     ...(timeout === undefined ? {} : { timeout }),
-    time: time === undefined ? inputTime(app) : time,
+    time: time === undefined ? lastInputTime(app) : time,
   });
 
   return {

--- a/src/foreignnodes.js
+++ b/src/foreignnodes.js
@@ -33,7 +33,7 @@
 import { XEMBED, XEmbedSocket } from 'ntk';
 
 import { isFocusable } from './a11y.js';
-import { inputTime } from './inputtime.js';
+import { lastInputTime } from './inputtime.js';
 import { Node, pixelFor } from './nodes.js';
 
 const px = (v) => Math.max(1, Math.round(v || 0));
@@ -258,7 +258,7 @@ export class ForeignNode extends Node {
   defaultFocus(info) {
     const socket = this.socket;
     if (!socket || !this.client) return;
-    const time = inputTime(this.app);
+    const time = lastInputTime(this.app);
     socket.activate(true, { time });
     const detail =
       info?.reason === 'key'
@@ -276,7 +276,7 @@ export class ForeignNode extends Node {
   defaultBlur() {
     const socket = this.socket;
     if (!socket) return;
-    const time = inputTime(this.app);
+    const time = lastInputTime(this.app);
     if (this._focusSent) {
       socket.send(XEMBED.FOCUS_OUT, 0, 0, 0, { time });
       this._focusSent = false;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -125,8 +125,12 @@ export interface Clipboard {
 /**
  * The ntk connection this tree renders onto — `app.fonts`, `app.cursors`,
  * `app.X` and the rest. Throws outside a tree rendered by `createRoot()`.
+ *
+ * The same type {@link Root.app} has, so what `createRoot()` hands back and
+ * what a component reaches for are one thing; ntk's own surface is behind an
+ * index signature rather than declared here.
  */
-export function useApp(): unknown;
+export function useApp(): NtkApp;
 
 /** The clipboard, scoped to this tree's connection. */
 export function useClipboard(): Clipboard;
@@ -331,6 +335,30 @@ export function launchTimestamp(): number | null;
  * `startupNotification: { completeOn: 'manual' }`.
  */
 export function notifyStartupComplete(): void;
+
+/**
+ * The server timestamp of the last input event this connection saw, or
+ * `undefined` when none has arrived yet.
+ *
+ * ICCCM's "the timestamp of the event that caused this" and EWMH's
+ * `_NET_WM_USER_TIME`, which is what a selection acquired *because the user
+ * did something* has to be stamped with. Never substitute `0` for the
+ * `undefined`: that is `CurrentTime`, which ICCCM 2.1 forbids and which
+ * leaves two clients racing for one selection unable to be ordered. Where
+ * there is no user action to name, {@link serverTime} is the answer.
+ */
+export function lastInputTime(app: NtkApp): number | undefined;
+
+/**
+ * A current timestamp from this connection's server, for an operation no
+ * user action caused — a tray taking its manager selection at startup, say.
+ *
+ * One round trip: there is no request that asks for the time, so this
+ * appends zero bytes to a property on a 1x1 window of ours and reads the
+ * time off the resulting `PropertyNotify`. Resolves `0` (`CurrentTime`) if
+ * the server has not answered within five seconds; never rejects.
+ */
+export function serverTime(app: NtkApp): Promise<number>;
 
 /** A mounted tree, as returned by {@link createRoot}. */
 export interface Root {

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ export { createStyles, flattenStyle } from './styles.js';
 export { windowIdOf, useWindowId, useTopLevelWindow } from './windowid.js';
 export { launchTimestamp, notifyStartupComplete } from './startup.js';
 export { activateWindow } from './activate.js';
+export { lastInputTime, serverTime } from './inputtime.js';
 export {
   onAppActivate,
   onAppOpen,

--- a/src/inputtime.js
+++ b/src/inputtime.js
@@ -1,4 +1,5 @@
-// The server timestamp of the last X input event, per app.
+// The server timestamp of the last X input event, per app — and a way to ask
+// the server for a fresh one when there has not been an input to name.
 //
 // X arbitrates between clients by timestamp, and every selection operation
 // wants one: taking a selection (ICCCM 2.1), converting one (ICCCM 2.4) and
@@ -15,8 +16,26 @@
 // Keyed on the app rather than stored on it: one process can drive several
 // roots on several connections, and a timestamp is only meaningful against
 // the server clock that issued it.
+//
+// ## Why both halves are public
+//
+// react-x11 owns the clipboard, so for a long time nothing outside this file
+// needed either. An application that owns a selection of its own does — a
+// system tray takes `_NET_SYSTEM_TRAY_S<screen>`, a clipboard manager takes
+// `CLIPBOARD_MANAGER`, an input method takes `XIM_SERVERS` — and the choice
+// it faces is exactly the one the two exports name:
+//
+//   - There **was** a user action behind this, and ICCCM wants that event's
+//     own time: `lastInputTime(app)`, free, already stashed.
+//   - There was **not** — a tray acquires its selection when it starts, not
+//     because anyone clicked — so there is no causing event and any current
+//     server time is correct: `await serverTime(app)`, one round trip.
+//
+// Both beat `CurrentTime`, which is the failure this exists to prevent: the
+// server takes it, two clients racing for one selection cannot be ordered by
+// it, and the loser is never told it lost.
 
-const lastInputTime = new WeakMap();
+const lastInput = new WeakMap();
 
 // Motion is deliberately not tracked. Nothing converts or acquires a
 // selection from a motion event — a drag-select owns PRIMARY on the mouseup
@@ -28,18 +47,160 @@ const TRACKED = new Set(['mousedown', 'mouseup', 'keydown', 'keyup']);
 export function noteInputTime(app, name, native) {
   if (!app || !TRACKED.has(name)) return;
   const time = native?.time;
-  if (typeof time === 'number') lastInputTime.set(app, time >>> 0);
+  if (typeof time === 'number') lastInput.set(app, time >>> 0);
 }
 
 /**
  * The last input timestamp seen on this app's connection, or `undefined`
  * when no input has arrived yet.
  *
+ * ```jsx
+ * const app = useApp();
+ * // acquiring PRIMARY because the user just selected something
+ * app.X.SetSelectionOwner(wid, atom, lastInputTime(app));
+ * ```
+ *
+ * This is EWMH's own definition of `_NET_WM_USER_TIME` and ICCCM's "the
+ * timestamp of the event that caused this", so it is the right value for
+ * anything happening *because the user did something* — which includes every
+ * selection a keystroke or a click acquires, and the `_NET_ACTIVE_WINDOW`
+ * request behind {@link activateWindow}.
+ *
  * `undefined` is passed straight through to ntk rather than replaced with a
- * zero: `write()` turns it into a real server timestamp, and CurrentTime is
- * what ICCCM 2.1 forbids. A caller with no event to name should get ntk's
- * fallback, not a made-up number.
+ * zero: ntk's `write()` turns it into a real server timestamp, and
+ * CurrentTime is what ICCCM 2.1 forbids. Elsewhere `undefined` means there
+ * is no user action to name and {@link serverTime} is the answer — a caller
+ * who reaches for `?? 0` has written CurrentTime back in.
  */
-export function inputTime(app) {
-  return app ? lastInputTime.get(app) : undefined;
+export function lastInputTime(app) {
+  return app ? lastInput.get(app) : undefined;
+}
+
+/** ms before `serverTime()` gives up on the round trip. */
+const TIMEOUT = 5000;
+
+/** x11.eventMask.PropertyChange, and PropertyNotify's event code. */
+const PROPERTY_CHANGE_MASK = 4194304;
+const PROPERTY_NOTIFY = 28;
+
+/** ChangeProperty's Append mode, and PropertyNotify's NewValue state. */
+const APPEND = 2;
+const NEW_VALUE = 0;
+
+const TIME_PROPERTY = '_REACT_X11_TIMESTAMP';
+
+/** The 1x1 window and property atom each connection derives times through. */
+const timeSources = new WeakMap();
+
+/**
+ * A current timestamp from this connection's server.
+ *
+ * ```jsx
+ * // a tray taking its manager selection at startup: nothing the user did
+ * // caused this, so there is no event time to use
+ * app.X.SetSelectionOwner(manager, selection, await serverTime(app));
+ * ```
+ *
+ * There is no request that just asks for the time, so this is the trick every
+ * X client uses instead: append zero bytes to a property on a window we own
+ * and watch, and read the time off the `PropertyNotify` that generates. One
+ * round trip, no visible side effect — the window is 1x1, never mapped, and
+ * created once per connection.
+ *
+ * Prefer {@link lastInputTime} where a user action caused the operation: it
+ * is free, and ICCCM asks for the causing event's time specifically. Reach
+ * for this where nothing did, and where a stale value would be wrong anyway —
+ * `SetSelectionOwner` is refused outright if the timestamp predates the
+ * current owner's acquisition, so "the last thing the user touched, an hour
+ * ago" is not a safe substitute for "now".
+ *
+ * Resolves `0` — CurrentTime — if the server has not answered within five
+ * seconds, or if this app has no connection to ask. Never rejects and never
+ * hangs: a caller stuck waiting for a timestamp is worse than one told the
+ * connection is not answering.
+ */
+export async function serverTime(app) {
+  const X = app?.X;
+  const source = await timeSource(app);
+  if (!source) return 0;
+  return new Promise((resolve) => {
+    const done = (time) => {
+      clearTimeout(timer);
+      X.removeListener('event', onEvent);
+      resolve(time);
+    };
+    const onEvent = (ev) => {
+      if (
+        ev.type === PROPERTY_NOTIFY &&
+        ev.wid === source.window &&
+        ev.atom === source.atom &&
+        ev.state === NEW_VALUE
+      ) {
+        done(ev.time >>> 0);
+      }
+    };
+    const timer = setTimeout(() => done(0), TIMEOUT);
+    timer.unref?.();
+    X.on('event', onEvent);
+    // Appending nothing still rewrites the property, which is what generates
+    // the event; replacing would too, but appending cannot grow the property
+    // however many times this is called.
+    X.ChangeProperty(
+      APPEND,
+      source.window,
+      source.atom,
+      X.atoms.STRING,
+      8,
+      Buffer.alloc(0),
+    );
+  });
+}
+
+/**
+ * The window and atom to bounce a timestamp off, created on first use and
+ * shared by every later call on the same connection.
+ *
+ * Its own window rather than one of the app's: selecting PropertyChange on a
+ * `<window>` would put every property the window manager writes on it — and
+ * `_NET_WM_STATE` changes constantly — through this connection's event stream
+ * for the life of the app, to serve a call that happens once.
+ *
+ * A promise because the property atom has to be interned before anything can
+ * be appended to it; awaiting it is also what keeps two calls racing at
+ * startup from creating two windows. Resolves null on a connection that
+ * cannot do this at all, which is a headless mock rather than any real
+ * server.
+ */
+function timeSource(app) {
+  if (!app || typeof app !== 'object') return null;
+  const cached = timeSources.get(app);
+  if (cached !== undefined) return cached;
+
+  const X = app.X;
+  const root = X?.display?.screen?.[0]?.root;
+  if (
+    root == null ||
+    typeof X.AllocID !== 'function' ||
+    typeof X.CreateWindow !== 'function' ||
+    typeof X.ChangeProperty !== 'function' ||
+    typeof X.on !== 'function'
+  ) {
+    timeSources.set(app, null);
+    return null;
+  }
+
+  const window = X.AllocID();
+  // InputOutput rather than InputOnly: properties are legal on both, but a
+  // 1x1 window that is never mapped costs the same either way, and this is
+  // the shape every other toolkit's timestamp window has.
+  X.CreateWindow(window, root, -100, -100, 1, 1, 0, 0, 1, 0, {
+    eventMask: PROPERTY_CHANGE_MASK,
+  });
+  const pending = new Promise((resolve) => {
+    X.InternAtom(false, TIME_PROPERTY, (err, atom) =>
+      resolve(err || !atom ? null : { window, atom }),
+    );
+  });
+  timeSources.set(app, pending);
+  return pending;
 }

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -46,6 +46,7 @@ import {
   XDND_VERSION,
 } from './dnd.js';
 import { addPendingFrame, clearPendingFrame } from './frames.js';
+import { createClientMessages } from './clientmessage.js';
 import {
   argbVisual,
   compositingActive,
@@ -65,7 +66,7 @@ import { windowIdOf } from './windowid.js';
 import { paintCacheFor } from './paintcache.js';
 import { hooks as traceHooks } from './trace-registry.js';
 import { runWithPriority, DiscreteEventPriority } from './priority.js';
-import { inputTime } from './inputtime.js';
+import { lastInputTime } from './inputtime.js';
 import { armPasteState, canPaste } from './pastestate.js';
 import { ctrlChordLetter } from './keysyms.js';
 import {
@@ -4550,7 +4551,7 @@ export class TextInputNode extends Node {
       // what arbitrates a race with another app copying at the same moment.
       // It also saves ntk a round trip asking the server for one, which on
       // PRIMARY is a round trip per selection-extending keystroke.
-      ?.write(text, { selection, time: inputTime(this.app) })
+      ?.write(text, { selection, time: lastInputTime(this.app) })
       .catch((err) => {
         // Losing the race is now possible rather than theoretical: a real
         // event timestamp can be older than another client's, where the
@@ -4571,7 +4572,7 @@ export class TextInputNode extends Node {
       // ICCCM 2.4: convert with the timestamp of the event that asked for
       // the paste, so an owner that has replaced its data since can tell
       // which value was wanted (ntk >= 5.4.0)
-      ?.read({ selection, time: inputTime(this.app) })
+      ?.read({ selection, time: lastInputTime(this.app) })
       .then((text) => {
         if (!this.destroyed && text) this._insert(text);
       })
@@ -6373,10 +6374,27 @@ export class WindowNode extends Scrollable(Node) {
       .setProperty('XdndAware', [XDND_VERSION], { type: 'ATOM' })
       .catch(() => {});
     wnd.on('message', (ev) => {
-      this._dnd.handleMessage(ev);
-      // a drag *out* of this window gets its XdndStatus/XdndFinished back
-      // on the same channel
-      this._dragSession?.handleMessage(ev);
+      // XDND is a *default action* on a ClientMessage, so it follows the same
+      // rule every other one does: it runs after the application's handler
+      // and is skipped when that handler called `preventDefault()`. That is
+      // the seam for a window answering the drag protocol itself.
+      //
+      // `_attachWindowListeners` subscribed to this stream first, so normally
+      // the flag is already decided by the time this runs. `pending()` is the
+      // exception it cannot cover: a message whose type had to be named with
+      // a round trip is dispatched a few turns later, and answering the drag
+      // before the application has been asked would make `preventDefault()`
+      // depend on whether an atom happened to be cached.
+      const said = this._clientMessages?.pending();
+      const route = () => {
+        if (ev.defaultPrevented) return;
+        this._dnd.handleMessage(ev);
+        // a drag *out* of this window gets its XdndStatus/XdndFinished back
+        // on the same channel
+        this._dragSession?.handleMessage(ev);
+      };
+      if (said) said.then(route);
+      else route();
     });
   }
 
@@ -6742,6 +6760,39 @@ export class WindowNode extends Scrollable(Node) {
     });
     wnd.on('expose', (ev) => {
       this.props.onExpose?.(ev);
+    });
+    // Every ClientMessage addressed to this window (src/clientmessage.js).
+    // Unconditional, unlike the two opt-ins below it: a ClientMessage is
+    // delivered to the window's owner whatever event mask it selected, so
+    // there is nothing to arm and nothing a window without the prop pays.
+    // That in turn means the handler can be read from `props` per message —
+    // the rule every other event here follows — instead of being frozen at
+    // realize time.
+    //
+    // Attached before `_initDnd`'s listener on the same stream, which is what
+    // makes `preventDefault()` able to stop react-x11 answering XDND itself.
+    //
+    // Another client asking this one for something is a user action arriving
+    // by another route, so it lands at the priority — and in the paint — a
+    // click would get: `discrete`, like the WM close below.
+    this._clientMessages = createClientMessages(
+      this,
+      discrete((ev) => {
+        // Read here rather than where the message was taken, since a type the
+        // server had to be asked to name puts a round trip in between and
+        // React may have replaced the handler across it.
+        const handler = this.props.onClientMessage;
+        if (!handler) return;
+        runWithPriority(DiscreteEventPriority, () => {
+          callHandler(this, 'onClientMessage', handler, ev);
+        });
+      }),
+    );
+    wnd.on('message', (raw) => {
+      // A window with no handler takes nothing on the queue and asks the
+      // server for nothing, on a stream that carries every XDND step of a
+      // drag passing over it.
+      if (this.props.onClientMessage) this._clientMessages.handle(raw);
     });
     // What the window manager actually did, which is the other half of the
     // controlled pair — the props say what to ask for, this says what is

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -15,6 +15,7 @@ import type {
 import type { AnchorOptions } from './components.js';
 import type {
   ChangeEvent,
+  ClientMessageEvent,
   EventHandlers,
   MouseEvent,
   ScrollEvent,
@@ -361,6 +362,29 @@ export interface WindowProps
   onStatesChange?: (states: WindowState[]) => void;
   /** The WM close button; opts the window into `WM_DELETE_WINDOW`. */
   onCloseRequest?: (ev: SyntheticEvent<NtkWindow>) => void;
+  /**
+   * Every ClientMessage addressed to this window — the carrier of EWMH,
+   * XEmbed, the system tray, and whatever two copies of one application
+   * agree between themselves.
+   *
+   * `ev.messageType` is the atom's **name**, so a handler is a `switch` over
+   * strings rather than a comparison against ids it had to intern first.
+   * Messages arrive in the order the server sent them, which the chunked
+   * protocols depend on.
+   *
+   * ```jsx
+   * <window onClientMessage={(ev) => {
+   *   if (ev.messageType !== '_NET_SYSTEM_TRAY_OPCODE') return;
+   *   if (ev.data[1] === SYSTEM_TRAY_REQUEST_DOCK) dock(ev.data[2]);
+   * }} />
+   * ```
+   *
+   * react-x11 answers some of these itself: `preventDefault()` stops it
+   * doing so for XDND. Nothing has to be armed — a ClientMessage reaches its
+   * window whatever event mask it selected — so a window without the prop
+   * costs nothing.
+   */
+  onClientMessage?: (ev: ClientMessageEvent) => void;
 }
 
 /**

--- a/src/types/events.d.ts
+++ b/src/types/events.d.ts
@@ -384,3 +384,45 @@ export interface WindowResizeEvent {
   window: NtkWindow;
   target: NtkWindow;
 }
+
+/**
+ * `<window onClientMessage>`: a ClientMessage addressed to this window —
+ * EWMH, XEmbed, the system tray, or a convention two copies of one
+ * application agreed between themselves.
+ *
+ * Not a synthetic event: a ClientMessage is addressed to a *window*, so
+ * there is no node under it, nothing to hit test and no chain to bubble
+ * along. Delivered in arrival order, which the chunked protocols depend on.
+ */
+export interface ClientMessageEvent {
+  /** X event type number (33, ClientMessage). */
+  type: number;
+  /**
+   * The message type atom's **name** — `'_NET_SYSTEM_TRAY_OPCODE'`,
+   * `'_XEMBED'`, `'WM_PROTOCOLS'` — which is what a handler branches on.
+   *
+   * `null` for an atom this connection has never named. An application
+   * acting on a protocol has interned its atoms already, so that is the
+   * passive-observer case rather than a coin flip; {@link atom} is exact
+   * either way.
+   */
+  messageType: string | null;
+  /** The message type atom id, as it arrived. */
+  atom: number;
+  /** How wide the 20 payload bytes are read. */
+  format: 8 | 16 | 32;
+  /** 5 values at format 32, 10 at 16, 20 at 8. */
+  data: number[];
+  /** The window it was delivered to. */
+  window: NtkWindow;
+  target: NtkWindow;
+  /** ntk's raw event. */
+  nativeEvent: unknown;
+  defaultPrevented: boolean;
+  /**
+   * Stop react-x11 acting on this message itself — which today means XDND,
+   * for a window answering the drag protocol on its own terms. It does not
+   * reach the WM close button; `onCloseRequest` is that seam.
+   */
+  preventDefault(): void;
+}

--- a/test/client-message.test.js
+++ b/test/client-message.test.js
@@ -1,0 +1,507 @@
+// `<window onClientMessage>` and the two selection timestamps, against a real
+// server: react-x11 on one connection to node-x11's in-process X server, a
+// plain X client on a second sending the messages. The point of doing it over
+// the wire rather than by emitting on the ntk window is that a ClientMessage's
+// whole promise is that it comes from *another process* — the tray client, the
+// window manager, the other copy of this application.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient, StaticFontSource } from 'ntk';
+
+import { createRoot, lastInputTime, serverTime } from '../src/index.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+
+async function headlessPair() {
+  const server = xserver.createServer({ width: 320, height: 240 });
+  const connect = async () => {
+    const [serverEnd, clientEnd] = xserver.createStreamPair();
+    server.addClientStream(serverEnd);
+    return createClient({
+      stream: clientEnd,
+      fontSource: new StaticFontSource(),
+    });
+  };
+  return { app: await connect(), peer: await connect() };
+}
+
+const settle = (app) =>
+  new Promise((resolve) => app.X.GetInputFocus(() => setImmediate(resolve)));
+
+async function until(app, predicate, what) {
+  for (let i = 0; i < 200; i++) {
+    if (predicate()) return;
+    await settle(app);
+  }
+  assert.fail(`timed out waiting for ${what}`);
+}
+
+const render = (element, root) =>
+  new Promise((resolve) => root.render(element, resolve));
+
+const intern = (X, name) =>
+  new Promise((resolve, reject) =>
+    X.InternAtom(false, name, (err, atom) =>
+      err ? reject(err) : resolve(atom),
+    ),
+  );
+
+/** A ClientMessage from the other client, aimed at the window itself —
+ * event mask 0, which is what a message to another application's window
+ * takes (SubstructureNotify is for the ones aimed at the root). */
+function send(peer, wid, atom, data, format = 32) {
+  peer.X.SendClientMessage(wid, wid, atom, format, data, 0);
+}
+
+// --- the seam ---------------------------------------------------------------
+
+test('onClientMessage names the atom and carries the payload', async () => {
+  const { app, peer } = await headlessPair();
+  const root = await createRoot({ app });
+  try {
+    const seen = [];
+    const instance = await render(
+      h('window', {
+        width: 100,
+        height: 80,
+        onClientMessage: (ev) => seen.push(ev),
+      }),
+      root,
+    );
+    // interned on the *peer* only: an application receiving a protocol it
+    // does not send still gets the name, because an atom belongs to the
+    // server rather than to a connection
+    const opcode = await intern(peer.X, '_NET_SYSTEM_TRAY_OPCODE');
+    send(peer, instance.id, opcode, [0, 0, 12345, 0, 0]);
+    await until(app, () => seen.length === 1, 'the message to arrive');
+
+    const ev = seen[0];
+    assert.equal(ev.messageType, '_NET_SYSTEM_TRAY_OPCODE');
+    assert.equal(ev.atom, opcode);
+    assert.equal(ev.type, 33, 'X ClientMessage');
+    assert.equal(ev.format, 32);
+    assert.deepEqual(ev.data, [0, 0, 12345, 0, 0]);
+    assert.equal(ev.window, instance, 'the window it was delivered to');
+    assert.equal(ev.target, instance);
+    assert.equal(ev.defaultPrevented, false);
+    await root.unmount();
+  } finally {
+    await app.close();
+    await peer.close();
+  }
+});
+
+test('a format-8 payload arrives as its 20 bytes', async () => {
+  // The tray's balloon messages are format 8, and a reader that assumed 5
+  // longs would silently truncate them to nothing.
+  const { app, peer } = await headlessPair();
+  const root = await createRoot({ app });
+  try {
+    const seen = [];
+    const instance = await render(
+      h('window', {
+        width: 100,
+        height: 80,
+        onClientMessage: (ev) => seen.push(ev),
+      }),
+      root,
+    );
+    const atom = await intern(peer.X, '_NET_SYSTEM_TRAY_MESSAGE_DATA');
+    const bytes = Array.from({ length: 20 }, (_, i) => 65 + i);
+    send(peer, instance.id, atom, bytes, 8);
+    await until(app, () => seen.length === 1, 'the message to arrive');
+
+    assert.equal(seen[0].format, 8);
+    assert.deepEqual(seen[0].data, bytes);
+    await root.unmount();
+  } finally {
+    await app.close();
+    await peer.close();
+  }
+});
+
+test('an atom the server itself does not know comes through as null', async () => {
+  // The only case left after the round trip: a sender naming an atom that
+  // was never created. `atom` is still exact, so a handler can log it.
+  const { app, peer } = await headlessPair();
+  const root = await createRoot({ app });
+  try {
+    const seen = [];
+    const instance = await render(
+      h('window', {
+        width: 100,
+        height: 80,
+        onClientMessage: (ev) => seen.push(ev),
+      }),
+      root,
+    );
+    const bogus = 0x00ffffff;
+    send(peer, instance.id, bogus, [1, 2, 3, 4, 5]);
+    await until(app, () => seen.length === 1, 'the message to arrive');
+
+    assert.equal(seen[0].messageType, null, 'no name to give');
+    assert.equal(seen[0].atom, bogus, 'the id is still exact');
+    await root.unmount();
+  } finally {
+    await app.close();
+    await peer.close();
+  }
+});
+
+test('messages are delivered in the order they were sent', async () => {
+  // What the chunked protocols depend on: _NET_SYSTEM_TRAY_BEGIN_MESSAGE and
+  // the _NET_SYSTEM_TRAY_MESSAGE_DATA pieces that follow it reassemble by
+  // arrival order and nothing else. Naming an atom this connection has never
+  // seen takes a round trip, and this is the case that says every message
+  // behind it waits rather than overtaking it.
+  const { app, peer } = await headlessPair();
+  const root = await createRoot({ app });
+  try {
+    const seen = [];
+    const instance = await render(
+      h('window', {
+        width: 100,
+        height: 80,
+        onClientMessage: (ev) => seen.push(ev.data[0]),
+      }),
+      root,
+    );
+    // WM_NAME is predefined, so the app connection has it already; the other
+    // two are interned on the peer alone, which is exactly the "a protocol
+    // this application only receives" case — each costs one GetAtomName.
+    const known = app.X.atoms.WM_NAME;
+    const cold = await intern(peer.X, '_ORDERING_COLD');
+    const colder = await intern(peer.X, '_ORDERING_COLDER');
+    assert.equal(app.X.atom_names[cold], undefined, 'genuinely unknown here');
+
+    // interleaved, so a dispatch that let a synchronous message past a
+    // pending lookup would scramble them rather than merely lag
+    const order = [known, cold, known, colder, cold, known, colder, known];
+    order.forEach((atom, i) => send(peer, instance.id, atom, [i, 0, 0, 0, 0]));
+
+    await until(app, () => seen.length === order.length, 'every message');
+    assert.deepEqual(seen, [0, 1, 2, 3, 4, 5, 6, 7]);
+    await root.unmount();
+  } finally {
+    await app.close();
+    await peer.close();
+  }
+});
+
+test('the handler a re-render installed is the one called', async () => {
+  const { app, peer } = await headlessPair();
+  const root = await createRoot({ app });
+  try {
+    const first = [];
+    const second = [];
+    const instance = await render(
+      h('window', {
+        width: 100,
+        height: 80,
+        onClientMessage: (ev) => first.push(ev),
+      }),
+      root,
+    );
+    await render(
+      h('window', {
+        width: 100,
+        height: 80,
+        onClientMessage: (ev) => second.push(ev),
+      }),
+      root,
+    );
+    const atom = await intern(peer.X, '_HANDLER_SWAP');
+    send(peer, instance.id, atom, [1, 0, 0, 0, 0]);
+    await until(app, () => second.length === 1, 'the message to arrive');
+
+    assert.equal(first.length, 0, 'the replaced handler is not called');
+    await root.unmount();
+  } finally {
+    await app.close();
+    await peer.close();
+  }
+});
+
+test('a message is scoped to the window it was addressed to', async () => {
+  // The whole point of the element seam over `X.on("event")`: a nested
+  // <window> hears its own messages and only those.
+  const { app, peer } = await headlessPair();
+  const root = await createRoot({ app });
+  try {
+    const parent = [];
+    const child = [];
+    const childRef = React.createRef();
+    const instance = await render(
+      h(
+        'window',
+        {
+          width: 200,
+          height: 160,
+          onClientMessage: (ev) => parent.push(ev.atom),
+        },
+        h('window', {
+          ref: childRef,
+          width: 40,
+          height: 40,
+          x: 10,
+          y: 10,
+          onClientMessage: (ev) => child.push(ev.atom),
+        }),
+      ),
+      root,
+    );
+    const atom = await intern(peer.X, '_SCOPED_TO_A_WINDOW');
+    send(peer, childRef.current.id, atom, [7, 0, 0, 0, 0]);
+    await until(app, () => child.length === 1, 'the child to hear it');
+
+    assert.deepEqual(child, [atom]);
+    assert.deepEqual(parent, [], 'the parent hears nothing');
+
+    send(peer, instance.id, atom, [8, 0, 0, 0, 0]);
+    await until(app, () => parent.length === 1, 'the parent to hear its own');
+    assert.equal(child.length, 1, 'and the child still hears nothing more');
+    await root.unmount();
+  } finally {
+    await app.close();
+    await peer.close();
+  }
+});
+
+// --- preventDefault, over XDND ----------------------------------------------
+
+/**
+ * The XDND half of a drag source: enough to make react-x11 answer an
+ * XdndPosition with an XdndStatus. A window with no drop targets still
+ * answers — one refusal covering the whole window — which is what makes this
+ * a clean probe for whether core handled the message at all.
+ */
+async function xdndProbe(peer) {
+  const names = ['XdndEnter', 'XdndPosition', 'XdndStatus', 'XdndActionCopy'];
+  const atoms = {};
+  for (const name of names) atoms[name] = await intern(peer.X, name);
+  const wnd = peer.createWindow({ width: 10, height: 10 });
+  const replies = [];
+  peer.X.on('event', (ev) => {
+    if (ev.type === 33 && ev.message_type === atoms.XdndStatus)
+      replies.push(ev);
+  });
+  return {
+    atoms,
+    replies,
+    /** XDND puts the *source* in `data[0]` and the target in the event's own
+     * window field — which is also what ntk routes a `'message'` by, so
+     * getting it backwards delivers to nobody. */
+    drag(target) {
+      send(peer, target, atoms.XdndEnter, [wnd.id, 5 << 24, 0, 0, 0]);
+      send(peer, target, atoms.XdndPosition, [
+        wnd.id,
+        0,
+        (5 << 16) | 5,
+        1,
+        atoms.XdndActionCopy,
+      ]);
+    },
+  };
+}
+
+test('XDND is answered when the handler leaves it alone', async () => {
+  const { app, peer } = await headlessPair();
+  const root = await createRoot({ app });
+  try {
+    const seen = [];
+    const instance = await render(
+      h('window', {
+        width: 100,
+        height: 80,
+        onClientMessage: (ev) => seen.push(ev.messageType),
+      }),
+      root,
+    );
+    const probe = await xdndProbe(peer);
+    probe.drag(instance.id);
+    await until(peer, () => probe.replies.length === 1, 'an XdndStatus back');
+
+    assert.deepEqual(
+      seen,
+      ['XdndEnter', 'XdndPosition'],
+      'the handler saw both, named',
+    );
+    await root.unmount();
+  } finally {
+    await app.close();
+    await peer.close();
+  }
+});
+
+test('preventDefault() stops react-x11 answering XDND itself', async () => {
+  const { app, peer } = await headlessPair();
+  const root = await createRoot({ app });
+  try {
+    const seen = [];
+    const instance = await render(
+      h('window', {
+        width: 100,
+        height: 80,
+        onClientMessage: (ev) => {
+          seen.push(ev.messageType);
+          ev.preventDefault();
+          assert.equal(ev.defaultPrevented, true);
+        },
+      }),
+      root,
+    );
+    const probe = await xdndProbe(peer);
+    probe.drag(instance.id);
+    await until(app, () => seen.length === 2, 'both messages to be seen');
+    // give an XdndStatus every chance to turn up before concluding it never
+    // will: the drop session answers off a promise chain, not inline
+    for (let i = 0; i < 20; i++) {
+      await settle(app);
+      await settle(peer);
+    }
+
+    assert.deepEqual(probe.replies, [], 'core kept out of the conversation');
+    await root.unmount();
+  } finally {
+    await app.close();
+    await peer.close();
+  }
+});
+
+test('preventDefault() still reaches XDND when the type needed naming', async () => {
+  // The case `pending()` exists for. react-x11 interns the XDND atoms itself,
+  // so the drag messages normally resolve synchronously and the flag is set
+  // before the drop session ever sees them; forgetting one puts a round trip
+  // in between. Whether `preventDefault()` works must not depend on that.
+  const { app, peer } = await headlessPair();
+  const root = await createRoot({ app });
+  try {
+    const seen = [];
+    const instance = await render(
+      h('window', {
+        width: 100,
+        height: 80,
+        onClientMessage: (ev) => {
+          seen.push(ev.messageType);
+          ev.preventDefault();
+        },
+      }),
+      root,
+    );
+    const probe = await xdndProbe(peer);
+    await settle(app); // let react-x11's own interning land, then undo it
+    delete app.X.atom_names[probe.atoms.XdndEnter];
+    delete app.X.atom_names[probe.atoms.XdndPosition];
+
+    probe.drag(instance.id);
+    await until(app, () => seen.length === 2, 'both messages to be seen');
+    for (let i = 0; i < 20; i++) {
+      await settle(app);
+      await settle(peer);
+    }
+
+    assert.deepEqual(
+      seen,
+      ['XdndEnter', 'XdndPosition'],
+      'named the slow way, still in order',
+    );
+    assert.deepEqual(probe.replies, [], 'and core still kept out of it');
+    await root.unmount();
+  } finally {
+    await app.close();
+    await peer.close();
+  }
+});
+
+// --- the timestamps ---------------------------------------------------------
+
+test('lastInputTime is the server time the input event carried', async () => {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  try {
+    const instance = await render(h('window', { width: 60, height: 40 }), root);
+    assert.equal(
+      lastInputTime(app),
+      undefined,
+      'no input has arrived, and 0 would be CurrentTime',
+    );
+
+    instance.emit('mousedown', { x: 5, y: 5, keycode: 1, time: 918273 });
+    assert.equal(lastInputTime(app), 918273);
+    instance.emit('keyup', { x: 5, y: 5, keycode: 38, time: 918290 });
+    assert.equal(lastInputTime(app), 918290, 'the latest one wins');
+
+    // motion is deliberately not tracked: nothing acquires a selection from
+    // one, and it would be a write per pointer step
+    instance.emit('mousemove', { x: 6, y: 6, time: 999999 });
+    assert.equal(lastInputTime(app), 918290);
+    await root.unmount();
+  } finally {
+    await app.close();
+  }
+});
+
+test('lastInputTime is per connection', async () => {
+  const a = createMockApp();
+  const b = createMockApp();
+  const rootA = await createRoot({ app: a });
+  const rootB = await createRoot({ app: b });
+  try {
+    const wndA = await render(h('window', { width: 60, height: 40 }), rootA);
+    await render(h('window', { width: 60, height: 40 }), rootB);
+    wndA.emit('mousedown', { x: 1, y: 1, keycode: 1, time: 4242 });
+
+    assert.equal(lastInputTime(a), 4242);
+    assert.equal(lastInputTime(b), undefined, 'another server, another clock');
+    await rootA.unmount();
+    await rootB.unmount();
+  } finally {
+    await a.close();
+    await b.close();
+  }
+});
+
+test('serverTime answers with a real timestamp, and reuses one window', async () => {
+  const { app, peer } = await headlessPair();
+  try {
+    const before = await countWindows(peer, app);
+    const first = await serverTime(app);
+    assert.ok(first > 0, `a real timestamp, got ${first}`);
+
+    const second = await serverTime(app);
+    assert.ok(second >= first, 'the server clock does not go backwards');
+
+    // the 1x1 timestamp window is created once and shared, so a second call
+    // is a round trip and nothing else
+    assert.equal(
+      (await countWindows(peer, app)) - before,
+      1,
+      'one timestamp window for both calls',
+    );
+  } finally {
+    await app.close();
+    await peer.close();
+  }
+});
+
+/** How many children the root has, counted from the other connection. */
+async function countWindows(peer, app) {
+  await settle(app);
+  const root = peer.X.display.screen[0].root;
+  const tree = await new Promise((resolve, reject) =>
+    peer.X.QueryTree(root, (err, res) => (err ? reject(err) : resolve(res))),
+  );
+  return tree.children.length;
+}
+
+test('serverTime resolves CurrentTime where there is nothing to ask', async () => {
+  // A headless mock models no window creation at all, which is the same
+  // answer a torn-down connection gives: 0 rather than a hang.
+  const app = createMockApp();
+  assert.equal(await serverTime(app), 0);
+  assert.equal(await serverTime(null), 0);
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -38,6 +38,7 @@ import {
   NoFileDialogError,
   openFile,
   saveFile,
+  serverTime,
   sessionBus,
   systemBus,
   useApp,
@@ -53,6 +54,7 @@ import {
   createStyles,
   Dialog,
   flattenStyle,
+  lastInputTime,
   launchTimestamp,
   MenuBar,
   notifyStartupComplete,
@@ -228,6 +230,15 @@ function Elements() {
       style={s.root}
       onCloseRequest={() => {}}
       onResize={(ev) => void (ev.resized && ev.width + ev.height)}
+      onClientMessage={(ev) => {
+        // the name is what a handler branches on; null only for an atom the
+        // server itself does not know
+        if (ev.messageType === '_NET_SYSTEM_TRAY_OPCODE') {
+          void (ev.data[1] + ev.data[2]);
+          ev.preventDefault();
+        }
+        void (ev.atom + ev.format + Number(ev.defaultPrevented));
+      }}
     >
       <box
         ref={boxRef}
@@ -917,6 +928,21 @@ function _Clip() {
     void [app, text, rich, png, first, offered];
   }
   void go;
+  return null;
+}
+
+// the two selection timestamps, straight off what useApp() hands back
+function _SelectionTime() {
+  const app = useApp();
+  async function own(wid: number, selection: number) {
+    // there was a user action, so ICCCM wants that event's own time
+    const when: number | undefined = lastInputTime(app);
+    app.X.SetSelectionOwner(wid, selection, when);
+    // and there was not, so ask the server rather than writing CurrentTime
+    const now: number = await serverTime(app);
+    app.X.SetSelectionOwner(wid, selection, now);
+  }
+  void own;
   return null;
 }
 


### PR DESCRIPTION
Closes the two core gaps recorded in [react-x11-components#18](https://github.com/sidorares/react-x11-components/pull/18)'s "Two gaps in core this ran into".

Nearly every convention layered over X11 is carried by ClientMessage — EWMH's requests to the window manager, ICCCM's WM_PROTOCOLS, XEmbed, the system tray, whatever two copies of one application agree between themselves. An application that speaks one had exactly one route into it: subscribe to `X.on('event')`, which is every event on the connection for every window, and filter on `ev.wid`.

```jsx
<window
  onClientMessage={(ev) => {
    if (ev.messageType !== '_NET_SYSTEM_TRAY_OPCODE') return;
    if (ev.data[1] === SYSTEM_TRAY_REQUEST_DOCK) dock(ev.data[2]);
  }}
/>
```

Nothing has to be armed: a ClientMessage reaches its window's owner whatever event mask that window selected, so a `<window>` without the prop pays nothing and one with it needs no other setup.

## Gap 1 — `<window onClientMessage>`

`src/xsettings.js` still listens on the whole connection and filters, and that is right *there* — a settings daemon's window is nobody's element. It is the wrong shape to hand an application: not scoped to a window, not tied to a mount, and expressed in atom ids rather than names.

### Decisions worth reviewing

- **The type is a name.** `ev.messageType` is `'_NET_SYSTEM_TRAY_OPCODE'` rather than a number, so a handler is a `switch` over strings instead of an atom table it had to intern and wait for first. That table is the boilerplate the seam exists to delete. `ev.atom` still carries the id, `ev.format` is 8/16/32 and `ev.data` is the payload at that width.
- **And every message behind an unnamed one waits.** A protocol an application only *receives* has never named its atoms, so the first message of a type costs a `GetAtomName`. The protocols carried this way are chunked (`_NET_SYSTEM_TRAY_BEGIN_MESSAGE` and the `_NET_SYSTEM_TRAY_MESSAGE_DATA` pieces reassemble by arrival order and nothing else) or sequenced (XEmbed), so a round trip that let a later message overtake an earlier one would corrupt them in a way no handler could detect. Same FIFO gate `src/dnd.js` runs its own messages through. `messageType` is therefore `null` only for an atom the **server** does not know, which is a broken sender.
- **`preventDefault()` is the usual default-action seam**, and reaches XDND — the one ClientMessage protocol core answers on the same stream — for a window answering the drag protocol itself. `pending()` is what makes that work on a message whose type needed naming: without it, whether `preventDefault()` took effect would depend on whether an atom happened to be cached. It deliberately does not cover the WM close button, because `onCloseRequest` both opts into `WM_DELETE_WINDOW` and handles it.
- **Not a `SyntheticEvent`.** A ClientMessage is addressed to a window, so there is no node under it, nothing to hit test and no chain to bubble along — the shape `onResize` already has, for the same reason. It is dispatched `discrete`, like the WM close: another client asking this one for something is a user action arriving by another route.
- **The handler is read per message, not frozen at realize time** — unlike `onCloseRequest`/`onStatesChange`, which are opt-ins because subscribing *arms* something. Nothing is armed here, so it follows the ordinary rule, and it is read at dispatch rather than at enqueue because a round trip may sit in between and React may have replaced it across one.

## Gap 2 — the selection timestamps are exported

`lastInputTime(app)` is the last input event's server time — ICCCM's "the timestamp of the event that caused this", already stashed off the event stream because the causing event is four frames above the code that copies. `serverTime(app)` derives a fresh one for an acquisition no user action caused, which is what a tray taking its manager selection at startup has; it is the trick #18's `#timestamp()` had to hand-roll, and it costs one round trip and creates one 1x1 window per connection.

Both are needed because the failure they prevent is silent: `CurrentTime` is accepted by the server, two clients racing for one selection cannot be ordered by it, and the loser is never told it lost. So the documentation is explicit that `lastInputTime(app) ?? 0` puts the footgun straight back.

The window `serverTime` bounces off is its own rather than one of the app's: selecting `PropertyChange` on a `<window>` would route every property the WM writes on it — and `_NET_WM_STATE` changes constantly — through the event stream for the life of the app, to serve a call that happens once.

## Found on the way

- **ntk isolates the atom tables per connection** (`App._isolateAtoms`, ntk 7.5.0), where node-x11 shares `X.atoms` process-wide. That is the right call, and it means a name can only be resolved from the connection that learnt it — which is what makes the `GetAtomName` path load-bearing rather than a fallback nobody reaches. A first attempt read the shared table instead and passed its tests for the wrong reason.
- **ntk routes `'message'` by the event's `window` field**, not by the ClientMessage's destination. So `onClientMessage` is scoped exactly as the protocol intends, and an EWMH message sent to the root about our window does not arrive here — a window manager wants the raw stream for those (`examples/wm-core.js`). Documented rather than worked around. It also cost an hour of a test probe that put the *source* window there, which is how XDND's `data[0]` reads and not how its event field does.

## Tests

`test/client-message.test.js`, 13 tests, react-x11 on one connection to node-x11's in-process X server and a plain X client on a second — over the wire, because a ClientMessage's whole promise is that it comes from another process. Naming, format-8 payloads, an atom the server does not know, arrival order across two cold types, a handler swapped by a re-render, scoping to a nested `<window>`, XDND answered and XDND prevented, and prevented again with the type deliberately un-cached so the round trip is in play. Plus the two timestamps: per connection, motion untracked, and one timestamp window shared by repeated calls.

Two of them were checked against their own premise the way `test/dirty-rect.test.js` does — the ordering test fails with the FIFO gate removed, and the deferred-`preventDefault` test fails with `pending()` stubbed to null — because both would otherwise pass on the fast path alone.

Suite is 1171 green; the two failures on this machine (`textinput ink`, `<tex> formula ink`) are fontconfig-related and fail identically on `master`. `npm run lint`, `npm run typecheck` and the three `website/` gates all pass.

## Breaking

`useApp()` is typed as `NtkApp` rather than `unknown` — the same type `Root.app` already had. `lastInputTime(useApp())` does not compile otherwise, so the declarations had to agree; a call site that leant on the `unknown` needs its cast removed. Nothing in the runtime changes.
