### PR TITLE
A native macOS backend over Core Animation

### DIFF
--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1,0 +1,1041 @@
+# A native macOS backend
+
+**Status: research RFC with a working POC.** Written 2026-09-01 against
+react-x11 2.2.1, ntk 8.8.0, and `node-calayers` 0.1.0 — a proof-of-concept
+Node addon (Objective-C++, ~900 lines native + 155 JS) that already does
+retained CALayer trees, CoreText measurement and rasterization, native
+control bezels, window snapshots, and an NSApplication event pump driven
+from Node's own loop. The POC is local (not yet published); publishing it
+against the API contract in this document is the first actionable step.
+The line counts and inventories below are measurements, not estimates;
+where a companion number comes from [wayland.md](wayland.md), it is cited
+rather than re-measured.
+
+## What this is, and is not
+
+This is a plan for a **third target, second backend family**: the same
+React tree, the same components and the same application code running as a
+first-class macOS app — real `NSWindow`s, the system menu bar, native
+control rendering, Core Animation compositing — with no X server anywhere.
+X11 stays what it is: the flagship remote target ([remote.md](remote.md)),
+the window-manager story, and the only backend for `<foreign>`/XEmbed.
+Nothing here proposes changing how the X11 path works, and the plan is
+explicitly shaped so that its refactors are pinned by the existing pixel
+and bench gates before any macOS code lands on top of them.
+
+The relationship to the [Wayland RFC](wayland.md) matters, because the two
+inversions are opposite and one architecture has to hold both:
+
+- **Wayland deletes the drawing protocol downward** — the client
+  rasterizes finished pixels. Its natural seam is _below_ ntk's 2d
+  context: a span compositor behind the same `getContext('2d')` name.
+- **macOS deletes the drawing protocol upward** — the WindowServer is a
+  retained compositor and the client's job is to _mutate a persistent
+  layer tree_, not to encode draw calls and not to rasterize (except
+  where it chooses to). Its natural seam is _above_ the 2d context: at
+  the node tree itself.
+
+Both seams can exist at once, and the extraction this document proposes
+(§"One renderer, two presenters") leaves the Wayland plan intact — a
+Wayland presenter is the X11 presenter with a different surface under it.
+
+Goals, unchanged from the project's standing ones: perceived performance
+first (input-to-photon), then stability, then client CPU and memory; the
+whole range of desktop UI that the platform permits; a small portable
+codebase, with a native module admissible where the runtime leaves no
+other way to reach a required OS facility — and macOS is the clearest
+case of that clause: there is no wire protocol to speak, only
+frameworks, so the bridge is a compiled addon by necessity. What keeps
+the spirit of the rule is keeping the addon **thin and mechanism-only**
+(create/set/add/remove/pump — no policy, no widget logic), which is
+exactly the shape `node-calayers` already has.
+
+Out of scope on this backend, honestly and up front, the same way
+wayland.md declares its walls:
+
+- **A window manager cannot be written against Cocoa.** `examples/wm.jsx`
+  and the substructure-redirect half of the API remain X11-only.
+- **Cross-process window embedding does not exist on macOS.** `<foreign>`,
+  the XEmbed half of `<Frame>`, `@react-x11/components`' tray-host and its
+  mpv/VLC `--wid` embedding have no equivalent; `<Frame>` on macOS becomes
+  a parented toplevel or an in-process pane, exactly the fate wayland.md
+  assigns it.
+- **XQuartz is not deprecated by this.** react-x11 already runs on macOS
+  today through XQuartz; that path remains the way to run the X11 backend
+  (and the WM example) on a Mac. This backend is for shipping _native_
+  apps.
+
+## What macOS actually changes
+
+X11 is "the client encodes drawing, the server rasterizes and composites."
+Wayland is "the client rasterizes, the compositor composites." macOS is a
+third shape: **the client owns a retained scene graph (the CALayer tree)
+and the render server composites it on the GPU** — geometry, colors,
+corner radii, shadows, opacity, transforms, filters, and whole animations
+are _properties of persistent objects_, committed atomically in
+transactions and interpolated server-side without the client's further
+involvement.
+
+That shape is not an obstacle to this renderer; it is this renderer's own
+architecture, one level down. react-x11 is already a retained tree — every
+drawn element is a lightweight node holding style, a yoga node and an
+absolute rect, and React commits arrive as property diffs against it
+(`commitUpdate` → `applyProps(new, old)`). On X11 those diffs then have to
+be _flattened into paint_: damage rects, a paint walk, clip bounding,
+scroll blits, a paint cache — ~1,000 lines of machinery whose entire job
+is to turn retained-tree diffs back into efficient immediate-mode drawing.
+On macOS the diff **is** the drawing: a commit maps to one `CATransaction`
+of `layer.set(...)` calls, layout writes frames inside the same
+transaction, and the WindowServer recomposites what changed. The
+reconciler's native output format and Core Animation's native input format
+are the same thing — a property diff over a retained tree — with no
+serialization through an immediate-mode bottleneck between them.
+
+Three consequences are worth naming before any code, because they shape
+the whole plan:
+
+- **Animation leaves the JS thread.** A CA animation runs in the render
+  server; the POC's spinner stays smooth while JS is stalled. The
+  project's first goal is answering the input on the frame it arrived —
+  a `transition:` on `:active` that the _system_ interpolates is that
+  goal with the JS thread taken out of the loop entirely.
+- **Scrolling becomes a property.** The scroll-blit fast path — gates,
+  ledger, claim clipping, `CopyArea` (AGENTS.md §protocol efficiency) —
+  exists because scrolling on X11 is repainting. On a layer tree,
+  scrolling is `bounds.origin` on one clipping layer: constant cost,
+  server-side, and the entire fast-path apparatus does not need to exist
+  in that presenter.
+- **Retina inverts from cost to freebie.** On the X11 path a 2× display
+  quadruples every rasterized pixel; layers carry `contentsScale` and the
+  GPU composites at native resolution, with rasterization confined to the
+  nodes that actually rasterize (text, images, custom drawing).
+
+The other thing macOS changes is _expectation_: a Mac app has the menu bar
+at the top of the screen, native-looking controls, native open/save
+dialogs, ⌘-shortcuts. This project's answer to the same question on Linux
+was built desktop-first (D-Bus global menu with in-window fallback,
+portals, XSETTINGS), and this document keeps that stance: the menu bar
+becomes `NSMenu`, controls prefer native rendering with an escape hatch,
+dialogs go native — each behind the same "default that serves the main
+customer, seam for everyone else" rule the codebase already follows.
+
+## What the POC already proves
+
+`node-calayers` (local, `~/tmp/node-calayers`) settles the risky
+mechanisms, which is what a POC is for:
+
+- **A Node process can own NSApplication.** Node's main thread _is_ the
+  process main thread on macOS; the addon initializes the app and JS
+  drives an event pump (`nextEventMatchingMask:` with `distantPast`) off
+  a timer. No `[NSApp run]`, no second process, no thread hop.
+- **Retained layers behave.** `Layer`/`TextLayer`/`GradientLayer`/
+  `ShapeLayer` wrappers over real `CALayer`s: frame/bounds/position,
+  backgroundColor, cornerRadius, borderWidth, shadows, opacity,
+  zPosition, masks, `masksToBounds`, transforms — mutated with
+  `layer.set(props)`, batched with `CATransaction`, suppressed with
+  `disableActions` (the reconciler-commit mode), animated implicitly and
+  explicitly (`CABasicAnimation` on any keyPath, running in the render
+  server through a JS stall).
+- **Top-left coordinates work.** A layer-hosting, flipped `NSView` makes
+  the hosted tree top-left-origin (`geometryFlipped`); the two flip
+  gotchas (`hitTest:` stays bottom-up, `renderInContext:` ignores the
+  flip) are handled in native code, and snapshots read the window's real
+  composited pixels via `CGWindowListCreateImage` — no screen-recording
+  permission needed for the process's own windows.
+- **CoreText measures and rasterizes.** `text.measure()` →
+  `{width, ascent, descent, leading}` via `CTLine`;
+  `text.render()` → CGImage via `CTFramesetter`, set as layer contents —
+  the glyph path a text visual needs. `CATextLayer` works too, taking the
+  WindowServer path for retina-crisp static text.
+- **Native control bezels render offscreen** — the WebKit/Firefox form
+  technique: `NSButtonCell`/`NSPopUpButtonCell` via `drawWithFrame:`
+  under `performAsCurrentDrawingAppearance:` (so dark mode and the user's
+  accent apply), and the two controls modern AppKit refuses to draw as
+  cells (`NSSlider`, `NSSwitch`) via a real unparented control's
+  `displayRectIgnoringOpacity:`. Push (incl. accent-filled default),
+  checkbox, radio, popup, slider, switch — interactive states, both
+  appearances, re-renderable live.
+- **Events arrive.** Mouse/key/wheel from the real pump to a JS callback;
+  synthetic event posting through the same pump for tests
+  (`postMouseEvent`), which is the `fireEvent` transport a test harness
+  wants.
+- **Hit testing round-trips.** `-[CALayer hitTest:]` maps back to JS
+  wrapper objects by layer name. (react-x11 will not use it — the node
+  tree already hit-tests — but it validates the tree's integrity.)
+
+Known POC limits, all of which are Phase-0 work items rather than
+unknowns: no modifier flags on events, one shared event callback with no
+per-window routing, no `NSWindowDelegate` (resize/close/focus arrive only
+by polling), sublayer append-only (no insert-at-index), no raw-buffer
+`contents` upload (only CGImages produced native-side), no menu API, no
+pasteboard, no drag session, no display-link frame clock, and the
+pump-on-a-timer model leaves AppKit's internal modal loops (live resize,
+menu tracking) starving JS. The full required API is specified in
+§"node-calayers: the required API".
+
+## What already carries over
+
+The measured split from [wayland.md](wayland.md) §"What already carries
+over" applies unchanged, because it was measured against the display
+system, not against Wayland specifically: **~16,200 lines of portable
+core** (reconciler, yoga, styles/decorations parsing, palette, a11y
+model, keysyms, compose, text-selection model, anchors) and **~8,700
+lines of `components/` + `frame/` + `refresh/`** carry over as-is. Of
+`nodes.js`'s 11,515 lines, only `WindowNode` + `PopupNode` (~3,100)
+speak X; `BoxNode`, `TextNode`, `ImageNode`, `CanvasNode`,
+`TextInputNode`, `TextAreaNode` and the layout/hit-test machinery never
+name the display system. The honest per-backend surface is the same
+~9–10k-line list wayland.md names — window realize/present, events, DnD,
+clipboard, screens, window state, scale, keyboard state, compositing,
+input time, startup — plus, for macOS, the presenter itself.
+
+What the _consumers_ actually depend on was inventoried for this RFC
+across both sibling repos (`@react-x11/workbench` 0.1.0,
+`@react-x11/components` 0.4.0, cloned and grepped 2026-09-01):
+
+- The workbench is a thin consumer: `<box>`, `<text>`, `<window>`
+  (`title`/`width`/`height`/`onCloseRequest` only), `<textinput>`, seven
+  core components, `react-x11/test`, and
+  `jsxImportSource: "react-x11"`. Nothing X-shaped at all.
+- `@react-x11/components` is the real contract: **all ten subpaths**
+  (`.`, `/host`, `/node`, `/style`, `/keysyms`, `/test`, `/yoga`,
+  `/ntk`, `/jsx-runtime`, `/jsx-dev-runtime`, `/debug`). It subclasses
+  `Node` and overrides `paint(ctx)`/`measureContent`/`default*` in seven
+  registered elements; it uses the ntk `Context2D` dialect **including
+  the extensions** `fillRects`, `drawGlyphs`, `positioned`,
+  `layoutSubtree`, `vw`/`vh`/`em`; it reads X keysyms (`XK_*`) in twenty
+  files; and its tests name backends
+  (`renderX11(..., { backend: 'mock' | 'xserver' | ... })`).
+- Its genuinely X-only reaches are few and localized: offscreen
+  `ntk.Surface` allocation (charts, terminal, flow), `createWindow({id})`
+  for an embedded client's title, the XEmbed `windowId` flow feeding
+  mpv/VLC, `serverTime()`, and the tray host. Those stay X11-only
+  features of those components, not portability obligations.
+
+Two conclusions fall straight out of that inventory. First, **the public
+API does not need a redesign to go native** — the compatibility surface
+is the intrinsics, the components, the style system, the hooks, the
+`Node`/`Context2D`/`registerElement` seam, the keysym vocabulary and the
+test harness, and every one of those is implementable on Cocoa. Second,
+**`XK_*` keysyms are the cross-platform key vocabulary by adoption**, not
+an X leak to be replaced: they are symbolic integers used by every
+consumer, `keysymOf()`/`ctrlChordLetter()` already abstract them, and the
+macOS input layer synthesizes them (Latin-1 keysyms are their code
+points, the rest via the `0x01000000 + UCS` rule plus a ~50-entry `kVK_*`
+table for arrows/function/editing keys). Renaming them would break every
+consumer to remove a prefix.
+
+Desktop integration repeats Wayland's pleasant surprise, further along:
+the appearance ladder **already has a macOS rung** (`appearance.js` reads
+`AppleInterfaceStyle`/accent through a long-lived `osascript` child), and
+so does the file dialog ladder. The native backend upgrades those rungs
+from `osascript` to real API and deletes nothing.
+
+## One renderer, two presenters
+
+The user-facing question first — _conditional per-OS host components
+inside one reconciler, or a completely separate reconciler exposing the
+same public API?_ — because everything else hangs off it.
+
+**A separate reconciler is the wrong split, and the inventory above says
+why.** The public API that must stay identical is not a thin façade: it
+includes the retained `Node` contract itself (subclassed by consumers),
+the style system with its state blocks and transitions, the event
+synthesis rules ("answer the input" — press chains, `:active`
+narrowing, capture/bubble order), focus and tab order, text editing with
+undo/coalescing, selection, scroll semantics, the a11y model, the anchor
+math, and the test harness's behavioral assumptions. A second
+implementation of all of that is a second toolkit wearing the first one's
+types — two copies of every behavioral decision AGENTS.md records, one
+maintainer, and a drift surface the size of the project. The measured
+portable core (~25k lines with components) is precisely the code a
+separate reconciler would fork.
+
+**A pure "conditional host components" split is too shallow**, though: the
+difference between X11 and Core Animation is not _which_ box node to
+instantiate, it is _what happens after commit_ — immediate-mode paint
+versus retained-property sync. The seam has to sit at that boundary, and
+the codebase is already shaped for it in three load-bearing ways:
+
+1. `createInstance` performs **no platform calls** (the render phase is
+   discardable); every real window is created in the commit phase via
+   `realize()`. The host config is already platform-free.
+2. Nodes do not paint themselves spontaneously — they **announce**:
+   `invalidate(layoutChanged, node, reason)` is the one channel through
+   which every change reaches the screen, and `WindowNode.flush()` is the
+   one consumer. The X11 damage/paint pipeline is an _implementation of
+   that channel_, not part of the node model.
+3. Everything a node needs from the platform is already reached through
+   the `app` object — `createWindow`, `fonts.layout`, `clipboard`, the
+   event emitter — and `createRoot({ app })` injects it. The headless
+   mock in `src/testing/mock-app.js` passes the whole suite, which is
+   the existence proof that the contract is closed.
+
+So the proposal is **one renderer, one node model, two presenters**, plus
+per-platform service modules behind the existing hook APIs:
+
+| seam            | X11 implementation (today's code)                              | Cocoa implementation                                          |
+| --------------- | -------------------------------------------------------------- | ------------------------------------------------------------- |
+| **WindowHost**  | `WindowNode.realize()` → ntk `CreateWindow`, WM hints, mapping | `NSWindow` + layer-hosting flipped view; delegates → events   |
+| **Presenter**   | damage rects → paint walk → ntk 2d ctx → XRender               | dirty nodes → per-node visuals → `CATransaction` property set |
+| **TextEngine**  | ntk `FontManager.layout` (fontkit shaping, glyph atlas)        | CoreText (`CTFramesetter`/`CTLine`) behind the same interface |
+| **InputSource** | ntk window events (X11, XI2)                                   | NSEvent pump → the same normalized event shapes               |
+| **FrameClock**  | ntk rAF (Present completions + fence)                          | `CADisplayLink`/`CVDisplayLink`; CA transactions for pacing   |
+| **services**    | screens/scale/appearance/clipboard/DnD/menus/… (X + D-Bus)     | NSScreen/backingScale/NSAppearance/NSPasteboard/NSMenu/…      |
+
+The refactor this requires of the X11 code is bounded and mechanical:
+`WindowNode.flush()`'s paint half and the `_paint*` methods become the
+X11 presenter (moved, not rewritten), and the node model keeps layout,
+absolutize, hit testing, events, focus, selection and props. It lands as
+its own phase with **zero behavior change**, pinned by the existing
+pixel tests, `test/dirty-rect.test.js`, and `npm run bench -- --check` —
+the same discipline the scroll-blit work used. Registered third-party
+elements keep their `paint(ctx)` contract on both presenters (see
+§"Custom drawing on a layer tree").
+
+This split also answers the "complete rewrite vs seams" question with
+numbers: seams cost a ~3–4k-line mechanical extraction inside `nodes.js`
+plus per-backend modules that had to be written under any design; a
+rewrite duplicates ~25k lines of accumulated behavior and every future
+fix twice. And the extraction is not macOS-only spend — the Wayland
+plan's "WindowNode.realize grows a second path" and the presenter split
+are the same seams.
+
+## Two tiers, one architecture — and the reconciler fit
+
+Both integration levels from the exploration brief are real, and the plan
+uses both — but **they are stages of one build, not alternatives**, and
+the design target is the retained tier. The commitment made here, so the
+bring-up stage cannot calcify into the architecture: _Tier S exists to
+validate mechanisms and to serve as the raster fallback inside Tier L;
+every interface is designed for Tier L from day one._
+
+### Tier S — surface presenter (canvas2d, single layer per window)
+
+Implement the `app`/`window`/`ctx` contract (the `mock-app.js` shape)
+over Cocoa: an `NSWindow` whose content is one bitmap-backed layer, a
+canvas2d context over `CGContext`, CoreText behind `app.fonts`, NSEvents
+mapped to the ntk event names. `createRoot({ app: cocoaApp })` then runs
+today's renderer unchanged — damage rects, paint walk, dirty-rect
+machinery and all, painting into the bitmap and committing changed rects
+to the layer (`setNeedsDisplayInRect`-style partial uploads, or an
+IOSurface pair).
+
+Everything here is load-bearing later, which is what justifies building
+it first:
+
+- the **CG-backed 2d context** is Tier L's raster fallback for
+  `<canvas>`, `<svg>` and registered elements (CG is canvas2d's ancestor;
+  the dialect including `fillRects` maps to `CGContextFillRects`
+  directly);
+- the **CoreText TextEngine** is the same object Tier L's text visuals
+  measure and rasterize through;
+- the **window host, event mapping and run-loop work** carry verbatim;
+- the whole thing runs the existing test suite and examples on macOS
+  natively, which is the fastest possible detector for event/text/input
+  contract gaps.
+
+What Tier S cannot do, structurally: offload animation (every transition
+frame is a JS-side repaint + upload), make scrolling cheap (the blit
+becomes a `memmove` + upload), or exploit retina (2× is 4× the raster
+and 4× the upload). It is a correct port with X11's cost model on
+hardware that offers a better one.
+
+### Tier L — layer presenter (retained, the design target)
+
+The Cocoa presenter consumes the same `invalidate()` stream but keeps a
+**visual** per drawn node — lazily, only for nodes that draw something —
+and on flush syncs dirty nodes into layer properties inside one
+`CATransaction` per frame, actions disabled by default. Layout runs
+exactly as today (yoga, absolutize); frames are written from the yoga
+rects. The commit pipeline becomes:
+
+```
+React commit → applyProps diff → invalidate(node)
+  frame: yoga layout → for dirty nodes: visual.sync(node) → CATransaction commit
+```
+
+No damage rects, no paint walk, no paint cache, no scroll-blit ledger, no
+`_outsideDamage` culling — that machinery is the X11 presenter's private
+business. The style vocabulary maps almost embarrassingly well, which is
+not a coincidence — both vocabularies are children of CSS:
+
+| style prop                              | CALayer mapping                                                                   |
+| --------------------------------------- | --------------------------------------------------------------------------------- |
+| `backgroundColor`                       | `backgroundColor`                                                                 |
+| `borderRadius`                          | `cornerRadius` (+ `cornerCurve: continuous` — a native nicety X11 cannot offer)   |
+| uniform `border*`                       | `borderWidth`/`borderColor`                                                       |
+| per-edge border colors, `borderStyle`   | four edge sublayers, or the raster fallback for that node                         |
+| `backgroundImage: linear-gradient(...)` | `CAGradientLayer` (the parsed spec from `decorations.js` feeds it directly)       |
+| `boxShadow`                             | `shadowColor/Opacity/Radius/Offset` + **`shadowPath`** set from the rounded rect  |
+| `zIndex`                                | `zPosition` (+ sibling order for equal z)                                         |
+| `outline*` (focus ring)                 | one sublayer outside bounds                                                       |
+| `overflow: hidden`/scroll clipping      | `masksToBounds` on the clipping node's layer                                      |
+| scroll offset                           | `bounds.origin` on the clip layer — the whole scroll path                         |
+| `:hover`/`:active`/`:focus` state block | property sets on one layer (exactly the "repaint of one node" they were built as) |
+| `transition: { prop: ms }`              | `CATransaction` duration / `CABasicAnimation` — **runs in the render server**     |
+
+The `shadowPath` row carries a scar worth transferring: issue #413 was a
+blur re-run per composite that cost 700× and showed up in no request
+count. CA has the same trap in the same place — a shadow without
+`shadowPath` makes the render server derive the silhouette per frame —
+and the fix is the same shape: hand it the geometry once. The presenter
+sets `shadowPath` always, from the same resolved rect + radius the
+border uses.
+
+Nodes whose visual exceeds the property vocabulary do not fail — they
+**degrade to raster per node**: the visual allocates a bitmap, replays
+the node's paint through the CG-backed 2d context (translated so
+`this.abs` lands at the layer origin), and sets it as `contents`. That
+one rule carries `<canvas onDraw>`, `<svg>`, all seven of
+`@react-x11/components`' registered elements, per-edge borders and any
+future paint feature ahead of its layer mapping — correctness never
+waits for a mapping, and mappings are pure optimization.
+
+Two structural decisions inside Tier L, called out because they are easy
+to get wrong:
+
+- **Layer per drawing node, not per node.** A layout-only `<box>` (no
+  background, border, shadow, clip, or scroll) materializes no layer;
+  its children parent to the nearest ancestor with one, positioned by
+  the already-absolute rects. A clipping or scrolling node always
+  materializes (it _is_ the mask/viewport). This keeps the layer count
+  proportional to visible painted content — the same quantity the X11
+  path rasterizes — rather than to tree shape, and virtualized lists
+  (`Table`, `monitor`) already bound visible content by construction.
+  Whether collapsing is needed at all is a Phase-3 measurement
+  (`CATransaction` commit cost vs. layer count), and the fallback of
+  "every drawn node gets a layer" is the simpler first cut.
+- **The node tree stays the source of truth for input.** Hit testing,
+  capture/bubble, press chains, focus — all continue to run on node
+  rects exactly as on X11. `CALayer hitTest:` is not used for dispatch.
+  One event model, one set of tests, identical interaction semantics on
+  both backends; the layer tree is write-only presentation.
+
+Text in Tier L is a raster visual by default: the TextEngine's layout
+(same object that measured for yoga) rasterizes into the node's layer
+contents at `contentsScale`, so measurement and pixels cannot disagree.
+`CATextLayer` (attributed strings, WindowServer-side re-raster on scale
+change, animatable `foregroundColor`) is an _optional_ fast path for
+static single-style text, adopted only if profiling says the raster
+visuals' memory or update cost matters — it uses its own framesetter,
+and two framesetters is one framesetter too many for anything
+selection- or caret-bearing.
+
+### Why the retained tier is the design target, in this project's terms
+
+The project grades itself on input-to-photon, then stability, then client
+CPU (AGENTS.md, [wayland.md](wayland.md) goals). Per scenario, against
+Tier S on the same hardware:
+
+- **Hover/press feedback** (`:hover`/`:active` blocks): Tier S repaints
+  the control's rect into the bitmap and uploads; Tier L sets properties
+  on one layer. Both answer on the input's frame; L does it with less
+  work and _keeps doing it_ when the JS thread is busy mid-transition.
+- **Scrolling a 500-row list**: S = memmove + strip repaint + upload per
+  notch (the X11 fast path, minus the server doing the blit for us);
+  L = one `bounds.origin` write. The entire class of scroll-blit gates,
+  ledgers and bail conditions stops existing on this backend.
+- **Transitions** (Switch thumb, hover fades): S = JS frame loop ×
+  raster × upload for the duration; L = one animation handed to the
+  render server, frame-perfect under JS stalls. This is the qualitative
+  gap — no amount of Tier S optimization reaches "smooth while the app
+  thread is blocked".
+- **Window live-resize**: S re-lays-out and re-rasters everything per
+  tick on the modal loop's cadence; L re-lays-out and updates frames —
+  the WindowServer interpolates the rest. (Both need the run-loop work
+  in §"Input and the run loop" to receive resize ticks at all.)
+- **Typing**: equivalent — caret/selection damage is small either way;
+  L still wins on retina by shipping properties instead of pixels.
+
+And one honest cost column: Tier L pays **per-layer memory** for
+rasterized contents (text bitmaps especially — X11's shared glyph atlas
+has no direct equivalent; mitigations if measurement demands them: an
+atlas texture behind `contents`+`contentsRect`, or `CATextLayer`),
+**commit overhead** proportional to layers mutated per transaction (kept
+off the NAPI floor by the batched-ops call in the addon API), and
+**complexity in the visuals** (edge sublayers, gradient layers) that the
+raster fallback bounds.
+
+### Measure first — the gate between the tiers
+
+Per the exploration brief's own instruction: the retained tier is built
+because the model fits, but it is _kept_ because the numbers say so. The
+macOS twin of `scripts/bench` (Phase 1 exit) runs the same scenarios —
+hover storm, wheel scroll on the 500-row list, virtualized re-slice,
+transition storm, typing — and reports, per scenario: wall-clock frame
+time, **input-to-photon** (NSEvent timestamp → the display-link
+timestamp of the frame containing the response; CA has no
+presentation-time protocol, but a display link plus
+`CATransaction.completionBlock` brackets it within a frame), CPU time,
+and RSS. Tier S is the baseline; Tier L must beat it where the model
+says it should (scroll, transitions, resize) and must not regress
+typing or cold mount. If a scenario shows Tier S already saturating the
+display's refresh with headroom on target hardware, that scenario's
+Tier-L machinery (e.g. layer collapsing) is deferred — measured, not
+assumed, in both directions. The numbers land in this document's
+successor the way wayland.md carries its measurements.
+
+## Windowing semantics: what maps, what bends, what breaks
+
+| react-x11 today                                    | macOS                                                                                                      | verdict                                                                     |
+| -------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| `<window>`, WM-managed                             | `NSWindow` (titled), delegate events for move/resize/close/focus                                           | maps; the app _can_ place itself (unlike Wayland)                           |
+| `<window x y>` screen position                     | `setFrameOrigin` (flip Y against the screen frame)                                                         | maps                                                                        |
+| auto-sizing (`width: 'auto'`)                      | measure first, then size the window before ordering front — same commit-phase shape as `realize()`         | maps cleanly                                                                |
+| `<popup>` (override-redirect, self-placed)         | borderless non-activating `NSPanel`, `addChildWindow` to the anchor's window, screen-coordinate placement  | maps — `anchor.js` flip/clamp math survives against `NSScreen.visibleFrame` |
+| `<popup grab>` dismissal                           | no pointer grabs; local+global event monitors, or key-window resignation                                   | bends — same UX, different mechanism                                        |
+| `decorations: false`                               | `styleMask: [.borderless]` (or `.fullSizeContentView` for CSD-ish looks)                                   | maps                                                                        |
+| `states`: maximized/fullscreen/minimized/attention | `zoom:`, `toggleFullScreen:`, `miniaturize:`, `requestUserAttention:`; readback via delegate notifications | maps; `sticky`/`below`/`skip_taskbar`/`shaded` have no equivalent           |
+| `alwaysOnTop`                                      | `window.level = .floating`                                                                                 | maps                                                                        |
+| `transientFor`                                     | `addChildWindow:` / sheets                                                                                 | maps for the dialog case                                                    |
+| `wmClass`, `onClientMessage`, size-increment hints | —                                                                                                          | gone; bundle identity lives in Info.plist                                   |
+| `transparent`                                      | `isOpaque = false`, clear background — always composited, no compositor probe needed                       | maps _better_; `useSupports('transparency')` is constant-true               |
+| frame clock (Present + fence + estimator)          | `CADisplayLink` (macOS 14+) / `CVDisplayLink`                                                              | simpler; per-window, refresh-rate-aware                                     |
+| scale ladder (env → XSETTINGS → Xft → RandR)       | `backingScaleFactor` + `windowDidChangeBackingProperties`                                                  | collapses to one authoritative, live source                                 |
+| screens (`useScreens`)                             | `NSScreen.screens` + change notification                                                                   | maps                                                                        |
+| appearance ladder                                  | `NSApp.effectiveAppearance` KVO + `NSColor.controlAccentColor`; accent-change notification                 | upgrades the existing osascript rung                                        |
+| clipboard (selections, INCR, targets)              | `NSPasteboard` (+ lazy providers for the ownership model); no PRIMARY selection                            | maps; `transfer.js` MIME plumbing reusable; INCR dies unmourned             |
+| DnD (XDND)                                         | `NSDraggingSource`/`NSDraggingDestination` on the hosting view                                             | maps; the `dropAccept`/`onDrag*` prop contract holds                        |
+| global menu (D-Bus registrar, in-window fallback)  | `NSApp.mainMenu` — **always present**, delegation never fails                                              | maps _better_; see §Menus                                                   |
+| file dialogs (portal → osascript → drawn)          | `NSOpenPanel`/`NSSavePanel` replace the osascript rung                                                     | upgrades                                                                    |
+| a11y (AT-SPI over D-Bus)                           | `NSAccessibility` protocol, virtual `NSAccessibilityElement` tree fed from the same `a11y.js` model        | maps; the model carries, the bridge is new (the Chromium/Flutter shape)     |
+| idle / keep-awake                                  | `IOPMAssertion` / `NSProcessInfo` activity                                                                 | maps                                                                        |
+| startup notification, `activateWindow`             | `NSApp.activate`, `NSRunningApplication`; Launch Services owns launch UX                                   | mostly dissolves                                                            |
+| URI schemes / single instance (`application.js`)   | Apple Events (`kAEGetURL`) + Launch Services registration; single-instance is the platform default         | maps; same hooks (`onAppOpen`/`onAppActivate`), new plumbing                |
+| tray                                               | `NSStatusItem`                                                                                             | **gained** — X11 has no core tray today                                     |
+| `<glarea>` (GLX / direct CGL)                      | `CAOpenGLLayer`/`NSOpenGLContext` (deprecated but functional), or ANGLE/Metal later                        | bends; ntk's existing `cgl` direct backend is prior art                     |
+| `<foreign>`, XEmbed `<Frame>`, `examples/wm.jsx`   | —                                                                                                          | **gone by design**                                                          |
+| `ssh -X` remoting                                  | —                                                                                                          | X11 backend remains the remote answer                                       |
+| keyboard state (Caps Lock before first key)        | `NSEvent.modifierFlags` (static read + `flagsChanged`)                                                     | maps                                                                        |
+
+The popup row deserves the same sit-down wayland.md gave it, with the
+opposite conclusion: macOS _keeps_ client-side placement, so `anchor.js`
+stays the single source of truth on this backend — the math that had to
+move into Wayland's positioner stays exactly where it is here, reading
+`NSScreen` geometry instead of Xinerama.
+
+## Text: the engine contract
+
+Everything the renderer needs from text goes through one object today —
+`app.fonts.layout(spans, base, options)` returning a layout with
+`{width, height, draw(ctx, x, y), indexAt(x, y), caretPosition(index),
+rangeBands(...)}` plus font loading (`openFont`/`loadFont`) and glyph
+queries. That interface _is_ the TextEngine contract; the macOS backend
+implements it over CoreText:
+
+- **Matching**: family list + weight/style/`fontVariationSettings` →
+  `CTFontDescriptor`/`CTFontCreateWithName`, with the CSS generic
+  families mapped to system faces (`sans-serif` → SF via
+  `systemFontOfSize`, which also finally answers the fontconfig-on-macOS
+  wrong-font issue #86 for this backend — the right fix on the native
+  path is not having fontconfig in it at all). `opsz` behaves (SF's
+  optical sizing is CoreText-native).
+- **Shaping/wrapping/bidi/truncation**: `CTFramesetter` over an
+  attributed string built from the same span list (spans map to
+  attribute ranges — the nested-`<text>` model transfers directly).
+- **Metrics for yoga**: the same framesetter answers `measureContent`,
+  so measure and render cannot disagree. Whole-pixel answers, per the
+  yoga content-floor rules.
+- **Carets/hit/selection**: `CTLineGetStringIndexForPosition`,
+  `CTLineGetOffsetForStringIndex`, line origins → `indexAt`,
+  `caretPosition`, `rangeBands` — the `<textinput>`/selection surface,
+  method-for-method.
+- **Raster**: draw the frame into a bitmap for the node's layer
+  (`contentsScale`-aware); glyph-run-level drawing
+  (`CTFontDrawGlyphs`) backs the `drawGlyphs`/`positioned` context
+  extensions the terminal and code-editor components use.
+
+The alternative — reusing ntk's fontkit shaping stack on macOS and
+rasterizing through the Wayland Tier-A span compositor — is recorded,
+not chosen: it buys byte-identical metrics across backends (one test
+suite, one wrap behavior) at the cost of client-side font matching
+against the macOS font system (the exact pain #86 documents), no
+system-font niceties, and a hard dependency on the Wayland renderer
+workstream. The seam keeps it swappable if cross-backend metric parity
+turns out to matter more than platform-correct text; the default is the
+platform's own text system, matching how every other ladder in this
+project prefers the platform's own answer.
+
+Grayscale antialiasing (macOS dropped subpixel AA in Mojave) means
+self-rastered text is not visibly second-class — the field's CPU-raster
+toolkits look native on modern macOS.
+
+**IME** is the reason to be on this text stack eventually:
+`NSTextInputClient` on the hosting view, routed to the focused node's
+composition events (`CompositionStart/Update/End` already exist in the
+event vocabulary), gives dead keys, marked text and CJK input the way
+the platform means it — the capability X11 issue #272 wants and cannot
+yet have. Phase 5, but the view is written with the protocol stubs from
+day one.
+
+## Input and the run loop
+
+Event mapping is mechanical — the normalized shapes already exist and the
+dispatcher never sees platform structs:
+
+- Mouse/wheel: NSEvent → `{x, y}` flipped to top-left (POC does this),
+  buttons, click counts (`clickCount` → `detail`), `scrollingDeltaX/Y`
+  with `hasPreciseScrollingDeltas` → the `smooth` wheel flag (macOS is
+  the smooth-scroll platform; the wheel pipeline already handles pixel
+  deltas), enter/exit via a tracking area, per-window routing by
+  `windowNumber`.
+- Modifiers: `modifierFlags` → `shiftKey/ctrlKey/altKey/metaKey`
+  (⌘ = meta, ⌥ = alt — the DOM's own macOS convention, which the event
+  API borrowed already).
+- Keys: `keyCode` (kVK) + `characters`/`charactersIgnoringModifiers` →
+  `keysym` (rule above), `codepoint`, `key`, `repeat`. The Latin-chord
+  rule from `keyboard.js` (shortcuts keep working under a Cyrillic
+  layout) is reimplemented from
+  `charactersByApplyingModifiers:`/the kVK position map — same behavior,
+  simpler source.
+
+**The run loop is the one architectural risk in the whole plan**, so it
+gets the full treatment. The POC's model — Node's loop is master, a
+timer pumps `nextEventMatchingMask:` — works until AppKit runs one of
+its internal modal loops (live window resize/drag, menu tracking,
+drag sessions, panel runModal), which happen _inside_ the pump call: JS
+is then frozen for the duration, timers queue, React cannot commit, and
+only render-server animations keep moving. Three options, in ascending
+order of invasiveness:
+
+1. **Timer pump only** (POC today). Acceptable for the spike; input
+   latency is the timer cadence; modal loops starve the app. Not
+   shippable as the default.
+2. **Timer pump + a libuv drain inside AppKit's loops** — install a
+   `CFRunLoopObserver`/source that runs
+   `uv_run(uv_default_loop(), UV_RUN_NOWAIT)` (plus microtask
+   checkpoint) each cycle of _whatever_ run loop is spinning. AppKit's
+   modal loops then keep Node alive: React commits during live resize,
+   menu items update while a menu is open, timers fire. This is the
+   standard libuv embedding recipe pointed the other way, and it is
+   bounded addon work. The risk to design for is re-entrancy — JS
+   running from inside a native frame that a JS call started — which the
+   addon guards with an in-pump flag (no nested drains) and by keeping
+   drains off the pump's own cycle.
+3. **Full inversion** — `[NSApp run]` owns the process, libuv embedded
+   as a slave (the Electron shape: watch `uv_backend_fd` on a helper
+   thread, wake the main loop, drain there). Most correct, most
+   invasive; not needed until proven needed.
+
+**Decision: build 2, keep 1 as the fallback switch, hold 3 in reserve.**
+Exit criterion for Phase 0: during a live window resize, a React
+state-driven relayout visibly tracks the drag — that single demo proves
+the drain works where it matters most.
+
+The frame clock rides the display link: `requestAnimationFrame`
+callbacks fire on link ticks, commits wrap in explicit `CATransaction`s,
+and the "answer the input" early-flush (`flushPendingFrames` on handler
+unwind) maps to committing the transaction before the pump returns to
+AppKit — same policy, new mechanism.
+
+## Native controls
+
+House rule applied: **default native, seam out.** On the Cocoa backend
+core controls render with AppKit's own pixels; interaction, focus,
+keyboard and a11y semantics stay the shared implementation (the
+"answer-the-input" press model is behavior this project considers part
+of its identity, and AppKit's own controls would take it over
+wholesale — different focus ring timing, different keyboard rules,
+different event routing — which is why real `NSView` controls embedded
+in the layer tree are _not_ the mechanism).
+
+The mechanism is the POC's proven one: **offscreen NSCell/control
+rendering into cached images** (the WebKit/Gecko technique), keyed
+`(kind, size, state, appearance, accent)`, nine-slice-stretched via
+`contentsCenter` where the bezel allows, set as the control node's layer
+contents. Push buttons (including the accent-filled default button),
+checkbox, radio, popup, slider knob/track, switch — all render today in
+both appearances with pressed/on states.
+
+Wiring, shaped as theme policy rather than per-widget forks:
+
+- `ThemeProvider` grows `controls: 'native' | 'drawn'` — default
+  `'native'` on the Cocoa backend, `'drawn'` (and the only legal value)
+  on X11. Per-instance escape hatch: `native={false}` on a control for
+  the odd custom-branded button. A drawn control on macOS keeps today's
+  themed rendering, so custom-designed apps lose nothing.
+- Components keep their exact public contracts (`checked`/`onChange`,
+  the `changeEvent` shape, `useControl` states) and swap only the
+  _bezel_: where the drawn variant renders well/track/thumb boxes, the
+  native variant renders a bezel-image node sized by the cell's natural
+  metrics. Hover/press/focus continue to drive it — pressed bezels are
+  re-keyed images, and the press state still lands on the press frame.
+- The palette gains a macOS system theme whose tokens read semantic
+  `NSColor`s (accent, text, separators) so _drawn_ content — cards,
+  tables, custom widgets — sits harmoniously beside native bezels, and
+  the desktop accent reaches `theme.accent` on this backend through the
+  same explicit adoption rule as on Linux.
+- Text controls stay drawn everywhere for now: `<textinput>`'s editing
+  model (undo, selection, caret cadence from desktop settings) is deep
+  shared behavior, and a native `NSTextField` would fork it. The native
+  win for text is IME (§Text), not the bezel.
+- `NSSwitch`'s knob animation: the native bezel pair + the existing
+  `transition` on the thumb reproduces it; if fidelity disappoints, the
+  switch is the one control worth revisiting as a real view. Menus and
+  popover _panels_ are never bezel-rastered — their vibrancy needs
+  private API; they go native for real (§Menus) or stay drawn.
+
+`useSupports('nativeControls')` reports the capability so component code
+and apps can branch the way `'shaders'` consumers already do.
+
+## Menus: the global menu, finally at home
+
+The Linux global menu was built for exactly this moment: the item
+vocabulary is data (dbusmenu's), `MenuBar` draws the same array it
+exports, and the pure `snapshot`/`diffSnapshots`/`IdAllocator` machinery
+in `dbusmenu.js` produces stable ids and structural-vs-property diffs
+with no D-Bus in sight. The macOS adapter consumes precisely that:
+
+- `snapshot(menus)` → build/patch an `NSMenu` tree; `IdAllocator` ids
+  key an `NSMenuItem` cache across re-renders; `diffSnapshots` decides
+  patch-in-place (title/enabled/state) vs. rebuild (structure).
+  `itemProperties()` is the one function swapped — dbusmenu props out,
+  `{title, enabled, hidden, state, keyEquivalent(+mask), submenu}` in.
+- Item activation carries the id back; `itemFor(id).onSelect` fires —
+  the same contract the registrar path has.
+- `useGlobalMenu` on this backend **always delegates** — the fallback
+  drawn bar (`if (delegated) return null` in `MenuBar`) simply never
+  renders, and `onGlobalMenuChange(true)` reports it. No registrar
+  probing, no liveness rules: the menu bar is a platform constant.
+- macOS requires the standard skeleton — the application menu
+  (About/Preferences/Hide/Quit), Edit, Window — which the adapter
+  synthesizes around the app's menus by default (the main customer
+  ships a Mac-correct menu bar with zero configuration), with the
+  app-menu items reachable as props for the apps that name their own
+  (`about`, `preferences` handlers). `editmenu.js`'s item set feeds the
+  standard Edit menu so text controls get theirs.
+- **Accelerators invert.** On X11 the app window matches chords itself;
+  in `NSMenu` the key equivalent belongs to the item. The adapter maps
+  chords → `keyEquivalent` + modifier mask, and `useMenuAccelerators`
+  disarms for delegated bars (it already re-anchors on delegation — the
+  macOS case is "never arm"). The chord grammar gains one token:
+  **`Primary`** — ⌘ on macOS, `Control` elsewhere — because
+  `[['Control','S']]` written literally would demand ⌃S on a Mac.
+  `matchesShortcut`/`useAccelerator` accept it too, so non-menu
+  shortcuts follow the same convention. Existing menus keep working;
+  examples and docs move to `Primary`.
+- `ContextMenu` defaults to a native `NSMenu` popup on this backend
+  (same adapter, `popUpMenuPositioningItem:`), with the drawn popup as
+  the seam (`native={false}`) — the drawn one exists, works, and some
+  apps will want visual consistency with custom themes. Note the native
+  menu runs a tracking loop: run-loop option 2 is what keeps React
+  alive while it is open (menu-item enablement updating live is the
+  test).
+
+## Custom drawing on a layer tree
+
+The escape hatches all reduce to one rule stated in Tier L: **a node
+whose content is painted code gets a raster visual** — a bitmap-backed
+layer, the CG canvas2d context translated to its box, redraw on the
+node's own damage claims, `contentsScale` from the window.
+
+- `<canvas onDraw>`: `paintContent` runs against the CG ctx; a new
+  `onDraw` closure invalidates the node (existing rule); `putImageData`
+  keeps its absolute-coordinates contract via the same `info.x/y`.
+- `cacheKey`/`mono`: the pattern transfers — keyed bitmaps shared
+  across canvases; `mono` renders an alpha-only mask once per
+  (name, size) and tints per ink via `CGContextClipToMask` + fill, so
+  the a8-coverage economics survive (ink stays out of the raster key).
+- `registerElement` + `Node.paint(ctx)` subclasses (all seven components
+  elements): work unchanged through the raster visual. The
+  `Context2D` dialect the consumers exercise — including `fillRects`,
+  `drawGlyphs`, `positioned`, `layoutSubtree`, `vw/vh/em` — is part of
+  the ctx contract on both backends.
+- `ntk.Surface` offscreen allocation (charts, terminal): the Cocoa app
+  object supplies a `Surface`-compatible bitmap surface (CG bitmap
+  context + drawImage back into a node ctx). The `react-x11/ntk`
+  subpath on this backend serves the _drawing-adjacent_ names
+  (`Surface`, `cssColorStraight`, `decodeImage`, `Image`) from
+  backend-neutral implementations; the X-only names stay X-only.
+- `<svg>`: the declarative vocabulary (`SvgChildNode`) is portable; the
+  rasterizer behind it renders through the same CG ctx.
+- A future, deliberate seam — not built until a consumer needs it:
+  `registerElement({ visual })`, letting an element supply a
+  layer-aware visual instead of raster (a chart that wants its series
+  as shape layers, say). The raster default means nobody _has_ to.
+
+## Animations and transforms: the API the model unlocks
+
+The existing declarative vocabulary is the seam: `transition:` and
+`animation:` in styles. On X11 they run on the frame clock (JS
+interpolation, repaint per frame — including the premultiplied-lerp
+rule). The Cocoa presenter maps the same declarations to
+`CATransaction`/`CABasicAnimation` on the affected layer properties, and
+the render server interpolates. Semantics to pin when this lands
+(Phase 5): timing-function parity, transition-interrupt behavior
+(CA's additive animations vs. the JS loop's retargeting), and the
+completion moment `onStatesChange`-style code can observe. Until then,
+the JS frame loop works on Cocoa too — correctness first, offload as the
+measured upgrade.
+
+Two style capabilities currently rejected everywhere become cheap on
+layers and are proposed as **capability-gated additions** rather than
+macOS-only forks, keeping one style vocabulary:
+
+- **`opacity`** — free on a layer (`opacity`); on X11 implementable as
+  group-raster through an ntk `Surface` at composite time (bounded,
+  cacheable). Ship on both, the X11 cost documented.
+- **`transform`** (2D: translate/scale/rotate) — free on a layer;
+  XRender pictures do transform, so a bounded X11 story exists for
+  leaf-ish content even if the general case (transformed subtrees with
+  events) is deferred. Proposed staged: layer backend first behind
+  `useSupports('transforms')` + an `@supports` style block, X11 catch-up
+  or documented divergence decided by real demand.
+
+Both wait until the presenter exists; they are listed because "hardware
+composited layers with animation and transformations" is half the reason
+to build Tier L, and the API shape (style props + capability gates)
+should be agreed before someone builds a macOS-only thing.
+
+## Public API: what changes
+
+Measured against both consumers, the surface holds; the deltas are
+additive or mechanical:
+
+1. **Backend selection.** `createRoot()` gains
+   `backend: 'x11' | 'cocoa' | 'auto'` (default `'auto'`: Cocoa on
+   darwin when the bridge is installed, else X11 via `$DISPLAY`;
+   `REACT_X11_BACKEND` overrides for A/B). Backend-specific options
+   stay flat but documented per backend (`display`/`stream`/`glxVisual`/
+   `glPolicy` are X11's; an unknown-to-this-backend option throws with
+   the usual corrective error). `createRoot({ app })` keeps working and
+   is how tests inject mocks of either flavor.
+2. **Capabilities.** `useSupports` grows `'nativeControls'`,
+   `'globalMenu'`, `'transforms'` (when built) beside `'transparency'`
+   and `'shaders'`; same store-and-settle semantics.
+3. **Inert props policy** (wayland.md open question 1, now decided the
+   way it leaned): same JSX everywhere; a prop with no meaning on this
+   backend (`wmClass`, `xi2`, `onClientMessage`, X-only states) is
+   inert with a one-time dev-mode note naming the backend — not a
+   throw, so shared app code stays branch-free.
+4. **Keysyms are the key vocabulary**, formally: documented as
+   react-x11's own symbolic key codes (X heritage acknowledged), with
+   the Cocoa input layer synthesizing them. No consumer changes.
+5. **Chord grammar** gains `Primary` (§Menus). Existing tokens keep
+   their literal meanings.
+6. **Test harness**: `renderX11(..., { backend })` namespace gains
+   `'cocoa'` (real, windowed) and `'cocoa-mock'` (headless presenter
+   recorder); existing names untouched. `toPNG`/`pixelAt` on Cocoa read
+   the window snapshot. Pixel _hashes_ are per-backend by construction
+   (CoreText raster ≠ ntk raster); cross-backend assertions compare
+   structure and behavior, not bytes.
+7. **Packaging.** `node-calayers` publishes as its own package — a
+   freestanding, toolkit-agnostic Cocoa bridge (its README already
+   documents the host-config mapping for any reconciler), `os:
+["darwin"]`, prebuilds for arm64/x64, N-API (which keeps the Bun
+   door open; verify in Phase 1). react-x11 references it as an
+   `optionalDependency` exactly as it does `dbus-native`: absent on
+   Linux installs, absent even on macOS if the user skips optional
+   deps — and `backend: 'auto'` then falls back to X11 with a
+   diagnostic. The Cocoa backend code itself lives in-repo
+   (`src/cocoa/…`), not a separate package: one repo, one test suite,
+   one release train, the same reasoning wayland.md's open question 2
+   leaned to.
+8. **The name.** Nothing in this design _requires_ renaming `react-x11`,
+   and both consumers import it by that name today. But this RFC is the
+   moment the name becomes descriptive of one backend out of three
+   planned, and pre-release is the last cheap moment to change it. The
+   options are (a) keep it (Electron ships Chromium nobody renamed;
+   the name becomes heritage), or (b) rename once, now, to something
+   backend-neutral, with `react-x11` republished as an alias or left as
+   the X11-flavored entry. **This document deliberately does not decide
+   it** — it is a taste call for the maintainer — but it does say:
+   decide before the Cocoa backend ships, because every README, example
+   and import written after that multiplies the cost, and do not ship a
+   compatibility alias _afterward_ (AGENTS.md's own shim rule).
+
+## node-calayers: the required API
+
+The contract to publish against — grouped, with the POC's coverage
+marked. Mechanism only; policy stays in the renderer.
+
+**App & run loop.** `initApp()`; `pump()` ✅; run-loop drain hook
+(option 2: install/remove the libuv drain, with the re-entrancy guard)
+🆕; display link per window (`onFrame(cb)` with timestamps, start/stop)
+🆕; activation policy + `activate()`, app/dock name 🆕; termination and
+`applicationShouldTerminate` routing 🆕; open-URL/open-file Apple Event
+callbacks (for `onAppOpen`) 🆕.
+
+**Windows.** create ✅ with style options (titled/borderless/panel,
+non-activating, level, opaque/clear) 🆕partial; close ✅; title, frame
+get/set in top-left global coords 🆕 (size ✅); min/max size, aspect 🆕;
+zoom/miniaturize/fullscreen + state readback 🆕; `addChildWindow` 🆕;
+delegate events — resized (live-resize ticks included), moved,
+close-requested, key/main changed, backing-scale changed, screen
+changed, miniaturized 🆕; `scale` ✅; snapshot ✅; per-window event
+routing (window id on every event) 🆕; `requestUserAttention`,
+`orderFront/out` 🆕.
+
+**Layers.** create Layer/Text/Gradient/Shape ✅; `set(props)` for
+frame/bounds/position/anchor, backgroundColor, cornerRadius (+
+`cornerCurve`, `maskedCorners`), border, shadow (+ **`shadowPath`** 🆕),
+opacity, zPosition, transform, `masksToBounds`, mask, `contentsScale`,
+`contentsCenter`/`contentsRect`/`contentsGravity` 🆕partial;
+`addSublayer` ✅ + **`insertSublayer(at/below/above)`** 🆕; remove ✅;
+`bounds.origin` scroll offset (covered by `set`) ✅; **raw-buffer
+contents upload** (premultiplied BGRA/RGBA + stride → layer contents,
+ideally IOSurface-backed for no-copy) 🆕; image contents ✅; **batched
+ops** — one call applying a serialized list of (layer, props) mutations
+inside one transaction, so a big commit is one NAPI crossing 🆕;
+transactions ✅ (`begin/commit`, duration, timing, `disableActions`,
+completion callback 🆕); explicit animations ✅ (+ removal ✅,
+`animationDidStop` callback 🆕).
+
+**Drawing (raster fallback).** A CG bitmap surface object: create at
+size×scale, obtain a canvas2d-compatible context (native-side
+implementation of the ctx verbs the dialect needs — CG covers the
+standard set; `fillRects` → `CGContextFillRects`; `drawGlyphs` →
+`CTFontDrawGlyphs`), read pixels, hand to a layer as contents without a
+copy where possible 🆕. (Alternative: rasterize JS-side and use the
+raw-buffer upload; the API supports both so the choice can be measured.)
+
+**Text.** measure ✅ → full layout object 🆕: build from span list
+(attributed string), report lines/runs/origins, `indexAt`,
+`caretOffset`, range rects, truncation/`maxLines`, draw-to-bitmap ✅ and
+draw-into-surface 🆕, glyph-run access for `drawGlyphs` 🆕; font
+matching by family list/weight/style/variations → descriptor, and
+loading app-supplied font files (`loadFont`) 🆕; `hasGlyph` 🆕.
+
+**Controls.** `controls.render` ✅ (push/default/checkbox/radio/popup/
+slider/switch, states, sizes, appearance) — add: focus-ring state,
+progress bars (bar/spinner), disclosure, natural-metrics query,
+nine-slice insets per kind 🆕; `controls.isDark` ✅ → replaced by
+appearance API below.
+
+**Menus.** Build/patch NSMenu trees from an item list (title, enabled,
+hidden, state/mixed, keyEquivalent+mask, separator, submenu, image?);
+stable item handles for in-place patching; set as main menu; standard
+app/Edit/Window skeleton helpers; context popup at screen point;
+`onAction(id)`; `menuWillOpen` hook 🆕 (all new).
+
+**Pasteboard.** read/write types (string, RTF?, file URLs, custom UTIs
+mapped from MIME), change count polling, lazy provider callback 🆕.
+
+**Drag & drop.** Begin drag session (image, items); destination
+registration on the view with enter/over/exit/drop callbacks carrying
+position + types 🆕.
+
+**Screens & appearance.** `NSScreen` list (frame, visibleFrame, scale,
+id) + change notification; `effectiveAppearance` (dark/light, high
+contrast, reduce motion, accent + change notifications) 🆕
+(replaces `appearanceIsDark` ✅).
+
+**Cursors & misc.** Standard cursor set + hide/show (`setCursor`
+parity) 🆕; `NSStatusItem` (tray; later) 🆕; open/save panels (later)
+🆕; a11y virtual element tree (later, its own design) 🆕.
+
+**Testing hooks.** `postMouseEvent` ✅ extended with modifiers, wheel,
+key events 🆕; window snapshot ✅; a headless mode statement (CI:
+windowed Aqua sessions on macOS runners are expected to work — verify
+in Phase 1; the mock presenter keeps unit tests off the GUI entirely).
+
+## Testing
+
+The strategy mirrors the X11 suite's shape rather than its mechanism:
+
+- **Unit tier, headless, any OS**: `backend: 'cocoa-mock'` — the Cocoa
+  presenter running against a recorded layer-op sink and a metrics-only
+  TextEngine stub (the `mock-app.js` precedent). Asserts _which layer
+  mutations a commit produces_ — the retained twin of the dirty-rect
+  tests — plus all the shared behavioral tests, which run on the node
+  model and don't care about the presenter.
+- **Integration tier, macOS**: real windows on a runner's Aqua session;
+  pixels via window snapshot; input via the posted-event path (the
+  harness's `fireEvent` transport). Per-backend pixel baselines; the
+  scenario-level structural assertions (find-by-color, behavior) shared.
+- **The bench twin** (§Measure first) is part of the definition of done
+  for the presenter, not an afterthought — the scroll and transition
+  scenarios are the reason Tier L exists, so they are what fences it.
+
+## The plan
+
+Each phase has an exit that makes the next safe to start; the first two
+run against today's renderer with no core changes.
+
+- **Phase 0 — the bridge contract (node-calayers).** Close the POC gaps
+  that block everything else: event modifiers + per-window routing +
+  wheel/key posting, window delegates, `insertSublayer`, raw-buffer/
+  IOSurface contents, batched ops, display link, run-loop drain
+  (option 2), and the menu API skeleton. Publish 0.2.0 with prebuilds.
+  _Exit: a demo app live-resizes with JS-driven relayout tracking the
+  drag, and a native menu's items enable/disable from JS while open._
+- **Phase 1 — the surface backend (Tier S).** `src/cocoa/app.js`
+  implementing the ntk app/window/ctx/fonts contract; CoreText
+  TextEngine v1; event mapping; `createRoot({ backend })` selection;
+  `cocoa-mock` harness backend. Run the examples; port the test suite
+  where the mock reaches. Build the bench twin and record Tier-S
+  baselines, including input-to-photon. _Exit: `examples:widgets`,
+  `tasks`, `form` fully interactive natively; suite green on
+  cocoa-mock; baselines recorded._
+- **Phase 2 — the presenter seam (X11-neutral refactor).** Extract
+  paint/damage/flush into the X11 presenter behind the
+  invalidate/flush contract; nodes keep model+events+layout. **Zero
+  behavior change**, pinned by pixel gates, dirty-rect tests and
+  `bench --check` on X11. _Exit: X11 suite and bench byte- and
+  number-identical; the presenter interface documented in
+  docs/extending.md terms._
+- **Phase 3 — the layer presenter (Tier L core).** Visuals for
+  box/text/image/canvas + raster fallback; clipping and scrolling via
+  layer properties; popups as panels; `CATransaction` per commit.
+  Measure against Tier-S baselines; apply the §Measure-first gates
+  (layer-collapse and text-atlas work only where numbers demand).
+  _Exit: the bench twin shows Tier L beating Tier S on scroll and
+  transition scenarios and regressing none; examples run on layers;
+  Tier S demoted to fallback/A-B switch._
+- **Phase 4 — the platform (macOS services).** NSMenu global menu +
+  `Primary` chords; native appearance/screens/scale/window-state;
+  pasteboard clipboard; native control bezels behind
+  `controls: 'native'`; native file dialogs; `useSupports` additions.
+  _Exit: `examples:menu` is the system menu bar; `widgets` renders
+  native bezels; appearance flips live without osascript._
+- **Phase 5 — the deep integrations.** DnD; NSAccessibility bridge over
+  the a11y model; IME via NSTextInputClient; transitions offloaded to
+  CA (+ `opacity`, then `transform`, capability-gated); `<glarea>` over
+  CAOpenGLLayer/ntk-cgl; tray via NSStatusItem; app lifecycle
+  (open-URL → `onAppOpen`). Each is its own bounded design against a
+  by-then-stable presenter. _Exit: per-feature; the a11y bridge's is
+  VoiceOver reading the widgets example the way Orca reads it today._
+
+## Open questions
+
+1. **The name** (§Public API #8) — decide before Phase 4 ships anything
+   user-visible.
+2. **Layer granularity numbers** — layer-per-drawn-node is the bet;
+   collapse thresholds and the text-atlas question are Phase-3
+   measurements, and the §Measure-first gates decide them.
+3. **Run-loop option 3** — is the drain (option 2) enough for menu
+   tracking + live resize + drag sessions in practice, or does a real
+   inversion become necessary? Phase 0/1 experience answers it.
+4. **Transition semantics under CA** — retarget/interrupt parity with
+   the JS loop needs a written spec before Phase 5 flips the default.
+5. **Cross-backend text metrics** — accepted divergence (per-backend
+   pixel baselines) vs. the shared-shaping option if component layout
+   portability bites in practice.
+6. **Bun on the Cocoa backend** — N-API under Bun is expected to work;
+   verify early (Phase 1) since single-file packaging is a stated goal.
+7. **`@react-x11/components` on Cocoa** — the seven registered elements
+   should light up via the raster path untouched; the X-only corners
+   (tray-host, embed, media-player embedding, `serverTime`) need
+   per-module capability statements rather than silent absence.
+
+## References
+
+- [wayland.md](wayland.md) — the sibling RFC; shared inventory and the
+  opposite rendering inversion.
+- [remote.md](remote.md), [embedding.md](embedding.md),
+  [globalmenu.md](globalmenu.md), [appearance.md](appearance.md),
+  [filedialog.md](filedialog.md), [accessibility.md](accessibility.md),
+  [events.md](events.md), [styling.md](styling.md),
+  [extending.md](extending.md), [testing.md](testing.md) — the
+  per-feature contracts this plan maps onto Cocoa.
+- Apple: Core Animation Programming Guide; `CATransaction`,
+  `CALayer.shadowPath`, `contentsCenter`, `NSTextInputClient`,
+  `NSAccessibilityElement`, `NSDraggingSession`, `NSPasteboard`,
+  `CADisplayLink` (macOS 14+).
+- libuv — "Embedding libuv in other event loops" (the run-loop drain's
+  recipe, pointed at AppKit).
+- WebKit/Gecko form-control rendering via offscreen `NSCell` drawing —
+  the native-bezel technique the POC reproduces.
+- `node-calayers` POC — `~/tmp/node-calayers` (to be published; §"the
+  required API" is its 0.2.0 contract).

--- a/examples/configurator/index.jsx
+++ b/examples/configurator/index.jsx
@@ -586,7 +586,11 @@ const s = createStyles({
     flexShrink: 1,
     minHeight: 0,
     flexDirection: 'column',
-    alignItems: 'stretch',
+    // centred, not stretched: the lid (424) and the base (496) are
+    // different widths on purpose — a laptop's deck is wider than its
+    // screen — and stretch-alignment left both flush left, base jutting
+    // out to one side
+    alignItems: 'center',
     justifyContent: 'center',
     gap: 0,
     '@height < 720': { display: 'none' },
@@ -651,7 +655,10 @@ const s = createStyles({
 
   // The GL surface is a real X window stacked above everything the parent
   // paints, so it gets the stage to itself and the chips sit below it.
-  stageGl: { flexGrow: 1, minHeight: 0 },
+  // `alignSelf: 'stretch'`: the stage centres its children now (the flat
+  // laptop's lid and base are deliberately different widths), and the GL
+  // surface still wants the full column.
+  stageGl: { flexGrow: 1, minHeight: 0, alignSelf: 'stretch' },
   chipsRow: {
     flexDirection: 'row',
     flexWrap: 'wrap',

--- a/examples/configurator/index.jsx
+++ b/examples/configurator/index.jsx
@@ -319,9 +319,11 @@ const usd = (n) => '$' + n.toLocaleString('en-US');
  * makes — that it renders identically anywhere — is kept by the lockfile
  * rather than by the repository.
  *
- * They are `.woff2`, which fontkit reads directly, and they are the **latin**
- * subsets, since everything on this page is latin. What the subset costs is
- * written down where it bites — see `Check` below.
+ * They are `.woff` — the container both engines read: fontkit directly, and
+ * the macOS backend's CoreText after a zlib unwrap (`.woff2`'s compression
+ * is the one CoreText cannot take). They are the **latin** subsets, since
+ * everything on this page is latin. What the subset costs is written down
+ * where it bites — see `Check` below.
  */
 const require_ = createRequire(import.meta.url);
 
@@ -339,16 +341,16 @@ const require_ = createRequire(import.meta.url);
  */
 const FONT_FILES = {
   sans: {
-    400: '@fontsource/inter/files/inter-latin-400-normal.woff2',
-    500: '@fontsource/inter/files/inter-latin-500-normal.woff2',
-    600: '@fontsource/inter/files/inter-latin-600-normal.woff2',
-    700: '@fontsource/inter/files/inter-latin-700-normal.woff2',
+    400: '@fontsource/inter/files/inter-latin-400-normal.woff',
+    500: '@fontsource/inter/files/inter-latin-500-normal.woff',
+    600: '@fontsource/inter/files/inter-latin-600-normal.woff',
+    700: '@fontsource/inter/files/inter-latin-700-normal.woff',
   },
   serif:
-    '@fontsource/instrument-serif/files/instrument-serif-latin-400-normal.woff2',
+    '@fontsource/instrument-serif/files/instrument-serif-latin-400-normal.woff',
   serifItalic:
-    '@fontsource/instrument-serif/files/instrument-serif-latin-400-italic.woff2',
-  mono: '@fontsource/jetbrains-mono/files/jetbrains-mono-latin-400-normal.woff2',
+    '@fontsource/instrument-serif/files/instrument-serif-latin-400-italic.woff',
+  mono: '@fontsource/jetbrains-mono/files/jetbrains-mono-latin-400-normal.woff',
 };
 
 function useShippedFonts() {

--- a/examples/fonts.jsx
+++ b/examples/fonts.jsx
@@ -220,9 +220,11 @@ function paintGuideLines(ctx, width, rows, lines) {
  * one above; the line it belongs to has not moved, and the colour is what
  * ties the two together.
  */
-function paintGuideLabels(ctx, width, height, rows) {
-  ctx.font = '9px sans-serif';
-  const gap = 11;
+function paintGuideLabels(ctx, width, height, rows, scale = 1) {
+  // the canvas draws in device pixels; a size written as if logical is
+  // half-height on a 2x display
+  ctx.font = `${Math.round(9 * scale)}px sans-serif`;
+  const gap = 11 * scale;
   let lowest = -Infinity;
   for (const { label, colour, y } of rows) {
     const at = Math.min(height - 2, Math.max(y, lowest + gap));
@@ -255,7 +257,7 @@ function paintGlyphBox(ctx, hover) {
 }
 
 /** The specimen: a background, guides, a shadow, the face, and a hover box. */
-function paintSpecimen(ctx, { width, height, node }, opts) {
+function paintSpecimen(ctx, { width, height, node, scale = 1 }, opts) {
   const {
     gradient,
     ink,
@@ -356,7 +358,7 @@ function paintSpecimen(ctx, { width, height, node }, opts) {
   layout.draw(ctx, TEXT_X, top);
   ctx.restore();
 
-  if (rows.length) paintGuideLabels(ctx, width, height, rows);
+  if (rows.length) paintGuideLabels(ctx, width, height, rows, scale);
   if (hover) paintGlyphBox(ctx, hover);
 }
 

--- a/examples/icons.jsx
+++ b/examples/icons.jsx
@@ -483,7 +483,11 @@ function watchPaint(root, { quiet = 0 } = {}) {
     const entry = { n, where, area, client, why, server: undefined };
     queue.push(entry);
 
-    if (!X) {
+    // No X connection (headless), or a backend whose display has no fence
+    // request (the Cocoa backend talks to no X server): the client column is
+    // still real, but there is no server tail to wait on — report it as
+    // unmeasured rather than inventing a number.
+    if (typeof X?.GetInputFocus !== 'function') {
       entry.server = null;
       drain();
       return result;

--- a/examples/menu.jsx
+++ b/examples/menu.jsx
@@ -260,6 +260,7 @@ function App() {
         {
           label: 'Quit',
           icon: ICONS.power,
+          iconName: 'power',
           shortcut: [['Control', 'Q']],
           onSelect: note('Quit'),
         },
@@ -271,12 +272,14 @@ function App() {
         {
           label: 'Undo',
           icon: ICONS.undo,
+          iconName: 'arrow.uturn.backward',
           shortcut: [['Control', 'Z']],
           onSelect: note('Undo'),
         },
         {
           label: 'Redo',
           icon: ICONS.redo,
+          iconName: 'arrow.uturn.forward',
           shortcut: [['Control', 'Y']],
           enabled: false,
         },
@@ -284,6 +287,7 @@ function App() {
         {
           label: 'Cut',
           icon: ICONS.scissors,
+          iconName: 'scissors',
           shortcut: [['Control', 'X']],
           onSelect: note('Cut'),
         },

--- a/examples/stress/index.jsx
+++ b/examples/stress/index.jsx
@@ -28,14 +28,6 @@ import { ControlsPanel } from './controls.jsx';
 import { DamagePanel } from './damage.jsx';
 import { MixedPanel } from './mixed.jsx';
 
-const PALETTE = {
-  background: '#f5f6fa',
-  surface: '#ffffff',
-  text: '#2d3436',
-  textMuted: '#7f8c8d',
-  edge: '#dfe6e9',
-};
-
 const s = createStyles({
   window: { backgroundColor: '$background' },
   shell: { flexGrow: 1, minHeight: 0 },
@@ -78,7 +70,6 @@ function App({ onRoot, width = 1100, height = 760, section: initial }) {
       height={height}
       minWidth={640}
       minHeight={480}
-      theme={PALETTE}
       style={s.window}
     >
       <box ref={shell} style={s.shell}>

--- a/examples/stress/typography.jsx
+++ b/examples/stress/typography.jsx
@@ -19,14 +19,14 @@ const s = createStyles({
   row: { flexDirection: 'row', gap: 16, alignItems: 'flex-start' },
   col: { flexGrow: 1, flexBasis: 0, minWidth: 0, gap: 8 },
   card: {
-    backgroundColor: '$background',
+    backgroundColor: '$surface',
     borderWidth: 1,
     borderColor: '$track',
     borderRadius: 4,
     padding: 12,
     gap: 6,
   },
-  label: { fontSize: 10, color: '$border' },
+  label: { fontSize: 10, color: '$textMuted' },
   controls: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -62,7 +62,7 @@ const VARIANTS = [
   },
   { label: 'centered', style: { fontSize: 13, textAlign: 'center' } },
   { label: 'right', style: { fontSize: 13, textAlign: 'right' } },
-  { label: 'dim colour', style: { fontSize: 13, color: '#95a5a6' } },
+  { label: 'dim colour', style: { fontSize: 13, color: '$textMuted' } },
 ];
 
 // Bidi: Hebrew with an embedded Latin word. The Latin runs LTR inside an RTL

--- a/examples/themes.js
+++ b/examples/themes.js
@@ -13,9 +13,16 @@
 // That is what `background` (the ground) and `surface` (what is raised off
 // it) are now, so the demo's own tokens are gone.
 
+// Each impression names `controls: 'drawn'`: these palettes ARE the point,
+// and on the Cocoa backend — where the widgets default to AppKit's own
+// bezels — a green GitHub button rendered as a native macOS button would be
+// the theme demo demonstrating nothing. The macOS impression is the one
+// exception, upgraded by the panel itself where the backend can oblige.
+
 /** GitHub's Primer: square-ish, roomy, green primary buttons. */
 const github = {
   light: {
+    controls: 'drawn',
     background: '#ffffff',
     surface: '#f6f8fa',
     text: '#1f2328',
@@ -37,6 +44,7 @@ const github = {
     paddingY: 10,
   },
   dark: {
+    controls: 'drawn',
     background: '#0d1117',
     surface: '#21262d',
     text: '#e6edf3',
@@ -70,6 +78,7 @@ const sfMono = '".SF NS Mono", "SF Mono", monospace';
 /** macOS: softer greys, tighter type, the system blue. */
 const macos = {
   light: {
+    controls: 'drawn',
     fontFamily: sfText,
     monoFamily: sfMono,
     background: '#ececec',
@@ -93,6 +102,7 @@ const macos = {
     paddingY: 9,
   },
   dark: {
+    controls: 'drawn',
     fontFamily: sfText,
     monoFamily: sfMono,
     background: '#1e1e1e',
@@ -120,6 +130,7 @@ const macos = {
 /** Windows 11 / Fluent: tighter corners, flatter surfaces. */
 const windows = {
   light: {
+    controls: 'drawn',
     background: '#f3f3f3',
     surface: '#ffffff',
     text: '#1b1b1b',
@@ -141,6 +152,7 @@ const windows = {
     paddingY: 10,
   },
   dark: {
+    controls: 'drawn',
     background: '#202020',
     surface: '#323232',
     text: '#ffffff',

--- a/examples/theming.jsx
+++ b/examples/theming.jsx
@@ -6,7 +6,7 @@
 // the palette it is given, the panel's own styles name it with `$tokens`,
 // and switching theme replaces one object.
 // Run with: npm run examples:theming  (needs an X server / DISPLAY)
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import {
   Button,
   Checkbox,
@@ -20,6 +20,7 @@ import {
   Switch,
   Tabs,
   ThemeProvider,
+  useSupports,
   useSystemAppearance,
 } from '../src/index.js';
 import { THEME_OPTIONS, themeFor } from './themes.js';
@@ -118,7 +119,18 @@ export function ThemingPanel() {
   const [tab, setTab] = useState('one');
   const [presses, setPresses] = useState(0);
 
-  const theme = themeFor(name, mode);
+  // Every demo theme draws its own controls (`controls: 'drawn'` in
+  // themes.js) — except that picking the macOS impression on a backend that
+  // can render the real thing swaps the lookalike for AppKit's own bezels.
+  // `useSupports` is the capability question, so the same file runs on X11
+  // (where the impression stays drawn) without a warning.
+  const nativeControls = useSupports('nativeControls');
+  const theme = useMemo(() => {
+    const base = themeFor(name, mode);
+    return name === 'macos' && nativeControls
+      ? { ...base, controls: 'native' }
+      : base;
+  }, [name, mode, nativeControls]);
 
   return (
     // One provider, both channels: the widgets read it with useTheme() and

--- a/examples/theming.jsx
+++ b/examples/theming.jsx
@@ -102,7 +102,7 @@ function ModeIcon({ mode, color }) {
   );
 }
 
-export function ThemingPanel() {
+export function ThemingPanel({ windowSize }) {
   const [name, setName] = useState('github');
   // **The desktop until the user picks.** `null` means "follow"; the toggle
   // in the header sets an explicit mode and takes over from there. Starting
@@ -158,7 +158,12 @@ export function ThemingPanel() {
         </Button>
         <box style={s.spacerHide} />
         <text style={s.caption}>
-          resize me: the gallery splits in two past 620px
+          {windowSize
+            ? // the measured size first, so it survives the clip when the
+              // bar runs out of room: logical px, the unit the 520/620
+              // thresholds are in
+              `${Math.round(windowSize.width)}×${Math.round(windowSize.height)} — resize me: the gallery splits in two past 620px`
+            : 'resize me: the gallery splits in two past 620px'}
         </text>
       </box>
 
@@ -267,9 +272,18 @@ export function ThemingPanel() {
 }
 
 function App() {
+  // `onResize` reports in logical px — the same unit the `@width` blocks
+  // above compare against — so the caption shows exactly what is measured.
+  const [size, setSize] = useState({ width: 720, height: 480 });
   return (
-    <window title="theming" width={720} height={480} minWidth={360}>
-      <ThemingPanel />
+    <window
+      title="theming"
+      width={720}
+      height={480}
+      minWidth={360}
+      onResize={(ev) => setSize({ width: ev.width, height: ev.height })}
+    >
+      <ThemingPanel windowSize={size} />
     </window>
   );
 }

--- a/examples/widgets.jsx
+++ b/examples/widgets.jsx
@@ -72,7 +72,12 @@ export function WidgetsPanel() {
           `$dangerText` — derived from the fill, so it stays legible if the
           theme moves the red. */}
       <Row label="Status">
+        {/* A control that names its own colours opts out of the platform
+            bezel: a native button ignores style fills, so `native={false}`
+            keeps the danger ramp everywhere (docs/macos.md §Native
+            controls — the per-instance escape hatch). */}
         <Button
+          native={false}
           style={{
             backgroundColor: '$danger',
             borderColor: '$danger',

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "node": ">=20.19"
       },
       "optionalDependencies": {
+        "@windowkit/appkit": "^0.1.0",
         "dbus-native": "^0.15.1"
       },
       "peerDependencies": {
@@ -1509,6 +1510,23 @@
       ],
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@windowkit/appkit": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@windowkit/appkit/-/appkit-0.1.0.tgz",
+      "integrity": "sha512-rJcknQzdqnzf2gXNBjT3WkjFHzlvCkMlu9Cb3hvlFlr1VoN9xqWHVlBTKq4kSVN1cBNMKqAhyIm8yynDO5Dj0w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "node-addon-api": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/acorn": {
@@ -3951,6 +3969,16 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.2.tgz",
+      "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
     },
     "node_modules/node-exports-info": {
       "version": "1.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,8 @@
       },
       "optionalDependencies": {
         "@windowkit/appkit": "^0.1.0",
-        "dbus-native": "^0.15.1"
+        "dbus-native": "^0.15.1",
+        "x11-dri": "^0.7.0"
       },
       "peerDependencies": {
         "@babel/core": "^8.0.0",
@@ -5324,9 +5325,9 @@
       }
     },
     "node_modules/x11-dri": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/x11-dri/-/x11-dri-0.5.0.tgz",
-      "integrity": "sha512-tJ9whTTg3JhCXnyOtTLDAb3X8aKW4HY1TVOV3e759H1YK3xgxGJvMPJtBPT2SvPtNXB5q6tq+B8tpO33YUvyhg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/x11-dri/-/x11-dri-0.7.0.tgz",
+      "integrity": "sha512-YRA62Q+MDMngeeKQ4Nx4N7zBO1xf7w9S1SXri+lJp4reAuusnVh1axy85qlBVFu3ft2KtjvqIMWY8NEaaln4SQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "yoga-layout": "^3.2.1"
   },
   "optionalDependencies": {
+    "@windowkit/appkit": "^0.1.0",
     "dbus-native": "^0.15.1"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "bench:frames": "tsx scripts/bench/frames.js",
     "docs:dev": "npm --prefix website start",
     "docs:build": "npm --prefix website run build",
-    "docs:test": "npm --prefix website test"
+    "docs:test": "npm --prefix website test",
+    "bench:presenters": "node --import tsx scripts/bench/presenters.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
   },
   "optionalDependencies": {
     "@windowkit/appkit": "^0.1.0",
-    "dbus-native": "^0.15.1"
+    "dbus-native": "^0.15.1",
+    "x11-dri": "^0.7.0"
   },
   "peerDependencies": {
     "@babel/core": "^8.0.0",

--- a/scripts/bench/presenters.js
+++ b/scripts/bench/presenters.js
@@ -416,6 +416,32 @@ async function runChild() {
       stats.layersMade += 1;
       return createLayer(...a);
     };
+    // the IOSurface swapchain's present path: a flip plus a damage-sized
+    // catch-up copy — counted into the same columns so the table reads the
+    // same either way (uploads = handoffs, kpx = pixels actually moved)
+    if (native.copySurfaceRegion) {
+      const copy = native.copySurfaceRegion.bind(native);
+      native.copySurfaceRegion = (src, dst, rects) => {
+        const t0 = performance.now();
+        copy(src, dst, rects);
+        stats.uploadMs += performance.now() - t0;
+        if (rects && rects.length) {
+          for (let i = 0; i + 3 < rects.length; i += 4) {
+            stats.uploadPx += rects[i + 2] * rects[i + 3];
+          }
+        } else {
+          const size = sizeOf(src);
+          stats.uploadPx += size.width * size.height;
+        }
+      };
+    }
+    if (native.setLayerContentsIOSurface) {
+      const flip = native.setLayerContentsIOSurface.bind(native);
+      native.setLayerContentsIOSurface = (layer, id) => {
+        stats.uploads += 1;
+        return flip(layer, id);
+      };
+    }
   }
 
   let tick = 0;

--- a/scripts/bench/presenters.js
+++ b/scripts/bench/presenters.js
@@ -191,6 +191,64 @@ const SCENARIOS = {
     },
   },
 
+  /** 24 SVG icons re-tinted every tick — the icon hot path. In layers mode
+   *  each icon is retained CAShapeLayers, so a tint change is setShapeProps
+   *  on the render server's own primitives: zero rasters, zero uploads. The
+   *  surface presenter re-rasters the claim and re-uploads the window. */
+  svg: {
+    tree: (tick) => {
+      const TINT = ['#e8590c', '#1c7ed6', '#2f9e44', '#9c36b5'];
+      const icons = [];
+      for (let i = 0; i < 24; i += 1) {
+        const color = TINT[(i + tick) % TINT.length];
+        icons.push(
+          e(
+            'svg',
+            {
+              key: i,
+              viewBox: '0 0 24 24',
+              style: { width: 72, height: 72 },
+            },
+            e('circle', {
+              cx: 12,
+              cy: 12,
+              r: 9,
+              fill: 'none',
+              stroke: color,
+              strokeWidth: 2.5,
+            }),
+            e('path', {
+              d: 'M12 7 v5 l4 3',
+              stroke: color,
+              strokeWidth: 2.5,
+              fill: 'none',
+              strokeLinecap: 'round',
+            }),
+          ),
+        );
+      }
+      return windowOf(
+        [
+          e(
+            'box',
+            {
+              style: {
+                flexGrow: 1,
+                padding: 20,
+                flexDirection: 'row',
+                flexWrap: 'wrap',
+                gap: 16,
+                alignContent: 'flex-start',
+              },
+            },
+            ...icons,
+          ),
+        ],
+        'bench svg',
+      );
+    },
+  },
+
   /** A wheel notch per tick over 300 rows. The layers presenter's native
    *  scroll should answer with ~2 property sets and no uploads; the
    *  surface presenter blits and re-uploads the window. Also an input

--- a/scripts/bench/presenters.js
+++ b/scripts/bench/presenters.js
@@ -1,0 +1,539 @@
+// Cocoa presenter benchmark: the measure-first gate of docs/macos.md, as a
+// number. One scenario, two presenters, the same ticks — and every frame
+// broken into the stages that can be the bottleneck:
+//
+//   flush     JS building the frame: painters into the surface, or the
+//             layer sync (prop diffing + per-visual rasters). The one paint
+//             channel, so this is "client cost per frame".
+//   upload    surfaceToLayer calls — the CGImage handoff to Core Animation.
+//             The surface presenter pays one per frame at WINDOW size
+//             whatever the damage; the layers presenter pays one per
+//             re-rastered visual at the visual's size. kpx tells that story.
+//   props     setLayerProps calls per frame — the layers presenter's other
+//             half. A pure scroll should be ~2; a recolour wall should be
+//             ~N with zero uploads (PropBox); a number that scales with the
+//             tree on a one-box change is a diffing bug.
+//   input     for the input scenarios: postMouseEvent → the end of the
+//             flush that answered it, through the real NSApp queue and the
+//             pump — the "answer the input" number, p50/p95.
+//
+//   npm run bench:presenters                    # every scenario, both
+//   npm run bench:presenters -- --scenario=cards --seconds=8
+//   npm run bench:presenters -- --x11           # third column via $DISPLAY
+//   npm run bench:presenters -- --shots         # snapshot each run's last
+//                                               # frame for an eyeball diff
+//
+// Scenario design: each isolates one shape of change, because the two
+// presenters differ per shape, not overall — a wall recolour is layer
+// properties on one side and full-window paint on the other, while a text
+// change rasters on both and measures pure raster throughput.
+//
+// Comparisons hold within a run (same machine, same session); absolute
+// numbers travel about as well as any timing does — that is, they don't.
+import { spawnSync } from 'node:child_process';
+import React from 'react';
+
+const e = React.createElement;
+
+const args = process.argv.slice(2);
+const flag = (name, fallback) => {
+  const hit = args.find((a) => a.startsWith(`--${name}=`));
+  return hit ? hit.slice(name.length + 3) : fallback;
+};
+const SECONDS = Number(flag('seconds', 6));
+const ONLY = flag('scenario', null);
+const WITH_X11 = args.includes('--x11');
+const SHOTS = args.includes('--shots');
+const CHILD = args.includes('--child');
+
+const W = 900;
+const H = 700;
+const TICK_MS = 16;
+
+// ---------------------------------------------------------------------------
+// Scenarios. Each is { tree(tick), drive? } — `tree` is rendered per tick
+// (the React-state shape of change), `drive` instead pushes real events and
+// leaves the tree alone (the input shape). `latency: true` marks the ones
+// whose headline number is input→flush rather than fps.
+// ---------------------------------------------------------------------------
+
+const TINTS = ['#ffffff', '#eef4fb', '#fdf1e7', '#eefaf1'];
+
+function windowOf(children, title) {
+  return e(
+    'window',
+    { width: W, height: H, title, style: { backgroundColor: '#e9edf2' } },
+    ...children,
+  );
+}
+
+const SCENARIOS = {
+  /** Paint-only bounded change: one 100px box recolours. The layers
+   *  presenter should answer with one backgroundColor prop and zero
+   *  rasters; the surface presenter with a bounded repaint plus a
+   *  window-sized upload — the upload column is the point. */
+  color: {
+    tree: (tick) =>
+      windowOf(
+        [
+          e('box', {
+            style: {
+              position: 'absolute',
+              left: 340,
+              top: 120,
+              width: 100,
+              height: 100,
+              borderRadius: 8,
+              backgroundColor: tick % 2 ? '#3498db' : '#e74c3c',
+            },
+          }),
+          e(
+            'text',
+            { style: { margin: 16, color: '#7f8c8d' } },
+            'static text to give the frame some weight',
+          ),
+        ],
+        'bench color',
+      ),
+  },
+
+  /** Position-only change: the same box slides. A layout pass claims
+   *  broadly, so this measures how each presenter survives over-claimed
+   *  damage — frames.js measured the same cliff on X11. */
+  move: {
+    tree: (tick) =>
+      windowOf(
+        [
+          e('box', {
+            style: {
+              position: 'absolute',
+              left: Math.round(340 + 300 * Math.sin(tick / 20)),
+              top: 120,
+              width: 100,
+              height: 100,
+              borderRadius: 8,
+              backgroundColor: '#3498db',
+            },
+          }),
+          e(
+            'text',
+            { style: { margin: 16, color: '#7f8c8d' } },
+            'static text to give the frame some weight',
+          ),
+        ],
+        'bench move',
+      ),
+  },
+
+  /** Text relayout + raster: the label changes every tick. Both presenters
+   *  must raster glyphs; the layers presenter rasters one text visual, the
+   *  surface presenter repaints the claim. Raster throughput, mostly. */
+  text: {
+    tree: (tick) =>
+      windowOf(
+        [
+          e(
+            'box',
+            { style: { flexGrow: 1, padding: 16, gap: 12 } },
+            e(
+              'text',
+              { style: { fontSize: 20, color: '#222222' } },
+              `tick ${tick}`,
+            ),
+            e(
+              'text',
+              { style: { color: '#7f8c8d' } },
+              'static text below to give the frame some weight',
+            ),
+          ),
+        ],
+        'bench text',
+      ),
+  },
+
+  /** The wall from issue #219: 48 rounded bordered cards, all recoloured
+   *  every frame. Chrome churn — the layers presenter's best case (N
+   *  property sets, no rasters) against the surface presenter's near-full
+   *  repaint. */
+  cards: {
+    tree: (tick) => {
+      const CARD_W = 130;
+      const CARD_H = 70;
+      const GAP = 12;
+      const PAD = 16;
+      const perRow = Math.max(
+        1,
+        Math.floor((W - 2 * PAD + GAP) / (CARD_W + GAP)),
+      );
+      const cards = [];
+      for (let i = 0; i < 48; i += 1) {
+        cards.push(
+          e('box', {
+            key: i,
+            style: {
+              position: 'absolute',
+              left: PAD + (i % perRow) * (CARD_W + GAP),
+              top: PAD + Math.floor(i / perRow) * (CARD_H + GAP),
+              width: CARD_W,
+              height: CARD_H,
+              backgroundColor: TINTS[(i + tick) % TINTS.length],
+              borderRadius: 8,
+              borderWidth: 1,
+              borderColor: '#c3ccd8',
+            },
+          }),
+        );
+      }
+      return windowOf(
+        [e('box', { style: { flexGrow: 1 } }, ...cards)],
+        'bench cards',
+      );
+    },
+  },
+
+  /** A wheel notch per tick over 300 rows. The layers presenter's native
+   *  scroll should answer with ~2 property sets and no uploads; the
+   *  surface presenter blits and re-uploads the window. Also an input
+   *  scenario: the notch goes through the window's event path. */
+  scroll: {
+    latency: true,
+    tree: () =>
+      windowOf(
+        [
+          e(
+            'box',
+            { style: { flexGrow: 1, overflow: 'scroll' } },
+            ...Array.from({ length: 300 }, (_, i) =>
+              e(
+                'box',
+                {
+                  key: i,
+                  style: {
+                    height: 28,
+                    paddingLeft: 16,
+                    flexDirection: 'row',
+                    alignItems: 'center',
+                    backgroundColor: i % 2 ? '#f6f8fb' : '#ffffff',
+                  },
+                },
+                e(
+                  'text',
+                  { style: { color: '#444444' } },
+                  `row ${i} — some list content`,
+                ),
+              ),
+            ),
+          ),
+        ],
+        'bench scroll',
+      ),
+    drive(ctx) {
+      const { wnd, node, stamp } = ctx;
+      const scroller = ctx.find((n) => n.isScroller?.());
+      if (!scroller) return;
+      const x = scroller.abs.x + scroller.abs.width / 2;
+      const y = scroller.abs.y + scroller.abs.height / 2;
+      const down = ctx.tick % 120 < 60; // sweep down, then back up
+      stamp();
+      wnd.emit('wheel', {
+        name: 'wheel',
+        x,
+        y,
+        rootx: 0,
+        rooty: 0,
+        buttons: 0,
+        deltaX: 0,
+        deltaY: down ? 3 : -3,
+        deltaMode: 'line',
+        smooth: false,
+        source: 'button',
+      });
+      void node;
+    },
+  },
+
+  /** Pointer wiggle over a hover-styled grid, through the REAL NSApp event
+   *  queue (postMouseEvent): input→flush is the headline. The hover flip
+   *  is one node's style state — the smallest interactive change there is,
+   *  so this is the floor of perceived latency. */
+  hover: {
+    latency: true,
+    input: 'native',
+    tree: () =>
+      windowOf(
+        [
+          e(
+            'box',
+            {
+              style: {
+                flexGrow: 1,
+                padding: 24,
+                flexDirection: 'row',
+                flexWrap: 'wrap',
+                gap: 16,
+                alignContent: 'flex-start',
+              },
+            },
+            ...Array.from({ length: 24 }, (_, i) =>
+              e('box', {
+                key: i,
+                style: {
+                  width: 120,
+                  height: 56,
+                  borderRadius: 8,
+                  backgroundColor: '#ffffff',
+                  borderWidth: 1,
+                  borderColor: '#c3ccd8',
+                  ':hover': { backgroundColor: '#dbe7f4' },
+                },
+              }),
+            ),
+          ),
+        ],
+        'bench hover',
+      ),
+    drive(ctx) {
+      // alternate between two card centres, in points
+      const cards = ctx.findAll((n) => n.style?.[':hover'] !== undefined);
+      const a = cards[0];
+      const b = cards[7] ?? cards[cards.length - 1];
+      const target = ctx.tick % 2 ? a : b;
+      if (!target) return;
+      const s = ctx.wnd.scale;
+      ctx.stamp();
+      ctx.native.postMouseEvent(
+        ctx.wnd._h,
+        'move',
+        (target.abs.x + target.abs.width / 2) / s,
+        (target.abs.y + target.abs.height / 2) / s,
+      );
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Child: run one (scenario, presenter/backend) and print a JSON line.
+// ---------------------------------------------------------------------------
+
+async function runChild() {
+  const name = flag('run', 'color');
+  const scenario = SCENARIOS[name];
+  process.env.REACT_X11_NO_AUTORUN = '1';
+  const { createRoot } = await import('../../src/index.js');
+  const root = await createRoot();
+  const app = root.app;
+  const cocoa = Boolean(app._native);
+
+  // --- instrumentation: wrap the native bridge, count per current frame
+  const stats = {
+    flushes: 0,
+    flushMs: [],
+    uploads: 0,
+    uploadMs: 0,
+    uploadPx: 0,
+    props: 0,
+    layersMade: 0,
+    latency: [],
+  };
+  let inFlight = []; // input stamps waiting for the flush that answers them
+  if (cocoa) {
+    const native = app._native;
+    const surfaceToLayer = native.surfaceToLayer.bind(native);
+    const sizeOf = native.surfaceSize.bind(native);
+    native.surfaceToLayer = (surface, layer) => {
+      const t0 = performance.now();
+      surfaceToLayer(surface, layer);
+      stats.uploadMs += performance.now() - t0;
+      stats.uploads += 1;
+      const size = sizeOf(surface);
+      stats.uploadPx += size.width * size.height;
+    };
+    const setLayerProps = native.setLayerProps.bind(native);
+    native.setLayerProps = (layer, props) => {
+      stats.props += 1;
+      return setLayerProps(layer, props);
+    };
+    const createLayer = native.createLayer.bind(native);
+    native.createLayer = (...a) => {
+      stats.layersMade += 1;
+      return createLayer(...a);
+    };
+  }
+
+  let tick = 0;
+  root.render(scenario.tree(0));
+  await new Promise((r) => setTimeout(r, 700));
+
+  const node = app._rootChildren?.[0] ?? null;
+  const wnd = cocoa ? [...app._windows.values()][0] : null;
+  if (node) {
+    const flush = node.flush.bind(node);
+    node.flush = (...a) => {
+      const t0 = performance.now();
+      const out = flush(...a);
+      const t1 = performance.now();
+      stats.flushes += 1;
+      stats.flushMs.push(t1 - t0);
+      for (const sent of inFlight) stats.latency.push(t1 - sent);
+      inFlight = [];
+      return out;
+    };
+  }
+
+  function* walk(n) {
+    yield n;
+    for (const c of n?.children ?? []) yield* walk(c);
+  }
+  const ctx = {
+    get tick() {
+      return tick;
+    },
+    wnd,
+    node,
+    native: app._native,
+    stamp: () => inFlight.push(performance.now()),
+    find: (pred) => [...walk(node)].find(pred) ?? null,
+    findAll: (pred) => [...walk(node)].filter(pred),
+  };
+
+  // settle counters after mount: steady state is the measurement
+  stats.flushes = 0;
+  stats.flushMs = [];
+  stats.uploads = 0;
+  stats.uploadMs = 0;
+  stats.uploadPx = 0;
+  stats.props = 0;
+  stats.layersMade = 0;
+
+  const t0 = performance.now();
+  const timer = setInterval(() => {
+    tick += 1;
+    if (scenario.drive) scenario.drive(ctx);
+    else root.render(scenario.tree(tick));
+  }, TICK_MS);
+  await new Promise((r) => setTimeout(r, SECONDS * 1000));
+  clearInterval(timer);
+  await new Promise((r) => setTimeout(r, 120));
+  const elapsed = (performance.now() - t0) / 1000;
+
+  if (SHOTS && wnd) {
+    wnd.snapshot(
+      `/tmp/bench-${name}-${process.env.REACT_X11_COCOA_PRESENTER ?? 'surface'}.png`,
+    );
+  }
+
+  const sorted = [...stats.flushMs].sort((a, b) => a - b);
+  const lat = [...stats.latency].sort((a, b) => a - b);
+  const q = (a, p) =>
+    a.length ? a[Math.min(a.length - 1, Math.floor(p * a.length))] : null;
+  const sum = (a) => a.reduce((s, v) => s + v, 0);
+  const out = {
+    frames: stats.flushes,
+    fps: stats.flushes / elapsed,
+    ticks: tick,
+    flushAvg: sorted.length ? sum(sorted) / sorted.length : null,
+    flushP95: q(sorted, 0.95),
+    flushMax: sorted.at(-1) ?? null,
+    clientMsPerSec: (sum(sorted) + stats.uploadMs) / elapsed,
+    uploadsPerFrame: stats.flushes ? stats.uploads / stats.flushes : 0,
+    uploadKpxPerFrame: stats.flushes
+      ? stats.uploadPx / stats.flushes / 1000
+      : 0,
+    uploadMsPerFrame: stats.flushes ? stats.uploadMs / stats.flushes : 0,
+    propsPerFrame: stats.flushes ? stats.props / stats.flushes : 0,
+    layersMade: stats.layersMade,
+    latP50: q(lat, 0.5),
+    latP95: q(lat, 0.95),
+    latMax: lat.at(-1) ?? null,
+    latN: lat.length,
+  };
+  console.log(`RESULT ${JSON.stringify(out)}`);
+  await root.unmount();
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Parent: the matrix, one child process per cell so the presenters never
+// share a session — and a crash in one cell is one dash, not a lost run.
+// ---------------------------------------------------------------------------
+
+function runCell(name, env) {
+  const res = spawnSync(
+    process.execPath,
+    [
+      '--import',
+      'tsx',
+      new URL(import.meta.url).pathname,
+      '--child',
+      `--run=${name}`,
+      `--seconds=${SECONDS}`,
+      ...(SHOTS ? ['--shots'] : []),
+    ],
+    {
+      env: { ...process.env, ...env },
+      encoding: 'utf8',
+      timeout: (SECONDS + 25) * 1000,
+    },
+  );
+  const line = (res.stdout ?? '')
+    .split('\n')
+    .find((l) => l.startsWith('RESULT '));
+  if (!line) {
+    const tail = (res.stderr ?? '').split('\n').filter(Boolean).slice(-3);
+    return { error: tail.join(' | ') || 'no result' };
+  }
+  return JSON.parse(line.slice(7));
+}
+
+const ms = (v) => (v == null ? '    -' : v.toFixed(2).padStart(5));
+const n1 = (v) => (v == null ? '    -' : v.toFixed(1).padStart(5));
+
+if (CHILD) {
+  await runChild();
+} else {
+  const names = ONLY ? [ONLY] : Object.keys(SCENARIOS);
+  const columns = [
+    ['surface', { REACT_X11_COCOA_PRESENTER: 'surface' }],
+    ['layers', { REACT_X11_COCOA_PRESENTER: 'layers' }],
+    ...(WITH_X11 ? [['x11', { REACT_X11_BACKEND: 'x11' }]] : []),
+  ];
+  console.log(
+    `presenter bench — ${W}x${H} window, ${SECONDS}s per cell, tick ${TICK_MS}ms`,
+  );
+  for (const name of names) {
+    if (!SCENARIOS[name]) {
+      console.error(
+        `unknown scenario ${name} — ${Object.keys(SCENARIOS).join(', ')}`,
+      );
+      process.exit(1);
+    }
+    console.log(`\n${name}`);
+    console.log(
+      '            fps   flush avg/p95/max      upload/frame        props  input p50/p95/max',
+    );
+    for (const [label, env] of columns) {
+      const r = runCell(name, env);
+      if (r.error) {
+        console.log(`  ${label.padEnd(9)} FAILED: ${r.error}`);
+        continue;
+      }
+      const upload =
+        r.uploadsPerFrame > 0
+          ? `${r.uploadsPerFrame.toFixed(1)}x ${Math.round(r.uploadKpxPerFrame).toString().padStart(4)}kpx ${ms(r.uploadMsPerFrame)}ms`
+          : '        none      ';
+      const input =
+        r.latN > 0
+          ? `${ms(r.latP50)}/${ms(r.latP95)}/${ms(r.latMax)}`
+          : '        -';
+      console.log(
+        `  ${label.padEnd(9)}${n1(r.fps)}  ${ms(r.flushAvg)}/${ms(r.flushP95)}/${ms(r.flushMax)}ms  ${upload}  ${r.propsPerFrame.toFixed(1).padStart(5)}  ${input}`,
+      );
+    }
+  }
+  console.log(
+    '\nnotes: upload = surfaceToLayer (CGImage handoff), at window size on the' +
+      '\nsurface presenter and per re-rastered visual on layers; props =' +
+      '\nsetLayerProps per frame; input = event sent → end of the flush that' +
+      '\nanswered it, through the pump. Compare within this run only.',
+  );
+}

--- a/scripts/cocoa-drive.mjs
+++ b/scripts/cocoa-drive.mjs
@@ -1,0 +1,32 @@
+// Drive an example on the cocoa backend headlessly-ish: mount it, let the
+// pump run, snapshot every window, exit. For development of the backend —
+// not part of the test suite (that gets a cocoa-mock harness backend).
+//
+//   node --import tsx scripts/cocoa-drive.mjs examples/simple.jsx out.png [ms]
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import React from 'react';
+
+process.env.REACT_X11_NO_AUTORUN = '1';
+
+const [, , exampleFile, outFile = '/tmp/cocoa-drive.png', holdMs = '900'] =
+  process.argv;
+
+const { createRoot } = await import('../src/index.js');
+const mod = await import(pathToFileURL(path.resolve(exampleFile)).href);
+const App = mod.default ?? mod.App;
+
+const root = await createRoot();
+root.render(React.createElement(App));
+
+setTimeout(() => {
+  let i = 0;
+  for (const wnd of root.app._windows.values()) {
+    const file = i === 0 ? outFile : outFile.replace(/\.png$/, `-${i}.png`);
+    console.log('window', wnd.windowNumber, wnd.width, 'x', wnd.height, '->');
+    console.log('  ', file, wnd.snapshot(file));
+    i++;
+  }
+  root.unmount().then(() => process.exit(0));
+}, Number(holdMs));

--- a/scripts/cocoa-interact.mjs
+++ b/scripts/cocoa-interact.mjs
@@ -1,0 +1,154 @@
+// Interactive smoke-drive of examples/chat.jsx on the cocoa backend: every
+// gesture goes through the REAL pump (postMouseEvent/postKeyEvent -> NSApp
+// -> pump2 -> the router -> EventManager), so what this proves is the whole
+// input path, not the tree.
+import React from 'react';
+
+process.env.REACT_X11_NO_AUTORUN = '1';
+
+const { createRoot } = await import('../src/index.js');
+const { loadNative } = await import('../src/cocoa/native.js');
+const { default: App } = await import('../examples/chat.jsx');
+
+const native = loadNative();
+const root = await createRoot();
+root.render(React.createElement(App));
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function windowNodes() {
+  return root.app._rootChildren ?? [];
+}
+
+function* walk(node) {
+  yield node;
+  for (const child of node.children ?? []) yield* walk(child);
+}
+
+function find(pred, from = null) {
+  const roots = from ? [from] : windowNodes();
+  for (const rootNode of roots) {
+    for (const node of walk(rootNode)) if (pred(node)) return node;
+  }
+  return null;
+}
+
+const byLabel = (label) => (n) => n.props?.['aria-label'] === label;
+const byText = (text) => (n) =>
+  n.kind === 'text' && [...(n.children ?? [])].some((c) => c.text === text);
+
+function pointFor(node) {
+  const win = node.root ?? node;
+  const wnd = win.window;
+  const s = wnd.scale;
+  const abs = node.abs;
+  return {
+    wnd,
+    x: (abs.x + abs.width / 2) / s,
+    y: (abs.y + abs.height / 2) / s,
+  };
+}
+
+async function click(node, { hold = 0 } = {}) {
+  const { wnd, x, y } = pointFor(node);
+  native.postMouseEvent(wnd._h, 'move', x, y);
+  await sleep(30);
+  native.postMouseEvent(wnd._h, 'down', x, y);
+  if (hold) await sleep(hold);
+  native.postMouseEvent(wnd._h, 'up', x, y);
+  await sleep(60);
+}
+
+async function typeText(wnd, text) {
+  for (const ch of text) {
+    const keyCode = ch === '\n' ? 36 : 0;
+    const chars = ch === '\n' ? '\r' : ch;
+    native.postKeyEvent(wnd._h, true, keyCode, chars);
+    native.postKeyEvent(wnd._h, false, keyCode, chars);
+    await sleep(12);
+  }
+  await sleep(40);
+}
+
+async function wheel(node, notches) {
+  const { wnd, x, y } = pointFor(node);
+  // no native wheel posting yet: emit at the window layer (device px), the
+  // one stage this script skips
+  wnd.emit('wheel', {
+    name: 'wheel',
+    x: x * wnd.scale,
+    y: y * wnd.scale,
+    rootx: 0,
+    rooty: 0,
+    buttons: 0,
+    deltaX: 0,
+    deltaY: notches,
+    deltaMode: 'line',
+    smooth: false,
+    source: 'button',
+  });
+  await sleep(80);
+}
+
+const shot = (name) => {
+  let i = 0;
+  for (const win of root.app._windows.values()) {
+    const file = `/tmp/chat-${name}${i ? `-${i}` : ''}.png`;
+    win.present();
+    console.log(name, i, win.snapshot(file) ? file : 'FAILED');
+    i++;
+  }
+};
+
+try {
+  await sleep(1200); // history suspense resolves, bots may talk
+
+  // 1. switch channels
+  const x11row = find(byLabel('#x11'));
+  console.log('channel row found:', Boolean(x11row));
+  await click(x11row);
+  await sleep(700); // its history loads
+  shot('1-switched');
+
+  // 2. type into the composer and submit
+  const input = find(byLabel('message #x11'));
+  console.log('composer found:', Boolean(input));
+  await click(input);
+  const mainWnd = pointFor(input).wnd;
+  await typeText(mainWnd, 'hello from the cocoa backend');
+  shot('2-typed');
+  await typeText(mainWnd, '\n');
+  await sleep(120); // optimistic row, still pending
+  shot('3-optimistic');
+  await sleep(700); // fixture latency passes, tick lands
+  shot('4-delivered');
+
+  // 3. scroll the log up and back
+  const log = find((n) => n.props?.['data-testname'] === 'log-#x11');
+  await wheel(log, -3);
+  shot('5-scrolled');
+
+  // 4. open the sidebar menu (a <popup>)
+  const menuButton = find(byText('⋮'));
+  console.log('menu button found:', Boolean(menuButton));
+  await click(menuButton);
+  await sleep(250);
+  shot('6-menu');
+
+  // 5. choose "Join a channel…" -> Dialog (managed popup window)
+  const joinItem = find(byText('Join a channel…'));
+  console.log('join item found:', Boolean(joinItem), joinItem?.root?.isPopup);
+  if (joinItem) {
+    await click(joinItem);
+    await sleep(600);
+    shot('7-dialog');
+    // type a filter into the dialog's autofocused input
+    const dialogWnd = [...root.app._windows.values()].at(-1);
+    await typeText(dialogWnd, 'fonts');
+    await sleep(400);
+    shot('8-filtered');
+  }
+} finally {
+  await root.unmount();
+  process.exit(0);
+}

--- a/scripts/cocoa-interact2.mjs
+++ b/scripts/cocoa-interact2.mjs
@@ -1,0 +1,129 @@
+// Round 2: grab dismissal, Switch toggle, Dialog join, resize.
+import React from 'react';
+
+process.env.REACT_X11_NO_AUTORUN = '1';
+
+const { createRoot } = await import('../src/index.js');
+const { loadNative } = await import('../src/cocoa/native.js');
+const { default: App } = await import('../examples/chat.jsx');
+
+const native = loadNative();
+const root = await createRoot();
+root.render(React.createElement(App));
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function* walk(node) {
+  yield node;
+  for (const child of node.children ?? []) yield* walk(child);
+}
+function find(pred) {
+  for (const rootNode of root.app._rootChildren ?? []) {
+    for (const node of walk(rootNode)) if (pred(node)) return node;
+  }
+  return null;
+}
+const byLabel = (label) => (n) => n.props?.['aria-label'] === label;
+const byText = (text) => (n) =>
+  n.kind === 'text' && [...(n.children ?? [])].some((c) => c.text === text);
+
+function pointFor(node) {
+  const wnd = (node.root ?? node).window;
+  const s = wnd.scale;
+  return {
+    wnd,
+    x: (node.abs.x + node.abs.width / 2) / s,
+    y: (node.abs.y + node.abs.height / 2) / s,
+  };
+}
+async function click(node) {
+  const { wnd, x, y } = pointFor(node);
+  native.postMouseEvent(wnd._h, 'move', x, y);
+  await sleep(25);
+  native.postMouseEvent(wnd._h, 'down', x, y);
+  native.postMouseEvent(wnd._h, 'up', x, y);
+  await sleep(80);
+}
+const windows = () => [...root.app._windows.values()];
+const shot = (name) => {
+  windows().forEach((w, i) => {
+    w.present();
+    console.log(
+      name,
+      i,
+      w.snapshot(`/tmp/chat2-${name}${i ? `-${i}` : ''}.png`),
+    );
+  });
+};
+
+try {
+  await sleep(1000);
+  const mainWnd = windows()[0];
+
+  // 1. open the menu, then click elsewhere in the main window -> the grab
+  // routes the press to the popup as an outside press -> onDismiss closes it
+  await click(find(byText('⋮')));
+  await sleep(200);
+  console.log(
+    'menu open, windows:',
+    windows().length,
+    'grab:',
+    Boolean(root.app._grabWindow),
+  );
+  native.postMouseEvent(mainWnd._h, 'down', 400, 300);
+  native.postMouseEvent(mainWnd._h, 'up', 400, 300);
+  await sleep(250);
+  console.log(
+    'after outside press, windows:',
+    windows().length,
+    'grab:',
+    Boolean(root.app._grabWindow),
+  );
+  shot('1-dismissed');
+
+  // 2. toggle the Switch (transition-driven thumb slide)
+  const flaky = find(byLabel('drop the next send'));
+  console.log('switch found:', Boolean(flaky));
+  await click(flaky);
+  await sleep(80); // mid-transition
+  shot('2-switch-mid');
+  await sleep(300);
+  shot('3-switch-on');
+
+  // 3. join a channel end-to-end through the dialog
+  await click(find(byText('⋮')));
+  await sleep(150);
+  await click(find(byText('Join a channel…')));
+  await sleep(600);
+  const dialogInput = find(byLabel('channel to join'));
+  console.log(
+    'dialog input focused:',
+    dialogInput === dialogInput?.root?.events?.focusManager?.focused,
+  );
+  const wnd2 = windows().at(-1);
+  for (const ch of 'lobsters') {
+    native.postKeyEvent(wnd2._h, true, 0, ch);
+    native.postKeyEvent(wnd2._h, false, 0, ch);
+    await sleep(10);
+  }
+  await sleep(300);
+  await click(find(byText('Join')));
+  await sleep(400);
+  const joined = find(byLabel('#lobsters'));
+  console.log(
+    'joined channel row:',
+    Boolean(joined),
+    'windows now:',
+    windows().length,
+  );
+  shot('4-joined');
+
+  // 4. resize the window (controlled path + delegate echo)
+  native.setWindowFrame(mainWnd._h, null, null, 560, 420);
+  await sleep(300);
+  console.log('after resize wnd:', mainWnd.width, mainWnd.height);
+  shot('5-resized');
+} finally {
+  await root.unmount();
+  process.exit(0);
+}

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -577,7 +577,7 @@ const isNtkApp = (v) =>
  * `'auto'` — the default — is one rule: macOS gets the native Core
  * Animation backend, everything else gets X11 via `$DISPLAY`. (More rungs —
  * Wayland — join this ladder, not a new one; docs/wayland.md.) On a mac
- * without the `node-calayers` bridge installed, auto falls back to X11 so
+ * without the `@windowkit/appkit` bridge installed, auto falls back to X11 so
  * an XQuartz setup keeps working; asking for `'cocoa'` by name means the
  * bridge is required, and its absence is an error that says how to fix it.
  * `REACT_X11_BACKEND` overrides for A/B runs without touching code.
@@ -737,7 +737,7 @@ export async function createRoot(options = {}) {
             if (cocoaAsked) throw err;
             if (process.env.NODE_ENV !== 'production') {
               console.warn(
-                'react-x11: no node-calayers bridge — falling back to the ' +
+                'react-x11: no @windowkit/appkit bridge — falling back to the ' +
                   `X11 backend. (${err.message.split('\n')[0]})`,
               );
             }

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -571,6 +571,36 @@ async function connect(options) {
 const isNtkApp = (v) =>
   Boolean(v) && typeof v.createWindow === 'function' && typeof v.X === 'object';
 
+/**
+ * Which display system a root that opens its own connection talks to.
+ *
+ * `'auto'` — the default — is one rule: macOS gets the native Core
+ * Animation backend, everything else gets X11 via `$DISPLAY`. (More rungs —
+ * Wayland — join this ladder, not a new one; docs/wayland.md.) On a mac
+ * without the `node-calayers` bridge installed, auto falls back to X11 so
+ * an XQuartz setup keeps working; asking for `'cocoa'` by name means the
+ * bridge is required, and its absence is an error that says how to fix it.
+ * `REACT_X11_BACKEND` overrides for A/B runs without touching code.
+ */
+function resolveBackend(options) {
+  const asked = options.backend ?? process.env.REACT_X11_BACKEND ?? 'auto';
+  if (asked === 'x11' || asked === 'cocoa') return asked;
+  if (asked !== 'auto') {
+    throw new Error(
+      `react-x11: unknown backend ${JSON.stringify(asked)} — expected ` +
+        "'x11', 'cocoa' or 'auto'.",
+    );
+  }
+  // Naming an X endpoint is choosing X11: a `display` or a `stream` (the
+  // tests' in-process server, a tunnel) would be silently ignored by any
+  // other backend, and an ignored connection option is worse than either
+  // answer.
+  if (options.display !== undefined || options.stream !== undefined) {
+    return 'x11';
+  }
+  return process.platform === 'darwin' ? 'cocoa' : 'x11';
+}
+
 // What a root that opens its own connection forwards to ntk. `stream` is
 // how you reach a server that is not on the other end of $DISPLAY — an
 // in-process one, a tunnel — and is what the tests connect through.
@@ -652,11 +682,24 @@ export async function createRoot(options = {}) {
   }
   const { app: borrowed, onDisconnect, ...rest } = options;
   const owned = borrowed === undefined;
+  // Which display system this root speaks — resolved before anything runs,
+  // because the desktop-integration default below depends on it. A borrowed
+  // app already IS a backend, so the option only steers owned connections.
+  const backend = owned ? resolveBackend(rest) : null;
   // Before anything starts, for two reasons: a bad `desktop` shape must throw
   // with nothing in flight, like the check above it — and `startA11y()` below
   // reads this policy, so it has to be settled before the first await, not
   // after (src/desktopintegration.js).
-  setDesktopIntegration(rest.desktop);
+  //
+  // The cocoa backend's desktop is not freedesktop's: the AT-SPI bridge and
+  // the D-Bus global menu have nothing to register against there, so they
+  // default off (their macOS replacements are their own workstream —
+  // docs/macos.md). The appearance ladder stays on: its macOS rung is the
+  // one that answers. An explicit `desktop` option still wins.
+  setDesktopIntegration(
+    rest.desktop ??
+      (backend === 'cocoa' ? { a11y: false, globalMenu: false } : undefined),
+  );
   // The connection is started first, and the order is the point rather than a
   // detail. `loadLayout()` is only nominally asynchronous: instantiating the
   // engine blocks the event loop for 15-50 ms before it returns its promise
@@ -669,16 +712,38 @@ export async function createRoot(options = {}) {
   // synchronous block, and only where the handshake takes longer than it. It
   // is not measurable on a Unix socket, and it is lost in the noise on a link
   // slow enough to matter. This is the right order, not a fast one.
-  const connecting = owned
-    ? connect(
-        Object.fromEntries(
-          CONNECT_OPTIONS.filter((k) => rest[k] !== undefined).map((k) => [
-            k,
-            rest[k],
-          ]),
-        ),
-      )
-    : Promise.resolve(borrowed);
+  const connectX11 = () =>
+    connect(
+      Object.fromEntries(
+        CONNECT_OPTIONS.filter((k) => rest[k] !== undefined).map((k) => [
+          k,
+          rest[k],
+        ]),
+      ),
+    );
+  const cocoaAsked =
+    rest.backend === 'cocoa' || process.env.REACT_X11_BACKEND === 'cocoa';
+  const connecting = !owned
+    ? Promise.resolve(borrowed)
+    : backend === 'cocoa'
+      ? import('./cocoa/app.js')
+          .then(({ createCocoaApp }) => createCocoaApp(rest))
+          .catch((err) => {
+            // Asked for by name, the bridge is required and its absence is
+            // the error (it says how to install). Reached by 'auto', a mac
+            // without it falls back to X11 so an XQuartz setup keeps
+            // working — said once, because a silent fallback would look
+            // like the native backend being broken rather than absent.
+            if (cocoaAsked) throw err;
+            if (process.env.NODE_ENV !== 'production') {
+              console.warn(
+                'react-x11: no node-calayers bridge — falling back to the ' +
+                  `X11 backend. (${err.message.split('\n')[0]})`,
+              );
+            }
+            return connectX11();
+          })
+      : connectX11();
   const layout = loadLayout();
   const integrations = loadIntegrations(); // null when there is nothing to install
   const [app] = await Promise.all([connecting, layout, integrations]);

--- a/src/anchor.js
+++ b/src/anchor.js
@@ -28,11 +28,20 @@ import { availableArea } from './screens.js';
 export function screenRect(node) {
   if (!node?.abs) return null;
   const origin = windowOrigin(node);
+  // Logical pixels, like every rect application code touches: this is a
+  // public export, and the rects it is compared against — `anchorRect`'s
+  // result, `anchorArea` — answer in logical too. The device-pixel sum
+  // (origin + abs) divides once, here; a caller that needs the device rect
+  // is placement math and multiplies back by `node.scale` itself. On a 1x
+  // display the two units coincide, which is how a mix survived until the
+  // first 2x backend ran the tooltip arrow into the wrong half of the
+  // bubble.
+  const s = node.scale ?? 1;
   return {
-    x: origin.x + node.abs.x,
-    y: origin.y + node.abs.y,
-    width: node.abs.width,
-    height: node.abs.height,
+    x: (origin.x + node.abs.x) / s,
+    y: (origin.y + node.abs.y) / s,
+    width: node.abs.width / s,
+    height: node.abs.height / s,
   };
 }
 
@@ -136,7 +145,8 @@ export function deviceAnchorArea(node) {
   const app = node?.app;
   if (!app) return null;
   const at = screenRect(node);
-  return availableArea(app, at ? { x: at.x, y: at.y } : null);
+  const s = node.scale ?? 1;
+  return availableArea(app, at ? { x: at.x * s, y: at.y * s } : null);
 }
 
 /**

--- a/src/appcontext.js
+++ b/src/appcontext.js
@@ -57,7 +57,16 @@ export function useApp() {
   return app;
 }
 
-const SUPPORTS_FEATURES = new Set(['transparency', 'shaders']);
+const SUPPORTS_FEATURES = new Set([
+  'transparency',
+  'shaders',
+  'nativeControls',
+]);
+
+// 'nativeControls' is a property of the backend, decided before the first
+// render and never changing after — so its subscription has nothing to
+// deliver and its snapshot is a property test.
+const NEVER_CHANGES = () => () => {};
 
 /**
  * Can this **display** do something, as a value a component can branch on?
@@ -105,6 +114,13 @@ const SUPPORTS_FEATURES = new Set(['transparency', 'shaders']);
  * disagree exactly when the policy did not ask. The capabilities also say
  * *why* this is false; see docs/gl.md.
  *
+ * `'nativeControls'` is true when this backend renders the platform's own
+ * control bezels — today the Cocoa backend, never X11. The widget set
+ * already branches on it through the theme's `controls: 'auto'` policy, so
+ * this hook is for application code composing its own controls that wants
+ * to sit beside native ones. It is a property of the backend and never
+ * changes over the app's life.
+ *
  * Unlike `'transparency'`, which comes and goes with the compositor, this
  * settles once and then holds still: under a policy that could pick direct,
  * `createRoot()` waits for ntk's probe before handing the app back, so the
@@ -127,18 +143,22 @@ export function useSupports(feature) {
   // side of it from disagreeing (see watchDirectGL).
   const subscribe = useCallback(
     (onChange) =>
-      feature === 'shaders'
-        ? watchDirectGL(app, onChange)
-        : watchCompositing(app, onChange),
+      feature === 'nativeControls'
+        ? NEVER_CHANGES()
+        : feature === 'shaders'
+          ? watchDirectGL(app, onChange)
+          : watchCompositing(app, onChange),
     [app, feature],
   );
   // a boolean, so the snapshot is stable for a given state — returning the
   // visual object here would tear on every render
   const snapshot = useCallback(
     () =>
-      feature === 'shaders'
-        ? hasDirectGL(app)
-        : compositingActive(app) && Boolean(argbVisual(app)),
+      feature === 'nativeControls'
+        ? Boolean(app.nativeBezels)
+        : feature === 'shaders'
+          ? hasDirectGL(app)
+          : compositingActive(app) && Boolean(argbVisual(app)),
     [app, feature],
   );
   return useSyncExternalStore(subscribe, snapshot, snapshot);

--- a/src/cocoa/app.js
+++ b/src/cocoa/app.js
@@ -40,6 +40,13 @@ class CocoaApp {
     this.scale = screens[0]?.scale ?? 1;
     this._screens = screens;
 
+    // 'surface' (the measured default) or 'layers' — the retained CALayer
+    // presenter, opt-in while docs/macos.md's measure-first gate is open.
+    this._presenterMode =
+      options.cocoa?.presenter ??
+      process.env.REACT_X11_COCOA_PRESENTER ??
+      'surface';
+
     this.fonts = new CocoaFontManager();
 
     // The X stub: just enough for the modules that carry an X escape hatch

--- a/src/cocoa/app.js
+++ b/src/cocoa/app.js
@@ -1,0 +1,398 @@
+// The Cocoa application object — what `createRoot({ backend: 'cocoa' })`
+// hands the renderer instead of an ntk connection. It answers the same
+// contract the headless mock proves closed (src/testing/mock-app.js):
+// createWindow / fonts / clipboard / X-stub / close, plus the event pump
+// that stands in for the X socket.
+//
+// The run loop is deliberately the simple version (docs/macos.md §"Input
+// and the run loop", option 1): Node's loop is master and a timer pumps
+// AppKit. Input latency is the pump cadence; AppKit's internal modal loops
+// (live resize, menu tracking) stall JS timers — but not the delegate
+// callbacks, which is why live resize still relayouts: the resize event
+// flushes the frame synchronously on its way through (`flushPendingFrames`,
+// the same early-flush a click gets). The CFRunLoop drain (option 2) is the
+// measured upgrade, not the first version.
+import { cssColorStraight } from 'ntk';
+
+import { flushPendingFrames } from '../frames.js';
+import { setCompositingForTests } from '../compositing.js';
+import { setScreensForTests } from '../screens.js';
+import { setScaleForTests } from '../scale.js';
+import { CocoaFontManager } from './fonts.js';
+import { CocoaWindow } from './window.js';
+import { decodeKey, modifierMask } from './keymap.js';
+import { loadNative } from './native.js';
+
+const RAF_INTERVAL_MS = 16;
+
+class CocoaApp {
+  constructor(native, options = {}) {
+    this._native = native;
+    this.options = options;
+    this._windows = new Map(); // windowNumber -> CocoaWindow
+    this._grabWindow = null;
+    this._rafQueue = [];
+    this._rafLast = 0;
+    this._pump = null;
+    this._closed = false;
+
+    const screens = native.listScreens();
+    this.scale = screens[0]?.scale ?? 1;
+    this._screens = screens;
+
+    this.fonts = new CocoaFontManager();
+
+    // The X stub: just enough for the modules that carry an X escape hatch
+    // to no-op the way they do against the headless mock.
+    const listeners = {};
+    this.X = {
+      display: { screen: [{ root: 1 }] },
+      keycode2keysyms: {},
+      InternAtom: (onlyIfExists, name, cb) => {
+        if (!this._atoms.has(name)) {
+          this._atoms.set(name, 1000 + this._atoms.size);
+        }
+        cb(null, this._atoms.get(name));
+      },
+      ConfigureWindow() {},
+      SendClientMessage() {},
+      on(event, fn) {
+        (listeners[event] ??= []).push(fn);
+      },
+      emit(event, ...args) {
+        for (const fn of listeners[event] ?? []) fn(...args);
+      },
+    };
+    this._atoms = new Map();
+
+    this.clipboard = {
+      write: (data) => {
+        const text =
+          typeof data === 'string'
+            ? data
+            : (data?.UTF8_STRING ?? data?.STRING ?? '');
+        native.pasteboardWriteText(String(text));
+        return Promise.resolve();
+      },
+      clear: () => {
+        native.pasteboardClear();
+        return Promise.resolve();
+      },
+      targets: () => {
+        const text = native.pasteboardReadText();
+        return Promise.resolve(text == null ? [] : ['UTF8_STRING', 'STRING']);
+      },
+      read: ({ target } = {}) => {
+        const text = native.pasteboardReadText();
+        if (text == null) {
+          return Promise.reject(
+            new Error('clipboard: nothing to paste — the pasteboard is empty'),
+          );
+        }
+        if (target === undefined) return Promise.resolve(text);
+        if (target === 'UTF8_STRING' || target === 'STRING') {
+          return Promise.resolve(Buffer.from(text, 'utf8'));
+        }
+        return Promise.reject(
+          new Error(`clipboard: cannot convert the pasteboard to ${target}`),
+        );
+      },
+      watch: () => Promise.resolve(() => {}),
+    };
+  }
+
+  _parseColor(value) {
+    return typeof value === 'string' ? cssColorStraight(value) : null;
+  }
+
+  findArgbVisual() {
+    // every Cocoa window composites; the "visual" is a formality
+    return { visual: 1, depth: 32 };
+  }
+
+  createWindow(attributes = {}) {
+    if (attributes.parent) {
+      throw new Error(
+        'react-x11: nested <window> elements are not supported on the ' +
+          'cocoa backend yet — track docs/macos.md.',
+      );
+    }
+    return new CocoaWindow(this, attributes);
+  }
+
+  _registerWindow(wnd) {
+    this._windows.set(wnd.windowNumber, wnd);
+  }
+
+  _unregisterWindow(wnd) {
+    this._windows.delete(wnd.windowNumber);
+    if (this._grabWindow === wnd) this._grabWindow = null;
+  }
+
+  // --- the pump ------------------------------------------------------------
+
+  start({ pumpInterval = 8 } = {}) {
+    if (this._pump) return;
+    const native = this._native;
+    native.initApp();
+    native.setBackendEventCallback((ev) => this._route(ev));
+    this._pump = setInterval(() => {
+      native.pump2();
+      this._tickFrames();
+      this._presentAll();
+    }, pumpInterval);
+  }
+
+  _requestFrame(cb) {
+    this._rafQueue.push(cb);
+    return this._rafQueue.length;
+  }
+
+  _tickFrames() {
+    if (!this._rafQueue.length) return;
+    const now = Date.now();
+    if (now - this._rafLast < RAF_INTERVAL_MS) return;
+    this._rafLast = now;
+    const queue = this._rafQueue;
+    this._rafQueue = [];
+    for (const cb of queue) {
+      try {
+        cb(now);
+      } catch (err) {
+        queueMicrotask(() => {
+          throw err;
+        });
+      }
+    }
+  }
+
+  _presentAll() {
+    for (const wnd of this._windows.values()) wnd.present();
+  }
+
+  /** After any synchronously dispatched input: paint the response now (the
+   * same early flush a discrete event gets on X11) and put it on glass. */
+  _afterInput() {
+    flushPendingFrames();
+    this._presentAll();
+  }
+
+  // --- event routing -------------------------------------------------------
+
+  _route(ev) {
+    if (this._closed) return;
+    switch (ev.type) {
+      case 'mousedown':
+      case 'mouseup':
+        return this._routeButton(ev);
+      case 'mousemove':
+        return this._routeMotion(ev, 'mousemove');
+      case 'mouseleave':
+        return this._routeMotion(ev, 'mouseout');
+      case 'mouseenter':
+        return this._routeMotion(ev, 'mousemove');
+      case 'wheel':
+        return this._routeWheel(ev);
+      case 'keydown':
+      case 'keyup':
+        return this._routeKey(ev);
+      case 'window-resize':
+      case 'window-move':
+        return this._routeGeometry(ev);
+      case 'window-close-request':
+        return this._routeClose(ev);
+      case 'window-focus':
+        return this._routeFocus(ev, 'focus');
+      case 'window-blur':
+        return this._routeFocus(ev, 'blur');
+      default:
+        return undefined;
+    }
+  }
+
+  _window(ev) {
+    return ev.windowNumber != null
+      ? (this._windows.get(ev.windowNumber) ?? null)
+      : null;
+  }
+
+  /**
+   * The grab rule, X-shaped: while a popup holds the "pointer grab", a press
+   * in any other window of ours is delivered to the grab holder in the grab
+   * holder's coordinates — landing outside its bounds, which is what its
+   * event manager reads as a dismissal (events.js `_pressOutside`).
+   */
+  _grabTarget(ev, wnd) {
+    const grab = this._grabWindow;
+    if (!grab || grab.destroyed || grab === wnd) return null;
+    const s = this.scale;
+    return {
+      wnd: grab,
+      x: Math.round(ev.gx * s) - grab._screenOrigin.x,
+      y: Math.round(ev.gy * s) - grab._screenOrigin.y,
+    };
+  }
+
+  _routeButton(ev) {
+    const wnd = this._window(ev);
+    if (!wnd) return;
+    const s = this.scale;
+    const buttons = modifierMask(ev);
+    const redirect = ev.type === 'mousedown' ? this._grabTarget(ev, wnd) : null;
+    const target = redirect?.wnd ?? wnd;
+    target.emit(ev.type, {
+      x: redirect ? redirect.x : Math.round(ev.x * s),
+      y: redirect ? redirect.y : Math.round(ev.y * s),
+      rootx: Math.round(ev.gx * s),
+      rooty: Math.round(ev.gy * s),
+      keycode: ev.button,
+      buttons,
+      time: ev.time,
+    });
+    this._afterInput();
+  }
+
+  _routeMotion(ev, name) {
+    const wnd = this._window(ev);
+    if (!wnd) return;
+    const s = this.scale;
+    wnd.emit(name, {
+      x: Math.round(ev.x * s),
+      y: Math.round(ev.y * s),
+      rootx: Math.round(ev.gx * s),
+      rooty: Math.round(ev.gy * s),
+      buttons: modifierMask(ev),
+      time: ev.time,
+    });
+    // motion is paced on the frame clock, not flushed per event
+  }
+
+  _routeWheel(ev) {
+    const wnd = this._window(ev);
+    if (!wnd) return;
+    const s = this.scale;
+    // AppKit: positive deltas scroll toward the top (natural direction
+    // already folded in); the renderer's notches are the X convention,
+    // positive = content advancing downward. Precise deltas are points —
+    // 48 device pixels is one notch, so a swipe maps 1:1 onto pixels.
+    const toNotches = (delta) =>
+      ev.precise
+        ? (-delta * s) / 48
+        : -Math.sign(delta) * Math.ceil(Math.abs(delta));
+    const deltaX = toNotches(ev.dx);
+    const deltaY = toNotches(ev.dy);
+    if (!deltaX && !deltaY) return;
+    wnd.emit('wheel', {
+      name: 'wheel',
+      x: Math.round(ev.x * s),
+      y: Math.round(ev.y * s),
+      rootx: Math.round(ev.gx * s),
+      rooty: Math.round(ev.gy * s),
+      buttons: modifierMask(ev),
+      deltaX,
+      deltaY,
+      deltaMode: 'line',
+      smooth: Boolean(ev.precise),
+      source: ev.precise ? 'valuator' : 'button',
+    });
+  }
+
+  _routeKey(ev) {
+    // keys go to the key window; without one (all popups) the last focused
+    // toplevel keeps the keyboard, which matches the focus model upstairs
+    const wnd = this._window(ev) ?? this._lastKeyWindow;
+    if (!wnd) return;
+    const decoded = decodeKey(ev);
+    wnd.emit(ev.type, {
+      keycode: ev.keyCode,
+      keysym: decoded.keysym,
+      baseKeysym: decoded.baseKeysym,
+      codepoint: decoded.codepoint,
+      buttons: modifierMask(ev),
+      group: 0,
+      time: ev.time,
+    });
+    this._afterInput();
+  }
+
+  _routeGeometry(ev) {
+    const wnd = this._window(ev);
+    if (!wnd || wnd.destroyed) return;
+    wnd._nativeResized(ev);
+    wnd.emit('resize', {
+      width: wnd.width,
+      height: wnd.height,
+      x: wnd.x,
+      y: wnd.y,
+      moved: true,
+      resized: ev.type === 'window-resize',
+    });
+    // During a live resize AppKit's modal loop owns the thread and Node
+    // timers stall; flushing here is what keeps layout tracking the drag.
+    this._afterInput();
+  }
+
+  _routeClose(ev) {
+    const wnd = this._window(ev);
+    if (!wnd) return;
+    wnd.emit('close', {
+      preventDefault() {},
+    });
+    this._afterInput();
+  }
+
+  _routeFocus(ev, name) {
+    const wnd = this._window(ev);
+    if (!wnd) return;
+    if (name === 'focus') this._lastKeyWindow = wnd;
+    wnd.emit(name, { buttons: 0, time: ev.time });
+    this._afterInput();
+  }
+
+  // --- teardown ------------------------------------------------------------
+
+  close() {
+    if (this._closed) return Promise.resolve();
+    this._closed = true;
+    if (this._pump) clearInterval(this._pump);
+    this._pump = null;
+    this._native.setBackendEventCallback(null);
+    for (const wnd of [...this._windows.values()]) wnd.destroy();
+    return Promise.resolve();
+  }
+}
+
+/**
+ * Build the app and seed the platform stores the way the mock seeds them —
+ * `beginScale`/`beginScreens`/`beginCompositing` find a session already
+ * open and leave it alone, so `createRoot`'s shared flow runs unchanged.
+ */
+export async function createCocoaApp(options = {}) {
+  const native = loadNative();
+  const app = new CocoaApp(native, options);
+
+  setScaleForTests(app, app.scale, 'cocoa');
+  const s = app.scale;
+  const monitors = app._screens.map((screen) => ({
+    x: Math.round(screen.x * s),
+    y: Math.round(screen.y * s),
+    width: Math.round(screen.width * s),
+    height: Math.round(screen.height * s),
+  }));
+  const primary = app._screens[0];
+  setScreensForTests(app, {
+    monitors,
+    workArea: primary
+      ? {
+          x: Math.round(primary.visible.x * s),
+          y: Math.round(primary.visible.y * s),
+          width: Math.round(primary.visible.width * s),
+          height: Math.round(primary.visible.height * s),
+        }
+      : null,
+  });
+  setCompositingForTests(app, true);
+
+  app.start(options.cocoa ?? {});
+  return app;
+}

--- a/src/cocoa/app.js
+++ b/src/cocoa/app.js
@@ -19,6 +19,7 @@ import { setCompositingForTests } from '../compositing.js';
 import { setScreensForTests } from '../screens.js';
 import { setScaleForTests } from '../scale.js';
 import { BezelStore } from './bezels.js';
+import { CocoaGLArea, cocoaGLConfig, resolveCocoaGLRuntime } from './glarea.js';
 import { CocoaFontManager } from './fonts.js';
 import { CocoaWindow } from './window.js';
 import { decodeKey, modifierMask } from './keymap.js';
@@ -57,6 +58,13 @@ class CocoaApp {
     // (X11, the headless mock) draws the themed controls with no further
     // branching.
     this.nativeBezels = new BezelStore(native);
+
+    // The GL policy, glbackend.js's shape. No GLX exists here, so the
+    // default is 'auto' (the direct backend where the runtime loads);
+    // useSupports('shaders') stays false until the first <glarea> resolves
+    // the runtime and settles _glCapsResolved.
+    this.glPolicy = { mode: options.glPolicy ?? 'auto' };
+    this._cocoaGL = null;
 
     // The X stub: just enough for the modules that carry an X escape hatch
     // to no-op the way they do against the headless mock.
@@ -128,12 +136,41 @@ class CocoaApp {
 
   createWindow(attributes = {}) {
     if (attributes.parent) {
+      // A parented "window" here is a GL child surface — GlAreaNode's
+      // contract, the one child-window consumer this backend has. It is a
+      // sublayer, not an NSWindow; nested <window> elements proper are
+      // still not supported.
+      if (attributes.parent instanceof CocoaWindow) {
+        return new CocoaGLArea(this, attributes);
+      }
       throw new Error(
         'react-x11: nested <window> elements are not supported on the ' +
           'cocoa backend yet — track docs/macos.md.',
       );
     }
     return new CocoaWindow(this, attributes);
+  }
+
+  /**
+   * The `<glarea>` config seam (src/glnodes.js): resolve the GL runtime and
+   * answer which rung of the API ladder this area draws through. See
+   * src/cocoa/glarea.js for the ladder.
+   */
+  chooseGLConfig(spec) {
+    return cocoaGLConfig(this, spec);
+  }
+
+  /**
+   * What the machine can do, `useSupports('shaders')`'s slow half: ntk
+   * settles this during its connect handshake, and here it settles on the
+   * first ask — watchDirectGL calls it exactly when a component subscribes
+   * before any <glarea> forced the probe (src/glbackend.js).
+   */
+  glCapabilities() {
+    return resolveCocoaGLRuntime(this).then(
+      () => this._glCapsResolved,
+      () => this._glCapsResolved,
+    );
   }
 
   _registerWindow(wnd) {
@@ -386,6 +423,8 @@ class CocoaApp {
     this._closed = true;
     if (this._pump) clearInterval(this._pump);
     this._pump = null;
+    this._cocoaGL?.destroy();
+    this._cocoaGL = null;
     this._native.setBackendEventCallback(null);
     for (const wnd of [...this._windows.values()]) wnd.destroy();
     return Promise.resolve();

--- a/src/cocoa/app.js
+++ b/src/cocoa/app.js
@@ -33,6 +33,7 @@ class CocoaApp {
     this._grabWindow = null;
     this._rafQueue = [];
     this._rafLast = 0;
+    this._shadowStale = new Set();
     this._pump = null;
     this._closed = false;
 
@@ -144,7 +145,13 @@ class CocoaApp {
     native.initApp();
     native.setBackendEventCallback((ev) => this._route(ev));
     this._pump = setInterval(() => {
-      native.pump2();
+      native.pump2(); // flushes the previous tick's CATransaction
+      if (this._shadowStale.size) {
+        for (const wnd of this._shadowStale) {
+          if (!wnd.destroyed) native.invalidateWindowShadow(wnd._h);
+        }
+        this._shadowStale.clear();
+      }
       this._tickFrames();
       this._presentAll();
     }, pumpInterval);
@@ -337,6 +344,14 @@ class CocoaApp {
     // During a live resize AppKit's modal loop owns the thread and Node
     // timers stall; flushing here is what keeps layout tracking the drag.
     this._afterInput();
+    // The React HALF of the response — an anchored popup following the
+    // window, an onResize setState — commits on a microtask AFTER this
+    // handler returns, and the pump that would paint it is the thing the
+    // modal loop stalled. A second flush queued BEHIND that commit is what
+    // lets an open menu resize with the drag instead of on release.
+    queueMicrotask(() => {
+      if (!this._closed) this._afterInput();
+    });
   }
 
   _routeClose(ev) {

--- a/src/cocoa/app.js
+++ b/src/cocoa/app.js
@@ -20,6 +20,7 @@ import { setScreensForTests } from '../screens.js';
 import { setScaleForTests } from '../scale.js';
 import { BezelStore } from './bezels.js';
 import { CocoaGLArea, cocoaGLConfig, resolveCocoaGLRuntime } from './glarea.js';
+import { CocoaGlobalMenuExport } from './globalmenu.js';
 import { CocoaFontManager } from './fonts.js';
 import { CocoaWindow } from './window.js';
 import { decodeKey, modifierMask } from './keymap.js';
@@ -65,6 +66,12 @@ class CocoaApp {
     // the runtime and settles _glCapsResolved.
     this.glPolicy = { mode: options.glPolicy ?? 'auto' };
     this._cocoaGL = null;
+
+    // the global-menu exports, newest active: the macOS menu bar is one per
+    // app, so the most recent MenuBar owns it (per-focused-window switching
+    // is the follow-up — docs/macos.md §Menus)
+    this._globalMenus = [];
+    this._activeGlobalMenu = null;
 
     // The X stub: just enough for the modules that carry an X escape hatch
     // to no-op the way they do against the headless mock.
@@ -158,6 +165,28 @@ class CocoaApp {
    */
   chooseGLConfig(spec) {
     return cocoaGLConfig(this, spec);
+  }
+
+  /**
+   * The `useGlobalMenu` transport seam: same owner shape as the D-Bus
+   * GlobalMenuExport (start/stop/update), pointed at the macOS menu bar.
+   */
+  createGlobalMenuExport(options) {
+    return new CocoaGlobalMenuExport(this, options);
+  }
+
+  _registerGlobalMenu(exporter) {
+    this._globalMenus.push(exporter);
+    this._activeGlobalMenu = exporter;
+  }
+
+  _unregisterGlobalMenu(exporter) {
+    this._globalMenus = this._globalMenus.filter((e) => e !== exporter);
+    if (this._activeGlobalMenu === exporter) {
+      this._activeGlobalMenu = this._globalMenus.at(-1) ?? null;
+      if (this._activeGlobalMenu) this._activeGlobalMenu._install();
+      else this._native.setMainMenu([{ title: 'App', items: [] }]);
+    }
   }
 
   /**
@@ -264,6 +293,9 @@ class CocoaApp {
         return this._routeFocus(ev, 'focus');
       case 'window-blur':
         return this._routeFocus(ev, 'blur');
+      case 'menu-activate':
+        this._activeGlobalMenu?.activate(ev.id);
+        return this._afterInput();
       default:
         return undefined;
     }

--- a/src/cocoa/app.js
+++ b/src/cocoa/app.js
@@ -21,6 +21,8 @@ import { setScaleForTests } from '../scale.js';
 import { BezelStore } from './bezels.js';
 import { CocoaGLArea, cocoaGLConfig, resolveCocoaGLRuntime } from './glarea.js';
 import { CocoaGlobalMenuExport } from './globalmenu.js';
+import { CocoaPaneHost } from './panehost.js';
+import { CocoaPaneWindow } from './panewindow.js';
 import { CocoaFontManager } from './fonts.js';
 import { CocoaWindow } from './window.js';
 import { decodeKey, modifierMask } from './keymap.js';
@@ -72,6 +74,11 @@ class CocoaApp {
     // is the follow-up — docs/macos.md §Menus)
     this._globalMenus = [];
     this._activeGlobalMenu = null;
+
+    // Frame-pane mode: this process renders a pane whose pixels a host
+    // composites (REACT_X11_FRAME is what the Frame host sets on the fork).
+    this._paneMode = options.pane ?? process.env.REACT_X11_FRAME === '1';
+    this._paneSend = null;
 
     // The X stub: just enough for the modules that carry an X escape hatch
     // to no-op the way they do against the headless mock.
@@ -142,6 +149,12 @@ class CocoaApp {
   }
 
   createWindow(attributes = {}) {
+    // A frame pane's window: no NSWindow at all — the pane paints into
+    // shared IOSurfaces and the HOST composites them (src/cocoa/
+    // panewindow.js). Chosen by the same prop the X11 pane uses.
+    if (this._paneMode && attributes.embeddable) {
+      return new CocoaPaneWindow(this, attributes);
+    }
     if (attributes.parent) {
       // A parented "window" here is a GL child surface — GlAreaNode's
       // contract, the one child-window consumer this backend has. It is a
@@ -165,6 +178,15 @@ class CocoaApp {
    */
   chooseGLConfig(spec) {
     return cocoaGLConfig(this, spec);
+  }
+
+  /**
+   * The Frame host seam (src/frame/index.js): a pane's composited region
+   * in this window. Its presence is what routes <Frame> to the shared-
+   * memory pane path instead of the X foreign-window embed.
+   */
+  createPaneHost(wnd) {
+    return new CocoaPaneHost(this, wnd);
   }
 
   /**
@@ -206,6 +228,33 @@ class CocoaApp {
     this._windows.set(wnd.windowNumber, wnd);
   }
 
+  /**
+   * The pane's end of the frame channel (childmain hands it over,
+   * feature-detected so the X11 pane path never notices): geometry and
+   * input come in, pane-present goes out.
+   */
+  attachPaneChannel(channel) {
+    if (!this._paneMode) return;
+    this._paneSend = (msg) => {
+      try {
+        channel.send(msg);
+      } catch {
+        // the host is going away; its shutdown owns the rest
+      }
+    };
+    channel.onMessage((msg) => {
+      const wnd = [...this._windows.values()][0];
+      if (!wnd) return;
+      if (msg?.type === 'pane-rect') {
+        wnd.setPaneSize(msg.width, msg.height, msg.scale);
+        this._afterInput();
+      } else if (msg?.type === 'pane-event') {
+        wnd.emit(msg.name, msg.ev);
+        this._afterInput();
+      }
+    });
+  }
+
   _unregisterWindow(wnd) {
     this._windows.delete(wnd.windowNumber);
     if (this._grabWindow === wnd) this._grabWindow = null;
@@ -216,6 +265,15 @@ class CocoaApp {
   start({ pumpInterval = 8 } = {}) {
     if (this._pump) return;
     const native = this._native;
+    // A pane process has no NSApplication to pump — no windows, no events,
+    // no dock presence. Its loop is frames and presents only.
+    if (this._paneMode) {
+      this._pump = setInterval(() => {
+        this._tickFrames();
+        this._presentAll();
+      }, pumpInterval);
+      return;
+    }
     native.initApp();
     native.setBackendEventCallback((ev) => this._route(ev));
     this._pump = setInterval(() => {

--- a/src/cocoa/app.js
+++ b/src/cocoa/app.js
@@ -18,6 +18,7 @@ import { flushPendingFrames } from '../frames.js';
 import { setCompositingForTests } from '../compositing.js';
 import { setScreensForTests } from '../screens.js';
 import { setScaleForTests } from '../scale.js';
+import { BezelStore } from './bezels.js';
 import { CocoaFontManager } from './fonts.js';
 import { CocoaWindow } from './window.js';
 import { decodeKey, modifierMask } from './keymap.js';
@@ -49,6 +50,13 @@ class CocoaApp {
       'surface';
 
     this.fonts = new CocoaFontManager();
+
+    // AppKit-rendered control bezels. Its *presence* is the capability:
+    // `useSupports('nativeControls')` and the widget set's `controls:
+    // 'auto'` policy both test for this property, so a backend without it
+    // (X11, the headless mock) draws the themed controls with no further
+    // branching.
+    this.nativeBezels = new BezelStore(native);
 
     // The X stub: just enough for the modules that carry an X escape hatch
     // to no-op the way they do against the headless mock.

--- a/src/cocoa/bezels.js
+++ b/src/cocoa/bezels.js
@@ -1,0 +1,161 @@
+// Native control bezels — AppKit's own pixels for the core controls, cached
+// as surfaces the ordinary 2d paint path can blit (docs/macos.md §Native
+// controls). The mechanism is offscreen NSCell/NSControl rendering, the
+// WebKit/Gecko form-control technique: interaction, focus and keyboard stay
+// the shared component implementation, and only the *bezel* — the pixels of
+// the well, the track, the button face — is asked of the system.
+//
+// Everything here is measured in points at the native boundary and delivered
+// in device pixels, the same split the rest of the backend keeps.
+//
+// ## The ink box
+//
+// AppKit cells draw inside margins of their own: a push button cell insets
+// its bezel ~6pt each side, a checkbox floats its 16pt well in an 18pt
+// frame. Component layout wants the *visible* control — a well that is 16px
+// is 16px in the row it sits in — so the store scans each (kind, size)'s
+// alpha bounding box once, and every bezel afterwards is rendered into a
+// frame padded back out by those insets and blitted from the ink region.
+// Scanned rather than hard-coded so a macOS release that redraws its
+// controls moves the answer instead of breaking it.
+export class BezelStore {
+  constructor(native) {
+    this._native = native;
+    this._canonical = new Map(); // kind|size|scale → { insets, natural }
+    this._cache = new Map(); // full param key → { surface, sx, sy, sw, sh }
+    this._MAX = 160;
+  }
+
+  /**
+   * The control's natural size in logical px — the size the bezel is
+   * designed at, which layout adopts for the kinds that must not stretch
+   * (checkbox, radio, switch). For the stretchable kinds only `height` is
+   * meaningful: a push button is as wide as its label needs.
+   */
+  natural(kind, controlSize = 'regular') {
+    const c = this._scan(kind, controlSize, 2);
+    return {
+      width: Math.round(c.natural.width),
+      height: Math.round(c.natural.height),
+    };
+  }
+
+  /**
+   * The bezel for one laid-out box: `w`/`h` in device px, blit-ready.
+   * Returns `{ surface, sx, sy, sw, sh }` — draw with the 9-arg
+   * `ctx.drawImage` so the ink region lands exactly on the box.
+   */
+  get(params, w, h, scale) {
+    const controlSize = params.controlSize ?? 'regular';
+    const c = this._scan(params.kind, controlSize, scale);
+    const key = JSON.stringify([
+      params.kind,
+      controlSize,
+      params.state ?? 0,
+      params.pressed ?? false,
+      params.enabled ?? true,
+      params.isDefault ?? false,
+      params.value,
+      params.appearance,
+      w,
+      h,
+      scale,
+    ]);
+    let entry = this._cache.get(key);
+    if (entry) {
+      // Map order is the recency order: re-inserting keeps the hot bezels
+      // at the young end when the cache is over budget.
+      this._cache.delete(key);
+      this._cache.set(key, entry);
+      return entry;
+    }
+    const fw = w / scale + c.insets.left + c.insets.right;
+    const fh = h / scale + c.insets.top + c.insets.bottom;
+    const surface = this._native.createSurface(
+      Math.max(1, Math.round(fw * scale)),
+      Math.max(1, Math.round(fh * scale)),
+      scale,
+    );
+    this._native.drawControlIntoSurface(surface, {
+      ...params,
+      controlSize,
+    });
+    entry = {
+      surface,
+      sx: Math.round(c.insets.left * scale),
+      sy: Math.round(c.insets.top * scale),
+      sw: w,
+      sh: h,
+    };
+    this._cache.set(key, entry);
+    if (this._cache.size > this._MAX) {
+      // eldest first; the surface itself is freed by its External finalizer
+      const oldest = this._cache.keys().next().value;
+      this._cache.delete(oldest);
+    }
+    return entry;
+  }
+
+  /**
+   * One render + alpha scan per (kind, size, scale): where does this cell
+   * actually put ink inside the frame it is given? The frame is the natural
+   * cellSize widened by 24pt so a stretchable bezel's side margins are
+   * visible as margins rather than crowding the ends.
+   */
+  _scan(kind, controlSize, scale) {
+    const key = `${kind}|${controlSize}|${scale}`;
+    let c = this._canonical.get(key);
+    if (c) return c;
+    const m = this._native.measureControl({ kind, controlSize });
+    const fw = m.width + 24;
+    const fh = m.height;
+    const pw = Math.max(1, Math.round(fw * scale));
+    const ph = Math.max(1, Math.round(fh * scale));
+    const surface = this._native.createSurface(pw, ph, scale);
+    this._native.drawControlIntoSurface(surface, {
+      kind,
+      controlSize,
+      // the fullest state, so the scan sees the whole footprint
+      state: 1,
+      value: 0.5,
+      enabled: true,
+      appearance: 'light',
+    });
+    const buf = this._native.ctxGetImageData(surface, 0, 0, pw, ph);
+    let x0 = pw;
+    let y0 = ph;
+    let x1 = -1;
+    let y1 = -1;
+    for (let y = 0; y < ph; y++) {
+      for (let x = 0; x < pw; x++) {
+        if (buf[(y * pw + x) * 4 + 3] > 8) {
+          if (x < x0) x0 = x;
+          if (x > x1) x1 = x;
+          if (y < y0) y0 = y;
+          if (y > y1) y1 = y;
+        }
+      }
+    }
+    if (x1 < 0) {
+      // nothing painted (should not happen) — treat the frame as the ink
+      x0 = 0;
+      y0 = 0;
+      x1 = pw - 1;
+      y1 = ph - 1;
+    }
+    c = {
+      insets: {
+        left: x0 / scale,
+        top: y0 / scale,
+        right: fw - (x1 + 1) / scale,
+        bottom: fh - (y1 + 1) / scale,
+      },
+      natural: {
+        width: (x1 - x0 + 1) / scale,
+        height: (y1 - y0 + 1) / scale,
+      },
+    };
+    this._canonical.set(key, c);
+    return c;
+  }
+}

--- a/src/cocoa/context2d.js
+++ b/src/cocoa/context2d.js
@@ -558,19 +558,47 @@ export class CocoaContext2D {
     this._dirty();
   }
 
-  getImageData(x, y, w, h) {
-    const buf = this._native.ctxGetImageData(
-      this._s(),
-      Math.round(x),
-      Math.round(y),
-      Math.round(w),
-      Math.round(h),
-    );
-    return {
-      data: new Uint8ClampedArray(buf.buffer, buf.byteOffset, buf.length),
-      width: Math.round(w),
-      height: Math.round(h),
+  /**
+   * ntk's contract, not the browser's: with a callback it delivers
+   * `(err, imageData)`; without one it returns a Promise. On X11 the read
+   * is a server round trip, so every consumer in the tree is written
+   * async — the configurator's screen capture, the pixel harness,
+   * scripts/capture.js — and a backend that answered synchronously would
+   * strand their callbacks unfired. The pixels are read at call time (the
+   * surface only changes in the pump, which cannot run before a
+   * microtask), the delivery is a tick later like a resolved promise's.
+   */
+  getImageData(x, y, w, h, cb) {
+    const read = () => {
+      const buf = this._native.ctxGetImageData(
+        this._s(),
+        Math.round(x),
+        Math.round(y),
+        Math.round(w),
+        Math.round(h),
+      );
+      return {
+        data: new Uint8ClampedArray(buf.buffer, buf.byteOffset, buf.length),
+        width: Math.round(w),
+        height: Math.round(h),
+      };
     };
+    let result;
+    let failure;
+    try {
+      result = read();
+    } catch (err) {
+      failure = err;
+    }
+    const promise = failure ? Promise.reject(failure) : Promise.resolve(result);
+    if (typeof cb === 'function') {
+      promise.then(
+        (data) => cb(null, data),
+        (err) => cb(err),
+      );
+      return undefined;
+    }
+    return promise;
   }
 
   // --- text (minimal: enough for <canvas onDraw> users) --------------------

--- a/src/cocoa/context2d.js
+++ b/src/cocoa/context2d.js
@@ -1,4 +1,4 @@
-// A canvas-shaped 2d context over a node-calayers CoreGraphics surface.
+// A canvas-shaped 2d context over a @windowkit/appkit CoreGraphics surface.
 //
 // This is the raster half of the Cocoa backend: on the surface presenter it
 // is the whole drawing path, and on the layer presenter it stays as the
@@ -67,7 +67,7 @@ class LinearGradient {
 
 export class CocoaContext2D {
   /**
-   * @param native the node-calayers module
+   * @param native the @windowkit/appkit module
    * @param surfaceOf () => current surface handle — the owner replaces the
    *   surface on resize, and this context follows it.
    * @param genOf () => surface generation number

--- a/src/cocoa/context2d.js
+++ b/src/cocoa/context2d.js
@@ -1,0 +1,427 @@
+// A canvas-shaped 2d context over a node-calayers CoreGraphics surface.
+//
+// This is the raster half of the Cocoa backend: on the surface presenter it
+// is the whole drawing path, and on the layer presenter it stays as the
+// fallback every painted-code node (<canvas>, <svg>, registered elements)
+// rasters through — docs/macos.md §"Custom drawing on a layer tree".
+//
+// The native surface holds the real graphics state (paths, CTM, clip); this
+// class keeps the JS-visible state (fillStyle strings, gradient objects,
+// dash arrays) and re-syncs it when the backing surface is replaced after a
+// resize — `_gen` is that generation.
+import { cssColorStraight } from 'ntk';
+
+const BLACK = [0, 0, 0, 1];
+
+function parseColor(value) {
+  if (value == null) return BLACK;
+  return cssColorStraight(String(value)) ?? BLACK;
+}
+
+class LinearGradient {
+  constructor(x0, y0, x1, y1) {
+    this._coords = [x0, y0, x1, y1];
+    this._stops = [];
+  }
+
+  addColorStop(offset, color) {
+    const [r, g, b, a] = parseColor(color);
+    this._stops.push(offset, r, g, b, a);
+  }
+}
+
+export class CocoaContext2D {
+  /**
+   * @param native the node-calayers module
+   * @param surfaceOf () => current surface handle — the owner replaces the
+   *   surface on resize, and this context follows it.
+   * @param genOf () => surface generation number
+   */
+  constructor(native, surfaceOf, genOf) {
+    this._native = native;
+    this._surfaceOf = surfaceOf;
+    this._genOf = genOf;
+    this._gen = -1;
+    this._stack = [];
+    this._state = {
+      fillStyle: '#000',
+      strokeStyle: '#000',
+      lineWidth: 1,
+      lineCap: 'butt',
+      lineJoin: 'miter',
+      globalAlpha: 1,
+      dash: [],
+      dashOffset: 0,
+      font: '10px sans-serif',
+    };
+    this._onDirty = null;
+  }
+
+  _s() {
+    const surface = this._surfaceOf();
+    const gen = this._genOf();
+    if (gen !== this._gen) {
+      // fresh surface: push the sticky state back into it
+      this._gen = gen;
+      const n = this._native;
+      const st = this._state;
+      n.ctxSetLineWidth(surface, st.lineWidth);
+      n.ctxSetLineCap(surface, st.lineCap);
+      n.ctxSetLineJoin(surface, st.lineJoin);
+      n.ctxSetGlobalAlpha(surface, st.globalAlpha);
+      n.ctxSetLineDash(surface, st.dash, st.dashOffset);
+      this._stack.length = 0;
+    }
+    return surface;
+  }
+
+  _dirty() {
+    this._onDirty?.();
+  }
+
+  // --- state ---------------------------------------------------------------
+
+  get fillStyle() {
+    return this._state.fillStyle;
+  }
+
+  set fillStyle(value) {
+    this._state.fillStyle = value;
+  }
+
+  get strokeStyle() {
+    return this._state.strokeStyle;
+  }
+
+  set strokeStyle(value) {
+    this._state.strokeStyle = value;
+  }
+
+  get lineWidth() {
+    return this._state.lineWidth;
+  }
+
+  set lineWidth(value) {
+    if (typeof value === 'number' && value > 0) {
+      this._state.lineWidth = value;
+      this._native.ctxSetLineWidth(this._s(), value);
+    }
+  }
+
+  get lineCap() {
+    return this._state.lineCap;
+  }
+
+  set lineCap(value) {
+    this._state.lineCap = value;
+    this._native.ctxSetLineCap(this._s(), String(value));
+  }
+
+  get lineJoin() {
+    return this._state.lineJoin;
+  }
+
+  set lineJoin(value) {
+    this._state.lineJoin = value;
+    this._native.ctxSetLineJoin(this._s(), String(value));
+  }
+
+  get globalAlpha() {
+    return this._state.globalAlpha;
+  }
+
+  set globalAlpha(value) {
+    if (typeof value === 'number' && value >= 0 && value <= 1) {
+      this._state.globalAlpha = value;
+      this._native.ctxSetGlobalAlpha(this._s(), value);
+    }
+  }
+
+  get font() {
+    return this._state.font;
+  }
+
+  set font(value) {
+    this._state.font = String(value);
+  }
+
+  setLineDash(segments) {
+    this._state.dash = Array.isArray(segments) ? segments : [];
+    this._native.ctxSetLineDash(this._s(), this._state.dash, 0);
+  }
+
+  getLineDash() {
+    return [...this._state.dash];
+  }
+
+  save() {
+    this._stack.push({ ...this._state, dash: [...this._state.dash] });
+    this._native.ctxSave(this._s());
+  }
+
+  restore() {
+    const prev = this._stack.pop();
+    if (prev) this._state = prev;
+    this._native.ctxRestore(this._s());
+  }
+
+  translate(x, y) {
+    this._native.ctxTranslate(this._s(), x, y);
+  }
+
+  scale(x, y) {
+    this._native.ctxScale(this._s(), x, y);
+  }
+
+  rotate(angle) {
+    this._native.ctxRotate(this._s(), angle);
+  }
+
+  // --- paths ---------------------------------------------------------------
+
+  beginPath() {
+    this._native.ctxBeginPath(this._s());
+  }
+
+  moveTo(x, y) {
+    this._native.ctxMoveTo(this._s(), x, y);
+  }
+
+  lineTo(x, y) {
+    this._native.ctxLineTo(this._s(), x, y);
+  }
+
+  rect(x, y, w, h) {
+    this._native.ctxRect(this._s(), x, y, w, h);
+  }
+
+  roundRect(x, y, w, h, radii) {
+    let r = radii ?? 0;
+    if (typeof r === 'number') r = [r, r, r, r];
+    else if (r.length === 1) r = [r[0], r[0], r[0], r[0]];
+    else if (r.length === 2) r = [r[0], r[1], r[0], r[1]];
+    else if (r.length === 3) r = [r[0], r[1], r[2], r[1]];
+    const cap = Math.min(Math.abs(w) / 2, Math.abs(h) / 2);
+    const clamp = (v) => Math.max(0, Math.min(Number(v) || 0, cap));
+    this._native.ctxRoundRect(
+      this._s(),
+      x,
+      y,
+      w,
+      h,
+      clamp(r[0]),
+      clamp(r[1]),
+      clamp(r[2]),
+      clamp(r[3]),
+    );
+  }
+
+  arc(x, y, radius, start, end, anticlockwise = false) {
+    this._native.ctxArc(this._s(), x, y, radius, start, end, anticlockwise);
+  }
+
+  ellipse(x, y, rx, ry) {
+    this._native.ctxEllipse(this._s(), x, y, rx, ry);
+  }
+
+  bezierCurveTo(c1x, c1y, c2x, c2y, x, y) {
+    this._native.ctxCurveTo(this._s(), c1x, c1y, c2x, c2y, x, y);
+  }
+
+  quadraticCurveTo(cx, cy, x, y) {
+    this._native.ctxQuadTo(this._s(), cx, cy, x, y);
+  }
+
+  closePath() {
+    this._native.ctxClosePath(this._s());
+  }
+
+  // --- painting ------------------------------------------------------------
+
+  createLinearGradient(x0, y0, x1, y1) {
+    return new LinearGradient(x0, y0, x1, y1);
+  }
+
+  createRadialGradient() {
+    // radial paints flat until someone needs it; the stop list still works
+    return new LinearGradient(0, 0, 0, 0);
+  }
+
+  _applyFill() {
+    const [r, g, b, a] = parseColor(this._state.fillStyle);
+    this._native.ctxSetFillColor(this._s(), r, g, b, a);
+  }
+
+  _applyStroke() {
+    const [r, g, b, a] = parseColor(this._state.strokeStyle);
+    this._native.ctxSetStrokeColor(this._s(), r, g, b, a);
+  }
+
+  fill(rule) {
+    const style = this._state.fillStyle;
+    if (style instanceof LinearGradient) {
+      const [x0, y0, x1, y1] = style._coords;
+      this._native.ctxFillLinearGradient(
+        this._s(),
+        x0,
+        y0,
+        x1,
+        y1,
+        style._stops,
+      );
+    } else {
+      this._applyFill();
+      this._native.ctxFill(this._s(), rule === 'evenodd');
+    }
+    this._dirty();
+  }
+
+  stroke() {
+    this._applyStroke();
+    this._native.ctxStroke(this._s());
+    this._dirty();
+  }
+
+  clip() {
+    this._native.ctxClip(this._s());
+  }
+
+  fillRect(x, y, w, h) {
+    if (!(w > 0) || !(h > 0)) return;
+    const style = this._state.fillStyle;
+    if (style instanceof LinearGradient) {
+      const [x0, y0, x1, y1] = style._coords;
+      this._native.ctxFillLinearGradient(
+        this._s(),
+        x0,
+        y0,
+        x1,
+        y1,
+        style._stops,
+        x,
+        y,
+        w,
+        h,
+      );
+    } else {
+      this._applyFill();
+      this._native.ctxFillRect(this._s(), x, y, w, h);
+    }
+    this._dirty();
+  }
+
+  fillRects(rects) {
+    const flat = Array.isArray(rects?.[0]) ? rects.flat() : (rects ?? []);
+    if (!flat.length) return;
+    this._applyFill();
+    this._native.ctxFillRects(this._s(), flat);
+    this._dirty();
+  }
+
+  strokeRect(x, y, w, h) {
+    this._applyStroke();
+    this._native.ctxStrokeRect(this._s(), x, y, w, h);
+    this._dirty();
+  }
+
+  clearRect(x, y, w, h) {
+    this._native.ctxClearRect(this._s(), x, y, w, h);
+    this._dirty();
+  }
+
+  drawImage(image, ...args) {
+    const src = image?._surfaceHandle ?? image?._surface?._surfaceHandle;
+    if (!src) return; // ntk Images/Pictures are not on this backend yet
+    const size = this._native.surfaceSize(src);
+    let sx = 0;
+    let sy = 0;
+    let sw = size.width;
+    let sh = size.height;
+    let dx;
+    let dy;
+    let dw;
+    let dh;
+    if (args.length >= 8) {
+      [sx, sy, sw, sh, dx, dy, dw, dh] = args;
+    } else if (args.length >= 4) {
+      [dx, dy, dw, dh] = args;
+    } else {
+      [dx, dy] = args;
+      dw = sw;
+      dh = sh;
+    }
+    this._native.ctxDrawSurface(this._s(), src, sx, sy, sw, sh, dx, dy, dw, dh);
+    this._dirty();
+  }
+
+  putImageData(data, x, y) {
+    if (!data?.data) return;
+    const buf = Buffer.isBuffer(data.data)
+      ? data.data
+      : Buffer.from(data.data.buffer ?? data.data);
+    this._native.ctxPutImageData(
+      this._s(),
+      buf,
+      data.width,
+      data.height,
+      Math.round(x),
+      Math.round(y),
+    );
+    this._dirty();
+  }
+
+  getImageData(x, y, w, h) {
+    const buf = this._native.ctxGetImageData(
+      this._s(),
+      Math.round(x),
+      Math.round(y),
+      Math.round(w),
+      Math.round(h),
+    );
+    return {
+      data: new Uint8ClampedArray(buf.buffer, buf.byteOffset, buf.length),
+      width: Math.round(w),
+      height: Math.round(h),
+    };
+  }
+
+  // --- text (minimal: enough for <canvas onDraw> users) --------------------
+
+  _drawLayout(layout, x, y) {
+    this._native.drawLayout(this._s(), layout._handle, x, y);
+    this._dirty();
+  }
+
+  measureText(text) {
+    const layout = this._fontLayout(text);
+    return layout
+      ? { width: layout.width }
+      : { width: String(text).length * 7 };
+  }
+
+  fillText(text, x, y) {
+    const layout = this._fontLayout(text, this._state.fillStyle);
+    if (!layout) return;
+    // canvas fillText's y is the baseline; layouts draw from their top
+    const baseline = layout.lines[0]?.baseline ?? 0;
+    this._drawLayout(layout, x, y - baseline);
+  }
+
+  _fontLayout(text, color) {
+    const fonts = this._fonts;
+    if (!fonts) return null;
+    const m =
+      /^(?:(italic|oblique)\s+)?(?:(\d{3}|bold)\s+)?(\d+(?:\.\d+)?)px\s+(.+)$/.exec(
+        this._state.font,
+      );
+    const size = m ? Number(m[3]) : 12;
+    const family = m ? m[4] : 'sans-serif';
+    const weight = m?.[2] === 'bold' ? 700 : m?.[2] ? Number(m[2]) : 400;
+    const style = m?.[1] ? 'italic' : 'normal';
+    return fonts.layout(
+      [{ text: String(text), family, size, weight, style, color }],
+      { family, size, weight, style, color: color ?? '#000' },
+      {},
+    );
+  }
+}

--- a/src/cocoa/context2d.js
+++ b/src/cocoa/context2d.js
@@ -542,6 +542,22 @@ export class CocoaContext2D {
     this._dirty();
   }
 
+  /**
+   * Browser contract: a blank RGBA pixel block for the caller to fill and
+   * hand back to putImageData. Pure allocation — nothing touches the
+   * surface — but it lives on the context because that is where every
+   * canvas consumer looks for it (the Frame pane's mandelbrot does).
+   */
+  createImageData(width, height) {
+    const w = Math.max(1, Math.round(width));
+    const h = Math.max(1, Math.round(height));
+    return {
+      data: new Uint8ClampedArray(w * h * 4),
+      width: w,
+      height: h,
+    };
+  }
+
   putImageData(data, x, y) {
     if (!data?.data) return;
     const buf = Buffer.isBuffer(data.data)

--- a/src/cocoa/context2d.js
+++ b/src/cocoa/context2d.js
@@ -28,6 +28,41 @@ class LinearGradient {
     const [r, g, b, a] = parseColor(color);
     this._stops.push(offset, r, g, b, a);
   }
+
+  /**
+   * CoreGraphics requires stop locations inside [0, 1]; the decorations
+   * parser deliberately pads a gradient's line past both ends (its end
+   * colours pinned there — see src/decorations.js). Out-of-range locations
+   * fed to CGGradient render as a solid block, so the line is re-derived:
+   * the coordinates extend to cover the outermost stops and every location
+   * remaps into [0, 1].
+   */
+  _normalized() {
+    const stops = [];
+    for (let i = 0; i + 4 < this._stops.length; i += 5) {
+      stops.push(this._stops.slice(i, i + 5));
+    }
+    stops.sort((p, q) => p[0] - q[0]);
+    if (stops.length === 0) return { coords: this._coords, flat: [] };
+    if (stops.length === 1) stops.push([...stops[0]]);
+    const min = Math.min(0, stops[0][0]);
+    const max = Math.max(1, stops[stops.length - 1][0]);
+    let [x0, y0, x1, y1] = this._coords;
+    if (min !== 0 || max !== 1) {
+      const dx = x1 - x0;
+      const dy = y1 - y0;
+      const nx0 = x0 + dx * min;
+      const ny0 = y0 + dy * min;
+      x1 = x0 + dx * max;
+      y1 = y0 + dy * max;
+      x0 = nx0;
+      y0 = ny0;
+      const span = max - min;
+      for (const stop of stops) stop[0] = (stop[0] - min) / span;
+    }
+    for (const stop of stops) stop[0] = Math.min(1, Math.max(0, stop[0]));
+    return { coords: [x0, y0, x1, y1], flat: stops.flat() };
+  }
 }
 
 export class CocoaContext2D {
@@ -53,6 +88,11 @@ export class CocoaContext2D {
       dash: [],
       dashOffset: 0,
       font: '10px sans-serif',
+      shadowBlur: 0,
+      shadowOffsetX: 0,
+      shadowOffsetY: 0,
+      shadowColor: 'rgba(0,0,0,0)',
+      ctm: [1, 0, 0, 1, 0, 0],
     };
     this._onDirty = null;
   }
@@ -145,6 +185,64 @@ export class CocoaContext2D {
     this._state.font = String(value);
   }
 
+  get shadowBlur() {
+    return this._state.shadowBlur;
+  }
+
+  set shadowBlur(value) {
+    if (typeof value === 'number' && value >= 0) {
+      this._state.shadowBlur = value;
+      this._syncShadow();
+    }
+  }
+
+  get shadowOffsetX() {
+    return this._state.shadowOffsetX;
+  }
+
+  set shadowOffsetX(value) {
+    if (typeof value === 'number') {
+      this._state.shadowOffsetX = value;
+      this._syncShadow();
+    }
+  }
+
+  get shadowOffsetY() {
+    return this._state.shadowOffsetY;
+  }
+
+  set shadowOffsetY(value) {
+    if (typeof value === 'number') {
+      this._state.shadowOffsetY = value;
+      this._syncShadow();
+    }
+  }
+
+  get shadowColor() {
+    return this._state.shadowColor;
+  }
+
+  set shadowColor(value) {
+    this._state.shadowColor = value;
+    this._syncShadow();
+  }
+
+  _syncShadow() {
+    const st = this._state;
+    const [r, g, b, a] = parseColor(st.shadowColor);
+    const on = st.shadowBlur > 0 && a > 0;
+    this._native.ctxSetShadow(
+      this._s(),
+      on ? st.shadowBlur : 0,
+      st.shadowOffsetX,
+      st.shadowOffsetY,
+      r,
+      g,
+      b,
+      a,
+    );
+  }
+
   setLineDash(segments) {
     this._state.dash = Array.isArray(segments) ? segments : [];
     this._native.ctxSetLineDash(this._s(), this._state.dash, 0);
@@ -165,16 +263,69 @@ export class CocoaContext2D {
     this._native.ctxRestore(this._s());
   }
 
+  _concat(a2, b2, c2, d2, e2, f2) {
+    const [a, b, c, d, e, f] = this._state.ctm;
+    this._state.ctm = [
+      a * a2 + c * b2,
+      b * a2 + d * b2,
+      a * c2 + c * d2,
+      b * c2 + d * d2,
+      a * e2 + c * f2 + e,
+      b * e2 + d * f2 + f,
+    ];
+  }
+
   translate(x, y) {
+    this._concat(1, 0, 0, 1, x, y);
     this._native.ctxTranslate(this._s(), x, y);
   }
 
   scale(x, y) {
+    this._concat(x, 0, 0, y, 0, 0);
     this._native.ctxScale(this._s(), x, y);
   }
 
   rotate(angle) {
+    const cos = Math.cos(angle);
+    const sin = Math.sin(angle);
+    this._concat(cos, sin, -sin, cos, 0, 0);
     this._native.ctxRotate(this._s(), angle);
+  }
+
+  transform(a, b, c, d, e, f) {
+    this._concat(a, b, c, d, e, f);
+    this._native.ctxTransform(this._s(), a, b, c, d, e, f);
+  }
+
+  setTransform(a, b, c, d, e, f) {
+    if (typeof a === 'object' && a) ({ a, b, c, d, e, f } = a);
+    // concat the delta that takes the current matrix to the requested one
+    const [ca, cb, cc, cd, ce, cf] = this._state.ctm;
+    const det = ca * cd - cb * cc;
+    if (!det) return;
+    const ia = cd / det;
+    const ib = -cb / det;
+    const ic = -cc / det;
+    const id = ca / det;
+    const ie = -(ia * ce + ic * cf);
+    const iff = -(ib * ce + id * cf);
+    this.transform(
+      ia * a + ic * b,
+      ib * a + id * b,
+      ia * c + ic * d,
+      ib * c + id * d,
+      ia * e + ic * f + ie,
+      ib * e + id * f + iff,
+    );
+  }
+
+  resetTransform() {
+    this.setTransform(1, 0, 0, 1, 0, 0);
+  }
+
+  getTransform() {
+    const [a, b, c, d, e, f] = this._state.ctm;
+    return { a, b, c, d, e, f };
   }
 
   // --- paths ---------------------------------------------------------------
@@ -257,17 +408,44 @@ export class CocoaContext2D {
     this._native.ctxSetStrokeColor(this._s(), r, g, b, a);
   }
 
-  fill(rule) {
+  /**
+   * Replay an ntk/canvas Path2D (normalized M/L/C/Q/Z commands on `_cmds`)
+   * into the native context path. The fill/stroke/clip overloads that take
+   * a path argument route through this — ignoring the argument would run
+   * the operation on whatever path a PREVIOUS painter left behind, which
+   * is how a 44px SVG icon once filled a whole card with its accent.
+   */
+  _replayPath(path) {
+    const cmds = path?._cmds;
+    if (!Array.isArray(cmds)) return false;
+    const n = this._native;
+    const s = this._s();
+    n.ctxBeginPath(s);
+    for (const c of cmds) {
+      if (c.type === 'M') n.ctxMoveTo(s, c.x, c.y);
+      else if (c.type === 'L') n.ctxLineTo(s, c.x, c.y);
+      else if (c.type === 'C')
+        n.ctxCurveTo(s, c.x1, c.y1, c.x2, c.y2, c.x, c.y);
+      else if (c.type === 'Q') n.ctxQuadTo(s, c.x1, c.y1, c.x, c.y);
+      else if (c.type === 'Z') n.ctxClosePath(s);
+    }
+    return true;
+  }
+
+  fill(pathOrRule, maybeRule) {
+    const hasPath = pathOrRule != null && typeof pathOrRule === 'object';
+    const rule = hasPath ? maybeRule : pathOrRule;
+    if (hasPath && !this._replayPath(pathOrRule)) return;
     const style = this._state.fillStyle;
     if (style instanceof LinearGradient) {
-      const [x0, y0, x1, y1] = style._coords;
+      const { coords, flat } = style._normalized();
       this._native.ctxFillLinearGradient(
         this._s(),
-        x0,
-        y0,
-        x1,
-        y1,
-        style._stops,
+        coords[0],
+        coords[1],
+        coords[2],
+        coords[3],
+        flat,
       );
     } else {
       this._applyFill();
@@ -276,13 +454,23 @@ export class CocoaContext2D {
     this._dirty();
   }
 
-  stroke() {
+  stroke(path) {
+    if (path != null && typeof path === 'object' && !this._replayPath(path)) {
+      return;
+    }
     this._applyStroke();
     this._native.ctxStroke(this._s());
     this._dirty();
   }
 
-  clip() {
+  clip(pathOrRule) {
+    if (
+      pathOrRule != null &&
+      typeof pathOrRule === 'object' &&
+      !this._replayPath(pathOrRule)
+    ) {
+      return;
+    }
     this._native.ctxClip(this._s());
   }
 
@@ -290,14 +478,14 @@ export class CocoaContext2D {
     if (!(w > 0) || !(h > 0)) return;
     const style = this._state.fillStyle;
     if (style instanceof LinearGradient) {
-      const [x0, y0, x1, y1] = style._coords;
+      const { coords, flat } = style._normalized();
       this._native.ctxFillLinearGradient(
         this._s(),
-        x0,
-        y0,
-        x1,
-        y1,
-        style._stops,
+        coords[0],
+        coords[1],
+        coords[2],
+        coords[3],
+        flat,
         x,
         y,
         w,
@@ -388,6 +576,26 @@ export class CocoaContext2D {
   // --- text (minimal: enough for <canvas onDraw> users) --------------------
 
   _drawLayout(layout, x, y) {
+    if (layout._contextInk) {
+      const style = this._state.fillStyle;
+      if (style instanceof LinearGradient) {
+        const { coords, flat } = style._normalized();
+        this._native.drawLayoutGradient(
+          this._s(),
+          layout._handle,
+          x,
+          y,
+          coords[0],
+          coords[1],
+          coords[2],
+          coords[3],
+          flat,
+        );
+        this._dirty();
+        return;
+      }
+      this._applyFill();
+    }
     this._native.drawLayout(this._s(), layout._handle, x, y);
     this._dirty();
   }
@@ -400,7 +608,7 @@ export class CocoaContext2D {
   }
 
   fillText(text, x, y) {
-    const layout = this._fontLayout(text, this._state.fillStyle);
+    const layout = this._fontLayout(text);
     if (!layout) return;
     // canvas fillText's y is the baseline; layouts draw from their top
     const baseline = layout.lines[0]?.baseline ?? 0;

--- a/src/cocoa/fonts.js
+++ b/src/cocoa/fonts.js
@@ -14,9 +14,57 @@
 // code points (what the selection and caret code speak). CoreText itself is
 // UTF-16 end to end; the code-point conversion happens at this boundary and
 // nowhere else.
+import { readFileSync } from 'node:fs';
+import { inflateSync } from 'node:zlib';
+
 import { cssColorStraight } from 'ntk';
 
 import { loadNative } from './native.js';
+
+/**
+ * WOFF v1 -> sfnt: the same table directory, zlib per table. ~40 lines of
+ * unwrapping is what lets every `.woff` an app already ships keep working
+ * on this backend without a converter in the build.
+ */
+function woffToSfnt(woff) {
+  const numTables = woff.readUInt16BE(12);
+  const flavor = woff.readUInt32BE(4);
+  const entries = [];
+  for (let i = 0; i < numTables; i++) {
+    const at = 44 + i * 20;
+    const compLength = woff.readUInt32BE(at + 8);
+    const origLength = woff.readUInt32BE(at + 12);
+    const offset = woff.readUInt32BE(at + 4);
+    const compressed = woff.subarray(offset, offset + compLength);
+    entries.push({
+      tag: woff.readUInt32BE(at),
+      checksum: woff.readUInt32BE(at + 16),
+      data: compLength === origLength ? compressed : inflateSync(compressed),
+      origLength,
+    });
+  }
+  const headerSize = 12 + numTables * 16;
+  let total = headerSize;
+  for (const entry of entries) total += (entry.origLength + 3) & ~3;
+  const out = Buffer.alloc(total);
+  out.writeUInt32BE(flavor, 0);
+  out.writeUInt16BE(numTables, 4);
+  const pow2 = 1 << Math.floor(Math.log2(numTables));
+  out.writeUInt16BE(pow2 * 16, 6); // searchRange
+  out.writeUInt16BE(Math.floor(Math.log2(numTables)), 8); // entrySelector
+  out.writeUInt16BE(numTables * 16 - pow2 * 16, 10); // rangeShift
+  let dataAt = headerSize;
+  entries.forEach((entry, i) => {
+    const dir = 12 + i * 16;
+    out.writeUInt32BE(entry.tag, dir);
+    out.writeUInt32BE(entry.checksum, dir + 4);
+    out.writeUInt32BE(dataAt, dir + 8);
+    out.writeUInt32BE(entry.origLength, dir + 12);
+    entry.data.copy(out, dataAt);
+    dataAt += (entry.origLength + 3) & ~3;
+  });
+  return out;
+}
 
 /** family list string -> array: 'Inter, "SF Pro", sans-serif' */
 function familyList(family) {
@@ -98,12 +146,61 @@ function flushFor(align, direction) {
   return ALIGN_FLUSH[align] ?? 0;
 }
 
+const GENERIC_FAMILIES = new Set([
+  'sans-serif',
+  'serif',
+  'monospace',
+  'cursive',
+  'system-ui',
+  'ui-sans-serif',
+  'ui-monospace',
+]);
+
 export class CocoaFontManager {
   constructor() {
     this._native = loadNative();
     this._fonts = new Map(); // family|weight|italic|size -> handle
     this._faces = new Map(); // family|weight|italic -> face wrapper
-    this._loaded = []; // families registered via load(), tried first
+  }
+
+  /**
+   * The catalogue seam ntk exposes as `fonts.source` — what the fonts app
+   * browses. On X that is fontconfig; here it is CoreText's collection.
+   * Pattern syntax: the family, with fontconfig's `:modifiers` tolerated
+   * and ignored (`Menlo:bold`, `:lang=ru` — the part after the colon is
+   * fontconfig vocabulary CoreText does not speak).
+   */
+  get source() {
+    return (this._source ??= {
+      matchSortedAsync: async ({ family } = {}) => {
+        const pattern = String(family ?? '').trim();
+        let name = pattern.split(':')[0].trim();
+        if (name && GENERIC_FAMILIES.has(name.toLowerCase())) {
+          // Rendering resolves generics to the system face, but its family
+          // is a hidden name (`.AppleSystemUIFont`) the catalogue cannot
+          // enumerate — a browser wants the visible families instead.
+          name =
+            {
+              serif: 'Times New Roman',
+              monospace: 'Menlo',
+              'ui-monospace': 'Menlo',
+              cursive: 'Snell Roundhand',
+            }[name.toLowerCase()] ?? 'Helvetica Neue';
+        }
+        const rows = this._native.listFonts(
+          name ? { family: name } : { limit: 400 },
+        );
+        return rows
+          .filter((row) => row.path)
+          .map((row) => ({
+            path: row.path,
+            postscriptName: row.postScriptName,
+            family: row.familyName,
+            style: row.styleName,
+            charset: '',
+          }));
+      },
+    });
   }
 
   _font(family, weight, italic, size) {
@@ -111,7 +208,7 @@ export class CocoaFontManager {
     let handle = this._fonts.get(key);
     if (!handle) {
       handle = this._native.matchFont({
-        families: [...this._loaded, ...familyList(family)],
+        families: familyList(family),
         size,
         weight,
         italic,
@@ -152,27 +249,64 @@ export class CocoaFontManager {
   }
 
   /**
-   * `loadFont()`'s engine half: register font bytes with CoreText for this
-   * process and put the family first in every later match.
+   * `loadFont()`'s engine half: register the face with CoreText so the
+   * process can match it by family name (with real weight/italic traits —
+   * they are read off the file, so four weights of one family resolve the
+   * way `fontWeight` expects). `source` is a path or the font bytes, the
+   * two shapes `src/fonts.js` hands over.
+   *
+   * Container rule: CoreText reads sfnt (ttf/otf/ttc). A `.woff` is those
+   * same tables zlib-wrapped and is unwrapped here; a `.woff2` is a
+   * different compression CoreText cannot take and this engine does not
+   * rebuild — the error says what to load instead.
    */
-  load(data) {
-    const info = this._native.loadFontData(
-      Buffer.isBuffer(data) ? data : Buffer.from(data),
-    );
-    if (!info) {
+  load(source) {
+    let data;
+    if (typeof source === 'string') {
+      data = readFileSync(source);
+    } else if (Buffer.isBuffer(source)) {
+      data = source;
+    } else if (source instanceof Uint8Array) {
+      data = Buffer.from(source.buffer, source.byteOffset, source.byteLength);
+    } else {
       throw new Error(
-        'react-x11: loadFont — CoreText could not read the font data.',
+        'react-x11: loadFont — expected a file path or font bytes, got ' +
+          typeof source,
       );
     }
-    if (!this._loaded.includes(info.familyName)) {
-      this._loaded.unshift(info.familyName);
+    const magic = data.length >= 4 ? data.readUInt32BE(0) : 0;
+    if (magic === 0x774f4632 /* wOF2 */) {
+      throw new Error(
+        'react-x11: loadFont — this is a .woff2 file, and the macOS font ' +
+          'loader (CoreText) does not read that container. Load the .ttf, ' +
+          '.otf or .woff of the same face instead — @fontsource packages ' +
+          'ship a .woff beside every .woff2.',
+      );
     }
-    // sized matches are stale the moment a better family exists
+    if (magic === 0x774f4646 /* wOFF */) data = woffToSfnt(data);
+    const info = this._native.loadFontData(data);
+    if (!info) {
+      throw new Error(
+        'react-x11: loadFont — CoreText could not read the font data' +
+          (typeof source === 'string' ? ` in ${source}` : '') +
+          ' (expected .ttf, .otf, .ttc or .woff).',
+      );
+    }
+    // matches resolved before this face existed are stale now
     this._fonts.clear();
-    return { family: info.familyName, postScriptName: info.postScriptName };
+    this._faces.clear();
+    // `null` on purpose: src/fonts.js keeps the fontkit face it already
+    // opened as the handle, which is the one whose metrics apps can read;
+    // the CoreText registration above is what rendering matches against.
+    return null;
   }
 
   layout(spans, base, options = {}) {
+    // ntk's contract: a bare string or a single span are one-span
+    // paragraphs. TextInputNode's value layout passes the string form, and
+    // iterating a string as spans was a caret pinned to x = 0.
+    if (typeof spans === 'string') spans = [{ text: spans }];
+    else if (!Array.isArray(spans)) spans = [spans];
     const { maxWidth, align, lineHeight, maxLines, overflow, direction } =
       options;
     const nativeSpans = [];

--- a/src/cocoa/fonts.js
+++ b/src/cocoa/fonts.js
@@ -17,7 +17,7 @@
 import { readFileSync } from 'node:fs';
 import { inflateSync } from 'node:zlib';
 
-import { cssColorStraight } from 'ntk';
+import { cssColorStraight, Font } from 'ntk';
 
 import { loadNative } from './native.js';
 
@@ -161,6 +161,121 @@ export class CocoaFontManager {
     this._native = loadNative();
     this._fonts = new Map(); // family|weight|italic|size -> handle
     this._faces = new Map(); // family|weight|italic -> face wrapper
+    this._registered = new Map(); // lowercase family -> [{cg, weight, italic}]
+    this._byKey = new Map(); // ntk Font key -> { cg } | { ps }
+    this._sized = new Map(); // face key|size|variations -> CTFont handle
+    this._layouts = new Map(); // layout signature -> CocoaTextLayout (LRU)
+  }
+
+  /**
+   * `openFont()`'s engine seam (src/fonts.js `openThrough`): parse the face
+   * with fontkit — the object applications read metrics and axes off — and
+   * feed the same bytes to CoreText so the face RENDERS here too, by
+   * family name or as a `span.font`. An opened file is a face the user
+   * chose to look at; a backend where it measures but draws as the system
+   * font answers a different question than the one asked.
+   */
+  _open(candidate) {
+    const { key, path, data, postscriptName } = candidate;
+    const font =
+      path !== undefined
+        ? Font.loadSync(path, postscriptName)
+        : Font.fromData(data, candidate);
+    try {
+      let bytes =
+        path !== undefined
+          ? readFileSync(path)
+          : Buffer.isBuffer(data)
+            ? data
+            : Buffer.from(data.buffer ?? data);
+      const magic = bytes.length >= 4 ? bytes.readUInt32BE(0) : 0;
+      if (magic === 0x774f4646) bytes = woffToSfnt(bytes);
+      if (magic !== 0x774f4632 /* woff2 stays fontkit-only */) {
+        const info = this._native.fontFromData(bytes);
+        // a .ttc's data handle is its FIRST face; when a specific face was
+        // asked for and this is not it, leave rendering to the PostScript
+        // route (installed collections resolve there anyway)
+        const face = postscriptName ?? font.postscriptName;
+        if (info && (!face || info.postScriptName === face)) {
+          this._byKey.set(font.key ?? key, { cg: info.cg });
+          const family = (info.familyName ?? '').toLowerCase();
+          if (family) {
+            const faces = this._registered.get(family) ?? [];
+            faces.push({
+              cg: info.cg,
+              weight: numericWeight(info.weight),
+              italic: Boolean(info.italic),
+            });
+            this._registered.set(family, faces);
+          }
+          this._fonts.clear();
+          this._faces.clear();
+          this._sized.clear();
+        }
+      }
+    } catch {
+      // the fontkit face still measures; rendering falls back by family
+    }
+    return font;
+  }
+
+  /**
+   * A CTFont for an ntk `Font` face handed over as `span.font` — the way
+   * the fonts app renders the face it opened, and the way `loadFont`'s
+   * faces reach glyphs. Resolution: an installed face by its exact
+   * PostScript name; otherwise the file's own bytes (unwrapping `.woff`),
+   * cached per face key.
+   */
+  _faceFont(face, size, variations) {
+    const key = face.key ?? `${face.path ?? ''}#${face.postscriptName ?? ''}`;
+    let entry = this._byKey.get(key);
+    if (!entry) {
+      entry = {};
+      const ps = face.postscriptName;
+      if (ps && this._native.fontByPostScriptName(ps, 12)) {
+        entry.ps = ps;
+      } else {
+        let data = null;
+        if (face.path) {
+          try {
+            data = readFileSync(face.path);
+          } catch {
+            data = null;
+          }
+        }
+        if (!data && face.fk?.stream?.buffer) {
+          data = Buffer.from(face.fk.stream.buffer);
+        }
+        if (data) {
+          if (data.length >= 4 && data.readUInt32BE(0) === 0x774f4646) {
+            data = woffToSfnt(data);
+          }
+          const info = this._native.fontFromData(data);
+          if (info) entry.cg = info.cg;
+        }
+      }
+      this._byKey.set(key, entry);
+    }
+    const sizedKey = `${key}|${size}|${variations ? JSON.stringify(variations) : ''}`;
+    let handle = this._sized.get(sizedKey);
+    if (handle) return handle;
+    if (entry.ps) handle = this._native.fontByPostScriptName(entry.ps, size);
+    else if (entry.cg) handle = this._native.cgFontWithSize(entry.cg, size);
+    if (!handle) return null;
+    handle = this._withVariations(handle, variations);
+    this._sized.set(sizedKey, handle);
+    return handle;
+  }
+
+  _withVariations(handle, variations) {
+    if (
+      variations &&
+      typeof variations === 'object' &&
+      Object.keys(variations).length > 0
+    ) {
+      return this._native.fontApplyVariations(handle, variations);
+    }
+    return handle;
   }
 
   /**
@@ -207,7 +322,26 @@ export class CocoaFontManager {
     const key = `${family}|${weight}|${italic}|${size}`;
     let handle = this._fonts.get(key);
     if (!handle) {
-      handle = this._native.matchFont({
+      // Faces the app loaded win over system matching for their family —
+      // an app that ships a font means the one it ships (src/fonts.js).
+      for (const name of familyList(family)) {
+        const faces = this._registered.get(name.toLowerCase());
+        if (!faces?.length) continue;
+        let best = null;
+        let bestCost = Infinity;
+        for (const face of faces) {
+          const cost =
+            Math.abs(face.weight - weight) +
+            (face.italic === italic ? 0 : 1000);
+          if (cost < bestCost) {
+            bestCost = cost;
+            best = face;
+          }
+        }
+        handle = this._native.cgFontWithSize(best.cg, size);
+        break;
+      }
+      handle ??= this._native.matchFont({
         families: familyList(family),
         size,
         weight,
@@ -260,7 +394,7 @@ export class CocoaFontManager {
    * different compression CoreText cannot take and this engine does not
    * rebuild — the error says what to load instead.
    */
-  load(source) {
+  load(source, opts = {}) {
     let data;
     if (typeof source === 'string') {
       data = readFileSync(source);
@@ -284,7 +418,7 @@ export class CocoaFontManager {
       );
     }
     if (magic === 0x774f4646 /* wOFF */) data = woffToSfnt(data);
-    const info = this._native.loadFontData(data);
+    const info = this._native.fontFromData(data);
     if (!info) {
       throw new Error(
         'react-x11: loadFont — CoreText could not read the font data' +
@@ -292,12 +426,27 @@ export class CocoaFontManager {
           ' (expected .ttf, .otf, .ttc or .woff).',
       );
     }
+    // The process's own handle to the face, kept in a registry family
+    // matching consults FIRST — CoreText registration of in-memory data is
+    // best-effort at most, and rendering must not depend on it.
+    const family = (opts.family ?? info.familyName ?? '').toLowerCase();
+    if (family) {
+      const faces = this._registered.get(family) ?? [];
+      faces.push({
+        cg: info.cg,
+        weight: numericWeight(opts.weight ?? info.weight),
+        italic: opts.style ? isItalic(opts.style) : Boolean(info.italic),
+      });
+      this._registered.set(family, faces);
+    }
     // matches resolved before this face existed are stale now
     this._fonts.clear();
     this._faces.clear();
+    this._sized.clear();
+    this._layouts.clear();
     // `null` on purpose: src/fonts.js keeps the fontkit face it already
     // opened as the handle, which is the one whose metrics apps can read;
-    // the CoreText registration above is what rendering matches against.
+    // the registry above is what rendering resolves against.
     return null;
   }
 
@@ -307,23 +456,68 @@ export class CocoaFontManager {
     // iterating a string as spans was a caret pinned to x = 0.
     if (typeof spans === 'string') spans = [{ text: spans }];
     else if (!Array.isArray(spans)) spans = [spans];
+    // Memoized: an immediate-mode caller (the fonts app's specimen canvas,
+    // a hover pass) lays the same paragraph out every repaint, and a
+    // CTFramesetter per pointer move is what sluggish feels like. The key
+    // is everything shaping reads; ~64 entries covers a screenful.
+    const signature = JSON.stringify([
+      spans.map((sp) => [
+        sp.text,
+        sp.family ?? base.family,
+        sp.size ?? base.size,
+        sp.weight ?? base.weight,
+        sp.style ?? base.style,
+        sp.color ?? base.color ?? null,
+        sp.variations ?? base.variations ?? null,
+        (sp.font ?? base.font)?.key ?? null,
+      ]),
+      options.maxWidth,
+      options.align,
+      options.lineHeight,
+      options.maxLines,
+      options.overflow,
+      options.direction,
+    ]);
+    const hit = this._layouts.get(signature);
+    if (hit) {
+      // refresh LRU position
+      this._layouts.delete(signature);
+      this._layouts.set(signature, hit);
+      return hit;
+    }
     const { maxWidth, align, lineHeight, maxLines, overflow, direction } =
       options;
     const nativeSpans = [];
     let text = '';
+    let contextInk = false;
     for (const span of spans) {
       const t = String(span.text ?? '');
       if (!t) continue;
       text += t;
-      nativeSpans.push({
-        text: t,
-        font: this._font(
+      const size = span.size ?? base.size ?? 14;
+      const variations = span.variations ?? base.variations;
+      // A span may carry the face itself — an ntk Font from openFont(),
+      // which is how the fonts app renders exactly the file it opened.
+      const face = span.font ?? base.font;
+      let handle =
+        face && (face.postscriptName || face.path || face.fk)
+          ? this._faceFont(face, size, variations)
+          : null;
+      handle ??= this._withVariations(
+        this._font(
           span.family ?? base.family,
           numericWeight(span.weight ?? base.weight),
           isItalic(span.style ?? base.style),
-          span.size ?? base.size ?? 14,
+          size,
         ),
-        color: parseColor(span.color ?? base.color),
+        variations,
+      );
+      const color = span.color ?? base.color;
+      if (color == null) contextInk = true;
+      nativeSpans.push({
+        text: t,
+        font: handle,
+        ...(color == null ? {} : { color: parseColor(color) }),
       });
     }
     const raw = this._native.createLayout({
@@ -336,6 +530,12 @@ export class CocoaFontManager {
       ellipsis: overflow === 'ellipsis',
       rtl: direction === 'rtl',
     });
-    return new CocoaTextLayout(this._native, raw, text);
+    const layout = new CocoaTextLayout(this._native, raw, text);
+    layout._contextInk = contextInk;
+    this._layouts.set(signature, layout);
+    if (this._layouts.size > 64) {
+      this._layouts.delete(this._layouts.keys().next().value);
+    }
+    return layout;
   }
 }

--- a/src/cocoa/fonts.js
+++ b/src/cocoa/fonts.js
@@ -1,0 +1,207 @@
+// The Cocoa text engine: CoreText behind the same `app.fonts` contract ntk's
+// FontManager answers on the X11 backend. The renderer touches exactly this
+// surface (docs/macos.md §"Text: the engine contract"):
+//
+//   fonts.layout(spans, base, { maxWidth, align, lineHeight, maxLines,
+//                               overflow, direction })
+//     -> { width, height, lines, draw(ctx, x, y),
+//          indexAt(x, y), caretPosition(cp) }
+//   fonts.match(family, { weight, style }) -> { metrics(size) }
+//
+// Index spaces, because two meet here: `lines[].start/end` and
+// `runs[].start/end` are UTF-16 code units (what `rangeBands` in nodes.js
+// compares against), while `caretPosition()` takes and `indexAt()` returns
+// code points (what the selection and caret code speak). CoreText itself is
+// UTF-16 end to end; the code-point conversion happens at this boundary and
+// nowhere else.
+import { cssColorStraight } from 'ntk';
+
+import { loadNative } from './native.js';
+
+/** family list string -> array: 'Inter, "SF Pro", sans-serif' */
+function familyList(family) {
+  if (Array.isArray(family)) return family;
+  return String(family ?? 'sans-serif')
+    .split(',')
+    .map((f) => f.trim().replace(/^["']|["']$/g, ''))
+    .filter(Boolean);
+}
+
+function numericWeight(weight) {
+  if (typeof weight === 'number') return weight;
+  if (weight === 'bold') return 700;
+  if (weight === 'medium') return 500;
+  if (weight === 'semibold') return 600;
+  if (weight === 'light') return 300;
+  return 400;
+}
+
+const isItalic = (style) => style === 'italic' || style === 'oblique';
+
+function parseColor(color) {
+  const parsed = cssColorStraight(color ?? '#000');
+  return parsed ?? [0, 0, 0, 1];
+}
+
+/** UTF-16 offset of each code point boundary, plus the end. */
+function codeUnitOffsets(text) {
+  const offsets = [0];
+  for (const ch of text) offsets.push(offsets[offsets.length - 1] + ch.length);
+  return offsets;
+}
+
+class CocoaTextLayout {
+  constructor(native, raw, text) {
+    this._native = native;
+    this._handle = raw.handle;
+    this._text = text;
+    this._cpToCu = codeUnitOffsets(text);
+    this.width = raw.width;
+    this.height = raw.height;
+    this.lines = raw.lines;
+  }
+
+  _cuOf(cp) {
+    const t = this._cpToCu;
+    return t[Math.max(0, Math.min(cp, t.length - 1))];
+  }
+
+  _cpOf(cu) {
+    const t = this._cpToCu;
+    // t is sorted; layouts are short, a linear walk is fine
+    for (let i = 0; i < t.length; i++) if (t[i] >= cu) return i;
+    return t.length - 1;
+  }
+
+  draw(ctx, x, y) {
+    ctx._drawLayout(this, x, y);
+  }
+
+  /** Code point boundary nearest the point, in layout coordinates. */
+  indexAt(x, y) {
+    return this._cpOf(this._native.layoutIndexAt(this._handle, x, y));
+  }
+
+  /** Caret rect for a code-point index: { x, y, height }. */
+  caretPosition(cp) {
+    return this._native.layoutCaret(this._handle, this._cuOf(cp));
+  }
+}
+
+const ALIGN_FLUSH = { left: 0, center: 0.5, right: 1 };
+
+function flushFor(align, direction) {
+  if (align === 'start' || align === undefined) {
+    return direction === 'rtl' ? 1 : 0;
+  }
+  if (align === 'end') return direction === 'rtl' ? 0 : 1;
+  return ALIGN_FLUSH[align] ?? 0;
+}
+
+export class CocoaFontManager {
+  constructor() {
+    this._native = loadNative();
+    this._fonts = new Map(); // family|weight|italic|size -> handle
+    this._faces = new Map(); // family|weight|italic -> face wrapper
+    this._loaded = []; // families registered via load(), tried first
+  }
+
+  _font(family, weight, italic, size) {
+    const key = `${family}|${weight}|${italic}|${size}`;
+    let handle = this._fonts.get(key);
+    if (!handle) {
+      handle = this._native.matchFont({
+        families: [...this._loaded, ...familyList(family)],
+        size,
+        weight,
+        italic,
+      });
+      this._fonts.set(key, handle);
+    }
+    return handle;
+  }
+
+  /**
+   * A face by family/weight/style — what `textBoxTrim` reads `capHeight`
+   * from. The face defers size, like ntk's: `metrics(size)` answers for a
+   * concrete pixel size.
+   */
+  match(family, { weight, style } = {}) {
+    const w = numericWeight(weight);
+    const italic = isItalic(style);
+    const key = `${family}|${w}|${italic}`;
+    let face = this._faces.get(key);
+    if (!face) {
+      const manager = this;
+      face = {
+        metrics(size) {
+          return manager._native.fontMetrics(
+            manager._font(family, w, italic, size ?? 14),
+          );
+        },
+        hasGlyph(char) {
+          return manager._native.fontHasGlyph(
+            manager._font(family, w, italic, 14),
+            String(char),
+          );
+        },
+      };
+      this._faces.set(key, face);
+    }
+    return face;
+  }
+
+  /**
+   * `loadFont()`'s engine half: register font bytes with CoreText for this
+   * process and put the family first in every later match.
+   */
+  load(data) {
+    const info = this._native.loadFontData(
+      Buffer.isBuffer(data) ? data : Buffer.from(data),
+    );
+    if (!info) {
+      throw new Error(
+        'react-x11: loadFont — CoreText could not read the font data.',
+      );
+    }
+    if (!this._loaded.includes(info.familyName)) {
+      this._loaded.unshift(info.familyName);
+    }
+    // sized matches are stale the moment a better family exists
+    this._fonts.clear();
+    return { family: info.familyName, postScriptName: info.postScriptName };
+  }
+
+  layout(spans, base, options = {}) {
+    const { maxWidth, align, lineHeight, maxLines, overflow, direction } =
+      options;
+    const nativeSpans = [];
+    let text = '';
+    for (const span of spans) {
+      const t = String(span.text ?? '');
+      if (!t) continue;
+      text += t;
+      nativeSpans.push({
+        text: t,
+        font: this._font(
+          span.family ?? base.family,
+          numericWeight(span.weight ?? base.weight),
+          isItalic(span.style ?? base.style),
+          span.size ?? base.size ?? 14,
+        ),
+        color: parseColor(span.color ?? base.color),
+      });
+    }
+    const raw = this._native.createLayout({
+      spans: nativeSpans,
+      maxWidth:
+        Number.isFinite(maxWidth) && maxWidth > 0 ? maxWidth : undefined,
+      align: flushFor(align, direction),
+      lineHeight: typeof lineHeight === 'number' ? lineHeight : undefined,
+      maxLines: Number.isFinite(maxLines) ? maxLines : undefined,
+      ellipsis: overflow === 'ellipsis',
+      rtl: direction === 'rtl',
+    });
+    return new CocoaTextLayout(this._native, raw, text);
+  }
+}

--- a/src/cocoa/glarea.js
+++ b/src/cocoa/glarea.js
@@ -1,0 +1,321 @@
+// <glarea> on the Cocoa backend: GL into a CALayer, no X server anywhere.
+//
+// The shape mirrors the X11 direct path (ntk's renderingcontext_cgl) with
+// the XQuartz-specific half swapped out: the same x11-dri CGL context and
+// WebGL-shaped `gl` table, but instead of attaching to a window surface the
+// X server exported, frames render into IOSurface-backed framebuffers
+// (x11-dri `createTarget`) and present by handing the IOSurface's process-
+// global id to the area's own sublayer (`setLayerContentsIOSurface`). Two
+// targets alternate, like any swapchain; the WindowServer composites.
+//
+// What GlAreaNode needs from us is the child-"window" contract it already
+// speaks (src/glnodes.js): `createWindow({ parent, … })` answering an
+// object with `getContext('opengl', config)`, `setState(rect)`, `map()`,
+// `destroy()`, `requestAnimationFrame`. On X11 that child is a real X
+// window stacked above the parent's drawing; here it is a sublayer of the
+// window's root layer with a high zPosition — the same "GL sits above the
+// 2D" semantics, by the same mechanism the platform gives us.
+//
+// ## The API ladder
+//
+// `chooseGLConfig(spec)` honours `spec.api` (the `<glarea glx>` prop):
+// `'auto'` and `'gl'` are this file — CGL, OpenGL 4.1 core on Metal, the
+// zero-dependency rung that exists on every Mac. `'gles'` (ANGLE on Metal)
+// and `'webgpu'` are named rungs that answer with what they would take,
+// so the ladder is visible before it is built. Policy decides, the machine
+// answers — the same rule the GL policy follows everywhere else.
+
+const RUNGS = ['auto', 'gl'];
+const KNOWN_RUNGS = ['auto', 'gl', 'gles', 'webgpu'];
+
+let driPromise = null;
+function loadDri() {
+  if (!driPromise) {
+    driPromise = import('x11-dri').then((m) => m.default ?? m);
+  }
+  return driPromise;
+}
+
+/**
+ * The app-wide GL runtime: one CGL context shared by every `<glarea>`, the
+ * way the X11 direct backend shares one GPU context per connection. Created
+ * lazily by the first `chooseGLConfig` and kept on the app.
+ */
+export class CocoaGLRuntime {
+  constructor(dri) {
+    this.dri = dri;
+    this.gl = dri.gl;
+    this.ctx = new dri.apple.Context({
+      alphaSize: 8,
+      depthSize: 24,
+      stencilSize: 8,
+      doubleBuffer: false,
+      profile: 'core',
+    });
+    this.ctx.makeCurrent();
+    this.glVersion = this.ctx.glVersion;
+    // frame pacing: how long a swap closes the canRender gate for. macOS
+    // answers directly — XQuartz's RandR never could (x11-dri >= 0.6).
+    const hz = dri.apple.refreshRate?.();
+    this.frameInterval = hz ? 1000 / hz : 1000 / 60;
+  }
+
+  destroy() {
+    this.ctx.destroy();
+  }
+}
+
+/** Resolve the app's runtime, throwing the reason when there is none. */
+export async function cocoaGLConfig(app, spec) {
+  const mode = app.glPolicy?.mode ?? 'auto';
+  if (mode === 'off') {
+    const err = new Error(
+      "glPolicy is 'off' on this connection, so no GL context is created at all",
+    );
+    err.code = 'GL_DISABLED';
+    throw err;
+  }
+  if (mode === 'indirect') {
+    const err = new Error(
+      "glPolicy is 'indirect', which is GLX — the Cocoa backend has no X " +
+        "server to speak it to. Use 'auto' (the default here) or 'direct'.",
+    );
+    err.code = 'GL_POLICY_INDIRECT';
+    throw err;
+  }
+  const api = spec?.api ?? 'auto';
+  if (!RUNGS.includes(api)) {
+    const err = new Error(
+      KNOWN_RUNGS.includes(api)
+        ? `<glarea> api '${api}' is a named rung this backend has not ` +
+            `built yet — today's rungs are ${RUNGS.join(', ')} (CGL, OpenGL ` +
+            `4.1 core on Metal). 'gles' arrives with vendored ANGLE, ` +
+            `'webgpu' with a wgpu bridge.`
+        : `<glarea> api '${api}' is not a rung — expected one of ` +
+            `${KNOWN_RUNGS.join(', ')}.`,
+    );
+    err.code = 'GL_API_UNAVAILABLE';
+    throw err;
+  }
+  await resolveCocoaGLRuntime(app);
+  return { backend: 'direct', api: 'gl' };
+}
+
+/**
+ * One runtime per app, one probe per app: chooseGLConfig and
+ * `app.glCapabilities()` share this promise, so two `<glarea>`s mounting in
+ * the same commit cannot race two contexts into existence, and the settled
+ * answer lands in `_glCapsResolved` either way — the property
+ * `useSupports('shaders')` reads (src/glbackend.js).
+ */
+export function resolveCocoaGLRuntime(app) {
+  if (!app._cocoaGLPromise) {
+    app._cocoaGLPromise = loadDri()
+      .then((dri) => {
+        app._cocoaGL = new CocoaGLRuntime(dri);
+        app._glCapsResolved = { direct: true };
+        return app._cocoaGL;
+      })
+      .catch((cause) => {
+        const err = new Error(
+          '<glarea> on the Cocoa backend needs the x11-dri addon (the ' +
+            'GPU/GL half); it did not load: ' +
+            cause.message,
+        );
+        err.code = 'GL_NO_ADDON';
+        app._glCapsResolved = { direct: false, reason: err };
+        throw err;
+      });
+  }
+  return app._cocoaGLPromise;
+}
+
+/**
+ * The child-"window" a GlAreaNode owns here: one sublayer of the owning
+ * window's root layer, above everything the 2D presenters put there.
+ */
+export class CocoaGLArea {
+  constructor(app, options) {
+    this.app = app;
+    this.parent = options.parent;
+    this._native = app._native;
+    this.scale = this.parent.scale ?? app.scale ?? 1;
+    this.destroyed = false;
+    this._reactX11Node = null;
+    this.onWheel = options.onWheel ?? null;
+    this.layer = this._native.createLayer();
+    this._native.addSublayer(this.parent._layer, this.layer);
+    this.rect = null;
+    this.setState({
+      x: options.x ?? 0,
+      y: options.y ?? 0,
+      width: options.width ?? 1,
+      height: options.height ?? 1,
+    });
+    this._context = null;
+    this._listeners = new Map();
+  }
+
+  /** Geometry in device px, the unit GlAreaNode's rects are in. */
+  setState(rect) {
+    if (this.destroyed) return;
+    this.rect = rect;
+    const s = this.scale;
+    this._native.setLayerProps(this.layer, {
+      frame: [rect.x / s, rect.y / s, rect.width / s, rect.height / s],
+      // above both presenters' content: the surface presenter's contents
+      // live on the root layer itself, the layers presenter's visuals top
+      // out at paintOrder zPositions — this clears either.
+      zPosition: 1e7,
+      // GL renders bottom-up and an IOSurface displays row 0 at the top;
+      // mirroring the layer is the flip, applied where the compositor is
+      // already transforming instead of in anyone's shader.
+      transform: { scaleY: -1 },
+      hidden: false,
+    });
+    this._context?._resized(rect.width, rect.height);
+  }
+
+  get width() {
+    return this.rect?.width ?? 0;
+  }
+
+  get height() {
+    return this.rect?.height ?? 0;
+  }
+
+  move(x, y) {
+    this.setState({ ...this.rect, x, y });
+  }
+
+  resize(width, height) {
+    this.setState({ ...this.rect, width, height });
+  }
+
+  map() {
+    if (!this.destroyed) {
+      this._native.setLayerProps(this.layer, { hidden: false });
+    }
+  }
+
+  on(name, fn) {
+    let set = this._listeners.get(name);
+    if (!set) this._listeners.set(name, (set = new Set()));
+    set.add(fn);
+  }
+
+  emit(name, ev) {
+    for (const fn of this._listeners.get(name) ?? []) fn(ev);
+  }
+
+  requestAnimationFrame(cb) {
+    return this.parent.requestAnimationFrame(cb);
+  }
+
+  getContext(kind, config) {
+    if (kind !== 'opengl' || this.destroyed) return null;
+    if (!this._context) {
+      this._context = createGLAreaContext(this.app._cocoaGL, this, config);
+    }
+    return this._context;
+  }
+
+  destroy() {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this._context?._destroy();
+    this._context = null;
+    this._native.removeFromSuperlayer(this.layer);
+  }
+}
+
+/**
+ * The `gl` a `<glarea>`'s onDraw receives: the shared WebGL-shaped table
+ * with this area's swapchain behind it. Prototype-delegates to the table so
+ * every entry point is present without copying; the own properties are the
+ * per-area contract GlAreaNode drives (`backend`, `ready`, `makeCurrent`,
+ * `SwapBuffers`, `canRender`, `onFrameAvailable`).
+ */
+function createGLAreaContext(runtime, area, config) {
+  const native = area._native;
+  const ctx = Object.create(runtime.gl);
+  let front = null;
+  let back = null;
+  let width = 0;
+  let height = 0;
+  let gateClosed = false;
+  let gateTimer = null;
+  let destroyed = false;
+
+  const ensureTargets = () => {
+    const w = Math.max(1, area.rect?.width ?? 1);
+    const h = Math.max(1, area.rect?.height ?? 1);
+    if (front && width === w && height === h) return;
+    front?.destroy();
+    back?.destroy();
+    front = runtime.ctx.createTarget(w, h);
+    back = runtime.ctx.createTarget(w, h);
+    width = w;
+    height = h;
+  };
+
+  ctx.backend = 'direct';
+  ctx.config = config;
+  ctx.glVersion = runtime.glVersion;
+  ctx.ready = Promise.resolve();
+  ctx.onFrameAvailable = null;
+
+  // On the direct backend every buffer may still be held by the display;
+  // here the WindowServer reads the front IOSurface while we draw the back
+  // one, so the honest gate is one display period per swap — the same
+  // timer-reopened gate the XQuartz CGL flavor uses (no backpressure
+  // exists on either).
+  ctx.canRender = () => !destroyed && !gateClosed;
+
+  ctx.makeCurrent = () => {
+    if (destroyed) return;
+    ensureTargets();
+    runtime.ctx.bindTarget(back);
+  };
+
+  // WebGL's "null means the default framebuffer" — and this surface's
+  // default is the back target's FBO, not GL's framebuffer zero, which on
+  // a swapchain like this is nothing at all. A scene that renders through
+  // its own FBO and unbinds at the end (the SSAA pattern) lands back here.
+  ctx.bindFramebuffer = (target, fb) => {
+    runtime.gl.bindFramebuffer(target, fb == null ? (back?.fbo ?? 0) : fb);
+  };
+
+  ctx.SwapBuffers = () => {
+    if (destroyed || !back) return;
+    runtime.gl.flush();
+    native.setLayerContentsIOSurface(area.layer, back.iosurfaceId);
+    const shown = back;
+    back = front;
+    front = shown;
+    gateClosed = true;
+    gateTimer = setTimeout(() => {
+      gateTimer = null;
+      gateClosed = false;
+      ctx.onFrameAvailable?.();
+    }, runtime.frameInterval);
+    // the timer must not hold the process open for an idle scene
+    gateTimer.unref?.();
+  };
+
+  ctx._resized = () => {
+    // targets are rebuilt lazily on the next makeCurrent, so a resize
+    // storm costs two allocations per drawn frame, not per notify
+  };
+
+  ctx._destroy = () => {
+    if (destroyed) return;
+    destroyed = true;
+    if (gateTimer) clearTimeout(gateTimer);
+    front?.destroy();
+    back?.destroy();
+    front = back = null;
+  };
+
+  return ctx;
+}

--- a/src/cocoa/globalmenu.js
+++ b/src/cocoa/globalmenu.js
@@ -107,6 +107,11 @@ export class CocoaGlobalMenuExport {
         if (props.enabled === false) out.enabled = false;
         if (props.visible === false) out.hidden = true;
         if (props['toggle-state'] === 1) out.checked = true;
+        // the serialisable icon pair (menuitem.js): the name is read in
+        // the platform's icon theme — SF Symbols here, freedesktop on a
+        // Linux panel — and the bytes are the literal-pixel fallback
+        if (props['icon-name']) out.iconName = props['icon-name'];
+        if (props['icon-data']) out.iconData = props['icon-data'];
         const key = keyEquivalent(props.shortcut);
         if (key) {
           out.key = key.key;

--- a/src/cocoa/globalmenu.js
+++ b/src/cocoa/globalmenu.js
@@ -1,0 +1,144 @@
+// The macOS menu bar as a global-menu export (docs/macos.md §Menus).
+//
+// The Linux global menu was built for exactly this moment: the item
+// vocabulary is data, and the pure snapshot/IdAllocator machinery in
+// dbusmenu.js produces stable ids with no D-Bus in sight. This adapter
+// consumes precisely that — same owner shape as GlobalMenuExport
+// (start/stop/update/onChange), so `useGlobalMenu` swaps the transport and
+// nothing above it can tell. Where the D-Bus export must wait for a
+// registrar to answer, the menu bar is a platform constant: `onChange(true)`
+// fires as soon as the menu is installed, and `MenuBar`'s drawn fallback
+// never renders here.
+//
+// Activation comes back as a backend event carrying the item's id —
+// AppKit's menu tracking is a modal loop, and those already deliver into JS
+// on this backend (live resize does) — routed by the app to the active
+// export, which runs the item's own onSelect: the same contract the
+// registrar path has.
+import { IdAllocator, ROOT_ID, snapshot } from '../dbusmenu.js';
+
+// The synthesized app menu's Quit item. Negative on purpose: IdAllocator
+// only counts up from ROOT_ID, so no real item can collide with it.
+const QUIT_ID = -2;
+
+// NSEventModifierFlags
+const FLAG_SHIFT = 1 << 17;
+const FLAG_CONTROL = 1 << 18;
+const FLAG_OPTION = 1 << 19;
+const FLAG_COMMAND = 1 << 20;
+
+/**
+ * One dbusmenu chord — `[['Control', 'z']]` — as NSMenu key equivalents.
+ * `Control` maps to Command deliberately: a cross-platform app writes its
+ * shortcuts in the primary modifier, and on macOS the primary modifier is
+ * ⌘ — a literal mapping would put every accelerator on a modifier no Mac
+ * user presses. Multi-chord sequences and non-character keys have no
+ * NSMenu spelling and are dropped (the shortcut still works — the app's
+ * own key handling is untouched; only the menu's hint goes unshown).
+ */
+function keyEquivalent(shortcut) {
+  const chord = Array.isArray(shortcut) ? shortcut[0] : null;
+  if (!Array.isArray(chord) || shortcut.length !== 1) return null;
+  let modifiers = 0;
+  let key = null;
+  for (const part of chord) {
+    if (part === 'Control' || part === 'Super') modifiers |= FLAG_COMMAND;
+    else if (part === 'Shift') modifiers |= FLAG_SHIFT;
+    else if (part === 'Alt') modifiers |= FLAG_OPTION;
+    else key = part;
+  }
+  if (typeof key !== 'string' || [...key].length !== 1) return null;
+  return { key: key.toLowerCase(), modifiers: modifiers || FLAG_COMMAND };
+}
+
+export class CocoaGlobalMenuExport {
+  constructor(app, { getMenus, onSelect, onAboutToShow, target, onChange }) {
+    this.app = app;
+    this.getMenus = getMenus;
+    this.onSelect = onSelect;
+    this.onAboutToShow = onAboutToShow;
+    this.target = target;
+    this.onChange = onChange;
+    this.alloc = new IdAllocator();
+    this.nodes = null;
+    this.exported = false;
+  }
+
+  async start() {
+    this.app._registerGlobalMenu(this);
+    this.update(this.getMenus?.() ?? []);
+    this.exported = true;
+    this.onChange?.(true);
+  }
+
+  async stop() {
+    this.exported = false;
+    this.app._unregisterGlobalMenu(this);
+    this.onChange?.(false);
+  }
+
+  update(menus) {
+    this.nodes = snapshot(menus ?? [], this.alloc);
+    if (this.app._activeGlobalMenu === this) this._install();
+  }
+
+  _install() {
+    this.app._native.setMainMenu(this._spec());
+  }
+
+  /**
+   * The snapshot as the bridge's menu spec. The app menu is synthesized in
+   * front — macOS requires the first menu and shows the process name on it
+   * regardless of title — carrying Quit, which routes back through
+   * `activate` like every real item.
+   */
+  _spec() {
+    const itemsOf = (ids) =>
+      ids.map((id) => {
+        const node = this.nodes.get(id);
+        const props = node.props;
+        const out = { id };
+        if (props.type === 'separator') {
+          out.separator = true;
+          if (props.visible === false) out.hidden = true;
+          return out;
+        }
+        out.title = String(props.label ?? '');
+        if (props.enabled === false) out.enabled = false;
+        if (props.visible === false) out.hidden = true;
+        if (props['toggle-state'] === 1) out.checked = true;
+        const key = keyEquivalent(props.shortcut);
+        if (key) {
+          out.key = key.key;
+          out.modifiers = key.modifiers;
+        }
+        if (node.childIds.length) out.items = itemsOf(node.childIds);
+        return out;
+      });
+    const root = this.nodes.get(ROOT_ID);
+    const menus = itemsOf(root.childIds).map((menu) => ({
+      title: menu.title ?? '',
+      items: menu.items ?? [],
+    }));
+    return [
+      {
+        title: 'App',
+        items: [{ id: QUIT_ID, title: 'Quit', key: 'q' }],
+      },
+      ...menus,
+    ];
+  }
+
+  /** A backend menu-activate event landed on this export. */
+  activate(id) {
+    if (id === QUIT_ID) {
+      // the same route the close button takes: the app decides what
+      // closing means, exactly as it would for the red light
+      const wnd = this.target?.window ?? [...this.app._windows.values()][0];
+      wnd?.emit('close', { preventDefault() {} });
+      return;
+    }
+    const item = this.nodes?.get(id)?.item;
+    if (item) this.onSelect?.(item);
+  }
+}

--- a/src/cocoa/globalmenu.js
+++ b/src/cocoa/globalmenu.js
@@ -21,9 +21,9 @@ import { IdAllocator, ROOT_ID, snapshot } from '../dbusmenu.js';
 // only counts up from ROOT_ID, so no real item can collide with it.
 const QUIT_ID = -2;
 
-// NSEventModifierFlags
+// NSEventModifierFlags. No Control here on purpose: a cross-platform
+// shortcut's primary modifier maps to Command, not the Mac's own ⌃.
 const FLAG_SHIFT = 1 << 17;
-const FLAG_CONTROL = 1 << 18;
 const FLAG_OPTION = 1 << 19;
 const FLAG_COMMAND = 1 << 20;
 

--- a/src/cocoa/keymap.js
+++ b/src/cocoa/keymap.js
@@ -18,7 +18,9 @@ import { keysymOf, MOD } from '../keysyms.js';
 const VK_KEYSYMS = new Map([
   [36, 0xff0d], // Return
   [48, 0xff09], // Tab
-  [49, 0x0020], // Space
+  // NOT space (kVK 49): space TYPES a character, so it goes through the
+  // character rule below and keeps its code point — a table entry here made
+  // `codepoint` undefined and a pressed spacebar inserted nothing.
   [51, 0xff08], // Delete (backspace)
   [53, 0xff1b], // Escape
   [76, 0xff8d], // KP_Enter

--- a/src/cocoa/keymap.js
+++ b/src/cocoa/keymap.js
@@ -1,0 +1,84 @@
+// macOS key events -> the renderer's keysym vocabulary (src/keysyms.js).
+//
+// The rule mirrors X's own: Latin-1 keysyms are their code points, everything
+// else printable is 0x01000000 + code point, and the editing/navigation keys
+// have fixed keysyms looked up here by kVK_* virtual key code. NSEvent's
+// three character views map onto the three keysym roles events.js reads:
+//
+//   charsBase    (modifiers stripped)  -> baseKeysym — what chords match
+//   charsShifted (only Shift applied)  -> keysym / codepoint — what was typed
+//
+// Function and editing keys type Unicode private-use characters (U+F700…),
+// which must never leak out as code points; the kVK table wins over the
+// character rule for exactly those.
+import { keysymOf, MOD } from '../keysyms.js';
+
+// kVK_* virtual key codes -> X keysyms, for the keys whose characters are
+// private-use or nothing at all.
+const VK_KEYSYMS = new Map([
+  [36, 0xff0d], // Return
+  [48, 0xff09], // Tab
+  [49, 0x0020], // Space
+  [51, 0xff08], // Delete (backspace)
+  [53, 0xff1b], // Escape
+  [76, 0xff8d], // KP_Enter
+  [115, 0xff50], // Home
+  [116, 0xff55], // Page Up
+  [117, 0xffff], // Forward Delete
+  [119, 0xff57], // End
+  [121, 0xff56], // Page Down
+  [123, 0xff51], // Left
+  [124, 0xff53], // Right
+  [125, 0xff54], // Down
+  [126, 0xff52], // Up
+  [114, 0xff63], // Help -> Insert
+  [122, 0xffbe], // F1
+  [120, 0xffbf], // F2
+  [99, 0xffc0], // F3
+  [118, 0xffc1], // F4
+  [96, 0xffc2], // F5
+  [97, 0xffc3], // F6
+  [98, 0xffc4], // F7
+  [100, 0xffc5], // F8
+  [101, 0xffc6], // F9
+  [109, 0xffc7], // F10
+  [103, 0xffc8], // F11
+  [111, 0xffc9], // F12
+]);
+
+const PRIVATE_USE = (cp) => cp >= 0xf700 && cp <= 0xf8ff;
+
+function keysymFromChars(chars) {
+  if (!chars) return 0;
+  const cp = chars.codePointAt(0);
+  if (cp == null || cp < 0x20 || PRIVATE_USE(cp)) return 0;
+  return keysymOf(String.fromCodePoint(cp));
+}
+
+/**
+ * The three key facts events.js reads off a native key event, from the raw
+ * node-calayers payload.
+ */
+export function decodeKey(ev) {
+  const fixed = VK_KEYSYMS.get(ev.keyCode);
+  if (fixed) {
+    return { keysym: fixed, baseKeysym: fixed, codepoint: undefined };
+  }
+  const keysym = keysymFromChars(ev.charsShifted);
+  const baseKeysym = keysymFromChars(ev.charsBase) || keysym;
+  const cp = ev.charsShifted?.codePointAt(0);
+  const codepoint =
+    cp != null && cp >= 0x20 && !PRIVATE_USE(cp) ? cp : undefined;
+  return { keysym: keysym || baseKeysym, baseKeysym, codepoint };
+}
+
+/** AppKit modifier booleans -> the X-style state mask events carry. */
+export function modifierMask(ev) {
+  let mask = 0;
+  if (ev.shift) mask |= MOD.Shift;
+  if (ev.capsLock) mask |= MOD.Lock;
+  if (ev.control) mask |= MOD.Control;
+  if (ev.option) mask |= MOD.Alt; // ⌥ is Alt (Mod1), the DOM's own mapping
+  if (ev.command) mask |= MOD.Super; // ⌘ is Super (Mod4) -> ev.metaKey
+  return mask;
+}

--- a/src/cocoa/keymap.js
+++ b/src/cocoa/keymap.js
@@ -59,7 +59,7 @@ function keysymFromChars(chars) {
 
 /**
  * The three key facts events.js reads off a native key event, from the raw
- * node-calayers payload.
+ * @windowkit/appkit payload.
  */
 export function decodeKey(ev) {
   const fixed = VK_KEYSYMS.get(ev.keyCode);

--- a/src/cocoa/native.js
+++ b/src/cocoa/native.js
@@ -1,14 +1,19 @@
-// The bridge to node-calayers — the macOS Cocoa/Core Animation backend's
-// native half. Resolved lazily so that importing react-x11 on Linux (or on
-// a mac without the addon installed) costs nothing; `createRoot` only walks
-// in here once the backend decision has landed on 'cocoa'.
+// The bridge to @windowkit/appkit — the macOS Cocoa/Core Animation
+// backend's native half. Resolved lazily so that importing react-x11 on
+// Linux (or on a mac without the addon installed) costs nothing;
+// `createRoot` only walks in here once the backend decision has landed on
+// 'cocoa'. That laziness is what lets the package be an *optional*
+// dependency: on Linux npm skips it (its `os` field is darwin-only) and
+// nothing here ever asks for it.
 //
-// Resolution order: `REACT_X11_CALAYERS_PATH` (a checkout, for development),
-// then the installed `node-calayers` package. The addon is CommonJS + a
-// .node binary, so `createRequire` is the honest loader.
+// Resolution order: `REACT_X11_CALAYERS_PATH` (a checkout, for
+// development), then the installed `@windowkit/appkit` package. The addon
+// is CommonJS + a .node binary, so `createRequire` is the honest loader.
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
+
+const PACKAGE = '@windowkit/appkit';
 
 let cached = null;
 
@@ -23,7 +28,7 @@ export function loadNative() {
   }
   const tried = [];
   const path = process.env.REACT_X11_CALAYERS_PATH;
-  for (const spec of [path, 'node-calayers'].filter(Boolean)) {
+  for (const spec of [path, PACKAGE].filter(Boolean)) {
     try {
       const mod = require(spec);
       // the package's index.js exports the raw addon as `native`; a direct
@@ -35,10 +40,10 @@ export function loadNative() {
     }
   }
   throw new Error(
-    'react-x11: the cocoa backend needs the node-calayers native bridge ' +
+    `react-x11: the cocoa backend needs the ${PACKAGE} native bridge ` +
       'and none could be loaded:\n' +
       tried.join('\n') +
-      '\nInstall it with `npm install node-calayers` (macOS, needs the ' +
+      `\nInstall it with \`npm install ${PACKAGE}\` (macOS, needs the ` +
       'Xcode command-line tools), or point REACT_X11_CALAYERS_PATH at a ' +
       'built checkout. To use X11 instead, set DISPLAY and pass ' +
       "createRoot({ backend: 'x11' }).",

--- a/src/cocoa/native.js
+++ b/src/cocoa/native.js
@@ -1,0 +1,46 @@
+// The bridge to node-calayers — the macOS Cocoa/Core Animation backend's
+// native half. Resolved lazily so that importing react-x11 on Linux (or on
+// a mac without the addon installed) costs nothing; `createRoot` only walks
+// in here once the backend decision has landed on 'cocoa'.
+//
+// Resolution order: `REACT_X11_CALAYERS_PATH` (a checkout, for development),
+// then the installed `node-calayers` package. The addon is CommonJS + a
+// .node binary, so `createRequire` is the honest loader.
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+let cached = null;
+
+export function loadNative() {
+  if (cached) return cached;
+  if (process.platform !== 'darwin') {
+    throw new Error(
+      "react-x11: the 'cocoa' backend is macOS-only. On this platform use " +
+        'the X11 backend (the default when DISPLAY is set), or pass ' +
+        "createRoot({ backend: 'x11' }).",
+    );
+  }
+  const tried = [];
+  const path = process.env.REACT_X11_CALAYERS_PATH;
+  for (const spec of [path, 'node-calayers'].filter(Boolean)) {
+    try {
+      const mod = require(spec);
+      // the package's index.js exports the raw addon as `native`; a direct
+      // path to a built checkout may be the addon itself
+      cached = mod.native ?? mod;
+      return cached;
+    } catch (err) {
+      tried.push(`  ${spec}: ${err.message}`);
+    }
+  }
+  throw new Error(
+    'react-x11: the cocoa backend needs the node-calayers native bridge ' +
+      'and none could be loaded:\n' +
+      tried.join('\n') +
+      '\nInstall it with `npm install node-calayers` (macOS, needs the ' +
+      'Xcode command-line tools), or point REACT_X11_CALAYERS_PATH at a ' +
+      'built checkout. To use X11 instead, set DISPLAY and pass ' +
+      "createRoot({ backend: 'x11' }).",
+  );
+}

--- a/src/cocoa/panehost.js
+++ b/src/cocoa/panehost.js
@@ -1,0 +1,50 @@
+// The host's half of a Cocoa frame pane: one sublayer over the window
+// content (the same stacking a glarea and an X11 foreign window get), whose
+// contents are whatever IOSurface the pane process last presented. The pane
+// owns its buffers and its drawing; this side owns the layer, the layout
+// and the input — CPU offloading, not isolation (docs/frame.md).
+export class CocoaPaneHost {
+  constructor(app, wnd) {
+    this.app = app;
+    this.wnd = wnd;
+    this._native = app._native;
+    this.layer = this._native.createLayer();
+    this._native.addSublayer(wnd._layer, this.layer);
+    this.destroyed = false;
+    this._rect = null;
+  }
+
+  /** Geometry in device px, the node's abs — points at the layer. */
+  setRect(rect) {
+    if (this.destroyed) return;
+    const s = this.wnd.scale;
+    const prev = this._rect;
+    if (
+      prev &&
+      prev.x === rect.x &&
+      prev.y === rect.y &&
+      prev.width === rect.width &&
+      prev.height === rect.height
+    ) {
+      return;
+    }
+    this._rect = { ...rect };
+    this._native.setLayerProps(this.layer, {
+      frame: [rect.x / s, rect.y / s, rect.width / s, rect.height / s],
+      zPosition: 1e7,
+      hidden: false,
+    });
+  }
+
+  /** A pane-present landed: scan out of the named shared surface. */
+  present(iosurfaceId) {
+    if (this.destroyed) return;
+    this._native.setLayerContentsIOSurface(this.layer, iosurfaceId);
+  }
+
+  destroy() {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this._native.removeFromSuperlayer(this.layer);
+  }
+}

--- a/src/cocoa/panewindow.js
+++ b/src/cocoa/panewindow.js
@@ -43,7 +43,9 @@ export class CocoaPaneWindow {
     this._surface = null;
     this._surfaceGen = 0;
     this._surfaceSize = null;
-    this._chain = null;
+    this._ring = null;
+    this._drawIndex = 0;
+    this._shownIndex = -1;
     this._ctx = null;
     this._dirty = false;
     this._flushDamage = 'full';
@@ -100,22 +102,35 @@ export class CocoaPaneWindow {
     return false;
   }
 
+  // Three buffers, not two. A pane is cross-process: the host keeps
+  // scanning the last buffer it was handed until it processes the next
+  // present message, and nothing here waits for that. With two buffers the
+  // next paint (and the catch-up copy) lands in the very buffer the host is
+  // still displaying — every present tears it, the flash. A third buffer is
+  // always at least two presents behind what the host shows, so the pane
+  // never writes a buffer the host might still be reading. Same-process
+  // windows need only two because Core Animation latches the front buffer.
+  static RING = 3;
+
   _ensureSurface() {
     const w = this.width;
     const h = this.height;
     if (
-      !this._surface ||
+      !this._ring ||
       this._surfaceSize?.width !== w ||
       this._surfaceSize?.height !== h
     ) {
-      const hadSurface = Boolean(this._surface);
-      const a = this._native.createSurfaceIOSurface(w, h, this.scale, true);
-      const b = this._native.createSurfaceIOSurface(w, h, this.scale, true);
-      this._chain = { back: a, front: b };
-      this._native.surfaceLock(a.handle);
-      this._native.ctxClearRect(a.handle, 0, 0, w, h);
-      this._native.ctxClearRect(b.handle, 0, 0, w, h);
-      this._surface = a.handle;
+      const hadSurface = Boolean(this._ring);
+      this._ring = [];
+      for (let i = 0; i < CocoaPaneWindow.RING; i += 1) {
+        const s = this._native.createSurfaceIOSurface(w, h, this.scale, true);
+        this._native.ctxClearRect(s.handle, 0, 0, w, h);
+        this._ring.push(s);
+      }
+      this._drawIndex = 0;
+      this._shownIndex = -1;
+      this._native.surfaceLock(this._ring[0].handle);
+      this._surface = this._ring[0].handle;
       this._surfaceSize = { width: w, height: h };
       this._surfaceGen++;
       this._flushDamage = 'full';
@@ -174,9 +189,9 @@ export class CocoaPaneWindow {
 
   /** Flip and tell the host, instead of touching any layer of our own. */
   present() {
-    if (!this._dirty || !this._surface || this.destroyed) return;
+    if (!this._dirty || !this._ring || this.destroyed) return;
     this._dirty = false;
-    const shown = this._chain.back;
+    const shown = this._ring[this._drawIndex];
     this._native.surfaceUnlock(shown.handle);
     const damage = this._flushDamage;
     this._flushDamage = null;
@@ -187,23 +202,24 @@ export class CocoaPaneWindow {
       width: this.width,
       height: this.height,
     });
-    this._chain.back = this._chain.front;
-    this._chain.front = shown;
-    this._surface = this._chain.back.handle;
+    this._shownIndex = this._drawIndex;
+    // the next buffer round the ring — two behind what the host will be
+    // showing, so it is safe to write even before the host has switched
+    this._drawIndex = (this._drawIndex + 1) % CocoaPaneWindow.RING;
+    const next = this._ring[this._drawIndex];
+    this._surface = next.handle;
     this._surfaceGen++;
-    this._native.surfaceLock(this._surface);
-    this._native.copySurfaceRegion(
-      shown.handle,
-      this._surface,
-      damage === 'full' || !damage
-        ? null
-        : damage.flatMap((r) => [
-            Math.floor(r.x),
-            Math.floor(r.y),
-            Math.ceil(r.width) + 1,
-            Math.ceil(r.height) + 1,
-          ]),
-    );
+    this._native.surfaceLock(next.handle);
+    // A full-repaint frame overwrites everything next, so no catch-up is
+    // needed. A partial frame paints only its damage, so `next` must first
+    // hold the last complete frame underneath — and the WHOLE of it, not
+    // just this frame's rects, because in a three-buffer ring `next` was
+    // last drawn two presents ago and is stale everywhere. A full copy of
+    // the just-shown buffer is the complete background; the safe target is
+    // what triple buffering buys.
+    if (damage !== 'full' && damage) {
+      this._native.copySurfaceRegion(shown.handle, next.handle, null);
+    }
   }
 
   snapshot() {
@@ -214,7 +230,7 @@ export class CocoaPaneWindow {
     if (this.destroyed) return;
     this.destroyed = true;
     this.app._unregisterWindow(this);
-    this._chain = null;
+    this._ring = null;
     this._surface = null;
   }
 }

--- a/src/cocoa/panewindow.js
+++ b/src/cocoa/panewindow.js
@@ -1,0 +1,220 @@
+// The pane process's "window" on the Cocoa backend — docs/frame.md's child
+// half, with the X server replaced by shared memory.
+//
+// On X11 a pane renders into a real window of its own and the host embeds
+// it; here there is no server to share, so the pane paints into IOSurfaces
+// created shared (kIOSurfaceIsGlobal) and presents by message: the host
+// looks the id up and points the pane's sublayer at it. Same swapchain
+// discipline as CocoaWindow — draw into back, flip, catch the new back up
+// by the damage — because the host's WindowServer reads the shown buffer
+// asynchronously either way.
+//
+// What the node tree sees is the ordinary window contract: getContext,
+// present, scrollRegion, noteFrameDamage, requestAnimationFrame, events
+// via emit. Geometry and input arrive as channel messages (the host owns
+// layout and hit-testing — this is CPU offloading, not isolation), and the
+// only outbound traffic is pane-present.
+import { CocoaContext2D } from './context2d.js';
+
+let nextPaneId = 1;
+
+export class CocoaPaneWindow {
+  constructor(app, attributes = {}) {
+    this.app = app;
+    this._native = app._native;
+    this.destroyed = false;
+    // a real-looking id so the shared ready/handshake path (which polls
+    // windowIdOf) fires; the host on this backend never dereferences it
+    this.windowId = 0xc0c0a000 + nextPaneId++;
+    // windowIdOf reads `.id` (the ntk Window field) — the ready handshake
+    // polls it through the pane's ref, so both spellings answer
+    this.id = this.windowId;
+    this.windowNumber = this.windowId;
+    this.scale = app.scale ?? 2;
+    this.width = Math.max(
+      1,
+      Math.round((attributes.width ?? 400) * this.scale),
+    );
+    this.height = Math.max(
+      1,
+      Math.round((attributes.height ?? 300) * this.scale),
+    );
+    this._listeners = new Map();
+    this._surface = null;
+    this._surfaceGen = 0;
+    this._surfaceSize = null;
+    this._chain = null;
+    this._ctx = null;
+    this._dirty = false;
+    this._flushDamage = 'full';
+    this._seq = 0;
+    this._reactX11Node = null;
+    app._registerWindow(this);
+  }
+
+  // --- the channel-facing half --------------------------------------------
+
+  /** The host's layout answer: logical size plus the display scale. */
+  setPaneSize(width, height, scale) {
+    if (this.destroyed) return;
+    if (scale) this.scale = scale;
+    const w = Math.max(1, Math.round(width * this.scale));
+    const h = Math.max(1, Math.round(height * this.scale));
+    if (w === this.width && h === this.height) return;
+    this.width = w;
+    this.height = h;
+    this.emit('resize', {
+      width: w,
+      height: h,
+      x: 0,
+      y: 0,
+      moved: false,
+      resized: true,
+    });
+  }
+
+  // --- the window contract -------------------------------------------------
+
+  on(name, fn) {
+    let set = this._listeners.get(name);
+    if (!set) this._listeners.set(name, (set = new Set()));
+    set.add(fn);
+    return () => set.delete(fn);
+  }
+
+  emit(name, ev) {
+    for (const fn of [...(this._listeners.get(name) ?? [])]) fn(ev);
+  }
+
+  map() {}
+
+  focus() {}
+
+  setTitle() {}
+
+  requestAnimationFrame(cb) {
+    return this.app._requestFrame(cb);
+  }
+
+  frameInFlight() {
+    return false;
+  }
+
+  _ensureSurface() {
+    const w = this.width;
+    const h = this.height;
+    if (
+      !this._surface ||
+      this._surfaceSize?.width !== w ||
+      this._surfaceSize?.height !== h
+    ) {
+      const hadSurface = Boolean(this._surface);
+      const a = this._native.createSurfaceIOSurface(w, h, this.scale, true);
+      const b = this._native.createSurfaceIOSurface(w, h, this.scale, true);
+      this._chain = { back: a, front: b };
+      this._native.surfaceLock(a.handle);
+      this._native.ctxClearRect(a.handle, 0, 0, w, h);
+      this._native.ctxClearRect(b.handle, 0, 0, w, h);
+      this._surface = a.handle;
+      this._surfaceSize = { width: w, height: h };
+      this._surfaceGen++;
+      this._flushDamage = 'full';
+      if (hadSurface) {
+        queueMicrotask(() => {
+          const node = this._reactX11Node;
+          if (node && !node.destroyed) node.invalidate(true, null, 'resize');
+        });
+      }
+    }
+    return this._surface;
+  }
+
+  getContext() {
+    if (!this._ctx) {
+      this._ctx = new CocoaContext2D(
+        this._native,
+        () => this._ensureSurface(),
+        () => {
+          this._ensureSurface();
+          return this._surfaceGen;
+        },
+      );
+      this._ctx._fonts = this.app.fonts;
+      this._ctx._onDirty = () => {
+        this._dirty = true;
+      };
+    }
+    return this._ctx;
+  }
+
+  noteFrameDamage(rects) {
+    if (this._flushDamage === 'full') return;
+    if (!rects) {
+      this._flushDamage = 'full';
+      return;
+    }
+    (this._flushDamage ??= []).push(...rects);
+  }
+
+  scrollRegion(rect, dx, dy) {
+    if (!this._surface) return false;
+    if (!Number.isInteger(dx) || !Number.isInteger(dy)) return false;
+    const moved = this._native.scrollSurface(
+      this._surface,
+      Math.round(rect.x),
+      Math.round(rect.y),
+      Math.round(rect.width),
+      Math.round(rect.height),
+      dx,
+      dy,
+    );
+    if (moved) this._dirty = true;
+    return Boolean(moved);
+  }
+
+  /** Flip and tell the host, instead of touching any layer of our own. */
+  present() {
+    if (!this._dirty || !this._surface || this.destroyed) return;
+    this._dirty = false;
+    const shown = this._chain.back;
+    this._native.surfaceUnlock(shown.handle);
+    const damage = this._flushDamage;
+    this._flushDamage = null;
+    this.app._paneSend?.({
+      type: 'pane-present',
+      seq: ++this._seq,
+      id: shown.iosurfaceId,
+      width: this.width,
+      height: this.height,
+    });
+    this._chain.back = this._chain.front;
+    this._chain.front = shown;
+    this._surface = this._chain.back.handle;
+    this._surfaceGen++;
+    this._native.surfaceLock(this._surface);
+    this._native.copySurfaceRegion(
+      shown.handle,
+      this._surface,
+      damage === 'full' || !damage
+        ? null
+        : damage.flatMap((r) => [
+            Math.floor(r.x),
+            Math.floor(r.y),
+            Math.ceil(r.width) + 1,
+            Math.ceil(r.height) + 1,
+          ]),
+    );
+  }
+
+  snapshot() {
+    return false; // no window of our own to capture; the host's shows it
+  }
+
+  destroy() {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this.app._unregisterWindow(this);
+    this._chain = null;
+    this._surface = null;
+  }
+}

--- a/src/cocoa/presenter.js
+++ b/src/cocoa/presenter.js
@@ -129,12 +129,29 @@ class ShapeRecorder {
     this._dash = Array.isArray(segments) ? segments : [];
   }
 
-  createLinearGradient() {
-    this.unsupported = true;
-    return { addColorStop() {} };
+  /**
+   * A recording gradient: SvgView resolves an SVG paint server to canvas
+   * gradient calls, and CAGradientLayer speaks the same vocabulary — a
+   * line, stops, colours — so a linear fill stays retained instead of
+   * pushing the whole document to the raster fallback. The line is mapped
+   * through the current matrix at creation, which is also where SvgView
+   * computes it.
+   */
+  createLinearGradient(x0, y0, x1, y1) {
+    return {
+      __shapeGradient: true,
+      a: this._apply(x0, y0),
+      b: this._apply(x1, y1),
+      stops: [],
+      addColorStop(offset, color) {
+        this.stops.push([offset, color]);
+      },
+    };
   }
 
   createRadialGradient() {
+    // CA's radial type does not speak canvas's two-circle geometry; wrong
+    // pixels are worse than rastered ones, so this stays the fallback.
     this.unsupported = true;
     return { addColorStop() {} };
   }
@@ -192,8 +209,33 @@ class ShapeRecorder {
 
   fill(path, rule) {
     const ops = this._pathOps(path);
-    const color = this._color(this.fillStyle);
-    if (!ops || !color || color[3] === 0) return;
+    if (!ops) return;
+    const style = this.fillStyle;
+    if (style && style.__shapeGradient) {
+      const stops = [];
+      for (const [offset, color] of style.stops) {
+        const parsed = cssColorStraight(String(color));
+        if (!parsed) continue;
+        const [r, g, b, a] = parsed;
+        stops.push([
+          Math.min(1, Math.max(0, offset)),
+          [r, g, b, a * this._alpha],
+        ]);
+      }
+      if (stops.length === 0) return;
+      stops.sort((p, q) => p[0] - q[0]);
+      this.ops.push({
+        kind: 'gradientFill',
+        path: ops,
+        a: style.a,
+        b: style.b,
+        stops,
+        rule: rule ?? 'nonzero',
+      });
+      return;
+    }
+    const color = this._color(style);
+    if (!color || color[3] === 0) return;
     this.ops.push({ kind: 'fill', path: ops, color, rule: rule ?? 'nonzero' });
   }
 
@@ -574,21 +616,55 @@ export class CocoaLayerPresenter {
     const native = this.native;
     visual.shapeLayers ??= [];
     while (visual.shapeLayers.length > recorder.ops.length) {
-      native.removeFromSuperlayer(visual.shapeLayers.pop());
+      native.removeFromSuperlayer(visual.shapeLayers.pop().layer);
     }
+    const w = rect.width / s;
+    const h = rect.height / s;
     recorder.ops.forEach((op, i) => {
-      let layer = visual.shapeLayers[i];
-      if (!layer) {
-        layer = native.createShapeLayer();
-        native.addSublayer(visual.layer, layer);
-        visual.shapeLayers[i] = layer;
+      const wantGradient = op.kind === 'gradientFill';
+      let entry = visual.shapeLayers[i];
+      if (entry && entry.gradient !== wantGradient) {
+        native.removeFromSuperlayer(entry.layer);
+        entry = null;
       }
-      native.setLayerProps(layer, {
-        frame: [0, 0, rect.width / s, rect.height / s],
+      if (!entry) {
+        entry = wantGradient
+          ? {
+              gradient: true,
+              layer: native.createGradientLayer(),
+              // the mask is not in the sublayer tree — CA owns the
+              // relationship, and the External's finalizer owns the memory
+              mask: native.createShapeLayer(),
+            }
+          : { gradient: false, layer: native.createShapeLayer() };
+        native.addSublayer(visual.layer, entry.layer);
+        visual.shapeLayers[i] = entry;
+      }
+      native.setLayerProps(entry.layer, {
+        frame: [0, 0, w, h],
         zPosition: i,
+        ...(wantGradient ? { mask: entry.mask } : {}),
       });
+      if (wantGradient) {
+        native.setLayerProps(entry.mask, { frame: [0, 0, w, h] });
+        native.setShapeProps(entry.mask, {
+          path: op.path,
+          fillColor: [0, 0, 0, 1],
+          strokeColor: null,
+          fillRule: op.rule,
+        });
+        // start/end are unit coordinates across the layer's bounds
+        native.setGradientProps(entry.layer, {
+          colors: op.stops.map(([, color]) => color),
+          locations: op.stops.map(([offset]) => offset),
+          startPoint: [op.a[0] / (w || 1), op.a[1] / (h || 1)],
+          endPoint: [op.b[0] / (w || 1), op.b[1] / (h || 1)],
+          type: 'axial',
+        });
+        return;
+      }
       native.setShapeProps(
-        layer,
+        entry.layer,
         op.kind === 'fill'
           ? {
               path: op.path,
@@ -611,8 +687,8 @@ export class CocoaLayerPresenter {
 
   _dropSvgShapes(visual) {
     if (!visual.shapeLayers) return;
-    for (const layer of visual.shapeLayers) {
-      this.native.removeFromSuperlayer(layer);
+    for (const entry of visual.shapeLayers) {
+      this.native.removeFromSuperlayer(entry.layer);
     }
     visual.shapeLayers = null;
     visual.shapeSignature = null;

--- a/src/cocoa/presenter.js
+++ b/src/cocoa/presenter.js
@@ -23,9 +23,194 @@
 // same "no bound named repaints everything" rule the X11 damage model has),
 // and geometry is re-diffed every frame because comparing four numbers is
 // cheaper than knowing.
+import { cssColorStraight } from 'ntk';
+
 import { CocoaContext2D } from './context2d.js';
 
 const RASTER_PAD = 2; // antialiasing/italic overhang outside the ink bounds
+
+/**
+ * A recording "context" for ntk's SvgView.draw: instead of rasterizing, it
+ * captures every fill/stroke as a flat op the bridge's CAShapeLayer path
+ * vocabulary can take verbatim. SVG is CA's native tongue — a path per
+ * layer, composited and tintable by the render server — and this recorder
+ * is what turns the existing, fully-debugged SvgView traversal into that
+ * without reimplementing SVG. Anything it cannot express (gradients,
+ * images, text, clips) flips `unsupported` and the node falls back to the
+ * raster visual, so correctness never depends on coverage.
+ */
+class ShapeRecorder {
+  constructor(matrix) {
+    this.ops = [];
+    this.unsupported = false;
+    this._stack = [];
+    this._m = matrix; // [a, b, c, d, e, f]
+    this._alpha = 1;
+    this.fillStyle = '#000';
+    this.strokeStyle = 'none';
+    this.lineWidth = 1;
+    this.lineCap = 'butt';
+    this.lineJoin = 'miter';
+    this._dash = [];
+  }
+
+  _apply(x, y) {
+    const [a, b, c, d, e, f] = this._m;
+    return [a * x + c * y + e, b * x + d * y + f];
+  }
+
+  _scaleFactor() {
+    const [a, b, c, d] = this._m;
+    return Math.sqrt(Math.abs(a * d - b * c));
+  }
+
+  save() {
+    this._stack.push({ m: [...this._m], alpha: this._alpha });
+  }
+
+  restore() {
+    const prev = this._stack.pop();
+    if (prev) {
+      this._m = prev.m;
+      this._alpha = prev.alpha;
+    }
+  }
+
+  translate(x, y) {
+    const [a, b, c, d, e, f] = this._m;
+    this._m = [a, b, c, d, a * x + c * y + e, b * x + d * y + f];
+  }
+
+  scale(x, y) {
+    const [a, b, c, d, e, f] = this._m;
+    this._m = [a * x, b * x, c * y, d * y, e, f];
+  }
+
+  rotate(angle) {
+    const cos = Math.cos(angle);
+    const sin = Math.sin(angle);
+    const [a, b, c, d, e, f] = this._m;
+    this._m = [
+      a * cos + c * sin,
+      b * cos + d * sin,
+      c * cos - a * sin,
+      d * cos - b * sin,
+      e,
+      f,
+    ];
+  }
+
+  transform(a2, b2, c2, d2, e2, f2) {
+    const [a, b, c, d, e, f] = this._m;
+    this._m = [
+      a * a2 + c * b2,
+      b * a2 + d * b2,
+      a * c2 + c * d2,
+      b * c2 + d * d2,
+      a * e2 + c * f2 + e,
+      b * e2 + d * f2 + f,
+    ];
+  }
+
+  getTransform() {
+    const [a, b, c, d, e, f] = this._m;
+    return { a, b, c, d, e, f };
+  }
+
+  set globalAlpha(value) {
+    if (typeof value === 'number') this._alpha = value;
+  }
+
+  get globalAlpha() {
+    return this._alpha;
+  }
+
+  setLineDash(segments) {
+    this._dash = Array.isArray(segments) ? segments : [];
+  }
+
+  createLinearGradient() {
+    this.unsupported = true;
+    return { addColorStop() {} };
+  }
+
+  createRadialGradient() {
+    this.unsupported = true;
+    return { addColorStop() {} };
+  }
+
+  drawImage() {
+    this.unsupported = true;
+  }
+
+  fillText() {
+    this.unsupported = true;
+  }
+
+  clip() {
+    this.unsupported = true;
+  }
+
+  _pathOps(path) {
+    const cmds = path?._cmds;
+    if (!Array.isArray(cmds)) {
+      this.unsupported = true;
+      return null;
+    }
+    const out = [];
+    for (const c of cmds) {
+      if (c.type === 'M') out.push(['move', ...this._apply(c.x, c.y)]);
+      else if (c.type === 'L') out.push(['line', ...this._apply(c.x, c.y)]);
+      else if (c.type === 'C')
+        out.push([
+          'curve',
+          ...this._apply(c.x1, c.y1),
+          ...this._apply(c.x2, c.y2),
+          ...this._apply(c.x, c.y),
+        ]);
+      else if (c.type === 'Q')
+        out.push([
+          'quad',
+          ...this._apply(c.x1, c.y1),
+          ...this._apply(c.x, c.y),
+        ]);
+      else if (c.type === 'Z') out.push(['close']);
+    }
+    return out;
+  }
+
+  _color(style) {
+    if (typeof style !== 'string') {
+      this.unsupported = true;
+      return null;
+    }
+    const parsed = cssColorStraight(style);
+    if (!parsed) return null;
+    const [r, g, b, a] = parsed;
+    return [r, g, b, a * this._alpha];
+  }
+
+  fill(path, rule) {
+    const ops = this._pathOps(path);
+    const color = this._color(this.fillStyle);
+    if (!ops || !color || color[3] === 0) return;
+    this.ops.push({ kind: 'fill', path: ops, color, rule: rule ?? 'nonzero' });
+  }
+
+  stroke(path) {
+    const ops = this._pathOps(path);
+    const color = this._color(this.strokeStyle);
+    if (!ops || !color || color[3] === 0) return;
+    this.ops.push({
+      kind: 'stroke',
+      path: ops,
+      color,
+      lineWidth: this.lineWidth * this._scaleFactor(),
+      lineCap: this.lineCap,
+      dash: this._dash.map((v) => v * this._scaleFactor()),
+    });
+  }
+}
 
 /** Paint everything a node draws itself — Node.paint minus the children. */
 function paintSelf(node, ctx) {
@@ -328,6 +513,87 @@ export class CocoaLayerPresenter {
     });
   }
 
+  /**
+   * `<svg>` as CAShapeLayers: record SvgView's own traversal through the
+   * ShapeRecorder and hand each captured fill/stroke to a shape layer. One
+   * icon becomes two or three server-composited paths instead of a bitmap;
+   * anything the recorder cannot express falls back to the raster visual.
+   * Returns whether the shape route handled the node.
+   */
+  _trySvgShapes(node, visual, rect, sizeChanged) {
+    const s = this.scale;
+    if (
+      !sizeChanged &&
+      !this.dirtyAll &&
+      !this.dirty.has(node) &&
+      visual.shapeSignature
+    ) {
+      return true; // shapes are current
+    }
+    const recorder = new ShapeRecorder([
+      1 / s,
+      0,
+      0,
+      1 / s,
+      -rect.x / s,
+      -rect.y / s,
+    ]);
+    try {
+      node.paintContent(recorder);
+    } catch {
+      return false;
+    }
+    if (recorder.unsupported) return false;
+    const signature = JSON.stringify(recorder.ops);
+    if (signature === visual.shapeSignature) return true;
+    visual.shapeSignature = signature;
+    const native = this.native;
+    visual.shapeLayers ??= [];
+    while (visual.shapeLayers.length > recorder.ops.length) {
+      native.removeFromSuperlayer(visual.shapeLayers.pop());
+    }
+    recorder.ops.forEach((op, i) => {
+      let layer = visual.shapeLayers[i];
+      if (!layer) {
+        layer = native.createShapeLayer();
+        native.addSublayer(visual.layer, layer);
+        visual.shapeLayers[i] = layer;
+      }
+      native.setLayerProps(layer, {
+        frame: [0, 0, rect.width / s, rect.height / s],
+        zPosition: i,
+      });
+      native.setShapeProps(
+        layer,
+        op.kind === 'fill'
+          ? {
+              path: op.path,
+              fillColor: op.color,
+              strokeColor: null,
+              fillRule: op.rule,
+            }
+          : {
+              path: op.path,
+              fillColor: null,
+              strokeColor: op.color,
+              lineWidth: op.lineWidth,
+              lineCap: op.lineCap,
+              ...(op.dash.length ? { lineDashPattern: op.dash } : {}),
+            },
+      );
+    });
+    return true;
+  }
+
+  _dropSvgShapes(visual) {
+    if (!visual.shapeLayers) return;
+    for (const layer of visual.shapeLayers) {
+      this.native.removeFromSuperlayer(layer);
+    }
+    visual.shapeLayers = null;
+    visual.shapeSignature = null;
+  }
+
   _syncRaster(node, visual, parentOrigin, order) {
     const bounds = node._ownPaintBounds
       ? node._ownPaintBounds()
@@ -364,6 +630,14 @@ export class CocoaLayerPresenter {
     }
     const sizeChanged =
       raster.width !== rect.width || raster.height !== rect.height;
+    if (node.kind === 'svg') {
+      if (this._trySvgShapes(node, visual, rect, sizeChanged)) {
+        raster.width = rect.width;
+        raster.height = rect.height;
+        return;
+      }
+      this._dropSvgShapes(visual);
+    }
     if (!this.dirtyAll && !this.dirty.has(node) && !sizeChanged) return;
     const ctx = raster.ensure(this, rect.width, rect.height, this.window.scale);
     ctx.save();

--- a/src/cocoa/presenter.js
+++ b/src/cocoa/presenter.js
@@ -1,0 +1,411 @@
+// The retained layer presenter — Tier L of docs/macos.md: one CALayer per
+// drawn node, React commits landing as property sets inside a single
+// disabled-actions CATransaction per frame, the WindowServer compositing.
+//
+// The node tree stays the model (layout, hit testing, events, focus); the
+// layer tree is write-only presentation. Three visual kinds cover the whole
+// vocabulary:
+//
+//   PropBox      a plain <box> — backgroundColor, uniform border, radius,
+//                clip — expressed entirely as layer properties. Zero raster.
+//   Raster       every painted-code node (text, textinput, canvas, svg,
+//                images, registered elements) and any box whose self-paint
+//                exceeds the property vocabulary (gradients, shadows,
+//                per-edge borders, focus outlines): its OWN paint replayed
+//                through the CG context into a bitmap layer. Children are
+//                never inside — they get visuals of their own.
+//   Bars         a scroller's scrollbars, rastered into an overlay sublayer
+//                above the content (zPosition keeps it on top).
+//
+// Sibling order is zPosition, assigned from the node's own paintOrder() —
+// no sublayer-list surgery, ever. Dirt arrives on the invalidate channel
+// (`noteInvalidate`): a node means that node, null means everything (the
+// same "no bound named repaints everything" rule the X11 damage model has),
+// and geometry is re-diffed every frame because comparing four numbers is
+// cheaper than knowing.
+import { CocoaContext2D } from './context2d.js';
+
+const RASTER_PAD = 2; // antialiasing/italic overhang outside the ink bounds
+
+/** Paint everything a node draws itself — Node.paint minus the children. */
+function paintSelf(node, ctx) {
+  node._paintShadow(ctx);
+  node._paintBackground(ctx);
+  node.paintContent(ctx);
+  node._paintBorder(ctx);
+  node._paintOutline(ctx);
+}
+
+const EDGE_PROPS = [
+  'borderTopColor',
+  'borderRightColor',
+  'borderBottomColor',
+  'borderLeftColor',
+  'borderStartColor',
+  'borderEndColor',
+  'borderTopWidth',
+  'borderRightWidth',
+  'borderBottomWidth',
+  'borderLeftWidth',
+  'borderStartWidth',
+  'borderEndWidth',
+];
+
+function stylePaintsPlain(node) {
+  if (node.kind !== 'box') return false;
+  const style = node.style ?? {};
+  if (style.backgroundImage || style.boxShadow || style.outlineWidth) {
+    return false;
+  }
+  for (const prop of EDGE_PROPS) if (style[prop] !== undefined) return false;
+  if (style.borderStyle !== undefined && style.borderStyle !== 'solid') {
+    return false;
+  }
+  if (style.borderWidth !== undefined && typeof style.borderWidth !== 'number')
+    return false;
+  return uniformRadius(style.borderRadius) !== null;
+}
+
+function uniformRadius(radius) {
+  if (radius === undefined) return 0;
+  if (typeof radius === 'number') return radius;
+  return null; // per-corner shapes go to raster
+}
+
+class Visual {
+  constructor(presenter, node) {
+    this.presenter = presenter;
+    this.node = node;
+    this.layer = presenter.native.createLayer();
+    this.parentVisual = null;
+    this.props = {}; // last-sent layer properties, diffed against
+  }
+
+  set(next) {
+    const diff = {};
+    let changed = false;
+    for (const key of Object.keys(next)) {
+      const value = next[key];
+      const prev = this.props[key];
+      const same = Array.isArray(value)
+        ? Array.isArray(prev) &&
+          prev.length === value.length &&
+          value.every((v, i) => v === prev[i])
+        : value === prev;
+      if (!same) {
+        diff[key] = value;
+        this.props[key] = value;
+        changed = true;
+      }
+    }
+    if (changed) this.presenter.native.setLayerProps(this.layer, diff);
+  }
+
+  attach(parentVisual) {
+    if (this.parentVisual === parentVisual) return;
+    this.presenter.native.removeFromSuperlayer(this.layer);
+    this.presenter.native.addSublayer(parentVisual.layer, this.layer);
+    this.parentVisual = parentVisual;
+    // a reparented layer re-sends everything: the new superlayer changes
+    // what `frame` is relative to
+    this.props = {};
+  }
+
+  destroy() {
+    this.presenter.native.removeFromSuperlayer(this.layer);
+  }
+}
+
+class RasterState {
+  constructor() {
+    this.surface = null;
+    this.gen = 0;
+    this.width = 0;
+    this.height = 0;
+    this.ctx = null;
+  }
+
+  ensure(presenter, width, height, scale) {
+    if (!this.surface || this.width !== width || this.height !== height) {
+      this.surface = presenter.native.createSurface(width, height, scale);
+      this.width = width;
+      this.height = height;
+      this.gen++;
+      if (!this.ctx) {
+        this.ctx = new CocoaContext2D(
+          presenter.native,
+          () => this.surface,
+          () => this.gen,
+        );
+        this.ctx._fonts = presenter.fonts;
+      }
+    }
+    return this.ctx;
+  }
+}
+
+export class CocoaLayerPresenter {
+  constructor(window) {
+    this.window = window;
+    this.native = window._native;
+    this.scale = window.scale;
+    this.fonts = window.app.fonts;
+    this.visuals = new Map(); // node -> Visual
+    this.rasters = new Map(); // node -> RasterState
+    this.bars = new Map(); // scroller node -> { layer, raster, props }
+    this.dirty = new Set();
+    this.dirtyAll = true; // first frame rasters everything
+    this.rootVisual = {
+      layer: window._layer,
+    };
+    this.rootBackground = undefined;
+  }
+
+  noteInvalidate(damage, layoutChanged) {
+    if (damage == null) {
+      this.dirtyAll = true;
+    } else if (damage.kind) {
+      this.dirty.add(damage);
+    } else if (layoutChanged) {
+      // A structural claim that names a rect (a child-list mutation's
+      // pre-arrangement bound) or nothing at all: the walk finds new and
+      // removed nodes by itself, but a SURVIVING node's content can have
+      // changed behind an unchanged box — a swapped text child in a
+      // flex-grown label was the shot that caught it — and a rect cannot
+      // say which node that was. Everything re-rasters; a scroll names its
+      // node and stays off this path.
+      this.dirtyAll = true;
+    }
+  }
+
+  /** The whole frame: one walk, one transaction, property diffs only. */
+  frame(windowNode) {
+    const native = this.native;
+    native.txBegin({ disableActions: true });
+    try {
+      this._syncWindowBackground(windowNode);
+      const seen = new Set();
+      this._syncChildren(windowNode, this.rootVisual, seen);
+      for (const [node, visual] of this.visuals) {
+        if (!seen.has(node)) {
+          visual.destroy();
+          this.visuals.delete(node);
+          this.rasters.delete(node);
+          const bars = this.bars.get(node);
+          if (bars) {
+            native.removeFromSuperlayer(bars.layer);
+            this.bars.delete(node);
+          }
+        }
+      }
+    } finally {
+      native.txCommit();
+    }
+    this.dirty.clear();
+    this.dirtyAll = false;
+  }
+
+  _syncWindowBackground(windowNode) {
+    const color = windowNode._windowBackground?.();
+    if (color === this.rootBackground) return;
+    this.rootBackground = color;
+    const parsed =
+      typeof color === 'string' ? this.window.app._parseColor(color) : null;
+    this.native.setLayerProps(this.rootVisual.layer, {
+      backgroundColor: parsed ?? [0, 0, 0, 0],
+    });
+  }
+
+  _syncChildren(node, parentVisual, seen) {
+    let order = 0;
+    for (const child of node.paintOrder()) {
+      if (child.isWindow || !child.yoga) continue; // popups are windows
+      this._syncNode(child, parentVisual, order++, seen);
+    }
+  }
+
+  _syncNode(node, parentVisual, order, seen) {
+    if (node.style?.display === 'none') return;
+    seen.add(node);
+    const wantsRaster = !stylePaintsPlain(node);
+    let visual = this.visuals.get(node);
+    if (visual && visual.isRaster !== wantsRaster) {
+      visual.destroy();
+      this.rasters.delete(node);
+      visual = null;
+    }
+    if (!visual) {
+      visual = new Visual(this, node);
+      visual.isRaster = wantsRaster;
+      this.visuals.set(node, visual);
+    }
+    visual.attach(parentVisual);
+
+    const parentOrigin = this._originOf(parentVisual);
+    if (wantsRaster) {
+      this._syncRaster(node, visual, parentOrigin, order);
+    } else {
+      this._syncPropBox(node, visual, parentOrigin, order);
+    }
+    // Children live inside the node's CONTENT box. A property box clips on
+    // its own layer; a rastered box whose layer covers its ink bounds needs
+    // an inner clip layer at the content box, or `overflow: hidden` under a
+    // gradient background would stop clipping.
+    let childHost = visual;
+    if (wantsRaster && node.clipsChildren?.()) {
+      childHost = this._ensureClipHost(node, visual);
+    } else if (visual.clipHost) {
+      this.native.removeFromSuperlayer(visual.clipHost.layer);
+      visual.clipHost = null;
+    }
+    if (node.isScroller?.()) this._syncBars(node, childHost);
+    // A <text>'s spans are painted by the paragraph's own raster
+    // (collectSpans walks them); giving them layers would draw them twice.
+    if (node.kind !== 'text') this._syncChildren(node, childHost, seen);
+  }
+
+  _ensureClipHost(node, visual) {
+    if (!visual.clipHost) {
+      const layer = this.native.createLayer();
+      this.native.addSublayer(visual.layer, layer);
+      visual.clipHost = { layer, props: {} };
+    }
+    const abs = node.abs;
+    const host = visual.clipHost;
+    const s = this.scale;
+    const frame = [
+      (abs.x - visual.origin.x) / s,
+      (abs.y - visual.origin.y) / s,
+      Math.max(0, abs.width) / s,
+      Math.max(0, abs.height) / s,
+    ];
+    const prev = host.props.frame;
+    if (!prev || prev.some((value, i) => value !== frame[i])) {
+      host.props.frame = frame;
+      this.native.setLayerProps(host.layer, {
+        frame,
+        masksToBounds: true,
+        zPosition: 0.5,
+      });
+    }
+    host.origin = { x: abs.x, y: abs.y };
+    return host;
+  }
+
+  _originOf(visual) {
+    return visual.origin ?? { x: 0, y: 0 };
+  }
+
+  _syncPropBox(node, visual, parentOrigin, order) {
+    const abs = node.abs;
+    const style = node.style ?? {};
+    const s = this.scale;
+    visual.origin = { x: abs.x, y: abs.y };
+    const border =
+      typeof style.borderWidth === 'number' ? style.borderWidth : 0;
+    visual.set({
+      frame: [
+        (abs.x - parentOrigin.x) / s,
+        (abs.y - parentOrigin.y) / s,
+        Math.max(0, abs.width) / s,
+        Math.max(0, abs.height) / s,
+      ],
+      zPosition: order,
+      hidden: Boolean(node.hidden),
+      masksToBounds: Boolean(node.clipsChildren?.()),
+      cornerRadius: (uniformRadius(style.borderRadius) ?? 0) / s,
+      backgroundColor: style.backgroundColor
+        ? (this.window.app._parseColor(String(style.backgroundColor)) ?? [
+            0, 0, 0, 0,
+          ])
+        : [0, 0, 0, 0],
+      borderWidth: border / s,
+      borderColor: style.borderColor
+        ? (this.window.app._parseColor(String(style.borderColor)) ?? [
+            0, 0, 0, 0,
+          ])
+        : [0, 0, 0, 0],
+    });
+  }
+
+  _syncRaster(node, visual, parentOrigin, order) {
+    const bounds = node._ownPaintBounds
+      ? node._ownPaintBounds()
+      : { ...node.abs };
+    const rect = {
+      x: Math.floor(bounds.x) - RASTER_PAD,
+      y: Math.floor(bounds.y) - RASTER_PAD,
+      width: Math.ceil(bounds.width) + RASTER_PAD * 2,
+      height: Math.ceil(bounds.height) + RASTER_PAD * 2,
+    };
+    // the layer's local origin is the ink rect's corner, and that is what
+    // children (and the clip host) position against
+    visual.origin = { x: rect.x, y: rect.y };
+    const s = this.scale;
+    visual.set({
+      frame: [
+        (rect.x - parentOrigin.x) / s,
+        (rect.y - parentOrigin.y) / s,
+        rect.width / s,
+        rect.height / s,
+      ],
+      zPosition: order,
+      hidden: Boolean(node.hidden),
+      // the layer covers the ink bounds; clipping (if any) belongs to the
+      // CONTENT box, which a raster self cannot express — scrolling
+      // containers that also raster keep clipping via a child guard below
+      masksToBounds: false,
+    });
+
+    let raster = this.rasters.get(node);
+    if (!raster) {
+      raster = new RasterState();
+      this.rasters.set(node, raster);
+    }
+    const sizeChanged =
+      raster.width !== rect.width || raster.height !== rect.height;
+    if (!this.dirtyAll && !this.dirty.has(node) && !sizeChanged) return;
+    const ctx = raster.ensure(this, rect.width, rect.height, this.window.scale);
+    ctx.save();
+    try {
+      ctx.clearRect(0, 0, rect.width, rect.height);
+      ctx.translate(-rect.x, -rect.y);
+      paintSelf(node, ctx);
+    } finally {
+      ctx.restore();
+    }
+    this.native.surfaceToLayer(raster.surface, visual.layer);
+  }
+
+  _syncBars(node, visual) {
+    const scrollbars = node._scrollbars?.() ?? [];
+    let bars = this.bars.get(node);
+    if (!scrollbars.length) {
+      if (bars) this.native.setLayerProps(bars.layer, { hidden: true });
+      return;
+    }
+    if (!bars) {
+      bars = { layer: this.native.createLayer(), raster: new RasterState() };
+      this.native.addSublayer(visual.layer, bars.layer);
+      this.bars.set(node, bars);
+    }
+    const abs = node.abs;
+    const width = Math.max(1, Math.ceil(abs.width));
+    const height = Math.max(1, Math.ceil(abs.height));
+    this.native.setLayerProps(bars.layer, {
+      frame: [0, 0, width / this.scale, height / this.scale],
+      zPosition: 1e6,
+      hidden: false,
+    });
+    const ctx = bars.raster.ensure(this, width, height, this.window.scale);
+    ctx.save();
+    try {
+      ctx.clearRect(0, 0, width, height);
+      ctx.translate(-abs.x, -abs.y);
+      node._paintScrollbars(ctx);
+    } finally {
+      ctx.restore();
+    }
+    this.native.surfaceToLayer(bars.raster.surface, bars.layer);
+  }
+}

--- a/src/cocoa/presenter.js
+++ b/src/cocoa/presenter.js
@@ -337,7 +337,7 @@ export class CocoaLayerPresenter {
     this.fonts = window.app.fonts;
     this.visuals = new Map(); // node -> Visual
     this.rasters = new Map(); // node -> RasterState
-    this.bars = new Map(); // scroller node -> { layer, raster, props }
+    this.bars = new Map(); // scroller node -> Map(axis -> { layer, raster })
     this.dirty = new Set();
     this.dirtyAll = true; // first frame rasters everything
     this.rootVisual = {
@@ -378,7 +378,9 @@ export class CocoaLayerPresenter {
           this.rasters.delete(node);
           const bars = this.bars.get(node);
           if (bars) {
-            native.removeFromSuperlayer(bars.layer);
+            for (const entry of bars.values()) {
+              native.removeFromSuperlayer(entry.layer);
+            }
             this.bars.delete(node);
           }
         }
@@ -673,40 +675,87 @@ export class CocoaLayerPresenter {
     this.native.surfaceToLayer(raster.surface, visual.layer);
   }
 
+  /**
+   * One thin overlay layer per scroll axis, rastered at the bar's own strip
+   * — never at the scroller's size. The strip is the track extent by the
+   * bar width plus an antialiasing pad, so a scroll frame re-rasters a few
+   * thousand pixels instead of the viewport: the first run of the
+   * presenter bench caught the full-size version costing more than the
+   * content it decorated (scripts/bench/presenters.js, `scroll`).
+   *
+   * The painter is still `_paintScrollbars` — both bars, one call — with
+   * the other axis's ink falling outside this strip's surface, where
+   * CoreGraphics clips it for free. Cheaper than a per-bar painting seam,
+   * and the corner case where both bars show costs two thin rasters
+   * instead of one bounding box that would be nearly the scroller again.
+   */
   _syncBars(node, visual) {
     const scrollbars = node._scrollbars?.() ?? [];
     let bars = this.bars.get(node);
     if (!scrollbars.length) {
-      if (bars) this.native.setLayerProps(bars.layer, { hidden: true });
+      if (bars) {
+        for (const entry of bars.values()) {
+          this.native.setLayerProps(entry.layer, { hidden: true });
+        }
+      }
       return;
     }
     if (!bars) {
-      bars = { layer: this.native.createLayer(), raster: new RasterState() };
-      this.native.addSublayer(visual.layer, bars.layer);
+      bars = new Map();
       this.bars.set(node, bars);
     }
-    const abs = node.abs;
-    const width = Math.max(1, Math.ceil(abs.width));
-    const height = Math.max(1, Math.ceil(abs.height));
-    this.native.setLayerProps(bars.layer, {
-      frame: [
-        (abs.x - visual.origin.x) / this.scale,
-        (abs.y - visual.origin.y) / this.scale,
-        width / this.scale,
-        height / this.scale,
-      ],
-      zPosition: 1e6,
-      hidden: false,
-    });
-    const ctx = bars.raster.ensure(this, width, height, this.window.scale);
-    ctx.save();
-    try {
-      ctx.clearRect(0, 0, width, height);
-      ctx.translate(-abs.x, -abs.y);
-      node._paintScrollbars(ctx);
-    } finally {
-      ctx.restore();
+    const s = this.scale;
+    const pad = Math.ceil(2 * s);
+    const seen = new Set();
+    for (const bar of scrollbars) {
+      seen.add(bar.axis);
+      let entry = bars.get(bar.axis);
+      if (!entry) {
+        entry = { layer: this.native.createLayer(), raster: new RasterState() };
+        this.native.addSublayer(visual.layer, entry.layer);
+        bars.set(bar.axis, entry);
+      }
+      const strip =
+        bar.axis === 'x'
+          ? {
+              x: bar.trackStart - pad,
+              y: bar.crossStart - pad,
+              width: bar.trackLength + 2 * pad,
+              height: bar.height + 2 * pad,
+            }
+          : {
+              x: bar.crossStart - pad,
+              y: bar.trackStart - pad,
+              width: bar.width + 2 * pad,
+              height: bar.trackLength + 2 * pad,
+            };
+      const width = Math.max(1, Math.ceil(strip.width));
+      const height = Math.max(1, Math.ceil(strip.height));
+      this.native.setLayerProps(entry.layer, {
+        frame: [
+          (strip.x - visual.origin.x) / s,
+          (strip.y - visual.origin.y) / s,
+          width / s,
+          height / s,
+        ],
+        zPosition: 1e6,
+        hidden: false,
+      });
+      const ctx = entry.raster.ensure(this, width, height, this.window.scale);
+      ctx.save();
+      try {
+        ctx.clearRect(0, 0, width, height);
+        ctx.translate(-strip.x, -strip.y);
+        node._paintScrollbars(ctx);
+      } finally {
+        ctx.restore();
+      }
+      this.native.surfaceToLayer(entry.raster.surface, entry.layer);
     }
-    this.native.surfaceToLayer(bars.raster.surface, bars.layer);
+    for (const [axis, entry] of bars) {
+      if (!seen.has(axis)) {
+        this.native.setLayerProps(entry.layer, { hidden: true });
+      }
+    }
   }
 }

--- a/src/cocoa/presenter.js
+++ b/src/cocoa/presenter.js
@@ -434,22 +434,26 @@ export class CocoaLayerPresenter {
     }
     // Children live inside the node's CONTENT box. A property box clips on
     // its own layer; a rastered box whose layer covers its ink bounds needs
-    // an inner clip layer at the content box, or `overflow: hidden` under a
-    // gradient background would stop clipping.
+    // an inner clip layer at the content box — and a SCROLLER always gets
+    // one, because the clip host is where Core Animation's native scroll
+    // lives: children sit at content coordinates and the host's bounds
+    // origin is the offset, so a wheel notch is one property set and the
+    // render server shifts what it already has.
+    const scroller = Boolean(node.isScroller?.());
     let childHost = visual;
-    if (wantsRaster && node.clipsChildren?.()) {
-      childHost = this._ensureClipHost(node, visual);
+    if (scroller || (wantsRaster && node.clipsChildren?.())) {
+      childHost = this._ensureClipHost(node, visual, scroller);
     } else if (visual.clipHost) {
       this.native.removeFromSuperlayer(visual.clipHost.layer);
       visual.clipHost = null;
     }
-    if (node.isScroller?.()) this._syncBars(node, childHost);
+    if (scroller) this._syncBars(node, visual);
     // A <text>'s spans are painted by the paragraph's own raster
     // (collectSpans walks them); giving them layers would draw them twice.
     if (node.kind !== 'text') this._syncChildren(node, childHost, seen);
   }
 
-  _ensureClipHost(node, visual) {
+  _ensureClipHost(node, visual, scroller = false) {
     if (!visual.clipHost) {
       const layer = this.native.createLayer();
       this.native.addSublayer(visual.layer, layer);
@@ -458,22 +462,40 @@ export class CocoaLayerPresenter {
     const abs = node.abs;
     const host = visual.clipHost;
     const s = this.scale;
+    const scrollX = scroller ? (node.scrollX ?? 0) : 0;
+    const scrollY = scroller ? (node.scrollY ?? 0) : 0;
     const frame = [
       (abs.x - visual.origin.x) / s,
       (abs.y - visual.origin.y) / s,
       Math.max(0, abs.width) / s,
       Math.max(0, abs.height) / s,
     ];
-    const prev = host.props.frame;
-    if (!prev || prev.some((value, i) => value !== frame[i])) {
-      host.props.frame = frame;
+    const bounds = [
+      scrollX / s,
+      scrollY / s,
+      Math.max(0, abs.width) / s,
+      Math.max(0, abs.height) / s,
+    ];
+    const prev = host.props;
+    const frameChanged =
+      !prev.frame || prev.frame.some((value, i) => value !== frame[i]);
+    const boundsChanged =
+      !prev.bounds || prev.bounds.some((value, i) => value !== bounds[i]);
+    if (frameChanged || boundsChanged) {
+      prev.frame = frame;
+      prev.bounds = bounds;
       this.native.setLayerProps(host.layer, {
         frame,
+        bounds,
         masksToBounds: true,
         zPosition: 0.5,
       });
     }
-    host.origin = { x: abs.x, y: abs.y };
+    // Children position against CONTENT coordinates: node.abs already has
+    // the scroll subtracted (absolutize applies the offset), so adding it
+    // back here means a pure scroll changes nothing about any child's
+    // frame — only the bounds origin above moves.
+    host.origin = { x: abs.x - scrollX, y: abs.y - scrollY };
     return host;
   }
 
@@ -497,7 +519,7 @@ export class CocoaLayerPresenter {
       ],
       zPosition: order,
       hidden: Boolean(node.hidden),
-      masksToBounds: Boolean(node.clipsChildren?.()),
+      masksToBounds: Boolean(node.clipsChildren?.()) && !node.isScroller?.(),
       cornerRadius: (uniformRadius(style.borderRadius) ?? 0) / s,
       backgroundColor: style.backgroundColor
         ? (this.window.app._parseColor(String(style.backgroundColor)) ?? [
@@ -667,7 +689,12 @@ export class CocoaLayerPresenter {
     const width = Math.max(1, Math.ceil(abs.width));
     const height = Math.max(1, Math.ceil(abs.height));
     this.native.setLayerProps(bars.layer, {
-      frame: [0, 0, width / this.scale, height / this.scale],
+      frame: [
+        (abs.x - visual.origin.x) / this.scale,
+        (abs.y - visual.origin.y) / this.scale,
+        width / this.scale,
+        height / this.scale,
+      ],
       zPosition: 1e6,
       hidden: false,
     });

--- a/src/cocoa/window.js
+++ b/src/cocoa/window.js
@@ -1,0 +1,265 @@
+// An ntk-window-shaped object over an NSWindow — the contract WindowNode
+// realizes against (src/testing/mock-app.js is the reference shape; this
+// file is that shape with real glass behind it).
+//
+// Units: everything crossing THIS object's boundary is device pixels, like
+// an X window — attributes, reported width/height, event coordinates,
+// _screenOrigin. The divide-by-scale into Cocoa points happens against the
+// native layer and nowhere above it.
+import { CocoaContext2D } from './context2d.js';
+
+let nextWindowId = 1;
+
+export class CocoaWindow {
+  constructor(app, attributes = {}) {
+    this.app = app;
+    this._native = app._native;
+    this.attributes = attributes;
+    this.scale = app.scale;
+    this.id = nextWindowId++;
+    this.X = app.X;
+    this.destroyed = false;
+    this.mapped = false;
+    this._handlers = new Map();
+    this._surface = null;
+    this._surfaceGen = 0;
+    this._ctx = null;
+    this._dirty = false;
+
+    const s = this.scale;
+    this.width = Math.max(1, Math.round(attributes.width ?? 640));
+    this.height = Math.max(1, Math.round(attributes.height ?? 480));
+    this.title = attributes.title ?? '';
+    this._popup = attributes.overrideRedirect === true;
+
+    const options = {
+      width: this.width / s,
+      height: this.height / s,
+      title: this.title,
+      kind: this._popup
+        ? 'popup'
+        : attributes.decorations === false
+          ? 'borderless'
+          : 'normal',
+      resizable: attributes.resizable !== false,
+    };
+    if (typeof attributes.x === 'number' && typeof attributes.y === 'number') {
+      options.x = attributes.x / s;
+      options.y = attributes.y / s;
+    }
+    if (attributes.backgroundColor !== undefined) {
+      const parsed = app._parseColor(attributes.backgroundColor);
+      if (parsed) options.backgroundColor = parsed;
+    }
+    // `transparent` arrives as a 32-bit visual request on X; here every
+    // window can composite, so the flag simply makes the glass clear.
+    if (attributes.visual !== undefined || attributes.transparent) {
+      options.opaque = false;
+    }
+    this._h = this._native.createWindow2(options);
+    this.windowNumber = this._native.windowNumber(this._h);
+    this._layer = this._native.windowRootLayer(this._h);
+    this._refreshOrigin();
+    if (attributes.sizeHints) this.setSizeHints(attributes.sizeHints);
+    app._registerWindow(this);
+  }
+
+  // --- events --------------------------------------------------------------
+
+  on(name, fn) {
+    let list = this._handlers.get(name);
+    if (!list) this._handlers.set(name, (list = []));
+    list.push(fn);
+  }
+
+  emit(name, ev) {
+    const list = this._handlers.get(name);
+    if (!list) return;
+    for (const fn of [...list]) fn(ev);
+  }
+
+  // --- geometry ------------------------------------------------------------
+
+  _refreshOrigin() {
+    const f = this._native.getWindowFrame(this._h);
+    const s = this.scale;
+    this.x = Math.round(f.x * s);
+    this.y = Math.round(f.y * s);
+    this._screenOrigin = { x: this.x, y: this.y };
+  }
+
+  /** Native geometry changed (delegate event, points). */
+  _nativeResized(points) {
+    const s = this.scale;
+    this.width = Math.max(1, Math.round(points.width * s));
+    this.height = Math.max(1, Math.round(points.height * s));
+    this.x = Math.round(points.x * s);
+    this.y = Math.round(points.y * s);
+    this._screenOrigin = { x: this.x, y: this.y };
+  }
+
+  resize(width, height) {
+    const s = this.scale;
+    this.width = Math.max(1, Math.round(width));
+    this.height = Math.max(1, Math.round(height));
+    this._native.setWindowFrame(
+      this._h,
+      null,
+      null,
+      this.width / s,
+      this.height / s,
+    );
+  }
+
+  move(x, y) {
+    const s = this.scale;
+    this.x = Math.round(x);
+    this.y = Math.round(y);
+    this._native.setWindowFrame(this._h, x / s, y / s, null, null);
+    this._screenOrigin = { x: this.x, y: this.y };
+  }
+
+  // --- lifecycle -----------------------------------------------------------
+
+  map() {
+    if (this.destroyed) return;
+    this.mapped = true;
+    // A popup must not take the keyboard from its owner; a toplevel's first
+    // map is the app coming up and takes it.
+    this._native.showWindow(this._h, !this._popup);
+    this._refreshOrigin();
+  }
+
+  unmap() {
+    if (this.destroyed) return;
+    this.mapped = false;
+    this._native.hideWindow(this._h);
+  }
+
+  destroy() {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this.mapped = false;
+    this.app._unregisterWindow(this);
+    this._native.destroyWindow2(this._h);
+    this._surface = null;
+  }
+
+  // --- window-manager-ish surface (feature-detected by nodes.js) -----------
+
+  setTitle(title) {
+    this.title = title;
+    this._native.setWindowTitle(this._h, String(title ?? ''));
+  }
+
+  setSizeHints(hints = {}) {
+    const s = this.scale;
+    const box = {};
+    if (typeof hints.minWidth === 'number') box.minWidth = hints.minWidth / s;
+    if (typeof hints.minHeight === 'number')
+      box.minHeight = hints.minHeight / s;
+    if (typeof hints.maxWidth === 'number') box.maxWidth = hints.maxWidth / s;
+    if (typeof hints.maxHeight === 'number')
+      box.maxHeight = hints.maxHeight / s;
+    if (Object.keys(box).length) this._native.setWindowMinMax(this._h, box);
+  }
+
+  setClass() {}
+
+  setWindowType() {}
+
+  setActions() {}
+
+  setTransientFor() {
+    // addChildWindow attachment comes with the layer presenter phase; a
+    // managed dialog already floats via its own window today.
+  }
+
+  setCursor(name) {
+    this._native.setCursor(String(name ?? 'default'));
+  }
+
+  grabPointer(options, cb) {
+    this.app._grabWindow = this;
+    cb?.(null, 0);
+  }
+
+  ungrabPointer() {
+    if (this.app._grabWindow === this) this.app._grabWindow = null;
+  }
+
+  selectXI2() {
+    // AppKit's precise scroll deltas are already flowing; nothing to select.
+    return Promise.resolve(true);
+  }
+
+  // --- drawing -------------------------------------------------------------
+
+  _ensureSurface() {
+    const w = this.width;
+    const h = this.height;
+    if (
+      !this._surface ||
+      this._surfaceSize?.width !== w ||
+      this._surfaceSize?.height !== h
+    ) {
+      this._surface = this._native.createSurface(w, h, this.scale);
+      this._surfaceSize = { width: w, height: h };
+      this._surfaceGen++;
+    }
+    return this._surface;
+  }
+
+  getContext() {
+    if (!this._ctx) {
+      this._ctx = new CocoaContext2D(
+        this._native,
+        () => this._ensureSurface(),
+        () => {
+          this._ensureSurface();
+          return this._surfaceGen;
+        },
+      );
+      this._ctx._fonts = this.app.fonts;
+      this._ctx._onDirty = () => {
+        this._dirty = true;
+      };
+    }
+    return this._ctx;
+  }
+
+  /** The scroll-blit fast path: move pixels inside the backing surface. */
+  scrollRegion(rect, dx, dy) {
+    if (!this._surface) return false;
+    this._native.scrollSurface(
+      this._surface,
+      Math.round(rect.x),
+      Math.round(rect.y),
+      Math.round(rect.width),
+      Math.round(rect.height),
+      Math.round(dx),
+      Math.round(dy),
+    );
+    this._dirty = true;
+    return true;
+  }
+
+  frameInFlight() {
+    return false;
+  }
+
+  requestAnimationFrame(cb) {
+    return this.app._requestFrame(cb);
+  }
+
+  /** Push the backing surface at the WindowServer, if anything drew. */
+  present() {
+    if (!this._dirty || !this._surface || this.destroyed) return;
+    this._dirty = false;
+    this._native.surfaceToLayer(this._surface, this._layer);
+  }
+
+  snapshot(path) {
+    return this._native.snapshotWindow(this._h, path);
+  }
+}

--- a/src/cocoa/window.js
+++ b/src/cocoa/window.js
@@ -7,6 +7,7 @@
 // _screenOrigin. The divide-by-scale into Cocoa points happens against the
 // native layer and nowhere above it.
 import { CocoaContext2D } from './context2d.js';
+import { CocoaLayerPresenter } from './presenter.js';
 
 let nextWindowId = 1;
 
@@ -47,20 +48,39 @@ export class CocoaWindow {
       options.x = attributes.x / s;
       options.y = attributes.y / s;
     }
-    if (attributes.backgroundColor !== undefined) {
-      const parsed = app._parseColor(attributes.backgroundColor);
-      if (parsed) options.backgroundColor = parsed;
-    }
     // `transparent` arrives as a 32-bit visual request on X; here every
     // window can composite, so the flag simply makes the glass clear.
-    if (attributes.visual !== undefined || attributes.transparent) {
-      options.opaque = false;
+    const transparent =
+      attributes.visual !== undefined || attributes.transparent;
+    if (transparent) options.opaque = false;
+    // The root layer's background is the "what newly exposed area shows"
+    // attribute an X window has — worth seeding on an opaque window so a
+    // resize flashes the right colour. On a transparent one it would sit
+    // OPAQUE behind the alpha the renderer paints (rounded corners went
+    // square behind it), and the honest ground there is nothing at all.
+    if (!transparent && attributes.backgroundColor !== undefined) {
+      const parsed = app._parseColor(attributes.backgroundColor);
+      if (parsed) options.backgroundColor = parsed;
     }
     this._h = this._native.createWindow2(options);
     this.windowNumber = this._native.windowNumber(this._h);
     this._layer = this._native.windowRootLayer(this._h);
     this._refreshOrigin();
     if (attributes.sizeHints) this.setSizeHints(attributes.sizeHints);
+
+    // The retained layer presenter (docs/macos.md Tier L), behind
+    // REACT_X11_COCOA_PRESENTER=layers while the surface path is the
+    // measured default. Its two hooks exist only in this mode, so the
+    // feature detection in nodes.js keeps the surface path byte-identical;
+    // the scroll blit is shadowed off because a layer frame has no backing
+    // bitmap to blit.
+    if (app._presenterMode === 'layers') {
+      this._presenter = new CocoaLayerPresenter(this);
+      this.presentFrame = (windowNode) => this._presenter.frame(windowNode);
+      this.noteInvalidate = (damage, layoutChanged) =>
+        this._presenter.noteInvalidate(damage, layoutChanged);
+      this.scrollRegion = null;
+    }
     app._registerWindow(this);
   }
 
@@ -254,6 +274,7 @@ export class CocoaWindow {
 
   /** Push the backing surface at the WindowServer, if anything drew. */
   present() {
+    if (this._presenter) return; // layers upload as they sync
     if (!this._dirty || !this._surface || this.destroyed) return;
     this._dirty = false;
     this._native.surfaceToLayer(this._surface, this._layer);

--- a/src/cocoa/window.js
+++ b/src/cocoa/window.js
@@ -222,6 +222,17 @@ export class CocoaWindow {
 
   // --- drawing -------------------------------------------------------------
 
+  /**
+   * The backing store is a two-buffer IOSurface swapchain: painters draw
+   * into the back buffer's CG bitmap, and presenting is `layer.contents =
+   * iosurface` — zero-copy, where the plain-surface path paid a
+   * window-sized CGImage copy per dirty frame (12ms at 900x700@2x — the
+   * presenter bench's whole surface-vs-layers gap on bounded damage).
+   * After a flip the new back buffer is one frame stale, so present copies
+   * the just-shown frame's damage across — a damage-sized memcpy replacing
+   * a window-sized upload. Falls back to the single plain surface where
+   * IOSurface creation fails.
+   */
   _ensureSurface() {
     const w = this.width;
     const h = this.height;
@@ -231,10 +242,22 @@ export class CocoaWindow {
       this._surfaceSize?.height !== h
     ) {
       const hadSurface = Boolean(this._surface);
-      this._surface = this._native.createSurface(w, h, this.scale);
-      this._native.ctxClearRect(this._surface, 0, 0, w, h);
+      this._chain = null;
+      try {
+        const a = this._native.createSurfaceIOSurface(w, h, this.scale);
+        const b = this._native.createSurfaceIOSurface(w, h, this.scale);
+        this._chain = { back: a, front: b };
+        this._native.surfaceLock(a.handle);
+        this._native.ctxClearRect(a.handle, 0, 0, w, h);
+        this._native.ctxClearRect(b.handle, 0, 0, w, h);
+        this._surface = a.handle;
+      } catch {
+        this._surface = this._native.createSurface(w, h, this.scale);
+        this._native.ctxClearRect(this._surface, 0, 0, w, h);
+      }
       this._surfaceSize = { width: w, height: h };
       this._surfaceGen++;
+      this._flushDamage = 'full';
       // A replaced backing surface holds nothing: whatever bounded damage
       // this frame carries, everything else on it would be garbage. Ask for
       // the full frame — one extra repaint per real resize, correctness for
@@ -247,6 +270,21 @@ export class CocoaWindow {
       }
     }
     return this._surface;
+  }
+
+  /**
+   * The per-flush painted rects (nodes.js's swapchain seam), accumulated
+   * until the next present: they are what the flip's catch-up copy covers.
+   * `'full'`/null collapse the set — one full copy beats bookkeeping.
+   */
+  noteFrameDamage(rects) {
+    if (this._presenter) return;
+    if (this._flushDamage === 'full') return;
+    if (!rects) {
+      this._flushDamage = 'full';
+      return;
+    }
+    (this._flushDamage ??= []).push(...rects);
   }
 
   getContext() {
@@ -300,6 +338,34 @@ export class CocoaWindow {
     if (this._presenter) return; // layers upload as they sync
     if (!this._dirty || !this._surface || this.destroyed) return;
     this._dirty = false;
+    if (this._chain) {
+      const shown = this._chain.back;
+      this._native.surfaceUnlock(shown.handle);
+      this._native.setLayerContentsIOSurface(this._layer, shown.iosurfaceId);
+      this._chain.back = this._chain.front;
+      this._chain.front = shown;
+      this._surface = this._chain.back.handle;
+      // a different native surface owns the graphics state now — the
+      // context re-syncs its sticky state off the generation
+      this._surfaceGen++;
+      this._native.surfaceLock(this._surface);
+      const damage = this._flushDamage;
+      this._flushDamage = null;
+      this._native.copySurfaceRegion(
+        shown.handle,
+        this._surface,
+        damage === 'full' || !damage
+          ? null
+          : damage.flatMap((r) => [
+              Math.floor(r.x),
+              Math.floor(r.y),
+              Math.ceil(r.width) + 1,
+              Math.ceil(r.height) + 1,
+            ]),
+      );
+      if (this._transparentWindow) this.app._shadowStale.add(this);
+      return;
+    }
     this._native.surfaceToLayer(this._surface, this._layer);
     // AppKit derives a transparent window's shadow from the content's
     // opaque shape and does not recompute it on repaints — a popup whose

--- a/src/cocoa/window.js
+++ b/src/cocoa/window.js
@@ -28,8 +28,14 @@ export class CocoaWindow {
     this._dirty = false;
 
     const s = this.scale;
-    this.width = Math.max(1, Math.round(attributes.width ?? 640));
-    this.height = Math.max(1, Math.round(attributes.height ?? 480));
+    // Snapped to whole POINTS: AppKit rounds window sizes to the point
+    // grid, so an odd device-pixel request comes back one short in the
+    // resize echo, the echo re-requests, and the backing surface churns —
+    // each swap an uninitialized canvas only the next damage rect repaints.
+    const snap = (v, fallback) =>
+      Math.max(1, Math.round(Math.max(1, Math.round(v ?? fallback)) / s) * s);
+    this.width = snap(attributes.width, 640);
+    this.height = snap(attributes.height, 480);
     this.title = attributes.title ?? '';
     this._popup = attributes.overrideRedirect === true;
 
@@ -52,6 +58,7 @@ export class CocoaWindow {
     // window can composite, so the flag simply makes the glass clear.
     const transparent =
       attributes.visual !== undefined || attributes.transparent;
+    this._transparentWindow = Boolean(transparent);
     if (transparent) options.opaque = false;
     // The root layer's background is the "what newly exposed area shows"
     // attribute an X window has — worth seeding on an opaque window so a
@@ -120,8 +127,8 @@ export class CocoaWindow {
 
   resize(width, height) {
     const s = this.scale;
-    this.width = Math.max(1, Math.round(width));
-    this.height = Math.max(1, Math.round(height));
+    this.width = Math.max(1, Math.round(Math.round(width) / s) * s);
+    this.height = Math.max(1, Math.round(Math.round(height) / s) * s);
     this._native.setWindowFrame(
       this._h,
       null,
@@ -223,9 +230,21 @@ export class CocoaWindow {
       this._surfaceSize?.width !== w ||
       this._surfaceSize?.height !== h
     ) {
+      const hadSurface = Boolean(this._surface);
       this._surface = this._native.createSurface(w, h, this.scale);
+      this._native.ctxClearRect(this._surface, 0, 0, w, h);
       this._surfaceSize = { width: w, height: h };
       this._surfaceGen++;
+      // A replaced backing surface holds nothing: whatever bounded damage
+      // this frame carries, everything else on it would be garbage. Ask for
+      // the full frame — one extra repaint per real resize, correctness for
+      // every pixel outside the damage rect.
+      if (hadSurface) {
+        queueMicrotask(() => {
+          const node = this._reactX11Node;
+          if (node && !node.destroyed) node.invalidate(true, null, 'resize');
+        });
+      }
     }
     return this._surface;
   }
@@ -278,6 +297,14 @@ export class CocoaWindow {
     if (!this._dirty || !this._surface || this.destroyed) return;
     this._dirty = false;
     this._native.surfaceToLayer(this._surface, this._layer);
+    // AppKit derives a transparent window's shadow from the content's
+    // opaque shape and does not recompute it on repaints — a popup whose
+    // card lands a frame after the map keeps the full-frame square AppKit
+    // guessed first. Recompute — but only once this present's transaction
+    // has actually flushed to the render server, or the recompute reads
+    // the frame BEFORE this one and keeps the square rim for menus that
+    // paint once and are only hovered after.
+    if (this._transparentWindow) this.app._shadowStale.add(this);
   }
 
   snapshot(path) {

--- a/src/cocoa/window.js
+++ b/src/cocoa/window.js
@@ -267,20 +267,24 @@ export class CocoaWindow {
     return this._ctx;
   }
 
-  /** The scroll-blit fast path: move pixels inside the backing surface. */
+  /** The scroll-blit fast path: move pixels inside the backing surface,
+   * with ntk Window.scrollRegion's contract — the shift happens WITHIN the
+   * rect, and a delta that leaves no surviving band reports false so the
+   * caller falls back to the plain repaint. */
   scrollRegion(rect, dx, dy) {
     if (!this._surface) return false;
-    this._native.scrollSurface(
+    if (!Number.isInteger(dx) || !Number.isInteger(dy)) return false;
+    const moved = this._native.scrollSurface(
       this._surface,
       Math.round(rect.x),
       Math.round(rect.y),
       Math.round(rect.width),
       Math.round(rect.height),
-      Math.round(dx),
-      Math.round(dy),
+      dx,
+      dy,
     );
-    this._dirty = true;
-    return true;
+    if (moved) this._dirty = true;
+    return Boolean(moved);
   }
 
   frameInFlight() {

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -3,6 +3,14 @@
 // build-step-free for consumers.
 
 import React from 'react';
+import { useAppOrNull } from '../appcontext.js';
+import {
+  ABS_FILL,
+  Bezel,
+  bezelNatural,
+  pressWash,
+  useNativeControls,
+} from './native.js';
 import { labelContent, useControl, useTheme } from './theme.js';
 
 const h = React.createElement;
@@ -46,6 +54,7 @@ export function Button({
   variant = 'solid',
   size = 'medium',
   disabled = false,
+  native,
   style,
   ...boxProps
 }) {
@@ -61,12 +70,71 @@ export function Button({
     throw new Error(`<Button size="${size}">: one of ${SIZES.join(', ')}`);
   }
   const theme = useTheme();
+  const app = useAppOrNull();
+  const nativeControls = useNativeControls(native);
   const { props, style: controlStyle } = useControl(disabled, onPress, {
     styled: true,
   });
   const solid = variant === 'solid';
   const ghost = variant === 'ghost';
   const small = size === 'small';
+
+  // Only the solid variant has a native counterpart: outline and ghost are
+  // deliberately chrome-less designs AppKit has no bezel for, so they keep
+  // the drawn rendering under every policy.
+  if (nativeControls && solid) {
+    const controlSize = small ? 'small' : 'regular';
+    const nat = bezelNatural(app, 'push', controlSize);
+    return h(
+      'box',
+      {
+        theme,
+        role: 'button',
+        ...props,
+        ...boxProps,
+        style: [
+          controlStyle,
+          {
+            flexDirection: 'row',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: small ? 6 : 8,
+            // AppKit's metrics, not the palette's: a native bezel is
+            // designed at its own height, and stretching it is what this
+            // mode exists to avoid. Width still follows the label.
+            height: nat.height,
+            paddingLeft: small ? 10 : 14,
+            paddingRight: small ? 10 : 14,
+            color: disabled
+              ? theme.textMuted
+              : primary
+                ? theme.accentText
+                : theme.text,
+          },
+          style,
+        ],
+      },
+      h(Bezel, {
+        kind: 'push',
+        controlSize,
+        enabled: !disabled,
+        // the Return-key accent fill is AppKit's own "default button"
+        isDefault: primary && !disabled,
+        style: ABS_FILL,
+      }),
+      labelContent(children ?? label),
+      // The press answer. Last child on purpose: `:active` marks the
+      // pressed node and its ancestors, and the topmost child is what the
+      // press lands on. No hover tint — AppKit buttons have none.
+      h('box', {
+        style: [
+          ABS_FILL,
+          { borderRadius: small ? 5 : 6 },
+          !disabled && { ':active': { backgroundColor: pressWash(theme) } },
+        ],
+      }),
+    );
+  }
   const background = !solid
     ? // `transparent` rather than the ground's colour: an outline or ghost
       // button sits on whatever it sits on — a toolbar, a card, a table row —

--- a/src/components/Checkbox.js
+++ b/src/components/Checkbox.js
@@ -3,8 +3,10 @@
 // build-step-free for consumers.
 
 import React from 'react';
+import { useAppOrNull } from '../appcontext.js';
 import { changeEvent } from './change.js';
 import { Icon } from './Icon.js';
+import { Bezel, bezelNatural, useNativeControls } from './native.js';
 import { focusRingStyle, labelContent, useControl, useTheme } from './theme.js';
 
 const h = React.createElement;
@@ -32,10 +34,13 @@ export function Checkbox({
   onChange,
   name,
   disabled = false,
+  native,
   style,
   ...boxProps
 }) {
   const theme = useTheme();
+  const app = useAppOrNull();
+  const nativeControls = useNativeControls(native);
   const {
     hover,
     focused,
@@ -45,6 +50,44 @@ export function Checkbox({
   } = useControl(disabled, () =>
     onChange?.(changeEvent('checkbox', name, !checked)),
   );
+
+  // Native mode swaps only the well: AppKit's checkbox bezel at its natural
+  // size, driven by the same React press state the drawn well uses — the
+  // pressed bezel is a re-keyed image, so the press still lands on the
+  // press frame. Focus keeps the shared ring (the one focus look the whole
+  // app has), and hover has no tint because AppKit checkboxes have none.
+  if (nativeControls) {
+    const nat = bezelNatural(app, 'checkbox');
+    return h(
+      'box',
+      {
+        theme,
+        role: 'checkbox',
+        'aria-checked': checked,
+        ...props,
+        ...boxProps,
+        style: [
+          controlStyle,
+          { flexDirection: 'row', alignItems: 'center', gap: 8 },
+          style,
+        ],
+      },
+      h(Bezel, {
+        kind: 'checkbox',
+        state: checked ? 1 : 0,
+        pressed,
+        enabled: !disabled,
+        style: {
+          width: nat.width,
+          height: nat.height,
+          ...focusRingStyle(theme, focused),
+        },
+      }),
+      labelContent(children ?? label, {
+        color: disabled ? theme.textMuted : theme.text,
+      }),
+    );
+  }
   const fill = disabled
     ? theme.textMuted
     : pressed

--- a/src/components/Radio.js
+++ b/src/components/Radio.js
@@ -3,7 +3,9 @@
 // build-step-free for consumers.
 
 import React, { useContext, useEffect, useMemo, useRef } from 'react';
+import { useAppOrNull } from '../appcontext.js';
 import { changeEvent } from './change.js';
+import { Bezel, bezelNatural, useNativeControls } from './native.js';
 import { focusRingStyle, labelContent, useControl, useTheme } from './theme.js';
 import { XK_DOWN, XK_LEFT, XK_RIGHT, XK_UP } from './keys.js';
 
@@ -52,8 +54,10 @@ export function RadioGroup({
   );
 }
 
-export function Radio({ value, children, label, disabled = false }) {
+export function Radio({ value, children, label, disabled = false, native }) {
   const theme = useTheme();
+  const app = useAppOrNull();
+  const nativeControls = useNativeControls(native);
   const group = useContext(RadioGroupContext);
   if (!group) {
     throw new Error('react-x11: <Radio> must be inside a <RadioGroup>');
@@ -78,6 +82,38 @@ export function Radio({ value, children, label, disabled = false }) {
       if (ev.keysym === XK_DOWN || ev.keysym === XK_RIGHT) group.move(1);
       else if (ev.keysym === XK_UP || ev.keysym === XK_LEFT) group.move(-1);
     };
+  }
+
+  // The well swap Checkbox documents, with the radio bezel.
+  if (nativeControls) {
+    const nat = bezelNatural(app, 'radio');
+    return h(
+      'box',
+      {
+        theme,
+        role: 'radio',
+        'aria-checked': selected,
+        ...props,
+        style: [
+          controlStyle,
+          { flexDirection: 'row', alignItems: 'center', gap: 8 },
+        ],
+      },
+      h(Bezel, {
+        kind: 'radio',
+        state: selected ? 1 : 0,
+        pressed,
+        enabled: !disabled,
+        style: {
+          width: nat.width,
+          height: nat.height,
+          ...focusRingStyle(theme, focused),
+        },
+      }),
+      labelContent(children ?? label, {
+        color: disabled ? theme.textMuted : theme.text,
+      }),
+    );
   }
   // The dot only appears on the release, so the well answers the press
   // itself — see Checkbox, both for the three-look treatment and for why

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -3,8 +3,16 @@
 // build-step-free for consumers.
 
 import React, { useEffect, useRef, useState } from 'react';
+import { useAppOrNull } from '../appcontext.js';
 import { capBand, capTrim, rowRadius, useTheme } from './theme.js';
 import { Icon } from './Icon.js';
+import {
+  ABS_FILL,
+  Bezel,
+  bezelNatural,
+  pressWash,
+  useNativeControls,
+} from './native.js';
 import { changeEvent } from './change.js';
 import {
   anchorArea,
@@ -184,10 +192,13 @@ export function Select({
   onChange,
   name,
   placeholder = 'Select…',
+  native,
   style,
   ...boxProps
 }) {
   const theme = useTheme();
+  const app = useAppOrNull();
+  const nativeControls = useNativeControls(native);
   const [open, setOpen] = useState(false);
   const [anchor, setAnchor] = useState(null);
   const [focused, setFocused] = useState(false);
@@ -336,25 +347,38 @@ export function Select({
       onKeyDown,
       ...boxProps,
       style: [
-        {
-          cursor: 'pointer',
-          flexDirection: 'row',
-          alignItems: 'center',
-          gap: 8,
-          // The vertical padding is the palette's, the same one a `<Button>`
-          // takes, because these are controls of one family and a form puts
-          // them in a row together. Horizontally it is its own, tighter
-          // number: a dropdown is a field with a value in it, not a button
-          // with a word centred on it.
-          paddingTop: theme.paddingY,
-          paddingBottom: theme.paddingY,
-          paddingLeft: 10,
-          paddingRight: 10,
-          borderWidth: theme.borderWidth,
-          borderRadius: theme.radius,
-          borderColor: focused || open ? theme.borderFocus : theme.border,
-          backgroundColor: theme.surface,
-        },
+        nativeControls
+          ? // The native popup bezel carries the border, the fill and the
+            // arrow capsule, so the trigger keeps only its row layout and
+            // AppKit's own height. The right padding clears the arrows.
+            {
+              cursor: 'pointer',
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: 8,
+              height: bezelNatural(app, 'popup').height,
+              paddingLeft: 10,
+              paddingRight: 26,
+            }
+          : {
+              cursor: 'pointer',
+              flexDirection: 'row',
+              alignItems: 'center',
+              gap: 8,
+              // The vertical padding is the palette's, the same one a `<Button>`
+              // takes, because these are controls of one family and a form puts
+              // them in a row together. Horizontally it is its own, tighter
+              // number: a dropdown is a field with a value in it, not a button
+              // with a word centred on it.
+              paddingTop: theme.paddingY,
+              paddingBottom: theme.paddingY,
+              paddingLeft: 10,
+              paddingRight: 10,
+              borderWidth: theme.borderWidth,
+              borderRadius: theme.radius,
+              borderColor: focused || open ? theme.borderFocus : theme.border,
+              backgroundColor: theme.surface,
+            },
         // Hover and press belong to the trigger while it is *shut*: they say
         // "this opens". Once the menu is down that is answered, and the
         // trigger's job is to read as one surface with the popup hanging off
@@ -364,13 +388,25 @@ export function Select({
         // state block always outranks the base style, so there is no colour
         // the open state could put in `backgroundColor` that `:hover` would
         // not overwrite. The only way for open to win is to not be competing.
-        !open && {
-          ':hover': { backgroundColor: theme.surfaceHover },
-          ':active': { backgroundColor: theme.surfaceActive },
-        },
+        // (In native mode the wash overlay below answers the press instead.)
+        !nativeControls &&
+          !open && {
+            ':hover': { backgroundColor: theme.surfaceHover },
+            ':active': { backgroundColor: theme.surfaceActive },
+          },
         style,
       ],
     },
+    // `pressed` while the menu is down: AppKit's popup answers being open
+    // by highlighting the arrow capsule, which is the open look this
+    // trigger otherwise lost with its borderFocus.
+    nativeControls &&
+      h(Bezel, {
+        kind: 'popup',
+        pressed: open,
+        enabled: true,
+        style: ABS_FILL,
+      }),
     h(
       'text',
       { style: [capTrim, { color: current ? theme.text : theme.textMuted }] },
@@ -382,11 +418,20 @@ export function Select({
     // row have to be one height, and they only are if the tallest thing in
     // each is measured the same way. A glyph taller than the cap band makes
     // the dropdown alone two pixels taller than everything next to it.
-    h(Icon, {
-      name: 'chevronDown',
-      size: capBand(theme.fontSize),
-      color: theme.textMuted,
-    }),
+    // The native bezel draws its own arrow capsule instead.
+    nativeControls
+      ? h('box', {
+          style: [
+            ABS_FILL,
+            { borderRadius: 6 },
+            !open && { ':active': { backgroundColor: pressWash(theme) } },
+          ],
+        })
+      : h(Icon, {
+          name: 'chevronDown',
+          size: capBand(theme.fontSize),
+          color: theme.textMuted,
+        }),
     open &&
       anchor &&
       h(

--- a/src/components/Slider.js
+++ b/src/components/Slider.js
@@ -3,6 +3,8 @@
 // build-step-free for consumers.
 
 import React, { useRef, useState } from 'react';
+import { useAppOrNull } from '../appcontext.js';
+import { Bezel, bezelNatural, useNativeControls } from './native.js';
 import { useTheme } from './theme.js';
 import { changeEvent } from './change.js';
 import {
@@ -42,10 +44,13 @@ export function Slider({
   name,
   disabled = false,
   height = 4,
+  native,
   style,
   ...boxProps
 }) {
   const theme = useTheme();
+  const app = useAppOrNull();
+  const nativeControls = useNativeControls(native);
   const [focused, setFocused] = useState(false);
   const [dragging, setDragging] = useState(false);
   const trackRef = useRef(null);
@@ -151,6 +156,60 @@ export function Slider({
           }
         },
       };
+
+  // The whole control as one NSSlider render, keyed by the value so a drag
+  // is a sequence of cached-or-rendered bezels. Pointer math, keyboard and
+  // a11y are the shared implementation above — the bezel is presentation.
+  //
+  // The *small* control size on purpose: its 16pt knob is exactly the
+  // drawn thumb's footprint, so rows laid out for the drawn slider fit,
+  // and the pointer math shares one thumb constant across both modes —
+  // the regular size's 20pt knob overflowed every compact row it met.
+  if (nativeControls) {
+    const nat = bezelNatural(app, 'slider', 'small');
+    return h(
+      'box',
+      {
+        theme,
+        role: 'slider',
+        'aria-valuenow': clamp(value),
+        'aria-valuemin': min,
+        'aria-valuemax': max,
+        'aria-orientation': 'horizontal',
+        ref: trackRef,
+        ...controlProps,
+        ...boxProps,
+        style: [
+          disabled || { cursor: 'pointer' },
+          {
+            height: nat.height,
+            minWidth: 0,
+            hitSlop: {
+              top: Math.max(0, (24 - nat.height) / 2),
+              bottom: Math.max(0, (24 - nat.height) / 2),
+            },
+          },
+          style,
+        ],
+      },
+      h(Bezel, {
+        kind: 'slider',
+        controlSize: 'small',
+        // quantized so a drag reuses cache entries instead of minting one
+        // per sub-pixel float; 400 steps is finer than any track is wide
+        value: Math.round(fraction * 400) / 400,
+        enabled: !disabled,
+        style: {
+          position: 'absolute',
+          top: 0,
+          right: 0,
+          bottom: 0,
+          left: 0,
+          pointerEvents: 'none',
+        },
+      }),
+    );
+  }
 
   return h(
     'box',

--- a/src/components/Switch.js
+++ b/src/components/Switch.js
@@ -3,8 +3,16 @@
 // build-step-free for consumers.
 
 import React from 'react';
+import { useAppOrNull } from '../appcontext.js';
 import { createStyles } from '../styles.js';
 import { changeEvent } from './change.js';
+import {
+  ABS_FILL,
+  Bezel,
+  bezelNatural,
+  pressWash,
+  useNativeControls,
+} from './native.js';
 import { useControl, useTheme } from './theme.js';
 
 const h = React.createElement;
@@ -74,15 +82,59 @@ export function Switch({
   onChange,
   name,
   disabled = false,
+  native,
   style,
   ...boxProps
 }) {
   const theme = useTheme();
+  const app = useAppOrNull();
+  const nativeControls = useNativeControls(native);
   const control = useControl(
     disabled,
     () => onChange?.(changeEvent('checkbox', name, !checked)),
     { styled: true },
   );
+
+  // NSSwitch's own pixels, on/off as two cached bezels. The knob slide is
+  // the fidelity this loses for now (docs/macos.md flags the switch as the
+  // one control worth revisiting if that disappoints); the press keeps its
+  // answer as the wash, since NSSwitch renders no pressed state offscreen.
+  if (nativeControls) {
+    const nat = bezelNatural(app, 'switch');
+    return h(
+      'box',
+      {
+        theme,
+        role: 'switch',
+        'aria-checked': checked,
+        ...control.props,
+        ...boxProps,
+        style: [
+          control.style,
+          {
+            width: nat.width,
+            height: nat.height,
+            hitSlop: Math.max(0, (24 - nat.height) / 2),
+          },
+          style,
+        ],
+      },
+      h(Bezel, {
+        kind: 'switch',
+        state: checked ? 1 : 0,
+        enabled: !disabled,
+        style: ABS_FILL,
+      }),
+      h('box', {
+        style: [
+          ABS_FILL,
+          { borderRadius: nat.height / 2 },
+          !disabled && { ':active': { backgroundColor: pressWash(theme) } },
+        ],
+      }),
+    );
+  }
+
   return h(
     'box',
     {

--- a/src/components/native.js
+++ b/src/components/native.js
@@ -1,0 +1,142 @@
+// The native half of the widget set (docs/macos.md §Native controls).
+//
+// House rule: **default native, seam out.** On a backend that renders the
+// platform's own control bezels — today the Cocoa backend — the core
+// controls wear AppKit's pixels while interaction, focus, keyboard and
+// a11y stay the shared implementation. The mechanism is a bezel *image*
+// drawn through the ordinary paint path, never an embedded platform view:
+// the press model, the focus rules and the event routing are behaviour this
+// project considers part of its identity, and a real NSControl would take
+// them over wholesale.
+//
+// The policy lives in the theme (`controls: 'auto' | 'native' | 'drawn'`),
+// because whether an app looks native is an app-identity decision, not a
+// per-node style. The per-instance escape hatch is `native={false}` on the
+// one custom-branded control — a themed `style` override is ignored by a
+// native bezel, so a control that names its own colours should also name
+// `native={false}` (the widgets keep today's drawn rendering everywhere the
+// bezel is off, so custom-designed apps lose nothing).
+
+import React, { useCallback } from 'react';
+import { useAppOrNull } from '../appcontext.js';
+import { useTheme } from './theme.js';
+
+const h = React.createElement;
+
+let warnedUnsupported = false;
+
+/**
+ * Should this control render the platform bezel? Combines the per-instance
+ * `native` prop, the theme's `controls` policy and the backend capability.
+ * An explicit `controls: 'native'` on a backend without the capability
+ * warns once and draws — erroring would make the same app code illegal on
+ * X11, which is the opposite of what a cross-backend widget set is for.
+ */
+export function useNativeControls(native) {
+  const app = useAppOrNull();
+  const theme = useTheme();
+  const capable = Boolean(app?.nativeBezels);
+  if (native === false) return false;
+  const mode = native === true ? 'native' : (theme.controls ?? 'auto');
+  if (mode === 'drawn') return false;
+  if (mode === 'native' && !capable && !warnedUnsupported) {
+    warnedUnsupported = true;
+    console.warn(
+      "react-x11: controls: 'native' — this backend has no native control " +
+        'rendering; the themed drawn controls are used instead.',
+    );
+  }
+  return capable;
+}
+
+/**
+ * The control's natural size in logical px — AppKit's own metrics, which
+ * native-mode layout adopts (a stretched checkbox is a wrong checkbox).
+ * `null` where there is no bezel store, so callers can guard in one step.
+ */
+export function bezelNatural(app, kind, controlSize = 'regular') {
+  return app?.nativeBezels?.natural(kind, controlSize) ?? null;
+}
+
+/** Absolute fill inside the control's box — where every bezel layer goes. */
+export const ABS_FILL = Object.freeze({
+  position: 'absolute',
+  top: 0,
+  right: 0,
+  bottom: 0,
+  left: 0,
+});
+
+/**
+ * The press wash — the one hover/press affordance native mode keeps.
+ * AppKit's controls have no hover state, so hover tints are deliberately
+ * absent here; the press is answered with a translucent wash over the
+ * bezel, dark on light and light on dark, the direction macOS itself steps
+ * a pressed control.
+ */
+export const pressWash = (theme) =>
+  theme.scheme === 'dark' ? 'rgba(255,255,255,0.12)' : 'rgba(0,0,0,0.07)';
+
+/**
+ * `<Bezel kind …states style>` — one AppKit bezel, rendered at exactly the
+ * box layout gives it. A `<canvas>` under the hood: the bezel comes out of
+ * the app's `BezelStore` (cached by every parameter that changes the
+ * pixels) and is blitted with the 9-arg `drawImage`, so a state change is a
+ * cache lookup and one blit, bounded to this node's damage.
+ */
+export function Bezel({
+  kind,
+  state = 0,
+  pressed = false,
+  enabled = true,
+  isDefault = false,
+  value,
+  controlSize = 'regular',
+  style,
+}) {
+  const app = useAppOrNull();
+  const theme = useTheme();
+  // The theme in force decides the bezel's appearance, not the desktop: a
+  // pinned-light app on a dark desktop gets light bezels beside its light
+  // surfaces. `scheme` is the palette's own statement of which it is.
+  const appearance = theme.scheme === 'dark' ? 'dark' : 'light';
+  const params = {
+    kind,
+    controlSize,
+    state: state ? 1 : 0,
+    pressed: Boolean(pressed),
+    enabled: Boolean(enabled),
+    isDefault: Boolean(isDefault),
+    appearance,
+  };
+  if (value !== undefined) params.value = value;
+  const sig = JSON.stringify(params);
+  const store = app?.nativeBezels;
+  // Keyed on the parameter signature so an unchanged bezel keeps its
+  // `onDraw` identity — CanvasNode invalidates when the closure changes,
+  // and a Button re-rendered by its parent must not repaint its bezel.
+  const onDraw = useCallback(
+    (ctx, info) => {
+      if (!store || !info.width || !info.height) return;
+      const bezel = store.get(
+        JSON.parse(sig),
+        info.width,
+        info.height,
+        info.scale,
+      );
+      ctx.drawImage(
+        { _surfaceHandle: bezel.surface },
+        bezel.sx,
+        bezel.sy,
+        bezel.sw,
+        bezel.sh,
+        0,
+        0,
+        info.width,
+        info.height,
+      );
+    },
+    [store, sig],
+  );
+  return h('canvas', { onDraw, style });
+}

--- a/src/editmenu.js
+++ b/src/editmenu.js
@@ -21,6 +21,11 @@
  */
 import { formatShortcut, isSeparator } from './menuitem.js';
 
+// Logical px, multiplied by the display scale where they are used: the
+// menu's text is measured and painted in device pixels (fonts are sized on
+// the device grid), so the chrome around it has to live on the same grid —
+// unscaled constants against scaled glyph ink is rows shorter than their
+// own labels (the compact-menu bug, first seen on the 2x Cocoa backend).
 const ROW_HEIGHT = 22;
 const SEPARATOR_HEIGHT = 7;
 const PAD_X = 10;
@@ -143,33 +148,35 @@ export function editMenuItems(actions = {}, { canPaste = true } = {}) {
  * @param {(text: string) => number|null} [measure] text width, or null when
  *   nothing can be measured yet
  */
-export function editMenuGeometry(items, measure) {
+export function editMenuGeometry(items, measure, scale = 1) {
   const widthOf = (text) => {
     if (!text) return 0;
     const w = measure?.(text);
     return typeof w === 'number' && w > 0
       ? w
-      : text.length * FALLBACK_CHAR_WIDTH;
+      : text.length * FALLBACK_CHAR_WIDTH * scale;
   };
   const rows = [];
-  let y = PAD_Y;
+  let y = PAD_Y * scale;
   let widest = 0;
   for (const item of items) {
     const separator = isSeparator(item);
     const shortcut = formatShortcut(item.shortcut);
-    const height = separator ? SEPARATOR_HEIGHT : ROW_HEIGHT;
+    const height = (separator ? SEPARATOR_HEIGHT : ROW_HEIGHT) * scale;
     rows.push({ ...item, separator, shortcut, y, height });
     y += height;
     if (separator) continue;
     widest = Math.max(
       widest,
-      widthOf(item.label) + (shortcut ? SHORTCUT_GAP + widthOf(shortcut) : 0),
+      widthOf(item.label) +
+        (shortcut ? SHORTCUT_GAP * scale + widthOf(shortcut) : 0),
     );
   }
   return {
     rows,
-    width: Math.max(MIN_WIDTH, Math.ceil(widest + PAD_X * 2)),
-    height: Math.ceil(y + PAD_Y),
+    scale,
+    width: Math.max(MIN_WIDTH * scale, Math.ceil(widest + PAD_X * scale * 2)),
+    height: Math.ceil(y + PAD_Y * scale),
   };
 }
 
@@ -220,12 +227,14 @@ export function paintEditMenu(
   { geometry, active = -1, colors = EDIT_MENU_COLORS, layoutOf, radius = 4 },
 ) {
   const { width, height, rows } = geometry;
+  const s = geometry.scale ?? 1;
+  const padX = PAD_X * s;
 
-  panelPath(ctx, width, height, radius);
+  panelPath(ctx, width, height, radius * s);
   ctx.fillStyle = colors.background;
   ctx.fill();
   ctx.strokeStyle = colors.border;
-  ctx.lineWidth = 1;
+  ctx.lineWidth = s;
   ctx.stroke();
 
   const label = (text, color, x, row) => {
@@ -241,10 +250,10 @@ export function paintEditMenu(
     if (row.separator) {
       ctx.fillStyle = colors.separator;
       ctx.fillRect(
-        PAD_X,
+        padX,
         Math.round(row.y + row.height / 2) + 0.5,
-        width - PAD_X * 2,
-        1,
+        width - padX * 2,
+        s,
       );
       continue;
     }
@@ -259,14 +268,14 @@ export function paintEditMenu(
       : on
         ? colors.highlightText
         : colors.text;
-    label(row.label, color, PAD_X, row);
+    label(row.label, color, padX, row);
     if (row.shortcut) {
       // the shortcut column stays quieter than the label, except in the
       // highlighted row where it has to stay legible on the accent
       const shortcutColor = on ? colors.highlightText : colors.dim;
       const layout = layoutOf?.(row.shortcut, shortcutColor);
       const w = layout?.width ?? 0;
-      label(row.shortcut, shortcutColor, width - PAD_X - w, row);
+      label(row.shortcut, shortcutColor, width - padX - w, row);
     }
   }
 }

--- a/src/frame/childmain.js
+++ b/src/frame/childmain.js
@@ -233,6 +233,15 @@ export async function runFrameChild(transport, options = {}) {
     return fatal('connect', err);
   }
 
+  // A backend that presents panes over shared memory instead of a server
+  // (the Cocoa one) takes the channel itself: geometry and input in,
+  // presents out. Feature-detected — the X11 pane path has a real window
+  // and a real server and needs none of this.
+  root.app.attachPaneChannel?.({
+    send: (msg) => transport.send(msg),
+    onMessage: (cb) => transport.onMessage(cb),
+  });
+
   let closing = false;
   const close = async () => {
     if (closing) return;

--- a/src/frame/index.js
+++ b/src/frame/index.js
@@ -481,19 +481,30 @@ function PaneHostView({
   focusable,
   onEmbedError,
 }) {
+  // `onEmbedError` is a fresh closure every host render (it captures
+  // setState), and the host ticks its own state many times a second — so it
+  // must not be an effect dependency, or the effect below tears the pane
+  // layer down and rebuilds it on every host render, and the gap between
+  // `host.destroy()` and the next present is a visible full-pane flash. A
+  // ref carries the latest callback into a once-per-session effect.
+  const embedErrorRef = useRef(onEmbedError);
+  embedErrorRef.current = onEmbedError;
+
   useEffect(() => {
     const s = session.current;
     const node = containerRef.current;
     const wnd = node?.root?.window;
     if (!s || !node || !wnd) {
-      onEmbedError?.(new Error('the pane region has no window to sit in'));
+      embedErrorRef.current?.(
+        new Error('the pane region has no window to sit in'),
+      );
       return undefined;
     }
     let host;
     try {
       host = app.createPaneHost(wnd);
     } catch (err) {
-      onEmbedError?.(err);
+      embedErrorRef.current?.(err);
       return undefined;
     }
     s.paneHost = host;
@@ -540,7 +551,7 @@ function PaneHostView({
       if (s.paneHost === host) s.paneHost = null;
       host.destroy();
     };
-  }, [app, session, containerRef, onEmbedError]);
+  }, [app, session, containerRef]);
 
   const forward = (name, data) => (ev) => {
     const s = session.current;

--- a/src/frame/index.js
+++ b/src/frame/index.js
@@ -43,6 +43,7 @@ import React, {
   useState,
 } from 'react';
 
+import { useAppOrNull } from '../appcontext.js';
 import { FrameEnv } from './env.js';
 import { CallbackTable, PROTOCOL } from './protocol.js';
 
@@ -220,6 +221,11 @@ export function Frame({
   ref,
 }) {
   const env = useContext(FrameEnv);
+  // A backend that composites panes from shared memory (Cocoa) declares
+  // itself with createPaneHost; everything else embeds the pane's real
+  // window through <foreign>, exactly as before.
+  const appOrNull = useAppOrNull();
+  const paneApp = appOrNull?.createPaneHost ? appOrNull : null;
   const [state, setState] = useState({
     phase: 'starting',
     windowId: null,
@@ -365,9 +371,10 @@ export function Frame({
     // rather than one frame of default before an update lands.
     const { props: p, env: e, bridge: b } = current.current;
     const node = containerRef.current;
+    const sc = node?.scale ?? 1;
     const rect = {
-      width: Math.max(1, Math.round(node?.abs?.width || 0)) || 400,
-      height: Math.max(1, Math.round(node?.abs?.height || 0)) || 300,
+      width: Math.round((node?.abs?.width || 0) / sc) || 400,
+      height: Math.round((node?.abs?.height || 0) / sc) || 300,
     };
     s.sent = { props: p, env: e, bridge: b };
     trySend({
@@ -413,6 +420,23 @@ export function Frame({
   }, [props, env, bridge, generation]);
 
   if (state.phase === 'running') {
+    if (paneApp) {
+      return h(PaneHostView, {
+        containerRef,
+        session,
+        app: paneApp,
+        style,
+        focusable,
+        onEmbedError: (err) => {
+          session.current?.shutdown?.();
+          setState({
+            phase: 'failed',
+            windowId: null,
+            error: Object.assign(err, { phase: 'embed' }),
+          });
+        },
+      });
+    }
     return h('foreign', {
       ref: containerRef,
       windowId: state.windowId,
@@ -441,4 +465,129 @@ export function Frame({
         : fallback
       : null,
   );
+}
+
+/**
+ * The Cocoa pane region: a box for layout, focus and input — hit-tested
+ * here, in the host, and forwarded over the channel — with a backend pane
+ * host object carrying the composited layer. The pane process presents by
+ * message; this view points the layer at each presented buffer.
+ */
+function PaneHostView({
+  containerRef,
+  session,
+  app,
+  style,
+  focusable,
+  onEmbedError,
+}) {
+  useEffect(() => {
+    const s = session.current;
+    const node = containerRef.current;
+    const wnd = node?.root?.window;
+    if (!s || !node || !wnd) {
+      onEmbedError?.(new Error('the pane region has no window to sit in'));
+      return undefined;
+    }
+    let host;
+    try {
+      host = app.createPaneHost(wnd);
+    } catch (err) {
+      onEmbedError?.(err);
+      return undefined;
+    }
+    s.paneHost = host;
+
+    // The pane's size is this box's laid-out size, told to the pane whenever
+    // it changes — the same absolutize hook a <foreign> child window uses
+    // (src/foreignnodes.js), because onViewport fires only for scrollers.
+    let sentSize = null;
+    const syncSize = () => {
+      host.setRect(node.abs);
+      const sc = node.scale ?? 1;
+      const width = Math.max(1, Math.round(node.abs.width / sc));
+      const height = Math.max(1, Math.round(node.abs.height / sc));
+      if (sentSize && sentSize.width === width && sentSize.height === height) {
+        return;
+      }
+      sentSize = { width, height };
+      s.trySend?.({ type: 'pane-rect', width, height, scale: sc });
+    };
+    const origAbsolutize = node.absolutize.bind(node);
+    node.absolutize = (ox, oy) => {
+      origAbsolutize(ox, oy);
+      syncSize();
+    };
+    const origShift = node._shiftAbs?.bind(node);
+    if (origShift) {
+      node._shiftAbs = (dx, dy) => {
+        origShift(dx, dy);
+        host.setRect(node.abs);
+      };
+    }
+    if (node.abs?.width) syncSize();
+
+    const off = s.transport.onMessage((msg) => {
+      if (msg?.type === 'pane-present') {
+        host.setRect(node.abs);
+        host.present(msg.id);
+      }
+    });
+    return () => {
+      off();
+      node.absolutize = origAbsolutize;
+      if (origShift) node._shiftAbs = origShift;
+      if (s.paneHost === host) s.paneHost = null;
+      host.destroy();
+    };
+  }, [app, session, containerRef, onEmbedError]);
+
+  const forward = (name, data) => (ev) => {
+    const s = session.current;
+    const node = containerRef.current;
+    if (!s || !node) return;
+    const sc = node.scale ?? 1;
+    const payload = {
+      x: Math.max(0, Math.round(ev.x * sc - node.abs.x)),
+      y: Math.max(0, Math.round(ev.y * sc - node.abs.y)),
+      rootx: Math.round(ev.x * sc),
+      rooty: Math.round(ev.y * sc),
+      buttons: ev.buttons ?? 0,
+      time: Date.now(),
+      ...data(ev),
+    };
+    try {
+      s.trySend?.({ type: 'pane-event', name, ev: payload });
+    } catch {
+      // the exit path owns the failure story
+    }
+  };
+
+  return h('box', {
+    ref: containerRef,
+    style,
+    focusable: focusable ?? true,
+    onMouseDown: forward('mousedown', (ev) => ({ keycode: ev.button ?? 1 })),
+    onMouseUp: forward('mouseup', (ev) => ({ keycode: ev.button ?? 1 })),
+    onMouseMove: forward('mousemove', () => ({})),
+    onWheel: forward('wheel', (ev) => ({
+      deltaX: ev.deltaX ?? 0,
+      deltaY: ev.deltaY ?? 0,
+      deltaMode: ev.deltaMode ?? 'line',
+      smooth: Boolean(ev.smooth),
+      source: 'forwarded',
+    })),
+    onKeyDown: forward('keydown', (ev) => ({
+      keysym: ev.keysym,
+      baseKeysym: ev.baseKeysym ?? ev.keysym,
+      codepoint: ev.codepoint,
+      keycode: ev.keycode ?? 0,
+    })),
+    onKeyUp: forward('keyup', (ev) => ({
+      keysym: ev.keysym,
+      baseKeysym: ev.baseKeysym ?? ev.keysym,
+      codepoint: ev.codepoint,
+      keycode: ev.keycode ?? 0,
+    })),
+  });
 }

--- a/src/globalmenu.js
+++ b/src/globalmenu.js
@@ -67,6 +67,7 @@ import {
   snapshot,
   IdAllocator,
 } from './dbusmenu.js';
+import { useAppOrNull } from './appcontext.js';
 import { useTopLevelWindow, windowIdOf } from './windowid.js';
 
 export const REGISTRAR_NAME = 'com.canonical.AppMenu.Registrar';
@@ -649,6 +650,7 @@ export function useGlobalMenu(
   { onSelect, onAboutToShow, enabled = true } = {},
 ) {
   const target = useTopLevelWindow();
+  const app = useAppOrNull();
   const [exported, setExported] = useState(false);
   const exportRef = useRef(null);
 
@@ -661,7 +663,7 @@ export function useGlobalMenu(
 
   useEffect(() => {
     if (!enabled) return undefined;
-    const owner = new GlobalMenuExport({
+    const config = {
       getMenus: () => live.current.menus ?? [],
       onSelect: (item) => {
         item.onSelect?.(item);
@@ -670,7 +672,13 @@ export function useGlobalMenu(
       onAboutToShow: (item) => live.current.onAboutToShow?.(item),
       target,
       onChange: setExported,
-    });
+    };
+    // The transport is the backend's where it has one — the Cocoa backend
+    // owns the macOS menu bar and answers immediately — and D-Bus with the
+    // registrar dance everywhere else. Same owner contract either way.
+    const owner = app?.createGlobalMenuExport
+      ? app.createGlobalMenuExport(config)
+      : new GlobalMenuExport(config);
     exportRef.current = owner;
     owner.start().catch(() => {});
     return () => {
@@ -678,7 +686,7 @@ export function useGlobalMenu(
       setExported(false);
       owner.stop().catch(() => {});
     };
-  }, [enabled, target]);
+  }, [enabled, target, app]);
 
   useEffect(() => {
     exportRef.current?.update(menus ?? []);

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -170,6 +170,16 @@ export interface ErrorInfo {
 }
 
 export interface RootOptions {
+  /**
+   * Which display system a root that opens its own connection talks to.
+   * `'auto'` (the default) uses the native Core Animation backend on macOS
+   * and X11 via `$DISPLAY` everywhere else; on a mac without the
+   * `node-calayers` bridge installed it falls back to X11. Naming
+   * `'cocoa'` makes the bridge required. `REACT_X11_BACKEND` overrides.
+   * Ignored when {@link RootOptions.app} is passed — a connection already
+   * is a backend.
+   */
+  backend?: 'auto' | 'x11' | 'cocoa';
   /** `':1'`, `'host:0.0'`, or a unix socket path. Defaults to `$DISPLAY`. */
   display?: string;
   /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -174,7 +174,7 @@ export interface RootOptions {
    * Which display system a root that opens its own connection talks to.
    * `'auto'` (the default) uses the native Core Animation backend on macOS
    * and X11 via `$DISPLAY` everywhere else; on a mac without the
-   * `node-calayers` bridge installed it falls back to X11. Naming
+   * `@windowkit/appkit` bridge installed it falls back to X11. Naming
    * `'cocoa'` makes the bridge required. `REACT_X11_BACKEND` overrides.
    * Ignored when {@link RootOptions.app} is passed — a connection already
    * is a backend.

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -10489,6 +10489,11 @@ export class WindowNode extends Scrollable(Node) {
       }
       (this._frameReasons ??= new Set()).add(reason);
     }
+    // A retained presenter keeps a per-node diff instead of damage rects,
+    // and this is the one channel every change already announces itself on
+    // (docs/macos.md §"One renderer, two presenters"). Feature-detected: an
+    // ntk window has no ear here and the X11 path is byte-identical.
+    this.window?.noteInvalidate?.(damage, layoutChanged, reason);
     if (layoutChanged) {
       this.needsLayout = true;
       // The content floors are measured from the tree, so anything that
@@ -10729,6 +10734,16 @@ export class WindowNode extends Scrollable(Node) {
       );
     }
     this._fullRepaintCause = null;
+    // A retained presenter takes the frame from here: the model half above —
+    // animations, layout, absolutize, the scroll offsets — is shared, and
+    // what changes per backend is how a frame reaches the screen. The damage
+    // list was still taken (its bookkeeping is what keeps the two paths one
+    // code) and is simply not consumed; the presenter diffs at the layer.
+    if (typeof this.window.presentFrame === 'function') {
+      this.window.presentFrame(this, damage);
+      this.app._reactX11Startup?.painted();
+      return;
+    }
     if (typeof this.window.getContext !== 'function') return; // headless mock
     // ntk getContext creates a fresh context (with window-event
     // subscriptions) on every call — cache one per window

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -6567,13 +6567,16 @@ export function openEditMenu(node, at, actions = {}) {
   if (items.length === 0) return;
 
   const style = node.resolvedTextStyle();
+  // `at` is `{x: ev.x, y: ev.y}` per the doc above — logical, like every
+  // coordinate a handler reads — and everything below is device: the
+  // geometry takes the scale so its chrome lands on the same grid as the
+  // device-sized text it measures.
+  const s = node.scale;
   const geometry = editMenuGeometry(
     items,
     (text) => app?.fonts?.layout(text, style)?.width,
+    s,
   );
-  // `at` is `{x: ev.x, y: ev.y}` per the doc above — logical, like every
-  // coordinate a handler reads — and the origin math below is device.
-  const s = node.scale;
   const deviceAt = at && {
     ...at,
     ...(Number.isFinite(at.x) && { x: at.x * s }),

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -10264,8 +10264,20 @@ export class WindowNode extends Scrollable(Node) {
    * before laying out. This is the whole reason a size query may carry
    * layout properties while a state block may not: it only ever runs inside
    * a layout pass the resize already required.
+   *
+   * Callers pass the size in device pixels — it comes off the window or out
+   * of yoga, and both live on the device grid — but `querySize` is stored
+   * in **logical** pixels, because that is the unit the thresholds were
+   * written in: `'@width >= 620'` sits in a style block next to `width:
+   * 620`, and the same number must mean the same thing. At scale 1 the two
+   * coincide, which is how comparing device pixels survived every 1x
+   * display it was ever run on and broke on the first retina one (every
+   * query read double, so none of them ever changed answer under a drag).
    */
-  _resolveSizeQueries(width, height) {
+  _resolveSizeQueries(deviceWidth, deviceHeight) {
+    const s = this.scale || 1;
+    const width = deviceWidth / s;
+    const height = deviceHeight / s;
     if (this._sizeQueryNodes.size === 0) {
       this.querySize = this.querySize ?? { width, height };
       return false;

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -10779,6 +10779,12 @@ export class WindowNode extends Scrollable(Node) {
     // after every region: an entry drawn in one damage rect must not be
     // evicted before the next rect of the same frame asks for it
     this._paintCache?.endFrame();
+    // The swapchain seam: a backend presenting from double buffers has to
+    // know exactly which pixels each flush touched — several flushes can
+    // land between two presents, so reading only the last frame's rects
+    // would leave the flipped-in back buffer stale where an earlier flush
+    // painted. Feature-detected like presentFrame; null means everything.
+    this.window.noteFrameDamage?.(damage ?? null);
     if (frameHook) {
       frameHook({
         root: this,

--- a/src/palette.js
+++ b/src/palette.js
@@ -222,6 +222,19 @@ export const DefaultTheme = {
   // than it looks next to a CSS padding for that reason: 12 here is about
   // what 8 came to once a typical face's ascent had been added on.
   paddingY: 12,
+  // Which scheme this palette *is* — 'light' or 'dark'. Not a colour but a
+  // fact about the colours, for the consumers that have to match them with
+  // something they do not paint themselves: the Cocoa backend picks the
+  // AppKit appearance its native control bezels are rendered in from this,
+  // so a pinned-light app gets light bezels on a dark desktop. A custom
+  // dark palette built over the light base should say `scheme: 'dark'`.
+  scheme: 'light',
+  // How the core controls render where the backend offers the platform's
+  // own: `'auto'` (native where supported — today the Cocoa backend),
+  // `'native'` (ask for it; warns and falls back to drawn where there is
+  // none) or `'drawn'` (always the themed rendering). Per-instance escape
+  // hatch: `native={false}` on the one custom-branded control.
+  controls: 'auto',
 };
 
 // Which pressed token is derived from which pair, when the palette does not
@@ -332,6 +345,7 @@ export function resolveTheme(value, base = DefaultTheme) {
  * theme after it gets to do.
  */
 export const DarkTheme = resolveTheme({
+  scheme: 'dark',
   // A near-black with a little blue in it rather than #000: pure black shows
   // every seam between a window and the widgets on it, and no desktop's dark
   // theme uses it.

--- a/src/styles.js
+++ b/src/styles.js
@@ -466,6 +466,11 @@ const isState = (key) => key.charCodeAt(0) === 58; /* ':' */
  * what a style can usefully ask about here is the window it is being laid
  * out in, not the screen.
  *
+ * The threshold is **logical** pixels, like every other number in a style
+ * block: `'@width >= 620'` flips where `width: 620` would fit, whatever
+ * the display scale (the window node divides its device size out before
+ * matching — `_resolveSizeQueries`).
+ *
  * Unlike a state block, a size query *may* set layout properties. That is
  * not an inconsistency: pointer state changes must never reflow the tree,
  * but a size query is only ever re-evaluated during a layout pass that a

--- a/test/native-controls.test.js
+++ b/test/native-controls.test.js
@@ -1,0 +1,135 @@
+// The native-controls policy (docs/macos.md §Native controls): the theme's
+// `controls` token and the per-instance `native` prop decide whether a
+// control wears the platform bezel, and a backend without the capability —
+// the mock, X11 — draws the themed controls under every setting. The bezels
+// themselves are Cocoa-only and verified against the live backend; what is
+// pinned here is the resolution logic and that the drawn path is untouched.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+
+import {
+  Button,
+  Checkbox,
+  Switch,
+  ThemeProvider,
+  createRoot,
+} from '../src/index.js';
+import { useSupports } from '../src/appcontext.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+const settle = async () => {
+  await tick();
+  await tick();
+};
+
+const rootOf = (app) => app.windows[0]._reactX11Node;
+
+async function mount(element, width = 400, height = 300) {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(h('window', { width, height }, element));
+  await settle();
+  return { app, x11Root, tree: rootOf(app) };
+}
+
+const findRole = (tree, role) => {
+  let found = null;
+  const walk = (n) => {
+    if (found) return;
+    if (n.props?.role === role) {
+      found = n;
+      return;
+    }
+    for (const c of n.children) if (!c.isWindow) walk(c);
+  };
+  walk(tree);
+  return found;
+};
+
+test('the mock backend draws the themed controls under every policy', async () => {
+  for (const controls of ['auto', 'native', 'drawn']) {
+    const { x11Root, tree } = await mount(
+      h(
+        ThemeProvider,
+        { value: { controls } },
+        h(Button, null, 'Save'),
+        h(Checkbox, { checked: true }, 'Agree'),
+        h(Switch, { checked: false }),
+      ),
+    );
+    const button = findRole(tree, 'button');
+    const checkbox = findRole(tree, 'checkbox');
+    const toggle = findRole(tree, 'switch');
+    // The drawn button is its label; the native one would carry a bezel
+    // <canvas> and a wash overlay box around it.
+    assert.deepStrictEqual(
+      [...button.children].map((c) => c.kind),
+      ['text'],
+      `controls: ${controls} — button gained non-drawn children`,
+    );
+    // the drawn well is a box; the native well is a canvas
+    assert.strictEqual(checkbox.children[0].kind, 'box');
+    // the drawn switch holds its sliding thumb box
+    assert.strictEqual(toggle.children[0].kind, 'box');
+    // the drawn look keeps its background answer
+    assert.ok(button.style.backgroundColor);
+    await x11Root.unmount();
+  }
+});
+
+test("controls: 'native' without the capability warns once, not per control", async () => {
+  const warnings = [];
+  const original = console.warn;
+  console.warn = (...args) => warnings.push(args.join(' '));
+  try {
+    const { x11Root } = await mount(
+      h(
+        ThemeProvider,
+        { value: { controls: 'native' } },
+        h(Button, null, 'One'),
+        h(Button, null, 'Two'),
+        h(Checkbox, {}, 'Three'),
+      ),
+    );
+    await x11Root.unmount();
+  } finally {
+    console.warn = original;
+  }
+  const relevant = warnings.filter((w) => w.includes('native control'));
+  // once across the whole app — module-level, deliberately, because the
+  // theme is app-wide and one line says everything three hundred would
+  assert.ok(relevant.length <= 1, `warned ${relevant.length} times`);
+});
+
+test('useSupports(nativeControls) answers false off the Cocoa backend', async () => {
+  let answer = null;
+  function Probe() {
+    answer = useSupports('nativeControls');
+    return null;
+  }
+  const { x11Root } = await mount(h(Probe));
+  assert.strictEqual(answer, false);
+  await x11Root.unmount();
+});
+
+test('native={false} is a complete opt-out whatever the theme says', async () => {
+  // On the mock this is indistinguishable from drawn-by-incapacity, so what
+  // is pinned is that the prop is accepted and renders the drawn control —
+  // the Cocoa half of the contract is verified against the live backend.
+  const { x11Root, tree } = await mount(
+    h(
+      ThemeProvider,
+      { value: { controls: 'native' } },
+      h(Button, { native: false }, 'Branded'),
+    ),
+  );
+  const button = findRole(tree, 'button');
+  assert.deepStrictEqual(
+    [...button.children].map((c) => c.kind),
+    ['text'],
+  );
+  await x11Root.unmount();
+});

--- a/test/size-queries.test.js
+++ b/test/size-queries.test.js
@@ -213,3 +213,30 @@ test('a query that hides a node takes it out of the paint too', async () => {
 
   await x11Root.unmount();
 });
+
+test('the threshold is logical pixels, whatever the display scale', async () => {
+  // An 800-logical window on a 2x display is 1600 device pixels. The
+  // threshold sits in a style block next to `width:`-style numbers, so it
+  // must read the logical size: `@width < 1000` matches here, where the
+  // device size would not. Comparing device pixels was invisible at scale
+  // 1 and made every query on a retina display read double — none of them
+  // ever changed answer under a resize.
+  const app = createMockApp();
+  const x11Root = await createRoot({ app, scale: 2 });
+  x11Root.render(
+    h(
+      'window',
+      { width: 800, height: 300 },
+      h('box', {
+        style: {
+          width: 10,
+          height: 10,
+          '@width < 1000': { backgroundColor: 'red' },
+        },
+      }),
+    ),
+  );
+  await tick();
+  assert.strictEqual(nodeOf(app).children[0].style.backgroundColor, 'red');
+  await x11Root.unmount();
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -1013,6 +1013,14 @@ async function main() {
   const borrowing = await createRoot({ app: root.app });
   await borrowing.unmount();
 
+  // the backend ladder: auto (the default), or one by name
+  const native = await createRoot({ backend: 'cocoa' });
+  await native.unmount();
+  await (await createRoot({ backend: 'auto' })).unmount();
+  await (await createRoot({ backend: 'x11', display: ':1' })).unmount();
+  // @ts-expect-error -- not a backend
+  await createRoot({ backend: 'wayland' });
+
   // startup notification: on by default, three ways to say otherwise
   const off = await createRoot({ startupNotification: false });
   await off.unmount();

--- a/website/scripts/browser-shims/zlib.js
+++ b/website/scripts/browser-shims/zlib.js
@@ -1,0 +1,18 @@
+// Browser stub for node's `zlib`. One caller: react-x11's Cocoa font
+// manager uses `inflateSync` to unwrap a `.woff` (zlib-compressed per table)
+// into sfnt bytes CoreText can read. That path exists only on the macOS
+// backend, which a browser never selects — but esbuild follows the dynamic
+// import of the cocoa backend and bundles it, so the specifier has to
+// resolve. Callable and throwing rather than silently empty: there is no
+// Core Animation in a web page, so this is never actually reached, and a
+// throw is the honest answer if it somehow were.
+const nope = () => {
+  throw new Error(
+    'react-x11 playground: node:zlib is used only by the macOS backend ' +
+      '(woff decoding) and has no browser implementation.',
+  );
+};
+
+module.exports = {
+  inflateSync: nope,
+};

--- a/website/scripts/build-demo-bundles.mjs
+++ b/website/scripts/build-demo-bundles.mjs
@@ -152,6 +152,11 @@ await esbuild.build({
     'node:path': path.join(shimsDir, 'path.js'),
     util: path.join(shimsDir, 'util.js'),
     'node:util': path.join(shimsDir, 'util.js'),
+    // the Cocoa font manager's woff decoder — macOS-backend only, never
+    // reached in a browser, but esbuild bundles the dynamically-imported
+    // cocoa backend and must resolve the specifier
+    zlib: path.join(shimsDir, 'zlib.js'),
+    'node:zlib': path.join(shimsDir, 'zlib.js'),
     // createRequire, used by react-x11 to read its own package.json
     module: path.join(shimsDir, 'module.js'),
     'node:module': path.join(shimsDir, 'module.js'),


### PR DESCRIPTION
A second backend for react-x11 that targets macOS directly — Core Animation layer trees, CoreText, IOSurface presentation — so the same app code runs on X11 and on a Mac with no XQuartz. `createRoot()` picks the backend automatically: darwin → cocoa, otherwise X11 (overridable with `REACT_X11_BACKEND` / `backend:`; a `display`/`stream` option keeps X11 under auto).

Design is in [docs/macos.md](docs/macos.md) (first commit). The short version: **one renderer, two presenters.** The node tree, layout, events, focus, damage model — all shared with X11. Only the leaf that turns a frame into pixels differs.

## What works

Every example in the fleet runs natively on macOS with no X server — chat, widgets, configurator, fonts, transparent, menus, tooltips, stress, theming, frame — verified by driving real NSEvents through the pump with snapshot/readback assertions.

- **2D rendering** — a canvas-shaped CG context (premultiplied BGRA, retina-correct), CoreText end to end (the font path never rasterises through fontkit), gradients, shadows, transforms, the scroll-blit fast path.
- **Two presenters.** `surface` (default) paints the window into one CG bitmap. `layers` (`REACT_X11_COCOA_PRESENTER=layers`) is retained Core Animation — one CALayer per drawn node, React commits landing as property sets, the WindowServer compositing. A benchmark (`npm run bench:presenters`) measures them head to head and breaks each frame into flush / upload / property-set / input-latency.
- **IOSurface swapchain presentation** — the window presents zero-copy (`layer.contents = iosurface` + a damage-sized catch-up) instead of a per-frame window-sized CGImage copy. Brought the surface presenter from ~42 to the frame-rate ceiling on bounded damage.
- **Native controls** — Button, Checkbox, Radio, Switch, Slider, Select wear AppKit's own bezels (offscreen NSCell rendering, cached and blitted through the paint path — no embedded NSView, so the press/focus/keyboard model stays the shared implementation). Policy is `ThemeProvider`'s `controls: 'auto' | 'native' | 'drawn'`, with a `native={false}` per-instance escape hatch; `useSupports('nativeControls')` reports it.
- **The global menu** — `MenuBar` renders in the real macOS menu bar, reusing the Linux global-menu snapshot/id machinery verbatim (a backend transport seam, so `useGlobalMenu` can't tell). Item icons cross too (SF Symbol names + PNG bytes).
- **`<glarea>`** — GL into a CALayer with no X server, through x11-dri's IOSurface render targets (0.7.0). The direct-GL shader lab and the configurator's live 3D laptop both run; the API-ladder prop (`gl` / `gles` / `webgpu`) is in place with CGL live today.
- **`<Frame>` CPU-offload** — a pane runs in its own process, painting into shared IOSurfaces the host composites, so React/yoga/paint move off the main thread. The X11 `<foreign>` embedding path is byte-identical (feature-detected); verified on XQuartz.
- **SVG as retained CA** — in layers mode `<svg>` (including linear gradients) stays CAShapeLayers/CAGradientLayers, so an icon re-tint is a property set with zero rasters.

## Native bridge

The macOS native half is the published **[@windowkit/appkit](https://www.npmjs.com/package/@windowkit/appkit)** addon (Core Animation / CoreText / IOSurface / NSMenu / control bezels). react-x11 will likely move under `@windowkit/react` later; for now both backends live here.

## Dependencies stay optional — Linux installs cleanly

`@windowkit/appkit` (macOS bridge) and `x11-dri ^0.7.0` (the GL addon, for glarea targets) are **optionalDependencies**, the mirror of `dbus-native`. appkit declares `os: [darwin]`, so npm installs it on a Mac and silently skips it on Linux — no `EBADPLATFORM`, no failed install for a Linux client. Both are loaded lazily (only once the backend resolves to cocoa, or a `<glarea>` mounts), so a Linux import never asks for a package that is not there.

## Testing

Suite stays green: **1700 pass**, plus the 6 documented macOS-only appearance-ladder cases that answer where the tests expect Linux silence (they pass on CI, which is Linux). Lint, typecheck and prettier clean. The Cocoa backend is exercised live — real NSEvents through the pump, snapshot and pixel-readback assertions — throughout.

## Not in this PR (RFC phases 4–5 remainders)

Nested `<window>`, `<image>`/foreign embedding on cocoa, DnD, IME, and the CFRunLoop drain (the run loop is the timer-pump option 1 by design — measure, then improve) are follow-ups per docs/macos.md.