### PR TITLE
feat(bench): protocol-efficiency analyzer, hover scenario, CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,29 @@ jobs:
       # for the one that never finished.
       - run: npm test -- --test-reporter=spec
 
+  # The protocol-efficiency gate: every scenario in scripts/bench/protocol.js
+  # runs against the in-process X server and its requests, bytes, composite
+  # pixels, blocking round trips (stalls), repeated identical queries and
+  # short-lived resource churn are compared to the committed baseline. A PR
+  # that makes the renderer chattier — or reintroduces a create/free cycle
+  # the baseline shows removed — fails here with the metric that moved.
+  # Improvements sail through (--check only fails on increases); re-save the
+  # baseline on the base branch first, then on the PR, so the diff is honest.
+  bench:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      # One retry: the counts carry a little event-loop/GC jitter (see the
+      # header of scripts/bench/protocol.js) and the tolerances absorb it,
+      # but a real regression fails twice; a rare unlucky run does not.
+      - run: npm run bench -- --check || npm run bench -- --check
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/scripts/bench/baseline.json
+++ b/scripts/bench/baseline.json
@@ -1,138 +1,200 @@
 {
   "text: paragraph, no clip": {
-    "requests": 28,
-    "bytesOut": 5704,
-    "bytesIn": 32,
-    "replies": 1,
+    "requests": 29,
+    "bytesOut": 5712,
+    "bytesIn": 64,
+    "replies": 2,
     "composites": 1,
-    "compositePixels": 160000
+    "compositePixels": 160000,
+    "stalls": 0,
+    "dupQueries": 0,
+    "churn": 0
   },
   "text: paragraph, inside a rect clip": {
-    "requests": 30,
-    "bytesOut": 5744,
-    "bytesIn": 32,
-    "replies": 1,
+    "requests": 32,
+    "bytesOut": 5760,
+    "bytesIn": 64,
+    "replies": 2,
     "composites": 1,
-    "compositePixels": 160000
+    "compositePixels": 160000,
+    "stalls": 0,
+    "dupQueries": 0,
+    "churn": 1
   },
   "clips: 40 nested rect clips with text": {
-    "requests": 147,
-    "bytesOut": 92948,
-    "bytesIn": 32,
-    "replies": 1,
+    "requests": 148,
+    "bytesOut": 92956,
+    "bytesIn": 64,
+    "replies": 2,
     "composites": 1,
-    "compositePixels": 160000
+    "compositePixels": 160000,
+    "stalls": 0,
+    "dupQueries": 0,
+    "churn": 0
   },
   "shapes: 50 filled rounded boxes": {
-    "requests": 111,
-    "bytesOut": 6316,
-    "bytesIn": 32,
-    "replies": 1,
+    "requests": 112,
+    "bytesOut": 6324,
+    "bytesIn": 64,
+    "replies": 2,
     "composites": 1,
-    "compositePixels": 160000
+    "compositePixels": 160000,
+    "stalls": 0,
+    "dupQueries": 0,
+    "churn": 0
   },
   "shapes: 24 rounded bordered cards, 2px border": {
-    "requests": 107,
-    "bytesOut": 6776,
-    "bytesIn": 32,
-    "replies": 1,
+    "requests": 108,
+    "bytesOut": 6784,
+    "bytesIn": 64,
+    "replies": 2,
     "composites": 1,
-    "compositePixels": 160000
+    "compositePixels": 160000,
+    "stalls": 0,
+    "dupQueries": 0,
+    "churn": 0
   },
   "shapes: 24 rounded bordered cards, 1px border": {
-    "requests": 107,
-    "bytesOut": 6776,
-    "bytesIn": 32,
-    "replies": 1,
+    "requests": 108,
+    "bytesOut": 6784,
+    "bytesIn": 64,
+    "replies": 2,
     "composites": 1,
-    "compositePixels": 160000
+    "compositePixels": 160000,
+    "stalls": 0,
+    "dupQueries": 0,
+    "churn": 0
   },
   "mount: window with 40 boxes and labels": {
-    "requests": 104,
-    "bytesOut": 3992,
-    "bytesIn": 896,
-    "replies": 26,
+    "requests": 110,
+    "bytesOut": 4116,
+    "bytesIn": 1024,
+    "replies": 30,
     "composites": 21,
-    "compositePixels": 298240
+    "compositePixels": 298240,
+    "stalls": 0,
+    "dupQueries": 4,
+    "churn": 0
   },
   "scroll: 10 notches over 500 rows": {
-    "requests": 332,
-    "bytesOut": 12120,
-    "bytesIn": 576,
-    "replies": 18,
+    "requests": 341,
+    "bytesOut": 12264,
+    "bytesIn": 800,
+    "replies": 25,
     "composites": 81,
-    "compositePixels": 644480
+    "compositePixels": 644480,
+    "stalls": 1,
+    "dupQueries": 1,
+    "churn": 40
   },
   "svg: 100 unchanged icons, full repaint": {
-    "requests": 106,
-    "bytesOut": 3704,
-    "bytesIn": 128,
-    "replies": 4,
+    "requests": 108,
+    "bytesOut": 3724,
+    "bytesIn": 224,
+    "replies": 7,
     "composites": 101,
-    "compositePixels": 200000
+    "compositePixels": 200000,
+    "stalls": 0,
+    "dupQueries": 1,
+    "churn": 0
   },
   "svg: 10 unchanged icons in a damaged row": {
-    "requests": 40,
-    "bytesOut": 940,
-    "bytesIn": 96,
-    "replies": 3,
+    "requests": 44,
+    "bytesOut": 992,
+    "bytesIn": 224,
+    "replies": 7,
     "composites": 11,
-    "compositePixels": 10292
+    "compositePixels": 10292,
+    "stalls": 0,
+    "dupQueries": 1,
+    "churn": 2
   },
   "window: 10 pure moves": {
-    "requests": 43,
-    "bytesOut": 476,
-    "bytesIn": 1376,
-    "replies": 33,
+    "requests": 44,
+    "bytesOut": 492,
+    "bytesIn": 1472,
+    "replies": 36,
     "composites": 0,
-    "compositePixels": 0
+    "compositePixels": 0,
+    "stalls": 11,
+    "dupQueries": 11,
+    "churn": 0
+  },
+  "hover: checkbox enter/leave x5": {
+    "requests": 204,
+    "bytesOut": 5352,
+    "bytesIn": 1312,
+    "replies": 31,
+    "composites": 10,
+    "compositePixels": 3240,
+    "stalls": 31,
+    "dupQueries": 0,
+    "churn": 20
   },
   "shapes: 24 gradient+shadow cards, 5 full repaints": {
     "requests": 381,
     "bytesOut": 475564,
-    "bytesIn": 352,
-    "replies": 11,
+    "bytesIn": 384,
+    "replies": 12,
     "composites": 245,
-    "compositePixels": 2020640
+    "compositePixels": 2020640,
+    "stalls": 1,
+    "dupQueries": 0,
+    "churn": 0
   },
   "update: 5 color flips, no layout": {
-    "requests": 48,
-    "bytesOut": 968,
-    "bytesIn": 224,
-    "replies": 7,
+    "requests": 53,
+    "bytesOut": 1048,
+    "bytesIn": 384,
+    "replies": 12,
     "composites": 10,
-    "compositePixels": 25020
+    "compositePixels": 25020,
+    "stalls": 2,
+    "dupQueries": 1,
+    "churn": 10
   },
   "update: 5 absolute box moves (layout)": {
-    "requests": 47,
-    "bytesOut": 952,
-    "bytesIn": 224,
-    "replies": 7,
+    "requests": 52,
+    "bytesOut": 1032,
+    "bytesIn": 384,
+    "replies": 12,
     "composites": 10,
-    "compositePixels": 31320
+    "compositePixels": 31320,
+    "stalls": 4,
+    "dupQueries": 1,
+    "churn": 10
   },
   "scene: 5 drag steps over 300 cells in one node": {
-    "requests": 239,
-    "bytesOut": 45076,
-    "bytesIn": 288,
-    "replies": 9,
+    "requests": 242,
+    "bytesOut": 45124,
+    "bytesIn": 416,
+    "replies": 13,
     "composites": 133,
-    "compositePixels": 75896
+    "compositePixels": 75896,
+    "stalls": 3,
+    "dupQueries": 1,
+    "churn": 10
   },
   "scene: 5 pan steps over 374 cells in one node": {
-    "requests": 983,
-    "bytesOut": 177444,
-    "bytesIn": 320,
-    "replies": 10,
+    "requests": 987,
+    "bytesOut": 177520,
+    "bytesIn": 480,
+    "replies": 15,
     "composites": 606,
-    "compositePixels": 298517
+    "compositePixels": 298517,
+    "stalls": 1,
+    "dupQueries": 1,
+    "churn": 20
   },
   "scene: 5 pan steps with a HUD strip beside them": {
-    "requests": 3059,
-    "bytesOut": 610088,
-    "bytesIn": 352,
-    "replies": 11,
+    "requests": 3063,
+    "bytesOut": 610140,
+    "bytesIn": 480,
+    "replies": 15,
     "composites": 1971,
-    "compositePixels": 1097691
+    "compositePixels": 1097691,
+    "stalls": 0,
+    "dupQueries": 1,
+    "churn": 30
   }
 }

--- a/scripts/bench/protocol.js
+++ b/scripts/bench/protocol.js
@@ -1,11 +1,24 @@
 // Protocol-traffic benchmark: how much X11 work does each scenario cost?
 //
-//   npm run bench            # print the current numbers
-//   npm run bench -- --save  # rewrite the committed baseline
-//   npm run bench -- --check # fail if a metric regressed past its tolerance
+//   npm run bench                        # print the current numbers
+//   npm run bench -- --save              # rewrite the committed baseline
+//   npm run bench -- --check             # fail if a metric regressed
+//   npm run bench -- --hotspots          # per-scenario efficiency detail:
+//                                        #   the request-name histogram, and
+//                                        #   which requests stalled, repeated
+//                                        #   or churned
+//   npm run bench -- --record-dir <dir>  # one .x11cap per scenario, openable
+//                                        #   and diffable with x11vis
 //
 // Runs against node-x11's in-process pure-JS X server, so the numbers are
-// deterministic and need no $DISPLAY.
+// stable and need no $DISPLAY. Stable, not perfectly deterministic: the
+// client runs on a live event loop, so wall-clock timers (ntk's frame
+// pacing, the 5ms output-buffer age limit) and GC (ntk frees X resources
+// from FinalizationRegistry callbacks) move a few requests between runs,
+// and `stalls` depends on whether a reply happened to land before the next
+// request went out. The --check tolerances below are sized to that noise —
+// they exist to catch step changes (a new per-frame resource cycle, a new
+// serialized round trip), not single-request jitter.
 //
 // Metrics, and why each is here:
 //
@@ -16,19 +29,57 @@
 //                        request is 36 bytes whether it touches ten pixels
 //                        or the whole surface), and it is where "correct
 //                        but does far too much pixel work" shows up
-import { readFileSync, writeFileSync } from 'node:fs';
+//   stalls               blocking round trips: replies that arrived while
+//                        their request was the last thing sent, so nothing
+//                        was pipelined behind it. The bench's own settle()
+//                        fences are a fixed floor per scenario; growth means
+//                        a new serialized wait crept into the path
+//   dupQueries           repeated identical queries — a reply-carrying
+//                        request whose exact bytes were already sent on the
+//                        connection (a cacheable InternAtom, GetProperty,
+//                        QueryExtension...)
+//   churn                short-lived server resources: created and freed
+//                        inside the measured window (the "full-window mask
+//                        pixmap rebuilt every frame" class). Steady-state
+//                        interactions should reuse, i.e. stay near 0
+//
+// The in-process server answers in microseconds, so `stalls` counts the
+// round trips but cannot price them — a fence that costs nothing here costs
+// a full RTT on a real display. Grading latency work needs the real-display
+// lane (x11vis --record / --diff); this lane keeps the counts honest.
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import React from 'react';
 import xserver from 'x11/lib/xserver/index.js';
 import { createClient, StaticFontSource } from 'ntk';
 
-import { compositePixels, countStream } from './xcount.js';
+import {
+  analysisMark,
+  captureLines,
+  compositePixels,
+  countStream,
+  windowAnalysis,
+} from './xcount.js';
 
 process.env.REACT_X11_NO_AUTORUN = '1';
 const { createRoot } = await import('../../src/index.js');
 const { registerElement } = await import('../../src/host.js');
 const { Node } = await import('../../src/node.js');
+const { Checkbox } = await import('../../src/components/index.js');
+
+const args = process.argv.slice(2);
+const recordDir = args.includes('--record-dir')
+  ? args[args.indexOf('--record-dir') + 1]
+  : null;
+if (
+  args.includes('--record-dir') &&
+  (!recordDir || recordDir.startsWith('--'))
+) {
+  console.error('--record-dir needs a directory argument');
+  process.exit(1);
+}
+if (recordDir) mkdirSync(recordDir, { recursive: true });
 
 const require = createRequire(import.meta.url);
 const fontDir = join(
@@ -48,14 +99,14 @@ async function connect() {
   const server = xserver.createServer({ width: W, height: H });
   const [serverEnd, clientEnd] = xserver.createStreamPair();
   server.addClientStream(serverEnd);
-  const { stats } = countStream(clientEnd);
+  const { stats } = countStream(clientEnd, { record: Boolean(recordDir) });
   const source = new StaticFontSource();
   source.add(readFileSync(join(fontDir, 'KaTeX_Main-Regular.ttf')), {
     family: 'Bench',
   });
   source.alias('sans-serif', 'Bench');
   const app = await createClient({ stream: clientEnd, fontSource: source });
-  return { app, stats };
+  return { app, stats, server };
 }
 
 const settle = (app) =>
@@ -66,11 +117,11 @@ const settle = (app) =>
  * tree, say — whose cost is drained and *not* measured, so `run` can time
  * an interaction rather than a mount. */
 async function measure(name, fn) {
-  const { app, stats } = await connect();
+  const { app, stats, server } = await connect();
   const x11Root = await createRoot({ app });
   await settle(app);
   if (typeof fn !== 'function') {
-    await fn.prepare(app, x11Root);
+    await fn.prepare(app, x11Root, server);
     await settle(app);
     fn = fn.run;
   }
@@ -80,6 +131,7 @@ async function measure(name, fn) {
     bytesIn: stats.bytesIn,
     replies: stats.replies,
     composites: stats.composites.length,
+    analysis: analysisMark(stats),
   };
   // A scenario that throws used to be reported as a very fast scenario:
   // React swallows the render error, the renderer logs it, and what lands
@@ -91,7 +143,7 @@ async function measure(name, fn) {
   };
   process.on('uncaughtException', onUncaught);
   try {
-    await fn(app, x11Root);
+    await fn(app, x11Root, server);
   } catch (err) {
     failure ??= err;
   } finally {
@@ -109,6 +161,7 @@ async function measure(name, fn) {
     { composites: stats.composites.slice(0, mark.composites) },
     app.display.Render.majorOpcode,
   );
+  const analysis = windowAnalysis(stats, mark.analysis);
   const result = {
     requests: stats.requests - mark.requests,
     bytesOut: stats.bytesOut - mark.bytesOut,
@@ -116,10 +169,21 @@ async function measure(name, fn) {
     replies: stats.replies - mark.replies,
     composites: after.composites - beforePx.composites,
     compositePixels: after.pixels - beforePx.pixels,
+    stalls: analysis.stalls,
+    dupQueries: analysis.dupQueries,
+    churn: analysis.churn,
   };
+  hotspots[name] = analysis;
+  if (recordDir) {
+    const file = join(recordDir, `${name.replace(/[^a-z0-9]+/gi, '-')}.x11cap`);
+    writeFileSync(file, captureLines(stats, `bench: ${name}`));
+  }
   await app.close();
   return [name, result];
 }
+
+/** Per-scenario efficiency detail, filled by measure(), shown by --hotspots. */
+const hotspots = {};
 
 // --- scenarios ---------------------------------------------------------
 
@@ -719,6 +783,96 @@ const SCENARIOS = [
     })(),
   ],
   [
+    // The interaction from the protocol-efficiency audit: the
+    // pointer crosses onto a <Checkbox> row and off again, five times. Real
+    // injection through the server (EnterNotify/MotionNotify, hit testing,
+    // useControl's hover state, cursor updates), so this window carries
+    // everything a hover costs on the wire today: the hover commit's
+    // damage-clipped repaint of the well — including ntk's full-window A8
+    // clip-mask build/destroy cycle, which is what the `churn` column pins —
+    // plus the cursor write and its void-sync round trip, which is what
+    // `stalls` pins beyond the bench's own fences.
+    'hover: checkbox enter/leave x5',
+    (() => {
+      let ctl;
+      let over;
+      let away;
+      const findRole = (node, role) => {
+        if (node.props?.role === role) return node;
+        for (const child of node.children ?? []) {
+          const hit = findRole(child, role);
+          if (hit) return hit;
+        }
+        return null;
+      };
+      // Let the injected events propagate (stream pair delivers on a
+      // setImmediate), let React commit the hover state (in Node the
+      // scheduler flushes on setImmediate too), then paint and fence. No
+      // wall-clock timers: a setTimeout lap would race the deliveries and
+      // make the interleaving — and with it the stall count — machine-speed
+      // dependent. One settle per pump, so the fence count is fixed.
+      const pump = async (app) => {
+        for (let i = 0; i < 4; i++) {
+          await new Promise((resolve) => setImmediate(resolve));
+          await new Promise((resolve) => setImmediate(resolve));
+          ctl.frame();
+        }
+        await settle(app);
+      };
+      return {
+        prepare: async (app, x11Root, server) => {
+          ctl = await mounted(
+            x11Root,
+            React.createElement(
+              'window',
+              { width: W, height: H, style: { backgroundColor: '#2f3640' } },
+              React.createElement(
+                'box',
+                { style: { flexGrow: 1, padding: 16, gap: 12 } },
+                React.createElement(
+                  'text',
+                  { style: { fontSize: 12, color: '#dcdde1' } },
+                  'size',
+                ),
+                React.createElement(
+                  Checkbox,
+                  { checked: false, onChange: () => {} },
+                  'Shout it',
+                ),
+              ),
+            ),
+          );
+          // pace on the fence alone, like the pure-moves scenario: the
+          // in-process server does not model Present completions
+          ctl.root.window.frameClock = 'fence';
+          ctl.root.window.frameInterval = 0;
+          const row = findRole(ctl.root, 'checkbox');
+          if (!row?.abs) throw new Error('checkbox row not laid out');
+          const origin = ctl.root.window._screenOrigin ?? {
+            x: ctl.root.window.x ?? 0,
+            y: ctl.root.window.y ?? 0,
+          };
+          over = {
+            x: Math.round(origin.x + row.abs.x + row.abs.width / 2),
+            y: Math.round(origin.y + row.abs.y + row.abs.height / 2),
+          };
+          away = { x: origin.x + 5, y: origin.y + 5 };
+          // start from a known spot so the first crossing is a crossing
+          server.injectPointerMove(away.x, away.y);
+          await pump(app);
+        },
+        run: async (app, x11Root, server) => {
+          for (let i = 0; i < 5; i++) {
+            server.injectPointerMove(over.x, over.y);
+            await pump(app);
+            server.injectPointerMove(away.x, away.y);
+            await pump(app);
+          }
+        },
+      };
+    })(),
+  ],
+  [
     // What the two decorations cost per frame (issue #345): 24 cards, each
     // with a gradient background and a blurred shadow, repainted in full
     // five times. The gradient is a source picture the fill samples, so it
@@ -958,11 +1112,12 @@ const SCENARIOS = [
 
 const results = {};
 for (const [name, fn] of SCENARIOS) {
+  // progress to stderr so a hung CI run says which scenario it was in
+  process.stderr.write(`· ${name}\n`);
   const [key, value] = await measure(name, fn);
   results[key] = value;
 }
 
-const args = process.argv.slice(2);
 if (args.includes('--save')) {
   writeFileSync(baselinePath, `${JSON.stringify(results, null, 2)}\n`);
   console.log(`wrote ${baselinePath}`);
@@ -970,12 +1125,27 @@ if (args.includes('--save')) {
 
 const pad = (v, n) => String(v).padStart(n);
 console.log(
-  `${'scenario'.padEnd(38)} ${pad('reqs', 6)} ${pad('bytesOut', 9)} ${pad('replies', 8)} ${pad('composites', 11)} ${pad('Mpx', 8)}`,
+  `${'scenario'.padEnd(38)} ${pad('reqs', 6)} ${pad('bytesOut', 9)} ${pad('replies', 8)} ${pad('composites', 11)} ${pad('Mpx', 8)} ${pad('stalls', 7)} ${pad('dupQ', 5)} ${pad('churn', 6)}`,
 );
 for (const [name, r] of Object.entries(results)) {
   console.log(
-    `${name.padEnd(38)} ${pad(r.requests, 6)} ${pad(r.bytesOut, 9)} ${pad(r.replies, 8)} ${pad(r.composites, 11)} ${pad((r.compositePixels / 1e6).toFixed(2), 8)}`,
+    `${name.padEnd(38)} ${pad(r.requests, 6)} ${pad(r.bytesOut, 9)} ${pad(r.replies, 8)} ${pad(r.composites, 11)} ${pad((r.compositePixels / 1e6).toFixed(2), 8)} ${pad(r.stalls, 7)} ${pad(r.dupQueries, 5)} ${pad(r.churn, 6)}`,
   );
+}
+
+if (args.includes('--hotspots')) {
+  const list = (entries, limit = 8) =>
+    entries
+      .slice(0, limit)
+      .map(([key, n]) => `${key} ×${n}`)
+      .join(', ');
+  for (const [name, a] of Object.entries(hotspots)) {
+    console.log(`\n${name}`);
+    console.log(`  requests   ${list(a.byName)}`);
+    if (a.stallsBy.length) console.log(`  stalled on ${list(a.stallsBy)}`);
+    if (a.dupsBy.length) console.log(`  repeated   ${list(a.dupsBy)}`);
+    if (a.churnBy.length) console.log(`  churned    ${list(a.churnBy)}`);
+  }
 }
 
 if (args.includes('--check')) {
@@ -986,19 +1156,38 @@ if (args.includes('--check')) {
     console.error('\nno baseline — run `npm run bench -- --save` first');
     process.exit(1);
   }
-  // generous, so this catches step changes rather than noise
-  const TOLERANCE = 1.15;
+  // A scenario in only one of the two sets means the baseline is stale —
+  // and a renamed scenario would otherwise silently lose its gate.
+  const missing = [
+    ...Object.keys(results).filter((name) => !baseline[name]),
+    ...Object.keys(baseline).filter((name) => !results[name]),
+  ];
+  if (missing.length) {
+    console.error('\nbaseline out of date — run `npm run bench -- --save`:');
+    for (const name of missing) console.error(`  ${name}`);
+    process.exit(1);
+  }
+  // Per-metric [factor, slack], sized to the noise documented in the file
+  // header so the gate catches step changes rather than jitter. The slack
+  // also means a zero baseline tolerates a few units before failing — the
+  // price of not flaking; a real regression class (a per-frame cycle, a
+  // per-step round trip) lands far past it.
+  const GATES = {
+    requests: [1.15, 8],
+    bytesOut: [1.15, 256],
+    composites: [1.15, 2],
+    compositePixels: [1.15, 2],
+    stalls: [1.25, 5],
+    dupQueries: [1.15, 2],
+    churn: [1.15, 4],
+  };
   const regressions = [];
   for (const [name, now] of Object.entries(results)) {
     const was = baseline[name];
-    if (!was) continue;
-    for (const metric of [
-      'requests',
-      'bytesOut',
-      'composites',
-      'compositePixels',
-    ]) {
-      const limit = was[metric] * TOLERANCE + 2;
+    for (const [metric, [factor, slack]] of Object.entries(GATES)) {
+      // a baseline from before a metric existed gates nothing for it
+      if (was[metric] === undefined) continue;
+      const limit = was[metric] * factor + slack;
       if (now[metric] > limit) {
         regressions.push(
           `${name} — ${metric}: ${was[metric]} -> ${now[metric]}`,

--- a/scripts/bench/xcount.js
+++ b/scripts/bench/xcount.js
@@ -8,7 +8,170 @@
 //               real 32-bit length follows.
 //   replies   — first byte 1, extra length (4-byte units) at [4..8)
 //   errors    — first byte 0, always 32 bytes
-//   events    — anything else, 32 bytes (GenericEvent carries extra)
+//   events    — anything else, 32 bytes; GenericEvent (35) carries an
+//               extra length at [4..8) exactly like a reply
+//
+// Beyond the totals, the parse feeds a protocol-efficiency analysis
+// (`stats.analysis`) aimed at the waste categories a request count hides:
+//
+//   stalls        — blocking round trips: a reply that arrives while its
+//                   request was the *last* thing the client sent, i.e. the
+//                   client had nothing pipelined behind it. One per frame is
+//                   the fence clock working; growth is new serialized waits.
+//   dupQueries    — repeated identical queries: a reply-carrying request
+//                   whose exact bytes were already sent on this connection
+//                   (a cacheable InternAtom / GetProperty / QueryExtension).
+//                   GetInputFocus is exempt: it is the sync primitive, its
+//                   repeats are fences and void-syncs, priced under stalls.
+//   churnPairs    — short-lived resources: an XID created *and* freed inside
+//                   the window (pixmap/picture/gc/region/…), with the
+//                   create's parameters kept so "same-sized pixmap rebuilt
+//                   every frame" is visible as repeats of one churn key.
+//
+// Requests are named (core table + extension majors learned live from
+// QueryExtension replies, minor tables for the extensions this stack uses),
+// so a histogram says *which* request type moved, not just "+40 requests".
+//
+// `countStream(stream, { record: true })` additionally keeps every chunk,
+// hex-encoded with timing and direction, in x11vis's `.x11cap` line-JSON
+// shape (`captureLines()`), so a bench run can be opened — and diffed —
+// in the protocol visualizer.
+
+const CORE_NAMES = {
+  1: 'CreateWindow',
+  2: 'ChangeWindowAttributes',
+  3: 'GetWindowAttributes',
+  4: 'DestroyWindow',
+  5: 'DestroySubwindows',
+  7: 'ReparentWindow',
+  8: 'MapWindow',
+  10: 'UnmapWindow',
+  12: 'ConfigureWindow',
+  14: 'GetGeometry',
+  15: 'QueryTree',
+  16: 'InternAtom',
+  17: 'GetAtomName',
+  18: 'ChangeProperty',
+  19: 'DeleteProperty',
+  20: 'GetProperty',
+  21: 'ListProperties',
+  22: 'SetSelectionOwner',
+  23: 'GetSelectionOwner',
+  24: 'ConvertSelection',
+  25: 'SendEvent',
+  26: 'GrabPointer',
+  27: 'UngrabPointer',
+  28: 'GrabButton',
+  31: 'GrabKeyboard',
+  33: 'GrabKey',
+  35: 'AllowEvents',
+  38: 'QueryPointer',
+  40: 'TranslateCoordinates',
+  41: 'WarpPointer',
+  42: 'SetInputFocus',
+  43: 'GetInputFocus',
+  45: 'OpenFont',
+  46: 'CloseFont',
+  47: 'QueryFont',
+  48: 'QueryTextExtents',
+  53: 'CreatePixmap',
+  54: 'FreePixmap',
+  55: 'CreateGC',
+  56: 'ChangeGC',
+  59: 'SetClipRectangles',
+  60: 'FreeGC',
+  61: 'ClearArea',
+  62: 'CopyArea',
+  63: 'CopyPlane',
+  65: 'PolyLine',
+  66: 'PolySegment',
+  67: 'PolyRectangle',
+  69: 'FillPoly',
+  70: 'PolyFillRectangle',
+  72: 'PutImage',
+  73: 'GetImage',
+  84: 'AllocColor',
+  85: 'AllocNamedColor',
+  93: 'CreateCursor',
+  94: 'CreateGlyphCursor',
+  95: 'FreeCursor',
+  97: 'QueryBestSize',
+  98: 'QueryExtension',
+  99: 'ListExtensions',
+  101: 'GetKeyboardMapping',
+  113: 'KillClient',
+  127: 'NoOperation',
+};
+
+const EXT_MINORS = {
+  RENDER: {
+    0: 'QueryVersion',
+    1: 'QueryPictFormats',
+    4: 'CreatePicture',
+    5: 'ChangePicture',
+    6: 'SetPictureClipRectangles',
+    7: 'FreePicture',
+    8: 'Composite',
+    10: 'Trapezoids',
+    11: 'Triangles',
+    17: 'CreateGlyphSet',
+    18: 'ReferenceGlyphSet',
+    19: 'FreeGlyphSet',
+    20: 'AddGlyphs',
+    22: 'FreeGlyphs',
+    23: 'CompositeGlyphs8',
+    24: 'CompositeGlyphs16',
+    25: 'CompositeGlyphs32',
+    26: 'FillRectangles',
+    27: 'CreateCursor',
+    28: 'SetPictureTransform',
+    30: 'SetPictureFilter',
+    32: 'AddTraps',
+    33: 'CreateSolidFill',
+    34: 'CreateLinearGradient',
+    35: 'CreateRadialGradient',
+    36: 'CreateConicalGradient',
+  },
+  XFIXES: {
+    0: 'QueryVersion',
+    2: 'SelectSelectionInput',
+    3: 'SelectCursorInput',
+    5: 'CreateRegion',
+    10: 'DestroyRegion',
+    11: 'SetRegion',
+  },
+  Present: {
+    0: 'QueryVersion',
+    1: 'Pixmap',
+    2: 'NotifyMSC',
+    3: 'SelectInput',
+    4: 'QueryCapabilities',
+  },
+  'BIG-REQUESTS': { 0: 'Enable' },
+  'XC-MISC': { 0: 'GetVersion', 1: 'GetXIDRange', 2: 'GetXIDList' },
+};
+
+// The sync primitive. Its repeats are fences/void-syncs — flow control, not
+// cacheable data — so it is priced as stalls, never as duplicate queries.
+const SYNC_OPCODE = 43;
+
+/** FNV-1a over a request's bytes: identical request ⇒ identical hash. */
+function fnv1a(buf, len) {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < len; i++) {
+    h ^= buf[i];
+    h = (h + ((h << 1) + (h << 4) + (h << 7) + (h << 8) + (h << 24))) >>> 0;
+  }
+  return h;
+}
+
+/** Widen a 16-bit wire sequence number against the full request count. */
+function widenSeq(low, current) {
+  let full = (current & ~0xffff) | low;
+  if (full > current) full -= 0x10000;
+  return full;
+}
+
 /**
  * Attach counters to an existing X11 stream without replacing it: wrap
  * `write` for the client->server direction and intercept the 'data' event
@@ -16,7 +179,23 @@
  * owning backpressure, which is easy to get subtly wrong and would make
  * the measurement itself a variable.
  */
-export function countStream(inner) {
+export function countStream(inner, { record = false } = {}) {
+  const analysis = {
+    seq: 0, // requests parsed so far (widened sequence space)
+    lastWritten: 0, // seq of the most recent request on the wire
+    reqLog: [], // 1-based by seq: { op, minor, name, len, hash }
+    stalls: 0,
+    stallList: [], // { seq, name }
+    dupQueries: 0,
+    dupList: [], // { seq, name }
+    queryHashes: new Map(), // hash -> { name, count }
+    churnPairs: 0,
+    churned: [], // { type, key, createdSeq, freedSeq }
+    live: new Map(), // xid -> { type, key, seq }
+    extNames: new Map(), // major opcode -> extension name
+    pendingQueryExt: new Map(), // seq -> extension name asked about
+  };
+
   const stats = {
     requests: 0,
     bytesOut: 0,
@@ -28,12 +207,151 @@ export function countStream(inner) {
     // (major, minor, w, h) for every 36-byte request, so Render Composite
     // pixel area can be totalled once the extension opcode is known
     composites: [],
+    analysis,
+    captureRecords: record ? [] : null,
   };
 
   let outBuf = Buffer.alloc(0);
   let inBuf = Buffer.alloc(0);
   let handshakeOut = false; // first client message is the connection setup
   let handshakeIn = false;
+
+  const nameOf = (op, minor) => {
+    const ext = analysis.extNames.get(op);
+    if (ext) return `${ext}:${EXT_MINORS[ext]?.[minor] ?? `minor${minor}`}`;
+    return CORE_NAMES[op] ?? `op${op}`;
+  };
+
+  const trackResource = (op, minor, buf, base) => {
+    // `base` skips the BIG-REQUESTS extended length word when present, so
+    // argument offsets are the same for both framings
+    const xid = (at) => buf.readUInt32LE(base + at);
+    const ext = analysis.extNames.get(op);
+    let create = null; // { id, type, key }
+    let free = null;
+    if (ext === 'RENDER') {
+      if (minor === 4) create = { id: xid(4), type: 'picture', key: 'picture' };
+      else if (minor === 33)
+        create = { id: xid(4), type: 'picture', key: 'solid-fill' };
+      else if (minor === 34 || minor === 35 || minor === 36)
+        create = { id: xid(4), type: 'picture', key: 'gradient' };
+      else if (minor === 17)
+        create = { id: xid(4), type: 'glyphset', key: 'glyphset' };
+      else if (minor === 7 || minor === 19) free = xid(4);
+    } else if (ext === 'XFIXES') {
+      if (minor === 5) create = { id: xid(4), type: 'region', key: 'region' };
+      else if (minor === 10) free = xid(4);
+    } else if (!ext) {
+      switch (op) {
+        case 1:
+          create = { id: xid(4), type: 'window', key: 'window' };
+          break;
+        case 4:
+          free = xid(4);
+          break;
+        case 53:
+          create = {
+            id: xid(4),
+            type: 'pixmap',
+            key: `pixmap ${buf.readUInt16LE(base + 12)}x${buf.readUInt16LE(base + 14)}x${buf[1]}`,
+          };
+          break;
+        case 54:
+          free = xid(4);
+          break;
+        case 55:
+          create = { id: xid(4), type: 'gc', key: 'gc' };
+          break;
+        case 60:
+          free = xid(4);
+          break;
+        case 45:
+          create = { id: xid(4), type: 'font', key: 'font' };
+          break;
+        case 46:
+          free = xid(4);
+          break;
+        case 93:
+        case 94:
+          create = { id: xid(4), type: 'cursor', key: 'cursor' };
+          break;
+        case 95:
+          free = xid(4);
+          break;
+      }
+    }
+    if (create) {
+      analysis.live.set(create.id, {
+        type: create.type,
+        key: create.key,
+        seq: analysis.seq,
+      });
+    } else if (free != null) {
+      const entry = analysis.live.get(free);
+      if (entry) {
+        analysis.live.delete(free);
+        analysis.churnPairs += 1;
+        analysis.churned.push({
+          type: entry.type,
+          key: entry.key,
+          createdSeq: entry.seq,
+          freedSeq: analysis.seq,
+        });
+      }
+    }
+  };
+
+  const onRequest = (buf, len) => {
+    const op = buf[0];
+    const minor = buf[1];
+    // BIG-REQUESTS framing: length field 0, real length in an extra word at
+    // [4..8) — every argument after the header shifts by 4 bytes
+    const base = buf.readUInt16LE(2) === 0 ? 4 : 0;
+    analysis.seq += 1;
+    analysis.lastWritten = analysis.seq;
+    const entry = {
+      op,
+      minor,
+      name: nameOf(op, minor),
+      len,
+      hash: fnv1a(buf, len),
+    };
+    analysis.reqLog[analysis.seq] = entry;
+    if (op === 98 && len >= base + 8) {
+      const n = buf.readUInt16LE(base + 4);
+      if (len >= base + 8 + n) {
+        analysis.pendingQueryExt.set(
+          analysis.seq,
+          buf.toString('latin1', base + 8, base + 8 + n),
+        );
+      }
+    }
+    trackResource(op, minor, buf, base);
+  };
+
+  const onReply = (buf) => {
+    const seq = widenSeq(buf.readUInt16LE(2), analysis.seq);
+    const entry = analysis.reqLog[seq];
+    if (seq === analysis.lastWritten) {
+      analysis.stalls += 1;
+      analysis.stallList.push({ seq, name: entry?.name ?? '?' });
+    }
+    const asked = analysis.pendingQueryExt.get(seq);
+    if (asked !== undefined) {
+      analysis.pendingQueryExt.delete(seq);
+      if (buf[8]) analysis.extNames.set(buf[9], asked);
+    }
+    if (entry && entry.op !== SYNC_OPCODE) {
+      const known = analysis.queryHashes.get(entry.hash);
+      if (known) {
+        known.count += 1;
+        analysis.dupQueries += 1;
+        analysis.dupList.push({ seq, name: entry.name });
+      } else {
+        analysis.queryHashes.set(entry.hash, { name: entry.name, count: 1 });
+      }
+    }
+  };
 
   const countRequests = () => {
     for (;;) {
@@ -66,6 +384,7 @@ export function countStream(inner) {
           outBuf.readUInt16LE(34),
         ]);
       }
+      onRequest(outBuf, len);
       outBuf = outBuf.subarray(len);
     }
   };
@@ -88,19 +407,39 @@ export function countStream(inner) {
         total = 32 + inBuf.readUInt32LE(4) * 4;
         if (inBuf.length < total) return;
         stats.replies += 1;
+        onReply(inBuf);
       } else if (type === 0) {
         stats.errors += 1;
       } else {
+        // GenericEvent (XGE, e.g. Present CompleteNotify) carries an extra
+        // length like a reply; every other event is a fixed 32 bytes.
+        if ((type & 0x7f) === 35) {
+          total = 32 + inBuf.readUInt32LE(4) * 4;
+          if (inBuf.length < total) return;
+        }
         stats.events += 1;
       }
       inBuf = inBuf.subarray(total);
     }
   };
 
+  const recordChunk = (dir, buf) => {
+    stats.captureRecords.push(
+      JSON.stringify({
+        c: 0,
+        d: dir,
+        m: Math.round(performance.now()),
+        w: Date.now(),
+        b: buf.toString('hex'),
+      }),
+    );
+  };
+
   const write = inner.write.bind(inner);
   inner.write = (chunk, ...rest) => {
     const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
     stats.bytesOut += buf.length;
+    if (stats.captureRecords) recordChunk('c2s', buf);
     outBuf = Buffer.concat([outBuf, buf]);
     countRequests();
     return write(chunk, ...rest);
@@ -111,6 +450,7 @@ export function countStream(inner) {
     if (name === 'data') {
       const buf = args[0];
       stats.bytesIn += buf.length;
+      if (stats.captureRecords) recordChunk('s2c', buf);
       inBuf = Buffer.concat([inBuf, buf]);
       countReplies();
     }
@@ -118,6 +458,83 @@ export function countStream(inner) {
   };
 
   return { stream: inner, stats };
+}
+
+/**
+ * Snapshot the analysis counters, so a caller can measure a window: take a
+ * mark, run the interaction, and hand both to `windowAnalysis`.
+ */
+export function analysisMark(stats) {
+  const a = stats.analysis;
+  return {
+    seq: a.seq,
+    stalls: a.stalls,
+    dupQueries: a.dupQueries,
+    churnPairs: a.churnPairs,
+  };
+}
+
+/**
+ * The efficiency numbers for everything after `mark`, plus the hotspot
+ * detail behind each number: which request names stalled, which queries
+ * repeated, which resources churned (keyed by their creation parameters,
+ * so "same-size pixmap rebuilt per frame" reads as one line with a count).
+ */
+export function windowAnalysis(stats, mark) {
+  const a = stats.analysis;
+  const byName = new Map();
+  for (let seq = mark.seq + 1; seq <= a.seq; seq++) {
+    const entry = a.reqLog[seq];
+    if (entry) byName.set(entry.name, (byName.get(entry.name) ?? 0) + 1);
+  }
+  const tally = (list, keyOf) => {
+    const out = new Map();
+    for (const item of list) {
+      const key = keyOf(item);
+      out.set(key, (out.get(key) ?? 0) + 1);
+    }
+    return [...out.entries()].sort((x, y) => y[1] - x[1]);
+  };
+  const inWindow = (seq) => seq > mark.seq;
+  // Churn means created AND freed inside the window — a run phase tearing
+  // down something prepare built is a one-off, not a create/free cycle, so
+  // it must not count (and must not trip the gate when a cleanup moves).
+  const churned = a.churned.filter(
+    (c) => inWindow(c.createdSeq) && inWindow(c.freedSeq),
+  );
+  return {
+    stalls: a.stalls - mark.stalls,
+    dupQueries: a.dupQueries - mark.dupQueries,
+    churn: churned.length,
+    byName: [...byName.entries()].sort((x, y) => y[1] - x[1]),
+    stallsBy: tally(
+      a.stallList.filter((s) => inWindow(s.seq)),
+      (s) => s.name,
+    ),
+    dupsBy: tally(
+      a.dupList.filter((d) => inWindow(d.seq)),
+      (d) => d.name,
+    ),
+    churnBy: tally(churned, (c) => c.key),
+  };
+}
+
+/**
+ * The recorded session as `.x11cap` text (x11vis's line-JSON format:
+ * header line, then one hex-encoded chunk per line), so bench runs can be
+ * opened with `x11vis --open` and compared with `x11vis --diff`.
+ */
+export function captureLines(stats, target = 'react-x11 bench (in-process)') {
+  if (!stats.captureRecords) {
+    throw new Error('countStream was not created with { record: true }');
+  }
+  const header = JSON.stringify({
+    x11cap: 1,
+    savedAt: Date.now(),
+    target,
+    connections: [],
+  });
+  return `${[header, ...stats.captureRecords].join('\n')}\n`;
 }
 
 /**

--- a/test/protocol-analysis.test.js
+++ b/test/protocol-analysis.test.js
@@ -1,0 +1,323 @@
+// The protocol-efficiency analyzer behind `npm run bench`: stalls (blocking
+// round trips), repeated identical queries, short-lived resource churn, the
+// named request histogram, and the .x11cap export.
+//
+// Two layers on purpose. The synthetic tests feed hand-built wire bytes
+// through `countStream`, so every rule is pinned against a stream whose
+// ground truth is written next to it — including the negative cases (a
+// pipelined reply is NOT a stall, a differing query is NOT a dup), which is
+// what catches a broken rule that flags everything or nothing. The
+// integration test then runs the real client against the in-process server,
+// so the encodings the analyzer parses are the ones node-x11 actually
+// writes (BIG-REQUESTS framing, extension init, id allocation).
+import assert from 'node:assert';
+import { EventEmitter } from 'node:events';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { test } from 'node:test';
+
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient, StaticFontSource } from 'ntk';
+
+import {
+  analysisMark,
+  captureLines,
+  countStream,
+  windowAnalysis,
+} from '../scripts/bench/xcount.js';
+
+// --- synthetic wire builders -------------------------------------------
+
+function fakeStream() {
+  const stream = new EventEmitter();
+  stream.write = () => true;
+  return stream;
+}
+
+/** A counted stream with the connection handshake already consumed. */
+function started(options) {
+  const { stream, stats } = countStream(fakeStream(), options);
+  stream.write(Buffer.alloc(12)); // setup request, no auth strings
+  const setupReply = Buffer.alloc(8);
+  setupReply[0] = 1; // success, zero extra words
+  stream.emit('data', setupReply);
+  return { stream, stats };
+}
+
+/** A request: 4-byte header plus 32-bit argument words. */
+function req(op, minor = 0, words = []) {
+  const b = Buffer.alloc(4 + words.length * 4);
+  b[0] = op;
+  b[1] = minor;
+  b.writeUInt16LE(1 + words.length, 2);
+  words.forEach((w, i) => b.writeUInt32LE(w >>> 0, 4 + i * 4));
+  return b;
+}
+
+/** A reply to sequence number `seq`, with `extra` trailing words. */
+function reply(seq, extra = 0, patch = null) {
+  const b = Buffer.alloc(32 + extra * 4);
+  b[0] = 1;
+  b.writeUInt16LE(seq & 0xffff, 2);
+  b.writeUInt32LE(extra, 4);
+  patch?.(b);
+  return b;
+}
+
+const GET_INPUT_FOCUS = 43;
+const GET_PROPERTY = 20;
+
+// --- stalls -------------------------------------------------------------
+
+test('a reply to the last-sent request is a stall; a pipelined one is not', () => {
+  const { stream, stats } = started();
+  // nothing pipelined: the client sent one request and its reply lands
+  stream.write(req(GET_INPUT_FOCUS));
+  stream.emit('data', reply(1));
+  assert.strictEqual(stats.analysis.stalls, 1);
+  // two requests in flight: the first reply arrives with #3 already sent,
+  // so the client was never blocked on it — not a stall. The second IS the
+  // last thing sent when its reply lands, so it stalls.
+  stream.write(req(GET_INPUT_FOCUS));
+  stream.write(req(GET_INPUT_FOCUS));
+  stream.emit('data', reply(2));
+  assert.strictEqual(stats.analysis.stalls, 1);
+  stream.emit('data', reply(3));
+  assert.strictEqual(stats.analysis.stalls, 2);
+  assert.deepStrictEqual(
+    stats.analysis.stallList.map((s) => s.seq),
+    [1, 3],
+  );
+});
+
+// --- repeated identical queries ----------------------------------------
+
+test('an identical answered query repeats; different bytes do not', () => {
+  const { stream, stats } = started();
+  stream.write(req(GET_PROPERTY, 0, [7, 42, 0, 0, 0]));
+  stream.emit('data', reply(1));
+  stream.write(req(GET_PROPERTY, 0, [7, 42, 0, 0, 0])); // same bytes
+  stream.emit('data', reply(2));
+  stream.write(req(GET_PROPERTY, 0, [7, 43, 0, 0, 0])); // different property
+  stream.emit('data', reply(3));
+  assert.strictEqual(stats.analysis.dupQueries, 1);
+  assert.strictEqual(stats.analysis.dupList[0].name, 'GetProperty');
+});
+
+test('GetInputFocus repeats are sync traffic, never duplicate queries', () => {
+  const { stream, stats } = started();
+  for (let seq = 1; seq <= 3; seq++) {
+    stream.write(req(GET_INPUT_FOCUS));
+    stream.emit('data', reply(seq));
+  }
+  assert.strictEqual(stats.analysis.dupQueries, 0);
+  assert.strictEqual(stats.analysis.stalls, 3);
+});
+
+// --- resource churn -----------------------------------------------------
+
+/** CreatePixmap pid on drawable, sized w x h at `depth`. */
+function createPixmap(pid, w, h, depth) {
+  const b = req(53, depth, [pid, 1, 0]);
+  b.writeUInt16LE(w, 12);
+  b.writeUInt16LE(h, 14);
+  return b;
+}
+
+test('created-then-freed resources churn, keyed by their parameters', () => {
+  const { stream, stats } = started();
+  stream.write(createPixmap(0x2001, 420, 380, 8));
+  stream.write(req(54, 0, [0x2001])); // FreePixmap
+  stream.write(createPixmap(0x2001, 420, 380, 8)); // the recycled-id rebuild
+  stream.write(req(54, 0, [0x2001]));
+  stream.write(createPixmap(0x2002, 16, 16, 24)); // still live: not churn
+  assert.strictEqual(stats.analysis.churnPairs, 2);
+  const windowed = windowAnalysis(stats, {
+    seq: 0,
+    stalls: 0,
+    dupQueries: 0,
+    churnPairs: 0,
+  });
+  assert.deepStrictEqual(windowed.churnBy, [['pixmap 420x380x8', 2]]);
+});
+
+test('freeing a pre-window resource is teardown, not window churn', () => {
+  const { stream, stats } = started();
+  stream.write(createPixmap(0x2001, 420, 380, 8)); // created before the mark
+  const mark = analysisMark(stats);
+  stream.write(req(54, 0, [0x2001])); // freed inside the window
+  stream.write(createPixmap(0x2002, 8, 8, 24)); // a real in-window cycle
+  stream.write(req(54, 0, [0x2002]));
+  const windowed = windowAnalysis(stats, mark);
+  assert.strictEqual(windowed.churn, 1);
+  assert.deepStrictEqual(windowed.churnBy, [['pixmap 8x8x24', 1]]);
+});
+
+test('stall and dup detail lists respect the measurement window', () => {
+  const { stream, stats } = started();
+  stream.write(req(GET_PROPERTY, 0, [7, 42, 0, 0, 0]));
+  stream.emit('data', reply(1)); // pre-mark stall and first sighting
+  const mark = analysisMark(stats);
+  stream.write(req(GET_PROPERTY, 0, [7, 42, 0, 0, 0]));
+  stream.emit('data', reply(2)); // in-window: stall + duplicate of #1
+  const windowed = windowAnalysis(stats, mark);
+  assert.strictEqual(windowed.stalls, 1);
+  assert.strictEqual(windowed.dupQueries, 1);
+  assert.deepStrictEqual(windowed.stallsBy, [['GetProperty', 1]]);
+  assert.deepStrictEqual(windowed.dupsBy, [['GetProperty', 1]]);
+});
+
+test('BIG-REQUESTS framing shifts argument offsets by one word', () => {
+  const { stream, stats } = started();
+  // CreatePixmap in extended framing: 16-bit length 0, real length at
+  // [4..8), every argument 4 bytes later than in the classic frame
+  const b = Buffer.alloc(20);
+  b[0] = 53;
+  b[1] = 24; // depth
+  b.writeUInt16LE(0, 2);
+  b.writeUInt32LE(5, 4); // 20 bytes in 4-byte units
+  b.writeUInt32LE(0x2001, 8); // pid
+  b.writeUInt32LE(1, 12); // drawable
+  b.writeUInt16LE(64, 16); // width
+  b.writeUInt16LE(32, 18); // height
+  stream.write(b);
+  stream.write(req(54, 0, [0x2001]));
+  assert.strictEqual(stats.analysis.churned[0].key, 'pixmap 64x32x24');
+});
+
+// --- extension learning and naming --------------------------------------
+
+/** QueryExtension by name, and the reply granting it `major`. */
+function queryExtension(stream, seq, name, major) {
+  const padded = (name.length + 3) & ~3;
+  const b = Buffer.alloc(8 + padded);
+  b[0] = 98;
+  b.writeUInt16LE((8 + padded) / 4, 2);
+  b.writeUInt16LE(name.length, 4);
+  b.write(name, 8, 'latin1');
+  stream.write(b);
+  stream.emit(
+    'data',
+    reply(seq, 0, (r) => {
+      r[8] = 1; // present
+      r[9] = major;
+    }),
+  );
+}
+
+test('extension majors are learned from QueryExtension and name requests', () => {
+  const { stream, stats } = started();
+  queryExtension(stream, 1, 'RENDER', 130);
+  stream.write(req(130, 26, [1, 2, 3])); // RENDER FillRectangles
+  stream.write(req(130, 99, [1])); // unnamed minor
+  const windowed = windowAnalysis(stats, {
+    seq: 0,
+    stalls: 0,
+    dupQueries: 0,
+    churnPairs: 0,
+  });
+  const names = new Map(windowed.byName);
+  assert.strictEqual(names.get('RENDER:FillRectangles'), 1);
+  assert.strictEqual(names.get('RENDER:minor99'), 1);
+});
+
+test('RENDER create/free cycles churn as pictures', () => {
+  const { stream, stats } = started();
+  queryExtension(stream, 1, 'RENDER', 130);
+  stream.write(req(130, 4, [0x3001, 0x2001, 0x11, 0])); // CreatePicture
+  stream.write(req(130, 7, [0x3001])); // FreePicture
+  assert.strictEqual(stats.analysis.churnPairs, 1);
+  assert.strictEqual(stats.analysis.churned[0].key, 'picture');
+});
+
+// --- GenericEvent framing ----------------------------------------------
+
+test('a long GenericEvent does not desync the reply parser', () => {
+  const { stream, stats } = started();
+  stream.write(req(GET_INPUT_FOCUS));
+  // XGE (e.g. Present CompleteNotify) with 2 extra words, then the reply.
+  // Without the extended-length read the parser would treat the event as 32
+  // bytes and misparse its tail as the next message.
+  const xge = Buffer.alloc(40);
+  xge[0] = 35;
+  xge.writeUInt32LE(2, 4);
+  stream.emit('data', Buffer.concat([xge, reply(1)]));
+  assert.strictEqual(stats.events, 1);
+  assert.strictEqual(stats.replies, 1);
+  assert.strictEqual(stats.analysis.stalls, 1);
+});
+
+// --- .x11cap export -----------------------------------------------------
+
+test('captureLines round-trips the wire bytes in x11vis line-JSON', () => {
+  const { stream, stats } = started({ record: true });
+  const request = req(GET_INPUT_FOCUS);
+  stream.write(request);
+  stream.emit('data', reply(1));
+  const lines = captureLines(stats, 'test').trim().split('\n');
+  const header = JSON.parse(lines[0]);
+  assert.strictEqual(header.x11cap, 1);
+  const records = lines.slice(1).map((line) => JSON.parse(line));
+  // setup out, setup reply, request, reply — in order, with directions
+  assert.deepStrictEqual(
+    records.map((r) => r.d),
+    ['c2s', 's2c', 'c2s', 's2c'],
+  );
+  assert.strictEqual(records[2].b, request.toString('hex'));
+  for (const r of records) {
+    assert.strictEqual(r.c, 0);
+    assert.strictEqual(typeof r.m, 'number');
+    assert.strictEqual(typeof r.w, 'number');
+  }
+});
+
+// --- against the real client and server ---------------------------------
+
+const require = createRequire(import.meta.url);
+const fontDir = join(
+  dirname(require.resolve('katex/package.json')),
+  'dist',
+  'fonts',
+);
+
+test('the analyzer prices real node-x11 traffic', async () => {
+  const server = xserver.createServer({ width: 200, height: 200 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const { stats } = countStream(clientEnd);
+  const source = new StaticFontSource();
+  source.add(readFileSync(join(fontDir, 'KaTeX_Main-Regular.ttf')), {
+    family: 'Bench',
+  });
+  const app = await createClient({ stream: clientEnd, fontSource: source });
+  try {
+    const X = app.X;
+    await new Promise((resolve) => X.GetInputFocus(resolve));
+    const mark = analysisMark(stats);
+
+    // an awaited sync with nothing pipelined behind it is a blocking RT
+    await new Promise((resolve) => X.GetInputFocus(resolve));
+
+    // two interns of one name in the same tick: node-x11 only caches after
+    // the reply, so both hit the wire — the duplicate the analyzer flags
+    await Promise.all([
+      new Promise((resolve) => X.InternAtom(false, 'BENCH_DUP_ATOM', resolve)),
+      new Promise((resolve) => X.InternAtom(false, 'BENCH_DUP_ATOM', resolve)),
+    ]);
+
+    // a pixmap created and freed inside the window is churn, keyed by size
+    const pixmap = app.createPixmap({ width: 32, height: 16, depth: 24 });
+    pixmap.destroy();
+    await new Promise((resolve) => X.GetInputFocus(resolve));
+
+    const windowed = windowAnalysis(stats, mark);
+    assert.ok(windowed.stalls >= 1, `stalls: ${windowed.stalls}`);
+    assert.strictEqual(windowed.dupQueries, 1);
+    assert.deepStrictEqual(windowed.dupsBy, [['InternAtom', 1]]);
+    const churn = new Map(windowed.churnBy);
+    assert.strictEqual(churn.get('pixmap 32x16x24'), 1);
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
A protocol trace of one pointer hover over a `<Checkbox>` — 38 requests across two frames for a rounded rectangle in a different colour — turned out to be mostly waste, and nothing in the bench could see any of it. This adds the measurement that can.

## What the bench could not see

`scripts/bench/protocol.js` counted requests, bytes and composite pixels. Those are blind to three kinds of protocol waste that dominate an interaction:

- **serialized round trips** — a reply the client waited on with nothing pipelined behind it;
- **repeated identical requests** — a query whose exact bytes already went out on this connection;
- **short-lived resources** — a pixmap or picture created and freed inside one frame, where a cache would do.

And no scenario moved the pointer, so hover traffic had no coverage at all.

## The analyzer

`countStream` in `scripts/bench/xcount.js` now parses what it counts and derives three metrics, each gated:

| metric | meaning |
| --- | --- |
| `stalls` | blocking round trips: a reply that arrived while its request was the last thing sent |
| `dupQueries` | repeated identical queries: exact-byte repeat of an already-answered request (`GetInputFocus` exempt — it is the sync primitive, its repeats are fences) |
| `churn` | short-lived resources: an XID created *and* freed inside the measured window, keyed by creation parameters |

Requests are named — core table plus extension majors learned live from `QueryExtension` replies — so a regression reads as `RENDER:CreatePicture ×10`, not "+40 requests". `GenericEvent` framing now reads its extended length, which the old parser did not: it would have desynced on the first Present-clocked stream it saw.

`churn` keys on creation parameters, so per-frame resource cycling reads as one line with a count:

```
hover: checkbox enter/leave x5
  requests   RENDER:FillRectangles ×40, RENDER:SetPictureClipRectangles ×40, GetInputFocus ×34, ...
  stalled on GetInputFocus ×34
  churned    picture ×10, pixmap 400x400x8 ×10
```

## The hover scenario

`hover: checkbox enter/leave x5` drives a real pointer through the in-process server onto a `<Checkbox>` row and off again — `injectPointerMove`, so it exercises hit testing, `useControl`'s hover state and the cursor path, not a synthetic `emit`. It pins what a hover costs today: the damage-clipped repaint with its full-window a8 clip-mask build/destroy cycle per frame, four clip stamps per frame, the cursor write and its round trip.

Pointed at the existing scenarios, the analyzer independently found the same shapes the trace showed: `pixmap 400x400x8` churn in every partial-repaint scenario, `TranslateCoordinates ×10` repeats in `window: 10 pure moves`, and duplicate `InternAtom`/`QueryExtension` at mount.

## Interop and CI

- `--hotspots` prints the per-scenario detail above.
- `--record-dir <dir>` writes one `.x11cap` per scenario in x11vis's line-JSON format — verified loadable and diffable by `x11vis --diff`, so bench runs and real-display captures speak one format.
- A `bench` job runs `npm run bench -- --check` on every PR. The committed baseline gated nothing before this.

## On determinism

The header used to claim the numbers are deterministic. They are stable, not deterministic: the client runs on a live event loop, so ntk's frame pacing, the output buffer's 5 ms age limit and GC (ntk frees X resources from `FinalizationRegistry` callbacks) move a few requests between runs, and `stalls` depends on whether a reply landed before the next request went out. Measured across repeated runs on one machine, that is ±1–3 requests and ±2 stalls on the interaction scenarios.

So the header now says that, per-metric tolerances are sized to it, and the CI step retries once — a real regression fails twice, an unlucky run does not. The gate also now fails on a scenario present in only one of results/baseline, which previously dropped that scenario's gating silently on a rename.

## Tests

`test/protocol-analysis.test.js`, 12 tests. The rules are pinned against hand-built wire bytes with the ground truth written beside them, including the negative cases — a pipelined reply is not a stall, differing bytes are not a duplicate, a resource freed but created before the window is teardown rather than churn — then one integration test runs the real client against the in-process server so the encodings parsed are the ones node-x11 actually writes. Mutation-checked: breaking the stall rule or the XGE length read fails the tests that name them.

## What this measures, and what it cannot

The in-process server answers in microseconds. This lane counts round trips honestly but cannot price them — a fence that is free here costs a full RTT on a real display. Grading latency work still needs a capture against a real server through the x11vis proxy; this lane keeps the counts from regressing.

## Note for sequencing

Branch `claude/x11-protocol-efficiency-e486a7` carries the first fixes from the same audit (event mask at CreateWindow, concurrent startup probes) and touches `scripts/bench/protocol.js` and `baseline.json` too. Landing this one first and rebasing that one on top keeps its diff self-documenting: its win then shows up directly in the new `stalls`/`churn` columns.

Follow-ups filed against ntk from the same audit — the fixes that make the hover trace shrink, all pixel-identical: sidorares/ntk#307 (`_fillRect` builds a window-sized a8 mask under a rectangular clip), sidorares/ntk#308 (the picture clip is stamped and reset per drawing), sidorares/ntk#309 (no-op callbacks inject a round trip per cursor change).
