### PR TITLE
test(system): the double-click test stops racing the clock

### DIFF
--- a/test/system-hooks.test.js
+++ b/test/system-hooks.test.js
@@ -755,14 +755,18 @@ describe('desktop interaction settings', () => {
     const { app } = await renderX11(h('box'), { backend: 'mock' });
     const events = app.windows[0]._reactX11Node.events;
     setDesktopSettingsForTests(app, {
-      doubleClickMs: 1,
+      // Wide enough that the clock can never be what decides this. The
+      // window used to be 1ms, which reads as "time is irrelevant here" and
+      // means the opposite: two calls more than a millisecond apart are a
+      // fresh click, and on a loaded CI runner they are. It failed twice on
+      // the Node 20 job for that reason and nothing else.
+      doubleClickMs: 60_000,
       doubleClickDistance: 0,
     });
     const at = (x, y) => ({ x, y });
-    // Distance rather than time, because the clock cannot be held still here
-    // and two calls in one tick are 0ms apart whatever the window is. A
-    // desktop that demands the second click land on the same pixel makes one
-    // 3px away a fresh click.
+    // Distance rather than time: with the window that wide, only the pointer
+    // can end a double-click. A desktop that demands the second click land on
+    // the same pixel makes one 3px away a fresh click.
     assert.equal(events._clickDetail(at(10, 10)), 1);
     assert.equal(events._clickDetail(at(13, 10)), 1);
     // …and on the same pixel, still a double


### PR DESCRIPTION
`the double-click window is the desktop's` failed twice on the Node 20 job in one afternoon — [once](https://github.com/sidorares/react-x11/actions/runs/31978529770) on #328 and [once](https://github.com/sidorares/react-x11/actions/runs/31986693091) on #325 — both times `1 == 2`, both times for a reason unrelated to the code under test.

## Why

It sets `doubleClickMs: 1`, and its own comment says why:

> Distance rather than time, because the clock cannot be held still here and two calls in one tick are 0ms apart whatever the window is.

The intent is right and the value contradicts it. **A 1ms window does not make time irrelevant — it makes time maximally relevant.** Two `_clickDetail` calls more than a millisecond apart are a fresh click, and on a loaded runner they are more than a millisecond apart. The assertion that fails is the third one, which expects the second click on the same pixel to read as a double.

## The fix

Widen the window so only the pointer can end a double-click, which is what the test was always about. No assertion changes.

## It still tests what it says

Verified by mutation: stub out the distance comparison in `src/events.js` (`Math.abs(native.x - last.x) <= doubleClickDistance`) and the test goes red. Widening the time window did not weaken it.

`npm test` — 1387 tests, and the six macOS-only `appearance.test.js` failures that were already there.