### PR TITLE
build(deps)!: ntk 8

### DIFF
--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -34,9 +34,11 @@ Three things about that command are load-bearing.
 **`--format=esm` is the easy path, not the only one.** It tolerates top-level
 await anywhere in the graph; `cjs` does not, and refuses to build with
 `Top-level await is currently not supported with the "cjs" output format`.
-Since ntk 5 nothing in this stack forces the issue — see
-[tier 3](#tier-3--node-single-executable), which needs `cjs` — so the choice
-is only about what your own code does at module scope.
+Nothing in this stack forces the issue — ntk has had no top-level await
+since 5, and the layout engine, which was the other source of one, is loaded
+rather than imported here (below). See
+[tier 3](#tier-3--node-single-executable), which needs `cjs`; the choice is
+only about what your own code does at module scope.
 
 **The `--banner:js` is not optional.** node-x11 is CommonJS and uses dynamic
 `require`, which esbuild cannot resolve statically. Without the banner the

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^7.7.0",
+        "ntk": "^8.0.0",
         "react-reconciler": "^0.33.0",
         "yoga-layout": "^3.2.1"
       },
@@ -1763,19 +1763,6 @@
         "require-from-string": "^2.0.2"
       }
     },
-    "node_modules/boolbase": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-2.0.0.tgz",
-      "integrity": "sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
     "node_modules/brace-expansion": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
@@ -1982,6 +1969,7 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
       "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -2007,39 +1995,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/css-select": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-7.0.0.tgz",
-      "integrity": "sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^2.0.0",
-        "css-what": "^8.0.0",
-        "domhandler": "^6.0.1",
-        "domutils": "^4.0.2",
-        "nth-check": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/css-what": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/css-what/-/css-what-8.0.0.tgz",
-      "integrity": "sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw==",
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/csstype": {
@@ -3167,15 +3122,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/highlight.js": {
-      "version": "11.11.1",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
-      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
     "node_modules/hot-module-replacement": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/hot-module-replacement/-/hot-module-replacement-4.0.1.tgz",
@@ -3823,6 +3769,7 @@
       "version": "0.18.1",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.18.1.tgz",
       "integrity": "sha512-Td8GCYSxDAoMhHOlKmCFMJ/hz5qlAAb71n66Dryw9nfCVfumLo7nhuotbvKom/XPADmrYC3O5QR71EPq4DarJQ==",
+      "dev": true,
       "funding": [
         "https://opencollective.com/katex",
         "https://github.com/sponsors/katex"
@@ -3934,18 +3881,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/marked": {
-      "version": "18.0.7",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.7.tgz",
-      "integrity": "sha512-iDVQ5ldaiKXn6b2JroX5kgRfmwgqolW7NpaEzTl1k/2Zh1njIEN9yniyLV/mOvWwtsE8OGgkjsCYvijuPk1dtA==",
-      "license": "MIT",
-      "bin": {
-        "marked": "bin/marked.js"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3975,24 +3910,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -4037,45 +3954,23 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/nth-check": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-3.0.1.tgz",
-      "integrity": "sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/fb55/nth-check?sponsor=1"
-      }
-    },
     "node_modules/ntk": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-7.7.0.tgz",
-      "integrity": "sha512-upHew/QG0WhPpYkr87xmoEaFJUd0j+sjwvXwM6UjP+2UO73rrHtoSHgHrwZwv5uigpRg2bycYIc9EnyuSr6ytQ==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-8.0.0.tgz",
+      "integrity": "sha512-bAdm+rXe11lJQyzoWuuY/FxcUoVb1a69Gmr2YuyaODF1ezGoFP7PiT6J4lClsojT0yLWX7PLVAmAMMKm4/+L5Q==",
       "license": "MIT",
       "dependencies": {
         "bidi-js": "^1.0.3",
         "canvas-fontstyle": "^1.0.1",
-        "css-select": "^7.0.0",
         "domutils": "^4.0.2",
         "extrude-polyline": "^1.0.6",
         "fontkit": "^2.0.4",
-        "highlight.js": "^11.11.1",
         "htmlparser2": "^12.0.0",
         "jpeg-js": "^0.4.4",
-        "katex": "^0.18.1",
         "linebreak": "^1.1.0",
-        "marked": "^18.0.7",
         "parse-color": "^1.0.0",
         "pngjs": "^7.0.0",
-        "postcss": "^8.5.23",
-        "x11": "^3.9.0",
-        "yoga-layout": "^3.2.1"
+        "x11": "^3.9.0"
       },
       "engines": {
         "node": ">=18.19.0"
@@ -4339,6 +4234,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/pngjs": {
@@ -4367,34 +4263,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/postcss": {
-      "version": "8.5.23",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
-      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.16",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prelude-ls": {
@@ -4857,15 +4725,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/source-map-js": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
-      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/stop-iteration-iterator": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^7.7.0",
+    "ntk": "^8.0.0",
     "react-reconciler": "^0.33.0",
     "yoga-layout": "^3.2.1"
   },

--- a/src/ntk.d.ts
+++ b/src/ntk.d.ts
@@ -8,6 +8,10 @@
  * never needs it — `measureContent` states its constraints in words so that
  * yoga's ABI stays out of the extension seam.
  *
+ * Documents are not here either: ntk 8 removed `MarkdownView`, `HtmlView` and
+ * `layoutTex` with the engine. Use `@react-x11/components` for those;
+ * `SvgView` remains, since a drawing is not a document.
+ *
  * ntk ships no types of its own, so these are deliberately loose rather
  * than a hand-written mirror that would drift out of date silently. The
  * named exports are the ones an extension actually reaches for; anything

--- a/src/ntk.js
+++ b/src/ntk.js
@@ -14,5 +14,12 @@
 // outside needs it either: an element's `measureContent` is handed its
 // constraints in words (`'at-most'`, `'exactly'`), precisely so that yoga's
 // ABI does not become part of the extension seam.
+//
+// Documents are not here either, and never were ntk's to give: ntk 8 removed
+// `MarkdownView`, `HtmlView` and `layoutTex` along with the layout engine, so
+// `export *` no longer carries them. A package that was reaching through here
+// for one — they were reachable but never declared — wants
+// `@react-x11/components` (`<Markdown>`, `<Formula>`). `SvgView` is still
+// here; a drawing is not a document.
 export * from 'ntk';
 export { default } from 'ntk';

--- a/website/scripts/build-demo-bundles.mjs
+++ b/website/scripts/build-demo-bundles.mjs
@@ -54,6 +54,9 @@ const entrySource = [
   "export * as reactX11 from 'react-x11';",
   "export { default as React } from 'react';",
   "export * as ntk from 'ntk';",
+  // the layout engine is react-x11's, not ntk's, since ntk 8 — check-bundle
+  // asserts on it, and it is what a demo doing its own layout would reach for
+  "export * as yoga from 'react-x11/yoga';",
   "export { default as x11 } from 'x11';",
   "export * as xserver from 'x11/lib/xserver/index.js';",
   "export { createStreamPair } from 'x11/lib/xserver/index.js';",
@@ -120,6 +123,9 @@ await esbuild.build({
   alias: {
     // the renderer, the toolkit and the protocol client (single instances)
     'react-x11': path.join(repoRoot, 'src', 'index.js'),
+    // `alias` matches whole specifiers, so a subpath needs its own entry —
+    // without this, 'react-x11/yoga' is rewritten to '<…>/src/index.js/yoga'
+    'react-x11/yoga': path.join(repoRoot, 'src', 'yoga.js'),
     ntk: path.join(repoRoot, 'node_modules', 'ntk', 'lib', 'index.js'),
     x11: x11Dir,
     // ONE React. The entry resolves 'react' from website/node_modules

--- a/website/scripts/check-bundle.mjs
+++ b/website/scripts/check-bundle.mjs
@@ -56,22 +56,29 @@ assert.ok(globalThis.Buffer, 'Buffer global installed by the bundle');
 assert.notStrictEqual(globalThis.Buffer, nodeBuffer, "it is the bundle's own");
 assert.ok(globalThis.process?.env, 'process global installed by the bundle');
 
-// yoga is what react-x11 lays out with. Since ntk 5 its enums are there on
-// import and the WebAssembly arrives with loadLayout() — which createClient()
+// yoga is what react-x11 lays out with, and since ntk 8 it is react-x11's own
+// (`react-x11/yoga`) rather than something ntk re-exports. Its enums are there
+// on import and the WebAssembly arrives with loadLayout() — which createRoot()
 // calls, and which is what keeps top-level await out of the bundle (see the
 // repo's docs/packaging.md). Both halves are checked: constants first, then
 // the assembly, which is what breaks if the WASM ever fails to load here.
 assert.strictEqual(
-  typeof rx.ntk.Yoga?.FLEX_DIRECTION_ROW,
+  typeof rx.yoga.Yoga?.FLEX_DIRECTION_ROW,
   'number',
-  'ntk.Yoga enums on import',
+  'yoga enums on import',
 );
-await rx.ntk.loadLayout();
 assert.strictEqual(
-  typeof rx.ntk.Yoga?.Node?.create,
-  'function',
-  'ntk.Yoga assembly after loadLayout()',
+  rx.yoga.layoutLoaded(),
+  false,
+  'and not loaded before asked',
 );
+await rx.yoga.loadLayout();
+assert.strictEqual(
+  typeof rx.yoga.Yoga?.Node?.create,
+  'function',
+  'yoga assembly after loadLayout()',
+);
+assert.strictEqual(rx.yoga.layoutLoaded(), true, 'layoutLoaded() agrees');
 
 // --- JSX transform ---------------------------------------------------------
 const compiled = rx.transformJsx(


### PR DESCRIPTION
[ntk 8.0.0](https://github.com/sidorares/ntk/releases) is the release that
removed the document widgets and the layout engine. The renderer stopped using
both before it — #315 took the engine here and dropped
`<markdown>`/`<html>`/`<tex>` — so the bump is one line and the suite does not
move.

```diff
-    "ntk": "^7.7.0",
+    "ntk": "^8.0.0",
```

ntk 8's dependency list is 11 packages, down from 17: `marked`, `katex`,
`highlight.js`, `postcss`, `css-select` and `yoga-layout` all left with the
code that used them.

## `react-x11/ntk` carries less

It is `export * from 'ntk'`, so this bump silently shrinks it. Verified
against the installed 8.0.0 — gone: `MarkdownView`, `HtmlView`, `TexView`,
`TexBox`, `layoutTex`, `configureTex`, `highlightCode`, `cssLength`, and
`Yoga`/`loadLayout`/`layoutLoaded`. Still there: `SvgView`, `cssColor`.

None was declared in `ntk.d.ts` and nothing in this repo used one, so nothing
breaks here — but they *were* reachable, and a package that had been reaching
deserves to be told where they went. `src/ntk.js` and `src/ntk.d.ts` now say
so, pointing at `@react-x11/components`. `SvgView` stays because a drawing is
not a document.

## Two things that were true only until now

**`docs/packaging.md`** credited "ntk 5" with keeping top-level await out of
the graph. That was half the story even then: the other source was the layout
engine, which is loaded rather than imported and lives here now.

**`website/scripts/check-bundle.mjs` asserted on `ntk.Yoga`** — and that is how
this bump got caught rather than shipped:

```
AssertionError: ntk.Yoga enums on import
+ actual: 'undefined'
- expected: 'number'
```

ntk 8 has no Yoga at all. The check now targets `react-x11/yoga` and tests
both halves of the contract it was written for — enums present synchronously,
assembly after `loadLayout()` — with `layoutLoaded()` asserted false before
and true after, which the old version could not check because ntk exposed no
such predicate through the bundle.

Getting that export into the bundle needed one more thing: esbuild's `alias`
matches whole specifiers, so `react-x11` → `src/index.js` was rewriting
`react-x11/yoga` to `<…>/src/index.js/yoga`. The subpath has its own alias
entry now, which is worth knowing before the next subpath is added.

## Verification

- `npm test` — **1377 pass, 6 fail**, the pre-existing darwin-only appearance
  failures (the ladder finds macOS's native source before the XSETTINGS rung).
  Confirmed stable across consecutive runs; one earlier run showed a seventh,
  transient and not reproducible, with the same six named.
- `npm run typecheck`, `npm run lint` — clean
- `npm run docs:test` — all three playground gates green: bundle loads and
  renders, **15/15 demos** mount and respond to injected input, share links
  round-trip. This is the gate that matters here, since it bundles ntk's real
  module graph rather than mocking it.