### PR TITLE
feat(extending): the blit an element with a viewport of its own can ask for

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -131,6 +131,11 @@ plain path on the same build, and as first aid if a scroll ever
 misrenders. Read once at startup, like the switches above, and like them
 it answers only to `1` — any other value leaves the blit on.
 
+It covers the element-owned form of the same shift as well —
+[`scrollContents`](extending.md#panning-a-scene-you-drew), which a pane
+that pans a scene it drew itself calls — so a scene that misrenders while
+panning is one variable away from being told apart from one that misdraws.
+
 ## `REACT_X11_NO_TRANSPARENCY=1`
 
 Makes every display answer the way one with no 32-bit visual does:

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -933,6 +933,11 @@ of this without being asked: a pure scroll of one viewport blits the
 surviving band inside ntk's backing pixmap rather than repainting it. This
 is that optimisation, for a buffer you retained yourself.
 
+An element that draws its content live rather than into a surface asks for
+the window-side half directly, with
+[`scrollContents`](#panning-a-scene-you-drew) — the same shift, one layer
+out.
+
 ### Drawing a scene into one node
 
 _Issue #301._ A frame repaints **rects, not windows**: claims coalesce into
@@ -1050,6 +1055,84 @@ seams — the same frame, with the parts of it nobody can see left unsent.
 `REACT_X11_DEBUG_PAINT=1` is how to watch it: the pass's rect is stroked in
 the frame's colour, so a scene that is still repainting whole strobes across
 the pane instead of outlining what moved ([debugging.md](debugging.md)).
+
+#### Panning a scene you drew
+
+_Issue #303._ The two seams above scope a frame to the part of the scene
+that changed. A **pan** has no such part: it translates every pixel, so the
+honest claim is the whole pane and the honest frame is a full repaint — of a
+picture that is already on screen, one shift away from being right.
+
+That is the shape `<box overflow="scroll">` has been treating as a special
+case since issue #138: blit the band that survives inside ntk's backing
+store, repaint only the strip the shift exposed. `scrollContents` is that
+same dance, for a viewport of your own:
+
+```js
+class FlowNode extends Node {
+  onDragPan(dx, dy) {
+    this.panX += dx;
+    this.panY += dy;
+    // "the pixels in here moved by (dx, dy); the rest of it is new"
+    this.scrollContents(this.contentBox(), dx, dy);
+  }
+
+  paintContent(ctx) {
+    // …and this is the exposed strip, not the pane. Nothing here changes.
+    const damage = this.paintDamage();
+    for (const item of this.scene()) {
+      if (damage && !overlaps(item.bounds, damage)) continue;
+      this.draw(ctx, item);
+    }
+  }
+}
+```
+
+The call claims `rect` — the conservative answer, and the one that stands if
+anything declines — and arms the frame to blit instead. At frame time core
+asks ntk to move the surviving band and **narrows that claim to the band the
+shift exposed**, which is what `paintDamage()` then hands your paint. So the
+element draws the strip and nothing else without ever asking whether the
+blit happened, and every gate below falls back to repainting `rect`, which is
+the behaviour without the call at all.
+
+Four things worth knowing, in the order they bite:
+
+**`dx`/`dy` are how far the pixels moved.** The sense `Surface.copyWithin`
+and ntk's `scrollRegion` use, not a scroll offset's: panning the scene right
+by ten is `dx: 10`, and the exposed band is down the left edge. Both whole
+pixels — a fractional shift is not a copy — and `rect` in window coordinates
+(the same space as `abs`, `contentBox()` and an event's `x`/`y`) and inside
+your node.
+
+**You promise one thing: that inside `rect` the frame really is that
+translation.** Everything else is core's to check, and each of them declines
+rather than misrenders — a claim from anywhere else reaching into the rect, a
+sibling drawing over it, a child of your node laid out on top of it, your own
+border ring or rounded corner, a layout pass that moved something, a region
+too small or a shift too large to be worth it. Several pans in one frame
+coalesce into one blit by their net shift; two different regions of one node
+do not, and fall back.
+
+**Diagonal is fine here**, unlike the scroll containers' one-axis-at-a-time
+rule. That rule exists because the L of exposed strips overlaps the scrollbar
+rects and the merges balloon back towards the whole viewport; with no bars
+the L is two disjoint rects and stays two. A drag-pan is diagonal almost
+every frame, so this is the case rather than the corner.
+
+**Zoom is not a blit.** Scaling resamples; it is a full repaint and should
+be. That is the right trade: a zoom is a gesture step, a pan is sixty of them
+a second.
+
+The protocol bench prices it at five diagonal pan steps over a 374-cell scene
+— 983 requests / 606 composites / 0.30 Mpx, against 9845 / 6533 / 4.22 for
+the same five steps under `REACT_X11_NO_SCROLL_BLIT=1`, which is exactly the
+fallback every gate here takes.
+
+If your element keeps its drawing in a `Surface` of its own rather than
+drawing it live, the shift you want is
+[`copyWithin`](#scrolling-the-pixels-not-just-the-offset) on that surface —
+same idea, one layer in.
 
 ### Drawing once instead of every frame
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^7.6.1",
+        "ntk": "^7.7.0",
         "react-reconciler": "^0.33.0"
       },
       "devDependencies": {
@@ -4034,9 +4034,9 @@
       }
     },
     "node_modules/ntk": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-7.6.1.tgz",
-      "integrity": "sha512-JPvscPa4hE04PGJcVrW2mUOLOBGB9AsBKeyqBVb9tOx6yL9lMf2bJVOh9ij373fASr4Zgx12wPeMLXOvjiPCJA==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-7.7.0.tgz",
+      "integrity": "sha512-upHew/QG0WhPpYkr87xmoEaFJUd0j+sjwvXwM6UjP+2UO73rrHtoSHgHrwZwv5uigpRg2bycYIc9EnyuSr6ytQ==",
       "license": "MIT",
       "dependencies": {
         "bidi-js": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^7.6.1",
+    "ntk": "^7.7.0",
     "react-reconciler": "^0.33.0"
   },
   "optionalDependencies": {

--- a/scripts/bench/baseline.json
+++ b/scripts/bench/baseline.json
@@ -49,25 +49,25 @@
   },
   "mount: window with 40 boxes and labels": {
     "requests": 104,
-    "bytesOut": 3976,
-    "bytesIn": 864,
-    "replies": 25,
+    "bytesOut": 3992,
+    "bytesIn": 896,
+    "replies": 26,
     "composites": 21,
     "compositePixels": 298240
   },
   "scroll: 10 notches over 500 rows": {
-    "requests": 340,
-    "bytesOut": 14168,
-    "bytesIn": 544,
-    "replies": 17,
+    "requests": 332,
+    "bytesOut": 12120,
+    "bytesIn": 576,
+    "replies": 18,
     "composites": 81,
     "compositePixels": 644480
   },
   "svg: 100 unchanged icons, full repaint": {
-    "requests": 104,
-    "bytesOut": 3672,
-    "bytesIn": 96,
-    "replies": 3,
+    "requests": 106,
+    "bytesOut": 3704,
+    "bytesIn": 128,
+    "replies": 4,
     "composites": 101,
     "compositePixels": 200000
   },

--- a/scripts/bench/baseline.json
+++ b/scripts/bench/baseline.json
@@ -110,5 +110,13 @@
     "replies": 9,
     "composites": 133,
     "compositePixels": 75896
+  },
+  "scene: 5 pan steps over 374 cells in one node": {
+    "requests": 983,
+    "bytesOut": 177444,
+    "bytesIn": 320,
+    "replies": 10,
+    "composites": 606,
+    "compositePixels": 298517
   }
 }

--- a/scripts/bench/protocol.js
+++ b/scripts/bench/protocol.js
@@ -353,6 +353,69 @@ registerElement('scene', {
   selfDamagedProps: ['cells'],
 });
 
+// --- and panning it (issue #303) ----------------------------------------
+//
+// The other half of the same pane's cost. A drag step moves one cell and
+// claims the box it moved through; a *pan* translates every pixel, so the
+// scoped claim the seams above buy is the whole pane by construction — and
+// the frame is one CopyArea away from being right. `scrollContents` is that
+// call: the surviving band shifts inside the backing store and the claim
+// narrows to the strips the shift exposed, which `paintDamage()` then hands
+// the paint.
+//
+// The grid here is a *world* grid, one period wider than the pane on every
+// side, so a pan always has cells to bring in — a scene whose content
+// stopped at the viewport edge would flatter the exposed strip.
+
+class PanSceneNode extends SceneNode {
+  constructor(kind, props, app) {
+    super(kind, props, app);
+    this.panX = 0;
+    this.panY = 0;
+  }
+
+  cellRect(i) {
+    const box = this.contentBox();
+    const w = box.width / SCENE_COLS;
+    const h = box.height / SCENE_ROWS;
+    return {
+      x: box.x + ((i % PAN_COLS) - 1) * w + this.panX,
+      y: box.y + (Math.floor(i / PAN_COLS) - 1) * h + this.panY,
+      width: w,
+      height: h,
+    };
+  }
+
+  pan(dx, dy) {
+    this.panX += dx;
+    this.panY += dy;
+    this.scrollContents(this.contentBox(), dx, dy);
+  }
+}
+
+const PAN_COLS = SCENE_COLS + 2;
+const PAN_ROWS = SCENE_ROWS + 2;
+const panCells = () =>
+  Array.from({ length: PAN_COLS * PAN_ROWS }, (_, i) =>
+    i % 3 ? '#dfe6e9' : '#b2bec3',
+  );
+
+registerElement('panscene', {
+  create: (props, app) => new PanSceneNode('panscene', props, app),
+  semanticNames: ['cells'],
+  selfDamagedProps: ['cells'],
+});
+
+const panSceneWindow = () =>
+  React.createElement(
+    'window',
+    { width: W, height: H, style: { backgroundColor: '#f5f6fa' } },
+    React.createElement('panscene', {
+      cells: panCells(),
+      style: { flexGrow: 1, margin: 8 },
+    }),
+  );
+
 const sceneWindow = (cells) =>
   React.createElement(
     'window',
@@ -720,6 +783,33 @@ const SCENARIOS = [
             await new Promise((resolve) =>
               x11Root.render(sceneWindow(sceneCells(i)), resolve),
             );
+            ctl.frame();
+            await settle(app);
+          }
+        },
+      };
+    })(),
+  ],
+  [
+    // The pan (issue #303). Five diagonal steps of the same pane: every
+    // pixel translates, so the damage seams of #301 have nothing to scope
+    // to and the frame is the whole pane by construction. `scrollContents`
+    // turns each step into one CopyArea plus the two strips it exposed.
+    // The same five steps under REACT_X11_NO_SCROLL_BLIT=1 — every gate
+    // here falls back to exactly that — cost 9845 requests / 6533
+    // composites / 4.22 Mpx, against 982 / 606 / 0.30 with the blit.
+    'scene: 5 pan steps over 374 cells in one node',
+    (() => {
+      let ctl;
+      let pane;
+      return {
+        prepare: async (app, x11Root) => {
+          ctl = await mounted(x11Root, panSceneWindow());
+          pane = ctl.root.children.find((n) => n.kind === 'panscene');
+        },
+        run: async (app, x11Root) => {
+          for (let i = 0; i < 5; i++) {
+            pane.pan(7, 5);
             ctl.frame();
             await settle(app);
           }

--- a/src/node.d.ts
+++ b/src/node.d.ts
@@ -234,6 +234,24 @@ export declare class Node {
    */
   paintDamage(): Rect | null;
   /**
+   * "The pixels in `rect` moved by (dx, dy); the rest of it is new" — for an
+   * element with a viewport of its own, whose pan is a scroll in every way
+   * but the bookkeeping.
+   *
+   * Claims `rect`, and arms the frame to blit the surviving band inside the
+   * backing store instead — after which the claim is narrowed to the band
+   * the shift exposed, which is what `paintDamage()` hands the paint. The
+   * element draws the strip and nothing else, without asking whether the
+   * blit happened.
+   *
+   * `dx`/`dy` are how far the **pixels** moved, the sense `Surface.copyWithin`
+   * uses rather than a scroll offset's, and whole. `rect` is in window
+   * coordinates and inside this node. The return says whether the frame is
+   * still a blit candidate; the gates that matter close at frame time, and
+   * every one of them falls back to repainting `rect`.
+   */
+  scrollContents(rect: Rect, dx: number, dy: number): boolean;
+  /**
    * Did anything this node draws change? True damages the whole node, false
    * contributes no damage at all, and the default answers true for any prop
    * that is not identical to the one it replaced — conservative, because a

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -276,6 +276,13 @@ const SCROLL_BLIT_MIN_KEEP = 0.5;
 // up-front clear like any real origin, so it lives exactly one frame.
 const BLIT_POISONED = Object.freeze({ poisoned: true });
 
+// A frame armed by `Node.scrollContents` rather than by a scroll offset
+// (issue #303): there is no origin to record, because the element handed
+// over the shift itself. Truthy for the same reason as the poison — so the
+// `??=` in both arming paths reads "already armed" — with the rect and the
+// net delta in `_pendingBlitContents` beside it.
+const BLIT_CONTENTS = Object.freeze({ contents: true });
+
 const rectContains = (outer, inner) =>
   outer.x <= inner.x &&
   outer.y <= inner.y &&
@@ -2579,6 +2586,106 @@ export class Node {
   }
 
   /**
+   * "The pixels in `rect` moved by (dx, dy); the rest of it is new" — the
+   * public form of the dance `<box overflow="scroll">` has been doing since
+   * issue #138, for an element with a viewport of its own (issue #303).
+   *
+   * A pan is a scroll in every way but the bookkeeping: it translates every
+   * pixel of the pane, so an element that can only say "everything changed"
+   * repaints the lot, sixty times a second, for a frame whose content is
+   * already on screen one shift away. This claims `rect` — the conservative
+   * answer, and the one that stands if anything below declines — and arms
+   * the frame to blit instead: at frame time core asks ntk to move the
+   * surviving band inside the backing store (`Window.scrollRegion`) and
+   * **narrows this claim to the band the shift exposed**, which is what
+   * `paintDamage()` then hands the paint. So the element draws the strip and
+   * nothing else, without ever asking whether the blit happened.
+   *
+   * `dx`/`dy` are **how far the pixels moved**, the sense `Surface.copyWithin`
+   * and `Window.scrollRegion` use rather than a scroll offset's — panning a
+   * graph right by 10 is `dx: 10`, and the exposed band is down the left
+   * edge. Whole pixels, both of them, and `rect` in window coordinates
+   * (`abs`, `contentBox()`, an event's `x`/`y`) and inside this node.
+   *
+   * The element promises one thing in return: that inside `rect` the frame
+   * really is that translation and nothing else. Every other way it could be
+   * false is core's to check — a claim from anywhere else reaching into the
+   * rect, a sibling drawing over it, a child of this node laid out on top of
+   * it, an ancestor's border ring or rounded corner, a layout pass that
+   * moved something — and each of them falls back to repainting the rect,
+   * which is the behaviour without this call at all.
+   *
+   * Returns whether the frame is still a blit candidate. The real answer
+   * arrives as `paintDamage()`, because most of the gates cannot be decided
+   * until the frame closes; a `false` here is only the ones that can.
+   */
+  scrollContents(rect, dx, dy) {
+    const root = this.root;
+    if (
+      !root ||
+      this.destroyed ||
+      !rect ||
+      !(rect.width > 0) ||
+      !(rect.height > 0)
+    ) {
+      return false;
+    }
+    // Nothing moved, so there is nothing to claim either — an element
+    // rounding a gesture to whole pixels lands here on most events.
+    if (!dx && !dy) return true;
+    const pending = this._pendingBlitContents;
+    // The rect has to be the same one all frame: two different regions of
+    // one node shifting by different deltas is not one CopyArea, and the
+    // second claim would coalesce into the first past the point either can
+    // be told apart. Same for a Scrollable element that also scrolls its
+    // offsets this frame — two shifts of the same pixels, and a frame can
+    // only have one.
+    if (
+      this._pendingBlitFrom != null &&
+      (!pending ||
+        pending.rect.x !== rect.x ||
+        pending.rect.y !== rect.y ||
+        pending.rect.width !== rect.width ||
+        pending.rect.height !== rect.height)
+    ) {
+      this._pendingBlitFrom = BLIT_POISONED;
+    } else if (this._pendingBlitFrom == null && Array.isArray(root._damage)) {
+      // Arming is the one moment the evidence still exists — the claim
+      // below coalesces earlier ones into itself, after which a change
+      // inside the rect is indistinguishable from this call's own claim.
+      // The same reasoning, and the same poison rather than a disarm, as
+      // scrollTo (react-x11#295).
+      const zone = insetRect(rect, -(DAMAGE_SLOP * 2 + 1));
+      for (const claimed of root._damage) {
+        if (rectsOverlap(claimed, zone)) {
+          this._pendingBlitFrom = BLIT_POISONED;
+          break;
+        }
+      }
+    }
+    const state = (this._pendingBlitContents ??= {
+      // our own copy: the caller's rect is very often the live
+      // `contentBox()` of a node that is about to be laid out again
+      rect: { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+      dx: 0,
+      dy: 0,
+    });
+    // several pans in one frame blit once, by the net shift — the same
+    // coalescing scrollTo gets from recording an origin
+    state.dx += dx;
+    state.dy += dy;
+    this._pendingBlitFrom ??= BLIT_CONTENTS;
+    (root._pendingScrolls ??= new Set()).add(this);
+    // ...and the claim about to be recorded is the shift itself, not a
+    // reason to un-blit it. `state.rect` by identity, so a second call this
+    // frame is recognised as the same claim rather than as foreign damage.
+    root._scrollClaim = state.rect;
+    root.invalidate(false, state.rect, 'scroll');
+    root._scrollClaim = null;
+    return this._pendingBlitFrom !== BLIT_POISONED;
+  }
+
+  /**
    * A layout-affecting change confined to this node: claim the subtree as
    * it stands now, and queue it for a second claim once layout has run —
    * the same before/after protocol `_childListChanged` uses. Anything
@@ -4173,6 +4280,10 @@ export const Scrollable = (Base) =>
             }
           }
         }
+        // An element that also shifted its own drawing this frame
+        // (`scrollContents`, issue #303) is two shifts of the same pixels,
+        // and a frame can only have one.
+        if (this._pendingBlitContents) this._pendingBlitFrom = BLIT_POISONED;
         // The offsets whose pixels are on screen, captured before the first
         // change of the frame: the frame's blit fast path (issue #138) shifts
         // from *these* to wherever layout settles, however many scrollTo
@@ -8134,9 +8245,12 @@ export class WindowNode extends Scrollable(Node) {
     ) {
       const rect = damage.paintBounds ? damage.paintBounds() : damage;
       for (const sv of pendingScrolls) {
+        // an element blitting a region of its own drawing (issue #303) is
+        // waiting on that region, not on the whole node it lives in
+        const waiting = sv._pendingBlitContents?.rect ?? sv.abs;
         if (
-          !sv.abs ||
-          rectsOverlap(rect, insetRect(sv.abs, -(DAMAGE_SLOP * 2 + 1)))
+          !waiting ||
+          rectsOverlap(rect, insetRect(waiting, -(DAMAGE_SLOP * 2 + 1)))
         ) {
           // Poison rather than disarm (react-x11#295): a null here would
           // let a second scrollTo in the same frame re-arm from a
@@ -8333,7 +8447,11 @@ export class WindowNode extends Scrollable(Node) {
     const nodes = [...pending];
     pending.clear();
     const from = nodes[0]._pendingBlitFrom;
-    for (const n of nodes) n._pendingBlitFrom = null;
+    const contents = nodes[0]._pendingBlitContents;
+    for (const n of nodes) {
+      n._pendingBlitFrom = null;
+      n._pendingBlitContents = null;
+    }
     // two viewports scrolling in one frame is rare enough that sorting out
     // whether their regions interact is not worth it
     if (nodes.length !== 1) return;
@@ -8359,6 +8477,13 @@ export class WindowNode extends Scrollable(Node) {
     // pure scroll, and a blit under rearranged content would shift stale
     // pixels into place the repaint no longer covers
     if (layoutMoved) return;
+    // From here the two arming paths part company: an element handed us the
+    // region and the shift itself (issue #303), where a scroll container is
+    // its whole viewport shifted by the change in its offsets.
+    if (contents) {
+      this._applyContentsBlit(node, contents, width, height);
+      return;
+    }
     // children clip to the border box, so a border ring or rounded corner
     // would be shifted like content — any painted side counts
     const blitBorder = resolveBorderWidths(node.style, node.direction);
@@ -8403,26 +8528,8 @@ export class WindowNode extends Scrollable(Node) {
     ) {
       return;
     }
-    // A pure scroll and nothing else: the frame's only claim touching the
-    // viewport must be the viewport claim itself (scrollTo's, with its
-    // slop). Any other rect reaching in — a virtualized table's row swap, a
-    // hover restyle mid-scroll — means content changed, and changed pixels
-    // must not be blitted around.
-    const keep = [];
-    let sawClaim = false;
-    const slopped = insetRect(vp, -(DAMAGE_SLOP + 1));
-    for (const rect of this._damage) {
-      if (!rectsOverlap(rect, vp)) {
-        keep.push(rect);
-        continue;
-      }
-      if (rectContains(rect, vp) && rectContains(slopped, rect)) {
-        sawClaim = true;
-        continue;
-      }
-      return;
-    }
-    if (!sawClaim) return;
+    const keep = this._blitKeptDamage(vp);
+    if (!keep) return;
     if (!this._scrollBlitSafe(node, vp)) return;
     // scroll offsets grow down/right; the pixels move the other way
     // (0 - x rather than -x: negating +0 yields -0, which survives into
@@ -8482,6 +8589,129 @@ export class WindowNode extends Scrollable(Node) {
     }
     const crossBar = node._scrollbar(axis === 'y' ? 'x' : 'y');
     if (crossBar) rects = addDamageRect(rects, scrollbarTrackRect(crossBar));
+    this._damage = rects;
+  }
+
+  /**
+   * The frame's damage with the shift's own claim taken out, or null if the
+   * shift is not the only thing that happened inside `vp`.
+   *
+   * The claim recorded by `scrollTo` (with its slop) or by `scrollContents`
+   * (exactly `vp`) is the one rect allowed to reach in. Anything else — a
+   * virtualized table's row swap, a hover restyle mid-scroll, a coalesce
+   * that swallowed the claim into a bigger box — means pixels in there
+   * changed, and changed pixels must not be blitted around.
+   */
+  _blitKeptDamage(vp) {
+    const keep = [];
+    let sawClaim = false;
+    const slopped = insetRect(vp, -(DAMAGE_SLOP + 1));
+    for (const rect of this._damage) {
+      if (!rectsOverlap(rect, vp)) {
+        keep.push(rect);
+        continue;
+      }
+      if (rectContains(rect, vp) && rectContains(slopped, rect)) {
+        sawClaim = true;
+        continue;
+      }
+      return null;
+    }
+    return sawClaim ? keep : null;
+  }
+
+  /**
+   * The other half of the blit: a region an element shifted itself
+   * (`Node.scrollContents`, issue #303).
+   *
+   * The gates are the scroll path's, minus everything that was about a
+   * scroll container — there are no offsets to be whole, no scrollbars to
+   * repair, and no extent that decided the delta — and plus the two things
+   * only an element-owned region raises: the region has to be inside what
+   * the element itself draws, and this node's *children* are laid out over
+   * that drawing rather than being it.
+   *
+   * Diagonal shifts are allowed here, unlike the scroll path, and that is
+   * the point rather than an oversight: a pan is diagonal almost every
+   * frame, and the reason the scroll path takes one axis at a time is that
+   * the L of exposed strips overlaps the scrollbar rects and the merges
+   * balloon back towards the whole viewport. With no bars the L is two
+   * disjoint rects and stays two.
+   */
+  _applyContentsBlit(node, { rect: vp, dx, dy }, width, height) {
+    // only a whole-pixel shift of a whole-pixel region is a copy
+    if (!isIntegerRect(vp)) return;
+    if (!Number.isInteger(dx) || !Number.isInteger(dy)) return;
+    // the net shift of the frame, which several pans can cancel out of
+    if (dx === 0 && dy === 0) return;
+    if (Math.abs(dx) >= vp.width || Math.abs(dy) >= vp.height) return;
+    // the worth-it heuristics, the scroll path's: below these the plain
+    // repaint is one cheap pass and the bookkeeping outweighs it
+    const area = vp.width * vp.height;
+    if (area < SCROLL_BLIT_MIN_AREA) return;
+    const kept = (vp.width - Math.abs(dx)) * (vp.height - Math.abs(dy));
+    if (kept < area * SCROLL_BLIT_MIN_KEEP) return;
+    // the band shifts in from inside the window; a region poking out of it
+    // has nothing there to shift
+    if (
+      vp.x < 0 ||
+      vp.y < 0 ||
+      vp.x + vp.width > width ||
+      vp.y + vp.height > height
+    ) {
+      return;
+    }
+    // Inside the element, and clear of its own border ring and rounded
+    // corners: those are `Node.paint`'s, not the element's drawing, and
+    // they do not translate. A solid background does, so the fill under the
+    // region is not a reason to decline.
+    const bw = resolveBorderWidths(node.style ?? EMPTY_STYLE, node.direction);
+    const inset = Math.max(
+      bw.top,
+      bw.right,
+      bw.bottom,
+      bw.left,
+      node.style?.borderRadius ?? 0,
+    );
+    if (!rectContains(insetRect(node.abs, inset), vp)) return;
+    // A scroll container's children *are* the scrolled content, which is
+    // why _scrollBlitSafe skips that subtree. An element's are not: it
+    // draws the region in paintContent and its children are laid out on
+    // top, so one reaching in would have its pixels dragged along.
+    for (const child of node.children) {
+      if (child.isWindow || !child.yoga || child.hidden) continue;
+      if (child.style?.display === 'none') continue;
+      if (rectsOverlap(child._subtreeBounds(), vp)) return;
+    }
+    const keep = this._blitKeptDamage(vp);
+    if (!keep) return;
+    if (!this._scrollBlitSafe(node, vp)) return;
+    // the element's deltas are already how far the pixels moved, the sense
+    // scrollRegion takes (0 + x rather than x: a caller's -0 would survive
+    // into request buffers and test comparisons)
+    if (!this.window.scrollRegion({ ...vp }, 0 + dx, 0 + dy)) return;
+    let rects = keep;
+    // The strips the shift exposed, on the sides the pixels came from. The
+    // horizontal one takes the full width and the vertical one takes what
+    // is left, so a diagonal shift claims two rects that do not overlap —
+    // overlapping claims merge into their box, and the box of an L is the
+    // whole region again.
+    if (dy !== 0) {
+      rects = addDamageRect(rects, {
+        x: vp.x,
+        y: dy > 0 ? vp.y : vp.y + vp.height + dy,
+        width: vp.width,
+        height: Math.abs(dy),
+      });
+    }
+    if (dx !== 0) {
+      rects = addDamageRect(rects, {
+        x: dx > 0 ? vp.x : vp.x + vp.width + dx,
+        y: dy > 0 ? vp.y + dy : vp.y,
+        width: Math.abs(dx),
+        height: vp.height - Math.abs(dy),
+      });
+    }
     this._damage = rects;
   }
 

--- a/test/element-scroll.test.js
+++ b/test/element-scroll.test.js
@@ -1,0 +1,569 @@
+// The blit an element with a viewport of its own can ask for (issue #303).
+//
+// `<box overflow="scroll">` has moved its surviving band inside ntk's
+// backing store since issue #138, through bookkeeping — `pendingScrolls`,
+// the poison-over-disarm of #295, the damage gate — that a custom element
+// could not reach. A graph pane's pan is the same shape and none of that
+// machinery: the content is unbounded in both directions, there is a zoom,
+// and `contentWidth`/`contentHeight` mean nothing, so the `Scrollable` mixin
+// is the wrong answer and a raw CopyArea would reintroduce the race #295
+// closed. `Node.scrollContents(rect, dx, dy)` is that dance made public.
+//
+// Every gate here falls back to repainting `rect`, which is the behaviour
+// without the call at all — so the worst mistake the fast path can make is
+// not firing. The pixel test at the end is the one that asserts the other
+// direction: that when it does fire, what lands on the screen is what a full
+// repaint would have put there.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient } from 'ntk';
+
+import { createRoot } from '../src/index.js';
+import { registerElement, unregisterElement } from '../src/host.js';
+import { Node, Scrollable } from '../src/node.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+const W = 480;
+const H = 480;
+const CELL = 40;
+
+// The pane is inset from the window on purpose: a claim that covers the
+// window makes the whole frame unbounded (`_clampDamage`), which would hide
+// the difference between "declined the blit" and "repainted everything"
+// behind the same `null`.
+const INSET = 40;
+const VP = { x: INSET, y: INSET, width: W - 2 * INSET, height: H - 2 * INSET };
+
+const overlaps = (a, b) =>
+  a.x < b.x + b.width &&
+  b.x < a.x + a.width &&
+  a.y < b.y + b.height &&
+  b.y < a.y + a.height;
+
+/**
+ * A pane that draws a scene of its own and pans it: a grid of cells at an
+ * offset nobody laid out, culled against the pass's rect the way core culls
+ * the tree (issue #301). `pan` is the whole point — it moves the offset and
+ * tells core the pixels moved with it.
+ */
+class PanNode extends Node {
+  constructor(props, app) {
+    super('pan', props, app);
+    this.panX = 0;
+    this.panY = 0;
+    this.passes = [];
+    this.drawn = [];
+  }
+
+  /** The region the drawing lives in — the whole node here. */
+  viewport() {
+    return { ...this.abs };
+  }
+
+  pan(dx, dy) {
+    this.panX += dx;
+    this.panY += dy;
+    return this.scrollContents(this.viewport(), dx, dy);
+  }
+
+  /**
+   * A world grid drawn at the pan offset — a *translation* of itself and
+   * nothing else, which is exactly the promise `scrollContents` makes. Wide
+   * enough that the pane is covered at every offset these tests reach.
+   */
+  cells() {
+    const vp = this.abs;
+    const out = [];
+    for (let row = -8; row < 20; row++) {
+      for (let col = -8; col < 20; col++) {
+        out.push({
+          x: vp.x + col * CELL + this.panX,
+          y: vp.y + row * CELL + this.panY,
+          width: CELL - 4,
+          height: CELL - 4,
+          color: (row + col) % 2 ? '#2ecc71' : '#e74c3c',
+        });
+      }
+    }
+    return out;
+  }
+
+  paint(ctx) {
+    super.paint(ctx);
+    const damage = this.paintDamage();
+    this.passes.push(damage);
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(this.abs.x, this.abs.y, this.abs.width, this.abs.height);
+    ctx.clip();
+    let drawn = 0;
+    for (const cell of this.cells()) {
+      if (damage && !overlaps(cell, damage)) continue;
+      ctx.fillStyle = cell.color;
+      ctx.fillRect(cell.x, cell.y, cell.width, cell.height);
+      drawn += 1;
+    }
+    ctx.restore();
+    this.drawn.push(drawn);
+  }
+}
+
+/** The same pane, but a scroll container too: the one element that could
+ * arm both halves of the blit in one frame. */
+class ScrollPanNode extends Scrollable(PanNode) {
+  isScroller() {
+    return true;
+  }
+
+  measureScrollContent() {
+    return { width: 2000, height: 2000 };
+  }
+}
+
+const registered = new Set();
+function register(type = 'pan', definition = {}) {
+  registerElement(type, {
+    create: (p, a) => new PanNode(p, a),
+    override: registered.has(type),
+    ...definition,
+  });
+  registered.add(type);
+}
+
+const blits = (wnd) => wnd.calls.filter(([name]) => name === 'scrollRegion');
+
+const area = (rects) => rects.reduce((sum, r) => sum + r.width * r.height, 0);
+
+async function mount({ paneProps = {}, extra = null, definition } = {}) {
+  register('pan', definition);
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const ref = React.createRef();
+  x11Root.render(
+    h(
+      'window',
+      { width: W, height: H, style: { backgroundColor: '#101820' } },
+      h('pan', { ref, style: { flexGrow: 1, margin: INSET }, ...paneProps }),
+      extra,
+    ),
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const node = ref.current;
+  wnd.calls.length = 0;
+  node.passes.length = 0;
+  node.drawn.length = 0;
+  return { app, wnd, node, root: node.root, x11Root };
+}
+
+test.afterEach(() => {
+  for (const type of registered) unregisterElement(type);
+  registered.clear();
+});
+
+test('a pan blits the region and repaints only the band it exposed', async () => {
+  const { wnd, node, root } = await mount();
+
+  // dragging the scene down: the pixels move down, and what comes in is a
+  // strip along the top
+  assert.strictEqual(node.pan(0, 40), true, 'the frame is a blit candidate');
+  await tick();
+
+  assert.deepStrictEqual(blits(wnd), [['scrollRegion', { ...VP }, 0, 40]]);
+  const rects = root._lastDamageRects;
+  assert.ok(rects, 'the frame stayed bounded');
+  assert.deepStrictEqual(
+    rects,
+    [{ x: VP.x, y: VP.y, width: VP.width, height: 40 }],
+    'the exposed strip and nothing else',
+  );
+  // and the element is told the band, so it culls to it
+  assert.deepStrictEqual(node.passes, [
+    { x: VP.x, y: VP.y, width: VP.width, height: 40 },
+  ]);
+  assert.ok(
+    node.drawn[0] < 30,
+    `drew ${node.drawn[0]} cells for a one-row strip`,
+  );
+});
+
+test('the band is on the side the pixels came from, on either axis', async () => {
+  const { wnd, node, root } = await mount();
+
+  node.pan(0, -40);
+  await tick();
+  assert.deepStrictEqual(blits(wnd).at(-1), [
+    'scrollRegion',
+    { ...VP },
+    0,
+    -40,
+  ]);
+  assert.deepStrictEqual(root._lastDamageRects, [
+    { x: VP.x, y: VP.y + VP.height - 40, width: VP.width, height: 40 },
+  ]);
+
+  node.pan(-24, 0);
+  await tick();
+  assert.deepStrictEqual(blits(wnd).at(-1), [
+    'scrollRegion',
+    { ...VP },
+    -24,
+    0,
+  ]);
+  assert.deepStrictEqual(root._lastDamageRects, [
+    { x: VP.x + VP.width - 24, y: VP.y, width: 24, height: VP.height },
+  ]);
+});
+
+test('a diagonal pan is one blit and two disjoint strips', async () => {
+  // The scroll path takes one axis at a time, because the L of exposed
+  // strips overlaps the scrollbar rects and the merges balloon back towards
+  // the whole viewport. There are no bars here, and a drag-pan is diagonal
+  // almost every frame.
+  const { wnd, node, root } = await mount();
+
+  node.pan(20, 30);
+  await tick();
+
+  assert.deepStrictEqual(blits(wnd), [['scrollRegion', { ...VP }, 20, 30]]);
+  const rects = root._lastDamageRects;
+  assert.deepStrictEqual(rects, [
+    { x: VP.x, y: VP.y, width: VP.width, height: 30 },
+    { x: VP.x, y: VP.y + 30, width: 20, height: VP.height - 30 },
+  ]);
+  assert.ok(
+    area(rects) < VP.width * VP.height * 0.25,
+    `repainted ${area(rects)}px² of ${VP.width * VP.height}`,
+  );
+});
+
+test('several pans in one frame blit once, by the net shift', async () => {
+  const { wnd, node } = await mount();
+
+  node.pan(0, 24);
+  node.pan(0, 24);
+  node.pan(0, -8);
+  await tick();
+
+  assert.deepStrictEqual(blits(wnd), [['scrollRegion', { ...VP }, 0, 40]]);
+});
+
+test('pans that cancel out claim the region and blit nothing', async () => {
+  const { wnd, node, root } = await mount();
+
+  node.pan(0, 24);
+  node.pan(0, -24);
+  await tick();
+
+  assert.deepStrictEqual(blits(wnd), [], 'no pixels moved');
+  assert.deepStrictEqual(
+    root._lastDamageRects,
+    [{ ...VP }],
+    'but the region was claimed, because the drawing may have changed',
+  );
+});
+
+test('a pan of nothing claims nothing at all', async () => {
+  const { wnd, node, root } = await mount();
+
+  assert.strictEqual(node.pan(0, 0), true);
+  await tick();
+
+  assert.deepStrictEqual(blits(wnd), []);
+  assert.strictEqual(root.needsPaint, false, 'no frame is owed');
+});
+
+test('other damage inside the region keeps the full repaint', async () => {
+  const { wnd, node, root } = await mount();
+
+  node.pan(0, 40);
+  // a hover restyle, a badge, a tooltip — changed pixels, which must not be
+  // blitted around
+  node.invalidate(false, { x: 100, y: 100, width: 20, height: 20 }, 'props');
+  await tick();
+
+  assert.deepStrictEqual(blits(wnd), [], 'not a pure shift: no blit');
+  assert.deepStrictEqual(node.passes, [{ ...VP }]);
+  assert.ok(root._lastDamageRects, 'still bounded, just not narrowed');
+});
+
+test('damage claimed before the frame’s first pan poisons it (#295)', async () => {
+  const { wnd, node } = await mount();
+
+  // The race the scroll path closes by poisoning at arming time: the claim
+  // lands while nothing is pending, so the claim-time check never tests it,
+  // and the region claim that follows coalesces the rect away.
+  node.invalidate(false, { x: 100, y: 100, width: 20, height: 20 }, 'props');
+  assert.strictEqual(node.pan(0, 40), false, 'and the call says so');
+  await tick();
+
+  assert.deepStrictEqual(blits(wnd), []);
+});
+
+test('a claim between two pans cannot re-arm the blit mid-frame (#295)', async () => {
+  const { wnd, node } = await mount();
+
+  node.pan(0, 40); // arms
+  node.invalidate(false, { x: 100, y: 100, width: 20, height: 20 }, 'props');
+  assert.strictEqual(node.pan(0, 40), false, 'poisoned, not disarmed');
+  await tick();
+
+  assert.deepStrictEqual(
+    blits(wnd),
+    [],
+    'a band displaced by the first delta is not a band anybody repainted',
+  );
+});
+
+test('two regions of one node in a frame is not one CopyArea', async () => {
+  const { wnd, node } = await mount();
+
+  node.scrollContents({ ...VP }, 0, 40);
+  node.scrollContents({ ...VP, height: 200 }, 0, 40);
+  await tick();
+
+  assert.deepStrictEqual(blits(wnd), []);
+});
+
+test('a child laid out over the region keeps the full repaint', async () => {
+  // A scroll container's children *are* the scrolled content. An element's
+  // are not: it draws the region itself and they sit on top, so one reaching
+  // in would have its pixels dragged along.
+  const { wnd, node } = await mount({
+    paneProps: {
+      children: h('box', {
+        style: {
+          position: 'absolute',
+          left: 300,
+          top: 300,
+          width: 40,
+          height: 40,
+          backgroundColor: '#ffffff',
+        },
+      }),
+    },
+  });
+
+  node.pan(0, 40);
+  await tick();
+  assert.deepStrictEqual(blits(wnd), []);
+});
+
+test('an overlapping sibling above the region keeps the full repaint', async () => {
+  const { wnd, node } = await mount({
+    extra: h('box', {
+      style: {
+        position: 'absolute',
+        left: 200,
+        top: 200,
+        width: 60,
+        height: 60,
+        backgroundColor: '#ffffff',
+      },
+    }),
+  });
+
+  node.pan(0, 40);
+  await tick();
+  assert.deepStrictEqual(blits(wnd), []);
+});
+
+test('a rounded corner on the element itself keeps the full repaint', async () => {
+  // the ring and the corners are `Node.paint`'s, not the element's drawing,
+  // and they do not translate
+  const { wnd, node } = await mount({
+    paneProps: { style: { flexGrow: 1, margin: INSET, borderRadius: 8 } },
+  });
+
+  node.pan(0, 40);
+  await tick();
+  assert.deepStrictEqual(blits(wnd), []);
+});
+
+test('a region outside the element is refused', async () => {
+  const { wnd, node } = await mount({
+    paneProps: { style: { flexGrow: 1, margin: INSET } },
+  });
+
+  // the whole window, from a node that owns the inset box inside it
+  node.scrollContents({ x: 0, y: 0, width: W, height: H }, 0, 40);
+  await tick();
+  assert.deepStrictEqual(blits(wnd), []);
+});
+
+test('a fractional shift or region keeps the full repaint', async () => {
+  const { wnd, node, root } = await mount();
+
+  node.pan(0, 12.5);
+  await tick();
+  assert.deepStrictEqual(blits(wnd), [], 'only a whole-pixel shift is a copy');
+  assert.deepStrictEqual(root._lastDamageRects, [{ ...VP }]);
+
+  node.scrollContents({ ...VP, y: VP.y + 0.5 }, 0, 40);
+  await tick();
+  assert.deepStrictEqual(blits(wnd), []);
+});
+
+test('the worth-it gates: a small region, and a shift that keeps too little', async () => {
+  const { wnd, node } = await mount();
+
+  // 120x120 is 14400px², below the area a repaint is one cheap pass at
+  node.scrollContents({ x: VP.x, y: VP.y, width: 120, height: 120 }, 0, 20);
+  await tick();
+  assert.deepStrictEqual(blits(wnd), [], 'not worth the bookkeeping');
+
+  node.pan(0, 260); // 35% of the region survives
+  await tick();
+  assert.deepStrictEqual(blits(wnd), [], 'the exposed band is most of it');
+
+  node.pan(0, H); // nothing survives at all
+  await tick();
+  assert.deepStrictEqual(blits(wnd), []);
+});
+
+test('an ntk without scrollRegion gets the old behaviour untouched', async () => {
+  const { wnd, node, root } = await mount();
+  delete wnd.scrollRegion;
+
+  node.pan(0, 40);
+  await tick();
+
+  assert.deepStrictEqual(node.passes, [{ ...VP }]);
+  assert.ok(root._lastDamageRects, 'the region claim stands');
+});
+
+test('a refused blit falls back to the full repaint', async () => {
+  const { wnd, node } = await mount();
+  wnd.scrollRegion = () => false;
+
+  node.pan(0, 40);
+  await tick();
+  assert.deepStrictEqual(node.passes, [{ ...VP }]);
+});
+
+test('REACT_X11_DEBUG_PAINT is on the whole window, so it blits nothing', async () => {
+  // the overlay draws over the pane; a blit would drag a shifted copy along
+  const { wnd, node, root } = await mount();
+  root._highlight = { abs: { x: 0, y: 0, width: 10, height: 10 } };
+
+  node.pan(0, 40);
+  await tick();
+  assert.deepStrictEqual(blits(wnd), []);
+});
+
+test('a Scrollable that also shifts its own drawing does neither', async () => {
+  // Two shifts of the same pixels in one frame, and a frame can only have
+  // one — whichever armed first. Both orders, because the arming is a `??=`
+  // in two different places.
+  const scrollable = { create: (p, a) => new ScrollPanNode(p, a) };
+
+  const first = await mount({ definition: scrollable });
+  first.node.pan(0, 40);
+  first.node.scrollTo(20);
+  await tick();
+  assert.deepStrictEqual(blits(first.wnd), [], 'contents armed, then scrollTo');
+
+  const second = await mount({ definition: scrollable });
+  second.node.scrollTo(20);
+  second.node.pan(0, 40);
+  await tick();
+  assert.deepStrictEqual(
+    blits(second.wnd),
+    [],
+    'scrollTo armed, then contents',
+  );
+});
+
+// --- and that the pixels are right ---------------------------------------
+
+async function headlessApp() {
+  const server = xserver.createServer({ width: 640, height: 480 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  return createClient({ stream: clientEnd });
+}
+
+const settle = (app) =>
+  new Promise((resolve, reject) =>
+    app.X.GetInputFocus((err) => (err ? reject(err) : resolve())),
+  );
+
+const readPixels = (ctx) =>
+  new Promise((resolve, reject) =>
+    ctx.getImageData(0, 0, W, H, (err, data) =>
+      err ? reject(err) : resolve(Buffer.from(data.data)),
+    ),
+  );
+
+test('a blitted pan is byte-identical to the repaint it replaced', async (t) => {
+  register();
+  const app = await headlessApp();
+  const x11Root = await createRoot({ app });
+  try {
+    const ref = React.createRef();
+    const instance = await new Promise((resolve) =>
+      x11Root.render(
+        h(
+          'window',
+          { width: W, height: H, style: { backgroundColor: '#101820' } },
+          h('pan', { ref, style: { flexGrow: 1, margin: INSET } }),
+        ),
+        resolve,
+      ),
+    );
+    if (typeof instance.scrollRegion !== 'function') {
+      t.skip('installed ntk has no Window.scrollRegion yet');
+      return;
+    }
+    const node = ref.current;
+    const root = node.root;
+    const frame = () => {
+      root._scheduled = false;
+      root.flush();
+    };
+    frame();
+    await settle(app);
+
+    let blitCalls = 0;
+    const real = instance.scrollRegion.bind(instance);
+    instance.scrollRegion = (...args) => {
+      blitCalls += 1;
+      return real(...args);
+    };
+
+    // the diagonal case, which is the one a drag-pan actually produces
+    node.drawn.length = 0;
+    node.pan(20, 30);
+    frame();
+    await settle(app);
+    assert.strictEqual(blitCalls, 1, 'the fast path fired');
+    assert.ok(root._lastDamageRects, 'and the frame stayed bounded');
+    assert.ok(
+      node.drawn[0] < 60,
+      `drew ${node.drawn[0]} cells for two strips, out of ${node.cells().length}`,
+    );
+    const blitted = await readPixels(
+      root._ctx ?? (root._ctx = root.window.getContext('2d')),
+    );
+
+    // the same scene again with no bound: the ground truth
+    root.invalidate(false);
+    frame();
+    await settle(app);
+    const repainted = await readPixels(root._ctx);
+
+    assert.ok(
+      blitted.equals(repainted),
+      'blitted pixels differ from a full repaint of the same scene',
+    );
+  } finally {
+    await x11Root.unmount();
+    await app.close();
+  }
+});

--- a/test/types/extend.tsx
+++ b/test/types/extend.tsx
@@ -346,6 +346,7 @@ registerElement('miniticker', {
 class FlowNode extends Node {
   private zoom = 1;
   private hovered: string | null = null;
+  private dragFrom: { x: number; y: number } | null = null;
 
   constructor(props: Record<string, unknown>, app: never) {
     super('flow', props, app);
@@ -370,6 +371,19 @@ class FlowNode extends Node {
   defaultMouseLeave(_ev: MouseEvent): void {
     this.hovered = null;
     this.invalidate(false, this.abs, 'content');
+  }
+
+  // …and the pan (#303): the pixels moved, so the frame is a blit and a
+  // strip rather than a repaint of everything the drag translated
+  defaultMouseDrag(ev: MouseEvent): void {
+    const from = this.dragFrom ?? { x: ev.x, y: ev.y };
+    this.dragFrom = { x: ev.x, y: ev.y };
+    const armed: boolean = this.scrollContents(
+      this.contentBox(),
+      ev.x - from.x,
+      ev.y - from.y,
+    );
+    void armed;
   }
 
   paintContent(_ctx: unknown): void {


### PR DESCRIPTION
Closes #303.

`<box overflow="scroll">` has moved its surviving band inside ntk's backing store since #137/#139: a pure scroll of one viewport is a `CopyArea` plus a repaint of the strip it exposed, rather than a repaint of every pixel it translated. A pane that draws its own scene cannot reach any of that. The `Scrollable` mixin is the wrong shape for it — the content is unbounded in both directions, there is a zoom, and `contentWidth`/`contentHeight` mean nothing — and a raw blit without the `pendingScrolls` bookkeeping would reintroduce the race #295 closed.

Found building `<Flow>` in `@react-x11/components`, where a drag step costs ~400 requests with the seams of #305 and a **pan costs ~2465 by construction**: a pan translates every pixel, so the scoped claim those seams buy is the whole pane and there is nothing left to scope.

## The seam

`Node.scrollContents(rect, dx, dy)` is that dance made public.

```js
onDragPan(dx, dy) {
  this.panX += dx;
  this.panY += dy;
  this.scrollContents(this.contentBox(), dx, dy);
}
```

It claims `rect` — the conservative answer, and the one that stands if anything declines — and arms the frame to blit instead. At frame time core moves the surviving band and **narrows that claim to the band the shift exposed**, which `paintDamage()` then hands the paint. The element draws the strip and nothing else without ever asking whether the blit happened, and `paintContent` does not change at all.

`dx`/`dy` are how far the **pixels** moved — the sense `Surface.copyWithin` and ntk's `scrollRegion` use rather than a scroll offset's, because an element-owned viewport has no offsets to be the delta of.

## What the element promises, and what it does not

Only that inside `rect` the frame really is that translation. Every other way it could be false is core's to check, and each of them declines rather than misrenders: a claim from anywhere else reaching into the rect (poisoned at arming time *and* at claim time, the #295 shape), a sibling drawing over it, a child of the node laid out on top of it, the node's own border ring or rounded corner, a layout pass that moved something, a fractional rect or delta, and the worth-it heuristics. A `Scrollable` element that arms both halves in one frame gets neither.

**Diagonal shifts are allowed here**, unlike the scroll path — and that is the point rather than an oversight: a drag-pan is diagonal almost every frame. The scroll path takes one axis at a time because the L of exposed strips overlaps the scrollbar rects and the merges balloon back towards the whole viewport; with no bars the L is two disjoint rects and stays two.

## Numbers

New protocol-bench scenario, five diagonal pan steps over a 374-cell scene:

| | requests | composites | Mpx |
| --- | --- | --- | --- |
| `scrollContents` | 983 | 606 | 0.30 |
| `REACT_X11_NO_SCROLL_BLIT=1` | 9845 | 6533 | 4.22 |

The second row is not a separate code path — it is exactly the fallback every declined gate takes.

## Tests

Twenty-one in `test/element-scroll.test.js`, one per gate, plus the `.d.ts`, the type test and docs. The last one pins the other direction: a blitted diagonal pan reads back **byte-identical** to a full repaint of the same scene. Reverting the children check, the arm-time poison, the `scrollTo` interlock, or the side the band lands on each fails tests.

## Also here

`fix(deps): bump ntk to 7.7.0` as its own commit — `createPattern` (sidorares/ntk#265) and the scattered-subpath path cost (sidorares/ntk#267), which is the shape of every edge layer in a graph view. The protocol baseline moves with it and that drift is in the bump commit, so the feature commit's baseline diff is purely additive.

## Not in scope

Zoom stays a full repaint. Scaling resamples; it is not a blit, and a zoom is a gesture step where a pan is sixty of them a second.