### PR TITLE
feat(events): the modifier the user held is the modifier the handler reads — altKey and metaKey

### DIFF
--- a/docs/click-to-component.md
+++ b/docs/click-to-component.md
@@ -54,10 +54,9 @@ babel/jsx-source plugin, no build-time instrumentation:
   resolve source maps itself at runtime).
 
 Alt+Click is recognized in `EventManager._onMouseDown`
-(`src/events.js`) — `native.buttons & 8` is X11's `Mod1Mask` bit, the same
-`buttons` bitmask `shiftKey`/`ctrlKey` already read elsewhere in that file —
-ahead of the normal press handling, so it never also starts a drag or moves
-focus.
+(`src/events.js`) — `native.buttons & MOD.Alt` is X11's `Mod1Mask` bit, the
+same `buttons` bitmask every synthetic event's `altKey` reads — ahead of the
+normal press handling, so it never also starts a drag or moves focus.
 
 GUI editors (cursor/code/code-insiders/windsurf, or any unrecognized
 `REACT_X11_EDITOR` value treated as a raw scheme) are opened by navigating

--- a/docs/events.md
+++ b/docs/events.md
@@ -101,6 +101,7 @@ const root = await createRoot({
   localX, localY,                   // target-relative
   nativeEvent,                      // the raw ntk/X11 event
   shiftKey, ctrlKey,                // on every event, not just keys
+  altKey, metaKey,                  // Mod1 and Mod4 — see Modifiers below
   preventDefault(), stopPropagation(),
   capturePointer(), releasePointer(),   // see Pointer capture below
   // mouse: button, detail (DOM-style click count: 2 = double, 3 = triple)
@@ -129,6 +130,32 @@ onKeyDown={(ev) => {
 That keeps working under a Cyrillic or Greek layout too: `ev.keysym` is the
 Latin keysym for the key however the layout is switched — see
 [Layouts](#layouts).
+
+### Modifiers
+
+Four booleans, DOM names, on **every** event rather than only the keyboard
+ones — a shift+click, an Alt+drag and a Super+wheel all need them:
+
+| property   | X11 modifier | usually |
+| ---------- | ------------ | ------- |
+| `shiftKey` | Shift        | Shift   |
+| `ctrlKey`  | Control      | Ctrl    |
+| `altKey`   | Mod1         | Alt     |
+| `metaKey`  | Mod4         | Super   |
+
+```js
+onKeyDown={(ev) => {
+  if (ev.altKey && ev.keysym === keysymOf('b')) wordLeft();
+}}
+```
+
+**Mod1 is Alt and Mod4 is Super by convention, not by protocol.** X says
+only that there are eight modifier rows and lets the keymap decide which
+keys sit in each; those two are where `setxkbmap` puts Alt and Super, and
+where every toolkit — GTK and Qt included — reads them from. The setup that
+disagrees still has the raw mask: `ev.nativeEvent.buttons` is the state
+field as it arrived, and `MOD` in `react-x11/keysyms` names its bits
+(`MOD.Mod3`, `MOD.Lock` for Caps Lock, and so on).
 
 ## Handlers
 

--- a/src/events.js
+++ b/src/events.js
@@ -15,6 +15,7 @@ import { noteInputTime } from './inputtime.js';
 import { hooks as a11yHooks, isFocusable } from './a11y.js';
 import { Composer, composeTableFor } from './compose.js';
 import { acceleratorKeysym } from './keyboard.js';
+import { MOD } from './keysyms.js';
 
 const XK_TAB = 0xff09;
 // The core protocol has no wheel: it is a click of button 4/5 (vertical) or
@@ -39,9 +40,6 @@ const WHEEL_BUTTONS = new Set([4, 5, 6, 7]);
  */
 export const WHEEL_NOTCH_PX = 48;
 const RIGHT_BUTTON = 3;
-// X11 KeyButMask bit for Mod1 (Alt on virtually every layout), same bitmask
-// `shiftKey`/`ctrlKey` above already read `buttons` from.
-const MOD1_MASK = 8;
 
 /** How many leading entries two node paths share. */
 function sharedPrefix(a, b) {
@@ -75,10 +73,19 @@ class SyntheticEvent {
     this.target = manager._public(target);
     this.currentTarget = null;
     this.nativeEvent = native;
-    // X11 modifier mask: bit 0 Shift, bit 2 Control. Carried on every
-    // event, not just keys — shift+click needs it too.
-    this.shiftKey = Boolean(native?.buttons & 1);
-    this.ctrlKey = Boolean(native?.buttons & 4);
+    // X11 modifier mask, DOM names: bit 0 Shift, bit 2 Control, bit 3 Mod1,
+    // bit 6 Mod4. Carried on every event, not just keys — shift+click needs
+    // it too, and so does Alt+drag.
+    //
+    // Mod1 is Alt and Mod4 is Super by *convention*: the protocol says only
+    // that there are eight modifier rows, and which keys sit in them is
+    // whatever the keymap says. Every toolkit ships the convention anyway
+    // (GTK and Qt decode exactly these two), and the setup that remaps them
+    // still has the raw mask on `nativeEvent.buttons`.
+    this.shiftKey = Boolean(native?.buttons & MOD.Shift);
+    this.ctrlKey = Boolean(native?.buttons & MOD.Control);
+    this.altKey = Boolean(native?.buttons & MOD.Alt);
+    this.metaKey = Boolean(native?.buttons & MOD.Super);
     this.defaultPrevented = false;
     this.propagationStopped = false;
     if (extra) Object.assign(this, extra);
@@ -463,7 +470,7 @@ export class EventManager {
   _onMouseDown(native) {
     // the wheel arrived as `wheel`, with a distance the press cannot carry
     if (WHEEL_BUTTONS.has(native.keycode)) return;
-    if (clickToComponentHandler && Boolean(native.buttons & MOD1_MASK)) {
+    if (clickToComponentHandler && Boolean(native.buttons & MOD.Alt)) {
       clickToComponentHandler(this._hit(native), native);
       return;
     }

--- a/src/keysyms.js
+++ b/src/keysyms.js
@@ -150,8 +150,10 @@ export function ctrlChordLetter(ev) {
 
 /**
  * The X11 modifier mask bits, as they arrive on `ev.nativeEvent.buttons`
- * and as `fireEvent` takes them. Bit 3 (Mod1) is Alt on virtually every
- * layout; the renderer reads Shift, Control and Mod1.
+ * and as `fireEvent` takes them. Bit 3 (Mod1) is Alt and bit 6 (Mod4) is
+ * Super on virtually every layout; those four — Shift, Control, Mod1, Mod4
+ * — are the ones a synthetic event decodes, as `shiftKey`/`ctrlKey`/
+ * `altKey`/`metaKey`.
  */
 export const MOD = {
   Shift: 1,

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -68,7 +68,7 @@ import { hooks as traceHooks } from './trace-registry.js';
 import { runWithPriority, DiscreteEventPriority } from './priority.js';
 import { lastInputTime } from './inputtime.js';
 import { armPasteState, canPaste } from './pastestate.js';
-import { ctrlChordLetter } from './keysyms.js';
+import { ctrlChordLetter, MOD } from './keysyms.js';
 import {
   editMenuColors,
   editMenuGeometry,
@@ -4108,8 +4108,10 @@ export class TextInputNode extends Node {
       y: native?.y ?? 0,
       target: this,
       nativeEvent: native ?? null,
-      shiftKey: Boolean(native?.buttons & 1),
-      ctrlKey: Boolean(native?.buttons & 4),
+      shiftKey: Boolean(native?.buttons & MOD.Shift),
+      ctrlKey: Boolean(native?.buttons & MOD.Control),
+      altKey: Boolean(native?.buttons & MOD.Alt),
+      metaKey: Boolean(native?.buttons & MOD.Super),
       defaultPrevented: false,
       propagationStopped: false,
       preventDefault() {

--- a/src/types/events.d.ts
+++ b/src/types/events.d.ts
@@ -40,6 +40,14 @@ export interface SyntheticEvent<T = DrawnNode> {
   nativeEvent: NativeEvent;
   shiftKey: boolean;
   ctrlKey: boolean;
+  /**
+   * X11 Mod1 — Alt on virtually every keymap, but a convention rather than
+   * a rule of the protocol. `nativeEvent.buttons` has the raw mask for a
+   * setup that remaps it.
+   */
+  altKey: boolean;
+  /** X11 Mod4 — Super, under the DOM's name for it. Same caveat as `altKey`. */
+  metaKey: boolean;
   defaultPrevented: boolean;
   propagationStopped: boolean;
   /** Suppress the element's built-in behaviour (editing, wheel scrolling…). */

--- a/test/modifiers.test.js
+++ b/test/modifiers.test.js
@@ -1,0 +1,119 @@
+// Alt and Super on synthetic events (#284).
+//
+// An X event's state field carries eight modifier rows, and the renderer
+// used to decode two of them. Alt and Super are the two an application
+// reaches for next — a terminal encodes Alt+key as an ESC prefix, an editor
+// moves by word on Alt, a window manager owns Super — and until they were
+// decoded here every one of them rediscovered `nativeEvent.buttons & 8` for
+// itself.
+//
+// These go through the in-process server rather than a hand-built event
+// object: the bit is set by pressing the real Alt_L/Super_L keycode, so what
+// is tested is the mask the server computed, not one the test wrote down.
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+
+import {
+  renderX11,
+  cleanup,
+  act,
+  fireEvent,
+  keysymOf,
+} from '../src/testing/index.js';
+import { MOD } from '../src/keysyms.js';
+
+const h = React.createElement;
+
+afterEach(cleanup);
+
+/** The four booleans, in the order the event object lists them. */
+const modsOf = (ev) => [ev.shiftKey, ev.ctrlKey, ev.altKey, ev.metaKey];
+
+async function mount() {
+  const events = [];
+  const record = (ev) => events.push([ev.type, ...modsOf(ev)]);
+  const { windowNode } = await renderX11(
+    h(
+      'window',
+      { width: 200, height: 120, onMouseDown: record, onKeyDown: record },
+      h('box', { style: { flexGrow: 1 } }),
+    ),
+  );
+  return { events, target: windowNode.children[0] };
+}
+
+test('a press carries Alt and Super as altKey and metaKey', async () => {
+  const { events, target } = await mount();
+
+  await act(async () => fireEvent.mouseDown(target));
+  assert.deepStrictEqual(
+    events.at(-1),
+    ['mouseDown', false, false, false, false],
+    'no modifier held, none reported',
+  );
+
+  await act(async () => fireEvent.mouseDown(target, { modifiers: ['Alt'] }));
+  assert.deepStrictEqual(events.at(-1), [
+    'mouseDown',
+    false,
+    false,
+    true,
+    false,
+  ]);
+
+  await act(async () => fireEvent.mouseDown(target, { modifiers: ['Super'] }));
+  assert.deepStrictEqual(events.at(-1), [
+    'mouseDown',
+    false,
+    false,
+    false,
+    true,
+  ]);
+
+  // and they combine with each other and with the two that were always here
+  await act(async () =>
+    fireEvent.mouseDown(target, {
+      modifiers: ['Shift', 'Control', 'Alt', 'Super'],
+    }),
+  );
+  assert.deepStrictEqual(events.at(-1), ['mouseDown', true, true, true, true]);
+});
+
+test('a key carries them too, so Alt chords read like DOM ones', async () => {
+  const { events, target } = await mount();
+
+  await act(async () =>
+    fireEvent.key(keysymOf('b'), { target, modifiers: ['Alt'] }),
+  );
+  assert.deepStrictEqual(events.at(-1), ['keyDown', false, false, true, false]);
+
+  await act(async () =>
+    fireEvent.key(keysymOf('l'), { target, modifiers: ['Super'] }),
+  );
+  assert.deepStrictEqual(events.at(-1), ['keyDown', false, false, false, true]);
+});
+
+test('the raw mask is still there for a keymap that disagrees', async () => {
+  // Mod1 is Alt and Mod4 is Super by convention, not by protocol, so the
+  // decode is a reading of the state field rather than a replacement for it:
+  // `nativeEvent.buttons` is the mask exactly as it arrived, which is what a
+  // remapped setup falls back to.
+  const seen = [];
+  const { windowNode } = await renderX11(
+    h(
+      'window',
+      {
+        width: 200,
+        height: 120,
+        onMouseDown: (ev) => seen.push(ev.nativeEvent.buttons),
+      },
+      h('box', { style: { flexGrow: 1 } }),
+    ),
+  );
+
+  await act(async () =>
+    fireEvent.mouseDown(windowNode.children[0], { modifiers: ['Alt'] }),
+  );
+  assert.strictEqual(seen.at(-1) & MOD.Mod1, MOD.Mod1);
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -330,6 +330,9 @@ function Events() {
         void ev.key;
         void ev.codepoint;
         void ev.shiftKey;
+        // Mod1 and Mod4, under the names the DOM gives them
+        const chord: boolean = ev.altKey || ev.metaKey;
+        void chord;
         // the Latin keysym, and which layout typed the character
         const layout: number = ev.group;
         void layout;


### PR DESCRIPTION
Closes #284.

## What

`altKey` and `metaKey` on every synthetic event, beside the `shiftKey`/`ctrlKey` that were already there:

```js
this.altKey = Boolean(native?.buttons & MOD.Alt); // Mod1
this.metaKey = Boolean(native?.buttons & MOD.Super); // Mod4
```

DOM naming, DOM placement — on the shared base, so a mouse event carries them for the same reason it already carried `shiftKey`: an Alt+drag needs them as much as an Alt+key does.

## Why

An X event's state field has eight modifier rows in it and the renderer decoded two. Anything with an Alt or Super chord — an editor moving by word, a window manager owning Super, the pure-JS VT backend in sidorares/react-x11-components#7 encoding Alt+key as the ESC prefix every terminal speaks — went around the event object and read `ev.nativeEvent.buttons & 8`, which is the decode this file already does, rediscovered once per application.

## The caveat, written down where it lives

Mod1 is Alt and Mod4 is Super **by convention**. X says only that there are eight modifier rows and lets the keymap decide which keys sit in each; those two are where `setxkbmap` puts Alt and Super, and where GTK and Qt read them from. So the convention is the useful reading, and the setup that disagrees still has the state field exactly as it arrived on `ev.nativeEvent.buttons` — whose bits `MOD` in `react-x11/keysyms` names. That is in the code comment, in the `.d.ts`, and in a new "Modifiers" section in docs/events.md.

`MOD` also replaces the two hand-written masks and the local `MOD1_MASK` the click-to-component Alt+Click was checking, so the bit is spelled once.

## Tests

New `test/modifiers.test.js`, three tests, through the published test surface: the modifier bit is set by injecting the real `Alt_L`/`Super_L` keycode into the in-process X server, so what is asserted is the mask the server computed rather than one the test wrote onto an event. Presses and keys, the four booleans together, and the raw mask still being reachable.

Mutation-checked: removing the two decodes fails the first two and leaves the raw-mask one green, which is the split it should have.

## Checks

- `npm test` — 1173 pass, 6 fail, all six in `test/appearance.test.js` and all six failing identically on a clean checkout of this branch's base (macOS host: the appearance ladder answers `macos` where the test wants `xsettings`).
- `npm run typecheck`, `npm run lint`, `prettier --check .` — clean.

No visual change, so no screenshots.
