### PR TITLE
feat(image): accept in-memory pixels, and an existing Picture/Drawable id (composite without re-upload)

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -1407,19 +1407,106 @@ window behind it rather than swallowing it.
 
 ## `<image>`
 
-| prop  |                                                                                        |
-| ----- | -------------------------------------------------------------------------------------- |
-| `src` | file path (PNG/JPEG, decoded in JS)                                                    |
-| `alt` | the accessible name — what a screen reader says ([accessibility.md](accessibility.md)) |
+| prop       |                                                                                        |
+| ---------- | -------------------------------------------------------------------------------------- |
+| `src`      | client-side pixels, in any of the four forms below                                     |
+| `picture`  | `{ id, width, height }` — an existing server-side Picture, composited as-is            |
+| `drawable` | `{ id, width, height, depth? }` — an existing Pixmap/Window, composited as-is          |
+| `cacheKey` | the source's identity, when `src` is re-derived per render                             |
+| `alt`      | the accessible name — what a screen reader says ([accessibility.md](accessibility.md)) |
+
+One source per element — `src`, `picture` and `drawable` are mutually
+exclusive, and passing two throws.
 
 Sized by style — `style={{ width, height }}`, never flat props, since both
 are style names. With only one of the two set the other follows the natural
 aspect ratio; with neither, the image measures at its natural size, shrunk
-to the width on offer.
+to the width on offer. For the server-side sources the "natural size" is the
+`width`/`height` stated in the descriptor.
 
 ```jsx
 <image src={photo} style={{ height: 64 }} /> // width follows the aspect ratio
 ```
+
+### `src` — pixels the client has
+
+```jsx
+<image src="./logo.png" />                     // file path or file URL
+<image src={pngBuffer} />                      // encoded PNG/JPEG bytes
+<image src={{ width, height, data }} />        // raw straight RGBA
+<image src={ntkImage} />                       // an ntk Image (or Surface)
+```
+
+A file path (or `new URL('./logo.png', import.meta.url)`) is read and
+decoded asynchronously; the element measures 0×0 until the decode lands,
+then reflows. The three in-memory forms are synchronous — pixels that
+arrived from a socket, a decoder, or a `getImageData` readback go on screen
+without touching the filesystem. Raw `data` is `width × height × 4` bytes of
+straight (non-premultiplied) RGBA — exactly what `getImageData` hands back —
+and the object is treated as immutable content: hand over a new object when
+the pixels change, or the renderer cannot tell.
+
+Decoded pixels are uploaded to the server once and composited from there on
+every repaint (ntk's `Image` caches its upload per connection), so the cost
+of an image is one `PutImage` at first paint, not one per frame.
+
+An ntk `Image` is used as-is and never destroyed by the element — identity
+is yours, which is also the sharing idiom: one `Image` shown by many
+`<image>`s is one decode and one upload, however many places composite it.
+
+### `cacheKey` — when the buffer is new but the picture is not
+
+A component that re-derives its bytes per render — decoding a protocol
+stream, slicing a capture — hands `<image>` a structurally new `src` every
+time, and without help that is a fresh decode and a fresh upload each
+render. `cacheKey` is the `<canvas cacheKey>` contract applied to sources:
+an unchanged key vouches that the new buffer is the same picture, so nothing
+is re-decoded or re-uploaded — and two `<image>`s with one key share one
+decoded copy, freed when the last of them unmounts.
+
+```jsx
+<image src={frame.rgba} cacheKey={`frame:${frame.serial}`} />
+```
+
+The key must name the content: a key that stays the same while the pixels
+change shows the old pixels. Development warns when two sizes collide under
+one key, which is the cheap symptom of that mistake. The key is not
+consulted for an ntk `Image` (the object is its own identity), and is
+refused with `picture`/`drawable` (there is nothing client-side to cache).
+
+### `picture` / `drawable` — pixels the server already has
+
+When the content is already a server-side Picture or Drawable — a pixmap the
+app rendered offscreen, `NameWindowPixmap` from Composite, a cached tile —
+showing it must not mean reading it back and uploading it again. These
+composite straight from the existing resource: one `RenderComposite` into
+the window, no `PutImage`, no round trip.
+
+```jsx
+<image picture={{ id: pic, width: 64, height: 64 }} />
+<image drawable={{ id: pixmap, width: 128, height: 96, depth: 32 }} />
+```
+
+The caller states the size because asking the server for it would be a round
+trip, which these props exist to avoid. The descriptor is compared by value,
+so an object literal rebuilt every render costs nothing. Scaling (a box
+styled to a different size than the source) is server-side, through the
+picture transform with bilinear filtering — note that drawing a `picture`
+scaled sets that picture's transform and filter for the composite and resets
+them to identity/nearest after, the same bracket ntk puts around its own
+uploads; a picture that must keep a transform of its own should be
+composited 1:1.
+
+`drawable` wraps the pixmap or window in a Picture the element creates and
+owns (freed on unmount; the drawable stays yours). `depth` picks the format
+it is composited through: 24 — the screen's default depth, what a window
+pixmap from Composite is — is the default, 32 is argb, and 8 composites as
+ink through its alpha, which is what previewing a mask looks like. A
+`picture` needs no depth: its format was fixed when it was created.
+
+Both descriptors also accept the richer objects that already carry these
+fields — an ntk `Pixmap` is `{ id, width, height, depth }` and goes straight
+in as `drawable`.
 
 ## `<canvas>`
 

--- a/src/imagesource.js
+++ b/src/imagesource.js
@@ -1,0 +1,349 @@
+// What `<image>` can show beyond a file path (issue #367): in-memory pixels
+// — encoded bytes, raw RGBA, an ntk `Image` — and pictures that already live
+// on the server, composited without a pixel ever crossing the wire.
+//
+// The split follows `decorations.js`: classification, validation, decoding
+// and the `cacheKey` cache live here, where a test needs no server; the node
+// half in nodes.js is only lifecycle — when to resolve, when to claim
+// damage, when to let go.
+import { Image, Picture, decodeImage } from 'ntk';
+
+/**
+ * A client-side object the 2d context composites as-is: an ntk `Image` or
+ * `Surface`, or anything with a size and a `picture(app)`. The same
+ * duck-typing ntk's own `drawImage` uses, so the two answers cannot drift —
+ * whatever passes here is something the paint will accept.
+ */
+export function isDirectImageSource(src) {
+  return (
+    src != null &&
+    typeof src === 'object' &&
+    typeof src.picture === 'function' &&
+    Number.isFinite(src.width) &&
+    Number.isFinite(src.height)
+  );
+}
+
+/**
+ * A file path or file URL. URLs are matched structurally, mirroring the
+ * declared `FileUrl` — the declarations use only ES lib types, so `URL`
+ * cannot be named there, and the runtime accepting exactly what the type
+ * accepts is what keeps the two from disagreeing.
+ */
+export function isPathImageSource(src) {
+  if (typeof src === 'string' || src instanceof URL) return true;
+  return (
+    src != null &&
+    typeof src === 'object' &&
+    typeof src.href === 'string' &&
+    typeof src.protocol === 'string'
+  );
+}
+
+/** …normalized for ntk's `loadImage`, which wants a string or a real URL. */
+export const toLoadablePath = (src) =>
+  typeof src === 'string' || src instanceof URL ? src : new URL(src.href);
+
+/** Raw straight-RGBA pixels: `{ width, height, data }` — the shape
+ * `getImageData` hands back. (A `Buffer` of encoded bytes is a `Uint8Array`
+ * subclass, so the two byte forms are one check elsewhere.) */
+export function isRawImageSource(src) {
+  return (
+    src != null &&
+    typeof src === 'object' &&
+    !(src instanceof Uint8Array) &&
+    !isPathImageSource(src) &&
+    !isDirectImageSource(src) &&
+    'data' in src
+  );
+}
+
+const positiveInt = (v) => Number.isInteger(v) && v > 0;
+
+const describe = (value) =>
+  value === null
+    ? 'null'
+    : typeof value === 'object'
+      ? (value.constructor?.name ?? 'an object')
+      : typeof value;
+
+/** Stated once, so every error lists the same set of accepted forms. */
+const SRC_FORMS =
+  'a file path or file URL (PNG/JPEG), encoded PNG/JPEG bytes (Buffer or ' +
+  'Uint8Array), raw RGBA ({ width, height, data }), or an ntk Image/Surface';
+
+function validateServerSource(kind, desc) {
+  const shape =
+    kind === 'drawable'
+      ? '{ id, width, height, depth? }'
+      : '{ id, width, height }';
+  const explain =
+    `react-x11: <image ${kind}> takes ${shape} — the ${kind === 'picture' ? 'Picture' : 'Pixmap/Window'}'s ` +
+    'X id and its size in pixels. The size is stated by the caller because ' +
+    'asking the server for it would be a round trip, which this prop exists to avoid.';
+  if (desc == null || typeof desc !== 'object') {
+    throw new Error(`${explain} Got ${describe(desc)}.`);
+  }
+  if (!positiveInt(desc.id)) {
+    throw new Error(
+      `${explain} \`id\` must be an X resource id, got ${desc.id}.`,
+    );
+  }
+  if (!positiveInt(desc.width) || !positiveInt(desc.height)) {
+    throw new Error(
+      `${explain} Got a size of ${desc.width}x${desc.height} for id ${desc.id}.`,
+    );
+  }
+  if (
+    kind === 'drawable' &&
+    desc.depth != null &&
+    !(desc.depth in DEPTH_FORMATS)
+  ) {
+    throw new Error(
+      `react-x11: <image drawable> supports depth 24 (rgb, the default), 32 ` +
+        `(argb) and 8 (alpha only, composited as ink through its coverage) — ` +
+        `got ${desc.depth}. A depth the RENDER standard formats do not cover ` +
+        `cannot be composited without knowing the visual, so wrap the drawable ` +
+        `in a Picture yourself and pass <image picture>.`,
+    );
+  }
+}
+
+function validateRawSource(src) {
+  if (!positiveInt(src.width) || !positiveInt(src.height)) {
+    throw new Error(
+      'react-x11: <image src={{ width, height, data }}> needs positive ' +
+        `integer dimensions, got ${src.width}x${src.height}.`,
+    );
+  }
+  const { data } = src;
+  const bytes =
+    data instanceof Uint8Array || data instanceof Uint8ClampedArray
+      ? data.length
+      : null;
+  const want = src.width * src.height * 4;
+  if (bytes !== want) {
+    throw new Error(
+      'react-x11: <image src={{ width, height, data }}> wants straight ' +
+        '(non-premultiplied) RGBA bytes — data.length must be ' +
+        `width × height × 4 = ${want}, got ${bytes ?? describe(data)}. ` +
+        'For encoded PNG/JPEG bytes pass the buffer itself as `src`.',
+    );
+  }
+}
+
+/**
+ * Structural validation for the source props, at prop-arrival time — so the
+ * throw lands in render/commit where React can report it against the
+ * component, never inside a layout or paint pass. Content failures (a file
+ * that is not there, bytes that do not decode) are not structural and are
+ * handled where they surface: logged, and the element shows nothing.
+ */
+export function validateImageProps(props) {
+  const named = ['src', 'picture', 'drawable'].filter((k) => props[k] != null);
+  if (named.length > 1) {
+    throw new Error(
+      `react-x11: <image> shows one source, got ${named.length} ` +
+        `(${named.join(', ')}). Pass exactly one of \`src\` (client-side ` +
+        'pixels), `picture` (an existing server-side Picture) or `drawable` ' +
+        '(an existing server-side Pixmap/Window).',
+    );
+  }
+  if (
+    props.cacheKey != null &&
+    (props.picture != null || props.drawable != null)
+  ) {
+    throw new Error(
+      'react-x11: <image cacheKey> names decoded client-side pixels, and a ' +
+        '`picture`/`drawable` is already server-side — there is nothing to ' +
+        'cache. Drop the cacheKey; the composite is already upload-free.',
+    );
+  }
+  if (props.picture != null) validateServerSource('picture', props.picture);
+  if (props.drawable != null) validateServerSource('drawable', props.drawable);
+  const src = props.src;
+  if (src == null) return;
+  if (isPathImageSource(src)) return;
+  if (src instanceof Uint8Array) return;
+  if (isDirectImageSource(src)) return;
+  if (typeof src === 'object' && 'data' in src) return validateRawSource(src);
+  throw new Error(
+    `react-x11: <image src> must be ${SRC_FORMS} — got ${describe(src)}.`,
+  );
+}
+
+/**
+ * Decode a synchronous source into an ntk `Image`: encoded bytes through the
+ * PNG/JPEG decoders, raw RGBA wrapped as-is (no copy — the object is treated
+ * as immutable content from here on). File paths stay async and do not come
+ * here. May throw on corrupt bytes; the caller treats that as a content
+ * failure, because encoded bytes usually arrive from outside the program.
+ */
+export function decodeImageSource(src) {
+  if (src instanceof Uint8Array) return decodeImage(src);
+  return new Image({ width: src.width, height: src.height, data: src.data });
+}
+
+const sameServerSource = (a, b) =>
+  (a?.id ?? null) === (b?.id ?? null) &&
+  (a?.width ?? null) === (b?.width ?? null) &&
+  (a?.height ?? null) === (b?.height ?? null) &&
+  (a?.depth ?? null) === (b?.depth ?? null);
+
+/**
+ * Did the *content* behind the source props change?
+ *
+ * By value for the server descriptors — React rebuilds inline objects every
+ * render, and `{ id: 7, … }` is the same picture however fresh the object.
+ * By identity for client sources, except that an unchanged `cacheKey`
+ * vouches for a rebuilt buffer: same key, same picture. A direct source (an
+ * ntk `Image`) is its own identity, so the key never overrides one — a
+ * caller switching between bytes and an `Image` under a stable key still
+ * gets the switch.
+ */
+export function imageSourceChanged(next, prev) {
+  if (!sameServerSource(next.picture, prev.picture)) return true;
+  if (!sameServerSource(next.drawable, prev.drawable)) return true;
+  if (next.cacheKey !== prev.cacheKey) return true;
+  if (next.src === prev.src) return false;
+  if ((next.src == null) !== (prev.src == null)) return true;
+  if (isDirectImageSource(next.src) || isDirectImageSource(prev.src))
+    return true;
+  return next.cacheKey == null;
+}
+
+// --- the cacheKey cache -----------------------------------------------------
+//
+// ntk's `Image` already caches its server upload per connection; what it
+// cannot know is that the buffer an app re-derived this render is the same
+// picture as last render's. `cacheKey` is the caller saying so — the same
+// contract as `<canvas cacheKey>`: the key names the content, and two
+// `<image>`s with one key share one decoded image and one upload.
+//
+// Refcounted rather than LRU, unlike the paint cache, for two reasons: an
+// entry holds a server pixmap, the resource X gives no back-pressure on, and
+// unlike a rendered widget an image cannot be re-made from its key once the
+// source is gone. So an entry lives exactly as long as some mounted <image>
+// holds it and is freed with the last one; a remount decodes again, which is
+// the honest cost of not keeping dead pixmaps around.
+
+/** app -> Map<key, entry>. Per connection, because the upload is. */
+const sourceCaches = new WeakMap();
+
+/**
+ * Take a hold on the entry for `key`, creating it with `load()` on first
+ * use. `load` returns `{ image }` for a synchronous source or `{ promise }`
+ * for a file read — the promise resolves an `Image` or, on content failure,
+ * `null` (never rejects; the loader reports the failure once, not per
+ * holder). Every acquire is paired with a `releaseImageSource`.
+ */
+export function acquireImageSource(app, key, load) {
+  let cache = sourceCaches.get(app);
+  if (!cache) sourceCaches.set(app, (cache = new Map()));
+  let entry = cache.get(key);
+  if (!entry) {
+    entry = { key, refs: 0, image: null, promise: null, released: false };
+    cache.set(key, entry);
+    const made = load();
+    if (made.promise) {
+      entry.promise = made.promise.then((image) => {
+        entry.promise = null;
+        // every holder unmounted while it decoded — free, don't adopt
+        if (entry.released) {
+          image?.destroy();
+          return null;
+        }
+        entry.image = image;
+        return image;
+      });
+    } else {
+      entry.image = made.image;
+    }
+  }
+  entry.refs++;
+  return entry;
+}
+
+/** Drop one hold; the last one out frees the entry and its server upload. */
+export function releaseImageSource(app, entry) {
+  if (--entry.refs > 0) return;
+  sourceCaches.get(app)?.delete(entry.key);
+  entry.released = true;
+  entry.image?.destroy();
+  entry.image = null;
+}
+
+// --- server-side sources ----------------------------------------------------
+
+/** RENDER's depth-implied standard formats — the ones a drawable can be
+ * composited through without knowing its visual. */
+const DEPTH_FORMATS = { 8: 'a8', 24: 'rgb24', 32: 'rgba32' };
+
+/**
+ * An existing server-side Picture, as a source `drawImage` accepts: showing
+ * it is one `RenderComposite` — no `PutImage`, no readback, no round trip.
+ *
+ * The picture is the caller's: nothing here creates or frees anything. The
+ * one liberty taken is temporary — drawing it *scaled* sets the picture's
+ * transform and filter for the composite and resets them to
+ * identity/nearest after, which is the same bracket ntk puts around its own
+ * cached uploads. A picture that must keep a transform of its own should be
+ * composited 1:1 (style the box to the stated size).
+ */
+export class PictureSource {
+  constructor(app, { id, width, height }) {
+    this.app = app;
+    this.id = id;
+    this.width = width;
+    this.height = height;
+    this._handle = null;
+  }
+
+  /** Built on first paint, so a headless tree never touches Render. */
+  picture() {
+    return (this._handle ??= {
+      id: this.id,
+      setFilter: (name, params) =>
+        this.app.display.Render.SetPictureFilter(this.id, name, params),
+    });
+  }
+}
+
+/**
+ * An existing server-side Pixmap or Window, composited through a Picture
+ * created over it — created lazily at first paint, owned here, freed by
+ * `destroy()`. The drawable itself stays the caller's.
+ *
+ * `depth` picks the picture format and defaults to 24, the screen's default
+ * depth — what a window pixmap from Composite's `NameWindowPixmap` is. A
+ * caller with an ARGB drawable says 32; 8 composites as ink through its
+ * alpha, which is what previewing a mask looks like. A wrong depth is a
+ * server-side BadMatch, which is why the mismatch the client *can* catch
+ * (an unsupported number) throws in validation instead.
+ */
+export class DrawableSource {
+  constructor(app, { id, width, height, depth = 24 }) {
+    this.app = app;
+    this.id = id;
+    this.width = width;
+    this.height = height;
+    this.depth = depth;
+    this._picture = null;
+  }
+
+  picture() {
+    if (!this._picture) {
+      const Render = this.app.display.Render;
+      this._picture = new Picture(this.app, {
+        drawable: { id: this.id },
+        format: Render[DEPTH_FORMATS[this.depth]],
+      });
+    }
+    return this._picture;
+  }
+
+  destroy() {
+    this._picture?.destroy();
+    this._picture = null;
+  }
+}

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -47,6 +47,19 @@ import {
   shadowExtent,
   shadowSpecs,
 } from './decorations.js';
+import {
+  DrawableSource,
+  PictureSource,
+  acquireImageSource,
+  decodeImageSource,
+  imageSourceChanged,
+  isDirectImageSource,
+  isPathImageSource,
+  isRawImageSource,
+  releaseImageSource,
+  toLoadablePath,
+  validateImageProps,
+} from './imagesource.js';
 import { Yoga } from './yoga.js';
 // Namespace import for `Surface`, the same shape and the same reason as
 // `paintcache.js`: a named import of something an older ntk does not export
@@ -4453,47 +4466,226 @@ export class TextNode extends Node {
   }
 }
 
+/** The props `ImageNode.applyProps` diffs by value itself, kept out of the
+ * base class's identity walk — a buffer rebuilt under an unchanged
+ * `cacheKey` and a `{ id, … }` descriptor rebuilt with the same numbers are
+ * both "nothing changed". */
+const IMAGE_SOURCE_PROPS = new Set(['src', 'picture', 'drawable', 'cacheKey']);
+
 export class ImageNode extends Node {
   constructor(props, app) {
     super('image', props, app);
+    validateImageProps(props);
     this.image = null;
     this._loadToken = 0;
-    this._load(props.src);
+    /** hold on the `cacheKey` cache entry, when one is held */
+    this._hold = null;
+    /** an Image decoded for this node alone (no cacheKey), freed on release */
+    this._ownedImage = null;
+    /** PictureSource/DrawableSource, when the source is server-side */
+    this._serverSource = null;
+    // Resolution waits for the first layout/paint: the constructor runs in
+    // the render phase, which React may discard, and resolving here would
+    // start file reads and take cache holds nothing would ever release.
+    this._sourceDirty = true;
   }
 
-  /** The decoded size, kept to its aspect ratio. Read per measure rather
-   * than once, because it arrives late. */
+  get selfDamagedProps() {
+    return IMAGE_SOURCE_PROPS;
+  }
+
+  paintChanged(next, prev) {
+    return imageSourceChanged(next, prev) || super.paintChanged(next, prev);
+  }
+
+  /** The source's size, kept to its aspect ratio. Read per measure rather
+   * than once, because a decode can arrive late. */
   measureContent(constraints) {
+    this._ensureSource();
     return intrinsicSize(
       { width: this.image?.width ?? 0, height: this.image?.height ?? 0 },
       constraints,
     );
   }
 
-  async _load(src) {
-    if (!src) return;
+  /** First layout or paint after a mount or a source change — both run
+   * after commit, so an instance a concurrent render threw away never
+   * resolves anything. */
+  _ensureSource() {
+    if (!this._sourceDirty || this.destroyed) return;
+    this._sourceDirty = false;
+    this._resolveSource();
+  }
+
+  _resolveSource() {
+    const { src, picture, drawable, cacheKey } = this.props;
+    if (picture != null || drawable != null) {
+      this._serverSource =
+        picture != null
+          ? new PictureSource(this.app, picture)
+          : new DrawableSource(this.app, drawable);
+      this.image = this._serverSource;
+      return;
+    }
+    if (src == null) return;
+    if (isDirectImageSource(src)) {
+      // the caller's object — its upload cache is the dedupe, and it is
+      // never destroyed here
+      this.image = src;
+      return;
+    }
+    if (cacheKey != null) {
+      const entry = acquireImageSource(this.app, cacheKey, () =>
+        this._loadEntry(src),
+      );
+      this._hold = entry;
+      if (entry.image) {
+        this.image = entry.image;
+        if (DEV) this._devCheckCacheKey(src, entry.image, cacheKey);
+      } else {
+        entry.promise?.then((image) => {
+          if (image && this._hold === entry && !this.destroyed) {
+            this._setImage(image);
+          }
+        });
+      }
+      return;
+    }
+    if (isPathImageSource(src)) {
+      this._loadFile(src);
+      return;
+    }
+    const image = this._decode(src);
+    if (image) {
+      this._ownedImage = image;
+      this.image = image;
+    }
+  }
+
+  /** `{ image }` or `{ promise }` for the cache. Failures resolve to null
+   * and are reported once, here — not per node holding the key. */
+  _loadEntry(src) {
+    if (isPathImageSource(src)) {
+      return {
+        promise: ntk.loadImage(toLoadablePath(src)).then(
+          (image) => image,
+          (err) => {
+            console.error(
+              `react-x11: failed to load image ${src}:`,
+              err.message,
+            );
+            return null;
+          },
+        ),
+      };
+    }
+    return { image: this._decode(src) };
+  }
+
+  _decode(src) {
+    try {
+      return decodeImageSource(src);
+    } catch (err) {
+      // corrupt or unrecognized bytes are a content failure, not a
+      // programming error: log and show nothing, like a missing file
+      console.error(
+        'react-x11: <image src> bytes did not decode:',
+        err.message,
+      );
+      return null;
+    }
+  }
+
+  async _loadFile(src) {
     const token = ++this._loadToken;
     try {
-      const { loadImage } = await import('ntk');
-      const image = await loadImage(src);
+      const image = await ntk.loadImage(toLoadablePath(src));
       if (token !== this._loadToken || this.destroyed) return;
-      this.image = image;
-      this.invalidateMeasure('content');
+      this._ownedImage = image;
+      this._setImage(image);
     } catch (err) {
-      console.error(`react-x11: failed to load image ${src}:`, err.message);
+      if (token === this._loadToken && !this.destroyed) {
+        console.error(`react-x11: failed to load image ${src}:`, err.message);
+      }
     }
+  }
+
+  /** Adopt pixels that arrived after the frame that asked for them. A size
+   * change reflows; same-size new pixels claim only this node's box. */
+  _setImage(image) {
+    const prev = this.image;
+    this.image = image;
+    if (
+      (prev?.width ?? 0) !== (image?.width ?? 0) ||
+      (prev?.height ?? 0) !== (image?.height ?? 0)
+    ) {
+      this.invalidateMeasure('content');
+    } else {
+      this.root?.invalidate(false, this, 'content');
+    }
+  }
+
+  /** Two different pictures sharing one cacheKey is the one mistake this
+   * design can make show stale pixels; the raw form carries enough to catch
+   * the common case cheaply. */
+  _devCheckCacheKey(src, image, key) {
+    if (!isRawImageSource(src)) return;
+    if (src.width === image.width && src.height === image.height) return;
+    console.error(
+      `react-x11: <image cacheKey=${JSON.stringify(key)}> is ` +
+        `${image.width}x${image.height} in the cache, but this src says ` +
+        `${src.width}x${src.height}. Two different pictures are sharing one ` +
+        'cacheKey — the key must name the content, so include whatever ' +
+        'distinguishes them.',
+    );
+  }
+
+  _releaseSource() {
+    this._loadToken++; // orphan any in-flight file read
+    if (this._hold) {
+      releaseImageSource(this.app, this._hold);
+      this._hold = null;
+    }
+    if (this._ownedImage) {
+      // frees the per-app upload; the caller's own Images are never here
+      this._ownedImage.destroy();
+      this._ownedImage = null;
+    }
+    if (this._serverSource) {
+      this._serverSource.destroy?.();
+      this._serverSource = null;
+    }
+    this.image = null;
   }
 
   applyProps(newProps, oldProps) {
     const before = oldProps ?? this.props;
+    const sourceChanged = imageSourceChanged(newProps, before);
+    // before super touches anything, so a bad update leaves the node whole
+    if (sourceChanged) validateImageProps(newProps);
     super.applyProps(newProps, oldProps);
-    if (newProps.src !== before.src) {
-      this.image = null;
-      this._load(newProps.src);
+    if (!sourceChanged) return;
+    const prev = this.image;
+    this._releaseSource();
+    this._sourceDirty = false;
+    this._resolveSource();
+    // paintChanged already claimed this node's box through super; only a
+    // new intrinsic size needs more than that
+    if (
+      (prev?.width ?? 0) !== (this.image?.width ?? 0) ||
+      (prev?.height ?? 0) !== (this.image?.height ?? 0)
+    ) {
+      this.invalidateMeasure('content');
     }
   }
 
+  destroySubtree() {
+    this._releaseSource();
+    super.destroySubtree();
+  }
+
   paintContent(ctx) {
+    this._ensureSource();
     if (!this.image) return;
     const content = this.contentBox();
     ctx.drawImage(

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -607,14 +607,111 @@ export interface TextAreaProps extends TextInputProps {
   rows?: number;
 }
 
+/**
+ * Raw, straight (non-premultiplied) RGBA pixels: the shape `getImageData`
+ * hands back, and what ntk's `new Image()` takes. `data` is
+ * `width * height * 4` bytes. Treated as immutable content — hand over a
+ * new object when the pixels change, or the renderer cannot tell.
+ */
+export interface RawImageSource {
+  width: number;
+  height: number;
+  data: Uint8Array | Uint8ClampedArray;
+}
+
+/**
+ * A client-side picture source the 2d context composites as-is: an ntk
+ * `Image` or `Surface`, or anything with a size and a `picture(app)`.
+ * Passing one puts identity in your hands — the object's server upload is
+ * cached per connection, so many `<image>`s showing one `Image` upload once.
+ */
+export interface DirectImageSource {
+  readonly width: number;
+  readonly height: number;
+  picture(app: unknown): unknown;
+}
+
+/**
+ * A WHATWG `URL`, matched structurally because these declarations use only
+ * ES lib types (no DOM, no node ambients). The useful case is a file URL
+ * from `new URL('./icon.png', import.meta.url)`, which finds an asset
+ * relative to the module however the app is launched.
+ */
+export interface FileUrl {
+  readonly href: string;
+  readonly protocol: string;
+}
+
+/**
+ * What `src` accepts: a file path or file URL (PNG/JPEG, decoded in JS),
+ * encoded PNG/JPEG bytes, raw RGBA pixels, or an ntk `Image`/`Surface`.
+ */
+export type ImageSource =
+  string | FileUrl | Uint8Array | RawImageSource | DirectImageSource;
+
+/**
+ * An existing server-side Picture, named by X id. The size is stated by the
+ * caller because asking the server for it would be a round trip — which
+ * this prop exists to avoid.
+ */
+export interface ImagePictureSource {
+  id: number;
+  width: number;
+  height: number;
+}
+
+/**
+ * An existing server-side Pixmap or Window, named by X id. `depth` picks
+ * the picture format it is composited through: 24 (rgb, the default — what
+ * a window pixmap from Composite is), 32 (argb), or 8 (alpha only,
+ * composited as ink through its coverage).
+ */
+export interface ImageDrawableSource {
+  id: number;
+  width: number;
+  height: number;
+  depth?: 8 | 24 | 32;
+}
+
 export interface ImageProps extends DrawnProps<DrawnNode> {
-  /** File path; PNG or JPEG, decoded in JS. */
-  src: string;
+  /**
+   * Client-side pixels: a file path or file URL (PNG/JPEG, decoded in JS),
+   * encoded PNG/JPEG bytes (no temp file), raw RGBA
+   * (`{ width, height, data }`), or an ntk `Image`/`Surface` used as-is.
+   *
+   * One source per element: `src`, `picture` and `drawable` are mutually
+   * exclusive, and passing two throws.
+   */
+  src?: ImageSource;
+  /**
+   * Composite an existing server-side Picture into the element — one
+   * `RenderComposite`, no `PutImage`, no readback. The picture stays the
+   * caller's; drawing it scaled sets its transform/filter for the composite
+   * and resets them after.
+   */
+  picture?: ImagePictureSource;
+  /**
+   * Composite an existing server-side Pixmap or Window, through a Picture
+   * the element creates over it (and frees when done). The drawable stays
+   * the caller's.
+   */
+  drawable?: ImageDrawableSource;
+  /**
+   * The source's identity, when `src` is re-derived per render: an
+   * unchanged key means unchanged content, so a structurally new buffer is
+   * neither re-decoded nor re-uploaded — and two `<image>`s with one key
+   * share one decoded copy. The `<canvas cacheKey>` contract: the key must
+   * name the content. Not consulted for an ntk `Image` (the object is its
+   * own identity) and meaningless with `picture`/`drawable` (throws).
+   */
+  cacheKey?: string | number;
   /** The accessible name — what a screen reader says for this image. */
   alt?: string;
 }
 // Size is `style={{ width, height }}`, like every other element: `width`
-// and `height` are style names, so they are not declared here.
+// and `height` are style names, so they are not declared here. With no
+// style size, the source's own size (stated, for the server-side sources)
+// is the natural one, kept to its aspect ratio.
 
 /** What `onDraw` is told about the node it is painting. */
 export interface DrawInfo {

--- a/test/image-source.test.js
+++ b/test/image-source.test.js
@@ -1,0 +1,515 @@
+// <image> sources beyond a file path (issue #367): in-memory pixels in three
+// forms, `cacheKey` as the caller-controlled identity behind them, and the
+// two server-side sources that composite without an upload.
+//
+// The unit half runs against the mock app — classification, validation, the
+// refcounted cache, ownership on unmount. The pixel half runs against the
+// in-process X server, because "composited an existing Picture" is a claim
+// about what reaches the surface, and only a readback proves it.
+import assert from 'node:assert';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { test, afterEach } from 'node:test';
+import React from 'react';
+import { PNG } from 'pngjs';
+import * as ntk from 'ntk';
+
+import { createRoot } from '../src/index.js';
+import {
+  imageSourceChanged,
+  isPathImageSource,
+  toLoadablePath,
+  validateImageProps,
+} from '../src/imagesource.js';
+import {
+  renderX11,
+  cleanup,
+  createMockApp,
+  expectPixel,
+} from '../src/testing/index.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+afterEach(cleanup);
+
+/** Raw straight-RGBA source: `pixels` is rows of [r, g, b] triples. */
+function raw(pixels) {
+  const height = pixels.length;
+  const width = pixels[0].length;
+  const data = new Uint8Array(width * height * 4);
+  pixels.flat().forEach(([r, g, b], i) => {
+    data.set([r, g, b, 255], i * 4);
+  });
+  return { width, height, data };
+}
+
+/** Encoded PNG bytes for the same rows-of-triples shape. */
+function png(pixels) {
+  const { width, height, data } = raw(pixels);
+  const image = new PNG({ width, height });
+  Buffer.from(data).copy(image.data);
+  return PNG.sync.write(image);
+}
+
+const RED = [255, 0, 0];
+const GREEN = [0, 255, 0];
+const BLUE = [0, 0, 255];
+const WHITE = [255, 255, 255];
+
+/** Mount one element in a mock-app window and hand back its node. */
+async function mounted(element, { width = 200, height = 200 } = {}) {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(h('window', { width, height }, element));
+  await tick();
+  const node = app.windows[0]._reactX11Node.children[0];
+  return { app, root, node };
+}
+
+// --- classification and validation ------------------------------------------
+
+test('validateImageProps rejects two sources, naming both', () => {
+  assert.throws(
+    () =>
+      validateImageProps({
+        src: 'a.png',
+        picture: { id: 1, width: 8, height: 8 },
+      }),
+    /one source.*src, picture/s,
+  );
+});
+
+test('validateImageProps explains the server-source shape', () => {
+  assert.throws(
+    () => validateImageProps({ picture: { id: 5 } }),
+    /round trip/,
+    'the error says why the caller states the size',
+  );
+  assert.throws(
+    () => validateImageProps({ drawable: { id: 0 } }),
+    /X resource id/,
+  );
+  assert.throws(
+    () =>
+      validateImageProps({
+        drawable: { id: 5, width: 8, height: 8, depth: 16 },
+      }),
+    /depth 24.*32.*8/s,
+  );
+});
+
+test('validateImageProps rejects cacheKey on a server-side source', () => {
+  assert.throws(
+    () =>
+      validateImageProps({
+        picture: { id: 1, width: 8, height: 8 },
+        cacheKey: 'k',
+      }),
+    /nothing to cache/,
+  );
+});
+
+test('validateImageProps checks the raw form arithmetic', () => {
+  assert.throws(
+    () =>
+      validateImageProps({
+        src: { width: 2, height: 2, data: new Uint8Array(15) },
+      }),
+    /width × height × 4 = 16, got 15/,
+  );
+  assert.throws(
+    () => validateImageProps({ src: 42 }),
+    /file path.*Uint8Array/s,
+  );
+});
+
+test('imageSourceChanged: a stable cacheKey vouches for a rebuilt buffer', () => {
+  const a = png([[RED]]);
+  const b = png([[RED]]);
+  assert.equal(
+    imageSourceChanged({ src: a, cacheKey: 'k' }, { src: b, cacheKey: 'k' }),
+    false,
+  );
+  assert.equal(
+    imageSourceChanged({ src: a, cacheKey: 'k' }, { src: b, cacheKey: 'j' }),
+    true,
+  );
+  assert.equal(imageSourceChanged({ src: a }, { src: b }), true);
+  assert.equal(imageSourceChanged({ src: a }, { src: a }), false);
+});
+
+test('imageSourceChanged: server descriptors compare by value, not identity', () => {
+  const next = { picture: { id: 7, width: 8, height: 8 } };
+  const prev = { picture: { id: 7, width: 8, height: 8 } };
+  assert.equal(imageSourceChanged(next, prev), false);
+  assert.equal(
+    imageSourceChanged({ picture: { id: 8, width: 8, height: 8 } }, prev),
+    true,
+  );
+  assert.equal(
+    imageSourceChanged(
+      { drawable: { id: 7, width: 8, height: 8, depth: 32 } },
+      { drawable: { id: 7, width: 8, height: 8 } },
+    ),
+    true,
+    'a depth change re-creates the picture over the drawable',
+  );
+});
+
+test('imageSourceChanged: a direct source is its own identity, key or no key', () => {
+  const direct = { width: 1, height: 1, picture: () => null };
+  const other = { width: 1, height: 1, picture: () => null };
+  assert.equal(
+    imageSourceChanged(
+      { src: direct, cacheKey: 'k' },
+      { src: other, cacheKey: 'k' },
+    ),
+    true,
+  );
+  assert.equal(imageSourceChanged({ src: direct }, { src: direct }), false);
+});
+
+test('a URL is a path source, matched structurally like the declared FileUrl', () => {
+  const url = pathToFileURL('/tmp/logo.png');
+  assert.equal(isPathImageSource(url), true);
+  assert.equal(isPathImageSource('/tmp/logo.png'), true);
+  // the structural stand-in the declarations use, normalized to a real URL
+  const structural = { href: url.href, protocol: url.protocol };
+  assert.equal(isPathImageSource(structural), true);
+  assert.ok(toLoadablePath(structural) instanceof URL);
+  assert.equal(toLoadablePath(structural).href, url.href);
+  assert.equal(isPathImageSource(new Uint8Array(4)), false);
+  assert.equal(isPathImageSource({ width: 1, height: 1, data: null }), false);
+});
+
+// --- resolution, headless ---------------------------------------------------
+
+test('raw RGBA decodes synchronously and measures at its natural size', async () => {
+  const { node } = await mounted(
+    h('image', {
+      src: raw([[RED, GREEN, BLUE, WHITE]]),
+      style: { alignSelf: 'flex-start' },
+    }),
+  );
+  assert.equal(node.image?.width, 4);
+  assert.equal(node.image?.height, 1);
+  assert.deepStrictEqual([node.abs.width, node.abs.height], [4, 1]);
+});
+
+test('encoded PNG bytes decode without a temp file', async () => {
+  const { node } = await mounted(
+    h('image', {
+      src: png([
+        [RED, GREEN],
+        [BLUE, WHITE],
+      ]),
+      style: { alignSelf: 'flex-start' },
+    }),
+  );
+  assert.equal(node.image?.width, 2);
+  assert.equal(node.image?.height, 2);
+});
+
+test('an ntk Image passed as src is used as-is and never destroyed', async () => {
+  const image = new ntk.Image(raw([[RED]]));
+  let destroyed = 0;
+  const original = image.destroy.bind(image);
+  image.destroy = () => {
+    destroyed++;
+    original();
+  };
+  const { root, node } = await mounted(h('image', { src: image }));
+  assert.equal(node.image, image, 'the object itself, no copy, no re-decode');
+  root.render(null);
+  await tick();
+  assert.equal(destroyed, 0, 'the caller owns it; unmount must not free it');
+});
+
+test('a node-owned image is freed when the node unmounts', async () => {
+  const { root, node } = await mounted(h('image', { src: png([[RED]]) }));
+  let destroyed = 0;
+  const original = node.image.destroy.bind(node.image);
+  node.image.destroy = () => {
+    destroyed++;
+    original();
+  };
+  root.render(null);
+  await tick();
+  assert.equal(destroyed, 1);
+});
+
+test('a stable cacheKey skips the re-decode a rebuilt buffer would cost', async () => {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  const render = (bytes) =>
+    root.render(
+      h(
+        'window',
+        { width: 200, height: 200 },
+        h('image', { src: bytes, cacheKey: 'icon:1' }),
+      ),
+    );
+  render(png([[RED]]));
+  await tick();
+  const node = app.windows[0]._reactX11Node.children[0];
+  const first = node.image;
+  assert.ok(first, 'decoded on first flush');
+  // a structurally new buffer whose *content* the key vouches for — and to
+  // prove the decode was skipped, one that decodes to different pixels
+  render(png([[GREEN]]));
+  await tick();
+  assert.equal(node.image, first, 'same key, same image — no re-decode');
+  render(png([[GREEN]]));
+  await tick();
+  assert.equal(node.image, first);
+});
+
+test('two <image>s with one cacheKey share one decoded image, freed with the last', async () => {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  const pair = (count) =>
+    root.render(
+      h(
+        'window',
+        { width: 200, height: 200 },
+        ...Array.from({ length: count }, (_, i) =>
+          h('image', { key: i, src: png([[BLUE]]), cacheKey: 'shared' }),
+        ),
+      ),
+    );
+  pair(2);
+  await tick();
+  const [a, b] = app.windows[0]._reactX11Node.children;
+  assert.ok(a.image, 'decoded');
+  assert.equal(a.image, b.image, 'one decode for both nodes');
+  let destroyed = 0;
+  const original = a.image.destroy.bind(a.image);
+  a.image.destroy = () => {
+    destroyed++;
+    original();
+  };
+  pair(1);
+  await tick();
+  assert.equal(destroyed, 0, 'still held by the survivor');
+  root.render(null);
+  await tick();
+  assert.equal(destroyed, 1, 'the last hold frees the entry');
+});
+
+test('a file src under one cacheKey is read and decoded once for both holders', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'react-x11-image-'));
+  const file = join(dir, 'dot.png');
+  await writeFile(file, png([[RED]]));
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(
+    h(
+      'window',
+      { width: 200, height: 200 },
+      h('image', { key: 'a', src: file, cacheKey: 'dot' }),
+      // the second node joins the first's in-flight decode instead of
+      // starting its own read
+      h('image', { key: 'b', src: pathToFileURL(file), cacheKey: 'dot' }),
+    ),
+  );
+  const nodes = app.windows[0]._reactX11Node.children;
+  // a real read resolves on the event loop's schedule, not on a tick count
+  for (let i = 0; i < 200 && !(nodes[0].image && nodes[1].image); i++) {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  assert.ok(nodes[0].image, 'the read landed');
+  assert.equal(nodes[0].image, nodes[1].image, 'one decode, both nodes');
+});
+
+test('a changed cacheKey re-resolves and releases the old entry', async () => {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  const render = (key, bytes) =>
+    root.render(
+      h(
+        'window',
+        { width: 200, height: 200 },
+        h('image', { src: bytes, cacheKey: key }),
+      ),
+    );
+  render('a', png([[RED]]));
+  await tick();
+  const node = app.windows[0]._reactX11Node.children[0];
+  const first = node.image;
+  let destroyed = 0;
+  const original = first.destroy.bind(first);
+  first.destroy = () => {
+    destroyed++;
+    original();
+  };
+  render('b', png([[GREEN, GREEN]]));
+  await tick();
+  assert.notEqual(node.image, first);
+  assert.equal(node.image.width, 2, 'the new key decoded the new bytes');
+  assert.equal(destroyed, 1, 'nobody holds the old entry any more');
+});
+
+test('<image picture> measures at the stated size with no server call', async () => {
+  const { node } = await mounted(
+    h('image', {
+      picture: { id: 7, width: 400, height: 100 },
+      style: { alignSelf: 'flex-start' },
+    }),
+  );
+  assert.deepStrictEqual(
+    [node.abs.width, node.abs.height],
+    [200, 50],
+    'shrunk to the width on offer, ratio kept — the <image src> rule',
+  );
+});
+
+test('a rebuilt but equal descriptor does not re-create the source', async () => {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  const render = (id) =>
+    root.render(
+      h(
+        'window',
+        { width: 200, height: 200 },
+        h('image', { drawable: { id, width: 8, height: 8, depth: 32 } }),
+      ),
+    );
+  render(7);
+  await tick();
+  const node = app.windows[0]._reactX11Node.children[0];
+  const source = node._serverSource;
+  assert.ok(source, 'resolved');
+  render(7);
+  await tick();
+  assert.equal(node._serverSource, source, 'same numbers, same source');
+  render(8);
+  await tick();
+  assert.notEqual(node._serverSource, source, 'a new id is a new source');
+});
+
+// --- pixels, against the real server ----------------------------------------
+
+test('raw RGBA pixels reach the screen, unscaled and scaled', async () => {
+  const source = raw([
+    [RED, GREEN],
+    [BLUE, WHITE],
+  ]);
+  const { ctx } = await renderX11(
+    h(
+      'box',
+      { style: { flexDirection: 'row', alignItems: 'flex-start' } },
+      h('image', { src: source, style: { width: 2, height: 2 } }),
+      // the scaled path goes through the picture transform; sample the
+      // quadrant interiors, clear of the bilinear seam
+      h('image', { src: source, style: { width: 40, height: 40 } }),
+    ),
+  );
+  await expectPixel(ctx, 0, 0, RED, { tolerance: 4 });
+  await expectPixel(ctx, 1, 1, WHITE, { tolerance: 4 });
+  await expectPixel(ctx, 2 + 10, 10, RED, { tolerance: 24 });
+  await expectPixel(ctx, 2 + 29, 29, WHITE, { tolerance: 24 });
+});
+
+test('encoded PNG bytes render, and a cacheKey survives a source rebuild', async () => {
+  // 2x2, so the scaled sample at the middle sits between same-colour pixel
+  // centers — a 1x1 source bleeds its RepeatNone edge into every sample
+  const dot = () =>
+    png([
+      [GREEN, GREEN],
+      [GREEN, GREEN],
+    ]);
+  const { ctx, windowNode, rerender } = await renderX11(
+    h('image', {
+      src: dot(),
+      cacheKey: 'dot',
+      style: { width: 20, height: 20, alignSelf: 'flex-start' },
+    }),
+  );
+  await expectPixel(ctx, 10, 10, GREEN, { tolerance: 4 });
+  const node = windowNode.children[0];
+  const first = node.image;
+  await rerender(
+    h('image', {
+      src: dot(),
+      cacheKey: 'dot',
+      style: { width: 20, height: 20, alignSelf: 'flex-start' },
+    }),
+  );
+  assert.equal(node.image, first, 'rebuilt bytes, same key: no re-decode');
+  await expectPixel(ctx, 10, 10, GREEN, { tolerance: 4 });
+});
+
+test('one ntk Image in two <image>s is one server upload', async () => {
+  const image = new ntk.Image(
+    raw([
+      [BLUE, BLUE],
+      [BLUE, BLUE],
+    ]),
+  );
+  const { ctx, app } = await renderX11(
+    h(
+      'box',
+      { style: { flexDirection: 'row', alignItems: 'flex-start' } },
+      h('image', { src: image, style: { width: 10, height: 10 } }),
+      h('image', { src: image, style: { width: 10, height: 10 } }),
+    ),
+  );
+  await expectPixel(ctx, 5, 5, BLUE, { tolerance: 4 });
+  await expectPixel(ctx, 15, 5, BLUE, { tolerance: 4 });
+  // the per-app upload cache is the point of handing over the object: two
+  // composites, one PutImage. `_uploads` is the Image's own upload table.
+  assert.equal(image._uploads.size, 1);
+  assert.ok(image._uploads.has(app));
+});
+
+test('<image picture> composites an existing Picture without an upload', async () => {
+  const { ctx, app, rerender } = await renderX11(h('box', null));
+  // something the server already holds: a Surface, filled tomato
+  const surface = new ntk.Surface(app, { width: 8, height: 8 });
+  surface.render((sctx) => {
+    sctx.fillStyle = '#ff6347';
+    sctx.fillRect(0, 0, 8, 8);
+  });
+  const id = surface.picture(app).id;
+  await rerender(
+    h('image', {
+      picture: { id, width: 8, height: 8 },
+      style: { width: 8, height: 8, alignSelf: 'flex-start' },
+    }),
+  );
+  await expectPixel(ctx, 4, 4, '#ff6347', { tolerance: 4 });
+  surface.destroy();
+});
+
+test('<image drawable> composites an existing Pixmap by id', async () => {
+  const { ctx, app, rerender } = await renderX11(h('box', null));
+  const Render = app.display.Render;
+  const pixmap = new ntk.Pixmap(app, { depth: 32, width: 8, height: 8 });
+  {
+    // fill it server-side; the fill colour is premultiplied floats 0..1
+    const fill = new ntk.Picture(app, {
+      drawable: pixmap,
+      format: Render.rgba32,
+    });
+    Render.FillRectangles(
+      Render.PictOp.Src,
+      fill.id,
+      [0, 1, 0, 1],
+      [0, 0, 8, 8],
+    );
+    fill.destroy();
+  }
+  // the descriptor is { id, width, height, depth } — which an ntk Pixmap
+  // already is, so the object goes straight in
+  await rerender(
+    h('image', {
+      drawable: pixmap,
+      style: { width: 8, height: 8, alignSelf: 'flex-start' },
+    }),
+  );
+  await expectPixel(ctx, 4, 4, GREEN, { tolerance: 4 });
+  pixmap.destroy();
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -371,6 +371,30 @@ function Elements() {
       />
       <textarea rows={4} defaultValue="multi" />
       <image src="./logo.png" style={{ width: 32, height: 32 }} />
+      {/* a WHATWG URL matches FileUrl structurally — these declarations use
+          only ES lib types, so the global URL cannot be named here */}
+      <image
+        src={{ href: 'file:///tmp/logo.png', protocol: 'file:' }}
+        alt="logo"
+      />
+      {/* in-memory sources (issue #367): encoded bytes, raw RGBA, an ntk
+          Image-like — no temp file, and identity is the caller's */}
+      <image src={new Uint8Array(8)} cacheKey="stream:42" />
+      <image
+        src={{ width: 2, height: 2, data: new Uint8Array(16) }}
+        cacheKey={7}
+      />
+      <image src={{ width: 2, height: 2, data: new Uint8ClampedArray(16) }} />
+      <image
+        src={{ width: 8, height: 8, picture: (app: unknown) => app }}
+        alt="an ntk Image or Surface satisfies DirectImageSource"
+      />
+      {/* pixels already on the server: composite, never re-upload */}
+      <image picture={{ id: 0x2c0001, width: 64, height: 64 }} />
+      <image
+        drawable={{ id: 0x2c0002, width: 128, height: 96, depth: 32 }}
+        style={{ width: 32 }}
+      />
       <canvas
         style={{ flexGrow: 1 }}
         onDraw={(ctx, { width, height }) => {
@@ -436,6 +460,17 @@ const _classy = <box className="nope" />;
 // themselves do not get to take it flat either (issue #118).
 // @ts-expect-error — <image> is sized by style, not by a width prop
 const _sized = <image src="./logo.png" width={40} />;
+// …including the server-side sources: the width in the descriptor is the
+// source's own geometry, and the box is still styled.
+const pictureDesc = { id: 1, width: 8, height: 8 };
+// @ts-expect-error — <image picture> is sized by style too
+const _sizedPicture = <image picture={pictureDesc} width={40} />;
+// @ts-expect-error — a picture descriptor states its size; id alone is not enough
+const _bareId = <image picture={{ id: 1 }} />;
+// @ts-expect-error — depth 16 has no RENDER standard format
+const _depth = <image drawable={{ id: 1, width: 8, height: 8, depth: 16 }} />;
+// @ts-expect-error — raw pixels state their size; bytes alone could be anything
+const _bareData = <image src={{ data: new Uint8Array(16) }} />;
 // @ts-expect-error — nor is <svg>
 const _svg = <svg source="<svg/>" height={40} />;
 // @ts-expect-error — and <svg>'s ink is style={{ color }}, not a prop


### PR DESCRIPTION
Closes #367.

Every source form, rendered by this PR's code against the in-process server (raw RGBA, PNG bytes, one ntk `Image` composited twice off a single upload, an existing Picture, an existing Pixmap):

<!-- drag in: image-sources.png -->

## `src` — in-memory pixels

```jsx
<image src={pngBuffer} />                        // encoded PNG/JPEG bytes
<image src={{ width, height, data }} />          // raw straight RGBA
<image src={ntkImage} />                         // ntk Image or Surface, as-is
<image src="./logo.png" />                       // file path / file URL, as before
```

The in-memory forms decode synchronously — pixels from a protocol stream or a decoder go on screen the same frame, no temp file. The raw form is exactly the `getImageData` shape, and "Image-or-Surface" is ntk's own `drawImage` duck-typing (`width`/`height` + `picture(app)`), so what classification accepts and what paint accepts cannot drift. A caller's `Image` is used as-is and never destroyed by the element; node-decoded images are freed on unmount.

## `picture` / `drawable` — pixels already on the server

```jsx
<image picture={{ id: pic, width: 64, height: 64 }} />
<image drawable={{ id: pixmap, width: 128, height: 96, depth: 32 }} />
```

One `RenderComposite` from the existing resource into the node — no `PutImage`, no readback, no round trip. Scaling is server-side through the picture transform (set for the composite, reset after — the bracket ntk already puts around its own uploads). `drawable` wraps the id in a Picture the element owns and frees; `depth` picks the RENDER standard format (24 default — a `NameWindowPixmap` of a normal window — 32 for argb, 8 composites as ink through coverage, and anything else is refused with a pointer to `picture`).

**One deviation from the issue's sketch:** the sizes ride the descriptor object rather than flat `width`/`height` props. Those are style names — `<image width>` throws by the style discipline (#118), and the descriptor keeps `<image picture={…} style={{ width: 32 }} />` unambiguous: source geometry vs box. It also means an ntk `Pixmap` (already `{ id, width, height, depth }`) goes straight in as `drawable`. Descriptors compare by value, so inline object literals rebuilt per render cost nothing.

## `cacheKey` — identity for re-derived sources

```jsx
<image src={frame.rgba} cacheKey={`frame:${frame.serial}`} />
```

The `<canvas cacheKey>` contract applied to sources: an unchanged key vouches that a structurally new buffer is the same picture — no re-decode, no re-upload, and no damage claimed (`selfDamagedProps` + a `paintChanged` override keep the base identity walk out of it). Two `<image>`s with one key share one decoded copy. The cache is per-connection and **refcounted rather than LRU** — entries hold server pixmaps, which X gives no back-pressure on, and an image can't be re-made from its key once the source is gone — so an entry lives exactly as long as a mounted holder and is freed with the last one. Development warns when two sizes collide under one key (the cheap symptom of a key that doesn't name the content). The key is not consulted for an ntk `Image` and is refused with `picture`/`drawable`.

## Lifecycle

Sources now resolve at first layout/paint instead of in the constructor: the render phase is discardable under concurrent React, and resolving there would start file reads and take cache holds nothing releases. (This also stops the pre-existing discarded-instance file read.) `applyProps` re-resolves on a by-value source change; same-size new pixels keep the bounded damage claim, only an intrinsic-size change reflows.

Structural misuse throws with the fix in the message (two sources, malformed descriptors, RGBA length arithmetic, unsupported depth); content failures (missing file, corrupt bytes) log and render nothing, as before.

## Notes

- `ImageProps` stays an `interface` (exclusivity enforced at runtime) rather than a `never`-union: the `element-props` meta-test parses interfaces out of the `.d.ts` by regex, and a type alias would silently drop `<image>` from that check.
- The declarations use only ES lib types, so `URL` can't be named there — `FileUrl` matches it structurally and the runtime accepts exactly the same shape, normalizing to a real `URL` for ntk's `loadImage`.
- New module `src/imagesource.js` carries the pure half (classification, validation, decode, cache, the two server-source classes), following the `decorations.js` split; `ImageNode` in `nodes.js` is only lifecycle.

## Testing

- `test/image-source.test.js`: 23 tests — classification/validation/`imageSourceChanged` units, headless resolution + ownership + refcounting against the mock app, and pixel readbacks against the in-process X server for all five forms (including "two `<image>`s, one `Image`, one upload" via the upload table, and the Pixmap-as-descriptor case).
- `npm test` (1631 pass), `npm run lint`, `npm run typecheck` (new positive cases + `@ts-expect-error`s for flat sizes, bare ids, depth 16, sizeless raw data), `npm run bench -- --check` (no regressions — the hot paths gained only a boolean flag check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
