### PR TITLE
feat(examples): San Francisco via fontconfig — the macOS lookalike setup

### DIFF
--- a/examples/labs/sf-fonts.conf
+++ b/examples/labs/sf-fonts.conf
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<!--
+  Make the generic families resolve to Apple's San Francisco, so every
+  example renders with the macOS system font without touching any code:
+
+      FONTCONFIG_FILE=$PWD/examples/labs/sf-fonts.conf npm run examples:widgets
+
+  "System Font" is the family name SFNS.ttf declares (fc-list shows it as
+  ".SF NS" too; both match). The rules sit AFTER the include on purpose:
+  rules run in load order, and the stock config canonicalizes the pattern
+  fc-match builds from the string "sans-serif" (parsed as family "sans" —
+  the hyphen is fc-name syntax) into family "sans-serif" only in its own
+  rules, so a test for "sans-serif" placed before the include never fires.
+  The prepend is strong-bound, and a strong family beats the lang-based
+  scoring that otherwise hands sans-serif to Hiragino on a macOS box.
+-->
+<fontconfig>
+  <include ignore_missing="yes">/opt/homebrew/etc/fonts/fonts.conf</include>
+  <match target="pattern">
+    <test qual="any" name="family"><string>sans-serif</string></test>
+    <edit name="family" mode="prepend" binding="strong"><string>System Font</string></edit>
+  </match>
+  <match target="pattern">
+    <test qual="any" name="family"><string>monospace</string></test>
+    <edit name="family" mode="prepend" binding="strong"><string>.SF NS Mono</string></edit>
+  </match>
+</fontconfig>

--- a/examples/themes.js
+++ b/examples/themes.js
@@ -59,9 +59,19 @@ const github = {
   },
 };
 
+// The macOS theme also names the platform's faces. On a Mac, fontconfig
+// resolves "System Font" to /System/Library/Fonts/SFNS.ttf — San Francisco,
+// the family fc-list shows as ".SF NS" — and the mono list to SF Mono.
+// Anywhere those are not installed the lists fall through to the generic,
+// so the theme stays runnable off-platform; it just stops being a lookalike.
+const sfText = '"System Font", "SF Pro Text", sans-serif';
+const sfMono = '".SF NS Mono", "SF Mono", monospace';
+
 /** macOS: softer greys, tighter type, the system blue. */
 const macos = {
   light: {
+    fontFamily: sfText,
+    monoFamily: sfMono,
     background: '#ececec',
     surface: '#ffffff',
     text: '#000000',
@@ -83,6 +93,8 @@ const macos = {
     paddingY: 9,
   },
   dark: {
+    fontFamily: sfText,
+    monoFamily: sfMono,
     background: '#1e1e1e',
     surface: '#3a3a3c',
     text: '#ffffff',


### PR DESCRIPTION
Every example can now render in the macOS system font with one env var:

```
FONTCONFIG_FILE=$PWD/examples/labs/sf-fonts.conf npm run examples:widgets
```

## What this is

macOS ships San Francisco as ttf files in `/System/Library/Fonts` — `SFNS.ttf` declares family **"System Font"** (fc-list also shows it as `.SF NS`), with the italics in `SFNSItalic.ttf` under the same family and SF Mono in `SFNSMono.ttf`. Homebrew fontconfig already indexes them; the only reason `sans-serif` comes up Hiragino (the default nobody chose, per `examples/fonts.jsx`) is ranking — lang scoring beats weak family entries. `sf-fonts.conf` strong-prepends the SF families onto `sans-serif` and `monospace`, which is exactly what wins over that scoring, and regular/bold/italic/mono all resolve to the SF files (verified with `fc-match` and by rendering).

Two traps are written into the file's comment so the next reader keeps the hour this cost:

- The rules must sit **after** the `<include>`. fc-name parses the string `sans-serif` as family `sans` — the hyphen is syntax — and only the stock config canonicalizes it back, so a rule testing `sans-serif` placed before the include never fires. (`monospace` has no hyphen and works either way, which makes the failure look haunted.)
- "SF Pro" is the *downloadable* family and is not what macOS ships; `fc-match 'SF Pro'` silently falls back to Verdana. The installed family is "System Font".

The macos theme in `examples/themes.js` now names the platform faces too — `"System Font", "SF Pro Text", sans-serif` and the SF Mono equivalent — with the generics as the fallthrough, so the theme stays runnable off-platform; it just stops being a lookalike.

## Known limit, deliberately not fixed here

A `ThemeProvider` *inside* a window feeds `useTheme()` and `$token` styles but not the default text face: the cascade floors `fontFamily` at the root window's theme (`inheritedTextStyle`, src/nodes.js), and `planted()` only puts the theme on the window when the provider wraps a `<window>` child. `theming.jsx` hosts its provider inside the window (so `ThemingPanel` stays embeddable in `app.jsx`), so the new theme keys are inert there for plain text until that gap is closed — verified by rendering the same tree both ways. Filed separately rather than smuggled into an examples change.

## Screenshots

Rendered by react-x11 itself on XQuartz (same specimen tree, this branch's tree state), before and after the override — SF's tighter advances, real italics from SFNSItalic, SF Mono on the code line. Attached below.



![sf-before-hiragino](https://github.com/user-attachments/assets/4bb5fd3c-05d2-4434-83d2-1ef2b6bb8bb1)



![sf-after-san-francisco](https://github.com/user-attachments/assets/e06fba98-72c1-47c8-bb48-82a19b8b493e)
