### PR TITLE
fix(selection): a press and a drag land under the pointer, whatever the display scale

### DIFF
--- a/src/textselection.js
+++ b/src/textselection.js
@@ -169,7 +169,7 @@ export class TextSelection {
 
   press(ev) {
     if (ev.button !== 1) return;
-    const at = this.positionAt(ev.x, ev.y);
+    const at = this.positionAt(...this.devicePoint(ev));
     if (!at) return;
     this.granularity =
       ev.detail >= 3 ? 'block' : ev.detail === 2 ? 'word' : 'char';
@@ -190,7 +190,7 @@ export class TextSelection {
 
   drag(ev) {
     if (!this.dragging) return;
-    const at = this.positionAt(ev.x, ev.y);
+    const at = this.positionAt(...this.devicePoint(ev));
     if (!at) return;
     this.focus = at;
     this.apply();
@@ -221,9 +221,27 @@ export class TextSelection {
     }
   }
 
+  /**
+   * The pointer in the space `abs` and the four accessors are in — device
+   * pixels (docs/scale.md). A synthetic event's `x`/`y` are logical, so on
+   * a 2x panel they name a point half as far from the window's origin as the
+   * pointer is: a press landed on the wrong character and a drag stopped
+   * short at half its distance. The X event underneath already carries the
+   * device numbers; an event synthesized without one is multiplied up, the
+   * way every other pointer consumer in nodes.js does it.
+   */
+  devicePoint(ev) {
+    const scale = this.node.scale > 0 ? this.node.scale : 1;
+    return [
+      ev.nativeEvent?.x ?? ev.x * scale,
+      ev.nativeEvent?.y ?? ev.y * scale,
+    ];
+  }
+
   // --- the selection itself ----------------------------------------------
 
-  /** The participant and index nearest a point in window coordinates. */
+  /** The participant and index nearest a point in window coordinates —
+   * device pixels, the unit `abs` and `textIndexAt` speak. */
   positionAt(x, y) {
     let best = null;
     let bestScore = Infinity;

--- a/test/text-selection.test.js
+++ b/test/text-selection.test.js
@@ -631,3 +631,47 @@ test('a press lands on the character the accessors name', async () => {
   fireEvent.mouseUp(text, { dx: to.x - centre });
   await act();
 });
+
+// --- the display scale ------------------------------------------------------
+//
+// `abs` and the four accessors are device pixels; a synthetic event's `x`/`y`
+// are logical (docs/scale.md). At 1x — every other test here — the two
+// coincide, which is how a press resolved straight from `ev.x` landed on the
+// right character in this suite and then, on a retina panel, on one half as
+// far from the window's origin (#435). The press-and-drag test again at 2x,
+// with the text set in from the origin so a wrong unit cannot cancel out.
+
+test('at a display scale of 2 a press and a drag land under the pointer', async () => {
+  const surface = React.createRef();
+  const { windowNode } = await renderX11(
+    scene(
+      h(
+        'box',
+        { ref: surface, selectable: true, style: { width: 300, padding: 20 } },
+        h('text', null, 'alpha beta gamma'),
+      ),
+    ),
+    { fonts: FONTS, wrap: false, width: W, height: H, scale: 2 },
+  );
+  const [text] = find(windowNode, 'text');
+  assert.ok(
+    text.abs.x >= 40 && text.abs.y >= 40,
+    `the text is set in from the origin on the device grid: ${text.abs.x},${text.abs.y}`,
+  );
+  // the accessors answer in device pixels — a 16px face shaped at 32
+  const from = text.textCaretRect(6);
+  const to = text.textCaretRect(10);
+  assert.ok(
+    to.x - from.x > 40,
+    `"beta" is ${to.x - from.x} device pixels wide`,
+  );
+  // ...and so do the harness's offsets, from the node's device `abs`
+  const centre = text.abs.x + text.abs.width / 2;
+  fireEvent.mouseDown(text, { dx: from.x - centre });
+  await act();
+  await dragTo(text, { dx: to.x - centre });
+  assert.deepStrictEqual(text.selectionRange, { start: 6, end: 10 });
+  assert.equal(surface.current.selectedText(), 'beta');
+  fireEvent.mouseUp(text, { dx: to.x - centre });
+  await act();
+});


### PR DESCRIPTION
Fixes #435.

`TextSelection.press` and `drag` resolved the pointer from the synthetic event's `x`/`y` — logical pixels — and handed it to `positionAt`, which scores participants against `node.abs` and asks `textIndexAt`, both device-pixel contracts (docs/scale.md). At 1x the two units coincide, which is how every test in `test/text-selection.test.js` passed; on a 2x panel the selection resolved a point half as far from the window's origin as the pointer was, so a press landed on the wrong character and a drag stopped short at half its distance.

- `src/textselection.js`: `devicePoint(ev)` takes the point the way every other pointer consumer in `nodes.js` does — `ev.nativeEvent?.x ?? ev.x * scale`, with the surface node's `scale` — and `press`/`drag` go through it. `positionAt`'s contract is now stated as device pixels. Ctrl+A / Ctrl+C, the accessors and the painted bands are untouched: they were already on the device grid.
- `test/text-selection.test.js`: the press-and-drag test again at `scale: 2`, with the text padded in from the origin so a wrong unit cannot cancel out. It fails on the previous code (the press resolves to index 2 rather than 6).

Found from the other side in sidorares/react-x11-components#59, where a registered element with device-pixel accessors saw the same short drag as a plain `<text>`.
