### PR TITLE
perf(nodes): amortize a commit's per-insert bookkeeping across the parent (#397)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1071,6 +1071,40 @@ onDraw>`, `value`, `placeholder`. `children` and event handlers are
     out-of-flow node animating a layout property is bounded by its parent,
     which contains both where it was and where it is going.
 
+- **A commit's per-insert bookkeeping is amortized, not paid per row**
+  (issue #397). React mounts a subtree one `insertBefore` at a time, so a
+  virtualized list's re-slice — a hundred rows into one pane, per commit, for
+  the length of a scrollbar scrub — used to pay for the whole pane per row: a
+  `paintBounds()` walk for the before-damage, a scan of every sibling in front
+  of the new row to find its yoga slot, and two `indexOf` over the child list.
+  O(rows x pane), and about a third of commit time in the profile that found
+  it. Three pieces of bookkeeping replaced the scans:
+
+  - `_childListBefore()` walks the subtree **once per node per frame** and
+    hands the same rect to every later mutation. Sound because nothing is laid
+    out or painted between two mutations of one frame, so a child still in the
+    list carries the rect it was last painted at and one that leaves later was
+    inside the first walk's bound. `root._reflowed` is the marker for the
+    window — joined at the first claim, cleared by `flush()`.
+  - `_nonYogaKids` counts the children standing outside the parent's yoga tree
+    (`<window>`, `<popup>`, text chunks), so the usual all-boxes list answers
+    `_yogaIndexAt` with the child index instead of a walk.
+  - `_indexOfChild` remembers a child's slot and **proves** it before use —
+    `children[i] === child`, a node appearing in the list once — rather than
+    trusting it, so a stale hint costs a scan and never a wrong answer.
+    `_spliceChild` refreshes the two slots it knows, which is what keeps a run
+    of inserts in front of the same trailing sibling off the scan entirely.
+
+  Mounting 100 rows into an 800-row pane: 785k `_subtreeBounds` visits down to
+  23k, 89k `_joinsYoga` calls to 900, 55ms of `insertBefore` to 4ms.
+  `test/child-list-commit.test.js` fences the shape — the same commit against
+  a pane four times as long asks the same number of questions — and pins the
+  pixels against a full repaint. The pane in that pixel test is deliberately
+  smaller than the rows it holds and does not clip them: a row that leaves is
+  in no layout diff, and the arrangement claimed _after_ layout no longer
+  reaches the band it occupied, so the pre-mutation walk is the only thing
+  that erases it.
+
 - **A stalled frame clock under synthetic input.** ntk paces
   `requestAnimationFrame` behind a fence (a `GetInputFocus` whose reply
   confirms the server consumed the last frame). Driving events with

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -1441,6 +1441,13 @@ function shallowEqual(a, b) {
   return ka.length === kb.length && ka.every((k) => a[k] === b[k]);
 }
 
+/** The half of `Node._joinsYoga` that is about the child alone — a real X
+ * window (`<window>`, `<popup>`) or a node built without a box at all (a text
+ * chunk) sits outside whatever parent it lands in. This is what
+ * `_nonYogaKids` counts, so the count stays right for a parent that has no
+ * box of its own either. */
+const outsideYoga = (child) => !child.yoga || child.isWindow;
+
 export class Node {
   get ownerDocument() {
     return DEVTOOLS_FAKE_DOCUMENT;
@@ -1465,6 +1472,20 @@ export class Node {
     this.app = app;
     this.parent = null;
     this.children = [];
+    // Where this node sits in `parent.children`, and how many of *this*
+    // node's children sit outside its yoga tree. Both are bookkeeping that
+    // turns the scans `insertBefore` used to do over the whole child list
+    // into constant work, which is what stops a commit that mounts a
+    // virtualized list's window from costing O(rows x pane) (issue #397).
+    // The index is a hint — `_indexOfChild` proves it before using it — and
+    // the count is exact, maintained by the three places `children` is
+    // spliced.
+    this._childIndex = -1;
+    this._nonYogaKids = 0;
+    // The pre-mutation bounds this frame already claimed for this node, so
+    // that a second mutation reuses the rect instead of walking the subtree
+    // again. Lives exactly as long as membership in `root._reflowed`.
+    this._reflowBefore = null;
     this.root = null; // owning WindowNode once attached
     this.hidden = false;
     this.destroyed = false;
@@ -2256,6 +2277,12 @@ export class Node {
   /** Number of yoga-bearing children before `index` (window children and
    * text spans/chunks do not join the parent's yoga tree). */
   _yogaIndexAt(index) {
+    // A list of ordinary boxes — a scroll pane's rows, which is the list
+    // this is asked about a hundred times in one commit — has every child in
+    // the yoga tree, and then the yoga index *is* the child index. Counting
+    // the exceptions as they arrive turns that answer into a read instead of
+    // a walk of every sibling in front of the new row (issue #397).
+    if (this._nonYogaKids === 0) return index;
     let n = 0;
     for (let i = 0; i < index; i++) {
       if (this._joinsYoga(this.children[i])) n++;
@@ -2265,6 +2292,24 @@ export class Node {
 
   _joinsYoga(child) {
     return Boolean(this.yoga && child.yoga && !child.isWindow);
+  }
+
+  /**
+   * Where `child` sits in `this.children`.
+   *
+   * The cached slot is checked rather than trusted: a node appears in the
+   * list once, so `children[i] === child` *is* the proof that `i` is its
+   * index, and a cache that has gone stale costs a scan rather than a wrong
+   * answer. `_spliceChild` refreshes the two slots it knows — the child it
+   * placed and the sibling it pushed along — which is what keeps a run of
+   * inserts in front of the same trailing sibling (every virtualized list's
+   * commit) off the scan entirely.
+   */
+  _indexOfChild(child) {
+    if (this.children[child._childIndex] === child) return child._childIndex;
+    const i = this.children.indexOf(child);
+    child._childIndex = i;
+    return i;
   }
 
   /**
@@ -2354,12 +2399,22 @@ export class Node {
    * by calling insertBefore with a child that is *already* mounted here, and
    * without the removal it would appear twice. Returns the new index. */
   _spliceChild(child, beforeChild) {
-    const from = this.children.indexOf(child);
+    // `parent === this` is the cheap form of "already in this list" — the
+    // two are set and cleared together — so a child arriving for the first
+    // time, which is every node of a freshly mounted subtree, pays no scan
+    // at all for the question.
+    const from = child.parent === this ? this._indexOfChild(child) : -1;
     if (from !== -1) this.children.splice(from, 1);
-    const before =
-      beforeChild == null ? -1 : this.children.indexOf(beforeChild);
+    else if (outsideYoga(child)) this._nonYogaKids++;
+    const before = beforeChild == null ? -1 : this._indexOfChild(beforeChild);
     const index = before === -1 ? this.children.length : before;
     this.children.splice(index, 0, child);
+    // The two slots this splice knows. Every other cached index at or after
+    // `index` has shifted by one and will be caught by the check in
+    // `_indexOfChild`; these two are the ones a run of inserts in front of
+    // the same sibling asks about again on the very next call.
+    child._childIndex = index;
+    if (beforeChild != null) beforeChild._childIndex = index + 1;
     return index;
   }
 
@@ -2408,10 +2463,10 @@ export class Node {
     }
     // captured before the child joins, so it covers the arrangement that is
     // about to be replaced (see _childListChanged)
-    const before = this.paintBounds();
+    const before = this._childListBefore();
     // a move has to leave the yoga tree too — yoga aborts on insertChild of
     // a node that still has a parent
-    if (this.children.includes(child) && this._joinsYoga(child)) {
+    if (child.parent === this && this._joinsYoga(child)) {
       this.yoga.removeChild(child.yoga);
     }
     const index = this._spliceChild(child, beforeChild);
@@ -2427,6 +2482,36 @@ export class Node {
     this._textContentChanged();
     this._childListChanged(before);
     a11yHooks.attached?.(this, child);
+  }
+
+  /**
+   * This node's paint bounds from before a child-list mutation — the `before`
+   * half of `_childListChanged`'s protocol, captured while a departing child
+   * is still attached.
+   *
+   * Walked once per node per frame rather than once per mutation. A commit
+   * that mounts a virtualized list's window inserts a hundred rows into one
+   * pane, one `insertBefore` at a time, and a walk of the whole pane per row
+   * is what made that commit O(rows x pane) (issue #397).
+   *
+   * Reusing the first walk's answer is not an approximation. Nothing is laid
+   * out or painted between two mutations in the same frame, so every child
+   * still carries the rect it was last painted at, and a child that leaves
+   * later in the frame was in the list — and so inside the rect — when the
+   * first walk ran. `root._reflowed` is the marker for "this frame already
+   * has one", which is exactly its lifetime: joined at the first claim,
+   * cleared by `flush()`.
+   */
+  _childListBefore() {
+    const root = this.root;
+    // A subtree still being built off-tree claims nothing — this is the
+    // `appendInitialChild` path, which is most of a mount, and where the
+    // walk used to be thrown away by `_childListChanged`'s `!root` return.
+    if (!root) return null;
+    if (root._reflowed.has(this) && this._reflowBefore) {
+      return this._reflowBefore;
+    }
+    return (this._reflowBefore = this.paintBounds());
   }
 
   /**
@@ -2453,15 +2538,16 @@ export class Node {
   }
 
   removeChild(child) {
-    const index = this.children.indexOf(child);
+    const index = this._indexOfChild(child);
     if (index === -1) return;
     // told while the child is still wired, so the bridge can compute the
     // index the AT will see the removal at
     a11yHooks.detach?.(this, child);
     // captured while the child is still attached, so it covers the rect the
     // child is about to stop occupying
-    const before = this.paintBounds();
+    const before = this._childListBefore();
     this.children.splice(index, 1);
+    if (outsideYoga(child)) this._nonYogaKids--;
     if (this._joinsYoga(child)) {
       this.yoga.removeChild(child.yoga);
     }
@@ -3199,7 +3285,10 @@ export class Node {
   _invalidateLayout(reason) {
     const root = this.root;
     if (!root) return;
-    root.invalidate(true, this.paintBounds(), reason);
+    // Same walk, same frame, same answer — see `_childListBefore`, whose
+    // record this shares so that a reflow and a child-list change on one
+    // node in one frame walk the subtree once between them.
+    root.invalidate(true, this._childListBefore(), reason);
     root._reflowed.add(this);
   }
 
@@ -9488,8 +9577,11 @@ export class WindowNode extends Scrollable(Node) {
 
   removeChild(child) {
     if (child.isWindow) {
-      const index = this.children.indexOf(child);
-      if (index !== -1) this.children.splice(index, 1);
+      const index = this._indexOfChild(child);
+      if (index !== -1) {
+        this.children.splice(index, 1);
+        this._nonYogaKids--;
+      }
       const id = child.window?.id;
       child.parent = null;
       child.destroySubtree();
@@ -10091,6 +10183,8 @@ export class WindowNode extends Scrollable(Node) {
       // replaced it. Claimed after layout because an inserted child has no
       // rect before it.
       for (const node of this._reflowed) {
+        // …and the pre-mutation walk this frame reused goes with it
+        node._reflowBefore = null;
         if (!node.destroyed)
           this._damage =
             this._damage === FULL_DAMAGE
@@ -10099,6 +10193,7 @@ export class WindowNode extends Scrollable(Node) {
       }
       this._reflowed.clear();
     } else if (this._reflowed.size) {
+      for (const node of this._reflowed) node._reflowBefore = null;
       this._reflowed.clear();
     }
     // any node this pass laid out may be what an open popup is anchored to

--- a/test/child-list-commit.test.js
+++ b/test/child-list-commit.test.js
@@ -1,0 +1,396 @@
+// Mounting a commitful of rows into a pane that already holds a lot of them
+// (issue #397). React inserts a virtualized list's window one `insertBefore`
+// at a time, and every insert used to pay for the whole pane: a
+// `paintBounds()` walk for the before-damage, a scan of every sibling in
+// front of the new row to find its yoga slot, and two `indexOf` over the
+// child list. A commit of N rows into a pane of M nodes cost O(N x M).
+//
+// The tests come in two halves. The counting ones assert the shape of the
+// cost — the same commit against a pane four times as long asks the same
+// number of questions — and are what a reintroduction trips over. The rest
+// assert that the bookkeeping which replaced the scans is *right*: a child's
+// remembered index, and the count of children standing outside the parent's
+// yoga tree, both of which are only ever visible as a row landing in the
+// wrong place.
+import assert from 'node:assert';
+import { test } from 'node:test';
+import React from 'react';
+
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient } from 'ntk';
+
+import { createRoot } from '../src/index.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+const settle = async () => {
+  for (let i = 0; i < 6; i++) await tick();
+};
+
+/** Every node's `_nonYogaKids` against a fresh count of the same thing. The
+ * counter is maintained by hand at the three places `children` is spliced,
+ * so this is the check that none of them was missed. */
+function assertCountsExact(node, where) {
+  const outside = node.children.filter((c) => !c.yoga || c.isWindow).length;
+  assert.strictEqual(
+    node._nonYogaKids,
+    outside,
+    `${where}: <${node.kind}> counts ${node._nonYogaKids} children outside ` +
+      `its yoga tree, but ${outside} are`,
+  );
+  for (const child of node.children) assertCountsExact(child, where);
+}
+
+/** The rows' vertical order, which is the only place a wrong yoga index
+ * shows up: yoga lays a column out in *its* order, not the child list's. */
+const columnOrder = (pane) =>
+  pane.children
+    .filter((c) => c.yoga && !c.isWindow)
+    .slice()
+    .sort((a, b) => a.abs.y - b.abs.y)
+    .map((c) => c.props.name);
+
+/**
+ * A pane of named rows in a column, rebuilt from `rows` on demand. The
+ * trailing row is what everything is inserted in front of — the
+ * after-spacer every virtualized list ends with, and the sibling whose
+ * `indexOf` the old code re-scanned for every row of the batch.
+ */
+async function pane(initial, extras = () => []) {
+  const app = createMockApp({ width: 200, height: 400 });
+  const x11Root = await createRoot({ app });
+  const ref = React.createRef();
+  let setRows;
+  function App() {
+    const [rows, set] = React.useState(initial);
+    setRows = set;
+    return h(
+      'window',
+      { style: { width: 200, height: 400 } },
+      h(
+        'box',
+        { ref, style: { flexDirection: 'column' } },
+        ...extras(),
+        ...rows.map((name) =>
+          h('box', { key: name, name, style: { height: 4 } }),
+        ),
+        h('box', { key: 'tail', name: 'tail', style: { height: 4 } }),
+      ),
+    );
+  }
+  await new Promise((resolve) => x11Root.render(h(App), resolve));
+  await settle();
+  return {
+    app,
+    x11Root,
+    node: ref.current,
+    async set(rows) {
+      setRows(rows);
+      await settle();
+    },
+  };
+}
+
+const names = (n, prefix = 'r') =>
+  Array.from({ length: n }, (_, i) => `${prefix}${i}`);
+
+// --- the shape of the cost ------------------------------------------------
+
+/**
+ * Mount `batch` rows into a pane that already holds `resident`, and count
+ * what the pane was asked. `paintBounds` is patched on the instance, which
+ * is where `_childListBefore` and the post-layout claim both go through.
+ */
+async function commitCost(resident, batch) {
+  const p = await pane(names(resident));
+  const node = p.node;
+  let walks = 0;
+  let scans = 0;
+  const paintBounds = node.paintBounds.bind(node);
+  node.paintBounds = () => {
+    walks++;
+    return paintBounds();
+  };
+  const indexOfChild = node._indexOfChild.bind(node);
+  node._indexOfChild = (child) => {
+    // a cache hit is proved by the slot, so anything else is a real scan
+    if (node.children[child._childIndex] !== child) scans++;
+    return indexOfChild(child);
+  };
+  await p.set([...names(resident), ...names(batch, 'b')]);
+  assertCountsExact(node, `${resident}+${batch}`);
+  await p.x11Root.unmount?.();
+  p.app.close?.();
+  return { walks, scans, children: node.children.length };
+}
+
+test('mounting a batch of rows asks the pane a fixed number of questions', async () => {
+  const small = await commitCost(20, 40);
+  const large = await commitCost(80, 40);
+
+  assert.strictEqual(small.children, 61);
+  assert.strictEqual(large.children, 121);
+
+  // The point of the issue: four times the pane, the same commit. Before the
+  // fix these were 40 walks and 120 scans either way — one set per row —
+  // and each walk and each scan was itself proportional to the pane.
+  assert.deepStrictEqual(
+    { walks: small.walks, scans: small.scans },
+    { walks: large.walks, scans: large.scans },
+    'the cost of a 40-row commit does not follow the length of the pane',
+  );
+  assert.ok(
+    large.walks <= 2,
+    `the pane is walked once before the batch and once after layout, ` +
+      `not ${large.walks} times`,
+  );
+  assert.strictEqual(
+    large.scans,
+    0,
+    'and a run of inserts in front of the same sibling never scans the list',
+  );
+});
+
+test('removing a batch of rows is amortized the same way', async () => {
+  const p = await pane(names(60));
+  const node = p.node;
+  let walks = 0;
+  const paintBounds = node.paintBounds.bind(node);
+  node.paintBounds = () => {
+    walks++;
+    return paintBounds();
+  };
+  await p.set(names(10));
+  assert.ok(walks <= 2, `${walks} walks for a 50-row removal`);
+  assertCountsExact(node, 'after removal');
+  assert.deepStrictEqual(columnOrder(node), [...names(10), 'tail']);
+  await p.x11Root.unmount?.();
+  p.app.close?.();
+});
+
+test('the walk is amortized across a frame, not across the pane’s life', async () => {
+  // The window the reuse is sound in is one frame — after `flush()` the tree
+  // has been laid out and painted, and the rect from before it says nothing
+  // about what is on the surface now.
+  const p = await pane(names(10));
+  const node = p.node;
+  const walks = [];
+  let n = 0;
+  const paintBounds = node.paintBounds.bind(node);
+  node.paintBounds = () => {
+    n++;
+    return paintBounds();
+  };
+  for (const rows of [names(20), names(5), names(14)]) {
+    n = 0;
+    await p.set(rows);
+    walks.push(n);
+  }
+  assert.ok(
+    walks.every((w) => w >= 1),
+    `each commit walks the pane again: ${walks.join(', ')}`,
+  );
+  await p.x11Root.unmount?.();
+  p.app.close?.();
+});
+
+// --- the bookkeeping that replaced the scans ------------------------------
+
+test('a keyed reorder still lands every row in its yoga slot', async () => {
+  const p = await pane(names(6));
+  const orders = [
+    ['r5', 'r4', 'r3', 'r2', 'r1', 'r0'],
+    ['r3', 'r0', 'r5', 'r1', 'r4', 'r2'],
+    ['r2', 'r3', 'r4', 'r5', 'r0', 'r1'],
+    // and one that inserts, moves and removes in the same commit
+    ['r4', 'new', 'r1', 'r0'],
+  ];
+  for (const order of orders) {
+    await p.set(order);
+    assert.deepStrictEqual(
+      p.node.children.map((c) => c.props.name),
+      [...order, 'tail'],
+      `child list after ${order.join(',')}`,
+    );
+    assert.deepStrictEqual(
+      columnOrder(p.node),
+      [...order, 'tail'],
+      `laid-out order after ${order.join(',')}`,
+    );
+    assertCountsExact(p.node, order.join(','));
+  }
+  await p.x11Root.unmount?.();
+  p.app.close?.();
+});
+
+test('a popup among the rows does not take a yoga slot', async () => {
+  // A `<popup>` is its own window: it sits in the child list and outside the
+  // parent's yoga tree, which is exactly the case the fast path in
+  // `_yogaIndexAt` has to refuse.
+  const p = await pane(names(4), () => [
+    h('popup', { key: 'p', x: 0, y: 0, style: { width: 20, height: 20 } }),
+  ]);
+  assert.strictEqual(p.node._nonYogaKids, 1, 'the popup is counted as outside');
+  assertCountsExact(p.node, 'with a popup');
+  assert.deepStrictEqual(columnOrder(p.node), [...names(4), 'tail']);
+
+  // …and a batch mounted in front of the trailing row still stacks in order
+  await p.set(['r0', 'r1', 'r2', 'r3', ...names(20, 'b')]);
+  assertCountsExact(p.node, 'with a popup, after a batch');
+  assert.deepStrictEqual(columnOrder(p.node), [
+    ...names(4),
+    ...names(20, 'b'),
+    'tail',
+  ]);
+  await p.x11Root.unmount?.();
+  p.app.close?.();
+});
+
+test('text chunks are outside their parent’s yoga tree and counted so', async () => {
+  const app = createMockApp({ width: 200, height: 200 });
+  const x11Root = await createRoot({ app });
+  const ref = React.createRef();
+  let setLabel;
+  function App() {
+    const [label, set] = React.useState('one');
+    setLabel = set;
+    return h(
+      'window',
+      { style: { width: 200, height: 200 } },
+      h(
+        'box',
+        { ref, style: { flexDirection: 'column' } },
+        h('text', {}, label),
+      ),
+    );
+  }
+  await new Promise((resolve) => x11Root.render(h(App), resolve));
+  await settle();
+  assertCountsExact(ref.current, 'text mounted');
+  setLabel('two');
+  await settle();
+  assertCountsExact(ref.current, 'text updated');
+  await x11Root.unmount?.();
+  app.close?.();
+});
+
+// --- that the amortized claim is safe -------------------------------------
+
+const W = 160;
+const H = 120;
+const ROW_H = 6;
+
+async function headlessApp() {
+  const server = xserver.createServer({ width: 400, height: 400 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  return createClient({ stream: clientEnd });
+}
+
+const flushed = (app) =>
+  new Promise((resolve, reject) =>
+    app.X.GetInputFocus((err) => (err ? reject(err) : resolve())),
+  );
+
+async function image(app, root) {
+  const ctx = (root._ctx ??= root.window.getContext('2d'));
+  const data = await new Promise((resolve, reject) =>
+    ctx.getImageData(0, 0, W, H, (err, d) => (err ? reject(err) : resolve(d))),
+  );
+  return Buffer.from(data.data);
+}
+
+test('a re-sliced window paints what a full repaint of it paints', async () => {
+  // The invariant behind claiming the pane's bounds once instead of once per
+  // insert: nothing is laid out or painted between two mutations of the same
+  // frame, so the first walk already covers every pixel the later ones would
+  // have.
+  //
+  // The pane here is deliberately *smaller* than the rows it holds and does
+  // not clip them, which is what puts weight on that claim. A row that leaves
+  // is gone before layout runs, so it is in no layout diff; and the
+  // arrangement claimed after layout no longer reaches the band it occupied.
+  // The pre-mutation walk is the only thing that erases it — and this commit
+  // makes thirteen of them leave at once.
+  const app = await headlessApp();
+  const x11Root = await createRoot({ app });
+  try {
+    let setSlice;
+    const paneRef = React.createRef();
+    function App() {
+      const [slice, set] = React.useState({ from: 0, count: 16 });
+      setSlice = set;
+      const rows = [];
+      for (let i = 0; i < slice.count; i++) {
+        const n = slice.from + i;
+        rows.push(
+          h('box', {
+            key: n,
+            style: {
+              height: ROW_H,
+              backgroundColor: n % 2 ? '#e74c3c' : '#2ecc71',
+            },
+          }),
+        );
+      }
+      return h(
+        'window',
+        { width: W, height: H, style: { backgroundColor: '#101820' } },
+        h(
+          'box',
+          { ref: paneRef, style: { flexDirection: 'column', height: 20 } },
+          ...rows,
+          h('box', {
+            key: 'tail',
+            style: { height: 4, backgroundColor: '#f1c40f' },
+          }),
+        ),
+      );
+    }
+    await new Promise((resolve) => x11Root.render(h(App), resolve));
+    await tick();
+    const root = paneRef.current.root;
+    root.flush();
+    await flushed(app);
+
+    // Each of these is one commit that mounts a batch of rows in front of the
+    // trailing spacer and drops the ones that left — a scrollbar scrub's
+    // re-slice, then one that lands near the end of a short list.
+    for (const slice of [
+      { from: 6, count: 14 },
+      { from: 40, count: 3 },
+      { from: 0, count: 16 },
+    ]) {
+      const where = `slice ${slice.from}+${slice.count}`;
+      setSlice(slice);
+      await settle();
+      root.flush();
+      await flushed(app);
+      const amortized = await image(app, root);
+
+      assert.ok(
+        root._lastDamageRects,
+        `${where}: the frame stayed bounded — a full repaint would prove ` +
+          'nothing',
+      );
+      assertCountsExact(root, where);
+
+      // the same tree again with the bound thrown away
+      root.needsPaint = true;
+      root._damage = null;
+      root.flush();
+      await flushed(app);
+      const full = await image(app, root);
+
+      assert.ok(
+        amortized.equals(full),
+        `${where}: one claim for the whole commit erases everything the ` +
+          'commit moved',
+      );
+    }
+  } finally {
+    await x11Root.unmount?.();
+    app.close?.();
+  }
+});


### PR DESCRIPTION
Amortizes the per-insert bookkeeping in `Node.insertBefore` / `removeChild`, so a commit that mounts N children into a parent of M nodes costs O(N + M) rather than O(N × M).

Fixes #397.

## What was per-insert

React mounts a subtree one `insertBefore` at a time, and each insert paid for the whole parent:

- **`paintBounds()`** was captured per insert for the before-damage — a `_subtreeBounds` walk over the whole pane, per row. On a detached subtree it was walked and then thrown away, which is the `appendInitialChild` path and most of a mount.
- **`_yogaIndexAt(index)`** scanned every sibling in front of the new child, calling `_joinsYoga` — and its `isWindow` getter — on each.
- **`_spliceChild`** ran two `Array.indexOf` over the child list, and `insertBefore` a third `children.includes`.

## What replaces them

**`_childListBefore()`** walks the subtree once per node per frame and hands the same rect to every later mutation. Not an approximation: nothing is laid out or painted between two mutations of one frame, so a child still in the list carries the rect it was last painted at, and one that leaves later was in the list — and inside the bound — when the first walk ran. `root._reflowed` is the marker for that window; it is joined at the first claim and cleared by `flush()`, which is exactly the right lifetime. `_invalidateLayout` shares the record, so a reflow and a child-list change on one node in one frame walk once between them. A parent with no root returns null and skips the walk outright.

**`_nonYogaKids`** counts the children standing outside the parent's yoga tree — `<window>`, `<popup>`, text chunks — maintained at the three places `children` is spliced. The usual all-boxes list then answers `_yogaIndexAt` with the child index; anything else falls back to the scan.

**`_indexOfChild`** remembers a child's slot and *proves* it before use — a node appears in the list once, so `children[i] === child` is the proof — which makes a stale hint cost a scan rather than a wrong answer. `_spliceChild` refreshes the two slots it knows, the child it placed and the sibling it pushed along, which keeps a run of inserts in front of the same trailing sibling off the scan entirely. "Already in this list" is now asked of `child.parent` rather than by scanning.

## Numbers

100 rows of 8 cells mounted into a pane in one commit, driven through React against the mock app; a viewport that clips over a content column that does not, which is the shape a virtualized list has. Counters are per commit, `insertBefore` is its total self time.

| resident rows | `_subtreeBounds` visits | `_joinsYoga` calls | list-scan steps | `insertBefore` |
| --- | --- | --- | --- | --- |
| 100 — before | 142,056 | 18,750 | 53,850 | 10.1ms |
| 100 — after | 4,509 | 900 | 0 | 0.9ms |
| 400 — before | 417,456 | 48,750 | 143,850 | 20.6ms |
| 400 — after | 12,609 | 900 | 0 | 1.2ms |
| 800 — before | 784,656 | 88,750 | 263,850 | 54.9ms |
| 800 — after | 23,409 | 900 | 0 | 3.9ms |

The remaining `_subtreeBounds` visits are the two walks a commit still owes the pane — one before the batch, one after layout — and they follow the pane, not the batch. `getHostSibling` on the React side is untouched; the issue calls it inherent to fibers.

`npm run bench -- --check` and `npm run bench:pixels -- --check` both report no change, which is the point: the damage a frame claims is the same, it is just computed once.

## Tests

`test/child-list-commit.test.js`:

- **the shape of the cost** — the same 40-row commit against a pane of 20 and of 80 asks the same number of questions, the pane is walked at most twice, and a run of inserts in front of the same sibling never scans the list. Removals are checked the same way, and a third test pins the amortization window to one frame.
- **the bookkeeping is right** — keyed reorders, including a commit that inserts, moves and removes at once, land every row in its yoga slot; a `<popup>` among the rows is counted as outside the yoga tree and refuses the fast path; text chunks likewise. Every assertion re-counts `_nonYogaKids` from the live child list, which is what catches a missed splice site.
- **the amortized claim is safe** — three successive re-slices are painted, then repainted with the bound thrown away, and compared byte for byte. The pane there is deliberately smaller than the rows it holds and does not clip them: a row that leaves is in no layout diff, and the arrangement claimed after layout no longer reaches the band it occupied, so the pre-mutation walk is the only thing that erases it. Replacing that walk with a degenerate rect fails this test.

Every test in the file fails against `master`, and the two mutants that matter — always taking the `_yogaIndexAt` fast path, and trusting the cached index without proving it — are each caught.

Local suite is otherwise unchanged: the six known macOS-only `appearance.test.js` failures, and nothing else, on `master` and on this branch alike.

`AGENTS.md` gains a note in the performance section with the invariant, the three mechanisms and the numbers.
