### PR TITLE
Menus and the menu bar, measured against the platform's

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -1122,12 +1122,17 @@ panel uses ([globalmenu.md](globalmenu.md)). One column rather than
 two, because a second would indent every label in the menu to reserve room
 for icons most items do not have.
 
-The column is there for the menus that use it and gone from the ones that
-do not: a menu whose items are all plain commands has no column at all and
-its labels sit where a label sits, while one icon or one `toggleType`
-anywhere in a menu indents every label in it. That is deliberate — the
-reservation exists so a checkable row does not shuffle sideways as it is
-ticked, which is an argument about the menu rather than about the row.
+The column is there for the menus that draw in it and gone from the ones
+that do not. What counts is what a row actually paints: one icon, or one
+toggle that is _on_, anywhere in a menu indents every label in it — and a
+menu of plain commands, or of checkboxes that all happen to be off, has no
+column at all and its labels sit where a label sits.
+
+So ticking the first item in such a menu moves its labels sideways, once.
+Toolkits that reserve the column unconditionally are buying stillness in
+that one frame, and paying for it with an indent on every menu that has a
+toggle anywhere in it — this one makes the other trade. A menu that already
+has a mark in it keeps the column whatever happens to the rest.
 
 Pass a **function** for anything real. It is called with the colour the
 row's label is being drawn in and the size the column allows, which is what

--- a/docs/components.md
+++ b/docs/components.md
@@ -1114,13 +1114,20 @@ first frame of a new bar always shows everything and the cut lands on the
 next — and none of this happens on a desktop whose panel has taken the menu,
 where there is no bar of ours to overflow.
 
-**Icons.** `icon` fills the 16px column left of the label — the same column
-a `toggleType` mark uses, so an item that is both checked and iconned shows
+**Icons.** `icon` fills the column left of the label — the same column a
+`toggleType` mark uses, so an item that is both checked and iconned shows
 the check: the check is state, the icon is only identity. `icon` is drawn by
 react-x11 and never crosses the bus; `iconName` is the icon-theme name a
 panel uses ([globalmenu.md](globalmenu.md)). One column rather than
 two, because a second would indent every label in the menu to reserve room
 for icons most items do not have.
+
+The column is there for the menus that use it and gone from the ones that
+do not: a menu whose items are all plain commands has no column at all and
+its labels sit where a label sits, while one icon or one `toggleType`
+anywhere in a menu indents every label in it. That is deliberate — the
+reservation exists so a checkable row does not shuffle sideways as it is
+ticked, which is an argument about the menu rather than about the row.
 
 Pass a **function** for anything real. It is called with the colour the
 row's label is being drawn in and the size the column allows, which is what

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.1.2",
       "license": "MIT",
       "dependencies": {
-        "ntk": "^8.4.0",
+        "ntk": "^8.5.0",
         "react-reconciler": "^0.33.0",
         "yoga-layout": "^3.2.1"
       },
@@ -3956,9 +3956,9 @@
       "license": "MIT"
     },
     "node_modules/ntk": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/ntk/-/ntk-8.4.0.tgz",
-      "integrity": "sha512-NWWq0qX5Iq5/QvS3csfZnWLojIwpb6D+TEdQhljO++XOJfE7YOjqKEzQ4HGlEGAO/Q1cDsL7m/BEAKV8jUINeA==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/ntk/-/ntk-8.5.0.tgz",
+      "integrity": "sha512-rizNocAS4plq0DYXdV7c33gGz6LdnbiJHgYekFwh2rd8LgdHmaRnINaKbRdpaDmjONpL92zWX1Xjl0UniI2SEg==",
       "license": "MIT",
       "dependencies": {
         "bidi-js": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
-    "ntk": "^8.4.0",
+    "ntk": "^8.5.0",
     "react-reconciler": "^0.33.0",
     "yoga-layout": "^3.2.1"
   },

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -137,6 +137,17 @@ const MENU_ICON_GAP = 8;
 // column at all — so the whole of the column's width is the space after it.
 const MENU_GUTTER = MENU_ICON_SIZE + MENU_ICON_GAP;
 
+// Menu text sits a step above the body weight. A menu is read in glances
+// rather than in sentences — a title on a strip, a row under the pointer —
+// and the native ones are all set a shade heavier for it. Where the face has
+// a medium this picks it; where it has only a regular and a bold, 500 is
+// nearer the regular and nothing changes, which is the right failure.
+//
+// Every label measured for a popup's width is measured at this weight too
+// (`measureLabel` takes it), since a menu sized in regular for rows drawn in
+// medium is a menu whose own labels run into its shortcuts.
+const MENU_TEXT_WEIGHT = 500;
+
 const MENU_SHORTCUT_GAP = 24;
 // menus size to their content rather than scrolling, so a page is a fixed
 // stride — deriving one from the menu height would just equal Home/End
@@ -182,11 +193,14 @@ function menuListWidth(node, items, fontSize) {
     if (isSeparator(item)) continue;
     const label = measureLabel(node, item.label ?? '', {
       size: fontSize,
+      weight: MENU_TEXT_WEIGHT,
     }).width;
     const accelerator = formatShortcut(item.shortcut);
     const shortcut = accelerator
-      ? measureLabel(node, accelerator, { size: fontSize }).width +
-        MENU_SHORTCUT_GAP
+      ? measureLabel(node, accelerator, {
+          size: fontSize,
+          weight: MENU_TEXT_WEIGHT,
+        }).width + MENU_SHORTCUT_GAP
       : 0;
     widest = Math.max(widest, label + shortcut);
   }
@@ -206,7 +220,10 @@ function menuListWidth(node, items, fontSize) {
  * `menuListWidth` so the two cannot drift.
  */
 function barItemWidth(node, label, fontSize) {
-  const text = measureLabel(node, label ?? '', { size: fontSize }).width;
+  const text = measureLabel(node, label ?? '', {
+    size: fontSize,
+    weight: MENU_TEXT_WEIGHT,
+  }).width;
   return Math.ceil(text) + (BAR_ITEM_PAD_X + BAR_GAP) * 2;
 }
 
@@ -449,16 +466,25 @@ function MenuRow({
         },
         gutterMark(item, { color: rowInk, fontSize }),
       ),
-    h('text', { style: [capTrim, { fontSize }] }, item.label),
+    h(
+      'text',
+      { style: [capTrim, { fontSize, fontWeight: MENU_TEXT_WEIGHT }] },
+      item.label,
+    ),
     h('box', { style: { flexGrow: 1 } }),
-    // The accelerator and the chevron are quieter than the label at rest and
-    // rise with the row when it is chosen — so on an active row they say
-    // nothing and take what the row set.
+    // The accelerator is quieter than the label at rest and rises with the
+    // row when it is chosen — so on an active row it says nothing and takes
+    // what the row set. A shortcut is a second way to do what the label
+    // already says; the chevron below it is not, and keeps the row's ink.
     accelerator &&
       h(
         'text',
         {
-          style: [capTrim, { fontSize }, !active && { color: theme.textMuted }],
+          style: [
+            capTrim,
+            { fontSize, fontWeight: MENU_TEXT_WEIGHT },
+            !active && { color: theme.textMuted },
+          ],
         },
         accelerator,
       ),
@@ -471,7 +497,9 @@ function MenuRow({
         // stands as tall as its box, so `MENU_ICON_SIZE` would put an arrow
         // beside the label taller than the label.
         size: capBand(fontSize),
-        style: !active && { color: theme.textMuted },
+        // no `color`: the arrow is the row saying it has more behind it, as
+        // much a part of the entry as its label, and a muted one reads as a
+        // row that is half disabled rather than one with a submenu
       }),
   );
 }
@@ -1338,7 +1366,11 @@ export function MenuBar({
               name: 'moreVertical',
               size: iconSize(fontSize),
             })
-          : h('text', { style: [capTrim, { fontSize }] }, menu.label),
+          : h(
+              'text',
+              { style: [capTrim, { fontSize, fontWeight: MENU_TEXT_WEIGHT }] },
+              menu.label,
+            ),
       );
     }),
     openIndex >= 0 &&

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -86,9 +86,13 @@ const MENU_BORDER = 1;
 // two ends: a pill that starts in the window's own corner reads as part of
 // the frame rather than as something on a strip, and the first menu is the
 // one every pointer arrives at.
+//
+// At the *ends* only. Between two titles there is nothing — no margin, no
+// strip showing through — and the space there is the two paddings meeting.
+// Only one title is ever lit, so two pills that touch never draw as one
+// shape, and a margin between them is a gap the pointer crosses on its way
+// from one menu to the next for no reason the eye can see.
 const BAR_INSET = 3;
-// the gap between two pills, split between them
-const BAR_GAP = 1;
 
 // A bar item wears the same pill as a row in the menu it opens, so it takes
 // the row's padding rather than numbers of its own: a title packed tighter
@@ -97,13 +101,14 @@ const BAR_GAP = 1;
 // text — which makes the pill `menuRowHeight` tall, and the bar that much
 // taller for it.
 //
-// Horizontally it takes a little more. A row's label in a menu that has a
-// check column is `MENU_ITEM_PAD + MENU_GUTTER` from the pill's edge rather
-// than `MENU_ITEM_PAD`, so matching the row's padding here would read as
-// the cramped one — a title on a strip has no column to sit past, but it
-// does sit shoulder to shoulder with the next title, with nothing but that
-// padding between one label and the next.
-const BAR_ITEM_PAD_X = MENU_ITEM_PAD + 4;
+// Horizontally it takes a little more, and the number is measured rather
+// than argued: macOS leaves 22px between the ink of two menu bar titles, and
+// since the pills touch, that space is two of these. A row's label in a menu
+// with a check column is `MENU_ITEM_PAD + MENU_GUTTER` from the pill's edge
+// anyway, so the row's own padding would read as the cramped one here — a
+// title has no column to sit past, but it does sit shoulder to shoulder with
+// the next title.
+const BAR_ITEM_PAD_X = MENU_ITEM_PAD + 3;
 
 // The bar entry that stands for the titles that did not fit. A symbol rather
 // than a `label`, because it is the one entry on the bar the application did
@@ -224,12 +229,11 @@ function barItemWidth(node, label, fontSize) {
     size: fontSize,
     weight: MENU_TEXT_WEIGHT,
   }).width;
-  return Math.ceil(text) + (BAR_ITEM_PAD_X + BAR_GAP) * 2;
+  return Math.ceil(text) + BAR_ITEM_PAD_X * 2;
 }
 
 /** The same, for the chevron: an icon box where a title has its label. */
-const barOverflowWidth = (fontSize) =>
-  iconSize(fontSize) + (BAR_ITEM_PAD_X + BAR_GAP) * 2;
+const barOverflowWidth = (fontSize) => iconSize(fontSize) + BAR_ITEM_PAD_X * 2;
 
 /**
  * How many titles the bar can paint, and therefore where it is cut. The rest
@@ -249,7 +253,7 @@ const barOverflowWidth = (fontSize) =>
  */
 function barCut(node, menus, fontSize, width) {
   const widths = menus.map((menu) => barItemWidth(node, menu.label, fontSize));
-  const inner = width - (BAR_INSET - BAR_GAP) * 2;
+  const inner = width - BAR_INSET * 2;
   const total = widths.reduce((sum, w) => sum + w, 0);
   if (total <= inner) return menus.length;
   const room = inner - barOverflowWidth(fontSize);
@@ -1199,8 +1203,8 @@ export function MenuBar({
           flexDirection: 'row',
           alignItems: 'center',
           backgroundColor: theme.surfaceHover,
-          paddingLeft: BAR_INSET - BAR_GAP,
-          paddingRight: BAR_INSET - BAR_GAP,
+          paddingLeft: BAR_INSET,
+          paddingRight: BAR_INSET,
           // `scroll` is what makes a box report its viewport, and the clip
           // that comes with it is wanted in its own right: it is what holds
           // the one frame before the first measurement — and any bar whose
@@ -1314,14 +1318,14 @@ export function MenuBar({
               //
               // The margin is what a radius needs to be seen — a rounded
               // rect flush against the strip's own edges reads as a cut
-              // corner rather than a pill. It sits *outside* the padding, so
-              // the bar is a menu row plus its two insets tall: the item and
-              // the row below it are then the same pill in the same size,
-              // which is the whole point of giving the bar one.
+              // corner rather than a pill. Vertical only: the strip's own
+              // padding does that job at the two ends, and between two titles
+              // there is nothing to hold apart. It sits *outside* the
+              // padding, so the bar is a menu row plus its two insets tall:
+              // the item and the row below it are then the same pill in the
+              // same size, which is the whole point of giving the bar one.
               marginTop: BAR_INSET,
               marginBottom: BAR_INSET,
-              marginLeft: BAR_GAP,
-              marginRight: BAR_GAP,
               paddingTop: MENU_ITEM_PAD,
               paddingBottom: MENU_ITEM_PAD,
               borderRadius: rowRadius(theme, MENU_BORDER, MENU_PAD),

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -147,9 +147,10 @@ const SUBMENU_GAP = 0;
 const MENU_ICON_SIZE = 12;
 // The air between that mark and the label it belongs to. A mark set against
 // its label with a pixel or two to spare reads as part of the word rather
-// than as a column of its own, so this is nearer the space between two words
-// than the hairline a centred icon box happens to leave over.
-const MENU_ICON_GAP = 8;
+// than as a column of its own — but the column is an indent every label in
+// the menu pays for, so it is the smallest gap that still reads as one:
+// enough to separate two things, less than the space between two words.
+const MENU_ICON_GAP = 6;
 // The check column: the mark's own box plus that gap. The mark starts at the
 // row's padding — flush with where a label starts in a menu that has no
 // column at all — so the whole of the column's width is the space after it.
@@ -182,24 +183,32 @@ function menuListHeight(items, fontSize) {
 }
 
 /**
- * The width of this menu's check column, which is `0` for a menu that has
- * nothing to put in it.
+ * The width of this menu's check column, which is `0` for a menu with
+ * nothing to draw in it.
  *
- * A menu of plain commands has no column, because a column of empty boxes is
- * an indent every label pays for and no row uses — the reason the gutter is
- * reserved at all is that a *checkable* item must not shuffle sideways as it
- * is ticked, and that argument only holds where something is checkable. So
- * the question is asked of the level as a whole rather than of the row: one
- * icon anywhere in a menu indents all of its labels, which is what keeps the
- * labels in a column of their own.
+ * The question is asked of the level rather than of the row — one mark
+ * anywhere in a menu indents every label in it, which is what puts the
+ * labels in a column of their own — and what counts is what is *drawn*, not
+ * what could be. A checkbox that is off draws nothing, so a menu of unticked
+ * toggles is a menu of plain commands as far as the eye is concerned, and it
+ * gets the plain menu's left edge.
  *
- * `toggleType` counts whatever the state is — an unticked checkbox is
- * exactly the case the reservation exists for — and a separator answers for
- * nothing, since it spans the row.
+ * The cost is the one every toolkit reserving this column is avoiding:
+ * ticking the first item in such a menu moves its labels sideways. That is
+ * the trade this codebase makes deliberately — an indent on every menu with
+ * a toggle anywhere in it, paid by every label in it, buys stillness in the
+ * one frame where something is ticked. A menu that already has a mark keeps
+ * the column whatever happens to the rest, so the movement is once at the
+ * boundary rather than on every tick.
+ *
+ * `toggleState` is dbusmenu's three-state one: `-1` draws a dash and counts,
+ * `0` draws nothing and does not. A separator answers for nothing either way,
+ * since it spans the row.
  */
 function menuGutter(items) {
   const wanted = visibleItems(items).some(
-    (item) => !isSeparator(item) && (item.toggleType || item.icon != null),
+    (item) =>
+      !isSeparator(item) && (toggleMark(item) != null || item.icon != null),
   );
   return wanted ? MENU_GUTTER : 0;
 }

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -81,25 +81,14 @@ const MENU_PAD = 4;
 // borders on its *controls* does not mean a 2px outline around every menu.
 const MENU_BORDER = 1;
 
-// How far a bar item's pill sits inside the bar, taken out of its padding so
-// the bar's height does not change. The strip carries the same inset at its
-// two ends: a pill that starts in the window's own corner reads as part of
-// the frame rather than as something on a strip, and the first menu is the
-// one every pointer arrives at.
-//
-// At the *ends* only. Between two titles there is nothing — no margin, no
-// strip showing through — and the space there is the two paddings meeting.
-// Only one title is ever lit, so two pills that touch never draw as one
-// shape, and a margin between them is a gap the pointer crosses on its way
-// from one menu to the next for no reason the eye can see.
-const BAR_INSET = 3;
-
 // A bar item wears the same pill as a row in the menu it opens, so it takes
 // the row's padding rather than numbers of its own: a title packed tighter
 // than its own first row is the tell that the two were measured separately.
 // Vertically that is `MENU_ITEM_PAD` exactly — same padding, same `capTrim`
-// text — which makes the pill `menuRowHeight` tall, and the bar that much
-// taller for it.
+// text — which makes the pill `menuRowHeight` tall and the strip exactly
+// that: a menu bar is one row, and its highlight fills it top to bottom the
+// way a real one does. Inset the pill instead and the bar is a row plus two
+// margins tall, with a highlight floating in a band of leftover strip.
 //
 // Horizontally it takes a little more, and the number is measured rather
 // than argued: the bar this one is imitating leaves 22px between the ink of
@@ -126,10 +115,13 @@ const BAR_ITEM_PAD_X = MENU_ITEM_PAD + 3;
 // five of a title's own highlight would open its neighbour's menu.
 const BAR_PILL_BLEED = 5;
 
-// The strip's own ends have to hold the bleed as well as the pill, or the
-// first title's highlight is cut off square by the window's edge — the one
-// place a pill has no room to be a pill.
-const BAR_END_PAD = BAR_INSET + BAR_PILL_BLEED;
+// What is left of the strip at its two ends, before the first pill and after
+// the last: a highlight cut off square by the window's edge is the one place
+// a pill has no room to be a pill. Measured like the rest — a native bar
+// leaves five — and the strip's padding is that plus the bleed, since the
+// pill starts before its item does.
+const BAR_END_INSET = 5;
+const BAR_END_PAD = BAR_END_INSET + BAR_PILL_BLEED;
 
 // The bar entry that stands for the titles that did not fit. A symbol rather
 // than a `label`, because it is the one entry on the bar the application did
@@ -1344,14 +1336,10 @@ export function MenuBar({
             {
               paddingLeft: BAR_ITEM_PAD_X,
               paddingRight: BAR_ITEM_PAD_X,
-              // The margin is what a radius needs to be seen — a rounded
-              // rect flush against the strip's own edges reads as a cut
-              // corner rather than a pill. It sits *outside* the padding, so
-              // the bar is a menu row plus its two insets tall: the item and
-              // the row below it are then the same pill in the same size,
-              // which is the whole point of giving the bar one.
-              marginTop: BAR_INSET,
-              marginBottom: BAR_INSET,
+              // No vertical margin: the pill fills the strip, which is a
+              // menu row tall and nothing more. The item and the first row
+              // of the menu it opens are then the same pill in the same
+              // size, which is the whole point of giving the bar one.
               paddingTop: MENU_ITEM_PAD,
               paddingBottom: MENU_ITEM_PAD,
               // No ring while this item's menu is up. Walking the bar with

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -59,7 +59,12 @@ const h = React.createElement;
 const MENU_ITEM_PAD = 8;
 const menuRowHeight = (fontSize) => capBand(fontSize) + MENU_ITEM_PAD * 2;
 
-const MENU_SEPARATOR_HEIGHT = 7;
+// A separator is the hairline plus the air that makes it a division rather
+// than a row with a line through it — the two groups it stands between have
+// to read as apart, and at three pixels a side the line just crowds the
+// labels above and below it.
+const MENU_SEPARATOR_PAD = 5;
+const MENU_SEPARATOR_HEIGHT = MENU_SEPARATOR_PAD * 2 + 1;
 
 const MENU_MIN_WIDTH = 140;
 
@@ -92,11 +97,12 @@ const BAR_GAP = 1;
 // text — which makes the pill `menuRowHeight` tall, and the bar that much
 // taller for it.
 //
-// Horizontally it takes a little more. A row's label is not `MENU_ITEM_PAD`
-// from the pill's edge but a whole `MENU_GUTTER` in, past the check column,
-// so matching the row's padding here would read as the cramped one: on a
-// strip the pills sit shoulder to shoulder, with nothing but that padding
-// between one label and the next.
+// Horizontally it takes a little more. A row's label in a menu that has a
+// check column is `MENU_ITEM_PAD + MENU_GUTTER` from the pill's edge rather
+// than `MENU_ITEM_PAD`, so matching the row's padding here would read as
+// the cramped one — a title on a strip has no column to sit past, but it
+// does sit shoulder to shoulder with the next title, with nothing but that
+// padding between one label and the next.
 const BAR_ITEM_PAD_X = MENU_ITEM_PAD + 4;
 
 // The bar entry that stands for the titles that did not fit. A symbol rather
@@ -119,9 +125,17 @@ const OVERFLOW_KEY = '\0menubar-overflow';
 // way (`movingToward`), so this is a matter of taste rather than of reach.
 const SUBMENU_GAP = 0;
 
-const MENU_GUTTER = 24; // room for the check column
-// what a self-drawing icon gets to fill, inside that column's 16px
+// what a self-drawing icon gets to fill
 const MENU_ICON_SIZE = 12;
+// The air between that mark and the label it belongs to. A mark set against
+// its label with a pixel or two to spare reads as part of the word rather
+// than as a column of its own, so this is nearer the space between two words
+// than the hairline a centred icon box happens to leave over.
+const MENU_ICON_GAP = 8;
+// The check column: the mark's own box plus that gap. The mark starts at the
+// row's padding — flush with where a label starts in a menu that has no
+// column at all — so the whole of the column's width is the space after it.
+const MENU_GUTTER = MENU_ICON_SIZE + MENU_ICON_GAP;
 
 const MENU_SHORTCUT_GAP = 24;
 // menus size to their content rather than scrolling, so a page is a fixed
@@ -136,6 +150,29 @@ function menuListHeight(items, fontSize) {
     0,
   );
   return body + (MENU_PAD + MENU_BORDER) * 2;
+}
+
+/**
+ * The width of this menu's check column, which is `0` for a menu that has
+ * nothing to put in it.
+ *
+ * A menu of plain commands has no column, because a column of empty boxes is
+ * an indent every label pays for and no row uses — the reason the gutter is
+ * reserved at all is that a *checkable* item must not shuffle sideways as it
+ * is ticked, and that argument only holds where something is checkable. So
+ * the question is asked of the level as a whole rather than of the row: one
+ * icon anywhere in a menu indents all of its labels, which is what keeps the
+ * labels in a column of their own.
+ *
+ * `toggleType` counts whatever the state is — an unticked checkbox is
+ * exactly the case the reservation exists for — and a separator answers for
+ * nothing, since it spans the row.
+ */
+function menuGutter(items) {
+  const wanted = visibleItems(items).some(
+    (item) => !isSeparator(item) && (item.toggleType || item.icon != null),
+  );
+  return wanted ? MENU_GUTTER : 0;
 }
 
 /** Widest label + shortcut, measured, so the popup can be sized up front. */
@@ -156,9 +193,9 @@ function menuListWidth(node, items, fontSize) {
   return Math.max(
     MENU_MIN_WIDTH,
     Math.ceil(widest) +
-      MENU_GUTTER +
+      menuGutter(items) +
       (MENU_PAD + MENU_BORDER) * 2 +
-      MENU_ITEM_PAD +
+      MENU_ITEM_PAD * 2 +
       2,
   );
 }
@@ -314,6 +351,10 @@ function MenuRow({
   onMove,
   onSelect,
   fontSize,
+  // The width of the level's check column — the same number the popup was
+  // sized with, passed down rather than asked of the item, since a row with
+  // no mark of its own still keeps the column its neighbours need.
+  gutter,
   nodeRef,
 }) {
   const theme = useTheme();
@@ -369,7 +410,6 @@ function MenuRow({
         alignItems: 'center',
         paddingLeft: MENU_ITEM_PAD,
         paddingRight: MENU_ITEM_PAD,
-        cursor: dim ? undefined : 'pointer',
         // A pill inside the sheet: the row is inset from the popup edge by
         // the list's padding, and rounded so that its corner and the sheet's
         // share a centre — the two curves are then one shape rather than two
@@ -397,11 +437,18 @@ function MenuRow({
           : { ':active': { backgroundColor: theme.accentActive } }),
       },
     },
-    h(
-      'box',
-      { style: { width: MENU_GUTTER - MENU_ITEM_PAD, alignItems: 'center' } },
-      gutterMark(item, { color: rowInk, fontSize }),
-    ),
+    gutter > 0 &&
+      h(
+        'box',
+        {
+          // The mark sits at the head of the column and the gap is what
+          // follows it, rather than the column centring its box and leaving
+          // half the gap on either side: the label is the thing that has to
+          // stand clear, and the row's own padding already spaces the mark.
+          style: { width: gutter, alignItems: 'flex-start' },
+        },
+        gutterMark(item, { color: rowInk, fontSize }),
+      ),
     h('text', { style: [capTrim, { fontSize }] }, item.label),
     h('box', { style: { flexGrow: 1 } }),
     // The accelerator and the chevron are quieter than the label at rest and
@@ -463,6 +510,9 @@ function MenuLevel({
 }) {
   const theme = useTheme();
   const items = levelItems(rootItems, path, depth);
+  // one answer for the level, so every row indents by the same amount the
+  // popup was measured with
+  const gutter = menuGutter(items);
   const active = path[depth] ?? -1;
   const childItems = visibleItems(items[active]?.items);
   const childOpen = path.length > depth + 1 && childItems.length > 0;
@@ -621,6 +671,7 @@ function MenuLevel({
           item,
           state: rowState(index, active, handedOn),
           fontSize,
+          gutter,
           nodeRef: index === active ? activeRowRef : undefined,
           onHover: (ev) => hover(index, ev),
           onMove: (ev) => move(index, ev),
@@ -1226,7 +1277,6 @@ export function MenuBar({
           },
           style: [
             {
-              cursor: 'pointer',
               paddingLeft: BAR_ITEM_PAD_X,
               paddingRight: BAR_ITEM_PAD_X,
               // The same pill the rows inside the menu wear, at the same

--- a/src/components/Menu.js
+++ b/src/components/Menu.js
@@ -102,13 +102,34 @@ const BAR_INSET = 3;
 // taller for it.
 //
 // Horizontally it takes a little more, and the number is measured rather
-// than argued: macOS leaves 22px between the ink of two menu bar titles, and
-// since the pills touch, that space is two of these. A row's label in a menu
-// with a check column is `MENU_ITEM_PAD + MENU_GUTTER` from the pill's edge
-// anyway, so the row's own padding would read as the cramped one here — a
-// title has no column to sit past, but it does sit shoulder to shoulder with
-// the next title.
+// than argued: the bar this one is imitating leaves 22px between the ink of
+// two titles, so that is what a title's own padding and its neighbour's have
+// to add up to. A row's label in a menu with a check column is
+// `MENU_ITEM_PAD + MENU_GUTTER` from the pill's edge anyway, so the row's own
+// padding would read as the cramped one here — a title has no column to sit
+// past, but it does sit shoulder to shoulder with the next title.
+//
 const BAR_ITEM_PAD_X = MENU_ITEM_PAD + 3;
+
+// The pill is wider than the item that owns it. Measured off the same bar:
+// its highlight runs 16px past the ink of the title it belongs to, which is
+// five past the halfway line between that title and the next — so a lit
+// title reaches *into* both neighbours' halves of the strip rather than
+// stopping politely at the boundary. It reads as one object sitting on the
+// bar; a pill that stops at the midpoint reads as one cell of a table that
+// happens to be filled in.
+//
+// Drawn, not laid out. The item box still tiles the strip, so the 22px
+// between two titles is still two paddings and the pointer still belongs to
+// exactly one item everywhere along the bar. Widening the boxes to the size
+// of the pill instead would overlap them by ten pixels, and then the last
+// five of a title's own highlight would open its neighbour's menu.
+const BAR_PILL_BLEED = 5;
+
+// The strip's own ends have to hold the bleed as well as the pill, or the
+// first title's highlight is cut off square by the window's edge — the one
+// place a pill has no room to be a pill.
+const BAR_END_PAD = BAR_INSET + BAR_PILL_BLEED;
 
 // The bar entry that stands for the titles that did not fit. A symbol rather
 // than a `label`, because it is the one entry on the bar the application did
@@ -253,7 +274,7 @@ const barOverflowWidth = (fontSize) => iconSize(fontSize) + BAR_ITEM_PAD_X * 2;
  */
 function barCut(node, menus, fontSize, width) {
   const widths = menus.map((menu) => barItemWidth(node, menu.label, fontSize));
-  const inner = width - BAR_INSET * 2;
+  const inner = width - BAR_END_PAD * 2;
   const total = widths.reduce((sum, w) => sum + w, 0);
   if (total <= inner) return menus.length;
   const room = inner - barOverflowWidth(fontSize);
@@ -985,6 +1006,11 @@ export function MenuBar({
   const theme = useTheme();
   const rtl = useDirection() === 'rtl';
   const [openIndex, setOpenIndex] = useState(-1);
+  // The pointer's title, tracked here rather than left to a `:hover` block,
+  // because the thing that lights up is no longer the node the pointer is
+  // over: the pill is a child that reaches past its own item, and a state
+  // block only ever answers for the node it is written on.
+  const [hoverIndex, setHoverIndex] = useState(-1);
   const [rect, setRect] = useState(null);
   const [path, setPath] = useState([]);
   const refs = useRef([]);
@@ -1203,8 +1229,8 @@ export function MenuBar({
           flexDirection: 'row',
           alignItems: 'center',
           backgroundColor: theme.surfaceHover,
-          paddingLeft: BAR_INSET,
-          paddingRight: BAR_INSET,
+          paddingLeft: BAR_END_PAD,
+          paddingRight: BAR_END_PAD,
           // `scroll` is what makes a box report its viewport, and the clip
           // that comes with it is wanted in its own right: it is what holds
           // the one frame before the first measurement — and any bar whose
@@ -1255,9 +1281,16 @@ export function MenuBar({
           onMouseDown: () =>
             openIndex === index ? close() : openMenu(index, 'pointer'),
           onMouseEnter: () => {
+            setHoverIndex(index);
             if (openIndex >= 0 && openIndex !== index) {
               openMenu(index, 'pointer');
             }
+          },
+          onMouseLeave: () => {
+            // the index rather than -1 unconditionally: the pointer reaches
+            // the next title before this one hears it left, and clearing
+            // then would put the bar back to nothing lit for a frame
+            setHoverIndex((current) => (current === index ? -1 : current));
           },
           // read live: by the time a hand-off blurs this item, the item
           // taking over has already claimed the bar
@@ -1311,30 +1344,16 @@ export function MenuBar({
             {
               paddingLeft: BAR_ITEM_PAD_X,
               paddingRight: BAR_ITEM_PAD_X,
-              // The same pill the rows inside the menu wear, at the same
-              // radius: the bar item and the first row of the menu it opens
-              // are one gesture, and a square title over rounded rows reads
-              // as two widgets that have not met.
-              //
               // The margin is what a radius needs to be seen — a rounded
               // rect flush against the strip's own edges reads as a cut
-              // corner rather than a pill. Vertical only: the strip's own
-              // padding does that job at the two ends, and between two titles
-              // there is nothing to hold apart. It sits *outside* the
-              // padding, so the bar is a menu row plus its two insets tall:
-              // the item and the row below it are then the same pill in the
-              // same size, which is the whole point of giving the bar one.
+              // corner rather than a pill. It sits *outside* the padding, so
+              // the bar is a menu row plus its two insets tall: the item and
+              // the row below it are then the same pill in the same size,
+              // which is the whole point of giving the bar one.
               marginTop: BAR_INSET,
               marginBottom: BAR_INSET,
               paddingTop: MENU_ITEM_PAD,
               paddingBottom: MENU_ITEM_PAD,
-              borderRadius: rowRadius(theme, MENU_BORDER, MENU_PAD),
-              backgroundColor:
-                barState === 'active'
-                  ? theme.hoverBackground
-                  : barState === 'path'
-                    ? theme.surfaceActive
-                    : undefined,
               // No ring while this item's menu is up. Walking the bar with
               // the arrow keys opens each menu as it arrives, so the item is
               // already inverted with a menu hanging off it — a ring on top
@@ -1349,16 +1368,40 @@ export function MenuBar({
               // said once for whichever of the two the title turns out to be
               color: barState === 'active' ? theme.hoverText : theme.text,
             },
-            // Only while this menu is shut, as in `Select`: an open one is
-            // already showing the answer, and a state block would outrank
-            // the base colour that says so. The menu opens on the release,
-            // so `:active` is the whole of the answer to a held press.
-            openIndex !== index && {
-              ':hover': { backgroundColor: theme.surface },
-              ':active': { backgroundColor: theme.surfaceActive },
-            },
           ],
         },
+        // The pill, drawn before the title so the title is drawn on it. It
+        // is a box of its own rather than this item's background because it
+        // is wider than this item: `BAR_PILL_BLEED` past both edges, which
+        // is where a native bar's highlight ends (see the constant). Only
+        // while it has a colour to be — nothing at rest, since the strip
+        // under it is already that colour.
+        //
+        // Hover is the state that used to be a `:hover` block here and is
+        // now `hoverIndex`, and only while this menu is shut: an open one is
+        // already showing the answer, and the hover colour would outrank the
+        // base colour that says so.
+        (barState || hoverIndex === index) &&
+          h('box', {
+            style: {
+              position: 'absolute',
+              left: -BAR_PILL_BLEED,
+              right: -BAR_PILL_BLEED,
+              top: 0,
+              bottom: 0,
+              // the same radius the rows inside the menu wear: the bar item
+              // and the first row of the menu it opens are one gesture, and
+              // a square title over rounded rows reads as two widgets that
+              // have not met
+              borderRadius: rowRadius(theme, MENU_BORDER, MENU_PAD),
+              backgroundColor:
+                barState === 'active'
+                  ? theme.hoverBackground
+                  : barState === 'path'
+                    ? theme.surfaceActive
+                    : theme.surface,
+            },
+          }),
         overflow
           ? h(Icon, {
               // The set's own overflow mark, rather than the `»` Qt and

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -131,7 +131,6 @@ function Option({
         justifyContent: 'center',
         paddingLeft: ITEM_PAD_LEFT,
         paddingRight: ITEM_PAD_RIGHT,
-        cursor: 'pointer',
         // the menus' pill, for the same reason and by the same rule: an
         // option list and a menu are one surface with rows in it, and two
         // shapes for that would only say the widgets were written apart

--- a/src/components/anchor.js
+++ b/src/components/anchor.js
@@ -165,18 +165,27 @@ export function measureLabel(node, text, style) {
   // exactly the kind of error that turns into an ellipsis on the longest
   // label in the menu (src/scale.js).
   const s = node?.scale ?? 1;
+  // The face **this node inherits**, not the literal `sans-serif` at whatever
+  // the defaults are: the labels these popups are sized around name no type
+  // of their own, so the one they are drawn in is the one that cascades down
+  // to them. Measuring in a different face is measuring the wrong label — a
+  // menu sized in sans-serif for a row that paints in a wider mono is a menu
+  // whose own options wrap.
+  //
+  // Which is every property that changes a glyph's advance, not the family
+  // alone. `fontVariationSettings` is the one that bites: a tree that sets
+  // `{ opsz: 17 }` on its window — the text cut of a variable face, wider
+  // than the display cut most files default to — draws every row in it and
+  // used to measure none, and the popup came out narrow enough to wrap its
+  // own labels. An explicit `style` still wins, since a caller that names a
+  // face is measuring something it is about to draw in that face.
+  const inherited = node?.inheritedTextStyle;
   const layout = fonts.layout(String(text), {
-    // The face **this node inherits**, not the literal `sans-serif`: the
-    // labels these popups are sized around name no family of their own, so
-    // the one they are drawn in is the palette's. Measuring in a different
-    // face is measuring the wrong label — a menu sized in sans-serif for a
-    // row that paints in a wider mono is a menu whose own options wrap.
-    family: style?.family ?? node?.inheritedTextStyle?.family ?? 'sans-serif',
+    family: style?.family ?? inherited?.family ?? 'sans-serif',
     size: size * s,
-    weight: style?.weight ?? 'normal',
-    // dropping this would measure a different face from the one drawn, and
-    // the popup sized here would be the wrong width for its own label
-    variations: style?.variations,
+    weight: style?.weight ?? inherited?.weight ?? 'normal',
+    style: style?.style ?? inherited?.style,
+    variations: style?.variations ?? inherited?.variations,
   });
   return { width: layout.width / s, height: layout.height / s };
 }

--- a/test/popup-chrome.test.js
+++ b/test/popup-chrome.test.js
@@ -210,16 +210,28 @@ test('the bar item is the first link in the trail', async () => {
   const item = wnd._reactX11Node.children[0].children[0];
   const theme = list.theme;
 
-  assert.equal(item.style.borderRadius, RADIUS_ROW, 'the same pill');
+  // The lit area is a child of the item rather than the item's own
+  // background, because it is wider than the item: it reaches past both
+  // edges into the neighbouring titles' halves of the strip, which is where
+  // a native bar's highlight ends. The item boxes still tile, so the pointer
+  // belongs to exactly one title everywhere along the bar.
+  const pill = () => item.children[0];
+  assert.equal(pill().style.borderRadius, RADIUS_ROW, 'the same pill');
+  assert.ok(pill().style.left < 0, 'reaches past the item it belongs to');
   assert.equal(
-    item.style.backgroundColor,
+    pill().style.left,
+    pill().style.right,
+    'by the same amount on both sides',
+  );
+  assert.equal(
+    pill().style.backgroundColor,
     theme.hoverBackground,
     'lit while its menu is open with nothing chosen in it',
   );
 
   await hoverRow(menu, 0);
   assert.equal(
-    item.style.backgroundColor,
+    pill().style.backgroundColor,
     theme.surfaceActive,
     'and quiet once a row down there takes the selection over',
   );

--- a/test/popup-chrome.test.js
+++ b/test/popup-chrome.test.js
@@ -239,6 +239,66 @@ test('the bar item is the first link in the trail', async () => {
   await x11Root.unmount();
 });
 
+test('the check column is there for the marks that are drawn', async () => {
+  // Three menus of the same four commands: one plain, one whose first item
+  // is a checkbox that is *off*, one whose first item is ticked. What the
+  // column answers to is what a row draws, so only the last is indented.
+  const bar = [
+    { label: 'Plain', items: [{ label: 'Alpha' }, { label: 'Beta' }] },
+    {
+      label: 'Off',
+      items: [
+        { label: 'Alpha', toggleType: 'checkbox', toggleState: 0 },
+        { label: 'Beta' },
+      ],
+    },
+    {
+      label: 'On',
+      items: [
+        { label: 'Alpha', toggleType: 'checkbox', toggleState: 1 },
+        { label: 'Beta' },
+      ],
+    },
+  ];
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(
+    h(
+      'window',
+      { width: 300, height: 200 },
+      h(MenuBar, { menus: bar, fontSize: 13, globalMenu: false }),
+    ),
+  );
+  await tick();
+  const wnd = app.windows[0];
+
+  /** Where the second row's label starts, inside the popup `title` opens. */
+  const labelX = async (index) => {
+    const item = wnd._reactX11Node.children[0].children[index];
+    pressButton(wnd, item.abs.x + 4, item.abs.y + 4);
+    await tick();
+    await tick();
+    const popup = app.windows.at(-1);
+    // 'Beta' either way — the row with no mark of its own, which is the one
+    // the column has to answer for
+    const row = popup._reactX11Node.children[0].children[1];
+    const label = row.children.find((c) => c.kind === 'text');
+    const x = label.abs.x - popup._reactX11Node.abs.x;
+    pressButton(wnd, item.abs.x + 4, item.abs.y + 4); // shut it again
+    await tick();
+    return x;
+  };
+
+  const plain = await labelX(0);
+  assert.equal(await labelX(1), plain, 'a toggle that is off draws nothing');
+  assert.ok(
+    (await labelX(2)) > plain,
+    'and one that is ticked indents every label in its menu',
+  );
+
+  await x11Root.unmount();
+});
+
 test('only the live end of the trail is selection-coloured', async () => {
   const { app, x11Root, menu, list } = await openMenu();
   const theme = list.theme;


### PR DESCRIPTION
Menus and the menu bar, measured against the platform bar sitting above them rather than adjusted by feel. Every number below was read off a real macOS menu bar with a pixel probe (`screencapture` of the strip, ink-run analysis) or off the rendered result, and the constants carry the measurement in their comments.

Screenshots are **before | after**, rendered headlessly at d005d20 and at its merge base 3f14e53 through the real pipeline — the in-process X server, the real event path, `scripts/capture.js` — at 2×.

## Menu rows

<img width="668" alt="menu with icons, before and after" src="https://github.com/user-attachments/assets/06184e05-6596-40f8-9806-24c816f62eea" />

**The check column is a column.** It was 24px measured from the row's edge: 8 of padding, then a 16px box with a 12px icon centred in it — two pixels between icon and label, which reads as one word rather than two things. Rebuilt from the mark out: the icon starts where a label would, and the whole of the column after it is the gap (`MENU_ICON_SIZE + MENU_ICON_GAP`).

**A separator gets its air back.** 7px → 11px. A hairline with three pixels either side is a row with a line through it, not a division between two groups.

**No cursor styling** on menu rows, bar titles, or `Select`'s option rows. `Select`'s trigger keeps its pointer — that is a control, not a menu.

## Menus with nothing to put in the column

<img width="656" alt="menu with no icons, before and after" src="https://github.com/user-attachments/assets/baa0364f-5143-49ad-ad51-2eec1e59da0e" />

A menu with nothing to draw in that column has **no column at all** now, and its popup is that much narrower. The question is asked of the level (`menuGutter`) and answered once for the popup's width and every row in it — and what counts is what a row *paints*: an icon, or a toggle that is on. A menu of plain commands and a menu of checkboxes that all happen to be off look the same to the eye, and they get the same left edge: 13px, which is what the platform's own plain menus measure.

The cost, since it is a real one: ticking the first item in such a menu moves its labels sideways, once. Reserving the column unconditionally buys stillness in that one frame and pays for it with an indent on every menu with a toggle anywhere in it, forever — this is the other trade, and a menu that already has a mark keeps its column whatever happens to the rest.

<img width="640" alt="the same one-checkbox menu, off and on" src="https://github.com/user-attachments/assets/c1b33ac2-5ef9-4297-9439-949711d082be" />

**The submenu chevron takes the row's ink** instead of `textMuted`. A shortcut is a second way to do what the label says and can afford to be quiet; the arrow *is* the row saying it has more behind it, and muted it read as a row half disabled.

**Menu text is set at 500.** Where the face has a medium — SF, Inter — that is what native menus are set in and what this picks up; where there is only a regular and a bold, 500 resolves to the regular and nothing changes.

## The bar

<img width="1496" alt="menu bar, before and after" src="https://github.com/user-attachments/assets/537c7d77-fcad-408d-99db-0bdb9dc41fca" />

| | before | after | macOS |
| --- | --- | --- | --- |
| between the ink of two titles | 27px | 22px | 22px |
| highlight past a title's ink | 9px | 16px | 16px |
| highlight height | 25 of a 31px strip | 25 of 25 | 24 of 24 |
| bar before the first pill | 3px | 5px | 5px |

Three changes to get there. The **space between two titles is one gap, not two margins** — each item carried a margin on both sides, so the gap was margin + padding + padding + margin. The **lit title reaches past the halfway line**: a native bar's highlight crosses five pixels into each neighbour's half of the strip, which reads as one object sitting on the bar where a pill stopping at the midpoint reads as one filled-in cell of a table. And the **strip is one row tall**, with the highlight filling it — the bar was a row plus a 3px margin at each end, so the lit title floated in a band of leftover strip. Windows with a menu bar gain those six pixels back as content.

The pill is *drawn* wider rather than laid out wider: the item boxes still tile the strip, so the pointer belongs to exactly one title everywhere along the bar. Widening the boxes would have overlapped them by ten pixels, and then the last five of a title's own highlight would open its neighbour's menu. The cost is that `:hover` can no longer light it — a state block only answers for the node it is written on — so the bar tracks the hovered title itself.

## A popup is measured in the type it will be drawn in

Not cosmetic, and the reason this branch has an `anchor.js` commit: `measureLabel` took the *family* off the node it measured against and nothing else, so weight, slant and variation settings all came from its own defaults.

`fontVariationSettings` is the one that bites. A variable font's optical-size axis usually defaults to a display cut, so a tree that asks for the text cut it should have at UI sizes (`{ opsz: 17 }` on the window) draws a wider face than the default. Every row was drawn in it and none of it was measured in it, and the popup arrived narrow — a "Large menu items" checkbox came out 12px short and wrapped onto a second line. `Tooltip` and `Select` size themselves through the same function and had the same bug.

Related: ntk's own optical-size handling is https://github.com/sidorares/ntk/issues/332 — `instantiate()` sets `wght` from the CSS weight and leaves `opsz` at the file's default, which is why a tree has to ask for it by hand at all.

## Also

- **ntk 8.5.0**, lockfile with it.
- The gutter change is documented in `docs/components.md`; the bar-item test follows the pill to where it now lives and asserts the bleed (a pill that stops at the item's edge fails it — checked by reverting the constant).

## Testing

`npm test -- test/*.test.js` against ntk 8.5.0: 1618 pass, 7 fail — the six `appearance.test.js` failures that fail on this machine and pass in CI, plus one heavy suite that times out under parallel load and passes on its own. No failures from these changes; `prettier --check .` and `eslint` clean.

