### PR TITLE
feat(examples): live window previews in the wm example

### DIFF
--- a/examples/wm-core.js
+++ b/examples/wm-core.js
@@ -295,13 +295,21 @@ export class Thumbnails {
     entry.drawable = null;
   }
 
-  /** Stop tracking `id` and hand the frame back to the server. */
+  /**
+   * Stop tracking `id`.
+   *
+   * The redirect is not undone, and that is deliberate twice over. A
+   * window's redirection dies with the window, and the only caller is the
+   * one place a frame is about to be unmounted — so there is nothing left
+   * to hand back. And `UnredirectWindow` could not do it anyway:
+   * node-x11 encodes it eight bytes long with no `update` field where the
+   * protocol says twelve with one, so the request is a BadLength on every
+   * real server. See sidorares/node-x11#292.
+   */
   forget(id) {
-    const entry = this._entries.get(id);
-    if (!entry) return;
+    if (!this._entries.has(id)) return;
     this.invalidate(id);
     this._entries.delete(id);
-    this.composite.UnredirectWindow(entry.frameId);
   }
 }
 

--- a/examples/wm-core.js
+++ b/examples/wm-core.js
@@ -7,6 +7,8 @@
 // shown or resized the server asks *us* instead of doing it. Everything
 // below follows from that one fact.
 
+import { Pixmap } from 'ntk';
+
 // X11 protocol constants, spelled out rather than imported: x11 is ntk's
 // dependency, not this package's.
 const SUBSTRUCTURE_NOTIFY = 0x00080000; // event masks
@@ -153,13 +155,169 @@ export function resizeRect(start, edges, dx, dy, limits) {
   return { x, y, width, height };
 }
 
+// ---------------------------------------------------------------------------
+// Live window contents
+//
+// A window manager can show what a window looks like without reading a
+// single pixel back. The Composite extension redirects a window's drawing
+// into an offscreen pixmap; `NameWindowPixmap` gives that pixmap an id, and
+// react-x11's `<image drawable>` composites straight from it through
+// XRender. The server does the scaling, so a 900x600 window shown 240px
+// wide costs one composite per repaint and nothing at all on the socket.
+//
+// `Automatic` is the update type that keeps this a *reparenting* window
+// manager rather than a compositing one: the server goes on painting the
+// redirected window into its parent itself, so the desktop looks and
+// behaves exactly as it did before the redirect. `Manual` is what a
+// compositing manager asks for, and it takes on the job of putting every
+// window on screen in return.
+//
+// Two things about a named pixmap decide the shape of the class below.
+//
+//  - **It is a generation, not a handle.** The server drops it when the
+//    window is resized, so a resize has to name a new one — which is why
+//    `invalidate` exists and why `setGeometry` calls it.
+//  - **Naming it again is cheap and always current.** Every name refers to
+//    the pixmap the window is drawing into *now*, so re-naming is how a
+//    preview stays live: a new id is what tells `<image>` its source
+//    changed. DAMAGE would say exactly when that is worth doing instead of
+//    on a timer, and this example does not go that far — see the note in
+//    wm.jsx.
+//
+// Not everywhere, though: XQuartz carries RENDER, DAMAGE, XFIXES and SHAPE
+// but no Composite at all, and neither does node-x11's in-process server.
+// So `wm.thumbnails` is null on those and everything else works unchanged.
+// ---------------------------------------------------------------------------
+
+/**
+ * The offscreen pixmap behind each frame, named on demand.
+ *
+ * `WindowManager` takes the opener as a seam (`new WindowManager(app, {
+ * openThumbnails })`) so a test can hand it a fake — the real one needs a
+ * server with Composite, which the headless suite does not have.
+ */
+export class Thumbnails {
+  /** The provider for `app`, or null where the server has no Composite. */
+  static async open(app) {
+    const composite = await app.composite?.();
+    return composite ? new Thumbnails(app, composite) : null;
+  }
+
+  constructor(app, composite) {
+    this.app = app;
+    this.X = app.X;
+    this.composite = composite;
+    // client id -> { frameId, pixmap, retired, drawable }
+    this._entries = new Map();
+  }
+
+  /**
+   * Start redirecting `frame`, so its contents can be named later.
+   *
+   * Done for every frame rather than for the ones somebody looks at:
+   * redirection only decides *where* the server draws, and under
+   * `Automatic` it draws to both places, so the window that is never
+   * previewed costs one request and nothing after it. Naming a pixmap is
+   * the part that waits for a reason.
+   */
+  track(id, frame) {
+    if (this._entries.has(id)) return;
+    this.composite.RedirectWindow(frame.id, this.composite.Redirect.Automatic);
+    this._entries.set(id, {
+      frameId: frame.id,
+      pixmap: null,
+      retired: null,
+      drawable: null,
+    });
+  }
+
+  /** The descriptor `<image drawable>` takes, or null until `capture`. */
+  get(id) {
+    return this._entries.get(id)?.drawable ?? null;
+  }
+
+  /**
+   * Name this frame's current pixmap and take ownership of it.
+   *
+   * Adopting is what confirms the name landed: `NameWindowPixmap` is a void
+   * request against an id we allocated ourselves, so a frame that is not
+   * viewable yet fails asynchronously, and an unchecked id reaches XRender
+   * as a BadPixmap in the middle of a paint — a much worse place to find
+   * out. ntk's `Pixmap.adopt` is built for exactly this handover and says
+   * so; it also skips its round trip when the geometry is already known,
+   * which is every refresh after the first in a generation.
+   */
+  async capture(id) {
+    const entry = this._entries.get(id);
+    if (!entry) return null;
+    const name = this.X.AllocID();
+    this.composite.NameWindowPixmap(entry.frameId, name);
+    const known = entry.drawable;
+    const pixmap = await Pixmap.adopt(
+      this.app,
+      name,
+      known
+        ? { width: known.width, height: known.height, depth: known.depth }
+        : {},
+    ).catch(() => null);
+    // the client can be gone by the time a first adopt answers
+    if (!pixmap || !this._entries.has(id)) {
+      pixmap?.destroy();
+      return null;
+    }
+    // One generation behind on purpose. React has already been handed
+    // `entry.pixmap` and swapped its Picture over to it, so nothing is
+    // compositing from `entry.retired` any more.
+    entry.retired?.destroy();
+    entry.retired = entry.pixmap;
+    entry.pixmap = pixmap;
+    entry.drawable = {
+      id: pixmap.id,
+      width: pixmap.width,
+      height: pixmap.height,
+      depth: pixmap.depth,
+    };
+    return entry.drawable;
+  }
+
+  /**
+   * The frame changed size, so the pixmap the server was drawing into is
+   * gone and the geometry we cached with it is wrong. The next `capture`
+   * names the new generation and pays the round trip to measure it.
+   */
+  invalidate(id) {
+    const entry = this._entries.get(id);
+    if (!entry) return;
+    entry.pixmap?.destroy();
+    entry.retired?.destroy();
+    entry.pixmap = null;
+    entry.retired = null;
+    entry.drawable = null;
+  }
+
+  /** Stop tracking `id` and hand the frame back to the server. */
+  forget(id) {
+    const entry = this._entries.get(id);
+    if (!entry) return;
+    this.invalidate(id);
+    this._entries.delete(id);
+    this.composite.UnredirectWindow(entry.frameId);
+  }
+}
+
 /**
  * The managed-client registry. React subscribes to it with
  * useSyncExternalStore, so every change here — a new window, a new title, a
  * drag in progress — is one re-render of the frames.
  */
 export class WindowManager {
-  constructor(app) {
+  /**
+   * `openThumbnails` is the seam: it is what talks to the server about
+   * Composite, and the headless suite has no Composite to talk to. The
+   * default is the real thing; a test passes a fake, or one that answers
+   * null to drive the no-previews path.
+   */
+  constructor(app, { openThumbnails = Thumbnails.open } = {}) {
     this.app = app;
     this.X = app.X;
     this.root = app.rootWindow();
@@ -171,6 +329,9 @@ export class WindowManager {
     this._ourWindows = new Set(); // frames and the taskbar
     this._placed = 0;
     this._serial = 0;
+    this._openThumbnails = openThumbnails;
+    /** The Composite-backed preview store, or null where there is none. */
+    this.thumbnails = null;
   }
 
   get workArea() {
@@ -194,6 +355,9 @@ export class WindowManager {
     this._snapshot = [...this.clients.values()].map((client) => ({
       ...client,
       focused: client.id === this.focused,
+      // null until something asks for one with `peek` — and null forever
+      // on a server without Composite
+      thumbnail: this.thumbnails?.get(client.id) ?? null,
     }));
     this.publishState();
     for (const listener of this._listeners) listener();
@@ -227,6 +391,10 @@ export class WindowManager {
 
     await this.announce();
     await this.internWatchedAtoms();
+    // Before adoptExisting, which attaches no frames itself but is the
+    // first thing that can lead to one: a provider that arrived late would
+    // miss the redirect for every window already on screen.
+    this.thumbnails = await this._openThumbnails(this.app);
     this.paintDesktop();
     this.watchClientClicks();
 
@@ -492,6 +660,7 @@ export class WindowManager {
       client.window.reparentTo(this.root, client.x, client.y);
       client.window.removeFromSaveSet();
     }
+    this.thumbnails?.forget(id);
     this.clients.delete(id);
     if (this.focused === id) {
       this.focused = null;
@@ -597,6 +766,9 @@ export class WindowManager {
     if (!client || client.frame === frame) return;
     client.frame = frame;
     this._ourWindows.add(frame.id);
+    // Before the reparent, so the client's very first paint already lands
+    // in the frame's offscreen pixmap rather than only in the one after it.
+    this.thumbnails?.track(id, frame);
 
     // Redirect the frame *before* reparenting into it. A window's requests
     // are redirected by whoever holds SubstructureRedirect on its parent —
@@ -685,6 +857,12 @@ export class WindowManager {
     };
     const resized =
       next.width !== client.width || next.height !== client.height;
+    // Before `_update`, which is what rebuilds the snapshot: the server
+    // drops the named pixmap when the frame resizes, and a snapshot still
+    // carrying it hands React an id that is already a BadPixmap. Dropping
+    // it here means the worst a preview does across a resize is disappear
+    // for the round trip it takes to name the next generation.
+    if (resized) this.thumbnails?.invalidate(id);
     const updated = this._update(id, next);
     // a plain move does not touch the client: it rides along inside the
     // frame, and one ConfigureWindow per motion event is enough
@@ -711,6 +889,8 @@ export class WindowManager {
           width: area.width - 2 * BORDER,
           height: area.height - 2 * BORDER - TITLE_H,
         };
+    // before `_update`, for the reason setGeometry gives
+    this.thumbnails?.invalidate(id);
     const updated = this._update(id, next);
     updated.window.resize(updated.width, updated.height);
     this.notifyGeometry(updated);
@@ -768,6 +948,20 @@ export class WindowManager {
     // bump it to the top of the focus order so repeated Alt+Tab keeps moving
     next.serial = ++this._serial;
     this.focus(next.id);
+  }
+
+  /**
+   * Refresh the preview for `id` and wake React with it.
+   *
+   * Called by whatever is showing one, on its own cadence: naming a pixmap
+   * for a window nobody is looking at buys nothing, and naming it again is
+   * how the preview stays current (see Thumbnails). A no-op where the
+   * server has no Composite, which is what makes the caller's "is there a
+   * thumbnail?" the only check it needs.
+   */
+  async peek(id) {
+    if (!this.thumbnails || !this.clients.has(id)) return;
+    if (await this.thumbnails.capture(id)) this._changed();
   }
 
   async close(id) {

--- a/examples/wm.jsx
+++ b/examples/wm.jsx
@@ -7,6 +7,17 @@
 // answering map and configure requests, keeping the client list — and this
 // file is the part you can restyle.
 //
+// Hovering a taskbar item shows what that window looks like right now. That
+// is the Composite extension: the server is asked to draw each frame into
+// an offscreen pixmap as well as onto the screen, and `<image drawable>`
+// composites the preview straight from it — the server scales it, and not
+// one pixel crosses the socket. wm-core.js's `Thumbnails` is that half.
+//
+// **Composite is not everywhere.** XQuartz has RENDER, DAMAGE, XFIXES and
+// SHAPE but no Composite at all, and neither does the in-process server the
+// tests run against. There, `wm.thumbnails` is null, a taskbar item says
+// "no preview", and everything else here works exactly as it does with it.
+//
 // Run it against a nested server so it does not fight the one managing your
 // desktop:
 //
@@ -20,6 +31,7 @@ import React, {
   useEffect,
   useMemo,
   useRef,
+  useState,
   useSyncExternalStore,
 } from 'react';
 import { Image } from 'ntk';
@@ -43,6 +55,7 @@ const theme = {
   titleDim: '#a4b0be',
   taskbar: '#1e2029',
   taskbarItem: '#2f3542',
+  preview: '#12141c',
   button: '#57606f',
   close: '#ff4757',
 };
@@ -97,6 +110,17 @@ const s = createStyles({
   taskbarLabel: { fontSize: 11, color: theme.title },
   hint: { fontSize: 11, color: theme.titleDim },
   spacer: { flexGrow: 1 },
+
+  previewWindow: { backgroundColor: theme.frameActive },
+  preview: {
+    flexGrow: 1,
+    margin: 2,
+    padding: 4,
+    backgroundColor: theme.preview,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  previewLabel: { fontSize: 11, color: theme.titleDim },
 });
 
 // The eight resize handles, named by the edges each one drags. resizeRect
@@ -191,6 +215,92 @@ function Icon({ icon, size = ICON_SIZE }) {
       style={{ width: size, height: size }}
       onDraw={(ctx) => ctx.drawImage(image, 0, 0, size, size)}
     />
+  );
+}
+
+// A preview is as wide as this and as tall as the frame's aspect ratio
+// makes it, so it reads as the window rather than as a box with a window in
+// it. PREVIEW_TICK is how often the pixmap is named again — see Preview.
+const PREVIEW_WIDTH = 240;
+const PREVIEW_TICK = 200;
+const PREVIEW_GAP = 8;
+const PREVIEW_CHROME = 12; // the two margins and the two paddings above
+
+/**
+ * What a managed window looks like right now, floating above the taskbar.
+ *
+ * Nothing here reads a pixel. `client.thumbnail` is the id of the offscreen
+ * pixmap the server is already drawing that window into (wm-core's
+ * Thumbnails), and `<image drawable>` composites from it through XRender —
+ * scaled by the server, so the size of the preview costs nothing.
+ *
+ * **Why the timer.** `<image>` compares its `drawable` by value, which is
+ * the right rule everywhere else: React rebuilds the object every render
+ * and `{ id: 7, ... }` is the same picture however fresh it is. So a
+ * preview repaints when the id changes, and the id changes when the pixmap
+ * is named again — which `wm.peek` does. DAMAGE is the extension that would
+ * say exactly when that is worth doing; this example does not use it, and
+ * five times a second is what stands in for it. That is a real gap and it
+ * is visible: something animating in a window updates in steps, not
+ * smoothly.
+ */
+function Preview({ wm, client, at, area }) {
+  const ref = useRef(null);
+  // Ours, and above the frames. Claiming keeps it out of the client list —
+  // override-redirect already keeps it out of `manage`, but the taskbar
+  // does the same and one rule for our own windows is easier to trust.
+  useEffect(() => {
+    if (!ref.current) return;
+    wm.claim(ref.current);
+    ref.current.raise();
+  }, [wm]);
+
+  useEffect(() => {
+    let live = true;
+    const refresh = () => {
+      if (live) wm.peek(client.id);
+    };
+    refresh();
+    const timer = setInterval(refresh, PREVIEW_TICK);
+    return () => {
+      live = false;
+      clearInterval(timer);
+    };
+  }, [wm, client.id]);
+
+  const thumb = client.thumbnail;
+  // Sized from the frame rather than from the pixmap: the pixmap arrives a
+  // round trip late, and a preview that resizes as it appears reads as a
+  // glitch. They agree by the time it is on screen.
+  const scale = PREVIEW_WIDTH / frameWidth(client.width);
+  const inner = Math.round(frameHeight(client.height) * scale);
+  const width = PREVIEW_WIDTH + PREVIEW_CHROME;
+  const height = inner + PREVIEW_CHROME;
+  const x = Math.round(
+    Math.min(Math.max(at - width / 2, 4), Math.max(4, area.width - width - 4)),
+  );
+
+  return (
+    <window
+      ref={ref}
+      x={x}
+      y={area.height - height - PREVIEW_GAP}
+      width={width}
+      height={height}
+      overrideRedirect
+      style={s.previewWindow}
+    >
+      <box style={s.preview}>
+        {thumb ? (
+          <image
+            drawable={thumb}
+            style={{ width: PREVIEW_WIDTH, height: inner }}
+          />
+        ) : (
+          <text style={s.previewLabel}>no preview</text>
+        )}
+      </box>
+    </window>
   );
 }
 
@@ -315,7 +425,7 @@ function ResizeHandle({ edges, wm, client, frameRef, origin, remember }) {
   );
 }
 
-function Taskbar({ wm, clients }) {
+function Taskbar({ wm, clients, onHover }) {
   const ref = useRef(null);
   useEffect(() => {
     if (ref.current) wm.claim(ref.current);
@@ -341,6 +451,14 @@ function Taskbar({ wm, clients }) {
           <box
             key={client.id}
             style={[s.taskbarItem, client.focused && s.taskbarItemActive]}
+            // `ev.x` is measured in the window the tree lives in, and this
+            // taskbar is a full-width window at x = 0, so on this axis its
+            // coordinates and the root's are the same number. Only
+            // `onDrag*` events carry real `screenX`.
+            onMouseEnter={(ev) => onHover({ id: client.id, at: ev.x })}
+            onMouseLeave={() =>
+              onHover((current) => (current?.id === client.id ? null : current))
+            }
             onClick={() =>
               client.minimized ? wm.restore(client.id) : wm.focus(client.id)
             }
@@ -363,10 +481,23 @@ function Taskbar({ wm, clients }) {
 
 function Desktop({ wm }) {
   const clients = useSyncExternalStore(wm.subscribe, wm.getSnapshot);
+  // { id, at } — `at` is where the pointer entered the taskbar item, in root
+  // coordinates, so the preview stays put instead of sliding under the
+  // pointer. The state lives here rather than in the taskbar because the
+  // preview is a window of its own, a sibling of the frames.
+  const [hover, setHover] = useState(null);
+  const previewed =
+    hover &&
+    clients.find((client) => client.id === hover.id && !client.minimized);
 
   return (
     <>
-      <Taskbar wm={wm} clients={clients} />
+      <Taskbar wm={wm} clients={clients} onHover={setHover} />
+      {/* a window that closes, or is minimized, while its preview is up
+          takes the preview with it */}
+      {previewed && (
+        <Preview wm={wm} client={previewed} at={hover.at} area={wm.workArea} />
+      )}
       {/* minimized frames stay mounted — the client is a child of the frame
           now, and unmounting one would take the application with it. The
           core unmaps them instead. */}

--- a/examples/wm.jsx
+++ b/examples/wm.jsx
@@ -17,6 +17,8 @@
 // SHAPE but no Composite at all, and neither does the in-process server the
 // tests run against. There, `wm.thumbnails` is null, a taskbar item says
 // "no preview", and everything else here works exactly as it does with it.
+// Xephyr does have it, so `Xephyr :10 -screen 1200x800` is where to see
+// this — which is the nested server this file already recommends.
 //
 // Run it against a nested server so it does not fight the one managing your
 // desktop:

--- a/test/wm.test.js
+++ b/test/wm.test.js
@@ -657,7 +657,7 @@ test('Thumbnails reports nothing when the name did not land', async () => {
   await clientApp.close();
 });
 
-test('forgetting a tracked frame frees its pixmaps and undoes the redirect', async () => {
+test('forgetting a tracked frame frees every pixmap it named', async () => {
   const { wmApp, clientApp, wm, app } = await oneFramedClient();
   const X = wmApp.X;
   const root = wmApp.display.screen[0].root;
@@ -673,8 +673,11 @@ test('forgetting a tracked frame frees its pixmaps and undoes the redirect', asy
   await settle(wmApp);
   assert.equal(await alive(wmApp, first.id), false, 'the retired one goes too');
   assert.equal(await alive(wmApp, second.id), false);
-  assert.deepEqual(composite.calls.unredirected, [frame.id]);
   assert.equal(thumbnails.get(app.id), null);
+  // The redirect is left alone on purpose: it dies with the frame, which is
+  // about to be unmounted, and node-x11's UnredirectWindow is a BadLength on
+  // a real server anyway — sidorares/node-x11#292.
+  assert.deepEqual(composite.calls.unredirected, []);
 
   await wmApp.close();
   await clientApp.close();

--- a/test/wm.test.js
+++ b/test/wm.test.js
@@ -11,6 +11,7 @@ import {
   BORDER,
   TASKBAR_H,
   TITLE_H,
+  Thumbnails,
   WindowManager,
   frameHeight,
   frameWidth,
@@ -50,8 +51,8 @@ async function until(app, predicate, what) {
 }
 
 /** A window manager with a fake frame per client — this tests wm-core, not JSX. */
-async function startWM(wmApp) {
-  const wm = new WindowManager(wmApp);
+async function startWM(wmApp, options) {
+  const wm = new WindowManager(wmApp, options);
   await wm.start();
   // React normally hands the frame over once it has realized the <window>;
   // here the test plays that part.
@@ -398,4 +399,283 @@ test('a second window manager is refused', async () => {
 test('the frame is the client plus its decoration', () => {
   assert.equal(frameWidth(300), 300 + 2 * BORDER);
   assert.equal(frameHeight(200), 200 + 2 * BORDER + TITLE_H);
+});
+
+// --- previews ---------------------------------------------------------------
+//
+// The real provider needs a server with Composite, which the in-process one
+// does not have (it registers RENDER and nothing else) — so `openThumbnails`
+// is the seam and these drive both sides of it: a fake for the wiring, and
+// the real `Thumbnails` against a fake extension for the pixmap bookkeeping.
+
+/** Records what the window manager asks a provider to do. */
+function recordingThumbnails() {
+  const calls = [];
+  const drawables = new Map();
+  return {
+    calls,
+    provider: {
+      track: (id) => calls.push(['track', id]),
+      get: (id) => drawables.get(id) ?? null,
+      capture: async (id) => {
+        const drawable = { id: 0x900 + id, width: 40, height: 30, depth: 24 };
+        drawables.set(id, drawable);
+        calls.push(['capture', id]);
+        return drawable;
+      },
+      invalidate: (id) => {
+        drawables.delete(id);
+        calls.push(['invalidate', id]);
+      },
+      forget: (id) => calls.push(['forget', id]),
+    },
+  };
+}
+
+/** A managed client, framed, with `wm` already running. */
+async function oneFramedClient(options) {
+  const { wmApp, clientApp } = await headlessPair();
+  const { wm, frames } = await startWM(wmApp, options);
+  const app = clientApp.createWindow({ width: 300, height: 200 });
+  app.map();
+  await until(wmApp, () => wm.clients.size === 1, 'the client to be managed');
+  wm.attachFakeFrames();
+  await settle(wmApp);
+  return { wmApp, clientApp, wm, frames, app };
+}
+
+test('a server without Composite manages windows with no previews at all', async () => {
+  // the default opener, against a server that really has no Composite
+  const { wmApp, clientApp, wm, app } = await oneFramedClient();
+
+  assert.equal(wm.thumbnails, null, 'no provider where there is no extension');
+  assert.equal(wm.getSnapshot()[0].thumbnail, null);
+
+  // and the call the UI makes is a no-op rather than a throw, which is what
+  // lets the React side ask for a preview without checking first
+  let woken = 0;
+  wm.subscribe(() => woken++);
+  await wm.peek(app.id);
+  assert.equal(woken, 0, 'nothing to publish, nothing to re-render for');
+  assert.equal(wm.getSnapshot()[0].thumbnail, null);
+
+  await wmApp.close();
+  await clientApp.close();
+});
+
+test('a frame is tracked when it is attached and released when the client goes', async () => {
+  const { calls, provider } = recordingThumbnails();
+  const { wmApp, clientApp, wm, app } = await oneFramedClient({
+    openThumbnails: async () => provider,
+  });
+
+  assert.deepEqual(calls, [['track', app.id]], 'redirected at attach time');
+
+  app.destroy();
+  await until(wmApp, () => wm.clients.size === 0, 'the client to be dropped');
+  assert.deepEqual(calls.at(-1), ['forget', app.id]);
+
+  await wmApp.close();
+  await clientApp.close();
+});
+
+test('peek publishes a preview into the snapshot, and wakes React once', async () => {
+  const { provider } = recordingThumbnails();
+  const { wmApp, clientApp, wm, app } = await oneFramedClient({
+    openThumbnails: async () => provider,
+  });
+
+  let woken = 0;
+  wm.subscribe(() => woken++);
+  assert.equal(wm.getSnapshot()[0].thumbnail, null, 'nothing until asked');
+
+  await wm.peek(app.id);
+  assert.equal(woken, 1);
+  assert.deepEqual(wm.getSnapshot()[0].thumbnail, {
+    id: 0x900 + app.id,
+    width: 40,
+    height: 30,
+    depth: 24,
+  });
+
+  await wmApp.close();
+  await clientApp.close();
+});
+
+test('a resize drops the preview and a move keeps it', async () => {
+  const { calls, provider } = recordingThumbnails();
+  const { wmApp, clientApp, wm, app } = await oneFramedClient({
+    openThumbnails: async () => provider,
+  });
+  await wm.peek(app.id);
+
+  // a drag is a move: the client rides along inside the frame at its own
+  // size, so the pixmap the server named is still the right one
+  wm.setGeometry(app.id, { x: 120, y: 90 });
+  assert.ok(wm.getSnapshot()[0].thumbnail, 'a move keeps the preview');
+  assert.equal(
+    calls.filter(([what]) => what === 'invalidate').length,
+    0,
+    'and asks for nothing',
+  );
+
+  // a resize ends the generation the pixmap belonged to
+  wm.setGeometry(app.id, { width: 420 });
+  assert.deepEqual(calls.at(-1), ['invalidate', app.id]);
+  assert.equal(wm.getSnapshot()[0].thumbnail, null);
+
+  // as does maximizing, which is a resize by another name
+  await wm.peek(app.id);
+  wm.toggleMaximize(app.id);
+  assert.deepEqual(calls.at(-1), ['invalidate', app.id]);
+
+  await wmApp.close();
+  await clientApp.close();
+});
+
+/**
+ * A Composite that does what the server does: `NameWindowPixmap` really
+ * creates a pixmap at the id the caller allocated, so `Pixmap.adopt` can
+ * measure it and `FreePixmap` can take it away again. Without that the test
+ * would only be checking that we called a function.
+ */
+function fakeComposite(X, { width, height, depth = 24 }, root) {
+  const calls = { redirected: [], unredirected: [], named: [] };
+  return {
+    calls,
+    Redirect: { Automatic: 0, Manual: 1 },
+    RedirectWindow: (window, type) => calls.redirected.push([window, type]),
+    UnredirectWindow: (window) => calls.unredirected.push(window),
+    NameWindowPixmap: (window, pixmap) => {
+      calls.named.push([window, pixmap]);
+      X.CreatePixmap(pixmap, root, depth, width, height);
+    },
+  };
+}
+
+/**
+ * Run `fn` with ntk's warning about unroutable X errors turned off.
+ *
+ * Asking about a pixmap that is meant to be gone answers with a
+ * BadDrawable, and node-x11 emits those on the client as well as handing
+ * them to the callback — so the tests below would print a warning per
+ * assertion, as if something had gone wrong. Settles before restoring, so
+ * the error the request provokes is still inside the quiet window.
+ */
+async function withoutXErrorWarnings(app, fn) {
+  const previous = app.options.onXError;
+  app.options.onXError = () => {};
+  try {
+    const answer = await fn();
+    await settle(app);
+    return answer;
+  } finally {
+    app.options.onXError = previous;
+  }
+}
+
+/** Does `pixmap` still exist? GetGeometry is the cheapest way to ask. */
+const alive = (app, pixmap) =>
+  withoutXErrorWarnings(
+    app,
+    () =>
+      new Promise((resolve) =>
+        app.X.GetGeometry(pixmap, (err) => resolve(!err)),
+      ),
+  );
+
+test('Thumbnails names a fresh pixmap each time and measures it once', async () => {
+  const { wmApp, clientApp, wm, app } = await oneFramedClient();
+  const X = wmApp.X;
+  const root = wmApp.display.screen[0].root;
+  const composite = fakeComposite(X, { width: 308, height: 230 }, root);
+  const thumbnails = new Thumbnails(wmApp, composite);
+
+  thumbnails.track(app.id, wm.clients.get(app.id).frame);
+  assert.equal(composite.calls.redirected.length, 1);
+  assert.equal(
+    composite.calls.redirected[0][1],
+    composite.Redirect.Automatic,
+    'Automatic: the server keeps painting the window itself',
+  );
+  assert.equal(thumbnails.get(app.id), null, 'tracking names nothing yet');
+
+  const first = await thumbnails.capture(app.id);
+  assert.equal(first.width, 308, 'geometry comes from the server, not a guess');
+  assert.equal(first.height, 230);
+  assert.equal(first.depth, 24);
+  assert.deepEqual(thumbnails.get(app.id), first);
+
+  // A second name is a different id for the same window contents — which is
+  // the whole mechanism behind a live preview, because the id is what tells
+  // <image> its source changed.
+  const second = await thumbnails.capture(app.id);
+  assert.notEqual(second.id, first.id);
+  assert.deepEqual(
+    [second.width, second.height, second.depth],
+    [308, 230, 24],
+    'and the same rectangle',
+  );
+
+  // one generation behind: nothing has composited from `first` since React
+  // was handed `second`, but it was still alive while it might have been
+  assert.equal(
+    await alive(wmApp, first.id),
+    true,
+    'kept for one more generation',
+  );
+  const third = await thumbnails.capture(app.id);
+  assert.equal(await alive(wmApp, first.id), false, 'and freed by the next');
+  assert.equal(await alive(wmApp, second.id), true);
+  assert.equal(await alive(wmApp, third.id), true);
+
+  await wmApp.close();
+  await clientApp.close();
+});
+
+test('Thumbnails reports nothing when the name did not land', async () => {
+  const { wmApp, clientApp, wm, app } = await oneFramedClient();
+  // a Composite whose NameWindowPixmap creates nothing — what a frame that
+  // is not viewable yet looks like from here
+  const composite = {
+    Redirect: { Automatic: 0 },
+    RedirectWindow: () => {},
+    UnredirectWindow: () => {},
+    NameWindowPixmap: () => {},
+  };
+  const thumbnails = new Thumbnails(wmApp, composite);
+  thumbnails.track(app.id, wm.clients.get(app.id).frame);
+
+  assert.equal(
+    await withoutXErrorWarnings(wmApp, () => thumbnails.capture(app.id)),
+    null,
+    'an id that names nothing is reported, not handed on to XRender',
+  );
+  assert.equal(thumbnails.get(app.id), null);
+
+  await wmApp.close();
+  await clientApp.close();
+});
+
+test('forgetting a tracked frame frees its pixmaps and undoes the redirect', async () => {
+  const { wmApp, clientApp, wm, app } = await oneFramedClient();
+  const X = wmApp.X;
+  const root = wmApp.display.screen[0].root;
+  const composite = fakeComposite(X, { width: 308, height: 230 }, root);
+  const thumbnails = new Thumbnails(wmApp, composite);
+  const frame = wm.clients.get(app.id).frame;
+
+  thumbnails.track(app.id, frame);
+  const first = await thumbnails.capture(app.id);
+  const second = await thumbnails.capture(app.id);
+
+  thumbnails.forget(app.id);
+  await settle(wmApp);
+  assert.equal(await alive(wmApp, first.id), false, 'the retired one goes too');
+  assert.equal(await alive(wmApp, second.id), false);
+  assert.deepEqual(composite.calls.unredirected, [frame.id]);
+  assert.equal(thumbnails.get(app.id), null);
+
+  await wmApp.close();
+  await clientApp.close();
 });


### PR DESCRIPTION
Closes #425.

Hovering a taskbar item in `examples/wm.jsx` now shows what that window looks like right now.

![pr-preview](https://github.com/user-attachments/assets/0c0d85b6-4485-4235-8c9b-560866147f68)
![pr-preview-live](https://github.com/user-attachments/assets/79fb1fb3-da36-4d62-b056-ca11c713f7f5)

The second shot is the same preview a moment later, after the application repainted itself — the point being that a preview tracks the window rather than snapshotting it when it opens.

## How

Nothing reads a pixel back:

```
Composite.RedirectWindow(frame, Automatic)
  -> NameWindowPixmap(frame, id)
     -> <image drawable={{ id, width, height, depth }}>
        -> DrawableSource -> RenderComposite, scaled by the server
```

`DrawableSource` has named `NameWindowPixmap` as its intended producer since it landed — `src/imagesource.js:318` — and nothing in the repo called it. This is that seam being used.

`Automatic` is the update type on purpose. The server goes on painting the redirected window into its parent itself, so the desktop looks and behaves exactly as it did: this stays a reparenting window manager that can *read* window contents, rather than becoming a compositing one that owns putting every window on screen.

## Three things shaped the code

**A named pixmap is a generation, not a handle.** The server drops it when the window resizes. So `setGeometry` and `toggleMaximize` invalidate *before* `_update` rebuilds the snapshot — a test caught the other order, where React is handed an id that is already a BadPixmap.

**Naming it again is cheap and always current**, which is what makes the preview live. `<image>` compares `drawable` by value, so a fresh id is what tells it the source changed; `wm.peek` names it again on a timer. DAMAGE is the extension that would say exactly when instead of guessing at 5 Hz — that gap is named in the code rather than steered around.

**`Pixmap.adopt` confirms the name landed.** `NameWindowPixmap` is a void request against a caller-allocated id, so a frame that is not viewable yet fails asynchronously and an unchecked id surfaces as a BadPixmap in the middle of a paint. ntk's `Pixmap.adopt` is built for this handover and says so, and it skips its round trip once the geometry is known — which is every refresh after the first in a generation.

## Composite is optional

`openThumbnails` is the seam. XQuartz has RENDER, DAMAGE, XFIXES and SHAPE but no Composite at all, and neither does node-x11's in-process server, so `wm.thumbnails` is null there: a taskbar item says "no preview" and everything else works unchanged. The example header says so.

## Testing

Seven new cases in `test/wm.test.js`, 21 in the file, and both sides of the seam are driven:

- the default opener against the in-process server, which really has no Composite — no provider, `thumbnail: null`, and `peek` a no-op rather than a throw
- a recording fake for the wiring: tracked at attach, forgotten when the client goes, published by `peek`, dropped by a resize and kept by a move
- the real `Thumbnails` against a fake Composite whose `NameWindowPixmap` genuinely `CreatePixmap`s at the caller's id, so `Pixmap.adopt` measures a real pixmap. That covers a fresh id per name, geometry read from the server rather than guessed, the retire-one-generation-behind rule asserted with `GetGeometry` against the server, and an id that names nothing being reported instead of handed to XRender

Mutation-checked: five planted bugs — no track at attach, retire immediately instead of one behind, no invalidate on resize, publish an unconfirmed id, no unredirect on forget — each fail exactly one test.

Full suite: 1695 pass, 6 fail, all in `appearance.test.js` and all failing the same way on master — the known macOS-only baseline. `prettier --check .`, `eslint .` and `tsc` are clean.

Screenshots are rendered by this branch's own code at a76447e, on a real Xvfb, because the in-process server has no Composite and so cannot show this at all. A pointer warp drives the hover, so the EnterNotify the taskbar item reacts to is the server's own.

## An upstream bug this turned up

Testing the teardown path on Xephyr — the one server to hand that has Composite — found that `Composite.UnredirectWindow` is encoded eight bytes long with no `update` field, where `compositeproto.h` says twelve with one. Every call is a `BadLength`. Reported as sidorares/node-x11#292, with the redirect half verified working on the same server so the scope is just the two undo requests.

The second commit here stops sending it. Nothing replaces it: a window's redirection dies with the window, and the only caller is the one place a frame is about to be unmounted.

Worth recording how it hid, because it is a gap in this PR's own testing as much as upstream's. The wiring tests drive `forget` through a fake provider, so the request is never encoded; the in-process server has no Composite at all; and the display run that produced the screenshots never closed a window. A `BadLength` at teardown, on a window being destroyed anyway, is close to invisible. It took driving a client all the way to exit on a real compositing-capable server.

For anyone reproducing: `Xephyr :10 -screen 1200x800` has Composite 0.4, DAMAGE 1.1, XFIXES 5.0, RENDER, Present and XTEST. `GetOverlayWindow`, `RedirectSubwindows` in `Manual` mode, `NameWindowPixmap` and `DamageNotify` all work there end to end — I read the painted pixels back out of a redirected window's pixmap to check. XQuartz has none of it.

## Not in scope

Investigated `BufferFromPixmap` / `BuffersFromPixmap` / `FDFromFence`, newly implemented in node-x11 4.1.0 by sidorares/node-x11#290, as a route to the same pixels. For anything drawn flat they are the wrong tool: they need Bun with `receiveFds: true`, a DRI3 server, and a dma-buf import that does not exist yet — sidorares/node-x11-dri#17, sidorares/ntk#345 — and then they would move pixels the server already composites for us. They pay only when the destination is a GL texture.


