### PR TITLE
fix(scale): a server that is not describing hardware no longer answers the ladder

### DIFF
--- a/docs/scale.md
+++ b/docs/scale.md
@@ -101,6 +101,34 @@ Monitor", VMware, VirtualBox, Parallels, Hyper-V) and by connector name
 the compositor owns scaling there and publishes its decision through rung
 2, in both of its Xwayland modes.
 
+### Servers that are not describing hardware
+
+Rungs 4–5 read a panel, so they are skipped where the connection has no
+panel to describe. Two cases, both of them servers people really run:
+
+- **XQuartz**, detected by the `Apple-WM` extension. macOS composes the
+  desktop in _points_ and hands X the point space, already normalised for
+  density: a 16″ retina lid arrives as 1728×1080, a 1x monitor beside it as
+  2560×1403, and the window server scales what it is given onto whichever
+  panel the window lands on. Inferring a factor here doubles a size macOS
+  is about to double again, so the ladder answers 1x with the source
+  `xquartz` — the same exemption `XWAYLAND` gets, for the same reason.
+- **A single synthetic output covering every monitor.** XQuartz, Xvfb,
+  x11vnc and TigerVNC, Xephyr and pre-RandR drivers answer the output walk
+  with one output — usually named `default`, always without millimetres —
+  whose CRTC is the _union_ of the desktop. Two 2560×1440 monitors union to
+  5120×1440, which rung 5 reads as a retina panel; the machine this was
+  found on unioned a retina lid and two 1x monitors into 5120×2520 and drew
+  every widget at double size. Xinerama reports those heads separately, so
+  more heads than outputs retires rung 5 (`isUnionOutput`). Rung 4 survives
+  it — credible millimetres describe real glass however the pixels were
+  divided up, which is what an `xrandr --setmonitor` split of one ultrawide
+  is.
+
+Both guards sit _below_ the configured rungs: `REACT_X11_SCALE`,
+`GDK_SCALE` and a desktop's own XSETTINGS still win, because a person who
+typed a factor outranks the platform.
+
 ### The machine this was built against
 
 A 16″ MacBook panel handed 1:1 to a UTM Linux guest (XFCE, X11) defeats

--- a/scripts/scale-probe.mjs
+++ b/scripts/scale-probe.mjs
@@ -19,6 +19,11 @@
 //   4. RandR            per-output pixel and millimetre geometry + EDID
 //   5. resolution class the retina-panel guess, when the mm are not credible
 //
+// Between 3 and 4 it also prints what kind of *server* this is, because two
+// kinds retire the hardware rungs: XQuartz (macOS already composed in
+// points) and any server whose single RandR output is really the union of
+// several Xinerama heads.
+//
 // This is the probe that shaped the ladder: on the machine it was written
 // against (a 16" MacBook panel handed 1:1 to a UTM Linux guest), sources
 // 1-4 all answer "1x" — the VM's EDID invents 870x550mm to make the maths
@@ -32,6 +37,7 @@ import {
   parseResourceManager,
   monitorScaleFromMetadata,
   classifyMm,
+  isUnionOutput,
 } from '../src/scale.js';
 
 const out = (...args) => console.log(...args);
@@ -173,7 +179,33 @@ section('RESOURCE_MANAGER (xrdb)');
   }
 }
 
-// --------------------------------------------------------- 5. RandR
+// ------------------------------------------------- 5. the server itself
+// Two facts about the *server* decide whether the hardware rungs below get
+// to speak at all: XQuartz hands X macOS's point space (already scaled),
+// and a server with no real output model answers RandR with one output
+// covering every monitor, which Xinerama contradicts.
+section('server');
+const quartz = await new Promise((resolve) =>
+  X.QueryExtension('Apple-WM', (err, reply) =>
+    resolve(!err && !!reply?.present),
+  ),
+);
+const heads = await (async () => {
+  const xin = await requireExt(X, display, 'xinerama');
+  if (!xin?.QueryScreens) return null;
+  const screens = await call(xin.QueryScreens);
+  return screens?.length ? screens.length : null;
+})();
+out(`  Apple-WM extension: ${quartz ? 'present — this is XQuartz' : 'absent'}`);
+out(`  Xinerama heads: ${heads ?? '(no answer)'}`);
+if (quartz) {
+  out(
+    '  -> the hardware rungs are skipped: macOS composes in points and\n' +
+      '     scales onto the panel itself, so the ladder answers 1x',
+  );
+}
+
+// --------------------------------------------------------- 6. RandR
 section('RandR outputs');
 const randr = await requireExt(X, display, 'randr');
 if (!randr) {
@@ -184,12 +216,26 @@ if (!randr) {
   const edidAtom = await new Promise((resolve) =>
     X.InternAtom(true, 'EDID', (err, atom) => resolve(err ? null : atom)),
   );
+  // Collected before anything is judged: whether the resolution class gets
+  // a vote depends on how many outputs there turn out to be (isUnionOutput).
+  const connected = [];
   for (const id of res?.outputs ?? []) {
     const info = await call(randr.GetOutputInfo, id, res.config_timestamp);
     if (!info || info.connection !== 0) continue; // not connected
     const crtc = info.crtc
       ? await call(randr.GetCrtcInfo, info.crtc, res.config_timestamp)
       : null;
+    connected.push({ id, info, crtc });
+  }
+  const perPanel = !isUnionOutput(connected, heads);
+  if (!perPanel) {
+    out(
+      `  ${connected.length} connected output against ${heads} Xinerama heads —\n` +
+        '  this output is the union of the desktop, not a panel, so its pixel\n' +
+        '  count is not evidence of density (the resolution class is skipped)',
+    );
+  }
+  for (const { id, info, crtc } of connected) {
     out(`  ${info.name}${id === primary ? ' (primary)' : ''}`);
     out(`    reported physical ${info.mm_width} x ${info.mm_height} mm`);
     if (crtc)
@@ -218,19 +264,22 @@ if (!randr) {
           (edid.virtual ? '  ** virtual machine display **' : ''),
       );
     }
-    const verdict = monitorScaleFromMetadata({
-      name: info.name,
-      width: crtc?.width ?? 0,
-      height: crtc?.height ?? 0,
-      widthMM: info.mm_width,
-      heightMM: info.mm_height,
-      edid,
-    });
+    const verdict = monitorScaleFromMetadata(
+      {
+        name: info.name,
+        width: crtc?.width ?? 0,
+        height: crtc?.height ?? 0,
+        widthMM: info.mm_width,
+        heightMM: info.mm_height,
+        edid,
+      },
+      { perPanel },
+    );
     out(`    -> metadata verdict: ${verdict.scale}x (${verdict.reason})`);
   }
 }
 
-// ------------------------------------------------------ 6. Xinerama
+// ------------------------------------------------------ 7. Xinerama
 section('Xinerama');
 {
   const xin = await requireExt(X, display, 'xinerama');

--- a/src/scale.js
+++ b/src/scale.js
@@ -54,6 +54,23 @@
 //      subtly wrong size everywhere.
 //   6. **1**, the answer X11 shipped with in 1987.
 //
+// Rungs 4 and 5 read hardware, so they are skipped where the connection is
+// not describing hardware, and both cases are servers people really run:
+//
+//   * **XQuartz** composes in macOS *points* and hands X the point space —
+//     the retina lid arrives as 1728x1080, already density-normalised, and
+//     the window server scales it onto the panel afterwards. Inferring a
+//     factor here doubles a size macOS is about to double again. Detected
+//     by the `Apple-WM` extension, exempted exactly like `XWAYLAND` in
+//     `VIRTUAL_OUTPUT_NAME`: the compositor owns scaling, so we do not.
+//   * **A single synthetic output** covering every monitor. XQuartz, Xvfb,
+//     VNC servers and Xephyr answer the RandR walk with one output named
+//     `default` whose CRTC is the *union* of the desktop; two 2560x1440
+//     monitors union to 5120x1440, which rung 5 would read as a retina
+//     panel. Xinerama reports those heads separately, so more heads than
+//     outputs retires rung 5 — see `isUnionOutput`. Rung 4 survives it:
+//     millimetres describe real glass however the pixels were split.
+//
 // A machine can defeat every rung above the last two — the one this was
 // written against does: UTM in retina mode hands the guest the MacBook's
 // full 3456x2168 grid, QEMU's EDID invents millimetres that read as 100dpi,
@@ -270,12 +287,47 @@ export function snapScale(value) {
 }
 
 /**
+ * Is this RandR output list describing panels, or one synthetic output
+ * covering the whole desktop?
+ *
+ * Servers that never grew a real output model — XQuartz, Xvfb, x11vnc and
+ * TigerVNC, Xephyr, old drivers under `xorg.conf` — answer the RandR walk
+ * with a single output (usually named `default`, always without
+ * millimetres) whose CRTC is the *union* of every monitor attached. On a
+ * desktop with two monitors side by side that union is twice as wide as any
+ * panel in it, and rung 5 reads pixel counts: a pair of 2560x1440 monitors
+ * unions to 5120x1440 and is judged retina-class, which is how a 1x desk
+ * ends up drawing everything at double size.
+ *
+ * Xinerama is the cross-check, and it is free of the same blind spot: the
+ * same servers report the heads individually there, because that is the
+ * only geometry protocol they implement. More heads than outputs means the
+ * output list is not per-panel data, whatever it claims.
+ */
+export function isUnionOutput(outputs, heads) {
+  return (
+    Array.isArray(outputs) &&
+    outputs.length > 0 &&
+    Number.isInteger(heads) &&
+    outputs.length < heads
+  );
+}
+
+/**
  * One monitor's metadata → `{ scale, source, reason }`, using only what the
  * connection reported: pixel geometry, claimed millimetres, EDID. This is
  * rungs 4 and 5 of the ladder for one output; the caller stacks the
  * desktop-configuration rungs above it.
+ *
+ * `perPanel: false` says this record's geometry spans more than one monitor
+ * (`isUnionOutput` above), which retires rung 5 alone: the resolution class
+ * is a statement about *a panel* and means nothing about a union of them.
+ * Rung 4 still answers when it can, because credible millimetres describe
+ * real glass however the pixels were divided up afterwards — a `--setmonitor`
+ * split of one ultrawide is the case that reaches this branch on a server
+ * whose RandR is otherwise perfectly honest.
  */
-export function monitorScaleFromMetadata(monitor) {
+export function monitorScaleFromMetadata(monitor, { perPanel = true } = {}) {
   const mm = classifyMm(monitor, monitor);
   const pxW = monitor.width ?? 0;
   const pxH = monitor.height ?? 0;
@@ -306,7 +358,7 @@ export function monitorScaleFromMetadata(monitor) {
   // grids stay at 1 on purpose — 2560x1440 is the commonest *1x* desk
   // monitor there is, and only millimetres could tell it from a 13" retina
   // lid, which is exactly the data this branch does not have.
-  if (Math.min(pxW, pxH) >= 1800 || Math.max(pxW, pxH) >= 3000) {
+  if (perPanel && (Math.min(pxW, pxH) >= 1800 || Math.max(pxW, pxH) >= 3000)) {
     return {
       scale: 2,
       source: 'resolution',
@@ -316,7 +368,10 @@ export function monitorScaleFromMetadata(monitor) {
   return {
     scale: 1,
     source: 'default',
-    reason: `no credible density data (mm ${mm}, ${pxW}x${pxH})`,
+    reason: perPanel
+      ? `no credible density data (mm ${mm}, ${pxW}x${pxH})`
+      : `${pxW}x${pxH} spans several monitors, so its pixel count says ` +
+        `nothing about any panel (mm ${mm})`,
   };
 }
 
@@ -468,6 +523,57 @@ async function readOutputs(app) {
   return connected.length ? connected : null;
 }
 
+/**
+ * How many monitors Xinerama says are attached, or null where the server
+ * does not answer. Read only to sanity-check the RandR walk against
+ * (`isUnionOutput`) — the geometry itself is `screens.js`'s business.
+ *
+ * A server with the extension present but inactive replies with one screen
+ * covering everything, which is the same answer as "one monitor" and is
+ * treated as such: the cross-check needs a *disagreement* to fire.
+ */
+async function countHeads(app) {
+  const xinerama = await requireExtension(app, 'xinerama');
+  if (!xinerama?.QueryScreens) return null;
+  const screens = await call(xinerama.QueryScreens.bind(xinerama));
+  return Array.isArray(screens) && screens.length ? screens.length : null;
+}
+
+/**
+ * Is this XQuartz?
+ *
+ * It matters because XQuartz is not handing us a framebuffer: macOS composes
+ * the desktop in *points* and hands X the point space, already normalised
+ * for density. A 16" retina lid arrives as 1728x1080 and a 1x desk monitor
+ * beside it as 2560x1403 — the same 14pt text is the same physical size on
+ * both, and the window server scales what it is given onto whichever panel
+ * the window lands on. Every hardware rung below is therefore answering a
+ * question that was already answered: inferring 2x from the pixels would
+ * double a size macOS is about to double again.
+ *
+ * This is the `XWAYLAND` exemption in `VIRTUAL_OUTPUT_NAME` for the same
+ * reason and by the same rule — the compositor owns scaling, so we do not —
+ * and it sits below the configured rungs, not above them, because a person
+ * who typed `REACT_X11_SCALE` or `GDK_SCALE` outranks the platform.
+ *
+ * `Apple-WM` is the extension quartz-wm drives; it is present on every
+ * XQuartz server and on no other X server, including when the client is
+ * remote and only the display is a Mac (which is exactly when the point
+ * space is still the truth).
+ */
+function isQuartzServer(X) {
+  if (typeof X?.QueryExtension !== 'function') return Promise.resolve(false);
+  return new Promise((resolve) => {
+    try {
+      X.QueryExtension('Apple-WM', (err, reply) =>
+        resolve(!err && !!reply?.present),
+      );
+    } catch {
+      resolve(false);
+    }
+  });
+}
+
 // --------------------------------------------------------------------------
 // The session
 // --------------------------------------------------------------------------
@@ -555,11 +661,35 @@ export async function beginScale(app, option) {
     return session;
   }
 
-  // Rungs 4-5: the hardware, one verdict per output.
-  const outputs = await readOutputs(app);
+  // Rungs 4-5: the hardware, one verdict per output — but only where the
+  // connection is describing hardware. The three reads go out together
+  // because none of them depends on another and this is the chain the first
+  // window waits behind.
+  const [quartz, outputs, heads] = await Promise.all([
+    isQuartzServer(X),
+    readOutputs(app),
+    countHeads(app),
+  ]);
+
+  if (quartz) {
+    // 1, and not because nothing answered: macOS already did the scaling.
+    session.source = 'xquartz';
+    trace(
+      '1x from Apple-WM — XQuartz hands X macOS point space, already scaled',
+    );
+    return session;
+  }
+
+  const perPanel = !isUnionOutput(outputs, heads);
   if (outputs) {
+    if (!perPanel) {
+      trace(
+        `${outputs.length} RandR output(s) against ${heads} Xinerama heads: ` +
+          'the output list is not per-panel, so the resolution class is out',
+      );
+    }
     for (const monitor of outputs) {
-      const verdict = monitorScaleFromMetadata(monitor);
+      const verdict = monitorScaleFromMetadata(monitor, { perPanel });
       session.monitors.set(monitor.name, {
         scale: verdict.scale,
         source: verdict.source,

--- a/test/scale.test.js
+++ b/test/scale.test.js
@@ -14,12 +14,14 @@ import {
   parseResourceManager,
   parseEdid,
   classifyMm,
+  isUnionOutput,
   monitorScaleFromMetadata,
   snapScale,
   desktopScaleFromXSettings,
   desktopScaleFromResources,
   beginScale,
   scaleOf,
+  scaleSourceOf,
 } from '../src/scale.js';
 
 // -------------------------------------------------------------- fixtures
@@ -390,4 +392,152 @@ test('REACT_X11_SCALE outranks even the explicit option', async () => {
 
 test('scaleOf answers 1 for an app the ladder never ran on', () => {
   assert.strictEqual(scaleOf({}), 1);
+});
+
+// --------------------------------------- servers that are not describing hardware
+
+test('isUnionOutput: fewer outputs than heads means the list is not per-panel', () => {
+  const one = [{ name: 'default' }];
+  // XQuartz, Xvfb, VNC: one synthetic output, several real monitors
+  assert.strictEqual(isUnionOutput(one, 3), true);
+  assert.strictEqual(isUnionOutput(one, 2), true);
+  // an ordinary desktop: RandR names every panel it drives
+  assert.strictEqual(isUnionOutput([{}, {}], 2), false);
+  assert.strictEqual(isUnionOutput(one, 1), false);
+  // a mirrored pair is one head on two outputs — the disagreement that
+  // fires this check only ever runs the other way
+  assert.strictEqual(isUnionOutput([{}, {}], 1), false);
+  // no Xinerama answer is not evidence of anything
+  assert.strictEqual(isUnionOutput(one, null), false);
+  assert.strictEqual(isUnionOutput(null, 3), false);
+  assert.strictEqual(isUnionOutput([], 3), false);
+});
+
+test('a union output retires the resolution class but not the millimetres', () => {
+  // the desktop this was found on: XQuartz over a retina lid and two 1x
+  // monitors, unioned into 5120x2520 with no millimetres at all
+  const union = { name: 'default', width: 5120, height: 2520 };
+  assert.strictEqual(verdict(union).scale, 2); // what it used to answer
+  const guarded = monitorScaleFromMetadata(union, { perPanel: false });
+  assert.strictEqual(guarded.scale, 1);
+  assert.strictEqual(guarded.source, 'default');
+  assert.match(guarded.reason, /spans several monitors/);
+
+  // rung 4 is untouched: an ultrawide split by `xrandr --setmonitor` is one
+  // real panel with real millimetres, however its pixels were divided
+  const ultrawide = monitorScaleFromMetadata(
+    { name: 'DP-1', width: 5120, height: 2160, widthMM: 600, heightMM: 253 },
+    { perPanel: false },
+  );
+  assert.strictEqual(ultrawide.source, 'randr-mm');
+  assert.strictEqual(ultrawide.scale, 2);
+});
+
+/**
+ * Enough of a connection for the ladder to climb: no XSETTINGS daemon (no
+ * `GetSelectionOwner`, which is how `beginXSettings` says "nothing here"),
+ * an empty `RESOURCE_MANAGER`, and a RandR walk that answers with whatever
+ * outputs the test hands it. The methods are arrows because `readOutputs`
+ * calls them unbound.
+ */
+function fakeConnection({ appleWM = false, outputs = [], heads = null } = {}) {
+  const ids = outputs.map((_, i) => i + 1);
+  const byId = new Map(ids.map((id, i) => [id, outputs[i]]));
+  const randr = {
+    GetScreenResourcesCurrent: (root, cb) =>
+      cb(null, { outputs: ids, config_timestamp: 1 }),
+    GetOutputPrimary: (root, cb) => cb(null, ids[0] ?? 0),
+    GetOutputInfo: (id, ts, cb) => {
+      const o = byId.get(id);
+      cb(null, {
+        name: o.name,
+        connection: 0,
+        crtc: id, // non-zero: readOutputs drops an output with no CRTC
+        mm_width: o.widthMM ?? 0,
+        mm_height: o.heightMM ?? 0,
+      });
+    },
+    GetCrtcInfo: (crtc, ts, cb) => {
+      const o = byId.get(crtc);
+      cb(null, { x: 0, y: 0, width: o.width, height: o.height });
+    },
+    GetOutputProperty: (id, atom, a, b, c, d, e, cb) =>
+      cb(null, { data: null }),
+  };
+  const xinerama = {
+    QueryScreens: (cb) =>
+      heads === null
+        ? cb(new Error('no xinerama'))
+        : cb(
+            null,
+            Array.from({ length: heads }, () => ({
+              x: 0,
+              y: 0,
+              width: 1,
+              height: 1,
+            })),
+          ),
+  };
+  const X = {
+    display: { screen: [{ root: 1 }] },
+    GetProperty: (del, wid, atom, type, long0, longN, cb) =>
+      cb(null, { data: Buffer.alloc(0) }),
+    InternAtom: (onlyIfExists, name, cb) => cb(null, 7),
+    QueryExtension: (name, cb) =>
+      cb(null, { present: name === 'Apple-WM' ? appleWM : false }),
+    require: (name, cb) =>
+      name === 'randr'
+        ? cb(null, randr)
+        : name === 'xinerama'
+          ? cb(null, xinerama)
+          : cb(new Error(`no ${name}`)),
+  };
+  return { X };
+}
+
+test('the hardware rungs read a retina panel on an ordinary server', async () => {
+  // the control for the two guards below: same pixels, honest server
+  const app = fakeConnection({
+    outputs: [{ name: 'eDP-1', width: 3456, height: 2168 }],
+    heads: 1,
+  });
+  await beginScale(app, 'auto');
+  assert.strictEqual(scaleOf(app), 2);
+  assert.strictEqual(scaleSourceOf(app), 'resolution');
+});
+
+test('XQuartz answers 1x: macOS handed X a point space it already scaled', async () => {
+  const app = fakeConnection({
+    appleWM: true,
+    // the union XQuartz really reports for a retina lid + two 1x monitors
+    outputs: [{ name: 'default', width: 5120, height: 2520 }],
+    heads: 3,
+  });
+  await beginScale(app, 'auto');
+  assert.strictEqual(scaleOf(app), 1);
+  assert.strictEqual(scaleSourceOf(app), 'xquartz');
+});
+
+test('a single output covering several heads never reaches the resolution class', async () => {
+  // not a Mac: Xvfb, a VNC server, an old driver — one `default` output
+  // whose CRTC is two 2560x1440 monitors side by side
+  const app = fakeConnection({
+    outputs: [{ name: 'default', width: 5120, height: 1440 }],
+    heads: 2,
+  });
+  await beginScale(app, 'auto');
+  assert.strictEqual(scaleOf(app), 1);
+  assert.strictEqual(scaleSourceOf(app), 'default');
+});
+
+test('a configured desktop still outranks both guards', async () => {
+  process.env.GDK_SCALE = '2';
+  try {
+    const app = fakeConnection({ appleWM: true, heads: 3 });
+    await beginScale(app, 'auto');
+    assert.strictEqual(scaleOf(app), 2);
+    assert.strictEqual(scaleSourceOf(app), 'GDK_SCALE');
+  } finally {
+    delete process.env.GDK_SCALE;
+  }
 });


### PR DESCRIPTION
`scale: 'auto'` resolves 2x on my Mac and draws every widget at double size. The ladder is reading hardware metadata from a server that is not describing hardware.

## What this display reports

XQuartz, three monitors — a 16" retina lid and two 1x Lenovo panels:

```
core screen      5120 x 2520 px, "1344 x 658 mm"  -> 96.8 dpi, synthesised
XSETTINGS        no daemon owns _XSETTINGS_S0
RESOURCE_MANAGER empty, nothing ever ran xrdb
RandR            one output named default, 0 x 0 mm, CRTC 5120x2520+0+0
Xinerama         1728x1080, 2560x1403, 2560x1403
verdict          2x via the resolution class — wrong
```

Rungs 1-3 say nothing, so the ladder reaches the hardware and finds a single output whose CRTC is the union of all three monitors. 5120 is over the retina threshold, so rung 5 calls it a retina panel. It is not a panel at all.

Two separate things are wrong there, so there are two guards.

## Guard 1 — XQuartz, detected by the Apple-WM extension

macOS composes the desktop in points and hands X a space it has already normalised for density: the retina lid arrives as 1728x1080, a 1x monitor beside it as 2560x1403. The same 14px text is the same physical size on both, and the window server scales onto whichever panel the window lands on. Inferring a factor here doubles a size macOS is about to double again. `XWAYLAND` already had this exemption for the same reason; XQuartz now gets it too, answering 1x with the source `xquartz`.

## Guard 2 — one synthetic output covering several heads

Xvfb, x11vnc, TigerVNC, Xephyr and pre-RandR drivers all answer the output walk with a single output spanning the whole desktop. Two 2560x1440 monitors union to 5120x1440, which rung 5 reads as retina. Xinerama reports those heads separately, so fewer outputs than heads means the list is not per-panel data, and `isUnionOutput` retires rung 5 for it.

Rung 4 survives that guard: credible millimetres describe real glass however the pixels were divided up afterwards, which is what an `xrandr --setmonitor` split of one ultrawide is.

Both guards sit below the configured rungs, so `REACT_X11_SCALE`, `GDK_SCALE` and a desktop's own XSETTINGS still outrank them.

Why both, when either one fixes this desktop: XQuartz's `GetScreenResourcesCurrent` often replies with zero outputs until some client issues a full `GetScreenResources` — I hit exactly that between two runs while writing this, and `xrandr` priming the server is what brought the output back. Guard 2 needs RandR to answer, guard 1 does not, so XQuartz is deterministic either way; and guard 2 covers the servers that are not Macs.

## Before and after

Same scene, same pinned fonts and frozen clock, rendered by this branch's own code against the real XQuartz display, each window at its true pixel size. Left: `src/scale.js` as merged — 1040 x 680 device pixels for a 520 x 340 logical window. Right: this branch — 520 x 340.

![scale-before-after](https://github.com/user-attachments/assets/398c9fed-07aa-4d8e-af8e-649f2230bf8c)

## Also in here

- `scripts/scale-probe.mjs` grew a `server` section reporting the extension and the head count, and passes the same per-panel flag into each verdict, so `npm run scale:probe` and the ladder agree again.
- `docs/scale.md` documents both cases under "Servers that are not describing hardware".

## Tests

Five new in `test/scale.test.js`: the `isUnionOutput` truth table, the verdict split, and three ladder runs against a fake connection — a control that still resolves 2x on an honest server with a 3456x2168 panel, the XQuartz case, a non-Mac 5120x1440 union, and `GDK_SCALE` outranking both guards. Mutation-checked: disabling either guard fails exactly the tests that cover it, and nothing else.

Full suite 1594 passing. The seven failures are the pre-existing macOS-local ones — six in `appearance.test.js`, one in `font-explorer.test.js` — identical with `src/scale.js` reverted to master.

