### PR TITLE
feat(focus): focus follows visibility, so a hidden subtree stops taking keys

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,16 @@ no override-redirect staging (issue #4).
   event, XI2 valuators where the server has them and buttons 4-7 where it
   does not, converted from notches to pixels here (#273) — focus/Tab).
   Three ancestor-chain diffs live here and share one shape — `:hover`,
-  `:active` over the press chain, and `:focus-within`.
+  `:active` over the press chain, and `:focus-within`. **Focus follows
+  visibility** (#202): a subtree that goes off the screen — `hideInstance`
+  for `<Suspense>`/`<Activity>`, a `display: 'none'`, a `<popup>` unmapped —
+  gives up the keyboard, and gets it back on the reveal unless something
+  else took it meanwhile. Two things about that are easy to undo. The
+  question is _containment_, since React only hides the topmost host
+  instance of a branch and the focused control is usually deeper; and the
+  restore is not a navigation — it neither scrolls nor calls `SetInputFocus`,
+  because a background window revealing something must not take the keyboard
+  off another application.
 - `src/clientmessage.js` — `<window onClientMessage>`: the element-scoped
   seam for the protocols X layers on ClientMessage (EWMH, XEmbed, the system
   tray), where the alternative was `X.on('event')` over the whole connection

--- a/docs/events.md
+++ b/docs/events.md
@@ -511,6 +511,31 @@ when the window is focused again. Calling `focus()` on a node in a window
 that does not have the input focus asks for it (X `SetInputFocus`), though
 a window manager is free to refuse.
 
+### Focus and visibility
+
+**Focus follows visibility.** A subtree that goes off the screen gives up
+the keyboard: a `<Suspense>` boundary showing its fallback, an `<Activity
+mode="hidden">`, a `display: 'none'`, a `<popup>` being unmapped. The
+focused node fires `onBlur`, `:focus`/`:focus-within` come off, and keys go
+to the window instead — because a control nobody can see must not be
+collecting keystrokes, and the application's state must not advance from
+them. Tab skips invisible nodes for the same reason.
+
+**And it comes back with it.** When the subtree is revealed, focus returns
+to where it was, ring and all, so a boundary that re-suspended mid-edit
+leaves the user typing where they were. Two rules keep that from being
+focus stealing:
+
+- it only happens when **nothing else has the keyboard** — anything focused
+  while the subtree was away keeps focus;
+- it is a restore rather than a navigation: no scrolling into view, and no
+  X `SetInputFocus`, so a background window revealing something never takes
+  the keyboard off another application.
+
+`createRoot({ restoreFocusOnReveal: false })` turns the second half off, for
+an app that wants the browser's answer — focus that fell to nothing stays
+there, and coming back is the user's own Tab. The release is not optional.
+
 ## Cursors
 
 The `cursor` style property (`'pointer'`, `'text'`, `'wait'`, `'move'`,

--- a/docs/react-features.md
+++ b/docs/react-features.md
@@ -218,6 +218,13 @@ to the fallback and jumps back on reveal.
 </Suspense>
 ```
 
+**Focus goes with the hidden tree and comes back with it.** A field inside
+the boundary gives up the keyboard when the fallback appears — nothing
+invisible collects keystrokes — and gets it back on the reveal unless
+something else took focus meanwhile, so a boundary that re-suspends
+mid-edit does not drop the user out of what they were typing. See
+[events.md](events.md#focus-and-visibility) for the rules and the way out.
+
 If a `<window>` is inside the boundary, hiding it **unmaps the real window**.
 The window manager treats the reveal as a new window: it may re-place it,
 restack it, or apply its own geometry, and anything the user did to it can be
@@ -379,9 +386,12 @@ unaffected and work normally.
 
 Open bugs where a React feature does not yet mean here what it should:
 
-- [#202](https://github.com/sidorares/react-x11/issues/202) — hiding a
-  subtree with `<Suspense>` or `<Activity>` does not move focus out of it, so
-  a focused control keeps receiving keystrokes while invisible.
+- A `<popup>` written inside a subtree that `<Suspense>` or `<Activity>`
+  hides stays on screen: React hides the topmost host instance of the branch
+  and the popup is its own X window below it, so nothing unmaps it. Focus
+  follows what is actually visible, so the popup keeps the keyboard — but
+  the popup itself has to be conditional in your JSX rather than left to the
+  boundary.
 - The bundled types declare `invalidate()` on every node; at runtime only the
   owning `<window>` has it. Reach it as `ref.current.root` — or better, drive
   repaints through props and `cacheKey`.

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -43,6 +43,7 @@ import {
 import { hooks as a11yHooks, startA11y } from './a11y.js';
 import { beginStartup } from './startup.js';
 import { beginCompose } from './compose.js';
+import { beginFocus } from './events.js';
 import { beginKeyboard } from './keyboard.js';
 import { beginCompositing, endCompositing } from './compositing.js';
 import { beginScreens, endScreens } from './screens.js';
@@ -712,6 +713,12 @@ export async function createRoot(options = {}) {
   // process, and only `compose: 'system'` or a file of your own reads
   // anything from disk.
   beginCompose(app, rest.compose);
+
+  // Whether a subtree coming back out of hiding — a `<Suspense>` boundary
+  // resolving, an `<Activity>` shown again — takes the keyboard back with it
+  // (src/events.js, `subtreeRevealed`). On by default; `false` is the
+  // browser's answer, where focus stays wherever the hide dropped it.
+  beginFocus(app, rest.restoreFocusOnReveal);
 
   // Which keysym a shortcut matches when the layout is not Latin
   // (src/keyboard.js). Pure bookkeeping — the work happens per key event,

--- a/src/a11y.js
+++ b/src/a11y.js
@@ -782,8 +782,9 @@ const bit = (states, state) => {
 };
 
 /** True when the node and every ancestor up to its window is neither
- * `hidden` nor `display: 'none'`. */
-function effectivelyVisible(node) {
+ * `hidden` nor `display: 'none'`. Shared with the focus manager, which
+ * releases focus on exactly this answer turning false (src/events.js). */
+export function effectivelyVisible(node) {
   for (let n = node; n; n = n.parent) {
     if (n.destroyed || n.hidden || n.style?.display === 'none') return false;
     if (n.isWindow) break;

--- a/src/events.js
+++ b/src/events.js
@@ -1118,9 +1118,25 @@ export class EventManager {
     const focused = this.focused;
     // focus only comes back if it was inside the scope that just closed
     if (focused && !this._within(focused, node)) return;
-    const restore = scope.restore;
-    const alive = restore && !restore.destroyed && this._isFocusable(restore);
-    this.focus(alive ? restore : null);
+    this.focus(this._canRestoreTo(scope.restore) ? scope.restore : null);
+  }
+
+  /**
+   * Somewhere focus can be handed *back* to: still in the tree, still
+   * focusable, and still on screen.
+   *
+   * Three callers ask it — a focus scope closing, an edit menu closing
+   * (`closeEditMenu`, nodes.js) and a subtree coming out of hiding — and the
+   * third is why the question includes visibility. Whatever a modal was
+   * opened from may have suspended while it was up, and handing the keyboard
+   * back to it would put keys on an invisible control by the other route.
+   *
+   * "Still in the tree" is part of the same answer rather than a check of its
+   * own: `effectivelyVisible` starts at `destroyed`, since a node that has
+   * left is not on screen either.
+   */
+  _canRestoreTo(node) {
+    return Boolean(node && this._isFocusable(node) && effectivelyVisible(node));
   }
 
   /** The innermost live focus scope, or the window node when there is none.
@@ -1283,12 +1299,12 @@ export class EventManager {
     this._hiddenFocus.delete(node);
     if (this.focused) return;
     if (!restoresFocusOnReveal(this.node.app)) return;
-    const target = was.node;
     // it may have been unmounted, or hidden again by something inside the
     // subtree, while it was away
-    if (target.destroyed || !effectivelyVisible(target)) return;
-    if (!this._isFocusable(target)) return;
-    this.focus(target, was.visible ? 'script' : 'pointer', { restoring: true });
+    if (!this._canRestoreTo(was.node)) return;
+    this.focus(was.node, was.visible ? 'script' : 'pointer', {
+      restoring: true,
+    });
   }
 
   /** Called when a node leaves the tree so stale references don't linger. */

--- a/src/events.js
+++ b/src/events.js
@@ -13,7 +13,7 @@ import { callHandler } from './errors.js';
 import { armDrag } from './dnd.js';
 import { desktopSettings } from './desktopsettings.js';
 import { noteInputTime } from './inputtime.js';
-import { hooks as a11yHooks, isFocusable } from './a11y.js';
+import { hooks as a11yHooks, isFocusable, effectivelyVisible } from './a11y.js';
 import { Composer, composeTableFor } from './compose.js';
 import { acceleratorKeysym } from './keyboard.js';
 import { MOD } from './keysyms.js';
@@ -142,6 +142,20 @@ export function setInspectHandler(fn) {
 }
 
 /**
+ * `createRoot({ restoreFocusOnReveal })`: whether a subtree coming back
+ * brings the keyboard back with it (`EventManager.subtreeRevealed`).
+ */
+export function beginFocus(app, option) {
+  if (app) app._reactX11RestoreFocus = option !== false;
+}
+
+/** Defaults to on for an app that never went through `createRoot` — a mock,
+ * a unit test — the way `composeTableFor` falls back to the built-ins. */
+function restoresFocusOnReveal(app) {
+  return app?._reactX11RestoreFocus ?? true;
+}
+
+/**
  * Wrap an ntk event callback for a *discrete* event — one whose response is
  * a single visual state, so there is nothing a frame's wait could coalesce
  * it with. That is everything ntk does not coalesce: mousedown/mouseup,
@@ -190,6 +204,9 @@ export class EventManager {
     this._previousFocus = null;
     // focus scopes, innermost last: [{ node, restore }]
     this.scopes = [];
+    // what focus to hand back to a subtree that comes out of hiding, keyed by
+    // the node that hid: hidden node → { node, visible } (subtreeHidden)
+    this._hiddenFocus = new WeakMap();
     // resolved lazily for popups: the manager that owns focus (focusManager)
     this._focusOwner = null;
     // the dead-key/Compose state machine, built on the first key (undefined
@@ -994,10 +1011,15 @@ export class EventManager {
    * back-Tab, because that is what tells an embedded client whether to focus
    * its first widget or its last (`<foreign>`, src/foreignnodes.js). It
    * reaches the node through `defaultFocus({ reason, backwards })`.
+   *
+   * `restoring` says this is a subtree coming back out of hiding rather than
+   * focus going somewhere new (`subtreeRevealed`), and it turns off the two
+   * things that move the world to meet the node.
    */
-  focus(node, reason = 'script', backwards = false) {
+  focus(node, reason = 'script', options = {}) {
     const manager = this.focusManager;
-    if (manager !== this) return manager.focus(node, reason, backwards);
+    if (manager !== this) return manager.focus(node, reason, options);
+    const { backwards = false, restoring = false } = options;
     if (node === this.focused) return;
     // before `focused` moves, so the element that was collecting the
     // sequence is the one told to drop it
@@ -1020,11 +1042,17 @@ export class EventManager {
       old.root?.invalidate(false, old, 'focus');
     }
     if (node) {
-      // keys only reach a node whose window has the X focus
-      if (!this.windowFocused) this.node.window?.focus?.();
+      // keys only reach a node whose window has the X focus — but a restore
+      // must not *take* it: a window revealing something in the background
+      // would pull the keyboard off another application, and SetInputFocus
+      // on a window the reveal has not mapped yet is a BadMatch.
+      if (!this.windowFocused && !restoring) this.node.window?.focus?.();
       node.setStyleState(':focus', true);
       node.setStyleState(':focus-visible', reason !== 'pointer');
-      this._scrollIntoView(node);
+      // …and nothing scrolls to meet it either: the node is coming back to
+      // the arrangement it left, and this reveal's layout has not run, so a
+      // scroll here would be computed from a rect that does not exist yet.
+      if (!restoring) this._scrollIntoView(node);
       if (this.windowFocused) node.defaultFocus?.({ reason, backwards });
       node.props.onFocus?.(this._makeEvent('focus', null, node));
       node.root?.invalidate(false, node, 'focus');
@@ -1134,11 +1162,15 @@ export class EventManager {
   /** Focusable nodes in tree order, from `root` down. Windows are their own
    * focus roots, so a nested `<window>` or `<popup>` is not walked into —
    * except when it _is_ the root, which is how a modal popup's own
-   * focusables are reached. */
+   * focusables are reached.
+   *
+   * Invisible either way is invisible: `display: 'none'` takes a subtree out
+   * of the layout, the paint and the hit test, so Tab has no business
+   * landing in it either. */
   _focusables(root = this._scopeRoot()) {
     const out = [];
     const walk = (node) => {
-      if (node.hidden) return;
+      if (node.hidden || node.style.display === 'none') return;
       if (this._isFocusable(node)) out.push(node);
       for (const child of node.children) {
         if (!child.isWindow) walk(child);
@@ -1173,7 +1205,9 @@ export class EventManager {
     const index = list.indexOf(this.focused);
     if (index === -1) {
       // nothing focused, or focus sits outside the current scope: Tab enters
-      this.focus(backwards ? list[list.length - 1] : list[0], 'key', backwards);
+      this.focus(backwards ? list[list.length - 1] : list[0], 'key', {
+        backwards,
+      });
       return;
     }
     this.focus(
@@ -1181,8 +1215,80 @@ export class EventManager {
         ? list[(index || list.length) - 1]
         : list[(index + 1) % list.length],
       'key',
-      backwards,
+      { backwards },
     );
+  }
+
+  /**
+   * A subtree just stopped being visible: `<Suspense>` showing its fallback,
+   * `<Activity mode="hidden">`, or a style that turned `display: 'none'`.
+   *
+   * **Focus follows visibility.** Every other route already read it that way
+   * — `hitTest` and `paintOrder` skip the node, `_focusables` will not Tab
+   * into it — and focus was the one left open, so keys kept landing on a
+   * control the user could no longer see and the application's state kept
+   * advancing from them (issue #202). In a browser the browser plays this
+   * part; here nobody did.
+   *
+   * The question is **containment**, not identity. React calls `hideInstance`
+   * on the topmost host instance of a hidden branch, so in any tree deeper
+   * than one node the focused control still has `hidden === false` itself and
+   * is invisible only because a yoga ancestor is `DISPLAY_NONE` — the same
+   * question `popScope` asks on the way out of a modal. `effectivelyVisible`
+   * is the second half of it, and it is what tells a `<box>` inside the
+   * hidden node from a `<popup>` hanging off it: a popup is its own X window,
+   * nothing unmapped it, and it is still on screen holding the keyboard.
+   */
+  subtreeHidden(node) {
+    const manager = this.focusManager;
+    if (manager !== this) return manager.subtreeHidden(node);
+    const focused = this.focused;
+    if (!focused || !node.contains(focused)) return;
+    if (effectivelyVisible(focused)) return;
+    // Ring included: a restore puts back the state hiding took away rather
+    // than making a new focus, and whether the user could see where focus
+    // was is part of that state.
+    this._hiddenFocus.set(node, {
+      node: focused,
+      visible: focused.states[':focus-visible'] === true,
+    });
+    this.focus(null);
+  }
+
+  /**
+   * …and the way back, which is the half that is a decision rather than a
+   * bug fix.
+   *
+   * It restores. `<Activity>` exists to keep what a hidden subtree had, and a
+   * boundary re-suspending is not something the user did — so a field they
+   * were typing in comes back focused and they carry on, instead of being
+   * silently dropped out of it by a fallback that flashed.
+   *
+   * Two rules keep that from being focus stealing, and they are what make the
+   * restore safe enough to be the default. It only happens when **nothing
+   * else has the keyboard**: anything focused while the subtree was away
+   * keeps focus, so a reveal somewhere the user is not looking can never take
+   * over what they are doing. And it is a *restore* rather than a navigation
+   * — no scroll, no pull on the X input focus (see `focus`).
+   *
+   * `createRoot({ restoreFocusOnReveal: false })` is the way out, for an app
+   * that wants the browser's answer: focus that fell to the body stays there,
+   * and coming back is the user's own Tab.
+   */
+  subtreeRevealed(node) {
+    const manager = this.focusManager;
+    if (manager !== this) return manager.subtreeRevealed(node);
+    const was = this._hiddenFocus.get(node);
+    if (!was) return;
+    this._hiddenFocus.delete(node);
+    if (this.focused) return;
+    if (!restoresFocusOnReveal(this.node.app)) return;
+    const target = was.node;
+    // it may have been unmounted, or hidden again by something inside the
+    // subtree, while it was away
+    if (target.destroyed || !effectivelyVisible(target)) return;
+    if (!this._isFocusable(target)) return;
+    this.focus(target, was.visible ? 'script' : 'pointer', { restoring: true });
   }
 
   /** Called when a node leaves the tree so stale references don't linger. */

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -286,6 +286,20 @@ export interface RootOptions {
    *   a character: `{ 52: 'z' }`.
    */
   accelerators?: 'latin' | 'layout' | Record<number, number | string>;
+  /**
+   * Whether a subtree coming back out of hiding takes the keyboard back with
+   * it (docs/events.md, "Focus and visibility"). Default `true`.
+   *
+   * Hiding a subtree — `<Suspense>` showing its fallback, `<Activity
+   * mode="hidden">`, a `display: 'none'` — always releases focus inside it,
+   * since keys must not land on a control nobody can see. Revealing it puts
+   * focus back where it was, but only when nothing else has taken the
+   * keyboard in the meantime.
+   *
+   * `false` is the browser's answer: focus that fell to nothing stays there,
+   * and coming back is the user's own Tab.
+   */
+  restoreFocusOnReveal?: boolean;
 }
 
 export interface ComposeOptions {

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -1479,6 +1479,12 @@ export class Node {
     if (!inThemeWalk && displayed.direction !== this.style.direction) {
       this._redirectSubtree();
     }
+    // `display: 'none'` hides a subtree as completely as React's own flag
+    // does, whether it arrived from a prop, a state block or a size query —
+    // so focus leaves it by the same rule (`_visibilityChanged`).
+    if (displayed.display !== this.style.display) {
+      this._visibilityChanged(this.style.display !== 'none');
+    }
     return this.style;
   }
 
@@ -2230,6 +2236,22 @@ export class Node {
           : Yoga.DISPLAY_FLEX,
       );
     }
+    this._visibilityChanged(!hidden);
+  }
+
+  /**
+   * Whether this subtree is on screen just changed, so focus has to follow
+   * it — released when it goes, handed back when it returns. The rule and
+   * the reasoning live on the focus manager (`subtreeHidden`, events.js);
+   * this is the funnel every route to it comes through: the `hidden` flag
+   * React sets for `<Suspense>`/`<Activity>`, and `display: 'none'` from a
+   * style, a state block or a size query (`_retarget`).
+   */
+  _visibilityChanged(visible) {
+    const events = this._focusManager();
+    if (!events) return;
+    if (visible) events.subtreeRevealed(this);
+    else events.subtreeHidden(this);
   }
 
   /**
@@ -8269,6 +8291,11 @@ export class WindowNode extends Scrollable(Node) {
    */
   setHidden(hidden) {
     this.hidden = hidden;
+    // An unmapped window is off screen however focused the server thinks it
+    // is, and a `<popup>` is worse than that: it shares the owner window's
+    // keyboard, so a node inside one that is no longer on screen would go on
+    // taking keys the owner window is still receiving.
+    this._visibilityChanged(!hidden);
     // A map still queued for the end of this commit reads `hidden` when it
     // runs, so there is nothing to send here — and an unmap sent now would
     // do nothing anyway, the server not having mapped the window yet

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -5090,10 +5090,10 @@ export function closeEditMenu(node) {
   // focus goes back where the menu took it from, so typing carries on where
   // it left off — as a pointer focus, since a right-click is what opened the
   // menu and a ring appearing on the way back would be news to nobody. A
-  // surface that was not focusable in the first place gets nothing back,
-  // rather than the destroyed menu canvas keeping the keyboard.
-  const alive = restore && !restore.destroyed && a11yFocusable(restore);
-  events.focus(alive ? restore : null, 'pointer');
+  // surface that was not focusable in the first place, or that stopped being
+  // on screen while the menu was up, gets nothing back rather than the
+  // destroyed menu canvas keeping the keyboard.
+  events.focus(events._canRestoreTo(restore) ? restore : null, 'pointer');
 }
 
 /**

--- a/test/focus-visibility.test.js
+++ b/test/focus-visibility.test.js
@@ -431,6 +431,55 @@ test('a popup that is still on screen keeps the keyboard', async () => {
   await root.unmount();
 });
 
+test('a modal closing does not hand the keyboard to a field that hid meanwhile', async () => {
+  // The other direction into the same defect: a focus scope hands focus back
+  // to whatever it was opened from, and that panel may have gone away while
+  // the modal was up. Nothing released it — focus was in the modal, not in
+  // the panel — so the restore is the last place that has to ask.
+  let setState;
+  const App = () => {
+    const [{ modal, panel }, set] = React.useState({
+      modal: false,
+      panel: true,
+    });
+    setState = set;
+    return h(
+      'window',
+      { width: 200, height: 140 },
+      h(
+        'box',
+        { style: { display: panel ? 'flex' : 'none' } },
+        h(
+          'box',
+          null,
+          h('textinput', { name: 'behind', autoFocus: true, style: FIELD }),
+        ),
+      ),
+      modal
+        ? h(
+            'popup',
+            { trapFocus: true, x: 10, y: 10, width: 120, height: 60 },
+            h('textinput', { name: 'modal', autoFocus: true, style: FIELD }),
+          )
+        : null,
+    );
+  };
+  const { root, events } = await mount(h(App));
+  assert.equal(focusedName(events), 'behind');
+
+  await flush(() => setState({ modal: true, panel: true }));
+  assert.equal(focusedName(events), 'modal', 'the dialog took the keyboard');
+
+  // the panel behind it goes away while the dialog is up, and the dialog
+  // then closes: the field it would hand focus back to is not on screen
+  await flush(() => setState({ modal: true, panel: false }));
+  await flush(() => setState({ modal: false, panel: false }));
+
+  assert.equal(focusedName(events), null, 'so nothing gets it back');
+
+  await root.unmount();
+});
+
 test('a field unmounted while hidden is not focused when the tree comes back', async () => {
   let setState;
   const App = () => {

--- a/test/focus-visibility.test.js
+++ b/test/focus-visibility.test.js
@@ -1,0 +1,469 @@
+// Focus follows visibility (#202).
+//
+// A `<Suspense>` boundary showing its fallback, an `<Activity mode="hidden">`
+// and a `display: 'none'` all take a subtree off the screen. Every other
+// route already read that: `hitTest` returns null, `paintOrder` drops the
+// node, Tab does not visit it. Focus was the one left open — the focused
+// control kept the keyboard, so keys landed on something the user could not
+// see and the application's state advanced from them.
+//
+// The trap these tests exist for is in the *shape* of the fix: React calls
+// `hideInstance` on the topmost host instance of a hidden branch, so in any
+// tree deeper than one node the focused control still has `hidden === false`
+// itself. Every hide here is therefore at least one level above the field,
+// which is what a fix asking "am I the focused node?" would pass while
+// leaving the bug in place.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+
+import { createRoot } from '../src/index.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+/** React first: a hidden `<Activity>` mounts its children at a deferred lane,
+ * and a boundary that re-suspends commits its fallback on one too, so the
+ * commit under test is not the one `render()` returns from. The flag goes
+ * back afterwards, since the input below is emitted outside `act`. */
+async function flush(fn) {
+  const previous = globalThis.IS_REACT_ACT_ENVIRONMENT;
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  try {
+    await React.act(async () => {
+      await fn?.();
+    });
+  } finally {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = previous;
+  }
+  await tick();
+}
+
+async function mount(element, options) {
+  const app = createMockApp();
+  const root = await createRoot({ app, ...options });
+  await flush(() => root.render(element));
+  const tree = app.windows[0]._reactX11Node;
+  return { app, root, wnd: app.windows[0], tree, events: tree.events };
+}
+
+/** Every node under `node`, its `<popup>` windows included. */
+function all(node, out = []) {
+  out.push(node);
+  for (const child of node.children) all(child, out);
+  return out;
+}
+
+/** Everything here is named, and every assertion about focus is about a
+ * name: `assert.equal` on two nodes inspects the whole retained tree when it
+ * fails, which is twenty seconds and a diff nobody can read. */
+const byName = (tree, name) =>
+  all(tree).find((n) => n.props.name === name) ?? null;
+const focusedName = (events) => events.focused?.props.name ?? null;
+
+/** A click on a node, which is the focus that lights no ring. */
+function press(wnd, node) {
+  const at = {
+    x: node.abs.x + node.abs.width / 2,
+    y: node.abs.y + node.abs.height / 2,
+  };
+  wnd.emit('mousedown', { ...at, keycode: 1 });
+  wnd.emit('mouseup', { ...at, keycode: 1 });
+}
+
+/** Simulate an ntk keydown: bind the keysym to a synthetic keycode and emit
+ * the raw event shape the EventManager consumes. */
+function type(app, wnd, text) {
+  for (const ch of text) {
+    const codepoint = ch.codePointAt(0);
+    const keycode = (codepoint % 248) + 8;
+    app.X.keycode2keysyms[keycode] = [codepoint];
+    wnd.emit('keydown', { keycode, keysym: codepoint, codepoint, buttons: 0 });
+  }
+}
+
+// Text measures 0x0 against the mock, which has no fonts, so a field a press
+// can land on is sized by hand.
+const FIELD = { width: 100, height: 20 };
+
+/** A boundary whose primary tree suspends on demand, around a field that is
+ * two levels below the `<box>` React will hide. */
+function suspendable() {
+  const state = { setSuspend: null, changes: [], blurs: 0, focuses: 0 };
+  const Suspender = ({ suspend }) => {
+    if (suspend) throw new Promise(() => {});
+    return null;
+  };
+  const App = () => {
+    const [suspend, setSuspend] = React.useState(false);
+    state.setSuspend = setSuspend;
+    return h(
+      'window',
+      { width: 200, height: 100 },
+      h('textinput', { name: 'outside', style: FIELD }),
+      h(
+        React.Suspense,
+        { fallback: h('box', { style: { width: 10, height: 10 } }) },
+        h(
+          'box',
+          null,
+          h(
+            'box',
+            null,
+            h('textinput', {
+              name: 'inside',
+              autoFocus: true,
+              defaultValue: 'hi',
+              style: FIELD,
+              onChange: (ev) => state.changes.push(ev.target.value),
+              onBlur: () => state.blurs++,
+              onFocus: () => state.focuses++,
+            }),
+          ),
+        ),
+        h(Suspender, { suspend }),
+      ),
+    );
+  };
+  return { state, element: h(App) };
+}
+
+test('a boundary that re-suspends takes the keyboard with it', async () => {
+  const { state, element } = suspendable();
+  const { app, root, wnd, tree, events } = await mount(element);
+  assert.equal(focusedName(events), 'inside', 'autoFocus took the keyboard');
+  const input = byName(tree, 'inside');
+
+  await flush(() => state.setSuspend(true));
+
+  // the premise: this is the deep case, where the field itself was never
+  // hidden and only collapsed because a yoga ancestor did
+  assert.equal(input.hidden, false, 'React hid the branch, not the field');
+  assert.equal(input.parent.parent.hidden, true, 'the branch above it');
+  assert.equal(input.destroyed, false, 'and it is still mounted');
+
+  assert.equal(focusedName(events), null, 'nothing invisible holds it');
+  assert.equal(state.blurs, 1, 'the field heard about it');
+  assert.equal(events.focusWithinPath.length, 0, ':focus-within went too');
+
+  type(app, wnd, 'XY');
+  assert.deepEqual(state.changes, [], 'and the keys land nowhere');
+
+  await root.unmount();
+});
+
+test('…and hands it back, ring and all, when the boundary resolves', async () => {
+  const { state, element } = suspendable();
+  const { app, root, wnd, tree, events } = await mount(element);
+  const input = byName(tree, 'inside');
+  assert.equal(
+    input.states[':focus-visible'],
+    true,
+    'autoFocus is not a press, so the ring was on',
+  );
+
+  await flush(() => state.setSuspend(true));
+  await flush(() => state.setSuspend(false));
+
+  assert.equal(focusedName(events), 'inside', 'back where the user left it');
+  assert.equal(state.focuses, 2, 'and the field was told, not just marked');
+  assert.equal(
+    input.states[':focus-visible'],
+    true,
+    'a restore puts back the state hiding took, ring included',
+  );
+
+  type(app, wnd, 'Z');
+  assert.deepEqual(state.changes, ['hiZ'], 'typing carries on');
+
+  await root.unmount();
+});
+
+test('…and a field the user clicked comes back without one', async () => {
+  // The other half of "put the state back": a press lights no ring, so a
+  // reveal that lit one would be announcing focus the user never lost.
+  const { state, element } = suspendable();
+  const { root, wnd, tree, events } = await mount(element);
+  press(wnd, byName(tree, 'outside')); // off the autoFocus, ring and all
+  const input = byName(tree, 'inside');
+  press(wnd, input);
+  assert.equal(focusedName(events), 'inside', 'the press focused it');
+  assert.equal(input.states[':focus-visible'], false, '…without a ring');
+
+  await flush(() => state.setSuspend(true));
+  await flush(() => state.setSuspend(false));
+
+  assert.equal(focusedName(events), 'inside');
+  assert.equal(input.states[':focus-visible'], false, 'and still without one');
+
+  await root.unmount();
+});
+
+test('a reveal never takes the keyboard from wherever it went', async () => {
+  const { state, element } = suspendable();
+  const { root, tree, events } = await mount(element);
+
+  await flush(() => state.setSuspend(true));
+  // the user moved on while the boundary was away — nothing about the
+  // content coming back is a reason to interrupt what they are doing now
+  byName(tree, 'outside').focus();
+  await flush(() => state.setSuspend(false));
+
+  assert.equal(
+    focusedName(events),
+    'outside',
+    'the field they are in keeps it',
+  );
+  assert.equal(state.focuses, 1, 'the revealed field was not re-focused');
+
+  await root.unmount();
+});
+
+test('a restore does not pull the X input focus', async () => {
+  // A window that is not the one the server sends keys to still has a focused
+  // node (docs/events.md, "Window focus"). Taking the keyboard back for it
+  // would be taking it off another application because something in the
+  // background finished loading — and SetInputFocus on a window a reveal has
+  // not mapped yet is a BadMatch.
+  const { state, element } = suspendable();
+  const { root, wnd, events } = await mount(element);
+  const asked = [];
+  wnd.focus = () => asked.push('focus'); // ntk >= 3.7.0; the mock has none
+
+  wnd.emit('blur', {});
+  assert.equal(events.windowFocused, false, 'the window manager took it away');
+
+  await flush(() => state.setSuspend(true));
+  await flush(() => state.setSuspend(false));
+
+  assert.equal(focusedName(events), 'inside', 'the node is focused again');
+  assert.deepEqual(asked, [], 'without asking the server for the keyboard');
+
+  await root.unmount();
+});
+
+test('createRoot({ restoreFocusOnReveal: false }) leaves focus where the hide dropped it', async () => {
+  const { state, element } = suspendable();
+  const { root, tree, events } = await mount(element, {
+    restoreFocusOnReveal: false,
+  });
+  assert.equal(focusedName(events), 'inside');
+
+  await flush(() => state.setSuspend(true));
+  await flush(() => state.setSuspend(false));
+
+  assert.equal(focusedName(events), null, 'the browser answer: it stays lost');
+  assert.equal(
+    byName(tree, 'inside').states[':focus'],
+    false,
+    'and nothing is drawn focused',
+  );
+
+  await root.unmount();
+});
+
+test('<Activity mode="hidden"> releases the keyboard and gives it back', async () => {
+  let setMode;
+  const App = () => {
+    const [mode, set] = React.useState('visible');
+    setMode = set;
+    return h(
+      'window',
+      { width: 200, height: 100 },
+      h(
+        React.Activity,
+        { mode },
+        h(
+          'box',
+          null,
+          h('textinput', { name: 'field', autoFocus: true, style: FIELD }),
+        ),
+      ),
+    );
+  };
+  const { root, events } = await mount(h(App));
+  assert.equal(focusedName(events), 'field');
+
+  await flush(() => setMode('hidden'));
+  assert.equal(focusedName(events), null, 'a hidden tab holds no keyboard');
+
+  await flush(() => setMode('visible'));
+  assert.equal(
+    focusedName(events),
+    'field',
+    'the state it kept includes focus',
+  );
+
+  await root.unmount();
+});
+
+test("a style that turns display: 'none' releases the keyboard too", async () => {
+  // The same defect through an application's own hands rather than React's:
+  // `hideInstance` is not involved, the node is invisible because a style
+  // took its subtree out of the layout.
+  let setShown;
+  const App = () => {
+    const [shown, set] = React.useState(true);
+    setShown = set;
+    return h(
+      'window',
+      { width: 200, height: 100 },
+      h(
+        'box',
+        { style: { display: shown ? 'flex' : 'none' } },
+        h(
+          'box',
+          null,
+          h('textinput', { name: 'field', autoFocus: true, style: FIELD }),
+        ),
+      ),
+    );
+  };
+  const { root, tree, events } = await mount(h(App));
+  assert.equal(focusedName(events), 'field');
+
+  await flush(() => setShown(false));
+  assert.equal(
+    byName(tree, 'field').hidden,
+    false,
+    'nothing set the flag React sets',
+  );
+  assert.equal(focusedName(events), null, 'and it lost the keyboard anyway');
+
+  await flush(() => setShown(true));
+  assert.equal(focusedName(events), 'field', 'back when the panel comes back');
+
+  await root.unmount();
+});
+
+test("Tab does not visit a display: 'none' node", async () => {
+  const { root, events } = await mount(
+    h(
+      'window',
+      { width: 200, height: 100 },
+      h('box', { name: 'gone', focusable: true, style: { display: 'none' } }),
+      h('box', { name: 'here', focusable: true, style: FIELD }),
+    ),
+  );
+
+  assert.deepEqual(
+    events._tabbables().map((n) => n.props.name),
+    ['here'],
+    'invisible either way is invisible',
+  );
+  events._cycleFocus(false);
+  assert.equal(focusedName(events), 'here');
+
+  await root.unmount();
+});
+
+test('a hidden <popup> gives the owner window its keyboard back', async () => {
+  // A popup shares the owner window's focus — an override-redirect window
+  // never gets the X input focus itself — so a node inside one that is no
+  // longer on screen would go on taking keys the owner window still receives.
+  let setMode;
+  const App = () => {
+    const [mode, set] = React.useState('visible');
+    setMode = set;
+    return h(
+      'window',
+      { width: 200, height: 100 },
+      h(
+        React.Activity,
+        { mode },
+        h(
+          'popup',
+          { x: 10, y: 10, width: 120, height: 60 },
+          h('textinput', { name: 'in-popup', autoFocus: true, style: FIELD }),
+        ),
+      ),
+    );
+  };
+  const { app, root, events } = await mount(h(App));
+  assert.equal(focusedName(events), 'in-popup', 'the owner window holds it');
+
+  await flush(() => setMode('hidden'));
+  assert.equal(app.windows[1].mapped, false, 'the premise: it was unmapped');
+  assert.equal(focusedName(events), null, 'so the keyboard is not in it');
+
+  await flush(() => setMode('visible'));
+  assert.equal(focusedName(events), 'in-popup', 'and comes back with it');
+
+  await root.unmount();
+});
+
+test('a popup that is still on screen keeps the keyboard', async () => {
+  // The other half of the containment question, and the reason it is asked
+  // as "is the focused node still visible" rather than "is it in there". A
+  // `<popup>` is written as a child in the JSX but is its own X window:
+  // hiding the `<box>` it hangs off unmaps nothing, so it is still in front
+  // of the user and still where their keys should go.
+  let setMode;
+  const App = () => {
+    const [mode, set] = React.useState('visible');
+    setMode = set;
+    return h(
+      'window',
+      { width: 200, height: 100 },
+      h(
+        React.Activity,
+        { mode },
+        h(
+          'box',
+          { name: 'branch' },
+          h(
+            'popup',
+            { x: 10, y: 10, width: 120, height: 60 },
+            h('textinput', { name: 'in-popup', autoFocus: true, style: FIELD }),
+          ),
+        ),
+      ),
+    );
+  };
+  const { app, root, tree, events } = await mount(h(App));
+
+  await flush(() => setMode('hidden'));
+  assert.equal(byName(tree, 'branch').hidden, true, 'the box around it went');
+  assert.equal(app.windows[1].mapped, true, 'the premise: the popup did not');
+  assert.equal(focusedName(events), 'in-popup', 'so it keeps the keyboard');
+
+  await root.unmount();
+});
+
+test('a field unmounted while hidden is not focused when the tree comes back', async () => {
+  let setState;
+  const App = () => {
+    const [{ mode, field }, set] = React.useState({
+      mode: 'visible',
+      field: true,
+    });
+    setState = set;
+    return h(
+      'window',
+      { width: 200, height: 100 },
+      h(
+        React.Activity,
+        { mode },
+        h(
+          'box',
+          null,
+          field
+            ? h('textinput', { name: 'field', autoFocus: true, style: FIELD })
+            : null,
+        ),
+      ),
+    );
+  };
+  const { root, tree, events } = await mount(h(App));
+  const input = byName(tree, 'field');
+
+  await flush(() => setState({ mode: 'hidden', field: true }));
+  await flush(() => setState({ mode: 'hidden', field: false }));
+  assert.equal(input.destroyed, true, 'the premise: it went away while away');
+
+  await flush(() => setState({ mode: 'visible', field: false }));
+  assert.equal(focusedName(events), null, 'nothing is focused, nothing threw');
+
+  await root.unmount();
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -996,6 +996,13 @@ async function main() {
   // (a third name is caught at runtime rather than here: a string satisfies
   // `Record<number, string>`, since indexing one gives a string back)
 
+  // focus comes back with a subtree that was hidden, unless an app says not
+  const noRestore = await createRoot({ restoreFocusOnReveal: false });
+  await noRestore.unmount();
+
+  // @ts-expect-error — it is on or off, not a moment
+  await createRoot({ restoreFocusOnReveal: 'reveal' });
+
   root.render(<Scene />);
   root.render(<RawGl />);
   root.render(<Popup />, () => {});


### PR DESCRIPTION
Closes #202.

A focused control kept the keyboard when the subtree around it went off the
screen, so keys landed on something invisible and the app's state advanced
from them. The rule this lands is one sentence: **focus follows visibility**
— which is what `hitTest`, `paintOrder` and (now) Tab already read, and what
focus was the last route not to.

### The release

`Node.setHidden` / `WindowNode.setHidden` / `_retarget` all funnel into
`_visibilityChanged`, so the three ways a subtree can leave the screen are
covered by one rule:

| route | what does it |
| --- | --- |
| `<Suspense>` fallback, `<Activity mode="hidden">` | `hideInstance` → `setHidden` |
| `display: 'none'` from a prop, a state block or a size query | `_retarget` |
| a `<popup>` or `<window>` React hides | `WindowNode.setHidden` (unmap) |

The condition is the one the issue called out: React hides the **topmost host
instance** of a branch, so the focused control usually still has
`hidden === false` and only collapses because a yoga ancestor is
`DISPLAY_NONE`. `subtreeHidden` therefore asks containment (`node.contains`,
the same question `popScope` asks) **and** `effectivelyVisible`, which is
shared with the accessibility model. The second half is not belt and braces:
a `<popup>` written inside the hidden branch is its own X window and nothing
unmapped it, so it is still in front of the user and still where the keys
belong.

The node hears `onBlur`, `:focus`/`:focus-visible`/`:focus-within` come off,
and keys fall back to the window.

### The reveal — the question the issue left open

**It restores.** `<Activity>` exists to preserve what a hidden subtree had,
and a boundary re-suspending is not something the user did: a field they were
typing in comes back focused and they carry on, rather than being silently
dropped out of it by a fallback that flashed. The ring goes back the way it
was too — restored from a press, no ring; from `autoFocus` or Tab, a ring —
because a restore puts back the state hiding took away rather than making a
new focus.

Two rules are what make that safe enough to be the default:

- **only when nothing else has the keyboard.** Anything focused while the
  subtree was away keeps focus, so a reveal somewhere the user is not looking
  can never take over what they are doing now.
- **a restore is not a navigation.** It does not scroll the node into view
  (the reveal's layout has not run yet, so the rect does not exist) and it
  does not call `SetInputFocus` — a background window revealing something must
  not take the keyboard off another application, and focusing a window a
  reveal has not mapped yet is a `BadMatch`.

The way out is `createRoot({ restoreFocusOnReveal: false })`, which is the
browser's answer: focus that fell to nothing stays there and coming back is
the user's own Tab. The **release** has no switch — keys landing on an
invisible control is a bug, not a preference.

### Also in here

`_focusables` skipped `node.hidden` but not `display: 'none'`, so Tab visited
nodes that are not painted and cannot be clicked. Same rule, same file, one
line.

### Tests

`test/focus-visibility.test.js`, twelve cases: the issue's repro (deep tree,
`onBlur`, `onChange` silent afterwards, `:focus-within` cleared), the restore
and its ring in both directions, no-steal, no `SetInputFocus`, the opt-out,
`<Activity>`, `display: 'none'`, Tab, a hidden `<popup>`, a popup that is
still on screen, and a field unmounted while away. Each was mutation-checked:
eleven separate breakages of the implementation, every one caught by the case
that should catch it and no other.

`npm test` is otherwise unchanged (1374 pass; the six `appearance.test.js`
failures are the pre-existing macOS-only ones), `lint` and `typecheck` clean,
`website && npm test` green.

Nothing here is visible in a screenshot: a hidden subtree paints nothing
either way, and the revealed state looks exactly as it did.

### Noticed on the way, not fixed here

A `<popup>` written inside a subtree that `<Suspense>` or `<Activity>` hides
**stays on screen** — the hide walk stops at the topmost host instance and the
popup is its own window below it. Focus follows what is actually visible, so
this PR leaves the keyboard in the popup rather than papering over it; the
mapping question is a separate call. Written down in
`docs/react-features.md` under "Known gaps".


### Second commit: the other direction

A focus scope hands the keyboard back to whatever the modal was opened from,
and that panel may have gone away while the modal was up — nothing released
it, since focus was *in the modal* rather than in the panel — so closing the
dialog put keys back on an invisible control. `popScope`, `closeEditMenu` and
the reveal now ask one question, `_canRestoreTo`: still focusable, still on
screen. (Its `destroyed` check went with the consolidation: mutation testing
showed it was dead, `effectivelyVisible` starting there itself.)

Worth knowing for review: a hidden `<Activity>` re-commits its subtree on
later updates, so `hideInstance` fires again and the release above happens to
clean up a stale focus by itself. That is why the modal case here is written
with a `display: 'none'` panel — with `<Activity>` the test passes either way
and pins nothing.
