### PR TITLE
perf(theme): mounting a token-styled subtree no longer repaints the window

### DIFF
--- a/src/nodes.js
+++ b/src/nodes.js
@@ -2244,8 +2244,19 @@ export class Node {
   }
 
   /** The theme above or on this node changed: drop the caches and restyle
-   * the subtree, since a token can appear at any depth. */
-  _themeChanged() {
+   * the subtree, since a token can appear at any depth.
+   *
+   * `mounting` is `insertBefore` attaching a subtree that has never been in
+   * the tree: the walk still resolves every token — the nodes can see their
+   * ancestors now — but it claims no damage (issue #402). A node that has
+   * never painted has no stale pixels to cover, and the rect it is about to
+   * occupy is claimed by the child-list/layout-diff protocol like any other
+   * inserted child's; the unbounded claims below would turn every commit
+   * that mounts a token-styled node into a full-window repaint — which is
+   * every re-slice of a virtualized list whose rows follow the palette. A
+   * live theme *swap* is the other caller and keeps them: it moves pixels
+   * that are already on screen, anywhere in the subtree. */
+  _themeChanged(mounting = false) {
     // This walk visits every node itself, so the per-node re-resolution below
     // is enough — a style swap it causes must not start a second walk of the
     // same subtree from halfway down.
@@ -2269,19 +2280,23 @@ export class Node {
         if (localTextStyleChanged(this.style, before)) {
           this._textContentChanged();
         }
-        this.root?.invalidate(true, null, 'theme');
+        if (!mounting) this.root?.invalidate(true, null, 'theme');
       }
       // The palette is the floor under the cascade, so a theme swap moves the
       // resolved style of every node that named none of its own — and none of
       // that is in a style object, so nothing above would have noticed. A
       // swap that only changes `fontFamily` is the case that made this worth
       // having: nothing else about the node changes, and a cached layout
-      // carries the face it was shaped with.
-      if (this._retext() !== 0) this.root?.invalidate(true, null, 'theme');
+      // carries the face it was shaped with. `_retext` runs on a mount too —
+      // its own claims are bounded — but cannot answer non-zero there: a
+      // node that was never attached has never resolved a text style.
+      if (this._retext() !== 0 && !mounting) {
+        this.root?.invalidate(true, null, 'theme');
+      }
       if (wasDirection !== undefined && this.direction !== wasDirection) {
         this._directionMoved();
       }
-      for (const child of this.children) child._themeChanged();
+      for (const child of this.children) child._themeChanged(mounting);
     } finally {
       inThemeWalk--;
     }
@@ -2447,9 +2462,10 @@ export class Node {
       // popups live anywhere in the JSX tree but are independent
       // override-redirect windows: bookkeeping only, no yoga, no paint —
       // but they do inherit the theme of where they are written
+      const mounting = child.parent == null;
       this._spliceChild(child, beforeChild);
       child.parent = this;
-      if (this.theme || child.props.theme) child._themeChanged();
+      if (this.theme || child.props.theme) child._themeChanged(mounting);
       a11yHooks.attached?.(this, child);
       return;
     }
@@ -2495,6 +2511,10 @@ export class Node {
     if (child.parent === this && this._joinsYoga(child)) {
       this.yoga.removeChild(child.yoga);
     }
+    // no parent means never attached: this insert is a mount, and the theme
+    // walk resolves without claiming — a keyed reorder arrives here too, with
+    // its parent still set, and that one keeps the claims (issue #402)
+    const mounting = child.parent == null;
     const index = this._spliceChild(child, beforeChild);
     child.parent = this;
     if (this._joinsYoga(child)) {
@@ -2504,7 +2524,7 @@ export class Node {
     child._registerSizeQueries();
     // it can see its ancestors now, so any token in its style can resolve.
     // With no theme anywhere there is nothing to resolve and nothing to walk
-    if (this.theme || child.props.theme) child._themeChanged();
+    if (this.theme || child.props.theme) child._themeChanged(mounting);
     this._textContentChanged();
     this._childListChanged(before);
     a11yHooks.attached?.(this, child);
@@ -9743,6 +9763,7 @@ export class WindowNode extends Scrollable(Node) {
       return;
     }
     if (child.isWindow) {
+      const mounting = child.parent == null;
       this._spliceChild(child, beforeChild);
       child.parent = this;
       // Initial children are realized when this window realizes; a child
@@ -9754,7 +9775,7 @@ export class WindowNode extends Scrollable(Node) {
         child.realize(this.window);
         if (child.window) this._xStack.push(child.window.id);
       }
-      if (this.theme || child.props.theme) child._themeChanged();
+      if (this.theme || child.props.theme) child._themeChanged(mounting);
       // React reorders a keyed list with one insertBefore per moved child;
       // restacking once at the end of the commit skips the intermediate
       // orders, which nobody ever sees.

--- a/test/scroll-blit.test.js
+++ b/test/scroll-blit.test.js
@@ -394,7 +394,12 @@ test('the scrolled thumb is repainted at both its old and new place', async () =
 const ROW = 40;
 const ROWS = 1000;
 
-function VirtualList({ scrollRef, height }) {
+const LITERAL_ROWS = {
+  row: (i) => (i % 2 ? '#ffffff' : '#dbe4ee'),
+  marker: (hot) => (hot ? '#c03030' : '#8fa8c8'),
+};
+
+function VirtualList({ scrollRef, height, colors = LITERAL_ROWS }) {
   const [top, setTop] = React.useState(0);
   const first = Math.floor(top / ROW);
   const last = Math.min(ROWS, first + Math.ceil(height / ROW) + 2);
@@ -409,7 +414,7 @@ function VirtualList({ scrollRef, height }) {
             height: ROW,
             flexShrink: 0,
             padding: 8,
-            backgroundColor: i % 2 ? '#ffffff' : '#dbe4ee',
+            backgroundColor: colors.row(i),
           },
         },
         // A marker that follows the slice rather than the row: two rows in
@@ -420,7 +425,7 @@ function VirtualList({ scrollRef, height }) {
           style: {
             width: 24,
             height: 24,
-            backgroundColor: i === first + 3 ? '#c03030' : '#8fa8c8',
+            backgroundColor: colors.marker(i === first + 3),
           },
         }),
       ),
@@ -485,6 +490,59 @@ test('a virtualized list keeps the fast path through a wheel flick (#398)', asyn
     worst < 400 * 400 * 0.25,
     `worst frame repainted ${worst}px² of 160000 — the strip and the ` +
       'entering rows, not the viewport',
+  );
+  await x11Root.unmount();
+});
+
+test('token-styled rows keep the fast path too (issue #402)', async () => {
+  // The same flick with the rows' colours arriving through the palette
+  // instead of being written out — which is what docs/styling.md tells an
+  // app to do, and what the components stress tree does. Mounting a node
+  // whose style mentions a `$token` used to claim full-window damage from
+  // the theme walk, so a re-slice degraded every frame from the second on
+  // and the ledger never saw an eligible one.
+  const THEME = {
+    rowA: '#ffffff',
+    rowB: '#dbe4ee',
+    hot: '#c03030',
+    cold: '#8fa8c8',
+  };
+  const TOKEN_ROWS = {
+    row: (i) => (i % 2 ? '$rowA' : '$rowB'),
+    marker: (hot) => (hot ? '$hot' : '$cold'),
+  };
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const ref = React.createRef();
+  x11Root.render(
+    h(
+      'window',
+      { width: 400, height: 400, theme: THEME },
+      h(VirtualList, { scrollRef: ref, height: 400, colors: TOKEN_ROWS }),
+    ),
+  );
+  const wnd = app.windows[0];
+  for (let i = 0; i < 3; i++) await tick();
+
+  let blitted = 0;
+  const notches = 12;
+  for (let i = 0; i < notches; i++) {
+    wnd.calls.length = 0;
+    spinWheel(wnd, 100, 100, { deltaY: 1 });
+    await tick();
+    if (blits(wnd).length) blitted += 1;
+  }
+  assert.strictEqual(
+    blitted,
+    notches,
+    `only ${blitted}/${notches} notches blitted — following the palette ` +
+      'must not cost the fast path',
+  );
+  // and the rows really are the palette's colours, not stripped tokens
+  const row = ref.current.children[1];
+  assert.ok(
+    [THEME.rowA, THEME.rowB].includes(row.style.backgroundColor),
+    `row resolved to ${row.style.backgroundColor}`,
   );
   await x11Root.unmount();
 });

--- a/test/theme-mount-damage.test.js
+++ b/test/theme-mount-damage.test.js
@@ -1,0 +1,139 @@
+// What the theme walk claims, on the two occasions it runs (issue #402).
+//
+// `insertBefore` restyles every freshly attached subtree — the nodes can see
+// their ancestors now, so a `$token` that resolved provisionally resolves
+// for real. That walk used to claim full-window damage for every node whose
+// style mentions a token, which turned any commit that mounts one into a
+// full repaint: a virtualized list whose rows follow the palette — exactly
+// what docs/styling.md recommends — degraded every re-slice, and the scroll
+// ledger above it (issue #398) never saw an eligible frame. A node that has
+// never painted has no stale pixels, and the rect it is about to occupy is
+// already claimed by the child-list/layout-diff protocol; so a mount now
+// resolves without claiming, and these tests pin both halves: the commit
+// stays bounded, and the tokens still resolve.
+//
+// A live theme *swap* is the other caller of the same walk and is the
+// counter-case: it moves pixels that are already on screen, at any depth,
+// so it keeps the unbounded claim. The last test is what keeps the mount
+// flag from ever leaking into it.
+import assert from 'node:assert';
+import { test } from 'node:test';
+import React from 'react';
+
+import { createRoot } from '../src/index.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+const settle = async () => {
+  for (let i = 0; i < 6; i++) await tick();
+};
+
+const THEME = {
+  panel: '#dbe4ee',
+  accent: '#c03030',
+};
+
+const contains = (outer, inner) =>
+  outer.x <= inner.x &&
+  outer.y <= inner.y &&
+  outer.x + outer.width >= inner.x + inner.width &&
+  outer.y + outer.height >= inner.y + inner.height;
+
+test('mounting a token-styled node keeps the commit bounded', async () => {
+  const app = createMockApp({ width: 300, height: 200 });
+  const x11Root = await createRoot({ app });
+  const ref = React.createRef();
+  let reveal;
+  function App() {
+    const [extra, set] = React.useState(false);
+    reveal = set;
+    return h(
+      'window',
+      { width: 300, height: 200, theme: THEME },
+      // The pane the insert lands in is smaller than the window on purpose:
+      // the child-list protocol claims the pane, so what would prove the
+      // theme walk claimed nothing is the strip below staying out of the
+      // damage. A pane that filled the window would make every claim look
+      // unbounded.
+      h(
+        'box',
+        { style: { height: 80, flexDirection: 'column' } },
+        h('box', { style: { height: 40, backgroundColor: '#ffffff' } }),
+        extra &&
+          h('box', {
+            ref,
+            style: { height: 40, backgroundColor: '$panel' },
+          }),
+      ),
+      h('box', { style: { flexGrow: 1, backgroundColor: '#f5f6fa' } }),
+    );
+  }
+  await new Promise((resolve) => x11Root.render(h(App), resolve));
+  await settle();
+  const root = app.windows[0]._reactX11Node;
+
+  reveal(true);
+  await settle();
+
+  // resolution is not what was traded away: the walk still ran, it just
+  // claimed nothing
+  assert.strictEqual(ref.current.style.backgroundColor, THEME.panel);
+  assert.ok(
+    root._lastDamage,
+    'a commit that mounts a token-styled node repainted the window',
+  );
+  assert.ok(
+    contains(root._lastDamage, ref.current.abs),
+    `damage ${JSON.stringify(root._lastDamage)} misses the mounted node at ` +
+      JSON.stringify(ref.current.abs),
+  );
+  assert.ok(
+    root._lastDamage.y + root._lastDamage.height < 200,
+    `damage ${JSON.stringify(root._lastDamage)} reaches the strip below ` +
+      'the pane',
+  );
+  assert.ok(
+    !root._lastReasons.includes('theme'),
+    `a mount is not a theme change (reasons: ${root._lastReasons.join('+')})`,
+  );
+
+  await x11Root.unmount();
+});
+
+test('a live theme swap still repaints the window', async () => {
+  const app = createMockApp({ width: 300, height: 200 });
+  const x11Root = await createRoot({ app });
+  const ref = React.createRef();
+  const render = (theme) =>
+    x11Root.render(
+      h(
+        'window',
+        { width: 300, height: 200, theme },
+        h('box', {
+          ref,
+          style: { flexGrow: 1, backgroundColor: '$panel' },
+        }),
+      ),
+    );
+  render(THEME);
+  await settle();
+  const root = app.windows[0]._reactX11Node;
+
+  render({ ...THEME, panel: '#1e272e' });
+  await settle();
+
+  assert.strictEqual(ref.current.style.backgroundColor, '#1e272e');
+  assert.strictEqual(
+    root._lastDamage,
+    null,
+    'a swap moves pixels already on screen, at any depth — nothing narrower ' +
+      'than the window is safe',
+  );
+  assert.ok(
+    root._lastReasons.includes('theme'),
+    `the frame knows why it ran (reasons: ${root._lastReasons.join('+')})`,
+  );
+
+  await x11Root.unmount();
+});


### PR DESCRIPTION
Fixes #402.

## The bug

`insertBefore` restyles every freshly attached subtree so its `$token`s can resolve against the real ancestry — and that walk (`_themeChanged`) claimed **full-window damage** for every node whose style mentions a token, for pixels the node does not have yet. Since the base palette means there is always a theme in force, this fired in every app, no `ThemeProvider` required: any commit that mounts a token-styled node degraded to a full repaint.

The shape that made it measurable is the one #402 measured: a virtualized list re-slices on every scroll notch, mounting a handful of rows per commit. If any row content uses a token — as docs/styling.md recommends — every notch's frame went full-window, `reasons=theme`, and the #398 blit ledger never saw an eligible frame.

## The fix

The three `insertBefore` call sites (drawn children, popups, child windows) now thread a `mounting` flag into `_themeChanged`, computed as `child.parent == null` — never attached. Under it the walk still resolves every token exactly as before but skips the two unbounded `invalidate(true, null, 'theme')` calls.

Nothing is left uncovered:

- a node that has never painted has no stale pixels to erase;
- the rect it is about to occupy is claimed by the child-list/layout-diff protocol like any other inserted child's (`_childListChanged` + the `_reflowed` post-layout re-measure), and a fresh window's first frame is full by construction;
- a live theme **swap** (`applyProps`, `appearanceChanged`) passes no flag and keeps the unbounded claim — it moves pixels already on screen, at any depth;
- a keyed **reorder** arrives at `insertBefore` with its parent still set, so it also keeps today's behaviour.

## Measured

The #398 wheel-flick test, with the rows' colours moved from literals into the palette (the new `token-styled rows keep the fast path too` test):

| | blitted notches |
|---|---|
| before | **1 / 12** — the first; every later re-slice poisoned the frame |
| after | **12 / 12** |

## Tests

- `test/scroll-blit.test.js` — the token-styled variant of the #398 virtualized-list flick (`VirtualList` grew a `colors` seam; the literal test is unchanged). Also asserts the rows resolved to the palette's actual colours, so the claim-skip cannot silently become a resolution-skip.
- `test/theme-mount-damage.test.js` — the unit-level pair: a commit mounting a token-styled node stays bounded (damage covers the mounted node, stays inside its pane, no `theme` in the frame's reasons), and a live theme swap still repaints the window with `theme` in the reasons.

Both new tests were mutation-checked: with `src/nodes.js` reverted to master they fail (`only 1/12 notches blitted`, and the mount commit repaints the window).

Full suite: 1624/1630 pass; the 6 failures are the known macOS-local `appearance.test.js` baseline (system appearance detection differs off-CI), unrelated to this change.

## Noted while here, not in this PR

Layout-valued tokens (`padding: '$gutter'`) resolve in the style object but never reach yoga — `_themeChanged` re-resolves without `applyLayoutStyle`, at mount and on swap alike, and the existing style.test.js assertion that claims to cover it is vacuous. Left for a follow-up rather than folded in here.
