### PR TITLE
feat(a11y): the editor somebody else wrote, read by the paths ours is

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1097,7 +1097,12 @@ right-click used to collapse the selection.
 The AT-SPI accessibility work is done and in core (NEXT_STEPS §11.3,
 [docs/accessibility.md](docs/accessibility.md)): standard `role`/`aria-*`
 props on every element, `src/a11y.js` (the model) + `src/atspi.js` (the
-bridge), Orca-verified. Next: a generic Popover and a file open/save
+bridge), Orca-verified. An element core did not write reaches the same feed
+through the node seam (#257): `a11yRole`, `a11yTextState()` +
+`notifyA11yTextChanged()`, and the two optional writes `a11ySetSelection` /
+`a11yReplaceText` — normalized in `customTextState()` so a third-party
+editor is read by the paths `<textinput>` is read by, never by a second
+model. Next: a generic Popover and a file open/save
 dialog. **#85** (keyboard layout switching ignored) is done — ntk decodes
 the active XKB group, and `src/keyboard.js` keeps shortcuts on the Latin
 keysym even where XQuartz's keymap rewrite has left no Latin group

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -228,6 +228,68 @@ on top of the text-changed feed would have a screen reader say the accent
 twice; an application that wants to narrate composition state can call
 `announce()` itself from `onCompositionUpdate`.
 
+### Text of your own
+
+A [registered element](extending.md) that draws its own text — a code
+editor, a markdown viewer, a terminal, a canvas-backed table with cell
+editing — reports it through one method and is then read by everything
+above: character count, reading by character/word/line, caret, selection,
+the text-changed deltas, and an AT that can navigate and type.
+
+```js
+class EditorNode extends Node {
+  a11yTextState() {
+    return {
+      value: this.text, // what is drawn, composition included
+      caret: this.caret, // code-point offsets into `value`
+      selectionStart: this.anchor,
+      selectionEnd: this.caret,
+      editable: true, // an editor rather than a viewer
+      multiline: true,
+    };
+  }
+
+  insert(text) {
+    /* …the edit… */ this.notifyA11yTextChanged();
+  }
+}
+```
+
+| member                              |                                                                                                     |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `a11yTextState()`                   | `{ value, caret, selectionStart, selectionEnd, editable, multiline, preedit }` — `null` for no text |
+| `notifyA11yTextChanged()`           | the text moved. Free when nothing is listening, so no guard around it                               |
+| `a11ySetSelection(start, end)`      | an AT moved the caret or made a selection                                                           |
+| `a11yReplaceText(start, end, text)` | an AT edited — insert, delete and replace all arrive as this                                        |
+| `a11yRole`                          | the role the element is when the app writes none; `role` still wins                                 |
+
+Two tiers, because the read-only one is a real element and not a
+degenerate editor. `{ value, selectionStart, selectionEnd }` alone is a
+document: the `Text` interface, a `document` role, a selection an AT reads
+and sets — which is what a markdown view with Ctrl+C needs and all it
+needs. `editable: true` adds the EDITABLE state, an `entry` role and, once
+`a11yReplaceText` exists, the `EditableText` interface. Nothing is exposed
+that would not work: an element that reports editable text but implements
+no write is announced as editable and reports its own edits, but is not
+offered to an AT as one to type into.
+
+Offsets are code points and index the string the element **draws** — an
+open composition included, for the same reason `<textinput>`'s do. Report
+which part is uncommitted as `preedit: { offset, text }` and its churn is
+marked `:system`, so a reader stays quiet through a dead key and speaks the
+character it commits. Offsets are clamped on the way out, so a stale caret
+cannot become an out-of-range answer on the wire.
+
+The known limits of the tier, none of which stop a screen reader working:
+per-character screen rectangles fall back to the element's own rect (a
+magnifier tracks the element, not the glyph), and AT-driven paste and copy
+are the built-ins' — an element's own Ctrl+C/Ctrl+V is unaffected. Both
+want a layout the element alone has; say so on the issue if you have one.
+
+The seam is observed by the test spy exactly as core's is, so an editor in
+another package can assert what it says with no bus and no desktop —
+[below](#asserting-what-a-screen-reader-would-hear).
+
 ## The compatibility ladder
 
 `createRoot()` starts one climb per process, off the critical path:
@@ -272,7 +334,11 @@ whatever the tree says. The seams, in increasing order of involvement:
 - `onAccessibilityAction` — when an AT can _set_ something on your control.
 - A [registered element](extending.md) is a host element like any other:
   its instances take all of the above, and a class that should default to a
-  role can set `props.role` in its constructor.
+  role assigns `this.a11yRole` in its constructor (a `role` prop still
+  wins).
+- `a11yTextState()` + `notifyA11yTextChanged()` — when your element draws
+  text of its own, which is the one thing props cannot express
+  ([above](#text-of-your-own)).
 
 ## Testing and verifying
 

--- a/docs/architecture/accessibility.md
+++ b/docs/architecture/accessibility.md
@@ -277,6 +277,47 @@ exactly as the GTK bridge does.
   single mutation point typing uses, so `onChange` fires and undo history
   records — an AT edit _is_ a user edit. Offsets need no conversion
   anywhere: AT-SPI counts code points, and `_chars()`/`_caret` already do.
+  Every write is expressed as **one replacement** — `[start, end) := text`
+  — because that is the primitive both implementations can offer: the
+  built-ins splice and `_commit`, and a registered element implements
+  `a11yReplaceText`, which its own editing needs anyway. Set-the-lot,
+  insert and delete are that call with one end moved.
+
+## 8a. Text from elements core did not write (#257)
+
+A registered element draws text core cannot see: `<textinput>`'s state is
+read off `_chars()`/`_caret`/`_selection`, which a `<codeeditor>` in
+another package does not have. The seam is a **pull** — `a11yTextState()`
+answers `{ value, caret, selectionStart, selectionEnd, editable,
+multiline, preedit }` — plus a **push** that says it is worth pulling,
+`Node.notifyA11yTextChanged()`, which is the same `hooks.textState` slot
+`_repaint` already fed. Three consequences make it the cheap shape:
+
+- **One normalizer, no second model.** `customTextState()` turns the
+  element's answer into the `{ chars, caret, selection, preedit }` the
+  bridge and the spy already speak, clamping the offsets on the way — so
+  granularity, attribute runs, the diff, `:system` composition marking and
+  the spy's transcript are the same code paths `<textinput>` uses. A
+  third-party editor cannot be read _differently_ from core's, only less.
+- **Two tiers, because viewers are not degenerate editors.** `editable`
+  splits them: without it an element is `Text` and a `document` role,
+  which is exactly the markdown/code-block/terminal case (selection,
+  Ctrl+C, no caret semantics); with it, EDITABLE, an `entry` role, and —
+  only if `a11yReplaceText` exists — the `EditableText` interface.
+  Exporting an interface whose every method answered false would be a lie
+  an AT has no way to test.
+- **Declared, not inferred.** `a11yRole` is the element's own default
+  role (below a `role` prop, above the scroller rule, so an editor that
+  scrolls is still an entry), and `multiline` is a claim rather than a
+  guess off the value — inferring it from a `\n` would report the
+  element's _shape_ changing the first time somebody pressed Enter, the
+  same objection that keeps the scroll-pane role off `isScroller()`
+  flicker.
+
+Deliberately not in the seam: per-character extents (they need a layout
+only the element has; the fallback is the element's own rect, which is
+honest and keeps a magnifier tracking something real) and AT-driven
+copy/paste, which stay the built-ins' clipboard round trip.
 
 ## 9. Testing
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -433,6 +433,93 @@ of milliseconds apart. Stop the timer in `defaultBlur` _and_ in
 `destroySubtree`: a node that unmounts while focused is forgotten rather than
 blurred, so `defaultBlur` is not guaranteed to run.
 
+### Text a screen reader can read
+
+An element that draws text of its own is, to an assistive technology,
+nothing at all: a painted rectangle with no characters, no caret and no
+selection in it. `<textinput>` is not — it implements AT-SPI's `Text` and
+`EditableText` interfaces in full — and the difference is one method
+(issue #257):
+
+```js
+class EditorNode extends Node {
+  a11yTextState() {
+    return {
+      value: this.lines.join('\n'), // what is drawn
+      caret: this.caret, // code points, into `value`
+      selectionStart: this.anchor,
+      selectionEnd: this.caret,
+      editable: true,
+      multiline: true,
+    };
+  }
+
+  insert(text) {
+    // …the element's own edit…
+    this.notifyA11yTextChanged();
+  }
+}
+```
+
+That alone buys the whole read side: character count, reading by character,
+word and line, the caret, the selection, and the `text-changed` /
+`text-caret-moved` / `text-selection-changed` deltas Orca narrates from —
+through the same code that serves `<textinput>`, so a third-party editor is
+read by the paths core is read by rather than by a parallel set of them.
+
+| member                              | when                                                                                                                              |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `a11yTextState()`                   | always, for an element holding text. `null` for one that holds none                                                               |
+| `notifyA11yTextChanged()`           | every edit, caret move, selection change and composition — the state is _pulled_ when this says it moved                          |
+| `a11ySetSelection(start, end)`      | an AT moved the caret or selected a range; the caret belongs at `end`. Without it the element is read but not navigated           |
+| `a11yReplaceText(start, end, text)` | an AT edited: replace that range. Insert, delete and set-the-lot all arrive here. Without it the element is read but not typed in |
+| `a11yRole`                          | the ARIA role this element is when the app writes none — `'textbox'`, `'log'`, `'document'`. Assign it in the constructor         |
+
+**The two tiers are the two kinds of element.** A viewer — a markdown
+document, a code block, a log, a terminal — reports `value` and a selection
+and stops there: it gets the `Text` interface, a `document` role, and a
+selection an AT can read and set, which is the whole of what "select this
+paragraph and copy it" needs. An editor adds `editable: true` and
+`a11yReplaceText`, which is what turns on the EDITABLE state and the
+`EditableText` interface. An element that claims `editable` without
+implementing the write **is** still announced as editable and reports its
+own edits — it simply is not exposed as one an AT may type into, because an
+interface whose every method answered "no" is a lie an AT cannot see
+through.
+
+Four details, each of which is a defect the other way round:
+
+**Offsets are code points and they index what you draw.** `Array.from(value)`
+is the counting, and `value` is the string on the screen — an open
+composition included, because every geometric answer beside it (the extents
+of character _n_, a magnifier's highlight) is read off the glyphs a sighted
+user sees. Say which part is uncommitted with `preedit: { offset, text }`
+and its churn is marked as text the user did not type, exactly as
+`<textinput>`'s is ([accessibility.md](accessibility.md#while-a-composition-is-open)).
+Offsets you report are clamped for you, so a caret left stale between an
+edit and your own bookkeeping cannot become an out-of-range answer on the
+wire.
+
+**`notifyA11yTextChanged()` is free when nobody is listening** — one
+property read, the hook slots being empty until a bridge or the test spy
+fills them. So call it from every path that moves the text, rather than
+asking whether accessibility is on.
+
+**`a11yTextState()` is called several times per change**, for the role, the
+states and the diff. Answer from state the element already holds; it must
+not shape, copy a buffer, or invalidate.
+
+**Say `multiline`.** Left unsaid, neither the single-line nor the
+multi-line state is claimed — better than a guess read off the current
+value, which would report the element's shape _changing_ the first time
+somebody pressed Enter.
+
+The behaviour is assertable without a screen reader, a desktop or a bus:
+`renderX11(el, { a11y: true })` hands back a spy that records the same feed
+([accessibility.md](accessibility.md#asserting-what-a-screen-reader-would-hear)),
+and `test/a11y-custom-text.test.js` in this repo is a worked editor and a
+worked viewer driven through it.
+
 ### Scrolling content you painted
 
 A `<box overflow="scroll">` scrolls **children**: layout knows where they

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -262,6 +262,11 @@ A composition is in there as itself: a dead key logs one `preedit` entry
 with `:system`, which is how a test catches a screen reader that would echo
 a half-typed accent.
 
+A [registered element](extending.md#text-a-screen-reader-can-read) that
+reports its own text is observed through the same seam, so a package
+shipping an editor or a document view can assert what it says with no bus
+and no desktop — `test/a11y-custom-text.test.js` is the worked pair.
+
 `at.events()` / `at.since()` are precise facts, `at.transcript()` the
 one-line summaries, `at.focusables()` every keyboard stop in Tab order with
 its utterance — a nameless control reads `"(no accessible name)"`, which

--- a/src/a11y.js
+++ b/src/a11y.js
@@ -390,23 +390,37 @@ const INTERNAL_KINDS = new Set(['textchunk', 'svgchild']);
  */
 const scrolls = (node) => !node.isWindow && node.isScroller?.() === true;
 
-/** The web role name in force on a node: the `role` prop, else the kind's
- * default name (only the kinds with real semantics have one). */
+/**
+ * The web role name in force on a node, in the order the answers get less
+ * specific: what the application wrote, what the element says it is
+ * (`node.a11yRole` — a registered element's own default, see
+ * docs/extending.md), what it holds, whether it scrolls, and finally the
+ * kind's default name (only the kinds with real semantics have one).
+ *
+ * A registered element's declaration sits **above** the scroller rule on
+ * purpose: an editor that scrolls its own painted text is a text box that
+ * happens to scroll, and reading it as a scroll pane would lose the only
+ * part a screen reader cares about.
+ */
 export function roleNameOf(node) {
   const role = node.props?.role;
   if (typeof role === 'string' && role !== '') return role;
+  const own = node.a11yRole;
+  if (typeof own === 'string' && own !== '') return own;
+  const text = textRoleName(node);
+  if (text !== null) return text;
   if (scrolls(node)) return 'scrollable';
   return KIND_ROLE_NAMES[node.kind] ?? null;
 }
 
-/** The AT-SPI role number for a node. An unknown `role` string falls back
- * to the kind default rather than to nothing — a typo should not turn a
- * button into a filler silently, but it must not crash either; the DEV
- * check below is what reports it. */
-export function a11yRole(node) {
-  const role = node.props?.role;
-  if (typeof role === 'string') {
-    const mapped = ROLE_TO_ATSPI.get(role);
+/** The AT-SPI role number for a node, by the same order. An unknown role
+ * string falls back to the next answer rather than to nothing — a typo
+ * should not turn a button into a filler silently, but it must not crash
+ * either; the DEV check below is what reports it. */
+export function atspiRoleOf(node) {
+  for (const name of [node.props?.role, node.a11yRole, textRoleName(node)]) {
+    if (typeof name !== 'string') continue;
+    const mapped = ROLE_TO_ATSPI.get(name);
     if (mapped !== undefined) return mapped;
   }
   if (scrolls(node)) return ATSPI_ROLE.SCROLL_PANE;
@@ -477,8 +491,9 @@ export function subtreeText(node) {
       parts.push(n.text);
       return;
     }
-    // do not read a nested widget's editable content as its parent's label
-    if (n.kind === 'textinput' || n.kind === 'textarea') return;
+    // do not read a nested control's own text as its parent's label — its
+    // value is its Text interface, not a name for whatever contains it
+    if (n !== node && textShapeOf(n) !== null) return;
     for (const child of n.children ?? []) {
       if (!child.isWindow) walk(child);
     }
@@ -615,9 +630,15 @@ export function a11yStates(node) {
 
   const readOnly = props['aria-readonly'] === true;
   if (readOnly) bit(states, S.READ_ONLY);
-  if (node.kind === 'textinput' || node.kind === 'textarea') {
-    bit(states, node.kind === 'textarea' ? S.MULTI_LINE : S.SINGLE_LINE);
-    if (!props.disabled && !readOnly) bit(states, S.EDITABLE);
+  const text = textShapeOf(node);
+  if (text) {
+    // `multiline` is a claim about the element's shape, so a registered
+    // element that makes none gets neither state rather than a guess read
+    // off its current value — which would report the shape *changing* the
+    // first time somebody pressed Enter.
+    if (text.multiline === true) bit(states, S.MULTI_LINE);
+    else if (text.multiline === false) bit(states, S.SINGLE_LINE);
+    if (text.editable && !props.disabled && !readOnly) bit(states, S.EDITABLE);
   }
 
   if (node.isWindow) {
@@ -691,14 +712,101 @@ export function a11yActivatable(node) {
 // technology read out of this control right now?
 // --------------------------------------------------------------------------
 
-/** Kinds whose value is editable text with a caret. */
-export const isTextControl = (node) =>
+/** The built-in editable controls, which report through their own
+ * internals rather than through the seam below. */
+export const isNativeTextControl = (node) =>
   node.kind === 'textinput' || node.kind === 'textarea';
 
-/** Kinds that expose the AT-SPI Text interface at all — the editable
- * controls plus `<text>` labels, which are readable but caret-less. */
+/**
+ * A registered element's own answer to "what text am I holding, and where
+ * is the caret" (issue #257), normalized into the shape the bridge and the
+ * spy already speak — or null for an element that holds none.
+ *
+ * The element writes `{ value, caret, selectionStart, selectionEnd,
+ * editable, multiline, preedit }` and every field but `value` is optional;
+ * offsets are code points (`Array.from`), clamped here so a stale caret an
+ * element hands over cannot become an out-of-range answer on the wire.
+ * Everything downstream — character counts, word and line granularity,
+ * attribute runs, the text-changed diff — is then the same code that
+ * serves `<textinput>`, which is the point: a third-party editor is
+ * readable by the same paths, not by a parallel set of them.
+ *
+ * This is called several times per change (role, states, the diff), so an
+ * element's implementation has to be a cheap read of what it already
+ * holds — never a shaping pass or a copy of its buffer.
+ */
+export function customTextState(node) {
+  if (typeof node.a11yTextState !== 'function') return null;
+  const state = node.a11yTextState();
+  if (state == null) return null;
+  const chars = Array.from(String(state.value ?? ''));
+  const at = (value, fallback) => {
+    const index = Math.trunc(Number(value));
+    return Number.isFinite(index)
+      ? Math.max(0, Math.min(index, chars.length))
+      : fallback;
+  };
+  const start = at(state.selectionStart, 0);
+  const end = at(state.selectionEnd, start);
+  const composing = state.preedit ? String(state.preedit.text ?? '') : '';
+  return {
+    chars,
+    caret: at(state.caret, end),
+    selection: [Math.min(start, end), Math.max(start, end)],
+    preedit: composing
+      ? {
+          offset: at(state.preedit.offset, 0),
+          length: Array.from(composing).length,
+          text: composing,
+        }
+      : null,
+    editable: state.editable === true,
+    multiline: typeof state.multiline === 'boolean' ? state.multiline : null,
+  };
+}
+
+/**
+ * What kind of text an element holds — whether it is editable, and whether
+ * it is one line or many (`null` for an element that has not said). Null
+ * when it holds none.
+ */
+export function textShapeOf(node) {
+  if (isNativeTextControl(node)) {
+    return { editable: true, multiline: node.kind === 'textarea' };
+  }
+  const custom = customTextState(node);
+  if (!custom) return null;
+  return { editable: custom.editable, multiline: custom.multiline };
+}
+
+/** The role an element reporting text falls back to when it declares
+ * none: an entry when an assistive technology may type into it, a
+ * document when it may only read. */
+function textRoleName(node) {
+  const shape = textShapeOf(node);
+  if (!shape) return null;
+  return shape.editable ? 'textbox' : 'document';
+}
+
+/** Whether the value is editable text with a caret — what the EDITABLE
+ * state and the AT-SPI EditableText interface are about. */
+export const isTextControl = (node) => textShapeOf(node)?.editable === true;
+
+/** Everything that exposes the AT-SPI Text interface at all — the editable
+ * controls, `<text>` labels (readable but caret-less), and any registered
+ * element reporting a text state, editable or not. The read-only tier is
+ * what makes a document viewer with a selection speak: markdown, a code
+ * block, a terminal. */
 export const hasTextInterface = (node) =>
-  isTextControl(node) || node.kind === 'text';
+  isNativeTextControl(node) ||
+  node.kind === 'text' ||
+  customTextState(node) !== null;
+
+/** Whether an assistive technology can write to this element's text: the
+ * built-ins always can, a registered element when it implements the write
+ * half of the seam. */
+export const acceptsTextEdits = (node) =>
+  isNativeTextControl(node) || typeof node.a11yReplaceText === 'function';
 
 /**
  * The code points and caret/selection of anything with a Text interface —
@@ -721,7 +829,7 @@ export const hasTextInterface = (node) =>
  * (see `_diffText` in atspi.js).
  */
 export function textStateOf(node) {
-  if (isTextControl(node)) {
+  if (isNativeTextControl(node)) {
     const shown = node._displayValue ? node._displayValue() : null;
     const toDisplay = (index) => node._displayIndex?.(index) ?? index;
     const [start, end] = node._selection?.() ?? [0, 0];
@@ -739,6 +847,8 @@ export function textStateOf(node) {
         : null,
     };
   }
+  const custom = customTextState(node);
+  if (custom) return custom;
   const spans = node.collectSpans?.([]) ?? [];
   const chars = Array.from(spans.map((s) => s.text).join(''));
   return { chars, caret: 0, selection: [0, 0], preedit: null };
@@ -791,16 +901,20 @@ const warned = new Set();
  * warning list that lags the spec teaches people to stop trusting it.
  */
 export function devCheckA11yProps(node) {
-  const role = node.props?.role;
-  if (role == null) return;
-  if (typeof role !== 'string' || ROLE_TO_ATSPI.has(role)) return;
-  if (role === 'none' || role === 'presentation') return;
-  if (warned.has(role)) return;
-  warned.add(role);
-  console.warn(
-    `react-x11: unknown role "${role}" on <${node.kind}> — it will read as ` +
-      `the element default. Known roles: ${KNOWN_ROLES.join(', ')}.`,
-  );
+  // the element's own default is checked too: a registered element that
+  // misspells its `a11yRole` is silently the kind default forever, and it
+  // is written once in a constructor rather than visibly at a call site
+  for (const role of [node.props?.role, node.a11yRole]) {
+    if (role == null) continue;
+    if (typeof role !== 'string' || ROLE_TO_ATSPI.has(role)) continue;
+    if (role === 'none' || role === 'presentation') continue;
+    if (warned.has(role)) continue;
+    warned.add(role);
+    console.warn(
+      `react-x11: unknown role "${role}" on <${node.kind}> — it will read ` +
+        `as the element default. Known roles: ${KNOWN_ROLES.join(', ')}.`,
+    );
+  }
 }
 
 // --------------------------------------------------------------------------
@@ -820,7 +934,8 @@ export function devCheckA11yProps(node) {
  *  - `propsChanged(node)` — after applyProps landed new props.
  *  - `textContent(node)` — a text chunk's string changed.
  *  - `textState(node)` — a text control's value/caret/selection may have
- *    moved (funnelled through `_repaint`, which every edit path calls).
+ *    moved (funnelled through `_repaint`, which every edit path calls, and
+ *    through `Node.notifyA11yTextChanged()` for a registered element).
  *  - `focus(previous, next)` — the owning manager moved focus.
  *  - `windowFocus(windowNode, focused)` — the WM moved input focus.
  *  - `commit()` — a React commit finished (resetAfterCommit).

--- a/src/atspi.js
+++ b/src/atspi.js
@@ -39,7 +39,7 @@ import {
   ATSPI_STATE,
   ATSPI_STATE_NICK,
   ATSPI_ROLE_NICK,
-  a11yRole,
+  atspiRoleOf,
   a11yErased,
   a11yPruned,
   a11yChildren,
@@ -52,6 +52,8 @@ import {
   a11yAttributes,
   a11yActivatable,
   isTextControl,
+  isNativeTextControl,
+  acceptsTextEdits,
   hasTextInterface,
   textStateOf,
   inPreedit,
@@ -429,19 +431,19 @@ const AccessibleImpl = {
     return [];
   },
   GetRole() {
-    return a11yRole(this.n);
+    return atspiRoleOf(this.n);
   },
   // The AT-SPI role name, not the ARIA one the app wrote — see
   // ATSPI_ROLE_NICK. The ARIA role is reported through `xml-roles` in
   // GetAttributes, as the browsers do.
   GetRoleName() {
-    return ATSPI_ROLE_NICK[a11yRole(this.n)] ?? 'unknown';
+    return ATSPI_ROLE_NICK[atspiRoleOf(this.n)] ?? 'unknown';
   },
   GetLocalizedRoleName() {
     // No localisation here: answering the untranslated name is what a
     // toolkit with no message catalogue should do, and libatspi falls back
     // to its own translations anyway.
-    return ATSPI_ROLE_NICK[a11yRole(this.n)] ?? 'unknown';
+    return ATSPI_ROLE_NICK[atspiRoleOf(this.n)] ?? 'unknown';
   },
   GetState() {
     return a11yStates(this.n);
@@ -622,10 +624,7 @@ const TextImpl = {
     return chars[offset].codePointAt(0);
   },
   SetCaretOffset(offset) {
-    const node = this.n;
-    if (typeof node._moveCaret !== 'function') return false;
-    node._moveCaret(valueOffset(node, offset), false);
-    return true;
+    return this.b.setCaret(this.n, offset);
   },
   GetAttributes(offset) {
     return attributeRun(textStateOf(this.n), offset);
@@ -679,44 +678,29 @@ const TextImpl = {
   },
   RemoveSelection(index) {
     if (index !== 0) return false;
-    const node = this.n;
-    if (typeof node._moveCaret !== 'function') return false;
-    node._moveCaret(node._caret ?? 0, false);
-    return true;
+    return this.b.setCaret(this.n, textStateOf(this.n).caret);
   },
 };
 
+/**
+ * Every write is one replacement — `editText(node, start, end, text)` —
+ * because that is the one primitive both sides can implement: the
+ * built-ins have `_commit`, and a registered element implements
+ * `a11yReplaceText`, which it needs anyway for its own editing.
+ */
 const EditableTextImpl = {
   SetTextContents(newContents) {
-    return this.b.editText(this.n, () => {
-      const chars = Array.from(String(newContents));
-      this.n._commit(chars, chars.length);
-    });
+    const { chars } = textStateOf(this.n);
+    return this.b.editText(this.n, 0, chars.length, newContents);
   },
   InsertText(position, text, length) {
-    return this.b.editText(this.n, () => {
-      const node = this.n;
-      const at = valueOffset(node, position);
-      const chars = node._chars();
-      const insert = Array.from(String(text)).slice(
-        0,
-        length < 0 ? undefined : length,
-      );
-      chars.splice(at, 0, ...insert);
-      node._commit(chars, at + insert.length);
-    });
+    const insert = Array.from(String(text))
+      .slice(0, length < 0 ? undefined : length)
+      .join('');
+    return this.b.editText(this.n, position, position, insert);
   },
   DeleteText(start, end) {
-    return this.b.editText(this.n, () => {
-      const node = this.n;
-      const a = valueOffset(node, start);
-      const b = valueOffset(node, end);
-      const chars = node._chars();
-      const s = Math.min(a, b);
-      const e = Math.max(a, b);
-      chars.splice(s, e - s);
-      node._commit(chars, s);
-    });
+    return this.b.editText(this.n, start, end, '');
   },
   CopyText(start, end) {
     this.b.copyTextRange(this.n, start, end);
@@ -729,6 +713,8 @@ const EditableTextImpl = {
   PasteText(position) {
     const node = this.n;
     if (!this.b.editable(node)) return false;
+    // the clipboard round trip is the built-ins' own: an element with a
+    // seam of its own is handed the text, not asked to fetch it
     if (typeof node._pasteFrom !== 'function') return false;
     node._moveCaret?.(valueOffset(node, position), false);
     node._pasteFrom('CLIPBOARD');
@@ -803,7 +789,13 @@ class AtspiBridge {
     if (a11yActivatable(node)) ifaces.push(IFACE.ACTION);
     if (a11yValue(node) !== null) ifaces.push(IFACE.VALUE);
     if (hasTextInterface(node)) ifaces.push(IFACE.TEXT);
-    if (isTextControl(node)) ifaces.push(IFACE.EDITABLE_TEXT);
+    // EditableText only where an edit would actually land: a registered
+    // element that reports editable text but implements no write seam is
+    // readable and reports its own edits, and an interface whose every
+    // method answered false would be a lie an AT cannot see through
+    if (isTextControl(node) && acceptsTextEdits(node)) {
+      ifaces.push(IFACE.EDITABLE_TEXT);
+    }
     return ifaces;
   }
 
@@ -994,18 +986,53 @@ class AtspiBridge {
     if (node.props?.disabled || node.props?.['aria-readonly'] === true) {
       return false;
     }
+    return acceptsTextEdits(node);
+  }
+
+  /**
+   * Replace `[start, end)` — in the displayed string, which is what the AT
+   * was told — with `text`. Insert, delete and set-the-lot are all this
+   * with one end moved, and a registered element answers it whole through
+   * `a11yReplaceText` rather than through five methods it would have to
+   * keep consistent with each other.
+   */
+  editText(node, start, end, text) {
+    if (!this.editable(node)) return false;
+    const { chars: shown } = textStateOf(node);
+    const from = clampOffset(Math.min(start, end), shown.length);
+    const to = clampOffset(Math.max(start, end), shown.length);
+    if (!isNativeTextControl(node)) {
+      return node.a11yReplaceText(from, to, String(text)) !== false;
+    }
+    if (typeof node._commit !== 'function') return false;
+    const a = valueOffset(node, from);
+    const b = valueOffset(node, to);
+    const chars = node._chars();
+    const insert = Array.from(String(text));
+    chars.splice(a, b - a, ...insert);
+    node._commit(chars, a + insert.length);
     return true;
   }
 
-  editText(node, edit) {
-    if (!this.editable(node)) return false;
-    if (typeof node._commit !== 'function') return false;
-    edit();
-    return true;
+  /** Put the caret at an offset, selecting nothing. Legitimate on a
+   * read-only element too — caret browsing through a document is a read,
+   * not an edit. */
+  setCaret(node, offset) {
+    return this.setTextSelection(node, offset, offset);
   }
 
   setTextSelection(node, start, end) {
-    if (!isTextControl(node) || node.destroyed) return false;
+    if (node.destroyed) return false;
+    if (typeof node.a11ySetSelection === 'function') {
+      const { chars } = textStateOf(node);
+      return (
+        node.a11ySetSelection(
+          clampOffset(start, chars.length),
+          clampOffset(end, chars.length),
+        ) !== false
+      );
+    }
+    if (!isNativeTextControl(node)) return false;
     node._anchor = valueOffset(node, start);
     node._caret = valueOffset(node, end);
     node._repaint?.();
@@ -1013,7 +1040,7 @@ class AtspiBridge {
   }
 
   copyTextRange(node, start, end) {
-    if (!isTextControl(node) || node.destroyed) return;
+    if (!isNativeTextControl(node) || node.destroyed) return;
     if (typeof node._copySelection !== 'function') return;
     const caret = node._caret;
     const anchor = node._anchor;
@@ -1081,7 +1108,7 @@ class AtspiBridge {
       a11yChildren(node).length,
       this.interfacesOf(node),
       a11yName(node),
-      a11yRole(node),
+      atspiRoleOf(node),
       a11yDescription(node),
       a11yStates(node),
     ];

--- a/src/node.d.ts
+++ b/src/node.d.ts
@@ -63,6 +63,33 @@ export interface TextStyle {
 }
 
 /**
+ * What an element holding text tells an assistive technology
+ * (`a11yTextState`). Offsets are **code points**, counted the way
+ * `Array.from(value).length` counts, and index `value` — the string the
+ * element *draws*, an open composition included.
+ */
+export interface A11yTextState {
+  /** The text as drawn. */
+  value: string;
+  /** Where the caret is. Defaults to `selectionEnd`. */
+  caret?: number;
+  /** The selected range; equal offsets mean a bare caret. Default 0. */
+  selectionStart?: number;
+  selectionEnd?: number;
+  /** Whether this is text the user edits — an editor rather than a viewer.
+   * Sets the EDITABLE state and, with `a11yReplaceText`, the AT-SPI
+   * EditableText interface. */
+  editable?: boolean;
+  /** One line or many. Left unsaid, neither state is claimed rather than
+   * guessed from the current value. */
+  multiline?: boolean;
+  /** The part of `value` that is an open composition — a dead key, a
+   * half-typed Compose sequence — so a reader can tell it from the
+   * character it commits. `offset` is where it starts in `value`. */
+  preedit?: { offset: number; text: string } | null;
+}
+
+/**
  * The `measureContent` body for content with a natural size and an aspect
  * ratio to keep — `<image>` and `<svg>` are written on it:
  *
@@ -204,6 +231,44 @@ export declare class Node {
   /** The cursor to show over this element when nothing in the style says
    * otherwise — `'text'` for something editable. A `cursor` style wins. */
   defaultCursor?: string;
+  /**
+   * The ARIA role this element is when the application writes none — the
+   * registered-element counterpart of `<textinput>` defaulting to
+   * `textbox`. A `role` prop still wins, and an unknown name warns in
+   * development. Assign it in the constructor.
+   */
+  a11yRole?: string;
+  /**
+   * What text this element holds, for the AT-SPI `Text` interface and the
+   * test spy (docs/accessibility.md). `null` when it holds none. Implement
+   * it and an editor, a viewer or a terminal is readable, navigable and
+   * announced through the same paths `<textinput>` uses.
+   *
+   * Called several times per change, so answer from state the element
+   * already holds — never a shaping pass or a copy of a buffer.
+   */
+  a11yTextState?(): A11yTextState | null;
+  /**
+   * An assistive technology moved the caret or the selection: `start` and
+   * `end` are code-point offsets into the reported `value`, and the caret
+   * belongs at `end`. Return false to refuse. Without it an AT can read
+   * this element but not navigate it.
+   */
+  a11ySetSelection?(start: number, end: number): boolean;
+  /**
+   * An assistive technology edited the text: replace `[start, end)` with
+   * `text`. Insert, delete and replace-everything all arrive here. Only an
+   * element that implements this exposes AT-SPI's `EditableText`, so an
+   * editor without it is read but never typed into.
+   */
+  a11yReplaceText?(start: number, end: number, text: string): boolean;
+  /**
+   * The text reported by `a11yTextState()` may have moved — an edit, a
+   * caret move, a selection change, a composition. Free when no assistive
+   * technology is listening, so call it from every path that changes the
+   * text rather than guarding it.
+   */
+  notifyA11yTextChanged(): void;
   /** Props changed. A subclass calls `super.applyProps(next, prev)`. */
   applyProps(
     nextProps: Record<string, unknown>,

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -1970,6 +1970,21 @@ export class Node {
     return false;
   }
 
+  /**
+   * The text this element reports through `a11yTextState()` may have moved
+   * — an edit, a caret move, a selection change, a composition (#257). The
+   * same notification `<textinput>`'s `_repaint` makes, and the reason an
+   * assistive technology hears a third-party editor at all: the state is
+   * *pulled* when this says it is worth pulling.
+   *
+   * Free when nobody is listening — one property read, the hook slots being
+   * null until a bridge or the test spy fills them — so an element may call
+   * it on every edit without asking whether accessibility is on.
+   */
+  notifyA11yTextChanged() {
+    a11yHooks.textState?.(this);
+  }
+
   /** Where focus for this node lives: its own window's EventManager, or —
    * inside a `<popup>`, which never receives the X input focus — the owner
    * window's (see EventManager.focusManager). */

--- a/src/testing/a11y.js
+++ b/src/testing/a11y.js
@@ -47,7 +47,7 @@ import {
   ATSPI_ROLE_NICK,
   ATSPI_STATE,
   ATSPI_STATE_NICK,
-  a11yRole,
+  atspiRoleOf,
   a11yName,
   a11yStates,
   a11yValue,
@@ -122,7 +122,7 @@ function stateNicksOf(node) {
 export function nodeUtterance(node) {
   return utteranceOf({
     name: a11yName(node),
-    role: ATSPI_ROLE_NICK[a11yRole(node)],
+    role: ATSPI_ROLE_NICK[atspiRoleOf(node)],
     states: stateNicksOf(node),
     value: a11yValue(node),
   });
@@ -308,7 +308,7 @@ export class A11ySpy {
     return {
       node,
       name: a11yName(node),
-      role: ATSPI_ROLE_NICK[a11yRole(node)],
+      role: ATSPI_ROLE_NICK[atspiRoleOf(node)],
       states: stateNicksOf(node),
       utterance: nodeUtterance(node),
     };

--- a/test/a11y-custom-text.test.js
+++ b/test/a11y-custom-text.test.js
@@ -1,0 +1,407 @@
+// Text hooks for custom editable elements (#257): a registered element that
+// holds text — a code editor, a markdown viewer, a terminal — says so on
+// public API and is read by exactly the paths `<textinput>` is read by.
+//
+// Two tiers, and both are here because they fail differently. An **editable**
+// element reports a caret and takes edits; a **read-only** one reports a
+// selection and nothing else, which is the whole of what a document viewer
+// with Ctrl+C needs to stop being silent.
+//
+// Everything registers through `react-x11/host` and subclasses
+// `react-x11/node`, because the point of the issue is that a sibling package
+// can do this: a test reaching into src/nodes.js would prove nothing.
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+
+import { registerElement, unregisterElement } from '../src/host.js';
+import { Node } from '../src/node.js';
+import {
+  ATSPI_ROLE,
+  ATSPI_STATE,
+  atspiRoleOf,
+  a11yName,
+  a11yStates,
+  hasTextInterface,
+  textStateOf,
+} from '../src/a11y.js';
+import {
+  cleanup,
+  renderX11,
+  screen,
+  userEvent,
+  keysymOf,
+  XK_DEAD_ACUTE,
+  XK_LEFT,
+} from '../src/testing/index.js';
+
+const h = React.createElement;
+
+const hasState = (states, bit) =>
+  bit < 32
+    ? Boolean(states[0] & (1 << bit))
+    : Boolean(states[1] & (1 << (bit - 32)));
+
+/**
+ * A miniature editor: a string, a caret, a selection, and a composition it
+ * draws but has not committed — the state any real editor already holds.
+ * The accessibility seam is the four members at the top; everything below
+ * them is the element's own editing, which is what makes the point that the
+ * seam reports state rather than owning it.
+ */
+class EditorNode extends Node {
+  constructor(props, app) {
+    super('minieditor', props, app);
+    this.focusableByDefault = true;
+    this.text = String(props.defaultValue ?? '');
+    this.caret = this.text.length;
+    this.anchor = this.caret;
+    this.preedit = '';
+  }
+
+  a11yTextState() {
+    const chars = Array.from(this.text);
+    const composing = Array.from(this.preedit).length;
+    const caret = this.caret + composing;
+    // a composition replaces whatever was selected, so there is nothing
+    // selected while one is open
+    const [start, end] = composing
+      ? [caret, caret]
+      : [Math.min(this.caret, this.anchor), Math.max(this.caret, this.anchor)];
+    return {
+      // what is drawn, the composition included — the offsets index it
+      value:
+        chars.slice(0, this.caret).join('') +
+        this.preedit +
+        chars.slice(this.caret).join(''),
+      caret,
+      selectionStart: start,
+      selectionEnd: end,
+      editable: true,
+      multiline: true,
+      preedit: this.preedit ? { offset: this.caret, text: this.preedit } : null,
+    };
+  }
+
+  a11yReplaceText(start, end, text) {
+    const chars = Array.from(this.text);
+    chars.splice(start, end - start, ...Array.from(text));
+    this.text = chars.join('');
+    this.caret = start + Array.from(text).length;
+    this.anchor = this.caret;
+    this.notifyA11yTextChanged();
+    return true;
+  }
+
+  a11ySetSelection(start, end) {
+    this.anchor = start;
+    this.caret = end;
+    this.notifyA11yTextChanged();
+    return true;
+  }
+
+  // --- the element's own editing ------------------------------------------
+
+  insert(text) {
+    this.a11yReplaceText(this.caret, this.caret, text);
+  }
+
+  moveCaret(to, extend) {
+    this.caret = Math.max(0, Math.min(to, Array.from(this.text).length));
+    if (!extend) this.anchor = this.caret;
+    this.notifyA11yTextChanged();
+  }
+
+  defaultKeyDown(ev) {
+    if (ev.keysym === XK_LEFT) {
+      this.moveCaret(this.caret - 1, ev.shiftKey);
+      return;
+    }
+    if (ev.codepoint >= 0x20) this.insert(ev.key);
+  }
+
+  defaultComposition(ev) {
+    if (ev.type === 'compositionEnd') {
+      this.preedit = '';
+      if (ev.data) this.insert(ev.data);
+      else this.notifyA11yTextChanged();
+      return;
+    }
+    this.preedit = ev.data;
+    this.notifyA11yTextChanged();
+  }
+}
+
+/** The tier below: a rendered document that can be selected and copied but
+ * never typed into — `<Markdown>`, a code block, a log view. */
+class ViewerNode extends Node {
+  constructor(props, app) {
+    super('minidoc', props, app);
+    this.focusableByDefault = true;
+    this.selection = [0, 0];
+  }
+
+  a11yTextState() {
+    return {
+      value: String(this.props.text ?? ''),
+      selectionStart: this.selection[0],
+      selectionEnd: this.selection[1],
+    };
+  }
+
+  a11ySetSelection(start, end) {
+    this.selection = [start, end];
+    this.notifyA11yTextChanged();
+    return true;
+  }
+
+  selectAll() {
+    this.a11ySetSelection(0, Array.from(String(this.props.text ?? '')).length);
+  }
+}
+
+/** An element that reports text and declares nothing else about itself. */
+class BareNode extends Node {
+  constructor(props, app) {
+    super('minibare', props, app);
+    this.a11yRole = 'log';
+  }
+
+  a11yTextState() {
+    return { value: String(this.props.text ?? '') };
+  }
+}
+
+const registered = new Set();
+function register(type, definition) {
+  registerElement(type, definition);
+  registered.add(type);
+}
+
+function registerAll() {
+  register('minieditor', {
+    create: (props, app) => new EditorNode(props, app),
+    semanticNames: ['defaultValue'],
+    childrenAllowed: false,
+  });
+  register('minidoc', {
+    create: (props, app) => new ViewerNode(props, app),
+    semanticNames: ['text'],
+    childrenAllowed: false,
+  });
+  register('minibare', {
+    create: (props, app) => new BareNode(props, app),
+    semanticNames: ['text'],
+    childrenAllowed: false,
+  });
+}
+
+afterEach(async () => {
+  await cleanup();
+  for (const type of registered) unregisterElement(type);
+  registered.clear();
+});
+
+const editorOf = () => screen.all((n) => n.kind === 'minieditor')[0];
+
+// ---------------------------------------------------------------------------
+// The model: what the element is, before any of it becomes an event
+// ---------------------------------------------------------------------------
+
+test('an element that reports editable text reads as an entry', async () => {
+  registerAll();
+  await renderX11(
+    h('minieditor', { defaultValue: 'let x = 1', style: { width: 200 } }),
+    { backend: 'mock' },
+  );
+  const editor = editorOf();
+
+  assert.equal(atspiRoleOf(editor), ATSPI_ROLE.ENTRY, 'entry, not unknown');
+  assert.equal(hasTextInterface(editor), true);
+  const states = a11yStates(editor);
+  assert.ok(hasState(states, ATSPI_STATE.EDITABLE), 'editable');
+  assert.ok(hasState(states, ATSPI_STATE.MULTI_LINE), 'multi-line, as it said');
+  assert.ok(!hasState(states, ATSPI_STATE.SINGLE_LINE));
+
+  const { chars, caret, selection } = textStateOf(editor);
+  assert.equal(chars.join(''), 'let x = 1');
+  assert.equal(caret, 9);
+  assert.deepEqual(selection, [9, 9]);
+});
+
+test('a viewer is readable text without being editable', async () => {
+  registerAll();
+  await renderX11(h('minidoc', { text: 'one two' }), { backend: 'mock' });
+  const doc = screen.all((n) => n.kind === 'minidoc')[0];
+
+  // no role declared and nothing to type into: a document, not an entry
+  assert.equal(atspiRoleOf(doc), ATSPI_ROLE.DOCUMENT_FRAME);
+  assert.equal(hasTextInterface(doc), true);
+  const states = a11yStates(doc);
+  assert.ok(!hasState(states, ATSPI_STATE.EDITABLE), 'nothing may type here');
+  // it said nothing about its shape, so neither line state is claimed
+  assert.ok(!hasState(states, ATSPI_STATE.MULTI_LINE));
+  assert.ok(!hasState(states, ATSPI_STATE.SINGLE_LINE));
+  assert.equal(textStateOf(doc).chars.join(''), 'one two');
+});
+
+test('a declared a11yRole wins over the text default, a prop over both', async () => {
+  registerAll();
+  await renderX11(
+    h(
+      'box',
+      null,
+      h('minibare', { text: 'log line' }),
+      h('minibare', { text: 'log line', role: 'status' }),
+    ),
+    { backend: 'mock' },
+  );
+  const [bare, overridden] = screen.all((n) => n.kind === 'minibare');
+  assert.equal(atspiRoleOf(bare), ATSPI_ROLE.LOG);
+  assert.equal(atspiRoleOf(overridden), ATSPI_ROLE.STATUS_BAR);
+});
+
+test('the element is not read as a label for whatever contains it', async () => {
+  registerAll();
+  await renderX11(
+    h(
+      'box',
+      { role: 'button', 'aria-label': undefined },
+      h('text', null, 'Body'),
+      h('minieditor', { defaultValue: 'secret draft' }),
+    ),
+    { backend: 'mock' },
+  );
+  const button = screen.all((n) => n.props?.role === 'button')[0];
+  assert.equal(
+    a11yName(button),
+    'Body',
+    "a nested control's value is its own text, never its parent's name",
+  );
+});
+
+test('offsets an element hands over are clamped, not trusted', async () => {
+  registerAll();
+  await renderX11(h('minieditor', { defaultValue: 'abc' }), {
+    backend: 'mock',
+  });
+  const editor = editorOf();
+  // a stale caret is what an editor hands over between an edit and its own
+  // bookkeeping; an out-of-range answer on the wire is an AT crash
+  editor.caret = 99;
+  editor.anchor = -4;
+  const { caret, selection } = textStateOf(editor);
+  assert.equal(caret, 3);
+  assert.deepEqual(selection, [0, 3]);
+});
+
+test('notifying with nobody listening costs a property read', async () => {
+  registerAll();
+  await renderX11(h('minieditor', { defaultValue: '' }), { backend: 'mock' });
+  // no bridge, no spy: the hook slots are null and this is a no-op rather
+  // than a branch the element has to write itself
+  assert.doesNotThrow(() => editorOf().notifyA11yTextChanged());
+});
+
+// ---------------------------------------------------------------------------
+// The feed: what an assistive technology is told, through the same spy an
+// application's own suite uses
+// ---------------------------------------------------------------------------
+
+test('typing into a registered element reaches the AT as a diff', async () => {
+  registerAll();
+  const { at } = await renderX11(
+    h('minieditor', { defaultValue: '', style: { width: 200, height: 60 } }),
+    { a11y: true },
+  );
+  const editor = editorOf();
+  await userEvent.click(editor);
+  at.since();
+
+  await userEvent.type(editor, 'hi', { skipClick: true });
+  assert.deepEqual(
+    at.since().map((e) => e.summary),
+    // an insert carries its own caret; a caret entry is for a move that
+    // edited nothing
+    ['insert: "h"', 'insert: "i"'],
+  );
+  assert.equal(editor.text, 'hi');
+});
+
+test('a caret move with no edit is a caret event', async () => {
+  registerAll();
+  const { at } = await renderX11(
+    h('minieditor', {
+      defaultValue: 'abc',
+      style: { width: 200, height: 60 },
+    }),
+    { a11y: true },
+  );
+  const editor = editorOf();
+  await userEvent.click(editor);
+  at.since();
+
+  await userEvent.key(XK_LEFT, { target: editor });
+  assert.deepEqual(
+    at.since().map((e) => e.summary),
+    ['caret: 2'],
+  );
+});
+
+test('a selection an element makes is spoken, editable or not', async () => {
+  registerAll();
+  const { at } = await renderX11(h('minidoc', { text: 'one two' }), {
+    a11y: true,
+  });
+  const doc = screen.all((n) => n.kind === 'minidoc')[0];
+  at.since();
+
+  doc.selectAll();
+  assert.deepEqual(
+    at.since().map((e) => e.summary),
+    // the caret rides the far end of the selection, the pair AT-SPI's
+    // TextCaretMoved + TextSelectionChanged carry
+    ['caret: 7', 'selection: 0..7'],
+  );
+});
+
+test('a composition a registered element draws is not text the user typed', async () => {
+  registerAll();
+  const { at } = await renderX11(
+    h('minieditor', { defaultValue: '', style: { width: 200, height: 60 } }),
+    { a11y: true },
+  );
+  const editor = editorOf();
+  await userEvent.click(editor);
+  at.since();
+
+  // the dead key: on the screen, in nobody's value
+  await userEvent.key(XK_DEAD_ACUTE, { target: editor });
+  assert.deepEqual(
+    at.since().map((e) => e.summary),
+    ['preedit: "´"'],
+  );
+  assert.equal(editor.text, '', 'the value did not move');
+
+  // the letter: one insert, of the character the sequence made
+  await userEvent.key(keysymOf('e'), { target: editor });
+  assert.deepEqual(
+    at.since().map((e) => e.summary),
+    ['preedit: cleared', 'insert: "é"'],
+  );
+  assert.equal(editor.text, 'é');
+});
+
+test('the audit an application would write passes over a custom editor', async () => {
+  registerAll();
+  const { at } = await renderX11(
+    h('minieditor', {
+      'aria-label': 'Source',
+      defaultValue: '',
+      style: { width: 200, height: 60 },
+    }),
+    { a11y: true },
+  );
+  const [stop] = at.focusables();
+  assert.equal(stop.utterance, 'Source, entry');
+});

--- a/test/a11y.test.js
+++ b/test/a11y.test.js
@@ -19,7 +19,7 @@ import {
 import {
   ATSPI_ROLE,
   ATSPI_STATE,
-  a11yRole,
+  atspiRoleOf,
   roleNameOf,
   a11yChildren,
   a11yParent,
@@ -77,19 +77,19 @@ test('kind defaults: an unlabelled tree is boring, not wrong', async () => {
       h('box', { style: { overflow: 'scroll' } }, h('box')),
     ),
   );
-  assert.equal(a11yRole(root), ATSPI_ROLE.FRAME);
+  assert.equal(atspiRoleOf(root), ATSPI_ROLE.FRAME);
   const box = find(root, (n) => n.kind === 'box');
-  assert.equal(a11yRole(box), ATSPI_ROLE.FILLER);
+  assert.equal(atspiRoleOf(box), ATSPI_ROLE.FILLER);
   assert.equal(
-    a11yRole(find(root, (n) => n.kind === 'text')),
+    atspiRoleOf(find(root, (n) => n.kind === 'text')),
     ATSPI_ROLE.LABEL,
   );
   assert.equal(
-    a11yRole(find(root, (n) => n.kind === 'textinput')),
+    atspiRoleOf(find(root, (n) => n.kind === 'textinput')),
     ATSPI_ROLE.ENTRY,
   );
   assert.equal(
-    a11yRole(find(root, (n) => n.isScroller?.())),
+    atspiRoleOf(find(root, (n) => n.isScroller?.())),
     ATSPI_ROLE.SCROLL_PANE,
   );
 });
@@ -104,10 +104,10 @@ test('the role prop maps to AT-SPI, and an unknown one falls back', async () => 
       h('box', { role: 'no-such-role' }),
     ),
   );
-  assert.equal(a11yRole(byRole(root, 'button')), ATSPI_ROLE.BUTTON);
-  assert.equal(a11yRole(byRole(root, 'switch')), ATSPI_ROLE.SWITCH);
+  assert.equal(atspiRoleOf(byRole(root, 'button')), ATSPI_ROLE.BUTTON);
+  assert.equal(atspiRoleOf(byRole(root, 'switch')), ATSPI_ROLE.SWITCH);
   // unknown: reads as the element default rather than vanishing
-  assert.equal(a11yRole(byRole(root, 'no-such-role')), ATSPI_ROLE.FILLER);
+  assert.equal(atspiRoleOf(byRole(root, 'no-such-role')), ATSPI_ROLE.FILLER);
   assert.equal(roleNameOf(byRole(root, 'button')), 'button');
 });
 

--- a/test/atspi.test.js
+++ b/test/atspi.test.js
@@ -41,7 +41,13 @@ const VALUE = 'org.a11y.atspi.Value';
 const PROPERTIES = 'org.freedesktop.DBus.Properties';
 
 const ROLE = { APPLICATION: 75, FRAME: 23, BUTTON: 43, ENTRY: 79, LABEL: 29 };
-const STATE = { CHECKED: 4, ENABLED: 8, FOCUSABLE: 11, FOCUSED: 12 };
+const STATE = {
+  CHECKED: 4,
+  EDITABLE: 7,
+  ENABLED: 8,
+  FOCUSABLE: 11,
+  FOCUSED: 12,
+};
 const hasState = ([lo, hi], bit) =>
   bit < 32 ? Boolean(lo & (1 << bit)) : Boolean(hi & (1 << (bit - 32)));
 
@@ -639,6 +645,178 @@ describe('the AT-SPI bridge', { concurrency: 1, ...needsBroker }, () => {
     assert.equal(detail, '');
     assert.equal(politeness, 2);
     assert.equal(dbus.variantValue(text), 'saved');
+  });
+
+  test('a registered element that reports text is read and edited like an input', async () => {
+    // #257: the seam a package outside react-x11 implements — a text state
+    // it reports and a replacement it accepts — has to reach the wire as
+    // the Text/EditableText pair, or a third-party editor is silent to Orca
+    // with no way to fix it from outside.
+    const { registerElement, unregisterElement } =
+      await import('../src/host.js');
+    const { Node } = await import('../src/node.js');
+
+    class MiniEditorNode extends Node {
+      constructor(props, app) {
+        super('minieditor', props, app);
+        this.text = String(props.defaultValue ?? '');
+        this.caret = this.text.length;
+      }
+      a11yTextState() {
+        return {
+          value: this.text,
+          caret: this.caret,
+          selectionStart: this.caret,
+          selectionEnd: this.caret,
+          editable: true,
+          multiline: true,
+        };
+      }
+      a11yReplaceText(start, end, text) {
+        const chars = Array.from(this.text);
+        chars.splice(start, end - start, ...Array.from(text));
+        this.text = chars.join('');
+        this.caret = start + Array.from(text).length;
+        this.notifyA11yTextChanged();
+        return true;
+      }
+      a11ySetSelection(start, end) {
+        this.caret = end;
+        void start;
+        this.notifyA11yTextChanged();
+        return true;
+      }
+    }
+
+    /** The read-only tier: text and a selection, nothing to type into. */
+    class MiniDocNode extends Node {
+      constructor(props, app) {
+        super('minidoc', props, app);
+      }
+      a11yTextState() {
+        return { value: String(this.props.text ?? '') };
+      }
+    }
+
+    /** Editable text the user types but an AT may not: the element
+     * implements no write half. */
+    class MiniOwnNode extends Node {
+      constructor(props, app) {
+        super('miniown', props, app);
+      }
+      a11yTextState() {
+        return { value: 'mine', editable: true, multiline: false };
+      }
+    }
+
+    registerElement('minieditor', {
+      create: (props, app) => new MiniEditorNode(props, app),
+      semanticNames: ['defaultValue'],
+      childrenAllowed: false,
+    });
+    registerElement('minidoc', {
+      create: (props, app) => new MiniDocNode(props, app),
+      semanticNames: ['text'],
+      childrenAllowed: false,
+    });
+    registerElement('miniown', {
+      create: (props, app) => new MiniOwnNode(props, app),
+      childrenAllowed: false,
+    });
+    x11Root.render(
+      h(
+        'window',
+        { title: 'Bridge Test', width: 320, height: 200 },
+        h('minieditor', { defaultValue: 'let x = 1' }),
+        h('minidoc', { text: 'read me' }),
+        h('miniown', null),
+      ),
+    );
+    await settle();
+    const frameChildren = await call(
+      appBus,
+      framePath,
+      ACCESSIBLE,
+      'GetChildren',
+    );
+    const editorPath = frameChildren[0][1];
+    const docPath = frameChildren[1][1];
+    const ownPath = frameChildren[2][1];
+
+    // the role it never declared, from the text it reports
+    assert.equal(
+      await call(appBus, editorPath, ACCESSIBLE, 'GetRole'),
+      ROLE.ENTRY,
+    );
+    const ifaces = await call(appBus, editorPath, ACCESSIBLE, 'GetInterfaces');
+    assert.ok(ifaces.includes(TEXT), 'the Text interface');
+    assert.ok(ifaces.includes(EDITABLE), 'and EditableText, since it writes');
+    // the viewer reads, and only reads: an EditableText whose every method
+    // answered false would be a lie an AT cannot see through
+    const docIfaces = await call(appBus, docPath, ACCESSIBLE, 'GetInterfaces');
+    assert.ok(docIfaces.includes(TEXT));
+    assert.ok(!docIfaces.includes(EDITABLE), 'nothing may type into a viewer');
+    assert.equal(
+      await call(appBus, docPath, TEXT, 'GetText', 'ii', [0, -1]),
+      'read me',
+    );
+    // …and an element whose text only *it* edits is announced as editable
+    // without being offered as one an AT may write to
+    const ownIfaces = await call(appBus, ownPath, ACCESSIBLE, 'GetInterfaces');
+    assert.ok(ownIfaces.includes(TEXT));
+    assert.ok(!ownIfaces.includes(EDITABLE), 'no write half, no EditableText');
+    assert.ok(
+      hasState(
+        await call(appBus, ownPath, ACCESSIBLE, 'GetState'),
+        STATE.EDITABLE,
+      ),
+      'the EDITABLE state is still true of it',
+    );
+
+    assert.equal(await getProp(appBus, editorPath, TEXT, 'CharacterCount'), 9);
+    assert.deepEqual(
+      await call(appBus, editorPath, TEXT, 'GetStringAtOffset', 'iu', [4, 1]),
+      ['x', 4, 5],
+    );
+
+    // the AT types: one replacement through the element's own seam, and the
+    // diff comes back off the state it reports afterwards
+    signals.length = 0;
+    assert.equal(
+      await call(appBus, editorPath, EDITABLE, 'InsertText', 'isi', [
+        9,
+        ' + 2',
+        4,
+      ]),
+      true,
+    );
+    await until(
+      () =>
+        eventsNamed('TextChanged').some(
+          (s) => s.path === editorPath && s.body[0] === 'insert',
+        ),
+      'the edit as a text-changed insert',
+    );
+    assert.equal(
+      await call(appBus, editorPath, TEXT, 'GetText', 'ii', [0, -1]),
+      'let x = 1 + 2',
+    );
+
+    // …and the caret it moves is a caret the element moved
+    signals.length = 0;
+    assert.equal(
+      await call(appBus, editorPath, TEXT, 'SetCaretOffset', 'i', [3]),
+      true,
+    );
+    await until(
+      () => eventsNamed('TextCaretMoved').some((s) => s.path === editorPath),
+      'the caret move',
+    );
+    assert.equal(await getProp(appBus, editorPath, TEXT, 'CaretOffset'), 3);
+
+    unregisterElement('minieditor');
+    unregisterElement('minidoc');
+    unregisterElement('miniown');
   });
 
   test('unmounting removes the tree and tells the cache', async () => {

--- a/test/overflow-scroll.test.js
+++ b/test/overflow-scroll.test.js
@@ -10,7 +10,7 @@ import { test } from 'node:test';
 import assert from 'node:assert';
 import React from 'react';
 import { createRoot } from '../src/index.js';
-import { a11yRole, ATSPI_ROLE } from '../src/a11y.js';
+import { atspiRoleOf, ATSPI_ROLE } from '../src/a11y.js';
 import { createMockApp, spinWheel } from './helpers/mock-app.js';
 
 const h = React.createElement;
@@ -57,7 +57,7 @@ test('a box only scrolls when overflow says scroll', async () => {
   assert.equal(box._maxScroll('y'), 0);
   assert.deepEqual(box._scrollbars(), []);
   assert.equal(box.focusableByDefault, false, 'not a tab stop');
-  assert.equal(a11yRole(box), ATSPI_ROLE.FILLER, 'not a scroll pane');
+  assert.equal(atspiRoleOf(box), ATSPI_ROLE.FILLER, 'not a scroll pane');
 
   // ...and the content is still where it was laid out
   assert.equal(node.children[0].children[0].abs.y, 0);
@@ -77,7 +77,7 @@ test('overflow: scroll turns the same box into a scroll pane', async () => {
     true,
     'a tab stop, having somewhere to go',
   );
-  assert.equal(a11yRole(box), ATSPI_ROLE.SCROLL_PANE);
+  assert.equal(atspiRoleOf(box), ATSPI_ROLE.SCROLL_PANE);
   assert.equal(box._scrollbars().length, 1, 'a vertical thumb, no horizontal');
 });
 
@@ -181,7 +181,7 @@ test('a window scrolls its own content', async () => {
   assert.equal(node.children[0].abs.y, -80, 'the children moved under it');
 
   // a window is a frame to a screen reader whatever its overflow says
-  assert.equal(a11yRole(node), ATSPI_ROLE.FRAME);
+  assert.equal(atspiRoleOf(node), ATSPI_ROLE.FRAME);
 });
 
 test('the wheel scrolls the window when nothing inner takes it', async () => {

--- a/test/scroll-protocol.test.js
+++ b/test/scroll-protocol.test.js
@@ -25,7 +25,7 @@ import { createClient, StaticFontSource } from 'ntk';
 import { createRoot } from '../src/index.js';
 import { registerElement, unregisterElement } from '../src/host.js';
 import { Node, Scrollable } from '../src/node.js';
-import { a11yRole, ATSPI_ROLE } from '../src/a11y.js';
+import { atspiRoleOf, ATSPI_ROLE } from '../src/a11y.js';
 import { XK_PAGE_DOWN } from '../src/keysyms.js';
 import { createMockApp, spinWheel } from './helpers/mock-app.js';
 
@@ -242,7 +242,7 @@ test('painted content gets the bars, the keys and the scroll-pane role', async (
   );
 
   assert.equal(editor.focusableByDefault, true, 'a tab stop, being scrollable');
-  assert.equal(a11yRole(editor), ATSPI_ROLE.SCROLL_PANE);
+  assert.equal(atspiRoleOf(editor), ATSPI_ROLE.SCROLL_PANE);
 
   editor.focus();
   await tick();

--- a/test/types/extend.tsx
+++ b/test/types/extend.tsx
@@ -20,7 +20,11 @@ import {
   intrinsicSize,
   CARET_BLINK_MS,
 } from '../../src/node.js';
-import type { MeasureConstraints, TextStyle } from '../../src/node.js';
+import type {
+  A11yTextState,
+  MeasureConstraints,
+  TextStyle,
+} from '../../src/node.js';
 import type { Rect } from '../../src/types/nodes.js';
 import { XK_ESCAPE, XK_TAB } from '../../src/keysyms.js';
 // the synthetic events, not the DOM's same-named globals
@@ -167,11 +171,43 @@ class ThumbNode extends Node {
 class EditorNode extends Node {
   private caretOn = false;
   private tabEscapes = false;
+  private text = '';
+  private caret = 0;
 
   constructor(props: Record<string, unknown>, app: never) {
     super('codeeditor', props, app);
     this.focusableByDefault = true;
     this.defaultCursor = 'text';
+    // what it is when the application writes no `role` (#257)
+    this.a11yRole = 'textbox';
+  }
+
+  // The accessibility seam (#257): the state a screen reader reads, the two
+  // writes it may make, and the notification that ties them to the element's
+  // own editing.
+  a11yTextState(): A11yTextState {
+    return {
+      value: this.text,
+      caret: this.caret,
+      selectionStart: this.caret,
+      selectionEnd: this.caret,
+      editable: true,
+      multiline: true,
+      preedit: null,
+    };
+  }
+
+  a11ySetSelection(_start: number, end: number): boolean {
+    this.caret = end;
+    this.notifyA11yTextChanged();
+    return true;
+  }
+
+  a11yReplaceText(start: number, end: number, text: string): boolean {
+    this.text = this.text.slice(0, start) + text + this.text.slice(end);
+    this.caret = start + text.length;
+    this.notifyA11yTextChanged();
+    return true;
   }
 
   defaultKeyDown(ev: KeyboardEvent): void {


### PR DESCRIPTION
Closes #257.

A registered element that draws text is silent to a screen reader: core's editable controls feed AT-SPI from `_chars()`/`_caret`/`_selection`, which a `<codeeditor>` in another package does not have, so it had a role string and nothing else — no text interface, no caret, no text-changed events, and no seam to grow one from outside.

## The seam

| member | |
| --- | --- |
| `a11yTextState()` | `{ value, caret, selectionStart, selectionEnd, editable, multiline, preedit }`, or `null` for an element holding no text |
| `notifyA11yTextChanged()` | the text moved — the push that says the state is worth pulling again. Free when nothing is listening |
| `a11ySetSelection(start, end)` | an AT moved the caret or made a selection |
| `a11yReplaceText(start, end, text)` | an AT edited: insert, delete and replace-everything all arrive as this |
| `a11yRole` | the element's own default role, below a `role` prop |

```js
class EditorNode extends Node {
  a11yTextState() {
    return {
      value: this.lines.join('\n'),
      caret: this.caret,
      selectionStart: this.anchor,
      selectionEnd: this.caret,
      editable: true,
      multiline: true,
    };
  }

  insert(text) {
    /* …the edit… */ this.notifyA11yTextChanged();
  }
}
```

That buys the whole read side — character count, reading by character/word/line, caret, selection, and the `text-changed` / `text-caret-moved` / `text-selection-changed` deltas Orca narrates from.

## Decisions worth reviewing

- **Two tiers, because a viewer is not a degenerate editor.** Value plus a selection is a document with the `Text` interface — markdown, a code block, a log, a terminal — which is the read-only half of the same gap raised in the issue comment. `editable: true` adds the EDITABLE state and an `entry` role; `a11yReplaceText` adds `EditableText`. An element that claims editable text without implementing the write is announced as editable and reports its own edits, but is **not** exposed as one an AT may type into — an interface whose every method answered false is a lie an AT cannot test.
- **One normalizer, not a second model.** `customTextState()` turns the element's answer into the `{ chars, caret, selection, preedit }` the bridge and the spy already speak, clamping offsets (code points) on the way — so granularity, attribute runs, the diff, `:system` composition marking and the spy transcript are all the code that serves `<textinput>`. A third-party editor cannot be read *differently* from core's, only less.
- **Every EditableText write is one replacement.** `SetTextContents`/`InsertText`/`DeleteText` are now `editText(node, start, end, text)` with one end moved — the primitive both implementations can offer, and one an editor needs anyway.
- **Declared, not inferred.** `a11yRole` sits above the scroller rule, so an editor that scrolls its painted text stays an entry rather than becoming a scroll pane; `multiline` left unsaid claims neither line state, because guessing it off a `\n` would report the element's *shape* changing the first time somebody pressed Enter.
- **`a11yRole` replaces the old advice** in docs/accessibility.md to set `props.role` in a constructor — props are replaced wholesale by `applyProps`, so that never survived the first update.
- Internal rename: `a11yRole(node)` → `atspiRoleOf(node)` in `src/a11y.js`, freeing the name for the node-side declaration. Not part of any public entry point.

## Limits, stated in the docs

Per-character extents fall back to the element's own rect (a magnifier tracks the element, not the glyph), and AT-driven copy/paste stays the built-ins' clipboard round trip. Both need a layout only the element has; an element's own Ctrl+C/Ctrl+V is unaffected.

## Tests

- `test/a11y-custom-text.test.js` — a worked editor and a worked viewer, driven through `renderX11(…, { a11y: true })`: role and states, clamping, typing as a diff, a caret move with no edit, a selection in a read-only document, and a composition that is one preedit and then the character it commits.
- `test/atspi.test.js` — the same over real D-Bus: the registered element exports `Text` (+ `EditableText` only where it writes), an AT reads it, `InsertText` lands through the element's own seam and comes back as a text-changed insert, `SetCaretOffset` moves a caret the element moved.
- Mutation-checked: disabling `customTextState` fails 8 of 11 new tests plus the wire test; emptying `notifyA11yTextChanged` fails 4 plus the wire test.
- `npm test` is otherwise unchanged (the six `test/appearance.test.js` failures on this machine are pre-existing on master — macOS answers the appearance ladder before the mocked XSETTINGS does), `npm run lint`, `npm run typecheck` and the docs-site build all pass.

No screenshots: nothing here is visible on screen.
