### PR TITLE
feat(fonts): openFont, loadFont and useFont — a font file the app opens itself

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,19 @@ no override-redirect staging (issue #4).
   user action caused. The failure they exist to prevent is silent —
   `CurrentTime` is accepted by the server and leaves two clients racing for a
   selection unorderable — so neither should ever be `?? 0`-ed at a call site.
+- `src/fonts.js` + `src/fonthooks.js` — a font file an application opens
+  for itself (#346): `openFont(app, source)` reads one, `loadFont` reads it
+  **and** registers it, `useFont` is the hook. The line between the two is
+  the whole design and is easy to erase by accident — registering a face
+  does not only make a `fontFamily` resolve to it, it puts the face ahead of
+  the system chain for **every codepoint the current font is missing**, so a
+  font browser that registered what it previewed would change the glyphs its
+  own UI borrows. The family name is derived from the file rather than
+  invented by the caller, and scoped (`Inter 2`) only where a second file
+  would otherwise be unreachable — a family is a _set_ of faces, so bold
+  beside regular is not a collision. Both verbs go through `app.fonts`,
+  including its `_open`, because a second `Font` for one file is a second
+  glyph atlas.
 - `src/compose.js` — dead keys and the Compose key (#272): the sequence
   table and the state machine `EventManager` runs between an application's
   `onKeyDown` and the element's `defaultKeyDown`. The dead-key half is

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,9 @@
   [selecting read-only text](elements.md#selecting-text) with `selectable`.
 - [styling.md](styling.md) — the `style` prop: layout and paint properties,
   `:hover`/`:focus`/`:active`/`:disabled` blocks, transitions, theme tokens,
-  window size queries, `createStyles`.
+  window size queries, `createStyles`, and
+  [a font file of your own](styling.md#a-font-file-of-your-own) —
+  `openFont`/`loadFont`/`useFont`.
 - [components.md](components.md) — widget components built on the
   primitives: theming, the basic controls (`Button`, `Checkbox`,
   `Radio`/`RadioGroup`, `Switch`, `ProgressBar`), `Select`, `Slider`,

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -959,6 +959,11 @@ around the labels in it
 `textAlign` and `lineHeight` do not: they shape the box the lines flow in,
 which belongs to the `<text>` that owns it.
 
+A face the app supplies itself — one it ships, or one the user picked in a
+dialog — is opened with `loadFont`/`useFont`, which hand back the family
+name to put in `fontFamily`
+([styling.md](styling.md#a-font-file-of-your-own)).
+
 `start` and `end` are resolved against the box's own **direction**, not
 against the first strong character in the string — the box says which way it
 reads and the paragraph is laid out at that base level, so `"(12) files"` in

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -480,6 +480,86 @@ descendant has. `<Icon>`'s `size` does not inherit either — a glyph is a
 drawing rather than a letter, so it takes its default from the palette's
 `fontSize` and stays put when a label around it shrinks.
 
+## A font file of your own
+
+An app that ships a face, or that shows one — a picker, a specimen, a
+preferences page with a family name in it — asks for the file by path (or by
+bytes) and gets back what to draw it with:
+
+```jsx
+import { loadFont } from 'react-x11';
+
+// `app` is the ntk connection — the one `createRoot({ app })` took, or
+// `useApp()`'s inside a tree
+const { font, family } = loadFont(app, '/path/to/Inter.ttf');
+
+<text style={{ fontFamily: family, fontSize: 20 }}>Handgloves</text>;
+```
+
+`family` comes **off the file** rather than out of the caller's head: it is
+the font's own name, so an app that ships `Inter.ttf` goes on writing
+`fontFamily: 'Inter'` in the styles it already has, and a registered face
+beats fontconfig for that name — which is the point of shipping one. Several
+faces of one family — regular, bold, italic — all keep the name and
+`fontWeight` picks between them. Only a second file that would be
+_unreachable_ under it, the same family at the same weight and slant, is
+scoped: that one comes back as `Inter 2`. Draw with the name that comes back
+and the question never arises.
+
+`loadFont(app, path, { family: 'preview' })` names it yourself instead —
+worth doing for a file the _user_ picked, to keep it out of the way of the
+app's own type. `weight` and `style` override what the file claims about
+itself, and `postscriptName` picks one face out of a `.ttc`.
+
+From a component, `useFont` is the same thing with the connection already in
+hand, and it returns null before anything is picked:
+
+```jsx
+function Specimen({ path }) {
+  const picked = useFont(path); // path may be null
+  return <text style={{ fontFamily: picked?.family }}>Handgloves</text>;
+}
+```
+
+A file that will not parse throws, which an error boundary is the right home
+for when the app ships the font and the wrong one when a user just chose it
+in a dialog — reach for `loadFont` in that handler and catch there.
+
+### Reading a font without installing it
+
+`openFont(app, source)` reads the file and changes nothing else:
+
+```js
+const font = openFont(app, path);
+font.metrics(30); // what the renderer lays out with
+font.variationAxes; // { wght: { name, min, default, max } }
+font.hasGlyph(0x20b8); // is the tenge sign in this face?
+```
+
+The difference from `loadFont` is worth knowing before a font browser picks
+one over the other. Registering a face does not only make a `fontFamily`
+resolve to it: every registered font is consulted, ahead of the system
+fonts, for **any codepoint the current face is missing**. That is exactly
+what an app shipping a symbol or icon face wants, and exactly what an app
+that is merely _previewing_ files does not — it would quietly change which
+face draws the bullets and the curly quotes in its own UI.
+
+Both verbs read a given file once per connection, however often they are
+called: the face is cached in the app's font manager, so `useFont` in a
+component that re-renders sixty times a second parses nothing, and
+`loadFont` after `openFont` on the same path registers the face already
+open. This matters more than it looks — a second copy of a font is a second
+glyph cache and a second server-side glyphset, and a node built against one
+copy cannot be painted by the other.
+
+`font` is ntk's `Font`, which has more on it than the four members above
+([ntk's docs/fonts.md](https://github.com/sidorares/ntk/blob/master/docs/fonts.md)). If you need
+anything else of ntk's — `Path2D`, `Image`, `Surface` — **import it from
+`react-x11/ntk`, never from `ntk`**, and never declare `ntk` as a dependency
+of your own. Two copies in one process are two font caches and two glyph
+atlases, with the same consequence as above and a great deal further from
+its cause.
+
 ## `createStyles`
 
 Identity is the point — a hoisted style object lets `applyProps` skip the

--- a/examples/variable-fonts.jsx
+++ b/examples/variable-fonts.jsx
@@ -2,7 +2,7 @@
 // axis the file actually has — read off the font, not configured here.
 //
 //   Select font…  ->  useFileDialog()      the desktop's own dialog
-//   app.fonts.load(path)                   register it at runtime
+//   loadFont(app, path)                    read it, register it, name it
 //   font.variationAxes                     { wght: {name, min, default, max} }
 //   font.fk.namedVariations                the designer's chosen points
 //
@@ -24,7 +24,6 @@
 //
 // Run with: npm run examples:variable-fonts  (needs an X server / DISPLAY)
 import React, { useCallback, useMemo, useState } from 'react';
-import { Font } from 'ntk';
 
 import {
   Button,
@@ -33,6 +32,7 @@ import {
   Switch,
   createRoot,
   createStyles,
+  loadFont,
   useApp,
   useFileDialog,
 } from '../src/index.js';
@@ -127,8 +127,7 @@ const s = createStyles({
  * font — this is the whole of "what can I move?", and a static face answers
  * with `{}` rather than with an error.
  */
-function inspect(path, family) {
-  const font = Font.loadSync(path);
+function inspect(font, path, family) {
   const axes = font.variationAxes;
   const named = font.fk.namedVariations ?? {};
   let instancing = null; // an error message, when the axes cannot be cut
@@ -146,15 +145,12 @@ function inspect(path, family) {
     path,
     family,
     file: path.split('/').pop(),
-    name: font.familyName ?? '(unnamed)',
     axes,
     named: Object.keys(named).length ? named : null,
     namedCoords: named,
     instancing,
   };
 }
-
-let loaded = 0; // unique family counter, so picks never collide
 
 const defaults = (axes) =>
   Object.fromEntries(Object.entries(axes).map(([tag, a]) => [tag, a.default]));
@@ -174,17 +170,16 @@ const num = (v) =>
  * and one weight prop needs nothing else.
  */
 function snippetFor({ font, size, values, sample }) {
-  // The family printed is the font's own, not the private alias this app
-  // registers it under — the snippet is meant to be read and copied, and a
-  // `picked-3` in it would be a lie about how the font got there. The line
-  // above it is how it got there.
-  const family = font.label;
+  // The family in the snippet is the one `loadFont` handed back and the one
+  // the specimen above is actually drawn with — the font's own name, unless
+  // a second file had already claimed it. There is nothing here for the app
+  // to have invented, which is what the line above the element says.
   const lines = [
-    `// app.fonts.load('${font.file}', { family: '${family}' })`,
+    `// const { family } = loadFont(app, '${font.file}'); // '${font.family}'`,
     '<text',
     '  style={{',
   ];
-  lines.push(`    fontFamily: '${family}',`);
+  lines.push('    fontFamily: family,');
   lines.push(`    fontSize: ${num(size)},`);
   if (font.axes.wght) lines.push(`    fontWeight: ${num(values.wght)},`);
   const others = Object.keys(font.axes)
@@ -255,14 +250,17 @@ function Lab({ initialFont = null }) {
   const load = useCallback(
     (path) => {
       try {
-        // a fresh family per pick, so a second font never resolves to the
-        // first: `fonts.load` registers by family, and two files claiming
-        // "Ubuntu" would otherwise be one family with two faces
-        const family = `picked-${++loaded}`;
-        const info = inspect(path, family);
-        app.fonts.load(path, { family });
-        setFont({ ...info, name: family, label: info.name });
-        setValues(defaults(info.axes));
+        // One call: the file is read, registered, and handed back with the
+        // name to draw it with — its own, or `Ubuntu 2` where a previous
+        // pick already claimed it, since two files claiming "Ubuntu" would
+        // otherwise be one family whose second face never draws.
+        //
+        // `loadFont` rather than `useFont` because the path came from a
+        // dialog: a file that will not parse is this app's error message,
+        // not an error boundary's.
+        const { font, family } = loadFont(app, path);
+        setFont(inspect(font, path, family));
+        setValues(defaults(font.variationAxes));
         setPicked(null);
         setError(null);
       } catch (err) {
@@ -331,7 +329,7 @@ function Lab({ initialFont = null }) {
             <box style={s.spacer} />
             {font && (
               <text style={s.dim}>
-                {font.label} · {font.file}
+                {font.family} · {font.file}
               </text>
             )}
             <Button label="Select font…" primary onPress={pick} />
@@ -357,7 +355,7 @@ function Lab({ initialFont = null }) {
               <box style={[s.card, s.sample]}>
                 <text
                   style={{
-                    fontFamily: font.name,
+                    fontFamily: font.family,
                     fontSize: size,
                     fontWeight: font.axes.wght ? values.wght : undefined,
                     fontVariationSettings: variations,

--- a/src/fonthooks.js
+++ b/src/fonthooks.js
@@ -1,0 +1,64 @@
+// `useFont()` — a font file, from a component.
+//
+// The imperative half lives in `fonts.js` and is where the reasoning is. The
+// hook is thin on purpose: `loadFont` is already idempotent per app and
+// file, so the memo here saves a map lookup rather than a file read, and a
+// component that re-renders sixty times a second still parses nothing.
+//
+// It reads `useApp()` rather than taking the connection, since a component
+// three levels down has one and does not have the app.
+
+import { useMemo } from 'react';
+
+import { useApp } from './appcontext.js';
+import { loadFont } from './fonts.js';
+
+/**
+ * The font in `source`, registered and ready to draw with.
+ *
+ * ```jsx
+ * const { family } = useFont(fontPath);
+ *
+ * <text style={{ fontFamily: family, fontSize: 32 }}>Handgloves</text>;
+ * ```
+ *
+ * `font` is ntk's `Font` — `metrics(size)`, `variationAxes`, `hasGlyph(cp)` —
+ * and `family` is the name to put in `fontFamily`, read off the file rather
+ * than invented here. See {@link loadFont} for what that name is and when it
+ * is scoped.
+ *
+ * **Returns null when `source` is null**, so a picker can call it before
+ * anything is picked without a branch around the hook:
+ *
+ * ```jsx
+ * const picked = useFont(path); // path may be null
+ * <text style={{ fontFamily: picked?.family }}>{sample}</text>;
+ * ```
+ *
+ * The file is read on the render that first names it, and never again: the
+ * face is cached in the connection's font manager, which is also where a
+ * `openFont`/`loadFont` call outside the tree would find it.
+ *
+ * **A file that cannot be read throws during render**, which is an error
+ * boundary's business — right for a font the app ships and wrong for one a
+ * user just picked in a dialog, where the app wants to say so in its own UI.
+ * Call `loadFont(app, path)` in the handler that picked it for that case, and
+ * catch there.
+ *
+ * @param {string|Uint8Array|Buffer|null} [source] path, or the file's bytes
+ * @param {{ family?: string, weight?: number|string, style?: string,
+ *   postscriptName?: string }} [opts]
+ */
+export function useFont(source, opts) {
+  const app = useApp();
+  // The options are folded into the memo key rather than listed as
+  // dependencies: an inline `{ family: 'preview' }` is a fresh object every
+  // render and would defeat the memo on identity alone.
+  const key = `${opts?.family ?? ''}|${opts?.weight ?? ''}|${opts?.style ?? ''}|${
+    opts?.postscriptName ?? ''
+  }`;
+  return useMemo(
+    () => (source == null ? null : loadFont(app, source, opts)),
+    [app, source, key],
+  );
+}

--- a/src/fonts.js
+++ b/src/fonts.js
@@ -1,0 +1,301 @@
+// Opening a font file, from the application's side of the seam.
+//
+// An app that wants to *look at* a font — a picker, a specimen, a
+// preferences page that shows a family name — or to *ship* one had to leave
+// react-x11 to do either (issue #346). The reading half was ntk's own class,
+// `Font.loadSync(path)`, reached through an import an application author has
+// no reason to know exists; the drawing half was a second, unrelated call,
+// `app.fonts.load(path, { family: 'a-name-i-made-up' })`, and the made-up
+// name then had to be kept consistent between the two by hand. Two calls,
+// two mental models, and a string with no author.
+//
+// The two verbs here are the two things that were being confused:
+//
+//   openFont(app, source)   read the file. Nothing about the app changes.
+//   loadFont(app, source)   read it *and* make it drawable, under a family
+//                           name taken off the file and handed back.
+//
+// **Why opening does not register.** A registered face is not just an entry
+// in a lookup table: ntk consults every registered font, in registration
+// order, for *any codepoint the current face is missing* (`fallbackFor`), so
+// an app that registered each file it merely previewed would quietly change
+// which face draws the bullets and the curly quotes in its own UI. Reading a
+// file and installing a font are different acts, so they are different
+// calls, and the one whose name says "open" is the one that changes nothing.
+//
+// **Why both go through `app.fonts`.** The manager is the connection's one
+// font cache, and a `Font` carries a glyph cache and a server-side glyphset
+// with it: a second copy of a face is a second atlas uploaded over the wire,
+// and a node built against one copy cannot be painted by the other. So
+// neither verb parses a file the manager has already read — `loadFont` after
+// `openFont` on the same path re-uses the open face rather than opening a
+// second one, and a face fontconfig already matched is not re-read either.
+//
+// The same rule is why `react-x11/ntk` exists, for the code that does need
+// `Font` itself: import ntk through react-x11, never as a dependency of its
+// own (docs/styling.md#a-font-file-of-your-own).
+
+import { basename, extname } from 'node:path';
+
+import { Font } from 'ntk';
+
+/**
+ * Per-app bookkeeping. Keyed on the app rather than stored on it, like
+ * `inputtime.js`: one process can drive several roots on several
+ * connections, and a family registered on one is not registered on another.
+ *
+ * `opened` maps a source key to the handle for it, which is what makes both
+ * verbs idempotent — a component that calls `useFont` on every render
+ * re-reads nothing and registers nothing twice. `claims` is the family
+ * namespace: `family|weight|italic` -> the key of the file that holds it.
+ */
+const state = new WeakMap();
+
+function stateFor(app) {
+  let s = state.get(app);
+  if (!s) {
+    s = { opened: new Map(), dataKeys: new WeakMap(), claims: new Map(), n: 0 };
+    state.set(app, s);
+  }
+  return s;
+}
+
+function managerOf(app, fn) {
+  const fonts = app?.fonts;
+  if (!fonts) {
+    throw new Error(
+      `react-x11: ${fn}(app, …) needs the ntk connection — the app from ` +
+        '`createRoot({ app })` or `useApp()`, which is what carries `app.fonts`',
+    );
+  }
+  return fonts;
+}
+
+/**
+ * The cache key for a source.
+ *
+ * A path's key is the one ntk computes for itself
+ * (`` `${path}#${postscriptName}` ``, its font.js) rather than one of ours,
+ * which is what makes `loadFont`'s `app.fonts.load()` land on the face
+ * `openFont` already opened instead of parsing the file a second time.
+ *
+ * Bytes have no name to key on, so they are keyed by the identity of the
+ * buffer they arrived in — the same array is the same font, a copy of it is
+ * not, which is the only answer available without hashing megabytes.
+ */
+function keyFor(st, source, postscriptName) {
+  if (typeof source === 'string') return `${source}#${postscriptName || ''}`;
+  let key = st.dataKeys.get(source);
+  if (!key) {
+    key = `data:${st.n++}#${postscriptName || ''}`;
+    st.dataKeys.set(source, key);
+  }
+  return key;
+}
+
+/**
+ * ntk's cache, reached through the method that owns it.
+ *
+ * `_open` is underscored because ntk has no public "open without
+ * registering" — this module *is* that route from an application, which is
+ * the whole of issue #346. If a future ntk renames it, parsing directly is
+ * the honest fallback: a duplicated face costs memory and an extra glyph
+ * atlas, where throwing would cost the feature entirely.
+ */
+function openThrough(fonts, candidate) {
+  if (typeof fonts._open === 'function') return fonts._open(candidate);
+  return candidate.path !== undefined
+    ? Font.loadSync(candidate.path, candidate.postscriptName)
+    : Font.fromData(candidate.data, candidate);
+}
+
+/** `/usr/share/fonts/Inter-Variable.ttf` -> `Inter-Variable`. */
+function stemOf(source) {
+  if (typeof source !== 'string') return '';
+  return basename(source, extname(source));
+}
+
+/**
+ * Where in a family this face sits — `weight|italic`, the two things ntk
+ * resolves a family's faces by.
+ *
+ * This mirrors ntk's own `detectStyle`, which is not exported. Mirroring is
+ * safe here in a way it would not be on the paint path: the answer only
+ * decides what a file is *named*, so drifting from ntk costs a scoped alias
+ * where none was needed, never a wrong glyph.
+ */
+function faceOf(font, opts) {
+  const os2 = font.fk?.['OS/2'];
+  const weight = opts.weight ?? (os2 ? os2.usWeightClass : 400);
+  const italic =
+    opts.style !== undefined
+      ? /italic|oblique/i.test(opts.style)
+      : !!(
+          os2?.fsSelection?.italic ||
+          font.fk?.italicAngle ||
+          /italic|oblique/i.test(font.fk?.subfamilyName || '')
+        );
+  return `${weight}|${italic}`;
+}
+
+/**
+ * The family name a loaded file is registered under, when the caller did not
+ * name one.
+ *
+ * **The font's own name**, which is the decision worth stating: an app that
+ * ships `Inter.ttf` wants `fontFamily: 'Inter'` to mean *its* Inter, in
+ * every style it has already written, and registered faces beat fontconfig
+ * in `match()` — this is `@font-face` behaving the way the web taught
+ * everyone it behaves.
+ *
+ * **Scoped only when the face would be unreachable**, which is the other
+ * half. A family is a set of faces, so `Inter-Regular.ttf` and
+ * `Inter-Bold.ttf` both want to be "Inter" and `fontWeight` picks between
+ * them — that is a family being assembled, not a collision. Two *different*
+ * files claiming the same family at the same weight and slant are a
+ * collision, because ntk resolves that tie to whichever was registered first
+ * and the second file would never draw: it gets `Ubuntu 2`. Nobody has to
+ * know that happened — the family to draw with is the one `loadFont` hands
+ * back, and a caller that always uses it is always right.
+ *
+ * A name the `family` option asked for is used verbatim: two faces under one
+ * alias is a thing a caller may well mean, and second-guessing a name
+ * somebody chose is worse than the tie. It still claims its slot, so a later
+ * auto-derived name never lands on top of it.
+ */
+function claim(st, key, base, face, verbatim) {
+  const slot = (name) => `${name.toLowerCase()}|${face}`;
+  const held = (name) => st.claims.get(slot(name));
+  if (verbatim || !held(base) || held(base) === key) {
+    st.claims.set(slot(base), key);
+    return base;
+  }
+  for (let n = 2; ; n++) {
+    const alias = `${base} ${n}`;
+    if (!held(alias) || held(alias) === key) {
+      st.claims.set(slot(alias), key);
+      return alias;
+    }
+  }
+}
+
+/**
+ * Read a font file: metrics, coverage, variation axes.
+ *
+ * ```js
+ * const font = openFont(app, '/usr/share/fonts/truetype/inter/Inter.ttf');
+ * font.familyName; // 'Inter'
+ * font.metrics(30); // { ascent, descent, lineGap, capHeight, … }
+ * font.variationAxes; // { wght: { name, min, default, max } }
+ * font.hasGlyph(0x20b8); // is the tenge sign in this face?
+ * ```
+ *
+ * `source` is a path to a `.ttf`/`.otf`/`.ttc`/`.woff`/`.woff2`, or the
+ * file's bytes. `postscriptName` picks one face out of a `.ttc` collection
+ * (the first otherwise).
+ *
+ * **Nothing about the app changes.** The face is not registered, so it is
+ * not a candidate for any `fontFamily` — and, the part that is easy to miss,
+ * it does not join the fallback chain either, which is what stops a font
+ * browser from changing the glyphs its own UI falls back to. {@link loadFont}
+ * is the call for when the point is to draw with it.
+ *
+ * The file is read once per app: the face is cached in the connection's font
+ * manager, so opening it again — every render, every repaint — hands back
+ * the same `Font`, and so does {@link loadFont} afterwards.
+ *
+ * Throws what ntk throws for a file that is missing or unparseable. When the
+ * path came from a user (a file dialog), that is a `try`/`catch` around this
+ * call rather than an error boundary.
+ *
+ * @param {object} app the ntk connection (`useApp()`)
+ * @param {string|Uint8Array|Buffer} source path, or the font file's bytes
+ * @param {{ postscriptName?: string }} [opts]
+ * @returns {object} ntk's `Font`
+ */
+export function openFont(app, source, opts = {}) {
+  const fonts = managerOf(app, 'openFont');
+  const st = stateFor(app);
+  const key = keyFor(st, source, opts.postscriptName);
+  const known = st.opened.get(key);
+  if (known) return known.font;
+  const font = openThrough(fonts, {
+    key,
+    postscriptName: opts.postscriptName,
+    ...(typeof source === 'string' ? { path: source } : { data: source }),
+  });
+  st.opened.set(key, { font, family: null });
+  return font;
+}
+
+/**
+ * Read a font file **and** register it, so `fontFamily` can name it.
+ *
+ * ```jsx
+ * const { font, family } = loadFont(app, '/path/to/Inter.ttf');
+ * <text style={{ fontFamily: family, fontSize: 20 }}>Handgloves</text>;
+ * ```
+ *
+ * `family` is read off the file rather than invented by the caller: the
+ * font's own name, so an app that ships `Inter.ttf` can go on writing
+ * `fontFamily: 'Inter'` in the styles it already has. Several faces of one
+ * family — regular, bold, italic — all keep that name and `fontWeight` picks
+ * between them. Only a second file that would be *unreachable* under it,
+ * same family at the same weight and slant, is scoped: it comes back as
+ * `Inter 2`. Draw with the name that comes back and the question never
+ * arises.
+ *
+ * A registered face wins over fontconfig for its name, which is the point:
+ * an app that ships a font means the one it ships. Pass `family` to name it
+ * something else — `loadFont(app, picked, { family: 'preview' })` keeps a
+ * file the user chose out of the way of the app's own type. `weight` and
+ * `style` override what the file says about itself; `postscriptName` picks a
+ * face out of a `.ttc`.
+ *
+ * Registering also puts the face in the fallback chain, ahead of the system
+ * fonts: text in some other family that has no glyph for a character borrows
+ * it from here before fontconfig is asked. That is what an app shipping a
+ * symbol or icon face wants, and {@link openFont} is the call for when it is
+ * not.
+ *
+ * Idempotent per app and file: calling it again returns the same handle and
+ * registers nothing twice.
+ *
+ * @param {object} app the ntk connection (`useApp()`)
+ * @param {string|Uint8Array|Buffer} source path, or the font file's bytes
+ * @param {{ family?: string, weight?: number|string, style?: string,
+ *   postscriptName?: string }} [opts]
+ * @returns {{ font: object, family: string }} ntk's `Font`, and the family
+ *   name to draw it with
+ */
+export function loadFont(app, source, opts = {}) {
+  const fonts = managerOf(app, 'loadFont');
+  const st = stateFor(app);
+  const key = keyFor(st, source, opts.postscriptName);
+  const known = st.opened.get(key);
+  if (known?.family && (!opts.family || opts.family === known.family)) {
+    return known;
+  }
+
+  // Opened first, because the name to register under is read off the face —
+  // and this is the read that does not happen twice: for a path, `load()`
+  // below computes the same cache key and gets this very font back.
+  const font = openFont(app, source, opts);
+  const family = claim(
+    st,
+    key,
+    opts.family || font.familyName || stemOf(source) || 'font',
+    faceOf(font, opts),
+    !!opts.family,
+  );
+
+  const registered = fonts.load(source, { ...opts, family });
+  // Bytes are the one source `load` cannot look up: the key it makes for
+  // them counts entries rather than naming the data, so it parses the buffer
+  // again and the face above is not the one that got registered. Keep the
+  // registered face — it is the one that will be drawn with, and so the one
+  // whose glyph cache is worth sharing — and let the other go.
+  const handle = { font: registered ?? font, family };
+  st.opened.set(key, handle);
+  return handle;
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -21,6 +21,7 @@ export * from './types/dbus.js';
 export * from './types/application.js';
 export * from './types/filedialog.js';
 export * from './types/appearance.js';
+export * from './types/fonts.js';
 export * from './types/system.js';
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,8 @@ export { keepAwake } from './idle.js';
 export { useIdle, useKeepAwake } from './idlehooks.js';
 export { useKeyboardState } from './keyboardstatehooks.js';
 export { useDesktopSettings } from './desktopsettingshooks.js';
+export { loadFont, openFont } from './fonts.js';
+export { useFont } from './fonthooks.js';
 export { systemLocale } from './locale.js';
 export { useLocale } from './localehooks.js';
 export {

--- a/src/types/fonts.d.ts
+++ b/src/types/fonts.d.ts
@@ -1,0 +1,124 @@
+/**
+ * Font files an application opens for itself — reading one, and registering
+ * one so `fontFamily` can name it. See docs/styling.md#a-font-file-of-your-own.
+ */
+
+import type { NtkApp } from './nodes.js';
+
+/**
+ * ntk's `Font`, as much of it as is worth declaring by hand.
+ *
+ * Deliberately loose, for the same reason `react-x11/ntk` is: ntk ships no
+ * types, and a full mirror written here would drift out of date silently.
+ * The members below are the ones an application reads; everything else the
+ * class has is still there at runtime.
+ */
+export interface Font {
+  /** The family the file calls itself — not necessarily what it is
+   *  registered as; see {@link loadFont}. */
+  readonly familyName: string;
+  readonly postscriptName: string;
+  readonly unitsPerEm: number;
+  /** Stable cache key — the same file opened twice has the same one. */
+  readonly key: string;
+  /** The path it was opened from, or null for a font opened from bytes. */
+  readonly path: string | null;
+  /** fontkit's own font object, for what this interface does not cover
+   *  (`namedVariations`, the raw tables). */
+  readonly fk: Record<string, unknown> & {
+    namedVariations?: Record<string, Record<string, number>>;
+  };
+  /**
+   * `{}` for a static face, so `Object.keys(font.variationAxes).length` is
+   * the whole of "is this variable?".
+   */
+  readonly variationAxes: Record<
+    string,
+    { name?: string; min: number; default: number; max: number }
+  >;
+  /** Scaled to a pixel size. A metric the face never declared is `null`
+   *  rather than 0 — a cap height it did not state is not a cap height of
+   *  zero. */
+  metrics(size: number): {
+    ascent: number;
+    descent: number;
+    lineGap: number;
+    capHeight: number | null;
+    xHeight: number | null;
+    [key: string]: number | null;
+  };
+  hasGlyph(codepoint: number): boolean;
+  /** This face at a point in its design space: `variation({ wght: 460 })`. */
+  variation(settings: Record<string, number>): Font;
+}
+
+export interface OpenFontOptions {
+  /** Which face of a `.ttc` collection; the first otherwise. */
+  postscriptName?: string;
+}
+
+export interface LoadFontOptions extends OpenFontOptions {
+  /** Register under this name instead of the font's own, and use it
+   *  verbatim. */
+  family?: string;
+  /** Override the weight the file declares. */
+  weight?: number | string;
+  /** `'italic'` / `'oblique'`, overriding what the file declares. */
+  style?: string;
+}
+
+export interface LoadedFont {
+  readonly font: Font;
+  /** What to put in `fontFamily` — the font's own name, scoped to
+   *  `Inter 2` only where a second file would otherwise be unreachable. */
+  readonly family: string;
+}
+
+/**
+ * Read a font file — metrics, coverage, variation axes — through the
+ * connection's font cache, so it is read once however often this is called.
+ *
+ * ```ts
+ * const font = openFont(app, '/usr/share/fonts/truetype/inter/Inter.ttf');
+ * font.metrics(30);
+ * font.variationAxes;
+ * ```
+ *
+ * Nothing about the app changes: the face is not registered, so it is
+ * neither a `fontFamily` candidate nor part of the fallback chain. Use
+ * {@link loadFont} to draw with it.
+ */
+export function openFont(
+  app: NtkApp,
+  source: string | Uint8Array,
+  opts?: OpenFontOptions,
+): Font;
+
+/**
+ * Read a font file and register it, returning the face and the family name
+ * to draw it with.
+ *
+ * ```tsx
+ * const { family } = loadFont(app, '/path/to/Inter.ttf');
+ * <text style={{ fontFamily: family }}>Handgloves</text>;
+ * ```
+ */
+export function loadFont(
+  app: NtkApp,
+  source: string | Uint8Array,
+  opts?: LoadFontOptions,
+): LoadedFont;
+
+/**
+ * {@link loadFont} from a component, memoized per app and file. Null when
+ * `source` is null, so a picker can call it before anything is picked.
+ *
+ * ```tsx
+ * const picked = useFont(path);
+ * <text style={{ fontFamily: picked?.family }}>{sample}</text>;
+ * ```
+ */
+export function useFont(
+  source?: string | Uint8Array | null,
+  opts?: LoadFontOptions,
+): LoadedFont | null;

--- a/test/fonts.test.js
+++ b/test/fonts.test.js
@@ -1,0 +1,269 @@
+// `openFont` / `loadFont` / `useFont` — a font file, opened by the app.
+//
+// The subject is the seam rather than the parsing: fontkit reads the file and
+// ntk caches it, and what is tested here is the three decisions react-x11
+// makes on top (issue #346).
+//
+//   1. **Opening registers nothing.** The distinction is invisible in
+//      `match()` alone — a registered face only shadows a family somebody
+//      asked for — so the assertion that carries it is the *fallback* chain,
+//      which every registered font joins for every codepoint the current
+//      face is missing.
+//   2. **One cache.** A second `Font` for one file is a second glyph atlas,
+//      so the test is object identity across both verbs, not a re-read that
+//      happens to be fast.
+//   3. **The family comes off the file** — the name a caller no longer has
+//      to invent — with the tie broken only where a face would otherwise be
+//      unreachable.
+//
+// The faces are KaTeX's, from devDependencies, so the names and weights are
+// the same on every machine; fontconfig is the thing being replaced here and
+// cannot also be the fixture. `KaTeX_Main` ships as Regular/Bold/Italic,
+// which is a *family* rather than a collision, and that is the pair the
+// scoping rule has to tell apart.
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { test, describe, afterEach } from 'node:test';
+import React from 'react';
+
+import { FontManager, StaticFontSource } from 'ntk';
+
+import { loadFont, openFont } from '../src/fonts.js';
+import { useFont } from '../src/fonthooks.js';
+import { cleanup, renderX11 } from '../src/testing/index.js';
+
+const require = createRequire(import.meta.url);
+const katex = join(
+  dirname(require.resolve('katex/package.json')),
+  'dist',
+  'fonts',
+);
+const MAIN = join(katex, 'KaTeX_Main-Regular.ttf');
+const BOLD = join(katex, 'KaTeX_Main-Bold.ttf');
+const AMS = join(katex, 'KaTeX_AMS-Regular.ttf');
+// the system face for these tests: KaTeX's brackets, which have no letters
+const SYSTEM = join(katex, 'KaTeX_Size1-Regular.ttf');
+const VF = join(
+  dirname(fileURLToPath(import.meta.url)),
+  'fixtures',
+  'MonelogicsSubset[wght].ttf',
+);
+
+/** 'a' — in KaTeX_Main, and in none of the faces the system source has. */
+const LETTER = 0x61;
+
+/**
+ * An app is only `app.fonts` as far as these two functions are concerned, so
+ * this is the whole of one: a manager over a source holding a single face
+ * that covers no letters, which makes "did this file join the fallback
+ * chain?" a question with a yes/no answer.
+ */
+function fontApp() {
+  const source = new StaticFontSource();
+  source.add(readFileSync(SYSTEM), { family: 'System' });
+  source.alias('sans-serif', 'system');
+  return { fonts: new FontManager({ source }) };
+}
+
+const ps = (font) => font?.postscriptName ?? null;
+
+// ---------------------------------------------------------------------------
+// openFont — reading a file
+// ---------------------------------------------------------------------------
+
+describe('openFont', () => {
+  test('answers what a picker asks a font file', () => {
+    const app = fontApp();
+    const font = openFont(app, VF);
+
+    assert.equal(font.familyName, 'monelogics Thin');
+    assert.equal(font.variationAxes.wght.min, 100);
+    assert.equal(font.variationAxes.wght.max, 900);
+    assert.ok(font.hasGlyph(LETTER), 'the face has letters');
+    // metrics are the numbers the renderer lays out with, scaled to a size
+    const metrics = font.metrics(30);
+    assert.ok(
+      metrics.ascent > 0 && metrics.lineHeight > metrics.ascent,
+      JSON.stringify(metrics),
+    );
+  });
+
+  test('reads the file once, however often it is opened', () => {
+    const app = fontApp();
+    const first = openFont(app, MAIN);
+    assert.strictEqual(openFont(app, MAIN), first, 'a second open re-reads');
+    // and the load path lands on the same face rather than parsing again —
+    // two Fonts for one file is two glyph atlases on the wire
+    assert.strictEqual(loadFont(app, MAIN).font, first);
+  });
+
+  test('a second connection opens its own', () => {
+    const a = fontApp();
+    const b = fontApp();
+    assert.notStrictEqual(openFont(a, MAIN), openFont(b, MAIN));
+  });
+
+  test('changes nothing about the app', () => {
+    const app = fontApp();
+    // the family the file calls itself resolves to the system face...
+    assert.equal(ps(app.fonts.match('KaTeX_Main')), 'KaTeX_Size1-Regular');
+    // ...and nothing covers a letter
+    assert.equal(app.fonts.fallbackFor(LETTER, 'sans-serif'), null);
+
+    openFont(app, MAIN);
+
+    assert.equal(
+      ps(app.fonts.match('KaTeX_Main')),
+      'KaTeX_Size1-Regular',
+      'opening a file must not make it a candidate for its own name',
+    );
+    assert.equal(
+      app.fonts.fallbackFor(LETTER, 'sans-serif'),
+      null,
+      'nor put it in the fallback chain — a font browser would otherwise ' +
+        'change the glyphs its own UI borrows',
+    );
+  });
+
+  test('says which argument is missing when there is no connection', () => {
+    assert.throws(() => openFont({}, MAIN), /app\.fonts/);
+    assert.throws(() => loadFont(null, MAIN), /loadFont\(app/);
+  });
+
+  test('a file that is not there throws where it was asked for', () => {
+    const app = fontApp();
+    assert.throws(() => openFont(app, join(katex, 'NoSuchFont.ttf')));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadFont — registering one
+// ---------------------------------------------------------------------------
+
+describe('loadFont', () => {
+  test('hands back the family name it registered, read off the file', () => {
+    const app = fontApp();
+    const { font, family } = loadFont(app, MAIN);
+
+    assert.equal(family, 'KaTeX_Main');
+    assert.strictEqual(app.fonts.match(family), font);
+    assert.strictEqual(
+      app.fonts.fallbackFor(LETTER, 'sans-serif'),
+      font,
+      'a registered face is in the fallback chain, which is what openFont ' +
+        'deliberately is not',
+    );
+  });
+
+  test('several faces of one family keep that family', () => {
+    const app = fontApp();
+    const regular = loadFont(app, MAIN);
+    const bold = loadFont(app, BOLD);
+
+    assert.equal(bold.family, 'KaTeX_Main', 'a bold face is not a collision');
+    assert.strictEqual(
+      app.fonts.match('KaTeX_Main', { weight: 700 }),
+      bold.font,
+    );
+    assert.strictEqual(
+      app.fonts.match('KaTeX_Main', { weight: 400 }),
+      regular.font,
+    );
+  });
+
+  test('a second file that would be unreachable is scoped', () => {
+    const app = fontApp();
+    const first = loadFont(app, MAIN);
+    // the same face arriving as bytes: a different file as far as anything
+    // here can tell, at the same weight and slant, so the name is taken
+    const second = loadFont(app, readFileSync(MAIN));
+
+    assert.equal(second.family, 'KaTeX_Main 2');
+    assert.notStrictEqual(second.font, first.font);
+    assert.strictEqual(app.fonts.match('KaTeX_Main 2'), second.font);
+    assert.strictEqual(
+      app.fonts.match('KaTeX_Main'),
+      first.font,
+      'and the first file keeps the name it was given',
+    );
+  });
+
+  test('loading the same file again registers nothing new', () => {
+    const app = fontApp();
+    const first = loadFont(app, MAIN);
+    const again = loadFont(app, MAIN);
+
+    assert.strictEqual(again, first);
+    assert.equal(again.family, 'KaTeX_Main', 'not scoped against itself');
+  });
+
+  test('a family the caller names is used verbatim', () => {
+    const app = fontApp();
+    const { font, family } = loadFont(app, AMS, { family: 'preview' });
+
+    assert.equal(family, 'preview');
+    assert.strictEqual(app.fonts.match('preview'), font);
+    // and it holds the name against a file that would have derived it
+    const other = loadFont(app, MAIN, { family: 'preview' });
+    assert.equal(other.family, 'preview');
+  });
+
+  test('weight the file does not claim can be declared for it', () => {
+    const app = fontApp();
+    const { font } = loadFont(app, MAIN, { weight: 900 });
+    assert.strictEqual(app.fonts.match('KaTeX_Main', { weight: 900 }), font);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useFont — the same thing from a component
+// ---------------------------------------------------------------------------
+
+describe('useFont', () => {
+  afterEach(cleanup);
+
+  test('registers the file and re-uses it across renders', async () => {
+    const seen = [];
+    function Specimen({ sample }) {
+      const picked = useFont(MAIN);
+      seen.push(picked);
+      return React.createElement(
+        'text',
+        { style: { fontFamily: picked.family, fontSize: 20 } },
+        sample,
+      );
+    }
+
+    const { app, rerender } = await renderX11(
+      React.createElement(Specimen, { sample: 'Handgloves' }),
+      { fonts: { 'sans-serif': SYSTEM } },
+    );
+
+    assert.equal(seen[0].family, 'KaTeX_Main');
+    assert.strictEqual(app.fonts.match('KaTeX_Main'), seen[0].font);
+
+    await rerender(React.createElement(Specimen, { sample: 'Hamburgefons' }));
+
+    assert.ok(seen.length > 1, 'the component re-rendered');
+    assert.strictEqual(
+      seen.at(-1),
+      seen[0],
+      'a re-render must not re-read the file or register it a second time',
+    );
+  });
+
+  test('a font nobody has picked yet is null, not a branch', async () => {
+    let picked = 'unset';
+    function Picker() {
+      picked = useFont(null);
+      return React.createElement('box');
+    }
+    await renderX11(React.createElement(Picker), {
+      fonts: { 'sans-serif': SYSTEM },
+    });
+    assert.equal(picked, null);
+  });
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -21,7 +21,9 @@ import type {
   BusStatus,
   DesktopSettings,
   FileDialogBackend,
+  Font,
   KeyboardState,
+  LoadedFont,
   MessageBus,
   Screen,
   Screens,
@@ -42,6 +44,9 @@ import {
   iconNames,
   iconSize,
   fileDialogBackend,
+  loadFont,
+  openFont,
+  useFont,
   onAppOpen,
   registerApplication,
   useAppActivate,
@@ -1261,6 +1266,38 @@ function _System() {
   void [locale, weekStartsOn, timeZone, rtl];
 
   return <window ref={win} width={400} height={300} />;
+}
+
+/** Fonts an app opens for itself (#346). */
+function _Fonts({ path }: { path: string | null }) {
+  const app = useApp();
+
+  // reading one: nothing about the app changes
+  const face: Font = openFont(app, '/usr/share/fonts/Inter.ttf');
+  const cap: number | null = face.metrics(30).capHeight;
+  const variable: boolean = Object.keys(face.variationAxes).length > 0;
+  const covered: boolean = face.hasGlyph(0x20b8);
+  void [cap, variable, covered, face.familyName, face.fk.namedVariations];
+
+  // loading one: the family comes back rather than being invented
+  const { family }: LoadedFont = loadFont(app, '/usr/share/fonts/Inter.ttf');
+  const aliased = loadFont(app, new Uint8Array(), {
+    family: 'preview',
+    weight: 700,
+    style: 'italic',
+    postscriptName: 'Inter-Bold',
+  });
+  void aliased.font.postscriptName;
+
+  // and from a component, where a null source is an answer
+  const picked: LoadedFont | null = useFont(path);
+  // @ts-expect-error — null when nothing is picked, so it has to be checked
+  const bad: string = picked.family;
+  void bad;
+
+  return (
+    <text style={{ fontFamily: picked?.family ?? family }}>Handgloves</text>
+  );
 }
 
 /** The imperative twins, for host-side code with no component to hang off. */


### PR DESCRIPTION
Closes #346.

An app that wants to *look at* a font — a picker, a specimen, a preferences page that shows a family name — or to **ship** one had to leave react-x11 to do either. The reading half was ntk's own class, reached through an import an application author has no reason to know exists; the drawing half was a second, unrelated call, and the name in it had no author:

```js
import { Font } from 'ntk';                                // ← the example did this
const font = Font.loadSync(path);
app.fonts.load(path, { family: 'x11-fonts-specimen' });    // a name I made up
```

Two verbs on react-x11's own surface instead, both through `app.fonts` so there is one font cache by construction:

```js
const font = openFont(app, path);              // metrics, variationAxes, hasGlyph
const { font, family } = loadFont(app, path);  // …and drawable, under a name off the file
const picked = useFont(path);                  // the same, from a component
```

## The line between the two verbs

`openFont` **registers nothing**, and that is the decision the whole module is arranged around. Registering a face is not just a lookup-table entry: ntk consults every registered font, ahead of the system chain, for *any codepoint the current face is missing* (`fallbackFor`). A font browser that registered each file it merely previewed would quietly change which face draws the bullets and the curly quotes in its own UI. So reading a file and installing a font are different acts and stay different calls — and the pair of assertions that carries this is the fallback chain, not `match()`, where the difference is invisible.

## The family name, which is the real design question in the issue

It comes **off the file**: the font's own name, so an app that ships `Inter.ttf` goes on writing `fontFamily: 'Inter'` in the styles it already has, and a registered face beats fontconfig for that name — `@font-face` behaving the way the web taught everyone it behaves.

Scoped **only where a face would otherwise be unreachable**. A family is a *set* of faces, so `Inter-Regular.ttf` and `Inter-Bold.ttf` both keep "Inter" and `fontWeight` picks between them — that is a family being assembled, not a collision. Two *different* files at the same family, weight and slant are a collision, because ntk resolves that tie to whichever was registered first and the second would never draw: that one comes back as `Inter 2`. A caller that always uses the name it is handed is always right, and `{ family: 'preview' }` is the seam for a file the user picked that should stay out of the way of the app's own type.

`Inter-Regular` + `Inter-Bold` keeping one family is the case a scope-on-any-collision rule silently breaks, so it is its own test.

## `examples/variable-fonts.jsx`

The example the issue calls out: it imported `Font` from `'ntk'` directly and invented a `picked-N` family per pick, which the snippet panel then had to apologise for in a comment. Both are gone — the header shows the font's real name, and the printed snippet is code that can be copied.

![variable-fonts](https://github.com/user-attachments/assets/8467dbb3-4ea8-4bc4-b25e-2860113adcb6)

Rendered from 528acd5 by the same headless path `npm run screenshots` uses (in-process X server, `scripts/capture.js`), with `test/fixtures/MonelogicsSubset[wght].ttf` as the picked file.

## Docs

`docs/styling.md` gains **A font file of your own** — the two verbs, why registration is not free, and, said once where an *application* author is already reading, the sentence that until now lived only in the "writing a package" docs: reach ntk through `react-x11/ntk`, never as a dependency of your own. `docs/elements.md`'s `<text>` section and the docs index point at it.

## Testing

`test/fonts.test.js`, 14 tests against KaTeX's faces from devDependencies (fontconfig is the thing being replaced here and cannot also be the fixture). All mutation-checked:

| test | mutation that kills it |
| --- | --- |
| opening changes nothing about the app | make `openFont` register |
| a registered face is in the fallback chain | (the same, inverted) |
| the file is read once, however often it is opened | bypass ntk's cache |
| the family comes off the file | — |
| several faces of one family keep that family | scope on any name collision |
| a second file that would be unreachable is scoped | never scope |
| loading the same file again registers nothing new | drop the idempotence check |
| a family the caller names is used verbatim | scope explicit names too |
| `useFont` re-uses the handle across renders | — |

Full suite 1457 pass / 6 fail, the six being the known macOS-only `appearance.test.js` failures, unchanged on master. `npm run lint`, `format:check`, `typecheck` and the website build (which is what validates the new doc anchors) all clean.
