### PR TITLE
feat(events): an `unstable_onAttention` event — the pointer is heading here (ntk#37)

### DIFF
--- a/examples/attention.jsx
+++ b/examples/attention.jsx
@@ -1,0 +1,201 @@
+// Attention: which box is the pointer heading for, said before it gets there.
+//
+// Move the pointer across the window and watch a box light up *ahead* of the
+// cursor. That is `unstable_onAttention` plus an `:attention` style block —
+// prototype for ntk#37, and the thing this example exists to make visible,
+// because a prediction is very hard to believe from a test.
+//
+// Three things are worth watching for, and the layout is arranged to show
+// each of them:
+//
+//   - **Direction beats distance.** Sweep left-to-right along the middle row
+//     and the box you are moving *towards* lights up while a nearer box
+//     behind you stays dark. Sweep back and it reverses.
+//   - **Only one box at a time.** Attention is a single node per window, so
+//     the previous holder gives it up as the new one takes it. Each box also
+//     keeps a count of how many times it has been picked, in React state, so
+//     you can see the handovers accumulate.
+//   - **Overlap and absolute positioning are not special.** The stacked pair
+//     on the right overlaps; the two loose boxes are `position: 'absolute'`.
+//     Nothing is hit tested here — a box wins by being the first rectangle
+//     the trajectory would enter — so stacking order does not decide it, and
+//     a box the pointer never touches can still be picked.
+//
+// The `eta` on the event is the useful part in a real application: it is
+// roughly how many milliseconds away the pointer is, which is what tells you
+// whether it is worth starting anything. Each box prints its own.
+//
+// This file is the only documentation the feature has, deliberately. It is a
+// prototype and the shape may not survive — the tuning is uncalibrated, and
+// whether the handler earns its keep depends on there being work worth
+// starting early — so it stays out of `docs/` until that is settled, rather
+// than being announced and then depended on.
+//
+// Run with: npm run examples:attention  (needs an X server / DISPLAY)
+import React, { useCallback, useRef, useState } from 'react';
+import { createRoot } from '../src/index.js';
+
+const INK = '#dcdde1';
+const DIM = '#7f8c9b';
+
+/**
+ * One box. `:attention` does the paint, so the visual costs no React render
+ * at all — it is a repaint of one node, the same as `:hover`.
+ *
+ * The handler is here to show the other half: in a real application this is
+ * where a cache is warmed or a request goes out. Setting React state from it,
+ * as this does, is the *expensive* way to react to attention and is done here
+ * only because the counter is the point.
+ */
+function Box({ label, hue, style }) {
+  const [picks, setPicks] = useState(0);
+  const [eta, setEta] = useState(null);
+  const onAttention = useCallback((ev) => {
+    setPicks((n) => n + 1);
+    setEta(ev.eta);
+  }, []);
+
+  return (
+    <box
+      unstable_onAttention={onAttention}
+      style={{
+        padding: 10,
+        gap: 2,
+        borderRadius: 6,
+        borderWidth: 2,
+        borderColor: 'transparent',
+        backgroundColor: hue,
+        transition: { borderColor: 90, backgroundColor: 90 },
+        // the prediction…
+        ':attention': { borderColor: '#f5f6fa' },
+        // …and the fact, which outranks it once the pointer really lands
+        ':hover': { borderColor: '#f5f6fa', backgroundColor: '#5c6bc0' },
+        ...style,
+      }}
+    >
+      <text style={{ fontSize: 13, color: INK }}>{label}</text>
+      <text style={{ fontSize: 11, color: DIM }}>
+        {picks === 0 ? 'not yet' : `picked ${picks}×`}
+      </text>
+      <text style={{ fontSize: 11, color: DIM }}>
+        {eta === null ? ' ' : `~${eta}ms away`}
+      </text>
+    </box>
+  );
+}
+
+function App() {
+  // Where the pointer is and which way it is going, so the prediction can be
+  // read against it — in a still screenshot this is the only thing that says
+  // *why* a particular box lit up. `useRef` for the previous sample so the
+  // arrow costs no extra render.
+  const [pointer, setPointer] = useState(null);
+  const last = useRef(null);
+  const onMouseMove = useCallback((ev) => {
+    const previous = last.current;
+    const heading =
+      previous && Math.abs(ev.x - previous.x) > 2
+        ? ev.x > previous.x
+          ? '→'
+          : '←'
+        : (previous?.heading ?? '·');
+    last.current = { x: ev.x, y: ev.y, heading };
+    setPointer({ x: Math.round(ev.x), y: Math.round(ev.y), heading });
+  }, []);
+
+  return (
+    <window
+      title="Attention"
+      width={780}
+      height={460}
+      onMouseMove={onMouseMove}
+      style={{ backgroundColor: '#2f3640', padding: 18, gap: 14 }}
+    >
+      <text style={{ fontSize: 15, color: INK }}>
+        Move the pointer around. A box lights up before you reach it.
+      </text>
+      <box style={{ flexDirection: 'row', gap: 10, alignItems: 'center' }}>
+        <text style={{ fontSize: 12, color: DIM }}>
+          Sweep along a row: the box ahead of you is picked, the one behind is
+          not.
+        </text>
+        <text style={{ fontSize: 12, color: INK }}>
+          {pointer
+            ? `pointer ${pointer.heading} at ${pointer.x},${pointer.y}`
+            : 'pointer —'}
+        </text>
+      </box>
+
+      {/* The middle row — the direction demonstration. Wide gaps so there is
+          room to build up speed between them. */}
+      <box style={{ flexDirection: 'row', gap: 40, marginTop: 8 }}>
+        <Box label="one" hue="#3d4451" />
+        <Box label="two" hue="#44506b" />
+        <Box label="three" hue="#3d4451" />
+        <Box label="four" hue="#44506b" />
+      </box>
+
+      {/* Overlapping pair: `over` sits on top of `under`, but `under` reaches
+          further left, so a pointer arriving from the left is predicted into
+          `under` first — entry order, not stacking order. */}
+      <box style={{ height: 150, marginTop: 6 }}>
+        <Box
+          label="under"
+          hue="#4a3f55"
+          style={{
+            position: 'absolute',
+            left: 20,
+            top: 10,
+            width: 220,
+            height: 110,
+          }}
+        />
+        <Box
+          label="over"
+          hue="#5b4a63"
+          style={{
+            position: 'absolute',
+            left: 150,
+            top: 40,
+            width: 150,
+            height: 90,
+            zIndex: 1,
+          }}
+        />
+
+        {/* Loose absolutely-positioned boxes, off on their own. Nothing
+            contains them and nothing routes to them; they are candidates
+            because they said so. */}
+        <Box
+          label="adrift"
+          hue="#3f5548"
+          style={{
+            position: 'absolute',
+            left: 400,
+            top: 0,
+            width: 130,
+            height: 70,
+          }}
+        />
+        <Box
+          label="corner"
+          hue="#55503f"
+          style={{
+            position: 'absolute',
+            left: 580,
+            top: 60,
+            width: 140,
+            height: 80,
+          }}
+        />
+      </box>
+
+      <text style={{ fontSize: 11, color: DIM, marginTop: 'auto' }}>
+        A white border is the prediction; landing on a box turns it indigo.
+      </text>
+    </window>
+  );
+}
+
+const root = await createRoot();
+root.render(<App />);

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "examples:tasks:hot": "node --enable-source-maps --import react-x11/refresh/register examples/tasks-hot.jsx",
     "examples:menu": "tsx examples/menu.jsx",
     "examples:monitor": "tsx examples/monitor.jsx",
+    "examples:attention": "tsx examples/attention.jsx",
     "examples:tooltips": "tsx examples/tooltips.jsx",
     "examples:chat": "tsx examples/chat.jsx",
     "examples:clipboard": "tsx examples/clipboard.jsx",

--- a/src/events.js
+++ b/src/events.js
@@ -162,6 +162,95 @@ function restoresFocusOnReveal(app) {
   return app?._reactX11RestoreFocus ?? true;
 }
 
+/* --- attention (ntk#37) ------------------------------------------------- *
+ *
+ * Every other event here is *routed*: hit test the pointer, build the
+ * ancestor path, walk it. Attention cannot work that way, because the whole
+ * point is to reach a node the pointer has **not** arrived at. So it is
+ * *matched* instead: each motion event updates a velocity estimate, and every
+ * registered candidate is asked "does this trajectory enter you, and how
+ * soon". The nearest answer wins. There is no capture, no bubble and no
+ * ancestor chain — an ancestor is not on the way to its child in any sense
+ * the pointer knows about, and a handler that fired for a descendant it never
+ * named would be guessing.
+ *
+ * Cost is the reason the candidates are a registry rather than a tree walk.
+ * A window whose tree contains no `unstable_onAttention` and no
+ * `:attention` block
+ * runs one `Set.size` read per motion event and nothing else — see
+ * `_onMouseMove`.
+ *
+ * **Deliberately absent from `docs/`.** This is a prototype and the shape may
+ * not survive: nothing here has been calibrated against real pointer traces,
+ * and the case for the handler rests on there being work worth starting
+ * early, which the interaction paths measured so far mostly do not have. It
+ * stays out of the documentation so that nothing comes to depend on it before
+ * that is settled — `examples/attention.jsx` is the only prose, and it says
+ * the same. Removing the feature is a `git revert` of the commit that added
+ * it; keep it that way.
+ */
+
+/** How many pointer samples the velocity is averaged over. Two is a
+ *  difference and jitters; a handful smooths a hand without adding lag
+ *  anything at this timescale can feel. */
+const ATTENTION_SAMPLES = 5;
+
+/** Samples older than this are stale — a pointer that stopped and started
+ *  again must not inherit the direction it had before the pause. */
+const ATTENTION_SAMPLE_MS = 120;
+
+/** Below this the pointer is settling rather than travelling (device px per
+ *  ms; ~50 px/s). Extrapolating a direction from noise this small points
+ *  attention at whatever happens to be off to one side, so the slow case
+ *  falls back to "what is under the pointer" instead. */
+const ATTENTION_MIN_SPEED = 0.05;
+
+/** How far ahead to look, in milliseconds of travel at the current speed.
+ *  This is the honest unit for it: the question a warm-up wants answered is
+ *  "will the user be here soon enough for the work to have paid off", and
+ *  that is a time, not a distance. Long enough to be worth acting on, short
+ *  enough that a flick across the window does not nominate everything on the
+ *  line. */
+const ATTENTION_HORIZON_MS = 250;
+
+/**
+ * When the ray from `px,py` along `vx,vy` (device px per ms) first enters
+ * `rect`, in milliseconds — 0 if it starts inside, null if it never does.
+ *
+ * Slab method, the standard ray/AABB test. Because the velocity is per
+ * millisecond, the parameter that falls out *is* the time to arrival, which
+ * is what both the horizon test and `ev.eta` want.
+ */
+function attentionEta(px, py, vx, vy, rect) {
+  const x1 = rect.x;
+  const x2 = rect.x + rect.width;
+  const y1 = rect.y;
+  const y2 = rect.y + rect.height;
+  if (px >= x1 && px < x2 && py >= y1 && py < y2) return 0;
+  let tmin = 0;
+  let tmax = Infinity;
+  // x slab, then y slab; a zero component means the ray never crosses that
+  // axis, so it has to already be within the slab or it misses entirely
+  if (vx === 0) {
+    if (px < x1 || px >= x2) return null;
+  } else {
+    const a = (x1 - px) / vx;
+    const b = (x2 - px) / vx;
+    tmin = Math.max(tmin, Math.min(a, b));
+    tmax = Math.min(tmax, Math.max(a, b));
+  }
+  if (vy === 0) {
+    if (py < y1 || py >= y2) return null;
+  } else {
+    const a = (y1 - py) / vy;
+    const b = (y2 - py) / vy;
+    tmin = Math.max(tmin, Math.min(a, b));
+    tmax = Math.min(tmax, Math.max(a, b));
+  }
+  if (tmin > tmax) return null;
+  return tmin >= 0 ? tmin : null;
+}
+
 /**
  * Wrap an ntk event callback for a *discrete* event — one whose response is
  * a single visual state, so there is nothing a frame's wait could coalesce
@@ -251,6 +340,13 @@ export class EventManager {
     // release that continue the same gesture follow
     this._downDefaulted = false;
     this.capturedNode = null;
+    // Attention (ntk#37): the one node the pointer looks like it is heading
+    // for, the recent pointer samples the trajectory is estimated from, and
+    // the window's candidate registry held directly so the motion path costs
+    // one property read to find out there is nothing to do.
+    this.attentionNode = null;
+    this._attentionSamples = [];
+    this._attentionNodes = windowNode?._attentionNodes ?? new Set();
     this.focused = null;
     // the focused node and its ancestors, which is what draws `:focus-within`
     this.focusWithinPath = [];
@@ -865,6 +961,13 @@ export class EventManager {
       if (this._downDefaulted && this.downNode && !this.downNode.destroyed) {
         this.downNode.defaultMouseDrag?.(ev);
       }
+      // Attention, last (ntk#37). Two reasons for the position. It is
+      // speculative work, and "answer the input, not the outcome" says the
+      // real response to this motion — the hover repaint, the drag — goes out
+      // before anything done on a guess about the next one. And this line is
+      // the whole cost of the feature for a tree that never asked for it: one
+      // `size` read on a set the window built empty, no walk, no allocation.
+      if (this._attentionNodes.size !== 0) this._updateAttention(native);
     });
   }
 
@@ -905,6 +1008,12 @@ export class EventManager {
   _onMouseOut(native) {
     runWithPriority(ContinuousEventPriority, () => {
       this._updateHover([], native);
+      // the pointer is somewhere else entirely: whatever it was heading for
+      // in here, it is not heading for it now
+      if (this._attentionNodes.size !== 0) {
+        this._attentionSamples.length = 0;
+        this._setAttention(null, native);
+      }
       // the pointer left the window with a button still down: a release out
       // there synthesizes its click on the window, so that is as much of the
       // press chain as may still look pressed
@@ -987,6 +1096,110 @@ export class EventManager {
     }
     this.hoverPath = newPath;
     this._updateCursor(newPath);
+  }
+
+  /**
+   * Who is the pointer heading for? Runs only when the window has
+   * candidates — see the guard in `_onMouseMove`.
+   *
+   * Three steps, and the middle one is the whole idea. Sample the pointer to
+   * get a velocity; ask every candidate when this trajectory would enter it;
+   * give attention to the soonest answer inside the horizon. Nothing is hit
+   * tested and nothing is walked: a candidate wins by being *ahead*, which is
+   * exactly the thing a hit test cannot tell you.
+   *
+   * Below `ATTENTION_MIN_SPEED` there is no trajectory worth extrapolating —
+   * a resting hand jitters a pixel or two and its "direction" is noise — so
+   * the slow case degrades to the candidate under the pointer, which is both
+   * the honest answer and the one that keeps attention from flickering around
+   * the room while somebody reads.
+   */
+  _updateAttention(native) {
+    const now = native?.time ?? Date.now();
+    const samples = this._attentionSamples;
+    samples.push({ x: native.x, y: native.y, t: now });
+    // drop what is too old to describe the movement happening now, and cap
+    // the window: this array is touched at motion rate and must not grow
+    while (
+      samples.length > ATTENTION_SAMPLES ||
+      (samples.length > 1 && now - samples[0].t > ATTENTION_SAMPLE_MS)
+    ) {
+      samples.shift();
+    }
+
+    const first = samples[0];
+    const dt = now - first.t;
+    let vx = 0;
+    let vy = 0;
+    if (samples.length > 1 && dt > 0) {
+      vx = (native.x - first.x) / dt;
+      vy = (native.y - first.y) / dt;
+    }
+    const speed = Math.hypot(vx, vy);
+
+    let best = null;
+    let bestEta = Infinity;
+    for (const node of this._attentionNodes) {
+      // the registry is swept lazily, like `_sizeQueryNodes`: an unmount has
+      // more urgent things to do than reach into every window registry
+      if (node.destroyed || !node.root) {
+        this._attentionNodes.delete(node);
+        continue;
+      }
+      const rect = node.abs;
+      // a node that has never been laid out has no rectangle to aim at, and
+      // one that is hidden or untargetable is not somewhere the pointer can
+      // arrive
+      if (!rect?.width || !rect.height) continue;
+      if (node.hidden || node.style.display === 'none') continue;
+      if (node.style.pointerEvents === 'none') continue;
+      const eta =
+        speed < ATTENTION_MIN_SPEED
+          ? attentionEta(native.x, native.y, 0, 0, rect)
+          : attentionEta(native.x, native.y, vx, vy, rect);
+      if (eta === null || eta > ATTENTION_HORIZON_MS) continue;
+      if (eta < bestEta) {
+        bestEta = eta;
+        best = node;
+      }
+    }
+    this._setAttention(best, native, bestEta);
+  }
+
+  /**
+   * Move attention, which only one node in a window can hold.
+   *
+   * **The handler fires on arrival only.** Losing attention is deliberately
+   * not an event: the thing the handler is for is starting work early — a
+   * cache warmed, an image decoded, a query sent — and none of that wants
+   * undoing because the pointer changed its mind. What *is* visual is handled
+   * by `:attention`, which is cleared here like any other state, so the
+   * common case needs no handler at all. If a real use for the loss turns up,
+   * the seam is a second prop rather than a `null` argument every
+   * handler would have to null-check.
+   *
+   * No capture, no bubble: see the note at the top of this file. Attention is
+   * matched against a registry, so the node that matched is the only node
+   * that could meaningfully hear about it.
+   */
+  _setAttention(node, native, eta = 0) {
+    const previous = this.attentionNode;
+    if (previous === node) return;
+    if (previous && !previous.destroyed) {
+      previous.setStyleState(':attention', false);
+    }
+    this.attentionNode = node;
+    if (!node) return;
+    node.setStyleState(':attention', true);
+    const handler = node.props.unstable_onAttention;
+    if (!handler) return;
+    // `eta` is the point of the event rather than decoration: "the pointer
+    // arrives here in about 40ms" and "in about 200ms" justify very different
+    // amounts of speculative work, and only the renderer knows which it is.
+    const ev = this._makeEvent('attention', native, node, {
+      eta: Math.round(eta),
+    });
+    callHandler(node, 'unstable_onAttention', handler, ev);
   }
 
   /** Apply the deepest hovered node's `cursor` prop to the window.

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -1572,6 +1572,20 @@ export class Node {
       if (asks) this.root._supportsQueryNodes.add(this);
       else this.root._supportsQueryNodes.delete(this);
     }
+    // Attention candidates keep a registry for the same reason and are
+    // registered the same unconditional way — a `<window>`'s own style is
+    // resolved before `root` is assigned, so a "did it change" guard would
+    // leave it unregistered forever. Unlike hover, attention is *matched*
+    // against this set rather than hit-tested, so a node that is not in it
+    // is not a candidate at all.
+    const wantsAttention = Boolean(
+      props.unstable_onAttention || this._baseStyle[':attention'],
+    );
+    this._wantsAttention = wantsAttention;
+    if (this.root?._attentionNodes) {
+      if (wantsAttention) this.root._attentionNodes.add(this);
+      else this.root._attentionNodes.delete(this);
+    }
     if (queried || asks) {
       this._baseStyle = resolveQueries(this._baseStyle, {
         size: this.root?.querySize ?? null,
@@ -1902,6 +1916,9 @@ export class Node {
       // a node mounted into a window that already knows its capabilities
       // has to match against those, not against the startup default
       this._sizeQueriesChanged();
+    }
+    if (this._wantsAttention && this.root?._attentionNodes) {
+      this.root._attentionNodes.add(this);
     }
     for (const child of this.children) {
       if (!child.isWindow) child._registerSizeQueries();
@@ -7836,6 +7853,13 @@ export class WindowNode extends Scrollable(Node) {
     this.needsLayout = true;
     this.needsPaint = true;
     this._scheduled = false;
+    // Nodes that want the `attention` event (ntk#37) — an
+    // `unstable_onAttention` prop,
+    // an `:attention` block, or both. Built before the EventManager so the
+    // manager can hold the reference itself: the whole feature has to be
+    // behind one `size` read on the motion path, and a tree that never asked
+    // for attention must not pay a property walk to find that out.
+    this._attentionNodes = new Set();
     this.events = new EventManager(this);
     // ids of the child windows in the order the *server* stacks them,
     // bottom to top — see _restackWindowChildren

--- a/src/styles.js
+++ b/src/styles.js
@@ -374,7 +374,14 @@ export function axesEqual(a, b) {
 export const isLayoutProp = (name) =>
   Object.prototype.hasOwnProperty.call(LAYOUT_APPLIERS, name);
 export const isPaintProp = (name) => PAINT_PROPS.has(name);
-export const isEventProp = (name) => /^on[A-Z]/.test(name);
+/**
+ * A handler prop. `unstable_`-prefixed ones count: the prefix marks an API as
+ * provisional (React's own idiom), it does not stop the prop being a handler.
+ * Both callers care — a handler must not reach `CreateWindow` as a window
+ * attribute, and `paintChanged` must not claim a repaint every time a render
+ * passes a fresh inline arrow.
+ */
+export const isEventProp = (name) => /^(?:unstable_)?on[A-Z]/.test(name);
 
 /**
  * State blocks, lowest precedence first. These are *node* states, not
@@ -393,6 +400,11 @@ export const isEventProp = (name) => /^on[A-Z]/.test(name);
  * labels inside, the way it does in CSS.
  */
 export const STATE_KEYS = [
+  // The pointer is heading here but has not arrived (ntk#37). Lowest
+  // precedence of the lot, because it is the only *prediction* in the list
+  // and every other state is a fact: once the pointer actually lands,
+  // `:hover` is the truth and has to win.
+  ':attention',
   ':hover',
   // Focus is on this node or inside it — CSS's `:focus-within`. Below
   // `:focus` on purpose: it is the broader fact, so a node that is itself

--- a/src/testing/mock-app.js
+++ b/src/testing/mock-app.js
@@ -411,9 +411,17 @@ export function createMockApp() {
   return app;
 }
 
-/** Move the pointer inside a window, in window coordinates. */
-export function moveMouse(wnd, x, y) {
-  wnd.emit('mousemove', { x, y });
+/**
+ * Move the pointer inside a window, in window coordinates.
+ *
+ * `time` is the X server timestamp in milliseconds. Anything that reads the
+ * pointer's *speed* rather than its position needs it — the attention
+ * tracker estimates a trajectory from consecutive samples — and a test that
+ * leaves it out gets the wall clock, which makes the velocity depend on how
+ * fast the machine ran the loop.
+ */
+export function moveMouse(wnd, x, y, { time } = {}) {
+  wnd.emit('mousemove', time === undefined ? { x, y } : { x, y, time });
 }
 
 /** Press and release button 1 at a point; pass {release:false} to hold. */

--- a/src/types/events.d.ts
+++ b/src/types/events.d.ts
@@ -70,6 +70,28 @@ export interface MouseEvent<T = DrawnNode> extends SyntheticEvent<T> {
   detail: number;
 }
 
+/**
+ * The pointer looks like it is heading here (ntk#37) — said *before* it
+ * arrives, so there is time to do something about it.
+ *
+ * Not routed like the other pointer events. Nothing is hit tested and there
+ * is no capture or bubble phase: nodes that want attention register
+ * themselves, the pointer's trajectory is matched against their rectangles,
+ * and the one it would enter soonest is the one that hears about it. Only one
+ * node in a window holds attention at a time.
+ */
+export interface AttentionEvent<T = DrawnNode> extends SyntheticEvent<T> {
+  /**
+   * Roughly how many milliseconds until the pointer arrives, at the speed it
+   * is currently travelling — 0 when it is already inside.
+   *
+   * This is the number worth branching on. "The pointer is here in 30ms" and
+   * "in 220ms" justify very different amounts of speculative work, and the
+   * renderer is the only party that knows which one this is.
+   */
+  eta: number;
+}
+
 export interface WheelEvent<T = DrawnNode> extends SyntheticEvent<T> {
   /** Pixels, positive right — one notch of the wheel is 48 of them. */
   deltaX: number;
@@ -331,6 +353,26 @@ export interface PointerHandlers<T = DrawnNode> {
   /** Does not propagate — synthesized by hover-path diffing. */
   onMouseEnter?: (ev: MouseEvent<T>) => void;
   onMouseLeave?: (ev: MouseEvent<T>) => void;
+  /**
+   * **Provisional — the `unstable_` prefix is the contract.** A prototype for
+   * ntk#37, kept out of `docs/` on purpose: the shape may change or be
+   * withdrawn, and dropping the prefix is what would say it had settled.
+   *
+   * The pointer is heading for this node and has not arrived. For starting
+   * work early — warming a cache, decoding an image, sending the query whose
+   * answer the click will want.
+   *
+   * Fires on arrival of attention only. There is no matching "lost" event:
+   * work started on a hint does not want undoing because the pointer changed
+   * its mind, and anything *visual* belongs in an `:attention` style block,
+   * which is cleared automatically. Declaring either one registers the node
+   * as a candidate; a tree that declares neither costs nothing per motion
+   * event.
+   *
+   * Does not propagate, and unlike `onMouseEnter` it is not the hover path
+   * either — see `AttentionEvent`.
+   */
+  unstable_onAttention?: (ev: AttentionEvent<T>) => void;
   onWheel?: (ev: WheelEvent<T>) => void;
   onWheelCapture?: (ev: WheelEvent<T>) => void;
   /**

--- a/src/types/style.d.ts
+++ b/src/types/style.d.ts
@@ -365,6 +365,19 @@ export type SizeQuery = `@${'width' | 'height'} ${string}`;
 export interface StyleBlocks {
   transition?: Transition;
   animation?: Animation;
+  /**
+   * **Provisional.** A prototype for ntk#37, kept out of `docs/` on purpose:
+   * the shape may change or be withdrawn, so do not build on it yet.
+   *
+   * The pointer is heading for this node but has not arrived — a
+   * prediction from its trajectory, not a fact about where it is. Lowest
+   * precedence of the state blocks for exactly that reason: once the pointer
+   * really lands, `:hover` is the truth and wins.
+   *
+   * Declaring it registers the node as an attention candidate; see
+   * `unstable_onAttention` for the handler half.
+   */
+  ':attention'?: StateStyle;
   ':hover'?: StateStyle;
   /** Set while focus is on this node **or inside it** — CSS's
    * `:focus-within`, and the way a row highlights while the field in it is

--- a/test/attention.test.js
+++ b/test/attention.test.js
@@ -1,0 +1,518 @@
+// The `attention` event (ntk#37): the pointer looks like it is heading for
+// this node, said before it gets there.
+//
+// The thing under test is the *routing*, which is unlike every other event
+// here. Attention is not hit tested and does not bubble — candidates register
+// themselves and are matched against the pointer's trajectory — so most of
+// what follows is about which node wins and why, not about dispatch order.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import { createRoot } from '../src/index.js';
+import { createMockApp, moveMouse } from './helpers/mock-app.js';
+import { isEventProp } from '../src/styles.js';
+
+const h = React.createElement;
+const tick = () => new Promise((r) => setImmediate(r));
+
+/** An absolutely positioned box, so every rect in a test is stated. */
+function boxAt(props, { x, y, width, height, ...style }) {
+  return h('box', {
+    ...props,
+    style: { position: 'absolute', left: x, top: y, width, height, ...style },
+  });
+}
+
+/**
+ * Sweep the pointer along a straight line at a known speed. Samples carry
+ * explicit timestamps: the tracker estimates velocity from consecutive
+ * samples, so a test that let the wall clock supply them would be measuring
+ * the machine.
+ */
+function sweep(wnd, from, to, { steps = 5, msPerStep = 10 } = {}) {
+  for (let i = 1; i <= steps; i++) {
+    const k = i / steps;
+    moveMouse(
+      wnd,
+      Math.round(from.x + (to.x - from.x) * k),
+      Math.round(from.y + (to.y - from.y) * k),
+      { time: 1000 + i * msPerStep },
+    );
+  }
+}
+
+async function mount(element) {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const instance = await new Promise((res) => x11Root.render(element, res));
+  const root = instance._reactX11Node;
+  root._scheduled = false;
+  root.flush();
+  await tick();
+  return { app, x11Root, root, wnd: app.windows[0] };
+}
+
+const find = (node, key) => {
+  if (node.props?.testId === key) return node;
+  for (const child of node.children ?? []) {
+    const hit = find(child, key);
+    if (hit) return hit;
+  }
+  return null;
+};
+
+// --- the cost of not using it ----------------------------------------------
+
+test('a tree with no attention anywhere runs nothing per motion event', async () => {
+  const { x11Root, root, wnd } = await mount(
+    h(
+      'window',
+      { width: 400, height: 400 },
+      boxAt({}, { x: 200, y: 180, width: 60, height: 40 }),
+      h('box', {
+        style: { width: 10, height: 10, ':hover': { color: '#fff' } },
+      }),
+    ),
+  );
+
+  assert.strictEqual(
+    root._attentionNodes.size,
+    0,
+    'nothing registered, so there is nothing to match against',
+  );
+
+  // the guard in _onMouseMove is a `size` read on this set; if it ever stops
+  // being the only thing between a motion event and the tracker, this fails
+  let ran = 0;
+  const real = root.events._updateAttention.bind(root.events);
+  root.events._updateAttention = (...a) => {
+    ran++;
+    return real(...a);
+  };
+  sweep(wnd, { x: 10, y: 200 }, { x: 120, y: 200 });
+  await tick();
+  assert.strictEqual(ran, 0, 'the tracker never ran');
+
+  await x11Root.unmount();
+});
+
+test('a node registers by prop or by style block, and unregisters again', async () => {
+  const { x11Root, root } = await mount(
+    h(
+      'window',
+      { width: 400, height: 400 },
+      boxAt(
+        { testId: 'byProp', unstable_onAttention: () => {} },
+        { x: 10, y: 10, width: 20, height: 20 },
+      ),
+      boxAt(
+        { testId: 'byStyle' },
+        {
+          x: 40,
+          y: 10,
+          width: 20,
+          height: 20,
+          ':attention': { backgroundColor: '#f00' },
+        },
+      ),
+      boxAt({ testId: 'neither' }, { x: 70, y: 10, width: 20, height: 20 }),
+    ),
+  );
+  assert.strictEqual(
+    root._attentionNodes.size,
+    2,
+    'the prop and the block, not the plain box',
+  );
+  assert.ok(root._attentionNodes.has(find(root, 'byProp')));
+  assert.ok(root._attentionNodes.has(find(root, 'byStyle')));
+  assert.ok(!root._attentionNodes.has(find(root, 'neither')));
+
+  // dropping the prop drops the registration
+  await new Promise((res) =>
+    x11Root.render(
+      h(
+        'window',
+        { width: 400, height: 400 },
+        boxAt({ testId: 'byProp' }, { x: 10, y: 10, width: 20, height: 20 }),
+        boxAt(
+          { testId: 'byStyle' },
+          {
+            x: 40,
+            y: 10,
+            width: 20,
+            height: 20,
+            ':attention': { backgroundColor: '#f00' },
+          },
+        ),
+        boxAt({ testId: 'neither' }, { x: 70, y: 10, width: 20, height: 20 }),
+      ),
+      res,
+    ),
+  );
+  await tick();
+  assert.strictEqual(
+    root._attentionNodes.size,
+    1,
+    'only the style block is left',
+  );
+
+  await x11Root.unmount();
+});
+
+test('an inline handler does not repaint the node on every render', async () => {
+  // `unstable_onAttention` does not match the plain `/^on[A-Z]/` an event prop
+  // used to be recognised by, and both callers of `isEventProp` care. This is
+  // the one that bites silently: `paintChanged` compares every prop it does
+  // not know about by identity, so an unrecognised handler would make a fresh
+  // inline arrow — which is what every render passes — read as a changed prop
+  // and claim a full repaint of the node, forever.
+  const { x11Root, root } = await mount(
+    h(
+      'window',
+      { width: 400, height: 400 },
+      boxAt(
+        { testId: 'target', unstable_onAttention: () => {} },
+        { x: 200, y: 180, width: 60, height: 40 },
+      ),
+    ),
+  );
+  const target = find(root, 'target');
+  const prev = { unstable_onAttention: () => {} };
+  const next = { unstable_onAttention: () => {} };
+  assert.notStrictEqual(prev.unstable_onAttention, next.unstable_onAttention);
+  assert.strictEqual(
+    target.paintChanged(next, prev),
+    false,
+    'a new function identity is not a paint change',
+  );
+  // and the window path agrees: a handler is not a CreateWindow attribute
+  assert.ok(isEventProp('unstable_onAttention'));
+  await x11Root.unmount();
+});
+
+// --- the routing ------------------------------------------------------------
+
+test('a box the pointer is heading for hears about it before the pointer arrives', async () => {
+  const seen = [];
+  const { x11Root, root, wnd } = await mount(
+    h(
+      'window',
+      { width: 400, height: 400 },
+      boxAt(
+        { testId: 'ahead', unstable_onAttention: (ev) => seen.push(ev) },
+        { x: 200, y: 180, width: 60, height: 40 },
+      ),
+    ),
+  );
+
+  // 10 → 60 along y=200 at 1 device px/ms: the box starts 140px ahead, which
+  // is 140ms away and inside the horizon
+  sweep(wnd, { x: 10, y: 200 }, { x: 60, y: 200 });
+  await tick();
+
+  assert.strictEqual(seen.length, 1, 'fired once, on arrival of attention');
+  const ahead = find(root, 'ahead');
+  assert.strictEqual(root.events.attentionNode, ahead);
+  assert.ok(
+    seen[0].eta > 100 && seen[0].eta < 200,
+    `eta should be about 140ms, got ${seen[0].eta}`,
+  );
+  assert.ok(
+    !ahead.states[':hover'],
+    'and the pointer has not actually got there — that is the whole point',
+  );
+
+  await x11Root.unmount();
+});
+
+test('direction decides it, not distance: a box behind the pointer never matches', async () => {
+  const seen = [];
+  const { x11Root, wnd } = await mount(
+    h(
+      'window',
+      { width: 400, height: 400 },
+      // 30px behind the sweep's start, far closer than the box in the test
+      // above, and never nominated
+      boxAt(
+        { unstable_onAttention: () => seen.push('behind') },
+        { x: 100, y: 180, width: 40, height: 40 },
+      ),
+    ),
+  );
+  sweep(wnd, { x: 150, y: 200 }, { x: 200, y: 200 });
+  await tick();
+  assert.deepStrictEqual(seen, [], 'the pointer is moving away from it');
+  await x11Root.unmount();
+});
+
+test('a box off the line of travel is not on the way', async () => {
+  const seen = [];
+  const { x11Root, wnd } = await mount(
+    h(
+      'window',
+      { width: 400, height: 400 },
+      // directly ahead in x, but the sweep runs along y=200 and this sits at
+      // the top of the window
+      boxAt(
+        { unstable_onAttention: () => seen.push('aside') },
+        { x: 200, y: 0, width: 60, height: 40 },
+      ),
+    ),
+  );
+  sweep(wnd, { x: 10, y: 200 }, { x: 60, y: 200 });
+  await tick();
+  assert.deepStrictEqual(seen, []);
+  await x11Root.unmount();
+});
+
+test('the soonest candidate wins, and only one holds attention at a time', async () => {
+  const seen = [];
+  const { x11Root, root, wnd } = await mount(
+    h(
+      'window',
+      { width: 400, height: 400 },
+      boxAt(
+        { testId: 'near', unstable_onAttention: () => seen.push('near') },
+        { x: 150, y: 180, width: 40, height: 40 },
+      ),
+      boxAt(
+        { testId: 'far', unstable_onAttention: () => seen.push('far') },
+        { x: 260, y: 180, width: 40, height: 40 },
+      ),
+    ),
+  );
+
+  sweep(wnd, { x: 10, y: 200 }, { x: 60, y: 200 });
+  await tick();
+  assert.deepStrictEqual(seen, ['near'], 'the one it reaches first');
+  assert.strictEqual(root.events.attentionNode, find(root, 'near'));
+  assert.ok(find(root, 'near').states[':attention']);
+  assert.ok(!find(root, 'far').states[':attention']);
+
+  // carry on past the near box and the far one becomes the soonest
+  sweep(wnd, { x: 200, y: 200 }, { x: 250, y: 200 });
+  await tick();
+  assert.deepStrictEqual(seen, ['near', 'far']);
+  assert.strictEqual(root.events.attentionNode, find(root, 'far'));
+  assert.ok(
+    !find(root, 'near').states[':attention'],
+    'the previous holder gives it up — only one node has attention',
+  );
+
+  await x11Root.unmount();
+});
+
+test('overlapping boxes are resolved by which one the trajectory enters first', async () => {
+  const seen = [];
+  const { x11Root, wnd } = await mount(
+    h(
+      'window',
+      { width: 400, height: 400 },
+      // `under` is painted first and reaches further left, so the ray enters
+      // it first even though `over` is on top of it in the stack
+      boxAt(
+        { unstable_onAttention: () => seen.push('under') },
+        { x: 180, y: 170, width: 120, height: 60 },
+      ),
+      boxAt(
+        { unstable_onAttention: () => seen.push('over') },
+        { x: 220, y: 180, width: 60, height: 40 },
+      ),
+    ),
+  );
+  sweep(wnd, { x: 10, y: 200 }, { x: 60, y: 200 });
+  await tick();
+  assert.deepStrictEqual(seen, ['under'], 'entry order, not stacking order');
+  await x11Root.unmount();
+});
+
+test('attention does not bubble: a parent hears nothing for its child', async () => {
+  const seen = [];
+  const { x11Root, wnd } = await mount(
+    h(
+      'window',
+      { width: 400, height: 400 },
+      h(
+        'box',
+        {
+          // the parent is not a candidate — no prop, no block — so its rect
+          // containing the child's buys it nothing
+          style: {
+            position: 'absolute',
+            left: 190,
+            top: 170,
+            width: 100,
+            height: 60,
+          },
+        },
+        boxAt(
+          { unstable_onAttention: () => seen.push('child') },
+          { x: 10, y: 10, width: 60, height: 40 },
+        ),
+      ),
+      h('box', {
+        unstable_onAttentionCapture: () => seen.push('capture'),
+        style: { position: 'absolute', left: 0, top: 0, width: 1, height: 1 },
+      }),
+    ),
+  );
+  sweep(wnd, { x: 10, y: 200 }, { x: 60, y: 200 });
+  await tick();
+  assert.deepStrictEqual(
+    seen,
+    ['child'],
+    'the matched node only — there is no capture or bubble phase',
+  );
+  await x11Root.unmount();
+});
+
+test('a resting pointer falls back to what is under it rather than extrapolating noise', async () => {
+  const seen = [];
+  const { x11Root, root, wnd } = await mount(
+    h(
+      'window',
+      { width: 400, height: 400 },
+      boxAt(
+        { testId: 'under', unstable_onAttention: () => seen.push('under') },
+        { x: 100, y: 180, width: 60, height: 40 },
+      ),
+      boxAt(
+        { unstable_onAttention: () => seen.push('elsewhere') },
+        { x: 300, y: 180, width: 60, height: 40 },
+      ),
+    ),
+  );
+
+  // a hand at rest: a pixel of jitter over 40ms is well under the speed floor
+  moveMouse(wnd, 130, 200, { time: 1000 });
+  moveMouse(wnd, 131, 200, { time: 1040 });
+  moveMouse(wnd, 130, 201, { time: 1080 });
+  await tick();
+
+  assert.deepStrictEqual(seen, ['under'], 'the box the pointer is actually in');
+  assert.strictEqual(root.events.attentionNode, find(root, 'under'));
+  await x11Root.unmount();
+});
+
+test('leaving the window gives up attention', async () => {
+  const { x11Root, root, wnd } = await mount(
+    h(
+      'window',
+      { width: 400, height: 400 },
+      boxAt(
+        { testId: 'ahead', unstable_onAttention: () => {} },
+        { x: 200, y: 180, width: 60, height: 40 },
+      ),
+    ),
+  );
+  sweep(wnd, { x: 10, y: 200 }, { x: 60, y: 200 });
+  await tick();
+  assert.ok(root.events.attentionNode, 'held');
+
+  wnd.emit('mouseout', { x: -1, y: 200 });
+  await tick();
+  assert.strictEqual(root.events.attentionNode, null);
+  assert.ok(!find(root, 'ahead').states[':attention']);
+  await x11Root.unmount();
+});
+
+test('a popup keeps its own candidates: registries do not cross windows', async () => {
+  const seen = [];
+  const { x11Root, root, wnd } = await mount(
+    h(
+      'window',
+      { width: 400, height: 400 },
+      boxAt(
+        { testId: 'inWindow', unstable_onAttention: () => seen.push('window') },
+        { x: 200, y: 180, width: 60, height: 40 },
+      ),
+      h(
+        'popup',
+        { x: 10, y: 10, width: 200, height: 120 },
+        boxAt(
+          { testId: 'inPopup', unstable_onAttention: () => seen.push('popup') },
+          { x: 100, y: 40, width: 60, height: 40 },
+        ),
+      ),
+    ),
+  );
+
+  const popupNode = root.children.find((n) => n.isPopup);
+  assert.ok(popupNode, 'the popup mounted');
+  const inPopup = find(root, 'inPopup');
+  const inWindow = find(root, 'inWindow');
+
+  // A `<popup>` is its own X window with its own pointer stream and its own
+  // coordinate space, so a candidate inside one must never be matched against
+  // the owner's pointer — `abs` would be read in the wrong space and the
+  // prediction would point at a rectangle that is somewhere else entirely.
+  //
+  // Two things happen to make that true, and only the second is a decision.
+  // `insertBefore` splices a popup in as bookkeeping only and never hands it
+  // the parent's root, so it keeps the `root = this` its constructor gave it
+  // and its subtree registers with it. And the registry is **per window**
+  // rather than per connection, which is the part worth pinning: one shared
+  // set would be the obvious simplification, it would look right in every
+  // single-window test, and it is what this fails on.
+  assert.ok(
+    root._attentionNodes.has(inWindow),
+    'the window owns the box declared in it',
+  );
+  assert.ok(
+    !root._attentionNodes.has(inPopup),
+    'and not the one inside the popup',
+  );
+  assert.ok(popupNode._attentionNodes.has(inPopup), 'the popup owns that one');
+
+  // driving the owner window's pointer can only ever reach the owner's
+  // candidate, whatever the popup's geometry happens to overlap
+  sweep(wnd, { x: 10, y: 200 }, { x: 60, y: 200 });
+  await tick();
+  assert.deepStrictEqual(seen, ['window']);
+  assert.strictEqual(popupNode.events.attentionNode, null);
+
+  await x11Root.unmount();
+});
+
+// --- the style block --------------------------------------------------------
+
+test(':attention paints, and loses to :hover once the pointer really arrives', async () => {
+  const { x11Root, root, wnd } = await mount(
+    h(
+      'window',
+      { width: 400, height: 400, style: { backgroundColor: '#000' } },
+      boxAt(
+        { testId: 'target' },
+        {
+          x: 200,
+          y: 180,
+          width: 60,
+          height: 40,
+          backgroundColor: '#111111',
+          ':attention': { backgroundColor: '#222222' },
+          ':hover': { backgroundColor: '#333333' },
+        },
+      ),
+    ),
+  );
+  const target = find(root, 'target');
+  assert.strictEqual(target.style.backgroundColor, '#111111', 'resting');
+
+  sweep(wnd, { x: 10, y: 200 }, { x: 60, y: 200 });
+  await tick();
+  assert.ok(target.states[':attention']);
+  assert.strictEqual(
+    target.style.backgroundColor,
+    '#222222',
+    'heading there, not there yet',
+  );
+
+  // and now actually arrive: both states are on, and `:hover` outranks the
+  // prediction because it is a fact
+  moveMouse(wnd, 230, 200, { time: 2000 });
+  await tick();
+  assert.ok(target.states[':hover']);
+  assert.strictEqual(target.style.backgroundColor, '#333333');
+
+  await x11Root.unmount();
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -493,6 +493,20 @@ const _fitContent = <window width="fit-content" />;
 // @ts-expect-error — there is no containing block to be a percentage of
 const _percent = <window height="100%" />;
 
+// Attention: the handler takes an AttentionEvent with an `eta`, the style
+// block is a state block like any other, and neither propagates.
+const _attention = (
+  <box
+    unstable_onAttention={(ev) => {
+      const ms: number = ev.eta;
+      void ms;
+    }}
+    style={{ ':attention': { backgroundColor: '#333' } }}
+  />
+);
+// @ts-expect-error — a state block may only set paint properties
+const _attentionLayout = <box style={{ ':attention': { padding: 4 } }} />;
+
 // `xi2` is a three-way choice, not a boolean: 'auto' (the default) selects
 // XI2 on the first wheel, `true` at creation, `false` never.
 const _xi2Auto = <window xi2="auto" />;


### PR DESCRIPTION
A prototype for [ntk#37](https://github.com/sidorares/ntk/issues/37) — *"when it's likely that user is about to click, notify all interested parties"*.

`unstable_onAttention` fires when the pointer looks like it is heading for a node and **has not arrived**, so an application can start work early: warm a cache, decode an image, send the query the click is going to want. `:attention` is the style half.

```jsx
<box
  unstable_onAttention={(ev) => prefetchRow(id, { budgetMs: ev.eta })}
  style={{ ':attention': { borderColor: '$accent' } }}
/>
```

> **Deliberately provisional, in the two ways that carry weight.** Nothing in `docs/` mentions this — that file set is byte-identical to master — and the handler is named `unstable_onAttention`.
>
> The prefix rather than a tag, because on a hand-written `.d.ts` no tag does anything: `tsc` acts on `@deprecated` and nothing else, TSDoc's `@experimental`/`@beta` need API Extractor, and `@internal` only affects declaration emit, which this package does not do. The name is the only part a caller cannot miss. **`:attention` deliberately keeps its plain name** — there is no prefix convention for a pseudo-state, and a style block someone experiments with is far cheaper to abandon than a handler an application has built a loading strategy around.
>
> One catch worth flagging, since it would have shipped silently: `isEventProp` was `/^on[A-Z]/`, which the prefixed name does not match. It gates window-attribute assembly *and* `paintChanged` — and an unrecognised handler prop makes the fresh inline arrow every render passes read as a changed prop, claiming a full repaint of the node forever. The regex widens to `/^(?:unstable_)?on[A-Z]/` and there is a mutation-checked test.

![attention-shot](https://github.com/user-attachments/assets/b27647d6-ea38-419c-9e52-9f954c536c87)

Left panel: the pointer is at 118,128 heading **→**, so `two` — which it has not touched — carries the prediction. Right panel: the same scene with the pointer at 460,128 heading **←**, and `four` has it instead. Same boxes, same distances, different answer. Rendered by this branch's own code.

## The routing is the design

Every other pointer event here starts from a hit test: find the node under the pointer, build its ancestor path, walk it. Attention cannot, because the point is to reach a node the pointer has *not* got to.

So nodes that want it **register themselves**, and each motion event turns the recent pointer samples into a velocity, asks every candidate rectangle when that trajectory would enter it (ray/AABB, so the parameter that falls out *is* the time to arrival), and gives attention to the soonest answer inside a 250ms horizon.

Three consequences, all of which surprise people expecting `onMouseEnter`:

- **No capture and no bubble.** Only the matched node hears about it. An ancestor is not "on the way to" its child in any sense the pointer knows, and a handler firing for a descendant it never named would be guessing. An ancestor that wants attention declares it and is matched on its own rectangle, like anything else.
- **Direction decides it, not distance.** A box 30px behind the pointer is never nominated; one 200px ahead is, if the pointer is moving fast enough to arrive inside the horizon.
- **One node per window holds it**, and the previous holder gives it up as the new one takes it.

Below a speed floor (~50 px/s) there is no trajectory worth extrapolating — a resting hand jitters a pixel or two and its "direction" is noise, which would point attention around the room while somebody reads. The slow case degrades to the candidate under the pointer.

## Nothing runs for a tree that doesn't use it

This was an explicit requirement and it shaped the design. Candidates live in a per-window registry rather than being discovered by a walk, so the whole feature costs **one `Set.size` read per motion event** when the set is empty — no hit test, no iteration, no allocation:

```js
// _onMouseMove, last line
if (this._attentionNodes.size !== 0) this._updateAttention(native);
```

It is last on purpose as well as cheap: "answer the input, not the outcome" says the real response to *this* motion — the hover repaint, the drag — goes out before anything done on a guess about the next one. A test spies on the tracker and fails if anything is ever added above that guard.

## `:attention`

Lowest-precedence state block, below `:hover`. It is the only *prediction* in the list and every other state is a fact, so the moment the pointer actually lands `:hover` wins. Declaring the block is also what registers the node, so a purely visual use needs no handler at all — and, like `:hover`, it is a repaint of one node with no React render.

## There is no "attention lost"

You asked me to think about this one. I looked at calling the handler with `null` on the way out, and at a separate lost event, and shipped neither.

Work started on a hint does not want undoing because the pointer changed its mind — a warmed cache does not need cooling — and anything *visual* is already `:attention`, which clears itself. A `null` argument would put a null check in every handler to serve the rare case. If a real use turns up the seam is a second prop, which composes better than overloading the one that exists.

The measured argument for this landed after the fact and is in a comment below: attention changes hands ~1.8 times per approach, so roughly half of all grants are wasted. That makes the handler contract "cheap, idempotent, pointless-if-unused" — and anything you would want to undo should not have been started.

`ev.eta` — roughly how many milliseconds away the pointer is at the moment attention is granted — is on the event because it is the number actually worth branching on: 30ms and 220ms justify very different amounts of speculative work.

## Verification

`test/attention.test.js`, 11 tests, **mutation-checked** — matching by distance instead of trajectory fails the two direction tests; moving `:attention` above `:hover` fails the precedence test; dropping the previous-holder clear fails the single-holder and mouseout tests; removing the guard fails the zero-cost test.

Full suite at the usual six macOS-only `appearance.test.js` failures, identical on master. Lint, typecheck and `prettier --check .` clean. The `.d.ts` entries and the type test move with the API; `docs/` is untouched.

## Cost of merging, and of removing it again

Measured, not estimated:

| | added | deleted |
|---|---|---|
| Implementation (`events.js`, `nodes.js`, `styles.js`) | 240 | **0** |
| — real code, comments and blanks stripped | **110** | |
| Types, test helper, example, tests | 767 | 3 |

Zero deletions in the implementation is the structural point: **nothing existing was rewritten**, so nothing has to be restored on removal. The whole coupling is five insertions — one line in `STATE_KEYS`, three small blocks in `nodes.js` (two of them copies of the `_supportsQueryNodes` pattern directly beside them), and two one-line hooks in `EventManager`. Nothing in `src/components/` or elsewhere in `src/` refers to it.

I checked removability by doing it rather than claiming it: `git revert` of this commit on a scratch branch diffs to **exactly zero** against master, with lint, typecheck, format and the full suite green. If it does not earn its keep, it comes out in one command.

## Prototype caveats, deliberately left

- **The tuning is guesses.** 250ms horizon, 5 samples, 50 px/s floor. They behave well in the example but nothing has calibrated them against real pointer traces.
- **No slop on the rectangles.** A trajectory that passes 2px beside a box does not nominate it. Real futurelink grew its targets; whether that is better here wants a real UI to try it on.
- **The candidate scan is linear** in registered nodes per motion event. I guessed this would matter and then measured it, and it does not: **~9 ns per candidate**, so even a thousand of them cost 8.6 µs per motion event — half a millisecond per second of pointer movement at 60Hz. A spatial index is not needed anywhere near a plausible UI. (Measured by mounting one 1000-box tree and resizing the registry between interleaved trials, so only the candidate count moves. For context, the *hit test* on that same 1000-box tree is 15.8 µs per event — the existing motion path dwarfs the scan.)

| candidates | µs/event | vs 0 | ms/s at 60Hz |
|---|---|---|---|
| 0 | 15.79 | — | 0.95 |
| 10 | 15.90 | +0.10 | 0.95 |
| 100 | 16.50 | +0.71 | 0.99 |
| 500 | 22.28 | +6.49 | 1.34 |
| 1000 | 24.40 | +8.60 | 1.46 |




