### PR TITLE
feat(layout)!: everything shrinks, and nothing shrinks below what it needs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,10 @@ no override-redirect staging (issue #4).
   face, the size — what travels down the tree) and `LOCAL_TEXT_PROPS` (what
   shapes a node's own box and therefore cannot arrive from above). Which
   side a text property is on decides who has to react when it moves, so a
-  new one goes in exactly one of them.
+  new one goes in exactly one of them. And the two places a style means more
+  than it says: `resolveComputedStyle` (the `flex` shorthand, and the
+  defaults `overflow: 'scroll'` implies) and `applyLayoutDefaults` (the yoga
+  defaults that are not CSS's — `flexShrink`, see the gotcha below).
 - `src/events.js` — `EventManager`: ntk window events → synthetic events
   (click synthesis, hover enter/leave diffing, the wheel — ntk's `wheel`
   event, XI2 valuators where the server has them and buttons 4-7 where it
@@ -954,21 +957,40 @@ onDraw>`, `value`, `placeholder`. `children` and event handlers are
   monotonicity test catches it.
 - **Layouts sized against one font break in another.** `sans-serif` is
   whatever fontconfig hands you, and a row of things sized by their own text
-  does not compress to fit (see the `flexShrink` note below) — it overflows and
-  gets clipped. Three buttons that sat comfortably in a 250px card under the
-  test fonts ran off the edge of it on a real desktop. Rows of buttons or chips
-  want `flexWrap: 'wrap'`. `npm run stress:check -- --wide` renders the whole
-  app in a monospace UI face and fails on any node overflowing a pinned-width
-  ancestor, which is the pass that would have caught it.
-- **Yoga defaults `flexShrink` to 0**, where CSS defaults it to 1. A box with
-  `flexGrow: 1` and the default `flexBasis: auto` therefore takes its
-  content's max-content size as its base and **cannot shrink back** to the
-  space actually available — a wrapping row inside it never wraps and
-  overflows instead. Use `flexBasis: 0` for "take whatever is left"; that is
-  what `SplitPane`'s second pane does, with a regression test in
-  `test/tabs-splitpane.test.js`. Note also that `flexBasis` wins over `width`
-  on the main axis, so spreading a `flexBasis: 0` style into a fixed-width
-  box collapses it to nothing.
+  compresses only as far as the words inside it (see the content floors
+  below) — past that it overflows and gets clipped. Three buttons that sat
+  comfortably in a 250px card under the test fonts ran off the edge of it on
+  a real desktop. Rows of buttons or chips want `flexWrap: 'wrap'`.
+  `npm run stress:check -- --wide` renders the whole app in a monospace UI
+  face and fails on any node overflowing a pinned-width ancestor, which is
+  the pass that would have caught it.
+- **`flexShrink` defaults to 1 and every flex item carries a content floor**
+  (#249, `nodes.js`: `contentSpan`, `writeContentFloors`). Yoga defaults the
+  shrink to 0 and has no floor at all, and **neither of its two answers is
+  usable on its own**: with 0 a row never squeezes into the space it has, and
+  with 1 everything collapses to nothing — scrolling stops existing, because
+  a pane's content shrinks to its viewport. CSS has both halves, so the
+  renderer measures the missing one: one min-content pass per axis on any
+  frame that changes the layout, written onto the yoga nodes as
+  `minWidth`/`minHeight` and taken back off before the next measurement.
+  Things to know before touching it:
+  - the measuring passes run **`measuringExactly`** (yoga's pixel grid off).
+    Rounded sizes summed with exact paddings make a floor a pixel too tall,
+    and a floor that exceeds the natural size does not hold a box, it
+    _grows_ it — a pixel per nesting level, all the way up.
+  - the measuring passes also **borrow `flexShrink`** (`setMeasuringShrink`):
+    min-content means "nothing gives", so a pass run at the real default
+    would answer that the content needs no room at all.
+  - `_floorsDirty` is what keeps this off the input path — `invalidate()`
+    sets it for every layout change **except a scroll**, which moves no yoga
+    node.
+  - the deliberate deviation from CSS is that a **named size is kept**: CSS
+    floors an item at `min(its size, its content)`, which is fine on the web
+    where a `<div>` is a block container and its children are not flex items,
+    and is not fine here where every box is a flex container. `minHeight: 0`
+    is how a style asks for CSS's answer.
+  - `flexBasis` still wins over `width` on the main axis, so spreading a
+    `flexBasis: 0` style into a fixed-width box collapses it to nothing.
 
 - **No X11 side effects in the render phase.** Window nodes are handles
   until `realize(parentWindow)` runs in the commit phase
@@ -981,8 +1003,9 @@ onDraw>`, `value`, `placeholder`. `children` and event handlers are
 - `<popup>` is a `WindowNode` subclass with `isPopup = true`: allowed as a
   child of drawn nodes (bookkeeping only — no yoga, no reparent, own
   paint/event root). A scrolling `<box>` applies its offset during `absolutize`,
-  so painting and hit testing see shifted rects; it defaults `flexShrink`
-  to 1 (yoga's 0 would size the viewport to its content). The wheel default
+  so painting and hit testing see shifted rects; it defaults `minWidth` and
+  `minHeight` to 0, which is what lets a viewport be smaller than what is
+  inside it (CSS's own rule, and the content floors read it). The wheel default
   action (EventManager) scrolls the nearest enclosing scroll pane unless
   `preventDefault()` is called.
 - Closing an app right after `setTitle`/`setActions` crashed ntk <= 3.1.0

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -31,7 +31,7 @@ Numbers are pixels, strings like `'50%'` / `'auto'` pass through to yoga.
 - **Flex**: `flexDirection` (`row`, `column`, `row-reverse`,
   `column-reverse`), `justifyContent` (`flex-start`, `center`, `flex-end`,
   `space-between`, `space-around`, `space-evenly`), `alignItems`,
-  `alignSelf`, `alignContent`, `flexWrap`, `flexGrow`, `flexShrink`,
+  `alignSelf`, `alignContent`, `flexWrap`, `flex`, `flexGrow`, `flexShrink`,
   `flexBasis`, `gap`, `rowGap`, `columnGap`
 - **Position**: `position` (`relative`, `absolute`, `static`), `top`,
   `right`, `bottom`, `left`
@@ -40,13 +40,51 @@ Numbers are pixels, strings like `'50%'` / `'auto'` pass through to yoga.
 - **Visibility**: `display` (`flex`, `none`), `overflow` (`visible`,
   `hidden`, `scroll`)
 
-**yoga defaults `flexShrink` to 0, where CSS defaults it to 1.** An item
-whose base size comes from its content therefore refuses to shrink, and
-content wider than the space available pushes the row past its container
-instead of being squeezed into it. Write `flex: 1` in full —
-`{ flexGrow: 1, flexBasis: 0, minWidth: 0 }` — for anything that should take
-the space that is left rather than the space its content wants.
-A box with `overflow: 'scroll'` applies exactly that to itself by default.
+### Everything shrinks, nothing shrinks to nothing
+
+`flexShrink` is `1`, as in CSS: an item hands back the space it has spare
+when the row it is in runs short, rather than pushing the row past its
+container. And **it never gives up what is inside it** — every item carries a
+floor of its own min-content size, which is CSS's automatic minimum size
+(`min-width: auto` on a flex item) written out by the renderer, since yoga
+implements the shrinking half and not the floor half. A row of chips squeezes
+until it wraps; a label squeezes to its longest word; a `height: 40` row
+stays 40 tall.
+
+Three ways a style says otherwise:
+
+| write                             | to mean                                   |
+| --------------------------------- | ----------------------------------------- |
+| `flexShrink: 0`                   | never give up any space at all            |
+| `minWidth: 0` / `minHeight: 0`    | this may shrink past its content, to zero |
+| `overflow: 'hidden'` / `'scroll'` | the same, and clip what no longer fits    |
+
+The last two are CSS's own rule — `min-*: auto` computes to `0` on anything
+whose overflow is not `visible` — and they are what makes a scroll pane
+possible: a viewport is a box that is _allowed_ to be smaller than what is
+inside it. A `<box overflow="scroll">` gets `minWidth: 0` and `minHeight: 0`
+for free.
+
+One deliberate difference from CSS: **a size that was named is kept**. CSS
+floors an item at `min(the size it was given, its content)`, so an empty
+`height: 40` box squashes to nothing in a column too short for it; that is
+survivable on the web because a `<div>` is a _block_ container and its
+children are not flex items at all, and it is not survivable here, where
+every box lays its children out with flex. Say `minHeight: 0` to get CSS's
+answer for one.
+
+The measurement costs the tree an extra layout pass per axis, on frames that
+change the layout — a scroll, which moves no box, keeps the single pass it
+always had.
+
+### `flex`, the shorthand
+
+`flex: 1` is `{ flexGrow: 1, flexShrink: 1, flexBasis: 0 }` — "take this
+share of what is left, from a base size of nothing" — which is what makes it
+the right thing for a pane that should fill its window rather than its
+content. `flex: 'auto'` grows and shrinks from the content's own size, and
+`flex: 'none'` does neither. A longhand written beside it wins, so
+`{ flex: 1, flexBasis: 'auto' }` reads the way it does in CSS.
 
 ## Paint properties
 
@@ -216,24 +254,25 @@ and the floor is how far it still reached. What each node contributes is
 whatever its own style lets it shrink to, which makes the interesting part
 what _doesn't_ count:
 
-| the node                                               | contributes       |
-| ------------------------------------------------------ | ----------------- |
-| a rigid box (`flexShrink` is 0 by default — see above) | its whole size    |
-| a wrapping row                                         | its widest item   |
-| text                                                   | its longest word  |
-| `overflow: 'scroll'` / `'hidden'`                      | nothing           |
-| `flexShrink: 1`, or a `minWidth: 0` of its own         | what it shrank to |
+| the node                          | contributes      |
+| --------------------------------- | ---------------- |
+| a box that named a size           | that size        |
+| a wrapping row                    | its widest item  |
+| text                              | its longest word |
+| `overflow: 'scroll'` / `'hidden'` | nothing          |
+| a `minWidth: 0` of its own        | nothing          |
+| a `minWidth: 240` of its own      | 240              |
 
 A registered element contributes whatever its `measureContent` answers when
 asked for the smallest size it can be drawn at — see
 [extending.md](extending.md#a-size-of-your-own).
 
-The last two rows are the escape hatch, and they are the same one CSS,
-Qt and GTK all spell — `min-width: 0`, `QScrollArea`, `min-content-width`.
-A node that was told it may shrink is taken at its word and its contents
-stop counting, so a window around a scrolling pane is floored by everything
-_except_ that pane. Naming a number (`minWidth: 240` on the box) is an
-answer too, and stops the measurement there.
+This is the same measurement every node's own floor comes from (above), read
+at the top of the tree — so the escape hatch is the same one, and it is the
+one CSS, Qt and GTK all spell: `min-width: 0`, `QScrollArea`,
+`min-content-width`. A node that named a floor of its own is taken at its
+word and its contents stop counting, so a window around a scrolling pane is
+floored by everything _except_ that pane.
 
 `maxWidth`/`maxHeight` take `'auto'` as well, and it means the other half of
 the pair: **the size the content wanted** — the natural size above, not the
@@ -266,10 +305,10 @@ Three things worth knowing before reaching for it:
   so an auto window around a long list opens as tall as the screen. Give the
   window a `height`, or the scrolling box a `maxHeight`, if the scrolling is
   meant to happen inside a smaller window.
-- With no available width nothing wraps (and yoga defaults `flexShrink` to
-  0 — see [styling.md](styling.md)), so an auto width is the **unwrapped**
-  row. That makes the width font-dependent: the same window is wider under a
-  wide UI face than under a narrow one.
+- The natural size is measured with **no available width**, where nothing
+  wraps and nothing is short of room to shrink into, so an auto width is the
+  **unwrapped** row. That makes the width font-dependent: the same window is
+  wider under a wide UI face than under a narrow one.
 - Measuring costs an extra layout pass per frame that lays out, for as long
   as the window is still tracking. A window with both sizes given pays
   nothing.
@@ -813,20 +852,20 @@ never moves the caret.
 
 ### The layout defaults it brings
 
-`overflow: 'scroll'` folds four CSS idioms into the resolved style, so a
+`overflow: 'scroll'` folds three CSS idioms into the resolved style, so a
 scroll container does not have to restate them:
 
 | default                        | when                                     |
 | ------------------------------ | ---------------------------------------- |
 | `flexBasis: 0`                 | `flexGrow > 0` and no `width` / `height` |
-| `flexShrink: 1`                | always (yoga's own default is `0`)       |
 | `minWidth: 0` / `minHeight: 0` | always                                   |
 
 `min-*: 0` is the CSS spec's own rule — `min-*: auto` computes to `0` on a
-flex item whose overflow is not `visible` — and the other two are what
-`flex: 1` means. Without them a header/scroll/footer window grows past its
-own bounds as rows are added and the footer is pushed out of view. Set any
-of them yourself to opt out; an explicit value always wins.
+flex item whose overflow is not `visible` — and it is what lets a viewport be
+smaller than what is inside it, which is what scrolling is. The zero basis is
+half of what `flex: 1` means. Without them a header/scroll/footer window
+grows past its own bounds as rows are added and the footer is pushed out of
+view. Set either yourself to opt out; an explicit value always wins.
 
 ### Props
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -229,12 +229,16 @@ answer in all three, and the mode is there for the cases where it is not:
 | `at-most` with 0 | **the smallest it can be drawn at** — an editor: a character or two of one line; something that scrolls inside: honestly small |
 | `exactly`        | the style decided this axis; hand the number back and answer for the other one                                                 |
 
-The `at-most 0` row is the one worth reading twice, because something else
-asks it: `<window minWidth="auto">` measures the smallest size its content
-can be drawn at by laying the tree out with **no room at all** and asking
-every leaf directly ([elements.md](elements.md#a-floor-the-content-decides)).
-An element that answers 0 there is saying it can be squeezed to nothing, and
-the window's floor comes out without it.
+The `at-most 0` row is the one worth reading twice, because it is not only
+the layout that asks it. The renderer measures the smallest size every node
+can be drawn at — by laying the tree out with **no room at all** and asking
+each leaf directly — and writes that back as the element's own floor, so a
+row too narrow for it squeezes it that far and no further
+([elements.md](elements.md#everything-shrinks-nothing-shrinks-to-nothing)).
+The same measurement read at the top of the tree is what
+`<window minWidth="auto">` sends the window manager. An element that answers
+0 there is saying it can be squeezed to nothing, and both floors come out
+without it.
 
 `at-most` is what is _available_, not a cap that will be enforced: an element
 may answer larger and it will be laid out at what it asked for, overflowing

--- a/examples/rules.jsx
+++ b/examples/rules.jsx
@@ -517,13 +517,11 @@ const s = createStyles({
   // the row while it is held: off the page rather than in it, which without
   // a shadow to cast is said with the fill and an edge the flow rows lack
   rowLifted: { backgroundColor: '$background', borderColor: '$border' },
-  // the wrapping half of a row. `flexBasis: 0` because yoga defaults
-  // flexShrink to 0: with `auto`, this takes its content's max-content width
-  // as its base, cannot shrink back, and the fields never wrap at all
+  // the wrapping half of a row. `flex: 1` rather than a content-sized basis:
+  // with `auto` this takes its content's max-content width as its base, and
+  // the fields wrap only once it has been squeezed all the way back to it
   fields: {
-    flexGrow: 1,
-    flexShrink: 1,
-    flexBasis: 0,
+    flex: 1,
     minWidth: 0,
     flexDirection: 'row',
     alignItems: 'center',

--- a/examples/stress/controls.jsx
+++ b/examples/stress/controls.jsx
@@ -47,10 +47,10 @@ const s = createStyles({
   title: { fontSize: 12, color: '$text' },
   row: { flexDirection: 'row', alignItems: 'center', gap: 10 },
   // A row of things sized by their own text — buttons, chips — has to wrap.
-  // Yoga defaults flexShrink to 0, so without this they do not compress to
-  // fit, they overflow: three buttons that sit comfortably in a 250px card in
-  // one font run off the edge of it in a wider one. Anything laid out against
-  // the metrics of the font you happened to test with is a latent bug, and a
+  // They compress only as far as the words inside them, so without this they
+  // overflow: three buttons that sit comfortably in a 250px card in one font
+  // run off the edge of it in a wider one. Anything laid out against the
+  // metrics of the font you happened to test with is a latent bug, and a
   // desktop app cannot know the metrics in advance.
   buttonRow: {
     flexDirection: 'row',

--- a/examples/widgets.jsx
+++ b/examples/widgets.jsx
@@ -143,11 +143,11 @@ export function WidgetsPanel() {
       </Row>
 
       <Row label="Markdown" alignItems="flex-start">
-        {/* `flex: 1` in full — grow *and* a zero basis. yoga defaults
-            flexShrink to 0 (CSS says 1), so with a content-sized basis the
-            markdown's natural width became a floor and pushed the row past
-            the window edge */}
-        <box style={{ flexGrow: 1, flexBasis: 0, minWidth: 0, gap: 8 }}>
+        {/* `flex: 1` — the zero basis is the point: with a content-sized
+            basis the markdown's natural width sets this column's base size
+            and pushes the row past the window edge. `minWidth: 0` lets it go
+            below the content's floor as well */}
+        <box style={{ flex: 1, minWidth: 0, gap: 8 }}>
           {/* the textarea is the source, the <markdown> element is the
               preview: every keystroke re-parses through ntk's
               MarkdownView, which is cheap enough for a document this size */}

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -1070,8 +1070,9 @@ export function MenuBar({
           // scroll to once the cut lands, so the bar answers no keys and
           // takes no wheel (docs/elements.md).
           overflow: 'scroll',
-          // A scroll container brings `flexShrink: 1`; a menu bar is not a
-          // thing that gives up height when the window is short.
+          // A scroll container brings `minHeight: 0` with it; a menu bar is
+          // not a thing that gives up height when the window is short, so it
+          // opts out of shrinking altogether.
           flexShrink: 0,
         },
         style,

--- a/src/components/SplitPane.js
+++ b/src/components/SplitPane.js
@@ -15,13 +15,13 @@ const KEY_STEP = 16;
 const s = createStyles({
   root: { flexGrow: 1, minHeight: 0, minWidth: 0 },
   pane: { minHeight: 0, minWidth: 0 },
-  // `flexBasis: 0` is load-bearing, not tidying. Yoga defaults flexShrink to
-  // 0 (CSS defaults it to 1), so with the default `flexBasis: auto` this pane
-  // takes its content's max-content size as a base and then cannot shrink
-  // back to the space actually left over. A second pane holding a wrapping
-  // row would lay out at its unwrapped width and overflow the window instead
-  // of wrapping. Basing it at 0 makes it exactly "whatever is left".
-  grow: { flexGrow: 1, flexBasis: 0, minHeight: 0, minWidth: 0 },
+  // `flex: 1` is load-bearing, not tidying: the zero basis in it is what
+  // makes this pane "whatever is left" rather than "as much as my content
+  // wants, shrunk as far as it will go". With a content basis the pane still
+  // could not go below the content's own floor, so a second pane holding a
+  // wrapping row would lay out at its unwrapped width and overflow. The
+  // `min-*: 0` on top says this one may go below even that.
+  grow: { flex: 1, minHeight: 0, minWidth: 0 },
   divider: {
     flexShrink: 0,
     alignItems: 'center',

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -5,6 +5,9 @@
 import {
   Yoga,
   applyLayoutStyle,
+  applyLayoutDefaults,
+  createLayoutNode,
+  measuringExactly,
   paintPropsChanged,
   textStyleFrom,
   DEFAULT_TEXT_STYLE,
@@ -15,7 +18,7 @@ import {
   flattenStyle,
   validateStyle,
   resolveStyleStates,
-  resolveScrollContainer,
+  resolveComputedStyle,
   hasStateStyles,
   isStyleProp,
   isEventProp,
@@ -745,41 +748,100 @@ function captureLeafHeights(node, out) {
 }
 
 /**
- * Whether this node's laid-out size is already the answer for `axis`, so
- * that what is inside it stops counting towards a floor.
- *
- * The question only arises because the layout being read was run with no
- * room in it: a node whose size came from its container rather than from
- * itself came out at nothing, and nothing is not a measurement. So the test
- * is *who decided this size* —
+ * Whether this node has **named a floor of its own** on `axis` — the cases
+ * where CSS's `min-*: auto` is not the content-based minimum, so the node may
+ * give way to whatever squeezes it and its contents stop counting:
  *
  * - it clips, so what overflows it is not something to make room for. CSS
- *   says the same in `min-width: auto` computing to `0` on anything whose
- *   overflow is not `visible`, and it is the escape hatch Qt spells
- *   `QScrollArea` and GTK spells `min-content-width`;
- * - the author named a size, a floor or a ceiling on this axis. All three
- *   are answers, `minWidth: 0` — "I can be any size" — included;
- * - it was told it may shrink, on the axis its container lays out along.
- *   `flexShrink` is the opt-in, and it means nothing on the other axis.
+ *   computes `min-*: auto` to `0` on anything whose overflow is not
+ *   `visible`, and it is the escape hatch Qt spells `QScrollArea` and GTK
+ *   spells `min-content-width`;
+ * - the author wrote a number in `minWidth`/`minHeight`. `0` — "I can be any
+ *   size" — is the one that matters and the one a scroll container gets
+ *   given.
  *
- * Anything else was sized by its parent — a stretched cross-axis child is
- * the usual one — and has to be looked inside.
+ * This used to read "it was told it may shrink", back when `flexShrink`
+ * defaulted to yoga's `0` and asking for `1` was therefore a statement. Every
+ * node may shrink now (#249), so the clause carried no information and had to
+ * go: `minWidth: 0` is how a style says "down to nothing", and `flexShrink`
+ * is back to meaning only how eagerly the space *above* the floor is given
+ * up.
  */
-function boundsItsOwnContent(node, axis, axisIsMain) {
+function namesOwnFloor(node, axis) {
   const style = node.style;
   if (style.overflow === 'scroll' || style.overflow === 'hidden') return true;
-  const [size, min, max] =
+  return (
+    typeof (axis === 'width' ? style.minWidth : style.minHeight) === 'number'
+  );
+}
+
+/**
+ * Whether this node's laid-out extent in a min-content pass is already the
+ * answer, so there is no need to look inside it. Everything that names a
+ * floor, plus the two other ways a style can bound itself: a **size**, which
+ * a min-content measurement here keeps rather than shrinking past (see
+ * `writeContentFloors`), and a **ceiling**, since CSS clamps the content
+ * suggestion by the specified `max-*` too.
+ */
+function declaresOwnMinimum(node, axis) {
+  if (namesOwnFloor(node, axis)) return true;
+  const style = node.style;
+  const [size, max] =
     axis === 'width'
-      ? [style.width, style.minWidth, style.maxWidth]
-      : [style.height, style.minHeight, style.maxHeight];
-  if (
-    typeof size === 'number' ||
-    typeof min === 'number' ||
-    typeof max === 'number'
-  ) {
-    return true;
+      ? [style.width, style.maxWidth]
+      : [style.height, style.maxHeight];
+  return typeof size === 'number' || typeof max === 'number';
+}
+
+/** In this node's parent's flow at all: an absolute or `display: 'none'`
+ *  child is not a flex item and contributes nothing to what contains it —
+ *  CSS says the same about both. */
+function inFlow(node) {
+  return (
+    node.yoga &&
+    !node.isWindow &&
+    node.style.position !== 'absolute' &&
+    node.style.display !== 'none'
+  );
+}
+
+/** Which axis this node lays its children out along. */
+const mainAxisOf = (node) => {
+  const direction = node.style.flexDirection ?? 'column';
+  return direction === 'row' || direction === 'row-reverse'
+    ? 'width'
+    : 'height';
+};
+
+/**
+ * Put the tree in the state a **min-content** measurement means: a node that
+ * has said how small it can be is let go all the way down to it, and a node
+ * that has not cannot give at all, because what it needs is the thing being
+ * measured.
+ *
+ * This is what the layout pass with no room on offer used to get from yoga's
+ * own `flexShrink: 0` default. Now that the default is CSS's `1` (#249) the
+ * pass has to be told, or every node would shrink to nothing and answer that
+ * the content needs no room — which is true of no content anywhere.
+ */
+function setMeasuringShrink(node, axis) {
+  for (const child of node.children) {
+    if (!child.yoga || child.isWindow) continue;
+    child.yoga.setFlexShrink(namesOwnFloor(child, axis) ? 1 : 0);
+    // …and not into a `display: 'none'` subtree, which the measurement does
+    // not read and `writeContentFloors` therefore does not walk back through
+    if (child.style.display === 'none') continue;
+    setMeasuringShrink(child, axis);
   }
-  return axisIsMain && (style.flexShrink ?? 0) > 0;
+}
+
+/** …and back to the layout everything else is run from. */
+function restoreShrink(node) {
+  for (const child of node.children) {
+    if (!child.yoga || child.isWindow) continue;
+    child.yoga.setFlexShrink(child.style.flexShrink ?? 1);
+    restoreShrink(child);
+  }
 }
 
 /**
@@ -799,20 +861,27 @@ function boundsItsOwnContent(node, axis, axisIsMain) {
  * `display: 'none'` one is not there at all.
  *
  * `intrinsic` carries what the leaves measured to before the pass being read
- * squashed them — see `_measureMinimum`, which is the only caller that needs
- * it. A container that came out at nothing is recovered by looking inside
- * it; a leaf has nothing inside, so it has to be remembered.
+ * squashed them — see `_measureContentSpans`, which is the only caller that
+ * needs it. A container that came out at nothing is recovered by looking
+ * inside it; a leaf has nothing inside, so it has to be remembered.
+ *
+ * `out` collects, for every node on the way, **the extent it contributes to
+ * the box around it** — which is exactly that node's automatic minimum size,
+ * so one pass and one walk give the whole tree its floors (#249) instead of
+ * a measurement per node. The recursion is therefore over all the children,
+ * even the ones whose own content does not count towards this one's: a
+ * scroll pane contributes nothing to the floor above it and still needs
+ * floors written *inside* it, or the column of rows it holds would shrink to
+ * the viewport and there would be nothing left to scroll.
  */
-function contentSpan(node, axis, intrinsic) {
+function contentSpan(node, axis, intrinsic, out) {
   const yoga = node.yoga;
   const horizontal = axis === 'width';
   const own = horizontal ? yoga.getComputedWidth() : yoga.getComputedHeight();
   const [startEdge, endEdge] = horizontal
     ? [Yoga.EDGE_LEFT, Yoga.EDGE_RIGHT]
     : [Yoga.EDGE_TOP, Yoga.EDGE_BOTTOM];
-  const direction = node.style.flexDirection ?? 'column';
-  const rowFirst = direction === 'row' || direction === 'row-reverse';
-  const axisIsMain = rowFirst === horizontal;
+  const axisIsMain = mainAxisOf(node) === axis;
   let start = Infinity;
   let end = -Infinity;
   // What the children after this one were laid out too early by. A node the
@@ -824,19 +893,25 @@ function contentSpan(node, axis, intrinsic) {
     // the same set that joins the flex tree: a nested <window> is laid out
     // by itself, and a <text> span has no box of its own
     if (!child.yoga || child.isWindow) continue;
-    if (child.style.position === 'absolute') continue;
     if (child.style.display === 'none') continue;
+    const span = contentSpan(child, axis, intrinsic, out);
+    const laidOut = horizontal
+      ? child.yoga.getComputedWidth()
+      : child.yoga.getComputedHeight();
+    // What the child needs from this box. A node that has said how small it
+    // can be is taken at its word — the measuring pass already let it shrink
+    // to exactly that — and anything else is asked what is inside it. Its
+    // laid-out size is deliberately *not* a floor under that answer: nothing
+    // shrank in this pass, so a box that measures its own content is sitting
+    // at its **max**-content size, which is the width a label would like to
+    // be rather than the width it can be squeezed to.
+    const extent = declaresOwnMinimum(child, axis) ? laidOut : span;
+    out?.set(child, extent);
+    if (child.style.position === 'absolute') continue;
     const at =
       (horizontal
         ? child.yoga.getComputedLeft()
         : child.yoga.getComputedTop()) + shift;
-    const laidOut = horizontal
-      ? child.yoga.getComputedWidth()
-      : child.yoga.getComputedHeight();
-    let extent = laidOut;
-    if (!boundsItsOwnContent(child, axis, axisIsMain)) {
-      extent = Math.max(extent, contentSpan(child, axis, intrinsic));
-    }
     // Only along the axis the children are packed on: on the other one they
     // all start from the same edge, so nothing follows anything.
     if (axisIsMain) shift += extent - laidOut;
@@ -845,26 +920,93 @@ function contentSpan(node, axis, intrinsic) {
   }
   if (start === Infinity) {
     // A leaf: nothing inside to look at, and what the pass did to it may
-    // have been a stretch rather than a measurement. So it is asked again —
-    // across, for the size its content cannot go below, which for a
-    // paragraph is its longest word; down, for what it measured before the
-    // collapse, since a height at a settled width is not a leaf's to give.
-    const measured = horizontal
-      ? node._measureFn?.(
-          0,
-          Yoga.MEASURE_MODE_AT_MOST,
-          undefined,
-          Yoga.MEASURE_MODE_UNDEFINED,
-        )?.width
-      : intrinsic?.get(node);
-    return Math.max(own, measured ?? 0);
+    // have been a stretch rather than a measurement. So it is asked again.
+    //
+    // **Across**, a leaf that measures itself answers outright: the width it
+    // gives when offered none is its min-content width, which for a
+    // paragraph is its longest word. That *replaces* the laid-out width
+    // rather than joining it in a `max`, because a measured leaf's base size
+    // is its max-content width — the whole line, unwrapped — and taking the
+    // larger of the two would floor every label at the width it would like
+    // to be. A leaf that measures nothing has only its own box to report.
+    //
+    // **Down**, it is what the leaf measured before the collapse squashed
+    // it: a height at a settled width is not a leaf's to give.
+    if (horizontal) {
+      const measured = node._measureFn?.(
+        0,
+        Yoga.MEASURE_MODE_AT_MOST,
+        undefined,
+        Yoga.MEASURE_MODE_UNDEFINED,
+      )?.width;
+      return measured ?? own;
+    }
+    return Math.max(own, intrinsic?.get(node) ?? 0);
   }
   const edges =
     yoga.getComputedPadding(startEdge) +
     yoga.getComputedPadding(endEdge) +
     yoga.getComputedBorder(startEdge) +
     yoga.getComputedBorder(endEdge);
-  return Math.max(own, end - start + edges);
+  return end - start + edges;
+}
+
+/**
+ * Write CSS's **automatic minimum size** onto every flex item under `node`:
+ * a floor of the extent it needs, along the axis its container lays out on,
+ * and restore the `flexShrink` the measurement borrowed on the way past.
+ *
+ * This is the other half of `flexShrink` defaulting to `1` (#249), and
+ * neither half is any good without the other. Yoga implements the shrink and
+ * not the floor, so a default of `1` on its own shrinks everything to
+ * nothing — a scroll pane's content collapses into its viewport and there is
+ * nothing left to scroll — while a default of `0` never squeezes a row into
+ * the space it has. CSS has both, and what makes its `flex-shrink: 1` safe is
+ * that `min-width: auto` on a flex item resolves to the item's min-content
+ * size. That is what this writes.
+ *
+ * Only the **main** axis, as in CSS: shrinking happens along the axis the
+ * container packs on, and on the other one an item is stretched or fits its
+ * content either way.
+ *
+ * Where this deliberately parts company with CSS is a node that named a
+ * size: CSS floors that at `min(the size, the content)`, so a `height: 40`
+ * box with nothing in it still squashes to nothing in a column too short for
+ * it. That rule is survivable on the web because a `<div>` is a *block*
+ * container and its children are not flex items at all; here every box lays
+ * its children out with flex, so it would apply to the whole tree — and a
+ * row of 40px cells silently 8px tall is not what anyone wrote. **A size
+ * that was named is a size that is kept**, and `minHeight: 0` is how an
+ * author says otherwise.
+ *
+ * `mins` is what every node contributes to the box around it, measured in
+ * one pass by `contentSpan`. `floored` collects what was written so the next
+ * measurement can take it back off — a floor left in place would be read
+ * back as content that cannot give, and could then only ratchet upwards.
+ */
+function writeContentFloors(node, axis, mins, floored) {
+  const axisIsMain = mainAxisOf(node) === axis;
+  const own = axis === 'width' ? 'minWidth' : 'minHeight';
+  for (const child of node.children) {
+    if (!child.yoga || child.isWindow) continue;
+    child.yoga.setFlexShrink(child.style.flexShrink ?? 1);
+    if (child.style.display === 'none') continue;
+    // A floor of 0 is what yoga does anyway, and an author who named their
+    // own `minWidth`/`minHeight` has already answered — overwriting it would
+    // put a measurement of ours above a number they wrote.
+    const floor = mins.get(child) ?? 0;
+    if (
+      axisIsMain &&
+      inFlow(child) &&
+      floor > 0 &&
+      typeof child.style[own] !== 'number'
+    ) {
+      if (axis === 'width') child.yoga.setMinWidth(floor);
+      else child.yoga.setMinHeight(floor);
+      floored.add(child);
+    }
+    writeContentFloors(child, axis, mins, floored);
+  }
 }
 
 /**
@@ -1086,8 +1228,9 @@ export class Node {
     this._paintOrderCache = null;
     this._hitBoundsCache = null;
     this._syncStyle(props);
-    this.yoga = yoga ? Yoga.Node.create() : null;
+    this.yoga = yoga ? createLayoutNode() : null;
     if (this.yoga) {
+      applyLayoutDefaults(this.yoga);
       applyLayoutStyle(this.yoga, this.style);
       // An element with a size of its own says so by implementing
       // `measureContent`, and the base class is what wires it to layout —
@@ -1159,7 +1302,7 @@ export class Node {
     }
     this._stateful = hasStateStyles(this._baseStyle);
     return this._retarget(
-      resolveScrollContainer(
+      resolveComputedStyle(
         this._stateful
           ? resolveStyleStates(this._baseStyle, this.states)
           : this._baseStyle,
@@ -1260,8 +1403,14 @@ export class Node {
     if (layoutChanged && this.yoga) {
       applyLayoutStyle(this.yoga, this.style, before);
       // a transition on a layout property costs a layout pass per frame —
-      // the author asked for that by transitioning one (docs/styling.md)
-      if (this.root) this.root.needsLayout = true;
+      // the author asked for that by transitioning one (docs/styling.md) —
+      // and a fresh set of content floors with it, since one of the
+      // properties it can be animating is a padding the floors were measured
+      // through
+      if (this.root) {
+        this.root.needsLayout = true;
+        this.root._floorsDirty = true;
+      }
     }
     // A tick writes `this.style` without going through `_retarget`, so it
     // owes the cascade the same notice — and it is the only thing that owes
@@ -1280,7 +1429,7 @@ export class Node {
     if (this.states[name] === on) return;
     this.states[name] = on;
     if (!this._stateful || this.destroyed) return;
-    const next = resolveScrollContainer(
+    const next = resolveComputedStyle(
       resolveStyleStates(this._baseStyle, this.states),
     );
     if (shallowEqual(next, this._targetStyle)) return;
@@ -3294,9 +3443,9 @@ export const Scrollable = (Base) =>
      * reads, and the reason `overflow: 'scroll'` and `overflow: 'hidden'`
      * are now genuinely different things: both clip, only this one scrolls.
      *
-     * The layout defaults that go with it — `flex-basis: 0`, `min-height: 0`,
-     * `flexShrink: 1` — are folded into the resolved style by
-     * `resolveScrollContainer` (styles.js), so they travel through the same
+     * The layout defaults that go with it — `flex-basis: 0`, `min-width: 0`,
+     * `min-height: 0` — are folded into the resolved style by
+     * `resolveComputedStyle` (styles.js), so they travel through the same
      * diff as any other style and come back off when the overflow does.
      */
     isScroller() {
@@ -5633,6 +5782,12 @@ export class WindowNode extends Scrollable(Node) {
     // it moves (see _sendSizeHints for why the size is part of it)
     this._sentHints = null;
     this._sentHintsAt = null;
+    // The automatic minimum size (#249): the nodes carrying a floor this
+    // window measured, whether the floors are still the answer, and the
+    // width the height half of them was measured for.
+    this._floored = new Set();
+    this._floorsDirty = true;
+    this._floorsWidth = null;
   }
 
   /**
@@ -5641,17 +5796,16 @@ export class WindowNode extends Scrollable(Node) {
    * `minHeight` resolves to.
    *
    * One layout pass **with no space on offer at all**, which is the whole
-   * trick — yoga answers it with every node at the smallest size its own
-   * style allows. Nothing shrinks unless the author said it may (yoga
-   * defaults `flexShrink` to 0, and `overflow: 'scroll'` sets it to 1 along
-   * with `minWidth: 0`), text measures at its longest word, and a wrapping
-   * row wraps at every item. `contentSpan` then reads how far that reached.
+   * trick — every node comes out at the smallest size its own style allows,
+   * text measures at its longest word, and a wrapping row wraps at every
+   * item. `contentSpan` then reads how far that reached, recovering a node
+   * the pass squashed by looking inside it.
    *
    * What it deliberately does *not* do is second-guess that layout. A node
-   * that shrank was told it may shrink, so it contributes what it shrank to
-   * and its content stops counting — CSS's `min-width: 0`, Qt's
-   * `QScrollArea`, GTK's `min-content-width`. All three spell the same
-   * escape hatch, and a scroll container gets it here for free.
+   * that said how small it can be — `minWidth: 0`, or an `overflow` that
+   * clips — is taken at its word and its content stops counting. That is
+   * CSS's `min-width: 0`, Qt's `QScrollArea` and GTK's `min-content-width`,
+   * and a scroll container gets it here for free.
    *
    * `forWidth` is the width the height is measured for, and there has to be
    * one: a paragraph's minimum height is a height *for a width*. GTK asks
@@ -5686,7 +5840,7 @@ export class WindowNode extends Scrollable(Node) {
     this.invalidate(true, null, 'direction');
   }
 
-  _measureMinimum(axis, forWidth) {
+  _measureContentSpans(axis, forWidth, out) {
     const yoga = this.yoga;
     const dir = this._rootDirection;
     // The root carries whatever size the last pass pinned on it, and an
@@ -5694,20 +5848,80 @@ export class WindowNode extends Scrollable(Node) {
     yoga.setWidth(undefined);
     yoga.setHeight(undefined);
     if (axis === 'width') {
+      setMeasuringShrink(this, axis);
       yoga.calculateLayout(0, undefined, dir);
-      return Math.ceil(contentSpan(this, axis));
+      return contentSpan(this, axis, undefined, out);
     }
     // Height takes two passes. The first is the tree at its real width with
     // no bound on the height, which is where every leaf reports the height
     // it actually needs there — a wrapped paragraph's is settled by the
-    // width, and no leaf can give any of it back. The second is the one
-    // that collapses, and it squashes a leaf that a `row` stretches: those
-    // are the ones the map above puts back.
+    // width, and no leaf can give any of it back. It runs before the shrink
+    // is borrowed, since the widths it settles are the real ones. The second
+    // is the one that collapses, and it squashes a leaf that a `row`
+    // stretches: those are the ones the map above puts back.
     yoga.calculateLayout(forWidth, undefined, dir);
     const intrinsic = new Map();
     captureLeafHeights(this, intrinsic);
+    setMeasuringShrink(this, axis);
     yoga.calculateLayout(forWidth, 0, dir);
-    return Math.ceil(contentSpan(this, axis, intrinsic));
+    return contentSpan(this, axis, intrinsic, out);
+  }
+
+  _measureMinimum(axis, forWidth) {
+    // Measured from the styles alone, so the floors this window wrote itself
+    // have to come off first: they were derived from this same measurement,
+    // and left in place they would be read back as content the tree cannot
+    // give up — a floor that could only ever ratchet upwards.
+    this._resetContentFloors();
+    const min = measuringExactly(() =>
+      Math.ceil(this._measureContentSpans(axis, forWidth)),
+    );
+    restoreShrink(this);
+    return min;
+  }
+
+  /**
+   * Give every flex item in this window's tree the floor CSS calls its
+   * automatic minimum size, so that `flexShrink`'s default of `1` squeezes a
+   * row into the space it has without squeezing its contents out of
+   * existence. See `writeContentFloors` for what that means and why both
+   * halves are needed.
+   *
+   * Two measurements, in this order because they depend that way round: the
+   * widths from a pass with no room on offer at all, then — with those floors
+   * already applied — the heights at the width the window is about to be laid
+   * out at, since a minimum height is always a height *for a width*.
+   *
+   * Nothing about this is per frame: the floors are content, so they survive
+   * every frame that did not change any (`_floorsDirty`), which is what keeps
+   * a wheel notch to the one layout pass it always was.
+   */
+  _applyContentFloors(width) {
+    if (!this._floorsDirty && this._floorsWidth === width) return;
+    this._resetContentFloors();
+    measuringExactly(() => {
+      const widths = new Map();
+      this._measureContentSpans('width', undefined, widths);
+      writeContentFloors(this, 'width', widths, this._floored);
+      const heights = new Map();
+      this._measureContentSpans('height', width, heights);
+      writeContentFloors(this, 'height', heights, this._floored);
+    });
+    this._floorsDirty = false;
+    this._floorsWidth = width;
+  }
+
+  /** Take the measured floors back off, leaving each node with whatever its
+   *  own style says. */
+  _resetContentFloors() {
+    if (!this._floored.size) return;
+    for (const node of this._floored) {
+      if (node.destroyed || !node.yoga) continue;
+      node.yoga.setMinWidth(node.style.minWidth);
+      node.yoga.setMinHeight(node.style.minHeight);
+    }
+    this._floored.clear();
+    this._floorsDirty = true;
   }
 
   /**
@@ -7128,6 +7342,9 @@ export class WindowNode extends Scrollable(Node) {
       return false;
     }
     this.querySize = { width, height };
+    // a query block may carry layout properties, so the floors measured from
+    // the styles it is replacing are not the answer any more
+    this._floorsDirty = true;
     for (const node of [...this._sizeQueryNodes]) {
       if (node.destroyed) this._sizeQueryNodes.delete(node);
       else node._sizeQueriesChanged();
@@ -7242,7 +7459,15 @@ export class WindowNode extends Scrollable(Node) {
       }
       (this._frameReasons ??= new Set()).add(reason);
     }
-    if (layoutChanged) this.needsLayout = true;
+    if (layoutChanged) {
+      this.needsLayout = true;
+      // The content floors are measured from the tree, so anything that
+      // changed it has to give them up — and **scrolling does not**, which is
+      // the whole reason this is not just `needsLayout`: a scroll moves an
+      // offset applied during `absolutize` and leaves every yoga node exactly
+      // as it was, at input rate, on the biggest trees in any app.
+      if (reason !== 'scroll') this._floorsDirty = true;
+    }
     // A layout change with no bound named repaints everything, because a
     // reflow can move any node and one that moved leaves stale pixels at a
     // rect its new position does not cover. Naming a node alongside
@@ -7340,6 +7565,7 @@ export class WindowNode extends Scrollable(Node) {
     const layoutRan = this.needsLayout;
     if (this.needsLayout) {
       this._resolveSizeQueries(width, height);
+      this._applyContentFloors(width);
       this.yoga.setWidth(width);
       this.yoga.setHeight(height);
       this.yoga.calculateLayout(width, height, this._rootDirection);

--- a/src/styles.js
+++ b/src/styles.js
@@ -51,6 +51,28 @@ const DISPLAY = {
   none: Yoga.DISPLAY_NONE,
 };
 
+/**
+ * CSS's `flex` shorthand, as the three properties it sets. A number is
+ * `flex: <grow> 1 0` — "take this share of what is left, from a base size of
+ * nothing" — which is what `flex: 1` means everywhere it is written; the two
+ * keywords are CSS's own, `'auto'` for "grow and shrink from my content" and
+ * `'none'` for "do neither".
+ *
+ * It is here rather than in `LAYOUT_APPLIERS` because a shorthand is not a
+ * yoga property: it expands into three of them before the diff runs, so
+ * `{ flex: 1, flexBasis: 'auto' }` resolves the way CSS does — the longhand
+ * after the shorthand wins — and the applier for each still sees a plain
+ * value changing.
+ */
+const FLEX_SHORTHAND = {
+  none: { flexGrow: 0, flexShrink: 0, flexBasis: 'auto' },
+  auto: { flexGrow: 1, flexShrink: 1, flexBasis: 'auto' },
+};
+
+const isFlexShorthand = (v) =>
+  (typeof v === 'number' && Number.isFinite(v) && v >= 0) ||
+  (typeof v === 'string' && v in FLEX_SHORTHAND);
+
 const OVERFLOW = {
   visible: Yoga.OVERFLOW_VISIBLE,
   hidden: Yoga.OVERFLOW_HIDDEN,
@@ -379,6 +401,9 @@ const STATE_PROPS = new Set([...PAINT_PROPS, 'color']);
 
 const STYLE_PROPS = new Set([
   ...Object.keys(LAYOUT_APPLIERS),
+  // the one layout property that is not a yoga property: a shorthand for
+  // three of them, expanded by `resolveComputedStyle`
+  'flex',
   ...PAINT_PROPS,
   ...TEXT_LAYOUT_PROPS,
   ...TEXT_PAINT_PROPS,
@@ -541,6 +566,13 @@ function validateStyle(style, where) {
     }
     if (!STYLE_PROPS.has(key)) {
       throw new Error(`react-x11: unknown style property "${key}" in ${where}`);
+    }
+    if (key === 'flex' && !isFlexShorthand(style[key])) {
+      throw new Error(
+        `react-x11: invalid flex ${JSON.stringify(style[key])} in ${where} ` +
+          '(expected a number — flex: 1 is flexGrow: 1, flexShrink: 1, ' +
+          "flexBasis: 0 — or 'auto' / 'none')",
+      );
     }
   }
 }
@@ -832,43 +864,117 @@ export function resolveTokens(style, theme, where = 'style', strict = true) {
 export { validateStyle };
 
 /**
- * The layout defaults `overflow: 'scroll'` implies, folded into the resolved
- * style so they travel through the ordinary diff — a scroll container is a
- * *style*, not a species of node, and every one of these is a CSS idiom the
- * author would otherwise have to remember.
+ * The style the layout is actually run from: the `flex` shorthand expanded,
+ * and the defaults `overflow: 'scroll'` implies folded in. Both are things a
+ * style *means* rather than things it says, and doing them here — once, on
+ * the resolved object — is what lets everything downstream stay a flat diff
+ * of yoga properties.
+ *
+ * Returns `style` itself when there is nothing to add, so identity comparisons
+ * upstream keep meaning "the style did not change".
+ *
+ * The scroll-container half, property by property:
  *
  * - **`min-width/height: 0`** is the spec's own rule, not an invention: CSS
  *   computes `min-*: auto` to `0` on a flex item whose overflow is not
- *   `visible`. Yoga does not, and without it the item's min-content size is
- *   a floor the viewport cannot shrink below.
- * - **`flexShrink: 1`** because yoga's default is `0`, which sizes the
- *   viewport to its content — a scroll container has to yield to the layout
- *   around it instead.
+ *   `visible`. It is the one place the automatic minimum size (`Node`'s
+ *   content floors) does not apply, and the reason a viewport can be smaller
+ *   than what is inside it — which is what scrolling is.
  * - **`flexBasis: 0`** — what CSS's `flex: 1` means — only when the author
  *   asked it to grow and gave it no size of its own. A flex item's base size
  *   is its content, and a window whose scrolling pane holds more rows than
  *   fit grew *past* the window, pushing the footer out of view however small
  *   the window got. Zeroing the basis fixes the whole ancestor chain at once,
  *   since the content stops counting towards any of their heights.
- *
- * Returns `style` itself when there is nothing to add, so identity comparisons
- * upstream keep meaning "the style did not change".
  */
-export function resolveScrollContainer(style) {
-  if (style.overflow !== 'scroll') return style;
-  const out = { ...style };
-  if (out.flexShrink === undefined) out.flexShrink = 1;
-  if (out.minWidth === undefined) out.minWidth = 0;
-  if (out.minHeight === undefined) out.minHeight = 0;
-  if (
-    out.flexBasis === undefined &&
-    out.width === undefined &&
-    out.height === undefined &&
-    (out.flexGrow ?? 0) > 0
-  ) {
-    out.flexBasis = 0;
+export function resolveComputedStyle(style) {
+  const scrolls = style.overflow === 'scroll';
+  if (style.flex === undefined && !scrolls) return style;
+  const out = {};
+  if (style.flex !== undefined) {
+    const expansion =
+      typeof style.flex === 'number'
+        ? { flexGrow: style.flex, flexShrink: 1, flexBasis: 0 }
+        : FLEX_SHORTHAND[style.flex];
+    if (!expansion) {
+      throw new Error(
+        `react-x11: invalid flex ${JSON.stringify(style.flex)} ` +
+          "(expected a number, 'auto' or 'none')",
+      );
+    }
+    Object.assign(out, expansion);
+  }
+  // after the expansion, so a longhand written beside the shorthand wins
+  for (const key of Object.keys(style)) {
+    if (key !== 'flex') out[key] = style[key];
+  }
+  if (scrolls) {
+    if (out.minWidth === undefined) out.minWidth = 0;
+    if (out.minHeight === undefined) out.minHeight = 0;
+    if (
+      out.flexBasis === undefined &&
+      out.width === undefined &&
+      out.height === undefined &&
+      (out.flexGrow ?? 0) > 0
+    ) {
+      out.flexBasis = 0;
+    }
   }
   return out;
+}
+
+/**
+ * The renderer's own yoga config — one for the process, shared by every node
+ * — which exists so that a **measurement** can be taken off the pixel grid.
+ *
+ * Yoga rounds a finished layout to whole pixels, and does it on absolute
+ * positions, so a box 36.4 tall reads back as 36 or 37 depending on where it
+ * landed. Summing those with exact paddings is how a min-content measurement
+ * of 36.4 comes out as 37 — and a floor of 37 does not hold a box at the size
+ * it already was, it *grows* it, one pixel per nesting level, all the way up
+ * the tree. Measuring with the grid switched off is what keeps a floor a
+ * promise not to shrink rather than an instruction to grow.
+ *
+ * The final layout — the one that decides where anything is actually drawn —
+ * always runs rounded, which is what keeps a border on a whole pixel.
+ */
+let config = null;
+const layoutConfig = () => (config ??= Yoga.Config.create());
+
+/** A yoga node in the renderer's config. */
+export const createLayoutNode = () => Yoga.Node.create(layoutConfig());
+
+/**
+ * Run `measure` with the pixel grid switched off, and put it back however
+ * that goes: a throw here would otherwise leave every later layout in the
+ * process unrounded, which is a class of blurry-by-a-half-pixel bug nothing
+ * would connect back to this.
+ */
+export function measuringExactly(measure) {
+  const cfg = layoutConfig();
+  cfg.setPointScaleFactor(0);
+  try {
+    return measure();
+  } finally {
+    cfg.setPointScaleFactor(1);
+  }
+}
+
+/**
+ * The yoga defaults that are not CSS's, written once per node.
+ *
+ * `applyLayoutStyle` only calls a setter for a property that **changed**, so
+ * a style that never mentions `flexShrink` never reaches the `?? 1` in its
+ * applier and yoga's own `0` would stand. A default that only exists in the
+ * reset path is not a default; this is where it actually happens.
+ *
+ * The pair to it is the automatic minimum size — a flex item that may shrink
+ * still cannot shrink below its content unless it says so. Yoga has no such
+ * rule, so the renderer measures the floors itself; see `Node`'s content
+ * floors in nodes.js.
+ */
+export function applyLayoutDefaults(yogaNode) {
+  yogaNode.setFlexShrink(1);
 }
 
 /**

--- a/src/types/style.d.ts
+++ b/src/types/style.d.ts
@@ -95,7 +95,17 @@ export interface LayoutStyle {
   alignSelf?: Align;
   alignContent?: Align;
   flexWrap?: FlexWrap;
+  /**
+   * CSS's shorthand: `flex: 1` is `flexGrow: 1, flexShrink: 1,
+   * flexBasis: 0` — take this share of what is left, from a base size of
+   * nothing. `'auto'` grows and shrinks from the content's own size,
+   * `'none'` does neither. A longhand written beside it wins.
+   */
+  flex?: number | 'auto' | 'none';
   flexGrow?: number;
+  /** How eagerly this item gives up the space it has **above its content**;
+   *  `1` by default, as in CSS. It never shrinks past what is inside it —
+   *  say `minWidth: 0` (or an `overflow` that clips) for that. */
   flexShrink?: number;
   flexBasis?: Dimension;
   position?: PositionType;

--- a/test/content-floors.test.js
+++ b/test/content-floors.test.js
@@ -1,0 +1,325 @@
+// `flexShrink` defaults to CSS's `1`, and the automatic minimum size that
+// makes that safe (#249).
+//
+// The pair is the whole feature: everything may shrink, and nothing shrinks
+// below what it needs. So most of this file is about where "what it needs"
+// stops — a size that was named, a `minWidth: 0` that gives it up, an
+// `overflow` that clips — and about the axis the rule applies on, which is
+// the container's main one, as in CSS.
+//
+// Headless, so there are no fonts and text measures 0x0 (see AGENTS.md): the
+// content is sized boxes throughout, and "content that can compress" is a
+// wrapping row rather than a paragraph.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import { createRoot } from '../src/index.js';
+import { createStyles } from '../src/styles.js';
+import { Node } from '../src/node.js';
+import { createMockApp, spinWheel } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+/** Render `children` in a window of a fixed size, settled through a frame. */
+async function mount(children, windowProps = {}) {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(
+    h(
+      'window',
+      { title: 'floors', width: 300, height: 200, ...windowProps },
+      children,
+    ),
+  );
+  await tick();
+  app.windows[0].flushFrame?.();
+  await tick();
+  return { app, root, node: app.windows[0]._reactX11Node };
+}
+
+const box = (style, ...children) => h('box', { style }, ...children);
+const size = (node) => [node.current.abs.width, node.current.abs.height];
+
+// --- everything shrinks -----------------------------------------------------
+
+test('a style that never mentions flexShrink still gets CSS’s 1', async () => {
+  // A node on its own, before anything has laid it out, because that is
+  // where the bug was: `applyLayoutStyle` only calls a setter for a property
+  // that *changed*, so the `?? 1` in the applier was only ever reached by a
+  // style that had already said something about shrinking, and yoga's own
+  // `0` stood for every style that had not.
+  const app = createMockApp();
+  assert.strictEqual(new Node('box', {}, app).yoga.getFlexShrink(), 1);
+  assert.strictEqual(
+    new Node('box', { style: { flexShrink: 0 } }, app).yoga.getFlexShrink(),
+    0,
+    'still opt-out-able',
+  );
+});
+
+test('a row too narrow for its content squeezes it instead of overflowing', async () => {
+  // The headline of the issue. The item's own width comes from its content —
+  // three 40px chips that can wrap — so 120 of content has to fit in 100,
+  // and with yoga's `flexShrink: 0` it simply did not: the row ran off the
+  // end of the box that contained it.
+  const item = React.createRef();
+  const { root } = await mount(
+    box(
+      { flexDirection: 'row', width: 100 },
+      h(
+        'box',
+        { ref: item, style: { flexDirection: 'row', flexWrap: 'wrap' } },
+        ...[0, 1, 2].map((i) =>
+          h('box', { key: i, style: { width: 40, height: 10 } }),
+        ),
+      ),
+    ),
+  );
+  assert.deepStrictEqual(size(item), [100, 20], 'squeezed, and so wrapped');
+  await root.unmount();
+});
+
+test('a box does not shrink past what is inside it', async () => {
+  // The other half, and the reason flipping the default alone was worse than
+  // leaving it: yoga shrinks to nothing, CSS floors every flex item at its
+  // min-content size. Nothing here can compress, so nothing gives.
+  const giving = React.createRef();
+  const { root } = await mount(
+    box(
+      { flexDirection: 'row', width: 50 },
+      h(
+        'box',
+        { ref: giving, style: { flexShrink: 1 } },
+        box({ width: 100, height: 20 }),
+      ),
+    ),
+  );
+  assert.deepStrictEqual(
+    size(giving),
+    [100, 20],
+    'the 100px inside is a floor',
+  );
+  await root.unmount();
+});
+
+test('a column keeps the heights its rows were given', async () => {
+  // CSS would floor a `height: 40` item at `min(40, its content)` — which is
+  // 0 for an empty box — because on the web the box around it is usually a
+  // *block* container and its children are not flex items at all. Here every
+  // box lays its children out with flex, so that rule would apply to the
+  // whole tree: 10 rows of 40 in a 100px pane, each silently 10 tall.
+  const rows = Array.from({ length: 10 }, () => React.createRef());
+  const { root } = await mount(
+    box(
+      { overflow: 'scroll', height: 100 },
+      ...rows.map((ref, i) => h('box', { key: i, ref, style: { height: 40 } })),
+    ),
+  );
+  assert.deepStrictEqual(
+    rows.map((ref) => ref.current.abs.height),
+    Array(10).fill(40),
+    'a size that was named is a size that is kept',
+  );
+  await root.unmount();
+});
+
+// --- how a node gives it up -------------------------------------------------
+
+test('minWidth: 0 is how a style says "down to nothing"', async () => {
+  const giving = React.createRef();
+  const { root } = await mount(
+    box(
+      { flexDirection: 'row', width: 120 },
+      h(
+        'box',
+        { ref: giving, style: { minWidth: 0 } },
+        box({ width: 40, height: 10 }),
+      ),
+      box({ width: 100, height: 10 }),
+    ),
+  );
+  assert.strictEqual(giving.current.abs.width, 20, 'gave up 20 of its 40');
+  await root.unmount();
+});
+
+test('a clipping box gives it up too, without being asked', async () => {
+  // CSS's own exemption — `min-*: auto` computes to `0` on anything whose
+  // overflow is not `visible` — and the reason a scroll pane can be smaller
+  // than what is inside it.
+  for (const overflow of ['scroll', 'hidden']) {
+    const giving = React.createRef();
+    const { root } = await mount(
+      box(
+        { flexDirection: 'row', width: 120 },
+        h(
+          'box',
+          { ref: giving, style: { overflow } },
+          box({ width: 40, height: 10 }),
+        ),
+        box({ width: 100, height: 10 }),
+      ),
+    );
+    assert.strictEqual(giving.current.abs.width, 20, `overflow: ${overflow}`);
+    await root.unmount();
+  }
+});
+
+test('a minWidth of its own is never overwritten by a measurement', async () => {
+  const floored = React.createRef();
+  const { root } = await mount(
+    box(
+      { flexDirection: 'row', width: 120 },
+      h(
+        'box',
+        { ref: floored, style: { minWidth: 30 } },
+        box({ width: 60, height: 10 }),
+      ),
+      box({ width: 100, height: 10 }),
+    ),
+  );
+  assert.strictEqual(floored.current.abs.width, 30, 'the number it was given');
+  await root.unmount();
+});
+
+// --- where the floor is not written -----------------------------------------
+
+test('the floor is the main axis only, as in CSS', async () => {
+  // Across the row nothing shrinks by flexing, so a cross-axis floor would
+  // only ever be a way to make a container overflow itself. This box is
+  // taller than the row that holds it and is cut off, not floored.
+  const tall = React.createRef();
+  const { root } = await mount(
+    box(
+      { flexDirection: 'row', width: 200, height: 30, overflow: 'hidden' },
+      h('box', { ref: tall }, box({ width: 20, height: 90 })),
+    ),
+  );
+  assert.strictEqual(tall.current.abs.height, 30, 'stretched to the row');
+  await root.unmount();
+});
+
+test('an absolutely positioned child is floored by nothing', async () => {
+  const badge = React.createRef();
+  const { root } = await mount(
+    box(
+      { flexDirection: 'row', width: 100 },
+      h(
+        'box',
+        {
+          ref: badge,
+          style: { position: 'absolute', left: 0, top: 0, width: '50%' },
+        },
+        box({ width: 400, height: 10 }),
+      ),
+    ),
+  );
+  assert.strictEqual(
+    badge.current.abs.width,
+    50,
+    'its own 50%, not its content',
+  );
+  await root.unmount();
+});
+
+// --- what it costs ----------------------------------------------------------
+
+test('scrolling does not re-measure the floors', async () => {
+  // The floors are content, and a scroll is the one layout change that moves
+  // no yoga node at all — it applies an offset during `absolutize`. It also
+  // happens at input rate on the biggest trees in any app, so paying three
+  // layout passes for it would be the whole cost of the feature landing in
+  // the one place that cannot afford it.
+  const { app, root, node } = await mount(
+    box(
+      { overflow: 'scroll', height: 100 },
+      ...Array.from({ length: 10 }, (_, i) =>
+        h('box', { key: i, style: { height: 40 } }),
+      ),
+    ),
+  );
+  assert.strictEqual(node._floorsDirty, false, 'settled after the first frame');
+  const floored = node._floored.size;
+  assert.ok(floored > 0, 'the rows carry floors');
+
+  spinWheel(app.windows[0], 50, 50, 1);
+  app.windows[0].flushFrame?.();
+  await tick();
+  assert.strictEqual(node._floorsDirty, false, 'still the same answer');
+  assert.strictEqual(node._floored.size, floored);
+  await root.unmount();
+});
+
+// --- the `flex` shorthand ---------------------------------------------------
+
+test('flex: 1 is grow 1, shrink 1, basis 0', async () => {
+  const a = React.createRef();
+  const b = React.createRef();
+  const { root } = await mount(
+    box(
+      { flexDirection: 'row', width: 120 },
+      h('box', { ref: a, style: { flex: 1 } }, box({ width: 200, height: 10 })),
+      h('box', { ref: b, style: { flex: 2 } }),
+    ),
+  );
+  // the basis is 0, so the 200px inside `a` counts for nothing in the share
+  // — and the floor is *its* min-content, which is what stops it at 200
+  assert.strictEqual(b.current.abs.width, 80, 'two shares of three');
+  assert.strictEqual(a.current.style.flexBasis, 0);
+  assert.strictEqual(a.current.style.flexShrink, 1);
+  await root.unmount();
+});
+
+test('a longhand written beside the shorthand wins', async () => {
+  const ref = React.createRef();
+  const { root } = await mount(
+    box(
+      { flexDirection: 'row', width: 120 },
+      h('box', { ref, style: { flex: 1, flexShrink: 0, flexBasis: 40 } }),
+    ),
+  );
+  assert.strictEqual(ref.current.style.flexShrink, 0);
+  assert.strictEqual(ref.current.style.flexBasis, 40);
+  assert.strictEqual(
+    ref.current.style.flexGrow,
+    1,
+    'the shorthand still set this',
+  );
+  assert.strictEqual(
+    ref.current.style.flex,
+    undefined,
+    'expanded, not passed on',
+  );
+  await root.unmount();
+});
+
+test("flex: 'none' and flex: 'auto' are CSS's two keywords", async () => {
+  const none = React.createRef();
+  const auto = React.createRef();
+  const { root } = await mount(
+    box(
+      { flexDirection: 'row', width: 100 },
+      h(
+        'box',
+        { ref: none, style: { flex: 'none' } },
+        box({ width: 60, height: 10 }),
+      ),
+      h(
+        'box',
+        { ref: auto, style: { flex: 'auto' } },
+        box({ width: 20, height: 10 }),
+      ),
+    ),
+  );
+  assert.strictEqual(none.current.style.flexShrink, 0);
+  assert.strictEqual(none.current.style.flexBasis, 'auto');
+  assert.deepStrictEqual(size(auto), [40, 10], 'grew into what was left');
+  await root.unmount();
+});
+
+test('an unknown flex value says what the three are', async () => {
+  assert.throws(
+    () => createStyles({ bad: { flex: 'fill' } }),
+    /invalid flex "fill" in styles\.bad .*expected a number/s,
+  );
+});

--- a/test/overflow-scroll.test.js
+++ b/test/overflow-scroll.test.js
@@ -105,7 +105,7 @@ test('the scroll-container layout defaults come off the style, not a constructor
   );
   assert.equal(grown.current.style.flexBasis, 0, 'flex-basis: 0 injected');
   assert.equal(grown.current.style.minHeight, 0, 'min-height: 0 injected');
-  assert.equal(grown.current.style.flexShrink, 1);
+  assert.equal(grown.current.style.minWidth, 0, 'min-width: 0 injected');
   assert.equal(sized.current.style.flexBasis, undefined, 'sized: left alone');
   assert.equal(sized.current.abs.height, 50);
 });

--- a/test/tabs-splitpane.test.js
+++ b/test/tabs-splitpane.test.js
@@ -241,11 +241,11 @@ test('SplitPane sizes the first pane and gives the rest to the second', async ()
 });
 
 test('the second pane does not grow to fit content wider than it', async () => {
-  // Yoga defaults flexShrink to 0 where CSS defaults it to 1, so a pane left
-  // at `flexBasis: auto` takes its content's max-content width as a base and
-  // then cannot shrink back to the space actually available. The symptom is a
-  // wrapping row that never wraps and overflows the window instead, which is
-  // invisible in the empty-pane test above: with no content there is no
+  // A pane left at `flexBasis: auto` takes its content's max-content width
+  // as a base, and shrinking only ever brings it back to the content's own
+  // floor — which for a row of rigid cards is that same width. The symptom is
+  // a wrapping row that never wraps and overflows the window instead, which
+  // is invisible in the empty-pane test above: with no content there is no
   // natural width for the basis to pick up.
   const app = createMockApp();
   const x11Root = await createRoot({ app });

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -166,6 +166,16 @@ const composed: StyleProp = [s.root, false, null, [s.row, { padding: 4 }]];
 const flat: Style = flattenStyle(composed);
 const grow: number | undefined = flat.flexGrow;
 
+// the `flex` shorthand: a share of what is left, or one of CSS's two keywords
+createStyles({
+  fill: { flex: 1 },
+  sized: { flex: 'auto' },
+  rigid: { flex: 'none', flexShrink: 0 },
+});
+
+// @ts-expect-error — 'fill' is not one of them
+createStyles({ bad: { flex: 'fill' } });
+
 // @ts-expect-error — 'sideways' is not a flexDirection
 createStyles({ bad: { flexDirection: 'sideways' } });
 

--- a/test/window-min-size.test.js
+++ b/test/window-min-size.test.js
@@ -2,10 +2,11 @@
 //
 // The floor is measured by laying the tree out with no room at all and
 // reading how far it still reached — so what a node contributes is whatever
-// its own style lets it shrink to, and a node that was told it may shrink
-// (`flexShrink`, `overflow: 'scroll'`) contributes nothing. That is the
-// escape hatch Qt spells `QScrollArea` and GTK spells `min-content-width`,
-// and most of what is asserted here is which side of it a node falls on.
+// its own style lets it shrink to, and a node that named a floor of its own
+// (`minWidth: 0`, `overflow: 'scroll'`) contributes that instead of its
+// content. That is the escape hatch Qt spells `QScrollArea` and GTK spells
+// `min-content-width`, and most of what is asserted here is which side of it
+// a node falls on.
 //
 // Headless, so there are no fonts and text measures 0x0 (see AGENTS.md): the
 // content is sized boxes throughout, and the height-for-width case is built
@@ -125,7 +126,7 @@ test('a column is floored by its widest row, not by their sum', async () => {
 
 test('a scroll container contributes nothing to the floor', async () => {
   // The escape hatch, and it costs the author nothing to reach: `overflow:
-  // 'scroll'` already resolves to `minWidth: 0, flexShrink: 1`, so the pass
+  // 'scroll'` already resolves to `minWidth: 0, minHeight: 0`, so the pass
   // that measures the floor finds a pane that can give everything. What is
   // left is the rigid sidebar beside it.
   const { wnd, root } = await mount(
@@ -148,7 +149,33 @@ test('a scroll container contributes nothing to the floor', async () => {
   await root.unmount();
 });
 
-test('a box told it may shrink is taken at its word', async () => {
+test('a box that says minWidth: 0 is taken at its word', async () => {
+  const { wnd, root } = await mount(
+    h(
+      'window',
+      { minWidth: 'auto', width: 600, height: 200 },
+      h(
+        'box',
+        { style: { flexDirection: 'row' } },
+        h(
+          'box',
+          { key: 'giving', style: { minWidth: 0 } },
+          box({ width: 400, height: 20 }, 'inside'),
+        ),
+        box({ width: 100, height: 20 }, 'rigid'),
+      ),
+    ),
+  );
+  assert.strictEqual(hintsOf(wnd).minWidth, 100);
+  await root.unmount();
+});
+
+test('flexShrink alone gives up no content (#249)', async () => {
+  // The same tree with the escape hatch spelled the way it used to be. Back
+  // when yoga's `flexShrink: 0` was the default, asking for `1` was a
+  // statement — "this one can give" — and the floor read it as one. Every
+  // node may shrink now, so it says nothing about how far, and the 400px
+  // box inside still has to fit.
   const { wnd, root } = await mount(
     h(
       'window',
@@ -161,11 +188,11 @@ test('a box told it may shrink is taken at its word', async () => {
           { key: 'giving', style: { flexShrink: 1 } },
           box({ width: 400, height: 20 }, 'inside'),
         ),
-        box({ width: 100, height: 20, flexShrink: 0 }, 'rigid'),
+        box({ width: 100, height: 20 }, 'rigid'),
       ),
     ),
   );
-  assert.strictEqual(hintsOf(wnd).minWidth, 100);
+  assert.strictEqual(hintsOf(wnd).minWidth, 500);
   await root.unmount();
 });
 

--- a/website/src/demos/layout.js
+++ b/website/src/demos/layout.js
@@ -4,7 +4,7 @@ export default {
   description:
     'Layout is yoga — the same flexbox engine React Native uses. Every <box> ' +
     'is one yoga node, laid out in the renderer and painted into the window; ' +
-    'none of these are X windows. Try changing flexDirection, gap or flexGrow.',
+    'none of these are X windows. Try changing flexDirection, gap or flex.',
   code: `import React, { useState } from 'react';
 import { createRoot } from 'react-x11';
 
@@ -13,8 +13,7 @@ const COLORS = ['#2980b9', '#27ae60', '#e67e22', '#8e44ad'];
 function Panel({ label, grow, color }) {
   return (
     <box style={{
-      flexGrow: grow,
-      flexBasis: 0,
+      flex: grow,
       backgroundColor: color,
       borderRadius: 8,
       padding: 12,
@@ -49,15 +48,15 @@ function App() {
         </text>
       </box>
 
-      {/* the flex container: children share the space by flexGrow */}
+      {/* the flex container: children share the space by their flex share */}
       <box style={{
         flexGrow: 1,
         flexDirection: row ? 'row' : 'column',
         gap: 10,
       }}>
-        <Panel label="flexGrow 1" grow={1} color={COLORS[0]} />
-        <Panel label="flexGrow 2" grow={2} color={COLORS[1]} />
-        <Panel label="flexGrow 1" grow={1} color={COLORS[2]} />
+        <Panel label="flex 1" grow={1} color={COLORS[0]} />
+        <Panel label="flex 2" grow={2} color={COLORS[1]} />
+        <Panel label="flex 1" grow={1} color={COLORS[2]} />
       </box>
 
       {/* absolute positioning works too, relative to the nearest ancestor */}


### PR DESCRIPTION
Closes #249.

Today an unstyled box **never shrinks**: `applyLayoutStyle` only calls a setter for a property that *changed*, so a style that never mentions `flexShrink` never reaches the `?? 1` in its applier and yoga's own `0` stands. Content wider than the space available pushes its row past the container instead of being squeezed into it.

The issue is about what to replace that with, because — as it measured — **flipping the default alone is worse**: 23 new failures, in two clusters, both of which are yoga implementing one half of a pair. CSS's `flex-shrink: 1` travels with **`min-width: auto` on flex items** — the automatic minimum size, which resolves to the item's min-content size. Without that floor a scroll pane's content shrinks into its viewport and there is nothing left to scroll, and a `<window minWidth="auto">` measures no content at all.

So both halves land here.

## What changed

- **`flexShrink` defaults to `1`**, seeded per node (`applyLayoutDefaults`) rather than left to a reset path nothing reaches.
- **Every flex item carries a content floor** — CSS's automatic minimum size, measured by the renderer since yoga has no rule for it. One min-content pass per axis, recorded for *every* node by the same walk that already computed the root's for #248, written onto the yoga nodes as `minWidth`/`minHeight` and taken back off before the next measurement. Main axis only, as in CSS.
- **`flex` as a style property**: `flex: 1` is `{ flexGrow: 1, flexShrink: 1, flexBasis: 0 }`, plus CSS's `'auto'` and `'none'`; a longhand written beside it wins. The cheap win the issue asked for either way.
- **`boundsItsOwnContent` reads a different signal**, as the issue predicted: "was told it may shrink" carried information only while the default was `0`. The escape hatch is now `minWidth: 0` / `minHeight: 0`, or an `overflow` that clips — CSS's own exemption, and what `overflow: 'scroll'` already injects. It no longer injects `flexShrink: 1`, which is the default now.

## Two details that are load-bearing rather than incidental

- The measuring passes run with **yoga's pixel grid off** (`measuringExactly`). Rounded sizes summed with exact paddings make a floor a pixel too tall, and a floor above the natural size does not *hold* a box — it **grows** it, a pixel per nesting level, all the way up the tree. This is what took the first working version from "every example one pixel taller" to byte-identical screenshots.
- They also **borrow `flexShrink`** (`setMeasuringShrink`): min-content means "nothing gives", so a pass run at the new default answers that the content needs no room at all.

## The deliberate deviation from CSS

**A size that was named is kept.** CSS floors an item at `min(its size, its content)`, so an empty `height: 40` box squashes to nothing in a column too short for it. That is survivable on the web because a `<div>` is a *block* container and its children are not flex items; it is not survivable here, where every box lays its children out with flex — 10 rows of 40 in a 100px pane, each silently 10 tall. `minHeight: 0` asks for CSS's answer.

## Rendered by this PR's own code

Same scene, `master` and this branch: a row of buttons and a label in a card too narrow for them, and a scroll pane that must keep working.

**Before** — the row runs off the card, the label past its edge:

![before](https://github.com/user-attachments/assets/76f649ce-ca0f-4863-ba86-9882b0beb790)

**After** — each squeezes to its longest word and wraps; the scroll pane is unchanged:

![after](https://github.com/user-attachments/assets/6db4cbc7-dc51-4e24-af80-dbc7aa5958f1)

## Cost, and what is fenced against it

- `npm run bench -- --check`: **no regressions**. The floors add no protocol traffic.
- Wall clock: the measurement is ~3 layout passes plus O(n) walks on a frame that *changes the layout*. On a deliberately pathological tree — 900 nodes, every one re-rendered every frame — that is 12ms → 18ms per frame; a normal tree is a fraction of it, and it is zero for a frame that changed nothing.
- **`_floorsDirty` keeps it off the input path**: `invalidate()` gives the floors up for every layout change *except* a scroll, which moves no yoga node. `test/content-floors.test.js` pins that a wheel notch re-measures nothing.
- `docs/img/*.png` regenerated: **byte-identical** to a regeneration on `master`. Where a layout already had the room it wanted, nothing moves.

## Tests

`test/content-floors.test.js` is new — 14 cases over both halves, the escape hatches, the axis rule, the scroll gate and the shorthand. Mutation-checked: stubbing `_applyContentFloors` out fails 6 of them, and reverting the default fails the one that reads the yoga node directly.

`test/window-min-size.test.js`'s "a box told it may shrink is taken at its word" becomes "a box that says `minWidth: 0` is taken at its word", with a companion pinning that `flexShrink` alone now gives up no content — the #248/#249 coupling the issue named, changed in the same PR.

Docs, the `.d.ts`, the type test, the examples and the website demo move with it; `npm test` in `website/` is green.

Note for the reviewer: `npm run stress:check` fails with `Maximum call stack size exceeded` on this machine — **on `master` too**, unchanged by this branch.


