### PR TITLE
feat(extending): the furniture an element blit keeps beside it

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1216,6 +1216,29 @@ rects and the merges balloon back towards the whole viewport; with no bars
 the L is two disjoint rects and stays two. A drag-pan is diagonal almost
 every frame, so this is the case rather than the corner.
 
+**Every gate above is about `rect`, not about your node.** A pane usually
+has furniture pinned to a corner — a minimap, zoom controls, a HUD strip —
+that has to repaint on a pan frame and whose pixels must _not_ ride the blit.
+Carve it out of the region you shift and claim it the ordinary way; the claim
+lands beside the rect and the frame stays a blit:
+
+```js
+onDragPan(dx, dy) {
+  this.panX += dx;
+  this.panY += dy;
+  const box = this.contentBox();
+  const hud = { ...box, y: box.y + box.height - HUD, height: HUD };
+  this.scrollContents({ ...box, height: box.height - HUD }, dx, dy);
+  this.invalidate(false, hud, 'props'); // repainted, not shifted
+}
+```
+
+A claim that _reaches into_ the rect — by so much as a pixel — still declines
+the frame, and that is the whole of the rule (issue #309). Overlay panels
+mounted as sibling nodes work the same way, as long as they sit outside the
+rect: one drawing over it is dragged along by the blit, so it declines
+instead.
+
 **Zoom is not a blit.** Scaling resamples; it is a full repaint and should
 be. That is the right trade: a zoom is a gesture step, a pan is sixty of them
 a second.
@@ -1223,7 +1246,9 @@ a second.
 The protocol bench prices it at five diagonal pan steps over a 374-cell scene
 — 983 requests / 606 composites / 0.30 Mpx, against 9845 / 6533 / 4.22 for
 the same five steps under `REACT_X11_NO_SCROLL_BLIT=1`, which is exactly the
-fallback every gate here takes.
+fallback every gate here takes. The same five steps with a HUD strip claimed
+beside the region cost 3059 / 1971 / 1.10 — the blit plus the strip, where
+the whole pane repainting is that 9845 again.
 
 If your element keeps its drawing in a `Surface` of its own rather than
 drawing it live, the shift you want is

--- a/scripts/bench/baseline.json
+++ b/scripts/bench/baseline.json
@@ -118,5 +118,13 @@
     "replies": 10,
     "composites": 606,
     "compositePixels": 298517
+  },
+  "scene: 5 pan steps with a HUD strip beside them": {
+    "requests": 3059,
+    "bytesOut": 610088,
+    "bytesIn": 352,
+    "replies": 11,
+    "composites": 1971,
+    "compositePixels": 1097691
   }
 }

--- a/scripts/bench/protocol.js
+++ b/scripts/bench/protocol.js
@@ -391,7 +391,30 @@ class PanSceneNode extends SceneNode {
     this.panY += dy;
     this.scrollContents(this.contentBox(), dx, dy);
   }
+
+  /**
+   * The same pan with a HUD along the bottom of the pane (issue #309): a
+   * minimap and zoom controls, which have to repaint on a pan frame and
+   * whose pixels must not ride the blit. The element carves their strip out
+   * of the region it shifts and claims it as ordinary damage, so the two
+   * claims sit edge to edge.
+   */
+  panBeside(dx, dy) {
+    this.panX += dx;
+    this.panY += dy;
+    const box = this.contentBox();
+    const hud = {
+      x: box.x,
+      y: box.y + box.height - HUD_HEIGHT,
+      width: box.width,
+      height: HUD_HEIGHT,
+    };
+    this.scrollContents({ ...box, height: box.height - HUD_HEIGHT }, dx, dy);
+    this.invalidate(false, hud, 'props');
+  }
 }
+
+const HUD_HEIGHT = 60;
 
 const PAN_COLS = SCENE_COLS + 2;
 const PAN_ROWS = SCENE_ROWS + 2;
@@ -810,6 +833,32 @@ const SCENARIOS = [
         run: async (app, x11Root) => {
           for (let i = 0; i < 5; i++) {
             pane.pan(7, 5);
+            ctl.frame();
+            await settle(app);
+          }
+        },
+      };
+    })(),
+  ],
+  [
+    // The same five steps with furniture up (issue #309). A pane's minimap
+    // and zoom controls have to repaint on a pan frame, and their pixels
+    // must not ride the blit — so the element carves their strip out of the
+    // region it shifts and claims it itself. The claim lands *beside* the
+    // blit rect, which is the whole point: the gate is the rect, not the
+    // node, so the pan stays a blit and pays for the strip on top.
+    'scene: 5 pan steps with a HUD strip beside them',
+    (() => {
+      let ctl;
+      let pane;
+      return {
+        prepare: async (app, x11Root) => {
+          ctl = await mounted(x11Root, panSceneWindow());
+          pane = ctl.root.children.find((n) => n.kind === 'panscene');
+        },
+        run: async (app, x11Root) => {
+          for (let i = 0; i < 5; i++) {
+            pane.panBeside(7, 5);
             ctl.frame();
             await settle(app);
           }

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -2632,6 +2632,13 @@ export class Node {
    * moved something — and each of them falls back to repainting the rect,
    * which is the behaviour without this call at all.
    *
+   * All of those are about `rect`, not about this node (issue #309). An
+   * element with furniture pinned to a corner of its pane — a minimap, zoom
+   * controls, a HUD strip that has to repaint on a pan frame and whose
+   * pixels must not ride the blit — carves it out of the region it shifts
+   * and claims it as ordinary damage. Those claims land beside the rect and
+   * the frame stays a blit.
+   *
    * Returns whether the frame is still a blit candidate. The real answer
    * arrives as `paintDamage()`, because most of the gates cannot be decided
    * until the frame closes; a `false` here is only the ones that can.
@@ -2672,9 +2679,17 @@ export class Node {
       // inside the rect is indistinguishable from this call's own claim.
       // The same reasoning, and the same poison rather than a disarm, as
       // scrollTo (react-x11#295).
-      const zone = insetRect(rect, -(DAMAGE_SLOP * 2 + 1));
+      //
+      // The zone is `rect` itself, where scrollTo's is the viewport plus
+      // slop (issue #309): the claim recorded below *is* this rect, so a
+      // claim it could swallow has to overlap it, and every claim carries
+      // its own slop already — `paintBounds` inflates a node's region by
+      // `DAMAGE_SLOP` on every side, so ink that bleeds into `rect` is
+      // claimed overlapping it. Furniture *beside* the rect — a minimap in
+      // a corner the element carved out and repaints itself — is not a
+      // change to the pixels about to move.
       for (const claimed of root._damage) {
-        if (rectsOverlap(claimed, zone)) {
+        if (rectsOverlap(claimed, rect)) {
           this._pendingBlitFrom = BLIT_POISONED;
           break;
         }
@@ -8262,13 +8277,25 @@ export class WindowNode extends Scrollable(Node) {
     ) {
       const rect = damage.paintBounds ? damage.paintBounds() : damage;
       for (const sv of pendingScrolls) {
-        // an element blitting a region of its own drawing (issue #303) is
-        // waiting on that region, not on the whole node it lives in
-        const waiting = sv._pendingBlitContents?.rect ?? sv.abs;
-        if (
-          !waiting ||
-          rectsOverlap(rect, insetRect(waiting, -(DAMAGE_SLOP * 2 + 1)))
-        ) {
+        // An element blitting a region of its own drawing (issue #303) is
+        // waiting on that region, not on the whole node it lives in — and
+        // it is waiting on it *exactly* (issue #309). Its claim is the rect
+        // itself, and `_blitKeptDamage` recognises it as the rect itself, so
+        // a foreign claim that could be swallowed by it has to overlap it:
+        // the ring outside is beyond reach. A scroll container's claim is
+        // its viewport plus slop and is recognised to that tolerance, so a
+        // claim in that ring *can* merge into it without ever touching the
+        // viewport — and the wider zone is what keeps it out.
+        //
+        // The difference is what lets an element carve furniture out of the
+        // rect it blits — a minimap pinned to a corner, a strip it repaints
+        // itself — and keep the pan at blit cost while that furniture
+        // claims beside it.
+        const contents = sv._pendingBlitContents;
+        const waiting = contents
+          ? contents.rect
+          : sv.abs && insetRect(sv.abs, -(DAMAGE_SLOP * 2 + 1));
+        if (!waiting || rectsOverlap(rect, waiting)) {
           // Poison rather than disarm (react-x11#295): a null here would
           // let a second scrollTo in the same frame re-arm from a
           // mid-frame origin, and the blit would then move pixels that
@@ -8618,8 +8645,16 @@ export class WindowNode extends Scrollable(Node) {
    * virtualized table's row swap, a hover restyle mid-scroll, a coalesce
    * that swallowed the claim into a bigger box — means pixels in there
    * changed, and changed pixels must not be blitted around.
+   *
+   * `exact` is how an element blit asks for the strict form of that: the
+   * claim has to still *be* `vp`, not merely cover it within the slop
+   * (issue #309). The claim is dropped here in favour of the strips the
+   * shift exposed, so anything merged into it is dropped with it — and the
+   * damage cap merges neighbours on its own, without a claim-time gate to
+   * poison first. Requiring the rect back unchanged is what lets the
+   * claim-time gate narrow to `vp` itself and let furniture beside it live.
    */
-  _blitKeptDamage(vp) {
+  _blitKeptDamage(vp, exact = false) {
     const keep = [];
     let sawClaim = false;
     const slopped = insetRect(vp, -(DAMAGE_SLOP + 1));
@@ -8628,7 +8663,14 @@ export class WindowNode extends Scrollable(Node) {
         keep.push(rect);
         continue;
       }
-      if (rectContains(rect, vp) && rectContains(slopped, rect)) {
+      if (
+        exact
+          ? rect.x === vp.x &&
+            rect.y === vp.y &&
+            rect.width === vp.width &&
+            rect.height === vp.height
+          : rectContains(rect, vp) && rectContains(slopped, rect)
+      ) {
         sawClaim = true;
         continue;
       }
@@ -8700,7 +8742,7 @@ export class WindowNode extends Scrollable(Node) {
       if (child.style?.display === 'none') continue;
       if (rectsOverlap(child._subtreeBounds(), vp)) return;
     }
-    const keep = this._blitKeptDamage(vp);
+    const keep = this._blitKeptDamage(vp, true);
     if (!keep) return;
     if (!this._scrollBlitSafe(node, vp)) return;
     // the element's deltas are already how far the pixels moved, the sense

--- a/test/element-scroll.test.js
+++ b/test/element-scroll.test.js
@@ -39,6 +39,15 @@ const CELL = 40;
 // behind the same `null`.
 const INSET = 40;
 const VP = { x: INSET, y: INSET, width: W - 2 * INSET, height: H - 2 * INSET };
+// the furniture strip along the bottom of the pane (issue #309)
+const BAND = 80;
+const CARVED = { ...VP, height: VP.height - BAND };
+const FURNITURE = {
+  x: VP.x,
+  y: VP.y + VP.height - BAND,
+  width: VP.width,
+  height: BAND,
+};
 
 const overlaps = (a, b) =>
   a.x < b.x + b.width &&
@@ -70,6 +79,37 @@ class PanNode extends Node {
     this.panX += dx;
     this.panY += dy;
     return this.scrollContents(this.viewport(), dx, dy);
+  }
+
+  /**
+   * The same pan with furniture in the way (issue #309): a strip along the
+   * bottom of the pane — a minimap, a zoom control — that has to repaint on
+   * a pan frame and whose pixels must *not* ride the blit. The element
+   * carves it out of the region it shifts and claims it as ordinary damage,
+   * so the two claims sit edge to edge with nothing between them.
+   */
+  panBeside(dx, dy, band = BAND) {
+    this.panX += dx;
+    this.panY += dy;
+    const vp = this.viewport();
+    const armed = this.scrollContents(
+      { ...vp, height: vp.height - band },
+      dx,
+      dy,
+    );
+    this.invalidate(false, this.furniture(band), 'props');
+    return armed;
+  }
+
+  /** The strip the pan above leaves to itself. */
+  furniture(band = BAND) {
+    const vp = this.viewport();
+    return {
+      x: vp.x,
+      y: vp.y + vp.height - band,
+      width: vp.width,
+      height: band,
+    };
   }
 
   /**
@@ -291,6 +331,109 @@ test('other damage inside the region keeps the full repaint', async () => {
   assert.deepStrictEqual(blits(wnd), [], 'not a pure shift: no blit');
   assert.deepStrictEqual(node.passes, [{ ...VP }]);
   assert.ok(root._lastDamageRects, 'still bounded, just not narrowed');
+});
+
+// --- furniture beside the rect (issue #309) ------------------------------
+//
+// The gate above is the blit *rect*, not the node it lives in. An element
+// whose pane has a minimap or zoom controls pinned to a corner has to
+// repaint them on a pan frame — their pixels must not ride the blit — so it
+// carves them out of the region it shifts and claims them itself. Those
+// claims land beside the rect, edge to edge with it, and a node-granular
+// gate would cancel every pan frame that had the HUD up.
+
+test('furniture beside the blit rect coexists with it', async () => {
+  const { wnd, node, root } = await mount();
+
+  assert.strictEqual(node.panBeside(0, 40), true, 'still a blit candidate');
+  await tick();
+
+  assert.deepStrictEqual(blits(wnd), [['scrollRegion', { ...CARVED }, 0, 40]]);
+  assert.deepStrictEqual(
+    root._lastDamageRects,
+    [
+      { ...FURNITURE },
+      { x: CARVED.x, y: CARVED.y, width: CARVED.width, height: 40 },
+    ],
+    'the furniture and the strip the shift exposed — not the pane',
+  );
+  assert.ok(
+    area(root._lastDamageRects) < VP.width * VP.height * 0.6,
+    `repainted ${area(root._lastDamageRects)}px² of ${VP.width * VP.height}`,
+  );
+});
+
+test('furniture claimed before the pan lets it arm too', async () => {
+  // the arming gate reads the claims already recorded, and it reads them
+  // against the rect for the same reason
+  const { wnd, node } = await mount();
+
+  node.invalidate(false, node.furniture(), 'props');
+  assert.strictEqual(node.scrollContents({ ...CARVED }, 0, 40), true);
+  await tick();
+
+  assert.deepStrictEqual(blits(wnd), [['scrollRegion', { ...CARVED }, 0, 40]]);
+});
+
+test('a claim one pixel inside the blit rect still poisons it', async () => {
+  // the line the gate draws: beside is beside, over is over. Both orders,
+  // because arming and claiming are two different checks.
+  const over = {
+    ...FURNITURE,
+    y: FURNITURE.y - 1,
+    height: FURNITURE.height + 1,
+  };
+
+  const after = await mount();
+  after.node.scrollContents({ ...CARVED }, 0, 40);
+  after.node.invalidate(false, over, 'props');
+  await tick();
+  assert.deepStrictEqual(blits(after.wnd), [], 'claimed after arming');
+
+  const before = await mount();
+  before.node.invalidate(false, over, 'props');
+  assert.strictEqual(
+    before.node.scrollContents({ ...CARVED }, 0, 40),
+    false,
+    'claimed before arming, and the call says so',
+  );
+  await tick();
+  assert.deepStrictEqual(blits(before.wnd), []);
+});
+
+test('a claim the damage cap merged into the blit claim keeps the repaint', async () => {
+  // The other half of the narrowed gate. A claim beside the rect is let
+  // through, and the cap (four rects) merges the pair that wastes least —
+  // which is exactly a claim flush against the rect. The frame gets the
+  // claim back bigger than the rect it armed for: the blit would drop that
+  // claim in favour of the exposed strip, taking the merged furniture with
+  // it, so the whole thing falls back.
+  const { wnd, node, root } = await mount();
+
+  node.scrollContents({ ...CARVED }, 0, 40);
+  // flush against the claim, and two pixels tall: a merge of the two is
+  // still within the tolerance the scroll path recognises its claim by
+  node.invalidate(false, { ...FURNITURE, height: 2 }, 'props');
+  for (let i = 0; i < 4; i++) {
+    node.invalidate(
+      false,
+      { x: VP.x + i * 90, y: FURNITURE.y + 40, width: 20, height: 20 },
+      'props',
+    );
+  }
+  await tick();
+
+  assert.deepStrictEqual(
+    blits(wnd),
+    [],
+    'the claim came back a different rect',
+  );
+  assert.ok(
+    root._lastDamageRects.some(
+      (r) => r.height > CARVED.height && r.y === CARVED.y,
+    ),
+    'and the merged claim is repainted whole, furniture included',
+  );
 });
 
 test('damage claimed before the frame’s first pan poisons it (#295)', async () => {
@@ -561,6 +704,70 @@ test('a blitted pan is byte-identical to the repaint it replaced', async (t) => 
     assert.ok(
       blitted.equals(repainted),
       'blitted pixels differ from a full repaint of the same scene',
+    );
+  } finally {
+    await x11Root.unmount();
+    await app.close();
+  }
+});
+
+test('so is one that carved furniture out of the region (#309)', async (t) => {
+  // The pixels behind the claim-time gate: the pane shifts everything but a
+  // strip along its bottom, which is claimed as ordinary damage and repaints
+  // at the new offset. A blit that dragged the strip's pixels along, or a
+  // frame that dropped its claim, shows up here as a difference.
+  register();
+  const app = await headlessApp();
+  const x11Root = await createRoot({ app });
+  try {
+    const ref = React.createRef();
+    const instance = await new Promise((resolve) =>
+      x11Root.render(
+        h(
+          'window',
+          { width: W, height: H, style: { backgroundColor: '#101820' } },
+          h('pan', { ref, style: { flexGrow: 1, margin: INSET } }),
+        ),
+        resolve,
+      ),
+    );
+    if (typeof instance.scrollRegion !== 'function') {
+      t.skip('installed ntk has no Window.scrollRegion yet');
+      return;
+    }
+    const node = ref.current;
+    const root = node.root;
+    const frame = () => {
+      root._scheduled = false;
+      root.flush();
+    };
+    frame();
+    await settle(app);
+
+    let blitCalls = 0;
+    const real = instance.scrollRegion.bind(instance);
+    instance.scrollRegion = (...args) => {
+      blitCalls += 1;
+      return real(...args);
+    };
+
+    node.panBeside(20, 30);
+    frame();
+    await settle(app);
+    assert.strictEqual(blitCalls, 1, 'the fast path fired beside the strip');
+    assert.ok(root._lastDamageRects, 'and the frame stayed bounded');
+    const blitted = await readPixels(
+      root._ctx ?? (root._ctx = root.window.getContext('2d')),
+    );
+
+    root.invalidate(false);
+    frame();
+    await settle(app);
+    const repainted = await readPixels(root._ctx);
+
+    assert.ok(
+      blitted.equals(repainted),
+      'the carved pan differs from a full repaint of the same scene',
     );
   } finally {
     await x11Root.unmount();


### PR DESCRIPTION
Closes #309.

## What was already there, and what wasn't

The claim-time gate has read `pending.rect` rather than `sv.abs` since #307 — a claim well clear of the blit rect already coexists with it today. What stayed node-shaped is the **tolerance**: the zone was `insetRect(rect, -(DAMAGE_SLOP * 2 + 1))`, three pixels of slop around the rect, and a claim flush against the rect lands inside it.

Flush against the rect is exactly what the workaround the issue asks for produces. Carving a HUD band out of the region you shift puts the two claims edge to edge with nothing between them, so every pan frame with the furniture up was still poisoned — the symptom in the title, one gate further in than the diagnosis.

## The change

Both zones — arming and claiming — are the rect itself. Claims already carry their own slop: `paintBounds` inflates a node's region by `DAMAGE_SLOP` on every side, so ink that bleeds into the rect is claimed overlapping it. A claim one pixel inside still poisons, in both orders.

What the wider zone was really guarding is at the other end of the frame. `_blitKeptDamage` recognises the shift's own claim as "covers the viewport, within two pixels of it", and then **drops** it in favour of the strips the shift exposed. A neighbour that merged into the claim is dropped with it — and `addDamageRect` merges neighbours on its own once the damage list passes `MAX_DAMAGE_RECTS`, with no claim-time gate to poison first. It picks the pair that wastes the least area, which is precisely a claim flush against the rect.

So an element blit now asks for its claim back **exactly** as it armed with. Any merge, forced by the cap or otherwise, changes the rect and the frame declines — which is what makes the narrower poison zone safe rather than a hole. `scrollTo`'s half is untouched: its claim is the viewport plus slop, recognised to that tolerance, so a claim in that ring can reach it without ever touching the viewport and the wider zone is what keeps it out.

## Numbers

New protocol-bench scenario — the pan scenario from #307 with a 60px HUD strip carved out and claimed beside the region, five diagonal steps:

|  | requests | bytesOut | composites | Mpx |
| --- | --- | --- | --- | --- |
| before | 9845 | 2178396 | 6533 | 4.22 |
| after | 3059 | 610088 | 1971 | 1.10 |

The "before" row is not a separate path: it is the full-pane repaint every declined gate falls back to, and it is byte-for-byte what `REACT_X11_NO_SCROLL_BLIT=1` costs on this branch too. The remaining 3059 is the blit plus the strip — the furniture has to repaint, and the scene under it with it.

The plain pan scenario is unchanged at 982, and so is `scroll: 10 notches over 500 rows` at 342: the scroll path is not on this diff.

## Tests

Five in `test/element-scroll.test.js`, 26 in the file:

- furniture beside the blit rect coexists with it — the blit fires and the frame is the strip plus the furniture;
- furniture claimed *before* the pan lets it arm too, which is the other gate;
- a claim one pixel inside still poisons, claimed before arming and after;
- a claim the damage cap merged into the blit claim keeps the repaint — the safety half of the narrowing;
- and a pixel readback: a pan that carved furniture out is byte-identical to a full repaint of the same scene.

Each fails against the change it pins — the old inflated zone in either gate, and `_blitKeptDamage` without the exact form. Full suite: 1310 pass, 6 pre-existing macOS-only `appearance.test.js` failures unrelated to this. Lint, typecheck and format clean.
