### PR TITLE
fix(text): a trimmed label measures to a whole pixel

### DIFF
--- a/src/nodes.js
+++ b/src/nodes.js
@@ -1218,6 +1218,19 @@ function contentSpan(node, axis, intrinsic, out) {
  * one pass by `contentSpan`. `floored` collects what was written so the next
  * measurement can take it back off — a floor left in place would be read
  * back as content that cannot give, and could then only ratchet upwards.
+ *
+ * A floor is written **unrounded**, and the measurement it came from ran
+ * with the pixel grid off (`measuringExactly`) for the reason given there:
+ * rounding a floor grows the tree a pixel per nesting level. What that
+ * leaves is a sharp edge in yoga worth knowing about before writing a
+ * measure function. A line whose items are all held at their floors is one
+ * yoga freezes item by item, subtracting each item's shrink factor from the
+ * line's total as it goes; the total only cancels to zero if the sizes add
+ * up exactly in binary. Three items of, say, 239.28 in a column that
+ * overflows do not, and yoga divides the overflow by the rounding residue
+ * instead of skipping the division — the items come back a billion pixels
+ * tall (issue #411). Whole pixels cancel exactly, which is why the text
+ * measures here answer in them (`TextNode._trim`).
  */
 function writeContentFloors(node, axis, mins, floored) {
   const axisIsMain = mainAxisOf(node) === axis;
@@ -4587,7 +4600,12 @@ export class TextNode extends Node {
 
   /** Height for a width: the paragraph shaped into whatever is on offer.
    * The offer is `Infinity` when nothing bounds it, which is also what
-   * `textWrap: 'nowrap'` asks for, so neither needs a mode. */
+   * `textWrap: 'nowrap'` asks for, so neither needs a mode.
+   *
+   * Both answers are **whole pixels**, the trimmed one included — see
+   * `_trim` for why the rounding is not cosmetic. The glyphs are placed
+   * from the unrounded trim (`_placedLayout`), so what the rounding moves
+   * is the bottom edge of the box, by less than half a pixel. */
   measureContent({ width }) {
     const layout = this._layoutFor(this._wrapWidth(width));
     if (!layout) return { width: 0, height: 0 };
@@ -4596,7 +4614,9 @@ export class TextNode extends Node {
       width: Math.ceil(layout.width),
       height: Math.max(
         0,
-        Math.ceil(layout.height) - (trim ? trim.top + trim.bottom : 0),
+        trim
+          ? Math.round(Math.ceil(layout.height) - (trim.top + trim.bottom))
+          : Math.ceil(layout.height),
       ),
     };
   }
@@ -4852,6 +4872,21 @@ export class TextNode extends Node {
    * Measured in the coordinates the layout is **drawn** in, not the ones it
    * reports: `halfLeading` shifts it, and deriving the baseline from the
    * metrics again would silently disagree the day that shift changes.
+   *
+   * The amounts are fractions of a pixel and stay that way — the glyphs are
+   * placed from them (`_placedLayout`). What must not stay fractional is the
+   * **box** they leave behind, which is why `measureContent` rounds the
+   * height it reports and this does not (issue #411).
+   *
+   * A trimmed label measures to the cap band, and a cap height is a fraction
+   * of the em — so before the rounding, a column of trimmed titles handed
+   * yoga three or four flex items whose main size had a fraction in it and
+   * whose content floors (#249) were that same fraction. Yoga freezes a line
+   * like that item by item and divides the overflow by a total shrink factor
+   * that should have cancelled to zero; a fraction that is not exact in
+   * binary leaves a rounding residue there instead, and dividing by it laid
+   * the section titles of `examples/configurator` out 5.6 billion pixels
+   * tall. See `writeContentFloors`, which is the other end of it.
    */
   _trim(layout) {
     if (this.style.textBoxTrim !== 'cap-alphabetic') return null;
@@ -6645,8 +6680,8 @@ export class TextInputNode extends Node {
   /** A preferred width, capped to whatever is on offer — `Infinity` when
    * nothing is, which is what makes the `Math.min` the whole rule. */
   measureContent({ width }) {
-    // Not rounded here: a trimmed `<text>` hands layout the raw cap band
-    // too, and rounding one of them and not the other is a pixel of
+    // `_capBand` rounds, and a trimmed `<text>` rounds the same band the
+    // same way — rounding one of them and not the other is a pixel of
     // difference between a field and the button beside it.
     return { width: Math.min(150, width), height: this._capBand() };
   }
@@ -6896,12 +6931,16 @@ export class TextInputNode extends Node {
     };
   }
 
+  /** Whole pixels either way: a field's height is a flex item's main size,
+   *  and a fractional one costs the tree its content floors (see
+   *  `TextNode._trim`, issue #411). The face with no `capHeight` to round is
+   *  the one that reaches the fallback. */
   _capBand() {
     const style = this.resolvedTextStyle();
     const cap = this.app?.fonts
       ?.match?.(style.family, { weight: style.weight, style: style.style })
       ?.metrics?.(style.size)?.capHeight;
-    return cap ? Math.round(cap) : this._lineHeight();
+    return Math.round(cap || this._lineHeight());
   }
 
   /** Shaped layout of the current value, cached per (value, style,

--- a/test/content-floors.test.js
+++ b/test/content-floors.test.js
@@ -12,12 +12,22 @@
 // wrapping row rather than a paragraph.
 import { test } from 'node:test';
 import assert from 'node:assert';
+import path from 'node:path';
+import { createRequire } from 'node:module';
 import React from 'react';
 import { createRoot } from '../src/index.js';
 import { createStyles } from '../src/styles.js';
 import { registerElement, unregisterElement } from '../src/host.js';
 import { Node } from '../src/node.js';
 import { createMockApp, spinWheel } from './helpers/mock-app.js';
+import { renderX11, screen, cleanup } from '../src/testing/index.js';
+
+const require = createRequire(import.meta.url);
+const fontsDir = path.join(
+  path.dirname(require.resolve('katex/package.json')),
+  'dist',
+  'fonts',
+);
 
 const h = React.createElement;
 const tick = () => new Promise((resolve) => setImmediate(resolve));
@@ -416,4 +426,99 @@ test('an unknown flex value says what the three are', async () => {
     () => createStyles({ bad: { flex: 'fill' } }),
     /invalid flex "fill" in styles\.bad .*expected a number/s,
   );
+});
+
+// --- a floor is only exact if the content is whole pixels --------------------
+//
+// The one place in this file with real faces loaded, because the bug needs a
+// content size with a fraction in it and headless text measures 0x0.
+//
+// A floor is written unrounded and measured with the pixel grid off, on
+// purpose (`measuringExactly`): rounding one grows the tree a pixel per
+// level. What that costs is exactness — `contentSpan` adds the pieces up in
+// doubles and yoga keeps the floor as a float, so a fractional content size
+// comes back as a floor one ulp *under* the size it was measured from. Yoga's
+// shrink pass then has a line of items each a hair over their floor, freezes
+// all of them, and divides by a total shrink factor that should have
+// cancelled to zero and is instead the rounding residue. Three items in a
+// column are enough; the answer comes back in the billions of pixels
+// (issue #411).
+//
+// So the rule the measure functions keep is that a content size is a whole
+// number of pixels — `textBoxTrim: 'cap-alphabetic'` was the one that did
+// not, since the cap band it measures to is a fraction of the em.
+const trimFonts = {
+  // cap height 9.562 at 14px: the fraction that used to reach yoga
+  'sans-serif': path.join(fontsDir, 'KaTeX_Main-Regular.ttf'),
+};
+
+const trimmedSection = (i) =>
+  h(
+    'box',
+    { key: i, style: { flexDirection: 'column', gap: 14 } },
+    h('text', { style: { textBoxTrim: 'cap-alphabetic' } }, 'Room to think.'),
+    box({ height: 60 }),
+    box({ height: 60 }),
+    box({ height: 60 }),
+  );
+
+test('a trimmed label measures to a whole pixel', async () => {
+  const label = React.createRef();
+  await renderX11(
+    h(
+      'text',
+      { ref: label, style: { textBoxTrim: 'cap-alphabetic' } },
+      'Room to think.',
+    ),
+    { width: 300, height: 120, fonts: trimFonts },
+  );
+  const measured = label.current.measureContent({ width: 300 });
+  assert.strictEqual(
+    measured.height,
+    Math.round(measured.height),
+    `the trimmed cap band reached layout as ${measured.height}`,
+  );
+  assert.ok(measured.height > 0, 'and it is still the cap band');
+  await cleanup();
+});
+
+test('a scroll pane of trimmed titles lays out in pixels, not billions', async () => {
+  // The issue's own tree: a column that overflows its viewport, so every
+  // section is squeezed against the floor its content just wrote.
+  await renderX11(
+    h(
+      'box',
+      {
+        'data-testname': 'pane',
+        style: {
+          width: 500,
+          overflow: 'scroll',
+          flexDirection: 'column',
+          gap: 30,
+          padding: 36,
+        },
+      },
+      ...Array.from({ length: 4 }, (_, i) => trimmedSection(i)),
+    ),
+    { width: 600, height: 400, fonts: trimFonts },
+  );
+  const pane = screen.getByTestName('pane');
+  for (const section of pane.children) {
+    assert.ok(
+      section.abs.height > 0 && section.abs.height < 1000,
+      `section laid out at ${section.abs.height}px`,
+    );
+  }
+  // and the ones past the fold are still where the ones above put them
+  const tops = pane.children.map((section) => section.abs.y);
+  assert.deepStrictEqual(
+    tops,
+    [...tops].sort((a, b) => a - b),
+    'sections stack in order',
+  );
+  assert.ok(
+    tops[3] - tops[0] < 1000,
+    `the fourth section sits at ${tops[3]}, ${tops[3] - tops[0]} below the first`,
+  );
+  await cleanup();
 });


### PR DESCRIPTION
A `<text>` with `textBoxTrim: 'cap-alphabetic'` measures to the cap band, and
a cap height is a fraction of the em — so the box it handed layout had a
fraction in it. Four such titles in a scroll pane the content overflows came
back 5.6 billion pixels tall, and everything past the first section painted
off the bottom of the world.

| master | this branch |
| --- | --- |
| ![before-master](https://github.com/user-attachments/assets/6f7f4c4d-3864-4a07-a8f8-60ee3f5a275e) | ![after-fix](https://github.com/user-attachments/assets/15917174-c4b5-45d8-94a7-4ec3ed00af4a) |

Same scene both sides, rendered by each side's own code: a column of section
titles with `textBoxTrim: 'cap-alphabetic'` over cards, in a scroll pane the
content overflows. Top row at rest, bottom row after four wheel notches —
which is where the pane laid out in the billions has nothing left to show.

## What it actually was

Not a ratchet: the floors are taken back off before every measurement, and a
single layout pass produces the garbage. The fraction is the whole story, and
the trim only supplies it.

A flex line whose items are all held at their content floors (#249) is one
yoga freezes item by item, subtracting each item's shrink factor from the
line's total as it goes. That total cancels to zero only when the sizes add
up exactly in binary. Three items of `239.28` in a column that overflows do
not, so yoga divides the overflow by the rounding residue instead of skipping
the division, and the items come back around `2^32`.

It reproduces in yoga alone, with no react-x11 in the picture:

```js
// three siblings, a fractional height, a floor equal to it, an overflowing column
const pane = Yoga.Node.create();
pane.setWidth(400); pane.setHeight(100);
for (let i = 0; i < 3; i++) {
  const kid = Yoga.Node.create();
  kid.setHeight(239.28); kid.setFlexShrink(1); kid.setMinHeight(239.28);
  pane.insertChild(kid, i);
}
pane.calculateLayout(400, 100, Yoga.DIRECTION_LTR);
// 4844314624, 4844314624, 4844314624
```

Two items are fine — `a + a` is exact. `239.5` and `239.25` are fine — they
are exact in binary. Whole pixels are always fine, which is the rule the text
measures here already kept: `Math.ceil(layout.height)` on an untrimmed
paragraph. The trimmed branch subtracted the cap band back out afterwards and
lost it.

## The change

- `TextNode.measureContent` rounds the trimmed height. The glyphs go on being
  placed from the unrounded trim, so what moves is the bottom edge of the
  box, by less than half a pixel — the trim's optical evenness is unchanged
  and `test/integration.test.js`'s ink assertions still hold.
- `TextInputNode._capBand` rounds in the fallback case too. It already
  rounded a declared `capHeight`; a face that declares none fell through to a
  raw line height, and a field's height is a flex item's main size like any
  other. A field and the trimmed label beside it stay the same height either
  way, which is what #327 was about.
- Comments at both ends — `TextNode._trim` and `writeContentFloors` — so the
  next person to write a measure function here knows why the rounding is not
  cosmetic, and why the floors are deliberately *not* rounded.

## Tests

Two in `test/content-floors.test.js`, the first real faces in that file: a
trimmed label measures to a whole pixel, and the issue's own scroll pane lays
out in pixels rather than billions. Both fail on master — the bundled KaTeX
faces reproduce it at a range of sizes, so no new fixture is needed.

Whole suite green apart from the six macOS-only `appearance.test.js` failures
that are already there on master; typecheck, lint and prettier clean.

## What this does not fix

The same yoga arithmetic is reachable without any text at all — three
siblings with `height: 17.28` in an overflowing scroll pane blow up exactly
the same way, and so would an `<image>` whose aspect fit lands on a fraction.
This PR closes the source the renderer itself supplies. Making the renderer
proof against a fractional size an application writes is a bigger call —
either an upstream fix in yoga, or quantizing layout inputs to the pixel grid
— and I would rather that be its own issue than ride in here. Happy to open
it with the repro above.

Fixes #411

