### PR TITLE
feat(tooltip): element labels size themselves — measure hidden, place, then map

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -856,13 +856,14 @@ import { Tooltip } from 'react-x11';
 </Tooltip>;
 ```
 
-| prop              |                                                              |
-| ----------------- | ------------------------------------------------------------ |
-| `label`           | the hint: a string, or an element (nothing shows without it) |
-| `direction`       | `'auto'` (default), `'top'`, `'bottom'`, `'left'`, `'right'` |
-| `delay`           | ms of hover before showing (default 500)                     |
-| `fontSize`        | label size, also used to size the popup                      |
-| `width`, `height` | the bubble's size — required for an element `label`          |
+| prop                    |                                                                        |
+| ----------------------- | ---------------------------------------------------------------------- |
+| `label`                 | the hint: a string, or an element (nothing shows without it)           |
+| `direction`             | `'auto'` (default), `'top'`, `'bottom'`, `'left'`, `'right'`           |
+| `delay`                 | ms of hover before showing (default 500)                               |
+| `fontSize`              | label size, also used to size the popup                                |
+| `width`, `height`       | pin an axis of the bubble exactly; anything not pinned is measured     |
+| `maxWidth`, `maxHeight` | cap what an element label measures out to, inside the screen's own cap |
 
 Wraps its children in a row box carrying the hover handlers and the anchor
 ref, so it composes around any element. Hides immediately on leave and on
@@ -886,9 +887,14 @@ is the older name for the same prop and still wins where it is given.)
 
 A **string** `label` is measured and the popup sized around it, because a
 `<popup>` is a real X window and needs its size before layout. An
-**element** is the same problem without a way to measure, so the caller
-gives `width`/`height` — and then gets the bubble to fill, with no padding
-imposed on it:
+**element** label is measured too — nothing to size, nothing to guess: the
+popup is rendered once [`hidden`](elements.md#hidden--realized-laid-out-not-on-screen)
+at its natural size (a real layout of the real content, capped at the screen
+and at `maxWidth`/`maxHeight`), the size is read back, and the same
+placement math runs before anything is mapped. Both commits land in the same
+task and the popup maps last, so it is only ever on screen placed and at its
+final size. The element gets the bubble to fill, with no padding imposed on
+it:
 
 ```jsx
 <Tooltip
@@ -898,13 +904,19 @@ imposed on it:
       <ProgressBar value={used} />
     </box>
   }
-  width={200}
-  height={82}
+  maxWidth={260}
   direction="right"
 >
   <box>…</box>
 </Tooltip>
 ```
+
+`width`/`height` still pin an axis exactly: give both and the measuring pass
+is skipped entirely (the guaranteed-fit mode element labels used to
+require); give one and the other is measured for it, so `width={340}` is a
+fixed column whose height fits the message. The size is settled at open —
+content that changes size while the hint is up keeps the bubble it opened
+with until the next open, which is a hint's lifetime away.
 
 Anything renders in there, widgets included — it is a real tree in a real
 window, not a rich-text label. `examples/tooltips.jsx` has both kinds.

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -176,6 +176,7 @@ A real X11 window; the flex, paint and event root for its subtree.
 | `onClientMessage(ev)`       | a ClientMessage addressed to this window — EWMH, XEmbed, the tray (below)                                                                                                                               |
 | `theme`                     | palette that `$token` style values resolve against, for this subtree                                                                                                                                    |
 | `embeddable`                | created but never self-mapped: the window waits for an embedder ([`<foreign>`](embedding.md) on the other side), which maps it after the reparent. What a [`<Frame>`](frame.md) pane's root window sets |
+| `hidden`                    | realized and laid out, never mapped while true (below)                                                                                                                                                  |
 
 Windows may be nested inside other windows (real X11 child windows).
 **Ref**: the live ntk `Window` — `getContext('2d')`,
@@ -317,6 +318,32 @@ Three things worth knowing before reaching for it:
 - Measuring costs an extra layout pass per frame that lays out, for as long
   as the window is still tracking. A window with both sizes given pays
   nothing.
+
+### `hidden` — realized, laid out, not on screen
+
+```jsx
+<window hidden={minimized} title="scratch" />
+```
+
+The X window exists at its size — auto sizes included, the content is really
+measured — and the tree behind it is live; the window is simply never mapped
+while `hidden` is true. Clearing it maps the window where it stands. Unlike
+conditional rendering nothing unmounts in between, so component state,
+subscriptions and the X window itself all survive a hide: this is the
+declarative form of "minimize by unmapping", and what
+[`Tooltip`](components.md#tooltip) measures an element label in before
+placing it.
+
+A subtree hidden by React — `<Activity mode="hidden">`, a `<Suspense>` that
+suspended — composes rather than competes: the window is on screen only
+while **neither** says hidden. Hiding releases the keyboard focus of
+anything inside (the [focus-follows-visibility](events.md) rule), and the
+reveal hands it back unless something else took it meanwhile.
+
+On a `<popup>` the pair of unmap/map is the whole story. On a managed
+`<window>` an unmap is ICCCM's _withdraw_ — the window manager forgets the
+window, and the re-map is a fresh `MapRequest`, so a WM may frame or place
+it anew and `states` are re-declared rather than remembered.
 
 ### `onResize` fires for moves
 

--- a/examples/tooltips.jsx
+++ b/examples/tooltips.jsx
@@ -2,10 +2,13 @@
 //
 // A `label` that is a **string** is measured and the popup is sized around
 // it — the common case, and the one that needs nothing from the caller. A
-// `label` that is an **element** gets the bubble to fill and a `width`/
-// `height` to fill it at, because a <popup> is a real X window: it needs its
-// size before React can lay anything out inside it. Anything renders in
-// there, widgets included — the last card below has a real <ProgressBar>.
+// `label` that is an **element** is measured too: the popup is rendered
+// once hidden at its natural size, read back, and placed before it is ever
+// mapped — so the swatch cards below are each exactly as big as what is in
+// them, with no numbers from the caller. `width`/`height` still pin an axis
+// where one axis is a design decision: the last card pins `width` and lets
+// the height fit. Anything renders in there, widgets included — that same
+// card has a real <ProgressBar>.
 //
 // `direction` picks the side. The default, `"auto"`, takes the first side
 // the hint fits on measured against the *screen* (a popup is a real window,
@@ -38,9 +41,11 @@ const SWATCHES = [
  * A tooltip that is a component rather than a line of text: a chip of the
  * colour, its name and hex, and a note under them.
  *
- * `flexGrow: 1` because the bubble hands an element the whole rectangle and
- * imposes no padding of its own — the card draws its own, which is the
- * point of passing one.
+ * No size anywhere: the bubble is measured from this card, so each swatch's
+ * hint is exactly as big as its own note — the long one is not clipped and
+ * the short one is not swimming in a bubble sized for the long one. The
+ * bubble imposes no padding of its own; the card draws its own, which is
+ * the point of passing one.
  *
  * The tokens are the **bubble's**, not the window's: a hint is drawn in the
  * palette's ink, so inside it `$text` is the ink *on that surface* and
@@ -50,7 +55,7 @@ const SWATCHES = [
  */
 function SwatchCard({ swatch }) {
   return (
-    <box style={{ flexGrow: 1, padding: 10, gap: 8 }}>
+    <box style={{ padding: 10, gap: 8 }}>
       <box style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
         <box
           style={{
@@ -73,7 +78,8 @@ function SwatchCard({ swatch }) {
 }
 
 /** And one with a live widget in it, to make the point that it is a real
- *  tree and not a rich-text label. */
+ *  tree and not a rich-text label. The tooltip pins `width` — a progress
+ *  bar has no natural width of its own — and the height is measured for it. */
 function UsageCard({ used }) {
   return (
     <box style={{ flexGrow: 1, padding: 10, gap: 7, justifyContent: 'center' }}>
@@ -130,14 +136,13 @@ function Panel() {
         </Tooltip>
       </Row>
 
-      {/* An element label: the caller says how big, and fills it. */}
+      {/* An element label: measured like everything else, so each card is
+          exactly the size of what is in it. */}
       <Row label="Component">
         {SWATCHES.map((swatch) => (
           <Tooltip
             key={swatch.hex}
             label={<SwatchCard swatch={swatch} />}
-            width={190}
-            height={78}
             delay={250}
           >
             <box
@@ -159,7 +164,6 @@ function Panel() {
         <Tooltip
           label={<UsageCard used={used} />}
           width={200}
-          height={82}
           direction="right"
           delay={250}
         >

--- a/src/components/Tooltip.js
+++ b/src/components/Tooltip.js
@@ -5,6 +5,7 @@
 import React, {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -41,11 +42,10 @@ const ARROW_DEPTH = 6;
 // the edge leaves a hairline of half-covered pixels between them.
 const ARROW_OVERLAP = 1;
 
-// What a `label` that is not text gets when the caller sizes nothing. A
-// popup is a real X window: it needs its size before anything inside it can
-// be laid out, so there is no measuring our way out of this one.
-const RICH_WIDTH = 220;
-const RICH_HEIGHT = 80;
+// There is no default size for a `label` that is not text: the popup is
+// rendered once **hidden** at its natural size — a real layout of the real
+// content, never on screen — and placed from what that measured. See
+// `surface()` for the two lives, and the measuring effect for the order.
 
 const isText = (label) =>
   typeof label === 'string' || typeof label === 'number';
@@ -247,14 +247,23 @@ function paintArrow(ctx, { width, height }, side, color) {
  * is given, so that nothing that named a side has to change.)
  *
  * `label` is usually a string, and then the popup is sized from the
- * **measured** text — not because a `<popup>` cannot size itself (it can,
- * see "Natural size" in docs/elements.md) but because `anchorRect` needs the
- * size to decide which side of the trigger the hint fits on, and that is
- * decided during the render that opens it. It can equally be an element — a
- * swatch and a hex code, a shortcut in its own type, a whole card — and then
- * the caller says how big with `width`/`height`, for the same reason. The
- * element fills the bubble and draws its own padding; a string gets the
- * bubble's.
+ * **measured** text — synchronously, because `anchorRect` needs the size to
+ * decide which side of the trigger the hint fits on, and that is decided
+ * during the render that opens it. It can equally be an element — a swatch
+ * and a hex code, a shortcut in its own type, a whole card — and then the
+ * content is **measured too**: the popup is rendered once `hidden` at its
+ * natural size (a real layout of the real content, capped at the screen and
+ * at `maxWidth`/`maxHeight`), the size is read back, and the same placement
+ * math runs before anything is mapped — so a card whose height depends on
+ * what is in it gets the bubble it needs, not a guess (issue #368). Both
+ * commits land in the same task and the popup maps last, so it is only ever
+ * on screen placed and at its final size. `width`/`height` still pin an
+ * axis exactly — give both and the measuring pass is skipped entirely; give
+ * one and the other is measured for it, so `width={340}` is a fixed column
+ * whose height fits the message. The element fills the bubble and draws its
+ * own padding; a string gets the bubble's. The size is settled at open —
+ * content that changes size while the hint is up is clipped or short until
+ * the next open, which is a hint's lifetime away.
  *
  * On a display that composites, the popup is a real ARGB window: a rounded
  * bubble with a small arrow pointing back at the trigger, and everything the
@@ -271,14 +280,22 @@ export function Tooltip({
   fontSize = DEFAULT_LABEL_SIZE,
   width,
   height,
+  maxWidth,
+  maxHeight,
   style,
   ...boxProps
 }) {
   const theme = useTheme();
   const app = useApp();
   const ref = useRef(null);
+  const popup = useRef(null);
   const measureAnchor = useAnchor(ref);
   const [rect, setRect] = useState(null);
+  // An element label's measured size — what the hidden pass below produced,
+  // and what placement reads for as long as the hint is up. Text is
+  // measured synchronously instead and never lands here.
+  const [bubble, setBubble] = useState(null);
+  const [measuring, setMeasuring] = useState(false);
   const timer = useRef(null);
   // Whether there is an arrow at all has to be settled *before* the popup
   // exists — it is part of how big the window is — so this is the display
@@ -302,6 +319,10 @@ export function Tooltip({
     cancel();
     if (showing.get(app) === hide) showing.delete(app);
     setRect(null);
+    // the measurement goes with the hint: the next open re-measures, so a
+    // label that changed while nothing showed opens at its new size
+    setBubble(null);
+    setMeasuring(false);
   }, [app, cancel]);
 
   // safe-polygon hover (docs/components.md): leaving the trigger *toward*
@@ -332,45 +353,55 @@ export function Tooltip({
     };
   }, [app, cancel, hide]);
 
-  // The bubble, which is the popup minus whatever the arrow takes.
+  // `!label` would have thrown away `0`, which is a hint like any other;
+  // an empty string is not one
+  const hasLabel = !(label == null || label === false || label === '');
+
+  // The bubble, which is the popup minus whatever the arrow takes: measured
+  // text for a string, the caller's numbers where both were given, and the
+  // hidden pass's answer for an element — null until that pass has run.
   const bubbleSize = (node) => {
-    if (!isText(label)) {
-      return { width: width ?? RICH_WIDTH, height: height ?? RICH_HEIGHT };
+    if (isText(label)) {
+      const text = measureLabel(node, label, { size: fontSize });
+      return {
+        width: width ?? Math.ceil(text.width) + TOOLTIP_PADDING_X * 2,
+        height: height ?? Math.ceil(text.height) + TOOLTIP_PADDING_Y * 2,
+      };
     }
-    const text = measureLabel(node, label, { size: fontSize });
-    return {
-      width: width ?? Math.ceil(text.width) + TOOLTIP_PADDING_X * 2,
-      height: height ?? Math.ceil(text.height) + TOOLTIP_PADDING_Y * 2,
-    };
+    if (width != null && height != null) return { width, height };
+    return bubble;
   };
 
-  const tooltipAnchorOptions = () => {
-    const node = ref.current;
-    // `!label` would have thrown away `0`, which is a hint like any other;
-    // an empty string is not one
-    if (!node || label == null || label === false || label === '') return null;
-    const bubble = bubbleSize(node);
+  // The anchor options for a bubble of this size: which side of the trigger,
+  // and the popup grown by the arrow along the axis that faces it.
+  const optionsFor = (node, size) => {
     const grow = composited ? ARROW_DEPTH : 0;
     const want = placement ?? direction;
     const side =
       want === 'auto'
         ? autoDirection(node, {
-            width: bubble.width + grow,
-            height: bubble.height + grow,
+            width: size.width + grow,
+            height: size.height + grow,
           })
         : want;
     const vertical = side === 'top' || side === 'bottom';
     return {
       placement: side,
       align: 'center',
-      width: bubble.width + (vertical ? 0 : grow),
-      height: bubble.height + (vertical ? grow : 0),
+      width: size.width + (vertical ? 0 : grow),
+      height: size.height + (vertical ? grow : 0),
     };
   };
 
-  const show = () => {
-    const options = tooltipAnchorOptions();
-    if (!options) return;
+  const tooltipAnchorOptions = () => {
+    const node = ref.current;
+    if (!node || !hasLabel) return null;
+    const size = bubbleSize(node);
+    if (!size) return null;
+    return optionsFor(node, size);
+  };
+
+  const place = (options) => {
     const next = measureAnchor(options);
     if (!next) return;
     // claim the slot at the moment there is something to see, so a hint
@@ -379,6 +410,33 @@ export function Tooltip({
     showing.set(app, hide);
     setRect(next);
   };
+
+  const show = () => {
+    if (!ref.current || !hasLabel) return;
+    const options = tooltipAnchorOptions();
+    // No options with a node and a label means an element label whose size
+    // is not known yet: render the popup hidden at its natural size, and
+    // the measuring effect below finishes the job.
+    if (options) place(options);
+    else setMeasuring(true);
+  };
+
+  // The second half of opening an element label: the commit that set
+  // `measuring` rendered the popup hidden — realized, laid out, never
+  // mapped — so its natural size is now a fact. Read it back, run the same
+  // placement `show()` runs, and re-render placed; a layout effect, so both
+  // commits land in the same task, nothing paints in between, and the popup
+  // maps only once it is the right size in the right place.
+  useLayoutEffect(() => {
+    if (!measuring) return;
+    setMeasuring(false);
+    const wnd = popup.current;
+    const node = ref.current;
+    if (!wnd || !node) return;
+    const size = { width: wnd.width, height: wnd.height };
+    setBubble(size);
+    place(optionsFor(node, size));
+  });
 
   // keeps the tooltip pinned to its trigger for as long as it is shown: a
   // scrolled ancestor, the trigger's own layout moving it, or the owner
@@ -407,23 +465,41 @@ export function Tooltip({
   };
 
   /**
-   * The popup, in two absolutely-positioned pieces: the bubble, and the
-   * arrow beside it. Absolute rather than a flex column, because the two are
+   * The popup, in its two lives.
+   *
+   * **Measuring** (no `rect` yet): `hidden` — realized and laid out, never
+   * mapped — with the bubble in flow and no arrow, so the popup's natural
+   * size *is* the bubble's. One commit later the effect above has read it
+   * back and placed it; nothing is ever on screen unplaced.
+   *
+   * **Placed**: two absolutely-positioned pieces, the bubble and the arrow
+   * beside it. Absolute rather than a flex column, because the two are
    * placed by the same arithmetic that decided how big the window is, and
-   * that arithmetic has to run before there is a window to lay anything out
-   * in. Whatever neither covers is the transparent margin the arrow needs to
-   * point through.
+   * that arithmetic has to run before the window is on screen. Whatever
+   * neither covers is the transparent margin the arrow needs to point
+   * through.
+   *
+   * One `<popup>` element for both, so the transition is a configure and a
+   * map on the same X window — never a second window — and the label's
+   * component instances (their state, their subscriptions) survive from the
+   * layout they were measured in to the one that shows them.
    */
   const surface = () => {
     // the side `anchorRect` settled on, which is the one it was asked for
     // unless a screen edge flipped it
-    const side = rect.placement ?? 'top';
+    const side = rect ? (rect.placement ?? 'top') : null;
     const vertical = side === 'top' || side === 'bottom';
-    const arrow = composited
-      ? arrowPlacement(side, rect, screenRect(ref.current), theme.radiusTooltip)
-      : null;
+    const arrow =
+      rect && composited
+        ? arrowPlacement(
+            side,
+            rect,
+            screenRect(ref.current),
+            theme.radiusTooltip,
+          )
+        : null;
     const inset = arrow ? ARROW_DEPTH : 0;
-    const bubble = {
+    const bubbleRect = rect && {
       // the arrow is always on the side facing the trigger, so the bubble is
       // pushed off that edge and fills the rest
       left: side === 'right' ? inset : 0,
@@ -435,13 +511,27 @@ export function Tooltip({
     return h(
       'popup',
       {
+        ref: popup,
         theme,
-        x: rect.x,
-        y: rect.y,
-        width: rect.width,
-        height: rect.height,
         windowType: 'tooltip',
         transparent: true,
+        ...(rect
+          ? { x: rect.x, y: rect.y, width: rect.width, height: rect.height }
+          : {
+              // measuring: never mapped, so the position is nobody's; the
+              // axes the caller pinned stay pinned and the rest are
+              // measured, which is what makes `width` alone a fixed column
+              // whose height fits the content
+              hidden: true,
+              x: 0,
+              y: 0,
+              width: width ?? 'auto',
+              height: height ?? 'auto',
+            }),
+        // in both lives, so the props do not churn between them — inert on
+        // an exact axis, the measurement's cap on an auto one
+        ...(maxWidth != null ? { maxWidth } : null),
+        ...(maxHeight != null ? { maxHeight } : null),
         style: {
           backgroundColor: theme.text,
           '@supports transparency': { backgroundColor: 'transparent' },
@@ -453,25 +543,33 @@ export function Tooltip({
           role: 'tooltip',
           onMouseEnter: cancel,
           onMouseLeave: hide,
-          style: {
-            position: 'absolute',
-            left: bubble.left,
-            top: bubble.top,
-            width: bubble.width,
-            height: bubble.height,
-            justifyContent: 'center',
-            backgroundColor: theme.text,
-            // No border. On a hint this small a 1px outline in a colour
-            // close to the fill is a smudge on the corners and nothing
-            // anywhere else; the arrow is what tells you where it belongs.
-            ...(isText(label)
+          style: [
+            bubbleRect
               ? {
-                  paddingLeft: TOOLTIP_PADDING_X,
-                  paddingRight: TOOLTIP_PADDING_X,
+                  position: 'absolute',
+                  left: bubbleRect.left,
+                  top: bubbleRect.top,
+                  width: bubbleRect.width,
+                  height: bubbleRect.height,
                 }
-              : null),
-            '@supports transparency': { borderRadius: theme.radiusTooltip },
-          },
+              : // measuring: in flow, so the popup takes the bubble's
+                // natural size
+                null,
+            {
+              justifyContent: 'center',
+              backgroundColor: theme.text,
+              // No border. On a hint this small a 1px outline in a colour
+              // close to the fill is a smudge on the corners and nothing
+              // anywhere else; the arrow is what tells you where it belongs.
+              ...(isText(label)
+                ? {
+                    paddingLeft: TOOLTIP_PADDING_X,
+                    paddingRight: TOOLTIP_PADDING_X,
+                  }
+                : null),
+              '@supports transparency': { borderRadius: theme.radiusTooltip },
+            },
+          ],
         },
         // the content is on the inverted surface, and is given the palette
         // that says so — both routes at once, which is what `ThemeProvider`
@@ -515,7 +613,7 @@ export function Tooltip({
       style: [{ flexDirection: 'row', alignItems: 'center' }, style],
     },
     children,
-    rect && surface(),
+    (rect || measuring) && surface(),
   );
 }
 

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -1282,7 +1282,7 @@ export function windowAttributes(props, scale = 1) {
   for (const key of Object.keys(props)) {
     if (key === 'children' || key === 'style' || isEventProp(key)) continue;
     if (key === 'transientFor' || key === 'transparent') continue;
-    if (key === 'anchor') continue;
+    if (key === 'anchor' || key === 'hidden') continue;
     if ((key === 'width' || key === 'height') && isAutoSize(props[key])) {
       continue;
     }
@@ -7821,6 +7821,14 @@ export class WindowNode extends Scrollable(Node) {
     this.root = this;
     this.attributes = attributes;
     this.window = null;
+    // `hidden` has two writers — the reconciler (React hiding a subtree for
+    // `<Suspense>`/`<Activity>`) and the element's own `hidden` prop — and
+    // the window is off screen while *either* says so. The reconciler's half
+    // is remembered here so that a `<Suspense>` revealing its content does
+    // not map a window whose prop still hides it. `this.hidden` stays the
+    // one flag everything reads (`_mapNow`, painting, a11y, anchoring).
+    this._reactHidden = false;
+    this.hidden = Boolean(props.hidden);
     // whether this is the tree's own top-level window rather than a nested
     // one or a popup — decided by realize(), read when it maps
     this._topLevel = false;
@@ -8355,13 +8363,13 @@ export class WindowNode extends Scrollable(Node) {
       // grab whose window stops being viewable, so a menu that hid and
       // reappeared would be one no press outside could dismiss — the
       // `onDismiss` that reads as "click anywhere to close" would simply
-      // stop happening.
+      // stop happening. The re-take is `PopupNode._mapNow`'s, which is what
+      // keeps it beside the map on every route back to the screen.
       if (lost) {
         if (this.props.grab) this.window.ungrabPointer?.();
         this.window.unmap?.();
       } else {
         this._mapNow();
-        if (this.props.grab) this.window.grabPointer?.({}, () => {});
       }
     }
     if (lost || !size) return;
@@ -8577,19 +8585,21 @@ export class WindowNode extends Scrollable(Node) {
    * still ends the startup sequence on its real first map.
    */
   _mapNow() {
-    if (this.destroyed || !this.window || this.hidden) return;
+    if (this.destroyed || !this.window || this.hidden) return false;
     // An `embeddable` window never maps itself: a window waiting to be
     // embedded is unmapped — that is what waiting looks like — and from the
     // reparent on, mapping is the embedder's decision (ntk's XEmbedSocket
     // maps a plain client the moment it takes it). Self-mapping here would
     // put a frame pane on the desktop as a top-level for the beat before
     // its <Frame> embeds it, long enough for a window manager to frame it.
-    if (this.props.embeddable) return;
+    if (this.props.embeddable) return false;
     // An anchor that is not on screen is a popup that has nowhere to be
     // (`_followAnchor`); it maps from there, when the anchor comes back.
-    if (this._anchorLost) return;
+    if (this._anchorLost) return false;
     this.window.map?.();
     if (this._topLevel) this.app._reactX11Startup?.mapped(this.window);
+    // whether the map went out, so `PopupNode` can hang its grab off it
+    return true;
   }
 
   /**
@@ -9506,6 +9516,10 @@ export class WindowNode extends Scrollable(Node) {
         ...this.attributes,
         ...windowAttributes(newProps, this.scale),
       };
+      // The flag `realize()`'s map will read — set directly, since there is
+      // nothing on screen yet for the notification half of `_applyHidden`
+      // to be about.
+      this.hidden = this._reactHidden || Boolean(newProps.hidden);
       return;
     }
 
@@ -9603,6 +9617,13 @@ export class WindowNode extends Scrollable(Node) {
       const wasLost = this._anchorLost;
       this._anchorLost = false;
       if (wasLost) this._mapNow();
+    }
+
+    // After the geometry above on purpose: a window revealed and moved in
+    // the same commit is configured first and mapped second, so it is never
+    // on screen at the position it was hidden at.
+    if (Boolean(newProps.hidden) !== Boolean(before.hidden)) {
+      this._applyHidden();
     }
 
     const layoutChanged =
@@ -9765,6 +9786,20 @@ export class WindowNode extends Scrollable(Node) {
    * gone out yet not to bother.
    */
   setHidden(hidden) {
+    this._reactHidden = hidden;
+    this._applyHidden();
+  }
+
+  /**
+   * Re-derive `this.hidden` from its two writers — the reconciler's flag and
+   * the `hidden` prop — and make the window agree. Either saying "hidden"
+   * wins, so a `<Suspense>` revealing its content does not map a window the
+   * app is holding off screen, and clearing the prop does not map one React
+   * still hides.
+   */
+  _applyHidden() {
+    const hidden = this._reactHidden || Boolean(this.props.hidden);
+    if (hidden === this.hidden) return;
     this.hidden = hidden;
     // An unmapped window draws nothing, so a loop inside one is frames
     // nobody sees — the same stop the WM's own minimize gets, by the same
@@ -9781,8 +9816,21 @@ export class WindowNode extends Scrollable(Node) {
     // do nothing anyway, the server not having mapped the window yet
     // (issue #201).
     if (pendingMaps.has(this)) return;
-    if (hidden) this.window?.unmap?.();
-    else this._mapNow();
+    if (hidden) {
+      // release before the unmap, the order `_followAnchor` uses — X would
+      // drop the grab with the viewability anyway, but not on the mock, and
+      // an explicit release is one less state to reason about
+      if (this.props.grab) this.window?.ungrabPointer?.();
+      this.window?.unmap?.();
+    } else if (inCommit) {
+      // A reveal mid-commit waits for the end of it the way a fresh window's
+      // first map does, so anything later in the same commit that hides the
+      // window again (React hides a subtree only after mutating it) is
+      // known before the map goes out — the same WM race as issue #201.
+      pendingMaps.add(this);
+    } else {
+      this._mapNow();
+    }
   }
 
   /**
@@ -10720,12 +10768,19 @@ export class PopupNode extends WindowNode {
    * user clicked. With the grab, that press arrives here instead, outside
    * our bounds, and `onDismiss` fires. Needs ntk >= 3.7.0; without it the
    * popup simply behaves as before.
+   *
+   * The grab rides the map, not `realize()`: X refuses a grab on an
+   * unviewable window (`GrabNotViewable`) and silently drops one whose
+   * window unmaps, so a popup born `hidden` — or one whose anchor is off
+   * screen — takes the grab when it actually reaches the screen. Grabbing
+   * from realize looked equivalent until `hidden` existed, and would have
+   * left a revealed menu holding no grab: open forever behind the first
+   * outside click, with nothing saying why.
    */
-  realize(parentWindow) {
-    super.realize(parentWindow);
-    if (this.props.grab && !this.destroyed) {
-      this.window?.grabPointer?.({}, () => {});
-    }
+  _mapNow() {
+    if (!super._mapNow()) return false;
+    if (this.props.grab) this.window.grabPointer?.({}, () => {});
+    return true;
   }
 
   destroySubtree() {

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -385,9 +385,10 @@ export type Placement = 'top' | 'bottom' | 'left' | 'right';
 export interface TooltipProps extends WidgetProps {
   /**
    * The hint. A string is measured and the popup sized around it; an
-   * element is given the bubble to fill and sized by {@link TooltipProps.width}
-   * / {@link TooltipProps.height}, since a `<popup>` is a real X window and
-   * needs its size before anything in it can be laid out.
+   * element **self-sizes too** — the popup is rendered once hidden at its
+   * natural size, read back, and placed before it is ever mapped — so a card
+   * whose height depends on its content needs no numbers. It gets the
+   * bubble to fill and draws its own padding.
    */
   label: ReactNode;
   children?: ReactNode;
@@ -403,10 +404,21 @@ export interface TooltipProps extends WidgetProps {
   /** ms before it appears (default 500). */
   delay?: number;
   fontSize?: number;
-  /** The bubble's size. Required for an element `label` (defaults to
-   * 220×80); for text it overrides the measured size. */
+  /**
+   * Pin an axis of the bubble exactly. For text they override the measured
+   * size; for an element, a pinned axis stays pinned and the other is
+   * measured for it — `width={340}` is a fixed column whose height fits the
+   * message. Give both and nothing is measured at all.
+   */
   width?: number;
   height?: number;
+  /**
+   * Cap what an element label may measure out to, on top of the screen's
+   * own cap. Inert on an axis pinned by {@link TooltipProps.width} /
+   * {@link TooltipProps.height}, and on a text label, which stays one line.
+   */
+  maxWidth?: number;
+  maxHeight?: number;
   style?: StyleProp;
 }
 export const Tooltip: ComponentType<TooltipProps>;

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -273,6 +273,20 @@ export interface WindowProps
    */
   embeddable?: boolean;
   /**
+   * Realized and laid out, but not on screen: the X window exists at its
+   * size (auto sizes included — the content is really measured), the tree
+   * behind it is live, and the window is simply never mapped while this is
+   * true. Clearing it maps the window where it stands; unlike conditional
+   * rendering, nothing unmounts in between, so state, subscriptions and the
+   * X window itself survive a hide.
+   *
+   * What `Tooltip` measures an element label in before placing it, and the
+   * declarative form of "minimize by unmapping". A subtree hidden by React
+   * (`<Activity mode="hidden">`, a suspended `<Suspense>`) composes with it:
+   * the window is on screen only when neither says hidden.
+   */
+  hidden?: boolean;
+  /**
    * Window geometry — window state, not yoga style: the user may resize.
    *
    * `'auto'`, which is also what leaving the prop out means, sizes the

--- a/test/popup-chrome.test.js
+++ b/test/popup-chrome.test.js
@@ -419,6 +419,93 @@ test('an element label fills a bubble the caller sized', async () => {
   await x11Root.unmount();
 });
 
+// --- element labels sizing themselves (issue #368) --------------------------
+
+test('an element label with no size is measured, placed, and only then mapped', async () => {
+  const { x11Root, wrapper, tip } = await showTip(
+    {
+      label: h('box', { style: { width: 140, height: 48 } }),
+    },
+    // enough padding that a 54px hint has room above the trigger
+    { screen: ROOMY, pad: 120 },
+  );
+
+  // sized from the content, not from a default
+  assert.equal(tip.width, 140);
+  assert.equal(tip.height, 48 + ARROW_DEPTH, 'the arrow rides on top');
+  const [bubble] = tip._reactX11Node.children;
+  assert.equal(bubble.abs.width, 140);
+  assert.equal(bubble.abs.height, 48);
+  assert.equal(bubble.style.paddingLeft, undefined, 'still no imposed padding');
+
+  // placed by the same math a sized label gets: centred above the trigger
+  assert.equal(tip.y + tip.height + 2, wrapper.abs.y, 'above, 2px gap');
+  const off = tip.x + tip.width / 2 - (wrapper.abs.x + wrapper.abs.width / 2);
+  assert.ok(Math.abs(off) <= 1, `centred on the trigger (off by ${off}px)`);
+
+  // measure-then-place, and the map goes out last: the window was born
+  // hidden at its natural size, configured to its final rect, and mapped
+  // only then — at no point was it on screen anywhere else
+  assert.equal(tip.mapped, true);
+  const maps = tip.calls.filter(([op]) => op === 'map');
+  assert.equal(maps.length, 1, 'mapped exactly once');
+  const mapAt = tip.calls.findIndex(([op]) => op === 'map');
+  const moveAt = tip.calls.findIndex(([op]) => op === 'move');
+  assert.ok(moveAt >= 0 && moveAt < mapAt, 'placed before it was mapped');
+
+  await x11Root.unmount();
+});
+
+test('one pinned axis stays pinned; the other is measured for it', async () => {
+  const { x11Root, tip } = await showTip(
+    {
+      label: h('box', { style: { width: 120, height: 40 } }),
+      width: 200,
+    },
+    { screen: ROOMY },
+  );
+
+  assert.equal(tip.width, 200, 'the caller’s column width');
+  assert.equal(tip.height, 40 + ARROW_DEPTH, 'the content’s height');
+
+  await x11Root.unmount();
+});
+
+test('maxWidth caps what an element label measures out to', async () => {
+  const { x11Root, tip } = await showTip(
+    {
+      label: h(
+        'box',
+        { style: { flexDirection: 'row' } },
+        h('box', { style: { width: 100, height: 20 } }),
+        h('box', { style: { width: 100, height: 20 } }),
+      ),
+      maxWidth: 150,
+    },
+    { screen: ROOMY },
+  );
+
+  assert.equal(tip.width, 150, 'capped, not the 200 the row wanted');
+  assert.equal(tip.height, 20 + ARROW_DEPTH);
+
+  await x11Root.unmount();
+});
+
+test('a measured hint hides on leave like any other', async () => {
+  const { x11Root, wnd, tip } = await showTip(
+    { label: h('box', { style: { width: 60, height: 22 } }) },
+    { screen: ROOMY },
+  );
+  assert.equal(tip.mapped, true);
+
+  moveMouse(wnd, 2, 2);
+  await tick();
+  await tick();
+  assert.equal(tip.destroyed, true);
+
+  await x11Root.unmount();
+});
+
 test('direction="auto" goes above where it fits, and below where it does not', async () => {
   const roomy = await showTip({}, { screen: ROOMY });
   const [above, aboveArrow] = roomy.tip._reactX11Node.children;

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -5926,3 +5926,116 @@ test('decorations={false} writes _MOTIF_WM_HINTS with its own type atom', async 
 
   await x11Root.unmount();
 });
+
+test('hidden: a window renders realized and laid out, but never mapped', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const render = (hidden) =>
+    x11Root.render(
+      React.createElement(
+        'window',
+        { width: 200, height: 100, hidden },
+        React.createElement('box', {
+          style: { width: 80, height: 30 },
+        }),
+      ),
+    );
+  render(true);
+  await tick();
+
+  const wnd = app.windows[0];
+  assert.strictEqual(wnd.mapped, false, 'realized, not mapped');
+  assert.strictEqual(
+    wnd._reactX11Node.children[0].abs.width,
+    80,
+    'and the tree behind it is laid out',
+  );
+
+  // clearing the prop is what puts it on screen
+  render(false);
+  await tick();
+  assert.strictEqual(wnd.mapped, true);
+
+  // …and setting it back takes it off without unmounting anything
+  render(true);
+  await tick();
+  assert.strictEqual(wnd.mapped, false);
+  assert.strictEqual(wnd.destroyed, false);
+  assert.strictEqual(
+    wnd.calls.filter(([op]) => op === 'map').length,
+    1,
+    'one map, one unmap — never a second window',
+  );
+
+  await x11Root.unmount();
+});
+
+test('hidden: a popup with an auto size is born at its natural size, unmapped', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(
+    React.createElement(
+      'window',
+      { width: 300, height: 200 },
+      React.createElement(
+        'popup',
+        { hidden: true, x: 0, y: 0 },
+        React.createElement('box', { style: { width: 130, height: 44 } }),
+      ),
+    ),
+  );
+  await tick();
+
+  const popup = app.windows[1];
+  assert.strictEqual(popup.attributes.overrideRedirect, true);
+  assert.strictEqual(popup.mapped, false);
+  assert.strictEqual(popup.width, 130, 'measured, so the size is readable');
+  assert.strictEqual(popup.height, 44);
+
+  await x11Root.unmount();
+});
+
+test('hidden: a grabbing popup takes the grab on reveal, not while hidden', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const render = (hidden) =>
+    x11Root.render(
+      React.createElement(
+        'window',
+        { width: 300, height: 200 },
+        React.createElement('popup', {
+          grab: true,
+          hidden,
+          x: 10,
+          y: 10,
+          width: 80,
+          height: 60,
+        }),
+      ),
+    );
+  render(true);
+  await tick();
+
+  const popup = app.windows[1];
+  // X refuses a grab on an unviewable window (GrabNotViewable), so taking
+  // it here would only look like it worked on the mock
+  assert.strictEqual(popup.mapped, false);
+  assert.strictEqual(popup.grabbed, undefined, 'no grab while hidden');
+
+  render(false);
+  await tick();
+  assert.strictEqual(popup.mapped, true);
+  assert.strictEqual(popup.grabbed, true, 'the grab rides the map');
+  const calls = popup.calls.map(([op]) => op);
+  assert.ok(
+    calls.indexOf('map') < calls.indexOf('grabPointer'),
+    'mapped first: a grab before the map is refused server-side',
+  );
+
+  render(true);
+  await tick();
+  assert.strictEqual(popup.mapped, false);
+  assert.strictEqual(popup.grabbed, false, 'released with the hide');
+
+  await x11Root.unmount();
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -835,6 +835,14 @@ function Widgets() {
         <Tooltip label="hi" placement="bottom" delay={200}>
           <box />
         </Tooltip>
+        {/* an element label self-sizes; maxWidth/maxHeight cap what it
+            measures out to, and one pinned axis leaves the other measured */}
+        <Tooltip label={<box style={{ padding: 8 }} />} maxWidth={340}>
+          <box />
+        </Tooltip>
+        <Tooltip label={<box />} width={340} maxHeight={200}>
+          <box />
+        </Tooltip>
 
         <RadioGroup<string>
           value="a"
@@ -1501,6 +1509,9 @@ function _Panes() {
         />
         {/* an embeddable window never maps itself */}
         <window embeddable width={200} height={100} />
+        {/* hidden: realized and laid out, never mapped while true */}
+        <window hidden width={200} height={100} />
+        <popup hidden x={0} y={0} />
       </window>
     </Session.Provider>
   );


### PR DESCRIPTION
Closes #368.

An element-labeled `Tooltip` was the one place in the renderer a caller had to guess pixels. This takes the issue's direction (1) — *measure while unmapped, then place* — and it turns out the renderer already had almost all of it: a `<popup>`'s natural size is settled before `CreateWindow`, so the only missing primitive was rendering one **without mapping it**.

## How it works

- **New core prop: `<window hidden>` / `<popup hidden>`** — realized and laid out, never mapped while true. The X window exists at its size (auto sizes included — the content is really measured), and clearing the prop maps it where it stands. It composes with React's own hiding (`<Activity mode="hidden">`, a suspended `<Suspense>`): the window is on screen only while *neither* says hidden. It is also the declarative form of what `examples/wm.jsx` does by hand — minimize by unmapping.
- **`Tooltip` element labels measure themselves.** On open, the popup is rendered once `hidden` at its natural size; a layout effect reads the size back, runs the *existing* placement math (`autoDirection`, arrow growth, `anchorRect`) and re-renders placed. Both commits land in the same task and the map goes out last, after the configure — the popup is never on screen unplaced or unsized, so there is nothing to flash. One `<popup>` element serves both passes, so the transition is a configure + map on the same X window and the label's component instances (state, subscriptions) survive from the layout they were measured in to the one that shows them.
- **`width`/`height` still pin an axis exactly.** Both given → the measuring pass is skipped entirely (the old guaranteed-fit mode, unchanged); one given → the other is measured *for it*, so `width={340}` is a fixed column whose height fits the message — this also covers the issue's `<CreatorPreview>` case with one number instead of two guesses.
- **New `maxWidth`/`maxHeight`** on `Tooltip` — direction (4)'s cap semantics, in the same vocabulary `<window>`/`<popup>` already use — bound what an element label measures out to, inside the screen's own cap.
- **Text labels are untouched**: still measured synchronously, still a single commit.

One bug fixed in passing because `hidden` exposed it: `PopupNode` took its pointer `grab` in `realize()`, but X refuses a grab on an unviewable window (`GrabNotViewable`) — so a popup born hidden would have come back to the screen holding no grab, i.e. a menu no outside click could dismiss. The grab now rides `_mapNow()`, which also serves the anchor-scrolled-away-and-back path that previously re-grabbed inline.

## Before / after

The issue's own scenario — a protocol inspector where hovering a resource shows a card whose content (a swatch, a decoded thumbnail, or neither) is not knowable up front. Before: every card gets the same `340×110`; the one-liner swims and the tall card is clipped. After: no numbers passed, each card is exactly the size of its content (113×52, 226×121, 184×63).

<!-- drag in: before.png -->
<!-- drag in: after.png -->

And the shipped `examples/tooltips.jsx`, updated to demonstrate both modes — the swatch cards fully self-sized, the `ProgressBar` card with `width` pinned and height measured:

<!-- drag in: example.png -->

(Shots are rendered by this PR's code against node-x11's in-process X server; it has no 32-bit visual, so they show the square no-compositor fallback rather than the rounded/arrow design. The composited path is covered by the popup-chrome tests; a hover on a live compositor is worth a look before merging.)

## Tests

- `popup-chrome.test.js`: element label with no size is measured, placed by the same math, and **mapped only after the move** (call-order asserted); one pinned axis leaves the other measured; `maxWidth` caps the measurement; a measured hint hides on leave. All existing tooltip tests (string labels, fully-sized element labels, auto direction, axis change, one-at-a-time) pass unchanged.
- `smoke.test.js`: `hidden` renders realized-and-laid-out but unmapped, flips on prop change without unmounting (one map, one unmap, same window); an auto-sized hidden popup is born at its natural size with the size readable; a grabbing popup takes the grab on reveal, not while hidden, and releases it on hide.
- `test/types/api.tsx` covers the new props; docs updated (`elements.md` `hidden` section, `components.md` Tooltip sizing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
