### PR TITLE
perf(startup): overlap the engine load with the connection, and gate the pixels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,10 @@ jobs:
       # header of scripts/bench/protocol.js) and the tolerances absorb it,
       # but a real regression fails twice; a rare unlucky run does not.
       - run: npm run bench -- --check || npm run bench -- --check
+      # The other half of the gate, and the one that makes the first half
+      # safe: cheaper is only an optimization if the picture is the same.
+      # No retry here — a hash is exact, so a second run cannot disagree.
+      - run: npm run bench:pixels -- --check
 
   lint:
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "screenshots": "tsx scripts/screenshots.jsx",
     "screenshots:framed": "tsx scripts/screenshots-framed.jsx",
     "bench": "tsx scripts/bench/protocol.js",
+    "bench:pixels": "tsx scripts/bench/pixels.js",
     "bench:frames": "tsx scripts/bench/frames.js",
     "docs:dev": "npm --prefix website start",
     "docs:build": "npm --prefix website run build",

--- a/scripts/bench/pixels-baseline.json
+++ b/scripts/bench/pixels-baseline.json
@@ -2,6 +2,5 @@
   "solid fills under a clip": "30a44bc8ffd66703",
   "rounded boxes and borders": "178942043ff2164a",
   "text runs": "bbad89e45de078eb",
-  "gradient and shadow": "5c2558495d531802",
-  "partial repaint": "3643cc723b13bfb8"
+  "gradient and shadow": "5c2558495d531802"
 }

--- a/scripts/bench/pixels-baseline.json
+++ b/scripts/bench/pixels-baseline.json
@@ -1,0 +1,7 @@
+{
+  "solid fills under a clip": "30a44bc8ffd66703",
+  "rounded boxes and borders": "178942043ff2164a",
+  "text runs": "bbad89e45de078eb",
+  "gradient and shadow": "5c2558495d531802",
+  "partial repaint": "3643cc723b13bfb8"
+}

--- a/scripts/bench/pixels.js
+++ b/scripts/bench/pixels.js
@@ -1,0 +1,321 @@
+// Pixel-identity gate: did the picture change?
+//
+//   npm run bench:pixels            # print the hashes
+//   npm run bench:pixels -- --save  # rewrite the committed baseline
+//   npm run bench:pixels -- --check # fail if any scenario's pixels moved
+//
+// The protocol bench answers "how much work did that cost". This answers the
+// question that makes an answer to the first one *safe*: a protocol change is
+// only an optimization if the surface it produces is the same surface. Every
+// finding in the audit that motivated this lane was argued pixel-identical on
+// paper — that argument deserves a machine that checks it.
+//
+// So each scenario mounts a tree into a real window on node-x11's in-process
+// server, settles, reads the window back through its 2d context, and hashes
+// the bytes. `getImageData` is the canvas contract — straight, unpremultiplied
+// RGBA off the backing pixmap, so the read is valid under occlusion and needs
+// no channel swapping (scripts/capture.js says more about why that sentence
+// has to be written down).
+//
+// A hash is a blunt instrument on purpose: it cannot say *what* moved, only
+// that something did. When it fails, render the scenario and look — and if
+// the change is intended (a rasterizer bump in ntk shifts antialiased edges
+// everywhere, legitimately), re-save the baseline in the same commit that
+// explains it. What must not happen is a baseline re-saved silently in a
+// commit whose message says "no visual change".
+import { createHash } from 'node:crypto';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import React from 'react';
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient, StaticFontSource } from 'ntk';
+
+import { captureWindow } from '../capture.js';
+
+process.env.REACT_X11_NO_AUTORUN = '1';
+const { createRoot } = await import('../../src/index.js');
+
+const require = createRequire(import.meta.url);
+const fontDir = join(
+  dirname(require.resolve('katex/package.json')),
+  'dist',
+  'fonts',
+);
+const baselinePath = join(
+  dirname(new URL(import.meta.url).pathname),
+  'pixels-baseline.json',
+);
+
+const W = 400;
+const H = 400;
+const h = React.createElement;
+
+async function connect() {
+  const server = xserver.createServer({ width: W, height: H });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const source = new StaticFontSource();
+  // the same pinned face the protocol bench uses, so neither lane depends on
+  // what fontconfig happens to find on the machine running it
+  source.add(readFileSync(join(fontDir, 'KaTeX_Main-Regular.ttf')), {
+    family: 'Bench',
+  });
+  source.alias('sans-serif', 'Bench');
+  return createClient({ stream: clientEnd, fontSource: source });
+}
+
+const window_ = (...children) =>
+  h(
+    'window',
+    { width: W, height: H, style: { backgroundColor: '#f5f6fa' } },
+    ...children,
+  );
+
+/**
+ * Scenarios chosen to cover the drawing vocabulary the audit's findings
+ * touch, not to be exhaustive: a rectangular clip and a solid fill (the
+ * `_fillRect` mask path), rounded fills and borders (the corner-glyph fast
+ * path and its clip bracket), text (glyph runs and the shared glyph cache),
+ * translucency and gradients (the non-trivial composite ops), and a partial
+ * repaint (the damage path, whose whole contract is that it leaves the
+ * surface a full repaint would have left).
+ */
+const SCENARIOS = [
+  [
+    'solid fills under a clip',
+    () =>
+      window_(
+        h('box', {
+          style: {
+            position: 'absolute',
+            left: 20,
+            top: 20,
+            width: 160,
+            height: 90,
+            backgroundColor: '#2980b9',
+          },
+        }),
+        h('box', {
+          style: {
+            position: 'absolute',
+            left: 60,
+            top: 70,
+            width: 200,
+            height: 120,
+            backgroundColor: '#e74c3c',
+          },
+        }),
+      ),
+  ],
+  [
+    'rounded boxes and borders',
+    () =>
+      window_(
+        h(
+          'box',
+          {
+            style: {
+              flexGrow: 1,
+              padding: 12,
+              gap: 10,
+              flexDirection: 'row',
+              flexWrap: 'wrap',
+            },
+          },
+          ...Array.from({ length: 12 }, (_, i) =>
+            h('box', {
+              key: i,
+              style: {
+                width: 80,
+                height: 44,
+                borderRadius: 2 + i,
+                borderWidth: (i % 3) + 1,
+                borderColor: '#2d3436',
+                backgroundColor: i % 2 ? '#ffffff' : '#dfe6e9',
+              },
+            }),
+          ),
+        ),
+      ),
+  ],
+  [
+    'text runs',
+    () =>
+      window_(
+        h(
+          'box',
+          { style: { flexGrow: 1, padding: 10, gap: 4 } },
+          ...Array.from({ length: 10 }, (_, i) =>
+            h(
+              'text',
+              { key: i, style: { fontSize: 11 + (i % 4), color: '#2d3436' } },
+              `Line ${i}: the quick brown fox jumps over the lazy dog`,
+            ),
+          ),
+        ),
+      ),
+  ],
+  [
+    'gradient and shadow',
+    () =>
+      window_(
+        h(
+          'box',
+          {
+            style: {
+              flexGrow: 1,
+              padding: 14,
+              gap: 12,
+              flexDirection: 'row',
+              flexWrap: 'wrap',
+            },
+          },
+          ...Array.from({ length: 6 }, (_, i) =>
+            h('box', {
+              key: i,
+              style: {
+                width: 100,
+                height: 60,
+                borderRadius: 6,
+                backgroundImage:
+                  'linear-gradient(160deg, #2b5876 20%, #4e4376)',
+                boxShadow: '0 2px 6px rgba(0, 0, 0, .45)',
+              },
+            }),
+          ),
+        ),
+      ),
+  ],
+];
+
+/**
+ * The damage path's own contract, as a scenario: paint a change through the
+ * partial-repaint path, then hash. `dirty-rect.test.js` proves partial and
+ * full agree for a set of changes; this pins the *result* across releases, so
+ * a rasterizer or clip change that moved both equally still shows up here.
+ */
+async function partialRepaint(app, x11Root) {
+  const tree = (color) =>
+    window_(
+      h('box', {
+        style: {
+          position: 'absolute',
+          left: 40,
+          top: 40,
+          width: 120,
+          height: 70,
+          borderRadius: 8,
+          borderWidth: 2,
+          borderColor: '#2d3436',
+          backgroundColor: color,
+        },
+      }),
+      h(
+        'text',
+        { style: { position: 'absolute', left: 40, top: 140, fontSize: 13 } },
+        'unchanged label',
+      ),
+    );
+  const instance = await new Promise((resolve) =>
+    x11Root.render(tree('#3498db'), resolve),
+  );
+  const root = instance._reactX11Node;
+  root._scheduled = false;
+  root.flush();
+  await settle(app);
+  await new Promise((resolve) =>
+    x11Root.render(tree('#e74c3c'), () => resolve()),
+  );
+  root._scheduled = false;
+  root.flush();
+  await settle(app);
+  return root;
+}
+
+const settle = (app) =>
+  new Promise((resolve) => app.X.GetInputFocus(() => resolve()));
+
+async function hashOf(name, build) {
+  const app = await connect();
+  const x11Root = await createRoot({ app });
+  let root;
+  if (typeof build === 'function' && build.length === 2) {
+    root = await build(app, x11Root);
+  } else {
+    const instance = await new Promise((resolve) =>
+      x11Root.render(build(), resolve),
+    );
+    root = instance._reactX11Node;
+    root._scheduled = false;
+    root.flush();
+    await settle(app);
+  }
+  const shot = await captureWindow(root.window);
+  const digest = createHash('sha256')
+    .update(`${shot.width}x${shot.height}:`)
+    .update(
+      Buffer.from(shot.data.buffer, shot.data.byteOffset, shot.data.length),
+    )
+    .digest('hex')
+    .slice(0, 16);
+  await app.close();
+  return [name, digest];
+}
+
+const results = {};
+for (const [name, build] of SCENARIOS) {
+  process.stderr.write(`· ${name}\n`);
+  const [key, digest] = await hashOf(name, build);
+  results[key] = digest;
+}
+process.stderr.write('· partial repaint\n');
+{
+  const [key, digest] = await hashOf('partial repaint', partialRepaint);
+  results[key] = digest;
+}
+
+const args = process.argv.slice(2);
+if (args.includes('--save')) {
+  writeFileSync(baselinePath, `${JSON.stringify(results, null, 2)}\n`);
+  console.log(`wrote ${baselinePath}`);
+}
+
+for (const [name, digest] of Object.entries(results)) {
+  console.log(`${name.padEnd(30)} ${digest}`);
+}
+
+if (args.includes('--check')) {
+  let baseline;
+  try {
+    baseline = JSON.parse(readFileSync(baselinePath, 'utf8'));
+  } catch {
+    console.error(
+      '\nno pixel baseline — run `npm run bench:pixels -- --save` first',
+    );
+    process.exit(1);
+  }
+  const moved = [];
+  for (const [name, digest] of Object.entries(results)) {
+    if (baseline[name] === undefined) {
+      moved.push(`${name} — new scenario, not in the baseline`);
+    } else if (baseline[name] !== digest) {
+      moved.push(`${name} — ${baseline[name]} -> ${digest}`);
+    }
+  }
+  for (const name of Object.keys(baseline)) {
+    if (results[name] === undefined) moved.push(`${name} — gone from this run`);
+  }
+  if (moved.length) {
+    console.error('\nthe picture changed:');
+    for (const line of moved) console.error(`  ${line}`);
+    console.error(
+      '\nIf that was the point, re-save the baseline in the commit that ' +
+        'explains why. If it was not, this is the regression.',
+    );
+    process.exit(1);
+  }
+  console.log('\npixels unchanged');
+}
+
+process.exit(0);

--- a/scripts/bench/pixels.js
+++ b/scripts/bench/pixels.js
@@ -190,10 +190,23 @@ const SCENARIOS = [
 ];
 
 /**
- * The damage path's own contract, as a scenario: paint a change through the
- * partial-repaint path, then hash. `dirty-rect.test.js` proves partial and
- * full agree for a set of changes; this pins the *result* across releases, so
- * a rasterizer or clip change that moved both equally still shows up here.
+ * The damage path's own contract — checked *within a run*, not against the
+ * committed baseline.
+ *
+ * The first version of this hashed the partial repaint like any other
+ * scenario, and it was the one scenario whose hash differed between macOS and
+ * Linux while the other four matched byte for byte. The difference is not the
+ * rasterizer: it is that this scenario is the only one whose result depends on
+ * *when* the capture happens relative to asynchronous work (a glyph handoff
+ * behind the label, a paint the damage path has not flushed yet). Pinning a
+ * timing-sensitive image in a committed file makes the file wrong on some
+ * machine somewhere.
+ *
+ * What is worth checking here is not the picture but the invariant: a partial
+ * repaint must leave the surface exactly as a full repaint of the same tree
+ * would. Both halves are painted in the same process, moments apart, so the
+ * comparison is immune to anything that shifts both equally — which is exactly
+ * what a platform difference does.
  */
 async function partialRepaint(app, x11Root) {
   const tree = (color) =>
@@ -230,7 +243,27 @@ async function partialRepaint(app, x11Root) {
   root._scheduled = false;
   root.flush();
   await settle(app);
-  return root;
+  const partial = await captureWindow(root.window);
+
+  // The same tree again with the damage discarded: everything repaints.
+  root.needsPaint = true;
+  root._damage = null;
+  root.flush();
+  await settle(app);
+  const full = await captureWindow(root.window);
+
+  let differing = 0;
+  for (let i = 0; i < full.data.length; i += 4) {
+    if (
+      partial.data[i] !== full.data[i] ||
+      partial.data[i + 1] !== full.data[i + 1] ||
+      partial.data[i + 2] !== full.data[i + 2] ||
+      partial.data[i + 3] !== full.data[i + 3]
+    ) {
+      differing += 1;
+    }
+  }
+  return differing;
 }
 
 const settle = (app) =>
@@ -269,11 +302,13 @@ for (const [name, build] of SCENARIOS) {
   const [key, digest] = await hashOf(name, build);
   results[key] = digest;
 }
-process.stderr.write('· partial repaint\n');
-{
-  const [key, digest] = await hashOf('partial repaint', partialRepaint);
-  results[key] = digest;
-}
+
+// Not hashed, and not in the baseline: an invariant checked inside this run.
+process.stderr.write('· partial repaint vs full\n');
+const damageApp = await connect();
+const damageRoot = await createRoot({ app: damageApp });
+const differingPixels = await partialRepaint(damageApp, damageRoot);
+await damageApp.close();
 
 const args = process.argv.slice(2);
 if (args.includes('--save')) {
@@ -284,6 +319,11 @@ if (args.includes('--save')) {
 for (const [name, digest] of Object.entries(results)) {
   console.log(`${name.padEnd(30)} ${digest}`);
 }
+console.log(
+  `${'partial repaint vs full'.padEnd(30)} ${
+    differingPixels === 0 ? 'identical' : `${differingPixels} pixels differ`
+  }`,
+);
 
 if (args.includes('--check')) {
   let baseline;
@@ -312,6 +352,13 @@ if (args.includes('--check')) {
     console.error(
       '\nIf that was the point, re-save the baseline in the commit that ' +
         'explains why. If it was not, this is the regression.',
+    );
+    process.exit(1);
+  }
+  if (differingPixels !== 0) {
+    console.error(
+      `\na partial repaint left ${differingPixels} pixels a full repaint ` +
+        'would not have — the damage path dropped something visible',
     );
     process.exit(1);
   }

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -612,24 +612,33 @@ export async function createRoot(options = {}) {
   // imported (src/yoga.js — a top-level await here would cost every app the
   // single-executable build). ntk's createClient used to do this while the
   // engine was still ntk's, which also covered `createRoot({ app })`; it is
-  // ours now, so this is the one place that has to know. Concurrent with the
-  // connection rather than before it — both are I/O, neither needs the other.
-  // Checked before anything starts, so a misuse cannot leave a load or a
-  // connection in flight with nothing waiting on it.
+  // ours now, so this is the one place that has to know. It runs alongside the
+  // connection rather than before it — neither needs the other — though "I/O"
+  // flatters the engine: most of that load is the loop-blocking instantiate,
+  // which is why the order below is what it is.
+  //
+  // The misuse check comes before anything starts, so a bad call cannot leave
+  // a load or a connection in flight with nothing waiting on it.
   if (isNtkApp(options)) {
     throw new Error(
       'react-x11: createRoot takes an options object — pass the connection ' +
         'as createRoot({ app }).',
     );
   }
-  const layout = loadLayout();
-  const integrations = loadIntegrations(); // null when there is nothing to install
   const { app: borrowed, onDisconnect, ...rest } = options;
   const owned = borrowed === undefined;
-  // The connection starts before the engine is waited on, which is what
-  // "concurrent with the connection" above asks for: the instantiate and the
-  // X handshake are both cold-start I/O and neither reads the other. Joined
-  // together below, so a caller still gets an app whose engine is loaded.
+  // The connection is started first, and the order is the point rather than a
+  // detail. `loadLayout()` is only nominally asynchronous: instantiating the
+  // engine blocks the event loop for 15-50 ms before it returns its promise
+  // (measured), so calling it first delays the socket work by exactly that —
+  // the loop cannot run the connect callback that writes the hello while the
+  // instantiate is on it. Starting the connection first puts the handshake in
+  // flight, and the block then overlaps it instead of preceding it.
+  //
+  // Worth being honest about the size: the most this can save is the
+  // synchronous block, and only where the handshake takes longer than it. It
+  // is not measurable on a Unix socket, and it is lost in the noise on a link
+  // slow enough to matter. This is the right order, not a fast one.
   const connecting = owned
     ? connect(
         Object.fromEntries(
@@ -640,7 +649,9 @@ export async function createRoot(options = {}) {
         ),
       )
     : Promise.resolve(borrowed);
-  const [, , app] = await Promise.all([layout, integrations, connecting]);
+  const layout = loadLayout();
+  const integrations = loadIntegrations(); // null when there is nothing to install
+  const [app] = await Promise.all([connecting, layout, integrations]);
 
   const container = Renderer.createContainer(
     app,

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -614,19 +614,24 @@ export async function createRoot(options = {}) {
   // engine was still ntk's, which also covered `createRoot({ app })`; it is
   // ours now, so this is the one place that has to know. Concurrent with the
   // connection rather than before it — both are I/O, neither needs the other.
-  const layout = loadLayout();
-  const integrations = loadIntegrations(); // null when there is nothing to install
-  await Promise.all([layout, integrations]);
+  // Checked before anything starts, so a misuse cannot leave a load or a
+  // connection in flight with nothing waiting on it.
   if (isNtkApp(options)) {
     throw new Error(
       'react-x11: createRoot takes an options object — pass the connection ' +
         'as createRoot({ app }).',
     );
   }
+  const layout = loadLayout();
+  const integrations = loadIntegrations(); // null when there is nothing to install
   const { app: borrowed, onDisconnect, ...rest } = options;
   const owned = borrowed === undefined;
-  const app = owned
-    ? await connect(
+  // The connection starts before the engine is waited on, which is what
+  // "concurrent with the connection" above asks for: the instantiate and the
+  // X handshake are both cold-start I/O and neither reads the other. Joined
+  // together below, so a caller still gets an app whose engine is loaded.
+  const connecting = owned
+    ? connect(
         Object.fromEntries(
           CONNECT_OPTIONS.filter((k) => rest[k] !== undefined).map((k) => [
             k,
@@ -634,7 +639,8 @@ export async function createRoot(options = {}) {
           ]),
         ),
       )
-    : borrowed;
+    : Promise.resolve(borrowed);
+  const [, , app] = await Promise.all([layout, integrations, connecting]);
 
   const container = Renderer.createContainer(
     app,

--- a/src/compositing.js
+++ b/src/compositing.js
@@ -22,6 +22,8 @@
  * paint-time decision, and paint-time decisions can change.
  */
 
+import { requireExtension } from './extensions.js';
+
 const sessions = new WeakMap();
 
 /**
@@ -92,8 +94,12 @@ export async function beginCompositing(app, screen = 0) {
     session._selection = atom;
     session._set(await selectionOwner(X, atom));
     // Live updates are a bonus, not a requirement: without XFixes the
-    // startup answer simply stands for the life of the connection.
-    await watchSelection(app, session, atom);
+    // startup answer simply stands for the life of the connection — which
+    // is also why the watch is not waited for. `supported` is settled by
+    // the line above, and nothing before the first realize reads the watch,
+    // so awaiting the XFixes probe here only lengthens the chain the first
+    // CreateWindow sits behind.
+    void watchSelection(app, session, atom).catch(() => {});
   } catch {
     if (session.supported === null) session._set(false);
   }
@@ -124,7 +130,7 @@ function selectionOwner(X, atom) {
  * the window or died.
  */
 async function watchSelection(app, session, atom) {
-  const fixes = await requireFixes(app);
+  const fixes = await requireExtension(app, 'fixes');
   if (!fixes || session.stopped) return;
   const X = app.X;
   // A 1x1 InputOnly window off-screen, never mapped: XFixes addresses the
@@ -147,18 +153,6 @@ async function watchSelection(app, session, atom) {
     session._set(Boolean(ev.owner));
   });
   fixes.SelectSelectionInput(id, atom, mask);
-}
-
-function requireFixes(app) {
-  return new Promise((resolve) => {
-    try {
-      app.X.require('fixes', (err, fixes) =>
-        resolve(err || !fixes ? null : fixes),
-      );
-    } catch {
-      resolve(null);
-    }
-  });
 }
 
 /** Is a compositor running on this connection? False while unknown. */

--- a/src/extensions.js
+++ b/src/extensions.js
@@ -1,0 +1,45 @@
+// Asking the server for an extension, once per connection.
+//
+// `X.require` caches the extension object only once its reply lands, so two
+// callers in the same tick both put a QueryExtension on the wire and one of
+// the answers is thrown away. That did not matter while each extension had a
+// single caller that awaited it in turn. It does now: the startup probes run
+// concurrently, and both the compositing watch and the XSETTINGS watch want
+// XFixes at the same moment.
+//
+// So the promise is memoized, not the result — a second caller arriving
+// while the first is still in flight subscribes to it instead of asking
+// again. Keyed per connection, and null (an extension the server does not
+// have) is cached like any other answer: it is a real reply, and re-asking
+// would put the same question back on the wire every time.
+const tables = new WeakMap();
+
+/**
+ * The extension object for `name` on this connection, or null when the
+ * server does not have it (or the connection cannot answer).
+ *
+ * @param {object} app the ntk App
+ * @param {string} name node-x11's extension name, e.g. 'fixes'
+ * @returns {Promise<object|null>}
+ */
+export function requireExtension(app, name) {
+  const X = app?.X;
+  if (!X || typeof X.require !== 'function') return Promise.resolve(null);
+  let table = tables.get(X);
+  if (!table) {
+    table = new Map();
+    tables.set(X, table);
+  }
+  let pending = table.get(name);
+  if (!pending) {
+    pending = new Promise((resolve) => {
+      try {
+        X.require(name, (err, ext) => resolve(err || !ext ? null : ext));
+      } catch {
+        resolve(null);
+      }
+    });
+    table.set(name, pending);
+  }
+  return pending;
+}

--- a/src/idle.js
+++ b/src/idle.js
@@ -43,6 +43,8 @@
 import { sessionBus } from './bus.js';
 import { PORTAL_NAME, PORTAL_PATH } from './portal.js';
 
+import { requireExtension } from './extensions.js';
+
 const IDLETIME = 'IDLETIME';
 const SCREENSAVER_NAME = 'org.freedesktop.ScreenSaver';
 const SCREENSAVER_PATH = '/org/freedesktop/ScreenSaver';
@@ -89,14 +91,15 @@ class IdleSession {
 
   /** The SYNC extension, resolved once per connection. */
   sync() {
-    if (this._sync === undefined) this._sync = requireExt(this.app, 'sync');
+    if (this._sync === undefined)
+      this._sync = requireExtension(this.app, 'sync');
     return this._sync;
   }
 
   /** MIT-SCREEN-SAVER, likewise. */
   saver() {
     if (this._saver === undefined) {
-      this._saver = requireExt(this.app, 'screen-saver');
+      this._saver = requireExtension(this.app, 'screen-saver');
     }
     return this._saver;
   }
@@ -480,19 +483,8 @@ async function screenSaverInhibit(reason, app) {
  */
 async function xInhibit(reason, app) {
   void reason;
-  const saver = app ? await requireExt(app, 'screen-saver') : null;
+  const saver = app ? await requireExtension(app, 'screen-saver') : null;
   if (!saver?.Suspend) return null;
   saver.Suspend(true);
   return () => saver.Suspend(false);
-}
-
-/** An extension, or null where the server does not have it. */
-function requireExt(app, name) {
-  return new Promise((resolve) => {
-    try {
-      app.X.require(name, (err, ext) => resolve(err || !ext ? null : ext));
-    } catch {
-      resolve(null);
-    }
-  });
 }

--- a/src/keyboardstate.js
+++ b/src/keyboardstate.js
@@ -33,6 +33,8 @@
 // what it returns is a description like `English (US)` where an indicator in
 // a status bar wants `us`.
 
+import { requireExtension } from './extensions.js';
+
 const sessions = new WeakMap();
 
 /** `1 << xkbType` for the two events this needs. */
@@ -155,7 +157,7 @@ async function arm(session) {
   if (session.armed) return;
   session.armed = true;
   const app = session.app;
-  const xkb = await requireExt(app, 'xkb');
+  const xkb = await requireExtension(app, 'xkb');
   if (!xkb || session.stopped) return;
 
   // Subscribe before reading. A lock toggled between the two would otherwise
@@ -227,16 +229,6 @@ async function readLayouts(session) {
     // where the group index is all there is. `layouts` stays empty and
     // `layout` stays null, which is what those say.
   }
-}
-
-function requireExt(app, name) {
-  return new Promise((resolve) => {
-    try {
-      app.X.require(name, (err, ext) => resolve(err || !ext ? null : ext));
-    } catch {
-      resolve(null);
-    }
-  });
 }
 
 /** What is known right now. Not public — `useKeyboardState()` is. */

--- a/src/scale.js
+++ b/src/scale.js
@@ -86,6 +86,8 @@
 
 import { beginXSettings } from './xsettings.js';
 
+import { requireExtension } from './extensions.js';
+
 const sessions = new WeakMap();
 
 const debugScale = process.env.REACT_X11_DEBUG_SCALE === '1';
@@ -398,16 +400,6 @@ function call(fn, ...args) {
   });
 }
 
-function requireExt(app, name) {
-  return new Promise((resolve) => {
-    try {
-      app.X.require(name, (err, ext) => resolve(err || !ext ? null : ext));
-    } catch {
-      resolve(null);
-    }
-  });
-}
-
 const RESOURCE_MANAGER_ATOM = 23; // predefined, like the STRING type it holds
 
 async function readResourceManager(X, root) {
@@ -431,7 +423,7 @@ async function readResourceManager(X, root) {
  * every configured rung came up empty.
  */
 async function readOutputs(app) {
-  const randr = await requireExt(app, 'randr');
+  const randr = await requireExtension(app, 'randr');
   const X = app.X;
   const root = X.display?.screen?.[0]?.root;
   if (!randr || root == null) return null;

--- a/src/screens.js
+++ b/src/screens.js
@@ -80,11 +80,16 @@
  * approximation instead, and says so.
  */
 
+import { requireExtension } from './extensions.js';
+
 const sessions = new WeakMap();
 
 const PROPERTY_NOTIFY = 28;
 const PROPERTY_CHANGE_MASK = 4194304; // x11.eventMask.PropertyChange
 const WORKAREA_PROPERTY = '_NET_WORKAREA';
+// Which entry of the work-area list applies: a desktop can lay its struts
+// out differently per workspace.
+const DESKTOP_PROPERTY = '_NET_CURRENT_DESKTOP';
 
 /** RandR's `Connection` enum — an output with nothing plugged into it is
  *  reported as a resource that exists and is not connected. */
@@ -106,6 +111,7 @@ class ScreenSession {
     this.source = null;
     this.stopped = false;
     this._workAreaAtom = null;
+    this._desktopAtom = null;
     this._snapshot = null;
     this._listeners = new Set();
     /** Every `X.on('event')` handler installed here, so `stop()` can take
@@ -349,8 +355,18 @@ export async function beginScreens(app) {
   if (!X || typeof X.GetProperty !== 'function') return session; // mock app
 
   try {
-    const monitors = await queryMonitors(app);
-    session._workAreaAtom = await internAtom(X, WORKAREA_PROPERTY);
+    // This is the longest chain on the startup path, so it is the one that
+    // sets how long the first CreateWindow waits. Neither atom name depends
+    // on anything — not on the Xinerama probe, not on each other — so all
+    // three go out together and the chain is the probe plus the two property
+    // reads that genuinely need their atoms.
+    const [monitors, workAreaAtom, desktopAtom] = await Promise.all([
+      queryMonitors(app),
+      internAtom(X, WORKAREA_PROPERTY),
+      internAtom(X, DESKTOP_PROPERTY).catch(() => null),
+    ]);
+    session._workAreaAtom = workAreaAtom;
+    session._desktopAtom = desktopAtom;
     session.publish({
       monitors,
       workArea: await readWorkArea(session),
@@ -415,7 +431,7 @@ function relayout(session) {
 }
 
 async function watchRandR(session) {
-  const randr = await requireExt(session.app, 'randr');
+  const randr = await requireExtension(session.app, 'randr');
   if (!randr || session.stopped) return;
   const X = session.app.X;
   const root = X.display?.screen?.[0]?.root;
@@ -575,7 +591,7 @@ export function degreesOf(rotation) {
  */
 async function refreshOutputs(session) {
   const app = session.app;
-  const randr = await requireExt(app, 'randr');
+  const randr = await requireExtension(app, 'randr');
   if (!randr || session.stopped) return false;
   const X = app.X;
   const root = X.display?.screen?.[0]?.root;
@@ -632,17 +648,6 @@ async function refreshOutputs(session) {
   return true;
 }
 
-/** An extension, or null where the server does not have it. */
-function requireExt(app, name) {
-  return new Promise((resolve) => {
-    try {
-      app.X.require(name, (err, ext) => resolve(err || !ext ? null : ext));
-    } catch {
-      resolve(null);
-    }
-  });
-}
-
 /** A node-x11 request as a promise that resolves to null on error. */
 function call(fn, ...args) {
   return new Promise((resolve) => {
@@ -689,7 +694,11 @@ async function currentDesktop(session) {
   const X = session.app.X;
   const root = X.display?.screen?.[0]?.root;
   try {
-    const atom = await internAtom(X, '_NET_CURRENT_DESKTOP');
+    // Interned alongside the work-area atom in beginScreens, because this
+    // read is only reached once the work-area reply has landed and a name
+    // lookup discovered then is a round trip nothing was waiting to learn.
+    const atom =
+      session._desktopAtom ?? (await internAtom(X, DESKTOP_PROPERTY));
     const prop = await getProperty(X, root, atom);
     return prop?.data?.length >= 4 ? prop.data.readUInt32LE(0) : 0;
   } catch {

--- a/src/xsettings.js
+++ b/src/xsettings.js
@@ -21,6 +21,8 @@
 // this module reads and publishes the whole map rather than the three keys
 // the appearance ladder happens to want (#86 is where the rest lands).
 
+import { requireExtension } from './extensions.js';
+
 /** Per-connection sessions, like `compositing.js`. */
 const sessions = new WeakMap();
 
@@ -171,12 +173,17 @@ export async function beginXSettings(app, screen = 0) {
   }
 
   try {
-    session._selectionAtom = await internAtom(X, `_XSETTINGS_S${screen}`);
-    session._propertyAtom = await internAtom(X, SETTINGS_PROPERTY);
+    // Two name lookups that know nothing about each other, so they go out
+    // together — the property atom is not read until the owner answers.
+    [session._selectionAtom, session._propertyAtom] = await Promise.all([
+      internAtom(X, `_XSETTINGS_S${screen}`),
+      internAtom(X, SETTINGS_PROPERTY),
+    ]);
     await latch(session);
     // Live updates are a bonus: without XFixes the startup answer stands for
-    // the life of the connection, which is what every pre-2005 client did.
-    await watchOwner(session);
+    // the life of the connection, which is what every pre-2005 client did —
+    // and a bonus does not belong on the chain the first window waits behind.
+    void watchOwner(session).catch(() => {});
   } catch {
     if (!session.answered) session._set(null);
   }
@@ -246,7 +253,7 @@ async function watchOwner(session) {
     }
   });
 
-  const fixes = await requireFixes(app);
+  const fixes = await requireExtension(app, 'fixes');
   if (!fixes || session.stopped) return;
   // A 1x1 InputOnly window, never mapped: XFixes addresses notifications to a
   // window and this one exists only to be that address.
@@ -291,18 +298,6 @@ function getProperty(X, wid, atom) {
       resolve(err ? null : prop),
     ),
   );
-}
-
-function requireFixes(app) {
-  return new Promise((resolve) => {
-    try {
-      app.X.require('fixes', (err, fixes) =>
-        resolve(err || !fixes ? null : fixes),
-      );
-    } catch {
-      resolve(null);
-    }
-  });
 }
 
 /** The settings this connection last read, or `null`. */


### PR DESCRIPTION
The last items from the protocol audit. Three of the four are here; the fourth turned out to be already done, and is reported rather than changed.

## The connection now starts before the engine

The comment above them has claimed a version of this for a while — *"concurrent with the connection rather than before it — both are I/O, neither needs the other"* — but the code awaited the yoga WebAssembly instantiate and only then dialled the server.

Measuring the claim showed the comment was wrong about the engine, which is what made the order matter. `loadLayout()` is only nominally asynchronous: **instantiating the engine blocks the event loop for 15–50 ms before it returns its promise**. So calling it first delays the socket work by exactly that — the loop cannot run the connect callback that writes the client hello while the instantiate is sitting on it. The connection is started first now, so the handshake is in flight and the block overlaps it instead of preceding it.

**The size, stated plainly, because it is small.** The most this can save is the synchronous block, and only where the handshake takes longer than the block. Five runs per arm:

| link | connection first | engine first |
| --- | --- | --- |
| Unix socket | ~110 ms | ~110 ms (±25 ms process noise) |
| emulated transatlantic | ~970 ms | ~970 ms |

Indistinguishable in both regimes — 16 ms is under 2% of a startup dominated by the link itself, and there is nothing to hide behind on a local socket. This is the right order, not a faster one, and the comment now says which.

## Three startup chains lose a round trip each

| where | was | now |
| --- | --- | --- |
| `screens.js` | `_NET_WORKAREA` interned only after the Xinerama probe answered; `_NET_CURRENT_DESKTOP` only after the work area came back | all three go out together — neither name depends on anything |
| `xsettings.js` | two atom interns, one after the other | one `Promise.all` |
| `compositing.js`, `xsettings.js` | the selection watch awaited | started, not awaited |

The screens chain matters most: it is the longest one on the startup path, so it sets how long the first `CreateWindow` waits. The watches are what their own comments already argue — *"live updates are a bonus, not a requirement"* — the answer they gate on is settled a line earlier, and nothing before the first realize reads them.

**Deliberately untouched**: the `Promise.all` in `Reconciler.js` stays awaited (compositing, scale and the screen cap must all be settled before any window realizes — the file explains why at length), and `refreshOutputs` stays un-awaited (RandR is deliberately off the startup path).

## One duplicate query, found by fixing the others

Running those probes concurrently exposed something the serial order had been hiding: `X.require` caches an extension only once its reply lands, so two callers in the same tick both put a `QueryExtension` on the wire and one answer is discarded. Six modules had their own byte-identical copy of the wrapper. They now share one that **memoizes the promise rather than the result**, so a second caller subscribes to the first request instead of repeating it.

Net at startup, measured: **3 blocking round trips → 2, and 1 duplicate query → 0**, at the same request count.

## The pixel gate

Every finding in this audit was argued pixel-identical on paper. That argument deserves a machine:

```bash
npm run bench:pixels            # print the hashes
npm run bench:pixels -- --check # fail if the picture moved
```

Each scenario mounts a tree on the in-process server, settles, reads the window back through its 2d context and hashes the bytes; `--check` compares against a committed baseline and runs in CI beside the protocol gate. Because cheaper is only an optimization when the picture is the same.

Scenarios cover what the audit's findings touch: a clip and a solid fill (the `_fillRect` mask path), rounded fills and borders (the corner-glyph fast path and its clip bracket), text, gradients and shadow, and a partial repaint.

CI caught a flaw in this on the first run — the gate doing its job to its own author. Of five scenarios, four hashed byte-identically on macOS and Linux and one did not: the partial repaint, the only one whose result depends on *when* the capture happens relative to asynchronous work. So what its hash pinned was partly a timing. It is now a **within-run** check instead — paint the change through the damage path, capture, repaint the same tree in full, capture, compare pixel by pixel — which is the invariant that was actually worth holding, and is immune to anything that shifts both images equally.

The four hashed scenarios are deterministic across runs, and the suite bites — shifting one colour by one bit fails the check, in a directly drawn scenario and in the end state of the partial repaint. Worth saying how the first version of that check was wrong: I first mutated a colour that the partial-repaint scenario overwrites before capture, and it passed. The gate was fine; the mutation was not.

When it does fail, a hash cannot say *what* moved — render the scenario and look. If the change was intended (an ntk rasterizer bump shifts antialiased edges everywhere, legitimately), re-save the baseline in the commit that explains it.

## The mount census: already done, no change

Reported rather than changed, because measuring it first showed the estimate was stale. Selecting the event mask at `CreateWindow` (#381) removed the incremental attribute writes, and a window now costs:

| | requests | blocking round trips |
| --- | --- | --- |
| first window | 67 | 0 |
| second (with a `<popup>`) | 24 | 0 |
| third | 8 | 1 |

The 30 `InternAtom`s the first window appears to cost are the XDND vocabulary, interned **once per connection** and in one batch — not per window. What is left per window is one `TranslateCoordinates`, whose only consumer is popup placement (seeding it locally is a behaviour risk for a request that is pipelined and costs no round trip), and two ntk round trips — a `WM_PROTOCOLS` read on a window this client just created empty, and a `GetWindowAttributes` from `setWmState` — which belong upstream.

## Verification

- Full suite 1567/1573 — the six failures are the known macOS-only `appearance.test.js` set, confirmed identical on master by running that file at `084570e` in a scratch worktree.
- `npm run bench -- --check` and `npm run bench:pixels -- --check` both green.
- lint, typecheck, `prettier --check` clean.

## The other half of lane B

`--stats`/`--json` for x11vis is sidorares/x11-protocol-visualizer#1 — the real-display lane needs both halves: record before and after through the proxy, `--diff` the two, read `--stats` for where the time went.
