### PR TITLE
docs(extending): the primitive a scrolling element needs is in the box it already opens

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -550,6 +550,72 @@ When the drawing changes its own extent — a line was typed, rows arrived —
 say so the way any other layout change is said, with
 `this.invalidate(true, this, 'scroll')`; the next pass asks again.
 
+#### Scrolling the pixels, not just the offset
+
+`scrollBy` moves a number; nobody moves pixels. For a drawing that is cheap
+to redraw, that is the end of it — `paintContent` runs again at the new
+offset and the frame is correct. For one that is expensive per row and
+already lives in a retained buffer — a terminal grid, a log view, a minimap,
+a chart that pans — a scroll changes almost nothing: the band that stays
+visible is the same pixels, one shift away. A `Surface` can move that band
+itself, server-side:
+
+```js
+import { Node, Scrollable } from 'react-x11/node';
+import { Surface } from 'react-x11/ntk';
+
+class GridNode extends Scrollable(Node) {
+  ensureSurface(width, height) {
+    if (this.surface?.width === width && this.surface?.height === height)
+      return;
+    this.surface?.destroy();
+    this.surface = new Surface(this.app, { width, height });
+    this.drawRows(this.visibleRows()); // a new buffer starts transparent
+  }
+
+  scrollBy(by) {
+    const from = this.scrollY;
+    super.scrollBy(by);
+    // ask *after*: the scroller clamped it to the extent you reported
+    const dy = from - this.scrollY;
+    if (!dy || !this.surface) return;
+    const all = {
+      x: 0,
+      y: 0,
+      width: this.surface.width,
+      height: this.surface.height,
+    };
+    if (this.surface.copyWithin(all, 0, dy)) this.drawRows(this.exposedBy(dy));
+    else this.drawRows(this.visibleRows());
+  }
+
+  paintContent(ctx) {
+    const box = this.contentBox();
+    ctx.drawImage(this.surface, box.x, box.y);
+  }
+
+  destroySubtree() {
+    this.surface?.destroy();
+    super.destroySubtree();
+  }
+}
+```
+
+`copyWithin(src, dx, dy)` shifts `src` (`{x, y, width, height}`, in surface
+coordinates) in place by an integer delta and answers **whether anything
+survived** — `false` means repaint the lot, which is the branch a fresh
+buffer, a jump to the far end and a resize all take. It is one `CopyArea`
+inside the pixmap: nothing crosses the wire but the request, the overlap is
+safe, and no exposure events come back.
+
+Two things it lines up with. The deltas you are handed are already whole
+pixels — the sub-pixel carry described above exists so that a shift is
+always expressible — so an element scrolling this way never has a fraction
+to round. And `<box overflow="scroll">` has been doing the window-side half
+of this without being asked: a pure scroll of one viewport blits the
+surviving band inside ntk's backing pixmap rather than repainting it. This
+is that optimisation, for a buffer you retained yourself.
+
 ### Drawing once instead of every frame
 
 A drawing that does not change between frames does not have to be redrawn
@@ -641,7 +707,7 @@ not create. Three things it has to do that a GL surface does not:
 | `react-x11/host`    | `registerElement`, `unregisterElement`, `registeredElements`, `hostTypes`, `knownElements`, `drawnKinds` |
 | `react-x11/node`    | `Node`, the built-in node classes, `Scrollable`, `intrinsicSize`                                         |
 | `react-x11/style`   | `createStyles`, `flattenStyle`, `isStyleProp`, `resolveTokens`, the rest of the vocabulary               |
-| `react-x11/ntk`     | ntk itself, re-exported                                                                                  |
+| `react-x11/ntk`     | ntk itself, re-exported — `Surface`, `Path2D`, `Image`, `Pixmap`, the font sources, `createClient`       |
 | `react-x11/keysyms` | the `XK_*` constants, `keysymOf`, `charOf`, `MOD`, `ctrlChordLetter`                                     |
 
 **Reach ntk through `react-x11/ntk`, not a second dependency.** Two copies

--- a/src/ntk.d.ts
+++ b/src/ntk.d.ts
@@ -18,6 +18,12 @@ export const Clipboard: new (...args: unknown[]) => unknown;
 export const Path2D: new (...args: unknown[]) => unknown;
 export const Image: new (...args: unknown[]) => unknown;
 export const Pixmap: new (...args: unknown[]) => unknown;
+/**
+ * Draw once, composite many — and, for an element that scrolls a retained
+ * buffer, `copyWithin(src, dx, dy)` shifts the surviving band server-side.
+ * See [extending.md](../docs/extending.md).
+ */
+export const Surface: new (...args: unknown[]) => unknown;
 export const Yoga: Record<string, unknown>;
 /** `code` values on a failed GL setup — see `<Canvas3D fallback>`. */
 export const GLXError: {


### PR DESCRIPTION
ntk 7.6.0 promotes `Surface.copyWithin(src, dx, dy)` — an overlapping self-copy inside an offscreen pixmap, `scrollRegion` for a buffer nobody presents (sidorares/ntk#252, sidorares/ntk#255).

#285 already brought that release in for `ctx.fillRects`, so the dependency half of #283 is paid before this branch touches anything. What is left is that nothing tells an element author the primitive is there. Custom elements reach ntk through `react-x11/ntk` precisely so a second copy never enters the process — which makes this package's docs the only place the reachable surface is described, and this package's release the moment a promoted ntk API becomes real for them.

## What this changes

**`docs/extending.md` gains `#### Scrolling the pixels, not just the offset`**, at the end of "Scrolling content you painted" — where an element that paints its own content is already reading, rather than in a section it would have to know to look for. It carries a worked `Scrollable(Node)` example that:

- creates the `Surface` and re-creates it on resize, since a new buffer starts transparent;
- reads the delta **after** `super.scrollBy` — the scroller clamped it to the extent you reported, and reading it before is the bug this line exists to prevent;
- branches on the return value, because `false` means nothing survived and the caller repaints the lot;
- frees the surface in `destroySubtree`, like any other server resource.

Two ties to text already on the page: the wheel's deltas are already whole pixels — the sub-pixel carry exists so a shift is always expressible — so an element scrolling this way never has a fraction to round; and `<box overflow="scroll">` has been doing the window-side half of this unasked since the scroll-blit path landed.

**The subpath table** names `Surface` among what `react-x11/ntk` carries, alongside `Path2D`, `Image`, `Pixmap`, the font sources and `createClient`.

**`src/ntk.d.ts` declares `Surface`.** ntk ships no types and that file is a hand-listed set of named exports, so `import { Surface } from 'react-x11/ntk'` — the line the new section tells people to write — did not compile. Slightly beyond the issue's letter, but documenting an import that fails at the seam it advertises seemed worse.

## What it deliberately does not change

Core has **no** raw `X.CopyArea` call site to replace: window scrolling goes through ntk's `scrollRegion`, and every other mention in the tree is prose, a debug request-name table, or a comment about ntk's internal copy. The escape hatch this retires is the hand-written `CreateGC` + `CopyArea` in react-x11-components' VT terminal renderer (sidorares/react-x11-components#7); that replacement lands there, unblocked by the dependency this repo already carries.

## Verification

`typecheck`, `eslint` and `prettier --check .` clean over the whole tree. Full suite before the rebase: 1176 tests, 1170 pass — the six failures are all in `test/appearance.test.js` and fail identically with the branch stashed, a darwin-host artifact of the real macOS rung at `src/appearance.js:201` beating the injected XSETTINGS answer. No new links or anchors, so the docs job has nothing new to validate.

Closes #283