### PR TITLE
fix(window): the WM close button asks, instead of killing the connection

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -166,7 +166,7 @@ A real X11 window; the flex, paint and event root for its subtree.
 | `backgroundColor`           | full-window clear color (default white)                                                                                                                                                                 |
 | `onResize(ev)`              | ConfigureNotify — the tree reflows automatically. Fires for **moves** too (see below)                                                                                                                   |
 | `onExpose(ev)`              | after a repaint was required                                                                                                                                                                            |
-| `onCloseRequest(ev)`        | WM close button (opts into `WM_DELETE_WINDOW`)                                                                                                                                                          |
+| `onCloseRequest(ev)`        | WM close button — replaces the default answer (see below); `WM_DELETE_WINDOW` is advertised either way                                                                                                  |
 | `states`                    | EWMH `_NET_WM_STATE` — controlled, see below                                                                                                                                                            |
 | `fullscreen`, `alwaysOnTop` | boolean sugar for two of those states                                                                                                                                                                   |
 | `decorations`               | `false` asks the WM for no titlebar or border                                                                                                                                                           |
@@ -456,6 +456,50 @@ and returns a getter, like `useAnchor`.
 Xfwm, Openbox and i3. A window manager that ignores it simply decorates the
 window; there is no way to force the matter.
 
+### Closing a window
+
+Every window the window manager manages advertises `WM_DELETE_WINDOW` in
+`WM_PROTOCOLS`, whether or not you pass `onCloseRequest`. That property is
+what lets the WM _ask_ a window to close; a client without it can only be
+shot, so the close button becomes `XKillClient` — the connection dies
+mid-frame, effects never clean up, and IceWM asks the user to confirm the
+kill first. Advertising it is not an opt-in feature, it is the difference
+between closing and crashing, so react-x11 does it for you.
+
+Windows the WM does not frame never advertise it, because nothing would read
+it: a child `<window>` (a region inside another window) and an
+override-redirect `<popup>`. A [managed `<popup>`](#a-managed-popup-is-a-dialog)
+is a real dialog and does.
+
+What a close request _does_ is the part you can change:
+
+|                     |                                                                                                                                                                           |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| no `onCloseRequest` | the **primary window** unmounts the tree and closes the connection — effects clean up and the process ends on a drained loop. Any other window refuses, and warns in dev. |
+| `onCloseRequest`    | nothing happens except your handler: `setOpen(false)` for a dialog, a "save your work?" prompt, `root.unmount()` for a quit of your own.                                  |
+
+The primary window is inferred, not declared: the first top-level `<window>`
+that is not `transientFor` another and has no `windowType` of its own. A
+one-window app — nearly every app — is unambiguous, and a lone window is the
+app whatever type it declares.
+
+The refusal for secondary windows is deliberate. A `{open && <window/>}` was
+opened by a `setOpen(true)` somewhere, and closing it behind React's back
+would leave a window the app still believes is open and can never reopen. So
+a dialog wants a handler:
+
+```jsx
+{
+  showSettings && (
+    <window
+      title="Settings"
+      transientFor={main}
+      onCloseRequest={() => setShowSettings(false)}
+    />
+  );
+}
+```
+
 ### Window state
 
 `states` is EWMH `_NET_WM_STATE`: `modal`, `sticky`, `maximized` (or
@@ -534,7 +578,7 @@ Three things worth knowing:
 - **`preventDefault()` stops react-x11 acting on the message itself**, which
   today means XDND — for a window answering the drag protocol on its own
   terms. It does not cover the WM close button; `onCloseRequest` is that
-  seam, and it opts into `WM_DELETE_WINDOW` as well as handling it.
+  seam.
 
 Sending is `useApp().X.SendClientMessage(destination, aboutWindow, atom,
 format, data, eventMask)`, or ntk's `window.sendClientMessage(name, data)`

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -757,7 +757,7 @@ export async function createRoot(options = {}) {
   // is seeded from disk and the ladder runs when something asks.
   const stopAppearance = watchAppearance(() => appearanceChanged(app));
 
-  return {
+  const root = {
     app,
     render(element, callback) {
       // The provider wraps rather than replaces: it renders no host node, so
@@ -801,6 +801,15 @@ export async function createRoot(options = {}) {
         unregisterApp(app);
         await app.close();
       }
+      if (app._reactX11Root === root) app._reactX11Root = null;
     },
   };
+
+  // What a WM close request with no onCloseRequest unmounts (see
+  // WindowNode#_defaultCloseRequest). The first root wins, because it is the
+  // one whose window the request will be arriving on; a second root sharing a
+  // borrowed connection owns its own teardown either way.
+  app._reactX11Root ??= root;
+
+  return root;
 }

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -101,7 +101,7 @@ import {
   devCheckA11yProps,
   hasClickHandler,
 } from './a11y.js';
-import { windowIdOf } from './windowid.js';
+import { topLevelWindows, windowIdOf } from './windowid.js';
 import { paintCacheFor } from './paintcache.js';
 import { hooks as traceHooks } from './trace-registry.js';
 import { runWithPriority, DiscreteEventPriority } from './priority.js';
@@ -7940,7 +7940,7 @@ export class WindowNode extends Scrollable(Node) {
     ];
     wnd.measure ??= (callback) => callback?.(0, 0, wnd.width, wnd.height, 0, 0);
     wnd.ownerDocument ??= DEVTOOLS_FAKE_DOCUMENT;
-    this._attachWindowListeners();
+    this._attachWindowListeners(parentWindow);
     for (const child of this.children) {
       if (child.isWindow && !child.isPopup) {
         child.realize(wnd);
@@ -8508,7 +8508,12 @@ export class WindowNode extends Scrollable(Node) {
     return WINDOW_SEMANTIC_NAMES;
   }
 
-  _attachWindowListeners() {
+  /**
+   * `parentWindow` is realize()'s, and only the close handshake reads it:
+   * whether the window manager frames this window decides whether
+   * WM_DELETE_WINDOW means anything on it.
+   */
+  _attachWindowListeners(parentWindow) {
     const wnd = this.window;
     if (typeof wnd.on !== 'function') return;
     wnd.on('resize', (ev) => {
@@ -8617,19 +8622,28 @@ export class WindowNode extends Scrollable(Node) {
         });
       });
     }
-    // WM close button: with an onCloseRequest prop the window opts into the
-    // WM_DELETE_WINDOW protocol and the handler decides what happens
-    // (unmount, hide, quit). Without it the WM default stands (the server
-    // kills the connection). Opt-in is decided at realize time.
+    // WM close button. Armed for every window the window manager actually
+    // manages, prop or no prop, because the alternative is not "no close
+    // handling" but a killed connection: a client with no WM_DELETE_WINDOW
+    // in WM_PROTOCOLS cannot be *asked* to close, so XKillClient is the only
+    // move the WM has left. Effects never clean up, and IceWM puts a "do you
+    // want to kill this client?" dialog in front of the user first. Every
+    // other toolkit arms this unconditionally for the same reason; making it
+    // the prop's side effect only moved that trap one level up.
+    //
+    // Not armed where the property is dead weight, which is every window the
+    // WM does not frame: a child <window> (a region inside another window)
+    // and an override-redirect <popup>. A `<popup overrideRedirect={false}>`
+    // is a real dialog and does get it.
     //
     // ntk >= 5.3 owns the protocol: listening for 'close' self-arms
     // WM_PROTOCOLS and decodes the ClientMessage (#160). Its default action
     // — destroy the window — is always prevented, because what happens next
-    // is this handler's decision, and usually a React unmount: ntk tearing
-    // the window down underneath the reconciler is exactly what the prop
-    // exists to avoid. This also leaves the raw 'message' stream free for
-    // protocols react-x11 speaks itself (XDND, src/dnd.js).
-    if (this.props.onCloseRequest) {
+    // is React's decision: ntk tearing the window down underneath the
+    // reconciler is exactly what this handler exists to avoid. This also
+    // leaves the raw 'message' stream free for protocols react-x11 speaks
+    // itself (XDND, src/dnd.js).
+    if (!parentWindow && this.attributes?.overrideRedirect !== true) {
       wnd.on(
         'close',
         // a WM close is a user action: discrete priority and a discrete
@@ -8642,11 +8656,82 @@ export class WindowNode extends Scrollable(Node) {
           runWithPriority(DiscreteEventPriority, () => {
             const handler = this.props.onCloseRequest;
             if (handler) callHandler(this, 'onCloseRequest', handler, ev);
+            else this._defaultCloseRequest();
           });
         }),
       );
     }
     this.events.attach();
+  }
+
+  /**
+   * A close request nobody handled — `onCloseRequest` is the override, this
+   * is what happens without one.
+   *
+   * Closing the app's primary window closes the app, which is what the
+   * button means everywhere else on the desktop. The tree unmounts and the
+   * connection closes, so effects clean up and the process ends on a drained
+   * loop rather than on a dead socket.
+   *
+   * Any other top-level window is a dialog or a satellite, and whether it
+   * goes away is app state this renderer cannot write: a `{open && <window/>}`
+   * was opened by a `setOpen(true)` somewhere, and unmapping it behind
+   * React's back would leave a window the app still believes is open and can
+   * never reopen. So the request is refused, and in dev it is said out loud —
+   * an inert close button is a bug, but a recoverable one, where guessing at
+   * the app's state is not.
+   */
+  _defaultCloseRequest() {
+    if (this._isPrimaryWindow()) {
+      // fire and forget: unmount() is async (it awaits the connection
+      // closing) and a WM close request is answered synchronously or not at
+      // all. Errors reach the app's own handler, never an unhandled rejection.
+      Promise.resolve(this.app?._reactX11Root?.unmount?.()).catch((err) => {
+        this.app?.options?.onXError?.(err);
+      });
+      return;
+    }
+    if (DEV && !this._warnedNoCloseHandler) {
+      this._warnedNoCloseHandler = true;
+      console.warn(
+        'react-x11: the window manager asked <window%s> to close, and it has ' +
+          "no onCloseRequest — so nothing happened. Only the app's primary " +
+          'window closes the app by default; a second window is opened by ' +
+          'app state and only app state can close it.',
+        this.props.title ? ` title=${JSON.stringify(this.props.title)}` : '',
+      );
+    }
+  }
+
+  /**
+   * Whether this is the window whose close button means "quit".
+   *
+   * Inferred, not declared, because the tree already says it. A window that
+   * is somebody's `transientFor` is a dialog *of* that window, and one with
+   * an EWMH type of its own (`dialog`, `utility`, `splash`, …) has already
+   * announced it is not the main window; what is left, in creation order, is
+   * the app. That is the same rule startup.js uses to decide which window
+   * carries the launch id, and for one-window apps — nearly all of them — it
+   * is not a heuristic at all.
+   *
+   * A lone window is the app whatever it calls itself: an app whose only
+   * window is a `utility` still has to be closable. An app that disagrees
+   * with any of this passes `onCloseRequest`, which never reaches here.
+   */
+  _isPrimaryWindow() {
+    const tops = topLevelWindows(this.app);
+    if (!tops.includes(this)) return false;
+    const candidates = tops.filter((node) => node._isPrimaryCandidate());
+    if (candidates.length === 0) return tops.length === 1;
+    return candidates[0] === this;
+  }
+
+  /** Top-level, nobody's dialog, and of no special type: a main-window shape. */
+  _isPrimaryCandidate() {
+    if (this.props.transientFor != null) return false;
+    const type = this.props.windowType;
+    const plain = (t) => t == null || t === 'normal';
+    return Array.isArray(type) ? plain(type[0]) : plain(type);
   }
 
   /** Child <window>s in the order they should stack, bottom to top: the same

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -398,7 +398,25 @@ export interface WindowProps
    * costs nothing.
    */
   onStatesChange?: (states: WindowStateName[]) => void;
-  /** The WM close button; opts the window into `WM_DELETE_WINDOW`. */
+  /**
+   * The window manager's close button, and anything else that asks a window
+   * to close (Alt+F4, a taskbar's "Close", `wmctrl -c`).
+   *
+   * Every WM-managed window speaks `WM_DELETE_WINDOW` whether or not this
+   * prop is passed — without it the window manager cannot ask at all and
+   * kills the connection instead. This prop replaces the default answer:
+   *
+   * - **without it** the app's primary window unmounts the tree and closes
+   *   the connection, and any other window refuses (a dialog is opened by
+   *   app state, so only app state can close it — dev warns).
+   * - **with it** nothing happens except this handler, which decides:
+   *   `setOpen(false)` for a dialog, a "save your work?" prompt, or
+   *   `root.unmount()` for a quit of your own.
+   *
+   * The primary window is the first top-level `<window>` that is not
+   * `transientFor` another and has no `windowType` of its own — a lone
+   * window always qualifies.
+   */
   onCloseRequest?: (ev: SyntheticEvent<NtkWindow>) => void;
   /**
    * Every ClientMessage addressed to this window — the carrier of EWMH,

--- a/test/window-close.test.js
+++ b/test/window-close.test.js
@@ -1,0 +1,275 @@
+// The WM close handshake: which windows advertise WM_DELETE_WINDOW, and what
+// happens to a close request no `onCloseRequest` answered.
+//
+// The arming half is asserted through `defaultPrevented`: react-x11 always
+// prevents ntk's default (destroying the window under the reconciler), so a
+// close event that comes back prevented is one a listener received, and an
+// untouched one is a window that never armed the protocol.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import { createRoot } from '../src/index.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+function closeEvent() {
+  const ev = {
+    name: 'close',
+    time: 0,
+    defaultPrevented: false,
+    preventDefault() {
+      ev.defaultPrevented = true;
+    },
+  };
+  return ev;
+}
+
+/** Run `fn` with console.warn captured. */
+async function withWarnings(fn) {
+  const warnings = [];
+  const original = console.warn;
+  console.warn = (...args) => warnings.push(args.join(' '));
+  try {
+    await fn();
+  } finally {
+    console.warn = original;
+  }
+  return warnings;
+}
+
+test('a lone window arms WM_DELETE_WINDOW with no onCloseRequest', async () => {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(React.createElement('window', { width: 100, height: 80 }));
+  await tick();
+
+  const ev = closeEvent();
+  app.windows[0].emit('close', ev);
+  await tick();
+
+  assert.strictEqual(
+    ev.defaultPrevented,
+    true,
+    'the window is listening, so the WM can ask instead of killing us',
+  );
+});
+
+test('closing the primary window unmounts the tree', async () => {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  const cleaned = [];
+  function App() {
+    React.useEffect(() => () => cleaned.push('effect'), []);
+    return React.createElement('window', { width: 100, height: 80 });
+  }
+  root.render(React.createElement(App));
+  await tick();
+  const wnd = app.windows[0];
+
+  wnd.emit('close', closeEvent());
+  await tick();
+
+  assert.strictEqual(wnd.destroyed, true, 'the window went away');
+  assert.deepStrictEqual(
+    cleaned,
+    ['effect'],
+    'effects cleaned up — the whole point of not being XKillClient-ed',
+  );
+});
+
+test('onCloseRequest replaces the default: no unmount unless it says so', async () => {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  const seen = [];
+  root.render(
+    React.createElement('window', {
+      width: 100,
+      height: 80,
+      onCloseRequest: () => seen.push('asked'),
+    }),
+  );
+  await tick();
+  const wnd = app.windows[0];
+
+  wnd.emit('close', closeEvent());
+  await tick();
+
+  assert.deepStrictEqual(seen, ['asked']);
+  assert.strictEqual(
+    wnd.destroyed,
+    false,
+    'the handler decides; a window that ignores the request stays open',
+  );
+});
+
+test('a second window refuses rather than guessing at app state', async () => {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(
+    React.createElement(
+      React.Fragment,
+      null,
+      React.createElement('window', { width: 100, height: 80, title: 'main' }),
+      React.createElement('window', { width: 90, height: 70, title: 'second' }),
+    ),
+  );
+  await tick();
+  assert.strictEqual(app.windows.length, 2);
+  const [main, second] = app.windows;
+
+  const warnings = await withWarnings(async () => {
+    second.emit('close', closeEvent());
+    await tick();
+  });
+
+  assert.strictEqual(second.destroyed, false, 'not closed behind React');
+  assert.strictEqual(main.destroyed, false, 'and the app did not quit');
+  assert.strictEqual(warnings.length, 1, 'said out loud in dev');
+  assert.match(warnings[0], /onCloseRequest/);
+  assert.match(warnings[0], /second/, 'names the window that went inert');
+
+  // repeated clicks are one piece of news, not a running commentary
+  const again = await withWarnings(async () => {
+    second.emit('close', closeEvent());
+    await tick();
+  });
+  assert.deepStrictEqual(again, []);
+});
+
+test('closing the primary window still quits with a second window open', async () => {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(
+    React.createElement(
+      React.Fragment,
+      null,
+      React.createElement('window', { width: 100, height: 80, title: 'main' }),
+      React.createElement('window', { width: 90, height: 70, title: 'second' }),
+    ),
+  );
+  await tick();
+
+  app.windows[0].emit('close', closeEvent());
+  await tick();
+
+  assert.strictEqual(app.windows[0].destroyed, true);
+  assert.strictEqual(
+    app.windows[1].destroyed,
+    true,
+    'the satellite goes with the app it belonged to',
+  );
+});
+
+test('a dialog is not the primary window; the plain one behind it is', async () => {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  // declared in dialog-first order, so ordering alone would get this wrong
+  root.render(
+    React.createElement(
+      React.Fragment,
+      null,
+      React.createElement('window', {
+        width: 90,
+        height: 70,
+        title: 'dialog',
+        windowType: 'dialog',
+      }),
+      React.createElement('window', { width: 100, height: 80, title: 'main' }),
+    ),
+  );
+  await tick();
+  const [dialog, main] = app.windows;
+
+  await withWarnings(async () => {
+    dialog.emit('close', closeEvent());
+    await tick();
+  });
+  assert.strictEqual(main.destroyed, false, 'a dialog closing is not a quit');
+
+  main.emit('close', closeEvent());
+  await tick();
+  assert.strictEqual(main.destroyed, true, 'the plain window is the app');
+});
+
+test('a lone window is the app whatever type it declares', async () => {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(
+    React.createElement('window', {
+      width: 100,
+      height: 80,
+      windowType: 'utility',
+    }),
+  );
+  await tick();
+
+  app.windows[0].emit('close', closeEvent());
+  await tick();
+
+  assert.strictEqual(
+    app.windows[0].destroyed,
+    true,
+    'a one-window app has to be closable however it labels its window',
+  );
+});
+
+test('windows the WM does not frame never arm the protocol', async () => {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(
+    React.createElement(
+      'window',
+      { width: 300, height: 200, title: 'main' },
+      // a region: a real X subwindow, but inside the frame, with no close
+      // button of its own
+      React.createElement('window', { width: 50, height: 50, x: 10, y: 10 }),
+      // a menu: override-redirect, so the WM does not manage it either
+      React.createElement('popup', { width: 60, height: 40 }),
+    ),
+  );
+  await tick();
+  const [, child, popup] = app.windows;
+
+  for (const [what, wnd] of [
+    ['child <window>', child],
+    ['<popup>', popup],
+  ]) {
+    const ev = closeEvent();
+    wnd.emit('close', ev);
+    await tick();
+    assert.strictEqual(
+      ev.defaultPrevented,
+      false,
+      `${what} has no close listener: the property would be dead weight`,
+    );
+  }
+});
+
+test('a WM-managed popup is a dialog and does arm', async () => {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  const seen = [];
+  root.render(
+    React.createElement(
+      'window',
+      { width: 300, height: 200, title: 'main' },
+      React.createElement('popup', {
+        width: 60,
+        height: 40,
+        overrideRedirect: false,
+        grab: false,
+        onCloseRequest: () => seen.push('asked'),
+      }),
+    ),
+  );
+  await tick();
+
+  const popup = app.windows[app.windows.length - 1];
+  const ev = closeEvent();
+  popup.emit('close', ev);
+  await tick();
+
+  assert.strictEqual(ev.defaultPrevented, true);
+  assert.deepStrictEqual(seen, ['asked']);
+});


### PR DESCRIPTION
## The bug

Closing a react-x11 window through the window manager kills the connection
instead of asking the app to close. Under IceWM the user gets a confirmation
dialog first:

> **Kill Client: react-x11** — WARNING! All unsaved changes will be lost when
> this client is killed. Do you wish to proceed?

Other window managers do the same thing without asking, which is why this
looked like an IceWM quirk rather than a missing handshake.

## Why

A window only ever receives `WM_DELETE_WINDOW` if it advertised it in
`WM_PROTOCOLS`. react-x11 advertised it as a *side effect* of passing
`onCloseRequest`, so a window without the prop never got the property, and
the WM's only remaining move was `XKillClient`.

Traced on a live IceWM session (`Xvfb` + icewm 4.0, clicking the real
titlebar button through XTEST, reading the property off the window):

| example | `WM_PROTOCOLS` | clicking ✕ |
| --- | --- | --- |
| `examples/simple.jsx` | `<not set>` | Kill Client dialog, connection killed |
| `examples/windows.jsx` (has the prop) | `[WM_DELETE_WINDOW]` | closes cleanly |

**30 of the 32 windowed examples** never pass the prop — and neither does any
app whose author did not read that far. ntk is not at fault: listening for
`'close'` self-arms the protocol correctly, react-x11 just did it
conditionally.

## The change

Arm the protocol for every window the window manager actually frames, prop or
no prop. It is the difference between closing and crashing, not a feature to
opt into — every other toolkit arms it unconditionally.

Windows the WM does not frame stay out of it, because nothing would read the
property: a child `<window>` (a region inside another window) and an
override-redirect `<popup>`. A `<popup overrideRedirect={false}>` is a real
dialog and does get it.

What a close request does when no `onCloseRequest` answers it:

- **the app's primary window** unmounts the tree and closes the connection —
  effects clean up and the process ends on a drained loop, rather than on a
  dead socket;
- **any other window** refuses, and says so in dev. A `{open && <window/>}`
  was opened by a `setOpen(true)` somewhere, and closing it behind React's
  back would leave a window the app still believes is open and can never
  reopen.

`onCloseRequest` is unchanged, and remains the override for everything else.

## "Which window is the main one?"

`<window>` is also dialogs, satellites and regions, so the default action
needs to know which window is the app. No new prop: the tree already says it.

The primary window is the first top-level `<window>` that is nobody's
`transientFor` and has no `windowType` of its own — the same rule
`startup.js` already uses to decide which window carries the launch id. A
one-window app, which is nearly all of them, is unambiguous rather than
heuristic, and a lone window qualifies whatever type it declares. An app that
disagrees passes `onCloseRequest`, which never reaches the default at all.

## Verified

- New `test/window-close.test.js` (9 tests): arming, the primary-window
  unmount, effect cleanup, the secondary-window refusal and its one-shot
  warning, dialog-first ordering, lone windows of a declared type, and the
  child-window / popup / managed-popup split.
- Full suite green: **1607 tests**, lint, typecheck, prettier.
- On a real IceWM session: `WM_PROTOCOLS` now `[WM_DELETE_WINDOW]`, no kill
  dialog, `EFFECT CLEANUP RAN`, exit code 0 — checked on `simple.jsx`,
  `menu.jsx` (popups and a D-Bus global menu) and a two-window app, where
  closing the satellite warns and closing the main window quits.
