### PR TITLE
feat(button): outline and ghost variants, a small size, and the ink reaches element children

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -493,12 +493,45 @@ one. See [docs/ecosystem/forms.md](ecosystem/forms.md).
 
 ### `Button`
 
-| prop                 |                                           |
-| -------------------- | ----------------------------------------- |
-| `children` / `label` | the label                                 |
-| `onPress()`          | click, Space or Enter                     |
-| `primary`            | accent fill instead of the surface colour |
-| `disabled`           | inert, dimmed, not focusable              |
+| prop                 |                                                                         |
+| -------------------- | ----------------------------------------------------------------------- |
+| `children` / `label` | the label                                                               |
+| `onPress()`          | click, Space or Enter                                                   |
+| `variant`            | `'solid'` (default), `'outline'`, `'ghost'` — the chrome                |
+| `size`               | `'medium'` (default) or `'small'` — the compact metric                  |
+| `primary`            | speaks in the accent: the fill when solid, the ink and border otherwise |
+| `disabled`           | inert, dimmed, not focusable                                            |
+
+Chrome and colour are two axes, and they compose. `variant` is how much box
+the button carries — `solid` a fill, `outline` a border on nothing, `ghost`
+neither, for the affordance that sits inside other content (a `✕` on a chip,
+a delete on a form row) and must not add a box to the row it lives in.
+`primary` is whose colours it speaks in. So a dialog footer is an `outline`
+beside a `primary` solid, and a toolbar's loudest icon is
+`primary variant="ghost"` — every combination keeps the widget states, which
+is the point of not hand-drawing the chrome-less ones. All variants keep the
+border _width_, so a mixed row lines up to the pixel.
+
+`size="small"` halves the control padding — the toolbar and inline-row
+metric. It is derived from the palette, so a theme that moves `paddingY`
+moves both sizes together, which a hand-made `style={{ height: 22 }}` would
+not.
+
+An **element** child inherits the resolved label colour — the ink is set on
+the button's box and `color` inherits ([styling.md](styling.md)) — so an
+icon+label button is correct by construction in every state, disabled
+included, with nothing passed to the icon:
+
+```jsx
+<Button primary disabled={busy} onPress={run}>
+  <Icon name="chevronRight" />
+  Continue
+</Button>
+
+<Button variant="ghost" size="small" aria-label="Remove" onPress={remove}>
+  <Icon name="close" />
+</Button>
+```
 
 ### `Checkbox`
 

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -7,10 +7,29 @@ import { labelContent, useControl, useTheme } from './theme.js';
 
 const h = React.createElement;
 
+const VARIANTS = ['solid', 'outline', 'ghost'];
+const SIZES = ['medium', 'small'];
+
 /**
- * <Button onPress primary disabled …boxProps>label</Button> — the standard
- * push button the examples kept re-implementing: hover/press/focus feedback,
- * Space/Enter activation, pointer cursor.
+ * <Button onPress variant size primary disabled …boxProps>label</Button> —
+ * the standard push button the examples kept re-implementing: hover/press/
+ * focus feedback, Space/Enter activation, pointer cursor.
+ *
+ * Two axes rather than one list of looks. `variant` is how much chrome the
+ * button carries — `solid` a fill, `outline` a border on nothing, `ghost`
+ * neither, for the affordance that sits *inside* other content (a `✕` on a
+ * chip, a jump arrow beside a value) and must not add a box to the row it
+ * lives in. `primary` is whose colours it speaks in: the accent as the fill
+ * when there is one, the accent as ink and border when there is not. The
+ * axes compose, so a dialog footer's secondary action is `variant="outline"`
+ * next to a `primary` solid, and a toolbar's loudest icon is
+ * `primary variant="ghost"` — one component, one set of states.
+ *
+ * `size="small"` is the compact metric a toolbar or an inline row wants:
+ * half the control padding, everything else in proportion. In the component
+ * rather than in a `style` because the padding is derived from the palette —
+ * a theme that moves `paddingY` moves both sizes together, where a hand-made
+ * `{ height: 22 }` would be left behind.
  *
  * `onPress` fires on the **release**, as a click does everywhere — so the
  * button darkens on the press instead, and keeps the darker fill for as long
@@ -24,24 +43,55 @@ export function Button({
   label,
   onPress,
   primary = false,
+  variant = 'solid',
+  size = 'medium',
   disabled = false,
   style,
   ...boxProps
 }) {
+  // Before the hook on purpose, as `<Icon name>` does it: an unknown value
+  // never renders, so the message lands on the call site — where TypeScript
+  // is not there to catch the typo, silence would be an outline button.
+  if (!VARIANTS.includes(variant)) {
+    throw new Error(
+      `<Button variant="${variant}">: one of ${VARIANTS.join(', ')}`,
+    );
+  }
+  if (!SIZES.includes(size)) {
+    throw new Error(`<Button size="${size}">: one of ${SIZES.join(', ')}`);
+  }
   const theme = useTheme();
   const { props, style: controlStyle } = useControl(disabled, onPress, {
     styled: true,
   });
-  const background = disabled
-    ? theme.surfaceHover
-    : primary
-      ? theme.accent
-      : theme.surface;
+  const solid = variant === 'solid';
+  const ghost = variant === 'ghost';
+  const small = size === 'small';
+  const background = !solid
+    ? // `transparent` rather than the ground's colour: an outline or ghost
+      // button sits on whatever it sits on — a toolbar, a card, a table row —
+      // and naming a fill would give it a box on any ground but one
+      'transparent'
+    : disabled
+      ? theme.surfaceHover
+      : primary
+        ? theme.accent
+        : theme.surface;
   const color = disabled
     ? theme.textMuted
     : primary
-      ? theme.accentText
+      ? solid
+        ? theme.accentText
+        : theme.accent
       : theme.text;
+  // A ghost button keeps the border *width* and loses only the colour, so
+  // every variant is the same sum and a mixed row lines up — a field padded
+  // with `$paddingY` is exactly this tall too (docs/styling.md).
+  const borderColor = ghost
+    ? 'transparent'
+    : disabled || !primary
+      ? theme.border
+      : theme.accent;
   return h(
     'box',
     {
@@ -55,43 +105,74 @@ export function Button({
           flexDirection: 'row',
           alignItems: 'center',
           justifyContent: 'center',
-          gap: 8,
-          paddingTop: theme.paddingY,
-          paddingBottom: theme.paddingY,
-          paddingLeft: theme.paddingX,
-          paddingRight: theme.paddingX,
-          borderRadius: theme.radius,
+          gap: small ? 6 : 8,
+          paddingTop: small ? Math.round(theme.paddingY / 2) : theme.paddingY,
+          paddingBottom: small
+            ? Math.round(theme.paddingY / 2)
+            : theme.paddingY,
+          paddingLeft: small ? Math.round(theme.paddingX / 2) : theme.paddingX,
+          paddingRight: small ? Math.round(theme.paddingX / 2) : theme.paddingX,
+          borderRadius: small ? theme.radiusSmall : theme.radius,
           borderWidth: theme.borderWidth,
-          borderColor: disabled
-            ? theme.border
-            : primary
-              ? theme.accent
-              : theme.border,
+          borderColor,
           backgroundColor: background,
+          // The label ink goes on the box, not on the label: `color` is
+          // inherited (docs/styling.md), so an element child — an <Icon>,
+          // a <text> — takes the same answer a string child always got,
+          // and an icon+label button dims as one thing when disabled.
+          color,
         },
         // All three as state blocks: a repaint of one node each, where React
         // state re-rendered the button and its label to change a colour.
         // `:focus-visible` rather than `:focus` is the difference between
         // "you clicked here" and "your keyboard is here", and only the
         // second is worth a ring.
-        !disabled && {
-          ':hover': {
-            backgroundColor: primary ? theme.accentHover : theme.surfaceHover,
-            borderColor: primary ? theme.accentHover : theme.border,
-          },
-          // the border follows the fill: a dark pressed face inside a
-          // resting-coloured ring reads as a rendering bug, not a press
-          ':active': {
-            backgroundColor: primary ? theme.accentActive : theme.surfaceActive,
-            borderColor: primary ? theme.accentActive : theme.textMuted,
-          },
-          ':focus-visible': {
-            borderColor: primary ? theme.accentHover : theme.borderFocus,
-          },
-        },
+        !disabled &&
+          (solid
+            ? {
+                ':hover': {
+                  backgroundColor: primary
+                    ? theme.accentHover
+                    : theme.surfaceHover,
+                  borderColor: primary ? theme.accentHover : theme.border,
+                },
+                // the border follows the fill: a dark pressed face inside a
+                // resting-coloured ring reads as a rendering bug, not a press
+                ':active': {
+                  backgroundColor: primary
+                    ? theme.accentActive
+                    : theme.surfaceActive,
+                  borderColor: primary ? theme.accentActive : theme.textMuted,
+                },
+                ':focus-visible': {
+                  borderColor: primary ? theme.accentHover : theme.borderFocus,
+                },
+              }
+            : {
+                // Outline and ghost answer the pointer with the neutral wash
+                // whichever colours they speak in: the surface steps are the
+                // hover-and-press ramp for anything without an accent fill,
+                // and the background paints under the border band, so a ghost
+                // button's wash covers the full box.
+                ':hover': { backgroundColor: theme.surfaceHover },
+                ':active': {
+                  backgroundColor: theme.surfaceActive,
+                  ...(ghost
+                    ? null
+                    : {
+                        borderColor: primary
+                          ? theme.accentActive
+                          : theme.textMuted,
+                      }),
+                },
+                // …which on a ghost button makes the border appear, and that
+                // is right: the keyboard has no hover, so the ring is how a
+                // chrome-less control says "your keyboard is here".
+                ':focus-visible': { borderColor: theme.borderFocus },
+              }),
         style,
       ],
     },
-    labelContent(children ?? label, { color }),
+    labelContent(children ?? label),
   );
 }

--- a/src/types/components.d.ts
+++ b/src/types/components.d.ts
@@ -275,6 +275,10 @@ export interface ButtonProps extends WidgetProps {
   label?: string;
   onPress?: (ev: MouseEvent<DrawnNode>) => void;
   primary?: boolean;
+  /** How much chrome: a fill, a border on nothing, or neither. */
+  variant?: 'solid' | 'outline' | 'ghost';
+  /** `'small'` is the compact metric for toolbars and inline rows. */
+  size?: 'medium' | 'small';
   disabled?: boolean;
   style?: StyleProp;
 }

--- a/test/button-variants.test.js
+++ b/test/button-variants.test.js
@@ -1,0 +1,206 @@
+// The Button axes (#369): `variant` is how much chrome the control carries,
+// `size` is the toolbar metric, and the resolved label ink lands on the box
+// so an *element* child — an <Icon>, a <text> — is coloured the way a string
+// child always was.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+
+import { Button, Icon, createRoot } from '../src/index.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+const settle = async () => {
+  await tick();
+  await tick();
+};
+
+const rootOf = (app) => app.windows[0]._reactX11Node;
+
+const find = (node, pred) =>
+  pred(node)
+    ? node
+    : node.children.reduce(
+        (a, c) => a || (c.isWindow ? null : find(c, pred)),
+        null,
+      );
+
+async function mount(element, width = 400, height = 300) {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(h('window', { width, height }, element));
+  await settle();
+  return { app, x11Root, wnd: app.windows[0], tree: rootOf(app) };
+}
+
+const centre = (node) => ({
+  x: node.abs.x + node.abs.width / 2,
+  y: node.abs.y + node.abs.height / 2,
+});
+
+const buttons = (tree) => {
+  const found = [];
+  const walk = (n) => {
+    if (n.props?.role === 'button') found.push(n);
+    for (const c of n.children) if (!c.isWindow) walk(c);
+  };
+  walk(tree);
+  return found;
+};
+
+// --- the chrome axis ----------------------------------------------------
+
+test('outline keeps the border and loses the fill; ghost loses both', async () => {
+  const { x11Root, tree } = await mount(
+    h(
+      'box',
+      { style: { flexDirection: 'row', gap: 8 } },
+      h(Button, { variant: 'outline' }, 'Outline'),
+      h(Button, { variant: 'ghost' }, 'Ghost'),
+    ),
+  );
+  const [outline, ghost] = buttons(tree);
+  const theme = outline.theme;
+
+  assert.strictEqual(outline.style.backgroundColor, 'transparent');
+  assert.strictEqual(outline.style.borderColor, theme.border);
+
+  assert.strictEqual(ghost.style.backgroundColor, 'transparent');
+  assert.strictEqual(ghost.style.borderColor, 'transparent');
+
+  await x11Root.unmount();
+});
+
+test('primary speaks in the accent: the fill when solid, the ink and border otherwise', async () => {
+  const { x11Root, tree } = await mount(
+    h(
+      'box',
+      { style: { flexDirection: 'row', gap: 8 } },
+      h(Button, { primary: true }, 'Solid'),
+      h(Button, { primary: true, variant: 'outline' }, 'Outline'),
+      h(Button, { primary: true, variant: 'ghost' }, 'Ghost'),
+    ),
+  );
+  const [solid, outline, ghost] = buttons(tree);
+  const theme = solid.theme;
+
+  assert.strictEqual(solid.style.backgroundColor, theme.accent);
+  assert.strictEqual(solid.style.color, theme.accentText);
+
+  assert.strictEqual(outline.style.backgroundColor, 'transparent');
+  assert.strictEqual(outline.style.borderColor, theme.accent);
+  assert.strictEqual(outline.style.color, theme.accent);
+
+  assert.strictEqual(ghost.style.borderColor, 'transparent');
+  assert.strictEqual(ghost.style.color, theme.accent);
+
+  await x11Root.unmount();
+});
+
+test('every variant is the same sum, so a mixed row lines up', async () => {
+  // The ghost button keeps the border *width* and loses only the colour;
+  // otherwise it would come out 2px shorter than the solid one beside it.
+  const { x11Root, tree } = await mount(
+    h(
+      'box',
+      { style: { flexDirection: 'row', gap: 8, alignItems: 'flex-start' } },
+      h(Button, null, 'A'),
+      h(Button, { variant: 'outline' }, 'B'),
+      h(Button, { variant: 'ghost' }, 'C'),
+    ),
+  );
+  const [a, b, c] = buttons(tree);
+  assert.ok(a.abs.height > 0, 'laid out');
+  assert.strictEqual(b.abs.height, a.abs.height, 'outline matches solid');
+  assert.strictEqual(c.abs.height, a.abs.height, 'ghost matches solid');
+
+  await x11Root.unmount();
+});
+
+// --- the size axis ------------------------------------------------------
+
+test('size="small" halves the control padding, from the palette', async () => {
+  const { x11Root, tree } = await mount(
+    h(
+      'box',
+      { style: { flexDirection: 'row', gap: 8, alignItems: 'flex-start' } },
+      h(Button, null, 'Medium'),
+      h(Button, { size: 'small' }, 'Small'),
+    ),
+  );
+  const [medium, small] = buttons(tree);
+  const theme = medium.theme;
+  const shrink = 2 * (theme.paddingY - Math.round(theme.paddingY / 2));
+  assert.strictEqual(medium.abs.height - small.abs.height, shrink);
+
+  await x11Root.unmount();
+});
+
+// --- the ink reaches element children -----------------------------------
+
+test('an element child inherits the resolved label colour', async () => {
+  const { x11Root, tree } = await mount(
+    h(
+      'box',
+      { style: { flexDirection: 'row', gap: 8 } },
+      h(Button, { primary: true }, h(Icon, { name: 'chevronRight' }), 'Go'),
+      h(Button, { disabled: true }, h(Icon, { name: 'close' }), 'No'),
+    ),
+  );
+  const [primary, disabled] = buttons(tree);
+  const theme = primary.theme;
+  const iconOf = (btn) => find(btn, (n) => n.kind === 'canvas');
+
+  assert.strictEqual(
+    iconOf(primary).resolvedTextStyle().color,
+    theme.accentText,
+    'the icon reads the same ink the label does',
+  );
+  assert.strictEqual(
+    iconOf(disabled).resolvedTextStyle().color,
+    theme.textMuted,
+    'and dims with the control when it is disabled',
+  );
+
+  await x11Root.unmount();
+});
+
+// --- the press still answers without chrome ------------------------------
+
+test('a held ghost button paints the neutral pressed wash', async () => {
+  // A chrome-less button still owes an answer on the press (AGENTS.md,
+  // "Answer the input"): the surface ramp is the feedback the accent fill
+  // provides for solid, and it has to reach the wire before the release.
+  const { x11Root, wnd, tree } = await mount(
+    h(Button, { variant: 'ghost' }, 'Go'),
+  );
+  const [button] = buttons(tree);
+  const theme = button.theme;
+  wnd.ctx.ops.length = 0;
+
+  // deliberately no mouseup: holding the button is the gesture under test
+  wnd.emit('mousedown', { ...centre(button), keycode: 1 });
+
+  assert.ok(
+    wnd.ctx.ops.some((op) => op.includes(theme.surfaceActive)),
+    `painted ${theme.surfaceActive} from the press handler`,
+  );
+
+  await x11Root.unmount();
+});
+
+// --- the call-site check ------------------------------------------------
+
+test('an unknown variant or size throws before anything renders', () => {
+  // Reachable without a tree, as <Icon name>'s check is: the throw is
+  // ahead of the hooks on purpose, so the message lands on the call site.
+  assert.throws(
+    () => Button({ variant: 'filled', children: 'x' }),
+    /one of solid, outline, ghost/,
+  );
+  assert.throws(
+    () => Button({ size: 'tiny', children: 'x' }),
+    /one of medium, small/,
+  );
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -754,6 +754,17 @@ function Widgets() {
           press
         </Button>
         <Button label="labelled" disabled />
+        {/* the two axes compose: chrome and colour are separate choices,
+            and an element child needs no colour of its own — it inherits
+            the resolved label ink from the button's box */}
+        <Button variant="ghost" size="small" aria-label="Close">
+          <Icon name="close" />
+        </Button>
+        <Button variant="outline" primary label="secondary" />
+        {/* @ts-expect-error - not a variant */}
+        <Button variant="filled" label="no" />
+        {/* @ts-expect-error - not a size */}
+        <Button size="tiny" label="no" />
         {/* the system icon set: a name from the union, and the drawings
             themselves for anything wanting the glyph without the component */}
         <Icon name="chevronDown" />

--- a/website/src/demos/widgets.js
+++ b/website/src/demos/widgets.js
@@ -35,6 +35,8 @@ function Controls() {
       <box style={{ flexDirection: 'row', gap: 10, alignItems: 'center' }}>
         <Button primary onPress={() => setVolume(0)}>Mute</Button>
         <Button onPress={() => setVolume(100)}>Max</Button>
+        <Button variant="outline" onPress={() => setVolume(45)}>Reset</Button>
+        <Button variant="ghost" size="small" onPress={() => setVolume(45)}>Ghost</Button>
         <Button disabled>Disabled</Button>
       </box>
 


### PR DESCRIPTION
Closes #369 — all three gaps, as one change, because they are the same story: the moment an app needs an icon in a button, a compact button, or a chrome-less button, it stops using `<Button>` and starts hand-drawing controls that no longer match the toolkit's states.

![button-369](https://github.com/user-attachments/assets/fad25860-108b-4286-829d-343a0a8c190b)

*Rendered by this PR's code, headlessly, into node-x11's in-process server — both `Held` buttons are genuinely held (mousedown, no mouseup), one press chain per window.*

## Two axes, not one list

- **`variant`** is how much chrome the button carries: `solid` (the default, unchanged) a fill, `outline` a border on nothing, `ghost` neither — for the affordance that sits *inside* other content (a `✕` on a chip, a delete on a form row) and must not add a box to the row it lives in.
- **`primary`** stays what it was, and becomes whose colours the button speaks in: the accent as the fill when solid, the accent as ink and border otherwise.

The axes compose — a dialog footer is an `outline` beside a `primary` solid, a toolbar's loudest icon is `primary variant="ghost"` — and every combination keeps the widget states. The chrome-less variants answer the pointer with the neutral surface ramp (`surfaceHover`/`surfaceActive`), hover and press both, per AGENTS.md "Answer the input"; on `:focus-visible` a ghost button's border *appears* (`borderFocus`), which is right — the keyboard has no hover, so the ring is how a chrome-less control says "your keyboard is here".

Two details worth calling out:

- A ghost button keeps the border **width** and loses only the colour (`transparent`), so every variant is the same sum and a mixed row lines up to the pixel — including the `$paddingY`-padded field from docs/styling.md. There's a test pinning this.
- The fill is `transparent` rather than the ground's colour, so an outline/ghost button sits on whatever it sits on — a card, a table row — not just the window.

An unknown `variant`/`size` throws with the valid list, before the hooks, the way `<Icon name>` does — TypeScript isn't there for the JS caller, and silence would have been an outline button.

## `size="small"`

Halves the control padding (`radiusSmall`, tighter gap), **derived from the palette** — a theme that moves `paddingY` moves both sizes together, which is exactly what the hand-made `style={{ height: 22 }}` from the issue couldn't do.

## Element children get the resolved ink

The label colour now lands on the button's **box** instead of on the string child: `color` inherits (docs/styling.md), so an `<Icon>` or `<text>` child takes the same answer the string path always got, and an icon+label button dims as one thing when disabled — correct by construction, nothing passed to the icon:

```jsx
<Button primary disabled={busy} onPress={run}>
  <Icon name="chevronRight" />
  Continue
</Button>
```

(An icon that *names* a colour still wins — a node's own style beats what it inherits — and so does a `color` in the caller's `style`, which merges last.)

## Tests

`test/button-variants.test.js`: rest chrome per variant and per `primary`, height parity across variants, the small-size delta measured against the palette, the inherited ink on element children (enabled and disabled), the ghost pressed wash reaching the wire before the release, and the call-site throw. Mutation-checked: 5 of 7 fail against the old implementation (the other two guard behaviour the old code had no axis for). Docs, `.d.ts`, the `.tsx` type test and the website widgets demo updated in the same PR; full suite, typecheck, lint and `prettier --check .` green (the one local failure is the known macOS-only `appearance.test.js` baseline).

