### PR TITLE
perf(scroll): a pure scroll frame no longer re-walks the pane's content

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -983,15 +983,20 @@ somewhere to go is a tab stop, one that fits is not — and assigning over the
 getter throws. Override the getter if your element is focusable for a reason
 of its own.
 
-`measureScrollContent` is called once per layout pass, from `absolutize`, so
-it may read layout geometry, but it must not paint or invalidate. It has to
-return finite numbers: a `NaN` extent would otherwise become a `NaN` offset
-and a subtree laid out at `NaN`, so returning anything else throws naming the
-element, exactly as `measureContent` does.
+`measureScrollContent` is called at most once per layout pass, from
+`absolutize`, so it may read layout geometry, but it must not paint or
+invalidate. It has to return finite numbers: a `NaN` extent would otherwise
+become a `NaN` offset and a subtree laid out at `NaN`, so returning anything
+else throws naming the element, exactly as `measureContent` does. The answer
+is cached across passes that laid nothing inside the pane out again — a pass
+that merely scrolled reuses it, since a scroll cannot change how far the
+content reaches.
 
 When the drawing changes its own extent — a line was typed, rows arrived —
 say so the way any other layout change is said, with
-`this.invalidate(true, this, 'scroll')`; the next pass asks again.
+`this.invalidate(true, this, 'scroll')`; the next pass asks again. That call
+is also what re-arms the measurement above: content that grows silently and
+never invalidates would scroll against the stale extent.
 
 #### Scrolling the pixels, not just the offset
 

--- a/src/foreignnodes.js
+++ b/src/foreignnodes.js
@@ -340,6 +340,13 @@ export class ForeignNode extends Node {
     this._syncGeometry();
   }
 
+  // the scroll fast path moves `abs` without coming through absolutize
+  // (issue #405), and the embedded window has to follow it all the same
+  _shiftAbs(dx, dy) {
+    super._shiftAbs(dx, dy);
+    this._syncGeometry();
+  }
+
   _syncGeometry() {
     const socket = this.socket;
     if (!socket) return;

--- a/src/glnodes.js
+++ b/src/glnodes.js
@@ -230,6 +230,13 @@ export class GlAreaNode extends Node {
     this._syncGeometry();
   }
 
+  // the scroll fast path moves `abs` without coming through absolutize
+  // (issue #405), and the real X window has to follow it all the same
+  _shiftAbs(dx, dy) {
+    super._shiftAbs(dx, dy);
+    this._syncGeometry();
+  }
+
   _syncGeometry() {
     const wnd = this.window;
     if (!wnd) return;

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -3262,6 +3262,74 @@ export class Node {
   }
 
   /**
+   * Move an already-laid-out subtree by a constant, without asking yoga
+   * anything — the scroll fast path's walk (issue #405).
+   *
+   * A pure-scroll frame changes nothing about the arrangement inside a
+   * viewport: every descendant sits exactly where the last pass put it,
+   * shifted by the scroll delta. `absolutize` would re-derive each rect
+   * through four wasm-boundary getters to learn what one addition already
+   * says, so the scroller calls this instead — only after proving nothing
+   * inside was laid out this pass (see `_absolutizeChildren`).
+   *
+   * `abs` is adjusted in place rather than replaced: its identity is
+   * already long-lived (`_assignAbs` keeps the object whenever a rect is
+   * unchanged), and everything that records a rect for later copies it.
+   * The cached hit bounds ride along instead of being dropped — a uniform
+   * translation is the one change a cached union survives — which keeps a
+   * wheel flick from rebuilding the pane's whole hit-bounds tree per notch.
+   *
+   * No layout diff runs here, and none is owed: under a blit ledger the
+   * shifted diff's claims are the *deviations* from exactly this
+   * translation, and a subtree nothing laid out again has none.
+   */
+  _shiftAbs(dx, dy) {
+    if (!this.yoga) return;
+    const abs = this.abs;
+    abs.x += dx;
+    abs.y += dy;
+    const b = this._hitBoundsCache;
+    if (b) {
+      b.left += dx;
+      b.right += dx;
+      b.top += dy;
+      b.bottom += dy;
+    }
+    this._shiftChildren(dx, dy);
+  }
+
+  /** Split from `_shiftAbs` so a scroller can reroute its children through
+   * its own offset bookkeeping — the box moves rigidly, but the children's
+   * origin also carries scroll offsets that may have changed again this
+   * same frame (`Scrollable._shiftChildren`). */
+  _shiftChildren(dx, dy) {
+    for (const child of this.children) {
+      if (!child.isWindow) child._shiftAbs(dx, dy);
+    }
+  }
+
+  /**
+   * A layout-affecting change at this node may change how far the content
+   * of an enclosing scroll pane reaches through a route yoga never
+   * witnesses — an element that paints its own content growing its extent
+   * announces it with `invalidate(true, this, 'scroll')`
+   * (docs/extending.md), and no yoga node is dirtied by that. Mark every
+   * scroller whose measurement can see this node, so the next pass asks
+   * `measureScrollContent` again instead of reusing the cached reach
+   * (issue #405). The walk stops where the measurement does: at the first
+   * ancestor that clips its children, whose overflow is its own business.
+   */
+  _markScrollMeasureDirty() {
+    for (let n = this; n; n = n.parent) {
+      // only a Scrollable carries the flag; a stale `true` on a box that is
+      // not currently a scroller costs nothing and re-measures correctly if
+      // its style later makes it one
+      if (n._scrollMeasureDirty === false) n._scrollMeasureDirty = true;
+      if (n !== this && n.clipsChildren()) return;
+    }
+  }
+
+  /**
    * Ask the owning window to repaint. The damage lives on the window node,
    * which is the only node with a frame clock — this forwards there, so an
    * element says `this.invalidate(false, this, 'props')` and never has to
@@ -3274,6 +3342,9 @@ export class Node {
    * the mount invalidates in full anyway.
    */
   invalidate(layoutChanged = false, damage = null, reason = null) {
+    // a layout change may grow what an enclosing scroll pane has to scroll,
+    // through a route yoga never sees (issue #405)
+    if (layoutChanged) this._markScrollMeasureDirty();
     this.root?.invalidate(layoutChanged, damage, reason);
   }
 
@@ -3429,6 +3500,7 @@ export class Node {
    * FULL_DAMAGE the way a bare `invalidate(true, null)` would.
    */
   _invalidateLayout(reason) {
+    this._markScrollMeasureDirty();
     const root = this.root;
     if (!root) return;
     // Same walk, same frame, same answer — see `_childListBefore`, whose
@@ -5279,6 +5351,10 @@ export const Scrollable = (Base) =>
       this.scrollX = 0;
       this.contentHeight = 0;
       this.contentWidth = 0;
+      // `measureScrollContent` owed a fresh answer — true until the first
+      // layout pass measures, and re-raised by any change yoga cannot see
+      // (`_markScrollMeasureDirty`, issue #405)
+      this._scrollMeasureDirty = true;
     }
 
     /**
@@ -5301,6 +5377,9 @@ export const Scrollable = (Base) =>
      * position the same way when a box stops scrolling.
      */
     _overflowChanged() {
+      // whichever way the style flipped, the next scrolling pass starts
+      // from a fresh measurement
+      this._scrollMeasureDirty = true;
       if (this.isScroller()) return;
       this._scrollIntoViewTarget = null;
       this._childOrigin = null;
@@ -5335,20 +5414,39 @@ export const Scrollable = (Base) =>
         return;
       }
       const rtl = this.direction === 'rtl';
-      const size = this.measureScrollContent();
-      if (!Number.isFinite(size?.width) || !Number.isFinite(size?.height)) {
-        // A NaN here does not throw on its own: it becomes a NaN max scroll,
-        // a NaN offset, and every child laid out at NaN — a whole tree gone
-        // with nothing naming the element that did it.
-        throw new Error(
-          `react-x11: <${this.kind}>.measureScrollContent() must return ` +
-            '{ width, height } as finite numbers; it returned ' +
-            `${describeSize(size)}. Return { width: 0, height: 0 } for ` +
-            'content that has not arrived yet.',
-        );
+      // A pure-scroll pass re-learns nothing by walking (issue #405): the
+      // content reach and every child's place *inside* the pane only change
+      // when layout inside the pane changes. Yoga's own has-new-layout flag
+      // is the witness — consumed here and nowhere else — set by any pass
+      // that laid this node or anything under it out again, and left clear
+      // by one that merely scrolled. `_scrollMeasureDirty` covers the one
+      // route yoga cannot see: an element that paints its own content
+      // growing its extent (docs/extending.md), announced through
+      // `invalidate(true, this, 'scroll')`. The root's yoga node re-flags
+      // on every pass, so a `<window overflow='scroll'>` always takes the
+      // full walk — the pane that holds an app's long list is a box.
+      const clean =
+        this._childOrigin != null &&
+        !this._scrollMeasureDirty &&
+        !this.yoga.hasNewLayout();
+      if (!clean) {
+        const size = this.measureScrollContent();
+        if (!Number.isFinite(size?.width) || !Number.isFinite(size?.height)) {
+          // A NaN here does not throw on its own: it becomes a NaN max
+          // scroll, a NaN offset, and every child laid out at NaN — a whole
+          // tree gone with nothing naming the element that did it.
+          throw new Error(
+            `react-x11: <${this.kind}>.measureScrollContent() must return ` +
+              '{ width, height } as finite numbers; it returned ' +
+              `${describeSize(size)}. Return { width: 0, height: 0 } for ` +
+              'content that has not arrived yet.',
+          );
+        }
+        this.contentWidth = size.width;
+        this.contentHeight = size.height;
+        this._scrollMeasureDirty = false;
+        this.yoga.markLayoutSeen();
       }
-      this.contentWidth = size.width;
-      this.contentHeight = size.height;
       this._resolveScrollIntoView();
       this.scrollY = clampScroll(this.scrollY, this._maxScroll('y'));
       this.scrollX = clampScroll(this.scrollX, this._maxScroll('x'));
@@ -5373,6 +5471,23 @@ export const Scrollable = (Base) =>
       const wasOrigin = this._childOrigin;
       const shifted = wasOrigin && (wasOrigin.x !== ox || wasOrigin.y !== oy);
       this._childOrigin = { x: ox, y: oy };
+      if (clean) {
+        // The fast path (issue #405): nothing inside was laid out, so every
+        // child sits exactly where the last pass put it, shifted by however
+        // far the origin moved — one uniform translation instead of a
+        // per-node yoga re-derivation. The layout diff is owed nothing by
+        // construction: under a blit ledger the shifted diff's claims are
+        // the deviations from this very translation, and a clean pane has
+        // none — the walk below lands every node where the diff would have
+        // reported silence.
+        if (!shifted) return;
+        const dx = ox - wasOrigin.x;
+        const dy = oy - wasOrigin.y;
+        for (const child of this.children) {
+          if (!child.isWindow) child._shiftAbs(dx, dy);
+        }
+        return;
+      }
       const outer = layoutDiffSink;
       const outerShift = layoutDiffShift;
       const ledger = shifted && this._blitLedgerOpen();
@@ -5414,6 +5529,22 @@ export const Scrollable = (Base) =>
         layoutDiffSink = outer;
         layoutDiffShift = outerShift;
       }
+    }
+
+    /**
+     * A scroller inside a shifting subtree does not ride the translation
+     * blindly: its box moves rigidly, but its children's origin also
+     * carries the scroll offsets, which may have changed again this very
+     * frame — a wheel on a nested pane while an outer one scrolls.
+     * Re-entering `_absolutizeChildren` folds both into one delta, and
+     * re-runs the gate, so a nested pane that is not clean still walks
+     * properly. (Reached only under an outer pane's fast path, which
+     * proved nothing in here was laid out — the nested gate can only
+     * decline over its own `_scrollMeasureDirty`.)
+     */
+    _shiftChildren(dx, dy) {
+      if (!this.isScroller()) return super._shiftChildren(dx, dy);
+      this._absolutizeChildren(this.abs.x, this.abs.y);
     }
 
     /**
@@ -5477,8 +5608,14 @@ export const Scrollable = (Base) =>
      * wheel, the scrollbars, the scroll keys and the AT-SPI scroll pane all
      * read the numbers this returns (docs/extending.md).
      *
-     * Called once per layout pass, from `absolutize`, so it may read yoga
-     * geometry but must not invalidate or paint.
+     * Called at most once per layout pass, from `absolutize`, so it may
+     * read yoga geometry but must not invalidate or paint — and cached
+     * across passes that laid nothing inside the pane out again (issue
+     * #405): a pass that merely scrolled reuses the last answer, since a
+     * scroll cannot change how far the content reaches. An element whose
+     * extent changed by a route layout never saw — rows arrived, a line
+     * was typed — announces it with `invalidate(true, this, 'scroll')`,
+     * and the next pass asks again.
      */
     measureScrollContent() {
       const rtl = this.direction === 'rtl';

--- a/test/scroll-pure-frame.test.js
+++ b/test/scroll-pure-frame.test.js
@@ -1,0 +1,220 @@
+// What a pure scroll frame is allowed to cost (issue #405).
+//
+// A frame whose only change is a viewport's offset moves every descendant by
+// one constant and changes nothing else — so it must not re-measure the
+// content reach, and it must not re-derive every descendant's rect from
+// yoga. What is tested here is the seam that skipping those walks exposes:
+// the cached measurement coming back fresh when something inside really
+// changes (through layout, or through an element announcing pixels yoga
+// never saw), and the shifted rects landing exactly where the full walk
+// would have put them — for hit testing, for RTL, for nested panes scrolled
+// in the same frame, and for a pane whose own box was moved from outside.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import { createRoot } from '../src/index.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+async function mount(children, windowProps = {}) {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(
+    h('window', { width: 200, height: 100, ...windowProps }, children),
+  );
+  await tick();
+  const wnd = app.windows[0];
+  wnd.flushFrame?.();
+  await tick();
+  return { app, wnd, node: wnd._reactX11Node, x11Root };
+}
+
+const flush = async (wnd) => {
+  wnd.flushFrame?.();
+  await tick();
+};
+
+const rows = (n = 10, height = 40) =>
+  Array.from({ length: n }, (_, i) =>
+    h('box', { key: i, style: { height, flexShrink: 0 } }),
+  );
+
+/** Count calls without changing answers. */
+function countMeasures(node) {
+  const counter = { calls: 0 };
+  const real = node.measureScrollContent.bind(node);
+  node.measureScrollContent = (...args) => {
+    counter.calls++;
+    return real(...args);
+  };
+  return counter;
+}
+
+test('a pure scroll reuses the measured content reach', async () => {
+  const ref = React.createRef();
+  const { wnd } = await mount(
+    h('box', { ref, style: { overflow: 'scroll', flexGrow: 1 } }, ...rows()),
+  );
+  const box = ref.current;
+  const measures = countMeasures(box);
+
+  box.scrollTo(50);
+  await flush(wnd);
+  box.scrollTo(120);
+  await flush(wnd);
+  assert.equal(measures.calls, 0, 'scrolling re-derives nothing');
+  // ...and the cached numbers still drive the clamp
+  box.scrollTo(9999);
+  await flush(wnd);
+  assert.equal(box.scrollY, 300, 'clamped against the cached extent');
+});
+
+test('layout inside the pane re-measures; layout outside does not', async () => {
+  const ref = React.createRef();
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const render = (rowHeight, sidebarWidth) =>
+    x11Root.render(
+      h(
+        'window',
+        { width: 200, height: 100, style: { flexDirection: 'row' } },
+        h('box', { style: { width: sidebarWidth, flexShrink: 0 } }),
+        h(
+          'box',
+          { ref, style: { overflow: 'scroll', flexGrow: 1 } },
+          ...rows(10, rowHeight),
+        ),
+      ),
+    );
+  render(40, 20);
+  await tick();
+  const wnd = app.windows[0];
+  await flush(wnd);
+  const box = ref.current;
+  box.scrollTo(50);
+  await flush(wnd);
+  const measures = countMeasures(box);
+
+  // the sidebar widening is a real layout pass, but everything it moves is
+  // outside the pane; the pane's own box shifts rigidly and the rows follow
+  render(40, 30);
+  await tick();
+  await flush(wnd);
+  assert.equal(box.abs.x, 30, 'the pane itself moved');
+  assert.equal(box.children[0].abs.x, 30, 'rows moved with it');
+  assert.equal(box.children[2].abs.y, 80 - 50, 'still scrolled by 50');
+
+  // a row growing is layout inside: the reach must be re-learned
+  render(50, 30);
+  await tick();
+  await flush(wnd);
+  assert.ok(measures.calls >= 1, 're-measured after an inside reflow');
+  assert.equal(box.contentHeight, 500, 'and the new reach is the truth');
+});
+
+test('a pure scroll lands every child where the full walk would', async () => {
+  const ref = React.createRef();
+  const { wnd, node } = await mount(
+    h('box', { ref, style: { overflow: 'scroll', flexGrow: 1 } }, ...rows()),
+  );
+  const box = ref.current;
+  // populated *before* the scroll, so what the second hit test reads is the
+  // cached bounds as the shift left them, not a cache built fresh after it
+  assert.ok(node.hitTest(100, 25) === box.children[0], 'row 0 before');
+  box.scrollTo(70);
+  await flush(wnd);
+  for (let i = 0; i < box.children.length; i++) {
+    assert.equal(box.children[i].abs.y, i * 40 - 70, `row ${i}`);
+  }
+  // 25 from the top was inside row 0; scrolled by 70 it is inside row 2
+  assert.ok(node.hitTest(100, 25) === box.children[2], 'row 2 after');
+});
+
+test('a sideways pure scroll under RTL shifts the other way', async () => {
+  const ref = React.createRef();
+  const { wnd } = await mount(
+    h(
+      'box',
+      {
+        ref,
+        style: {
+          overflow: 'scroll',
+          flexGrow: 1,
+          flexDirection: 'row',
+          direction: 'rtl',
+        },
+      },
+      ...Array.from({ length: 5 }, (_, i) =>
+        h('box', { key: i, style: { width: 100, flexShrink: 0 } }),
+      ),
+    ),
+  );
+  const box = ref.current;
+  const first = box.children[0].abs.x;
+  box.scrollTo({ x: 60 });
+  await flush(wnd);
+  // scrollX is a distance from the start edge — the right-hand one here —
+  // so the content moves right, exactly as the full walk moves it
+  assert.equal(box.children[0].abs.x, first + 60);
+});
+
+test('a nested pane wheeled in the same frame still lands', async () => {
+  const outer = React.createRef();
+  const inner = React.createRef();
+  const { wnd } = await mount(
+    h(
+      'box',
+      { ref: outer, style: { overflow: 'scroll', flexGrow: 1 } },
+      h('box', { style: { height: 30, flexShrink: 0 } }),
+      h(
+        'box',
+        {
+          ref: inner,
+          style: { height: 60, flexShrink: 0, overflow: 'scroll' },
+        },
+        ...rows(8, 20),
+      ),
+      ...rows(6, 40),
+    ),
+  );
+  await flush(wnd);
+  // both offsets change before one frame runs: the outer pane's shift and
+  // the inner pane's own scroll must fold into one move for the inner rows
+  outer.current.scrollTo(25);
+  inner.current.scrollTo(40);
+  await flush(wnd);
+  const innerTop = inner.current.abs.y;
+  assert.equal(innerTop, 30 - 25, 'the inner pane rode the outer scroll');
+  assert.equal(
+    inner.current.children[0].abs.y,
+    innerTop - 40,
+    "…and its rows carry the inner pane's own offset too",
+  );
+});
+
+test('painted content re-arms the measurement by invalidating', async () => {
+  const ref = React.createRef();
+  const { wnd } = await mount(
+    h('box', { ref, style: { overflow: 'scroll', flexGrow: 1 } }),
+  );
+  const box = ref.current;
+  // an element whose content is pixels rather than children answers the
+  // reach itself (docs/extending.md) — stand in for one on a live node
+  let lines = 20;
+  box.measureScrollContent = () => ({ width: 0, height: lines * 16 });
+  // the measurement above has never been asked: any layout change asks it
+  box.invalidate(true, box, 'scroll');
+  await flush(wnd);
+  assert.equal(box._maxScroll('y'), 20 * 16 - 100);
+
+  box.scrollTo(50);
+  await flush(wnd);
+
+  // rows arrive; the documented announcement is what re-asks the question
+  lines = 40;
+  box.invalidate(true, box, 'scroll');
+  await flush(wnd);
+  assert.equal(box._maxScroll('y'), 40 * 16 - 100, 'the extent grew');
+});


### PR DESCRIPTION
Fixes #405.

## What

A frame whose only change is a viewport's offset paid O(all nodes in the pane) twice over:

1. `measureScrollContent` re-walked the whole subtree — four wasm-boundary yoga getters per node — to re-derive a content reach a scroll cannot have changed.
2. The absolutize walk re-assigned every descendant's `abs` node by node, allocating a fresh rect each, to apply what is one uniform translation.

This PR is tiers (1) and (2) of the issue, behind a single gate:

- **The gate.** Yoga's own has-new-layout flag on the scroller (consumed here and nowhere else, cleared with `markLayoutSeen` after each full walk) witnesses whether the pass laid anything inside the pane out again. Verified against the assembly: a clean pass leaves a seen node's flag false; any relayout that can touch the subtree — inner dirt, child insert/remove, display flips, a resize from above — sets it. A `_scrollMeasureDirty` flag covers the one route yoga cannot see: an element that paints its own content growing its extent, announced through the `invalidate(true, this, 'scroll')` call docs/extending.md already prescribes. That announcement (and every other layout-changing invalidate) marks the enclosing scrollers via a walk that stops where the measurement itself stops, at the first clipping ancestor.
- **Measure cache (tier 1).** When the gate says clean, the pane reuses `contentWidth`/`contentHeight`; clamps, bars, keys and the viewport report all read the cached pair.
- **Shift walk (tier 2).** The children move by one delta added to each `abs` in place — no yoga traffic, no allocation — and the cached hit bounds ride along instead of being dropped, since a uniform translation is the one change a cached union survives. The layout diff is owed nothing by construction: under a blit ledger the shifted diff's claims are the deviations from exactly this translation, and a clean pane has none — so the blit fast path (#138/#398) fires exactly as before, which `scroll-blit.test.js`'s byte-identical assertions confirm.
- **Composition.** A nested pane reroutes the shift through its own `_absolutizeChildren`, folding an outer pane's shift and its own same-frame wheel into one delta — and re-running its own gate. `<glarea>`/`<foreign>` follow the shift with their real-window geometry sync, which the plain walk previously reached through `absolutize`.

The root's yoga node re-flags on every `calculateLayout`, so a `<window overflow='scroll'>` always takes the full walk — the pane that holds an app's long list is a box, which is the case this closes.

## Numbers

Wheel notches (48px) over a non-virtualized log pane (row = box + two texts), headless mock app, this machine — client layout/frame cost per notch, mean of 40:

| rows | nodes | master | this PR | |
|---|---|---|---|---|
| 2,000 | 10k | 7.15ms | 0.65ms | 11x |
| 10,000 | 50k | 40.0ms | 5.7ms | 7.0x |
| 20,000 | 100k | 80.0ms | 11.9ms | 6.7x |

The issue's Xvfb profile attributed ~68% of the burst to the two walks (measure 14.9+3.5, assign/absolutize 7.5+4.1+3.4, yoga getter traffic ~25, plus the GC their allocation fed); both are gone from a pure-scroll frame. What remains is O(rows) with a small constant: the shift walk itself and the paint pass's own per-child culling (`paintOrder` freshness + `_offscreen` per child), which were never part of the layout walks — the compositor-style end state the issue sketches (content-space rects, offset applied at read time) would take those too, and stays open under #405.

## Contract

`measureScrollContent` is now called **at most** once per layout pass; docs/extending.md and the method's own note updated. The documented announcement for painted content whose extent changed — `invalidate(true, this, 'scroll')` — is unchanged and is what re-arms the measurement; content that grows and never invalidates was already scrolling against numbers nobody re-read that frame.

## Tests

`test/scroll-pure-frame.test.js`: measure reuse across pure scrolls and the clamp against the cached extent; re-measure on inside reflow but not on an outside one that moves the pane rigidly; shifted rects landing exactly where the full walk puts them, including primed hit-bounds caches, RTL sideways scroll, and a nested pane wheeled in the same frame as its outer; the painted-content re-arm route. Each assertion was mutation-checked: forcing the gate always-dirty, always-clean, and dropping the hit-bounds shift each fail the suite (the last needed the cache primed before the scroll — a fresh cache reads already-shifted rects and hides the bug). Full suite green except the six known macOS-only appearance.test.js failures (local baseline; they pass in CI).