### PR TITLE
feat(eyedropper): pickScreenColor() / useEyedropper() — sample a colour from the screen

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -77,6 +77,12 @@
   `useFileDialog()`, the three-rung ladder (the desktop's own portal,
   `osascript` on macOS, a browser react-x11 draws itself), why cancelling is
   `null` rather than a throw, and the places the backends genuinely differ.
+- [eyedropper.md](eyedropper.md) — sample a colour from the screen:
+  `useEyedropper()`/`pickScreenColor()`, the two-rung ladder (the portal's
+  own picker, a crosshair grab on plain X11), the interface `version`
+  property that gates the portal rung where `hasService()` cannot, and why
+  the grab's whole lifecycle — including the `<popup grab>` it displaces —
+  belongs to core.
 - [appearance.md](appearance.md) — light or dark, the accent colour,
   contrast and reduced motion: `useSystemAppearance()`, `<ThemeProvider dark>`
   for apps that only want to follow the desktop, why the answer is remembered

--- a/docs/eyedropper.md
+++ b/docs/eyedropper.md
@@ -1,0 +1,187 @@
+# The eyedropper
+
+Sample one pixel from the screen — any window, any application, the
+wallpaper — and get a colour an app can paint with.
+
+```jsx
+import { useEyedropper } from 'react-x11';
+
+function StrokePicker({ value, onChange }) {
+  const eyedropper = useEyedropper();
+
+  return (
+    <Button
+      label="Pick from screen"
+      disabled={eyedropper.picking}
+      onPress={async () => {
+        const hex = await eyedropper.pick();
+        if (hex) onChange(hex); // '#rrggbb'
+      }}
+    />
+  );
+}
+```
+
+Cancelling — Escape, or the desktop dialog's own cancel — resolves to `null`.
+It is an ordinary outcome, not an exception, on both backends, so the whole
+error path is one `if`. The same contract as the
+[file dialogs](filedialog.md), on purpose.
+
+## The ladder
+
+|     |                |                                                                                                                                                                                                                                         |
+| --- | -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | **the portal** | `org.freedesktop.portal.Screenshot.PickColor` over D-Bus. The desktop draws its own magnifier and hands the colour back. GNOME and KDE ship it; it is also the only route that exists on Wayland.                                       |
+| 2   | **X11**        | The classic route: grab the pointer with a crosshair, wait for the click, read the 1×1 under it, decode by the server's own pixel layout. Works under a bare WM, over ssh, on XQuartz — everywhere there is a display and nothing else. |
+
+`screenColorBackend()` reports which rung this machine lands on without
+grabbing anything; `useEyedropper().supported` is the same answer as render
+state.
+
+There is no third rung to draw, and that is the difference from the file
+dialog's ladder: the thing being read — the whole screen — is precisely what
+an application cannot draw itself. So the hook adds binding, not a fallback
+of its own.
+
+### The version gate
+
+`PickColor` arrived in **version 2** of the Screenshot interface, and the
+portal being on the bus says nothing about that: `hasService()` sees the
+service, not what its backends provide. XFCE's portal, for example, ships no
+Screenshot interface at all — a machine where every FileChooser call works
+and every PickColor would fail. So the probe reads the interface's own
+`version` property, via `portalVersion()` (exported, since the next portal
+feature will need the same question answered):
+
+```js
+import { portalVersion } from 'react-x11';
+
+const v = await portalVersion('org.freedesktop.portal.Screenshot');
+// 0 — not there at all; 1 — there, but before PickColor; 2+ — usable
+```
+
+Where the answer is below 2, the ladder falls through to the X11 rung
+rather than calling a method the portal would refuse.
+
+## `useEyedropper()`
+
+```ts
+const { pick, supported, picking } = useEyedropper(defaults?);
+
+pick(options?): Promise<string | null>; // '#rrggbb', or null on cancel
+supported: boolean; // screenColorBackend() !== null, resolved for you
+picking: boolean;   // a pick is in flight — the button's pressed state
+```
+
+| option         |                                                           |
+| -------------- | --------------------------------------------------------- |
+| `parentWindow` | override the owner window; inferred otherwise             |
+| `signal`       | an `AbortSignal` that ends the pick and releases the grab |
+| `backend`      | force a rung; the seam for a kiosk, and for tests         |
+
+Options given to the hook are defaults for every pick; options given to a
+call win. The portal's dialog is parented to the window the component is in,
+resolved when the pick starts — the `useFileDialog()` inference, with
+`parentWindow` as the override for a tree with several top-level windows.
+
+Two things the hook does beyond forwarding:
+
+- **`picking` is the pressed state**, and it is honest: while it is true, a
+  second `pick()` returns the promise already in flight rather than starting
+  a second grab — so a double-clicked button cannot make the user click
+  twice.
+- **`supported` is almost always true on this toolkit.** A react-x11 tree
+  has an X connection by definition, and the connection _is_ the fallback
+  rung. It goes false when a forced `backend: 'portal'` finds no portal —
+  and it is the seam that keeps the button honest on whatever platform comes
+  later.
+
+## The bare function
+
+```js
+import { pickScreenColor, screenColorBackend } from 'react-x11';
+
+const hex = await pickScreenColor({ app });
+```
+
+Same options, same results. The one addition is `app`: the X11 rung needs a
+connection to grab and read on, and a bare function has no tree to take one
+from — pass the app `createRoot()` returned (or `useApp()` in a component,
+or a `parentWindow` that points at a mounted node, which carries its
+connection with it). Without a portal and without a connection it rejects
+with `NoScreenColorError` — a **typed** rejection, so it reads as "hide the
+button", not as a crash.
+
+One pick per connection at a time: a second concurrent `pickScreenColor()`
+on the same app is refused loudly, because a second grab from the same
+client would silently _replace_ the first and one pick would settle with the
+other's click. The hook's shared in-flight promise is the friendly version
+of the same rule.
+
+## What differs between the rungs
+
+- **The portal draws a magnifier; the X11 rung deliberately does not.** On
+  X11 it is grab, crosshair, click — and Escape cancels. The desktops whose
+  users expect a loupe have a portal that draws one; a hand-rolled loupe on
+  the bottom rung would be a screenshot of the screen re-rendered at 8×,
+  permanently slightly wrong about scaling and colour management.
+- **On the X11 rung the keyboard also picks.** Return, KP Enter or space
+  samples the pixel under the pointer without a click — GTK's shape — and
+  the keyboard is grabbed for the duration so Escape works wherever the
+  focus happens to be.
+- **What is sampled is what is on the screen.** The X11 rung reads the
+  rendered pixel, so a colour under a translucent overlay is the blend, not
+  the window's own value. What exactly the portal samples is the desktop's
+  choice, not this API's — GNOME's and KDE's pickers read the composited
+  screen too.
+- **Both rungs answer `'#rrggbb'`.** The portal hands back `(ddd)` floats
+  and X11 hands back server-layout words; every consumer wants a CSS colour
+  it can paint with, so the conversion happens once, here. If something
+  later needs the unrounded portal values, an option can widen the return —
+  starting with channels would have made the common case do arithmetic.
+
+## The grab, and what it displaces
+
+The X11 rung holds a **server pointer grab** while it waits. That is the
+dangerous part of the feature — an application that leaks a grab leaves a
+desktop that has stopped answering clicks — and it is why the grab's whole
+lifecycle belongs to core rather than to apps:
+
+- Every way out — click, Escape, abort, error — releases the grab before the
+  promise settles. The `signal` option releases it too; that is guaranteed
+  here, not delegated to the caller.
+- A `<popup grab>` that was open when the pick started — an open `Select`,
+  a menu, the colour panel the eyedropper button itself sits in — had its
+  grab silently replaced by the pick's (same client, so X raises no error
+  and tells no one). When the pick ends, core hands that popup its grab
+  back, so dismiss-on-outside-click still works afterwards.
+- A grab released out from under a pick — this client's own popup teardown
+  calls `UngrabPointer`, which releases whatever the client's active grab is
+  — is detected (the server announces it with a `LeaveNotify` of mode
+  `Ungrab` on the grab window) and taken back, rather than leaving a pick
+  that never resolves while the app answers clicks as if nothing were
+  happening.
+
+## Running it anywhere
+
+| where                                              | rung                                                                                                               |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| GNOME / KDE, or any portal with Screenshot ≥ 2     | portal                                                                                                             |
+| XFCE (portal present, no Screenshot interface)     | X11                                                                                                                |
+| ssh, `startx`, XQuartz, a container with a display | X11                                                                                                                |
+| Node 20, where npm skips `dbus-native`             | X11                                                                                                                |
+| Wayland, some day                                  | portal only — there is no root window to read, which is a further reason the ladder lives here and not in each app |
+
+## Building a colour picker on it
+
+The eyedropper is the one part of a colour picker that cannot be composed
+out of public elements, which is why it lives in core and the picker panel
+does not. A `<ColorPicker>` in `@react-x11/components` consumes it as a
+function prop:
+
+```jsx
+<ColorPicker eyedropper={pickScreenColor} value={fill} onChange={setFill} />
+```
+
+and once that component exists, this function is its default and no app
+changes.

--- a/docs/filedialog.md
+++ b/docs/filedialog.md
@@ -180,10 +180,11 @@ client subscribes _before_ it calls and cannot lose the answer:
 
 ```js
 const { response, results } = await portalRequest(busRef, {
-  iface: 'org.freedesktop.portal.Settings',
-  member: 'ReadAll',
+  iface: 'org.freedesktop.portal.FileChooser',
+  member: 'OpenFile',
   parentWindow: 'x11:1a00007',
-  options: {},
+  title: 'Open',
+  options: { multiple: true },
 });
 ```
 
@@ -192,11 +193,36 @@ first, `Request.Close()` on abort (which emits **no** `Response`, so the
 promise has to be settled locally), and no timeout on the answer — a dialog can
 legitimately be open for an hour, and only the initial call is deadlined.
 
+The default argument shape is FileChooser's, `(s parent_window, s title, a{sv}
+options)` — and that shape is FileChooser's alone. Every other Request-shaped
+portal has its own leading arguments, so a caller states them, as `signature`
+and `args` together; the [eyedropper](eyedropper.md)'s `PickColor`, which has
+no title, is the worked example:
+
+```js
+await portalRequest(busRef, {
+  iface: 'org.freedesktop.portal.Screenshot',
+  member: 'PickColor',
+  signature: 'sa{sv}',
+  args: [parentWindow],
+});
+```
+
+The signature must end in `a{sv}` — the options dict is where `handle_token`
+rides, so a method without one does not answer through a `Request` and wants a
+plain `bus.invoke` instead.
+
 `hasService(name)` answers whether a service is reachable — owned now **or
 activatable on demand**. `NameHasOwner` alone is the wrong question:
 `org.freedesktop.portal.Desktop` is D-Bus-activatable, so on a healthy desktop
 where no app has touched a portal yet it has no owner, and a feature gated on
 that takes the fallback path forever.
+
+`portalVersion(iface)` answers the question `hasService()` cannot: whether the
+portal's backends provide one _interface_, and at what version — `0` when it
+is not there at all. Capability lives in the interface's own `version`
+property, and gating on the service alone breaks exactly on the desktops that
+provide some portals and not others (XFCE has FileChooser and no Screenshot).
 
 See [dbus.md](dbus.md) for the connection these sit on.
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -21,6 +21,7 @@ export * from './types/globalmenu.js';
 export * from './types/dbus.js';
 export * from './types/application.js';
 export * from './types/filedialog.js';
+export * from './types/screencolor.js';
 export * from './types/appearance.js';
 export * from './types/fonts.js';
 export * from './types/system.js';

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ export {
   PortalCancelledError,
   hasService,
   portalRequest,
+  portalVersion,
 } from './portal.js';
 export {
   NoFileDialogError,
@@ -35,6 +36,12 @@ export {
   selectFolder,
 } from './filedialog.js';
 export { useFileDialog } from './filedialoghooks.js';
+export {
+  NoScreenColorError,
+  pickScreenColor,
+  screenColorBackend,
+} from './screencolor.js';
+export { useEyedropper } from './screencolorhooks.js';
 export { systemAppearance } from './appearance.js';
 export { useSystemAppearance } from './appearancehooks.js';
 export { useScreens } from './screenshooks.js';

--- a/src/portal.js
+++ b/src/portal.js
@@ -134,6 +134,70 @@ export async function hasService(name, busRef) {
 /** Test seam, not public: forget what was learned about the bus. */
 export function _resetServiceCache() {
   reachable.clear();
+  versions.clear();
+}
+
+// --------------------------------------------------------------------------
+// portalVersion
+// --------------------------------------------------------------------------
+
+/**
+ * Positive answers only, like {@link hasService}'s cache and for the same
+ * reason: a version can only move by the portal restarting, which is rare
+ * enough to ignore, while a cached "not there" would disable a feature for
+ * the life of the process on a machine where the portal appears one call
+ * later.
+ */
+const versions = new Map();
+
+/**
+ * The version of one portal *interface*, or `0` when it is not there.
+ *
+ * `hasService()` answers a different question. The portal service being
+ * reachable says nothing about which interfaces its backends provide —
+ * XFCE's portal has no `Screenshot` interface at all, and a GNOME old enough
+ * has it at version 1, before `PickColor` existed. Capability lives in the
+ * interface's own `version` property, so gating a feature means reading it:
+ *
+ * ```js
+ * if ((await portalVersion('org.freedesktop.portal.Screenshot', ref)) >= 2) {
+ *   // PickColor is there
+ * }
+ * ```
+ *
+ * `0` collapses "no bus", "no portal", "no such interface" and "no version
+ * property" into one answer, because every caller would branch the same way
+ * on all four.
+ */
+export async function portalVersion(iface, busRef) {
+  const cached = versions.get(iface);
+  if (cached !== undefined) return cached;
+  const ref = busRef ?? (await sessionBus());
+  if (!ref) return 0;
+  try {
+    const value = await ref.bus.invoke(
+      {
+        destination: PORTAL_NAME,
+        path: PORTAL_PATH,
+        interface: 'org.freedesktop.DBus.Properties',
+        member: 'Get',
+        signature: 'ss',
+        body: [iface, 'version'],
+      },
+      { timeout: 10_000 },
+    );
+    // dbus-native unwraps the `v` reply to its value.
+    const version = typeof value === 'number' && value > 0 ? value : 0;
+    if (version > 0) versions.set(iface, version);
+    return version;
+  } catch {
+    // `org.freedesktop.DBus.Error.InvalidArgs` — the portal is there and the
+    // interface is not, which is XFCE today for Screenshot. Or no portal at
+    // all. The caller's branch is the same either way.
+    return 0;
+  } finally {
+    if (!busRef) await ref.release();
+  }
 }
 
 // --------------------------------------------------------------------------
@@ -153,6 +217,26 @@ export function _resetServiceCache() {
  *   options: { multiple: true },
  * });
  * ```
+ *
+ * The default argument shape is FileChooser's, `(s parent_window, s title,
+ * a{sv} options)` — but that shape is FileChooser's alone. Every other portal
+ * that answers through a `Request` has its own leading arguments
+ * (`Screenshot.PickColor` has no title, `Print` carries a serial, …), so a
+ * caller states them, as `signature` and `args` together:
+ *
+ * ```js
+ * await portalRequest(ref, {
+ *   iface: 'org.freedesktop.portal.Screenshot',
+ *   member: 'PickColor',
+ *   signature: 'sa{sv}',
+ *   args: [parentWindow],
+ * });
+ * ```
+ *
+ * `signature` is the method's full argument signature and must end in
+ * `a{sv}` — the options dict is where `handle_token` rides, so a method
+ * without one cannot be Request-shaped. `args` is everything before it;
+ * the options dict itself stays in `options` and is appended here.
  *
  * Three things it owns, so that no caller reimplements them:
  *
@@ -177,8 +261,40 @@ export function _resetServiceCache() {
  */
 export async function portalRequest(
   busRef,
-  { iface, member, parentWindow = '', title = '', options = {}, signal },
+  {
+    iface,
+    member,
+    parentWindow = '',
+    title = '',
+    signature,
+    args,
+    options = {},
+    signal,
+  },
 ) {
+  // They travel as a pair: the signature says what the args are, and either
+  // half alone is a call that marshals wrong at the far end with no error
+  // anywhere near the mistake.
+  if ((signature === undefined) !== (args === undefined)) {
+    throw new Error(
+      `react-x11: portalRequest(${iface}.${member}) got ` +
+        `${signature === undefined ? '`args` without `signature`' : '`signature` without `args`'}` +
+        " — they describe each other, so pass both (e.g. signature: 'sa{sv}'," +
+        ' args: [parentWindow]), or neither for the FileChooser shape.',
+    );
+  }
+  if (signature === undefined) {
+    signature = 'ssa{sv}';
+    args = [parentWindow, title];
+  } else if (!signature.endsWith('a{sv}')) {
+    throw new Error(
+      `react-x11: portalRequest(${iface}.${member}) — the signature ` +
+        `'${signature}' does not end in the options dict (a{sv}). ` +
+        'handle_token rides in that dict, so a method without one does not ' +
+        'answer through a Request; call bus.invoke directly instead.',
+    );
+  }
+
   const { bus, uniqueName } = busRef;
   const token = await newToken();
   const path = `${PORTAL_PATH}/request/${senderPath(uniqueName)}/${token}`;
@@ -263,8 +379,8 @@ export async function portalRequest(
           path: PORTAL_PATH,
           interface: iface,
           member,
-          signature: 'ssa{sv}',
-          body: [parentWindow, title, { ...options, handle_token: token }],
+          signature,
+          body: [...args, { ...options, handle_token: token }],
         },
         { timeout: 10_000 },
       )

--- a/src/screencolor.js
+++ b/src/screencolor.js
@@ -1,0 +1,640 @@
+// Sample one pixel from the screen — the eyedropper, through whatever this
+// machine actually has.
+//
+// The file dialog's ladder again (docs/filedialog.md), two rungs this time:
+//
+//   1. **the portal** — `org.freedesktop.portal.Screenshot.PickColor`. The
+//      desktop draws its own magnifier and hands back the colour, which is
+//      also the only route that works under a compositor that would refuse a
+//      root read, and the only route Wayland has at all. Needs version 2 of
+//      the Screenshot interface — XFCE ships none, GNOME and KDE ship 2 —
+//      so the gate is the interface's `version` property, not `hasService()`.
+//   2. **X11** — grab the pointer with a crosshair, wait for the click,
+//      `GetImage` a 1×1 at it, decode by the server's own pixel layout.
+//      Reached under a bare WM, over ssh, on XQuartz: everywhere there is a
+//      display and nothing else, which is the case react-x11 exists for.
+//
+// There is no third rung to draw, because the thing being read — the whole
+// screen — is precisely what an application cannot draw itself. So unlike
+// `useFileDialog()`, `useEyedropper()` adds no rung; it adds the binding a
+// component wants (`picking`, `supported`, the owner window) over the same
+// two.
+//
+// ## The grab is the dangerous part
+//
+// An application that leaks a pointer grab leaves a desktop that has stopped
+// answering clicks. Everything in the X11 rung is shaped by that: one
+// `settle()` gate owns the cleanup, the abort listener goes on before the
+// first request goes out, cancellation releases the grab before it reports,
+// and losing the grab to someone else is detected (the server says so, with
+// a LeaveNotify of mode Ungrab) rather than waited out.
+
+import { pixelLayout, toStraightRgba } from 'ntk';
+
+import { sessionBus } from './bus.js';
+import { XK_ESCAPE, XK_KP_ENTER, XK_RETURN, XK_SPACE } from './keysyms.js';
+import {
+  PORTAL_NAME,
+  PortalCancelledError,
+  RESPONSE_OK,
+  hasService,
+  parentWindowHandle,
+  portalRequest,
+  portalVersion,
+} from './portal.js';
+import { windowIdOf } from './windowid.js';
+
+export const SCREENSHOT_IFACE = 'org.freedesktop.portal.Screenshot';
+/** `PickColor` arrived in version 2 of the Screenshot interface. */
+const PICK_COLOR_VERSION = 2;
+
+/**
+ * Nothing here can sample the screen, and nothing can be drawn instead.
+ *
+ * A **typed** rejection, the `NoFileDialogError` rule: a caller hides or
+ * disables its eyedropper button rather than crashing — which is what
+ * `useEyedropper().supported` does for you.
+ */
+export class NoScreenColorError extends Error {
+  constructor(message, cause) {
+    super(
+      `react-x11: ${
+        message ??
+        'no way to sample a colour from the screen — there is no ' +
+          'Screenshot portal with PickColor (interface version 2) on the ' +
+          'session bus, and no X connection was given for the fallback. ' +
+          'Pass `app` (from createRoot() or useApp()), or use useEyedropper().'
+      }`,
+      { cause },
+    );
+    this.name = 'NoScreenColorError';
+  }
+}
+
+// --------------------------------------------------------------------------
+// Rung 1: the portal
+// --------------------------------------------------------------------------
+
+/**
+ * The portal's `(ddd)` — sRGB in [0, 1] — as `'#rrggbb'`, or null when the
+ * triple is not one. A string because every consumer wants to paint with it;
+ * the same reasoning as the appearance portal's accent colour.
+ */
+function hexFromPortalColor(triple) {
+  if (!Array.isArray(triple) || triple.length < 3) return null;
+  const channels = triple.slice(0, 3);
+  if (!channels.every((c) => typeof c === 'number' && Number.isFinite(c))) {
+    return null;
+  }
+  return (
+    '#' +
+    channels
+      .map((c) =>
+        Math.round(Math.min(1, Math.max(0, c)) * 255)
+          .toString(16)
+          .padStart(2, '0'),
+      )
+      .join('')
+  );
+}
+
+async function portalPick(opts, ref) {
+  const { response, results } = await portalRequest(ref, {
+    iface: SCREENSHOT_IFACE,
+    member: 'PickColor',
+    // Not FileChooser's shape: PickColor is `(s parent_window, a{sv}
+    // options)` — no title — which is the whole reason portalRequest takes a
+    // signature now.
+    signature: 'sa{sv}',
+    args: [parentWindowHandle(windowIdOf(opts.parentWindow))],
+    options: {},
+    signal: opts.signal,
+  });
+  if (response !== RESPONSE_OK) throw new PortalCancelledError(response);
+  const hex = hexFromPortalColor(results?.color);
+  if (!hex) {
+    throw new Error(
+      'react-x11: the Screenshot portal answered PickColor without a ' +
+        'colour — expected a (ddd) triple in `results.color`, got ' +
+        `${JSON.stringify(results?.color)}.`,
+    );
+  }
+  return hex;
+}
+
+/** Portal reachable *and* recent enough for PickColor, on this ref. */
+async function portalCanPick(ref) {
+  return (
+    (await hasService(PORTAL_NAME, ref)) &&
+    (await portalVersion(SCREENSHOT_IFACE, ref)) >= PICK_COLOR_VERSION
+  );
+}
+
+// --------------------------------------------------------------------------
+// Rung 2: X11
+// --------------------------------------------------------------------------
+
+// x11.eventMask bits, spelled out the way xsettings.js spells its one. No
+// key mask anywhere: GrabKeyboard has no event-mask argument — a keyboard
+// grab delivers every key event to the grab window unconditionally.
+const BUTTON_MASK = 4 | 8; // ButtonPress | ButtonRelease
+const CROSSING_MASK = 0x10 | 0x20; // EnterWindow | LeaveWindow
+
+// Core event types.
+const KEY_PRESS = 2;
+const BUTTON_PRESS = 4;
+const LEAVE_NOTIFY = 8;
+
+/** LeaveNotify `mode` when a grab this client held was released. */
+const NOTIFY_UNGRAB = 2;
+
+const GRAB_STATUS = {
+  1:
+    'another application is holding a pointer grab (a menu or a drag is ' +
+    'probably open) — try again once it closes',
+  2: 'the grab was refused for an out-of-order timestamp (InvalidTime)',
+  3: 'the grab window is not viewable, which is a react-x11 bug',
+  4: 'the pointer is frozen by another grab (GrabFrozen)',
+};
+
+/**
+ * One pick per connection at a time. A second `GrabPointer` from the same
+ * client silently *replaces* the first — two concurrent picks would settle
+ * one of them with the other's click, so the second is refused loudly
+ * instead. `useEyedropper()` never gets here: it hands the in-flight promise
+ * back.
+ */
+const inflight = new WeakSet();
+
+/**
+ * The keysyms a keycode can produce, from the map ntk keeps current. An
+ * unfilled map — possible in the first moments of a connection — answers
+ * `[]`, which quietly costs the keyboard shortcuts and nothing else: the
+ * click and the abort signal never depend on it.
+ */
+function keysymsOf(X, keycode) {
+  return X.keycode2keysyms?.[keycode] ?? [];
+}
+
+/**
+ * GrabKeyboard, marshalled by hand — **do not use `X.GrabKeyboard` here.**
+ *
+ * node-x11 writes pointer-mode and keyboard-mode at request offsets 10/11,
+ * which the protocol says are the top half of the *time* field; the real
+ * offsets, 12/13, stay zero. So every `X.GrabKeyboard` with CurrentTime and
+ * asynchronous modes reaches a real server as a garbage timestamp with
+ * **synchronous** modes: Xorg answers InvalidTime, and a time that survived
+ * would freeze the keyboard. The pure-JS test server never reads those
+ * bytes, which is how the bug stays green headlessly — this was found by
+ * running the pick on a live display. Marshalled the way node-x11's own
+ * extension modules marshal what the core tables lack; delete when the fix
+ * lands upstream.
+ */
+function grabKeyboard(X, wid, cb) {
+  X.seq_num++;
+  const b = Buffer.alloc(16);
+  b[0] = 31; // GrabKeyboard
+  b[1] = 0; // owner-events: false
+  b.writeUInt16LE(4, 2);
+  b.writeUInt32LE(wid >>> 0, 4);
+  b.writeUInt32LE(0, 8); // CurrentTime
+  b[12] = 1; // pointer-mode: Asynchronous
+  b[13] = 1; // keyboard-mode: Asynchronous
+  X.pack_stream.put(b);
+  // The status rides byte 1 of the reply header, which the reply dispatcher
+  // hands over as the unpack's second argument.
+  X.replies[X.seq_num] = [(buf, status) => status, cb];
+  X.pack_stream.submit(true);
+}
+
+/**
+ * Restore the grab of a `<popup grab>` the pick displaced.
+ *
+ * A grabbing popup — an open Menu, Select, or the colour panel the
+ * eyedropper button itself sits in — holds this client's pointer grab, and
+ * our `GrabPointer` **replaced** it (same client, so no AlreadyGrabbed).
+ * The popup is never told; nothing in X says "your grab moved". After the
+ * pick releases, the popup would be left open with dismiss-on-outside-click
+ * silently dead — so the grab is handed back here, by the renderer, which is
+ * the one party that can know both grabs existed.
+ */
+function regrabPopup(app) {
+  let found = null;
+  const walk = (node) => {
+    if (!node) return;
+    if (
+      node.isPopup &&
+      node.props?.grab &&
+      node.window &&
+      !node.destroyed &&
+      !node._anchorLost
+    ) {
+      // Later in tree order approximates higher in the stack; with the
+      // renderer's own rule of one grabbing popup at a time (submenus ride
+      // the root menu's grab) there is at most one anyway.
+      found = node;
+    }
+    for (const child of node.children ?? []) walk(child);
+  };
+  for (const root of app._rootChildren ?? []) walk(root);
+  found?.window?.grabPointer?.({}, () => {});
+}
+
+/**
+ * The classic route: grab, crosshair, click, Escape cancels.
+ *
+ * Resolves `'#rrggbb'` on a click (or Return/space/KP_Enter, which pick at
+ * the pointer, GTK's shape), `null` on Escape, rejects on abort — with the
+ * grab released on every one of those paths before the promise settles.
+ *
+ * No magnifier and no live preview, deliberately: the desktops whose users
+ * expect a loupe have a portal that draws one.
+ */
+function x11Pick(opts, app) {
+  const X = app.X;
+  if (inflight.has(app)) {
+    return Promise.reject(
+      new Error(
+        'react-x11: pickScreenColor() is already waiting for a click on ' +
+          'this connection. One eyedropper at a time — disable the button ' +
+          'while `useEyedropper().picking` is true.',
+      ),
+    );
+  }
+  inflight.add(app);
+
+  return new Promise((resolve, reject) => {
+    const root = X.display.screen[0].root;
+    // The crosshair is feedback, not mechanism: an app whose ntk predates
+    // cursors still picks, with the arrow.
+    let cursor = 0;
+    try {
+      cursor = app.cursors?.get?.('crosshair') ?? 0;
+    } catch {
+      cursor = 0;
+    }
+
+    // The grab window. Invisible twice over — InputOnly, and offscreen —
+    // because a mapped InputOnly window *does* intercept input wherever it
+    // sits, and (0, 0) is somebody's hot corner. It exists so that grabbed
+    // events land on an id nothing else owns: delivering them through a real
+    // window of the tree would put every pick click through the renderer's
+    // own dispatcher, and the app would see itself being clicked.
+    const wid = X.AllocID();
+    X.CreateWindow(wid, root, -100, -100, 1, 1, 0, 0, 2 /* InputOnly */, 0, {
+      overrideRedirect: true,
+      // The grab's own event mask governs delivery of the grabbed events;
+      // this attribute mask is for the crossing events the *server* sends
+      // about the grab itself — LeaveNotify mode Ungrab is how we learn the
+      // grab was taken from us (see below).
+      eventMask: CROSSING_MASK,
+    });
+    X.MapWindow(wid);
+
+    let settled = false;
+    let grabSent = false;
+    let keyboardGrabbed = false;
+    let regrabs = 0;
+
+    const cleanup = () => {
+      X.removeListener('event', onEvent);
+      if (opts.signal) opts.signal.removeEventListener('abort', onAbort);
+      try {
+        if (grabSent) X.UngrabPointer(0);
+        if (keyboardGrabbed) X.UngrabKeyboard(0);
+        X.DestroyWindow(wid);
+        X.ReleaseID(wid);
+      } catch {
+        // The connection died mid-pick. The server released the grab with
+        // it, which is the outcome cleanup exists to guarantee.
+      }
+      inflight.delete(app);
+      // After our ungrab, never before: X holds one active grab per client,
+      // so handing the popup its grab back first would only have ours
+      // replace it again on the next line.
+      if (grabSent) {
+        try {
+          regrabPopup(app);
+        } catch {
+          // A half-torn-down tree mid-unmount. The popup this would have
+          // served is on its way out with it.
+        }
+      }
+    };
+
+    /** Every way out funnels through here, so the grab cannot outlive us. */
+    const settle = (fn) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      fn();
+    };
+
+    const fail = (message, cause) =>
+      settle(() => reject(new Error(`react-x11: ${message}`, { cause })));
+
+    // `'#rrggbb'` from a 1×1 GetImage at root coordinates. The reply is raw
+    // server words; `pixelLayout`/`toStraightRgba` are the "what do these
+    // bytes mean" answer, asked of the display rather than assumed — the
+    // lesson scripts/capture.js already learned the hard way.
+    const sample = (drawable, x, y) => {
+      X.GetImage(
+        2 /* ZPixmap */,
+        drawable,
+        x,
+        y,
+        1,
+        1,
+        0xffffffff,
+        (err, img) => {
+          if (err) {
+            return reject(
+              new Error(
+                'react-x11: could not read the picked pixel back ' +
+                  `(GetImage at ${x},${y})`,
+                { cause: err },
+              ),
+            );
+          }
+          try {
+            const layout = pixelLayout(X.display, img.depth);
+            const [r, g, b] = toStraightRgba(img.data, layout, 1, 1);
+            resolve(
+              '#' +
+                [r, g, b].map((c) => c.toString(16).padStart(2, '0')).join(''),
+            );
+          } catch (cause) {
+            // A 16-bit display, in practice. Rare enough to report rather
+            // than unpack by hand.
+            reject(
+              new Error(
+                `react-x11: could not decode the picked pixel — ${cause.message}`,
+                { cause },
+              ),
+            );
+          }
+        },
+      );
+    };
+
+    // Ungrab first, then read: the crosshair reverts on the very click, and
+    // a failed read can no longer strand the grab. Safe against repaints
+    // because the grabbed click reached no application — nothing gained
+    // focus, nothing redrew.
+    const pickAt = (drawable, x, y) => settle(() => sample(drawable, x, y));
+
+    const onEvent = (ev) => {
+      if (settled || ev.wid !== wid) return;
+      if (ev.type === BUTTON_PRESS) {
+        // Button 1 picks. The rest are ignored rather than treated as
+        // cancel: a stray middle-click paste reflex should not silently eat
+        // the pick, and Escape is one key away.
+        if (ev.keycode === 1) pickAt(ev.root || root, ev.rootx, ev.rooty);
+        return;
+      }
+      if (ev.type === KEY_PRESS) {
+        const syms = keysymsOf(X, ev.keycode);
+        if (syms.includes(XK_ESCAPE)) {
+          settle(() => resolve(null));
+        } else if (
+          syms.includes(XK_RETURN) ||
+          syms.includes(XK_KP_ENTER) ||
+          syms.includes(XK_SPACE)
+        ) {
+          // Pick at the pointer without a click — the keyboard's half of the
+          // gesture, same as GTK's dropper.
+          X.QueryPointer(root, (err, pointer) => {
+            if (settled) return;
+            if (err || !pointer)
+              return fail('could not locate the pointer', err);
+            pickAt(pointer.root || root, pointer.rootX, pointer.rootY);
+          });
+        }
+        return;
+      }
+      // The grab was taken from us — LeaveNotify with mode Ungrab on the
+      // grab window is the one signal X gives. Not hypothetical: this
+      // client's own popups release the active grab in their teardown, so a
+      // pick started from a closing menu loses its grab a tick later. Take
+      // it back; the alternative is a pick that silently never resolves
+      // while the app answers clicks as if nothing were happening.
+      if (ev.type === LEAVE_NOTIFY && ev.mode === NOTIFY_UNGRAB && grabSent) {
+        if (++regrabs > 5) {
+          return fail(
+            'the pointer grab kept being released out from under the ' +
+              'eyedropper — something on this connection is calling ' +
+              'UngrabPointer repeatedly',
+          );
+        }
+        X.GrabPointer(
+          wid,
+          false,
+          BUTTON_MASK,
+          1 /* async */,
+          1 /* async */,
+          0,
+          cursor,
+          0,
+          (err, status) => {
+            if (settled) return;
+            if (err || status !== 0) {
+              fail(
+                `lost the pointer grab and could not take it back — ${
+                  GRAB_STATUS[status] ?? `status ${status}`
+                }`,
+                err ?? undefined,
+              );
+            }
+          },
+        );
+      }
+    };
+
+    const onAbort = () =>
+      settle(() => reject(opts.signal.reason ?? new PortalCancelledError()));
+
+    // Abort wiring before the first request goes out, the portalRequest
+    // lesson: an abort landing while the grab replies are in flight must
+    // still release everything.
+    if (opts.signal) {
+      if (opts.signal.aborted) {
+        // Nothing sent yet; unwind what this function itself created.
+        X.removeListener?.('event', onEvent);
+        try {
+          X.DestroyWindow(wid);
+          X.ReleaseID(wid);
+        } catch {
+          // never mind — the reject below is the answer
+        }
+        inflight.delete(app);
+        settled = true;
+        return reject(opts.signal.reason ?? new PortalCancelledError());
+      }
+      opts.signal.addEventListener('abort', onAbort, { once: true });
+    }
+
+    // The listener goes on before the grab request: events start the moment
+    // the grab activates, and the reply races them on a busy connection.
+    X.on('event', onEvent);
+
+    // ownerEvents: **false**. Every pointer event during the pick reports to
+    // the grab window and only there — with true, a click over the app's own
+    // windows would flow through the renderer's dispatcher and the app would
+    // handle a press that was meant for the eyedropper.
+    grabSent = true;
+    X.GrabPointer(
+      wid,
+      false,
+      BUTTON_MASK,
+      1 /* async */,
+      1 /* async */,
+      0 /* no confineTo: the whole screen is the target */,
+      cursor,
+      0 /* CurrentTime */,
+      (err, status) => {
+        if (settled) return;
+        if (err || status !== 0) {
+          return fail(
+            `could not grab the pointer to pick a colour — ${
+              GRAB_STATUS[status] ?? `status ${status}`
+            }`,
+            err ?? undefined,
+          );
+        }
+        // The keyboard grab is what makes Escape work wherever the focus
+        // happens to be. Refusal is survivable — the click and the abort
+        // signal still end the pick — so a failure here degrades instead of
+        // failing the pick.
+        grabKeyboard(X, wid, (kbErr, kbStatus) => {
+          if (!kbErr && kbStatus === 0) {
+            keyboardGrabbed = true;
+            // The pick may have settled while this reply was in flight; the
+            // grab it just took has to go with it.
+            if (settled) {
+              try {
+                X.UngrabKeyboard(0);
+              } catch {
+                // connection gone, grab gone with it
+              }
+            }
+          }
+        });
+      },
+    );
+  });
+}
+
+// --------------------------------------------------------------------------
+// The ladder
+// --------------------------------------------------------------------------
+
+/**
+ * The connection behind a `parentWindow`, when it points at a live node —
+ * so `pickScreenColor({ parentWindow: winRef })` reaches the X11 rung
+ * without the caller repeating the app it is already naming a window of.
+ */
+function appOf(target) {
+  if (!target || typeof target !== 'object') return null;
+  if ('current' in target && !target.isWindow) return appOf(target.current);
+  return target.app ?? target.window?.app ?? target.root?.window?.app ?? null;
+}
+
+/** The connection a pick would use, or null. */
+function appFor(opts) {
+  return opts.app ?? appOf(opts.parentWindow);
+}
+
+/**
+ * Which rung this machine lands on, without grabbing anything.
+ *
+ * `'portal'` needs the Screenshot interface at version 2 — the probe reads
+ * the interface's `version` property, because `hasService()` cannot see
+ * which interfaces a portal's backends actually provide (XFCE's provides no
+ * Screenshot at all). `'x11'` needs a connection to answer with, so pass
+ * `app` (or a `parentWindow` that resolves to one); without either the
+ * fallback is unreachable and the honest answer is `null`.
+ *
+ * Acquires a bus reference and releases it, so it is cheap but not free —
+ * `useEyedropper().supported` caches it for you.
+ *
+ * @returns {Promise<'portal'|'x11'|null>}
+ */
+export async function screenColorBackend(options = {}) {
+  const backend = options.backend;
+  if (!backend || backend === 'portal') {
+    const ref = await sessionBus();
+    if (ref) {
+      try {
+        if (await portalCanPick(ref)) return 'portal';
+      } finally {
+        await ref.release();
+      }
+    }
+    if (backend === 'portal') return null;
+  }
+  return appFor(options) ? 'x11' : null;
+}
+
+async function runPick(opts) {
+  const wantPortal = !opts.backend || opts.backend === 'portal';
+  if (wantPortal) {
+    const ref = await sessionBus();
+    if (ref) {
+      try {
+        if (await portalCanPick(ref)) {
+          return await portalPick(opts, ref);
+        }
+      } finally {
+        await ref.release();
+      }
+    }
+    if (opts.backend === 'portal') {
+      throw new NoScreenColorError(
+        'no Screenshot portal with PickColor here — the session bus has no ' +
+          `${SCREENSHOT_IFACE} at version ${PICK_COLOR_VERSION} or newer — ` +
+          "and backend: 'portal' rules out the X11 fallback.",
+      );
+    }
+  }
+
+  const app = appFor(opts);
+  if (app) return x11Pick(opts, app);
+  throw new NoScreenColorError(
+    opts.backend === 'x11'
+      ? "backend: 'x11' needs a connection to grab on. Pass `app` (from " +
+          'createRoot() or useApp()), or a `parentWindow` that points at a ' +
+          'mounted window.'
+      : undefined,
+  );
+}
+
+/**
+ * Sample one pixel from the screen: the desktop's own picker where there is
+ * one, a crosshair grab on plain X11 everywhere else.
+ *
+ * ```js
+ * const hex = await pickScreenColor({ app });
+ * if (hex) setFill(hex);            // '#rrggbb'; null means cancelled
+ * ```
+ *
+ * Resolves to **`'#rrggbb'`**, or `null` when the user cancelled (Escape, or
+ * the portal dialog's own cancel) — cancelling is an ordinary outcome and
+ * should not need a `try`. Rejects with {@link NoScreenColorError} when
+ * neither rung is reachable, which is the signal to hide the button;
+ * `signal` aborts the pick and releases the grab before the rejection is
+ * reported.
+ *
+ * In a component, reach for {@link useEyedropper} instead — it binds the
+ * connection and the owner window, and exposes `picking`/`supported` as
+ * render state.
+ *
+ * @returns {Promise<string | null>}
+ */
+export async function pickScreenColor(options = {}) {
+  try {
+    return await runPick(options);
+  } catch (err) {
+    if (err instanceof PortalCancelledError) return null;
+    throw err;
+  }
+}

--- a/src/screencolorhooks.js
+++ b/src/screencolorhooks.js
@@ -1,0 +1,101 @@
+// `useEyedropper()` — the screen colour pick as a component sees it.
+//
+// The bare `pickScreenColor()` is complete; what a component wants on top of
+// it is *binding*, not another rung (there is no rung to draw — the screen
+// is the one thing an application cannot draw itself). The hook binds the
+// tree's connection and owner window once, exposes `supported` for the
+// button's existence and `picking` for its pressed state, and hands a
+// second click the pick that is already in flight instead of a second grab.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { useApp } from './appcontext.js';
+import { pickScreenColor, screenColorBackend } from './screencolor.js';
+import { useTopLevelWindow } from './windowid.js';
+
+/**
+ * An eyedropper for a component.
+ *
+ * ```jsx
+ * const eyedropper = useEyedropper();
+ *
+ * {eyedropper.supported && (
+ *   <Button
+ *     label="Pick from screen"
+ *     disabled={eyedropper.picking}
+ *     onPress={async () => {
+ *       const hex = await eyedropper.pick();
+ *       if (hex) onChange(hex);     // '#rrggbb'; null means cancelled
+ *     }}
+ *   />
+ * )}
+ * ```
+ *
+ * `pick()` resolves to `'#rrggbb'`, or `null` when the user cancelled. It
+ * never rejects for lack of a backend on an X11 tree — the connection this
+ * tree renders through *is* the fallback rung — so `supported` is about the
+ * forced-backend and future-platform cases, not a check most apps must make.
+ *
+ * The portal dialog is parented to the window this component is in, the
+ * `useFileDialog()` way: resolved at the moment the pick starts, with
+ * `parentWindow` as the override for a tree with several top-level windows.
+ *
+ * While a pick is in flight, `picking` is true and another `pick()` returns
+ * **the same promise** — a double-clicked button must not queue a second
+ * grab behind the first.
+ */
+export function useEyedropper(defaults = {}) {
+  const app = useApp();
+  const owner = useTopLevelWindow();
+  const [picking, setPicking] = useState(false);
+  const [supported, setSupported] = useState(false);
+  const inflight = useRef(null);
+
+  const backend = defaults.backend;
+  useEffect(() => {
+    let alive = true;
+    screenColorBackend({ app, backend }).then(
+      (rung) => {
+        if (alive) setSupported(rung !== null);
+      },
+      () => {
+        if (alive) setSupported(false);
+      },
+    );
+    return () => {
+      alive = false;
+    };
+  }, [app, backend]);
+
+  const pick = useCallback(
+    (options = {}) => {
+      if (inflight.current) return inflight.current;
+      // `app` last: the tree's connection is what this hook exists to bind,
+      // not an override surface.
+      const opts = { parentWindow: owner, ...defaults, ...options, app };
+      setPicking(true);
+      const run = pickScreenColor(opts).finally(() => {
+        inflight.current = null;
+        setPicking(false);
+      });
+      inflight.current = run;
+      return run;
+    },
+    // `defaults` is deliberately not a dependency — the useFileDialog rule:
+    // an app writes it inline, and a new object every render would rebuild
+    // the callback every render.
+    [app, owner],
+  );
+
+  return useMemo(
+    () => ({
+      /** @returns {Promise<string | null>} `'#rrggbb'`, or null if cancelled */
+      pick,
+      /** `screenColorBackend()` resolved — false until it answers. */
+      supported,
+      /** A pick is in flight — the button's pressed/disabled state. */
+      picking,
+    }),
+    [pick, supported, picking],
+  );
+}

--- a/src/types/filedialog.d.ts
+++ b/src/types/filedialog.d.ts
@@ -220,6 +220,14 @@ export interface PortalRequestOptions {
   /** `'x11:1a00007'`, or `''` for none. */
   parentWindow?: string;
   title?: string;
+  /**
+   * The method's full argument signature, ending in the options dict —
+   * `'sa{sv}'` for `Screenshot.PickColor`. Travels with `args`; omitting
+   * both means FileChooser's `'ssa{sv}'` with `[parentWindow, title]`.
+   */
+  signature?: string;
+  /** The leading arguments the signature describes, before the options dict. */
+  args?: unknown[];
   options?: Record<string, unknown>;
   signal?: AbortSignalLike;
 }
@@ -236,3 +244,17 @@ export declare function portalRequest(
   busRef: { bus: MessageBus; uniqueName: string },
   options: PortalRequestOptions,
 ): Promise<{ response: number; results: Record<string, unknown> }>;
+
+/**
+ * The version of one portal *interface*, or `0` when it is not there.
+ *
+ * {@link hasService} answers a different question: the portal service being
+ * reachable says nothing about which interfaces its backends provide.
+ * Capability lives in the interface's own `version` property — `PickColor`
+ * needs `org.freedesktop.portal.Screenshot` at 2, and XFCE's portal has no
+ * Screenshot interface at all.
+ */
+export declare function portalVersion(
+  iface: string,
+  busRef?: { bus: MessageBus; uniqueName: string },
+): Promise<number>;

--- a/src/types/screencolor.d.ts
+++ b/src/types/screencolor.d.ts
@@ -1,0 +1,84 @@
+/**
+ * Sampling a colour from the screen — the eyedropper. See docs/eyedropper.md.
+ */
+
+import type { AbortSignalLike, WindowTarget } from './filedialog.js';
+import type { NtkApp } from './nodes.js';
+
+/** Which rung of the ladder answered — or would. */
+export type ScreenColorBackend = 'portal' | 'x11';
+
+export interface PickScreenColorOptions {
+  /**
+   * The window the picker belongs to — `parent_window` for the portal, and
+   * (when it points at a mounted node) the connection the X11 rung grabs on.
+   * `useEyedropper()` infers it from the tree.
+   */
+  parentWindow?: WindowTarget;
+  /** Abort the pick. Closes the portal request, or releases the X11 grab —
+   * the grab is released **before** the rejection is reported. */
+  signal?: AbortSignalLike;
+  /** Force a rung, for kiosks and for tests. */
+  backend?: ScreenColorBackend;
+  /**
+   * The connection the X11 rung grabs and reads on. Required for that rung
+   * when `parentWindow` does not resolve to a mounted node — the hook passes
+   * the tree's own.
+   */
+  app?: NtkApp;
+}
+
+/**
+ * Nothing here can sample the screen, and nothing can be drawn instead. A
+ * **typed** rejection — the `NoFileDialogError` rule — so a caller hides its
+ * eyedropper button rather than crashing; `useEyedropper().supported` is
+ * that branch made render state.
+ */
+export declare class NoScreenColorError extends Error {
+  readonly name: 'NoScreenColorError';
+  readonly cause?: unknown;
+}
+
+/**
+ * Sample one pixel from the screen: the desktop's own picker
+ * (`org.freedesktop.portal.Screenshot.PickColor`, Screenshot interface
+ * version 2) where there is one, a crosshair pointer grab on plain X11
+ * everywhere else.
+ *
+ * Resolves to `'#rrggbb'`, or `null` when the user cancelled — Escape on the
+ * X11 rung, the dialog's own cancel on the portal. Rejects with
+ * {@link NoScreenColorError} when neither rung is reachable.
+ */
+export declare function pickScreenColor(
+  options?: PickScreenColorOptions,
+): Promise<string | null>;
+
+/**
+ * Which rung this machine lands on, without grabbing anything. `'x11'` needs
+ * a connection to answer with — pass `app`, or a `parentWindow` pointing at
+ * a mounted node — and `null` means {@link pickScreenColor} would reject.
+ */
+export declare function screenColorBackend(
+  options?: Pick<PickScreenColorOptions, 'app' | 'backend' | 'parentWindow'>,
+): Promise<ScreenColorBackend | null>;
+
+export interface Eyedropper {
+  /**
+   * Start a pick. `'#rrggbb'`, or `null` when cancelled. While one is in
+   * flight, another call returns the **same promise** rather than queueing a
+   * second grab.
+   */
+  pick(options?: Omit<PickScreenColorOptions, 'app'>): Promise<string | null>;
+  /** `screenColorBackend()` resolved, for hiding or disabling the button. */
+  supported: boolean;
+  /** A pick is in flight — the button's pressed state. */
+  picking: boolean;
+}
+
+/**
+ * The eyedropper for a component: the tree's connection and owner window
+ * bound once, `picking` and `supported` as render state.
+ */
+export declare function useEyedropper(
+  defaults?: Omit<PickScreenColorOptions, 'app'>,
+): Eyedropper;

--- a/test/filedialog.test.js
+++ b/test/filedialog.test.js
@@ -28,7 +28,7 @@ import {
   saveFile,
   selectFolder,
 } from '../src/filedialog.js';
-import { _resetBusState, closeBus, sessionBus } from '../src/bus.js';
+import { sessionBus } from '../src/bus.js';
 import { FileDialog } from '../src/components/FileDialog.js';
 import { useFileDialog } from '../src/filedialoghooks.js';
 import { useTopLevelWindow, windowIdOf } from '../src/windowid.js';
@@ -40,7 +40,12 @@ import {
   screen,
 } from '../src/testing/index.js';
 import { fakePortal } from './helpers/fake-portal.js';
-import { transportAvailable, until, withBus } from './helpers/with-bus.js';
+import {
+  transportAvailable,
+  until,
+  withBus,
+  withNoBus,
+} from './helpers/with-bus.js';
 
 const haveTransport = await transportAvailable();
 const needsBroker = haveTransport
@@ -717,43 +722,6 @@ describe('the ladder', () => {
     );
   });
 });
-
-/**
- * Run `fn` on a machine with no session bus and no macOS.
- *
- * **The `closeBus()` is load-bearing, not tidying.** The shared connection
- * stays up across acquisitions by design, so pointing the env var at nothing
- * changes what the *next* connect would dial and not what is already open —
- * and a test that skipped this on a developer's own desktop would reach the
- * real portal and put a file dialog on their screen, then wait for a human.
- * That is exactly what happened while writing these.
- */
-async function withNoBus(fn) {
-  const saved = {
-    address: process.env.DBUS_SESSION_BUS_ADDRESS,
-    runtime: process.env.XDG_RUNTIME_DIR,
-    platform: process.platform,
-  };
-  await closeBus('session').catch(() => {});
-  _resetBusState();
-  _resetServiceCache();
-  process.env.DBUS_SESSION_BUS_ADDRESS = 'unix:path=/nonexistent/no-bus-here';
-  delete process.env.XDG_RUNTIME_DIR;
-  Object.defineProperty(process, 'platform', { value: 'linux' });
-  try {
-    return await fn();
-  } finally {
-    Object.defineProperty(process, 'platform', { value: saved.platform });
-    if (saved.address === undefined)
-      delete process.env.DBUS_SESSION_BUS_ADDRESS;
-    else process.env.DBUS_SESSION_BUS_ADDRESS = saved.address;
-    if (saved.runtime !== undefined)
-      process.env.XDG_RUNTIME_DIR = saved.runtime;
-    await closeBus('session').catch(() => {});
-    _resetBusState();
-    _resetServiceCache();
-  }
-}
 
 /** Let effects, the frame clock and one directory read all land. */
 async function settle() {

--- a/test/helpers/fake-portal.js
+++ b/test/helpers/fake-portal.js
@@ -16,13 +16,14 @@
 import { PORTAL_NAME, PORTAL_PATH, senderPath } from '../../src/portal.js';
 
 const FILE_CHOOSER = 'org.freedesktop.portal.FileChooser';
+const SCREENSHOT = 'org.freedesktop.portal.Screenshot';
 const REQUEST_IFACE = 'org.freedesktop.portal.Request';
 
 /**
  * Start a fake portal against `address`.
  *
- * `handlers` is `{ OpenFile, SaveFile }`, each `(call) => ({ response,
- * results })` or a promise of one, where `call` is
+ * `handlers` is `{ OpenFile, SaveFile, PickColor }`, each `(call) =>
+ * ({ response, results })` or a promise of one, where `call` is
  * `{ parentWindow, title, options, path }`. The default answers with one file.
  *
  * The returned object records every call in `calls`, so a test can assert on
@@ -35,11 +36,17 @@ const REQUEST_IFACE = 'org.freedesktop.portal.Request';
  * between "the portal has a dialog up" and "the client knows the handle"
  * wide enough to test deliberately, instead of waiting for a loaded CI runner
  * to land in it by accident.
+ *
+ * `screenshotVersion` exports the `Screenshot` interface — `PickColor`, whose
+ * argument list is `(s parent_window, a{sv} options)`, **not** FileChooser's —
+ * with its `version` property answering that number, the way the capability
+ * probe reads it. Unset, the interface is absent entirely, which is what
+ * XFCE's real portal looks like.
  */
 export async function fakePortal(
   address,
   handlers = {},
-  { holdReply = 0 } = {},
+  { holdReply = 0, screenshotVersion } = {},
 ) {
   const dbus = (await import('dbus-native')).default;
   const bus = dbus.createClient({ busAddress: address });
@@ -122,6 +129,28 @@ export async function fakePortal(
     },
   });
   await bus.export(PORTAL_PATH, iface);
+
+  if (screenshotVersion !== undefined) {
+    const screenshot = dbus.defineInterface({
+      name: SCREENSHOT,
+      methods: {
+        PickColor: {
+          in: { parent_window: 's', options: 'a{sv}' },
+          out: { handle: 'o' },
+          handler: (args, ctx) =>
+            answer(
+              'PickColor',
+              [args.parent_window, undefined, args.options],
+              ctx,
+            ),
+        },
+      },
+      properties: {
+        version: { type: 'u', access: 'read', value: screenshotVersion },
+      },
+    });
+    await bus.export(PORTAL_PATH, screenshot);
+  }
 
   return portal;
 }

--- a/test/helpers/with-bus.js
+++ b/test/helpers/with-bus.js
@@ -16,6 +16,7 @@
 // closing what the harness caused, not a seam into production code.
 
 import { _resetBusState, closeBus } from '../../src/bus.js';
+import { _resetServiceCache } from '../../src/portal.js';
 
 /**
  * The transport, loaded on demand — this file is imported by a suite that has
@@ -71,6 +72,43 @@ export async function withBus(fn) {
 function restore(name, value) {
   if (value === undefined) delete process.env[name];
   else process.env[name] = value;
+}
+
+/**
+ * Run `fn` on a machine with no session bus and no macOS.
+ *
+ * **The `closeBus()` is load-bearing, not tidying.** The shared connection
+ * stays up across acquisitions by design, so pointing the env var at nothing
+ * changes what the *next* connect would dial and not what is already open —
+ * and a test that skipped this on a developer's own desktop would reach the
+ * real portal and put a dialog on their screen, then wait for a human. That
+ * is exactly what happened while writing the file-dialog tests.
+ */
+export async function withNoBus(fn) {
+  const saved = {
+    address: process.env.DBUS_SESSION_BUS_ADDRESS,
+    runtime: process.env.XDG_RUNTIME_DIR,
+    platform: process.platform,
+  };
+  await closeBus('session').catch(() => {});
+  _resetBusState();
+  _resetServiceCache();
+  process.env.DBUS_SESSION_BUS_ADDRESS = 'unix:path=/nonexistent/no-bus-here';
+  delete process.env.XDG_RUNTIME_DIR;
+  Object.defineProperty(process, 'platform', { value: 'linux' });
+  try {
+    return await fn();
+  } finally {
+    Object.defineProperty(process, 'platform', { value: saved.platform });
+    if (saved.address === undefined)
+      delete process.env.DBUS_SESSION_BUS_ADDRESS;
+    else process.env.DBUS_SESSION_BUS_ADDRESS = saved.address;
+    if (saved.runtime !== undefined)
+      process.env.XDG_RUNTIME_DIR = saved.runtime;
+    await closeBus('session').catch(() => {});
+    _resetBusState();
+    _resetServiceCache();
+  }
 }
 
 /** A listening broker, with a live client count attached. */

--- a/test/screencolor.test.js
+++ b/test/screencolor.test.js
@@ -1,0 +1,569 @@
+// The eyedropper (issue #360): pickScreenColor() / useEyedropper(), and the
+// portalRequest generalization underneath the portal rung.
+//
+// Organised by rung, the filedialog.test.js way: the portal against a fake
+// Screenshot interface on the broker (this is also where the version gate —
+// the reason `portalVersion()` exists — is pinned), and the X11 rung against
+// node-x11's in-process server, whose grab and GetImage machinery are real.
+// The last group is the hook.
+import { test, describe, afterEach } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+
+import { XK_ESCAPE, XK_RETURN } from '../src/keysyms.js';
+import {
+  _resetServiceCache,
+  portalRequest,
+  portalVersion,
+} from '../src/portal.js';
+import {
+  NoScreenColorError,
+  pickScreenColor,
+  screenColorBackend,
+} from '../src/screencolor.js';
+import { useEyedropper } from '../src/screencolorhooks.js';
+import { act, cleanup, fireEvent, renderX11 } from '../src/testing/index.js';
+import { fakePortal } from './helpers/fake-portal.js';
+import {
+  transportAvailable,
+  until,
+  withBus,
+  withNoBus,
+} from './helpers/with-bus.js';
+
+const haveTransport = await transportAvailable();
+const needsBroker = haveTransport
+  ? {}
+  : { skip: 'dbus-native is not installed (expected on Node < 22.12)' };
+
+afterEach(() => {
+  _resetServiceCache();
+});
+
+// ---------------------------------------------------------------------------
+
+describe('portalRequest with a signature of its own', () => {
+  // The validation runs before anything touches the bus, so no broker is
+  // needed to pin the two mistakes it exists to catch.
+  test('signature and args travel as a pair', async () => {
+    const ref = { bus: null, uniqueName: ':1.1' };
+    await assert.rejects(
+      () =>
+        portalRequest(ref, {
+          iface: 'org.freedesktop.portal.Screenshot',
+          member: 'PickColor',
+          signature: 'sa{sv}',
+        }),
+      /`signature` without `args`/,
+    );
+    await assert.rejects(
+      () =>
+        portalRequest(ref, {
+          iface: 'org.freedesktop.portal.Screenshot',
+          member: 'PickColor',
+          args: [''],
+        }),
+      /`args` without `signature`/,
+    );
+  });
+
+  test('a signature not ending in the options dict is refused', async () => {
+    // handle_token rides in the trailing a{sv}; a method without one does not
+    // answer through a Request, so the helper cannot serve it.
+    await assert.rejects(
+      () =>
+        portalRequest(
+          { bus: null, uniqueName: ':1.1' },
+          {
+            iface: 'org.freedesktop.portal.Inhibit',
+            member: 'Inhibit',
+            signature: 'su',
+            args: ['', 8],
+          },
+        ),
+      /does not end in the options dict/,
+    );
+  });
+});
+
+describe('the portal rung', { ...needsBroker }, () => {
+  test('portalVersion reads the interface version, and 0 means not there', async () => {
+    await withBus(async (address) => {
+      // No Screenshot interface at all — XFCE's portal, as found on the
+      // machine this feature was built on.
+      const bare = await fakePortal(address);
+      try {
+        assert.equal(
+          await portalVersion('org.freedesktop.portal.Screenshot'),
+          0,
+        );
+      } finally {
+        await bare.stop();
+      }
+
+      _resetServiceCache();
+      const versioned = await fakePortal(address, {}, { screenshotVersion: 3 });
+      try {
+        assert.equal(
+          await portalVersion('org.freedesktop.portal.Screenshot'),
+          3,
+        );
+      } finally {
+        await versioned.stop();
+      }
+    });
+  });
+
+  test('PickColor: its own argument shape, and (ddd) becomes #rrggbb', async () => {
+    await withBus(async (address) => {
+      const portal = await fakePortal(
+        address,
+        {
+          PickColor: () => ({
+            response: 0,
+            // a{sv} as (key, [signature, value]) pairs; the struct arrives
+            // at the client as a plain [r, g, b] array.
+            results: [['color', ['(ddd)', [1, 0.5, 0]]]],
+          }),
+        },
+        { screenshotVersion: 2 },
+      );
+      try {
+        const hex = await pickScreenColor({ parentWindow: 0x1a00007 });
+        assert.equal(hex, '#ff8000');
+        assert.equal(portal.calls.length, 1);
+        assert.equal(portal.calls[0].member, 'PickColor');
+        // PickColor is (s parent_window, a{sv} options) — no title anywhere,
+        // which is exactly what the hardcoded FileChooser shape could not say.
+        assert.equal(portal.calls[0].parentWindow, 'x11:1a00007');
+        assert.equal(portal.calls[0].title, undefined);
+        assert.match(
+          portal.calls[0].options.handle_token,
+          /^rx11_[0-9a-f]{16}$/,
+        );
+      } finally {
+        await portal.stop();
+      }
+    });
+  });
+
+  test('the portal cancel resolves to null, not a throw', async () => {
+    await withBus(async (address) => {
+      const portal = await fakePortal(
+        address,
+        { PickColor: () => ({ response: 1, results: {} }) },
+        { screenshotVersion: 2 },
+      );
+      try {
+        assert.equal(await pickScreenColor(), null);
+      } finally {
+        await portal.stop();
+      }
+    });
+  });
+
+  test('abort closes the request rather than walking away', async () => {
+    await withBus(async (address) => {
+      const portal = await fakePortal(
+        address,
+        { PickColor: () => ({ silent: true }) },
+        { screenshotVersion: 2 },
+      );
+      try {
+        const ac = new AbortController();
+        const pending = pickScreenColor({ signal: ac.signal });
+        await until(() => portal.calls.length === 1, 'the call to arrive');
+        ac.abort();
+        await assert.rejects(pending, /aborted/i);
+        await until(
+          () => portal.closed.length === 1,
+          'the portal to see Close()',
+        );
+      } finally {
+        await portal.stop();
+      }
+    });
+  });
+
+  test('Screenshot v1 is not a rung: PickColor is version 2', async () => {
+    await withBus(async (address) => {
+      // The interface exists — hasService() and even an introspection would
+      // say yes — but PickColor arrived in version 2, so calling it would
+      // error at the far end. The version property is the honest gate.
+      const portal = await fakePortal(
+        address,
+        { PickColor: () => ({ response: 0, results: {} }) },
+        { screenshotVersion: 1 },
+      );
+      try {
+        await assert.rejects(
+          () => pickScreenColor(),
+          (err) => err instanceof NoScreenColorError,
+        );
+        assert.equal(portal.calls.length, 0, 'PickColor was never called');
+      } finally {
+        await portal.stop();
+      }
+    });
+  });
+
+  test("backend: 'portal' with no Screenshot is a typed rejection", async () => {
+    await withBus(async (address) => {
+      const portal = await fakePortal(address); // no Screenshot interface
+      try {
+        await assert.rejects(
+          () => pickScreenColor({ backend: 'portal' }),
+          (err) => {
+            assert.ok(err instanceof NoScreenColorError);
+            assert.match(err.message, /version 2/);
+            return true;
+          },
+        );
+      } finally {
+        await portal.stop();
+      }
+    });
+  });
+});
+
+describe('screenColorBackend', () => {
+  test('no bus and no connection is null; a connection is the x11 rung', async () => {
+    await withNoBus(async () => {
+      assert.equal(await screenColorBackend(), null);
+      // Reachability, not validity: any connection object makes the fallback
+      // answerable. The pick itself is what exercises it.
+      assert.equal(await screenColorBackend({ app: { X: {} } }), 'x11');
+      assert.equal(
+        await screenColorBackend({ app: { X: {} }, backend: 'portal' }),
+        null,
+      );
+    });
+  });
+
+  test(
+    'a Screenshot portal at version 2 answers portal',
+    { ...needsBroker },
+    async () => {
+      await withBus(async (address) => {
+        const portal = await fakePortal(address, {}, { screenshotVersion: 2 });
+        try {
+          assert.equal(await screenColorBackend(), 'portal');
+          // Forcing the rung skips the probe entirely.
+          assert.equal(
+            await screenColorBackend({ app: { X: {} }, backend: 'x11' }),
+            'x11',
+          );
+        } finally {
+          await portal.stop();
+        }
+      });
+    },
+  );
+
+  test(
+    'a portal without Screenshot falls to x11 — the XFCE case',
+    { ...needsBroker },
+    async () => {
+      await withBus(async (address) => {
+        const portal = await fakePortal(address); // FileChooser only
+        try {
+          assert.equal(await screenColorBackend({ app: { X: {} } }), 'x11');
+          assert.equal(await screenColorBackend(), null);
+        } finally {
+          await portal.stop();
+        }
+      });
+    },
+  );
+
+  test('no rung at all: pickScreenColor names the way out', async () => {
+    await withNoBus(async () => {
+      await assert.rejects(
+        () => pickScreenColor(),
+        (err) => {
+          assert.ok(err instanceof NoScreenColorError);
+          assert.match(err.message, /useEyedropper|`app`/);
+          return true;
+        },
+      );
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The X11 rung, against the in-process server's real grab machinery.
+// ---------------------------------------------------------------------------
+
+/** Fill a rect of the ROOT window with a colour, so a pick has a known
+ * answer. GetImage on the root is what the rung reads. */
+function paintRoot(app, x, y, pixel) {
+  const X = app.X;
+  const root = X.display.screen[0].root;
+  const gc = X.AllocID();
+  X.CreateGC(gc, root, { foreground: pixel });
+  X.PolyFillRectangle(root, gc, [x, y, 20, 20]);
+  X.FreeGC(gc);
+  X.ReleaseID(gc);
+}
+
+/** The grab window is nothing the tree owns — assert that, and hand back
+ * its id so the test can talk about it. */
+function grabWindowOf(view) {
+  const grab = view.server.grabs.pointer;
+  assert.ok(grab, 'a pointer grab is active');
+  assert.notEqual(grab.wid, view.windowNode.window.id);
+  return grab.wid;
+}
+
+describe('the X11 rung', () => {
+  afterEach(cleanup);
+
+  test('grab, crosshair, click: the pixel under the pointer, then everything released', async () => {
+    const view = await renderX11(
+      React.createElement('window', { width: 200, height: 120 }),
+      { wrap: false },
+    );
+    paintRoot(view.app, 300, 300, 0x336699);
+
+    const pending = pickScreenColor({ app: view.app, backend: 'x11' });
+    await until(() => view.server.grabs.pointer, 'the grab to activate');
+    const wid = grabWindowOf(view);
+    assert.notEqual(
+      view.server.grabs.pointer.cursor,
+      0,
+      'the grab carries the crosshair',
+    );
+
+    view.server.injectPointerMove(310, 310);
+    view.server.injectButton(1, true);
+    view.server.injectButton(1, false);
+
+    assert.equal(await pending, '#336699');
+    assert.equal(view.server.grabs.pointer, null, 'pointer grab released');
+    assert.equal(view.server.grabs.keyboard, null, 'keyboard grab released');
+    // The InputOnly grab window went with it.
+    assert.equal(view.server.resources?.get?.(wid) ?? null, null);
+  });
+
+  test('Escape cancels: null, with the grab released first', async () => {
+    const view = await renderX11(
+      React.createElement('window', { width: 200, height: 120 }),
+      { wrap: false },
+    );
+    const pending = pickScreenColor({ app: view.app, backend: 'x11' });
+    await until(() => view.server.grabs.keyboard, 'the keyboard grab');
+
+    // fireEvent resolves the keysym and injects at the server; the active
+    // keyboard grab is what routes it to the eyedropper rather than to the
+    // window the event nominally targets — which is the mechanism under test.
+    fireEvent.key(XK_ESCAPE, { target: view.windowNode });
+
+    assert.equal(await pending, null);
+    // The cancel resolves the moment it is decided; the ungrab requests are
+    // on the wire ahead of it and land a round trip later.
+    await until(() => !view.server.grabs.pointer, 'the pointer grab release');
+    await until(() => !view.server.grabs.keyboard, 'the keyboard grab release');
+  });
+
+  test('Return picks at the pointer without a click', async () => {
+    const view = await renderX11(
+      React.createElement('window', { width: 200, height: 120 }),
+      { wrap: false },
+    );
+    paintRoot(view.app, 340, 200, 0xaa00ff);
+    view.server.injectPointerMove(345, 205);
+
+    const pending = pickScreenColor({ app: view.app, backend: 'x11' });
+    await until(() => view.server.grabs.keyboard, 'the keyboard grab');
+    fireEvent.key(XK_RETURN, { target: view.windowNode });
+
+    assert.equal(await pending, '#aa00ff');
+    assert.equal(view.server.grabs.pointer, null);
+  });
+
+  test('other buttons neither pick nor cancel', async () => {
+    const view = await renderX11(
+      React.createElement('window', { width: 200, height: 120 }),
+      { wrap: false },
+    );
+    paintRoot(view.app, 300, 300, 0x00ff00);
+    const pending = pickScreenColor({ app: view.app, backend: 'x11' });
+    await until(() => view.server.grabs.pointer, 'the grab to activate');
+
+    view.server.injectPointerMove(310, 310);
+    // A middle-click paste reflex must not eat the pick.
+    view.server.injectButton(2, true);
+    view.server.injectButton(2, false);
+    assert.ok(view.server.grabs.pointer, 'still picking');
+
+    view.server.injectButton(1, true);
+    view.server.injectButton(1, false);
+    assert.equal(await pending, '#00ff00');
+  });
+
+  test('abort releases the grab before the rejection reports', async () => {
+    const view = await renderX11(
+      React.createElement('window', { width: 200, height: 120 }),
+      { wrap: false },
+    );
+    const ac = new AbortController();
+    const reason = new Error('changed my mind');
+    const pending = pickScreenColor({
+      app: view.app,
+      backend: 'x11',
+      signal: ac.signal,
+    });
+    await until(() => view.server.grabs.pointer, 'the grab to activate');
+    ac.abort(reason);
+    await assert.rejects(pending, (err) => err === reason);
+    // The cleanup ran synchronously on the abort; the requests are on the
+    // wire before the rejection was reported. One round trip proves them.
+    await until(() => !view.server.grabs.pointer, 'the grab to be released');
+    assert.equal(view.server.grabs.keyboard, null);
+  });
+
+  test('a second pick on the same connection is refused, loudly', async () => {
+    const view = await renderX11(
+      React.createElement('window', { width: 200, height: 120 }),
+      { wrap: false },
+    );
+    const first = pickScreenColor({ app: view.app, backend: 'x11' });
+    await until(() => view.server.grabs.pointer, 'the grab to activate');
+    // A second GrabPointer from the same client would silently *replace* the
+    // first — one pick would settle with the other's click.
+    await assert.rejects(
+      () => pickScreenColor({ app: view.app, backend: 'x11' }),
+      /already waiting for a click/,
+    );
+    fireEvent.key(XK_ESCAPE, { target: view.windowNode });
+    assert.equal(await first, null);
+  });
+
+  test('a <popup grab> gets its grab back after the pick', async () => {
+    const view = await renderX11(
+      React.createElement(
+        'window',
+        { width: 200, height: 120 },
+        React.createElement(
+          'box',
+          null,
+          React.createElement('popup', {
+            grab: true,
+            x: 10,
+            y: 10,
+            width: 60,
+            height: 40,
+          }),
+        ),
+      ),
+      { wrap: false },
+    );
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 30));
+    });
+    await until(() => view.server.grabs.pointer, "the popup's own grab");
+    const popupWid = view.server.grabs.pointer.wid;
+
+    paintRoot(view.app, 300, 300, 0xdd2200);
+    const pending = pickScreenColor({ app: view.app, backend: 'x11' });
+    // Same client, so the pick *replaces* the popup's grab rather than
+    // failing AlreadyGrabbed — and the popup is never told.
+    await until(
+      () => view.server.grabs.pointer?.wid !== popupWid,
+      'the pick to take the grab over',
+    );
+
+    view.server.injectPointerMove(310, 310);
+    view.server.injectButton(1, true);
+    view.server.injectButton(1, false);
+    assert.equal(await pending, '#dd2200');
+
+    // The renderer is the only party that knew both grabs existed, so it is
+    // the one that hands the popup its dismiss-on-outside-click back.
+    await until(
+      () => view.server.grabs.pointer?.wid === popupWid,
+      "the popup's grab to be restored",
+    );
+  });
+
+  test('a grab released out from under the pick is taken back', async () => {
+    const view = await renderX11(
+      React.createElement('window', { width: 200, height: 120 }),
+      { wrap: false },
+    );
+    paintRoot(view.app, 300, 300, 0x112233);
+    const pending = pickScreenColor({ app: view.app, backend: 'x11' });
+    await until(() => view.server.grabs.pointer, 'the grab to activate');
+    const wid = view.server.grabs.pointer.wid;
+
+    // What a closing popup's teardown does: UngrabPointer on the shared
+    // connection, releasing whatever the client's active grab is — ours. A
+    // real server announces it with LeaveNotify mode Ungrab on the grab
+    // window; the in-process one does not synthesise crossing events, so the
+    // announcement is replayed here.
+    view.app.X.UngrabPointer(0);
+    await until(() => !view.server.grabs.pointer, 'the grab to be lost');
+    view.app.X.emit('event', { type: 8, wid, mode: 2 });
+
+    await until(
+      () => view.server.grabs.pointer?.wid === wid,
+      'the pick to take the grab back',
+    );
+
+    view.server.injectPointerMove(310, 310);
+    view.server.injectButton(1, true);
+    view.server.injectButton(1, false);
+    assert.equal(await pending, '#112233');
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('useEyedropper', () => {
+  afterEach(cleanup);
+
+  test('supported resolves, picking tracks the pick, one grab per double click', async () => {
+    let eyedropper;
+    function Probe() {
+      eyedropper = useEyedropper({ backend: 'x11' });
+      return React.createElement('box', { style: { flex: 1 } });
+    }
+    const view = await renderX11(
+      React.createElement(
+        'window',
+        { width: 200, height: 120 },
+        React.createElement(Probe),
+      ),
+      { wrap: false },
+    );
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 30));
+    });
+    assert.equal(eyedropper.supported, true);
+    assert.equal(eyedropper.picking, false);
+
+    paintRoot(view.app, 300, 300, 0x123456);
+    let pending;
+    let second;
+    await act(async () => {
+      pending = eyedropper.pick();
+      // The double click: the in-flight promise is handed back, not queued
+      // behind a second grab.
+      second = eyedropper.pick();
+      await new Promise((r) => setTimeout(r, 30));
+    });
+    assert.equal(second, pending);
+    assert.equal(eyedropper.picking, true);
+
+    await until(() => view.server.grabs.pointer, 'the grab to activate');
+    view.server.injectPointerMove(310, 310);
+    view.server.injectButton(1, true);
+    view.server.injectButton(1, false);
+    assert.equal(await pending, '#123456');
+
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 30));
+    });
+    assert.equal(eyedropper.picking, false);
+  });
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -14,6 +14,7 @@ import { registerRefresh, createTransformer } from 'react-x11/refresh/loader';
 import type { ReloadEvent } from 'react-x11/refresh';
 import type { RefreshOptions } from 'react-x11/refresh/loader';
 import type {
+  AbortSignalLike,
   BusHandle,
   CalendarHandle,
   BusKind,
@@ -26,6 +27,7 @@ import type {
   LoadedFont,
   MessageBus,
   Screen,
+  ScreenColorBackend,
   Screens,
   SystemLocale,
   WindowState,
@@ -52,9 +54,14 @@ import {
   useAppActivate,
   useAppOpen,
   NoFileDialogError,
+  NoScreenColorError,
   openFile,
+  pickScreenColor,
+  portalVersion,
   saveFile,
+  screenColorBackend,
   serverTime,
+  useEyedropper,
   sessionBus,
   systemBus,
   useApp,
@@ -1267,6 +1274,54 @@ function _Files() {
       }
     }
     void [target, dirs, bare, backend];
+  }
+  void go;
+  return null;
+}
+
+// the eyedropper: hex-or-null, the rung report, and the hook's render state
+function _Eyedropper() {
+  const win = useRef<NtkWindow | null>(null);
+  const { pick, supported, picking } = useEyedropper({
+    parentWindow: win,
+    backend: 'x11',
+  });
+
+  async function go() {
+    // Cancelling is `null`, not a throw — same contract as the file dialog.
+    const hex: string | null = await pick();
+    if (hex) hex.toUpperCase();
+
+    // The bare function for host-side code; `app` is how the X11 rung is
+    // reached without a tree.
+    const signal: AbortSignalLike = {
+      aborted: false,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    };
+    const bare: string | null = await pickScreenColor({
+      parentWindow: 0x1a00007,
+      signal,
+    });
+    const rung: ScreenColorBackend | null = await screenColorBackend();
+    // @ts-expect-error — not a rung: there is nothing to draw a third one with
+    await pickScreenColor({ backend: 'builtin' });
+    // @ts-expect-error — the hook binds the tree's connection itself
+    pick({ app: undefined });
+
+    const version: number = await portalVersion(
+      'org.freedesktop.portal.Screenshot',
+    );
+
+    try {
+      await pickScreenColor({ backend: 'portal' });
+    } catch (err) {
+      if (err instanceof NoScreenColorError) {
+        const why: unknown = err.cause;
+        void why;
+      }
+    }
+    void [bare, rung, supported, picking, version];
   }
   void go;
   return null;

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -191,6 +191,7 @@ const ORDER = [
   'globalmenu.md',
   'uri-schemes.md',
   'filedialog.md',
+  'eyedropper.md',
   'appearance.md',
   'system.md',
   'remote.md',


### PR DESCRIPTION
Implements #360: `pickScreenColor()` / `useEyedropper()` — the file-dialog ladder again, two rungs this time, with its names and conventions carried over rather than re-decided.

## The ladder

1. **The portal** — `org.freedesktop.portal.Screenshot.PickColor`. Gated on the interface's `version` property (PickColor is Screenshot **v2**) via the new **`portalVersion()`**, because `hasService()` cannot see which interfaces a portal's backends provide — this was built on an XFCE session whose portal ships FileChooser and no Screenshot interface at all, which is exactly the machine the gate exists for.
2. **X11** — grab the pointer with `cursorShapes.crosshair`, wait for the click, `GetImage` a 1×1 at `rootx/rooty`, decode with `pixelLayout()`/`toStraightRgba()`. Grab, crosshair, click; Escape cancels; Return/space/KP Enter pick at the pointer (GTK's shape). No magnifier, as proposed in the issue.

Conventions carried over: cancel resolves `null` and does not throw; `NoScreenColorError` is the typed floor; `backend` forces a rung; `signal` aborts **and releases the grab before the rejection reports** — core's to guarantee, not the app's. Returns `'#rrggbb'` on both rungs.

## The smaller ask

`portalRequest()` now says its signature: `signature` + `args` travel as a pair, defaulting to FileChooser's `'ssa{sv}'` with `[parentWindow, title]`, so every existing caller is unchanged and `PickColor`'s `(s parent_window, a{sv} options)` is expressible. A signature not ending in `a{sv}` is refused — `handle_token` rides in that dict, so a method without one is not Request-shaped.

## The grab is the dangerous part

A leaked pointer grab is a desktop that stopped answering clicks, so the X11 rung's lifecycle all funnels through one gate:

- Every way out — click, Escape, abort, error — releases the grab before the promise settles.
- The grab window is a dedicated offscreen InputOnly window, so pick clicks never flow through the renderer's own dispatcher.
- A `<popup grab>` open when the pick starts (an open Select, a menu, the colour panel the eyedropper button sits in) has its grab silently *replaced* by the pick's — same client, no AlreadyGrabbed, and X tells no one. Core hands the popup its grab back afterwards, so dismiss-on-outside-click survives a pick.
- A grab released out from under the pick — this client's own popup teardown calls `UngrabPointer`, which releases whatever the active grab is — is detected by the `LeaveNotify` mode `Ungrab` the server sends on the grab window, and taken back. Verified against real Xorg.
- One pick per connection: a second concurrent bare pick is refused loudly (a second same-client grab would settle one pick with the other's click); the hook hands back the in-flight promise instead, so `picking` doubles as the button's pressed state.

## Found upstream while verifying on a real display

node-x11's `GrabKeyboard` writes pointer-mode/keyboard-mode at request offsets **10/11 — inside the `time` field** — instead of the protocol's 12/13. Every `X.GrabKeyboard` with CurrentTime reaches a real server as a garbage timestamp with synchronous modes: Xorg answers InvalidTime, and the pure-JS test server never reads those bytes, which is how it stays green headlessly. `src/screencolor.js` marshals the request by hand (the way node-x11's own extension modules do) with a comment naming the bug; worth fixing upstream in node-x11 — ntk's `Window.grabKeyboard` is broken on real servers by the same offsets.

## Verified

- 21 new tests: the portal rung against a fake Screenshot interface on the broker (including the v1/v2 version gate and abort→`Request.Close`), the X11 rung against node-x11's in-process server (real grab machinery: click/decode/cleanup, Escape, Return-at-pointer, ignored buttons, abort, concurrency, popup-grab restore, stolen-grab recovery), and the hook.
- Full suite: 1629 pass; lint, typecheck, prettier clean; `test/types/api.tsx` extended.
- **End to end on a live Xorg/XFCE session**, driven over XTEST: backend resolves to `x11` (portal present, no Screenshot — the issue's motivating machine), pick answers the exact pixel of a test window, Escape cancels, Return picks at the pointer, and the stolen-grab recovery round-trips through real `LeaveNotify` crossings.

## Docs

`docs/eyedropper.md` (in the site sidebar after the file dialogs), the `portalRequest`/`portalVersion` section of `docs/filedialog.md`, and the `docs/README.md` index.

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)
