### PR TITLE
fix(bench): a scenario's numbers no longer depend on what ran before it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,14 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
-      # One retry: the counts carry a little event-loop/GC jitter (see the
-      # header of scripts/bench/protocol.js) and the tolerances absorb it,
-      # but a real regression fails twice; a rare unlucky run does not.
+      # Each scenario runs in its own process (issue #416): in one process
+      # they are not independent — a change to an earlier scenario's garbage
+      # moves when the collector runs inside a later one, and a pause inside
+      # a paced frame turns that frame's bounded repaint into a full-window
+      # one, which is a 6x metric swing no tolerance can absorb.
+      # One retry on top, for the per-scenario event-loop jitter the header
+      # of scripts/bench/protocol.js describes: a real regression fails
+      # twice; a rare unlucky run does not.
       - run: npm run bench -- --check || npm run bench -- --check
       # The other half of the gate, and the one that makes the first half
       # safe: cheaper is only an optimization if the picture is the same.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -822,6 +822,15 @@ unchanged across the fix.
 
 - `npm run bench -- --save` rewrites `scripts/bench/baseline.json`
 - `npm run bench -- --check` fails if a metric regressed past tolerance
+- `npm run bench -- --only <substring>` runs (and with `--save`, re-records)
+  just the scenarios whose names match — repeatable
+- Each scenario runs in its own process, because they are not independent in
+  one: ntk frees X resources from FinalizationRegistry callbacks, so a change
+  to an _earlier_ scenario's garbage moves when the collector runs inside a
+  later one, and a pause inside a paced frame turns a bounded repaint into a
+  full-window one (issue #416 — 6x the composite pixels in a scenario the
+  change never touched). `--no-isolate` puts them back in one process: ~3x
+  faster for a development loop, and coupled again
 
 For a live app rather than the bench scenarios, `REACT_X11_TRACE=summary`
 (or `requests`, or `chrome:/tmp/t.json` for Perfetto) traces the protocol

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "stress:check": "tsx scripts/check-stress.jsx",
     "screenshots": "tsx scripts/screenshots.jsx",
     "screenshots:framed": "tsx scripts/screenshots-framed.jsx",
-    "bench": "tsx scripts/bench/protocol.js",
+    "bench": "node --expose-gc --import tsx scripts/bench/protocol.js",
     "bench:pixels": "tsx scripts/bench/pixels.js",
     "bench:frames": "tsx scripts/bench/frames.js",
     "docs:dev": "npm --prefix website start",

--- a/scripts/bench/protocol.js
+++ b/scripts/bench/protocol.js
@@ -3,10 +3,17 @@
 //   npm run bench                        # print the current numbers
 //   npm run bench -- --save              # rewrite the committed baseline
 //   npm run bench -- --check             # fail if a metric regressed
+//   npm run bench -- --only <substring>  # only scenarios whose name matches
+//                                        #   (repeatable; --save then updates
+//                                        #   just those baseline entries)
+//   npm run bench -- --no-isolate        # all scenarios in one process: ~3x
+//                                        #   faster, and coupled (see below)
 //   npm run bench -- --hotspots          # per-scenario efficiency detail:
 //                                        #   the request-name histogram, and
 //                                        #   which requests stalled, repeated
 //                                        #   or churned
+//   npm run bench -- --baseline <file>   # --save/--check against another
+//                                        #   file than the committed one
 //   npm run bench -- --record-dir <dir>  # one .x11cap per scenario, openable
 //                                        #   and diffable with x11vis
 //
@@ -19,6 +26,27 @@
 // request went out. The --check tolerances below are sized to that noise —
 // they exist to catch step changes (a new per-frame resource cycle, a new
 // serialized round trip), not single-request jitter.
+//
+// That jitter is per-*ordering*, not per-metric, which is why the run is
+// arranged the way it is (issue #416). Scenarios sharing a process are not
+// independent in it: a change that only alters how much garbage an
+// *earlier* scenario leaves moves a later, unrelated one, because the
+// collection lands inside the later scenario's paced frames. A frame that
+// misses its deadline repaints the whole window instead of its damage —
+// 6x the composite pixels in a scenario the change never touched.
+// Tolerances sized for "a few requests" cannot absorb a frame changing
+// category, so the run removes the coupling instead of widening the gates:
+//
+//   * every scenario gets its own process, which is the only way the
+//     numbers are actually independent. This is the default; --no-isolate
+//     puts them all back in one process, ~3x faster and coupled again;
+//   * under --no-isolate, `global.gc()` runs between scenarios (the `bench`
+//     script passes --expose-gc), which collapses the FinalizationRegistry
+//     backlog at a point where nothing is being measured. Cheaper, and it
+//     narrows the coupling rather than removing it.
+//
+// --only is the third piece: a --check failure naming a scenario a change
+// does not touch is worth re-running on its own before believing it.
 //
 // Metrics, and why each is here:
 //
@@ -55,9 +83,11 @@
 // round trips but cannot price them — a fence that costs nothing here costs
 // a full RTT on a real display. Grading latency work needs the real-display
 // lane (x11vis --record / --diff); this lane keeps the counts honest.
+import { spawnSync } from 'node:child_process';
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
 import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import React from 'react';
 import xserver from 'x11/lib/xserver/index.js';
 import { createClient, StaticFontSource } from 'ntk';
@@ -78,17 +108,36 @@ const { Node } = await import('../../src/node.js');
 const { Checkbox } = await import('../../src/components/index.js');
 
 const args = process.argv.slice(2);
-const recordDir = args.includes('--record-dir')
-  ? args[args.indexOf('--record-dir') + 1]
-  : null;
-if (
-  args.includes('--record-dir') &&
-  (!recordDir || recordDir.startsWith('--'))
-) {
-  console.error('--record-dir needs a directory argument');
-  process.exit(1);
+
+/** Every value given for a repeatable `--flag <value>` option. */
+function flagValues(flag) {
+  const values = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] !== flag) continue;
+    const value = args[i + 1];
+    if (!value || value.startsWith('--')) {
+      console.error(`${flag} needs an argument`);
+      process.exit(1);
+    }
+    values.push(value);
+  }
+  return values;
 }
+
+const recordDir = flagValues('--record-dir').at(-1) ?? null;
 if (recordDir) mkdirSync(recordDir, { recursive: true });
+
+// Case-insensitive substring match, so `--only pan` picks both pan
+// scenarios and `--only 'absolute box'` picks exactly one.
+const only = flagValues('--only').map((s) => s.toLowerCase());
+// The child half of --isolate: run one scenario, print its numbers as JSON,
+// exit. Internal — the parent passes an index, not a name, so a scenario
+// whose name contains another's cannot be misdirected here.
+const childIndex = flagValues('--child-scenario').at(-1) ?? null;
+// On by default: a coupled number is not worth its ~3x speed, and a
+// printed table that does not match what --check gates is worse than a
+// slow one. --no-isolate is the fast development loop.
+const isolate = !childIndex && !args.includes('--no-isolate');
 
 const require = createRequire(import.meta.url);
 const fontDir = join(
@@ -96,10 +145,11 @@ const fontDir = join(
   'dist',
   'fonts',
 );
-const baselinePath = join(
-  dirname(new URL(import.meta.url).pathname),
-  'baseline.json',
-);
+// --baseline points --save/--check at another file: a scratch copy in a
+// test, or the baseline a branch you are comparing against committed.
+const baselinePath =
+  flagValues('--baseline').at(-1) ??
+  join(dirname(new URL(import.meta.url).pathname), 'baseline.json');
 
 const W = 400;
 const H = 400;
@@ -1345,16 +1395,121 @@ const SCENARIOS = [
 
 // --- run ---------------------------------------------------------------
 
+/**
+ * Collapse the GC backlog between scenarios (issue #416).
+ *
+ * ntk frees X resources from FinalizationRegistry callbacks, so whatever a
+ * scenario dropped is collected at some arbitrary later point — inside the
+ * *next* scenario's paced frames, where the pause can push a frame past its
+ * deadline and turn a bounded repaint into a full-window one. Collecting
+ * here puts that work at a point where nothing is being measured.
+ *
+ * The finalization callbacks are scheduled after the collection rather than
+ * run inside it, so this gives them a turn and then collects again to sweep
+ * what they released. A no-op without --expose-gc (the `bench` script passes
+ * it; `npx tsx scripts/bench/protocol.js` does not).
+ */
+async function collectGarbage() {
+  if (typeof globalThis.gc !== 'function') return;
+  for (let i = 0; i < 2; i++) {
+    globalThis.gc();
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
+const selected = SCENARIOS.map((scenario, index) => [index, scenario]).filter(
+  ([, [name]]) =>
+    only.length === 0 ||
+    only.some((needle) => name.toLowerCase().includes(needle)),
+);
+if (!selected.length) {
+  console.error(`--only matched no scenario: ${only.join(', ')}`);
+  console.error('scenarios are:');
+  for (const [name] of SCENARIOS) console.error(`  ${name}`);
+  process.exit(1);
+}
+
+// The isolation child: one scenario, its numbers on stdout as JSON.
+if (childIndex !== null) {
+  const scenario = SCENARIOS[Number(childIndex)];
+  if (!scenario) {
+    console.error(`--child-scenario ${childIndex} is not a scenario index`);
+    process.exit(1);
+  }
+  const [name, fn] = scenario;
+  const [key, value] = await measure(name, fn);
+  process.stdout.write(
+    `${JSON.stringify({ name: key, result: value, hotspots: hotspots[key] })}\n`,
+  );
+  process.exit(0);
+}
+
+/** Run one scenario in a fresh process, so nothing that ran before it can
+ * have left the heap — or the server — in a different state. */
+function measureIsolated(index, name) {
+  const childArgs = [
+    ...process.execArgv,
+    fileURLToPath(import.meta.url),
+    '--child-scenario',
+    String(index),
+    ...(recordDir ? ['--record-dir', recordDir] : []),
+  ];
+  const child = spawnSync(process.execPath, childArgs, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'inherit'],
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (child.status !== 0) {
+    console.error(`\nscenario "${name}" failed in its own process`);
+    process.exit(child.status || 1);
+  }
+  try {
+    return JSON.parse(child.stdout.trim().split('\n').at(-1));
+  } catch {
+    console.error(`\nscenario "${name}" printed no numbers:`);
+    console.error(child.stdout);
+    process.exit(1);
+  }
+}
+
 const results = {};
-for (const [name, fn] of SCENARIOS) {
+for (const [index, [name, fn]] of selected) {
   // progress to stderr so a hung CI run says which scenario it was in
   process.stderr.write(`· ${name}\n`);
+  if (isolate) {
+    const child = measureIsolated(index, name);
+    results[child.name] = child.result;
+    hotspots[child.name] = child.hotspots;
+    continue;
+  }
   const [key, value] = await measure(name, fn);
   results[key] = value;
+  await collectGarbage();
 }
 
 if (args.includes('--save')) {
-  writeFileSync(baselinePath, `${JSON.stringify(results, null, 2)}\n`);
+  // --only saves the scenarios it ran and leaves the rest of the file
+  // alone — re-measuring one entry must not drop the other twenty, and a
+  // partial run is not evidence that an entry it never ran is stale.
+  let saved = results;
+  if (only.length) {
+    let previous = {};
+    try {
+      previous = JSON.parse(readFileSync(baselinePath, 'utf8'));
+    } catch {
+      // no baseline yet — a filtered --save writes the first entries
+    }
+    // SCENARIOS order, so the file stays diffable against a full --save
+    const merged = { ...previous, ...results };
+    saved = {};
+    for (const [name] of SCENARIOS) {
+      if (merged[name] !== undefined) saved[name] = merged[name];
+    }
+    for (const [name, value] of Object.entries(merged)) {
+      saved[name] ??= value;
+    }
+  }
+  writeFileSync(baselinePath, `${JSON.stringify(saved, null, 2)}\n`);
   console.log(`wrote ${baselinePath}`);
 }
 
@@ -1393,10 +1548,14 @@ if (args.includes('--check')) {
     process.exit(1);
   }
   // A scenario in only one of the two sets means the baseline is stale —
-  // and a renamed scenario would otherwise silently lose its gate.
+  // and a renamed scenario would otherwise silently lose its gate. Under
+  // --only the run is deliberately partial, so a baseline entry that did
+  // not run is expected; an entry that ran without one is still stale.
   const missing = [
     ...Object.keys(results).filter((name) => !baseline[name]),
-    ...Object.keys(baseline).filter((name) => !results[name]),
+    ...(only.length
+      ? []
+      : Object.keys(baseline).filter((name) => !results[name])),
   ];
   if (missing.length) {
     console.error('\nbaseline out of date — run `npm run bench -- --save`:');
@@ -1439,9 +1598,25 @@ if (args.includes('--check')) {
   if (regressions.length) {
     console.error('\nprotocol regressions:');
     for (const r of regressions) console.error(`  ${r}`);
+    // Naming one scenario is the fastest way to look at it on its own —
+    // and under --no-isolate it is also how you tell a real regression from
+    // one an earlier scenario's garbage caused (issue #416).
+    const first = regressions[0].split(' — ')[0];
+    console.error(
+      `\nto re-run just this one: npm run bench -- --only ${JSON.stringify(first)}`,
+    );
+    if (!isolate) {
+      console.error(
+        'these scenarios shared a process (--no-isolate): re-run without it',
+      );
+    }
     process.exit(1);
   }
-  console.log('\nno regressions against the baseline');
+  console.log(
+    only.length
+      ? `\nno regressions against the baseline (${Object.keys(results).length} of ${SCENARIOS.length} scenarios)`
+      : '\nno regressions against the baseline',
+  );
 }
 
 process.exit(0);

--- a/test/bench-runner.test.js
+++ b/test/bench-runner.test.js
@@ -1,0 +1,131 @@
+// The protocol bench's runner, not its numbers (#416).
+//
+// Scenarios used to share a process, and they are not independent in one:
+// ntk frees X resources from FinalizationRegistry callbacks, so a change to
+// how much garbage an *earlier* scenario leaves moves when the collector
+// runs inside a *later* one — and a pause landing inside a paced frame
+// turns that frame's bounded repaint into a full-window one. `--check` then
+// failed by 6x on a scenario the change never touched.
+//
+// So the runner now gives each scenario its own process, and `--only` runs
+// one by name. These pin the plumbing that makes both usable: the filter
+// selects, a filter that matches nothing says so instead of measuring
+// nothing, a filtered `--save` updates its entries without dropping the
+// rest of the baseline, and a scenario missing from the baseline is still
+// reported as stale when the run is partial.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { runNode } from './helpers/run-script.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const script = join(here, '..', 'scripts', 'bench', 'protocol.js');
+const baselinePath = join(here, '..', 'scripts', 'bench', 'baseline.json');
+
+// The two cheapest scenarios in the file: a state flip and five color
+// flips, ~20 requests each. What is being tested is the runner.
+const FLIP = 'rounded box state flip';
+const COLORS = 'color flips';
+
+const bench = (...args) =>
+  runNode(['--import', 'tsx', script, ...args], {}, 120000);
+
+/** The scenario names of a run, read back off the printed table. */
+const rows = (stdout) =>
+  stdout
+    .split('\n')
+    .slice(1)
+    .filter((line) => line.includes(':'))
+    .map((line) => line.split(/ {2,}/)[0]);
+
+test('--only runs just the scenarios whose names match', async () => {
+  const { code, stdout } = await bench('--only', FLIP, '--no-isolate');
+  assert.equal(code, 0);
+  assert.deepEqual(rows(stdout), ['hover: rounded box state flip, on and off']);
+});
+
+test('--only is repeatable', async () => {
+  const { code, stdout } = await bench(
+    '--only',
+    FLIP,
+    '--only',
+    COLORS,
+    '--no-isolate',
+  );
+  assert.equal(code, 0);
+  assert.equal(rows(stdout).length, 2);
+});
+
+test('a filter that matches nothing fails and lists the scenarios', async () => {
+  const { code, stderr } = await bench('--only', 'no such scenario');
+  assert.equal(code, 1);
+  assert.match(stderr, /matched no scenario/);
+  assert.match(stderr, /hover: rounded box state flip, on and off/);
+});
+
+test('--only needs an argument', async () => {
+  const { code, stderr } = await bench('--only');
+  assert.equal(code, 1);
+  assert.match(stderr, /--only needs an argument/);
+});
+
+test('a filtered --save updates its entries and keeps the rest', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'bench-baseline-'));
+  const file = join(dir, 'baseline.json');
+  const before = JSON.parse(readFileSync(baselinePath, 'utf8'));
+  const name = 'hover: rounded box state flip, on and off';
+  // a value no run can produce, so "was it rewritten" has one answer
+  before[name] = { ...before[name], requests: 999999 };
+  writeFileSync(file, JSON.stringify(before, null, 2));
+
+  const { code } = await bench(
+    '--only',
+    FLIP,
+    '--save',
+    '--baseline',
+    file,
+    '--no-isolate',
+  );
+  assert.equal(code, 0);
+
+  const after = JSON.parse(readFileSync(file, 'utf8'));
+  assert.deepEqual(Object.keys(after), Object.keys(before));
+  assert.notEqual(after[name].requests, 999999);
+  for (const other of Object.keys(after)) {
+    if (other === name) continue;
+    assert.deepEqual(after[other], before[other]);
+  }
+});
+
+test('--check under --only still catches a scenario the baseline lacks', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'bench-baseline-'));
+  const file = join(dir, 'baseline.json');
+  const baseline = JSON.parse(readFileSync(baselinePath, 'utf8'));
+  const name = 'hover: rounded box state flip, on and off';
+  delete baseline[name];
+  writeFileSync(file, JSON.stringify(baseline, null, 2));
+
+  const { code, stderr } = await bench(
+    '--only',
+    FLIP,
+    '--check',
+    '--baseline',
+    file,
+    '--no-isolate',
+  );
+  assert.equal(code, 1);
+  assert.match(stderr, /baseline out of date/);
+  assert.match(stderr, new RegExp(name));
+});
+
+test('--check under --only ignores the scenarios it did not run', async () => {
+  const { code, stdout } = await bench('--only', FLIP, '--check');
+  assert.equal(code, 0);
+  assert.match(
+    stdout,
+    /no regressions against the baseline \(1 of \d+ scenarios\)/,
+  );
+});


### PR DESCRIPTION
Fixes #416.

## The coupling

Every scenario in `npm run bench` shared one process, and in one process they are not independent. ntk frees X resources from FinalizationRegistry callbacks, so a change that only alters how much garbage an *earlier* scenario leaves moves when the collector runs inside a *later* one. A pause landing inside a paced frame makes that frame miss its deadline, and a missed deadline repaints the whole window instead of its damage — 6x the `compositePixels` in a scenario the change never touched, which is far past tolerances sized for a few requests of event-loop jitter.

The issue reports it twice, once as pixels and once as 2.4x the requests on the pan scenario, and both took a bisect to disprove.

## What changed

All three suggestions from the issue, plus the flag that made the merge testable:

- **A process per scenario.** The default now; `--no-isolate` puts them all back in one, ~3x faster for a development loop and coupled again. This is the only way the numbers are actually independent, so it is on for the printed table too — a table that does not match what `--check` gates is worse than a slow one.
- **`global.gc()` between scenarios** under `--no-isolate`, collapsing the finalization backlog where nothing is being measured. The `bench` script passes `--expose-gc` for it.
- **`--only <substring>`**, repeatable and case-insensitive. A filtered `--save` rewrites those baseline entries and leaves the rest of the file alone; a filtered `--check` gates what it ran and prints `no regressions against the baseline (2 of 21 scenarios)`. A `--check` failure also prints the `--only` line that re-runs the scenario it names.
- **`--baseline <file>`** points `--save`/`--check` at another file — a scratch copy in a test, or the baseline a branch you are comparing against committed.

## What it costs, and what it does not

| | before | after |
| --- | --- | --- |
| `npm run bench` | 5.8s | 16.6s |
| `npm run bench -- --no-isolate` | — | 5.8s |

Three consecutive isolated runs on this machine differ only in the two scroll scenarios, by ±4 requests; `composites` and `compositePixels` — the metrics that flipped in the issue — are identical across all three.

**The committed baseline is unchanged.** Isolated numbers pass `--check` against it as they stand, and this PR changes no renderer code, so re-recording would only swap one machine's snapshot for another's.

CI keeps its one retry, for the per-scenario jitter that remains; the comment there now says which failure mode each half covers.

## Tests

`test/bench-runner.test.js` covers the runner rather than the numbers: the filter selects, a filter that matches nothing lists the scenarios and exits 1, a missing argument is reported, a filtered `--save` updates its entries without dropping the other twenty, a partial `--check` still reports a scenario the baseline lacks, and it ignores the ones it did not run. Mutation-checked — reverting each of those three behaviours in turn fails the test that names it.

`npm run typecheck`, `npx eslint .`, `prettier --check .`, `npm run bench -- --check` and `npm run bench:pixels -- --check` all pass.