### PR TITLE
feat(cocoa): the face and the ctx grow ntk's glyph-run seams

### DIFF
--- a/docs/macos.md
+++ b/docs/macos.md
@@ -546,6 +546,24 @@ implements it over CoreText:
   (`CTFontDrawGlyphs`) backs the `drawGlyphs`/`positioned` context
   extensions the terminal and code-editor components use.
 
+The glyph-run seams are part of that contract on both backends (issue
+#432, over windowkit/appkit#1). The face `fonts.match()` returns answers
+ntk's `glyphIdFor(cp)` (`null` when unmapped), `advanceOf(id, size)` and
+`shape(text, size)` beside `metrics(size)` — which reports ntk's
+`lineGap`/`lineHeight` alongside CoreText's `leading` — and the manager
+answers `fallbackFor(cp, family, opts)` off the app's loaded faces and
+then CoreText's cascade. The context answers `drawGlyphs(op, src,
+positioned)`, `createSolidPicture(r, g, b, a)` and
+`Render.PictOp.{Over, Src}` with ntk's exact run contract, grouping the
+runs by face and size into one `CTFontDrawGlyphs` per colour, so a
+renderer written against ntk's context — `<Terminal backend="vt">` —
+runs unchanged. Two things differ from ntk and are stated where they
+live: `shape()` may hand back a glyph carrying the face CoreText
+substituted (an emoji cluster in Menlo draws as the emoji, where ntk
+shapes `.notdef`), and the transform scales glyphs as well as their
+origins, because CoreGraphics draws text through the CTM like everything
+else.
+
 The alternative — reusing ntk's fontkit shaping stack on macOS and
 rasterizing through the Wayland Tier-A span compositor — is recorded,
 not chosen: it buys byte-identical metrics across backends (one test
@@ -893,9 +911,11 @@ raw-buffer upload; the API supports both so the choice can be measured.)
 **Text.** measure ✅ → full layout object 🆕: build from span list
 (attributed string), report lines/runs/origins, `indexAt`,
 `caretOffset`, range rects, truncation/`maxLines`, draw-to-bitmap ✅ and
-draw-into-surface 🆕, glyph-run access for `drawGlyphs` 🆕; font
-matching by family list/weight/style/variations → descriptor, and
-loading app-supplied font files (`loadFont`) 🆕; `hasGlyph` 🆕.
+draw-into-surface 🆕, glyph-run access for `drawGlyphs` ✅
+(`fontGlyphForCodepoint`, `fontGlyphAdvances`, `fontFallbackFor`,
+`fontWithSize`, `fontShapeText`, `ctxDrawGlyphs` — windowkit/appkit#1);
+font matching by family list/weight/style/variations → descriptor, and
+loading app-supplied font files (`loadFont`) 🆕; `hasGlyph` ✅.
 
 **Controls.** `controls.render` ✅ (push/default/checkbox/radio/popup/
 slider/switch, states, sizes, appearance) — add: focus-ring state,

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -547,7 +547,7 @@ implements it over CoreText:
   extensions the terminal and code-editor components use.
 
 The glyph-run seams are part of that contract on both backends (issue
-#432, over @windowkit/appkit 0.2's glyph natives — windowkit/appkit#1).
+#432, over @windowkit/appkit 0.3's glyph natives — windowkit/appkit#1).
 The face `fonts.match()` returns answers ntk's `glyphIdFor(cp)` (`null`
 when unmapped), `advanceOf(id, size)` and `shape(text, size)` beside
 `metrics(size)` — which reports ntk's `lineGap`/`lineHeight` alongside
@@ -558,11 +558,10 @@ context answers `drawGlyphs(op, src, positioned)`,
 ntk's exact run contract, grouping the runs by face and size into one
 `CTFontDrawGlyphs` per colour, so a renderer written against ntk's
 context — `<Terminal backend="vt">` — runs unchanged. Three things
-differ from ntk and are stated where they live: `shape()` answers
-covered text from the cmap and sends anything that needs the typesetter
-(marks, emoji sequences, uncovered or right-to-left text) through one
-`createLayout` as a single glyph carrying its line, which `drawGlyphs`
-draws — so an emoji cluster in Menlo comes out as the emoji, where ntk
+differ from ntk and are stated where they live: `shape()` runs the text
+through the typesetter (`fontShapeText`), and a glyph from a run
+CoreText substituted carries that face as `font`, which `drawGlyphs`
+honours — so an emoji cluster in Menlo comes out as the emoji, where ntk
 shapes `.notdef`; every op draws as Over, which for the opaque inks text
 uses is what Src does too; and the transform scales glyphs as well as
 their origins, because CoreGraphics draws text through the CTM like
@@ -917,9 +916,8 @@ raw-buffer upload; the API supports both so the choice can be measured.)
 `caretOffset`, range rects, truncation/`maxLines`, draw-to-bitmap ✅ and
 draw-into-surface 🆕, glyph-run access for `drawGlyphs` ✅
 (`fontGlyphForCodepoint`, `fontGlyphAdvances`, `fontFallbackFor`,
-`ctxDrawGlyphs` — windowkit/appkit#1, shipped in 0.2.0; a shaped line
-read back as glyph ids would let `shape()` answer clusters as real
-glyphs instead of a typeset line);
+`ctxDrawGlyphs` in 0.2.0, `fontShapeText` and `fontWithSize` in 0.3.0 —
+windowkit/appkit#1);
 font matching by family list/weight/style/variations → descriptor, and
 loading app-supplied font files (`loadFont`) 🆕; `hasGlyph` ✅.
 

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -547,22 +547,26 @@ implements it over CoreText:
   extensions the terminal and code-editor components use.
 
 The glyph-run seams are part of that contract on both backends (issue
-#432, over windowkit/appkit#1). The face `fonts.match()` returns answers
-ntk's `glyphIdFor(cp)` (`null` when unmapped), `advanceOf(id, size)` and
-`shape(text, size)` beside `metrics(size)` — which reports ntk's
-`lineGap`/`lineHeight` alongside CoreText's `leading` — and the manager
-answers `fallbackFor(cp, family, opts)` off the app's loaded faces and
-then CoreText's cascade. The context answers `drawGlyphs(op, src,
-positioned)`, `createSolidPicture(r, g, b, a)` and
-`Render.PictOp.{Over, Src}` with ntk's exact run contract, grouping the
-runs by face and size into one `CTFontDrawGlyphs` per colour, so a
-renderer written against ntk's context — `<Terminal backend="vt">` —
-runs unchanged. Two things differ from ntk and are stated where they
-live: `shape()` may hand back a glyph carrying the face CoreText
-substituted (an emoji cluster in Menlo draws as the emoji, where ntk
-shapes `.notdef`), and the transform scales glyphs as well as their
-origins, because CoreGraphics draws text through the CTM like everything
-else.
+#432, over @windowkit/appkit 0.2's glyph natives — windowkit/appkit#1).
+The face `fonts.match()` returns answers ntk's `glyphIdFor(cp)` (`null`
+when unmapped), `advanceOf(id, size)` and `shape(text, size)` beside
+`metrics(size)` — which reports ntk's `lineGap`/`lineHeight` alongside
+CoreText's `leading` — and the manager answers `fallbackFor(cp, family,
+opts)` off the app's loaded faces and then CoreText's cascade. The
+context answers `drawGlyphs(op, src, positioned)`,
+`createSolidPicture(r, g, b, a)` and `Render.PictOp.{Over, Src}` with
+ntk's exact run contract, grouping the runs by face and size into one
+`CTFontDrawGlyphs` per colour, so a renderer written against ntk's
+context — `<Terminal backend="vt">` — runs unchanged. Three things
+differ from ntk and are stated where they live: `shape()` answers
+covered text from the cmap and sends anything that needs the typesetter
+(marks, emoji sequences, uncovered or right-to-left text) through one
+`createLayout` as a single glyph carrying its line, which `drawGlyphs`
+draws — so an emoji cluster in Menlo comes out as the emoji, where ntk
+shapes `.notdef`; every op draws as Over, which for the opaque inks text
+uses is what Src does too; and the transform scales glyphs as well as
+their origins, because CoreGraphics draws text through the CTM like
+everything else.
 
 The alternative — reusing ntk's fontkit shaping stack on macOS and
 rasterizing through the Wayland Tier-A span compositor — is recorded,
@@ -913,7 +917,9 @@ raw-buffer upload; the API supports both so the choice can be measured.)
 `caretOffset`, range rects, truncation/`maxLines`, draw-to-bitmap ✅ and
 draw-into-surface 🆕, glyph-run access for `drawGlyphs` ✅
 (`fontGlyphForCodepoint`, `fontGlyphAdvances`, `fontFallbackFor`,
-`fontWithSize`, `fontShapeText`, `ctxDrawGlyphs` — windowkit/appkit#1);
+`ctxDrawGlyphs` — windowkit/appkit#1, shipped in 0.2.0; a shaped line
+read back as glyph ids would let `shape()` answer clusters as real
+glyphs instead of a typeset line);
 font matching by family list/weight/style/variations → descriptor, and
 loading app-supplied font files (`loadFont`) 🆕; `hasGlyph` ✅.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "node": ">=20.19"
       },
       "optionalDependencies": {
-        "@windowkit/appkit": "^0.1.0",
+        "@windowkit/appkit": "^0.2.0",
         "dbus-native": "^0.15.1",
         "x11-dri": "^0.7.0"
       },
@@ -1514,9 +1514,9 @@
       }
     },
     "node_modules/@windowkit/appkit": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@windowkit/appkit/-/appkit-0.1.0.tgz",
-      "integrity": "sha512-rJcknQzdqnzf2gXNBjT3WkjFHzlvCkMlu9Cb3hvlFlr1VoN9xqWHVlBTKq4kSVN1cBNMKqAhyIm8yynDO5Dj0w==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@windowkit/appkit/-/appkit-0.2.0.tgz",
+      "integrity": "sha512-mcSiE9hn+6nUp5RW4/MjQEmBAHWfLL40Q3S3wjqI76r6snRpkYpUPEdTXLflppZgK8aeW7+imz6H52rJMlH7Qw==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "node": ">=20.19"
       },
       "optionalDependencies": {
-        "@windowkit/appkit": "^0.2.0",
+        "@windowkit/appkit": "^0.3.0",
         "dbus-native": "^0.15.1",
         "x11-dri": "^0.7.0"
       },
@@ -1514,9 +1514,9 @@
       }
     },
     "node_modules/@windowkit/appkit": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@windowkit/appkit/-/appkit-0.2.0.tgz",
-      "integrity": "sha512-mcSiE9hn+6nUp5RW4/MjQEmBAHWfLL40Q3S3wjqI76r6snRpkYpUPEdTXLflppZgK8aeW7+imz6H52rJMlH7Qw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@windowkit/appkit/-/appkit-0.3.0.tgz",
+      "integrity": "sha512-2d/mQcb5vEAR5QWQeRfp9bLFaEK56neOSjiUC72Nk7ekJ+eTMrzSYxzwkXpsbWqOSUQ4xHUpuE45oJuScNzdfQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "yoga-layout": "^3.2.1"
   },
   "optionalDependencies": {
-    "@windowkit/appkit": "^0.2.0",
+    "@windowkit/appkit": "^0.3.0",
     "dbus-native": "^0.15.1",
     "x11-dri": "^0.7.0"
   },

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "yoga-layout": "^3.2.1"
   },
   "optionalDependencies": {
-    "@windowkit/appkit": "^0.1.0",
+    "@windowkit/appkit": "^0.2.0",
     "dbus-native": "^0.15.1",
     "x11-dri": "^0.7.0"
   },

--- a/src/cocoa/context2d.js
+++ b/src/cocoa/context2d.js
@@ -65,6 +65,32 @@ class LinearGradient {
   }
 }
 
+const clamp01 = (v) => Math.min(1, Math.max(0, Number(v) || 0));
+
+/**
+ * The Render ops text draws with, numbered as XRender numbers them so a
+ * caller's `ctx.Render?.PictOp?.Over ?? 3` reads the same on both
+ * backends. `Over` composites; `Src` replaces (CG's copy blend mode over
+ * the glyph coverage, the nearest thing to XRender's). Anything else
+ * `drawGlyphs` is handed draws as Over.
+ */
+const PICT_OP = Object.freeze({ Src: 1, Over: 3 });
+const RENDER = Object.freeze({ PictOp: PICT_OP });
+
+/**
+ * A solid ink for `drawGlyphs` — ntk's `createSolidPicture` answers an
+ * XRender picture; here it is the colour itself. Premultiplied 0..1 in, as
+ * XRender solids are (the identity for the opaque inks text uses), straight
+ * for CoreGraphics inside.
+ */
+class SolidPicture {
+  constructor(r, g, b, a) {
+    const alpha = clamp01(a);
+    const straight = (c) => (alpha > 0 ? clamp01(c / alpha) : 0);
+    this._rgba = [straight(r), straight(g), straight(b), alpha];
+  }
+}
+
 export class CocoaContext2D {
   /**
    * @param native the @windowkit/appkit module
@@ -615,6 +641,107 @@ export class CocoaContext2D {
       return undefined;
     }
     return promise;
+  }
+
+  // --- glyph runs (ntk's documented run contract) --------------------------
+
+  /** ntk's Render extension object, as much of it as text needs. */
+  get Render() {
+    return RENDER;
+  }
+
+  createSolidPicture(r, g, b, a) {
+    return new SolidPicture(r, g, b, a);
+  }
+
+  /**
+   * Composite glyph runs — ntk's contract (its docs/text.md#glyph-runs),
+   * so a renderer written against ntk's context runs here unchanged:
+   * `positioned` is `[{ run: { font, size, glyphs: [{ id, ax, dx, dy }] },
+   * x, y }]`, `x`/`y` the run's baseline origin in user space, the pen
+   * starting at `x` and each glyph inking at `(pen + dx, y - dy)` — `dy`
+   * y-up — before advancing by `ax`. `op` is `Render.PictOp.Over` or
+   * `.Src`; `src` a `createSolidPicture` ink.
+   *
+   * The glyphs are grouped by face and size and go out as one native call
+   * — `CTFontDrawGlyphs` per group, with the fill set to `src`'s colour —
+   * so a frame of terminal text is one call per foreground colour.
+   * `run.font` is a face from `fonts.match()`/`fallbackFor()`, or an ntk
+   * `Font` from `openFont()` (resolved to CoreText from the same bytes, so
+   * its glyph ids hold); a glyph carrying a `font` of its own — what
+   * `shape()` produces when CoreText substituted a face — draws with that
+   * face.
+   *
+   * One difference from ntk, stated: the transform applies to the glyphs as
+   * well as to their origins, because CoreGraphics draws text through the
+   * CTM like everything else, where ntk moves the origins and keeps the
+   * advances in device pixels. Under a translate, which is what a node's
+   * paint runs in, the two agree.
+   */
+  drawGlyphs(op, src, positioned) {
+    if (!Array.isArray(positioned) || positioned.length === 0) return;
+    const fonts = this._fonts;
+    if (typeof fonts?._runHandle !== 'function') return;
+    const batches = new Map(); // CTFont handle -> { font, glyphs, positions }
+    for (const placed of positioned) {
+      const run = placed?.run;
+      const glyphs = run?.glyphs;
+      if (!glyphs?.length) continue;
+      const size = run.size;
+      const runHandle = fonts._runHandle(run.font, size);
+      let pen = 0;
+      for (const g of glyphs) {
+        const handle = g.font ? fonts._runHandle(g.font, size) : runHandle;
+        if (handle) {
+          let batch = batches.get(handle);
+          if (!batch) {
+            batch = { font: handle, glyphs: [], positions: [] };
+            batches.set(handle, batch);
+          }
+          batch.glyphs.push(g.id);
+          batch.positions.push(
+            placed.x + pen + (g.dx || 0),
+            placed.y - (g.dy || 0),
+          );
+        }
+        pen += g.ax || 0;
+      }
+    }
+    if (batches.size === 0) return;
+    const [r, g, b, a] = this._inkOf(src);
+    const surface = this._s();
+    this._native.ctxSetFillColor(surface, r, g, b, a);
+    const runs = [];
+    for (const batch of batches.values()) {
+      runs.push({
+        font: batch.font,
+        glyphs: Uint16Array.from(batch.glyphs),
+        positions: Float64Array.from(batch.positions),
+      });
+    }
+    this._native.ctxDrawGlyphs(surface, runs, op === PICT_OP.Src);
+    this._dirty();
+  }
+
+  /**
+   * The straight colour a `drawGlyphs` source paints with: a solid ink, a
+   * CSS colour string, a straight `[r, g, b, a]` — or, for anything else
+   * (a gradient, which glyph runs do not fill through here), the fill
+   * style in force.
+   */
+  _inkOf(src) {
+    if (src instanceof SolidPicture) return src._rgba;
+    if (typeof src === 'string') return parseColor(src);
+    if (Array.isArray(src) && src.length >= 3) {
+      return [
+        clamp01(src[0]),
+        clamp01(src[1]),
+        clamp01(src[2]),
+        src.length > 3 ? clamp01(src[3]) : 1,
+      ];
+    }
+    const style = this._state.fillStyle;
+    return style instanceof LinearGradient ? BLACK : parseColor(style);
   }
 
   // --- text (minimal: enough for <canvas onDraw> users) --------------------

--- a/src/cocoa/context2d.js
+++ b/src/cocoa/context2d.js
@@ -70,9 +70,9 @@ const clamp01 = (v) => Math.min(1, Math.max(0, Number(v) || 0));
 /**
  * The Render ops text draws with, numbered as XRender numbers them so a
  * caller's `ctx.Render?.PictOp?.Over ?? 3` reads the same on both
- * backends. `Over` composites; `Src` replaces (CG's copy blend mode over
- * the glyph coverage, the nearest thing to XRender's). Anything else
- * `drawGlyphs` is handed draws as Over.
+ * backends. Every op draws as Over here: the bridge composites glyph
+ * coverage with the context's fill and offers no blend-mode switch, and
+ * for the opaque inks text uses Src and Over agree.
  */
 const PICT_OP = Object.freeze({ Src: 1, Over: 3 });
 const RENDER = Object.freeze({ PictOp: PICT_OP });
@@ -668,9 +668,9 @@ export class CocoaContext2D {
    * so a frame of terminal text is one call per foreground colour.
    * `run.font` is a face from `fonts.match()`/`fallbackFor()`, or an ntk
    * `Font` from `openFont()` (resolved to CoreText from the same bytes, so
-   * its glyph ids hold); a glyph carrying a `font` of its own — what
-   * `shape()` produces when CoreText substituted a face — draws with that
-   * face.
+   * its glyph ids hold). A glyph carrying a typeset line — what `shape()`
+   * answers for a cluster the cmap alone cannot — draws that line at the
+   * pen instead, in the same ink.
    *
    * One difference from ntk, stated: the transform applies to the glyphs as
    * well as to their origins, because CoreGraphics draws text through the
@@ -683,43 +683,50 @@ export class CocoaContext2D {
     const fonts = this._fonts;
     if (typeof fonts?._runHandle !== 'function') return;
     const batches = new Map(); // CTFont handle -> { font, glyphs, positions }
+    const lines = []; // typeset clusters: [layout, x, y]
     for (const placed of positioned) {
       const run = placed?.run;
       const glyphs = run?.glyphs;
       if (!glyphs?.length) continue;
-      const size = run.size;
-      const runHandle = fonts._runHandle(run.font, size);
+      const handle = fonts._runHandle(run.font, run.size);
       let pen = 0;
       for (const g of glyphs) {
-        const handle = g.font ? fonts._runHandle(g.font, size) : runHandle;
-        if (handle) {
+        const x = placed.x + pen + (g.dx || 0);
+        const y = placed.y - (g.dy || 0);
+        if (g._layout) {
+          lines.push([g._layout, x, y]);
+        } else if (handle) {
           let batch = batches.get(handle);
           if (!batch) {
             batch = { font: handle, glyphs: [], positions: [] };
             batches.set(handle, batch);
           }
           batch.glyphs.push(g.id);
-          batch.positions.push(
-            placed.x + pen + (g.dx || 0),
-            placed.y - (g.dy || 0),
-          );
+          batch.positions.push(x, y);
         }
         pen += g.ax || 0;
       }
     }
-    if (batches.size === 0) return;
+    if (batches.size === 0 && lines.length === 0) return;
     const [r, g, b, a] = this._inkOf(src);
     const surface = this._s();
     this._native.ctxSetFillColor(surface, r, g, b, a);
-    const runs = [];
-    for (const batch of batches.values()) {
-      runs.push({
-        font: batch.font,
-        glyphs: Uint16Array.from(batch.glyphs),
-        positions: Float64Array.from(batch.positions),
-      });
+    if (batches.size) {
+      const runs = [];
+      for (const batch of batches.values()) {
+        runs.push({
+          font: batch.font,
+          glyphs: Uint16Array.from(batch.glyphs),
+          positions: Float64Array.from(batch.positions),
+        });
+      }
+      this._native.ctxDrawGlyphs(surface, runs);
     }
-    this._native.ctxDrawGlyphs(surface, runs, op === PICT_OP.Src);
+    for (const [layout, x, y] of lines) {
+      // a line draws from its top; the glyph's y is its baseline
+      const baseline = layout.lines[0]?.baseline ?? 0;
+      this._native.drawLayout(surface, layout._handle, x, y - baseline);
+    }
     this._dirty();
   }
 

--- a/src/cocoa/context2d.js
+++ b/src/cocoa/context2d.js
@@ -668,9 +668,9 @@ export class CocoaContext2D {
    * so a frame of terminal text is one call per foreground colour.
    * `run.font` is a face from `fonts.match()`/`fallbackFor()`, or an ntk
    * `Font` from `openFont()` (resolved to CoreText from the same bytes, so
-   * its glyph ids hold). A glyph carrying a typeset line — what `shape()`
-   * answers for a cluster the cmap alone cannot — draws that line at the
-   * pen instead, in the same ink.
+   * its glyph ids hold); a glyph carrying a `font` of its own — what
+   * `shape()` produces when CoreText substituted a face — draws with that
+   * face.
    *
    * One difference from ntk, stated: the transform applies to the glyphs as
    * well as to their origins, because CoreGraphics draws text through the
@@ -683,50 +683,43 @@ export class CocoaContext2D {
     const fonts = this._fonts;
     if (typeof fonts?._runHandle !== 'function') return;
     const batches = new Map(); // CTFont handle -> { font, glyphs, positions }
-    const lines = []; // typeset clusters: [layout, x, y]
     for (const placed of positioned) {
       const run = placed?.run;
       const glyphs = run?.glyphs;
       if (!glyphs?.length) continue;
-      const handle = fonts._runHandle(run.font, run.size);
+      const size = run.size;
+      const runHandle = fonts._runHandle(run.font, size);
       let pen = 0;
       for (const g of glyphs) {
-        const x = placed.x + pen + (g.dx || 0);
-        const y = placed.y - (g.dy || 0);
-        if (g._layout) {
-          lines.push([g._layout, x, y]);
-        } else if (handle) {
+        const handle = g.font ? fonts._runHandle(g.font, size) : runHandle;
+        if (handle) {
           let batch = batches.get(handle);
           if (!batch) {
             batch = { font: handle, glyphs: [], positions: [] };
             batches.set(handle, batch);
           }
           batch.glyphs.push(g.id);
-          batch.positions.push(x, y);
+          batch.positions.push(
+            placed.x + pen + (g.dx || 0),
+            placed.y - (g.dy || 0),
+          );
         }
         pen += g.ax || 0;
       }
     }
-    if (batches.size === 0 && lines.length === 0) return;
+    if (batches.size === 0) return;
     const [r, g, b, a] = this._inkOf(src);
     const surface = this._s();
     this._native.ctxSetFillColor(surface, r, g, b, a);
-    if (batches.size) {
-      const runs = [];
-      for (const batch of batches.values()) {
-        runs.push({
-          font: batch.font,
-          glyphs: Uint16Array.from(batch.glyphs),
-          positions: Float64Array.from(batch.positions),
-        });
-      }
-      this._native.ctxDrawGlyphs(surface, runs);
+    const runs = [];
+    for (const batch of batches.values()) {
+      runs.push({
+        font: batch.font,
+        glyphs: Uint16Array.from(batch.glyphs),
+        positions: Float64Array.from(batch.positions),
+      });
     }
-    for (const [layout, x, y] of lines) {
-      // a line draws from its top; the glyph's y is its baseline
-      const baseline = layout.lines[0]?.baseline ?? 0;
-      this._native.drawLayout(surface, layout._handle, x, y - baseline);
-    }
+    this._native.ctxDrawGlyphs(surface, runs);
     this._dirty();
   }
 

--- a/src/cocoa/fonts.js
+++ b/src/cocoa/fonts.js
@@ -12,9 +12,9 @@
 // and a face is ntk's `Font` as far as a renderer that positions glyphs
 // itself reads it — `metrics(size)`, `hasGlyph(cp)`, `glyphIdFor(cp)`,
 // `advanceOf(id, size)`, `shape(text, size)` — so a run built here draws
-// through `ctx.drawGlyphs` here (issue #432, over @windowkit/appkit 0.2's
+// through `ctx.drawGlyphs` here (issue #432, over @windowkit/appkit 0.3's
 // fontGlyphForCodepoint / fontGlyphAdvances / fontFallbackFor /
-// ctxDrawGlyphs).
+// fontShapeText / fontWithSize / ctxDrawGlyphs).
 //
 // Index spaces, because two meet here: `lines[].start/end` and
 // `runs[].start/end` are UTF-16 code units (what `rangeBands` in nodes.js
@@ -167,18 +167,6 @@ const GENERIC_FAMILIES = new Set([
 /** The size a face is probed at when the question has no size in it. */
 const PROBE_SIZE = 14;
 
-/** Grapheme clusters of a string — what one glyph of `shape()` covers. */
-const graphemes = (() => {
-  const segmenter =
-    typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function'
-      ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
-      : null;
-  return (text) =>
-    segmenter
-      ? Array.from(segmenter.segment(text), (s) => s.segment)
-      : Array.from(text);
-})();
-
 /**
  * A face — what `match()` and `fallbackFor()` answer — in the shape of
  * ntk's `Font` as far as a renderer that positions glyphs itself reads it
@@ -291,57 +279,46 @@ export class CocoaFace {
 
   /**
    * Shape a run of text at a pixel size: `{ font, size, direction, width,
-   * glyphs: [{ id, ax, dx, dy }] }` in ntk's pen contract — `ax` the
-   * advance, `dx`/`dy` the drawing offset from the pen, y up.
+   * glyphs: [{ id, ax, dx, dy }] }`, glyphs in visual order with ntk's
+   * pen contract — `ax` the advance, `dx`/`dy` the drawing offset from the
+   * pen (y up). One CTLine through the typesetter (`fontShapeText`),
+   * which is what a cluster — a base with combining marks, an emoji
+   * sequence, a variation selector — needs and a grid renderer bypasses
+   * for everything else; the terminal shapes a cluster at a time and
+   * caches the run, so the typesetter runs once per distinct cluster.
    *
-   * Text this face covers one glyph per code point — every grapheme a
-   * single code point the cmap maps, left to right — answers from the
-   * cmap: real glyph ids and their advances, unshaped, which is what ntk
-   * answers too. Anything else goes through the typesetter as ONE glyph:
-   * a base with combining marks, an emoji sequence, a code point this face
-   * lacks, right-to-left text. The bridge reads a typeset line back only
-   * as pixels, so that glyph is `id` 0 carrying the line itself
-   * (`_layout`), `ax` the line's width, and this backend's `drawGlyphs`
-   * draws the line where the glyph goes. CoreText substitutes faces,
-   * composes marks and joins sequences inside it, so `☺️` in Menlo comes
-   * out as the emoji — where ntk shapes `.notdef`. The terminal shapes a
-   * cluster at a time and caches the run, so the typesetter runs once per
-   * distinct cluster, never per frame.
+   * One thing ntk's `shape()` never does happens here: CoreText substitutes
+   * a face for characters this one lacks instead of shaping them as
+   * `.notdef`, and a glyph from a substituted run carries that face as
+   * `font` — an extra field ntk's contract ignores and this backend's
+   * `drawGlyphs` honours, so `☺️` in Menlo comes out as the emoji rather
+   * than Menlo's glyph at the emoji font's index.
    */
   shape(text, size, opts = {}) {
     const manager = this._manager;
-    const s = String(text);
+    const raw = manager._native.fontShapeText(this._handle(size), String(text));
     const glyphs = [];
-    let width = 0;
-    if (opts.direction !== 'rtl') {
-      for (const cluster of graphemes(s)) {
-        const cp = cluster.codePointAt(0);
-        if (cp === undefined || String.fromCodePoint(cp) !== cluster) break;
-        const id = this.glyphIdFor(cp);
-        if (id === null) break;
-        const ax = this.advanceOf(id, size);
-        glyphs.push({ id, ax, dx: 0, dy: 0 });
-        width += ax;
-      }
-    }
-    if (glyphs.length !== graphemes(s).length || (s && !glyphs.length)) {
-      glyphs.length = 0;
-      width = 0;
-      if (s) {
-        const layout = manager.layout(
-          [{ text: s }],
-          { font: this, size },
-          { direction: opts.direction },
-        );
-        glyphs.push({ id: 0, ax: layout.width, dx: 0, dy: 0, _layout: layout });
-        width = layout.width;
+    let pen = 0;
+    for (const run of raw.runs) {
+      const face = run.font ? manager._faceOfHandle(run.font, size) : null;
+      for (let i = 0; i < run.glyphs.length; i++) {
+        const ax = run.advances[i];
+        const glyph = {
+          id: run.glyphs[i],
+          ax,
+          dx: run.positions[i * 2] - pen,
+          dy: run.positions[i * 2 + 1],
+        };
+        if (face) glyph.font = face;
+        glyphs.push(glyph);
+        pen += ax;
       }
     }
     return {
       font: this,
       size,
       direction: opts.direction ?? 'ltr',
-      width,
+      width: raw.width,
       glyphs,
     };
   }
@@ -632,8 +609,7 @@ export class CocoaFontManager {
         // the bridge answers the probe handle itself when the face covers
         // the text: no substitution needed
         if (handle === probe) found = base;
-        else if (handle)
-          found = this._faceOfHandle(handle, PROBE_SIZE, base, text);
+        else if (handle) found = this._faceOfHandle(handle, PROBE_SIZE);
       }
     }
     if (
@@ -658,19 +634,19 @@ export class CocoaFontManager {
   }
 
   /**
-   * The face behind a CTFont handle CoreText chose itself for `text` off
-   * `base` — one object per PostScript name, so the same fallback reached
-   * from two bases groups together in `drawGlyphs`. The handle seeds the
-   * size it came at; another size asks CoreText the same question at that
-   * size, which is how a face with no family to re-match by answers
-   * `metrics(size)` and advances everywhere.
+   * The face behind a CTFont handle CoreText chose itself — a fallback, or
+   * a substituted run inside `shape()` — one object per PostScript name, so
+   * runs from either route group together in `drawGlyphs`. The handle seeds
+   * the size it came at; other sizes are copies of it (`fontWithSize`),
+   * which is how a face with no family to re-match by answers
+   * `metrics(size)` and advances everywhere, as itself.
    */
-  _faceOfHandle(handle, size, base, text) {
+  _faceOfHandle(handle, size) {
     const ps = this._native.fontMetrics(handle).postScriptName;
     let face = this._faceByPs.get(ps);
     if (!face) {
       face = new CocoaFace(this, `ps:${ps}`, (s) =>
-        this._native.fontFallbackFor(base._handle(s), text),
+        this._native.fontWithSize(handle, s),
       );
       this._faceByPs.set(ps, face);
     }

--- a/src/cocoa/fonts.js
+++ b/src/cocoa/fonts.js
@@ -12,8 +12,9 @@
 // and a face is ntk's `Font` as far as a renderer that positions glyphs
 // itself reads it — `metrics(size)`, `hasGlyph(cp)`, `glyphIdFor(cp)`,
 // `advanceOf(id, size)`, `shape(text, size)` — so a run built here draws
-// through `ctx.drawGlyphs` here (issue #432; the natives are
-// windowkit/appkit#1).
+// through `ctx.drawGlyphs` here (issue #432, over @windowkit/appkit 0.2's
+// fontGlyphForCodepoint / fontGlyphAdvances / fontFallbackFor /
+// ctxDrawGlyphs).
 //
 // Index spaces, because two meet here: `lines[].start/end` and
 // `runs[].start/end` are UTF-16 code units (what `rangeBands` in nodes.js
@@ -166,6 +167,18 @@ const GENERIC_FAMILIES = new Set([
 /** The size a face is probed at when the question has no size in it. */
 const PROBE_SIZE = 14;
 
+/** Grapheme clusters of a string — what one glyph of `shape()` covers. */
+const graphemes = (() => {
+  const segmenter =
+    typeof Intl !== 'undefined' && typeof Intl.Segmenter === 'function'
+      ? new Intl.Segmenter(undefined, { granularity: 'grapheme' })
+      : null;
+  return (text) =>
+    segmenter
+      ? Array.from(segmenter.segment(text), (s) => s.segment)
+      : Array.from(text);
+})();
+
 /**
  * A face — what `match()` and `fallbackFor()` answer — in the shape of
  * ntk's `Font` as far as a renderer that positions glyphs itself reads it
@@ -190,6 +203,7 @@ export class CocoaFace {
     this.key = key;
     this._sizedHandle = sizedHandle;
     this._sized = new Map(); // size -> handle
+    this._covers = new Map(); // code point -> face that covers it | null
     this._names = null;
   }
 
@@ -277,46 +291,72 @@ export class CocoaFace {
 
   /**
    * Shape a run of text at a pixel size: `{ font, size, direction, width,
-   * glyphs: [{ id, ax, dx, dy }] }`, glyphs in visual order with ntk's
-   * pen contract — `ax` the advance, `dx`/`dy` the drawing offset from the
-   * pen (y up). One CTLine through the typesetter, which is what a cluster
-   * (a base with combining marks, an emoji with a variation selector)
-   * needs and a grid renderer bypasses for everything else.
+   * glyphs: [{ id, ax, dx, dy }] }` in ntk's pen contract — `ax` the
+   * advance, `dx`/`dy` the drawing offset from the pen, y up.
    *
-   * One thing ntk's `shape()` never does happens here: CoreText substitutes
-   * a face for characters this one lacks instead of shaping them as
-   * `.notdef`, and a glyph from a substituted run carries that face as
-   * `font` — an extra field ntk's contract ignores and this backend's
-   * `drawGlyphs` honours, so `☺️` in Menlo comes out as the emoji rather
-   * than Menlo's glyph at the emoji font's index.
+   * Text this face covers one glyph per code point — every grapheme a
+   * single code point the cmap maps, left to right — answers from the
+   * cmap: real glyph ids and their advances, unshaped, which is what ntk
+   * answers too. Anything else goes through the typesetter as ONE glyph:
+   * a base with combining marks, an emoji sequence, a code point this face
+   * lacks, right-to-left text. The bridge reads a typeset line back only
+   * as pixels, so that glyph is `id` 0 carrying the line itself
+   * (`_layout`), `ax` the line's width, and this backend's `drawGlyphs`
+   * draws the line where the glyph goes. CoreText substitutes faces,
+   * composes marks and joins sequences inside it, so `☺️` in Menlo comes
+   * out as the emoji — where ntk shapes `.notdef`. The terminal shapes a
+   * cluster at a time and caches the run, so the typesetter runs once per
+   * distinct cluster, never per frame.
    */
   shape(text, size, opts = {}) {
     const manager = this._manager;
-    const raw = manager._native.fontShapeText(this._handle(size), String(text));
+    const s = String(text);
     const glyphs = [];
-    let pen = 0;
-    for (const run of raw.runs) {
-      const face = run.font ? manager._faceOfHandle(run.font, size) : null;
-      for (let i = 0; i < run.glyphs.length; i++) {
-        const ax = run.advances[i];
-        const glyph = {
-          id: run.glyphs[i],
-          ax,
-          dx: run.positions[i * 2] - pen,
-          dy: run.positions[i * 2 + 1],
-        };
-        if (face) glyph.font = face;
-        glyphs.push(glyph);
-        pen += ax;
+    let width = 0;
+    if (opts.direction !== 'rtl') {
+      for (const cluster of graphemes(s)) {
+        const cp = cluster.codePointAt(0);
+        if (cp === undefined || String.fromCodePoint(cp) !== cluster) break;
+        const id = this.glyphIdFor(cp);
+        if (id === null) break;
+        const ax = this.advanceOf(id, size);
+        glyphs.push({ id, ax, dx: 0, dy: 0 });
+        width += ax;
+      }
+    }
+    if (glyphs.length !== graphemes(s).length || (s && !glyphs.length)) {
+      glyphs.length = 0;
+      width = 0;
+      if (s) {
+        const layout = manager.layout(
+          [{ text: s }],
+          { font: this, size },
+          { direction: opts.direction },
+        );
+        glyphs.push({ id: 0, ax: layout.width, dx: 0, dy: 0, _layout: layout });
+        width = layout.width;
       }
     }
     return {
       font: this,
       size,
       direction: opts.direction ?? 'ltr',
-      width: raw.width,
+      width,
       glyphs,
     };
+  }
+
+  /**
+   * A face that covers `codepoint` when this one does not — this face
+   * itself when it does, `null` when nothing on the system does. Faces the
+   * app loaded first, then CoreText's cascade off this face
+   * (`fontFallbackFor`). Cached per code point.
+   */
+  _coverFor(codepoint) {
+    if (this._covers.has(codepoint)) return this._covers.get(codepoint);
+    const found = this._manager._fallbackFrom(this, codepoint);
+    this._covers.set(codepoint, found);
+    return found;
   }
 }
 
@@ -330,8 +370,16 @@ export class CocoaFontManager {
     this._byKey = new Map(); // ntk Font key -> { cg } | { ps }
     this._sized = new Map(); // face key|size|variations -> CTFont handle
     this._layouts = new Map(); // layout signature -> CocoaTextLayout (LRU)
-    this._fallbacks = new Map(); // family|weight|italic -> Map(cp -> face|null)
     this._faceByPs = new Map(); // PostScript name -> face CoreText chose itself
+  }
+
+  /** A face the app loaded joins every fallback chain: what the faces that
+   *  outlive `_faces.clear()` remembered about coverage is stale. */
+  _forgetCovers() {
+    for (const face of this._faceByPs.values()) face._covers.clear();
+    for (const faces of this._registered.values()) {
+      for (const reg of faces) reg.face?._covers.clear();
+    }
   }
 
   /**
@@ -378,7 +426,7 @@ export class CocoaFontManager {
           this._fonts.clear();
           this._faces.clear();
           this._sized.clear();
-          this._fallbacks.clear();
+          this._forgetCovers();
         }
       }
     } catch {
@@ -555,19 +603,11 @@ export class CocoaFontManager {
     if (typeof codepoint !== 'number') {
       codepoint = String(codepoint).codePointAt(0) ?? -1;
     }
-    const w = numericWeight(opts.weight);
-    const italic = isItalic(opts.style);
-    const cacheKey = `${family}|${w}|${italic}`;
-    let perCp = this._fallbacks.get(cacheKey);
-    if (!perCp) {
-      perCp = new Map();
-      this._fallbacks.set(cacheKey, perCp);
-    }
-    if (perCp.has(codepoint)) return perCp.get(codepoint);
-    const base = this.match(family, {
-      weight: w,
-      style: italic ? 'italic' : 'normal',
-    });
+    return this.match(family, opts)._coverFor(codepoint);
+  }
+
+  /** `fallbackFor` from a face rather than a family — see `_coverFor`. */
+  _fallbackFrom(base, codepoint) {
     let found = null;
     for (const faces of this._registered.values()) {
       for (const reg of faces) {
@@ -586,11 +626,15 @@ export class CocoaFontManager {
       } catch {
         text = null; // not a scalar value: nothing covers it
       }
-      const handle =
-        text === null
-          ? null
-          : this._native.fontFallbackFor(base._handle(PROBE_SIZE), text);
-      if (handle) found = this._faceOfHandle(handle, PROBE_SIZE);
+      if (text !== null) {
+        const probe = base._handle(PROBE_SIZE);
+        const handle = this._native.fontFallbackFor(probe, text);
+        // the bridge answers the probe handle itself when the face covers
+        // the text: no substitution needed
+        if (handle === probe) found = base;
+        else if (handle)
+          found = this._faceOfHandle(handle, PROBE_SIZE, base, text);
+      }
     }
     if (
       found &&
@@ -599,7 +643,6 @@ export class CocoaFontManager {
     ) {
       found = base;
     }
-    perCp.set(codepoint, found);
     return found;
   }
 
@@ -615,17 +658,19 @@ export class CocoaFontManager {
   }
 
   /**
-   * The face behind a CTFont handle CoreText chose itself — a fallback, or
-   * a substituted run inside `shape()` — one object per PostScript name, so
-   * runs from either route group together in `drawGlyphs`. The handle seeds
-   * the size it came at; other sizes are copies of it.
+   * The face behind a CTFont handle CoreText chose itself for `text` off
+   * `base` — one object per PostScript name, so the same fallback reached
+   * from two bases groups together in `drawGlyphs`. The handle seeds the
+   * size it came at; another size asks CoreText the same question at that
+   * size, which is how a face with no family to re-match by answers
+   * `metrics(size)` and advances everywhere.
    */
-  _faceOfHandle(handle, size) {
+  _faceOfHandle(handle, size, base, text) {
     const ps = this._native.fontMetrics(handle).postScriptName;
     let face = this._faceByPs.get(ps);
     if (!face) {
       face = new CocoaFace(this, `ps:${ps}`, (s) =>
-        this._native.fontWithSize(handle, s),
+        this._native.fontFallbackFor(base._handle(s), text),
       );
       this._faceByPs.set(ps, face);
     }
@@ -709,7 +754,7 @@ export class CocoaFontManager {
     this._faces.clear();
     this._sized.clear();
     this._layouts.clear();
-    this._fallbacks.clear();
+    this._forgetCovers();
     // `null` on purpose: src/fonts.js keeps the fontkit face it already
     // opened as the handle, which is the one whose metrics apps can read;
     // the registry above is what rendering resolves against.

--- a/src/cocoa/fonts.js
+++ b/src/cocoa/fonts.js
@@ -6,7 +6,14 @@
 //                               overflow, direction })
 //     -> { width, height, lines, draw(ctx, x, y),
 //          indexAt(x, y), caretPosition(cp) }
-//   fonts.match(family, { weight, style }) -> { metrics(size) }
+//   fonts.match(family, { weight, style }) -> face
+//   fonts.fallbackFor(codepoint, family, { weight, style }) -> face | null
+//
+// and a face is ntk's `Font` as far as a renderer that positions glyphs
+// itself reads it — `metrics(size)`, `hasGlyph(cp)`, `glyphIdFor(cp)`,
+// `advanceOf(id, size)`, `shape(text, size)` — so a run built here draws
+// through `ctx.drawGlyphs` here (issue #432; the natives are
+// windowkit/appkit#1).
 //
 // Index spaces, because two meet here: `lines[].start/end` and
 // `runs[].start/end` are UTF-16 code units (what `rangeBands` in nodes.js
@@ -156,15 +163,175 @@ const GENERIC_FAMILIES = new Set([
   'ui-monospace',
 ]);
 
+/** The size a face is probed at when the question has no size in it. */
+const PROBE_SIZE = 14;
+
+/**
+ * A face — what `match()` and `fallbackFor()` answer — in the shape of
+ * ntk's `Font` as far as a renderer that positions glyphs itself reads it
+ * (ntk docs/text.md#glyph-runs): `metrics`, `hasGlyph`, `glyphIdFor`,
+ * `advanceOf`, `shape`. The face defers size the way ntk's does: `_handle`
+ * is the CTFont at a concrete pixel size, and every member that needs one
+ * asks for it, so one face serves a terminal at 13px and a label at 24px.
+ *
+ * Glyph ids are the font's own indices in both engines, so a run built
+ * from `glyphIdFor` here draws through `ctx.drawGlyphs` here with no
+ * translation; `run.font` is simply this object.
+ */
+export class CocoaFace {
+  /**
+   * @param manager the CocoaFontManager
+   * @param key stable identity (the match key, or the PostScript name of a
+   *   face that arrived by substitution)
+   * @param sizedHandle (size) => CTFont handle for this face at that size
+   */
+  constructor(manager, key, sizedHandle) {
+    this._manager = manager;
+    this.key = key;
+    this._sizedHandle = sizedHandle;
+    this._sized = new Map(); // size -> handle
+    this._names = null;
+  }
+
+  _handle(size) {
+    const s = Number.isFinite(size) && size > 0 ? size : PROBE_SIZE;
+    let handle = this._sized.get(s);
+    if (handle === undefined) {
+      handle = this._sizedHandle(s) ?? null;
+      this._sized.set(s, handle);
+    }
+    return handle;
+  }
+
+  _name() {
+    if (!this._names) {
+      const m = this._manager._native.fontMetrics(this._handle(PROBE_SIZE));
+      this._names = {
+        familyName: m.familyName ?? '',
+        postscriptName: m.postScriptName ?? '',
+      };
+    }
+    return this._names;
+  }
+
+  /** The family CoreText resolved — `Menlo`, `Apple Color Emoji`. */
+  get familyName() {
+    return this._name().familyName;
+  }
+
+  /** ntk's spelling of the PostScript name, for callers written against
+   *  its `Font`. */
+  get postscriptName() {
+    return this._name().postscriptName;
+  }
+
+  /**
+   * Scaled to a pixel size. CoreText's names (`leading`) and ntk's
+   * (`lineGap`, `lineHeight`) side by side, so a caller written against
+   * either reads a finite line height.
+   */
+  metrics(size) {
+    const m = this._manager._native.fontMetrics(this._handle(size));
+    return {
+      ...m,
+      lineGap: m.leading,
+      lineHeight: m.ascent + m.descent + m.leading,
+    };
+  }
+
+  /**
+   * Coverage. A code point (ntk's contract) or a string — the two forms
+   * `hasGlyph` has been asked in.
+   */
+  hasGlyph(codepoint) {
+    if (typeof codepoint === 'number')
+      return this.glyphIdFor(codepoint) !== null;
+    return this._manager._native.fontHasGlyph(
+      this._handle(PROBE_SIZE),
+      String(codepoint),
+    );
+  }
+
+  /**
+   * Glyph id for a code point, or `null` when this face does not map it —
+   * the lookup twin of `hasGlyph` (ntk#254). A cmap lookup only: no
+   * shaping, so text that needs ligatures or marks goes through `shape()`.
+   */
+  glyphIdFor(codepoint) {
+    if (typeof codepoint !== 'number') return null;
+    return this._manager._native.fontGlyphForCodepoint(
+      this._handle(PROBE_SIZE),
+      codepoint,
+    );
+  }
+
+  /** Nominal (unshaped) horizontal advance of a glyph id, in pixels at
+   *  `size`. */
+  advanceOf(glyphId, size) {
+    const advances = this._manager._native.fontGlyphAdvances(
+      this._handle(size),
+      [glyphId],
+    );
+    return advances[0] ?? 0;
+  }
+
+  /**
+   * Shape a run of text at a pixel size: `{ font, size, direction, width,
+   * glyphs: [{ id, ax, dx, dy }] }`, glyphs in visual order with ntk's
+   * pen contract — `ax` the advance, `dx`/`dy` the drawing offset from the
+   * pen (y up). One CTLine through the typesetter, which is what a cluster
+   * (a base with combining marks, an emoji with a variation selector)
+   * needs and a grid renderer bypasses for everything else.
+   *
+   * One thing ntk's `shape()` never does happens here: CoreText substitutes
+   * a face for characters this one lacks instead of shaping them as
+   * `.notdef`, and a glyph from a substituted run carries that face as
+   * `font` — an extra field ntk's contract ignores and this backend's
+   * `drawGlyphs` honours, so `☺️` in Menlo comes out as the emoji rather
+   * than Menlo's glyph at the emoji font's index.
+   */
+  shape(text, size, opts = {}) {
+    const manager = this._manager;
+    const raw = manager._native.fontShapeText(this._handle(size), String(text));
+    const glyphs = [];
+    let pen = 0;
+    for (const run of raw.runs) {
+      const face = run.font ? manager._faceOfHandle(run.font, size) : null;
+      for (let i = 0; i < run.glyphs.length; i++) {
+        const ax = run.advances[i];
+        const glyph = {
+          id: run.glyphs[i],
+          ax,
+          dx: run.positions[i * 2] - pen,
+          dy: run.positions[i * 2 + 1],
+        };
+        if (face) glyph.font = face;
+        glyphs.push(glyph);
+        pen += ax;
+      }
+    }
+    return {
+      font: this,
+      size,
+      direction: opts.direction ?? 'ltr',
+      width: raw.width,
+      glyphs,
+    };
+  }
+}
+
 export class CocoaFontManager {
-  constructor() {
-    this._native = loadNative();
+  /** @param native the @windowkit/appkit module; the tests hand in a fake */
+  constructor(native = loadNative()) {
+    this._native = native;
     this._fonts = new Map(); // family|weight|italic|size -> handle
     this._faces = new Map(); // family|weight|italic -> face wrapper
     this._registered = new Map(); // lowercase family -> [{cg, weight, italic}]
     this._byKey = new Map(); // ntk Font key -> { cg } | { ps }
     this._sized = new Map(); // face key|size|variations -> CTFont handle
     this._layouts = new Map(); // layout signature -> CocoaTextLayout (LRU)
+    this._fallbacks = new Map(); // family|weight|italic -> Map(cp -> face|null)
+    this._faceByPs = new Map(); // PostScript name -> face CoreText chose itself
   }
 
   /**
@@ -211,6 +378,7 @@ export class CocoaFontManager {
           this._fonts.clear();
           this._faces.clear();
           this._sized.clear();
+          this._fallbacks.clear();
         }
       }
     } catch {
@@ -354,8 +522,10 @@ export class CocoaFontManager {
 
   /**
    * A face by family/weight/style — what `textBoxTrim` reads `capHeight`
-   * from. The face defers size, like ntk's: `metrics(size)` answers for a
-   * concrete pixel size.
+   * from and what a terminal builds its glyph runs on. The face defers
+   * size, like ntk's: `metrics(size)` answers for a concrete pixel size,
+   * and the family re-resolves per size through `_font` (SF's optical
+   * sizing is a different face at 13px and at 28px).
    */
   match(family, { weight, style } = {}) {
     const w = numericWeight(weight);
@@ -363,23 +533,118 @@ export class CocoaFontManager {
     const key = `${family}|${w}|${italic}`;
     let face = this._faces.get(key);
     if (!face) {
-      const manager = this;
-      face = {
-        metrics(size) {
-          return manager._native.fontMetrics(
-            manager._font(family, w, italic, size ?? 14),
-          );
-        },
-        hasGlyph(char) {
-          return manager._native.fontHasGlyph(
-            manager._font(family, w, italic, 14),
-            String(char),
-          );
-        },
-      };
+      face = new CocoaFace(this, key, (size) =>
+        this._font(family, w, italic, size),
+      );
       this._faces.set(key, face);
     }
     return face;
+  }
+
+  /**
+   * A face that covers `codepoint` when the one for `family` does not, or
+   * `null` when nothing on the system does — ntk's
+   * `FontManager.fallbackFor`, in its order: faces the app loaded first (an
+   * app that ships a font means the one it ships), then CoreText's cascade
+   * off the matched face (`CTFontCreateForString`), the same substitution
+   * `layout()` gets from the typesetter. Cached per family, weight, style
+   * and code point; the matched face itself when it already covers the
+   * code point, so runs group with the base's.
+   */
+  fallbackFor(codepoint, family = 'sans-serif', opts = {}) {
+    if (typeof codepoint !== 'number') {
+      codepoint = String(codepoint).codePointAt(0) ?? -1;
+    }
+    const w = numericWeight(opts.weight);
+    const italic = isItalic(opts.style);
+    const cacheKey = `${family}|${w}|${italic}`;
+    let perCp = this._fallbacks.get(cacheKey);
+    if (!perCp) {
+      perCp = new Map();
+      this._fallbacks.set(cacheKey, perCp);
+    }
+    if (perCp.has(codepoint)) return perCp.get(codepoint);
+    const base = this.match(family, {
+      weight: w,
+      style: italic ? 'italic' : 'normal',
+    });
+    let found = null;
+    for (const faces of this._registered.values()) {
+      for (const reg of faces) {
+        const face = this._registeredFace(reg);
+        if (face.glyphIdFor(codepoint) !== null) {
+          found = face;
+          break;
+        }
+      }
+      if (found) break;
+    }
+    if (!found) {
+      let text = null;
+      try {
+        text = String.fromCodePoint(codepoint);
+      } catch {
+        text = null; // not a scalar value: nothing covers it
+      }
+      const handle =
+        text === null
+          ? null
+          : this._native.fontFallbackFor(base._handle(PROBE_SIZE), text);
+      if (handle) found = this._faceOfHandle(handle, PROBE_SIZE);
+    }
+    if (
+      found &&
+      found !== base &&
+      found.postscriptName === base.postscriptName
+    ) {
+      found = base;
+    }
+    perCp.set(codepoint, found);
+    return found;
+  }
+
+  /** The face of a loaded file, over its own CGFont handle. */
+  _registeredFace(reg) {
+    if (!reg.face) {
+      reg.face = new CocoaFace(this, 'registered', (size) =>
+        this._native.cgFontWithSize(reg.cg, size),
+      );
+      reg.face.key = `registered:${reg.face.postscriptName}`;
+    }
+    return reg.face;
+  }
+
+  /**
+   * The face behind a CTFont handle CoreText chose itself — a fallback, or
+   * a substituted run inside `shape()` — one object per PostScript name, so
+   * runs from either route group together in `drawGlyphs`. The handle seeds
+   * the size it came at; other sizes are copies of it.
+   */
+  _faceOfHandle(handle, size) {
+    const ps = this._native.fontMetrics(handle).postScriptName;
+    let face = this._faceByPs.get(ps);
+    if (!face) {
+      face = new CocoaFace(this, `ps:${ps}`, (s) =>
+        this._native.fontWithSize(handle, s),
+      );
+      this._faceByPs.set(ps, face);
+    }
+    if (!face._sized.has(size)) face._sized.set(size, handle);
+    return face;
+  }
+
+  /**
+   * The CTFont a glyph run draws with (`CocoaContext2D.drawGlyphs`): a face
+   * of this engine's at the run's size, or an ntk `Font` — `openFont()`'s —
+   * resolved to CoreText from the same bytes, so the glyph ids it shaped
+   * with hold. Null for anything else, and the run is skipped.
+   */
+  _runHandle(font, size) {
+    if (font instanceof CocoaFace) return font._handle(size);
+    if (font && (font.postscriptName || font.path || font.fk)) {
+      return this._faceFont(font, size);
+    }
+    return null;
   }
 
   /**
@@ -444,6 +709,7 @@ export class CocoaFontManager {
     this._faces.clear();
     this._sized.clear();
     this._layouts.clear();
+    this._fallbacks.clear();
     // `null` on purpose: src/fonts.js keeps the fontkit face it already
     // opened as the handle, which is the one whose metrics apps can read;
     // the registry above is what rendering resolves against.
@@ -500,9 +766,11 @@ export class CocoaFontManager {
       // which is how the fonts app renders exactly the file it opened.
       const face = span.font ?? base.font;
       let handle =
-        face && (face.postscriptName || face.path || face.fk)
-          ? this._faceFont(face, size, variations)
-          : null;
+        face instanceof CocoaFace
+          ? this._withVariations(face._handle(size), variations)
+          : face && (face.postscriptName || face.path || face.fk)
+            ? this._faceFont(face, size, variations)
+            : null;
       handle ??= this._withVariations(
         this._font(
           span.family ?? base.family,

--- a/test/cocoa-glyph-runs.test.js
+++ b/test/cocoa-glyph-runs.test.js
@@ -7,10 +7,10 @@
 // the grouping, the pen walk, the dy flip, the colour, the caches —
 // asserted on what reaches the natives, which is the whole of what the glue
 // decides. The second runs only where the real bridge loads (a Mac with
-// @windowkit/appkit, or REACT_X11_CALAYERS_PATH at a built checkout) and
-// pins the CoreText facts the glue relies on, ending in pixels: a glyph
-// drawn through the whole stack lands upright at its baseline, in the ink
-// it was given.
+// @windowkit/appkit, or REACT_X11_CALAYERS_PATH at a checkout) and pins the
+// CoreText facts the glue relies on, ending in pixels: a glyph drawn
+// through the whole stack lands upright at its baseline, in the ink it was
+// given.
 import assert from 'node:assert';
 import { describe, test } from 'node:test';
 
@@ -21,11 +21,12 @@ import { loadNative } from '../src/cocoa/native.js';
 // --- the fake bridge ----------------------------------------------------------
 
 /**
- * A bridge shaped like @windowkit/appkit's font and glyph natives. Handles
- * are plain objects keyed by what made them, so the same request answers
- * the same object — the property `drawGlyphs`'s grouping stands on. Glyph
- * ids are `codepoint + 1` in the base faces, so a test can tell an id from
- * the code point it came from.
+ * A bridge shaped like @windowkit/appkit 0.2's font and glyph natives.
+ * Handles are plain objects keyed by what made them, so the same request
+ * answers the same object — the property `drawGlyphs`'s grouping and
+ * `fallbackFor`'s "no substitution needed" both stand on. Glyph ids are
+ * `codepoint + 1` in the base faces, so a test can tell an id from the code
+ * point it came from.
  */
 function fakeNative() {
   const calls = [];
@@ -38,12 +39,6 @@ function fakeNative() {
     }
     return h;
   };
-  const emojiAt = (size) =>
-    handleFor(`AppleColorEmoji@${size}`, {
-      ps: 'AppleColorEmoji',
-      family: 'Emoji',
-      size,
-    });
   const native = {
     calls,
     matchFont({ families, size, weight, italic }) {
@@ -78,13 +73,18 @@ function fakeNative() {
     fontGlyphAdvances(h, glyphs) {
       return Float64Array.from(glyphs, () => h.size * 0.6);
     },
-    fontWithSize(h, size) {
-      return handleFor(`${h.ps}@${size}`, { ps: h.ps, family: h.family, size });
-    },
+    // 0.2's contract: a code point or a string; the handle ITSELF when the
+    // face covers the text; null when nothing does
     fontFallbackFor(h, text) {
-      const cp = text.codePointAt(0);
-      if (cp < 0x80) return h; // the base covers it
-      if (cp >= 0x1f000) return emojiAt(h.size);
+      const cp = typeof text === 'number' ? text : text.codePointAt(0);
+      if (native.fontGlyphForCodepoint(h, cp) !== null) return h;
+      if (cp >= 0x1f000) {
+        return handleFor(`AppleColorEmoji@${h.size}`, {
+          ps: 'AppleColorEmoji',
+          family: 'Emoji',
+          size: h.size,
+        });
+      }
       if (cp < 0x3000) {
         return handleFor(`Fallback@${h.size}`, {
           ps: 'Fallback-Regular',
@@ -94,47 +94,29 @@ function fakeNative() {
       }
       return null;
     },
-    fontShapeText(h, text) {
-      if (text === 'é') {
-        // a base and a mark: the mark sits back over the base, raised
-        return {
-          width: 8,
-          runs: [
-            {
-              font: null,
-              glyphs: Uint16Array.from([0x66, 0x302]),
-              positions: Float64Array.from([0, 0, 6, 2]),
-              advances: Float64Array.from([8, 0]),
-            },
-          ],
-        };
-      }
-      if (text === '☺️') {
-        // CoreText substituted the emoji face for the whole cluster
-        return {
-          width: 16,
-          runs: [
-            {
-              font: emojiAt(h.size),
-              glyphs: Uint16Array.from([77]),
-              positions: Float64Array.from([0, 0]),
-              advances: Float64Array.from([16]),
-            },
-          ],
-        };
-      }
-      const cps = [...text].map((ch) => ch.codePointAt(0));
+    createLayout({ spans, rtl }) {
+      const text = spans.map((s) => s.text).join('');
+      const width = [...text].length * 8;
       return {
-        width: cps.length * 8,
-        runs: [
+        handle: { text, font: spans[0]?.font, rtl: Boolean(rtl) },
+        width,
+        height: 16,
+        lines: [
           {
-            font: null,
-            glyphs: Uint16Array.from(cps, (cp) => cp + 1),
-            positions: Float64Array.from(cps.flatMap((_, i) => [i * 8, 0])),
-            advances: Float64Array.from(cps, () => 8),
+            x: 0,
+            y: 0,
+            width,
+            height: 16,
+            baseline: 12,
+            start: 0,
+            end: text.length,
+            runs: [],
           },
         ],
       };
+    },
+    drawLayout(surface, handle, x, y) {
+      calls.push(['layout', handle.text, x, y]);
     },
     fontFromData() {
       return {
@@ -163,7 +145,7 @@ function fakeNative() {
     ctxSetFillColor(surface, r, g, b, a) {
       calls.push(['fill', r, g, b, a]);
     },
-    ctxDrawGlyphs(surface, runs, replace) {
+    ctxDrawGlyphs(surface, runs, ...rest) {
       calls.push([
         'draw',
         runs.map((run) => ({
@@ -171,7 +153,7 @@ function fakeNative() {
           glyphs: [...run.glyphs],
           positions: [...run.positions],
         })),
-        replace,
+        rest.length,
       ]);
     },
   };
@@ -224,33 +206,48 @@ test('a matched face answers ntk seams: glyph ids, advances at a size, both metr
   assert.equal(face.postscriptName, 'Menlo-400');
 });
 
-test('shape walks the pen: ax from the advances, dx/dy from the positions, y up', () => {
+test('shape answers covered text from the cmap: real ids, advances at the size, a pen that walks', () => {
   const fonts = new CocoaFontManager(fakeNative());
   const face = fonts.match('Menlo');
-  const shaped = face.shape('é', 14);
+  const shaped = face.shape('Hi', 14);
   assert.strictEqual(shaped.font, face);
   assert.equal(shaped.size, 14);
-  assert.equal(shaped.width, 8);
-  assert.deepEqual(shaped.glyphs, [glyph(0x66, 8), glyph(0x302, 0, -2, 2)]);
-  const plain = face.shape('Hi', 14).glyphs;
-  assert.deepEqual(plain, [glyph(0x49, 8), glyph(0x6a, 8)]);
+  assert.deepEqual(shaped.glyphs, [glyph(0x49, 8.4), glyph(0x6a, 8.4)]);
+  assert.equal(shaped.width, 16.8);
+  assert.equal(shaped.direction, 'ltr');
+  assert.deepEqual(face.shape('', 14).glyphs, []);
 });
 
-test('a run CoreText substituted carries its face on the glyph, and it is the fallback face', () => {
+test('shape sends what the cmap cannot answer through the typesetter, as one glyph carrying its line', () => {
   const fonts = new CocoaFontManager(fakeNative());
   const face = fonts.match('Menlo');
-  const shaped = face.shape('☺️', 14);
-  assert.strictEqual(shaped.font, face, 'the result is still this face');
-  assert.equal(shaped.glyphs.length, 1);
-  const emoji = shaped.glyphs[0].font;
-  assert.ok(emoji instanceof CocoaFace);
-  assert.equal(emoji.postscriptName, 'AppleColorEmoji');
-  assert.equal(emoji.glyphIdFor(0x1f600), 0x601);
-  // one object per PostScript name, whichever route found it
-  assert.strictEqual(fonts.fallbackFor(0x1f600, 'Menlo'), emoji);
-  // and it answers at every size through fontWithSize
-  assert.equal(emoji.advanceOf(1, 20), 12);
-  assert.equal(emoji.metrics(10).lineHeight, 11);
+  const cases = [
+    ['é', 'a base with a mark is one grapheme of two code points'],
+    ['☺️', 'an emoji with a variation selector'],
+    ['漢', 'a code point this face lacks'],
+    ['a漢', 'one uncovered cluster takes the whole text along'],
+  ];
+  for (const [text, why] of cases) {
+    const shaped = face.shape(text, 14);
+    assert.equal(shaped.glyphs.length, 1, why);
+    const [g] = shaped.glyphs;
+    assert.equal(g.id, 0, why);
+    assert.equal(g.ax, [...text].length * 8, `the line's width: ${why}`);
+    assert.equal(g.dx, 0);
+    assert.equal(g.dy, 0);
+    assert.equal(g._layout.lines[0].baseline, 12, why);
+    assert.strictEqual(
+      g._layout._handle.font,
+      face._handle(14),
+      'in this face at this size',
+    );
+    assert.equal(shaped.width, g.ax);
+  }
+  // right-to-left text is the typesetter's even when covered
+  const rtl = face.shape('ab', 14, { direction: 'rtl' });
+  assert.equal(rtl.glyphs.length, 1);
+  assert.equal(rtl.glyphs[0]._layout._handle.rtl, true);
+  assert.equal(rtl.direction, 'rtl');
 });
 
 test('fallbackFor: the base for what it covers, a cascade face otherwise, null when nothing does, cached', () => {
@@ -264,15 +261,36 @@ test('fallbackFor: the base for what it covers, a cascade face otherwise, null w
   assert.equal(box.familyName, 'Fallback');
   assert.equal(box.glyphIdFor(0x2500), 0x2500);
   assert.strictEqual(fonts.fallbackFor(0x2500, 'Menlo', opts), box, 'cached');
+  // one object per PostScript name, whichever base reached it
+  assert.strictEqual(fonts.fallbackFor(0x2501, 'Helvetica'), box);
   assert.equal(fonts.fallbackFor(0x3000, 'Menlo', opts), null);
   assert.equal(fonts.fallbackFor(0xd800, 'Menlo', opts), null, 'not a scalar');
   assert.equal(fonts.fallbackFor(Number.NaN, 'Menlo', opts), null);
   // a string is tolerated: its first code point
   assert.strictEqual(fonts.fallbackFor('─', 'Menlo', opts), box);
+  const emoji = fonts.fallbackFor(0x1f600, 'Menlo');
+  assert.equal(emoji.postscriptName, 'AppleColorEmoji');
+  assert.equal(emoji.glyphIdFor(0x1f600), 0x601);
 });
 
-test('a face the app loaded is consulted before the cascade', () => {
+test('a fallback face answers at every size by asking CoreText the same question at that size', () => {
+  const native = fakeNative();
+  const fonts = new CocoaFontManager(native);
+  const box = fonts.fallbackFor(0x2500, 'Menlo');
+  assert.equal(box._handle(14).size, 14, 'seeded with the handle it came at');
+  assert.equal(
+    box.advanceOf(0x2500, 20),
+    12,
+    'fontFallbackFor off Menlo at 20',
+  );
+  assert.equal(box._handle(20).key, 'Fallback@20');
+  assert.equal(box.metrics(10).lineHeight, 11);
+});
+
+test('a face the app loaded is consulted before the cascade, and loading forgets what was cached', () => {
   const fonts = new CocoaFontManager(fakeNative());
+  const before = fonts.fallbackFor(0x2500, 'Menlo');
+  assert.equal(before.familyName, 'Fallback');
   fonts.load(Buffer.from([0, 1, 0, 0, 0, 0]));
   const loaded = fonts.fallbackFor(0x2500, 'Menlo');
   assert.ok(loaded instanceof CocoaFace);
@@ -314,8 +332,12 @@ test('drawGlyphs groups by face and size, walks the pen, flips dy, and sets the 
   ]);
   assert.equal(native.calls.length, 2);
   assert.deepEqual(native.calls[0], ['fill', 1, 0, 0, 0.5]);
-  const [, runs, replace] = native.calls[1];
-  assert.equal(replace, false);
+  const [, runs, extraArgs] = native.calls[1];
+  assert.equal(
+    extraArgs,
+    0,
+    "0.2's ctxDrawGlyphs takes the surface and the runs",
+  );
   assert.equal(runs.length, 2, 'one native run per (face, size)');
   const at14 = runs.find((r) => r.font.size === 14);
   const at20 = runs.find((r) => r.font.size === 20);
@@ -331,18 +353,18 @@ test('drawGlyphs groups by face and size, walks the pen, flips dy, and sets the 
   assert.equal(dirty(), 1);
 });
 
-test('a glyph with a face of its own draws with that face; a run nobody can resolve is skipped', () => {
+test('a typeset cluster draws its line at the pen, top-aligned from the baseline; a run nobody can resolve is skipped', () => {
   const native = fakeNative();
   const { ctx, fonts } = context(native);
   const menlo = fonts.match('Menlo');
-  const emoji = fonts.fallbackFor(0x1f600, 'Menlo');
-  const cluster = {
+  const cluster = menlo.shape('☺️', 14).glyphs[0];
+  const run = {
     font: menlo,
     size: 14,
-    glyphs: [glyph(1, 8), { ...glyph(77, 16), font: emoji }, glyph(2, 8)],
+    glyphs: [glyph(1, 8), cluster, glyph(2, 8)],
   };
   ctx.drawGlyphs(3, ctx.createSolidPicture(1, 1, 1, 1), [
-    { run: cluster, x: 0, y: 10 },
+    { run, x: 0, y: 30 },
     {
       run: { font: { not: 'a face' }, size: 14, glyphs: [glyph(9, 8)] },
       x: 0,
@@ -350,31 +372,30 @@ test('a glyph with a face of its own draws with that face; a run nobody can reso
     },
     { run: { font: menlo, size: 14, glyphs: [] }, x: 0, y: 0 },
   ]);
+  assert.deepEqual(native.calls[0], ['fill', 1, 1, 1, 1]);
   const [, runs] = native.calls[1];
-  assert.equal(runs.length, 2);
-  const base = runs.find((r) => r.font.family === 'Menlo');
-  const sub = runs.find((r) => r.font.family === 'Emoji');
-  assert.deepEqual(base.glyphs, [1, 2]);
+  assert.equal(runs.length, 1);
+  assert.deepEqual(runs[0].glyphs, [1, 2]);
   assert.deepEqual(
-    base.positions,
-    [0, 10, 24, 10],
-    'the pen advanced past the emoji',
+    runs[0].positions,
+    [0, 30, 24, 30],
+    'the pen advanced past the cluster',
   );
-  assert.deepEqual(sub.glyphs, [77]);
-  assert.deepEqual(sub.positions, [8, 10]);
-  assert.equal(sub.font.size, 14, "the substitute at the run's size");
+  // the line: 16 wide (two code points in the fake), drawn after the glyph
+  // batch at x = 8 and a baseline (12) above y = 30
+  assert.deepEqual(native.calls[2], ['layout', '☺️', 8, 18]);
+  assert.equal(native.calls.length, 3);
 });
 
-test('Src replaces, anything else composites; nothing to draw is no call at all', () => {
+test('every op draws as Over on this bridge; nothing to draw is no call at all', () => {
   const native = fakeNative();
   const { ctx, fonts, dirty } = context(native);
   const run = { font: fonts.match('Menlo'), size: 14, glyphs: [glyph(1, 8)] };
   ctx.drawGlyphs(ctx.Render.PictOp.Src, ctx.createSolidPicture(0, 0, 0, 1), [
     { run, x: 0, y: 0 },
   ]);
-  assert.equal(native.calls[1][2], true);
   ctx.drawGlyphs(12, ctx.createSolidPicture(0, 0, 0, 1), [{ run, x: 0, y: 0 }]);
-  assert.equal(native.calls[3][2], false);
+  assert.deepEqual(native.calls[1], native.calls[3]);
   const before = native.calls.length;
   ctx.drawGlyphs(3, ctx.createSolidPicture(0, 0, 0, 1), []);
   ctx.drawGlyphs(3, ctx.createSolidPicture(0, 0, 0, 1), undefined);
@@ -426,15 +447,34 @@ describe(
     skip: bridge ? false : 'the @windowkit/appkit bridge is not loadable here',
   },
   () => {
-    const redRows = (px, width, height) => {
+    const inkRows = (px, width, height, isInk) => {
       const rows = new Set();
       for (let y = 0; y < height; y++) {
         for (let x = 0; x < width; x++) {
           const i = (y * width + x) * 4;
-          if (px[i] > 128 && px[i + 1] < 64) rows.add(y);
+          if (isInk(px[i], px[i + 1], px[i + 2])) rows.add(y);
         }
       }
       return [...rows].sort((a, b) => a - b);
+    };
+    const red = (r, g) => r > 128 && g < 64;
+
+    const paint = (fonts, width, height, draw) => {
+      const surface = bridge.createSurface(width, height, 1);
+      const ctx = new CocoaContext2D(
+        bridge,
+        () => surface,
+        () => 1,
+      );
+      ctx._fonts = fonts;
+      ctx.fillStyle = '#000';
+      ctx.fillRect(0, 0, width, height);
+      draw(ctx);
+      return {
+        ctx,
+        px: bridge.ctxGetImageData(surface, 0, 0, width, height),
+        surface,
+      };
     };
 
     test('Menlo: a glyph id, its advance, and a line height that is finite', () => {
@@ -453,61 +493,62 @@ describe(
       assert.equal(menlo.familyName, 'Menlo');
     });
 
-    test('fallbackFor: emoji to Apple Color Emoji, a noncharacter to null, the base for what it covers', () => {
+    test('fallbackFor: emoji to Apple Color Emoji at every size, a noncharacter to null, the base for what it covers', () => {
       const fonts = new CocoaFontManager(bridge);
       const menlo = fonts.match('Menlo');
       const emoji = fonts.fallbackFor(0x1f600, 'Menlo');
       assert.ok(emoji instanceof CocoaFace);
       assert.equal(emoji.familyName, 'Apple Color Emoji');
-      assert.ok(emoji.glyphIdFor(0x1f600) > 0);
-      assert.ok(emoji.advanceOf(emoji.glyphIdFor(0x1f600), 14) > 0);
+      const id = emoji.glyphIdFor(0x1f600);
+      assert.ok(id > 0);
+      // the same face at every size — a bitmap-strike font, so its advance
+      // grows with the size without being linear in it
+      const at14 = emoji.advanceOf(id, 14);
+      const at28 = emoji.advanceOf(id, 28);
+      assert.ok(at14 > 0 && at28 > at14, `${at14} ${at28}`);
+      assert.equal(emoji._handle(28) === emoji._handle(14), false);
+      assert.equal(emoji.postscriptName, 'AppleColorEmoji');
+      assert.equal(emoji.metrics(28).size, 28);
       assert.strictEqual(fonts.fallbackFor(0x30, 'Menlo'), menlo);
       assert.equal(fonts.fallbackFor(0xffff, 'Menlo'), null);
     });
 
-    test('shape: a cluster comes back positioned, a substituted one carrying its face', () => {
+    test('shape: covered text is real ids; a mark cluster, an emoji sequence and RTL are one typeset glyph', () => {
       const fonts = new CocoaFontManager(bridge);
       const menlo = fonts.match('Menlo');
-      const accented = menlo.shape('é', 14);
-      assert.ok(accented.glyphs.length >= 1);
-      assert.ok(accented.width > 0);
-      for (const g of accented.glyphs) {
-        assert.ok(Number.isInteger(g.id));
-        assert.ok(Number.isFinite(g.ax + g.dx + g.dy));
+      const plain = menlo.shape('Hé', 14);
+      assert.equal(plain.glyphs.length, 2);
+      assert.equal(plain.glyphs[0].id, menlo.glyphIdFor(0x48));
+      assert.equal(plain.glyphs[1].id, menlo.glyphIdFor(0xe9));
+      assert.ok(plain.width > 14);
+      for (const text of ['é', '☺️', '👍🏽', 'של']) {
+        const shaped = menlo.shape(
+          text,
+          14,
+          text === 'של' ? { direction: 'rtl' } : {},
+        );
+        assert.equal(shaped.glyphs.length, 1, text);
+        assert.equal(shaped.glyphs[0].id, 0, text);
+        assert.ok(shaped.glyphs[0]._layout, text);
+        assert.ok(shaped.glyphs[0].ax > 0, text);
+        assert.equal(shaped.width, shaped.glyphs[0].ax);
       }
-      const smiley = menlo.shape('☺️', 14);
-      assert.ok(smiley.glyphs.length >= 1);
-      assert.ok(
-        smiley.glyphs[0].font instanceof CocoaFace,
-        'CoreText substituted a face',
-      );
-      assert.equal(smiley.glyphs[0].font.familyName, 'Apple Color Emoji');
     });
 
     test('drawGlyphs puts an H upright between the cap line and its baseline, in the ink asked for', () => {
-      const surface = bridge.createSurface(64, 32, 1);
-      const ctx = new CocoaContext2D(
-        bridge,
-        () => surface,
-        () => 1,
-      );
       const fonts = new CocoaFontManager(bridge);
-      ctx._fonts = fonts;
-      ctx.fillStyle = '#000';
-      ctx.fillRect(0, 0, 64, 32);
       const menlo = fonts.match('Menlo');
-      const h = menlo.glyphIdFor(0x48);
-      const run = { font: menlo, size: 20, glyphs: [glyph(h, 12)] };
-      ctx.drawGlyphs(
-        ctx.Render.PictOp.Over,
-        ctx.createSolidPicture(1, 0, 0, 1),
-        [{ run, x: 4, y: 24 }],
+      const run = {
+        font: menlo,
+        size: 20,
+        glyphs: [glyph(menlo.glyphIdFor(0x48), 12)],
+      };
+      const { ctx, surface, px } = paint(fonts, 64, 32, (c) =>
+        c.drawGlyphs(c.Render.PictOp.Over, c.createSolidPicture(1, 0, 0, 1), [
+          { run, x: 4, y: 24 },
+        ]),
       );
-      const rows = redRows(
-        bridge.ctxGetImageData(surface, 0, 0, 64, 32),
-        64,
-        32,
-      );
+      const rows = inkRows(px, 64, 32, red);
       assert.ok(rows.length > 0, 'ink');
       const capHeight = menlo.metrics(20).capHeight;
       // the top of the H is a cap height above the baseline; nothing below it
@@ -523,11 +564,47 @@ describe(
       // and the fill style the context carries was not disturbed for the next painter
       ctx.fillStyle = '#0f0';
       ctx.fillRect(0, 0, 2, 2);
-      const px = bridge.ctxGetImageData(surface, 0, 0, 1, 1);
-      assert.deepEqual([...px].slice(0, 3), [0, 255, 0]);
+      assert.deepEqual(
+        [...bridge.ctxGetImageData(surface, 0, 0, 1, 1)].slice(0, 3),
+        [0, 255, 0],
+      );
     });
 
-    test('Src replaces where Over composites', () => {
+    test('a typeset cluster in a run draws where the pen puts it, in the same ink', () => {
+      const fonts = new CocoaFontManager(bridge);
+      const menlo = fonts.match('Menlo');
+      const cluster = menlo.shape('é', 20).glyphs[0];
+      const run = {
+        font: menlo,
+        size: 20,
+        glyphs: [glyph(menlo.glyphIdFor(0x48), 12), cluster],
+      };
+      const { px } = paint(fonts, 64, 32, (c) =>
+        c.drawGlyphs(3, c.createSolidPicture(1, 0, 0, 1), [
+          { run, x: 4, y: 24 },
+        ]),
+      );
+      // the cluster's column: x from 16 on; ink above the baseline, none below
+      const cols = new Set();
+      const rows = new Set();
+      for (let y = 0; y < 32; y++) {
+        for (let x = 16; x < 64; x++) {
+          const i = (y * 64 + x) * 4;
+          if (red(px[i], px[i + 1])) {
+            cols.add(x);
+            rows.add(y);
+          }
+        }
+      }
+      assert.ok(cols.size > 3, 'the cluster inked');
+      assert.ok(Math.max(...rows) <= 24, 'nothing below the baseline');
+      assert.ok(
+        Math.min(...rows) < 24 - 10,
+        'the mark sits above the x-height',
+      );
+    });
+
+    test('Src draws as Over on this bridge', () => {
       const fonts = new CocoaFontManager(bridge);
       const menlo = fonts.match('Menlo');
       const run = {
@@ -552,7 +629,7 @@ describe(
         return [...bridge.ctxGetImageData(surface, 6, 16, 1, 1)];
       };
       assert.deepEqual(stem(3), [255, 128, 128, 255]);
-      assert.deepEqual(stem(1), [255, 255, 255, 128]);
+      assert.deepEqual(stem(1), [255, 128, 128, 255]);
     });
   },
 );

--- a/test/cocoa-glyph-runs.test.js
+++ b/test/cocoa-glyph-runs.test.js
@@ -21,7 +21,7 @@ import { loadNative } from '../src/cocoa/native.js';
 // --- the fake bridge ----------------------------------------------------------
 
 /**
- * A bridge shaped like @windowkit/appkit 0.2's font and glyph natives.
+ * A bridge shaped like @windowkit/appkit 0.3's font and glyph natives.
  * Handles are plain objects keyed by what made them, so the same request
  * answers the same object — the property `drawGlyphs`'s grouping and
  * `fallbackFor`'s "no substitution needed" both stand on. Glyph ids are
@@ -94,29 +94,62 @@ function fakeNative() {
       }
       return null;
     },
-    createLayout({ spans, rtl }) {
-      const text = spans.map((s) => s.text).join('');
-      const width = [...text].length * 8;
-      return {
-        handle: { text, font: spans[0]?.font, rtl: Boolean(rtl) },
-        width,
-        height: 16,
-        lines: [
-          {
-            x: 0,
-            y: 0,
-            width,
-            height: 16,
-            baseline: 12,
-            start: 0,
-            end: text.length,
-            runs: [],
-          },
-        ],
-      };
+    fontWithSize(h, size) {
+      return handleFor(`${h.ps}@${size}`, {
+        ps: h.ps,
+        family: h.family,
+        size,
+      });
     },
-    drawLayout(surface, handle, x, y) {
-      calls.push(['layout', handle.text, x, y]);
+    // 0.3's contract: one CTLine read back run by run; a run's font is null
+    // for the font asked for and a handle for a face CoreText substituted
+    fontShapeText(h, text) {
+      if (text === 'é') {
+        // a base and a mark: the mark sits back over the base, raised
+        return {
+          width: 8,
+          runs: [
+            {
+              font: null,
+              glyphs: Uint16Array.from([0x66, 0x302]),
+              positions: Float64Array.from([0, 0, 6, 2]),
+              advances: Float64Array.from([8, 0]),
+            },
+          ],
+        };
+      }
+      if (text === '☺️') {
+        // CoreText substituted the emoji face for the whole cluster
+        return {
+          width: 16,
+          runs: [
+            {
+              font: handleFor(`AppleColorEmoji@${h.size}`, {
+                ps: 'AppleColorEmoji',
+                family: 'Emoji',
+                size: h.size,
+              }),
+              glyphs: Uint16Array.from([77]),
+              positions: Float64Array.from([0, 0]),
+              advances: Float64Array.from([16]),
+            },
+          ],
+        };
+      }
+      const cps = [...text].map((ch) => ch.codePointAt(0));
+      return {
+        width: cps.length * 8,
+        runs: cps.length
+          ? [
+              {
+                font: null,
+                glyphs: Uint16Array.from(cps, (cp) => cp + 1),
+                positions: Float64Array.from(cps.flatMap((_, i) => [i * 8, 0])),
+                advances: Float64Array.from(cps, () => 8),
+              },
+            ]
+          : [],
+      };
     },
     fontFromData() {
       return {
@@ -206,48 +239,45 @@ test('a matched face answers ntk seams: glyph ids, advances at a size, both metr
   assert.equal(face.postscriptName, 'Menlo-400');
 });
 
-test('shape answers covered text from the cmap: real ids, advances at the size, a pen that walks', () => {
+test('shape walks the pen: ax from the advances, dx/dy from the positions, y up', () => {
   const fonts = new CocoaFontManager(fakeNative());
   const face = fonts.match('Menlo');
-  const shaped = face.shape('Hi', 14);
+  const shaped = face.shape('é', 14);
   assert.strictEqual(shaped.font, face);
   assert.equal(shaped.size, 14);
-  assert.deepEqual(shaped.glyphs, [glyph(0x49, 8.4), glyph(0x6a, 8.4)]);
-  assert.equal(shaped.width, 16.8);
+  assert.equal(shaped.width, 8);
   assert.equal(shaped.direction, 'ltr');
+  assert.deepEqual(shaped.glyphs, [glyph(0x66, 8), glyph(0x302, 0, -2, 2)]);
+  const plain = face.shape('Hi', 14);
+  assert.deepEqual(plain.glyphs, [glyph(0x49, 8), glyph(0x6a, 8)]);
+  assert.equal(plain.width, 16);
+  assert.equal(
+    plain.glyphs[0].font,
+    undefined,
+    'no face on a glyph of the font asked for',
+  );
   assert.deepEqual(face.shape('', 14).glyphs, []);
+  assert.equal(face.shape('ab', 14, { direction: 'rtl' }).direction, 'rtl');
 });
 
-test('shape sends what the cmap cannot answer through the typesetter, as one glyph carrying its line', () => {
+test('a run CoreText substituted carries its face on the glyph, and it is the fallback face', () => {
   const fonts = new CocoaFontManager(fakeNative());
   const face = fonts.match('Menlo');
-  const cases = [
-    ['é', 'a base with a mark is one grapheme of two code points'],
-    ['☺️', 'an emoji with a variation selector'],
-    ['漢', 'a code point this face lacks'],
-    ['a漢', 'one uncovered cluster takes the whole text along'],
-  ];
-  for (const [text, why] of cases) {
-    const shaped = face.shape(text, 14);
-    assert.equal(shaped.glyphs.length, 1, why);
-    const [g] = shaped.glyphs;
-    assert.equal(g.id, 0, why);
-    assert.equal(g.ax, [...text].length * 8, `the line's width: ${why}`);
-    assert.equal(g.dx, 0);
-    assert.equal(g.dy, 0);
-    assert.equal(g._layout.lines[0].baseline, 12, why);
-    assert.strictEqual(
-      g._layout._handle.font,
-      face._handle(14),
-      'in this face at this size',
-    );
-    assert.equal(shaped.width, g.ax);
-  }
-  // right-to-left text is the typesetter's even when covered
-  const rtl = face.shape('ab', 14, { direction: 'rtl' });
-  assert.equal(rtl.glyphs.length, 1);
-  assert.equal(rtl.glyphs[0]._layout._handle.rtl, true);
-  assert.equal(rtl.direction, 'rtl');
+  const shaped = face.shape('☺️', 14);
+  assert.strictEqual(shaped.font, face, 'the result is still this face');
+  assert.equal(shaped.glyphs.length, 1);
+  const { font: emoji, ...rest } = shaped.glyphs[0];
+  assert.deepEqual(rest, glyph(77, 16));
+  assert.ok(emoji instanceof CocoaFace);
+  assert.equal(emoji.postscriptName, 'AppleColorEmoji');
+  assert.equal(emoji.glyphIdFor(0x1f600), 0x601);
+  // one object per PostScript name, whichever route found it
+  assert.strictEqual(fonts.fallbackFor(0x1f600, 'Menlo'), emoji);
+  // and it answers at every size through fontWithSize, as itself
+  assert.equal(emoji._handle(14).key, 'AppleColorEmoji@14');
+  assert.equal(emoji._handle(20).key, 'AppleColorEmoji@20');
+  assert.equal(emoji.advanceOf(1, 20), 12);
+  assert.equal(emoji.metrics(10).lineHeight, 11);
 });
 
 test('fallbackFor: the base for what it covers, a cascade face otherwise, null when nothing does, cached', () => {
@@ -273,17 +303,16 @@ test('fallbackFor: the base for what it covers, a cascade face otherwise, null w
   assert.equal(emoji.glyphIdFor(0x1f600), 0x601);
 });
 
-test('a fallback face answers at every size by asking CoreText the same question at that size', () => {
-  const native = fakeNative();
-  const fonts = new CocoaFontManager(native);
+test('a fallback face answers at every size as itself, through fontWithSize', () => {
+  const fonts = new CocoaFontManager(fakeNative());
   const box = fonts.fallbackFor(0x2500, 'Menlo');
-  assert.equal(box._handle(14).size, 14, 'seeded with the handle it came at');
   assert.equal(
-    box.advanceOf(0x2500, 20),
-    12,
-    'fontFallbackFor off Menlo at 20',
+    box._handle(14).key,
+    'Fallback@14',
+    'seeded with the handle it came at',
   );
-  assert.equal(box._handle(20).key, 'Fallback@20');
+  assert.equal(box.advanceOf(0x2500, 20), 12);
+  assert.equal(box._handle(20).key, 'Fallback-Regular@20');
   assert.equal(box.metrics(10).lineHeight, 11);
 });
 
@@ -353,7 +382,7 @@ test('drawGlyphs groups by face and size, walks the pen, flips dy, and sets the 
   assert.equal(dirty(), 1);
 });
 
-test('a typeset cluster draws its line at the pen, top-aligned from the baseline; a run nobody can resolve is skipped', () => {
+test('a glyph with a face of its own draws with that face; a run nobody can resolve is skipped', () => {
   const native = fakeNative();
   const { ctx, fonts } = context(native);
   const menlo = fonts.match('Menlo');
@@ -374,17 +403,23 @@ test('a typeset cluster draws its line at the pen, top-aligned from the baseline
   ]);
   assert.deepEqual(native.calls[0], ['fill', 1, 1, 1, 1]);
   const [, runs] = native.calls[1];
-  assert.equal(runs.length, 1);
-  assert.deepEqual(runs[0].glyphs, [1, 2]);
-  assert.deepEqual(
-    runs[0].positions,
-    [0, 30, 24, 30],
-    'the pen advanced past the cluster',
+  assert.equal(
+    runs.length,
+    2,
+    'the base face and the substitute, one native run each',
   );
-  // the line: 16 wide (two code points in the fake), drawn after the glyph
-  // batch at x = 8 and a baseline (12) above y = 30
-  assert.deepEqual(native.calls[2], ['layout', '☺️', 8, 18]);
-  assert.equal(native.calls.length, 3);
+  const base = runs.find((r) => r.font.family === 'Menlo');
+  const sub = runs.find((r) => r.font.family === 'Emoji');
+  assert.deepEqual(base.glyphs, [1, 2]);
+  assert.deepEqual(
+    base.positions,
+    [0, 30, 24, 30],
+    'the pen advanced past the emoji',
+  );
+  assert.deepEqual(sub.glyphs, [77]);
+  assert.deepEqual(sub.positions, [8, 30]);
+  assert.equal(sub.font.size, 14, "the substitute at the run's size");
+  assert.equal(native.calls.length, 2);
 });
 
 test('every op draws as Over on this bridge; nothing to draw is no call at all', () => {
@@ -513,26 +548,45 @@ describe(
       assert.equal(fonts.fallbackFor(0xffff, 'Menlo'), null);
     });
 
-    test('shape: covered text is real ids; a mark cluster, an emoji sequence and RTL are one typeset glyph', () => {
+    test('shape: real ids, a composed mark, and substituted runs carrying their face', () => {
       const fonts = new CocoaFontManager(bridge);
       const menlo = fonts.match('Menlo');
-      const plain = menlo.shape('Hé', 14);
-      assert.equal(plain.glyphs.length, 2);
-      assert.equal(plain.glyphs[0].id, menlo.glyphIdFor(0x48));
-      assert.equal(plain.glyphs[1].id, menlo.glyphIdFor(0xe9));
-      assert.ok(plain.width > 14);
-      for (const text of ['é', '☺️', '👍🏽', 'של']) {
-        const shaped = menlo.shape(
-          text,
-          14,
-          text === 'של' ? { direction: 'rtl' } : {},
-        );
-        assert.equal(shaped.glyphs.length, 1, text);
-        assert.equal(shaped.glyphs[0].id, 0, text);
-        assert.ok(shaped.glyphs[0]._layout, text);
-        assert.ok(shaped.glyphs[0].ax > 0, text);
-        assert.equal(shaped.width, shaped.glyphs[0].ax);
+      const plain = menlo.shape('Hi', 14);
+      assert.deepEqual(
+        plain.glyphs.map((g) => g.id),
+        [menlo.glyphIdFor(0x48), menlo.glyphIdFor(0x69)],
+      );
+      assert.ok(
+        Math.abs(plain.width - plain.glyphs[0].ax - plain.glyphs[1].ax) < 1e-6,
+      );
+      // e + combining acute composes into Menlo's own é
+      const composed = menlo.shape('e\u0301', 14);
+      assert.deepEqual(
+        composed.glyphs.map((g) => g.id),
+        [menlo.glyphIdFor(0xe9)],
+      );
+      assert.equal(composed.glyphs[0].font, undefined);
+      for (const [text, count] of [
+        ['☺️', 1],
+        ['👍🏽', 1],
+        ['של', 2],
+      ]) {
+        const shaped = menlo.shape(text, 14);
+        assert.equal(shaped.glyphs.length, count, text);
+        for (const g of shaped.glyphs) {
+          assert.ok(g.font instanceof CocoaFace, `${text}: a substituted face`);
+          assert.ok(Number.isInteger(g.id) && g.id > 0, text);
+          assert.ok(g.ax > 0, text);
+        }
       }
+      const smiley = menlo.shape('☺️', 14).glyphs[0];
+      assert.equal(smiley.font.familyName, 'Apple Color Emoji');
+      assert.strictEqual(
+        smiley.font,
+        fonts.fallbackFor(0x1f600, 'Menlo'),
+        'one face per PostScript name',
+      );
+      assert.equal(smiley.font.metrics(28).size, 28);
     });
 
     test('drawGlyphs puts an H upright between the cap line and its baseline, in the ink asked for', () => {
@@ -570,38 +624,36 @@ describe(
       );
     });
 
-    test('a typeset cluster in a run draws where the pen puts it, in the same ink', () => {
+    test('a substituted glyph in a run draws with its own face where the pen puts it', () => {
       const fonts = new CocoaFontManager(bridge);
       const menlo = fonts.match('Menlo');
-      const cluster = menlo.shape('é', 20).glyphs[0];
+      const [smiley] = menlo.shape('☺️', 20).glyphs;
       const run = {
         font: menlo,
         size: 20,
-        glyphs: [glyph(menlo.glyphIdFor(0x48), 12), cluster],
+        glyphs: [glyph(menlo.glyphIdFor(0x48), 12), smiley],
       };
-      const { px } = paint(fonts, 64, 32, (c) =>
+      const { px } = paint(fonts, 64, 40, (c) =>
         c.drawGlyphs(3, c.createSolidPicture(1, 0, 0, 1), [
-          { run, x: 4, y: 24 },
+          { run, x: 4, y: 30 },
         ]),
       );
-      // the cluster's column: x from 16 on; ink above the baseline, none below
-      const cols = new Set();
-      const rows = new Set();
-      for (let y = 0; y < 32; y++) {
-        for (let x = 16; x < 64; x++) {
+      // the emoji's column starts a Menlo advance past x = 4 and is coloured
+      // by the face itself, not by the red ink: yellow pixels there, and
+      // nothing above the H's cap line to its left
+      const capTop = 30 - menlo.metrics(20).capHeight - 1;
+      let yellow = 0;
+      let aboveTheH = 0;
+      for (let y = 0; y < 40; y++) {
+        for (let x = 0; x < 64; x++) {
           const i = (y * 64 + x) * 4;
-          if (red(px[i], px[i + 1])) {
-            cols.add(x);
-            rows.add(y);
-          }
+          const [r, g, b] = [px[i], px[i + 1], px[i + 2]];
+          if (x >= 16 && r > 128 && g > 100 && b < 120) yellow++;
+          if (x < 16 && y < capTop && r + g + b > 60) aboveTheH++;
         }
       }
-      assert.ok(cols.size > 3, 'the cluster inked');
-      assert.ok(Math.max(...rows) <= 24, 'nothing below the baseline');
-      assert.ok(
-        Math.min(...rows) < 24 - 10,
-        'the mark sits above the x-height',
-      );
+      assert.ok(yellow > 20, `the emoji inked in its own colours (${yellow})`);
+      assert.equal(aboveTheH, 0);
     });
 
     test('Src draws as Over on this bridge', () => {

--- a/test/cocoa-glyph-runs.test.js
+++ b/test/cocoa-glyph-runs.test.js
@@ -1,0 +1,558 @@
+// The Cocoa text engine's glyph-run seams — what `<Terminal backend="vt">`
+// reads (issue #432): a face from `fonts.match()` that answers `glyphIdFor`,
+// `advanceOf`, `shape` and ntk's metric names; `fonts.fallbackFor`; and a
+// context with `drawGlyphs`, `createSolidPicture` and `Render.PictOp`.
+//
+// Two layers. The first runs everywhere: the JS glue over a fake bridge —
+// the grouping, the pen walk, the dy flip, the colour, the caches —
+// asserted on what reaches the natives, which is the whole of what the glue
+// decides. The second runs only where the real bridge loads (a Mac with
+// @windowkit/appkit, or REACT_X11_CALAYERS_PATH at a built checkout) and
+// pins the CoreText facts the glue relies on, ending in pixels: a glyph
+// drawn through the whole stack lands upright at its baseline, in the ink
+// it was given.
+import assert from 'node:assert';
+import { describe, test } from 'node:test';
+
+import { CocoaContext2D } from '../src/cocoa/context2d.js';
+import { CocoaFace, CocoaFontManager } from '../src/cocoa/fonts.js';
+import { loadNative } from '../src/cocoa/native.js';
+
+// --- the fake bridge ----------------------------------------------------------
+
+/**
+ * A bridge shaped like @windowkit/appkit's font and glyph natives. Handles
+ * are plain objects keyed by what made them, so the same request answers
+ * the same object — the property `drawGlyphs`'s grouping stands on. Glyph
+ * ids are `codepoint + 1` in the base faces, so a test can tell an id from
+ * the code point it came from.
+ */
+function fakeNative() {
+  const calls = [];
+  const handles = new Map();
+  const handleFor = (key, props) => {
+    let h = handles.get(key);
+    if (!h) {
+      h = { key, ...props };
+      handles.set(key, h);
+    }
+    return h;
+  };
+  const emojiAt = (size) =>
+    handleFor(`AppleColorEmoji@${size}`, {
+      ps: 'AppleColorEmoji',
+      family: 'Emoji',
+      size,
+    });
+  const native = {
+    calls,
+    matchFont({ families, size, weight, italic }) {
+      const family = families[0];
+      return handleFor(`${family}|${weight}|${italic}|${size}`, {
+        ps: `${family}-${weight}${italic ? 'Italic' : ''}`,
+        family,
+        size,
+      });
+    },
+    fontMetrics(h) {
+      return {
+        ascent: h.size * 0.8,
+        descent: h.size * 0.2,
+        leading: h.size * 0.1,
+        capHeight: h.size * 0.7,
+        xHeight: h.size * 0.5,
+        size: h.size,
+        familyName: h.family,
+        postScriptName: h.ps,
+      };
+    },
+    fontHasGlyph(h, text) {
+      return native.fontGlyphForCodepoint(h, text.codePointAt(0)) !== null;
+    },
+    fontGlyphForCodepoint(h, cp) {
+      if (h.family === 'Emoji') return cp >= 0x1f000 ? cp - 0x1f000 + 1 : null;
+      if (h.family === 'Fallback') return cp >= 0x80 && cp < 0x3000 ? cp : null;
+      if (h.family === 'Loaded') return cp === 0x2500 ? 7 : null;
+      return cp < 0x80 ? cp + 1 : null;
+    },
+    fontGlyphAdvances(h, glyphs) {
+      return Float64Array.from(glyphs, () => h.size * 0.6);
+    },
+    fontWithSize(h, size) {
+      return handleFor(`${h.ps}@${size}`, { ps: h.ps, family: h.family, size });
+    },
+    fontFallbackFor(h, text) {
+      const cp = text.codePointAt(0);
+      if (cp < 0x80) return h; // the base covers it
+      if (cp >= 0x1f000) return emojiAt(h.size);
+      if (cp < 0x3000) {
+        return handleFor(`Fallback@${h.size}`, {
+          ps: 'Fallback-Regular',
+          family: 'Fallback',
+          size: h.size,
+        });
+      }
+      return null;
+    },
+    fontShapeText(h, text) {
+      if (text === 'é') {
+        // a base and a mark: the mark sits back over the base, raised
+        return {
+          width: 8,
+          runs: [
+            {
+              font: null,
+              glyphs: Uint16Array.from([0x66, 0x302]),
+              positions: Float64Array.from([0, 0, 6, 2]),
+              advances: Float64Array.from([8, 0]),
+            },
+          ],
+        };
+      }
+      if (text === '☺️') {
+        // CoreText substituted the emoji face for the whole cluster
+        return {
+          width: 16,
+          runs: [
+            {
+              font: emojiAt(h.size),
+              glyphs: Uint16Array.from([77]),
+              positions: Float64Array.from([0, 0]),
+              advances: Float64Array.from([16]),
+            },
+          ],
+        };
+      }
+      const cps = [...text].map((ch) => ch.codePointAt(0));
+      return {
+        width: cps.length * 8,
+        runs: [
+          {
+            font: null,
+            glyphs: Uint16Array.from(cps, (cp) => cp + 1),
+            positions: Float64Array.from(cps.flatMap((_, i) => [i * 8, 0])),
+            advances: Float64Array.from(cps, () => 8),
+          },
+        ],
+      };
+    },
+    fontFromData() {
+      return {
+        cg: { name: 'Loaded' },
+        familyName: 'Loaded',
+        postScriptName: 'Loaded-Regular',
+        weight: 400,
+        italic: false,
+      };
+    },
+    cgFontWithSize(cg, size) {
+      return handleFor(`cg:${cg.name}@${size}`, {
+        ps: `${cg.name}-Regular`,
+        family: cg.name,
+        size,
+      });
+    },
+    fontByPostScriptName(name, size) {
+      if (name !== 'KaTeX_Main-Regular') return null;
+      return handleFor(`ps:${name}@${size}`, {
+        ps: name,
+        family: 'KaTeX_Main',
+        size,
+      });
+    },
+    ctxSetFillColor(surface, r, g, b, a) {
+      calls.push(['fill', r, g, b, a]);
+    },
+    ctxDrawGlyphs(surface, runs, replace) {
+      calls.push([
+        'draw',
+        runs.map((run) => ({
+          font: run.font,
+          glyphs: [...run.glyphs],
+          positions: [...run.positions],
+        })),
+        replace,
+      ]);
+    },
+  };
+  // every other ctx verb the context syncs on a fresh surface is a no-op
+  return new Proxy(native, {
+    get: (target, key) => (key in target ? target[key] : () => undefined),
+  });
+}
+
+function context(native) {
+  const surface = { fake: true };
+  const ctx = new CocoaContext2D(
+    native,
+    () => surface,
+    () => 1,
+  );
+  ctx._fonts = new CocoaFontManager(native);
+  let dirty = 0;
+  ctx._onDirty = () => dirty++;
+  return { ctx, fonts: ctx._fonts, dirty: () => dirty };
+}
+
+const glyph = (id, ax, dx = 0, dy = 0) => ({ id, ax, dx, dy });
+
+// --- the face -----------------------------------------------------------------
+
+test('a matched face answers ntk seams: glyph ids, advances at a size, both metric vocabularies', () => {
+  const fonts = new CocoaFontManager(fakeNative());
+  const face = fonts.match('Menlo', { weight: 400 });
+  assert.ok(face instanceof CocoaFace);
+  assert.strictEqual(fonts.match('Menlo', { weight: 400 }), face, 'cached');
+  assert.equal(face.glyphIdFor(0x30), 0x31);
+  assert.equal(face.glyphIdFor(0x2500), null, 'uncovered is null, not 0');
+  assert.equal(face.glyphIdFor('0'), null, 'a code point, not a string');
+  // hasGlyph in both forms it has been asked in
+  assert.equal(face.hasGlyph(0x41), true);
+  assert.equal(face.hasGlyph(0x2500), false);
+  assert.equal(face.hasGlyph('A'), true);
+  // the advance is read off the handle AT that size — 16 * 0.6 in the fake
+  assert.equal(face.advanceOf(0x31, 16), 9.6);
+  assert.equal(face.advanceOf(0x31, 10), 6);
+  const m = face.metrics(20);
+  assert.equal(m.ascent, 16);
+  assert.equal(m.descent, 4);
+  assert.equal(m.leading, 2, "CoreText's name stays");
+  assert.equal(m.lineGap, 2, "ntk's name for the same gap");
+  assert.equal(m.lineHeight, 22, 'ascent + descent + gap, finite');
+  assert.equal(m.capHeight, 14);
+  assert.equal(face.familyName, 'Menlo');
+  assert.equal(face.postscriptName, 'Menlo-400');
+});
+
+test('shape walks the pen: ax from the advances, dx/dy from the positions, y up', () => {
+  const fonts = new CocoaFontManager(fakeNative());
+  const face = fonts.match('Menlo');
+  const shaped = face.shape('é', 14);
+  assert.strictEqual(shaped.font, face);
+  assert.equal(shaped.size, 14);
+  assert.equal(shaped.width, 8);
+  assert.deepEqual(shaped.glyphs, [glyph(0x66, 8), glyph(0x302, 0, -2, 2)]);
+  const plain = face.shape('Hi', 14).glyphs;
+  assert.deepEqual(plain, [glyph(0x49, 8), glyph(0x6a, 8)]);
+});
+
+test('a run CoreText substituted carries its face on the glyph, and it is the fallback face', () => {
+  const fonts = new CocoaFontManager(fakeNative());
+  const face = fonts.match('Menlo');
+  const shaped = face.shape('☺️', 14);
+  assert.strictEqual(shaped.font, face, 'the result is still this face');
+  assert.equal(shaped.glyphs.length, 1);
+  const emoji = shaped.glyphs[0].font;
+  assert.ok(emoji instanceof CocoaFace);
+  assert.equal(emoji.postscriptName, 'AppleColorEmoji');
+  assert.equal(emoji.glyphIdFor(0x1f600), 0x601);
+  // one object per PostScript name, whichever route found it
+  assert.strictEqual(fonts.fallbackFor(0x1f600, 'Menlo'), emoji);
+  // and it answers at every size through fontWithSize
+  assert.equal(emoji.advanceOf(1, 20), 12);
+  assert.equal(emoji.metrics(10).lineHeight, 11);
+});
+
+test('fallbackFor: the base for what it covers, a cascade face otherwise, null when nothing does, cached', () => {
+  const fonts = new CocoaFontManager(fakeNative());
+  const base = fonts.match('Menlo', { weight: 700, style: 'italic' });
+  const opts = { weight: 'bold', style: 'italic' };
+  assert.strictEqual(fonts.fallbackFor(0x41, 'Menlo', opts), base);
+  const box = fonts.fallbackFor(0x2500, 'Menlo', opts);
+  assert.ok(box instanceof CocoaFace);
+  assert.notStrictEqual(box, base);
+  assert.equal(box.familyName, 'Fallback');
+  assert.equal(box.glyphIdFor(0x2500), 0x2500);
+  assert.strictEqual(fonts.fallbackFor(0x2500, 'Menlo', opts), box, 'cached');
+  assert.equal(fonts.fallbackFor(0x3000, 'Menlo', opts), null);
+  assert.equal(fonts.fallbackFor(0xd800, 'Menlo', opts), null, 'not a scalar');
+  assert.equal(fonts.fallbackFor(Number.NaN, 'Menlo', opts), null);
+  // a string is tolerated: its first code point
+  assert.strictEqual(fonts.fallbackFor('─', 'Menlo', opts), box);
+});
+
+test('a face the app loaded is consulted before the cascade', () => {
+  const fonts = new CocoaFontManager(fakeNative());
+  fonts.load(Buffer.from([0, 1, 0, 0, 0, 0]));
+  const loaded = fonts.fallbackFor(0x2500, 'Menlo');
+  assert.ok(loaded instanceof CocoaFace);
+  assert.equal(loaded.familyName, 'Loaded');
+  assert.equal(loaded.key, 'registered:Loaded-Regular');
+  assert.equal(loaded.glyphIdFor(0x2500), 7);
+  assert.strictEqual(fonts.fallbackFor(0x2500, 'Menlo'), loaded);
+  // what the loaded face lacks still goes to the cascade
+  assert.equal(fonts.fallbackFor(0x2501, 'Menlo').familyName, 'Fallback');
+});
+
+// --- the context --------------------------------------------------------------
+
+test('Render.PictOp and createSolidPicture are there, in XRender numbering', () => {
+  const { ctx } = context(fakeNative());
+  assert.equal(ctx.Render.PictOp.Over, 3);
+  assert.equal(ctx.Render.PictOp.Src, 1);
+  assert.equal(typeof ctx.createSolidPicture, 'function');
+  assert.equal(typeof ctx.drawGlyphs, 'function');
+  assert.ok(ctx.createSolidPicture(1, 0, 0, 1));
+});
+
+test('drawGlyphs groups by face and size, walks the pen, flips dy, and sets the ink once', () => {
+  const native = fakeNative();
+  const { ctx, fonts, dirty } = context(native);
+  const menlo = fonts.match('Menlo');
+  const run = {
+    font: menlo,
+    size: 14,
+    glyphs: [glyph(1, 8), glyph(2, 8, 1, 2), glyph(3, 8)],
+  };
+  const other = { font: menlo, size: 20, glyphs: [glyph(4, 12)] };
+  // premultiplied half-alpha red in, straight red at half alpha out
+  const src = ctx.createSolidPicture(0.5, 0, 0, 0.5);
+  ctx.drawGlyphs(ctx.Render.PictOp.Over, src, [
+    { run, x: 10, y: 20 },
+    { run: other, x: 100, y: 50 },
+    { run, x: 30, y: 40 },
+  ]);
+  assert.equal(native.calls.length, 2);
+  assert.deepEqual(native.calls[0], ['fill', 1, 0, 0, 0.5]);
+  const [, runs, replace] = native.calls[1];
+  assert.equal(replace, false);
+  assert.equal(runs.length, 2, 'one native run per (face, size)');
+  const at14 = runs.find((r) => r.font.size === 14);
+  const at20 = runs.find((r) => r.font.size === 20);
+  assert.equal(at14.font.family, 'Menlo');
+  assert.deepEqual(at14.glyphs, [1, 2, 3, 1, 2, 3]);
+  // pen: x, x + 8, x + 16; the second glyph offset by (dx 1, dy 2 up)
+  assert.deepEqual(
+    at14.positions,
+    [10, 20, 19, 18, 26, 20, 30, 40, 39, 38, 46, 40],
+  );
+  assert.deepEqual(at20.glyphs, [4]);
+  assert.deepEqual(at20.positions, [100, 50]);
+  assert.equal(dirty(), 1);
+});
+
+test('a glyph with a face of its own draws with that face; a run nobody can resolve is skipped', () => {
+  const native = fakeNative();
+  const { ctx, fonts } = context(native);
+  const menlo = fonts.match('Menlo');
+  const emoji = fonts.fallbackFor(0x1f600, 'Menlo');
+  const cluster = {
+    font: menlo,
+    size: 14,
+    glyphs: [glyph(1, 8), { ...glyph(77, 16), font: emoji }, glyph(2, 8)],
+  };
+  ctx.drawGlyphs(3, ctx.createSolidPicture(1, 1, 1, 1), [
+    { run: cluster, x: 0, y: 10 },
+    {
+      run: { font: { not: 'a face' }, size: 14, glyphs: [glyph(9, 8)] },
+      x: 0,
+      y: 0,
+    },
+    { run: { font: menlo, size: 14, glyphs: [] }, x: 0, y: 0 },
+  ]);
+  const [, runs] = native.calls[1];
+  assert.equal(runs.length, 2);
+  const base = runs.find((r) => r.font.family === 'Menlo');
+  const sub = runs.find((r) => r.font.family === 'Emoji');
+  assert.deepEqual(base.glyphs, [1, 2]);
+  assert.deepEqual(
+    base.positions,
+    [0, 10, 24, 10],
+    'the pen advanced past the emoji',
+  );
+  assert.deepEqual(sub.glyphs, [77]);
+  assert.deepEqual(sub.positions, [8, 10]);
+  assert.equal(sub.font.size, 14, "the substitute at the run's size");
+});
+
+test('Src replaces, anything else composites; nothing to draw is no call at all', () => {
+  const native = fakeNative();
+  const { ctx, fonts, dirty } = context(native);
+  const run = { font: fonts.match('Menlo'), size: 14, glyphs: [glyph(1, 8)] };
+  ctx.drawGlyphs(ctx.Render.PictOp.Src, ctx.createSolidPicture(0, 0, 0, 1), [
+    { run, x: 0, y: 0 },
+  ]);
+  assert.equal(native.calls[1][2], true);
+  ctx.drawGlyphs(12, ctx.createSolidPicture(0, 0, 0, 1), [{ run, x: 0, y: 0 }]);
+  assert.equal(native.calls[3][2], false);
+  const before = native.calls.length;
+  ctx.drawGlyphs(3, ctx.createSolidPicture(0, 0, 0, 1), []);
+  ctx.drawGlyphs(3, ctx.createSolidPicture(0, 0, 0, 1), undefined);
+  assert.equal(native.calls.length, before);
+  assert.equal(dirty(), 2);
+});
+
+test('the source may be a CSS colour, a straight array, or the fill style in force', () => {
+  const native = fakeNative();
+  const { ctx, fonts } = context(native);
+  const run = { font: fonts.match('Menlo'), size: 14, glyphs: [glyph(1, 8)] };
+  ctx.drawGlyphs(3, '#00ff00', [{ run, x: 0, y: 0 }]);
+  assert.deepEqual(native.calls[0], ['fill', 0, 1, 0, 1]);
+  ctx.drawGlyphs(3, [0, 0, 1, 0.5], [{ run, x: 0, y: 0 }]);
+  assert.deepEqual(native.calls[2], ['fill', 0, 0, 1, 0.5]);
+  ctx.fillStyle = 'rgba(255, 0, 0, 0.25)';
+  ctx.drawGlyphs(3, null, [{ run, x: 0, y: 0 }]);
+  assert.deepEqual(native.calls[4], ['fill', 1, 0, 0, 0.25]);
+});
+
+test("an ntk Font as run.font resolves to CoreText by its PostScript name, so openFont()'s glyph ids hold", () => {
+  const native = fakeNative();
+  const { ctx } = context(native);
+  const katex = { key: 'katex-main', postscriptName: 'KaTeX_Main-Regular' };
+  ctx.drawGlyphs(3, ctx.createSolidPicture(0, 0, 0, 1), [
+    { run: { font: katex, size: 18, glyphs: [glyph(40, 9)] }, x: 5, y: 5 },
+  ]);
+  const [, runs] = native.calls[1];
+  assert.equal(runs.length, 1);
+  assert.equal(runs[0].font.ps, 'KaTeX_Main-Regular');
+  assert.equal(runs[0].font.size, 18);
+  assert.deepEqual(runs[0].glyphs, [40]);
+});
+
+// --- over the real bridge ---------------------------------------------------------
+
+let bridge = null;
+if (process.platform === 'darwin') {
+  try {
+    bridge = loadNative();
+  } catch {
+    bridge = null;
+  }
+}
+
+describe(
+  'over the real bridge',
+  {
+    skip: bridge ? false : 'the @windowkit/appkit bridge is not loadable here',
+  },
+  () => {
+    const redRows = (px, width, height) => {
+      const rows = new Set();
+      for (let y = 0; y < height; y++) {
+        for (let x = 0; x < width; x++) {
+          const i = (y * width + x) * 4;
+          if (px[i] > 128 && px[i + 1] < 64) rows.add(y);
+        }
+      }
+      return [...rows].sort((a, b) => a - b);
+    };
+
+    test('Menlo: a glyph id, its advance, and a line height that is finite', () => {
+      const fonts = new CocoaFontManager(bridge);
+      const menlo = fonts.match('Menlo');
+      const zero = menlo.glyphIdFor(0x30);
+      assert.ok(Number.isInteger(zero) && zero > 0);
+      assert.equal(menlo.hasGlyph(0x30), true);
+      assert.equal(menlo.glyphIdFor(0x1f600), null, 'no emoji in Menlo');
+      const advance = menlo.advanceOf(zero, 14);
+      assert.ok(advance > 7 && advance < 10, `Menlo 14 advance ${advance}`);
+      const m = menlo.metrics(14);
+      assert.ok(Number.isFinite(m.lineHeight));
+      assert.equal(m.lineHeight, m.ascent + m.descent + m.leading);
+      assert.equal(m.lineGap, m.leading);
+      assert.equal(menlo.familyName, 'Menlo');
+    });
+
+    test('fallbackFor: emoji to Apple Color Emoji, a noncharacter to null, the base for what it covers', () => {
+      const fonts = new CocoaFontManager(bridge);
+      const menlo = fonts.match('Menlo');
+      const emoji = fonts.fallbackFor(0x1f600, 'Menlo');
+      assert.ok(emoji instanceof CocoaFace);
+      assert.equal(emoji.familyName, 'Apple Color Emoji');
+      assert.ok(emoji.glyphIdFor(0x1f600) > 0);
+      assert.ok(emoji.advanceOf(emoji.glyphIdFor(0x1f600), 14) > 0);
+      assert.strictEqual(fonts.fallbackFor(0x30, 'Menlo'), menlo);
+      assert.equal(fonts.fallbackFor(0xffff, 'Menlo'), null);
+    });
+
+    test('shape: a cluster comes back positioned, a substituted one carrying its face', () => {
+      const fonts = new CocoaFontManager(bridge);
+      const menlo = fonts.match('Menlo');
+      const accented = menlo.shape('é', 14);
+      assert.ok(accented.glyphs.length >= 1);
+      assert.ok(accented.width > 0);
+      for (const g of accented.glyphs) {
+        assert.ok(Number.isInteger(g.id));
+        assert.ok(Number.isFinite(g.ax + g.dx + g.dy));
+      }
+      const smiley = menlo.shape('☺️', 14);
+      assert.ok(smiley.glyphs.length >= 1);
+      assert.ok(
+        smiley.glyphs[0].font instanceof CocoaFace,
+        'CoreText substituted a face',
+      );
+      assert.equal(smiley.glyphs[0].font.familyName, 'Apple Color Emoji');
+    });
+
+    test('drawGlyphs puts an H upright between the cap line and its baseline, in the ink asked for', () => {
+      const surface = bridge.createSurface(64, 32, 1);
+      const ctx = new CocoaContext2D(
+        bridge,
+        () => surface,
+        () => 1,
+      );
+      const fonts = new CocoaFontManager(bridge);
+      ctx._fonts = fonts;
+      ctx.fillStyle = '#000';
+      ctx.fillRect(0, 0, 64, 32);
+      const menlo = fonts.match('Menlo');
+      const h = menlo.glyphIdFor(0x48);
+      const run = { font: menlo, size: 20, glyphs: [glyph(h, 12)] };
+      ctx.drawGlyphs(
+        ctx.Render.PictOp.Over,
+        ctx.createSolidPicture(1, 0, 0, 1),
+        [{ run, x: 4, y: 24 }],
+      );
+      const rows = redRows(
+        bridge.ctxGetImageData(surface, 0, 0, 64, 32),
+        64,
+        32,
+      );
+      assert.ok(rows.length > 0, 'ink');
+      const capHeight = menlo.metrics(20).capHeight;
+      // the top of the H is a cap height above the baseline; nothing below it
+      assert.ok(
+        Math.abs(rows[0] - (24 - capHeight)) <= 1.5,
+        `top row ${rows[0]}`,
+      );
+      assert.equal(
+        rows[rows.length - 1],
+        23,
+        'the last inked row is just above the baseline',
+      );
+      // and the fill style the context carries was not disturbed for the next painter
+      ctx.fillStyle = '#0f0';
+      ctx.fillRect(0, 0, 2, 2);
+      const px = bridge.ctxGetImageData(surface, 0, 0, 1, 1);
+      assert.deepEqual([...px].slice(0, 3), [0, 255, 0]);
+    });
+
+    test('Src replaces where Over composites', () => {
+      const fonts = new CocoaFontManager(bridge);
+      const menlo = fonts.match('Menlo');
+      const run = {
+        font: menlo,
+        size: 20,
+        glyphs: [glyph(menlo.glyphIdFor(0x48), 12)],
+      };
+      const stem = (op) => {
+        const surface = bridge.createSurface(32, 32, 1);
+        const ctx = new CocoaContext2D(
+          bridge,
+          () => surface,
+          () => 1,
+        );
+        ctx._fonts = fonts;
+        ctx.fillStyle = '#f00';
+        ctx.fillRect(0, 0, 32, 32);
+        ctx.drawGlyphs(op, ctx.createSolidPicture(0.5, 0.5, 0.5, 0.5), [
+          { run, x: 4, y: 24 },
+        ]);
+        // the left stem of the H, mid-height
+        return [...bridge.ctxGetImageData(surface, 6, 16, 1, 1)];
+      };
+      assert.deepEqual(stem(3), [255, 128, 128, 255]);
+      assert.deepEqual(stem(1), [255, 255, 255, 128]);
+    });
+  },
+);


### PR DESCRIPTION
Closes #432, over `@windowkit/appkit` 0.3.0's glyph natives ([windowkit/appkit#1](https://github.com/windowkit/appkit/issues/1): four from [#2](https://github.com/windowkit/appkit/pull/2) in 0.2.0, `fontShapeText` and `fontWithSize` from [#5](https://github.com/windowkit/appkit/pull/5) in 0.3.0). The floor in `package.json` moves to `^0.3.0`, lock regenerated.

## What was wrong

`<Terminal backend="vt">` from `@react-x11/components` threw `regular.glyphIdFor is not a function` from paint on every pump tick under `backend: 'cocoa'`: `fonts.match()` answered a face with `metrics` and `hasGlyph` and nothing else, and the ctx had `fillRects` and `drawImage` but no `drawGlyphs`. `docs/macos.md` names the ctx dialect, `drawGlyphs`/`positioned` included, as part of the contract on both backends and `CTFontDrawGlyphs` as its implementation; the required-API list had glyph-run access as 🆕. This is that item.

## What changes

**The face** `fonts.match()` returns is a `CocoaFace` (`src/cocoa/fonts.js`), ntk's `Font` as far as a renderer that positions glyphs itself reads it:

| seam | now |
| --- | --- |
| `glyphIdFor(cp)` | the font's own glyph index, `null` when unmapped (`fontGlyphForCodepoint`) |
| `advanceOf(id, size)` | the advance at a handle of that size (`fontGlyphAdvances`) |
| `shape(text, size)` | one CTLine through the typesetter (`fontShapeText`), read back in ntk's pen contract `{ id, ax, dx, dy }`, glyphs in visual order; a glyph from a run CoreText substituted carries that face as `font` |
| `metrics(size)` | ntk's `lineGap`/`lineHeight` beside CoreText's `leading`, so a cell height computed against ntk's names is finite |
| `hasGlyph` | a code point (ntk's contract) as well as a string |

**The manager** answers `fallbackFor(cp, family, opts)`: faces the app loaded first, then CoreText's cascade off the matched face (`fontFallbackFor`), `null` when nothing covers the code point, and the matched face itself when it already does, so runs group with the base's. A face CoreText chose itself — from `fallbackFor` or from a substituted run inside `shape()` — is one object per PostScript name and answers every size as itself (`fontWithSize`).

**The context** (`src/cocoa/context2d.js`) answers `drawGlyphs(op, src, positioned)`, `createSolidPicture(r, g, b, a)` and `Render.PictOp.{Over, Src}` with ntk's exact run contract: groups by face and size, walks the pen (`pen + dx`, `y − dy`, then `pen += ax`), sets the fill to `src`'s colour, and issues one `ctxDrawGlyphs` per call — a frame of terminal text is one native call per foreground colour, emoji clusters included. An ntk `Font` from `openFont()` works as `run.font` too, resolved to CoreText from the same bytes.

Three differences from ntk, stated where they live: a glyph `shape()` hands back may carry the face CoreText substituted (an emoji cluster in Menlo draws as the emoji, where ntk shapes `.notdef`); every op draws as Over, which for the opaque inks text uses is what Src does too (the bridge has no blend-mode switch); and the transform scales glyphs as well as origins, because CoreGraphics draws text through the CTM. Under a translate, which is what a node's paint runs in, the two agree.

`docs/macos.md` records the seams under "Text: the engine contract" and flips the required-API markers.

## Tests

`test/cocoa-glyph-runs.test.js`, two layers:

- **Everywhere**: the JS glue over a fake bridge shaped like 0.3.0 — the grouping, the pen walk, the dy flip, the premultiplied→straight ink, the caches, the loaded-face-first fallback order, sized fallback faces, the substituted-run face on a glyph, the ntk-`Font` route — asserted on what reaches the natives.
- **Where the real bridge loads** (skipped otherwise, so CI on Linux is unaffected; run here against the published 0.3.0): Menlo's glyph ids and advances, `fallbackFor` answering Apple Color Emoji for 😀 at every size and `null` for U+FFFF, `shape()` giving real ids for `Hi`, composing `e + U+0301` into Menlo's own `é`, and carrying the substituted face for `☺️`, `👍🏽` and RTL Hebrew, and pixels — an `H` drawn through the whole stack inks exactly the rows between its cap line and its baseline, a substituted emoji glyph in the same run lands at the pen in its own colours, and the next painter's fill style is undisturbed.

`npm run lint`, `typecheck` and `format:check` are green.

## Verified on the terminal

`@react-x11/components`' `<Terminal backend="vt">` (its built dist, over this branch's `react-x11` and the published `@windowkit/appkit` 0.3.0), `createRoot({ backend: 'cocoa' })`, Menlo 14 — text, per-colour batches, bold, underline and inverse, box drawing, CJK and emoji through the fallback faces, the emoji+VS16 cluster through `shape()`. Screenshot below is the window's own backing surface.

## Not here

#433, the offscreen `Surface` for the retained renderer — the terminal runs on the direct renderer today.



![terminal-vt-cocoa](https://github.com/user-attachments/assets/87041476-30db-4b5d-aa75-04bf89be17a1)
