### PR TITLE
fix(paint): a frame scheduled before the connection closed paints nothing

### DIFF
--- a/src/nodes.js
+++ b/src/nodes.js
@@ -6065,6 +6065,17 @@ export class TextInputNode extends Node {
     // timer for it.
     if (caretBlink) {
       this._blinkTimer = setInterval(() => {
+        // A field can still hold focus when the connection goes — an app
+        // closing its own client, a server exit, a test closing the app it
+        // lent the root. Nothing blurs the field on that route, so this is
+        // the timer's own exit: the next tick would paint a caret onto a
+        // closing connection and throw out of the frame clock, where there
+        // is nothing to catch it.
+        if (this.destroyed || this.app?.X?._closing) {
+          clearInterval(this._blinkTimer);
+          this._blinkTimer = null;
+          return;
+        }
         this._caretOn = !this._caretOn;
         // twice a second, forever, for as long as a field has focus: the one
         // repaint that most wants to cost only the field it happens in
@@ -8423,6 +8434,14 @@ export class WindowNode extends Scrollable(Node) {
     // owes nothing at all.
     clearPendingFrame(this);
     if (this.destroyed || !this.yoga || !this.window) return;
+    // A frame is scheduled a tick before it is painted, and the connection
+    // can go in between: an app closing its own client, a server exit, a
+    // test closing the app it lent the root. Nothing unmounts the tree on
+    // that route, so the frame arrives with a live window node and a dead
+    // socket, and the first request it makes throws out of the frame clock
+    // where there is nothing waiting to catch it. There is no screen left to
+    // paint to, so this owes nothing either.
+    if (this.app?.X?._closing) return;
     // a transientFor whose owner was not realized yet at commit time. The
     // frame after the mount is the first moment refs have attached, so the
     // common "two <window>s in one tree" case resolves here rather than

--- a/test/create-root.test.js
+++ b/test/create-root.test.js
@@ -9,6 +9,7 @@ import React from 'react';
 import xserver from 'x11/lib/xserver/index.js';
 import { StaticFontSource } from 'ntk';
 import { createRoot } from '../src/index.js';
+import { setDesktopSettingsForTests } from '../src/desktopsettings.js';
 import { createMockApp } from './helpers/mock-app.js';
 
 const h = React.createElement;
@@ -206,5 +207,41 @@ test('a root that borrows a connection can outlive another root on it', async ()
   assert.ok(
     !second.calls.some(([name]) => name === 'destroy'),
     'and left the second tree standing on the same connection',
+  );
+});
+
+test('a caret stops blinking when the connection closes under it', async () => {
+  // A focused field arms an interval that repaints twice a second for as
+  // long as it holds focus, and closing the connection does not blur it —
+  // an app that closes its own client, or a test that closes the app it
+  // lent the root. The tick after the close used to reach the wire and
+  // throw "client is in closing state" out of the frame clock, where
+  // nothing is waiting to catch it: an uncaught exception with no test
+  // still running to attribute it to, which is what made
+  // test/selection-batch.test.js flake on the slower CI runners.
+  const root = await createRoot(headlessStream());
+  const ref = React.createRef();
+  root.render(
+    h(
+      'window',
+      { width: 60, height: 40 },
+      h('textinput', { ref, defaultValue: 'x', style: { width: 40 } }),
+    ),
+  );
+  await tick();
+  const input = ref.current;
+  setDesktopSettingsForTests(root.app, { caretBlinkMs: 5 });
+  input.defaultFocus();
+  assert.ok(input._blinkTimer, 'the caret is blinking');
+
+  // the first paint off the wire before the close, so the timer is the only
+  // thing left that can talk to the connection
+  await new Promise((resolve) => root.app.X.GetInputFocus(() => resolve()));
+  await root.app.close();
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  assert.strictEqual(
+    input._blinkTimer,
+    null,
+    'the first tick on a closing connection disarms the timer',
   );
 });


### PR DESCRIPTION
Master CI has been failing intermittently on the Node 20 job — runs on 2026-08-12, 2026-08-13 and twice on 2026-08-14, always the same file:

```
Test "the selection highlight costs the same however much is selected"
at test/selection-batch.test.js:106:1 generated asynchronous activity after
the test ended. This activity created the error "Error: client is in closing state"
```

Node 22 and 24 never produce the error at all. The Node 20 runner is simply slow enough for the timing to land: that file takes 1.6s there against 378ms locally.

## The bug

A repaint is scheduled a tick before it is painted, and the connection can go in between — an app closing its own client, a server exit, a test closing the app it lent the root. Nothing unmounts the tree on that route, so the frame arrives with a live window node and a dead socket, and the first request it makes throws `client is in closing state` synchronously out of `x11`. Nothing wraps the frame clock, so it surfaces as an uncaught exception.

`test/selection-batch.test.js` focuses a `<textarea>` and closes the app without unmounting. `defaultFocus` arms a 530ms caret-blink interval and a close never blurs the field, so the tick after `close` invalidates, flushes and throws — with no test still running to attribute it to.

The blink timer is the loudest source rather than the only one: the `invalidate` that `defaultFocus` queues for itself throws the same way from `_paintWindowBackground` if the close lands between the schedule and the flush.

Reproduced standalone: focus a field, close the app, wait — `UNCAUGHT: client is in closing state`.

## The fix

Two guards, both following the pattern already in `nodes.js` for `appearanceChanged` and `_syncWindowBackground`:

- `WindowNode.flush` returns on a closing connection, alongside the destroyed and unrealized cases it already returns on. This is the chokepoint every scheduled repaint passes through, so it covers the sources that are not the caret.
- The blink interval disarms itself on the first tick after the connection goes, rather than ticking twice a second forever against a dead socket.

## Testing

- A regression test in `test/create-root.test.js`. Mutation-checked: removing either guard alone fails it.
- Full suite: 1349 pass, 6 fail — those six are the pre-existing macOS-only `appearance.test.js` failures, which pass in CI.
- `prettier --check .` and `eslint .` clean.