### PR TITLE
feat(canvas): DrawInfo carries the node's origin, so putImageData can land in the node

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -1453,6 +1453,45 @@ ctx.fillRects(bars); // [[x, y, w, h], …] or one flat [x, y, w, h, x, …]
 composite op and clip — sent as a single `Render.FillRectangles` where the
 loop would have sent one composite each.
 
+### Raw pixels — the one call that is not translated
+
+Everything on the context honours "you are at the node's origin" — except
+the raw-pixel pair. `putImageData` and `getImageData` ignore the current
+transform _and_ the clip (the HTML canvas rule, kept by ntk), so their
+coordinates are the drawable's own: `ctx.putImageData(data, 0, 0)` lands at
+the **window** corner, not in the node, and nothing errors on the way.
+`onDraw`'s second argument carries the node's origin for exactly this case:
+
+```jsx
+<canvas
+  onDraw={(ctx, { width, height, x, y }) => {
+    ctx.putImageData({ width, height, data: rgba }, x, y); // in the node
+  }}
+  style={{ width, height }}
+/>
+```
+
+`x`/`y` are wherever the drawing is going — in a live paint the node's place
+in the window, under a [`cacheKey`](#cachekey--draw-it-once) the origin of
+the cache surface — so offsetting by them is correct in both. In
+development, a `putImageData` whose pixels land outside the node's box
+warns, once, naming this rule.
+
+Better, for pixels that survive more than one frame: upload through an
+`Image` source (ntk's, re-exported — see [the subpath
+exports](extending.md#the-subpath-exports)) and draw it.
+`drawImage` goes through the transform and the clip like everything else — a
+half-scrolled-out canvas stays cut at the viewport, which no raw write is —
+and the image caches its server-side pixmap instead of re-uploading the
+bytes on every repaint:
+
+```jsx
+import { Image } from 'react-x11/ntk';
+
+const img = new Image({ width, height, data: rgba }); // keep it memoized
+<canvas onDraw={(ctx) => ctx.drawImage(img, 0, 0, width, height)} />;
+```
+
 ### `cacheKey` — draw it once
 
 A drawing that does not change between frames does not have to be redrawn

--- a/src/errors.js
+++ b/src/errors.js
@@ -16,7 +16,7 @@ export function setErrorHandler(container, fn) {
 
 /** The component that rendered this node, which is the name worth printing
  * — `<box>` alone never tells anyone whose box it was. */
-function ownerName(node) {
+export function ownerName(node) {
   const type = node?._reactFiber?._debugOwner?.type;
   if (!type) return null;
   return type.displayName || type.name || '(anonymous)';

--- a/src/glnodes.js
+++ b/src/glnodes.js
@@ -292,7 +292,10 @@ export class GlAreaNode extends Node {
     gl.makeCurrent?.();
 
     const { width, height } = this.rect;
-    const info = { width, height, node: this };
+    // x/y are where the node's origin sits in the drawable being drawn
+    // into (DrawInfo's contract) — a <glarea> draws into its own X window,
+    // so that is the origin.
+    const info = { width, height, x: 0, y: 0, node: this };
     if (!this._created) {
       this._created = true;
       this.props.onCreated?.(gl, info);

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -94,7 +94,7 @@ import {
   windowOrigin,
 } from './anchor.js';
 import { baseTheme } from './palette.js';
-import { callHandler } from './errors.js';
+import { callHandler, ownerName } from './errors.js';
 import {
   hooks as a11yHooks,
   isFocusable as a11yFocusable,
@@ -5202,6 +5202,48 @@ export class BoxNode extends Scrollable(Node) {
   _textStyleMoved() {}
 }
 
+/**
+ * The one call `onDraw`'s translation cannot reach (#366).
+ *
+ * `putImageData` ignores the context's transform and clip — the HTML canvas
+ * rule, kept by ntk — so inside `onDraw`, whose whole contract is "you are at
+ * the node's origin", it is the one call whose coordinates are still the
+ * drawable's own. Nothing errors; the pixels simply land at the window
+ * origin instead of in the node. `DrawInfo.x`/`.y` is the way to say it
+ * right, and development watches for the write that says it wrong: a
+ * destination outside the node's box. Once per process — one thread to pull
+ * is enough, and `onDraw` runs on every repaint.
+ */
+let warnedPutImageData = false;
+export function resetPutImageDataWarningForTests() {
+  warnedPutImageData = false;
+}
+
+/** The rect `putImageData(data, x, y, …dirty)` actually writes — the spec's
+ *  dirty-rect normalisation, reproduced so the watch judges the write and
+ *  not the whole source image (a correct call may blit a window of a bigger
+ *  atlas). Null when the write is empty. */
+function putImageDataDest(data, x, y, dx = 0, dy = 0, dw, dh) {
+  const width = data?.width ?? 0;
+  const height = data?.height ?? 0;
+  dw ??= width;
+  dh ??= height;
+  if (dw < 0) {
+    dx += dw;
+    dw = -dw;
+  }
+  if (dh < 0) {
+    dy += dh;
+    dh = -dh;
+  }
+  const sx = Math.max(0, dx);
+  const sy = Math.max(0, dy);
+  const sw = Math.min(width, dx + dw) - sx;
+  const sh = Math.min(height, dy + dh) - sy;
+  if (!(sw > 0) || !(sh > 0)) return null;
+  return { x: x + sx, y: y + sy, width: sw, height: sh };
+}
+
 /** Escape hatch: a retained node whose content is painted by props.onDraw. */
 export class CanvasNode extends Node {
   constructor(props, app) {
@@ -5250,15 +5292,70 @@ export class CanvasNode extends Node {
     ctx.clip();
     ctx.translate(this.abs.x, this.abs.y);
     if (this.props.mono) this._presetMono(ctx, this._monoColor());
+    const unwatch = DEV ? this._watchPutImageData(ctx) : null;
     try {
       onDraw(ctx, {
         width: this.abs.width,
         height: this.abs.height,
+        // the translation above, said out loud: raw-pixel calls address the
+        // drawable itself, so they are written at `info.x + x` (#366)
+        x: this.abs.x,
+        y: this.abs.y,
         node: this,
       });
     } finally {
+      unwatch?.();
       ctx.restore();
     }
+  }
+
+  /**
+   * Shadow `ctx.putImageData` for the length of one `onDraw`, and warn on a
+   * write whose destination escapes the node's box — either coordinates
+   * that were never offset by `info.x`/`info.y`, which is the trap the
+   * watch exists for, or a drawing genuinely reaching outside bounds every
+   * other call is clipped to. The box test has a pixel of slack per edge:
+   * `abs` can sit on a fractional grid, and a rounded `info.x` must not
+   * read as an escape. Development only, and the shadow is not installed
+   * again once the warning has fired, so steady state costs nothing.
+   */
+  _watchPutImageData(ctx) {
+    const original = ctx.putImageData;
+    if (warnedPutImageData || typeof original !== 'function') return null;
+    const hadOwn = Object.hasOwn(ctx, 'putImageData');
+    const node = this;
+    ctx.putImageData = function (data, x, y, ...dirty) {
+      const dest = putImageDataDest(data, x, y, ...dirty);
+      const box = node.abs;
+      if (
+        !warnedPutImageData &&
+        dest &&
+        (dest.x < box.x - 1 ||
+          dest.y < box.y - 1 ||
+          dest.x + dest.width > box.x + box.width + 1 ||
+          dest.y + dest.height > box.y + box.height + 1)
+      ) {
+        warnedPutImageData = true;
+        const owner = ownerName(node);
+        console.warn(
+          `react-x11: putImageData in <canvas onDraw>${owner ? ` (in ${owner})` : ''} ` +
+            `wrote ${dest.width}x${dest.height} at ${dest.x},${dest.y} — outside the ` +
+            `node, which is ${box.width}x${box.height} at ${box.x},${box.y}. ` +
+            "putImageData ignores the context's transform (the HTML canvas rule), " +
+            "so unlike every other call in onDraw its coordinates are the drawable's, " +
+            "not the node's. Add the node's origin, which onDraw is handed: " +
+            'ctx.putImageData(data, info.x + x, info.y + y). Better, draw through an ' +
+            'image source — it honours the transform and the clip, and caches its ' +
+            'upload server-side: ctx.drawImage(new Image({ width, height, data }), x, y), ' +
+            'with Image from \'react-x11/ntk\'. See docs/elements.md, "<canvas>".',
+        );
+      }
+      return original.call(ctx, data, x, y, ...dirty);
+    };
+    return () => {
+      if (hadOwn) ctx.putImageData = original;
+      else delete ctx.putImageData;
+    };
   }
 
   /**
@@ -5343,7 +5440,16 @@ export class CanvasNode extends Node {
     // tint arrives at blit time, so any opaque colour renders the same mask.
     if (this.props.mono) this._presetMono(ctx, '#ffffff');
     try {
-      onDraw(ctx, { width: box.width, height: box.height, node: this });
+      onDraw(ctx, {
+        width: box.width,
+        height: box.height,
+        // the drawing goes into a surface of its own here, so the node's
+        // origin in it *is* the origin — and a raw-pixel write offset by
+        // `info.x`/`info.y` for the live path stays correct under a cacheKey
+        x: box.x,
+        y: box.y,
+        node: this,
+      });
     } finally {
       ctx.restore();
     }

--- a/src/testing/mock-app.js
+++ b/src/testing/mock-app.js
@@ -220,6 +220,14 @@ export function createMockApp() {
         drawImage(...args) {
           ops.push(['drawImage']);
         },
+        // the raw-pixel write, recorded with its destination — where these
+        // pixels land is the thing to assert about an `onDraw` that uses it,
+        // since putImageData ignores the transform (docs/elements.md,
+        // "<canvas>") and an un-offset call is a real bug this mock should
+        // not hide by crashing first
+        putImageData(data, x, y) {
+          ops.push(['putImageData', data?.width, data?.height, x, y]);
+        },
         // enough of the canvas surface for SvgView.draw to run headlessly
         scale(sx, sy) {
           ops.push(['scale', sx, sy]);

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -620,6 +620,19 @@ export interface ImageProps extends DrawnProps<DrawnNode> {
 export interface DrawInfo {
   width: number;
   height: number;
+  /**
+   * The node's origin in the drawable being drawn into — the translation
+   * already applied to the context, said out loud. Everything on the
+   * context works in node coordinates and never needs it; the raw-pixel
+   * calls are the exception, because `putImageData`/`getImageData` ignore
+   * the transform (the HTML canvas rule) and address the drawable
+   * directly: `ctx.putImageData(data, info.x + x, info.y + y)`. Zero when
+   * the drawing goes into a surface of its own — under a `cacheKey`, or a
+   * `<glarea>`'s window — so offsetting by it is correct everywhere.
+   */
+  x: number;
+  /** See {@link DrawInfo.x}. */
+  y: number;
   node: DrawnNode;
 }
 
@@ -627,6 +640,14 @@ export interface CanvasProps extends DrawnProps<DrawnNode> {
   /**
    * Paint the node. `ctx` is ntk's canvas-like 2d context, translated to
    * the node's origin and clipped to its bounds. Runs on every repaint.
+   *
+   * One exception to "you are at the node's origin": `putImageData` (and
+   * `getImageData`) ignore the transform and the clip — the HTML canvas
+   * rule — and address the drawable itself. Offset by `info.x`/`info.y`,
+   * or better, draw raw pixels through an `Image` source and `drawImage`,
+   * which honours both and caches its upload server-side. In development,
+   * a write that lands outside the node warns, once. See
+   * docs/elements.md, "`<canvas>`".
    */
   onDraw?: (ctx: any, info: DrawInfo) => void;
   /**

--- a/test/canvas-put-image-data.test.js
+++ b/test/canvas-put-image-data.test.js
@@ -1,0 +1,223 @@
+// <canvas onDraw> and the raw-pixel write (#366).
+//
+// `putImageData` ignores the context's transform and clip — the HTML canvas
+// rule, kept by ntk — so inside `onDraw`, whose contract is "you are at the
+// node's origin", an un-offset call lands at the *window* origin instead of
+// in the node, and nothing errors on the way. Two answers live here:
+// `DrawInfo.x`/`.y` carry the node's origin so the write is expressible,
+// and development warns once when a write escapes the node's box.
+//
+// The pixel tests run against node-x11's in-process X server: a real
+// translate, a real PutImage, a real readback. A mock cannot demonstrate
+// this bug — the whole point is that the coordinates *look* right.
+import assert from 'node:assert';
+import { test, afterEach } from 'node:test';
+import React from 'react';
+
+import {
+  renderX11,
+  cleanup,
+  screen,
+  settle,
+  pixelAt,
+  isNear,
+} from '../src/testing/index.js';
+import { resetPutImageDataWarningForTests } from '../src/nodes.js';
+
+const h = React.createElement;
+
+afterEach(async () => {
+  await cleanup();
+  resetPutImageDataWarningForTests();
+});
+
+/** Run `fn` with console.warn captured. */
+async function withWarnings(fn) {
+  const warnings = [];
+  const original = console.warn;
+  console.warn = (...args) => warnings.push(args.join(' '));
+  try {
+    await fn();
+  } finally {
+    console.warn = original;
+  }
+  return warnings;
+}
+
+const W = 200;
+const H = 120;
+// where the padding below puts the canvas
+const NODE_X = 60;
+const NODE_Y = 40;
+
+/** Solid red, shaped like ImageData. */
+function redBlock(width, height) {
+  const data = new Uint8ClampedArray(width * height * 4);
+  for (let i = 0; i < data.length; i += 4) {
+    data[i] = 255;
+    data[i + 3] = 255;
+  }
+  return { width, height, data };
+}
+
+/** A window with one canvas at a known offset — far enough from the origin
+ *  that "landed in the node" and "landed at the window corner" are
+ *  different pixels. */
+function pane(onDraw, props = {}) {
+  return h(
+    'window',
+    {
+      width: W,
+      height: H,
+      style: {
+        backgroundColor: '#101820',
+        paddingLeft: NODE_X,
+        paddingTop: NODE_Y,
+      },
+    },
+    h('canvas', { onDraw, style: { width: 100, height: 60 }, ...props }),
+  );
+}
+
+test("onDraw is told where it is: DrawInfo carries the node's origin", async () => {
+  const infos = [];
+  const { app } = await renderX11(
+    pane((ctx, info) => infos.push(info)),
+    {},
+  );
+  await settle(app);
+
+  const node = screen.all((n) => n.kind === 'canvas')[0];
+  assert.ok(infos.length > 0, 'painted at least once');
+  const info = infos.at(-1);
+  assert.equal(info.x, node.abs.x);
+  assert.equal(info.y, node.abs.y);
+  assert.equal(info.x, NODE_X);
+  assert.equal(info.y, NODE_Y);
+  assert.equal(info.width, node.abs.width);
+  assert.equal(info.height, node.abs.height);
+});
+
+test('an un-offset putImageData lands at the window origin, and dev says so once', async () => {
+  const block = redBlock(16, 8);
+  let paints = 0;
+  const warnings = await withWarnings(async () => {
+    const { ctx, app } = await renderX11(
+      pane((c) => {
+        paints++;
+        // node-local habits, drawable coordinates: the trap from the issue
+        c.putImageData(block, 0, 0);
+      }),
+    );
+    await settle(app);
+
+    // spec behaviour, end to end: the pixels are at the window corner…
+    assert.ok(
+      isNear(await pixelAt(ctx, 4, 3), [255, 0, 0]),
+      'red at the window origin',
+    );
+    // …and the node itself shows background
+    assert.ok(
+      !isNear(await pixelAt(ctx, NODE_X + 4, NODE_Y + 3), [255, 0, 0]),
+      'nothing landed in the node',
+    );
+
+    // a second frame runs the same write and does not warn again
+    const node = screen.all((n) => n.kind === 'canvas')[0];
+    node.root.invalidate(false, node, 'props');
+    node.root.flush();
+    await settle(app);
+    assert.ok(paints >= 2, 'painted again');
+  });
+
+  assert.equal(
+    warnings.length,
+    1,
+    `one warning, got ${warnings.length}: ${warnings.join('\n---\n')}`,
+  );
+  // the message carries both ways out, and where the rule is written down
+  assert.match(warnings[0], /putImageData/);
+  assert.match(warnings[0], /info\.x \+ x/);
+  assert.match(warnings[0], /drawImage/);
+  assert.match(warnings[0], /react-x11\/ntk/);
+  assert.match(warnings[0], /docs\/elements\.md/);
+});
+
+test('offset by info.x/info.y the pixels land in the node, and nothing warns', async () => {
+  const block = redBlock(16, 8);
+  const warnings = await withWarnings(async () => {
+    const { ctx, app } = await renderX11(
+      pane((c, info) => c.putImageData(block, info.x + 4, info.y + 2)),
+    );
+    await settle(app);
+
+    assert.ok(
+      isNear(await pixelAt(ctx, NODE_X + 4 + 2, NODE_Y + 2 + 2), [255, 0, 0]),
+      'red inside the node',
+    );
+    assert.ok(
+      !isNear(await pixelAt(ctx, 4, 2), [255, 0, 0]),
+      'window origin untouched',
+    );
+  });
+  assert.deepEqual(warnings, []);
+});
+
+test('the watch judges the write, not the source image', async () => {
+  // a dirty-rect window of an atlas bigger than the node: the destination
+  // is 10x10 inside the node, so a warning here would be judging the
+  // atlas's extent instead of the spec's normalised write
+  const atlas = redBlock(300, 300);
+  const warnings = await withWarnings(async () => {
+    const { app } = await renderX11(
+      pane((c, info) =>
+        c.putImageData(atlas, info.x - 50, info.y - 60, 50, 60, 10, 10),
+      ),
+    );
+    await settle(app);
+  });
+  assert.deepEqual(warnings, []);
+});
+
+test('under a cacheKey the origin is the surface’s own, so the same offset stays correct', async () => {
+  const infos = [];
+  const block = redBlock(16, 8);
+  const { ctx, app } = await renderX11(
+    pane(
+      (c, info) => {
+        infos.push({ x: info.x, y: info.y });
+        c.putImageData(block, info.x + 4, info.y + 2);
+      },
+      { cacheKey: 'raw-pixels' },
+    ),
+  );
+  await settle(app);
+
+  // the cache renders a key on its second sighting (the pending gate), so
+  // the first frame paints live — with the node's real origin
+  assert.deepEqual(infos.at(0), { x: NODE_X, y: NODE_Y });
+  const node = screen.all((n) => n.kind === 'canvas')[0];
+  node.root.invalidate(false, node, 'props');
+  node.root.flush();
+  await settle(app);
+
+  assert.deepEqual(
+    infos.at(-1),
+    { x: 0, y: 0 },
+    'the cache surface is a drawable of its own',
+  );
+  assert.ok(
+    isNear(await pixelAt(ctx, NODE_X + 4 + 2, NODE_Y + 2 + 2), [255, 0, 0]),
+    'composited back into the node',
+  );
+});
+
+test('the mock context records putImageData, so a headless app test can assert on it', async () => {
+  const block = redBlock(2, 2);
+  const { ctx } = await renderX11(
+    pane((c, info) => c.putImageData(block, info.x, info.y)),
+    { backend: 'mock' },
+  );
+  const op = ctx.ops.find((o) => o[0] === 'putImageData');
+  assert.deepEqual(op, ['putImageData', 2, 2, NODE_X, NODE_Y]);
+});

--- a/test/glarea.test.js
+++ b/test/glarea.test.js
@@ -115,6 +115,11 @@ test('<glarea> gets a GL child window and draws a frame', async () => {
     assert.deepEqual(drawn[0], {
       width: 280,
       height: 200,
+      // the node's origin in the drawable being drawn into — a <glarea>
+      // draws into its own X window, so zero even though yoga put the
+      // node at 20,20 in the parent
+      x: 0,
+      y: 0,
       node: area,
     });
 

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -373,9 +373,14 @@ function Elements() {
       <image src="./logo.png" style={{ width: 32, height: 32 }} />
       <canvas
         style={{ flexGrow: 1 }}
-        onDraw={(ctx, { width, height }) => {
+        onDraw={(ctx, { width, height, x, y }) => {
           ctx.fillStyle = 'tomato';
           ctx.fillRect(0, 0, width / 2, height);
+          // putImageData addresses the drawable, not the node — the origin
+          // in DrawInfo is what makes the offset expressible
+          const dx: number = x;
+          const dy: number = y;
+          ctx.putImageData({ width: 1, height: 1, data: [0, 0, 0, 0] }, dx, dy);
         }}
       />
       <svg source="<svg/>" />


### PR DESCRIPTION
Fixes #366.

`putImageData` ignores the context's transform and clip — the HTML canvas rule, kept by ntk — so inside `<canvas onDraw>`, whose contract is "you are at the node's origin", it was the one call whose coordinates were still the drawable's own. Pixels landed at the **window** origin, nothing errored, and `DrawInfo` carried no origin to offset by. This lands the issue's suggested resolution: `DrawInfo.x`/`.y` plus documentation, and the dev-mode warning as well, since any one of the three would have saved the debugging cycle and the warning is the one that fires without reading docs first.

### What changed

- **`DrawInfo.x`/`.y`** — the node's origin in the drawable being drawn into, i.e. the translation the renderer applied to the context, said out loud. `ctx.putImageData(data, info.x + u, info.y + v)` is now expressible, and the same code stays correct everywhere: under a `cacheKey` the drawing goes into a surface of its own so `info.x`/`.y` is `0,0`, and a `<glarea>` draws into its own X window, same. (`test/glarea.test.js`'s whole-object assert pins the gl side.)
- **A development warning, once per process** (`CanvasNode._watchPutImageData`): a `putImageData` inside a live `onDraw` whose destination escapes the node's box warns, naming the rule and both ways out — the `info.x` offset, and the better route through an `Image` source + `drawImage`, which honours the transform *and* the clip and caches its server-side upload. The watch judges the spec's normalised dirty rect, not the source image, so a correct call that blits a window of a bigger atlas stays quiet; the box test has a pixel of slack per edge for fractional layouts. Zero cost in production, and the shadow is not installed again once the warning has fired.
- **Docs**: a "Raw pixels" section in `docs/elements.md` under `<canvas>`, plus the `.d.ts` (`DrawInfo`, `CanvasProps.onDraw`) and a type-test line in `test/types/api.tsx`.
- **The mock context records `putImageData`** with its destination instead of crashing on it, so an app's headless test can assert where the pixels went.

### Tests

`test/canvas-put-image-data.test.js`, mostly against node-x11's in-process X server — a mock cannot demonstrate this bug, since the whole point is that the coordinates *look* right:

- `DrawInfo.x/.y` equal the node's absolute origin in a live paint;
- the trap, end to end: an un-offset write really lands at the window origin (pixel readback), the node shows background, and the warning fires once — with the message's escape hatches asserted — and not again on the next frame;
- offset by `info.x`/`info.y`, the pixels land in the node and nothing warns;
- the watch judges the write, not the source image (dirty-rect normalisation);
- under a `cacheKey` the second sighting renders into the cache surface at `0,0` and composites back into the node — same `onDraw`, same offset, right pixels;
- the mock context records the call.

Full suite 1614 passing, typecheck, lint, and `npm run bench -- --check` clean (the watch adds no protocol work; production is untouched).

### What it looks like

The issue's scenario, rendered by this branch's code into the in-process server — same checkerboard-plus-image `onDraw`, only the `putImageData` coordinates differ:

| `putImageData(card, 12, 12)` — the trap | `putImageData(card, info.x + 12, info.y + 12)` |
| --- | --- |
| <!-- drag in: put-image-data-before.png --> | <!-- drag in: put-image-data-after.png --> |

In the left shot the checkerboard (transform-aware `fillRect`) is inside the pane while the image sits over the toolbar — two calls, same callback, two coordinate spaces. The left render also produced the new warning:

```
react-x11: putImageData in <canvas onDraw> wrote 196x116 at 12,12 — outside the node, which is 220x140 at 70,72. putImageData ignores the context's transform (the HTML canvas rule), so unlike every other call in onDraw its coordinates are the drawable's, not the node's. Add the node's origin, which onDraw is handed: ctx.putImageData(data, info.x + x, info.y + y). Better, draw through an image source — it honours the transform and the clip, and caches its upload server-side: ctx.drawImage(new Image({ width, height, data }), x, y), with Image from 'react-x11/ntk'. See docs/elements.md, "<canvas>".
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)