### PR TITLE
fix(text): a field reads the direction of the box it is in

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -168,9 +168,12 @@ The rest each have one thing yoga could not answer:
 | `Calendar` / `DatePicker` | a week runs the other way, and so do Left/Right     |
 | `Select`, `PasswordInput` | the field's own insets follow the text              |
 
-`<textinput>` and `<textarea>` are the gap: they shape and draw bidi text
-correctly, but the field's own origin and caret scrolling are still
-left-to-right.
+`<textinput>` and `<textarea>` mirror on the inside too — the value, the
+placeholder and the caret are against the direction's start edge, and the
+value is shaped at the box's base level rather than at its own first strong
+character ([styling.md](styling.md#inside-an-editable-field)). What stays
+put: Left/Right and Home/End step through the string rather than across the
+screen.
 
 See [styling.md](styling.md#direction-and-the-logical-edges) for the style
 property and the logical edges.

--- a/docs/ecosystem/i18n.md
+++ b/docs/ecosystem/i18n.md
@@ -80,14 +80,10 @@ desktop choice; `i18next-http-backend` also works, since Node has `fetch`.
 These are react-x11 gaps rather than i18next ones, and they matter more than
 the library choice:
 
-- **Layout is computed left-to-right unconditionally.** react-x11 calls
-  yoga's `calculateLayout` with `DIRECTION_LTR` and there is no `direction`
-  style property, so an Arabic or Hebrew UI will mirror wrong even though
-  every string translates correctly. Yoga supports `DIRECTION_RTL`; wiring it
-  up is renderer work that has not been done.
-- **There is no X input method.** Input is limited to what the keyboard path
-  produces, with no XIM integration, so languages that need composition —
-  CJK, dead keys — can be _displayed_ but not typed.
+- **There is no X input method.** Dead keys and the Compose key are handled
+  in the renderer ([events.md](../events.md#composition)), but there is no
+  XIM/IBus integration, so a language that needs a real input method — CJK —
+  can be _displayed_ but not typed.
 - `<Trans>` with the default `<strong>`- and `<em>`-style numbered tags in
   translations is fine as long as every referenced component is a `<text>`
   span. An accidental DOM tag fails loudly at render, which is the good case.

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -1188,6 +1188,16 @@ across kerning, shaping boundaries and trailing whitespace.
 | `selectionColor`, `caretColor`    | selection/caret paint                      |
 | text style props                  | as `<text>`                                |
 
+The text style props include `textAlign`, and the field is laid out at its
+box's **direction** the way a `<text>` is: the value, the placeholder and the
+caret sit at the base direction's start edge — the right-hand one under
+`direction: 'rtl'` — and the value is shaped at that base level rather than
+at its own first strong character, which is what makes `"(1) 12:30 — نص"`
+punctuate the same way in a field and in the paragraph beside it. Clicking,
+the caret, the selection bands and the horizontal scroll are read from one
+placement, so they mirror together. See
+[styling.md](styling.md#inside-an-editable-field).
+
 ### The change event
 
 `onChange` and `onSubmit` get a synthetic event, the same shape every other

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -249,18 +249,44 @@ resize handle in a fixed corner.
 - **A `<window>`'s or `<popup>`'s explicit `x`/`y`** — screen coordinates.
 - **Vertical anything.** `top`/`bottom`, a column's order, a vertical
   scrollbar's travel, Up/Down on every control.
-- **`<textinput>` and `<textarea>`.** They shape and draw bidi text
-  correctly — that is ntk's doing — but the field's own origin, caret
-  scrolling and selection geometry are still written left-to-right. Wrapping
-  one in an RTL box mirrors the box around it and not the field inside it.
-  Tracked separately.
+- **The caret keys in a field.** Left and Right step through the _string_,
+  not across the screen, and so do Home and End — the editing model is
+  written in logical positions, and visual-order caret motion through bidi
+  text is its own question.
 
 What **does**, besides the box tree: a vertical scrollbar moves to the left;
 horizontal scrolling counts from the right-hand edge, so `scrollX: 0` still
 means "at the beginning"; `textAlign: 'start'`/`'end'` resolve against the
-box's direction rather than against the first strong character; and a popup
+box's direction rather than against the first strong character; a popup
 prefers the start side, so a submenu opens leftwards and still flips at the
-screen edge.
+screen edge; and the inside of a `<textinput>`/`<textarea>` — see below.
+
+### Inside an editable field
+
+A field is laid out at its box's direction, exactly as a `<text>` is, and the
+direction does two separate things there:
+
+- **It is the base level the value is shaped at.** UAX#9 resolves a run of
+  neutral characters — `"(1) 12:30"`, a filename, a lone bracket — against
+  the paragraph level, and "take it from the first strong character" is only
+  the rule for when nobody said. A field that never said reorders an Arabic
+  word typed into an English form as though the whole line were Arabic, in an
+  **LTR** window. So the field says.
+- **It is the edge the text is against.** The value, the placeholder and the
+  caret start at the direction's start edge — the right-hand one under
+  `direction: 'rtl'` — and an unscrolled field still shows the _beginning_ of
+  its value, so a value too long for its box overflows towards the left.
+  Clicking, the caret, the selection bands and the scroll are read from one
+  placement, so they mirror together.
+
+`textAlign` works on a field too: `'start'` (the default) is the base
+direction's start edge, and `'center'`/`'end'` do what they say while the
+value fits. A value that overflows its box is pinned to the start edge
+whatever the alignment says, because that is what it is scrolled from.
+
+The text's _own_ direction is not consulted: a Latin value in an RTL field is
+placed at the field's right edge, the way `<input dir="rtl">` places one, and
+there is no `dir="auto"` equivalent yet.
 
 ## Per-side borders
 

--- a/examples/settings.jsx
+++ b/examples/settings.jsx
@@ -50,15 +50,11 @@
 // **CJK.** No input method yet (#272), so the language list stops at scripts
 // you can type with a keyboard layout.
 //
-// ## What does not work yet
-//
-// **A field's text does not mirror (#341).** Pick Arabic and the window
-// flips, but a `<textinput>` still draws its value, its placeholder and its
-// caret from the *left* edge — it lays its text out without a base
-// direction and without an alignment, which `<text>` passes and it does
-// not. The search box at the top of the sidebar is where you see it. The
-// same omission reorders a mixed Latin/Arabic value wrongly in an LTR
-// window too, so it is not only an RTL problem.
+// **Visual-order caret keys.** Left and Right step through the string rather
+// than across the screen, in either direction — see `docs/styling.md`. The
+// fields themselves mirror (#341): pick Arabic and the search box at the top
+// of the sidebar draws its placeholder, its value and its caret from the
+// right, like everything around it.
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';

--- a/src/atspi.js
+++ b/src/atspi.js
@@ -925,9 +925,14 @@ class AtspiBridge {
     return [x, y, rect.width, rect.height];
   }
 
-  /** Where the text control paints its characters: the content box, minus
-   * the horizontal scroll a long value has been dragged by. */
+  /** Where the text control paints its characters. An element that answers
+   * `_placedValue` — every field in core does — has already resolved this,
+   * scroll and reading direction included, and it is the same answer the
+   * caret and the highlight are drawn from; the box minus its scroll is the
+   * fallback for one that only answers the geometry accessors. */
   _textOrigin(node) {
+    const placed = node._placedValue?.();
+    if (placed) return { x: placed.x, y: placed.y };
     const content = node.contentBox?.() ?? node.abs;
     return {
       x: content.x - (node._scrollX ?? 0),

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -5149,6 +5149,15 @@ export function closeEditMenu(node) {
   events.focus(events._canRestoreTo(restore) ? restore : null, 'pointer');
 }
 
+/** The caret's own width, in pixels — it is a rectangle rather than a line
+ * because a hairline disappears on a scaled-up display. */
+const CARET_WIDTH = 1.5;
+
+/** The room a line of a field's text leaves for the caret that follows it,
+ * at the right-hand edge of the content box in both directions — see
+ * `TextInputNode._lineOriginX`, which is where the asymmetry is explained. */
+const CARET_RESERVE = 2;
+
 /**
  * <textinput>: single-line editable text. Caret/selection via ntk TextLayout
  * prefix measurement, editing via the EventManager default-action hooks
@@ -5460,19 +5469,26 @@ export class TextInputNode extends Node {
     return cap ? Math.round(cap) : this._lineHeight();
   }
 
-  /** Shaped layout of the current value, cached per (value, style).
+  /** Shaped layout of the current value, cached per (value, style,
+   * direction).
    * Caret math rides ntk >= 3.3.0's TextLayout caret API, which is exact
    * across kerning/shaping boundaries, bidi runs and trailing whitespace
-   * (replaces the prefix-width measurement this used before). */
+   * (replaces the prefix-width measurement this used before).
+   *
+   * Laid out at its **natural width**, with no `maxWidth` and no `align`:
+   * a single-line field never wraps, and a `maxWidth` is what makes ntk
+   * break lines. So the alignment ntk would have applied inside the layout
+   * box is applied to the box instead, by `_lineOriginX` — see there. */
   _valueLayout() {
     const fonts = this.app?.fonts;
     if (!fonts) return null;
     const text = this._displayValue();
     const s = this.resolvedTextStyle();
-    const key = `${text}|${s.family}|${s.size}|${s.weight}|${s.style}`;
+    const direction = this.direction;
+    const key = `${text}|${s.family}|${s.size}|${s.weight}|${s.style}|${direction}`;
     if (this._valueLayoutKey !== key) {
       this._valueLayoutKey = key;
-      this._valueLayoutCache = fonts.layout(text, s);
+      this._valueLayoutCache = fonts.layout(text, s, { direction });
     }
     return this._valueLayoutCache;
   }
@@ -5928,6 +5944,59 @@ export class TextInputNode extends Node {
     };
   }
 
+  /**
+   * Where a line of the field's text starts, in window coordinates, before
+   * the scroll offset — the whole of the field's horizontal placement, and
+   * the only place that knows which edge the text is against.
+   *
+   * The line is laid out at its natural width (`_valueLayout`), so ntk had
+   * no container to align it in and `line.x` is 0. This is that alignment:
+   * `textAlign` resolved against the base direction, which is what puts an
+   * RTL field's value, placeholder and caret on the right-hand side without
+   * anybody asking for it.
+   *
+   * **The caret is why the reserve is at the right in both directions.** A
+   * caret is a rectangle drawn *rightwards* from the boundary it marks, so
+   * the one position that can fall outside the content box is the rightmost
+   * one: the end of the text in LTR — which is what the `+ 2` in the scroll
+   * clamp has always been keeping room for — and the *start* of it in RTL,
+   * where the text is flush against the right edge and index 0 sits on it.
+   * Without the reserve an empty RTL field has no visible caret at all.
+   *
+   * Alignment only has a say while the text fits. An overflowing field
+   * scrolls, and `_scrollX: 0` means "showing the start of the value", so
+   * the start edge is where an overflowing line is pinned whatever the
+   * alignment says.
+   */
+  _lineOriginX(layout, content) {
+    const rtl = this.direction === 'rtl';
+    const free = content.width - CARET_RESERVE - layout.width;
+    let align = this.style.textAlign ?? 'start';
+    if (align === 'start') align = rtl ? 'right' : 'left';
+    else if (align === 'end') align = rtl ? 'left' : 'right';
+    const offset = align === 'right' ? free : align === 'center' ? free / 2 : 0;
+    return content.x + (rtl ? Math.min(free, offset) : Math.max(0, offset));
+  }
+
+  /**
+   * How far the text is displaced by the scroll, signed. `_scrollX` counts
+   * from the start of the value in both directions — the rule
+   * `ScrollableNode` follows for a scroll box — and the start is the
+   * right-hand edge when the field reads right to left, so the text it
+   * uncovers is to the *left* and the displacement is the other way.
+   */
+  _scrollShift() {
+    return this.direction === 'rtl' ? this._scrollX : -this._scrollX;
+  }
+
+  /** How far a value wider than its box can be scrolled. The reserve is the
+   * caret's, the same one `_lineOriginX` keeps: at full scroll the far end
+   * of the text stops short of the edge by exactly the width of the caret
+   * that sits there. */
+  _maxScrollX(layout, content) {
+    return Math.max(0, layout.width - (content.width - CARET_RESERVE));
+  }
+
   /** The value's layout and where it is drawn, in window coordinates. The
    * placeholder is not in it: the accessors answer about the text the field
    * holds, and an empty field holds none. */
@@ -5940,7 +6009,11 @@ export class TextInputNode extends Node {
       content,
       this.resolvedTextStyle(),
     );
-    return { layout, x: content.x - this._scrollX, y: metrics.textY };
+    return {
+      layout,
+      x: this._lineOriginX(layout, content) + this._scrollShift(),
+      y: metrics.textY,
+    };
   }
 
   /** The value. The indices below are into this string, in code points — an
@@ -6225,7 +6298,13 @@ export class TextInputNode extends Node {
     const color = isEmpty
       ? (this.props.placeholderColor ?? this.theme.textMuted)
       : style.color;
-    const layout = fonts.layout([{ text: shown, ...style, color }], style);
+    // The placeholder is the *field's* chrome rather than the user's
+    // content, so it is laid out and placed at the field's own direction —
+    // an English hint in an Arabic form starts at the right-hand edge with
+    // everything else in the window.
+    const layout = fonts.layout([{ text: shown, ...style, color }], style, {
+      direction: this.direction,
+    });
     const { textY, markY, markHeight } = this._lineMetrics(
       layout,
       content,
@@ -6239,20 +6318,35 @@ export class TextInputNode extends Node {
     // were simply missing, which reads as a rendering bug rather than as a
     // scroll position. An unfocused field shows the beginning of its value,
     // the way a DOM input does.
+    //
+    // The chase is in *visual* coordinates — how far the caret is from the
+    // left of the content box once the value has been placed and scrolled —
+    // because that is the question the viewport asks, and it is the same
+    // question in both directions. Which way the scroll displaces the text
+    // is `_scrollShift`'s business.
+    const valueLayout = this._valueLayout();
     const caretX = this._prefixWidth(this._caret);
-    const textWidth = isEmpty ? 0 : layout.width;
+    // where the caret sits before the scroll, relative to the content box
+    const caretAt = valueLayout
+      ? this._lineOriginX(valueLayout, content) + caretX - content.x
+      : caretX;
+    const limit = content.width - CARET_RESERVE;
     if (!this._focused) this._scrollX = 0;
     else {
-      if (caretX - this._scrollX > content.width - 2) {
-        this._scrollX = caretX - content.width + 2;
-      }
-      if (caretX - this._scrollX < 0) {
-        this._scrollX = caretX;
-      }
+      let shift = this._scrollShift();
+      if (caretAt + shift > limit) shift = limit - caretAt;
+      if (caretAt + shift < 0) shift = -caretAt;
+      this._scrollX = this.direction === 'rtl' ? shift : -shift;
     }
-    this._scrollX = Math.min(
-      this._scrollX,
-      Math.max(0, textWidth - content.width + 2),
+    // The extent is the *value*'s, never the placeholder's: a hint longer
+    // than the box is clipped, not scrolled, since nothing can move the caret
+    // through it.
+    this._scrollX = Math.max(
+      0,
+      Math.min(
+        this._scrollX,
+        valueLayout ? this._maxScrollX(valueLayout, content) : 0,
+      ),
     );
 
     ctx.save();
@@ -6264,12 +6358,19 @@ export class TextInputNode extends Node {
     const clip = this._inkClip(content);
     ctx.rect(clip.x, clip.y, clip.width, clip.height);
     ctx.clip();
-    const originX = content.x - this._scrollX;
+    const shift = this._scrollShift();
+    // Where the ink goes, and where the marks over the value go. They are
+    // the same origin whenever there is a value to mark: the two differ only
+    // for an empty field, where the ink is the placeholder — as wide as the
+    // hint and placed for it — and the caret still belongs to the value,
+    // which is empty and sits at the start edge.
+    const originX = this._lineOriginX(layout, content) + shift;
+    const valueX = valueLayout
+      ? this._lineOriginX(valueLayout, content) + shift
+      : originX;
 
     const [a, b] = this._selection();
-    if (this._showsSelection() && a !== b && !isEmpty) {
-      const selStart = this._prefixWidth(a);
-      const selEnd = this._prefixWidth(b);
+    if (this._showsSelection() && a !== b && !isEmpty && valueLayout) {
       // A **translucent** accent rather than an opaque light blue. The ink
       // on top is `style.color`, which this fill does not control, so an
       // opaque highlight has to be picked to contrast with it — and no one
@@ -6278,15 +6379,30 @@ export class TextInputNode extends Node {
       // Tinting the surface instead leaves the ink's own contrast intact.
       ctx.fillStyle =
         this.props.selectionColor ?? tint(this.theme.accent, 0.35);
-      ctx.fillRect(originX + selStart, markY, selEnd - selStart, markHeight);
+      // One band per direction run, not one rectangle between the two caret
+      // positions: a range is contiguous in logical order and a line is laid
+      // out in visual order, so a selection that crosses into an Arabic word
+      // covers two disjoint stretches of pixels and the single rect this
+      // used to draw painted over text nobody had selected. The bands are
+      // `textRangeRects`'s, so the highlight is the geometry the accessors
+      // report; only the vertical extent is the field's own — a field
+      // highlights the cap band with breathing room rather than the line box.
+      for (const band of rangeBands(
+        valueLayout,
+        this._displayValue(),
+        this._displayIndex(a),
+        this._displayIndex(b),
+      )) {
+        ctx.fillRect(valueX + band.x, markY, band.width, markHeight);
+      }
     }
 
     layout.draw(ctx, originX, textY);
-    this._paintPreedit(ctx, originX, textY, style);
+    this._paintPreedit(ctx, valueX, textY, style);
 
     if (this._focused && this._caretOn && a === b) {
       ctx.fillStyle = this.props.caretColor ?? style.color;
-      ctx.fillRect(originX + caretX, markY, 1.5, markHeight);
+      ctx.fillRect(valueX + caretX, markY, CARET_WIDTH, markHeight);
     }
     ctx.restore();
   }
@@ -6416,12 +6532,33 @@ export class TextAreaNode extends TextInputNode {
     const color = isEmpty
       ? (this.props.placeholderColor ?? this.theme.textMuted)
       : s.color;
+    const direction = this.direction;
+    const align = this.style.textAlign ?? 'start';
+    // A wrapped field *has* a container, so — unlike `<textinput>` — the
+    // alignment is ntk's to apply: every line is placed inside the box it
+    // wrapped to, and `start` is resolved against the base direction, which
+    // puts an RTL value against the right-hand edge.
+    //
+    // The container is the content box less the caret's own width, because
+    // in RTL every line *starts* flush against that right edge — line 0,
+    // column 0 of an empty field included — and a caret is drawn rightwards
+    // from the boundary it marks, so with no reserve it lands entirely
+    // outside the clip and an RTL textarea shows no caret at all. In LTR the
+    // flush edge is the left one, where the caret has the whole box in front
+    // of it, and only a line that fills its width exactly could reach the
+    // other end — so nothing is taken off a direction that does not need it.
     const width = this.contentBox().width || undefined;
-    const key = `${width}|${color}|${shown}|${s.family}|${s.size}|${s.weight}|${s.style}`;
+    const container =
+      width === undefined || direction !== 'rtl'
+        ? width
+        : Math.max(0, width - CARET_RESERVE);
+    const key = `${width}|${color}|${shown}|${s.family}|${s.size}|${s.weight}|${s.style}|${direction}|${align}`;
     if (this._valueLayoutKey !== key) {
       this._valueLayoutKey = key;
       this._valueLayoutCache = fonts.layout([{ text: shown, ...s, color }], s, {
-        maxWidth: width,
+        maxWidth: container,
+        align,
+        direction,
       });
     }
     return this._valueLayoutCache;
@@ -6609,8 +6746,6 @@ export class TextAreaNode extends TextInputNode {
 
     const [a, b] = this._selection();
     if (this._showsSelection() && a !== b && !isEmpty) {
-      const posA = layout.caretPosition(this._displayIndex(a));
-      const posB = layout.caretPosition(this._displayIndex(b));
       // A **translucent** accent rather than an opaque light blue. The ink
       // on top is `style.color`, which this fill does not control, so an
       // opaque highlight has to be picked to contrast with it — and no one
@@ -6619,32 +6754,27 @@ export class TextAreaNode extends TextInputNode {
       // Tinting the surface instead leaves the ink's own contrast intact.
       ctx.fillStyle =
         this.props.selectionColor ?? tint(this.theme.accent, 0.35);
-      // Only the lines on screen, and all of them in one request. Ctrl+A in
-      // a 5000-line value selects 5000 lines and shows twenty: the clip
-      // throws the rest away *after* they have been sent, which is the one
-      // cost a clip cannot save. `indexAt` finds the first visible line
-      // without walking the list to it — conservatively, since an index on a
-      // wrap boundary answers with the line before, and one rect outside the
-      // clip is free where a scan of every line above the viewport is not.
+      // The bands `textRangeRects` reports — one per line and one per
+      // direction run inside a line, which is what a selection crossing into
+      // an Arabic word actually covers. Two caret positions and a rectangle
+      // between them, which is what this was, paints over text nobody
+      // selected on a line that has runs going both ways.
+      //
+      // Only the lines on screen are *sent*, and all of them in one request.
+      // Ctrl+A in a 5000-line value selects 5000 lines and shows twenty: the
+      // clip throws the rest away *after* they have been sent, which is the
+      // one cost a clip cannot save.
       const bottom = this._scrollY + content.height;
-      const first = Math.max(
-        posA.line,
-        layout.caretPosition(layout.indexAt(-1e6, this._scrollY)).line,
-      );
       const rects = [];
-      for (let li = first; li <= posB.line; li++) {
-        const line = layout.lines[li];
-        if (!line || line.y > bottom) break;
-        const x0 = li === posA.line ? posA.x : line.x;
-        const x1 = li === posB.line ? posB.x : line.x + line.width;
-        // a selected bare newline still shows as a sliver
-        const w = Math.max(x1 - x0, 4);
-        rects.push(
-          originX + x0,
-          originY + line.y,
-          w,
-          line.ascent + line.descent,
-        );
+      for (const band of rangeBands(
+        layout,
+        this._displayValue(),
+        this._displayIndex(a),
+        this._displayIndex(b),
+      )) {
+        if (band.y > bottom) break;
+        if (band.y + band.height < this._scrollY) continue;
+        rects.push(originX + band.x, originY + band.y, band.width, band.height);
       }
       // one `Render.FillRectangles` for the whole highlight, where a fill per
       // line is a full-surface-masked composite per line (ntk >= 7.6)
@@ -6656,7 +6786,7 @@ export class TextAreaNode extends TextInputNode {
 
     if (this._focused && this._caretOn && a === b) {
       ctx.fillStyle = this.props.caretColor ?? this.resolvedTextStyle().color;
-      ctx.fillRect(originX + pos.x, originY + pos.y, 1.5, pos.height);
+      ctx.fillRect(originX + pos.x, originY + pos.y, CARET_WIDTH, pos.height);
     }
     // inside the clip, so the thumb is bounded by the content box
     this._paintScrollbar(ctx, layout);

--- a/test/rtl.test.js
+++ b/test/rtl.test.js
@@ -5,8 +5,16 @@
 // side reads as a bug in a way that no support at all does not. So the two
 // halves are tested together: the direction that reaches yoga, and the
 // logical edges a stylesheet written for both directions is spelled in.
-import { test } from 'node:test';
+//
+// The last section is the same claim for the inside of an editable field
+// (issue #341), where the base direction is not only about which edge the
+// text is against: it is the level UAX#9 resolves brackets, digits and
+// dashes at, so a field that never states one reorders mixed content
+// wrongly in an *LTR* window too.
+import { test, afterEach } from 'node:test';
 import assert from 'node:assert';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
 import React from 'react';
 import {
   createRoot,
@@ -18,6 +26,13 @@ import {
 import { anchorRect } from '../src/components/anchor.js';
 import { localeDirection } from '../src/palette.js';
 import { createMockApp } from './helpers/mock-app.js';
+import {
+  act,
+  cleanup,
+  countPixels,
+  renderX11,
+  userEvent,
+} from '../src/testing/index.js';
 
 const h = React.createElement;
 const tick = () => new Promise((resolve) => setImmediate(resolve));
@@ -572,4 +587,282 @@ test('a text node hands its base direction to the shaper', async () => {
     'UAX#9 resolves neutrals against the paragraph level, so the box has to ' +
       'say what it is — and `textAlign: start` is resolved from it too',
   );
+});
+
+// --- inside a field (issue #341) ---------------------------------------------
+//
+// `<text>` above proves the base direction reaches the shaper. These prove the
+// same for `<textinput>`/`<textarea>`, and then the half a paragraph does not
+// have: a field is a viewport over its value, so where the value is placed,
+// where a click lands in it and which way it scrolls all have to mirror
+// together — `_placedValue()` is the one function they are all read from, and
+// a test per reader is what stops them drifting apart.
+
+const require = createRequire(import.meta.url);
+const FONT = join(
+  dirname(require.resolve('katex/package.json')),
+  'dist',
+  'fonts',
+  'KaTeX_Main-Regular.ttf',
+);
+// Pixel assertions need a font that is the same file on every machine —
+// `fc-match` is a different answer per box and no answer in a container. The
+// Arabic below has no glyphs in it and draws as notdef boxes, which is fine
+// and is the point: bidi is decided by the *characters*, so the ordering
+// under test is the same ordering a font with Arabic in it would shape.
+const fonts = { 'sans-serif': FONT };
+// A run of neutrals — brackets, digits, a colon, a dash — in front of a
+// strong RTL word. Exactly the string the first-strong-character rule gets
+// wrong: it resolves the paragraph as RTL and mirrors the brackets.
+const MIXED = '(1) 12:30 — نص';
+
+afterEach(cleanup);
+
+/** The visual run order, as logical ranges: `[[start, end], …]` left to
+ * right. What "the same glyph order" means when the glyphs are notdef. */
+const runOrder = (layout) => layout.lines[0].runs.map((r) => [r.start, r.end]);
+
+/** How much of a region is *not* the background — the ink, counted rather
+ * than sampled, since the question is which half of the box it is in. */
+const inkIn = async (ctx, region, background = '#ffffff') =>
+  region.width * region.height - (await countPixels(ctx, region, background));
+
+/** A window at `direction` with one field in it, over a white background. */
+async function fieldWindow(direction, props, kind = 'textinput') {
+  const view = await renderX11(
+    h(
+      'window',
+      {
+        width: 300,
+        height: 90,
+        style: { direction, padding: 10, backgroundColor: '#ffffff' },
+      },
+      h('text', { 'data-testname': 'para', style: { fontSize: 14 } }, MIXED),
+      h(kind, {
+        role: 'textbox',
+        'data-testname': 'field',
+        style: { width: 240, fontSize: 14, color: '#000000' },
+        ...props,
+      }),
+    ),
+    { fonts, width: 300, height: 90 },
+  );
+  return { ...view, field: view.getByTestName('field') };
+}
+
+test('a field lays its value out at the box direction, not at the first strong character', async () => {
+  // The LTR half of #341, and the half that is wrong in the direction almost
+  // everyone runs in: an Arabic word in an English form makes the *first
+  // strong character* Arabic, so a paragraph with no stated base level comes
+  // out RTL and `(1) 12:30` renders as `)1( 12:30`.
+  for (const direction of ['ltr', 'rtl']) {
+    const { field, getByTestName } = await fieldWindow(direction, {
+      value: MIXED,
+    });
+    const paragraph = getByTestName('para');
+    assert.deepStrictEqual(
+      runOrder(field._valueLayout()),
+      runOrder(paragraph._layoutFor(Infinity)),
+      `the field and the <text> reorder ${direction} identically`,
+    );
+    await cleanup();
+  }
+
+  // …and what that ordering *is*, so the two agreeing on the wrong answer
+  // would still fail: under `ltr` the leading neutrals stay leading.
+  const { field } = await fieldWindow('ltr', { value: MIXED });
+  assert.deepStrictEqual(
+    runOrder(field._valueLayout())[0],
+    [0, 4],
+    'the brackets and the digit are the leftmost thing on the line',
+  );
+});
+
+test('an RTL field puts its value, and its placeholder, against the right edge', async () => {
+  for (const [direction, half] of [
+    ['ltr', 'left'],
+    ['rtl', 'right'],
+  ]) {
+    for (const props of [{ value: 'Latin' }, { placeholder: 'Latin' }]) {
+      const { field, ctx } = await fieldWindow(direction, props);
+      const content = field.contentBox();
+      const width = Math.floor(content.width / 2);
+      const band = { y: field.abs.y, width, height: field.abs.height };
+      const left = await inkIn(ctx, { ...band, x: content.x });
+      const right = await inkIn(ctx, { ...band, x: content.x + width });
+      const what = Object.keys(props)[0];
+      if (half === 'left') {
+        assert.ok(left > 0 && right === 0, `${direction}: ${what} on the left`);
+      } else {
+        assert.ok(
+          right > 0 && left === 0,
+          `${direction}: ${what} on the right`,
+        );
+      }
+      await cleanup();
+    }
+  }
+});
+
+test('an empty RTL field blinks its caret at the right edge of the content box', async () => {
+  for (const direction of ['ltr', 'rtl']) {
+    const { field, ctx } = await fieldWindow(direction, { defaultValue: '' });
+    const content = field.contentBox();
+    // The caret is a rectangle drawn *rightwards* from the boundary it marks,
+    // so an RTL field has to keep its own width free at the flush edge or the
+    // one thing an empty field draws lands outside the clip.
+    const right = content.x + content.width;
+    const caret = field.textCaretRect(0);
+    if (direction === 'ltr') {
+      assert.strictEqual(caret.x, content.x, 'ltr: at the left edge');
+    } else {
+      assert.ok(
+        caret.x < right && caret.x >= right - 3,
+        `rtl: within a caret of the right edge, got ${caret.x} against ${right}`,
+      );
+    }
+
+    // and it is painted where the accessor says, which is the assertion the
+    // geometry alone cannot make
+    await userEvent.click(field);
+    field._repaint();
+    await act();
+    const band = {
+      y: field.abs.y,
+      width: Math.floor(content.width / 2),
+      height: field.abs.height,
+    };
+    const near = await inkIn(ctx, {
+      ...band,
+      x: direction === 'rtl' ? content.x + band.width : content.x,
+    });
+    const far = await inkIn(ctx, {
+      ...band,
+      x: direction === 'rtl' ? content.x : content.x + band.width,
+    });
+    assert.ok(near > 0, `${direction}: the caret is drawn on the start side`);
+    assert.strictEqual(far, 0, `${direction}: and nothing is on the other`);
+    await cleanup();
+  }
+});
+
+test('a click in an RTL field lands where the text is, not where it would be in LTR', async () => {
+  // The hit test and the paint are the pair that silently drift: a value
+  // placed on the right and hit-tested from the left puts the caret in a
+  // different character from the one under the pointer, and nothing about
+  // the screen says so until someone types.
+  for (const [direction, expected] of [
+    ['ltr', 5],
+    ['rtl', 0],
+  ]) {
+    const { field } = await fieldWindow(direction, { value: 'Latin' });
+    const content = field.contentBox();
+    const middle = content.x + content.width / 2;
+    assert.strictEqual(
+      field.textIndexAt(middle, content.y + 2),
+      expected,
+      `${direction}: the middle of the box is ${expected === 0 ? 'before' : 'after'} a short value`,
+    );
+    // …and the caret the click asks for is drawn back at the click's own end
+    // of the box, which is what proves the two read one geometry
+    const caret = field.textCaretRect(expected);
+    const side = direction === 'rtl' ? caret.x > middle : caret.x < middle;
+    assert.ok(side, `${direction}: the caret is on the value's own side`);
+    await cleanup();
+  }
+});
+
+test('an overflowing RTL field scrolls from the right, and _scrollX still counts from the start', async () => {
+  // `_scrollX: 0` means "showing the beginning of the value" in both
+  // directions — the rule a scroll box already follows — so in RTL it is the
+  // *right-hand* end that is showing and the text overflows to the left.
+  //
+  // The value is Arabic rather than Latin because that is what makes the
+  // sentence above one sentence: the paragraph's start edge is the right,
+  // and the *string's* start is only there too when the string reads that
+  // way. Latin in an RTL field is one LTR run placed against that same right
+  // edge, so what overflows is its beginning — which is what a browser shows
+  // for `<input dir="rtl">` too, and is the placement working rather than
+  // failing.
+  const long =
+    'نص طويل جدا لا يتسع داخل هذا الحقل الصغير أبدا وهو كذلك ولا يزال طويلا جدا';
+  const { field } = await fieldWindow('rtl', { value: long });
+  const content = field.contentBox();
+  const layout = field._valueLayout();
+  assert.ok(layout.width > content.width, 'the premise: it overflows');
+  assert.strictEqual(field._scrollX, 0, 'an unfocused field shows the start');
+  assert.ok(
+    field._placedValue().x + layout.width > content.x + content.width - 4,
+    'the start of the value is against the right edge, the rest runs left',
+  );
+
+  // typing at the end pulls the far end of the value into view, which in RTL
+  // means the text moves *right* rather than left
+  const before = field._placedValue().x;
+  await userEvent.click(field);
+  field._caret = Array.from(long).length;
+  field._repaint();
+  await act();
+  assert.ok(field._scrollX > 0, 'the caret chase scrolled to the end');
+  assert.ok(
+    field._placedValue().x > before,
+    'and it displaced the text to the right, not to the left',
+  );
+  assert.ok(
+    field.textCaretRect(field._caret).x >= content.x - 1,
+    'the caret it chased is inside the box',
+  );
+});
+
+test('the arrow keys and Home/End stay logical under either direction', async () => {
+  // Deliberately *not* mirrored. Left/Right step through the string rather
+  // than across the screen, which is what Home/End already do and what the
+  // editing model is written in; visual-order caret motion through bidi text
+  // is a separate question from where the field draws (issue #272's half).
+  for (const direction of ['ltr', 'rtl']) {
+    const { field } = await fieldWindow(direction, { value: 'Latin' });
+    await userEvent.click(field);
+    await userEvent.key(0xff50); // Home
+    assert.strictEqual(field._caret, 0, `${direction}: Home is the start`);
+    await userEvent.key(XK.RIGHT);
+    assert.strictEqual(field._caret, 1, `${direction}: Right steps forward`);
+    await userEvent.key(XK.LEFT);
+    assert.strictEqual(field._caret, 0, `${direction}: Left steps back`);
+    await userEvent.key(0xff57); // End
+    assert.strictEqual(field._caret, 5, `${direction}: End is the end`);
+    await cleanup();
+  }
+});
+
+test('a <textarea> aligns its wrapped lines at the base direction', async () => {
+  // The field with a container of its own: it wraps, so the alignment is
+  // ntk's to apply inside the layout rather than the placement's, and the
+  // two elements have to arrive at the same screen.
+  for (const direction of ['ltr', 'rtl']) {
+    const { field } = await fieldWindow(
+      direction,
+      { value: 'one two three four five six seven eight nine ten', rows: 3 },
+      'textarea',
+    );
+    const layout = field._valueLayout();
+    const content = field.contentBox();
+    assert.ok(layout.lines.length > 1, 'the premise: it wrapped');
+    const shortest = layout.lines.reduce((a, l) => (l.width < a.width ? l : a));
+    if (direction === 'ltr') {
+      assert.strictEqual(shortest.x, 0, 'ltr: every line starts at the left');
+    } else {
+      assert.ok(
+        shortest.x > 0,
+        `rtl: a short line is pushed right, got x ${shortest.x}`,
+      );
+      // and the caret at the start of a line is inside the box rather than
+      // on the far side of the clip — the reserve the container leaves
+      const caret = field.textCaretRect(0);
+      assert.ok(
+        caret.x <= content.x + content.width - 1,
+        `rtl: the line-start caret is inside the content box, got ${caret.x}`,
+      );
+    }
+    await cleanup();
+  }
 });

--- a/website/src/demos/rtl.js
+++ b/website/src/demos/rtl.js
@@ -5,13 +5,22 @@ export default {
     'One <ThemeProvider value={{ direction }}> mirrors the whole panel — ' +
     'rows run the other way, every logical edge swaps sides, the ' +
     "scrollbar moves to the left, and the widgets' own arithmetic follows: " +
-    'the slider travels the other way and its arrow keys swap with it. The ' +
-    'default comes from the locale, so an app started under LANG=ar_EG is ' +
-    'already like this. Click the button.',
+    'the slider travels the other way and its arrow keys swap with it. It ' +
+    'reaches inside a text field too: the value, the placeholder and the ' +
+    'caret go to the other edge, and the brackets around the number are ' +
+    'reordered because the box says which way the line reads. The default ' +
+    'comes from the locale, so an app started under LANG=ar_EG is already ' +
+    'like this. Click the button.',
   code: `import React, { useState } from 'react';
 import {
   createRoot, createStyles, ThemeProvider, Slider, Checkbox, Switch,
 } from 'react-x11';
+
+// Neutral characters — brackets, digits, a colon — in front of a strong
+// right-to-left word. Which way they face is decided by the box, not by the
+// first letter in the string, which is why the <text> and the field below
+// always agree.
+const MIXED = '(1) 12:30 — نص';
 
 const s = createStyles({
   root: { flexGrow: 1, padding: 14, gap: 10, backgroundColor: '#f4f6f8' },
@@ -35,6 +44,12 @@ const s = createStyles({
     paddingStart: 10,
     marginStart: 2,
   },
+  // A field is laid out at its box's direction like anything else: the value,
+  // the placeholder and the caret start at the edge the text begins at.
+  field: {
+    fontSize: 13, padding: 6, backgroundColor: '#ffffff',
+    borderWidth: 1, borderColor: '#d8dee4', borderRadius: 6,
+  },
   // …and the indent of a tree row means "inside", not "to the right"
   row: { flexDirection: 'row', alignItems: 'center', gap: 6, height: 20 },
   list: { height: 78, overflow: 'scroll', backgroundColor: '#ffffff',
@@ -46,7 +61,7 @@ function App() {
   const [volume, setVolume] = useState(30);
 
   return (
-    <window x={20} y={30} width={420} height={330} title="direction" style={s.root}>
+    <window x={20} y={30} width={420} height={430} title="direction" style={s.root}>
       <box style={s.button} onClick={() => setRtl(!rtl)}>
         <text style={{ color: '#ffffff', fontSize: 13 }}>
           {rtl ? 'switch to ltr' : 'switch to rtl'}
@@ -63,6 +78,13 @@ function App() {
           <text style={{ fontSize: 12, color: '#7b8794' }}>
             volume {volume}
           </text>
+
+          {/* the same string laid out twice: a paragraph and an editable
+              field, which mirror together because both are laid out at the
+              direction of the box they are in */}
+          <text style={{ fontSize: 13 }}>{MIXED}</text>
+          <textinput defaultValue={MIXED} style={s.field} />
+          <textinput placeholder="type here" style={s.field} />
         </box>
 
         <box style={s.list}>


### PR DESCRIPTION
Closes #341.

`TextNode` hands ntk a base direction and an alignment when it lays a paragraph out. `TextInputNode` handed it neither, and the two halves of that omission are separate bugs.

**Before** — master (fb88575), the same scene rendered by that checkout:

![before](https://github.com/user-attachments/assets/1bd6525a-4988-4a0b-b8ca-8012199d45c1)

**After** — this branch:

![after](https://github.com/user-attachments/assets/5b0718bc-f6cb-4c15-8d8c-1143977d3a28)

Both shots are rendered by the code they illustrate: `renderX11` into node-x11's in-process X server, read back with `getImageData`, saved with `toPNG`.

## The two halves

**The base direction is the one that bites in an LTR window**, which is where almost everyone meets it. UAX#9 resolves a run of neutrals — `"(1) 12:30"`, a filename, a lone bracket — against the paragraph level, and "take it from the first strong character" is only the rule for when nobody said. Nobody ever said, for a field: in the left column above, the `<text>` reads `(1) 12:30 — نص` and the field under it read `)1( 12:30 — نص`. It says now, and the two agree.

**The alignment is the visible half.** #271 mirrored the layout, so a window flipped correctly and then every field inside it kept its value, its placeholder and its caret against the physically-left edge — a half-finished mirror. The value is now placed at the base direction's start edge, and since `_placedValue()` is the one function `paintContent`, `textIndexAt`, `textCaretRect` and `textRangeRects` all read, the paint, the hit test, the caret and the selection bands mirror together or not at all.

## Three decisions worth reviewing

- **The alignment is applied to the box, not inside the layout.** ntk aligns within a `maxWidth`, and a `maxWidth` is also what makes it *wrap* — which a single-line field must never do. So `<textinput>` lays its value out at its natural width and `_lineOriginX` places it; `<textarea>`, which has a container because it wraps, passes `align` to ntk and lets it place each line. This is the one place the change departs from the issue's sketch. `textAlign` works on both fields as a result, with `'start'` the default.
- **The caret is why the reserve is at the right in both directions.** A caret is a rectangle drawn *rightwards* from the boundary it marks, so the one position that can fall outside the content box is the rightmost one: the end of the text in LTR — which is what the `+ 2` in the scroll clamp has always been keeping room for — and the *start* of it in RTL, where the text is flush against that edge and index 0 sits on it. Without the reserve an empty RTL field draws no caret at all, which is why the RTL textarea's wrap container is inset by it too.
- **`_scrollX` still counts from the start of the value.** Its clamp and both caret-chasing branches assumed the text starts at the left and overflows right. The chase is now in visual coordinates — how far the caret is from the left of the viewport once the value is placed — and which way the offset displaces the text is `_scrollShift`'s single decision, the way `ScrollableNode` already resolves it at `src/nodes.js` for a scroll box.

Two things came along because the mirror would have been visibly half done without them: the selection highlight in both fields is now the bands `textRangeRects` reports — one per line and one per direction run — rather than one rectangle between two caret positions, which paints over text nobody selected on a line whose runs go both ways; and `atspi.js` reads the field's own placement instead of rebuilding it from the content box, so a screen reader is told where the characters actually are.

## The open questions in the issue, answered

- **Is `align: 'start'` enough?** For now, yes: the field is placed at *its own* direction, never at its value's. A Latin value in an RTL field goes to the right edge, which is what `<input dir="rtl">` does; there is no `dir="auto"` equivalent, and adding one would be a third state on a prop rather than a change to this geometry. Written down in `docs/styling.md`.
- **Which direction wins for the placeholder?** The field's. The placeholder is the field's chrome in the app's language, not the user's content, so an English hint in an Arabic form starts at the right with everything else in the window.
- **Does the preedit follow?** Yes, for free — `_paintPreedit` takes the value's origin, which is the mirrored one.
- **Do the arrow keys need anything?** No, and that is now pinned rather than assumed: Left/Right and Home/End step through the string in either direction. Visual-order caret motion through bidi text is a separate question.

## Tests

Seven new tests in `test/rtl.test.js`, in a section of their own, all through `react-x11/test` against the in-process server with a repo-local font so the pixels are the same on every machine:

- the field and a `<text>` reorder the same mixed string identically, under `ltr` and under `rtl` — and under `ltr` the leading neutrals stay leading, so the two agreeing on the wrong answer still fails
- an RTL field paints its **value** and its **placeholder** in the right-hand half of its content box, and an LTR one in the left half — counted pixels, since the claim is about placement
- an empty RTL field's caret is within a caret's width of the right edge, and is *drawn* there
- a click in the middle of an RTL field lands before a short value rather than after it, and the caret it asks for is drawn back on the value's own side
- an overflowing RTL field starts at the right and scrolls left, with `_scrollX` still counting from the start of the value
- Left/Right and Home/End are logical under either direction
- a `<textarea>` pushes its short lines to the right under `rtl`, with its line-start caret inside the content box

Each was mutation-checked: reverting `src/nodes.js` and `src/atspi.js` fails all of them except the arrow-key pin, which is a pin of behaviour this does not change.

## Elsewhere in the tree

`docs/styling.md` gains an "inside an editable field" section and loses the bullet listing the fields as a thing that does not mirror; `docs/elements.md` and `docs/components.md` follow; the stale RTL/IME paragraph in `docs/ecosystem/i18n.md` — it still said there is no `direction` style property — is corrected; `examples/settings.jsx`'s "what does not work yet" section is retired, since #341 was the only thing in it; and the playground's `rtl` demo grows a paragraph and two fields showing the same string, so the flip button now demonstrates this too.

`npm test`: 1436 passing, six pre-existing failures in `test/appearance.test.js` that are macOS-only (the host answers the rung the test wants unanswered) and fail identically with this branch reverted. `npm run lint`, `prettier --check .`, `tsc -p tsconfig.json` and the website build are all clean.

