### PR TITLE
fix(styles): an unknown theme token reports instead of taking the app down

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -136,6 +136,38 @@ It covers the element-owned form of the same shift as well —
 that pans a scene it drew itself calls — so a scene that misrenders while
 panning is one variable away from being told apart from one that misdraws.
 
+## `REACT_X11_STRICT_TOKENS=1`
+
+Makes an unresolvable `$token` fatal instead of reported.
+
+By default a token the palette in force does not define is dropped, named
+loudly on stderr — token, element, owning component, and every token the
+palette _does_ have — and counted as a failure through `process.exitCode`.
+The widget paints one property short, which is visible, and the rest of the
+app keeps running. That is the default because the check runs when a node's
+ancestry completes, and on most of those paths a throw cannot be caught: on
+a fresh mount React is completing the `<window>`, so the error is attributed
+above every boundary inside it, and a desktop light/dark switch reaches the
+tree from an X event with no React on the stack at all.
+
+Set this when you would rather stop than paint something wrong — a kiosk, or
+a CI job that should fail at the first bad token rather than at the
+screenshot diff:
+
+```sh
+REACT_X11_STRICT_TOKENS=1 npm run examples:theming
+```
+
+Strict mode still throws somewhere useful. The error is raised from the
+offending node's own `commitMount`, on its own fiber, so an
+[error boundary](react-features.md) at any depth inside the window catches
+it and renders a fallback for that subtree rather than losing the window.
+With no boundary above it, it reaches `onUncaughtError` and the process
+stops — which is the point. The one path that cannot be routed is the
+desktop appearance switch; there strict mode crashes.
+
+Read once at startup like the switches above, and answers only to `1`.
+
 ## `REACT_X11_NO_TRANSPARENCY=1`
 
 Makes every display answer the way one with no 32-bit visual does:

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -820,12 +820,34 @@ not change are still updated — which is why a theme change also drops the
 memoised text layouts under it, or cached text would keep painting the old
 colour.
 
-An unknown token is an error naming what the theme does have, and a token
-with **no** theme above it at all warns in dev — that one is otherwise
-silent, since the whole style is stripped rather than one value failing.
-Resolution is cached per (style object, theme object), so a hoisted style
-under one theme keeps its identity across renders and the `===` fast path
-still applies.
+An unknown token is **reported and dropped**: the message names the token,
+the element, the component that wrote it, and every token the palette in
+force does have; that one property goes missing, so the widget paints
+visibly wrong rather than the app dying; and `process.exitCode` is set to 1,
+so a test run, a CI job or a supervisor still counts the run as failed.
+
+That is deliberately not a throw. Resolution happens when a node's ancestry
+completes — inside a commit, and also from an X event when the desktop
+switches between light and dark — and on both of those paths a throw is
+uncatchable: it either lands on the `<window>` fiber above every error
+boundary the app wrote inside it, or it unwinds into the frame loop with no
+React on the stack at all. One wrong character in a style value should not
+be able to blank the screen.
+
+Set **`REACT_X11_STRICT_TOKENS=1`** to make it fatal again — for a kiosk, or
+a build that would rather stop than paint something wrong. Strict mode also
+throws in the right _place_: the error is raised from the offending node's
+own `commitMount`, so an error boundary at any depth inside the window
+catches it and shows a fallback for that subtree. Where React genuinely is
+not on the stack — the desktop appearance switch — strict mode crashes,
+which is what it was asked for.
+
+A token with **no** theme above it at all warns in dev — that one is
+otherwise silent, since the whole style is stripped rather than one value
+failing. Resolution is cached per (style object, theme object), so a hoisted
+style under one theme keeps its identity across renders and the `===` fast
+path still applies; a misspelling in a shared style is reported for every
+node that wears it, not just the first.
 
 Resolution walks the node tree, not React context, so a palette has to reach
 the tree to be seen. `<ThemeProvider>` puts it in both places — the context
@@ -838,8 +860,8 @@ subtree — and in a style you pass one — with no provider anywhere.
 With no `theme` prop above it at all, a token resolves against **the
 desktop's palette** — `backgroundColor: '$background'` in an app that never
 wrote a `<ThemeProvider>` is dark on a dark desktop, which is how that app
-blends in ([appearance.md](appearance.md)). A token no palette defines is an
-error naming every token the one in force does have.
+blends in ([appearance.md](appearance.md)). A token no palette defines is
+reported the same way, naming every token the one in force does have.
 
 ## Transitions
 

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -34,7 +34,11 @@ import {
 } from './nodes.js';
 import { hasDropProps } from './dnd.js';
 import { AppProvider } from './appcontext.js';
-import { defaultRootHandlers, setErrorHandler } from './errors.js';
+import {
+  defaultRootHandlers,
+  setErrorHandler,
+  STRICT_TOKENS,
+} from './errors.js';
 import {
   registerApp,
   unregisterApp,
@@ -303,15 +307,29 @@ const HostConfig = {
     // and trapFocus need commitMount too — the node has to be in the tree
     // first, so it can find the EventManager that owns focus. Drop targets
     // likewise: registration needs the root, which insertion assigns.
+    //
+    // Under REACT_X11_STRICT_TOKENS every token-styled node asks for one as
+    // well, since a bad token is only *found* once the node is attached —
+    // which is after this ran — and commitMount is the first moment React
+    // holds that node's own fiber (nodes.js `_tokenProblem`). Gated on the
+    // flag so the default mount pays nothing for a debugging mode.
     return (
       type === 'popup' ||
       Boolean(props.autoFocus) ||
       Boolean(props.trapFocus) ||
-      hasDropProps(props)
+      hasDropProps(props) ||
+      (STRICT_TOKENS && instance._usesTokens)
     );
   },
 
   commitMount(instance, type, props) {
+    // first, and before any of the work below: the tree is on its way out.
+    // `false` afterwards marks this instance's one commitMount spent, so a
+    // later re-attach throws at once rather than deferring to a call that
+    // will never come (nodes.js `_tokenProblem`).
+    const tokenError = instance._tokenError;
+    instance._tokenError = false;
+    if (tokenError) throw tokenError;
     if (type === 'popup') {
       instance.realize(null);
     }

--- a/src/errors.js
+++ b/src/errors.js
@@ -59,6 +59,48 @@ export function reportHandlerError(node, handler, error) {
   markFailed();
 }
 
+/**
+ * `REACT_X11_STRICT_TOKENS=1` makes a `$token` the theme does not define
+ * fatal again, for a build that would rather stop than paint something
+ * wrong. The default reports and carries on — see `reportStyleError`.
+ *
+ * Guarded rather than a bare `process.env` because the playground bundle
+ * runs in a browser, where there is no `process` at all.
+ */
+export const STRICT_TOKENS =
+  (typeof process === 'undefined'
+    ? undefined
+    : process.env?.REACT_X11_STRICT_TOKENS) === '1';
+
+/** Messages already printed, so a shared misspelled style reports once per
+ *  (node, message) rather than once per restyle — a theme swap re-resolves
+ *  the whole subtree and would otherwise print the same line every time. */
+const reportedStyleErrors = new WeakMap();
+
+/**
+ * A style the node cannot resolve — today only an unknown `$token`.
+ *
+ * Not a throw, and deliberately: the mistake is one property in one style,
+ * and the tree it would take down is the whole GUI. The property is dropped
+ * (so the widget paints without it, visibly wrong), the message names the
+ * token and whose element wore it, and `process.exitCode` is set so a test
+ * run or a supervisor still counts this as a failure. `REACT_X11_STRICT_TOKENS=1`
+ * restores the throw.
+ */
+export function reportStyleError(node, message) {
+  const seen = reportedStyleErrors.get(node);
+  if (seen?.has(message)) return;
+  if (seen) seen.add(message);
+  else reportedStyleErrors.set(node, new Set([message]));
+  const owner = ownerName(node);
+  console.error(
+    `${message}${owner ? ` — in ${owner}` : ''}. ` +
+      'The property is dropped and the app carries on; set ' +
+      'REACT_X11_STRICT_TOKENS=1 to make this throw instead.',
+  );
+  markFailed();
+}
+
 /** Wrap a call to user code so a throw is reported instead of escaping. */
 export function callHandler(node, handler, fn, ev) {
   try {

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -109,7 +109,12 @@ import {
   windowOrigin,
 } from './anchor.js';
 import { baseTheme } from './palette.js';
-import { callHandler, ownerName } from './errors.js';
+import {
+  callHandler,
+  ownerName,
+  reportStyleError,
+  STRICT_TOKENS,
+} from './errors.js';
 import {
   hooks as a11yHooks,
   isFocusable as a11yFocusable,
@@ -1557,6 +1562,11 @@ export class Node {
     // subtree's hit reach, invalidated through _clearHitBounds()
     this._paintOrderCache = null;
     this._hitBoundsCache = null;
+    // a `$token` the theme does not define, held for `commitMount` to throw
+    // on this node's own fiber — see `_tokenProblem`. Strict mode only.
+    // `null` is "commitMount is still to come", `false` is "it has been and
+    // gone", and an Error is one waiting for it
+    this._tokenError = null;
     this._syncStyle(props);
     this.yoga = yoga ? createLayoutNode() : null;
     if (this.yoga) {
@@ -1588,7 +1598,7 @@ export class Node {
    * them. `baseStyle` is the flattened `style` prop; `style` is that with
    * the active state blocks overlaid.
    */
-  _syncStyle(props) {
+  _syncStyle(props, mounting = false) {
     if (DEV && this.stylable) {
       assertNoFlatStyleProps(props, this.kind, this.semanticNames);
       validateStyle(flattenStyle(props.style), `<${this.kind} style>`);
@@ -1597,12 +1607,16 @@ export class Node {
     this._usesTokens = this.stylable && styleUsesTokens(this._baseStyle);
     if (this._usesTokens) {
       const theme = this.theme;
+      const strict = this.placed;
+      const problems = strict ? [] : null;
       this._baseStyle = resolveTokens(
         this._baseStyle,
         theme,
         `<${this.kind} style>`,
-        this.placed,
+        strict,
+        problems,
       );
+      if (problems?.length) this._tokenProblem(problems, mounting);
     }
     // `disabled` is a prop, not something the pointer does, so it is read
     // straight off props rather than driven by the event manager
@@ -2241,6 +2255,46 @@ export class Node {
     return owner.isPopup ? owner.parent != null : true;
   }
 
+  /**
+   * A `$token` this node's completed ancestry does not define.
+   *
+   * The default is `reportStyleError`: say so loudly, set `process.exitCode`,
+   * and keep the property dropped. `REACT_X11_STRICT_TOKENS=1` makes it fatal
+   * again, and then *where* the throw lands is the whole question — an error
+   * boundary only catches what React invoked, on the fiber React thinks it
+   * is working on.
+   *
+   * `mounting` is the attach walk, which runs inside `appendInitialChild`
+   * while React is completing the nearest host *ancestor* — the `<window>`,
+   * for a whole tree rendered at once. A throw there is attributed to the
+   * window and sails past every boundary the app wrote inside it, which is
+   * the bug this deferral exists for (#420). Stashed instead, and thrown
+   * from `commitMount` on this node's own fiber, where the walk up finds a
+   * boundary at any depth.
+   *
+   * Every other caller already has the right fiber (`commitUpdate`) or has
+   * no React on the stack at all (`appearanceChanged`, from an X event) —
+   * for those, throwing here is both the earliest and the only option, and
+   * the second is the crash strict mode asked for.
+   *
+   * `commitMount` happens once per instance, so a node re-attached after it
+   * has been and gone has nothing left to defer *to*; stashing there would
+   * swallow the error instead of raising it late. Those throw at once, like
+   * the keyed reorder they resemble.
+   */
+  _tokenProblem(problems, mounting) {
+    if (!STRICT_TOKENS) {
+      // every one of them: two misspellings in a style are two things to
+      // fix, and a report that named only the first would send someone back
+      // for a second run to find the second
+      for (const message of problems) reportStyleError(this, message);
+      return;
+    }
+    const error = new Error(problems[0]);
+    if (mounting && this._tokenError === null) this._tokenError = error;
+    else throw error;
+  }
+
   /** The owning window resized: re-resolve, since a query block may now
    * match that did not, or the other way round. */
   _sizeQueriesChanged() {
@@ -2287,7 +2341,7 @@ export class Node {
       if (this.isWindow) this._syncWindowBackground();
       if (this._usesTokens) {
         const before = this.style;
-        this._syncStyle(this.props);
+        this._syncStyle(this.props, mounting);
         // a token change reaches the node without React re-rendering it, so
         // the invalidation a commit would have done has to happen here too
         if (localTextStyleChanged(this.style, before)) {

--- a/src/style.d.ts
+++ b/src/style.d.ts
@@ -43,12 +43,15 @@ export function tokenNames(
   style: StyleProperties,
   out?: Set<string>,
 ): Set<string>;
-/** Replace `$token` references with values from the theme. */
+/** Replace `$token` references with values from the theme. A token the theme
+ *  does not define is dropped either way; with `strict`, the message naming
+ *  it is pushed onto `problems` for the caller to report or throw. */
 export function resolveTokens(
   style: StyleProperties,
   theme: Record<string, unknown> | null | undefined,
   where?: string,
   strict?: boolean,
+  problems?: string[] | null,
 ): StyleProperties;
 
 export function styleHasSizeQueries(style: StyleProperties): boolean;

--- a/src/styles.js
+++ b/src/styles.js
@@ -1206,16 +1206,37 @@ export function stripTokens(style) {
  * `strict` says the node's ancestry is complete, so a token that does not
  * resolve is a mistake. While a subtree is still being built its nodes can
  * see only part of their ancestry — the theme two levels up does not exist
- * for them yet — so resolution there is provisional: unknown tokens are
- * dropped and the node restyles when it attaches.
+ * for them yet — so resolution there is provisional.
+ *
+ * Both cases drop the property, because a value is either resolved or absent
+ * and `'$textMuted1'` is not a colour. What `strict` changes is whether
+ * anyone hears about it: mistakes are pushed onto `problems` and the caller
+ * decides what one costs. Resolving itself never throws — it runs from a
+ * commit and from an X event alike, and only the caller knows whether React
+ * is on the stack to route a throw to a boundary (src/nodes.js).
+ *
+ * A cache hit replays the problems it recorded, so the second node to wear a
+ * misspelled shared style is reported like the first.
  */
-export function resolveTokens(style, theme, where = 'style', strict = true) {
+export function resolveTokens(
+  style,
+  theme,
+  where = 'style',
+  strict = true,
+  problems = null,
+) {
   if (!theme) return stripTokens(style);
   let byTheme = strict ? resolvedCache.get(style) : null;
   if (strict && !byTheme) resolvedCache.set(style, (byTheme = new WeakMap()));
   const hit = byTheme?.get(theme);
-  if (hit) return hit;
+  if (hit) {
+    if (problems && hit.problems) problems.push(...hit.problems);
+    return hit.out;
+  }
 
+  // collected here rather than pushed straight to `problems` so the cache
+  // entry can keep them: the caller that misses is not the only one to hear
+  const found = strict ? [] : null;
   const out = {};
   for (const key of Object.keys(style)) {
     const v = style[key];
@@ -1225,11 +1246,7 @@ export function resolveTokens(style, theme, where = 'style', strict = true) {
         out[key] = theme[name];
         continue;
       }
-      if (!strict) continue;
-      throw new Error(
-        `react-x11: unknown theme token "${v}" in ${where} ` +
-          `(theme has ${Object.keys(theme).join(', ') || 'nothing'})`,
-      );
+      if (strict) found.push(unknownToken(v, theme, where));
     } else if (mentionsToken(v)) {
       let unknown = null;
       const substituted = v.replace(TOKEN_IN_VALUE, (token) => {
@@ -1245,13 +1262,10 @@ export function resolveTokens(style, theme, where = 'style', strict = true) {
       // frame instead of at the style.
       if (!unknown) out[key] = substituted;
       else if (strict) {
-        throw new Error(
-          `react-x11: unknown theme token "${unknown}" in ${where} ${key} ` +
-            `(theme has ${Object.keys(theme).join(', ') || 'nothing'})`,
-        );
+        found.push(unknownToken(unknown, theme, `${where} ${key}`));
       }
     } else if (key.charCodeAt(0) === 58 && v) {
-      out[key] = resolveTokens(v, theme, `${where} ${key}`, strict);
+      out[key] = resolveTokens(v, theme, `${where} ${key}`, strict, found);
     } else if (key === 'animation' && v && typeof v === 'object') {
       const loops = {};
       let incomplete = false;
@@ -1266,11 +1280,11 @@ export function resolveTokens(style, theme, where = 'style', strict = true) {
           theme,
           `${where} animation ${prop}`,
           strict,
+          found,
         );
-        // A provisional resolution drops what it cannot resolve, which for
-        // an ordinary property means "not styled yet". A loop with one end
-        // missing is not a shorter loop, so the whole declaration waits for
-        // the ancestry to complete rather than throwing at a half of one.
+        // A loop with one end missing is not a shorter loop, so a
+        // declaration that lost a value is dropped whole rather than run
+        // between a colour and nothing.
         if (Object.keys(resolved).length !== Object.keys(entry).length) {
           incomplete = true;
         }
@@ -1281,8 +1295,18 @@ export function resolveTokens(style, theme, where = 'style', strict = true) {
       out[key] = v;
     }
   }
-  byTheme?.set(theme, out);
+  if (found?.length && problems) problems.push(...found);
+  byTheme?.set(theme, { out, problems: found?.length ? found : null });
   return out;
+}
+
+/** The one message, written once: what was named, and what the palette in
+ *  force actually has — listing the alternatives is most of the fix. */
+function unknownToken(token, theme, where) {
+  return (
+    `react-x11: unknown theme token "${token}" in ${where} ` +
+    `(theme has ${Object.keys(theme).join(', ') || 'nothing'})`
+  );
 }
 
 export { validateStyle };

--- a/test/style.test.js
+++ b/test/style.test.js
@@ -99,13 +99,23 @@ test('a $token resolves inside a decoration, not only as the whole value', async
       boxShadow: '0 2px 8px rgba(0, 0, 0, .4)',
     },
   );
-  assert.throws(
-    () =>
-      resolveTokens(
-        { backgroundImage: 'linear-gradient($nope, #000)' },
-        theme,
-        '<box style>',
-      ),
+  // A token inside a value is the same mistake as a whole-value one, and
+  // gets the same treatment: the property is dropped rather than painted
+  // half-substituted, and the message goes to the caller to place.
+  const problems = [];
+  assert.deepStrictEqual(
+    resolveTokens(
+      { backgroundImage: 'linear-gradient($nope, #000)' },
+      theme,
+      '<box style>',
+      true,
+      problems,
+    ),
+    {},
+    'a gradient missing one stop is not a shorter gradient',
+  );
+  assert.match(
+    problems.join('\n'),
     /unknown theme token "\$nope" in <box style> backgroundImage/,
   );
 });
@@ -967,14 +977,12 @@ test('a popup inherits the theme of where it is written, not its window', async 
 test('an unknown token is an error naming what the theme has', async () => {
   const app = createMockApp();
   const errors = [];
-  // The tree throws on purpose. `onUncaughtError` is the channel for that —
-  // the default one logs *and* sets process.exitCode, which is right for an
-  // app and wrong for a test asserting on the message.
-  const x11Root = await createRoot({
-    app,
-    onUncaughtError: (err) => errors.push(String(err?.message ?? err)),
-  });
+  const x11Root = await createRoot({ app });
+  // The report logs *and* sets process.exitCode, which is right for an app
+  // and wrong for a test asserting on the message (test/theme-token-errors
+  // pins both halves).
   const orig = console.error;
+  const origCode = process.exitCode;
   console.error = (...a) => errors.push(a.join(' '));
   try {
     x11Root.render(
@@ -987,6 +995,7 @@ test('an unknown token is an error naming what the theme has', async () => {
     await tick();
   } finally {
     console.error = orig;
+    process.exitCode = origCode;
   }
   assert.match(errors.join('\n'), /unknown theme token "\$pannel"/);
   // The palette a node sees is the built-in one with this `theme` prop
@@ -1175,11 +1184,9 @@ test('a $token with no provider resolves against the desktop’s palette', async
 test('a $token nothing defines is still an error, provider or not', async () => {
   const app = createMockApp();
   const errors = [];
-  const x11Root = await createRoot({
-    app,
-    onUncaughtError: (err) => errors.push(String(err?.message ?? err)),
-  });
+  const x11Root = await createRoot({ app });
   const orig = console.error;
+  const origCode = process.exitCode;
   console.error = (...a) => errors.push(a.join(' '));
   try {
     x11Root.render(
@@ -1192,6 +1199,7 @@ test('a $token nothing defines is still an error, provider or not', async () => 
     await tick();
   } finally {
     console.error = orig;
+    process.exitCode = origCode;
   }
   // It used to be a one-off warning and a silently dropped property, because
   // there was no palette to check against. Now there always is, so this is

--- a/test/theme-token-errors.test.js
+++ b/test/theme-token-errors.test.js
@@ -1,0 +1,358 @@
+// What a misspelled `$token` costs (#420).
+//
+// It used to cost the whole GUI: `resolveTokens` threw, and the throw was
+// raised from the attach walk inside `appendInitialChild` — React completing
+// the nearest host *ancestor*, which for a tree rendered at once is the
+// `<window>`. Attributed there, it sailed past every error boundary the app
+// had written inside that window and came out as `onUncaughtError`: a blank
+// screen from one wrong character in a style value.
+//
+// The default now reports and carries on. `REACT_X11_STRICT_TOKENS=1` puts
+// the throw back, and these pin the part that makes it usable: it lands on
+// the offending node's own fiber, so a boundary at any depth catches it.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import { createRoot } from '../src/index.js';
+import { appearanceChanged } from '../src/nodes.js';
+import { createMockApp } from './helpers/mock-app.js';
+import { runScript } from './helpers/run-script.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+const nodeOf = (app, index = 0) => app.windows[index]._reactX11Node;
+
+/** Capture console.error and process.exitCode around a body — the report
+ *  sets the exit code on purpose, and a test asserting on it must not leak
+ *  it into the runner's own result. */
+async function captured(body) {
+  const errors = [];
+  const origError = console.error;
+  const origCode = process.exitCode;
+  console.error = (...a) => errors.push(a.map(String).join(' '));
+  try {
+    await body(errors);
+  } finally {
+    console.error = origError;
+    errors.exitCode = process.exitCode;
+    process.exitCode = origCode;
+  }
+  return errors;
+}
+
+test('a misspelled token drops one property and leaves the app standing', async () => {
+  const app = createMockApp();
+  const uncaught = [];
+  const x11Root = await createRoot({
+    app,
+    onUncaughtError: (err) => uncaught.push(String(err?.message ?? err)),
+  });
+  const errors = await captured(async () => {
+    x11Root.render(
+      h(
+        'window',
+        { width: 100, height: 100 },
+        h('box', {
+          style: {
+            backgroundColor: '$textMuted1',
+            color: '$text',
+            flexGrow: 1,
+          },
+        }),
+      ),
+    );
+    await tick();
+  });
+
+  assert.deepStrictEqual(uncaught, [], 'nothing reaches the root as a crash');
+  assert.strictEqual(app.windows.length, 1, 'the window is still there');
+  const box = nodeOf(app).children[0];
+  assert.strictEqual(
+    box.style.backgroundColor,
+    undefined,
+    'the property nobody could resolve is dropped, not painted as "$…"',
+  );
+  assert.ok(box.style.color, 'the tokens that did resolve are untouched');
+  assert.match(errors.join('\n'), /unknown theme token "\$textMuted1"/);
+  assert.match(
+    errors.join('\n'),
+    /theme has border, borderFocus, background/,
+    'the message lists the palette in force, which is most of the fix',
+  );
+  assert.match(errors.join('\n'), /REACT_X11_STRICT_TOKENS=1/, 'and the seam');
+  assert.strictEqual(
+    errors.exitCode,
+    1,
+    'a run that painted something wrong must not exit 0 — CI still fails',
+  );
+  await x11Root.unmount();
+});
+
+test('the report names the component that wrote the style', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  function Sidebar() {
+    return h('box', { style: { backgroundColor: '$panle', flexGrow: 1 } });
+  }
+  const errors = await captured(async () => {
+    x11Root.render(h('window', { width: 100, height: 100 }, h(Sidebar)));
+    await tick();
+  });
+  // `<box>` alone never tells anyone whose box it was
+  assert.match(errors.join('\n'), /in Sidebar/);
+  await x11Root.unmount();
+});
+
+test('two misspellings in one style are two reports', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const errors = await captured(async () => {
+    x11Root.render(
+      h(
+        'window',
+        { width: 100, height: 100 },
+        h('box', {
+          style: { flexGrow: 1, backgroundColor: '$surfce', color: '$texd' },
+        }),
+      ),
+    );
+    await tick();
+  });
+  // naming only the first would send someone back for a second run
+  const joined = errors.join('\n');
+  assert.match(joined, /"\$surfce"/);
+  assert.match(joined, /"\$texd"/);
+  await x11Root.unmount();
+});
+
+test('a bad token in a state block is reported once, not once per restyle', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const errors = await captured(async () => {
+    x11Root.render(
+      h(
+        'window',
+        { width: 100, height: 100, theme: { panel: '#123456' } },
+        h('box', {
+          style: {
+            flexGrow: 1,
+            backgroundColor: '$panel',
+            ':hover': { backgroundColor: '$panell' },
+          },
+        }),
+      ),
+    );
+    await tick();
+    // a live theme swap re-resolves the whole subtree; the same misspelling
+    // must not print again for every palette the app tries
+    x11Root.render(
+      h(
+        'window',
+        { width: 100, height: 100, theme: { panel: '#654321' } },
+        h('box', {
+          style: {
+            flexGrow: 1,
+            backgroundColor: '$panel',
+            ':hover': { backgroundColor: '$panell' },
+          },
+        }),
+      ),
+    );
+    await tick();
+  });
+  const hits = errors.filter((line) => /\$panell/.test(line));
+  assert.strictEqual(hits.length, 1, `reported once, saw ${hits.length}`);
+  assert.match(hits[0], /in <box style> :hover/, 'named down to the block');
+  assert.strictEqual(
+    nodeOf(app).children[0].style.backgroundColor,
+    '#654321',
+    'and the token that does resolve still follows the swap',
+  );
+  await x11Root.unmount();
+});
+
+test('a desktop appearance change with a bad token does not take the process', async () => {
+  // `appearanceChanged` runs from an X event with no React on the stack, so
+  // there is no boundary anywhere that could catch a throw — it would unwind
+  // into the frame loop. This is the case the default exists for.
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const errors = await captured(async () => {
+    x11Root.render(
+      h(
+        'window',
+        { width: 100, height: 100 },
+        h('box', { style: { backgroundColor: '$nope', flexGrow: 1 } }),
+      ),
+    );
+    await tick();
+    assert.doesNotThrow(() => appearanceChanged(app));
+    await tick();
+  });
+  assert.match(errors.join('\n'), /unknown theme token "\$nope"/);
+  assert.strictEqual(app.windows.length, 1, 'the window survived the switch');
+  await x11Root.unmount();
+});
+
+// ---------------------------------------------------------------------------
+// REACT_X11_STRICT_TOKENS=1 — run out of process, since the flag is read once
+// at import and the reconciler's finalizeInitialChildren is gated on it.
+
+const STRICT = { REACT_X11_STRICT_TOKENS: '1' };
+
+const boundary = `
+  class Boundary extends React.Component {
+    constructor(p) { super(p); this.state = { err: null }; }
+    static getDerivedStateFromError(err) { return { err }; }
+    render() {
+      return this.state.err
+        ? React.createElement('box', { style: { backgroundColor: '#f00' } })
+        : this.props.children;
+    }
+  }
+`;
+
+test('strict: a boundary inside the window catches a bad token on mount', async () => {
+  // The whole point. Before the deferral to commitMount this was structurally
+  // impossible: the throw was attributed to the <window> above the boundary.
+  const { stdout } = await runScript(
+    `
+    import React from 'react';
+    import { createRoot } from './src/index.js';
+    import { createMockApp } from './test/helpers/mock-app.js';
+    const h = React.createElement;
+    ${boundary}
+    const app = createMockApp();
+    const uncaught = [];
+    const root = await createRoot({
+      app,
+      onUncaughtError: (e) => uncaught.push(String(e?.message ?? e)),
+      onCaughtError: () => {},
+    });
+    console.error = () => {};
+    root.render(
+      h('window', { width: 100, height: 100 },
+        h('box', null,
+          h(Boundary, null,
+            h('box', { style: { backgroundColor: '$nope', flexGrow: 1 } })))));
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    const box = app.windows[0]._reactX11Node.children[0].children[0];
+    process.stdout.write(JSON.stringify({
+      uncaught: uncaught.length,
+      windows: app.windows.length,
+      fallback: box.style.backgroundColor,
+    }));
+    process.exitCode = 0;
+    `,
+    STRICT,
+  );
+  assert.deepStrictEqual(JSON.parse(stdout), {
+    uncaught: 0,
+    windows: 1,
+    fallback: '#f00',
+    // the boundary's fallback is on screen and the window is still up: the
+    // blast radius is the subtree that named the token, not the app
+  });
+});
+
+test('strict: with no boundary it is fatal, which is what strict means', async () => {
+  const { stdout } = await runScript(
+    `
+    import React from 'react';
+    import { createRoot } from './src/index.js';
+    import { createMockApp } from './test/helpers/mock-app.js';
+    const h = React.createElement;
+    const app = createMockApp();
+    const uncaught = [];
+    const root = await createRoot({
+      app,
+      onUncaughtError: (e) => uncaught.push(String(e?.message ?? e)),
+    });
+    console.error = () => {};
+    root.render(
+      h('window', { width: 100, height: 100 },
+        h('box', { style: { backgroundColor: '$nope', flexGrow: 1 } })));
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    process.stdout.write(JSON.stringify({ uncaught }));
+    process.exitCode = 0;
+    `,
+    STRICT,
+  );
+  const { uncaught } = JSON.parse(stdout);
+  // React re-renders a root whose commit threw with nothing to catch it, so
+  // the same error can arrive more than once — what matters is that it got
+  // there at all, and said what it was
+  assert.ok(uncaught.length >= 1, 'the root heard about it');
+  for (const message of uncaught) {
+    assert.match(message, /unknown theme token "\$nope"/);
+  }
+});
+
+test('strict: a bad token arriving on an update reaches the boundary too', async () => {
+  const { stdout } = await runScript(
+    `
+    import React from 'react';
+    import { createRoot } from './src/index.js';
+    import { createMockApp } from './test/helpers/mock-app.js';
+    const h = React.createElement;
+    ${boundary}
+    const app = createMockApp();
+    const uncaught = [];
+    const root = await createRoot({
+      app,
+      onUncaughtError: (e) => uncaught.push(String(e?.message ?? e)),
+      onCaughtError: () => {},
+    });
+    console.error = () => {};
+    let go;
+    function Inner() {
+      const [bad, set] = React.useState(false);
+      go = () => set(true);
+      return h('box', {
+        style: { flexGrow: 1, backgroundColor: bad ? '$nope' : '#fff' },
+      });
+    }
+    root.render(
+      h('window', { width: 100, height: 100 },
+        h(Boundary, null, h(Inner))));
+    await new Promise((r) => setImmediate(r));
+    go();
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    const box = app.windows[0]._reactX11Node.children[0];
+    process.stdout.write(JSON.stringify({
+      uncaught: uncaught.length,
+      fallback: box.style.backgroundColor,
+    }));
+    process.exitCode = 0;
+    `,
+    STRICT,
+  );
+  assert.deepStrictEqual(JSON.parse(stdout), {
+    uncaught: 0,
+    fallback: '#f00',
+  });
+});
+
+test('strict: a good token still costs nothing but the commitMount', async () => {
+  const { stdout } = await runScript(
+    `
+    import React from 'react';
+    import { createRoot } from './src/index.js';
+    import { createMockApp } from './test/helpers/mock-app.js';
+    const h = React.createElement;
+    const app = createMockApp();
+    const root = await createRoot({ app });
+    root.render(
+      h('window', { width: 100, height: 100, theme: { panel: '#abcdef' } },
+        h('box', { style: { backgroundColor: '$panel', flexGrow: 1 } })));
+    await new Promise((r) => setImmediate(r));
+    const box = app.windows[0]._reactX11Node.children[0];
+    process.stdout.write(JSON.stringify({ bg: box.style.backgroundColor }));
+    `,
+    STRICT,
+  );
+  assert.deepStrictEqual(JSON.parse(stdout), { bg: '#abcdef' });
+});


### PR DESCRIPTION
A one-character typo in a style value could blank the whole app, and no error
boundary could stop it.

## What was wrong

`resolveTokens` threw on a `$token` the palette does not define. The throw was
raised from the attach walk inside `appendInitialChild` — React completing the
nearest host *ancestor*, which for a tree rendered in one pass is the
`<window>`. Attributed there, it is above every boundary the app wrote inside
that window, so none of them can catch it, at any depth. It came out as
`onUncaughtError` and the window never appeared.

Where the check lands, before this change:

| when the subtree gets its root | attributed to | a boundary inside the window catches it? |
| --- | --- | --- |
| initial mount of the whole window | the `<window>` fiber | **no** |
| a subtree mounts later into a live parent | the offending node's fiber | yes |
| a bad token arrives on a prop update | that node's fiber | yes |
| desktop light/dark switch, via `appearanceChanged` | nothing — an X event, no React on the stack | **no** |

Two of the four cannot be caught at all. And even where a boundary does catch
it, one high enough to be reliable sits outside the `<window>`, so catching
means losing the window anyway.

## What it does now

An unknown token is **reported and dropped**. The message names the token, the
element, the component that wrote it, and every token the palette in force
does have; that one property goes missing, so the widget paints visibly wrong;
and `process.exitCode` is set to 1, so a test run, a CI job or a supervisor
still counts the run as failed.

```
react-x11: unknown theme token "$textMuted1" in <text style> (theme has border, borderFocus, background, …) — in Panel.
The property is dropped and the app carries on; set REACT_X11_STRICT_TOKENS=1 to make this throw instead.
```

Every bad token in a style is named, deduped per node so a theme swap does not
reprint the same line, and reported for each node wearing a shared misspelled
style rather than only the first to miss the resolution cache.

## The seam

`REACT_X11_STRICT_TOKENS=1` makes it fatal again, for a kiosk or a CI job that
would rather stop than paint something wrong — and it throws somewhere useful.
The error found during the attach walk is stashed and raised from the offending
node's own `commitMount`, so React holds that node's fiber and **a boundary at
any depth inside the window catches it** and renders a fallback for that
subtree. With no boundary it reaches `onUncaughtError` and the process stops.
The appearance switch still cannot be routed and crashes there, which is what
strict mode is for.

`finalizeInitialChildren` opts a token-styled node into a `commitMount` only
under the flag, so a default mount pays nothing for the debugging mode.

## Screenshots

Same scene both sides, rendered headlessly into node-x11's in-process X server
by each checkout's own code. One `<text>` says `color: '$textMuted1'`, a typo
for `$textMuted`.

**Before — master.** The render dies in the commit and no window is ever
mapped. This is the bare root:

![before](https://github.com/user-attachments/assets/54a12d87-aca8-44bc-9873-5731b3495726)

**After — this branch.** The panel renders. The typo'd value, `running`, falls
back to the inherited colour instead of the muted grey the other three values
use, so the mistake is visible without being fatal:

![after](https://github.com/user-attachments/assets/2d329dd7-a6fe-4e20-8671-6e3b1c537808)

## Tests

`test/theme-token-errors.test.js`, nine tests over both modes: the drop and the
exit code, the owner name in the message, two misspellings reported twice, the
per-node dedup across a theme swap, the appearance switch surviving, and under
the flag — the in-window boundary catching a mount, the fatal no-boundary case,
the update path, and a good token still resolving.

Mutation-checked: reverting the `commitMount` deferral fails the boundary test,
and silencing the default fails all four default tests.

Full suite green apart from the six macOS-only `appearance.test.js` failures
that are already there on master. Lint, typecheck and `prettier --check` clean.

## Docs

`docs/styling.md` for the behaviour and why it is not a throw;
`docs/debugging.md` for the flag, beside the other switches.

