### PR TITLE
fix(dialog): a managed dialog draws its title once, in the frame

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -1041,15 +1041,15 @@ import { Button, Dialog } from 'react-x11';
 </Dialog>;
 ```
 
-| prop              |                                                              |
-| ----------------- | ------------------------------------------------------------ |
-| `open`            | renders nothing when false; the popup exists only while true |
-| `title`           | bold heading (optional)                                      |
-| `children`        | body content; strings become `<text>`                        |
-| `actions`         | elements for the right-aligned button row                    |
-| `onClose`         | Escape, or the window manager's close button                 |
-| `managed`         | `false` for the override-redirect popup 1.x shipped (below)  |
-| `width`, `height` | popup size (default 360×170)                                 |
+| prop              |                                                                                                    |
+| ----------------- | -------------------------------------------------------------------------------------------------- |
+| `open`            | renders nothing when false; the popup exists only while true                                       |
+| `title`           | names the dialog, drawn once: the frame's caption when managed, a bold in-content heading when not |
+| `children`        | body content; strings become `<text>`                                                              |
+| `actions`         | elements for the right-aligned button row                                                          |
+| `onClose`         | Escape, or the window manager's close button                                                       |
+| `managed`         | `false` for the override-redirect popup 1.x shipped (below)                                        |
+| `width`, `height` | popup size (default 360×170)                                                                       |
 
 The focus behaviour is the **renderer's**, not the component's: `trapFocus`
 keeps Tab inside the dialog, stops presses elsewhere from moving focus, and
@@ -1074,6 +1074,11 @@ first.)
 | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `true` (default) | a WM-managed window: frame, titlebar, movable, WM close button, transient for its owner, out of the taskbar. A press outside does **not** close it. |
 | `false`          | the override-redirect popup: no frame, not movable, a pointer grab, and a press anywhere outside calls `onClose`.                                   |
+
+The `title` follows the frame: managed, it is the frame's caption and the
+content starts with the body; unmanaged there is no frame, so the title is
+drawn as a bold heading at the top of the content instead. It is never drawn
+twice, and it names the dialog for accessibility either way.
 
 They are one choice, not two: a client-side pointer grab over a window the
 window manager is trying to let the user drag swallows the press that would

--- a/src/components/Dialog.js
+++ b/src/components/Dialog.js
@@ -34,6 +34,12 @@ const DEFAULT_HEIGHT = 170;
  * with no window manager at all, and the wrong one for anything the user
  * might want to move.
  *
+ * `title` is drawn exactly once (issue #370). Managed, it is the frame's
+ * caption and the window manager draws it, so the content starts with the
+ * body; unmanaged there is no frame, so it is drawn as a bold heading at the
+ * top of the content instead. Either way it names the dialog surface for
+ * accessibility (`aria-label`).
+ *
  * The two differ in how a press outside behaves, and it is not a bug either
  * way: a managed dialog stays open, because a real dialog does. Escape and
  * the WM close button both call `onClose`; so does a press outside when
@@ -160,7 +166,11 @@ export function Dialog({
               style,
             ],
           },
-          title &&
+          // a managed dialog's title is already in the WM frame's caption;
+          // drawing it again here showed it twice (issue #370). Only the
+          // unmanaged popup, which has no frame, needs the in-content heading.
+          !managed &&
+            title &&
             h(
               'text',
               {

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -3484,6 +3484,86 @@ test('Dialog: with nothing to autoFocus, the surface takes focus', async () => {
   await x11Root.unmount();
 });
 
+// issue #370: a managed dialog's title is the frame's caption, so drawing it
+// again at the top of the content showed it twice. The unmanaged popup has no
+// frame, so there the in-content heading is the only place the title can be.
+test('Dialog: the title is drawn once — frame caption when managed, in-content heading when not', async () => {
+  const { Dialog } = await import('../src/index.js');
+  const TITLE = 'Break on…';
+
+  const findTitleText = (n) => {
+    if (
+      n.kind === 'text' &&
+      n.children.some((c) => c.kind === 'textchunk' && c.text === TITLE)
+    ) {
+      return n;
+    }
+    for (const c of n.children) {
+      const hit = findTitleText(c);
+      if (hit) return hit;
+    }
+    return null;
+  };
+
+  const open = async (managed) => {
+    const app = createMockApp();
+    const x11Root = await createRoot({ app });
+    x11Root.render(
+      React.createElement(
+        'window',
+        { width: 400, height: 300 },
+        React.createElement(
+          Dialog,
+          { open: true, title: TITLE, managed },
+          'body',
+        ),
+      ),
+    );
+    await tick();
+    return { app, x11Root, dialog: app.windows[1] };
+  };
+
+  {
+    const { x11Root, dialog } = await open(true);
+    assert.strictEqual(
+      dialog.attributes.title,
+      TITLE,
+      'the managed dialog captions its frame',
+    );
+    // assert.ok, not strictEqual against null: a node in a failing
+    // strictEqual diff drags the whole retained tree into the message
+    assert.ok(
+      !findTitleText(dialog._reactX11Node),
+      'and does not repeat the title in the content',
+    );
+    assert.strictEqual(
+      dialog._reactX11Node.children[0].props['aria-label'],
+      TITLE,
+      'the surface is still named by the title',
+    );
+    await x11Root.unmount();
+  }
+
+  {
+    const { x11Root, dialog } = await open(false);
+    assert.strictEqual(
+      dialog.attributes.title,
+      undefined,
+      'an override-redirect popup has no frame to caption',
+    );
+    assert.ok(
+      findTitleText(dialog._reactX11Node),
+      'so the title is the in-content heading',
+    );
+    assert.strictEqual(
+      dialog._reactX11Node.children[0].props['aria-label'],
+      TITLE,
+      'and the surface is named by it here too',
+    );
+    await x11Root.unmount();
+  }
+});
+
 test('context menu: a press outside — the window frame — dismisses it', async () => {
   const app = createMockApp();
   const x11Root = await createRoot({ app });


### PR DESCRIPTION
Fixes #370.

A managed `<Dialog>` (the default) captions its WM frame with `title` and then drew the same string again as a bold heading at the top of its content — the heading appeared twice, once in the titlebar and once in the body. Of the two ways out the issue offers, this takes the first: **the in-content heading is drawn only when `managed={false}`**, where there is no frame and the heading is the only place the title can appear. The surface is still named by the title (`aria-label`) in both modes.

### Before / after (quartz-wm on XQuartz, captured with the frame)

| managed, before | managed, after | `managed={false}`, after |
| --- | --- | --- |
| ![before-managed](https://github.com/user-attachments/assets/b105d807-72fe-45ed-a794-48b9a222adaa) | ![after-managed](https://github.com/user-attachments/assets/c40dd3bf-1c4a-41a6-8b06-bf622799b01f) | ![after-unmanaged](https://github.com/user-attachments/assets/8e137185-97e0-462f-bcf9-7a6d8429a363) |

The framed shots are the dialog's actual frame window read back with `GetImage` (the `scripts/screenshots-framed.jsx` route), rendered by this branch and by `origin/master` (36440fa) respectively — same scene, same script.

### Changes

- `src/components/Dialog.js`: the in-content `<text>` heading is gated on `!managed`; the `aria-label` is untouched, so a managed dialog is still named for accessibility by its title.
- `test/smoke.test.js`: a test that the title is drawn exactly once — frame caption and no in-content copy when managed, in-content heading and no caption when not, `aria-label` in both. Mutation-checked: with the gate reverted, the managed half fails.
- `docs/components.md`: the `title` prop row and a paragraph under **`managed`** describing where the title goes.

No opt-out prop (`titleInContent`) was added — the issue calls the unconditional behaviour the expected one, and the repo's no-back-compat policy says not to keep the old rendering reachable.

