### PR TITLE
feat(extending): the rect a pass is painting, and the commit claim an element makes itself

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -48,7 +48,8 @@
   and how the declarations are kept from drifting.
 - [extending.md](extending.md) — `registerElement()` and the subpath
   exports: adding a host element from outside the package, the node
-  contract, and the two definition fields that fail far from their cause.
+  contract, the two definition fields that fail far from their cause, and
+  the damage seam an element that draws a whole scene reads and claims.
 - [embedding.md](embedding.md) — `<foreign>`: another application's window
   inside yours. XEmbed and the plain-reparent path most clients actually
   want, why unmount hands the window back rather than destroying it, and

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -115,6 +115,13 @@ Full repaints are the renderer's main performance bug class (see
 them. Expected full repaints exist too — a resize, the first frame after a
 mount, ntk invalidating its backing store — and their reasons say so.
 
+A bounded frame can still be doing the work of an unbounded one, and this is
+where to notice it: an element that draws a whole **scene** into one node — a
+graph view, a chart, an editor — is one node to the damage machinery, so a
+tight outline around what moved can sit over a pane that redrew all of
+itself inside it. Such an element reads the pass's rect and claims its own
+commits ([extending.md](extending.md#drawing-a-scene-into-one-node)).
+
 ## `REACT_X11_NO_SCROLL_BLIT=1`
 
 Disables the scroll-blit fast path (a pure scroll `CopyArea`s the

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -54,6 +54,7 @@ first created, so a late registration only affects trees mounted after it.
 | `create(props, app, hostCtx)` | builds the node. `app` is the ntk connection — the second argument every built-in node constructor takes. Must return a `Node`.       |
 | `drawn`                       | default `true`: lays out with yoga and paints into the owning window. `false` for a node that owns a real child X window (see below). |
 | `semanticNames`               | prop names this element owns even though they are also style names                                                                    |
+| `selfDamagedProps`            | prop names whose damage the element's own `applyProps` claims (see [Drawing a scene](#drawing-a-scene-into-one-node))                 |
 | `childrenAllowed`             | default `true`; `false` rejects children by name instead of laying out something that never paints                                    |
 | `override`                    | replace an existing registration. Off by default — two packages claiming one name is a conflict worth hearing about                   |
 
@@ -86,6 +87,7 @@ that only draws needs a constructor and a `paint`. What you may override:
 | `paint(ctx)`                   | draw. Call `super.paint(ctx)` first for background, border and clip, then draw inside `this.abs`.            |
 | `paintContent(ctx)`            | draw _between_ the background and the children — where the built-ins draw, and what a scroller needs (below) |
 | `applyProps(next, prev)`       | props changed. Call `super.applyProps(next, prev)`; invalidate if you cache anything derived.                |
+| `paintChanged(next, prev)`     | did anything you draw change? Only for an element that claims its own damage (below)                         |
 | `measureContent(constraints)`  | your content has a size of its own (below). Leaves only — an element that measures has no children.          |
 | `default*(ev)`                 | the element's own behaviour for a key, a press or focus (below) — what makes it _interactive_.               |
 | `hitTest(x, y)`                | non-rectangular hit areas. The default walks children in reverse paint order.                                |
@@ -112,6 +114,9 @@ And what you read:
   ([styling.md](styling.md#direction-and-the-logical-edges)).
 - `this.root` — the owning `<window>` node; `this.app` — the ntk connection.
 - `this.theme` — the nearest theme at or above this node.
+- `this.paintDamage()` — the rect the pass being painted covers, or `null`
+  for a full one. Only an element that draws a whole scene needs it
+  ([below](#drawing-a-scene-into-one-node)).
 
 To ask for a repaint: `this.invalidate(layout, damage, reason)`. Pass the
 damage — `this` is usually it, or a rect when you know a tighter one. An
@@ -885,6 +890,124 @@ to round. And `<box overflow="scroll">` has been doing the window-side half
 of this without being asked: a pure scroll of one viewport blits the
 surviving band inside ntk's backing pixmap rather than repainting it. This
 is that optimisation, for a buffer you retained yourself.
+
+### Drawing a scene into one node
+
+_Issue #301._ A frame repaints **rects, not windows**: claims coalesce into
+disjoint rectangles, each gets its own clipped pass, and a subtree that lands
+outside the pass being painted emits no drawing at all. All of that has one
+granularity — the retained node — which is exactly right until your element
+_is_ the scene. A graph view, a chart, a timeline, a code editor: the tree
+says "one node, 1100×700", so a pass over the 80×40 box a dragged node moved
+through redraws all three hundred nodes, all seven hundred edges, the grid
+and the minimap into a clip that throws almost all of it away.
+
+Two accessors make such an element a member of the same machinery rather
+than the one exception to it. Both are opt-in, and both keep core's answer
+when you say nothing.
+
+**Painting: `paintDamage()`.** The rect this pass covers, in the owning
+window's coordinates — the same space as `abs` and a mouse event's `x`/`y` —
+or `null` when the frame is unbounded and everything has to be drawn. Cull
+against it exactly as core culls the tree:
+
+```js
+class FlowNode extends Node {
+  paintContent(ctx) {
+    // null outside a paint and on a full pass, and both mean the same
+    // thing: nothing bounds you, draw the lot
+    const damage = this.paintDamage();
+    for (const cell of this.gridCells()) {
+      if (damage && !overlaps(cell, damage)) continue;
+      this.drawCell(ctx, cell);
+    }
+    for (const edge of this.edges) {
+      if (damage && !overlaps(edge.routedBounds, damage)) continue;
+      this.drawEdge(ctx, edge);
+    }
+    // …nodes, minimap, controls
+  }
+}
+```
+
+**Committing: `selfDamagedProps`.** `applyProps` damages the whole node when
+any non-event prop changes identity, which is right for every element whose
+node _is_ what changed and always-everything for a scene pane. A controlled
+graph app commits a new `nodes` array per drag step, so each step is one
+scoped claim from the gesture plus one full-pane claim from the commit — and
+the full-pane claim wins. Name the props whose damage your own `applyProps`
+claims and the commit contributes none of its own:
+
+```js
+registerElement('flow', {
+  create: (props, app) => new FlowNode(props, app),
+  semanticNames: ['nodes', 'edges'],
+  // "my applyProps diffs these and invalidates what actually moved"
+  selfDamagedProps: ['nodes', 'edges'],
+});
+```
+
+```js
+class FlowNode extends Node {
+  applyProps(next, prev) {
+    const before = prev ?? this.props;
+    super.applyProps(next, prev); // claims nothing for `nodes`
+    if (next.nodes !== before.nodes) {
+      // …so this is the only claim, and it is the box that moved
+      this.invalidate(
+        false,
+        this.movedBounds(next.nodes, before.nodes),
+        'props',
+      );
+    }
+  }
+}
+```
+
+When the answer depends on the _values_ rather than the names, override
+**`paintChanged(next, prev)`** instead — it is what the list feeds, so the
+two are the same seam:
+
+```js
+paintChanged(next, prev) {
+  if (next.nodes !== prev.nodes && onlyPositionsMoved(next.nodes, prev.nodes)) {
+    return false; // folded in place above, and the moved box is claimed
+  }
+  return super.paintChanged(next, prev);
+}
+```
+
+Three things about that contract, in the order they bite:
+
+**Everything you do not recognise goes to `super`.** An element that answers
+"nothing changed" about a prop it does not actually claim shows a stale
+pixel, and nothing comes back to fix it — so the override answers for the
+props it knows and hands the rest to core, which is conservative on purpose.
+That is what keeps an `aria-label`, a `title`, or a prop the element grows
+next year correct without anybody remembering this method exists.
+
+**A style change is not yours to excuse.** `style` is compared by value by
+the caller and never reaches either seam: what it moves is the background,
+the border and the clip that `Node.paint` draws for you.
+
+**Claim before you skip.** `selfDamagedProps` only says the commit will not
+claim — it does not claim anything on your behalf. An element that names a
+prop and then forgets to invalidate for it renders nothing at all on that
+change, which at least fails loudly the first time you drag something.
+
+And one place `paintDamage()` does not belong: inside `paintCached`
+([below](#drawing-once-instead-of-every-frame)). That draws into a surface in
+its own coordinates, and a copy culled against the window's damage is stored
+half-drawn under a key that says it is whole — so every later frame that hits
+the key gets the hole.
+
+Worth it because the numbers are not small. `@react-x11/components`' `<Flow>`
+on a 300-node / 745-edge scene at 1100×700 costs ~2470 X requests and ~150 ms
+per drag step redrawing the pane, and ~400 requests / ~30 ms with the two
+seams — the same frame, with the parts of it nobody can see left unsent.
+`REACT_X11_DEBUG_PAINT=1` is how to watch it: the pass's rect is stroked in
+the frame's colour, so a scene that is still repainting whole strobes across
+the pane instead of outlining what moved ([debugging.md](debugging.md)).
 
 ### Drawing once instead of every frame
 

--- a/examples/stress/data.jsx
+++ b/examples/stress/data.jsx
@@ -7,7 +7,7 @@
 // The ticker is the interesting damage case: a timer changes a handful of
 // cells per tick while the rest of the table holds still. Each tick is a
 // React commit that walks the mounted rows, so it is exactly the case
-// `_paintChanged` exists for — an unchanged row whose style object was
+// `paintChanged` exists for — an unchanged row whose style object was
 // rebuilt must not claim damage. Watch the frame log: ticks should report a
 // rect around the changed rows, not the window.
 //

--- a/scripts/bench/baseline.json
+++ b/scripts/bench/baseline.json
@@ -102,5 +102,13 @@
     "replies": 7,
     "composites": 10,
     "compositePixels": 31320
+  },
+  "scene: 5 drag steps over 300 cells in one node": {
+    "requests": 239,
+    "bytesOut": 45076,
+    "bytesIn": 288,
+    "replies": 9,
+    "composites": 133,
+    "compositePixels": 75896
   }
 }

--- a/scripts/bench/protocol.js
+++ b/scripts/bench/protocol.js
@@ -27,6 +27,8 @@ import { compositePixels, countStream } from './xcount.js';
 
 process.env.REACT_X11_NO_AUTORUN = '1';
 const { createRoot } = await import('../../src/index.js');
+const { registerElement } = await import('../../src/host.js');
+const { Node } = await import('../../src/node.js');
 
 const require = createRequire(import.meta.url);
 const fontDir = join(
@@ -260,6 +262,103 @@ function absBoxWindow(left, color) {
     }),
   );
 }
+
+// --- a scene drawn into one node (issue #301) ---------------------------
+//
+// The shape `@react-x11/components`' <Flow> has: one registered element
+// draws a whole graph, so to the damage machinery the scene is a single
+// retained node. A "drag step" is a controlled app committing a new array
+// and the element invalidating the box that actually moved — which only
+// stays scoped because of the two seams. `selfDamagedProps` keeps the
+// commit from claiming the pane over the top of it, and `paintDamage()` is
+// what the paint culls the other 299 cells against.
+
+const SCENE_COLS = 20;
+const SCENE_ROWS = 15;
+const SCENE_CELLS = SCENE_COLS * SCENE_ROWS;
+
+const sceneCells = (moved = -1) =>
+  Array.from({ length: SCENE_CELLS }, (_, i) =>
+    i === moved ? '#e74c3c' : i % 3 ? '#dfe6e9' : '#b2bec3',
+  );
+
+class SceneNode extends Node {
+  cellRect(i) {
+    const box = this.contentBox();
+    const w = box.width / SCENE_COLS;
+    const h = box.height / SCENE_ROWS;
+    return {
+      x: box.x + (i % SCENE_COLS) * w,
+      y: box.y + Math.floor(i / SCENE_COLS) * h,
+      width: w,
+      height: h,
+    };
+  }
+
+  paintContent(ctx) {
+    // null on an unbounded pass, which is the "draw everything" answer
+    const damage = this.paintDamage();
+    const cells = this.props.cells ?? [];
+    for (let i = 0; i < cells.length; i++) {
+      const r = this.cellRect(i);
+      if (
+        damage &&
+        !(
+          r.x < damage.x + damage.width &&
+          damage.x < r.x + r.width &&
+          r.y < damage.y + damage.height &&
+          damage.y < r.y + r.height
+        )
+      ) {
+        continue;
+      }
+      ctx.fillStyle = cells[i];
+      ctx.beginPath();
+      ctx.roundRect(r.x + 1, r.y + 1, r.width - 2, r.height - 2, 3);
+      ctx.fill();
+      ctx.strokeStyle = '#2d343680';
+      ctx.lineWidth = 1;
+      ctx.stroke();
+    }
+  }
+
+  applyProps(next, prev) {
+    const before = prev ?? this.props;
+    // claims nothing for `cells`, because the element claims it below
+    super.applyProps(next, prev);
+    if (next.cells === before.cells) return;
+    let box = null;
+    for (let i = 0; i < next.cells.length; i++) {
+      if (next.cells[i] === before.cells?.[i]) continue;
+      const r = this.cellRect(i);
+      box = box
+        ? {
+            x: Math.min(box.x, r.x),
+            y: Math.min(box.y, r.y),
+            width:
+              Math.max(box.x + box.width, r.x + r.width) - Math.min(box.x, r.x),
+            height:
+              Math.max(box.y + box.height, r.y + r.height) -
+              Math.min(box.y, r.y),
+          }
+        : r;
+    }
+    if (box) this.invalidate(false, box, 'props');
+  }
+}
+
+registerElement('scene', {
+  create: (props, app) => new SceneNode('scene', props, app),
+  semanticNames: ['cells'],
+  selfDamagedProps: ['cells'],
+});
+
+const sceneWindow = (cells) =>
+  React.createElement(
+    'window',
+    { width: W, height: H, style: { backgroundColor: '#f5f6fa' } },
+    React.createElement('scene', { cells, style: { flexGrow: 1, margin: 8 } }),
+  );
 
 /** Mount a tree, settle it, and hand back the root node plus a frame pump.
  * The mount is what `prepare` pays for, so `run` measures only repaints. */
@@ -582,6 +681,44 @@ const SCENARIOS = [
                 absBoxWindow(40 + (i + 1) * 30, '#3498db'),
                 resolve,
               ),
+            );
+            ctl.frame();
+            await settle(app);
+          }
+        },
+      };
+    })(),
+  ],
+  [
+    // Issue #301: five drag steps over a 300-cell scene drawn into ONE
+    // registered element. Each step is a React commit with a new `cells`
+    // array plus the element's own claim on the cell that moved.
+    //
+    // Baselined with both seams live, the way the scroll-blit scenario is:
+    // --check only fails on an increase, so a change that quietly stopped
+    // either of them working lands squarely here — and it takes both, which
+    // is the part worth writing down. The same five steps measured with one
+    // seam at a time, against 239 requests / 0.08 Mpx for the pair:
+    //
+    //   neither                     9054 reqs, 6005 composites, 4.09 Mpx
+    //   selfDamagedProps only       9054 reqs, 6005 composites, 3.35 Mpx
+    //   paintDamage() only          9054 reqs, 6005 composites, 4.09 Mpx
+    //
+    // A scoped commit whose paint cannot read the rect redraws all 300 cells
+    // into a clip that keeps four — the wire cost is identical and only the
+    // server's rasterization narrows. A paint that culls, in a frame the
+    // commit widened to the whole pane, has nothing to cull against.
+    'scene: 5 drag steps over 300 cells in one node',
+    (() => {
+      let ctl;
+      return {
+        prepare: async (app, x11Root) => {
+          ctl = await mounted(x11Root, sceneWindow(sceneCells()));
+        },
+        run: async (app, x11Root) => {
+          for (let i = 0; i < 5; i++) {
+            await new Promise((resolve) =>
+              x11Root.render(sceneWindow(sceneCells(i)), resolve),
             );
             ctl.frame();
             await settle(app);

--- a/src/host.d.ts
+++ b/src/host.d.ts
@@ -48,6 +48,19 @@ export interface ElementDefinition {
    * development.
    */
   semanticNames?: string[];
+  /**
+   * Prop names whose damage this element's own `applyProps` claims — so a
+   * commit that changes one of them contributes no damage of its own,
+   * instead of widening the frame to the whole node.
+   *
+   * For an element that draws a **scene** into one node: a graph view handed
+   * a new `nodes` array per drag step invalidates the box the dragged node
+   * moved through, and without this the commit claims the whole pane over
+   * the top of it. Everything left out keeps core's conservative answer, and
+   * an element that names a prop it does not actually claim shows stale
+   * pixels — see `Node.paintChanged` and docs/extending.md.
+   */
+  selfDamagedProps?: string[];
   /** Reject children, naming this element, instead of laying out something
    * that will never paint. Default true. */
   childrenAllowed?: boolean;

--- a/src/node.d.ts
+++ b/src/node.d.ts
@@ -160,6 +160,11 @@ export declare class Node {
   /** Style names this element owns as its own semantics. Registered
    * elements declare these to `registerElement` instead of overriding. */
   readonly semanticNames: ReadonlySet<string>;
+  /** Prop names whose damage this element's own `applyProps` claims, and
+   * which `paintChanged` therefore does not damage the whole node for.
+   * Empty unless declared — registered elements declare theirs to
+   * `registerElement`, so the common case needs no subclass. */
+  readonly selfDamagedProps: ReadonlySet<string>;
 
   // --- the text this element answers for (docs/extending.md) ---------------
   //
@@ -215,6 +220,34 @@ export declare class Node {
   /** Draw. A subclass calls `super.paint(ctx)` first, for the background,
    * border and clip, then draws inside `this.abs`. */
   paint(ctx: Context2D): void;
+  /**
+   * The rect this paint pass is repainting, or null when it is repainting
+   * the whole window — and null outside a paint, which means the same
+   * thing: nothing is bounding you, so draw everything.
+   *
+   * An element whose node is one node never needs it; being painted at all
+   * means it is inside the pass. An element that draws a **scene** into one
+   * node culls against it the way core culls the tree, instead of redrawing
+   * the scene into a clip that throws most of it away. Window coordinates,
+   * the same space as `abs`; read-only.
+   */
+  paintDamage(): Rect | null;
+  /**
+   * Did anything this node draws change? True damages the whole node, false
+   * contributes no damage at all, and the default answers true for any prop
+   * that is not identical to the one it replaced — conservative, because a
+   * wrong "no" is a stale pixel nothing comes back to fix.
+   *
+   * Overridden by an element that claims its own damage and can say so only
+   * by looking at the values; an element that can say so by *name* declares
+   * `selfDamagedProps` instead. Either way, call `super.paintChanged` for
+   * everything the element does not know about — `style` is compared by the
+   * caller and is never yours to excuse.
+   */
+  paintChanged(
+    nextProps: Record<string, unknown>,
+    prevProps: Record<string, unknown>,
+  ): boolean;
   /**
    * Implemented by an element whose size comes from its content — a gauge, a
    * chart, a terminal, an editor. Called during layout whenever the box's

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -124,6 +124,12 @@ export const DRAWN_KINDS = new Set([
  * element gets the exemption without subclassing the getter. */
 export const CUSTOM_SEMANTIC_NAMES = new Map();
 
+/** kind -> prop names a registered element claims the damage for itself.
+ * Filled by registry.js, read by `Node.selfDamagedProps` — the same
+ * arrangement as above, for the other declaration a scene-drawing element
+ * makes (issue #301). */
+export const CUSTOM_SELF_DAMAGED = new Map();
+
 // X ConfigureWindow stack-mode: Below places the window directly under the
 // named sibling (X11 protocol, ConfigureWindow).
 const STACK_BELOW = 1;
@@ -611,6 +617,11 @@ function assertNoFlatStyleProps(props, kind, semantic) {
 // it. `<window width>` is the X window's width; `<box width>` would be yoga
 // style, and there is no element where a name means both.
 const NO_SEMANTIC_NAMES = new Set();
+
+// And the default for the other declaration: an element that has not said
+// otherwise claims nothing for itself, so every prop it holds is core's to
+// be conservative about.
+const NO_SELF_DAMAGED = new Set();
 
 // X window geometry is CARD16 and coordinates are INT16, so a window wider
 // than this cannot be positioned or damaged coherently even where the server
@@ -1507,6 +1518,20 @@ export class Node {
   }
 
   /**
+   * Prop names whose damage this element's own `applyProps` claims, and
+   * which `paintChanged` therefore does not claim the whole node for.
+   *
+   * Empty for everything that has not said otherwise, which is what keeps
+   * the default conservative. Registered elements declare theirs to
+   * `registerElement`, so the common case needs no subclass; an element
+   * whose answer depends on the *values* rather than the names overrides
+   * `paintChanged` instead.
+   */
+  get selfDamagedProps() {
+    return CUSTOM_SELF_DAMAGED.get(this.kind) ?? NO_SELF_DAMAGED;
+  }
+
+  /**
    * The theme in force here: the nearest `theme` prop at or above this node,
    * with an inner one merged over the outer so a panel can restate a colour
    * or two without repeating a palette. Popups resolve through their place
@@ -2068,9 +2093,15 @@ export class Node {
     if (layoutChanged) {
       this._invalidateLayout('props');
     } else {
+      // The style half is asked here rather than inside `paintChanged`, and
+      // stays core's answer: what a style change moves is the background,
+      // the border and the clip that `Node.paint` draws, so an element is
+      // not in a position to excuse one.
+      const styleChanged =
+        style !== prevStyle && paintPropsChanged(style, prevStyle);
       this.root?.invalidate(
         false,
-        this._paintChanged(newProps, prev, style, prevStyle) ? this : NO_DAMAGE,
+        styleChanged || this.paintChanged(newProps, prev) ? this : NO_DAMAGE,
         'props',
       );
     }
@@ -2079,16 +2110,12 @@ export class Node {
   }
 
   /**
-   * Did anything this node *draws* change?
+   * Did anything this node *draws* change? Answering true damages the whole
+   * node; answering false contributes no damage at all.
    *
    * Deliberately conservative, because the cost of a wrong "no" is a stale
-   * pixel that nothing will come back to fix. Paint-relevant style is asked
-   * about by value, so a style object React rebuilt with the same contents
-   * costs nothing — that is the whole point, since React rebuilds sibling
-   * styles on every render and a commit would otherwise damage every node it
-   * walked.
-   *
-   * Everything else falls back to "yes it changed", which is what makes this
+   * pixel that nothing will come back to fix. A prop that is not equal to
+   * the one it replaced is "yes it changed", which is what makes the default
    * safe without knowing about subclasses: `<image src>`, `<canvas onDraw>`,
    * a `value`, a `placeholder`, a `caretColor` — any prop a subclass paints
    * from is a prop, so a change to it lands here as an inequality and damages
@@ -2098,13 +2125,38 @@ export class Node {
    *  - `children`, which the reconciler mutates through appendChild /
    *    removeChild / commitTextUpdate, each of which invalidates on its own;
    *  - event handlers, rebuilt every render and never painted;
-   *  - `style`, already compared by value above.
+   *  - `style`, compared by value by the caller — so a style object React
+   *    rebuilt with the same contents costs nothing, which is the whole
+   *    point, since React rebuilds sibling styles on every render and a
+   *    commit would otherwise damage every node it walked.
+   *
+   * **The seam (issue #301).** "The node" is the wrong granularity for an
+   * element that draws a *scene*: a graph view handed a new `nodes` array
+   * every drag step has already claimed the box the dragged node moved
+   * through, and this answering "yes" over the top widens that to the whole
+   * pane and throws the scoped work away. Such an element either names those
+   * props in `selfDamagedProps` — the declarative form, and what
+   * `registerElement({ selfDamagedProps })` fills — or overrides this method
+   * when the answer depends on the values rather than the names:
+   *
+   * ```js
+   * paintChanged(next, prev) {
+   *   // my own applyProps diffed these and claimed exactly what moved
+   *   if (onlyPositionsMoved(next.nodes, prev.nodes)) return false;
+   *   return super.paintChanged(next, prev);   // everything else is core's
+   * }
+   * ```
+   *
+   * An override that answers wrong shows stale pixels, so the part it does
+   * not know about has to reach `super` — a new `aria-label`, a prop the
+   * element grows next year.
    */
-  _paintChanged(newProps, prev, style, prevStyle) {
-    if (style !== prevStyle && paintPropsChanged(style, prevStyle)) return true;
+  paintChanged(newProps, prev) {
+    const claimed = this.selfDamagedProps;
     const keys = new Set([...Object.keys(newProps), ...Object.keys(prev)]);
     for (const key of keys) {
       if (key === 'children' || key === 'style' || isEventProp(key)) continue;
+      if (claimed.has(key)) continue;
       if (newProps[key] !== prev[key]) return true;
     }
     return false;
@@ -2496,6 +2548,34 @@ export class Node {
    */
   invalidate(layoutChanged = false, damage = null, reason = null) {
     this.root?.invalidate(layoutChanged, damage, reason);
+  }
+
+  /**
+   * The rect this paint pass is repainting, or null when it is repainting
+   * the whole window — and null outside a paint, which reads the same way:
+   * nothing is bounding you, so draw everything (issue #301).
+   *
+   * The other end of `invalidate`. A frame repaints one damage rect per
+   * pass, clipped to it and with whole subtrees outside it culled, so an
+   * element whose node *is* one node — a `<box>`, a `<text>` — never needs
+   * this: being painted at all already means it is inside. An element that
+   * draws a **scene** into one node does: without it, a `<flow>` handed a
+   * pass over the 80×40 box a dragged node moved through redraws all three
+   * hundred nodes, all seven hundred edges, the grid and the minimap into a
+   * clip that throws almost all of it away. With it, the element culls the
+   * same way core culls the tree.
+   *
+   * Window coordinates, the same space as `abs`, `contentBox()` and an
+   * event's `x`/`y`. Read-only, like `abs`: it is this frame's own rect and
+   * the clip is already set from it.
+   *
+   * Never inside `paintCached`, which draws into a surface in its own
+   * coordinates: a cached copy culled against the window's damage is stored
+   * half-drawn under a key claiming it is whole, and every later frame that
+   * hits the key gets the hole.
+   */
+  paintDamage() {
+    return this.root?._paintDamage ?? null;
   }
 
   /**
@@ -4396,7 +4476,7 @@ export class CanvasNode extends Node {
     super.applyProps(newProps, oldProps);
     // onDraw is read at paint time, so a new closure means new content — but
     // it also matches /^on[A-Z]/, which is how the base class recognises an
-    // event handler, so `_paintChanged` skips it and this is the only place
+    // event handler, so `paintChanged` skips it and this is the only place
     // that notices. Damage is bounded to this canvas: an unbounded call here
     // made every re-render of a component that draws through <canvas> repaint
     // the whole window, which is what a Checkbox's tick and a Select's chevron

--- a/src/registry.js
+++ b/src/registry.js
@@ -20,7 +20,16 @@
 //   vocabulary — `width`, `stroke`, `opacity` — throws on its own props in
 //   development and works in production, which is the worst shape a bug
 //   can have.
-import { DRAWN_KINDS, CUSTOM_SEMANTIC_NAMES, Node } from './nodes.js';
+//
+// And one that is an optimisation rather than a trap, `selfDamagedProps`,
+// which is the commit half of the damage seam `Node.paintDamage()` opens
+// (issue #301).
+import {
+  DRAWN_KINDS,
+  CUSTOM_SEMANTIC_NAMES,
+  CUSTOM_SELF_DAMAGED,
+  Node,
+} from './nodes.js';
 
 /** kind -> definition. Insertion-ordered, which is the order errors list. */
 const registry = new Map();
@@ -79,6 +88,12 @@ function assertNode(node, type) {
  *   window instead (`GlAreaNode` is the worked example).
  * @param {string[]} [definition.semanticNames] prop names this element owns
  *   even though they are also style names.
+ * @param {string[]} [definition.selfDamagedProps] prop names whose damage
+ *   the element's own `applyProps` claims, so a commit that changes one does
+ *   not also damage the whole node. For an element that draws a scene into
+ *   one node and invalidates the part of it that moved; an element that
+ *   answers wrong shows stale pixels, so everything left out stays core's
+ *   conservative answer (docs/extending.md).
  * @param {boolean} [definition.childrenAllowed=true] reject children in DEV
  *   with a message naming the element, rather than laying out something
  *   that cannot paint.
@@ -122,6 +137,7 @@ export function registerElement(type, definition) {
     create,
     drawn = true,
     semanticNames = [],
+    selfDamagedProps = [],
     childrenAllowed = true,
   } = definition;
 
@@ -137,6 +153,15 @@ export function registerElement(type, definition) {
   } else {
     CUSTOM_SEMANTIC_NAMES.delete(type);
   }
+
+  // Both maps are keyed on the kind and cleared when the name is not
+  // claimed, so re-registering with `override` cannot leave the previous
+  // definition's declarations behind for the new one to inherit.
+  if (selfDamagedProps.length > 0) {
+    CUSTOM_SELF_DAMAGED.set(type, new Set(selfDamagedProps));
+  } else {
+    CUSTOM_SELF_DAMAGED.delete(type);
+  }
 }
 
 /** Undo a registration. Mostly for tests, which must not leak an element
@@ -144,6 +169,7 @@ export function registerElement(type, definition) {
 export function unregisterElement(type) {
   DRAWN_KINDS.delete(type);
   CUSTOM_SEMANTIC_NAMES.delete(type);
+  CUSTOM_SELF_DAMAGED.delete(type);
   return registry.delete(type);
 }
 

--- a/test/element-damage.test.js
+++ b/test/element-damage.test.js
@@ -1,0 +1,399 @@
+// The damage seam an element that draws a *scene* needs (issue #301).
+//
+// Core's damage machinery already coalesces claims into disjoint rects,
+// paints one clipped pass per rect, and culls whole subtrees against the one
+// being painted. Its granularity is the retained node — which is exactly
+// right until the node *is* the whole pane, as it is for a graph view, a
+// chart or an editor that draws its content rather than laying it out. Both
+// ends of that conversation are opened here:
+//
+//  - `paintDamage()` — the rect the pass being painted covers, so the
+//    element can cull its own drawing the way core culls the tree;
+//  - `selfDamagedProps` and the `paintChanged` it feeds — a commit that
+//    changes a prop whose damage the element has already claimed itself
+//    contributes none of its own, instead of widening the frame to the
+//    whole pane over the top of the scoped claim.
+//
+// The pixel test below is the one that matters. Everything else here asserts
+// what an element is *told*; that one asserts that acting on it is safe — a
+// rect handed out that is not exactly the pass's clip shows up as a cell the
+// culling wrongly dropped, and the two readbacks stop being identical.
+import assert from 'node:assert';
+import { test, afterEach } from 'node:test';
+import React from 'react';
+
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient } from 'ntk';
+
+import { createRoot } from '../src/index.js';
+import { registerElement, unregisterElement } from '../src/host.js';
+import { Node } from '../src/node.js';
+import { renderX11, cleanup, screen } from '../src/testing/index.js';
+
+const h = React.createElement;
+
+const W = 200;
+const H = 120;
+
+const registered = new Set();
+function register(type, definition) {
+  registerElement(type, definition);
+  registered.add(type);
+}
+
+afterEach(async () => {
+  await cleanup();
+  for (const type of registered) unregisterElement(type);
+  registered.clear();
+});
+
+/**
+ * An element that draws a scene into one node: a grid of coloured cells,
+ * each culled against the pass's rect. `passes` records what every paint was
+ * told, and `drawn` how many cells that paint actually emitted — the number
+ * the issue is about.
+ */
+class SceneNode extends Node {
+  constructor(props, app) {
+    super('scene', props, app);
+    this.passes = [];
+    this.drawn = [];
+  }
+
+  cells() {
+    const cols = this.props.cols ?? 4;
+    const rows = this.props.rows ?? 3;
+    const { x, y, width, height } = this.abs;
+    const cw = width / cols;
+    const ch = height / rows;
+    const out = [];
+    for (let row = 0; row < rows; row++) {
+      for (let col = 0; col < cols; col++) {
+        out.push({
+          x: x + col * cw,
+          y: y + row * ch,
+          width: cw,
+          height: ch,
+          color: this.props.colors?.[row * cols + col] ?? '#3498db',
+        });
+      }
+    }
+    return out;
+  }
+
+  paint(ctx) {
+    super.paint(ctx);
+    const damage = this.paintDamage();
+    this.passes.push(damage);
+    let drawn = 0;
+    for (const cell of this.cells()) {
+      // the cull the seam exists for: a cell the pass cannot show is a cell
+      // whose requests never go on the wire
+      if (damage && !overlaps(cell, damage)) continue;
+      ctx.fillStyle = cell.color;
+      ctx.fillRect(cell.x, cell.y, cell.width, cell.height);
+      drawn++;
+    }
+    this.drawn.push(drawn);
+  }
+}
+
+const overlaps = (a, b) =>
+  a.x < b.x + b.width &&
+  b.x < a.x + a.width &&
+  a.y < b.y + b.height &&
+  b.y < a.y + a.height;
+
+// --- what the element is told --------------------------------------------
+
+async function mountScene(props = {}) {
+  await renderX11(h('scene', { style: { flexGrow: 1 }, ...props }), {
+    backend: 'mock',
+    width: W,
+    height: H,
+  });
+  const node = screen.all((n) => n.kind === 'scene')[0];
+  node.passes.length = 0;
+  node.drawn.length = 0;
+  return node;
+}
+
+test('paintDamage() is the rect of the pass being painted (#301)', async () => {
+  register('scene', { create: (p, a) => new SceneNode(p, a) });
+  const node = await mountScene();
+  const root = node.root;
+
+  assert.strictEqual(
+    node.paintDamage(),
+    null,
+    'outside a paint nothing bounds you, which reads the same as a full pass',
+  );
+
+  node.invalidate(false, { x: 10, y: 10, width: 30, height: 20 }, 'props');
+  root.flush();
+  assert.deepStrictEqual(
+    node.passes,
+    [{ x: 10, y: 10, width: 30, height: 20 }],
+    'one pass, told exactly the rect the frame clipped to',
+  );
+  assert.strictEqual(
+    node.paintDamage(),
+    null,
+    'and it is null again the moment the pass is over',
+  );
+
+  // 4x3 cells of 50x40 over the pane: the claim lands inside one of them
+  assert.deepStrictEqual(node.drawn, [1], 'the other eleven never drew');
+});
+
+test('one pass per damage rect, each with its own bound', async () => {
+  register('scene', { create: (p, a) => new SceneNode(p, a) });
+  const node = await mountScene();
+  const root = node.root;
+
+  // far apart, so the frame keeps them as two passes rather than merging
+  // into the box around them (damageToPaint's area test)
+  node.invalidate(false, { x: 4, y: 4, width: 20, height: 20 }, 'props');
+  node.invalidate(false, { x: 170, y: 90, width: 20, height: 20 }, 'props');
+  root.flush();
+
+  assert.deepStrictEqual(node.passes, [
+    { x: 4, y: 4, width: 20, height: 20 },
+    { x: 170, y: 90, width: 20, height: 20 },
+  ]);
+  assert.deepStrictEqual(node.drawn, [1, 1], 'one cell per pass');
+});
+
+test('an unbounded frame says so with null, and the element draws it all', async () => {
+  register('scene', { create: (p, a) => new SceneNode(p, a) });
+  const node = await mountScene();
+  const root = node.root;
+
+  node.invalidate(false, null, 'props');
+  root.flush();
+
+  assert.deepStrictEqual(node.passes, [null], 'no bound is null, not a rect');
+  assert.deepStrictEqual(node.drawn, [12], 'so every cell is drawn');
+});
+
+// --- that acting on it is safe -------------------------------------------
+
+async function headlessApp() {
+  const server = xserver.createServer({ width: 640, height: 480 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  return createClient({ stream: clientEnd });
+}
+
+const settle = (app) =>
+  new Promise((resolve, reject) =>
+    app.X.GetInputFocus((err) => (err ? reject(err) : resolve())),
+  );
+
+async function image(app, root) {
+  const ctx = (root._ctx ??= root.window.getContext('2d'));
+  const data = await new Promise((resolve, reject) =>
+    ctx.getImageData(0, 0, W, H, (err, d) => (err ? reject(err) : resolve(d))),
+  );
+  return Buffer.from(data.data);
+}
+
+test('a cull against paintDamage() paints what a full repaint paints', async () => {
+  register('scene', { create: (p, a) => new SceneNode(p, a) });
+  const app = await headlessApp();
+  const x11Root = await createRoot({ app });
+  try {
+    const ref = React.createRef();
+    const colors = Array.from({ length: 12 }, (_, i) =>
+      i % 2 ? '#e74c3c' : '#2ecc71',
+    );
+    await new Promise((resolve) =>
+      x11Root.render(
+        h(
+          'window',
+          { width: W, height: H, style: { backgroundColor: '#101820' } },
+          h('scene', { ref, colors, style: { flexGrow: 1 } }),
+        ),
+        resolve,
+      ),
+    );
+    await new Promise((r) => setImmediate(r));
+    const node = ref.current;
+    const root = node.root;
+    root.flush();
+    await settle(app);
+
+    // the drag step: one cell changes colour, and the element claims exactly
+    // that cell — the scoped invalidate the whole seam is for
+    const cell = node.cells()[6];
+    node.props.colors[6] = '#f1c40f';
+    node.passes.length = 0;
+    node.drawn.length = 0;
+    node.invalidate(false, cell, 'props');
+    root.flush();
+    await settle(app);
+    const partial = await image(app, root);
+
+    assert.ok(node.passes[0], 'the frame was bounded');
+    assert.deepStrictEqual(
+      node.drawn,
+      [1],
+      'and the element drew one cell, not twelve',
+    );
+
+    // the same tree again with the bound thrown away
+    root.needsPaint = true;
+    root._damage = null;
+    root.flush();
+    await settle(app);
+    const full = await image(app, root);
+
+    assert.deepStrictEqual(node.passes[1], null, 'the second frame was full');
+    assert.deepStrictEqual(node.drawn[1], 12);
+    assert.ok(
+      partial.equals(full),
+      'a pass the element culled against is pixel-identical to a full one',
+    );
+  } finally {
+    await x11Root.unmount?.();
+    app.close?.();
+  }
+});
+
+// --- the commit side ------------------------------------------------------
+
+/**
+ * What the commit half is asked, without a frame clock in the way: reset the
+ * window's bookkeeping, hand the node a props update the way the reconciler
+ * does, and read back what it claimed.
+ */
+function commit(node, next) {
+  const root = node.root;
+  root.needsPaint = false;
+  root._damage = null;
+  const prev = node.props;
+  node.applyProps({ ...prev, ...next }, prev);
+  return { needsPaint: root.needsPaint, damage: root._damage };
+}
+
+test('selfDamagedProps: a claimed prop contributes no damage of its own', async () => {
+  register('scene', {
+    create: (p, a) => new SceneNode(p, a),
+    selfDamagedProps: ['colors'],
+  });
+  const node = await mountScene({ colors: ['#111111'] });
+
+  assert.deepStrictEqual(
+    [...node.selfDamagedProps],
+    ['colors'],
+    'the declaration reaches the node',
+  );
+
+  // a controlled scene rebuilds this array every commit; the element's own
+  // applyProps is what claims the box that moved
+  const claimed = commit(node, { colors: ['#222222'] });
+  assert.deepStrictEqual(
+    claimed,
+    { needsPaint: false, damage: null },
+    'no frame is owed by the commit at all',
+  );
+
+  // and everything else keeps core's conservative answer
+  const other = commit(node, { 'aria-label': 'graph' });
+  assert.strictEqual(other.needsPaint, true);
+  assert.deepStrictEqual(
+    other.damage,
+    [node.paintBounds()],
+    'a prop the element said nothing about still damages the node',
+  );
+});
+
+test('a style change is core’s answer, not the element’s to excuse', async () => {
+  register('scene', {
+    create: (p, a) => new SceneNode(p, a),
+    // even a wildly over-claiming element
+    selfDamagedProps: ['colors', 'style'],
+  });
+  const node = await mountScene({ colors: ['#111111'] });
+
+  const restyled = commit(node, {
+    colors: ['#222222'],
+    style: { flexGrow: 1, backgroundColor: '#ff00ff' },
+  });
+  assert.strictEqual(
+    restyled.needsPaint,
+    true,
+    'the background, the border and the clip are drawn by core',
+  );
+  assert.deepStrictEqual(restyled.damage, [node.paintBounds()]);
+});
+
+test('paintChanged: the override form, for an answer only the values give', async () => {
+  // The <Flow> shape: a new `nodes` array every drag step, whose damage the
+  // element claims itself *when the change is only positions*. Anything else
+  // — a node added, a label edited — falls through to core.
+  class FlowNode extends SceneNode {
+    paintChanged(next, prev) {
+      if (
+        next.nodes !== prev.nodes &&
+        samePositionsOnly(next.nodes, prev.nodes)
+      )
+        return false;
+      return super.paintChanged(next, prev);
+    }
+  }
+  const samePositionsOnly = (next, prev) =>
+    Array.isArray(next) &&
+    Array.isArray(prev) &&
+    next.length === prev.length &&
+    next.every((n, i) => n.id === prev[i].id && n.label === prev[i].label);
+
+  register('scene', { create: (p, a) => new FlowNode(p, a) });
+  const nodes = [{ id: 'a', label: 'A', x: 0 }];
+  const node = await mountScene({ nodes });
+
+  const moved = commit(node, { nodes: [{ id: 'a', label: 'A', x: 40 }] });
+  assert.deepStrictEqual(
+    moved,
+    { needsPaint: false, damage: null },
+    'a position-only step is the element’s own claim and nothing else',
+  );
+
+  const relabelled = commit(node, { nodes: [{ id: 'a', label: 'B', x: 40 }] });
+  assert.strictEqual(
+    relabelled.needsPaint,
+    true,
+    'anything the override does not recognise reaches super',
+  );
+
+  const other = commit(node, { title: 'graph' });
+  assert.strictEqual(other.needsPaint, true, 'and so does every other prop');
+});
+
+test('the declaration is per registration, and leaves with it', async () => {
+  register('scene', {
+    create: (p, a) => new SceneNode(p, a),
+    selfDamagedProps: ['colors'],
+  });
+  const node = await mountScene({ colors: ['#111111'] });
+  assert.strictEqual(node.selfDamagedProps.has('colors'), true);
+  assert.strictEqual(commit(node, { colors: ['#222222'] }).needsPaint, false);
+
+  // re-registering must not leave the previous definition's claims behind
+  register('scene', { create: (p, a) => new SceneNode(p, a), override: true });
+  assert.strictEqual(node.selfDamagedProps.size, 0);
+  assert.strictEqual(
+    commit(node, { colors: ['#222222'] }).needsPaint,
+    true,
+    'and the conservative answer is back',
+  );
+
+  register('scene', {
+    create: (p, a) => new SceneNode(p, a),
+    selfDamagedProps: ['colors'],
+    override: true,
+  });
+  unregisterElement('scene');
+  registered.delete('scene');
+  assert.strictEqual(node.selfDamagedProps.size, 0);
+});

--- a/test/text-restyle.test.js
+++ b/test/text-restyle.test.js
@@ -4,7 +4,7 @@
 // `textAlign` are the inputs to a `<text>`'s measure function, and none of
 // them is a yoga property or a paint property. So a commit that changes one
 // and nothing else reaches `applyProps` with nothing for `applyLayoutStyle`
-// to notice and nothing for `_paintChanged` to claim — the frame is already
+// to notice and nothing for `paintChanged` to claim — the frame is already
 // decided by the time `TextNode.applyProps` marks the layout dirty. Ask for
 // no relayout there and the cleared layout is never rebuilt: React's state
 // is new, the node's props are new, the font manager hands back the right

--- a/test/types/extend.tsx
+++ b/test/types/extend.tsx
@@ -67,6 +67,10 @@ declare module '../../src/jsx-runtime.js' {
         // synthetic event rather than the DOM's same-named one
         onKeyDown?: (ev: KeyboardEvent) => void;
       };
+      flow: {
+        nodes: { id: string; x: number; y: number }[];
+        style?: Style;
+      };
     }
   }
 }
@@ -334,6 +338,55 @@ registerElement('miniticker', {
   childrenAllowed: false,
 });
 
+// An element that draws a whole scene into one node (#301): it reads the
+// rect of the pass it is being painted for, and the damage for the props it
+// diffs itself is its own to claim. Both shapes of the commit half are here
+// so both compile; a real element picks the one that fits.
+class FlowNode extends Node {
+  constructor(props: Record<string, unknown>, app: never) {
+    super('flow', props, app);
+  }
+
+  paintContent(_ctx: unknown): void {
+    // null outside a paint and on an unbounded one, and both read the same:
+    // nothing bounds you, draw the lot
+    const damage: Rect | null = this.paintDamage();
+    for (const box of this.routedBounds()) {
+      if (damage && box.x > damage.x + damage.width) continue;
+      void box;
+    }
+  }
+
+  routedBounds(): Rect[] {
+    return [this.contentBox()];
+  }
+
+  applyProps(
+    next: Record<string, unknown>,
+    prev: Record<string, unknown>,
+  ): void {
+    const before = prev ?? this.props;
+    super.applyProps(next, prev);
+    // …so the only claim for a drag step is the box that actually moved
+    if (next.nodes !== before.nodes) this.invalidate(false, this.abs, 'props');
+  }
+
+  paintChanged(
+    next: Record<string, unknown>,
+    prev: Record<string, unknown>,
+  ): boolean {
+    const claimed: ReadonlySet<string> = this.selfDamagedProps;
+    if (claimed.has('nodes') && next.nodes !== prev.nodes) return false;
+    return super.paintChanged(next, prev);
+  }
+}
+
+registerElement('flow', {
+  create: (props, app) => new FlowNode(props, app as never),
+  semanticNames: ['nodes'],
+  selfDamagedProps: ['nodes'],
+});
+
 registerElement('gauge', {
   create: (props, app) => new GaugeNode(props, app as never),
   semanticNames: ['ticks'],
@@ -368,6 +421,7 @@ function Chart() {
       <thumb />
       {/* an app handler and the element's own behaviour, composed */}
       <codeeditor value="const x = 1" onKeyDown={(ev) => void ev.keysym} />
+      <flow nodes={[{ id: 'a', x: 0, y: 0 }]} />
     </box>
   );
 }


### PR DESCRIPTION
Closes #301.

Core's damage machinery already coalesces claims into disjoint rects, paints one clipped pass per rect, and culls whole subtrees against the pass being painted. Its granularity is the retained node — right until the node **is** the scene. Then a pass over the 80×40 box a dragged node moved through redraws all three hundred nodes, all seven hundred edges, the grid and the minimap into a clip that keeps almost none of it; and the commit that caused it damages the whole pane over the top of the element's own scoped claim.

Two accessors, the two ends of the same conversation. Both opt-in, both leaving core's conservative answer wherever nothing is said.

## Painting: `Node.paintDamage()`

The rect of the pass, in the owning window's coordinates — the same space as `abs` and a mouse event's `x`/`y` — or `null` for a full pass. Also `null` outside a paint, which reads the same way: nothing bounds you, draw everything.

```js
paintContent(ctx) {
  const damage = this.paintDamage();
  for (const cell of this.gridCells()) {
    if (damage && !overlaps(cell, damage)) continue;
    this.drawCell(ctx, cell);
  }
}
```

## Committing: `selfDamagedProps`, or `paintChanged`

`applyProps` damages the whole node when any non-event prop changes identity. A controlled graph app commits a new `nodes` array per drag step, so each step was one scoped invalidate from the gesture plus one full-pane claim from the commit — and the commit won.

```js
registerElement('flow', {
  create: (props, app) => new FlowNode(props, app),
  selfDamagedProps: ['nodes', 'edges'],   // "my applyProps claims these"
});
```

When the answer depends on the values rather than the names, the private `_paintChanged` is now the documented, overridable **`paintChanged(next, prev)`** that the list feeds — so the two are one seam, not two:

```js
paintChanged(next, prev) {
  if (onlyPositionsMoved(next.nodes, prev.nodes)) return false;
  return super.paintChanged(next, prev);   // everything else is core's
}
```

Three rules, in the order they bite: everything an override does not recognise reaches `super`, because a wrong "nothing changed" is a stale pixel nothing comes back to fix; a **style** change is never yours to excuse, since what it moves is the background, the border and the clip `Node.paint` draws, and it is compared by value by the caller rather than inside either seam; and `selfDamagedProps` only says the commit will not claim — it claims nothing on your behalf.

## Measured

New bench scenario — five drag steps over a 300-cell scene drawn into one registered element, `npm run bench`:

| | requests | composites | Mpx |
| --- | --- | --- | --- |
| neither seam | 9054 | 6005 | 4.09 |
| `selfDamagedProps` only | 9054 | 6005 | 3.35 |
| `paintDamage()` only | 9054 | 6005 | 4.09 |
| **both** | **239** | **133** | **0.08** |

Either alone buys nothing, which is the part worth having in writing: a scoped commit whose paint cannot read the rect still emits all 300 cells and only the server's rasterization narrows, and a paint that culls has nothing to cull against in a frame the commit widened to the pane. The scenario is baselined with both live, so a change that quietly stops either working fails `npm run bench -- --check`.

## Tests

`test/element-damage.test.js`. The pixel test is the one that matters: an element that culls against `paintDamage()` reads back **byte-identical** to a full repaint of the same tree, against a real X server. Mutating `paintDamage()` to under-report by 60px fails exactly that assertion; returning `null` unconditionally fails the three paint-side tests; dropping the `selfDamagedProps` skip fails the commit-side one.

The rest: one pass per damage rect with its own bound, `null` for an unbounded frame, a claimed prop contributing no damage while every other prop still damages the node, a style change still claiming through an element that over-declares, the `paintChanged` override reaching `super`, and the registry clearing a declaration on `override`/`unregisterElement`.

## Also

- `docs/extending.md` gains "Drawing a scene into one node", the two new definition/override table rows and the `paintDamage()` reader; `docs/debugging.md` notes that a tight outline can sit over a pane that redrew all of itself; `src/node.d.ts` and `src/host.d.ts` declare the three members and `test/types/extend.tsx` compiles a `<flow>` that uses them.
- `_paintChanged` had no public callers, so this is additive: no `BREAKING CHANGE` footer.
- No screenshots — by construction this PR changes no pixels, which is what the pixel-equality test asserts.
- The bench baseline diff is my scenario only. `mount: window with 40 boxes and labels` and `svg: 100 unchanged icons` have drifted slightly on master since the ntk 7.6.1 bump in #300 — reproduced at `ceb9da5` with this branch's changes absent — so I left those entries alone rather than absorbing someone else's drift into this diff.
