### PR TITLE
perf(events): select XI2 on the first wheel, not at creation

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -357,12 +357,30 @@ which can only ever say one. It is the flag to branch on for anything that
 wants to animate a scroll — a whole notch is worth easing towards, a stream
 of measured pixels is not.
 
-**Nothing is opted into.** A `<window>` selects XI2 when it is created and
-falls back to the wheel buttons where the server has none, so a handler
-written against `deltaY` works on both and the difference is the value.
-`<window xi2={false}>` opts out. A `<popup>` is on the buttons deliberately —
-it holds a pointer grab, and a core grab delivers core events — so a scroll
-inside an open menu moves a notch at a time. Needs ntk >= 7.5.0.
+**Nothing is opted into.** A `<window>` selects XI2 the first time it is
+scrolled and falls back to the wheel buttons where the server has none, so a
+handler written against `deltaY` works on both and the difference is the
+value. A `<popup>` is on the buttons deliberately — it holds a pointer grab,
+and a core grab delivers core events — so a scroll inside an open menu moves
+a notch at a time. Needs ntk >= 7.5.0.
+
+The selection waits for the first wheel because it is not free. An XI2
+selection _replaces_ the core one for the same event type, and an `XIMotion`
+is around 136 bytes on the wire where a core `MotionNotify` is 32 — measured
+against Xorg 21.1. Motion is the one event that keeps arriving at frame rate
+for as long as the pointer is over the window, so selecting it up front bills
+every window about 8 KB/s of pointer traffic while the pointer crosses it,
+including the dialogs, toolbars and forms that never see a wheel at all.
+
+What waiting costs is the opening event of the first gesture in a window's
+life, and it costs less than it sounds: a mouse wheel reports whole notches
+either way, and ntk treats the first valuator event as a seed with no
+distance to report, so under an eager selection that same first event moves
+nothing at all.
+
+`<window xi2>` selects at creation anyway, for an app whose whole interaction
+is a touchpad and which wants the very first flick smooth. `<window
+xi2={false}>` refuses the selection for the window's whole life.
 
 Shift turns a vertical scroll sideways for a device with only one axis (the
 convention every toolkit follows); a device that reports its own horizontal

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "filedialog:probe": "node scripts/filedialog-probe.mjs",
     "a11y:probe": "node scripts/a11y-probe.mjs",
     "scale:probe": "node scripts/scale-probe.mjs",
+    "xi2:probe": "node scripts/xi2-probe.mjs",
     "globalmenu:host": "node scripts/globalmenu-host.mjs",
     "devtools:proxy": "node scripts/devtools-proxy.mjs",
     "examples:fonts": "tsx examples/fonts.jsx",

--- a/scripts/xi2-probe.mjs
+++ b/scripts/xi2-probe.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+// What does selecting XI2 cost a window on the wire?
+//
+// This is the measurement behind `xi2: 'auto'` (docs/events.md, and the long
+// comment in WindowNode.realize). It cannot live in `npm run bench`: the
+// in-process X server that lane runs against has no XInput2, so the whole
+// question is invisible there. Point this at a real display instead.
+//
+//   node scripts/xi2-probe.mjs              # $DISPLAY
+//   DISPLAY=:99 node scripts/xi2-probe.mjs  # another server
+//
+// It creates a plain ntk window, warps the pointer across it a few hundred
+// times, and counts the bytes the server sends back under four selections.
+// The warp traffic itself is the same in all four and is subtracted out, so
+// what is left is the per-motion-event cost of each.
+//
+// The two numbers the design turns on:
+//
+//   - an XIMotion is about four times a core MotionNotify, and motion is the
+//     one event that keeps arriving at frame rate for as long as the pointer
+//     is over the window;
+//   - "XI2 alone" and "core + XI2" are byte-identical, because an XI2
+//     selection replaces the core one for the same event type. So the core
+//     PointerMotion bit is free once XI2 is on, and making *that* lazy would
+//     save nothing at all.
+//
+// The last row is `PointerMotionHint`, X's own answer to motion traffic. It
+// reads as ~0 because ntk sets the bit and nothing ever follows up with the
+// QueryPointer the hint requires (sidorares/ntk#319) — so it is one event and
+// then silence, not a working option. Left in because it is the thing a
+// reader will ask about next.
+
+import net from 'node:net';
+import { createClient } from 'ntk';
+
+const DISPLAY = process.env.DISPLAY ?? ':0';
+const STEPS = Number(process.env.XI2_PROBE_STEPS ?? 600);
+
+function socketPath(display) {
+  const local = display.replace(/^:/, '').split('.')[0];
+  return `/tmp/.X11-unix/X${local}`;
+}
+
+/** Count the bytes the server sends us, by wrapping the socket. */
+function counted(stream) {
+  const stats = { bytesIn: 0 };
+  stream.on('data', (chunk) => {
+    stats.bytesIn += chunk.length;
+  });
+  return stats;
+}
+
+async function connect() {
+  const stream = net.connect(socketPath(DISPLAY));
+  await new Promise((resolve, reject) => {
+    stream.once('connect', resolve);
+    stream.once('error', reject);
+  });
+  const stats = counted(stream);
+  const app = await createClient({ stream });
+  return { app, stats };
+}
+
+const settle = (app) =>
+  new Promise((resolve) => app.X.GetInputFocus(() => resolve()));
+
+async function sweep(label, { core, xi2, hint }) {
+  const { app, stats } = await connect();
+  const wnd = app.createWindow({ x: 80, y: 80, width: 600, height: 400 });
+  wnd.map();
+  if (core) wnd.on('mousemove', () => {});
+  const selected = xi2 ? await wnd.selectXI2() : false;
+  if (hint) wnd.setMouseHintOnly(true);
+  await settle(app);
+
+  const root = app.X.display.screen[0].root;
+  const before = stats.bytesIn;
+  for (let i = 0; i < STEPS; i++) {
+    // inside the window, and never on the same pixel twice in a row
+    app.X.WarpPointer(
+      0,
+      root,
+      0,
+      0,
+      0,
+      0,
+      100 + (i % 560),
+      100 + ((i * 7) % 360),
+    );
+    if (i % 20 === 19) await settle(app);
+  }
+  await settle(app);
+  const bytes = stats.bytesIn - before;
+  await app.close();
+  return { label, bytes, perMove: bytes / STEPS, selected };
+}
+
+const rows = [];
+rows.push(await sweep('nothing selected', { core: false, xi2: false }));
+rows.push(await sweep('core PointerMotion', { core: true, xi2: false }));
+rows.push(await sweep('core + XI2 Motion', { core: true, xi2: true }));
+rows.push(await sweep('XI2 Motion, core bit off', { core: false, xi2: true }));
+rows.push(
+  await sweep('core + PointerMotionHint', {
+    core: true,
+    xi2: false,
+    hint: true,
+  }),
+);
+
+const floor = rows[0].perMove;
+const hasXI2 = rows.some((r) => r.selected);
+console.log(
+  `display ${DISPLAY} — XInput2 ${hasXI2 ? 'present' : 'ABSENT (every XI2 row will read as core)'}`,
+);
+console.log(`pointer warped ${STEPS} times inside the window, per selection\n`);
+const pad = (s, n) => String(s).padStart(n);
+console.log(
+  `${'selection'.padEnd(28)} ${pad('bytes in', 9)} ${pad('per move', 9)} ${pad('at 60 Hz', 11)}`,
+);
+for (const row of rows) {
+  // `net` would shadow the imported socket module; this is the per-event
+  // cost with the warp traffic every row shares taken off
+  const cost = Math.max(0, row.perMove - floor);
+  console.log(
+    `${row.label.padEnd(28)} ${pad(row.bytes, 9)} ${pad(`${cost.toFixed(1)} B`, 9)} ${pad(`${((cost * 60) / 1024).toFixed(1)} KB/s`, 11)}`,
+  );
+}

--- a/src/events.js
+++ b/src/events.js
@@ -628,6 +628,13 @@ export class EventManager {
    * render it started for the notch before.
    */
   _onWheel(native) {
+    // The first wheel is what says this window wants smooth scrolling. It was
+    // created on core events — an XI2 selection costs four times as many
+    // bytes per *pointer move*, which a window that is never scrolled would
+    // pay for nothing — and takes the selection here, once (nodes.js,
+    // `upgradeToXI2`). Ahead of the dismiss check, because a scroll this
+    // window heard is a scroll this window heard whatever it does with it.
+    this.node.upgradeToXI2?.();
     // A scroll somewhere else is an interaction somewhere else: the pointer
     // grab an open menu holds brings it here, and the menu is anchored to
     // content that is about to move out from under it. Same answer the press

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -8451,20 +8451,44 @@ export class WindowNode extends Scrollable(Node) {
     // with 0 — transparent black — when the ARGB visual is really there.
     if (this.props.transparent)
       Object.assign(attributes, this._argbAttributes());
-    // **Smooth scrolling, where the server can.** XI2 carries a scroll as
-    // the device's own valuators, so a touchpad's two-finger scroll arrives
-    // as the fractions of a notch it was rather than as the whole clicks of
-    // button 4/5 the server emulates for clients that cannot read them. ntk
-    // translates the device events back into the core-shaped ones the rest
-    // of this file reads, and falls back to those buttons where there is no
-    // XI2, so this is the whole cost of it here (issue #273).
+    // **Smooth scrolling, where the server can — and where the window turns
+    // out to want it.** XI2 carries a scroll as the device's own valuators,
+    // so a touchpad's two-finger scroll arrives as the fractions of a notch
+    // it was rather than as the whole clicks of button 4/5 the server
+    // emulates for clients that cannot read them. ntk translates the device
+    // events back into the core-shaped ones the rest of this file reads, and
+    // falls back to those buttons where there is no XI2 (issue #273).
     //
-    // Not on a `<popup>`, which is the window that holds a pointer grab: a
+    // **It is not free, which is why it is no longer selected up front.** An
+    // XI2 selection *replaces* the core one for the same event type, and an
+    // XIMotion is 136 bytes on the wire against a core MotionNotify's 32
+    // (`npm run xi2:probe`, Xorg 21.1). Motion is the one event that keeps
+    // arriving at frame rate for as long as the pointer is over the window,
+    // so an eager selection bills every window ~8 KB/s of pointer traffic
+    // while the pointer crosses it — for a feature most windows never use. A
+    // dialog, a toolbar, a form, a splash screen never see a wheel at all.
+    //
+    // So `'auto'` — the default — creates the window on core events and takes
+    // the selection the first time the window is actually scrolled
+    // (`upgradeToXI2`, from `EventManager._onWheel`). What that costs is the
+    // opening event of the first gesture in a window's life, and it costs
+    // less than it sounds: a mouse wheel reports whole notches whichever way
+    // the scroll arrived, and ntk's `ScrollTracker` treats the first valuator
+    // event as a seed with no distance to report — so under an eager
+    // selection that same first event moves nothing at all. `xi2` selects at
+    // creation for an app whose whole interaction is the touchpad; `false`
+    // refuses the selection outright.
+    //
+    // Never on a `<popup>`, which is the window that holds a pointer grab: a
     // core grab delivers core events, and ntk drops the emulated wheel
     // buttons on a window whose valuators are flowing — a menu that had
     // selected XI2 would be a menu the wheel could not reach while it was
-    // grabbing. Notch-at-a-time inside an open menu, smooth everywhere else.
-    attributes.xi2 ??= !this.isPopup;
+    // grabbing. An explicit `xi2` still wins there, because an app that says
+    // so has said so.
+    const wantsXI2 = this.props.xi2 ?? 'auto';
+    // `'auto'` is ours and must not reach ntk, whose `args.xi2` is truthiness
+    attributes.xi2 = wantsXI2 === true;
+    this._xi2Pending = wantsXI2 === 'auto' && !this.isPopup;
     // The full event mask, declared at creation — see WINDOW_EVENT_MASK.
     attributes.eventMask = (attributes.eventMask ?? 0) | WINDOW_EVENT_MASK;
     const wnd = this.app.createWindow(attributes);
@@ -8566,6 +8590,37 @@ export class WindowNode extends Scrollable(Node) {
     if (this._anchorLost) return;
     this.window.map?.();
     if (this._topLevel) this.app._reactX11Startup?.mapped(this.window);
+  }
+
+  /**
+   * Take the XI2 selection this window was deliberately created without —
+   * see `realize()` for why `xi2: 'auto'` starts on core events. Called by
+   * `EventManager._onWheel`, so the window that is scrolled is the window
+   * that pays for smooth scrolling.
+   *
+   * **One-shot and one-way.** `_xi2Pending` is cleared before the request
+   * goes out, so a burst of wheel events in one frame asks once. Coming back
+   * down is not offered: the only signal that would justify it is "nothing in
+   * here scrolls any more", which cannot be read without a per-node registry,
+   * and getting it wrong drops a live gesture from valuators back to notches
+   * mid-scroll — a visible regression, to save bytes on a window the user is
+   * actively using.
+   *
+   * Silent where the server has no XInput2: `selectXI2()` resolves `false`
+   * and the window keeps the emulated wheel buttons it already had, which is
+   * exactly where an eager selection would have landed too. Feature-detected
+   * on the method, for an ntk older than 7.5.0.
+   */
+  upgradeToXI2() {
+    if (!this._xi2Pending || this.destroyed) return;
+    this._xi2Pending = false;
+    if (typeof this.window?.selectXI2 !== 'function') return;
+    // fire and forget, like the eager selection in ntk's own createWindow:
+    // until the extension answers the window is on core events, which is
+    // where it would have been anyway
+    this.window.selectXI2().catch((err) => {
+      this.app?.options?.onXError?.(err);
+    });
   }
 
   /**

--- a/src/testing/mock-app.js
+++ b/src/testing/mock-app.js
@@ -288,6 +288,17 @@ export function createMockApp() {
           wnd.grabbed = false;
           wnd.calls.push(['ungrabPointer']);
         },
+        // ntk >= 7.5.0. `xi2: 'auto'` creates a window on core events and
+        // calls this the first time it is scrolled, so the call is the
+        // observable half of the upgrade — `wnd.xi2Selected` is what a test
+        // asserts on. Resolves `true` the way a server with XInput2 answers;
+        // `app.hasXI2 = false` is the other kind of display.
+        selectXI2(types) {
+          wnd.calls.push(['selectXI2', types]);
+          if (app.hasXI2 === false) return Promise.resolve(false);
+          wnd.xi2Selected = types === undefined || types.length > 0;
+          return Promise.resolve(true);
+        },
         resize(width, height) {
           wnd.width = width;
           wnd.height = height;

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -370,15 +370,28 @@ export interface WindowProps
    * Read the pointer through XI2, which is what makes scrolling smooth: the
    * device's own scroll valuators instead of the whole notches the server
    * emulates as button 4/5 presses, so a touchpad reports the fractions of a
-   * notch it measured. On by default, and ignored where the server has no
-   * XI2 — the wheel buttons answer as they always did. `false` opts out.
+   * notch it measured. Ignored where the server has no XI2 — the wheel
+   * buttons answer as they always did.
    *
-   * A `<popup>` is the exception and defaults to `false`: it holds a pointer
-   * grab, a core grab delivers core events, and a window whose valuators are
-   * flowing has its emulated wheel buttons dropped. Set at creation. Needs
-   * ntk >= 7.5.0.
+   * - `'auto'` (the default) selects XI2 the first time the window is
+   *   scrolled. An XI2 selection replaces the core one for the same event
+   *   type, and an XIMotion is ~136 bytes against a core MotionNotify's 32,
+   *   so an eager selection bills a window that never scrolls ~8 KB/s of
+   *   pointer traffic for nothing. The opening event of the first gesture is
+   *   a whole notch — which is all a mouse wheel ever reports anyway, and
+   *   all an eager selection would have delivered too, since the first
+   *   valuator event only seeds the accumulator.
+   * - `true` selects at creation, for an app whose whole interaction is a
+   *   touchpad and which wants the very first flick smooth.
+   * - `false` refuses the selection for the window's whole life.
+   *
+   * A `<popup>` never upgrades under `'auto'`: it holds a pointer grab, a
+   * core grab delivers core events, and a window whose valuators are flowing
+   * has its emulated wheel buttons dropped, so a menu that had selected XI2
+   * could not be wheeled while it was grabbing. An explicit `true` still
+   * wins there. Needs ntk >= 7.5.0.
    */
-  xi2?: boolean;
+  xi2?: boolean | 'auto';
   /**
    * Mark this window as a drag preview: the drag router never treats it as
    * the window under the pointer, so a `<popup dragPreview>` can follow the

--- a/test/smooth-scroll.test.js
+++ b/test/smooth-scroll.test.js
@@ -236,7 +236,7 @@ test('Shift turns a one-axis wheel sideways, whatever measured it', async () => 
 
 // --- selecting it -----------------------------------------------------------
 
-test('a window asks for XI2; a popup, which grabs, does not', async () => {
+test('no window selects XI2 at creation; the first wheel is what asks', async () => {
   const app = createMockApp();
   const x11Root = await createRoot({ app });
   x11Root.render(
@@ -251,23 +251,100 @@ test('a window asks for XI2; a popup, which grabs, does not', async () => {
   const [window, popup] = app.windows;
   assert.strictEqual(
     window.attributes.xi2,
-    true,
-    'the window scrolls smoothly',
-  );
-  assert.strictEqual(
-    popup.attributes.xi2,
     false,
+    'created on core events: an XIMotion is four times a MotionNotify, and ' +
+      'a window that is never scrolled must not pay it',
+  );
+  assert.strictEqual(popup.attributes.xi2, false);
+  assert.ok(!window.xi2Selected, 'and nothing has selected it yet');
+
+  spinWheel(window, 100, 100, { deltaY: 1 });
+  await tick();
+  assert.ok(window.xi2Selected, 'the first wheel takes the selection');
+
+  // …and a menu never does: it holds a pointer grab, and a core grab
+  // delivers core events, so valuators would cost it the wheel entirely
+  spinWheel(popup, 20, 20, { deltaY: 1 });
+  await tick();
+  assert.ok(
+    !popup.xi2Selected,
     'a grabbing menu stays on the wheel buttons the grab delivers',
   );
 
   await x11Root.unmount();
 });
 
-test('a window can turn it down', async () => {
+test('the upgrade is asked for once, however hard the window is scrolled', async () => {
   const app = createMockApp();
   const x11Root = await createRoot({ app });
-  x11Root.render(h('window', { width: 200, height: 200, xi2: false }));
+  x11Root.render(h('window', { width: 200, height: 200 }));
   await tick();
-  assert.strictEqual(app.windows[0].attributes.xi2, false);
+  const wnd = app.windows[0];
+
+  for (let i = 0; i < 8; i++) spinWheel(wnd, 100, 100, { deltaY: 1 });
+  await tick();
+
+  assert.strictEqual(
+    wnd.calls.filter(([name]) => name === 'selectXI2').length,
+    1,
+    'cleared before the request goes out, so a burst in one frame asks once',
+  );
+  await x11Root.unmount();
+});
+
+test('a window can ask for XI2 up front, or refuse it for good', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(
+    h(
+      React.Fragment,
+      null,
+      h('window', { width: 200, height: 200, xi2: true }),
+      h('window', { width: 200, height: 200, xi2: false }),
+    ),
+  );
+  await tick();
+  const [eager, never] = app.windows;
+
+  assert.strictEqual(eager.attributes.xi2, true, 'selected at creation');
+  assert.strictEqual(never.attributes.xi2, false);
+
+  spinWheel(never, 100, 100, { deltaY: 1 });
+  await tick();
+  assert.ok(
+    !never.xi2Selected,
+    'a refusal is for the window’s whole life, not just its creation',
+  );
+  assert.strictEqual(
+    never.calls.filter(([name]) => name === 'selectXI2').length,
+    0,
+    'and it does not even ask',
+  );
+
+  await x11Root.unmount();
+});
+
+test('the wheel still works where the server has no XInput2', async () => {
+  const app = createMockApp();
+  app.hasXI2 = false;
+  const x11Root = await createRoot({ app });
+  let scrolled = 0;
+  x11Root.render(
+    h('window', { width: 200, height: 200, onWheel: () => scrolled++ }),
+  );
+  await tick();
+  const wnd = app.windows[0];
+
+  spinWheel(wnd, 100, 100, { deltaY: 1 });
+  await tick();
+  spinWheel(wnd, 100, 100, { deltaY: 1 });
+  await tick();
+
+  assert.ok(!wnd.xi2Selected, 'the selection was refused by the server');
+  assert.strictEqual(
+    scrolled,
+    2,
+    'and the emulated wheel buttons carry the scroll, as they always did',
+  );
   await x11Root.unmount();
 });

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -493,6 +493,14 @@ const _fitContent = <window width="fit-content" />;
 // @ts-expect-error — there is no containing block to be a percentage of
 const _percent = <window height="100%" />;
 
+// `xi2` is a three-way choice, not a boolean: 'auto' (the default) selects
+// XI2 on the first wheel, `true` at creation, `false` never.
+const _xi2Auto = <window xi2="auto" />;
+const _xi2Eager = <window xi2 />;
+const _xi2Never = <window xi2={false} />;
+// @ts-expect-error — 'auto' is the only string the selection understands
+const _xi2Bogus = <window xi2="lazy" />;
+
 // --- popups ----------------------------------------------------------------
 
 function Popup() {


### PR DESCRIPTION
Every non-popup `<window>` selected XI2 as it was created — `attributes.xi2 ??= !this.isPopup` — for the scroll valuators that make a touchpad smooth. The selection is not free, and the bill does not land on scrolling. It lands on **pointer motion**.

An XI2 selection *replaces* the core one for the same event type, and an `XIMotion` is about four times the size of a core `MotionNotify`. Motion is the one event that keeps arriving at frame rate for as long as the pointer is over the window, so the cost is continuous, and every window paid it — including the dialogs, toolbars, forms and splash screens that never see a wheel.

## Measured

Xorg 21.1, pointer warped 600 times inside the window, bytes the server sent above the warp traffic every row shares (`npm run xi2:probe`, added here):

| window selects | per move | at 60 Hz |
|---|---|---|
| nothing | 0 B | — |
| core `PointerMotion` | 32 B | 1.9 KB/s |
| **core + XI2 Motion — before this PR** | **136 B** | **8.0 KB/s** |
| XI2 Motion, core bit off | 136 B | 8.0 KB/s |
| core + `PointerMotionHint` | 0.2 B | ~0 |

The last two rows are each their own finding.

**"XI2 alone" is byte-identical to "core + XI2".** Once XI2 Motion is selected the core `PointerMotion` bit costs nothing, so the change that looks obvious — making `EventManager`'s unconditional `wnd.on('mousemove')` lazy — would save no traffic at all on any display with XInput2. It would save react-x11's dispatch path, which measures 1.3–2.0 µs per event on a 400-to-1600-node tree, or about 0.1 ms per second of pointer movement. That is not where the bytes are, so this PR leaves the core mask alone.

**`PointerMotionHint` reads as ~0 because it is broken, not because it works.** ntk sets the bit and never makes the `QueryPointer` the hint protocol requires, so it is one event and then silence — filed as sidorares/ntk#319. Worth knowing it is not a shortcut sitting there unused.

## The change

`xi2` becomes a three-way choice, defaulting to `'auto'`:

- **`'auto'`** — created on core events; takes the selection the first time the window is actually scrolled (`WindowNode.upgradeToXI2`, called from `EventManager._onWheel`).
- **`true`** — selects at creation, as before, for an app whose whole interaction is a touchpad and which wants the very first flick smooth.
- **`false`** — refuses for the window's whole life, as before.

A `<popup>` never upgrades under `'auto'`: it holds a pointer grab, a core grab delivers core events, and ntk drops the emulated wheel buttons on a window whose valuators are flowing, so a menu that selected XI2 could not be wheeled while grabbing. An explicit `true` still wins there.

**What waiting costs** is the opening event of the first gesture in a window's life — and less than it sounds. A mouse wheel reports whole notches whichever way the scroll arrived, and ntk's `ScrollTracker` treats the first valuator event as a seed with *no distance to report*, so under an eager selection that same first event moved nothing at all. Waiting trades "nothing" for "one notch".

**The upgrade is one-shot and one-way.** Coming back down would need a per-node registry to answer "nothing in here scrolls any more", and getting it wrong drops a live gesture from valuators to notches mid-scroll — a visible regression, to save bytes on a window the user is actively using. Both directions do work at the protocol level (verified), so this is a deliberate scope line rather than a limitation.

## Verification

- `test/smooth-scroll.test.js` — four new tests: nothing selects at creation and the first wheel asks; the upgrade is asked for once however hard the window is scrolled; `true`/`false` still mean what they meant; and the wheel still works where the server has no XInput2. **Mutation-checked**: reverting the `_onWheel` trigger fails two of them, reverting the eager default fails two.
- End-to-end against real Xorg — window comes up with `_xi2 = null`, one wheel event leaves it `SELECTED (Motion,ButtonPress,ButtonRelease)`, and the scroll still reaches the handler with its full 48px.
- `npm run bench -- --check` passes. Comparing branch against master on the same machine over three runs each, exactly one delta is stable: `mount: window with 40 boxes and labels` drops from 101 to 100 requests — the XInput `QueryExtension` no longer sent at creation. Everything else moves between runs on both branches, which is the jitter the bench header documents.

**`baseline.json` is deliberately not regenerated.** The committed numbers sit about one request above what this machine produces on master too, so rewriting them here would bake in a local offset and cost the gate its headroom. `--check` only fails on increases and it passes.

Lint, typecheck and `prettier --check .` are clean; the full suite is at its usual six macOS-only `appearance.test.js` failures, identical on master.

Docs, `.d.ts` and the type test move with the prop.