### PR TITLE
fix(popup): a popup that declares nothing is a popup_menu, and the sheets say dropdown_menu

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -795,8 +795,11 @@ real dialog does not close because you clicked elsewhere.
 The [`Dialog`](components.md#dialog) component does exactly this, and takes
 `managed={false}` to go back to the override-redirect shape.
 
-Defaults to `windowType="dropdown_menu"`; pass `windowType` to override
-(`"tooltip"`, `"popup_menu"`, …). The hint is **additive** — override-
+Defaults to `windowType="popup_menu"` — the least-wrong answer for a popup
+that declares nothing; pass `windowType` to say what yours is
+(`"tooltip"`, `"dropdown_menu"`, …). The built-in widgets do:
+`Select`'s and `DatePicker`'s sheets are `dropdown_menu`, `Tooltip` is
+`tooltip`. The hint is **additive** — override-
 redirect is what keeps the WM from moving or decorating the popup, and
 stays on. The EWMH spec asks for the type hint on override-redirect
 windows too, so compositing managers can give menus and tooltips

--- a/src/components/DatePicker.js
+++ b/src/components/DatePicker.js
@@ -246,6 +246,8 @@ export function DatePicker({
           y: anchor.y,
           width,
           height,
+          // a sheet dropping from a control, same as `Select`'s
+          windowType: 'dropdown_menu',
           grab: true,
           onDismiss: close,
           // ARGB where the display has it, so the corners the sheet gives up

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -395,6 +395,9 @@ export function Select({
           y: anchor.y,
           width: anchor.width,
           height: menuHeight + 2,
+          // what this sheet *is* to the compositor: a menu dropping from a
+          // control, not the bare `<popup>` default of `popup_menu`
+          windowType: 'dropdown_menu',
           grab: true,
           onDismiss: close,
           // ARGB where the display has it, so the corners the sheet gives up

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -10030,13 +10030,16 @@ export class PopupNode extends WindowNode {
     // The EWMH type hint is additive — the spec asks for it on
     // override-redirect windows too, so compositing managers can give menus
     // and tooltips consistent shadows/animations. `windowType` overrides the
-    // default (e.g. "tooltip", "popup_menu").
+    // default (e.g. "tooltip", "dropdown_menu"); `popup_menu` is the
+    // least-wrong answer for a popup that declares nothing, and the widgets
+    // that know better say so themselves — `Select`'s sheet is a
+    // `dropdown_menu`, a `Tooltip` a `tooltip` (issue #298).
     super(
       app,
       {
         ...attributes,
         overrideRedirect: attributes.overrideRedirect ?? true,
-        windowType: attributes.windowType ?? 'dropdown_menu',
+        windowType: attributes.windowType ?? 'popup_menu',
       },
       props,
     );

--- a/test/calendar.test.js
+++ b/test/calendar.test.js
@@ -343,6 +343,9 @@ test('a DatePicker opens its calendar on the press and closes on the pick', asyn
   });
   await settle();
   assert.strictEqual(cells(app).length, 42, 'the press alone opened it');
+  // the sheet names its EWMH type: a menu dropping from a control, same as
+  // Select's (issue #298)
+  assert.strictEqual(app.windows[1].attributes.windowType, 'dropdown_menu');
 
   click(app, cells(app)[cellOf(12)]);
   await settle();

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -759,7 +759,7 @@ test('popup mounts as an override-redirect window and unmounts cleanly', async (
   // the EWMH type hint is additive — override-redirect still keeps the WM
   // from moving or decorating the menu; the hint only lets compositing
   // managers style it consistently (wm-spec asks for it on o-r windows)
-  assert.strictEqual(popup.attributes.windowType, 'dropdown_menu');
+  assert.strictEqual(popup.attributes.windowType, 'popup_menu');
   assert.deepStrictEqual([popup.attributes.x, popup.attributes.y], [300, 150]);
   assert.strictEqual(popup.mapped, true);
 
@@ -1313,6 +1313,8 @@ test('Select opens a popup menu, picks an option, closes on Escape', async () =>
   assert.strictEqual(app.windows.length, 2, 'menu popup window created');
   const popup = app.windows[1];
   assert.strictEqual(popup.attributes.overrideRedirect, true);
+  // a menu dropping from a control, and it says so (issue #298)
+  assert.strictEqual(popup.attributes.windowType, 'dropdown_menu');
   assert.strictEqual(popup.attributes.width, trigger.abs.width);
   await tick();
 
@@ -2578,7 +2580,7 @@ test('a <popup> can opt out of override-redirect and be WM-managed', async () =>
     true,
     'menus keep the default that makes them menus',
   );
-  assert.strictEqual(menu.attributes.windowType, 'dropdown_menu');
+  assert.strictEqual(menu.attributes.windowType, 'popup_menu');
   assert.strictEqual(dialog.attributes.overrideRedirect, false);
   assert.strictEqual(dialog.attributes.windowType, 'dialog');
 


### PR DESCRIPTION
## What

Finishes #298. Most of what the issue asks for had already shipped in #37 — the `windowType` prop on `<popup>`, the creation (`createWindow({ windowType })`) and update (`setWindowType`) paths, and the widget defaults (`Menu`/edit menu → `popup_menu`, `Tooltip` → `tooltip`, `Dialog` → `dialog`) — so the issue's core claim ("nothing passes it") was already stale. What genuinely remained:

- **A bare `<popup>` defaulted to `dropdown_menu`**, which is only the right EWMH label for a sheet dropping from a control. It now defaults to `popup_menu` — the least-wrong general answer for an override-redirect popup, as the issue suggests.
- **`Select` and `DatePicker` leaned on that class default** for their (correct) `dropdown_menu`. They now declare it explicitly, so the semantic stays put now that the bare default has moved.

Docs updated (`docs/elements.md`; the website reference copy is regenerated by `sync-docs`).

## Verification

- Updated the two smoke assertions pinning the bare default, added assertions for `Select`'s and `DatePicker`'s sheets. Mutation-checked: reverting the default in `src/nodes.js` fails the smoke test, restoring it passes.
- Full suite passes locally except the known macOS-only `appearance.test.js` baseline (`macos:dark` vs `xsettings`), which is unrelated.
- Checked on a real display (XQuartz): a bare `<popup>`'s window reads back `_NET_WM_WINDOW_TYPE(ATOM) = _NET_WM_WINDOW_TYPE_POPUP_MENU` via `xprop`.

Out of scope, as the issue itself notes: override-redirect stacking (the companion VisibilityNotify issue) and the downstream `@react-x11/components` chart tooltip (different repo; it already gets `tooltip` when built on `<Tooltip>`).

Closes #298