### PR TITLE
feat(text): textOverflow and maxLines, so a cut name says it was cut (#350)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -567,7 +567,7 @@ answer hides the state the UI most needs to get right, and a fake that
 resolves instantly leaves nothing to assert about the state in between.
 
 **Say what does not work.** Where an example meets a real gap — no IME, no
-HiDPI scale model, no `text-overflow: ellipsis` — name it and link the issue
+HiDPI scale model, no per-node container query — name it and link the issue
 rather than steering around it. That matches how `docs/` already handles
 compatibility ladders, and a reader who hits the same wall is better served by
 a sentence than by a silence.

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -68,8 +68,8 @@ the mousedown default action (`onLink` prop), and a scrolling `<box>` wrapping
 works via the normal measured-height path. Async content (HTML images)
 reflows through the widgets' `onInvalidate` hook — implemented upstream as
 sidorares/ntk#75, released in **ntk 3.4.0** (the dependency is bumped).
-`<paragraph>` stays out (see below — maxLines/ellipsis would be a
-TextLayout feature first).
+`<paragraph>` stays out: what it would have been for — `maxLines` and an
+ellipsis — is on `<text>` itself now (#350), where it belongs.
 
 Left for later: per-link pointer cursor (cursor is per-node today),
 `<tex>` baseline alignment with surrounding `<text>`.

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -950,14 +950,24 @@ run list so wrapping spans the whole content.
 | `textRendering`                                     | which glyph path to draw with — see below              |
 | `textAlign`                                         | `left`, `right`, `center`, `start`, `end` (bidi-aware) |
 | `lineHeight`                                        | multiplier over the natural font line height           |
+| `textWrap`                                          | `wrap` (default) or `nowrap`                           |
+| `maxLines`                                          | how many lines are kept — unlimited by default         |
+| `textOverflow`                                      | `clip` (default) or `ellipsis`, for what was cut       |
 
 The first four rows and `fontVariationSettings` and `textRendering`
 **inherit** — from a nested span's point of view that has always been true,
 and it is equally true across a `<box>`, so a caption block is written once
 around the labels in it
 ([styling.md](styling.md#inheritance-the-ink-the-face-and-the-size)).
-`textAlign` and `lineHeight` do not: they shape the box the lines flow in,
-which belongs to the `<text>` that owns it.
+The rest do not: they shape the box the lines flow in, which belongs to the
+`<text>` that owns it.
+
+`maxLines` and `textOverflow` are how a label says it did not fit —
+`{ textWrap: 'nowrap', textOverflow: 'ellipsis' }` is one line ending in a
+`…` at the pixel the box ends at, and an ellipsis with no `maxLines` means
+one line. The cut is a fact about the pixels only: the accessible name, the
+caret indices and `textContent()` are all still the whole string. See
+[styling.md](styling.md#keeping-text-on-one-line-and-saying-when-it-did-not-fit).
 
 A face the app supplies itself — one it ships, or one the user picked in a
 dialog — is opened with `loadFont`/`useFont`, which hand back the family

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -483,7 +483,7 @@ that padding twice, plus the border:
 `<textarea>` keeps its full line boxes, box and clip both: it is line spacing
 that a paragraph is made of, and nothing hangs out of a stack of them.
 
-## Keeping text on one line
+## Keeping text on one line, and saying when it did not fit
 
 ```jsx
 <text style={{ textWrap: 'nowrap' }}>{row.modified}</text>
@@ -498,7 +498,69 @@ side on the way. `'nowrap'` measures at unbounded width, so the overflow is
 horizontal, which `overflow: 'hidden'` on the box around it already knows what
 to do with. Default `'wrap'`.
 
-`<Table>` sets it on every cell and header for that reason.
+A date is the case that wants exactly that: it is a fixed width, it always
+fits, and clipping it would be a bug rather than a design. A **name** is not.
+Clipped, a truncated file name and a short one look equally complete, and the
+reader has no way to tell which they are looking at:
+
+```jsx
+<text style={{ textWrap: 'nowrap', textOverflow: 'ellipsis' }}>
+  {file.name}
+</text>
+```
+
+`textOverflow` is CSS's `text-overflow`: `'clip'` (the default) slices
+mid-glyph, `'ellipsis'` ends the line in a `…`. It is the careful version, not
+a substring —
+
+- the `…` is set in the font of the run it cut into, so an elided line ending
+  in a large or bold word gets a matching mark rather than one in the
+  paragraph's base style, and it falls back to `...` where neither that font
+  nor any fallback covers U+2026;
+- the cut is at a grapheme boundary and the tail is **re-shaped**, because
+  kerning and ligatures across the cut change widths;
+- it cuts the **visually** last run rather than the logically last one, so a
+  right-to-left line ends on its left.
+
+`maxLines` is the other half — CSS has no single-property spelling for it
+(`-webkit-line-clamp` is what everyone actually writes), so this is the name
+the platforms that got a clean shot at it chose. A three-line blurb that ends
+in a `…` is `{ maxLines: 3, textOverflow: 'ellipsis' }`; the lines past the
+cap are dropped before the box is measured, so the height is the kept lines'
+and not the whole paragraph's.
+
+**`textOverflow: 'ellipsis'` on its own means one line.** Eliding happens off
+a line count — the mark stands for the lines that were dropped — so an
+ellipsis with no cap would have nothing to say and would silently do nothing.
+One line is what a name, a path or a status line wants; `maxLines` is how to
+ask for two or three.
+
+### What `nowrap` and `ellipsis` do together
+
+They are not in tension, but they change what the `<text>` reports to layout,
+which is worth knowing before a row moves under you.
+
+A clipping `nowrap` label is measured at unbounded width, so it tells its
+container it needs the **whole string** — and CSS's automatic minimum size
+turns that into a floor. It cannot be squeezed, so a long name pushes the
+column next to it out of the row and the overflow is dealt with somewhere
+above.
+
+An eliding one is measured against the width on offer, because at unbounded
+width there is one line, one line is never over the cap, and nothing would
+ever be cut. So its floor is small and it **gives way**: it takes the room
+that is left, shows `Applicati…`, and the column beside it keeps its width.
+That is the behaviour a table wants — a column that cannot show a file name
+should say so rather than making every other column narrower to avoid it.
+
+`<Table>` sets `nowrap` and `ellipsis` on every cell and header for that
+reason.
+
+What is truncated is a fact about the pixels and nothing else. A `<text>` that
+was elided still reports the **whole** string as its accessible name, and the
+caret and selection indices still index into the whole string — a screen
+reader that read `Application Sup…` would be reading the layout instead of the
+content.
 
 ## Inheritance: the ink, the face and the size
 
@@ -557,10 +619,10 @@ and repaints, with no re-measuring and no reflow. A `fontSize` change
 _does_ re-measure, and it can only come from a React commit, a size query or
 a theme.
 
-What does **not** inherit: `textAlign`, `lineHeight`, `textWrap` and
-`textBoxTrim`. CSS inherits the first two; here they are read by the node
-that owns the **box** the text flows in, and a box is not something a
-descendant has. `<Icon>`'s `size` does not inherit either — a glyph is a
+What does **not** inherit: `textAlign`, `lineHeight`, `textWrap`,
+`textOverflow`, `maxLines` and `textBoxTrim`. CSS inherits the first two;
+here they are read by the node that owns the **box** the text flows in, and a
+box is not something a descendant has. `<Icon>`'s `size` does not inherit either — a glyph is a
 drawing rather than a letter, so it takes its default from the palette's
 `fontSize` and stays put when a label around it shrinks.
 

--- a/examples/finder.jsx
+++ b/examples/finder.jsx
@@ -246,7 +246,13 @@ const s = createStyles({
     ':hover': { backgroundColor: '$accentHover' },
   },
   glyph: { width: 16, fontSize: 12, color: '$textMuted' },
-  entry: { flexGrow: 1, fontSize: 12, color: '$text', textWrap: 'nowrap' },
+  entry: {
+    flexGrow: 1,
+    fontSize: 12,
+    color: '$text',
+    textWrap: 'nowrap',
+    textOverflow: 'ellipsis',
+  },
   entryCell: { flexGrow: 1, overflow: 'hidden' },
 
   message: { padding: 16, gap: 6 },

--- a/examples/monitor.jsx
+++ b/examples/monitor.jsx
@@ -376,11 +376,16 @@ const s = createStyles({
   },
   pid: { width: COL.pid, fontSize: 11, color: '$textMuted', textAlign: 'end' },
   // `overflow: 'hidden'` is what keeps a long name inside its column instead
-  // of running under the graph beside it. There is no `text-overflow:
-  // ellipsis` here, so the name is trimmed with one in JS as well — the clip
-  // is the backstop for the case the trim misjudges.
+  // of running under the graph beside it, and `textOverflow` is what makes it
+  // *say* it did: cut at the pixel the column ends at, in the font the name
+  // is set in, rather than at a character count guessed in JS.
   nameCell: { flexGrow: 1, overflow: 'hidden' },
-  name: { fontSize: 12, color: '$text', textWrap: 'nowrap' },
+  name: {
+    fontSize: 12,
+    color: '$text',
+    textWrap: 'nowrap',
+    textOverflow: 'ellipsis',
+  },
   spark: { width: COL.spark },
   num: { width: COL.num, fontSize: 11, color: '$text', textAlign: 'end' },
   onAccent: { color: '$accentText' },
@@ -403,13 +408,6 @@ const s = createStyles({
     borderColor: '$border',
   },
 });
-
-/** No `text-overflow: ellipsis` in react-x11, so the trim is here. Generous
- *  on purpose: the column clips whatever this misjudges, and a name cut two
- *  characters early reads worse than one cut exactly. */
-function clip(name, max = 44) {
-  return name.length > max ? `${name.slice(0, max - 1)}…` : name;
-}
 
 const SORTS = {
   cpu: (a, b) => b.cpu - a.cpu,
@@ -436,7 +434,7 @@ function ProcessRow({ row, selected, onSelect }) {
     >
       <text style={[s.pid, selected && s.onAccent]}>{String(row.pid)}</text>
       <box style={s.nameCell}>
-        <text style={[s.name, selected && s.onAccent]}>{clip(row.name)}</text>
+        <text style={[s.name, selected && s.onAccent]}>{row.name}</text>
       </box>
       <sparkline
         data={row.history ?? []}

--- a/src/components/FileDialog.js
+++ b/src/components/FileDialog.js
@@ -32,9 +32,11 @@ const h = React.createElement;
 
 const ALL_FILES = '__all__';
 
-// A row is one line high, so a name longer than its column is clipped at the
-// column's edge rather than wrapped into a line and a half of name.
-const NOWRAP = Object.freeze({ textWrap: 'nowrap' });
+// A row is one line high, so a name longer than its column ends at the
+// column's edge rather than wrapping into a line and a half of name — and
+// ends in a `…`, the same as the cells `<Table>` renders itself, so a cut
+// name and a short one do not read alike.
+const NOWRAP = Object.freeze({ textWrap: 'nowrap', textOverflow: 'ellipsis' });
 
 // Stat-ing every entry is one syscall each, which is nothing on a local
 // filesystem and very much something on a network mount with ten thousand

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -62,7 +62,7 @@ const s = createStyles({
     cursor: 'pointer',
     transition: { backgroundColor: 80 },
   },
-  headerLabel: { fontSize: 12, textWrap: 'nowrap' },
+  headerLabel: { fontSize: 12, textWrap: 'nowrap', textOverflow: 'ellipsis' },
   grip: {
     flexShrink: 0,
     cursor: 'col-resize',
@@ -90,8 +90,11 @@ const s = createStyles({
     overflow: 'hidden',
   },
   // one line, always: a row is a fixed height, so a cell that wrapped
-  // would be sliced rather than shown — `textWrap` in styling.md
-  cellText: { fontSize: 12, textWrap: 'nowrap' },
+  // would be sliced rather than shown — `textWrap` in styling.md. And it
+  // ends in a `…` when the column is too narrow for it, because a column is
+  // resizable: the reader is the one who decided how much of a name fits,
+  // and a clip gives them no way to tell a cut name from a short one.
+  cellText: { fontSize: 12, textWrap: 'nowrap', textOverflow: 'ellipsis' },
   spacer: { flexShrink: 0 },
   // The mark is pushed to the far end of the header by a spacer, so this is
   // the floor on the gap rather than the gap: it only does anything once a

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -4067,6 +4067,41 @@ export class TextNode extends Node {
   }
 
   /**
+   * `textOverflow: 'ellipsis'` — is this paragraph one that ends in a `…`
+   * when it does not fit, rather than one that is sliced?
+   *
+   * Read in four places, because eliding is not only a drawing decision: it
+   * changes how many lines there are, which width the paragraph is shaped
+   * against, and therefore what the node reports to layout.
+   */
+  _elides() {
+    return this.style.textOverflow === 'ellipsis';
+  }
+
+  /**
+   * How many lines are kept — CSS's `-webkit-line-clamp` under the name the
+   * platforms that got a clean shot at it chose. Unlimited by default.
+   *
+   * **`textOverflow: 'ellipsis'` on its own means one line.** ntk elides off
+   * a line *count* (`truncated = lineTokens.length > maxLines`), so an
+   * ellipsis with no cap can never fire: there is nothing over the cap to
+   * stand for. Leaving it inert would make `textOverflow: 'ellipsis'` a
+   * property that silently does nothing in the case it is most often
+   * written for — a name, a path, a status line — so the cap an author
+   * almost certainly meant is the default, and `maxLines` is how they say
+   * two or three instead.
+   *
+   * A cap below one keeps one: a `<text>` that renders nothing at all is
+   * conditional rendering, not a truncation setting, and it would look like
+   * a missing label rather than like a number.
+   */
+  _maxLines() {
+    const { maxLines } = this.style;
+    if (Number.isFinite(maxLines)) return Math.max(1, Math.floor(maxLines));
+    return this._elides() ? 1 : Infinity;
+  }
+
+  /**
    * `textWrap: 'nowrap'` — CSS's, and the reason a table cell is a table cell
    * rather than a paragraph.
    *
@@ -4077,15 +4112,39 @@ export class TextNode extends Node {
    * and the same is true of any name longer than its column. Measuring at
    * unbounded width makes the overflow horizontal instead, which is what
    * `overflow: 'hidden'` on the cell already knows how to deal with.
+   *
+   * **Unless it elides.** Then the unbounded measurement is exactly what has
+   * to go: at `maxWidth: Infinity` there is one line, one line is never over
+   * the cap, and nothing is ever cut — the single-line ellipsis, which is by
+   * a distance the common case, could not be spelled at all. So an eliding
+   * `nowrap` is shaped against the width on offer, and the two properties
+   * divide up cleanly: `textWrap` says the text does not wrap, `maxLines`
+   * says how much of it is kept, and the width is the box's either way.
+   *
+   * The visible consequence is in what the node reports back to layout. A
+   * clipping `nowrap` `<text>` measures its whole string at any offer, so
+   * its min-content floor is the full width and the box around it is pushed
+   * out to fit (and then clips). An eliding one measures inside the offer,
+   * so its floor is small and it gives way instead — which is the point: a
+   * column that cannot show a file name should show `Applicati…`, not force
+   * every other column narrower to avoid saying so.
    */
   _wrapWidth(maxWidth) {
-    return this.style.textWrap === 'nowrap' ? Infinity : maxWidth;
+    if (this.style.textWrap !== 'nowrap') return maxWidth;
+    return this._elides() ? maxWidth : Infinity;
   }
 
   _layoutFor(maxWidth) {
     const fonts = this.app?.fonts;
     if (!fonts) return null; // mock container in tests: no text metrics
-    const key = String(maxWidth);
+    const maxLines = this._maxLines();
+    const overflow = this.style.textOverflow;
+    // Both truncation options are inputs to the shaping, so both belong in
+    // the key. They can only change with the style, which clears the whole
+    // map on its way past — but a cache keyed on less than it depends on is
+    // one refactor away from answering with the wrong paragraph, and the
+    // wrong paragraph here is glyphs on screen that no error mentions.
+    const key = `${maxWidth}|${maxLines}|${overflow ?? ''}`;
     let layout = this._layouts.get(key);
     if (!layout) {
       const spans = this.collectSpans([]);
@@ -4094,6 +4153,10 @@ export class TextNode extends Node {
         maxWidth: Number.isFinite(maxWidth) ? maxWidth : undefined,
         align: this.style.textAlign,
         lineHeight: this.style.lineHeight,
+        maxLines: Number.isFinite(maxLines) ? maxLines : undefined,
+        // 'clip' is ntk's default, so an unset property and the CSS default
+        // are the same request rather than two paths through the layout.
+        overflow,
         // The paragraph's **base** direction, which is not the same question
         // as which script the characters are in. UAX#9 resolves a run of
         // neutrals — `"(1) 12:30"`, a filename, a lone bracket — against the

--- a/src/styles.js
+++ b/src/styles.js
@@ -240,6 +240,13 @@ export const TEXT_LAYOUT_PROPS = new Set([
   // unbounded width, so the text is one line and whatever contains it decides
   // what to do about the overflow
   'textWrap',
+  // The truncation pair. Both are handed straight to ntk's TextLayout, which
+  // does the careful version — the ellipsis in the cut run's own font, the
+  // cut on a grapheme boundary with the tail re-shaped, and on the visually
+  // last run rather than the logically last one. `textOverflow` changes what
+  // fits on a line, so it is a measurement input like the rest of this set.
+  'textOverflow',
+  'maxLines',
 ]);
 
 /**
@@ -264,10 +271,11 @@ export const TEXT_PAINT_PROPS = new Set(['textRendering']);
  *
  * This is CSS's inherited set narrowed to what a *descendant* can act on: the
  * face, the size, the ink and the glyph rounding. `textAlign`, `lineHeight`,
- * `textWrap` and `textBoxTrim` stay out even though CSS inherits the first
- * two — here they are read by the node that owns the **box** the text flows
- * in, and a box is not something a descendant has. A `<box>` that wants its
- * children aligned says so in the styles it gives them.
+ * `textWrap`, `textOverflow`, `maxLines` and `textBoxTrim` stay out even
+ * though CSS inherits the first two — here they are read by the node that
+ * owns the **box** the text flows in, and a box is not something a descendant
+ * has. A `<box>` that wants its children aligned says so in the styles it
+ * gives them.
  */
 export const INHERITED_TEXT_PROPS = new Set([
   'fontFamily',

--- a/src/types/style.d.ts
+++ b/src/types/style.d.ts
@@ -229,6 +229,10 @@ export interface PaintStyle {
 export type TextBoxTrim = 'none' | 'cap-alphabetic';
 export type TextWrap = 'wrap' | 'nowrap';
 
+/** CSS's `text-overflow`: what the end of a `<text>` that did not fit looks
+ *  like. `'clip'` slices it mid-glyph, `'ellipsis'` ends it in a `…`. */
+export type TextOverflow = 'clip' | 'ellipsis';
+
 export type TextRendering =
   'auto' | 'optimizeSpeed' | 'optimizeLegibility' | 'geometricPrecision';
 
@@ -256,8 +260,30 @@ export interface TextStyle {
   /** CSS's `text-wrap`. `'nowrap'` measures the text at unbounded width, so
    *  it stays on one line and overflows its box horizontally rather than
    *  wrapping to fit — what a fixed-height row wants, since a wrapped line in
-   *  one is sliced rather than shown. Default `'wrap'`. */
+   *  one is sliced rather than shown. Default `'wrap'`.
+   *
+   *  With `textOverflow: 'ellipsis'` it measures against the box instead:
+   *  there is nothing to elide off an unbounded line. See `textOverflow`. */
   textWrap?: TextWrap;
+  /**
+   * CSS's `text-overflow`, on text that was cut short by `maxLines`. Default
+   * `'clip'`, which slices mid-glyph; `'ellipsis'` ends the last kept line in
+   * a `…` — set in that line's own font, cut on a grapheme boundary with the
+   * tail re-shaped, and on the visually last run, so an RTL line ends on the
+   * left. What a truncated `<text>` reports to a screen reader, and what its
+   * caret indices index into, is the whole string either way.
+   *
+   * **On its own it means one line**, since there is nothing to elide without
+   * a cap: `maxLines` is how to say two or three instead.
+   */
+  textOverflow?: TextOverflow;
+  /**
+   * How many lines are kept — CSS's `-webkit-line-clamp`, under the name the
+   * platforms that got a clean shot at it chose. Unlimited by default, and
+   * `1` when `textOverflow: 'ellipsis'` is set without it. Lines past the cap
+   * are dropped before the box is measured, so the height is the kept lines'.
+   */
+  maxLines?: number;
   /** Default `'none'`. Applies to `<text>`; the editable controls keep their
    *  full line box, which their caret and selection geometry are measured
    *  against. */

--- a/test/text-truncation.test.js
+++ b/test/text-truncation.test.js
@@ -1,0 +1,288 @@
+// Truncation (#350): `textOverflow: 'ellipsis'` and `maxLines`.
+//
+// The whole feature is ntk's — `TextLayout` caps lines, elides at a grapheme
+// boundary, re-shapes the tail and picks the ellipsis character against the
+// cut run's own coverage. What is here is the wiring, and the wiring has two
+// decisions in it that no upstream test can pin:
+//
+//  1. **An ellipsis with no cap can never fire.** ntk elides off a line
+//     count, so `textOverflow: 'ellipsis'` alone has to mean one line or it
+//     is a property that silently does nothing.
+//  2. **`textWrap: 'nowrap'` measures at unbounded width** so that its
+//     overflow is horizontal — which leaves exactly one line, which is never
+//     over the cap. So an eliding `nowrap` has to stop taking that path, and
+//     the visible half of that is what the node reports back to *layout*: a
+//     clipping `nowrap` label pushes its row wider, an eliding one gives way.
+//     Pinned here in both directions, because the day it silently reverts is
+//     the day every table column starts fighting for width again.
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import React from 'react';
+
+import { renderX11, cleanup, screen } from '../src/testing/index.js';
+import { a11yName } from '../src/a11y.js';
+
+const require = createRequire(import.meta.url);
+const FONT_DIR = path.join(
+  path.dirname(require.resolve('katex/package.json')),
+  'dist',
+  'fonts',
+);
+// KaTeX Main covers U+2026, so the `…` branch of ntk's `_elide` is the one
+// taken here; `mono` is a second real face, for the question of *whose* font
+// the ellipsis is set in.
+const FONTS = {
+  'sans-serif': path.join(FONT_DIR, 'KaTeX_Main-Regular.ttf'),
+  mono: path.join(FONT_DIR, 'KaTeX_Typewriter-Regular.ttf'),
+};
+
+const h = React.createElement;
+
+// Wider than the 160px box below at 14px, and made of several words, so
+// there is both a line break opportunity to wrap at and a word to cut into.
+const LONG = 'Application Support and other long names';
+
+afterEach(cleanup);
+
+/** The paragraph as it is on screen, inside a 160px box that clips. */
+async function laidOut(style, { boxStyle = {}, children = [LONG] } = {}) {
+  await renderX11(
+    h(
+      'box',
+      { style: { width: 160, overflow: 'hidden', ...boxStyle } },
+      h('text', { 'data-testname': 'subject', style }, ...children),
+    ),
+    { width: 300, height: 120, fonts: FONTS },
+  );
+  const node = screen.getByTestName('subject');
+  return { node, layout: node._placedLayout().layout };
+}
+
+const runsOf = (layout, line = 0) => layout.lines[line].runs;
+const ellipsisRun = (layout, line = 0) =>
+  runsOf(layout, line).find((run) => run.ellipsis) ?? null;
+
+// --- the cap ---------------------------------------------------------------
+
+test('textOverflow: ellipsis elides, and means one line on its own', async () => {
+  const { layout } = await laidOut({ textOverflow: 'ellipsis' });
+  assert.equal(layout.truncated, true);
+  assert.equal(layout.lines.length, 1);
+  const mark = ellipsisRun(layout);
+  assert.ok(mark, 'the last line ends in an ellipsis run');
+  // it is the visually last thing on the line, and the line still fits
+  const last = runsOf(layout).at(-1);
+  assert.equal(last.ellipsis, true);
+  assert.ok(layout.width <= 160, `elided to ${layout.width}, box is 160`);
+});
+
+test('the same text without it wraps instead, and nothing is cut', async () => {
+  const { layout } = await laidOut({});
+  assert.equal(layout.truncated, false);
+  assert.equal(layout.lines.length, 2);
+  assert.equal(ellipsisRun(layout, 1), null);
+});
+
+test('maxLines caps a wrapping paragraph, and clips by default', async () => {
+  const { layout } = await laidOut(
+    { maxLines: 2 },
+    // narrow enough that the text needs four lines, so two are dropped
+    { boxStyle: { width: 80 } },
+  );
+  assert.equal(layout.lines.length, 2);
+  assert.equal(layout.truncated, true);
+  assert.equal(ellipsisRun(layout, 1), null, 'clip is the default');
+});
+
+test('maxLines with ellipsis puts the mark on the last kept line', async () => {
+  const { layout } = await laidOut(
+    { maxLines: 2, textOverflow: 'ellipsis' },
+    { boxStyle: { width: 80 } },
+  );
+  assert.equal(layout.lines.length, 2);
+  assert.equal(ellipsisRun(layout, 0), null);
+  assert.ok(ellipsisRun(layout, 1), 'the second line is the one that ends');
+});
+
+test('maxLines wins over the one line an ellipsis would imply', async () => {
+  const { layout } = await laidOut(
+    { maxLines: 3, textOverflow: 'ellipsis' },
+    {
+      boxStyle: { width: 80 },
+    },
+  );
+  assert.equal(layout.lines.length, 3);
+});
+
+test('a cap below one still keeps a line, rather than rendering nothing', async () => {
+  const { layout } = await laidOut({ maxLines: 0, textOverflow: 'ellipsis' });
+  assert.equal(layout.lines.length, 1);
+});
+
+// --- nowrap ---------------------------------------------------------------
+
+test('nowrap + ellipsis is shaped against the box, not at unbounded width', async () => {
+  const { layout } = await laidOut({
+    textWrap: 'nowrap',
+    textOverflow: 'ellipsis',
+  });
+  assert.equal(layout.truncated, true);
+  assert.equal(layout.lines.length, 1);
+  assert.ok(ellipsisRun(layout));
+  assert.ok(layout.width <= 160, `elided to ${layout.width}, box is 160`);
+});
+
+test('nowrap on its own still measures unbounded — the clip path is intact', async () => {
+  const { layout } = await laidOut({ textWrap: 'nowrap' });
+  assert.equal(layout.truncated, false);
+  assert.equal(layout.lines.length, 1);
+  assert.ok(
+    layout.width > 160,
+    `clipping nowrap reports its full ${layout.width}px, over the 160px box`,
+  );
+});
+
+/**
+ * The behaviour change the two paths add up to, in a row that has to divide
+ * 200px between a label and a 60px column beside it.
+ *
+ * Clipping, the label's min-content floor is the whole string, so the column
+ * is pushed clean off the end of the row. Eliding, the floor is small, the
+ * label takes what is left and says so with a `…`.
+ */
+async function row(style) {
+  await renderX11(
+    h(
+      'box',
+      { style: { flexDirection: 'row', width: 200 } },
+      h('text', { 'data-testname': 'label', style }, LONG),
+      h('box', {
+        'data-testname': 'column',
+        style: { width: 60, height: 10, flexShrink: 0 },
+      }),
+    ),
+    { width: 300, height: 120, fonts: FONTS },
+  );
+  return {
+    label: screen.getByTestName('label'),
+    columnX: screen.getByTestName('column').contentBox().x,
+  };
+}
+
+test('a clipping nowrap label pushes what follows it out of the row', async () => {
+  const { columnX } = await row({ textWrap: 'nowrap' });
+  assert.ok(columnX > 200, `the 60px column starts at ${columnX}, past 200`);
+});
+
+test('an eliding one gives way instead, and the column stays in the row', async () => {
+  const { label, columnX } = await row({
+    textWrap: 'nowrap',
+    textOverflow: 'ellipsis',
+  });
+  assert.equal(columnX, 140, 'the column keeps its 60px at the end of 200');
+  assert.equal(label._placedLayout().layout.truncated, true);
+});
+
+// --- who the ellipsis belongs to ------------------------------------------
+
+test('the ellipsis is set in the font of the run it cut into', async () => {
+  const { layout } = await laidOut(
+    { textOverflow: 'ellipsis' },
+    {
+      boxStyle: { width: 150 },
+      children: [
+        'App ',
+        h(
+          'text',
+          { style: { fontFamily: 'mono', fontSize: 20 } },
+          'Utilities Terminal.app',
+        ),
+      ],
+    },
+  );
+  const mark = ellipsisRun(layout);
+  assert.ok(mark, 'the line was elided');
+  // the cut lands inside the 20px monospace span, so the mark matches it —
+  // a paragraph-style ellipsis after a 20px word reads as a different size
+  // of type rather than as more text
+  assert.equal(mark.span.family, 'mono');
+  assert.equal(mark.span.size, 20);
+});
+
+// --- bidi ------------------------------------------------------------------
+
+test('in an RTL paragraph the ellipsis lands on the visual left', async () => {
+  const { layout } = await laidOut(
+    { textOverflow: 'ellipsis' },
+    { boxStyle: { direction: 'rtl' } },
+  );
+  const runs = runsOf(layout);
+  assert.equal(runs[0].ellipsis, true, 'first in visual order, i.e. leftmost');
+  assert.ok(runs.slice(1).every((run) => !run.ellipsis));
+});
+
+test('and on the visual right in an LTR one', async () => {
+  const { layout } = await laidOut({ textOverflow: 'ellipsis' });
+  const runs = runsOf(layout);
+  assert.equal(runs.at(-1).ellipsis, true);
+  assert.ok(runs.slice(0, -1).every((run) => !run.ellipsis));
+});
+
+// --- what is reported, and what is cached ----------------------------------
+
+test('a truncated <text> reports the whole string, not the elided one', async () => {
+  const { node, layout } = await laidOut({ textOverflow: 'ellipsis' });
+  assert.equal(layout.truncated, true);
+  // both the accessible name and the string the caret indices index into:
+  // what was cut is a fact about the pixels, and a screen reader that heard
+  // "Application Sup…" would be reading the layout rather than the content
+  assert.equal(a11yName(node), LONG);
+  assert.equal(node.textContent(), LONG);
+});
+
+test('the layout cache keys on the truncation options, not just the width', async () => {
+  const { node } = await laidOut({ textOverflow: 'ellipsis' });
+  const width = node.contentBox().width;
+  const elided = node._layoutFor(width);
+  assert.equal(elided.truncated, true);
+
+  // the same node, the same width, a different cap: a cache keyed on the
+  // width alone would hand back the one-line answer
+  node.style = { ...node.style, maxLines: 3 };
+  const clamped = node._layoutFor(width);
+  assert.equal(clamped.lines.length, 2, 'two lines is all this string needs');
+  assert.equal(clamped.truncated, false);
+  assert.equal(
+    node._layoutFor(width).lines.length,
+    2,
+    'and the second ask comes back off the cache under the new key',
+  );
+});
+
+test('changing maxLines through a re-render re-measures the box', async () => {
+  const tree = (style) =>
+    h(
+      'box',
+      { style: { width: 160, overflow: 'hidden' } },
+      h('text', { 'data-testname': 'subject', style }, LONG),
+    );
+  // Neither `maxLines` nor `textOverflow` is a yoga property or a paint
+  // property, so a commit that moves one and nothing else reaches
+  // `applyProps` with nothing for layout to notice — the same trap
+  // test/text-restyle.test.js exists for. It has to ask for the pass itself.
+  const { rerender } = await renderX11(tree({ textOverflow: 'ellipsis' }), {
+    width: 300,
+    height: 120,
+    fonts: FONTS,
+  });
+  const before = screen.getByTestName('subject').contentBox().height;
+
+  await rerender(tree({ textOverflow: 'ellipsis', maxLines: 2 }));
+  const after = screen.getByTestName('subject').contentBox().height;
+  assert.ok(
+    after > before,
+    `two lines (${after}) is taller than one (${before})`,
+  );
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -128,6 +128,10 @@ const s = createStyles({
   title: { fontSize: 20, color: '$text', fontWeight: 'bold' },
   // the box is the capitals down to the baseline, so this padding is even
   trimmed: { fontSize: 20, textBoxTrim: 'cap-alphabetic', padding: 8 },
+  // one line, ending in a `…` rather than mid-glyph (#350)
+  cell: { textWrap: 'nowrap', textOverflow: 'ellipsis' },
+  // and the clamp, which is a count rather than a keyword
+  blurb: { maxLines: 3, textOverflow: 'ellipsis' },
   card: {
     borderRadius: 8,
     borderWidth: 1,


### PR DESCRIPTION
Closes #350.

ntk's `TextLayout` has had the whole feature for a while — `maxLines`,
`overflow: 'ellipsis'`, and an elision that is the careful version rather than
a substring: the `…` in the cut run's own font, `...` where nothing covers
U+2026, the cut on a grapheme boundary with the tail re-shaped because kerning
and ligatures across it change widths, and the cut taken on the *visually* last
run so a right-to-left line ends on its left.

`TextNode._layoutFor` never asked for any of it. So this is wiring, and it is
two style properties:

```jsx
<text style={{ textWrap: 'nowrap', textOverflow: 'ellipsis' }}>{file.name}</text>
```

- `textOverflow: 'clip' | 'ellipsis'` — default `'clip'`, matching ntk's own.
- `maxLines: number` — CSS has no single-property spelling, so this is the name
  the platforms that got a clean shot at it chose.

![shot-truncation](https://github.com/user-attachments/assets/3acdead1-25b0-4e3f-ab82-6ff877613d54)

## The two decisions the wiring had to make

**An ellipsis with no cap can never fire.** ntk sets `truncated` off a line
*count*, so `textOverflow: 'ellipsis'` on its own would silently do nothing in
the case it is most often written for — a name, a path, a status line. It means
one line. `maxLines` is how to say two or three.

**`textWrap: 'nowrap'` stops taking the `Infinity` path when it elides.**
Unbounded width is the whole point of `nowrap`: it makes the overflow
horizontal so the box's `overflow: 'hidden'` deals with it, and it is what stops
a date wrapping into a taller row. But it leaves exactly one line, one line is
never over the cap, and nothing is ever cut. So an eliding `nowrap` is shaped
against the width on offer.

That is a real change in the intrinsic size a `nowrap` `<text>` reports, which
is the half worth looking at. A **clipping** one measures at unbounded width, so
CSS's automatic minimum size floors it at the whole string: it cannot be
squeezed, and a long name pushes the column beside it out of the row. An
**eliding** one measures inside the offer, so its floor is small and it gives
way — it takes the room that is left and says `Applicati…`. A column that cannot
show a file name should say so rather than making every other column narrower to
avoid it. Both directions are pinned in the tests, since a silent revert here is
every table column fighting for width again.

## What takes it

`<Table>`'s cells and headers, `<FileDialog>`'s name column, `examples/finder`,
and `examples/monitor` — which drops the character-count trim it was doing in JS
with a comment saying there was no `text-overflow: ellipsis` here. In the table,
a long header caption used to push the sort chevron out of its own header; now
the caption gives way and the chevron stays put.

![shot-table](https://github.com/user-attachments/assets/a13cf821-6491-4ddc-8470-f78d19e1bf35)

## Accessibility

What was cut is a fact about the pixels and nothing else. `a11yName` reads the
text chunks, so a truncated `<text>` reports the **whole** string, and the caret
and selection indices still index into the whole string. A screen reader that
read `Application Sup…` would be reading the layout instead of the content.
Pinned in a test.

## Also

- The `_layouts` cache keys on both new options alongside the width. They can
  only move with the style, which clears the map on its way past — but a cache
  keyed on less than it depends on is one refactor away from putting the wrong
  paragraph on screen with nothing reporting an error.
- `docs/styling.md`'s "Keeping text on one line" is no longer a workaround
  section, `docs/elements.md`'s `<text>` table gains the three rows it was
  missing, and the `AGENTS.md` line naming "no `text-overflow: ellipsis`" as a
  gap examples should admit to is gone.
- A `maxLines` below 1 keeps one line. A `<text>` that renders nothing is
  conditional rendering, not a truncation setting, and it would read as a
  missing label rather than as a number.

## Testing

`test/text-truncation.test.js` — 16 cases: the cap and its default, the clip
default, `nowrap` in both modes, the layout consequence in a real row, the
ellipsis taking a cut 20px span's font, the mark on the visual left in an RTL
paragraph and the right in an LTR one, the full string surviving to the
accessible name, and the cache key. Both halves mutation-checked against the
implementation.

Full suite green apart from the six `test/appearance.test.js` cases that fail on
macOS on master and pass in CI. `npm run typecheck`, `npm run lint` and
`prettier --check .` clean.

Screenshots rendered by this branch's own code at a32c595, headlessly into
node-x11's in-process X server.


