### PR TITLE
feat(styles): backgroundImage gradients and boxShadow, so a panel stays a box

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,19 @@ no override-redirect staging (issue #4).
   than it says: `resolveComputedStyle` (the `flex` shorthand, and the
   defaults `overflow: 'scroll'` implies) and `applyLayoutDefaults` (the yoga
   defaults that are not CSS's — `flexShrink`, see the gotcha below).
+- `src/decorations.js` — the two style values that are a small language
+  rather than a number: `backgroundImage`'s `linear-gradient(...)` and
+  `boxShadow` (#345). Pure — strings in, geometry out — so the renderer half
+  in `nodes.js` is only compositing, and the grammar is testable without a
+  server. Two things there are not obvious and are commented at length. The
+  gradient line carries **padding at both ends with the end colours pinned to
+  it**, because past its last stop an XRender gradient is transparent rather
+  than clamped (`RepeatPad` is unset, sidorares/ntk#271) — and that cannot be
+  caught by a pixel test, since node-x11's in-process RENDER clamps by
+  construction where a real server does not. And a CSS blur radius is _twice_
+  the gaussian's sigma while ntk's `setBlurFilter` takes the kernel's edge
+  length, so the two numbers that look interchangeable are the two that must
+  not be. `inset` shadows and colour hints are refused rather than ignored.
 - `src/events.js` — `EventManager`: ntk window events → synthetic events
   (click synthesis, hover enter/leave diffing, the wheel — ntk's `wheel`
   event, XI2 valuators where the server has them and buttons 4-7 where it

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -324,6 +324,90 @@ Two edges of the v1 shape:
   run between them. CSS mitres that corner diagonally; nothing built from
   bars and rules can tell the difference.
 
+## Gradients and shadows
+
+The two decorations a UI asks for after colour and radius, and the two that
+used to mean giving up on `<box>` and drawing the panel by hand:
+
+```jsx
+<box
+  style={{
+    padding: 16,
+    borderRadius: 10,
+    backgroundImage: 'linear-gradient(135deg, $accent, $accentActive)',
+    boxShadow: '0 2px 8px rgba(0, 0, 0, .4)',
+    ':hover': { boxShadow: '0 6px 20px rgba(0, 0, 0, .5)' },
+  }}
+>
+  <text style={{ color: '$accentText' }}>Header</text>
+</box>
+```
+
+Both are **paint** properties: legal in a state block, and outside layout
+entirely — a gradient fills the box the layout already decided on, and a
+shadow is drawn beyond it and moves nothing. Both are written in CSS's
+spelling, because both are values people already know by heart, and a
+`$token` resolves **inside** them as well as as a whole value, which is what
+keeps a themed decoration in a hoisted style.
+
+### `backgroundImage`
+
+`linear-gradient(<direction>?, <stop>, <stop>, …)` or `'none'`, resolved
+against the node's own box so it works wherever the node lands.
+
+- The direction is an angle in degrees clockwise from "up" (`135deg`), a side
+  (`to right`), or a corner (`to bottom right`). Left out, it is `to bottom`.
+- A stop is a colour, optionally followed by a `%` or a pixel position.
+  Positions left out are spread evenly; one that goes backwards is pulled up
+  to the one before it, so two stops at the same offset are a hard break.
+- It paints **over** `backgroundColor`, which is CSS's order — a translucent
+  gradient tints the colour underneath it rather than replacing it.
+
+Only linear gradients exist. A radial or conic one is a `<canvas onDraw>`
+away (ntk's context has `createRadialGradient` and `createConicalGradient`),
+and CSS's sizing keywords for them are most of the work for very little of
+the demand.
+
+One cost worth knowing, because it is not where anyone would look for it: a
+gradient is a server-side source picture, so a **square** one is as cheap as
+a colour — but a **rounded** one is not. ntk's rounded-rect fast path (cached
+corner glyphs plus `FillRectangles`) only takes a solid colour, so a rounded
+gradient falls back to a coverage mask rasterized on the client and uploaded
+per fill: about 4 KB per box per repaint. Damage bounding means that is only
+paid where something changed, but a list of rounded gradient rows is the one
+shape to think twice about — see the `shapes: 24 gradient+shadow cards`
+scenario in `npm run bench`, which prices it.
+
+### `boxShadow`
+
+`<x> <y> [blur] [spread] [colour]`, comma-separated for several, painted
+first-on-top like CSS's. The colour may be left out, which means the node's
+own `color`. A blurred shadow is a real gaussian — RENDER's convolution over
+a coverage surface — cached by size, radius and blur, so a list of identical
+cards renders one and composites it many times.
+
+What it does not do, and why:
+
+- **`inset` throws.** An inner shadow is a different drawing and a different
+  damage story, and painting an outer one where an inner was asked for is a
+  bug with no visible cause. An inset border or a `<canvas>` says it today.
+- **Ignored on `<window>` and `<popup>`** (with a warning in development). A
+  shadow is painted outside the box, and a toplevel owns no pixels there —
+  a real one needs the window to carry a translucent margin of its own,
+  which is a feature rather than a line in the painter. Put the shadow on a
+  `<box>` inside the window; for a floating menu, the popup's own
+  `borderRadius` plus a border is what reads as raised today.
+- **Neither transitions.** Both are several numbers and a colour in one
+  string, and `interpolate` moves one value; they snap. A card that wants to
+  rise on hover animates the `backgroundColor` or the border beside them.
+
+A shadow is the first thing in this vocabulary that inks pixels the node
+does not own, so it also widens what the node repaints — its offset, its
+spread and the blur's tail — and the frame that _removes_ one claims where
+it was. That is the renderer's business, not the application's, but it is
+the reason a shadow is not free the way a colour is: prefer one shadow on
+the card to one on every row inside it.
+
 ## Measuring text to its letters
 
 ```jsx
@@ -754,5 +838,7 @@ way it does not apply to an `<input type>` in the DOM. They report
 
 ## Next
 
-`opacity` (needs offscreen composition — see NEXT_STEPS §3), and per-node
-container queries if the window-level ones prove too coarse.
+`opacity` (needs offscreen composition — see NEXT_STEPS §3), a `boxShadow`
+that a `<popup>` can cast (the window needs a translucent margin around
+itself first — see [elements.md](elements.md) on `transparent` popups), and
+per-node container queries if the window-level ones prove too coarse.

--- a/scripts/bench/baseline.json
+++ b/scripts/bench/baseline.json
@@ -87,6 +87,14 @@
     "composites": 0,
     "compositePixels": 0
   },
+  "shapes: 24 gradient+shadow cards, 5 full repaints": {
+    "requests": 381,
+    "bytesOut": 475564,
+    "bytesIn": 352,
+    "replies": 11,
+    "composites": 245,
+    "compositePixels": 2020640
+  },
   "update: 5 color flips, no layout": {
     "requests": 48,
     "bytesOut": 968,

--- a/scripts/bench/protocol.js
+++ b/scripts/bench/protocol.js
@@ -719,6 +719,92 @@ const SCENARIOS = [
     })(),
   ],
   [
+    // What the two decorations cost per frame (issue #345): 24 cards, each
+    // with a gradient background and a blurred shadow, repainted in full
+    // five times. The gradient is a source picture the fill samples, so it
+    // is one composite like a colour; the shadow is a blurred a8 coverage
+    // surface, and every card's is the same size, so the paint cache should
+    // render **one** and composite it 24 times a frame.
+    //
+    // Baselined with the cache live, like the scroll-blit scenario above and
+    // for the same reason: --check only fails on an increase, so a change
+    // that quietly stopped the shadow surface being shared would land here
+    // rather than sail past a fallback number.
+    //
+    // The bytes are the interesting number and they are **not** ours: of the
+    // 475KB, 471KB is the rounded-rect coverage mask that ntk rasterizes
+    // client-side and uploads per fill, because its rounded-rect fast path
+    // (cached corner glyphs plus FillRectangles) only takes a solid colour.
+    // Measured by parts, same 5 frames over the same 24 cards:
+    //
+    //   solid colour, radius 6                    251 reqs   14.6 KB
+    //   + shadow                                  381 reqs   19.1 KB
+    //   gradient, radius 0                        135 reqs    4.6 KB
+    //   gradient, radius 6                        257 reqs  471.2 KB
+    //
+    // So a *square* gradient is a source picture and costs nothing on the
+    // wire, and the shadow — the expensive-looking half — is one cached
+    // surface composited 24 times. Teaching ntk's fast path to composite a
+    // non-solid source through the coverage it already builds would take
+    // this scenario back under 25KB; until then it is worth knowing that a
+    // rounded gradient is the priciest box in this vocabulary.
+    'shapes: 24 gradient+shadow cards, 5 full repaints',
+    (() => {
+      let ctl;
+      const cards = React.createElement(
+        'window',
+        { width: W, height: H, style: { backgroundColor: '#f5f6fa' } },
+        React.createElement(
+          'box',
+          {
+            style: {
+              flexGrow: 1,
+              padding: 10,
+              gap: 10,
+              flexDirection: 'row',
+              flexWrap: 'wrap',
+            },
+          },
+          Array.from({ length: 24 }, (_, i) =>
+            React.createElement('box', {
+              key: i,
+              style: {
+                width: 80,
+                height: 44,
+                borderRadius: 6,
+                backgroundImage:
+                  'linear-gradient(160deg, #2b5876 20%, #4e4376)',
+                boxShadow: '0 2px 6px rgba(0, 0, 0, .45)',
+              },
+            }),
+          ),
+        ),
+      );
+      return {
+        prepare: async (app, x11Root) => {
+          ctl = await mounted(x11Root, cards);
+          // the cache admits a key on its second sighting, so one warm-up
+          // frame is what makes this measure the steady state rather than
+          // the first two
+          for (let i = 0; i < 2; i++) {
+            ctl.root.needsPaint = true;
+            ctl.root._damage = null;
+            ctl.frame();
+            await settle(app);
+          }
+        },
+        run: async (app) => {
+          for (let i = 0; i < 5; i++) {
+            ctl.root.needsPaint = true;
+            ctl.root._damage = null;
+            ctl.frame();
+            await settle(app);
+          }
+        },
+      };
+    })(),
+  ],
+  [
     // A paint-only change: the box flips color in place. The damage tracker
     // bounds this to the box, so compositePixels stays near the box's own
     // area — this is the partial-repaint contract the Damage panel of

--- a/src/decorations.js
+++ b/src/decorations.js
@@ -1,0 +1,442 @@
+// The two decorations that are not a colour: the gradient behind a box
+// (`backgroundImage`) and the shadow under it (`boxShadow`). Both are pure
+// here — strings in, numbers out — so the renderer half in `nodes.js` is
+// only geometry and compositing, and the parsing can be tested without a
+// server (issue #345).
+//
+// ## Why they are strings
+//
+// Every other paint property in this vocabulary is a number or a colour,
+// and an object (`{ from, to, angle }`) would have been the house shape.
+// These two are strings because a gradient and a shadow are the two style
+// values people already know by heart in CSS's spelling, because a state
+// block wants to overwrite the whole decoration at once rather than merge
+// half an object into it, and because `linear-gradient(#2b5876, #4e4376)`
+// pastes out of a design tool. Parsing is memoized per string, so the cost
+// of the choice is one Map lookup per painted frame.
+//
+// ## What is deliberately not here
+//
+// - `radial-gradient` / `conic-gradient`: RENDER has both and ntk exposes
+//   them, but CSS's sizing keywords (`closest-side`, `farthest-corner`, an
+//   ellipse with two radii and a position) are most of the work and none of
+//   the demand. `linear-gradient` is what a header, a card and a selected
+//   row are made of.
+// - `inset` shadows: a different drawing (the coverage is the box *minus*
+//   the blurred rect) and a different damage story, since an inset shadow
+//   never leaves the node. Rejected loudly rather than ignored — see
+//   `parseBoxShadow` — because silently painting an outer shadow where an
+//   inner one was asked for is a bug the author cannot see the cause of.
+// - `textShadow`: per glyph, through the glyph cache, and much rarer in a
+//   desktop UI.
+
+/** A number, with or without the `px` CSS wants and this vocabulary does not. */
+const LENGTH = /^[+-]?(?:\d+\.?\d*|\.\d+)(?:px)?$/i;
+/** …and the same thing as a percentage, which colour stops also take. */
+const PERCENT = /^[+-]?(?:\d+\.?\d*|\.\d+)%$/;
+const ANGLE = /^([+-]?(?:\d+\.?\d*|\.\d+))(deg|grad|rad|turn)$/i;
+
+const TO_ANGLE = { top: 0, right: 90, bottom: 180, left: 270 };
+const VERTICAL = new Set(['top', 'bottom']);
+const HORIZONTAL = new Set(['left', 'right']);
+
+/**
+ * Split on `,` or on whitespace, but only at the top level: a stop is
+ * `rgba(0, 0, 0, .4)` as often as it is `#333`, and every naive split on
+ * this vocabulary gets that wrong.
+ */
+function splitTop(text, byComma) {
+  const out = [];
+  let depth = 0;
+  let start = 0;
+  const push = (end) => {
+    const piece = text.slice(start, end).trim();
+    if (byComma || piece) out.push(piece);
+  };
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === '(') depth++;
+    else if (ch === ')') depth--;
+    else if (
+      depth === 0 &&
+      (byComma ? ch === ',' : ch === ' ' || ch === '\t')
+    ) {
+      push(i);
+      start = i + 1;
+    }
+  }
+  push(text.length);
+  return out;
+}
+
+const number = (text) => parseFloat(text);
+
+function toDegrees(value, unit) {
+  switch (unit.toLowerCase()) {
+    case 'deg':
+      return value;
+    case 'grad':
+      return (value * 360) / 400;
+    case 'rad':
+      return (value * 180) / Math.PI;
+    default:
+      return value * 360; // turn
+  }
+}
+
+/**
+ * `linear-gradient(...)` → `{ angle, corner, stops }`, or null for `none`
+ * and for a value that is not a gradient at all.
+ *
+ * `angle` is CSS's: degrees clockwise from "up", so `180deg` is `to bottom`,
+ * which is also the default when a value names no direction. `corner` is
+ * `'top right'` and friends, which cannot become an angle until the box is
+ * known — the corner keywords are defined so that the gradient line is
+ * perpendicular to the box's *other* diagonal, and that depends on the
+ * aspect ratio (see `linearGradientGeometry`).
+ *
+ * Stops keep their authored position (`{ value, unit }`) or `null` for one
+ * that was left out; distributing those needs the gradient line's length,
+ * which is again the box's business.
+ *
+ * Throws on a malformed value rather than dropping it: a gradient that does
+ * not paint is a blank panel, and "why is my header empty" is a much worse
+ * afternoon than an error naming the property.
+ */
+export function parseLinearGradient(value) {
+  if (typeof value !== 'string') return null;
+  const text = value.trim();
+  if (!text || text === 'none') return null;
+  const open = text.indexOf('(');
+  const name = open === -1 ? text : text.slice(0, open).trim();
+  if (name !== 'linear-gradient') {
+    throw new Error(
+      `react-x11: backgroundImage ${JSON.stringify(value)} is not supported ` +
+        "(expected linear-gradient(…) or 'none'). url() images belong on " +
+        '<image src>, and a radial or conic gradient on a <canvas onDraw>.',
+    );
+  }
+  if (!text.endsWith(')')) {
+    throw new Error(
+      `react-x11: backgroundImage ${JSON.stringify(value)} is missing its ` +
+        'closing parenthesis',
+    );
+  }
+  const parts = splitTop(text.slice(open + 1, -1), true);
+  let angle = null;
+  let corner = null;
+  const first = parts[0] ?? '';
+  const asAngle = ANGLE.exec(first);
+  if (asAngle) {
+    angle = toDegrees(number(asAngle[1]), asAngle[2]);
+    parts.shift();
+  } else if (first.startsWith('to ') || first === 'to') {
+    const sides = splitTop(first.slice(2), false);
+    corner = readSides(sides, value);
+    if (typeof corner === 'number') {
+      angle = corner;
+      corner = null;
+    }
+    parts.shift();
+  }
+  const stops = parts.map((part) => readStop(part, value));
+  if (stops.length < 2) {
+    throw new Error(
+      `react-x11: backgroundImage ${JSON.stringify(value)} needs at least ` +
+        'two colour stops',
+    );
+  }
+  return { angle: angle ?? (corner ? null : TO_ANGLE.bottom), corner, stops };
+}
+
+/** `to bottom` → 180; `to bottom right` → the corner it names. */
+function readSides(sides, value) {
+  const bad = () =>
+    new Error(
+      `react-x11: backgroundImage ${JSON.stringify(value)} has an unusable ` +
+        "direction (expected 'to top', 'to bottom right', … or an angle " +
+        "like '135deg')",
+    );
+  if (sides.length === 1) {
+    const one = TO_ANGLE[sides[0]];
+    if (one === undefined) throw bad();
+    return one;
+  }
+  if (sides.length !== 2) throw bad();
+  const [a, b] = sides;
+  const vertical = VERTICAL.has(a) ? a : VERTICAL.has(b) ? b : null;
+  const horizontal = HORIZONTAL.has(a) ? a : HORIZONTAL.has(b) ? b : null;
+  if (!vertical || !horizontal) throw bad();
+  return `${vertical} ${horizontal}`;
+}
+
+/** `#333`, `$accent 40%`, `rgba(0, 0, 0, .4) 12px`. */
+function readStop(part, value) {
+  if (!part) {
+    throw new Error(
+      `react-x11: backgroundImage ${JSON.stringify(value)} has an empty ` +
+        'colour stop',
+    );
+  }
+  const pieces = splitTop(part, false);
+  const last = pieces[pieces.length - 1];
+  if (pieces.length === 1 && (PERCENT.test(last) || LENGTH.test(last))) {
+    // CSS's *colour hint* — a bare position between two stops that moves the
+    // midpoint of the blend. It is a curve, not a stop, and RENDER has no
+    // way to express one; two stops either side say the same thing.
+    throw new Error(
+      `react-x11: backgroundImage ${JSON.stringify(value)} uses a colour ` +
+        `hint ("${last}"), which is not supported — name the colour at that ` +
+        'position instead.',
+    );
+  }
+  if (pieces.length > 1 && (PERCENT.test(last) || LENGTH.test(last))) {
+    pieces.pop();
+    return {
+      color: pieces.join(' '),
+      position: { value: number(last), unit: PERCENT.test(last) ? '%' : 'px' },
+    };
+  }
+  return { color: part, position: null };
+}
+
+/**
+ * Where the gradient line runs for this box, and the stops along it — the
+ * whole of what `ctx.createLinearGradient` and `addColorStop` need.
+ *
+ * CSS's geometry, which is not the obvious one: the line passes through the
+ * box's centre at the given angle, and its length is the box's *projection*
+ * onto it (`|w·sinθ| + |h·cosθ|`), so that the two corners nearest each end
+ * land exactly on the end colours. That is what makes `135deg` on a wide
+ * header look the way it does in a browser instead of running out a third of
+ * the way across.
+ *
+ * ### The padding, and why it is not cosmetic
+ *
+ * Past its last stop an XRender gradient is **transparent**, not clamped:
+ * `RepeatPad` is a picture attribute the gradient path does not set today
+ * (sidorares/ntk#271, and the `TODO` in ntk's own `CanvasGradient`). CSS and
+ * canvas both clamp. So the line is extended by `pad` device pixels at each
+ * end and the stop offsets are remapped onto the longer line, with the end
+ * colours pinned at 0 and 1 — which *is* pad semantics, expressed in stops.
+ * Two pixels would do for the float noise at a corner; the width here also
+ * covers a caller that rounds the rect it fills after asking for the
+ * geometry.
+ *
+ * Note that this cannot be caught by a pixel test against the in-process X
+ * server: node-x11's RENDER pads by construction (`gradientAt` clamps to the
+ * edge stops), where a real server does not. `test/decorations.test.js`
+ * asserts the stops instead, which is the part that is ours.
+ *
+ * Returns null for a box with no area, which has no gradient line at all.
+ */
+export function linearGradientGeometry(spec, rect, pad = 4) {
+  const { width, height } = rect;
+  if (!(width > 0) || !(height > 0)) return null;
+  const degrees = spec.corner
+    ? cornerAngle(spec.corner, width, height)
+    : spec.angle;
+  const theta = (degrees * Math.PI) / 180;
+  // 0° points up and angles run clockwise, so the direction vector is
+  // (sin, -cos) in a coordinate system whose y grows downwards
+  const dx = Math.sin(theta);
+  const dy = -Math.cos(theta);
+  const length = Math.abs(width * dx) + Math.abs(height * dy);
+  if (!(length > 0)) return null;
+  const cx = rect.x + width / 2;
+  const cy = rect.y + height / 2;
+  const half = length / 2;
+  const offsets = resolveStopOffsets(spec.stops, length);
+  const total = length + pad * 2;
+  const stops = [];
+  if (pad > 0) stops.push([0, spec.stops[0].color]);
+  for (let i = 0; i < spec.stops.length; i++) {
+    stops.push([(pad + offsets[i] * length) / total, spec.stops[i].color]);
+  }
+  if (pad > 0) stops.push([1, spec.stops[spec.stops.length - 1].color]);
+  return {
+    x0: cx - dx * (half + pad),
+    y0: cy - dy * (half + pad),
+    x1: cx + dx * (half + pad),
+    y1: cy + dy * (half + pad),
+    stops,
+  };
+}
+
+/**
+ * The magic angle behind `to bottom right`: the gradient line is turned so
+ * that a perpendicular through it passes through the two *other* corners, so
+ * a square gives 45° and a wide box tends towards `to right`.
+ */
+function cornerAngle(corner, width, height) {
+  const base = (Math.atan2(width, height) * 180) / Math.PI;
+  switch (corner) {
+    case 'top right':
+      return base;
+    case 'bottom right':
+      return 180 - base;
+    case 'bottom left':
+      return 180 + base;
+    default: // top left
+      return 360 - base;
+  }
+}
+
+/**
+ * Stop positions as fractions of the gradient line, CSS's rules: a missing
+ * first is 0 and a missing last is 1, a run of missing ones is spread evenly
+ * between the neighbours that do have a position, and a position that goes
+ * backwards is pulled up to the largest so far (which is how a hard colour
+ * break — two stops at the same offset — stays expressible).
+ */
+function resolveStopOffsets(stops, length) {
+  const out = stops.map(({ position }) => {
+    if (!position) return null;
+    return position.unit === '%'
+      ? position.value / 100
+      : position.value / length;
+  });
+  if (out[0] === null) out[0] = 0;
+  if (out[out.length - 1] === null) out[out.length - 1] = 1;
+  for (let i = 1; i < out.length; i++) {
+    if (out[i] !== null) continue;
+    let end = i + 1;
+    while (out[end] === null) end++;
+    const from = out[i - 1];
+    const step = (out[end] - from) / (end - i + 1);
+    for (let j = i; j < end; j++) out[j] = from + step * (j - i + 1);
+    i = end - 1;
+  }
+  let highest = 0;
+  for (let i = 0; i < out.length; i++) {
+    highest = out[i] = Math.max(highest, Math.min(1, Math.max(0, out[i])));
+  }
+  return out;
+}
+
+/**
+ * `boxShadow` → a list of `{ dx, dy, blur, spread, color }`, painted in the
+ * order CSS paints them: first in the list is nearest the front, so the
+ * renderer draws the list back to front.
+ *
+ * `color` may be null, which is CSS's `currentColor` — the node's own ink,
+ * which the caller resolves because only it knows the cascade.
+ *
+ * Throws on `inset` and on anything unparseable; see the note at the top of
+ * this file for why a shadow that silently does the wrong thing is worse
+ * than one that refuses.
+ */
+export function parseBoxShadow(value) {
+  if (typeof value !== 'string') return null;
+  const text = value.trim();
+  if (!text || text === 'none') return null;
+  return splitTop(text, true).map((one) => readShadow(one, value));
+}
+
+function readShadow(part, value) {
+  const bad = (why) =>
+    new Error(
+      `react-x11: boxShadow ${JSON.stringify(value)} ${why} (expected ` +
+        "'<x> <y> [blur] [spread] [colour]', e.g. '0 2px 8px rgba(0, 0, 0, .4)')",
+    );
+  const pieces = splitTop(part, false);
+  if (!pieces.length) throw bad('has an empty shadow');
+  if (pieces.some((p) => p.toLowerCase() === 'inset')) {
+    throw new Error(
+      `react-x11: boxShadow ${JSON.stringify(value)} asks for an inset ` +
+        'shadow, which is not implemented — only outer shadows are. An ' +
+        'inner glow can be drawn with an inset border or a <canvas onDraw>.',
+    );
+  }
+  const lengths = [];
+  let color = null;
+  for (const piece of pieces) {
+    if (LENGTH.test(piece)) {
+      if (lengths.length === 4) throw bad('has more than four lengths');
+      lengths.push(number(piece));
+      continue;
+    }
+    if (color !== null) throw bad(`has more than one colour ("${piece}")`);
+    color = piece;
+  }
+  if (lengths.length < 2) throw bad('needs an x and a y offset');
+  const [dx, dy, blur = 0, spread = 0] = lengths;
+  if (blur < 0) throw bad('has a negative blur radius');
+  return { dx, dy, blur, spread, color };
+}
+
+/**
+ * The gaussian a CSS blur radius means, and the room it needs.
+ *
+ * CSS defines the blur radius as *twice* the standard deviation, and ntk's
+ * `Picture.setBlurFilter(size, sigma)` takes the convolution kernel's edge
+ * length rather than a radius — so the two names that look like they match
+ * are the two that must not be passed to each other. The kernel is cut at
+ * 3σ, where the gaussian is down to 1% and the truncation is invisible;
+ * `pad` is the same distance, and it is what stops the blur clipping square
+ * against the edge of the surface it was rendered into.
+ *
+ * `MAX_KERNEL` bounds a pathological value: the server convolves N² taps per
+ * pixel, so a 200px blur asked for by accident would otherwise be a frame
+ * that never lands.
+ */
+const MAX_KERNEL = 61;
+
+export function blurKernel(blur) {
+  const sigma = blur / 2;
+  const reach = Math.ceil(3 * sigma);
+  const size = Math.min(MAX_KERNEL, 2 * reach + 1);
+  return { sigma, size, pad: (size - 1) / 2 + 1 };
+}
+
+/**
+ * How far outside the node's own box this shadow list reaches, in device
+ * pixels — the damage inflation, and the reason a shadow is not just a
+ * colour. Symmetric on purpose: a shadow offset down and right claims the
+ * same slack above and left, which costs a few pixels of repaint and saves
+ * every caller from carrying four numbers around.
+ */
+export function shadowExtent(shadows) {
+  let extent = 0;
+  for (const s of shadows ?? []) {
+    const reach =
+      Math.max(Math.abs(s.dx), Math.abs(s.dy)) +
+      s.spread +
+      (s.blur > 0 ? blurKernel(s.blur).pad : 0);
+    if (reach > extent) extent = reach;
+  }
+  return Math.ceil(Math.max(0, extent));
+}
+
+// --- memoized parsing ------------------------------------------------------
+//
+// A style value is a string that is usually the same string as last frame —
+// a hoisted style, a theme token resolved to the same colour — so the parse
+// is keyed on it and never repeated. Failures are cached as `null` too:
+// `validateStyle` has already thrown for them in development, and a frame in
+// production must not re-throw once per node per frame for a value nothing
+// is going to fix mid-run.
+
+const MAX_CACHE = 256;
+const gradients = new Map();
+const shadows = new Map();
+
+function memoize(cache, key, parse) {
+  if (cache.has(key)) return cache.get(key);
+  let parsed = null;
+  try {
+    parsed = parse(key);
+  } catch {
+    parsed = null;
+  }
+  if (cache.size >= MAX_CACHE) cache.clear();
+  cache.set(key, parsed);
+  return parsed;
+}
+
+/** `parseLinearGradient`, memoized and non-throwing: the paint path's door. */
+export const gradientSpec = (value) =>
+  memoize(gradients, value, parseLinearGradient);
+
+/** `parseBoxShadow`, memoized and non-throwing. */
+export const shadowSpecs = (value) => memoize(shadows, value, parseBoxShadow);

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -37,7 +37,19 @@ import {
   resolveBorderColors,
   tint,
 } from './styles.js';
+import {
+  blurKernel,
+  gradientSpec,
+  linearGradientGeometry,
+  shadowExtent,
+  shadowSpecs,
+} from './decorations.js';
 import { Yoga } from './yoga.js';
+// Namespace import for `Surface`, the same shape and the same reason as
+// `paintcache.js`: a named import of something an older ntk does not export
+// is a *load-time* SyntaxError, which would take the renderer down rather
+// than the one feature that needs it.
+import * as ntk from 'ntk';
 import { cssColorStraight } from 'ntk';
 import {
   EventManager,
@@ -226,6 +238,7 @@ let layoutDiffSink = null;
 const INVALIDATE_REASONS = new Set([
   'props', // a React commit changed what a node draws
   'style-state', // :hover/:focus/:active/:disabled restyle
+  'shadow', // a boxShadow got smaller: where it *was* still owes a repaint
   'theme', // a theme/token change restyled a subtree
   'direction', // the reading direction moved: sides, glyph order, bar edge
   'animation', // a transition frame
@@ -577,10 +590,55 @@ function isPaintedColor(color) {
   return Boolean(color) && color !== 'transparent';
 }
 
+/**
+ * `rect`, rounded, as a path — the one shape the drawn layer is made of.
+ * `roundRect` needs ntk >= 3.2.0 and the square fallback is what an older
+ * one gets, which is the same degradation `_paintBorder` has always made.
+ */
+function roundedPath(ctx, rect, radius) {
+  ctx.beginPath();
+  if (radius > 0 && typeof ctx.roundRect === 'function') {
+    ctx.roundRect(rect.x, rect.y, rect.width, rect.height, radius);
+  } else {
+    ctx.rect(rect.x, rect.y, rect.width, rect.height);
+  }
+}
+
+/** A style's shadow reach, for the two callers that have a style rather than
+ *  a node (`_retarget`'s before/after pair). */
+function shadowExtentOf(style) {
+  const value = style?.boxShadow;
+  if (!value || value === 'none') return 0;
+  return shadowExtent(shadowSpecs(value));
+}
+
 const DEV = process.env.NODE_ENV !== 'production';
 
 // Connections already told they have no 32-bit visual (`_argbAttributes`).
 const warnedNoArgb = new WeakSet();
+
+/**
+ * `boxShadow` on a `<window>`/`<popup>`, warned about once.
+ *
+ * A shadow falls *outside* the box, and outside a toplevel there is nothing
+ * of ours to paint on — the pixels belong to the desktop. Doing it properly
+ * means the window asking for a translucent margin it does not otherwise
+ * want (an ARGB visual, a bigger X window, and hit testing that knows the
+ * difference), which is a feature of its own rather than a line in the
+ * painter. Said out loud because the alternative is a style that reads as
+ * ignored for no reason.
+ */
+let warnedWindowShadow = false;
+function devWarnWindowShadow(kind) {
+  if (warnedWindowShadow) return;
+  warnedWindowShadow = true;
+  console.warn(
+    `react-x11: boxShadow on <${kind}> is ignored — a shadow is painted ` +
+      'outside the box, and a toplevel window owns no pixels there. Put the ' +
+      'shadow on a <box> inside it, or draw the window with a translucent ' +
+      'margin of its own (docs/styling.md).',
+  );
+}
 
 // `borderRadius` on a non-uniform border warned about once (`_paintBorderSides`).
 let warnedSideRadius = false;
@@ -1490,6 +1548,21 @@ export class Node {
     // so focus leaves it by the same rule (`_visibilityChanged`).
     if (displayed.display !== this.style.display) {
       this._visibilityChanged(this.style.display !== 'none');
+    }
+    // A shadow that just got smaller — or went away — has to claim where it
+    // *was*. Every claim downstream of here is bounded by `paintBounds()`,
+    // which is computed from the style now in force, so a node that drops a
+    // `:hover` shadow would repaint its own box and leave the shadow printed
+    // around it. This is the only place both extents exist at once.
+    if (displayed.boxShadow !== this.style.boxShadow) {
+      const shrank = shadowExtentOf(displayed) - shadowExtentOf(this.style);
+      if (shrank > 0) {
+        this.root?.invalidate(
+          false,
+          insetRect(this.paintBounds(), -shrank),
+          'shadow',
+        );
+      }
     }
     return this.style;
   }
@@ -2853,15 +2926,21 @@ export class Node {
   }
 
   /**
-   * This node's own rect, grown by anything it draws outside it — which is
-   * the outline and nothing else. Per node rather than once at the top,
-   * because the ring belongs to whichever node has focus and the bound has
-   * to cover it wherever that is; and grown even when the ring is currently
-   * *off*, because the frame that erases it is claimed after the state has
-   * already flipped back.
+   * This node's own rect, grown by anything it draws outside it — the
+   * outline and the shadow, the only two. Per node rather than once at the
+   * top, because either can belong to any node and the bound has to cover it
+   * wherever it is; and the outline is counted even when the ring is
+   * currently *off*, because the frame that erases it is claimed after the
+   * state has already flipped back.
+   *
+   * A shadow cannot afford that trick — its extent is whatever the style
+   * says rather than a theme constant, so inflating for one that is not
+   * there would widen the claim of every node that has ever hovered. The
+   * frame that *removes* a shadow claims the old extent from `_retarget`
+   * instead, where both the old style and the new one are in hand.
    */
   _ownPaintBounds() {
-    const extent = this._outlineExtent();
+    const extent = Math.max(this._outlineExtent(), this._shadowExtent());
     if (extent <= 0) return this.abs;
     return {
       x: this.abs.x - extent,
@@ -2913,6 +2992,14 @@ export class Node {
       return 0;
     const outline = this._outline();
     return outline ? outline.width + Math.max(0, outline.offset) : 0;
+  }
+
+  /**
+   * How far outside `abs` this node's `boxShadow` reaches — the offset, the
+   * spread and the blur's tail, symmetrically (see `shadowExtent`).
+   */
+  _shadowExtent() {
+    return shadowExtentOf(this.style);
   }
 
   /** Would a keyboard focus land here? The one rule lives in a11y.js —
@@ -3196,6 +3283,11 @@ export class Node {
 
   paint(ctx) {
     if (this.hidden) return;
+    // Outside the box and under everything, which is the whole of what makes
+    // a shadow different from a colour: it is drawn before this node's own
+    // background so a translucent background does not sit on top of it, and
+    // it inks pixels this node does not own — see `_ownPaintBounds`.
+    this._paintShadow(ctx);
     this._paintBackground(ctx);
     // The paint cache covers a node's *content* — the expensive part — and
     // not its box: background and border are one composite each, and keeping
@@ -3247,29 +3339,187 @@ export class Node {
   }
 
   _roundedPath(ctx, radius) {
-    ctx.beginPath();
-    if (radius > 0 && typeof ctx.roundRect === 'function') {
-      ctx.roundRect(
-        this.abs.x,
-        this.abs.y,
-        this.abs.width,
-        this.abs.height,
-        radius,
-      );
-    } else {
-      ctx.rect(this.abs.x, this.abs.y, this.abs.width, this.abs.height);
-    }
+    roundedPath(ctx, this.abs, radius);
   }
 
   _paintBackground(ctx) {
     const { backgroundColor, borderRadius = 0 } = this.style;
-    if (!isPaintedColor(backgroundColor)) return;
-    ctx.fillStyle = backgroundColor;
-    if (borderRadius > 0) {
-      this._roundedPath(ctx, borderRadius);
-      ctx.fill();
-    } else {
-      ctx.fillRect(this.abs.x, this.abs.y, this.abs.width, this.abs.height);
+    const fill = (style) => {
+      ctx.fillStyle = style;
+      if (borderRadius > 0) {
+        this._roundedPath(ctx, borderRadius);
+        ctx.fill();
+      } else {
+        ctx.fillRect(this.abs.x, this.abs.y, this.abs.width, this.abs.height);
+      }
+    };
+    if (isPaintedColor(backgroundColor)) fill(backgroundColor);
+    // …and the gradient over it, which is CSS's order and not a detail: a
+    // translucent gradient over a solid colour is how a tint is written, and
+    // a node that sets only the gradient pays one composite either way.
+    const gradient = this._backgroundGradient(ctx);
+    if (gradient) fill(gradient);
+  }
+
+  /**
+   * The `backgroundImage` gradient for this node's current box, as the ntk
+   * `CanvasGradient` a fill style takes — or null when there is none, when
+   * the box has no area, or when the context cannot make one (the headless
+   * mock).
+   *
+   * Cached on the node and keyed by the value *and the rect*, because the
+   * coordinates are absolute. They have to be: a gradient created after a
+   * `translate()` ignores the transform (sidorares/ntk#271), and the drawn
+   * layer paints in window coordinates anyway, so there is no translation to
+   * be wrong about — the cost is that a node which moves rebuilds its
+   * gradient, which is one small request and a picture the GC reclaims
+   * through ntk's finalizer. Headers, cards and rows are the customers here
+   * and they move on layout, not on input.
+   */
+  _backgroundGradient(ctx, rect = this.abs) {
+    const value = this.style.backgroundImage;
+    if (!value || value === 'none') return null;
+    if (typeof ctx.createLinearGradient !== 'function') return null;
+    const spec = gradientSpec(value);
+    if (!spec) return null;
+    const { x, y, width, height } = rect;
+    const key = `${value}|${x},${y},${width},${height}`;
+    if (this._gradient?.key === key) return this._gradient.value;
+    const line = linearGradientGeometry(spec, rect);
+    if (!line) return null;
+    const gradient = ctx.createLinearGradient(
+      line.x0,
+      line.y0,
+      line.x1,
+      line.y1,
+    );
+    for (const [offset, color] of line.stops)
+      gradient.addColorStop(offset, color);
+    this._gradient = { key, value: gradient };
+    return gradient;
+  }
+
+  /**
+   * `boxShadow`. Back to front, like CSS: the first shadow in the list is
+   * the nearest the viewer, so the list is walked in reverse.
+   *
+   * A shadow with no blur is a rounded rectangle and costs one composite. A
+   * blurred one is coverage — an a8 surface holding the rectangle, blurred
+   * server-side by RENDER's convolution filter and then painted *through*
+   * the shadow colour, which is the same trick the glyph cache and `<canvas
+   * mono>` run on. That is what keeps the colour out of the cache key, so a
+   * `:hover` that only darkens the shadow reuses the surface it already
+   * rendered.
+   */
+  _paintShadow(ctx) {
+    const value = this.style.boxShadow;
+    if (!value || value === 'none') return;
+    const shadows = shadowSpecs(value);
+    if (!shadows?.length) return;
+    const radius = this.style.borderRadius ?? 0;
+    for (let i = shadows.length - 1; i >= 0; i--) {
+      const shadow = shadows[i];
+      // CSS's `currentColor`: this node's *resolved* ink, its own `color`
+      // over what it inherits — so a shadow written without a colour follows
+      // the text it sits under, including down a `:hover` that dims both
+      const color = shadow.color ?? this.resolvedTextStyle().color;
+      if (!isPaintedColor(color)) continue;
+      const rect = {
+        x: this.abs.x + shadow.dx - shadow.spread,
+        y: this.abs.y + shadow.dy - shadow.spread,
+        width: this.abs.width + shadow.spread * 2,
+        height: this.abs.height + shadow.spread * 2,
+      };
+      if (!(rect.width > 0) || !(rect.height > 0)) continue;
+      // the spread grows the corner with the box, the way CSS's does
+      const r = Math.max(0, radius + shadow.spread);
+      if (!(shadow.blur > 0)) {
+        ctx.fillStyle = color;
+        roundedPath(ctx, rect, r);
+        ctx.fill();
+        continue;
+      }
+      this._paintBlurredShadow(ctx, rect, r, shadow.blur, color);
+    }
+  }
+
+  /**
+   * One blurred shadow, through the paint cache when there is one.
+   *
+   * The surface is the shadow's rectangle plus `pad` on every side, and the
+   * padding is load-bearing: the convolution reads outside the picture as
+   * transparent, so a kernel that runs off the edge ends the shadow in a
+   * straight line. The blur is set on the *picture* rather than baked into
+   * the pixels, which is why it survives in a cached entry and why the
+   * surface itself is a plain white rectangle.
+   *
+   * `maxPixels` is raised well above the cache's default: a card's shadow is
+   * as big as the card, an entry for one is a8 (a byte a pixel), and the
+   * thing being avoided — a convolution per frame over the whole box — is
+   * exactly the cost the default cap exists to bound elsewhere.
+   */
+  _paintBlurredShadow(ctx, rect, radius, blur, color) {
+    const { sigma, size, pad } = blurKernel(blur);
+    // integral, because the surface is pixels; the blur is far wider than
+    // the rounding, so nothing about the result is visibly quantized
+    const width = Math.round(rect.width);
+    const height = Math.round(rect.height);
+    const plan = {
+      key: `shadow|${width}x${height}|r${radius}|b${blur}`,
+      x: Math.round(rect.x) - pad,
+      y: Math.round(rect.y) - pad,
+      width: width + pad * 2,
+      height: height + pad * 2,
+      format: 'a8',
+      tint: color,
+      maxPixels: 1024 * 1024,
+      draw: (sctx, box) => {
+        // full coverage: the colour arrives at composite time
+        sctx.fillStyle = '#ffffff';
+        roundedPath(
+          sctx,
+          { x: box.x + pad, y: box.y + pad, width, height },
+          radius,
+        );
+        sctx.fill();
+      },
+      after: (surface) => surface.picture().setBlurFilter(size, sigma),
+      live: () => this._paintShadowLive(ctx, plan),
+    };
+    const cache = this.root?._paintCache;
+    if (cache) cache.drawing(ctx, plan);
+    else this._paintShadowLive(ctx, plan);
+  }
+
+  /**
+   * The same drawing with no cache behind it — the paint-cache-disabled
+   * build, an entry too big for the budget, and the first frame of a shadow
+   * the cache has only seen once. A surface per frame is what a shadow costs
+   * without a cache; it is still one composite on the wire, and the
+   * alternative is not painting it.
+   */
+  _paintShadowLive(ctx, plan) {
+    if (typeof ntk.Surface !== 'function' || !this.app?.display?.Render) return;
+    let surface = null;
+    try {
+      surface = new ntk.Surface(this.app, {
+        width: plan.width,
+        height: plan.height,
+        format: 'a8',
+      });
+      surface.render((sctx) =>
+        plan.draw(sctx, { x: 0, y: 0, width: plan.width, height: plan.height }),
+      );
+      plan.after(surface);
+      const before = ctx.fillStyle;
+      ctx.fillStyle = plan.tint;
+      ctx.drawImage(surface, plan.x, plan.y);
+      ctx.fillStyle = before;
+    } catch {
+      // A server that will not give us a pixmap: the frame is still owed
+      // everything else in it, and a missing shadow is a cosmetic loss.
+    } finally {
+      surface?.destroy();
     }
   }
 
@@ -9243,44 +9493,57 @@ export class WindowNode extends Scrollable(Node) {
    */
   _paintWindowBackground(ctx, damage, width, height) {
     const { backgroundColor, borderRadius = 0 } = this.style;
-    if (this.transparencyEffective) {
-      if (!isPaintedColor(backgroundColor)) return;
-      ctx.fillStyle = backgroundColor;
-      if (borderRadius > 0 && typeof ctx.roundRect === 'function') {
+    if (DEV && this.style.boxShadow) devWarnWindowShadow(this.kind);
+    // A `backgroundImage` works wherever a `backgroundColor` does, which is
+    // the rule worth having — over the whole window, in window coordinates,
+    // and still filling only the damage rect: the gradient is a source
+    // picture in device space, so a slice of it is the slice that belongs
+    // there.
+    const gradient = this._backgroundGradient(ctx, {
+      x: 0,
+      y: 0,
+      width,
+      height,
+    });
+    const fill = (style, rounded) => {
+      ctx.fillStyle = style;
+      if (rounded) {
         // The path is the whole window however small the damage rect is —
         // the clip bounds it — so repainting one corner still draws that
         // corner's curve rather than a square patch of background.
         ctx.beginPath();
         ctx.roundRect(0, 0, width, height, borderRadius);
         ctx.fill();
-        return;
+      } else if (damage) {
+        ctx.fillRect(damage.x, damage.y, damage.width, damage.height);
+      } else {
+        ctx.fillRect(0, 0, width, height);
       }
-    } else {
-      // An ARGB window that nothing is compositing has an alpha channel it
-      // must not use. It gets filled edge to edge and square — `borderRadius`
-      // is ignored, because giving up the corners here would expose the
-      // black those pixels really are. A translucent colour is flattened
-      // over white rather than composited onto the last frame, which on a
-      // window with alpha would otherwise creep towards opaque a frame at a
-      // time and never settle anywhere predictable.
-      if (this._transparent) {
-        ctx.fillStyle = 'white';
-        if (damage) {
-          ctx.fillRect(damage.x, damage.y, damage.width, damage.height);
-        } else {
-          ctx.fillRect(0, 0, width, height);
-        }
-      }
-      // No `backgroundColor` means the desktop's, not white: a window whose
-      // widgets went dark on a dark desktop must not leave a white rectangle
-      // behind them. An app that named a colour gets the colour it named.
-      ctx.fillStyle = backgroundColor || this.theme.background;
+    };
+    if (this.transparencyEffective) {
+      if (!isPaintedColor(backgroundColor) && !gradient) return;
+      const rounded = borderRadius > 0 && typeof ctx.roundRect === 'function';
+      if (isPaintedColor(backgroundColor)) fill(backgroundColor, rounded);
+      if (gradient) fill(gradient, rounded);
+      return;
     }
+    // An ARGB window that nothing is compositing has an alpha channel it
+    // must not use. It gets filled edge to edge and square — `borderRadius`
+    // is ignored, because giving up the corners here would expose the
+    // black those pixels really are. A translucent colour is flattened
+    // over white rather than composited onto the last frame, which on a
+    // window with alpha would otherwise creep towards opaque a frame at a
+    // time and never settle anywhere predictable.
+    if (this._transparent) fill('white', false);
+    // No `backgroundColor` means the desktop's, not white: a window whose
+    // widgets went dark on a dark desktop must not leave a white rectangle
+    // behind them. An app that named a colour gets the colour it named.
+    //
     // repainting the background only where it is about to be drawn over is
     // the other half of the win: a full-window fill is a full-window
     // composite however little changed
-    if (damage) ctx.fillRect(damage.x, damage.y, damage.width, damage.height);
-    else ctx.fillRect(0, 0, width, height);
+    fill(backgroundColor || this.theme.background, false);
+    if (gradient) fill(gradient, false);
   }
 
   /**

--- a/src/paintcache.js
+++ b/src/paintcache.js
@@ -189,11 +189,35 @@ export class PaintCache {
    */
   paint(node, ctx) {
     const plan = node.paintCachePlan(ctx);
-    if (!plan || !isDeviceSpace(ctx)) return node.paintContent(ctx);
+    if (!plan) return node.paintContent(ctx);
+    return this.drawing(ctx, {
+      ...plan,
+      label: `<${node.kind}>`,
+      draw: (sctx, box) => node.paintCached(sctx, box),
+      live: () => node.paintContent(ctx),
+    });
+  }
 
-    if (plan.width * plan.height > MAX_ITEM_PIXELS) {
+  /**
+   * Paint a cacheable **drawing**, which a node's content is one kind of.
+   *
+   * `plan` is the node protocol's plan (`key`, `x`/`y`, `width`/`height`,
+   * `format`, `tint`) plus the three things a node supplies implicitly:
+   * `draw(sctx, box)` renders into the surface, `live()` paints the same
+   * thing straight to the target for every path that declines to cache, and
+   * the optional `after(surface)` runs once on a freshly rendered one — for
+   * a filter that belongs to the picture rather than to the pixels, which is
+   * how a blurred `boxShadow` is a cache entry at all (issue #345).
+   *
+   * `maxPixels` overrides the per-item cap for a caller whose drawing is
+   * legitimately box-sized rather than icon-sized.
+   */
+  drawing(ctx, plan) {
+    if (!isDeviceSpace(ctx)) return plan.live(ctx);
+
+    if (plan.width * plan.height > (plan.maxPixels ?? MAX_ITEM_PIXELS)) {
       this.stats.tooBig++;
-      return node.paintContent(ctx);
+      return plan.live(ctx);
     }
 
     const hit = this.entries.get(plan.key);
@@ -203,7 +227,7 @@ export class PaintCache {
       this.entries.set(plan.key, hit);
       this.inUse.add(hit);
       this.stats.hits++;
-      if (this.verify) this._verify(node, hit, plan);
+      if (this.verify) this._verify(hit, plan);
       return this._blit(ctx, hit, plan);
     }
 
@@ -212,19 +236,19 @@ export class PaintCache {
     if (seen < 2) {
       if (this.pending.size >= MAX_PENDING) this.pending.clear();
       this.pending.set(plan.key, seen);
-      return node.paintContent(ctx);
+      return plan.live(ctx);
     }
     this.pending.delete(plan.key);
 
-    const entry = this._render(node, plan);
-    if (!entry) return node.paintContent(ctx);
+    const entry = this._render(plan);
+    if (!entry) return plan.live(ctx);
     this.entries.set(plan.key, entry);
     this.bytes += entry.bytes;
     this.inUse.add(entry);
     return this._blit(ctx, entry, plan);
   }
 
-  _render(node, plan) {
+  _render(plan) {
     try {
       const surface = new ntk.Surface(this.app, {
         width: plan.width,
@@ -234,11 +258,9 @@ export class PaintCache {
       const box = { x: 0, y: 0, width: plan.width, height: plan.height };
       const state = { digest: 0x811c9dc5 };
       surface.render((sctx) =>
-        node.paintCached(
-          this.verify ? recordingContext(sctx, state) : sctx,
-          box,
-        ),
+        plan.draw(this.verify ? recordingContext(sctx, state) : sctx, box),
       );
+      plan.after?.(surface);
       this.stats.renders++;
       return {
         key: plan.key,
@@ -273,7 +295,7 @@ export class PaintCache {
    * name everything the paint reads, which is the one way this design
    * produces a wrong pixel rather than a slow frame.
    */
-  _verify(node, entry, plan) {
+  _verify(entry, plan) {
     const state = { digest: 0x811c9dc5 };
     let scratch = null;
     try {
@@ -283,7 +305,7 @@ export class PaintCache {
         format: plan.format,
       });
       scratch.render((sctx) =>
-        node.paintCached(recordingContext(sctx, state), {
+        plan.draw(recordingContext(sctx, state), {
           x: 0,
           y: 0,
           width: plan.width,
@@ -297,7 +319,7 @@ export class PaintCache {
     }
     if (state.digest === entry.digest) return;
     console.error(
-      `react-x11: paint cache key does not cover the paint of <${node.kind}>.\n` +
+      `react-x11: paint cache key does not cover the paint of ${plan.label ?? plan.key}.\n` +
         `  key: ${plan.key}\n` +
         '  The drawing changed while the key did not, so a cached frame would ' +
         'show stale pixels. Add whatever changed to the key.',

--- a/src/styles.js
+++ b/src/styles.js
@@ -5,6 +5,7 @@
 // module scope, which is what that module's synchronous half is for.
 import { cssColorStraight } from 'ntk';
 
+import { parseBoxShadow, parseLinearGradient } from './decorations.js';
 import { Yoga } from './yoga.js';
 
 const FLEX_DIRECTION = {
@@ -198,6 +199,14 @@ const LAYOUT_APPLIERS = {
 // under it reflows.
 const PAINT_PROPS = new Set([
   'backgroundColor',
+  // The two decorations that are not a colour (issue #345, src/decorations.js).
+  // Paint props like the rest of this set, which is what makes them legal in
+  // a state block — a card that lifts on `:hover` is the case they exist for
+  // — and what keeps them out of layout: a gradient is painted in the box the
+  // layout already decided on, and a shadow is drawn outside it and moves
+  // nothing.
+  'backgroundImage',
+  'boxShadow',
   'borderColor',
   'borderTopColor',
   'borderRightColor',
@@ -539,6 +548,30 @@ export function resolveQueries(style, { size = null, supports = null } = {}) {
   return out;
 }
 
+/**
+ * The two style values that are a small language rather than a number, and
+ * therefore the two that can be *wrong* rather than merely absent. Parsed in
+ * development wherever they are written — including inside a state block,
+ * which is the half of the surface a `continue` used to skip — so the error
+ * naming the property and the expected spelling arrives at the call site
+ * instead of as a blank panel three commits later.
+ *
+ * Tokens are still unresolved here (`$accent` is a colour as far as the
+ * grammar is concerned), so this checks the shape and never the colours.
+ */
+function validateValue(key, value, where) {
+  if (key !== 'backgroundImage' && key !== 'boxShadow') return;
+  try {
+    if (key === 'backgroundImage') parseLinearGradient(value);
+    else parseBoxShadow(value);
+  } catch (err) {
+    // the parser names the property and the grammar; only the call site is
+    // missing, and it is what turns the message into a place to look
+    err.message += `\n  in ${where}`;
+    throw err;
+  }
+}
+
 function validateStyle(style, where) {
   for (const key of Object.keys(style)) {
     if (isQuery(key)) {
@@ -560,7 +593,10 @@ function validateStyle(style, where) {
         );
       }
       for (const inner of Object.keys(style[key] ?? {})) {
-        if (STATE_PROPS.has(inner)) continue;
+        if (STATE_PROPS.has(inner)) {
+          validateValue(inner, style[key][inner], `${where} ${key}`);
+          continue;
+        }
         throw new Error(
           `react-x11: "${inner}" is not allowed inside "${key}" in ${where}. ` +
             'State blocks may only change paint properties ' +
@@ -573,6 +609,7 @@ function validateStyle(style, where) {
     if (!STYLE_PROPS.has(key)) {
       throw new Error(`react-x11: unknown style property "${key}" in ${where}`);
     }
+    validateValue(key, style[key], where);
     if (key === 'flex' && !isFlexShorthand(style[key])) {
       throw new Error(
         `react-x11: invalid flex ${JSON.stringify(style[key])} in ${where} ` +
@@ -657,6 +694,12 @@ export function hasStateStyles(style) {
  */
 const NOT_ANIMATABLE = new Set([
   'transition',
+  // Both are strings that describe several numbers and a colour at once, and
+  // `interpolate` works on one value. They snap, which for a state change is
+  // what the shorter durations look like anyway; a card that wants to *rise*
+  // on hover transitions its `borderColor` or its background beside them.
+  'backgroundImage',
+  'boxShadow',
   'zIndex',
   'direction',
   'flexDirection',
@@ -834,13 +877,28 @@ export const ease = (t) => 1 - (1 - t) ** 3;
  * outside render, with no access to React context — and still follow the
  * theme. The sigil is what keeps it unambiguous: `'red'` is a CSS colour,
  * `'$red'` is a token.
+ *
+ * A token also resolves **inside** a value that is a small language of its
+ * own — `linear-gradient($accent, $accentActive)`, `boxShadow: '0 2px 8px
+ * $shadow'`. Those two are the whole reason: the point of the palette is
+ * that a colour is named once, and a decoration that could not name one
+ * would push every gradient in an app back into `useTheme()` and out of a
+ * hoisted style. It is the same substitution either way, so the value that
+ * *is* a token keeps its fast path and the value that *mentions* one goes
+ * through the regexp.
  */
 const isToken = (v) => typeof v === 'string' && v.charCodeAt(0) === 36; /* $ */
+/** `$name`, anywhere in a string. Deliberately the same grammar as a whole
+ * token, so `'$accent'` and `'linear-gradient($accent, #000)'` cannot
+ * disagree about what a name is. */
+const TOKEN_IN_VALUE = /\$[A-Za-z_][A-Za-z0-9_-]*/g;
+const mentionsToken = (v) =>
+  typeof v === 'string' && v.charCodeAt(0) !== 36 && v.includes('$');
 
 export function styleUsesTokens(style) {
   for (const key of Object.keys(style)) {
     const v = style[key];
-    if (isToken(v)) return true;
+    if (isToken(v) || mentionsToken(v)) return true;
     if (key.charCodeAt(0) === 58 && v && styleUsesTokens(v)) return true;
   }
   return false;
@@ -853,6 +911,8 @@ export function tokenNames(style, out = new Set()) {
   for (const key of Object.keys(style)) {
     const v = style[key];
     if (isToken(v)) out.add(v);
+    else if (mentionsToken(v))
+      for (const m of v.match(TOKEN_IN_VALUE) ?? []) out.add(m);
     else if (key.charCodeAt(0) === 58 && v) tokenNames(v, out);
   }
   return out;
@@ -873,7 +933,9 @@ export function stripTokens(style) {
   const out = {};
   for (const key of Object.keys(style)) {
     const v = style[key];
-    if (isToken(v)) continue;
+    // a value that *mentions* a token goes too, and whole: half a gradient
+    // is not a gradient, and the node restyles on attach either way
+    if (isToken(v) || mentionsToken(v)) continue;
     out[key] = key.charCodeAt(0) === 58 && v ? stripTokens(v) : v;
   }
   return out;
@@ -907,6 +969,26 @@ export function resolveTokens(style, theme, where = 'style', strict = true) {
         `react-x11: unknown theme token "${v}" in ${where} ` +
           `(theme has ${Object.keys(theme).join(', ') || 'nothing'})`,
       );
+    } else if (mentionsToken(v)) {
+      let unknown = null;
+      const substituted = v.replace(TOKEN_IN_VALUE, (token) => {
+        const name = token.slice(1);
+        if (name in theme) return theme[name];
+        unknown ??= token;
+        return token;
+      });
+      // Same rule as a whole-value token, one level down: unknown is a
+      // mistake once the ancestry is complete, and provisional before that —
+      // and a half-substituted gradient is dropped rather than painted,
+      // since `$accent` is not a colour and the parse would fail at the
+      // frame instead of at the style.
+      if (!unknown) out[key] = substituted;
+      else if (strict) {
+        throw new Error(
+          `react-x11: unknown theme token "${unknown}" in ${where} ${key} ` +
+            `(theme has ${Object.keys(theme).join(', ') || 'nothing'})`,
+        );
+      }
     } else if (key.charCodeAt(0) === 58 && v) {
       out[key] = resolveTokens(v, theme, `${where} ${key}`, strict);
     } else {

--- a/src/types/style.d.ts
+++ b/src/types/style.d.ts
@@ -163,6 +163,30 @@ export interface LayoutStyle {
  */
 export interface PaintStyle {
   backgroundColor?: Color;
+  /**
+   * A gradient behind the node, in the box the layout gave it:
+   * `'linear-gradient(#2b5876, #4e4376)'`, `'linear-gradient(135deg, $accent,
+   * $accentActive)'`, or `'none'`.
+   *
+   * CSS's grammar and CSS's geometry — an angle in degrees clockwise from
+   * "up", the `to bottom right` keywords, `%`/`px` stop positions — with two
+   * differences: only `linear-gradient` exists (a radial or conic one is a
+   * `<canvas onDraw>`), and a colour stop may be a `$token`. It paints over
+   * `backgroundColor`, which is the CSS order, so a translucent gradient
+   * tints the colour underneath it.
+   */
+  backgroundImage?: string;
+  /**
+   * A shadow cast outside the box:
+   * `'0 2px 8px rgba(0, 0, 0, .4)'`, `'0 1px 2px #0003, 0 8px 24px $shadow'`
+   * (any `$token` the theme names), or `'none'`.
+   *
+   * `<x> <y> [blur] [spread] [colour]` per shadow, comma-separated, painted
+   * first-on-top like CSS's. The colour may be left out, which means the
+   * node's own `color`. Outer shadows only — `inset` throws — and ignored on
+   * `<window>`/`<popup>`, which own no pixels outside themselves.
+   */
+  boxShadow?: string;
   borderColor?: Color;
   /** Per-side colours fall back to `borderColor`. Paint properties, legal in
    *  state blocks like it. */

--- a/test/decorations.test.js
+++ b/test/decorations.test.js
@@ -1,0 +1,256 @@
+// The grammar and the geometry behind `backgroundImage` and `boxShadow`
+// (issue #345). Pure: no server, no node tree.
+//
+// Two of these assertions are here because a pixel test cannot make them.
+// The gradient's *padding* — the stops pinned at 0 and 1 that stand in for
+// `RepeatPad` — is invisible against node-x11's in-process server, whose
+// RENDER clamps to the edge stops by construction where a real one leaves
+// everything past the last stop transparent (sidorares/ntk#271). And the
+// blur kernel's mapping from a CSS blur radius to a gaussian is a number
+// that has to match a browser's, which no readback of ours can check.
+import assert from 'node:assert';
+import { test } from 'node:test';
+
+import {
+  blurKernel,
+  linearGradientGeometry,
+  parseBoxShadow,
+  parseLinearGradient,
+  shadowExtent,
+} from '../src/decorations.js';
+
+const BOX = { x: 0, y: 0, width: 100, height: 50 };
+const line = (value, rect = BOX, pad) =>
+  linearGradientGeometry(parseLinearGradient(value), rect, pad);
+const near = (actual, expected, tolerance = 0.001) =>
+  assert.ok(
+    Math.abs(actual - expected) <= tolerance,
+    `expected ${expected}, got ${actual}`,
+  );
+
+// --- direction -------------------------------------------------------------
+
+test('no direction means to bottom, CSS’s default', () => {
+  const spec = parseLinearGradient('linear-gradient(#000, #fff)');
+  assert.equal(spec.angle, 180);
+  const g = line('linear-gradient(#000, #fff)', BOX, 0);
+  assert.deepEqual(
+    [g.x0, g.y0, g.x1, g.y1].map(Math.round),
+    [50, 0, 50, 50],
+    'runs down the middle of the box, top to bottom',
+  );
+});
+
+test('an angle is degrees clockwise from up', () => {
+  const g = line('linear-gradient(90deg, #000, #fff)', BOX, 0);
+  assert.deepEqual([g.x0, g.y0, g.x1, g.y1].map(Math.round), [0, 25, 100, 25]);
+  const up = line('linear-gradient(0deg, #000, #fff)', BOX, 0);
+  assert.deepEqual(
+    [up.x0, up.y0, up.x1, up.y1].map(Math.round),
+    [50, 50, 50, 0],
+  );
+});
+
+test('turn, rad and grad are the same angle in other units', () => {
+  assert.equal(
+    parseLinearGradient('linear-gradient(0.25turn, #a, #b)').angle,
+    90,
+  );
+  near(
+    parseLinearGradient('linear-gradient(1.5708rad, #a, #b)').angle,
+    90,
+    0.01,
+  );
+  assert.equal(
+    parseLinearGradient('linear-gradient(100grad, #a, #b)').angle,
+    90,
+  );
+});
+
+test('to top / right / bottom / left', () => {
+  const angle = (side) =>
+    parseLinearGradient(`linear-gradient(to ${side}, #a, #b)`).angle;
+  assert.deepEqual(
+    ['top', 'right', 'bottom', 'left'].map(angle),
+    [0, 90, 180, 270],
+  );
+});
+
+test('a corner keyword is resolved against the box, not fixed at 45°', () => {
+  const spec = parseLinearGradient('linear-gradient(to top right, #a, #b)');
+  assert.equal(spec.corner, 'top right');
+  assert.equal(spec.angle, null, 'the angle needs the box to exist');
+  // a square gives 45°; a wide box leans towards `to right`, which is what
+  // makes the end colours land on the corners rather than near them
+  const square = line('linear-gradient(to top right, #a, #b)', {
+    x: 0,
+    y: 0,
+    width: 100,
+    height: 100,
+  });
+  near(Math.atan2(square.x1 - square.x0, square.y0 - square.y1), Math.PI / 4);
+  const wide = line('linear-gradient(to top right, #a, #b)', {
+    x: 0,
+    y: 0,
+    width: 400,
+    height: 20,
+  });
+  assert.ok(
+    Math.atan2(wide.x1 - wide.x0, wide.y0 - wide.y1) > Math.PI / 4,
+    'a wide box turns the line towards the horizontal',
+  );
+});
+
+test('the gradient line is the box’s projection onto it', () => {
+  // 90° over a 100x50 box: the line is the width. A diagonal is longer than
+  // either side, which is the whole reason CSS defines it this way.
+  const across = line('linear-gradient(90deg, #a, #b)', BOX, 0);
+  near(Math.hypot(across.x1 - across.x0, across.y1 - across.y0), 100);
+  const diagonal = line('linear-gradient(45deg, #a, #b)', BOX, 0);
+  near(
+    Math.hypot(diagonal.x1 - diagonal.x0, diagonal.y1 - diagonal.y0),
+    (100 + 50) / Math.SQRT2,
+  );
+});
+
+// --- stops -----------------------------------------------------------------
+
+test('stops with no position are spread evenly between the ones that have one', () => {
+  const g = line('linear-gradient(#a, #b, #c, #d)', BOX, 0);
+  assert.deepEqual(
+    g.stops.map(([offset]) => Number(offset.toFixed(4))),
+    [0, 0.3333, 0.6667, 1],
+  );
+});
+
+test('percentages and pixels both place a stop on the line', () => {
+  const g = line('linear-gradient(180deg, #a, #b 25%, #c)', BOX, 0);
+  assert.equal(g.stops[1][0], 0.25);
+  // the line is the box height here, so 10px is a fifth of it
+  const px = line('linear-gradient(180deg, #a, #b 10px, #c)', BOX, 0);
+  near(px.stops[1][0], 0.2);
+});
+
+test('a stop that goes backwards is pulled up to the one before it', () => {
+  // which is what keeps a hard colour break — two stops at one offset —
+  // expressible, and what stops a typo inverting the ramp
+  const g = line('linear-gradient(#a 60%, #b 20%, #c)', BOX, 0);
+  assert.deepEqual(
+    g.stops.map(([offset]) => offset),
+    [0.6, 0.6, 1],
+  );
+});
+
+test('a colour with spaces in it is one stop, not several', () => {
+  const spec = parseLinearGradient(
+    'linear-gradient(rgba(0, 0, 0, .4), rgb(255 255 255 / 50%) 80%)',
+  );
+  assert.deepEqual(
+    spec.stops.map((s) => s.color),
+    ['rgba(0, 0, 0, .4)', 'rgb(255 255 255 / 50%)'],
+  );
+  assert.deepEqual(spec.stops[1].position, { value: 80, unit: '%' });
+});
+
+// --- the pad that stands in for RepeatPad ---------------------------------
+
+test('the line is extended past the box and the end colours pinned to it', () => {
+  const g = line('linear-gradient(180deg, #a, #b)', BOX, 4);
+  // 4px beyond each end of a 50px line
+  near(g.y0, -4);
+  near(g.y1, 54);
+  assert.equal(g.stops.length, 4, 'two authored stops plus the two clamps');
+  assert.deepEqual(g.stops[0], [0, '#a']);
+  assert.deepEqual(g.stops[g.stops.length - 1], [1, '#b']);
+  // and the authored stops sit where the box is, not where the line now ends
+  near(g.stops[1][0], 4 / 58);
+  near(g.stops[2][0], 54 / 58);
+});
+
+test('a box with no area has no gradient line', () => {
+  assert.equal(
+    line('linear-gradient(#a, #b)', { x: 0, y: 0, width: 0, height: 10 }),
+    null,
+  );
+});
+
+// --- what the grammar refuses ---------------------------------------------
+
+test('an unusable backgroundImage names itself and the fix', () => {
+  const bad = (value, expected) =>
+    assert.throws(() => parseLinearGradient(value), expected, value);
+  bad('radial-gradient(#a, #b)', /not supported.*linear-gradient/s);
+  bad('url(bg.png)', /<image src>/);
+  bad('linear-gradient(#a)', /at least two colour stops/);
+  bad('linear-gradient(to nowhere, #a, #b)', /unusable direction/);
+  bad('linear-gradient(#a, 40%, #b)', /colour hint/);
+  bad('linear-gradient(#a, #b', /closing parenthesis/);
+});
+
+test('none and a missing value are simply no gradient', () => {
+  assert.equal(parseLinearGradient('none'), null);
+  assert.equal(parseLinearGradient(undefined), null);
+});
+
+// --- shadows ---------------------------------------------------------------
+
+test('offsets, blur, spread and colour, in CSS order', () => {
+  assert.deepEqual(parseBoxShadow('0 2px 8px rgba(0, 0, 0, .4)'), [
+    { dx: 0, dy: 2, blur: 8, spread: 0, color: 'rgba(0, 0, 0, .4)' },
+  ]);
+  assert.deepEqual(parseBoxShadow('1px -2px 6px 3px #123'), [
+    { dx: 1, dy: -2, blur: 6, spread: 3, color: '#123' },
+  ]);
+});
+
+test('a colour may be left out, which is CSS’s currentColor', () => {
+  assert.equal(parseBoxShadow('0 1px 2px')[0].color, null);
+});
+
+test('a list is a list, commas inside a colour and all', () => {
+  const list = parseBoxShadow('0 1px 2px rgba(0, 0, 0, .2), 0 8px 24px #0006');
+  assert.equal(list.length, 2);
+  assert.equal(list[0].dy, 1);
+  assert.equal(list[1].blur, 24);
+});
+
+test('an unusable boxShadow names itself and the fix', () => {
+  assert.throws(() => parseBoxShadow('4px'), /needs an x and a y offset/);
+  assert.throws(
+    () => parseBoxShadow('0 0 4px #fff #000'),
+    /more than one colour/,
+  );
+  assert.throws(() => parseBoxShadow('0 0 -4px #000'), /negative blur/);
+  // rejected rather than quietly painted as an outer shadow, which is a bug
+  // whose cause is invisible from the style
+  assert.throws(() => parseBoxShadow('inset 0 2px 4px #000'), /inset/);
+});
+
+// --- the blur, and what it costs in damage --------------------------------
+
+test('a CSS blur radius is twice the gaussian’s sigma', () => {
+  assert.equal(blurKernel(8).sigma, 4);
+  const { size, pad } = blurKernel(8);
+  assert.equal(size % 2, 1, 'a convolution kernel has a centre');
+  assert.ok(size >= 2 * 3 * 4, `cut at 3 sigma, got ${size}`);
+  assert.ok(pad >= (size - 1) / 2, 'the surface holds the whole kernel');
+});
+
+test('a huge blur is capped rather than convolving forever', () => {
+  assert.ok(blurKernel(400).size <= 61);
+});
+
+test('the extent a shadow claims covers offset, spread and the blur’s tail', () => {
+  assert.equal(shadowExtent(parseBoxShadow('0 0 0 #000')), 0);
+  assert.equal(shadowExtent(parseBoxShadow('0 0 0 5px #000')), 5);
+  // 4px down + 12px of blur reach
+  assert.equal(
+    shadowExtent(parseBoxShadow('0 4px 8px #000')),
+    4 + blurKernel(8).pad,
+  );
+  // the largest of the list wins
+  assert.equal(
+    shadowExtent(parseBoxShadow('0 1px 1px #000, 0 20px 0 #000')),
+    20,
+  );
+});

--- a/test/gradients-shadows.test.js
+++ b/test/gradients-shadows.test.js
@@ -1,0 +1,469 @@
+// `backgroundImage` and `boxShadow` as pixels (issue #345), against
+// node-x11's in-process X server — which implements RENDER's gradients and
+// its convolution filter for real, so both features are readable back rather
+// than merely "not throwing".
+//
+// The grammar and the geometry are `test/decorations.test.js`; this file is
+// the half that only a server can answer: that the gradient lands in the
+// node's own box, that a blurred shadow is drawn *outside* it and fades, and
+// that the damage a shadow claims covers it — including the frame that takes
+// one away, which is the one way this feature can leave stale pixels behind.
+import assert from 'node:assert';
+import { test } from 'node:test';
+import React from 'react';
+
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient } from 'ntk';
+
+import { createRoot } from '../src/index.js';
+
+const W = 240;
+const H = 180;
+const e = React.createElement;
+
+async function headlessApp() {
+  const server = xserver.createServer({ width: 400, height: 400 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  return createClient({ stream: clientEnd });
+}
+
+const settle = (app) =>
+  new Promise((resolve) => app.X.GetInputFocus(() => resolve()));
+
+async function mount(app, element) {
+  const x11Root = await createRoot({ app });
+  const instance = await new Promise((resolve) =>
+    x11Root.render(element, resolve),
+  );
+  const root = instance._reactX11Node;
+  root._scheduled = false;
+  root.flush();
+  await settle(app);
+  // re-render the same root, painting the frame it asks for
+  root.rerender = async (next) => {
+    await new Promise((resolve) => x11Root.render(next, resolve));
+    root._scheduled = false;
+    root.flush();
+    await settle(app);
+  };
+  return root;
+}
+
+/** The window, as RGBA rows. `getImageData` speaks straight RGBA (ntk >= 5.3). */
+async function shot(root) {
+  const ctx = (root._ctx ??= root.window.getContext('2d'));
+  const data = await new Promise((resolve, reject) =>
+    ctx.getImageData(0, 0, W, H, (err, d) => (err ? reject(err) : resolve(d))),
+  );
+  const bytes = Buffer.from(data.data);
+  return {
+    bytes,
+    at(x, y) {
+      const i = (y * W + x) * 4;
+      return [bytes[i], bytes[i + 1], bytes[i + 2]];
+    },
+    /** 0 = white, 255 = black: how much ink landed here. */
+    ink(x, y) {
+      const [r, g, b] = this.at(x, y);
+      return 255 - Math.round((r + g + b) / 3);
+    },
+  };
+}
+
+const near = (actual, expected, tolerance, what) =>
+  assert.ok(
+    Math.abs(actual - expected) <= tolerance,
+    `${what}: expected ~${expected}, got ${actual}`,
+  );
+
+/** One absolutely-positioned box, so every assertion has known geometry. */
+const BOX = { x: 60, y: 40, width: 100, height: 80 };
+function boxed(style, extra) {
+  return e(
+    'window',
+    { width: W, height: H, style: { backgroundColor: '#ffffff' }, ...extra },
+    e('box', {
+      style: {
+        position: 'absolute',
+        left: BOX.x,
+        top: BOX.y,
+        width: BOX.width,
+        height: BOX.height,
+        ...style,
+      },
+    }),
+  );
+}
+
+// --- gradients -------------------------------------------------------------
+
+test('a linear-gradient fills the node’s own box, end to end', async () => {
+  const app = await headlessApp();
+  try {
+    const root = await mount(
+      app,
+      boxed({ backgroundImage: 'linear-gradient(#ff0000, #0000ff)' }),
+    );
+    const img = await shot(root);
+    const mid = BOX.x + BOX.width / 2;
+    // the ends are the authored colours, not a blend that ran out early —
+    // which is what a gradient laid out in the wrong coordinates looks like
+    near(img.at(mid, BOX.y + 1)[0], 255, 12, 'red at the top');
+    near(img.at(mid, BOX.y + 1)[2], 0, 12, 'no blue at the top');
+    near(img.at(mid, BOX.y + BOX.height - 2)[2], 255, 12, 'blue at the bottom');
+    near(img.at(mid, BOX.y + BOX.height - 2)[0], 0, 12, 'no red at the bottom');
+    // and the middle is the middle
+    const [r, , b] = img.at(mid, BOX.y + BOX.height / 2);
+    near(r, 128, 24, 'half red in the middle');
+    near(b, 128, 24, 'half blue in the middle');
+    // nothing outside the box was painted
+    assert.deepEqual(img.at(BOX.x - 3, BOX.y + 4), [255, 255, 255]);
+  } finally {
+    await app.close();
+  }
+});
+
+test('an angle turns it: 90deg runs left to right', async () => {
+  const app = await headlessApp();
+  try {
+    const root = await mount(
+      app,
+      boxed({ backgroundImage: 'linear-gradient(90deg, #ff0000, #0000ff)' }),
+    );
+    const img = await shot(root);
+    const mid = BOX.y + BOX.height / 2;
+    near(img.at(BOX.x + 1, mid)[0], 255, 12, 'red on the left');
+    near(img.at(BOX.x + BOX.width - 2, mid)[2], 255, 12, 'blue on the right');
+  } finally {
+    await app.close();
+  }
+});
+
+test('a gradient follows the box when the box moves', async () => {
+  // The coordinates are absolute, so this is what pins the cache key that
+  // carries them: the same hoisted style, a different rect, and the ends
+  // still have to land on the ends rather than where they were last frame.
+  const app = await headlessApp();
+  try {
+    const style = {
+      backgroundImage: 'linear-gradient(90deg, #ff0000, #0000ff)',
+    };
+    const at = (left) =>
+      e(
+        'window',
+        { width: W, height: H, style: { backgroundColor: '#ffffff' } },
+        e('box', {
+          style: {
+            position: 'absolute',
+            left,
+            top: BOX.y,
+            width: BOX.width,
+            height: BOX.height,
+            ...style,
+          },
+        }),
+      );
+    const root = await mount(app, at(20));
+    await root.rerender(at(120));
+    const img = await shot(root);
+    const mid = BOX.y + BOX.height / 2;
+    near(img.at(121, mid)[0], 255, 12, 'red at the new left edge');
+    near(img.at(120 + BOX.width - 2, mid)[2], 255, 12, 'blue at the new right');
+    assert.deepEqual(img.at(21, mid), [255, 255, 255], 'and gone from the old');
+  } finally {
+    await app.close();
+  }
+});
+
+test('$token colour stops resolve against the theme', async () => {
+  const app = await headlessApp();
+  try {
+    const root = await mount(
+      app,
+      boxed(
+        { backgroundImage: 'linear-gradient($from, $to)' },
+        { theme: { from: '#ff0000', to: '#0000ff' } },
+      ),
+    );
+    const img = await shot(root);
+    const mid = BOX.x + BOX.width / 2;
+    near(img.at(mid, BOX.y + 1)[0], 255, 12, 'the first token’s colour');
+    near(img.at(mid, BOX.y + BOX.height - 2)[2], 255, 12, 'the second’s');
+  } finally {
+    await app.close();
+  }
+});
+
+test('a translucent gradient composites over the backgroundColor', async () => {
+  const app = await headlessApp();
+  try {
+    const root = await mount(
+      app,
+      boxed({
+        backgroundColor: '#00ff00',
+        // fully transparent at the top, opaque black at the bottom: the top
+        // must still be the green underneath it
+        backgroundImage: 'linear-gradient(rgba(0, 0, 0, 0), rgba(0, 0, 0, 1))',
+      }),
+    );
+    const img = await shot(root);
+    const mid = BOX.x + BOX.width / 2;
+    near(img.at(mid, BOX.y + 1)[1], 255, 12, 'the colour shows through');
+    assert.ok(
+      img.ink(mid, BOX.y + BOX.height - 2) > 200,
+      'and the opaque end covers it',
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+// --- shadows ---------------------------------------------------------------
+
+test('a blurred shadow is drawn outside the box and fades away', async () => {
+  const app = await headlessApp();
+  try {
+    const root = await mount(
+      app,
+      boxed({ backgroundColor: '#ffffff', boxShadow: '0 0 10px #000000' }),
+    );
+    const mid = BOX.y + BOX.height / 2;
+    const check = (img, when) => {
+      const close = img.ink(BOX.x - 2, mid);
+      const middling = img.ink(BOX.x - 7, mid);
+      const far = img.ink(BOX.x - 14, mid);
+      assert.ok(
+        close > 40,
+        `${when}: expected ink beside the box, got ${close}`,
+      );
+      assert.ok(
+        close > middling && middling > far,
+        `${when}: expected a falloff, got ${close} > ${middling} > ${far}`,
+      );
+      assert.equal(img.ink(BOX.x - 30, mid), 0, `${when}: nothing further out`);
+      // the box's own background is over the top of it
+      assert.deepEqual(
+        img.at(BOX.x + 4, mid),
+        [255, 255, 255],
+        `${when}: the shadow is under the node, not over it`,
+      );
+    };
+    check(await shot(root), 'painted live');
+
+    // …and again once the paint cache is serving it. The blur lives on the
+    // *picture*, not in the pixels, so a cached entry that lost its filter
+    // would come back as a hard-edged rectangle — which is the one thing
+    // about caching this drawing that is not like caching any other.
+    for (let i = 0; i < 3; i++) {
+      root.needsPaint = true;
+      root._damage = null;
+      root.flush();
+      await settle(app);
+    }
+    assert.ok(root._paintCache?.stats.hits > 0, 'the cache took it');
+    check(await shot(root), 'from the cache');
+  } finally {
+    await app.close();
+  }
+});
+
+test('an offset shadow lands on the side it was offset to', async () => {
+  const app = await headlessApp();
+  try {
+    const root = await mount(
+      app,
+      // no blur: a hard rectangle, so the offset is exactly measurable
+      boxed({ backgroundColor: '#ffffff', boxShadow: '8px 8px 0 #000000' }),
+    );
+    const img = await shot(root);
+    assert.equal(
+      img.ink(BOX.x + BOX.width + 4, BOX.y + BOX.height + 4),
+      255,
+      'solid ink down and to the right',
+    );
+    assert.equal(
+      img.ink(BOX.x - 4, BOX.y - 4),
+      0,
+      'and nothing up and to the left',
+    );
+    assert.equal(
+      img.ink(BOX.x + BOX.width + 9, BOX.y + BOX.height / 2),
+      0,
+      'the rectangle ends where the offset says',
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test('spread grows the shadow, blur or no blur', async () => {
+  const app = await headlessApp();
+  try {
+    const root = await mount(
+      app,
+      boxed({ backgroundColor: '#ffffff', boxShadow: '0 0 0 6px #000000' }),
+    );
+    const img = await shot(root);
+    const mid = BOX.y + BOX.height / 2;
+    assert.equal(img.ink(BOX.x - 5, mid), 255, 'inside the spread');
+    assert.equal(img.ink(BOX.x - 7, mid), 0, 'and outside it');
+  } finally {
+    await app.close();
+  }
+});
+
+test('a shadow with no colour is drawn in the node’s own ink', async () => {
+  // CSS's `currentColor`, resolved through the cascade — so a shadow named
+  // once in a palette follows the text it sits under
+  const app = await headlessApp();
+  try {
+    const root = await mount(
+      app,
+      boxed({
+        backgroundColor: '#ffffff',
+        color: '#ff0000',
+        boxShadow: '0 0 0 4px',
+      }),
+    );
+    const img = await shot(root);
+    assert.deepEqual(
+      img.at(BOX.x - 2, BOX.y + BOX.height / 2),
+      [255, 0, 0],
+      'the ring is the ink',
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test('a <window> takes a gradient too, damage-bounded like its colour', async () => {
+  const app = await headlessApp();
+  try {
+    const root = await mount(
+      app,
+      e('window', {
+        width: W,
+        height: H,
+        style: { backgroundImage: 'linear-gradient(#ff0000, #0000ff)' },
+      }),
+    );
+    const img = await shot(root);
+    near(img.at(W / 2, 1)[0], 255, 12, 'red at the top of the window');
+    near(img.at(W / 2, H - 2)[2], 255, 12, 'blue at the bottom');
+  } finally {
+    await app.close();
+  }
+});
+
+test('a shadow claims the pixels it paints, and the ones it stops painting', async () => {
+  const app = await headlessApp();
+  try {
+    const ref = React.createRef();
+    const root = await mount(
+      app,
+      e(
+        'window',
+        { width: W, height: H, style: { backgroundColor: '#ffffff' } },
+        e('box', {
+          ref,
+          style: {
+            position: 'absolute',
+            left: BOX.x,
+            top: BOX.y,
+            width: BOX.width,
+            height: BOX.height,
+            backgroundColor: '#ffffff',
+            ':hover': { boxShadow: '0 0 12px #000000' },
+          },
+        }),
+      ),
+    );
+    const node = ref.current;
+
+    // the bound grows with the decoration, or the frame that draws it cuts
+    // the shadow off at the node's own rect
+    assert.equal(
+      node.paintBounds().width,
+      BOX.width + 2,
+      'no shadow, no slack',
+    );
+    node.setStyleState(':hover', true);
+    assert.ok(
+      node.paintBounds().width > BOX.width + 20,
+      `expected room for the blur, got ${node.paintBounds().width}`,
+    );
+    root.flush();
+    await settle(app);
+    const hovered = await shot(root);
+    assert.ok(hovered.ink(BOX.x - 4, BOX.y + 40) > 20, 'the shadow is there');
+
+    // …and taking it away repaints where it was. The claim is bounded — the
+    // node's new bounds no longer contain the shadow — so this is the case
+    // that leaves a printed ring around the box when nothing claims the old
+    // extent (`_retarget`).
+    node.setStyleState(':hover', false);
+    root.flush();
+    await settle(app);
+    const partial = await shot(root);
+    assert.ok(root._lastDamage, 'the frame stayed bounded');
+
+    root.needsPaint = true;
+    root._damage = null;
+    root.flush();
+    await settle(app);
+    const full = await shot(root);
+    assert.ok(
+      partial.bytes.equals(full.bytes),
+      'a bounded repaint must leave the surface a full one would',
+    );
+    assert.equal(partial.ink(BOX.x - 4, BOX.y + 40), 0, 'the shadow is gone');
+  } finally {
+    await app.close();
+  }
+});
+
+test('identical shadows share one cached surface', async () => {
+  const app = await headlessApp();
+  try {
+    const rows = Array.from({ length: 4 }, (_, i) =>
+      e('box', {
+        key: i,
+        style: {
+          position: 'absolute',
+          left: 20,
+          top: 20 + i * 40,
+          width: 120,
+          height: 24,
+          backgroundColor: '#ffffff',
+          boxShadow: '0 2px 6px #000000',
+        },
+      }),
+    );
+    const root = await mount(
+      app,
+      e(
+        'window',
+        { width: W, height: H, style: { backgroundColor: '#ffffff' } },
+        ...rows,
+      ),
+    );
+    // the cache admits a key on its second sighting, so the second frame is
+    // the one that renders and the third is all hits
+    for (let i = 0; i < 3; i++) {
+      root.needsPaint = true;
+      root._damage = null;
+      root.flush();
+      await settle(app);
+    }
+    const cache = root._paintCache;
+    assert.ok(cache, 'the in-process server supports the paint cache');
+    const shadows = [...cache.entries.keys()].filter((k) =>
+      k.startsWith('shadow|'),
+    );
+    assert.equal(shadows.length, 1, `four rows, one surface: ${shadows}`);
+    assert.ok(cache.stats.hits >= 4, `expected reuse, got ${cache.stats.hits}`);
+  } finally {
+    await app.close();
+  }
+});

--- a/test/style.test.js
+++ b/test/style.test.js
@@ -57,6 +57,59 @@ test('createStyles rejects unknown properties and layout in state blocks', async
   );
 });
 
+test('a decoration is checked where it is written, not where it paints', async () => {
+  // `backgroundImage` and `boxShadow` are the two style values with a
+  // grammar of their own, so a typo in one has to fail at the style rather
+  // than as a blank header at the next frame (issue #345).
+  assert.throws(
+    () => createStyles({ a: { backgroundImage: 'linear-gradient(#333)' } }),
+    /at least two colour stops[\s\S]*in styles\.a/,
+  );
+  assert.throws(
+    () => createStyles({ a: { boxShadow: '2px' } }),
+    /needs an x and a y offset[\s\S]*in styles\.a/,
+  );
+  assert.throws(
+    () =>
+      createStyles({ a: { ':hover': { boxShadow: 'inset 0 0 4px #000' } } }),
+    /inset shadow[\s\S]*in styles\.a :hover/,
+    'a state block is validated as the block it is',
+  );
+  // both are paint, so both are legal in a state block
+  createStyles({
+    a: {
+      backgroundImage: 'linear-gradient(to top right, $accent, #000 80%)',
+      ':hover': { boxShadow: '0 2px 8px rgba(0, 0, 0, .4)' },
+    },
+  });
+});
+
+test('a $token resolves inside a decoration, not only as the whole value', async () => {
+  const theme = { accent: '#2980b9', shadow: 'rgba(0, 0, 0, .4)' };
+  assert.deepEqual(
+    resolveTokens(
+      {
+        backgroundImage: 'linear-gradient($accent, #000)',
+        boxShadow: '0 2px 8px $shadow',
+      },
+      theme,
+    ),
+    {
+      backgroundImage: 'linear-gradient(#2980b9, #000)',
+      boxShadow: '0 2px 8px rgba(0, 0, 0, .4)',
+    },
+  );
+  assert.throws(
+    () =>
+      resolveTokens(
+        { backgroundImage: 'linear-gradient($nope, #000)' },
+        theme,
+        '<box style>',
+      ),
+    /unknown theme token "\$nope" in <box style> backgroundImage/,
+  );
+});
+
 test('style drives layout and paint; props stay semantic', async () => {
   const app = createMockApp();
   const x11Root = await createRoot({ app });

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -144,6 +144,17 @@ const s = createStyles({
     transition: { outlineWidth: 80 },
     ':focus-visible': { outlineWidth: 3, outlineColor: '$accent' },
   },
+  // issue #345: the two decorations that are not a colour. Paint properties,
+  // so a state block may set either — which is what a card that lifts on
+  // hover is written as.
+  header: {
+    backgroundImage: 'linear-gradient(135deg, $accent, $accentActive)',
+    boxShadow: '0 2px 8px rgba(0, 0, 0, .4)',
+    ':hover': {
+      boxShadow: '0 4px 16px rgba(0, 0, 0, .4), 0 1px 2px #0003',
+      backgroundImage: 'none',
+    },
+  },
   target: { hitSlop: 4 },
   perSide: { hitSlop: { top: 4, bottom: 4 } },
   // issue #262: per-side borders — a side width overrides the shorthand the

--- a/website/src/demos/styling.js
+++ b/website/src/demos/styling.js
@@ -6,8 +6,9 @@ export default {
     'renderer — a pointer move repaints one node and never renders React. ' +
     'Plus inherited type (color and the font properties travel down the ' +
     'tree, so a :hover on a row reaches its labels), theme tokens ($name, ' +
-    'resolved against the nearest theme above the node) and transitions, ' +
-    'which lerp on the window frame clock.',
+    'resolved against the nearest theme above the node), transitions, ' +
+    'which lerp on the window frame clock, and the two decorations that are ' +
+    'not a colour: a linear-gradient background and a blurred box shadow.',
   code: `import React, { useState } from 'react';
 import { createRoot, createStyles } from 'react-x11';
 
@@ -62,6 +63,16 @@ const s = createStyles({
     transition: 140,
     ':hover': { color: '$accent', backgroundColor: '$panel' },
   },
+  // the two decorations that are not a colour. Paint properties like any
+  // other, so the shadow can be lifted from a ':hover' block — it snaps
+  // rather than lerping, being several numbers and a colour in one string
+  banner: {
+    padding: 12,
+    borderRadius: 8,
+    backgroundImage: 'linear-gradient(120deg, $accent, $text)',
+    boxShadow: '0 2px 8px rgba(0, 0, 0, .35)',
+    ':hover': { boxShadow: '0 10px 22px rgba(0, 0, 0, .45)' },
+  },
 });
 
 function App() {
@@ -69,7 +80,7 @@ function App() {
   const theme = isDark ? dark : light;
 
   return (
-    <window x={50} y={40} width={520} height={340} title="styling"
+    <window x={50} y={40} width={520} height={400} title="styling"
             theme={theme} style={s.root}>
 
       <box style={{ flexDirection: 'row', alignItems: 'center', gap: 10 }}>
@@ -109,6 +120,12 @@ function App() {
         <box style={[s.swatch, { backgroundColor: '$muted' }]} />
         <text style={s.body}>
           transition: 200 — colours lerp per channel when the theme flips
+        </text>
+      </box>
+
+      <box style={s.banner}>
+        <text style={{ color: '$accentText', fontSize: 13 }}>
+          backgroundImage and boxShadow — hover to lift this one
         </text>
       </box>
     </window>


### PR DESCRIPTION
Closes #345.

`src/styles.js` had no gradient and no shadow, so a header, a card, a dialog or a selected row that wanted either had to stop being a styled `<box>` and become a `<canvas onDraw>` — giving up the layout, the theme tokens, the state blocks, the text stack and the paint cache to get a two-colour fill. Both are now paint properties like `backgroundColor`.

```jsx
<box
  style={{
    padding: 16,
    borderRadius: 10,
    backgroundImage: 'linear-gradient(135deg, $accent, $accentActive)',
    boxShadow: '0 2px 8px rgba(0, 0, 0, .4)',
    ':hover': { boxShadow: '0 10px 24px rgba(0, 0, 0, .45)' },
  }}
>
  <text style={{ color: '$accentText' }}>Header</text>
</box>
```

![decorations](https://github.com/user-attachments/assets/6b2c2be1-3221-4f03-b674-2525082a250d)

Everything above is one `<window>` rendered by this branch into node-x11's in-process X server: a gradient header with a shadow under it, three shadows (blurred, bigger, and a spread ring with no blur), and three gradients — two stops, `to bottom right` with a stop at 70%, and a translucent gradient over a `backgroundColor`.

## The pure half

`src/decorations.js` is CSS's grammar and CSS's geometry, strings in and numbers out: the gradient line is the box's projection onto the angle, corner keywords resolve against the aspect ratio (a square gives 45°, a wide box leans towards `to right`), stops distribute evenly and clamp forwards. Two things there are not obvious and are commented at length:

- **The line carries padding at both ends, with the end colours pinned to it.** Past its last stop an XRender gradient is *transparent* rather than clamped — `RepeatPad` is a picture attribute the gradient path does not set (sidorares/ntk#271, and the `TODO` in ntk's own `CanvasGradient`). Extending the line and remapping the offsets *is* pad semantics, expressed in stops. This is also the one part a pixel test cannot check: node-x11's in-process RENDER clamps to the edge stops by construction where a real server does not, so `test/decorations.test.js` asserts the stops instead.
- **A CSS blur radius is twice the gaussian's sigma**, while ntk's `Picture.setBlurFilter(size, sigma)` takes the convolution kernel's *edge length*. The two numbers that look interchangeable are the two that must not be passed to each other; the kernel is cut at 3σ and capped, and the surface is padded by the same distance or the blur clips square against its own edge.

## The renderer half

A shadow with no blur is a rounded rectangle and one composite. A blurred one is **coverage**: an a8 surface holding the rectangle, blurred server-side by RENDER's convolution and painted *through* the shadow colour — the same trick the glyph cache and `<canvas mono>` run on, which keeps the colour out of the cache key, so four identical cards share one rendered surface and a `:hover` that only darkens the shadow reuses it. `PaintCache.drawing()` is the existing node protocol generalized to a drawing, plus an `after(surface)` hook for a filter that belongs to the picture rather than to the pixels. (ntk#272 would replace the surface dance with four context properties; this does not wait for it, and can drop onto it later without changing a style.)

A shadow is the first thing in this vocabulary that inks pixels the node does not own, and that is most of the work:

- `_ownPaintBounds()` grows by the offset, the spread and the blur's tail, so a bounded frame does not cut the shadow off at the node's rect — and so a sibling's shadow overlapping a scroll viewport still fails the scroll-blit containment test, which reads the same bounds;
- `_retarget()` claims the **old** extent when a shadow shrinks. Every claim downstream is computed from the style now in force, so dropping a `:hover` shadow would repaint the box and leave the shadow printed around it. Pinned by a partial-vs-full pixel comparison, which fails with that claim removed.

## Also here

- **A `$token` resolves inside a value that mentions one**, not only as the whole value — `linear-gradient($accent, $accentActive)`, `boxShadow: '0 2px 8px $shadow'`. The point of the palette is that a colour is named once, and a decoration that could not name one would push every gradient in an app out of a hoisted style and back into `useTheme()`. Same memoized pass, so it costs nothing per frame.
- **Both parse in development wherever they are written**, state blocks included, so a typo names itself and the grammar at the call site rather than painting a blank panel three commits later.
- **Refused rather than ignored**, each with a message that says what to do instead: `inset` shadows, CSS colour hints, `radial-gradient`/`url()`, and `boxShadow` on a `<window>`/`<popup>` (warned once — a toplevel owns no pixels outside itself; that half wants the window to carry a translucent margin, which is a feature of its own, as #345 says).
- **Neither transitions.** Both are several numbers and a colour in one string where `interpolate` moves one value, so they snap; documented next to the property rather than left to be discovered.
- `<window>`/`<popup>` do take `backgroundImage`, damage-bounded like their colour — "it works wherever `backgroundColor` does" is a better rule than a carve-out.

## Cost

New bench scenario, baselined with the paint cache live so a change that quietly stopped the shadow surface being shared lands on it rather than sailing past a fallback number. It also prices the one surprise, measured by parts over 24 cards and 5 full repaints:

| | requests | bytes out |
|---|---|---|
| solid colour, radius 6 | 251 | 14.6 KB |
| + shadow | 381 | 19.1 KB |
| gradient, radius 0 | 135 | 4.6 KB |
| gradient, radius 6 | 257 | **471.2 KB** |

So the expensive-looking half — the blur — is one cached surface composited 24 times, and the cheap-looking half is not: a **rounded** gradient falls back to a coverage mask rasterized on the client and uploaded per fill, because ntk's rounded-rect fast path (cached corner glyphs plus `FillRectangles`) only takes a solid colour. A square gradient is a source picture and free on the wire. Documented in `docs/styling.md`; teaching that fast path to composite a non-solid source through the coverage it already builds is worth an ntk issue, and would take the scenario back under 25 KB.

`npm run bench -- --check`: no regressions on any existing scenario.

## Tests

- `test/decorations.test.js` — 21 pure tests: direction, angle units, corner keywords against two aspect ratios, stop distribution and clamping, the pad remap, the blur mapping, the extent, and every refusal message.
- `test/gradients-shadows.test.js` — 12 against the in-process server with pixel readback: the gradient's ends land on the box's ends, an angle turns it, it follows a box that moves, `$token` stops, a translucent gradient over a colour, a blurred shadow's falloff **both live and once the cache is serving it**, offset, spread, `currentColor`, the `<window>` case, the damage claim in both directions, and four rows sharing one surface.
- Mutation-checked: removing the shrink claim, removing the shadow from the paint bounds, and dropping the blur filter on cached entries each fail exactly one test.
- `npm test`, `npm run lint`, `npm run typecheck`, `prettier --check .` and `website && npm test` (15 demos, share round-trip) all green. The six `appearance.test.js` failures on this machine are the known macOS-only baseline and are unrelated.

