### PR TITLE
fix(events): the caret follows the keyboard, not one of the windows sharing a focus

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -521,6 +521,16 @@ whichever of that top-level's windows it arrived at, and bubbles from there
 out through the JSX tree. Where more than one window holds a focused node,
 the one focused last is where the user is typing and the one that answers.
 
+"Unfocused" is likewise the **focus's** answer rather than any one window's.
+A `<popup>` shares its owner's focus, and a managed one — a `<Dialog>` — is a
+real window the window manager focuses in its own right, so opening one takes
+the X focus off the owner at the moment the field inside the dialog starts
+receiving keys. The caret follows the window that actually holds the
+keyboard, whichever of the ones sharing that focus it is; asking the owner
+alone is how a focused field ends up with a `:focus` ring and no caret. By
+the same token, `focus()` on a node inside an open dialog does not ask the
+server for the input focus — the dialog already has it.
+
 ### Focus and visibility
 
 **Focus follows visibility.** A subtree that goes off the screen gives up

--- a/src/events.js
+++ b/src/events.js
@@ -220,6 +220,15 @@ export class EventManager {
     // until told otherwise: ntk < 3.7 never reports focus changes, and a
     // toolkit that believed it was unfocused would blink no caret at all.
     this.windowFocused = true;
+    // on a *focus* manager: which of the windows sharing this focus holds
+    // the X input focus, when it is not this one — a managed `<popup>` is a
+    // window the WM focuses in its own right (`keyboardFocused`). Null until
+    // one of them says so, which leaves the answer this window's own.
+    this._keyboardWindow = null;
+    // what the focused node was last told about the keyboard, so the two
+    // windows' focus events settle it once rather than twice
+    // (`_syncDefaultFocus`)
+    this._defaultFocusOn = false;
     this._lastClick = { time: 0, x: 0, y: 0, detail: 0 };
     // the sub-pixel part of a smooth scroll the default action has not spent
     // yet — see `_onWheel`, which moves whole pixels so the scroll blit stays
@@ -247,6 +256,53 @@ export class EventManager {
     const manager = this.node.parent?.root?.events;
     if (manager && manager !== this) this._focusOwner = manager.focusManager;
     return this._focusOwner ?? this;
+  }
+
+  /**
+   * Whether the keyboard is on this focus — which is not the same question
+   * as whether it is on this *window*.
+   *
+   * One node is focused per focus manager, and a manager can span more than
+   * one X window: a `<popup>` shares its owner's focus, and a managed one —
+   * a `<Dialog>` — is a real window the window manager focuses in its own
+   * right. Opening one moves the X focus off the owner and onto the popup,
+   * so the owner's `windowFocused` goes false at the very moment the field
+   * inside the dialog starts receiving keys. Asking the owner alone is how
+   * a focused field ends up with a `:focus` ring and no caret (issue #333).
+   *
+   * So the answer is the group's: whichever of its windows last took the X
+   * focus, or this one while none has said otherwise.
+   */
+  get keyboardFocused() {
+    const manager = this.focusManager;
+    if (manager !== this) return manager.keyboardFocused;
+    // a dialog that closed while it held the keyboard leaves a record of a
+    // window that is not there any more, and the answer is this one's again
+    if (manager._keyboardWindow?.node.destroyed) manager._keyboardWindow = null;
+    return (manager._keyboardWindow ?? manager).windowFocused;
+  }
+
+  /**
+   * Tell the focused node whether the keyboard is actually on it — the
+   * `_focused` flag, the caret and its blink timer, which is everything
+   * `:focus` does not cover.
+   *
+   * Driven from here rather than from either window's focus event, because
+   * the two arrive in an order nobody chooses: opening a `<Dialog>` blurs
+   * the owner *before* it focuses the popup, and only one of those two
+   * managers has the focused node. Running it on both, against the group's
+   * answer, settles them the same way whichever lands last — and the record
+   * of what the node was last told is what keeps a `defaultFocus` from
+   * arming a second blink timer over the first.
+   */
+  _syncDefaultFocus() {
+    const on = this.keyboardFocused;
+    if (on === this._defaultFocusOn) return;
+    this._defaultFocusOn = on;
+    const node = this.focused;
+    if (!node || node.destroyed) return;
+    if (on) node.defaultFocus?.();
+    else node.defaultBlur?.();
   }
 
   /**
@@ -370,16 +426,23 @@ export class EventManager {
    * suspended, and `<window onFocus/onBlur>` gets told.
    */
   _onWindowFocus(focused, native) {
-    if (this.windowFocused === focused) return;
+    const changed = this.windowFocused !== focused;
     this.windowFocused = focused;
+    // Recorded even when nothing changed here. A window assumes it has the
+    // keyboard until told otherwise (`windowFocused`), so the FocusIn that
+    // actually hands a managed `<popup>` the keyboard is a no-op *for the
+    // popup* — while the manager holding the focused node is another one
+    // again, and has just been told the keyboard left (`keyboardFocused`).
+    const manager = this.focusManager;
+    if (focused) manager._keyboardWindow = this;
+    else if (manager._keyboardWindow === this) manager._keyboardWindow = null;
     // a half-typed accent does not wait for the user to come back: the keys
     // that would finish it are going somewhere else now
-    if (!focused) this._endComposition(native);
-    const node = this.focused;
-    if (node && !node.destroyed) {
-      if (focused) node.defaultFocus?.();
-      else node.defaultBlur?.();
-    }
+    if (changed && !focused) this._endComposition(native);
+    // …and the focused node hears the focus group's answer, not this
+    // window's, whichever of them the X focus just moved between
+    manager._syncDefaultFocus();
+    if (!changed) return;
     // …and the things that keep a window of their own open on the strength
     // of this one having focus — a menu, a dropdown — which the focused node
     // keeping its focus would otherwise never tell (`WindowNode`, nodes.js)
@@ -1089,6 +1152,9 @@ export class EventManager {
     const old = this.focused;
     this._previousFocus = old;
     this.focused = node;
+    // nothing has been told anything about the keyboard yet, whatever the
+    // node that just gave up focus was told (`_syncDefaultFocus`)
+    this._defaultFocusOn = false;
     // …and this window is now the one the top-level's keys belong to,
     // whichever of its windows they are addressed to (`_keyManager`)
     if (node) this.topLevelManager._focusHolder = this;
@@ -1107,18 +1173,24 @@ export class EventManager {
       old.root?.invalidate(false, old, 'focus');
     }
     if (node) {
-      // keys only reach a node whose window has the X focus — but a restore
+      // Keys only reach a node whose window has the X focus — but a restore
       // must not *take* it: a window revealing something in the background
       // would pull the keyboard off another application, and SetInputFocus
-      // on a window the reveal has not mapped yet is a BadMatch.
-      if (!this.windowFocused && !restoring) this.node.window?.focus?.();
+      // on a window the reveal has not mapped yet is a BadMatch. Asked of
+      // the focus group rather than of this window, or focusing something
+      // inside an open `<Dialog>` would drag the keyboard off the dialog
+      // and back onto the window that owns it.
+      if (!this.keyboardFocused && !restoring) this.node.window?.focus?.();
       node.setStyleState(':focus', true);
       node.setStyleState(':focus-visible', reason !== 'pointer');
       // …and nothing scrolls to meet it either: the node is coming back to
       // the arrangement it left, and this reveal's layout has not run, so a
       // scroll here would be computed from a rect that does not exist yet.
       if (!restoring) this._scrollIntoView(node);
-      if (this.windowFocused) node.defaultFocus?.({ reason, backwards });
+      if (this.keyboardFocused) {
+        this._defaultFocusOn = true;
+        node.defaultFocus?.({ reason, backwards });
+      }
       node.props.onFocus?.(this._makeEvent('focus', null, node));
       node.root?.invalidate(false, node, 'focus');
     }

--- a/src/foreignnodes.js
+++ b/src/foreignnodes.js
@@ -205,7 +205,8 @@ export class ForeignNode extends Node {
     // activation and the focus-in that went out before it was there — a
     // terminal spawned into a focused pane, which is the ordinary case.
     const manager = this._focusManager();
-    if (manager?.focused === this && manager.windowFocused) this.defaultFocus();
+    if (manager?.focused === this && manager.keyboardFocused)
+      this.defaultFocus();
     this.props.onEmbedded?.({ ...this.client, node: this });
   }
 

--- a/test/dialog-caret.test.js
+++ b/test/dialog-caret.test.js
@@ -1,0 +1,319 @@
+// The caret inside a `<Dialog>` (issue #333).
+//
+// A field is focused when the focus manager says so, and it *draws a caret*
+// when it has been told so — `defaultFocus`, which is also what arms the
+// blink. Two answers, and a managed `<popup>` is where they came apart: the
+// dialog is a real window, so the window manager moves the X input focus off
+// the owner and onto it, while the focused node lives in the owner's manager
+// because a popup shares its owner's focus (`focusManager`, events.js). The
+// owner heard "the keyboard left" and the popup heard "the keyboard arrived",
+// and neither of them was both the one holding the node and the one holding
+// the keyboard. The field drew its `:focus` ring and never a caret.
+//
+// Everything here therefore mounts against the in-process X server and then
+// **plays the window manager**, because the missing step is the one a WM
+// takes: `SetInputFocus` on the dialog. The harness does that once at mount
+// for the window it mounted (harness.js) and no session has a WM that stops
+// there — which is why the field looked fine under `react-x11/test` and was
+// broken on a display.
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import React from 'react';
+
+import {
+  renderX11,
+  cleanup,
+  act,
+  windowNodesOf,
+  countPixels,
+  userEvent,
+  XK_ESCAPE,
+} from '../src/testing/index.js';
+import { Dialog } from '../src/index.js';
+import { createRoot } from '../src/index.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const require = createRequire(import.meta.url);
+const FONT = join(
+  dirname(require.resolve('katex/package.json')),
+  'dist',
+  'fonts',
+  'KaTeX_Main-Regular.ttf',
+);
+const fonts = { 'sans-serif': FONT };
+
+// Not a colour any surface, border or glyph in the tree is, so a pixel of it
+// is the caret and nothing else.
+const CARET = '#ff00ff';
+
+afterEach(cleanup);
+
+/**
+ * The window manager hands `node`'s window the keyboard — one `SetInputFocus`
+ * and the FocusOut/FocusIn pair the server sends because of it. Injection
+ * runs inside the server against the state it has *now*, so the request has
+ * to have arrived before anything is read back (harness.js says the same
+ * about event masks).
+ */
+async function windowManagerFocuses(api, node) {
+  api.app.X.SetInputFocus(node.window.id, 2 /* RevertToParent */);
+  await new Promise((resolve) => setImmediate(resolve));
+  await act();
+}
+
+/** The `<popup>` the `Dialog` opened — its own X window, and its own ctx. */
+function popupOf(api) {
+  const popup = windowNodesOf(api.windowNode).find((w) => w.isPopup);
+  assert.ok(popup, 'the dialog opened a <popup>');
+  return popup;
+}
+
+/** How many caret-coloured pixels `node` is drawing, read back off the X
+ * window it is actually in — which for a dialog is not the one that mounted. */
+async function caretPixels(node) {
+  const ctx = node.root.window.getContext('2d');
+  const { x, y, width, height } = node.abs;
+  return countPixels(ctx, { x, y, width, height }, CARET, 4);
+}
+
+const field = (props) =>
+  h('textinput', {
+    placeholder: 'in dialog',
+    caretColor: CARET,
+    style: { height: 28 },
+    ...props,
+  });
+
+/** An owner window with a dialog over it — the reproduction in the issue. */
+function OwnerWithDialog({ children, onClose = () => {} }) {
+  return h(
+    'window',
+    { width: 380, height: 200, title: 'owner' },
+    h('box', { style: { padding: 16 } }, h('text', null, 'owner')),
+    h(
+      Dialog,
+      { open: true, title: 'D', width: 300, height: 150, onClose },
+      children,
+    ),
+  );
+}
+
+/**
+ * React first, and the act flag back off afterwards: the focus events below
+ * are emitted the way the server emits them, outside `act`, and React warns
+ * about every update they cause while the flag is still on.
+ */
+async function flush(fn) {
+  const previous = globalThis.IS_REACT_ACT_ENVIRONMENT;
+  globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  try {
+    await React.act(async () => {
+      await fn?.();
+    });
+  } finally {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = previous;
+  }
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+const mount = (children, props) =>
+  renderX11(h(OwnerWithDialog, { children, ...props }), {
+    wrap: false,
+    fonts,
+  });
+
+test('an autoFocus field in a Dialog draws its caret once the dialog has the keyboard', async () => {
+  const api = await mount(field({ autoFocus: true }));
+  const input = api.getByPlaceholder('in dialog');
+
+  await windowManagerFocuses(api, popupOf(api));
+
+  assert.strictEqual(input.focused, true, 'the field has focus');
+  assert.strictEqual(
+    input.states[':focus'],
+    true,
+    'and is drawn focused — the half that was never in doubt',
+  );
+  assert.ok(
+    (await caretPixels(input)) > 0,
+    'and there is a caret in it, which is the half the user was missing',
+  );
+});
+
+test('so does a <textarea>', async () => {
+  const api = await mount(
+    h('textarea', {
+      autoFocus: true,
+      placeholder: 'in dialog',
+      caretColor: CARET,
+      style: { height: 48 },
+    }),
+  );
+  const area = api.getByPlaceholder('in dialog');
+
+  await windowManagerFocuses(api, popupOf(api));
+
+  assert.strictEqual(area.focused, true);
+  assert.ok((await caretPixels(area)) > 0, 'a caret in the textarea');
+});
+
+test("Dialog's own fallback focus survives the same move", async () => {
+  // Nothing claims `autoFocus`, so the dialog surface takes focus itself
+  // (Dialog.js) — the thing that gives Escape and Tab somewhere to land.
+  const closed = [];
+  const api = await mount(field(), { onClose: () => closed.push('close') });
+  const input = api.getByPlaceholder('in dialog');
+  const popup = popupOf(api);
+  assert.strictEqual(input.focused, false, 'the field did not ask for focus');
+
+  await windowManagerFocuses(api, popup);
+
+  // the keys now arrive at the *dialog's* window, which is the whole of what
+  // moved, and the trap still answers them
+  await userEvent.tab();
+  assert.strictEqual(input.focused, true, 'Tab reached the field');
+  assert.ok((await caretPixels(input)) > 0, 'and the field draws a caret');
+  assert.strictEqual(
+    api.server.focus.wid,
+    popup.window.id,
+    'without the dialog having to give the keyboard back to get one',
+  );
+
+  await userEvent.key(XK_ESCAPE);
+  assert.deepStrictEqual(closed, ['close'], 'and Escape still closes it');
+});
+
+test('a field focused while the dialog already holds the keyboard draws a caret too', async () => {
+  // The other order: the WM focuses the dialog first and `focus()` runs
+  // afterwards, which is what a click or a Tab inside an open dialog does.
+  const api = await mount(field());
+  const input = api.getByPlaceholder('in dialog');
+  await windowManagerFocuses(api, popupOf(api));
+
+  input.focus();
+  await act();
+
+  assert.strictEqual(input.focused, true);
+  assert.ok(
+    (await caretPixels(input)) > 0,
+    'the caret is on without waiting for another focus event',
+  );
+});
+
+test('focusing inside an open dialog does not pull the keyboard back to its owner', async () => {
+  // `focus()` asks the server for the input focus when the focus does not
+  // have it — and asking on behalf of a node in a dialog that *does* have it
+  // would hand the keyboard back to the window underneath.
+  const api = await mount(field());
+  const input = api.getByPlaceholder('in dialog');
+  const popup = popupOf(api);
+  await windowManagerFocuses(api, popup);
+
+  input.focus();
+  await act();
+
+  assert.strictEqual(
+    api.server.focus.wid,
+    popup.window.id,
+    'the dialog still has the X input focus',
+  );
+});
+
+test('the caret goes out when the whole application loses the keyboard', async () => {
+  // The dialog holds it, so the dialog is the window that has to lose it —
+  // the owner lost it when the dialog opened and has nothing left to give.
+  const api = await mount(field({ autoFocus: true }));
+  const input = api.getByPlaceholder('in dialog');
+  await windowManagerFocuses(api, popupOf(api));
+  assert.ok((await caretPixels(input)) > 0, 'a caret to begin with');
+
+  api.app.X.SetInputFocus(1 /* PointerRoot */, 2);
+  await new Promise((resolve) => setImmediate(resolve));
+  await act();
+
+  assert.strictEqual(input.focused, true, 'the field keeps focus…');
+  assert.strictEqual(
+    await caretPixels(input),
+    0,
+    '…and stops drawing a caret, the way a browser blur does',
+  );
+});
+
+// The order the two focus events arrive in is the X server's and the window
+// manager's, not ours: closing a dialog can put the owner's FocusIn before
+// the dialog's FocusOut. Whichever lands last has to leave the same answer,
+// so both orders are pinned — against the mock app, which is the only place
+// the order is ours to choose.
+for (const order of ['blur first', 'focus first']) {
+  test(`the dialog's caret comes on whichever way round the focus events arrive (${order})`, async () => {
+    const app = createMockApp();
+    const root = await createRoot({ app });
+    let input = null;
+    await flush(() =>
+      root.render(
+        h(OwnerWithDialog, {
+          children: field({ autoFocus: true, ref: (n) => (input = n) }),
+        }),
+      ),
+    );
+
+    const [owner, popup] = app.windows;
+    if (order === 'blur first') {
+      owner.emit('blur', {});
+      popup.emit('focus', {});
+    } else {
+      popup.emit('focus', {});
+      owner.emit('blur', {});
+    }
+
+    assert.strictEqual(input.focused, true, 'the field has focus');
+    assert.strictEqual(
+      input._focused,
+      true,
+      'and has been told so — the caret and its blink live behind this flag',
+    );
+    await root.unmount();
+  });
+}
+
+test('a dialog closing hands the keyboard back to the field underneath', async () => {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  let outside = null;
+  const Owner = ({ open }) =>
+    h(
+      'window',
+      { width: 380, height: 200, title: 'owner' },
+      h('textinput', {
+        autoFocus: true,
+        ref: (n) => (outside = n),
+        style: { height: 28 },
+      }),
+      h(
+        Dialog,
+        { open, title: 'D', width: 300, height: 150, onClose: () => {} },
+        field({ autoFocus: true }),
+      ),
+    );
+
+  await flush(() => root.render(h(Owner, { open: true })));
+  const [owner, popup] = app.windows;
+  owner.emit('blur', {});
+  popup.emit('focus', {});
+
+  await flush(() => root.render(h(Owner, { open: false })));
+  // the WM gives it back to the owner, which is the event the record of
+  // "the dialog is holding the keyboard" has to be undone by
+  owner.emit('focus', {});
+
+  assert.strictEqual(outside.focused, true, 'focus went back to the owner');
+  assert.strictEqual(
+    outside._focused,
+    true,
+    'and the field it went back to is drawing a caret again',
+  );
+  await root.unmount();
+});


### PR DESCRIPTION
A `<textinput autoFocus>` inside a `<Dialog>` drew its `:focus` ring and never
a caret. Since #332 the keys arrive, so the field worked and looked broken —
focused by every measure the styling uses, with no sign of where typing would
land.

| before | after |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/0ccaaa86-f4ff-4824-befe-a03735848947) | ![after](https://github.com/user-attachments/assets/ff1ba04d-6c66-4a43-b9d4-bbc54166d695) |

Both rendered by this branch's own code against the in-process X server —
same scene, `origin/master` on the left.

## What was wrong

Two things track focus and they disagreed. `:focus` comes off the focus
manager, which said the field had focus. The caret comes off `defaultFocus`,
which had never been called.

One node is focused per focus manager, and a manager can span more than one X
window: a `<popup>` shares its owner's focus (`focusManager`), and a *managed*
one — a dialog — is a real window the window manager focuses in its own right.
On a display, opening the dialog produces exactly this:

```
_onWindowFocus  wid 10485762  isPopup false  focused false   <- the owner
_onWindowFocus  wid 10485763  isPopup true   focused true    <- the dialog
```

The owner holds the focused node and is told the keyboard left, at the very
moment the field inside the dialog starts receiving keys. The popup is told
the keyboard arrived while holding no focused node at all — and that FocusIn
was a no-op anyway, because a window assumes it has the keyboard until told
otherwise and the popup had never been told anything else. Neither manager was
both the one with the node and the one with the keyboard.

## The fix

"Is the keyboard here" becomes a question about the focus rather than about a
window (`keyboardFocused`), answered by whichever of the windows sharing it
last took the X focus. The node is told from there (`_syncDefaultFocus`)
rather than from either window's focus event, because the two arrive in an
order nobody chooses — closing a dialog can put the owner's FocusIn before the
dialog's FocusOut — and a record of what the node was last told is what keeps
a second blink timer from being armed over the first.

The same answer settles the other half of `focus()`, which asks the server for
the input focus when the focus does not have it. Asked of the owner alone,
focusing anything inside an open dialog — a Tab, a click — dragged the
keyboard back off the dialog and onto the window underneath. That is what made
the caret *look* right in a couple of the paths: it came back by stealing the
keyboard.

## Tests

`test/dialog-caret.test.js` mounts against the in-process server and then
**plays the window manager**, because that one `SetInputFocus` on the dialog
is the step a real session takes and the harness does not — which is why this
looked fine under `react-x11/test` and was broken on a display. Six of the
nine fail on `origin/master`:

- an `autoFocus` `<textinput>` in a `<Dialog>` draws a caret — asserted on the
  caret's own pixels, read back off the popup's window, with `:focus` asserted
  beside it so the two answers are pinned together
- the same for `<textarea>`
- `Dialog`'s own fallback, where nothing claims `autoFocus` and the surface
  takes focus: Tab reaches the field, it draws a caret, and the dialog still
  holds the X input focus afterwards
- focusing inside an open dialog leaves the input focus on the dialog
- the caret goes out when the application loses the keyboard altogether, while
  the field keeps focus
- both arrival orders of the two focus events, and a dialog closing handing
  the keyboard back to the field underneath

Full suite green apart from the six `appearance.test.js` failures that are
macOS-only and already failing on master. `docs/events.md` picks up the rule
under "Window focus".

Fixes #333

