### PR TITLE
fix(scroll): poison the blit when damage precedes the frame's first scrollTo

### DIFF
--- a/src/nodes.js
+++ b/src/nodes.js
@@ -262,6 +262,13 @@ const NO_SCROLL_BLIT = process.env.REACT_X11_NO_SCROLL_BLIT === '1';
 // exposed strip is most of a repaint anyway.
 const SCROLL_BLIT_MIN_KEEP = 0.5;
 
+// A scroll that must not blit this frame: content inside the viewport
+// already changed (see the arming check in scrollTo, and the claim-time
+// cancel in WindowNode.invalidate — react-x11#295). Truthy on purpose, so
+// scrollTo's `??=` cannot re-arm over it, and reset by _applyScrollBlits'
+// up-front clear like any real origin, so it lives exactly one frame.
+const BLIT_POISONED = Object.freeze({ poisoned: true });
+
 const rectContains = (outer, inner) =>
   outer.x <= inner.x &&
   outer.y <= inner.y &&
@@ -4042,6 +4049,24 @@ export const Scrollable = (Base) =>
       if (next.x === this.scrollX && next.y === this.scrollY) return;
       const root = this.root;
       if (root) {
+        // Arming is the one moment the evidence still exists: the viewport
+        // claim recorded below coalesces earlier claims into itself
+        // (addDamageRect keeps the list disjoint), after which a change
+        // inside the viewport is indistinguishable from the scroll's own
+        // claim — the blind spot the claim-time cancel in
+        // WindowNode.invalidate cannot cover (react-x11#295). The scroll
+        // has not claimed yet, so damage already overlapping this viewport
+        // is foreign by construction: poison the frame instead of arming,
+        // and the full-viewport repaint below stays in force.
+        if (this._pendingBlitFrom == null && Array.isArray(root._damage)) {
+          const zone = insetRect(this.abs, -(DAMAGE_SLOP * 2 + 1));
+          for (const rect of root._damage) {
+            if (rectsOverlap(rect, zone)) {
+              this._pendingBlitFrom = BLIT_POISONED;
+              break;
+            }
+          }
+        }
         // The offsets whose pixels are on screen, captured before the first
         // change of the frame: the frame's blit fast path (issue #138) shifts
         // from *these* to wherever layout settles, however many scrollTo
@@ -8001,13 +8026,19 @@ export class WindowNode extends Scrollable(Node) {
       this._scrollClaim !== damage
     ) {
       const rect = damage.paintBounds ? damage.paintBounds() : damage;
-      for (const sv of [...pendingScrolls]) {
+      for (const sv of pendingScrolls) {
         if (
           !sv.abs ||
           rectsOverlap(rect, insetRect(sv.abs, -(DAMAGE_SLOP * 2 + 1)))
         ) {
-          pendingScrolls.delete(sv);
-          sv._pendingBlitFrom = null;
+          // Poison rather than disarm (react-x11#295): a null here would
+          // let a second scrollTo in the same frame re-arm from a
+          // mid-frame origin, and the blit would then move pixels that
+          // were never repainted at that origin — a band displaced by the
+          // first scroll's delta. The node stays in pendingScrolls so the
+          // up-front clear in _applyScrollBlits resets the poison exactly
+          // like a real origin.
+          sv._pendingBlitFrom = BLIT_POISONED;
         }
       }
     }
@@ -8200,6 +8231,9 @@ export class WindowNode extends Scrollable(Node) {
     // whether their regions interact is not worth it
     if (nodes.length !== 1) return;
     const node = nodes[0];
+    // a poisoned frame (react-x11#295) falls back to the full-viewport
+    // claim the scroll recorded, like every other declined gate here
+    if (from === BLIT_POISONED) return;
     if (NO_SCROLL_BLIT || !from || node.destroyed || node.root !== this) return;
     const wnd = this.window;
     if (typeof wnd?.scrollRegion !== 'function') return; // ntk without #139

--- a/test/scroll-blit.test.js
+++ b/test/scroll-blit.test.js
@@ -366,3 +366,36 @@ test('a blitted scroll is byte-identical to the repaint it replaced', async (t) 
     await app.close();
   }
 });
+
+test('damage claimed before the frame’s first scrollTo keeps the full repaint (#295)', async () => {
+  const { wnd, root, ref } = await mount();
+  await tick();
+  const row = root.children[0].children[2];
+  wnd.calls.length = 0;
+  // The race: the claim lands first, while no scroll is pending, so the
+  // claim-time cancel in WindowNode.invalidate never tests it — and the
+  // viewport claim that follows coalesces the rect away (addDamageRect
+  // keeps the list disjoint), leaving the pure-scroll gate nothing to see.
+  root.invalidate(false, row);
+  ref.current.scrollTo(48);
+  await tick();
+  assert.strictEqual(blits(wnd).length, 0, 'not a pure scroll: no blit');
+});
+
+test('a claim between two scrolls cannot re-arm the blit mid-frame (#295)', async () => {
+  const { wnd, root, ref } = await mount();
+  await tick();
+  const row = root.children[0].children[2];
+  wnd.calls.length = 0;
+  ref.current.scrollTo(48); // arms, origin = the frame's true start
+  root.invalidate(false, row); // the claim-time cancel un-arms the blit
+  ref.current.scrollBy(48); // must not re-arm from the mid-frame origin
+  await tick();
+  assert.strictEqual(
+    blits(wnd).length,
+    0,
+    'a poisoned frame stays poisoned: pixels at the true origin were ' +
+      'never repainted, so a blit from the mid-frame origin would move ' +
+      'a band displaced by the first delta',
+  );
+});


### PR DESCRIPTION
Fixes #295 — both holes in the scroll-blit fast path's claim ordering.

## The two holes

**Claim-before-scroll.** The claim-time cancel in `WindowNode.invalidate` only runs while a scroll is pending; a bounded claim landing before the frame's first `scrollTo` is never tested, the viewport claim then coalesces it away (`addDamageRect` keeps the list disjoint), and `_applyScrollBlits`' pure-scroll gate sees nothing. The blit drags the stale pixels, the narrowed repaint never covers them, and they persist in the backing store — later pure-scroll frames move them around.

**Cancel-then-re-arm.** The cancel reset `_pendingBlitFrom` to `null`, so a scroll → claim → scroll frame re-armed from the *mid-frame* scroll position while the backing store still held pixels from the frame's true start: a blit by the wrong delta, a band geometrically displaced by the first scroll's amount.

## The fix

Arming is the one moment the evidence still exists — `scrollTo` arms *before* it claims the viewport, so at that instant any damage rect already overlapping the viewport is foreign by construction:

- `scrollTo` scans the root's `_damage` before first arm (the same `DAMAGE_SLOP * 2 + 1` zone the claim-time check uses) and sets a **poison sentinel** instead of arming;
- the claim-time cancel sets the same sentinel instead of `null`, so nothing can re-arm mid-frame;
- `_applyScrollBlits` treats the sentinel as "no blit"; its existing up-front clear resets it, so the poison lives exactly one frame.

Every poisoned frame falls back to the full-viewport claim the scroll already recorded — the fast path keeps its property that the worst mistake it can make is not firing.

## Tests

Two regressions in `test/scroll-blit.test.js`, one per hole; both fail on the base commit and pass with the fix. The 13 existing blit tests (pure scroll still blits, byte-identical to the repaint it replaced, every decline gate) stay green; the full suite shows no new failures (the appearance-ladder tests fail identically on the pristine base on this machine).

## Where it was found

Pixel diff in `@react-x11/components`' charts demo — a `ChartData` append racing a wheel tick. Same append + `scrollBy` in one frame, only the blit toggled (control: `REACT_X11_NO_SCROLL_BLIT=1`): with the blit, the chart still shows the entire pre-append frame; 2,423 pixels differ. Nothing charts-specific — a terminal's pty output or a media player's progress tick can race the same way.

![scroll-race-proof](https://github.com/user-attachments/assets/943ce955-14af-4666-821e-d2a299ac2417)

## Branch base

Cut from `b98d520` (pre-`feat(theme)!`), deliberately: downstream `@react-x11/components` pins core by sha and has not migrated the theme break yet, so this lets it pin the fix commit directly. `49fb2b3` touches `src/nodes.js` only at lines 1600/5786/5977 — no overlap, merges clean into master.

