### PR TITLE
perf(scroll): a blitting viewport keeps a ledger of what changed inside it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -978,10 +978,33 @@ onDraw>`, `value`, `placeholder`. `children` and event handlers are
   falls back to the plain repaint: too-small viewports and page-sized jumps
   are not worth the bookkeeping (`SCROLL_BLIT_MIN_AREA`,
   `SCROLL_BLIT_MIN_KEEP`), fractional offsets and diagonal deltas cannot
-  blit, any other claim near the viewport (checked at `invalidate` time,
-  _before_ rects coalesce and hide it), a border/borderRadius on the
-  scroll pane, an overlapping non-descendant, a debug overlay or DevTools
-  highlight all bail. The invariant, pinned by a pixel test in
+  blit, a border/borderRadius on the scroll pane, an overlapping
+  non-descendant, a debug overlay or DevTools highlight all bail.
+
+  A claim landing inside the viewport used to bail too. It now goes into a
+  per-frame **ledger** on the scrolling node (issue #398), recorded at
+  `invalidate` time — _before_ rects coalesce and hide it, the reason the
+  check was there at all (issue #295) — and repainted after the `CopyArea`,
+  moved by the frame's delta when the claim predates the layout pass. The
+  blit translates the previous frame's rendering, which is correct
+  everywhere the content did not change; the ledger is the list of places
+  it did. It still bails when a claim covers the viewport, when there are
+  more than `BLIT_MAX_CLAIMS` of them, or when what they add up to
+  (`BLIT_MAX_CLAIM_AREA`, and `SCROLL_BLIT_MAX_REPAINT` once the damage cap
+  has merged them with the strip and the scrollbar column) stops being
+  cheaper than the one pass it replaced. The case this exists for is the
+  **virtualized list**, whose own re-slice commit claims inside the viewport
+  on every scroll frame by construction — the spacers resize and the
+  entering rows mount — so the fast path used to fire on the first wheel
+  notch of a flick and never again. Three things feed the ledger the truth:
+  a claim from inside the viewport is clipped to it (`_claimBounds`, so a
+  spacer ninety thousand pixels tall does not coalesce the scroll's claim
+  into a damage rect many times the viewport), the container's child-list
+  claims go per-child instead of naming its own box, and the layout diff
+  runs under a scroll with the shift subtracted so it reports the children
+  that really moved rather than the ones that only rode the blit.
+
+  The invariant, pinned by a pixel test in
   `test/scroll-blit.test.js`, is that a blitted frame is byte-identical to
   the repaint it replaced; `REACT_X11_NO_SCROLL_BLIT=1` turns the path off
   for A/B measurement and as field first aid. The bench's scroll scenario is
@@ -990,6 +1013,9 @@ onDraw>`, `value`, `placeholder`. `children` and event handlers are
   silently stopped the fast path from firing would pass unnoticed. The fence
   is verifiable — `REACT_X11_NO_SCROLL_BLIT=1 npm run bench -- --check` must
   fail, and does (887 requests and 3.28 Mpx against a 437 / 0.65 baseline).
+  The virtualized-list scenario beside it is fenced the same way, and is
+  what prices the ledger: ten notches cost 295 requests / 0.56 Mpx with it
+  and 785 / 3.20 without.
 
   **Where scrolling actually spent its time was neither of those.** Profiling a
   50,000-row table found the cost in ntk's `clip()`: intersecting a clip

--- a/scripts/bench/baseline.json
+++ b/scripts/bench/baseline.json
@@ -109,6 +109,17 @@
     "dupQueries": 0,
     "churn": 0
   },
+  "scroll: 10 notches over a virtualized list": {
+    "requests": 295,
+    "bytesOut": 14104,
+    "bytesIn": 3032,
+    "replies": 44,
+    "composites": 70,
+    "compositePixels": 561760,
+    "stalls": 12,
+    "dupQueries": 0,
+    "churn": 0
+  },
   "svg: 100 unchanged icons, full repaint": {
     "requests": 105,
     "bytesOut": 3676,

--- a/scripts/bench/protocol.js
+++ b/scripts/bench/protocol.js
@@ -811,6 +811,104 @@ const SCENARIOS = [
     })(),
   ],
   [
+    // The same wheel flick over a *virtualized* list — the shape react-x11
+    // components' <Table> and <Tree> have, and the case the scroll-blit
+    // gate used to miss entirely (issue #398). Every notch is a scroll and
+    // a child-list commit in one frame: the two spacers resize and the
+    // entering rows mount, all inside the viewport the blit wants to keep.
+    //
+    // Baselined with the ledger live, like the plain scroll scenario above
+    // and for the same reason: --check only fails on an increase, so a
+    // change that quietly went back to poisoning the frame would sail past
+    // a fallback baseline and land on this one.
+    'scroll: 10 notches over a virtualized list',
+    (() => {
+      const ROW = 24;
+      const ROWS = 100000;
+      let root;
+      let setTop;
+      const frame = () => {
+        root._scheduled = false;
+        root.flush();
+      };
+      const List = () => {
+        const [top, set] = React.useState(0);
+        setTop = set;
+        const first = Math.floor(top / ROW);
+        const last = Math.min(ROWS, first + Math.ceil(H / ROW) + 2);
+        const rows = [];
+        for (let i = first; i < last; i++) {
+          rows.push(
+            React.createElement(
+              'box',
+              {
+                key: i,
+                style: {
+                  height: ROW,
+                  flexDirection: 'row',
+                  flexShrink: 0,
+                  gap: 6,
+                  padding: 4,
+                  backgroundColor: i % 2 ? '#ffffff' : '#eef1f5',
+                },
+              },
+              React.createElement(
+                'text',
+                { style: { fontSize: 11 } },
+                `row ${i}: the quick brown fox`,
+              ),
+            ),
+          );
+        }
+        return React.createElement(
+          'box',
+          { style: { flexGrow: 1, overflow: 'scroll' } },
+          React.createElement('box', {
+            key: 'above',
+            style: { height: first * ROW, flexShrink: 0 },
+          }),
+          ...rows,
+          React.createElement('box', {
+            key: 'below',
+            style: { height: (ROWS - last) * ROW, flexShrink: 0 },
+          }),
+        );
+      };
+      return {
+        prepare: async (app, x11Root) => {
+          const instance = await new Promise((resolve) =>
+            x11Root.render(
+              React.createElement(
+                'window',
+                { width: W, height: H, style: { backgroundColor: '#f5f6fa' } },
+                React.createElement(List),
+              ),
+              resolve,
+            ),
+          );
+          root = instance._reactX11Node;
+          frame();
+        },
+        run: async (app) => {
+          const scroller = root.children[0];
+          for (let i = 0; i < 10; i++) {
+            // `_scheduled` reads as "a flush is already booked", so the
+            // notch and the re-slice it triggers land in one frame — the
+            // interleaving a real wheel flick produces
+            root._scheduled = true;
+            scroller.scrollBy(48);
+            setTop(scroller.scrollY);
+            for (let t = 0; t < 4; t++) {
+              await new Promise((resolve) => setImmediate(resolve));
+            }
+            frame();
+            await new Promise((resolve) => app.X.GetInputFocus(resolve));
+          }
+        },
+      };
+    })(),
+  ],
+  [
     // The frame the <svg> rasterization cache (issue #149) exists for: every
     // icon is inside the damage rect and not one of them changed. Damage
     // culling already skips unchanged subtrees *outside* the damage, so this

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -2511,24 +2511,6 @@ export class Node {
   }
 
   /**
-   * This node's paint bounds from before a child-list mutation — the `before`
-   * half of `_childListChanged`'s protocol, captured while a departing child
-   * is still attached.
-   *
-   * Walked once per node per frame rather than once per mutation. A commit
-   * that mounts a virtualized list's window inserts a hundred rows into one
-   * pane, one `insertBefore` at a time, and a walk of the whole pane per row
-   * is what made that commit O(rows x pane) (issue #397).
-   *
-   * Reusing the first walk's answer is not an approximation. Nothing is laid
-   * out or painted between two mutations in the same frame, so every child
-   * still carries the rect it was last painted at, and a child that leaves
-   * later in the frame was in the list — and so inside the rect — when the
-   * first walk ran. `root._reflowed` is the marker for "this frame already
-   * has one", which is exactly its lifetime: joined at the first claim,
-   * cleared by `flush()`.
-   */
-  /**
    * Is this node a scroll container that has a blit armed and still clean
    * this frame (issue #398)?
    *
@@ -2560,12 +2542,15 @@ export class Node {
    * enough that there is nothing left for the blit to keep — which the
    * caller turns into the poison the gate used to apply unconditionally.
    *
-   * `pre` records which side of the frame's layout pass the rect came from:
-   * a claim made during the commit names where the content sits *now*, and
-   * the blit is about to move it, so `_applyScrollBlits` shifts it. A claim
-   * from the layout diff already names where it landed.
+   * Which side of the frame's layout pass the rect came from decides
+   * whether it moves with the blit: a claim made during the commit names
+   * where the content sits *now*, and the blit is about to shift it, so
+   * `_applyScrollBlits` shifts the rect too. A claim raised once layout has
+   * run — the diff's, the reflow queue's — already names where it landed.
+   * Read off the window rather than passed in, so a claim from application
+   * code reached during the layout pass is filed on the right side of it.
    */
-  _recordBlitClaim(rect, pre) {
+  _recordBlitClaim(rect) {
     const ledger = this._blitLedger;
     if (!ledger || ledger.length >= BLIT_MAX_CLAIMS) return false;
     const inside = intersectRects(rect, this.abs);
@@ -2574,10 +2559,28 @@ export class Node {
     if (!inside) return true;
     // …and a claim that covers the viewport leaves the blit nothing to keep
     if (rectContains(inside, this.abs)) return false;
-    ledger.push({ ...inside, pre });
+    ledger.push({ ...inside, pre: !this.root?._laidOut });
     return true;
   }
 
+  /**
+   * This node's paint bounds from before a child-list mutation — the `before`
+   * half of `_childListChanged`'s protocol, captured while a departing child
+   * is still attached.
+   *
+   * Walked once per node per frame rather than once per mutation. A commit
+   * that mounts a virtualized list's window inserts a hundred rows into one
+   * pane, one `insertBefore` at a time, and a walk of the whole pane per row
+   * is what made that commit O(rows x pane) (issue #397).
+   *
+   * Reusing the first walk's answer is not an approximation. Nothing is laid
+   * out or painted between two mutations in the same frame, so every child
+   * still carries the rect it was last painted at, and a child that leaves
+   * later in the frame was in the list — and so inside the rect — when the
+   * first walk ran. `root._reflowed` is the marker for "this frame already
+   * has one", which is exactly its lifetime: joined at the first claim,
+   * cleared by `flush()`.
+   */
   _childListBefore() {
     const root = this.root;
     // A subtree still being built off-tree claims nothing — this is the
@@ -3416,14 +3419,6 @@ export class Node {
   }
 
   /**
-   * The region this node can put ink in: its own rect unioned with every
-   * descendant's. Not the same as `abs` — a child of a node that does not
-   * clip may stick out of it (absolute positioning, a negative margin), and
-   * culling a subtree by the parent's rect alone would drop that child's
-   * paint. Recomputed on demand rather than cached in `absolutize`, because
-   * it is only ever asked for on the handful of nodes that invalidate.
-   */
-  /**
    * `paintBounds()` with the one clip a damage claim must respect: a scroll
    * container above this node that is waiting to blit (issue #398).
    *
@@ -3451,14 +3446,21 @@ export class Node {
    *  whose box clips them (issue #398). One property read when no blit is
    *  pending, which is every frame that is not a scroll. */
   _blitViewport() {
-    const root = this.root;
-    if (!root?._pendingScrolls?.size) return null;
-    for (let n = this.parent; n && n !== root; n = n.parent) {
+    if (!this.root?._pendingScrolls?.size) return null;
+    for (let n = this.parent; n; n = n.parent) {
       if (n._blitLedgerOpen()) return n;
     }
     return null;
   }
 
+  /**
+   * The region this node can put ink in: its own rect unioned with every
+   * descendant's. Not the same as `abs` — a child of a node that does not
+   * clip may stick out of it (absolute positioning, a negative margin), and
+   * culling a subtree by the parent's rect alone would drop that child's
+   * paint. Recomputed on demand rather than cached in `absolutize`, because
+   * it is only ever asked for on the handful of nodes that invalidate.
+   */
   paintBounds() {
     const bounds = this._subtreeBounds();
     // inflated once, here — doing it inside the recursion would compound the
@@ -5367,7 +5369,7 @@ export const Scrollable = (Base) =>
           const vp = insetRect(this.abs, -DAMAGE_SLOP);
           layoutDiffSink = (rect) => {
             const clipped = intersectRects(rect, vp);
-            if (clipped && !this._recordBlitClaim(clipped, false)) {
+            if (clipped && !this._recordBlitClaim(clipped)) {
               this._pendingBlitFrom = BLIT_POISONED;
             }
           };
@@ -5553,10 +5555,7 @@ export const Scrollable = (Base) =>
             // has made them — which the ledger reads conservatively: a blob
             // that swallowed the viewport says so and poisons, exactly as
             // this gate used to for every claim it saw.
-            if (
-              rectsOverlap(rect, zone) &&
-              !this._recordBlitClaim(rect, true)
-            ) {
+            if (rectsOverlap(rect, zone) && !this._recordBlitClaim(rect)) {
               this._pendingBlitFrom = BLIT_POISONED;
               break;
             }
@@ -10235,10 +10234,12 @@ export class WindowNode extends Scrollable(Node) {
     // fails the blit's damage gate by itself.)
     // The region this claim actually covers — a node's paint reach, clipped
     // to a blitting viewport above it (issue #398), or the bare rect a
-    // caller handed over. Null when the clip left nothing: the node draws
-    // where nothing can be seen, so it owes no pixels.
+    // caller handed over. Null when the clip left nothing (the node draws
+    // where nothing can be seen, so it owes no pixels), and null on a frame
+    // that is already unbounded, which owes neither a rect nor the subtree
+    // walk that measures one — a blit cannot fire there either.
     const bounds =
-      damage && damage !== NO_DAMAGE
+      damage && damage !== NO_DAMAGE && this._damage !== FULL_DAMAGE
         ? damage._claimBounds
           ? damage._claimBounds()
           : damage
@@ -10272,7 +10273,7 @@ export class WindowNode extends Scrollable(Node) {
           // same pixels on screen for a fraction of the drawing. The
           // ledger says no when the frame stops paying, and then this
           // falls through to the poison exactly as before.
-          if (sv._blitLedgerOpen() && sv._recordBlitClaim(rect, true)) {
+          if (sv._blitLedgerOpen() && sv._recordBlitClaim(rect)) {
             continue;
           }
           // Poison rather than disarm (react-x11#295): a null here would
@@ -10354,6 +10355,10 @@ export class WindowNode extends Scrollable(Node) {
     // not the flag's post-pass value
     const layoutRan = this.needsLayout;
     if (this.needsLayout) {
+      // From here on a claim names where its content *landed*, not where it
+      // sat before the scroll — which is what decides whether a blit
+      // ledger's rect moves with the shift (issue #398).
+      this._laidOut = true;
       this._resolveSizeQueries(width, height);
       this._applyContentFloors(width);
       this.yoga.setWidth(width);
@@ -10400,7 +10405,7 @@ export class WindowNode extends Scrollable(Node) {
         const after = node._claimBounds();
         if (!after) continue;
         const sv = node._blitViewport();
-        if (sv && !sv._recordBlitClaim(after, false)) {
+        if (sv && !sv._recordBlitClaim(after)) {
           sv._pendingBlitFrom = BLIT_POISONED;
         }
         this._damage = addDamageRect(this._damage, after);
@@ -10416,6 +10421,9 @@ export class WindowNode extends Scrollable(Node) {
     // a frame that turns out to be a pure scroll blits the surviving band
     // and narrows its claim to the exposed strip
     this._applyScrollBlits(width, height, layoutMoved);
+    // …and the next commit's claims name the arrangement this frame leaves
+    // behind again, from before whatever scroll comes with them
+    this._laidOut = false;
     if (!this.needsPaint) return;
     this.needsPaint = false;
     const damage = this._takeDamage(width, height);

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -254,6 +254,15 @@ const DAMAGE_SLOP = 1;
 // pass, and always restored through `finally`.
 let layoutDiffSink = null;
 
+// The uniform translation the subtree currently being walked is riding: set
+// while a scroll container whose blit is armed lays its children out, so the
+// diff can tell "moved" from "scrolled" (issue #398). Every child of such a
+// container lands at its old rect plus this shift, which is precisely what
+// the blit is about to do to those pixels — so it is not a change, and the
+// diff reports only the children that landed somewhere else. Null everywhere
+// else, and restored through `finally` like the sink beside it.
+let layoutDiffShift = null;
+
 // What an invalidate() may name as its reason — a small closed set, so the
 // frame log, the tracer and the full-repaint warning can print "why" next
 // to "where". A typo'd reason would silently vanish from every report, so
@@ -314,6 +323,13 @@ const NO_SCROLL_BLIT = process.env.REACT_X11_NO_SCROLL_BLIT === '1';
 // exposed strip is most of a repaint anyway.
 const SCROLL_BLIT_MIN_KEEP = 0.5;
 
+// …and how much of it the frame may end up repainting anyway. The strip and
+// the scrollbar repair sit under this by a wide margin; what can push past
+// it is a ledger repair (issue #398) that the damage cap had to merge with
+// the scrollbar column, whose box then reaches back across the viewport.
+// Past this the blit is buying a shift and paying for the viewport anyway.
+const SCROLL_BLIT_MAX_REPAINT = 0.75;
+
 // The server-side event mask every realized window ends up with. The
 // subscriptions are a constant — the EventManager's pointer/key/focus
 // listeners, the window's own resize/draw/expose pair, the backing store's
@@ -352,6 +368,14 @@ const BLIT_POISONED = Object.freeze({ poisoned: true });
 // `??=` in both arming paths reads "already armed" — with the rect and the
 // net delta in `_pendingBlitContents` beside it.
 const BLIT_CONTENTS = Object.freeze({ contents: true });
+
+// How much of what changed inside a blitting viewport the ledger will carry
+// before the frame gives up and repaints the viewport instead (issue #398).
+// A virtualized list's scroll frame changes a handful of regions — the two
+// spacers and the entering rows — and past that the blit plus a scatter of
+// repaints stops being cheaper than the one pass it replaced.
+const BLIT_MAX_CLAIMS = 8;
+const BLIT_MAX_CLAIM_AREA = 0.25;
 
 const rectContains = (outer, inner) =>
   outer.x <= inner.x &&
@@ -2462,8 +2486,10 @@ export class Node {
       );
     }
     // captured before the child joins, so it covers the arrangement that is
-    // about to be replaced (see _childListChanged)
-    const before = this._childListBefore();
+    // about to be replaced (see _childListChanged). A viewport mid-blit has
+    // nothing vacating — the child being added had no pixels — and the
+    // layout diff claims where it lands, so it names no region at all.
+    const before = this._blitLedgerOpen() ? null : this._childListBefore();
     // a move has to leave the yoga tree too — yoga aborts on insertChild of
     // a node that still has a parent
     if (child.parent === this && this._joinsYoga(child)) {
@@ -2502,6 +2528,56 @@ export class Node {
    * has one", which is exactly its lifetime: joined at the first claim,
    * cleared by `flush()`.
    */
+  /**
+   * Is this node a scroll container that has a blit armed and still clean
+   * this frame (issue #398)?
+   *
+   * While it is, the window keeps a *ledger* of the regions that actually
+   * changed inside the viewport instead of cancelling the blit at the first
+   * sign of one. The coarse claims this node would otherwise make — its own
+   * box, which is all `paintBounds()` can say for a node that clips — would
+   * cover the whole band the blit is about to move and throw that ledger
+   * away, so the paths that make them take a finer route while this is true.
+   *
+   * `scrollContents` is out: an element blit already tests foreign claims
+   * against the rect it handed over (issue #309), and its region is not a
+   * viewport whose children *are* the scrolled content.
+   */
+  _blitLedgerOpen() {
+    const from = this._pendingBlitFrom;
+    return (
+      from != null &&
+      from !== BLIT_POISONED &&
+      !this._pendingBlitContents &&
+      this._blitLedger != null
+    );
+  }
+
+  /**
+   * Write one changed region into this viewport's ledger, in the coordinates
+   * it was named in. Returns false when the frame is better off repainting
+   * the viewport — too many regions to be worth the bookkeeping, or one big
+   * enough that there is nothing left for the blit to keep — which the
+   * caller turns into the poison the gate used to apply unconditionally.
+   *
+   * `pre` records which side of the frame's layout pass the rect came from:
+   * a claim made during the commit names where the content sits *now*, and
+   * the blit is about to move it, so `_applyScrollBlits` shifts it. A claim
+   * from the layout diff already names where it landed.
+   */
+  _recordBlitClaim(rect, pre) {
+    const ledger = this._blitLedger;
+    if (!ledger || ledger.length >= BLIT_MAX_CLAIMS) return false;
+    const inside = intersectRects(rect, this.abs);
+    // beside the band the blit moves: those pixels are painted the ordinary
+    // way, out of the frame's own damage
+    if (!inside) return true;
+    // …and a claim that covers the viewport leaves the blit nothing to keep
+    if (rectContains(inside, this.abs)) return false;
+    ledger.push({ ...inside, pre });
+    return true;
+  }
+
   _childListBefore() {
     const root = this.root;
     // A subtree still being built off-tree claims nothing — this is the
@@ -2511,7 +2587,10 @@ export class Node {
     if (root._reflowed.has(this) && this._reflowBefore) {
       return this._reflowBefore;
     }
-    return (this._reflowBefore = this.paintBounds());
+    // NO_DAMAGE, not null, when a blitting viewport above clips this node
+    // away entirely (issue #398): null here would read as "somewhere" and
+    // repaint the window.
+    return (this._reflowBefore = this._claimBounds() ?? NO_DAMAGE);
   }
 
   /**
@@ -2533,6 +2612,17 @@ export class Node {
     this._clearHitBounds();
     const root = this.root;
     if (!root) return;
+    // A viewport keeping a ledger this frame (issue #398) says both halves
+    // of the protocol finer: `before` is the departing child's own rect
+    // rather than this node's box, and the "after" half comes from the
+    // shifted layout diff, which claims an entering child where it lands
+    // and says nothing about the ones that only rode the scroll. Joining
+    // `_reflowed` would undo both — its post-layout claim is this node's
+    // box, the whole band the blit is about to move.
+    if (this._blitLedgerOpen()) {
+      root.invalidate(true, before ?? NO_DAMAGE, 'child-list');
+      return;
+    }
     root.invalidate(true, before, 'child-list');
     root._reflowed.add(this);
   }
@@ -2544,8 +2634,11 @@ export class Node {
     // index the AT will see the removal at
     a11yHooks.detach?.(this, child);
     // captured while the child is still attached, so it covers the rect the
-    // child is about to stop occupying
-    const before = this._childListBefore();
+    // child is about to stop occupying — the child's own, for a viewport
+    // mid-blit, where this node's box is the whole scrolled band
+    const before = this._blitLedgerOpen()
+      ? (child._claimBounds() ?? NO_DAMAGE)
+      : this._childListBefore();
     this.children.splice(index, 1);
     if (outsideYoga(child)) this._nonYogaKids--;
     if (this._joinsYoga(child)) {
@@ -3106,7 +3199,37 @@ export class Node {
     this._clearHitBounds();
     if (layoutDiffSink) {
       const grow = this._outlineExtent() + DAMAGE_SLOP;
-      if (old.width > 0 && old.height > 0) {
+      const shift = layoutDiffShift;
+      const had = old.width > 0 && old.height > 0;
+      if (shift) {
+        // Riding a blit (issue #398): the rect this node *would* have had if
+        // nothing but the scroll had happened. Landing there is the blit's
+        // own translation and claims nothing — claiming it would repaint the
+        // band the blit exists to keep. Landing anywhere else is a real move,
+        // and both ends of it are claimed in post-blit coordinates, which is
+        // where the frame will paint them.
+        const was = {
+          x: old.x + shift.x,
+          y: old.y + shift.y,
+          width: old.width,
+          height: old.height,
+        };
+        if (
+          had &&
+          was.x === x &&
+          was.y === y &&
+          old.width === width &&
+          old.height === height
+        ) {
+          return;
+        }
+        if (had) layoutDiffSink(insetRect(was, -grow));
+        if (width > 0 && height > 0) {
+          layoutDiffSink(insetRect(this.abs, -grow));
+        }
+        return;
+      }
+      if (had) {
         layoutDiffSink(insetRect(old, -grow));
       }
       if (width > 0 && height > 0) {
@@ -3300,6 +3423,42 @@ export class Node {
    * paint. Recomputed on demand rather than cached in `absolutize`, because
    * it is only ever asked for on the handful of nodes that invalidate.
    */
+  /**
+   * `paintBounds()` with the one clip a damage claim must respect: a scroll
+   * container above this node that is waiting to blit (issue #398).
+   *
+   * A viewport clips its children, so the part of a claim outside its box is
+   * pixels that cannot appear — and leaving it in costs the blit the frame.
+   * A virtualized list is the shape that makes this concrete: its spacers
+   * are boxes thousands of pixels tall whose visible extent is a sliver or
+   * nothing at all, and their unclipped claims, coalesced into the scroll's
+   * own, leave `_blitKeptDamage` a damage rect many times the viewport to
+   * refuse. Null when the clip left nothing.
+   *
+   * Only while a blit is pending — outside that this is `paintBounds()` and
+   * one property read. Clipping every claim to every clipping ancestor
+   * would be correct too, and is a bigger change than the frame this is
+   * about.
+   */
+  _claimBounds() {
+    const bounds = this.paintBounds();
+    const sv = this._blitViewport();
+    return sv ? intersectRects(bounds, sv.paintBounds()) : bounds;
+  }
+
+  /** The scroll container above this node that is waiting to blit, if there
+   *  is one — the viewport whose ledger this node's claims belong in, and
+   *  whose box clips them (issue #398). One property read when no blit is
+   *  pending, which is every frame that is not a scroll. */
+  _blitViewport() {
+    const root = this.root;
+    if (!root?._pendingScrolls?.size) return null;
+    for (let n = this.parent; n && n !== root; n = n.parent) {
+      if (n._blitLedgerOpen()) return n;
+    }
+    return null;
+  }
+
   paintBounds() {
     const bounds = this._subtreeBounds();
     // inflated once, here — doing it inside the recursion would compound the
@@ -5189,13 +5348,31 @@ export const Scrollable = (Base) =>
       // real layout — claim it, but clipped to the viewport: ink below the
       // fold never reaches the surface, and an unclipped claim would repaint
       // whatever unrelated UI sits under this node's off-viewport extent.
-      const shifted =
-        this._childOrigin &&
-        (this._childOrigin.x !== ox || this._childOrigin.y !== oy);
+      const wasOrigin = this._childOrigin;
+      const shifted = wasOrigin && (wasOrigin.x !== ox || wasOrigin.y !== oy);
       this._childOrigin = { x: ox, y: oy };
       const outer = layoutDiffSink;
+      const outerShift = layoutDiffShift;
+      const ledger = shifted && this._blitLedgerOpen();
       if (outer) {
-        if (shifted) {
+        if (ledger) {
+          // The blit's own ledger takes this walk (issue #398). The shift
+          // below is what makes the diff worth running under a scroll at
+          // all: without it every child reports the move the blit is about
+          // to make for them, and the claims add up to the viewport. What
+          // is left is the virtualized list's real frame — the rows that
+          // entered, the ones that left, a spacer that resized — and it
+          // goes to the ledger rather than to `outer`, whose claims are
+          // what `layoutMoved` reads as "this frame is not a pure scroll".
+          const vp = insetRect(this.abs, -DAMAGE_SLOP);
+          layoutDiffSink = (rect) => {
+            const clipped = intersectRects(rect, vp);
+            if (clipped && !this._recordBlitClaim(clipped, false)) {
+              this._pendingBlitFrom = BLIT_POISONED;
+            }
+          };
+          layoutDiffShift = { x: ox - wasOrigin.x, y: oy - wasOrigin.y };
+        } else if (shifted) {
           layoutDiffSink = null;
         } else {
           const vp = insetRect(this.abs, -DAMAGE_SLOP);
@@ -5213,6 +5390,7 @@ export const Scrollable = (Base) =>
         }
       } finally {
         layoutDiffSink = outer;
+        layoutDiffShift = outerShift;
       }
     }
 
@@ -5363,10 +5541,22 @@ export const Scrollable = (Base) =>
         // has not claimed yet, so damage already overlapping this viewport
         // is foreign by construction: poison the frame instead of arming,
         // and the full-viewport repaint below stays in force.
-        if (this._pendingBlitFrom == null && Array.isArray(root._damage)) {
+        const arming = this._pendingBlitFrom == null;
+        // The ledger this frame's changes inside the viewport are written
+        // to (issue #398). Opened with the blit and read by
+        // _applyScrollBlits, which clears it beside the origin.
+        if (arming) this._blitLedger = [];
+        if (arming && Array.isArray(root._damage)) {
           const zone = insetRect(this.abs, -(DAMAGE_SLOP * 2 + 1));
           for (const rect of root._damage) {
-            if (rectsOverlap(rect, zone)) {
+            // Already coalesced, so these rects are as coarse as the frame
+            // has made them — which the ledger reads conservatively: a blob
+            // that swallowed the viewport says so and poisons, exactly as
+            // this gate used to for every claim it saw.
+            if (
+              rectsOverlap(rect, zone) &&
+              !this._recordBlitClaim(rect, true)
+            ) {
               this._pendingBlitFrom = BLIT_POISONED;
               break;
             }
@@ -10043,14 +10233,19 @@ export class WindowNode extends Scrollable(Node) {
     // rects coalesce a change inside the viewport is indistinguishable from
     // the scroll's own claim. (Unbounded claims need no check: FULL_DAMAGE
     // fails the blit's damage gate by itself.)
+    // The region this claim actually covers — a node's paint reach, clipped
+    // to a blitting viewport above it (issue #398), or the bare rect a
+    // caller handed over. Null when the clip left nothing: the node draws
+    // where nothing can be seen, so it owes no pixels.
+    const bounds =
+      damage && damage !== NO_DAMAGE
+        ? damage._claimBounds
+          ? damage._claimBounds()
+          : damage
+        : null;
     const pendingScrolls = this._pendingScrolls;
-    if (
-      pendingScrolls?.size &&
-      damage &&
-      damage !== NO_DAMAGE &&
-      this._scrollClaim !== damage
-    ) {
-      const rect = damage.paintBounds ? damage.paintBounds() : damage;
+    if (pendingScrolls?.size && bounds && this._scrollClaim !== damage) {
+      const rect = bounds;
       for (const sv of pendingScrolls) {
         // An element blitting a region of its own drawing (issue #303) is
         // waiting on that region, not on the whole node it lives in — and
@@ -10071,6 +10266,15 @@ export class WindowNode extends Scrollable(Node) {
           ? contents.rect
           : sv.abs && insetRect(sv.abs, -(DAMAGE_SLOP * 2 + 1));
         if (!waiting || rectsOverlap(rect, waiting)) {
+          // …unless this viewport is keeping a ledger of what changed
+          // inside it (issue #398): the region goes in the ledger and
+          // `_applyScrollBlits` repaints it after the blit, which is the
+          // same pixels on screen for a fraction of the drawing. The
+          // ledger says no when the frame stops paying, and then this
+          // falls through to the poison exactly as before.
+          if (sv._blitLedgerOpen() && sv._recordBlitClaim(rect, true)) {
+            continue;
+          }
           // Poison rather than disarm (react-x11#295): a null here would
           // let a second scrollTo in the same frame re-arm from a
           // mid-frame origin, and the blit would then move pixels that
@@ -10084,16 +10288,18 @@ export class WindowNode extends Scrollable(Node) {
     }
     if (layoutChanged && !damage) this._damage = FULL_DAMAGE;
     else if (!layoutChanged && !damage) this._damage = FULL_DAMAGE;
-    else if (this._damage !== FULL_DAMAGE) {
+    else if (!bounds) {
+      // A layout change that names no region: either NO_DAMAGE, from a
+      // caller with a finer claim already in flight, or a node whose reach
+      // a clipping ancestor left nothing of (issue #398). Unlike `!damage`
+      // neither is "something, somewhere", so neither costs a full repaint.
+    } else if (this._damage !== FULL_DAMAGE) {
       // a node, or a bare rect for a caller that has a region rather than a
       // node — a subtree that is about to be removed, say. Claims accumulate
       // as a list of rects rather than one box around them all, so two changes
       // at opposite corners of the window no longer repaint everything
       // between them.
-      this._damage = addDamageRect(
-        this._damage,
-        damage.paintBounds ? damage.paintBounds() : damage,
-      );
+      this._damage = addDamageRect(this._damage, bounds);
     }
     this.needsPaint = true;
     // Recorded before the `_scheduled` gate, not inside it: the debt is
@@ -10185,11 +10391,19 @@ export class WindowNode extends Scrollable(Node) {
       for (const node of this._reflowed) {
         // …and the pre-mutation walk this frame reused goes with it
         node._reflowBefore = null;
-        if (!node.destroyed)
-          this._damage =
-            this._damage === FULL_DAMAGE
-              ? FULL_DAMAGE
-              : addDamageRect(this._damage, node.paintBounds());
+        if (node.destroyed || this._damage === FULL_DAMAGE) continue;
+        // clipped to a blitting viewport above it, like every other claim
+        // this frame, and written to that viewport's ledger too (issue
+        // #398): the claim would otherwise coalesce into the scroll's own
+        // and be dropped with it, leaving the band the blit kept holding
+        // this node's pixels from before the reflow.
+        const after = node._claimBounds();
+        if (!after) continue;
+        const sv = node._blitViewport();
+        if (sv && !sv._recordBlitClaim(after, false)) {
+          sv._pendingBlitFrom = BLIT_POISONED;
+        }
+        this._damage = addDamageRect(this._damage, after);
       }
       this._reflowed.clear();
     } else if (this._reflowed.size) {
@@ -10280,9 +10494,11 @@ export class WindowNode extends Scrollable(Node) {
     pending.clear();
     const from = nodes[0]._pendingBlitFrom;
     const contents = nodes[0]._pendingBlitContents;
+    const ledger = nodes[0]._blitLedger;
     for (const n of nodes) {
       n._pendingBlitFrom = null;
       n._pendingBlitContents = null;
+      n._blitLedger = null;
     }
     // two viewports scrolling in one frame is rare enough that sorting out
     // whether their regions interact is not worth it
@@ -10362,11 +10578,39 @@ export class WindowNode extends Scrollable(Node) {
     }
     const keep = this._blitKeptDamage(vp);
     if (!keep) return;
+    // What changed inside the viewport while the blit was armed, in the
+    // coordinates the frame is about to paint in (issue #398). A claim made
+    // during the commit named where the content sat before the shift, and
+    // the blit is about to move those pixels by the frame's delta, so it
+    // moves with them; a claim from the layout diff already landed there.
+    //
+    // Repainting the result is what makes the blit honest about them: the
+    // blit translates the previous frame's rendering, which is correct
+    // everywhere the content did not change, and these are the places it
+    // did. That is finer than the strip-only rule issue #398 asks for and
+    // no more complicated, so a mid-viewport change — a row upgrading from
+    // skeleton to content while the list scrolls — rides the fast path too
+    // instead of falling back to the whole viewport.
+    const repairs = [];
+    let repairArea = 0;
+    for (const claim of ledger ?? []) {
+      const moved = claim.pre
+        ? {
+            x: claim.x - dx,
+            y: claim.y - dy,
+            width: claim.width,
+            height: claim.height,
+          }
+        : claim;
+      const inside = intersectRects(moved, vp);
+      if (!inside) continue;
+      repairs.push(inside);
+      repairArea += inside.width * inside.height;
+    }
+    // past this the blit plus a scatter of repaints is no longer cheaper
+    // than the one full-viewport pass it replaced
+    if (repairArea > area * BLIT_MAX_CLAIM_AREA) return;
     if (!this._scrollBlitSafe(node, vp)) return;
-    // scroll offsets grow down/right; the pixels move the other way
-    // (0 - x rather than -x: negating +0 yields -0, which survives into
-    // request buffers and test comparisons)
-    if (!wnd.scrollRegion({ ...vp }, 0 - dx, 0 - dy)) return;
     let rects = keep;
     // the strip the shift exposed, full breadth — it also covers the corner
     // gutter beside the bars, whose old pixels the blit did not overwrite
@@ -10421,6 +10665,24 @@ export class WindowNode extends Scrollable(Node) {
     }
     const crossBar = node._scrollbar(axis === 'y' ? 'x' : 'y');
     if (crossBar) rects = addDamageRect(rects, scrollbarTrackRect(crossBar));
+    for (const repair of repairs) rects = addDamageRect(rects, repair);
+    // The last gate, and the only one that has to wait until the rects are
+    // assembled: the frame carries at most MAX_DAMAGE_RECTS of them, so a
+    // repair that does not sit beside the strip is merged with whatever is
+    // nearest — the scrollbar column, most often — and the box of that
+    // merge can reach back across the viewport. When it does, the blit is
+    // buying a shift and paying for the viewport anyway, so let the plain
+    // repaint scrollTo already claimed have the frame.
+    let painted = 0;
+    for (const rect of rects) {
+      const inside = intersectRects(rect, vp);
+      if (inside) painted += inside.width * inside.height;
+    }
+    if (painted > area * SCROLL_BLIT_MAX_REPAINT) return;
+    // scroll offsets grow down/right; the pixels move the other way
+    // (0 - x rather than -x: negating +0 yields -0, which survives into
+    // request buffers and test comparisons)
+    if (!wnd.scrollRegion({ ...vp }, 0 - dx, 0 - dy)) return;
     this._damage = rects;
   }
 

--- a/test/scroll-blit.test.js
+++ b/test/scroll-blit.test.js
@@ -9,7 +9,7 @@ import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
 import React from 'react';
 import { createRoot } from '../src/index.js';
-import { createMockApp } from './helpers/mock-app.js';
+import { createMockApp, spinWheel } from './helpers/mock-app.js';
 
 import xserver from 'x11/lib/xserver/index.js';
 import { createClient, StaticFontSource } from 'ntk';
@@ -110,16 +110,152 @@ test('several scrollTo calls in one frame blit once, by the net delta', async ()
   ]);
 });
 
-test('other damage inside the viewport keeps the full repaint', async () => {
+// --- what changed inside the viewport rides along (issue #398) -----------
+//
+// A claim inside the viewport used to cancel the blit outright. It now goes
+// into the frame's ledger and is repainted where the shift leaves it, which
+// is what lets a virtualized list — whose own re-slice claims inside the
+// viewport on *every* scroll frame — keep the fast path.
+
+const covers = (rects, x, y) =>
+  rects.some(
+    (r) => x >= r.x && x < r.x + r.width && y >= r.y && y < r.y + r.height,
+  );
+
+test('other damage inside the viewport is repainted where the shift leaves it', async () => {
+  const { wnd, root, ref } = await mount();
+  await tick();
+  wnd.calls.length = 0;
+  ref.current.scrollTo(48);
+  // a second change lands in the same frame, inside the viewport, at the
+  // rect it occupies *before* the shift
+  root.invalidate(false, { x: 40, y: 120, width: 120, height: 40 });
+  await tick();
+  assert.deepStrictEqual(blits(wnd), [
+    ['scrollRegion', { x: 0, y: 0, width: 400, height: 400 }, 0, -48],
+  ]);
+  const rects = root._lastDamageRects;
+  assert.ok(rects, 'the frame stayed bounded');
+  // the blit moved those pixels up by 48, so the repaint has to follow them
+  // there rather than stay where the claim was made
+  assert.ok(
+    covers(rects, 50, 130 - 48),
+    `damage misses the moved region: ${JSON.stringify(rects)}`,
+  );
+  const area = rects.reduce((sum, r) => sum + r.width * r.height, 0);
+  assert.ok(
+    area < 400 * 400 * 0.5,
+    `repainted ${area}px² — the strip, the thumb and the moved region`,
+  );
+});
+
+test('a repaint the damage cap merged back across the viewport is not worth blitting', async () => {
+  const { wnd, root, ref } = await mount();
+  await tick();
+  const rows = root.children[0].children;
+  wnd.calls.length = 0;
+  ref.current.scrollTo(48);
+  // full-width rows at opposite ends of the viewport: the frame carries
+  // four damage rects, so these merge with each other and with the
+  // scrollbar column, and the box of that merge is the viewport back again
+  root.invalidate(false, rows[1]);
+  root.invalidate(false, rows[8]);
+  await tick();
+  assert.strictEqual(blits(wnd).length, 0, 'the blit would not pay: no blit');
+});
+
+test('a claim that covers the viewport keeps the full repaint', async () => {
+  const { wnd, root, ref } = await mount();
+  await tick();
+  const box = root.children[0];
+  wnd.calls.length = 0;
+  ref.current.scrollTo(48);
+  // the scroll box's own appearance changed: there is nothing left for the
+  // blit to keep, so the ledger declines and the frame poisons as before
+  root.invalidate(false, box);
+  await tick();
+  assert.strictEqual(blits(wnd).length, 0, 'not a pure scroll: no blit');
+});
+
+test('more changes than the ledger carries keep the full repaint', async () => {
+  const { wnd, root, ref } = await mount();
+  await tick();
+  const rows = root.children[0].children;
+  wnd.calls.length = 0;
+  ref.current.scrollTo(48);
+  for (let i = 0; i < 10; i++) root.invalidate(false, rows[i]);
+  await tick();
+  assert.strictEqual(blits(wnd).length, 0, 'past the ledger cap: no blit');
+});
+
+test('changes covering most of the viewport keep the full repaint', async () => {
+  const { wnd, root, ref } = await mount();
+  await tick();
+  const rows = root.children[0].children;
+  wnd.calls.length = 0;
+  ref.current.scrollTo(48);
+  // five 400x40 rows is half the viewport — past that the blit plus the
+  // repaints costs more than the one pass it replaced
+  for (let i = 0; i < 5; i++) root.invalidate(false, rows[i]);
+  await tick();
+  assert.strictEqual(blits(wnd).length, 0, 'not worth the blit: no blit');
+});
+
+test('a reflow inside the viewport keeps the full repaint', async () => {
   const { wnd, root, ref } = await mount();
   await tick();
   const row = root.children[0].children[2];
   wnd.calls.length = 0;
   ref.current.scrollTo(48);
-  // a second change lands in the same frame, inside the viewport
-  root.invalidate(false, row);
+  // a row grows in the same frame: everything below it moves relative to
+  // the content, which is not the translation the blit is about to make
+  row.applyProps({ style: { height: 90, flexShrink: 0 } }, row.props);
   await tick();
   assert.strictEqual(blits(wnd).length, 0, 'not a pure scroll: no blit');
+});
+
+test('content displaced by a sibling’s reflow keeps the full repaint', async () => {
+  // A narrow column inside the viewport, so the reflow's *own* claims stay
+  // small: what has to stop the blit here is the displacement of everything
+  // below the row that grew, which nothing claims but the layout diff.
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const ref = React.createRef();
+  const rowRef = React.createRef();
+  x11Root.render(
+    h(
+      'window',
+      { width: 400, height: 400 },
+      h(
+        'box',
+        { ref, style: { overflow: 'scroll', flexGrow: 1 } },
+        h(
+          'box',
+          { style: { width: 100, flexShrink: 0 } },
+          ...Array.from({ length: 20 }, (_, i) =>
+            h('box', {
+              key: i,
+              ref: i === 2 ? rowRef : undefined,
+              style: {
+                height: 40,
+                flexShrink: 0,
+                backgroundColor: i % 2 ? '#ffffff' : '#eef1f5',
+              },
+            }),
+          ),
+        ),
+      ),
+    ),
+  );
+  const wnd = app.windows[0];
+  await tick();
+  wnd.calls.length = 0;
+  ref.current.scrollTo(48);
+  const node = rowRef.current;
+  node.applyProps({ style: { height: 48, flexShrink: 0 } }, node.props);
+  await tick();
+  assert.strictEqual(blits(wnd).length, 0, 'not a pure scroll: no blit');
+  await x11Root.unmount();
 });
 
 test('a fractional target keeps the full repaint', async () => {
@@ -248,6 +384,111 @@ test('the scrolled thumb is repainted at both its old and new place', async () =
   }
 });
 
+// --- the virtualized list, the case the ledger exists for (issue #398) ---
+//
+// A list that re-slices itself on every scroll frame claims inside its own
+// viewport every frame, by design: the spacers resize and the entering rows
+// mount. Node-granular poisoning meant the blit fired on the first notch of
+// a wheel flick and never again.
+
+const ROW = 40;
+const ROWS = 1000;
+
+function VirtualList({ scrollRef, height }) {
+  const [top, setTop] = React.useState(0);
+  const first = Math.floor(top / ROW);
+  const last = Math.min(ROWS, first + Math.ceil(height / ROW) + 2);
+  const rows = [];
+  for (let i = first; i < last; i++) {
+    rows.push(
+      h(
+        'box',
+        {
+          key: i,
+          style: {
+            height: ROW,
+            flexShrink: 0,
+            padding: 8,
+            backgroundColor: i % 2 ? '#ffffff' : '#dbe4ee',
+          },
+        },
+        // A marker that follows the slice rather than the row: two rows in
+        // the middle of the viewport change appearance on every scroll
+        // frame, which is the skeleton-to-content upgrade issue #398 names
+        // — a claim in the band the blit keeps, not in the strip.
+        h('box', {
+          style: {
+            width: 24,
+            height: 24,
+            backgroundColor: i === first + 3 ? '#c03030' : '#8fa8c8',
+          },
+        }),
+      ),
+    );
+  }
+  return h(
+    'box',
+    {
+      ref: scrollRef,
+      style: { overflow: 'scroll', flexGrow: 1 },
+      onScroll: (e) => setTop(e.scrollY),
+    },
+    h('box', { key: 'above', style: { height: first * ROW, flexShrink: 0 } }),
+    ...rows,
+    h('box', {
+      key: 'below',
+      style: { height: (ROWS - last) * ROW, flexShrink: 0 },
+    }),
+  );
+}
+
+test('a virtualized list keeps the fast path through a wheel flick (#398)', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const ref = React.createRef();
+  x11Root.render(
+    h(
+      'window',
+      { width: 400, height: 400 },
+      h(VirtualList, { scrollRef: ref, height: 400 }),
+    ),
+  );
+  const wnd = app.windows[0];
+  const root = wnd._reactX11Node;
+  // three frames to settle: mount, first layout, the slice that reports
+  for (let i = 0; i < 3; i++) await tick();
+
+  let blitted = 0;
+  let worst = 0;
+  const notches = 12;
+  for (let i = 0; i < notches; i++) {
+    wnd.calls.length = 0;
+    // the notch lands while the previous notch's re-slice commit is still
+    // in flight, which is what makes every frame from the second on a
+    // scroll *and* a child-list change in the same frame
+    spinWheel(wnd, 100, 100, { deltaY: 1 });
+    await tick();
+    if (blits(wnd).length) blitted += 1;
+    const rects = root._lastDamageRects;
+    const area = rects
+      ? rects.reduce((sum, r) => sum + r.width * r.height, 0)
+      : 400 * 400;
+    worst = Math.max(worst, area);
+  }
+  assert.strictEqual(
+    blitted,
+    notches,
+    `only ${blitted}/${notches} notches blitted — the re-slice is ` +
+      'poisoning the frame again',
+  );
+  assert.ok(
+    worst < 400 * 400 * 0.25,
+    `worst frame repainted ${worst}px² of 160000 — the strip and the ` +
+      'entering rows, not the viewport',
+  );
+  await x11Root.unmount();
+});
+
 // --- pixel truth against the real ntk + in-process X server --------------
 //
 // The whole optimisation stands on one invariant: a blitted scroll frame is
@@ -367,35 +608,122 @@ test('a blitted scroll is byte-identical to the repaint it replaced', async (t) 
   }
 });
 
-test('damage claimed before the frame’s first scrollTo keeps the full repaint (#295)', async () => {
+test("a virtualized list's blitted frame is byte-identical to its repaint (#398)", async (t) => {
+  const app = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
+  try {
+    const ref = React.createRef();
+    const instance = await new Promise((resolve) =>
+      x11Root.render(
+        h(
+          'window',
+          { width: 400, height: 300, style: { backgroundColor: '#f5f6fa' } },
+          h(VirtualList, { scrollRef: ref, height: 300 }),
+        ),
+        resolve,
+      ),
+    );
+    if (typeof instance.scrollRegion !== 'function') {
+      t.skip('installed ntk has no Window.scrollRegion yet');
+      return;
+    }
+    const root = instance._reactX11Node;
+    const frame = () => {
+      root._scheduled = false;
+      root.flush();
+    };
+    frame();
+    await tick();
+    frame();
+    await settle(app);
+
+    let blitCalls = 0;
+    const realScrollRegion = instance.scrollRegion.bind(instance);
+    instance.scrollRegion = (...args) => {
+      blitCalls += 1;
+      return realScrollRegion(...args);
+    };
+
+    // Hold the frame open across the re-slice: `_scheduled` reads as "a
+    // flush is already booked", so the scroll and the commit its onScroll
+    // triggers land in one frame — the interleaving a wheel flick produces,
+    // and the one the ledger is for.
+    root._scheduled = true;
+    ref.current.scrollTo(48);
+    // React commits on its own scheduler, a turn or two out; the frame stays
+    // booked across all of it, so the commit's claims land in the scroll's
+    // own frame rather than the one after
+    for (let i = 0; i < 5; i++) await tick();
+    frame();
+    await settle(app);
+    assert.strictEqual(
+      blitCalls,
+      1,
+      'the fast path fired through the re-slice',
+    );
+    assert.ok(root._lastDamageRects, 'and the frame stayed bounded');
+    // the slice really did move: otherwise this is the plain-scroll test
+    assert.strictEqual(root.children[0].children[0].abs.height, 40);
+    const blitted = await readPixels(root._ctx, 400, 300);
+
+    // repaint the same state from scratch: the ground truth
+    root.invalidate(false);
+    frame();
+    await settle(app);
+    const repainted = await readPixels(root._ctx, 400, 300);
+    assert.ok(
+      Buffer.from(blitted.data).equals(Buffer.from(repainted.data)),
+      'blitted pixels differ from a full repaint of the same state',
+    );
+  } finally {
+    await x11Root.unmount();
+    await app.close();
+  }
+});
+
+test('damage claimed before the frame’s first scrollTo rides the blit too (#295)', async () => {
   const { wnd, root, ref } = await mount();
   await tick();
   const row = root.children[0].children[2];
+  const was = { ...row.abs };
   wnd.calls.length = 0;
   // The race: the claim lands first, while no scroll is pending, so the
-  // claim-time cancel in WindowNode.invalidate never tests it — and the
+  // claim-time gate in WindowNode.invalidate never sees it — and the
   // viewport claim that follows coalesces the rect away (addDamageRect
   // keeps the list disjoint), leaving the pure-scroll gate nothing to see.
+  // Arming reads the damage list for exactly that reason, and the rects it
+  // finds go into the ledger like any other.
   root.invalidate(false, row);
   ref.current.scrollTo(48);
   await tick();
-  assert.strictEqual(blits(wnd).length, 0, 'not a pure scroll: no blit');
+  assert.deepStrictEqual(blits(wnd), [
+    ['scrollRegion', { x: 0, y: 0, width: 400, height: 400 }, 0, -48],
+  ]);
+  assert.ok(
+    covers(root._lastDamageRects, was.x + 2, was.y + 2 - 48),
+    `damage misses the moved row: ${JSON.stringify(root._lastDamageRects)}`,
+  );
 });
 
 test('a claim between two scrolls cannot re-arm the blit mid-frame (#295)', async () => {
   const { wnd, root, ref } = await mount();
   await tick();
-  const row = root.children[0].children[2];
   wnd.calls.length = 0;
   ref.current.scrollTo(48); // arms, origin = the frame's true start
-  root.invalidate(false, row); // the claim-time cancel un-arms the blit
+  // lands between the two, naming the rect it occupies at the true origin
+  root.invalidate(false, { x: 40, y: 200, width: 120, height: 40 });
   ref.current.scrollBy(48); // must not re-arm from the mid-frame origin
   await tick();
-  assert.strictEqual(
-    blits(wnd).length,
-    0,
-    'a poisoned frame stays poisoned: pixels at the true origin were ' +
-      'never repainted, so a blit from the mid-frame origin would move ' +
-      'a band displaced by the first delta',
+  // The whole frame is one shift of 96 from the origin the first scrollTo
+  // recorded. A blit of 48 from a mid-frame origin would move a band the
+  // first delta had already displaced, and the ledger's rects — claimed
+  // at the true origin — would be repainted 48 pixels off.
+  assert.deepStrictEqual(blits(wnd), [
+    ['scrollRegion', { x: 0, y: 0, width: 400, height: 400 }, 0, -96],
+  ]);
+  assert.ok(
+    covers(root._lastDamageRects, 50, 210 - 96),
+    `damage misses the region at the true delta: ` +
+      JSON.stringify(root._lastDamageRects),
   );
 });


### PR DESCRIPTION
Closes #398.

## What was happening

`scrollTo`'s poison gate is node-granular: any claim landing inside the viewport while a blit is pending cancels it. A virtualized list has such a claim on **every** scroll frame by construction — its re-slice commit resizes the spacers and mounts the entering rows — so the fast path fired on the first wheel notch of a flick and never again.

Reproduced in `test/scroll-blit.test.js` with the shape react-x11-components' `<Tree>`/`<Table>` have (rows and two spacers as direct children of the scroll box): **1 of 12 notches blitted**, the other eleven repainting the whole viewport.

## What the issue asked for, and what this does instead

The issue asks for the strip-only rule: tolerate a foreign claim that lies wholly inside the exposed strip, since that strip repaints anyway. Two things came out of building it.

**The strip-only rule alone does not fix its own reproduction.** The claims a re-slice actually makes are not the entering rows' rects — they are the *container's own box*. `_childListBefore()` is `paintBounds()`, and for a node that clips its children that is the whole viewport. So is the post-layout `_reflowed` claim. Both cover the entire kept band; neither is anywhere near the strip. Narrowing the *test* without narrowing the *claims* changes nothing.

**And the finer follow-up the issue defers turns out to be the simpler rule.** A blit translates the previous frame's rendering, which is correct everywhere the content did not change. So the honest treatment of a claim inside the viewport is not "is it in the strip" but "repaint it where the shift leaves it" — which needs no strip test, covers the mid-viewport skeleton→content upgrade the issue names as the fallback case, and is the same amount of code.

So: the gate **records** instead of cancelling. Each claim reaching into the viewport goes into a per-frame *ledger* on the scrolling node, recorded at `invalidate` time — before rects coalesce and hide it, which is the reason #295 put the check there at all — and `_applyScrollBlits` repaints those regions after the `CopyArea`, moved by the frame's delta when the claim predates the layout pass.

Three supporting pieces make the ledger see the truth rather than the container's box:

- **a claim from inside the viewport is clipped to it** (`_claimBounds`). A virtualized list's spacers are boxes tens of thousands of pixels tall; unclipped, their claims coalesce the scroll's own claim into a damage rect many times the viewport, which `_blitKeptDamage` then refuses. Clipping is exact, not conservative — the container clips its children, so those pixels cannot appear;
- **the container's child-list claims go per-child**: `removeChild` claims the departing child's rect, `insertBefore` claims nothing (the child had no pixels), and the container stays out of `_reflowed`, whose post-layout claim is its own box again;
- **the layout diff runs under a scroll with the shift subtracted.** It is off today because every child would report the move the blit is about to make for them. Subtract that move and what is left is the frame's real content: the rows that entered, the ones that left, a spacer that resized — and, crucially, anything that moved for a reason the blit does not account for, which is how a reflow mid-scroll still declines.

`scrollContents` is untouched: an element blit already tests against the rect it handed over (#309), and its region is not a viewport whose children *are* the scrolled content.

## Still declines when it should

Every gate still falls back to the full-viewport repaint `scrollTo` already claimed:

- a claim that covers the viewport (nothing left to keep);
- more than `BLIT_MAX_CLAIMS` regions, or more than `BLIT_MAX_CLAIM_AREA` of the viewport between them;
- `SCROLL_BLIT_MAX_REPAINT` — the last gate, and the only one that has to wait until the rects are assembled. The frame carries at most four damage rects, so a repair that does not sit beside the strip gets merged with whatever is nearest (the scrollbar column, usually) and the box of that merge can reach back across the viewport. Past three quarters of it the blit is buying a shift and paying for the viewport anyway, so the plain repaint takes the frame;
- content displaced by a sibling's reflow, which only the shifted layout diff sees.

#295's posture is unchanged and still tested: the frame's origin is the one the first `scrollTo` recorded, a mid-frame claim cannot re-arm from a later one, and a claim that lands *before* the first `scrollTo` is recorded at arming from the damage list — coarse, because those rects have already coalesced, and a blob that swallowed the viewport still poisons.

## Numbers

`npm run bench`, ten wheel notches over a 100k-row virtualized list (new scenario, baselined with the ledger live so `--check` fences it the way the plain scroll scenario is fenced):

|            | before | after |
| ---------- | -----: | ----: |
| requests   |    785 |   295 |
| bytesOut   |  40044 | 14104 |
| composites |    190 |    70 |
| Composite Mpx |  3.20 |  0.56 |

The plain 500-row scroll scenario is unchanged (81 composites, 0.39 Mpx; request counts move inside their run-to-run noise of ±6).

## Tests

`test/scroll-blit.test.js`, all mutation-checked — each new assertion was confirmed to fail against the unmodified source, and the three central mechanisms (the pre-layout shift, the repairs reaching the damage, the shifted layout diff) were each individually reverted to confirm a test catches it:

- a virtualized list keeps the fast path through a 12-notch wheel flick, worst frame under a quarter of the viewport;
- **a virtualized list's blitted frame is byte-identical to its repaint** — the real proof, against the real ntk and the in-process X server, with the re-slice held inside the scroll's own frame and a marker that changes mid-viewport on every slice so the shift is exercised rather than assumed;
- a claim inside the viewport is repainted where the shift leaves it, at the true origin even across two scrolls in one frame;
- the decline cases above, one test each.

Six unrelated `appearance.test.js` failures locally are the known macOS-only baseline (portal/XSETTINGS); everything else passes, along with `lint`, `typecheck`, `prettier --check .`, `bench -- --check` and `bench:pixels -- --check`.
