### PR TITLE
feat(registry): re-registration policy for hot reload — the same definition does not throw

### DIFF
--- a/docs/ecosystem/dev-tooling.md
+++ b/docs/ecosystem/dev-tooling.md
@@ -146,10 +146,15 @@ What is _not_ enforced, so it is not rediscovered as a bug:
 - **Module-scope side effects re-run on every reload** of the module and
   of everything between it and its boundary. Keep hot modules'
   top level idempotent, and keep identity that must survive (contexts,
-  stores, `registerElement` calls) in modules outside the hot graph — via
-  the `ignore` seam or by extension. A re-registration policy so a
-  reloaded `registerElement` does not throw is
-  [#318](https://github.com/sidorares/react-x11/issues/318).
+  stores) in modules outside the hot graph — via the `ignore` seam or by
+  extension. `registerElement` at module scope is safe: once the first hot
+  re-import begins, a duplicate registration replaces silently instead of
+  throwing (the
+  [re-registration policy](../extending.md#hot-reload)) — mounted nodes keep the old
+  prototype until they remount, the same staleness contract Fast Refresh
+  has for classes. Remember the named-import rule applies to it like
+  anything else: call it as `Host.registerElement(...)` through a
+  namespace or default import.
 - Stack traces through hot modules are off by the prelude's lines (four,
   plus your own `prelude` entries). Dev-only.
 - Fast Refresh needs the dev reconciler; `NODE_ENV=production` is a

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -77,6 +77,31 @@ precedent: on a `<window>` it is the X window's width and never style.
 `react-x11/style`'s `isStyleProp(name)` is how to check whether a name you
 are about to use needs declaring.
 
+## Registering under hot reload {#hot-reload}
+
+Register at module scope — the pattern everything above shows, and the one
+tree-shaking forces on a component library. That module scope re-runs when
+[`react-x11/refresh`](ecosystem/dev-tooling.md#react-refresh) hot-reloads
+the module, so `registerElement` has a re-registration policy rather than
+a footnote:
+
+- **The same `create` reference is never a conflict.** A definition
+  arriving twice replaces silently, latest flags winning.
+- **Under an active hot-reload session, any duplicate replaces silently.**
+  The session begins with the first hot re-import and covers the rest of
+  the process: from then on, "already registered" would only mean
+  "registered by the previous version of yourself". Mounted nodes keep the
+  old prototype until they remount — the same staleness contract Fast
+  Refresh has for classes; new mounts get the new definition.
+- **Outside a session, a duplicate still throws.** Two packages claiming
+  one element name in a plain run is a conflict to be told about, and
+  `override: true` remains the way to say a replacement is deliberate.
+
+One thing the hot loader adds: inside a hot module, call it through a
+namespace or default import (`Host.registerElement(...)`) — a _named_
+import called at module top level is a transform error there, because
+named-import bindings initialize in a microtask after a reload.
+
 ## The node contract
 
 `Node` already implements the whole reconciler-facing surface, so an element

--- a/src/refresh/loader.js
+++ b/src/refresh/loader.js
@@ -26,6 +26,7 @@
 import { readFileSync } from 'node:fs';
 import * as nodeModule from 'node:module';
 import { fileURLToPath } from 'node:url';
+import { markHotReloadSession } from '../registry.js';
 
 const RUNTIME_URL = new URL('./index.js', import.meta.url).href;
 const SRC_DIR = fileURLToPath(new URL('../', import.meta.url));
@@ -371,6 +372,12 @@ export async function registerRefresh(options = {}) {
       if (!url.startsWith('file:')) {
         return nextLoad(url, context);
       }
+      // A ?hmr=N request is a hot re-import about to re-run a module
+      // scope. Told to the registry *before* the module evaluates — the
+      // first reloaded module may itself call registerElement at top
+      // level — and checked on every extension, because a chain reload
+      // re-imports plain .js modules this hook does not transform.
+      if (/[?&]hmr=\d+/.test(url)) markHotReloadSession();
       const fileUrl = new URL(url);
       fileUrl.search = ''; // hot-module-replacement cache-busts with ?hmr=N
       if (!transformer.matches(fileUrl.pathname)) {

--- a/src/registry.js
+++ b/src/registry.js
@@ -36,6 +36,26 @@ const registry = new Map();
 
 const RESERVED = new Set(['textchunk', 'svgchild']);
 
+// The re-registration policy for hot reload (issue #318). Module-scope
+// registration is the pattern the docs recommend and tree-shaking forces on
+// component libraries, and a hot re-import runs that module scope again —
+// so under an active reload session a duplicate registration replaces
+// silently instead of throwing. The flag is flipped by react-x11/refresh's
+// loader the moment the first hot re-import is compiled (before it
+// evaluates, so the first reloaded module's own registerElement is already
+// covered), and never outside a hot dev loop — a plain run still hears
+// about two packages claiming one name. It stays one-way on purpose: after
+// the first reload every registration may be a re-run of code that
+// registered before, and there is no later moment at which that stops
+// being true. The setter takes `false` only so tests can restore the
+// default; nothing else should ever pass it.
+let hotReloadSession = false;
+
+/** @internal — called by react-x11/refresh; not part of the public API. */
+export function markHotReloadSession(active = true) {
+  hotReloadSession = active;
+}
+
 function assertNode(node, type) {
   if (!(node instanceof Node)) {
     throw new Error(
@@ -126,11 +146,24 @@ export function registerElement(type, definition) {
     );
   }
   if (registry.has(type) && !definition.override) {
-    throw new Error(
-      `react-x11: <${type}> is already registered. Pass { override: true } ` +
-        'if replacing it is deliberate — two packages claiming one element ' +
-        'name is usually not.',
-    );
+    // Identical re-registration — the same create() reference — is the
+    // same definition arriving twice (a module evaluated twice, a test
+    // registering in a loop) and never a conflict; the latest flags win.
+    // Everything else is a real collision unless a hot-reload session is
+    // re-running module scopes, which is the one loop where "already
+    // registered" means "registered by the previous version of yourself".
+    // Mounted nodes keep the old prototype until they remount — the same
+    // staleness contract React Refresh has for classes.
+    const identical = registry.get(type).create === definition.create;
+    if (!identical && !hotReloadSession) {
+      throw new Error(
+        `react-x11: <${type}> is already registered. Pass { override: true } ` +
+          'if replacing it is deliberate — two packages claiming one element ' +
+          'name is usually not. (Under hot reload a module re-registering ' +
+          'its own elements replaces them silently; this error means two ' +
+          'different definitions collided outside any reload.)',
+      );
+    }
   }
 
   const {

--- a/test/fixtures/refresh/app.jsx
+++ b/test/fixtures/refresh/app.jsx
@@ -1,14 +1,37 @@
 // Hot module for the refresh e2e test. The test rewrites the VERSION
 // constant below and asserts the same useState id turns up with the new
 // version — hook state survived, code did not.
+//
+// The module also registers a host element at module scope — the pattern
+// tree-shaking forces on component libraries — so a reload exercises the
+// re-registration policy (#318): the second evaluation registers a new
+// create() under the same name and must replace silently, not throw.
+// Namespace imports, because inside a hot module only default/namespace
+// bindings initialize synchronously.
 import React from 'react';
+import * as Host from '../../../src/host.js';
+import * as XNode from '../../../src/node.js';
 
 const VERSION = 'v1';
+
+class BadgeNode extends XNode.Node {
+  constructor(props, app) {
+    super('badge', props, app);
+  }
+}
+
+Host.registerElement('badge', {
+  create: (props, app) => new BadgeNode(props, app),
+});
 
 export default function App() {
   const [id] = React.useState(() => Math.random().toString(36).slice(2, 10));
   React.useEffect(() => {
     console.log(`RENDER ${id} ${VERSION}`);
   });
-  return <box style={{ width: 60, height: 24, backgroundColor: '#3498db' }} />;
+  return (
+    <box style={{ width: 60, height: 24, backgroundColor: '#3498db' }}>
+      <badge style={{ width: 10, height: 10 }} />
+    </box>
+  );
 }

--- a/test/register-element.test.js
+++ b/test/register-element.test.js
@@ -204,6 +204,44 @@ test('the registry refuses names that could not work, and silent clashes', () =>
   });
 });
 
+// The re-registration policy for hot reload (#318): module-scope
+// registration re-runs on a hot re-import, so it must not collide with
+// itself — while two genuinely different definitions still do.
+test('the same create() reference re-registers without a conflict', () => {
+  const create = (p, a) => new Node('samedef', p, a);
+  register('samedef', { create });
+  // identical definition arriving twice — never a conflict, latest flags win
+  registerElement('samedef', { create, drawn: false });
+  assert.ok(!drawnKinds().includes('samedef'));
+  registerElement('samedef', { create });
+  assert.ok(drawnKinds().includes('samedef'));
+});
+
+test('a hot-reload session replaces module-scope registrations silently', async () => {
+  const { markHotReloadSession } = await import('../src/registry.js');
+  register('hotel', {
+    create: (p, a) => new Node('hotel', p, a),
+    semanticNames: ['size'],
+  });
+  markHotReloadSession();
+  try {
+    // a re-evaluated module registers a *new* create() under the old name
+    registerElement('hotel', { create: (p, a) => new Node('hotel', p, a) });
+    assert.strictEqual(
+      registeredElements().filter((t) => t === 'hotel').length,
+      1,
+    );
+  } finally {
+    markHotReloadSession(false);
+  }
+  // outside the session the collision is loud again
+  assert.throws(
+    () =>
+      registerElement('hotel', { create: (p, a) => new Node('hotel', p, a) }),
+    /already registered/,
+  );
+});
+
 test('a create() that returns the wrong thing is caught at the source', async () => {
   register('wrong', { create: () => ({ kind: 'wrong' }) });
   await rejectsQuietly(


### PR DESCRIPTION
Closes #318. Builds on #321 (`react-x11/refresh`, now on master) — the session flag is flipped from that loader.

## The policy

`registerElement` keeps throwing on duplicates by default — two packages claiming one element name in a plain run is a conflict worth hearing about, and `override: true` stays the deliberate-replacement seam. What changes is the two cases the issue names:

- **An identical re-registration — the same `create` function reference — never throws.** The same definition arriving twice is not a conflict; it replaces, latest flags winning.
- **Under an active hot-reload session, any duplicate replaces silently.** Module-scope registration is the pattern the docs recommend and tree-shaking forces on component libraries (`@react-x11/components` registers six elements this way), and a hot re-import re-runs that module scope. Mounted nodes keep the old prototype until they remount — the same staleness contract Fast Refresh already has for classes; new mounts get the new definition.

## When is a session "active"

The refresh **loader** marks it (`markHotReloadSession()`, an internal seam on `src/registry.js`) the moment it sees the first `?hmr=N` re-import in its load hook — **before** that module evaluates, so the first reloaded module's own top-level `registerElement` is already covered, and on every extension, because a chain reload re-imports plain `.js` modules the babel stage does not transform. The flag is one-way by design: after the first reload, every registration may be a re-run of code that registered before, and there is no later moment at which that stops being true. It never turns on outside the hot dev loop, so initial-load collisions still throw even under the refresh loader — this is deliberately narrower than the rejected dev-mode-global alternative.

## Tests

- `test/register-element.test.js` — two new cases: the same-reference tolerance (with flag replacement verified through `drawnKinds()`), and the session behavior including "outside the session the collision is loud again".
- `test/refresh-hot.test.js` — the e2e fixture now registers a `<badge>` element at module scope (through a namespace import, as the loader's own named-import rule requires) and renders it, so the existing edit-reload-assert cycle exercises exactly the scenario the issue describes. Mutation-checked: removing the loader's `markHotReloadSession` call fails the e2e with the `already registered` error.

## Docs

- `docs/extending.md` gains a "Registering under hot reload" section (the three rules, the staleness contract, and the namespace-import note).
- `docs/ecosystem/dev-tooling.md`'s module-scope-side-effects bullet now states the policy instead of pointing at the open issue.
- The duplicate-registration error message gained a parenthetical distinguishing the reload case from a real collision.
