### PR TITLE
perf(events): stop asking for a cursor and a mask the window already has

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -340,6 +340,11 @@ export class EventManager {
     // release that continue the same gesture follow
     this._downDefaulted = false;
     this.capturedNode = null;
+    // The cursor the window is already wearing. `null` rather than
+    // undefined on purpose: `null` *is* a cursor — X None, "inherit the
+    // parent's" — and it is the one a window starts with, so the first
+    // hover over a subtree that names no cursor has nothing to change.
+    this._appliedCursor = null;
     // Attention (ntk#37): the one node the pointer looks like it is heading
     // for, the recent pointer samples the trajectory is estimated from, and
     // the window's candidate registry held directly so the motion path costs

--- a/src/windowstate.js
+++ b/src/windowstate.js
@@ -43,6 +43,7 @@ import { useTopLevelWindow, windowIdOf } from './windowid.js';
 
 const VISIBILITY_NOTIFY = 15;
 const VISIBILITY_CHANGE_MASK = 65536; // x11.eventMask.VisibilityChange
+const PROPERTY_CHANGE_MASK = 4194304; // x11.eventMask.PropertyChange
 const FULLY_OBSCURED = 2;
 const DESKTOP_PROPERTY = '_NET_WM_DESKTOP';
 
@@ -198,6 +199,23 @@ function arm(session) {
   if (!wnd) return;
   session.armed = true;
 
+  // **One selection for everything this session needs.** Two masks are at
+  // stake — PropertyChange for `_NET_WM_STATE`/`_NET_WM_DESKTOP`, and
+  // VisibilityChange for the obscured watch — and ntk grows a window's mask
+  // one request per first listener of each kind. Asking for both here, before
+  // either subscription, makes the `statechange` listener below a detected
+  // no-op and leaves `watchVisibility` nothing to select: one
+  // ChangeWindowAttributes for a session instead of two, on a window that is
+  // already mapped and on screen by the time any of this runs.
+  if (typeof wnd.selectInput === 'function') {
+    Promise.resolve(
+      wnd.selectInput(PROPERTY_CHANGE_MASK | VISIBILITY_CHANGE_MASK),
+    ).catch(() => {
+      // a window destroyed between the ref resolving and this call; the
+      // defaults stand and nothing further will arrive
+    });
+  }
+
   // Focus, from the event manager rather than from ntk directly: it already
   // dedups FocusIn/FocusOut and already knows the answer for a window that
   // has not seen either yet.
@@ -269,9 +287,9 @@ function readDesktop(session) {
 
 /**
  * VisibilityNotify, which ntk has no event name for — its mask table stops
- * at the events a widget toolkit needs — so the mask goes on through
- * `selectInput` (which ORs into ntk's own tracked mask, so nothing it adds
- * later drops this) and the event is read off the raw connection.
+ * at the events a widget toolkit needs — so the event is read off the raw
+ * connection. The mask it needs was selected by `arm()`, together with the
+ * one the state watch needs.
  */
 function watchVisibility(session) {
   const wnd = session.node.window;
@@ -285,11 +303,6 @@ function watchVisibility(session) {
   };
   X.on('event', onEvent);
   session._offs.push(() => X.off?.('event', onEvent));
-
-  Promise.resolve(wnd.selectInput(VISIBILITY_CHANGE_MASK)).catch(() => {
-    // a window destroyed between the ref resolving and this call; the
-    // defaults stand and nothing further will arrive
-  });
 }
 
 /** What is known about a window right now. Stable until it changes. */

--- a/test/window-mask-requests.test.js
+++ b/test/window-mask-requests.test.js
@@ -1,0 +1,116 @@
+// ntk grows a window's server-side event mask lazily — one
+// ChangeWindowAttributes per first listener of each kind — so a value known
+// before the window exists is worth declaring at CreateWindow, which
+// `WINDOW_EVENT_MASK` does. These are the two places a request still gets
+// issued for a value that was knowable, and the cursor attribute that gets
+// set to the value it already had.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+
+import {
+  renderX11,
+  cleanup,
+  settle,
+  act,
+  fireEvent,
+} from '../src/testing/index.js';
+
+const h = React.createElement;
+
+/** Every ChangeWindowAttributes this connection sends, by window. */
+function recordAttributeWrites(app) {
+  const writes = [];
+  const original = app.X.ChangeWindowAttributes;
+  app.X.ChangeWindowAttributes = function (wid, values, ...rest) {
+    writes.push({ wid, values });
+    return original.call(this, wid, values, ...rest);
+  };
+  return writes;
+}
+
+test('hovering a subtree that names no cursor sets no cursor', async (t) => {
+  t.after(cleanup);
+  // A window starts out wearing X cursor None — "inherit the parent's" —
+  // which is exactly what a subtree declaring no cursor resolves to. The
+  // first hover has nothing to change, and `_appliedCursor` starting as
+  // `undefined` rather than `null` is what used to make it look otherwise.
+  const { app, getByText } = await renderX11(
+    h(
+      'window',
+      { width: 320, height: 240 },
+      h('box', { style: { width: 200, height: 60 } }, h('text', null, 'plain')),
+    ),
+  );
+  await settle(app, 3);
+
+  const writes = recordAttributeWrites(app);
+  const plain = getByText('plain');
+  await act(async () => {
+    for (let i = 0; i < 4; i++) fireEvent.mouseMove(plain, { dx: i });
+  });
+  await settle(app, 2);
+
+  assert.deepStrictEqual(
+    writes.filter((w) => 'cursor' in w.values),
+    [],
+    'the window was told to wear the cursor it was already wearing',
+  );
+});
+
+test('a window state session selects once, not twice', async (t) => {
+  t.after(cleanup);
+  // An `animation` arms `watchWindowState` so the loop can stop while the
+  // window is obscured, and that session needs two masks: PropertyChange for
+  // `_NET_WM_STATE`, VisibilityChange for the obscured watch. Asked for
+  // separately they are two requests, on a window that is already mapped and
+  // on screen.
+  //
+  // Mounted still and animated afterwards, so the arming happens where it
+  // can be counted rather than inside the first paint.
+  const { app, windowNode, rerender } = await renderX11(
+    h(
+      'window',
+      { width: 300, height: 120 },
+      h('box', { style: { width: 40, height: 40 } }),
+    ),
+  );
+  await settle(app, 4);
+
+  const writes = recordAttributeWrites(app);
+  // a whole <window>: the mounted element is one, so `rerender` renders what
+  // it is given as the root rather than wrapping it
+  await rerender(
+    h(
+      'window',
+      { width: 300, height: 120 },
+      h('box', {
+        style: {
+          width: 40,
+          height: 40,
+          backgroundColor: '#48f',
+          animation: {
+            left: { from: 0, to: 100, duration: 1200, alternate: true },
+          },
+        },
+      }),
+    ),
+  );
+  await settle(app, 4);
+
+  const id = windowNode.window.id;
+  const masks = writes.filter((w) => w.wid === id && 'eventMask' in w.values);
+  assert.strictEqual(
+    masks.length,
+    1,
+    `expected one late event-mask selection, got ${masks.length}: ` +
+      masks.map((m) => `0x${m.values.eventMask.toString(16)}`).join(', '),
+  );
+  const PROPERTY_CHANGE = 1 << 22;
+  const VISIBILITY_CHANGE = 1 << 16;
+  assert.ok(
+    masks[0].values.eventMask & PROPERTY_CHANGE &&
+      masks[0].values.eventMask & VISIBILITY_CHANGE,
+    'the one selection has to carry both bits the session needs',
+  );
+});


### PR DESCRIPTION
The two leftovers from the same protocol audit that produced #381's `WINDOW_EVENT_MASK`. Both issue a `ChangeWindowAttributes` for a value the window already holds. Both are **per window**, not per frame — so this is a request-count and trace-legibility change, no round trip, nothing on the input→photon path. Filed separately from #388, which is a correctness bug.

## `_appliedCursor` was never initialised

A window starts out wearing X cursor `None` — "inherit the parent's" — which is exactly what a subtree declaring no cursor resolves to. So the first hover over one has nothing to change. But the field started as `undefined`, `null !== undefined`, and ntk's `setCursor` does not early-return on null — it sends `{cursor: 0}`.

Seeding it with the cursor the window actually has makes the no-op a no-op. Every real transition still issues, the reset to `None` included:

| hover | request |
| --- | --- |
| plain subtree | — |
| onto `cursor: 'pointer'` | `pointer` |
| back to plain | `None` |
| onto `cursor: 'text'` | `text` |
| still on text | — |

## `watchWindowState` selected twice

It needs two masks — PropertyChange for `_NET_WM_STATE` and `_NET_WM_DESKTOP`, VisibilityChange for the obscured watch — and asked for them separately, so ntk grew the mask twice. Both land after the window is mapped and on screen.

One selection up front in `arm()` covers both, which leaves the `statechange` subscription a detected no-op and `watchVisibility` nothing of its own to select. Interning `_NET_WM_STATE` still happens: ntk's `newListener` hook does that above the mask check rather than behind it.

Not an exotic path. An `animation` style arms this so a loop can stop while the window is obscured, so an indeterminate progress bar puts an ordinary app in it.

## Measured

In-process server, per window, against master:

| | master | this branch |
| --- | --- | --- |
| first hover over a subtree naming no cursor | 1 request | 0 |
| window containing an animation | 2 requests | 1 |

**The protocol bench is unchanged in every scenario**, which is the honest result rather than a disappointing one: `hover: checkbox enter/leave x5` hovers a checkbox that *does* declare a cursor, so the seed changes nothing there, and no scenario mounts an animation. Neither path is covered by the gate. The two tests added here cover them, and both fail on master:

```
master:  ✖ hovering a subtree that names no cursor sets no cursor
           the window was told to wear the cursor it was already wearing
         ✖ a window state session selects once, not twice
           expected one late event-mask selection, got 2: 0x62806f, 0x63806f
branch:  ✔ ✔
```

`_updateCursor` had no test coverage at all before this.

Full suite 1589/1595, the six failures being the known macOS-only `appearance.test.js` XSETTINGS baseline. `prettier`, `eslint`, `tsc`, `npm run bench -- --check` all clean.

## Note on ordering

Independent of #388 — different files, no conflict — but #388 is the one worth landing first: it fixes a real breakage, this one fixes request counts.