### PR TITLE
fix(types): a registered element is a DrawnNode again

### DIFF
--- a/src/node.d.ts
+++ b/src/node.d.ts
@@ -6,7 +6,12 @@
  * internal and may change in a patch release. docs/extending.md is the
  * contract in prose.
  */
-import type { Rect, NtkApp } from './types/nodes.js';
+import type {
+  Rect,
+  NtkApp,
+  TextPosition,
+  TextSelectionSnapshot,
+} from './types/nodes.js';
 import type {
   FontStyle,
   FontWeight,
@@ -186,6 +191,26 @@ export declare class Node {
    * document around it skips its subtree whole and leaves its presses
    * alone. `<textinput>` sets it. */
   hasOwnSelection: boolean;
+
+  // --- being a selection surface -------------------------------------------
+  //
+  // The base class implements these for every node, which is what lets a
+  // registered element be passed anywhere a `DrawnNode` is taken — the
+  // interface in `types/nodes.d.ts` lists them, so leaving them out here
+  // made a subclass stop being one.
+
+  /** The selection this element owns, or null when it is not `selectable`.
+   * A snapshot: read it again after a change. */
+  readonly textSelection: TextSelectionSnapshot | null;
+  /** Select everything in this surface, and take PRIMARY with it. */
+  selectAll(): this;
+  /** Drop the selection. PRIMARY is left where it is: the text stays
+   * pasteable, which is what every other X client does. */
+  clearSelection(): this;
+  /** What a copy would put on the clipboard. */
+  selectedText(): string;
+  /** Set both ends by hand. `setSelection(null)` clears. */
+  setSelection(anchor: TextPosition | null, focus?: TextPosition | null): this;
 
   /** Draw. A subclass calls `super.paint(ctx)` first, for the background,
    * border and clip, then draws inside `this.abs`. */


### PR DESCRIPTION
`npm run typecheck` fails on master, and has since #289 and #291 met:

```
test/types/extend.tsx(249,7): error TS2345: Argument of type 'this' is not
  assignable to parameter of type 'DrawnNode'.
  Type 'EditorNode' is missing the following properties from type
  'DrawnNode': textSelection, selectAll, clearSelection, selectedText,
  setSelection
```

The selection work added those five members to the runtime base class and
to the `DrawnNode` interface in `types/nodes.d.ts`, but not to the `Node`
class declaration in `node.d.ts` — the one a registered element actually
extends. So a subclass quietly stopped satisfying `DrawnNode`, and the edit
menu helpers from #289, which take one, no longer accept `this`.

Each half was green alone, which is why nothing caught it before the merge:
the edit menu landed first, the selection API second.

This declares the five on `Node`, copying the wording already used for the
interface. Declarations only — the runtime has implemented them since the
selection work, and `test/types/extend.tsx` is both what caught this and
the guard against it recurring.

`npm run typecheck`, `npm run lint` and `prettier --check` are clean on
this branch.
