### PR TITLE
feat(desktop): an off switch for the bus-backed followers, and no blocking spawn before the first frame

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -380,6 +380,19 @@ Environment switches, in priority order:
   `react-x11/test` sets it, so a test run on a desktop does not parade
   phantom applications through a running screen reader.
 
+And one that is not environmental, for an app that has to turn the bridge off
+for itself without setting a variable every child process will inherit:
+
+```jsx
+await createRoot({ desktop: { a11y: false } });
+```
+
+It outranks every switch above, `REACT_X11_A11Y=1` included — see
+[desktop.md](desktop.md#turning-the-desktop-off), where `desktop: false` turns
+this off along with the other two integrations that talk to the session bus.
+Pass it on the first root: the climb happens once per process, and a second
+root's switch cannot unstart a bridge that is already up.
+
 A dead accessibility bus is not redialled — the same contract as
 [dbus.md](dbus.md): the app simply stops being accessible until restarted.
 

--- a/docs/appearance.md
+++ b/docs/appearance.md
@@ -243,6 +243,19 @@ socket goes back to `unref()`d: an app whose windows have closed still exits,
 and an app with a window on screen is awake anyway and gets the signal. The
 macOS child is spawned `unref()`d and killed on exit.
 
+### Not climbing it at all
+
+```jsx
+await createRoot({ desktop: { appearance: false } });
+```
+
+For an app that owns its palette, an embedder that follows the desktop its own
+way, and a test that needs the same answer on every machine. The ladder does
+not run and **the remembered answer is not read either**: `colorScheme` stays
+`'no-preference'` with `source: null`, which means use your own default. See
+[desktop.md](desktop.md#turning-the-desktop-off) — `desktop: false` turns this
+off along with the other two integrations that talk to the session bus.
+
 ## What each rung can actually answer
 
 |                 | portal                               | XSETTINGS           | macOS |

--- a/docs/dbus.md
+++ b/docs/dbus.md
@@ -129,6 +129,16 @@ would win? The address seam is D-Bus's own, `$DBUS_SESSION_BUS_ADDRESS`, plus
 an `$XDG_RUNTIME_DIR/bus` fallback until
 [dbus-native#389](https://github.com/sidorares/dbus-native/pull/389) lands.
 
+On **macOS** there is a third source and it is not a variable: D-Bus
+advertises the socket through launchd, and finding it means running
+`launchctl getenv`. That lookup is asynchronous and happens once per process,
+which is the whole of
+[#417](https://github.com/sidorares/react-x11/issues/417) — `dbus-native`
+would otherwise do it from a synchronous constructor with `spawnSync`, and
+120–150 ms of blocked event loop in front of the first frame is not a price
+for finding out whether there is a bus. See
+[desktop.md](desktop.md#not-blocking-the-first-frame-on-the-bus).
+
 ## One connection, on purpose
 
 `dbus-native`'s own `sessionBus()` is a constructor in disguise: every call

--- a/docs/desktop.md
+++ b/docs/desktop.md
@@ -1,9 +1,9 @@
 # Desktop integration
 
 What an app has to tell the desktop about itself, beyond drawing. Today that
-is startup notification, which is on by default and has nothing to call, and
-what a password field has to do to be reachable by the desktop's password
-managers.
+is startup notification, which is on by default and has nothing to call, what
+a password field has to do to be reachable by the desktop's password managers,
+and the one switch that turns off everything here that talks over D-Bus.
 
 The menu bar is the other half of this and has a page of its own —
 [globalmenu.md](globalmenu.md) — because on a desktop that shows application
@@ -154,6 +154,72 @@ it. On X11 that is the pre-existing no-isolation story rather than a new
 exposure — see [security.md](security.md) — but it is the reason the
 messages carry the id the launcher gave us and nothing invented, and the
 reason the variable's value is never logged.
+
+## Turning the desktop off
+
+Three things react-x11 turns on for you reach the **session bus**, and none
+of them was asked for:
+
+|              |                                                                         |                                      |
+| ------------ | ----------------------------------------------------------------------- | ------------------------------------ |
+| `appearance` | following the desktop's light/dark, accent, contrast and reduced motion | [appearance.md](appearance.md)       |
+| `a11y`       | the AT-SPI bridge — whether a screen reader can see the app             | [accessibility.md](accessibility.md) |
+| `globalMenu` | a `MenuBar` handing its menu to the panel instead of drawing it         | [globalmenu.md](globalmenu.md)       |
+
+Each is the right default: an app that follows the desktop looks like it
+belongs there, one a screen reader can read is one more person can use, and a
+menu in the panel is what the panel is for. But sooner or later an embedder
+owns the thing we assumed was ours, and until
+[#417](https://github.com/sidorares/react-x11/issues/417) the only way out was
+an **environment variable** — `NO_AT_BRIDGE=1`,
+`REACT_X11_NO_GLOBAL_MENU=1`, or unsetting `DBUS_SESSION_BUS_ADDRESS`. That is
+a seam an app cannot reach for itself: the environment is inherited, so
+setting one before `createRoot()` sets it for every child process too, and the
+D-Bus one takes the portals and the app's own exported services down with the
+follower.
+
+```jsx
+await createRoot({ desktop: false }); // none of the three
+await createRoot({ desktop: { appearance: false } }); // just that one
+```
+
+With all three off, **nothing dials the session bus at startup** — no
+connection, no subprocess, no portal probe. That is the shape an embedder
+wants, and a kiosk, and a test that needs the same answer on every machine.
+
+Turning `appearance` off means the app draws in its own palette rather than
+the desktop's: `useSystemAppearance()` reports `'no-preference'` with
+`source: null`, and the remembered answer on disk is not read either — an
+opted-out app that started in whatever colours the machine was in last time
+would be the opposite of what the switch is for.
+
+**Off is process-wide, and it latches.** There is one desktop, one D-Bus
+identity and one AT-SPI bridge per process, so the policy cannot honestly be
+per-root: a second root turning back on what the first turned off would be a
+bug rather than a feature. Nothing turns an integration back on, and a
+feature already started stays started — pass this on the first root.
+
+## Not blocking the first frame on the bus
+
+Worth knowing because it is invisible when it works, and was worth ~150 ms
+when it did not.
+
+On macOS the session bus address is not in the environment; D-Bus advertises
+it through **launchd**, and finding it means running `launchctl getenv`.
+`dbus-native`'s entry point is synchronous, so it has to do that with
+`spawnSync` — 120–150 ms of _blocked event loop_ on a cold page cache, landing
+in front of the X handshake, the layout engine's WebAssembly and the first
+paint, all so the accessibility bridge could find out there was nothing to
+connect to.
+
+Every dial now goes through one asynchronous, once-per-process lookup instead,
+and hands `dbus-native` a resolved `unix:path=…`. The same wall clock is
+spent, none of it on the loop: the handshake and the layout engine run
+straight through it. There is nothing to configure — it is the same address,
+found the same way, off the critical path.
+
+Linux is unaffected: `$DBUS_SESSION_BUS_ADDRESS` or `$XDG_RUNTIME_DIR/bus`
+answers without a subprocess, and always did.
 
 ## Password fields and password managers
 

--- a/docs/globalmenu.md
+++ b/docs/globalmenu.md
@@ -160,9 +160,17 @@ attaches to the live registrar rather than competing for the name.
 REACT_X11_NO_GLOBAL_MENU=1
 ```
 
-The prop is for one bar; the environment variable is process-wide and needs no
-application change, which is what an embedder that owns the toplevel — or a
-user working around a panel that renders something badly — actually has.
+```jsx
+await createRoot({ desktop: { globalMenu: false } });
+```
+
+The prop is for one bar. The other two are process-wide: the environment
+variable needs no application change, which is what a user working around a
+panel that renders something badly actually has, and the `createRoot` option
+is the one an embedder can reach without also setting it for every child
+process it spawns — see [desktop.md](desktop.md#turning-the-desktop-off),
+where `desktop: false` turns this off along with the other two integrations
+that talk to the session bus.
 
 ## Drawing your own bar
 

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -53,6 +53,7 @@ import { endIdle } from './idle.js';
 import { endKeyboardState } from './keyboardstate.js';
 import { endXSettings } from './xsettings.js';
 import { watchAppearance } from './appearance.js';
+import { setDesktopIntegration } from './desktopintegration.js';
 import { ForeignNode } from './foreignnodes.js';
 import { GlAreaNode } from './glnodes.js';
 import { createRegisteredNode, registeredElements } from './registry.js';
@@ -605,6 +606,12 @@ function watchConnection(app, onDisconnect, deliberate) {
  *
  * `display`, `fontSource`, `glxVisual` and `onXError` go straight to ntk.
  * Anything else ntk understands, build the client yourself and pass `app`.
+ *
+ * `desktop: false` turns off the three things this turns on for you that talk
+ * to the session bus — the appearance ladder, the accessibility bridge and
+ * the global menu — for an embedder that owns them, or a process that must
+ * not fork. `desktop: { appearance: false }` names one. See
+ * src/desktopintegration.js and docs/desktop.md.
  */
 export async function createRoot(options = {}) {
   // Before anything builds a node: every drawn node creates a yoga node in
@@ -627,6 +634,11 @@ export async function createRoot(options = {}) {
   }
   const { app: borrowed, onDisconnect, ...rest } = options;
   const owned = borrowed === undefined;
+  // Before anything starts, for two reasons: a bad `desktop` shape must throw
+  // with nothing in flight, like the check above it — and `startA11y()` below
+  // reads this policy, so it has to be settled before the first await, not
+  // after (src/desktopintegration.js).
+  setDesktopIntegration(rest.desktop);
   // The connection is started first, and the order is the point rather than a
   // detail. `loadLayout()` is only nominally asynchronous: instantiating the
   // engine blocks the event loop for 15-50 ms before it returns its promise

--- a/src/a11y.js
+++ b/src/a11y.js
@@ -40,6 +40,10 @@
 //     from gi.repository import Atspi; \
 //     print({k: int(getattr(Atspi.Role, k)) for k in dir(Atspi.Role) if not k.startswith('_')})"
 
+// The one import, and it keeps this file's promise: a `Set` and two functions
+// over it, with no D-Bus, no node builtins and nothing at module scope.
+import { desktopIntegrationEnabled } from './desktopintegration.js';
+
 /** AT-SPI role numbers (AtspiRole). */
 export const ATSPI_ROLE = Object.freeze({
   INVALID: 0,
@@ -1245,6 +1249,10 @@ let startPromise = null;
  * tests are exactly this case.
  */
 function a11yEnabled() {
+  // `createRoot({ desktop: false })` outranks every environment variable,
+  // including the one that forces the climb: it is the embedder saying this
+  // process does not talk to the desktop (src/desktopintegration.js, #417).
+  if (!desktopIntegrationEnabled('a11y')) return false;
   const own = process.env.REACT_X11_A11Y;
   if (own === '0') return false;
   if (own) return true;

--- a/src/appearance.js
+++ b/src/appearance.js
@@ -57,6 +57,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { sessionBus } from './bus.js';
+import { desktopIntegrationEnabled } from './desktopintegration.js';
 import { PORTAL_NAME, PORTAL_PATH } from './portal.js';
 import { beginXSettings, watchXSettings, xsettings } from './xsettings.js';
 
@@ -238,6 +239,12 @@ function sanitize(saved) {
 function load() {
   if (cacheChecked) return;
   cacheChecked = true;
+  // `createRoot({ desktop: false })` means this process does not follow the
+  // desktop, and that has to include the remembered answer: seeding from the
+  // cache would leave an app that opted out drawing in whatever colours this
+  // machine happened to be in last time, which is the opposite of the
+  // determinism the switch is asked for (#417).
+  if (!desktopIntegrationEnabled('appearance')) return;
   const file = cacheFile();
   if (!file) return;
   try {
@@ -702,6 +709,10 @@ async function runLadder(app) {
  */
 export function systemAppearance(options = {}) {
   if (owner) return Promise.resolve(snapshot);
+  // Turned off, so there is nothing to climb and nothing to remember: the
+  // defaults, which is a real answer — `'no-preference'` means *use your own*
+  // (src/desktopintegration.js).
+  if (!desktopIntegrationEnabled('appearance')) return Promise.resolve(NOTHING);
   load();
   if (!probe) {
     // **Failure is not cached**, for the same reason `bus.js` does not cache

--- a/src/atspi.js
+++ b/src/atspi.js
@@ -32,7 +32,7 @@
 // resurrected: the slots are cleared and the app simply stops being
 // accessible until restarted, the same contract bus.js documents.
 
-import { addressFor, loadTransport } from './bus.js';
+import { loadTransport, resolveAddress } from './bus.js';
 import {
   hooks,
   ATSPI_ROLE,
@@ -1818,8 +1818,11 @@ async function connected(bus) {
  */
 async function accessibilityBusAddress(dbus) {
   if (process.env.AT_SPI_BUS_ADDRESS) return process.env.AT_SPI_BUS_ADDRESS;
-  const busAddress = addressFor('session');
-  if (!busAddress && process.platform !== 'darwin') return null;
+  // Resolved, not read: on macOS this is where the session bus address comes
+  // from, and letting `dbus-native` find it for itself would be a blocking
+  // `spawnSync` on the way to the first frame (#417).
+  const busAddress = await resolveAddress('session');
+  if (!busAddress) return null;
   let sbus = null;
   try {
     sbus = dbus.createClient({ busAddress });

--- a/src/bus.js
+++ b/src/bus.js
@@ -135,9 +135,8 @@ export async function loadTransport() {
  * address is incoherent under sharing. Two callers, two addresses, one
  * socket — which would win? Tests use this same seam.
  *
- * Not public, but exported for atspi.js, whose one-shot discovery probe
- * dials its own short-lived connection rather than the shared one — see
- * the note in `accessibilityBusAddress`.
+ * Synchronous, and so it cannot answer on macOS — see `resolveAddress`,
+ * which is what every dial goes through.
  */
 export function addressFor(kind) {
   if (kind === 'system') {
@@ -149,21 +148,102 @@ export function addressFor(kind) {
   if (process.env.DBUS_SESSION_BUS_ADDRESS) {
     return process.env.DBUS_SESSION_BUS_ADDRESS;
   }
-  // macOS advertises the session bus through launchd, which dbus-native
-  // already falls back to on its own. Leave it undefined and let it.
+  // macOS advertises the session bus through launchd rather than through the
+  // environment, and asking launchd is a subprocess — see `launchdAddress`.
   if (process.platform === 'darwin') return undefined;
   const runtimeDir = process.env.XDG_RUNTIME_DIR;
   return runtimeDir ? `unix:path=${runtimeDir}/bus` : undefined;
 }
 
+/**
+ * The in-flight or settled lookup, shared by every dial in the process.
+ *
+ * **Failure is cached here**, which is the one place in this module where it
+ * is — and the exception is deliberate. A session bus can genuinely appear
+ * under `$XDG_RUNTIME_DIR` mid-run, so that answer is never remembered; what
+ * launchd exports is a *login session* fact, set when the bus is installed
+ * and started, which does not happen under a running app. Re-asking would be
+ * a fork per feature probe to learn the same "no".
+ */
+let launchd = null;
+
+/**
+ * Ask launchd where the session bus is, **without blocking the event loop**.
+ *
+ * This is the whole reason `resolveAddress` exists (#417). `dbus-native` will
+ * do this lookup itself, from `createStream`, with `spawnSync` — it has to,
+ * because its own entry point is synchronous — and a fork+exec of `launchctl`
+ * on a cold page cache costs 120–150 ms of *blocked loop*, measured. Landing
+ * that inside `createRoot()` stalls the X handshake, the yoga instantiate and
+ * the first paint behind a question about the colour scheme.
+ *
+ * Every caller here is already asynchronous, so the same lookup done with
+ * `execFile` costs the same wall clock and none of the loop: the handshake
+ * and the layout engine run through it. Handing `dbus-native` the resolved
+ * `unix:path=…` is then what keeps it off its own synchronous path.
+ *
+ * The variable name is D-Bus's, and the fallback to our own environment is
+ * `launchdSocketPath`'s: a process launched from a shell that has it already
+ * knows the answer.
+ */
+function launchdAddress() {
+  if (launchd) return launchd;
+  launchd = (async () => {
+    const VAR = 'DBUS_LAUNCHD_SESSION_BUS_SOCKET';
+    let fromLaunchd = '';
+    try {
+      const { execFile } = await import('node:child_process');
+      fromLaunchd = await new Promise((resolve) => {
+        execFile(
+          'launchctl',
+          ['getenv', VAR],
+          { encoding: 'utf8' },
+          (err, stdout) => resolve(err ? '' : String(stdout).trim()),
+        );
+      });
+    } catch {
+      // no `launchctl` on $PATH, or no child processes to be had at all
+    }
+    const socket = fromLaunchd || process.env[VAR] || '';
+    return socket ? `unix:path=${socket}` : undefined;
+  })();
+  return launchd;
+}
+
+/**
+ * Where to dial, resolved — the synchronous sources first, and launchd only
+ * where they have nothing to say.
+ *
+ * Not public, but exported for atspi.js, whose one-shot discovery probe
+ * dials its own short-lived connection rather than the shared one — see the
+ * note in `accessibilityBusAddress`. It matters that it goes through here
+ * too: two dials that each let `dbus-native` ask launchd are two blocking
+ * forks, and the answer is the same both times.
+ *
+ * @param {BusKind} kind
+ * @returns {Promise<string | undefined>}
+ */
+export async function resolveAddress(kind) {
+  const direct = addressFor(kind);
+  if (direct !== undefined) return direct;
+  if (kind !== 'session' || process.platform !== 'darwin') return undefined;
+  return await launchdAddress();
+}
+
 function noAddressError(kind) {
+  if (kind !== 'session') {
+    return new Error(
+      'react-x11: no system bus address. $DBUS_SYSTEM_BUS_ADDRESS is unset ' +
+        'and there is no default.',
+    );
+  }
   return new Error(
-    `react-x11: no ${kind} bus address. ` +
-      (kind === 'session'
-        ? '$DBUS_SESSION_BUS_ADDRESS is unset and $XDG_RUNTIME_DIR is not ' +
-          'set either, which is normal over ssh, under a bare startx and in ' +
-          'most containers.'
-        : '$DBUS_SYSTEM_BUS_ADDRESS is unset and there is no default.'),
+    'react-x11: no session bus address. $DBUS_SESSION_BUS_ADDRESS is unset ' +
+      (process.platform === 'darwin'
+        ? 'and launchd has no $DBUS_LAUNCHD_SESSION_BUS_SOCKET either, which ' +
+          'is normal on a Mac with no D-Bus installed.'
+        : 'and $XDG_RUNTIME_DIR is not set either, which is normal over ssh, ' +
+          'under a bare startx and in most containers.'),
   );
 }
 
@@ -216,8 +296,11 @@ async function connect(kind, generation) {
     return fail(noTransportError(cause));
   }
 
-  const busAddress = addressFor(kind);
-  if (!busAddress && process.platform !== 'darwin') {
+  // Resolved rather than read, so `dbus-native` never reaches its own
+  // `spawnSync` fallback on macOS (#417) — and so "this Mac has no D-Bus"
+  // fails here, before a socket is dialled, instead of inside a constructor.
+  const busAddress = await resolveAddress(kind);
+  if (!busAddress) {
     return fail(noAddressError(kind));
   }
 
@@ -538,6 +621,10 @@ export function busRefs(kind) {
  * exported object survives into the next test.
  */
 export function _resetBusState() {
+  // Including what launchd said: a suite that pins `process.platform` would
+  // otherwise inherit the answer — or the absence of one — from a case that
+  // ran under a different one.
+  launchd = null;
   for (const kind of KINDS) {
     state[kind] = newState(kind, state[kind].generation + 1);
     notify(kind);

--- a/src/desktopintegration.js
+++ b/src/desktopintegration.js
@@ -1,0 +1,98 @@
+// Whether this process talks to the desktop at all — the `desktop` option on
+// `createRoot()`, and the one place that decides what it covers.
+//
+// ## What is in the group and why
+//
+// Three things react-x11 turns on for you without being asked, and all three
+// reach the session bus:
+//
+//   `appearance`  the light/dark, accent, contrast and reduced-motion ladder
+//                 (src/appearance.js) — the settings portal, then macOS, then
+//                 XSETTINGS
+//   `a11y`        the AT-SPI bridge, started from `createRoot()`
+//                 (src/a11y.js, docs/accessibility.md)
+//   `globalMenu`  a `MenuBar` handing its menu to the panel instead of drawing
+//                 it (src/globalmenu.js, docs/globalmenu.md)
+//
+// Each already had an off switch and each of those was an **environment
+// variable** — `REACT_X11_A11Y=0`, `NO_AT_BRIDGE=1`,
+// `REACT_X11_NO_GLOBAL_MENU=1`, or unsetting `DBUS_SESSION_BUS_ADDRESS` for
+// the appearance ladder. That is a seam an app cannot reach for itself: the
+// environment is inherited, so a process that sets one before `createRoot()`
+// has also set it for every child it spawns, and the D-Bus one turns off the
+// portals and the app's own services along with the follower. AGENTS.md asks
+// for the off switch to be somewhere the embedder can actually stand.
+//
+// ## Why the policy is process-wide when the option is per-root
+//
+// Because so is the thing it describes. There is one desktop, one D-Bus
+// identity, and one AT-SPI bridge per process — `startA11y()` says so in its
+// name, and appearance.js says so in its header. A per-root flag over
+// process-wide state would be a seam that reads as finer than it is.
+//
+// So **off wins, and off latches.** A root that says `desktop: false` is a
+// root with a constraint — an embedder that owns the toplevel, a test, a
+// daemon that must not fork — and a second root quietly turning the feature
+// back on for it would be the bug. Turning something back *on* is a thing
+// this module deliberately cannot do.
+//
+// The one honest limit: a feature already started stays started. `startA11y()`
+// is memoised per process, so a second root's `desktop: false` stops the next
+// climb and not the bridge that is already up. Pass it on the first root.
+
+/** @typedef {'appearance'|'a11y'|'globalMenu'} DesktopFeature */
+
+/** @type {DesktopFeature[]} */
+const FEATURES = ['appearance', 'a11y', 'globalMenu'];
+
+/** What has been turned off, for the life of the process. */
+const off = new Set();
+
+/**
+ * Apply a root's `desktop` option. Not public — `createRoot({ desktop })` is
+ * the public shape.
+ *
+ * `undefined` is the default and means every feature stays on; `false` turns
+ * all of them off; an object names them one at a time, and a key left out is
+ * left alone.
+ *
+ * @param {boolean | Partial<Record<DesktopFeature, boolean>> | undefined} desktop
+ */
+export function setDesktopIntegration(desktop) {
+  if (desktop === undefined || desktop === true) return;
+  if (desktop === false) {
+    for (const feature of FEATURES) off.add(feature);
+    return;
+  }
+  if (typeof desktop !== 'object') {
+    throw new TypeError(
+      'react-x11: createRoot({ desktop }) takes false or an object of ' +
+        `${FEATURES.map((f) => `${f}: false`).join(', ')} — got ` +
+        `${JSON.stringify(desktop)}.`,
+    );
+  }
+  for (const [feature, on] of Object.entries(desktop)) {
+    if (!FEATURES.includes(/** @type {DesktopFeature} */ (feature))) {
+      throw new TypeError(
+        `react-x11: createRoot({ desktop: { ${feature} } }) — no such ` +
+          `desktop integration. Expected ${FEATURES.join(', ')}.`,
+      );
+    }
+    if (on === false) off.add(feature);
+  }
+}
+
+/**
+ * Whether a feature may run. Every one of the three asks this first, ahead of
+ * its own environment variable, so `desktop: false` is the outermost answer.
+ *
+ * @param {DesktopFeature} feature
+ */
+export function desktopIntegrationEnabled(feature) {
+  return !off.has(feature);
+}
+
+/** Test seam, not public: forget the latch. */
+export function _resetDesktopIntegration() {
+  off.clear();
+}

--- a/src/globalmenu.js
+++ b/src/globalmenu.js
@@ -57,6 +57,7 @@
 import { useEffect, useRef, useState } from 'react';
 
 import { loadTransport, sessionBus } from './bus.js';
+import { desktopIntegrationEnabled } from './desktopintegration.js';
 import {
   DBUSMENU_IFACE,
   PROPERTY_TYPES,
@@ -126,6 +127,10 @@ const menuPathFor = (xid) => `/com/react_x11/menus/${xid}`;
  * it is the one that works without touching application code.
  */
 function globalMenuEnabled() {
+  // `createRoot({ desktop: false })` first: handing the menu to a panel is
+  // one of the three things core turns on for you, and that is the switch
+  // that turns the group off (src/desktopintegration.js, #417).
+  if (!desktopIntegrationEnabled('globalMenu')) return false;
   const flag = process.env.REACT_X11_NO_GLOBAL_MENU;
   return !flag || flag === '0';
 }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -298,6 +298,43 @@ export interface RootOptions {
    * and coming back is the user's own Tab.
    */
   restoreFocusOnReveal?: boolean;
+  /**
+   * Whether this process talks to the desktop over D-Bus. On by default, and
+   * `false` turns off all three things react-x11 starts for you (#417,
+   * docs/desktop.md):
+   *
+   * | | |
+   * | --- | --- |
+   * | `appearance` | following the desktop's light/dark, accent, contrast and reduced motion (docs/appearance.md) |
+   * | `a11y` | the AT-SPI bridge that makes the app reachable by a screen reader (docs/accessibility.md) |
+   * | `globalMenu` | a `MenuBar` handing its menu to the panel instead of drawing it (docs/globalmenu.md) |
+   *
+   * ```js
+   * await createRoot({ desktop: false });                  // none of it
+   * await createRoot({ desktop: { appearance: false } });  // just that one
+   * ```
+   *
+   * For an embedder that owns those integrations itself, a kiosk or daemon
+   * that must not fork a subprocess to find the bus, and a test that wants
+   * one answer on every machine. With all three off nothing dials the
+   * session bus at startup.
+   *
+   * **Off is process-wide and it latches.** There is one desktop and one
+   * D-Bus identity per process, so a second root cannot turn back on what
+   * another turned off — and a feature already started stays started, so
+   * pass this on the first root.
+   */
+  desktop?: boolean | DesktopIntegrationOptions;
+}
+
+/** Which desktop integrations run. See {@link CreateRootOptions.desktop}. */
+export interface DesktopIntegrationOptions {
+  /** Follow the desktop's light/dark, accent, contrast and reduced motion. */
+  appearance?: boolean;
+  /** The AT-SPI bridge — whether a screen reader can see this app. */
+  a11y?: boolean;
+  /** Whether a `MenuBar` hands its menu to the panel. */
+  globalMenu?: boolean;
 }
 
 export interface ComposeOptions {

--- a/test/bus.test.js
+++ b/test/bus.test.js
@@ -7,7 +7,6 @@
 // session, a container, CI, a Node 20 install with no transport at all.
 import { test, describe } from 'node:test';
 import assert from 'node:assert';
-import { execFile } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import fs from 'node:fs/promises';
 import os from 'node:os';
@@ -17,12 +16,14 @@ import React from 'react';
 import {
   BusUnavailableError,
   closeBus,
+  resolveAddress,
   sessionBus,
   systemBus,
   _resetBusState,
 } from '../src/bus.js';
 import { useSessionBus } from '../src/bushooks.js';
 import { act, cleanup, renderX11 } from '../src/testing/index.js';
+import { runScript } from './helpers/run-script.js';
 import {
   startBroker,
   stopBroker,
@@ -32,7 +33,6 @@ import {
 } from './helpers/with-bus.js';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
-const repo = path.join(here, '..');
 
 // On Node 20 npm skips `dbus-native` (its own engines field is >=22.12), which
 // is the degradation this layer is designed around rather than a problem to
@@ -42,28 +42,6 @@ const haveTransport = await transportAvailable();
 const needsBroker = haveTransport
   ? {}
   : { skip: 'dbus-native is not installed (expected on Node < 22.12)' };
-
-function run(args, env = {}, timeout = 20000) {
-  return new Promise((resolve) => {
-    const child = execFile(
-      process.execPath,
-      args,
-      { cwd: repo, env: { ...process.env, ...env }, timeout },
-      (error, stdout, stderr) =>
-        resolve({ code: error?.code ?? 0, error, stdout, stderr }),
-    );
-    child.on('error', () => {});
-  });
-}
-
-/** Run a snippet of ESM in a child process, from the repo root. */
-function runScript(source, env = {}, nodeArgs = [], timeout) {
-  return run(
-    [...nodeArgs, '--input-type=module', '--eval', source],
-    env,
-    timeout,
-  );
-}
 
 /**
  * Poll a rendering condition, flushing React's queue between attempts.
@@ -683,5 +661,165 @@ describe('the hooks', { ...needsBroker }, () => {
         await cleanup();
       },
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe('finding the address without blocking the loop (#417)', () => {
+  // macOS keeps the session bus socket in launchd's environment rather than in
+  // ours, and `dbus-native` looks it up from `createStream` — which is
+  // synchronous, so it has to use `spawnSync`. A fork+exec of `launchctl` on a
+  // cold page cache is 120-150 ms of *blocked event loop*, and `createRoot()`
+  // put it in front of the X handshake, the layout engine and the first paint.
+  //
+  // The fix is that every dial goes through `resolveAddress()`, which asks
+  // asynchronously and once. These tests pin both halves: nothing here is
+  // synchronous, and the answer is not asked for twice.
+
+  /**
+   * Run `fn` as if on a Mac with no D-Bus in the environment, counting what
+   * `child_process` was asked to do.
+   *
+   * `syncBuiltinESMExports()` is what makes the patch visible to
+   * `await import('node:child_process')` inside src/bus.js — the ESM named
+   * exports of a builtin are bound at instantiation and only re-read on that
+   * call.
+   */
+  async function onFakeDarwin(fn) {
+    const nodeModule = await import('node:module');
+    // The *CommonJS* exports object: an ESM namespace is frozen, and this is
+    // also the object `dbus-native` reaches through `require`.
+    const cp = nodeModule.createRequire(import.meta.url)('node:child_process');
+    const real = { spawnSync: cp.spawnSync, execFile: cp.execFile };
+    const calls = { spawnSync: [], execFile: [] };
+    const saved = {
+      platform: process.platform,
+      address: process.env.DBUS_SESSION_BUS_ADDRESS,
+      socket: process.env.DBUS_LAUNCHD_SESSION_BUS_SOCKET,
+    };
+
+    cp.spawnSync = (...args) => {
+      calls.spawnSync.push(args[0]);
+      return real.spawnSync(...args);
+    };
+    cp.execFile = (...args) => {
+      calls.execFile.push(args[0]);
+      return real.execFile(...args);
+    };
+    nodeModule.syncBuiltinESMExports();
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    delete process.env.DBUS_SESSION_BUS_ADDRESS;
+    delete process.env.DBUS_LAUNCHD_SESSION_BUS_SOCKET;
+    _resetBusState();
+
+    try {
+      return await fn(calls);
+    } finally {
+      cp.spawnSync = real.spawnSync;
+      cp.execFile = real.execFile;
+      nodeModule.syncBuiltinESMExports();
+      Object.defineProperty(process, 'platform', { value: saved.platform });
+      if (saved.address !== undefined)
+        process.env.DBUS_SESSION_BUS_ADDRESS = saved.address;
+      if (saved.socket !== undefined)
+        process.env.DBUS_LAUNCHD_SESSION_BUS_SOCKET = saved.socket;
+      _resetBusState();
+    }
+  }
+
+  test('launchd is asked with execFile, never spawnSync', async () => {
+    await onFakeDarwin(async (calls) => {
+      await resolveAddress('session');
+      assert.deepEqual(
+        calls.spawnSync,
+        [],
+        'nothing blocked the loop looking for the bus',
+      );
+      assert.deepEqual(calls.execFile, ['launchctl']);
+    });
+  });
+
+  test('and asked once, however many dials there are', async () => {
+    await onFakeDarwin(async (calls) => {
+      await Promise.all([resolveAddress('session'), resolveAddress('session')]);
+      await resolveAddress('session');
+      // one fork for the process, not one per consumer: the shared bus, the
+      // a11y discovery probe and the appearance ladder all come through here
+      assert.deepEqual(calls.execFile, ['launchctl']);
+    });
+  });
+
+  test('the environment still wins, and costs no subprocess at all', async () => {
+    await onFakeDarwin(async (calls) => {
+      process.env.DBUS_LAUNCHD_SESSION_BUS_SOCKET = '/tmp/rx11-fake-socket';
+      _resetBusState();
+      assert.equal(
+        await resolveAddress('session'),
+        'unix:path=/tmp/rx11-fake-socket',
+      );
+      assert.deepEqual(calls.spawnSync, []);
+    });
+  });
+
+  test('a Mac with no D-Bus fails before it dials, and says so', async () => {
+    await onFakeDarwin(async () => {
+      // `launchctl` answers nothing here (or is not installed at all, off
+      // macOS), which used to reach dbus-native's `unknown bus address` throw
+      // via a second blocking spawn
+      if ((await resolveAddress('session')) !== undefined) return;
+      assert.equal(await sessionBus(), null);
+      await assert.rejects(
+        () => sessionBus({ required: true }),
+        (err) => {
+          assert.match(err.cause.message, /no session bus address/);
+          assert.match(err.cause.message, /DBUS_LAUNCHD_SESSION_BUS_SOCKET/);
+          return true;
+        },
+      );
+    });
+  });
+
+  test('a synchronous spawn never happens on the way to a root', async () => {
+    // The end-to-end shape of #417, in a child process so the count covers
+    // everything a cold start does: connect, the layout engine, the a11y
+    // climb. Run on whatever platform CI is: on a Mac it is the regression
+    // itself, everywhere else it is the guard that keeps the next blocking
+    // lookup from being added.
+    //
+    // Deliberately **not** the mock app: `react-x11/test` sets NO_AT_BRIDGE,
+    // which turns off the very climb this is watching — the assertion would
+    // hold for the wrong reason. A root over the in-process X server is a
+    // real cold start with accessibility on, the way an application runs.
+    const source = `
+      import module from 'node:module';
+      import cp from 'node:child_process';
+      const sync = [];
+      const real = cp.spawnSync;
+      cp.spawnSync = (...args) => { sync.push(args[0]); return real(...args); };
+      module.syncBuiltinESMExports();
+
+      const xserver = (await import('x11/lib/xserver/index.js')).default;
+      const { createRoot } = await import('./src/index.js');
+      const server = xserver.createServer({ width: 64, height: 48 });
+      const [serverEnd, clientEnd] = xserver.createStreamPair();
+      server.addClientStream(serverEnd);
+
+      const root = await createRoot({ stream: clientEnd });
+      // the a11y climb is deliberately not awaited by createRoot, so give it
+      // the turns of the loop it would have had before the first frame
+      await new Promise((r) => setTimeout(r, 500));
+      await root.unmount();
+      console.log(JSON.stringify(sync));
+    `;
+    // And NO_AT_BRIDGE cleared: importing `react-x11/test` sets it for the
+    // whole process, this suite does import it, and the child inherits the
+    // environment — so without this the climb never happens and the count is
+    // zero for a reason that has nothing to do with #417.
+    const { code, stdout, stderr } = await runScript(source, {
+      NO_AT_BRIDGE: '',
+    });
+    assert.equal(code, 0, stderr);
+    assert.deepEqual(JSON.parse(stdout.trim().split('\n').pop()), []);
   });
 });

--- a/test/bus.test.js
+++ b/test/bus.test.js
@@ -762,23 +762,30 @@ describe('finding the address without blocking the loop (#417)', () => {
     });
   });
 
-  test('a Mac with no D-Bus fails before it dials, and says so', async () => {
-    await onFakeDarwin(async () => {
-      // `launchctl` answers nothing here (or is not installed at all, off
-      // macOS), which used to reach dbus-native's `unknown bus address` throw
-      // via a second blocking spawn
-      if ((await resolveAddress('session')) !== undefined) return;
-      assert.equal(await sessionBus(), null);
-      await assert.rejects(
-        () => sessionBus({ required: true }),
-        (err) => {
-          assert.match(err.cause.message, /no session bus address/);
-          assert.match(err.cause.message, /DBUS_LAUNCHD_SESSION_BUS_SOCKET/);
-          return true;
-        },
-      );
-    });
-  });
+  // Guarded on the transport rather than on a broker: with `dbus-native`
+  // absent — Node 20 — `connect()` reports *that* and never reaches the
+  // address at all, which is the right answer and a different one.
+  test(
+    'a Mac with no D-Bus fails before it dials, and says so',
+    { ...needsBroker },
+    async () => {
+      await onFakeDarwin(async () => {
+        // `launchctl` answers nothing here (or is not installed at all, off
+        // macOS), which used to reach dbus-native's `unknown bus address`
+        // throw via a second blocking spawn
+        if ((await resolveAddress('session')) !== undefined) return;
+        assert.equal(await sessionBus(), null);
+        await assert.rejects(
+          () => sessionBus({ required: true }),
+          (err) => {
+            assert.match(err.cause.message, /no session bus address/);
+            assert.match(err.cause.message, /DBUS_LAUNCHD_SESSION_BUS_SOCKET/);
+            return true;
+          },
+        );
+      });
+    },
+  );
 
   test('a synchronous spawn never happens on the way to a root', async () => {
     // The end-to-end shape of #417, in a child process so the count covers

--- a/test/desktop-integration.test.js
+++ b/test/desktop-integration.test.js
@@ -1,0 +1,271 @@
+// `createRoot({ desktop })` — the off switch for the three things react-x11
+// starts for you that talk to the session bus (issue #417).
+//
+// The policy is process-wide and it latches, so every case here releases it
+// again in `afterEach`. That is the harness undoing what the harness caused;
+// there is deliberately no way for an application to turn an integration back
+// on, which is the behaviour the last test in the file pins down.
+import { test, describe, after, afterEach, before } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import React from 'react';
+
+import {
+  _resetDesktopIntegration,
+  desktopIntegrationEnabled,
+  setDesktopIntegration,
+} from '../src/desktopintegration.js';
+import {
+  _resetAppearance,
+  appearanceSnapshot,
+  systemAppearance,
+} from '../src/appearance.js';
+import { _resetBusState, busRefs } from '../src/bus.js';
+import { GlobalMenuExport } from '../src/globalmenu.js';
+import { createRoot } from '../src/index.js';
+import { createMockApp } from './helpers/mock-app.js';
+import { fakeRegistrar } from './helpers/fake-registrar.js';
+import { runScript } from './helpers/run-script.js';
+import { transportAvailable, until, withBus } from './helpers/with-bus.js';
+
+const haveTransport = await transportAvailable();
+const needsBroker = haveTransport
+  ? {}
+  : { skip: 'dbus-native is not installed (expected on Node < 22.12)' };
+
+const h = React.createElement;
+
+// The remembered answer lives in $XDG_CACHE_HOME; point it at a scratch
+// directory so nothing here reads — or writes — the developer's own desktop.
+let cacheHome;
+const savedCacheHome = process.env.XDG_CACHE_HOME;
+
+before(async () => {
+  cacheHome = await fs.mkdtemp(path.join(os.tmpdir(), 'rx11-desktop-'));
+  process.env.XDG_CACHE_HOME = cacheHome;
+});
+
+after(async () => {
+  if (savedCacheHome === undefined) delete process.env.XDG_CACHE_HOME;
+  else process.env.XDG_CACHE_HOME = savedCacheHome;
+  await fs.rm(cacheHome, { recursive: true, force: true });
+});
+
+/** Plant a remembered answer, the way a previous run of an app would have. */
+async function rememberDark() {
+  const file = path.join(cacheHome, 'react-x11', 'appearance.json');
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(
+    file,
+    JSON.stringify({
+      v: 1,
+      colorScheme: 'dark',
+      accent: '#ed5b00',
+      contrast: 'normal',
+      reducedMotion: false,
+    }),
+  );
+}
+
+afterEach(async () => {
+  await fs.rm(path.join(cacheHome, 'react-x11'), {
+    recursive: true,
+    force: true,
+  });
+  _resetDesktopIntegration();
+  _resetAppearance();
+  _resetBusState();
+});
+
+describe('the policy', () => {
+  test('everything is on with no option, and `true` changes nothing', () => {
+    setDesktopIntegration(undefined);
+    setDesktopIntegration(true);
+    for (const feature of ['appearance', 'a11y', 'globalMenu']) {
+      assert.equal(desktopIntegrationEnabled(feature), true, feature);
+    }
+  });
+
+  test('`false` turns off all three', () => {
+    setDesktopIntegration(false);
+    for (const feature of ['appearance', 'a11y', 'globalMenu']) {
+      assert.equal(desktopIntegrationEnabled(feature), false, feature);
+    }
+  });
+
+  test('the object form turns off only what it names', () => {
+    setDesktopIntegration({ appearance: false });
+    assert.equal(desktopIntegrationEnabled('appearance'), false);
+    assert.equal(desktopIntegrationEnabled('a11y'), true);
+    assert.equal(desktopIntegrationEnabled('globalMenu'), true);
+  });
+
+  test('off latches: nothing turns an integration back on', () => {
+    setDesktopIntegration(false);
+    setDesktopIntegration(true);
+    setDesktopIntegration({ appearance: true, a11y: true, globalMenu: true });
+    for (const feature of ['appearance', 'a11y', 'globalMenu']) {
+      assert.equal(desktopIntegrationEnabled(feature), false, feature);
+    }
+  });
+
+  test('a misspelt integration is a throw, not a silent no-op', () => {
+    // the failure mode this exists to prevent: `desktop: { a11Y: false }`
+    // leaving the bridge running and nothing saying so
+    assert.throws(
+      () => setDesktopIntegration({ notifications: false }),
+      /no such desktop integration/,
+    );
+    assert.throws(() => setDesktopIntegration('off'), /takes false or/);
+    // and nothing was applied on the way to the throw
+    assert.equal(desktopIntegrationEnabled('a11y'), true);
+  });
+});
+
+describe('through createRoot', () => {
+  test('the option is validated before anything is started', async () => {
+    await assert.rejects(
+      () => createRoot({ app: createMockApp(), desktop: { nope: false } }),
+      /no such desktop integration/,
+    );
+    assert.equal(desktopIntegrationEnabled('a11y'), true);
+  });
+
+  test('`desktop: false` turns the three off for the process', async () => {
+    const root = await createRoot({ app: createMockApp(), desktop: false });
+    try {
+      for (const feature of ['appearance', 'a11y', 'globalMenu']) {
+        assert.equal(desktopIntegrationEnabled(feature), false, feature);
+      }
+    } finally {
+      await root.unmount();
+    }
+  });
+
+  test('a second root cannot turn back on what the first turned off', async () => {
+    const app = createMockApp();
+    const first = await createRoot({ app, desktop: false });
+    const second = await createRoot({ app, desktop: true });
+    try {
+      assert.equal(desktopIntegrationEnabled('a11y'), false);
+    } finally {
+      await second.unmount();
+      await first.unmount();
+    }
+  });
+});
+
+describe('what turning a11y off actually stops', () => {
+  // In a child process, and it has to be: `startA11y()` memoises per process,
+  // and importing anything from `react-x11/test` sets NO_AT_BRIDGE — so an
+  // in-process assertion would be true for a reason that is not this one.
+  //
+  // `REACT_X11_A11Y=1` is the strongest form of "climb anyway": it overrides
+  // NO_AT_BRIDGE *and* makes every rung report why it stopped. What it prints
+  // is the observable — a silent run is a climb that never started.
+  const child = (source, env) =>
+    runScript(
+      `
+      const { startA11y } = await import('./src/a11y.js');
+      const { setDesktopIntegration } = await import(
+        './src/desktopintegration.js');
+      ${source}
+      console.log('bridge=' + (await startA11y()));
+    `,
+      { REACT_X11_A11Y: '1', NO_AT_BRIDGE: '', ...env },
+    );
+
+  test('the climb is loud without the switch, and silent with it', async () => {
+    const on = await child('');
+    assert.equal(on.code, 0, on.stderr);
+    assert.match(on.stdout, /bridge=null/);
+    assert.match(
+      on.stderr,
+      /accessibility off/,
+      'the forced climb reported where it stopped',
+    );
+
+    const off = await child('setDesktopIntegration(false);');
+    assert.equal(off.code, 0, off.stderr);
+    assert.match(off.stdout, /bridge=null/);
+    assert.equal(off.stderr.trim(), '', 'nothing climbed, so nothing reported');
+  });
+});
+
+describe(
+  'what turning the global menu off actually stops',
+  { ...needsBroker },
+  () => {
+    const MENUS = () => [{ id: 'file', label: 'File', items: [] }];
+
+    test('the menu is not exported, and no bus is dialled', async () => {
+      await withBus(async (address, broker) => {
+        const panel = await fakeRegistrar(address);
+        setDesktopIntegration({ globalMenu: false });
+
+        const owner = new GlobalMenuExport({
+          getMenus: MENUS,
+          target: {
+            id: 0x99,
+            setProperty: async () => {},
+            deleteProperty: async () => {},
+          },
+          onChange: () => {},
+        });
+        await owner.start();
+
+        assert.equal(owner.ref, null, 'no bus ref was taken');
+        assert.equal(owner.exported, false, 'nothing was exported');
+        assert.equal(busRefs('session'), 0);
+        // the panel is right there and listening; the switch is what stopped it
+        assert.equal(broker.liveClients, 1, 'only the fake panel connected');
+
+        await owner.stop();
+        await panel.stop();
+        await until(() => busRefs('session') === 0, 'the bus to be released');
+      });
+    });
+  },
+);
+
+describe('what turning appearance off actually stops', () => {
+  test('the ladder does not run, and no bus is acquired', async () => {
+    setDesktopIntegration({ appearance: false });
+    const answer = await systemAppearance();
+    assert.equal(answer.colorScheme, 'no-preference');
+    assert.equal(answer.accent, null);
+    assert.equal(answer.contrast, 'normal');
+    assert.equal(answer.reducedMotion, false);
+    // `source: null` is the tell that nothing answered — not even the cache,
+    // which would make an opted-out app draw in whatever colours this machine
+    // was in last time
+    assert.equal(answer.source, null);
+    assert.equal(busRefs('session'), 0);
+  });
+
+  test('the cache is not read either, on a machine that has one', async () => {
+    // the remembered answer is the *whole* point of the seeding path, so
+    // proving it is skipped needs a real one on disk: without the plant this
+    // test passes on any machine that has never run an app
+    await rememberDark();
+    assert.equal(appearanceSnapshot().colorScheme, 'dark', 'the plant took');
+
+    _resetAppearance();
+    setDesktopIntegration({ appearance: false });
+    assert.equal(appearanceSnapshot().colorScheme, 'no-preference');
+    assert.equal(appearanceSnapshot().source, null);
+  });
+
+  test('a tree still renders, in the defaults', async () => {
+    setDesktopIntegration(false);
+    const root = await createRoot({ app: createMockApp() });
+    try {
+      root.render(h('window', { width: 40, height: 30 }, h('box', null)));
+      assert.equal(desktopIntegrationEnabled('appearance'), false);
+    } finally {
+      await root.unmount();
+    }
+  });
+});

--- a/test/helpers/run-script.js
+++ b/test/helpers/run-script.js
@@ -1,0 +1,43 @@
+// A snippet of ESM run in a child process, from the repo root.
+//
+// The suites that need this are the ones asking what react-x11 does *before*
+// anything has touched it: what an import costs, what a cold `createRoot()`
+// spawns, what a process-wide latch does on a process that has only ever seen
+// one root. None of those questions survive being asked inside a test runner
+// that has already imported half the library and set NO_AT_BRIDGE on the way.
+//
+// The environment is inherited, so a caller that cares about a variable the
+// harness sets must clear it explicitly — `{ NO_AT_BRIDGE: '' }`.
+
+import { execFile } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repo = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/**
+ * @param {string[]} args node's own argv
+ * @param {Record<string, string>} [env] added to this process's environment
+ * @returns {Promise<{ code: number, error?: Error, stdout: string, stderr: string }>}
+ */
+export function runNode(args, env = {}, timeout = 20000) {
+  return new Promise((resolve) => {
+    const child = execFile(
+      process.execPath,
+      args,
+      { cwd: repo, env: { ...process.env, ...env }, timeout },
+      (error, stdout, stderr) =>
+        resolve({ code: error?.code ?? 0, error, stdout, stderr }),
+    );
+    child.on('error', () => {});
+  });
+}
+
+/** @param {string} source top-level `await` is available. */
+export function runScript(source, env = {}, nodeArgs = [], timeout) {
+  return runNode(
+    [...nodeArgs, '--input-type=module', '--eval', source],
+    env,
+    timeout,
+  );
+}

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -1060,6 +1060,20 @@ async function main() {
   // @ts-expect-error — it is on or off, not a moment
   await createRoot({ restoreFocusOnReveal: 'reveal' });
 
+  // the desktop integrations, as a group and one at a time
+  const noDesktop = await createRoot({ desktop: false });
+  await noDesktop.unmount();
+  const noAppearance = await createRoot({
+    desktop: { appearance: false, a11y: true, globalMenu: false },
+  });
+  await noAppearance.unmount();
+
+  // @ts-expect-error — no such integration
+  await createRoot({ desktop: { notifications: false } });
+
+  // @ts-expect-error — each one is on or off
+  await createRoot({ desktop: { appearance: 'portal' } });
+
   root.render(<RawGl />);
   root.render(<Popup />, () => {});
   root.render(<AnchoredPopup />);


### PR DESCRIPTION
Fixes #417.

Two things, and the issue is right that they are worth separating — though the diagnosis of the first one moves.

## The blocking spawn is real, but it is not the appearance ladder

`createRoot()` does not start the appearance follower. `watchAppearance()` in the reconciler only registers a repaint callback; the ladder itself runs from `useSystemAppearance()` / `<ThemeProvider dark>`, so an app that never asks what colour the desktop is never climbs it. Verified by instrumenting `spawnSync` around a cold `createRoot()`:

```
>>> spawnSync launchctl ["getenv","DBUS_LAUNCHD_SESSION_BUS_SOCKET"]
    at launchdSocketPath (node_modules/dbus-native/lib/address.js:38)
    at createStream         (node_modules/dbus-native/index.js:42)
    at accessibilityBusAddress (src/atspi.js:1825)
    at start                   (src/atspi.js:1879)
```

It is the **AT-SPI bridge's discovery probe**, which `createRoot()` does start unconditionally. Everything else in the issue holds: it is a synchronous `spawnSync('launchctl', …)` on the critical path, on macOS, so that the accessibility bridge can find out there is nothing to connect to.

### The fix

Every dial now goes through one asynchronous, once-per-process `resolveAddress()` in `src/bus.js`, which asks launchd with `execFile` and hands `dbus-native` a resolved `unix:path=…` — so it never reaches its own synchronous fallback. Same wall clock, none of it on the loop: the X handshake and the layout engine's WebAssembly run straight through it. It is also **one** fork instead of one per consumer (the a11y probe dials privately, the shared bus dials again).

Measured on this Mac, with `launchctl` warm — the reporter's 120–150 ms is a cold page cache, so treat this as the floor of the win rather than the size of it:

| | blocked in `spawnSync` |
| --- | --- |
| before | 4.0 / 5.4 / 5.3 ms |
| after | 0.0 / 0.0 / 0.0 ms |

A Mac with no D-Bus at all now fails *before* dialling a socket, with an error naming `$DBUS_LAUNCHD_SESSION_BUS_SOCKET` instead of `dbus-native`'s `unknown bus address`. Linux is untouched — `$DBUS_SESSION_BUS_ADDRESS` or `$XDG_RUNTIME_DIR/bus` answers with no subprocess, and always did.

## The off switch

The issue's second point is the wider one, and it is right about the group. Three things core turns on for you reach the session bus:

| | |
| --- | --- |
| `appearance` | the light/dark, accent, contrast and reduced-motion ladder |
| `a11y` | the AT-SPI bridge |
| `globalMenu` | a `MenuBar` handing its menu to the panel instead of drawing it |

Each had an off switch and each of those was an **environment variable** — exactly the complaint: the environment is inherited, so setting one before `createRoot()` sets it for every child process too, and the D-Bus one takes the portals and the app's own exported services down with the follower.

```jsx
await createRoot({ desktop: false });                  // none of the three
await createRoot({ desktop: { appearance: false } });  // just that one
```

With all three off, nothing dials the session bus at startup. Turning `appearance` off also stops **the remembered answer being read back** — an opted-out app starting in whatever colours the machine happened to be in last time would be the opposite of what the switch is for.

**Off is process-wide and it latches**, because so is the thing it describes: one desktop, one D-Bus identity, one bridge per process. A second root cannot turn back on what the first turned off, and a misspelt integration throws rather than silently leaving the feature running. The one honest limit, documented: a bridge already started stays started, so pass it on the first root.

Deliberately *not* done here: bus **injection** (the issue calls it "worth considering" rather than asking for it). Handing in a bus object is a larger design that touches every consumer's sharing contract, and it is orthogonal to both halves above.

## Tests

`test/desktop-integration.test.js` (13) and a new group in `test/bus.test.js` (5). Every one was mutation-checked — each gate removed in turn, and the test that covers it confirmed to fail:

- the end-to-end "no synchronous spawn on the way to a root" case is a child process over the in-process X server, deliberately **not** the mock app: `react-x11/test` sets `NO_AT_BRIDGE`, which turns off the very climb being watched. The first draft passed against the reverted implementation for exactly that reason.
- the a11y gate is asserted through `REACT_X11_A11Y=1`'s loud output — a silent run is a climb that never started — since `startA11y()` memoises per process and its return value is `null` either way on a machine with no a11y bus.
- the global-menu gate runs against a live broker with a fake panel listening, so "no bus dialled" is the switch and not the absence of a desktop.

`npm test` 1656 pass / 6 fail — the same six macOS-only `appearance.test.js` failures present on `master` at 2aa2a51 (they pass in CI). Lint, prettier, `tsc`, and the website build (docs links + anchors) all green.

## Docs

`docs/desktop.md` gains "Turning the desktop off" and "Not blocking the first frame on the bus"; `appearance.md`, `accessibility.md`, `globalmenu.md` and `dbus.md` link into them from their own off-switch sections. `.d.ts` and `test/types/api.tsx` updated with the prop.
