### PR TITLE
fix(focus): a click into a field lights its ring, and a clicked widget stops hiding its focus

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -579,7 +579,9 @@ back out of focus, whatever else it says.
 **A focused node shows a ring**, and how focus arrived decides whether it
 does. A press sets `:focus`; everything else — Tab, `autoFocus`,
 `node.focus()`, a modal handing focus back as it closes — also sets
-`:focus-visible`, and that is the state the ring is drawn on. It costs no
+`:focus-visible`, and that is the state the ring is drawn on. A press on a
+**text control** is the one press that sets both, because a field the
+keyboard is about to go to has to say so however focus got there. It costs no
 layout and needs no opt-in; see
 [styling.md](styling.md#the-focus-ring) for restyling it.
 

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -128,6 +128,12 @@ every click is noise, where a ring on Tab is the only cue a keyboard user
 has. Put focus rings in `:focus-visible` and colour changes that are welcome
 either way in `:focus`.
 
+The exception is CSS's too: a press on a **text control** — `<textinput>`,
+`<textarea>`, or a custom element reporting editable text — does set
+`:focus-visible`. What the click told the user is where the caret went, not
+that every keystroke from now on lands there, and that second fact is what
+the ring is for.
+
 `:focus-within` is focus on this node **or inside it** — CSS's, and the
 answer to "the row should light up while the field in it is being typed
 into", which is the one thing a node's own states cannot say. It is diffed
@@ -167,6 +173,8 @@ stays in React state.
 **Every focusable node draws one already**, on `:focus-visible`, with no
 styling at all — a bare `<box focusable>` included. It is not something an
 application opts into, because a keyboard user cannot opt into needing it.
+A text field gets it from a click as well as from Tab; everything else waits
+for the keyboard (see `:focus-visible` above).
 
 `outlineWidth`, `outlineColor` and `outlineOffset` override it, and they are
 paint properties like any other: animatable, legal in a state block, and

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -5,7 +5,7 @@
 import React from 'react';
 import { changeEvent } from './change.js';
 import { Icon } from './Icon.js';
-import { labelContent, useControl, useTheme } from './theme.js';
+import { focusRingStyle, labelContent, useControl, useTheme } from './theme.js';
 
 const h = React.createElement;
 
@@ -52,18 +52,28 @@ export function Checkbox({
       : hover
         ? theme.accentHover
         : theme.accent;
-  // An empty well has no fill to step, so it shows the two states in two
-  // different places: hovering firms the ring up, and pressing greys the
-  // inside as well. Three looks, which is the point — a hover the press
-  // cannot be told apart from says nothing about the press.
+  // An empty well has no fill to step, so it shows its states in two
+  // different places: focus is a *colour* on the border, hover and press are
+  // a *step* of the inside. Three looks, which is the point — a hover the
+  // press cannot be told apart from says nothing about the press — and four
+  // with focus, because the two channels compose instead of overwriting.
+  //
+  // They used to share the border, where hover won, and that made the focus
+  // colour unreachable by the gesture that focuses by pointer: a click ends
+  // with the pointer sitting on the control it just focused, so the well was
+  // hover-grey for as long as the user was looking at it and only turned
+  // blue once they moved the mouse away.
   const empty = {
-    borderColor:
-      pressed || hover
+    borderColor: focused
+      ? theme.borderFocus
+      : pressed || hover
         ? theme.textMuted
-        : focused
-          ? theme.borderFocus
-          : theme.border,
-    backgroundColor: pressed ? theme.surfaceActive : theme.surface,
+        : theme.border,
+    backgroundColor: pressed
+      ? theme.surfaceActive
+      : hover
+        ? theme.surfaceHover
+        : theme.surface,
   };
   return h(
     'box',
@@ -91,6 +101,9 @@ export function Checkbox({
           backgroundColor: checked ? fill : empty.backgroundColor,
           alignItems: 'center',
           justifyContent: 'center',
+          // a checked well is filled with the accent, so the border tier
+          // above has nothing left to say — see {@link focusRingStyle}
+          ...focusRingStyle(theme, checked && focused),
         },
       },
       checked &&

--- a/src/components/Radio.js
+++ b/src/components/Radio.js
@@ -4,7 +4,7 @@
 
 import React, { useContext, useEffect, useMemo, useRef } from 'react';
 import { changeEvent } from './change.js';
-import { labelContent, useControl, useTheme } from './theme.js';
+import { focusRingStyle, labelContent, useControl, useTheme } from './theme.js';
 import { XK_DOWN, XK_LEFT, XK_RIGHT, XK_UP } from './keys.js';
 
 const h = React.createElement;
@@ -109,16 +109,30 @@ export function Radio({ value, children, label, disabled = false }) {
           height: 16,
           borderRadius: 8,
           borderWidth: theme.borderWidth,
+          // Focus on the border, hover and press on the inside — the two
+          // channels Checkbox splits them into, and for the same reason: a
+          // click leaves the pointer on the control, so a focus colour hover
+          // can overwrite is one the pointer user never gets to see.
+          //
+          // A *selected* radio has spent its border on the fill, and the
+          // branch below it was unreachable — the one radio in a group that
+          // can be clicked without changing anything was also the only one
+          // with nothing to show for it. It gets the ring instead.
           borderColor: selected
             ? fill
-            : pressed || hover
-              ? theme.textMuted
-              : focused
-                ? theme.borderFocus
+            : focused
+              ? theme.borderFocus
+              : pressed || hover
+                ? theme.textMuted
                 : theme.border,
-          backgroundColor: pressed ? theme.surfaceActive : theme.surface,
+          backgroundColor: pressed
+            ? theme.surfaceActive
+            : hover
+              ? theme.surfaceHover
+              : theme.surface,
           alignItems: 'center',
           justifyContent: 'center',
+          ...focusRingStyle(theme, selected && focused),
         },
       },
       selected &&

--- a/src/components/theme.js
+++ b/src/components/theme.js
@@ -335,6 +335,35 @@ export const capTrim = Object.freeze({ textBoxTrim: 'cap-alphabetic' });
 export const capBand = (fontSize) => Math.round(fontSize * 0.72);
 
 /**
+ * The focus ring, as style, for the one part of a widget that has to draw
+ * its own — or `null`, to be spread away, when it does not.
+ *
+ * Every empty control says focus in its border (`borderFocus`), which is the
+ * `:focus` tier styling.md asks for: a colour change welcome however focus
+ * arrived. A **filled** one — a checked box, a selected radio — has spent
+ * that border on the fill and has no colour left to spend, so it says the
+ * same thing one ring further out instead.
+ *
+ * On the part, not the row. The row already draws core's ring, but that one
+ * is the *keyboard* tier — `:focus-visible`, so it arrives on Tab and not on
+ * a click — and it wraps the label with the well. This is the other tier,
+ * and the two stack the same way the border colour and that ring already do.
+ *
+ * `undefined` for the width when off, never `0`: a node with no
+ * `outlineWidth` of its own is one core can leave out of the widened damage
+ * rects entirely (`_outlineExtent`, src/nodes.js), and `0` is the documented
+ * way to opt *out* of a ring the node would otherwise get.
+ */
+export const focusRingStyle = (theme, on) =>
+  on
+    ? {
+        outlineWidth: theme.focusRingWidth,
+        outlineColor: theme.focusRing,
+        outlineOffset: theme.focusRingOffset,
+      }
+    : null;
+
+/**
  * The geometry of rows on a rounded sheet: how far a row sits inside the
  * sheet's edge, and how round its own corners are.
  *

--- a/src/events.js
+++ b/src/events.js
@@ -13,7 +13,12 @@ import { callHandler, reportHandlerError } from './errors.js';
 import { armDrag } from './dnd.js';
 import { desktopSettings } from './desktopsettings.js';
 import { noteInputTime } from './inputtime.js';
-import { hooks as a11yHooks, isFocusable, effectivelyVisible } from './a11y.js';
+import {
+  hooks as a11yHooks,
+  isFocusable,
+  isTextControl,
+  effectivelyVisible,
+} from './a11y.js';
 import { Composer, composeTableFor } from './compose.js';
 import { acceleratorKeysym } from './keyboard.js';
 import { MOD } from './keysyms.js';
@@ -1497,6 +1502,12 @@ export class EventManager {
    * handing focus back as it closes, `node.focus()` from an application —
    * lights one, because none of those tell the user where focus went.
    *
+   * With one exception, which is CSS's too: a **text control** clicked into
+   * lights a ring anyway (`_ringsOnPress`). What the pointer user knows is
+   * where they clicked, not that the next keystroke will land there, and a
+   * clicked field is about to swallow the keyboard — so the one thing the
+   * ring says that the click did not is exactly the thing worth saying.
+   *
    * `backwards` is only meaningful for `reason: 'key'`, and only one element
    * has ever needed it: XEmbed distinguishes a Tab arriving forwards from a
    * back-Tab, because that is what tells an embedded client whether to focus
@@ -1548,7 +1559,10 @@ export class EventManager {
       // and back onto the window that owns it.
       if (!this.keyboardFocused && !restoring) this.node.window?.focus?.();
       node.setStyleState(':focus', true);
-      node.setStyleState(':focus-visible', reason !== 'pointer');
+      node.setStyleState(
+        ':focus-visible',
+        reason !== 'pointer' || this._ringsOnPress(node),
+      );
       // …and nothing scrolls to meet it either: the node is coming back to
       // the arrangement it left, and this reveal's layout has not run, so a
       // scroll here would be computed from a rect that does not exist yet.
@@ -1562,6 +1576,26 @@ export class EventManager {
     }
     this._updateFocusWithin(node);
     a11yHooks.focus?.(old, node);
+  }
+
+  /**
+   * Whether a press lands `:focus-visible` on this node as well as `:focus`.
+   *
+   * The UA rule browsers settled on, and for the reason they settled on it:
+   * a control the keyboard is about to talk to has to show that it holds the
+   * keyboard, whichever way focus arrived. Clicking into a field puts the
+   * caret somewhere the user chose and then makes every keystroke go there —
+   * a state a button, a checkbox or a tab does not enter on a click, which
+   * is why those still stay dark until Tab.
+   *
+   * Asked as "does this element hold editable text", not as "is its kind
+   * `<textinput>`": `isTextControl` is the same predicate the AT-SPI
+   * EDITABLE state is built on (src/a11y.js), so `<textarea>` and a
+   * third-party editor reporting an editable text state answer yes on their
+   * own — the two routes that make a node take the keyboard cannot drift.
+   */
+  _ringsOnPress(node) {
+    return isTextControl(node);
   }
 
   /**

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -262,6 +262,7 @@ const INVALIDATE_REASONS = new Set([
   'props', // a React commit changed what a node draws
   'style-state', // :hover/:focus/:active/:disabled restyle
   'shadow', // a boxShadow got smaller: where it *was* still owes a repaint
+  'outline', // …and the same for an outline a style swap took away
   'theme', // a theme/token change restyled a subtree
   'direction', // the reading direction moved: sides, glyph order, bar edge
   'animation', // a transition frame
@@ -1704,6 +1705,26 @@ export class Node {
           false,
           insetRect(this.paintBounds(), -shrank),
           'shadow',
+        );
+      }
+    }
+    // An outline that just got smaller — or went away — owes the same debt,
+    // and it is only ever owed here. Core's own ring rides `:focus-visible`,
+    // where `EventManager.focus` claims the region while the ring is still
+    // on; what arrives through a style swap is the `outlineWidth` escape
+    // hatch (see `_outline`) — an application outlining a node for a reason
+    // of its own, or a widget ringing one *part* of itself, the way
+    // `<Checkbox>` rings its checked well and drops the ring again on blur.
+    if (
+      displayed.outlineWidth !== this.style.outlineWidth ||
+      displayed.outlineOffset !== this.style.outlineOffset
+    ) {
+      const shrank = this._outlineExtent(displayed) - this._outlineExtent();
+      if (shrank > 0) {
+        this.root?.invalidate(
+          false,
+          insetRect(this.paintBounds(), -shrank),
+          'outline',
         );
       }
     }
@@ -3260,8 +3281,7 @@ export class Node {
    * costs nothing until it is asked for — which is once per focused node
    * per frame, not once per node per commit.
    */
-  _outline() {
-    const style = this.style;
+  _outline(style = this.style) {
     const explicit = style.outlineWidth !== undefined;
     if (!explicit && !this._focusableForRing()) return null;
     const theme = this.theme;
@@ -3287,10 +3307,10 @@ export class Node {
    * *erases* a ring is the one case where the state has already flipped
    * back, and `EventManager.focus` claims the region before it does.
    */
-  _outlineExtent() {
-    if (this.style.outlineWidth === undefined && !this.states[':focus-visible'])
+  _outlineExtent(style = this.style) {
+    if (style.outlineWidth === undefined && !this.states[':focus-visible'])
       return 0;
-    const outline = this._outline();
+    const outline = this._outline(style);
     return outline ? outline.width + Math.max(0, outline.offset) : 0;
   }
 

--- a/test/focus-feedback.test.js
+++ b/test/focus-feedback.test.js
@@ -1,0 +1,302 @@
+// The focus state: what a control shows once it holds the keyboard, and in
+// particular what it shows when the pointer is what put it there.
+//
+// A press deliberately sets `:focus` without `:focus-visible` — a ring on
+// every click is the noise CSS grew the distinction to remove. That left
+// three ways for a mouse user to focus something and be told nothing at all,
+// and all three are the same mistake made in different places: the fact was
+// recorded and then had nowhere to show up.
+//
+//  1. A **text field** is the exception CSS itself makes. The click says
+//     where the caret went; it does not say that every keystroke from now on
+//     lands there, and that is the part worth drawing.
+//  2. `<Checkbox>`/`<Radio>` put focus and hover in the *same* channel, the
+//     well's border, with hover checked first — and a click ends with the
+//     pointer on the control it just focused, so the focus colour was
+//     unreachable by the one gesture that focuses by pointer.
+//  3. A **filled** well (checked, or the selected radio) had spent that
+//     border on the fill, so its focus branch was dead code in the ternary
+//     under it — no ring, pointer or keyboard, ever.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+
+import { Checkbox, Radio, RadioGroup, createRoot } from '../src/index.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+const settle = async () => {
+  await tick();
+  await tick();
+};
+
+const rootOf = (app) => app.windows[0]._reactX11Node;
+
+const all = (node, out = []) => {
+  out.push(node);
+  for (const child of node.children) all(child, out);
+  return out;
+};
+const byRole = (tree, role) => all(tree).filter((n) => n.props.role === role);
+/** Everything here is named, and every assertion is about a name or a
+ * colour: `assert.equal` on two nodes inspects the whole retained tree when
+ * it fails, which is twenty seconds and a diff nobody can read. */
+const byName = (tree, name) =>
+  all(tree).find((n) => n.props.name === name) ?? null;
+
+const centre = (node) => ({
+  x: node.abs.x + node.abs.width / 2,
+  y: node.abs.y + node.abs.height / 2,
+});
+
+/** A click, pointer and all: the motion that puts the pointer *on* the
+ * control is half of what these tests are about, so it is not optional. */
+const click = (wnd, node) => {
+  wnd.emit('mousemove', centre(node));
+  wnd.emit('mousedown', { ...centre(node), keycode: 1 });
+  wnd.emit('mouseup', { ...centre(node), keycode: 1 });
+};
+
+async function mount(element, width = 300, height = 200) {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(h('window', { width, height }, element));
+  await settle();
+  return { app, x11Root, wnd: app.windows[0], tree: rootOf(app) };
+}
+
+// Text measures 0x0 against the mock, which has no fonts, so a field a press
+// can land on is sized by hand.
+const FIELD = { width: 100, height: 20 };
+
+// --- 1. the field a click is about to type into -----------------------------
+
+test('a click into a text field lights a ring; a click on a box does not', async () => {
+  const { x11Root, wnd, tree } = await mount(
+    h(
+      'box',
+      { style: { gap: 10 } },
+      h('textinput', { name: 'field', style: FIELD }),
+      h('box', { name: 'plain', focusable: true, style: FIELD }),
+    ),
+  );
+  const field = byName(tree, 'field');
+  const plain = byName(tree, 'plain');
+
+  click(wnd, field);
+  await settle();
+  assert.strictEqual(field.states[':focus'], true, 'the press focused it');
+  assert.strictEqual(
+    field.states[':focus-visible'],
+    true,
+    'and it shows — the keys are going here now, which the click did not say',
+  );
+
+  click(wnd, plain);
+  await settle();
+  assert.strictEqual(plain.states[':focus'], true, 'this one is focused too');
+  assert.strictEqual(
+    plain.states[':focus-visible'],
+    false,
+    'but takes no keyboard of its own, so the click was the whole story',
+  );
+  assert.strictEqual(
+    field.states[':focus-visible'],
+    false,
+    'and the field let go of its ring with its focus',
+  );
+
+  await x11Root.unmount();
+});
+
+test('the rule is "holds editable text", not "is a <textinput>"', async () => {
+  // `<textarea>` is the second built-in, and it answers through the same
+  // predicate the AT-SPI EDITABLE state uses (`isTextControl`, src/a11y.js)
+  // rather than through a kind list this rule keeps its own copy of.
+  const { x11Root, wnd, tree } = await mount(
+    h('textarea', { name: 'area', style: { width: 100, height: 40 } }),
+  );
+  const area = byName(tree, 'area');
+
+  click(wnd, area);
+  await settle();
+  assert.strictEqual(area.states[':focus-visible'], true);
+
+  await x11Root.unmount();
+});
+
+// --- 2. focus and hover, in two channels ------------------------------------
+
+test('a clicked checkbox shows focus while the pointer is still on it', async () => {
+  const { x11Root, wnd, tree } = await mount(
+    h(Checkbox, { checked: false, label: 'Shout it', onChange: () => {} }),
+  );
+  const control = byRole(tree, 'checkbox')[0];
+  const well = control.children[0];
+  const theme = control.theme;
+
+  wnd.emit('mousemove', centre(control));
+  await settle();
+  assert.strictEqual(
+    well.style.borderColor,
+    theme.textMuted,
+    'hovering firms the ring up, as it always has',
+  );
+
+  click(wnd, control);
+  await settle();
+  assert.strictEqual(
+    tree.events.focused,
+    control,
+    'the click focused the control',
+  );
+  assert.strictEqual(
+    control.states[':hover'],
+    true,
+    'and left the pointer sitting on it — this is the whole trap',
+  );
+  assert.strictEqual(
+    well.style.borderColor,
+    theme.borderFocus,
+    'focus is a colour and hover is a step, so hover cannot overwrite it',
+  );
+  assert.strictEqual(
+    well.style.backgroundColor,
+    theme.surfaceHover,
+    'and the hover still says so, in the channel it moved to',
+  );
+
+  await x11Root.unmount();
+});
+
+test('an unselected radio does too', async () => {
+  const { x11Root, wnd, tree } = await mount(
+    h(
+      RadioGroup,
+      { value: 'normal', onChange: () => {} },
+      h(Radio, { value: 'normal', label: 'normal' }),
+      h(Radio, { value: 'bold', label: 'bold' }),
+    ),
+  );
+  const [, bold] = byRole(tree, 'radio');
+  const well = bold.children[0];
+  const theme = bold.theme;
+
+  click(wnd, bold);
+  await settle();
+  assert.strictEqual(bold.states[':hover'], true, 'pointer still on it');
+  assert.strictEqual(well.style.borderColor, theme.borderFocus);
+
+  await x11Root.unmount();
+});
+
+// --- 3. the well with no border left to spend -------------------------------
+
+test('a checked checkbox rings its well, since its border is the fill', async () => {
+  const { x11Root, wnd, tree } = await mount(
+    h(Checkbox, { checked: true, label: 'Shout it', onChange: () => {} }),
+  );
+  const control = byRole(tree, 'checkbox')[0];
+  const well = control.children[0];
+  const theme = control.theme;
+  assert.strictEqual(
+    well.style.outlineWidth,
+    undefined,
+    'nothing to draw before it is focused — and nothing to widen its damage',
+  );
+
+  click(wnd, control);
+  await settle();
+  assert.strictEqual(well.style.outlineWidth, theme.focusRingWidth);
+  assert.strictEqual(well.style.outlineColor, theme.focusRing);
+  assert.strictEqual(
+    well.style.borderColor,
+    theme.accentHover,
+    'the fill still steps for the hover it is under',
+  );
+
+  await x11Root.unmount();
+});
+
+test('…and so does the selected radio, which a click cannot otherwise change', async () => {
+  // The one radio in a group that can be clicked without anything happening
+  // was also the only one with nothing to show for the click.
+  const { x11Root, wnd, tree } = await mount(
+    h(
+      RadioGroup,
+      { value: 'normal', onChange: () => {} },
+      h(Radio, { value: 'normal', label: 'normal' }),
+      h(Radio, { value: 'bold', label: 'bold' }),
+    ),
+  );
+  const [normal, bold] = byRole(tree, 'radio');
+  const well = normal.children[0];
+  const theme = normal.theme;
+
+  click(wnd, normal);
+  await settle();
+  assert.strictEqual(well.style.outlineWidth, theme.focusRingWidth);
+  assert.strictEqual(well.style.outlineColor, theme.focusRing);
+
+  click(wnd, bold);
+  await settle();
+  assert.strictEqual(
+    well.style.outlineWidth,
+    undefined,
+    'and it goes when focus does',
+  );
+
+  await x11Root.unmount();
+});
+
+// --- the ring a widget draws itself has to be erasable ----------------------
+
+test('an outline a style swap takes away claims where it was', async () => {
+  // The enabling fix for the two above, and a hole in the `outlineWidth`
+  // escape hatch on its own: every claim downstream of a style swap is
+  // bounded by `paintBounds()` computed from the style *now in force*, so a
+  // node that drops a ring would repaint its own box and leave the ring
+  // printed around it. `boxShadow` had this; the outline did not, because
+  // core's own ring never arrives this way — `EventManager.focus` claims it
+  // while `:focus-visible` is still on.
+  const RING = { outlineWidth: 4, outlineColor: '#ff0000', outlineOffset: 2 };
+  const BOX = { marginTop: 20, marginLeft: 20, width: 40, height: 20 };
+  let setOn;
+  const App = () => {
+    const [on, set] = React.useState(true);
+    setOn = set;
+    return h('box', { name: 'b', style: { ...BOX, ...(on ? RING : null) } });
+  };
+  const { app, x11Root, tree } = await mount(h(App));
+  const box = byName(tree, 'b');
+  const lit = box.paintBounds();
+  assert.ok(
+    lit.x <= box.abs.x - 6,
+    `the ring reaches width + offset outside the box: ${JSON.stringify(lit)}`,
+  );
+
+  const claims = [];
+  const invalidate = tree.invalidate.bind(tree);
+  tree.invalidate = (full, target, reason) => {
+    if (reason === 'outline') claims.push(target);
+    return invalidate(full, target, reason);
+  };
+  setOn(false);
+  await settle();
+
+  assert.strictEqual(
+    box.style.outlineWidth,
+    undefined,
+    'the ring is off the style',
+  );
+  assert.deepStrictEqual(
+    claims,
+    [lit],
+    'and where it used to be was claimed, before the bounds shrank under it',
+  );
+
+  tree.invalidate = invalidate;
+  await x11Root.unmount();
+  assert.ok(app);
+});

--- a/test/focus-visibility.test.js
+++ b/test/focus-visibility.test.js
@@ -120,6 +120,10 @@ function suspendable() {
               onBlur: () => state.blurs++,
               onFocus: () => state.focuses++,
             }),
+            // A press on a *field* lights a ring — it is about to take the
+            // keyboard, which is the one thing the click did not say — so the
+            // no-ring half of the restore needs something that is not one.
+            h('box', { name: 'plain', focusable: true, style: FIELD }),
           ),
         ),
         h(Suspender, { suspend }),
@@ -180,22 +184,44 @@ test('…and hands it back, ring and all, when the boundary resolves', async () 
   await root.unmount();
 });
 
-test('…and a field the user clicked comes back without one', async () => {
-  // The other half of "put the state back": a press lights no ring, so a
-  // reveal that lit one would be announcing focus the user never lost.
+test('…and a control the user clicked comes back without one', async () => {
+  // The other half of "put the state back": a press on something that is not
+  // a text field lights no ring, so a reveal that lit one would be announcing
+  // focus the user never lost.
   const { state, element } = suspendable();
   const { root, wnd, tree, events } = await mount(element);
   press(wnd, byName(tree, 'outside')); // off the autoFocus, ring and all
+  const plain = byName(tree, 'plain');
+  press(wnd, plain);
+  assert.equal(focusedName(events), 'plain', 'the press focused it');
+  assert.equal(plain.states[':focus-visible'], false, '…without a ring');
+
+  await flush(() => state.setSuspend(true));
+  await flush(() => state.setSuspend(false));
+
+  assert.equal(focusedName(events), 'plain');
+  assert.equal(plain.states[':focus-visible'], false, 'and still without one');
+
+  await root.unmount();
+});
+
+test('…and a field the user clicked comes back with the ring it had', async () => {
+  // A press on a field *does* light one (`_ringsOnPress`), so this is the
+  // same rule read the other way: what comes back is what was taken away,
+  // and the restore's ring is the field's own rather than a fresh decision.
+  const { state, element } = suspendable();
+  const { root, wnd, tree, events } = await mount(element);
+  press(wnd, byName(tree, 'outside'));
   const input = byName(tree, 'inside');
   press(wnd, input);
   assert.equal(focusedName(events), 'inside', 'the press focused it');
-  assert.equal(input.states[':focus-visible'], false, '…without a ring');
+  assert.equal(input.states[':focus-visible'], true, 'ring and all');
 
   await flush(() => state.setSuspend(true));
   await flush(() => state.setSuspend(false));
 
   assert.equal(focusedName(events), 'inside');
-  assert.equal(input.states[':focus-visible'], false, 'and still without one');
+  assert.equal(input.states[':focus-visible'], true, 'and still with one');
 
   await root.unmount();
 });


### PR DESCRIPTION
A press sets `:focus` without `:focus-visible` on purpose — a ring on every
click is the noise CSS grew the distinction to remove. Three things followed
from that which were not on purpose, and they are one mistake made in three
places: focus was recorded, and then had nowhere to show up. Reported against
`examples/form.jsx`: click into the field, type, and nothing on screen says
the keys are going there.

Every shot below is `examples/form.jsx` rendered by the branch's own code,
driven by real clicks through node-x11's in-process X server. **Left is
`origin/master`, right is this branch**, same scene both sides.

### A click into a text field lights the ring

The exception CSS itself makes. The click says where the caret went; it does
not say that every keystroke from now on lands there, and that second fact is
what the ring is for. `EventManager.focus` asks `isTextControl` — the
predicate the AT-SPI EDITABLE state is built on — so `<textarea>` and a
third-party editor reporting editable text answer for themselves, instead of
through a kind list kept in a second place. Buttons, checkboxes and tabs still
stay dark until Tab, as they do in a browser.

<!-- drag in: pair-field.png -->

### Hover stops hiding focus on `<Checkbox>` and `<Radio>`

Both put focus and hover in the same channel, the well's border, with hover
tested first. A click ends with the pointer sitting on the control it just
focused, so the focus colour was unreachable by the one gesture that focuses
by pointer: the well stayed hover-grey for as long as the user was looking at
it, and only turned blue once they moved the mouse away. Focus is the border
colour now, and hover and press step the background.

### A filled well draws a ring, since its border is the fill

Checked, or the selected radio: the border had been spent on the fill, which
left the focus branch dead code in the ternary under it. The one radio in a
group that can be clicked without changing anything was also the only one with
nothing to show for the click. Both draw a ring on the well instead, through a
shared `focusRingStyle` in the widgets' theme module.

<!-- drag in: pair-checkbox.png -->

<!-- drag in: pair-radio.png -->

### …which needed a fix in core

Not a widget concern: a hole in the documented `outlineWidth` escape hatch for
any application. Every claim downstream of a style swap is bounded by
`paintBounds` computed from the style now in force, so a node that drops an
outline repaints its own box and leaves the ring printed around it.
`boxShadow` had that guard; the outline did not, because core's own ring never
arrives by a style swap — the focus manager claims its region while
`:focus-visible` is still on. Reproduced before fixing: the claim covered
42x22 where the ring had painted out to 54x34.

### Tests

`test/focus-feedback.test.js`, one case per fix, each mutation-checked against
the reverted change. The restore case in `test/focus-visibility.test.js` that
asserted "a clicked field comes back without a ring" now uses a focusable
`<box>` for the no-ring half, with a new case covering the ring the field has
gained. Full suite green apart from the six `appearance.test.js` cases that
already fail on macOS and pass in CI. `typecheck`, `eslint` and
`prettier --check .` clean.

Docs updated in `docs/styling.md` and `docs/events.md`.
