### PR TITLE
feat(elements): the text a reader can take — selection across a document

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,6 +141,24 @@ no override-redirect staging (issue #4).
   one would corrupt them undetectably. `preventDefault()` is the usual
   default-action seam, and reaches XDND (`src/dnd.js`), which is the one
   ClientMessage protocol core answers on the same stream.
+- `src/textselection.js` + `src/textrange.js` — selecting read-only text
+  (#259). `textrange.js` is the pure half: words, blocks, and the code
+  point ↔ code unit table anything reading ntk run geometry needs, shared
+  with `<textinput>`'s editing keys so a double click picks the same word in
+  a document and in a field. `textselection.js` is the model — the surface a
+  `selectable` element becomes, and the registry that holds the one rule no
+  surface can hold for itself: **only one selection is visible in an
+  application at a time**, so a drag across a document collapses the
+  highlight in the field beside it and vice versa. Two decisions live there.
+  A participant is any node that answers the four geometry accessors on
+  `Node` (`textContent`, `textIndexAt`, `textCaretRect`, `textRangeRects`),
+  so a terminal written outside this package joins a document with no
+  registration call. And the separators a copy assembles with come from the
+  **layout** rather than from the markup — two pieces of text sharing a band
+  of pixels are joined with a tab, one that starts below the last with a
+  newline — because core cannot know which `<text>` is a table cell, and
+  asking applications to say so would be a second authoring model for
+  something the screen already shows.
 - `src/inputtime.js` — the two selection timestamps, both public since #18's
   second gap: `lastInputTime(app)` is the last input event's server time,
   stashed off the event stream because ICCCM wants "the timestamp of the
@@ -316,7 +334,7 @@ stop it, in one place — see docs/desktop.md for the worked example.
   Runs in CI beside lint. **A prop change is not done until the `.d.ts` and a
   line in the type test change with it** — hand-written declarations drift
   silently otherwise, and nothing else catches it.
-- `npm run examples:{app,theming,simple,simple-nojsx,xeyes,dashboard,tasks,menu,form,richtext,widgets,react-features,windows,wm}`
+- `npm run examples:{app,theming,simple,simple-nojsx,xeyes,dashboard,tasks,menu,form,richtext,selection,widgets,react-features,windows,wm}`
   — need a running X server (`DISPLAY` set; XQuartz on macOS, Xvfb for
   automation). `examples:app` is the showcase: it hosts `form`, `widgets`
   and `tasks` as tabs by importing the panel each of them exports, so a new

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,8 @@
 - [elements.md](elements.md) — the host elements: `<window>`, `<popup>`,
   `<box>`, `<text>`, `<textinput>`, `<textarea>`, `<image>`, `<canvas>`,
   `<foreign>`, and the rich-content wrappers `<markdown>`, `<html>`,
-  `<svg>`, `<tex>`, their props and refs.
+  `<svg>`, `<tex>`, their props and refs — including
+  [selecting read-only text](elements.md#selecting-text) with `selectable`.
 - [styling.md](styling.md) — the `style` prop: layout and paint properties,
   `:hover`/`:focus`/`:active`/`:disabled` blocks, transitions, theme tokens,
   window size queries, `createStyles`.

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -39,7 +39,7 @@ is _boring_ to a screen reader rather than broken:
 | `<window>`              | frame, named by `title`                                     |
 | `<popup>`               | window (give the content a `role` — `menu`, `dialog`, …)    |
 | `<box>`                 | filler — skipped silently, like GTK's own layout boxes      |
-| `<text>`                | label, reading its content                                  |
+| `<text>`                | label, reading its content — and its selection, if any      |
 | `<textinput>`           | entry: editable, single-line, caret and selection live      |
 | `<textarea>`            | entry: editable, multi-line                                 |
 | `<image>` / `<svg>`     | image, named by `alt`                                       |
@@ -195,6 +195,13 @@ and type. Every edit and caret move emits the precise
 One honest limit: "line" granularity follows hard newlines, not the soft
 wraps of a `<textarea>`'s layout. Orca still reads everything; a
 line-by-line walk of one long wrapped paragraph is one stop, not several.
+
+A `<text>` has the `Text` interface too — readable, with no caret to move.
+What it now also reports is its **selection**: a paragraph inside a
+`selectable` surface ([elements.md](elements.md#selecting-text)) hands over
+the range the user has dragged across, and says so as it moves, so a
+magnifier's highlight and a braille display's cursor sit on the same
+characters the highlight is painted over.
 
 ### While a composition is open
 

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -111,6 +111,10 @@ a drag — and works with other X11 applications as well as inside the app.
 Their presence is what registers the node, so there is nothing else to
 mount: [drag-and-drop.md](drag-and-drop.md).
 
+`selectable` makes an element a **selection surface**: text inside it can be
+dragged over, copied and handed to the PRIMARY selection. See
+[Selecting text](#selecting-text) below.
+
 ---
 
 ## `<window>`
@@ -991,6 +995,133 @@ The cost is real: the precise path rasterizes outlines on every draw and
 caches nothing. That is the right trade for text being animated and the
 wrong one for a paragraph that never changes, which is why `auto` is the
 default rather than the other way round.
+
+## Selecting text
+
+_Issue #259._ A label is not selectable, the way `Gtk.Label` is not: a
+desktop application is full of text that is chrome rather than content, and
+a stray drag lighting up a button's caption is noise. Text becomes
+selectable when an element says so.
+
+```jsx
+<box selectable style={{ padding: 12 }}>
+  <text style={{ fontSize: 20, fontWeight: 'bold' }}>Release notes</text>
+  <text>Everything below this heading can be dragged over and copied.</text>
+</box>
+```
+
+That one prop is the whole feature. The element becomes a **surface**: a
+drag inside it selects across every piece of text under it, a double click
+takes a word, a triple click takes a block, Ctrl+A takes the surface and
+Ctrl+C copies it. Releasing the button hands the text to **PRIMARY**, so a
+middle click in a terminal pastes it — which is what selecting text means
+on X11 ([clipboard.md](clipboard.md)).
+
+### What is in a surface
+
+Everything under it that can answer for its own text, in document order.
+`<text>` can; so can any element that implements the accessors in
+[extending.md](extending.md#answering-for-your-own-text) — a terminal, a log
+view, a code editor written outside this package are all selected across by
+the same drag, with no registration call.
+
+What is **not** in it:
+
+- anything under a `selectable={false}`, which is CSS's `user-select: none`.
+  A list's bullets, a table's chrome, a button's caption inside a document;
+- `<textinput>` and `<textarea>`, and any element that says
+  `hasOwnSelection` — they keep their own selection, and a press in one is
+  theirs;
+- the document views (`<markdown>`, `<html>`, `<svg>`, `<tex>`), which draw
+  their text through an ntk widget that exposes no character geometry to us.
+
+### What a copy assembles
+
+The separators come from the **layout**, not from the markup: core cannot
+know that one `<text>` is a table cell and another is a paragraph, and
+asking every application to say so would be a second authoring model for
+something the screen already shows. Two pieces of text sharing a band of
+pixels are joined with a **tab**; one that starts below the last is joined
+with a **newline**. For a table laid out as rows of cells that is exactly
+"cells with tabs, rows with newlines", and for ordinary prose it is one
+paragraph per line.
+
+```jsx
+// copies as "name\tsize\nnotes\t4 kB"
+<box selectable>
+  <box style={{ flexDirection: 'row' }}>
+    <text style={{ width: 120 }}>name</text>
+    <text>size</text>
+  </box>
+  <box style={{ flexDirection: 'row' }}>
+    <text style={{ width: 120 }}>notes</text>
+    <text>4 kB</text>
+  </box>
+</box>
+```
+
+A list marker excluded with `selectable={false}` is absent from the copied
+text as well as from the highlight, which is the point of excluding it.
+
+### The props
+
+| prop                    |                                                                                           |
+| ----------------------- | ----------------------------------------------------------------------------------------- |
+| `selectable`            | `true` starts a surface; `false` opts a subtree out of the one above it                   |
+| `selectionColor`        | the highlight behind selected text (default: a tint of the theme's accent)                |
+| `onSelectionChange(ev)` | `ev.text` is what a copy would put on the clipboard, `ev.isCollapsed` whether it is empty |
+
+And on the surface's node, through a ref: `selectAll()`, `clearSelection()`,
+`selectedText()`, `setSelection(anchor, focus)` — each end
+`{ node, index }`, indices in code points — and `textSelection`, a snapshot of
+`{ isCollapsed, text, ranges }`.
+
+### One selection, and where the keys go
+
+**Only one selection is visible in an application at a time.** Selecting in
+a document collapses the highlight in the field beside it, and selecting in
+a field clears the document — the two never both claim to be showing the
+selection, which is a rule core holds rather than one every surface has to
+keep. That is also what makes PRIMARY honest: there is one selection on the
+display, so there is one here.
+
+A surface is a **focus target**, because Ctrl+A and Ctrl+C are keystrokes
+and a keystroke has to arrive somewhere. That puts it in the Tab cycle;
+`tabIndex={-1}` takes it back out while leaving it focusable by a press —
+which is the right choice for a document inside a larger UI, and the wrong
+one for a reader whose window is the document.
+
+The pointer shows an I-beam over a surface, the way it does over a field.
+`style={{ cursor: … }}` overrides it as usual.
+
+The selection is reported to assistive technology as it moves: a `<text>`
+already exposed AT-SPI's text interface, and the range a reader has dragged
+across now travels through it ([accessibility.md](accessibility.md#text-controls)).
+
+### The geometry underneath
+
+The selection is built out of four accessors that every drawn node answers,
+and they are public in their own right — a caret rect is what an
+autocomplete popup anchors to (`<popup anchor={{ to, at }}>`), and a hit
+test is how an app turns a click into a character offset:
+
+```js
+const node = paragraphRef.current;
+node.textContent(); // 'Everything below this heading…'
+node.textIndexAt(ev.x, ev.y); // 14 — window coordinates in, a code point out
+node.textCaretRect(14); // { x, y, width: 0, height }
+node.textRangeRects(4, 14); // the bands a highlight over [4, 14) fills
+```
+
+Indices are **code points**, not UTF-16 units, so an emoji is one position.
+Rectangles are in the owning window's coordinates — the same space as
+`abs`, `contentBox()` and a mouse event's `x`/`y`. `textRangeRects` returns
+one band per line _and_ one per direction run inside a line: a range that
+crosses from Latin into Arabic covers two separate stretches of pixels, and
+a single rectangle drawn between two caret positions would paint over text
+nobody selected.
+
+---
 
 ## `<textinput>`
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -182,6 +182,102 @@ called with `2` when a glyph can have moved and `1` when only the ink or the
 glyph rounding did. The default re-measures on the first and repaints on the
 second, which is right for most elements.
 
+### Answering for your own text
+
+_Issue #259._ An element that draws text can also let the user **select**
+it. There is no registration call and no list of blessed kinds: a
+`selectable` ancestor walks its subtree and asks every node four questions,
+and an element that answers them is part of the document.
+
+```js
+class LogViewNode extends Node {
+  // the string the three below index into — null (the default) means
+  // "this element has no text", which is the honest answer for a <box>
+  textContent() {
+    return this.lines.join('\n');
+  }
+
+  // window coordinates in, a code-point index out. Clamp: a point past the
+  // end of the text is the end of the text, which is what a drag into the
+  // margin depends on
+  textIndexAt(x, y) {
+    return this._layout().indexAt(x - this._originX(), y - this._originY());
+  }
+
+  // where a caret at that index stands: a zero-width rect, glyph top to
+  // glyph bottom
+  textCaretRect(index) {
+    const caret = this._layout().caretPosition(index);
+    return {
+      x: this._originX() + caret.x,
+      y: this._originY() + caret.y,
+      width: 0,
+      height: caret.height,
+    };
+  }
+
+  // and the bands a highlight over [start, end) fills
+  textRangeRects(start, end) {
+    /* one per line — see below */
+  }
+
+  paint(ctx) {
+    super.paint(ctx);
+    // the range the document selection has claimed of *this* element's
+    // text, pushed down whenever it moves. Paint it under the glyphs.
+    const range = this.selectionRange;
+    if (range) {
+      ctx.fillStyle = this.selectionColor;
+      const rects = [];
+      for (const r of this.textRangeRects(range.start, range.end)) {
+        rects.push(r.x, r.y, r.width, r.height);
+      }
+      ctx.fillRects(rects);
+    }
+    this._layout().draw(ctx, this._originX(), this._originY());
+  }
+}
+```
+
+**Two spaces, and both are the ones already in use.** Indices are **code
+points** — the space ntk's `TextLayout.caretPosition`/`indexAt` speak, so an
+emoji is one position and not two — and rectangles are in the **owning
+window's** coordinates, the same as `abs`, `contentBox()` and a mouse
+event's `x`/`y`. An element that answers in its own local coordinates is one
+whose highlight is drawn somewhere else on the screen.
+
+**Answer from what you draw.** `<text>` computes its layout and its origin
+in one place and uses it for painting and for all four accessors, because a
+caret answered from a differently-placed layout is a caret in the wrong
+place and nothing about it looks like a bug in the accessor. If your element
+scrolls, the origin has the scroll offset in it — that is what makes a hit
+test right after the user has scrolled.
+
+**One band per line, and one per direction run.** A selection is contiguous
+in _logical_ order and a line is laid out in _visual_ order, so a range that
+crosses from Latin into Arabic covers two disjoint stretches of pixels. If
+you are drawing with ntk's `TextLayout`, walk `line.runs` and intersect each
+one with the range rather than filling from one caret x to the other;
+`<text>` does this and `test/text-selection.test.js` pins it.
+
+**Say if you own a selection of your own.** An element that edits — anything
+with a caret the user moves — sets `hasOwnSelection = true` in its
+constructor. A `selectable` document then skips its subtree whole and never
+takes its presses, which is what keeps a `<textinput>` inside a document
+from having half of it lit by somebody else's drag.
+
+**Presses arrive through the base class.** `Node`'s `defaultMouseDown`,
+`defaultMouseDrag`, `defaultMouseUp` and `defaultKeyDown` hand the gesture
+to the nearest `selectable` ancestor, so an element that only draws needs to
+write none of them. An element that overrides one and does not call `super`
+has taken that gesture for itself — right for an editor, and the reason a
+drawing element that wants both should end its handler with
+`super.defaultMouseDown(ev)`.
+
+Everything about the surface side — what a copy assembles, what the
+separators are, which keys are bound — is in
+[elements.md](elements.md#selecting-text).
+
 ### A size of your own
 
 `<box>` is as big as its style and its children say; a gauge, a chart, a

--- a/examples/selection.jsx
+++ b/examples/selection.jsx
@@ -1,0 +1,125 @@
+// Selecting read-only text (#259), and the manual harness for the half of
+// it no headless test can reach: the PRIMARY selection.
+//
+//   npm run examples:selection      # needs an X server / DISPLAY
+//
+// The window is one `<box selectable>`. Drag across the paragraphs,
+// double-click for a word, triple-click for a block, Ctrl+A for everything,
+// Ctrl+C to copy. The strip at the bottom shows what a copy would put on
+// the clipboard, which is the part worth watching while dragging over the
+// table: cells arrive tab-separated and rows newline-separated, and the row
+// numbers — `selectable={false}` — never arrive at all.
+//
+// Things worth trying, all of which need another application:
+//   - Select something, then **middle-click in a terminal**. The release
+//     hands the text to PRIMARY, which is what selecting means on X11.
+//   - Select in the `<textinput>` at the top, then drag across a paragraph:
+//     the field's highlight goes out. Only one selection is visible in an
+//     application at a time, and the field and the document take turns.
+//   - Drag from the middle of a paragraph out past the bottom of the
+//     window and back. The nearest text answers, so the margin selects
+//     whole lines rather than nothing.
+//   - Type a right-to-left string into the field and copy it into the
+//     bidi line: a range that crosses direction is two bands of highlight,
+//     not one from caret to caret.
+import React, { useRef, useState } from 'react';
+
+import { createRoot, createStyles } from '../src/index.js';
+
+const s = createStyles({
+  doc: { padding: 18, gap: 12, flexGrow: 1 },
+  heading: { fontSize: 20, fontWeight: 'bold' },
+  para: { fontSize: 14, lineHeight: 1.4 },
+  row: { flexDirection: 'row', gap: 10 },
+  marker: { width: 22, color: '$dim' },
+  name: { width: 150 },
+  field: { flexDirection: 'row', gap: 8, alignItems: 'center' },
+  readout: {
+    padding: 10,
+    gap: 4,
+    backgroundColor: '$surfaceHover',
+    borderTopWidth: 1,
+    borderColor: '$track',
+  },
+  small: { fontSize: 11, color: '$dim' },
+});
+
+const files = [
+  ['README.md', '4 kB'],
+  ['index.js', '12 kB'],
+  ['notes.txt', '900 B'],
+];
+
+function App() {
+  const doc = useRef(null);
+  const [selected, setSelected] = useState('');
+
+  return (
+    <>
+      <box style={s.field}>
+        <text style={s.small}>a field, for the other half of the rule:</text>
+        <textinput defaultValue="select me too" style={{ width: 160 }} />
+      </box>
+
+      <box
+        ref={doc}
+        selectable
+        onSelectionChange={(ev) => setSelected(ev.text)}
+        style={s.doc}
+      >
+        <text style={s.heading}>Selecting text</text>
+        <text style={s.para}>
+          A label is not selectable here, the way a GTK label is not: a desktop
+          application is full of text that is chrome rather than content, and a
+          stray drag lighting up a button&apos;s caption is noise. Text becomes
+          selectable when an element says so.
+        </text>
+        <text style={s.para}>
+          Everything under that element is then one document — including
+          elements written outside this package, as long as they answer for
+          their own characters (docs/extending.md).
+        </text>
+        <text style={s.para}>
+          A line that changes direction: the file مرحبا is here.
+        </text>
+
+        {files.map(([name, size], i) => (
+          <box key={name} style={s.row}>
+            <text selectable={false} style={s.marker}>
+              {i + 1}.
+            </text>
+            <text style={s.name}>{name}</text>
+            <text>{size}</text>
+          </box>
+        ))}
+      </box>
+
+      <box style={s.readout}>
+        <text style={s.small}>what a copy would put on the clipboard:</text>
+        <text style={{ fontSize: 12 }}>
+          {selected ? JSON.stringify(selected) : '(nothing selected)'}
+        </text>
+      </box>
+    </>
+  );
+}
+
+export function Selection() {
+  return (
+    <window
+      width={540}
+      height={430}
+      title="react-x11 — selection"
+      style={{ backgroundColor: '$background' }}
+    >
+      <App />
+    </window>
+  );
+}
+
+export default Selection;
+
+if (!process.env.REACT_X11_NO_AUTORUN) {
+  const root = await createRoot();
+  root.render(<Selection />);
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "examples:form": "tsx examples/form.jsx",
     "examples:rules": "tsx examples/rules.jsx",
     "examples:richtext": "tsx examples/richtext.jsx",
+    "examples:selection": "tsx examples/selection.jsx",
     "examples:widgets": "tsx examples/widgets.jsx",
     "examples:datepicker": "tsx examples/datepicker.jsx",
     "examples:password": "tsx examples/password.jsx",

--- a/src/a11y.js
+++ b/src/a11y.js
@@ -537,9 +537,15 @@ export function a11yDescription(node) {
  */
 export function isFocusable(node) {
   if (node.props.disabled) return false;
+  // A `selectable` surface is a focus target for the same reason a scroll
+  // pane is: the keys that operate it — Ctrl+A, Ctrl+C — have to arrive
+  // somewhere, and a document nobody can copy from with the keyboard is a
+  // WCAG 2.1.1 failure on the one feature it exists for. `tabIndex={-1}`
+  // keeps it clickable and takes it back out of the Tab cycle.
+  const byDefault =
+    (node.focusableByDefault ?? false) || node.props.selectable === true;
   return (
-    node.props.focusable ??
-    (node.props.tabIndex != null ? true : (node.focusableByDefault ?? false))
+    node.props.focusable ?? (node.props.tabIndex != null ? true : byDefault)
   );
 }
 
@@ -851,7 +857,14 @@ export function textStateOf(node) {
   if (custom) return custom;
   const spans = node.collectSpans?.([]) ?? [];
   const chars = Array.from(spans.map((s) => s.text).join(''));
-  return { chars, caret: 0, selection: [0, 0], preedit: null };
+  // A label has no caret, but it can have a **selection**: a `<text>` inside
+  // a `selectable` surface is part of a document the user drags across
+  // (#259), and that range is the one thing about a label that moves at
+  // runtime. Reporting it is what puts a magnifier's highlight and a braille
+  // display's cursor on the same characters the highlight is painted over.
+  const range = node.selectionRange;
+  const selection = range ? [range.start, range.end] : [0, 0];
+  return { chars, caret: selection[1], selection, preedit: null };
 }
 
 /**

--- a/src/node.d.ts
+++ b/src/node.d.ts
@@ -151,6 +151,37 @@ export declare class Node {
    * elements declare these to `registerElement` instead of overriding. */
   readonly semanticNames: ReadonlySet<string>;
 
+  // --- the text this element answers for (docs/extending.md) ---------------
+  //
+  // Four questions in one index space and one coordinate space: characters
+  // are **code points**, rectangles are in the owning window's coordinates —
+  // the same ones `abs`, `contentBox()` and a mouse event's `x`/`y` use.
+  // An element that answers them can be selected across by a `selectable`
+  // ancestor with no registration of any kind.
+
+  /** This element's text, or null when it has none. The default. */
+  textContent(): string | null;
+  /** The character boundary nearest a point. Clamps to the ends. */
+  textIndexAt(x: number, y: number): number;
+  /** Where a caret at this index stands — a zero-width rect from the top of
+   * the glyphs to the bottom of them. */
+  textCaretRect(index: number): Rect | null;
+  /** The bands a highlight over `[start, end)` fills: one per line, and one
+   * per direction run within a line — a range that crosses from Latin into
+   * Arabic is two stretches of pixels, not the span between them. */
+  textRangeRects(start: number, end: number): Rect[];
+  /** The part of this element's text the document selection covers, or
+   * null. An element that paints its own text fills `textRangeRects` with
+   * `selectionColor` under the glyphs while this is set; that is the whole
+   * contract for taking part in a selection. */
+  readonly selectionRange: { start: number; end: number } | null;
+  /** What to fill those rectangles with while `selectionRange` is set. */
+  readonly selectionColor: string | null;
+  /** An element with a selection of its own — an editor. A `selectable`
+   * document around it skips its subtree whole and leaves its presses
+   * alone. `<textinput>` sets it. */
+  hasOwnSelection: boolean;
+
   /** Draw. A subclass calls `super.paint(ctx)` first, for the background,
    * border and clip, then draws inside `this.abs`. */
   paint(ctx: Context2D): void;
@@ -195,8 +226,17 @@ export declare class Node {
    * `defaultKeyDown`. See docs/extending.md.
    */
   defaultComposition?(ev: CompositionEvent): void;
-  /** The element's own behaviour for a press, after `onMouseDown` handlers:
-   * placing a caret, grabbing a scrollbar thumb, arming a drag. */
+  /**
+   * The element's own behaviour for a press, after `onMouseDown` handlers:
+   * placing a caret, grabbing a scrollbar thumb, arming a drag.
+   *
+   * The base class implements this (and the two below, and `defaultKeyDown`)
+   * to hand the gesture to the nearest `selectable` ancestor, so a press on
+   * anything inside a document reaches the selection. An element that
+   * overrides it and does not call `super` is, by that alone, not part of
+   * one — which is right for anything that edits, and wrong for anything
+   * that only draws.
+   */
   defaultMouseDown?(ev: MouseEvent): void;
   /** Pointer motion while this element holds the press — it keeps receiving
    * these wherever the pointer goes, as `onMouseMove` does not. */

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -70,6 +70,19 @@ import { lastInputTime } from './inputtime.js';
 import { armPasteState, canPaste } from './pastestate.js';
 import { ctrlChordLetter, MOD } from './keysyms.js';
 import {
+  codePointAtOffset,
+  codePoints,
+  codeUnitOffsets,
+  wordBoundary,
+  wordRangeAt,
+} from './textrange.js';
+import {
+  TextSelection,
+  dropVisibleSelection,
+  selectionSurfaceOf,
+  takeVisibleSelection,
+} from './textselection.js';
+import {
   editMenuColors,
   editMenuGeometry,
   editMenuIndexAt,
@@ -195,6 +208,7 @@ const INVALIDATE_REASONS = new Set([
   'animation', // a transition frame
   'scroll', // scrollTo/scrollBy/scrollIntoView, textarea/textinput panning
   'text', // text content, input value or caret editing
+  'selection', // the document selection lit or unlit a range of text
   'content', // async content arrived (image decode, rich-content reflow)
   'measure', // an element said its own size changed (invalidateMeasure)
   'child-list', // children were added, removed or reordered
@@ -1096,6 +1110,15 @@ export class Node {
       // with (#248), without knowing either of them exists.
       if (typeof this.measureContent === 'function') this._useMeasureContent();
     }
+    // the document selection: the state when this element is a `selectable`
+    // surface, and the part of somebody else's that lands on this one
+    this._textSelection = null;
+    this._selRange = null;
+    // an element with a selection of its own — `<textinput>` — whose subtree
+    // a document around it skips whole rather than lighting up half of what
+    // the user is editing
+    this.hasOwnSelection = false;
+    this._syncSelectable(props);
     if (DEV) devCheckA11yProps(this);
   }
 
@@ -1827,6 +1850,10 @@ export class Node {
    * freed by the caller via freeRecursive on the subtree top. */
   destroySubtree() {
     this.destroyed = true;
+    // a surface that goes away takes its selection with it, and the app-wide
+    // claim on being the one showing one goes with it too
+    this._textSelection?.destroy();
+    if (this.hasOwnSelection) dropVisibleSelection(this);
     for (const child of this.children) child.destroySubtree();
   }
 
@@ -1857,6 +1884,8 @@ export class Node {
     if (Boolean(newProps.trapFocus) !== Boolean((oldProps ?? prev).trapFocus)) {
       this._syncFocusScope();
     }
+    // and so does being a selection surface
+    this._syncSelectable(newProps);
     // drop-target registration follows the props edge, like trapFocus
     if (hasDropProps(newProps) !== hasDropProps(oldProps ?? prev)) {
       const root = this.root;
@@ -2478,6 +2507,162 @@ export class Node {
     ));
   }
 
+  // --- the text an element answers for (issue #259) ------------------------
+  //
+  // Four questions, in one index space and one coordinate space: characters
+  // are **code points** (an emoji is one position, not two — the space ntk's
+  // caret API speaks), and rectangles are in the owning window's coordinates,
+  // the same ones `abs`, `contentBox()` and a mouse event's `x`/`y` are in.
+  //
+  // They are what a selection is made of, and the reason they are on `Node`
+  // rather than on `<text>`: the selection service walks a subtree and asks,
+  // so an element that answers them joins a document without core knowing it
+  // exists. The defaults are the honest answers for an element with no text
+  // — a `<box>` has none, and `null` says so rather than claiming an empty
+  // string sits somewhere inside it.
+
+  /** This element's text, or null when it has none — the string the three
+   * accessors below index into. */
+  textContent() {
+    return null;
+  }
+
+  /** The character boundary nearest a point, in window coordinates. Clamps,
+   * so a point past the end of the text answers with the end of it. */
+  textIndexAt(x, y) {
+    return 0;
+  }
+
+  /** Where a caret at this index would stand, in window coordinates — a
+   * zero-width rect from the top of the glyphs to the bottom of them. */
+  textCaretRect(index) {
+    return null;
+  }
+
+  /**
+   * The bands a highlight over `[start, end)` fills, in window coordinates:
+   * one per line, and more than one on a line whose text changes direction
+   * halfway across it. Empty when the range is empty or off the end.
+   */
+  textRangeRects(start, end) {
+    return [];
+  }
+
+  /**
+   * The part of this element's text the document selection covers, as
+   * `{ start, end }` in code points, or null. An element that paints its own
+   * text paints a band under it while this is set — `textRangeRects` gives
+   * the rectangles and `selectionColor` the fill — and that is the whole of
+   * taking part in a selection. `<text>` keeps no more state than this.
+   */
+  get selectionRange() {
+    return this._selRange
+      ? { start: this._selRange.start, end: this._selRange.end }
+      : null;
+  }
+
+  /** What to fill `textRangeRects` with while `selectionRange` is set: the
+   * surface's `selectionColor`, or the theme's accent tinted. */
+  get selectionColor() {
+    return this._selRange?.color ?? null;
+  }
+
+  // --- being a selection surface -------------------------------------------
+
+  /** `selectable` arrived or left. `true` makes this element the surface a
+   * drag inside it selects across; `false` opts its subtree out of the one
+   * above it, and is read where the surface is looked up. */
+  _syncSelectable(props) {
+    const wanted = props.selectable === true;
+    if (wanted === Boolean(this._textSelection)) return;
+    if (wanted) {
+      this._textSelection = new TextSelection(this);
+      // The I-beam is what says the text here can be taken. A surface is
+      // also a focus target — a11y.js reads the same prop — because Ctrl+C
+      // is a keystroke and a keystroke has to arrive somewhere.
+      this.defaultCursor ??= 'text';
+    } else {
+      this._textSelection.destroy();
+      this._textSelection = null;
+      if (this.defaultCursor === 'text') this.defaultCursor = undefined;
+    }
+  }
+
+  /**
+   * The document selection this element owns, or null: a snapshot of
+   * `{ isCollapsed, text, ranges }`, not a live object.
+   *
+   * Named for the text rather than called `selection`, because a base class
+   * that claims a plain noun claims it from every element built on it — and
+   * `this.selection = ...` in a subclass constructor is then a TypeError
+   * against a getter, which is a bad way to find out.
+   */
+  get textSelection() {
+    const selection = this._textSelection;
+    if (!selection) return null;
+    return {
+      isCollapsed: selection.isCollapsed,
+      text: selection.text(),
+      ranges: [...selection.ranges].map(([node, [start, end]]) => ({
+        node,
+        start,
+        end,
+      })),
+    };
+  }
+
+  /** Select everything in this surface, and take PRIMARY with it. */
+  selectAll() {
+    this._textSelection?.selectAll();
+    return this;
+  }
+
+  /** Drop the selection in this surface. PRIMARY is left where it is: the
+   * text stays pasteable, which is what every other X client does. */
+  clearSelection() {
+    this._textSelection?.clear();
+    return this;
+  }
+
+  /** What a copy would put on the clipboard. */
+  selectedText() {
+    return this._textSelection?.text() ?? '';
+  }
+
+  /** Set both ends by hand — `{ node, index }` each, indices in code points.
+   * `setSelection(null)` is `clearSelection()`. */
+  setSelection(anchor, focus = anchor) {
+    this._textSelection?.setSelection(anchor, focus);
+    return this;
+  }
+
+  /** Another surface is showing the app's selection now. */
+  _selectionLost() {
+    this._textSelection?.lost();
+  }
+
+  // The pointer and the keys a selection is made with. They are default
+  // actions on the *base* class because the press lands on whatever is under
+  // the pointer — a `<text>`, an `<image>`, the gap between two paragraphs —
+  // and every one of them has to reach the surface above it. An element that
+  // takes presses of its own overrides these and is, by that alone, not part
+  // of a document; one that wants both calls `super`.
+  defaultMouseDown(ev) {
+    selectionSurfaceOf(this)?.press(ev);
+  }
+
+  defaultMouseDrag(ev) {
+    selectionSurfaceOf(this)?.drag(ev);
+  }
+
+  defaultMouseUp(ev) {
+    selectionSurfaceOf(this)?.release(ev);
+  }
+
+  defaultKeyDown(ev) {
+    this._textSelection?.keyDown(ev);
+  }
+
   paint(ctx) {
     if (this.hidden) return;
     this._paintBackground(ctx);
@@ -2832,6 +3017,93 @@ function halfLeading(layout) {
   return Math.max(0, (layout.height - (last.baseline + last.descent)) / 2);
 }
 
+/** A selected line with nothing on it still shows, so a blank line inside a
+ * selection does not read as the highlight having stopped. */
+const EMPTY_LINE_BAND = 4;
+
+/**
+ * The rectangles a highlight over `[start, end)` code points fills, in the
+ * layout's own coordinates — one per line, and one per **direction run**
+ * inside a line.
+ *
+ * The per-run walk is the whole reason this is not four lines of caret
+ * arithmetic. A selection is contiguous in *logical* order and a line is
+ * laid out in *visual* order, so in "the file مرحبا here" a range that
+ * crosses into the Arabic covers two disjoint stretches of pixels, and a
+ * single rect from one caret x to the other paints over text nobody
+ * selected. Each run is intersected with the range in code units — the space
+ * ntk reports run extents in — and only a boundary falling *inside* a run
+ * costs a `caretPosition`; a fully covered run is its own two edges, which
+ * with the merge below is what keeps a plain paragraph at one rect per line.
+ *
+ * It belongs in ntk's `TextLayout`, beside the private offset table it
+ * rebuilds here. It is here because the selection needs it now.
+ */
+function rangeBands(layout, text, start, end) {
+  const lines = layout.lines;
+  if (!lines?.length || end <= start) return [];
+  const offsets = codeUnitOffsets(text);
+  const last = offsets.length - 1;
+  const from = offsets[Math.max(0, Math.min(start, last))];
+  const to = offsets[Math.max(0, Math.min(end, last))];
+  if (to <= from) return [];
+  const bands = [];
+  for (const line of lines) {
+    if (line.end <= from || line.start >= to) continue;
+    const spans = [];
+    for (const positioned of line.runs) {
+      const a = Math.max(from, positioned.start);
+      const b = Math.min(to, positioned.end);
+      if (b <= a) continue;
+      const rtl = positioned.run?.direction === 'rtl';
+      const near = line.x + positioned.x;
+      const far = near + positioned.width;
+      // a boundary at the run's own logical edge is that edge — which side
+      // of the pixels it is on is what the run's direction decides
+      const edgeAt = (cu, logicalStart) => {
+        if (logicalStart ? cu <= positioned.start : cu >= positioned.end) {
+          return rtl === logicalStart ? far : near;
+        }
+        return layout.caretPosition(codePointAtOffset(offsets, cu)).x;
+      };
+      const x1 = edgeAt(a, true);
+      const x2 = edgeAt(b, false);
+      spans.push([Math.min(x1, x2), Math.max(x1, x2)]);
+    }
+    if (!spans.length) {
+      bands.push({
+        x: line.x,
+        y: line.y,
+        width: EMPTY_LINE_BAND,
+        height: line.height,
+      });
+      continue;
+    }
+    // Runs also split at every style span, so an ordinary line with a bold
+    // word in it is three rectangles that touch. Merging keeps the common
+    // case at one per line.
+    spans.sort((p, q) => p[0] - q[0]);
+    let [left, right] = spans[0];
+    for (let i = 1; i <= spans.length; i++) {
+      const next = spans[i];
+      if (next && next[0] <= right + 0.5) {
+        right = Math.max(right, next[1]);
+        continue;
+      }
+      if (right > left) {
+        bands.push({
+          x: left,
+          y: line.y,
+          width: right - left,
+          height: line.height,
+        });
+      }
+      if (next) [left, right] = next;
+    }
+  }
+  return bands;
+}
+
 /** Raw string/number children of <text>. */
 export class TextChunkNode extends Node {
   constructor(text, app) {
@@ -3095,14 +3367,88 @@ export class TextNode extends Node {
     };
   }
 
-  paintContent(ctx) {
+  /**
+   * The layout as it is on screen: the shaped paragraph, and where its box
+   * sits in the window. One place, because painting and every geometry
+   * question have to agree about it down to the trim — a caret answered from
+   * a differently-placed layout is a caret in the wrong place, and nothing
+   * about it would look like a bug in this function.
+   */
+  _placedLayout() {
     const content = this.contentBox();
     const layout = this._layoutFor(this._wrapWidth(content.width || Infinity));
-    if (!layout) return;
+    if (!layout) return null;
     // the box was shortened from the top, so the glyphs come up with it
     const trim = this._trim(layout);
-    const y = content.y + halfLeading(layout) - (trim ? trim.top : 0);
-    layout.draw(ctx, content.x, y);
+    return {
+      layout,
+      x: content.x,
+      y: content.y + halfLeading(layout) - (trim ? trim.top : 0),
+    };
+  }
+
+  /** The paragraph as one string — what the indices below index into. A
+   * nested `<text>` is a span of this one, so its characters are in here too,
+   * at the position they are written at. */
+  textContent() {
+    return this.collectSpans([])
+      .map((span) => span.text)
+      .join('');
+  }
+
+  textIndexAt(x, y) {
+    const placed = this._placedLayout();
+    if (!placed) return 0;
+    return placed.layout.indexAt(x - placed.x, y - placed.y);
+  }
+
+  textCaretRect(index) {
+    const placed = this._placedLayout();
+    if (!placed) return null;
+    const caret = placed.layout.caretPosition(index);
+    return {
+      x: placed.x + caret.x,
+      y: placed.y + caret.y,
+      width: 0,
+      height: caret.height,
+    };
+  }
+
+  textRangeRects(start, end) {
+    const placed = this._placedLayout();
+    if (!placed) return [];
+    return rangeBands(placed.layout, this.textContent(), start, end).map(
+      (band) => ({
+        x: placed.x + band.x,
+        y: placed.y + band.y,
+        width: band.width,
+        height: band.height,
+      }),
+    );
+  }
+
+  paintContent(ctx) {
+    const placed = this._placedLayout();
+    if (!placed) return;
+    this._paintSelection(ctx);
+    placed.layout.draw(ctx, placed.x, placed.y);
+  }
+
+  /** The band under the glyphs, when a document selection reaches this
+   * paragraph. Drawn from the same accessors a registered element would use,
+   * so the built-in and the custom surface cannot drift apart. */
+  _paintSelection(ctx) {
+    const range = this._selRange;
+    if (!range || range.end <= range.start) return;
+    const rects = [];
+    for (const r of this.textRangeRects(range.start, range.end)) {
+      rects.push(r.x, r.y, r.width, r.height);
+    }
+    if (!rects.length) return;
+    ctx.fillStyle = range.color;
+    // one Render.FillRectangles for the whole highlight, however many lines
+    // and however many direction changes it took (ntk >= 7.6)
+    ctx.fillRects(rects);
   }
 }
 
@@ -3611,6 +3957,14 @@ export const Scrollable = (Base) =>
      * grows past its viewport becomes reachable the moment it does.
      */
     get focusableByDefault() {
+      return this._scrollsWithKeys();
+    }
+
+    /** Is there anything here for the scroll keys to move? Separate from
+     * `focusableByDefault` because a box can now be a focus target for
+     * another reason — a `selectable` document is one (a11y.js) — and a
+     * document that does not scroll must still leave the arrows alone. */
+    _scrollsWithKeys() {
       return this._maxScroll('y') > 0 || this._maxScroll('x') > 0;
     }
 
@@ -3626,7 +3980,7 @@ export const Scrollable = (Base) =>
     defaultKeyDown(ev) {
       // nothing to scroll, nothing to swallow: a plain box must leave the
       // arrows and Page keys to whatever else would answer them
-      if (!this.focusableByDefault) return undefined;
+      if (!this._scrollsWithKeys()) return super.defaultKeyDown(ev);
       const page = Math.max(1, this.abs.height - SCROLL_KEY_PAGE_OVERLAP);
       // Left and Right are the directions on the *screen*, and `scrollX` runs
       // from the start of the content — so which of them moves it forward
@@ -3654,7 +4008,7 @@ export const Scrollable = (Base) =>
         case XK_SPACE:
           return this.scrollBy({ y: ev.shiftKey ? -page : page });
         default:
-          return undefined;
+          return super.defaultKeyDown(ev);
       }
     }
 
@@ -3784,10 +4138,13 @@ export const Scrollable = (Base) =>
         this.scrollBy(bar.axis === 'x' ? { x: delta } : { y: delta });
         return;
       }
+      // no bar under the press: it belongs to whatever is behind the bars,
+      // which for a `selectable` pane is the selection (issue #259)
+      super.defaultMouseDown(ev);
     }
 
     defaultMouseDrag(ev) {
-      if (this._barGrab == null) return;
+      if (this._barGrab == null) return super.defaultMouseDrag(ev);
       const bar = this._scrollbar(this._barGrab.axis);
       if (!bar || bar.travel <= 0) return;
       const at = along(bar, ev.x, ev.y) - this._barGrab.offset - bar.trackStart;
@@ -3796,8 +4153,12 @@ export const Scrollable = (Base) =>
       this.scrollTo(bar.axis === 'x' ? { x: to } : { y: to });
     }
 
-    defaultMouseUp() {
-      this._barGrab = null;
+    defaultMouseUp(ev) {
+      if (this._barGrab != null) {
+        this._barGrab = null;
+        return;
+      }
+      super.defaultMouseUp(ev);
     }
   };
 
@@ -4019,6 +4380,10 @@ export class TextInputNode extends Node {
     super(kind, props, app);
     this.focusableByDefault = true;
     this.defaultCursor = 'text';
+    // a field's selection is its own: a `selectable` document around it does
+    // not get to light up half of what is being typed, and the two take turns
+    // being the one selection on screen (textselection.js)
+    this.hasOwnSelection = true;
     this._value =
       props.defaultValue != null ? String(props.defaultValue) : null;
     // set only while an onChange/onSubmit handler is on the stack — see
@@ -4162,7 +4527,7 @@ export class TextInputNode extends Node {
   }
 
   _chars() {
-    return Array.from(this.value);
+    return codePoints(this.value);
   }
 
   // --- composition ---------------------------------------------------------
@@ -4703,51 +5068,125 @@ export class TextInputNode extends Node {
     }
   }
 
-  /** Click-to-caret: logical code-point index for a window x coordinate. */
-  _indexAtX(x) {
-    const layout = this._valueLayout();
-    if (!layout) return this._chars().length;
-    const content = this.contentBox();
-    return this._valueIndex(layout.indexAt(x - content.x + this._scrollX, 0));
-  }
-
-  /** Click-to-caret for a mouse event (textarea also uses ev.y). */
+  /** Click-to-caret for a mouse event. Both kinds answer it the same way —
+   * through the field's own geometry accessor, which is the one the caret
+   * and the highlight are drawn from. */
   _indexAtPoint(ev) {
-    return this._indexAtX(ev.x);
+    return this.textIndexAt(ev.x, ev.y);
   }
 
   /** Word range around a code-point index (whitespace-delimited). */
   _wordRangeAt(index) {
-    const chars = this._chars();
-    if (chars.length === 0) return [0, 0];
-    let i = Math.min(index, chars.length - 1);
-    const isSpace = (c) => /\s/.test(c);
-    if (isSpace(chars[i]) && i > 0) i--;
-    let a = i;
-    let b = i;
-    while (a > 0 && !isSpace(chars[a - 1])) a--;
-    while (b < chars.length && !isSpace(chars[b])) b++;
-    return [a, b];
+    return wordRangeAt(this._chars(), index);
   }
 
-  /**
-   * Caret index one word away, the way Ctrl+arrow moves in a text editor:
-   * skip any run of non-word characters, then the word itself. Word
-   * characters are letters, digits and underscore, so "foo-bar" is two
-   * words and "foo_bar" is one.
-   */
+  /** Caret index one word away, the way Ctrl+arrow moves in a text editor. */
   _wordBoundary(from, dir) {
-    const chars = this._chars();
-    const isWord = (c) => /[\p{L}\p{N}_]/u.test(c);
-    let i = Math.max(0, Math.min(from, chars.length));
-    if (dir > 0) {
-      while (i < chars.length && !isWord(chars[i])) i++;
-      while (i < chars.length && isWord(chars[i])) i++;
-    } else {
-      while (i > 0 && !isWord(chars[i - 1])) i--;
-      while (i > 0 && isWord(chars[i - 1])) i--;
-    }
-    return i;
+    return wordBoundary(this._chars(), from, dir);
+  }
+
+  // --- geometry (the accessors every text-bearing element answers) --------
+
+  /**
+   * Where a single line of text sits in the field, and the band a mark over
+   * it fills. Centred on the **capitals**, not on the line box and not on
+   * the ink.
+   *
+   * The layout box carries the line's leading entirely below the glyphs, so
+   * centring that pushes the text visually up (see `halfLeading`). Centring
+   * ascent + descent — what this did — fixes the leading but not the
+   * asymmetry underneath it: a font's ascent clears its capitals by
+   * `ascent - capHeight`, which is not its descent, so a single line of
+   * text sits off-centre by a number that belongs to the typeface. At 14px
+   * that is 0.7px of extra space above the capitals in SF NS and 2.5px the
+   * other way in Helvetica — visible in a field, where there is one short
+   * line and a border close on both sides to measure it against.
+   *
+   * So: put the baseline where the space above the capitals equals the
+   * space under it. A `<text>` says the same thing as `textBoxTrim`, but a
+   * field cannot trim its box — the caret and the selection are measured
+   * against the full line box — so it moves the line instead, and the marks
+   * follow because they are derived from the same origin.
+   */
+  _lineMetrics(layout, content, style) {
+    const line = layout.lines?.[0];
+    const inkHeight = line ? line.ascent + line.descent : layout.height;
+    const ascent = line?.ascent ?? 0;
+    const capHeight = this.app?.fonts
+      ?.match?.(style.family, {
+        weight: style.weight,
+        style: style.style,
+      })
+      ?.metrics?.(style.size)?.capHeight;
+    const textY =
+      capHeight && line
+        ? content.y + (content.height + capHeight) / 2 - ascent
+        : content.y + Math.max(0, (content.height - inkHeight) / 2);
+    // selection/caret read better with breathing room around the glyphs
+    // (a DOM input highlights the whole line box, not just the ink)
+    const markPad = Math.min(3, Math.max(0, textY - content.y));
+    return {
+      textY,
+      markY: textY - markPad,
+      markHeight: inkHeight + markPad * 2,
+      inkHeight,
+    };
+  }
+
+  /** The value's layout and where it is drawn, in window coordinates. The
+   * placeholder is not in it: the accessors answer about the text the field
+   * holds, and an empty field holds none. */
+  _placedValue() {
+    const layout = this._valueLayout();
+    if (!layout) return null;
+    const content = this.contentBox();
+    const metrics = this._lineMetrics(
+      layout,
+      content,
+      this.resolvedTextStyle(),
+    );
+    return { layout, x: content.x - this._scrollX, y: metrics.textY };
+  }
+
+  /** The value. The indices below are into this string, in code points — an
+   * open composition is spliced into what is *drawn* and never into what the
+   * field holds, so it is not in here either. */
+  textContent() {
+    return this.value;
+  }
+
+  textIndexAt(x, y) {
+    const placed = this._placedValue();
+    if (!placed) return this._chars().length;
+    return this._valueIndex(placed.layout.indexAt(x - placed.x, y - placed.y));
+  }
+
+  textCaretRect(index) {
+    const placed = this._placedValue();
+    if (!placed) return null;
+    const caret = placed.layout.caretPosition(this._displayIndex(index));
+    return {
+      x: placed.x + caret.x,
+      y: placed.y + caret.y,
+      width: 0,
+      height: caret.height,
+    };
+  }
+
+  textRangeRects(start, end) {
+    const placed = this._placedValue();
+    if (!placed) return [];
+    return rangeBands(
+      placed.layout,
+      this._displayValue(),
+      this._displayIndex(start),
+      this._displayIndex(end),
+    ).map((band) => ({
+      x: placed.x + band.x,
+      y: placed.y + band.y,
+      width: band.width,
+      height: band.height,
+    }));
   }
 
   defaultMouseDown(ev) {
@@ -4819,7 +5258,22 @@ export class TextInputNode extends Node {
 
   _ownSelection() {
     this._repaint();
-    if (this._caret !== this._anchor) this._copySelection('PRIMARY');
+    if (this._caret === this._anchor) return;
+    // Whatever else on screen was showing a selection stops: the highlight
+    // is a single-owner thing across the whole app, the way PRIMARY is
+    // across the whole display (issue #259).
+    takeVisibleSelection(this);
+    this._copySelection('PRIMARY');
+  }
+
+  /** Another surface took the visible selection. Collapse, rather than only
+   * stop drawing: two lit ranges on one screen is the state this exists to
+   * prevent, and a field that kept its own would light it up again the next
+   * time it was focused. */
+  _selectionLost() {
+    if (this._caret === this._anchor) return;
+    this._anchor = this._caret;
+    this._repaint();
   }
 
   /** The selection stays lit while its own menu is up: the popup holds the
@@ -4838,7 +5292,7 @@ export class TextInputNode extends Node {
   defaultMouseUp() {
     if (!this._dragging) return;
     this._dragging = false;
-    if (this._caret !== this._anchor) this._copySelection('PRIMARY');
+    this._ownSelection();
   }
 
   // --- the built-in edit menu -----------------------------------------
@@ -5124,41 +5578,11 @@ export class TextInputNode extends Node {
       ? (this.props.placeholderColor ?? this.theme.dim)
       : style.color;
     const layout = fonts.layout([{ text: shown, ...style, color }], style);
-    // Centre on the **capitals**, not on the line box and not on the ink.
-    //
-    // The layout box carries the line's leading entirely below the glyphs, so
-    // centring that pushes the text visually up (see `halfLeading`). Centring
-    // ascent + descent — what this did — fixes the leading but not the
-    // asymmetry underneath it: a font's ascent clears its capitals by
-    // `ascent - capHeight`, which is not its descent, so a single line of
-    // text sits off-centre by a number that belongs to the typeface. At 14px
-    // that is 0.7px of extra space above the capitals in SF NS and 2.5px the
-    // other way in Helvetica — visible in a field, where there is one short
-    // line and a border close on both sides to measure it against.
-    //
-    // So: put the baseline where the space above the capitals equals the
-    // space under it. A `<text>` says the same thing as `textBoxTrim`, but a
-    // field cannot trim its box — the caret and the selection are measured
-    // against the full line box — so it moves the line instead, and the marks
-    // below follow because they are derived from the same origin.
-    const line = layout.lines?.[0];
-    const inkHeight = line ? line.ascent + line.descent : layout.height;
-    const ascent = line?.ascent ?? 0;
-    const capHeight = fonts
-      .match?.(style.family, {
-        weight: style.weight,
-        style: style.style,
-      })
-      ?.metrics?.(style.size)?.capHeight;
-    const textY =
-      capHeight && line
-        ? content.y + (content.height + capHeight) / 2 - ascent
-        : content.y + Math.max(0, (content.height - inkHeight) / 2);
-    // selection/caret read better with breathing room around the glyphs
-    // (a DOM input highlights the whole line box, not just the ink)
-    const markPad = Math.min(3, Math.max(0, textY - content.y));
-    const markY = textY - markPad;
-    const markHeight = inkHeight + markPad * 2;
+    const { textY, markY, markHeight } = this._lineMetrics(
+      layout,
+      content,
+      style,
+    );
 
     // Keep the caret inside the viewport — but only while the field is being
     // edited. The caret starts at the *end* of the value, so chasing it
@@ -5361,13 +5785,15 @@ export class TextAreaNode extends TextInputNode {
     if (newProps.rows !== before.rows) this.invalidateMeasure('props');
   }
 
-  _indexAtPoint(ev) {
+  /** The wrapped value flows from the top of the content box, scrolled —
+   * there is no single line to centre, so none of `_lineMetrics` applies.
+   * Everything written against this (`textIndexAt`, `textCaretRect`,
+   * `textRangeRects`, click-to-caret) needs no override. */
+  _placedValue() {
     const layout = this._valueLayout();
-    if (!layout) return this._chars().length;
+    if (!layout) return null;
     const content = this.contentBox();
-    return this._valueIndex(
-      layout.indexAt(ev.x - content.x, ev.y - content.y + this._scrollY),
-    );
+    return { layout, x: content.x, y: content.y - this._scrollY };
   }
 
   /** How far the wrapped text reaches past the viewport. The measurement a

--- a/src/textrange.js
+++ b/src/textrange.js
@@ -1,0 +1,83 @@
+// Ranges over text, in the units the caret is in.
+//
+// Everything here is pure and takes an array of code points, because that is
+// the index space ntk's `TextLayout.caretPosition`/`indexAt` speak and
+// therefore the one every caret and every selection in this renderer is in
+// (a code point, not a UTF-16 unit — an emoji is one position, not two).
+//
+// It is its own module because two unrelated things need the same answers:
+// `<textinput>`'s editing keys, and the selection a reader drags across a
+// document (textselection.js). A double click has to pick the same word in
+// both, and Ctrl+Left has to stop where a double click would start.
+
+/** The code points of a string, which is the index space of every caret. */
+export function codePoints(text) {
+  return Array.from(text ?? '');
+}
+
+/**
+ * Code point index -> UTF-16 offset, with one extra entry for the end.
+ *
+ * ntk's line runs report their extent in **code units** while its caret API
+ * speaks code points, so anything that reads run geometry has to translate
+ * between them; this is the table that does it.
+ */
+export function codeUnitOffsets(text) {
+  const offsets = [];
+  const s = text ?? '';
+  for (let i = 0; i < s.length;) {
+    offsets.push(i);
+    i += s.codePointAt(i) > 0xffff ? 2 : 1;
+  }
+  offsets.push(s.length);
+  return offsets;
+}
+
+/** The code point index for a UTF-16 offset, rounded down to a whole
+ * character. Binary search over `codeUnitOffsets`. */
+export function codePointAtOffset(offsets, offset) {
+  let lo = 0;
+  let hi = offsets.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if (offsets[mid] <= offset) lo = mid;
+    else hi = mid - 1;
+  }
+  return lo;
+}
+
+/**
+ * The word around an index, the way a double click selects one:
+ * whitespace-delimited, and a click in the space between two words takes the
+ * word before it rather than nothing.
+ */
+export function wordRangeAt(chars, index) {
+  if (chars.length === 0) return [0, 0];
+  let i = Math.min(Math.max(0, index), chars.length - 1);
+  const isSpace = (c) => /\s/.test(c);
+  if (isSpace(chars[i]) && i > 0) i--;
+  let a = i;
+  let b = i;
+  while (a > 0 && !isSpace(chars[a - 1])) a--;
+  while (b < chars.length && !isSpace(chars[b])) b++;
+  return [a, b];
+}
+
+/**
+ * The index one word away, the way Ctrl+arrow moves in a text editor: skip
+ * any run of non-word characters, then the word itself. Word characters are
+ * letters, digits and underscore, so "foo-bar" is two words and "foo_bar" is
+ * one.
+ */
+export function wordBoundary(chars, from, dir) {
+  const isWord = (c) => /[\p{L}\p{N}_]/u.test(c);
+  let i = Math.max(0, Math.min(from, chars.length));
+  if (dir > 0) {
+    while (i < chars.length && !isWord(chars[i])) i++;
+    while (i < chars.length && isWord(chars[i])) i++;
+  } else {
+    while (i > 0 && !isWord(chars[i - 1])) i--;
+    while (i > 0 && isWord(chars[i - 1])) i--;
+  }
+  return i;
+}

--- a/src/textselection.js
+++ b/src/textselection.js
@@ -1,0 +1,439 @@
+// The selection a reader drags across a document (issue #259).
+//
+// Not the X selection — that is clipboard.js, and PRIMARY is where this ends
+// up rather than what it is. This is the state: which characters of which
+// elements are lit, what a copy assembles out of them, and the one rule that
+// cannot live outside core — **only one selection on screen at a time**.
+//
+// Three things are worth knowing before reading the rest.
+//
+// **A surface is a `selectable` element, and its participants are whatever
+// under it can answer for its own text.** An element joins by implementing
+// the four accessors in nodes.js (`textContent`, `textIndexAt`,
+// `textCaretRect`, `textRangeRects`) — `<text>` does, and so does a terminal
+// or a log view written outside this package. There is no registration call
+// and no list of blessed kinds: a document is a tree, and the tree is walked.
+//
+// **The separators a copy uses come from the layout, not from the markup.**
+// Core cannot know that one `<text>` is a table cell and another is a
+// paragraph, and asking applications to say so would be a second authoring
+// model for something the screen already shows. So two participants that
+// share a band of pixels are joined with a tab and one that starts below the
+// last is joined with a newline — which is exactly "cells with tabs, rows
+// with newlines" for a table, and plain paragraphs everywhere else.
+//
+// **Losing the selection is a message, not a poll.** `takeVisibleSelection`
+// tells the previous owner it is no longer showing one, and `<textinput>`
+// answers it too — so a drag across a document collapses the highlight in
+// the field beside it, and vice versa, without either of them knowing the
+// other exists.
+
+import { callHandler } from './errors.js';
+import { lastInputTime } from './inputtime.js';
+import { ctrlChordLetter } from './keysyms.js';
+import { codePoints, wordRangeAt } from './textrange.js';
+import { tint } from './styles.js';
+
+// --- who is showing a selection ------------------------------------------
+//
+// One node per app: a `<textinput>`, or the surface below. The registry is
+// what makes "two selectable surfaces cannot both claim the visible
+// selection" a property of the system rather than of every surface's good
+// behaviour — the loser is *told*, so it has nothing to check.
+
+const owners = new WeakMap();
+
+/** This node is now showing the app's selection. The previous owner, if it
+ * was another node, is told to stop. */
+export function takeVisibleSelection(node) {
+  const app = node?.app;
+  if (!app) return;
+  const previous = owners.get(app);
+  if (previous === node) return;
+  owners.set(app, node);
+  if (previous && !previous.destroyed) previous._selectionLost();
+}
+
+/** Give it up without telling anybody: the selection went away on its own. */
+export function dropVisibleSelection(node) {
+  const app = node?.app;
+  if (app && owners.get(app) === node) owners.delete(app);
+}
+
+/** The node showing the app's selection, or null. */
+export function visibleSelectionOwner(app) {
+  const node = owners.get(app);
+  if (!node) return null;
+  if (node.destroyed) {
+    owners.delete(app);
+    return null;
+  }
+  return node;
+}
+
+// --- finding the surface --------------------------------------------------
+
+/**
+ * The selection this node's presses belong to: the nearest `selectable`
+ * ancestor, or none at all once something on the way up has opted its
+ * subtree out.
+ *
+ * `selectable={false}` is CSS's `user-select: none` and the reason it is
+ * checked first: a button's label, a list's bullet or a table's chrome sits
+ * inside a document and is not part of it.
+ */
+export function selectionSurfaceOf(node) {
+  for (let n = node; n; n = n.parent) {
+    if (n.props?.selectable === false) return null;
+    // an editor answers its own presses; a document above it never sees them
+    if (n.hasOwnSelection) return null;
+    if (n._textSelection) return n._textSelection;
+    if (n.isWindow) break;
+  }
+  return null;
+}
+
+/** Elements that answer for their own text, in document order, skipping
+ * everything that has opted out and everything with a selection of its own. */
+function participants(surface) {
+  const out = [];
+  const walk = (node) => {
+    for (const child of node.children) {
+      if (child.props?.selectable === false) continue;
+      // an editor keeps its own selection: a document around it does not get
+      // to light up half a field the user is typing in
+      if (child.hasOwnSelection) continue;
+      if (child.hidden || child.style?.display === 'none') continue;
+      // a nested surface owns its subtree, the way the nearest `selectable`
+      // ancestor owns a press
+      if (child._textSelection) continue;
+      if (child.textContent?.() != null) out.push(child);
+      else walk(child);
+    }
+  };
+  walk(surface);
+  return out;
+}
+
+/** How far a point is from a rect, as a score that ranks a miss on the wrong
+ * line below any miss on the right one — dragging into the margin should
+ * reach the paragraph beside the pointer, not the one it is nearest to. */
+function distanceScore(rect, x, y) {
+  const dy =
+    y < rect.y
+      ? rect.y - y
+      : y > rect.y + rect.height
+        ? y - rect.y - rect.height
+        : 0;
+  const dx =
+    x < rect.x
+      ? rect.x - x
+      : x > rect.x + rect.width
+        ? x - rect.x - rect.width
+        : 0;
+  return dy * 4096 + dx;
+}
+
+/**
+ * Two participants on one line are cells; one that begins below the other is
+ * a new row. Derived from the boxes rather than from the elements, because
+ * the layout is the only thing here that knows which it is.
+ */
+function separatorBetween(previous, next) {
+  const above = previous.abs;
+  return next.abs.y >= above.y + above.height - 1 ? '\n' : '\t';
+}
+
+/**
+ * The selection of one surface. Lives on the node as `_selection` and is
+ * created by the `selectable` prop; everything public about it is reached
+ * through the node (`node.selectAll()`, `node.selectedText()`, ...).
+ */
+export class TextSelection {
+  constructor(node) {
+    this.node = node;
+    // { node, index } each, in code points — an unordered pair, because which
+    // end moves is the whole difference between extending and starting over
+    this.anchor = null;
+    this.focus = null;
+    // 'char' | 'word' | 'block', from the click count that started the drag.
+    // Kept for the whole drag: a selection begun on a double click keeps
+    // snapping to words as it grows, which is what every text view does.
+    this.granularity = 'char';
+    this.dragging = false;
+    // node -> { start, end, color }, so a change can repaint what moved
+    this.ranges = new Map();
+  }
+
+  // --- gestures ----------------------------------------------------------
+
+  press(ev) {
+    if (ev.button !== 1) return;
+    const at = this.positionAt(ev.x, ev.y);
+    if (!at) return;
+    this.granularity =
+      ev.detail >= 3 ? 'block' : ev.detail === 2 ? 'word' : 'char';
+    // shift+click extends the selection that is already there, the way it
+    // does in a field — the anchor stays where it was
+    if (ev.shiftKey && this.anchor) this.focus = at;
+    else {
+      this.anchor = at;
+      this.focus = at;
+    }
+    this.dragging = true;
+    this.apply();
+    // A word or a block is complete at the press: there is a selection on
+    // screen before the button comes up, so PRIMARY has something to own
+    // and the gesture has already answered.
+    if (this.granularity !== 'char') this.own();
+  }
+
+  drag(ev) {
+    if (!this.dragging) return;
+    const at = this.positionAt(ev.x, ev.y);
+    if (!at) return;
+    this.focus = at;
+    this.apply();
+  }
+
+  release() {
+    if (!this.dragging) return;
+    this.dragging = false;
+    this.own();
+  }
+
+  /**
+   * Ctrl+A and Ctrl+C, run as this element's default action — which is why a
+   * surface is a focus target (a11y.js): the copy has to have somewhere to
+   * arrive. Nothing else is bound. A read-only document has no caret, so
+   * shift+arrows would be caret browsing, which is a mode rather than a
+   * default.
+   */
+  keyDown(ev) {
+    if (!ev.ctrlKey) return;
+    const letter = ctrlChordLetter(ev);
+    if (letter === 0x61 /* a */) {
+      this.selectAll();
+      ev.preventDefault();
+    } else if (letter === 0x63 /* c */) {
+      this.copy('CLIPBOARD');
+      ev.preventDefault();
+    }
+  }
+
+  // --- the selection itself ----------------------------------------------
+
+  /** The participant and index nearest a point in window coordinates. */
+  positionAt(x, y) {
+    let best = null;
+    let bestScore = Infinity;
+    for (const node of participants(this.node)) {
+      const score = distanceScore(node.abs, x, y);
+      if (score < bestScore) {
+        bestScore = score;
+        best = node;
+      }
+    }
+    if (!best) return null;
+    return { node: best, index: best.textIndexAt(x, y) };
+  }
+
+  /** Anchor and focus in document order, resolved against the live tree, or
+   * null when there is nothing selected (or an end has gone away). */
+  ordered() {
+    if (!this.anchor || !this.focus) return null;
+    const nodes = participants(this.node);
+    const ai = nodes.indexOf(this.anchor.node);
+    const fi = nodes.indexOf(this.focus.node);
+    if (ai < 0 || fi < 0) return null;
+    const a = { at: ai, index: this.anchor.index };
+    const f = { at: fi, index: this.focus.index };
+    const forward = ai < fi || (ai === fi && a.index <= f.index);
+    const [start, end] = forward ? [a, f] : [f, a];
+    if (this.granularity === 'char') return { nodes, start, end };
+    // A word- or block-granular drag snaps both ends outwards, so the
+    // selection is always whole words even where the pointer is mid-word.
+    const startChars = codePoints(nodes[start.at].textContent() ?? '');
+    const endChars = codePoints(nodes[end.at].textContent() ?? '');
+    if (this.granularity === 'block') {
+      start.index = 0;
+      end.index = endChars.length;
+    } else {
+      // The far end is probed one character back, because an index is a
+      // boundary rather than a character: a focus that has just reached the
+      // start of the next word belongs to the word it came from, which is
+      // what a drag feels like. Unless there is nothing to come from — a
+      // double click has both ends on the same boundary.
+      const collapsed = end.at === start.at && end.index === start.index;
+      const probe = collapsed ? end.index : Math.max(0, end.index - 1);
+      start.index = wordRangeAt(startChars, start.index)[0];
+      end.index = wordRangeAt(endChars, probe)[1];
+    }
+    return { nodes, start, end };
+  }
+
+  /** node -> [start, end) for everything the selection covers. */
+  rangesOf(ordered) {
+    const out = new Map();
+    if (!ordered) return out;
+    const { nodes, start, end } = ordered;
+    for (let i = start.at; i <= end.at; i++) {
+      const node = nodes[i];
+      const length = codePoints(node.textContent() ?? '').length;
+      const from = i === start.at ? start.index : 0;
+      const to = i === end.at ? end.index : length;
+      if (to > from) out.set(node, [from, to]);
+    }
+    return out;
+  }
+
+  get isCollapsed() {
+    for (const [, [from, to]] of this.ranges) if (to > from) return false;
+    return true;
+  }
+
+  /**
+   * Push the ranges down to the elements that paint them, and repaint only
+   * the ones whose range moved. Every route to a new selection ends here —
+   * the drag, the keys, and the programmatic `setSelection`.
+   */
+  apply() {
+    const color =
+      this.node.props.selectionColor ?? tint(this.node.theme.accent, 0.35);
+    const next = this.rangesOf(this.ordered());
+    let changed = false;
+    for (const [node, range] of next) {
+      const before = node._selRange;
+      if (before && before.start === range[0] && before.end === range[1]) {
+        continue;
+      }
+      node._selRange = { start: range[0], end: range[1], color };
+      node.invalidate(false, node, 'selection');
+      // the same push a `<textinput>` makes when its selection moves: what
+      // is lit is what a screen reader should be reading (#288's seam)
+      node.notifyA11yTextChanged?.();
+      changed = true;
+    }
+    for (const node of this.ranges.keys()) {
+      if (next.has(node)) continue;
+      changed = true;
+      if (node.destroyed) continue;
+      node._selRange = null;
+      node.invalidate(false, node, 'selection');
+      node.notifyA11yTextChanged?.();
+    }
+    this.ranges = next;
+    if (!changed) return;
+    if (this.isCollapsed) dropVisibleSelection(this.node);
+    else takeVisibleSelection(this.node);
+    const handler = this.node.props.onSelectionChange;
+    if (handler) {
+      callHandler(this.node, 'onSelectionChange', handler, {
+        type: 'selectionChange',
+        target: this.node,
+        currentTarget: this.node,
+        text: this.text(),
+        isCollapsed: this.isCollapsed,
+      });
+    }
+  }
+
+  /** Everything in this surface, and PRIMARY with it — the same rule the
+   * mouse gestures follow, and what makes a middle-click paste after Ctrl+A
+   * paste what is on screen. */
+  selectAll() {
+    const nodes = participants(this.node);
+    if (!nodes.length) return;
+    const last = nodes[nodes.length - 1];
+    this.granularity = 'char';
+    this.anchor = { node: nodes[0], index: 0 };
+    this.focus = {
+      node: last,
+      index: codePoints(last.textContent() ?? '').length,
+    };
+    this.apply();
+    this.own();
+  }
+
+  clear() {
+    this.anchor = null;
+    this.focus = null;
+    this.dragging = false;
+    this.apply();
+  }
+
+  /** Set both ends by hand: `{ node, index }` each, in code points. */
+  setSelection(anchor, focus) {
+    this.granularity = 'char';
+    this.anchor = anchor ? { ...anchor } : null;
+    this.focus = focus ? { ...focus } : anchor ? { ...anchor } : null;
+    this.apply();
+  }
+
+  /**
+   * What a copy puts on the clipboard. Each participant contributes the code
+   * points the selection covers, joined by what the layout says they are —
+   * see `separatorBetween`.
+   */
+  text() {
+    const ordered = this.ordered();
+    if (!ordered) return '';
+    const ranges = this.rangesOf(ordered);
+    let out = '';
+    let previous = null;
+    for (const [node, [from, to]] of ranges) {
+      if (previous) out += separatorBetween(previous, node);
+      out += codePoints(node.textContent() ?? '')
+        .slice(from, to)
+        .join('');
+      previous = node;
+    }
+    return out;
+  }
+
+  /** Take PRIMARY, which in X is what "there is a selection here" means to
+   * every other application on the display. */
+  own() {
+    if (this.isCollapsed) return;
+    takeVisibleSelection(this.node);
+    this.copy('PRIMARY');
+  }
+
+  copy(selection) {
+    const text = this.text();
+    if (!text) return;
+    const clipboard = this.node.app?.clipboard;
+    if (!clipboard) return; // ntk < 5.4.0: no selection machinery to take
+    clipboard
+      // ICCCM 2.1: stamped with the input that caused the copy, so a race
+      // with another client copying at the same moment is orderable
+      .write(text, { selection, time: lastInputTime(this.node.app) })
+      .catch((err) => {
+        console.warn(
+          `react-x11: could not take the ${selection} selection: ${err?.message ?? err}`,
+        );
+      });
+  }
+
+  /** Somebody else is showing the app's selection now. */
+  lost() {
+    if (!this.anchor && !this.focus) return;
+    this.anchor = null;
+    this.focus = null;
+    this.dragging = false;
+    this.apply();
+  }
+
+  destroy() {
+    dropVisibleSelection(this.node);
+    for (const node of this.ranges.keys()) {
+      if (!node.destroyed) {
+        node._selRange = null;
+        node.invalidate(false, node, 'selection');
+      }
+    }
+    this.ranges = new Map();
+    this.anchor = null;
+    this.focus = null;
+  }
+}

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -15,6 +15,7 @@ import type {
 import type { AnchorOptions } from './components.js';
 import type {
   ChangeEvent,
+  SelectionChangeEvent,
   ClientMessageEvent,
   EventHandlers,
   MouseEvent,
@@ -179,8 +180,38 @@ export interface A11yProps {
 }
 
 export interface DrawnProps<T = DrawnNode>
-  extends CommonProps, InteractionProps, A11yProps, EventHandlers<T> {
+  extends
+    CommonProps,
+    InteractionProps,
+    A11yProps,
+    SelectionProps<T>,
+    EventHandlers<T> {
   ref?: Ref<T>;
+}
+
+/**
+ * Selecting read-only text. `selectable` on an element makes it the surface
+ * a drag inside it selects across — see
+ * [elements.md](elements.md#selecting-text).
+ */
+export interface SelectionProps<T = DrawnNode> {
+  /**
+   * `true` makes this element a selection surface: a drag across the text
+   * inside it selects, double and triple clicks take a word and a block,
+   * Ctrl+A and Ctrl+C work, and a release takes PRIMARY. It also makes the
+   * element a focus target, so the keys have somewhere to arrive —
+   * `tabIndex={-1}` keeps it out of the Tab cycle.
+   *
+   * `false` opts a subtree out of the surface above it, the way CSS's
+   * `user-select: none` does: a list's bullets, a table's chrome, a button
+   * inside a document.
+   */
+  selectable?: boolean;
+  /** The highlight behind selected text. Defaults to a tint of the theme's
+   * accent, which keeps the ink's own contrast intact on any palette. */
+  selectionColor?: Color;
+  /** The selection in this surface changed. */
+  onSelectionChange?: (ev: SelectionChangeEvent<T>) => void;
 }
 
 // --- windows ---------------------------------------------------------------

--- a/src/types/events.d.ts
+++ b/src/types/events.d.ts
@@ -261,6 +261,21 @@ export interface DropTargetProps<T = DrawnNode> {
  * when nothing did — a paste resolving, an undo, a value the parent pushed
  * back. Guard it.
  */
+/**
+ * The document selection in a `selectable` element changed — a drag, a
+ * double click, Ctrl+A, or a `selectAll()` from code. Not a pointer event:
+ * it reports state, and the gesture that moved it has already been
+ * dispatched as one.
+ */
+export interface SelectionChangeEvent<T = DrawnNode> {
+  type: 'selectionChange';
+  target: T;
+  currentTarget: T;
+  /** The selected text, assembled the way a copy would assemble it. */
+  text: string;
+  isCollapsed: boolean;
+}
+
 export interface ChangeEvent<T = TextInputNode> extends Omit<
   SyntheticEvent<T>,
   'nativeEvent'

--- a/src/types/nodes.d.ts
+++ b/src/types/nodes.d.ts
@@ -43,6 +43,56 @@ export interface DrawnNode {
   /** Whether `node` is this node or a descendant of it (DOM `contains`). */
   contains(node: DrawnNode | null): boolean;
   getClientRects(): Rect[];
+
+  // --- text geometry (docs/elements.md, "Selection") ------------------------
+  //
+  // Every drawn node answers these; an element with no text answers `null`,
+  // `0` and `[]`. Indices are **code points** and rectangles are in the
+  // owning window's coordinates — the same space as `abs` and a mouse
+  // event's `x`/`y`.
+
+  /** This element's text, or null when it has none. */
+  textContent(): string | null;
+  /** The character boundary nearest a point. Clamps to the ends. */
+  textIndexAt(x: number, y: number): number;
+  /** Where a caret at this index stands — a zero-width rect. */
+  textCaretRect(index: number): Rect | null;
+  /** The bands a highlight over `[start, end)` fills: one per line, and one
+   * per direction run within a line. */
+  textRangeRects(start: number, end: number): Rect[];
+  /** The part of this element's text the document selection covers. */
+  readonly selectionRange: { start: number; end: number } | null;
+  /** What to fill `textRangeRects` with while `selectionRange` is set. */
+  readonly selectionColor: string | null;
+
+  // --- being a selection surface (`selectable`) -----------------------------
+
+  /** The selection this element owns, or null when it is not `selectable`.
+   * A snapshot: read it again after a change. */
+  readonly textSelection: TextSelectionSnapshot | null;
+  /** Select everything in this surface, and take PRIMARY with it. */
+  selectAll(): this;
+  /** Drop the selection. PRIMARY is left where it is. */
+  clearSelection(): this;
+  /** What a copy would put on the clipboard. */
+  selectedText(): string;
+  /** Set both ends by hand. `setSelection(null)` clears. */
+  setSelection(anchor: TextPosition | null, focus?: TextPosition | null): this;
+}
+
+/** One end of a selection: a code-point index into an element's text. */
+export interface TextPosition {
+  node: DrawnNode;
+  index: number;
+}
+
+/** What `node.selection` answers with. */
+export interface TextSelectionSnapshot {
+  isCollapsed: boolean;
+  /** The assembled text, with the separators a copy would use. */
+  text: string;
+  /** Every element the selection reaches, in document order. */
+  ranges: readonly (TextPosition & { start: number; end: number })[];
 }
 
 export interface ScrollTarget {

--- a/test/text-selection.test.js
+++ b/test/text-selection.test.js
@@ -1,0 +1,633 @@
+// Selection over read-only text (#259): the geometry a `<text>` answers, and
+// the document selection built on it.
+//
+// Everything here runs against node-x11's in-process X server with a real
+// font, because there is no cheaper way to be right. The mock connection has
+// no font manager, so a `<text>` measures 0×0, every layout is null and every
+// accessor answers its fallback — a suite written there would pass against an
+// implementation that returns zeroes.
+//
+// The three acceptance criteria in the issue are the three groups below:
+// character geometry is public, a surface selects across elements, and two
+// surfaces cannot both be showing a selection.
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import React from 'react';
+
+import { act, cleanup, fireEvent, renderX11 } from '../src/testing/index.js';
+import { keysymOf } from '../src/keysyms.js';
+import {
+  hooks as a11yHooks,
+  hasTextInterface,
+  textStateOf,
+} from '../src/a11y.js';
+
+const h = React.createElement;
+const require = createRequire(import.meta.url);
+const katex = join(
+  dirname(require.resolve('katex/package.json')),
+  'dist',
+  'fonts',
+);
+const FONTS = {
+  'Test Main': join(katex, 'KaTeX_Main-Regular.ttf'),
+  'Test Bold': join(katex, 'KaTeX_Main-Bold.ttf'),
+};
+
+const W = 320;
+const H = 240;
+
+afterEach(cleanup);
+
+/** A window whose text is set in the one face this server has. */
+const scene = (...children) =>
+  h(
+    'window',
+    {
+      title: 'selection',
+      width: W,
+      height: H,
+      theme: { fontFamily: 'Test Main', fontSize: 16, text: '#000000' },
+      style: { backgroundColor: '#ffffff' },
+    },
+    ...children,
+  );
+
+const mount = (element) =>
+  renderX11(element, { fonts: FONTS, wrap: false, width: W, height: H });
+
+/**
+ * Drag the pointer, and wait for the motion to arrive.
+ *
+ * ntk coalesces `mousemove` onto its frame clock — a burst of pointer steps
+ * is one event per frame — and the harness's `act()` runs react-x11's paint
+ * frame rather than ntk's, so a move injected between two `act()`s is still
+ * sitting in the coalescing buffer when the assertions run. The timer is
+ * what lets ntk's own frame fire.
+ */
+async function dragTo(node, options) {
+  fireEvent.mouseMove(node, options);
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  await act();
+}
+
+const find = (node, kind, out = []) => {
+  if (node.kind === kind) out.push(node);
+  for (const child of node.children) find(child, kind, out);
+  return out;
+};
+
+// --- gap 1: the geometry is public -----------------------------------------
+
+test('a <text> answers for its own characters', async () => {
+  const ref = React.createRef();
+  const { windowNode } = await mount(
+    scene(h('text', { ref, style: { width: 300 } }, 'Handgloves')),
+  );
+  const text = ref.current;
+  assert.equal(windowNode.kind, 'window');
+
+  assert.equal(text.textContent(), 'Handgloves');
+
+  // the caret before the first character stands at the left of the content
+  // box; the one after the last is a whole word further along
+  const first = text.textCaretRect(0);
+  const last = text.textCaretRect(10);
+  assert.equal(first.x, text.contentBox().x);
+  assert.ok(last.x > first.x + 40, `the word is ${last.x - first.x}px wide`);
+  assert.ok(
+    first.height > 8,
+    `a caret has the height of the line: ${first.height}`,
+  );
+  assert.equal(first.width, 0);
+
+  // and the hit test is its inverse, to the character
+  assert.equal(text.textIndexAt(first.x, first.y + 1), 0);
+  assert.equal(text.textIndexAt(last.x, first.y + 1), 10);
+  const middle = text.textCaretRect(5);
+  assert.equal(text.textIndexAt(middle.x, middle.y + 1), 5);
+});
+
+test('a point past the end of the text answers with the end of it', async () => {
+  const ref = React.createRef();
+  await mount(scene(h('text', { ref, style: { width: 300 } }, 'Handgloves')));
+  const text = ref.current;
+  assert.equal(text.textIndexAt(text.abs.x + 10_000, text.abs.y), 10);
+  assert.equal(text.textIndexAt(text.abs.x - 10_000, text.abs.y), 0);
+});
+
+test('the index space is code points, not UTF-16 units', async () => {
+  const ref = React.createRef();
+  await mount(scene(h('text', { ref, style: { width: 300 } }, 'ab\u{1d400}c')));
+  const text = ref.current;
+  // 'ab' + one astral character + 'c' — four positions, five code units
+  assert.equal(text.textContent().length, 5);
+  assert.ok(text.textCaretRect(4).x > text.textCaretRect(3).x);
+  assert.equal(text.textCaretRect(5).x, text.textCaretRect(4).x, 'clamped');
+});
+
+test('a highlight over a wrapped range is one band per line', async () => {
+  const ref = React.createRef();
+  await mount(
+    scene(
+      h(
+        'text',
+        { ref, style: { width: 90, fontSize: 16 } },
+        'Handgloves and mittens',
+      ),
+    ),
+  );
+  const text = ref.current;
+  const rects = text.textRangeRects(0, text.textContent().length);
+  assert.ok(rects.length >= 2, `wrapped to ${rects.length} bands`);
+  const box = text.contentBox();
+  for (const rect of rects) {
+    assert.ok(rect.width > 0 && rect.height > 0);
+    assert.ok(rect.x >= box.x - 1, 'inside the content box');
+  }
+  // the bands stack: each one starts where the last ended, so a selection
+  // across a wrap has no gap in it
+  for (let i = 1; i < rects.length; i++) {
+    assert.ok(
+      rects[i].y >= rects[i - 1].y + rects[i - 1].height - 1,
+      'the next line is below the one before it',
+    );
+  }
+  assert.deepStrictEqual(text.textRangeRects(3, 3), [], 'an empty range');
+});
+
+// The case a single caret-x-to-caret-x rectangle gets wrong. Inside an RTL
+// run the later character is the one further *left*, so a highlight that
+// interpolates between two caret positions covers the characters nobody
+// selected — and a run boundary is where a logical index stops being a
+// visual one.
+test('a bidi line highlights the characters, not the span between them', async () => {
+  const ref = React.createRef();
+  await mount(scene(h('text', { ref, style: { width: 300 } }, 'ab אבג cd')));
+  const text = ref.current;
+  //           0123456789 — the Hebrew is [3, 6)
+  const whole = text.textRangeRects(0, 9);
+  assert.equal(whole.length, 1, 'everything selected is one band');
+
+  const firstLetter = text.textRangeRects(3, 4);
+  const lastLetter = text.textRangeRects(5, 6);
+  assert.equal(firstLetter.length, 1);
+  assert.equal(lastLetter.length, 1);
+  assert.ok(
+    lastLetter[0].x + lastLetter[0].width <= firstLetter[0].x + 0.5,
+    `the third letter (x=${lastLetter[0].x}) sits left of the first ` +
+      `(x=${firstLetter[0].x}): the run reads right to left`,
+  );
+  // and neither of them has spilled over the rest of the word
+  const hebrew = text.textRangeRects(3, 6)[0];
+  for (const band of [firstLetter[0], lastLetter[0]]) {
+    assert.ok(band.width < hebrew.width * 0.75, 'one letter, not three');
+    assert.ok(band.x >= hebrew.x - 0.5, 'inside the run');
+    assert.ok(band.x + band.width <= hebrew.x + hebrew.width + 0.5);
+  }
+});
+
+test('a <textinput> answers the same four questions', async () => {
+  const ref = React.createRef();
+  await mount(
+    scene(
+      h('textinput', {
+        ref,
+        defaultValue: 'Handgloves',
+        style: { width: 200 },
+      }),
+    ),
+  );
+  const input = ref.current;
+  assert.equal(input.textContent(), 'Handgloves');
+  const caret = input.textCaretRect(4);
+  assert.ok(caret.x > input.contentBox().x);
+  assert.equal(input.textIndexAt(caret.x, caret.y + 1), 4);
+  assert.equal(input.textRangeRects(0, 10).length, 1);
+});
+
+// --- gap 2: the selection model --------------------------------------------
+
+test('a drag selects across the elements of a document', async () => {
+  const surface = React.createRef();
+  const { windowNode } = await mount(
+    scene(
+      h(
+        'box',
+        { ref: surface, selectable: true, style: { padding: 8, width: 300 } },
+        h('text', null, 'First paragraph'),
+        h('text', null, 'Second paragraph'),
+      ),
+    ),
+  );
+  const [first, second] = find(windowNode, 'text');
+
+  fireEvent.mouseDown(first, { dx: -60 });
+  await act();
+  await dragTo(second, { dx: 60 });
+
+  assert.ok(first.selectionRange, 'the first paragraph is lit');
+  assert.ok(second.selectionRange, 'and so is the second');
+  assert.equal(first.selectionRange.end, 15, 'to the end of the first');
+  assert.equal(second.selectionRange.start, 0, 'from the start of the second');
+
+  const text = surface.current.selectedText();
+  assert.ok(
+    'First paragraph'.endsWith(text.split('\n')[0]),
+    `the tail of the first paragraph: ${JSON.stringify(text)}`,
+  );
+  assert.ok(text.endsWith('Second paragraph'), 'and all of the second');
+  assert.ok(text.includes('\n'), 'two blocks are joined by a newline');
+
+  fireEvent.mouseUp(second, { dx: 60 });
+  await act();
+  assert.equal(surface.current.textSelection.isCollapsed, false);
+});
+
+test('a click collapses it and a second document takes over', async () => {
+  const a = React.createRef();
+  const b = React.createRef();
+  const { windowNode } = await mount(
+    scene(
+      h(
+        'box',
+        { ref: a, selectable: true, style: { width: 300 } },
+        h('text', null, 'First document'),
+      ),
+      h(
+        'box',
+        { ref: b, selectable: true, style: { width: 300 } },
+        h('text', null, 'Second document'),
+      ),
+    ),
+  );
+  const [first, second] = find(windowNode, 'text');
+
+  a.current.selectAll();
+  await act();
+  assert.ok(first.selectionRange, 'the first document is lit');
+
+  b.current.selectAll();
+  await act();
+  assert.ok(second.selectionRange, 'the second is lit');
+  assert.equal(first.selectionRange, null, 'and the first is not');
+  assert.equal(a.current.textSelection.isCollapsed, true);
+});
+
+test('a double click takes the word under it, a triple the block', async () => {
+  const surface = React.createRef();
+  const { windowNode } = await mount(
+    scene(
+      h(
+        'box',
+        { ref: surface, selectable: true, style: { width: 300 } },
+        h('text', null, 'alpha beta gamma'),
+      ),
+    ),
+  );
+  const [text] = find(windowNode, 'text');
+  const point = text.textCaretRect(8); // inside "beta"
+
+  fireEvent.mouseDown(text, {
+    dx: point.x - (text.abs.x + text.abs.width / 2),
+  });
+  fireEvent.mouseUp(text);
+  fireEvent.mouseDown(text, {
+    dx: point.x - (text.abs.x + text.abs.width / 2),
+  });
+  await act();
+  assert.deepStrictEqual(
+    text.selectionRange,
+    { start: 6, end: 10 },
+    `"${surface.current.selectedText()}" is the word`,
+  );
+  fireEvent.mouseUp(text);
+  fireEvent.mouseDown(text, {
+    dx: point.x - (text.abs.x + text.abs.width / 2),
+  });
+  await act();
+  assert.deepStrictEqual(
+    text.selectionRange,
+    { start: 0, end: 16 },
+    'a third click takes the whole block',
+  );
+  fireEvent.mouseUp(text);
+  await act();
+});
+
+test('cells are joined with tabs and rows with newlines', async () => {
+  const surface = React.createRef();
+  const row = (...cells) =>
+    h('box', { style: { flexDirection: 'row' } }, ...cells);
+  await mount(
+    scene(
+      h(
+        'box',
+        { ref: surface, selectable: true, style: { width: 300 } },
+        row(
+          h('text', { style: { width: 100 } }, 'name'),
+          h('text', { style: { width: 100 } }, 'size'),
+        ),
+        row(
+          h('text', { style: { width: 100 } }, 'notes'),
+          h('text', { style: { width: 100 } }, '4kB'),
+        ),
+      ),
+    ),
+  );
+  surface.current.selectAll();
+  await act();
+  assert.equal(surface.current.selectedText(), 'name\tsize\nnotes\t4kB');
+});
+
+test('selectable={false} keeps a subtree out of the text and the gestures', async () => {
+  const surface = React.createRef();
+  const { windowNode } = await mount(
+    scene(
+      h(
+        'box',
+        { ref: surface, selectable: true, style: { width: 300 } },
+        h('box', { style: { flexDirection: 'row' } }, [
+          h('text', { key: 'marker', selectable: false }, '1. '),
+          h('text', { key: 'item' }, 'the item'),
+        ]),
+      ),
+    ),
+  );
+  surface.current.selectAll();
+  await act();
+  assert.equal(surface.current.selectedText(), 'the item');
+  const [marker] = find(windowNode, 'text');
+  assert.equal(marker.selectionRange, null, 'the marker is never lit');
+
+  // and a press that lands on it starts nothing — the selection made above
+  // is still the one on screen after a drag across the marker
+  surface.current.clearSelection();
+  await act();
+  fireEvent.mouseDown(marker);
+  await dragTo(marker, { dx: 40 });
+  assert.equal(surface.current.textSelection.isCollapsed, true);
+  fireEvent.mouseUp(marker);
+});
+
+test('Ctrl+A selects the surface and Ctrl+C copies it', async () => {
+  const surface = React.createRef();
+  const copied = [];
+  const { app } = await mount(
+    scene(
+      h(
+        'box',
+        { ref: surface, selectable: true, style: { width: 300 } },
+        h('text', null, 'copy me'),
+      ),
+    ),
+  );
+  app.clipboard.write = (data, options) => {
+    copied.push([options.selection, data]);
+    return Promise.resolve();
+  };
+
+  surface.current.focus();
+  await act();
+  fireEvent.key(keysymOf('a'), { modifiers: ['Control'] });
+  await act();
+  assert.equal(surface.current.selectedText(), 'copy me');
+  assert.deepStrictEqual(copied.at(-1), ['PRIMARY', 'copy me'], 'and PRIMARY');
+
+  fireEvent.key(keysymOf('c'), { modifiers: ['Control'] });
+  await act();
+  assert.deepStrictEqual(copied.at(-1), ['CLIPBOARD', 'copy me']);
+});
+
+test('onSelectionChange reports what is selected', async () => {
+  const surface = React.createRef();
+  const seen = [];
+  await mount(
+    scene(
+      h(
+        'box',
+        {
+          ref: surface,
+          selectable: true,
+          onSelectionChange: (ev) => seen.push(ev.text),
+          style: { width: 300 },
+        },
+        h('text', null, 'watch this'),
+      ),
+    ),
+  );
+  surface.current.selectAll();
+  await act();
+  assert.deepStrictEqual(seen, ['watch this']);
+  surface.current.clearSelection();
+  await act();
+  assert.deepStrictEqual(seen, ['watch this', '']);
+});
+
+// --- gap 3: one visible selection ------------------------------------------
+
+test('a document taking the selection collapses the field beside it', async () => {
+  const surface = React.createRef();
+  const input = React.createRef();
+  await mount(
+    scene(
+      h('textinput', { ref: input, defaultValue: 'in the field' }),
+      h(
+        'box',
+        { ref: surface, selectable: true, style: { width: 300 } },
+        h('text', null, 'in the document'),
+      ),
+    ),
+  );
+  input.current.focus();
+  input.current._selectAll();
+  await act();
+  assert.notEqual(
+    input.current._selection()[0],
+    input.current._selection()[1],
+    'the field has a selection',
+  );
+
+  surface.current.selectAll();
+  await act();
+  assert.equal(
+    input.current._selection()[0],
+    input.current._selection()[1],
+    'and gives it up when the document takes one',
+  );
+});
+
+test('a field taking the selection clears the document', async () => {
+  const surface = React.createRef();
+  const input = React.createRef();
+  const { windowNode } = await mount(
+    scene(
+      h('textinput', { ref: input, defaultValue: 'in the field' }),
+      h(
+        'box',
+        { ref: surface, selectable: true, style: { width: 300 } },
+        h('text', null, 'in the document'),
+      ),
+    ),
+  );
+  surface.current.selectAll();
+  await act();
+  const [text] = find(windowNode, 'text');
+  assert.ok(text.selectionRange, 'the document is lit');
+
+  input.current.focus();
+  input.current._selectAll();
+  await act();
+  assert.equal(
+    text.selectionRange,
+    null,
+    'and goes dark when the field takes one',
+  );
+  assert.equal(surface.current.textSelection.isCollapsed, true);
+});
+
+test('a <textinput> inside a document keeps its own selection', async () => {
+  const surface = React.createRef();
+  const input = React.createRef();
+  await mount(
+    scene(
+      h(
+        'box',
+        { ref: surface, selectable: true, style: { width: 300 } },
+        h('text', null, 'around it'),
+        h('textinput', { ref: input, defaultValue: 'inside it' }),
+      ),
+    ),
+  );
+  surface.current.selectAll();
+  await act();
+  assert.equal(
+    surface.current.selectedText(),
+    'around it',
+    'the field is not part of the document',
+  );
+
+  // and a press in the field is the field's, not the document's
+  surface.current.clearSelection();
+  await act();
+  fireEvent.mouseDown(input.current);
+  await dragTo(input.current, { dx: 20 });
+  assert.equal(surface.current.textSelection.isCollapsed, true);
+  fireEvent.mouseUp(input.current);
+});
+
+// --- what an assistive technology hears -------------------------------------
+
+test('the selection a document shows is the one a screen reader reads', async () => {
+  const surface = React.createRef();
+  const heard = [];
+  const { windowNode } = await mount(
+    scene(
+      h(
+        'box',
+        { ref: surface, selectable: true, style: { width: 300 } },
+        h('text', null, 'alpha beta'),
+      ),
+    ),
+  );
+  const [text] = find(windowNode, 'text');
+  // a `<text>` has always had the AT-SPI text interface; what it never had
+  // was a selection to report through it
+  assert.equal(hasTextInterface(text), true);
+  assert.deepStrictEqual(textStateOf(text).selection, [0, 0]);
+
+  a11yHooks.textState = (node) => heard.push(node);
+  try {
+    surface.current.setSelection(
+      { node: text, index: 6 },
+      { node: text, index: 10 },
+    );
+    await act();
+    assert.deepStrictEqual(textStateOf(text).selection, [6, 10]);
+    assert.equal(textStateOf(text).caret, 10, 'the caret follows the focus');
+    assert.ok(heard.includes(text), 'and the change was pushed, not polled');
+
+    heard.length = 0;
+    surface.current.clearSelection();
+    await act();
+    assert.deepStrictEqual(textStateOf(text).selection, [0, 0]);
+    assert.ok(heard.includes(text), 'unlighting is a change too');
+  } finally {
+    a11yHooks.textState = undefined;
+  }
+});
+
+// --- what it looks like ------------------------------------------------------
+
+const readPixels = (ctx, w, h) =>
+  new Promise((resolve, reject) =>
+    ctx.getImageData(0, 0, w, h, (err, image) =>
+      err ? reject(err) : resolve(image),
+    ),
+  );
+
+/** Pixels that are neither the white background nor the black ink: the
+ * highlight is a tint of the accent, so it is the only other colour. */
+function tinted(image) {
+  let count = 0;
+  for (let i = 0; i < image.data.length; i += 4) {
+    const [r, g, b] = [image.data[i], image.data[i + 1], image.data[i + 2]];
+    const white = r > 250 && g > 250 && b > 250;
+    const dark = r < 100 && g < 100 && b < 100;
+    if (!white && !dark && b > r) count++;
+  }
+  return count;
+}
+
+test('the selection is painted under the glyphs', async () => {
+  const surface = React.createRef();
+  const { ctx } = await mount(
+    scene(
+      h(
+        'box',
+        { ref: surface, selectable: true, style: { width: 300, padding: 8 } },
+        h('text', { style: { fontSize: 24 } }, 'Handgloves'),
+      ),
+    ),
+  );
+  const before = tinted(await readPixels(ctx, W, H));
+  assert.equal(before, 0, 'nothing is highlighted to begin with');
+
+  surface.current.selectAll();
+  await act();
+  const after = tinted(await readPixels(ctx, W, H));
+  assert.ok(after > 500, `the highlight is ${after} pixels`);
+
+  surface.current.clearSelection();
+  await act();
+  assert.equal(tinted(await readPixels(ctx, W, H)), 0, 'and it goes away');
+});
+
+test('a press lands on the character the accessors name', async () => {
+  const surface = React.createRef();
+  const { windowNode } = await mount(
+    scene(
+      h(
+        'box',
+        { ref: surface, selectable: true, style: { width: 300 } },
+        h('text', null, 'alpha beta gamma'),
+      ),
+    ),
+  );
+  const [text] = find(windowNode, 'text');
+  // the coordinates a mouse event carries and the ones the accessors answer
+  // in are the same space, so a press aimed at a caret rect selects from
+  // exactly that index
+  const centre = text.abs.x + text.abs.width / 2;
+  const from = text.textCaretRect(6);
+  const to = text.textCaretRect(10);
+  fireEvent.mouseDown(text, { dx: from.x - centre });
+  await act();
+  await dragTo(text, { dx: to.x - centre });
+  assert.deepStrictEqual(text.selectionRange, { start: 6, end: 10 });
+  assert.equal(surface.current.selectedText(), 'beta');
+  fireEvent.mouseUp(text, { dx: to.x - centre });
+  await act();
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -80,6 +80,7 @@ import {
 import type {
   ChangeEvent,
   DrawnNode,
+  Rect,
   CompositionEvent,
   KeyboardEvent,
   MouseEvent,
@@ -388,6 +389,69 @@ function Popup() {
     </popup>
   );
 }
+
+// issue #259: selection over read-only text — the geometry every drawn node
+// answers, and the surface a `selectable` element becomes
+function Document() {
+  const doc = useRef<DrawnNode>(null);
+  const para = useRef<DrawnNode>(null);
+  const copy = () => {
+    const node = doc.current;
+    if (!node) return '';
+    const snapshot = node.textSelection;
+    if (!snapshot || snapshot.isCollapsed) return '';
+    const first: { node: DrawnNode; start: number; end: number } | undefined =
+      snapshot.ranges[0];
+    void first;
+    return snapshot.text;
+  };
+  const measure = () => {
+    const node = para.current;
+    if (!node) return;
+    const text: string | null = node.textContent();
+    const index: number = node.textIndexAt(12, 40);
+    const caret: Rect | null = node.textCaretRect(index);
+    const bands: Rect[] = node.textRangeRects(0, index);
+    const lit: { start: number; end: number } | null = node.selectionRange;
+    const ink: string | null = node.selectionColor;
+    void [text, caret, bands, lit, ink];
+    // both ends by hand, and either of the two shorthands
+    node.setSelection({ node, index: 0 }, { node, index: 4 });
+    doc.current?.selectAll().clearSelection();
+    const selected: string = doc.current?.selectedText() ?? '';
+    void selected;
+  };
+  return (
+    <window title="reader">
+      <box
+        ref={doc}
+        selectable
+        tabIndex={-1}
+        selectionColor="#cfe4ff"
+        onSelectionChange={(ev) => {
+          const text: string = ev.text;
+          const empty: boolean = ev.isCollapsed;
+          void [text, empty, ev.target, copy(), measure()];
+        }}
+      >
+        <text ref={para}>the paragraph</text>
+        {/* CSS's user-select: none, for the chrome around a document */}
+        <text selectable={false}>1.</text>
+      </box>
+    </window>
+  );
+}
+
+// @ts-expect-error — `selectable` is a boolean, not CSS's keyword
+const _badSelectable = <box selectable="text" />;
+
+const _badSelectionHandler = (
+  <box
+    selectable
+    // @ts-expect-error — the selection reports state, not a pointer position
+    onSelectionChange={(ev) => void ev.clientX}
+  />
+);
 
 // issue #255: a popup that hangs off a node — or off a rect inside one —
 // and sizes itself from its content, so it never states a position at all
@@ -1104,5 +1168,8 @@ void grow;
 void _div;
 void _img;
 void _classy;
+void Document;
+void _badSelectable;
+void _badSelectionHandler;
 void _badSlider;
 void _badTabs;

--- a/test/types/extend.tsx
+++ b/test/types/extend.tsx
@@ -356,3 +356,45 @@ const _missingData = <sparkline color="red" />;
 registerElement('broken', { drawn: true });
 
 export default Chart;
+
+// issue #259: an element that answers for its own text joins a `selectable`
+// document — the four accessors and the range it paints, nothing else
+class LogViewNode extends Node {
+  constructor(props: Record<string, unknown>, app: never) {
+    super('logview', props, app);
+    // a log view is read-only: the document around it selects across it
+    this.hasOwnSelection = false;
+  }
+
+  textContent(): string {
+    return String(this.props.buffer ?? '');
+  }
+
+  textIndexAt(x: number, y: number): number {
+    const box = this.contentBox();
+    return Math.max(0, Math.round(x - box.x) + Math.round(y - box.y));
+  }
+
+  textCaretRect(index: number): Rect {
+    const box = this.contentBox();
+    return { x: box.x + index * 8, y: box.y, width: 0, height: 16 };
+  }
+
+  textRangeRects(start: number, end: number): Rect[] {
+    const from = this.textCaretRect(start);
+    const to = this.textCaretRect(end);
+    return [
+      { x: from.x, y: from.y, width: to.x - from.x, height: from.height },
+    ];
+  }
+
+  paint(ctx: unknown): void {
+    super.paint(ctx);
+    const range = this.selectionRange;
+    if (!range) return;
+    const fill: string | null = this.selectionColor;
+    void [this.textRangeRects(range.start, range.end), fill];
+  }
+}
+
+void LogViewNode;

--- a/website/src/demos/index.js
+++ b/website/src/demos/index.js
@@ -7,6 +7,7 @@ import widgets from './widgets.js';
 import events from './events.js';
 import dates from './dates.js';
 import password from './password.js';
+import selection from './selection.js';
 import tasks from './tasks.js';
 import canvas from './canvas.js';
 import menu from './menu.js';
@@ -30,6 +31,7 @@ const demos = [
   events,
   dates,
   password,
+  selection,
   tasks,
   canvas,
   menu,

--- a/website/src/demos/selection.js
+++ b/website/src/demos/selection.js
@@ -1,0 +1,74 @@
+export default {
+  id: 'selection',
+  title: 'Text you can take',
+  description:
+    'One prop — selectable — turns a box into a document: drag across the ' +
+    'paragraphs, double-click for a word, triple-click for a block, Ctrl+A ' +
+    'for everything, Ctrl+C to copy. The release hands the text to PRIMARY, ' +
+    'so a middle click in a terminal pastes it. The table below is the same ' +
+    'selection: what a copy assembles comes from the layout, so cells are ' +
+    'joined with tabs and rows with newlines, and the row numbers — marked ' +
+    'selectable={false} — are not in it at all.',
+  code: `import React, { useRef, useState } from 'react';
+import { createRoot } from 'react-x11';
+
+const rows = [
+  ['README.md', '4 kB'],
+  ['index.js', '12 kB'],
+  ['notes.txt', '900 B'],
+];
+
+function App() {
+  const doc = useRef(null);
+  const [copied, setCopied] = useState('');
+
+  return (
+    <window x={30} y={30} width={520} height={380} title="release notes"
+            style={{ backgroundColor: '#ffffff' }}>
+      <box
+        ref={doc}
+        selectable
+        onSelectionChange={(ev) => setCopied(ev.text)}
+        style={{ padding: 18, gap: 12, flexGrow: 1 }}
+      >
+        <text style={{ fontSize: 20, fontWeight: 'bold' }}>
+          Selecting text
+        </text>
+        <text style={{ fontSize: 14, lineHeight: 1.4 }}>
+          A label is not selectable here, the way a GTK label is not: a
+          desktop application is full of text that is chrome rather than
+          content. Text becomes selectable when an element says so, and then
+          everything under that element is one document.
+        </text>
+        <text style={{ fontSize: 14, lineHeight: 1.4 }}>
+          Drag from this paragraph into the one above it. Both light up, and
+          the copy has a newline between them.
+        </text>
+
+        {rows.map(([name, size], i) => (
+          <box key={name} style={{ flexDirection: 'row', gap: 10 }}>
+            <text selectable={false} style={{ width: 20, color: '#95a5a6' }}>
+              {i + 1}.
+            </text>
+            <text style={{ width: 140 }}>{name}</text>
+            <text>{size}</text>
+          </box>
+        ))}
+      </box>
+
+      <box style={{ padding: 12, gap: 4, backgroundColor: '#f4f6f8' }}>
+        <text style={{ fontSize: 11, color: '#7f8c8d' }}>
+          what a copy would put on the clipboard:
+        </text>
+        <text style={{ fontSize: 12 }}>
+          {copied ? JSON.stringify(copied) : '(nothing selected)'}
+        </text>
+      </box>
+    </window>
+  );
+}
+
+const root = await createRoot();
+root.render(<App />);
+`,
+};


### PR DESCRIPTION
Closes #259.

`<text>` answered no geometry questions and there was no selection model to
plug into, so the `<Markdown>` build had to ship a parallel text element —
`<text>` with its layout made answerable — plus a whole selection
coordinator of its own. Every piece of that is generic, and one piece is not
expressible outside core at all: two independent implementations on one
screen fight over PRIMARY and over which of them is showing the selection.

![selection-c961264](https://github.com/user-attachments/assets/cf99d6d6-29cd-4093-9677-b0e564e94609)

_A `<box selectable>`: one drag across two paragraphs and into the table.
The row numbers are `selectable={false}`, so they are neither lit nor in the
copied text; the strip at the bottom is `onSelectionChange`. Rendered by
this PR's code at c961264, headless, through `scripts/capture.js`._

## Gap 1 — the geometry is public

Every drawn node answers four questions:

```js
node.textContent(); // 'Everything below this heading…'
node.textIndexAt(ev.x, ev.y); // window coordinates in, a code point out
node.textCaretRect(14); // { x, y, width: 0, height }
node.textRangeRects(4, 14); // the bands a highlight over [4, 14) fills
```

One index space and one coordinate space: characters are **code points** —
the space ntk's caret API already speaks, so an emoji is one position — and
rectangles are in the **owning window's** coordinates, the same as `abs`,
`contentBox()` and a mouse event's `x`/`y`. `<text>`, `<textinput>` and
`<textarea>` answer off the layout they actually draw, from one placed-layout
helper each, so a caret rect and a glyph cannot disagree.

`textRangeRects` walks **direction runs** rather than interpolating between
two caret positions. A selection is contiguous in logical order and a line is
laid out in visual order, so a range crossing from Latin into Arabic covers
two disjoint stretches of pixels — a single rectangle between the carets
paints over text nobody selected. `test/text-selection.test.js` pins it on a
mixed-direction line, and mutating the run direction away fails it.

They are on `Node` rather than on `<text>` because that is what makes gap 2
open: the selection walks a subtree and asks, so an element written outside
this package joins a document by answering, with no registration call.

## Gap 2 — the selection is a core service

```jsx
<box selectable style={{ padding: 12 }}>
  <text style={{ fontSize: 20, fontWeight: 'bold' }}>Release notes</text>
  <text>Everything below this heading can be dragged over and copied.</text>
</box>
```

That prop is the whole feature: drag, double-click for a word, triple-click
for a block, Ctrl+A, Ctrl+C, and PRIMARY on release. `selectable={false}`
opts a subtree out — CSS's `user-select: none`, for a list's bullets or a
button's caption inside a document. On the node, through a ref:
`selectAll()`, `clearSelection()`, `selectedText()`, `setSelection(anchor,
focus)` and a `textSelection` snapshot; on the element, `selectionColor` and
`onSelectionChange`.

**What a copy assembles comes from the layout, not the markup.** Core cannot
know which `<text>` is a table cell, and asking applications to say so would
be a second authoring model for something the screen already shows. Two
participants sharing a band of pixels are joined with a **tab**; one that
starts below the last with a **newline**. For a table that is exactly "cells
with tabs, rows with newlines"; for prose it is one paragraph per line.

## Gap 3 — one visible selection

An app-scoped registry: whoever takes the visible selection **tells** the
previous owner. A drag across a document collapses the highlight in the
field beside it; Ctrl+A in the field clears the document. `<textinput>`
answers the same message, so the rule holds across kinds rather than only
between two documents — and PRIMARY stays honest, since there is one
selection on the display and now one here.

## Also in here

- A surface is a **focus target**, because Ctrl+C is a keystroke and a
  keystroke has to arrive somewhere. `tabIndex={-1}` takes it back out of the
  Tab cycle while leaving it focusable by a press.
- The **base class routes presses** to the nearest surface
  (`defaultMouseDown`/`Drag`/`Up`/`KeyDown`), so an element that only draws
  writes no handlers, and one that overrides them without `super` is by that
  alone not part of a document — right for anything that edits.
- `src/textrange.js`: the word and block helpers `<textinput>` had, now
  shared, so a double click picks the same word in a field and in a document.
- A `<text>` reports its selection to **assistive technology** through the
  text interface it already had (#288's `hooks.textState` push), so a
  magnifier's highlight and a braille cursor land on the characters the
  highlight is painted over.
- `Node.selection` was renamed `textSelection` before it existed publicly:
  #288 landed a test element that assigns `this.selection` in its
  constructor, which against a getter is a `TypeError`. A base class should
  not claim a plain noun from every element built on it.

## Not done, deliberately

`cursorAt(x, y)` — the pointer that changes over a link inside a paragraph.
The issue records it as a related nicety rather than an acceptance criterion,
and it wants a hover seam of its own rather than a rider on this one.

## Checks

- `npm test` — 1206 pass; the 6 failures are `test/appearance.test.js`,
  pre-existing on master on macOS (the ladder resolves `source: 'macos'`
  where the test wants `xsettings`).
- `npm run lint`, `npm run typecheck`, `prettier --check .` clean.
- `website && npm test` — all three gates, including the new `selection`
  demo, which mounts and paints. The Docusaurus `build` does not run on this
  machine (every page fails SSG on Node 26, on master content too), so the
  new doc anchors were checked by hand.
- New: `test/text-selection.test.js`, 19 tests against the in-process X
  server with a real font — geometry, gestures, granularity, copy assembly,
  the single-owner rule, the a11y report, and a pixel test that the highlight
  is painted and unpainted.

