### PR TITLE
fix(style): a field's text sits where its capitals are centred, leading and all

### DIFF
--- a/examples/labs/text-baseline.jsx
+++ b/examples/labs/text-baseline.jsx
@@ -1,0 +1,215 @@
+// A bench for where text sits inside a control, on a **real** X server.
+//
+//   npm run labs:text-baseline
+//   LAB_FONT="Hiragino Sans" npm run labs:text-baseline
+//   LAB_SHOT=/tmp/bench.png npm run labs:text-baseline   # capture and exit
+//
+// The in-process server is not a good enough witness for this. It renders
+// with whatever font file a test hands it, while a real run resolves
+// `sans-serif` through fontconfig — and on macOS that answer depends on which
+// `fc-match` is first on `PATH`:
+//
+//   /opt/homebrew/bin/fc-match sans-serif   ->  Hiragino Sans   (a CJK face)
+//   /opt/X11/bin/fc-match sans-serif        ->  Verdana
+//
+// The CJK face carries a 0.5em line gap where Verdana carries 0.03em, and
+// that is the whole of the bug this bench exists for: anything that positions
+// text by `ascent` rather than by the line's own baseline lands half a line
+// gap low — invisible on a Latin face, three pixels low on this one. See
+// issue #86 for the font-resolution half.
+//
+// Each row draws a control with a **red hairline through the middle of its
+// padding box**. If the text is centred the way the palette promises, the
+// capitals straddle that line evenly. Read the terminal for the numbers.
+import { fileURLToPath } from 'node:url';
+
+import React, { useEffect, useRef, useState } from 'react';
+
+import { Button, createRoot } from '../../src/index.js';
+
+const SAMPLES = ['XXXXXMMM', 'message #general', 'Hxg', '3'];
+
+/** A control with a guide through the centre of its padding box. */
+function Specimen({ label, children, height }) {
+  return (
+    <box style={{ gap: 2 }}>
+      <text style={{ fontSize: 10, color: '$textMuted' }}>{label}</text>
+      <box style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
+        {children}
+        <box style={{ width: 90, height, justifyContent: 'center' }}>
+          <box style={{ height: 1, backgroundColor: '#ff4d4d' }} />
+        </box>
+      </box>
+    </box>
+  );
+}
+
+const field = {
+  width: 220,
+  paddingStart: 10,
+  paddingEnd: 10,
+  paddingTop: '$paddingY',
+  paddingBottom: '$paddingY',
+  borderWidth: '$borderWidth',
+  borderColor: '$border',
+  borderRadius: '$radius',
+  backgroundColor: '$surface',
+};
+
+const badge = {
+  fontSize: 10,
+  color: '$accentText',
+  backgroundColor: '$accent',
+  paddingStart: 5,
+  paddingEnd: 5,
+  paddingTop: 1,
+  paddingBottom: 1,
+  borderRadius: 8,
+};
+
+/** Set once the field is mounted, so the capture below can reach its window
+ *  and read geometry a frame later — `abs` is 0 until layout has run. */
+export let benchField = null;
+
+export function BenchPanel({ onNodes }) {
+  const fieldRef = useRef(null);
+  const [report, setReport] = useState('');
+
+  useEffect(() => {
+    const node = fieldRef.current;
+    if (!node) return;
+    benchField = node;
+    const style = node.resolvedTextStyle();
+    const font = node.app?.fonts?.match?.(style.family, {});
+    const m = font?.metrics?.(style.size);
+    const layout = node.app?.fonts?.layout?.(
+      [{ text: 'XXXXXMMM', ...style }],
+      style,
+    );
+    const line = layout?.lines?.[0];
+    if (!m || !line) return;
+    const lines = [
+      `family asked for : ${style.family}`,
+      `size             : ${style.size}`,
+      `capHeight        : ${m.capHeight?.toFixed(3) ?? 'MISSING'}`,
+      `ascent / descent : ${m.ascent.toFixed(3)} / ${m.descent.toFixed(3)}`,
+      `line.baseline    : ${line.baseline.toFixed(3)}`,
+      `baseline-ascent  : ${(line.baseline - line.ascent).toFixed(3)}   <- the drop`,
+      `line gap         : ${(layout.height - line.ascent - line.descent).toFixed(3)}`,
+    ];
+
+    console.log(`\n${lines.join('\n')}\n`);
+    setReport(lines.slice(0, 6).join('\n'));
+    onNodes?.(node);
+  }, [onNodes]);
+
+  return (
+    <box style={{ flexGrow: 1, padding: 14, gap: 12 }}>
+      <text style={{ fontSize: 16, color: '$text' }}>
+        Where does the text sit?
+      </text>
+      <text style={{ fontSize: 11, color: '$textMuted' }}>
+        The red hairline is the middle of each control. Capitals should straddle
+        it.
+      </text>
+
+      {SAMPLES.map((sample, i) => (
+        <Specimen key={sample} label={`<textinput> "${sample}"`} height={36}>
+          <textinput
+            ref={i === 0 ? fieldRef : undefined}
+            defaultValue={sample}
+            style={field}
+          />
+        </Specimen>
+      ))}
+
+      <Specimen label="<Button> for comparison" height={36}>
+        <Button>XXXXXMMM</Button>
+      </Specimen>
+
+      {/* Three ways to draw a count. The first is the obvious one and the
+          one that rides low: padding round a `<text>` gives it the line box,
+          leading and all. The second trims to the capitals. The third stops
+          depending on font metrics at all — a fixed pill, centred with flex —
+          which is what examples/chat.jsx now does. */}
+      <Specimen label="badge: padded text / trimmed / fixed pill" height={18}>
+        <box style={{ flexDirection: 'row', gap: 8, alignItems: 'center' }}>
+          <text style={badge}>3</text>
+          <text style={{ ...badge, textBoxTrim: 'cap-alphabetic' }}>3</text>
+          <box
+            style={{
+              minWidth: 16,
+              height: 16,
+              paddingStart: 5,
+              paddingEnd: 5,
+              borderRadius: 8,
+              backgroundColor: '$accent',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <text
+              style={{
+                fontSize: 10,
+                color: '$accentText',
+                textBoxTrim: 'cap-alphabetic',
+              }}
+            >
+              3
+            </text>
+          </box>
+        </box>
+      </Specimen>
+
+      <text style={{ fontSize: 10, color: '$textMuted' }}>{report}</text>
+    </box>
+  );
+}
+
+export function App() {
+  return (
+    <window
+      width={420}
+      height={520}
+      title="text baseline bench"
+      style={{ backgroundColor: '$background' }}
+    >
+      <BenchPanel />
+    </window>
+  );
+}
+
+export default App;
+
+if (!process.env.REACT_X11_NO_AUTORUN) {
+  const root = await createRoot();
+  root.render(<App />);
+
+  // Capture and exit, so this can be iterated on without a human at the
+  // screen — the whole reason it is a file rather than a paragraph.
+  const shot = process.env.LAB_SHOT;
+  if (shot) {
+    const { captureWindow, toPng } = await import(
+      fileURLToPath(new URL('../../scripts/capture.js', import.meta.url))
+    );
+    const { writeFileSync } = await import('node:fs');
+    const { PNG } = await import('pngjs');
+    setTimeout(async () => {
+      const { benchField } = await import('./text-baseline.jsx');
+      const box = benchField.contentBox();
+
+      console.log(
+        `field abs        : y=${benchField.abs.y} h=${benchField.abs.height}\n` +
+          `content box      : ${box.y} .. ${box.y + box.height}\n`,
+      );
+      // `window` lives on the WindowNode, not on every node — walk up.
+      let owner = benchField;
+      while (owner && !owner.isWindow) owner = owner.parent;
+      const capture = await captureWindow(owner.window);
+      writeFileSync(shot, PNG.sync.write(toPng(capture)));
+
+      console.log(`wrote ${shot}`);
+      process.exit(0);
+    }, 900);
+  }
+}

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "examples:raster-gate": "tsx examples/raster-gate.jsx",
     "examples:stress": "tsx examples/stress/index.jsx",
     "examples:foreign": "tsx examples/foreign.jsx",
+    "labs:text-baseline": "tsx examples/labs/text-baseline.jsx",
     "examples:gl": "tsx examples/gl.jsx",
     "examples:three": "tsx examples/three.jsx",
     "examples:shader": "tsx examples/shader.jsx",

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -5842,6 +5842,15 @@ export class TextInputNode extends Node {
     const line = layout.lines?.[0];
     const inkHeight = line ? line.ascent + line.descent : layout.height;
     const ascent = line?.ascent ?? 0;
+    // Where the painter puts the first baseline inside the layout box. It is
+    // **not** `ascent`: the line carries its leading above the glyphs too, so
+    // on a face with a real line gap the two are pixels apart. Verdana's gap
+    // is 0.03em and the error rounds away; Hiragino Sans — which is what
+    // `sans-serif` resolves to on a macOS box with Homebrew's fontconfig
+    // first on PATH (#86) — carries 0.5em, and every field drew its text
+    // three pixels low. Positioning by `ascent` was the whole of that bug.
+    const baseline = line?.baseline ?? ascent;
+    const leading = baseline - ascent;
     const capHeight = this.app?.fonts
       ?.match?.(style.family, {
         weight: style.weight,
@@ -5850,14 +5859,17 @@ export class TextInputNode extends Node {
       ?.metrics?.(style.size)?.capHeight;
     const textY =
       capHeight && line
-        ? content.y + (content.height + capHeight) / 2 - ascent
-        : content.y + Math.max(0, (content.height - inkHeight) / 2);
+        ? content.y + (content.height + capHeight) / 2 - baseline
+        : content.y + Math.max(0, (content.height - inkHeight) / 2) - leading;
+    // The glyphs start a leading below the box they are drawn in, and the
+    // marks are measured against the glyphs rather than against the box.
+    const inkTop = textY + leading;
     // selection/caret read better with breathing room around the glyphs
     // (a DOM input highlights the whole line box, not just the ink)
-    const markPad = Math.min(3, Math.max(0, textY - content.y));
+    const markPad = Math.min(3, Math.max(0, inkTop - content.y));
     return {
       textY,
-      markY: textY - markPad,
+      markY: inkTop - markPad,
       markHeight: inkHeight + markPad * 2,
       inkHeight,
     };

--- a/test/text-leading.test.js
+++ b/test/text-leading.test.js
@@ -1,0 +1,102 @@
+// Where a field puts its one line of text, on a face that carries leading.
+//
+// docs/styling.md: a `<textinput>`'s "baseline goes where the space above the
+// capitals equals the space under it". It did not, on any face with a real
+// line gap: `_lineMetrics` derived its origin by subtracting `ascent`, while
+// the painter puts the first baseline at the line's own `baseline` — and
+// those differ by the leading the line carries above the glyphs.
+//
+// Measured on XQuartz, where `sans-serif` resolves to Hiragino Sans when
+// Homebrew's fontconfig is first on PATH (#86):
+//
+//   Verdana         baseline - ascent = 0.23   invisible
+//   Hiragino Sans   baseline - ascent = 3.50   three pixels low, every field
+//
+// **None of the fixture faces reproduce it.** Every KaTeX face ships a line
+// gap of ~0, so an end-to-end render here is green either way — the same trap
+// that hid the cap-band rounding in test/control-heights.test.js. So this
+// drives `_lineMetrics` with a line that *does* carry leading, which is the
+// smallest thing that can fail. `examples/labs/text-baseline.jsx` is the
+// end-to-end half, and it needs a real server and a real font.
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import React from 'react';
+
+import { renderX11, cleanup, screen } from '../src/testing/index.js';
+
+const require = createRequire(import.meta.url);
+const FONTS = {
+  'sans-serif': path.join(
+    path.dirname(require.resolve('katex/package.json')),
+    'dist',
+    'fonts',
+    'KaTeX_Main-Regular.ttf',
+  ),
+};
+
+const h = React.createElement;
+
+afterEach(cleanup);
+
+/** A line as a face with a 0.5em gap reports one: the baseline sits a half
+ *  leading below the top of the box, not at `ascent`. */
+const LEADED_LINE = { ascent: 12.32, descent: 1.68, baseline: 15.82 };
+const LEADED_LAYOUT = { height: 21, lines: [LEADED_LINE] };
+
+async function field() {
+  await renderX11(h('textinput', { placeholder: 'f', style: { width: 200 } }), {
+    width: 240,
+    height: 60,
+    fonts: FONTS,
+  });
+  return screen.getByPlaceholder('f');
+}
+
+test('the capitals straddle the middle of the box, leading and all', async () => {
+  const node = await field();
+  const style = node.resolvedTextStyle();
+  const cap = node.app.fonts
+    .match(style.family, {})
+    .metrics(style.size).capHeight;
+
+  const content = { x: 0, y: 25, width: 200, height: Math.round(cap) };
+  const { textY } = node._lineMetrics(LEADED_LAYOUT, content, style);
+
+  // Where the painter will actually put the baseline.
+  const baseline = textY + LEADED_LINE.baseline;
+  const above = baseline - cap - content.y;
+  const below = content.y + content.height - baseline;
+
+  assert.ok(
+    Math.abs(above - below) < 0.51,
+    `space above capitals ${above.toFixed(3)} vs below baseline ${below.toFixed(3)}`,
+  );
+});
+
+test('the caret band is measured from the glyphs, not from the box', async () => {
+  const node = await field();
+  const style = node.resolvedTextStyle();
+  const content = { x: 0, y: 25, width: 200, height: 10 };
+  const { textY, markY, markHeight } = node._lineMetrics(
+    LEADED_LAYOUT,
+    content,
+    style,
+  );
+
+  // The ink starts a leading below the layout box it is drawn in. A caret
+  // pinned to the box instead sits a leading high — visible as a caret that
+  // does not line up with the text it is in.
+  const inkTop = textY + (LEADED_LINE.baseline - LEADED_LINE.ascent);
+  const inkBottom = inkTop + LEADED_LINE.ascent + LEADED_LINE.descent;
+
+  assert.ok(
+    markY <= inkTop + 0.01 && markY >= inkTop - 3.01,
+    `caret top ${markY.toFixed(3)} against ink top ${inkTop.toFixed(3)}`,
+  );
+  assert.ok(
+    markY + markHeight >= inkBottom - 0.01,
+    `caret bottom ${(markY + markHeight).toFixed(3)} against ink bottom ${inkBottom.toFixed(3)}`,
+  );
+});


### PR DESCRIPTION
Follow-up to #327, and the second half of the same screenshot. The field is
the right *size* now; its text was sitting three pixels low inside it.

`docs/styling.md` says a `<textinput>`'s "baseline goes where the space above
the capitals equals the space under it". It did not, on any face that carries
a line gap.

## What it looks like

`examples/labs/text-baseline.jsx` at `95d8c4d`, on XQuartz with Hiragino Sans,
zoomed 3×. The magenta rule is the **exact vertical middle of the field's
padding box**. Top: before — it crosses near the top of the capitals. Bottom:
after — through their middle.

![before and after](https://github.com/user-attachments/assets/e841382e-e187-4852-87a2-0c2b28699f0f)


## What was wrong

`_lineMetrics` derived its origin by subtracting **`ascent`**. The painter
puts the first baseline at the line's own **`baseline`** — and the line
carries its leading above the glyphs, so the two differ by exactly that
leading. The text landed half a line gap low, and the caret with it.

| face | `baseline − ascent` | |
| --- | --- | --- |
| Verdana | 0.23 | rounds away |
| **Hiragino Sans** | **3.50** | three pixels, every field |

## Why it needed a real X server to see

`sans-serif` on macOS resolves through whichever `fc-match` is first on
`PATH`:

```
/opt/homebrew/bin/fc-match sans-serif   ->  Hiragino Sans   (a CJK face, 0.5em gap)
/opt/X11/bin/fc-match sans-serif        ->  Verdana         (0.03em gap)
```

So a developer with Homebrew's fontconfig sees this on every field, and the
in-process test server never can — it renders with the font file a test hands
it, never with the one a user gets. That is #86's other cost.

Measured on the real server, capitals against the padding box:

| | above | below |
| --- | --- | --- |
| before | 15 | 9 |
| **after** | **12** | **12** |

## The bench

`examples/labs/text-baseline.jsx` — fields, a `<Button>` and three ways of
drawing a badge, each against a hairline through the middle of its box, on a
real display with whatever font fontconfig picks. `LAB_SHOT=/tmp/x.png`
captures and exits, so it can be iterated on without a human at the screen.

```sh
npm run labs:text-baseline
LAB_SHOT=/tmp/bench.png npm run labs:text-baseline
```

## The test, and what it can't be

**No fixture face reproduces this.** Every KaTeX face ships a line gap of ~0,
so an end-to-end render is green either way — the same trap that hid the
cap-band rounding in #327, found the same way.

So `test/text-leading.test.js` drives `_lineMetrics` with a line that *does*
carry leading, which is the smallest thing that can fail. Verified by
reverting the change: both assertions fail, one of them the caret's.

```
space above capitals 3.719 vs below baseline -3.281
caret top 22.461 against ink top 25.961
```

## Checks

`npm test` — 1387 tests, the six macOS-only `appearance.test.js` failures
that were already there. `lint`, `typecheck`, `format:check` clean.
