### PR TITLE
fix(events): a key goes to the node that has focus, not to the window it landed on

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -511,6 +511,16 @@ when the window is focused again. Calling `focus()` on a node in a window
 that does not have the input focus asks for it (X `SetInputFocus`), though
 a window manager is free to refuse.
 
+Which of an application's windows a key is _delivered_ to is a separate
+question again, and not one the application answers: the server sends it to
+the window holding the input focus, or to whichever descendant of that
+window the pointer happens to be over. A nested `<window>` and a `<popup>`
+put the two apart — the field is focused inside them, the keyboard belongs
+to the top-level — so a key is dispatched to **the node that has focus**,
+whichever of that top-level's windows it arrived at, and bubbles from there
+out through the JSX tree. Where more than one window holds a focused node,
+the one focused last is where the user is typing and the one that answers.
+
 ### Focus and visibility
 
 **Focus follows visibility.** A subtree that goes off the screen gives up

--- a/src/events.js
+++ b/src/events.js
@@ -209,6 +209,10 @@ export class EventManager {
     this._hiddenFocus = new WeakMap();
     // resolved lazily for popups: the manager that owns focus (focusManager)
     this._focusOwner = null;
+    // on a *top-level* window's manager: which of this window's managers
+    // took node focus last, and so answers keys addressed to any of them
+    // (`_keyManager`). Its own, until a nested `<window>` says otherwise.
+    this._focusHolder = null;
     // the dead-key/Compose state machine, built on the first key (undefined
     // until then, null when the app turned composition off)
     this._composerInstance = undefined;
@@ -243,6 +247,57 @@ export class EventManager {
     const manager = this.node.parent?.root?.events;
     if (manager && manager !== this) this._focusOwner = manager.focusManager;
     return this._focusOwner ?? this;
+  }
+
+  /**
+   * The manager of the top-level window this one belongs to.
+   *
+   * A nested `<window>` is a child X window *inside* a top-level one, and a
+   * `<popup>` hangs off it; the X input focus only ever lands on the
+   * top-level (or, for a managed popup, on the popup itself, whose keys the
+   * owner already answers). So the top-level is the one place where "which
+   * of our windows is the keyboard's" can be recorded — see `_keyManager`.
+   */
+  get topLevelManager() {
+    const manager = this.focusManager;
+    const owner = manager.node.parent?.root?.events;
+    return owner && owner !== manager ? owner.topLevelManager : manager;
+  }
+
+  /**
+   * The manager a key that arrived *here* should be dispatched through.
+   *
+   * Focus is per `<window>` (docs/events.md), but delivery is not ours to
+   * choose: X sends a key to the focus window, or to the descendant of it
+   * the pointer happens to be over. With a nested `<window>` those come
+   * apart — the field is focused in the inner window's manager while the
+   * keyboard belongs to the outer one — and the key used to be dispatched
+   * against a manager with no focused node at all, which is a key that
+   * types nothing. It also meant *the pointer* decided whether typing
+   * worked: park it over the inner window and the same keystroke arrived
+   * somewhere else.
+   *
+   * So the window that holds the focused node answers, whichever of this
+   * top-level's windows the key was addressed to. `focus()` records it
+   * because only it knows the order they were focused in; a record whose
+   * node has since gone is no better than none (issue #331).
+   */
+  _keyManager() {
+    const manager = this.focusManager;
+    const holder = manager.topLevelManager._focusHolder;
+    // The record wins over this window's own `focused`, which is not the
+    // same question: focus is per window, so a nested `<window>` the user
+    // has since left still has a focused node in it. One of them is where
+    // the user is typing, and that is the one that took focus last.
+    if (
+      holder &&
+      !holder.node.destroyed &&
+      holder.focused &&
+      !holder.focused.destroyed
+    ) {
+      return holder;
+    }
+    return manager;
   }
 
   /**
@@ -897,6 +952,13 @@ export class EventManager {
       }
       return;
     }
+    // The key is this application's; which of its windows the server
+    // addressed it to is not the same question as which window is holding
+    // the keyboard (`_keyManager`). Redirected whole rather than target by
+    // target, so composition, the focus scope Tab cycles inside and the
+    // handlers the event bubbles through are all that window's.
+    const manager = this._keyManager();
+    if (manager !== this) return manager._onKey(name, native);
     runWithPriority(DiscreteEventPriority, () => {
       const wnd = this.node.window;
       // ntk decodes the key on the way in (window.js decorates the event
@@ -1027,6 +1089,9 @@ export class EventManager {
     const old = this.focused;
     this._previousFocus = old;
     this.focused = node;
+    // …and this window is now the one the top-level's keys belong to,
+    // whichever of its windows they are addressed to (`_keyManager`)
+    if (node) this.topLevelManager._focusHolder = this;
     if (old && !old.destroyed) {
       // Claimed *first*, while the ring is still on: a node's damage bound
       // only reaches outside its box while it is actually drawing an

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -3318,6 +3318,56 @@ test('<popup trapFocus> traps Tab and restores focus when it closes', async () =
   await x11Root.unmount();
 });
 
+// Which window the server hands a key to is not ours to choose: it goes to
+// the window holding the X input focus, or to whichever descendant of it the
+// pointer is over. A nested `<window>` puts those two apart — focus is per
+// window, and the keyboard belongs to the top-level — so a key can land on
+// one window while another holds the focused node, and it used to be
+// dispatched against a manager with nothing focused in it and type nothing
+// (issue #331). It also made *the pointer* decide, which is why both
+// directions are here.
+test('a key reaches the focused node whichever window it was sent to', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const refs = { outer: null, inner: null };
+  x11Root.render(
+    React.createElement(
+      'window',
+      { width: 400, height: 300 },
+      React.createElement('textinput', {
+        ref: (n) => (refs.outer = n),
+        defaultValue: '',
+        style: { height: 24 },
+      }),
+      React.createElement(
+        'window',
+        { width: 200, height: 100, x: 10, y: 40 },
+        React.createElement('textinput', {
+          ref: (n) => (refs.inner = n),
+          defaultValue: '',
+          style: { height: 24 },
+        }),
+      ),
+    ),
+  );
+  await tick();
+  const [outerWnd, innerWnd] = app.windows;
+  assert.ok(innerWnd, 'the nested <window> is a window of its own');
+
+  refs.inner.focus();
+  pressKey(app, outerWnd, { keysym: 0x68, codepoint: 0x68 });
+  await tick();
+  assert.strictEqual(refs.inner.value, 'h', 'the top-level passed it inwards');
+
+  refs.outer.focus();
+  pressKey(app, innerWnd, { keysym: 0x69, codepoint: 0x69 });
+  await tick();
+  assert.strictEqual(refs.outer.value, 'i', 'and the nested window outwards');
+  assert.strictEqual(refs.inner.value, 'h', 'without typing twice');
+
+  await x11Root.unmount();
+});
+
 test('Dialog: modal popup, Escape closes it, focus goes back', async () => {
   const { Dialog, Button } = await import('../src/index.js');
   const app = createMockApp();

--- a/test/test-entry.test.js
+++ b/test/test-entry.test.js
@@ -4,7 +4,7 @@
 // — no reaching into `src/nodes.js`, no hand-built harness — which is the
 // point: if this file needs an internal, the entry point is missing
 // something.
-import { test, afterEach } from 'node:test';
+import { test, afterEach, describe } from 'node:test';
 import assert from 'node:assert';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
@@ -280,6 +280,111 @@ test('Escape closes a Dialog, through the focus trap', async () => {
   assert.ok(queryByTestName('dialog-body'));
   await userEvent.key(XK_ESCAPE);
   assert.strictEqual(queryByTestName('dialog-body'), null);
+});
+
+// A dialog in an application that opens its **own** `<window>`, which is
+// every application there is — and, through `renderX11`, the harness's
+// window with the app's one inside it. That second window is the whole of
+// what issue #331 was: the field focused, drew its ring, and typed nothing,
+// because the keys the server handed to the outer window were dispatched
+// against a manager that had no focused node in it.
+//
+// Everything here fails on the commit before this one, and the reason each
+// one is here is that the failure is not narrow: a `<textinput>`, a
+// `<textarea>` and a `Button`'s Space are three different default actions
+// off the same missing route.
+describe('keys reach a Dialog opened by an app with its own <window>', () => {
+  const JoinApp = ({ open = true, onClose = () => {}, onJoin = () => {} }) => {
+    const [channel, setChannel] = React.useState('');
+    const [topic, setTopic] = React.useState('');
+    return h(
+      'window',
+      { width: 480, height: 340, title: 'app' },
+      h('textinput', {
+        placeholder: 'composer',
+        style: { height: 28 },
+      }),
+      h(
+        Dialog,
+        {
+          open,
+          title: 'Join a channel',
+          onClose,
+          actions: h(Button, { label: 'Join', onPress: () => onJoin(channel) }),
+        },
+        h('textinput', {
+          autoFocus: true,
+          placeholder: '#channel',
+          value: channel,
+          onChange: (ev) => setChannel(ev.value),
+          style: { height: 28 },
+        }),
+        h('textarea', {
+          placeholder: 'why',
+          value: topic,
+          onChange: (ev) => setTopic(ev.value),
+          style: { height: 48 },
+        }),
+      ),
+    );
+  };
+
+  const mount = (props) => renderX11(h(JoinApp, props), { fonts });
+
+  test('a <textinput> inside it types, and reports what was typed', async () => {
+    const { getByPlaceholder } = await mount();
+    const field = getByPlaceholder('#channel');
+    assert.strictEqual(field.focused, true, 'autoFocus took focus');
+    await userEvent.type(field, '#x11');
+    assert.strictEqual(field.value, '#x11');
+  });
+
+  test('so does a <textarea>', async () => {
+    const { getByPlaceholder } = await mount();
+    const area = getByPlaceholder('why');
+    await userEvent.type(area, 'hi');
+    assert.strictEqual(area.value, 'hi');
+  });
+
+  test("and Space activates a Button's default action", async () => {
+    const joined = [];
+    const { getByPlaceholder, getByRole } = await mount({
+      onJoin: (name) => joined.push(name),
+    });
+    await userEvent.type(getByPlaceholder('#channel'), '#x11');
+    getByRole('button', { name: 'Join' }).focus();
+    await userEvent.key(keysymOf(' '));
+    assert.deepStrictEqual(joined, ['#x11']);
+  });
+
+  test('Tab moves between the fields and stays in the dialog', async () => {
+    const { getByPlaceholder, getByRole } = await mount();
+    const field = getByPlaceholder('#channel');
+    const area = getByPlaceholder('why');
+    const composer = getByPlaceholder('composer');
+    await userEvent.tab();
+    assert.strictEqual(area.focused, true, 'Tab reached the second field');
+    await userEvent.tab();
+    assert.strictEqual(
+      getByRole('button', { name: 'Join' }).focused,
+      true,
+      'then the action button',
+    );
+    await userEvent.tab();
+    assert.strictEqual(field.focused, true, 'and wrapped back to the first');
+    assert.strictEqual(
+      composer.focused,
+      false,
+      'the trap held — Tab never left the dialog',
+    );
+  });
+
+  test('and Escape still closes it', async () => {
+    const closed = [];
+    await mount({ onClose: () => closed.push('close') });
+    await userEvent.key(XK_ESCAPE);
+    assert.deepStrictEqual(closed, ['close']);
+  });
 });
 
 test('withFrameClock drives a transition instead of sleeping through it', async () => {


### PR DESCRIPTION
A `<textinput>` inside a `<Dialog>` focused, drew its `:focus` border, reported `focused === true` — and typed nothing.

## What it was

Not focus. Both halves of the focus story were right, as #331 said. It is **delivery**.

Which of an application's windows a key arrives at is not the application's to choose: the server sends it to the window holding the input focus, or to whichever descendant of that window the pointer happens to be over. Focus is per `<window>`, and a `<popup>` shares its owner's — so an application that opens its own `<window>` (every application, and what `renderX11` gives a component that renders one: the harness's window with the app's inside it) puts the two apart. The dialog's field is focused in the app window's manager; the keyboard belongs to the top-level above it; the key was dispatched against a manager with nothing focused in it, and nothing typed.

The pointer was deciding as well. In the same tree, typing into a field in the nested window worked while the pointer sat over that window and stopped the moment it left — the chain the server walks starts at the pointer.

Nothing about it is specific to `Dialog`, `trapFocus` or a managed popup: a `<textinput>`, a `<textarea>` and a `Button`'s Space are three different default actions off the same missing route.

## The fix

The window holding the focused node answers, whichever of that top-level's windows the key was addressed to. `focus()` records which one that is, because only it knows the order they were focused in; where more than one window holds a focused node — focus being per window, a nested one the user has left still does — the last to take it is where the user is typing.

The redirect is of the whole `_onKey` rather than of the target alone, so composition, the focus scope Tab cycles inside, and the handlers the event bubbles through all belong to that window.

## Tests

Five through `react-x11/test`, in the shape the bug needs — an app component that opens its own `<window>`: the field types and reports what was typed, so does a `<textarea>`, Space activates a `Button`'s action, Tab moves between the fields and never leaves the dialog, and Escape still closes it. All five fail on the commit before this one and pass on it.

One more in `smoke.test.js` pins the routing rule itself, both directions: a key sent to the top-level while a nested `<window>` holds focus, and a key sent to the nested window while the top-level does.

`docs/events.md` gains a paragraph under "Window focus" — delivery and focus are separate questions, and the doc only answered the second.

Checked against a real display too (XQuartz + quartz-wm, keys injected with `SendEvent`): before the dialog opens the composer types, after it opens — with the WM having moved the input focus to the dialog window — the dialog field does, which is the case that already worked and still does.

Full suite: 1387 pass, 6 fail — the six `appearance.test.js` macOS-only failures that are red on `master` here and green in CI.
