### PR TITLE
feat(extending): the wheel and the hover a registered element can answer

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -17,11 +17,13 @@ events dispatched over the drawn node tree with DOM-like semantics.
 
 Step 4 is a documented seam, not a privilege of the built-in elements: an
 element added with `registerElement` implements the same `defaultKeyDown` /
-`defaultMouseDown` / … methods and gets the same ordering
-([extending.md](extending.md#behaviour-of-your-own)). The wheel's default
-action is the same story in a different shape — it walks out from the target
-asking each node `canScroll(deltaX, deltaY)`, so an element that scrolls
-content it painted joins the chain by answering
+`defaultMouseDown` / `defaultMouseMove` / … methods and gets the same
+ordering ([extending.md](extending.md#behaviour-of-your-own)). The wheel has
+one more layer than the rest: the node under the pointer gets `defaultWheel`
+first — for a pane whose wheel is a zoom rather than a scroll — and unless it
+consumes the event, the scroll chain walks outward from the target asking
+each node `canScroll(deltaX, deltaY)`, which is how an element that scrolls
+content it painted joins in
 ([extending.md](extending.md#scrolling-content-you-painted)).
 
 `ev.stopPropagation()` stops the walk. Handlers always read from current
@@ -213,9 +215,12 @@ inside an open menu moves a notch at a time. Needs ntk >= 7.5.0.
 
 Shift turns a vertical scroll sideways for a device with only one axis (the
 convention every toolkit follows); a device that reports its own horizontal
-axis keeps what it reported. The default action is the scroll chain — see
+axis keeps what it reported. The default action is the hit node's own
+`defaultWheel` and then the scroll chain — see
+[extending.md](extending.md#behaviour-of-your-own) for the element whose
+wheel is a zoom rather than a scroll, and
 [extending.md](extending.md#scrolling-content-you-painted) for how anything
-joins it.
+joins the chain.
 
 ## Composition: dead keys and Compose {#composition}
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -420,6 +420,9 @@ a React component wrapping the element.
 | `defaultMouseDown(ev)`   | a press. Place a caret, grab a handle; `ev.capturePointer()` to keep the rest of the gesture                                                                                                                                |
 | `defaultMouseDrag(ev)`   | motion while _this_ element holds the press — including outside its box, which `onMouseMove` does not give you                                                                                                              |
 | `defaultMouseUp(ev)`     | that press was released                                                                                                                                                                                                     |
+| `defaultMouseMove(ev)`   | the pointer moved over this element, no button down — light the node, the edge, the handle it is over. The first one after it arrives is the enter                                                                          |
+| `defaultMouseLeave(ev)`  | …and the pointer left: put that back                                                                                                                                                                                        |
+| `defaultWheel(ev)`       | the wheel, before the scroll chain — for the element whose wheel is not a scroll. `ev.preventDefault()` consumes it                                                                                                         |
 | `defaultContextMenu(ev)` | right-click, after the press: open your own menu. Separate so suppressing it keeps the caret placement                                                                                                                      |
 | `defaultFocus(info)`     | this element became the focused node (or its window got the X focus back): start the caret blinking. `info` is `{ reason, backwards }` — `'key'` with a direction is a Tab, which is the only thing that has ever needed it |
 | `defaultBlur()`          | focus left, or the window lost it: stop it                                                                                                                                                                                  |
@@ -472,13 +475,46 @@ class EditorNode extends Node {
 }
 ```
 
-Four details worth having in writing:
+Details worth having in writing:
 
 **A gesture is vetoed once, at its press.** `defaultMouseDrag` and
 `defaultMouseUp` are the continuation of the press `defaultMouseDown` got, so
 a handler that prevented the press means none of the three run — an element
 never hears about motion it has no press behind, and does not need a
 `dragging` flag of its own to discover that.
+
+**Hover is motion, not a state you are handed.** `defaultMouseMove` runs for
+the element the pointer is over — coalesced to once per frame, like every
+motion — and `defaultMouseLeave` when it goes elsewhere, which is everything
+a scene element needs to light the node, edge or handle under the pointer and
+put it back. There is no `defaultMouseEnter`: the first motion after the
+pointer arrives _is_ the enter, and it carries the position an enter would
+have to be asked for. A capture suspends the pair — while a gesture owns the
+pointer, hover stays frozen where it was and the motion goes to
+`defaultMouseDrag` instead. And a node that unmounts while hovered is
+_forgotten_ rather than left, exactly as one that unmounts while focused is,
+so anything with a lifetime behind the highlight is released in
+`destroySubtree` as well.
+
+**The wheel that is not a scroll.** `canScroll`/`scrollBy`
+([below](#scrolling-content-you-painted)) route the wheel for content that
+scrolls, and they hand the element deltas only — which is the whole of the
+gesture when the answer is "move by that much". It is not the whole of a zoom
+about the pointer: that needs the point that must _not_ move (`ev.x`/`ev.y`)
+and the modifier that tells a zoom from a pan, and it answers the wheel
+whether or not anything "can scroll". `defaultWheel(ev)` is the whole event,
+at the node under the pointer, before the chain walks; `ev.preventDefault()`
+consumes it and the walk never runs. The deltas are as the device measured
+them, fractions included — the whole-pixel rule the chain follows is there
+for the scroll blit, and a zoom factor is continuous.
+
+```js
+defaultWheel(ev) {
+  if (!ev.ctrlKey) return;             // an unmodified wheel still scrolls
+  this.zoomAbout(ev.x, ev.y, Math.exp(-ev.deltaY / 400));
+  ev.preventDefault();                 // …and this one was mine
+}
+```
 
 **Focus is a prerequisite, not a consequence.** Keys are delivered to the
 focused node, and nothing focuses an element that has not said it can be:
@@ -733,6 +769,12 @@ which is what a browser does and what a user flicking through a long page
 expects. `<textarea>` is the worked example in core — it scrolls wrapped text
 it painted, and since it answers `canScroll` off that text, a short one hands
 the gesture outward rather than swallowing it.
+
+The one thing ahead of the walk is the hit node's own `defaultWheel`
+([above](#behaviour-of-your-own)) — for an element whose wheel is not a
+scroll at all, a pane that zooms about the pointer. Consuming the event there
+is what keeps the walk from running; leaving it alone is what puts the
+element back in this chain.
 
 Answer `canScroll` from the **extent, not the position**: a viewport already
 scrolled to its bottom should keep the rest of a flick rather than pass it

--- a/src/events.js
+++ b/src/events.js
@@ -444,6 +444,23 @@ export class EventManager {
         smooth: Boolean(native.smooth),
       });
       if (ev.defaultPrevented) return;
+      // The element's own wheel, ahead of the scroll chain and in its own
+      // shape: the whole event, at the node the pointer is over. A graph
+      // pane's wheel is a zoom about the pointer, which needs the point that
+      // must not move (`ev.x`/`ev.y`) and the modifiers that say zoom from
+      // pan — neither of which a protocol handing out deltas can carry — and
+      // it answers the gesture whether or not anything "can scroll". An
+      // element whose wheel *is* a scroll stays on `canScroll`/`scrollBy`
+      // below; this is for the ones whose wheel is not (issue #302).
+      //
+      // It reads the delta before the truncation, fractions and all: whole
+      // pixels are the scroll blit's business, and a zoom factor is
+      // continuous.
+      target.defaultWheel?.(ev);
+      // …and consuming it ends the event here, so the chain never runs. Same
+      // word one layer down as everywhere else in the seam: what it prevents
+      // is the default action left after this one.
+      if (ev.defaultPrevented) return;
       // **The default action moves whole pixels and keeps the change.** A
       // scroll offset that is not an integer costs the scroll blit — the
       // server-side copy that makes a scroll cheap can only shift by whole
@@ -614,6 +631,15 @@ export class EventManager {
       if (this.downNode && !captured)
         this._setPressed(this._pressedAlong(path));
       const ev = this.dispatch('MouseMove', target, native, undefined, path);
+      // Hover motion, for an element that paints its own hover state — the
+      // node, the edge or the handle under the pointer lights up. Core
+      // already computes the path this needs, once per motion, for `:hover`
+      // and `onMouseEnter`/`Leave`; the element could not hear it (#302).
+      //
+      // Not while a capture holds the pointer: hover is deliberately frozen
+      // for the length of a gesture (see `_updateHover` above), and the
+      // motion of a gesture is `defaultMouseDrag`'s to deliver.
+      if (!captured && !ev.defaultPrevented) target.defaultMouseMove?.(ev);
       // drags deliver to the pressed node even when the pointer leaves it —
       // unless the press that started them was vetoed, see `_downDefaulted`
       if (this._downDefaulted && this.downNode && !this.downNode.destroyed) {
@@ -719,13 +745,20 @@ export class EventManager {
     const common = sharedPrefix(oldPath, newPath);
     for (let i = oldPath.length - 1; i >= common; i--) {
       const n = oldPath[i];
-      if (!n.destroyed) {
-        // the hover path is the ancestor chain, so a `:hover` block on a
-        // parent lights up while a child is hovered — CSS semantics, for
-        // free, because the path is already computed for enter/leave
-        n.setStyleState(':hover', false);
-        n.props.onMouseLeave?.(this._makeEvent('mouseLeave', native, n));
-      }
+      if (n.destroyed) continue;
+      // the hover path is the ancestor chain, so a `:hover` block on a
+      // parent lights up while a child is hovered — CSS semantics, for
+      // free, because the path is already computed for enter/leave
+      n.setStyleState(':hover', false);
+      const handler = n.props.onMouseLeave;
+      // the event is built only for a node with somewhere to deliver it:
+      // this loop runs per motion, over a whole ancestor chain (issue #188)
+      if (!handler && !n.defaultMouseLeave) continue;
+      const ev = this._makeEvent('mouseLeave', native, n);
+      handler?.(ev);
+      // …and the element clears the hover state it painted itself, after
+      // the application handler and vetoed by it, like the rest of the seam
+      if (!ev.defaultPrevented) n.defaultMouseLeave?.(ev);
     }
     for (let i = common; i < newPath.length; i++) {
       const n = newPath[i];

--- a/src/node.d.ts
+++ b/src/node.d.ts
@@ -22,6 +22,7 @@ import type {
   CompositionEvent,
   KeyboardEvent,
   MouseEvent,
+  WheelEvent,
 } from './types/events.js';
 
 /** ntk's 2d context. Typed loosely — it is ntk's API, not ours. */
@@ -306,6 +307,33 @@ export declare class Node {
   defaultMouseDrag?(ev: MouseEvent): void;
   /** The press this element received has been released. */
   defaultMouseUp?(ev: MouseEvent): void;
+  /**
+   * Plain pointer motion over this element, with no button down — the hook
+   * for an element that paints its own hover state, a scene where the node
+   * or handle under the pointer lights up.
+   *
+   * The element under the pointer gets it, so the first one after the
+   * pointer arrives is also the enter. Not delivered while a pointer
+   * capture is in force: that motion belongs to the gesture, and
+   * `defaultMouseDrag` is where it goes.
+   */
+  defaultMouseMove?(ev: MouseEvent): void;
+  /** The pointer left this element — clear what `defaultMouseMove` lit. A
+   * node that unmounts while hovered is *forgotten* rather than left, the
+   * way focus is, so a subtree torn down under the pointer never sees it. */
+  defaultMouseLeave?(ev: MouseEvent): void;
+  /**
+   * The wheel over this element, before the scroll chain gets it: a pane
+   * whose wheel is a zoom about the pointer rather than a scroll, which
+   * needs `ev.x`/`ev.y` and the modifiers as much as the deltas.
+   *
+   * `ev.preventDefault()` consumes it, and the chain then never runs — the
+   * answer for a gesture that is handled whether or not anything moved. An
+   * element whose wheel really is a scroll implements `canScroll`/`scrollBy`
+   * instead and joins the chain. Deltas are pixels, fractional where the
+   * device measured a fraction: the whole-pixel rule is the chain's.
+   */
+  defaultWheel?(ev: WheelEvent): void;
   /** Right-click, after `onContextMenu` handlers: open the element's own
    * menu. Separate from the press so suppressing the menu does not also
    * give up the caret placement `defaultMouseDown` did. */

--- a/test/default-actions.test.js
+++ b/test/default-actions.test.js
@@ -15,8 +15,8 @@ import React from 'react';
 import { createRoot } from '../src/index.js';
 import { registerElement, unregisterElement } from '../src/host.js';
 import { Node, CARET_BLINK_MS } from '../src/node.js';
-import { XK_TAB, XK_ESCAPE, XK_LEFT } from '../src/keysyms.js';
-import { createMockApp } from './helpers/mock-app.js';
+import { XK_TAB, XK_ESCAPE, XK_LEFT, MOD } from '../src/keysyms.js';
+import { createMockApp, spinWheel } from './helpers/mock-app.js';
 
 const h = React.createElement;
 const tick = () => new Promise((resolve) => setImmediate(resolve));
@@ -100,6 +100,51 @@ class EditorNode extends Node {
     clearInterval(this.blinkTimer);
     this.blinkTimer = null;
     super.destroySubtree();
+  }
+}
+
+/**
+ * The other element under test: a scene, the shape issue #302 was found
+ * building. It draws a graph into one node, so its wheel is a zoom about the
+ * pointer rather than a scroll and the hover it paints is the node under the
+ * pointer rather than a `:hover` block on a child that does not exist.
+ */
+class PaneNode extends Node {
+  constructor(props, app) {
+    super('minipane', props, app);
+    this.log = [];
+    this.zoom = 1;
+    this.hovered = null;
+  }
+
+  defaultWheel(ev) {
+    this.log.push(
+      `wheel:${ev.deltaY}@${ev.x},${ev.y}${ev.ctrlKey ? '+ctrl' : ''}`,
+    );
+    // `zooms={false}` is the same element declining the gesture, which is
+    // what puts it back in the scroll chain
+    if (this.props.zooms === false) return;
+    this.zoom *= Math.exp(-ev.deltaY / 400);
+    ev.preventDefault(); // consumed, whether or not anything "scrolled"
+  }
+
+  defaultMouseMove(ev) {
+    this.hovered = { x: ev.localX, y: ev.localY };
+    this.log.push(`move:${ev.x},${ev.y}`);
+  }
+
+  defaultMouseLeave() {
+    this.hovered = null;
+    this.log.push('leave');
+  }
+
+  defaultMouseDown(ev) {
+    this.log.push('down');
+    if (this.props.captures !== false) ev.capturePointer();
+  }
+
+  defaultMouseDrag(ev) {
+    this.log.push(`drag:${ev.x}`);
   }
 }
 
@@ -351,6 +396,208 @@ test('focus and blur bracket the element behaviour, including the window losing 
   await tick();
   assert.deepStrictEqual(editor.log, ['focus', 'blur', 'focus', 'blur']);
   assert.strictEqual(editor.blinkTimer, null, 'nothing left ticking');
+});
+
+// --- the wheel and hover motion (#302) --------------------------------------
+//
+// The two inputs that never reached the seam. `isScroller`/`scrollBy` route
+// the wheel for content that scrolls and hand out deltas only; a pane whose
+// wheel is a zoom about the pointer needs the point, the modifiers, and to
+// answer the gesture whether or not anything "can scroll". And core already
+// computes the hover path per motion for `:hover` and `onMouseEnter`/`Leave`
+// — an element painting its own hover state just could not hear it.
+
+/** Mount `<minipane>` over a tall sibling in a window that may scroll, so
+ * the chain behind the element is a real one for it to keep or hand on. */
+async function mountPane({ props = {}, windowProps = {} } = {}) {
+  register('minipane', {
+    create: (p, app) => new PaneNode(p, app),
+    childrenAllowed: false,
+    override: true,
+  });
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  const ref = React.createRef();
+  root.render(
+    h(
+      'window',
+      { width: 300, height: 200, ...windowProps },
+      h('minipane', {
+        ref,
+        style: { width: 200, height: 100, flexShrink: 0 },
+        ...props,
+      }),
+      h('box', { style: { height: 400, flexShrink: 0 } }),
+    ),
+  );
+  await tick();
+  const wnd = app.windows[0];
+  return { app, root, wnd, windowNode: wnd._reactX11Node, pane: ref.current };
+}
+
+test('the wheel reaches the element with the point and the modifiers', async () => {
+  const { wnd, pane } = await mountPane();
+  spinWheel(wnd, 50, 40, { deltaY: 1, buttons: MOD.Control });
+  await tick();
+  assert.deepStrictEqual(pane.log, ['wheel:48@50,40+ctrl']);
+  assert.ok(pane.zoom < 1, 'and the zoom it drove is about that point');
+});
+
+test('consuming the wheel keeps it from the scroll chain', async () => {
+  const { wnd, windowNode, pane } = await mountPane({
+    windowProps: { style: { overflow: 'scroll' } },
+  });
+  spinWheel(wnd, 50, 40);
+  await tick();
+  assert.strictEqual(pane.log.length, 1, 'the element answered it');
+  assert.strictEqual(windowNode.scrollY, 0, 'so the window behind it did not');
+});
+
+test('…and leaving it alone puts the element back in the chain', async () => {
+  const { wnd, windowNode, pane } = await mountPane({
+    props: { zooms: false },
+    windowProps: { style: { overflow: 'scroll' } },
+  });
+  spinWheel(wnd, 50, 40);
+  await tick();
+  assert.deepStrictEqual(pane.log, ['wheel:48@50,40'], 'it was offered first');
+  assert.strictEqual(pane.zoom, 1, 'and declined the gesture');
+  assert.strictEqual(windowNode.scrollY, 48, 'so the walk ran as before');
+});
+
+test('an app handler still gets the wheel first, and can veto it', async () => {
+  const seen = [];
+  const { wnd, pane } = await mountPane({
+    props: {
+      onWheel: (ev) => {
+        seen.push(ev.deltaY);
+        ev.preventDefault();
+      },
+    },
+  });
+  spinWheel(wnd, 50, 40);
+  await tick();
+  assert.deepStrictEqual(seen, [48], 'the handler ran');
+  assert.deepStrictEqual(pane.log, [], 'and the element behaviour did not');
+
+  // …while a handler that only watches leaves the element its wheel
+  const watched = await mountPane({
+    props: { onWheel: () => seen.push('saw') },
+  });
+  spinWheel(watched.wnd, 50, 40);
+  await tick();
+  assert.deepStrictEqual(seen, [48, 'saw']);
+  assert.deepStrictEqual(watched.pane.log, ['wheel:48@50,40']);
+});
+
+test('the fraction a touchpad measured reaches the element whole', async () => {
+  // the chain spends whole pixels and carries the rest, because a fractional
+  // scroll offset is one the blit cannot shift — a zoom factor is continuous
+  // and gets the delta as it was measured
+  const { wnd, windowNode, pane } = await mountPane({
+    props: { zooms: false },
+    windowProps: { style: { overflow: 'scroll' } },
+  });
+  spinWheel(wnd, 50, 40, { deltaY: 1 / 128, smooth: true });
+  await tick();
+  assert.deepStrictEqual(pane.log, ['wheel:0.375@50,40']);
+  assert.strictEqual(windowNode.scrollY, 0, 'a third of a pixel moves nothing');
+});
+
+test('hover motion reaches the element, and the leave that ends it', async () => {
+  const { wnd, pane } = await mountPane();
+
+  wnd.emit('mousemove', { x: 20, y: 30 });
+  await tick();
+  assert.deepStrictEqual(
+    pane.log,
+    ['move:20,30'],
+    'the first one is the enter',
+  );
+  assert.deepStrictEqual(pane.hovered, { x: 20, y: 30 }, 'local, as elsewhere');
+
+  wnd.emit('mousemove', { x: 40, y: 30 });
+  await tick();
+  assert.deepStrictEqual(pane.log, ['move:20,30', 'move:40,30']);
+
+  // out of the element's box, still inside the window
+  wnd.emit('mousemove', { x: 250, y: 30 });
+  await tick();
+  assert.deepStrictEqual(pane.log, ['move:20,30', 'move:40,30', 'leave']);
+  assert.strictEqual(pane.hovered, null, 'the highlight went with it');
+});
+
+test('the pointer leaving the window is a leave as well', async () => {
+  const { wnd, pane } = await mountPane();
+  wnd.emit('mousemove', { x: 20, y: 30 });
+  wnd.emit('mouseout', { x: -1, y: 30 });
+  await tick();
+  assert.deepStrictEqual(pane.log, ['move:20,30', 'leave']);
+});
+
+test('app handlers get motion and the leave first, and can veto either', async () => {
+  const seen = [];
+  const { wnd, pane } = await mountPane({
+    props: {
+      onMouseMove: (ev) => {
+        seen.push('move');
+        ev.preventDefault();
+      },
+      onMouseLeave: (ev) => {
+        seen.push('leave');
+        ev.preventDefault();
+      },
+    },
+  });
+  wnd.emit('mousemove', { x: 20, y: 30 });
+  wnd.emit('mousemove', { x: 250, y: 30 });
+  await tick();
+  assert.deepStrictEqual(seen, ['move', 'leave'], 'both handlers ran');
+  assert.deepStrictEqual(pane.log, [], 'and neither default action after them');
+
+  // …and handlers that only watch leave the element both of them
+  const watched = await mountPane({
+    props: {
+      onMouseMove: () => seen.push('saw move'),
+      onMouseLeave: () => seen.push('saw leave'),
+    },
+  });
+  watched.wnd.emit('mousemove', { x: 20, y: 30 });
+  watched.wnd.emit('mousemove', { x: 250, y: 30 });
+  await tick();
+  assert.deepStrictEqual(seen, ['move', 'leave', 'saw move', 'saw leave']);
+  assert.deepStrictEqual(watched.pane.log, ['move:20,30', 'leave']);
+});
+
+test('a capture keeps the motion on the drag hook', async () => {
+  const { wnd, pane } = await mountPane();
+  wnd.emit('mousedown', { x: 20, y: 30, keycode: 1 });
+  wnd.emit('mousemove', { x: 250, y: 30 });
+  await tick();
+  // hover is frozen for the length of the gesture, so the motion of one is
+  // the drag's and not also the hover's
+  assert.deepStrictEqual(pane.log, ['down', 'drag:250']);
+  assert.strictEqual(pane.hovered, null);
+
+  // …and a press that did not capture leaves hover live, in that order: what
+  // the pointer is over still lights up while the press follows it
+  const loose = await mountPane({ props: { captures: false } });
+  loose.wnd.emit('mousedown', { x: 20, y: 30, keycode: 1 });
+  loose.wnd.emit('mousemove', { x: 40, y: 30 });
+  await tick();
+  assert.deepStrictEqual(loose.pane.log, ['down', 'move:40,30', 'drag:40']);
+});
+
+test('a node that unmounts while hovered is forgotten, not left', async () => {
+  const { root, wnd, pane } = await mountPane();
+  wnd.emit('mousemove', { x: 20, y: 30 });
+  await tick();
+  assert.deepStrictEqual(pane.log, ['move:20,30'], 'hovered, and painting it');
+
+  pane.log.length = 0;
+  root.render(h('window', { width: 300, height: 200 }));
+  await tick();
+  assert.deepStrictEqual(pane.log, [], 'the same rule focus follows');
 });
 
 test('CARET_BLINK_MS is the cadence <textinput> blinks at', async () => {

--- a/test/types/extend.tsx
+++ b/test/types/extend.tsx
@@ -32,6 +32,7 @@ import type {
   CompositionEvent,
   KeyboardEvent,
   MouseEvent,
+  WheelEvent,
 } from '../../src/types/events.js';
 import {
   isStyleProp,
@@ -343,11 +344,37 @@ registerElement('miniticker', {
 // diffs itself is its own to claim. Both shapes of the commit half are here
 // so both compile; a real element picks the one that fits.
 class FlowNode extends Node {
+  private zoom = 1;
+  private hovered: string | null = null;
+
   constructor(props: Record<string, unknown>, app: never) {
     super('flow', props, app);
   }
 
+  // …and the two inputs the seam was missing (#302): a wheel that is a zoom
+  // about the pointer rather than a scroll, and the hover this element paints
+  // itself. Both after the app's handlers, both vetoed by `preventDefault`.
+  defaultWheel(ev: WheelEvent): void {
+    if (!ev.ctrlKey) return; // an unmodified wheel still scrolls the pane
+    const at: { x: number; y: number } = { x: ev.x, y: ev.y };
+    this.zoom *= Math.exp(-ev.deltaY / 400);
+    void at;
+    ev.preventDefault(); // consumed: the scroll chain never runs
+  }
+
+  defaultMouseMove(ev: MouseEvent): void {
+    this.hovered = `${ev.localX},${ev.localY}`;
+    this.invalidate(false, this.abs, 'content');
+  }
+
+  defaultMouseLeave(_ev: MouseEvent): void {
+    this.hovered = null;
+    this.invalidate(false, this.abs, 'content');
+  }
+
   paintContent(_ctx: unknown): void {
+    void this.hovered;
+    void this.zoom;
     // null outside a paint and on an unbounded one, and both read the same:
     // nothing bounds you, draw the lot
     const damage: Rect | null = this.paintDamage();


### PR DESCRIPTION
Closes #302.

#251 gave a registered element the default-action seam and #253 gave the wheel its scroll-chain protocol. Two inputs still never reached an element that draws its own scene — found building `<Flow>` in @react-x11/components, where the component layer has to wire `onWheel`, `onMouseMove` and `onMouseLeave` and forward them into the retained node, leaving the raw `<flowgraph>` element deaf to both.

## What lands

**`defaultWheel(ev)`** on the node under the pointer, after the application's `onWheel` and before the scroll chain walks; `ev.preventDefault` consumes it and the walk never runs. It is for the element whose wheel is not a scroll: a zoom about the pointer needs `ev.x`/`ev.y` — the point that must not move — and `ctrlKey`/`shiftKey` to tell a zoom from a pan, and it answers the gesture whether or not anything "can scroll". An element whose wheel really is a scroll keeps `isScroller`/`scrollBy` and is untouched.

The element reads the delta **before** the whole-pixel truncation, fractions and all: whole pixels are there for the scroll blit, and a zoom factor is continuous.

**`defaultMouseMove(ev)`** on the node under the pointer and **`defaultMouseLeave(ev)`** when the hover path drops it, so a scene element can light the node, edge or handle the pointer is over and put it back. Nothing new is computed — core already diffs that path per motion for `:hover` and `onMouseEnter`/`Leave` — and the leave event is still built only for a node with somewhere to deliver it, since that loop runs per motion over a whole ancestor chain.

Both keep the seam's ordering: the application's handlers first, the element's behaviour after, `preventDefault` in between.

Two rules worth a look in review, both pinned by tests:

- **A capture suspends the hover pair.** Hover is deliberately frozen for the length of a gesture, so the motion of one is `defaultMouseDrag`'s alone. A press that did **not** capture leaves hover live, and the order is move, then drag.
- **A node that unmounts while hovered is forgotten, not left** — exactly the rule focus follows.

## Design note

`defaultWheel` is offered to the hit node only, per the issue's sketch, rather than along the chain walk. An element that mounts overlay siblings over its own pane — the shape `<Flow>` uses for node bodies — therefore does not hear a wheel that landed on one of those siblings. Say the word if you would rather the offer chained outward the way `canScroll` does; it is a three-line difference, and the interleaved walk has a nice property of its own: a `<textarea>` body with somewhere to scroll would take the wheel before the pane got to zoom.

## Verification

`npm test` 1269 passing, plus `lint`, `typecheck` and `prettier --check .` clean. The six failures in `test/appearance.test.js` are pre-existing on this macOS box, where the host answers where the test expects XSETTINGS; they fail identically on master.

Ten new tests in `test/default-actions.test.js`, mutation-checked: with the three hooks reverted in `src/events.js`, all ten fail. Types and the type test moved with the `.d.ts`, and `docs/extending.md` and `docs/events.md` document the three methods, the capture rule and the unmount rule.

No visual change, so no screenshots.
