### PR TITLE
fix(layout): the width a content floor is a height for

### DIFF
--- a/src/nodes.js
+++ b/src/nodes.js
@@ -891,6 +891,54 @@ function restoreShrink(node) {
 }
 
 /**
+ * Pin every box under `node` at the width the pass just settled it at, so
+ * that the collapse which follows can only take **height** away.
+ *
+ * A minimum height is always a height *for a width* (`_applyContentFloors`),
+ * and the width it is for is the one the first pass settled — the tree at the
+ * size it is really about to be laid out at. The collapsing pass is asked
+ * only how much of that height the tree can give back, and it has no business
+ * re-deciding the widths on the way. Left to itself it does, because offering
+ * no height at all is not a small layout but a degenerate one: yoga answers a
+ * box measured against a zero cross size out of its bounds, without laying
+ * its children out at all, and where the width on offer was *also* undefined
+ * that bound is the node's `min-width` — the min-content floor this same
+ * routine wrote a moment earlier. Under a horizontally scrolling box the
+ * width is exactly what is undefined, a scroll container withholding its
+ * main-axis size from a child's flex basis the way browsers do. So the
+ * subtree was laid out at min-content **width**, where a label takes two
+ * lines, and the two-line height became the floor of the row around it: one
+ * line of text in a box that reserved two (issue #311).
+ *
+ * Pinning is enough because that answer is only wrong where there was no
+ * width to answer with — a box that names its own is measured at it whatever
+ * else the pass is doing, and its children are laid out inside that. It costs
+ * nothing either: every leaf is offered the width it was already measured at,
+ * so the paragraphs the first pass shaped come back out of the layout cache.
+ */
+function freezeWidths(node) {
+  for (const child of node.children) {
+    if (!child.yoga || child.isWindow) continue;
+    // as in `setMeasuringShrink`: a `display: 'none'` subtree was not laid
+    // out, so there is no width in there to keep
+    if (child.style.display === 'none') continue;
+    child.yoga.setWidth(child.yoga.getComputedWidth());
+    freezeWidths(child);
+  }
+}
+
+/** …and back to the width the style asks for. Walks what `freezeWidths`
+ *  walked, so a box it never pinned is never written to either. */
+function restoreWidths(node) {
+  for (const child of node.children) {
+    if (!child.yoga || child.isWindow) continue;
+    if (child.style.display === 'none') continue;
+    child.yoga.setWidth(child.style.width);
+    restoreWidths(child);
+  }
+}
+
+/**
  * How far this node's content actually reaches along one axis, in its own
  * coordinate space — the reading of a layout the root was given no room for,
  * where `getComputedWidth()` says nothing (a root offered 0 is clamped to 0)
@@ -6635,13 +6683,18 @@ export class WindowNode extends Scrollable(Node) {
     // width, and no leaf can give any of it back. It runs before the shrink
     // is borrowed, since the widths it settles are the real ones. The second
     // is the one that collapses, and it squashes a leaf that a `row`
-    // stretches: those are the ones the map above puts back.
+    // stretches: those are the ones the map above puts back. The widths the
+    // first pass settled are held across the second (`freezeWidths`), which
+    // is the only thing keeping it a collapse rather than a second opinion.
     yoga.calculateLayout(forWidth, undefined, dir);
     const intrinsic = new Map();
     captureLeafHeights(this, intrinsic);
+    freezeWidths(this);
     setMeasuringShrink(this, axis);
     yoga.calculateLayout(forWidth, 0, dir);
-    return contentSpan(this, axis, intrinsic, out);
+    const span = contentSpan(this, axis, intrinsic, out);
+    restoreWidths(this);
+    return span;
   }
 
   _measureMinimum(axis, forWidth) {

--- a/test/content-floors.test.js
+++ b/test/content-floors.test.js
@@ -15,6 +15,7 @@ import assert from 'node:assert';
 import React from 'react';
 import { createRoot } from '../src/index.js';
 import { createStyles } from '../src/styles.js';
+import { registerElement, unregisterElement } from '../src/host.js';
 import { Node } from '../src/node.js';
 import { createMockApp, spinWheel } from './helpers/mock-app.js';
 
@@ -220,6 +221,99 @@ test('an absolutely positioned child is floored by nothing', async () => {
     'its own 50%, not its content',
   );
   await root.unmount();
+});
+
+// --- the width the heights are measured for ---------------------------------
+
+// A paragraph, as layout sees one: `LINE` pixels of text that can be squeezed
+// down to its longest word and takes another line every time it is. There are
+// no fonts here (see the top of this file), and a `<text>` is nothing more
+// than this to yoga — a leaf whose height is a function of its width.
+const WORD = 50;
+const LINE = 100;
+const LINE_HEIGHT = 20;
+
+class ParagraphNode extends Node {
+  constructor(props, app) {
+    super('paragraph', props, app);
+  }
+
+  measureContent({ width }) {
+    const w = Math.max(WORD, Math.min(LINE, width));
+    return { width: w, height: LINE_HEIGHT * Math.ceil(LINE / w) };
+  }
+}
+
+/**
+ * The arrangement of issue #311: a horizontally scrolling row, a column with
+ * no width of its own, a row that aligns to `flex-start`, and inside that a
+ * row that centres one paragraph. `scroll` and `center` are the two of those
+ * four that dropping either used to fix it.
+ */
+const scrollerTree = (scroll, center, refs) =>
+  box(
+    {
+      flexDirection: 'row',
+      flexGrow: 1,
+      ...(scroll ? { overflow: 'scroll' } : {}),
+    },
+    h(
+      'box',
+      null,
+      box(
+        { flexDirection: 'row', alignItems: 'flex-start' },
+        box({ width: 20, height: 20 }), // the gutter
+        h(
+          'box',
+          { style: { flexDirection: 'column' } },
+          h(
+            'box',
+            {
+              ref: refs.row,
+              style: {
+                flexDirection: 'row',
+                ...(center ? { alignItems: 'center' } : {}),
+              },
+            },
+            h('paragraph', { ref: refs.label }),
+          ),
+        ),
+      ),
+    ),
+  );
+
+test('a scroller measures the heights inside it at their real width', async () => {
+  // The heights the floors are written from come from a pass that collapses
+  // the tree to nothing, and that pass has no business re-deciding the
+  // widths on the way — a minimum height is always a height *for a width*.
+  // It did anyway: a box measured against a zero cross size is answered from
+  // its bounds without its children being laid out, and where the width was
+  // undefined too — which is what a *horizontally* scrolling box hands its
+  // content — that bound was the min-content floor written a moment earlier.
+  // The paragraph was measured at its longest word, took two lines, and the
+  // row around it kept the two-line height while the paragraph itself, laid
+  // out for real at its full width, took one (#311).
+  registerElement('paragraph', {
+    create: (props, app) => new ParagraphNode(props, app),
+  });
+  try {
+    for (const [scroll, center] of [
+      [false, true],
+      [true, false],
+      [true, true],
+    ]) {
+      const refs = { row: React.createRef(), label: React.createRef() };
+      const { root } = await mount(scrollerTree(scroll, center, refs));
+      assert.deepStrictEqual(
+        [refs.row.current.abs.height, refs.label.current.abs.height],
+        [LINE_HEIGHT, LINE_HEIGHT],
+        `one line tall, with scroll=${scroll} center=${center}`,
+      );
+      await root.unmount();
+    }
+  } finally {
+    unregisterElement('paragraph');
+  }
 });
 
 // --- what it costs ----------------------------------------------------------


### PR DESCRIPTION
Fixes #311.

## What was wrong

The content floors (#249) are measured in two passes per axis. For heights,
the first lays the tree out at its real width with no bound on the height —
where every leaf reports the height it needs *there* — and the second
collapses it to nothing to find out how much of that height can be given
back.

The second pass was re-deciding the widths on the way. Offering no height at
all is not a small layout but a degenerate one: yoga answers a box measured
against a zero cross size out of its bounds, without laying its children out,
and where the width on offer was *also* undefined that bound is the node's
`min-width` — the min-content floor written a moment earlier by the width
half of the same routine. A **horizontally** scrolling box is exactly where
the width is undefined, since a scroll container withholds its main-axis size
from a child's flex basis (yoga's rule, and browsers').

So the subtree was laid out at min-content **width**, `Product shipped`
became two lines, and 33 was written as the row's `minHeight`. The real
layout then gave the text its full 102px, it set one line, and the row stayed
sized for two.

That is the whole of the issue's four-way coincidence: the scroller has to be
a row (a column scroller withholds the height instead), the inner row has to
be `alignItems: 'center'` (with the default `stretch` the collapsed row
squashes the label back to nothing, and the intrinsic height captured in the
first pass wins), and the arrangement above has to leave the column's width
undefined.

## The fix

`freezeWidths` pins every box at the width the first pass settled it at
before the collapsing pass runs, and `restoreWidths` puts the styles back
after it is read. A minimum height is always a height *for a width*, and the
width it is for is the one the tree is about to be laid out at — holding it
is what makes the second pass a collapse rather than a second opinion.

Pinning is enough because the degenerate answer is only wrong where there was
no width to answer with: a box that names its own is measured at it whatever
else the pass is doing, and its children are laid out inside that.

## Cost

None measurable. The floors pass over a 500-row tree is 8.7ms before and
8.8ms after (the extra walks pay for themselves in layout yoga no longer has
to solve), `npm run bench -- --check` reports no protocol regressions, and
`npm run screenshots` regenerates every image byte-identically to a
regeneration on `master`.

## Test

`test/content-floors.test.js` gets the issue's arrangement, with a registered
element standing in for the paragraph — that suite is headless, so there are
no fonts, and to yoga a `<text>` is nothing more than a leaf whose height is
a function of its width. It walks the same three cases the issue reports: the
two that always worked and the one that did not. Without the fix the last
one asserts `[40, 20]` against `[20, 20]`.