### PR TITLE
docs: the display scale model shipped, so stop calling it a gap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -603,11 +603,12 @@ found the hard way — a fake that answers a question the real one cannot yet
 answer hides the state the UI most needs to get right, and a fake that
 resolves instantly leaves nothing to assert about the state in between.
 
-**Say what does not work.** Where an example meets a real gap — no IME, no
-HiDPI scale model, no per-node container query — name it and link the issue
-rather than steering around it. That matches how `docs/` already handles
-compatibility ladders, and a reader who hits the same wall is better served by
-a sentence than by a silence.
+**Say what does not work.** Where an example meets a real gap — no IME
+([#272](https://github.com/sidorares/react-x11/issues/272)), no `opacity`, no
+per-node container query — name it and link the issue rather than steering
+around it. That matches how `docs/` already handles compatibility ladders, and
+a reader who hits the same wall is better served by a sentence than by a
+silence.
 
 **Check it on a real display.** This is the one that keeps being relearned.
 The headless harness renders with the font a test hands it, never the one

--- a/NEXT_STEPS.md
+++ b/NEXT_STEPS.md
@@ -1130,40 +1130,44 @@ adapter" is exactly this change. Same treatment for `onSubmit`, whose
 declared signature is `(text: string, ev: unknown)` — the `unknown` is an
 admission.
 
-### 12.5 HiDPI — pick the mechanism before anything freezes
+### 12.5 HiDPI — DONE (#116, PR #378)
 
-There is no notion of a pixel scale anywhere in react-x11, ntk or the app
-(#116). `src/nodes.js` creates yoga nodes on the default Config
-(pointScaleFactor 1); `src/styles.js` passes `fontSize` straight through as
-a device-pixel size; nothing reads `Xft.dpi`, `GDK_SCALE`/`QT_SCALE_FACTOR`,
-or the RandR per-output mm/pixel ratio. **On a 4K panel at `Xft.dpi=192` —
-the default GNOME/KDE 2× setup — every widget and every glyph renders at
-exactly half the size of every GTK and Qt app on the same desktop.** That is
-not cosmetic; the app is unreadable, and it is the state on a large share of
-the machines people actually run.
+The problem, as it stood: there was no notion of a pixel scale anywhere in
+react-x11, ntk or the app. **On a 4K panel at 2× — the default GNOME/KDE
+setup — every widget and every glyph rendered at exactly half the size of
+every GTK and Qt app on the same desktop.** That is not cosmetic; the app is
+unreadable, and it was the state on a large share of the machines people
+actually run.
 
-Scale is a **root** concern, not a style concern, because it has to multiply
-layout, font sizes and the paint transform together. Three wiring points,
-all small: one `Yoga.Config` per root with `setPointScaleFactor(scale)`;
-multiply the resolved font pixel size in `src/styles.js`; and
-`ctx.scale(scale, scale)` once at the top of `WindowNode.flush`, with the
-`<window width/height>` props multiplied on the way to `createWindow`.
-`node.abs` and `getClientRects()` stay in **logical** units, so `anchorRect`
-and everything built on it need no change. Yoga's point scale is exactly the
-answer to the objection that a float scale breaks the integer dirty-rect
-math: layout stays logical, computed edges snap to physical pixels so
-borders stay crisp, and rounding damage rects outward at the paint boundary
-holds the invariant.
+Shipped, and [docs/scale.md](docs/scale.md) is the record: every length an
+app writes is a **logical pixel**, `createRoot({ scale: 'auto' })` is the
+default, and `useScale()` reports the factor. **The mechanism is not the one
+this section originally proposed**, and the difference is worth keeping:
 
-`'auto'` resolves the way GTK4 and Qt6 do: `GDK_SCALE`/`QT_SCALE_FACTOR` →
-`Xft.dpi` parsed out of the root window's `RESOURCE_MANAGER` property → the
-RandR primary output's `pixel_width / (mm_width / 25.4) / 96` rounded to the
-nearest 0.25 → 1. Plus `REACT_X11_SCALE` to override. Static at startup is
-an acceptable v1 — a mid-session DPI change is rare and we do not select
-root-window events today — but say so rather than leaving it to be
-discovered.
+- **Values are multiplied, not the context.** No `ctx.scale()` anywhere.
+  ntk's 2d context gates its server-side fast paths (`Render.FillRectangles`,
+  rounded rects, glyph runs) on an identity transform, and it sizes glyphs
+  from the font while only _positioning_ them through the transform — so a
+  frame-wide `ctx.scale(2,2)` would rasterize the whole UI as polygons and
+  move the text without growing it. Multiplying at the end of the style
+  funnel (`scaleResolvedStyle()` in `_syncStyle`) leaves paint code, damage
+  rects, the scroll blit and the paint cache working in integer device
+  pixels with the transforms they always had.
+- **No `pointScaleFactor` games.** Layout runs directly in device pixels;
+  yoga's ordinary whole-pixel rounding is what keeps a 1-logical-px border
+  crisp at 1.5×. Fractional scales work end to end.
+- **Logical/device is a boundary, not a coordinate system.** `node.abs` and
+  yoga's computed layout are device; the app-facing egresses divide
+  (`SyntheticEvent`, `getClientRects`, `onScroll`, `useScreens`…).
+- **The ladder is longer than proposed.** Environment → XSETTINGS →
+  `RESOURCE_MANAGER` → audited RandR millimetres → resolution class → 1,
+  because `Gdk/WindowScalingFactor: 1` and `Xft.dpi: 96` are what daemons
+  publish when nobody configured anything, and VM EDIDs invent millimetres
+  that land on 96dpi. See the header of `src/scale.js`.
+- **Per-monitor answers ride on `useScreens()`**; the root takes the primary
+  output's. Static at startup, as proposed, and said out loud in the docs.
 
-**Separately, and do not confuse the two:** the hardcoded component
+**Still open, and do not confuse the two:** the hardcoded component
 constants (`DefaultTheme.fontSize`, `paddingX`/`paddingY`, the Checkbox and
 Radio wells, `SLIDER_THUMB`, the Switch geometry) should move into the theme
 regardless, as `theme.controlSize`, `theme.thumbSize` and friends. That is a

--- a/docs/system.md
+++ b/docs/system.md
@@ -58,9 +58,15 @@ Each entry in `screens`:
 | `refreshRate`            | Hz to two decimals (`59.99`), or null                          |
 | `rotation`               | `0`, `90`, `180` or `270`                                      |
 | `outputs`                | every output on this monitor — two names means it is mirrored  |
+| `scale`                  | this monitor's device pixels per logical pixel                 |
 
 Re-renders when a monitor is plugged in or unplugged, when the arrangement
 changes, and when a panel appears, moves or auto-hides.
+
+The rects are in **logical pixels**, like every other length an app touches,
+and `scale` is the per-monitor answer the display-scale ladder arrived at —
+a retina lid and an office monitor genuinely differ. The root's own scale
+is the primary monitor's; see [scale.md](scale.md).
 
 ### The names arrive after the geometry
 
@@ -367,8 +373,3 @@ this renderer already speaks.
 do not log out yet". The X-native answer (XSMP) is effectively dead and the live
 one is logind. The shape worth having is probably not a system hook but a
 `useBeforeQuit()` that unifies it with `<window onCloseRequest>`.
-
-**Display scale.** On a HiDPI desktop every widget renders at half size, and
-fixing it means a scale that multiplies layout, font sizes and the paint
-transform together — a root concern rather than a hook. Tracked as
-[#116](https://github.com/sidorares/react-x11/issues/116).


### PR DESCRIPTION
[#378](https://github.com/sidorares/react-x11/pull/378) shipped the display scale model and closed [#116](https://github.com/sidorares/react-x11/issues/116), but three documents still described HiDPI as missing. Docs only — no code changes.

### `docs/system.md`

Removed the **Display scale** entry from "What is not here".

While in that page, the `useScreens()` table gained the `scale` column it never had: every screen entry carries one — set in `src/screenshooks.js` and declared in `src/types/system.d.ts` — and `docs/scale.md` already says the per-output answers ride on this hook. Added a line noting the rects are logical pixels, pointing at `scale.md`.

### There was no second copy to edit

`website/docs/reference/` is gitignored and regenerated from `docs/` by `website/scripts/sync-docs.mjs` on every `prebuild`. The `website/docs/reference/system.md` in a working tree is a stale build artifact — the one I found also predated the `animations` docs. After a build, the generated file is identical to `docs/system.md` apart from its six-line front matter, so fixing the source is the whole fix.

### `AGENTS.md`

The rule "say what does not work" listed *no HiDPI scale model* as an example gap. Replaced with `opacity`, which still needs offscreen composition and is tracked in `docs/styling.md`. The IME item gained the issue link — [#272](https://github.com/sidorares/react-x11/issues/272) — that the sentence asks every example to carry.

### `NEXT_STEPS.md` §12.5

This was the design proposal that became #378, and **the mechanism it proposed is not the one that shipped**. Retitled `HiDPI — DONE`, following the section-level style of §11.1 and §11.4. The problem statement is kept in past tense; the proposal is replaced by what was actually built, explicitly flagged as a departure:

- values multiplied at the end of the style funnel, **not** a `ctx.scale()` — ntk gates its server-side fast paths on an identity transform and sizes glyphs from the font while only positioning them through the transform
- no yoga `pointScaleFactor`; layout runs in device pixels
- logical/device as a boundary, with division at the app-facing egresses
- a six-rung ladder rather than three, because `Gdk/WindowScalingFactor: 1` and `Xft.dpi: 96` are what daemons publish when nobody configured anything

`docs/scale.md` is named as the record throughout. The paragraph on moving hardcoded control constants into the theme is still open — `SLIDER_THUMB` is still a literal `16` — so it stays, retitled "Still open".

### Checks

- `npm run format:check` — clean over the whole tree
- `cd website && npm run build` — 48 reference pages, no broken links or anchors; `scale.md` is now in the generated reference, which is what the new cross-page link resolves against

Both re-run after rebasing onto `4bfc83c`.
