### PR TITLE
feat(devtools): the overlays, the picker and the style editor a backend asks its host for

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,10 +338,14 @@ REACT_X11_DEVTOOLS=1 npm run examples:dashboard   # 2. run any example with the 
 ```
 
 The component tree, props and hook state show up live in the DevTools
-window; selecting a component inspects it, and hovering an element in the
-tree tints its rect in the X11 window (highlight-on-hover).
-`REACT_X11_DEVTOOLS_HOST` / `REACT_X11_DEVTOOLS_PORT` override the default
-`localhost:8097`. See [docs/devtools.md](docs/devtools.md).
+window, and editing any of them re-renders the app. Hovering an element in
+the tree tints its rect in the X11 window; the toolbar's crosshair picks an
+element by clicking it in the app; "highlight updates when components
+render" outlines the rects that just re-rendered; the style editor edits a
+selected element's style live; and the Profiler can restart the app to
+record its mount. `REACT_X11_DEVTOOLS_HOST` / `REACT_X11_DEVTOOLS_PORT`
+override the default `localhost:8097`. See
+[docs/devtools.md](docs/devtools.md).
 
 Two more debugging aids:
 

--- a/docs/click-to-component.md
+++ b/docs/click-to-component.md
@@ -25,6 +25,11 @@ Alt+Shift+Click also logs the full ownership chain (who rendered who, up to
 the root) to the console — handy when the immediate owner is a shared
 wrapper rather than the component you actually meant.
 
+With React DevTools attached as well (`REACT_X11_DEVTOOLS=1`, see
+[devtools.md](devtools.md)), the same click also selects that element in the
+DevTools tree — one click to the source _and_ to its props. Nothing changes
+when DevTools is absent, which is the usual case.
+
 `REACT_X11_EDITOR` picks the editor (`cursor` by default): `code`,
 `code-insiders`, `windsurf`, `vim`, `nvim`, or any other value, treated as a
 custom URI scheme.

--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -22,16 +22,76 @@ few seconds).
 What you get:
 
 - the **component tree**, live as the app updates;
-- **props, hooks and state** when selecting a component;
+- **props, hooks and state** when selecting a component, and editing any of
+  them — the edit goes through the reconciler's own override path, so the
+  app really re-renders;
 - **highlight-on-hover** — hovering an element in the tree tints its rect
   in the X11 window;
-- the Profiler's commit list and flamegraph. **Not** its Timeline view,
-  which needs `injectProfilingHooks` — this reconciler build does not
-  expose it, so there is nothing to enable.
+- **"highlight updates when components render"** — the rects that just
+  re-rendered are outlined, in DevTools' own colour ramp (teal for a first
+  render through amber for one that keeps re-rendering), fading out on the
+  backend's clock;
+- the **element picker** — the crosshair in the DevTools toolbar. While it
+  is on, the pointer belongs to DevTools: motion tints whatever is under
+  it, a click selects that element in the tree, `Escape` gives up. The app
+  sees none of those events;
+- the **style editor** — the box model and the flattened `style` of a
+  selected element, editable live. Host elements are hidden by the default
+  component filter, so turn that filter off (⚙ → Components → uncheck
+  "host components") to have something with a style to select;
+- the Profiler's commit list and flamegraph, including **"reload and start
+  profiling"**, which re-execs the app with profiling already on so the
+  mount itself is recorded. **Not** its Timeline view, which needs
+  `injectProfilingHooks` — this reconciler build does not expose it, so
+  there is nothing to enable;
+- **DevTools' own settings** — component filters, console patching — kept
+  between runs, in `$XDG_CACHE_HOME/react-x11/devtools.json`
+  (`~/Library/Caches/react-x11/devtools.json` on macOS).
+
+With `REACT_X11_CLICK_TO_COMPONENT=1` as well, an Alt+Click also selects
+the clicked element in the DevTools tree on its way to opening the source
+([click-to-component.md](click-to-component.md)).
 
 `REACT_X11_DEVTOOLS_HOST` / `REACT_X11_DEVTOOLS_PORT` point the backend at
 a non-default standalone (e.g. devtools on another machine — handy when the
-X app runs on a headless box).
+X app runs on a headless box). `REACT_X11_DEVTOOLS_STATE` moves the
+settings file.
+
+DevTools has no network panel — nothing in its protocol carries network
+data, and no injection would change that. For that, `node --inspect` and
+`chrome://inspect` still work alongside all of this.
+
+## Opening the source from the DevTools panel
+
+The inspected-element panel already shows where a component was written —
+`file:///…/tasks.jsx:42:7`, from the same React 19 call-site stacks
+click-to-component reads, absolute and source-mapped. Making that line
+_clickable_ is a standalone-side setting, and it has two independent
+routes:
+
+- **Spawn an editor.** The standalone launches one itself, choosing it from
+  `REACT_EDITOR` (a full command line, shell-quoted), else — on macOS — by
+  looking through `ps x` for an editor that is already running, else
+  `VISUAL`, else `EDITOR`. It knows each editor's argument style — vim
+  takes `+42`, sublime and the JetBrains editors take `file:42` — so this
+  is the route to reach for:
+
+  ```sh
+  REACT_EDITOR=cursor npx react-devtools
+  ```
+
+- **Open a URL.** ⚙ → General → "Open local files directly in your code
+  editor", with the VS Code preset or a custom template using `{path}`,
+  `{line}` and `{column}`. The frontend turns our `file://` source into a
+  plain path before filling it in. The setting lives in the standalone's
+  own storage, not the app's.
+
+Both are configured where the standalone runs, which may be a different
+machine from the app. Neither is something the app can inject: the source
+location is all the backend is asked for, and it is already sent.
+Click-to-component ([click-to-component.md](click-to-component.md)) is the
+app-side answer to the same question, and the one that works when DevTools
+runs somewhere without your editor on it.
 
 The same backend, minus the socket, powers `react-x11/test`'s component
 inspection: `inspect()`/`setHook` in
@@ -40,6 +100,30 @@ interface the backend registers at injection, entirely in-process — no
 standalone app, no `ws`, no env variable. If a test run does set
 `REACT_X11_DEVTOOLS=1`, the two share one renderer registration (see the
 guard in `connect()`).
+
+## Watching the wire
+
+The bridge is a plain WebSocket carrying text frames of `{"event": …,
+"payload": …}` — no CDP, no binary framing. `scripts/devtools-proxy.mjs`
+sits in the middle of it and prints what goes past, decoding the packed
+`operations` arrays (the tree deltas) into readable lines:
+
+```sh
+npx react-devtools                      # terminal 1 — the real UI on :8097
+npm run devtools:proxy                  # terminal 2 — :8098 -> :8097
+REACT_X11_DEVTOOLS=1 REACT_X11_DEVTOOLS_PORT=8098 npm run examples:dashboard
+```
+
+```
+ 0.008 ▲ app operations 193B
+       · renderer 1, root 1
+       · add root 1
+       · add 3 <Counter> (Function) under 2
+ 0.291 ▼ devtools inspectElement {"id":3,"rendererID":1,…}
+```
+
+`--only`/`--skip` filter by event name, `--full` prints whole payloads, and
+`--jsonl FILE` appends every frame for later analysis.
 
 ## How it works (and its sharp edges)
 
@@ -74,6 +158,49 @@ Notes for maintainers:
   (`hook.reactDevtoolsAgent`, or the `'react-devtools'` hook event);
   `attachHighlightAgent` maps the public instance to its owning window
   node and paints a translucent overlay.
+- **What makes the native paths run at all** is
+  `isReactNativeEnvironment()`, which the backend defines as
+  `window.document == null`. That is true for a node process with
+  `window = global`, so the backend takes React Native's route everywhere:
+  it _asks the host_ to draw the highlight and the update outlines, and to
+  drive the picker, instead of drawing into a DOM overlay of its own. Every
+  injection below is one of those asks.
+- **Update outlines**: the backend counts updates, picks each rect's colour
+  and expires it on its own clock, then emits `drawTraceUpdates`
+  (`[{node, color}]` — the whole live set, every time) and
+  `disableTraceUpdates`. `attachTraceUpdatesAgent` groups them by window
+  and hands each root the rects; `WindowNode.setTraceUpdates` is a dumb
+  overlay that replaces rather than accumulates. It schedules those redraws
+  on `requestAnimationFrame`, which node does not have — `prepare()`
+  installs an unref'd `setTimeout` shim, and without it the first traced
+  commit throws inside the backend.
+- **The picker**: with no `window.addEventListener` to install, the backend
+  emits `startInspectingNative` and waits. `attachPickerAgent` takes the
+  pointer through `setInspectHandler` (events.js) — motion, press and
+  release are answered and go no further — and calls `agent.selectNode()`
+  then `agent.stopInspectingNative(true)`. Cancelling from the DevTools
+  side arrives as a bridge message with no host-facing event, so the
+  picker also listens on `agent._bridge` directly; without that a
+  cancelled picker would keep swallowing the app's input.
+- **The style editor** needs three things and is offered only if it gets
+  them: `resolveRNStyle` (our `flattenStyle`, minus state blocks, which are
+  not editable values), `nativeStyleEditorValidAttributes`
+  (`STYLE_PROP_NAMES`), and `instance.measure(cb)` on host instances for
+  the box model — RN's contract, implemented by `Node.measure`. Edits
+  arrive as `overrideValueAtPath` on `['style']` with the value wrapped in
+  an array, which works here only because a react-x11 `style` prop already
+  takes an array.
+- **Reload and profile** is gated on a backend check that asks whether
+  synchronous XHR works, so `isReloadAndProfileSupported: true` is passed
+  explicitly. Registering a renderer does not start profiling, either — the
+  run that comes back from the restart starts it itself, before the first
+  commit, which is the only reason to restart at all.
+- `localStorage`/`sessionStorage` are **defined** on the global rather than
+  assigned: reading `global.localStorage` first is what makes node print
+  its `--localstorage-file` warning on every DevTools run.
+- `test/devtools.test.js` drives the real backend over a socket for all of
+  the above; the fake-agent tests in `test/smoke.test.js` prove the drawing
+  but not that the backend still asks for it.
 
 ## Other debugging aids
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "filedialog:probe": "node scripts/filedialog-probe.mjs",
     "a11y:probe": "node scripts/a11y-probe.mjs",
     "globalmenu:host": "node scripts/globalmenu-host.mjs",
+    "devtools:proxy": "node scripts/devtools-proxy.mjs",
     "examples:form": "tsx examples/form.jsx",
     "examples:rules": "tsx examples/rules.jsx",
     "examples:richtext": "tsx examples/richtext.jsx",

--- a/scripts/devtools-proxy.mjs
+++ b/scripts/devtools-proxy.mjs
@@ -1,0 +1,436 @@
+#!/usr/bin/env node
+// A man-in-the-middle for the React DevTools bridge.
+//
+// The bridge is not CDP and not a binary protocol: the backend
+// (react-devtools-core, running inside the app) opens a plain WebSocket to
+// the standalone DevTools app and both ends exchange text frames of
+//
+//     {"event": "<name>", "payload": <json>}
+//
+// This script sits in the middle of that socket. It listens where the
+// backend expects DevTools, forwards every frame verbatim to the real
+// DevTools, and prints what goes past — including the packed `operations`
+// arrays, which are decoded here the way DevTools' own
+// `printOperationsArray` decodes them.
+//
+//   node scripts/devtools-proxy.mjs                      # :8098 -> :8097
+//   node scripts/devtools-proxy.mjs --listen 9000 --upstream box:8097
+//   node scripts/devtools-proxy.mjs --only operations,inspectElement
+//   node scripts/devtools-proxy.mjs --full --jsonl /tmp/bridge.jsonl
+//
+// Then start the app against the proxy port:
+//   REACT_X11_DEVTOOLS=1 REACT_X11_DEVTOOLS_PORT=8098 node app.js
+//
+// See docs/devtools.md.
+
+import { createWriteStream } from 'node:fs';
+import { WebSocketServer, WebSocket } from 'ws';
+
+// ---------------------------------------------------------------------------
+// Arguments
+// ---------------------------------------------------------------------------
+
+function parseArgs(argv) {
+  const opts = {
+    listen: 8098,
+    upstreamHost: 'localhost',
+    upstreamPort: 8097,
+    only: null,
+    skip: null,
+    full: false,
+    jsonl: null,
+    maxLength: 240,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const next = () => argv[++i];
+    switch (arg) {
+      case '--listen':
+      case '-l':
+        opts.listen = Number(next());
+        break;
+      case '--upstream':
+      case '-u': {
+        const [host, port] = String(next()).split(':');
+        opts.upstreamHost = host || 'localhost';
+        opts.upstreamPort = Number(port) || 8097;
+        break;
+      }
+      case '--only':
+        opts.only = new Set(String(next()).split(','));
+        break;
+      case '--skip':
+        opts.skip = new Set(String(next()).split(','));
+        break;
+      case '--full':
+        opts.full = true;
+        break;
+      case '--max':
+        opts.maxLength = Number(next());
+        break;
+      case '--jsonl':
+        opts.jsonl = String(next());
+        break;
+      case '--help':
+      case '-h':
+        console.log(
+          [
+            'usage: node scripts/devtools-proxy.mjs [options]',
+            '',
+            '  -l, --listen PORT        port the app connects to (default 8098)',
+            '  -u, --upstream HOST:PORT real DevTools (default localhost:8097)',
+            '      --only a,b           print only these events',
+            '      --skip a,b           print everything but these events',
+            '      --full               print whole payloads, not a summary',
+            '      --max N              summary length, in chars (default 240)',
+            '      --jsonl FILE         also append every frame as JSON lines',
+          ].join('\n'),
+        );
+        process.exit(0);
+        break;
+      default:
+        console.error(`devtools-proxy: unknown option ${arg}`);
+        process.exit(1);
+    }
+  }
+  return opts;
+}
+
+const opts = parseArgs(process.argv.slice(2));
+
+// ---------------------------------------------------------------------------
+// The operations array
+// ---------------------------------------------------------------------------
+//
+// A tree delta, packed into one flat array of numbers so a commit costs one
+// small frame: [rendererID, rootID, stringTableLength, ...stringTable,
+// ...operations]. Ported from react-devtools-shared's printOperationsArray
+// (react-devtools-core 7); if a future version adds an opcode, decoding
+// stops at it rather than lying about the rest.
+
+const TREE_OPERATION_ADD = 1;
+const TREE_OPERATION_REMOVE = 2;
+const TREE_OPERATION_REORDER_CHILDREN = 3;
+const TREE_OPERATION_UPDATE_TREE_BASE_DURATION = 4;
+const TREE_OPERATION_UPDATE_ERRORS_OR_WARNINGS = 5;
+const TREE_OPERATION_REMOVE_ROOT = 6;
+const TREE_OPERATION_SET_SUBTREE_MODE = 7;
+const SUSPENSE_TREE_OPERATION_ADD = 8;
+const SUSPENSE_TREE_OPERATION_REMOVE = 9;
+const SUSPENSE_TREE_OPERATION_REORDER_CHILDREN = 10;
+const SUSPENSE_TREE_OPERATION_RESIZE = 11;
+const SUSPENSE_TREE_OPERATION_SUSPENDERS = 12;
+
+const ELEMENT_TYPE_ROOT = 11;
+const ELEMENT_TYPE_NAMES = {
+  1: 'Class',
+  2: 'Context',
+  5: 'Function',
+  6: 'ForwardRef',
+  7: 'Host',
+  8: 'Memo',
+  9: 'Other',
+  10: 'Profiler',
+  11: 'Root',
+  12: 'Suspense',
+  13: 'SuspenseList',
+  14: 'TracingMarker',
+  15: 'Virtual',
+  16: 'ViewTransition',
+  17: 'Activity',
+};
+
+function decodeString(array, left, right) {
+  let string = '';
+  for (let i = left; i <= right; i++) string += String.fromCodePoint(array[i]);
+  return string;
+}
+
+function decodeOperations(operations) {
+  const logs = [];
+  const rendererID = operations[0];
+  const rootID = operations[1];
+  logs.push(`renderer ${rendererID}, root ${rootID}`);
+
+  let i = 2;
+  const stringTable = [null];
+  const stringTableEnd = i + 1 + operations[i];
+  i++;
+  while (i < stringTableEnd) {
+    const length = operations[i++];
+    stringTable.push(decodeString(operations, i, i + length - 1));
+    i += length;
+  }
+
+  while (i < operations.length) {
+    const op = operations[i];
+    switch (op) {
+      case TREE_OPERATION_ADD: {
+        const id = operations[i + 1];
+        const type = operations[i + 2];
+        i += 3;
+        if (type === ELEMENT_TYPE_ROOT) {
+          i += 4; // isStrictMode, profilingFlags, supportsStrictMode, hasOwnerMetadata
+          logs.push(`add root ${id}`);
+        } else {
+          const parentID = operations[i];
+          i += 2; // parentID, ownerID
+          const displayName = stringTable[operations[i]];
+          i += 3; // displayName, key, env
+          const kind = ELEMENT_TYPE_NAMES[type] ?? type;
+          logs.push(
+            `add ${id} <${displayName ?? 'null'}> (${kind}) under ${parentID}`,
+          );
+        }
+        break;
+      }
+      case TREE_OPERATION_REMOVE: {
+        const count = operations[i + 1];
+        i += 2;
+        const ids = operations.slice(i, i + count);
+        i += count;
+        logs.push(`remove ${ids.join(', ')}`);
+        break;
+      }
+      case TREE_OPERATION_REMOVE_ROOT:
+        i += 1;
+        logs.push(`remove root ${rootID}`);
+        break;
+      case TREE_OPERATION_SET_SUBTREE_MODE: {
+        logs.push(`subtree mode ${operations[i + 2]} for ${operations[i + 1]}`);
+        i += 3;
+        break;
+      }
+      case TREE_OPERATION_REORDER_CHILDREN: {
+        const id = operations[i + 1];
+        const count = operations[i + 2];
+        i += 3;
+        const children = operations.slice(i, i + count);
+        i += count;
+        logs.push(`reorder ${id} children ${children.join(', ')}`);
+        break;
+      }
+      case TREE_OPERATION_UPDATE_TREE_BASE_DURATION:
+        // [id, duration] — profiler bookkeeping, noise in a trace
+        i += 3;
+        break;
+      case TREE_OPERATION_UPDATE_ERRORS_OR_WARNINGS: {
+        logs.push(
+          `node ${operations[i + 1]}: ${operations[i + 2]} errors, ` +
+            `${operations[i + 3]} warnings`,
+        );
+        i += 4;
+        break;
+      }
+      case SUSPENSE_TREE_OPERATION_ADD: {
+        const id = operations[i + 1];
+        const parentID = operations[i + 2];
+        const name = stringTable[operations[i + 3]];
+        const isSuspended = operations[i + 4];
+        const numRects = operations[i + 5];
+        i += 6;
+        if (numRects !== -1) i += numRects * 4;
+        logs.push(
+          `add suspense ${id} <${name ?? 'null'}> under ${parentID}` +
+            (isSuspended ? ' (suspended)' : ''),
+        );
+        break;
+      }
+      case SUSPENSE_TREE_OPERATION_REMOVE: {
+        const count = operations[i + 1];
+        i += 2;
+        const ids = operations.slice(i, i + count);
+        i += count;
+        logs.push(`remove suspense ${ids.join(', ')}`);
+        break;
+      }
+      case SUSPENSE_TREE_OPERATION_REORDER_CHILDREN: {
+        const id = operations[i + 1];
+        const count = operations[i + 2];
+        i += 3 + count;
+        logs.push(`reorder suspense ${id}`);
+        break;
+      }
+      case SUSPENSE_TREE_OPERATION_RESIZE: {
+        const id = operations[i + 1];
+        const numRects = operations[i + 2];
+        i += 3;
+        if (numRects !== -1) i += numRects * 4;
+        logs.push(`resize suspense ${id}`);
+        break;
+      }
+      case SUSPENSE_TREE_OPERATION_SUSPENDERS: {
+        i += 1;
+        const count = operations[i++];
+        for (let c = 0; c < count; c++) {
+          const id = operations[i];
+          i += 3;
+          i += operations[i] + 1; // environment names
+          logs.push(`suspenders changed for ${id}`);
+        }
+        break;
+      }
+      default:
+        logs.push(`(unknown opcode ${op} at ${i} — stopping)`);
+        i = operations.length;
+    }
+  }
+  return logs;
+}
+
+// ---------------------------------------------------------------------------
+// Printing
+// ---------------------------------------------------------------------------
+
+const color = process.stdout.isTTY
+  ? {
+      dim: (s) => `\x1b[2m${s}\x1b[0m`,
+      up: (s) => `\x1b[36m${s}\x1b[0m`, // app -> devtools
+      down: (s) => `\x1b[35m${s}\x1b[0m`, // devtools -> app
+      bold: (s) => `\x1b[1m${s}\x1b[0m`,
+      red: (s) => `\x1b[31m${s}\x1b[0m`,
+    }
+  : {
+      dim: (s) => s,
+      up: (s) => s,
+      down: (s) => s,
+      bold: (s) => s,
+      red: (s) => s,
+    };
+
+const started = Date.now();
+const stamp = () => ((Date.now() - started) / 1000).toFixed(3).padStart(8);
+
+function summarize(payload) {
+  let text;
+  try {
+    text = JSON.stringify(payload);
+  } catch {
+    text = String(payload);
+  }
+  if (text === undefined) return '';
+  if (opts.full || text.length <= opts.maxLength) return text;
+  return `${text.slice(0, opts.maxLength)}… (${text.length} chars)`;
+}
+
+const jsonl = opts.jsonl ? createWriteStream(opts.jsonl, { flags: 'a' }) : null;
+
+function logFrame(direction, raw) {
+  let frame;
+  try {
+    frame = JSON.parse(raw);
+  } catch {
+    console.log(
+      `${color.dim(stamp())} ${direction} ${color.red('(non-JSON frame)')} ${raw.slice(0, 120)}`,
+    );
+    return;
+  }
+  const { event, payload } = frame;
+  jsonl?.write(
+    JSON.stringify({ t: Date.now() - started, direction, event, payload }) +
+      '\n',
+  );
+  if (opts.only && !opts.only.has(event)) return;
+  if (opts.skip?.has(event)) return;
+
+  const arrow =
+    direction === 'app→devtools' ? color.up('▲ app') : color.down('▼ devtools');
+  const size = `${raw.length}B`;
+
+  if (event === 'operations' && Array.isArray(payload)) {
+    const lines = decodeOperations(payload);
+    console.log(
+      `${color.dim(stamp())} ${arrow} ${color.bold(event)} ${color.dim(size)}`,
+    );
+    for (const line of lines) console.log(`         ${color.dim('·')} ${line}`);
+    if (opts.full)
+      console.log(`         ${color.dim(JSON.stringify(payload))}`);
+    return;
+  }
+
+  console.log(
+    `${color.dim(stamp())} ${arrow} ${color.bold(event)} ${color.dim(size)} ${summarize(payload)}`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// The proxy
+// ---------------------------------------------------------------------------
+
+const upstreamURL = `ws://${opts.upstreamHost}:${opts.upstreamPort}`;
+const server = new WebSocketServer({ port: opts.listen });
+let connections = 0;
+
+server.on('listening', () => {
+  console.log(
+    color.bold(
+      `devtools-proxy: listening on ws://localhost:${opts.listen} → ${upstreamURL}`,
+    ),
+  );
+  console.log(
+    color.dim(
+      `  run the app with REACT_X11_DEVTOOLS=1 REACT_X11_DEVTOOLS_PORT=${opts.listen}`,
+    ),
+  );
+});
+
+server.on('error', (err) => {
+  console.error(color.red(`devtools-proxy: ${err.message}`));
+  process.exit(1);
+});
+
+server.on('connection', (client, req) => {
+  const id = ++connections;
+  const from = req.socket.remoteAddress;
+  console.log(color.bold(`\n── #${id} app connected (${from}) ──`));
+
+  const upstream = new WebSocket(upstreamURL);
+  // Frames the app sends before DevTools' socket is open: the backend does
+  // not wait, and dropping them would cost the initial tree.
+  const pending = [];
+
+  upstream.on('open', () => {
+    console.log(color.dim(`   #${id} upstream ${upstreamURL} open`));
+    for (const raw of pending) upstream.send(raw);
+    pending.length = 0;
+  });
+
+  upstream.on('message', (data) => {
+    const raw = data.toString();
+    logFrame('devtools→app', raw);
+    if (client.readyState === WebSocket.OPEN) client.send(raw);
+  });
+
+  client.on('message', (data) => {
+    const raw = data.toString();
+    logFrame('app→devtools', raw);
+    if (upstream.readyState === WebSocket.OPEN) upstream.send(raw);
+    else pending.push(raw);
+  });
+
+  const closeBoth = (who) => () => {
+    console.log(color.dim(`   #${id} ${who} closed`));
+    if (client.readyState === WebSocket.OPEN) client.close();
+    if (upstream.readyState <= WebSocket.OPEN) upstream.close();
+  };
+  client.on('close', closeBoth('app'));
+  upstream.on('close', closeBoth('devtools'));
+
+  upstream.on('error', (err) => {
+    // The backend retries on its own, so failing loudly and hanging up is
+    // the useful behaviour: start the standalone app and it reconnects.
+    console.error(
+      color.red(`   #${id} upstream error: ${err.message} — is DevTools up?`),
+    );
+    if (client.readyState === WebSocket.OPEN) client.close();
+  });
+  client.on('error', (err) => {
+    console.error(color.red(`   #${id} app error: ${err.message}`));
+  });
+});
+
+process.on('SIGINT', () => {
+  console.log('\ndevtools-proxy: bye');
+  jsonl?.end();
+  server.close(() => process.exit(0));
+});

--- a/src/ClickToComponent.js
+++ b/src/ClickToComponent.js
@@ -13,6 +13,7 @@
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { setClickToComponentHandler } from './events.js';
+import { selectInDevTools } from './DevToolsIntegration.js';
 
 const STACK_FRAME = /^\s*at\s+(?:(.+?)\s+\()?(.+?):(\d+):(\d+)\)?\s*$/;
 
@@ -161,6 +162,10 @@ function handleClick(node, native) {
     // Alt+Shift+Click
     logOwnerChain(fiber);
   }
+  // With DevTools attached, the click that says which element this is says
+  // it there too — the tree jumps to the component instead of the user
+  // hunting for the row they just clicked. Nothing to do when it is not.
+  selectInDevTools(node);
   flashHighlight(node);
   openInEditor(location);
 }

--- a/src/DevToolsIntegration.js
+++ b/src/DevToolsIntegration.js
@@ -2,8 +2,107 @@
 // the environment; requires the `react-devtools-core` and `ws` dev
 // dependencies. Start the standalone UI first (`npx react-devtools`), then
 // run the app: REACT_X11_DEVTOOLS=1 npm run examples:dashboard
+//
+// Most of what DevTools can do costs this file nothing: the component tree,
+// props/state/hooks, and every edit the frontend makes go through the
+// renderer interface `injectIntoDevTools()` registers. What is left is the
+// part a browser gets from the DOM and an X11 app has to answer for itself
+// — the overlays (hover highlight, update outlines), the element picker,
+// the style editor's measurements, and the storage a restart survives.
+// Each of those is an agent listener or an option below.
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { setInspectHandler } from './events.js';
+import { flattenStyle, isStyleProp, STYLE_PROP_NAMES } from './styles.js';
+
 let api = null;
 let connected = false;
+
+// ---------------------------------------------------------------------------
+// State that outlives the process
+// ---------------------------------------------------------------------------
+
+/**
+ * The backend keeps its preferences in `localStorage` — component filters,
+ * console patching, the "reload and profile" flags — and a browser hands it
+ * one. Without it every DevTools setting resets on each run, and the
+ * backend's own reload-and-profile support check fails on the first line.
+ * A file in the cache directory is the same deal the appearance cache
+ * takes (see appearance.js): ordinary user-writable JSON, absent on the
+ * first run, and doing without it costs only persistence.
+ */
+function stateFile() {
+  if (process.env.REACT_X11_DEVTOOLS_STATE) {
+    return process.env.REACT_X11_DEVTOOLS_STATE;
+  }
+  let base = process.env.XDG_CACHE_HOME;
+  if (!base) {
+    let home;
+    try {
+      home = os.homedir();
+    } catch {
+      return null;
+    }
+    if (!home || home === '/') return null;
+    base =
+      process.platform === 'darwin'
+        ? path.join(home, 'Library', 'Caches')
+        : path.join(home, '.cache');
+  }
+  return path.join(base, 'react-x11', 'devtools.json');
+}
+
+/** A Storage that reads and writes one JSON object. `persist` false is
+ * sessionStorage: same interface, nothing on disk. Exported for its own
+ * test — a store that quietly stops persisting looks exactly like DevTools
+ * settings that never stuck. */
+export function createStorage(persist) {
+  const file = persist ? stateFile() : null;
+  let entries = new Map();
+  if (file) {
+    try {
+      entries = new Map(Object.entries(JSON.parse(fs.readFileSync(file))));
+    } catch {
+      // absent, unreadable or not JSON — start from nothing
+    }
+  }
+  const flush = () => {
+    if (!file) return;
+    try {
+      fs.mkdirSync(path.dirname(file), { recursive: true });
+      fs.writeFileSync(file, JSON.stringify(Object.fromEntries(entries)));
+    } catch {
+      // a read-only or full disk costs persistence, not the session
+    }
+  };
+  return {
+    get length() {
+      return entries.size;
+    },
+    key: (i) => [...entries.keys()][i] ?? null,
+    getItem: (key) => entries.get(String(key)) ?? null,
+    setItem(key, value) {
+      entries.set(String(key), String(value));
+      flush();
+    },
+    removeItem(key) {
+      entries.delete(String(key));
+      flush();
+    },
+    clear() {
+      entries.clear();
+      flush();
+    },
+    /** What a reload-and-profile restart carries into the child. */
+    toJSON: () => Object.fromEntries(entries),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Install
+// ---------------------------------------------------------------------------
 
 /**
  * Install the DevTools global hook. Must run before the first React commit
@@ -18,10 +117,47 @@ export async function prepare() {
     if (!global.WebSocket) {
       global.WebSocket = (await import('ws')).default;
     }
+    // The update-tracing overlay schedules its redraws on animation
+    // frames, which Node does not have; without these the first traced
+    // commit throws inside the backend. Unref'd, because an overlay must
+    // not be a reason for the process to stay up.
+    if (!global.requestAnimationFrame) {
+      global.requestAnimationFrame = (callback) => {
+        const timer = setTimeout(() => callback(Date.now()), 16);
+        timer.unref?.();
+        return timer;
+      };
+      global.cancelAnimationFrame = (timer) => clearTimeout(timer);
+    }
+    // Defined rather than assigned: *reading* `global.localStorage` first
+    // is what makes node print "localStorage is not available because
+    // --localstorage-file was not provided" on every DevTools run, and its
+    // storage is an unrelated opt-in feature this has no business waiting
+    // for.
+    for (const [name, persist] of [
+      ['localStorage', true],
+      ['sessionStorage', false],
+    ]) {
+      Object.defineProperty(global, name, {
+        value: createStorage(persist),
+        configurable: true,
+        writable: true,
+      });
+    }
+    // A reload-and-profile restart is the one thing that should look like a
+    // page reload rather than a new session: the selection and the
+    // profiling flags are handed to the child through its environment (see
+    // reloadAndProfile) and seeded back here.
+    for (const [key, value] of Object.entries(readSession())) {
+      global.sessionStorage.setItem(key, value);
+    }
     const mod = await import('react-devtools-core');
     // v7 exposes the API on the default export under node ESM interop
     api = mod.default?.initialize ? mod.default : mod;
-    api.initialize();
+    // The hook settings the user last chose in the DevTools UI — console
+    // patching and friends. `initialize()` takes them, `onSettingsUpdated`
+    // (below) records them, so a setting survives a restart.
+    api.initialize(readHookSettings());
   } catch (err) {
     api = null;
     console.warn(
@@ -32,16 +168,123 @@ export async function prepare() {
   }
 }
 
+const HOOK_SETTINGS_KEY = 'react-x11:hookSettings';
+
+function readHookSettings() {
+  try {
+    const raw = global.localStorage?.getItem(HOOK_SETTINGS_KEY);
+    return raw ? JSON.parse(raw) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readSession() {
+  try {
+    return JSON.parse(process.env.REACT_X11_DEVTOOLS_SESSION ?? '{}') ?? {};
+  } catch {
+    return {};
+  }
+}
+
+/** The profiling a restart was asked to start with, or null for a normal
+ * run. Set by reloadAndProfile() in the process that asked for the
+ * restart, read here in the one that came back. */
+function readProfilingOnStart() {
+  try {
+    const raw = process.env.REACT_X11_DEVTOOLS_PROFILING;
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * DevTools' "Reload and start profiling": profiling that covers the initial
+ * mount cannot be turned on in a running app, so the app restarts with it
+ * already on. A browser reloads the page; here that is re-exec'ing this
+ * process with the same node flags, the same argv and two extra
+ * environment variables — the profiling settings, and the session storage
+ * a reload would have kept.
+ */
+export function reloadAndProfile(recordChangeDescriptions, recordTimeline) {
+  const child = spawn(
+    process.execPath,
+    [...process.execArgv, ...process.argv.slice(1)],
+    {
+      stdio: 'inherit',
+      detached: true,
+      env: {
+        ...process.env,
+        REACT_X11_DEVTOOLS: '1',
+        REACT_X11_DEVTOOLS_PROFILING: JSON.stringify({
+          recordChangeDescriptions,
+          recordTimeline,
+        }),
+        REACT_X11_DEVTOOLS_SESSION: JSON.stringify(
+          global.sessionStorage?.toJSON?.() ?? {},
+        ),
+      },
+    },
+  );
+  // Only stand down once the replacement is actually running: a spawn that
+  // fails must leave the app the user was profiling alive.
+  child.on('spawn', () => {
+    child.unref();
+    process.exit(0);
+  });
+  child.on('error', (err) => {
+    console.warn(
+      'react-x11: DevTools asked for a restart to profile, but re-exec ' +
+        `failed (${err.code ?? err.message}). The app is still running; ` +
+        'profile from here instead.',
+    );
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Connect
+// ---------------------------------------------------------------------------
+
 /** Connect the backend to the standalone DevTools app and register the
  * renderer. Called by Reconciler.js right after the renderer is created. */
 export function connect(renderer) {
   if (!api || connected) return;
   connected = true;
+  const profiling = readProfilingOnStart();
 
   api.connectToDevTools({
     isAppActive: () => true,
     host: process.env.REACT_X11_DEVTOOLS_HOST || 'localhost',
     port: Number(process.env.REACT_X11_DEVTOOLS_PORT) || 8097,
+    // The style editor: `style` is a react-x11 style prop (an object, or a
+    // nested array of them), which is the shape DevTools' own resolver
+    // expects to be handed flat. `validAttributes` is what it offers to
+    // add to an element.
+    resolveRNStyle: resolveStyle,
+    nativeStyleEditorValidAttributes: STYLE_PROP_NAMES,
+    // Hook settings (console patching and so on) are the user's, not the
+    // run's: keep them where the next run will find them.
+    onSettingsUpdated: (settings) => {
+      try {
+        global.localStorage?.setItem(
+          HOOK_SETTINGS_KEY,
+          JSON.stringify(settings),
+        );
+      } catch {
+        // an unwritable store is not worth a warning per keystroke
+      }
+    },
+    // The backend's own check for this asks whether synchronous XHR works,
+    // which is a browser question — the honest answer for a node process
+    // that can re-exec itself is yes.
+    isReloadAndProfileSupported: true,
+    isProfiling: profiling != null,
+    onReloadAndProfile: reloadAndProfile,
+    onReloadAndProfileFlagsReset: () => {
+      delete process.env.REACT_X11_DEVTOOLS_PROFILING;
+      delete process.env.REACT_X11_DEVTOOLS_SESSION;
+    },
   });
 
   // No argument: react-reconciler 0.33 takes none, and the object this used
@@ -56,8 +299,72 @@ export function connect(renderer) {
   if (!global.__REACT_DEVTOOLS_GLOBAL_HOOK__?.rendererInterfaces?.size) {
     renderer.injectIntoDevTools();
   }
+  if (profiling) startProfiling(profiling);
 
   watchForAgent();
+}
+
+/**
+ * Turn profiling on before the first commit, which is the whole point of
+ * the restart: registering a renderer does not start it (the agent only
+ * does that when the frontend asks), so the run that came back from
+ * `reloadAndProfile` starts it itself.
+ */
+function startProfiling({ recordChangeDescriptions, recordTimeline }) {
+  const interfaces = global.__REACT_DEVTOOLS_GLOBAL_HOOK__?.rendererInterfaces;
+  const ri = interfaces && [...interfaces.values()].at(-1);
+  try {
+    ri?.startProfiling?.(recordChangeDescriptions, recordTimeline);
+  } catch (err) {
+    console.warn(
+      `react-x11: could not start profiling after restart: ${err.message}`,
+    );
+  }
+}
+
+/** A style prop as the style editor wants it: flat, and only the properties
+ * that are really style properties — a state block (`:hover`) or a query is
+ * neither editable nor a value, and listing them among the rest would
+ * invite editing something that cannot be edited. */
+export function resolveStyle(style) {
+  const flat = flattenStyle(style);
+  const resolved = {};
+  for (const key of Object.keys(flat)) {
+    if (isStyleProp(key)) resolved[key] = flat[key];
+  }
+  return resolved;
+}
+
+// ---------------------------------------------------------------------------
+// The overlays and the picker
+// ---------------------------------------------------------------------------
+
+// One highlight at a time, whoever asked for it: the tree hover and the
+// picker share the window's single tint, and the loser of a race would
+// otherwise leave its tint behind forever.
+let highlightedRoot = null;
+
+/** The retained node behind whatever DevTools handed us — public instances
+ * are ntk windows for `<window>`/`<popup>`, nodes everywhere else. */
+function nodeOf(target) {
+  const value = Array.isArray(target) ? target[0] : target;
+  return value?._reactX11Node ?? value ?? null;
+}
+
+function showHighlight(target) {
+  const node = nodeOf(target);
+  const root = node?.root;
+  if (!root || typeof root.setHighlight !== 'function') return;
+  if (highlightedRoot && highlightedRoot !== root) {
+    highlightedRoot.setHighlight(null);
+  }
+  highlightedRoot = root;
+  root.setHighlight(node);
+}
+
+function hideHighlight() {
+  highlightedRoot?.setHighlight(null);
+  highlightedRoot = null;
 }
 
 /**
@@ -66,30 +373,129 @@ export function connect(renderer) {
  * Exported separately so it can be tested without react-devtools-core.
  */
 export function attachHighlightAgent(agent) {
-  let highlightedRoot = null;
+  agent.addListener?.('showNativeHighlight', showHighlight);
+  agent.addListener?.('hideNativeHighlight', hideHighlight);
+  agent.addListener?.('shutdown', hideHighlight);
+}
 
-  const show = (payload) => {
-    // newer devtools versions pass an array of public instances
-    const target = Array.isArray(payload) ? payload[0] : payload;
-    // public instances are ntk windows for <window>/<popup>, nodes otherwise
-    const node = target?._reactX11Node ?? target;
-    const root = node?.root;
-    if (!root || typeof root.setHighlight !== 'function') return;
-    if (highlightedRoot && highlightedRoot !== root) {
-      highlightedRoot.setHighlight(null);
+/**
+ * "Highlight updates when components render". The backend counts the
+ * updates, picks each rect's colour off its own ramp and expires them on
+ * its own clock; all it wants from a host is somewhere to draw. It hands
+ * over the host instances that re-rendered — every live one, every time —
+ * so this replaces the overlay rather than adding to it.
+ */
+export function attachTraceUpdatesAgent(agent) {
+  let painted = new Set();
+
+  const draw = (entries) => {
+    const byRoot = new Map();
+    for (const entry of entries ?? []) {
+      const node = nodeOf(entry?.node);
+      const root = node?.root;
+      if (!root || root.destroyed) continue;
+      if (typeof root.setTraceUpdates !== 'function') continue;
+      const rect = node.abs;
+      if (!rect?.width) continue;
+      const rects = byRoot.get(root) ?? [];
+      rects.push({ ...rect, color: entry.color });
+      byRoot.set(root, rects);
     }
-    highlightedRoot = root;
-    root.setHighlight(node);
+    for (const root of painted) {
+      if (!byRoot.has(root) && !root.destroyed) root.setTraceUpdates(null);
+    }
+    for (const [root, rects] of byRoot) root.setTraceUpdates(rects);
+    painted = new Set(byRoot.keys());
   };
 
-  const hide = () => {
-    highlightedRoot?.setHighlight(null);
-    highlightedRoot = null;
+  const clear = () => {
+    // a window that closed while its outlines were up has nothing to clear
+    // and nothing to repaint
+    for (const root of painted) {
+      if (!root.destroyed) root.setTraceUpdates(null);
+    }
+    painted = new Set();
   };
 
-  agent.addListener?.('showNativeHighlight', show);
-  agent.addListener?.('hideNativeHighlight', hide);
-  agent.addListener?.('shutdown', hide);
+  agent.addListener?.('drawTraceUpdates', draw);
+  agent.addListener?.('disableTraceUpdates', clear);
+  agent.addListener?.('shutdown', clear);
+}
+
+/**
+ * The element picker — the crosshair in the DevTools toolbar. In a browser
+ * the backend listens on the page itself; with no DOM to listen to it says
+ * `startInspectingNative` and leaves the pointer to the host. While it is
+ * on, the pointer belongs to DevTools (see setInspectHandler in events.js):
+ * motion tints whatever is under it, a press selects that element in the
+ * tree, Escape gives up.
+ */
+export function attachPickerAgent(agent) {
+  let picking = false;
+
+  const stop = () => {
+    if (!picking) return;
+    picking = false;
+    setInspectHandler(null);
+    hideHighlight();
+  };
+
+  const onPointer = (kind, node) => {
+    if (kind === 'move') {
+      if (node) showHighlight(node);
+      else hideHighlight();
+      return;
+    }
+    if (kind === 'select' && node) {
+      // select first: the frontend leaves picking mode on the second
+      // message, and an element that arrives after it is ignored
+      agent.selectNode?.(node);
+      stop();
+      agent.stopInspectingNative?.(true);
+      return;
+    }
+    stop();
+    agent.stopInspectingNative?.(false);
+  };
+
+  const start = () => {
+    if (picking) return;
+    picking = true;
+    setInspectHandler(onPointer);
+  };
+
+  agent.addListener?.('startInspectingNative', start);
+  agent.addListener?.('shutdown', stop);
+  // Giving up from the DevTools side is a bridge message the backend
+  // answers by hiding its overlay, with nothing left for a host listener —
+  // so this reads the bridge directly rather than leave a picker running
+  // that swallows every event the app would have had.
+  agent._bridge?.addListener?.('stopInspectingHost', stop);
+}
+
+/**
+ * Select a node in the DevTools tree, if DevTools is attached and knows it.
+ * Click-to-component calls this: an Alt+Click that opens the source is also
+ * the click that says "this element", and saying it twice is silly.
+ */
+export function selectInDevTools(node) {
+  const agent = global.__REACT_DEVTOOLS_GLOBAL_HOOK__?.reactDevtoolsAgent;
+  if (!agent || !node) return false;
+  try {
+    // an element DevTools has no id for is one its filters hid; selecting
+    // it would be a message the frontend drops
+    if (!agent.getIDForHostInstance?.(node)) return false;
+    agent.selectNode(node);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function attachAgent(agent) {
+  attachHighlightAgent(agent);
+  attachTraceUpdatesAgent(agent);
+  attachPickerAgent(agent);
 }
 
 function watchForAgent() {
@@ -97,12 +503,12 @@ function watchForAgent() {
   if (!hook) return;
   try {
     if (hook.reactDevtoolsAgent) {
-      attachHighlightAgent(hook.reactDevtoolsAgent);
+      attachAgent(hook.reactDevtoolsAgent);
     } else if (typeof hook.on === 'function') {
       // the backend emits 'react-devtools' once the agent is initialized
-      hook.on('react-devtools', (agent) => attachHighlightAgent(agent));
+      hook.on('react-devtools', (agent) => attachAgent(agent));
     }
   } catch {
-    // highlight support is best-effort; the tree view still works without it
+    // the overlays are best-effort; the tree view still works without them
   }
 }

--- a/src/events.js
+++ b/src/events.js
@@ -18,6 +18,7 @@ import { acceleratorKeysym } from './keyboard.js';
 import { MOD } from './keysyms.js';
 
 const XK_TAB = 0xff09;
+const XK_ESCAPE = 0xff1b;
 // The core protocol has no wheel: it is a click of button 4/5 (vertical) or
 // 6/7 (horizontal). ntk derives its `wheel` event from those presses — or,
 // where the connection has XI2, from the scroll valuators that carry the real
@@ -125,6 +126,18 @@ class SyntheticEvent {
 let clickToComponentHandler = null;
 export function setClickToComponentHandler(fn) {
   clickToComponentHandler = fn;
+}
+
+// DevTools' element picker (see DevToolsIntegration.js). While a handler is
+// installed the pointer belongs to DevTools, not to the app: motion, press
+// and release are answered with the node under the pointer and go no
+// further, so picking an element cannot also hover a row, press a button or
+// start a drag. `Escape` cancels. Installed only while the user is actually
+// picking — the crosshair in the DevTools toolbar — so the cost outside
+// that is one null check per event.
+let inspectHandler = null;
+export function setInspectHandler(fn) {
+  inspectHandler = fn;
 }
 
 /**
@@ -470,6 +483,10 @@ export class EventManager {
   _onMouseDown(native) {
     // the wheel arrived as `wheel`, with a distance the press cannot carry
     if (WHEEL_BUTTONS.has(native.keycode)) return;
+    if (inspectHandler) {
+      inspectHandler('select', this._hit(native), native);
+      return;
+    }
     if (clickToComponentHandler && Boolean(native.buttons & MOD.Alt)) {
       clickToComponentHandler(this._hit(native), native);
       return;
@@ -525,6 +542,9 @@ export class EventManager {
 
   _onMouseUp(native) {
     if (WHEEL_BUTTONS.has(native.keycode)) return; // wheel release
+    // the press that picked an element never reached the app; its release
+    // must not either, or a control sees a mouseup it was never pressed for
+    if (inspectHandler) return;
     runWithPriority(DiscreteEventPriority, () => {
       // a completed drag ends the gesture: no mouseup, no click — as in
       // the DOM, where dragend replaces them
@@ -574,6 +594,10 @@ export class EventManager {
   }
 
   _onMouseMove(native) {
+    if (inspectHandler) {
+      inspectHandler('move', this._hit(native), native);
+      return;
+    }
     runWithPriority(ContinuousEventPriority, () => {
       // an active drag owns the pointer: drag-path diffing replaces hover,
       // onDrag replaces mousemove. Below the threshold this falls through.
@@ -798,6 +822,20 @@ export class EventManager {
   }
 
   _onKey(name, native) {
+    if (inspectHandler) {
+      // Escape is the way out of a picker the user changed their mind
+      // about; every other key is swallowed with the pointer.
+      const wnd = this.node.window;
+      const keysym = acceleratorKeysym(
+        this.node.app,
+        native.keycode,
+        native.baseKeysym ?? wnd?.X?.keycode2keysyms?.[native.keycode]?.[0],
+      );
+      if (name === 'KeyDown' && keysym === XK_ESCAPE) {
+        inspectHandler('cancel', null, native);
+      }
+      return;
+    }
     runWithPriority(DiscreteEventPriority, () => {
       const wnd = this.node.window;
       // ntk decodes the key on the way in (window.js decorates the event

--- a/src/node.d.ts
+++ b/src/node.d.ts
@@ -377,6 +377,20 @@ export declare class Node {
     reason?: string,
   ): void;
   getClientRects(): Rect[];
+  /** React Native's measure contract — position in the parent, size, then
+   * position in the window — which DevTools' style editor calls to draw
+   * the box model. Calls back with nothing for a node with no laid-out
+   * rect. */
+  measure(
+    callback: (
+      x?: number,
+      y?: number,
+      width?: number,
+      height?: number,
+      left?: number,
+      top?: number,
+    ) => void,
+  ): void;
 }
 
 /**

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -227,6 +227,7 @@ const INVALIDATE_REASONS = new Set([
   'mount', // the window was just realized; its first frame
   'expose', // ntk asked for a redraw (backing store invalidated)
   'highlight', // DevTools hover highlight
+  'trace-updates', // DevTools' outline of what just re-rendered
   'capabilities', // a compositor started or stopped: what the window may paint
 ]);
 
@@ -2310,6 +2311,31 @@ export class Node {
         bottom: r.y + r.height,
       },
     ];
+  }
+
+  /**
+   * React Native's measure contract, which is what DevTools' style editor
+   * calls to draw the box model beside the style it is editing:
+   * `(x, y, width, height, left, top)` — position within the parent, size,
+   * then position within the window. A node with no laid-out rect calls
+   * back with nothing, the "unmeasurable" answer the editor checks for.
+   */
+  measure(callback) {
+    if (typeof callback !== 'function') return;
+    const r = this.abs;
+    if (!(r.width > 0 || r.height > 0)) {
+      callback();
+      return;
+    }
+    const parent = this.parent?.abs;
+    callback(
+      parent ? r.x - parent.x : r.x,
+      parent ? r.y - parent.y : r.y,
+      r.width,
+      r.height,
+      r.x,
+      r.y,
+    );
   }
 
   /**
@@ -6872,6 +6898,7 @@ export class WindowNode extends Scrollable(Node) {
     wnd.getClientRects ??= () => [
       { x: 0, y: 0, left: 0, top: 0, width: wnd.width, height: wnd.height },
     ];
+    wnd.measure ??= (callback) => callback?.(0, 0, wnd.width, wnd.height, 0, 0);
     wnd.ownerDocument ??= DEVTOOLS_FAKE_DOCUMENT;
     this._attachWindowListeners();
     for (const child of this.children) {
@@ -8205,7 +8232,12 @@ export class WindowNode extends Scrollable(Node) {
     if (typeof wnd?.scrollRegion !== 'function') return; // ntk without #139
     // the debug overlays and the DevTools highlight draw over the whole
     // window; a blit would drag shifted copies of them along
-    if (debugPaint || process.env.REACT_X11_DEBUG_LAYOUT || this._highlight) {
+    if (
+      debugPaint ||
+      process.env.REACT_X11_DEBUG_LAYOUT ||
+      this._highlight ||
+      this._traceUpdates
+    ) {
       return;
     }
     if (!Array.isArray(this._damage)) return; // unbounded frame already
@@ -8447,6 +8479,17 @@ export class WindowNode extends Scrollable(Node) {
         ctx.fillStyle = 'rgba(41, 128, 185, 0.35)';
         ctx.fillRect(r.x, r.y, r.width, r.height);
       }
+      if (this._traceUpdates) {
+        ctx.lineWidth = 2;
+        for (const r of this._traceUpdates) {
+          ctx.strokeStyle = r.color;
+          ctx.beginPath();
+          // inset by the stroke so an outline on a rect flush with the
+          // window edge is not half-clipped away
+          ctx.rect(r.x + 1, r.y + 1, r.width - 2, r.height - 2);
+          ctx.stroke();
+        }
+      }
       if (debugPaint) {
         // Stroke the pass's rect in this frame's colour ("repaint rainbow"):
         // a region repainting every frame strobes, one that repaints once
@@ -8602,6 +8645,25 @@ export class WindowNode extends Scrollable(Node) {
       rects.push(n.abs);
     }
     for (const rect of rects) this.invalidate(false, rect, 'highlight');
+  }
+
+  /**
+   * DevTools' "highlight updates when components render": outline the rects
+   * that just re-rendered, in the colour the backend assigned each one (it
+   * ramps with the update count and fades them out on its own clock, so
+   * this is a dumb overlay — `rects` is the whole state, `null` clears it).
+   */
+  setTraceUpdates(rects) {
+    const previous = this._traceUpdates;
+    const next = rects?.length ? rects : null;
+    if (!previous && !next) return;
+    this._traceUpdates = next;
+    // The stroke sits inside the rect, but a rect whose node has since
+    // moved or gone claims where it *was*; both lists are claimed for the
+    // same reason setHighlight claims both of its rects.
+    for (const r of [...(previous ?? []), ...(next ?? [])]) {
+      this.invalidate(false, r, 'trace-updates');
+    }
   }
 
   /** REACT_X11_DEBUG_LAYOUT=1: outline every drawn node, color by depth. */

--- a/src/styles.js
+++ b/src/styles.js
@@ -422,6 +422,12 @@ const STYLE_PROPS = new Set([
 
 export const isStyleProp = (name) => STYLE_PROPS.has(name);
 
+/** Every style property, by name. DevTools' style editor takes this list as
+ * `nativeStyleEditorValidAttributes` — what it offers to add to an element
+ * — so it is the same set `isStyleProp` answers for rather than a second
+ * list that could drift from it. */
+export const STYLE_PROP_NAMES = Object.freeze([...STYLE_PROPS].sort());
+
 const isState = (key) => key.charCodeAt(0) === 58; /* ':' */
 
 /**

--- a/test/devtools.test.js
+++ b/test/devtools.test.js
@@ -1,0 +1,273 @@
+// The DevTools integration against the *real* react-devtools-core backend,
+// driven over the bridge the standalone app would drive it over: a
+// WebSocket server here stands in for the DevTools frontend, sends it the
+// same messages, and reads what comes back.
+//
+// The unit tests in smoke.test.js drive our own agent listeners with a fake
+// agent, which proves the drawing but not that the backend ever calls them.
+// That half is what this file is for — every feature below is one the
+// backend only offers a host that answers a particular way, and a version
+// bump that changes the offer should fail here rather than in someone's
+// window.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { WebSocketServer } from 'ws';
+import React from 'react';
+import { createMockApp } from './helpers/mock-app.js';
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/** The DevTools frontend, near enough: a socket that records what the app
+ * says and can say things back. The bridge batches, so everything here
+ * waits for an event rather than assuming it has arrived. */
+async function fakeDevTools() {
+  const server = new WebSocketServer({ port: 0 });
+  await new Promise((resolve) => server.on('listening', resolve));
+  const received = [];
+  let socket = null;
+  const connected = new Promise((resolve) => {
+    server.on('connection', (ws) => {
+      socket = ws;
+      ws.on('message', (data) => received.push(JSON.parse(data.toString())));
+      resolve(ws);
+    });
+  });
+  return {
+    port: server.address().port,
+    connected,
+    received,
+    send: (event, payload) => socket.send(JSON.stringify({ event, payload })),
+    async waitFor(event, timeout = 5000) {
+      const deadline = Date.now() + timeout;
+      for (;;) {
+        const hit = received.find((m) => m.event === event);
+        if (hit) return hit;
+        if (Date.now() > deadline) {
+          throw new Error(
+            `timed out waiting for "${event}"; saw ` +
+              [...new Set(received.map((m) => m.event))].join(', '),
+          );
+        }
+        await sleep(20);
+      }
+    },
+    async close() {
+      socket?.close();
+      await new Promise((resolve) => server.close(resolve));
+    },
+  };
+}
+
+test('the DevTools backend drives the overlays, the picker and the style editor', async (t) => {
+  const devtools = await fakeDevTools();
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), 'react-x11-dt-'));
+  const stateFile = path.join(stateDir, 'devtools.json');
+  process.env.REACT_X11_DEVTOOLS = '1';
+  process.env.REACT_X11_DEVTOOLS_PORT = String(devtools.port);
+  process.env.REACT_X11_DEVTOOLS_STATE = stateFile;
+  t.after(async () => {
+    delete process.env.REACT_X11_DEVTOOLS;
+    delete process.env.REACT_X11_DEVTOOLS_PORT;
+    delete process.env.REACT_X11_DEVTOOLS_STATE;
+    // A backend whose socket closes reconnects forever (handleClose ->
+    // scheduleRetry), which is what an app wants and what would keep this
+    // process alive after the last assertion. Every timer from here on is
+    // unref'd, so the retries continue without being a reason to stay up.
+    const realSetTimeout = global.setTimeout;
+    global.setTimeout = (fn, ms, ...rest) => {
+      const timer = realSetTimeout(fn, ms, ...rest);
+      timer.unref?.();
+      return timer;
+    };
+    await devtools.close();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  // imported after the environment is set: the hook installs from here
+  const { createRoot } = await import('../src/index.js');
+
+  let bump;
+  function Counter() {
+    const [n, setN] = React.useState(0);
+    bump = () => setN((value) => value + 1);
+    return React.createElement('box', {
+      style: { width: 60, height: 20, backgroundColor: n ? 'red' : 'blue' },
+    });
+  }
+
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(
+    React.createElement(
+      'window',
+      { width: 200, height: 100 },
+      React.createElement(Counter),
+    ),
+  );
+  await devtools.connected;
+  await devtools.waitFor('operations');
+  const wnd = app.windows[0];
+  const box = wnd._reactX11Node.children[0];
+  const outlines = (from) =>
+    wnd.ctx.ops
+      .slice(from)
+      .filter(
+        ([op, color]) => op === 'stroke' && String(color).startsWith('#'),
+      );
+
+  // 1. the style editor is offered at all, with our style vocabulary
+  const advert = await devtools.waitFor('isNativeStyleEditorSupported');
+  assert.strictEqual(advert.payload.isSupported, true);
+  assert.ok(
+    advert.payload.validAttributes?.includes('padding'),
+    'the editor is told which attributes an element takes',
+  );
+
+  // 2. "highlight updates when components render": the backend asks for
+  // tracing, a commit produces outlines, and its own clock expires them
+  devtools.send('setTraceUpdatesEnabled', true);
+  await sleep(200);
+  const beforeCommit = wnd.ctx.ops.length;
+  bump();
+  await sleep(400);
+  assert.ok(
+    outlines(beforeCommit).length > 0,
+    'the re-rendered node is outlined in the colour the backend chose',
+  );
+  await sleep(1600); // DISPLAY_DURATION, plus the redraw that clears it
+  const afterExpiry = wnd.ctx.ops.length;
+  await sleep(300);
+  assert.deepStrictEqual(
+    outlines(afterExpiry),
+    [],
+    'and stops being painted once the backend stops sending it',
+  );
+
+  // 3. the element picker: with no DOM to listen on, the backend hands the
+  // pointer over and waits to be told what was picked
+  devtools.send('startInspectingHost', false);
+  await sleep(200);
+  wnd.emit('mousemove', { x: 30, y: 10 });
+  await sleep(50);
+  wnd.emit('mousedown', { x: 30, y: 10, keycode: 1 });
+  wnd.emit('mouseup', { x: 30, y: 10, keycode: 1 });
+  const selected = await devtools.waitFor('selectElement');
+  assert.strictEqual(
+    typeof selected.payload,
+    'number',
+    'an element id comes back for whatever was under the pointer',
+  );
+  const stopped = await devtools.waitFor('stopInspectingHost');
+  assert.strictEqual(stopped.payload, true, 'and picking mode ends');
+
+  // 4. the style editor, on a host element — the default filters hide
+  // those, and a component id has no style to edit
+  devtools.send('updateComponentFilters', []);
+  await sleep(300);
+  const hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  const [rendererID] = [...hook.rendererInterfaces.keys()];
+  const renderer = hook.rendererInterfaces.get(rendererID);
+  const id = renderer.getElementIDForHostInstance(box);
+  devtools.send('NativeStyleEditor_measure', { id, rendererID });
+  const measured = await devtools.waitFor('NativeStyleEditor_styleAndLayout');
+  assert.deepStrictEqual(
+    measured.payload.style,
+    { width: 60, height: 20, backgroundColor: 'red' },
+    'the flattened style is what the editor shows',
+  );
+  assert.strictEqual(measured.payload.layout?.width, 60);
+  assert.strictEqual(measured.payload.layout?.height, 20);
+
+  // editing a value goes through the reconciler's own override path, so
+  // the app really re-renders and really re-lays-out
+  devtools.send('NativeStyleEditor_setValue', {
+    id,
+    rendererID,
+    name: 'width',
+    value: 120,
+  });
+  await sleep(400);
+  assert.strictEqual(box.abs.width, 120, 'the edited style took effect');
+
+  // 5. a setting changed in the DevTools UI is on disk for the next run
+  devtools.send('updateHookSettings', {
+    appendComponentStack: true,
+    breakOnConsoleErrors: false,
+    showInlineWarningsAndErrors: true,
+    hideConsoleLogsInStrictMode: false,
+  });
+  await sleep(300);
+  const stored = JSON.parse(await fs.readFile(stateFile, 'utf8'));
+  assert.deepStrictEqual(
+    JSON.parse(stored['react-x11:hookSettings']).showInlineWarningsAndErrors,
+    true,
+    'hook settings are written where the next run reads them',
+  );
+
+  await x11Root.unmount();
+});
+
+// "Reload and start profiling" restarts the app with profiling already on —
+// the only way to profile a mount. A browser reloads the page; this re-execs
+// the process, which has to keep the node flags, the argv and the session
+// state a reload would have kept.
+test('reload-and-profile re-execs the app with its flags intact', async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'react-x11-reload-'));
+  const module = fileURLToPath(
+    new URL('../src/DevToolsIntegration.js', import.meta.url),
+  );
+  const script = path.join(dir, 'restart.mjs');
+  await fs.writeFile(
+    script,
+    `import { reloadAndProfile } from ${JSON.stringify(module)};
+     if (process.env.REACT_X11_DEVTOOLS_PROFILING) {
+       console.log(JSON.stringify({
+         argv: process.argv.slice(1),
+         execArgv: process.execArgv,
+         profiling: process.env.REACT_X11_DEVTOOLS_PROFILING,
+         session: process.env.REACT_X11_DEVTOOLS_SESSION,
+         devtools: process.env.REACT_X11_DEVTOOLS,
+       }));
+       process.exit(0);
+     }
+     global.sessionStorage = { toJSON: () => ({ selection: '3' }) };
+     reloadAndProfile(true, false);\n`,
+  );
+  try {
+    const child = spawn(
+      process.execPath,
+      ['--title=react-x11-reload-test', script, '--an-argument'],
+      { stdio: ['ignore', 'pipe', 'inherit'] },
+    );
+    let out = '';
+    child.stdout.on('data', (chunk) => (out += chunk));
+    const code = await new Promise((resolve) => child.on('close', resolve));
+    assert.strictEqual(code, 0);
+    const restarted = JSON.parse(out.trim().split('\n').at(-1));
+    assert.deepStrictEqual(restarted.argv, [script, '--an-argument']);
+    assert.deepStrictEqual(restarted.execArgv, [
+      '--title=react-x11-reload-test',
+    ]);
+    assert.deepStrictEqual(JSON.parse(restarted.profiling), {
+      recordChangeDescriptions: true,
+      recordTimeline: false,
+    });
+    assert.deepStrictEqual(
+      JSON.parse(restarted.session),
+      { selection: '3' },
+      'the selection survives the restart, as it would a page reload',
+    );
+    assert.strictEqual(
+      restarted.devtools,
+      '1',
+      'the app that comes back has DevTools enabled whatever launched it',
+    );
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+});

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -21,6 +21,7 @@ function pressKey(app, wnd, { keysym, codepoint, buttons = 0, time }) {
 }
 
 const XK = {
+  Escape: 0xff1b,
   BackSpace: 0xff08,
   Tab: 0xff09,
   Return: 0xff0d,
@@ -1762,6 +1763,319 @@ test('DevTools agent highlight tints the hovered node', async () => {
   );
 
   await x11Root.unmount();
+});
+
+// The overlay DevTools draws for "highlight updates when components
+// render". The backend owns the colour ramp and the fade-out clock and
+// hands over the whole live set each time, so the host redraws rather than
+// accumulates — a rect that stops being sent has to stop being painted.
+test('DevTools trace updates outline the rects that re-rendered', async () => {
+  const { EventEmitter } = await import('node:events');
+  const { attachTraceUpdatesAgent } =
+    await import('../src/DevToolsIntegration.js');
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(
+    React.createElement(
+      'window',
+      { width: 200, height: 100 },
+      React.createElement(
+        'box',
+        { style: { flexDirection: 'row', flexGrow: 1 } },
+        React.createElement('box', { style: { flexGrow: 1 } }),
+        React.createElement('box', { style: { flexGrow: 1 } }),
+      ),
+    ),
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const [left, right] = wnd._reactX11Node.children[0].children;
+
+  const agent = new EventEmitter();
+  attachTraceUpdatesAgent(agent);
+
+  const outlines = (from) =>
+    wnd.ctx.ops
+      .slice(from)
+      .filter(([op, color]) => op === 'stroke' && String(color).startsWith('#'))
+      .map(([, color]) => color);
+
+  let before = wnd.ctx.ops.length;
+  agent.emit('drawTraceUpdates', [
+    { node: left, color: '#37afa9' },
+    { node: right, color: '#febc38' },
+  ]);
+  await tick();
+  assert.deepStrictEqual(
+    outlines(before),
+    ['#37afa9', '#febc38'],
+    'one outline per node, in the colour the backend assigned it',
+  );
+  const rects = wnd.ctx.ops
+    .slice(before)
+    .filter(([op]) => op === 'rect')
+    .map(([, x, y, w, h]) => [x, y, w, h]);
+  assert.ok(
+    rects.some(([x, y, w, h]) => x === 101 && y === 1 && w === 98 && h === 98),
+    `the right box's rect is outlined inside its bounds, got ${JSON.stringify(rects)}`,
+  );
+
+  // the backend expired one of them: what it no longer sends is no longer
+  // painted, without the other one flickering off and on
+  before = wnd.ctx.ops.length;
+  agent.emit('drawTraceUpdates', [{ node: left, color: '#63b19e' }]);
+  await tick();
+  assert.deepStrictEqual(outlines(before), ['#63b19e']);
+
+  before = wnd.ctx.ops.length;
+  agent.emit('disableTraceUpdates');
+  await tick();
+  assert.deepStrictEqual(
+    outlines(before),
+    [],
+    'turning the setting off clears the overlay',
+  );
+
+  await x11Root.unmount();
+});
+
+// The element picker: with no DOM to listen on, the backend hands the
+// pointer to the host and waits to be told what was picked.
+test('DevTools picker selects the element under the pointer', async () => {
+  const { EventEmitter } = await import('node:events');
+  const { attachPickerAgent } = await import('../src/DevToolsIntegration.js');
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const clicks = [];
+  x11Root.render(
+    React.createElement(
+      'window',
+      { width: 200, height: 100 },
+      React.createElement(
+        'box',
+        { style: { flexDirection: 'row', flexGrow: 1 } },
+        React.createElement('box', { style: { flexGrow: 1 } }),
+        React.createElement('box', {
+          style: { flexGrow: 1 },
+          onClick: () => clicks.push('right'),
+        }),
+      ),
+    ),
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const right = wnd._reactX11Node.children[0].children[1];
+
+  const selected = [];
+  const stopped = [];
+  const agent = Object.assign(new EventEmitter(), {
+    getIDForHostInstance: () => 7,
+    selectNode: (node) => selected.push(node),
+    stopInspectingNative: (value) => stopped.push(value),
+  });
+  attachPickerAgent(agent);
+  agent.emit('startInspectingNative');
+
+  wnd.emit('mousemove', { x: 150, y: 50 });
+  await tick();
+  const tint = () =>
+    wnd.ctx.ops.filter(
+      ([op, , , , , style]) =>
+        op === 'fillRect' && style === 'rgba(41, 128, 185, 0.35)',
+    );
+  assert.deepStrictEqual(
+    tint().at(-1),
+    ['fillRect', 100, 0, 100, 100, 'rgba(41, 128, 185, 0.35)'],
+    'motion tints whatever is under the pointer',
+  );
+
+  wnd.emit('mousedown', { x: 150, y: 50, keycode: 1 });
+  wnd.emit('mouseup', { x: 150, y: 50, keycode: 1 });
+  await tick();
+  // identity, not deepStrictEqual: a failing diff of two retained nodes
+  // walks the whole tree and reports nothing useful
+  assert.strictEqual(selected.length, 1, 'exactly one element selected');
+  assert.ok(selected[0] === right, 'the press selects the element under it');
+  assert.deepStrictEqual(stopped, [true], 'and tells DevTools picking is over');
+  assert.deepStrictEqual(
+    clicks,
+    [],
+    'the app never sees the press that picked an element',
+  );
+
+  // and with picking over, the app has its pointer back
+  wnd.emit('mousedown', { x: 150, y: 50, keycode: 1 });
+  wnd.emit('mouseup', { x: 150, y: 50, keycode: 1 });
+  await tick();
+  assert.deepStrictEqual(clicks, ['right']);
+
+  await x11Root.unmount();
+});
+
+test('Escape cancels the DevTools picker and hands the pointer back', async () => {
+  const { EventEmitter } = await import('node:events');
+  const { attachPickerAgent } = await import('../src/DevToolsIntegration.js');
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const clicks = [];
+  x11Root.render(
+    React.createElement('window', { width: 200, height: 100 }, [
+      React.createElement('box', {
+        key: 'b',
+        style: { flexGrow: 1 },
+        onClick: () => clicks.push('box'),
+      }),
+    ]),
+  );
+  await tick();
+  const wnd = app.windows[0];
+
+  const stopped = [];
+  const agent = Object.assign(new EventEmitter(), {
+    getIDForHostInstance: () => 7,
+    selectNode: () => {},
+    stopInspectingNative: (value) => stopped.push(value),
+  });
+  attachPickerAgent(agent);
+  agent.emit('startInspectingNative');
+
+  pressKey(app, wnd, { keysym: XK.Escape });
+  await tick();
+  assert.deepStrictEqual(stopped, [false], 'DevTools is told picking is off');
+
+  wnd.emit('mousedown', { x: 50, y: 50, keycode: 1 });
+  wnd.emit('mouseup', { x: 50, y: 50, keycode: 1 });
+  await tick();
+  assert.deepStrictEqual(clicks, ['box'], 'the app has its pointer back');
+
+  await x11Root.unmount();
+});
+
+test('selectInDevTools reveals a node when an agent is attached', async () => {
+  const { selectInDevTools } = await import('../src/DevToolsIntegration.js');
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(
+    React.createElement(
+      'window',
+      { width: 200, height: 100 },
+      React.createElement('box', { style: { flexGrow: 1 } }),
+    ),
+  );
+  await tick();
+  const box = app.windows[0]._reactX11Node.children[0];
+
+  assert.strictEqual(
+    selectInDevTools(box),
+    false,
+    'no DevTools attached: click-to-component just opens the editor',
+  );
+
+  const selected = [];
+  const previous = global.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  global.__REACT_DEVTOOLS_GLOBAL_HOOK__ = {
+    reactDevtoolsAgent: {
+      getIDForHostInstance: (node) => (node === box ? 4 : null),
+      selectNode: (node) => selected.push(node),
+    },
+  };
+  try {
+    assert.strictEqual(selectInDevTools(box), true);
+    assert.strictEqual(selected.length, 1);
+    assert.ok(selected[0] === box);
+    // an element DevTools' filters hid has no id, and no message to send
+    const other = app.windows[0]._reactX11Node;
+    assert.strictEqual(selectInDevTools(other), false);
+    assert.strictEqual(selected.length, 1);
+  } finally {
+    if (previous === undefined) delete global.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+    else global.__REACT_DEVTOOLS_GLOBAL_HOOK__ = previous;
+  }
+
+  await x11Root.unmount();
+});
+
+test('DevTools style editor gets a flat style and a measurable node', async () => {
+  const { resolveStyle } = await import('../src/DevToolsIntegration.js');
+  const { STYLE_PROP_NAMES } = await import('../src/styles.js');
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(
+    React.createElement(
+      'window',
+      { width: 200, height: 100 },
+      React.createElement('box', {
+        style: [{ flexGrow: 1, padding: 4 }, { padding: 8 }],
+      }),
+    ),
+  );
+  await tick();
+  const box = app.windows[0]._reactX11Node.children[0];
+
+  assert.deepStrictEqual(
+    resolveStyle([{ flexGrow: 1, padding: 4 }, { padding: 8 }]),
+    { flexGrow: 1, padding: 8 },
+    'array styles arrive flattened, later entries winning',
+  );
+  assert.deepStrictEqual(
+    resolveStyle({ color: 'red', ':hover': { color: 'blue' } }),
+    { color: 'red' },
+    'state blocks are not editable values and are left out',
+  );
+  assert.ok(
+    STYLE_PROP_NAMES.includes('padding') && STYLE_PROP_NAMES.includes('color'),
+    'the valid-attribute list is the style vocabulary itself',
+  );
+
+  // the box model beside the style comes from measure(), RN's contract
+  let measured = null;
+  box.measure((...args) => {
+    measured = args;
+  });
+  assert.deepStrictEqual(measured, [0, 0, 200, 100, 0, 0]);
+
+  await x11Root.unmount();
+});
+
+test('DevTools settings survive a restart, session state does not', async () => {
+  const { createStorage } = await import('../src/DevToolsIntegration.js');
+  const os = await import('node:os');
+  const path = await import('node:path');
+  const fsp = await import('node:fs/promises');
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), 'react-x11-devtools-'));
+  const file = path.join(dir, 'nested', 'devtools.json');
+  const previous = process.env.REACT_X11_DEVTOOLS_STATE;
+  process.env.REACT_X11_DEVTOOLS_STATE = file;
+  try {
+    const store = createStorage(true);
+    assert.strictEqual(store.getItem('missing'), null);
+    store.setItem('React::DevTools::componentFilters', '[{"type":1}]');
+    // a second process reading the same file is the whole point
+    assert.strictEqual(
+      createStorage(true).getItem('React::DevTools::componentFilters'),
+      '[{"type":1}]',
+    );
+    store.removeItem('React::DevTools::componentFilters');
+    assert.strictEqual(createStorage(true).length, 0);
+
+    const session = createStorage(false);
+    session.setItem('selection', '3');
+    assert.strictEqual(session.getItem('selection'), '3');
+    assert.deepStrictEqual(
+      session.toJSON(),
+      { selection: '3' },
+      'session state is what a reload-and-profile restart carries over',
+    );
+    assert.strictEqual(
+      createStorage(true).getItem('selection'),
+      null,
+      'and it never reaches the file',
+    );
+  } finally {
+    if (previous === undefined) delete process.env.REACT_X11_DEVTOOLS_STATE;
+    else process.env.REACT_X11_DEVTOOLS_STATE = previous;
+    await fsp.rm(dir, { recursive: true, force: true });
+  }
 });
 
 test('rich content elements mount, update and unmount headlessly', async () => {


### PR DESCRIPTION
Most of what React DevTools can do costs this renderer nothing: the tree,
props, hooks and every edit go through the renderer interface
`injectIntoDevTools` registers. What was missing is the half a browser gets
from the DOM and an X11 app has to answer for itself — the overlays, the
picker, the style editor's measurements, and the state a restart survives.
The backend was already asking for all of it. Nothing was listening.

What makes those paths run at all is the backend's own
`isReactNativeEnvironment`, which is just `window.document == null` — true
for a node process, so it takes React Native's route everywhere and asks
the host to draw instead of drawing into a DOM overlay of its own.

## Highlight updates when components render

The backend counts the updates, picks each rect's colour off its ramp and
expires it on its own clock, then emits `drawTraceUpdates` with the whole
live set. The window paints outlines and replaces them each time rather
than accumulating.

![devtools-trace-updates](https://github.com/user-attachments/assets/0100e8a6-8a02-4bc6-8119-d9a8150f9423)

It schedules those redraws on animation frames, which node does not have —
`prepare` installs an unref'd timer shim, and without it the first traced
commit throws inside the backend.

## The element picker

With no DOM to listen on, the backend emits `startInspectingNative` and
waits. A new inspect handler in `events.js` hands the pointer to DevTools:
motion tints whatever is under it, a press selects that element in the
tree, `Escape` gives up. The app sees none of those events.

![devtools-picker](https://github.com/user-attachments/assets/9c8636c8-2369-4a2c-ae6c-975ffc64a71d)

Cancelling from the DevTools side arrives as a bridge message with no
host-facing event, so the picker also listens on the bridge directly —
without that, a cancelled picker keeps swallowing the app's input.

## The style editor

Offered only to a host that supplies a style resolver, a list of valid
attributes and RN's `measure` contract on host instances. Edits arrive as
an override on the `style` prop with the value wrapped in an array, which
works here because a react-x11 `style` prop already takes one.

## Settings, and reload-and-profile

DevTools' own settings — component filters, console patching — now survive
a restart in a file-backed `localStorage`, with `sessionStorage` alongside
it. Both are *defined* on the global rather than assigned, because reading
`global.localStorage` first is what makes node print its
`--localstorage-file` warning on every DevTools run.

"Reload and start profiling" is the only way to profile a mount: the app
re-execs itself carrying its node flags, argv and session state, and the
run that comes back starts profiling before the first commit. Registering
a renderer does not start it, and the backend's own support check asks
whether synchronous XHR works, so the host has to say yes explicitly.

## Also

- Alt+Click selects the clicked element in the DevTools tree as well as
  opening its source, when both features are on.
- `scripts/devtools-proxy.mjs` — a man-in-the-middle for the bridge that
  prints both directions and decodes the packed `operations` arrays the way
  DevTools decodes them itself. Useful for anyone extending this.
- `docs/devtools.md` gains what each injection answers, and a section on
  making the panel's source line clickable — the standalone spawns
  `$REACT_EDITOR` itself, or opens a URL template from its settings.

## Verification

`test/devtools.test.js` drives the real `react-devtools-core` backend over
a socket standing in for the frontend: outlines appearing *and expiring on
the backend's clock*, a picker round trip, measure and edit, settings
hitting disk, and the re-exec in a child process. The fake-agent tests in
`smoke.test.js` prove the drawing but not that the backend still asks for
it, which is why both exist.

Suite is green. Screenshots above were rendered by this branch's code into
the in-process X server, driving the real agent listeners.

