### PR TITLE
feat(system): the machine around the app — screens, window state, idle, keyboard, settings, locale

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1155,6 +1155,25 @@ keysym even where XQuartz's keymap rewrite has left no Latin group
 (docs/events.md "Layouts"). One open issue left from that pair: **#86**
 `sans-serif` resolves to a CJK font on macOS.
 
+The **system hooks** are in ([docs/system.md](docs/system.md)): `useScreens()`
+(Xinerama for the geometry during `createRoot`, a RandR walk behind it for
+names/primary/mm/refresh), `useWindowState()` (`_NET_WM_STATE` via ntk's
+`statechange`, VisibilityNotify, focus), `useIdle()`/`useKeepAwake()` (SYNC
+`IDLETIME` alarms, no polling, with MIT-SCREEN-SAVER under them),
+`useKeyboardState()` (XKB `StateNotify` — Caps Lock before the first
+keystroke, which `PasswordInput` wanted), `useDesktopSettings()` and
+`useLocale()`. The last one is not only a hook: **the caret cadence, the
+double-click window and the drag threshold were four hardcoded constants and
+now come off XSETTINGS**, so `Net/CursorBlink: 0` — an accessibility setting —
+finally stops the caret blinking. Worth knowing when working here: the
+in-process test server has RENDER, BIG-REQUESTS and XC-MISC and _none_ of
+those extensions, so the reply decoders are tested as pure functions and the
+stores through their `set*ForTests` seams — the end-to-end walks only happen
+against a real display. Three bugs in this work were only visible there
+(`available` leaking a whole monitor record, XQuartz's synthetic 1 Hz mode,
+and its literal `empty` XKB layout); `scripts/` has no probe for it, so run
+one by hand against `$DISPLAY` before believing a protocol path.
+
 ## Pull requests
 
 - When a PR contains changes that can be detected by eye (rendering,

--- a/docs/README.md
+++ b/docs/README.md
@@ -81,6 +81,12 @@
   for apps that only want to follow the desktop, why the answer is remembered
   on disk so the first frame is not a flash, and what each rung of the ladder
   can actually answer.
+- [system.md](system.md) — the machine around the app: `useScreens()` for the
+  monitor layout, `useWindowState()` for what the window manager actually did,
+  `useIdle()`/`useKeepAwake()`, `useKeyboardState()` for Caps Lock and the live
+  layout, `useDesktopSettings()` for the timings the built-in controls already
+  follow, and `useLocale()`. Also what each one answers on a display with the
+  extension missing, and why `obscured` is always false under a compositor.
 - [remote.md](remote.md) — the flagship case: running the app on one
   machine and drawing to a display on another. `ssh -X` vs `-Y`, what the
   protocol costs on a link, the other X servers, and why Xwayland works

--- a/docs/system.md
+++ b/docs/system.md
@@ -1,0 +1,362 @@
+# The machine around the app
+
+Six hooks for the things an application has to read off the system rather than
+work out for itself: the monitors, what the window manager did with the
+window, whether anyone is at the desk, the state of the keyboard, how the
+desktop wants an app to feel, and the language it was launched in.
+
+```jsx
+import {
+  useScreens,
+  useWindowState,
+  useIdle,
+  useKeepAwake,
+  useKeyboardState,
+  useDesktopSettings,
+  useLocale,
+} from 'react-x11';
+```
+
+They share a shape, and it is worth knowing before reading any one of them:
+
+- **Nothing is asked of the server until a component asks.** Every one of
+  these costs round trips or an event selection, and an app that never calls
+  them pays for none of it.
+- **Every one has an answer with no extension present.** X is a protocol with
+  thirty years of optional pieces, and "this display cannot say" is a real
+  state rather than an error. Each hook below names what it reports then, and
+  which field tells that apart from a genuine "no".
+- **The colours are somewhere else.** Light or dark, the accent and reduced
+  motion are [system appearance](appearance.md), which has a ladder of its own.
+
+---
+
+## `useScreens()` — the monitors
+
+```jsx
+const { screens, primary, workArea, virtual, source } = useScreens();
+
+<Select
+  value={monitor}
+  onChange={setMonitor}
+  options={screens.map((s) => ({
+    value: s.name,
+    label: `${s.name} — ${s.width}×${s.height}`,
+  }))}
+/>;
+```
+
+Each entry in `screens`:
+
+|                          |                                                                |
+| ------------------------ | -------------------------------------------------------------- |
+| `name`                   | `'HDMI-1'`, `'eDP-1'` — **null** where the server has no RandR |
+| `x` `y` `width` `height` | the rect in virtual-screen coordinates                         |
+| `available`              | that rect minus the panels                                     |
+| `primary`                | the desktop's main monitor                                     |
+| `widthMM` `heightMM`     | physical size, or null                                         |
+| `refreshRate`            | Hz to two decimals (`59.99`), or null                          |
+| `rotation`               | `0`, `90`, `180` or `270`                                      |
+| `outputs`                | every output on this monitor — two names means it is mirrored  |
+
+Re-renders when a monitor is plugged in or unplugged, when the arrangement
+changes, and when a panel appears, moves or auto-hides.
+
+### The names arrive after the geometry
+
+`source` says which tier answered. The geometry resolves during `createRoot()`
+from **Xinerama**, which is one round trip; the names, the primary flag and the
+physical sizes take a **RandR** walk — `GetScreenResourcesCurrent`, then a
+`GetOutputInfo` and a `GetCrtcInfo` per output, ten or more round trips on an
+ordinary two-head desktop — and that deliberately does not hold startup up.
+
+So a component can render once with `source: 'xinerama'` and null names, and
+again a moment later with `source: 'randr'` and real ones. The rects do not
+move between the two: Xinerama on any modern server _is_ RandR's emulation of
+it, so what arrives late is added rather than corrected. Where a name is what
+gets persisted — "reopen on the monitor I was on" — treat null as _not known
+yet_ and keep the last one rather than writing it.
+
+`'screen'` is the tier under both: one entry covering the whole display, for a
+server with neither extension. `null` is a headless mock with no display at
+all.
+
+### `available` is an approximation, and the only one here
+
+`_NET_WORKAREA` — the desktop minus the docks and panels that reserved space —
+is published **for the whole virtual desktop**, not per monitor. That is an
+EWMH weakness rather than a choice made here. So it is applied as a _per-axis_
+bound on top of the monitor rect: exact on one head, and on several it still
+takes a top or bottom panel off the height without pretending to know which
+head the panel is on.
+
+A true per-monitor work area means reading `_NET_WM_STRUT_PARTIAL` off every
+window on the screen and intersecting the reservations that land on each head
+— a full window-tree walk, redone whenever any panel changes. If you need
+that, `useApp().X` is the escape hatch.
+
+### Mirroring
+
+Two outputs showing the same pixels share one CRTC and are reported as **one**
+monitor, with both names in `outputs`. A laptop mirroring to a projector is one
+screen to put a window on, and `screens.length === 2` there would be a wrong
+answer an app would act on.
+
+---
+
+## `useWindowState()` — what the window manager did
+
+```jsx
+const { focused, visible, fullscreen } = useWindowState();
+
+// a title bar that dims when the window is not the active one
+<text style={{ color: focused ? theme.text : theme.textMuted }}>{title}</text>;
+
+// and work that is pointless while nobody can see it
+useEffect(() => {
+  if (!visible) return;
+  const id = setInterval(poll, 1000);
+  return () => clearInterval(id);
+}, [visible]);
+```
+
+|              |                                                                    |
+| ------------ | ------------------------------------------------------------------ |
+| `focused`    | this window has the keyboard                                       |
+| `visible`    | **the one to branch on** — not minimized, not fully covered        |
+| `minimized`  | `_NET_WM_STATE_HIDDEN`: iconified, or shaded away                  |
+| `maximized`  | both axes; one axis alone shows up in `states`                     |
+| `fullscreen` | what the WM actually did, not what `<window fullscreen>` asked for |
+| `obscured`   | fully covered — **always false under a compositor**                |
+| `states`     | the raw `_NET_WM_STATE` names                                      |
+| `desktop`    | the workspace index, or null                                       |
+
+`<window states>` is what a window **asks for**; this is what it **got**. The
+two part company routinely — a user hits a maximize hotkey, a tiling WM
+declines a fullscreen request — and an app that mirrors the state in its own
+UI has nowhere else to read it.
+
+With no argument it reads the window the component is in, inferred the way
+[`useTopLevelWindow()`](filedialog.md) infers it: exact for a one-window app,
+and a documented guess for a tree with several. Pass a ref to be certain.
+
+```jsx
+const win = useRef(null);
+const { fullscreen } = useWindowState(win);
+return <window ref={win}>…</window>;
+```
+
+The first render answers `focused: true, visible: true` rather than waiting for
+a round trip. A window opens focused and on screen far more often than not, and
+a title bar that renders dimmed on frame one and un-dims on frame two is a
+flash on every launch.
+
+### `obscured` and the compositor
+
+**A composited window is never obscured.** The compositor redirects it to an
+offscreen pixmap, so the server considers it entirely visible whatever is
+stacked on top, and `VisibilityNotify` says so. One is running on every stock
+GNOME and KDE session. That is X working as designed and there is no protocol
+answer to it.
+
+So `obscured` is a bare-WM optimisation, and `visible` — which folds in
+`minimized`, the signal that _does_ survive compositing — is the field to
+branch on. An animation paused on `visible` stops when the window is minimized
+everywhere, and additionally when it is buried on a desktop with no compositor.
+
+---
+
+## `useIdle()` and `useKeepAwake()` — is anyone there
+
+```jsx
+const away = useIdle(5 * 60_000);
+<Avatar status={away ? 'away' : 'online'} />;
+```
+
+Idleness is the **whole display's**, not this window's: it counts input on
+every device, whichever application it went to. That is the right meaning for a
+presence indicator, an auto-save, or a dashboard that stops refreshing when the
+desk is empty — and the wrong one for "has the user ignored _my_ window", which
+is `useWindowState().focused`.
+
+Where the X server carries an `IDLETIME` counter — Xorg does — this costs **no
+timer at all**: a SYNC alarm fires when the counter crosses `timeout` and
+another when input pulls it back down, which is what every idle daemon on the
+desktop is built on. On a server without one (XQuartz) it falls back to polling
+MIT-SCREEN-SAVER, scheduled against the remaining time rather than on a tick.
+On a display with neither it stays `false`.
+
+`timeout` is a dependency, so hold it in a constant rather than building it
+inline from state that moves.
+
+### Keeping the screen on
+
+```jsx
+useKeepAwake(playing, 'Playing a video');
+```
+
+Held while the flag is true and the component is mounted, released on either —
+including on an unmount mid-playback, which is the case that leaves a desktop
+permanently un-blanking when this is done by hand.
+
+Three rungs: the settings portal's `Inhibit`, the older
+`org.freedesktop.ScreenSaver` service, and `ScreenSaverSuspend`, which is a
+plain X request and needs no session bus at all. **All three inhibit screen
+blanking only.** Nothing here stops a suspend — only the portal rung could, and
+a seam that works on one desktop in three is worse than not offering it.
+
+`reason` is shown by desktops that list what is holding the screen on, so it
+reads best as a sentence about the app's state rather than the app's name,
+which they already show.
+
+Failure is silent by design: a machine with no portal, no screensaver service
+and no MIT-SCREEN-SAVER cannot be asked, and a video player is not the place to
+surface that. `keepAwake()` is the imperative twin, and resolves to the release.
+
+---
+
+## `useKeyboardState()` — the locks and the layout
+
+```jsx
+const { capsLock, layout } = useKeyboardState();
+
+<PasswordInput value={password} onChange={setPassword} />;
+{
+  capsLock && <text style={{ color: theme.warning }}>Caps Lock is on</text>;
+}
+```
+
+|                      |                                            |
+| -------------------- | ------------------------------------------ |
+| `capsLock` `numLock` | on or off, **now**                         |
+| `group`              | the active XKB group, `0`–`3`              |
+| `layout`             | that group's layout code, `'ru'` — or null |
+| `layouts`            | every configured layout, `['us', 'ru']`    |
+
+The point of the first row is that it is true of the **keyboard** rather than
+of an event. A key event carries the modifier state at the moment it was
+pressed, so an app can see that Caps Lock was on for a key it received — which
+is no help at all in the case that matters, a password field that wants to warn
+while it is merely focused and before anything has been typed.
+
+The layout half is for a status-bar indicator, and for the other thing that
+costs people real time: a password typed in the wrong script, which looks
+identical to a wrong password. `layout` is a code rather than a description
+(`'ru'`, not `'Russian'`) because that is what an indicator shows; uppercase it
+for display.
+
+Everything here needs **XKB**, which Xorg and XQuartz both have. Where it is
+missing the locks read false and `layouts` is empty — so `layouts` is the field
+to check when the difference between "off" and "not known" matters. Changes
+arrive as `XkbStateNotify`, with no polling, even while another application has
+the keyboard.
+
+Which bit is which lock is worth writing down: Caps Lock is `LockMask`, fixed
+by the core protocol, and **Num Lock is not fixed by anything** — it is wherever
+the modifier map puts it, which is `Mod2` on every Linux and BSD desktop, on
+XQuartz, and in every toolkit that hardcodes it. This takes the convention.
+
+---
+
+## `useDesktopSettings()` — how the desktop wants an app to feel
+
+```jsx
+const { doubleClickMs, dragThreshold } = useDesktopSettings();
+```
+
+|                       |                                                          |
+| --------------------- | -------------------------------------------------------- |
+| `caretBlink`          | **false means do not blink at all**                      |
+| `caretBlinkMs`        | how long a caret stays in each state (530)               |
+| `doubleClickMs`       | how long a second click has to arrive in (400)           |
+| `doubleClickDistance` | and how far it may land from the first (4px)             |
+| `dragThreshold`       | how far a press moves before it is a drag (4px)          |
+| `source`              | `'xsettings'`, or null where no settings daemon answered |
+
+**The built-in controls already follow these.** `<textinput>`'s caret, the click
+counting behind `ev.detail`, and the drag threshold all read the same values, so
+an app that uses the widget set gets this for nothing. The hook is for an app
+drawing its own: a `<canvas>` with a text cursor in it, a custom gesture, a
+diagram editor with its own drag. Reach for it so that one widget on the screen
+does not feel unlike every other.
+
+`caretBlink` deserves the callout. A caret that ignores it is not a cosmetic
+miss: a moving thing on screen is what some people cannot read past, which is
+why the desktop offers the switch at all. **Draw the caret solid rather than not
+at all** — that is what the built-in controls do.
+
+[XSETTINGS](appearance.md#what-each-rung-can-actually-answer) is the only source; there is no portal
+interface for any of this. On a desktop with no settings daemon — a bare
+`startx`, most window managers, XQuartz — `source` is null and the numbers above
+are this renderer's own defaults. They are deliberately not GTK's, which blinks
+on a 1200ms cycle and drags at 8px: the point is to follow a desktop that
+expressed a preference, not to change what happens on one that did not.
+
+One seam worth knowing about. `createRoot()` starts XSETTINGS but does not
+**await** it — five round trips on every app's startup path, to answer a
+question that is not asked until the first interaction, is a bad trade. A field
+focused on the very first frame therefore gets the built-in default and the
+desktop's cadence from its next focus onward.
+
+---
+
+## `useLocale()` — the language and its conventions
+
+```jsx
+const { locale, weekStartsOn } = useLocale();
+
+<Calendar locale={locale} weekStartsOn={weekStartsOn} />;
+<text>{new Intl.NumberFormat(locale).format(total)}</text>;
+```
+
+|                |                                                             |
+| -------------- | ----------------------------------------------------------- |
+| `locale`       | a BCP-47 tag: `'en-GB'`, `'ru-RU'`                          |
+| `direction`    | `'ltr'` or `'rtl'`                                          |
+| `weekStartsOn` | `0` Sunday … `6` Saturday, from CLDR                        |
+| `timeZone`     | `'Europe/London'`, or null                                  |
+| `source`       | `'env'` when `LANG` and friends said, `'intl'` when ICU did |
+
+**`LC_ALL` / `LC_MESSAGES` / `LANG` win over `Intl`'s own answer.** node resolves
+`Intl.DateTimeFormat().resolvedOptions().locale` through ICU, and ICU answers
+what it has compiled in — a small-ICU build reports `en-US` for every
+environment there is. The POSIX variables are what the person who launched the
+app actually said. `C` and `POSIX` are not locales but the _absence_ of one, so
+they fall through to ICU rather than becoming a tag.
+
+**This does not change while the app runs**, and there is deliberately no
+subscription behind it: a process's environment is fixed at exec and ICU's
+resolution with it, so a desktop that switches language announces it for the
+_next_ login and nothing this process can observe has moved.
+
+For text direction inside a component prefer `useDirection()` over
+`useLocale().direction` — it also honours `<ThemeProvider direction>` and the
+`direction` style property, which the locale knows nothing about. See
+[styling](styling.md). The default theme is already seeded from the locale, so
+an app started under `LANG=ar_EG.UTF-8` mirrors without being told to.
+
+---
+
+## What is not here
+
+**Network status.** There is no X-level answer, so it is necessarily D-Bus or
+netlink, and the honest version of the API would be a hint rather than a fact —
+a failed request is always the better truth than a flag that says the link is
+up. Not ruled out; not built.
+
+**Battery, brightness, volume, media keys, notifications, a tray icon.** These
+are D-Bus services a third party can wrap without anything from here.
+Notifications and StatusNotifierItem are the two with a claim on core, because
+they are desktop standards rather than one vendor's service — and the tray in
+particular is cheap here, since its menu is [dbusmenu](globalmenu.md), which
+this renderer already speaks.
+
+**Session lifecycle** — "we are suspending, save now", and "I have unsaved work,
+do not log out yet". The X-native answer (XSMP) is effectively dead and the live
+one is logind. The shape worth having is probably not a system hook but a
+`useBeforeQuit()` that unifies it with `<window onCloseRequest>`.
+
+**Display scale.** On a HiDPI desktop every widget renders at half size, and
+fixing it means a scale that multiplies layout, font sizes and the paint
+transform together — a root concern rather than a hook. Tracked as
+[#116](https://github.com/sidorares/react-x11/issues/116).

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -46,6 +46,10 @@ import { beginCompose } from './compose.js';
 import { beginKeyboard } from './keyboard.js';
 import { beginCompositing, endCompositing } from './compositing.js';
 import { beginScreens, endScreens } from './screens.js';
+import { beginDesktopSettings, endDesktopSettings } from './desktopsettings.js';
+import { endIdle } from './idle.js';
+import { endKeyboardState } from './keyboardstate.js';
+import { endXSettings } from './xsettings.js';
 import { watchAppearance } from './appearance.js';
 import { ForeignNode } from './foreignnodes.js';
 import { GlAreaNode } from './glnodes.js';
@@ -752,6 +756,15 @@ export async function createRoot(options = {}) {
   // no window ever has to wait to know how big it is allowed to be.
   await beginScreens(app);
 
+  // How fast a caret blinks, how long a double click has, how far a press
+  // moves before it is a drag. **Not** awaited, unlike the two above: the
+  // renderer reads these synchronously but only on an interaction — a focus,
+  // a click, a drag — which is always many milliseconds after startup, so
+  // making every app wait five round trips for them would buy nothing. A
+  // field focused on the very first frame gets the built-in defaults and the
+  // desktop's cadence from its next focus on (src/desktopsettings.js).
+  beginDesktopSettings(app);
+
   // The desktop switching between light and dark reaches the widgets through
   // React — `useTheme()` subscribes — but the other theme route is the node
   // tree, which React does not re-render. This is that half: drop the cached
@@ -792,6 +805,14 @@ export async function createRoot(options = {}) {
       stopAppearance();
       endCompositing(app);
       endScreens(app);
+      endDesktopSettings(app);
+      endIdle(app);
+      endKeyboardState(app);
+      // The XSETTINGS session outlives both of its readers otherwise: it
+      // holds a PropertyChange selection on the settings daemon's window and
+      // an XFixes watch on the selection, neither of which anything else
+      // takes off.
+      endXSettings(app);
       if (owned) {
         unregisterApp(app);
         await app.close();

--- a/src/components/dates.js
+++ b/src/components/dates.js
@@ -195,27 +195,12 @@ function formatter(locale, options) {
   return f;
 }
 
-/**
- * Which day the week starts on for a locale: `0` Sunday … `6` Saturday.
- *
- * The runtime knows this — CLDR carries it — but only through
- * `Intl.Locale#getWeekInfo`, which is recent enough that a small-ICU build or
- * an older V8 has neither it nor the `weekInfo` property it was proposed as.
- * So it is feature-detected, and what is left when it is missing is **Monday**:
- * ISO 8601's answer, and the one most of the world uses.
- */
-export function localeWeekStart(locale) {
-  try {
-    const info = new Intl.Locale(locale ?? undefined);
-    const week = info.getWeekInfo?.() ?? info.weekInfo;
-    // CLDR counts 1 Monday … 7 Sunday; JS counts 0 Sunday … 6 Saturday
-    if (week?.firstDay) return week.firstDay % 7;
-  } catch {
-    // an invalid locale tag: the caller's formatters will complain about it
-    // more usefully than a week-start fallback could
-  }
-  return 1;
-}
+// Which day the week starts on lives in `locale.js` now, beside the rest of
+// what a locale decides — `useLocale()` reports the same number, and a
+// calendar and the app around it disagreeing about when the week starts is
+// exactly the bug two copies of this would produce. Re-exported because
+// `Calendar` has always imported it from here.
+export { localeWeekStart } from '../locale.js';
 
 /** `['Mon', 'Tue', …]` in the locale, rotated to start on `weekStartsOn`. */
 export function weekdayLabels(locale, weekStartsOn = 1) {

--- a/src/desktopsettings.js
+++ b/src/desktopsettings.js
@@ -1,0 +1,198 @@
+// The desktop's interaction settings: how fast a caret blinks, how long a
+// double click has, how far a press has to move before it is a drag.
+//
+// These were four constants in this codebase — `CARET_BLINK_MS` in nodes.js,
+// `DRAG_THRESHOLD` in dnd.js, and the 400ms/4px pair inside
+// `EventManager._clickDetail` — every one of them a guess at a number the
+// desktop already publishes and every other toolkit already reads.
+//
+// ## Why this is not part of the appearance ladder
+//
+// `appearance.js` climbs three sources for colour scheme and accent, because
+// those are answered by three different things and the portal is the modern
+// one. Nothing here has a portal equivalent: `org.freedesktop.appearance` has
+// four keys and none of them is a timing. XSETTINGS is the whole story, and
+// where there is no settings daemon — a bare `startx`, most window managers,
+// XQuartz — the defaults below stand.
+//
+// So this reads the map `xsettings.js` already maintains, rather than
+// standing up a source of its own.
+//
+// ## Two of these are read synchronously, which is what shapes the module
+//
+// A caret arms its blink inside `defaultFocus()` and a drag decides it has
+// started inside a mousemove. Neither has a round trip available, so
+// `desktopSettings(app)` is a synchronous read of an already-populated map
+// and `createRoot()` starts XSETTINGS **without awaiting it** — the settings
+// land in a few milliseconds and the first interaction is much later than
+// that. A field focused on the very first frame gets the defaults and the
+// desktop's cadence from the next focus onward; that is the one seam, and it
+// is worth more than the round trips on every app's startup path.
+
+import { beginXSettings, watchXSettings, xsettings } from './xsettings.js';
+
+/**
+ * What is true with no settings daemon to ask.
+ *
+ * These are **this renderer's existing constants**, not GTK's defaults. The
+ * two disagree — GTK blinks on a 1200ms cycle and drags at 8px, against 1060
+ * and 4 here — and changing what an app does on a desktop that never
+ * expressed a preference is a different decision from honouring one that
+ * did. This module only does the second.
+ */
+export const DEFAULTS = Object.freeze({
+  caretBlink: true,
+  // GTK, Qt and Windows all land within a few tens of milliseconds of this,
+  // and a blink out of step with the rest of the desktop is noticed even
+  // when the number cannot be named. Re-exported as `CARET_BLINK_MS` from
+  // `react-x11/node`, so an element drawing its own caret has one number to
+  // agree with rather than two.
+  caretBlinkMs: 530,
+  doubleClickMs: 400,
+  doubleClickDistance: 4,
+  // A press is a click until it moves this far. GTK's is 8; this is the
+  // DOM's, which is what the drag machinery here was built against.
+  dragThreshold: 4,
+  source: null,
+});
+
+const sessions = new WeakMap();
+
+/** A positive integer from the map, or undefined — a settings daemon can
+ *  export a key with a string value or a nonsense one, and a caret with a
+ *  blink period of `'fast'` would never come back on. */
+function positive(map, key) {
+  const value = map?.get(key);
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? value
+    : undefined;
+}
+
+/**
+ * An XSETTINGS map → the settings. Pure, and exported for the test: the
+ * in-process X server has no settings daemon, so this is the part of the
+ * path worth pinning without one.
+ *
+ * **`Net/CursorBlinkTime` is a full cycle**, on and off together — that is
+ * what GTK means by `gtk-cursor-blink-time` and what every daemon writes —
+ * and `caretBlinkMs` is how long the caret stays in *each* state, because
+ * that is the number that goes into a timer. Halving it is the whole
+ * conversion, and forgetting to is a caret that blinks at half speed and
+ * looks broken rather than wrong.
+ */
+export function fromXSettings(map) {
+  if (!map) return DEFAULTS;
+  const cycle = positive(map, 'Net/CursorBlinkTime');
+  const blink = map.get('Net/CursorBlink');
+  return Object.freeze({
+    // 0 is "do not blink at all", which is an accessibility setting rather
+    // than a preference: a moving thing on screen is what some people cannot
+    // read past. A caret that ignores it is the bug this module was written
+    // for. Only an explicit 0 turns it off — an absent key is not an answer.
+    caretBlink: blink !== 0,
+    caretBlinkMs: cycle
+      ? Math.max(1, Math.round(cycle / 2))
+      : DEFAULTS.caretBlinkMs,
+    doubleClickMs:
+      positive(map, 'Net/DoubleClickTime') ?? DEFAULTS.doubleClickMs,
+    doubleClickDistance:
+      positive(map, 'Net/DoubleClickDistance') ?? DEFAULTS.doubleClickDistance,
+    dragThreshold:
+      positive(map, 'Net/DndDragThreshold') ?? DEFAULTS.dragThreshold,
+    source: 'xsettings',
+  });
+}
+
+/**
+ * The settings for a connection, **synchronously**. Always a complete answer:
+ * the defaults before the daemon has been read, and on a display with none.
+ *
+ * Cached rather than derived per call, because `useDesktopSettings()` reads
+ * it through `useSyncExternalStore` and because the drag path calls it on
+ * every mousemove.
+ */
+export function desktopSettings(app) {
+  const session = sessions.get(app);
+  if (!session) return DEFAULTS;
+  if (!session.snapshot) {
+    session.snapshot = fromXSettings(xsettings(app));
+  }
+  return session.snapshot;
+}
+
+/**
+ * Start reading the settings on `app`.
+ *
+ * Deliberately **not** awaited by `createRoot()` — see the note at the top of
+ * the file. Never rejects.
+ */
+export function beginDesktopSettings(app) {
+  if (sessions.has(app)) return;
+  const session = { snapshot: null, listeners: new Set(), stop: null };
+  sessions.set(app, session);
+  beginXSettings(app).then(
+    () => {
+      if (!sessions.has(app)) return;
+      session.snapshot = null;
+      notify(session);
+      session.stop = watchXSettings(app, () => {
+        session.snapshot = null;
+        notify(session);
+      });
+    },
+    () => {
+      // no daemon, no raw connection, a headless mock: the defaults stand,
+      // which is what they are for
+    },
+  );
+}
+
+function notify(session) {
+  for (const fn of [...session.listeners]) {
+    try {
+      fn();
+    } catch {
+      // one subscriber throwing must not take the others with it
+    }
+  }
+}
+
+/** Subscribe to the settings changing. Not public — `useDesktopSettings()` is. */
+export function watchDesktopSettings(app, fn) {
+  let session = sessions.get(app);
+  if (!session) {
+    beginDesktopSettings(app);
+    session = sessions.get(app);
+  }
+  if (!session) return () => {};
+  session.listeners.add(fn);
+  return () => session.listeners.delete(fn);
+}
+
+/** Tear down with the root that started it. */
+export function endDesktopSettings(app) {
+  const session = sessions.get(app);
+  if (!session) return;
+  session.stop?.();
+  session.listeners.clear();
+  sessions.delete(app);
+}
+
+/**
+ * Test seam: state the settings without a settings daemon. Takes the same
+ * shape the hook returns; anything left out keeps its default.
+ */
+export function setDesktopSettingsForTests(app, values) {
+  let session = sessions.get(app);
+  if (!session) {
+    session = { snapshot: null, listeners: new Set(), stop: null };
+    sessions.set(app, session);
+  }
+  session.snapshot = Object.freeze({
+    ...DEFAULTS,
+    ...values,
+    source: values ? 'test' : null,
+  });
+  notify(session);
+  return session.snapshot;
+}

--- a/src/desktopsettingshooks.js
+++ b/src/desktopsettingshooks.js
@@ -1,0 +1,62 @@
+// `useDesktopSettings()` — the desktop's interaction timings, as something a
+// component re-renders on.
+//
+// The store lives in `desktopsettings.js`, which the renderer reads
+// synchronously on the caret, click and drag paths. This is the same values,
+// for an app drawing something the renderer does not.
+
+import { useCallback, useSyncExternalStore } from 'react';
+
+import { useApp } from './appcontext.js';
+import { desktopSettings, watchDesktopSettings } from './desktopsettings.js';
+
+/**
+ * How this desktop wants an application to feel, live.
+ *
+ * ```jsx
+ * const { doubleClickMs, dragThreshold } = useDesktopSettings();
+ *
+ * // a <canvas> implementing its own gestures matches the rest of the desktop
+ * const onPointerDown = (e) => {
+ *   const now = e.timeStamp;
+ *   if (now - last.current < doubleClickMs) openItem();
+ *   last.current = now;
+ * };
+ * ```
+ *
+ * | | |
+ * | --- | --- |
+ * | `caretBlink` | **false means do not blink at all** — an accessibility setting |
+ * | `caretBlinkMs` | how long a caret stays in each state (530) |
+ * | `doubleClickMs` | how long a second click has to arrive in (400) |
+ * | `doubleClickDistance` | and how far it may land from the first (4px) |
+ * | `dragThreshold` | how far a press moves before it is a drag, not a click (4px) |
+ * | `source` | `'xsettings'`, or null where no settings daemon answered |
+ *
+ * **The built-in controls already follow these** — `<textinput>`'s caret,
+ * the click counting behind `ev.detail`, and the XDND drag threshold all
+ * read the same values. This hook is for an app drawing its own: a `<canvas>`
+ * with a text cursor in it, a custom gesture, a diagram editor with its own
+ * drag. Reach for it so that one widget on the screen does not feel unlike
+ * every other.
+ *
+ * `caretBlink` deserves the callout. A caret that ignores it is not a
+ * cosmetic miss: a moving thing on screen is what some people cannot read
+ * past, which is why the desktop offers the switch. Draw the caret solid
+ * rather than not at all.
+ *
+ * XSETTINGS is the only source — there is no portal interface for any of
+ * this — so on a desktop with no settings daemon `source` is null and the
+ * numbers above are this renderer's own defaults. They are not GTK's: the
+ * point of this hook is to follow a desktop that expressed a preference, not
+ * to change what happens on one that did not.
+ */
+export function useDesktopSettings() {
+  const app = useApp();
+  const subscribe = useCallback(
+    (onChange) => watchDesktopSettings(app, onChange),
+    [app],
+  );
+  const snapshot = useCallback(() => desktopSettings(app), [app]);
+  return useSyncExternalStore(subscribe, snapshot, snapshot);
+}

--- a/src/dnd.js
+++ b/src/dnd.js
@@ -25,6 +25,7 @@ import {
   ContinuousEventPriority,
 } from './priority.js';
 import { callHandler, reportHandlerError } from './errors.js';
+import { desktopSettings } from './desktopsettings.js';
 import { discrete } from './events.js';
 import {
   TEXT_TARGETS,
@@ -1067,8 +1068,12 @@ export class DropSession {
 // transports apart except by asking.
 // ---------------------------------------------------------------------------
 
-/** DOM-ish drag threshold: a press is a click until it moves this far. */
-const DRAG_THRESHOLD = 4;
+// How far a press moves before it is a drag rather than a click lives in
+// `desktopsettings.js`: it is `Net/DndDragThreshold` where the desktop
+// published one, and this renderer's own 4px where it did not. A drag that
+// starts sooner here than in every other application is a drag people begin
+// by accident.
+
 /** How long to wait for a target's XdndFinished before ending the drag
  * anyway — the mirror of the drop side's watchdog. */
 const FINISH_TIMEOUT = 5_000;
@@ -1213,7 +1218,7 @@ export class DragSession {
     if (this.phase === 'armed') {
       const moved =
         Math.abs(native.x - this.press.x) + Math.abs(native.y - this.press.y);
-      if (moved < DRAG_THRESHOLD) return false;
+      if (moved < desktopSettings(this.app).dragThreshold) return false;
       if (!this._start(native)) return false;
     }
     if (this.phase !== 'dragging') return false;

--- a/src/events.js
+++ b/src/events.js
@@ -11,6 +11,7 @@ import {
 import { flushPendingFrames } from './frames.js';
 import { callHandler } from './errors.js';
 import { armDrag } from './dnd.js';
+import { desktopSettings } from './desktopsettings.js';
 import { noteInputTime } from './inputtime.js';
 import { hooks as a11yHooks, isFocusable } from './a11y.js';
 import { Composer, composeTableFor } from './compose.js';
@@ -227,15 +228,25 @@ export class EventManager {
     return this._focusOwner ?? this;
   }
 
-  /** DOM-style click counting: repeated presses within 400ms / 4px bump
-   * `detail` (2 = double click, 3 = triple …). */
+  /**
+   * DOM-style click counting: repeated presses close enough together in time
+   * and space bump `detail` (2 = double click, 3 = triple …).
+   *
+   * The window and the distance are the desktop's — `Net/DoubleClickTime`
+   * and `Net/DoubleClickDistance` — falling back to 400ms/4px where no
+   * settings daemon answered. A double click that needs to be faster here
+   * than everywhere else on the desktop is a double click people miss.
+   */
   _clickDetail(native) {
     const now = Date.now();
     const last = this._lastClick;
+    const { doubleClickMs, doubleClickDistance } = desktopSettings(
+      this.node?.app,
+    );
     const detail =
-      now - last.time < 400 &&
-      Math.abs(native.x - last.x) <= 4 &&
-      Math.abs(native.y - last.y) <= 4
+      now - last.time < doubleClickMs &&
+      Math.abs(native.x - last.x) <= doubleClickDistance &&
+      Math.abs(native.y - last.y) <= doubleClickDistance
         ? last.detail + 1
         : 1;
     this._lastClick = { time: now, x: native.x, y: native.y, detail };

--- a/src/idle.js
+++ b/src/idle.js
@@ -1,0 +1,498 @@
+// Whether the user is still there, and how to tell the desktop not to blank
+// the screen while something is playing.
+//
+// ## Idle: alarms, not polling
+//
+// X has a counter for this — `IDLETIME`, a SYNC system counter carrying
+// milliseconds since the last input on any device — and SYNC *alarms* fire an
+// event when a counter crosses a value. So "tell me when the user has been
+// idle for five minutes" is one alarm and no timer at all, which is what
+// every idle daemon on the desktop (xss-lock, KDE's, GNOME's) is built on.
+//
+// The idiom is a flip-flop, and it is the whole mechanism:
+//
+//   idle    ← alarm on IDLETIME >= timeout   (PositiveComparison)
+//   active  ← alarm on IDLETIME <= timeout   (NegativeComparison)
+//
+// One fires, the state flips, and the alarm is changed to watch for the
+// crossing back. Nothing runs in between — no interval, nothing waking the
+// process up to ask a question whose answer is usually "no".
+//
+// **`delta` must be sent as 0.** It defaults to 1, and the protocol rejects a
+// positive delta on a negative test with a Match error, so the half of the
+// flip-flop that waits for the user to come back would fail — and fail
+// silently, since a void request's error goes to the connection's error hook
+// rather than to a callback.
+//
+// Where there is no `IDLETIME` counter the fallback is MIT-SCREEN-SAVER's
+// `QueryInfo`, which answers the same number for one round trip but has no
+// event behind it, so that rung polls. It schedules against the answer rather
+// than on a fixed tick — with 12 seconds elapsed of a 300-second timeout the
+// next check is 288 seconds away — so an active user costs one round trip per
+// timeout period.
+//
+// ## Inhibition: three rungs that agree on what they do
+//
+// All three keep the **screen** awake and none of them stops a suspend. That
+// is not a simplification, it is the intersection: `ScreenSaverSuspend` is
+// an X request about blanking, `org.freedesktop.ScreenSaver` is the pre-portal
+// desktop interface for the same thing, and only the portal can also inhibit
+// logout and suspend. Exposing a `mode` that works on one rung out of three
+// would be a seam that mostly does not.
+
+import { sessionBus } from './bus.js';
+import { PORTAL_NAME, PORTAL_PATH } from './portal.js';
+
+const IDLETIME = 'IDLETIME';
+const SCREENSAVER_NAME = 'org.freedesktop.ScreenSaver';
+const SCREENSAVER_PATH = '/org/freedesktop/ScreenSaver';
+const INHIBIT_IFACE = 'org.freedesktop.portal.Inhibit';
+const REQUEST_IFACE = 'org.freedesktop.portal.Request';
+/** `org.freedesktop.portal.Inhibit`'s flag for "do not let the session idle". */
+const INHIBIT_IDLE = 8;
+
+const sessions = new WeakMap();
+
+// --------------------------------------------------------------------------
+// Idle
+// --------------------------------------------------------------------------
+
+/**
+ * One connection's idle machinery: the extensions it resolved once, and a
+ * watcher per distinct timeout. Two components asking for the same timeout
+ * share an alarm; asking for two different ones costs two.
+ */
+class IdleSession {
+  constructor(app) {
+    this.app = app;
+    this.watchers = new Map();
+    this.stopped = false;
+    this._sync = undefined;
+    this._saver = undefined;
+    this._counter = undefined;
+    this._handler = null;
+  }
+
+  stop() {
+    this.stopped = true;
+    for (const watcher of this.watchers.values()) watcher.stop();
+    this.watchers.clear();
+    if (this._handler && this.app?.X?.off) {
+      try {
+        this.app.X.off('event', this._handler);
+      } catch {
+        // an ntk old enough to hand back a client with no `off`
+      }
+    }
+    this._handler = null;
+  }
+
+  /** The SYNC extension, resolved once per connection. */
+  sync() {
+    if (this._sync === undefined) this._sync = requireExt(this.app, 'sync');
+    return this._sync;
+  }
+
+  /** MIT-SCREEN-SAVER, likewise. */
+  saver() {
+    if (this._saver === undefined) {
+      this._saver = requireExt(this.app, 'screen-saver');
+    }
+    return this._saver;
+  }
+
+  /**
+   * The `IDLETIME` counter's id, or null where the server has no such
+   * counter — which is every server without the XInput-driven idle tracking
+   * Xorg has, XQuartz among them.
+   */
+  counter() {
+    if (this._counter !== undefined) return this._counter;
+    this._counter = this.sync().then((sync) => {
+      if (!sync?.ListSystemCounters) return null;
+      return new Promise((resolve) => {
+        try {
+          sync.ListSystemCounters((err, counters) => {
+            if (err || !counters) return resolve(null);
+            resolve(counters.find((c) => c.name === IDLETIME)?.counter ?? null);
+          });
+        } catch {
+          resolve(null);
+        }
+      });
+    });
+    return this._counter;
+  }
+
+  /** One `event` listener for every alarm, installed once. */
+  listen(fn) {
+    if (this._handler) return;
+    const X = this.app?.X;
+    if (!X?.on) return;
+    this._handler = fn;
+    X.on('event', fn);
+  }
+}
+
+class IdleWatcher {
+  constructor(session, timeout) {
+    this.session = session;
+    this.timeout = timeout;
+    this.idle = false;
+    this.listeners = new Set();
+    this.stopped = false;
+    this.alarm = 0;
+    this._sync = null;
+    this._timer = null;
+  }
+
+  set(idle) {
+    if (this.stopped || this.idle === idle) return;
+    this.idle = idle;
+    for (const fn of [...this.listeners]) {
+      try {
+        fn();
+      } catch {
+        // one subscriber throwing must not take the others with it, nor the
+        // X event loop this runs on
+      }
+    }
+  }
+
+  stop() {
+    this.stopped = true;
+    this.listeners.clear();
+    clearTimeout(this._timer);
+    this._timer = null;
+    if (this.alarm) {
+      try {
+        this._sync?.DestroyAlarm(this.alarm);
+      } catch {
+        // the connection is going away with it
+      }
+      this.alarm = 0;
+    }
+  }
+}
+
+/**
+ * Arm a watcher: SYNC alarms where the counter exists, polling where it does
+ * not, and nothing at all where neither extension is present — on which the
+ * watcher reports "not idle" for good, which is the honest answer for a
+ * display that cannot be asked.
+ */
+async function armIdle(watcher) {
+  const session = watcher.session;
+  const counter = await session.counter();
+  if (watcher.stopped) return;
+
+  if (counter) {
+    const sync = await session.sync();
+    if (watcher.stopped || !sync) return;
+    watcher._sync = sync;
+    const X = session.app.X;
+    watcher.alarm = X.AllocID();
+
+    session.listen((ev) => {
+      if (session.stopped) return;
+      if (ev.type !== sync.firstEvent + sync.events.AlarmNotify) return;
+      for (const w of session.watchers.values()) {
+        if (w.alarm !== ev.alarm || w.stopped) continue;
+        // The counter value the alarm fired at says which way it crossed,
+        // rather than trusting the flip-flop's own idea of where it was: an
+        // alarm changed twice in a frame can deliver events out of order.
+        const idle = ev.counterValue >= w.timeout;
+        w.set(idle);
+        retest(sync, w, idle);
+      }
+    });
+
+    try {
+      sync.CreateAlarm(watcher.alarm, {
+        counter,
+        valueType: sync.ValueType.Absolute,
+        value: watcher.timeout,
+        testType: sync.TestType.PositiveComparison,
+        delta: 0,
+        events: 1,
+      });
+    } catch {
+      watcher.alarm = 0;
+    }
+    return;
+  }
+
+  // No counter: poll MIT-SCREEN-SAVER instead.
+  const saver = await session.saver();
+  if (watcher.stopped || !saver?.QueryInfo) return;
+  poll(watcher, saver);
+}
+
+/** Flip the alarm over to watch for the crossing back. */
+function retest(sync, watcher, idle) {
+  if (!watcher.alarm) return;
+  try {
+    sync.ChangeAlarm(watcher.alarm, {
+      valueType: sync.ValueType.Absolute,
+      value: watcher.timeout,
+      testType: idle
+        ? sync.TestType.NegativeComparison
+        : sync.TestType.PositiveComparison,
+      delta: 0,
+      events: 1,
+    });
+  } catch {
+    // the connection went away; nothing further will arrive either way
+  }
+}
+
+/**
+ * The fallback rung. Sleeps for exactly as long as the answer says it can:
+ * an idle time of 12s against a 300s timeout cannot become idle for another
+ * 288s, so that is when to look again.
+ *
+ * Once idle, there is nothing to compute a wait from — the counter only goes
+ * up until input resets it, and no input reaches this process when the user
+ * is typing in another window. So that direction polls on an interval scaled
+ * to the timeout, floored at a second and capped at half a minute: a
+ * five-minute away marker clears within 30s of the user coming back, and a
+ * ten-second one clears within a second.
+ */
+function poll(watcher, saver) {
+  if (watcher.stopped) return;
+  const root = watcher.session.app.X.display?.screen?.[0]?.root;
+  if (root == null) return;
+  saver.QueryInfo(root, (err, info) => {
+    if (watcher.stopped) return;
+    if (err || !info) return schedule(watcher, saver, watcher.timeout);
+    const elapsed = info.idle ?? 0;
+    const idle = elapsed >= watcher.timeout;
+    watcher.set(idle);
+    schedule(
+      watcher,
+      saver,
+      idle
+        ? Math.min(30_000, Math.max(1_000, watcher.timeout / 4))
+        : Math.max(250, watcher.timeout - elapsed),
+    );
+  });
+}
+
+function schedule(watcher, saver, delay) {
+  clearTimeout(watcher._timer);
+  watcher._timer = setTimeout(() => poll(watcher, saver), delay);
+  // Never a reason for this to keep the process alive: an app whose windows
+  // have closed does not care whether anyone is at the keyboard.
+  watcher._timer.unref?.();
+}
+
+/** Whether this timeout is currently elapsed. Not public — `useIdle()` is. */
+export function idleSnapshot(app, timeout) {
+  return sessions.get(app)?.watchers.get(timeout)?.idle ?? false;
+}
+
+/** Subscribe to a timeout elapsing and un-elapsing. */
+export function watchIdle(app, timeout, onChange) {
+  if (!app || !(timeout > 0)) return () => {};
+  let session = sessions.get(app);
+  if (!session) {
+    session = new IdleSession(app);
+    sessions.set(app, session);
+  }
+  let watcher = session.watchers.get(timeout);
+  if (!watcher) {
+    watcher = new IdleWatcher(session, timeout);
+    session.watchers.set(timeout, watcher);
+    armIdle(watcher).catch(() => {
+      // an extension that is not there is not an error, it is a rung
+    });
+  }
+  watcher.listeners.add(onChange);
+  return () => watcher.listeners.delete(onChange);
+}
+
+/** Tear down with the root that started it. */
+export function endIdle(app) {
+  const session = sessions.get(app);
+  if (!session) return;
+  session.stop();
+  sessions.delete(app);
+}
+
+/**
+ * Test seam: state that a timeout has or has not elapsed, without a server
+ * that has SYNC. The watcher it creates is inert — nothing arms it — so a
+ * test drives the value itself.
+ */
+export function setIdleForTests(app, timeout, idle) {
+  let session = sessions.get(app);
+  if (!session) {
+    session = new IdleSession(app);
+    sessions.set(app, session);
+  }
+  let watcher = session.watchers.get(timeout);
+  if (!watcher) {
+    watcher = new IdleWatcher(session, timeout);
+    session.watchers.set(timeout, watcher);
+  }
+  watcher.set(idle);
+  return watcher;
+}
+
+// --------------------------------------------------------------------------
+// Inhibition
+// --------------------------------------------------------------------------
+
+/**
+ * Ask the desktop not to blank the screen, and get back the release.
+ *
+ * ```js
+ * const release = await keepAwake({ reason: 'Playing a video', app });
+ * // …later
+ * release();
+ * ```
+ *
+ * Never rejects and never throws: a desktop with no portal, no screensaver
+ * service and no MIT-SCREEN-SAVER hands back a release that does nothing,
+ * because "could not ask" and "asked and it was ignored" are the same outcome
+ * for the caller and neither is worth an error path in a video player.
+ *
+ * `useKeepAwake()` is the shape a component wants; this is for imperative
+ * code and for tests.
+ */
+export async function keepAwake({ reason = 'Busy', app = null } = {}) {
+  for (const rung of [portalInhibit, screenSaverInhibit, xInhibit]) {
+    try {
+      const release = await rung(reason, app);
+      if (release) return once(release);
+    } catch {
+      // the next rung down
+    }
+  }
+  return () => {};
+}
+
+/** A release that runs once however many times it is called — a double
+ *  release would drop somebody else's inhibition on the counted X rung. */
+function once(fn) {
+  let done = false;
+  return () => {
+    if (done) return;
+    done = true;
+    try {
+      fn();
+    } catch {
+      // releasing something already gone is the outcome we wanted
+    }
+  };
+}
+
+/**
+ * Rung 1: `org.freedesktop.portal.Inhibit`.
+ *
+ * Not `portalRequest()`, though it is Request-shaped: this call's `Response`
+ * fires when the inhibition *ends*, so a helper that awaits one would hang
+ * for exactly as long as the feature is working. What is wanted is the
+ * handle, to `Close()` later.
+ */
+async function portalInhibit(reason, app) {
+  void app;
+  const ref = await sessionBus();
+  if (!ref) return null;
+  try {
+    const path = await ref.bus.invoke(
+      {
+        destination: PORTAL_NAME,
+        path: PORTAL_PATH,
+        interface: INHIBIT_IFACE,
+        member: 'Inhibit',
+        signature: 'sua{sv}',
+        // No parent window: an inhibition is not modal to anything, and the
+        // portal only uses the handle to place a dialog it does not show here.
+        body: ['', INHIBIT_IDLE, [['reason', ['s', reason]]]],
+      },
+      { timeout: 5_000 },
+    );
+    if (!path) return null;
+    return () => {
+      ref.bus
+        .invoke({
+          destination: PORTAL_NAME,
+          path,
+          interface: REQUEST_IFACE,
+          member: 'Close',
+          signature: '',
+          body: [],
+        })
+        .catch(() => {});
+    };
+  } finally {
+    // The inhibition belongs to the connection, not to this reference, and
+    // the connection stays open — holding a ref would keep the socket
+    // `ref()`d and the process alive for as long as a video was playing,
+    // which the window on screen is already doing.
+    await ref.release();
+  }
+}
+
+/** Rung 2: the pre-portal desktop interface, which KDE, Xfce, MATE and
+ *  every screensaver of that era implement. */
+async function screenSaverInhibit(reason, app) {
+  void app;
+  const ref = await sessionBus();
+  if (!ref) return null;
+  try {
+    const cookie = await ref.bus.invoke(
+      {
+        destination: SCREENSAVER_NAME,
+        path: SCREENSAVER_PATH,
+        interface: SCREENSAVER_NAME,
+        member: 'Inhibit',
+        signature: 'ss',
+        body: [process.title || 'react-x11', reason],
+      },
+      { timeout: 5_000 },
+    );
+    if (typeof cookie !== 'number') return null;
+    return () => {
+      ref.bus
+        .invoke({
+          destination: SCREENSAVER_NAME,
+          path: SCREENSAVER_PATH,
+          interface: SCREENSAVER_NAME,
+          member: 'UnInhibit',
+          signature: 'u',
+          body: [cookie],
+        })
+        .catch(() => {});
+    };
+  } finally {
+    await ref.release();
+  }
+}
+
+/**
+ * Rung 3: `ScreenSaverSuspend`, which needs no bus at all — the reason this
+ * ladder has a floor on a bare `startx` with no session services running.
+ *
+ * The server counts suspensions per client, so every `Suspend(true)` owes a
+ * `Suspend(false)`; `once()` above is what guarantees the pairing.
+ */
+async function xInhibit(reason, app) {
+  void reason;
+  const saver = app ? await requireExt(app, 'screen-saver') : null;
+  if (!saver?.Suspend) return null;
+  saver.Suspend(true);
+  return () => saver.Suspend(false);
+}
+
+/** An extension, or null where the server does not have it. */
+function requireExt(app, name) {
+  return new Promise((resolve) => {
+    try {
+      app.X.require(name, (err, ext) => resolve(err || !ext ? null : ext));
+    } catch {
+      resolve(null);
+    }
+  });
+}

--- a/src/idlehooks.js
+++ b/src/idlehooks.js
@@ -1,0 +1,100 @@
+// `useIdle()` and `useKeepAwake()` — the two halves of "is the user still
+// there", as things a component declares rather than manages.
+//
+// The machinery lives in `idle.js`, keyed by connection: idleness is a fact
+// about one display's input devices, and the inhibition is held for as long
+// as the component that asked for it is mounted.
+
+import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react';
+
+import { useApp } from './appcontext.js';
+import { idleSnapshot, keepAwake, watchIdle } from './idle.js';
+
+/**
+ * Whether the user has been away from the keyboard for `timeout`
+ * milliseconds.
+ *
+ * ```jsx
+ * const away = useIdle(5 * 60_000);
+ *
+ * <Avatar status={away ? 'away' : 'online'} />
+ * ```
+ *
+ * Idleness is the **whole display's**, not this window's: it counts input on
+ * every device, whichever application it went to. That is the right meaning
+ * for a presence indicator, an auto-save, or a dashboard that stops
+ * refreshing when the desk is empty, and the wrong one for "has the user
+ * ignored *my* window" — which is `useWindowState().focused`.
+ *
+ * Where the X server carries a `IDLETIME` counter — Xorg does — this costs
+ * **no timer at all**: a SYNC alarm fires when the counter crosses `timeout`
+ * and again when input pulls it back down. On a server without one (XQuartz)
+ * it falls back to polling MIT-SCREEN-SAVER, scheduled against the remaining
+ * time rather than on a tick. On a display with neither it stays `false`,
+ * which is the honest answer for a display that cannot be asked.
+ *
+ * `timeout` is a dependency: passing a computed value re-arms on every change,
+ * so hold it in a constant or a `useMemo` rather than building it inline from
+ * state that moves.
+ */
+export function useIdle(timeout) {
+  const app = useApp();
+  const subscribe = useCallback(
+    (onChange) => watchIdle(app, timeout, onChange),
+    [app, timeout],
+  );
+  const snapshot = useCallback(
+    () => idleSnapshot(app, timeout),
+    [app, timeout],
+  );
+  return useSyncExternalStore(subscribe, snapshot, snapshot);
+}
+
+/**
+ * Keep the screen awake while `active` is true.
+ *
+ * ```jsx
+ * useKeepAwake(playing, 'Playing a video');
+ * ```
+ *
+ * Held for as long as the flag is true and the component is mounted, and
+ * released on either — including on an unmount mid-playback, which is the
+ * case that leaves a desktop permanently un-blanking when it is done by hand.
+ *
+ * Three rungs, and **all three inhibit screen blanking only**: the settings
+ * portal's `Inhibit`, the older `org.freedesktop.ScreenSaver` service, and
+ * `ScreenSaverSuspend`, which is a plain X request and needs no session bus.
+ * Nothing here stops a **suspend** — only the portal rung could, and a seam
+ * that works on one desktop in three is worse than not offering it.
+ *
+ * `reason` is shown to the user by desktops that list what is holding the
+ * screen on, so it reads best as a sentence about the app's state rather than
+ * the app's name, which they already show.
+ *
+ * Failure is silent by design. A machine with no portal, no screensaver
+ * service and no MIT-SCREEN-SAVER cannot be asked, and a video player is not
+ * a place to surface that.
+ */
+export function useKeepAwake(active, reason = 'Busy') {
+  const app = useApp();
+  // Read through a ref so that editing the reason mid-playback does not drop
+  // the inhibition and take out a new one — a gap the screen can blank in.
+  const latest = useRef(reason);
+  latest.current = reason;
+
+  useEffect(() => {
+    if (!active) return undefined;
+    let release = null;
+    let cancelled = false;
+    keepAwake({ reason: latest.current, app }).then((fn) => {
+      // Unmounted while the bus round trip was in flight: take it out and
+      // give it straight back rather than leaking it for the process's life.
+      if (cancelled) fn();
+      else release = fn;
+    });
+    return () => {
+      cancelled = true;
+      release?.();
+    };
+  }, [active, app]);
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -21,6 +21,7 @@ export * from './types/dbus.js';
 export * from './types/application.js';
 export * from './types/filedialog.js';
 export * from './types/appearance.js';
+export * from './types/system.js';
 
 /**
  * The XID of the X11 window a ref points at, or `null` if there is not one

--- a/src/index.js
+++ b/src/index.js
@@ -37,6 +37,14 @@ export {
 export { useFileDialog } from './filedialoghooks.js';
 export { systemAppearance } from './appearance.js';
 export { useSystemAppearance } from './appearancehooks.js';
+export { useScreens } from './screenshooks.js';
+export { useWindowState } from './windowstate.js';
+export { keepAwake } from './idle.js';
+export { useIdle, useKeepAwake } from './idlehooks.js';
+export { useKeyboardState } from './keyboardstatehooks.js';
+export { useDesktopSettings } from './desktopsettingshooks.js';
+export { systemLocale } from './locale.js';
+export { useLocale } from './localehooks.js';
 export {
   useDropTarget,
   useDragSource,

--- a/src/keyboardstate.js
+++ b/src/keyboardstate.js
@@ -1,0 +1,286 @@
+// Caps Lock, Num Lock, and which keyboard layout is live.
+//
+// The one thing an application cannot work out for itself. A key event
+// carries the modifier state at the moment it was pressed, so an app can see
+// that Caps Lock was on for *a key it received* — which is exactly no help in
+// the case that matters, a password field that wants to warn before the first
+// character is typed and while the field is merely focused.
+//
+// XKB answers both halves directly: `GetState` for the state now,
+// `StateNotify` for every change after that, including the ones that happen
+// while another window has the keyboard. There is no polling and no timer.
+//
+// ## Which bit is which lock
+//
+// Caps Lock is `LockMask`, fixed by the core protocol. **Num Lock is not
+// fixed by anything** — it is wherever the modifier map puts it, and that is
+// `Mod2` on every Linux and BSD desktop, on XQuartz, and in every toolkit
+// that hardcodes it (GTK reads the modmap; Qt hardcodes Mod2). Reading the
+// modifier map to be sure costs a round trip and a keysym search to arrive at
+// Mod2 in every real case, so this takes the convention — the same one
+// `MOD.Mod2` in `keysyms.js` already documents for Alt and Super.
+//
+// ## Where the layout names come from
+//
+// `GetState().group` is an *index*, 0 to 3, and says nothing about what is in
+// the group. The names live in `_XKB_RULES_NAMES` on the root window — the
+// property `setxkbmap` writes and `setxkbmap -query` reads back — as
+// NUL-separated rules, model, layouts, variants and options. So `us,ru` plus
+// group 1 is `'ru'`.
+//
+// XKB's own `GetNames(GroupNames)` is the other route and is not used here:
+// it answers atoms that have to be interned back one round trip each, and
+// what it returns is a description like `English (US)` where an indicator in
+// a status bar wants `us`.
+
+const sessions = new WeakMap();
+
+/** `1 << xkbType` for the two events this needs. */
+const NEW_KEYBOARD_NOTIFY = 1 << 0;
+const STATE_NOTIFY = 1 << 2;
+
+const XKB_USE_CORE_KBD = 0x100;
+const LOCK_MASK = 2; // MOD.Lock — Caps Lock, per the core protocol
+const MOD2_MASK = 16; // MOD.Mod2 — Num Lock, per universal convention
+const RULES_PROPERTY = '_XKB_RULES_NAMES';
+
+/**
+ * What is known before XKB has answered, and what stays true on a display
+ * without the extension.
+ *
+ * Every field is the "off" answer rather than a null, because every caller of
+ * this is drawing something: a Caps Lock warning that renders `null` as truthy
+ * is worse than one that is briefly absent, and it is absent for one frame.
+ * `layouts` being empty is what distinguishes "not known" from "no lock on".
+ */
+const UNKNOWN = Object.freeze({
+  capsLock: false,
+  numLock: false,
+  group: 0,
+  layout: null,
+  layouts: Object.freeze([]),
+});
+
+class KeyboardSession {
+  constructor(app) {
+    this.app = app;
+    this.snapshot = UNKNOWN;
+    this.listeners = new Set();
+    this.armed = false;
+    this.stopped = false;
+    this._handler = null;
+  }
+
+  publish(values) {
+    const next = { ...this.snapshot, ...values };
+    // `layout` is derived in one place so it cannot disagree with the group
+    // and the list it comes from — a group index past the end of a
+    // just-reconfigured list is null rather than undefined.
+    next.layout = next.layouts[next.group] ?? null;
+    const prev = this.snapshot;
+    if (
+      next.capsLock === prev.capsLock &&
+      next.numLock === prev.numLock &&
+      next.group === prev.group &&
+      next.layout === prev.layout &&
+      // by value: `readLayouts` builds a fresh array every time it runs, and
+      // it runs again on every keymap replacement, most of which change
+      // nothing about the list
+      next.layouts.length === prev.layouts.length &&
+      next.layouts.every((l, i) => l === prev.layouts[i])
+    ) {
+      return;
+    }
+    this.snapshot = Object.freeze(next);
+    for (const fn of [...this.listeners]) {
+      try {
+        fn();
+      } catch {
+        // one subscriber throwing must not take the others with it, nor the
+        // X event loop this runs on
+      }
+    }
+  }
+
+  stop() {
+    this.stopped = true;
+    if (this._handler && this.app?.X?.off) {
+      try {
+        this.app.X.off('event', this._handler);
+      } catch {
+        // an ntk old enough to hand back a client with no `off`
+      }
+    }
+    this._handler = null;
+    this.listeners.clear();
+  }
+}
+
+/**
+ * `_XKB_RULES_NAMES` → the configured layout codes.
+ *
+ * Five NUL-terminated strings — rules, model, layouts, variants, options —
+ * of which the third is `us,ru`. Pure, and exported for the test: the
+ * in-process X server has no XKB, so this is the part of the path that can
+ * be pinned without one.
+ *
+ * A trailing NUL leaves an empty final field, and a layout list can
+ * legitimately have an empty entry (`us,,ru` from a hand-edited config), so
+ * the split keeps position and drops only what is empty at the ends.
+ */
+export function layoutsFromRules(data) {
+  if (!data?.length) return [];
+  const fields = data.toString('latin1').split('\0');
+  const layouts = fields[2];
+  if (!layouts) return [];
+  const list = layouts.split(',').map((s) => s.trim());
+  while (list.length && !list[list.length - 1]) list.pop();
+  // `empty` is a real xkeyboard-config layout, and what it is defined as is a
+  // layout with no symbols in it — which is exactly what XQuartz writes here,
+  // because it synthesizes its keymap from macOS and has no XKB layout to
+  // name. Reporting it would put "EMPTY" in a status-bar indicator; an empty
+  // list is what "this display cannot say" already means everywhere else here.
+  return list.every((name) => name === 'empty') ? [] : list;
+}
+
+/** Caps and Num out of a locked-modifier mask. */
+export function locksFromMods(lockedMods) {
+  return {
+    capsLock: Boolean(lockedMods & LOCK_MASK),
+    numLock: Boolean(lockedMods & MOD2_MASK),
+  };
+}
+
+async function arm(session) {
+  if (session.armed) return;
+  session.armed = true;
+  const app = session.app;
+  const xkb = await requireExt(app, 'xkb');
+  if (!xkb || session.stopped) return;
+
+  // Subscribe before reading. A lock toggled between the two would otherwise
+  // be lost for the life of the connection — the same ordering rule the
+  // appearance ladder and the clipboard watch both follow.
+  const handler = (ev) => {
+    if (session.stopped || ev.type !== xkb.firstEvent) return;
+    if (ev.xkbType === xkb.events.StateNotify) {
+      session.publish({ ...locksFromMods(ev.lockedMods), group: ev.group });
+      return;
+    }
+    // NewKeyboardNotify: the keymap itself was replaced, which is what
+    // `setxkbmap` does when the *set* of layouts changes rather than which
+    // one is active. Rare, and cheap to answer — one property read.
+    if (ev.xkbType === 0) readLayouts(session);
+  };
+  session._handler = handler;
+  app.X.on('event', handler);
+
+  try {
+    xkb.SelectEvents(
+      XKB_USE_CORE_KBD,
+      STATE_NOTIFY | NEW_KEYBOARD_NOTIFY,
+      0,
+      STATE_NOTIFY | NEW_KEYBOARD_NOTIFY,
+      0,
+      0,
+    );
+  } catch {
+    return;
+  }
+
+  readLayouts(session);
+
+  const state = await new Promise((resolve) => {
+    try {
+      xkb.GetState(XKB_USE_CORE_KBD, (err, value) =>
+        resolve(err ? null : value),
+      );
+    } catch {
+      resolve(null);
+    }
+  });
+  if (state && !session.stopped) {
+    session.publish({ ...locksFromMods(state.lockedMods), group: state.group });
+  }
+}
+
+async function readLayouts(session) {
+  const X = session.app.X;
+  const root = X.display?.screen?.[0]?.root;
+  if (root == null) return;
+  try {
+    const atom = await new Promise((resolve, reject) =>
+      X.InternAtom(false, RULES_PROPERTY, (err, value) =>
+        err ? reject(err) : resolve(value),
+      ),
+    );
+    const prop = await new Promise((resolve) =>
+      X.GetProperty(0, root, atom, 0, 0, 0x1fffffff, (err, value) =>
+        resolve(err ? null : value),
+      ),
+    );
+    if (session.stopped) return;
+    const layouts = layoutsFromRules(prop?.data);
+    if (layouts.length) session.publish({ layouts: Object.freeze(layouts) });
+  } catch {
+    // no rules property: a server configured by other means, or XQuartz,
+    // where the group index is all there is. `layouts` stays empty and
+    // `layout` stays null, which is what those say.
+  }
+}
+
+function requireExt(app, name) {
+  return new Promise((resolve) => {
+    try {
+      app.X.require(name, (err, ext) => resolve(err || !ext ? null : ext));
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
+/** What is known right now. Not public — `useKeyboardState()` is. */
+export function keyboardStateSnapshot(app) {
+  return sessions.get(app)?.snapshot ?? UNKNOWN;
+}
+
+/** Subscribe to the lock and layout state changing. */
+export function watchKeyboardState(app, onChange) {
+  if (!app) return () => {};
+  let session = sessions.get(app);
+  if (!session) {
+    session = new KeyboardSession(app);
+    sessions.set(app, session);
+  }
+  arm(session).catch(() => {
+    // an extension that is not there is not an error
+  });
+  session.listeners.add(onChange);
+  return () => session.listeners.delete(onChange);
+}
+
+/** Tear down with the root that started it. */
+export function endKeyboardState(app) {
+  const session = sessions.get(app);
+  if (!session) return;
+  session.stop();
+  sessions.delete(app);
+}
+
+/**
+ * Test seam: state the keyboard without a server that has XKB. Marks the
+ * session armed, so nothing tries to reach the extension behind the value.
+ */
+export function setKeyboardStateForTests(app, values) {
+  let session = sessions.get(app);
+  if (!session) {
+    session = new KeyboardSession(app);
+    sessions.set(app, session);
+  }
+  session.armed = true;
+  session.publish({
+    ...values,
+    layouts: Object.freeze(values.layouts ?? UNKNOWN.layouts),
+  });
+  return session;
+}

--- a/src/keyboardstatehooks.js
+++ b/src/keyboardstatehooks.js
@@ -1,0 +1,58 @@
+// `useKeyboardState()` — the locks and the active layout, as something a
+// component re-renders on.
+//
+// The store lives in `keyboardstate.js`, keyed by connection: there is one
+// keyboard per display, and its state is the same for every window on it.
+
+import { useCallback, useSyncExternalStore } from 'react';
+
+import { useApp } from './appcontext.js';
+import { keyboardStateSnapshot, watchKeyboardState } from './keyboardstate.js';
+
+/**
+ * The keyboard's locks and layout, live.
+ *
+ * ```jsx
+ * const { capsLock, layout } = useKeyboardState();
+ *
+ * <PasswordInput value={password} onChange={setPassword} />
+ * {capsLock && <text style={{ color: theme.warning }}>Caps Lock is on</text>}
+ * ```
+ *
+ * | | |
+ * | --- | --- |
+ * | `capsLock` `numLock` | on or off, **now** — not "was on for the last key" |
+ * | `group` | the active XKB group, `0`–`3` |
+ * | `layout` | that group's layout code, `'ru'` — or null |
+ * | `layouts` | every configured layout, `['us', 'ru']` — `[]` where unknown |
+ *
+ * The point of the first row is that it is true of the keyboard rather than
+ * of an event: a password field can warn about Caps Lock **before** the first
+ * character is typed, which is the only time the warning is worth anything.
+ * A key event's own modifier state cannot do that, because it needs a key.
+ *
+ * The second is for a status-bar indicator, and for the case that costs
+ * people real time — a password typed in the wrong script, which looks
+ * identical to a wrong password. `layout` is a code rather than a
+ * description (`'ru'`, not `'Russian'`) because that is what an indicator
+ * shows and what a lookup key wants; uppercase it for display.
+ *
+ * Everything here needs **XKB**, which Xorg and XQuartz both have. Where it
+ * is missing the locks read false and `layouts` is empty, and an app that
+ * renders a warning only when `capsLock` is true degrades to not warning.
+ * `layouts` is the field to check when the difference between "off" and "not
+ * known" matters.
+ *
+ * Nothing is asked of the server until a component calls this, and the change
+ * is delivered by `XkbStateNotify` — no polling, and it arrives even while
+ * another application has the keyboard.
+ */
+export function useKeyboardState() {
+  const app = useApp();
+  const subscribe = useCallback(
+    (onChange) => watchKeyboardState(app, onChange),
+    [app],
+  );
+  const snapshot = useCallback(() => keyboardStateSnapshot(app), [app]);
+  return useSyncExternalStore(subscribe, snapshot, snapshot);
+}

--- a/src/locale.js
+++ b/src/locale.js
@@ -1,0 +1,170 @@
+// Which language and conventions this app was started in.
+//
+// ## Why the environment comes before `Intl`
+//
+// `Intl.DateTimeFormat().resolvedOptions().locale` is the obvious answer and
+// it is the *second* one here, because node resolves it through ICU and ICU
+// answers `en-US` for a great many environments that are not en-US — a
+// small-ICU build has one locale compiled in, and a container with `LANG`
+// set but no locale archive still tells you what the user asked for. POSIX
+// `LC_ALL` / `LC_MESSAGES` / `LANG` is what the person who launched the app
+// actually said, so it wins where it says anything.
+//
+// `C` and `POSIX` are not locales — they are the *absence* of one, spelled
+// as a value — so they fall through rather than being converted to a tag.
+//
+// ## This does not change while an app runs
+//
+// A process's environment is fixed at exec, and `Intl`'s resolution with it.
+// `org.freedesktop.locale1` can announce a change for *future* logins, and
+// neither node nor ICU picks it up for this one, so publishing it here would
+// be reporting a change that has not happened to anything the app can see.
+//
+// So `useLocale()` subscribes to nothing, the way `useSupports('shaders')`
+// does — the hook shape is for composition and for the day a rung underneath
+// it can genuinely change, not because there is a store behind it.
+
+import { localeDirection } from './palette.js';
+
+const ENV = typeof process === 'undefined' ? {} : (process.env ?? {});
+
+/**
+ * A POSIX locale string → a BCP-47 tag, or null when it is not a locale.
+ *
+ * `ru_RU.UTF-8@euro` → `ru-RU`: the codeset after `.` and the modifier after
+ * `@` are POSIX's and mean nothing to `Intl`, and the territory separator is
+ * `_` where BCP-47 wants `-`.
+ *
+ * Pure, and exported for the test.
+ */
+export function toLanguageTag(value) {
+  if (typeof value !== 'string') return null;
+  const bare = value.split('.')[0].split('@')[0].trim().replace(/_/g, '-');
+  if (!bare) return null;
+  // The two values that mean "no locale at all". Passing either to `Intl`
+  // gets a RangeError from `C` and, worse, a plausible-looking `posix` tag
+  // from the other.
+  if (/^(C|POSIX)$/i.test(bare)) return null;
+  try {
+    // Canonicalises case and rejects a malformed tag — a `LANG` of
+    // `en_US_POSIX` or a typo should fall through to ICU rather than reach a
+    // formatter and throw there.
+    return Intl.getCanonicalLocales(bare)[0] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Which day the week starts on for a locale: `0` Sunday … `6` Saturday.
+ *
+ * The runtime knows this — CLDR carries it — but only through
+ * `Intl.Locale#getWeekInfo`, which is recent enough that a small-ICU build or
+ * an older V8 has neither it nor the `weekInfo` property it was proposed as.
+ * So it is feature-detected, and what is left when it is missing is **Monday**:
+ * ISO 8601's answer, and the one most of the world uses.
+ */
+export function localeWeekStart(locale) {
+  try {
+    const info = new Intl.Locale(locale ?? undefined);
+    const week = info.getWeekInfo?.() ?? info.weekInfo;
+    // CLDR counts 1 Monday … 7 Sunday; JS counts 0 Sunday … 6 Saturday
+    if (week?.firstDay) return week.firstDay % 7;
+  } catch {
+    // an invalid locale tag: the caller's formatters will complain about it
+    // more usefully than a week-start fallback could
+  }
+  return 1;
+}
+
+/**
+ * Which way a tag reads.
+ *
+ * CLDR knows, through `Intl.Locale#getTextInfo()`, and that is the answer
+ * where the runtime has it — it covers every script rather than the list of
+ * languages a hand-maintained set can hold. `localeDirection()` in
+ * `palette.js` is the fallback and the same set the default theme's direction
+ * is seeded from, so the two cannot disagree about a language both know.
+ */
+export function directionOf(tag, env = ENV) {
+  try {
+    const info = new Intl.Locale(tag ?? undefined);
+    const text = info.getTextInfo?.() ?? info.textInfo;
+    if (text?.direction === 'rtl' || text?.direction === 'ltr') {
+      return text.direction;
+    }
+  } catch {
+    // no getTextInfo in this build, or a tag Intl.Locale will not take
+  }
+  return localeDirection(tag ? { LANG: tag } : env);
+}
+
+/**
+ * Resolve everything at once. Pure in `env`, so a test can state an
+ * environment rather than mutate the process's.
+ */
+export function resolveLocale(env = ENV) {
+  const fromEnv =
+    toLanguageTag(env.LC_ALL) ??
+    toLanguageTag(env.LC_MESSAGES) ??
+    toLanguageTag(env.LANG);
+
+  let resolved = fromEnv;
+  let timeZone = null;
+  try {
+    const options = Intl.DateTimeFormat(
+      resolved ?? undefined,
+    ).resolvedOptions();
+    // ICU may not have the locale the environment named — a small build has
+    // one — in which case `resolvedOptions().locale` is the nearest it does
+    // have. The environment's answer still stands: it is what the user asked
+    // for, and every `Intl` call in the app will fall back the same way this
+    // one just did.
+    resolved ??= options.locale;
+    timeZone = options.timeZone ?? null;
+  } catch {
+    // no ICU at all
+  }
+
+  return Object.freeze({
+    locale: resolved ?? 'en-US',
+    direction: directionOf(resolved, env),
+    weekStartsOn: localeWeekStart(resolved),
+    timeZone,
+    source: fromEnv ? 'env' : resolved ? 'intl' : null,
+  });
+}
+
+/** Read once: see the note at the top about why there is nothing to watch. */
+let snapshot = null;
+
+/** The resolved locale, as one frozen object. Stable for the process. */
+export function systemLocale() {
+  snapshot ??= resolveLocale();
+  return snapshot;
+}
+
+/**
+ * Test seam: state a locale without re-execing the process. `null` releases
+ * the pin and resolves from the environment again.
+ *
+ * Naming a `locale` re-derives `direction` and `weekStartsOn` from it rather
+ * than keeping the process's own — pinning `he-IL` and silently staying
+ * left-to-right is not a locale anybody has.
+ */
+export function setLocaleForTests(values) {
+  if (values === null) {
+    snapshot = null;
+    return null;
+  }
+  const current = systemLocale();
+  const locale = values.locale ?? current.locale;
+  snapshot = Object.freeze({
+    locale,
+    direction: values.direction ?? directionOf(locale),
+    weekStartsOn: values.weekStartsOn ?? localeWeekStart(locale),
+    timeZone: values.timeZone ?? current.timeZone,
+    source: 'test',
+  });
+  return snapshot;
+}

--- a/src/localehooks.js
+++ b/src/localehooks.js
@@ -1,0 +1,47 @@
+// `useLocale()` — the language and conventions the app was started in.
+//
+// The resolution lives in `locale.js`. There is no store and no subscription
+// behind this: a process's locale is fixed at exec (see the note there), so
+// the hook exists for composition and discoverability rather than because
+// anything can change.
+
+import { systemLocale } from './locale.js';
+
+/**
+ * Which language and conventions this app was started in.
+ *
+ * ```jsx
+ * const { locale, weekStartsOn } = useLocale();
+ *
+ * <Calendar locale={locale} weekStartsOn={weekStartsOn} />
+ * <text>{new Intl.NumberFormat(locale).format(total)}</text>
+ * ```
+ *
+ * | | |
+ * | --- | --- |
+ * | `locale` | a BCP-47 tag: `'en-GB'`, `'ru-RU'` |
+ * | `direction` | `'ltr'` or `'rtl'` — what the default theme is already seeded with |
+ * | `weekStartsOn` | `0` Sunday … `6` Saturday, from CLDR |
+ * | `timeZone` | `'Europe/London'`, or null where ICU could not say |
+ * | `source` | `'env'` when `LANG` and friends said, `'intl'` when ICU did |
+ *
+ * **`LC_ALL` / `LC_MESSAGES` / `LANG` win over `Intl`'s own answer**, because
+ * ICU resolves to what it has compiled in rather than to what the user asked
+ * for — a small-ICU node reports `en-US` for every environment there is. The
+ * tag here is what the person who launched the app said; `Intl` is the
+ * fallback for a process started without any of them.
+ *
+ * **This does not change while the app runs**, and there is deliberately no
+ * subscription: a process's environment is fixed at exec and ICU's resolution
+ * with it, so a desktop that switches language announces it for the *next*
+ * login and nothing this process can observe has moved.
+ *
+ * Text direction is here for completeness and is rarely what you want to read
+ * — the widget set already mirrors itself from the same value, and
+ * `useDirection()` is the one to ask inside a component, because it also
+ * honours a `<ThemeProvider direction>` and a `direction` style property the
+ * locale knows nothing about. See docs/styling.md.
+ */
+export function useLocale() {
+  return systemLocale();
+}

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -58,6 +58,11 @@ import {
 } from './compositing.js';
 import { availableArea } from './screens.js';
 import {
+  DEFAULTS as DESKTOP_DEFAULTS,
+  desktopSettings,
+} from './desktopsettings.js';
+import { endWindowState } from './windowstate.js';
+import {
   anchorArea,
   anchorOffscreen,
   anchorRect,
@@ -4784,16 +4789,22 @@ const SCROLL_KEY_PAGE_OVERLAP = 24;
 const UNDO_LIMIT = 200;
 
 /**
- * How long a caret stays in each of its two states, in milliseconds. GTK,
- * Qt and Windows all land within a few tens of milliseconds of this, and a
- * blink that is out of step with the rest of the desktop is noticed even
- * when the number cannot be named.
+ * How long a caret stays in each of its two states, in milliseconds, on a
+ * desktop that did not say.
+ *
+ * A desktop that *did* say — `Net/CursorBlinkTime`, and `Net/CursorBlink: 0`
+ * for "do not blink at all" — is read through `desktopSettings(app)` at the
+ * moment a field takes focus. This is the floor under that, and what a
+ * connection with no settings daemon uses; it lives in `desktopsettings.js`
+ * beside the rest of them so there is one number rather than two.
  *
  * Exported from `react-x11/node` because an element that edits text draws
  * its own caret and would otherwise hardcode a second cadence — two carets
- * on one screen blinking against each other (issue #251).
+ * on one screen blinking against each other (issue #251). An element with a
+ * live connection to hand should prefer `useDesktopSettings().caretBlinkMs`,
+ * which is this value already reconciled with the desktop.
  */
-export const CARET_BLINK_MS = 530;
+export const CARET_BLINK_MS = DESKTOP_DEFAULTS.caretBlinkMs;
 
 // --- the standard edit menu ------------------------------------------------
 //
@@ -5996,13 +6007,23 @@ export class TextInputNode extends Node {
   defaultFocus() {
     this._focused = true;
     this._caretOn = true;
-    this._blinkTimer = setInterval(() => {
-      this._caretOn = !this._caretOn;
-      // twice a second, forever, for as long as a field has focus: the one
-      // repaint that most wants to cost only the field it happens in
-      this.root?.invalidate(false, this, 'caret');
-    }, CARET_BLINK_MS);
-    this._blinkTimer.unref?.();
+    // The desktop's cadence, read at focus rather than at import: XSETTINGS
+    // is started but not awaited by createRoot, so this is the first moment
+    // it is reliably in — and a field focused before that gets the default
+    // and the desktop's answer from the next focus on.
+    const { caretBlink, caretBlinkMs } = desktopSettings(this.root?.app);
+    // `Net/CursorBlink: 0` is an accessibility setting, not a preference: a
+    // solid caret is still a caret, so the field draws one and never arms a
+    // timer for it.
+    if (caretBlink) {
+      this._blinkTimer = setInterval(() => {
+        this._caretOn = !this._caretOn;
+        // twice a second, forever, for as long as a field has focus: the one
+        // repaint that most wants to cost only the field it happens in
+        this.root?.invalidate(false, this, 'caret');
+      }, caretBlinkMs);
+      this._blinkTimer.unref?.();
+    }
     this.root?.invalidate(false, this, 'focus');
   }
 
@@ -7943,6 +7964,9 @@ export class WindowNode extends Scrollable(Node) {
     clearPendingFrame(this);
     this._unwatchCompositing?.();
     this._unwatchCompositing = null;
+    // `useWindowState()`'s listeners, and the raw VisibilityNotify handler
+    // it put on the shared connection, which nothing else would take off
+    endWindowState(this);
     // Before the owner's next layout pass, which is this same commit: a
     // popup that has gone still holds a subscription to the window it was
     // anchored to, and answering that notification would configure a dead

--- a/src/screens.js
+++ b/src/screens.js
@@ -1,5 +1,11 @@
 /**
- * How big is a window allowed to get before anyone has asked for a size?
+ * The screen layout: how many monitors there are, where they are, and how
+ * much of each one a window may actually use.
+ *
+ * Two callers with very different needs share it, which is what shapes the
+ * whole module.
+ *
+ * ## The internal caller: how big may an auto-sized window get?
  *
  * `<window width="auto">` is sized from its content, and the one thing that
  * bound cannot be is "as large as the content wants" — a paragraph with no
@@ -32,14 +38,46 @@
  * natural size has to be resolved before `CreateWindow`, and there is no
  * round trip available at that point.
  *
- * What this deliberately does not model is the **window manager's frame**. A
- * window sized to exactly the work-area height is taller than that once it
- * has a titlebar, and the WM will shrink or shove it. EWMH's answer is
- * `_NET_REQUEST_FRAME_EXTENTS`, which a client sends *before* mapping and
- * the WM replies to by writing `_NET_FRAME_EXTENTS` — but that is a round
- * trip in the middle of a synchronous `realize()`, and plenty of window
- * managers never answer it. Letting the WM have the last word costs a
- * clamped-to-the-edge window one correction it would have made anyway.
+ * ## The application caller: `useScreens()`
+ *
+ * An app that remembers which monitor it was on, or offers to open a video
+ * on the other one, needs more than rects: a **name** to store, and a
+ * **primary** flag to default to. Xinerama has neither — its reply is four
+ * numbers per screen and nothing else — so that detail comes from RandR,
+ * which also carries physical size and refresh rate.
+ *
+ * **RandR is not on the startup path**, and that is the point. Xinerama
+ * answers the geometry in one round trip; the RandR walk is
+ * `GetScreenResourcesCurrent`, then a `GetOutputInfo` and a `GetCrtcInfo`
+ * per output, then `GetOutputPrimary` — ten or more round trips on an
+ * ordinary two-head desktop. Making `createRoot()` wait for that would cost
+ * every app startup latency for a question most of them never ask. So the
+ * cheap tier resolves first and the detailed one publishes over it a moment
+ * later.
+ *
+ * That is only safe because the second answer **adds to** the first rather
+ * than correcting it: Xinerama on any modern server is RandR's own
+ * emulation, so the rects agree, and what arrives late is the name, the
+ * primary flag, the millimetres and the refresh rate. A component that
+ * rendered against the early answer sees fields appear, not move.
+ *
+ * ## What this deliberately does not model
+ *
+ * **The window manager's frame.** A window sized to exactly the work-area
+ * height is taller than that once it has a titlebar, and the WM will shrink
+ * or shove it. EWMH's answer is `_NET_REQUEST_FRAME_EXTENTS`, which a client
+ * sends *before* mapping and the WM replies to by writing
+ * `_NET_FRAME_EXTENTS` — but that is a round trip in the middle of a
+ * synchronous `realize()`, and plenty of window managers never answer it.
+ * Letting the WM have the last word costs a clamped-to-the-edge window one
+ * correction it would have made anyway.
+ *
+ * **A per-monitor work area.** `_NET_WORKAREA` is one rect for the whole
+ * virtual desktop. Deriving a real per-monitor one means reading
+ * `_NET_WM_STRUT_PARTIAL` off every window on the screen and intersecting
+ * the reservations that fall on each head — a full window-tree walk, redone
+ * whenever any panel changes. `available` below is the per-axis
+ * approximation instead, and says so.
  */
 
 const sessions = new WeakMap();
@@ -48,23 +86,56 @@ const PROPERTY_NOTIFY = 28;
 const PROPERTY_CHANGE_MASK = 4194304; // x11.eventMask.PropertyChange
 const WORKAREA_PROPERTY = '_NET_WORKAREA';
 
+/** RandR's `Connection` enum — an output with nothing plugged into it is
+ *  reported as a resource that exists and is not connected. */
+const RR_CONNECTED = 0;
+
 /**
  * What a connection knows about its outputs. `monitors` is null until
- * Xinerama has answered (or for good, where it never does); `workArea` is
- * null until the desktop has published one. Both are advisory — `available()`
- * degrades through them in order and always has the screen to fall back on.
+ * something has answered (or for good, where nothing ever does); `workArea`
+ * is null until the desktop has published one. Both are advisory —
+ * `availableArea()` degrades through them in order and always has the screen
+ * to fall back on.
  */
 class ScreenSession {
   constructor(app) {
     this.app = app;
     this.monitors = null;
     this.workArea = null;
+    /** Which tier `monitors` came from, and the public `source`. */
+    this.source = null;
     this.stopped = false;
     this._workAreaAtom = null;
+    this._snapshot = null;
+    this._listeners = new Set();
+    /** Every `X.on('event')` handler installed here, so `stop()` can take
+     *  them off again rather than leaving one per root on a shared client. */
+    this._handlers = [];
   }
 
   stop() {
     this.stopped = true;
+    const X = this.app?.X;
+    if (X?.off) {
+      for (const fn of this._handlers) {
+        try {
+          X.off('event', fn);
+        } catch {
+          // an ntk old enough to hand back a client with no `off`; the
+          // `stopped` guard inside every handler is the real safety net
+        }
+      }
+    }
+    this._handlers.length = 0;
+    this._listeners.clear();
+  }
+
+  /** Install an X event handler that this session owns. */
+  onEvent(fn) {
+    const X = this.app?.X;
+    if (!X?.on) return;
+    X.on('event', fn);
+    this._handlers.push(fn);
   }
 
   /** The screen's own size — the tier everything falls back to. */
@@ -77,6 +148,31 @@ class ScreenSession {
       width: screen.pixel_width,
       height: screen.pixel_height,
     };
+  }
+
+  /**
+   * Replace what is known and tell anyone watching. The snapshot is dropped
+   * rather than rebuilt: nothing may need it, and `screensSnapshot()` is
+   * what rebuilds it on demand.
+   */
+  publish({ monitors, workArea, source }) {
+    if (monitors !== undefined) this.monitors = monitors;
+    if (workArea !== undefined) this.workArea = workArea;
+    if (source !== undefined) this.source = source;
+    this._snapshot = null;
+    for (const fn of [...this._listeners]) {
+      try {
+        fn();
+      } catch {
+        // one subscriber throwing must not take the others with it, nor the
+        // X event loop this runs on
+      }
+    }
+  }
+
+  subscribe(fn) {
+    this._listeners.add(fn);
+    return () => this._listeners.delete(fn);
   }
 }
 
@@ -105,6 +201,27 @@ function monitorAt(monitors, point) {
 }
 
 /**
+ * The monitor rect clamped per axis by `_NET_WORKAREA` — see the note on
+ * per-monitor work areas at the top of the file.
+ *
+ * Always **only** a rect. A monitor record carries a name, a primary flag and
+ * physical sizes as well, and spreading it here put all of that inside
+ * `screen.available`, where it read as a rect that had somehow grown a name.
+ */
+function usable(monitor, work) {
+  const rect = {
+    x: monitor.x,
+    y: monitor.y,
+    width: monitor.width,
+    height: monitor.height,
+  };
+  if (!work) return rect;
+  rect.width = Math.min(rect.width, work.width);
+  rect.height = Math.min(rect.height, work.height);
+  return rect;
+}
+
+/**
  * The rect an auto-sized window may grow into, or `null` where there is
  * nothing to ask. `near` is a screen-coordinate point the window will open
  * next to — a `transientFor` owner's origin, in practice — and picks the
@@ -116,23 +233,107 @@ export function availableArea(app, near = null) {
   if (!session) return screen;
   const monitor = monitorAt(session.monitors, near) ?? screen;
   if (!monitor) return null;
-  const work = session.workArea;
-  if (!work) return monitor;
-  // Per axis, not as a rect: `_NET_WORKAREA` spans the whole virtual screen,
-  // so intersecting it with a monitor would only ever give the monitor back
-  // on a multi-head desktop. Its *extent* is still the useful part.
-  return {
-    x: monitor.x,
-    y: monitor.y,
-    width: Math.min(monitor.width, work.width),
-    height: Math.min(monitor.height, work.height),
-  };
+  return usable(monitor, session.workArea);
+}
+
+// --------------------------------------------------------------------------
+// The public snapshot
+// --------------------------------------------------------------------------
+
+const EMPTY = Object.freeze({
+  screens: Object.freeze([]),
+  primary: null,
+  workArea: null,
+  virtual: null,
+  source: null,
+});
+
+/** The union of every monitor rect — what the virtual screen must be at
+ *  least, for a server that did not say. */
+function union(monitors) {
+  if (!monitors?.length) return null;
+  let x0 = Infinity;
+  let y0 = Infinity;
+  let x1 = -Infinity;
+  let y1 = -Infinity;
+  for (const m of monitors) {
+    x0 = Math.min(x0, m.x);
+    y0 = Math.min(y0, m.y);
+    x1 = Math.max(x1, m.x + m.width);
+    y1 = Math.max(y1, m.y + m.height);
+  }
+  return { x: x0, y: y0, width: x1 - x0, height: y1 - y0 };
 }
 
 /**
- * Start reading the screen layout on `app`. Resolves once the first answer
+ * What is known right now, as one frozen object.
+ *
+ * Frozen and cached because `useScreens()` reads it through
+ * `useSyncExternalStore`, whose `getSnapshot` must return the *same* object
+ * until something actually changes — building a fresh array per call is what
+ * makes React loop.
+ */
+export function screensSnapshot(app) {
+  const session = sessions.get(app);
+  if (!session) return EMPTY;
+  if (session._snapshot) return session._snapshot;
+
+  const screen = session.screenRect;
+  // Nothing answered, but there is still a screen: one monitor covering it
+  // is a truer answer than an empty list, which reads as "no displays".
+  const rects =
+    session.monitors ??
+    (screen ? [{ ...screen, name: null, primary: true }] : null);
+
+  const screens = Object.freeze(
+    (rects ?? []).map((m) =>
+      Object.freeze({
+        name: m.name ?? null,
+        outputs: Object.freeze(m.outputs ? [...m.outputs] : []),
+        x: m.x,
+        y: m.y,
+        width: m.width,
+        height: m.height,
+        available: Object.freeze(usable(m, session.workArea)),
+        primary: m.primary === true,
+        widthMM: m.widthMM ?? null,
+        heightMM: m.heightMM ?? null,
+        refreshRate: m.refreshRate ?? null,
+        rotation: m.rotation ?? 0,
+      }),
+    ),
+  );
+
+  session._snapshot = Object.freeze({
+    screens,
+    // No output is flagged primary on a single-head desktop that never ran
+    // `xrandr --primary`, and "the one monitor" is the useful answer there.
+    primary:
+      screens.find((s) => s.primary) ??
+      (screens.length === 1 ? screens[0] : null),
+    workArea: session.workArea ? Object.freeze({ ...session.workArea }) : null,
+    virtual: Object.freeze(screen ?? union(rects) ?? null),
+    source: session.source ?? (rects?.length ? 'screen' : null),
+  });
+  return session._snapshot;
+}
+
+/** Subscribe to the layout changing. Not public — `useScreens()` is. */
+export function watchScreens(app, fn) {
+  const session = sessions.get(app);
+  if (!session) return () => {};
+  return session.subscribe(fn);
+}
+
+// --------------------------------------------------------------------------
+// Starting up
+// --------------------------------------------------------------------------
+
+/**
+ * Start reading the screen layout on `app`. Resolves once the *cheap* answer
  * is in, so `createRoot` can await it and every window realized afterwards
- * sizes against a settled value.
+ * sizes against a settled value. The RandR walk that names the monitors runs
+ * behind it and is deliberately not awaited — see the note at the top.
  *
  * Never rejects. A server with no Xinerama, a desktop with no work area, an
  * ntk too old to reach the raw connection and a headless mock all degrade to
@@ -148,26 +349,37 @@ export async function beginScreens(app) {
   if (!X || typeof X.GetProperty !== 'function') return session; // mock app
 
   try {
-    session.monitors = await queryMonitors(app);
+    const monitors = await queryMonitors(app);
     session._workAreaAtom = await internAtom(X, WORKAREA_PROPERTY);
-    session.workArea = await readWorkArea(session);
+    session.publish({
+      monitors,
+      workArea: await readWorkArea(session),
+      source: monitors ? 'xinerama' : null,
+    });
     watchLayout(session);
   } catch {
     // every failure here means "one tier less to work with", which is what
     // the nulls already say
   }
+
+  // Detail, behind the geometry. Never awaited, and its failure is not this
+  // function's failure: a server with no RandR keeps the Xinerama answer.
+  refreshOutputs(session).catch(() => {});
   return session;
 }
 
 /**
- * Both of these change while an app runs — a monitor is plugged in, a panel
- * is added or auto-hidden — and both announce themselves on the root window,
- * so one `PropertyChange` selection covers them. A window already on screen
- * keeps its size; this is for whatever opens next.
+ * Both the layout and the work area change while an app runs — a monitor is
+ * plugged in, a panel is added or auto-hidden — and they announce themselves
+ * two different ways.
  *
- * RandR's own `ScreenChangeNotify` would be the direct signal for the first
- * one, but it needs the extension selected and an event mask on top of this,
- * and the WM republishes `_NET_WORKAREA` on a layout change anyway.
+ * `_NET_WORKAREA` is a root-window property, so a `PropertyChange` selection
+ * catches the panels. RandR's own `SelectInput` catches the rest, and it is
+ * needed rather than merely nice: a second monitor arriving beside the first
+ * without moving any dock changes no property at all, so a `_NET_WORKAREA`
+ * watch alone would never hear about it. Where RandR is missing the property
+ * watch still covers the common case, because a WM that rearranges monitors
+ * usually republishes the work area with it.
  */
 function watchLayout(session) {
   const X = session.app.X;
@@ -176,18 +388,57 @@ function watchLayout(session) {
   // PropertyChange on a window we do not own. Legal and shared — every
   // panel-aware application on the desktop selects this same event.
   X.ChangeWindowAttributes(root, { eventMask: PROPERTY_CHANGE_MASK }, () => {});
-  X.on('event', (ev) => {
+  session.onEvent((ev) => {
     if (session.stopped) return;
     if (ev.type !== PROPERTY_NOTIFY || ev.wid !== root) return;
     if (ev.atom !== session._workAreaAtom) return;
-    Promise.all([queryMonitors(session.app), readWorkArea(session)]).then(
-      ([monitors, workArea]) => {
-        if (session.stopped) return;
-        if (monitors) session.monitors = monitors;
-        session.workArea = workArea;
-      },
-      () => {},
+    relayout(session);
+  });
+  watchRandR(session);
+}
+
+/** Re-read everything the layout is built from and publish once. */
+function relayout(session) {
+  return Promise.all([queryMonitors(session.app), readWorkArea(session)]).then(
+    ([monitors, workArea]) => {
+      if (session.stopped) return;
+      session.publish({
+        // A failed re-query means "could not ask again", never "no monitors".
+        monitors: monitors ?? session.monitors,
+        workArea,
+        source: monitors ? 'xinerama' : session.source,
+      });
+      return refreshOutputs(session);
+    },
+    () => {},
+  );
+}
+
+async function watchRandR(session) {
+  const randr = await requireExt(session.app, 'randr');
+  if (!randr || session.stopped) return;
+  const X = session.app.X;
+  const root = X.display?.screen?.[0]?.root;
+  if (root == null) return;
+  try {
+    // ScreenChange alone misses a monitor that arrives without resizing the
+    // virtual screen, so the CRTC and output masks go on too. node-x11 only
+    // parses ScreenChangeNotify; the rest arrive as a bare `{type, seq}`,
+    // which is all this needs — every one of them means "ask again".
+    randr.SelectInput(
+      root,
+      randr.NotifyMask.ScreenChange |
+        randr.NotifyMask.CrtcChange |
+        randr.NotifyMask.OutputChange,
     );
+  } catch {
+    return;
+  }
+  const first = randr.firstEvent;
+  session.onEvent((ev) => {
+    if (session.stopped) return;
+    if (ev.type !== first && ev.type !== first + 1) return;
+    relayout(session);
   });
 }
 
@@ -217,6 +468,195 @@ function queryMonitors(app) {
     }
   });
 }
+
+// --------------------------------------------------------------------------
+// RandR: the names, the primary flag, the millimetres and the refresh rate
+// --------------------------------------------------------------------------
+
+/**
+ * Turn one RandR walk into monitor records.
+ *
+ * Pure, and exported for that reason: the in-process X server used by the
+ * tests has no RandR at all, so the walk cannot be driven end to end there
+ * and this is the part worth pinning.
+ *
+ * **Keyed by CRTC, not by output.** Two outputs showing the same pixels —
+ * a laptop mirroring to a projector — share one CRTC and are one monitor,
+ * however many cables are involved. RandR 1.5's `GetMonitors` is the
+ * protocol's own answer to this and node-x11 does not implement it, so the
+ * grouping happens here; `outputs` keeps both names so a mirrored pair is
+ * still legible.
+ */
+export function monitorsFromRandR({ outputs, crtcs, modes, primary }) {
+  const byMode = new Map((modes ?? []).map((m) => [m.id, m]));
+  const byCrtc = new Map();
+
+  for (const output of outputs ?? []) {
+    // An output with no CRTC is a port with nothing plugged in, or a
+    // connected screen the user has switched off. Neither is a monitor.
+    if (output.connection !== RR_CONNECTED || !output.crtc) continue;
+    const crtc = crtcs?.get?.(output.crtc) ?? null;
+    if (!crtc?.width || !crtc?.height) continue;
+
+    let monitor = byCrtc.get(output.crtc);
+    if (!monitor) {
+      monitor = {
+        name: output.name || null,
+        outputs: [],
+        x: crtc.x,
+        y: crtc.y,
+        width: crtc.width,
+        height: crtc.height,
+        primary: false,
+        // Physical size is per *output*, so a mirrored pair keeps the first
+        // one's — there is no single honest answer for two panels at once.
+        widthMM: output.widthMM || null,
+        heightMM: output.heightMM || null,
+        refreshRate: refreshRateOf(byMode.get(crtc.mode)),
+        rotation: degreesOf(crtc.rotation),
+      };
+      byCrtc.set(output.crtc, monitor);
+    }
+    if (output.name) monitor.outputs.push(output.name);
+    if (primary && output.id === primary) {
+      monitor.primary = true;
+      // The primary output names the monitor even when it is not the first
+      // one the walk reached.
+      if (output.name) monitor.name = output.name;
+    }
+  }
+
+  const list = [...byCrtc.values()];
+  // Left to right, then top to bottom: the order the desktop is laid out in,
+  // rather than the order the server happened to enumerate resources in,
+  // which is arbitrary and not stable across a replug.
+  list.sort((a, b) => a.x - b.x || a.y - b.y);
+  return list;
+}
+
+/**
+ * Hz from a mode line, to two decimals — `dot_clock / (h_total * v_total)`.
+ *
+ * The rounding is not cosmetic. A 60Hz mode is 59.9986… and a caller
+ * comparing rates, or printing one, wants `59.99` rather than a float whose
+ * last digits are a property of the timing table.
+ *
+ * **A result outside a plausible range is null rather than the number.** An X
+ * server that does not drive real hardware fills the timing fields in with
+ * something rather than leaving them out: XQuartz's active mode reports a
+ * `dot_clock` of exactly `h_total * v_total`, so the arithmetic is a
+ * blameless 1 Hz — and an app showing "1 Hz" beside a monitor name looks
+ * broken in a way that showing nothing does not. No panel a desktop is drawn
+ * on refreshes below 20Hz, so a value under it is a server saying "I do not
+ * know" in the only way the protocol lets it.
+ */
+export function refreshRateOf(mode) {
+  if (!mode?.dot_clock || !mode.h_total || !mode.v_total) return null;
+  const hz = mode.dot_clock / (mode.h_total * mode.v_total);
+  if (!Number.isFinite(hz) || hz < 20 || hz > 1000) return null;
+  return Math.round(hz * 100) / 100;
+}
+
+/** RandR's rotation bitmask → degrees. The reflection bits are ignored:
+ *  they say the image is mirrored, not that it is turned. */
+export function degreesOf(rotation) {
+  if (rotation & 8) return 270;
+  if (rotation & 4) return 180;
+  if (rotation & 2) return 90;
+  return 0;
+}
+
+/**
+ * Walk RandR and publish the detail over whatever Xinerama said.
+ *
+ * Resolves to false wherever the walk cannot finish — no extension, an
+ * ntk with no raw connection, a layout change mid-walk — leaving the
+ * cheaper answer standing.
+ */
+async function refreshOutputs(session) {
+  const app = session.app;
+  const randr = await requireExt(app, 'randr');
+  if (!randr || session.stopped) return false;
+  const X = app.X;
+  const root = X.display?.screen?.[0]?.root;
+  if (root == null) return false;
+
+  const resources = await call(randr.GetScreenResourcesCurrent, root);
+  if (!resources || session.stopped) return false;
+
+  const primary = await call(randr.GetOutputPrimary, root);
+
+  // Every output, then every CRTC one of them names. Issued together rather
+  // than in sequence: they are independent reads on one connection, so the
+  // whole walk costs one round trip's latency rather than one per output.
+  const infos = await Promise.all(
+    (resources.outputs ?? []).map((id) =>
+      call(randr.GetOutputInfo, id, resources.config_timestamp).then(
+        (info) => (info ? { ...info, id } : null),
+        () => null,
+      ),
+    ),
+  );
+  if (session.stopped) return false;
+
+  const wanted = new Set(infos.filter((o) => o?.crtc).map((o) => o.crtc));
+  const crtcs = new Map();
+  await Promise.all(
+    [...wanted].map((id) =>
+      call(randr.GetCrtcInfo, id, resources.config_timestamp).then(
+        (info) => info && crtcs.set(id, info),
+        () => {},
+      ),
+    ),
+  );
+  if (session.stopped) return false;
+
+  const monitors = monitorsFromRandR({
+    outputs: infos.filter(Boolean).map((o) => ({
+      id: o.id,
+      name: o.name,
+      crtc: o.crtc,
+      connection: o.connection,
+      widthMM: o.mm_width,
+      heightMM: o.mm_height,
+    })),
+    crtcs,
+    modes: resources.modeinfos,
+    primary,
+  });
+  // A walk that found nothing usable is a walk that failed, not a desktop
+  // with no monitors — every head could have been unplugged between the two
+  // requests, and Xinerama's answer is better than none.
+  if (!monitors.length) return false;
+  session.publish({ monitors, source: 'randr' });
+  return true;
+}
+
+/** An extension, or null where the server does not have it. */
+function requireExt(app, name) {
+  return new Promise((resolve) => {
+    try {
+      app.X.require(name, (err, ext) => resolve(err || !ext ? null : ext));
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
+/** A node-x11 request as a promise that resolves to null on error. */
+function call(fn, ...args) {
+  return new Promise((resolve) => {
+    try {
+      fn(...args, (err, value) => resolve(err ? null : value));
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
+// --------------------------------------------------------------------------
+// _NET_WORKAREA
+// --------------------------------------------------------------------------
 
 /**
  * `_NET_WORKAREA` is four CARDINALs per desktop — x, y, width, height — and
@@ -285,6 +725,10 @@ export function endScreens(app) {
  * Test seam: state a screen layout without an X server, the way
  * `setCompositingForTests` states a compositor. `null` for either argument
  * leaves that tier unknown, which is how the fallbacks are exercised.
+ *
+ * `monitors` entries may carry the RandR fields (`name`, `primary`,
+ * `widthMM`, `heightMM`, `refreshRate`, `rotation`) as well as the rect, so
+ * a test can state a named two-head desktop without a server that has RandR.
  */
 export function setScreensForTests(app, { monitors = null, workArea = null }) {
   let session = sessions.get(app);
@@ -292,7 +736,10 @@ export function setScreensForTests(app, { monitors = null, workArea = null }) {
     session = new ScreenSession(app);
     sessions.set(app, session);
   }
-  session.monitors = monitors;
-  session.workArea = workArea;
+  session.publish({
+    monitors,
+    workArea,
+    source: monitors ? 'test' : null,
+  });
   return session;
 }

--- a/src/screenshooks.js
+++ b/src/screenshooks.js
@@ -1,0 +1,77 @@
+// `useScreens()` — the monitor layout as something a component re-renders on.
+//
+// The store lives in `screens.js`, keyed by connection rather than shared
+// across the process the way `appearance.js` is: the screen layout is a fact
+// about one X display, and a process driving two of them is exactly what the
+// test suite does routinely.
+
+import { useCallback, useSyncExternalStore } from 'react';
+
+import { useApp } from './appcontext.js';
+import { screensSnapshot, watchScreens } from './screens.js';
+
+/**
+ * The monitors this display has, live.
+ *
+ * ```jsx
+ * const { screens, primary } = useScreens();
+ *
+ * <Select
+ *   value={monitor}
+ *   onChange={setMonitor}
+ *   options={screens.map((s) => ({
+ *     value: s.name,
+ *     label: `${s.name} — ${s.width}×${s.height}`,
+ *   }))}
+ * />
+ * ```
+ *
+ * Each entry is:
+ *
+ * | | |
+ * | --- | --- |
+ * | `name` | `'HDMI-1'`, `'eDP-1'` — **null** where the server has no RandR |
+ * | `x` `y` `width` `height` | the monitor's rect in virtual-screen coordinates |
+ * | `available` | that rect minus the panels — where a window can go |
+ * | `primary` | the desktop's main monitor, where panels and new windows land |
+ * | `widthMM` `heightMM` | physical size, or null |
+ * | `refreshRate` | Hz to two decimals (`59.99`), or null |
+ * | `rotation` | `0`, `90`, `180` or `270` |
+ * | `outputs` | every output on this monitor — two names means it is mirrored |
+ *
+ * and the object around them carries `primary` (the entry, or null), the
+ * desktop-wide `workArea`, the whole `virtual` screen, and `source`.
+ *
+ * **`name` is null before RandR answers, and on a server without it.** The
+ * geometry resolves during `createRoot()` from Xinerama, which is one round
+ * trip; the names, the primary flag and the physical sizes take a ten-round-
+ * trip RandR walk that deliberately does not hold startup up, so they appear
+ * a moment later. The rects do not move when they land — Xinerama on a
+ * modern server *is* RandR's emulation of it — so a component that rendered
+ * against the early answer sees fields fill in, not values change. Where a
+ * name is what gets persisted, treat null as "not known yet" and keep the
+ * last one, rather than writing it.
+ *
+ * `source` says which tier answered: `'randr'`, `'xinerama'`, `'screen'`
+ * (one entry covering the whole display, for a server with neither
+ * extension), `'test'`, or null on a headless mock with no display at all.
+ *
+ * **`available` is an approximation and the only one here.** `_NET_WORKAREA`
+ * is published for the whole virtual desktop rather than per monitor, so it
+ * is applied as a per-axis bound: exact on one head, and on several it still
+ * takes a top or bottom panel off the height. Deriving a true per-monitor
+ * work area means reading `_NET_WM_STRUT_PARTIAL` off every window on the
+ * screen — see the note in `screens.js`.
+ *
+ * Re-renders when a monitor is plugged in or unplugged, when the arrangement
+ * changes, and when a panel appears, moves or auto-hides.
+ */
+export function useScreens() {
+  const app = useApp();
+  const subscribe = useCallback(
+    (onChange) => watchScreens(app, onChange),
+    [app],
+  );
+  const snapshot = useCallback(() => screensSnapshot(app), [app]);
+  return useSyncExternalStore(subscribe, snapshot, snapshot);
+}

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -314,7 +314,7 @@ export interface WindowProps
    * Applied before the window is mapped, which is the only way to open
    * already fullscreen rather than flashing at the normal size first.
    */
-  states?: WindowState[];
+  states?: WindowStateName[];
   /** Sugar for `states={['fullscreen']}`; they union. */
   fullscreen?: boolean;
   /** Sugar for `states={['above']}`; they union. */
@@ -390,7 +390,7 @@ export interface WindowProps
    * what makes react-x11 watch `_NET_WM_STATE`, so a window with no handler
    * costs nothing.
    */
-  onStatesChange?: (states: WindowState[]) => void;
+  onStatesChange?: (states: WindowStateName[]) => void;
   /** The WM close button; opts the window into `WM_DELETE_WINDOW`. */
   onCloseRequest?: (ev: SyntheticEvent<NtkWindow>) => void;
   /**
@@ -422,8 +422,11 @@ export interface WindowProps
  * `_NET_WM_STATE` names, lower-cased without the atom prefix. `'maximized'`
  * is the one that is not an atom: EWMH maximizes an axis at a time, and it
  * expands to the vert/horz pair.
+ *
+ * These are what a `<window>` **asks for**. What the window manager actually
+ * did is `useWindowState()`, whose `states` is a list of these.
  */
-export type WindowState =
+export type WindowStateName =
   | 'modal'
   | 'sticky'
   | 'maximized'

--- a/src/types/system.d.ts
+++ b/src/types/system.d.ts
@@ -1,0 +1,265 @@
+/**
+ * What the machine around the app is doing — the monitors, the window
+ * manager, the keyboard, whether anyone is at the desk, and the conventions
+ * the app was launched under. See docs/system.md.
+ */
+
+import type { RefObject } from 'react';
+
+import type { WindowStateName } from './elements.js';
+import type { DrawnNode, NtkApp, NtkWindow, Rect } from './nodes.js';
+
+// --------------------------------------------------------------------------
+// Screens
+// --------------------------------------------------------------------------
+
+/**
+ * Which tier answered.
+ *
+ * `'xinerama'` is the geometry-only answer that resolves during
+ * `createRoot()`; `'randr'` is the same geometry with names, the primary flag
+ * and physical sizes, and lands a moment later. `'screen'` is one entry
+ * covering the whole display, for a server with neither extension.
+ */
+export type ScreensSource = 'randr' | 'xinerama' | 'screen' | 'test' | null;
+
+export interface Screen {
+  /** `'HDMI-1'`, `'eDP-1'` — **null** until RandR answers, and on a server
+   *  without it. Treat null as "not known yet" rather than persisting it. */
+  readonly name: string | null;
+  /** Every output driving this monitor. Two names means it is mirrored. */
+  readonly outputs: readonly string[];
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+  /**
+   * The monitor minus the panels — where a window can actually go.
+   *
+   * An approximation: `_NET_WORKAREA` is published for the whole virtual
+   * desktop rather than per monitor, so it is applied as a per-axis bound.
+   * Exact on one head; on several it still takes a top or bottom panel off
+   * the height.
+   */
+  readonly available: Rect;
+  readonly primary: boolean;
+  readonly widthMM: number | null;
+  readonly heightMM: number | null;
+  /** Hz to two decimals (`59.99`), or null. */
+  readonly refreshRate: number | null;
+  readonly rotation: 0 | 90 | 180 | 270;
+}
+
+export interface Screens {
+  readonly screens: readonly Screen[];
+  /** The primary monitor — or the only one, where nothing is flagged. */
+  readonly primary: Screen | null;
+  /** The desktop-wide `_NET_WORKAREA`, or null. */
+  readonly workArea: Rect | null;
+  /** The whole virtual screen every monitor sits in. */
+  readonly virtual: Rect | null;
+  readonly source: ScreensSource;
+}
+
+/**
+ * The monitors this display has, live — re-renders when one is plugged in or
+ * unplugged, when the arrangement changes, and when a panel moves.
+ *
+ * ```tsx
+ * const { screens, primary } = useScreens();
+ * ```
+ */
+export function useScreens(): Screens;
+
+// --------------------------------------------------------------------------
+// Window state
+// --------------------------------------------------------------------------
+
+export interface WindowState {
+  /** This window has the keyboard. */
+  readonly focused: boolean;
+  /** **The one to branch on**: not minimized, and not fully covered. */
+  readonly visible: boolean;
+  /**
+   * Fully covered by other windows — **always false when a compositing
+   * manager is running**, which it is on every stock GNOME and KDE session.
+   * A composited window is redirected offscreen and the server considers it
+   * entirely visible. Prefer `visible`.
+   */
+  readonly obscured: boolean;
+  /** `_NET_WM_STATE_HIDDEN`: iconified, or shaded away. */
+  readonly minimized: boolean;
+  /** Both axes. One axis alone shows up in `states`. */
+  readonly maximized: boolean;
+  /** What the window manager actually did, not what `<window fullscreen>`
+   *  asked for. */
+  readonly fullscreen: boolean;
+  /** The raw `_NET_WM_STATE` names, e.g. `['maximized_vert', 'focused']` —
+   *  what the window manager put there, where `<window states>` is what was
+   *  asked for. */
+  readonly states: readonly WindowStateName[];
+  /** The workspace index, or null. A sticky window shows up in `states`. */
+  readonly desktop: number | null;
+}
+
+/**
+ * What the window manager has done with a window, live.
+ *
+ * ```tsx
+ * const { focused, visible, fullscreen } = useWindowState();
+ * ```
+ *
+ * With no argument it reads the window the component is in, inferred the way
+ * {@link useTopLevelWindow} infers it. Pass a ref to be exact.
+ */
+export function useWindowState(
+  ref?: RefObject<NtkWindow | DrawnNode | null> | null,
+): WindowState;
+
+// --------------------------------------------------------------------------
+// Idle and inhibition
+// --------------------------------------------------------------------------
+
+/**
+ * Whether the user has been away from the keyboard for `timeout`
+ * milliseconds.
+ *
+ * ```tsx
+ * const away = useIdle(5 * 60_000);
+ * ```
+ *
+ * Idleness is the whole display's, not this window's — it counts input on
+ * every device, whichever application it went to. For "has the user ignored
+ * *my* window", read `useWindowState().focused`.
+ *
+ * Costs no timer where the X server carries an `IDLETIME` counter (Xorg
+ * does): a SYNC alarm fires on each crossing. Falls back to polling
+ * MIT-SCREEN-SAVER, and stays `false` on a display with neither.
+ */
+export function useIdle(timeout: number): boolean;
+
+/**
+ * Keep the screen awake while `active` is true, releasing on unmount.
+ *
+ * ```tsx
+ * useKeepAwake(playing, 'Playing a video');
+ * ```
+ *
+ * Inhibits **screen blanking only** — nothing here stops a suspend. Silent
+ * where no rung is available.
+ */
+export function useKeepAwake(active: boolean, reason?: string): void;
+
+export interface KeepAwakeOptions {
+  /** Shown by desktops that list what is holding the screen on. */
+  reason?: string;
+  /** The ntk connection, so the `ScreenSaverSuspend` rung can run — the one
+   *  that needs no session bus. */
+  app?: NtkApp;
+}
+
+/**
+ * The imperative twin of {@link useKeepAwake}: resolves to the release.
+ *
+ * Never rejects — a machine with no portal, no screensaver service and no
+ * MIT-SCREEN-SAVER hands back a release that does nothing.
+ */
+export function keepAwake(options?: KeepAwakeOptions): Promise<() => void>;
+
+// --------------------------------------------------------------------------
+// Keyboard
+// --------------------------------------------------------------------------
+
+export interface KeyboardState {
+  /** On or off **now** — not "was on for the last key", which is what an
+   *  event's modifier state can tell you. */
+  readonly capsLock: boolean;
+  readonly numLock: boolean;
+  /** The active XKB group, 0–3. */
+  readonly group: number;
+  /** That group's layout code — `'ru'` — or null. */
+  readonly layout: string | null;
+  /** Every configured layout, `['us', 'ru']`. Empty where XKB could not be
+   *  asked, which is what distinguishes "off" from "not known". */
+  readonly layouts: readonly string[];
+}
+
+/**
+ * The keyboard's locks and layout, live.
+ *
+ * ```tsx
+ * const { capsLock, layout } = useKeyboardState();
+ * ```
+ *
+ * True of the keyboard rather than of an event, so a password field can warn
+ * about Caps Lock before the first character is typed. Needs XKB; the locks
+ * read false without it.
+ */
+export function useKeyboardState(): KeyboardState;
+
+// --------------------------------------------------------------------------
+// Desktop interaction settings
+// --------------------------------------------------------------------------
+
+export interface DesktopSettings {
+  /** **False means do not blink at all** — an accessibility setting, not a
+   *  preference. Draw the caret solid rather than not at all. */
+  readonly caretBlink: boolean;
+  /** How long a caret stays in each state. The XSETTINGS key is a full
+   *  cycle; this is half of it, which is what goes into a timer. */
+  readonly caretBlinkMs: number;
+  readonly doubleClickMs: number;
+  readonly doubleClickDistance: number;
+  /** How far a press moves before it is a drag rather than a click. */
+  readonly dragThreshold: number;
+  /** `'xsettings'`, or null where no settings daemon answered and these are
+   *  the renderer's own defaults. */
+  readonly source: 'xsettings' | 'test' | null;
+}
+
+/**
+ * How this desktop wants an application to feel, live.
+ *
+ * ```tsx
+ * const { doubleClickMs, dragThreshold } = useDesktopSettings();
+ * ```
+ *
+ * The built-in controls already follow these. This is for an app drawing its
+ * own — a `<canvas>` with a text cursor, a custom gesture — so that one
+ * widget on the screen does not feel unlike every other.
+ */
+export function useDesktopSettings(): DesktopSettings;
+
+// --------------------------------------------------------------------------
+// Locale
+// --------------------------------------------------------------------------
+
+export interface SystemLocale {
+  /** A BCP-47 tag: `'en-GB'`, `'ru-RU'`. */
+  readonly locale: string;
+  readonly direction: 'ltr' | 'rtl';
+  /** `0` Sunday … `6` Saturday, from CLDR. */
+  readonly weekStartsOn: number;
+  readonly timeZone: string | null;
+  /** `'env'` when `LANG` and friends said, `'intl'` when ICU did. */
+  readonly source: 'env' | 'intl' | 'test' | null;
+}
+
+/**
+ * Which language and conventions this app was started in.
+ *
+ * ```tsx
+ * const { locale, weekStartsOn } = useLocale();
+ * ```
+ *
+ * `LC_ALL`/`LC_MESSAGES`/`LANG` win over `Intl`'s own answer. **This does not
+ * change while the app runs** and there is no subscription behind it — a
+ * process's environment is fixed at exec.
+ *
+ * For text direction inside a component prefer `useDirection()`, which also
+ * honours `<ThemeProvider direction>` and the `direction` style property.
+ */
+export function useLocale(): SystemLocale;
+
+/** The imperative twin of {@link useLocale}, for code outside a tree. */
+export function systemLocale(): SystemLocale;

--- a/src/windowstate.js
+++ b/src/windowstate.js
@@ -1,0 +1,393 @@
+// What the window manager has done with a window, as something a component
+// re-renders on.
+//
+// A `<window>` asks for `fullscreen` or `maximized` and the window manager
+// decides — and it decides on its own account too, when the user hits a
+// hotkey or the titlebar button. `nodes.js` sends the requests; this is the
+// half that reads back what actually happened, plus the two things an app
+// needs that are not states at all: whether it has the keyboard, and whether
+// anyone can see it.
+//
+// ## Where each field comes from
+//
+// | | |
+// | --- | --- |
+// | `focused` | FocusIn/FocusOut, via the event manager that already tracks it |
+// | `minimized` `maximized` `fullscreen` `states` | `_NET_WM_STATE`, as ntk's `statechange` event |
+// | `obscured` | VisibilityNotify |
+// | `desktop` | `_NET_WM_DESKTOP` |
+//
+// Nothing here is asked for until something subscribes. `_NET_WM_STATE`
+// costs a PropertyChange selection and a round trip per change,
+// VisibilityNotify costs a mask bit, and an app that never asks pays for
+// neither.
+//
+// ## The compositor caveat, because it will otherwise be found as a bug
+//
+// **`obscured` is always false when a compositing manager is running**, and
+// one is running on every stock GNOME and KDE session. A composited window
+// is redirected to an offscreen pixmap, so the server considers it entirely
+// visible whatever is stacked on top of it, and VisibilityNotify says so.
+// That is X working as designed and there is no protocol answer to it.
+//
+// So `obscured` is the bare-WM optimisation it looks like, and `visible` —
+// which folds in `minimized`, the signal that *does* survive compositing —
+// is the field to branch on. An animation paused on `visible` stops when the
+// window is minimized everywhere, and additionally when it is buried on a
+// desktop with no compositor.
+
+import { useCallback, useSyncExternalStore } from 'react';
+
+import { useAppOrNull } from './appcontext.js';
+import { useTopLevelWindow, windowIdOf } from './windowid.js';
+
+const VISIBILITY_NOTIFY = 15;
+const VISIBILITY_CHANGE_MASK = 65536; // x11.eventMask.VisibilityChange
+const FULLY_OBSCURED = 2;
+const DESKTOP_PROPERTY = '_NET_WM_DESKTOP';
+
+/**
+ * What is true before the window manager has said anything.
+ *
+ * `focused` and `visible` start **true**, and that is the whole reason this
+ * constant is written out rather than being a pile of falses: a window opens
+ * focused and on screen far more often than not, and a title bar that
+ * renders dimmed on the first frame and un-dims on the second is a visible
+ * flash on every launch. Starting from the common case makes the first paint
+ * right and the correction — for the rarer window that opened in the
+ * background — the thing that costs a re-render.
+ */
+const UNKNOWN = Object.freeze({
+  focused: true,
+  visible: true,
+  obscured: false,
+  minimized: false,
+  maximized: false,
+  fullscreen: false,
+  states: Object.freeze([]),
+  desktop: null,
+});
+
+const sessions = new WeakMap();
+
+const SAME = (a, b) =>
+  a.focused === b.focused &&
+  a.visible === b.visible &&
+  a.obscured === b.obscured &&
+  a.minimized === b.minimized &&
+  a.maximized === b.maximized &&
+  a.fullscreen === b.fullscreen &&
+  a.desktop === b.desktop &&
+  a.states.length === b.states.length &&
+  a.states.every((s, i) => s === b.states[i]);
+
+class WindowStateSession {
+  constructor(node) {
+    this.node = node;
+    this.snapshot = UNKNOWN;
+    this.listeners = new Set();
+    this.armed = false;
+    this.stopped = false;
+    this._desktopAtom = null;
+    this._offs = [];
+  }
+
+  /**
+   * Fold new fields into the snapshot and notify. A change that changes
+   * nothing notifies nobody: `statechange` fires on every `_NET_WM_STATE`
+   * rewrite, and window managers rewrite it with the same contents more
+   * often than they change it.
+   */
+  publish(values) {
+    const states = values.states ?? this.snapshot.states;
+    const next = Object.freeze({
+      ...this.snapshot,
+      ...values,
+      states: Object.freeze([...states]),
+      // Derived rather than reported, in one place, so `visible` cannot
+      // disagree with the fields it is made of.
+      minimized: values.states
+        ? states.includes('hidden')
+        : this.snapshot.minimized,
+      maximized: values.states
+        ? states.includes('maximized_vert') && states.includes('maximized_horz')
+        : this.snapshot.maximized,
+      fullscreen: values.states
+        ? states.includes('fullscreen')
+        : this.snapshot.fullscreen,
+    });
+    const settled = Object.freeze({
+      ...next,
+      visible: !next.minimized && !next.obscured,
+    });
+    if (SAME(settled, this.snapshot)) return;
+    this.snapshot = settled;
+    for (const fn of [...this.listeners]) {
+      try {
+        fn();
+      } catch {
+        // one subscriber throwing must not take the others with it, nor the
+        // X event loop this runs on
+      }
+    }
+  }
+
+  stop() {
+    this.stopped = true;
+    for (const off of this._offs) {
+      try {
+        off();
+      } catch {
+        // a window already destroyed takes its listeners with it
+      }
+    }
+    this._offs.length = 0;
+    this.listeners.clear();
+  }
+}
+
+/**
+ * The `WindowNode` behind a ref, a node, an ntk window or an XID.
+ *
+ * Popups are **not** excluded, unlike `topLevelWindows()`: a `<popup>` is
+ * override-redirect so the window manager never gives it a `_NET_WM_STATE`,
+ * and reporting the defaults for one is a truer answer than refusing to
+ * resolve it.
+ */
+function nodeOf(app, target) {
+  const value =
+    target &&
+    typeof target === 'object' &&
+    'current' in target &&
+    !target.isWindow
+      ? target.current
+      : target;
+  if (!value) return null;
+  if (value.isWindow && value.window) return value;
+  const id = windowIdOf(value);
+  if (id == null) return null;
+  return (
+    (app?._rootChildren ?? []).find(
+      (node) => node?.isWindow && node.window?.id === id,
+    ) ?? null
+  );
+}
+
+function sessionFor(node) {
+  let session = sessions.get(node);
+  if (!session) {
+    session = new WindowStateSession(node);
+    sessions.set(node, session);
+  }
+  return session;
+}
+
+/**
+ * Start listening on the X side. Once per window: the mask bits and the
+ * PropertyChange selection cannot be given back when the last subscriber
+ * leaves, and re-arming on the next one would cost another round trip for a
+ * selection the server still has.
+ */
+function arm(session) {
+  if (session.armed) return;
+  const node = session.node;
+  const wnd = node.window;
+  // Not armed yet, rather than armed against nothing: a window realizes
+  // during the commit that created it, so a subscription that got here first
+  // gets another chance on the next one.
+  if (!wnd) return;
+  session.armed = true;
+
+  // Focus, from the event manager rather than from ntk directly: it already
+  // dedups FocusIn/FocusOut and already knows the answer for a window that
+  // has not seen either yet.
+  if (typeof node.onWindowFocusChange === 'function') {
+    session._offs.push(
+      node.onWindowFocusChange((focused) => {
+        if (!session.stopped) session.publish({ focused });
+      }),
+    );
+    const now = node.events?.windowFocused;
+    if (typeof now === 'boolean') session.publish({ focused: now });
+  }
+
+  // _NET_WM_STATE. Adding the listener is what makes ntk select
+  // PropertyChange and intern the atom, so the read below is only for the
+  // state the window already had when this ran.
+  if (typeof wnd.on === 'function') {
+    const onState = (states) => {
+      if (!session.stopped) session.publish({ states: states ?? [] });
+    };
+    wnd.on('statechange', onState);
+    session._offs.push(() => wnd.off?.('statechange', onState));
+    Promise.resolve(wnd.getWmStates?.()).then(
+      (states) => states && !session.stopped && session.publish({ states }),
+      () => {},
+    );
+
+    // _NET_WM_DESKTOP rides on the PropertyChange selection the line above
+    // already asked for, so watching it costs one comparison per property
+    // change rather than a second selection.
+    const onProperty = (ev) => {
+      if (session.stopped || ev?.atom == null) return;
+      if (ev.atom !== session._desktopAtom) return;
+      readDesktop(session);
+    };
+    wnd.on('property', onProperty);
+    session._offs.push(() => wnd.off?.('property', onProperty));
+    Promise.resolve(wnd.atom?.(DESKTOP_PROPERTY)).then(
+      (atom) => {
+        session._desktopAtom = atom;
+        if (!session.stopped) readDesktop(session);
+      },
+      () => {},
+    );
+  }
+
+  watchVisibility(session);
+}
+
+function readDesktop(session) {
+  Promise.resolve(
+    session.node.window?.getProperty?.(DESKTOP_PROPERTY, { as: 'numbers' }),
+  ).then(
+    (values) => {
+      if (session.stopped) return;
+      const desktop = values?.[0];
+      // 0xffffffff is EWMH for "on every desktop", which `states` already
+      // reports as `sticky` — a workspace number is the wrong shape for it.
+      session.publish({
+        desktop:
+          typeof desktop === 'number' && desktop !== 0xffffffff
+            ? desktop
+            : null,
+      });
+    },
+    () => {},
+  );
+}
+
+/**
+ * VisibilityNotify, which ntk has no event name for — its mask table stops
+ * at the events a widget toolkit needs — so the mask goes on through
+ * `selectInput` (which ORs into ntk's own tracked mask, so nothing it adds
+ * later drops this) and the event is read off the raw connection.
+ */
+function watchVisibility(session) {
+  const wnd = session.node.window;
+  const X = session.node.app?.X ?? wnd?.X;
+  if (!X?.on || typeof wnd?.selectInput !== 'function') return;
+
+  const onEvent = (ev) => {
+    if (session.stopped) return;
+    if (ev.type !== VISIBILITY_NOTIFY || ev.wid !== wnd.id) return;
+    session.publish({ obscured: ev.state === FULLY_OBSCURED });
+  };
+  X.on('event', onEvent);
+  session._offs.push(() => X.off?.('event', onEvent));
+
+  Promise.resolve(wnd.selectInput(VISIBILITY_CHANGE_MASK)).catch(() => {
+    // a window destroyed between the ref resolving and this call; the
+    // defaults stand and nothing further will arrive
+  });
+}
+
+/** What is known about a window right now. Stable until it changes. */
+export function windowStateSnapshot(app, target) {
+  const node = nodeOf(app, target);
+  if (!node) return UNKNOWN;
+  return sessions.get(node)?.snapshot ?? UNKNOWN;
+}
+
+/** Subscribe to a window's state. Not public — `useWindowState()` is. */
+export function watchWindowState(app, target, onChange) {
+  const node = nodeOf(app, target);
+  if (!node) return () => {};
+  const session = sessionFor(node);
+  arm(session);
+  session.listeners.add(onChange);
+  return () => session.listeners.delete(onChange);
+}
+
+/**
+ * Test seam: state what the window manager did, without a window manager.
+ * Marks the session armed, so nothing reaches for `_NET_WM_STATE` behind the
+ * value; `states` re-derives `minimized`/`maximized`/`fullscreen` the way a
+ * real `statechange` does.
+ */
+export function setWindowStateForTests(app, target, values) {
+  const node = nodeOf(app, target);
+  if (!node) return null;
+  const session = sessionFor(node);
+  session.armed = true;
+  session.publish(values);
+  return session.snapshot;
+}
+
+/** Tear down with the window. Called from `WindowNode.destroy`. */
+export function endWindowState(node) {
+  const session = sessions.get(node);
+  if (!session) return;
+  session.stop();
+  sessions.delete(node);
+}
+
+/**
+ * What the window manager has done with this window, live.
+ *
+ * ```jsx
+ * const { focused, visible, fullscreen } = useWindowState();
+ *
+ * // a title bar that dims when the window is not the active one
+ * <text style={{ color: focused ? theme.text : theme.textMuted }}>{title}</text>
+ *
+ * // and work that is pointless while nobody can see it
+ * useEffect(() => {
+ *   if (!visible) return;
+ *   const id = setInterval(poll, 1000);
+ *   return () => clearInterval(id);
+ * }, [visible]);
+ * ```
+ *
+ * | | |
+ * | --- | --- |
+ * | `focused` | this window has the keyboard |
+ * | `visible` | **the one to branch on** — not minimized, not fully covered |
+ * | `minimized` | `_NET_WM_STATE_HIDDEN`: iconified, or shaded away |
+ * | `maximized` | both axes; one axis alone shows up in `states` |
+ * | `fullscreen` | what the WM actually did, not what `<window fullscreen>` asked for |
+ * | `obscured` | fully covered by other windows — **always false under a compositor** |
+ * | `states` | the raw `_NET_WM_STATE` names, e.g. `['maximized_vert', 'focused']` |
+ * | `desktop` | the workspace index, or null (a sticky window shows up in `states`) |
+ *
+ * With no argument it reads the window the component is in, inferred the way
+ * `useTopLevelWindow()` infers it — exact for the one-window app, and a
+ * documented guess for a tree with several. Pass a ref to be certain:
+ *
+ * ```jsx
+ * const win = useRef(null);
+ * const { fullscreen } = useWindowState(win);
+ * return <window ref={win}>…</window>;
+ * ```
+ *
+ * Nothing is asked of the server until something calls this, and the first
+ * render answers from the defaults — focused and visible — rather than
+ * waiting for a round trip. See the compositor note in this file's header
+ * before reaching for `obscured`.
+ */
+export function useWindowState(ref = null) {
+  const app = useAppOrNull();
+  const owner = useTopLevelWindow();
+  const target = ref ?? owner;
+  const subscribe = useCallback(
+    (onChange) => watchWindowState(app, target, onChange),
+    [app, target],
+  );
+  const snapshot = useCallback(
+    () => windowStateSnapshot(app, target),
+    [app, target],
+  );
+  return useSyncExternalStore(subscribe, snapshot, snapshot);
+}
+
+/** @typedef {typeof UNKNOWN} WindowState */

--- a/test/appearance.test.js
+++ b/test/appearance.test.js
@@ -249,6 +249,14 @@ describe('the XSETTINGS payload', () => {
         X.InternAtom(false, name, (e, a) => (e ? rej(e) : res(a))),
       );
 
+    // `createRoot` starts XSETTINGS itself now (the interaction settings the
+    // caret and the drag threshold read), and `beginXSettings` is memoized
+    // per connection — so the session that already exists latched onto a
+    // display with no daemon on it. Take it down before standing one up: on
+    // a real server XFixes would re-latch when the selection changed hands,
+    // and the in-process server has no XFixes.
+    endXSettings(app);
+
     // A settings daemon, in miniature: a window that owns the selection and
     // carries the property.
     const manager = X.AllocID();
@@ -295,6 +303,9 @@ describe('the XSETTINGS payload', () => {
     const { app } = await renderX11(React.createElement('box'), {
       fonts: FONTS,
     });
+    // …and here so that the null being asserted is this call's answer rather
+    // than the one `createRoot` already got.
+    endXSettings(app);
     await beginXSettings(app);
     assert.equal(xsettings(app), null);
     endXSettings(app);

--- a/test/system-hooks.test.js
+++ b/test/system-hooks.test.js
@@ -1,0 +1,858 @@
+// The system hooks: the machine around the app.
+//
+// `useScreens`, `useWindowState`, `useIdle`/`useKeepAwake`,
+// `useKeyboardState`, `useDesktopSettings` and `useLocale`, plus the three
+// renderer paths that now read the desktop's interaction settings instead of
+// a constant.
+//
+// **The in-process X server has RENDER, BIG-REQUESTS and XC-MISC and nothing
+// else** — no RandR, no Xinerama, no XKB, no SYNC, no MIT-SCREEN-SAVER, no
+// XFixes. So the protocol walks cannot be driven end to end here, and what is
+// pinned instead is the two things that can be:
+//
+//   1. the **pure** half of each one — the reply decoders and the derivations
+//      — against the shapes the extensions really answer with;
+//   2. the **store and the hook** through each module's test seam, which is
+//      the same seam `setCompositingForTests` and `setAppearanceForTests`
+//      already are.
+//
+// The degradation paths get the real thing, because a server with none of the
+// extensions is exactly what this one is.
+import { test, describe, afterEach } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+
+import {
+  degreesOf,
+  monitorsFromRandR,
+  refreshRateOf,
+  screensSnapshot,
+  setScreensForTests,
+} from '../src/screens.js';
+import { useScreens } from '../src/screenshooks.js';
+import {
+  setWindowStateForTests,
+  useWindowState,
+  watchWindowState,
+  windowStateSnapshot,
+} from '../src/windowstate.js';
+import { idleSnapshot, setIdleForTests } from '../src/idle.js';
+import { useIdle } from '../src/idlehooks.js';
+import {
+  keyboardStateSnapshot,
+  layoutsFromRules,
+  locksFromMods,
+  setKeyboardStateForTests,
+} from '../src/keyboardstate.js';
+import { useKeyboardState } from '../src/keyboardstatehooks.js';
+import {
+  DEFAULTS,
+  desktopSettings,
+  fromXSettings,
+  setDesktopSettingsForTests,
+} from '../src/desktopsettings.js';
+import { useDesktopSettings } from '../src/desktopsettingshooks.js';
+import {
+  directionOf,
+  localeWeekStart,
+  resolveLocale,
+  setLocaleForTests,
+  systemLocale,
+  toLanguageTag,
+} from '../src/locale.js';
+import { useLocale } from '../src/localehooks.js';
+import { CARET_BLINK_MS } from '../src/nodes.js';
+import { act, cleanup, renderX11, settle } from '../src/testing/index.js';
+
+const h = React.createElement;
+
+// ---------------------------------------------------------------------------
+// useScreens — the RandR walk
+// ---------------------------------------------------------------------------
+
+describe('monitorsFromRandR', () => {
+  // The shapes node-x11 really hands back: `GetOutputInfo` gives mm_width,
+  // connection and a name; `GetCrtcInfo` gives the rect and the mode id;
+  // `GetScreenResourcesCurrent` gives the mode lines.
+  const MODE_1080 = {
+    id: 70,
+    width: 1920,
+    height: 1080,
+    dot_clock: 148500000,
+    h_total: 2200,
+    v_total: 1125,
+  };
+  const MODE_1440 = {
+    id: 71,
+    width: 2560,
+    height: 1440,
+    dot_clock: 241500000,
+    h_total: 2720,
+    v_total: 1481,
+  };
+
+  const laptop = {
+    id: 66,
+    name: 'eDP-1',
+    crtc: 63,
+    connection: 0,
+    widthMM: 340,
+    heightMM: 190,
+  };
+  const external = {
+    id: 68,
+    name: 'HDMI-1',
+    crtc: 64,
+    connection: 0,
+    widthMM: 600,
+    heightMM: 340,
+  };
+
+  test('one entry per active CRTC, left to right', () => {
+    const monitors = monitorsFromRandR({
+      // deliberately not in layout order: the server enumerates resources
+      // however it likes, and a replug changes it
+      outputs: [external, laptop],
+      crtcs: new Map([
+        [63, { x: 0, y: 0, width: 1920, height: 1080, mode: 70, rotation: 1 }],
+        [
+          64,
+          { x: 1920, y: 0, width: 2560, height: 1440, mode: 71, rotation: 1 },
+        ],
+      ]),
+      modes: [MODE_1080, MODE_1440],
+      primary: 68,
+    });
+
+    assert.deepEqual(
+      monitors.map((m) => [m.name, m.x, m.width, m.primary]),
+      [
+        ['eDP-1', 0, 1920, false],
+        ['HDMI-1', 1920, 2560, true],
+      ],
+    );
+    assert.deepEqual(monitors[0].outputs, ['eDP-1']);
+    assert.equal(monitors[0].widthMM, 340);
+    assert.equal(monitors[1].heightMM, 340);
+  });
+
+  test('a disconnected output is a port, not a monitor', () => {
+    const monitors = monitorsFromRandR({
+      outputs: [
+        laptop,
+        // nothing plugged in
+        { id: 69, name: 'DP-2', crtc: 0, connection: 1 },
+        // plugged in, but the user turned it off: connected with no CRTC
+        { id: 70, name: 'DP-3', crtc: 0, connection: 0 },
+      ],
+      crtcs: new Map([
+        [63, { x: 0, y: 0, width: 1920, height: 1080, mode: 70, rotation: 1 }],
+      ]),
+      modes: [MODE_1080],
+      primary: 0,
+    });
+    assert.deepEqual(
+      monitors.map((m) => m.name),
+      ['eDP-1'],
+    );
+  });
+
+  // The case that makes this keyed by CRTC rather than by output. Two cables
+  // showing the same pixels are one monitor, and a `screens.length` of 2 for
+  // a laptop mirroring to a projector is a wrong answer an app would act on.
+  test('mirrored outputs share a CRTC and are one monitor', () => {
+    const monitors = monitorsFromRandR({
+      outputs: [
+        { ...laptop, crtc: 63 },
+        { ...external, crtc: 63 },
+      ],
+      crtcs: new Map([
+        [63, { x: 0, y: 0, width: 1920, height: 1080, mode: 70, rotation: 1 }],
+      ]),
+      modes: [MODE_1080],
+      primary: 68,
+    });
+    assert.equal(monitors.length, 1);
+    assert.deepEqual(monitors[0].outputs, ['eDP-1', 'HDMI-1']);
+    // and the primary output is the one that names it, even though the other
+    // was reached first
+    assert.equal(monitors[0].name, 'HDMI-1');
+  });
+
+  test('a CRTC with no geometry is skipped rather than reported as 0x0', () => {
+    const monitors = monitorsFromRandR({
+      outputs: [laptop],
+      crtcs: new Map([[63, { x: 0, y: 0, width: 0, height: 0, mode: 0 }]]),
+      modes: [],
+      primary: 0,
+    });
+    assert.deepEqual(monitors, []);
+  });
+
+  test('refresh rate is dot clock over the total, to two decimals', () => {
+    // 148500000 / (2200 * 1125) = 60 exactly
+    assert.equal(refreshRateOf(MODE_1080), 60);
+    // 241500000 / (2720 * 1481) = 59.951…
+    assert.equal(refreshRateOf(MODE_1440), 59.95);
+    // a mode line with no timing cannot answer, and must not answer Infinity
+    assert.equal(refreshRateOf({ dot_clock: 0, h_total: 0, v_total: 0 }), null);
+    assert.equal(refreshRateOf(undefined), null);
+  });
+
+  // A server that does not drive real hardware fills the timing fields in
+  // rather than leaving them out. This is **XQuartz's own active mode**, read
+  // off a running one: dot_clock is exactly h_total * v_total, so the
+  // arithmetic is a blameless 1 Hz. "1 Hz" beside a monitor name looks broken
+  // in a way that showing nothing does not.
+  test('an implausible rate is null, not the number', () => {
+    assert.equal(
+      refreshRateOf({
+        id: 248,
+        width: 1728,
+        height: 1080,
+        dot_clock: 1866240,
+        h_total: 1728,
+        v_total: 1080,
+      }),
+      null,
+    );
+    // and the real modes the same server lists still answer
+    assert.equal(
+      refreshRateOf({ dot_clock: 155520000, h_total: 1920, v_total: 1080 }),
+      75,
+    );
+  });
+
+  test('rotation is degrees, and the reflection bits are not rotation', () => {
+    assert.equal(degreesOf(1), 0); // Rotate_0
+    assert.equal(degreesOf(2), 90);
+    assert.equal(degreesOf(4), 180);
+    assert.equal(degreesOf(8), 270);
+    // Rotate_0 | Reflect_X — mirrored, not turned
+    assert.equal(degreesOf(1 | 16), 0);
+    // Rotate_90 | Reflect_Y
+    assert.equal(degreesOf(2 | 32), 90);
+  });
+});
+
+describe('useScreens', () => {
+  afterEach(cleanup);
+
+  // What a server with neither Xinerama nor RandR answers — which is what the
+  // in-process one is, so this runs against it rather than against the mock
+  // (whose `createMockApp` pins a monitor of its own). One entry covering the
+  // display beats an empty list: an app that maps over `screens` should draw
+  // one monitor, not none.
+  test('a display with no extensions is still one screen', async () => {
+    const { app } = await renderX11(h('box'));
+    const { screens, primary, source, virtual } = screensSnapshot(app);
+    assert.equal(screens.length, 1);
+    assert.equal(screens[0].name, null, 'no RandR means no name');
+    assert.equal(screens[0].primary, true);
+    assert.equal(primary, screens[0]);
+    assert.equal(source, 'screen');
+    assert.equal(screens[0].width, virtual.width);
+    // and it is the whole display, which is the only thing there was to say
+    assert.equal(screens[0].width, app.display.screen[0].pixel_width);
+  });
+
+  test('renders the layout and re-renders when a monitor arrives', async () => {
+    const seen = [];
+    function Probe() {
+      const { screens, primary } = useScreens();
+      seen.push(
+        `${screens.map((s) => `${s.name}@${s.x}`).join(',')}|${primary?.name ?? '-'}`,
+      );
+      return h('text', null, String(screens.length));
+    }
+    const { app } = await renderX11(h(Probe), { backend: 'mock' });
+
+    await act(async () => {
+      setScreensForTests(app, {
+        monitors: [
+          { name: 'eDP-1', x: 0, y: 0, width: 1920, height: 1080 },
+          {
+            name: 'HDMI-1',
+            x: 1920,
+            y: 0,
+            width: 2560,
+            height: 1440,
+            primary: true,
+          },
+        ],
+      });
+    });
+    await settle();
+    assert.equal(seen.at(-1), 'eDP-1@0,HDMI-1@1920|HDMI-1');
+
+    // unplugged
+    await act(async () => {
+      setScreensForTests(app, {
+        monitors: [{ name: 'eDP-1', x: 0, y: 0, width: 1920, height: 1080 }],
+      });
+    });
+    await settle();
+    // one monitor and nothing flagged primary: the one monitor is it
+    assert.equal(seen.at(-1), 'eDP-1@0|eDP-1');
+  });
+
+  // `_NET_WORKAREA` is one rect for the whole virtual desktop, so it is a
+  // per-axis bound rather than an intersection — the note this is pinning is
+  // that a 40px top panel comes off *both* heads' height and neither head's
+  // width, which is the honest reading of a desktop-wide value.
+  test('available is the monitor clamped per axis by the work area', async () => {
+    const { app } = await renderX11(h('box'), { backend: 'mock' });
+    setScreensForTests(app, {
+      monitors: [
+        { name: 'a', x: 0, y: 0, width: 1920, height: 1080 },
+        { name: 'b', x: 1920, y: 0, width: 2560, height: 1440 },
+      ],
+      workArea: { x: 0, y: 40, width: 4480, height: 1400 },
+    });
+    const { screens } = screensSnapshot(app);
+    assert.deepEqual(
+      screens.map((s) => [s.available.width, s.available.height]),
+      [
+        [1920, 1080], // narrower and shorter than the work area already
+        [2560, 1400], // the panel comes off the tall head
+      ],
+    );
+    // and it is a rect and nothing else. A monitor record carries a name and
+    // a primary flag too, and spreading it here put both inside `available`.
+    assert.deepEqual(Object.keys(screens[0].available).sort(), [
+      'height',
+      'width',
+      'x',
+      'y',
+    ]);
+  });
+
+  // The no-work-area branch is the one that had the bug, so it gets its own
+  // case: with nothing to clamp against, `available` is still only a rect.
+  test('available is a rect with no work area either', async () => {
+    const { app } = await renderX11(h('box'), { backend: 'mock' });
+    setScreensForTests(app, {
+      monitors: [
+        { name: 'a', x: 0, y: 0, width: 1920, height: 1080, primary: true },
+      ],
+    });
+    const [screen] = screensSnapshot(app).screens;
+    assert.deepEqual(screen.available, {
+      x: 0,
+      y: 0,
+      width: 1920,
+      height: 1080,
+    });
+  });
+
+  test('the snapshot is stable until something changes', async () => {
+    const { app } = await renderX11(h('box'), { backend: 'mock' });
+    setScreensForTests(app, {
+      monitors: [{ name: 'a', x: 0, y: 0, width: 800, height: 600 }],
+    });
+    // The invariant `useSyncExternalStore` needs: a fresh object per call is
+    // what makes React re-render forever.
+    assert.strictEqual(screensSnapshot(app), screensSnapshot(app));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useWindowState
+// ---------------------------------------------------------------------------
+
+describe('useWindowState', () => {
+  afterEach(cleanup);
+
+  // Focused and visible, not a pile of falses: a window opens focused far
+  // more often than not, and a title bar that renders dimmed on frame one
+  // and un-dims on frame two is a flash on every launch.
+  test('starts focused and visible rather than unknown', async () => {
+    const seen = [];
+    function Probe() {
+      const { focused, visible, fullscreen, states } = useWindowState();
+      seen.push(`${focused}:${visible}:${fullscreen}:${states.length}`);
+      return h('text', null, 'hi');
+    }
+    await renderX11(h(Probe), { backend: 'mock' });
+    assert.equal(seen[0], 'true:true:false:0');
+  });
+
+  test('derives minimized, maximized and fullscreen from _NET_WM_STATE', async () => {
+    const { app } = await renderX11(h('box'), { backend: 'mock' });
+    const node = app._rootChildren[0];
+    let renders = 0;
+    watchWindowState(app, node, () => renders++);
+
+    let state = setWindowStateForTests(app, node, {
+      states: ['maximized_vert', 'maximized_horz'],
+    });
+    assert.equal(state.maximized, true);
+    assert.equal(state.fullscreen, false);
+
+    state = setWindowStateForTests(app, node, { states: ['fullscreen'] });
+    assert.equal(state.fullscreen, true);
+    assert.equal(
+      state.maximized,
+      false,
+      'one axis gone is not still maximized',
+    );
+
+    // `hidden` is EWMH for iconified, and it is what `visible` folds in —
+    // the signal that survives a compositor, unlike VisibilityNotify.
+    state = setWindowStateForTests(app, node, { states: ['hidden'] });
+    assert.equal(state.minimized, true);
+    assert.equal(state.visible, false);
+    assert.equal(windowStateSnapshot(app, node), state);
+    assert.ok(renders > 0, 'subscribers heard about it');
+  });
+
+  test('obscured folds into visible, and a compositor never sets it', async () => {
+    const { app } = await renderX11(h('box'), { backend: 'mock' });
+    const node = app._rootChildren[0];
+
+    assert.equal(
+      setWindowStateForTests(app, node, { obscured: true }).visible,
+      false,
+    );
+    assert.equal(
+      setWindowStateForTests(app, node, { obscured: false }).visible,
+      true,
+    );
+  });
+
+  test('a state rewrite that changes nothing notifies nobody', async () => {
+    const { app } = await renderX11(h('box'), { backend: 'mock' });
+    const node = app._rootChildren[0];
+    let renders = 0;
+    watchWindowState(app, node, () => renders++);
+
+    setWindowStateForTests(app, node, { states: ['focused'] });
+    const after = renders;
+    // window managers rewrite `_NET_WM_STATE` with the same contents more
+    // often than they change it
+    setWindowStateForTests(app, node, { states: ['focused'] });
+    setWindowStateForTests(app, node, { states: ['focused'] });
+    assert.equal(renders, after);
+  });
+
+  test('the hook re-renders on what the window manager did', async () => {
+    const seen = [];
+    function Probe() {
+      const { maximized, visible } = useWindowState();
+      seen.push(`${maximized}:${visible}`);
+      return h('text', null, 'x');
+    }
+    const { app } = await renderX11(h(Probe), { backend: 'mock' });
+    const node = app._rootChildren[0];
+    assert.equal(seen[0], 'false:true');
+
+    await act(async () => {
+      setWindowStateForTests(app, node, {
+        states: ['maximized_vert', 'maximized_horz'],
+      });
+    });
+    await settle();
+    assert.equal(seen.at(-1), 'true:true');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useIdle
+// ---------------------------------------------------------------------------
+
+describe('useIdle', () => {
+  afterEach(cleanup);
+
+  test('a display that cannot be asked is never idle', async () => {
+    const seen = [];
+    function Probe() {
+      seen.push(useIdle(60_000));
+      return h('text', null, 'x');
+    }
+    await renderX11(h(Probe), { backend: 'mock' });
+    await settle();
+    // No SYNC and no MIT-SCREEN-SAVER: false for good, which is the honest
+    // answer for a display with no idle counter — not a hang, and not true.
+    assert.deepEqual([...new Set(seen)], [false]);
+  });
+
+  test('re-renders on the crossing, in both directions', async () => {
+    const seen = [];
+    function Probe() {
+      seen.push(useIdle(60_000));
+      return h('text', null, 'x');
+    }
+    const { app } = await renderX11(h(Probe), { backend: 'mock' });
+
+    await act(async () => setIdleForTests(app, 60_000, true));
+    await settle();
+    assert.equal(seen.at(-1), true);
+
+    await act(async () => setIdleForTests(app, 60_000, false));
+    await settle();
+    assert.equal(seen.at(-1), false);
+  });
+
+  test('two timeouts are two watchers', async () => {
+    const { app } = await renderX11(h('box'), { backend: 'mock' });
+    setIdleForTests(app, 10_000, true);
+    setIdleForTests(app, 300_000, false);
+    assert.equal(idleSnapshot(app, 10_000), true);
+    assert.equal(idleSnapshot(app, 300_000), false);
+    assert.equal(idleSnapshot(app, 999), false, 'one nobody asked for');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useKeyboardState
+// ---------------------------------------------------------------------------
+
+describe('useKeyboardState', () => {
+  afterEach(cleanup);
+
+  test('the lock bits', () => {
+    assert.deepEqual(locksFromMods(0), { capsLock: false, numLock: false });
+    // LockMask, fixed by the core protocol
+    assert.deepEqual(locksFromMods(2), { capsLock: true, numLock: false });
+    // Mod2, by universal convention
+    assert.deepEqual(locksFromMods(16), { capsLock: false, numLock: true });
+    assert.deepEqual(locksFromMods(2 | 16), { capsLock: true, numLock: true });
+    // Shift and Control held is not a lock
+    assert.deepEqual(locksFromMods(1 | 4), { capsLock: false, numLock: false });
+  });
+
+  test('the layouts come out of _XKB_RULES_NAMES', () => {
+    // rules, model, layouts, variants, options — NUL-separated, as setxkbmap
+    // writes it
+    const property = Buffer.from(
+      'evdev\0pc105\0us,ru\0,phonetic\0grp:alt_shift_toggle\0',
+      'latin1',
+    );
+    assert.deepEqual(layoutsFromRules(property), ['us', 'ru']);
+    // one layout, and the trailing NUL must not become a sixth empty entry
+    assert.deepEqual(
+      layoutsFromRules(Buffer.from('evdev\0pc105\0gb\0\0\0', 'latin1')),
+      ['gb'],
+    );
+    // no property at all, and a property with an empty layout field
+    assert.deepEqual(layoutsFromRules(undefined), []);
+    assert.deepEqual(layoutsFromRules(Buffer.from('evdev\0pc105\0\0\0\0')), []);
+
+    // **XQuartz's own property**, read off a running one. `empty` is a real
+    // xkeyboard-config layout and what it is defined as is a layout with no
+    // symbols — so reporting it would put "EMPTY" in a layout indicator,
+    // where the empty list already means "this display cannot say".
+    assert.deepEqual(
+      layoutsFromRules(Buffer.from('base\0empty\0empty\0\0\0', 'latin1')),
+      [],
+    );
+    // …but a real layout beside it is still a real layout
+    assert.deepEqual(
+      layoutsFromRules(Buffer.from('base\0pc105\0empty,us\0\0\0', 'latin1')),
+      ['empty', 'us'],
+    );
+  });
+
+  test('layout is the active group indexed into the list', async () => {
+    const seen = [];
+    function Probe() {
+      const { capsLock, group, layout } = useKeyboardState();
+      seen.push(`${capsLock ? 'CAPS' : '-'}:${group}:${layout}`);
+      return h('text', null, 'x');
+    }
+    const { app } = await renderX11(h(Probe), { backend: 'mock' });
+
+    await act(async () =>
+      setKeyboardStateForTests(app, { group: 0, layouts: ['us', 'ru'] }),
+    );
+    await settle();
+    assert.equal(seen.at(-1), '-:0:us');
+
+    // Alt+Shift, and the lock goes on
+    await act(async () =>
+      setKeyboardStateForTests(app, {
+        group: 1,
+        layouts: ['us', 'ru'],
+        capsLock: true,
+      }),
+    );
+    await settle();
+    assert.equal(seen.at(-1), 'CAPS:1:ru');
+  });
+
+  test('a group past the end of the list is null, not undefined', async () => {
+    const { app } = await renderX11(h('box'), { backend: 'mock' });
+    setKeyboardStateForTests(app, { group: 3, layouts: ['us'] });
+    assert.equal(keyboardStateSnapshot(app).layout, null);
+  });
+
+  test('no XKB reads as off with an empty layout list', async () => {
+    const { app } = await renderX11(h('box'), { backend: 'mock' });
+    await settle();
+    const state = keyboardStateSnapshot(app);
+    assert.equal(state.capsLock, false);
+    // the field that tells "off" apart from "could not be asked"
+    assert.deepEqual(state.layouts, []);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useDesktopSettings, and the three renderer paths that read it
+// ---------------------------------------------------------------------------
+
+describe('desktop interaction settings', () => {
+  afterEach(cleanup);
+
+  test('the XSETTINGS keys, and the full-cycle conversion', () => {
+    const map = new Map([
+      ['Net/CursorBlinkTime', 1200],
+      ['Net/DoubleClickTime', 250],
+      ['Net/DoubleClickDistance', 7],
+      ['Net/DndDragThreshold', 8],
+    ]);
+    const values = fromXSettings(map);
+    // The one that is easy to get wrong: the key is a **full cycle**, on and
+    // off together, and what goes into a timer is half of it. Forgetting the
+    // halving is a caret that blinks at half speed.
+    assert.equal(values.caretBlinkMs, 600);
+    assert.equal(values.doubleClickMs, 250);
+    assert.equal(values.doubleClickDistance, 7);
+    assert.equal(values.dragThreshold, 8);
+    assert.equal(values.source, 'xsettings');
+  });
+
+  test('an absent key keeps the default, and 0 turns blinking off', () => {
+    // A daemon that exports nothing this cares about still answers.
+    const empty = fromXSettings(new Map());
+    assert.equal(empty.caretBlink, true);
+    assert.equal(empty.caretBlinkMs, DEFAULTS.caretBlinkMs);
+    assert.equal(empty.dragThreshold, DEFAULTS.dragThreshold);
+
+    // `Net/CursorBlink: 0` is an accessibility setting, not a preference.
+    assert.equal(
+      fromXSettings(new Map([['Net/CursorBlink', 0]])).caretBlink,
+      false,
+    );
+    assert.equal(
+      fromXSettings(new Map([['Net/CursorBlink', 1]])).caretBlink,
+      true,
+    );
+
+    // A daemon can export a key with a value of the wrong type or a nonsense
+    // one; a caret whose period is `'fast'` never comes back on.
+    const junk = fromXSettings(
+      new Map([
+        ['Net/CursorBlinkTime', 'fast'],
+        ['Net/DndDragThreshold', -3],
+        ['Net/DoubleClickTime', 0],
+      ]),
+    );
+    assert.equal(junk.caretBlinkMs, DEFAULTS.caretBlinkMs);
+    assert.equal(junk.dragThreshold, DEFAULTS.dragThreshold);
+    assert.equal(junk.doubleClickMs, DEFAULTS.doubleClickMs);
+  });
+
+  test('no settings daemon answers the defaults with a null source', async () => {
+    const { app } = await renderX11(h('box'), { backend: 'mock' });
+    const values = desktopSettings(app);
+    assert.equal(values.source, null);
+    assert.equal(values.caretBlinkMs, CARET_BLINK_MS);
+  });
+
+  test('the hook re-renders when the desktop changes them', async () => {
+    const seen = [];
+    function Probe() {
+      const { doubleClickMs, dragThreshold } = useDesktopSettings();
+      seen.push(`${doubleClickMs}/${dragThreshold}`);
+      return h('text', null, 'x');
+    }
+    const { app } = await renderX11(h(Probe), { backend: 'mock' });
+    assert.equal(seen[0], '400/4');
+
+    await act(async () =>
+      setDesktopSettingsForTests(app, { doubleClickMs: 250, dragThreshold: 8 }),
+    );
+    await settle();
+    assert.equal(seen.at(-1), '250/8');
+  });
+
+  // The three renderer paths. Each one used to be a constant, and each one is
+  // the reason this module exists rather than the hook.
+  test('the caret takes its cadence from the desktop', async () => {
+    const { app } = await renderX11(
+      h('textinput', { value: 'x', style: { width: 80 } }),
+      { backend: 'mock' },
+    );
+    setDesktopSettingsForTests(app, { caretBlinkMs: 999 });
+    const input = app.windows[0]._reactX11Node.children[0];
+    input.defaultFocus();
+    // node's timers carry the interval they were armed with
+    assert.equal(input._blinkTimer._idleTimeout, 999);
+    input.defaultBlur();
+  });
+
+  test('`Net/CursorBlink: 0` arms no timer at all', async () => {
+    const { app } = await renderX11(
+      h('textinput', { value: 'x', style: { width: 80 } }),
+      { backend: 'mock' },
+    );
+    setDesktopSettingsForTests(app, { caretBlink: false });
+    const input = app.windows[0]._reactX11Node.children[0];
+    input.defaultFocus();
+    // Not a timer that fires and draws the same thing twice: a person who
+    // asked for no blinking asked for nothing on screen to move.
+    assert.equal(input._blinkTimer, undefined);
+    assert.equal(input._caretOn, true, 'and the caret is still drawn');
+    input.defaultBlur();
+  });
+
+  // The third path. 6px drags at the built-in 4px threshold and does not at a
+  // desktop that asked for 12 — a drag that starts sooner here than in every
+  // other application is one people begin by accident.
+  test('the drag threshold is the desktop’s', async () => {
+    const started = [];
+    const { app } = await renderX11(
+      h(
+        'box',
+        {
+          draggable: true,
+          dragData: { 'text/plain': 'hi' },
+          onDragStart: () => started.push('drag'),
+          style: { width: 100, height: 100 },
+        },
+        null,
+      ),
+      { backend: 'mock' },
+    );
+    const wnd = app.windows[0];
+    const at = (x, y) => ({
+      x,
+      y,
+      rootx: x,
+      rooty: y,
+      keycode: 1,
+      buttons: 0,
+      time: 100,
+    });
+
+    setDesktopSettingsForTests(app, { dragThreshold: 12 });
+    wnd.emit('mousedown', at(10, 10));
+    wnd.emit('mousemove', { ...at(14, 12), buttons: 256 });
+    wnd.emit('mouseup', at(14, 12));
+    await settle();
+    assert.deepEqual(started, [], '6px is under this desktop’s 12');
+
+    setDesktopSettingsForTests(app, { dragThreshold: 4 });
+    wnd.emit('mousedown', at(10, 10));
+    wnd.emit('mousemove', { ...at(14, 12), buttons: 256 });
+    await settle();
+    assert.deepEqual(started, ['drag'], '…and over the built-in 4');
+    wnd.emit('mouseup', at(14, 12));
+    await settle();
+  });
+
+  test('the double-click window is the desktop’s', async () => {
+    const { app } = await renderX11(h('box'), { backend: 'mock' });
+    const events = app.windows[0]._reactX11Node.events;
+    setDesktopSettingsForTests(app, {
+      doubleClickMs: 1,
+      doubleClickDistance: 0,
+    });
+    const at = (x, y) => ({ x, y });
+    // Distance rather than time, because the clock cannot be held still here
+    // and two calls in one tick are 0ms apart whatever the window is. A
+    // desktop that demands the second click land on the same pixel makes one
+    // 3px away a fresh click.
+    assert.equal(events._clickDetail(at(10, 10)), 1);
+    assert.equal(events._clickDetail(at(13, 10)), 1);
+    // …and on the same pixel, still a double
+    assert.equal(events._clickDetail(at(13, 10)), 2);
+
+    setDesktopSettingsForTests(app, {
+      doubleClickMs: 5_000,
+      doubleClickDistance: 20,
+    });
+    // 15px apart is outside the 4px default and inside this desktop's 20
+    assert.equal(events._clickDetail(at(28, 10)), 3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useLocale
+// ---------------------------------------------------------------------------
+
+describe('useLocale', () => {
+  afterEach(async () => {
+    setLocaleForTests(null);
+    await cleanup();
+  });
+
+  test('POSIX locale strings become BCP-47 tags', () => {
+    assert.equal(toLanguageTag('ru_RU.UTF-8'), 'ru-RU');
+    assert.equal(toLanguageTag('en_GB'), 'en-GB');
+    assert.equal(toLanguageTag('de_DE.UTF-8@euro'), 'de-DE');
+    assert.equal(toLanguageTag('fr'), 'fr');
+    // `C` and `POSIX` are the *absence* of a locale spelled as a value, and
+    // passing either to Intl gets a RangeError or a plausible-looking lie
+    assert.equal(toLanguageTag('C'), null);
+    assert.equal(toLanguageTag('POSIX'), null);
+    assert.equal(toLanguageTag(''), null);
+    assert.equal(toLanguageTag(undefined), null);
+    // a malformed tag falls through to ICU rather than reaching a formatter
+    assert.equal(toLanguageTag('not a locale at all'), null);
+  });
+
+  test('the environment wins over ICU’s own resolution', () => {
+    // ICU answers what it has compiled in — a small build says en-US for
+    // every environment there is — where LANG is what the user asked for.
+    assert.equal(resolveLocale({ LANG: 'ru_RU.UTF-8' }).locale, 'ru-RU');
+    assert.equal(resolveLocale({ LANG: 'ru_RU.UTF-8' }).source, 'env');
+    // and the more specific variables win over LANG
+    assert.equal(
+      resolveLocale({ LC_ALL: 'ja_JP.UTF-8', LANG: 'en_US.UTF-8' }).locale,
+      'ja-JP',
+    );
+    assert.equal(
+      resolveLocale({ LC_MESSAGES: 'he_IL', LANG: 'en_US' }).locale,
+      'he-IL',
+    );
+    // nothing set at all still answers, from ICU
+    const fallback = resolveLocale({});
+    assert.ok(fallback.locale.length > 0);
+    assert.equal(fallback.source, 'intl');
+    // `C` is not a locale, so it falls through rather than becoming a tag
+    assert.equal(resolveLocale({ LANG: 'C' }).source, 'intl');
+  });
+
+  test('direction and week start come off the resolved tag', () => {
+    assert.equal(directionOf('en-GB'), 'ltr');
+    assert.equal(directionOf('ar-EG'), 'rtl');
+    assert.equal(directionOf('he-IL'), 'rtl');
+    assert.equal(directionOf('fa-IR'), 'rtl');
+    assert.equal(resolveLocale({ LANG: 'ar_EG.UTF-8' }).direction, 'rtl');
+
+    // CLDR: Monday in most of the world, Sunday in the US — and the count is
+    // JS's (0 Sunday) rather than CLDR's (7 Sunday), which is the conversion
+    // worth pinning
+    assert.equal(localeWeekStart('en-GB'), 1);
+    assert.equal(localeWeekStart('en-US'), 0);
+    // and Monday — ISO 8601's answer — where there is no week info to be had,
+    // which is a tag `Intl.Locale` will not take, or a build without CLDR
+    assert.equal(localeWeekStart('not a locale'), 1);
+  });
+
+  test('renders the locale, and the seam re-derives from it', async () => {
+    const seen = [];
+    function Probe() {
+      const { locale, direction, weekStartsOn } = useLocale();
+      seen.push(`${locale}:${direction}:${weekStartsOn}`);
+      return h('text', null, locale);
+    }
+    // Pinning a locale re-derives the direction: `he-IL` and left-to-right
+    // is not a locale anybody has.
+    setLocaleForTests({ locale: 'he-IL' });
+    await renderX11(h(Probe), { backend: 'mock' });
+    assert.equal(seen.at(-1), 'he-IL:rtl:0');
+    assert.equal(systemLocale().source, 'test');
+  });
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -15,8 +15,15 @@ import type {
   BusKind,
   BusRef,
   BusStatus,
+  DesktopSettings,
   FileDialogBackend,
+  KeyboardState,
   MessageBus,
+  Screen,
+  Screens,
+  SystemLocale,
+  WindowState,
+  WindowStateName,
 } from 'react-x11';
 import {
   Button,
@@ -43,10 +50,19 @@ import {
   systemBus,
   useApp,
   useClipboard,
+  useDesktopSettings,
   useFileDialog,
   useGlobalMenu,
+  useIdle,
+  useKeepAwake,
+  useKeyboardState,
+  useLocale,
+  useScreens,
   useSessionBus,
   useSystemBus,
+  useWindowState,
+  keepAwake,
+  systemLocale,
   ContextMenu,
   createRoot,
   DatePicker,
@@ -1187,6 +1203,70 @@ function _Files() {
   return null;
 }
 
+/** The system hooks: the machine around the app. */
+function _System() {
+  const win = useRef(null);
+
+  const { screens, primary, workArea, virtual, source }: Screens = useScreens();
+  const first: Screen | undefined = screens[0];
+  // `name` is null until RandR answers, so it is not assignable to `string`.
+  const name: string | null = first?.name ?? null;
+  const hz: number | null = first?.refreshRate ?? null;
+  const turned: 0 | 90 | 180 | 270 = first?.rotation ?? 0;
+  // @ts-expect-error — the screen list is read-only
+  screens.push(first!);
+  void [primary, workArea, virtual, source, name, hz, turned];
+
+  // No argument infers the window; a ref is the exact form.
+  const state: WindowState = useWindowState();
+  const exact: WindowState = useWindowState(win);
+  const states: readonly WindowStateName[] = state.states;
+  const desktop: number | null = state.desktop;
+  // @ts-expect-error — `visible` is a boolean, not a rect
+  const bad: object = exact.visible;
+  void [states, desktop, bad];
+
+  const away: boolean = useIdle(5 * 60_000);
+  useKeepAwake(away, 'Rendering');
+  // The reason is optional.
+  useKeepAwake(false);
+  // @ts-expect-error — a timeout is required, and is a number
+  useIdle();
+
+  const keys: KeyboardState = useKeyboardState();
+  const layout: string | null = keys.layout;
+  const layouts: readonly string[] = keys.layouts;
+  void [keys.capsLock, keys.numLock, keys.group, layout, layouts];
+
+  const feel: DesktopSettings = useDesktopSettings();
+  const blinkFor: number = feel.caretBlink ? feel.caretBlinkMs : 0;
+  void [
+    feel.doubleClickMs,
+    feel.doubleClickDistance,
+    feel.dragThreshold,
+    blinkFor,
+  ];
+
+  const { locale, direction, weekStartsOn, timeZone }: SystemLocale =
+    useLocale();
+  const rtl: boolean = direction === 'rtl';
+  void [locale, weekStartsOn, timeZone, rtl];
+
+  return <window ref={win} width={400} height={300} />;
+}
+
+/** The imperative twins, for host-side code with no component to hang off. */
+async function _SystemImperative() {
+  const release: () => void = await keepAwake({ reason: 'Exporting' });
+  release();
+  await keepAwake();
+  const here: SystemLocale = systemLocale();
+  // @ts-expect-error — the snapshot is read-only
+  here.locale = 'fr-FR';
+}
+
+void _System;
+void _SystemImperative;
 void _Files;
 void _Bus;
 void _DeepLinks;

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -192,6 +192,7 @@ const ORDER = [
   'uri-schemes.md',
   'filedialog.md',
   'appearance.md',
+  'system.md',
   'remote.md',
   'security.md',
   'packaging.md',


### PR DESCRIPTION
Six hooks for what an application has to read off the system rather than work
out for itself — and one change that is not a hook at all.

Full reference: [docs/system.md](https://github.com/sidorares/react-x11/blob/claude/x11-system-hooks-200f5d/docs/system.md).

| | |
| --- | --- |
| `useScreens()` | the monitor layout, live |
| `useWindowState()` | what the window manager actually did with the window |
| `useIdle()` / `useKeepAwake()` | is anyone at the desk; keep the screen on |
| `useKeyboardState()` | Caps Lock, Num Lock and the active layout |
| `useDesktopSettings()` | the interaction timings the desktop publishes |
| `useLocale()` | the language and its conventions |

## The parts worth reviewing

**`useScreens()` splits its answer in two, deliberately.** Xinerama gives the
geometry in one round trip during `createRoot()`. The RandR walk that carries
the names, the primary flag, the millimetres and the refresh rate is
`GetScreenResourcesCurrent` plus a `GetOutputInfo` and a `GetCrtcInfo` per
output — ten or more round trips on an ordinary two-head desktop — and it runs
**unawaited** behind the geometry. Every app's startup would otherwise pay for
a question most never ask. That is only safe because the second answer adds
fields rather than moving rects: Xinerama on a modern server is RandR's own
emulation. Monitors are keyed by **CRTC**, so a laptop mirroring to a projector
is one screen with two names in `outputs`, not two screens.

**`useWindowState()` is what the WM did, where `<window states>` is what was
asked for.** The two part company routinely and nothing else reads it back.
`visible` is the field to branch on, not `obscured`: a composited window is
never obscured — the compositor redirects it offscreen and the server considers
it fully visible — and that is every stock GNOME and KDE session. Folding in
`minimized`, the signal that survives compositing, is what makes the field
useful. Called out prominently in the docs so it isn't found as a bug.

**`useIdle()` costs no timer.** X has an `IDLETIME` SYNC counter and SYNC has
alarms, so "tell me when the user has been idle for five minutes" is an alarm
flip-flop and nothing polling — the same mechanism every idle daemon on the
desktop uses. `delta` must be sent as `0`; it defaults to `1`, and the protocol
rejects a positive delta on a negative test with a `Match` error that goes to
the connection's error hook rather than to a callback, so getting it wrong
would silently break the half that notices the user coming back.
MIT-SCREEN-SAVER polls underneath where there is no counter.

**`useKeyboardState()` is true of the keyboard, not of an event.** A key event
carries the modifier state for a key you already received, which is no help in
the one case that matters: `PasswordInput` ships in this repo and could not warn
about Caps Lock before the first keystroke.

**The sixth item is mostly not a hook.** The caret cadence, the double-click
window and distance, and the drag threshold were four hardcoded constants
(`CARET_BLINK_MS`, the 400ms/4px pair inside `_clickDetail`, `DRAG_THRESHOLD`).
They now read XSETTINGS at the point of use, so the built-in controls follow the
desktop and an app drawing its own caret or gesture can read the same numbers.
**`Net/CursorBlink: 0` is an accessibility setting this renderer was ignoring**
— a moving thing on screen is what some people cannot read past — and it now
arms no timer and draws the caret solid.

Two pieces of housekeeping ride along: `createRoot()` starts XSETTINGS without
awaiting it (five round trips should not sit on the startup path for something
first read at the first interaction), and `unmount()` now ends the XSETTINGS
session, which nothing was doing before — it held a `PropertyChange` selection
and an XFixes watch that outlived every reader.

## Three bugs a headless test could not have found

The in-process X server has RENDER, BIG-REQUESTS and XC-MISC and **none** of
RandR, Xinerama, XKB, SYNC or MIT-SCREEN-SAVER. So the reply decoders are pinned
as pure functions and the stores through their `set*ForTests` seams, and the
end-to-end walks were probed by hand against a real display. That turned up
three things, each now pinned with the real XQuartz values as fixtures:

- `screen.available` was spreading the whole monitor record — a rect that had
  somehow grown a `name` and a `primary` flag.
- XQuartz's active mode reports a `dot_clock` of exactly `h_total * v_total`,
  so the refresh-rate arithmetic was a blameless **1 Hz**. Outside 20–1000 Hz is
  now `null`: a server saying "I do not know" in the only way the protocol lets
  it.
- XQuartz's `_XKB_RULES_NAMES` is literally `base\0empty\0empty`. `empty` is a
  real xkeyboard-config layout defined as having no symbols, so reporting it
  would put "EMPTY" in a layout indicator; it is now the empty list, which is
  what "cannot say" already means everywhere else here.

Against XQuartz after the fixes, with **no X protocol errors** across any of the
new paths — which is the only way to see that the `delta: 0` rule above is
right:

```
SCREENS:  1 screen, source "randr", name "default", available {0,0,1728,1080},
          refreshRate null, workArea null
KEYBOARD: {capsLock:false, numLock:false, group:0, layout:null, layouts:[]}
IDLE(2s): true          (the SYNC alarm fired; XQuartz has IDLETIME)
WINDOW:   {focused:true, visible:true, states:[], desktop:null}
X errors during all of it: none
```

## Verification

- **1347 pass / 6 fail**, three consecutive runs. `origin/master` is 1310 / 6 —
  the same six known macOS-only `appearance.test.js` failures, unchanged. +37
  tests.
- **11 mutations reverted, every one caught**: caret cadence, blink-off, the
  full-cycle halving, click detail, drag threshold, CRTC keying, `visible`,
  locale precedence, the Num Lock bit, and the two real-server fixes above.
- `lint`, `prettier --check .`, `typecheck`, all three website gates, and
  `website && npm run build` for the new page's links and anchors.

Two `test/appearance.test.js` cases needed a line each: `createRoot()` now owns
an XSETTINGS session, and `beginXSettings` is memoized per connection, so a test
that stands its own settings daemon up has to take the existing one down first.

## No screenshots, on purpose

Nothing here changes rendering, widgets or layout. The one visually detectable
behaviour is the caret **not** blinking under `Net/CursorBlink: 0`, and a still
image is the wrong medium for that. The real-display probe output above is the
evidence that would otherwise be a screenshot.

## Breaking

`WindowState` is now the object `useWindowState()` returns. The union of
`_NET_WM_STATE` names that `<window states>` takes is `WindowStateName`.
Types only; no runtime rename.
