### PR TITLE
feat(yoga): give the layout engine a public home

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1346,6 +1346,7 @@ not create. Three things it has to do that a GL surface does not:
 | `react-x11/host`    | `registerElement`, `unregisterElement`, `registeredElements`, `hostTypes`, `knownElements`, `drawnKinds` |
 | `react-x11/node`    | `Node`, the built-in node classes, `Scrollable`, `intrinsicSize`                                         |
 | `react-x11/style`   | `createStyles`, `flattenStyle`, `isStyleProp`, `resolveTokens`, the rest of the vocabulary               |
+| `react-x11/yoga`    | the layout engine — `Yoga`, `loadLayout`, `layoutLoaded`. Rarely needed; see below                       |
 | `react-x11/ntk`     | ntk itself, re-exported — `Surface`, `Path2D`, `Image`, `Pixmap`, the font sources, `createClient`       |
 | `react-x11/keysyms` | the `XK_*` constants, `keysymOf`, `charOf`, `MOD`, `ctrlChordLetter`                                     |
 
@@ -1354,11 +1355,38 @@ of ntk in one process means two font caches and two glyph atlases, and a
 node built against one cannot be painted by the other — a failure that
 looks like a drawing bug rather than a dependency bug.
 
-The layout engine is not among these entry points, and that is deliberate:
+**An element does not need the layout engine, and that is deliberate.**
 `measureContent` is handed its constraints in words (`'exactly'`,
 `'at-most'`, `'unconstrained'`) rather than yoga's integers, so an element
-never links against the engine and yoga's ABI never becomes part of this
-seam.
+never links against it and yoga's ABI never becomes part of this seam. If you
+are writing an element and reaching for `react-x11/yoga`, the answer is
+almost certainly `measureContent`.
+
+`react-x11/yoga` is for the case that is genuinely different: a package
+implementing a **layout algorithm of its own** that wants to delegate part of
+it. `@react-x11/components`'s `<Html>` is the worked example — its
+`display: flex` builds a small yoga tree, asks it, and reads the answer back
+rather than re-deriving flexbox, which is long, subtle, and silently wrong
+when it is wrong.
+
+Such a package must use **this** engine rather than its own `yoga-layout`
+dependency, for the same reason it must reach ntk through `react-x11/ntk`:
+two instances are two WebAssembly modules, and a node created by one cannot
+be inserted into a tree owned by the other. That failure surfaces as a crash
+inside the engine, naming nothing you wrote.
+
+```ts
+import { Yoga, loadLayout } from 'react-x11/yoga';
+
+await loadLayout(); // createRoot() has already done this inside an app
+const root = Yoga.Node.create();
+root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
+```
+
+The enum constants are readable from the first tick; `Node` and `Config`
+throw until the assembly is loaded, which `createRoot()` awaits before it
+builds anything (docs/packaging.md explains why it is loaded rather than
+imported).
 
 ## Typing
 

--- a/package.json
+++ b/package.json
@@ -138,6 +138,10 @@
       "types": "./src/style.d.ts",
       "default": "./src/style.js"
     },
+    "./yoga": {
+      "types": "./src/yoga.d.ts",
+      "default": "./src/yoga.js"
+    },
     "./ntk": {
       "types": "./src/ntk.d.ts",
       "default": "./src/ntk.js"

--- a/src/yoga.d.ts
+++ b/src/yoga.d.ts
@@ -1,0 +1,55 @@
+/**
+ * `react-x11/yoga` — the layout engine the renderer lays every box out with.
+ *
+ * **Most extensions never need this.** An element measures through
+ * `measureContent`, which is handed its constraints in words (`'exactly'`,
+ * `'at-most'`, `'unconstrained'`) rather than yoga's integers, precisely so
+ * that yoga's ABI does not become part of the extension seam — see
+ * [extending.md](../docs/extending.md).
+ *
+ * What this entry point is for is the other case: a package implementing a
+ * **layout algorithm of its own** and wanting to delegate part of it. The
+ * worked example is `@react-x11/components`'s `<Html>`, whose `display: flex`
+ * builds a small yoga tree, asks it, and reads the answer back rather than
+ * re-deriving flexbox by hand.
+ *
+ * Such a package must use **this** engine rather than its own `yoga-layout`
+ * dependency. Two instances mean two WebAssembly modules, and a node created
+ * by one cannot be inserted into a tree owned by the other — a failure that
+ * surfaces as a crash inside the engine, naming nothing the author wrote.
+ *
+ * The engine is loaded, not imported: `createRoot()` awaits `loadLayout()`
+ * before it builds anything, which is what keeps a top-level await out of
+ * every bundle containing react-x11 (docs/packaging.md). The enum constants
+ * are readable from the first tick regardless; `Node` and `Config` throw
+ * until the assembly is in place.
+ */
+import type { Yoga as YogaAssembly } from 'yoga-layout/load';
+
+export type { Config, MeasureFunction, Node } from 'yoga-layout/load';
+
+/**
+ * yoga's assembly — `Node.create()`, `Config`, and the rest — plus the flat
+ * `SCREAMING_CASE` enum constants (`EDGE_LEFT`, `FLEX_DIRECTION_ROW`,
+ * `MEASURE_MODE_AT_MOST`, …) that `styles.js` builds its lookup tables from.
+ *
+ * The constants are typed loosely because they are generated from yoga's
+ * typed enums at import time rather than declared; for a checked alternative,
+ * import the enums themselves from `yoga-layout/load` — they are plain
+ * JavaScript and carry no WebAssembly with them.
+ */
+export type LayoutEngine = YogaAssembly & Record<string, number>;
+
+export const Yoga: LayoutEngine;
+export default Yoga;
+
+/**
+ * Load the engine's WebAssembly. Idempotent, and resolves with the same
+ * `Yoga` object this module exports. `createRoot()` awaits it, so an
+ * application rarely calls it — code that builds nodes outside a root (a test
+ * harness over the mock app) needs it first.
+ */
+export function loadLayout(): Promise<LayoutEngine>;
+
+/** Whether the assembly is in place — `Yoga.Node` will not throw. */
+export function layoutLoaded(): boolean;

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -1278,3 +1278,18 @@ void _badSelectable;
 void _badSelectionHandler;
 void _badSlider;
 void _badTabs;
+
+// `react-x11/yoga` — the engine, for a package that implements a layout
+// algorithm of its own (@react-x11/components' <Html> and its `display: flex`).
+// An *element* never needs this: measureContent speaks in words.
+import { Yoga as LayoutYoga, loadLayout } from 'react-x11/yoga';
+const _engine: Promise<unknown> = loadLayout().then(() => {
+  const node = LayoutYoga.Node.create();
+  node.setWidth(120);
+  node.calculateLayout(120, 40, LayoutYoga.DIRECTION_LTR);
+  const w: number = node.getComputedWidth();
+  node.freeRecursive();
+  return w;
+});
+// the flat enum constants are numbers
+const _edge: number = LayoutYoga.EDGE_LEFT;


### PR DESCRIPTION
Fixes `The requested module 'react-x11/ntk' does not provide an export named
'Yoga'` — which is `@react-x11/components` master, red against this repo's
master since #315.

## What #315 got wrong

It removed `Yoga` from `react-x11/ntk` arguing that an element never needs the
engine. That is right, and incomplete.

Right: `measureContent` is handed its constraints in words (`'exactly'`,
`'at-most'`, `'unconstrained'`) rather than yoga's integers, specifically so
yoga's ABI does not become part of the element seam. An element reaching for
the engine is nearly always a `measureContent` it has not found yet.

Incomplete: a package implementing a **layout algorithm of its own** is a
different case, and there is a real one.
`@react-x11/components`'s `<Html>` delegates `display: flex` to a small yoga
tree rather than re-deriving flexbox — the right call, since flexbox is long,
subtle (`flex-basis: auto` vs `content`, min-size floors, `align-content`),
and silently wrong when it is wrong. It had been reaching through
`react-x11/ntk`, and #315 took that away.

## `react-x11/yoga`

```ts
import { Yoga, loadLayout } from 'react-x11/yoga';

await loadLayout(); // createRoot() has already done this inside an app
const root = Yoga.Node.create();
root.setFlexDirection(Yoga.FLEX_DIRECTION_ROW);
```

The honest name: the engine is not ntk's any more, so putting it back on
`react-x11/ntk` would be true only of where it used to live.

The constraint is the one `react-x11/ntk` already documents for ntk itself —
**use this engine, not a second `yoga-layout`**. Two instances are two
WebAssembly modules, and a node created by one cannot be inserted into a tree
owned by the other; that surfaces as a crash inside the engine, naming nothing
the author wrote. `docs/extending.md` now says so, and leads with the
"you probably want `measureContent`" case so the entry point does not read as
an invitation.

Typed against yoga's own declarations (`Node`, `Config`, `MeasureFunction` are
re-exported) rather than as the loose record `react-x11/ntk` used, so a
consumer can drop the hand-written node interface it otherwise has to write —
which is exactly what `flex.ts` did.

## Why now rather than after

`chore(master): release 2.0.0` (#69) is open and unmerged. 2.0.0 is the
version `@react-x11/components` will adopt — its `peerDependencies` already
say `^2.0.0`. If this lands first, 2.0.0 is one coherent release: the engine
moved here *and* has a public home. If it lands after, components adopts a
2.0.0 it cannot build against.

This is also why it goes before ntk's
[sidorares/ntk#269](https://github.com/sidorares/ntk/pull/269), though the two
are independent — #269 touches nothing here, and ntk has no `Yoga` export
either way.

## Verification

- `npm test` — 1347 pass, 6 fail (the pre-existing darwin-only appearance
  failures: the ladder finds macOS's native source before the XSETTINGS rung)
- `npm run typecheck` — clean, with the new subpath exercised in
  `test/types/api.tsx`: `Node.create()`, `calculateLayout`, a computed width
  and a flat enum constant, all without a cast
- `npm run lint` — clean
- runtime smoke: the enums read before `loadLayout()`, `layoutLoaded()` flips,
  and a node lays out after

## Follow-up

`@react-x11/components` then bumps its `react-x11` pin to a commit with this
subpath and changes the one import in `src/html/layout/flex.ts`. Its master is
green today only because the pin holds it at a commit predating #315.