### PR TITLE
fix(scroll-blit): an element blit survives a rounded ancestor, and the cocoa swapchain keeps the band it moved

### DIFF
--- a/src/cocoa/window.js
+++ b/src/cocoa/window.js
@@ -321,7 +321,22 @@ export class CocoaWindow {
       dx,
       dy,
     );
-    if (moved) this._dirty = true;
+    if (moved) {
+      this._dirty = true;
+      // The band moved inside the BACK buffer only. After the flip the
+      // other buffer still holds the band where it was, and the catch-up
+      // copy only covers what the flush painted — the strips the shift
+      // exposed — so the next frame would blit a band one frame stale.
+      // Record the shifted rect as painted, and the flip's copy carries it.
+      this.noteFrameDamage([
+        {
+          x: Math.round(rect.x),
+          y: Math.round(rect.y),
+          width: Math.round(rect.width),
+          height: Math.round(rect.height),
+        },
+      ]);
+    }
     return Boolean(moved);
   }
 

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -486,6 +486,25 @@ function rectsBounds(rects) {
 }
 
 /** Do two rects share any area? Touching edges do not count. */
+/** Does `rect` reach into any of the four `radius`-sized corner squares of
+ * `box` — the only part of a rounded border a translation cannot keep? */
+function cornerSquaresOverlap(box, radius, rect) {
+  const r = Math.min(radius, box.width / 2, box.height / 2);
+  if (!(r > 0)) return false;
+  const corners = [
+    { x: box.x, y: box.y, width: r, height: r },
+    { x: box.x + box.width - r, y: box.y, width: r, height: r },
+    { x: box.x, y: box.y + box.height - r, width: r, height: r },
+    {
+      x: box.x + box.width - r,
+      y: box.y + box.height - r,
+      width: r,
+      height: r,
+    },
+  ];
+  return corners.some((square) => rectsOverlap(square, rect));
+}
+
 function rectsOverlap(a, b) {
   return (
     a.x < b.x + b.width &&
@@ -11127,12 +11146,51 @@ export class WindowNode extends Scrollable(Node) {
     }
     const keep = this._blitKeptDamage(vp, true);
     if (!keep) return;
-    if (!this._scrollBlitSafe(node, vp)) return;
+    // An ancestor's rounded corners reach into the top and bottom rows of
+    // the region (a graph pane inside a rounded card is the common shape):
+    // those rows do not translate, so they leave the blit and get repainted
+    // as bands — the same carve the element does for its own furniture —
+    // and the band that shifts is what is left between them.
+    const bands = this._cornerBands(node, vp);
+    const shifted =
+      bands.top || bands.bottom
+        ? {
+            x: vp.x,
+            y: vp.y + bands.top,
+            width: vp.width,
+            height: vp.height - bands.top - bands.bottom,
+          }
+        : vp;
+    if (shifted.height <= 0 || Math.abs(dy) >= shifted.height) return;
+    if (
+      (shifted.width - Math.abs(dx)) * (shifted.height - Math.abs(dy)) <
+      area * SCROLL_BLIT_MIN_KEEP
+    ) {
+      return;
+    }
+    if (!this._scrollBlitSafe(node, shifted)) return;
     // the element's deltas are already how far the pixels moved, the sense
     // scrollRegion takes (0 + x rather than x: a caller's -0 would survive
     // into request buffers and test comparisons)
-    if (!this.window.scrollRegion({ ...vp }, 0 + dx, 0 + dy)) return;
+    if (!this.window.scrollRegion({ ...shifted }, 0 + dx, 0 + dy)) return;
     let rects = keep;
+    if (bands.top) {
+      rects = addDamageRect(rects, {
+        x: vp.x,
+        y: vp.y,
+        width: vp.width,
+        height: bands.top,
+      });
+    }
+    if (bands.bottom) {
+      rects = addDamageRect(rects, {
+        x: vp.x,
+        y: shifted.y + shifted.height,
+        width: vp.width,
+        height: bands.bottom,
+      });
+    }
+    vp = shifted;
     // The strips the shift exposed, on the sides the pixels came from. The
     // horizontal one takes the full width and the vertical one takes what
     // is left, so a diagonal shift claims two rects that do not overlap —
@@ -11155,6 +11213,28 @@ export class WindowNode extends Scrollable(Node) {
       });
     }
     this._damage = rects;
+  }
+
+  /**
+   * How many rows at the top and at the bottom of `vp` an ancestor's rounded
+   * corners reach into — the rows an element blit has to leave behind and
+   * repaint, so that what shifts stays clear of every corner square
+   * (`_scrollBlitSafe`). Whole pixels, and zero when no corner reaches in.
+   */
+  _cornerBands(node, vp) {
+    let top = 0;
+    let bottom = 0;
+    for (let n = node.parent; n && n !== this; n = n.parent) {
+      const radius = n.style?.borderRadius ?? 0;
+      if (!(radius > 0) || !n.abs) continue;
+      if (!cornerSquaresOverlap(n.abs, radius, vp)) continue;
+      top = Math.max(top, Math.ceil(n.abs.y + radius - vp.y));
+      bottom = Math.max(
+        bottom,
+        Math.ceil(vp.y + vp.height - (n.abs.y + n.abs.height - radius)),
+      );
+    }
+    return { top: Math.max(0, top), bottom: Math.max(0, bottom) };
   }
 
   /**
@@ -11186,14 +11266,18 @@ export class WindowNode extends Scrollable(Node) {
             child.style ?? EMPTY_STYLE,
             child.direction,
           );
-          const inset = Math.max(
-            bw.top,
-            bw.right,
-            bw.bottom,
-            bw.left,
-            child.style?.borderRadius ?? 0,
-          );
-          if (inset > 0 && !rectContains(insetRect(child.abs, inset), vp)) {
+          const ring = Math.max(bw.top, bw.right, bw.bottom, bw.left);
+          if (ring > 0 && !rectContains(insetRect(child.abs, ring), vp)) {
+            return false;
+          }
+          // A rounded corner is not a ring: the arc lives in the four
+          // radius-sized squares at the corners, and the straight run of
+          // the edge between them is the border ring already excluded
+          // above. A viewport that reaches the edge but stays clear of the
+          // squares — an element that carved the corner rows into bands it
+          // repaints (`_cornerBands`) — is translation-safe.
+          const radius = child.style?.borderRadius ?? 0;
+          if (radius > 0 && cornerSquaresOverlap(child.abs, radius, vp)) {
             return false;
           }
           if (typeof child._scrollbars === 'function') {

--- a/test/element-scroll.test.js
+++ b/test/element-scroll.test.js
@@ -180,16 +180,31 @@ const blits = (wnd) => wnd.calls.filter(([name]) => name === 'scrollRegion');
 
 const area = (rects) => rects.reduce((sum, r) => sum + r.width * r.height, 0);
 
-async function mount({ paneProps = {}, extra = null, definition } = {}) {
+async function mount({
+  paneProps = {},
+  extra = null,
+  definition,
+  wrapStyle = null,
+} = {}) {
   register('pan', definition);
   const app = createMockApp();
   const x11Root = await createRoot({ app });
   const ref = React.createRef();
+  // `wrapStyle` puts the pane inside a box carrying that style — the shape
+  // a widget takes when the app's own style (a border, a radius) goes on a
+  // box around the drawn element
+  const pane = wrapStyle
+    ? h(
+        'box',
+        { style: { flexGrow: 1, margin: INSET, ...wrapStyle } },
+        h('pan', { ref, style: { flexGrow: 1 }, ...paneProps }),
+      )
+    : h('pan', { ref, style: { flexGrow: 1, margin: INSET }, ...paneProps });
   x11Root.render(
     h(
       'window',
       { width: W, height: H, style: { backgroundColor: '#101820' } },
-      h('pan', { ref, style: { flexGrow: 1, margin: INSET }, ...paneProps }),
+      pane,
       extra,
     ),
   );
@@ -527,6 +542,56 @@ test('a rounded corner on the element itself keeps the full repaint', async () =
   node.pan(0, 40);
   await tick();
   assert.deepStrictEqual(blits(wnd), []);
+});
+
+test('a rounded ancestor leaves its corner rows behind and blits the rest', async () => {
+  // The arc of a rounded corner does not translate, but it lives in the
+  // four radius-sized squares at the corners and nowhere else: the rows
+  // they reach into come out of the blit as bands the element repaints,
+  // and the band between them shifts. A graph pane inside a rounded card
+  // panned at 3fps before this, on every backend.
+  const RADIUS = 8;
+  const { wnd, node, root } = await mount({ wrapStyle: { borderRadius: 8 } });
+  assert.deepStrictEqual(node.abs, VP, 'the pane fills the rounded box');
+
+  assert.strictEqual(node.pan(0, 40), true);
+  await tick();
+  const shifted = {
+    x: VP.x,
+    y: VP.y + RADIUS,
+    width: VP.width,
+    height: VP.height - 2 * RADIUS,
+  };
+  assert.deepStrictEqual(blits(wnd), [['scrollRegion', shifted, 0, 40]]);
+  const rects = root._lastDamageRects;
+  assert.ok(rects, 'the frame stayed bounded');
+  const byY = [...rects].sort((a, b) => a.y - b.y);
+  assert.deepStrictEqual(byY, [
+    { x: VP.x, y: VP.y, width: VP.width, height: RADIUS },
+    { x: VP.x, y: shifted.y, width: VP.width, height: 40 },
+    {
+      x: VP.x,
+      y: shifted.y + shifted.height,
+      width: VP.width,
+      height: RADIUS,
+    },
+  ]);
+  assert.ok(
+    area(rects) < VP.width * VP.height * 0.25,
+    `repainted ${area(rects)}px² of ${VP.width * VP.height}`,
+  );
+});
+
+test('a rounded ancestor whose corners stay clear of the region blits it whole', async () => {
+  const { wnd, node } = await mount({
+    wrapStyle: { borderRadius: 8, padding: 12 },
+  });
+  const inner = { ...node.abs };
+  assert.ok(inner.x > VP.x && inner.y > VP.y, 'the pane sits inside the box');
+
+  node.pan(0, 40);
+  await tick();
+  assert.deepStrictEqual(blits(wnd), [['scrollRegion', inner, 0, 40]]);
 });
 
 test('a region outside the element is refused', async () => {


### PR DESCRIPTION
## What was slow

`examples/flow-stress.tsx` in `@react-x11/components`, the 300-node fan-out scene, panned at **3.4 fps** on the cocoa surface presenter at 2x: 285 ms per frame, the whole 2148x1275 pane repainted every frame, even though the pane arms `scrollContents` on every pan step. Profiled by wrapping every bridge call and `WindowNode.flush`; the numbers below are from that harness.

Three independent causes came out, two of which this PR fixes.

## 1. A rounded ancestor declined the blit

`<Flow>` puts the app's `style` with `borderWidth: 1, borderRadius: 6` on a box around the `flowgraph` element. `_scrollBlitSafe` refused any ancestor whose uniform inset by the larger of border and radius did not contain the region, so the blit was declined every frame and the claim fell back to the whole pane. Same on X11.

The arc of a rounded corner lives in the four radius-sized corner squares and nowhere else; the straight run of the edge between them is the border ring, already excluded. So `cornerSquaresOverlap` is the new rule, and `_applyContentsBlit` carves the rows the corners reach into out of the region as top and bottom bands the element repaints, blitting what is left between them. No app or component change is needed.

| surface presenter, 2200x1440 device px, 300 nodes / 745 edges | before | after |
| --- | --- | --- |
| frame rate | 3.4 fps | 46 fps, tick-limited |
| flush per frame | 285 ms | 14.5 ms |
| blit frames | 0 | every frame |
| damage per frame | whole pane | furniture band + 10-row corner band + 4 px strip |

## 2. The IOSurface swapchain lost the blitted band

Once the blit fired, `CocoaWindow.scrollRegion` moved the band inside the back buffer only, while the flip's catch-up copy carried what the flush painted: the exposed strips. The other buffer's band was one frame stale, so every second frame blitted stale pixels. `scrollRegion` now records the shifted rect as flush damage and the copy carries it. The bench's `scroll` scenario pays about 1.5 ms of extra memcpy per frame and stays at the tick ceiling.

Verified by reading the presented frame back after a pan and diffing it against a full repaint of the same viewport, pane region only, differing pixels in red:

| before this fix | after |
| --- | --- |
| 744,237 px differ, deltas up to 128 levels | 8,118 px differ, all under 64 levels |

![pan-swapchain-before](https://github.com/user-attachments/assets/2d5fc4f7-8d3e-4a3e-b0f7-232ff7cfd79c)
![pan-swapchain-after](https://github.com/user-attachments/assets/1db349ed-a44a-4452-8926-08410c60036c)

What remains after the fix is three columns of grid dots differing by a few levels at pass boundaries, the pane's own strip painting rather than the swapchain.

## 3. Not in this PR: CoreGraphics strokes superlinearly in path size

The Flow painter batches all 745 edges into one path, which is the right call for ntk's masks. On CoreGraphics one stroke of that path is 260 to 290 ms of the 285 ms frame; the growth is far from linear:

| one stroke, segments | time |
| --- | --- |
| 2,000 | 5.7 ms |
| 4,000 | 18 ms |
| 8,000 | 88 ms |
| 16,000 | 692 ms |
| the same 16,000 as 8 strokes | 45 ms |

With the blit working this only matters for full repaints: zoom, the first paint, a drag through the whole graph. A cap of 1,000 to 2,000 segments per path in `Painter.strokeRuns` on the components side takes a full repaint from 297 ms to 43 to 53 ms in a prototype; that is a react-x11-components change and is not included here.

Also found and left for its own change: the layers presenter never paints elements that override `paint` rather than `paintContent`, and drops bare-rect claims, so this pane is invisible there.

## Tests

- `test/element-scroll.test.js`: a rounded ancestor leaves its corner rows behind and blits the rest; a rounded ancestor whose corners stay clear of the region blits it whole. The first fails without the change.
- Full suite on macOS: 1709 tests, 1703 pass, the 6 failures are the appearance-ladder baseline that passes in CI.

