### PR TITLE
feat(cocoa): an offscreen Surface through react-x11/ntk

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1066,6 +1066,15 @@ buffer, a jump to the far end and a resize all take. It is one `CopyArea`
 inside the pixmap: nothing crosses the wire but the request, the overlap is
 safe, and no exposure events come back.
 
+The same element runs unchanged on the Cocoa backend. `react-x11/ntk`'s
+`Surface` asks the app it is handed for the implementation — ntk's pixmap
+on an X connection, a CG bitmap on a Cocoa app — so the surface above is a
+bitmap there, `copyWithin` is one in-place copy of the band, and
+`drawImage` is one composite, with the element naming neither backend. The
+one thing to know: a bitmap has one graphics state, so `getContext('2d')`
+there answers the same context every time and its `destroy()` is a no-op
+(docs/macos.md "Custom drawing on a layer tree").
+
 Two things it lines up with. The deltas you are handed are already whole
 pixels — the sub-pixel carry described above exists so that a shift is
 always expressible — so an element scrolling this way never has a fraction
@@ -1390,19 +1399,22 @@ not create. Three things it has to do that a GL surface does not:
 
 ## The subpath exports
 
-| subpath             |                                                                                                          |
-| ------------------- | -------------------------------------------------------------------------------------------------------- |
-| `react-x11/host`    | `registerElement`, `unregisterElement`, `registeredElements`, `hostTypes`, `knownElements`, `drawnKinds` |
-| `react-x11/node`    | `Node`, the built-in node classes, `Scrollable`, `intrinsicSize`                                         |
-| `react-x11/style`   | `createStyles`, `flattenStyle`, `isStyleProp`, `resolveTokens`, the rest of the vocabulary               |
-| `react-x11/yoga`    | the layout engine — `Yoga`, `loadLayout`, `layoutLoaded`. Rarely needed; see below                       |
-| `react-x11/ntk`     | ntk itself, re-exported — `Surface`, `Path2D`, `Image`, `Pixmap`, the font sources, `createClient`       |
-| `react-x11/keysyms` | the `XK_*` constants, `keysymOf`, `charOf`, `MOD`, `ctrlChordLetter`                                     |
+| subpath             |                                                                                                                                          |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `react-x11/host`    | `registerElement`, `unregisterElement`, `registeredElements`, `hostTypes`, `knownElements`, `drawnKinds`                                 |
+| `react-x11/node`    | `Node`, the built-in node classes, `Scrollable`, `intrinsicSize`                                                                         |
+| `react-x11/style`   | `createStyles`, `flattenStyle`, `isStyleProp`, `resolveTokens`, the rest of the vocabulary                                               |
+| `react-x11/yoga`    | the layout engine — `Yoga`, `loadLayout`, `layoutLoaded`. Rarely needed; see below                                                       |
+| `react-x11/ntk`     | ntk itself, re-exported — `Path2D`, `Image`, `Pixmap`, the font sources, `createClient` — and `Surface`, on whichever backend the app is |
+| `react-x11/keysyms` | the `XK_*` constants, `keysymOf`, `charOf`, `MOD`, `ctrlChordLetter`                                                                     |
 
 **Reach ntk through `react-x11/ntk`, not a second dependency.** Two copies
 of ntk in one process means two font caches and two glyph atlases, and a
 node built against one cannot be painted by the other — a failure that
-looks like a drawing bug rather than a dependency bug.
+looks like a drawing bug rather than a dependency bug. It is also where a
+drawing-adjacent name gets its backend-neutral answer: `Surface` from here
+is a pixmap on X11 and a CG bitmap on the Cocoa backend, where `Surface`
+from `ntk` is the pixmap only.
 
 **An element does not need the layout engine, and that is deliberate.**
 `measureContent` is handed its constraints in words (`'exactly'`,

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -763,12 +763,25 @@ node's own damage claims, `contentsScale` from the window.
   `Context2D` dialect the consumers exercise — including `fillRects`,
   `drawGlyphs`, `positioned`, `layoutSubtree`, `vw/vh/em` — is part of
   the ctx contract on both backends.
-- `ntk.Surface` offscreen allocation (charts, terminal): the Cocoa app
-  object supplies a `Surface`-compatible bitmap surface (CG bitmap
-  context + drawImage back into a node ctx). The `react-x11/ntk`
-  subpath on this backend serves the _drawing-adjacent_ names
-  (`Surface`, `cssColorStraight`, `decodeImage`, `Image`) from
-  backend-neutral implementations; the X-only names stay X-only.
+- `ntk.Surface` offscreen allocation (charts, terminal, flow): the Cocoa
+  app object supplies one. `app.createSurface(options)` answers ntk's
+  `Surface` contract over a CG bitmap (`src/cocoa/surface.js`, issue
+  #433), and `react-x11/ntk`'s `Surface` asks the app it is handed before
+  falling through to ntk's pixmap, so a component allocates its buffer
+  the same way on both backends. `getContext('2d')` is the CG context,
+  `copyWithin` is one in-place copy of the surviving band (the bridge's
+  `scrollSurface`, ntk#252's exact contract, clamp for clamp), and
+  `ctx.drawImage(surface, …)` is one `CGContextDrawImage`. Sized in
+  device pixels like the window's backing store. Two things differ from
+  ntk and are stated where they live: a bitmap has one graphics state,
+  so a surface has one context for its life (`destroy()` on it is a
+  no-op) and `render()` brackets its callback in save/restore from the
+  identity; and `format: 'a8'` throws — the coverage surfaces the paint
+  cache and the shadows use stay on their X path until a consumer needs
+  them here. The subpath's other drawing-adjacent names
+  (`cssColorStraight`, `decodeImage`, `Image`) are pure JS already;
+  `Image` as a `drawImage` source is not wired on this backend yet, and
+  the X-only names stay X-only.
 - `<svg>`: the declarative vocabulary (`SvgChildNode`) is portable; the
   rasterizer behind it renders through the same CG ctx.
 - A future, deliberate seam — not built until a consumer needs it:
@@ -904,12 +917,19 @@ completion callback 🆕); explicit animations ✅ (+ removal ✅,
 `animationDidStop` callback 🆕).
 
 **Drawing (raster fallback).** A CG bitmap surface object: create at
-size×scale, obtain a canvas2d-compatible context (native-side
-implementation of the ctx verbs the dialect needs — CG covers the
-standard set; `fillRects` → `CGContextFillRects`; `drawGlyphs` →
-`CTFontDrawGlyphs`), read pixels, hand to a layer as contents without a
-copy where possible 🆕. (Alternative: rasterize JS-side and use the
-raw-buffer upload; the API supports both so the choice can be measured.)
+size×scale ✅, a canvas2d-compatible verb set over it ✅ (native-side,
+one call per verb — CG covers the standard set; `fillRects` →
+`CGContextFillRects` ✅; `drawGlyphs` → `CTFontDrawGlyphs` ✅), read and
+write pixels ✅, hand to a layer as contents without a copy ✅
+(`createSurfaceIOSurface` + `setLayerContentsIOSurface`), draw one
+surface into another ✅ (`ctxDrawSurface`), shift a band in place ✅
+(`scrollSurface`), copy rects between same-size surfaces ✅
+(`copySurfaceRegion`). Still 🆕: a pattern fill (`createPattern`, which
+`<Flow>`'s grid tiles ask for), radial gradients, a blend op for
+`PictOp.Src`, and an explicit free (a surface goes with its handle's
+finalizer). The alternative — rasterize JS-side and use the raw-buffer
+upload — stays open; the API supports both so the choice can be
+measured.
 
 **Text.** measure ✅ → full layout object 🆕: build from span list
 (attributed string), report lines/runs/origins, `indexAt`,
@@ -953,6 +973,121 @@ parity) 🆕; `NSStatusItem` (tray; later) 🆕; open/save panels (later)
 key events 🆕; window snapshot ✅; a headless mode statement (CI:
 windowed Aqua sessions on macOS runners are expected to work — verify
 in Phase 1; the mock presenter keeps unit tests off the GUI entirely).
+
+## The split: what the bridge owns, what the renderer owns
+
+Written 2026-09-03 against react-x11 2.4.0 and `@windowkit/appkit`
+0.3.0, when the question came up in the concrete form "if the bridge
+grew a full canvas2d API, could it replace ntk on this backend
+outright?" — with the retained tier's need to reach layers, and two
+more backends on the horizon (Wayland at the canvas2d level, Windows
+with primitives not yet chosen), to be held in the same design. The
+answer is a division of labour, and it is mostly the one the code
+already has.
+
+**What is where today.** The bridge exports 36 `ctx*` verbs over an
+opaque surface handle, 8 surface operations (create, IOSurface-backed
+create and lookup, lock/unlock, size, copy rects between two surfaces,
+scroll within one, hand to a layer), the CoreText natives, the layer
+and transaction natives, windows, pasteboard, menu, controls, screens
+and events — one N-API crossing per verb, no state, no policy. On top
+of it `src/cocoa/` is ~4,500 lines: the canvas-shaped context (the
+JS-visible state and the ntk dialect over the verbs), the text engine,
+the layer presenter, the window with its IOSurface swapchain, the app.
+What the cocoa path reaches ntk for is pure JS — colour parsing, the
+shadow math, `SvgView`'s traversal, the image decoders, fontkit metrics
+behind `openFont` — and no X object is constructed. So "replace ntk"
+is already true in substance: on macOS ntk is a utility library and
+the X implementation of the drawing dialect. The one ntk object a
+consumer still handed the backend was `Surface`, and the fix for that
+is dispatch (issue #433, `react-x11/ntk` asking the app), not a port.
+
+**The dialect is the floor contract, and it lives here.** Every backend
+implements canvas2d plus the ntk extensions — `fillRects`, `drawGlyphs`
+with its run contract, `positioned`, Path2D as an argument to
+fill/stroke/clip, the callback-shaped `getImageData`, `Render.PictOp`
+numbering. That is react-x11's policy: it is what `nodes.js` and every
+registered element paint against, X11 answers it through ntk's XRender
+encoder, Cocoa through `CocoaContext2D` over CG verbs, Wayland will
+through the `'2d-sw'` rasterizer [wayland.md](wayland.md) builds on
+X11 first. The JS class stays in this repository rather than moving
+into the bridge for three reasons. It is the dialect, and a dialect
+defined in three repositories drifts three ways — every context fix
+would become a floor bump, the way #434 cost a `^0.3.0` floor and a
+lock regeneration for two natives. A wrapper that forwards to a **verb
+table** is reusable by any addon that speaks the same verbs, so a
+Windows addon over a Direct2D render target plugs in with no wrapper
+changes at all, where a class inside `@windowkit/appkit` could never be
+reused by Windows or Wayland. And the fake-bridge tests already pin it
+here. The bridge's contribution is exactly the verb table — mechanism —
+and that table is the native-addon contract to standardise:
+`createSurface`/`surfaceSize`/`scrollSurface`/`copySurfaceRegion`/
+`ctxDrawSurface`/`ctxGetImageData`/`ctxPutImageData` and the `ctx*`
+verbs over an opaque handle. Cocoa's is `@windowkit/appkit`'s export
+list as it stands.
+
+**Layers are a ceiling, behind the seam that exists.** The bridge
+speaks two vocabularies, raster (surfaces, verbs, text) and retained
+(layers, transactions, shape and gradient layers, contents), and the
+renderer chooses per window; the node model never learns which. The
+retained presenter needs the raster vocabulary too — its Raster visual
+replays a node's paint into a bitmap and hands the bitmap to a layer —
+so canvas2d is what every backend must provide and layers are what a
+backend may add, behind `noteInvalidate`, `presentFrame` and a null
+`scrollRegion`: three feature-detected hooks, the X11 path
+byte-identical. That is the whole integration surface, and it should
+stay that size. The presenter does not move into the bridge (it
+consumes the node model, which is policy), and there is no third,
+hybrid mode: a node is either properties on a layer or a raster on
+one, decided per node per frame.
+
+**The channel is already node-granular.** `invalidate(layoutChanged,
+node | null, reason)` reaches the presenter as `noteInvalidate(damage,
+layoutChanged, reason)` — which node, what kind — and the X11 painter
+is the one reducing it to rects. The layer presenter today collapses a
+structural `null` into a walk of the whole tree, which is the measured
+~40 ms per frame at ~1,500 nodes (the presenter bench's largest open
+number). That is a presenter-internal fix — dirty-subtree pruning off
+yoga's per-node layout flags and the `_reflowed` set, the same signals
+the X11 path uses to keep layout dirt local — not a new channel. The
+`reason` vocabulary already separates `'scroll'`, which is the
+`bounds.origin` case.
+
+**What is genuinely shared across the coming backends** is the
+client-owned bitmap with double-buffered presentation. The window's
+swapchain (`_ensureSurface`/`present`/`scrollRegion`/`noteFrameDamage`,
+~120 lines) is written over five primitives — create, lock/unlock, copy
+region between two surfaces, scroll within one, present — and a
+Wayland `wl_buffer` pair, where the compositor holds the front buffer
+until `release`, is the same shape (catch-up copy or buffer-age damage,
+[wayland.md](wayland.md)); so is a Windows swap chain or DIB pair. The
+offscreen `Surface` is the same family: written over `createSurface`,
+`surfaceSize`, `scrollSurface` and `ctxDrawSurface` plus the wrapper,
+behind the app seam (`app.createSurface(options)`), so a Wayland app
+implements the seam over a CPU bitmap with its `'2d-sw'` context and
+`copyWithin` is the memmove `scrollSurface` already is. Per backend,
+then: Wayland's context is the JS rasterizer, so the dialect holds by
+construction, and with no retained tier (`wl_subsurface` is too coarse)
+`presentFrame` is absent and the X11 paint path runs verbatim over the
+swapchain; Windows' two candidate primitive sets are exactly the two
+vocabularies — a Direct2D target for the verb table, DirectComposition
+visuals for a presenter — so it starts at the floor with the wrapper
+and the swapchain reused and adds a composition presenter later behind
+the same seam.
+
+**In order, with the priority stated:** the existing two backends, X11
+and Cocoa, become stable and performant before a third is started, so
+the steps that serve them come first. (1) This section: the verb table
+and the surface operations are the native-addon contract. (2) Issue
+#433: `CocoaSurface` over that contract, the `createSurface` seam,
+dispatch in `react-x11/ntk` — landed with this text. (3) The
+presenter's dirty-subtree pruning, ahead of anything below because it
+is the open number on a shipped backend. (4) Moving the context
+wrapper and the swapchain under `src/backend/` with neutral names — when
+a second native backend or Wayland actually starts, and not before: a
+half-renamed tree is worse than either name. (5) Bridge growth stays
+verb-shaped — a pattern fill for `<Flow>`'s grid tiles, radial
+gradients, a blend op for `PictOp.Src` — and never a JS canvas class.
 
 ## Testing
 

--- a/src/cocoa/app.js
+++ b/src/cocoa/app.js
@@ -24,13 +24,14 @@ import { CocoaGlobalMenuExport } from './globalmenu.js';
 import { CocoaPaneHost } from './panehost.js';
 import { CocoaPaneWindow } from './panewindow.js';
 import { CocoaFontManager } from './fonts.js';
+import { CocoaSurface } from './surface.js';
 import { CocoaWindow } from './window.js';
 import { decodeKey, modifierMask } from './keymap.js';
 import { loadNative } from './native.js';
 
 const RAF_INTERVAL_MS = 16;
 
-class CocoaApp {
+export class CocoaApp {
   constructor(native, options = {}) {
     this._native = native;
     this.options = options;
@@ -187,6 +188,17 @@ class CocoaApp {
    */
   createPaneHost(wnd) {
     return new CocoaPaneHost(this, wnd);
+  }
+
+  /**
+   * The offscreen-surface seam `react-x11/ntk`'s `Surface` dispatches on:
+   * ntk's `Surface` contract over a CG bitmap (src/cocoa/surface.js). Its
+   * presence is what makes `new Surface(app, { width, height })` answer a
+   * surface here rather than ntk's pixmap, which needs an X connection — a
+   * backend without the method gets ntk's, so an X app is never asked.
+   */
+  createSurface(options) {
+    return new CocoaSurface(this, options);
   }
 
   /**

--- a/src/cocoa/app.js
+++ b/src/cocoa/app.js
@@ -54,7 +54,10 @@ export class CocoaApp {
       process.env.REACT_X11_COCOA_PRESENTER ??
       'surface';
 
-    this.fonts = new CocoaFontManager();
+    // the app's own bridge, so an app over a fake one (the tests) needs no
+    // real bridge on the machine — the manager's default loads it only when
+    // it is built standalone
+    this.fonts = new CocoaFontManager(native);
 
     // AppKit-rendered control bezels. Its *presence* is the capability:
     // `useSupports('nativeControls')` and the widget set's `controls:

--- a/src/cocoa/context2d.js
+++ b/src/cocoa/context2d.js
@@ -279,15 +279,33 @@ export class CocoaContext2D {
   }
 
   save() {
+    // Sync before pushing: a fresh surface empties the stack on its way in,
+    // and a state pushed ahead of that sync was lost to it — the first
+    // save/restore pair on a new context restored nothing.
+    const surface = this._s();
     this._stack.push({ ...this._state, dash: [...this._state.dash] });
-    this._native.ctxSave(this._s());
+    this._native.ctxSave(surface);
   }
 
   restore() {
+    // Canvas's rule: a restore with nothing saved does nothing. It is also
+    // what keeps a surface's base state safe under an unbalanced painter —
+    // the native stack below the JS one is the surface's own — and what a
+    // replaced backing surface wants, since it has nothing saved either.
+    const surface = this._s();
     const prev = this._stack.pop();
-    if (prev) this._state = prev;
-    this._native.ctxRestore(this._s());
+    if (!prev) return;
+    this._state = prev;
+    this._native.ctxRestore(surface);
   }
+
+  /**
+   * ntk's contract has a caller who took a context owing it a `destroy()`
+   * — there it is a GC and a Picture. Here a context is JS state over the
+   * surface's own graphics state, so there is nothing to free; the call is
+   * honoured so a caller written against ntk needs no branch.
+   */
+  destroy() {}
 
   _concat(a2, b2, c2, d2, e2, f2) {
     const [a, b, c, d, e, f] = this._state.ctm;

--- a/src/cocoa/surface.js
+++ b/src/cocoa/surface.js
@@ -1,0 +1,229 @@
+// An offscreen drawing surface on the Cocoa backend — ntk's `Surface`
+// contract (draw once, composite many, and shift a retained band in place)
+// over one @windowkit/appkit CG bitmap. `react-x11/ntk`'s `Surface` hands
+// out one of these when the app it is given is a Cocoa app (the app's
+// `createSurface` seam, src/cocoa/app.js), so a component allocates its
+// buffer the same way on both backends and names neither:
+//
+//   const surface = new Surface(app, { width, height });   // device pixels
+//   const ctx = surface.getContext('2d');                    // a CocoaContext2D
+//   ctx.fillRect(0, 0, width, height);
+//   surface.copyWithin({ x: 0, y: 0, width, height }, 0, -rowHeight);
+//   windowCtx.drawImage(surface, x, y);                      // one composite
+//
+// What is the same as ntk's: the constructor, `width`/`height`/`format`/
+// `depth`/`bytes`, `getContext`, `render`, `clear`, `copyWithin` down to its
+// clamping (ntk#252 — integer deltas, the band that survives, false when
+// nothing does), `destroy`/`Symbol.dispose`, and `drawImage` taking the
+// surface as a source. What differs is stated here, because this is where
+// it lives:
+//
+// - **One graphics state per surface.** CoreGraphics keeps the CTM, the
+//   clip and the path in the bitmap context itself, where an X connection
+//   keeps them per Picture/GC. So `getContext('2d')` answers the same
+//   context every time — a JS object over that one state, nothing to free,
+//   and `destroy()` on it is a no-op — and `render()` brackets its callback
+//   in save/restore from the identity transform, so a one-shot draw leaves
+//   no residue for the next painter, which is what ntk gets from building a
+//   fresh context per call.
+// - **`format: 'a8'` is not here yet.** Coverage surfaces are what the paint
+//   cache's masks and the shadows use, and both stay on their X path; every
+//   consumer that allocates a surface of its own asks for argb32. Asking
+//   for a8 throws rather than answering a colour surface that would
+//   composite differently.
+// - **No Picture.** `picture()` is X's compositing handle; here a surface
+//   composites through `ctx.drawImage`, and asking for the picture says so.
+// - **Freed on collection.** The bridge frees the bitmap from the handle's
+//   finalizer; `destroy()` drops the handle and refuses further use, so the
+//   memory goes with the next GC rather than on the call.
+//
+// Units are device pixels, like the window's backing store: a caller sizes
+// one from `contentBox()` numbers, which are device pixels already
+// (docs/scale.md). The bridge is told the app's scale so the bitmap carries
+// it — inert for a `drawImage` source, right for a layer's contents.
+import { CocoaContext2D } from './context2d.js';
+
+export class CocoaSurface {
+  constructor(app, { width, height, format = 'argb32' } = {}) {
+    if (
+      !Number.isInteger(width) ||
+      !Number.isInteger(height) ||
+      width <= 0 ||
+      height <= 0
+    ) {
+      throw new Error('Surface: width and height must be positive integers');
+    }
+    if (format === 'a8') {
+      throw new Error(
+        "Surface: format 'a8' (a coverage surface) is not on the cocoa " +
+          'backend yet — allocate argb32, which every backend has, and ' +
+          'tint through fillStyle/globalAlpha; track docs/macos.md ' +
+          '"Custom drawing on a layer tree".',
+      );
+    }
+    if (format !== 'argb32') {
+      throw new Error(
+        `Surface: unknown format ${JSON.stringify(format)} (argb32 or a8)`,
+      );
+    }
+    this.app = app;
+    this.width = width;
+    this.height = height;
+    this.format = format;
+    this.depth = 32;
+    this._native = app._native;
+    this._fonts = app.fonts ?? null;
+    this._ctx = null;
+    this._destroyed = false;
+    this._surfaceHandle = this._native.createSurface(
+      width,
+      height,
+      app.scale ?? 1,
+    );
+    // a fresh bitmap's contents are the allocator's; a surface that is only
+    // partly drawn must composite nothing where nothing was drawn
+    this.clear();
+  }
+
+  /** bytes of backing storage — what a cache budgets against */
+  get bytes() {
+    return this.width * this.height * 4;
+  }
+
+  /** X's compositing handle, which this backend does not have. */
+  picture() {
+    throw new Error(
+      'Surface: a surface on the cocoa backend has no XRender Picture — ' +
+        'composite it with ctx.drawImage(surface, x, y), which takes a ' +
+        'surface directly on both backends.',
+    );
+  }
+
+  _handle() {
+    if (this._destroyed) {
+      throw new Error(
+        'Surface: destroyed — a context on a destroyed surface cannot ' +
+          'draw; allocate a new Surface and draw into that.',
+      );
+    }
+    return this._surfaceHandle;
+  }
+
+  _context() {
+    if (!this._ctx) {
+      this._ctx = new CocoaContext2D(
+        this._native,
+        () => this._handle(),
+        () => 1,
+      );
+      this._ctx._fonts = this._fonts;
+    }
+    return this._ctx;
+  }
+
+  /**
+   * The 2d context on the bitmap — the same one every time, since the
+   * bitmap has one graphics state (see the header). ntk's contract has the
+   * caller owning it and owing it a `destroy()`; that call is honoured as a
+   * no-op, so a caller written against ntk needs no branch.
+   */
+  getContext(name = '2d') {
+    this._handle();
+    if (name !== '2d') {
+      throw new Error(
+        `Surface: getContext(${JSON.stringify(name)}) — a surface on the ` +
+          "cocoa backend has a '2d' context and nothing else.",
+      );
+    }
+    return this._context();
+  }
+
+  /**
+   * Draw into the surface through a context that starts clean — identity
+   * transform, the fill and line state as they were — and leaves the
+   * surface's state as it found it: the save/restore bracket stands in for
+   * the per-call context ntk builds and destroys.
+   */
+  render(fn) {
+    const ctx = this.getContext('2d');
+    ctx.save();
+    try {
+      ctx.resetTransform();
+      fn(ctx);
+    } finally {
+      ctx.restore();
+    }
+    return this;
+  }
+
+  /** Reset every pixel to fully transparent, whatever transform a live
+   * context holds — the clear is issued from the identity. */
+  clear() {
+    if (this._destroyed) return this;
+    const ctx = this._context();
+    ctx.save();
+    try {
+      ctx.resetTransform();
+      ctx.clearRect(0, 0, this.width, this.height);
+    } finally {
+      ctx.restore();
+    }
+    return this;
+  }
+
+  /**
+   * Scroll the pixels of `src` (surface coordinates, `{x, y, width,
+   * height}`) by (dx, dy) in place: one in-place copy of the band that
+   * survives the shift (the bridge's `scrollSurface`, a memmove per row), in
+   * place of redrawing everything that merely moved. True when the copy was
+   * issued; false means "nothing survives the shift here" and the caller
+   * repaints `src` exactly as it would have without this method.
+   *
+   * ntk#252's contract, clamp for clamp: refused when the delta is
+   * fractional (a sub-pixel shift changes every pixel), when it is zero,
+   * when nothing of `src` survives after clamping to the surface, or on a
+   * destroyed surface. The band is `clamped src ∩ (clamped src + delta)`,
+   * so nothing outside `src` is written; the overlap is safe because the
+   * copy walks rows in the direction that reads before it overwrites.
+   */
+  copyWithin(src, dx, dy) {
+    if (this._destroyed) return false;
+    if (!Number.isInteger(dx) || !Number.isInteger(dy)) return false;
+    if (dx === 0 && dy === 0) return false;
+    const x0 = Math.max(0, Math.floor(src.x));
+    const y0 = Math.max(0, Math.floor(src.y));
+    const x1 = Math.min(this.width, Math.ceil(src.x + src.width));
+    const y1 = Math.min(this.height, Math.ceil(src.y + src.height));
+    const dstX0 = Math.max(x0, x0 + dx);
+    const dstY0 = Math.max(y0, y0 + dy);
+    const dstX1 = Math.min(x1, x1 + dx);
+    const dstY1 = Math.min(y1, y1 + dy);
+    // written as the positive test so a NaN edge (a rect with no numbers
+    // in it) is a refusal too, never a native call with garbage
+    if (!(dstX1 > dstX0 && dstY1 > dstY0)) return false;
+    return Boolean(
+      this._native.scrollSurface(
+        this._surfaceHandle,
+        x0,
+        y0,
+        x1 - x0,
+        y1 - y0,
+        dx,
+        dy,
+      ),
+    );
+  }
+
+  destroy() {
+    if (this._destroyed) return;
+    this._destroyed = true;
+    this._surfaceHandle = null;
+    this._ctx = null;
+  }
+
+  [Symbol.dispose]() {
+    this.destroy();
+  }
+}
+
+export default CocoaSurface;

--- a/src/ntk.d.ts
+++ b/src/ntk.d.ts
@@ -16,7 +16,13 @@
  * than a hand-written mirror that would drift out of date silently. The
  * named exports are the ones an extension actually reaches for; anything
  * else ntk has is still there at runtime.
+ *
+ * `Surface` is the exception, typed in full: it is react-x11's own class,
+ * answering ntk's pixmap on an X connection and a CG bitmap on the cocoa
+ * backend, so its shape is this package's to declare.
  */
+import type { Context2D } from './node.js';
+
 export const createClient: (
   options?: Record<string, unknown>,
 ) => Promise<unknown>;
@@ -26,12 +32,65 @@ export const Clipboard: new (...args: unknown[]) => unknown;
 export const Path2D: new (...args: unknown[]) => unknown;
 export const Image: new (...args: unknown[]) => unknown;
 export const Pixmap: new (...args: unknown[]) => unknown;
+
+/** What `new Surface(app, options)` takes: a size in device pixels. */
+export interface SurfaceOptions {
+  width: number;
+  height: number;
+  /**
+   * `'argb32'` (the default) on every backend. `'a8'`, a coverage surface
+   * that composites as a mask for the fill style, is X11-only today and
+   * throws on the cocoa backend.
+   */
+  format?: 'argb32' | 'a8';
+}
+
+/** A rectangle in surface coordinates — what `copyWithin` shifts. */
+export interface SurfaceRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
 /**
- * Draw once, composite many — and, for an element that scrolls a retained
- * buffer, `copyWithin(src, dx, dy)` shifts the surviving band server-side.
- * See [extending.md](../docs/extending.md).
+ * An offscreen surface: draw once, composite many — and, for an element
+ * that scrolls a retained buffer, `copyWithin(src, dx, dy)` shifts the
+ * surviving band in place. On an X connection it is ntk's pixmap and
+ * Picture; on the cocoa backend a CG bitmap; the same object shape either
+ * way, and `ctx.drawImage(surface, …)` takes it as a source on both. See
+ * [extending.md](../docs/extending.md) "Scrolling the pixels, not just the
+ * offset".
  */
-export const Surface: new (...args: unknown[]) => unknown;
+export interface Surface {
+  readonly app: unknown;
+  readonly width: number;
+  readonly height: number;
+  readonly format: 'argb32' | 'a8';
+  readonly depth: 8 | 32;
+  /** Bytes of backing storage — what a cache budgets against. */
+  readonly bytes: number;
+  /**
+   * A 2d context on the surface. The caller owns it and owes it a
+   * `destroy()` — real on X11 (a GC and a Picture), a no-op on cocoa, where
+   * a surface has one context for its whole life.
+   */
+  getContext(name: '2d', ...args: unknown[]): Context2D;
+  /** Draw through a context that exists for the call. */
+  render(fn: (ctx: Context2D) => void): this;
+  /** Reset every pixel to fully transparent. */
+  clear(): this;
+  /**
+   * Shift `src` by a whole-pixel delta in place; true when a band survived
+   * the shift and was copied, false when the caller should repaint `src`.
+   */
+  copyWithin(src: SurfaceRect, dx: number, dy: number): boolean;
+  /** X11 only — the server-side Picture, for `<image picture>`. Throws on the cocoa backend. */
+  picture(app?: unknown): unknown;
+  destroy(): void;
+  [Symbol.dispose](): void;
+}
+export const Surface: new (app: unknown, options: SurfaceOptions) => Surface;
 /** `code` values on a failed GL setup — see `<glarea onError>`. */
 export const GLXError: {
   NO_EXTENSION: 'GLX_NO_EXTENSION';

--- a/src/ntk.js
+++ b/src/ntk.js
@@ -21,5 +21,35 @@
 // for one — they were reachable but never declared — wants
 // `@react-x11/components` (`<Markdown>`, `<Formula>`). `SvgView` is still
 // here; a drawing is not a document.
+//
+// One name is not a plain re-export. `Surface` below asks the app it is
+// handed for the implementation, because ntk's own is a pixmap and a
+// Picture — an X connection's — and a component allocates its buffer
+// without knowing which backend it was mounted on. This subpath is where a
+// drawing-adjacent name gets its backend-neutral answer; the X-only names
+// (`createClient`, `Pixmap`, `Picture`, `XEmbedSocket`) stay X-only.
+import { Surface as NtkSurface } from 'ntk';
+
 export * from 'ntk';
 export { default } from 'ntk';
+
+/**
+ * ntk's offscreen `Surface`, on whichever backend `app` is.
+ *
+ * An app that makes its own surfaces answers `createSurface(options)` —
+ * the Cocoa app does, over a CG bitmap (src/cocoa/surface.js) — and an ntk
+ * connection has no such method and gets ntk's pixmap. The result is
+ * whichever implementation answered, not an instance of this class: the
+ * contract is the shape — `width`/`height`, `getContext('2d')`, `render`,
+ * `clear`, `copyWithin`, `destroy`, and `ctx.drawImage(surface, …)` —
+ * (docs/extending.md "Scrolling the pixels, not just the offset"), and
+ * nothing needs `instanceof`.
+ */
+export class Surface {
+  constructor(app, options) {
+    if (typeof app?.createSurface === 'function') {
+      return app.createSurface(options);
+    }
+    return new NtkSurface(app, options);
+  }
+}

--- a/test/cocoa-surface.test.js
+++ b/test/cocoa-surface.test.js
@@ -1,0 +1,534 @@
+// The offscreen `Surface` on the Cocoa backend (issue #433): ntk's contract
+// over a CG bitmap, reached through `react-x11/ntk`'s `Surface`, which asks
+// the app it is handed. Two layers, the shape of cocoa-glyph-runs.test.js:
+// the JS over a fake bridge everywhere — what reaches the natives is the
+// whole of what the glue decides — and, where the real bridge loads,
+// pixels: a fill lands, a band moves in place, a composite arrives.
+import assert from 'node:assert';
+import { afterEach, describe, test } from 'node:test';
+import React from 'react';
+import * as ntk from 'ntk';
+
+import { CocoaApp } from '../src/cocoa/app.js';
+import { CocoaContext2D } from '../src/cocoa/context2d.js';
+import { loadNative } from '../src/cocoa/native.js';
+import { CocoaSurface } from '../src/cocoa/surface.js';
+import { Surface } from '../src/ntk.js';
+import { cleanup, renderX11 } from '../src/testing/index.js';
+
+const h = React.createElement;
+
+afterEach(cleanup);
+
+// --- the fake bridge ----------------------------------------------------------
+
+/**
+ * A bridge shaped like @windowkit/appkit's surface natives: handles are
+ * plain objects carrying their size, every verb that matters records what
+ * it was given, and everything else the context syncs is a no-op.
+ */
+function fakeNative({ scrolls = true } = {}) {
+  const calls = [];
+  let seq = 0;
+  const native = {
+    calls,
+    of: (name) => calls.filter((c) => c[0] === name),
+    createSurface(width, height, scale) {
+      const handle = { id: ++seq, width, height, scale };
+      calls.push(['createSurface', width, height, scale]);
+      return handle;
+    },
+    surfaceSize(handle) {
+      return {
+        width: handle.width,
+        height: handle.height,
+        scale: handle.scale,
+      };
+    },
+    scrollSurface(handle, x, y, w, hh, dx, dy) {
+      calls.push(['scrollSurface', handle.id, x, y, w, hh, dx, dy]);
+      return scrolls;
+    },
+    ctxDrawSurface(dst, src, ...rest) {
+      calls.push(['ctxDrawSurface', dst.id, src.id, ...rest]);
+    },
+    ctxClearRect(handle, ...rect) {
+      calls.push(['ctxClearRect', handle.id, ...rect]);
+    },
+    ctxFillRect(handle, ...rect) {
+      calls.push(['ctxFillRect', handle.id, ...rect]);
+    },
+    ctxSave(handle) {
+      calls.push(['ctxSave', handle.id]);
+    },
+    ctxRestore(handle) {
+      calls.push(['ctxRestore', handle.id]);
+    },
+    ctxTranslate(handle, x, y) {
+      calls.push(['ctxTranslate', handle.id, x, y]);
+    },
+    ctxTransform(handle, ...m) {
+      calls.push(['ctxTransform', handle.id, ...m]);
+    },
+    listScreens() {
+      return [
+        {
+          x: 0,
+          y: 0,
+          width: 1440,
+          height: 900,
+          scale: 2,
+          visible: { x: 0, y: 0, width: 1440, height: 875 },
+        },
+      ];
+    },
+  };
+  return new Proxy(native, {
+    get: (target, key) => (key in target ? target[key] : () => undefined),
+  });
+}
+
+/** The three things a surface reads off its app. */
+const appOver = (native, scale = 2) => ({
+  _native: native,
+  fonts: { engine: 'fake' },
+  scale,
+});
+
+// --- the surface --------------------------------------------------------------
+
+test('validates like ntk: positive integer sizes, and the formats this backend has', () => {
+  const app = appOver(fakeNative());
+  for (const bad of [
+    {},
+    { width: 0, height: 4 },
+    { width: 4, height: -1 },
+    { width: 2.5, height: 4 },
+    { width: '8', height: 8 },
+  ]) {
+    assert.throws(
+      () => new CocoaSurface(app, bad),
+      /width and height must be positive integers/,
+    );
+  }
+  assert.throws(
+    () => new CocoaSurface(app, { width: 4, height: 4, format: 'a8' }),
+    /'a8'.*not on the cocoa backend yet.*argb32/,
+  );
+  assert.throws(
+    () => new CocoaSurface(app, { width: 4, height: 4, format: 'rgb24' }),
+    /unknown format "rgb24" \(argb32 or a8\)/,
+  );
+  assert.equal(app._native.of('createSurface').length, 0, 'nothing allocated');
+});
+
+test('allocates a device-pixel bitmap carrying the app scale, and starts transparent', () => {
+  const native = fakeNative();
+  const app = appOver(native, 2);
+  const surface = new CocoaSurface(app, { width: 64, height: 32 });
+  assert.deepEqual(native.of('createSurface'), [['createSurface', 64, 32, 2]]);
+  assert.equal(surface.app, app);
+  assert.equal(surface.width, 64);
+  assert.equal(surface.height, 32);
+  assert.equal(surface.format, 'argb32');
+  assert.equal(surface.depth, 32);
+  assert.equal(surface.bytes, 64 * 32 * 4);
+  assert.equal(surface._surfaceHandle.id, 1, "drawImage's handle");
+  // the clear reached the bitmap, from a saved identity state
+  const names = native.calls.map((c) => c[0]);
+  const save = names.indexOf('ctxSave');
+  const clear = names.indexOf('ctxClearRect');
+  const restore = names.indexOf('ctxRestore');
+  assert.ok(save >= 0 && save < clear && clear < restore, names.join(','));
+  assert.deepEqual(native.of('ctxClearRect'), [
+    ['ctxClearRect', 1, 0, 0, 64, 32],
+  ]);
+  // a scale the app does not know defaults to 1
+  new CocoaSurface({ _native: native }, { width: 2, height: 2 });
+  assert.deepEqual(native.of('createSurface')[1], ['createSurface', 2, 2, 1]);
+});
+
+test("getContext answers one context over the bitmap's one graphics state, with the app's fonts", () => {
+  const app = appOver(fakeNative());
+  const surface = new CocoaSurface(app, { width: 8, height: 8 });
+  const ctx = surface.getContext('2d');
+  assert.ok(ctx instanceof CocoaContext2D);
+  assert.strictEqual(ctx._fonts, app.fonts);
+  assert.strictEqual(surface.getContext('2d'), ctx, 'the same one every time');
+  assert.strictEqual(surface.getContext(), ctx, "'2d' is the default");
+  ctx.destroy(); // ntk's contract, honoured as a no-op
+  assert.strictEqual(surface.getContext('2d'), ctx);
+  assert.throws(
+    () => surface.getContext('webgl'),
+    /getContext\("webgl"\).*'2d' context and nothing else/,
+  );
+});
+
+test('render brackets the callback: it starts from the identity and leaves no residue', () => {
+  const native = fakeNative();
+  const surface = new CocoaSurface(appOver(native), { width: 8, height: 8 });
+  const ctx = surface.getContext('2d');
+  // a held context with a translate in force, as a retained painter has
+  ctx.translate(5, 5);
+  ctx.fillStyle = '#123456';
+  let seen = null;
+  const back = surface.render((c) => {
+    assert.strictEqual(c, ctx, 'the one context');
+    seen = c.getTransform();
+    c.translate(10, 20);
+    c.fillStyle = '#f00';
+    c.fillRect(0, 0, 1, 1);
+  });
+  assert.strictEqual(back, surface);
+  assert.deepEqual(seen, { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 });
+  assert.deepEqual(ctx.getTransform(), { a: 1, b: 0, c: 0, d: 1, e: 5, f: 5 });
+  assert.equal(ctx.fillStyle, '#123456');
+  // and the fill went out with the callback's colour
+  assert.deepEqual(native.of('ctxFillRect').at(-1), [
+    'ctxFillRect',
+    1,
+    0,
+    0,
+    1,
+    1,
+  ]);
+});
+
+test('clear reaches every pixel whatever transform the live context holds', () => {
+  const native = fakeNative();
+  const surface = new CocoaSurface(appOver(native), { width: 8, height: 8 });
+  const ctx = surface.getContext('2d');
+  ctx.translate(100, 100);
+  const before = native.calls.length;
+  assert.strictEqual(surface.clear(), surface);
+  const since = native.calls.slice(before);
+  // the identity is restored for the clear — a transform undoing the
+  // translate goes out before it — and the caller's translate survives
+  const transform = since.find((c) => c[0] === 'ctxTransform');
+  assert.deepEqual(transform, ['ctxTransform', 1, 1, 0, 0, 1, -100, -100]);
+  assert.deepEqual(
+    since.find((c) => c[0] === 'ctxClearRect'),
+    ['ctxClearRect', 1, 0, 0, 8, 8],
+  );
+  assert.deepEqual(ctx.getTransform(), {
+    a: 1,
+    b: 0,
+    c: 0,
+    d: 1,
+    e: 100,
+    f: 100,
+  });
+});
+
+test("copyWithin: ntk#252's refusals in JS, then one scrollSurface of the clamped band", () => {
+  const native = fakeNative();
+  const surface = new CocoaSurface(appOver(native), { width: 64, height: 32 });
+  const all = { x: 0, y: 0, width: 64, height: 32 };
+  assert.equal(surface.copyWithin(all, 0, -0.5), false, 'a fractional shift');
+  assert.equal(surface.copyWithin(all, 0, 0), false, 'no shift');
+  assert.equal(surface.copyWithin(all, 0, -40), false, 'nothing survives');
+  assert.equal(
+    surface.copyWithin(all, 64, 0),
+    false,
+    'nothing survives across',
+  );
+  assert.equal(
+    surface.copyWithin({ x: 0, y: 0, width: 0, height: 32 }, 0, -1),
+    false,
+  );
+  assert.equal(surface.copyWithin({}, 0, -1), false, 'a rect with no numbers');
+  assert.equal(
+    native.of('scrollSurface').length,
+    0,
+    'every refusal is a refusal here',
+  );
+  // a band reaching outside the surface, with fractional edges: floored
+  // and ceiled like ntk, clamped to the bitmap, and handed over whole —
+  // the native does the same intersection and moves rect ∩ (rect + delta)
+  assert.equal(
+    surface.copyWithin({ x: -5, y: 10.5, width: 100, height: 20.2 }, 0, -8),
+    true,
+  );
+  assert.deepEqual(native.of('scrollSurface'), [
+    ['scrollSurface', 1, 0, 10, 64, 21, 0, -8],
+  ]);
+  assert.equal(surface.copyWithin(all, 3, 0), true, 'a horizontal shift');
+  assert.deepEqual(native.of('scrollSurface')[1], [
+    'scrollSurface',
+    1,
+    0,
+    0,
+    64,
+    32,
+    3,
+    0,
+  ]);
+  // the native's answer is the answer
+  const refusing = new CocoaSurface(appOver(fakeNative({ scrolls: false })), {
+    width: 8,
+    height: 8,
+  });
+  assert.equal(
+    refusing.copyWithin({ x: 0, y: 0, width: 8, height: 8 }, 0, -1),
+    false,
+  );
+});
+
+test('drawImage composites one surface into another through ctxDrawSurface, in every arity', () => {
+  const native = fakeNative();
+  const app = appOver(native);
+  const source = new CocoaSurface(app, { width: 16, height: 8 });
+  const target = new CocoaSurface(app, { width: 64, height: 32 });
+  const ctx = target.getContext('2d');
+  ctx.drawImage(source, 3, 4);
+  ctx.drawImage(source, 3, 4, 32, 16);
+  ctx.drawImage(source, 2, 1, 8, 4, 10, 20, 16, 8);
+  assert.deepEqual(native.of('ctxDrawSurface'), [
+    ['ctxDrawSurface', 2, 1, 0, 0, 16, 8, 3, 4, 16, 8],
+    ['ctxDrawSurface', 2, 1, 0, 0, 16, 8, 3, 4, 32, 16],
+    ['ctxDrawSurface', 2, 1, 2, 1, 8, 4, 10, 20, 16, 8],
+  ]);
+  // a destroyed source is nothing to draw, like any source this backend
+  // has no pixels for
+  source.destroy();
+  ctx.drawImage(source, 0, 0);
+  assert.equal(native.of('ctxDrawSurface').length, 3);
+});
+
+test('destroy drops the handle, refuses further drawing with a reason, and is idempotent', () => {
+  const native = fakeNative();
+  const surface = new CocoaSurface(appOver(native), { width: 8, height: 8 });
+  const ctx = surface.getContext('2d');
+  surface.destroy();
+  assert.equal(surface._surfaceHandle, null);
+  assert.throws(
+    () => ctx.fillRect(0, 0, 1, 1),
+    /Surface: destroyed.*allocate a new Surface/,
+  );
+  assert.throws(() => surface.getContext('2d'), /Surface: destroyed/);
+  assert.throws(() => surface.render(() => {}), /Surface: destroyed/);
+  const before = native.calls.length;
+  assert.strictEqual(
+    surface.clear(),
+    surface,
+    'clear on a dead surface is nothing',
+  );
+  assert.equal(
+    surface.copyWithin({ x: 0, y: 0, width: 8, height: 8 }, 0, -1),
+    false,
+  );
+  assert.equal(native.calls.length, before);
+  surface.destroy();
+  const disposable = new CocoaSurface(appOver(native), { width: 8, height: 8 });
+  disposable[Symbol.dispose]();
+  assert.equal(disposable._surfaceHandle, null);
+});
+
+test('picture() says where the composite is instead', () => {
+  const surface = new CocoaSurface(appOver(fakeNative()), {
+    width: 8,
+    height: 8,
+  });
+  assert.throws(
+    () => surface.picture(surface.app),
+    /no XRender Picture.*ctx\.drawImage\(surface/,
+  );
+});
+
+// --- the context's part -------------------------------------------------------
+
+test('a restore with nothing saved does nothing, as on canvas', () => {
+  const native = fakeNative();
+  const handle = native.createSurface(4, 4, 1);
+  const ctx = new CocoaContext2D(
+    native,
+    () => handle,
+    () => 1,
+  );
+  ctx.restore();
+  assert.equal(native.of('ctxRestore').length, 0);
+  ctx.save();
+  ctx.fillStyle = '#f00';
+  ctx.restore();
+  ctx.restore();
+  assert.equal(native.of('ctxRestore').length, 1);
+  assert.equal(ctx.fillStyle, '#000');
+  assert.equal(typeof ctx.destroy, 'function');
+  ctx.destroy();
+});
+
+// --- the dispatch -------------------------------------------------------------
+
+test("react-x11/ntk's Surface asks the app first: a Cocoa app answers its own", () => {
+  const app = new CocoaApp(fakeNative());
+  const surface = new Surface(app, { width: 32, height: 16 });
+  assert.ok(surface instanceof CocoaSurface);
+  assert.strictEqual(surface.app, app);
+  assert.equal(surface.width, 32);
+  assert.strictEqual(surface.getContext('2d')._fonts, app.fonts);
+  assert.deepEqual(app._native.of('createSurface'), [
+    ['createSurface', 32, 16, 2],
+  ]);
+  // any app with the seam is asked, and its answer is the answer
+  const asked = [];
+  const marker = { width: 1, height: 1 };
+  const other = { createSurface: (options) => (asked.push(options), marker) };
+  assert.strictEqual(new Surface(other, { width: 1, height: 1 }), marker);
+  assert.deepEqual(asked, [{ width: 1, height: 1 }]);
+});
+
+test("react-x11/ntk's Surface falls through to ntk's pixmap on an X connection", async () => {
+  const { app } = await renderX11(h('box', null));
+  assert.equal(typeof app.createSurface, 'undefined', 'ntk has no such seam');
+  const surface = new Surface(app, { width: 8, height: 8 });
+  assert.ok(surface instanceof ntk.Surface);
+  assert.equal(surface.width, 8);
+  assert.equal(typeof surface.picture(app).id, 'number');
+  surface.destroy();
+});
+
+// --- over the real bridge -----------------------------------------------------
+
+let bridge = null;
+if (process.platform === 'darwin') {
+  try {
+    bridge = loadNative();
+  } catch {
+    bridge = null;
+  }
+}
+
+describe(
+  'over the real bridge',
+  {
+    skip: bridge ? false : 'the @windowkit/appkit bridge is not loadable here',
+  },
+  () => {
+    const app = () => ({ _native: bridge, fonts: null, scale: 1 });
+    const pixel = (surface, x, y) => [
+      ...bridge.ctxGetImageData(surface._surfaceHandle, x, y, 1, 1),
+    ];
+    const rows = (surface) => {
+      const out = [];
+      for (let y = 0; y < surface.height; y++)
+        out.push(pixel(surface, 0, y)[0]);
+      return out;
+    };
+    /** Row y painted red at level 32·y, so every row is its own colour. */
+    const paintRows = (surface) => {
+      const ctx = surface.getContext('2d');
+      for (let y = 0; y < surface.height; y++) {
+        ctx.fillStyle = `rgb(${32 * y}, 0, 0)`;
+        ctx.fillRect(0, y, surface.width, 1);
+      }
+      return ctx;
+    };
+
+    test('a fresh surface is transparent, a fill lands, and clear reaches under a live translate', () => {
+      const surface = new CocoaSurface(app(), { width: 16, height: 16 });
+      assert.deepEqual(pixel(surface, 8, 8), [0, 0, 0, 0]);
+      const ctx = surface.getContext('2d');
+      ctx.fillStyle = '#ff0000';
+      ctx.fillRect(0, 0, 16, 16);
+      assert.deepEqual(pixel(surface, 8, 8), [255, 0, 0, 255]);
+      ctx.translate(100, 100); // and never restored
+      surface.clear();
+      assert.deepEqual(pixel(surface, 8, 8), [0, 0, 0, 0]);
+      assert.deepEqual(pixel(surface, 0, 15), [0, 0, 0, 0]);
+      assert.equal(ctx.getTransform().e, 100, "the caller's state is its own");
+      surface.destroy();
+    });
+
+    test('copyWithin moves the band in place, overlap included, and leaves the exposed strip alone', () => {
+      const surface = new CocoaSurface(app(), { width: 8, height: 8 });
+      paintRows(surface);
+      assert.deepEqual(rows(surface), [0, 32, 64, 96, 128, 160, 192, 224]);
+      const all = { x: 0, y: 0, width: 8, height: 8 };
+      // up by three: rows 0..4 take rows 3..7; rows 5..7 are the caller's
+      assert.equal(surface.copyWithin(all, 0, -3), true);
+      assert.deepEqual(rows(surface), [96, 128, 160, 192, 224, 160, 192, 224]);
+      // down by one over the overlap: rows walk bottom-up, so nothing is
+      // read after it was overwritten
+      assert.equal(surface.copyWithin(all, 0, 1), true);
+      assert.deepEqual(rows(surface), [96, 96, 128, 160, 192, 224, 160, 192]);
+      // a band, sideways: only its pixels move
+      paintRows(surface);
+      const ctx = surface.getContext('2d');
+      ctx.fillStyle = '#00ff00';
+      ctx.fillRect(0, 2, 2, 1); // a green pair at the left of row 2
+      assert.equal(
+        surface.copyWithin({ x: 0, y: 2, width: 8, height: 1 }, 3, 0),
+        true,
+      );
+      assert.deepEqual(pixel(surface, 3, 2), [0, 255, 0, 255]);
+      assert.deepEqual(pixel(surface, 4, 2), [0, 255, 0, 255]);
+      assert.deepEqual(
+        pixel(surface, 5, 2),
+        [64, 0, 0, 255],
+        'row 2 red past the pair',
+      );
+      assert.deepEqual(
+        pixel(surface, 0, 2),
+        [0, 255, 0, 255],
+        'the source column is not cleared',
+      );
+      assert.deepEqual(
+        pixel(surface, 3, 1),
+        [32, 0, 0, 255],
+        'the row above is untouched',
+      );
+      assert.equal(surface.copyWithin(all, 0, -8), false, 'nothing survives');
+      surface.destroy();
+    });
+
+    test('drawImage composites a surface into another, whole and cropped', () => {
+      const source = new CocoaSurface(app(), { width: 4, height: 4 });
+      source.render((c) => {
+        c.fillStyle = '#ff0000';
+        c.fillRect(0, 0, 2, 4);
+        c.fillStyle = '#00ff00';
+        c.fillRect(2, 0, 2, 4);
+      });
+      const target = new CocoaSurface(app(), { width: 16, height: 16 });
+      const ctx = target.getContext('2d');
+      ctx.drawImage(source, 6, 6);
+      assert.deepEqual(pixel(target, 6, 6), [255, 0, 0, 255]);
+      assert.deepEqual(pixel(target, 9, 9), [0, 255, 0, 255]);
+      assert.deepEqual(pixel(target, 5, 5), [0, 0, 0, 0]);
+      assert.deepEqual(pixel(target, 10, 10), [0, 0, 0, 0]);
+      // the right half only, scaled up to fill a 4x4 block at the origin
+      ctx.drawImage(source, 2, 0, 2, 4, 0, 0, 4, 4);
+      assert.deepEqual(pixel(target, 0, 0), [0, 255, 0, 255]);
+      assert.deepEqual(pixel(target, 3, 3), [0, 255, 0, 255]);
+      assert.deepEqual(pixel(target, 4, 4), [0, 0, 0, 0]);
+      source.destroy();
+      target.destroy();
+    });
+
+    test("the retained renderer's life: draw rows, scroll, composite the grid into the window", () => {
+      // the terminal's shape (@react-x11/components, RetainedRenderer):
+      // one context for the surface's life, rows drawn into it, a scroll as
+      // one copyWithin plus the exposed strip, the whole grid one drawImage
+      const grid = new CocoaSurface(app(), { width: 8, height: 8 });
+      const ctx = paintRows(grid);
+      assert.equal(
+        grid.copyWithin({ x: 0, y: 0, width: 8, height: 8 }, 0, -1),
+        true,
+      );
+      ctx.fillStyle = '#0000ff';
+      ctx.fillRect(0, 7, 8, 1); // the exposed row
+      const window = new CocoaSurface(app(), { width: 24, height: 24 });
+      window.getContext('2d').drawImage(grid, 0, 0, 8, 8, 4, 4, 8, 8);
+      assert.deepEqual(
+        pixel(window, 4, 4),
+        [32, 0, 0, 255],
+        'row 1 is now row 0',
+      );
+      assert.deepEqual(pixel(window, 4, 11), [0, 0, 255, 255], 'the new row');
+      assert.deepEqual(pixel(window, 3, 3), [0, 0, 0, 0]);
+      ctx.destroy();
+      grid.destroy();
+      window.destroy();
+    });
+  },
+);

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -9,6 +9,8 @@
 import React, { useRef, useState } from 'react';
 import { startTrace } from 'react-x11/debug';
 import { XK_MULTI_KEY, isDeadKeysym, keysymFromName } from 'react-x11/keysyms';
+import { Surface } from 'react-x11/ntk';
+import type { Context2D } from 'react-x11/node';
 import { onReload, performReactRefresh } from 'react-x11/refresh';
 import { registerRefresh, createTransformer } from 'react-x11/refresh/loader';
 import type { ReloadEvent } from 'react-x11/refresh';
@@ -1055,6 +1057,29 @@ async function main() {
 
   // @ts-expect-error — compose takes a table, not a boolean either way
   await createRoot({ compose: true });
+
+  // an offscreen surface, on whichever backend the app is: ntk's pixmap on
+  // X11, a CG bitmap on cocoa, one shape
+  const surface: Surface = new Surface(ownCompose.app, {
+    width: 64,
+    height: 32,
+  });
+  const sctx: Context2D = surface.getContext('2d');
+  void sctx;
+  surface.render((c: Context2D) => void c).clear();
+  const survived: boolean = surface.copyWithin(
+    { x: 0, y: 0, width: surface.width, height: surface.height },
+    0,
+    -8,
+  );
+  void survived;
+  const budget: number = surface.bytes;
+  void budget;
+  surface.destroy();
+  // @ts-expect-error — two formats, and a8 is one of them by name
+  new Surface(ownCompose.app, { width: 1, height: 1, format: 'rgb24' });
+  // @ts-expect-error — a size is not optional
+  new Surface(ownCompose.app, { width: 1 });
 
   // accelerators: the Latin keysym by default, and two ways to say otherwise
   const byLayout = await createRoot({ accelerators: 'layout' });


### PR DESCRIPTION
Closes #433 — the second half of running `@react-x11/components`' vt terminal on the Cocoa backend (the first was the glyph-run seams, #434).

## What was wrong

`react-x11/ntk` was `export * from 'ntk'`, and ntk's `Surface` is a pixmap and a Picture: on a Cocoa app `new Surface(app, { width, height })` read `app.display.screen[0].root` off an app with no display and threw a `TypeError`. Every consumer written against the contract — the terminal's `RetainedRenderer.ensure` first — caught it and fell back to redrawing everything, so a terminal scroll on macOS was a screenful of glyph work. `docs/macos.md` promised the Cocoa app object would supply one; this is that object and the export.

## What changes

**`CocoaSurface`** (`src/cocoa/surface.js`): ntk's `Surface` contract over one CG bitmap from the bridge.

| seam | now |
| --- | --- |
| `new Surface(app, { width, height, format })` | ntk's signature and validation; device pixels, like the window's backing store |
| `width`, `height`, `format`, `depth`, `bytes` | as ntk |
| `getContext('2d')` | a `CocoaContext2D` over the bitmap, with the app's fonts |
| `render(fn)`, `clear()` | as ntk; both issued from the identity transform inside a save/restore bracket |
| `copyWithin(src, dx, dy)` | ntk#252's contract, clamp for clamp — integer deltas, the band that survives, `false` when nothing does — over the bridge's in-place `scrollSurface` |
| `ctx.drawImage(surface, …)` | one `CGContextDrawImage`, every arity |
| `destroy()`, `Symbol.dispose` | drops the handle; the bridge frees the bitmap from its finalizer |

**The seam**: `CocoaApp.createSurface(options)` (the shape of `createPaneHost`/`createGlobalMenuExport`), and **`react-x11/ntk`'s `Surface` is now react-x11's own class** — it asks the app it is handed first and falls through to ntk's pixmap on an X connection. A component allocates its buffer the same way on both backends and names neither; `Surface` from `ntk` itself stays the pixmap.

Three differences from ntk, stated where they live: a CG bitmap has **one graphics state**, so a surface has one context for its life (`destroy()` on it is a no-op, which `CocoaContext2D` now honours) and `render()` brackets its callback in save/restore from the identity; **`format: 'a8'` throws** rather than answering a colour surface — the coverage surfaces the paint cache and the shadows use stay on their X path; and **`picture()` throws** pointing at `drawImage`.

Two fixes in `CocoaContext2D` on the way: `restore()` with nothing saved now does nothing (canvas's rule, and what keeps a surface's base state safe under an unbalanced painter), and `save()` syncs the surface before pushing — the first save/restore pair on a fresh context used to lose its JS state to the sync.

**Types**: `Surface` is declared in full in `src/ntk.d.ts` (it is this package's class now), with a block in the type test.

**Docs**: `docs/extending.md` says the scroll-the-pixels recipe runs unchanged on Cocoa; `docs/macos.md` records the seam, flips the required-API markers, and gains **"The split: what the bridge owns, what the renderer owns"** — the answer to "if the bridge grew a full canvas2d API, could it replace ntk on this backend outright?", measured against the retained tier and the Wayland and Windows backends to come. Short version: the bridge stays mechanism-only (the verb table over a surface handle is the native-addon contract); the dialect wrapper, the surfaces and the swapchain stay in react-x11; layers are a ceiling behind the three seams that exist; the invalidate channel is already node-granular, so the presenter's dirty-subtree pruning is the next step — ahead of any new backend, since X11 and Cocoa become stable and performant first.

## Tests

`test/cocoa-surface.test.js`, two layers:

- **Everywhere**: the glue over a fake bridge — validation, allocation at the app scale, the one-context rule, `render`'s bracket, `clear` under a live translate, every `copyWithin` refusal and the clamped band that reaches `scrollSurface`, `drawImage` in its three arities, destroy/dispose, the `restore()` rule, and the dispatch: a Cocoa app answers its own, an X app (the in-process server) gets ntk's.
- **Where the real bridge loads** (skipped otherwise, so CI on Linux is unaffected): pixels — a fill lands, `clear` reaches under a translate, in-place copies with their overlap in both directions and sideways, composites whole and cropped, and the retained renderer's whole life.

Full suite on this Mac: everything passes except the six `appearance.test.js` cases that fail on `origin/master` here too (the macOS rung answering where the tests expect silence). `lint`, `typecheck`, `format:check` green.

## Verified on the terminal

`@react-x11/components` 0.4.0's `<Terminal backend="vt">` (its built dist over this branch), `createRoot({ backend: 'cocoa' })`, Menlo 14: the retained renderer engages — `renderer.kind === 'retained'`, its surface a `CocoaSurface` — and a 60-line trickle through the pty is 62 frames with **37 scroll copies**, where before it was a full redraw per frame. The same drive on the X11 backend (Xvfb, ntk's `Surface`) gives 62 frames and 37 copies too. Screenshots below are each window's own backing surface.

## Found on the way: the top row is stale, on both backends

Filed as [react-x11-components#60](https://github.com/sidorares/react-x11-components/issues/60). Both screenshots show `line 1` on the first row above `line 39…60`. That is a bug in `@react-x11/components`, not here, and it is identical on X11 with ntk's own `Surface`. `RetainedRenderer.copyRows(srcRow, dstRow, count)` hands `copyWithin` the *source* rows as the rect with `dy = (dstRow − srcRow) · h`, but the contract shifts pixels *within* the rect (`dest = rect ∩ (rect + delta)`, the `scrollRegion` rule, which `CocoaSurface` matches clamp for clamp), so for a scroll-up by one the band lands in rows 1…R−2 and row 0 is never written — while the mirror, shifted as a block move, believes row 0 already holds the new line and never repaints it. Reproduced on ntk's `Surface` directly on the in-process X server: six painted rows, `copyWithin({ x: 0, y: 1, width, height: 5 }, 0, −1)` leaves row 0 untouched; the union rect `{ y: 0, height: 6 }` moves row 1 into it. The one-line fix is in that renderer — the rect is the union of source and destination, `{ y: min(srcRow, dstRow) · h, height: (count + |dstRow − srcRow|) · h }` with the same delta.

## Not here

`Image` as a `drawImage` source on this backend; `format: 'a8'`; `createPattern`, which `<Flow>`'s grid tile asks for before it allocates its surface; and the charts' image, which gates on `app.display.Render` of its own — all listed in docs/macos.md's required-API paragraph or the components' own capability statements.

![terminal-cocoa](https://github.com/user-attachments/assets/734e1040-5620-46ef-aea2-1231b5609585)

![terminal-x11](https://github.com/user-attachments/assets/36bb7f94-75f6-4c65-8f0c-a7a68c341d73)



