### PR TITLE
fix(gl): useSupports('shaders') answers for the connection, not the machine

### DIFF
--- a/docs/gl.md
+++ b/docs/gl.md
@@ -40,6 +40,19 @@ Everything about how the backend is chosen and why it might be unavailable —
 the `GLError` codes, `app.glCapabilities()`, the addon — is ntk's, and is
 documented in [ntk's context-gles.md](https://github.com/sidorares/ntk/blob/master/docs/context-gles.md).
 
+### The policy decides, not the machine
+
+`app.glCapabilities()` answers what the _machine_ could do, and it says
+`direct: true` on a DRI3-capable box whatever the policy is — a capability is
+not a decision. What draws is the backend the policy asked for, so that is
+what `useSupports('shaders')` and the direct-only elements answer: under the
+default `'indirect'`, both say no shaders on a machine that has a GPU, an
+addon and DRI3, because none of that is being used.
+
+The two questions are worth keeping apart. A scene branches on the backend it
+got; a diagnostic — "why did this desktop not get the fast path" — asks the
+capabilities, which is also where the reason lives.
+
 ## Shader materials
 
 ![A torus whose surface is banded and rim-lit by a fragment shader](img/shader-material.png)
@@ -129,6 +142,13 @@ const shaders = useSupports('shaders');
 `<Canvas3D fallback>` does not cover this: it is for a surface with no GL
 context at all, and a connection can have perfectly good indirect GL and no
 shaders.
+
+The answer settles once. Under a policy that could pick direct, `createRoot()`
+waits for ntk's probe before it hands the root back, so the first render
+already reads the final answer; a policy raised on the app after connecting
+has missed that probe, and the hook re-renders when it settles rather than
+leaving one component branching on `false` while its neighbour branches on
+`true`.
 
 ### Runtimes
 

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -197,21 +197,22 @@ const HostConfig = {
     }
     if (hostContext.isInside3d) {
       // A shader material needs a pipeline that has shaders. Whether this
-      // connection has one is already known — ntk settles it during connect —
-      // so the answer arrives here rather than as a blank surface later.
+      // connection draws through one is already known — the policy chose and
+      // ntk settled the probe during connect — so the answer arrives here
+      // rather than as a blank surface later.
       if (DIRECT_ONLY_KINDS[type] && !hasDirectGL(rootContainer)) {
-        // Say which of the several reasons it is. ntk worked it out during
-        // the connection handshake, and they call for different fixes — an
-        // addon to install, a display that cannot carry descriptors, a server
-        // without DRI3, or simply a policy left at its default.
+        // Say which of the several reasons it is. They call for different
+        // fixes — a policy that never asked for direct, an addon to install,
+        // a display that cannot carry descriptors, a server without DRI3 —
+        // and only the first is about this program rather than the machine.
         const reason = directGLFailure(rootContainer);
         const why = reason
           ? `\n\n${reason.code}: ${reason.message}` +
             (reason.hint ? `\n\n${reason.hint}` : '')
-          : '\n\nThe direct-rendering probe has not run on this connection. It runs ' +
-            'during createRoot() when glPolicy could select the direct backend, and ' +
-            'the default policy is "indirect":\n\n' +
-            "  const root = await createRoot({ glPolicy: 'auto' });";
+          : '\n\nThe direct-rendering probe has not answered yet on this connection. ' +
+            'createRoot() waits for it under a policy that could select the direct ' +
+            'backend, so a policy raised after connecting needs one settle first:\n\n' +
+            '  await app.glCapabilities();';
         const err = new Error(
           `react-x11: <${type}> needs direct rendering — ${DIRECT_ONLY_KINDS[type]} — ` +
             `and this connection does not have it.${why}\n\n` +

--- a/src/appcontext.js
+++ b/src/appcontext.js
@@ -26,7 +26,7 @@ import {
   compositingActive,
   watchCompositing,
 } from './compositing.js';
-import { hasDirectGL } from './glbackend.js';
+import { hasDirectGL, watchDirectGL } from './glbackend.js';
 
 const AppContext = createContext(null);
 
@@ -84,8 +84,8 @@ const SUPPORTS_FEATURES = new Set(['transparency', 'shaders']);
  * told which it is. Reach for the style block first; this is for decisions
  * that are not styling.
  *
- * `'shaders'` is true when 3D can run your own GLSL — that is, when ntk
- * resolved the **direct** rendering backend for this connection. It is the
+ * `'shaders'` is true when 3D can run your own GLSL — that is, when this
+ * connection draws through the **direct** rendering backend. It is the
  * question to ask before rendering a `<shaderMaterial>`, which throws where
  * there is no pipeline to compile it:
  *
@@ -97,11 +97,20 @@ const SUPPORTS_FEATURES = new Set(['transparency', 'shaders']);
  * </mesh>
  * ```
  *
- * It needs `createRoot({ glPolicy: 'auto' })` — the default policy is the
- * indirect backend, which has no shaders at all. Unlike `'transparency'` it
- * cannot change while the app runs, since the backend is settled during the
- * connection handshake. `app.glCapabilities()` says *why* it is false; see
- * docs/gl.md.
+ * It needs `createRoot({ glPolicy: 'auto' })`: the default policy is the
+ * indirect backend, which has no shaders at all, so this is false under it
+ * whatever the machine could do. That is the line between this and
+ * `app.glCapabilities()` — the hook answers which backend *this connection*
+ * got, the capabilities answer what the machine could offer, and they
+ * disagree exactly when the policy did not ask. The capabilities also say
+ * *why* this is false; see docs/gl.md.
+ *
+ * Unlike `'transparency'`, which comes and goes with the compositor, this
+ * settles once and then holds still: under a policy that could pick direct,
+ * `createRoot()` waits for ntk's probe before handing the app back, so the
+ * first render already reads the final answer. A policy raised after
+ * connecting has missed that probe, and re-renders its readers when it
+ * settles rather than leaving them with two different answers.
  */
 export function useSupports(feature) {
   const app = useApp();
@@ -112,13 +121,15 @@ export function useSupports(feature) {
     );
   }
   // Both features go through the same store, so the hooks below run in the
-  // same order whatever is being asked about. 'shaders' has nothing to watch:
-  // ntk settles the backend during the connection handshake and it cannot
-  // change after that, so its subscribe is a no-op rather than a compositing
-  // watch this caller never asked for.
+  // same order whatever is being asked about. Where compositing comes and
+  // goes for as long as the app runs, the backend settles at most once — and
+  // watching that one moment is what keeps two components rendered either
+  // side of it from disagreeing (see watchDirectGL).
   const subscribe = useCallback(
     (onChange) =>
-      feature === 'shaders' ? () => {} : watchCompositing(app, onChange),
+      feature === 'shaders'
+        ? watchDirectGL(app, onChange)
+        : watchCompositing(app, onChange),
     [app, feature],
   );
   // a boolean, so the snapshot is stable for a given state — returning the

--- a/src/glbackend.js
+++ b/src/glbackend.js
@@ -1,30 +1,114 @@
 // Which GL backend a connection got, asked synchronously.
 //
-// ntk settles this during its connection handshake — it probes for direct
-// rendering whenever `glPolicy` could select it — so by the time any element
-// is created the answer is a property read rather than a round trip. That is
-// what lets `<shaderMaterial>` fail at creation, with a reason, instead of
-// rendering an empty surface.
+// The question is about the **connection**, not the machine. ntk's
+// `glCapabilities()` answers the machine one — "could direct rendering work
+// here" — and consults `glPolicy` only far enough to honour `'off'`, so on a
+// DRI3-capable box it resolves `{ direct: true }` under the default
+// `'indirect'` policy too. What actually draws is what the policy asked for,
+// so that is what this module reports: the same rule ntk's own `backendFor()`
+// applies when `getContext` picks a backend, kept in step here because it is
+// not part of ntk's public API (issue #357).
 //
-// A leaf module on purpose: it imports nothing, so both `appcontext.js` (for
-// `useSupports('shaders')`) and the node layer can use it without the two
-// importing each other.
+// ntk settles the probe during its connection handshake — it runs it whenever
+// `glPolicy` could select direct — so by the time any element is created the
+// answer is a property read rather than a round trip. That is what lets
+// `<shaderMaterial>` fail at creation, with a reason, instead of rendering an
+// empty surface.
+//
+// A leaf module on purpose: it imports nothing of ours, so both
+// `appcontext.js` (for `useSupports('shaders')`) and the node layer can use
+// it without the two importing each other.
 
-/** Is the direct backend — the one with shaders — available on `app`? */
-export function hasDirectGL(app) {
-  return !!app?._glCapsResolved?.direct;
+import { GLError } from 'ntk';
+
+/** Does this connection's policy ever choose the direct backend? */
+const wantsDirect = (app) => {
+  const mode = app?.glPolicy?.mode;
+  return mode === 'auto' || mode === 'direct';
+};
+
+/** ntk's coded-error shape — `code` to branch on, `hint` for what to do. */
+function glError(code, message, hint) {
+  const err = new Error(message);
+  err.code = code;
+  if (hint) err.hint = hint;
+  return err;
 }
 
 /**
- * Why it is not, as ntk's coded error — or null when it is available, or
- * when nothing has asked yet.
+ * Is the direct backend — the one with shaders — what this connection draws
+ * through?
+ *
+ * False under a policy that never asks for it, whatever the machine could do,
+ * because the policy is what decides which backend is built.
+ */
+export function hasDirectGL(app) {
+  return wantsDirect(app) && !!app._glCapsResolved?.direct;
+}
+
+/**
+ * Why it is not, as a coded error — or null when it is available, or when the
+ * probe that would say has not answered yet.
  *
  * Worth surfacing rather than describing: the reasons are genuinely different
- * (no GPU addon, a connection that cannot pass descriptors, a server without
- * DRI3, a policy left at `'indirect'`) and only one of them is "turn the
+ * (a policy that never asked, no GPU addon, a connection that cannot pass
+ * descriptors, a server without DRI3) and only one of them is "turn the
  * policy on". A message that guesses sends people to check the wrong thing.
+ *
+ * The policy reasons are minted here because ntk has none to give: its probe
+ * consults the mode only for `'off'`, so a connection left on the default
+ * `'indirect'` carries capabilities with no `reason` in them at all — and on
+ * a capable machine, with `direct: true` in them.
  */
 export function directGLFailure(app) {
-  const caps = app?._glCapsResolved;
+  const mode = app?.glPolicy?.mode;
+  if (mode === 'off') {
+    return glError(
+      GLError.DISABLED,
+      "glPolicy is 'off' on this connection, so no GL context is created at all",
+      "Nothing inside <Canvas3D> draws under this policy. Pass glPolicy: 'auto'\n" +
+        'to createRoot(), or drop the option, to get a context back.',
+    );
+  }
+  if (!wantsDirect(app)) {
+    return glError(
+      'GL_POLICY_INDIRECT',
+      "glPolicy is 'indirect' — ntk's default — so this connection draws " +
+        'through indirect GLX, which has no shaders whatever this machine could do',
+      "createRoot({ glPolicy: 'auto' }) takes the direct backend where it is\n" +
+        'available and this one everywhere else, and NTK_GL_POLICY=auto switches\n' +
+        'a single run. app.glCapabilities() still answers what the machine can do.',
+    );
+  }
+  const caps = app._glCapsResolved;
   return caps && !caps.direct ? (caps.reason ?? null) : null;
+}
+
+/**
+ * Call `onChange` when that answer settles, and hand back the unsubscribe —
+ * the subscribe half of `useSupports('shaders')`.
+ *
+ * It settles at most once and then holds still. Under a policy that could
+ * pick direct, `createRoot()` waits for ntk's probe before it hands the app
+ * back, so the first render already reads the final answer and there is
+ * nothing to watch; under one that could not, the answer is false and stays
+ * false. What is left is a policy raised after connecting, which has missed
+ * the handshake probe — `glCapabilities()` is idempotent and cached, and is
+ * the same call ntk makes lazily when a context is created, so asking it here
+ * settles the answer rather than leaving one component reading false and the
+ * next reading true.
+ */
+export function watchDirectGL(app, onChange) {
+  if (!wantsDirect(app) || app._glCapsResolved) return () => {};
+  if (typeof app.glCapabilities !== 'function') return () => {};
+  let live = true;
+  // a probe that throws is a probe that found nothing: the answer stays
+  // false, and re-reading a boolean that did not move costs a comparison
+  const settled = () => {
+    if (live) onChange();
+  };
+  app.glCapabilities().then(settled, settled);
+  return () => {
+    live = false;
+  };
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -140,9 +140,13 @@ export function useClipboard(): Clipboard;
 /**
  * Features `useSupports()` can be asked about.
  *
- * `'shaders'` is whether 3D can run your own GLSL — the direct rendering
- * backend. Ask it before rendering a `<shaderMaterial>`, which throws where
- * there is no pipeline to compile it. Needs `createRoot({ glPolicy: 'auto' })`.
+ * `'shaders'` is whether 3D can run your own GLSL — that is, whether this
+ * connection draws through the direct rendering backend. Ask it before
+ * rendering a `<shaderMaterial>`, which throws where there is no pipeline to
+ * compile it. It needs `createRoot({ glPolicy: 'auto' })`: under the default
+ * policy it is false whatever the machine could do, because the indirect
+ * backend is what draws. `app.glCapabilities()` is the machine's answer, and
+ * says why.
  */
 export type SupportsFeature = 'transparency' | 'shaders';
 

--- a/test/gl-supports.test.js
+++ b/test/gl-supports.test.js
@@ -1,0 +1,157 @@
+// `useSupports('shaders')` answers about the **connection**, not the machine.
+//
+// The two come apart on a DRI3-capable box: ntk's capability probe reports
+// what the machine could do and consults glPolicy only for 'off', so it
+// resolves `direct: true` under the default 'indirect' policy — while the
+// context that draws is the indirect one. A hook that reported the machine
+// sent a scene into `<shaderMaterial>` that the mount guard then (correctly)
+// refused, so the same question had two answers in one render (issue #357).
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import React from 'react';
+
+import {
+  directGLFailure,
+  hasDirectGL,
+  watchDirectGL,
+} from '../src/glbackend.js';
+import { createRoot, useSupports } from '../src/index.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+// what a capable machine resolves to, in the shape ntk caches on the app
+const CAPABLE = {
+  direct: true,
+  indirect: true,
+  device: '/dev/dri/renderD128',
+  reason: null,
+};
+
+/** A mock app told what its policy says and what the probe found. */
+function glApp({ mode = 'indirect', caps } = {}) {
+  const app = createMockApp();
+  // ntk's App resolves this from its options on every read; a mock says it
+  app.glPolicy = {
+    mode,
+    devicePath: null,
+    maxInFlight: 2,
+    linearFallback: true,
+  };
+  if (caps) app._glCapsResolved = caps;
+  return app;
+}
+
+/** The last value a `useSupports(feature)` probe rendered with, and its root. */
+async function mountProbe(app, feature) {
+  const seen = [];
+  function Probe() {
+    seen.push(useSupports(feature));
+    return null;
+  }
+  const x11Root = await createRoot({ app });
+  x11Root.render(h('window', { width: 100, height: 100 }, h(Probe)));
+  await tick();
+  return { seen, x11Root };
+}
+
+test('the backend is the policy’s answer, not the machine’s', () => {
+  for (const mode of ['indirect', 'off']) {
+    assert.equal(
+      hasDirectGL(glApp({ mode, caps: CAPABLE })),
+      false,
+      `${mode} draws through no direct backend, whatever the box could do`,
+    );
+  }
+  for (const mode of ['auto', 'direct']) {
+    assert.equal(hasDirectGL(glApp({ mode, caps: CAPABLE })), true);
+  }
+  // a policy that asked, on a machine that cannot, or before the probe answered
+  assert.equal(
+    hasDirectGL(glApp({ mode: 'auto', caps: { direct: false, reason: null } })),
+    false,
+  );
+  assert.equal(hasDirectGL(glApp({ mode: 'auto' })), false);
+});
+
+test('the reason names the policy when the policy is the reason', () => {
+  const indirect = directGLFailure(glApp({ mode: 'indirect', caps: CAPABLE }));
+  assert.equal(indirect.code, 'GL_POLICY_INDIRECT');
+  assert.match(indirect.message, /glPolicy is 'indirect'/);
+  // and points at the one thing that would change it
+  assert.match(indirect.hint, /glPolicy: 'auto'/);
+
+  assert.equal(directGLFailure(glApp({ mode: 'off' })).code, 'GL_DISABLED');
+
+  // under a policy that did ask, ntk's own reason is the useful one and is
+  // handed on untouched — an addon to install is not a policy to change
+  const reason = Object.assign(
+    new Error('the x11-dri addon is not installed'),
+    {
+      code: 'GL_NO_ADDON',
+    },
+  );
+  const asked = glApp({ mode: 'auto', caps: { direct: false, reason } });
+  assert.equal(directGLFailure(asked), reason);
+
+  // nothing to report while the probe is still out, or when it found direct
+  assert.equal(directGLFailure(glApp({ mode: 'auto' })), null);
+  assert.equal(directGLFailure(glApp({ mode: 'auto', caps: CAPABLE })), null);
+});
+
+test('nothing is watched when nothing can move', () => {
+  // a policy that cannot say direct, and one whose probe already answered
+  for (const app of [
+    glApp({ mode: 'indirect' }),
+    glApp({ mode: 'auto', caps: CAPABLE }),
+  ]) {
+    app.glCapabilities = () => assert.fail('should not probe');
+    assert.equal(typeof watchDirectGL(app, () => {}), 'function');
+  }
+});
+
+test("useSupports('shaders') is false on a capable box the policy never asked", async () => {
+  const app = glApp({ mode: 'indirect', caps: CAPABLE });
+  const { seen, x11Root } = await mountProbe(app, 'shaders');
+  assert.deepEqual(seen, [false], 'indirect GLX has no shaders to offer');
+  await x11Root.unmount();
+});
+
+test("useSupports('shaders') is true once the policy asked and the probe agreed", async () => {
+  const app = glApp({ mode: 'auto', caps: CAPABLE });
+  const { seen, x11Root } = await mountProbe(app, 'shaders');
+  assert.deepEqual(seen, [true]);
+  await x11Root.unmount();
+});
+
+test('a probe that settles late re-renders its readers instead of tearing them', async () => {
+  // A policy raised after connecting misses the probe createRoot() waits for,
+  // so this is the one case where the answer still moves. It has to move for
+  // everyone at once: a component rendered before the settle and one rendered
+  // after it were reading different values of the same question.
+  const app = glApp({ mode: 'auto' });
+  let settle;
+  const probed = new Promise((resolve) => {
+    settle = resolve;
+  });
+  let probes = 0;
+  app.glCapabilities = () => {
+    probes++;
+    return probed.then((caps) => {
+      app._glCapsResolved = caps;
+      return caps;
+    });
+  };
+
+  const { seen, x11Root } = await mountProbe(app, 'shaders');
+  assert.deepEqual(seen, [false], 'an unanswered probe reads as no shaders');
+  assert.equal(probes, 1, 'subscribing asks the question ntk answers lazily');
+
+  settle(CAPABLE);
+  await probed;
+  await tick();
+  assert.equal(seen.at(-1), true, 're-rendered when the probe answered');
+
+  await x11Root.unmount();
+});

--- a/test/glarea.test.js
+++ b/test/glarea.test.js
@@ -525,6 +525,63 @@ for (const [what, scene] of [
   });
 }
 
+// What the guard was blurring: ntk's probe answers what the *machine* could
+// do and consults glPolicy only for 'off', so a DRI3-capable box resolves
+// `direct: true` under the default 'indirect' policy too — while the context
+// that draws is still indirect GLX. The element has to refuse there, and the
+// reason has to be the policy rather than one of the hardware ones, because
+// that is the only one the reader can do anything about (issue #357).
+test('a capable machine the policy never asked is not direct rendering', async () => {
+  const { app } = await createGlApp();
+  // the capabilities such a box caches: addon loaded, DRI3 and Present there
+  app._glCapsResolved = {
+    direct: true,
+    indirect: true,
+    device: '/dev/dri/renderD128',
+    reason: null,
+  };
+  const x11Root = await createRoot({ app });
+  const realError = console.error;
+  console.error = () => {};
+  try {
+    await assert.rejects(
+      () =>
+        flush(() =>
+          x11Root.render(
+            h(
+              'window',
+              { width: 320, height: 240 },
+              h(
+                Canvas3D,
+                { style: { flexGrow: 1 } },
+                h(
+                  'mesh',
+                  null,
+                  h('boxGeometry', { args: [1, 1, 1] }),
+                  h('shaderMaterial', {
+                    vertexShader: 'void main() {}',
+                    fragmentShader: 'void main() {}',
+                  }),
+                ),
+              ),
+            ),
+          ),
+        ),
+      (err) => {
+        assert.equal(err.code, 'GL_POLICY_INDIRECT');
+        assert.match(err.message, /<shaderMaterial> needs direct rendering/);
+        // the policy, named, and the change that would answer differently
+        assert.match(err.message, /glPolicy is 'indirect'/);
+        assert.match(err.message, /glPolicy: 'auto'/);
+        return true;
+      },
+    );
+  } finally {
+    console.error = realError;
+    await app.close();
+  }
+});
+
 // The fallback means "this machine has no 3D". A render target that came
 // back incomplete, or an addon too old to have framebuffer objects, is one
 // broken effect on a surface that is otherwise drawing — swapping the whole

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -59,6 +59,7 @@ import {
   systemBus,
   useApp,
   useClipboard,
+  useSupports,
   useDesktopSettings,
   useFileDialog,
   useGlobalMenu,
@@ -1068,6 +1069,18 @@ async function main() {
   // @ts-expect-error — not a sink
   startTrace({ sink: 'xml' });
   void [n, perOpcode, one.stats.errors, one.stop()];
+}
+
+// the two things a display can be asked about, both plain booleans — one is
+// about the machine and the compositor, the other about the backend this
+// connection got
+function _Supports() {
+  const canBlend: boolean = useSupports('transparency');
+  const shaders: boolean = useSupports('shaders');
+  // @ts-expect-error — not a feature useSupports knows
+  useSupports('webgpu');
+  void [canBlend, shaders];
+  return null;
 }
 
 // the clipboard facade: groups, options, and the two read contracts


### PR DESCRIPTION
Fixes #357.

## The gap

ntk's `glCapabilities()` answers the **machine** question — "could direct
rendering work here" — and consults `glPolicy` only far enough to honour
`'off'`. So on a DRI3-capable box it resolves `{ direct: true }` under the
default `'indirect'` policy too, while the context that draws is indirect
GLX. `useSupports('shaders')` read that probe straight, so it said yes on a
connection with no shaders in it, and the branch the docstring recommends
walked into the direct-only mount guard, which correctly threw.

The policy-aware answer already exists next door — ntk's `backendFor()`
returns `'indirect'` whenever the mode says so — but it is not part of ntk's
public API, so nothing on the hook path could reach it.

## What changed

- **`hasDirectGL()` is the policy's answer**, not the probe's:
  `wantsDirect(policy) && caps.direct`, matching `backendFor(app) ===
  'direct'`. The direct-only mount guard reads the same function, so the
  element and the hook now agree whatever the machine can do.
- **`directGLFailure()` mints the policy reasons ntk has none to give.** A
  connection left on the default carries capabilities with no `reason` in
  them — and, on a capable box, with `direct: true` in them — so "the policy
  never asked" was arriving at the guard as *no reason at all*, and it is the
  one cause the reader can actually do something about. It is now
  `GL_POLICY_INDIRECT` (or ntk's `GL_DISABLED` under `'off'`), naming the
  option that would change it. The hardware reasons are still ntk's, handed
  on untouched.
- **`'shaders'` has a real subscription.** The old subscribe was a no-op on
  the grounds that the backend cannot change once connected. It can: a policy
  raised after connecting has missed the handshake probe, so the first render
  read `false` and a later one read `true`, and components either side of the
  settle disagreed. `watchDirectGL()` waits on `glCapabilities()` — idempotent
  and cached, and the same call ntk makes lazily when a context is created —
  and only when the answer can still move. Under a policy that could pick
  direct, `createRoot()` already waited for the probe, so the common path
  subscribes to nothing.

Semantics only, no signature change: `useSupports('shaders')` is still
`boolean`. What moves is that it is now false on a capable machine the policy
never asked, which is what the docstring always promised.

## Tests

`test/gl-supports.test.js` (new) covers the four policy modes against a
capable probe, the reason split, the "nothing to watch" cases, and the late
settle re-rendering its readers rather than tearing them.
`test/glarea.test.js` gains the live repro: a `<shaderMaterial>` on a box
whose caps say `direct: true` under the default policy must still be refused,
with the policy named. Both halves were checked against the old
implementation — the mode test and the hook test fail on the old
`hasDirectGL`, the settle test fails on the old no-op subscribe.

Docs: a "the policy decides, not the machine" section in `docs/gl.md`
separating the two questions, the settle-once note beside the branch example,
and the `useSupports` docstring and `.d.ts` brought in line with what the
code now does. `test/types/api.tsx` gains a case for the hook, which had none.

## Note for ntk

`backendFor()` and `wantsDirect()` are exactly the policy-aware answer, and
neither is exported from `ntk`'s entry — `lib/gl.js` is not in the exports
map either. This PR keeps a two-line copy of that rule in `src/glbackend.js`
in step by hand. Happy to file it upstream if you want them public.

## Downstream

`@react-x11/components` PR #36 hardened around this locally (`<Canvas>` syncs
`supportsShaders` from the created context; the examples gate on
`useSupports('shaders') && backend === 'direct'`). Those workarounds become
redundant once this ships, though they stay correct.

---

Full suite: 1581/1582. The one failure is
`integration.test.js › textinput renders its value through the ntk text
stack`, which fails the same way on unmodified `origin/master` on this
machine (3/3) — pre-existing and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.ai/code)
