### PR TITLE
feat(events): Space and Enter press what a click would press

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -116,6 +116,14 @@ indistinguishable from a finger.
 click — because several controls act on the press: `Select` and `MenuBar`
 drop their menus on it, the way real menus do.)
 
+**The keyboard shares that click.** Space and Enter on a focused element with
+an `onClick` dispatch the same gesture through the same function, so a
+keyboard user and a screen-reader user are never served differently by the
+same element — see [events.md](events.md#space-and-enter-are-a-click). The
+role half of the rule above stays the AT's: a role _advertises_ an action to
+something that cannot press a key, and a `role="button"` with no `onClick`
+has no click for a key to be.
+
 The one thing that does need a handler is a _value_ write — Orca adjusting
 a slider through the Value interface. The handler receives one argument:
 

--- a/docs/components.md
+++ b/docs/components.md
@@ -390,8 +390,11 @@ control and nothing else says so.
 
 `Button`, `Checkbox`, `Radio`/`RadioGroup`, `Switch` and `ProgressBar` share
 one piece of plumbing, `useControl(disabled, onActivate)`: it makes the
-control focusable, activates it on click or Space (Enter as well, for
-`Button`), sets the pointer cursor, and expresses hover, press and focus
+control focusable, activates it on click — and so on Space and Enter, which
+are a click on anything with an `onClick`
+([events.md](events.md#space-and-enter-are-a-click)), the widgets having no
+key mapping of their own any more — sets the pointer cursor, and expresses
+hover, press and focus
 feedback as `:hover`/`:active`/`:focus` style blocks rather than React state
 — so moving the pointer over a control repaints one node instead of
 rendering.

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -809,7 +809,7 @@ window, valid after layout).
 
 With `overflow: 'scroll'` it is also the **scroll container** — see below.
 
-## Scrolling: `overflow: 'scroll'`
+## Scrolling: `overflow: 'scroll'` {#scrolling}
 
 There is no scrolling _element_. A `<box>` — or a `<window>` — whose style
 says `overflow: 'scroll'` becomes a clipped viewport over its own
@@ -846,6 +846,13 @@ nothing. **The wheel chains past it** to the next scroll container out — the
 same thing a browser does — so declaring a pane scrollable never steals a
 gesture the window would have answered. The keys are a default action, so an
 `onKeyDown` of your own runs first and `preventDefault()` cancels them.
+
+A pane that also has an `onClick` keeps Space for paging: paging is the
+pane's own default action and runs ahead of the keyboard activation Space
+would otherwise be, so such a pane pages with Space and activates with Enter
+([events.md](events.md#space-and-enter-are-a-click)). A focusable row _inside_
+a pane takes both keys and pages with neither — a default action runs on the
+focused node, and that is the row.
 
 The bar belongs to the scroller, not to the content painted under it — the
 same rule a browser applies — so a press on the thumb never reaches the row

--- a/docs/events.md
+++ b/docs/events.md
@@ -161,19 +161,59 @@ field as it arrived, and `MOD` in `react-x11/keysyms` names its bits
 
 ## Handlers
 
-| handler                                                           | notes                                                                                                                   |
-| ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `onClick`                                                         | fires on the nearest common ancestor of press & release; `detail` counts multi-clicks                                   |
-| `onMouseDown` / `onMouseUp` / `onMouseMove`                       | move is coalesced to once per frame by ntk                                                                              |
-| `onMouseEnter` / `onMouseLeave`                                   | do not propagate; synthesized by hover-path diffing                                                                     |
-| `onWheel`                                                         | pixels, from the device or from X buttons 4–7; default action scrolls the nearest scroll container with somewhere to go |
-| `onContextMenu`                                                   | right-click (button 3), after `onMouseDown`; default action opens the element's menu                                    |
-| `onKeyDown` / `onKeyUp`                                           | delivered to the focused node (or the window); Tab cycles focus unless the element took it                              |
-| `onCompositionStart` / `onCompositionUpdate` / `onCompositionEnd` | text still being typed — a dead key, a Compose sequence; see below                                                      |
-| `onFocus` / `onBlur`                                              | focus follows mousedown (nearest `focusable` ancestor) and Tab traversal                                                |
-| `onDragEnter` / `onDragLeave`                                     | do not propagate; drag-path diffing, the same shape as the hover pair above                                             |
-| `onDragOver` / `onDrop`                                           | on a drop target; `onDrop` may be async — [drag-and-drop.md](drag-and-drop.md)                                          |
-| `onDragStart` / `onDrag` / `onDragEnd`                            | on a `draggable` node; the press is a click until it moves 4px                                                          |
+| handler                                                           | notes                                                                                                                    |
+| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `onClick`                                                         | fires on the nearest common ancestor of press & release; `detail` counts multi-clicks                                    |
+| `onMouseDown` / `onMouseUp` / `onMouseMove`                       | move is coalesced to once per frame by ntk                                                                               |
+| `onMouseEnter` / `onMouseLeave`                                   | do not propagate; synthesized by hover-path diffing                                                                      |
+| `onWheel`                                                         | pixels, from the device or from X buttons 4–7; default action scrolls the nearest scroll container with somewhere to go  |
+| `onContextMenu`                                                   | right-click (button 3), after `onMouseDown`; default action opens the element's menu                                     |
+| `onKeyDown` / `onKeyUp`                                           | delivered to the focused node (or the window); Space/Enter click an `onClick`, and Tab cycles focus, unless it took them |
+| `onCompositionStart` / `onCompositionUpdate` / `onCompositionEnd` | text still being typed — a dead key, a Compose sequence; see below                                                       |
+| `onFocus` / `onBlur`                                              | focus follows mousedown (nearest `focusable` ancestor) and Tab traversal                                                 |
+| `onDragEnter` / `onDragLeave`                                     | do not propagate; drag-path diffing, the same shape as the hover pair above                                              |
+| `onDragOver` / `onDrop`                                           | on a drop target; `onDrop` may be async — [drag-and-drop.md](drag-and-drop.md)                                           |
+| `onDragStart` / `onDrag` / `onDragEnd`                            | on a `draggable` node; the press is a click until it moves 4px                                                           |
+
+## Space and Enter are a click {#space-and-enter-are-a-click}
+
+**An `onClick` on a focusable node is operable from the keyboard, with
+nothing else written.** Space or Enter on it dispatches the click — the whole
+press gesture, mousedown then mouseup then click, through the ordinary path —
+so a control hand-built out of a `<box>` behaves like a `<Button>`:
+
+```jsx
+<box focusable role="option" aria-selected={on} onClick={() => open(channel)}>
+  <text>{channel}</text>
+</box>
+```
+
+The keys are a **default action**, which is the whole of the contract:
+
+- `preventDefault()` in the node's own `onKeyDown` takes the key back — that
+  is how a widget that answers Enter with something other than its click
+  (`Tree` opens a branch; the click only moves the selection) keeps it;
+- a node with no `onClick` is untouched, whatever its `role` says. A role
+  advertises an action to an assistive technology, which has no other way to
+  ask; a key press is already at the node, so there is nothing to advertise
+  and nothing to activate. `role="button"` with only an `onKeyDown` stays
+  yours;
+- `<textinput>` and `<textarea>` never activate: their own `defaultKeyDown`
+  answers the keystroke, so Space types a space;
+- **a scroll pane keeps Space.** Space and Shift+Space page a scrolling `<box>`
+  ([elements.md](elements.md#scrolling)) — that is a default action too, and
+  the pane answers it before this one, so a clickable pane pages with Space
+  and activates with Enter. A focusable row _inside_ a pane is not affected
+  either way: default actions run on the focused node, and the pane is not
+  it.
+
+Modifiers travel: the synthesized click carries the key press's own modifier
+mask, so Shift+Enter reaches `onClick` as a shift-click.
+
+It is the same function an assistive technology's activation goes through, on
+purpose — one definition of "activate" for the pointer, the keyboard and
+Orca, which cannot then disagree about a control
+([accessibility.md](accessibility.md#at-driven-controls)).
 
 ## The wheel {#wheel}
 

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -554,6 +554,15 @@ to force. Consuming it means calling `ev.preventDefault()` from the default
 action: what that prevents is the default action _after_ this one, which for
 Tab is the focus cycle.
 
+**`super.defaultKeyDown(ev)` is the base class's own behaviour**, and there
+are two things in it: the text-selection keys, and Space/Enter dispatching
+the node's `onClick` as a click
+([events.md](events.md#space-and-enter-are-a-click)). An override that
+answers the keystroke itself — an editor, where Space types a space — simply
+does not call it, which is what `<textinput>` does. One that answers a few
+keys and leaves the rest, as the scroll pane does, ends its `default:` branch
+with `return super.defaultKeyDown(ev)` and keeps both.
+
 An element that eats Tab has taken the keyboard user's only way out of it, so
 it owes them another. The convention, above and worth converging on: **Escape
 arms one pass-through Tab.** Escape on its own does nothing visible, the next

--- a/examples/chat.jsx
+++ b/examples/chat.jsx
@@ -83,7 +83,6 @@ import {
   createRoot,
   createStyles,
 } from '../src/index.js';
-import { XK_RETURN } from '../src/keysyms.js';
 
 const CHANNELS = ['#general', '#x11', '#react'];
 
@@ -1045,18 +1044,11 @@ export function ChatPanel({ transport, nick = 'you' }) {
               aria-label={channel}
               aria-selected={on}
               focusable
+              // Space and Enter come with it: an `onClick` on a focusable
+              // node is a click the keyboard can make too (issue #329), so
+              // the row that draws a focus ring answers the keys the ring
+              // promises without six lines saying so.
               onClick={() => open(channel)}
-              // A focusable `<box>` is **not** activated by Space or Enter.
-              // `Button` gets that from `useControl`; a raw box gets a focus
-              // ring and nothing else, which is the worst of both — it looks
-              // reachable and does not answer. The keys belong to whatever
-              // draws the ring.
-              onKeyDown={(ev) => {
-                if (ev.codepoint === 32 || ev.keysym === XK_RETURN) {
-                  ev.preventDefault();
-                  open(channel);
-                }
-              }}
             >
               <text style={[s.channelName, on && s.channelNameOn]}>
                 {channel}
@@ -1165,12 +1157,6 @@ export function ChatPanel({ transport, nick = 'you' }) {
                     aria-label={c.name}
                     focusable
                     onClick={() => join(c.name)}
-                    onKeyDown={(ev) => {
-                      if (ev.codepoint === 32 || ev.keysym === XK_RETURN) {
-                        ev.preventDefault();
-                        join(c.name);
-                      }
-                    }}
                   >
                     <text style={s.directoryName}>{c.name}</text>
                     <text style={s.directoryUsers}>{String(c.users)}</text>

--- a/src/a11y.js
+++ b/src/a11y.js
@@ -933,12 +933,30 @@ export function a11yAttributes(node) {
   return attrs;
 }
 
+/**
+ * **The one thing "activatable" means**: there is a click here to make.
+ *
+ * Three input routes stand on this — the pointer, an AT's `DoAction`, and
+ * the keyboard's Space/Enter (`Node.defaultKeyDown`, nodes.js) — and they
+ * all dispatch the same click, so a control cannot answer one of them and
+ * not another. It lives here, beside the bridge's rule, because the bridge
+ * is the layer that already had to write the rule down.
+ */
+export const hasClickHandler = (node) =>
+  typeof node.props?.onClick === 'function';
+
 /** Whether the bridge should offer an "activate" action: an explicit
  * handler, or a role that promises one (widgets often keep the handler on
  * an ancestor of the role-carrying node — activation is dispatched through
- * the tree, so the promise still holds). */
+ * the tree, so the promise still holds).
+ *
+ * The role half is an AT's alone: it *advertises* an action to something
+ * that has no other way to ask for one, and the click it dispatches is
+ * answered by whichever ancestor holds the handler. The keyboard needs no
+ * advertisement — a key press is already at the node — so it takes the
+ * first clause and stops there (`hasClickHandler`). */
 export function a11yActivatable(node) {
-  if (typeof node.props?.onClick === 'function') return true;
+  if (hasClickHandler(node)) return true;
   // A drawn item whose element answers actions is activatable whatever it
   // is called: implementing the seam is the same promise a handler is, and
   // the roles a scene reaches for — `listitem` for a graph node — are

--- a/src/atspi.js
+++ b/src/atspi.js
@@ -62,7 +62,7 @@ import {
   diffChars,
 } from './a11y.js';
 import { onApp } from './trace-registry.js';
-import { discrete } from './events.js';
+import { synthesizeClick } from './events.js';
 import { callHandler } from './errors.js';
 
 const ROOT_PATH = '/org/a11y/atspi/accessible/root';
@@ -1004,7 +1004,8 @@ class AtspiBridge {
   /** DoAction("activate"): a synthetic click through the same dispatch a
    * real press uses — capture, bubble, default actions, discrete-priority
    * commit and paint — so an AT's activation is indistinguishable from the
-   * user's. On a scene item it is the click a mouse user would make on
+   * user's, and from the keyboard's, which reaches `synthesizeClick` too
+   * (events.js). On a scene item it is the click a mouse user would make on
    * what was drawn there: the element hit-tests its own scene already, so
    * the item's rect is the whole address, and an element whose activation
    * is not a click says so through `a11ySceneAction`. */
@@ -1012,37 +1013,9 @@ class AtspiBridge {
     if (node.a11yOwner) {
       if (this.sceneAction(node, 'activate')) return true;
       if (node.destroyed) return false;
-      return this._click(node.a11yOwner, node.abs);
+      return synthesizeClick(node.a11yOwner, node.abs);
     }
-    return this._click(node, node.abs);
-  }
-
-  _click(node, rect) {
-    const manager = node.root?.events;
-    if (!manager || node.destroyed) return false;
-    const abs = rect ?? { x: 0, y: 0, width: 0, height: 0 };
-    const native = {
-      x: Math.round(abs.x + abs.width / 2),
-      y: Math.round(abs.y + abs.height / 2),
-      buttons: 0,
-      keycode: 1,
-    };
-    // The whole press gesture, not just the click: several controls act on
-    // the *press* — `Select` and `MenuBar` drop their menus on mousedown,
-    // the way real menus do — and an AT activation has to reach those too.
-    // Handlers only; the coordinate-driven defaults (caret placement, drag
-    // arming) stay out, because a synthesized centre point is not a place
-    // the user chose.
-    discrete(() => {
-      manager.dispatch('MouseDown', node, native, { button: 1, detail: 1 });
-      if (!node.destroyed) {
-        manager.dispatch('MouseUp', node, native, { button: 1 });
-      }
-      if (!node.destroyed) {
-        manager.dispatch('Click', node, native, { button: 1, detail: 1 });
-      }
-    })(native);
-    return true;
+    return synthesizeClick(node, node.abs);
   }
 
   editable(node) {

--- a/src/components/Radio.js
+++ b/src/components/Radio.js
@@ -69,12 +69,14 @@ export function Radio({ value, children, label, disabled = false }) {
   } = useControl(disabled, () => {
     if (!selected) group.emit(value);
   });
-  const onKeyDown = props.onKeyDown;
-  if (onKeyDown) {
+  // The arrows are the group's, and they are all this handler is for: Space
+  // and Enter are the click core makes of them on anything with an `onClick`
+  // (issue #329), which for a radio is `useControl`'s. A disabled radio takes
+  // no keys and gets no handler — it has no `onClick` either.
+  if (!disabled) {
     props.onKeyDown = (ev) => {
       if (ev.keysym === XK_DOWN || ev.keysym === XK_RIGHT) group.move(1);
       else if (ev.keysym === XK_UP || ev.keysym === XK_LEFT) group.move(-1);
-      else onKeyDown(ev);
     };
   }
   // The dot only appears on the release, so the well answers the press

--- a/src/components/Tabs.js
+++ b/src/components/Tabs.js
@@ -5,15 +5,7 @@
 import React, { useRef, useState } from 'react';
 import { createStyles } from '../styles.js';
 import { labelContent, useDirection, useTheme } from './theme.js';
-import {
-  XK_DOWN,
-  XK_END,
-  XK_HOME,
-  XK_LEFT,
-  XK_RETURN,
-  XK_RIGHT,
-  XK_UP,
-} from './keys.js';
+import { XK_DOWN, XK_END, XK_HOME, XK_LEFT, XK_RIGHT, XK_UP } from './keys.js';
 
 const h = React.createElement;
 
@@ -125,11 +117,11 @@ export function Tabs({
         return;
       default:
     }
-    // in manual mode focus and selection differ, so commit what the focus
-    // is on rather than what is already selected
-    if (manual && (ev.keysym === XK_RETURN || ev.codepoint === 32)) {
-      select(focusedId);
-    }
+    // Space and Enter are not here: in manual mode, where focus and
+    // selection differ, committing the focused tab is exactly the click
+    // that tab's own `onClick` is, and core makes those keys that click
+    // (issue #329). In automatic mode the tab is already selected and the
+    // click is a no-op.
   };
 
   const active = items.find((item) => item.id === selected);

--- a/src/components/Tree.js
+++ b/src/components/Tree.js
@@ -192,6 +192,10 @@ export function Tree({
       default:
     }
     if (ev.keysym === XK_RETURN || ev.codepoint === 32) {
+      // the tree's own answer to these keys, so the row's click default
+      // action must not also run: a row's click *moves the selection*,
+      // which is a different thing from opening what is already selected
+      ev.preventDefault();
       if (row?.branch) toggle(row.item.id);
       if (row) onActivate?.(row.item.id, row.item);
       return;

--- a/src/components/theme.js
+++ b/src/components/theme.js
@@ -10,7 +10,6 @@
 import React, { useContext, useMemo, useState } from 'react';
 import { useAppearanceWhen } from '../appearancehooks.js';
 import { DarkTheme, DefaultTheme, resolveTheme } from '../palette.js';
-import { XK_RETURN } from './keys.js';
 
 const h = React.createElement;
 
@@ -216,13 +215,18 @@ export function useControl(disabled, onActivate, { styled = false } = {}) {
   const [pressed, setPressed] = useState(false);
   const activation = {
     focusable: true,
+    // The click, and nothing else: Space and Enter are a click on anything
+    // with an `onClick` now (`Node.defaultKeyDown`, issue #329), so the
+    // hand-rolled key mapping that used to live here is gone — and with it
+    // the reason a widget answered the keyboard while a hand-built control
+    // beside it did not.
+    //
     // the event travels: `ButtonProps.onPress` has always been declared as
     // taking one, and a handler that wants `ev.shiftKey` or `ev.detail` —
-    // shift-click, double-click — has no other way to get it
+    // shift-click, double-click — has no other way to get it. From the
+    // keyboard it is the synthesized click, carrying the key press's own
+    // modifiers, so Shift+Enter still reads as a shift-click.
     onClick: (ev) => onActivate?.(ev),
-    onKeyDown: (ev) => {
-      if (ev.codepoint === 32 || ev.keysym === XK_RETURN) onActivate?.(ev);
-    },
   };
   const props = disabled
     ? // the node still has to *say* it is disabled: `:disabled` style

--- a/src/events.js
+++ b/src/events.js
@@ -183,6 +183,52 @@ export function discrete(fn) {
   };
 }
 
+/**
+ * Activate a node the way a finger would: the **whole press gesture**
+ * through the normal dispatch — capture, bubble, handlers, the
+ * discrete-priority commit and the paint that follows it.
+ *
+ * One function, because there is more than one way to ask for it and they
+ * must not drift: an AT's `DoAction("activate")` (atspi.js) and the
+ * keyboard's Space/Enter on a focused control (`Node.defaultKeyDown`,
+ * nodes.js) both land here, so a control that acts on the *press* — `Select`
+ * and `MenuBar` drop their menus on mousedown, the way real menus do — is
+ * reached by either, and neither can be the one input route a widget forgot.
+ *
+ * Handlers only: the coordinate-driven default actions (caret placement,
+ * drag arming) stay out, because the centre of a rect is not a place the
+ * user chose.
+ *
+ * `source` is the native event that asked, when there was one — a key press.
+ * It carries the modifier mask and the X timestamp across, so Shift+Enter on
+ * a control reads as a shift-click and a handler that raises a window has a
+ * real time to do it with. An AT activation has neither and passes nothing.
+ */
+export function synthesizeClick(node, rect, source = null) {
+  const manager = node?.root?.events;
+  if (!manager || node.destroyed) return false;
+  const abs = rect ?? { x: 0, y: 0, width: 0, height: 0 };
+  const native = {
+    x: Math.round(abs.x + abs.width / 2),
+    y: Math.round(abs.y + abs.height / 2),
+    // the X `state` mask, which is where SyntheticEvent reads shift/ctrl/
+    // alt/super from on *every* event, not just keys
+    buttons: source?.buttons ?? 0,
+    keycode: 1,
+    time: source?.time,
+  };
+  discrete(() => {
+    manager.dispatch('MouseDown', node, native, { button: 1, detail: 1 });
+    if (!node.destroyed) {
+      manager.dispatch('MouseUp', node, native, { button: 1 });
+    }
+    if (!node.destroyed) {
+      manager.dispatch('Click', node, native, { button: 1, detail: 1 });
+    }
+  })(native);
+  return true;
+}
+
 export class EventManager {
   constructor(windowNode) {
     this.node = windowNode;

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -39,7 +39,12 @@ import {
 } from './styles.js';
 import { Yoga } from './yoga.js';
 import { cssColorStraight } from 'ntk';
-import { EventManager, discrete, WHEEL_NOTCH_PX } from './events.js';
+import {
+  EventManager,
+  discrete,
+  synthesizeClick,
+  WHEEL_NOTCH_PX,
+} from './events.js';
 import {
   DropSession,
   dndAtoms,
@@ -74,6 +79,7 @@ import {
   hooks as a11yHooks,
   isFocusable as a11yFocusable,
   devCheckA11yProps,
+  hasClickHandler,
 } from './a11y.js';
 import { windowIdOf } from './windowid.js';
 import { paintCacheFor } from './paintcache.js';
@@ -3137,8 +3143,55 @@ export class Node {
     selectionSurfaceOf(this)?.release(ev);
   }
 
+  /**
+   * The selection keys, and then **Space or Enter on anything clickable**.
+   *
+   * A focusable node with an `onClick` used to take focus, draw a ring, be
+   * reachable by Tab and be activatable by a screen reader — and do nothing
+   * at all when the keyboard pressed it (issue #329). It looked operable and
+   * was not, which is the failure mode a focus ring makes *worse*: the ring
+   * is a promise. Every control an application builds out of a `<box>`
+   * rather than out of `Button` had it, silently.
+   *
+   * It is the click itself, not a second definition of one: `synthesizeClick`
+   * is the function an AT's `DoAction("activate")` already went through, so
+   * a control that acts on the press hears the press either way and the two
+   * paths cannot drift. The rule for *what* is activatable is the same one
+   * the bridge writes down — there is an `onClick` here — minus the bridge's
+   * role clause, which advertises an action to something that cannot press a
+   * key (a11y.js, `hasClickHandler`).
+   *
+   * **One key rule, no role table.** The web gives `checkbox` Space and not
+   * Enter, and a link Enter and not Space, because on the web those keys are
+   * already spoken for — Space scrolls the page, Enter submits the form.
+   * Neither is true here: a default action runs on the focused node, so the
+   * scroll pane a row sits in never sees the row's Space, and there is no
+   * implicit submit. All a role table could buy, then, is *fewer* keys
+   * working on a control that draws a focus ring — which is the bug.
+   *
+   * The two ways out, both ordinary: `preventDefault()` in the element's own
+   * `onKeyDown` (the seam an application uses — a `<box>` that wants Enter
+   * for something else), and overriding this method (the seam an element
+   * uses). A scroll pane that is *itself* clickable takes the third: its
+   * `defaultKeyDown` answers Space with a page and never reaches here, so
+   * paging keeps the key it has always had and Enter activates.
+   */
   defaultKeyDown(ev) {
     this._textSelection?.keyDown(ev);
+    if (ev.defaultPrevented) return;
+    const enter = ev.keysym === XK_RETURN || ev.keysym === XK_KP_ENTER;
+    // Space by either name: `XK_space` *is* code point 32 — a Latin-1 keysym
+    // and its character are the same number — and both fields are read
+    // because a synthetic event may carry only one of them, the way the
+    // scroll keys next door read the keysym and every widget read the code
+    // point. A key an open composition took reaches no default action at all.
+    const space = ev.keysym === XK_SPACE || ev.codepoint === 32;
+    if (!enter && !space) return;
+    if (!hasClickHandler(this)) return;
+    // consumed, said the way every default action says it: what it prevents
+    // is the default action after this one
+    ev.preventDefault();
+    synthesizeClick(this, this.abs, ev.nativeEvent);
   }
 
   paint(ctx) {

--- a/test/accessibility.test.js
+++ b/test/accessibility.test.js
@@ -384,3 +384,214 @@ test('Switch and Slider clear the 24px minimum', async () => {
   await settle();
   assert.strictEqual(switched, true, 'a press in the slop toggles the switch');
 });
+
+// --- 4. Space and Enter are a click ----------------------------------------
+//
+// The same complaint as section 1, one rung out (#329). The ring arrived and
+// the activation did not: a focusable `<box onClick>` took focus, drew a
+// ring, was reachable by Tab and was activatable by Orca — the AT-SPI bridge
+// dispatches a synthetic click for anything with an `onClick` — and did
+// nothing at all when a keyboard-only user pressed Space or Enter. It is one
+// click now, `synthesizeClick`, and all three routes go through it.
+
+const XK_RETURN = 0xff0d;
+const XK_KP_ENTER = 0xff8d;
+const XK_A = 0x0061;
+
+/** A press that carries a code point as well as a keysym, the way ntk's
+ *  decoded event does — `press` above sends only the keysym. */
+function type(app, wnd, keysym, codepoint, { shift = false } = {}) {
+  const keycode = (keysym % 248) + 8;
+  app.X.keycode2keysyms[keycode] = [keysym];
+  wnd.emit('keydown', { keycode, keysym, codepoint, buttons: shift ? 1 : 0 });
+}
+
+/** A `<box focusable onClick>` that records the whole gesture, so a test can
+ *  compare what the keyboard sent with what the pointer sends. */
+const recorder = (log, props) =>
+  h('box', {
+    focusable: true,
+    style: { width: 60, height: 20 },
+    onMouseDown: () => log.push('down'),
+    onMouseUp: () => log.push('up'),
+    onClick: () => log.push('click'),
+    ...props,
+  });
+
+test('a focusable box with an onClick answers Space and Enter', async () => {
+  const log = [];
+  const { app, wnd, root } = await mount(recorder(log));
+  const box = root.children[0];
+  box.focus();
+
+  press(app, wnd, XK_SPACE);
+  assert.deepStrictEqual(log, ['down', 'up', 'click'], 'Space presses it');
+
+  log.length = 0;
+  press(app, wnd, XK_RETURN);
+  assert.deepStrictEqual(log, ['down', 'up', 'click'], 'and so does Enter');
+
+  log.length = 0;
+  press(app, wnd, XK_KP_ENTER);
+  assert.deepStrictEqual(log, ['down', 'up', 'click'], 'and the keypad one');
+
+  // ntk decodes a key into keysym *and* code point; a widget's hand-rolled
+  // mapping always read the code point, so the rule that replaced them has
+  // to answer both spellings of the same key
+  log.length = 0;
+  type(app, wnd, XK_SPACE, 32);
+  assert.deepStrictEqual(log, ['down', 'up', 'click'], 'a decoded Space too');
+
+  log.length = 0;
+  press(app, wnd, XK_A);
+  assert.deepStrictEqual(log, [], 'an ordinary letter is not an activation');
+});
+
+test('the keyboard sends the gesture the pointer sends', async () => {
+  const keyboard = [];
+  const pointer = [];
+  const { app, wnd, root } = await mount(
+    h('box', { style: { gap: 10, padding: 10 } }, [
+      h('box', { key: 'k' }, recorder(keyboard)),
+      h('box', { key: 'p' }, recorder(pointer)),
+    ]),
+  );
+  const [byKey, byPointer] = root.children[0].children.map(
+    (n) => n.children[0],
+  );
+
+  byKey.focus();
+  press(app, wnd, XK_RETURN);
+  pressButton(wnd, byPointer.abs.x + 5, byPointer.abs.y + 5);
+  await settle();
+  assert.deepStrictEqual(
+    keyboard,
+    pointer,
+    'press, release, click — a control acting on the press hears it either way',
+  );
+});
+
+test('a press on the keyboard carries the modifiers it was made with', async () => {
+  let ev = null;
+  const { app, wnd, root } = await mount(
+    h('box', {
+      focusable: true,
+      style: { width: 60, height: 20 },
+      onClick: (e) => (ev = e),
+    }),
+  );
+  root.children[0].focus();
+
+  type(app, wnd, XK_RETURN, undefined, { shift: true });
+  assert.ok(ev, 'the click arrived');
+  assert.strictEqual(ev.shiftKey, true, 'Shift+Enter reads as a shift-click');
+  assert.strictEqual(ev.detail, 1, 'and as a single click');
+});
+
+test('preventDefault in the element’s own onKeyDown suppresses it', async () => {
+  const log = [];
+  const { app, wnd, root } = await mount(
+    recorder(log, {
+      onKeyDown: (ev) => {
+        log.push(`key:${ev.keysym}`);
+        ev.preventDefault();
+      },
+    }),
+  );
+  root.children[0].focus();
+
+  press(app, wnd, XK_RETURN);
+  assert.deepStrictEqual(
+    log,
+    [`key:${XK_RETURN}`],
+    'the handler ran and the click did not',
+  );
+});
+
+test('a role is not a click: nothing with no onClick is activated', async () => {
+  const log = [];
+  const { app, wnd, root } = await mount(
+    h('box', {
+      focusable: true,
+      role: 'button',
+      style: { width: 60, height: 20 },
+      onMouseDown: () => log.push('down'),
+      onKeyDown: () => log.push('key'),
+    }),
+  );
+  root.children[0].focus();
+
+  press(app, wnd, XK_SPACE);
+  assert.deepStrictEqual(
+    log,
+    ['key'],
+    'a role advertises an action to an AT; it is not one',
+  );
+});
+
+test('a text input types a space rather than pressing itself', async () => {
+  const log = [];
+  const { app, wnd, root } = await mount(
+    h('textinput', {
+      defaultValue: 'a',
+      style: { width: 80 },
+      onClick: () => log.push('click'),
+    }),
+  );
+  const input = find(root, (n) => n.kind === 'textinput');
+  input.focus();
+
+  type(app, wnd, XK_SPACE, 32);
+  await settle();
+  assert.strictEqual(input.value, 'a ', 'the space was typed');
+  assert.deepStrictEqual(log, [], 'and nothing was activated');
+});
+
+// The one place two default actions want the same key, and the answer the
+// scroll pane's own `defaultKeyDown` already gives: it takes Space before
+// the base class ever sees it.
+test('a scrolling box keeps Space for paging and activates on Enter', async () => {
+  const log = [];
+  const { app, wnd, root } = await mount(
+    h(
+      'box',
+      {
+        style: { overflow: 'scroll', width: 100, height: 100 },
+        onClick: () => log.push('click'),
+      },
+      h('box', { style: { height: 400 } }),
+    ),
+  );
+  const view = root.children[0];
+  view.focus();
+
+  press(app, wnd, XK_SPACE);
+  assert.strictEqual(view.scrollY, 76, 'Space still pages the pane');
+  assert.deepStrictEqual(log, [], 'and does not press it');
+
+  press(app, wnd, XK_RETURN);
+  assert.deepStrictEqual(log, ['click'], 'Enter, which pages nothing, does');
+});
+
+test('a focusable row inside a scroll pane takes the keys, and always did', async () => {
+  const log = [];
+  const { app, wnd, root } = await mount(
+    h(
+      'box',
+      { style: { overflow: 'scroll', width: 100, height: 100 } },
+      h('box', { style: { height: 400 } }, recorder(log, { role: 'option' })),
+    ),
+  );
+  const view = root.children[0];
+  const row = find(root, (n) => n.props.role === 'option');
+  row.focus();
+
+  press(app, wnd, XK_SPACE);
+  assert.deepStrictEqual(log, ['down', 'up', 'click'], 'the row is pressed');
+  assert.strictEqual(
+    view.scrollY,
+    0,
+    'and the pane does not page — it never did with a row focused, ' +
+      'because a default action runs on the focused node',
+  );
+});

--- a/test/atspi.test.js
+++ b/test/atspi.test.js
@@ -315,7 +315,10 @@ describe('the AT-SPI bridge', { concurrency: 1, ...needsBroker }, () => {
     await until(() => pressed === 1, 'the onClick handler');
 
     // Controls that act on the *press* — Select and MenuBar drop their
-    // menus on mousedown — must hear an AT activation too.
+    // menus on mousedown — must hear an AT activation too. The keyboard
+    // sends this same gesture through this same function, and the pair of
+    // assertions that says so is in test/accessibility.test.js §4 (#329):
+    // one definition of "activate", so the two paths cannot drift.
     let pressedDown = 0;
     x11Root.render(
       h(


### PR DESCRIPTION
Closes #329.

A focusable element with an `onClick` took focus, drew a ring, was reachable by Tab and was activatable by a screen reader — the AT-SPI bridge already synthesizes a click for anything with a handler — and did nothing at all when a keyboard-only user pressed Space or Enter. It looked operable and was not, which the focus ring makes *worse* rather than better: the ring is a promise. Every control an application builds out of a `<box>` rather than out of `Button` had it, silently.

Space and Enter are now a default action on the focused node, dispatching **the same gesture through the same function** the bridge uses — `synthesizeClick` in `src/events.js`: press, release, click, so a control acting on the mousedown (`Select`, `MenuBar`) hears it either way, and there is one definition of "activate" for the pointer, the keyboard and Orca rather than two that can drift. The key press's own modifier mask travels with it, so Shift+Enter reaches `onClick` as a shift-click.

## What it looks like

`examples/chat.jsx`, driven by this PR's own code with nothing but Tab and Enter — its channel rows are plain `<box focusable role="option" onClick>` and their six-line keyboard workaround is deleted in this PR.

**1. Tab moves the ring to `#x11`. `#general` is still the open channel.**

![1-tabbed-to-the-row](https://github.com/user-attachments/assets/85fb2ddd-fbd8-4278-8770-968ed6ccb602)

**2. Enter, before this change** — the ring is a promise the keyboard cannot cash. Identical to the frame above.

![2-after-enter-BEFORE](https://github.com/user-attachments/assets/cb2ba419-37bc-4b0a-8b9c-0911c93c9281)

**3. Enter, after** — the row is pressed and `#x11` opens.

![2-after-enter](https://github.com/user-attachments/assets/79b53925-04dc-46e3-b402-e1778d7b1981)

(Shot 2 is the same script with the new default action stubbed out in `Node.defaultKeyDown`, so all three frames come from this branch and differ only in that line.)

## The two decisions the issue left open

The issue asked four questions and said they were conventions rather than facts. The answers, each written down beside the code that implements it:

**One key rule, no role table** (Q1). The web's table is not uniform — `checkbox` takes Space and not Enter, a link takes Enter and not Space — because on the web those keys are already spoken for: Space scrolls the page, Enter submits the form. Neither is true here. A default action runs on the focused node, so the scroll pane a row sits in never sees the row's Space, and there is no implicit submit anywhere. All a role table could buy, then, is *fewer* keys working on a control that draws a focus ring, which is the bug this closes.

**A role is not a handler** (Q2, Q4). A bare `onClick` with no role activates — the bridge says yes and so does this. A `role="button"` carrying only an `onKeyDown` does not: the bridge's role clause exists to *advertise* an action to a technology that has no other way to ask for one, and the click it then dispatches is answered by whichever ancestor holds the handler. A key press is already at the node; there is nothing to advertise and no click to make. The shared half of the two rules is now literally shared — `hasClickHandler` in `src/a11y.js`, called by `a11yActivatable` and by the keyboard.

**Precedence against scrolling** (Q3) turned out not to need a rule. Default actions run on the focused node, so a focusable row inside a scrolling `<box>` already did not page with Space before this change — the pane's `defaultKeyDown` is never reached with the row focused. Nothing is taken away by giving the row the key. A pane that is *itself* clickable answers Space in its own `defaultKeyDown` and never reaches the base class, so it keeps paging and activates on Enter. Both cases are tested and the tests say which way they went.

## Fallout in the widgets

- `useControl` loses its hand-rolled `onKeyDown` — it was exactly the click core now makes, and it was the reason a widget answered the keyboard while a hand-built control beside it did not.
- `Tabs` loses its manual-mode Enter/Space commit for the same reason: committing the focused tab *is* that tab's own `onClick`.
- `Tree` keeps Enter and Space with a `preventDefault()`, which is the documented way out — a tree row's click moves the selection, and Enter opens what is already selected. Those are different actions, so the row's click must not also run.
- `Radio`'s arrow keys move to a handler of their own, now that there is no `useControl` `onKeyDown` for them to wrap. This is the one place the change would have gone silently wrong; `test/smoke.test.js` caught it.
- `Select`, `DatePicker` and `MenuBar` are untouched: their triggers act on `onMouseDown` and carry no `onClick`, so nothing double-fires.
- `Table`'s column headers gain the behaviour for free — Tab to one and press Enter and it sorts, which it did not before.

## Tests

Eight in `test/accessibility.test.js` §4, beside the ring they are about, each mutation-checked (five go red with the default action removed; the three that stay green are the negative ones, and the role test goes red when the rule is widened to roles):

- a focusable `<box onClick>` fires on Space, Enter, KP_Enter and a decoded Space, and not on a letter;
- the gesture the keyboard sends is byte-for-byte the gesture the pointer sends;
- the modifiers travel;
- `preventDefault()` in the element's own `onKeyDown` suppresses it;
- a role with no `onClick` is not activated;
- a `<textinput onClick>` types a space instead of pressing itself;
- a scrolling box keeps Space and activates on Enter;
- a row inside a scroll pane takes the keys and the pane does not page.

`test/atspi.test.js`'s activation test points at them, so the two paths cannot drift apart unnoticed.

## Docs

`events.md` gains "Space and Enter are a click" with the whole contract; `accessibility.md`, `elements.md`, `extending.md` and `components.md` are updated where they described the old split. `npm test` (1413 pass; the six `appearance.test.js` failures are the pre-existing macOS-only baseline), `npm run lint`, `npm run typecheck`, `prettier --check .` and the website build are green.

