### PR TITLE
fix(deps): bump ntk to 7.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^7.6.0",
+        "ntk": "^7.6.1",
         "react-reconciler": "^0.33.0"
       },
       "devDependencies": {
@@ -4034,9 +4034,9 @@
       }
     },
     "node_modules/ntk": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-7.6.0.tgz",
-      "integrity": "sha512-VUjWYGmL/0dqizG9f+3zyteq2fY8G/aueY2EuHGXGSWIHH7CFJpzWmRcJvJMuFwa6Y220WxmirpIqF7k2M+aIQ==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-7.6.1.tgz",
+      "integrity": "sha512-JPvscPa4hE04PGJcVrW2mUOLOBGB9AsBKeyqBVb9tOx6yL9lMf2bJVOh9ij373fASr4Zgx12wPeMLXOvjiPCJA==",
       "license": "MIT",
       "dependencies": {
         "bidi-js": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^7.6.0",
+    "ntk": "^7.6.1",
     "react-reconciler": "^0.33.0"
   },
   "optionalDependencies": {


### PR DESCRIPTION
Bumps `ntk` `^7.6.0` → `^7.6.1` — the fix release for [ntk#259](https://github.com/sidorares/ntk/issues/259) (fixed by [ntk#260](https://github.com/sidorares/ntk/pull/260)).

## What 7.6.1 fixes

`ctx.stroke()` over a dense polyline with same-x bursts — several consecutive points sharing one x, the natural shape of a stream appending a few samples per timestamp — hit a rounding coincidence in ntk's reversal guard: bit-exact 180° double-backs could reach the extruder, which turned them into NaN join geometry. On real servers (XQuartz) that rendered as fat wedges radiating from the window origin; on the in-process test server the stroke silently lost most of its ink. This is exactly the input shape that broke the `@react-x11/components` streaming chart demo (three appends sharing one `Date.now()` timestamp), where it is currently sidestepped by collapsing same-column points before stroking — with 7.6.1 the raw burst input strokes correctly.

## Verification

- Lockfile delta is the `ntk` entry only.
- Full react-x11 suite run locally against 7.6.1: 1251/1257 pass — the 6 failures are the pre-existing macOS-appearance/XSETTINGS theme-detection tests, identical on `master` with 7.6.0, unrelated to this bump.