### PR TITLE
feat(extending): the scene a registered element describes to a screen reader

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1144,7 +1144,11 @@ through the node seam (#257): `a11yRole`, `a11yTextState()` +
 `notifyA11yTextChanged()`, and the two optional writes `a11ySetSelection` /
 `a11yReplaceText` — normalized in `customTextState()` so a third-party
 editor is read by the paths `<textinput>` is read by, never by a second
-model. Next: a generic Popover and a file open/save
+model. An element that draws _things_ rather than text says so the same way
+(#304): `a11yScene()` lists them, `notifyA11ySceneChanged()` says the list
+moved, `a11ySceneAction()` takes what an AT does to one — reconciled by
+`id` into objects carrying ordinary `role`/`aria-*` props, so the whole
+model reads them as it reads a `<box>`. Next: a generic Popover and a file open/save
 dialog. **#85** (keyboard layout switching ignored) is done — ntk decodes
 the active XKB group, and `src/keyboard.js` keeps shortcuts on the Latin
 keysym even where XQuartz's keymap rewrite has left no Latin group

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -297,6 +297,55 @@ The seam is observed by the test spy exactly as core's is, so an editor in
 another package can assert what it says with no bus and no desktop —
 [below](#asserting-what-a-screen-reader-would-hear).
 
+### A scene of your own
+
+The other half of the same gap. A [registered element](extending.md) that
+_draws_ interactive things — a graph pane, a chart, a timeline, a seating
+plan — is one node, so it is one accessible: "Flow graph, group", with
+three hundred selectable nodes inside it that no assistive technology can
+see. It says what it drew and each one becomes a child:
+
+```js
+class FlowNode extends Node {
+  a11yScene() {
+    return this.nodes.map((node) => ({
+      id: node.id, // stable while it is on screen: this is identity
+      role: 'listitem',
+      name: node.label,
+      rect: node.rect, // window coordinates
+      states: {
+        selected: this.selection.has(node.id),
+        focused: this.cursor === node.id,
+      },
+    }));
+  }
+
+  select(id) {
+    /* …the element's own selection… */ this.notifyA11ySceneChanged();
+  }
+}
+```
+
+| member                        |                                                                                                       |
+| ----------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `a11yScene()`                 | `[{ id, rect, role, name, description, focusable, states, props, children }]`                         |
+| `notifyA11ySceneChanged()`    | the scene moved between commits — a drag, an animation, your own arrow keys                           |
+| `a11ySceneAction(id, action)` | an AT sent `'activate'`, `'focus'` or `'scroll'`. `true` claims it; anything else keeps core's answer |
+
+They are read by the same model everything else is: `role` and the
+`aria-*`-shaped states above become the AT-SPI role and state set, `rect`
+becomes the Component extents a magnifier tracks and focus is drawn around,
+and a change to any of it is announced as that child changing rather than as
+the pane being replaced. Keyboard navigation _between_ items stays the
+element's own — the window's focus manager holds the element, which is why
+`states.focused` is the only way the cursor inside it is reported.
+
+Activation with no `a11ySceneAction` is a synthetic click at the item's own
+rect, which is exactly what a mouse user does to it; the seam is for the
+elements where that is not the truth. See
+[extending.md](extending.md#a-scene-a-screen-reader-can-walk) for the whole
+contract.
+
 ## The compatibility ladder
 
 `createRoot()` starts one climb per process, off the critical path:
@@ -346,6 +395,9 @@ whatever the tree says. The seams, in increasing order of involvement:
 - `a11yTextState()` + `notifyA11yTextChanged()` — when your element draws
   text of its own, which is the one thing props cannot express
   ([above](#text-of-your-own)).
+- `a11yScene()` + `notifyA11ySceneChanged()` — when your element draws
+  interactive _things_ of its own, which is the other one
+  ([above](#a-scene-of-your-own)).
 
 ## Testing and verifying
 

--- a/docs/architecture/accessibility.md
+++ b/docs/architecture/accessibility.md
@@ -189,6 +189,10 @@ The accessible tree is the node tree through three rules:
   is _boring_ rather than noisy. Everything with real semantics defaults to
   them (window→FRAME, text→LABEL, textinput→ENTRY, image→IMAGE, …).
 
+…plus a fourth source of children that is not in the node tree at all: what
+a registered element says it drew (§8b), appended after whatever it holds
+retained.
+
 Two structural notes. `<popup>`s stay **nested**: a popup's `parent` is the
 JSX node it was written under, so a menu appears inside the widget that
 opened it — GTK4 does the same with popovers, and it preserves context that
@@ -318,6 +322,59 @@ Deliberately not in the seam: per-character extents (they need a layout
 only the element has; the fallback is the element's own rect, which is
 honest and keeps a magnifier tracking something real) and AT-driven
 copy/paste, which stay the built-ins' clipboard round trip.
+
+## 8b. Structure from elements core did not write (#304)
+
+The same gap one level up. An element that _draws_ N interactive things is
+one node and therefore one accessible — a graph pane reads as "group" with
+nothing inside — and unlike the text case there is no prop that could have
+said otherwise, because the objects an AT needs do not exist anywhere.
+`a11yScene()` is the pull that produces them: `[{ id, rect, role, name,
+states, props, children }]`, with `Node.notifyA11ySceneChanged()` as the
+push, routed through the existing `hooks.propsChanged` slot because
+"re-read this node's accessible facts and announce the difference" is
+exactly what that slot already means.
+
+Four decisions, in the order they bite:
+
+- **Objects, not descriptors.** Everything else here is answered from the
+  live tree (§4), and a scene has no live tree to answer from — the
+  element rebuilds its description every frame. So a11y.js reconciles the
+  frame's descriptions against the last frame's by `id` and returns the
+  _same_ objects where the id survived. That is what an export can be keyed
+  on: paths, snapshots and every ref an AT is holding stay valid across a
+  scene rebuilt sixty times a second, and an id that disappears is marked
+  defunct rather than forgotten, so the bridge can still walk what it is
+  losing. Identity is the one thing core cannot derive, which is why `id`
+  is the only required field besides the rect.
+- **A scene item is read by the model, not beside it.** It carries `props`
+  in the same `role`/`aria-*` vocabulary and an `abs` rect in the same
+  window coordinates, so `atspiRoleOf`, `a11yName`, `a11yStates`,
+  `a11yAttributes`, the extents, the cache items, the snapshot diff and the
+  test spy are all the code that already existed — the same "no second
+  model" rule §8a's normalizer follows. The friendly `states: { selected,
+checked, expanded, disabled, busy }` is a table of five entries into
+  those props; `focused` is the exception, because element-internal focus
+  never reaches a window's focus manager and there is no ARIA spelling for
+  it.
+- **Actions fall back rather than fail.** `a11ySceneAction(id, action)`
+  claims with `true`; anything else takes core's answer — for `activate`, a
+  synthetic click through the ordinary dispatch at the item's own rect. An
+  element hit-tests its scene already, so that is not an approximation of
+  the user's click, it _is_ it. A single multiplexed hook (rather than one
+  method per action) is what makes claiming `focus` and leaving `activate`
+  to core the default reading of the code rather than a trap.
+- **An action is offered where one lands.** The role table decides as it
+  does everywhere else, plus: an element that implements the seam makes
+  every item it drew activatable, because implementing it is the same
+  promise a handler is — and the roles a scene reaches for (`listitem` for
+  a graph node) are mostly ones ARIA promises nothing about.
+
+Deferred with it: hit testing descends into items (`GetAccessibleAtPoint`
+answers with the item under the point, which is what a magnifier following
+the pointer needs), but the **testing queries** still walk retained nodes
+only, so `getByRole` cannot find a drawn item — the same shape as #260,
+and it wants that issue's answer rather than a second one here.
 
 ## 9. Testing
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -661,6 +661,98 @@ The behaviour is assertable without a screen reader, a desktop or a bus:
 and `test/a11y-custom-text.test.js` in this repo is a worked editor and a
 worked viewer driven through it.
 
+### A scene a screen reader can walk
+
+_Issue #304._ An element that draws a hundred interactive things is still
+one node, so it is one accessible: a graph pane full of selectable,
+draggable, connectable nodes reads out as **"Flow graph, group"** and stops
+there. Nothing in it can be found, named, activated or told apart, and no
+amount of `role`/`aria-*` on the element itself changes that — the objects
+an assistive technology would need are not in the tree, because you drew
+them.
+
+Describe them and they are:
+
+```js
+class FlowNode extends Node {
+  a11yScene() {
+    return this.nodes.map((node) => ({
+      id: node.id, // stable for as long as it is on screen
+      role: 'listitem',
+      name: node.label,
+      rect: node.rect, // window coordinates, like `abs`
+      states: {
+        selected: this.selection.has(node.id),
+        focused: this.cursor === node.id,
+      },
+    }));
+  }
+
+  select(id) {
+    // …the element's own selection…
+    this.notifyA11ySceneChanged();
+  }
+}
+```
+
+Each becomes a real child of your element's accessible: named, placed,
+walked into, focusable, with `selected` announced as it changes — the same
+model a `<box role="listitem" aria-selected>` goes through, because that is
+literally what these are read as. `id` is the whole of what core needs from
+you: it is what makes the child that was there last frame the same child
+this frame, and therefore what keeps every reference a screen reader is
+holding alive across a scene you rebuild sixty times a second.
+
+| member                        | when                                                                                                                            |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `a11yScene()`                 | always, for an element that draws interactive things. Called once per question about your children — a cheap read, never a pass |
+| `notifyA11ySceneChanged()`    | the scene moved between commits: a drag, an animation, your own arrow keys. A commit re-reads it on its own                     |
+| `a11ySceneAction(id, action)` | an AT acted on one of them. Return `true` to claim it; anything else keeps core's answer                                        |
+
+What one item may say:
+
+| field                  |                                                                                                                      |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| `id`                   | required. Its name for as long as it is drawn — ids are matched within their parent, not globally                    |
+| `rect`                 | required. Where it is, in window coordinates: where AT focus is drawn and what a magnifier follows                   |
+| `role`                 | an ARIA role. `'group'` if it says none                                                                              |
+| `name` / `description` | what a screen reader says. An unnamed item announces as having none, which is the defect being loud                  |
+| `states`               | `selected`, `checked`, `expanded`, `disabled`, `busy`, and `focused` for your own keyboard cursor                    |
+| `focusable`            | default true                                                                                                         |
+| `props`                | anything else an element carries — `aria-posinset`/`aria-setsize` for Orca's "3 of 7", `aria-level`, `aria-valuenow` |
+| `children`             | a scene with structure: series and points, groups and nodes                                                          |
+
+Four things worth knowing before you write one:
+
+**`focused` is the only way your cursor is reported.** The window's focus
+manager holds your element, not the thing inside it that arrow keys move —
+which is right, and it means the state has to come from you. Reporting it
+is all that is asked: navigation between items stays yours.
+
+**Actions fall back rather than fail.** With no `a11ySceneAction`, an
+activation is a synthetic click at the item's own rect — you hit-test your
+scene already, so the rect is the whole address and an AT's click is
+indistinguishable from a mouse user's. `focus` focuses the element,
+`scroll` reveals it. Implement the seam for the cases where that is wrong
+(an activation that is not a click, a cursor to move, a viewport of your
+own to scroll), claim those with `true`, and let the rest fall through.
+
+**An action needs a role that promises one** — `button`, `option`,
+`treeitem`, `checkbox` — _or_ your `a11ySceneAction`, which is the same
+promise made directly. A `listitem` with neither is read, not clicked, the
+same as everywhere else in ARIA.
+
+**`a11yScene()` is called once per question**, so answer from what you
+already hold. It is the same rule `a11yTextState()` follows, for the same
+reason: a shaping pass or a copy of your model behind it turns a screen
+reader walking the tree into a frame budget.
+
+Assertable with no bus and no desktop, through the same spy:
+`renderX11(el, { a11y: true })` records an item's states changing exactly as
+it records a `<Checkbox>`'s, and `test/a11y-scene.test.js` is a worked graph
+pane. The wire itself — children, extents, actions — is covered in
+`test/atspi.test.js`.
+
 ### The standard edit menu
 
 A `<textinput>` gets a right-click Undo / Cut / Copy / Paste / Select All
@@ -1047,6 +1139,10 @@ And one place `paintDamage()` does not belong: inside `paintCached`
 its own coordinates, and a copy culled against the window's damage is stored
 half-drawn under a key that says it is whole — so every later frame that hits
 the key gets the hole.
+
+The same scene has a second one-node problem, in the accessible tree rather
+than in the frame: see [A scene a screen reader can
+walk](#a-scene-a-screen-reader-can-walk).
 
 Worth it because the numbers are not small. `@react-x11/components`' `<Flow>`
 on a 300-node / 745-edge scene at 1100×700 costs ~2470 X requests and ~150 ms

--- a/src/a11y.js
+++ b/src/a11y.js
@@ -447,19 +447,25 @@ export function a11yPruned(node) {
 
 /**
  * A node's children as assistive technology sees them: pruned subtrees
- * gone, erased nodes replaced by their children. `<glarea>` children are 3D
- * scene nodes with their own vocabulary and no rectangles — a glarea is a
- * leaf up here.
+ * gone, erased nodes replaced by their children, and — for an element that
+ * draws its own scene — the items it says are in it (see below).
+ * `<glarea>` children are 3D scene nodes with their own vocabulary and no
+ * rectangles — a glarea is a leaf up here.
  */
 export function a11yChildren(node) {
   if (node.kind === 'glarea') return [];
   const out = [];
-  for (const child of node.children ?? []) {
-    if (child.destroyed || a11yPruned(child)) continue;
-    if (a11yErased(child)) out.push(...a11yChildren(child));
-    else out.push(child);
-  }
+  for (const child of node.children ?? []) accessibleInto(out, child);
+  // What an element drew comes after what it holds: both are its children,
+  // and only the retained ones have an order React gave them.
+  for (const item of a11ySceneItems(node)) accessibleInto(out, item);
   return out;
+}
+
+function accessibleInto(out, child) {
+  if (child.destroyed || a11yPruned(child)) return;
+  if (a11yErased(child)) out.push(...a11yChildren(child));
+  else out.push(child);
 }
 
 /** The accessible parent: the nearest ancestor that is itself in the
@@ -476,6 +482,230 @@ export function a11yParent(node) {
 export function a11yIndexIn(parent, node) {
   return a11yChildren(parent).indexOf(node);
 }
+
+// --------------------------------------------------------------------------
+// The scene an element draws (issue #304)
+// --------------------------------------------------------------------------
+//
+// A registered element that draws N interactive things — a graph, a chart, a
+// timeline, a seating plan — is one retained node, so it is one accessible:
+// "Flow graph, group", and nothing inside it exists. The way out is the same
+// one every canvas-scene toolkit ends up at (the web's fallback DOM, Qt's
+// QAccessibleInterface children): the element *describes* what it drew, and
+// those descriptions become accessible children.
+//
+// They are objects rather than plain descriptors because the bridge exports
+// one accessible per child and keys it on the object — a list rebuilt every
+// frame would otherwise be a tree that replaces itself between two reads,
+// with every ref an AT is holding dead. `id` is what survives the frame;
+// everything else is re-read from the element each time.
+//
+// Everything below is written so that a scene item is read by the same
+// functions a `<box>` is read by: it carries `props` in the same `role` /
+// `aria-*` vocabulary, an `abs` rect in the same window coordinates, and a
+// `parent`. There is no second model here, only a second way of producing
+// the one there is.
+
+/** The shared empty list, so a node with no scene allocates nothing. */
+const NO_ITEMS = Object.freeze([]);
+
+/** The states a scene item declares, and the prop each is read as. The
+ * element writes `selected`; the model reads `aria-selected` — the same
+ * props the element itself would have carried, so states are derived by
+ * `a11yStates` rather than by a table of their own. */
+const ITEM_STATE_PROPS = Object.entries({
+  selected: 'aria-selected',
+  checked: 'aria-checked',
+  expanded: 'aria-expanded',
+  busy: 'aria-busy',
+  disabled: 'disabled',
+});
+
+const finite = (value) => (Number.isFinite(value) ? value : 0);
+
+/**
+ * One thing an element drew, as an accessibility object. Data and identity
+ * only: what an assistive technology *does* to it is routed back to the
+ * element by the bridge, which is where every other AT-initiated behaviour
+ * lives.
+ */
+class SceneItem {
+  constructor(owner, parent, id) {
+    /** The element that drew this and the id it knows it by — the two
+     * halves of an action's address. */
+    this.a11yOwner = owner;
+    this.a11yId = id;
+    // The owner's element name on purpose: an item is part of that element,
+    // so a DEV warning about a role names the tag its author wrote rather
+    // than a word from in here. The role never falls through to the kind
+    // table anyway — `a11yRole` below is always set.
+    this.kind = owner.kind;
+    this.parent = parent;
+    this.children = NO_ITEMS;
+    this.props = {};
+    this.abs = { x: 0, y: 0, width: 0, height: 0 };
+    this.destroyed = false;
+    this.hidden = false;
+    /** What an item is when it names no role: audible, and promising
+     * nothing the element has not said. A real role — `listitem`,
+     * `button`, `treeitem` — is what makes it activatable. */
+    this.a11yRole = 'group';
+    /** The element's own keyboard cursor. It never reaches the window's
+     * focus manager, which is still holding the element itself. */
+    this.a11yFocused = false;
+    this.focusableByDefault = true;
+    /** id -> SceneItem for the nested scene, built only if there is one. */
+    this._a11ySceneCache = null;
+  }
+
+  /** The owning window, for the states and the coordinate systems. */
+  get root() {
+    return this.a11yOwner.root;
+  }
+
+  get isWindow() {
+    return false;
+  }
+
+  /** Re-read one frame's description. Same object, new facts. */
+  _read(desc) {
+    const props = { ...desc.props };
+    if (desc.role != null) props.role = desc.role;
+    if (desc.name != null) props['aria-label'] = String(desc.name);
+    if (desc.description != null) {
+      props['aria-description'] = String(desc.description);
+    }
+    const states = desc.states;
+    if (states) {
+      for (const [name, prop] of ITEM_STATE_PROPS) {
+        if (states[name] !== undefined) props[prop] = states[name];
+      }
+    }
+    this.props = props;
+    this.a11yFocused = states?.focused === true;
+    this.focusableByDefault = desc.focusable !== false;
+    const rect = desc.rect;
+    this.abs = {
+      x: finite(rect?.x),
+      y: finite(rect?.y),
+      width: finite(rect?.width),
+      height: finite(rect?.height),
+    };
+    const children = desc.children;
+    if (Array.isArray(children) && children.length > 0) {
+      this._a11ySceneCache ??= new Map();
+      this.children = reconcileScene(
+        this.a11yOwner,
+        this,
+        children,
+        this._a11ySceneCache,
+      );
+    } else {
+      if (this._a11ySceneCache?.size > 0) dropScene(this._a11ySceneCache);
+      this.children = NO_ITEMS;
+    }
+  }
+}
+
+/** An item that left the scene is defunct rather than forgotten: an AT may
+ * still be holding it, and the bridge has to walk the subtree it is losing
+ * to release the paths under it. */
+function markGone(item) {
+  item.destroyed = true;
+  for (const child of item.children) markGone(child);
+}
+
+function dropScene(cache) {
+  for (const item of cache.values()) markGone(item);
+  cache.clear();
+}
+
+const badIds = new Set();
+
+function devCheckItemId(owner, id, duplicate) {
+  if (process.env.NODE_ENV === 'production') return;
+  const key = `${owner.kind}:${id}:${duplicate}`;
+  if (badIds.has(key)) return;
+  badIds.add(key);
+  console.warn(
+    duplicate
+      ? `react-x11: <${owner.kind}> reported two accessible children with ` +
+          `the id "${id}" — ids address an item for the whole time it is on ` +
+          'screen, so the second one is dropped.'
+      : `react-x11: <${owner.kind}> reported an accessible child with no ` +
+          'id. An id is what keeps a child the same object across frames, ' +
+          'so this one is dropped.',
+  );
+}
+
+/**
+ * Match one frame's descriptions against the objects the last frame left:
+ * an id that is still there keeps its object — and with it its D-Bus path,
+ * its snapshot and every ref an AT is holding — a new one gets one, and one
+ * that is gone is marked defunct and dropped.
+ */
+function reconcileScene(owner, parent, declared, cache) {
+  if (!Array.isArray(declared) || declared.length === 0) {
+    if (cache.size > 0) dropScene(cache);
+    return NO_ITEMS;
+  }
+  const items = [];
+  const seen = new Set();
+  for (const desc of declared) {
+    const id = desc == null ? '' : String(desc.id ?? '');
+    if (id === '' || seen.has(id)) {
+      devCheckItemId(owner, id, id !== '');
+      continue;
+    }
+    seen.add(id);
+    let item = cache.get(id);
+    if (!item) {
+      item = new SceneItem(owner, parent, id);
+      cache.set(id, item);
+    }
+    item._read(desc);
+    items.push(item);
+  }
+  for (const [id, item] of cache) {
+    if (seen.has(id)) continue;
+    markGone(item);
+    cache.delete(id);
+  }
+  return items;
+}
+
+/**
+ * What an element says it drew, as accessibility objects with an identity
+ * that survives the frame. Empty — and free — for everything that draws no
+ * scene, which is every element core ships.
+ *
+ * Called once per question the bridge answers about the element's children,
+ * so `a11yScene()` has to be a cheap read of what the element already
+ * holds, exactly as `a11yTextState()` is.
+ */
+export function a11ySceneItems(node) {
+  if (typeof node.a11yScene !== 'function') return NO_ITEMS;
+  node._a11ySceneCache ??= new Map();
+  return reconcileScene(node, node, node.a11yScene(), node._a11ySceneCache);
+}
+
+/** The accessible children of a node that are drawn rather than retained:
+ * an element's own scene, or a scene item's nested one. */
+export function sceneChildrenOf(node) {
+  if (typeof node.a11yScene === 'function') return a11ySceneItems(node);
+  return node.a11yOwner ? node.children : NO_ITEMS;
+}
+
+/** The scene items a node last reported, without asking it again — for
+ * teardown, where the element is going away and its answer is moot. */
+export function knownSceneItems(node) {
+  if (typeof node.a11yScene !== 'function') return NO_ITEMS;
+  const cache = node._a11ySceneCache;
+  return cache && cache.size > 0 ? [...cache.values()] : NO_ITEMS;
+}
+
+/** Whether this object is one of an element's drawn children. */
+export const isSceneItem = (node) => node instanceof SceneItem;
 
 // --------------------------------------------------------------------------
 // Name, description, states, value
@@ -584,8 +814,11 @@ export function a11yStates(node) {
     bit(states, S.SENSITIVE);
   }
   if (isFocusable(node)) bit(states, S.FOCUSABLE);
-  const manager = node._focusManager?.();
-  if (manager?.focused === node) bit(states, S.FOCUSED);
+  // A scene item's focus is the element's own answer: a cursor inside a
+  // drawn scene never reaches the window's focus manager, which is still
+  // holding the element itself.
+  const focused = node.a11yFocused ?? node._focusManager?.()?.focused === node;
+  if (focused) bit(states, S.FOCUSED);
 
   if (effectivelyVisible(node)) {
     bit(states, S.VISIBLE);
@@ -708,6 +941,11 @@ export function a11yAttributes(node) {
  * the tree, so the promise still holds). */
 export function a11yActivatable(node) {
   if (typeof node.props?.onClick === 'function') return true;
+  // A drawn item whose element answers actions is activatable whatever it
+  // is called: implementing the seam is the same promise a handler is, and
+  // the roles a scene reaches for — `listitem` for a graph node — are
+  // mostly ones ARIA does not make that promise about.
+  if (typeof node.a11yOwner?.a11ySceneAction === 'function') return true;
   const role = roleNameOf(node);
   return role !== null && ACTIVATABLE_ROLES.has(role);
 }
@@ -944,7 +1182,10 @@ export function devCheckA11yProps(node) {
  *    `<window>` entered or left a container.
  *  - `attached(parent, child)` — a node joined a live tree (also popups).
  *  - `detach(parent, child)` — about to leave; called while still wired.
- *  - `propsChanged(node)` — after applyProps landed new props.
+ *  - `propsChanged(node)` — after applyProps landed new props, and through
+ *    `Node.notifyA11ySceneChanged()` when what an element drew moved
+ *    without any prop doing so. Both mean the same thing to a listener:
+ *    re-read this node's accessible facts and announce the difference.
  *  - `textContent(node)` — a text chunk's string changed.
  *  - `textState(node)` — a text control's value/caret/selection may have
  *    moved (funnelled through `_repaint`, which every edit path calls, and

--- a/src/atspi.js
+++ b/src/atspi.js
@@ -45,6 +45,8 @@ import {
   a11yChildren,
   a11yParent,
   a11yIndexIn,
+  sceneChildrenOf,
+  knownSceneItems,
   a11yName,
   a11yDescription,
   a11yStates,
@@ -459,6 +461,22 @@ const AccessibleImpl = {
   },
 };
 
+/** The innermost scene item covering a window-coordinate point, or the node
+ * itself. Last one wins: items are declared in the order they were drawn,
+ * so the one on top is the one the user sees. */
+function deepestItemAt(node, x, y) {
+  let found = node;
+  for (const item of sceneChildrenOf(node)) {
+    if (item.destroyed || a11yPruned(item)) continue;
+    const r = item.abs;
+    if (x < r.x || y < r.y || x >= r.x + r.width || y >= r.y + r.height) {
+      continue;
+    }
+    found = deepestItemAt(item, x, y);
+  }
+  return found;
+}
+
 const ComponentImpl = {
   Contains(x, y) {
     const r = this.b.extentsOf(this.n, COORD_SCREEN);
@@ -477,6 +495,10 @@ const ComponentImpl = {
     }
     let hit = win.hitTest?.(wx, wy) ?? null;
     while (hit && (a11yErased(hit) || a11yPruned(hit))) hit = hit.parent;
+    // Hit testing stops at the retained tree, so an element that draws a
+    // scene answers with itself; the item under the point is what a
+    // magnifier following the pointer is actually over.
+    if (hit) hit = deepestItemAt(hit, wx, wy);
     return hit ? this.b.refFor(hit) : this.b.nullRef();
   },
   GetExtents(coordType) {
@@ -496,20 +518,23 @@ const ComponentImpl = {
     return LAYER_WIDGET;
   },
   GrabFocus() {
-    if (typeof this.n.focus !== 'function') return false;
-    this.n.focus();
-    return true;
+    return this.b.grabFocus(this.n);
   },
   GetAlpha() {
     return 1.0;
   },
   ScrollTo() {
+    if (this.b.sceneAction(this.n, 'scroll')) return true;
+    // A scene item has no layout of its own, so the most core can reveal is
+    // the element that drew it — an element that can do better says so
+    // through the action above.
+    const target = this.n.a11yOwner ?? this.n;
     // `isScroller()`, not "has the method": every `<box>` carries
     // `scrollIntoView` now, and one that is not a scroll container would end
     // the walk having revealed nothing
-    for (let p = this.n.parent; p; p = p.parent) {
+    for (let p = target.parent; p; p = p.parent) {
       if (p.isScroller?.()) {
-        p.scrollIntoView(this.n);
+        p.scrollIntoView(target);
         return true;
       }
     }
@@ -855,6 +880,9 @@ class AtspiBridge {
       value: a11yValue(node)?.now ?? null,
       ifaces: this.exported.get(node)?.ifaces ?? [],
       text: null,
+      // the drawn children, which arrive and leave without a mount to
+      // notice them; the shared empty list for everything that draws none
+      scene: sceneChildrenOf(node),
     };
     if (hasTextInterface(node)) {
       const { chars, caret, selection, preedit } = textStateOf(node);
@@ -949,14 +977,50 @@ class AtspiBridge {
 
   // ---- AT-initiated behaviour -----------------------------------------
 
+  /**
+   * Offer an action on a scene item to the element that drew it. `true`
+   * means the element handled it; anything else — including not
+   * implementing the seam — falls through to core's default, which is why
+   * an element may answer only the actions it has an answer for.
+   */
+  sceneAction(node, action) {
+    const owner = node.a11yOwner;
+    if (!owner || owner.destroyed) return false;
+    return owner.a11ySceneAction?.(node.a11yId, action) === true;
+  }
+
+  /** GrabFocus. An element owns the keyboard among the items it drew — the
+   * window's focus manager only ever holds the element — so the item asks
+   * it first and otherwise focuses the element itself, which is where the
+   * keys that move between items go anyway. */
+  grabFocus(node) {
+    if (this.sceneAction(node, 'focus')) return true;
+    const target = node.a11yOwner ?? node;
+    if (typeof target.focus !== 'function') return false;
+    target.focus();
+    return true;
+  }
+
   /** DoAction("activate"): a synthetic click through the same dispatch a
    * real press uses — capture, bubble, default actions, discrete-priority
    * commit and paint — so an AT's activation is indistinguishable from the
-   * user's. */
+   * user's. On a scene item it is the click a mouse user would make on
+   * what was drawn there: the element hit-tests its own scene already, so
+   * the item's rect is the whole address, and an element whose activation
+   * is not a click says so through `a11ySceneAction`. */
   activate(node) {
+    if (node.a11yOwner) {
+      if (this.sceneAction(node, 'activate')) return true;
+      if (node.destroyed) return false;
+      return this._click(node.a11yOwner, node.abs);
+    }
+    return this._click(node, node.abs);
+  }
+
+  _click(node, rect) {
     const manager = node.root?.events;
     if (!manager || node.destroyed) return false;
-    const abs = node.abs ?? { x: 0, y: 0, width: 0, height: 0 };
+    const abs = rect ?? { x: 0, y: 0, width: 0, height: 0 };
     const native = {
       x: Math.round(abs.x + abs.width / 2),
       y: Math.round(abs.y + abs.height / 2),
@@ -1224,10 +1288,13 @@ class AtspiBridge {
       const wasExported = this.exported.has(child);
       const childPath = this.pathOf(child);
       const childRef = [this.bus.name, childPath];
-      // unexport the whole subtree the AT may hold refs into; each exported
-      // node also tells the client caches it is gone
+      // unexport the whole subtree the AT may hold refs into — the drawn
+      // children included, read from what the element last said rather than
+      // by asking one that is being torn down; each exported node also
+      // tells the client caches it is gone
       const walk = (n) => {
         for (const c of n.children ?? []) walk(c);
+        for (const item of knownSceneItems(n)) walk(item);
         this._unexport(n);
       };
       walk(child);
@@ -1369,6 +1436,59 @@ class AtspiBridge {
       }
     }
     if (before.text && now.text) this._diffText(node, before.text, now.text);
+    if (before.scene.length > 0 || now.scene.length > 0) {
+      this._diffScene(node, before.scene, now.scene);
+    }
+  }
+
+  /**
+   * The items an element drew, as children arriving and leaving. Identity
+   * is the element's own id, resolved in a11y.js, so a scene rebuilt every
+   * frame produces events only where something actually changed — and a
+   * surviving item is re-diffed through `syncNode`, the same path a
+   * `<box>`'s props take, which is what gets its name and its selected
+   * state onto the bus without a second diff living here.
+   */
+  _diffScene(parent, before, now) {
+    const kept = new Set(now);
+    for (const item of before) {
+      if (kept.has(item)) continue;
+      if (!this.exported.has(item)) continue;
+      const ref = [this.bus.name, this.pathOf(item)];
+      const walk = (n) => {
+        for (const c of n.children ?? []) walk(c);
+        this._unexport(n);
+      };
+      walk(item);
+      this._signal(
+        this.pathOf(parent),
+        IFACE.EVENT_OBJECT,
+        'ChildrenChanged',
+        'remove',
+        // where it was: the retained children it sat behind, then its own
+        // place in the scene it has just left
+        a11yChildren(parent).length - now.length + before.indexOf(item),
+        0,
+        ['(so)', ref],
+      );
+    }
+    const gone = new Set(before);
+    for (const item of now) {
+      if (gone.has(item)) {
+        this.syncNode(item);
+        continue;
+      }
+      this.emitCacheAdd(item);
+      this._signal(
+        this.pathOf(parent),
+        IFACE.EVENT_OBJECT,
+        'ChildrenChanged',
+        'add',
+        a11yIndexIn(parent, item),
+        0,
+        ['(so)', this.refFor(item)],
+      );
+    }
   }
 
   syncText(node) {

--- a/src/node.d.ts
+++ b/src/node.d.ts
@@ -96,6 +96,56 @@ export interface A11yTextState {
 }
 
 /**
+ * One thing an element drew, as an assistive technology should meet it
+ * (`a11yScene`). Everything but `id` and `rect` is optional, and what is
+ * left out is simply not claimed.
+ */
+export interface A11ySceneItem {
+  /** This item's name for the whole time it is on screen. Identity is
+   * matched on it frame to frame, so a fresh id per frame is a child that
+   * is destroyed and recreated under every screen reader holding it. */
+  id: string;
+  /** Where it is drawn, in the owning window's coordinates — the same
+   * space as `abs` and a mouse event's `x`/`y`. Where AT focus draws and
+   * what a magnifier follows. */
+  rect: Rect;
+  /** The ARIA role it plays. `'group'` when it says none, which is
+   * audible and promises nothing. A role that promises activation
+   * (`button`, `option`, `treeitem`, …) gives it an AT-SPI action, and so
+   * does the element implementing `a11ySceneAction`. */
+  role?: string;
+  /** What a screen reader says. Anything unnamed is announced as having no
+   * accessible name, which is the defect being loud rather than hidden. */
+  name?: string;
+  description?: string;
+  /** Whether an AT may put its focus here. Default true. */
+  focusable?: boolean;
+  states?: {
+    selected?: boolean;
+    checked?: boolean | 'mixed';
+    expanded?: boolean;
+    disabled?: boolean;
+    busy?: boolean;
+    /** The element's own keyboard cursor — the item arrow keys would act
+     * on. Element-internal focus never reaches the window's focus manager,
+     * so this is the only way it is reported. */
+    focused?: boolean;
+  };
+  /** Anything else this item would carry as an element: `aria-level`,
+   * `aria-posinset`/`aria-setsize` (Orca's "3 of 7"), `aria-valuenow`,
+   * `aria-keyshortcuts`, `aria-hidden`. Read exactly as they are on a
+   * `<box>`; the fields above win where they overlap. */
+  props?: Record<string, unknown>;
+  /** A scene with structure — series and points, groups and nodes. Ids are
+   * matched within their parent, so they only have to be unique there. */
+  children?: A11ySceneItem[];
+}
+
+/** What an assistive technology asks an element to do with one of the
+ * things it drew. */
+export type A11ySceneAction = 'activate' | 'focus' | 'scroll';
+
+/**
  * The `measureContent` body for content with a natural size and an aspect
  * ratio to keep — `<image>` and `<svg>` are written on it:
  *
@@ -418,6 +468,33 @@ export declare class Node {
    * text rather than guarding it.
    */
   notifyA11yTextChanged(): void;
+  /**
+   * The interactive things this element draws, as accessible children
+   * (docs/extending.md). Without it a scene of any size is one accessible
+   * — "Flow graph, group" — and nothing in it can be found, named or
+   * activated.
+   *
+   * Called once per question asked about this element's children, so
+   * answer from state the element already holds: no layout pass, no copy.
+   */
+  a11yScene?(): A11ySceneItem[];
+  /**
+   * An assistive technology acted on one of them: `id` is the one this
+   * element gave it. Return `true` to claim the action; anything else
+   * falls back to core — a synthetic click at the item's rect for
+   * `activate`, focusing the element for `focus`, revealing the element
+   * for `scroll` — so an element only answers what it has a better answer
+   * for.
+   */
+  a11ySceneAction?(id: string, action: A11ySceneAction): boolean | void;
+  /**
+   * The scene reported by `a11yScene()` has changed — an item added or
+   * removed, one selected, the keyboard cursor moved. A commit re-reads it
+   * on its own, so this is for what the element does between commits: a
+   * drag, an animation, its own arrow keys. Free when nothing is
+   * listening.
+   */
+  notifyA11ySceneChanged(): void;
   /** Props changed. A subclass calls `super.applyProps(next, prev)`. */
   applyProps(
     nextProps: Record<string, unknown>,

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -2236,6 +2236,23 @@ export class Node {
     a11yHooks.textState?.(this);
   }
 
+  /**
+   * The scene this element reports through `a11yScene()` has changed — an
+   * item added or removed, one selected, the element's own cursor moved
+   * onto another one (#304). The children an assistive technology is
+   * holding are re-read and the difference announced.
+   *
+   * A scene that is a function of the props needs no call: a commit already
+   * re-reads it. This is for everything the element does on its own —
+   * a drag, an animation, its own arrow keys.
+   *
+   * Free when nobody is listening, the same one property read
+   * `notifyA11yTextChanged()` costs.
+   */
+  notifyA11ySceneChanged() {
+    a11yHooks.propsChanged?.(this);
+  }
+
   /** Where focus for this node lives: its own window's EventManager, or —
    * inside a `<popup>`, which never receives the X input focus — the owner
    * window's (see EventManager.focusManager). */

--- a/src/testing/a11y.js
+++ b/src/testing/a11y.js
@@ -52,6 +52,7 @@ import {
   a11yStates,
   a11yValue,
   a11yParent,
+  sceneChildrenOf,
   hasTextInterface,
   textStateOf,
   inPreedit,
@@ -343,6 +344,10 @@ export class A11ySpy {
     if (node.destroyed || CONTENT_KINDS.has(node.kind)) return;
     if (!this._snapshots.has(node)) this._resnapshot(node);
     for (const child of node.children ?? []) this._snapshotTree(child);
+    // what an element drew is baselined with everything else, or the first
+    // thing that happens to an item — the selection landing on it — reads
+    // as a mount and says nothing
+    for (const item of sceneChildrenOf(node)) this._snapshotTree(item);
   }
 
   /**
@@ -460,6 +465,12 @@ export class A11ySpy {
         });
       }
     }
+
+    // An element that draws its own children reports them through the one
+    // notification it makes about itself (#304), so they are diffed here
+    // rather than through a feed of their own — a scene item is a node to
+    // everything above.
+    for (const item of sceneChildrenOf(node)) this._diffNode(item);
   }
 }
 

--- a/test/a11y-scene.test.js
+++ b/test/a11y-scene.test.js
@@ -1,0 +1,415 @@
+// The scene an element draws, as accessible children (#304): a registered
+// element that paints N interactive things into one node describes them, and
+// an assistive technology meets each one — named, placed, selectable,
+// activatable — instead of meeting a single "group" with nothing in it.
+//
+// The element under test is a miniature graph pane, which is the shape the
+// issue came from: nodes it draws itself, a selection and a keyboard cursor
+// of its own, and no retained children at all. Everything goes through
+// `react-x11/host` and `react-x11/node`, because the point is that a sibling
+// package can do this without reaching into src/.
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+
+import { registerElement, unregisterElement } from '../src/host.js';
+import { Node } from '../src/node.js';
+import {
+  ATSPI_ROLE,
+  ATSPI_STATE,
+  atspiRoleOf,
+  a11yChildren,
+  a11yIndexIn,
+  a11yName,
+  a11yParent,
+  a11yStates,
+  a11yActivatable,
+  a11ySceneItems,
+  isSceneItem,
+} from '../src/a11y.js';
+import { cleanup, renderX11, screen } from '../src/testing/index.js';
+
+const h = React.createElement;
+
+const hasState = (states, bit) =>
+  bit < 32
+    ? Boolean(states[0] & (1 << bit))
+    : Boolean(states[1] & (1 << (bit - 32)));
+
+/**
+ * A graph pane: it draws its nodes into its own rectangle, keeps the
+ * selection and the keyboard cursor itself, and has no children in the
+ * retained tree. `a11yScene()` is the whole of what it says about them —
+ * everything below it is the element's own behaviour, which is what makes
+ * the point that the seam reports state rather than owning it.
+ */
+class GraphNode extends Node {
+  constructor(props, app) {
+    super('minigraph', props, app);
+    this.focusableByDefault = true;
+    this.selected = null;
+    this.cursor = null;
+    /** what an AT asked this element to do, for the assertions */
+    this.acted = [];
+    this.handles = null;
+  }
+
+  a11yScene() {
+    return (this.props.nodes ?? []).map((node) => ({
+      id: node.id,
+      role: 'listitem',
+      name: node.label,
+      rect: { x: node.x, y: node.y, width: 60, height: 20 },
+      states: {
+        selected: this.selected === node.id,
+        focused: this.cursor === node.id,
+        disabled: node.disabled === true,
+      },
+      props: { 'aria-setsize': this.props.nodes.length },
+      children: node.ports?.map((port) => ({
+        id: port,
+        role: 'option',
+        name: port,
+        rect: { x: node.x, y: node.y + 20, width: 12, height: 12 },
+      })),
+    }));
+  }
+
+  a11ySceneAction(id, action) {
+    this.acted.push([id, action]);
+    if (this.handles && !this.handles.includes(action)) return false;
+    if (action === 'focus') this.cursor = id;
+    if (action === 'activate') this.select(id);
+    return true;
+  }
+
+  select(id) {
+    this.selected = id;
+    this.notifyA11ySceneChanged();
+  }
+
+  moveCursor(id) {
+    this.cursor = id;
+    this.notifyA11ySceneChanged();
+  }
+}
+
+/** An element that draws things and says nothing else about them. */
+class BareSceneNode extends Node {
+  constructor(props, app) {
+    super('minibare-scene', props, app);
+  }
+
+  a11yScene() {
+    return this.props.items ?? [];
+  }
+}
+
+const registered = new Set();
+function registerAll() {
+  for (const [type, create] of [
+    ['minigraph', (props, app) => new GraphNode(props, app)],
+    ['minibare-scene', (props, app) => new BareSceneNode(props, app)],
+  ]) {
+    registerElement(type, {
+      create,
+      semanticNames: ['nodes', 'items'],
+      childrenAllowed: false,
+    });
+    registered.add(type);
+  }
+}
+
+afterEach(async () => {
+  await cleanup();
+  for (const type of registered) unregisterElement(type);
+  registered.clear();
+});
+
+const NODES = [
+  { id: 'a', label: 'Fetch', x: 10, y: 10 },
+  { id: 'b', label: 'Parse', x: 10, y: 50 },
+  { id: 'c', label: 'Render', x: 10, y: 90 },
+];
+
+const graphOf = () => screen.all((n) => n.kind === 'minigraph')[0];
+
+async function renderGraph(nodes = NODES, props = {}) {
+  registerAll();
+  await renderX11(
+    h('minigraph', { nodes, style: { width: 200, height: 140 }, ...props }),
+    { backend: 'mock' },
+  );
+  return graphOf();
+}
+
+// ---------------------------------------------------------------------------
+// The projection: what an element that drew a scene is, to the model
+// ---------------------------------------------------------------------------
+
+test('a drawn scene is children, where the tree has none', async () => {
+  const graph = await renderGraph();
+  assert.equal(graph.children.length, 0, 'nothing retained under it');
+
+  const children = a11yChildren(graph);
+  assert.equal(children.length, 3);
+  assert.deepEqual(
+    children.map((item) => [a11yName(item), atspiRoleOf(item)]),
+    [
+      ['Fetch', ATSPI_ROLE.LIST_ITEM],
+      ['Parse', ATSPI_ROLE.LIST_ITEM],
+      ['Render', ATSPI_ROLE.LIST_ITEM],
+    ],
+  );
+  // and they are children in the full sense: the walk back up lands on the
+  // element, which is what an AT's Parent/GetIndexInParent answer with
+  assert.ok(a11yParent(children[1]) === graph, 'the element is the parent');
+  assert.equal(a11yIndexIn(graph, children[1]), 1);
+  assert.equal(isSceneItem(children[0]), true);
+});
+
+test('an item is placed where it was drawn, in window coordinates', async () => {
+  const graph = await renderGraph();
+  const [first] = a11yChildren(graph);
+  assert.deepEqual(first.abs, { x: 10, y: 10, width: 60, height: 20 });
+  assert.ok(first.root === graph.root, 'the same window as the element');
+});
+
+test('an item with no role is audible and promises nothing', async () => {
+  registerAll();
+  await renderX11(
+    h('minibare-scene', {
+      items: [{ id: 'x', name: 'Slice', rect: { x: 0, y: 0, w: 1 } }],
+    }),
+    { backend: 'mock' },
+  );
+  const [item] = a11yChildren(
+    screen.all((n) => n.kind === 'minibare-scene')[0],
+  );
+  assert.equal(atspiRoleOf(item), ATSPI_ROLE.GROUPING);
+  assert.equal(a11yName(item), 'Slice');
+  // a rect written in some other vocabulary is zeroes, never NaN on the wire
+  assert.deepEqual(item.abs, { x: 0, y: 0, width: 0, height: 0 });
+  assert.equal(a11yActivatable(item), false, 'group promises no action');
+});
+
+test('states come from the same facts the element draws from', async () => {
+  const graph = await renderGraph([
+    ...NODES,
+    { id: 'd', label: 'Off', x: 10, y: 130, disabled: true },
+  ]);
+  graph.selected = 'b';
+  graph.cursor = 'c';
+
+  const [a, b, c, d] = a11yChildren(graph);
+  const S = ATSPI_STATE;
+  assert.ok(hasState(a11yStates(b), S.SELECTED), 'the selected one');
+  assert.ok(!hasState(a11yStates(a), S.SELECTED));
+  // declaring the state at all is what makes every item selectable
+  assert.ok(hasState(a11yStates(a), S.SELECTABLE));
+  // the element's own cursor, which never reaches the window's focus manager
+  assert.ok(hasState(a11yStates(c), S.FOCUSED), "the element's own cursor");
+  assert.ok(!hasState(a11yStates(b), S.FOCUSED));
+  assert.ok(hasState(a11yStates(a), S.FOCUSABLE), 'focusable by default');
+  assert.ok(hasState(a11yStates(a), S.SHOWING), 'the window is on screen');
+  assert.ok(!hasState(a11yStates(d), S.ENABLED), 'a disabled item');
+  assert.ok(!hasState(a11yStates(d), S.FOCUSABLE));
+  assert.ok(hasState(a11yStates(a), S.ENABLED));
+});
+
+test('the props escape hatch is read as it would be on a box', async () => {
+  const graph = await renderGraph();
+  const [first] = a11yChildren(graph);
+  const { a11yAttributes } = await import('../src/a11y.js');
+  assert.deepEqual(a11yAttributes(first), [
+    ['xml-roles', 'listitem'],
+    ['setsize', '3'],
+  ]);
+});
+
+test('a scene with structure nests', async () => {
+  const graph = await renderGraph([
+    { id: 'a', label: 'Fetch', x: 10, y: 10, ports: ['in', 'out'] },
+  ]);
+  const [node] = a11yChildren(graph);
+  const ports = a11yChildren(node);
+  assert.deepEqual(
+    ports.map((p) => a11yName(p)),
+    ['in', 'out'],
+  );
+  assert.ok(
+    a11yParent(ports[0]) === node,
+    'nested under the item, not the element',
+  );
+  assert.equal(atspiRoleOf(ports[1]), ATSPI_ROLE.LIST_ITEM);
+});
+
+test('an element with a scene keeps whatever it holds in the tree', async () => {
+  registerAll();
+  await renderX11(
+    h(
+      'box',
+      { role: 'group' },
+      h('text', null, 'Legend'),
+      h('minigraph', { nodes: NODES.slice(0, 1) }),
+    ),
+    { backend: 'mock' },
+  );
+  const box = screen.all((n) => n.props?.role === 'group')[0];
+  const children = a11yChildren(box);
+  // the retained child first, then what its sibling drew — under it
+  assert.equal(children.length, 2);
+  assert.equal(children[0].kind, 'text');
+  assert.equal(a11yChildren(children[1]).length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// Identity: the half that decides whether an AT's refs survive a frame
+// ---------------------------------------------------------------------------
+
+test('an id keeps its object across frames, so a ref stays alive', async () => {
+  const graph = await renderGraph();
+  const before = a11yChildren(graph);
+  // the same scene, described again — the element rebuilt every descriptor
+  const again = a11yChildren(graph);
+  // identity asserted as a boolean on purpose: a failing object comparison
+  // walks the whole retained tree through `a11yOwner` before it reports
+  assert.ok(
+    again.every((item, i) => item === before[i]),
+    'the same objects, not equal copies of them',
+  );
+
+  graph.select('b');
+  const selected = a11yChildren(graph);
+  assert.ok(selected[1] === before[1], 'a state change is not a new child');
+  assert.ok(hasState(a11yStates(selected[1]), ATSPI_STATE.SELECTED));
+});
+
+test('an item that leaves the scene is defunct, not forgotten', async () => {
+  const graph = await renderGraph();
+  const [, parse] = a11yChildren(graph);
+  graph.props = { ...graph.props, nodes: [NODES[0], NODES[2]] };
+
+  const after = a11yChildren(graph);
+  assert.deepEqual(
+    after.map((item) => a11yName(item)),
+    ['Fetch', 'Render'],
+  );
+  assert.equal(parse.destroyed, true, 'an AT still holding it hears defunct');
+  assert.ok(hasState(a11yStates(parse), ATSPI_STATE.DEFUNCT));
+  // and it does not come back as itself when the id returns
+  graph.props = { ...graph.props, nodes: NODES };
+  assert.ok(
+    a11yChildren(graph)[1] !== parse,
+    'a fresh object for a fresh child',
+  );
+});
+
+test('an item without an id is dropped, loudly', async () => {
+  registerAll();
+  const warnings = [];
+  const warn = console.warn;
+  console.warn = (...args) => warnings.push(args.join(' '));
+  try {
+    await renderX11(
+      h('minibare-scene', {
+        items: [
+          { id: 'one', name: 'One', rect: { x: 0, y: 0 } },
+          { name: 'nameless', rect: { x: 0, y: 0 } },
+          { id: 'one', name: 'again', rect: { x: 0, y: 0 } },
+        ],
+      }),
+      { backend: 'mock' },
+    );
+    const owner = screen.all((n) => n.kind === 'minibare-scene')[0];
+    const items = a11yChildren(owner);
+    assert.deepEqual(
+      items.map((item) => a11yName(item)),
+      ['One'],
+      'the id-less one and the duplicate are dropped',
+    );
+    assert.equal(warnings.length, 2);
+    assert.match(warnings[0], /<minibare-scene> reported an accessible child/);
+    assert.match(warnings[1], /two accessible children with the id "one"/);
+  } finally {
+    console.warn = warn;
+  }
+});
+
+test('an element that draws nothing costs nothing', async () => {
+  await renderGraph();
+  const plain = screen.all((n) => n.kind === 'minigraph')[0].root;
+  // the shared empty list, so walking an ordinary tree allocates none
+  assert.ok(
+    a11ySceneItems(plain) === a11ySceneItems(plain),
+    'one list, shared',
+  );
+  assert.equal(a11ySceneItems(plain).length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// The feed: what an assistive technology is told, through the same spy an
+// application's own suite uses
+// ---------------------------------------------------------------------------
+
+test('selecting a drawn node reaches the AT as that node changing', async () => {
+  registerAll();
+  const { at } = await renderX11(
+    h('minigraph', { nodes: NODES, style: { width: 200, height: 140 } }),
+    { a11y: true },
+  );
+  const graph = graphOf();
+  at.since();
+
+  graph.select('b');
+  const entries = at.since();
+  assert.deepEqual(
+    entries.map((e) => e.summary),
+    ['state: selected'],
+  );
+  assert.equal(a11yName(entries[0].node), 'Parse', 'the item, not the pane');
+
+  graph.moveCursor('c');
+  assert.deepEqual(
+    at.since().map((e) => e.summary),
+    ['state: focused'],
+  );
+});
+
+test('a scene that is a function of the props needs no notification', async () => {
+  registerAll();
+  const { at, rerender } = await renderX11(
+    h('minigraph', { nodes: NODES, style: { width: 200, height: 140 } }),
+    { a11y: true },
+  );
+  at.since();
+  await rerender(
+    h('minigraph', {
+      nodes: [{ ...NODES[0], label: 'Fetching…' }, ...NODES.slice(1)],
+      style: { width: 200, height: 140 },
+    }),
+  );
+  assert.deepEqual(
+    at.since().map((e) => e.summary),
+    ['name: Fetching…'],
+    'the commit re-read the scene on its own',
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Actions: the write half
+// ---------------------------------------------------------------------------
+
+test('an element answers the actions it has an answer for', async () => {
+  const graph = await renderGraph();
+  graph.handles = ['focus'];
+  const [, parse] = a11yChildren(graph);
+  // the routing the bridge performs, without a bus in the way
+  assert.equal(graph.a11ySceneAction(parse.a11yId, 'focus'), true);
+  assert.equal(graph.cursor, 'b');
+  assert.equal(graph.a11ySceneAction(parse.a11yId, 'activate'), false);
+  assert.deepEqual(graph.acted, [
+    ['b', 'focus'],
+    ['b', 'activate'],
+  ]);
+});

--- a/test/atspi.test.js
+++ b/test/atspi.test.js
@@ -40,13 +40,21 @@ const EDITABLE = 'org.a11y.atspi.EditableText';
 const VALUE = 'org.a11y.atspi.Value';
 const PROPERTIES = 'org.freedesktop.DBus.Properties';
 
-const ROLE = { APPLICATION: 75, FRAME: 23, BUTTON: 43, ENTRY: 79, LABEL: 29 };
+const ROLE = {
+  APPLICATION: 75,
+  FRAME: 23,
+  BUTTON: 43,
+  ENTRY: 79,
+  LABEL: 29,
+  LIST_ITEM: 32,
+};
 const STATE = {
   CHECKED: 4,
   EDITABLE: 7,
   ENABLED: 8,
   FOCUSABLE: 11,
   FOCUSED: 12,
+  SELECTED: 23,
 };
 const hasState = ([lo, hi], bit) =>
   bit < 32 ? Boolean(lo & (1 << bit)) : Boolean(hi & (1 << (bit - 32)));
@@ -817,6 +825,224 @@ describe('the AT-SPI bridge', { concurrency: 1, ...needsBroker }, () => {
     unregisterElement('minieditor');
     unregisterElement('minidoc');
     unregisterElement('miniown');
+  });
+
+  test('a drawn scene is children an AT can walk, name and act on', async () => {
+    // #304: an element that paints N interactive things is one accessible
+    // to the bridge and therefore one object to Orca — "group", nothing
+    // inside. What it says it drew has to arrive as real children, with
+    // rectangles, states, and actions that reach the element.
+    const { registerElement, unregisterElement } =
+      await import('../src/host.js');
+    const { Node } = await import('../src/node.js');
+
+    const clicks = [];
+    const routed = [];
+    let graphNode = null;
+
+    class MiniGraphNode extends Node {
+      constructor(props, app, kind = 'minigraph') {
+        super(kind, props, app);
+        this.focusableByDefault = true;
+        this.selected = null;
+      }
+      a11yScene() {
+        return (this.props.nodes ?? []).map((node, i) => ({
+          id: node.id,
+          role: this.props.itemRole ?? 'button',
+          name: node.label,
+          rect: {
+            x: this.abs.x + 8,
+            y: this.abs.y + 8 + i * 30,
+            width: 120,
+            height: 24,
+          },
+          states: { selected: this.selected === node.id },
+        }));
+      }
+      select(id) {
+        this.selected = id;
+        this.notifyA11ySceneChanged();
+      }
+    }
+
+    /** The other half of the seam: an element that answers for itself. */
+    class MiniChartNode extends MiniGraphNode {
+      constructor(props, app) {
+        super(props, app, 'minichart');
+      }
+      a11ySceneAction(id, action) {
+        routed.push([id, action]);
+        return true;
+      }
+    }
+
+    registerElement('minigraph', {
+      create: (props, app) => (graphNode = new MiniGraphNode(props, app)),
+      semanticNames: ['nodes', 'itemRole'],
+      childrenAllowed: false,
+    });
+    registerElement('minichart', {
+      create: (props, app) => new MiniChartNode(props, app),
+      semanticNames: ['nodes', 'itemRole'],
+      childrenAllowed: false,
+    });
+
+    const nodes = [
+      { id: 'fetch', label: 'Fetch' },
+      { id: 'parse', label: 'Parse' },
+    ];
+    const graph = (props) =>
+      h(
+        'window',
+        { title: 'Bridge Test', width: 320, height: 200 },
+        h('minigraph', {
+          nodes,
+          onClick: (ev) => clicks.push([ev.x, ev.y]),
+          style: { width: 200, height: 100 },
+          ...props,
+        }),
+        h('minichart', {
+          nodes,
+          // a role ARIA promises no activation for: the element answering
+          // actions is what makes these activatable anyway
+          itemRole: 'listitem',
+          style: { width: 200, height: 100 },
+        }),
+      );
+    x11Root.render(graph());
+    await settle();
+
+    const [graphRef, chartRef] = await call(
+      appBus,
+      framePath,
+      ACCESSIBLE,
+      'GetChildren',
+    );
+    const graphPath = graphRef[1];
+    const items = await call(appBus, graphPath, ACCESSIBLE, 'GetChildren');
+    assert.equal(items.length, 2, 'one accessible per drawn node');
+    const [fetchPath, parsePath] = items.map((ref) => ref[1]);
+
+    assert.equal(
+      await call(appBus, fetchPath, ACCESSIBLE, 'GetRole'),
+      ROLE.BUTTON,
+    );
+    assert.equal(
+      await getProp(appBus, parsePath, ACCESSIBLE, 'Name'),
+      'Parse',
+      'named, where the element was one nameless group',
+    );
+    assert.equal(
+      await call(appBus, parsePath, ACCESSIBLE, 'GetIndexInParent'),
+      1,
+    );
+    assert.deepEqual(
+      await getProp(appBus, parsePath, ACCESSIBLE, 'Parent'),
+      [appBus, graphPath],
+      'the element is the parent an AT walks back up to',
+    );
+
+    // a rectangle is what focus is drawn around and what a magnifier tracks
+    const extents = await call(
+      appBus,
+      parsePath,
+      COMPONENT,
+      'GetExtents',
+      'u',
+      [1],
+    );
+    assert.deepEqual(extents.slice(2), [120, 24]);
+    // …and the point inside it answers with the item, not with the element
+    const atPoint = await call(
+      appBus,
+      graphPath,
+      COMPONENT,
+      'GetAccessibleAtPoint',
+      'iiu',
+      [extents[0] + 4, extents[1] + 4, 1],
+    );
+    assert.deepEqual(atPoint, [appBus, parsePath]);
+
+    // activating one is the click a mouse user would make on it, at the
+    // rect the element drew — the element hit-tests its own scene already
+    assert.equal(
+      await call(appBus, parsePath, ACTION, 'DoAction', 'i', [0]),
+      true,
+    );
+    await until(() => clicks.length === 1, 'the click at the item');
+    const [x, y] = clicks[0];
+    assert.ok(
+      x >= extents[0] && x < extents[0] + 120,
+      'inside the item horizontally',
+    );
+    assert.ok(y >= extents[1] && y < extents[1] + 24, 'and vertically');
+
+    // a scene the element changes on its own reaches the bus as that child
+    // changing, not as the pane being rebuilt
+    signals.length = 0;
+    graphNode.select('parse');
+    await until(
+      () =>
+        eventsNamed('StateChanged').some(
+          (s) => s.path === parsePath && s.body[0] === 'selected',
+        ),
+      'the selection as a state change on the item',
+    );
+    assert.ok(
+      hasState(
+        await call(appBus, parsePath, ACCESSIBLE, 'GetState'),
+        STATE.SELECTED,
+      ),
+    );
+
+    // an item that leaves is a child removed, and its path goes with it
+    signals.length = 0;
+    x11Root.render(graph({ nodes: [nodes[0]] }));
+    await settle();
+    await until(
+      () =>
+        eventsNamed('ChildrenChanged').some(
+          (s) => s.path === graphPath && s.body[0] === 'remove',
+        ),
+      'the child removal',
+    );
+    await until(async () => {
+      try {
+        await call(appBus, parsePath, ACCESSIBLE, 'GetRole');
+        return false;
+      } catch {
+        return true; // the path went with it
+      }
+    }, 'the departed item to be unexported');
+    assert.equal(
+      (await call(appBus, graphPath, ACCESSIBLE, 'GetChildren')).length,
+      1,
+    );
+
+    // …and an element with an answer of its own is the one that acts
+    const chartItems = await call(
+      appBus,
+      chartRef[1],
+      ACCESSIBLE,
+      'GetChildren',
+    );
+    assert.equal(
+      await call(appBus, chartItems[1][1], ACTION, 'DoAction', 'i', [0]),
+      true,
+    );
+    assert.equal(
+      await call(appBus, chartItems[0][1], COMPONENT, 'GrabFocus'),
+      true,
+    );
+    assert.deepEqual(routed, [
+      ['parse', 'activate'],
+      ['fetch', 'focus'],
+    ]);
+    assert.equal(clicks.length, 1, 'and core did not click as well');
+
+    unregisterElement('minigraph');
+    unregisterElement('minichart');
   });
 
   test('unmounting removes the tree and tells the cache', async () => {

--- a/test/types/extend.tsx
+++ b/test/types/extend.tsx
@@ -21,6 +21,8 @@ import {
   CARET_BLINK_MS,
 } from '../../src/node.js';
 import type {
+  A11ySceneAction,
+  A11ySceneItem,
   A11yTextState,
   MeasureConstraints,
   TextStyle,
@@ -524,3 +526,59 @@ class LogViewNode extends Node {
 }
 
 void LogViewNode;
+
+// An element that draws a scene (#304): what it painted, as accessible
+// children, and the actions an assistive technology sends back.
+class GraphPaneNode extends Node {
+  private selected: string | null = null;
+  private cursor: string | null = null;
+
+  constructor(props: Record<string, unknown>, app: never) {
+    super('graphpane', props, app);
+    this.focusableByDefault = true;
+  }
+
+  private items(): Array<{ id: string; label: string; ports: string[] }> {
+    return (this.props.nodes ?? []) as Array<{
+      id: string;
+      label: string;
+      ports: string[];
+    }>;
+  }
+
+  a11yScene(): A11ySceneItem[] {
+    return this.items().map((node, i) => ({
+      id: node.id,
+      role: 'listitem',
+      name: node.label,
+      rect: { x: this.abs.x, y: this.abs.y + i * 24, width: 120, height: 24 },
+      states: {
+        selected: this.selected === node.id,
+        focused: this.cursor === node.id,
+      },
+      props: { 'aria-posinset': i + 1, 'aria-setsize': this.items().length },
+      children: node.ports.map((port) => ({
+        id: port,
+        role: 'option',
+        name: port,
+        rect: { x: this.abs.x, y: this.abs.y + i * 24, width: 12, height: 12 },
+      })),
+    }));
+  }
+
+  a11ySceneAction(id: string, action: A11ySceneAction): boolean {
+    if (action === 'focus') {
+      this.cursor = id;
+      this.notifyA11ySceneChanged();
+      return true;
+    }
+    return false; // activate and scroll keep core's answer
+  }
+
+  select(id: string): void {
+    this.selected = id;
+    this.notifyA11ySceneChanged();
+  }
+}
+
+void GraphPaneNode;


### PR DESCRIPTION
Closes #304.

An element that draws N interactive things is one retained node, so it is one accessible. `@react-x11/components`' [`<Flow>`](https://github.com/sidorares/react-x11-components/issues/14) is the case that found it: a graph of selectable, draggable, connectable nodes reads out as "Flow graph, group" and stops there. No prop could have fixed it — the objects an assistive technology needs do not exist anywhere, because the element drew them.

`a11yScene()` produces them. Printed through the same model the AT-SPI bridge answers from and the same utterance formatter the test spy uses, on a three-node pane:

```
before — the element is one accessible

- Pipeline, grouping
  - Flow graph, grouping

after — what it drew, described

- Pipeline, grouping
  - Flow graph, grouping
    - Fetch orders, list item
    - Parse CSV, list item, selected
    - Render table, list item
```

## The seam

```js
class FlowNode extends Node {
  a11yScene() {
    return this.nodes.map((node) => ({
      id: node.id, // stable for as long as it is on screen
      role: 'listitem',
      name: node.label,
      rect: node.rect, // window coordinates, like `abs`
      states: {
        selected: this.selection.has(node.id),
        focused: this.cursor === node.id,
      },
    }));
  }

  select(id) {
    // …the element's own selection…
    this.notifyA11ySceneChanged();
  }
}
```

| member | when |
| --- | --- |
| `a11yScene()` | always, for an element that draws interactive things. Called once per question about its children, so it must be a cheap read |
| `notifyA11ySceneChanged()` | the scene moved between commits: a drag, an animation, the element's own arrow keys. A commit re-reads it anyway |
| `a11ySceneAction(id, action)` | an AT sent `activate`, `focus` or `scroll`. `true` claims it; anything else keeps core's answer |

Each entry becomes a real child of the element's accessible: named, placed, walked into, focusable, with `selected` announced as it changes. Nested `children` give a scene with structure; `props` carries anything else an element would — `aria-posinset`/`aria-setsize` for Orca's "3 of 7", `aria-level`, `aria-valuenow`.

## Four decisions

**Identity is the id.** The items are objects reconciled frame to frame by id, because the bridge exports one accessible per child and keys it on the object. A description rebuilt every frame would otherwise be a tree that replaces itself between two reads, with every ref an AT holds dead. An id that disappears is marked defunct rather than forgotten, so the subtree being lost can still be walked and released.

**No second model.** An item carries `props` in the same role/aria vocabulary and an `abs` rect in the same window coordinates, so roles, names, states, attributes, extents, cache items, the snapshot diff and the test spy are all code that already existed — the rule `customTextState()` follows for #257. The friendly `states: { selected, checked, expanded, disabled, busy }` is a five-entry table into those props. `focused` is the exception: an element's own cursor never reaches the window's focus manager, and ARIA has no spelling for it.

**Actions fall back rather than fail.** With no `a11ySceneAction`, an activation is a synthetic click through the ordinary dispatch at the item's own rect — an element hit-tests its scene already, so that is not an approximation of the user's click, it is the same one. `focus` focuses the element, `scroll` reveals it. One multiplexed hook claiming with `true` is what makes answering only `focus` the obvious reading rather than a trap.

**An action is offered where one lands**: the role table as everywhere else, plus any element that implements the seam — the roles a scene reaches for, `listitem` for a graph node, are mostly ones ARIA promises nothing about.

Hit testing descends into items too, so a magnifier following the pointer is told what it is actually over. The testing queries still walk retained nodes only; that is the same gap as #260 and wants its answer rather than a second one here.

## Tests

- `test/a11y-scene.test.js` — a worked graph pane through `registerElement` and `react-x11/node`: the projection, the states, nesting, ids surviving a frame and an item leaving it, an id-less child dropped loudly, and the spy feed an application would assert on.
- `test/atspi.test.js` — the same over real D-Bus against the in-process broker: `GetChildren`, roles, names, `GetIndexInParent`, `Parent`, extents, `GetAccessibleAtPoint`, `DoAction` landing as a click inside the item's rect, an element answering for itself, and the `ChildrenChanged` a departing item causes.

Both were mutation-checked: dropping the spy recursion fails the two spy tests, and dropping the scene from the bridge's snapshot fails the wire test.

Docs: [extending.md](https://github.com/sidorares/react-x11/blob/claude/react-x11-issue-304-0c2443/docs/extending.md#a-scene-a-screen-reader-can-walk) for the contract, [accessibility.md](https://github.com/sidorares/react-x11/blob/claude/react-x11-issue-304-0c2443/docs/accessibility.md#a-scene-of-your-own) for the reference, and §8b of the architecture record for why it is shaped this way.

No screenshots: nothing about this is visible on screen — the tree above is what changed.
