### PR TITLE
fix(deps): resolve x11 to 4.1.0 so Bun apps keep shared memory and direct GL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5288,9 +5288,9 @@
       }
     },
     "node_modules/x11": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/x11/-/x11-4.0.1.tgz",
-      "integrity": "sha512-24vEriWj4eu2fQxM+SP4wyTKaM8ZCG43BaFskjEy7teHE5I0skQrMuvIpv/4p6DOZFNcWEZHh6DaWQ1rWnibbA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/x11/-/x11-4.1.0.tgz",
+      "integrity": "sha512-3QU0LZjAH8tIkDxosqmW8MPfJngGqGRmmzIFxnBQLuVqLSy64XMfSWnPX4IELlLiq8CJhQ6+GpFohsQVDOAGyw==",
       "engines": {
         "node": ">=18"
       }


### PR DESCRIPTION
## What

Refresh `package-lock.json` so the transitive `x11` dependency resolves to **4.1.0** instead of the pinned **4.0.1**. Lockfile only — three lines, no `package.json` change.

```diff
 "node_modules/x11": {
-  "version": "4.0.1",
+  "version": "4.1.0",
```

`ntk@8.7.0` already declares `"x11": "^4.0.1"`, so 4.1.0 satisfies the existing range; only the lockfile was holding it back. `ntk` is the sole dependent, so this is a single resolution.

## Why

node-x11 4.1.0 — sidorares/node-x11#290 — adds fd passing under Bun via `bun:ffi`. react-x11 apps run under Bun, and on 4.0.1 a Bun app is not fd-capable, so two paths turn themselves off silently:

- **MIT-SHM.** `lib/ext/shm.js` builds its provider only when `serverHasFd && ext.fdCapable`, and Node has no SysV `shmget`/`shmat` to fall back to, so `AttachFd` is the only way in. That is ntk's `lib/shm-upload.js` fast path — image uploads above 64 KB and readbacks above 16 KB.
- **DRI3 direct GL.** `<glarea>`, `<scene3d>` and shaders fall back to indirect GLX.

Neither failure raises an error, which is what makes the stale pin worth fixing rather than noticing later.

## Verification

Against ntk's own `canPassDescriptors` predicate at `lib/gl.js:299`, on Xvfb `:99` with ntk 8.7.0, Bun 1.4.0, Node 26:

| `x11` | Node | Bun |
| --- | --- | --- |
| 4.0.1 | ✅ true | ❌ **false** |
| 4.1.0 | ✅ true | ✅ **true** |

The mechanism is visible in the predicate's inputs — on 4.0.1 under Bun the stream carries neither `_fdCapable` nor `sendFds`, so it short-circuits:

```
x11 4.0.1  Bun   isLocalSocket=true  _fdCapable=false  sendFds=false  -> false
x11 4.1.0  Bun   isLocalSocket=true  _fdCapable=true   sendFds=true   -> true
```

4.1.0 adds `lib/fdpass-bun.js`, absent in 4.0.1, which supplies both. Node is unaffected either way, and react-x11 renders correctly under Bun on both versions — what changes is only whether the fast paths are reachable.

The lockfile's `integrity` and `resolved` were checked against the registry, and `engines` is unchanged at `node >=18`.

## Checks

All CI gates run locally on the updated lockfile:

- `npm test` — **1688 / 1694 pass, 0 skipped.** The 6 failures are the known macOS-only ones in `test/appearance.test.js`; re-running that file against 4.0.1 produces a **byte-identical** set of six, so they are pre-existing and unrelated.
- `npm run lint` — clean
- `npm run format:check` — clean over the whole tree
- `npm run typecheck` — clean
- `npm run bench -- --check` — no regressions against the baseline
- `npm run bench:pixels -- --check` — pixels unchanged

No screenshots: this is not detectable by eye.
