### PR TITLE
fix: stop tracking the node_modules symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-node_modules/
+# No trailing slash: a slash matches a directory only, and this repo once
+# committed a `node_modules` *symlink* (a worktree pointing at the main
+# checkout) straight past the ignore rule.
+node_modules
 *.log
 .DS_Store
 

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/laplace/Projects/react-x11/node_modules


### PR DESCRIPTION
`.gitignore` said `node_modules/`, and a trailing slash matches a directory only. A worktree set up with `node_modules` as a **symlink** to the main checkout therefore walked straight past the rule, and the link was committed in #379:

```
$ git ls-files node_modules
node_modules
$ git show master:node_modules
/Users/laplace/Projects/react-x11/node_modules
```

So every clone starts with a dangling `node_modules` symlink pointing into one machine's home directory, before the first install has run.

Scope of the damage is small — `files` is `["src"]` so nothing published carries it, and no CI job reads the working tree for cleanliness — but `npm ci` against a dangling symlink at that path is a confusing place to start.

Two lines: drop the trailing slash so the rule matches the symlink as well as the directory, and `git rm --cached` the link.