### PR TITLE
fix(click-to-component): climb to the owner that wrote the element

### DIFF
--- a/docs/click-to-component.md
+++ b/docs/click-to-component.md
@@ -25,6 +25,24 @@ Alt+Shift+Click also logs the full ownership chain (who rendered who, up to
 the root) to the console — handy when the immediate owner is a shared
 wrapper rather than the component you actually meant.
 
+## Elements you didn't write
+
+An element rendered by an installed component — a design system's
+`<Toolbar>`, a chart library's internals — has its JSX call site inside that
+package, not in your code. Clicking one resolves to the nearest owner up the
+chain that _is_ your source: the `<Toolbar ... />` line in your file that put
+it on screen. The console line says how far it had to climb, so a location
+that doesn't match what you clicked is never a surprise:
+
+```
+[click-to-component] App → src/ui/App.tsx:432:7 (1 owner up from the clicked <box>)
+```
+
+When no owner in the chain is application source (a screen rendered entirely
+by a package), the package's own file is opened instead and the line is
+marked `— inside an installed package`. Only a tree with no React debug info
+at all resolves to nothing.
+
 With React DevTools attached as well (`REACT_X11_DEVTOOLS=1`, see
 [devtools.md](devtools.md)), the same click also selects that element in the
 DevTools tree — one click to the source _and_ to its props. Nothing changes
@@ -51,12 +69,22 @@ babel/jsx-source plugin, no build-time instrumentation:
 - Node's `--enable-source-maps` (already on for both the plain `tsx`
   examples and `examples:tasks:hot`'s loader) has rewritten that Error's
   stack to original source before we ever see it, so resolving a location
-  is just parsing stack-trace text and skipping frames inside
-  `node_modules` — no source-map library required (this is the one place
+  is just parsing stack-trace text and skipping the frames React and this
+  renderer add on top of the call site (`react`, `react-reconciler`,
+  `scheduler`, `react-x11`'s own `src/`) — no source-map library required
+  (this is the one place
   the design diverges from a browser DOM version of the same idea: a
   browser doesn't remap `Error.stack` for you, so a tool like
   [show-component](https://github.com/sidorares/show-component) has to
   resolve source maps itself at runtime).
+
+Frames from _other_ packages are deliberately kept rather than skipped: a
+call site inside an installed component is a real location, it just isn't
+one in your source, and telling those apart is what lets the resolver climb
+the `_debugOwner` chain to the line that is. Skipping every `node_modules`
+frame instead walks past the library component entirely and lands on
+whichever frame of yours happens to be deeper in the render stack — usually
+the `render()` call at startup, which looks like an answer and isn't.
 
 Alt+Click is recognized in `EventManager._onMouseDown`
 (`src/events.js`) — `native.buttons & MOD.Alt` is X11's `Mod1Mask` bit, the
@@ -79,6 +107,11 @@ no URI scheme to navigate, so those are still spawned directly with a
 
 - Needs React running in development mode (fiber debug fields are stripped
   in production builds).
+- The editor is launched detached, so a failure is only visible as a
+  warning: an editor whose URI scheme nothing claims (`REACT_X11_EDITOR`
+  naming an editor that isn't installed) prints
+  `click-to-component — \`open cursor://...\` exited 1` next to the
+  resolved location rather than silently doing nothing.
 - A node's `_reactFiber` is only refreshed on mount, not on every update —
   usually harmless (the JSX call site of a given element rarely moves
   between renders of the same tree shape), but a node that was

--- a/src/ClickToComponent.js
+++ b/src/ClickToComponent.js
@@ -11,14 +11,44 @@
 // original source — we only have to parse the stack text and skip the
 // frames inside React/the reconciler itself.
 import { spawn } from 'node:child_process';
+import { dirname, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { setClickToComponentHandler } from './events.js';
 import { selectInDevTools } from './DevToolsIntegration.js';
 
 const STACK_FRAME = /^\s*at\s+(?:(.+?)\s+\()?(.+?):(\d+):(\d+)\)?\s*$/;
 
+// The frames to walk past before the JSX call site itself: React captures
+// the Error inside `jsxDEV`/`createElement`, and an element created by this
+// renderer (or by node internals) is never what a click means. `SELF_DIR` is
+// whichever copy of react-x11 is running — the repo's own `src/` for the
+// examples and tests, an installed `node_modules/react-x11/src` for an app.
+//
+// Everything *else* in `node_modules` is deliberately not skipped here: a
+// frame inside an installed package is a real call site, it is just not one
+// in the application's source, and telling the two apart is what lets
+// `resolveOwnedLocation` climb to the owner that is. Skipping every
+// `node_modules` frame instead would walk straight past the library
+// component and land on whatever application frame happens to be deeper in
+// the render stack — usually the `render()` call at startup, which looks
+// like an answer and isn't.
+const REACT_RUNTIME =
+  /[\\/]node_modules[\\/](react|react-dom|react-reconciler|scheduler)[\\/]/;
+const SELF_DIR = dirname(fileURLToPath(import.meta.url)) + sep;
+
+function isInternalFrame(file) {
+  return (
+    file.startsWith('node:') ||
+    file === '<anonymous>' ||
+    file.startsWith(SELF_DIR) ||
+    REACT_RUNTIME.test(file)
+  );
+}
+
 /** The first stack frame outside React/the reconciler/node internals — the
- * user's own JSX call site for whatever element this Error was captured at.
+ * JSX call site for whatever element this Error was captured at, wherever it
+ * was written. `installed` marks a call site that lives inside an installed
+ * package rather than in the application's own source.
  * Exported because `react-x11/test`'s `sourceOf` answers the same question
  * for a test that a click answers for an editor. */
 export function resolveLocation(debugStack) {
@@ -28,24 +58,52 @@ export function resolveLocation(debugStack) {
     const match = line.match(STACK_FRAME);
     if (!match) continue;
     const [, functionName, rawFile, lineStr, columnStr] = match;
-    if (
-      rawFile.includes('/node_modules/') ||
-      rawFile.startsWith('node:') ||
-      rawFile === '<anonymous>'
-    ) {
-      continue;
-    }
     const file = rawFile.startsWith('file://')
       ? fileURLToPath(rawFile)
       : rawFile;
+    if (isInternalFrame(file)) continue;
     return {
       functionName,
       file,
       line: Number(lineStr),
       column: Number(columnStr),
+      installed: file.includes(`${sep}node_modules${sep}`),
     };
   }
   return null;
+}
+
+/** The nearest source location a click can mean: the clicked element's own
+ * JSX call site when the application wrote it, and otherwise the first owner
+ * up the chain that it did write. An element rendered by an installed
+ * component — a design system's `<Toolbar>`, a chart library's internals —
+ * has its call site inside that package; what the user meant by clicking it
+ * is the `<Toolbar ... />` line in their own file that put it on screen.
+ *
+ * Returns `{ fiber, location, depth }`, `depth` being how many owners up the
+ * location came from (0 = the clicked element's own). Falls back to the
+ * nearest installed call site when nothing in the chain is application
+ * source — opening a package's own file beats refusing to open anything —
+ * and null only when React has no debug info at all. */
+export function resolveOwnedLocation(fiber) {
+  let fallback = null;
+  let depth = 0;
+  for (let owner = fiber; owner; owner = owner._debugOwner, depth++) {
+    const location = resolveLocation(owner._debugStack);
+    if (!location) continue;
+    if (!location.installed) return { fiber: owner, location, depth };
+    fallback ??= { fiber: owner, location, depth };
+  }
+  return fallback;
+}
+
+/** What the clicked thing *is* — `<box>` for a host node, the component's
+ * name for a composite one. (`componentName` below answers a different
+ * question: who *wrote* it.) */
+function elementLabel(fiber) {
+  const type = fiber.type;
+  if (typeof type === 'string') return `<${type}>`;
+  return type?.displayName || type?.name || '(anonymous)';
 }
 
 function componentName(fiber) {
@@ -119,11 +177,37 @@ function openInEditor({ file, line, column }) {
     bin = OPEN_URI_COMMAND;
     args = [editorUri(scheme, file, line, column)];
   }
-  const child = spawn(bin, args, { detached: true, stdio: 'ignore' });
+  // stderr is kept (rather than the whole stdio ignored) for one reason:
+  // `open`/`xdg-open` exit non-zero and print *there* when nothing claims
+  // the scheme — an editor that isn't installed, or one whose URL handler
+  // was never registered. Swallowing that is what makes click-to-component
+  // look like it only logs: the location resolves, the console line prints,
+  // and the editor silently never opens.
+  const child = spawn(bin, args, {
+    detached: true,
+    stdio: ['ignore', 'ignore', 'pipe'],
+  });
+  let stderr = '';
+  // ...and unref'd, so keeping it does not keep the process alive: a pipe is
+  // a ref'd handle, and an editor that outlives the app it was launched from
+  // is the normal case, not a reason to hold the event loop open.
+  child.stderr.unref();
+  child.stderr.on('data', (chunk) => {
+    stderr += chunk;
+  });
   child.on('error', (err) => {
     console.warn(
       `react-x11: click-to-component could not launch "${bin}" (${err.code ?? err.message}). ` +
         'Set REACT_X11_EDITOR to your editor CLI (cursor, code, code-insiders, windsurf, vim, nvim).',
+    );
+  });
+  child.on('exit', (code) => {
+    if (!code) return;
+    console.warn(
+      `react-x11: click-to-component — \`${bin} ${args.join(' ')}\` exited ${code}. ` +
+        (stderr.trim() ? `${stderr.trim()} ` : '') +
+        `Set REACT_X11_EDITOR to the editor you actually use (currently "${name}"; ` +
+        'cursor, code, code-insiders, windsurf, vim, nvim, or any registered URI scheme).',
     );
   });
   child.unref();
@@ -146,17 +230,29 @@ function handleClick(node, native) {
     );
     return;
   }
-  const location = resolveLocation(fiber._debugStack);
-  if (!location) {
+  const resolved = resolveOwnedLocation(fiber);
+  if (!resolved) {
     console.warn(
-      'react-x11: click-to-component — no source location found. This needs ' +
-        'React running in development mode (fiber._debugStack).',
+      'react-x11: click-to-component — no source location found for this ' +
+        'element or any of its owners. This needs React running in ' +
+        'development mode (fiber._debugStack).',
     );
     return;
   }
+  const { fiber: sourceFiber, location, depth } = resolved;
+  // What was clicked is not always what has a source: say so rather than
+  // silently opening a file the click doesn't obviously correspond to.
+  const climbed =
+    depth > 0
+      ? ` (${depth} owner${depth > 1 ? 's' : ''} up from the clicked ` +
+        `${elementLabel(fiber)})`
+      : '';
+  const installed = location.installed ? ' — inside an installed package' : '';
   console.log(
-    `[click-to-component] ${componentName(fiber)} → ` +
-      `${location.file}:${location.line}:${location.column}`,
+    `[click-to-component] ${componentName(sourceFiber)} → ` +
+      `${location.file}:${location.line}:${location.column}` +
+      climbed +
+      installed,
   );
   if (native?.buttons & 1) {
     // Alt+Shift+Click

--- a/test/click-to-component.test.js
+++ b/test/click-to-component.test.js
@@ -1,8 +1,16 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { readFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import React from 'react';
 import { createRoot } from '../src/index.js';
 import xserver from 'x11/lib/xserver/index.js';
@@ -83,4 +91,90 @@ test('Alt+Click resolves the fiber to its JSX call site and logs it', async () =
   assert.ok(resolved, 'expected a resolved-location log line');
   assert.match(resolved, /Leaf/);
   assert.match(resolved, /click-to-component\.test\.js:\d+:\d+$/);
+});
+
+// An element rendered by an installed component has its JSX call site inside
+// that package — the click means the `<Toolbar />` line in the application's
+// own file. The fixture is written under a real `node_modules/` path (in a
+// temp dir, so the repo's own tree stays clean) because that path segment is
+// exactly what the resolver reads.
+async function installedToolbar() {
+  const root = mkdtempSync(join(tmpdir(), 'react-x11-c2c-'));
+  const dir = join(root, 'node_modules', '@fake', 'ui');
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, 'index.mjs');
+  // `createElement` is passed in rather than imported: nothing resolves
+  // `react` from a temp directory, and the point is only that the call site
+  // is inside node_modules.
+  writeFileSync(
+    file,
+    'export function makeToolbar(createElement) {\n' +
+      '  return function Toolbar() {\n' +
+      "    return createElement('box', {\n" +
+      "      id: 'from-lib',\n" +
+      "      style: { width: 50, height: 50, backgroundColor: 'blue' },\n" +
+      '    });\n' +
+      '  };\n' +
+      '}\n',
+  );
+  const { makeToolbar } = await import(pathToFileURL(file).href);
+  return { root, Toolbar: makeToolbar(React.createElement) };
+}
+
+test('a click inside an installed component resolves to its owner in your code', async () => {
+  const clickToComponent = await import('../src/ClickToComponent.js');
+  clickToComponent.install();
+
+  const { root: fixtureRoot, Toolbar } = await installedToolbar();
+  const { app } = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
+  function App() {
+    return React.createElement(Toolbar);
+  }
+  const instance = await new Promise((resolve) => {
+    x11Root.render(
+      React.createElement(
+        'window',
+        { width: 200, height: 200 },
+        React.createElement(App),
+      ),
+      (i) => resolve(i),
+    );
+  });
+
+  const windowNode = instance._reactX11Node;
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  const target = windowNode.hitTest(10, 10);
+  assert.strictEqual(target?.kind, 'box');
+  assert.strictEqual(target?.props?.id, 'from-lib');
+
+  // the element's own call site is the package's file — not what a click means
+  const own = clickToComponent.resolveLocation(target._reactFiber._debugStack);
+  assert.strictEqual(own.installed, true);
+  assert.match(own.file, /node_modules/);
+
+  const owned = clickToComponent.resolveOwnedLocation(target._reactFiber);
+  assert.strictEqual(owned.depth, 1, 'resolved one owner up');
+  assert.strictEqual(owned.location.installed, false);
+  assert.match(owned.location.file, /click-to-component\.test\.js$/);
+
+  let resolved = null;
+  const originalLog = console.log;
+  console.log = (...args) => {
+    const msg = args.join(' ');
+    if (msg.startsWith('[click-to-component]') && msg.includes('→')) {
+      resolved = msg;
+    }
+    originalLog(...args);
+  };
+  try {
+    windowNode.events._onMouseDown({ x: 10, y: 10, keycode: 1, buttons: 8 });
+  } finally {
+    console.log = originalLog;
+  }
+
+  assert.ok(resolved, 'expected a resolved-location log line');
+  assert.match(resolved, /click-to-component\.test\.js:\d+:\d+/);
+  assert.match(resolved, /1 owner up from the clicked <box>/);
+  rmSync(fixtureRoot, { recursive: true, force: true });
 });


### PR DESCRIPTION
Alt/Option+Click on an element rendered by an installed component resolved to nothing:

```
react-x11: click-to-component — no source location found. This needs React running in development mode (fiber._debugStack).
```

That element's JSX call site really is inside the package, so skipping every `node_modules` frame in `fiber._debugStack` — what the resolver did — walks past the library component and lands on whichever frame of the application's happens to sit deeper in the render stack, usually the `render()` call at startup. Null, or a plausible-looking wrong line.

## What changed

- **Only React's and this renderer's frames are skipped now** — `react`, `react-dom`, `react-reconciler`, `scheduler`, and whichever copy of react-x11 is executing, found via `import.meta.url` rather than a name match. A call site inside another package survives and is flagged `installed: true`.
- **`resolveOwnedLocation(fiber)`** walks the `_debugOwner` chain until it reaches a call site in application source and returns `{ fiber, location, depth }`. It falls back to the nearest installed call site, so a screen rendered entirely by a package opens the package's file instead of refusing to open anything; null now means React has no debug info at all.
- **The climb is reported**, so a location that doesn't match what you clicked is never a surprise:

  ```
  [click-to-component] App → src/ui/App.tsx:432:7 (1 owner up from the clicked <box>)
  ```

- **Editor failures stop being silent.** The child was spawned with all stdio ignored, but `open`/`xdg-open` reports an unclaimed URI scheme on stderr and exits non-zero — an editor that isn't installed looked exactly like a feature that only logs. stderr is kept and a non-zero exit is warned about, naming the command and the `REACT_X11_EDITOR` value in effect.

## Testing

New test renders a component whose source lives under a real `node_modules/@fake/ui/` path in a temp dir, and asserts the click resolves one owner up into the test file, that the element's own call site is `installed`, and that the log line says how far it climbed. Mutation-checked: restoring the old skip-all-`node_modules` rule fails it.

`click-to-component.test.js`, `component-testing.test.js` and `smoke.test.js` pass locally; `prettier --check .` is clean.