### PR TITLE
perf(text): only the lines on screen, and all of them in one request

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -931,6 +931,15 @@ onDraw>`, `value`, `placeholder`. `children` and event handlers are
   needle was skipping clips nobody needed, because each of those rebuilt an a8
   mask. Measure a change in wall clock or in Composite pixels before optimising
   a request count — `npm run bench` reports both for that reason.
+- **A clip bounds the pixels, not the drawing.** Anything drawn per line, per
+  row or per cell has to be culled to the viewport by the code that draws it:
+  the clip discards what falls outside, but only after the request has been
+  built, sent and turned into a masked composite. `<textarea>` drew a fill
+  per selected line, so Ctrl+A in a 400-line value cost 422 requests to light
+  the seven lines on screen; drawing only the visible ones — and drawing them
+  as one `ctx.fillRects` batch (ntk >= 7.6, one `Render.FillRectangles`) —
+  made it 25, and flat in the size of the value. `test/selection-batch.test.js`
+  measures the two sizes against each other rather than pinning a number.
 - **Interpolate colours premultiplied.** `transparent` is _black_ at zero
   alpha, so lerping the four straight channels drags every fade-in towards
   black on the way: half way from `transparent` to a near-white hover fill

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -1184,6 +1184,19 @@ conical, `setLineDash`, round caps/joins, images, text — XRender-backed),
 translated to the node's origin and clipped to its bounds. `onDraw` runs on
 every repaint of the window.
 
+A drawing made of many small rectangles in one colour — a sparkline, a heat
+map, row striping, terminal cells — has a batch primitive, and the
+difference is a whole frame's worth of requests:
+
+```jsx
+ctx.fillStyle = theme.accent;
+ctx.fillRects(bars); // [[x, y, w, h], …] or one flat [x, y, w, h, x, …]
+```
+
+`fillRects` is `fillRect` per rectangle — the same fill style, alpha,
+composite op and clip — sent as a single `Render.FillRectangles` where the
+loop would have sent one composite each.
+
 ### `cacheKey` — draw it once
 
 A drawing that does not change between frames does not have to be redrawn

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -337,6 +337,11 @@ operations. No server, no connection, much faster, and no pixels — good for
 asserting on layout and on the node tree, which is most tests. Input
 injection is not available and says so.
 
+A batch records as the fills it stands for: `ctx.fillRects([[x, y, w, h], …])`
+leaves one `fillRect` operation per rectangle, because the only difference
+between them is a request count and there is no server here to send it to. So
+an assertion on what a drawing painted holds whether or not it batched.
+
 ## Testing Library itself
 
 It does not work here and no shim will fix it: its queries are built on a

--- a/examples/password.jsx
+++ b/examples/password.jsx
@@ -49,11 +49,14 @@ function bars(ctx, { width, height, seed, color }) {
   const step = width / count;
   ctx.fillStyle = color;
   let n = seed >>> 0;
+  const rects = [];
   for (let i = 0; i < count && i * step < width; i++) {
     n = (n * 1103515245 + 12345) >>> 0;
     const h = 2 + ((n >>> 16) % Math.max(2, height - 2));
-    ctx.fillRect(i * step, height - h, Math.max(1, step - 2), h);
+    rects.push(i * step, height - h, Math.max(1, step - 2), h);
   }
+  // bars in one colour are one request, not one each
+  ctx.fillRects(rects);
 }
 
 /** The panel, without a window round it, so examples/app.jsx can show it in

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^7.5.0",
+        "ntk": "^7.6.0",
         "react-reconciler": "^0.33.0"
       },
       "devDependencies": {
@@ -4034,9 +4034,9 @@
       }
     },
     "node_modules/ntk": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-7.5.0.tgz",
-      "integrity": "sha512-R0GYBAQd/xYcVo5ng6uzNDfLPxIcF+U4+cCupY1f6ynF64IAW1KwBIucFClUNZJPc6ZIZekIhcEKQFr/gnQZZw==",
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-7.6.0.tgz",
+      "integrity": "sha512-VUjWYGmL/0dqizG9f+3zyteq2fY8G/aueY2EuHGXGSWIHH7CFJpzWmRcJvJMuFwa6Y220WxmirpIqF7k2M+aIQ==",
       "license": "MIT",
       "dependencies": {
         "bidi-js": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^7.5.0",
+    "ntk": "^7.6.0",
     "react-reconciler": "^0.33.0"
   },
   "optionalDependencies": {

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -5217,21 +5217,19 @@ export class TextInputNode extends Node {
     const from = layout.caretPosition(start);
     const to = layout.caretPosition(start + Array.from(this._preedit).length);
     ctx.fillStyle = style.color;
-    // a line loop rather than one rectangle, because `<textarea>` shares
-    // this and a composition at a wrap point is two spans
+    // a span per line rather than one rectangle, because `<textarea>` shares
+    // this and a composition at a wrap point is two spans — drawn as one
+    // batch, so the underline costs one request however it wraps
+    const rects = [];
     for (let li = from.line; li <= to.line; li++) {
       const line = layout.lines[li];
       if (!line) break;
       const x0 = li === from.line ? from.x : line.x;
       const x1 = li === to.line ? to.x : line.x + line.width;
       if (x1 <= x0) continue;
-      ctx.fillRect(
-        originX + x0,
-        originY + line.y + line.ascent + 1,
-        x1 - x0,
-        1,
-      );
+      rects.push(originX + x0, originY + line.y + line.ascent + 1, x1 - x0, 1);
     }
+    if (rects.length) ctx.fillRects(rects);
   }
 }
 
@@ -5530,19 +5528,36 @@ export class TextAreaNode extends TextInputNode {
       // Tinting the surface instead leaves the ink's own contrast intact.
       ctx.fillStyle =
         this.props.selectionColor ?? tint(this.theme.accent, 0.35);
-      for (let li = posA.line; li <= posB.line; li++) {
+      // Only the lines on screen, and all of them in one request. Ctrl+A in
+      // a 5000-line value selects 5000 lines and shows twenty: the clip
+      // throws the rest away *after* they have been sent, which is the one
+      // cost a clip cannot save. `indexAt` finds the first visible line
+      // without walking the list to it — conservatively, since an index on a
+      // wrap boundary answers with the line before, and one rect outside the
+      // clip is free where a scan of every line above the viewport is not.
+      const bottom = this._scrollY + content.height;
+      const first = Math.max(
+        posA.line,
+        layout.caretPosition(layout.indexAt(-1e6, this._scrollY)).line,
+      );
+      const rects = [];
+      for (let li = first; li <= posB.line; li++) {
         const line = layout.lines[li];
+        if (!line || line.y > bottom) break;
         const x0 = li === posA.line ? posA.x : line.x;
         const x1 = li === posB.line ? posB.x : line.x + line.width;
         // a selected bare newline still shows as a sliver
         const w = Math.max(x1 - x0, 4);
-        ctx.fillRect(
+        rects.push(
           originX + x0,
           originY + line.y,
           w,
           line.ascent + line.descent,
         );
       }
+      // one `Render.FillRectangles` for the whole highlight, where a fill per
+      // line is a full-surface-masked composite per line (ntk >= 7.6)
+      if (rects.length) ctx.fillRects(rects);
     }
 
     layout.draw(ctx, originX, originY);

--- a/src/testing/mock-app.js
+++ b/src/testing/mock-app.js
@@ -156,6 +156,20 @@ export function createMockApp() {
         fillRect(x, y, w, h) {
           ops.push(['fillRect', x, y, w, h, ctx.fillStyle]);
         },
+        // A batch is `fillRect` per rectangle — that is what ntk's own
+        // `fillRects` promises, and the only difference there is the request
+        // count, which a mock with no server does not have. So it records
+        // the fills themselves: an assertion on what was drawn holds whether
+        // the drawing batched or not, and `[x, y, w, h]` quadruples and one
+        // flat list are the same drawing too.
+        fillRects(rects) {
+          const flat = Array.isArray(rects?.[0]) ? rects.flat() : (rects ?? []);
+          for (let i = 0; i + 3 < flat.length; i += 4) {
+            if (flat[i + 2] > 0 && flat[i + 3] > 0) {
+              ctx.fillRect(flat[i], flat[i + 1], flat[i + 2], flat[i + 3]);
+            }
+          }
+        },
         // ntk's context has this beside `fillRect`, so an `onDraw` that
         // outlines a box paints on a real server and used to crash on the
         // mock — a missing method here is an app's headless test failing at

--- a/test/selection-batch.test.js
+++ b/test/selection-batch.test.js
@@ -1,0 +1,194 @@
+// The `<textarea>` selection highlight: what it costs, and what it draws.
+//
+// A selection spans lines and a line is a rectangle, so the drawing that
+// falls out of the geometry is one fill per selected line — every line,
+// whether or not the viewport shows it. Ctrl+A in a 400-line value then
+// sends 400 masked composites to light seven lines of highlight, and the
+// clip throws the other 393 away *after* they have crossed the wire, which
+// is the one cost a clip cannot save.
+//
+// Both halves of the fix are pinned here: the lines the viewport cannot show
+// are never drawn, and the ones it can go out as a single
+// `Render.FillRectangles` (`ctx.fillRects`, ntk >= 7.6). Together they make
+// the highlight cost a constant — which is what the first test measures, by
+// selecting ten times as much text and expecting the same bill.
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { test } from 'node:test';
+import React from 'react';
+
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient, StaticFontSource } from 'ntk';
+
+import { createRoot } from '../src/index.js';
+import { startTrace } from '../src/debug.js';
+
+const require = createRequire(import.meta.url);
+const fontDir = join(
+  dirname(require.resolve('katex/package.json')),
+  'dist',
+  'fonts',
+);
+
+const W = 240;
+const H = 200;
+
+async function headlessApp() {
+  const server = xserver.createServer({ width: 400, height: 400 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const fontSource = new StaticFontSource();
+  fontSource.add(readFileSync(join(fontDir, 'KaTeX_Main-Regular.ttf')), {
+    family: 'Test Main',
+  });
+  fontSource.alias('sans-serif', 'Test Main');
+  return createClient({ stream: clientEnd, fontSource });
+}
+
+/** Wait for the server to work through everything sent so far. */
+const settled = (app) =>
+  new Promise((resolve) => app.X.GetInputFocus(() => resolve()));
+
+const readPixels = (ctx, w, h) =>
+  new Promise((resolve, reject) =>
+    ctx.getImageData(0, 0, w, h, (err, data) =>
+      err ? reject(err) : resolve(data),
+    ),
+  );
+
+/** A focused `<textarea>` of `lines` lines with everything selected. */
+async function selectedTextarea(app, lines) {
+  const x11Root = await createRoot({ app });
+  const ref = React.createRef();
+  await new Promise((resolve) =>
+    x11Root.render(
+      React.createElement(
+        'window',
+        { width: W, height: H, style: { backgroundColor: '#f5f6fa' } },
+        React.createElement(
+          'box',
+          { style: { flexGrow: 1, padding: 6 } },
+          React.createElement('textarea', {
+            ref,
+            defaultValue: Array.from(
+              { length: lines },
+              (_, i) => `line ${i}`,
+            ).join('\n'),
+            style: { flexGrow: 1, backgroundColor: '#ffffff' },
+          }),
+        ),
+      ),
+      resolve,
+    ),
+  );
+  await new Promise((r) => setImmediate(r));
+  const node = ref.current;
+  node.focus();
+  node._selectAll();
+  const root = node.root;
+  root.flush(); // the first paint, with its glyph uploads and clip masks
+  await settled(app);
+  return { node, root };
+}
+
+/** Requests the server sees for one repaint of the field. */
+async function repaintCost(app, lines) {
+  const { node, root } = await selectedTextarea(app, lines);
+  const trace = startTrace({ app });
+  node._repaint();
+  root.flush();
+  await settled(app);
+  return trace.stop().requests;
+}
+
+test('the selection highlight costs the same however much is selected', async () => {
+  const short = await headlessApp();
+  const long = await headlessApp();
+  try {
+    const few = await repaintCost(short, 40);
+    const many = await repaintCost(long, 400);
+    // Ten times the selection, the same viewport. Not `===`: the values
+    // differ ("line 39" against "line 399"), so a glyph page can land on
+    // one side and not the other. Per-line fills would put ~360 requests
+    // between these.
+    assert.ok(
+      Math.abs(many - few) <= 8,
+      `40 selected lines cost ${few} requests, 400 cost ${many}`,
+    );
+  } finally {
+    await short.close();
+    await long.close();
+  }
+});
+
+test('the batch paints exactly what a fill per line painted', async () => {
+  const app = await headlessApp();
+  try {
+    const { node, root } = await selectedTextarea(app, 400);
+    const ctx = root._ctx;
+
+    // What the highlight actually asked for: one batch, and only the lines
+    // the field can show. Both are what makes the comparison below a test of
+    // the batched path rather than of two identical frames.
+    const real = ctx.fillRects.bind(ctx);
+    const batches = [];
+    ctx.fillRects = (rects) => {
+      batches.push(rects.length / 4);
+      return real(rects);
+    };
+    node._repaint();
+    root.flush();
+    await settled(app);
+    assert.strictEqual(batches.length, 1, 'the highlight is one batch');
+    const visibleLines = Math.ceil(
+      node.contentBox().height / node._valueLayout().lines[0].height,
+    );
+    assert.ok(
+      batches[0] <= visibleLines + 2,
+      `${batches[0]} rectangles for a field showing about ${visibleLines} lines`,
+    );
+    const batched = await readPixels(ctx, W, H);
+
+    // ntk's own fallback for a gradient or a transformed context: the same
+    // rectangles, one `fillRect` each. The pixels must not be able to tell.
+    ctx.fillRects = (rects) => {
+      const flat = Array.isArray(rects[0]) ? rects.flat() : rects;
+      for (let i = 0; i + 3 < flat.length; i += 4) {
+        ctx.fillRect(flat[i], flat[i + 1], flat[i + 2], flat[i + 3]);
+      }
+    };
+    node._repaint();
+    root.flush();
+    await settled(app);
+    const perLine = await readPixels(ctx, W, H);
+    ctx.fillRects = real;
+
+    let differences = 0;
+    for (let i = 0; i < batched.data.length; i++) {
+      if (batched.data[i] !== perLine.data[i]) differences++;
+    }
+    assert.strictEqual(differences, 0, `${differences} bytes differ`);
+
+    // …and the highlight is actually on screen, so the comparison above is
+    // not two identical blanks: the field's first line carries pixels that
+    // the window background does not.
+    const at = (x, y) => {
+      const i = (y * W + x) * 4;
+      return [batched.data[i], batched.data[i + 1], batched.data[i + 2]];
+    };
+    const field = node.contentBox();
+    const inside = at(
+      Math.round(field.x + 2),
+      Math.round(field.y + field.height / 2),
+    );
+    assert.notDeepStrictEqual(
+      inside,
+      [255, 255, 255],
+      'the selection tint should be over the field, not plain white',
+    );
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
ntk 7.6.0 landed three things. This is what react-x11 does with them — one of
the three has a caller here today, and the survey for the other two is at the
bottom so the next person does not repeat it.

## `ctx.fillRects` — the selection highlight

`fillRects` is `fillRect` per rectangle semantically (same fill style, alpha,
composite op, clip and damage reporting), compiled into a **single**
`Render.FillRectangles` for a solid colour under a rectangular clip, where N
`fillRect` calls are N mask-composited requests.

The `<textarea>` selection highlight is the drawing here that wanted it, and
it had a second problem a batch alone would not have fixed: it drew a rect per
selected line — **every** line, whether or not the viewport could show it. A
clip bounds the pixels, not the drawing: those rects were built, sent and
composited before the server discarded them.

So the loop now starts at the first visible line, stops at the last, and hands
the whole highlight over as one batch. One repaint of a fully selected
`<textarea>`, in-process X server, counted with `react-x11/debug`:

| selected lines | before | after |
| -------------- | -----: | ----: |
| 40             |     60 |    23 |
| 400            |    422 |    25 |

Flat in the size of the value, which is the property that matters — the old
cost was a function of the document and the new one is a function of the
viewport. The composition underline, which is two spans when a preedit crosses
a wrap, goes out the same way.

Everything else this touches:

- **`react-x11/test`'s mock context** gains `fillRects`, recorded as the fills
  it stands for. Two reasons: an app whose `onDraw` batches used to paint on a
  real server and crash in its own headless tests (the same gap `strokeRect`
  was added for), and an assertion on what a drawing painted should hold
  whether or not the drawing batched.
- **`docs/elements.md`** documents the batch on `<canvas onDraw>`, where an
  app most likely has a hundred rectangles in one colour — a sparkline, a heat
  map, row striping. `docs/testing.md` notes how the mock records it.
- **`examples/password.jsx`** draws its bar chart through it.
- **`AGENTS.md`** records the finding as a rule: a clip does not make an
  off-screen drawing free.

## Tests

`test/selection-batch.test.js`, against the in-process JS X server:

- the cost of a 40-line selection against a 400-line one — a ratio rather than
  a pinned number, so it fails on the regression and not on ntk's request
  arithmetic changing under it. Reverting the paint change fails it with
  `40 selected lines cost 60 requests, 400 cost 422`.
- the highlight is exactly one batch, of no more rectangles than the field has
  visible lines, and the surface it produces is byte-identical to the one the
  per-rect fallback produces — the path a gradient or a transform would take
  inside ntk.

`npm test` is otherwise unchanged: 1172 pass, and the 6 failures on this
machine are `test/appearance.test.js` picking up the host's macOS appearance,
which fail the same way on master.

## The other two, and why nothing here uses them

**`surface.copyWithin`** shifts an offscreen surface's pixels in place. The
only surfaces react-x11 owns are the paint cache's, and those are
content-keyed stills — nothing scrolls one. Window scrolling already has its
own primitive (`Window.scrollRegion`, the blit in `_applyScrollBlits`), which
this does not replace. Where it would pay is an element that keeps its scrolled
content in a retained surface — the canvas-backed editor/terminal
`docs/extending.md` describes — and that element does not exist yet; today it
repaints the viewport. Worth having in mind when it does.

**`Font.glyphIdFor` and the `drawGlyphs` run contract** are for a renderer that
positions glyphs by grid arithmetic instead of shaping. All text here goes
through ntk's `TextLayout`, which already batches a whole paragraph into one
`drawGlyphs` call, and core draws no character it did not get from the app or
from a font-independent path — the icons are paths, the shortcut labels are
ASCII words. The motivating consumer is the VT backend in
react-x11-components, not this repo.
