### PR TITLE
feat(scale): a display scale model — apps write logical pixels, 'auto' resolves the factor from the connection

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -82,6 +82,11 @@
   for apps that only want to follow the desktop, why the answer is remembered
   on disk so the first frame is not a flash, and what each rung of the ladder
   can actually answer.
+- [scale.md](scale.md) — HiDPI: every length you write is a logical pixel,
+  `createRoot({ scale: 'auto' })` resolves how many device pixels one is
+  worth (environment → XSETTINGS/`Xft.dpi` → audited RandR millimetres →
+  the resolution class), `useScale()`, per-monitor answers on
+  `useScreens()`, and why a virtual machine's EDID needs the audit.
 - [system.md](system.md) — the machine around the app: `useScreens()` for the
   monitor layout, `useWindowState()` for what the window manager actually did,
   `useIdle()`/`useKeepAwake()`, `useKeyboardState()` for Caps Lock and the live

--- a/docs/scale.md
+++ b/docs/scale.md
@@ -1,0 +1,206 @@
+# Display scale
+
+Every length in react-x11 is a **logical pixel**: a unit sized so that
+`fontSize: 14` is comfortably readable at the distance the display is
+actually viewed from. On the panels of the last decade one logical pixel is
+two device pixels — or 1.5, or 1.25 — and the renderer multiplies exactly
+once, on the way to the server. An app says nothing and gets a UI the same
+physical size on a 2013 monitor and a retina laptop.
+
+```jsx
+const root = await createRoot();               // scale: 'auto' is the default
+const root = await createRoot({ scale: 2 });   // pin it
+REACT_X11_SCALE=1.5 node app.js                // the user outranks everybody
+```
+
+```jsx
+import { useScale } from 'react-x11';
+const scale = useScale(); // 1, 2, 1.5... static for the life of the root
+```
+
+## What is logical and what is device
+
+**Logical — everything application code touches:**
+
+- every style length (`width`, `padding`, `fontSize`, `borderRadius`, the
+  lengths inside `boxShadow` and gradient stops, `hitSlop`…)
+- window geometry props (`width`, `height`, `x`, `y`, `minWidth`…) and the
+  `onResize` payload
+- event coordinates: `ev.x`/`ev.y`/`ev.localX`/`ev.localY`, wheel
+  `deltaX`/`deltaY`, drag `screenX`/`screenY`
+- `getClientRects()`, `measure()`, `useScreens()` rects,
+  `anchorRect`/`centerRect`/`anchorArea`
+- the scroll surface: `scrollTo()`/`scrollBy()` arguments, `onScroll` and
+  `onViewport` payloads
+- the theme: `DefaultTheme.fontSize` is 14 and stays 14
+
+**Device — the renderer's internals and the deliberate escape hatches:**
+
+- `node.abs`, yoga's computed layout, everything painted
+- `node.scrollX`/`scrollY`/`contentWidth`/`contentHeight` read directly off
+  a ref (positions in the rendered surface; use the `onScroll` payload for
+  logical math)
+- `<canvas onDraw>`: the browser's own canvas contract — the box arrives in
+  device pixels and the payload carries `scale`, so detail is drawn on the
+  real grid. Deliberately **not** a `ctx.scale()`: ntk positions glyphs
+  through the transform but sizes them from the font, so a scaled transform
+  would move an app's `fillText` without growing it — and it would knock
+  every fill off ntk's server-side fast paths besides.
+- a registered element's `paint()` and `hitTest()` (see
+  [extending.md](extending.md)): `this.style` and `this.abs` arrive already
+  device, synthetic events are logical, and `this.scale` is on every node
+  for the constants that never pass through a style.
+
+Fonts are the point of the whole exercise: a `fontSize: 14` at scale 2 is
+shaped, measured and rasterized at 28px. Text on a retina panel is _sharper_,
+not bigger-blurrier — the same reason every native toolkit renders this way
+instead of transform-scaling a 1x picture.
+
+## How `'auto'` decides
+
+X11 never grew a scale protocol, so the answer is scattered across four
+generations of convention. The ladder consults each rung only when the ones
+above said nothing, ordered by "who is closest to a human having decided":
+
+1. **Environment** — `REACT_X11_SCALE` (ours, wins over everything including
+   an explicit `scale:` number — it is the accessibility escape hatch), then
+   `GDK_SCALE`, then `QT_SCALE_FACTOR`. The user already told their other
+   toolkits; an app of ours on the same desktop should agree.
+2. **XSETTINGS** — `Gdk/WindowScalingFactor` when it is 2+, then `Xft/DPI`
+   (in 1024ths of a dpi on the wire; a daemon writing plain dpi is read
+   right too). This is what the desktop's own settings dialog writes and
+   what every GTK app on the screen is already obeying.
+3. **`RESOURCE_MANAGER`** — `Xft.dpi`, the `xrdb` convention winit,
+   Chromium and every terminal emulator read.
+4. **RandR millimetres** — the panel's physical size against its pixel
+   size, run per output, under mutter's viewing-distance model: the DPI
+   that counts as "1x" is 135 under a 20″ diagonal (a panel in your lap at
+   ~50cm) and 110 over it (across a desk). Snapped to quarter steps in
+   [1, 3]. For calibration: a 27″ 2560×1440 desk monitor computes 109dpi →
+   1x; a 27″ 4K computes 163dpi → 1.5x; a 16″ MacBook panel computes
+   255dpi → 2x, matching macOS.
+5. **The resolution class** — when the millimetres are absent or caught
+   lying, the pixel grid itself is the last signal: nothing ships a 1x
+   panel with a ≥3000-wide or ≥1800-short-side grid, so those are called 2x
+   and everything else 1x. Only the confident call is made without physical
+   data — 2560×1440 stays 1x on purpose, because it is the commonest 1x
+   desk monitor there is and only millimetres could tell it from a 13″
+   retina lid.
+6. **1.**
+
+Two readings deserve their asterisks. **96 is not an answer**: `Xft.dpi: 96`
+and `Gdk/WindowScalingFactor: 1` are what daemons publish when nobody ever
+opened the dialog (xfsettingsd writes both unconditionally), so they fall
+through to the hardware instead of pinning an unconfigured 4K laptop to
+microscopic. And **millimetres are audited before they are believed**
+(`classifyMm`): zeroes, aspect-ratios-as-sizes (16×9 "millimetres"),
+physical/pixel aspect disagreement, and — the one that motivated all of
+this — virtual machines, detected by EDID vendor and model (`RHT` / "QEMU
+Monitor", VMware, VirtualBox, Parallels, Hyper-V) and by connector name
+(`Virtual-*`, `qxl`, …). `XWAYLAND*` outputs skip the hardware rung too:
+the compositor owns scaling there and publishes its decision through rung
+2, in both of its Xwayland modes.
+
+### The machine this was built against
+
+A 16″ MacBook panel handed 1:1 to a UTM Linux guest (XFCE, X11) defeats
+rungs 1–4 simultaneously, which is why the ladder has five:
+
+```
+core screen      3456×2168 px, "914×573mm"   → synthesized to exactly 96dpi
+XSETTINGS        Gdk/WindowScalingFactor 1, Xft/DPI 98304 (= 96·1024)
+RESOURCE_MANAGER Xft.dpi: 96                 → the never-configured default
+RandR            Virtual-1 "870×550mm"       → a 40″ panel that is 16″
+EDID             vendor RHT, model "QEMU Monitor"  → the lie, signed
+verdict          2x via the resolution class → correct
+```
+
+Every millimetre in that transcript is invented — QEMU fabricates a size
+that makes the maths land on ~100dpi — and every configured source is an
+untouched default. Run `node scripts/scale-probe.mjs` against any display
+to see the same table for it, or `REACT_X11_DEBUG_SCALE=1` in an app to
+watch the ladder resolve.
+
+## Several monitors
+
+Rungs 4–5 are computed for every connected output, because a desktop with a
+retina lid and an office monitor genuinely has two answers. The **root's**
+scale — the one layout and paint use — is the primary output's (the largest,
+where nothing is flagged primary), matching what GNOME does on X11: one
+scale for the session, chosen for the display you called primary.
+
+The per-output answers ride on `useScreens()` — every entry carries its own
+`scale` — so an app that places windows can do better, and a window can be
+pinned with `createRoot({ scale })` per root. What this deliberately does
+not do is re-scale a window as it is dragged between mismatched monitors:
+X11 has one coordinate space and no per-window scale protocol, so that move
+is a resize the window manager fights mid-drag; Qt is the one toolkit that
+tries it, and "chosen at creation, static after" is the behaviour of
+everything else on this window system.
+
+Static-at-startup is the other honest limitation: a mid-session change of
+`Xft.dpi` or a monitor swap does not re-scale running windows. Rare enough
+that GTK3 apps mostly share it; restart the app.
+
+## Prior art, and where this sits
+
+| Toolkit                          | X11 sources, in order                                                                                     | Notes                                                                                                             |
+| -------------------------------- | --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| GTK 3/4                          | `GDK_SCALE` env; XSETTINGS `Gdk/WindowScalingFactor`                                                      | integer only; fonts via `Xft/DPI`                                                                                 |
+| Qt 5/6                           | `QT_SCALE_FACTOR`, `QT_SCREEN_SCALE_FACTORS`; per-screen logical DPI (`Xft.dpi`), physical DPI from RandR | the only per-screen attempt on X11                                                                                |
+| winit                            | `WINIT_X11_SCALE_FACTOR`; `Xft.dpi`; RandR mm                                                             | mm path famously burned by 1×1mm and VM EDIDs ([winit#1983](https://github.com/rust-windowing/winit/issues/1983)) |
+| Chromium/Electron                | `Xft.dpi` via XSETTINGS then xrdb; `GDK_SCALE`                                                            | never trusts RandR mm                                                                                             |
+| SDL 2/3                          | `Xft.dpi` only                                                                                            | 1x on every unconfigured desktop                                                                                  |
+| mutter (the config UI's default) | per-monitor mm under the 135/110-dpi viewing-distance model                                               | the model rung 4 adopts, constants and all                                                                        |
+
+The composition is the contribution: desktop configuration first (rungs
+1–3, which is where Chromium/SDL stop — correct on configured desktops,
+tiny on unconfigured HiDPI ones), mutter's perceptual model where the
+hardware is honest (which is where winit's mm math stops — right until an
+EDID lies), and the resolution class where it is not (which nobody else
+has, and which is the only rung that survives a VM).
+
+## Design notes
+
+**Why multiply values instead of transforming the context.** Two hard
+reasons, both ntk's. Its 2d context batches solid fills into server-side
+`Render.FillRectangles` and takes similar fast paths for strokes, rounded
+rects and glyph runs — all gated on an identity transform, so a frame-wide
+`ctx.scale(2,2)` would rasterize every box in the UI as polygons. And its
+text model sizes glyphs from the font while only _positioning_ them through
+the transform, so scaled-transform text comes out moved but not grown.
+Multiplying at the style funnel instead means paint code, damage rects, the
+scroll blit and the paint cache all keep working in integer device pixels
+with the transforms they always had. (`paintcache.js` even guards against
+the other choice: a non-identity CTM disables it entirely.)
+
+**Where the multiply lives.** One place for styles —
+`scaleResolvedStyle()`, at the end of the style funnel in `_syncStyle`, so
+state blocks, size queries and the flex shorthand all still think in the
+logical pixels the app wrote. One place for the theme's font size — the
+root branch of `inheritedTextStyle`, because descendants inherit an
+already-resolved size and any second multiply would compound. One place for
+window geometry (`scaleWindowGeometry`), one per string-parsed decoration
+(`shadowSpecs`/`gradientSpec`, whose parses are memoized on the raw string
+so the scale rides into the memo key), and division at each app-facing
+egress (`SyntheticEvent`, `getClientRects`, `onScroll`, `useScreens`…).
+`yoga` needs no `pointScaleFactor` games: layout runs directly in device
+pixels and its ordinary whole-pixel rounding is what keeps a 1-logical-px
+border crisp at 1.5x.
+
+**Fractional scales** work end to end (`1.25`, `1.5`, quarter steps from
+the ladder), with the usual X11 caveat: a 1-logical-px hairline at 1.25x is
+1 or 2 device pixels depending on where it lands. Integer scales have no
+such seams.
+
+**What tests see.** The headless harnesses resolve to exactly 1 — a mock
+app has no display to ask — so every geometry assertion in the suite means
+its numbers literally. `createRoot({ app, scale: 2 })` opts a test in;
+`test/scale-render.test.js` is the boundary contract pinned as tests.
+`setScaleForTests()` (from `src/scale.js`) pins a factor without a
+connection.
+
+**Known costs.** The paint cache's per-item budget is device pixels, so at
+2x a widget occupies 4× the budget it did — icons and checkboxes still fit
+comfortably. Damage rects, protocol traffic and backing stores scale the
+same way any HiDPI surface does.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "labs:urischeme": "tsx examples/labs/urischeme.jsx",
     "filedialog:probe": "node scripts/filedialog-probe.mjs",
     "a11y:probe": "node scripts/a11y-probe.mjs",
+    "scale:probe": "node scripts/scale-probe.mjs",
     "globalmenu:host": "node scripts/globalmenu-host.mjs",
     "devtools:proxy": "node scripts/devtools-proxy.mjs",
     "examples:fonts": "tsx examples/fonts.jsx",

--- a/scripts/scale-probe.mjs
+++ b/scripts/scale-probe.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+// What can this display connection tell us about pixel density?
+//
+// Everything a react-x11 process could use to pick a scale factor, read the
+// way the renderer itself would read it — over the X connection, no
+// subprocesses, no xrdb, no gsettings. Point it at a display and it prints
+// each source, what it says, and what scale each detection rung would
+// conclude. The last line is the ladder's verdict, which is what
+// `createRoot({ scale: 'auto' })` resolves.
+//
+//   node scripts/scale-probe.mjs             # $DISPLAY
+//   DISPLAY=:1 node scripts/scale-probe.mjs  # another server
+//
+// The sources, in the order the ladder consults them (docs/scale.md):
+//
+//   1. environment      REACT_X11_SCALE, GDK_SCALE, QT_SCALE_FACTOR
+//   2. XSETTINGS        Gdk/WindowScalingFactor, Gdk/UnscaledDPI, Xft/DPI
+//   3. RESOURCE_MANAGER Xft.dpi (what `xrdb -query` shows)
+//   4. RandR            per-output pixel and millimetre geometry + EDID
+//   5. resolution class the retina-panel guess, when the mm are not credible
+//
+// This is the probe that shaped the ladder: on the machine it was written
+// against (a 16" MacBook panel handed 1:1 to a UTM Linux guest), sources
+// 1-4 all answer "1x" — the VM's EDID invents 870x550mm to make the maths
+// come out at ~100dpi — and only the resolution class knows the panel is
+// retina. See docs/scale.md for why each rung outranks the next.
+
+import x11 from 'x11';
+import { parseXSettings } from '../src/xsettings.js';
+import {
+  parseEdid,
+  parseResourceManager,
+  monitorScaleFromMetadata,
+  classifyMm,
+} from '../src/scale.js';
+
+const out = (...args) => console.log(...args);
+const section = (title) => out(`\n=== ${title} ===`);
+
+function connect() {
+  return new Promise((resolve, reject) => {
+    x11.createClient((err, display) => (err ? reject(err) : resolve(display)));
+  });
+}
+
+const req =
+  (X) =>
+  (fn, ...args) =>
+    new Promise((resolve) => {
+      try {
+        fn.call(X, ...args, (err, value) => resolve(err ? null : value));
+      } catch {
+        resolve(null);
+      }
+    });
+
+function requireExt(X, display, name) {
+  return new Promise((resolve) => {
+    try {
+      X.require(name, (err, ext) => resolve(err ? null : ext));
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
+function getProperty(X, wid, atom, type = 0) {
+  return new Promise((resolve) => {
+    X.GetProperty(0, wid, atom, type, 0, 0x1fffffff, (err, prop) =>
+      resolve(err ? null : prop),
+    );
+  });
+}
+
+const display = await connect().catch((e) => {
+  console.error(
+    `cannot connect to ${process.env.DISPLAY ?? '(unset)'}: ${e.message}`,
+  );
+  process.exit(1);
+});
+const X = display.client;
+const call = req(X);
+const screen = display.screen[0];
+const root = screen.root;
+
+// ---------------------------------------------------------------- 1. env
+section('environment');
+for (const name of [
+  'REACT_X11_SCALE',
+  'GDK_SCALE',
+  'GDK_DPI_SCALE',
+  'QT_SCALE_FACTOR',
+  'QT_SCREEN_SCALE_FACTORS',
+  'QT_AUTO_SCREEN_SCALE_FACTOR',
+]) {
+  out(`  ${name} = ${process.env[name] ?? '(unset)'}`);
+}
+
+// ------------------------------------------------------- 2. core screen
+section('core protocol screen');
+out(`  pixels      ${screen.pixel_width} x ${screen.pixel_height}`);
+out(`  millimetres ${screen.mm_width} x ${screen.mm_height}`);
+const coreDpi = (screen.pixel_width / (screen.mm_width / 25.4)).toFixed(1);
+out(
+  `  -> ${coreDpi} dpi  (servers synthesise mm to land near 96 — never trust this)`,
+);
+
+// -------------------------------------------------------- 3. XSETTINGS
+section('XSETTINGS');
+{
+  const selection = await new Promise((resolve) =>
+    X.InternAtom(false, '_XSETTINGS_S0', (err, atom) =>
+      resolve(err ? null : atom),
+    ),
+  );
+  const owner = selection
+    ? await new Promise((resolve) =>
+        X.GetSelectionOwner(selection, (err, wid) => resolve(err ? null : wid)),
+      )
+    : null;
+  if (!owner) {
+    out('  no settings daemon owns _XSETTINGS_S0');
+  } else {
+    out(`  manager window 0x${owner.toString(16)}`);
+    const propAtom = await new Promise((resolve) =>
+      X.InternAtom(false, '_XSETTINGS_SETTINGS', (err, atom) =>
+        resolve(err ? null : atom),
+      ),
+    );
+    const prop = propAtom ? await getProperty(X, owner, propAtom) : null;
+    const map = prop?.data?.length ? parseXSettings(prop.data) : null;
+    if (!map) {
+      out('  _XSETTINGS_SETTINGS unreadable');
+    } else {
+      for (const key of [
+        'Gdk/WindowScalingFactor',
+        'Gdk/UnscaledDPI',
+        'Xft/DPI',
+        'Gtk/CursorThemeSize',
+      ]) {
+        if (map.has(key)) out(`  ${key} = ${map.get(key)}`);
+        else out(`  ${key}   (absent)`);
+      }
+      const xftDpi = map.get('Xft/DPI');
+      if (typeof xftDpi === 'number' && xftDpi > 0) {
+        // In XSETTINGS the value is 1024ths of a dpi (GNOME, XFCE publish it
+        // that way); a daemon writing plain dpi is legal too, so say both.
+        const scaled = xftDpi > 1024 ? xftDpi / 1024 : xftDpi;
+        out(
+          `  -> Xft/DPI reads as ${scaled} dpi (${(scaled / 96).toFixed(2)}x)`,
+        );
+      }
+    }
+  }
+}
+
+// ------------------------------------------------ 4. RESOURCE_MANAGER
+section('RESOURCE_MANAGER (xrdb)');
+{
+  const prop = await getProperty(X, root, 23 /* RESOURCE_MANAGER */, 31);
+  if (!prop?.data?.length) {
+    out('  property empty (nothing ever ran xrdb)');
+  } else {
+    const resources = parseResourceManager(prop.data.toString('latin1'));
+    const interesting = ['Xft.dpi', 'Xcursor.size', 'Xft.rgba'];
+    for (const key of interesting) {
+      out(`  ${key}: ${resources.get(key) ?? '(absent)'}`);
+    }
+    const dpi = Number(resources.get('Xft.dpi'));
+    if (Number.isFinite(dpi)) {
+      out(`  -> Xft.dpi says ${(dpi / 96).toFixed(2)}x`);
+    }
+  }
+}
+
+// --------------------------------------------------------- 5. RandR
+section('RandR outputs');
+const randr = await requireExt(X, display, 'randr');
+if (!randr) {
+  out('  extension not present');
+} else {
+  const res = await call(randr.GetScreenResourcesCurrent, root);
+  const primary = await call(randr.GetOutputPrimary, root);
+  const edidAtom = await new Promise((resolve) =>
+    X.InternAtom(true, 'EDID', (err, atom) => resolve(err ? null : atom)),
+  );
+  for (const id of res?.outputs ?? []) {
+    const info = await call(randr.GetOutputInfo, id, res.config_timestamp);
+    if (!info || info.connection !== 0) continue; // not connected
+    const crtc = info.crtc
+      ? await call(randr.GetCrtcInfo, info.crtc, res.config_timestamp)
+      : null;
+    out(`  ${info.name}${id === primary ? ' (primary)' : ''}`);
+    out(`    reported physical ${info.mm_width} x ${info.mm_height} mm`);
+    if (crtc)
+      out(`    pixels ${crtc.width} x ${crtc.height} at +${crtc.x}+${crtc.y}`);
+    if (crtc && info.mm_width > 0) {
+      const dpi = crtc.width / (info.mm_width / 25.4);
+      const diag = Math.hypot(info.mm_width, info.mm_height) / 25.4;
+      out(`    -> ${dpi.toFixed(1)} dpi across a ${diag.toFixed(1)}" diagonal`);
+    }
+    out(`    mm plausibility: ${classifyMm(info, crtc)}`);
+    let edid = null;
+    if (edidAtom) {
+      const prop = await new Promise((resolve) =>
+        randr.GetOutputProperty(id, edidAtom, 0, 0, 64, 0, 0, (err, p) =>
+          resolve(err ? null : p),
+        ),
+      );
+      if (prop?.data?.length >= 128) edid = parseEdid(prop.data);
+    }
+    if (!edid) {
+      out('    EDID: none readable');
+    } else {
+      out(
+        `    EDID: vendor ${edid.vendor}, model "${edid.model ?? '(unnamed)'}", ` +
+          `${edid.mmWidth ?? '?'} x ${edid.mmHeight ?? '?'} mm` +
+          (edid.virtual ? '  ** virtual machine display **' : ''),
+      );
+    }
+    const verdict = monitorScaleFromMetadata({
+      name: info.name,
+      width: crtc?.width ?? 0,
+      height: crtc?.height ?? 0,
+      widthMM: info.mm_width,
+      heightMM: info.mm_height,
+      edid,
+    });
+    out(`    -> metadata verdict: ${verdict.scale}x (${verdict.reason})`);
+  }
+}
+
+// ------------------------------------------------------ 6. Xinerama
+section('Xinerama');
+{
+  const xin = await requireExt(X, display, 'xinerama');
+  if (!xin?.QueryScreens) out('  extension not present');
+  else {
+    const screens = await call(xin.QueryScreens);
+    if (!screens?.length) out('  inactive');
+    else
+      for (const s of screens)
+        out(
+          `  head ${s.width} x ${s.height} at +${s.x}+${s.y}  (geometry only — no density data)`,
+        );
+  }
+}
+
+section('verdict');
+out(
+  '  what createRoot({ scale: "auto" }) would resolve on this display is the\n' +
+    '  first rung above that answered: env, then XSETTINGS/Xft.dpi when they\n' +
+    '  say more than the 96dpi default, then credible RandR millimetres, then\n' +
+    '  the resolution class of the panel. Run with REACT_X11_DEBUG_SCALE=1 in\n' +
+    '  a real app to watch the same ladder resolve.',
+);
+
+X.close?.();
+process.exit(0);

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -47,6 +47,7 @@ import { beginFocus } from './events.js';
 import { beginKeyboard } from './keyboard.js';
 import { beginCompositing, endCompositing } from './compositing.js';
 import { beginScreens, endScreens } from './screens.js';
+import { beginScale, scaleOf } from './scale.js';
 import { beginDesktopSettings, endDesktopSettings } from './desktopsettings.js';
 import { endIdle } from './idle.js';
 import { endKeyboardState } from './keyboardstate.js';
@@ -244,10 +245,18 @@ const HostConfig = {
       case 'window':
         // No X11 calls here: the render phase may be discarded. The real
         // window is created top-down in the commit phase (realize).
-        node = new WindowNode(rootContainer, windowAttributes(props), props);
+        node = new WindowNode(
+          rootContainer,
+          windowAttributes(props, scaleOf(rootContainer)),
+          props,
+        );
         break;
       case 'popup':
-        node = new PopupNode(rootContainer, windowAttributes(props), props);
+        node = new PopupNode(
+          rootContainer,
+          windowAttributes(props, scaleOf(rootContainer)),
+          props,
+        );
         break;
       case 'box':
         node = new BoxNode(props, rootContainer);
@@ -731,6 +740,16 @@ export async function createRoot(options = {}) {
   // realized before the answer landed would paint the wrong thing once and
   // correct itself visibly. One round trip, on a path that is already async.
   await beginCompositing(app);
+
+  // Awaited for the strongest version of the same reason: the display scale
+  // multiplies every style length, every font size and every CreateWindow
+  // rectangle, so it must be settled before the first node resolves a style
+  // — there is no "correct it a frame later" for a tree that laid out at
+  // half size. Normally free or one round trip (the environment answers, or
+  // XSETTINGS does — a read this startup path already performs); the RandR
+  // hardware walk behind those is only paid on desktops where nothing
+  // cheaper answered (src/scale.js).
+  await beginScale(app, rest.scale);
 
   // Awaited for the same reason, and it is the same shape of question: a
   // `<window>` with no size given is sized from its content and capped at the

--- a/src/anchor.js
+++ b/src/anchor.js
@@ -69,6 +69,19 @@ export function subRect(node, at) {
   };
 }
 
+/** `at` in logical pixels (it comes off an `anchor` prop) → the same rect in
+ *  the device pixels `node.abs` and everything downstream are in. */
+function deviceAt(at, s) {
+  if (!at || s === 1) return at;
+  return {
+    ...at,
+    ...(typeof at.x === 'number' && { x: at.x * s }),
+    ...(typeof at.y === 'number' && { y: at.y * s }),
+    ...(typeof at.width === 'number' && { width: at.width * s }),
+    ...(typeof at.height === 'number' && { height: at.height * s }),
+  };
+}
+
 /**
  * Has the thing this popup points at scrolled out of view? The check paint
  * culling uses (`Node._offscreen`), asked about the sub-rect rather than
@@ -80,7 +93,7 @@ export function subRect(node, at) {
  * having no area is not the same as being off screen.
  */
 export function anchorOffscreen(node, at) {
-  const rect = subRect(node, at);
+  const rect = subRect(node, deviceAt(at, node?.scale ?? 1));
   if (!rect || typeof node._offscreen !== 'function') return false;
   return node._offscreen({
     x: rect.x,
@@ -104,6 +117,22 @@ export function anchorOffscreen(node, at) {
  * placement then neither flips nor clamps.
  */
 export function anchorArea(node) {
+  const area = deviceAnchorArea(node);
+  const s = node?.scale ?? 1;
+  if (!area || s === 1) return area;
+  // Public callers size popups from this — `maxHeight` styles, widths —
+  // and those are logical like every style, so the answer is too.
+  return {
+    x: area.x / s,
+    y: area.y / s,
+    width: area.width / s,
+    height: area.height / s,
+  };
+}
+
+/** The same area in device pixels, for placement math that runs against
+ *  `abs` rects and window origins — here and in the edit menu's. */
+export function deviceAnchorArea(node) {
   const app = node?.app;
   if (!app) return null;
   const at = screenRect(node);
@@ -158,23 +187,31 @@ export function anchorArea(node) {
  */
 export function anchorRect(node, options = {}) {
   if (!node?.abs) return null;
+  // Options are logical pixels — they come from application code, like
+  // every length — and so is the returned rect, which is headed for a
+  // popup's `x`/`y` props. The math between runs in device pixels, because
+  // `abs`, the window origin and the monitor area are (src/scale.js).
+  const s = node.scale ?? 1;
   const {
     placement = 'bottom',
     align = 'start',
-    alignOffset = 0,
-    offset = 2,
+    alignOffset: logicalAlignOffset = 0,
+    offset: logicalOffset = 2,
     at,
     alignTo,
     direction = node.direction,
   } = options;
+  const alignOffset = logicalAlignOffset * s;
+  const offset = logicalOffset * s;
   const rtl = direction === 'rtl';
 
   // The anchor is the sub-rect where there is one, all the way through:
   // the side that flips, the edge that aligns, and — since a popup with no
   // size of its own is as wide as the thing it hangs off — the default
   // width.
-  const anchor = subRect(node, at);
-  const { width = anchor.width, height = 0 } = options;
+  const anchor = subRect(node, deviceAt(at, s));
+  const width = options.width !== undefined ? options.width * s : anchor.width;
+  const height = options.height !== undefined ? options.height * s : 0;
 
   const origin = windowOrigin(node);
   const ax = origin.x + anchor.x;
@@ -188,7 +225,7 @@ export function anchorRect(node, options = {}) {
   const cx = origin.x + cross.x;
   const cy = origin.y + cross.y;
 
-  const area = anchorArea(node);
+  const area = deviceAnchorArea(node);
   const left = area?.x ?? 0;
   const top = area?.y ?? 0;
   const right = area ? area.x + area.width : null;
@@ -270,7 +307,15 @@ export function anchorRect(node, options = {}) {
   if (right != null) x = Math.max(left, Math.min(x, right - width));
   if (bottom != null && height) y = Math.max(top, Math.min(y, bottom - height));
 
-  return { x: Math.round(x), y: Math.round(y), width, height, placement: side };
+  // Back to logical on the way out. Rounded in *device* pixels first, so
+  // the placement still lands on the device grid it was computed on.
+  return {
+    x: Math.round(x) / s,
+    y: Math.round(y) / s,
+    width: width / s,
+    height: height / s,
+    placement: side,
+  };
 }
 
 /**
@@ -279,8 +324,13 @@ export function anchorRect(node, options = {}) {
  * the window rather than to a widget, which is the one placement
  * `anchorRect` cannot express.
  */
-export function centerRect(node, { width, height }) {
+export function centerRect(node, { width: logicalW, height: logicalH }) {
   if (!node) return null;
+  // Logical in, logical out, device in between — anchorRect's contract,
+  // for the same caller: the result becomes a popup's `x`/`y` props.
+  const s = node.scale ?? 1;
+  const width = logicalW * s;
+  const height = logicalH * s;
   const win = node.root?.window;
   const ww = win?.width ?? width;
   const wh = win?.height ?? height;
@@ -296,10 +346,15 @@ export function centerRect(node, { width, height }) {
   let x = origin.x + (ww - width) / 2;
   let y = origin.y + (wh - height) / 2;
 
-  const area = anchorArea(node);
+  const area = deviceAnchorArea(node);
   if (area) {
     x = Math.max(area.x, Math.min(x, area.x + area.width - width));
     y = Math.max(area.y, Math.min(y, area.y + area.height - height));
   }
-  return { x: Math.round(x), y: Math.round(y), width, height };
+  return {
+    x: Math.round(x) / s,
+    y: Math.round(y) / s,
+    width: logicalW,
+    height: logicalH,
+  };
 }

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -807,9 +807,10 @@ export function ContextMenu({
     const height = menuListHeight(items, fontSize);
     const area = anchorArea(node);
     // anchored at the pointer rather than at a widget: clamp by hand, since
-    // there is no anchor rect to flip around
-    const x = ev.nativeEvent?.rootx ?? ev.x;
-    const y = ev.nativeEvent?.rooty ?? ev.y;
+    // there is no anchor rect to flip around. Root coordinates are device;
+    // the rect feeds popup props, which are logical like the area.
+    const x = (ev.nativeEvent?.rootx ?? ev.x * node.scale) / node.scale;
+    const y = (ev.nativeEvent?.rooty ?? ev.y * node.scale) / node.scale;
     setRect({
       x: area ? Math.max(area.x, Math.min(x, area.x + area.width - width)) : x,
       y: area

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -94,7 +94,10 @@ function menuWidth(node, options, value, scrolls, fontSize) {
     ITEM_PAD_LEFT +
     ITEM_PAD_RIGHT +
     (scrolls ? SCROLLBAR_WIDTH : 0);
-  const width = Math.max(node.abs.width, Math.ceil(widest) + chrome);
+  // logical throughout: the trigger's rect divided out of device pixels,
+  // the measured labels already logical (measureLabel), the area logical
+  const trigger = node.abs.width / node.scale;
+  const width = Math.max(trigger, Math.ceil(widest) + chrome);
   const area = anchorArea(node);
   return area ? Math.min(width, area.width) : width;
 }

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -76,14 +76,18 @@ export function Slider({
    */
   const valueAt = (ev) => {
     const node = trackRef.current;
-    if (!node?.abs?.width) return value;
+    // getClientRects rather than raw `abs`: the event, the thumb constant
+    // and this rect must share a unit, and the public rect is logical like
+    // they are — `abs` is device (src/scale.js)
+    const rect = node?.getClientRects?.()[0];
+    if (!rect?.width) return value;
     // the thumb is centred on the value, so the usable travel is the track
     // minus one thumb width — otherwise min/max are unreachable at the ends
-    const travel = Math.max(1, node.abs.width - SLIDER_THUMB);
+    const travel = Math.max(1, rect.width - SLIDER_THUMB);
     const x =
       node.direction === 'rtl'
-        ? node.abs.x + node.abs.width - ev.x - SLIDER_THUMB / 2
-        : ev.x - node.abs.x - SLIDER_THUMB / 2;
+        ? rect.x + rect.width - ev.x - SLIDER_THUMB / 2
+        : ev.x - rect.x - SLIDER_THUMB / 2;
     return quantize(min + (Math.min(travel, Math.max(0, x)) / travel) * span);
   };
 

--- a/src/components/SplitPane.js
+++ b/src/components/SplitPane.js
@@ -83,7 +83,9 @@ export function SplitPane({
 
   /** Clamp against the container as laid out right now. */
   const commit = (next) => {
-    const box = rootRef.current?.abs;
+    // logical throughout: `next` becomes a style width/height, and the
+    // container rect has to be in the same unit (`abs` is device)
+    const box = rootRef.current?.getClientRects?.()[0];
     const total = (vertical ? box?.height : box?.width) ?? 0;
     const room = Math.max(min, total - DIVIDER - minSecond);
     const clamped = Math.min(Math.max(min, next), total > 0 ? room : next);
@@ -108,7 +110,8 @@ export function SplitPane({
   const dividerProps = {
     focusable: true,
     onMouseDown: (ev) => {
-      const box = rootRef.current?.abs;
+      const box = rootRef.current?.getClientRects?.()[0];
+      if (!box) return;
       // where in the divider it was taken, so it does not jump on press
       grab.current = alongSplit(ev, box) - sizeRef.current;
       ev.capturePointer();
@@ -117,7 +120,7 @@ export function SplitPane({
     },
     onMouseMove: (ev) => {
       if (!draggingRef.current) return;
-      const box = rootRef.current?.abs;
+      const box = rootRef.current?.getClientRects?.()[0];
       if (!box) return;
       commit(alongSplit(ev, box) - grab.current);
     },

--- a/src/components/Table.js
+++ b/src/components/Table.js
@@ -218,9 +218,13 @@ export function Table({
     const top = index * rowHeight;
     const node = body.current;
     if (!node) return;
-    if (top < node.scrollY) node.scrollTo({ y: top });
-    else if (top + rowHeight > node.scrollY + node.abs.height) {
-      node.scrollTo({ y: top + rowHeight - node.abs.height });
+    // `top` is logical (rows are style heights); the node's offset and
+    // viewport are device fields, divided here so all three share a unit
+    const scrollY = node.scrollY / node.scale;
+    const viewH = node.abs.height / node.scale;
+    if (top < scrollY) node.scrollTo({ y: top });
+    else if (top + rowHeight > scrollY + viewH) {
+      node.scrollTo({ y: top + rowHeight - viewH });
     }
   };
 

--- a/src/components/anchor.js
+++ b/src/components/anchor.js
@@ -158,6 +158,13 @@ export function measureLabel(node, text, style) {
   if (!fonts?.layout) {
     return { width: String(text).length * size * 0.55, height: size * 1.4 };
   }
+  // Measured at the size the glyphs are actually rasterized — the logical
+  // size times the display scale — then divided back, so the logical answer
+  // carries the true metrics. Measuring at the logical size and trusting
+  // linearity is off by the accumulated per-glyph rounding, which is
+  // exactly the kind of error that turns into an ellipsis on the longest
+  // label in the menu (src/scale.js).
+  const s = node?.scale ?? 1;
   const layout = fonts.layout(String(text), {
     // The face **this node inherits**, not the literal `sans-serif`: the
     // labels these popups are sized around name no family of their own, so
@@ -165,13 +172,13 @@ export function measureLabel(node, text, style) {
     // face is measuring the wrong label — a menu sized in sans-serif for a
     // row that paints in a wider mono is a menu whose own options wrap.
     family: style?.family ?? node?.inheritedTextStyle?.family ?? 'sans-serif',
-    size,
+    size: size * s,
     weight: style?.weight ?? 'normal',
     // dropping this would measure a different face from the one drawn, and
     // the popup sized here would be the wrong width for its own label
     variations: style?.variations,
   });
-  return { width: layout.width, height: layout.height };
+  return { width: layout.width / s, height: layout.height / s };
 }
 
 export const DEFAULT_LABEL_SIZE = 13;

--- a/src/decorations.js
+++ b/src/decorations.js
@@ -434,9 +434,53 @@ function memoize(cache, key, parse) {
   return parsed;
 }
 
-/** `parseLinearGradient`, memoized and non-throwing: the paint path's door. */
-export const gradientSpec = (value) =>
-  memoize(gradients, value, parseLinearGradient);
+/**
+ * The display scale's route into these two values, which is unlike every
+ * other style length's: `boxShadow` and `backgroundImage` are *strings*,
+ * so the multiply at the style funnel (styles.js, scaleResolvedStyle)
+ * cannot reach the numbers inside them — and the parses are memoized on
+ * the raw string, so the scaled result has to be memoized beside it
+ * rather than patched after. The scale rides into the memo key.
+ */
+function scaleShadows(specs, scale) {
+  if (!specs || scale === 1) return specs;
+  return specs.map((s) => ({
+    ...s,
+    dx: s.dx * scale,
+    dy: s.dy * scale,
+    blur: s.blur * scale,
+    spread: s.spread * scale,
+  }));
+}
 
-/** `parseBoxShadow`, memoized and non-throwing. */
-export const shadowSpecs = (value) => memoize(shadows, value, parseBoxShadow);
+function scaleGradient(spec, scale) {
+  if (!spec || scale === 1) return spec;
+  let stops = spec.stops;
+  if (stops?.some((stop) => stop.position?.unit === 'px')) {
+    stops = stops.map((stop) =>
+      stop.position?.unit === 'px'
+        ? {
+            ...stop,
+            position: { ...stop.position, value: stop.position.value * scale },
+          }
+        : stop,
+    );
+    return { ...spec, stops };
+  }
+  return spec;
+}
+
+/** `parseLinearGradient`, memoized and non-throwing: the paint path's door.
+ *  `scale` converts any `px` stop positions to device pixels — percentages
+ *  and angles mean the same thing at any density. */
+export const gradientSpec = (value, scale = 1) =>
+  memoize(gradients, scale === 1 ? value : `${scale}\u0000${value}`, () =>
+    scaleGradient(parseLinearGradient(value), scale),
+  );
+
+/** `parseBoxShadow`, memoized and non-throwing. `scale` converts the
+ *  offsets, the blur and the spread to device pixels. */
+export const shadowSpecs = (value, scale = 1) =>
+  memoize(shadows, scale === 1 ? value : `${scale}\u0000${value}`, () =>
+    scaleShadows(parseBoxShadow(value), scale),
+  );

--- a/src/dnd.js
+++ b/src/dnd.js
@@ -218,19 +218,18 @@ function scrollerIn(path) {
  * axis takes the nearer of its two edges, so a viewport shorter than two
  * bands still scrolls one way rather than fighting itself.
  */
-function edgeVelocity(rect, x, y) {
+function edgeVelocity(rect, x, y, scale = 1) {
   const inside =
     x >= rect.x &&
     x <= rect.x + rect.width &&
     y >= rect.y &&
     y <= rect.y + rect.height;
   if (!inside) return null;
+  const edge = AUTOSCROLL_EDGE * scale;
   const ramp = (distance) =>
-    distance >= AUTOSCROLL_EDGE
+    distance >= edge
       ? 0
-      : Math.ceil(
-          (1 - Math.max(0, distance) / AUTOSCROLL_EDGE) * AUTOSCROLL_STEP,
-        );
+      : Math.ceil((1 - Math.max(0, distance) / edge) * AUTOSCROLL_STEP * scale);
   const top = y - rect.y;
   const bottom = rect.y + rect.height - y;
   const left = x - rect.x;
@@ -700,8 +699,10 @@ export class DropSession {
       actions: this._askOffer?.actions ?? [],
       actionDescriptions: this._askOffer?.descriptions ?? [],
       source: this._source,
-      screenX: native.rootx,
-      screenY: native.rooty,
+      // root-window coordinates, divided to logical like every coordinate
+      // a handler reads (src/scale.js)
+      screenX: native.rootx / windowNode.events.scale,
+      screenY: native.rooty / windowNode.events.scale,
       accept: (action) => {
         if (!answer) return;
         answer.accept = true;
@@ -815,7 +816,9 @@ export class DropSession {
    */
   _updateAutoScroll(path, x, y) {
     const node = scrollerIn(path);
-    const velocity = node?.abs ? edgeVelocity(node.abs, x, y) : null;
+    const velocity = node?.abs
+      ? edgeVelocity(node.abs, x, y, node.scale)
+      : null;
     if (!velocity) return this._stopAutoScroll();
     this._autoScroll = { node, ...velocity };
     // already stepping: the line above is the whole update
@@ -854,7 +857,8 @@ export class DropSession {
     // is free to unmount whatever this was scrolling.
     try {
       const before = `${node.scrollX},${node.scrollY}`;
-      node.scrollBy({ x: dx, y: dy });
+      if (node._scrollByDevice) node._scrollByDevice(dx, dy);
+      else node.scrollBy({ x: dx / node.scale, y: dy / node.scale });
       // at the limit: no movement, so nothing under the pointer changed and
       // there is nothing to re-route. The timer stays armed — the content
       // can still grow, and the pointer is still in the band.
@@ -1218,7 +1222,9 @@ export class DragSession {
     if (this.phase === 'armed') {
       const moved =
         Math.abs(native.x - this.press.x) + Math.abs(native.y - this.press.y);
-      if (moved < desktopSettings(this.app).dragThreshold) return false;
+      // the desktop's threshold is logical pixels; the motion is device
+      if (moved < desktopSettings(this.app).dragThreshold * this.node.scale)
+        return false;
       if (!this._start(native)) return false;
     }
     if (this.phase !== 'dragging') return false;
@@ -1243,8 +1249,8 @@ export class DragSession {
       types: this.types,
       action: this.currentAction,
       source: 'internal',
-      screenX: native.rootx ?? native.x,
-      screenY: native.rooty ?? native.y,
+      screenX: (native.rootx ?? native.x) / this.node.events.scale,
+      screenY: (native.rooty ?? native.y) / this.node.events.scale,
     });
     if (ev.defaultPrevented) {
       this._reset();
@@ -1338,8 +1344,8 @@ export class DragSession {
           action: this.currentAction,
           source: this.localSession ? 'internal' : 'external',
           accepted: this.accepted,
-          screenX: rootX,
-          screenY: rootY,
+          screenX: rootX / this.node.events.scale,
+          screenY: rootY / this.node.events.scale,
         }),
       );
     }
@@ -1388,8 +1394,8 @@ export class DragSession {
         action,
         dropped,
         source: 'internal',
-        screenX: native.rootx ?? native.x ?? 0,
-        screenY: native.rooty ?? native.y ?? 0,
+        screenX: (native.rootx ?? native.x ?? 0) / this.node.events.scale,
+        screenY: (native.rooty ?? native.y ?? 0) / this.node.events.scale,
       });
     }
     this._reset();

--- a/src/events.js
+++ b/src/events.js
@@ -67,11 +67,18 @@ function eventType(name) {
  */
 class SyntheticEvent {
   constructor(manager, type, native, target, extra) {
+    // Native coordinates are device pixels off the wire; handlers are
+    // application code, which thinks in the logical pixels it wrote its
+    // styles in — so the divide happens here, at the one door events leave
+    // by, and `localX` below subtracts an `abs` divided the same way
+    // (src/scale.js). Everything *internal* — hit testing, drag
+    // thresholds, the scroll accumulator — keeps reading `native`.
+    const s = manager.scale;
     this._manager = manager;
     this._targetNode = target;
     this.type = type;
-    this.x = native?.x ?? 0;
-    this.y = native?.y ?? 0;
+    this.x = (native?.x ?? 0) / s;
+    this.y = (native?.y ?? 0) / s;
     this.target = manager._public(target);
     this.currentTarget = null;
     this.nativeEvent = native;
@@ -92,8 +99,8 @@ class SyntheticEvent {
     this.propagationStopped = false;
     if (extra) Object.assign(this, extra);
     if (target.abs) {
-      this.localX = this.x - target.abs.x;
-      this.localY = this.y - target.abs.y;
+      this.localX = this.x - target.abs.x / s;
+      this.localY = this.y - target.abs.y / s;
     }
   }
 
@@ -232,6 +239,8 @@ export function synthesizeClick(node, rect, source = null) {
 export class EventManager {
   constructor(windowNode) {
     this.node = windowNode;
+    // resolved before any window realizes, constant after (src/scale.js)
+    this.scale = windowNode?.scale ?? 1;
     this.hoverPath = [];
     this.downNode = null;
     // where a press landed, and how much of that chain still draws `:active`
@@ -421,10 +430,12 @@ export class EventManager {
     const { doubleClickMs, doubleClickDistance } = desktopSettings(
       this.node?.app,
     );
+    // the desktop's slop is logical pixels; the coordinates are device
+    const slop = doubleClickDistance * this.scale;
     const detail =
       now - last.time < doubleClickMs &&
-      Math.abs(native.x - last.x) <= doubleClickDistance &&
-      Math.abs(native.y - last.y) <= doubleClickDistance
+      Math.abs(native.x - last.x) <= slop &&
+      Math.abs(native.y - last.y) <= slop
         ? last.detail + 1
         : 1;
     this._lastClick = { time: now, x: native.x, y: native.y, detail };
@@ -666,8 +677,11 @@ export class EventManager {
       // renderer has into a full repaint, which is the opposite of the
       // trade. The fraction is not dropped, it is carried to the next event,
       // so a slow scroll still moves — it moves a pixel at a time.
-      const owedX = this._wheelOwed.x + ev.deltaX;
-      const owedY = this._wheelOwed.y + ev.deltaY;
+      // `ev.deltaX/Y` are logical (what handlers read); the scroll they
+      // become moves device pixels, and truncating *after* the multiply is
+      // what keeps the blit on whole device pixels at fractional scales.
+      const owedX = this._wheelOwed.x + ev.deltaX * this.scale;
+      const owedY = this._wheelOwed.y + ev.deltaY * this.scale;
       const dx = Math.trunc(owedX);
       const dy = Math.trunc(owedY);
       this._wheelOwed = { x: owedX - dx, y: owedY - dy };
@@ -685,7 +699,10 @@ export class EventManager {
       // have to be named here to be reachable (issue #253).
       for (let n = target; n; n = n.parent) {
         if (n.canScroll?.(dx, dy)) {
-          n.scrollBy({ x: dx, y: dy });
+          // built-in scrollers take the device delta whole; a registered
+          // element's own scrollBy speaks the public (logical) unit
+          if (n._scrollByDevice) n._scrollByDevice(dx, dy);
+          else n.scrollBy({ x: dx / this.scale, y: dy / this.scale });
           break;
         }
         if (n === this.node) break;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -229,6 +229,25 @@ export interface RootOptions {
         maxInFlight?: number;
         linearFallback?: boolean;
       };
+  /**
+   * Device pixels per logical pixel — the display scale (docs/scale.md).
+   *
+   * `'auto'` (the default) resolves it from the connection: environment
+   * overrides (`REACT_X11_SCALE`, `GDK_SCALE`, `QT_SCALE_FACTOR`), then the
+   * desktop's own configuration (XSETTINGS `Gdk/WindowScalingFactor` and
+   * `Xft/DPI`, `Xft.dpi` from `RESOURCE_MANAGER`), then the panel's RandR
+   * millimetres under mutter's viewing-distance model — with EDIDs that lie
+   * (every virtual machine's does) audited out — and finally the resolution
+   * class of the pixel grid itself. A number pins it; `REACT_X11_SCALE` in
+   * the environment outranks even that, as the user's accessibility escape
+   * hatch.
+   *
+   * Every length the app writes stays logical — styles, `fontSize`, window
+   * geometry, event coordinates, `getClientRects`, `useScreens` — and the
+   * renderer multiplies exactly once on the way to the server. Resolved
+   * before the first window realizes and static for the life of the root.
+   */
+  scale?: 'auto' | number;
   /** X protocol errors no request callback claimed. Default warns. */
   onXError?: (err: Error) => void;
   onUncaughtError?: (error: unknown, errorInfo: ErrorInfo) => void;

--- a/src/index.js
+++ b/src/index.js
@@ -38,6 +38,7 @@ export { useFileDialog } from './filedialoghooks.js';
 export { systemAppearance } from './appearance.js';
 export { useSystemAppearance } from './appearancehooks.js';
 export { useScreens } from './screenshooks.js';
+export { useScale } from './scalehooks.js';
 export { useWindowState } from './windowstate.js';
 export { keepAwake } from './idle.js';
 export { useIdle, useKeepAwake } from './idlehooks.js';

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -21,6 +21,7 @@ import {
   validateStyle,
   resolveStyleStates,
   resolveComputedStyle,
+  scaleResolvedStyle,
   hasStateStyles,
   isStyleProp,
   isEventProp,
@@ -61,6 +62,7 @@ import {
   validateImageProps,
 } from './imagesource.js';
 import { Yoga } from './yoga.js';
+import { scaleOf } from './scale.js';
 // Namespace import for `Surface`, the same shape and the same reason as
 // `paintcache.js`: a named import of something an older ntk does not export
 // is a *load-time* SyntaxError, which would take the renderer down rather
@@ -101,7 +103,7 @@ import {
   windowStateSnapshot,
 } from './windowstate.js';
 import {
-  anchorArea,
+  deviceAnchorArea,
   anchorOffscreen,
   anchorRect,
   windowOrigin,
@@ -360,18 +362,19 @@ function intersectRects(a, b) {
 /** The full track strip a scrollbar occupies (thumb travel included), with
  * a pixel of slop for the thumb's antialiased corners. */
 function scrollbarTrackRect(bar) {
+  const width = SCROLLBAR_WIDTH * (bar.scale ?? 1);
   const rect =
     bar.axis === 'x'
       ? {
           x: bar.trackStart,
           y: bar.crossStart,
           width: bar.trackLength,
-          height: SCROLLBAR_WIDTH,
+          height: width,
         }
       : {
           x: bar.crossStart,
           y: bar.trackStart,
-          width: SCROLLBAR_WIDTH,
+          width,
           height: bar.trackLength,
         };
   return insetRect(rect, -1);
@@ -625,12 +628,13 @@ function roundedPath(ctx, rect, radius) {
   }
 }
 
-/** A style's shadow reach, for the two callers that have a style rather than
- *  a node (`_retarget`'s before/after pair). */
-function shadowExtentOf(style) {
+/** A style's shadow reach, for the callers that have a style rather than
+ *  a node (`_retarget`'s before/after pair). `scale` because the value is a
+ *  string the style funnel could not convert (see decorations.js). */
+function shadowExtentOf(style, scale = 1) {
   const value = style?.boxShadow;
   if (!value || value === 'none') return 0;
-  return shadowExtent(shadowSpecs(value));
+  return shadowExtent(shadowSpecs(value, scale));
 }
 
 const DEV = process.env.NODE_ENV !== 'production';
@@ -1210,9 +1214,46 @@ function writeContentFloors(node, axis, mins, floored) {
  * `transparent` names a visual that has to be looked up on the connection
  * (WindowNode._argbAttributes) rather than a value ntk takes.
  */
-export function windowAttributes(props) {
+// The WM hints that are distances. The aspect pair are ratios — the same in
+// any unit — and `gravity` is an enum; scaling either would be wrong.
+const LENGTH_HINT_PROPS = new Set([
+  'minWidth',
+  'minHeight',
+  'maxWidth',
+  'maxHeight',
+  'widthInc',
+  'heightInc',
+  'baseWidth',
+  'baseHeight',
+]);
+
+/**
+ * A window's geometry props, converted to the device pixels every consumer
+ * — `_measure`'s yoga math, `setState`, the WM hints — works in. Numbers
+ * multiply; `'auto'` and the content bounds pass through; the identity
+ * fast path keeps the 1x world allocation-free.
+ */
+function scaleWindowGeometry(props, scale) {
+  if (scale === 1) return props;
+  const out = { ...props };
+  for (const key of ['width', 'height', 'x', 'y']) {
+    if (typeof out[key] === 'number') out[key] = Math.round(out[key] * scale);
+  }
+  for (const key of LENGTH_HINT_PROPS) {
+    if (typeof out[key] === 'number') out[key] = Math.round(out[key] * scale);
+  }
+  return out;
+}
+
+export function windowAttributes(props, scale = 1) {
   const attributes = {};
   const hints = {};
+  // Geometry props are logical pixels like everything an app writes, and
+  // this is their one door into device pixels: X windows are device-pixel
+  // rectangles, so the multiply happens where CreateWindow's numbers are
+  // assembled, and `abs`/`_requestedSize`/ConfigureNotify all stay in one
+  // unit downstream (src/scale.js). Rounded because the wire is integers.
+  const device = (v) => (typeof v === 'number' ? Math.round(v * scale) : v);
   for (const key of Object.keys(props)) {
     if (key === 'children' || key === 'style' || isEventProp(key)) continue;
     if (key === 'transientFor' || key === 'transparent') continue;
@@ -1223,10 +1264,17 @@ export function windowAttributes(props) {
     if (WINDOW_HINT_PROPS.includes(key)) {
       // An `'auto'` bound is not a number ntk can be given; `realize()`
       // measures it and merges the answer in before CreateWindow.
-      if (!isContentBound(props[key])) hints[key] = props[key];
+      if (!isContentBound(props[key])) {
+        hints[key] = LENGTH_HINT_PROPS.has(key)
+          ? device(props[key])
+          : props[key];
+      }
       continue;
     }
-    attributes[key] = props[key];
+    attributes[key] =
+      key === 'width' || key === 'height' || key === 'x' || key === 'y'
+        ? device(props[key])
+        : props[key];
   }
   if (Object.keys(hints).length > 0) attributes.sizeHints = hints;
   if (props.style !== undefined) {
@@ -1372,6 +1420,19 @@ export class Node {
     return DEVTOOLS_FAKE_DOCUMENT;
   }
 
+  /**
+   * Device pixels per logical pixel for this node's connection — resolved
+   * once by `createRoot` (src/scale.js) and constant for the node's life,
+   * which is what makes the instance cache below sound. `this.style` and
+   * `this.abs` are already device pixels; this is for the values that never
+   * pass through a style — a paint constant like the caret's width, or an
+   * event coordinate on its way back to logical. A registered element that
+   * draws with its own constants multiplies them by this.
+   */
+  get scale() {
+    return (this._scaleCache ??= scaleOf(this.app));
+  }
+
   constructor(kind, props, app, { yoga = true } = {}) {
     this.kind = kind;
     this.props = props;
@@ -1495,11 +1556,18 @@ export class Node {
       });
     }
     this._stateful = hasStateStyles(this._baseStyle);
+    // The scale multiplies *after* every merge — state blocks, queries,
+    // the flex shorthand — so each of those keeps thinking in the logical
+    // pixels the app wrote, and device pixels exist only downstream of
+    // this line (src/scale.js).
     return this._retarget(
-      resolveComputedStyle(
-        this._stateful
-          ? resolveStyleStates(this._baseStyle, this.states)
-          : this._baseStyle,
+      scaleResolvedStyle(
+        resolveComputedStyle(
+          this._stateful
+            ? resolveStyleStates(this._baseStyle, this.states)
+            : this._baseStyle,
+        ),
+        this.scale,
       ),
     );
   }
@@ -1589,7 +1657,9 @@ export class Node {
     // `:hover` shadow would repaint its own box and leave the shadow printed
     // around it. This is the only place both extents exist at once.
     if (displayed.boxShadow !== this.style.boxShadow) {
-      const shrank = shadowExtentOf(displayed) - shadowExtentOf(this.style);
+      const shrank =
+        shadowExtentOf(displayed, this.scale) -
+        shadowExtentOf(this.style, this.scale);
       if (shrank > 0) {
         this.root?.invalidate(
           false,
@@ -1617,7 +1687,14 @@ export class Node {
    * `_updateLoops`.
    */
   _syncLoops(target) {
-    const specs = target.animation == null ? null : animationsOf(target);
+    // `target` is device pixels by now, so the declared ends of a loop have
+    // to arrive in the same unit — the scale rides in rather than being
+    // applied after, because a `from` defaulted off the style is already
+    // device and must not double (see animationsOf).
+    const specs =
+      target.animation == null
+        ? null
+        : animationsOf(target, 'a style', this.scale);
     if (!specs && !this._loops) return false;
     this._loops = specs;
     if (!specs) this.root?._forgetLoopNode(this);
@@ -1772,8 +1849,9 @@ export class Node {
     if (this.states[name] === on) return;
     this.states[name] = on;
     if (!this._stateful || this.destroyed) return;
-    const next = resolveComputedStyle(
-      resolveStyleStates(this._baseStyle, this.states),
+    const next = scaleResolvedStyle(
+      resolveComputedStyle(resolveStyleStates(this._baseStyle, this.states)),
+      this.scale,
     );
     if (shallowEqual(next, this._targetStyle)) return;
     this._retarget(next);
@@ -1954,7 +2032,13 @@ export class Node {
     // resolved one — `<box theme={{ text: 'red' }}>` merges and derives
     // nothing (styling.md) — so neither of these is guaranteed to be there.
     const family = theme.fontFamily ?? DEFAULT_TEXT_STYLE.family;
-    const size = theme.fontSize ?? DEFAULT_TEXT_STYLE.size;
+    // The theme thinks in logical pixels like every style does, and this is
+    // the one door its font size enters the cascade by: a node's own
+    // `fontSize` was scaled at the style funnel, and every descendant
+    // inherits an already-resolved (device) size — so multiplying here,
+    // exactly once at the root of the cascade, is what keeps text and
+    // layout in the same unit without ever double-scaling (src/scale.js).
+    const size = (theme.fontSize ?? DEFAULT_TEXT_STYLE.size) * this.scale;
     const base = this._textBase;
     if (base?.color !== color || base.family !== family || base.size !== size) {
       this._textBase = { ...DEFAULT_TEXT_STYLE, color, family, size };
@@ -2702,16 +2786,19 @@ export class Node {
   getClientRects() {
     const r = this.abs;
     if (!(r.width > 0 || r.height > 0)) return [];
+    // `abs` is device pixels; this is public API, which is logical — the
+    // same conversion events make on the way out (src/scale.js)
+    const s = this.scale;
     return [
       {
-        x: r.x,
-        y: r.y,
-        left: r.x,
-        top: r.y,
-        width: r.width,
-        height: r.height,
-        right: r.x + r.width,
-        bottom: r.y + r.height,
+        x: r.x / s,
+        y: r.y / s,
+        left: r.x / s,
+        top: r.y / s,
+        width: r.width / s,
+        height: r.height / s,
+        right: (r.x + r.width) / s,
+        bottom: (r.y + r.height) / s,
       },
     ];
   }
@@ -2730,14 +2817,15 @@ export class Node {
       callback();
       return;
     }
+    const s = this.scale;
     const parent = this.parent?.abs;
     callback(
-      parent ? r.x - parent.x : r.x,
-      parent ? r.y - parent.y : r.y,
-      r.width,
-      r.height,
-      r.x,
-      r.y,
+      (parent ? r.x - parent.x : r.x) / s,
+      (parent ? r.y - parent.y : r.y) / s,
+      r.width / s,
+      r.height / s,
+      r.x / s,
+      r.y / s,
     );
   }
 
@@ -3169,7 +3257,7 @@ export class Node {
    * spread and the blur's tail, symmetrically (see `shadowExtent`).
    */
   _shadowExtent() {
-    return shadowExtentOf(this.style);
+    return shadowExtentOf(this.style, this.scale);
   }
 
   /** Would a keyboard focus land here? The one rule lives in a11y.js —
@@ -3550,7 +3638,7 @@ export class Node {
     const value = this.style.backgroundImage;
     if (!value || value === 'none') return null;
     if (typeof ctx.createLinearGradient !== 'function') return null;
-    const spec = gradientSpec(value);
+    const spec = gradientSpec(value, this.scale);
     if (!spec) return null;
     const { x, y, width, height } = rect;
     const key = `${value}|${x},${y},${width},${height}`;
@@ -3584,7 +3672,7 @@ export class Node {
   _paintShadow(ctx) {
     const value = this.style.boxShadow;
     if (!value || value === 'none') return;
-    const shadows = shadowSpecs(value);
+    const shadows = shadowSpecs(value, this.scale);
     if (!shadows?.length) return;
     const radius = this.style.borderRadius ?? 0;
     for (let i = shadows.length - 1; i >= 0; i--) {
@@ -4499,11 +4587,21 @@ export class ImageNode extends Node {
   }
 
   /** The source's size, kept to its aspect ratio. Read per measure rather
-   * than once, because a decode can arrive late. */
+   * than once, because a decode can arrive late.
+   *
+   * Source pixels are *logical* pixels, the browser's rule: a 100px-wide
+   * PNG occupies 100 logical px at any display scale (upscaled onto the
+   * device grid at 2x, the way an `<img>` without `srcset` is), rather
+   * than shrinking to half its neighbours' size. The constraints are
+   * already device, so only the natural size converts (src/scale.js). */
   measureContent(constraints) {
     this._ensureSource();
+    const s = this.scale;
     return intrinsicSize(
-      { width: this.image?.width ?? 0, height: this.image?.height ?? 0 },
+      {
+        width: (this.image?.width ?? 0) * s,
+        height: (this.image?.height ?? 0) * s,
+      },
       constraints,
     );
   }
@@ -4737,12 +4835,18 @@ function scrollbarGeometry({
   inset = 0,
   shorten = 0,
   direction = 'ltr',
+  scale = 1,
 }) {
   const length = viewport - shorten;
   if (length <= 0 || !(content > viewport)) return null;
+  // The strip's own dimensions are logical constants; everything the caller
+  // passed — rects, content extents, offsets — is already device. The bar
+  // carries `scale` so the track, the hit slop and the thumb's corner
+  // radius downstream draw from the same number.
+  const barWidth = SCROLLBAR_WIDTH * scale;
   const rtl = direction === 'rtl';
   const thumbLength = Math.max(
-    SCROLLBAR_MIN_THUMB,
+    SCROLLBAR_MIN_THUMB * scale,
     (length * length) / content,
   );
   const range = content - viewport;
@@ -4755,9 +4859,10 @@ function scrollbarGeometry({
   const crossStart =
     rtl && axis === 'y'
       ? crossStart0 + inset
-      : crossStart0 + crossSize - SCROLLBAR_WIDTH - inset;
+      : crossStart0 + crossSize - barWidth - inset;
   return {
     axis,
+    scale,
     trackStart: start,
     trackLength: length,
     thumbStart,
@@ -4772,8 +4877,8 @@ function scrollbarGeometry({
     // the thumb as a rect, for painting
     x: axis === 'x' ? thumbStart : crossStart,
     y: axis === 'x' ? crossStart : thumbStart,
-    width: axis === 'x' ? thumbLength : SCROLLBAR_WIDTH,
-    height: axis === 'x' ? SCROLLBAR_WIDTH : thumbLength,
+    width: axis === 'x' ? thumbLength : barWidth,
+    height: axis === 'x' ? barWidth : thumbLength,
   };
 }
 
@@ -4785,9 +4890,10 @@ const across = (bar, x, y) => (bar.axis === 'x' ? y : x);
 function scrollbarHit(bar, x, y) {
   if (!bar) return null;
   const c = across(bar, x, y);
+  const s = bar.scale ?? 1;
   if (
-    c < bar.crossStart - SCROLLBAR_SLOP ||
-    c > bar.crossStart + SCROLLBAR_WIDTH + SCROLLBAR_SLOP
+    c < bar.crossStart - SCROLLBAR_SLOP * s ||
+    c > bar.crossStart + (SCROLLBAR_WIDTH + SCROLLBAR_SLOP) * s
   ) {
     return null;
   }
@@ -4802,7 +4908,7 @@ function paintScrollbarThumb(ctx, bar, color) {
   ctx.fillStyle = color || 'rgba(0, 0, 0, 0.25)';
   ctx.beginPath();
   if (typeof ctx.roundRect === 'function') {
-    ctx.roundRect(bar.x, bar.y, bar.width, bar.height, 3);
+    ctx.roundRect(bar.x, bar.y, bar.width, bar.height, 3 * (bar.scale ?? 1));
   } else {
     ctx.rect(bar.x, bar.y, bar.width, bar.height);
   }
@@ -4968,11 +5074,14 @@ export const Scrollable = (Base) =>
      * it also arrives for a list nobody has scrolled yet.
      */
     _reportViewport() {
+      // logical, like onScroll's payload: finder.jsx divides this height by
+      // a row height it wrote in a style
+      const s = this.scale;
       const next = {
-        width: this.abs.width,
-        height: this.abs.height,
-        contentWidth: this.contentWidth,
-        contentHeight: this.contentHeight,
+        width: this.abs.width / s,
+        height: this.abs.height / s,
+        contentWidth: this.contentWidth / s,
+        contentHeight: this.contentHeight / s,
       };
       const last = this._lastViewport;
       if (
@@ -5065,8 +5174,22 @@ export const Scrollable = (Base) =>
      * `scrollTo(y)` scrolls vertically, as it always has; `scrollTo({x, y})`
      * moves either axis, leaving out whichever is omitted.
      */
+    /** Public entry, logical pixels — application code writes `scrollTo(120)`
+     * in the same unit as its styles. Internal callers hold device offsets
+     * and use `_scrollToDevice`/`_scrollByDevice` instead (src/scale.js). */
     scrollTo(to) {
-      const want = typeof to === 'number' ? { y: to } : { x: to?.x, y: to?.y };
+      const s = this.scale;
+      this._scrollToDevice(
+        typeof to === 'number'
+          ? { y: to * s }
+          : {
+              x: to?.x == null ? undefined : to.x * s,
+              y: to?.y == null ? undefined : to.y * s,
+            },
+      );
+    }
+
+    _scrollToDevice(want) {
       const next = {
         x:
           want.x == null
@@ -5114,13 +5237,17 @@ export const Scrollable = (Base) =>
       }
       this.scrollX = next.x;
       this.scrollY = next.y;
+      // the handler is application code: logical, like every payload —
+      // finder.jsx's row virtualisation divides scrollY by a row height it
+      // wrote in a style, and those must be the same unit
+      const s = this.scale;
       this.props.onScroll?.({
-        scrollX: next.x,
-        scrollY: next.y,
-        contentWidth: this.contentWidth,
-        contentHeight: this.contentHeight,
-        viewportWidth: this.abs.width,
-        viewportHeight: this.abs.height,
+        scrollX: next.x / s,
+        scrollY: next.y / s,
+        contentWidth: this.contentWidth / s,
+        contentHeight: this.contentHeight / s,
+        viewportWidth: this.abs.width / s,
+        viewportHeight: this.abs.height / s,
       });
       // A scroll reflows this viewport's contents and nothing else, and the
       // viewport clips them, so the damage is this node's own rect. It is a
@@ -5150,12 +5277,24 @@ export const Scrollable = (Base) =>
       return false;
     }
 
-    /** `scrollBy(dy)`, or `scrollBy({x, y})` for either axis. */
+    /** `scrollBy(dy)`, or `scrollBy({x, y})` for either axis. Logical, like
+     * `scrollTo`. */
     scrollBy(by) {
-      if (typeof by === 'number') return this.scrollTo(this.scrollY + by);
-      this.scrollTo({
-        x: by?.x == null ? undefined : this.scrollX + by.x,
-        y: by?.y == null ? undefined : this.scrollY + by.y,
+      const s = this.scale;
+      if (typeof by === 'number')
+        return this._scrollToDevice({ y: this.scrollY + by * s });
+      this._scrollToDevice({
+        x: by?.x == null ? undefined : this.scrollX + by.x * s,
+        y: by?.y == null ? undefined : this.scrollY + by.y * s,
+      });
+    }
+
+    /** The wheel's and the key handler's entry: whole device pixels, which
+     * is what keeps the scroll blit on the pixel grid at any scale. */
+    _scrollByDevice(dx, dy) {
+      this._scrollToDevice({
+        x: dx ? this.scrollX + dx : undefined,
+        y: dy ? this.scrollY + dy : undefined,
       });
     }
 
@@ -5196,32 +5335,35 @@ export const Scrollable = (Base) =>
       // nothing to scroll, nothing to swallow: a plain box must leave the
       // arrows and Page keys to whatever else would answer them
       if (!this._scrollsWithKeys()) return super.defaultKeyDown(ev);
-      const page = Math.max(1, this.abs.height - SCROLL_KEY_PAGE_OVERLAP);
+      const step = SCROLL_KEY_STEP * this.scale;
+      const page = Math.max(
+        1,
+        this.abs.height - SCROLL_KEY_PAGE_OVERLAP * this.scale,
+      );
       // Left and Right are the directions on the *screen*, and `scrollX` runs
       // from the start of the content — so which of them moves it forward
       // depends on which way the content runs. Home/End and the Page keys
       // need no such rule: they already name the logical ends.
-      const forward =
-        this.direction === 'rtl' ? -SCROLL_KEY_STEP : SCROLL_KEY_STEP;
+      const forward = this.direction === 'rtl' ? -step : step;
       switch (ev.keysym) {
         case XK_DOWN:
-          return this.scrollBy({ y: SCROLL_KEY_STEP });
+          return this._scrollByDevice(0, step);
         case XK_UP:
-          return this.scrollBy({ y: -SCROLL_KEY_STEP });
+          return this._scrollByDevice(0, -step);
         case XK_RIGHT:
-          return this.scrollBy({ x: forward });
+          return this._scrollByDevice(forward, 0);
         case XK_LEFT:
-          return this.scrollBy({ x: -forward });
+          return this._scrollByDevice(-forward, 0);
         case XK_PAGE_DOWN:
-          return this.scrollBy({ y: page });
+          return this._scrollByDevice(0, page);
         case XK_PAGE_UP:
-          return this.scrollBy({ y: -page });
+          return this._scrollByDevice(0, -page);
         case XK_HOME:
-          return this.scrollTo({ y: 0 });
+          return this._scrollToDevice({ y: 0 });
         case XK_END:
-          return this.scrollTo({ y: this._maxScroll('y') });
+          return this._scrollToDevice({ y: this._maxScroll('y') });
         case XK_SPACE:
-          return this.scrollBy({ y: ev.shiftKey ? -page : page });
+          return this._scrollByDevice(0, ev.shiftKey ? -page : page);
         default:
           return super.defaultKeyDown(ev);
       }
@@ -5309,9 +5451,10 @@ export const Scrollable = (Base) =>
         across: horizontal ? this.abs.y : this.abs.x,
         crossSize: horizontal ? this.abs.height : this.abs.width,
         scroll: horizontal ? this.scrollX : this.scrollY,
-        inset: 2,
-        shorten: other ? SCROLLBAR_WIDTH + 2 : 0,
+        inset: 2 * this.scale,
+        shorten: other ? (SCROLLBAR_WIDTH + 2) * this.scale : 0,
         direction: this.direction,
+        scale: this.scale,
       });
     }
 
@@ -5335,10 +5478,14 @@ export const Scrollable = (Base) =>
     }
 
     defaultMouseDown(ev) {
+      // bar geometry is device pixels; the synthetic event is logical, so
+      // the hit tests here read the native coordinates
+      const nx = ev.nativeEvent?.x ?? ev.x * this.scale;
+      const ny = ev.nativeEvent?.y ?? ev.y * this.scale;
       for (const bar of this._scrollbars()) {
-        const hit = scrollbarHit(bar, ev.x, ev.y);
+        const hit = scrollbarHit(bar, nx, ny);
         if (!hit) continue;
-        const at = along(bar, ev.x, ev.y);
+        const at = along(bar, nx, ny);
         if (hit === 'thumb') {
           // remember where in the thumb it was grabbed, so it does not jump
           this._barGrab = { axis: bar.axis, offset: at - bar.thumbStart };
@@ -5350,7 +5497,8 @@ export const Scrollable = (Base) =>
         const page = bar.axis === 'x' ? this.abs.width : this.abs.height;
         const back = at < bar.thumbStart ? !bar.reversed : bar.reversed;
         const delta = back ? -page : page;
-        this.scrollBy(bar.axis === 'x' ? { x: delta } : { y: delta });
+        if (bar.axis === 'x') this._scrollByDevice(delta, 0);
+        else this._scrollByDevice(0, delta);
         return;
       }
       // no bar under the press: it belongs to whatever is behind the bars,
@@ -5362,10 +5510,12 @@ export const Scrollable = (Base) =>
       if (this._barGrab == null) return super.defaultMouseDrag(ev);
       const bar = this._scrollbar(this._barGrab.axis);
       if (!bar || bar.travel <= 0) return;
-      const at = along(bar, ev.x, ev.y) - this._barGrab.offset - bar.trackStart;
+      const nx = ev.nativeEvent?.x ?? ev.x * this.scale;
+      const ny = ev.nativeEvent?.y ?? ev.y * this.scale;
+      const at = along(bar, nx, ny) - this._barGrab.offset - bar.trackStart;
       const from = bar.reversed ? bar.travel - at : at;
       const to = (from / bar.travel) * bar.range;
-      this.scrollTo(bar.axis === 'x' ? { x: to } : { y: to });
+      this._scrollToDevice(bar.axis === 'x' ? { x: to } : { y: to });
     }
 
     defaultMouseUp(ev) {
@@ -5486,6 +5636,12 @@ export class CanvasNode extends Node {
     if (this.props.mono) this._presetMono(ctx, this._monoColor());
     const unwatch = DEV ? this._watchPutImageData(ctx) : null;
     try {
+      // Device pixels, the browser's own canvas contract: the backing
+      // store is the panel's grid and `scale` says how many of its pixels
+      // one logical pixel is worth. Deliberately NOT a ctx.scale() — ntk
+      // positions glyphs through the transform but sizes them from the
+      // font, so a scaled transform would move an app's fillText without
+      // growing it (src/scale.js).
       onDraw(ctx, {
         width: this.abs.width,
         height: this.abs.height,
@@ -5493,6 +5649,7 @@ export class CanvasNode extends Node {
         // drawable itself, so they are written at `info.x + x` (#366)
         x: this.abs.x,
         y: this.abs.y,
+        scale: this.scale,
         node: this,
       });
     } finally {
@@ -5720,7 +5877,7 @@ function editMenuOrigin(node, at, size) {
   // near a seam flips back onto the screen it was opened on — the same
   // answer `<ContextMenu>` clamps a pointer-anchored menu into. Clamped, not
   // flipped: there is no anchor rect to flip around.
-  const area = anchorArea(node);
+  const area = deviceAnchorArea(node);
   if (area) {
     x = Math.max(area.x, Math.min(x, area.x + area.width - size.width));
     y = Math.max(area.y, Math.min(y, area.y + area.height - size.height));
@@ -5791,7 +5948,15 @@ export function openEditMenu(node, at, actions = {}) {
     items,
     (text) => app?.fonts?.layout(text, style)?.width,
   );
-  const { x, y } = editMenuOrigin(node, at, geometry);
+  // `at` is `{x: ev.x, y: ev.y}` per the doc above — logical, like every
+  // coordinate a handler reads — and the origin math below is device.
+  const s = node.scale;
+  const deviceAt = at && {
+    ...at,
+    ...(Number.isFinite(at.x) && { x: at.x * s }),
+    ...(Number.isFinite(at.y) && { y: at.y * s }),
+  };
+  const { x, y } = editMenuOrigin(node, deviceAt, geometry);
   const colors = editMenuColors(node.theme);
   const state = { active: -1 };
   const choose = (id) => {
@@ -5815,13 +5980,13 @@ export function openEditMenu(node, at, actions = {}) {
             app?.fonts?.layout([{ text, ...style, color }], style),
         }),
       onMouseMove: (mv) => {
-        const next = editMenuIndexAt(geometry, mv.y);
+        const next = editMenuIndexAt(geometry, mv.nativeEvent?.y ?? mv.y * s);
         if (next === state.active) return;
         state.active = next;
         popup.invalidate(false, null, 'style-state');
       },
       onMouseUp: (mv) => {
-        const i = editMenuIndexAt(geometry, mv.y);
+        const i = editMenuIndexAt(geometry, mv.nativeEvent?.y ?? mv.y * s);
         if (i !== -1) choose(geometry.rows[i].id);
         else closeEditMenu(node);
       },
@@ -5862,8 +6027,10 @@ export function openEditMenu(node, at, actions = {}) {
       // `flexGrow`s is nothing at all, so this popup opened 1x1 and the menu
       // was invisible. Every other popup in the tree comes from React, where
       // one props object is both, so nothing else could reach it.
-      width: geometry.width,
-      height: geometry.height,
+      // Props are the logical contract (`_measure` multiplies them back);
+      // the attributes above carry the same size already in device pixels.
+      width: geometry.width / s,
+      height: geometry.height / s,
       grab: true,
       // a press outside the menu closes it and goes no further, which is
       // what the grab is for
@@ -5917,13 +6084,16 @@ export function closeEditMenu(node) {
   events.focus(events._canRestoreTo(restore) ? restore : null, 'pointer');
 }
 
-/** The caret's own width, in pixels — it is a rectangle rather than a line
- * because a hairline disappears on a scaled-up display. */
+/** The caret's own width, in *logical* pixels — it is a rectangle rather
+ * than a line because a hairline disappears in a sea of dense pixels.
+ * Multiplied by the node's scale where it is drawn and reserved for, like
+ * every paint constant that never passes through a style (src/scale.js). */
 const CARET_WIDTH = 1.5;
 
 /** The room a line of a field's text leaves for the caret that follows it,
  * at the right-hand edge of the content box in both directions — see
- * `TextInputNode._lineOriginX`, which is where the asymmetry is explained. */
+ * `TextInputNode._lineOriginX`, which is where the asymmetry is explained.
+ * Logical, like CARET_WIDTH. */
 const CARET_RESERVE = 2;
 
 /**
@@ -6657,7 +6827,14 @@ export class TextInputNode extends Node {
    * through the field's own geometry accessor, which is the one the caret
    * and the highlight are drawn from. */
   _indexAtPoint(ev) {
-    return this.textIndexAt(ev.x, ev.y);
+    // `textIndexAt` is the device-pixel geometry contract (it is also what
+    // the a11y bridge calls with screen points); the synthetic event is
+    // logical, so the click goes back through its native coordinates.
+    const native = ev.nativeEvent;
+    return this.textIndexAt(
+      native?.x ?? ev.x * this.scale,
+      native?.y ?? ev.y * this.scale,
+    );
   }
 
   /** Word range around a code-point index (whitespace-delimited). */
@@ -6756,7 +6933,7 @@ export class TextInputNode extends Node {
    */
   _lineOriginX(layout, content) {
     const rtl = this.direction === 'rtl';
-    const free = content.width - CARET_RESERVE - layout.width;
+    const free = content.width - CARET_RESERVE * this.scale - layout.width;
     let align = this.style.textAlign ?? 'start';
     if (align === 'start') align = rtl ? 'right' : 'left';
     else if (align === 'end') align = rtl ? 'left' : 'right';
@@ -6780,7 +6957,10 @@ export class TextInputNode extends Node {
    * of the text stops short of the edge by exactly the width of the caret
    * that sits there. */
   _maxScrollX(layout, content) {
-    return Math.max(0, layout.width - (content.width - CARET_RESERVE));
+    return Math.max(
+      0,
+      layout.width - (content.width - CARET_RESERVE * this.scale),
+    );
   }
 
   /** The value's layout and where it is drawn, in window coordinates. The
@@ -7116,7 +7296,7 @@ export class TextInputNode extends Node {
     const caretAt = valueLayout
       ? this._lineOriginX(valueLayout, content) + caretX - content.x
       : caretX;
-    const limit = content.width - CARET_RESERVE;
+    const limit = content.width - CARET_RESERVE * this.scale;
     if (!this._focused) this._scrollX = 0;
     else {
       let shift = this._scrollShift();
@@ -7188,7 +7368,12 @@ export class TextInputNode extends Node {
 
     if (this._focused && this._caretOn && a === b) {
       ctx.fillStyle = this.props.caretColor ?? style.color;
-      ctx.fillRect(valueX + caretX, markY, CARET_WIDTH, markHeight);
+      ctx.fillRect(
+        valueX + caretX,
+        markY,
+        CARET_WIDTH * this.scale,
+        markHeight,
+      );
     }
     ctx.restore();
   }
@@ -7240,23 +7425,27 @@ export class TextAreaNode extends TextInputNode {
    */
   defaultMouseDown(ev) {
     const bar = this._scrollbar();
-    const hit = scrollbarHit(bar, ev.x, ev.y);
+    // device coordinates against device bar geometry, as in Scrollable
+    const nx = ev.nativeEvent?.x ?? ev.x * this.scale;
+    const ny = ev.nativeEvent?.y ?? ev.y * this.scale;
+    const hit = scrollbarHit(bar, nx, ny);
     if (!hit) return super.defaultMouseDown(ev);
     if (hit === 'thumb') {
-      this._barGrab = ev.y - bar.thumbStart;
+      this._barGrab = ny - bar.thumbStart;
       ev.capturePointer();
       return;
     }
     const page = this.contentBox().height;
-    this._scrollTo(this._scrollY + (ev.y < bar.thumbStart ? -page : page), bar);
+    this._scrollTo(this._scrollY + (ny < bar.thumbStart ? -page : page), bar);
   }
 
   defaultMouseDrag(ev) {
     if (this._barGrab == null) return super.defaultMouseDrag(ev);
     const bar = this._scrollbar();
     if (!bar || bar.travel <= 0) return;
+    const ny = ev.nativeEvent?.y ?? ev.y * this.scale;
     this._scrollTo(
-      ((ev.y - this._barGrab - bar.trackStart) / bar.travel) * bar.range,
+      ((ny - this._barGrab - bar.trackStart) / bar.travel) * bar.range,
       bar,
     );
   }
@@ -7337,7 +7526,7 @@ export class TextAreaNode extends TextInputNode {
     const container =
       width === undefined || direction !== 'rtl'
         ? width
-        : Math.max(0, width - CARET_RESERVE);
+        : Math.max(0, width - CARET_RESERVE * this.scale);
     const key = `${width}|${color}|${shown}|${s.family}|${s.size}|${s.weight}|${s.style}|${direction}|${align}`;
     if (this._valueLayoutKey !== key) {
       this._valueLayoutKey = key;
@@ -7391,7 +7580,13 @@ export class TextAreaNode extends TextInputNode {
    * so the wheel's default action calls every scroller the same way. `x` is
    * accepted and ignored: wrapped text has no horizontal extent. */
   scrollBy(by) {
+    // logical, like Scrollable's — the public unit
     const dy = typeof by === 'number' ? by : (by?.y ?? 0);
+    this._scrollByDevice(0, dy * this.scale);
+  }
+
+  /** Device-pixel core, the wheel's entry (see Scrollable). */
+  _scrollByDevice(dx, dy) {
     if (!dy) return;
     const next = Math.min(Math.max(0, this._scrollY + dy), this._maxScrollY());
     if (next === this._scrollY) return;
@@ -7492,6 +7687,7 @@ export class TextAreaNode extends TextInputNode {
       across: box.x,
       crossSize: box.width,
       scroll: this._scrollY,
+      scale: this.scale,
     });
   }
 
@@ -7572,7 +7768,12 @@ export class TextAreaNode extends TextInputNode {
 
     if (this._focused && this._caretOn && a === b) {
       ctx.fillStyle = this.props.caretColor ?? this.resolvedTextStyle().color;
-      ctx.fillRect(originX + pos.x, originY + pos.y, CARET_WIDTH, pos.height);
+      ctx.fillRect(
+        originX + pos.x,
+        originY + pos.y,
+        CARET_WIDTH * this.scale,
+        pos.height,
+      );
     }
     // inside the clip, so the thumb is bounded by the content box
     this._paintScrollbar(ctx, layout);
@@ -7832,7 +8033,10 @@ export class WindowNode extends Scrollable(Node) {
    * owes a layout pass anyway.
    */
   _measure() {
-    const props = this.props;
+    // Every number below — yoga's answers, the monitor rects, the window's
+    // live size — is device pixels, so the geometry props convert on entry
+    // and the rest of the function never thinks about units again.
+    const props = scaleWindowGeometry(this.props, this.scale);
     const autoW = isAutoSize(props.width);
     const autoH = isAutoSize(props.height);
     const yoga = this.yoga;
@@ -8071,12 +8275,24 @@ export class WindowNode extends Scrollable(Node) {
     const anchor = this.props.anchor;
     const node = this._anchorTarget(anchor?.to);
     if (!node) return null;
-    return anchorRect(node, {
+    // `anchorRect` is public API and speaks logical pixels on both sides;
+    // this caller's `size` came from `_measure` (device) and its result is
+    // headed for CreateWindow (device), so both convert here.
+    const s = this.scale;
+    const rect = anchorRect(node, {
       ...anchor,
       alignTo: this._anchorTarget(anchor.alignTo) ?? undefined,
-      width: size.width,
-      height: size.height,
+      width: size.width / s,
+      height: size.height / s,
     });
+    if (!rect || s === 1) return rect;
+    return {
+      ...rect,
+      x: Math.round(rect.x * s),
+      y: Math.round(rect.y * s),
+      width: Math.round(rect.width * s),
+      height: Math.round(rect.height * s),
+    };
   }
 
   /**
@@ -8233,10 +8449,19 @@ export class WindowNode extends Scrollable(Node) {
     wnd._reactX11Node = this;
     wnd._reactFiber = this._reactFiber;
     // windows are DevTools public instances too — see Node.getClientRects
+    const s = this.scale;
     wnd.getClientRects ??= () => [
-      { x: 0, y: 0, left: 0, top: 0, width: wnd.width, height: wnd.height },
+      {
+        x: 0,
+        y: 0,
+        left: 0,
+        top: 0,
+        width: wnd.width / s,
+        height: wnd.height / s,
+      },
     ];
-    wnd.measure ??= (callback) => callback?.(0, 0, wnd.width, wnd.height, 0, 0);
+    wnd.measure ??= (callback) =>
+      callback?.(0, 0, wnd.width / s, wnd.height / s, 0, 0);
     wnd.ownerDocument ??= DEVTOOLS_FAKE_DOCUMENT;
     this._attachWindowListeners(parentWindow);
     for (const child of this.children) {
@@ -8744,9 +8969,12 @@ export class WindowNode extends Scrollable(Node) {
 
   /** The WM size hints among these props, as the author wrote them. */
   _sizeHints(props) {
+    // WM_NORMAL_HINTS reach the window manager, which measures the real
+    // window — device pixels, like every geometry prop's destination.
+    const scaled = scaleWindowGeometry(props, this.scale);
     const hints = {};
     for (const key of WINDOW_HINT_PROPS) {
-      if (props[key] !== undefined) hints[key] = props[key];
+      if (scaled[key] !== undefined) hints[key] = scaled[key];
     }
     return hints;
   }
@@ -8853,7 +9081,23 @@ export class WindowNode extends Scrollable(Node) {
       // window or a deduped older copy, which then keep the unconditional
       // refresh rather than losing the anchor.
       if (ev.moved ?? true) this._refreshScreenOrigin();
-      this.props.onResize?.(ev);
+      if (this.props.onResize) {
+        // the payload is application-facing: an app that stores this size
+        // and writes it back as `width`/`height` props must round-trip
+        // through one unit, and props are logical
+        const s = this.scale;
+        this.props.onResize(
+          s === 1
+            ? ev
+            : {
+                ...ev,
+                width: ev.width / s,
+                height: ev.height / s,
+                x: ev.x / s,
+                y: ev.y / s,
+              },
+        );
+      }
     });
     // A reparent is the other way the origin moves: the window manager puts
     // the window inside its frame, and ConfigureNotify coordinates become
@@ -9176,7 +9420,10 @@ export class WindowNode extends Scrollable(Node) {
       // `ev.preventDefault is not a function` in a <popup>'s onKeyDown: ntk
       // registers any `onFoo` in its creation args as a raw listener, so the
       // handler was called a second time with the native X event.
-      this.attributes = { ...this.attributes, ...windowAttributes(newProps) };
+      this.attributes = {
+        ...this.attributes,
+        ...windowAttributes(newProps, this.scale),
+      };
       return;
     }
 
@@ -9225,34 +9472,36 @@ export class WindowNode extends Scrollable(Node) {
     // about to change. Without that the echo of a one-axis configure would
     // disagree with the record on the other axis and read as somebody else
     // setting the size — locking the window on the app's own update.
+    // The comparisons above ran on the raw props — logical against logical
+    // — and everything below talks to the server, so it is device from here
+    // (`wnd.width`, `_requestedSize` and the ConfigureNotify echo are all
+    // device pixels; a logical number among them would misread every user
+    // resize as `_userSized`).
+    const geo = scaleWindowGeometry(newProps, this.scale);
     if (sizeChanged) {
       this._userSized = false;
       this._requestedSize = {
-        width: isAutoSize(newProps.width) ? wnd.width : newProps.width,
-        height: isAutoSize(newProps.height) ? wnd.height : newProps.height,
+        width: isAutoSize(geo.width) ? wnd.width : geo.width,
+        height: isAutoSize(geo.height) ? wnd.height : geo.height,
       };
     }
     if (geometryChanged) {
       if (typeof wnd.setState === 'function') {
         wnd.setState({
-          x: anchored ? undefined : newProps.x,
-          y: anchored ? undefined : newProps.y,
+          x: anchored ? undefined : geo.x,
+          y: anchored ? undefined : geo.y,
           // `'auto'` is not a geometry ntk can be given: an axis the app has
           // handed back is left alone here and resolved by `_refit()` on the
           // layout this same commit is about to schedule.
-          width: isAutoSize(newProps.width) ? undefined : newProps.width,
-          height: isAutoSize(newProps.height) ? undefined : newProps.height,
+          width: isAutoSize(geo.width) ? undefined : geo.width,
+          height: isAutoSize(geo.height) ? undefined : geo.height,
         });
       } else {
-        if (
-          sizeChanged &&
-          !isAutoSize(newProps.width) &&
-          !isAutoSize(newProps.height)
-        ) {
-          wnd.resize?.(newProps.width, newProps.height);
+        if (sizeChanged && !isAutoSize(geo.width) && !isAutoSize(geo.height)) {
+          wnd.resize?.(geo.width, geo.height);
         }
         if (movedByProps) {
-          wnd.move?.(newProps.x, newProps.y);
+          wnd.move?.(geo.x, geo.y);
         }
       }
     }

--- a/src/scale.js
+++ b/src/scale.js
@@ -1,0 +1,634 @@
+// The display scale: how many device pixels one logical pixel is worth.
+//
+// Every length an app writes — `width: 200`, `fontSize: 14`, the theme's
+// spacing — is meant in *visible* pixels: units sized so that "14px text" is
+// comfortably readable at the distance this kind of display is actually
+// viewed from. On the panels the last decade shipped, one visible pixel is
+// two device pixels (or 1.5, or 1.25), and a renderer that treats the two as
+// the same unit draws every widget at half size. This module answers the one
+// question that fixes that: **what is the factor, and how sure are we?**
+//
+// ## Where the answer can come from, and why this order
+//
+// X11 never grew a scale protocol, so the answer is scattered across four
+// generations of convention. Each rung below is consulted only when the ones
+// above it said nothing, and the order is "who is closest to a human having
+// decided", not "who is most precise":
+//
+//   1. **Environment** — `REACT_X11_SCALE` (ours), then `GDK_SCALE` and
+//      `QT_SCALE_FACTOR` (the user already told their other toolkits; an app
+//      of ours on the same desktop should agree). A person typed these.
+//   2. **XSETTINGS** — `Gdk/WindowScalingFactor` when it is 2 or more, then
+//      `Xft/DPI`. This is what the desktop's own settings dialog writes, and
+//      it is what every GTK app on the screen is already obeying — matching
+//      it is what makes us look native. `WindowScalingFactor: 1` is *not* an
+//      answer: it is the value daemons publish when nobody ever touched the
+//      dialog, and treating it as "the user chose 1x" is how a toolkit ends
+//      up microscopic on an unconfigured 4K laptop.
+//   3. **`RESOURCE_MANAGER`** — `Xft.dpi`, the `xrdb` convention winit,
+//      Chromium and every terminal emulator read. Same caveat, sharper: 96
+//      exactly is the value of *never configured* (xfsettingsd writes it
+//      unconditionally — the machine this was developed on says `Xft.dpi:
+//      96` while driving a 254dpi panel), so 96 falls through to the
+//      hardware and anything else is a person's decision.
+//   4. **RandR millimetres** — the panel's physical size against its pixel
+//      size, the only rung that needs no configuration at all. This is
+//      mutter's model, constants and all: perceived size is angular, and a
+//      laptop is read at half the distance of a desk monitor, so the DPI
+//      that counts as "1x" is 135 under a 20" diagonal and 110 over it.
+//      The catch is that the millimetres are self-reported EDID data, and
+//      EDIDs lie in well-known ways — a projector reports zero, a KVM
+//      strips the block, cheap panels report their *aspect ratio* as a
+//      size, and **every virtual machine invents dimensions that make the
+//      maths land on ~96dpi** (QEMU hands a 16" MacBook panel to the guest
+//      as "870x550mm"). So the millimetres are audited before they are
+//      believed — see `classifyMm` — and the EDID vendor is read precisely
+//      to catch the VMs at it.
+//   5. **The resolution class** — when the millimetres are absent or
+//      caught lying, the pixel grid itself is the last signal standing.
+//      Nobody makes a 1x panel 3456 pixels wide; a mode that size *is* a
+//      retina panel (or a VM window covering one, which wants the same
+//      answer). Only the confident call is made here — 2 for
+//      unmistakably-retina grids, 1 for everything else — because
+//      fractional guesses without physical data are how a UI ends up a
+//      subtly wrong size everywhere.
+//   6. **1**, the answer X11 shipped with in 1987.
+//
+// A machine can defeat every rung above the last two — the one this was
+// written against does: UTM in retina mode hands the guest the MacBook's
+// full 3456x2168 grid, QEMU's EDID invents millimetres that read as 100dpi,
+// and XFCE publishes the 96 it was never asked to change. Rungs 1-4 all say
+// "1x" on that box and are all wrong. Rung 5 is why the ladder still lands
+// on 2.
+//
+// ## Per monitor, then one for the root
+//
+// Rungs 4 and 5 are computed for every connected output, because a desktop
+// with a retina laptop lid and an office monitor genuinely has two answers.
+// The *root's* scale — the one layout and paint use — is the primary
+// output's, matching what GNOME does on X11: one scale for the session,
+// chosen for the display you called primary. The per-output answers ride on
+// `useScreens()` so an app that places windows can do better, and a window
+// can be pinned with `<window scale={n}>`. What this deliberately does not
+// do is re-scale a window as it is dragged between mismatched monitors:
+// X11 has one coordinate space and no per-window scale protocol, so that
+// move is a resize the WM fights; Qt is the one toolkit that tries, and
+// "static per window, chosen at creation" is the behaviour of everything
+// else on this window system.
+//
+// Resolution happens once, inside `createRoot`, before the first window
+// realizes — the scale multiplies CreateWindow geometry, so it cannot
+// arrive later. The cost is honest: the environment is free, XSETTINGS is
+// already being read for other reasons, and the RandR walk (three batched
+// round trips) is only paid on desktops where nothing cheaper answered.
+//
+// `REACT_X11_DEBUG_SCALE=1` prints every rung's evidence and verdict.
+
+import { beginXSettings } from './xsettings.js';
+
+const sessions = new WeakMap();
+
+const debugScale = process.env.REACT_X11_DEBUG_SCALE === '1';
+const trace = (...args) => {
+  if (debugScale) console.error('react-x11 scale:', ...args);
+};
+
+// --------------------------------------------------------------------------
+// Small parsers, exported for the probe (`scripts/scale-probe.mjs`) and the
+// tests — everything here is a pure function of bytes it was handed.
+// --------------------------------------------------------------------------
+
+/**
+ * `RESOURCE_MANAGER` is the text `xrdb` loaded, one `name: value` per line.
+ * Only the flat, fully-qualified names matter here (`Xft.dpi: 192`); the
+ * wildcard grammar (`*dpi`, `?`) is for matching against widget paths, which
+ * is a lookup this module never does.
+ */
+export function parseResourceManager(text) {
+  const out = new Map();
+  if (typeof text !== 'string') return out;
+  for (const line of text.split('\n')) {
+    const colon = line.indexOf(':');
+    if (colon <= 0) continue;
+    const name = line.slice(0, colon).trim();
+    if (!name || name.startsWith('!')) continue;
+    out.set(name, line.slice(colon + 1).trim());
+  }
+  return out;
+}
+
+/** PNP vendor id: three letters, five bits each, packed big-endian into
+ *  bytes 8-9 of the EDID block. `A` is 1. */
+function edidVendor(buffer) {
+  const raw = (buffer[8] << 8) | buffer[9];
+  const letter = (n) => String.fromCharCode(64 + ((raw >> n) & 0x1f));
+  const vendor = letter(10) + letter(5) + letter(0);
+  return /^[A-Z]{3}$/.test(vendor) ? vendor : null;
+}
+
+/**
+ * The EDID vendors and model strings that mean "this display is software".
+ *
+ * QEMU registered `RHT` (Red Hat); VMware, VirtualBox, Parallels and
+ * Hyper-V each have their own. The model-name check backs the vendor list
+ * up because nested and forked hypervisors ship EDIDs with the name kept
+ * and the vendor changed. Matching one of these does not make the *pixels*
+ * less real — it makes the *millimetres* fiction, because a VM's EDID
+ * describes a window, not a panel, and every hypervisor fills the size in
+ * with whatever makes ~96dpi come out.
+ */
+const VIRTUAL_EDID_VENDORS = new Set([
+  'RHT',
+  'VMW',
+  'VBX',
+  'PRL',
+  'MSF',
+  'XEN',
+]);
+const VIRTUAL_MODEL = /qemu|virtual|vbox|vmware|parallels|bochs|bhyve/i;
+
+/**
+ * The 128-byte EDID base block → what the scale ladder wants from it:
+ * vendor, model name, the physical size, and the one derived judgement —
+ * `virtual` — that says the size is invented.
+ *
+ * Not a general EDID parser on purpose. Detailed timing descriptors carry a
+ * second, finer physical size, but a lying EDID lies in both places, so
+ * reading it would add code and no information.
+ */
+export function parseEdid(buffer) {
+  if (!buffer || buffer.length < 128) return null;
+  // the fixed 8-byte header; anything else is not an EDID
+  if (
+    buffer[0] !== 0x00 ||
+    buffer[1] !== 0xff ||
+    buffer[6] !== 0xff ||
+    buffer[7] !== 0x00
+  ) {
+    return null;
+  }
+  const vendor = edidVendor(buffer);
+  // bytes 21/22: maximum image size in whole centimetres; 0 means "unknown
+  // or variable", which projectors use honestly and KVMs use lazily
+  const mmWidth = buffer[21] ? buffer[21] * 10 : null;
+  const mmHeight = buffer[22] ? buffer[22] * 10 : null;
+  let model = null;
+  // four 18-byte descriptors; 0xFC is the display product name
+  for (let at = 54; at + 18 <= 126; at += 18) {
+    if (buffer[at] === 0 && buffer[at + 1] === 0 && buffer[at + 3] === 0xfc) {
+      model = buffer
+        .toString('latin1', at + 5, at + 18)
+        .split('\n')[0]
+        .trim();
+      break;
+    }
+  }
+  const virtual =
+    (vendor !== null && VIRTUAL_EDID_VENDORS.has(vendor)) ||
+    (model !== null && VIRTUAL_MODEL.test(model));
+  return { vendor, model, mmWidth, mmHeight, virtual };
+}
+
+// --------------------------------------------------------------------------
+// Judging a monitor's metadata
+// --------------------------------------------------------------------------
+
+/** Output names that mean the display is software even when no EDID says so:
+ *  QEMU's virtio connector, VirtualBox's, VMware's, qxl. `XWAYLAND` is here
+ *  for a different reason — those millimetres are usually *true*, but the
+ *  compositor owns scaling on that path and publishes its decision through
+ *  XSETTINGS, so hardware inference would double what rung 2 already knows. */
+const VIRTUAL_OUTPUT_NAME =
+  /^(Virtual|VIRTUAL|VBOX|VMWARE|qxl|hyperv|XWAYLAND)/i;
+
+/**
+ * Can these millimetres be trusted to compute a density?  Returns
+ * `'credible'` or the reason they cannot be:
+ *
+ *   'absent'          zero or missing — projectors, stripped EDIDs
+ *   'virtual'         a VM's EDID or connector; the size is invented
+ *   'aspect-as-size'  the panel wrote its aspect ratio where the size goes
+ *                     (16x9 "millimetres" — a real panel the size of a
+ *                     matchbook does not exist)
+ *   'aspect-mismatch' the physical and pixel aspect ratios disagree by more
+ *                     than a quarter — one of them is wrong and there is no
+ *                     way to know which
+ *
+ * A *huge* diagonal is deliberately not a reason: a 60" panel is a real
+ * thing with real millimetres, and the viewing-distance model below already
+ * answers it with 1x. The audit here is only about lies.
+ */
+export function classifyMm(output, crtc) {
+  const mmW = output?.mm_width ?? output?.widthMM ?? 0;
+  const mmH = output?.mm_height ?? output?.heightMM ?? 0;
+  const name = output?.name ?? '';
+  const edid = output?.edid ?? null;
+  if (edid?.virtual || VIRTUAL_OUTPUT_NAME.test(name)) return 'virtual';
+  if (!(mmW > 0) || !(mmH > 0)) return 'absent';
+  // the classic junk values: an aspect ratio in a size's clothing
+  if (mmW <= 16 && mmH <= 16) return 'aspect-as-size';
+  if ((mmW === 160 && mmH === 90) || (mmW === 160 && mmH === 100))
+    return 'aspect-as-size';
+  const pxW = crtc?.width ?? output?.width ?? 0;
+  const pxH = crtc?.height ?? output?.height ?? 0;
+  if (pxW > 0 && pxH > 0) {
+    // compare in a rotation-proof way: a portrait CRTC on a landscape panel
+    // is a real desk arrangement, not a lie
+    // 0.15 is picked to pass a panel whose EDID measured the module with
+    // its bezel (16:9 pixels on 16:10-ish glass is ~0.11 off) and fail the
+    // classic lie of 4:3 millimetres on a 16:10 grid (~0.2 off).
+    const pxAspect = Math.max(pxW, pxH) / Math.min(pxW, pxH);
+    const mmAspect = Math.max(mmW, mmH) / Math.min(mmW, mmH);
+    if (Math.abs(pxAspect - mmAspect) / mmAspect > 0.15)
+      return 'aspect-mismatch';
+  }
+  return 'credible';
+}
+
+/**
+ * mutter's perceptual model, constants and all: the DPI that reads as "1x"
+ * depends on viewing distance, and diagonal size is the proxy for distance
+ * that actually ships. Under 20 inches the panel is in your lap at ~50cm
+ * and 135dpi is the baseline; over it the panel is across a desk and 110
+ * is. (For calibration: a 27" 2560x1440 desk monitor computes 109dpi → 1x;
+ * a 16" MacBook panel computes 255dpi → 1.9 → 2x; a 13" 1920x1080 laptop
+ * computes 169dpi → 1.25.)
+ */
+const TARGET_DPI_MOBILE = 135;
+const TARGET_DPI_LARGE = 110;
+const MOBILE_DIAGONAL_INCHES = 20;
+
+/** Snap to the quarter steps every desktop offers, inside [1, 3]. Quarters
+ *  are what the plumbing downstream can draw crisply — layout snaps to the
+ *  device grid through yoga's point scale — and three doubles the largest
+ *  factor any shipping desktop configures. */
+export function snapScale(value) {
+  if (!Number.isFinite(value)) return 1;
+  return Math.min(3, Math.max(1, Math.round(value * 4) / 4));
+}
+
+/**
+ * One monitor's metadata → `{ scale, source, reason }`, using only what the
+ * connection reported: pixel geometry, claimed millimetres, EDID. This is
+ * rungs 4 and 5 of the ladder for one output; the caller stacks the
+ * desktop-configuration rungs above it.
+ */
+export function monitorScaleFromMetadata(monitor) {
+  const mm = classifyMm(monitor, monitor);
+  const pxW = monitor.width ?? 0;
+  const pxH = monitor.height ?? 0;
+  const mmW = monitor.widthMM ?? monitor.mm_width ?? 0;
+  const mmH = monitor.heightMM ?? monitor.mm_height ?? 0;
+
+  if (mm === 'credible' && pxW > 0) {
+    const diagonalInches = Math.hypot(mmW, mmH) / 25.4;
+    // long pixel axis over long physical axis, so a portrait CRTC on a
+    // landscape panel measures the same density as its neighbour
+    const dpi = Math.max(pxW, pxH) / (Math.max(mmW, mmH) / 25.4);
+    const target =
+      diagonalInches < MOBILE_DIAGONAL_INCHES
+        ? TARGET_DPI_MOBILE
+        : TARGET_DPI_LARGE;
+    const scale = snapScale(dpi / target);
+    return {
+      scale,
+      source: 'randr-mm',
+      reason: `${Math.round(dpi)}dpi across ${diagonalInches.toFixed(1)}" (target ${target})`,
+    };
+  }
+
+  // No physical truth to reason from. The pixel grid alone still separates
+  // "unmistakably a retina panel" from everything else: the smallest grids
+  // this matches are 2880x1800 and 3024x1964, both shipped only as 2x
+  // panels, and every VM window covering one lands here too. 2560-wide
+  // grids stay at 1 on purpose — 2560x1440 is the commonest *1x* desk
+  // monitor there is, and only millimetres could tell it from a 13" retina
+  // lid, which is exactly the data this branch does not have.
+  if (Math.min(pxW, pxH) >= 1800 || Math.max(pxW, pxH) >= 3000) {
+    return {
+      scale: 2,
+      source: 'resolution',
+      reason: `${pxW}x${pxH} is a retina-class grid (mm ${mm})`,
+    };
+  }
+  return {
+    scale: 1,
+    source: 'default',
+    reason: `no credible density data (mm ${mm}, ${pxW}x${pxH})`,
+  };
+}
+
+// --------------------------------------------------------------------------
+// The desktop-configuration rungs
+// --------------------------------------------------------------------------
+
+function envScale() {
+  const own = Number(process.env.REACT_X11_SCALE);
+  // wider bounds than `snapScale` on purpose: an explicit override is a
+  // person telling us, and 0.5 ("shrink it, my panel is dense and my eyes
+  // are good") is a thing people legitimately ask toolkits for
+  if (Number.isFinite(own) && own >= 0.5 && own <= 8) {
+    return { scale: own, source: 'REACT_X11_SCALE' };
+  }
+  const gdk = Number(process.env.GDK_SCALE);
+  if (Number.isInteger(gdk) && gdk >= 1 && gdk <= 8 && gdk !== 1) {
+    return { scale: gdk, source: 'GDK_SCALE' };
+  }
+  const qt = Number(process.env.QT_SCALE_FACTOR);
+  if (Number.isFinite(qt) && qt > 0 && qt <= 8 && qt !== 1) {
+    return { scale: qt, source: 'QT_SCALE_FACTOR' };
+  }
+  return null;
+}
+
+/**
+ * `Xft/DPI` on the wire is 1024ths of a dot per inch — the machine this
+ * was written on publishes 98304, which is 96 — but daemons writing plain
+ * DPI exist too, and no plausible density is over 1024, so the magnitude
+ * itself says which convention the daemon used.
+ */
+function dpiFromXftValue(value) {
+  if (typeof value !== 'number' || value <= 0) return null;
+  return value > 1024 ? value / 1024 : value;
+}
+
+/** Rung 2 as a pure function of the XSETTINGS map — exported for the tests. */
+export function desktopScaleFromXSettings(map) {
+  if (!map) return null;
+  const factor = map.get('Gdk/WindowScalingFactor');
+  // 2 and up is a decision; 1 is what the dialog says before anyone opens it
+  if (Number.isInteger(factor) && factor >= 2) {
+    return { scale: Math.min(factor, 8), source: 'Gdk/WindowScalingFactor' };
+  }
+  const dpi = dpiFromXftValue(map.get('Xft/DPI'));
+  if (dpi !== null && Math.round(dpi) !== 96) {
+    return {
+      scale: snapScale(dpi / 96),
+      source: `Xft/DPI (${Math.round(dpi)})`,
+    };
+  }
+  return null;
+}
+
+/** Rung 3 as a pure function of the parsed resource map — for the tests. */
+export function desktopScaleFromResources(resources) {
+  const dpi = Number(resources.get('Xft.dpi'));
+  if (Number.isFinite(dpi) && dpi > 0 && Math.round(dpi) !== 96) {
+    return {
+      scale: snapScale(dpi / 96),
+      source: `Xft.dpi (${Math.round(dpi)})`,
+    };
+  }
+  return null;
+}
+
+// --------------------------------------------------------------------------
+// Reading the connection
+// --------------------------------------------------------------------------
+
+/** A node-x11 request as a promise that resolves null on error, because
+ *  every read here is a rung that is allowed to answer nothing. */
+function call(fn, ...args) {
+  return new Promise((resolve) => {
+    try {
+      fn(...args, (err, value) => resolve(err ? null : value));
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
+function requireExt(app, name) {
+  return new Promise((resolve) => {
+    try {
+      app.X.require(name, (err, ext) => resolve(err || !ext ? null : ext));
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
+const RESOURCE_MANAGER_ATOM = 23; // predefined, like the STRING type it holds
+
+async function readResourceManager(X, root) {
+  const prop = await call(
+    X.GetProperty.bind(X),
+    0,
+    root,
+    RESOURCE_MANAGER_ATOM,
+    0,
+    0,
+    0x1fffffff,
+  );
+  if (!prop?.data?.length) return new Map();
+  return parseResourceManager(prop.data.toString('latin1'));
+}
+
+/**
+ * The hardware walk: every connected output's pixel geometry, claimed
+ * millimetres and EDID, in three batched round trips (resources, then all
+ * output infos at once, then all CRTCs and EDIDs at once). Only run when
+ * every configured rung came up empty.
+ */
+async function readOutputs(app) {
+  const randr = await requireExt(app, 'randr');
+  const X = app.X;
+  const root = X.display?.screen?.[0]?.root;
+  if (!randr || root == null) return null;
+  const resources = await call(randr.GetScreenResourcesCurrent, root);
+  if (!resources) return null;
+  const primary = await call(randr.GetOutputPrimary, root);
+  const edidAtom = await new Promise((resolve) =>
+    X.InternAtom(false, 'EDID', (err, atom) => resolve(err ? null : atom)),
+  );
+  const infos = (
+    await Promise.all(
+      (resources.outputs ?? []).map((id) =>
+        call(randr.GetOutputInfo, id, resources.config_timestamp).then(
+          (info) => (info ? { ...info, id } : null),
+        ),
+      ),
+    )
+  ).filter((info) => info && info.connection === 0 && info.crtc);
+  const monitors = await Promise.all(
+    infos.map(async (info) => {
+      const [crtc, edidProp] = await Promise.all([
+        call(randr.GetCrtcInfo, info.crtc, resources.config_timestamp),
+        edidAtom
+          ? call(randr.GetOutputProperty, info.id, edidAtom, 0, 0, 64, 0, 0)
+          : null,
+      ]);
+      if (!crtc || !(crtc.width > 0)) return null;
+      return {
+        name: info.name,
+        primary: info.id === primary,
+        x: crtc.x,
+        y: crtc.y,
+        width: crtc.width,
+        height: crtc.height,
+        widthMM: info.mm_width,
+        heightMM: info.mm_height,
+        edid: edidProp?.data?.length >= 128 ? parseEdid(edidProp.data) : null,
+      };
+    }),
+  );
+  const connected = monitors.filter(Boolean);
+  return connected.length ? connected : null;
+}
+
+// --------------------------------------------------------------------------
+// The session
+// --------------------------------------------------------------------------
+
+class ScaleSession {
+  constructor() {
+    /** The root's factor — what layout, fonts and paint multiply by. */
+    this.scale = 1;
+    /** Which rung answered, for `REACT_X11_DEBUG_SCALE` and the tests. */
+    this.source = 'default';
+    /** Per-output verdicts, keyed by RandR output name, for `useScreens`
+     *  and for windows placed by an app that knows better than "primary". */
+    this.monitors = new Map();
+  }
+}
+
+/**
+ * Resolve the scale for this connection. Called from `createRoot`, awaited,
+ * before any window realizes — the factor multiplies CreateWindow geometry,
+ * so it has to be settled first and stay settled (see the header for why it
+ * is static).
+ *
+ * `option` is `createRoot`'s `scale`: a number pins it (clamped to [0.5, 8]
+ * — past those bounds it is a typo, not a preference), `'auto'` or
+ * `undefined` climbs the ladder. `REACT_X11_SCALE` outranks even the
+ * explicit number, because the person running the app outranks the person
+ * who wrote it — that is the accessibility escape hatch when a hardcoded
+ * `scale: 1` meets a screen it is wrong on.
+ */
+export async function beginScale(app, option) {
+  let session = sessions.get(app);
+  if (session) return session;
+  session = new ScaleSession();
+  sessions.set(app, session);
+
+  const own = Number(process.env.REACT_X11_SCALE);
+  if (Number.isFinite(own) && own >= 0.5 && own <= 8) {
+    session.scale = own;
+    session.source = 'REACT_X11_SCALE';
+    trace(`${session.scale}x from REACT_X11_SCALE`);
+    return session;
+  }
+
+  if (typeof option === 'number' && Number.isFinite(option)) {
+    session.scale = Math.min(8, Math.max(0.5, option));
+    session.source = 'option';
+    trace(`${session.scale}x from createRoot({ scale })`);
+    return session;
+  }
+
+  const X = app?.X;
+  const root = X?.display?.screen?.[0]?.root;
+  if (!X || typeof X.GetProperty !== 'function' || root == null) {
+    // the headless mock: tests mean their numbers literally
+    return session;
+  }
+
+  const env = envScale();
+  if (env) {
+    session.scale = env.scale;
+    session.source = env.source;
+    trace(`${env.scale}x from ${env.source}`);
+    return session;
+  }
+
+  // Rung 2: the desktop's own channel. `beginXSettings` is idempotent and
+  // shared with appearance/desktopsettings; awaiting it here costs the one
+  // selection-owner round trip this path needed anyway.
+  const xsettings = await beginXSettings(app);
+  const fromDaemon = desktopScaleFromXSettings(xsettings?.values);
+  if (fromDaemon) {
+    session.scale = fromDaemon.scale;
+    session.source = fromDaemon.source;
+    trace(`${fromDaemon.scale}x from XSETTINGS ${fromDaemon.source}`);
+    return session;
+  }
+
+  // Rung 3: xrdb.
+  const resources = await readResourceManager(X, root);
+  const fromXrdb = desktopScaleFromResources(resources);
+  if (fromXrdb) {
+    session.scale = fromXrdb.scale;
+    session.source = fromXrdb.source;
+    trace(`${fromXrdb.scale}x from RESOURCE_MANAGER ${fromXrdb.source}`);
+    return session;
+  }
+
+  // Rungs 4-5: the hardware, one verdict per output.
+  const outputs = await readOutputs(app);
+  if (outputs) {
+    for (const monitor of outputs) {
+      const verdict = monitorScaleFromMetadata(monitor);
+      session.monitors.set(monitor.name, {
+        scale: verdict.scale,
+        source: verdict.source,
+        primary: monitor.primary,
+        x: monitor.x,
+        y: monitor.y,
+        width: monitor.width,
+        height: monitor.height,
+      });
+      trace(
+        `  ${monitor.name}${monitor.primary ? ' (primary)' : ''}: ` +
+          `${verdict.scale}x via ${verdict.source} — ${verdict.reason}`,
+      );
+    }
+    // The root's answer: the primary output's, like GNOME on X11. No
+    // primary flag is a desktop that never ran `xrandr --primary`; the
+    // largest output is the best stand-in for "the one you look at".
+    const chosen =
+      [...session.monitors.values()].find((m) => m.primary) ??
+      [...session.monitors.values()].sort(
+        (a, b) => b.width * b.height - a.width * a.height,
+      )[0];
+    if (chosen) {
+      session.scale = chosen.scale;
+      session.source = chosen.source;
+    }
+  }
+  trace(`${session.scale}x from ${session.source}`);
+  return session;
+}
+
+/**
+ * The resolved factor for this connection — 1 until `beginScale` settles,
+ * which `createRoot` guarantees happened before anything renders.
+ * Synchronous because its callers are: styles apply inside React's commit,
+ * paint runs inside the frame clock, and neither has a round trip to spend.
+ */
+export function scaleOf(app) {
+  return sessions.get(app)?.scale ?? 1;
+}
+
+/** Which rung answered, for tests and the debug overlay. */
+export function scaleSourceOf(app) {
+  return sessions.get(app)?.source ?? 'default';
+}
+
+/** Per-output verdicts (name → {scale, source, primary, geometry}), for
+ *  `useScreens` to join onto its monitor list. Empty on desktops where a
+ *  configured rung answered — one factor is the whole story there. */
+export function monitorScalesOf(app) {
+  return sessions.get(app)?.monitors ?? new Map();
+}
+
+/** Tests pin the factor without a connection. */
+export function setScaleForTests(app, scale, source = 'test') {
+  let session = sessions.get(app);
+  if (!session) {
+    session = new ScaleSession();
+    sessions.set(app, session);
+  }
+  session.scale = scale;
+  session.source = source;
+  return session;
+}

--- a/src/scalehooks.js
+++ b/src/scalehooks.js
@@ -1,0 +1,27 @@
+// The display scale, as rendering code reads it.
+//
+// One number and it never changes — `createRoot` resolves it before the
+// first window realizes and it is static for the life of the connection
+// (src/scale.js explains why) — so this is the rare hook with nothing to
+// subscribe to. It exists because the number is still *occasionally* an
+// app's business even though every style, event and rect already speaks
+// logical pixels: a `<canvas onDraw>` sizing its backing detail, a
+// screenshot tool captioning what it captured, a settings pane showing
+// "2x (from Xft.dpi)" the way it shows the DPI.
+
+import { useApp } from './appcontext.js';
+import { scaleOf } from './scale.js';
+
+/**
+ * Device pixels per logical pixel for this root — `1` on an ordinary
+ * display, `2` on the retina panel this feature was built against,
+ * fractional on the desktops that configure 1.25/1.5.
+ *
+ * Everything the renderer hands an app is already logical (styles, event
+ * coordinates, `getClientRects`, `useScreens`), so multiply by this only
+ * to reach *device* pixels deliberately — the `<canvas onDraw>` payload
+ * carries the same number as `scale` for exactly that.
+ */
+export function useScale() {
+  return scaleOf(useApp());
+}

--- a/src/screenshooks.js
+++ b/src/screenshooks.js
@@ -9,6 +9,63 @@ import { useCallback, useSyncExternalStore } from 'react';
 
 import { useApp } from './appcontext.js';
 import { screensSnapshot, watchScreens } from './screens.js';
+import { scaleOf, monitorScalesOf } from './scale.js';
+
+/**
+ * The raw snapshot is device pixels — `screens.js` clamps CreateWindow
+ * geometry with it and must stay that way — and the hook's callers are
+ * application code, which thinks in logical pixels like every prop it
+ * writes. Divided here, per snapshot object so referential stability
+ * survives (useSyncExternalStore re-renders on identity).
+ *
+ * Each screen also carries its own `scale`: on a desktop where the ladder
+ * read the hardware (src/scale.js), a retina lid and an office monitor
+ * really do answer differently, and an app that places windows can honour
+ * that. Where the desktop configured one factor, every entry carries it.
+ */
+const logicalSnapshots = new WeakMap();
+
+function logicalScreens(app, raw) {
+  if (!raw) return raw;
+  const cached = logicalSnapshots.get(raw);
+  if (cached) return cached;
+  const s = scaleOf(app);
+  const perMonitor = monitorScalesOf(app);
+  const rect = (r) =>
+    r == null
+      ? r
+      : Object.freeze({
+          ...r,
+          x: r.x / s,
+          y: r.y / s,
+          width: r.width / s,
+          height: r.height / s,
+        });
+  const out = Object.freeze({
+    ...raw,
+    screens: Object.freeze(
+      raw.screens.map((screen) =>
+        Object.freeze({
+          ...rect(screen),
+          available: rect(screen.available),
+          scale:
+            (screen.name && perMonitor.get(screen.name)?.scale) ??
+            perMonitor.get(screen.outputs?.[0])?.scale ??
+            s,
+        }),
+      ),
+    ),
+    primary: null, // reattached below so it stays an identity into `screens`
+    workArea: rect(raw.workArea),
+    virtual: rect(raw.virtual),
+  });
+  const primary =
+    out.screens.find((screen) => screen.primary) ??
+    (out.screens.length === 1 ? out.screens[0] : null);
+  const finished = Object.freeze({ ...out, primary });
+  logicalSnapshots.set(raw, finished);
+  return finished;
+}
 
 /**
  * The monitors this display has, live.
@@ -72,6 +129,9 @@ export function useScreens() {
     (onChange) => watchScreens(app, onChange),
     [app],
   );
-  const snapshot = useCallback(() => screensSnapshot(app), [app]);
+  const snapshot = useCallback(
+    () => logicalScreens(app, screensSnapshot(app)),
+    [app],
+  );
   return useSyncExternalStore(subscribe, snapshot, snapshot);
 }

--- a/src/styles.js
+++ b/src/styles.js
@@ -878,7 +878,7 @@ function parseAnimation(spec, where) {
  * and both ends checked for a midpoint. Null when there are none, so the
  * common case allocates nothing.
  */
-export function animationsOf(style, where = 'a style') {
+export function animationsOf(style, where = 'a style', scale = 1) {
   const spec = style.animation;
   if (spec == null) return null;
   let parsed = parsedAnimations.get(spec);
@@ -888,6 +888,18 @@ export function animationsOf(style, where = 'a style') {
   }
   if (parsed.length === 0) return null;
   return parsed.map((entry) => {
+    // The display scale, only where the caller says the style is already in
+    // device pixels (`_syncLoops` passes the node's). The declared ends are
+    // logical like everything an app writes; a `from` *defaulted* from the
+    // style is a device value already and is left alone — which is why the
+    // scaling happens here, where the two can still be told apart.
+    if (scale !== 1 && SCALED_LENGTHS.has(entry.prop)) {
+      entry = {
+        ...entry,
+        ...(typeof entry.from === 'number' && { from: entry.from * scale }),
+        ...(typeof entry.to === 'number' && { to: entry.to * scale }),
+      };
+    }
     const from = entry.from === undefined ? style[entry.prop] : entry.from;
     if (from === undefined) {
       throw new Error(
@@ -1328,6 +1340,103 @@ export function resolveComputedStyle(style) {
   // and the animated one the same layout: yoga is set up from this style.
   if (loops) {
     for (const loop of loops) out[loop.prop] = loop.from;
+  }
+  return out;
+}
+
+/**
+ * The style lengths that are *distances on the screen*, and therefore the
+ * complete set the display scale multiplies (src/scale.js). Everything a
+ * style can say that is not here is deliberately not here: `lineHeight` is
+ * a multiplier over the font's own height, `aspectRatio` and the flex
+ * factors are ratios, `opacity` and `zIndex` are not lengths, and
+ * `boxShadow` is a string whose lengths are scaled where it is parsed
+ * (src/decorations.js), because its parse is memoized on the raw string.
+ */
+export const SCALED_LENGTH_PROPS = [
+  'width',
+  'height',
+  'minWidth',
+  'minHeight',
+  'maxWidth',
+  'maxHeight',
+  'flexBasis',
+  'top',
+  'right',
+  'bottom',
+  'left',
+  'start',
+  'end',
+  'margin',
+  'marginTop',
+  'marginRight',
+  'marginBottom',
+  'marginLeft',
+  'marginStart',
+  'marginEnd',
+  'padding',
+  'paddingTop',
+  'paddingRight',
+  'paddingBottom',
+  'paddingLeft',
+  'paddingStart',
+  'paddingEnd',
+  'gap',
+  'rowGap',
+  'columnGap',
+  'borderWidth',
+  'borderTopWidth',
+  'borderRightWidth',
+  'borderBottomWidth',
+  'borderLeftWidth',
+  'borderStartWidth',
+  'borderEndWidth',
+  'borderRadius',
+  'outlineWidth',
+  'outlineOffset',
+  'fontSize',
+];
+
+const SCALED_LENGTHS = new Set(SCALED_LENGTH_PROPS);
+
+/**
+ * A resolved style in logical pixels → the same style in device pixels.
+ *
+ * This is the whole mechanism by which the display scale reaches layout,
+ * paint and text: it runs once, at the end of the style funnel
+ * (`_syncStyle` → `resolveComputedStyle` → here → `_retarget`), so yoga,
+ * every `this.style.borderRadius ?? 0` at a paint site, and the font size
+ * the text stack shapes at are all *already* device pixels and none of them
+ * ever multiplies again. Numbers scale; `'50%'`, `'auto'` and every other
+ * string mean the same thing at any density and pass through; `hitSlop`
+ * scales inside its number-or-per-side shape.
+ *
+ * Never mutates: `flattenStyle` hands back the app's own hoisted object
+ * when it can, and scaling it in place would corrupt the next render.
+ * Identity is preserved at scale 1 — the everyday case costs one compare.
+ */
+export function scaleResolvedStyle(style, scale) {
+  if (!style || !scale || scale === 1) return style;
+  let out = style;
+  for (const key of SCALED_LENGTH_PROPS) {
+    const value = style[key];
+    if (typeof value !== 'number' || value === 0) continue;
+    if (out === style) out = { ...style };
+    out[key] = value * scale;
+  }
+  const slop = style.hitSlop;
+  if (typeof slop === 'number') {
+    if (out === style) out = { ...style };
+    out.hitSlop = slop * scale;
+  } else if (slop && typeof slop === 'object') {
+    if (out === style) out = { ...style };
+    out.hitSlop = {
+      ...slop,
+      ...(typeof slop.top === 'number' && { top: slop.top * scale }),
+      ...(typeof slop.right === 'number' && { right: slop.right * scale }),
+      ...(typeof slop.bottom === 'number' && { bottom: slop.bottom * scale }),
+      ...(typeof slop.left === 'number' && { left: slop.left * scale }),
+    };
   }
   return out;
 }

--- a/src/svgnodes.js
+++ b/src/svgnodes.js
@@ -120,13 +120,18 @@ export class SvgNode extends Node {
     this._paintedRevision = -1;
   }
 
-  /** The viewBox is the natural size; `<image>`'s rules do the rest. */
+  /** The viewBox is the natural size; `<image>`'s rules do the rest —
+   * including the unit: natural sizes are logical pixels, multiplied to
+   * device here so an unsized drawing keeps its size relative to
+   * everything else. Unlike a bitmap it costs nothing: the document
+   * rasterizes at whatever box layout settles on (src/scale.js). */
   measureContent(constraints) {
     const view = this._ensureView();
+    const s = this.scale;
     return intrinsicSize(
       {
-        width: view?.naturalWidth ?? 0,
-        height: view?.naturalHeight ?? 0,
+        width: (view?.naturalWidth ?? 0) * s,
+        height: (view?.naturalHeight ?? 0) * s,
       },
       constraints,
     );

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -715,6 +715,13 @@ export interface ImageProps extends DrawnProps<DrawnNode> {
 
 /** What `onDraw` is told about the node it is painting. */
 export interface DrawInfo {
+  /**
+   * The node's box in **device pixels** — the browser's own canvas
+   * contract: the backing store is the panel's grid, and `scale` says how
+   * many of its pixels one logical pixel is worth (docs/scale.md). A
+   * drawing that works in fractions of the box needs neither; one that
+   * draws N-logical-px strokes multiplies by `scale`.
+   */
   width: number;
   height: number;
   /**
@@ -730,6 +737,8 @@ export interface DrawInfo {
   x: number;
   /** See {@link DrawInfo.x}. */
   y: number;
+  /** Device pixels per logical pixel — `useScale()`'s number. */
+  scale: number;
   node: DrawnNode;
 }
 

--- a/src/types/system.d.ts
+++ b/src/types/system.d.ts
@@ -48,6 +48,14 @@ export interface Screen {
   /** Hz to two decimals (`59.99`), or null. */
   readonly refreshRate: number | null;
   readonly rotation: 0 | 90 | 180 | 270;
+  /**
+   * This monitor's own device-pixels-per-logical-pixel (docs/scale.md).
+   * Where the desktop configured one factor it is the root's on every
+   * entry; where the hardware answered, a retina lid and an office monitor
+   * really do differ, and an app that places windows can honour that.
+   * Geometry above is logical, like every rect the renderer hands out.
+   */
+  readonly scale: number;
 }
 
 export interface Screens {
@@ -70,6 +78,20 @@ export interface Screens {
  * ```
  */
 export function useScreens(): Screens;
+
+/**
+ * Device pixels per logical pixel for this root — `1` on an ordinary
+ * display, `2` on a retina panel, fractional on desktops configured to
+ * 1.25/1.5. Resolved once by `createRoot` (see `RootOptions.scale`,
+ * docs/scale.md) and static for the life of the root, so there is nothing
+ * to subscribe to.
+ *
+ * Everything the renderer hands an app is already logical; reach for this
+ * only to talk about device pixels deliberately — sizing detail in a
+ * `<canvas onDraw>` (whose payload carries the same number), or showing
+ * the factor in a settings pane.
+ */
+export function useScale(): number;
 
 // --------------------------------------------------------------------------
 // Window state

--- a/test/scale-render.test.js
+++ b/test/scale-render.test.js
@@ -1,0 +1,227 @@
+// The display scale, end to end through the renderer: logical pixels on
+// every application-facing surface, device pixels on every internal one,
+// converted exactly once at each boundary (src/scale.js, docs/scale.md).
+//
+// Everything here runs at `scale: 2` against the headless mock and asserts
+// both sides of the boundary at once: the style an app wrote (logical) and
+// the geometry the server was told (device). The 1x world needs no tests of
+// its own — every suite in this directory is one, since 1x is the identity
+// fast path through the same code.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import { createRoot } from '../src/index.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+/** Render one tree at the given scale, hand back the mock window. */
+async function mount(element, { scale = 2 } = {}) {
+  const app = createMockApp();
+  const root = await createRoot({ app, scale });
+  root.render(element);
+  await tick();
+  const wnd = app.windows[0];
+  wnd?.flushFrame?.();
+  await tick();
+  return { app, root, wnd, node: wnd?._reactX11Node };
+}
+
+const child = (node, i = 0) => node.children[i];
+
+test('layout: styles are logical, yoga and abs are device', async () => {
+  const { root, wnd, node } = await mount(
+    h(
+      'window',
+      { title: 't', width: 300, height: 200 },
+      h(
+        'box',
+        { style: { margin: 10, width: 100, height: 50, padding: 8 } },
+        h('box', { style: { width: 20, height: 20 } }),
+      ),
+    ),
+  );
+  // the window is created at device size...
+  assert.strictEqual(wnd.width, 600);
+  assert.strictEqual(wnd.height, 400);
+  // ...the outer box lays out at twice its logical style...
+  const outer = child(node);
+  assert.deepStrictEqual(outer.abs, { x: 20, y: 20, width: 200, height: 100 });
+  // ...and padding positions the inner child in device pixels too
+  const inner = child(outer);
+  assert.deepStrictEqual(inner.abs, { x: 36, y: 36, width: 40, height: 40 });
+  await root.unmount();
+});
+
+test('the public rect APIs hand the logical numbers back', async () => {
+  const { root, node } = await mount(
+    h(
+      'window',
+      { title: 't', width: 300, height: 200 },
+      h('box', { style: { margin: 10, width: 100, height: 50 } }),
+    ),
+  );
+  const outer = child(node);
+  const [rect] = outer.getClientRects();
+  assert.deepStrictEqual(
+    { x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+    { x: 10, y: 10, width: 100, height: 50 },
+  );
+  let measured;
+  outer.measure((...args) => (measured = args));
+  assert.deepStrictEqual(measured, [10, 10, 100, 50, 10, 10]);
+  await root.unmount();
+});
+
+test('an auto-sized window measures its content in device pixels', async () => {
+  const { root, wnd } = await mount(
+    h(
+      'window',
+      { title: 'natural' },
+      h(
+        'box',
+        { style: { padding: 10, flexDirection: 'row', gap: 8 } },
+        h('box', { style: { width: 120, height: 40 } }),
+        h('box', { style: { width: 300, height: 80 } }),
+      ),
+    ),
+  );
+  // (10 + 120 + 8 + 300 + 10) x (10 + 80 + 10) logical, times two
+  assert.strictEqual(wnd.width, 896);
+  assert.strictEqual(wnd.height, 200);
+  await root.unmount();
+});
+
+test('WM size hints are written in device pixels', async () => {
+  const { root, wnd } = await mount(
+    h('window', {
+      title: 't',
+      width: 300,
+      height: 200,
+      minWidth: 150,
+      maxWidth: 500,
+      widthInc: 10,
+    }),
+  );
+  const hints = wnd.attributes?.sizeHints ?? wnd.sizeHints;
+  assert.strictEqual(hints.minWidth, 300);
+  assert.strictEqual(hints.maxWidth, 1000);
+  assert.strictEqual(hints.widthInc, 20);
+  await root.unmount();
+});
+
+test('font sizes resolve at device size, from a logical style and theme', async () => {
+  const { root, node } = await mount(
+    h(
+      'window',
+      { title: 't', width: 300, height: 200 },
+      h('text', { style: { fontSize: 14 } }, 'sized'),
+      h('text', null, 'themed'),
+    ),
+  );
+  const sized = child(node, 0);
+  const themed = child(node, 1);
+  assert.strictEqual(sized.resolvedTextStyle().size, 28);
+  // DefaultTheme.fontSize is 14 logical; the cascade enters device once,
+  // at the root (inheritedTextStyle)
+  assert.strictEqual(themed.resolvedTextStyle().size, 28);
+  await root.unmount();
+});
+
+test('pointer events arrive logical, in both x/y and localX/localY', async () => {
+  const seen = [];
+  const { root, wnd } = await mount(
+    h(
+      'window',
+      { title: 't', width: 300, height: 200 },
+      h('box', {
+        style: { margin: 10, width: 100, height: 50 },
+        onMouseDown: (ev) => seen.push([ev.x, ev.y, ev.localX, ev.localY]),
+      }),
+    ),
+  );
+  // a press at device (40, 40) is inside the box (device rect 20..220)
+  wnd.emit('mousedown', { x: 40, y: 40, keycode: 1, buttons: 0 });
+  assert.deepStrictEqual(seen, [[20, 20, 10, 10]]);
+  await root.unmount();
+});
+
+test('scroll speaks logical on the ref and in onScroll', async () => {
+  const events = [];
+  const { root, node } = await mount(
+    h(
+      'window',
+      { title: 't', width: 100, height: 100 },
+      h(
+        'box',
+        {
+          style: { width: 80, height: 80, overflow: 'scroll' },
+          onScroll: (ev) => events.push(ev),
+        },
+        h('box', { style: { width: 80, height: 300 } }),
+      ),
+    ),
+  );
+  const scroller = child(node);
+  scroller.scrollTo({ y: 30 });
+  // internal offset is device...
+  assert.strictEqual(scroller.scrollY, 60);
+  // ...the handler heard logical, including the extents
+  assert.strictEqual(events.length, 1);
+  assert.strictEqual(events[0].scrollY, 30);
+  assert.strictEqual(events[0].contentHeight, 300);
+  assert.strictEqual(events[0].viewportHeight, 80);
+  // scrollBy accumulates in the same unit and clamps in device
+  scroller.scrollBy({ y: 1000 });
+  assert.strictEqual(scroller.scrollY, (300 - 80) * 2);
+  await root.unmount();
+});
+
+test('explicit x/y window positions are logical desktop coordinates', async () => {
+  const { root, wnd } = await mount(
+    h('window', { title: 't', width: 100, height: 100, x: 50, y: 25 }),
+  );
+  assert.strictEqual(wnd.x, 100);
+  assert.strictEqual(wnd.y, 50);
+  await root.unmount();
+});
+
+test('an image or svg natural size is logical, the browser rule', async () => {
+  const { root, node } = await mount(
+    h(
+      'window',
+      { title: 't', width: 200, height: 100 },
+      h('image', {
+        // raw RGBA decodes synchronously (test/image-source.test.js), so
+        // the natural size is known at first layout: 4x2 *logical* px
+        src: { width: 4, height: 2, data: new Uint8Array(4 * 2 * 4) },
+        style: { alignSelf: 'flex-start' },
+      }),
+    ),
+  );
+  const image = child(node);
+  // occupies 4x2 logical like it would at 1x — which is 8x4 on the device
+  // grid, upscaled the way an <img> without srcset is
+  assert.deepStrictEqual([image.abs.width, image.abs.height], [8, 4]);
+  await root.unmount();
+});
+
+test('a fractional scale still lands layout on whole device pixels', async () => {
+  const { root, wnd, node } = await mount(
+    h(
+      'window',
+      { title: 't', width: 200, height: 100 },
+      h('box', { style: { width: 101, height: 33 } }),
+    ),
+    { scale: 1.5 },
+  );
+  assert.strictEqual(wnd.width, 300);
+  assert.strictEqual(wnd.height, 150);
+  const box = child(node);
+  // 101 x 1.5 = 151.5 and 33 x 1.5 = 49.5: yoga's grid rounding settles
+  // them onto integers, which is what keeps 1-logical-px borders crisp
+  assert.strictEqual(box.abs.width, Math.round(box.abs.width));
+  assert.strictEqual(box.abs.height, Math.round(box.abs.height));
+  await root.unmount();
+});

--- a/test/scale.test.js
+++ b/test/scale.test.js
@@ -1,0 +1,393 @@
+// The scale ladder's judgement calls, each pinned to the machine or lie it
+// was designed against (src/scale.js). Everything here is a pure function of
+// bytes and numbers — the one integration below runs the ladder against a
+// mock app to prove the headless default stays exactly 1.
+//
+// The QEMU EDID is not synthetic: it is the block a UTM guest on a 16"
+// MacBook actually serves, captured with `xrandr --verbose`. It claims
+// 870x550mm — a 40" panel — for a screen that is physically 16 inches,
+// which is the fabrication the whole `virtual` branch exists to catch.
+import { test } from 'node:test';
+import assert from 'node:assert';
+
+import {
+  parseResourceManager,
+  parseEdid,
+  classifyMm,
+  monitorScaleFromMetadata,
+  snapScale,
+  desktopScaleFromXSettings,
+  desktopScaleFromResources,
+  beginScale,
+  scaleOf,
+} from '../src/scale.js';
+
+// -------------------------------------------------------------- fixtures
+
+const QEMU_EDID = Buffer.from(
+  '00ffffffffffff004914341200000000' +
+    '2a180104a557377806ee91a3544c9926' +
+    '0f5054210800e1c0d1c0d100a940b300' +
+    '950081808140000000f7000a00408200' +
+    '2820000000000000000000fd00327d1e' +
+    'a0ff010a202020202020000000fc0051' +
+    '454d55204d6f6e69746f720a00000010' +
+    '00000000000000000000000000000281',
+  'hex',
+);
+
+/** A believable panel EDID: vendor + size in cm + a product-name block. */
+function panelEdid({ vendor = 0x0610 /* APP */, cmW = 34, cmH = 22 } = {}) {
+  const b = Buffer.alloc(128);
+  b.set([0x00, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x00], 0);
+  b.writeUInt16BE(vendor, 8);
+  b[21] = cmW;
+  b[22] = cmH;
+  b.set([0x00, 0x00, 0x00, 0xfc, 0x00], 54);
+  b.write('Color LCD\n', 59, 'latin1');
+  return b;
+}
+
+// --------------------------------------------------- RESOURCE_MANAGER text
+
+test('parseResourceManager reads xrdb lines and skips junk', () => {
+  const map = parseResourceManager(
+    '*customization:\t-color\n' +
+      'Xft.dpi:\t96\n' +
+      'Xcursor.size:\t0\n' +
+      '! a comment\n' +
+      'broken-line-no-colon\n' +
+      'Xft.rgba: none\n',
+  );
+  assert.strictEqual(map.get('Xft.dpi'), '96');
+  assert.strictEqual(map.get('Xft.rgba'), 'none');
+  assert.strictEqual(map.get('*customization'), '-color');
+  assert.strictEqual(map.size, 4);
+});
+
+// ------------------------------------------------------------------ EDID
+
+test('parseEdid reads the QEMU block: vendor RHT, fabricated size, virtual', () => {
+  const edid = parseEdid(QEMU_EDID);
+  assert.strictEqual(edid.vendor, 'RHT');
+  assert.strictEqual(edid.model, 'QEMU Monitor');
+  assert.strictEqual(edid.mmWidth, 870);
+  assert.strictEqual(edid.mmHeight, 550);
+  assert.strictEqual(edid.virtual, true);
+});
+
+test('parseEdid reads a real panel as not virtual', () => {
+  const edid = parseEdid(panelEdid());
+  assert.strictEqual(edid.vendor, 'APP');
+  assert.strictEqual(edid.model, 'Color LCD');
+  assert.strictEqual(edid.mmWidth, 340);
+  assert.strictEqual(edid.mmHeight, 220);
+  assert.strictEqual(edid.virtual, false);
+});
+
+test('parseEdid rejects short and headerless buffers', () => {
+  assert.strictEqual(parseEdid(Buffer.alloc(64)), null);
+  assert.strictEqual(parseEdid(Buffer.alloc(128)), null);
+  assert.strictEqual(parseEdid(null), null);
+});
+
+// ----------------------------------------------------------- millimetres
+
+test('classifyMm: honest panels are credible, including rotated ones', () => {
+  assert.strictEqual(
+    classifyMm(
+      { name: 'eDP-1', widthMM: 344, heightMM: 215 },
+      { width: 3456, height: 2234 },
+    ),
+    'credible',
+  );
+  // portrait CRTC on a landscape panel — a desk arrangement, not a lie
+  assert.strictEqual(
+    classifyMm(
+      { name: 'DP-1', widthMM: 597, heightMM: 336 },
+      { width: 1440, height: 2560 },
+    ),
+    'credible',
+  );
+});
+
+test('classifyMm: the well-known lies each get their name', () => {
+  assert.strictEqual(
+    classifyMm({ name: 'HDMI-1', widthMM: 0, heightMM: 0 }, null),
+    'absent',
+  );
+  assert.strictEqual(
+    classifyMm(
+      { name: 'HDMI-1', widthMM: 16, heightMM: 9 },
+      { width: 1920, height: 1080 },
+    ),
+    'aspect-as-size',
+  );
+  assert.strictEqual(
+    classifyMm(
+      { name: 'HDMI-1', widthMM: 160, heightMM: 90 },
+      { width: 1920, height: 1080 },
+    ),
+    'aspect-as-size',
+  );
+  // 4:3 millimetres against a 16:10 grid — one of them is wrong
+  assert.strictEqual(
+    classifyMm(
+      { name: 'DP-2', widthMM: 400, heightMM: 300 },
+      { width: 1920, height: 1200 },
+    ),
+    'aspect-mismatch',
+  );
+  assert.strictEqual(
+    classifyMm(
+      { name: 'Virtual-1', widthMM: 870, heightMM: 550 },
+      { width: 3456, height: 2168 },
+    ),
+    'virtual',
+  );
+  assert.strictEqual(
+    classifyMm(
+      { name: 'XWAYLAND0', widthMM: 597, heightMM: 336 },
+      { width: 1920, height: 1080 },
+    ),
+    'virtual',
+  );
+  assert.strictEqual(
+    classifyMm(
+      {
+        name: 'HDMI-1',
+        widthMM: 870,
+        heightMM: 550,
+        edid: parseEdid(QEMU_EDID),
+      },
+      { width: 3456, height: 2168 },
+    ),
+    'virtual',
+  );
+});
+
+// --------------------------------------------------- per-monitor verdicts
+
+const verdict = (m) => monitorScaleFromMetadata(m);
+
+test('credible millimetres follow the viewing-distance model', () => {
+  // the 16" MacBook panel itself: 255dpi in your lap → 2x, matching macOS
+  assert.strictEqual(
+    verdict({
+      name: 'eDP-1',
+      width: 3456,
+      height: 2234,
+      widthMM: 344,
+      heightMM: 215,
+    }).scale,
+    2,
+  );
+  // 27" QHD desk monitor: the canonical 1x
+  assert.strictEqual(
+    verdict({
+      name: 'DP-1',
+      width: 2560,
+      height: 1440,
+      widthMM: 597,
+      heightMM: 336,
+    }).scale,
+    1,
+  );
+  // 27" 4K: the canonical fractional
+  assert.strictEqual(
+    verdict({
+      name: 'DP-1',
+      width: 3840,
+      height: 2160,
+      widthMM: 597,
+      heightMM: 336,
+    }).scale,
+    1.5,
+  );
+  // 13" 1080p laptop: dense but readable → 1.25
+  assert.strictEqual(
+    verdict({
+      name: 'eDP-1',
+      width: 1920,
+      height: 1080,
+      widthMM: 294,
+      heightMM: 166,
+    }).scale,
+    1.25,
+  );
+  // a 55" TV is far away; its low density is correct, not small
+  assert.strictEqual(
+    verdict({
+      name: 'HDMI-1',
+      width: 3840,
+      height: 2160,
+      widthMM: 1218,
+      heightMM: 685,
+    }).scale,
+    1,
+  );
+  // portrait 4K measures like its landscape neighbour
+  assert.strictEqual(
+    verdict({
+      name: 'DP-2',
+      width: 2160,
+      height: 3840,
+      widthMM: 336,
+      heightMM: 597,
+    }).scale,
+    1.5,
+  );
+});
+
+test('the machine this was built on: QEMU lies, the resolution class answers', () => {
+  const v = verdict({
+    name: 'Virtual-1',
+    width: 3456,
+    height: 2168,
+    widthMM: 870,
+    heightMM: 550,
+    edid: parseEdid(QEMU_EDID),
+  });
+  assert.strictEqual(v.scale, 2);
+  assert.strictEqual(v.source, 'resolution');
+});
+
+test('without physical data only the confident retina call is made', () => {
+  // a VM window on an ordinary panel
+  assert.strictEqual(
+    verdict({
+      name: 'Virtual-1',
+      width: 1280,
+      height: 800,
+      widthMM: 338,
+      heightMM: 211,
+    }).scale,
+    1,
+  );
+  // a projector reports no size and hangs on a wall — 1x
+  assert.strictEqual(
+    verdict({
+      name: 'HDMI-1',
+      width: 1920,
+      height: 1080,
+      widthMM: 0,
+      heightMM: 0,
+    }).scale,
+    1,
+  );
+  // a 4K panel behind a KVM that stripped the EDID: still unmistakably dense
+  const kvm = verdict({
+    name: 'DP-1',
+    width: 3840,
+    height: 2160,
+    widthMM: 0,
+    heightMM: 0,
+  });
+  assert.strictEqual(kvm.scale, 2);
+  assert.strictEqual(kvm.source, 'resolution');
+  // 2560x1440 without millimetres could be a 27" desk monitor or a 13"
+  // retina lid; the desk monitor is the common case and gets the call
+  assert.strictEqual(
+    verdict({
+      name: 'DP-1',
+      width: 2560,
+      height: 1440,
+      widthMM: 0,
+      heightMM: 0,
+    }).scale,
+    1,
+  );
+});
+
+// ---------------------------------------------------------------- snapping
+
+test('snapScale lands on quarters inside [1, 3]', () => {
+  assert.strictEqual(snapScale(1.89), 2);
+  assert.strictEqual(snapScale(0.99), 1);
+  assert.strictEqual(snapScale(1.48), 1.5);
+  assert.strictEqual(snapScale(1.13), 1.25);
+  assert.strictEqual(snapScale(5), 3);
+  assert.strictEqual(snapScale(0.2), 1);
+  assert.strictEqual(snapScale(NaN), 1);
+});
+
+// -------------------------------------------------- desktop-configured rungs
+
+test('XSETTINGS: a configured factor answers, the untouched default does not', () => {
+  assert.deepStrictEqual(
+    desktopScaleFromXSettings(new Map([['Gdk/WindowScalingFactor', 2]])).scale,
+    2,
+  );
+  // what xfsettingsd publishes before anyone opens the dialog — no answer
+  assert.strictEqual(
+    desktopScaleFromXSettings(
+      new Map([
+        ['Gdk/WindowScalingFactor', 1],
+        ['Xft/DPI', 98304], // 96 x 1024, the wire's units
+      ]),
+    ),
+    null,
+  );
+  // a configured HiDPI desktop publishes 1024ths...
+  assert.strictEqual(
+    desktopScaleFromXSettings(new Map([['Xft/DPI', 196608]])).scale,
+    2,
+  );
+  // ...but a daemon writing plain dpi is read right too
+  assert.strictEqual(
+    desktopScaleFromXSettings(new Map([['Xft/DPI', 192]])).scale,
+    2,
+  );
+  assert.strictEqual(
+    desktopScaleFromXSettings(new Map([['Xft/DPI', 120 * 1024]])).scale,
+    1.25,
+  );
+  assert.strictEqual(desktopScaleFromXSettings(new Map()), null);
+  assert.strictEqual(desktopScaleFromXSettings(null), null);
+});
+
+test('RESOURCE_MANAGER: Xft.dpi answers except at the 96 default', () => {
+  assert.strictEqual(
+    desktopScaleFromResources(new Map([['Xft.dpi', '192']])).scale,
+    2,
+  );
+  assert.strictEqual(
+    desktopScaleFromResources(new Map([['Xft.dpi', '144']])).scale,
+    1.5,
+  );
+  assert.strictEqual(
+    desktopScaleFromResources(new Map([['Xft.dpi', '96']])),
+    null,
+  );
+  assert.strictEqual(desktopScaleFromResources(new Map()), null);
+});
+
+// ------------------------------------------------------------- the ladder
+
+test('a mock app resolves to exactly 1 — tests mean their numbers literally', async () => {
+  const app = {};
+  const session = await beginScale(app, 'auto');
+  assert.strictEqual(session.scale, 1);
+  assert.strictEqual(scaleOf(app), 1);
+});
+
+test('an explicit number pins the scale without a connection', async () => {
+  const app = {};
+  await beginScale(app, 1.5);
+  assert.strictEqual(scaleOf(app), 1.5);
+});
+
+test('REACT_X11_SCALE outranks even the explicit option', async () => {
+  process.env.REACT_X11_SCALE = '2';
+  try {
+    const app = {};
+    await beginScale(app, 1);
+    assert.strictEqual(scaleOf(app), 2);
+  } finally {
+    delete process.env.REACT_X11_SCALE;
+  }
+});
+
+test('scaleOf answers 1 for an app the ladder never ran on', () => {
+  assert.strictEqual(scaleOf({}), 1);
+});


### PR DESCRIPTION
Closes #116.

Every length an app writes — styles, `fontSize`, window geometry, the theme — is now a **logical pixel**, and the renderer multiplies exactly once on the way to the server. On the default 2x desktop a react-x11 app now renders the same physical size as every GTK/Qt app beside it, with text shaped at device size (sharper, not zoomed).

```jsx
const root = await createRoot();               // scale: 'auto' is the default
const root = await createRoot({ scale: 2 });   // pin it
REACT_X11_SCALE=1.5 node app.js                // the user outranks everybody
```

## How `'auto'` decides

A ladder ordered by "who is closest to a human having decided", consulting each rung only when the ones above said nothing (`src/scale.js`, full rationale in `docs/scale.md`):

1. **Environment** — `REACT_X11_SCALE` (wins over everything, the accessibility escape hatch), `GDK_SCALE`, `QT_SCALE_FACTOR`
2. **XSETTINGS** — `Gdk/WindowScalingFactor` when ≥ 2, `Xft/DPI` (1024ths on the wire; plain dpi read too)
3. **`RESOURCE_MANAGER`** — `Xft.dpi`, the xrdb convention
4. **RandR millimetres**, per output, under mutter's viewing-distance model (135dpi target under a 20″ diagonal, 110 over; quarter steps in [1, 3]) — with the millimetres **audited first**: VM EDIDs (RHT/VMW/VBX/PRL/…, "QEMU Monitor"), `Virtual-*`/`qxl`/`XWAYLAND*` connectors, aspect-ratio-as-size junk, physical/pixel aspect disagreement
5. **The resolution class** — when the mm are absent or caught lying, a ≥3000-wide or ≥1800-short-side grid is a retina panel; 2560×1440 stays 1x on purpose
6. **1**

The two judgement calls that make it work with zero config: `Xft.dpi: 96` / `WindowScalingFactor: 1` are read as *never configured* rather than "chose 1x" (xfsettingsd writes both unconditionally), and fabricated millimetres never reach the density math. The machine this was built against — a 16″ MacBook panel handed 1:1 to a UTM guest — defeats rungs 1–4 simultaneously (QEMU's EDID invents 870×550mm ≈ 100dpi; every configured source is an untouched 96) and lands correctly on 2x via rung 5. `npm run scale:probe` prints that whole table for any display; `REACT_X11_DEBUG_SCALE=1` traces the ladder in an app.

## Why not `ctx.scale()` (where this diverges from the issue)

The issue proposed yoga `pointScaleFactor` + a frame-wide paint transform. Reading ntk ruled that out twice over: its solid-fill/stroke/rounded-rect/glyph fast paths are **identity-transform gated** (a frame-wide scale would rasterize every box in the UI as polygons), and its text model deliberately sizes glyphs from the font while only *positioning* them through the transform — transform-scaled text moves without growing. `paintcache.js` even disables itself under a non-identity CTM.

So the architecture is **value multiplication with one conversion per boundary**:

- device inside: yoga runs directly in device px (ordinary whole-pixel rounding keeps 1-logical-px borders crisp at 1.5x), `node.abs`, paint, damage rects, the scroll blit, fonts shaped/measured at device size
- logical at every app-facing surface: the style funnel (`scaleResolvedStyle`, one multiply after state blocks/queries/flex expand), the theme's font size (entering the cascade once, at the root), window geometry (`windowAttributes`/`_measure`/hints/`setState`), string-parsed decorations (`boxShadow`/gradient px stops, scale in the memo key), and division on egress — synthetic events (`x`/`y`/`localX`/`localY`, wheel deltas, drag `screenX/Y`), `getClientRects`/`measure`, `onScroll`/`onViewport`/`onResize`, `useScreens`, `anchorRect`/`centerRect`/`anchorArea`, `scrollTo`/`scrollBy`
- deliberate device escape hatches, documented: `<canvas onDraw>` keeps the browser's device-pixel canvas contract and now carries `scale` in its payload; registered elements paint against device `abs`/`style` with `node.scale` for their own constants; ref fields `scrollX`/`contentHeight` stay device (the `onScroll` payload is the logical surface)

Internal constants that never pass through a style scale at their use sites (caret, scrollbars, autoscroll band, drag/double-click slop against device motion), and the widget set was audited for unit mixing (Slider drag math, SplitPane, Table keep-in-view, Select/Menu popup sizing via `measureLabel` now measuring at device size and answering logical).

## Multi-display

Rungs 4–5 run per output; each `useScreens()` entry carries its own `scale`, the root takes the primary's (largest when none is flagged) like GNOME on X11, and a root can be pinned. No mid-drag rescale across mismatched monitors and no mid-session re-resolve — static per root, documented with the reasoning (X11 has one coordinate space and no per-window scale protocol; Qt is the only toolkit that tries).

## Validation

- `test/scale.test.js` — 16 ladder tests, the QEMU EDID captured from the real guest as a fixture
- `test/scale-render.test.js` — 9 renderer-boundary tests at scale 2 and 1.5 (layout doubling, WM hints, font resolution from style and theme, logical events, scroll units, whole-device-pixel layout at fractional scale)
- all 1624 pre-existing tests pass unchanged — 1x is the identity fast path — plus lint, typecheck, prettier
- verified live on the UTM retina guest: the ladder resolves 2x from the resolution rung, a 340×260 logical widget window opens at 680×520 device with every control proportional and text re-shaped

New public API: `RootOptions.scale`, `useScale()`, `Screen.scale`, `DrawInfo.scale`, `node.scale`; new files `src/scale.js`, `src/scalehooks.js`, `scripts/scale-probe.mjs`, `docs/scale.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
