### PR TITLE
feat(frame): <Frame> — a module in its own process, its window in yours

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,23 @@ no override-redirect staging (issue #4).
   React tree before any handler saw it. The X focus stays on our window and
   forwarding happens in `defaultKeyDown`/`defaultKeyUp`, which is what makes
   the rule "app chords first, everything else forwards" mechanical.
+- `src/frame/` — `<Frame>`: a pane of the application in its own process,
+  its window embedded over `<foreign>` (docs/frame.md). Four small files
+  along the seams: `protocol.js` (pure — the six messages, the callback
+  table with its one-update grace window, argument sanitizing), `env.js`
+  (the context bridge: `createFrameContext`, the `FrameEnv` accumulator the
+  theme publishes into), `index.js` (the host: fork, supervision,
+  coalesced updates, fallback), `childmain.js` + `child.js` (the pane
+  bootstrap behind an injectable transport, which is what lets the tests
+  run a real pane in-process over a loopback — `test/frame.test.js` forks
+  for real exactly once, over a TCP bridge onto the in-process server).
+  Two things are deliberate and easy to undo: the **update listener goes up
+  before the pane module import starts** (a store the tree subscribes to
+  later — a listener scoped to the mounted tree would drop every update
+  that landed during the import), and the host's transport listeners
+  **outlive the effect cleanup until the exit**, because a `useFrameClose`
+  handler flushing through a callback prop sends its `invoke` after the
+  unmount message.
 - `src/scene3d.js` — the 3D scene tree inside a `<glarea>`: `<mesh>`,
   `<group>`, geometry/material nodes and the renderer that compiles each
   geometry into a server-side **display list** (a frame is matrices +

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -159,22 +159,23 @@ dragged over, copied and handed to the PRIMARY selection. See
 
 A real X11 window; the flex, paint and event root for its subtree.
 
-| prop                        |                                                                                                                                               |
-| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `title`                     | window title (UTF-8, via `WM_NAME` + `_NET_WM_NAME`)                                                                                          |
-| `width`, `height`, `x`, `y` | window geometry (window state, not yoga style — the user may resize). A size is pixels or `'auto'`, and leaving it out means `'auto'` (below) |
-| `backgroundColor`           | full-window clear color (default white)                                                                                                       |
-| `onResize(ev)`              | ConfigureNotify — the tree reflows automatically. Fires for **moves** too (see below)                                                         |
-| `onExpose(ev)`              | after a repaint was required                                                                                                                  |
-| `onCloseRequest(ev)`        | WM close button (opts into `WM_DELETE_WINDOW`)                                                                                                |
-| `states`                    | EWMH `_NET_WM_STATE` — controlled, see below                                                                                                  |
-| `fullscreen`, `alwaysOnTop` | boolean sugar for two of those states                                                                                                         |
-| `decorations`               | `false` asks the WM for no titlebar or border                                                                                                 |
-| `transparent`               | 32-bit ARGB visual — rounded, translucent windows (below)                                                                                     |
-| `transientFor`              | ICCCM `WM_TRANSIENT_FOR` — the window this one belongs to (below)                                                                             |
-| `onStatesChange(states)`    | what the window manager actually did                                                                                                          |
-| `onClientMessage(ev)`       | a ClientMessage addressed to this window — EWMH, XEmbed, the tray (below)                                                                     |
-| `theme`                     | palette that `$token` style values resolve against, for this subtree                                                                          |
+| prop                        |                                                                                                                                                                                                         |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `title`                     | window title (UTF-8, via `WM_NAME` + `_NET_WM_NAME`)                                                                                                                                                    |
+| `width`, `height`, `x`, `y` | window geometry (window state, not yoga style — the user may resize). A size is pixels or `'auto'`, and leaving it out means `'auto'` (below)                                                           |
+| `backgroundColor`           | full-window clear color (default white)                                                                                                                                                                 |
+| `onResize(ev)`              | ConfigureNotify — the tree reflows automatically. Fires for **moves** too (see below)                                                                                                                   |
+| `onExpose(ev)`              | after a repaint was required                                                                                                                                                                            |
+| `onCloseRequest(ev)`        | WM close button (opts into `WM_DELETE_WINDOW`)                                                                                                                                                          |
+| `states`                    | EWMH `_NET_WM_STATE` — controlled, see below                                                                                                                                                            |
+| `fullscreen`, `alwaysOnTop` | boolean sugar for two of those states                                                                                                                                                                   |
+| `decorations`               | `false` asks the WM for no titlebar or border                                                                                                                                                           |
+| `transparent`               | 32-bit ARGB visual — rounded, translucent windows (below)                                                                                                                                               |
+| `transientFor`              | ICCCM `WM_TRANSIENT_FOR` — the window this one belongs to (below)                                                                                                                                       |
+| `onStatesChange(states)`    | what the window manager actually did                                                                                                                                                                    |
+| `onClientMessage(ev)`       | a ClientMessage addressed to this window — EWMH, XEmbed, the tray (below)                                                                                                                               |
+| `theme`                     | palette that `$token` style values resolve against, for this subtree                                                                                                                                    |
+| `embeddable`                | created but never self-mapped: the window waits for an embedder ([`<foreign>`](embedding.md) on the other side), which maps it after the reparent. What a [`<Frame>`](frame.md) pane's root window sets |
 
 Windows may be nested inside other windows (real X11 child windows).
 **Ref**: the live ntk `Window` — `getContext('2d')`,

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -17,6 +17,15 @@ That is a terminal pane, a video surface, a docked tray icon and a
 control-panel applet — four things an application cannot draw for itself and
 has no business reimplementing.
 
+When the other process is a module of **your own application**, don't wire
+this up by hand: [`<Frame>`](frame.md) is `<foreign>` plus the process — the
+fork, the props, the callbacks, the bridged theme, the crash fallback. This
+page is the window half, and everything below about stacking, focus and
+teardown holds for a `<Frame>` pane too. The pane's own root window opts in
+with `<window embeddable>`: created **unmapped** — a window waiting to be
+embedded is unmapped, that is what waiting looks like — and mapped by the
+embedder once reparented.
+
 The protocol underneath is [XEmbed](http://specifications.freedesktop.org/xembed/0.5/),
 implemented in ntk (`XEmbedSocket`, ntk ≥ 7.4.0). This page is the React half:
 what the element does, what it promises about a window it does not own, and

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -118,10 +118,15 @@ The theme is the one ambient thing the app authors, so it crosses **by
 default**: a `<ThemeProvider>` above a `<Frame>` reaches the pane as a real
 `ThemeProvider` around it — both routes, `useTheme()` and `$token` styles —
 and it is in the pane's very first commit, so there is no frame of default
-palette first. With no provider above the frame, nothing is bridged and the
-pane follows the desktop by itself: same answer, no bridge. A pane that
-wants its own look mounts its own provider, which wins below the bridged
-one the way an inner provider always wins.
+palette first. The bridged provider wraps the pane's **window** itself, the
+position it held in the host: the window's own background follows the app's
+palette rather than the pane process's desktop, and the window is the top
+of the node tree every `$token` beneath it resolves through — so a theme
+toggle in the host moves the pane's background and its static text, not
+only what re-renders through `useTheme()`. With no provider above the
+frame, nothing is bridged and the pane follows the desktop by itself: same
+answer, no bridge. A pane that wants its own look mounts its own provider,
+which wins below the bridged one the way an inner provider always wins.
 
 For a context of your own, create it with `createFrameContext` in a module
 **both sides import** — which the pane already does, since its components

--- a/docs/frame.md
+++ b/docs/frame.md
@@ -1,0 +1,251 @@
+# Panes in their own process: `<Frame>`
+
+```jsx
+import { Frame } from 'react-x11';
+
+<Frame
+  src={new URL('./charts.pane.js', import.meta.url)}
+  props={{ rows, range, onPick }}
+  style={{ flexGrow: 1, backgroundColor: '$surface' }}
+  fallback={({ error, restart }) => <Crashed error={error} onRetry={restart} />}
+/>;
+```
+
+`<Frame>` mounts a module of your application in a **process of its own** and
+embeds its window here, laid out like any other child. It is this package's
+iframe: the same composition of a window boundary and a process boundary,
+behind one element. Both boundaries already existed separately — the window
+half is [`<foreign>`](embedding.md), the process half is a forked node — and
+`<Frame>` is deliberately nothing more than the contract between them.
+
+What the process boundary buys is the part no amount of careful coding buys
+in-process:
+
+- **Parallelism where this framework is CPU-bound.** The pane's
+  reconciliation, layout, text shaping and painting run on another core. A
+  pane that grinds for 400ms does not delay the shell's input handling by a
+  microsecond — `npm run examples:frame` makes the difference visible with a
+  ticker you can watch freeze, or not.
+- **Crash isolation.** An uncaught throw, a native-module crash, an OOM: the
+  pane dies, the `fallback` renders, `restart()` respawns. The shell never
+  knew.
+- **Leak isolation.** A pane that leaks is a bounded, killable leak, and its
+  GC pauses are its own.
+
+And what it does not buy, said once here and again in
+[security.md](security.md): **it is not a security boundary.** The pane
+holds a full-privilege connection to the same X server — it can read keys,
+take screenshots, move windows. `<Frame>` contains a pane's _failures_, not
+its intentions; code you would not run in-process is code you should not run
+at all.
+
+## The pane module
+
+`src` names a module whose **default export is the pane's root component**:
+
+```jsx
+// charts.pane.js
+export default function ChartsPane({ rows, range, onPick }) {
+  return <box style={{ flexGrow: 1 }}>…</box>;
+}
+```
+
+Pass `src` as `new URL('./charts.pane.js', import.meta.url)` or an absolute
+path — a relative string is refused, because it would resolve against
+react-x11's own files rather than yours.
+
+A pane module is an ordinary component module. The same file can run inline
+(`import ChartsPane from './charts.pane.js'` and render it), be its own
+application, or be a pane — `isFramed()` answers which, and the examples'
+autorun guard is where to ask:
+
+```js
+import { isFramed } from 'react-x11';
+
+if (!isFramed() && !process.env.REACT_X11_NO_AUTORUN) {
+  const root = await createRoot();
+  root.render(<ChartsPane {...defaults} />);
+}
+```
+
+The pane process inherits the parent's `execArgv`, which is what carries a
+dev loader (tsx, the refresh loader) into it during development; a bundled
+application forks plain JavaScript and needs none. It connects to the
+display the host names in `display`, or `$DISPLAY` like everything else.
+
+## Props: a bag of data, and stubs for the functions in it
+
+`props` crosses by **structured clone** — Dates, Maps, TypedArrays and
+cycles survive; component instances, refs and React elements do not. One
+message goes out per parent commit that changed the bag (a shallow
+`Object.is` pass decides "changed", so a parent re-rendering without
+touching the pane's inputs sends nothing), and props and bridged context
+travel in the **same message**, so a theme flip and the state change that
+caused it land in the pane as one commit rather than a torn pair.
+
+Functions anywhere in the bag become **fire-and-forget stubs** on the pane
+side: calling one sends its arguments back and returns `undefined`. The
+arguments are sanitized on the way — functions inside them are dropped, the
+data around them kept — because a pane calls `onPick(item, ev)` the way it
+would call any handler, and `ev` is full of methods.
+
+Callback identity follows function identity: a handler the parent keeps
+stable (`useCallback`) keeps its id across updates, and an id from the
+previous update still lands — one update of grace, which is what covers a
+click racing a props change. A stub stashed outside the props flow and
+called two updates later is dropped with a warning, not delivered to the
+wrong function.
+
+Two rules of thumb that keep the wire small:
+
+- **The pane owns its data.** Props are for queries, ids, ranges — the pane
+  fetches its own rows, the way an iframe fetches its own resources.
+  Shipping a dataset through `props` on every commit works, and is the
+  slowest possible way to have the pane know it.
+- **The pane owns its animation.** An update is an IPC hop plus a pane
+  commit: the right price for "show this now", the wrong one for driving a
+  spinner at 60fps from the host.
+
+## Context: bridged explicitly, theme by default
+
+React context cannot cross a process boundary, and most of it should not
+try: appearance, locale, desktop settings and fonts are resolved from the
+desktop identically on both sides, so each process just asks. The rule the
+bridge implements: **bridge what the app defines; let each process resolve
+what the desktop defines.**
+
+The theme is the one ambient thing the app authors, so it crosses **by
+default**: a `<ThemeProvider>` above a `<Frame>` reaches the pane as a real
+`ThemeProvider` around it — both routes, `useTheme()` and `$token` styles —
+and it is in the pane's very first commit, so there is no frame of default
+palette first. With no provider above the frame, nothing is bridged and the
+pane follows the desktop by itself: same answer, no bridge. A pane that
+wants its own look mounts its own provider, which wins below the bridged
+one the way an inner provider always wins.
+
+For a context of your own, create it with `createFrameContext` in a module
+**both sides import** — which the pane already does, since its components
+read the context from it. The import is what registers the key, so identity
+needs no wiring:
+
+```js
+// contexts.js — imported by the app and by the pane's components
+import { createFrameContext } from 'react-x11';
+export const Session = createFrameContext('session', null);
+```
+
+```jsx
+// app side: an ordinary provider that also publishes to frames below it
+<Session.Provider value={{ user, workspace }}>
+  <Frame src={paneUrl} … />
+</Session.Provider>;
+
+// pane side: nothing to wire
+const { user } = Session.use();
+```
+
+In-process it is an ordinary React context. Across a frame the value is
+snapshotted, sent with the props, and recreated as a provider around the
+pane — providers nest in the parent's own order, and a frame inside a pane
+re-bridges automatically, because the pane's providers republish what they
+received.
+
+**Bridged values are data.** A value that will not structured-clone is
+dropped with a warning naming the key, and that is deliberate: a bridged
+`{ state, dispatch }` would hand live RPC stubs to every pane under the
+provider — invisible wiring, with an unanswerable question about which
+incarnation of a restarted pane holds which stub. Dispatchers travel in
+`props`, where the wiring is visible. `serialize`/`revive` options on
+`createFrameContext` cover a value that is data in spirit but a class in
+shape.
+
+`bridge` is the off switch the default owes: `bridge={false}` bridges
+nothing, `bridge={['react-x11:theme', 'session']}` is an allowlist.
+
+One honest limitation: the pane commits an IPC hop after the host, so a
+theme flip repaints the shell a frame before the panes. Every asynchronous
+boundary has this; nothing here pretends otherwise.
+
+## Lifecycle, from both sides
+
+The host's view:
+
+- **`onStarted({ pid, windowId })`** — the pane mounted; its window is
+  being embedded.
+- **`onExit({ code, signal, expected })`** — the pane process ended.
+  `expected` is `true` when this side asked (unmount, `restart()`, a `src`
+  change) — and the event still fires after the frame unmounted, because
+  the exit a graceful close ends in always arrives after the unmount that
+  asked for it.
+- **`fallback`** — what the rect shows when the pane crashed or could not
+  start: an element, or `({ error, restart }) => …`. `error.phase` says
+  where it went wrong: `spawn`, `load` (the commonest — a bad `src`),
+  `connect`, `handshake` (version skew), `runtime`, `send`, `embed`, or
+  plain `exit`.
+- **`ref`** — `{ restart(), pid }`.
+
+The pane's view:
+
+- **`useFrameClose(handler)`** — the host is letting the pane go: the
+  `<Frame>` unmounted, or the host app is exiting. The handler may return a
+  promise and may still call callback props — flushing through one is what
+  it is for. The patience is real but bounded: the host asks by message,
+  escalates to SIGTERM at 1.5s, SIGKILL at 4s. Not called on a crash; a
+  close handler is a courtesy, and anything that must survive a crash
+  belongs on disk before the close.
+- **`isFramed()`** — see above.
+- A host that dies without asking takes the IPC channel with it, and the
+  pane exits on the disconnect — no orphans either way.
+
+## Sizing, stacking, input
+
+The embedded pane is a [`<foreign>`](embedding.md), and its rules apply
+verbatim. The rect comes from `style` and yoga like any child — there is no
+content-driven sizing across the boundary. The pane's window is a real X
+child window, so **host-drawn content cannot overlap it**; a HUD or a
+"reconnecting…" banner belongs in a sibling `<popup>`. Pointer events over
+the pane are the pane's without the host ever seeing them; keys follow
+[embedding.md's focus rules](embedding.md#focus-and-who-gets-the-keys) —
+the host's handlers see every key first, and what they do not consume is
+forwarded.
+
+`backgroundColor` in the frame's `style` is what shows before the pane's
+first frame and after one dies — the same server-painted rectangle
+`<foreign>` documents.
+
+## What a pane costs
+
+A pane is a node process with React and ntk loaded: roughly 40–70MB and
+100–300ms of module graph before its first frame, plus an X connection.
+That is the price of an event loop of one's own — right for a handful of
+heavy panes, wrong as a general componentization strategy. A hundred
+buttons belong in your process; the log viewer that parses gigabytes does
+not.
+
+## The transport seam
+
+Everything between the host and the pane is six message types over an
+injectable transport, and `transport` replaces the fork wholesale — it is
+how the tests run a real pane (module, root, window, props, callbacks,
+close handlers) in-process over a loopback pair against the in-process X
+server, with `structuredClone` standing in for the fork's serialization
+(`test/helpers/frame-loopback.js`, and `runFrameChild` in
+`src/frame/childmain.js` is the pane's whole bootstrap behind the same
+seam). It is also the door to running a pane somewhere other than a child
+process without `<Frame>` learning about it.
+
+## Known gaps
+
+Named so they are not rediscovered:
+
+- **Accessibility**: a pane registers on the AT-SPI bus as its own
+  application. Orca reads it, and Tab crosses the boundary, but the tree is
+  not unified under the host's.
+- **DevTools**: a pane is its own React tree; `REACT_X11_DEVTOOLS=1` in the
+  pane process attaches a separate DevTools, not a merged one.
+- **No intrinsic size**: the host decides the rect; a `measure` protocol
+  could exist and does not yet.
+- The `<window embeddable>` underneath (created unmapped, waiting for an
+  embedder — see [embedding.md](embedding.md)) speaks plain reparenting
+  today, not the `_XEMBED` messages; focus works through the forwarding
+  rules above rather than XEmbed's own handshake.

--- a/examples/frame-mandelbrot.jsx
+++ b/examples/frame-mandelbrot.jsx
@@ -1,0 +1,95 @@
+// The pane examples/frame.jsx mounts — in its own process through
+// `<Frame>`, or inline for the comparison the example is about. Same file
+// either way: a pane module is an ordinary component module, and this one
+// says which situation it is in by printing its own pid.
+//
+// The compute is honest: escape-time Mandelbrot, one synchronous pass over
+// every pixel inside `onDraw`. Several hundred milliseconds at pane size,
+// blocking whichever process it runs in — which is the point. Watch the
+// host's ticker while it runs framed, then inline.
+import React, { useCallback } from 'react';
+
+import { isFramed, useFrameClose } from '../src/index.js';
+
+/** Where the interesting parts of the set are: centre + half-width. */
+export const VIEWS = [
+  { name: 'home', x: -0.6, y: 0, scale: 1.6 },
+  { name: 'seahorse valley', x: -0.746, y: 0.11, scale: 0.02 },
+  { name: 'elephant valley', x: 0.2755, y: 0.006, scale: 0.01 },
+  { name: 'spiral', x: -0.7453, y: 0.1127, scale: 0.0018 },
+];
+
+function paint(img, width, height, view, iterations) {
+  const data = img.data;
+  const aspect = width / height;
+  const half = view.scale;
+  for (let py = 0; py < height; py++) {
+    const ci = view.y + ((py / height) * 2 - 1) * half;
+    for (let px = 0; px < width; px++) {
+      const cr = view.x + ((px / width) * 2 - 1) * half * aspect;
+      let zr = 0;
+      let zi = 0;
+      let n = 0;
+      while (n < iterations && zr * zr + zi * zi <= 4) {
+        const next = zr * zr - zi * zi + cr;
+        zi = 2 * zr * zi + ci;
+        zr = next;
+        n++;
+      }
+      const at = (py * width + px) * 4;
+      if (n === iterations) {
+        data[at] = 8;
+        data[at + 1] = 8;
+        data[at + 2] = 24;
+      } else {
+        // smooth-ish colouring from the escape count alone
+        const t = n / 48;
+        data[at] = Math.floor(128 + 127 * Math.sin(t));
+        data[at + 1] = Math.floor(128 + 127 * Math.sin(t + 2.1));
+        data[at + 2] = Math.floor(128 + 127 * Math.sin(t + 4.2));
+      }
+      data[at + 3] = 255;
+    }
+  }
+}
+
+export default function FractalPane({
+  view = VIEWS[0],
+  iterations = 400,
+  crash = false,
+  onStats,
+}) {
+  if (crash) throw new Error('the pane was asked to crash');
+  useFrameClose(() => {
+    // the moment to flush anything worth keeping; this pane just says so
+    console.log('fractal pane: host let go, exiting');
+  });
+  const draw = useCallback(
+    (ctx, { width, height, node }) => {
+      const w = Math.max(1, Math.floor(width));
+      const h = Math.max(1, Math.floor(height));
+      const started = performance.now();
+      const img = ctx.createImageData(w, h);
+      paint(img, w, h, view, iterations);
+      // putImageData is spec-faithful: not transform-affected, so the
+      // node's own origin has to be named (docs/elements.md#canvas)
+      ctx.putImageData(img, Math.round(node.abs.x), Math.round(node.abs.y));
+      onStats?.({
+        ms: Math.round(performance.now() - started),
+        pixels: w * h,
+        iterations,
+        pid: process.pid,
+      });
+    },
+    [view, iterations, onStats],
+  );
+  const where = isFramed() ? `process ${process.pid}` : 'in-process';
+  return (
+    <box style={{ flexGrow: 1, padding: 10, gap: 8 }}>
+      <text style={{ color: '$textMuted' }}>
+        {`${view.name} — ${iterations} iterations — computing in ${where}`}
+      </text>
+      <canvas onDraw={draw} style={{ flexGrow: 1 }} />
+    </box>
+  );
+}

--- a/examples/frame.jsx
+++ b/examples/frame.jsx
@@ -1,0 +1,206 @@
+// <Frame>: the same pane, in its own process or in yours — feel the
+// difference.
+//
+// The pane (frame-mandelbrot.jsx) computes a Mandelbrot region in one
+// synchronous pass: several hundred milliseconds of pure CPU per frame. The
+// host runs a ticker — a dot stepping along a strip — that freezes whenever
+// *this* process is busy. Run the pane framed and the dot never breaks
+// stride while the fractal grinds; switch to inline and every recompute
+// stops it dead. Same module both ways, which is the deal `<Frame>` offers:
+// a component you already have, moved off your event loop.
+//
+// Also here: the theme crossing the process boundary (toggle dark and the
+// pane follows — the bridge, docs/frame.md), a crash that stays in the pane
+// (crash it framed: the fallback offers a restart; inline, an error
+// boundary is all that stands between the pane and the whole app), and the
+// pane printing which pid it computes in.
+//
+// What does not work, so it is not rediscovered: the pane's window is a
+// real X child window, so host-drawn content cannot overlap it — an overlay
+// belongs in a sibling <popup> (docs/embedding.md). And the process
+// boundary contains failures, not intentions: the pane holds a
+// full-privilege connection to the same X server (docs/security.md).
+//
+// Run with: npm run examples:frame     (needs an X server / DISPLAY)
+import React, { useCallback, useEffect, useState } from 'react';
+
+import { Button, Frame, ThemeProvider, createRoot } from '../src/index.js';
+import FractalPane, { VIEWS } from './frame-mandelbrot.jsx';
+
+const PANE = new URL('./frame-mandelbrot.jsx', import.meta.url);
+const TICKS = 22;
+
+/** The host's heartbeat: a dot stepping along a strip. It freezes exactly
+ *  when this process's event loop does — the whole instrument. */
+function Ticker() {
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    const timer = setInterval(() => setTick((t) => t + 1), 80);
+    return () => clearInterval(timer);
+  }, []);
+  return (
+    <box style={{ flexDirection: 'row', gap: 2 }}>
+      {Array.from({ length: TICKS }, (_, i) => (
+        <box
+          key={i}
+          style={{
+            width: 8,
+            height: 8,
+            borderRadius: 2,
+            backgroundColor: tick % TICKS === i ? '$accent' : '$surfaceActive',
+          }}
+        />
+      ))}
+    </box>
+  );
+}
+
+/** Inline mode's seatbelt: an inline crash is the app's crash, and this
+ *  boundary is all that catches it. Framed mode needs none — that is the
+ *  comparison. */
+class InlineBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null };
+  }
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+  render() {
+    if (this.state.error) {
+      return (
+        <box style={{ flexGrow: 1, padding: 16, gap: 10 }}>
+          <text style={{ color: '$danger' }}>
+            {`inline crash reached the app: ${this.state.error.message}`}
+          </text>
+          <Button
+            onPress={() =>
+              this.props.onReset(() => this.setState({ error: null }))
+            }
+          >
+            Recover
+          </Button>
+        </box>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+/** `frameTransport`, `initialFramed` and `onStats` are the test seams:
+ *  the pane spawn and the one number that proves it ran go behind them
+ *  (test/frame-example.test.js). */
+export function App({ frameTransport, initialFramed = true, onStats } = {}) {
+  const [dark, setDark] = useState(false);
+  const [framed, setFramed] = useState(initialFramed);
+  const [viewIndex, setViewIndex] = useState(0);
+  const [zoom, setZoom] = useState(0);
+  const [crash, setCrash] = useState(false);
+  const [stats, setStats] = useState(null);
+
+  const view = VIEWS[viewIndex];
+  const paneProps = {
+    view: { ...view, scale: view.scale / 2 ** zoom },
+    iterations: 300 + zoom * 150,
+    crash,
+    onStats: useCallback(
+      (s) => {
+        setStats(s);
+        onStats?.(s);
+      },
+      [onStats],
+    ),
+  };
+
+  return (
+    <ThemeProvider value={{}} colorScheme={dark ? 'dark' : 'light'}>
+      <window
+        title="frame — a pane in its own process"
+        width={960}
+        height={600}
+        style={{ backgroundColor: '$background', flexDirection: 'row' }}
+      >
+        <box style={{ width: 270, padding: 14, gap: 10 }}>
+          <text style={{ fontSize: 15, color: '$text' }}>
+            the host stays responsive…
+          </text>
+          <Ticker />
+          <text style={{ color: '$textMuted' }}>
+            {stats
+              ? `pane frame: ${stats.ms}ms, pid ${stats.pid}`
+              : 'waiting for the first pane frame'}
+          </text>
+          <box style={{ height: 10 }} />
+          <Button primary onPress={() => setFramed((f) => !f)}>
+            {framed ? 'Run inline instead' : 'Run in its own process'}
+          </Button>
+          <Button onPress={() => setDark((d) => !d)}>
+            {dark ? 'Light theme' : 'Dark theme'}
+          </Button>
+          <Button
+            onPress={() => {
+              setViewIndex((i) => (i + 1) % VIEWS.length);
+              setZoom(0);
+            }}
+          >
+            {`Next region (${view.name})`}
+          </Button>
+          <Button onPress={() => setZoom((z) => Math.min(z + 1, 6))}>
+            Zoom in
+          </Button>
+          <Button onPress={() => setZoom((z) => Math.max(z - 1, 0))}>
+            Zoom out
+          </Button>
+          <Button onPress={() => setCrash(true)}>Crash the pane</Button>
+        </box>
+        {framed ? (
+          <Frame
+            src={PANE}
+            transport={frameTransport}
+            props={paneProps}
+            style={{ flexGrow: 1, backgroundColor: '$surface' }}
+            fallback={({ error, restart }) => (
+              <box style={{ flexGrow: 1, padding: 16, gap: 10 }}>
+                <text style={{ color: '$danger' }}>
+                  {`the pane is gone: ${error?.message ?? 'unknown'}`}
+                </text>
+                <text style={{ color: '$textMuted' }}>
+                  …and the host never noticed, which is the point.
+                </text>
+                <Button
+                  primary
+                  onPress={() => {
+                    setCrash(false);
+                    restart();
+                  }}
+                >
+                  Restart the pane
+                </Button>
+              </box>
+            )}
+            onStarted={({ pid }) => console.log(`pane started, pid ${pid}`)}
+            onExit={({ code, signal, expected }) =>
+              console.log(
+                `pane exited (${signal ?? `code ${code}`}), ` +
+                  (expected ? 'asked to' : 'crashed'),
+              )
+            }
+          />
+        ) : (
+          <box style={{ flexGrow: 1, backgroundColor: '$surface' }}>
+            <InlineBoundary onReset={(clear) => (setCrash(false), clear())}>
+              <FractalPane {...paneProps} />
+            </InlineBoundary>
+          </box>
+        )}
+      </window>
+    </ThemeProvider>
+  );
+}
+
+export default App;
+
+if (!process.env.REACT_X11_NO_AUTORUN && !import.meta.hot) {
+  const root = await createRoot();
+  root.render(<App />);
+}

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "examples:stress": "tsx examples/stress/index.jsx",
     "examples:finder": "tsx examples/finder.jsx",
     "examples:foreign": "tsx examples/foreign.jsx",
+    "examples:frame": "tsx examples/frame.jsx",
     "labs:text-baseline": "tsx examples/labs/text-baseline.jsx",
     "examples:gl": "tsx examples/gl.jsx",
     "examples:three": "tsx examples/three.jsx",

--- a/src/components/theme.js
+++ b/src/components/theme.js
@@ -142,8 +142,12 @@ export const THEME_ENV_KEY = 'react-x11:theme';
 // the complete merged palette, so it wins every token; a pane's own inner
 // ThemeProvider still overrides below it, which is the opt-out a pane that
 // wants its own look already has.
-registerFrameProvider(THEME_ENV_KEY, (value, children) =>
-  h(ThemeProvider, { value }, children),
+registerFrameProvider(
+  THEME_ENV_KEY,
+  (value, children) => h(ThemeProvider, { value }, children),
+  // directly around the pane's window: `planted` puts the palette on a
+  // window among its direct children, and the window is where it must land
+  { innermost: true },
 );
 
 /**

--- a/src/components/theme.js
+++ b/src/components/theme.js
@@ -9,6 +9,7 @@
 
 import React, { useContext, useMemo, useState } from 'react';
 import { useAppearanceWhen } from '../appearancehooks.js';
+import { EnvValue, registerFrameProvider } from '../frame/env.js';
 import { DarkTheme, DefaultTheme, resolveTheme } from '../palette.js';
 
 const h = React.createElement;
@@ -118,9 +119,32 @@ export function ThemeProvider({
   return h(
     ThemeContext.Provider,
     { value: theme },
-    planted(children, theme, boxStyle),
+    // The palette also crosses into any <Frame> below here (THEME_ENV_KEY):
+    // it is the one ambient thing the *app* authors, so a pane that said
+    // nothing about colour comes up in the app's palette rather than one
+    // frame of default. With no provider at all nothing is published, and
+    // the pane follows the desktop by itself — same answer, no bridge.
+    h(
+      EnvValue,
+      { k: THEME_ENV_KEY, value: theme },
+      planted(children, theme, boxStyle),
+    ),
   );
 }
+
+/** What the theme is called on a frame's wire (docs/frame.md). */
+export const THEME_ENV_KEY = 'react-x11:theme';
+
+// The child half of the default theme bridge: recreate with the *real*
+// provider, because the palette travels two routes — the context widgets
+// read, and the `theme` prop planted on a node so `$token` styles resolve
+// (#119) — and only ThemeProvider itself feeds both. The bridged value is
+// the complete merged palette, so it wins every token; a pane's own inner
+// ThemeProvider still overrides below it, which is the opt-out a pane that
+// wants its own look already has.
+registerFrameProvider(THEME_ENV_KEY, (value, children) =>
+  h(ThemeProvider, { value }, children),
+);
 
 /**
  * The node that carries the palette into the tree. Normally a box — but a

--- a/src/frame/child.js
+++ b/src/frame/child.js
@@ -1,0 +1,33 @@
+// The file a `<Frame>` forks. Everything of substance is in childmain.js
+// behind the transport seam; this is the seam's other resident — the one
+// transport a fork actually has, node's IPC channel, wired straight off
+// `process`. Kept import-light and JSX-free on purpose: it runs before
+// anything decided what loaders this process has.
+
+import { runFrameChild } from './childmain.js';
+
+if (typeof process.send !== 'function') {
+  console.error(
+    'react-x11: frame/child.js is the entry a <Frame> forks — it needs the ' +
+      'IPC channel fork() sets up, and cannot be run directly.',
+  );
+  process.exit(1);
+}
+
+runFrameChild({
+  send: (msg) => {
+    try {
+      process.send(msg);
+    } catch {
+      // the parent's end is closing; its exit handling takes it from here
+    }
+  },
+  onMessage: (cb) => {
+    process.on('message', cb);
+    return () => process.off('message', cb);
+  },
+  onDisconnect: (cb) => {
+    process.on('disconnect', cb);
+    return () => process.off('disconnect', cb);
+  },
+});

--- a/src/frame/childmain.js
+++ b/src/frame/childmain.js
@@ -1,0 +1,251 @@
+// The pane process, from hello to exit. `src/frame/child.js` is the file
+// the parent actually forks; everything it does beyond `process.send`
+// plumbing is here, behind an injectable transport — so the tests run a
+// real pane (module, root, window, props, callbacks, close handlers) in
+// process, over a loopback pair, against the in-process X server. The fork
+// boundary itself is the only thing this seam cannot cover, and the only
+// thing the forked entry adds.
+//
+// Order matters three times in this file:
+//
+//  - The **update listener goes up before the module import starts.** The
+//    import is the slow part of booting a pane, the parent sends updates
+//    whenever its commits produce them, and a listener scoped to the
+//    mounted tree would drop everything that arrived in between. So the
+//    listener is a store the tree subscribes to later: the last update
+//    always wins, however early it came.
+//
+//  - The module is imported **before** the root is created. A `src` that
+//    does not resolve is the commonest way a frame fails, and failing it
+//    should not cost an X connection — or worse, report a connection error
+//    when the truth is a typo in a path.
+//
+//  - `ready` is sent only once the pane's window has an id, which is after
+//    the commit that realizes it. The parent embeds on `ready`; an id sent
+//    early would have the embedder reparenting a window that does not
+//    exist.
+//
+// The window is `<window embeddable>`: created unmapped, because a window
+// waiting to be embedded is unmapped — that is what waiting looks like —
+// and the embedder maps it once it is reparented (ntk's XEmbedSocket).
+
+import { isAbsolute } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import React, { useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
+
+import { createRoot } from '../index.js';
+import { windowIdOf } from '../windowid.js';
+import { registeredFrameContext } from './env.js';
+import { markFramed, runCloseHandlers } from './lifecycle.js';
+import { PROTOCOL, reviveCallbacks } from './protocol.js';
+
+const h = React.createElement;
+
+/**
+ * @typedef {object} ChildTransport The child's end of the wire.
+ * @property {(msg: object) => void} send
+ * @property {(cb: (msg: object) => void) => () => void} onMessage
+ * @property {(cb: () => void) => () => void} onDisconnect the parent's end
+ *   closed — there is nobody left to talk to
+ */
+
+/** Recreate the bridged providers, outermost first — the parent's own
+ * nesting order, which the env Map records and structured clone preserves.
+ * A key the pane never registered wraps nothing: no module in this process
+ * reads it. */
+function wrapEnv(env, inner) {
+  let tree = inner;
+  for (const [key, value] of [...env].reverse()) {
+    const registered = registeredFrameContext(key);
+    if (!registered) continue;
+    tree = registered.render
+      ? registered.render(value, tree)
+      : h(
+          registered.Context.Provider,
+          { value: registered.revive ? registered.revive(value) : value },
+          tree,
+        );
+  }
+  return tree;
+}
+
+function Bridge({ Component, store, rect, invoke, onReady }) {
+  const wire = useSyncExternalStore(
+    (cb) => {
+      store.listeners.add(cb);
+      return () => store.listeners.delete(cb);
+    },
+    () => store.value,
+  );
+  const snapshot = useMemo(
+    () => ({
+      props: reviveCallbacks(wire.props ?? {}, invoke),
+      env: new Map(wire.env ?? []),
+    }),
+    [wire, invoke],
+  );
+  const ref = useRef(null);
+
+  // The window realizes in the commit this effect follows — but `ready`
+  // must carry its id, so a beat where the ref is still empty retries on a
+  // fresh task rather than reporting a pane with no window.
+  useEffect(() => {
+    let cancelled = false;
+    const report = (tries) => {
+      if (cancelled) return;
+      const windowId = windowIdOf(ref);
+      if (windowId) onReady(windowId);
+      else if (tries > 0) setTimeout(() => report(tries - 1), 10);
+      else onReady(null);
+    };
+    report(200);
+    return () => {
+      cancelled = true;
+    };
+  }, [onReady]);
+
+  return h(
+    'window',
+    {
+      ref,
+      embeddable: true,
+      width: Math.max(1, rect?.width ?? 400),
+      height: Math.max(1, rect?.height ?? 300),
+    },
+    wrapEnv(snapshot.env, h(Component, snapshot.props)),
+  );
+}
+
+/**
+ * Run the pane: handshake, load `src`, mount its default export, follow
+ * updates, and exit when told to (or when the parent goes away).
+ *
+ * `exit` and `rootOptions` are the test seams: a test passes a loopback
+ * transport, a borrowed in-process connection (`rootOptions.app`) and an
+ * `exit` that resolves instead of killing the runner.
+ */
+export async function runFrameChild(transport, options = {}) {
+  const {
+    exit = (code) => process.exit(code),
+    rootOptions,
+    // The pane process's last resort: an async throw nothing else caught is
+    // reported before the exit it forces. Off in the in-process tests,
+    // where "the process" is the test runner and trapping its errors would
+    // convert a failing test into a politely-reported pane crash.
+    trapProcessErrors = true,
+  } = options;
+
+  const fatal = (phase, err) => {
+    try {
+      transport.send({
+        type: 'fatal',
+        phase,
+        message: err?.message ?? String(err),
+        stack: err?.stack,
+      });
+    } catch {
+      // the channel is gone; the exit code still says what happened
+    }
+    console.error(`react-x11 frame pane (${phase}):`, err);
+    exit(1);
+  };
+
+  if (trapProcessErrors) {
+    process.on('uncaughtException', (err) => fatal('runtime', err));
+    process.on('unhandledRejection', (err) => fatal('runtime', err));
+  }
+  markFramed();
+
+  const hello = await new Promise((resolve) => {
+    const off = transport.onMessage((msg) => {
+      if (msg?.type !== 'hello') return;
+      off();
+      resolve(msg);
+    });
+  });
+  if (hello.protocol !== PROTOCOL) {
+    return fatal(
+      'handshake',
+      new Error(
+        `frame protocol ${hello.protocol} from the host, ${PROTOCOL} here — ` +
+          'host and pane are running different react-x11 versions',
+      ),
+    );
+  }
+
+  // From here every update is kept, mounted tree or not: last one wins.
+  const store = {
+    value: { props: hello.props ?? {}, env: hello.env ?? [] },
+    listeners: new Set(),
+  };
+  transport.onMessage((msg) => {
+    if (msg?.type !== 'update') return;
+    store.value = { props: msg.props ?? {}, env: msg.env ?? [] };
+    for (const listener of [...store.listeners]) listener();
+  });
+
+  let Component;
+  try {
+    const url = isAbsolute(hello.src)
+      ? pathToFileURL(hello.src).href
+      : hello.src;
+    const mod = await import(url);
+    Component = mod.default;
+    if (typeof Component !== 'function' && typeof Component !== 'object') {
+      throw new Error(`${hello.src} has no default export to mount`);
+    }
+  } catch (err) {
+    return fatal('load', err);
+  }
+
+  let root;
+  try {
+    root = await createRoot({
+      ...(hello.display ? { display: hello.display } : {}),
+      ...rootOptions,
+      onUncaughtError: (err) => fatal('runtime', err),
+    });
+  } catch (err) {
+    return fatal('connect', err);
+  }
+
+  let closing = false;
+  const close = async () => {
+    if (closing) return;
+    closing = true;
+    try {
+      await runCloseHandlers();
+      await root.unmount();
+    } catch {
+      // exiting is the point; nothing downstream of it to protect
+    }
+    exit(0);
+  };
+
+  transport.onMessage((msg) => {
+    if (msg?.type === 'unmount') close();
+  });
+  transport.onDisconnect(close);
+
+  root.render(
+    h(Bridge, {
+      Component,
+      store,
+      rect: hello.rect,
+      invoke: (id, args) => {
+        try {
+          transport.send({ type: 'invoke', id, args });
+        } catch {
+          // the host is going away; its shutdown handles the rest
+        }
+      },
+      onReady: (windowId) => {
+        if (windowId) transport.send({ type: 'ready', windowId });
+        else fatal('runtime', new Error('the pane window never realized'));
+      },
+    }),
+  );
+
+  return { root, close };
+}

--- a/src/frame/childmain.js
+++ b/src/frame/childmain.js
@@ -50,22 +50,34 @@ const h = React.createElement;
  *   closed — there is nobody left to talk to
  */
 
-/** Recreate the bridged providers, outermost first — the parent's own
- * nesting order, which the env Map records and structured clone preserves.
- * A key the pane never registered wraps nothing: no module in this process
- * reads it. */
+/** Recreate the bridged providers around the pane's window, outermost
+ * first — the parent's own nesting order, which the env Map records and
+ * structured clone preserves. A key the pane never registered wraps
+ * nothing: no module in this process reads it. Providers registered
+ * `innermost` (the theme) wrap directly around the window, inside the
+ * rest — see registerFrameProvider (src/frame/env.js) for why the
+ * adjacency matters. */
 function wrapEnv(env, inner) {
-  let tree = inner;
-  for (const [key, value] of [...env].reverse()) {
+  const wrap = (tree, [key, value]) => {
     const registered = registeredFrameContext(key);
-    if (!registered) continue;
-    tree = registered.render
+    if (!registered) return tree;
+    return registered.render
       ? registered.render(value, tree)
       : h(
           registered.Context.Provider,
           { value: registered.revive ? registered.revive(value) : value },
           tree,
         );
+  };
+  const entries = [...env];
+  const isInnermost = ([key]) =>
+    registeredFrameContext(key)?.innermost === true;
+  let tree = inner;
+  for (const entry of entries.filter(isInnermost).reverse()) {
+    tree = wrap(tree, entry);
+  }
+  for (const entry of entries.filter((e) => !isInnermost(e)).reverse()) {
+    tree = wrap(tree, entry);
   }
   return tree;
 }
@@ -105,15 +117,26 @@ function Bridge({ Component, store, rect, invoke, onReady }) {
     };
   }, [onReady]);
 
-  return h(
-    'window',
-    {
-      ref,
-      embeddable: true,
-      width: Math.max(1, rect?.width ?? 400),
-      height: Math.max(1, rect?.height ?? 300),
-    },
-    wrapEnv(snapshot.env, h(Component, snapshot.props)),
+  // The bridged providers wrap the *window*, not the pane component — the
+  // same position they held in the host. ThemeProvider plants the palette
+  // on a window it finds among its children (theme.js, `planted`), and the
+  // window is where it has to land: the window's own background follows the
+  // palette, and it is the top of the node tree every `$token` beneath
+  // resolves through. Mounted inside the window, the palette reached a box
+  // and the window kept resolving against the pane process's own desktop —
+  // a dark-desktop pane in a light-themed app, wrong in both directions.
+  return wrapEnv(
+    snapshot.env,
+    h(
+      'window',
+      {
+        ref,
+        embeddable: true,
+        width: Math.max(1, rect?.width ?? 400),
+        height: Math.max(1, rect?.height ?? 300),
+      },
+      h(Component, snapshot.props),
+    ),
   );
 }
 

--- a/src/frame/env.js
+++ b/src/frame/env.js
@@ -1,0 +1,132 @@
+// The frame environment: which context values cross into a `<Frame>`.
+//
+// React context cannot cross a process boundary — a context object is
+// process-local, and React has no API for enumerating "the providers above
+// this node". Both halves of that problem are answered here with one
+// structure:
+//
+//  - **Identity** is a string key plus a module both sides import. A pane's
+//    components read a context by importing the module that created it, and
+//    creating it (`createFrameContext`) is what registers it — so by the
+//    time the child bridge has a value to recreate, the context it belongs
+//    to is in the registry *by construction*. A key that arrives with no
+//    registration means the pane never imported the module, which means
+//    nothing in the pane reads it: skipped, silently.
+//
+//  - **Enumeration** is an accumulator: every bridging provider also merges
+//    its value into `FrameEnv`, a single internal context holding a
+//    `Map(key → value)`. `<Frame>` reads that one context at its own tree
+//    position and gets exactly the values an in-process child would have
+//    seen there — and re-renders when any of them changes, which is the
+//    entire subscription mechanism. Map insertion order is the parent's
+//    provider nesting order (outermost first), v8's structured clone
+//    preserves it, and the child recreates providers in that order.
+//
+// What deliberately does not cross: functions. Props run the callback
+// bridge because props are visible per-frame wiring; a context is ambient,
+// and bridging a `{ state, dispatch }` pair would hand live RPC stubs to
+// every pane under the provider — invisible IPC, with an unanswerable
+// question about which incarnation of a restarted child holds which stub.
+// A bridged value that fails structured clone is dropped with a warning
+// naming the key (src/frame/index.js), and dispatchers travel in `props`.
+//
+// The other line this file draws: bridge what the **app** defines, and let
+// each process resolve what the **desktop** defines. Appearance, locale,
+// desktop settings and fonts are read from the environment identically on
+// both sides of the boundary, so bridging them would only add a stale copy.
+// The theme is the one ambient thing the app authors, which is why
+// `ThemeProvider` publishes here by default (src/components/theme.js).
+
+import React, { useContext, useMemo } from 'react';
+
+const h = React.createElement;
+
+const EMPTY = new Map();
+
+/** `Map(key → serialized value)` of every bridged context above here. */
+export const FrameEnv = React.createContext(EMPTY);
+
+/** The env a `<Frame>` at this position would hand its child. */
+export function useFrameEnv() {
+  return useContext(FrameEnv);
+}
+
+/**
+ * key → how the child recreates the provider:
+ * `{ Context, revive }` from `createFrameContext`, or `{ render }` from
+ * `registerFrameProvider`. Last registration wins, which is what lets a
+ * hot-reloaded module re-register itself without a guard.
+ */
+const registry = new Map();
+
+/** The child bridge's lookup (src/frame/childmain.js). */
+export function registeredFrameContext(key) {
+  return registry.get(key) ?? null;
+}
+
+/**
+ * Register how the child side recreates `key` — for a provider that is more
+ * than `Context.Provider`, like `ThemeProvider`, which also plants the
+ * palette on a node so `$token` styles resolve. `render(value, children)`
+ * returns the wrapped element.
+ */
+export function registerFrameProvider(key, render) {
+  registry.set(key, { render });
+}
+
+/**
+ * Publish one `key → value` into the frame environment. Used by
+ * `createFrameContext`'s Provider and by `ThemeProvider`; not part of the
+ * public API.
+ */
+export function EnvValue({ k, value, children }) {
+  const env = useContext(FrameEnv);
+  const next = useMemo(() => new Map(env).set(k, value), [env, k, value]);
+  return h(FrameEnv.Provider, { value: next }, children);
+}
+
+/**
+ * A React context whose value follows the app into its `<Frame>` panes.
+ *
+ * ```js
+ * // contexts.js — imported by the app *and* by the pane's components
+ * export const Session = createFrameContext('session', null);
+ *
+ * // app side
+ * <Session.Provider value={{ user, database }}>
+ *   <Frame src={paneUrl} … />
+ * </Session.Provider>
+ *
+ * // pane side — no wiring; the value was in force where the Frame stood
+ * const { user } = Session.use();
+ * ```
+ *
+ * In-process it is an ordinary context. Across a `<Frame>` the value is
+ * snapshotted with structured clone, sent with the frame's props, and
+ * recreated as a real Provider around the pane — one direction, data only.
+ *
+ * `key` names the value on the wire and must be unique per app;
+ * `serialize`/`revive` are for values structured clone cannot carry
+ * (a class instance), and default to identity.
+ */
+export function createFrameContext(key, defaultValue, options = {}) {
+  if (typeof key !== 'string' || key.length === 0) {
+    throw new Error('react-x11: createFrameContext needs a string key');
+  }
+  const { serialize, revive } = options;
+  const Context = React.createContext(defaultValue);
+  registry.set(key, { Context, revive });
+  function Provider({ value, children }) {
+    return h(
+      EnvValue,
+      { k: key, value: serialize ? serialize(value) : value },
+      h(Context.Provider, { value }, children),
+    );
+  }
+  return {
+    key,
+    Context,
+    Provider,
+    use: () => useContext(Context),
+  };
+}

--- a/src/frame/env.js
+++ b/src/frame/env.js
@@ -69,9 +69,17 @@ export function registeredFrameContext(key) {
  * than `Context.Provider`, like `ThemeProvider`, which also plants the
  * palette on a node so `$token` styles resolve. `render(value, children)`
  * returns the wrapped element.
+ *
+ * `innermost: true` puts the provider directly around the pane's window,
+ * inside every other bridged provider. ThemeProvider needs the adjacency:
+ * it plants the palette on a window it finds among its *direct* children,
+ * and the window is where the palette must land — the window's own
+ * background follows it, and the node tree under it is what every `$token`
+ * resolves through. Plain context providers have no such constraint and
+ * keep the host's nesting order outside.
  */
-export function registerFrameProvider(key, render) {
-  registry.set(key, { render });
+export function registerFrameProvider(key, render, { innermost = false } = {}) {
+  registry.set(key, { render, innermost });
 }
 
 /**

--- a/src/frame/index.js
+++ b/src/frame/index.js
@@ -48,7 +48,14 @@ import { CallbackTable, PROTOCOL } from './protocol.js';
 
 const h = React.createElement;
 
-const CHILD = fileURLToPath(new URL('./child.js', import.meta.url));
+/** The forked entry's path — resolved at first spawn, not at import. The
+ * website playground bundles this module with throw-on-call stubs for the
+ * node builtins, and a top-level `fileURLToPath` would throw on *load*;
+ * lazily, `<Frame>` imports everywhere and says "needs a desktop" only
+ * when something actually spawns. */
+let childEntry = null;
+const childPath = () =>
+  (childEntry ??= fileURLToPath(new URL('./child.js', import.meta.url)));
 
 /**
  * @typedef {object} FrameTransport The parent's end of the wire to a pane.
@@ -64,7 +71,7 @@ const CHILD = fileURLToPath(new URL('./child.js', import.meta.url));
  * inherited, which is what carries a dev loader (tsx, the refresh loader)
  * into the pane; a bundled app forks plain JS and needs none. */
 function forkTransport({ src, display }) {
-  const child = fork(CHILD, [], {
+  const child = fork(childPath(), [], {
     serialization: 'advanced',
     // dev loaders (tsx, the refresh loader) follow into the pane; the test
     // runner's own flags must not — `--test` in execArgv would run the pane

--- a/src/frame/index.js
+++ b/src/frame/index.js
@@ -1,0 +1,437 @@
+// <Frame>: a pane of this application, running in its own process.
+//
+// The composition is deliberately thin, because both halves already exist:
+// the window boundary is `<foreign>` (the pane's window, embedded and laid
+// out like any child — docs/embedding.md), and the process boundary is a
+// forked node with `src/frame/child.js` as its entry. What this file owns is
+// the contract between them, and the contract is narrow on purpose:
+//
+//  - **`props` is a bag of data**, snapshotted per parent commit and sent
+//    whole (structured clone; `serialization: 'advanced'`). Functions in it
+//    become RPC stubs — fire and forget, one direction (src/frame/protocol.js).
+//  - **Context crosses only through the bridge** (src/frame/env.js):
+//    `createFrameContext` values, and the theme by default, because a pane
+//    that silently loses the app's palette looks broken in a way that
+//    indicts the whole feature. `bridge={false}` (or an allowlist) is the
+//    off switch that default owes.
+//  - **The pane owns its data and its animation.** Props are for queries,
+//    ids, ranges — an update is an IPC hop plus a child commit, the right
+//    cost for "show this now", the wrong one for driving a spinner at 60fps.
+//
+// What a process boundary is here, and is not: an uncaught throw, a leak or
+// a GC pause in the pane stays in the pane, and the shell's event loop never
+// waits for it. It is **not a security boundary** — the pane holds a
+// full-privilege connection to the same X server (docs/security.md), so
+// `<Frame>` contains a pane's *failures*, not its intentions.
+//
+// Lifecycle, from both sides: the child reports `ready` (→ `onStarted`,
+// and the embed), `fatal` (why the exit about to happen is one) and exit
+// (→ `onExit`, and `fallback` when the host did not ask for it). The host
+// closes a pane by message first — `useFrameClose` handlers run there —
+// and only escalates to signals when asked nicely stops working.
+
+import { fork } from 'node:child_process';
+import { isAbsolute } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react';
+
+import { FrameEnv } from './env.js';
+import { CallbackTable, PROTOCOL } from './protocol.js';
+
+const h = React.createElement;
+
+const CHILD = fileURLToPath(new URL('./child.js', import.meta.url));
+
+/**
+ * @typedef {object} FrameTransport The parent's end of the wire to a pane.
+ * @property {(msg: object) => void} send may throw when the channel is gone
+ * @property {(cb: (msg: object) => void) => () => void} onMessage
+ * @property {(cb: (info: { code: number|null, signal: string|null }) => void) => () => void} onExit
+ * @property {(signal: string) => void} [kill] escalation; absent on
+ *   transports with nothing to kill
+ * @property {number} [pid]
+ */
+
+/** The default transport: fork this package's child entry. `execArgv` is
+ * inherited, which is what carries a dev loader (tsx, the refresh loader)
+ * into the pane; a bundled app forks plain JS and needs none. */
+function forkTransport({ src, display }) {
+  const child = fork(CHILD, [], {
+    serialization: 'advanced',
+    // dev loaders (tsx, the refresh loader) follow into the pane; the test
+    // runner's own flags must not — `--test` in execArgv would run the pane
+    // entry as a test file
+    execArgv: process.execArgv.filter(
+      (a) => a !== '--test' && !a.startsWith('--test-'),
+    ),
+    env: {
+      ...process.env,
+      REACT_X11_FRAME: '1',
+      ...(display ? { DISPLAY: display } : {}),
+    },
+  });
+  void src; // resolved by the child from the hello, not from argv
+  return {
+    send: (msg) => {
+      if (!child.connected) throw new Error('the pane process is gone');
+      child.send(msg);
+    },
+    onMessage: (cb) => {
+      child.on('message', cb);
+      return () => child.off('message', cb);
+    },
+    onExit: (cb) => {
+      const onExit = (code, signal) => cb({ code, signal });
+      const onError = (err) =>
+        cb({ code: null, signal: null, error: err ?? null });
+      child.on('exit', onExit);
+      child.on('error', onError);
+      return () => {
+        child.off('exit', onExit);
+        child.off('error', onError);
+      };
+    },
+    kill: (signal) => {
+      try {
+        child.kill(signal);
+      } catch {
+        // already gone, which is what the signal was for
+      }
+    },
+    pid: child.pid,
+  };
+}
+
+function srcString(src) {
+  if (src !== null && typeof src === 'object' && typeof src.href === 'string') {
+    return src.href;
+  }
+  if (
+    typeof src === 'string' &&
+    (/^[a-z][a-z0-9+.-]*:/i.test(src) || isAbsolute(src))
+  ) {
+    return src;
+  }
+  throw new Error(
+    'react-x11: <Frame src> must be a URL or an absolute path — a relative ' +
+      "one would resolve against react-x11's own files, not yours. Pass " +
+      "src={new URL('./pane.js', import.meta.url)}.",
+  );
+}
+
+/** Bridged values are data; here is where that is enforced. A value that
+ * cannot cross is dropped with its key named — once — rather than taking
+ * the whole update down with a DataCloneError deep in a send. */
+const cloneable = new WeakSet();
+const warnedKeys = new Set();
+function bridgedEnv(env, bridge) {
+  if (bridge === false) return new Map();
+  const allow = Array.isArray(bridge) ? new Set(bridge) : null;
+  const out = new Map();
+  for (const [key, value] of env) {
+    if (allow && !allow.has(key)) continue;
+    if (value !== null && typeof value === 'object' && !cloneable.has(value)) {
+      try {
+        structuredClone(value);
+        cloneable.add(value);
+      } catch (err) {
+        if (!warnedKeys.has(key)) {
+          warnedKeys.add(key);
+          console.warn(
+            `react-x11: <Frame> cannot bridge context '${key}' ` +
+              `(${err.message}) — bridged values are data only; dispatchers ` +
+              'and other functions travel in props (docs/frame.md)',
+          );
+        }
+        continue;
+      }
+    } else if (typeof value === 'function') {
+      if (!warnedKeys.has(key)) {
+        warnedKeys.add(key);
+        console.warn(
+          `react-x11: <Frame> cannot bridge context '${key}': it is a ` +
+            'function — bridged values are data only (docs/frame.md)',
+        );
+      }
+      continue;
+    }
+    out.set(key, value);
+  }
+  return out;
+}
+
+/** One `Object.is` pass over the bag, so a parent that re-renders without
+ * touching the pane's inputs does not wake the pane. Inline handlers defeat
+ * it — a new closure is a new value — and that only costs the send. */
+function shallowEqual(a, b) {
+  if (a === b) return true;
+  const ak = Object.keys(a);
+  const bk = Object.keys(b);
+  if (ak.length !== bk.length) return false;
+  for (const k of ak) if (!Object.is(a[k], b[k])) return false;
+  return true;
+}
+
+const EMPTY_PROPS = {};
+
+/**
+ * A module of this application, mounted in its own process, its window
+ * embedded here.
+ *
+ * ```jsx
+ * <Frame
+ *   src={new URL('./charts.pane.js', import.meta.url)}
+ *   props={{ rows, range, onPick }}
+ *   style={{ flexGrow: 1, backgroundColor: '$surface' }}
+ *   fallback={({ error, restart }) => <Crashed error={error} onRetry={restart} />}
+ * />
+ * ```
+ *
+ * The pane module's default export is the component; it receives `props`
+ * (functions arrive as fire-and-forget stubs), under the bridged context
+ * providers. `ref` exposes `{ restart(), pid }`.
+ */
+export function Frame({
+  src,
+  props = EMPTY_PROPS,
+  style,
+  display,
+  bridge = true,
+  fallback,
+  focusable,
+  onStarted,
+  onExit,
+  transport,
+  ref,
+}) {
+  const env = useContext(FrameEnv);
+  const [state, setState] = useState({
+    phase: 'starting',
+    windowId: null,
+    error: null,
+  });
+  const [generation, setGeneration] = useState(0);
+  const session = useRef(null);
+  // the latest render's callbacks and bags, for the long-lived effect
+  const current = useRef(null);
+  current.current = { props, env, bridge, onStarted, onExit };
+
+  const restart = useCallback(() => {
+    setState({ phase: 'starting', windowId: null, error: null });
+    setGeneration((g) => g + 1);
+  }, []);
+  useImperativeHandle(ref, () => ({
+    restart,
+    get pid() {
+      return session.current?.transport?.pid ?? null;
+    },
+  }));
+
+  const source = srcString(src);
+  const makeTransport = transport ?? forkTransport;
+  const containerRef = useRef(null);
+
+  // The session: one child process per (src, display, transport, restart).
+  // Declared before the update effect so that on the mounting commit the
+  // hello goes out first and the update pass sees itself already sent.
+  useEffect(() => {
+    let alive = true;
+    const fail = (error) => {
+      if (!alive) return;
+      setState({ phase: 'failed', windowId: null, error });
+    };
+
+    let t;
+    try {
+      t = makeTransport({ src: source, display });
+    } catch (err) {
+      fail(Object.assign(err, { phase: 'spawn' }));
+      return undefined;
+    }
+    const s = {
+      transport: t,
+      table: new CallbackTable(),
+      closing: false,
+      fatal: null,
+      sent: null,
+      shutdown: null,
+    };
+    session.current = s;
+
+    const trySend = (msg) => {
+      try {
+        t.send(msg);
+        return true;
+      } catch (err) {
+        // hello or an update that would not serialize (or a channel that
+        // closed mid-send): the pane cannot follow the app from here
+        if (!s.closing) fail(Object.assign(err, { phase: 'send' }));
+        return false;
+      }
+    };
+    s.trySend = trySend;
+
+    // Both listeners live until the *exit*, not until the effect cleanup: a
+    // `useFrameClose` handler flushing through a callback prop sends its
+    // `invoke` after the unmount message, and dropping it would make the
+    // close hook useless for the one thing it is for.
+    let offMessage = t.onMessage((msg) => {
+      if (msg?.type === 'ready') {
+        if (!alive || s.closing) return;
+        setState({ phase: 'running', windowId: msg.windowId, error: null });
+        current.current.onStarted?.({
+          pid: t.pid ?? null,
+          windowId: msg.windowId,
+        });
+      } else if (msg?.type === 'invoke') {
+        s.table.invoke(msg.id, msg.args);
+      } else if (msg?.type === 'fatal') {
+        s.fatal = msg;
+      }
+    });
+
+    let clearEscalation = null;
+    let offExit = null;
+    const detach = () => {
+      offMessage?.();
+      offMessage = null;
+      offExit?.();
+      offExit = null;
+    };
+    offExit = t.onExit(({ code = null, signal = null, error } = {}) => {
+      clearEscalation?.();
+      detach();
+      const expected = s.closing;
+      if (alive && !expected) {
+        const f = s.fatal;
+        const err = Object.assign(
+          new Error(
+            f?.message ??
+              error?.message ??
+              `the pane exited (${signal ?? `code ${code}`})`,
+          ),
+          { phase: f?.phase ?? 'exit', code, signal },
+        );
+        if (f?.stack) err.stack = f.stack;
+        fail(err);
+      }
+      // Deliberately not gated on `alive`: the exit a graceful close ends in
+      // arrives *after* the unmount that asked for it, and `expected: true`
+      // would otherwise be an event no one can ever receive. The exit
+      // belongs to the session, not to the mounted lifetime.
+      current.current.onExit?.({ code, signal, expected });
+    });
+
+    // Ask first, signal later. The message lets `useFrameClose` handlers
+    // run and the root unmount cleanly; the signals are for a pane that
+    // stopped listening — which a crashed or wedged one has.
+    s.shutdown = () => {
+      if (s.closing) return;
+      s.closing = true;
+      let sent = false;
+      try {
+        t.send({ type: 'unmount' });
+        sent = true;
+      } catch {
+        // never came up, or already gone — straight to the signal
+      }
+      const term = setTimeout(() => t.kill?.('SIGTERM'), sent ? 1500 : 0);
+      const kill = setTimeout(() => t.kill?.('SIGKILL'), 4000);
+      term.unref?.();
+      kill.unref?.();
+      clearEscalation = () => {
+        clearTimeout(term);
+        clearTimeout(kill);
+      };
+    };
+
+    // The hello carries everything the first paint needs — above all the
+    // bridged theme, so the pane's first frame is in the app's palette
+    // rather than one frame of default before an update lands.
+    const { props: p, env: e, bridge: b } = current.current;
+    const node = containerRef.current;
+    const rect = {
+      width: Math.max(1, Math.round(node?.abs?.width || 0)) || 400,
+      height: Math.max(1, Math.round(node?.abs?.height || 0)) || 300,
+    };
+    s.sent = { props: p, env: e, bridge: b };
+    trySend({
+      type: 'hello',
+      protocol: PROTOCOL,
+      src: source,
+      display,
+      rect,
+      props: s.table.snapshot(p),
+      env: bridgedEnv(e, b),
+    });
+
+    return () => {
+      alive = false;
+      s.shutdown();
+      // the listeners and escalation timers outlive the effect on purpose:
+      // the listeners deliver what the close handlers still send and clear
+      // the escalation on exit, the timers bound a pane that ignores the
+      // ask, and everything is unref'd so nothing holds the host open
+      if (session.current === s) session.current = null;
+    };
+  }, [source, display, generation, makeTransport]);
+
+  // One update per commit that changed the pane's inputs, props and env in
+  // the same message — so a theme flip and the state change that caused it
+  // land in the child as one commit, not a torn pair.
+  useEffect(() => {
+    const s = session.current;
+    if (!s || s.closing || !s.sent) return;
+    if (
+      shallowEqual(s.sent.props, props) &&
+      s.sent.env === env &&
+      s.sent.bridge === bridge
+    ) {
+      return;
+    }
+    s.sent = { props, env, bridge };
+    s.trySend({
+      type: 'update',
+      props: s.table.snapshot(props),
+      env: bridgedEnv(env, bridge),
+    });
+  }, [props, env, bridge, generation]);
+
+  if (state.phase === 'running') {
+    return h('foreign', {
+      ref: containerRef,
+      windowId: state.windowId,
+      style,
+      ...(focusable === undefined ? {} : { focusable }),
+      onError: (err) => {
+        session.current?.shutdown?.();
+        setState({
+          phase: 'failed',
+          windowId: null,
+          error: Object.assign(err, { phase: 'embed' }),
+        });
+      },
+      // the exit path owns the state change; the window vanishing first is
+      // just the order X delivers the same death in
+      onClientGone: () => {},
+    });
+  }
+  const showFallback = state.phase === 'failed' && fallback !== undefined;
+  return h(
+    'box',
+    { ref: containerRef, style },
+    showFallback
+      ? typeof fallback === 'function'
+        ? fallback({ error: state.error, restart })
+        : fallback
+      : null,
+  );
+}

--- a/src/frame/lifecycle.js
+++ b/src/frame/lifecycle.js
@@ -1,0 +1,67 @@
+// The pane's side of the frame lifecycle — the two things a module loaded
+// into a `<Frame>` can ask about the world it landed in. Its own file so a
+// pane (and the components it imports) can use these without pulling in the
+// parent-side supervisor or the child bootstrap, neither of which belongs in
+// a bundle of UI code.
+
+import { useEffect } from 'react';
+
+/**
+ * Whether this process is a `<Frame>` pane. An environment fact rather
+ * than a hook, so a module can branch at load time — the usual reason to
+ * ask is "am I my own application?", and a pane module's
+ * `import.meta.main`-style autorun guard is where that question is asked.
+ *
+ * The env var is what the fork sets and what load-time code reads; the
+ * flag beside it is `runFrameChild` saying so directly, which is what
+ * makes a pane run behind a custom transport — no fork, no env — answer
+ * the same.
+ */
+let framed = false;
+export function isFramed() {
+  return framed || process.env.REACT_X11_FRAME === '1';
+}
+
+/** `runFrameChild`'s mark. Internal. */
+export function markFramed() {
+  framed = true;
+}
+
+/** What `runCloseHandlers` drains. Module state, like the compose table:
+ * one pane process has one close, however many components listen for it. */
+const closeHandlers = new Set();
+
+/**
+ * `handler` runs when the host is letting this pane go — the `<Frame>`
+ * unmounted, the host app is exiting — and the pane has a moment to flush
+ * what it would mind losing. It may return a promise; the host's patience
+ * is bounded (the parent escalates to SIGTERM), so "a moment" is meant
+ * literally: hundreds of milliseconds, not a sync.
+ *
+ * Not called when the pane crashes, and not called when the host is killed
+ * outright — a close handler is a courtesy, and anything that must survive
+ * a crash belongs on disk before the close.
+ *
+ * Outside a frame it registers nothing and the handler never runs.
+ */
+export function useFrameClose(handler) {
+  useEffect(() => {
+    if (!isFramed() || typeof handler !== 'function') return undefined;
+    closeHandlers.add(handler);
+    return () => closeHandlers.delete(handler);
+  }, [handler]);
+}
+
+/**
+ * Run every close handler, bounded by `timeout`. The bootstrap calls this
+ * on the `unmount` message, before unmounting the root — so a handler still
+ * has its tree, its connection and its state.
+ */
+export async function runCloseHandlers(timeout = 800) {
+  if (closeHandlers.size === 0) return;
+  const pending = [...closeHandlers].map(async (handler) => handler());
+  await Promise.race([
+    Promise.allSettled(pending),
+    new Promise((resolve) => setTimeout(resolve, timeout).unref?.()),
+  ]);
+}

--- a/src/frame/protocol.js
+++ b/src/frame/protocol.js
@@ -1,0 +1,179 @@
+// The wire between a `<Frame>` and its pane process. Pure data — no React,
+// no X11, no `child_process` — so the same protocol runs over node's IPC
+// channel (the fork transport), a loopback pair (the tests), or whatever a
+// custom transport is built on.
+//
+// Six messages, all objects with a `type`:
+//
+//   parent → child
+//     hello    { protocol, src, display, rect, props, env }   first, once
+//     update   { props, env }        full snapshots, one per parent commit
+//     unmount  {}                    run close handlers, unmount, exit
+//
+//   child → parent
+//     ready    { windowId }          the pane mounted; embed this
+//     invoke   { id, args }          a bridged callback fired
+//     fatal    { phase, message, stack }   why the exit about to happen is one
+//
+// Values cross by **structured clone** (fork uses `serialization:
+// 'advanced'`), so Dates, Maps, TypedArrays and cycles survive — and
+// functions do not, which is what the callback bridge is for: the parent
+// swaps each function in `props` for a `{ [CALLBACK]: id }` marker and keeps
+// the function; the child revives markers as stubs that send `invoke` back.
+// Fire and forget — a stub returns undefined, because a return value would
+// make every event handler an await and every await a frame of latency.
+//
+// Ids are **monotonic across updates**, never reused. The table keeps the
+// current snapshot's entries and the previous one's: React recreates handler
+// closures render to render, so a click that raced a props update arrives
+// with the previous snapshot's id and must still land — one snapshot of
+// grace covers the in-flight window, while an id from two updates ago is
+// dropped (with a warning) rather than delivered to the wrong function.
+// Functions the caller keeps stable (`useCallback`) keep their id, which is
+// what makes the grace window about racing messages rather than about how
+// the app was written.
+
+export const PROTOCOL = 1;
+
+/** The marker key a function in `props` becomes on the wire. */
+export const CALLBACK = '$$reactX11FrameCallback';
+
+const isPlainObject = (v) =>
+  v !== null &&
+  typeof v === 'object' &&
+  (Object.getPrototypeOf(v) === Object.prototype ||
+    Object.getPrototypeOf(v) === null);
+
+/**
+ * The parent's side of the callback bridge: give out wire snapshots of a
+ * props bag, answer `invoke` messages with the function each id stood for.
+ */
+export class CallbackTable {
+  constructor({ warn = console.warn } = {}) {
+    this._ids = new WeakMap(); // fn → id, stable across snapshots
+    this._seq = 0;
+    this._live = new Map(); // id → fn, the latest snapshot
+    this._prev = new Map(); // …and the one before it: the grace window
+    this._warn = warn;
+  }
+
+  /**
+   * Deep-copy `props` with every function replaced by its marker. Walks
+   * plain objects and arrays — a function buried in a `Map` value is not
+   * found, and the send will refuse the clone, which is the honest failure.
+   * Cycle-safe: a value already walked keeps one wire identity.
+   */
+  snapshot(props) {
+    const found = new Map();
+    const seen = new Map();
+    const walk = (value) => {
+      if (typeof value === 'function') {
+        let id = this._ids.get(value);
+        if (id === undefined) {
+          id = this._seq++;
+          this._ids.set(value, id);
+        }
+        found.set(id, value);
+        return { [CALLBACK]: id };
+      }
+      if (Array.isArray(value)) {
+        if (seen.has(value)) return seen.get(value);
+        const out = [];
+        seen.set(value, out);
+        for (const item of value) out.push(walk(item));
+        return out;
+      }
+      if (isPlainObject(value)) {
+        if (seen.has(value)) return seen.get(value);
+        const out = {};
+        seen.set(value, out);
+        for (const key of Object.keys(value)) out[key] = walk(value[key]);
+        return out;
+      }
+      return value;
+    };
+    const wire = walk(props);
+    this._prev = this._live;
+    this._live = found;
+    return wire;
+  }
+
+  /** Answer an `invoke` from the child. Returns whether an entry was found. */
+  invoke(id, args = []) {
+    const fn = this._live.get(id) ?? this._prev.get(id);
+    if (!fn) {
+      this._warn(
+        `react-x11: <Frame> dropped a callback (id ${id}) that outlived ` +
+          'two props updates — the child held a stub outside the props flow',
+      );
+      return false;
+    }
+    fn(...args);
+    return true;
+  }
+}
+
+/**
+ * The child's side: rebuild `props` with each marker replaced by a stub
+ * that sends `invoke(id, args)`. Same walk, other direction.
+ */
+export function reviveCallbacks(wire, invoke) {
+  const seen = new Map();
+  const walk = (value) => {
+    if (Array.isArray(value)) {
+      if (seen.has(value)) return seen.get(value);
+      const out = [];
+      seen.set(value, out);
+      for (const item of value) out.push(walk(item));
+      return out;
+    }
+    if (isPlainObject(value)) {
+      if (CALLBACK in value) {
+        const id = value[CALLBACK];
+        return (...args) => invoke(id, sanitizeArgs(args));
+      }
+      if (seen.has(value)) return seen.get(value);
+      const out = {};
+      seen.set(value, out);
+      for (const key of Object.keys(value)) out[key] = walk(value[key]);
+      return out;
+    }
+    return value;
+  };
+  return walk(wire);
+}
+
+/**
+ * Callback arguments, made sendable. A pane calls `onPick(item, ev)` the
+ * way it would call any handler, and `ev` is full of functions and node
+ * references — dropping what cannot cross (functions become `undefined`,
+ * everything else is kept) beats throwing away the whole call, which is
+ * what an unfiltered structured clone would do.
+ */
+export function sanitizeArgs(args) {
+  const seen = new Map();
+  const walk = (value) => {
+    if (typeof value === 'function') return undefined;
+    if (Array.isArray(value)) {
+      if (seen.has(value)) return seen.get(value);
+      const out = [];
+      seen.set(value, out);
+      for (const item of value) out.push(walk(item));
+      return out;
+    }
+    if (isPlainObject(value)) {
+      if (seen.has(value)) return seen.get(value);
+      const out = {};
+      seen.set(value, out);
+      for (const key of Object.keys(value)) {
+        const walked = walk(value[key]);
+        if (walked !== undefined || value[key] === undefined) {
+          out[key] = walked;
+        }
+      }
+      return out;
+    }
+    return value;
+  };
+  return args.map(walk);
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,6 +16,7 @@ export * from './types/events.js';
 export * from './types/nodes.js';
 export * from './types/elements.js';
 export * from './types/components.js';
+export * from './types/frame.js';
 export * from './types/globalmenu.js';
 export * from './types/dbus.js';
 export * from './types/application.js';

--- a/src/index.js
+++ b/src/index.js
@@ -89,6 +89,14 @@ export {
   Canvas3D,
 } from './components/index.js';
 
+// A pane of this application in its own process, and the context bridge
+// that follows the app into it (docs/frame.md). `useFrameClose`/`isFramed`
+// are the pane's side, exported here so a module can be a pane and an
+// application with one import.
+export { Frame } from './frame/index.js';
+export { createFrameContext } from './frame/env.js';
+export { isFramed, useFrameClose } from './frame/lifecycle.js';
+
 import { createRoot } from './Reconciler.js';
 
 export default { createRoot };

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -8004,6 +8004,13 @@ export class WindowNode extends Scrollable(Node) {
    */
   _mapNow() {
     if (this.destroyed || !this.window || this.hidden) return;
+    // An `embeddable` window never maps itself: a window waiting to be
+    // embedded is unmapped — that is what waiting looks like — and from the
+    // reparent on, mapping is the embedder's decision (ntk's XEmbedSocket
+    // maps a plain client the moment it takes it). Self-mapping here would
+    // put a frame pane on the desktop as a top-level for the beat before
+    // its <Frame> embeds it, long enough for a window manager to frame it.
+    if (this.props.embeddable) return;
     // An anchor that is not on screen is a popup that has nowhere to be
     // (`_followAnchor`); it maps from there, when the anchor comes back.
     if (this._anchorLost) return;

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -266,6 +266,13 @@ export interface WindowProps
   /** Window title (UTF-8, via `WM_NAME` + `_NET_WM_NAME`). */
   title?: string;
   /**
+   * Created but never self-mapped: this window is waiting to be embedded
+   * (XEmbed / `<foreign>` on the other side), and from the reparent on,
+   * mapping is the embedder's decision. What a `<Frame>` pane's root window
+   * sets; without an embedder the window simply never appears.
+   */
+  embeddable?: boolean;
+  /**
    * Window geometry — window state, not yoga style: the user may resize.
    *
    * `'auto'`, which is also what leaving the prop out means, sizes the

--- a/src/types/frame.d.ts
+++ b/src/types/frame.d.ts
@@ -1,0 +1,146 @@
+/**
+ * `<Frame>` — a pane of this application in its own process — and the
+ * context bridge that follows the app into it. See docs/frame.md.
+ */
+
+import type { Context, ReactElement, ReactNode, Ref } from 'react';
+import type { StyleProp } from './style.js';
+
+/**
+ * The props bag a `<Frame>` sends its pane. Values cross by structured
+ * clone; functions become fire-and-forget stubs on the pane side, so a
+ * callback's return value is always `undefined` over there.
+ */
+export type FrameProps = Record<string, unknown>;
+
+/** Why a pane is not running, for `fallback` and `onExit` to read. */
+export interface FrameError extends Error {
+  /** Where it went wrong: `'spawn' | 'load' | 'connect' | 'handshake' |
+   * 'runtime' | 'send' | 'embed' | 'exit'`. */
+  phase?: string;
+  code?: number | null;
+  signal?: string | null;
+}
+
+export interface FrameHandle {
+  /** Start a fresh pane process; what `fallback` receives to retry with. */
+  restart(): void;
+  /** The pane's pid, `null` before the first spawn and after an exit. */
+  pid: number | null;
+}
+
+export interface FrameComponentProps {
+  /**
+   * The pane module: its default export is mounted as the pane's root
+   * component. A `URL` (`new URL('./pane.js', import.meta.url)` — typed
+   * structurally so no DOM lib is needed) or an absolute path — never
+   * relative, which would resolve against react-x11's own files rather
+   * than the caller's.
+   */
+  src: { href: string } | string;
+  /** Data for the pane, snapshotted and sent whole once per commit that
+   * changes it. Functions anywhere in the bag become RPC stubs. */
+  props?: FrameProps;
+  /** The embedded pane's rect in this tree — sized like any other child. */
+  style?: StyleProp;
+  /** X display for the pane process; defaults to the inherited `$DISPLAY`. */
+  display?: string;
+  /**
+   * Which bridged contexts follow the app into this pane: `true` (default)
+   * for every registered one — the theme included — `false` for none, or an
+   * allowlist of keys.
+   */
+  bridge?: boolean | string[];
+  /**
+   * What this rect shows when the pane crashed or could not start: an
+   * element, or a function of the error and a `restart` that respawns.
+   * Without one the rect is an empty box in its `style`.
+   */
+  fallback?:
+    | ReactElement
+    | ((info: { error: FrameError | null; restart: () => void }) => ReactNode);
+  /** Whether the pane joins the tab order, like any `<foreign>`. */
+  focusable?: boolean;
+  /** The pane mounted and its window is being embedded. */
+  onStarted?(info: { pid: number | null; windowId: number }): void;
+  /** The pane process ended. `expected` is true when this side asked —
+   * unmount, `restart()`, a `src` change — and false for a crash. */
+  onExit?(info: {
+    code: number | null;
+    signal: string | null;
+    expected: boolean;
+  }): void;
+  /**
+   * Replace the fork with a transport of your own — the seam the tests use
+   * (a loopback pair into `runFrameChild`), and the door to running a pane
+   * somewhere other than a child process. Advanced; see docs/frame.md.
+   */
+  transport?(options: { src: string; display?: string }): FrameTransport;
+  ref?: Ref<FrameHandle>;
+}
+
+/** The parent's end of the wire to a pane. */
+export interface FrameTransport {
+  /** May throw when the channel is gone or the message will not clone. */
+  send(msg: object): void;
+  onMessage(cb: (msg: object) => void): () => void;
+  onExit(
+    cb: (info: {
+      code?: number | null;
+      signal?: string | null;
+      error?: Error | null;
+    }) => void,
+  ): () => void;
+  kill?(signal: string): void;
+  pid?: number;
+}
+
+/**
+ * A module of this application, mounted in its own process, its window
+ * embedded here (over `<foreign>`). Props cross as data, callbacks as
+ * fire-and-forget stubs, context through the bridge — and the process
+ * boundary contains the pane's failures, not its intentions: it is not a
+ * security boundary (docs/security.md).
+ */
+export function Frame(props: FrameComponentProps): ReactElement | null;
+
+export interface FrameContext<T> {
+  /** The name this value travels under; unique per application. */
+  key: string;
+  /** The ordinary React context, for `useContext` and class consumers. */
+  Context: Context<T>;
+  /** The provider that also publishes the value to `<Frame>` panes. */
+  Provider: (props: { value: T; children?: ReactNode }) => ReactElement;
+  /** `useContext(Context)`, as a method. */
+  use(): T;
+}
+
+/**
+ * A React context whose value follows the app into its `<Frame>` panes:
+ * in-process an ordinary context, across a frame a structured-clone
+ * snapshot recreated as a real provider around the pane. One direction,
+ * data only — a value that will not clone is dropped with a warning, and
+ * dispatchers travel in `props` where the wiring is visible.
+ *
+ * Both sides must import the module that calls this — which the pane
+ * already does, since its components read the context from it.
+ */
+export function createFrameContext<T>(
+  key: string,
+  defaultValue: T,
+  options?: {
+    serialize?: (value: T) => unknown;
+    revive?: (wire: unknown) => T;
+  },
+): FrameContext<T>;
+
+/**
+ * Runs when the host is letting this pane go — the `<Frame>` unmounted,
+ * the host app is exiting — bounded by the host's patience (it escalates
+ * to signals). May return a promise. Not called on a crash; outside a
+ * frame it never runs.
+ */
+export function useFrameClose(handler: () => void | Promise<void>): void;
+
+/** Whether this process is a `<Frame>` pane. */
+export function isFramed(): boolean;

--- a/test/fixtures/frame-contexts.js
+++ b/test/fixtures/frame-contexts.js
@@ -1,0 +1,6 @@
+// The shared-module half of a frame context: the app imports this to
+// provide, the pane imports it to read, and the import is what registers
+// the key on both sides — identity by construction (src/frame/env.js).
+import { createFrameContext } from '../../src/frame/env.js';
+
+export const Session = createFrameContext('test:session', { user: null });

--- a/test/fixtures/frame-pane.js
+++ b/test/fixtures/frame-pane.js
@@ -1,0 +1,36 @@
+// The pane the frame tests mount: reports what reached it (props, bridged
+// theme, bridged context) through a bridged callback, crashes on demand,
+// and flushes through a callback from its close handler. Boxes only — no
+// text — so the forked variant needs no fonts on the machine.
+import React, { useEffect } from 'react';
+
+import { useTheme } from '../../src/components/theme.js';
+import { useFrameClose } from '../../src/frame/lifecycle.js';
+import { Session } from './frame-contexts.js';
+
+const h = React.createElement;
+
+export default function Pane({ label, crash, onReport, onClosed }) {
+  if (crash) throw new Error('pane asked to crash');
+  const theme = useTheme();
+  const session = Session.use();
+  useFrameClose(() => {
+    // the second argument is full of functions on purpose: what arrives is
+    // what sanitizeArgs let through
+    onClosed?.('closing', { flush: () => {} });
+  });
+  const accent = theme.accent;
+  const user = session?.user ?? null;
+  useEffect(() => {
+    onReport?.(
+      { label: label ?? null, accent, user },
+      {
+        preventDefault: () => {},
+        kept: 'yes',
+      },
+    );
+  }, [label, accent, user, onReport]);
+  return h('box', {
+    style: { flexGrow: 1, backgroundColor: accent },
+  });
+}

--- a/test/fixtures/frame-pane.js
+++ b/test/fixtures/frame-pane.js
@@ -30,7 +30,14 @@ export default function Pane({ label, crash, onReport, onClosed }) {
       },
     );
   }, [label, accent, user, onReport]);
+  // `$accent` on purpose: the *node* route. The report above carries the
+  // context route's answer; the pixels this paints carry the planted-theme
+  // route's, and a theme update has to move both (issue: a framed pane
+  // whose Button re-coloured while its $token background stayed). The
+  // margin bares a band of the pane's *window*, whose background follows
+  // the palette on its own — the third route, and the one that only works
+  // when the bridge plants the palette on the window itself.
   return h('box', {
-    style: { flexGrow: 1, backgroundColor: accent },
+    style: { flexGrow: 1, margin: 6, backgroundColor: '$accent' },
   });
 }

--- a/test/frame-example.test.js
+++ b/test/frame-example.test.js
@@ -1,0 +1,92 @@
+// examples/frame.jsx, kept honest headlessly: the pane runs behind the
+// example's transport seam (a loopback into runFrameChild), and the same
+// module runs inline — the comparison the example exists to make. The
+// interesting number both ways is `onStats`: the pane really painted, and
+// it says which process it painted in.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import React from 'react';
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient } from 'ntk';
+
+import { createRoot } from '../src/index.js';
+import { loopbackFrameFactory } from './helpers/frame-loopback.js';
+
+// before the example is imported: its autorun block connects to a real
+// display otherwise, which is the example working as designed
+process.env.REACT_X11_NO_AUTORUN = '1';
+
+const { App } = await import('../examples/frame.jsx');
+
+const h = React.createElement;
+
+async function headlessPair() {
+  const server = xserver.createServer({ width: 1280, height: 800 });
+  // no fontSource: the example is full of text, so fonts come from
+  // fontconfig, the way the monitor and chat example tests already do
+  const connect = async () => {
+    const [serverEnd, clientEnd] = xserver.createStreamPair();
+    server.addClientStream(serverEnd);
+    return createClient({ stream: clientEnd, onXError: () => {} });
+  };
+  return { server, app: await connect(), other: await connect() };
+}
+
+const render = (element, x11Root) =>
+  new Promise((resolve) => x11Root.render(element, resolve));
+
+const settle = (app) =>
+  new Promise((resolve) => app.X.GetInputFocus(() => setImmediate(resolve)));
+
+async function until(app, predicate, what, { tries = 600, delay = 3 } = {}) {
+  for (let i = 0; i < tries; i++) {
+    if (await predicate()) return;
+    await settle(app);
+    await new Promise((resolve) => setTimeout(resolve, delay));
+  }
+  assert.fail(`timed out waiting for ${what}`);
+}
+
+async function teardown(x11Root, app, other) {
+  await x11Root.unmount().catch(() => {});
+  await settle(app);
+  await app.close();
+  await other.close();
+}
+
+test('the example runs its pane behind the seam, and the stats flow back', async () => {
+  const { app, other } = await headlessPair();
+  const x11Root = await createRoot({ app });
+  const factory = loopbackFrameFactory({ childApp: other });
+  const stats = [];
+  try {
+    await render(
+      h(App, { frameTransport: factory, onStats: (s) => stats.push(s) }),
+      x11Root,
+    );
+    await until(app, () => stats.length >= 1, 'the pane stats');
+    assert.equal(typeof stats[0].ms, 'number');
+    assert.ok(stats[0].pixels > 0);
+    assert.equal(factory.sessions.length, 1);
+  } finally {
+    await teardown(x11Root, app, other);
+  }
+});
+
+test('the same module runs inline', async () => {
+  const { app, other } = await headlessPair();
+  const x11Root = await createRoot({ app });
+  const stats = [];
+  try {
+    await render(
+      h(App, { initialFramed: false, onStats: (s) => stats.push(s) }),
+      x11Root,
+    );
+    await until(app, () => stats.length >= 1, 'the inline stats');
+    // inline means this process: the pane's own pid is the proof
+    assert.equal(stats[0].pid, process.pid);
+  } finally {
+    await teardown(x11Root, app, other);
+  }
+});

--- a/test/frame.test.js
+++ b/test/frame.test.js
@@ -1,0 +1,432 @@
+// <Frame>: a pane of the application in its own process (docs/frame.md).
+//
+// Three altitudes, because the feature is three claims:
+//
+//  - The **protocol** is pure and is tested pure: callback ids survive the
+//    updates they should and not the ones they should not, and what a stub's
+//    arguments lose crossing the wire is exactly the functions.
+//  - The **pane lifecycle** runs end to end in this process, over the
+//    transport seam `<Frame transport>` exists for: a real module import, a
+//    real second root on a second connection to the in-process X server, a
+//    real embed — with `structuredClone` on every message so nothing
+//    crosses here that would not survive the fork's serialization.
+//  - The **fork** is real once: a child process, the default transport, a
+//    TCP bridge onto the same in-process server — because the seam covers
+//    everything except the boundary itself.
+import assert from 'node:assert/strict';
+import net from 'node:net';
+import { test } from 'node:test';
+
+import React from 'react';
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient, StaticFontSource } from 'ntk';
+
+import { createRoot } from '../src/index.js';
+import { Frame } from '../src/frame/index.js';
+import {
+  CallbackTable,
+  reviveCallbacks,
+  sanitizeArgs,
+} from '../src/frame/protocol.js';
+import { ThemeProvider } from '../src/components/theme.js';
+import { Session } from './fixtures/frame-contexts.js';
+import { loopbackFrameFactory } from './helpers/frame-loopback.js';
+
+const h = React.createElement;
+
+const PANE = new URL('./fixtures/frame-pane.js', import.meta.url);
+
+// ---------------------------------------------------------------- protocol
+
+test('callback ids: stable for stable functions, one update of grace', () => {
+  const warnings = [];
+  const table = new CallbackTable({ warn: (msg) => warnings.push(msg) });
+  const stable = () => {};
+  let hits = [];
+  const first = table.snapshot({ keep: stable, drop: () => hits.push('old') });
+  const keepId = first.keep.$$reactX11FrameCallback;
+  const dropId = first.drop.$$reactX11FrameCallback;
+  assert.equal(typeof keepId, 'number');
+
+  const second = table.snapshot({ keep: stable, next: () => {} });
+  // a function the app kept keeps its id…
+  assert.equal(second.keep.$$reactX11FrameCallback, keepId);
+  // …and one from the previous snapshot still lands: the grace window
+  assert.equal(table.invoke(dropId), true);
+  assert.deepEqual(hits, ['old']);
+
+  table.snapshot({ keep: stable });
+  // two snapshots later it is gone, with a warning rather than a wrong call
+  assert.equal(table.invoke(dropId), false);
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /outlived two props updates/);
+});
+
+test('revive + sanitize: stubs call home, functions do not cross back', () => {
+  const table = new CallbackTable();
+  const got = [];
+  const wire = structuredClone(
+    table.snapshot({
+      deep: { list: [{ onPick: (row, ev) => got.push({ row, ev }) }] },
+    }),
+  );
+  const sent = [];
+  const revived = reviveCallbacks(wire, (id, args) => {
+    sent.push({ id, args });
+    table.invoke(id, args);
+  });
+  revived.deep.list[0].onPick(42, { preventDefault: () => {}, kept: 'yes' });
+  assert.equal(got.length, 1);
+  assert.equal(got[0].row, 42);
+  assert.equal(got[0].ev.kept, 'yes');
+  // the function was dropped, not the object around it
+  assert.equal('preventDefault' in got[0].ev, false);
+  // and what went over the wire was already clean
+  assert.equal(typeof sent[0].args[1], 'object');
+});
+
+test('sanitizeArgs keeps cycles and non-function leaves', () => {
+  const ring = { name: 'a', fn: () => {} };
+  ring.self = ring;
+  const [clean] = sanitizeArgs([ring]);
+  assert.equal(clean.name, 'a');
+  assert.equal(clean.self, clean);
+  assert.equal('fn' in clean, false);
+  // …and survives the clone the transport will apply
+  structuredClone(clean);
+});
+
+// ------------------------------------------------------ in-process pane
+
+async function headlessPair() {
+  const server = xserver.createServer({ width: 640, height: 480 });
+  const connect = async (onXError) => {
+    const [serverEnd, clientEnd] = xserver.createStreamPair();
+    server.addClientStream(serverEnd);
+    return createClient({
+      stream: clientEnd,
+      fontSource: new StaticFontSource(),
+      onXError,
+    });
+  };
+  const xErrors = [];
+  return {
+    server,
+    xErrors,
+    app: await connect((err) => xErrors.push(err)),
+    other: await connect(() => {}),
+  };
+}
+
+const render = (element, x11Root) =>
+  new Promise((resolve) => x11Root.render(element, resolve));
+
+const settle = (app) =>
+  new Promise((resolve) => app.X.GetInputFocus(() => setImmediate(resolve)));
+
+/** Drain until `predicate` (possibly async) holds. */
+async function until(app, predicate, what, { tries = 400, delay = 2 } = {}) {
+  for (let i = 0; i < tries; i++) {
+    if (await predicate()) return;
+    await settle(app);
+    await new Promise((resolve) => setTimeout(resolve, delay));
+  }
+  assert.fail(`timed out waiting for ${what}`);
+}
+
+const queryTree = (app, wid) =>
+  new Promise((resolve, reject) =>
+    app.X.QueryTree(wid, (err, tree) => (err ? reject(err) : resolve(tree))),
+  );
+
+const alive = (app, wid) =>
+  new Promise((resolve) => app.X.GetGeometry(wid, (err) => resolve(!err)));
+
+async function teardown(x11Root, app, other) {
+  await x11Root.unmount().catch(() => {});
+  await settle(app);
+  await app.close();
+  await other.close();
+}
+
+test('a pane runs behind the seam: props, callbacks, theme, context, close', async () => {
+  const { app, other } = await headlessPair();
+  const x11Root = await createRoot({ app });
+  const factory = loopbackFrameFactory({ childApp: other });
+  const reports = [];
+  const closed = [];
+  const exits = [];
+  const started = [];
+  const onReport = (data, extras) => reports.push({ data, extras });
+  const onClosed = (word, extras) => closed.push({ word, extras });
+
+  const tree = ({ label, accent, mounted = true }) =>
+    h(
+      'window',
+      { width: 320, height: 240 },
+      h(
+        ThemeProvider,
+        { value: { accent } },
+        h(
+          Session.Provider,
+          { value: { user: 'ada' } },
+          mounted
+            ? h(Frame, {
+                src: PANE,
+                transport: factory,
+                props: { label, onReport, onClosed },
+                style: { flexGrow: 1 },
+                onStarted: (info) => started.push(info),
+                onExit: (info) => exits.push(info),
+              })
+            : h('box', {}),
+        ),
+      ),
+    );
+
+  try {
+    const instance = await render(
+      tree({ label: 'one', accent: '#123456' }),
+      x11Root,
+    );
+
+    await until(app, () => reports.length >= 1, 'the first report');
+    // props, the bridged theme and the bridged context all arrived in the
+    // pane's first paint-worth of state — no default-theme frame first
+    assert.deepEqual(reports[0].data, {
+      label: 'one',
+      accent: '#123456',
+      user: 'ada',
+    });
+    // callback args crossed sanitized: the function is gone, the data kept
+    assert.equal(reports[0].extras.kept, 'yes');
+    assert.equal('preventDefault' in reports[0].extras, false);
+    // `ready` races the pane's own first effects (children's effects run
+    // first), so the started event is waited for, not assumed
+    await until(app, () => started.length === 1, 'onStarted');
+    assert.equal(typeof started[0].windowId, 'number');
+
+    // the pane's window really is inside ours: toplevel → container → pane
+    let paneWid = null;
+    await until(
+      app,
+      async () => {
+        const top = await queryTree(app, instance.id);
+        if (top.children.length !== 1) return false;
+        const container = await queryTree(app, top.children[0]);
+        if (container.children.length !== 1) return false;
+        paneWid = container.children[0];
+        return true;
+      },
+      'the pane window inside the container',
+    );
+    assert.equal(paneWid, started[0].windowId);
+
+    // a props change is one update; so is a theme change, through the env
+    await render(tree({ label: 'two', accent: '#123456' }), x11Root);
+    await until(
+      app,
+      () => reports.some((r) => r.data.label === 'two'),
+      'the props update',
+    );
+    await render(tree({ label: 'two', accent: '#654321' }), x11Root);
+    await until(
+      app,
+      () => reports.some((r) => r.data.accent === '#654321'),
+      'the theme update',
+    );
+
+    // unmount: close handlers flush through callbacks, then a clean exit
+    await render(
+      tree({ label: 'two', accent: '#654321', mounted: false }),
+      x11Root,
+    );
+    const done = await factory.sessions[0].done;
+    assert.equal(done.code, 0);
+    assert.equal(closed.length, 1);
+    assert.equal(closed[0].word, 'closing');
+    assert.equal('flush' in closed[0].extras, false);
+    await until(app, () => exits.length === 1, 'the exit event');
+    assert.equal(exits[0].expected, true);
+    assert.equal(factory.sessions[0].kills.length, 0);
+    // the pane window belonged to the pane's root, which unmounted
+    await until(
+      app,
+      async () => !(await alive(app, paneWid)),
+      'the pane window to be destroyed by its own root',
+    );
+  } finally {
+    await teardown(x11Root, app, other);
+  }
+});
+
+test('a crash shows the fallback; restart() gets a fresh pane', async () => {
+  const { app, other } = await headlessPair();
+  const x11Root = await createRoot({ app });
+  const factory = loopbackFrameFactory({ childApp: other });
+  const reports = [];
+  const exits = [];
+  const fallbacks = [];
+  const handle = React.createRef();
+
+  const tree = ({ crash }) =>
+    h(
+      'window',
+      { width: 320, height: 240 },
+      h(Frame, {
+        ref: handle,
+        src: PANE,
+        transport: factory,
+        props: { label: 'boom', crash, onReport: (d) => reports.push(d) },
+        style: { flexGrow: 1 },
+        fallback: ({ error, restart }) => {
+          fallbacks.push({ message: error?.message, phase: error?.phase });
+          return h('box', { style: { flexGrow: 1 } });
+        },
+        onExit: (info) => exits.push(info),
+      }),
+    );
+
+  try {
+    await render(tree({ crash: true }), x11Root);
+    await until(app, () => exits.length === 1, 'the crash exit');
+    assert.equal(exits[0].expected, false);
+    assert.equal(factory.sessions[0].exitCode, 1);
+    await until(app, () => fallbacks.length >= 1, 'the fallback render');
+    assert.match(fallbacks[0].message, /pane asked to crash/);
+    assert.equal(fallbacks[0].phase, 'runtime');
+
+    // stop crashing, then ask the handle for a fresh pane
+    await render(tree({ crash: false }), x11Root);
+    handle.current.restart();
+    await until(app, () => reports.length >= 1, 'the pane after restart');
+    assert.equal(reports[0].label, 'boom');
+    assert.equal(factory.sessions.length, 2);
+  } finally {
+    await teardown(x11Root, app, other);
+  }
+});
+
+test('a src that does not resolve fails as load, not as a hang', async () => {
+  const { app, other } = await headlessPair();
+  const x11Root = await createRoot({ app });
+  const factory = loopbackFrameFactory({ childApp: other });
+  const errors = [];
+  try {
+    await render(
+      h(
+        'window',
+        { width: 200, height: 100 },
+        h(Frame, {
+          src: '/frame-pane-that-does-not-exist.js',
+          transport: factory,
+          style: { flexGrow: 1 },
+          fallback: ({ error }) => {
+            errors.push(error);
+            return null;
+          },
+        }),
+      ),
+      x11Root,
+    );
+    await until(app, () => errors.length >= 1, 'the load failure');
+    assert.equal(errors[0].phase, 'load');
+    assert.equal(factory.sessions[0].exitCode, 1);
+  } finally {
+    await teardown(x11Root, app, other);
+  }
+});
+
+// ------------------------------------------------------------- real fork
+
+/** The in-process server, listening where a real display would: the child
+ * process connects to `127.0.0.1:<n>` and lands on the same server the
+ * parent reached over a stream pair. */
+async function tcpDisplay(server) {
+  const bridge = net.createServer((socket) => server.addClientStream(socket));
+  for (let n = 91; n <= 99; n++) {
+    const ok = await new Promise((resolve) => {
+      bridge.once('error', () => resolve(false));
+      bridge.listen(6000 + n, '127.0.0.1', () => resolve(true));
+    });
+    if (ok) return { bridge, display: `127.0.0.1:${n}` };
+  }
+  throw new Error('no free port for the frame fork test');
+}
+
+test('the default transport forks a real pane process', async () => {
+  const { app, other, server } = await headlessPair();
+  const x11Root = await createRoot({ app });
+  const { bridge, display } = await tcpDisplay(server);
+  const reports = [];
+  const exits = [];
+  const started = [];
+
+  const tree = (mounted) =>
+    h(
+      'window',
+      { width: 320, height: 240 },
+      h(
+        ThemeProvider,
+        { value: { accent: '#abcdef' } },
+        h(
+          Session.Provider,
+          { value: { user: 'grace' } },
+          mounted
+            ? h(Frame, {
+                src: PANE,
+                display,
+                props: {
+                  label: 'forked',
+                  onReport: (data) => reports.push(data),
+                },
+                style: { flexGrow: 1 },
+                onStarted: (info) => started.push(info),
+                onExit: (info) => exits.push(info),
+              })
+            : h('box', {}),
+        ),
+      ),
+    );
+
+  try {
+    const instance = await render(tree(true), x11Root);
+    await until(app, () => reports.length >= 1, 'the forked pane report', {
+      tries: 4000,
+      delay: 5,
+    });
+    // theme and context crossed a real process boundary
+    assert.deepEqual(reports[0], {
+      label: 'forked',
+      accent: '#abcdef',
+      user: 'grace',
+    });
+    await until(app, () => started.length === 1, 'the forked onStarted', {
+      tries: 4000,
+      delay: 5,
+    });
+    assert.equal(typeof started[0].pid, 'number');
+    await until(
+      app,
+      async () => {
+        const top = await queryTree(app, instance.id);
+        if (top.children.length !== 1) return false;
+        const container = await queryTree(app, top.children[0]);
+        return container.children.length === 1;
+      },
+      'the forked pane window inside the container',
+      { tries: 4000, delay: 5 },
+    );
+
+    await render(tree(false), x11Root);
+    await until(app, () => exits.length === 1, 'the forked pane exit', {
+      tries: 4000,
+      delay: 5,
+    });
+    assert.equal(exits[0].expected, true);
+    assert.equal(exits[0].code, 0);
+  } finally {
+    bridge.close();
+    await teardown(x11Root, app, other);
+  }
+});

--- a/test/frame.test.js
+++ b/test/frame.test.js
@@ -21,6 +21,7 @@ import React from 'react';
 import xserver from 'x11/lib/xserver/index.js';
 import { createClient, StaticFontSource } from 'ntk';
 
+import { captureDrawable, rgbAt } from '../scripts/capture.js';
 import { createRoot } from '../src/index.js';
 import { Frame } from '../src/frame/index.js';
 import {
@@ -160,13 +161,13 @@ test('a pane runs behind the seam: props, callbacks, theme, context, close', asy
   const onReport = (data, extras) => reports.push({ data, extras });
   const onClosed = (word, extras) => closed.push({ word, extras });
 
-  const tree = ({ label, accent, mounted = true }) =>
+  const tree = ({ label, accent, background, mounted = true }) =>
     h(
       'window',
       { width: 320, height: 240 },
       h(
         ThemeProvider,
-        { value: { accent } },
+        { value: { accent, background } },
         h(
           Session.Provider,
           { value: { user: 'ada' } },
@@ -186,7 +187,7 @@ test('a pane runs behind the seam: props, callbacks, theme, context, close', asy
 
   try {
     const instance = await render(
-      tree({ label: 'one', accent: '#123456' }),
+      tree({ label: 'one', accent: '#123456', background: '#204060' }),
       x11Root,
     );
 
@@ -222,18 +223,59 @@ test('a pane runs behind the seam: props, callbacks, theme, context, close', asy
     );
     assert.equal(paneWid, started[0].windowId);
 
+    // Three routes, three pixels/values: useTheme() (the report above),
+    // `$accent` on a box (the node route, read mid-pane), and the pane
+    // *window's* own background (read in the band the box's margin bares —
+    // it follows the palette only if the bridge planted the palette on the
+    // window itself, which is the bug this pins). The first frame must
+    // already be in the bridged palette on all three.
+    const paneRgb = async (x, y) => {
+      const shot = await captureDrawable(app, paneWid);
+      return rgbAt(shot, x, y ?? Math.floor(shot.height / 2));
+    };
+    await until(
+      app,
+      async () => String(await paneRgb(30)) === '18,52,86', // box: #123456
+      'the $accent background in the bridged palette',
+    );
+    await until(
+      app,
+      async () => String(await paneRgb(1, 1)) === '32,64,96', // window: #204060
+      'the pane window background in the bridged palette',
+    );
+
     // a props change is one update; so is a theme change, through the env
-    await render(tree({ label: 'two', accent: '#123456' }), x11Root);
+    await render(
+      tree({ label: 'two', accent: '#123456', background: '#204060' }),
+      x11Root,
+    );
     await until(
       app,
       () => reports.some((r) => r.data.label === 'two'),
       'the props update',
     );
-    await render(tree({ label: 'two', accent: '#654321' }), x11Root);
+    await render(
+      tree({ label: 'two', accent: '#654321', background: '#402010' }),
+      x11Root,
+    );
     await until(
       app,
       () => reports.some((r) => r.data.accent === '#654321'),
       'the theme update',
+    );
+    // …and the same update must move the $token paint and the window's own
+    // background, not only useTheme(): the planted-theme route is what a
+    // pane's static styles resolve through (the bug: a framed pane whose
+    // Button re-coloured while its background and static text stayed)
+    await until(
+      app,
+      async () => String(await paneRgb(30)) === '101,67,33', // #654321
+      'the $accent background following the theme update',
+    );
+    await until(
+      app,
+      async () => String(await paneRgb(1, 1)) === '64,32,16', // #402010
+      'the pane window background following the theme update',
     );
 
     // unmount: close handlers flush through callbacks, then a clean exit

--- a/test/helpers/frame-loopback.js
+++ b/test/helpers/frame-loopback.js
@@ -1,0 +1,101 @@
+// A `<Frame>` transport that runs the pane in this process — the seam the
+// component was given for exactly this (docs/frame.md). The pane is real:
+// `runFrameChild`, a real module import, a real root on a second connection
+// to the in-process X server. Only the process boundary is simulated, and
+// its one observable property — values cross by copy — is kept honest by
+// `structuredClone` on every message, so a props bag that would not survive
+// the fork's serialization does not survive this either.
+
+import { runFrameChild } from '../../src/frame/childmain.js';
+
+/**
+ * A transport factory to pass as `<Frame transport>`. Each spawn runs
+ * `runFrameChild` against `childApp` (a borrowed connection) and appears in
+ * `factory.sessions` with its `done` promise, recorded kills, and exit code.
+ */
+export function loopbackFrameFactory({ childApp }) {
+  const sessions = [];
+  const factory = ({ src, display }) => {
+    const parentInbox = { queue: [], handlers: new Set() };
+    const childInbox = { queue: [], handlers: new Set() };
+    const exitListeners = new Set();
+    const disconnectListeners = new Set();
+
+    const deliver = (inbox, msg) => {
+      const wire = structuredClone(msg);
+      queueMicrotask(() => {
+        if (inbox.handlers.size === 0) inbox.queue.push(wire);
+        else for (const cb of [...inbox.handlers]) cb(wire);
+      });
+    };
+    const attach = (inbox, cb) => {
+      inbox.handlers.add(cb);
+      if (inbox.queue.length) {
+        const drained = inbox.queue.splice(0);
+        queueMicrotask(() => {
+          for (const msg of drained) {
+            for (const handler of [...inbox.handlers]) handler(msg);
+          }
+        });
+      }
+      return () => inbox.handlers.delete(cb);
+    };
+
+    const session = {
+      src,
+      display,
+      exitCode: null,
+      exitSignal: null,
+      kills: [],
+    };
+    let settle;
+    session.done = new Promise((resolve) => {
+      settle = (code, signal) => {
+        if (session.exitCode !== null || session.exitSignal !== null) return;
+        session.exitCode = code;
+        session.exitSignal = signal ?? null;
+        resolve({ code, signal: signal ?? null });
+        queueMicrotask(() => {
+          for (const cb of [...exitListeners]) {
+            cb({ code, signal: signal ?? null });
+          }
+        });
+      };
+    });
+
+    session.child = runFrameChild(
+      {
+        send: (msg) => deliver(parentInbox, msg),
+        onMessage: (cb) => attach(childInbox, cb),
+        onDisconnect: (cb) => {
+          disconnectListeners.add(cb);
+          return () => disconnectListeners.delete(cb);
+        },
+      },
+      {
+        exit: (code) => settle(code, null),
+        rootOptions: { app: childApp },
+        trapProcessErrors: false,
+      },
+    );
+    session.child.catch(() => {});
+
+    session.transport = {
+      send: (msg) => deliver(childInbox, msg),
+      onMessage: (cb) => attach(parentInbox, cb),
+      onExit: (cb) => {
+        exitListeners.add(cb);
+        return () => exitListeners.delete(cb);
+      },
+      kill: (signal) => {
+        session.kills.push(signal);
+        if (signal === 'SIGKILL') settle(null, 'SIGKILL');
+      },
+      pid: 4242,
+    };
+    sessions.push(session);
+    return session.transport;
+  };
+  factory.sessions = sessions;
+  return factory;
+}

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -1423,3 +1423,53 @@ const _engine: Promise<unknown> = loadLayout().then(() => {
 });
 // the flat enum constants are numbers
 const _edge: number = LayoutYoga.EDGE_LEFT;
+
+// `<Frame>` — a pane in its own process (docs/frame.md), and the context
+// that follows the app into it.
+import { Frame, createFrameContext, isFramed, useFrameClose } from 'react-x11';
+import type { FrameError, FrameHandle, FrameTransport } from 'react-x11';
+
+const Session = createFrameContext('session', { user: null as string | null });
+const _sessionValue: { user: string | null } = Session.use();
+
+function _Panes() {
+  const handle = useRef<FrameHandle>(null);
+  useFrameClose(async () => {});
+  const framed: boolean = isFramed();
+  return (
+    <Session.Provider value={{ user: 'me' }}>
+      <window>
+        <Frame
+          ref={handle}
+          src="/abs/path/to/pane.js"
+          props={{ rows: [1, 2, 3], onPick: (row: number) => void row }}
+          style={{ flexGrow: 1 }}
+          bridge={['react-x11:theme', 'session']}
+          fallback={({ error, restart }) => (
+            <text onMouseDown={restart}>
+              {error?.message ?? String(framed)}
+            </text>
+          )}
+          onStarted={({ pid, windowId }) => void [pid, windowId]}
+          onExit={({ code, signal, expected }) => void [code, signal, expected]}
+        />
+        {/* an embeddable window never maps itself */}
+        <window embeddable width={200} height={100} />
+      </window>
+    </Session.Provider>
+  );
+}
+// a custom transport is the test seam; the shape is public
+const _loopback: FrameTransport = {
+  send: () => {},
+  onMessage: () => () => {},
+  onExit: () => () => {},
+};
+const _err: FrameError = Object.assign(new Error('x'), { phase: 'load' });
+// @ts-expect-error — src is required
+const _badFrame = <Frame props={{}} />;
+void _Panes;
+void _loopback;
+void _err;
+void _badFrame;
+void _sessionValue;


### PR DESCRIPTION
`<Frame src>` mounts a module of the application in a **process of its own** and embeds its window as an ordinary laid-out child — this renderer's iframe. The window half already existed (`<foreign>`, XEmbed); the process half is a forked node; this PR is the narrow contract between them, and the machinery stays split along that seam.

## The contract

- **`props` is a bag of data** — structured clone (`serialization: 'advanced'`), one message per parent commit that changed it (shallow `Object.is` gate), props and bridged context in the same message so a theme flip and the state change that caused it land as one commit, not a torn pair.
- **Functions in the bag become fire-and-forget stubs** — a lightweight RPC: ids are monotonic and follow function identity (`useCallback` keeps its id), with **one update of grace** so a click racing a props change still lands; arguments are sanitized (functions dropped, data kept) so `onPick(item, ev)` survives `ev` being full of methods.
- **Context crosses only through the bridge** (`createFrameContext`, a key + a module both sides import — the import is the registration, so identity needs no wiring). **The theme crosses by default**: a `ThemeProvider` above a `<Frame>` reaches the pane as a real provider — both routes, `useTheme()` and `$token` — in the pane's *first* commit. `bridge={false | [keys]}` is the off switch the default owes. Bridged values are **data only**: a value that won't clone is dropped with its key named, and dispatchers travel in `props` where the wiring is visible.
- **Lifecycle, both sides**: `onStarted({pid, windowId})`, `onExit({code, signal, expected})` (fires even after unmount — the exit a graceful close ends in always arrives after the unmount that asked for it), `fallback({error, restart})` with `error.phase` (`spawn/load/connect/handshake/runtime/send/embed/exit`), `ref → {restart(), pid}`. Pane side: `useFrameClose(handler)` — runs on the ask, may flush through callback props (host listeners deliberately outlive the effect cleanup until the exit), bounded by message → SIGTERM 1.5s → SIGKILL 4s; `isFramed()`. A host that dies takes the IPC channel, and the pane exits on the disconnect — no orphans either way.
- Said plainly in the docs: **not a security boundary** — the pane holds a full-privilege connection to the same X server. It contains a pane's failures, not its intentions.

## Core changes

- **`<window embeddable>`** (one guard in `_mapNow()`): created but never self-mapped — a window waiting to be embedded is unmapped, and ntk's `XEmbedSocket` maps a plain client the moment it takes it. No WM race, no flash.
- `ThemeProvider` publishes its complete merged palette into the frame env (`react-x11:theme`) and registers the pane-side provider.
- Everything else is new files under `src/frame/`: `protocol.js` (pure), `env.js` (the bridge), `index.js` (host + supervisor + fork transport), `childmain.js`/`child.js` (pane bootstrap behind an injectable transport). Two ordering decisions are commented at length: the update listener goes up **before** the pane module import starts (a store, so no update is dropped during the slow import), and the module is imported **before** the root is created (a typo'd `src` should not cost an X connection or misreport as a connect error).

## Tests

`test/frame.test.js`, `test/frame-example.test.js` — headless, no `$DISPLAY`:

- protocol pure: id stability, the grace window, sanitize round-trips;
- the pane end-to-end **in-process over the transport seam** — real module import, real second root on a second connection to the in-process X server, real embed (`QueryTree`: toplevel → container → pane), props/theme/context updates, close handlers flushing through callbacks, crash → fallback → `restart()`, load-failure phase;
- **one real fork**: the default transport, the in-process server bridged onto TCP (`127.0.0.1:9x`), theme and a `createFrameContext` value crossing an actual process boundary, graceful exit 0 on unmount. (`forkTransport` strips `--test*` from the inherited `execArgv` so the runner's flags don't turn the pane entry into a test file.)

## Example, verified live

`npm run examples:frame` — a Mandelbrot pane computing several hundred ms per frame, and a host ticker that freezes only when *your* process is busy: run the same module framed, then inline (one click), and watch the difference. Also on show: the pane printing which pid it computes in, dark/light crossing the boundary, crash → fallback → restart. Verified on Xvfb end to end, including a live toplevel resize propagating host → container → pane ConfigureNotify → recompute at the new size.

Docs: `docs/frame.md` (the page), cross-links from `embedding.md`/`elements.md`, `AGENTS.md` layout entry, hand-written `.d.ts` + type-test lines per the house rule.

## Known gaps (named in the docs)

AT-SPI: a pane registers as its own app on the a11y bus. DevTools attach per process. No intrinsic sizing (host decides the rect; a `measure` message could exist later). The embeddable window speaks plain reparenting, not the `_XEMBED` message half — focus works through `<foreign>`'s forwarding rules; an ntk `XEmbedPlug` would upgrade both this and embeddability in GTK/Qt sockets.
