### PR TITLE
fix(screens): select the work-area watch through ntk's root window

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
-        "dbus-native": "0.15.2",
-        "ntk": "^8.3.0",
+        "ntk": "^8.3.1",
         "react-reconciler": "^0.33.0",
         "yoga-layout": "^3.2.1"
       },
@@ -3957,9 +3956,9 @@
       "license": "MIT"
     },
     "node_modules/ntk": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-8.3.0.tgz",
-      "integrity": "sha512-GQaeMAntMKYAYcxXwHfyJIgtQBGGz3rkWcse9qnWc46hTyHUOGCdVMlmBEFSAsXNKKT3S6q/leDgRR9nFNQpIA==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-8.3.1.tgz",
+      "integrity": "sha512-uOe/dHeO4xA9U6qd60OIYDUEfN5BawmJ+rrfTbB7tKMQnZsHGGELC3oqG1GzKs67keLX0LbrfYwEK1SVgymCmQ==",
       "license": "MIT",
       "dependencies": {
         "bidi-js": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^8.3.0",
+    "ntk": "^8.3.1",
     "react-reconciler": "^0.33.0",
     "yoga-layout": "^3.2.1"
   },

--- a/src/screens.js
+++ b/src/screens.js
@@ -401,9 +401,6 @@ function watchLayout(session) {
   const X = session.app.X;
   const root = X.display?.screen?.[0]?.root;
   if (root == null) return;
-  // PropertyChange on a window we do not own. Legal and shared — every
-  // panel-aware application on the desktop selects this same event.
-  X.ChangeWindowAttributes(root, { eventMask: PROPERTY_CHANGE_MASK }, () => {});
   session.onEvent((ev) => {
     if (session.stopped) return;
     if (ev.type !== PROPERTY_NOTIFY || ev.wid !== root) return;
@@ -411,6 +408,27 @@ function watchLayout(session) {
     relayout(session);
   });
   watchRandR(session);
+  // PropertyChange on a window we do not own. Legal and shared — every
+  // panel-aware application on the desktop selects this same event.
+  //
+  // Through ntk's root Window rather than as a raw ChangeWindowAttributes,
+  // because an X event mask is absolute per client: whoever writes last wins
+  // outright. ntk keeps selections additive by tracking the mask on a Window
+  // it caches per id, and adopting the root — which the shared-glyph
+  // directory does to hear MANAGER announcements — starts that tracked mask
+  // at zero and writes StructureNotify over whatever was there. A raw write
+  // is a value the next adopter silently overwrites, in either direction:
+  // reversed, it is a window manager's SubstructureRedirect that goes.
+  //
+  // Last in this function on purpose. `rootWindow()` constructs a Window,
+  // which can throw, and `beginScreens` calls this inside a bare catch — so
+  // ahead of the two registrations above, a throw here would take the
+  // work-area handler and the RandR watch with it rather than only the
+  // selection it belongs to.
+  session.app
+    .rootWindow()
+    .selectInput(PROPERTY_CHANGE_MASK)
+    .catch(() => {});
 }
 
 /** Re-read everything the layout is built from and publish once. */

--- a/test/root-event-mask.test.js
+++ b/test/root-event-mask.test.js
@@ -1,0 +1,130 @@
+// The root window's event mask is shared bookkeeping. react-x11 selects
+// PropertyChange on it to hear about `_NET_WORKAREA` (src/screens.js), and
+// ntk adopts the same window for its own reasons — the shared-glyph
+// directory watches for MANAGER announcements there, and simply *adopting* a
+// window selects StructureNotify on it. X event masks are absolute per
+// client, not additive, so whoever writes last wins outright unless every
+// writer goes through one accumulator. ntk's Window is that accumulator (it
+// caches per id and ORs into a tracked mask); a raw ChangeWindowAttributes
+// is outside it, and is silently overwritten by the next adopter.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient } from 'ntk';
+
+import { createRoot } from '../src/index.js';
+import { screensSnapshot } from '../src/screens.js';
+import { renderX11, cleanup, settle, waitFor } from '../src/testing/index.js';
+
+const h = React.createElement;
+
+const PROPERTY_CHANGE = 1 << 22;
+const SUBSTRUCTURE_REDIRECT = 1 << 20;
+const CARDINAL = 6;
+
+const rootMask = (app) =>
+  new Promise((resolve, reject) => {
+    // `your-event-mask`: what *this* connection selected, not the union
+    app.X.GetWindowAttributes(app.X.display.screen[0].root, (err, attrs) =>
+      err ? reject(err) : resolve(attrs.myEventMasks),
+    );
+  });
+
+// The text matters: drawing a glyph is what brings ntk's shared-glyph client
+// up, and that is what adopts the root.
+const mountWithText = () =>
+  renderX11(h('window', { width: 320, height: 240 }, h('text', null, 'hi')));
+
+test('the work-area watch survives ntk adopting the root window', async (t) => {
+  t.after(cleanup);
+  const { app } = await mountWithText();
+  await settle(app, 4);
+  const mask = await rootMask(app);
+  assert.ok(
+    mask & PROPERTY_CHANGE,
+    `root event mask is 0x${mask.toString(16)}: PropertyChange is not ` +
+      'selected, so a panel appearing or resizing will never reach useScreens()',
+  );
+  // The other half of the same bug, and the half nothing else would notice:
+  // an absolute write leaves ntk's accumulator believing a mask the server
+  // does not hold, and nothing ever reconciles the two. Every later
+  // `selectInput` on the root then ORs into a fiction.
+  assert.strictEqual(
+    app.rootWindow().eventMask,
+    mask,
+    "ntk's tracked mask for the root and the server's disagree",
+  );
+});
+
+test('a _NET_WORKAREA change reaches the screen layout', async (t) => {
+  t.after(cleanup);
+  const { app } = await mountWithText();
+  await settle(app, 4);
+
+  // what a panel does when it reserves space along the top edge
+  const X = app.X;
+  const root = X.display.screen[0].root;
+  const atom = await new Promise((resolve, reject) =>
+    X.InternAtom(false, '_NET_WORKAREA', (err, a) =>
+      err ? reject(err) : resolve(a),
+    ),
+  );
+  const area = Buffer.alloc(16);
+  for (const [i, v] of [0, 28, 900, 500].entries())
+    area.writeUInt32LE(v, i * 4);
+  X.ChangeProperty(0 /* Replace */, root, atom, CARDINAL, 32, area);
+
+  await waitFor(() =>
+    assert.deepStrictEqual(
+      screensSnapshot(app).workArea,
+      { x: 0, y: 28, width: 900, height: 500 },
+      'the work area published by useScreens() did not follow the property',
+    ),
+  );
+});
+
+test('a window manager on this connection keeps its redirect', async (t) => {
+  // The same collision from the other side. A client already holding
+  // SubstructureRedirect on the root is a window manager, and an absolute
+  // write over that mask stops MapRequest reaching it — it silently stops
+  // managing windows. Neither bit is "the one that should win": the raw
+  // write leaves ntk's accumulator holding a mask the server does not, and
+  // from there the two ping-pong, so which of the two selections is alive
+  // depends on who wrote last. Only holding both is correct.
+  const server = xserver.createServer({ width: 800, height: 600 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  // system fonts, like `renderX11` above: this window paints, and an empty
+  // font source has nothing for the first frame to measure with
+  const app = await createClient({ stream: clientEnd });
+  t.after(() => app.X.terminate());
+
+  await app.rootWindow().selectInput(SUBSTRUCTURE_REDIRECT);
+  const root = await createRoot({ app });
+  t.after(() => root.unmount?.());
+  await React.act(async () => {
+    root.render(
+      h('window', { width: 200, height: 100 }, h('text', null, 'hi')),
+    );
+  });
+  await settle(app, 4);
+
+  const mask = await rootMask(app);
+  assert.ok(
+    mask & SUBSTRUCTURE_REDIRECT,
+    `root event mask is 0x${mask.toString(16)}: react-x11 wrote over the ` +
+      'window manager’s SubstructureRedirect — MapRequest stops arriving',
+  );
+  assert.ok(
+    mask & PROPERTY_CHANGE,
+    `root event mask is 0x${mask.toString(16)}: the window manager's ` +
+      'selection went over the work-area watch',
+  );
+  assert.strictEqual(
+    app.rootWindow().eventMask,
+    mask,
+    "ntk's tracked mask for the root and the server's disagree",
+  );
+});


### PR DESCRIPTION
A packet-trace audit of window startup turned this up. After #381 removed the per-listener `ChangeWindowAttributes` burst on the app window, the only ones left were three on the **root** — and they were overwriting each other.

## What happens

An X event mask is absolute per client. `watchLayout` selected PropertyChange on the root with a raw `X.ChangeWindowAttributes`, which is outside ntk's bookkeeping — ntk keeps selections additive by tracking the mask on a per-id cached `Window` and OR-ing into it.

Adopting a window starts that tracked mask at zero, because ntk cannot know what another client already selected. ntk's own `on('map')` bookkeeping then runs through the public `newListener` hook and writes StructureNotify absolutely. So adoption alone — no explicit selection anywhere — wipes a raw write made before it:

| step | root mask |
| --- | --- |
| after a raw absolute PropertyChange write | `0x400000` |
| after `app.rootWindow()` | `0x20000` |
| after `selectInput(SubstructureRedirect)` | `0x120000` |

**It goes both ways, which is the point.** With a window manager on the same connection, the raw write is the one that destroys something:

| | server | ntk's tracked mask |
| --- | --- | --- |
| after WM `selectInput` | `0x120000` | `0x120000` |
| after `createRoot` | `0x400000` | `0x120000` ← redirect gone, and desynced |
| with this change | `0x520000` | `0x520000` |

That second column is the half nothing else would notice: an absolute write leaves ntk's accumulator holding a mask the server does not, nothing reconciles them, and every later `selectInput` ORs into a fiction. The two selections then ping-pong, so which one is alive depends on who wrote last. The fix is not "PropertyChange should win" — it is that nothing on the root may write absolutely.

## What breaks

PropertyChange on the root is how `_NET_WORKAREA` reaches `useScreens()` — a panel appearing, resizing or auto-hiding. It also feeds `availableArea`, which clamps an `'auto'` window's height and places anchored popups.

RandR's own `SelectInput` is a separate mechanism and is untouched, so monitor hotplug still works. It is specifically the panel clause of the documented promise in `docs/system.md` that fails. On the window-manager side, the casualty is MapRequest.

## Why it shows up now

The raw write has always been unsafe, and `examples/wm-core.js` plus the XEmbed reparent in `src/foreignnodes.js` have adopted the root all along. ntk 8.3.0's shared-glyph directory adopts the root on the first glyph a client draws, which widens the exposure from "apps that adopt the root" to **every app that draws text**.

Measured on `1f4bf6c`, minimal `<window><text>hi</text></window>`, server-side `your-event-mask` on the root:

| | root mask | PropertyChange |
| --- | --- | --- |
| master | `0x20000` | no |
| master, `NTK_NO_SHARED_GLYPHS=1` | `0x400000` | yes |
| this branch | `0x420000` | yes |

## Cost

It depends where you count, and the two answers have opposite signs. All figures against ntk 8.3.1.

**Whole-connection startup grows**, because react-x11 now adopts the root itself: **+2 requests / +20 bytes** for an app that draws text, **+4 / +36** for one that draws none — the latter pays the `GetGeometry`/`GetWindowAttributes` adoption, where nothing else would have adopted the root at all. No new round trip.

**The protocol bench falls**, 2 requests per scenario — `text: paragraph, no clip` 39 → 37, `mount: window with 40 boxes and labels` 109 → 107. It drains the connection to quiet before measuring, and its own `drain` docstring names ntk's shared-glyph chain as exactly what that drain exists to exclude; adopting the root during startup makes that chain's later `rootWindow()` a cache hit, so those requests leave the measured window instead of appearing in it.

Both are real, they just bound different things. `npm run bench -- --check` passes.

## The ntk floor

`ntk` moves to `^8.3.1`, and it is a floor rather than a courtesy bump.

Routing the selection through `rootWindow()` makes every react-x11 process adopt the root. Under ntk 8.3.0 that alone was enough to crash a process on the way out — a routed `child-event` built a `Window` on a closing connection and the constructor's `GetGeometry` threw out of the X event callback, which an out-of-process `<frame>` pane turns into a nonzero exit. `test/frame.test.js` on Node 20.20.0, ten runs each:

| ntk | failures |
| --- | --- |
| 8.3.0 | 4/10 |
| 8.3.1 | 0/10 |

Fixed upstream in sidorares/ntk#324 (sidorares/ntk#321), with sidorares/ntk#323 (sidorares/ntk#322) removing the silent adoption write alongside it.

**ntk#323 does not remove the need for this change.** It stops *adoption* writing a mask nobody asked for, but `sharedglyphs.js` still selects StructureNotify explicitly, from a tracked mask that starts at zero, and that write is still absolute — so a raw write still loses. Verified against 8.3.1: master still ends at `0x20000` with PropertyChange gone, and all three tests below still fail on it.

The selection is the **last** statement in `watchLayout` deliberately. `rootWindow()` constructs a `Window`, which can throw, and `beginScreens` calls `watchLayout` inside a bare `catch` — placed ahead of the `session.onEvent` and `watchRandR` registrations, a throw would take the work-area handler and the RandR watch down with it rather than only the selection it belongs to. Master's callback-based raw write could not fail that way.

## Tests

Three, because the mask assertion alone is weak — it says nothing about whether the watch still *works*, and an "adoption happened" precondition can never fail once the fix itself adopts the root.

1. **the work-area watch survives ntk adopting the root window** — PropertyChange is held, *and* ntk's tracked mask agrees with the server's. The second assertion is the only thing that catches the desync.
2. **a `_NET_WORKAREA` change reaches the screen layout** — writes the property on the root the way a panel does, waits for the published layout to follow. This is the one that tests the consequence rather than the mechanism.
3. **a window manager on this connection keeps its redirect** — holds SubstructureRedirect before `createRoot`, requires both bits afterwards.

All three fail on master and pass here:

```
master:  ℹ pass 0   ℹ fail 3
branch:  ℹ pass 3   ℹ fail 0
```

There was no test for `src/screens.js` before this. Every existing screen-layout test goes through `setScreensForTests`, which publishes directly and never enters `watchLayout` — the only place the mask is written.

Full suite 1600/1606 on ntk 8.3.1, rebased onto `1a0b480`, the six failures being the known macOS-only `appearance.test.js` XSETTINGS baseline. `prettier`, `eslint`, `tsc`, `npm run bench -- --check` clean.

## Follow-ups, not in this PR

- `src/xsettings.js` still writes an absolute `{eventMask}` on the XSETTINGS selection owner. Benign only while nobody wraps that window in an ntk `Window` — the same latent pattern, and the last raw absolute mask write left in the tree. Worth a comment or a lint rule banning raw `ChangeWindowAttributes({eventMask})` on a window this client did not create.
- The other two request-count fixes from this audit landed in #389.
- `selectInput` skipping a write that adds no bits landed upstream in sidorares/ntk#323, so that half of sidorares/ntk#322 is done too.


