### PR TITLE
feat(bench): price a composite by the taps behind it, not just its area

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -798,10 +798,27 @@ Rules, in rough order of how much they usually matter:
 ### Measuring it
 
 `npm run bench` runs scenarios against the in-process X server and reports
-requests, bytes, replies, Render composites and **the pixel area those
-composites touch**. That last metric exists because the others hide the
-most common regression: a change can add almost nothing to the wire while
-multiplying the server's work many times over.
+requests, bytes, replies, Render composites, **the pixel area those
+composites touch** and **the multiply-accumulates inside that area**. Those
+last two exist because the others hide the most common regression: a change
+can add almost nothing to the wire while multiplying the server's work many
+times over.
+
+Area and taps are two different assumptions, and both get away from you:
+
+- `Mpx` is area, and assumes a pixel costs the same everywhere.
+- `convMpx` is `kernel_w × kernel_h × area`, summed over any `convolution`
+  filter the composite's source or mask carries. A picture's filter is
+  re-applied by the server on _every_ composite that reads it, so the same
+  request over the same rectangle is one tap a pixel or 3721 depending on
+  picture state neither the request count nor the area looks at. Equal to
+  `Mpx` means nothing is filtered; `--hotspots` names the kernels.
+
+The gap between them is issue #413: a blurred `boxShadow` set the filter on
+its cached coverage instead of baking the blur in, every shadowed repaint
+re-convolved (~700x slower on a real display), and requests, bytes,
+composites, area, stalls, dups, churn and the rendered pixels were all
+unchanged across the fix.
 
 - `npm run bench -- --save` rewrites `scripts/bench/baseline.json`
 - `npm run bench -- --check` fails if a metric regressed past tolerance

--- a/docs/architecture/protocol-efficiency.md
+++ b/docs/architecture/protocol-efficiency.md
@@ -94,10 +94,18 @@ Two complementary rigs, both now in-repo or one command away:
 
 **Deterministic (CI-grade): `npm run bench`.** Runs scenarios against
 node-x11's in-process X server and counts requests / bytesOut / replies /
-`Composite` count / **composite pixel area** per scenario
-(`scripts/bench/xcount.js`). Requests and bytes miss pixel work entirely — a
-Composite is 36 bytes whether it touches ten pixels or the whole surface — so
-the Mpx column is the one that catches "correct but does far too much".
+`Composite` count / **composite pixel area** / **convolved pixels** per
+scenario (`scripts/bench/xcount.js`). Requests and bytes miss pixel work
+entirely — a Composite is 36 bytes whether it touches ten pixels or the whole
+surface — so the Mpx column is the one that catches "correct but does far too
+much". The convMpx column catches the layer under _that_: area prices every
+destination pixel the same, but a source or mask picture carrying RENDER's
+`convolution` filter is re-convolved by the server on every composite that
+reads it, so `kernel_w × kernel_h × area` is what the server actually runs.
+Issue #413 is the case that motivated it — a blurred `boxShadow` left the
+blur as a picture filter rather than baking it into the pixels, which made
+every shadowed repaint ~700x slower with requests, bytes, composites, area,
+stalls, dups, churn and the rendered pixels all unchanged.
 Since #380 the same counting proxy also analyses the stream: `stalls`
 (blocking round trips nothing was pipelined behind), `dupQueries` (repeated
 identical reply-carrying requests) and `churn` (server resources created and

--- a/scripts/bench/baseline.json
+++ b/scripts/bench/baseline.json
@@ -6,6 +6,8 @@
     "replies": 7,
     "composites": 1,
     "compositePixels": 160000,
+    "filteredComposites": 0,
+    "convolvedPixels": 0,
     "stalls": 0,
     "dupQueries": 0,
     "churn": 0
@@ -17,6 +19,8 @@
     "replies": 7,
     "composites": 1,
     "compositePixels": 160000,
+    "filteredComposites": 0,
+    "convolvedPixels": 0,
     "stalls": 0,
     "dupQueries": 0,
     "churn": 0
@@ -28,6 +32,8 @@
     "replies": 7,
     "composites": 1,
     "compositePixels": 160000,
+    "filteredComposites": 0,
+    "convolvedPixels": 0,
     "stalls": 0,
     "dupQueries": 0,
     "churn": 0
@@ -39,6 +45,8 @@
     "replies": 7,
     "composites": 1,
     "compositePixels": 160000,
+    "filteredComposites": 0,
+    "convolvedPixels": 0,
     "stalls": 0,
     "dupQueries": 0,
     "churn": 0
@@ -50,6 +58,8 @@
     "replies": 7,
     "composites": 1,
     "compositePixels": 160000,
+    "filteredComposites": 0,
+    "convolvedPixels": 0,
     "stalls": 0,
     "dupQueries": 0,
     "churn": 0
@@ -61,6 +71,8 @@
     "replies": 7,
     "composites": 1,
     "compositePixels": 160000,
+    "filteredComposites": 0,
+    "convolvedPixels": 0,
     "stalls": 0,
     "dupQueries": 0,
     "churn": 0
@@ -72,6 +84,8 @@
     "replies": 1,
     "composites": 21,
     "compositePixels": 179200,
+    "filteredComposites": 0,
+    "convolvedPixels": 0,
     "stalls": 1,
     "dupQueries": 0,
     "churn": 0
@@ -83,6 +97,8 @@
     "replies": 4,
     "composites": 2,
     "compositePixels": 800,
+    "filteredComposites": 0,
+    "convolvedPixels": 0,
     "stalls": 2,
     "dupQueries": 0,
     "churn": 0
@@ -94,6 +110,8 @@
     "replies": 32,
     "composites": 21,
     "compositePixels": 298240,
+    "filteredComposites": 0,
+    "convolvedPixels": 0,
     "stalls": 0,
     "dupQueries": 2,
     "churn": 0
@@ -105,6 +123,8 @@
     "replies": 22,
     "composites": 81,
     "compositePixels": 389520,
+    "filteredComposites": 0,
+    "convolvedPixels": 0,
     "stalls": 4,
     "dupQueries": 0,
     "churn": 0
@@ -116,6 +136,8 @@
     "replies": 44,
     "composites": 70,
     "compositePixels": 561760,
+    "filteredComposites": 0,
+    "convolvedPixels": 0,
     "stalls": 12,
     "dupQueries": 0,
     "churn": 0
@@ -127,6 +149,8 @@
     "replies": 3,
     "composites": 101,
     "compositePixels": 200000,
+    "filteredComposites": 0,
+    "convolvedPixels": 0,
     "stalls": 1,
     "dupQueries": 0,
     "churn": 0
@@ -138,6 +162,8 @@
     "replies": 3,
     "composites": 11,
     "compositePixels": 10292,
+    "filteredComposites": 0,
+    "convolvedPixels": 0,
     "stalls": 1,
     "dupQueries": 0,
     "churn": 0
@@ -149,6 +175,8 @@
     "replies": 36,
     "composites": 0,
     "compositePixels": 0,
+    "filteredComposites": 0,
+    "convolvedPixels": 0,
     "stalls": 12,
     "dupQueries": 10,
     "churn": 0
@@ -160,6 +188,8 @@
     "replies": 31,
     "composites": 10,
     "compositePixels": 3240,
+    "filteredComposites": 0,
+    "convolvedPixels": 0,
     "stalls": 31,
     "dupQueries": 0,
     "churn": 0
@@ -171,6 +201,8 @@
     "replies": 11,
     "composites": 245,
     "compositePixels": 2020640,
+    "filteredComposites": 120,
+    "convolvedPixels": 277248000,
     "stalls": 1,
     "dupQueries": 0,
     "churn": 0
@@ -182,6 +214,8 @@
     "replies": 8,
     "composites": 10,
     "compositePixels": 25020,
+    "filteredComposites": 0,
+    "convolvedPixels": 0,
     "stalls": 4,
     "dupQueries": 0,
     "churn": 0
@@ -193,6 +227,8 @@
     "replies": 6,
     "composites": 10,
     "compositePixels": 31320,
+    "filteredComposites": 0,
+    "convolvedPixels": 0,
     "stalls": 6,
     "dupQueries": 0,
     "churn": 0
@@ -204,6 +240,8 @@
     "replies": 7,
     "composites": 69,
     "compositePixels": 14863,
+    "filteredComposites": 0,
+    "convolvedPixels": 0,
     "stalls": 5,
     "dupQueries": 0,
     "churn": 0
@@ -215,6 +253,8 @@
     "replies": 10,
     "composites": 308,
     "compositePixels": 59166,
+    "filteredComposites": 0,
+    "convolvedPixels": 0,
     "stalls": 2,
     "dupQueries": 0,
     "churn": 0
@@ -226,6 +266,8 @@
     "replies": 11,
     "composites": 993,
     "compositePixels": 428249,
+    "filteredComposites": 0,
+    "convolvedPixels": 0,
     "stalls": 0,
     "dupQueries": 0,
     "churn": 0

--- a/scripts/bench/protocol.js
+++ b/scripts/bench/protocol.js
@@ -29,6 +29,14 @@
 //                        request is 36 bytes whether it touches ten pixels
 //                        or the whole surface), and it is where "correct
 //                        but does far too much pixel work" shows up
+//   convolved            multiply-accumulates inside those composites: the
+//                        area again, but multiplied by the kernel of any
+//                        `convolution` filter its source or mask carries.
+//                        Area assumes a pixel costs the same everywhere; a
+//                        filtered picture is re-convolved by the server on
+//                        every composite that reads it, so the same area can
+//                        be one tap a pixel or 3721 (issue #413). Equal to
+//                        `pixels` means nothing is filtered
 //   stalls               blocking round trips: replies that arrived while
 //                        their request was the last thing sent, so nothing
 //                        was pipelined behind it. The bench's own settle()
@@ -58,6 +66,7 @@ import {
   analysisMark,
   captureLines,
   compositePixels,
+  convolvedPixels,
   countStream,
   windowAnalysis,
 } from './xcount.js';
@@ -184,24 +193,26 @@ async function measure(name, fn) {
   }
   await settle(app);
 
-  const after = compositePixels(stats, app.display.Render.majorOpcode);
-  const beforePx = compositePixels(
-    { composites: stats.composites.slice(0, mark.composites) },
-    app.display.Render.majorOpcode,
-  );
+  const render = app.display.Render.majorOpcode;
+  // only what `fn` caused: the composites recorded after the mark
+  const drawn = { composites: stats.composites.slice(mark.composites) };
+  const area = compositePixels(drawn, render);
+  const conv = convolvedPixels(drawn, render);
   const analysis = windowAnalysis(stats, mark.analysis);
   const result = {
     requests: stats.requests - mark.requests,
     bytesOut: stats.bytesOut - mark.bytesOut,
     bytesIn: stats.bytesIn - mark.bytesIn,
     replies: stats.replies - mark.replies,
-    composites: after.composites - beforePx.composites,
-    compositePixels: after.pixels - beforePx.pixels,
+    composites: area.composites,
+    compositePixels: area.pixels,
+    filteredComposites: conv.composites,
+    convolvedPixels: conv.pixels,
     stalls: analysis.stalls,
     dupQueries: analysis.dupQueries,
     churn: analysis.churn,
   };
-  hotspots[name] = analysis;
+  hotspots[name] = { ...analysis, kernels: conv.byKernel };
   if (recordDir) {
     const file = join(recordDir, `${name.replace(/[^a-z0-9]+/gi, '-')}.x11cap`);
     writeFileSync(file, captureLines(stats, `bench: ${name}`));
@@ -1118,6 +1129,14 @@ const SCENARIOS = [
     // non-solid source through the coverage it already builds would take
     // this scenario back under 25KB; until then it is worth knowing that a
     // rounded gradient is the priciest box in this vocabulary.
+    //
+    // `convMpx` is the other number to read here, and it is ours: 277 Mpx
+    // against 2.02 composited, because each of the 120 shadow composites
+    // reads its coverage through a live 19x19 `convolution` filter and the
+    // server re-runs all 361 taps every frame. That is issue #413 — the cost
+    // no other column in this table can see. sidorares/react-x11#412 bakes
+    // the blur into the pixels and takes this column to 0.00 with every
+    // other metric in the row unmoved.
     'shapes: 24 gradient+shadow cards, 5 full repaints',
     (() => {
       let ctl;
@@ -1341,11 +1360,11 @@ if (args.includes('--save')) {
 
 const pad = (v, n) => String(v).padStart(n);
 console.log(
-  `${'scenario'.padEnd(38)} ${pad('reqs', 6)} ${pad('bytesOut', 9)} ${pad('replies', 8)} ${pad('composites', 11)} ${pad('Mpx', 8)} ${pad('stalls', 7)} ${pad('dupQ', 5)} ${pad('churn', 6)}`,
+  `${'scenario'.padEnd(38)} ${pad('reqs', 6)} ${pad('bytesOut', 9)} ${pad('replies', 8)} ${pad('composites', 11)} ${pad('Mpx', 8)} ${pad('convMpx', 9)} ${pad('stalls', 7)} ${pad('dupQ', 5)} ${pad('churn', 6)}`,
 );
 for (const [name, r] of Object.entries(results)) {
   console.log(
-    `${name.padEnd(38)} ${pad(r.requests, 6)} ${pad(r.bytesOut, 9)} ${pad(r.replies, 8)} ${pad(r.composites, 11)} ${pad((r.compositePixels / 1e6).toFixed(2), 8)} ${pad(r.stalls, 7)} ${pad(r.dupQueries, 5)} ${pad(r.churn, 6)}`,
+    `${name.padEnd(38)} ${pad(r.requests, 6)} ${pad(r.bytesOut, 9)} ${pad(r.replies, 8)} ${pad(r.composites, 11)} ${pad((r.compositePixels / 1e6).toFixed(2), 8)} ${pad((r.convolvedPixels / 1e6).toFixed(2), 9)} ${pad(r.stalls, 7)} ${pad(r.dupQueries, 5)} ${pad(r.churn, 6)}`,
   );
 }
 
@@ -1361,6 +1380,7 @@ if (args.includes('--hotspots')) {
     if (a.stallsBy.length) console.log(`  stalled on ${list(a.stallsBy)}`);
     if (a.dupsBy.length) console.log(`  repeated   ${list(a.dupsBy)}`);
     if (a.churnBy.length) console.log(`  churned    ${list(a.churnBy)}`);
+    if (a.kernels.length) console.log(`  convolved  ${list(a.kernels)}`);
   }
 }
 
@@ -1393,6 +1413,11 @@ if (args.includes('--check')) {
     bytesOut: [1.15, 256],
     composites: [1.15, 2],
     compositePixels: [1.15, 2],
+    // A filtered composite is the same request over the same area, so these
+    // two move with the same jitter as the pair above — and step by the
+    // kernel, which is three orders of magnitude past any tolerance.
+    filteredComposites: [1.15, 2],
+    convolvedPixels: [1.15, 2],
     stalls: [1.25, 5],
     dupQueries: [1.15, 2],
     churn: [1.15, 4],

--- a/scripts/bench/xcount.js
+++ b/scripts/bench/xcount.js
@@ -30,6 +30,10 @@
 //                   the window (pixmap/picture/gc/region/…), with the
 //                   create's parameters kept so "same-sized pixmap rebuilt
 //                   every frame" is visible as repeats of one churn key.
+//   filters       — the live `convolution` filter, if any, on every picture,
+//                   so a Composite can be priced by the taps the server runs
+//                   per pixel rather than by area alone (see
+//                   `convolvedPixels`).
 //
 // Requests are named (core table + extension majors learned live from
 // QueryExtension replies, minor tables for the extensions this stack uses),
@@ -178,6 +182,20 @@ function fnv1a(buf, len) {
   return h;
 }
 
+// RENDER minors the picture-filter tracker cares about. A filter is picture
+// *state*: it is set once and re-applied by the server on every composite
+// that reads the picture, so pricing a Composite needs the filter that was
+// live when the Composite went out — which means following the state, not
+// looking at the Composite alone.
+const RENDER_CREATE_PICTURE = 4;
+const RENDER_FREE_PICTURE = 7;
+const RENDER_COMPOSITE = 8;
+const RENDER_SET_PICTURE_FILTER = 30;
+// CreateSolidFill / CreateLinear|Radial|ConicalGradient: also pictures, and
+// also worth clearing, because node-x11 recycles XIDs
+const RENDER_CREATE_SOURCE = new Set([33, 34, 35, 36]);
+const FIXED = 65536; // RENDER FIXED: 16.16 signed
+
 /** Widen a 16-bit wire sequence number against the full request count. */
 function widenSeq(low, current) {
   let full = (current & ~0xffff) | low;
@@ -207,6 +225,7 @@ export function countStream(inner, { record = false } = {}) {
     live: new Map(), // xid -> { type, key, seq }
     extNames: new Map(), // major opcode -> extension name
     pendingQueryExt: new Map(), // seq -> extension name asked about
+    filters: new Map(), // picture xid -> { taps, key } for a convolution
   };
 
   const stats = {
@@ -217,8 +236,9 @@ export function countStream(inner, { record = false } = {}) {
     errors: 0,
     bytesIn: 0,
     byOpcode: new Map(),
-    // (major, minor, w, h) for every 36-byte request, so Render Composite
-    // pixel area can be totalled once the extension opcode is known
+    // (major, minor, w, h, taps, kernel) for every 36-byte request, so Render
+    // Composite pixel area — and the convolution work inside that area —
+    // can be totalled once the extension opcode is known
     composites: [],
     analysis,
     captureRecords: record ? [] : null,
@@ -314,6 +334,84 @@ export function countStream(inner, { record = false } = {}) {
     }
   };
 
+  /**
+   * Follow RENDER's per-picture `convolution` filter.
+   *
+   * SetPictureFilter draws nothing itself, but it decides what every later
+   * Composite through that picture *does*: the server re-runs the kernel per
+   * composite, so a 61x61 filter turns each destination pixel into 3721
+   * multiply-accumulates. The XID is cleared on FreePicture and on any
+   * picture create, because node-x11 recycles ids and a stale kernel would
+   * price the wrong surface.
+   */
+  const trackFilter = (op, minor, buf, base, len) => {
+    if (analysis.extNames.get(op) !== 'RENDER') return;
+    if (
+      minor === RENDER_FREE_PICTURE ||
+      minor === RENDER_CREATE_PICTURE ||
+      RENDER_CREATE_SOURCE.has(minor)
+    ) {
+      analysis.filters.delete(buf.readUInt32LE(base + 4));
+      return;
+    }
+    if (minor !== RENDER_SET_PICTURE_FILTER || len < base + 12) return;
+    const pid = buf.readUInt32LE(base + 4);
+    const nameLen = buf.readUInt16LE(base + 8);
+    const nameEnd = base + 12 + nameLen;
+    // any other filter — and a convolution whose parameters we cannot read —
+    // is one tap a pixel, i.e. exactly what compositePixels already prices
+    if (len < nameEnd) return;
+    const params = base + 12 + ((nameLen + 3) & ~3);
+    if (
+      buf.toString('latin1', base + 12, nameEnd) !== 'convolution' ||
+      len < params + 8
+    ) {
+      analysis.filters.delete(pid);
+      return;
+    }
+    // a convolution's first two FIXED parameters are the kernel's extent
+    const kw = Math.max(1, Math.round(buf.readInt32LE(params) / FIXED));
+    const kh = Math.max(1, Math.round(buf.readInt32LE(params + 4) / FIXED));
+    analysis.filters.set(pid, { taps: kw * kh, key: `${kw}x${kh}` });
+  };
+
+  /**
+   * A Composite, with the convolution its source and mask carry folded in.
+   * Priced here rather than in `convolvedPixels` because the filter is
+   * mutable state: by the end of the run the picture may carry a different
+   * kernel, or none, or belong to something else entirely.
+   */
+  const trackComposite = (op, minor, buf, base, len) => {
+    if (len - base !== 36) return;
+    let taps = 0;
+    const kernels = [];
+    if (
+      analysis.extNames.get(op) === 'RENDER' &&
+      minor === RENDER_COMPOSITE &&
+      analysis.filters.size
+    ) {
+      for (const [role, at] of [
+        ['src', 8],
+        ['mask', 12],
+      ]) {
+        const filter = analysis.filters.get(buf.readUInt32LE(base + at));
+        if (!filter) continue;
+        taps += filter.taps;
+        kernels.push(`${role} ${filter.key}`);
+      }
+    }
+    const w = buf.readUInt16LE(base + 32);
+    const h = buf.readUInt16LE(base + 34);
+    stats.composites.push([
+      op,
+      minor,
+      w,
+      h,
+      taps * w * h,
+      kernels.join(' + ') || null,
+    ]);
+  };
+
   const onRequest = (buf, len) => {
     const op = buf[0];
     const minor = buf[1];
@@ -340,6 +438,8 @@ export function countStream(inner, { record = false } = {}) {
       }
     }
     trackResource(op, minor, buf, base);
+    trackFilter(op, minor, buf, base, len);
+    trackComposite(op, minor, buf, base, len);
   };
 
   const onReply = (buf) => {
@@ -389,14 +489,6 @@ export function countStream(inner, { record = false } = {}) {
       if (len === 0 || outBuf.length < len) return;
       stats.requests += 1;
       stats.byOpcode.set(opcode, (stats.byOpcode.get(opcode) ?? 0) + 1);
-      if (len === 36) {
-        stats.composites.push([
-          opcode,
-          outBuf[1],
-          outBuf.readUInt16LE(32),
-          outBuf.readUInt16LE(34),
-        ]);
-      }
       onRequest(outBuf, len);
       outBuf = outBuf.subarray(len);
     }
@@ -560,12 +652,50 @@ export function compositePixels(stats, renderOpcode) {
   let px = 0;
   let n = 0;
   for (const [major, minor, w, h] of stats.composites) {
-    if (major === renderOpcode && minor === 8) {
+    if (major === renderOpcode && minor === RENDER_COMPOSITE) {
       px += w * h;
       n += 1;
     }
   }
   return { composites: n, pixels: px };
+}
+
+/**
+ * Multiply-accumulates inside those composites. `compositePixels` counts
+ * *area*, and by doing so assumes a destination pixel costs the same
+ * everywhere. A source or mask picture carrying RENDER's `convolution`
+ * filter breaks that assumption, and breaks it by orders of magnitude: the
+ * server re-runs the kernel on every composite that reads the picture, so
+ * one composite of a 65k-pixel surface is 65k taps or 244M depending on a
+ * piece of picture state neither the request count nor the area can see.
+ *
+ * That is not hypothetical — it is issue #413. A blurred `boxShadow` set the
+ * filter on a cached coverage surface instead of baking the blur into its
+ * pixels; every shadowed repaint re-convolved, ~700x slower on a real
+ * display, and requests, bytes, composites, area, stalls, dups, churn and
+ * the rendered pixels were all unchanged across the fix.
+ *
+ * `pixels` is the tap count — `kernel_w × kernel_h × area`, summed over the
+ * source and the mask when both are filtered — so it is directly comparable
+ * with `compositePixels`: equal means one tap a pixel, 3721x means a 61x61
+ * gaussian is running over every one of them.
+ */
+export function convolvedPixels(stats, renderOpcode) {
+  let taps = 0;
+  let n = 0;
+  const byKernel = new Map();
+  for (const [major, minor, , , price, kernel] of stats.composites) {
+    if (major !== renderOpcode || minor !== RENDER_COMPOSITE || !price)
+      continue;
+    taps += price;
+    n += 1;
+    byKernel.set(kernel, (byKernel.get(kernel) ?? 0) + 1);
+  }
+  return {
+    composites: n,
+    pixels: taps,
+    byKernel: [...byKernel.entries()].sort((a, b) => b[1] - a[1]),
+  };
 }
 
 export function summarize(stats, topOpcodes = 6) {

--- a/test/protocol-analysis.test.js
+++ b/test/protocol-analysis.test.js
@@ -18,11 +18,13 @@ import { dirname, join } from 'node:path';
 import { test } from 'node:test';
 
 import xserver from 'x11/lib/xserver/index.js';
-import { createClient, StaticFontSource } from 'ntk';
+import { createClient, StaticFontSource, Surface } from 'ntk';
 
 import {
   analysisMark,
   captureLines,
+  compositePixels,
+  convolvedPixels,
   countStream,
   windowAnalysis,
 } from '../scripts/bench/xcount.js';
@@ -250,6 +252,113 @@ test('RENDER create/free cycles churn as pictures', () => {
   assert.strictEqual(stats.analysis.churned[0].key, 'picture');
 });
 
+// --- filtered composites ------------------------------------------------
+
+const RENDER = 130;
+
+/** RENDER SetPictureFilter, packed the way node-x11 packs it. */
+function setPictureFilter(pid, name, params = []) {
+  const padded = (name.length + 3) & ~3;
+  const b = Buffer.alloc(12 + padded + params.length * 4);
+  b[0] = RENDER;
+  b[1] = 30;
+  b.writeUInt16LE(b.length / 4, 2);
+  b.writeUInt32LE(pid, 4);
+  b.writeUInt16LE(name.length, 8);
+  b.write(name, 12, 'latin1');
+  params.forEach((v, i) =>
+    b.writeInt32LE(Math.round(v * 65536), 12 + padded + i * 4),
+  );
+  return b;
+}
+
+/** RENDER Composite of `src` through `mask` onto `dst`, `w` x `h`. */
+function composite(src, mask, dst, w, h) {
+  const b = Buffer.alloc(36);
+  b[0] = RENDER;
+  b[1] = 8;
+  b.writeUInt16LE(9, 2);
+  b.writeUInt32LE(src, 8);
+  b.writeUInt32LE(mask, 12);
+  b.writeUInt32LE(dst, 16);
+  b.writeUInt16LE(w, 32);
+  b.writeUInt16LE(h, 34);
+  return b;
+}
+
+/** A 19x19 gaussian's worth of parameters — only the extent is read. */
+const kernel19 = [19, 19, ...Array(361).fill(1 / 361)];
+
+test('a convolution prices a composite by its kernel, not by its area', () => {
+  const { stream, stats } = started();
+  queryExtension(stream, 1, 'RENDER', RENDER);
+  stream.write(setPictureFilter(0x3001, 'convolution', kernel19));
+  stream.write(composite(0x3002, 0x3001, 0x3003, 40, 20)); // filtered mask
+  stream.write(composite(0x3002, 0, 0x3003, 40, 20)); // nothing filtered
+  // area cannot tell the two apart: same request, same rectangle
+  assert.deepStrictEqual(compositePixels(stats, RENDER), {
+    composites: 2,
+    pixels: 2 * 800,
+  });
+  const conv = convolvedPixels(stats, RENDER);
+  assert.strictEqual(conv.composites, 1);
+  assert.strictEqual(conv.pixels, 361 * 800);
+  assert.deepStrictEqual(conv.byKernel, [['mask 19x19', 1]]);
+});
+
+test('a filter on the source counts too, and both roles add up', () => {
+  const { stream, stats } = started();
+  queryExtension(stream, 1, 'RENDER', RENDER);
+  stream.write(setPictureFilter(0x3001, 'convolution', [3, 3, ...Array(9)]));
+  stream.write(composite(0x3001, 0, 0x3003, 10, 10));
+  stream.write(setPictureFilter(0x3002, 'convolution', [5, 5, ...Array(25)]));
+  stream.write(composite(0x3001, 0x3002, 0x3003, 10, 10));
+  const conv = convolvedPixels(stats, RENDER);
+  assert.strictEqual(conv.composites, 2);
+  assert.strictEqual(conv.pixels, 9 * 100 + (9 + 25) * 100);
+  assert.deepStrictEqual(conv.byKernel, [
+    ['src 3x3', 1],
+    ['src 3x3 + mask 5x5', 1],
+  ]);
+});
+
+test('the filter is picture state: it stops counting when it goes away', () => {
+  const { stream, stats } = started();
+  queryExtension(stream, 1, 'RENDER', RENDER);
+  const filtered = setPictureFilter(0x3001, 'convolution', kernel19);
+  const draw = () => stream.write(composite(0x3002, 0x3001, 0x3003, 40, 20));
+
+  stream.write(filtered);
+  draw();
+  // a plain resampling filter is one tap a pixel — already priced by area
+  stream.write(setPictureFilter(0x3001, 'bilinear'));
+  draw();
+  // FreePicture, then the recycled XID handed to a fresh unfiltered picture:
+  // node-x11 reuses ids, so a stale kernel would price the wrong surface
+  stream.write(filtered);
+  stream.write(req(RENDER, 7, [0x3001]));
+  draw();
+  stream.write(filtered);
+  stream.write(req(RENDER, 4, [0x3001, 0x2001, 0x11, 0])); // CreatePicture
+  draw();
+
+  const conv = convolvedPixels(stats, RENDER);
+  assert.strictEqual(conv.composites, 1);
+  assert.strictEqual(conv.pixels, 361 * 800);
+});
+
+test('a 1x1 convolution is one tap a pixel: filtered, but not costly', () => {
+  const { stream, stats } = started();
+  queryExtension(stream, 1, 'RENDER', RENDER);
+  // ntk sends this for a zero-radius blur — a filter, so the server's
+  // unfiltered fast path is off, but the same work per pixel as no filter
+  stream.write(setPictureFilter(0x3001, 'convolution', [1, 1, 1]));
+  stream.write(composite(0x3002, 0x3001, 0x3003, 40, 20));
+  const conv = convolvedPixels(stats, RENDER);
+  assert.strictEqual(conv.composites, 1);
+  assert.strictEqual(conv.pixels, compositePixels(stats, RENDER).pixels);
+});
+
 // --- GenericEvent framing ----------------------------------------------
 
 test('a long GenericEvent does not desync the reply parser', () => {
@@ -336,6 +445,54 @@ test('the analyzer prices real node-x11 traffic', async () => {
     assert.deepStrictEqual(windowed.dupsBy, [['InternAtom', 1]]);
     const churn = new Map(windowed.churnBy);
     assert.strictEqual(churn.get('pixmap 32x16x24'), 1);
+  } finally {
+    await app.close();
+  }
+});
+
+test('a real blurred shadow is priced by its kernel, not by its box', async () => {
+  const server = xserver.createServer({ width: 200, height: 200 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const { stats } = countStream(clientEnd);
+  const app = await createClient({
+    stream: clientEnd,
+    fontSource: new StaticFontSource(),
+  });
+  try {
+    const render = app.display.Render.majorOpcode;
+    // exactly what a blurred `boxShadow` did (src/nodes.js): coverage in an
+    // a8 surface, the blur set on its *picture*, painted through a colour.
+    // The parse has to survive node-x11's own SetPictureFilter packing —
+    // padded name, 16.16 FIXED parameters — which is why this runs against
+    // the real client rather than hand-built bytes.
+    const shadow = new Surface(app, { width: 32, height: 16, format: 'a8' });
+    shadow.render((ctx) => {
+      ctx.fillStyle = '#ffffff';
+      ctx.fillRect(0, 0, 32, 16);
+    });
+    shadow.picture().setBlurFilter(19, 9.5);
+    const dst = new Surface(app, { width: 64, height: 64 });
+    const mark = { composites: stats.composites.length };
+    dst.render((ctx) => {
+      ctx.fillStyle = '#000000';
+      ctx.drawImage(shadow, 0, 0);
+    });
+    await new Promise((resolve) => app.X.GetInputFocus(resolve));
+
+    const drawn = { composites: stats.composites.slice(mark.composites) };
+    const area = compositePixels(drawn, render);
+    const conv = convolvedPixels(drawn, render);
+    // ntk stages the tinted coverage, so the shadow is two composites of the
+    // surface — one of which reads it through the convolution
+    assert.strictEqual(area.pixels, area.composites * 32 * 16);
+    assert.strictEqual(conv.composites, 1);
+    assert.deepStrictEqual(conv.byKernel, [['mask 19x19', 1]]);
+    // the whole point: 36 bytes and 512 pixels on the wire either way, and
+    // 361 multiply-accumulates per pixel behind them
+    assert.strictEqual(conv.pixels, 361 * 32 * 16);
+    shadow.destroy();
+    dst.destroy();
   } finally {
     await app.close();
   }


### PR DESCRIPTION
`compositePixels` counts *area*, and by doing so assumes a destination pixel costs the same everywhere. RENDER's `convolution` filter breaks that assumption: a filter is picture **state**, re-applied by the server on every composite that reads the picture, so one composite of a 65k-pixel surface is 65k multiply-accumulates or 244M depending on a piece of state neither the request count nor the area looks at.

That is #413. A blurred `boxShadow` set the blur on its cached coverage picture instead of baking it into the pixels; every shadowed repaint re-convolved — 1586ms for one card's `:hover` on XQuartz against 1.5ms once baked — and requests, bytesOut, composites, compositePixels, replies, stalls, dupQueries, churn, the paint-cache statistics and the rendered pixels were all unchanged across the fix. `npm run bench -- --check` said "no regressions against the baseline" on both sides of a ~700x change.

## What this does

Follow the state. `scripts/bench/xcount.js` now tracks the live convolution kernel per picture — set by `SetPictureFilter`, cleared on `FreePicture` and on any picture create, because node-x11 recycles XIDs — and prices each `Composite` at `kernel_w × kernel_h × area`, summed over its source **and** its mask. The mask half is not optional: a blurred shadow is a8 coverage painted through a colour, so the filtered picture arrives as the mask, not the source.

Two metrics fall out, both gated like `compositePixels`:

- **`convolvedPixels`** — a `convMpx` column beside `Mpx`. Equal to `Mpx` means nothing is filtered; 361x means a 19x19 gaussian is running over every pixel.
- **`filteredComposites`** — how many composites carry a filter at all, which is what makes `convMpx` readable.

`--hotspots` names the kernels: `convolved  mask 19x19 ×120`.

## What the table says now

On master today, `shapes: 24 gradient+shadow cards, 5 full repaints`:

```
scenario                                 reqs  bytesOut  replies  composites      Mpx   convMpx  stalls  dupQ  churn
shapes: 24 gradient+shadow cards, ...     381    475564       11         245     2.02    277.25       1     0      0
```

2.02 Mpx composited, **277.25 Mpx convolved** — 137x. That is 120 shadow composites, each reading its coverage through a live 19x19 filter, 361 taps a pixel. #412 takes that column to `0.00` with every other number in the row unmoved, which is precisely the one-line diff the issue asked for.

The baseline is a pure addition — only the two new keys were merged into `scripts/bench/baseline.json`, every committed number left alone, so this PR locks in nothing and absorbs no drift. `--check` passes before and after.

## Tests

`test/protocol-analysis.test.js`, in the two layers that file already uses:

- Synthetic wire bytes for each rule: a kernel prices by taps rather than area; a filter on the source counts and both roles add up; a 1x1 convolution is one tap a pixel, filtered but not costly; and the filter stops counting when it is replaced by a plain resampling filter, freed, or its XID handed to a fresh picture.
- Against the real client and server: an ntk `Surface` with `setBlurFilter`, drawn through a colour exactly the way `_paintBlurredShadow` does it — so the parse is pinned against node-x11's own `SetPictureFilter` packing, padded name and 16.16 FIXED parameters, rather than against bytes I hand-built to match my own parser.

Mutation-checked: dropping the mask role, ignoring the FIXED scale, or not clearing on `FreePicture` each fail.

## Also

- `AGENTS.md` and `docs/architecture/protocol-efficiency.md` — the two assumptions, area and taps, and why both get away from you.
- A comment on the shapes scenario itself, so the 277 Mpx in the table has its explanation next to it.

Closes #413
