### PR TITLE
fix(types): declare Node.scale and renderX11's scale, and say which rects are device

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -1251,7 +1251,8 @@ node.textRangeRects(4, 14); // the bands a highlight over [4, 14) fills
 
 Indices are **code points**, not UTF-16 units, so an emoji is one position.
 Rectangles are in the owning window's coordinates — the same space as
-`abs`, `contentBox()` and a mouse event's `x`/`y`. `textRangeRects` returns
+`abs` and `contentBox()`, which is device pixels; a mouse event's `x`/`y`
+are logical ([scale.md](scale.md)). `textRangeRects` returns
 one band per line _and_ one per direction run inside a line: a range that
 crosses from Latin into Arabic covers two separate stretches of pixels, and
 a single rectangle drawn between two caret positions would paint over text

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -130,6 +130,15 @@ And what you read:
   layout.
 - `this.contentBox()` — `abs` inset by the border and the padding: where the
   content goes, and where every built-in draws.
+- `this.scale` — device pixels per logical pixel ([scale.md](scale.md)).
+  `this.style`, `this.abs`, `contentBox()`, the paint context, every rect you
+  hand `invalidate` or `scrollContents` and every rect you report to a screen
+  reader are device pixels already; a synthetic event's `x`/`y` are logical,
+  so a hit test against `abs` reads `ev.nativeEvent.x`/`y`, or multiplies.
+  On a 1x display the two units coincide — which is exactly how an element
+  that mixes them passes every headless test and then hovers, drags and
+  frames at half the distance on a retina panel.
+  `renderX11(element, { scale: 2 })` is the test that catches it.
 - `this.resolvedTextStyle()` — the text style this node resolves to, ready to
   hand to `app.fonts.layout` (below).
 - `this.direction` — which way this node reads, resolved: `'ltr'` or
@@ -272,9 +281,10 @@ class LogViewNode extends Node {
 **Two spaces, and both are the ones already in use.** Indices are **code
 points** — the space ntk's `TextLayout.caretPosition`/`indexAt` speak, so an
 emoji is one position and not two — and rectangles are in the **owning
-window's** coordinates, the same as `abs`, `contentBox()` and a mouse
-event's `x`/`y`. An element that answers in its own local coordinates is one
-whose highlight is drawn somewhere else on the screen.
+window's** coordinates, the same as `abs` and `contentBox()`: device pixels.
+(A mouse event's `x`/`y` are the same coordinates in logical pixels —
+[scale.md](scale.md).) An element that answers in its own local coordinates
+is one whose highlight is drawn somewhere else on the screen.
 
 **Answer from what you draw.** `<text>` computes its layout and its origin
 in one place and uses it for painting and for all four accessors, because a
@@ -1085,8 +1095,8 @@ than the one exception to it. Both are opt-in, and both keep core's answer
 when you say nothing.
 
 **Painting: `paintDamage()`.** The rect this pass covers, in the owning
-window's coordinates — the same space as `abs` and a mouse event's `x`/`y` —
-or `null` when the frame is unbounded and everything has to be drawn. Cull
+window's coordinates — the same space as `abs`, in device pixels — or `null`
+when the frame is unbounded and everything has to be drawn. Cull
 against it exactly as core culls the tree:
 
 ```js
@@ -1236,9 +1246,9 @@ Four things worth knowing, in the order they bite:
 **`dx`/`dy` are how far the pixels moved.** The sense `Surface.copyWithin`
 and ntk's `scrollRegion` use, not a scroll offset's: panning the scene right
 by ten is `dx: 10`, and the exposed band is down the left edge. Both whole
-pixels — a fractional shift is not a copy — and `rect` in window coordinates
-(the same space as `abs`, `contentBox()` and an event's `x`/`y`) and inside
-your node.
+device pixels — a fractional shift is not a copy — and `rect` in window
+coordinates (the same space as `abs` and `contentBox()`: device pixels) and
+inside your node.
 
 **You promise one thing: that inside `rect` the frame really is that
 translation.** Everything else is core's to check, and each of them declines

--- a/docs/scale.md
+++ b/docs/scale.md
@@ -48,8 +48,10 @@ const scale = useScale(); // 1, 2, 1.5... static for the life of the root
   every fill off ntk's server-side fast paths besides.
 - a registered element's `paint()` and `hitTest()` (see
   [extending.md](extending.md)): `this.style` and `this.abs` arrive already
-  device, synthetic events are logical, and `this.scale` is on every node
-  for the constants that never pass through a style.
+  device, and so are `paintDamage()`, the rects handed to `invalidate` and
+  `scrollContents` and the rects of an a11y scene; synthetic events are
+  logical, and `this.scale` is on every node for the constants that never
+  pass through a style and the event coordinate on its way to `abs`.
 
 Fonts are the point of the whole exercise: a `fontSize: 14` at scale 2 is
 shaped, measured and rasterized at 28px. Text on a retina panel is _sharper_,
@@ -223,7 +225,8 @@ such seams.
 
 **What tests see.** The headless harnesses resolve to exactly 1 — a mock
 app has no display to ask — so every geometry assertion in the suite means
-its numbers literally. `createRoot({ app, scale: 2 })` opts a test in;
+its numbers literally. `createRoot({ app, scale: 2 })` opts a test in, and
+so does `renderX11(element, { scale: 2 })` from `react-x11/test`;
 `test/scale-render.test.js` is the boundary contract pinned as tests.
 `setScaleForTests()` (from `src/scale.js`) pins a factor without a
 connection.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -44,14 +44,15 @@ what they mean there.
 Mounts the tree and returns a handle **plus the queries bound to it**, so
 `const { getByText } = await renderX11(<App />)` reads the familiar way.
 
-| option            |                                                                       |
-| ----------------- | --------------------------------------------------------------------- |
-| `width`, `height` | the window (default 640×480)                                          |
-| `screen`          | the display (defaults comfortably larger than the window — see below) |
-| `backend`         | `'xserver'` (default) or `'mock'`                                     |
-| `fonts`           | `{ family: '/path/to.ttf' }` — **required for text pixels**           |
-| `wrap`            | wrap in a `<window>`; default true unless the element is one          |
-| `app`             | render into a connection you already have                             |
+| option            |                                                                        |
+| ----------------- | ---------------------------------------------------------------------- |
+| `width`, `height` | the window (default 640×480)                                           |
+| `screen`          | the display (defaults comfortably larger than the window — see below)  |
+| `backend`         | `'xserver'` (default) or `'mock'`                                      |
+| `fonts`           | `{ family: '/path/to.ttf' }` — **required for text pixels**            |
+| `wrap`            | wrap in a `<window>`; default true unless the element is one           |
+| `app`             | render into a connection you already have                              |
+| `scale`           | pin the display scale — `2` renders as a retina panel would; default 1 |
 
 | on the result         |                                                                       |
 | --------------------- | --------------------------------------------------------------------- |

--- a/src/node.d.ts
+++ b/src/node.d.ts
@@ -106,8 +106,9 @@ export interface A11ySceneItem {
    * is destroyed and recreated under every screen reader holding it. */
   id: string;
   /** Where it is drawn, in the owning window's coordinates — the same
-   * space as `abs` and a mouse event's `x`/`y`. Where AT focus draws and
-   * what a magnifier follows. */
+   * space as `abs`, which is device pixels; a mouse event's `x`/`y` are
+   * logical, `scale` apart (docs/scale.md). Where AT focus draws and what
+   * a magnifier follows. */
   rect: Rect;
   /** The ARIA role it plays. `'group'` when it says none, which is
    * audible and promises nothing. A role that promises activation
@@ -186,8 +187,19 @@ export declare class Node {
   /** The owning `<window>` node, once attached. */
   readonly root: Node | null;
   readonly destroyed: boolean;
-  /** Position and size within the owning window, valid after layout. */
+  /** Position and size within the owning window, valid after layout. In
+   * device pixels, like everything painted (docs/scale.md). */
   readonly abs: Rect;
+  /**
+   * Device pixels per logical pixel for this node's connection — resolved
+   * once by `createRoot` (docs/scale.md) and constant for the node's life.
+   * `this.style`, `this.abs` and `contentBox()` are already device pixels;
+   * a synthetic event's `x`/`y` are logical. This is for what never passes
+   * through a style — a paint constant such as a caret's width, or an
+   * event coordinate on its way to a comparison with `abs`. `1` on an
+   * ordinary display, `2` on a retina panel.
+   */
+  readonly scale: number;
   /** `abs` inset by the border and the padding — where the content goes,
    * and where every built-in draws. The insets come off the layout, which
    * is where percentages and the per-side overrides have already been
@@ -221,9 +233,10 @@ export declare class Node {
   //
   // Four questions in one index space and one coordinate space: characters
   // are **code points**, rectangles are in the owning window's coordinates —
-  // the same ones `abs`, `contentBox()` and a mouse event's `x`/`y` use.
-  // An element that answers them can be selected across by a `selectable`
-  // ancestor with no registration of any kind.
+  // the same ones `abs` and `contentBox()` use, which are device pixels; a
+  // mouse event's `x`/`y` are the logical ones, `scale` apart. An element
+  // that answers them can be selected across by a `selectable` ancestor
+  // with no registration of any kind.
 
   /** This element's text, or null when it has none. The default. */
   textContent(): string | null;

--- a/src/testing/index.d.ts
+++ b/src/testing/index.d.ts
@@ -66,6 +66,14 @@ export interface RenderX11Options {
    * D-Bus anywhere. See docs/accessibility.md.
    */
   a11y?: boolean;
+  /**
+   * Pin the display scale — device pixels per logical pixel (docs/scale.md).
+   * The headless harnesses resolve to exactly 1 on their own, so every
+   * geometry assertion means its numbers literally; `2` renders the tree
+   * the way a retina panel does, which is the only way to catch an element
+   * that compares a logical event coordinate with its device `abs`.
+   */
+  scale?: 'auto' | number;
 }
 
 /** One recorded assistive-technology fact, plus its one-line `summary`. */

--- a/src/types/events.d.ts
+++ b/src/types/events.d.ts
@@ -13,7 +13,8 @@ export interface NativeEvent {
   /** X event type number. */
   type: number;
   name?: string;
-  /** Window-relative pointer position. */
+  /** Window-relative pointer position, in device pixels — the numbers off
+   * the wire, and the ones to compare with a node's `abs` (docs/scale.md). */
   x: number;
   y: number;
   /** Screen coordinates — what you anchor a `<popup>` at. */
@@ -33,7 +34,9 @@ export interface SyntheticEvent<T = DrawnNode> {
   target: T;
   /** The node whose handler is running. */
   currentTarget: T | null;
-  /** Window coordinates. */
+  /** Window coordinates, in logical pixels — the unit styles are written
+   * in. `nativeEvent.x`/`y` are the same point in device pixels, which is
+   * what a node's `abs` is in (docs/scale.md). */
   x: number;
   y: number;
   /** Coordinates relative to `target`'s box. */

--- a/test/types/extend.tsx
+++ b/test/types/extend.tsx
@@ -87,6 +87,7 @@ class SparklineNode extends Node {
     super.paint(ctx);
     // the subclass surface docs/extending.md promises
     const _rect: number = this.abs.width;
+    const _scale: number = this.scale;
     const _kind: string = this.kind;
     const _destroyed: boolean = this.destroyed;
     void this.style;

--- a/test/types/test-api.tsx
+++ b/test/types/test-api.tsx
@@ -61,6 +61,7 @@ async function suite() {
     fonts: { 'sans-serif': '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf' },
     wrap: true,
     title: 'a test',
+    scale: 2,
   });
 
   // queries return nodes, and the node API is the public one


### PR DESCRIPTION
A registered element sees two units (docs/scale.md): `abs`, `contentBox()`, `style`, the paint context, `paintDamage()`, the rects it hands `invalidate` and `scrollContents` and the rects of its a11y scene are **device** pixels, while a synthetic event's `x`/`y` are **logical**. The declarations and the docs said otherwise in four places — "the same space as `abs` and a mouse event's `x`/`y`" — and left `scale` off `Node` and off `RenderX11Options`.

An element written against them in TypeScript therefore compared `ev.x` with `contentBox()`, passed every headless test (which run at 1x, where the two units coincide), and hovered at half the distance, panned at half speed and framed its content at half size the first time the native macOS backend reported a retina panel. That is exactly what happened to `<Flow>` in @react-x11/components; the fix there is a sibling PR, and this is the part of it that belongs here.

## What changes

- `Node.scale` is declared (`src/node.d.ts`). It has been on every node at runtime since the scale model landed (#378); a registered element could not read it without a cast.
- `NativeEvent.x`/`y` and `SyntheticEvent.x`/`y` (`src/types/events.d.ts`) say which unit they are in.
- `RenderX11Options.scale` is declared (`src/testing/index.d.ts`). `renderX11` has forwarded it to `createRoot` through `...rootOptions` all along; `renderX11(el, { scale: 2 })` is the test that catches the mix, and it now type-checks.
- The four "same space as `abs` and a mouse event's `x`/`y`" passages — `node.d.ts` twice, `docs/extending.md` three times, `docs/elements.md` — say device for the rects and logical for the events. `docs/extending.md`'s "what you read" list gains `this.scale`; `docs/scale.md` and `docs/testing.md` mention the harness option.
- `test/types/extend.tsx` reads `this.scale`; `test/types/test-api.tsx` passes `scale: 2`.

No runtime change. `npm run typecheck` passes.
