### PR TITLE
perf(cocoa): the frame clock, the resize loop and the large tree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,32 @@ jobs:
       # No retry here — a hash is exact, so a second run cannot disagree.
       - run: npm run bench:pixels -- --check
 
+  # The Cocoa frame-clock gate, run only when a change can reach it. The
+  # touched runner reads the PR's diff against its base and owes the
+  # presenters bench for hot-path files alone — the paint walk and damage
+  # model, the layout floors, the event dispatch, src/cocoa, the benches and
+  # the dependency manifest — so a docs PR spends nothing here and a
+  # nodes.js PR spends two minutes. What it judges is structural
+  # (scripts/bench/presenters-gate.json): full-window frames, the share of
+  # the window one cell repaints, frames per resize tick, frames painted for
+  # a window nobody can see. Never milliseconds — a shared runner's timings
+  # say nothing, and the table it prints is for the human reading the log.
+  # A push to master runs every scenario, for the trend.
+  bench-cocoa:
+    runs-on: macos-14
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # the diff against the PR base is what decides whether to run
+          fetch-depth: 0
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run bench:touched -- --benches=presenters --ci ${{ github.event_name == 'push' && '--all' || format('--base={0}', github.event.pull_request.base.sha) }}
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -728,6 +728,36 @@ unchanged across the fix.
   change never touched). `--no-isolate` puts them back in one process: ~3x
   faster for a development loop, and coupled again
 
+### Which bench a change owes
+
+A hot path is a short list of files — the paint walk and the damage model
+(`nodes.js`), the layout floors and styles, the paint cache, the event
+dispatch that decides when a frame goes out (`events.js`, `frames.js`),
+`src/cocoa/`, the benches and their baselines, and `package.json`, because
+an ntk bump moves everything under all of them. `npm run bench:touched`
+reads your diff against `origin/master`, matches it against that list
+(`scripts/bench/touched.js` is the list, in one place), and runs the gates
+the matches owe: the X11 protocol and pixel gates for a `nodes.js` change,
+the Cocoa frame-clock gate as well on a mac, nothing for a docs change.
+`--dry` says which without running them. CI does the same on every PR —
+the `bench` job runs the X11 gates unconditionally on Linux, and
+`bench-cocoa` runs the touched runner on a macOS runner, so a change that
+cannot reach a frame costs no runner time there.
+
+The Cocoa gate (`npm run bench:presenters -- --check`,
+`scripts/bench/presenters-gate.json`) is deliberately **structural**:
+full-window frames, the share of the window one cell repaints, frames per
+resize tick, backing surfaces per resize tick, frames painted for a window
+nobody can see. Never milliseconds — a shared runner's timing says nothing,
+while "one cell repainted 60% of the window" is the same finding on every
+machine. The timing table still prints, and the CI job appends it to the
+run's summary for the trend. When a change is _meant_ to move the frame
+clock — a cadence, a deferral, a cache — run the full table on a real
+display (`npm run bench:presenters`, 6s per cell, nothing else running) and
+put the before/after rows in the PR, the way docs/macos.md "Measured"
+records them; and loosen a rule in the same PR only with the number that
+made it necessary.
+
 For a live app rather than the bench scenarios, `REACT_X11_TRACE=summary`
 (or `requests`, or `chrome:/tmp/t.json` for Perfetto) traces the protocol
 with the same splitter, `REACT_X11_DEBUG_PAINT=1` flashes damage rects and
@@ -1192,6 +1222,22 @@ onDraw>`, `value`, `placeholder`. `children` and event handlers are
   `src/styles.js` use the straight parser for exactly that reason. Note that
   opaque colours are identical either way, so a test with `#000000` and
   `#ffffff` cannot tell the two apart.
+- **A subtree's paint reach is cached, and every change to it has to be
+  announced.** `_subtreeBounds()` — the rect a bounded frame culls against,
+  and the one every damage claim is measured from — is computed once and
+  kept on the node (`_paintBoundsCache`), because recomputing it per pass
+  made a one-cell repaint walk the whole tree (1.25ms at 3,600 nodes, 0.37ms
+  cached; `npm run bench:presenters -- --scenario=tree`). It is dropped up
+  the chain by `_assignAbs`, `_childListChanged`, `_retarget` (every style
+  swap), `setStyleState` and `Node.invalidate` — so a node whose reach
+  changes through some new route has to come through one of those, or the
+  frame culls it out of the region it draws in and nothing says why.
+  `REACT_X11_NO_BOUNDS_CACHE=1` is the first aid, and `test/paint-reach.test.js`
+  the fence. The cap on damage rects (`MAX_DAMAGE_RECTS`, four) is the
+  server-side cost of a pass on X11; a backend whose pass is cheaper says so
+  on its window (`damageRectCap`) — the Cocoa window keeps sixteen, which
+  is what turned twelve scattered cell updates from 1.5Mpx of repaint into
+  0.26.
 - **A frame that claims no damage repaints everything**, deliberately — the
   safe default when nothing can say what changed. It also means a test that
   changes one thing cannot demonstrate a missed repaint: with nothing bounding

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -168,6 +168,19 @@ desktop appearance switch; there strict mode crashes.
 
 Read once at startup like the switches above, and answers only to `1`.
 
+## `REACT_X11_NO_BOUNDS_CACHE=1`
+
+Disables the cached paint reach. A bounded frame asks every subtree on the
+way to its rect whether it reaches in, and the answer — the node's rect
+unioned with its descendants' — is kept until something that moves it says
+so: a rect assigned by layout, a child list change, a style swap, a state
+flip, a change the node announces about itself. Recomputing it per pass made
+a one-cell repaint cost the whole tree (1.25ms at 3,600 nodes, 0.37ms
+cached). With this set every walk is fresh, so if a node ever goes missing
+from a bounded repaint — culled by a reach nobody updated — this is the
+first thing to try, and a fix that lands here is a change nobody announced
+through `invalidate`. Read once at startup; answers only to `1`.
+
 ## `REACT_X11_NO_TRANSPARENCY=1`
 
 Makes every display answer the way one with no 32-bit visual does:

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -648,7 +648,13 @@ The frame clock rides the display link: `requestAnimationFrame`
 callbacks fire on link ticks, commits wrap in explicit `CATransaction`s,
 and the "answer the input" early-flush (`flushPendingFrames` on handler
 unwind) maps to committing the transaction before the pump returns to
-AppKit — same policy, new mechanism.
+AppKit — same policy, new mechanism. What runs today is the timer pump
+with a frame interval over it (`frameInterval`, 16ms by default; the gate
+is the interval less half a pump, so a frame lands on the first tick at or
+after it rather than alternating between the tick before and the tick
+after), discrete input and the wheel flushed on the event, and a
+window that is not on glass deferring its frames — see "Measured" below
+for what each of those was worth.
 
 ## Native controls
 
@@ -1088,6 +1094,122 @@ a second native backend or Wayland actually starts, and not before: a
 half-renamed tree is worse than either name. (5) Bridge growth stays
 verb-shaped — a pattern fill for `<Flow>`'s grid tiles, radial
 gradients, a blend op for `PictOp.Src` — and never a JS canvas class.
+
+## Measured: the frame clock and the large tree
+
+Written 2026-09-03 against react-x11 2.5.0 and `@windowkit/appkit` 0.3.0,
+on an M1 Pro at 2x, from the stress scenarios `npm run bench:presenters`
+grew for it — "state update → pixels" and "interaction → pixels" inside a
+tree the size of an application screen (`--cells`, 1,200 labelled boxes:
+3,662 nodes) — and the surface presenter, which is the default. The
+numbers travel as well as any timing does; the ratios are the findings.
+
+**What a frame cost, and what it costs now** (median flush unless said
+otherwise; `cpu` is the process as a share of one core, driver ticks at
+62.5Hz):
+
+| scenario                                  | before                     | after                      |
+| ----------------------------------------- | -------------------------- | -------------------------- |
+| `tree` — one memoized cell per tick       | 1.25ms                     | 0.35ms                     |
+| `tiny` — one of 5,000 cells (14k nodes)   | 7.2ms p95                  | 1.2ms p95                  |
+| `multi` — 12 scattered cells per tick     | 11.9ms, 1,470kpx repainted | 2.8ms, 264kpx              |
+| `press` — down/up, input → flush          | 4.3ms p50 / 10.2 p95       | 2.6ms p50 / 8.7 p95        |
+| `scroll` — wheel notch, input → flush     | 15.2ms p50                 | 1.9ms p50                  |
+| `resize` — a live tick, 40-tick drag      | 71ms, 2 full frames each   | 28ms, 1 frame + 1 catch-up |
+| `occluded` — hidden window, cell per tick | 207 frames, 50% cpu        | 0 frames                   |
+| `layout` — every cell reflows per tick    | 44ms (18fps)               | 44ms — see below           |
+
+Five changes, each fenced by a test:
+
+- **The paint reach is cached** (`Node._paintBoundsCache`, nodes.js). A
+  bounded frame asked every subtree on the way to its rect whether it
+  reached in, and each answer walked the subtree: a one-cell repaint cost
+  the whole tree, linearly. The union is now kept until something that
+  moves it announces itself — layout, a child list change, a style swap, a
+  state flip, `invalidate` — with `REACT_X11_NO_BOUNDS_CACHE=1` as first
+  aid. Shared with X11, and the protocol bench is unchanged by it:
+  `test/paint-reach.test.js`.
+- **The damage rect cap is the backend's** (`window.damageRectCap`). Four
+  rects is what a pass costs the X server; a Cocoa pass is one CoreGraphics
+  clip and a culled walk, so its window keeps sixteen — twelve components
+  ticking at once paint their twelve rects instead of the box around them.
+- **A resize tick is one frame** (`CocoaWindow._freshSurface`,
+  `_routeGeometry`). Replacing the backing surface used to queue a second
+  full frame behind the one already painting it, and the React-half flush
+  was queued per event — and inside AppKit's resize loop no microtask runs
+  until the drag ends, so a forty-tick drag ran eighty full frames on the
+  mouse release: the freeze after a resize. A fresh surface now asks for a
+  frame only when the flush that found it was bounded, and holds the
+  present until that frame lands; the release owes at most one flush.
+  `test/cocoa-frames.test.js`.
+- **A live resize defers the content floors** (`_deferContentFloors`,
+  nodes.js). The floors (#249) are three extra layout passes and their
+  walks — 21 of the 44ms a relayout costs on this tree — and a drag calls
+  the frame from inside every pointer move. A live tick lays out against
+  the floors it has (exact along the main axis, a frame stale for wrapped
+  text across it) and the first pump tick after the release measures once
+  and lays out again: answer the input, then catch up. Only under
+  `liveResizing`, which the Cocoa window reads off AppKit's flag and the
+  pump clears; an X window never sets it. A content change mid-drag takes
+  the measured path.
+- **A window nobody can see owes nothing** (`CocoaWindow._visible`): frames
+  for a window that is ordered out or miniaturized wait in the queue and
+  its present waits with them; one catch-up frame when it is back. Occlusion
+  by another application's window is not read yet — the bridge does not
+  forward `windowDidChangeOcclusionState`, and that is the one place to add
+  it. The frame gate also moved from "one interval since the last frame" to
+  "the first pump tick at or after it", which took a 16/24/16/24ms cadence
+  to a steady 16 (52 → 56fps against the 62.5Hz driver), and the wheel is
+  answered on the event like a press — AppKit already delivers scroll
+  events at the display's rate, so that is once per refresh by
+  construction.
+
+The structural half of these numbers is a gate now:
+`npm run bench:presenters -- --check` judges full-window frames, the share
+of the window a cell repaints, frames per resize tick and frames for a
+hidden window against `scripts/bench/presenters-gate.json`, and
+`npm run bench:touched` runs it — with the X11 gates — only for a change
+that reaches a hot path. CI's `bench-cocoa` job does the same on a macOS
+runner.
+
+**What is left, in order of what it costs:**
+
+1. **A full relayout of a large tree: 44ms at 3,600 nodes, 320ms at
+   14,000.** Half of it is the content floors, a third is yoga through its
+   JS binding (three measuring passes plus the real one, each a full tree
+   of getters and setters across the wasm boundary), the rest is paint —
+   1,200 rounded fills and 1,200 `CTLineDraw`s at about 4µs and 3µs each.
+   The floors are the target: they are measured from scratch on every
+   layout change, and an incremental version — per-subtree content
+   signatures, so a padding change on a container re-measures nothing
+   below it — is the change that would take a panel toggle or a theme
+   switch on a big screen from 18fps to 40. Bounded, not small; it touches
+   the passes `test/content-floors.test.js` pins.
+2. **The swapchain is reallocated per resize tick** — two window-sized
+   IOSurfaces, 20MB at 900x700@2x, freed on GC. Allocation is 0.1ms; the
+   cost is memory (`rss +80MB` over a 40-tick drag) and the GC that
+   eventually returns it. Two fixes, both in the bridge: report native
+   memory to V8 (`napi_adjust_external_memory`) so collection is prompt, or
+   a `releaseSurface` verb so the window frees the old pair on the flip.
+   Over-allocating the chain to a rounded-up size would need
+   `contentsRect` on the layer, which `setLayerProps` does not take yet.
+3. **The frame interval is a guess at the display.** 16ms is right on a
+   60Hz panel and half the rate of a 120Hz one; `createRoot({ cocoa: {
+frameInterval: 8 } })` is the seam, and on this 120Hz panel it is worth
+   taking: `anim` runs at 102fps instead of 51 for 40% of a core instead of
+   36, and hover's input → flush goes from 5.4ms p50 / 18 p95 to 2.8 / 10
+   (`npm run bench:presenters -- --frame=8`). The honest default is the
+   display's own period — `NSScreen.maximumFramesPerSecond`, which
+   `listScreens` should report.
+4. **The paint cache is off on this backend** (`paintCacheFor` gates on an
+   X `Render` extension), so 300 mono icons re-tinted per tick are 300
+   live canvas paints (`icons`: 2.9ms). `CocoaSurface` exists now; wiring
+   the cache over `app.createSurface` (argb only — the a8 coverage entries
+   need a tint in the key here) is the remaining step.
+5. **Nothing is drawn at a level of detail.** `tiny` shapes and draws 5,000
+   five-pixel labels nobody can read. A box smaller than a pixel already
+   costs one fill; text below a legible size could cost one strip. Not
+   started.
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "docs:dev": "npm --prefix website start",
     "docs:build": "npm --prefix website run build",
     "docs:test": "npm --prefix website test",
-    "bench:presenters": "node --import tsx scripts/bench/presenters.js"
+    "bench:presenters": "node --import tsx scripts/bench/presenters.js",
+    "bench:touched": "node scripts/bench/touched.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/bench/presenters-gate.json
+++ b/scripts/bench/presenters-gate.json
@@ -1,0 +1,32 @@
+{
+  "//": [
+    "The cocoa frame-clock gate: what a frame must and must not do, judged on",
+    "the surface presenter by `npm run bench:presenters -- --check`. Counts",
+    "and shares of the window, never milliseconds — a timing on a shared",
+    "runner says nothing, a full-window repaint for one cell says everything.",
+    "maxDamageShare is the repainted area per painting frame as a fraction of",
+    "the window in device pixels, so it reads the same at 1x and 2x. A rule",
+    "that has to loosen is a decision to record in the PR that loosens it."
+  ],
+  "rules": {
+    "color": { "maxFullPct": 0, "maxDamageShare": 0.03, "minFrames": 30 },
+    "tree": { "maxFullPct": 0, "maxDamageShare": 0.005, "minFrames": 30 },
+    "leaf": { "maxFullPct": 0, "maxDamageShare": 0.005, "minFrames": 30 },
+    "multi": { "maxFullPct": 0, "maxDamageShare": 0.15, "minFrames": 30 },
+    "press": {
+      "maxFullPct": 0,
+      "maxDamageShare": 0.01,
+      "minFrames": 30,
+      "minInputs": 20
+    },
+    "scroll": { "maxFullPct": 0, "maxDamageShare": 0.35, "minFrames": 30 },
+    "anim": { "maxFullPct": 0, "minFrames": 30 },
+    "resize": {
+      "maxFlushesPerResize": 1.05,
+      "maxSettleFlushes": 1,
+      "maxSurfacesPerResize": 2
+    },
+    "occluded": { "maxFrames": 0 },
+    "idle": { "maxFrames": 0 }
+  }
+}

--- a/scripts/bench/presenters.js
+++ b/scripts/bench/presenters.js
@@ -1,36 +1,55 @@
 // Cocoa presenter benchmark: the measure-first gate of docs/macos.md, as a
-// number. One scenario, two presenters, the same ticks — and every frame
-// broken into the stages that can be the bottleneck:
+// number — and the stress rig for "state update → pixels" and "interaction
+// → pixels" on a live display. One scenario, N presenters/backends, the same
+// ticks — and every frame broken into the stages that can be the bottleneck:
 //
 //   flush     JS building the frame: painters into the surface, or the
 //             layer sync (prop diffing + per-visual rasters). The one paint
 //             channel, so this is "client cost per frame".
-//   upload    surfaceToLayer calls — the CGImage handoff to Core Animation.
-//             The surface presenter pays one per frame at WINDOW size
-//             whatever the damage; the layers presenter pays one per
-//             re-rastered visual at the visual's size. kpx tells that story.
+//   damage    what the frame repainted: kpx per painting frame and the share
+//             of frames that repainted the whole window. On the surface
+//             presenter this is the raster work; on layers it is what the
+//             X11 damage model would have painted (still computed, unused).
+//   cpu       process CPU over the run, as a percentage of one core — the
+//             pump, React, layout, paint, and the bridge's own work. The
+//             number to watch for "what does this app cost while it runs".
+//   upload    handoffs to Core Animation per frame: surfaceToLayer (CGImage
+//             copies) and, on the IOSurface swapchain, flips plus the
+//             damage-sized catch-up copy. kpx tells the story.
 //   props     setLayerProps calls per frame — the layers presenter's other
 //             half. A pure scroll should be ~2; a recolour wall should be
 //             ~N with zero uploads (PropBox); a number that scales with the
 //             tree on a one-box change is a diffing bug.
-//   input     for the input scenarios: postMouseEvent → the end of the
-//             flush that answered it, through the real NSApp queue and the
-//             pump — the "answer the input" number, p50/p95.
+//   input     for the input scenarios: event posted → the end of the flush
+//             that answered it (the "answer the input" number), and → the
+//             end of the present that put it on glass. p50/p95/max.
 //
 //   npm run bench:presenters                    # every scenario, both
 //   npm run bench:presenters -- --scenario=cards --seconds=8
-//   npm run bench:presenters -- --x11           # third column via $DISPLAY
+//   npm run bench:presenters -- --columns=surface   # one presenter only
+//   npm run bench:presenters -- --x11           # extra column via $DISPLAY
+//   npm run bench:presenters -- --cells=2400    # bigger stress trees
+//   npm run bench:presenters -- --prof --scenario=tree --columns=surface
+//                                               # a .cpuprofile per cell
 //   npm run bench:presenters -- --shots         # snapshot each run's last
 //                                               # frame for an eyeball diff
+//   npm run bench:presenters -- --check         # the structural gate
+//                                               # (presenters-gate.json)
 //
-// Scenario design: each isolates one shape of change, because the two
-// presenters differ per shape, not overall — a wall recolour is layer
-// properties on one side and full-window paint on the other, while a text
-// change rasters on both and measures pure raster throughput.
+// Scenario design: each isolates one shape of change, because the presenters
+// differ per shape, not overall — a wall recolour is layer properties on one
+// side and full-window paint on the other, while a text change rasters on
+// both and measures pure raster throughput. The stress scenarios (`tree`,
+// `commit`, `layout`, `multi`, `tiny`, `typing`, `press`, `resize`, `anim`,
+// `icons`, `occluded`, `idle`) put the same shapes inside a tree the size of
+// a real application screen — `--cells` boxes, each with a label — because a
+// path that is cheap on twelve nodes and quadratic on a thousand only shows
+// there.
 //
 // Comparisons hold within a run (same machine, same session); absolute
 // numbers travel about as well as any timing does — that is, they don't.
 import { spawnSync } from 'node:child_process';
+import { appendFileSync, readFileSync } from 'node:fs';
 import React from 'react';
 
 const e = React.createElement;
@@ -40,24 +59,40 @@ const flag = (name, fallback) => {
   const hit = args.find((a) => a.startsWith(`--${name}=`));
   return hit ? hit.slice(name.length + 3) : fallback;
 };
-const SECONDS = Number(flag('seconds', 6));
-const ONLY = flag('scenario', null);
+const SECONDS = Number(flag('seconds', args.includes('--ci') ? 3 : 6));
+const ONLY = flag('scenario', flag('only', null));
 const WITH_X11 = args.includes('--x11');
 const SHOTS = args.includes('--shots');
+const PROF = args.includes('--prof');
 const CHILD = args.includes('--child');
+const CELLS = Number(flag('cells', 1200));
+const COLUMNS = flag('columns', null);
+const SIZE = flag('size', '900x700');
+const FRAME = flag('frame', null); // cocoa frame interval, ms
+// --check: the structural gate (scripts/bench/presenters-gate.json) — counts
+// and areas the frame clock and the damage model must keep, judged per
+// scenario and never in milliseconds, so the answer is the same on a shared
+// runner as on the machine the rules were written on. --ci is --check with
+// the short run and the table appended to the job summary.
+const CI = args.includes('--ci');
+const CHECK = args.includes('--check') || CI;
 
-const W = 900;
-const H = 700;
+const [W, H] = SIZE.split('x').map(Number);
 const TICK_MS = 16;
 
 // ---------------------------------------------------------------------------
-// Scenarios. Each is { tree(tick), drive? } — `tree` is rendered per tick
-// (the React-state shape of change), `drive` instead pushes real events and
-// leaves the tree alone (the input shape). `latency: true` marks the ones
-// whose headline number is input→flush rather than fps.
+// Scenarios. Each is { tree(tick), drive?, setup?, latency?, input? } —
+// `tree` is rendered per tick (the React-state shape of change), `drive`
+// instead pushes real events and leaves the tree alone (the input shape).
+// `latency: true` marks the ones whose headline number is input→flush
+// rather than fps; `input: 'native'` means the events go through the
+// NSApp queue and the scenario has no meaning on X11; `cocoaOnly` skips it
+// there outright.
 // ---------------------------------------------------------------------------
 
 const TINTS = ['#ffffff', '#eef4fb', '#fdf1e7', '#eefaf1'];
+const HOT = ['#0984e3', '#00b894', '#e17055', '#6c5ce7', '#fdcb6e'];
+const COLD = '#eef2f5';
 
 function windowOf(children, title) {
   return e(
@@ -65,6 +100,175 @@ function windowOf(children, title) {
     { width: W, height: H, title, style: { backgroundColor: '#e9edf2' } },
     ...children,
   );
+}
+
+// --- the stress grid ---------------------------------------------------------
+
+// `--cells` boxes in a grid close to the window's aspect, each with a label.
+// A cell is a <box> around a <text>, so a tree of N cells is 2N drawn nodes
+// plus N text chunks — the shape of a dashboard, a table body, a tool grid.
+const COLS = Math.max(4, Math.round(Math.sqrt((CELLS * W) / H)));
+const ROWS = Math.max(2, Math.ceil(CELLS / COLS));
+
+const CELL = {
+  flexGrow: 1,
+  flexBasis: 0,
+  minWidth: 0,
+  minHeight: 0,
+  alignItems: 'center',
+  justifyContent: 'center',
+  borderRadius: 2,
+};
+const ROW = {
+  flexDirection: 'row',
+  flexGrow: 1,
+  flexBasis: 0,
+  minHeight: 0,
+  gap: 1,
+};
+
+/** A memoized cell: only a cell whose colour or label changed re-renders,
+ * so a one-cell tick is a one-node commit — what a well-written app does. */
+const Cell = React.memo(function Cell({ color, label, fontSize }) {
+  return e(
+    'box',
+    { style: { ...CELL, backgroundColor: color } },
+    label == null
+      ? null
+      : e('text', { style: { fontSize, color: '#2d3436' } }, label),
+  );
+});
+
+/**
+ * A cell that owns its colour through a store: `useSyncExternalStore` on
+ * the store's tick, hot when the tick lands on it. The commit that follows
+ * a poke is this one component and nothing above it.
+ */
+const StoreCell = React.memo(function StoreCell({
+  store,
+  index,
+  label,
+  fontSize,
+}) {
+  // the snapshot is THIS cell's state — the tick while it is the hot one,
+  // -1 otherwise — so React re-renders the two cells whose answer moved and
+  // bails out of the other twelve hundred at the snapshot compare
+  const tick = React.useSyncExternalStore(store.subscribe, () => {
+    const t = store.read();
+    return t % store.count === index ? t : -1;
+  });
+  const hot = tick >= 0;
+  return e(
+    'box',
+    {
+      style: { ...CELL, backgroundColor: hot ? HOT[tick % HOT.length] : COLD },
+    },
+    label == null
+      ? null
+      : e('text', { style: { fontSize, color: '#2d3436' } }, label),
+  );
+});
+
+function makeStore(count) {
+  let tick = 0;
+  const listeners = new Set();
+  return {
+    count,
+    subscribe(fn) {
+      listeners.add(fn);
+      return () => listeners.delete(fn);
+    },
+    read: () => tick,
+    poke(next) {
+      tick = next;
+      for (const fn of listeners) fn();
+    },
+  };
+}
+
+/** The same cell, re-rendered every tick with a rebuilt style of the same
+ * contents — what an app without memoization does, and the shape that
+ * prices the commit walk (applyProps over every node, NO_DAMAGE from all
+ * but one). */
+function LiveCell({ color, label, fontSize }) {
+  return e(
+    'box',
+    { style: { ...CELL, backgroundColor: color } },
+    label == null
+      ? null
+      : e('text', { style: { fontSize, color: '#2d3436' } }, label),
+  );
+}
+
+function grid({
+  cols = COLS,
+  rows = ROWS,
+  hot = new Set(),
+  hotColor = HOT[0],
+  pad = 8,
+  fontSize = 9,
+  labels = true,
+  live = false,
+  store = null,
+  key = 'grid',
+} = {}) {
+  const C = live ? LiveCell : Cell;
+  const rowEls = [];
+  for (let r = 0; r < rows; r += 1) {
+    const cells = [];
+    for (let c = 0; c < cols; c += 1) {
+      const k = `${r}:${c}`;
+      cells.push(
+        store
+          ? e(StoreCell, {
+              key: k,
+              store,
+              index: r * cols + c,
+              label: labels ? `${r}.${c}` : null,
+              fontSize,
+            })
+          : e(C, {
+              key: k,
+              color: hot.has(k) ? hotColor : COLD,
+              label: labels ? `${r}.${c}` : null,
+              fontSize,
+            }),
+      );
+    }
+    rowEls.push(e('box', { key: r, style: ROW }, ...cells));
+  }
+  return e(
+    'box',
+    { key, style: { flexGrow: 1, minHeight: 0, gap: 1, padding: pad } },
+    ...rowEls,
+  );
+}
+
+const hotOne = (tick, cols = COLS, rows = ROWS) =>
+  new Set([`${tick % rows}:${(tick * 7) % cols}`]);
+
+const hotMany = (tick, n, cols = COLS, rows = ROWS) => {
+  const hot = new Set();
+  for (let i = 0; i < n; i += 1) {
+    const idx = (i * 7919 + tick * 104729) % (cols * rows);
+    hot.add(`${Math.floor(idx / cols)}:${idx % cols}`);
+  }
+  return hot;
+};
+
+const header = (text) =>
+  e(
+    'text',
+    { key: 'head', style: { margin: 8, fontSize: 14, color: '#2d3436' } },
+    text,
+  );
+
+/** The centre of a node, in points — where postMouseEvent aims. */
+function centreOf(node, scale) {
+  return [
+    (node.abs.x + node.abs.width / 2) / scale,
+    (node.abs.y + node.abs.height / 2) / scale,
+  ];
 }
 
 const SCENARIOS = {
@@ -286,14 +490,32 @@ const SCENARIOS = {
         'bench scroll',
       ),
     drive(ctx) {
-      const { wnd, node, stamp } = ctx;
+      const { win, stamp } = ctx;
       const scroller = ctx.find((n) => n.isScroller?.());
       if (!scroller) return;
       const x = scroller.abs.x + scroller.abs.width / 2;
       const y = scroller.abs.y + scroller.abs.height / 2;
       const down = ctx.tick % 120 < 60; // sweep down, then back up
       stamp();
-      wnd.emit('wheel', {
+      if (ctx.app._routeWheel && ctx.wnd) {
+        // the bridge's event shape, in points: the same route a real notch
+        // takes, so what the app does with a wheel is in the number
+        const s = ctx.wnd.scale;
+        ctx.app._routeWheel({
+          type: 'wheel',
+          windowNumber: ctx.wnd.windowNumber,
+          x: x / s,
+          y: y / s,
+          gx: (ctx.wnd.x + x) / s,
+          gy: (ctx.wnd.y + y) / s,
+          dx: 0,
+          dy: down ? -3 : 3,
+          precise: false,
+          time: performance.now(),
+        });
+        return;
+      }
+      win.emit('wheel', {
         name: 'wheel',
         x,
         y,
@@ -306,7 +528,6 @@ const SCENARIOS = {
         smooth: false,
         source: 'button',
       });
-      void node;
     },
   },
 
@@ -357,15 +578,410 @@ const SCENARIOS = {
       const b = cards[7] ?? cards[cards.length - 1];
       const target = ctx.tick % 2 ? a : b;
       if (!target) return;
-      const s = ctx.wnd.scale;
       ctx.stamp();
       ctx.native.postMouseEvent(
         ctx.wnd._h,
         'move',
-        (target.abs.x + target.abs.width / 2) / s,
-        (target.abs.y + target.abs.height / 2) / s,
+        ...centreOf(target, ctx.wnd.scale),
       );
     },
+  },
+
+  // --- the stress scenarios -------------------------------------------------
+
+  /** A large component tree, one cell recolouring per tick: the plain
+   *  "state update → pixels" case at application size. The commit is one
+   *  node (the cells are memoized), the damage one cell; what is left is
+   *  the fixed cost of a frame over a big tree — the walks that are not
+   *  bounded by the damage. Compare `flush` here against `color`. */
+  tree: {
+    tree: (tick) =>
+      windowOf(
+        [header(`tree — ${COLS}x${ROWS} cells`), grid({ hot: hotOne(tick) })],
+        'bench tree',
+      ),
+  },
+
+  /** The same tree, but the update arrives the way an app's does: one cell
+   *  subscribes to a store and re-renders alone when it is poked. No root
+   *  re-render, no element tree rebuilt, no memo compares — what is left in
+   *  `cpu` is the renderer's own cost of one commit and one frame over a
+   *  large tree, which is the number `tree` cannot separate from React's. */
+  leaf: {
+    tree: (tick, { store }) =>
+      windowOf(
+        [
+          header(`leaf — one cell of ${COLS}x${ROWS} through a store`),
+          grid({ store, hot: hotOne(0) }),
+        ],
+        'bench leaf',
+      ),
+    drive(ctx) {
+      ctx.store.poke(ctx.tick);
+    },
+  },
+
+  /** The same tree, every cell re-rendered every tick with an equal style —
+   *  the commit walk itself. Every applyProps runs and all but one answer
+   *  NO_DAMAGE; `flush` should match `tree`, and the difference in `cpu` is
+   *  React plus the per-node diff — the price of not memoizing. */
+  commit: {
+    tree: (tick) =>
+      windowOf(
+        [
+          header(`commit — ${COLS}x${ROWS} live cells`),
+          grid({ hot: hotOne(tick), live: true }),
+        ],
+        'bench commit',
+      ),
+  },
+
+  /** A large layout: the container's padding toggles every tick, so every
+   *  cell moves by a pixel or two. A full yoga pass over the tree, every
+   *  text re-measured at its new width, and an unbounded repaint — the
+   *  worst frame a resize or a panel toggle produces, at 60Hz. */
+  layout: {
+    tree: (tick) =>
+      windowOf(
+        [
+          header(`layout — ${COLS}x${ROWS} cells reflowing`),
+          grid({ hot: hotOne(tick), pad: tick % 2 ? 8 : 12 }),
+        ],
+        'bench layout',
+      ),
+  },
+
+  /** Many components updating in the same commit: 12 cells scattered over
+   *  the grid recolour per tick. Damage is a list capped at four rects, so
+   *  the paint area is what the cap costs — `damage` against twelve cells'
+   *  worth — and the frame is what several independent widgets ticking at
+   *  once (a clock, a graph, a status row) actually pay. */
+  multi: {
+    tree: (tick) =>
+      windowOf(
+        [
+          header(`multi — 12 of ${COLS * ROWS} cells per tick`),
+          grid({ hot: hotMany(tick, 12), hotColor: HOT[tick % HOT.length] }),
+        ],
+        'bench multi',
+      ),
+  },
+
+  /** A zoomed-out view: thousands of tiny cells with 5px labels, one
+   *  changing per tick and the whole grid reflowing every 40th. Nothing in
+   *  the labels can be read, and the question is whether the renderer still
+   *  shapes and rasters every one of them — the "if we cannot see the
+   *  detail we should not pay for it" case. */
+  tiny: {
+    tree: (tick) => {
+      const cols = 100;
+      const rows = Math.ceil((CELLS * 4) / cols);
+      return windowOf(
+        [
+          header(`tiny — ${cols}x${rows} cells, 5px labels`),
+          grid({
+            cols,
+            rows,
+            hot: hotOne(tick, cols, rows),
+            fontSize: 5,
+            pad: Math.floor(tick / 40) % 2 ? 6 : 8,
+          }),
+        ],
+        'bench tiny',
+      );
+    },
+  },
+
+  /** Typing into a field above the big tree, through the NSApp queue: a
+   *  key down and up per tick. The answer is one caret and one glyph; the
+   *  cost that must not be there is anything proportional to the tree. */
+  typing: {
+    latency: true,
+    input: 'native',
+    tree: () =>
+      windowOf(
+        [
+          e(
+            'box',
+            { key: 'bar', style: { padding: 8, flexDirection: 'row' } },
+            e('textinput', {
+              placeholder: 'type here',
+              style: {
+                width: 320,
+                height: 30,
+                paddingLeft: 8,
+                backgroundColor: '#ffffff',
+                borderWidth: 1,
+                borderColor: '#c3ccd8',
+                borderRadius: 4,
+              },
+            }),
+          ),
+          grid({ rows: Math.floor(ROWS / 2) }),
+        ],
+        'bench typing',
+      ),
+    setup(ctx) {
+      const input = ctx.find((n) => n.kind === 'textinput');
+      if (!input) return;
+      const [x, y] = centreOf(input, ctx.wnd.scale);
+      ctx.native.postMouseEvent(ctx.wnd._h, 'down', x, y);
+      ctx.native.postMouseEvent(ctx.wnd._h, 'up', x, y);
+    },
+    drive(ctx) {
+      // kVK_ANSI_A is 0; every 24th key a backspace (51) keeps the field short
+      const erase = ctx.tick % 24 === 0;
+      ctx.stamp();
+      ctx.native.postKeyEvent(
+        ctx.wnd._h,
+        true,
+        erase ? 51 : 0,
+        erase ? '' : 'a',
+      );
+      ctx.native.postKeyEvent(
+        ctx.wnd._h,
+        false,
+        erase ? 51 : 0,
+        erase ? '' : 'a',
+      );
+    },
+  },
+
+  /** A press and release on a button above the big tree, through the NSApp
+   *  queue: `:active` on the down, back on the up. The press state is the
+   *  renderer's own repaint of one node; both halves are stamped, so the
+   *  latency column is the whole "answer the input" promise. */
+  press: {
+    latency: true,
+    input: 'native',
+    tree: () =>
+      windowOf(
+        [
+          e(
+            'box',
+            {
+              key: 'bar',
+              style: { padding: 8, flexDirection: 'row', gap: 8 },
+            },
+            ...Array.from({ length: 6 }, (_, i) =>
+              e(
+                'box',
+                {
+                  key: i,
+                  style: {
+                    width: 110,
+                    height: 32,
+                    borderRadius: 6,
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    backgroundColor: '#ffffff',
+                    borderWidth: 1,
+                    borderColor: '#c3ccd8',
+                    ':hover': { backgroundColor: '#eef4fb' },
+                    ':active': { backgroundColor: '#b9c9dc' },
+                  },
+                },
+                e('text', { style: { color: '#2d3436' } }, `button ${i}`),
+              ),
+            ),
+          ),
+          grid({ rows: Math.floor(ROWS / 2) }),
+        ],
+        'bench press',
+      ),
+    drive(ctx) {
+      const button = ctx.find((n) => n.style?.[':active'] !== undefined);
+      if (!button) return;
+      const [x, y] = centreOf(button, ctx.wnd.scale);
+      ctx.stamp();
+      ctx.native.postMouseEvent(ctx.wnd._h, ctx.tick % 2 ? 'down' : 'up', x, y);
+    },
+  },
+
+  /** A live resize of a window holding the big tree, then a press the
+   *  moment it ends. Forty size changes through the window delegate (the
+   *  route a drag takes, minus AppKit's modal loop), each answered
+   *  synchronously: relayout, repaint, swapchain. Then a mouse down and up.
+   *  Reported: ms per resize, flushes per resize, backing surfaces made,
+   *  the settle after the last resize, and the press latency after it —
+   *  which is where a freeze or a stale frame would show. */
+  resize: {
+    latency: true,
+    input: 'native',
+    seconds: 4,
+    tree: () =>
+      windowOf(
+        [header(`resize — ${COLS}x${ROWS} cells`), grid()],
+        'bench resize',
+      ),
+    setup(ctx) {
+      // A drag, not a script: the delegate reports every tick as live, and
+      // no pump runs between them (AppKit's modal loop owns the thread) —
+      // so the end-of-drag reset the pump performs is held off until the
+      // burst is over, when `drive` puts it back.
+      const app = ctx.app;
+      const route = app._routeGeometry.bind(app);
+      app._routeGeometry = (ev) => route({ ...ev, live: true });
+      ctx.extra.endLiveResizes = app._endLiveResizes.bind(app);
+      app._endLiveResizes = () => {};
+    },
+    drive(ctx) {
+      const { tick, native, wnd, extra } = ctx;
+      const steps = 40;
+      if (tick === steps + 1 && extra.endLiveResizes) {
+        // the mouse release: the modal loop ends, the pump runs again
+        ctx.app._endLiveResizes = extra.endLiveResizes;
+        extra.endLiveResizes = null;
+      }
+      if (tick <= steps) {
+        // a sawtooth: mostly growing, with a shrink every few steps, the way
+        // a hand on a corner wobbles
+        const dw = ((tick * 11) % 60) - 10;
+        const dh = ((tick * 7) % 40) - 8;
+        extra.flushesAtFirstResize ??= ctx.stats.flushes;
+        const t0 = performance.now();
+        native.setWindowFrame(wnd._h, null, null, W + dw, H + dh);
+        const t1 = performance.now();
+        extra.resizes = (extra.resizes ?? 0) + 1;
+        extra.resizeMs = (extra.resizeMs ?? 0) + (t1 - t0);
+        extra.resizeMax = Math.max(extra.resizeMax ?? 0, t1 - t0);
+        // snapshotted synchronously: what lands after this tick's microtasks
+        // (a queued full frame, a React commit) is the resize's cost too
+        extra.flushesAtLastResize = ctx.stats.flushes;
+        extra.lastResizeEnd = t1;
+        return;
+      }
+      if (tick === steps + 1) {
+        // frames per resize, counted a tick later so the ones a resize
+        // leaves behind on the microtask queue are attributed to it
+        extra.resizeFlushes =
+          ctx.stats.flushes - (extra.flushesAtFirstResize ?? 0);
+      }
+      if (tick === steps + 3 || tick === steps + 4) {
+        const head = ctx.find((n) => n.kind === 'text');
+        if (!head) return;
+        if (tick === steps + 3) {
+          // how long the tree kept painting after the last size landed, and
+          // how many frames that took — a burst here is the backlog a drag
+          // leaves behind
+          extra.settleMs = Math.max(
+            0,
+            (ctx.stats.lastFlushEnd ?? extra.lastResizeEnd) -
+              extra.lastResizeEnd,
+          );
+          extra.settleFlushes =
+            ctx.stats.flushes - (extra.flushesAtLastResize ?? 0);
+        }
+        const [x, y] = centreOf(head, wnd.scale);
+        ctx.stamp();
+        native.postMouseEvent(wnd._h, tick === steps + 3 ? 'down' : 'up', x, y);
+      }
+    },
+  },
+
+  /** Transitions: 48 cards with a 240ms backgroundColor transition, the
+   *  palette rotating every 15 ticks. Between commits the renderer's own
+   *  animation frames run — fps and damage are the animation path's, and
+   *  cpu is what a screen of gentle fades costs. */
+  anim: {
+    tree: (tick) => {
+      const CARD_W = 130;
+      const CARD_H = 70;
+      const GAP = 12;
+      const PAD = 16;
+      const step = Math.floor(tick / 15);
+      const perRow = Math.max(
+        1,
+        Math.floor((W - 2 * PAD + GAP) / (CARD_W + GAP)),
+      );
+      const cards = [];
+      for (let i = 0; i < 48; i += 1) {
+        cards.push(
+          e('box', {
+            key: i,
+            style: {
+              position: 'absolute',
+              left: PAD + (i % perRow) * (CARD_W + GAP),
+              top: PAD + Math.floor(i / perRow) * (CARD_H + GAP),
+              width: CARD_W,
+              height: CARD_H,
+              backgroundColor: HOT[(i + step) % HOT.length],
+              borderRadius: 8,
+              transition: { backgroundColor: 240 },
+            },
+          }),
+        );
+      }
+      return windowOf(
+        [e('box', { style: { flexGrow: 1 } }, ...cards)],
+        'bench anim',
+      );
+    },
+  },
+
+  /** 300 system icons (`<Icon>`, a mono <canvas> each) re-tinted every
+   *  tick. On X11 a mono icon is an a8 coverage entry in the paint cache and
+   *  a tint is a composite; wherever the cache is not engaged every tick is
+   *  300 live canvas paints. The `damage` column stays the same either way,
+   *  which is why `flush` and `cpu` are the columns to read. */
+  icons: {
+    tree: (tick, { Icon }) => {
+      const names = ['check', 'chevronDown', 'close', 'chevronRight'];
+      const icons = [];
+      for (let i = 0; i < 300; i += 1) {
+        icons.push(
+          e(Icon, {
+            key: i,
+            name: names[i % names.length],
+            size: 16,
+            color: HOT[(i + tick) % HOT.length],
+          }),
+        );
+      }
+      return windowOf(
+        [
+          e(
+            'box',
+            {
+              style: {
+                flexGrow: 1,
+                padding: 12,
+                flexDirection: 'row',
+                flexWrap: 'wrap',
+                gap: 6,
+                alignContent: 'flex-start',
+              },
+            },
+            ...icons,
+          ),
+        ],
+        'bench icons',
+      );
+    },
+  },
+
+  /** The big tree with a cell changing per tick — in a window nobody can
+   *  see (ordered out after the mount). The right answer is no frames and
+   *  no presents: "if it is not visible it should cost nothing". */
+  occluded: {
+    cocoaOnly: true,
+    tree: (tick) =>
+      windowOf(
+        [header('occluded'), grid({ hot: hotOne(tick) })],
+        'bench occluded',
+      ),
+    setup(ctx) {
+      ctx.native.hideWindow(ctx.wnd._h);
+    },
+  },
+
+  /** Nothing happens: the big tree on screen, no ticks. What the app costs
+   *  at rest is the pump and nothing else — `cpu` and `pump` are the
+   *  columns, and `frames` must be zero. */
+  idle: {
+    tree: () =>
+      windowOf([header('idle'), grid({ hot: hotOne(0) })], 'bench idle'),
+    drive() {},
   },
 };
 
@@ -378,7 +994,12 @@ async function runChild() {
   const scenario = SCENARIOS[name];
   process.env.REACT_X11_NO_AUTORUN = '1';
   const { createRoot } = await import('../../src/index.js');
-  const root = await createRoot();
+  const { Icon } = await import('../../src/components/Icon.js');
+  const store = makeStore(COLS * ROWS);
+  const deps = { Icon, store };
+  const root = await createRoot(
+    FRAME ? { cocoa: { frameInterval: Number(FRAME) } } : {},
+  );
   const app = root.app;
   const cocoa = Boolean(app._native);
 
@@ -386,80 +1007,154 @@ async function runChild() {
   const stats = {
     flushes: 0,
     flushMs: [],
+    damagePx: 0,
+    fullFrames: 0,
     uploads: 0,
     uploadMs: 0,
     uploadPx: 0,
     props: 0,
     layersMade: 0,
+    presents: 0,
+    presentMs: 0,
+    surfaces: 0,
+    surfaceBytes: 0,
+    surfaceMs: 0,
+    pumpMs: 0,
+    pumps: 0,
+    pumpAfterPresentMs: 0,
+    pumpsAfterPresent: 0,
+    presentedSincePump: 0,
     latency: [],
+    presentLatency: [],
+    lastFlushEnd: null,
   };
   let inFlight = []; // input stamps waiting for the flush that answers them
+  let answered = []; // …and then for the present that shows the answer
+  const native = app._native;
   if (cocoa) {
-    const native = app._native;
-    const surfaceToLayer = native.surfaceToLayer.bind(native);
+    const wrap = (key, fn) => {
+      const orig = native[key]?.bind(native);
+      if (!orig) return;
+      native[key] = (...a) => fn(orig, ...a);
+    };
     const sizeOf = native.surfaceSize.bind(native);
-    native.surfaceToLayer = (surface, layer) => {
+    wrap('surfaceToLayer', (orig, surface, layer) => {
       const t0 = performance.now();
-      surfaceToLayer(surface, layer);
+      orig(surface, layer);
       stats.uploadMs += performance.now() - t0;
       stats.uploads += 1;
       const size = sizeOf(surface);
       stats.uploadPx += size.width * size.height;
-    };
-    const setLayerProps = native.setLayerProps.bind(native);
-    native.setLayerProps = (layer, props) => {
+    });
+    wrap('setLayerProps', (orig, layer, props) => {
       stats.props += 1;
-      return setLayerProps(layer, props);
-    };
-    const createLayer = native.createLayer.bind(native);
-    native.createLayer = (...a) => {
+      return orig(layer, props);
+    });
+    wrap('createLayer', (orig, ...a) => {
       stats.layersMade += 1;
-      return createLayer(...a);
-    };
+      return orig(...a);
+    });
     // the IOSurface swapchain's present path: a flip plus a damage-sized
     // catch-up copy — counted into the same columns so the table reads the
     // same either way (uploads = handoffs, kpx = pixels actually moved)
-    if (native.copySurfaceRegion) {
-      const copy = native.copySurfaceRegion.bind(native);
-      native.copySurfaceRegion = (src, dst, rects) => {
-        const t0 = performance.now();
-        copy(src, dst, rects);
-        stats.uploadMs += performance.now() - t0;
-        if (rects && rects.length) {
-          for (let i = 0; i + 3 < rects.length; i += 4) {
-            stats.uploadPx += rects[i + 2] * rects[i + 3];
-          }
-        } else {
-          const size = sizeOf(src);
-          stats.uploadPx += size.width * size.height;
+    wrap('copySurfaceRegion', (orig, src, dst, rects) => {
+      const t0 = performance.now();
+      orig(src, dst, rects);
+      stats.uploadMs += performance.now() - t0;
+      if (rects && rects.length) {
+        for (let i = 0; i + 3 < rects.length; i += 4) {
+          stats.uploadPx += rects[i + 2] * rects[i + 3];
         }
-      };
+      } else {
+        const size = sizeOf(src);
+        stats.uploadPx += size.width * size.height;
+      }
+    });
+    wrap('setLayerContentsIOSurface', (orig, layer, id) => {
+      stats.uploads += 1;
+      return orig(layer, id);
+    });
+    for (const key of ['createSurface', 'createSurfaceIOSurface']) {
+      wrap(key, (orig, w, h, ...rest) => {
+        const t0 = performance.now();
+        const out = orig(w, h, ...rest);
+        stats.surfaceMs += performance.now() - t0;
+        stats.surfaces += 1;
+        stats.surfaceBytes += w * h * 4;
+        return out;
+      });
     }
-    if (native.setLayerContentsIOSurface) {
-      const flip = native.setLayerContentsIOSurface.bind(native);
-      native.setLayerContentsIOSurface = (layer, id) => {
-        stats.uploads += 1;
-        return flip(layer, id);
-      };
-    }
+    // pump2 ends with [CATransaction flush]. A present whose commit was
+    // deferred into an implicit transaction is paid for HERE, on the next
+    // tick — so a pump that follows a present costing more than a pump that
+    // follows nothing is that deferral, measured.
+    wrap('pump2', (orig) => {
+      const t0 = performance.now();
+      orig();
+      const dt = performance.now() - t0;
+      stats.pumpMs += dt;
+      stats.pumps += 1;
+      if (stats.presentedSincePump) {
+        stats.pumpAfterPresentMs += dt;
+        stats.pumpsAfterPresent += 1;
+        stats.presentedSincePump = 0;
+      }
+    });
   }
 
   let tick = 0;
-  root.render(scenario.tree(0));
-  await new Promise((r) => setTimeout(r, 700));
+  const treeAt = (t) => scenario.tree(t, deps);
+  root.render(treeAt(0));
+  let node = null;
+  for (let i = 0; i < 100 && !node; i += 1) {
+    await new Promise((r) => setTimeout(r, 20));
+    node = app._rootChildren?.[0] ?? null;
+  }
+  if (!node) throw new Error('the window never mounted');
 
-  const node = app._rootChildren?.[0] ?? null;
   const wnd = cocoa ? [...app._windows.values()][0] : null;
-  if (node) {
+  const win = node.window;
+  {
     const flush = node.flush.bind(node);
     node.flush = (...a) => {
+      const willPaint =
+        node.needsPaint || node.needsLayout || node._animating?.size > 0;
+      if (!willPaint) return flush(...a);
       const t0 = performance.now();
       const out = flush(...a);
       const t1 = performance.now();
       stats.flushes += 1;
       stats.flushMs.push(t1 - t0);
-      for (const sent of inFlight) stats.latency.push(t1 - sent);
+      stats.lastFlushEnd = t1;
+      const rects = node._lastDamageRects;
+      if (rects) {
+        for (const r of rects) stats.damagePx += r.width * r.height;
+      } else {
+        stats.fullFrames += 1;
+        stats.damagePx += (win.width ?? 0) * (win.height ?? 0);
+      }
+      for (const sent of inFlight) {
+        stats.latency.push(t1 - sent);
+        answered.push(sent);
+      }
       inFlight = [];
+      return out;
+    };
+  }
+  if (wnd) {
+    const present = wnd.present.bind(wnd);
+    wnd.present = (...a) => {
+      const dirty = wnd._dirty;
+      const t0 = performance.now();
+      const out = present(...a);
+      if (dirty) {
+        const t1 = performance.now();
+        stats.presents += 1;
+        stats.presentMs += t1 - t0;
+        stats.presentedSincePump = 1;
+        for (const sent of answered) stats.presentLatency.push(t1 - sent);
+        answered = [];
+      }
       return out;
     };
   }
@@ -468,37 +1163,68 @@ async function runChild() {
     yield n;
     for (const c of n?.children ?? []) yield* walk(c);
   }
+  const extra = {};
   const ctx = {
     get tick() {
       return tick;
     },
+    app,
     wnd,
+    win,
     node,
-    native: app._native,
+    native,
+    stats,
+    extra,
+    store,
     stamp: () => inFlight.push(performance.now()),
     find: (pred) => [...walk(node)].find(pred) ?? null,
     findAll: (pred) => [...walk(node)].filter(pred),
   };
 
-  // settle counters after mount: steady state is the measurement
-  stats.flushes = 0;
-  stats.flushMs = [];
-  stats.uploads = 0;
-  stats.uploadMs = 0;
-  stats.uploadPx = 0;
-  stats.props = 0;
-  stats.layersMade = 0;
+  // settle: a tree of a few thousand nodes mounts over more than one frame,
+  // and the first frame of a scenario is not its steady state
+  const settled = async (quietMs, maxMs) => {
+    const start = performance.now();
+    let last = stats.flushes;
+    let lastAt = performance.now();
+    while (performance.now() - start < maxMs) {
+      await new Promise((r) => setTimeout(r, 25));
+      if (stats.flushes !== last) {
+        last = stats.flushes;
+        lastAt = performance.now();
+      } else if (performance.now() - lastAt > quietMs) break;
+    }
+  };
+  await settled(300, 8000);
+  if (scenario.setup) {
+    scenario.setup(ctx);
+    await settled(300, 3000);
+  }
+  const nodeCount = [...walk(node)].length;
 
+  // steady state is the measurement
+  for (const key of Object.keys(stats)) {
+    if (Array.isArray(stats[key])) stats[key] = [];
+    else if (typeof stats[key] === 'number') stats[key] = 0;
+  }
+  inFlight = [];
+  answered = [];
+
+  const seconds = scenario.seconds ?? SECONDS;
+  const cpu0 = process.cpuUsage();
+  const rss0 = process.memoryUsage().rss;
   const t0 = performance.now();
   const timer = setInterval(() => {
     tick += 1;
     if (scenario.drive) scenario.drive(ctx);
-    else root.render(scenario.tree(tick));
+    else root.render(treeAt(tick));
   }, TICK_MS);
-  await new Promise((r) => setTimeout(r, SECONDS * 1000));
+  await new Promise((r) => setTimeout(r, seconds * 1000));
   clearInterval(timer);
   await new Promise((r) => setTimeout(r, 120));
   const elapsed = (performance.now() - t0) / 1000;
+  const cpu = process.cpuUsage(cpu0);
+  const rss1 = process.memoryUsage().rss;
 
   if (SHOTS && wnd) {
     wnd.snapshot(
@@ -508,28 +1234,47 @@ async function runChild() {
 
   const sorted = [...stats.flushMs].sort((a, b) => a - b);
   const lat = [...stats.latency].sort((a, b) => a - b);
+  const plat = [...stats.presentLatency].sort((a, b) => a - b);
   const q = (a, p) =>
     a.length ? a[Math.min(a.length - 1, Math.floor(p * a.length))] : null;
   const sum = (a) => a.reduce((s, v) => s + v, 0);
+  const frames = stats.flushes;
   const out = {
-    frames: stats.flushes,
-    fps: stats.flushes / elapsed,
+    nodes: nodeCount,
+    scale: win?.scale ?? 1,
+    frames,
+    fps: frames / elapsed,
     ticks: tick,
     flushAvg: sorted.length ? sum(sorted) / sorted.length : null,
     flushP95: q(sorted, 0.95),
     flushMax: sorted.at(-1) ?? null,
-    clientMsPerSec: (sum(sorted) + stats.uploadMs) / elapsed,
-    uploadsPerFrame: stats.flushes ? stats.uploads / stats.flushes : 0,
-    uploadKpxPerFrame: stats.flushes
-      ? stats.uploadPx / stats.flushes / 1000
+    damageKpxPerFrame: frames ? stats.damagePx / frames / 1000 : 0,
+    fullPct: frames ? (100 * stats.fullFrames) / frames : 0,
+    cpuPct: (100 * (cpu.user + cpu.system)) / 1000 / (elapsed * 1000),
+    rssMb: (rss1 - rss0) / (1 << 20),
+    pumpMsPerSec: stats.pumpMs / elapsed,
+    pumpUs: stats.pumps ? (1000 * stats.pumpMs) / stats.pumps : 0,
+    pumpAfterPresentUs: stats.pumpsAfterPresent
+      ? (1000 * stats.pumpAfterPresentMs) / stats.pumpsAfterPresent
       : 0,
-    uploadMsPerFrame: stats.flushes ? stats.uploadMs / stats.flushes : 0,
-    propsPerFrame: stats.flushes ? stats.props / stats.flushes : 0,
+    presents: stats.presents,
+    presentMsPerFrame: stats.presents ? stats.presentMs / stats.presents : 0,
+    surfaces: stats.surfaces,
+    surfaceMb: stats.surfaceBytes / (1 << 20),
+    surfaceMs: stats.surfaceMs,
+    uploadsPerFrame: frames ? stats.uploads / frames : 0,
+    uploadKpxPerFrame: frames ? stats.uploadPx / frames / 1000 : 0,
+    uploadMsPerFrame: frames ? stats.uploadMs / frames : 0,
+    propsPerFrame: frames ? stats.props / frames : 0,
     layersMade: stats.layersMade,
     latP50: q(lat, 0.5),
     latP95: q(lat, 0.95),
     latMax: lat.at(-1) ?? null,
     latN: lat.length,
+    platP50: q(plat, 0.5),
+    platP95: q(plat, 0.95),
+    platMax: plat.at(-1) ?? null,
+    extra,
   };
   console.log(`RESULT ${JSON.stringify(out)}`);
   await root.unmount();
@@ -542,21 +1287,32 @@ async function runChild() {
 // ---------------------------------------------------------------------------
 
 function runCell(name, env) {
+  const seconds = SCENARIOS[name].seconds ?? SECONDS;
   const res = spawnSync(
     process.execPath,
     [
       '--import',
       'tsx',
+      ...(PROF
+        ? [
+            '--cpu-prof',
+            `--cpu-prof-dir=${process.env.PROF_DIR ?? '/tmp'}`,
+            `--cpu-prof-name=${name}-${env.REACT_X11_COCOA_PRESENTER ?? env.REACT_X11_BACKEND ?? 'cell'}.cpuprofile`,
+          ]
+        : []),
       new URL(import.meta.url).pathname,
       '--child',
       `--run=${name}`,
       `--seconds=${SECONDS}`,
+      `--cells=${CELLS}`,
+      `--size=${SIZE}`,
+      ...(FRAME ? [`--frame=${FRAME}`] : []),
       ...(SHOTS ? ['--shots'] : []),
     ],
     {
       env: { ...process.env, ...env },
       encoding: 'utf8',
-      timeout: (SECONDS + 25) * 1000,
+      timeout: (seconds + 40) * 1000,
     },
   );
   const line = (res.stdout ?? '')
@@ -569,20 +1325,116 @@ function runCell(name, env) {
   return JSON.parse(line.slice(7));
 }
 
+// ---------------------------------------------------------------------------
+// The gate. A rule is a bound on something a frame either does or does not
+// do — repaint the whole window, paint more than a share of it for one
+// cell, flush twice for one resize tick, paint a window nobody can see —
+// which is what regresses when the frame clock or the damage model is
+// touched, and what a timing on someone else's machine cannot say.
+// ---------------------------------------------------------------------------
+
+const GATE_PATH = new URL('./presenters-gate.json', import.meta.url);
+
+function loadGate() {
+  return JSON.parse(readFileSync(GATE_PATH, 'utf8'));
+}
+
+/** The verdicts one cell's numbers earn against its rules. */
+function judge(name, r, rules) {
+  const out = [];
+  const windowPx = W * H * r.scale * r.scale;
+  const share = (r.damageKpxPerFrame * 1000) / windowPx;
+  const x = r.extra ?? {};
+  const rule = (ok, what) => out.push({ ok, what });
+  if (rules.maxFullPct !== undefined) {
+    rule(
+      r.fullPct <= rules.maxFullPct,
+      `full-window frames ${r.fullPct.toFixed(0)}% (max ${rules.maxFullPct}%)`,
+    );
+  }
+  if (rules.maxDamageShare !== undefined) {
+    rule(
+      share <= rules.maxDamageShare,
+      `repainted ${(100 * share).toFixed(2)}% of the window per frame (max ${(100 * rules.maxDamageShare).toFixed(1)}%)`,
+    );
+  }
+  if (rules.minFrames !== undefined) {
+    rule(
+      r.frames >= rules.minFrames,
+      `${r.frames} frames (min ${rules.minFrames})`,
+    );
+  }
+  if (rules.maxFrames !== undefined) {
+    rule(
+      r.frames <= rules.maxFrames,
+      `${r.frames} frames (max ${rules.maxFrames})`,
+    );
+  }
+  if (rules.minInputs !== undefined) {
+    rule(
+      r.latN >= rules.minInputs,
+      `${r.latN} inputs answered (min ${rules.minInputs})`,
+    );
+  }
+  if (rules.maxUploadsPerFrame !== undefined) {
+    rule(
+      r.uploadsPerFrame <= rules.maxUploadsPerFrame,
+      `${r.uploadsPerFrame.toFixed(2)} uploads per frame (max ${rules.maxUploadsPerFrame})`,
+    );
+  }
+  if (rules.maxFlushesPerResize !== undefined) {
+    const per = x.resizes ? x.resizeFlushes / x.resizes : Infinity;
+    rule(
+      per <= rules.maxFlushesPerResize,
+      `${per.toFixed(2)} frames per resize tick (max ${rules.maxFlushesPerResize})`,
+    );
+  }
+  if (rules.maxSettleFlushes !== undefined) {
+    rule(
+      (x.settleFlushes ?? Infinity) <= rules.maxSettleFlushes,
+      `${x.settleFlushes ?? '?'} frames after the last tick (max ${rules.maxSettleFlushes})`,
+    );
+  }
+  if (rules.maxSurfacesPerResize !== undefined) {
+    const per = x.resizes ? r.surfaces / x.resizes : Infinity;
+    rule(
+      per <= rules.maxSurfacesPerResize,
+      `${per.toFixed(1)} backing surfaces per resize tick (max ${rules.maxSurfacesPerResize})`,
+    );
+  }
+  return out;
+}
+
 const ms = (v) => (v == null ? '    -' : v.toFixed(2).padStart(5));
 const n1 = (v) => (v == null ? '    -' : v.toFixed(1).padStart(5));
+const n0 = (v) => (v == null ? '   -' : Math.round(v).toString().padStart(4));
 
 if (CHILD) {
   await runChild();
 } else {
-  const names = ONLY ? [ONLY] : Object.keys(SCENARIOS);
-  const columns = [
-    ['surface', { REACT_X11_COCOA_PRESENTER: 'surface' }],
-    ['layers', { REACT_X11_COCOA_PRESENTER: 'layers' }],
-    ...(WITH_X11 ? [['x11', { REACT_X11_BACKEND: 'x11' }]] : []),
-  ];
+  const gate = CHECK ? loadGate() : null;
+  // the gate judges the default presenter over the scenarios it has rules
+  // for; the timing table still prints, for the human reading the log
+  const names = ONLY
+    ? ONLY.split(',')
+    : gate
+      ? Object.keys(gate.rules)
+      : Object.keys(SCENARIOS);
+  const columnNames = COLUMNS
+    ? COLUMNS.split(',')
+    : gate
+      ? ['surface']
+      : ['surface', 'layers', ...(WITH_X11 ? ['x11'] : [])];
+  const verdicts = [];
+  const summary = [];
+  const envOf = {
+    surface: { REACT_X11_COCOA_PRESENTER: 'surface' },
+    layers: { REACT_X11_COCOA_PRESENTER: 'layers' },
+    x11: { REACT_X11_BACKEND: 'x11' },
+  };
   console.log(
-    `presenter bench — ${W}x${H} window, ${SECONDS}s per cell, tick ${TICK_MS}ms`,
+    `presenter bench — ${W}x${H} window, ${SECONDS}s per cell, tick ${TICK_MS}ms, ` +
+      `${COLS}x${ROWS} stress cells`,
   );
   for (const name of names) {
     if (!SCENARIOS[name]) {
@@ -591,33 +1443,117 @@ if (CHILD) {
       );
       process.exit(1);
     }
+    const scenario = SCENARIOS[name];
     console.log(`\n${name}`);
     console.log(
-      '            fps   flush avg/p95/max      upload/frame        props  input p50/p95/max',
+      '            fps   flush avg/p95/max    damage/frame   cpu   upload/frame          props  input→flush p50/p95/max  →present p50/p95',
     );
-    for (const [label, env] of columns) {
+    for (const label of columnNames) {
+      const env = envOf[label];
+      if (!env) {
+        console.log(`  ${label.padEnd(9)} unknown column`);
+        continue;
+      }
+      if (
+        label === 'x11' &&
+        (scenario.cocoaOnly || scenario.input === 'native')
+      ) {
+        console.log(`  ${label.padEnd(9)} n/a (native input / cocoa only)`);
+        continue;
+      }
       const r = runCell(name, env);
       if (r.error) {
         console.log(`  ${label.padEnd(9)} FAILED: ${r.error}`);
+        if (gate?.rules[name] && label === 'surface') {
+          verdicts.push({ name, ok: false, what: `did not run: ${r.error}` });
+        }
         continue;
+      }
+      if (gate?.rules[name] && label === 'surface') {
+        for (const v of judge(name, r, gate.rules[name])) {
+          verdicts.push({ name, ...v });
+        }
       }
       const upload =
         r.uploadsPerFrame > 0
           ? `${r.uploadsPerFrame.toFixed(1)}x ${Math.round(r.uploadKpxPerFrame).toString().padStart(4)}kpx ${ms(r.uploadMsPerFrame)}ms`
-          : '        none      ';
+          : '        none         ';
       const input =
         r.latN > 0
           ? `${ms(r.latP50)}/${ms(r.latP95)}/${ms(r.latMax)}`
-          : '        -';
+          : '        -          ';
+      const present =
+        r.platP50 != null ? `${ms(r.platP50)}/${ms(r.platP95)}` : '      -';
       console.log(
-        `  ${label.padEnd(9)}${n1(r.fps)}  ${ms(r.flushAvg)}/${ms(r.flushP95)}/${ms(r.flushMax)}ms  ${upload}  ${r.propsPerFrame.toFixed(1).padStart(5)}  ${input}`,
+        `  ${label.padEnd(9)}${n1(r.fps)}  ${ms(r.flushAvg)}/${ms(r.flushP95)}/${ms(r.flushMax)}ms  ` +
+          `${n0(r.damageKpxPerFrame)}kpx ${n0(r.fullPct)}%full  ${n0(r.cpuPct)}%  ${upload}  ` +
+          `${r.propsPerFrame.toFixed(1).padStart(5)}  ${input}  ${present}`,
+      );
+      const notes = [];
+      if (r.nodes) notes.push(`${r.nodes} nodes`);
+      if (r.frames === 0) notes.push('no frames');
+      if (r.presents) notes.push(`${r.presents} presents`);
+      if (r.surfaces) {
+        notes.push(
+          `${r.surfaces} surfaces made (${r.surfaceMb.toFixed(0)}MB, ${(r.surfaceMs / r.surfaces).toFixed(2)}ms each)`,
+        );
+      }
+      if (r.pumpMsPerSec) {
+        notes.push(
+          `pump ${r.pumpMsPerSec.toFixed(1)}ms/s (${Math.round(r.pumpUs)}us, ${Math.round(r.pumpAfterPresentUs)}us after a present)`,
+        );
+      }
+      if (Math.abs(r.rssMb) >= 8)
+        notes.push(`rss ${r.rssMb > 0 ? '+' : ''}${r.rssMb.toFixed(0)}MB`);
+      const x = r.extra ?? {};
+      if (x.resizes) {
+        notes.push(
+          `${x.resizes} resizes: ${(x.resizeMs / x.resizes).toFixed(1)}ms avg, ${x.resizeMax.toFixed(1)}ms max, ` +
+            `${(x.resizeFlushes / x.resizes).toFixed(1)} flushes each; settle ${Math.round(x.settleMs ?? 0)}ms / ${x.settleFlushes ?? 0} frames`,
+        );
+      }
+      if (notes.length) console.log(`            ${notes.join(' · ')}`);
+      summary.push(
+        `| ${name} | ${label} | ${n1(r.fps).trim()} | ${ms(r.flushAvg).trim()} / ${ms(r.flushP95).trim()} / ${ms(r.flushMax).trim()} | ` +
+          `${Math.round(r.damageKpxPerFrame)}kpx, ${Math.round(r.fullPct)}% full | ${Math.round(r.cpuPct)}% | ` +
+          `${r.latN > 0 ? `${ms(r.latP50).trim()} / ${ms(r.latP95).trim()}` : '-'} |`,
       );
     }
   }
+  if (gate) {
+    console.log('\ngate');
+    for (const v of verdicts) {
+      console.log(`  ${v.ok ? 'ok  ' : 'FAIL'} ${v.name.padEnd(9)} ${v.what}`);
+    }
+    const failed = verdicts.filter((v) => !v.ok);
+    console.log(
+      failed.length
+        ? `\n${failed.length} rule${failed.length === 1 ? '' : 's'} failed — scripts/bench/presenters-gate.json says what each one keeps`
+        : `\nall ${verdicts.length} rules hold`,
+    );
+    // the table, where the run's page can show it
+    if (process.env.GITHUB_STEP_SUMMARY) {
+      appendFileSync(
+        process.env.GITHUB_STEP_SUMMARY,
+        `## presenter bench — ${W}x${H}, ${SECONDS}s per cell\n\n` +
+          '| scenario | presenter | fps | flush avg / p95 / max ms | damage per frame | cpu | input→flush p50 / p95 ms |\n' +
+          '| --- | --- | --- | --- | --- | --- | --- |\n' +
+          summary.join('\n') +
+          '\n\n' +
+          verdicts
+            .map((v) => `- ${v.ok ? '✅' : '❌'} \`${v.name}\` ${v.what}`)
+            .join('\n') +
+          '\n',
+      );
+    }
+    process.exit(failed.length ? 1 : 0);
+  }
   console.log(
-    '\nnotes: upload = surfaceToLayer (CGImage handoff), at window size on the' +
-      '\nsurface presenter and per re-rastered visual on layers; props =' +
+    '\nnotes: damage = the repainted area per painting frame and the share of' +
+      '\nfull-window frames; cpu = process CPU as % of one core; upload = CA' +
+      '\nhandoffs (surfaceToLayer, swapchain flips + catch-up copies); props =' +
       '\nsetLayerProps per frame; input = event sent → end of the flush that' +
-      '\nanswered it, through the pump. Compare within this run only.',
+      '\nanswered it, and → end of the present that showed it, through the' +
+      '\npump. Compare within this run only.',
   );
 }

--- a/scripts/bench/touched.js
+++ b/scripts/bench/touched.js
@@ -1,0 +1,157 @@
+// Which benches does this change owe?
+//
+//   npm run bench:touched                     # against origin/master
+//   npm run bench:touched -- --base=HEAD~3    # against another ref
+//   npm run bench:touched -- --dry            # say which, run nothing
+//   npm run bench:touched -- --benches=presenters --ci   # CI's macOS job
+//   npm run bench:touched -- --all            # every bench, whatever changed
+//
+// A performance regression is a change to a hot path, and a hot path is a
+// short list of files: the paint walk and the damage model, the layout
+// floors, the paint cache, the event dispatch that decides when a frame
+// goes out, the Cocoa frame clock and swapchain, the benches and their
+// baselines themselves, and the dependency manifest, because an ntk bump
+// moves everything under all of them. This script reads the diff against
+// the base, matches it against that list, and runs the benches the matches
+// owe — nothing for a docs change, the X11 protocol gate for a `nodes.js`
+// change, the Cocoa frame-clock gate as well on a mac. The list is the
+// policy, in one place, and it is deliberately short: a path that is not on
+// it is a path a regression cannot reach without going through one that is.
+//
+// Every bench it runs is a gate someone can run by hand
+// (`npm run bench -- --check`, `npm run bench:pixels -- --check`,
+// `npm run bench:presenters -- --check`); this only decides which.
+import { spawnSync } from 'node:child_process';
+
+const args = process.argv.slice(2);
+const flag = (name, fallback) => {
+  const hit = args.find((a) => a.startsWith(`--${name}=`));
+  return hit ? hit.slice(name.length + 3) : fallback;
+};
+const BASE = flag('base', process.env.BENCH_BASE ?? 'origin/master');
+const DRY = args.includes('--dry');
+const CI = args.includes('--ci');
+const ALL = args.includes('--all');
+const BENCHES = flag('benches', null)?.split(',') ?? null;
+
+/**
+ * The hot paths, per bench. `platform` names where the bench can run at
+ * all — the Cocoa gate needs a mac with a window server, the X11 benches
+ * run anywhere on the in-process server.
+ */
+const BENCHES_BY_NAME = {
+  protocol: {
+    what: 'X11 protocol efficiency (requests, bytes, composite pixels)',
+    command: ['npm', ['run', 'bench', '--', '--check']],
+    // the retry the CI job makes, for the per-scenario jitter protocol.js
+    // describes: a real regression fails twice
+    retry: true,
+    paths: [
+      /^src\/(nodes|node|paintcache|styles|decorations|svgnodes|events|frames|compositing|scale|yoga)\.js$/,
+      /^src\/components\//,
+      /^scripts\/bench\/(protocol|xcount)\.js$/,
+      /^scripts\/bench\/baseline\.json$/,
+      /^package(-lock)?\.json$/,
+    ],
+  },
+  pixels: {
+    what: 'X11 rendered pixels (hashes per scenario)',
+    command: ['npm', ['run', 'bench:pixels', '--', '--check']],
+    paths: [
+      /^src\/(nodes|node|paintcache|styles|decorations|svgnodes|events|frames|compositing|scale|yoga)\.js$/,
+      /^src\/components\//,
+      /^scripts\/bench\/pixels\.js$/,
+      /^scripts\/bench\/pixels-baseline\.json$/,
+      /^package(-lock)?\.json$/,
+    ],
+  },
+  presenters: {
+    what: 'Cocoa frame clock and damage model (structural gate)',
+    command: ['npm', ['run', 'bench:presenters', '--', '--check']],
+    platform: 'darwin',
+    paths: [
+      /^src\/cocoa\//,
+      /^src\/(nodes|node|paintcache|styles|events|frames|scale)\.js$/,
+      /^scripts\/bench\/presenters(-gate\.json|\.js)$/,
+      /^package(-lock)?\.json$/,
+    ],
+  },
+};
+
+function changedFiles(base) {
+  const range = `${base}...HEAD`;
+  const res = spawnSync('git', ['diff', '--name-only', range], {
+    encoding: 'utf8',
+  });
+  if (res.status !== 0) {
+    throw new Error(
+      `git diff ${range} failed: ${res.stderr.trim()} — pass --base=<ref> ` +
+        'or fetch the base first',
+    );
+  }
+  const committed = res.stdout.split('\n').filter(Boolean);
+  // …plus whatever is not committed yet, which is what a developer asks about
+  const working = spawnSync('git', ['status', '--porcelain'], {
+    encoding: 'utf8',
+  })
+    .stdout.split('\n')
+    .filter(Boolean)
+    .map((line) => line.slice(3).split(' -> ').pop());
+  return [...new Set([...committed, ...working])];
+}
+
+const wanted = Object.entries(BENCHES_BY_NAME).filter(
+  ([name, bench]) =>
+    (!BENCHES || BENCHES.includes(name)) &&
+    (!bench.platform || bench.platform === process.platform),
+);
+
+let files = [];
+if (!ALL) {
+  files = changedFiles(BASE);
+}
+
+const owed = [];
+for (const [name, bench] of wanted) {
+  const hits = ALL
+    ? ['--all']
+    : files.filter((f) => bench.paths.some((p) => p.test(f)));
+  if (hits.length) owed.push({ name, bench, hits });
+}
+
+if (!ALL) {
+  console.log(
+    `${files.length} changed file${files.length === 1 ? '' : 's'} against ${BASE}`,
+  );
+}
+if (!owed.length) {
+  console.log('no hot path touched — no bench owed');
+  process.exit(0);
+}
+for (const { name, bench, hits } of owed) {
+  console.log(`\n${name}: ${bench.what}`);
+  console.log(
+    `  owed by ${hits.slice(0, 6).join(', ')}${hits.length > 6 ? ` and ${hits.length - 6} more` : ''}`,
+  );
+}
+if (DRY) process.exit(0);
+
+let failed = 0;
+for (const { name, bench } of owed) {
+  console.log(`\n=== ${name} ===`);
+  const [cmd, cmdArgs] = bench.command;
+  const argv = CI && name === 'presenters' ? [...cmdArgs, '--ci'] : cmdArgs;
+  const run = () =>
+    spawnSync(cmd, argv, { stdio: 'inherit', env: process.env }).status;
+  let status = run();
+  if (status !== 0 && bench.retry) {
+    console.log(`\n${name} failed once — running it again`);
+    status = run();
+  }
+  if (status !== 0) failed += 1;
+}
+if (failed) {
+  console.log(`\n${failed} bench${failed === 1 ? '' : 'es'} failed`);
+  process.exit(1);
+}
+console.log('\nevery owed bench holds');

--- a/src/cocoa/app.js
+++ b/src/cocoa/app.js
@@ -29,7 +29,14 @@ import { CocoaWindow } from './window.js';
 import { decodeKey, modifierMask } from './keymap.js';
 import { loadNative } from './native.js';
 
+// The frame interval: how often a scheduled frame may paint, in ms. 16 is a
+// 60Hz display's period. `createRoot({ cocoa: { frameInterval } })` sets it
+// — 8 on a 120Hz panel paints every refresh — and the honest default is the
+// display's own period, which the bridge does not report yet
+// (NSScreen.maximumFramesPerSecond); until it does, 60Hz is the floor every
+// Mac clears rather than a ceiling half of them hit.
 const RAF_INTERVAL_MS = 16;
+const PUMP_INTERVAL_MS = 8;
 
 export class CocoaApp {
   constructor(native, options = {}) {
@@ -37,8 +44,11 @@ export class CocoaApp {
     this.options = options;
     this._windows = new Map(); // windowNumber -> CocoaWindow
     this._grabWindow = null;
-    this._rafQueue = [];
+    this._rafQueue = []; // [{ cb, wnd }]
     this._rafLast = 0;
+    this._frameInterval = options.cocoa?.frameInterval ?? RAF_INTERVAL_MS;
+    this._pumpInterval = PUMP_INTERVAL_MS;
+    this._geometryFlushQueued = false;
     this._shadowStale = new Set();
     this._pump = null;
     this._closed = false;
@@ -277,8 +287,9 @@ export class CocoaApp {
 
   // --- the pump ------------------------------------------------------------
 
-  start({ pumpInterval = 8 } = {}) {
+  start({ pumpInterval = PUMP_INTERVAL_MS } = {}) {
     if (this._pump) return;
+    this._pumpInterval = pumpInterval;
     const native = this._native;
     // A pane process has no NSApplication to pump — no windows, no events,
     // no dock presence. Its loop is frames and presents only.
@@ -292,6 +303,7 @@ export class CocoaApp {
     native.initApp();
     native.setBackendEventCallback((ev) => this._route(ev));
     this._pump = setInterval(() => {
+      this._endLiveResizes();
       native.pump2(); // flushes the previous tick's CATransaction
       if (this._shadowStale.size) {
         for (const wnd of this._shadowStale) {
@@ -304,21 +316,48 @@ export class CocoaApp {
     }, pumpInterval);
   }
 
-  _requestFrame(cb) {
-    this._rafQueue.push(cb);
+  /**
+   * A pump tick means no modal loop owns the thread, so no window is being
+   * resized live right now: the flag the delegate set on the last tick of a
+   * drag comes off here, ahead of the frames that tick, and the catch-up
+   * frame a deferred layout owes (nodes.js) runs on this very tick.
+   */
+  _endLiveResizes() {
+    for (const wnd of this._windows.values()) wnd.liveResizing = false;
+  }
+
+  _requestFrame(cb, wnd = null) {
+    this._rafQueue.push({ cb, wnd });
     return this._rafQueue.length;
   }
 
   _tickFrames() {
     if (!this._rafQueue.length) return;
-    const now = Date.now();
-    if (now - this._rafLast < RAF_INTERVAL_MS) return;
+    const now = performance.now();
+    // The gate is the interval less half a pump, so a frame lands on the
+    // first pump tick at or after the interval. Gated at exactly one
+    // interval, timer drift put every other frame a tick late — 16ms frames
+    // arriving as 16, 24, 16, 24 — which a 60Hz display shows as a 50fps
+    // stutter, and which the presenter bench measured as 52fps against a
+    // 62.5Hz driver.
+    if (now - this._rafLast < this._frameInterval - this._pumpInterval / 2) {
+      return;
+    }
     this._rafLast = now;
     const queue = this._rafQueue;
     this._rafQueue = [];
-    for (const cb of queue) {
+    for (const entry of queue) {
+      // A window nobody can see owes no frame: its callback waits here until
+      // it is back on glass, and the damage it answers accumulates on the
+      // node — one catch-up frame then, instead of a full paint per tick
+      // into a backing store no one reads. `_visible` is the window's own
+      // rule (mapped, not ordered out, not miniaturized).
+      if (entry.wnd && !entry.wnd._visible()) {
+        this._rafQueue.push(entry);
+        continue;
+      }
       try {
-        cb(now);
+        entry.cb(now);
       } catch (err) {
         queueMicrotask(() => {
           throw err;
@@ -459,6 +498,13 @@ export class CocoaApp {
       smooth: Boolean(ev.precise),
       source: ev.precise ? 'valuator' : 'button',
     });
+    // Painted now, like a press. On X11 the wheel is paced on the frame
+    // clock because ntk coalesces a touchpad's dozens of reports per frame
+    // into one event; AppKit already delivers scroll events at the
+    // display's rate, so answering each one is answering once per refresh
+    // — and answering it on the next frame tick instead was a 15ms median
+    // between the notch and the scroll, most of a refresh period of nothing.
+    this._afterInput();
   }
 
   _routeKey(ev) {
@@ -499,9 +545,18 @@ export class CocoaApp {
     // handler returns, and the pump that would paint it is the thing the
     // modal loop stalled. A second flush queued BEHIND that commit is what
     // lets an open menu resize with the drag instead of on release.
-    queueMicrotask(() => {
-      if (!this._closed) this._afterInput();
-    });
+    //
+    // One, not one per event: inside the modal loop no microtask runs until
+    // the drag ends, so a drag's every tick queued another — and they all
+    // ran on the release, each finding the frame the previous one had just
+    // paid. Coalesced, the release owes at most one flush.
+    if (!this._geometryFlushQueued) {
+      this._geometryFlushQueued = true;
+      queueMicrotask(() => {
+        this._geometryFlushQueued = false;
+        if (!this._closed) this._afterInput();
+      });
+    }
   }
 
   _routeClose(ev) {

--- a/src/cocoa/panewindow.js
+++ b/src/cocoa/panewindow.js
@@ -134,12 +134,9 @@ export class CocoaPaneWindow {
       this._surfaceSize = { width: w, height: h };
       this._surfaceGen++;
       this._flushDamage = 'full';
-      if (hadSurface) {
-        queueMicrotask(() => {
-          const node = this._reactX11Node;
-          if (node && !node.destroyed) node.invalidate(true, null, 'resize');
-        });
-      }
+      // decided when the flush reports its rects — see CocoaWindow's
+      // `_ensureSurface` for why not a queued full frame from here
+      if (hadSurface) this._freshSurface = true;
     }
     return this._surface;
   }
@@ -163,6 +160,20 @@ export class CocoaPaneWindow {
   }
 
   noteFrameDamage(rects) {
+    if (this._freshSurface) {
+      this._freshSurface = false;
+      // a bounded flush onto a fresh ring leaves garbage outside its rects:
+      // one full frame, and no present until it lands (CocoaWindow's rule)
+      if (rects) {
+        this._holdPresent = true;
+        const node = this._reactX11Node;
+        if (node && !node.destroyed) node.invalidate(false, null, 'resize');
+      } else {
+        this._holdPresent = false;
+      }
+    } else if (!rects) {
+      this._holdPresent = false;
+    }
     if (this._flushDamage === 'full') return;
     if (!rects) {
       this._flushDamage = 'full';
@@ -190,6 +201,7 @@ export class CocoaPaneWindow {
   /** Flip and tell the host, instead of touching any layer of our own. */
   present() {
     if (!this._dirty || !this._ring || this.destroyed) return;
+    if (this._holdPresent) return;
     this._dirty = false;
     const shown = this._ring[this._drawIndex];
     this._native.surfaceUnlock(shown.handle);

--- a/src/cocoa/window.js
+++ b/src/cocoa/window.js
@@ -75,6 +75,15 @@ export class CocoaWindow {
     this._refreshOrigin();
     if (attributes.sizeHints) this.setSizeHints(attributes.sizeHints);
 
+    // How many damage rects a frame may keep before merging them (nodes.js,
+    // MAX_DAMAGE_RECTS is the X11 answer). A pass here costs one CoreGraphics
+    // clip and a culled walk, where an X pass costs the server a clip mask,
+    // so a frame in which a clock, a graph and a status row all ticked keeps
+    // the three small rects instead of the box around them — which on a
+    // large tree was most of the window, painted for three cells' worth of
+    // change.
+    this.damageRectCap = 16;
+
     // The retained layer presenter (docs/macos.md Tier L), behind
     // REACT_X11_COCOA_PRESENTER=layers while the surface path is the
     // measured default. Its two hooks exist only in this mode, so the
@@ -123,6 +132,12 @@ export class CocoaWindow {
     this.x = Math.round(points.x * s);
     this.y = Math.round(points.y * s);
     this._screenOrigin = { x: this.x, y: this.y };
+    // AppKit's inLiveResize, as the delegate reported it: the renderer
+    // answers a live tick with the layout floors it has and measures fresh
+    // ones after the drag (nodes.js, `_deferContentFloors`). Cleared by
+    // the pump (`_endLiveResizes`), because the pump cannot run while the
+    // resize loop owns the thread — a tick of it is the drag being over.
+    if (points.live === true) this.liveResizing = true;
   }
 
   resize(width, height) {
@@ -258,16 +273,17 @@ export class CocoaWindow {
       this._surfaceSize = { width: w, height: h };
       this._surfaceGen++;
       this._flushDamage = 'full';
-      // A replaced backing surface holds nothing: whatever bounded damage
-      // this frame carries, everything else on it would be garbage. Ask for
-      // the full frame — one extra repaint per real resize, correctness for
-      // every pixel outside the damage rect.
-      if (hadSurface) {
-        queueMicrotask(() => {
-          const node = this._reactX11Node;
-          if (node && !node.destroyed) node.invalidate(true, null, 'resize');
-        });
-      }
+      // A replaced backing surface holds nothing but what the flush now
+      // painting puts on it. Whether that is enough is decided when the
+      // flush reports its rects (`noteFrameDamage`) — not here, and not by
+      // queueing a full frame behind this one. That used to be the answer,
+      // and it made every tick of a live resize two full frames: the resize
+      // event's own unbounded repaint, then this one, painting the same
+      // pixels again. Worse, inside AppKit's resize loop no microtask runs
+      // until the drag ends, so a drag of forty ticks queued forty full
+      // frames that all ran on the mouse release — the freeze after a
+      // resize, measured at seconds on a large tree.
+      if (hadSurface) this._freshSurface = true;
     }
     return this._surface;
   }
@@ -279,12 +295,44 @@ export class CocoaWindow {
    */
   noteFrameDamage(rects) {
     if (this._presenter) return;
+    if (this._freshSurface) {
+      this._freshSurface = false;
+      // A full flush painted every pixel of the new surface, and a resize
+      // event's flush is one (nodes.js, the 'resize' listener). A bounded
+      // one left garbage outside its rects: hold the present until the full
+      // frame asked for here lands, so the garbage is never on glass.
+      if (rects) {
+        this._holdPresent = true;
+        const node = this._reactX11Node;
+        if (node && !node.destroyed) node.invalidate(false, null, 'resize');
+      } else {
+        this._holdPresent = false;
+      }
+    } else if (!rects) {
+      this._holdPresent = false;
+    }
     if (this._flushDamage === 'full') return;
     if (!rects) {
       this._flushDamage = 'full';
       return;
     }
     (this._flushDamage ??= []).push(...rects);
+  }
+
+  /**
+   * Whether anyone can see this window: mapped by the renderer, and not
+   * ordered out or miniaturized by the user. A window that fails this owes
+   * no frames — its callbacks wait in the app's queue (`_tickFrames`) and
+   * its last paint stays unpresented until it is back on glass, where one
+   * catch-up frame covers everything that changed in between.
+   *
+   * Occlusion by another application's window is not read here yet: AppKit
+   * reports it through `windowDidChangeOcclusionState`, which the bridge
+   * does not forward. When it does, this is the one place to add it.
+   */
+  _visible() {
+    if (this.destroyed || !this.mapped) return false;
+    return this._native.windowIsVisible(this._h) !== false;
   }
 
   getContext() {
@@ -345,13 +393,16 @@ export class CocoaWindow {
   }
 
   requestAnimationFrame(cb) {
-    return this.app._requestFrame(cb);
+    return this.app._requestFrame(cb, this);
   }
 
   /** Push the backing surface at the WindowServer, if anything drew. */
   present() {
     if (this._presenter) return; // layers upload as they sync
     if (!this._dirty || !this._surface || this.destroyed) return;
+    // …and if anyone would see it. `_dirty` stays set, so the pump asks
+    // again next tick and the frame goes out the moment the window is back.
+    if (this._holdPresent || !this._visible()) return;
     this._dirty = false;
     if (this._chain) {
       const shown = this._chain.back;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -180,6 +180,22 @@ export interface RootOptions {
    * is a backend.
    */
   backend?: 'auto' | 'x11' | 'cocoa';
+  /**
+   * The Cocoa backend's knobs (docs/macos.md). `presenter` picks the frame
+   * path: `'surface'` (the measured default — one bitmap per window, the
+   * X11 paint machinery over an IOSurface swapchain) or `'layers'` (one
+   * CALayer per drawn node, opt-in while it is measured).
+   * `frameInterval` is how often a scheduled frame may paint, in ms —
+   * 16 by default, a 60Hz display's period; 8 paints every refresh of a
+   * 120Hz panel. `pumpInterval` is the AppKit event pump's cadence, in
+   * ms (8 by default), which is the floor under input latency. Ignored
+   * off macOS and when {@link RootOptions.app} is passed.
+   */
+  cocoa?: {
+    presenter?: 'surface' | 'layers';
+    frameInterval?: number;
+    pumpInterval?: number;
+  };
   /** `':1'`, `'host:0.0'`, or a unix socket path. Defaults to `$DISPLAY`. */
   display?: string;
   /**

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -250,6 +250,10 @@ const NO_DAMAGE = Symbol('no-damage');
 // against it.
 const DAMAGE_SLOP = 1;
 
+/** Stale bounds are undebuggable, and every other cache here has an escape
+ * hatch — see NO_SCROLL_BLIT and the paint cache's DISABLED. */
+const NO_BOUNDS_CACHE = process.env.REACT_X11_NO_BOUNDS_CACHE === '1';
+
 // While a bounded frame's layout pass runs, every node whose absolute rect
 // comes out different reports its old and new rects here (each already
 // inflated by that node's own paint reach) — which is what lets a layout
@@ -548,13 +552,13 @@ function coalesceRects(rects) {
  * neighbours go first and far-apart rects last. That merge can itself overlap a
  * third rect, so the result is coalesced again.
  */
-function addDamageRect(rects, add) {
+function addDamageRect(rects, add, cap = MAX_DAMAGE_RECTS) {
   let out = coalesceRects(
     (rects ?? []).concat([
       { x: add.x, y: add.y, width: add.width, height: add.height },
     ]),
   );
-  while (out.length > MAX_DAMAGE_RECTS) {
+  while (out.length > cap) {
     let bestI = 0;
     let bestJ = 1;
     let bestWaste = Infinity;
@@ -1762,6 +1766,10 @@ export class Node {
     this.style = this._anim?.size
       ? { ...target, ...this._animatedValues() }
       : target;
+    // The paint reach reads the style now in force — a shadow's spread, an
+    // outline's width — so it is dropped on every swap, here, before the
+    // old-extent claims below measure the new reach against the old one.
+    this._clearPaintBounds();
     // `hitSlop` feeds the cached hit reach and `overflow` decides where its
     // invalidation walks stop, so a swap that changes either clears here —
     // the one funnel every style path goes through. Animation ticks never
@@ -2014,6 +2022,9 @@ export class Node {
   setStyleState(name, on) {
     if (this.states[name] === on) return;
     this.states[name] = on;
+    // the focus ring's reach is read off `:focus-visible` whether or not
+    // the node has a state block of its own (`_outlineExtent`)
+    this._clearPaintBounds();
     if (!this._stateful || this.destroyed) return;
     const next = scaleResolvedStyle(
       resolveComputedStyle(resolveStyleStates(this._baseStyle, this.states)),
@@ -3249,6 +3260,9 @@ export class Node {
    * invalid, whose own clear walked the rest of the way up.
    */
   _clearHitBounds() {
+    // what moves a hit reach moves the paint reach — first, because the
+    // walk below returns from wherever it finds an ancestor already clear
+    this._clearPaintBounds();
     this._hitBoundsCache = null;
     for (let n = this.parent; n; n = n.parent) {
       if (n.clipsChildren() || n._hitBoundsCache === null) return;
@@ -3392,6 +3406,13 @@ export class Node {
     const abs = this.abs;
     abs.x += dx;
     abs.y += dy;
+    // the paint reach rides along the same way — unless it *is* `abs`,
+    // which just moved
+    const p = this._paintBoundsCache;
+    if (p && p !== abs) {
+      p.x += dx;
+      p.y += dy;
+    }
     const b = this._hitBoundsCache;
     if (b) {
       b.left += dx;
@@ -3449,6 +3470,10 @@ export class Node {
     // a layout change may grow what an enclosing scroll pane has to scroll,
     // through a route yoga never sees (issue #405)
     if (layoutChanged) this._markScrollMeasureDirty();
+    // a node that says its appearance changed may have changed how far it
+    // reaches — a shadow, an outline, a scene element's ink — so its cached
+    // paint reach goes with the claim
+    if (damage === this || damage === null) this._clearPaintBounds();
     this.root?.invalidate(layoutChanged, damage, reason);
   }
 
@@ -3682,14 +3707,42 @@ export class Node {
    * almost nothing.
    */
   _subtreeBounds() {
+    // Cached like the hit reach (`_hitBounds`), and for the same reason: a
+    // bounded frame asks every subtree on the way to its rect whether it
+    // reaches in, and answering by walking the subtree made a one-cell
+    // repaint cost the whole tree — a millisecond at four thousand nodes,
+    // five at fourteen thousand, every frame. The cache is dropped up the
+    // chain by whatever changes a reach: a rect assigned by layout, a
+    // child list mutation (`_clearHitBounds`), and every change a node
+    // announces about itself (`invalidate`, `setStyleState`) — so a stale
+    // answer would need a change nobody announced, which is already a
+    // repaint bug.
+    const cached = this._paintBoundsCache;
+    if (cached && !NO_BOUNDS_CACHE) return cached;
     let bounds = this._ownPaintBounds();
-    if (this.clipsChildren()) return bounds;
-    for (const child of this.children) {
-      if (child.isWindow || !child.yoga || child.hidden) continue;
-      if (child.style?.display === 'none') continue;
-      bounds = unionRect(bounds, child._subtreeBounds());
+    if (!this.clipsChildren()) {
+      for (const child of this.children) {
+        if (child.isWindow || !child.yoga || child.hidden) continue;
+        if (child.style?.display === 'none') continue;
+        bounds = unionRect(bounds, child._subtreeBounds());
+      }
     }
+    this._paintBoundsCache = bounds;
     return bounds;
+  }
+
+  /**
+   * This node's paint reach changed: drop the cached union here and up the
+   * chain, stopping where `_clearHitBounds` stops and for the same reasons
+   * — a clipping ancestor's reach is its own rect, and an ancestor already
+   * cleared has cleared the rest of the way up.
+   */
+  _clearPaintBounds() {
+    this._paintBoundsCache = null;
+    for (let n = this.parent; n; n = n.parent) {
+      if (n.clipsChildren() || n._paintBoundsCache === null) return;
+      n._paintBoundsCache = null;
+    }
   }
 
   /**
@@ -8515,6 +8568,10 @@ export class WindowNode extends Scrollable(Node) {
     this._floored = new Set();
     this._floorsDirty = true;
     this._floorsWidth = null;
+    // whether the tree's CONTENT moved since the floors were measured — a
+    // resize alone does not, which is what lets a live resize defer them
+    this._floorsContentDirty = true;
+    this._floorsCatchUp = false;
   }
 
   /**
@@ -8640,7 +8697,71 @@ export class WindowNode extends Scrollable(Node) {
       writeContentFloors(this, 'height', heights, this._floored);
     });
     this._floorsDirty = false;
+    this._floorsContentDirty = false;
     this._floorsWidth = width;
+  }
+
+  /**
+   * Answer a live resize with the floors already in hand, and measure fresh
+   * ones once the drag is over.
+   *
+   * The floors are half of a relayout on a large tree — three extra layout
+   * passes and their walks, measured at 21 of a 44ms frame on 3,600 nodes
+   * (`npm run bench:presenters -- --scenario=layout`) — and a resize is the
+   * one layout change they cannot follow at input rate: AppKit's resize loop
+   * calls the frame for every pointer move, from inside the event, and the
+   * next move waits for the frame. So a tick of a drag lays the tree out
+   * against the floors the last measurement left, which are exact along the
+   * main axis (a min-content width is content, and the content did not move)
+   * and a frame stale for wrapped text along the other, and the frame after
+   * the release measures once and lays out again — "answer the input, then
+   * catch up". Only while the window says it is being resized live
+   * (`liveResizing`, the Cocoa window's reading of AppKit's flag; an X
+   * window has no such thing and takes the measured path every time), only
+   * when the floors exist to reuse, and never over a content change the
+   * floors have not seen — a row that mounted mid-drag has no floor at all,
+   * and no floor is the collapse #249 exists to prevent.
+   */
+  _deferContentFloors(width) {
+    // nothing to measure: `_applyContentFloors` returns at once, and a
+    // catch-up frame would owe nothing
+    if (!this._floorsDirty && this._floorsWidth === width) return false;
+    return (
+      this.window?.liveResizing === true &&
+      this._floorsWidth != null &&
+      !this._floorsContentDirty
+    );
+  }
+
+  /**
+   * The frame a deferred measurement owes: a full relayout with fresh
+   * floors, run on the first frame tick after the live resize ends. One at
+   * a time — a drag is many ticks, and the catch-up waits for the last of
+   * them rather than following each.
+   */
+  _scheduleFloorsCatchUp() {
+    if (this._floorsCatchUp) return;
+    this._floorsCatchUp = true;
+    const schedule =
+      typeof this.window?.requestAnimationFrame === 'function'
+        ? (cb) => this.window.requestAnimationFrame(cb)
+        : (cb) => setImmediate(cb);
+    const run = () => {
+      if (this.destroyed || !this.window) {
+        this._floorsCatchUp = false;
+        return;
+      }
+      // still dragging (a pump tick inside a pause of the drag): wait on
+      if (this.window.liveResizing) {
+        schedule(run);
+        return;
+      }
+      this._floorsCatchUp = false;
+      this._floorsDirty = true;
+      this.invalidate(true, null, 'resize');
+      this.flush();
+    };
+    schedule(run);
   }
 
   /** Take the measured floors back off, leaving each node with whatever its
@@ -10536,6 +10657,9 @@ export class WindowNode extends Scrollable(Node) {
       // offset applied during `absolutize` and leaves every yoga node exactly
       // as it was, at input rate, on the biggest trees in any app.
       if (reason !== 'scroll') this._floorsDirty = true;
+      if (reason !== 'scroll' && reason !== 'resize') {
+        this._floorsContentDirty = true;
+      }
     }
     // A layout change with no bound named repaints everything, because a
     // reflow can move any node and one that moved leaves stale pixels at a
@@ -10627,7 +10751,7 @@ export class WindowNode extends Scrollable(Node) {
       // as a list of rects rather than one box around them all, so two changes
       // at opposite corners of the window no longer repaint everything
       // between them.
-      this._damage = addDamageRect(this._damage, bounds);
+      this._damage = addDamageRect(this._damage, bounds, this._damageRectCap());
     }
     this.needsPaint = true;
     // Recorded before the `_scheduled` gate, not inside it: the debt is
@@ -10687,7 +10811,8 @@ export class WindowNode extends Scrollable(Node) {
       // ledger's rect moves with the shift (issue #398).
       this._laidOut = true;
       this._resolveSizeQueries(width, height);
-      this._applyContentFloors(width);
+      if (this._deferContentFloors(width)) this._scheduleFloorsCatchUp();
+      else this._applyContentFloors(width);
       this.yoga.setWidth(width);
       this.yoga.setHeight(height);
       this.yoga.calculateLayout(width, height, this._rootDirection);
@@ -10696,15 +10821,17 @@ export class WindowNode extends Scrollable(Node) {
       // the root's rect is written here, not through _assignAbs, so its
       // cached hit reach is dropped here too (children bubble their own)
       this._hitBoundsCache = null;
+      this._paintBoundsCache = null;
       // A bounded frame watches the walk: whatever this pass actually moved
       // claims its old and new rects through the sink, and the frame stays
       // a few rects instead of the whole window. An unbounded frame skips
       // the bookkeeping — it repaints everything anyway.
       if (this._damage !== FULL_DAMAGE) {
+        const cap = this._damageRectCap();
         layoutDiffSink = (rect) => {
           if (this._damage === FULL_DAMAGE) return;
           layoutMoved = true;
-          this._damage = addDamageRect(this._damage, rect);
+          this._damage = addDamageRect(this._damage, rect, cap);
         };
       }
       try {
@@ -10736,7 +10863,11 @@ export class WindowNode extends Scrollable(Node) {
         if (sv && !sv._recordBlitClaim(after)) {
           sv._pendingBlitFrom = BLIT_POISONED;
         }
-        this._damage = addDamageRect(this._damage, after);
+        this._damage = addDamageRect(
+          this._damage,
+          after,
+          this._damageRectCap(),
+        );
       }
       this._reflowed.clear();
     } else if (this._reflowed.size) {
@@ -11458,6 +11589,19 @@ export class WindowNode extends Scrollable(Node) {
    * has to clear the flag, so it degrades to a full repaint rather than
    * painting nothing.
    */
+  /**
+   * How many rects a frame's damage may hold before `addDamageRect` merges
+   * the closest pair. Four on X11 (`MAX_DAMAGE_RECTS`), where every pass
+   * costs the server a clip mask; a backend whose pass is a client-side
+   * clip and a culled walk says so on its window (`damageRectCap`) and
+   * keeps more of them — a clock, a graph and a status row ticking in one
+   * frame stay three small rects instead of the box around all three.
+   */
+  _damageRectCap() {
+    const cap = this.window?.damageRectCap;
+    return Number.isInteger(cap) && cap > 0 ? cap : MAX_DAMAGE_RECTS;
+  }
+
   _takeDamage(width, height) {
     const damage = this._damage;
     this._damage = null;

--- a/test/cocoa-frames.test.js
+++ b/test/cocoa-frames.test.js
@@ -1,0 +1,449 @@
+// The Cocoa backend's frame clock and swapchain, over a fake bridge — the
+// shape of cocoa-surface.test.js: what reaches the natives is the whole of
+// what the glue decides, so a bridge that records its calls is the pixels'
+// witness. Four rules pinned here, each measured before it was written
+// (scripts/bench/presenters.js, the `resize`, `occluded`, `hover` and
+// `scroll` scenarios):
+//
+//   - a live-resize tick is ONE full frame, and its microtasks add none;
+//   - a bounded flush onto a fresh backing surface asks for a full frame and
+//     holds the present until it lands, so garbage is never on glass;
+//   - a window nobody can see owes no frame and no present;
+//   - a wheel notch is answered on the event, like a press.
+import assert from 'node:assert';
+import { afterEach, test } from 'node:test';
+import React from 'react';
+
+import { CocoaApp } from '../src/cocoa/app.js';
+import { setCompositingForTests } from '../src/compositing.js';
+import { createRoot } from '../src/index.js';
+import { setScaleForTests } from '../src/scale.js';
+import { setScreensForTests } from '../src/screens.js';
+
+process.env.NO_AT_BRIDGE ??= '1';
+
+const h = React.createElement;
+
+// --- the fake bridge ----------------------------------------------------------
+
+/**
+ * Enough of @windowkit/appkit for a window with a box tree: windows carry
+ * a number and a frame, `setWindowFrame` answers the way AppKit's delegate
+ * does (a `window-resize` event through the backend callback, synchronously,
+ * from inside the call), surfaces are handles with a size, and every verb
+ * that decides something is recorded.
+ */
+function fakeBridge() {
+  const calls = [];
+  let seq = 0;
+  let backendCb = null;
+  const native = {
+    calls,
+    of: (name) => calls.filter((c) => c[0] === name),
+    visible: true,
+    listScreens: () => [
+      {
+        x: 0,
+        y: 0,
+        width: 1440,
+        height: 900,
+        scale: 2,
+        visible: { x: 0, y: 0, width: 1440, height: 875 },
+        primary: true,
+      },
+    ],
+    createWindow2(options) {
+      const handle = { id: ++seq, options: { ...options } };
+      calls.push(['createWindow2', options.width, options.height]);
+      return handle;
+    },
+    windowNumber: (handle) => handle.id,
+    windowRootLayer: (handle) => ({ root: handle.id }),
+    getWindowFrame: (handle) => ({
+      x: 0,
+      y: 0,
+      width: handle.options.width,
+      height: handle.options.height,
+    }),
+    showWindow(handle) {
+      calls.push(['showWindow', handle.id]);
+    },
+    hideWindow(handle) {
+      calls.push(['hideWindow', handle.id]);
+    },
+    windowIsVisible: () => native.visible,
+    setBackendEventCallback(cb) {
+      backendCb = cb;
+    },
+    initApp() {},
+    setWindowFrame(handle, x, y, width, height) {
+      if (typeof width === 'number') handle.options.width = width;
+      if (typeof height === 'number') handle.options.height = height;
+      calls.push([
+        'setWindowFrame',
+        handle.options.width,
+        handle.options.height,
+      ]);
+      // the delegate's windowDidResize, from inside setFrame: — the route a
+      // drag takes, minus the modal loop around it
+      backendCb?.({
+        type: 'window-resize',
+        windowNumber: handle.id,
+        width: handle.options.width,
+        height: handle.options.height,
+        x: 0,
+        y: 0,
+        live: true,
+      });
+    },
+    createSurfaceIOSurface(width, height, scale) {
+      const id = ++seq;
+      calls.push(['createSurfaceIOSurface', width, height]);
+      return { handle: { id, width, height, scale }, iosurfaceId: id };
+    },
+    createSurface(width, height, scale) {
+      calls.push(['createSurface', width, height]);
+      return { id: ++seq, width, height, scale };
+    },
+    surfaceSize: (handle) => ({
+      width: handle.width,
+      height: handle.height,
+      scale: handle.scale,
+    }),
+    setLayerContentsIOSurface(layer, id) {
+      calls.push(['flip', id]);
+    },
+    copySurfaceRegion(src, dst, rects) {
+      calls.push(['copy', rects ? rects.length / 4 : 'all']);
+    },
+    ctxClearRect(handle, ...rect) {
+      calls.push(['ctxClearRect', ...rect]);
+    },
+    ctxFillRect(handle, ...rect) {
+      calls.push(['ctxFillRect', ...rect]);
+    },
+    scrollSurface() {
+      calls.push(['scrollSurface']);
+      return true;
+    },
+  };
+  return new Proxy(native, {
+    get: (target, key) => (key in target ? target[key] : () => undefined),
+  });
+}
+
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+const roots = [];
+afterEach(async () => {
+  for (const root of roots.splice(0)) await root.unmount();
+});
+
+/**
+ * A CocoaApp over the fake, seeded the way `createCocoaApp` seeds the
+ * platform stores, with no pump: frames tick when the test says so
+ * (`app._tickFrames()`), and the cadence gate is off unless a test turns
+ * it on.
+ */
+async function mount(children, { width = 100, height = 80 } = {}) {
+  const native = fakeBridge();
+  const app = new CocoaApp(native);
+  setScaleForTests(app, 2, 'cocoa');
+  setScreensForTests(app, {
+    monitors: [{ x: 0, y: 0, width: 2880, height: 1800 }],
+    workArea: { x: 0, y: 0, width: 2880, height: 1750 },
+  });
+  setCompositingForTests(app, true);
+  app._frameInterval = 0;
+  native.setBackendEventCallback((ev) => app._route(ev));
+  const root = await createRoot({ app });
+  roots.push(root);
+  root.render(h('window', { width, height }, children));
+  await tick();
+  const wnd = [...app._windows.values()][0];
+  const node = wnd._reactX11Node;
+  const flushes = { count: 0, full: 0 };
+  const flush = node.flush.bind(node);
+  node.flush = (...a) => {
+    const painting =
+      node.needsPaint || node.needsLayout || node._animating.size > 0;
+    const out = flush(...a);
+    if (painting) {
+      flushes.count += 1;
+      if (!node._lastDamageRects) flushes.full += 1;
+    }
+    return out;
+  };
+  app._tickFrames();
+  return { native, app, root, wnd, node, flushes };
+}
+
+const box = (style) => h('box', { style });
+
+const flips = (native) => native.of('flip').length;
+
+// --- a live resize --------------------------------------------------------------
+
+test('a resize tick is one full frame, and its microtasks add none', async () => {
+  const { native, app, wnd, flushes } = await mount(
+    box({ flexGrow: 1, backgroundColor: '#3498db' }),
+  );
+  assert.equal(flushes.count, 1, 'the mount frame');
+  assert.equal(native.of('createSurfaceIOSurface').length, 2, 'one pair');
+
+  // five ticks of a drag, each answered from inside the delegate
+  for (let i = 1; i <= 5; i += 1) {
+    native.setWindowFrame(wnd._h, null, null, 100 + i * 4, 80 + i * 2);
+  }
+  assert.equal(flushes.count, 6, 'one flush per tick, synchronously');
+  assert.equal(flushes.full, 6, 'each a full frame');
+  assert.equal(
+    native.of('createSurfaceIOSurface').length,
+    12,
+    'a fresh pair per size',
+  );
+  // the drag ends: everything the ticks queued runs now
+  await tick();
+  await tick();
+  assert.equal(
+    flushes.count,
+    6,
+    'the release owes no frame — the ticks already painted every pixel',
+  );
+  assert.equal(wnd._holdPresent, false, 'nothing holds the present');
+  // the frame each tick scheduled before flushing early is still queued;
+  // it runs, finds nothing owed, and paints nothing
+  app._tickFrames();
+  assert.equal(flushes.count, 6, 'the queued callback is a no-op');
+  // every tick presented from inside the delegate — the same early present
+  // a press gets — so the release finds nothing left to put on glass
+  assert.equal(flips(native), 5, 'one present per tick');
+  wnd.present();
+  assert.equal(flips(native), 5, 'and nothing owed after');
+});
+
+test('the second flush a resize tick queues is one per burst, not one per tick', async () => {
+  const { native, app, wnd } = await mount(
+    box({ flexGrow: 1, backgroundColor: '#3498db' }),
+  );
+  const afterInput = [];
+  const original = app._afterInput.bind(app);
+  app._afterInput = () => {
+    afterInput.push('flush');
+    return original();
+  };
+  for (let i = 1; i <= 8; i += 1) {
+    native.setWindowFrame(wnd._h, null, null, 100 + i, 80);
+  }
+  assert.equal(afterInput.length, 8, 'one synchronous flush per tick');
+  await tick();
+  await tick();
+  // the React half of a resize commits on a microtask, and one flush
+  // behind it is what paints it — one, because inside AppKit's resize
+  // loop no microtask runs until the drag ends, and eight queued here
+  // were eight full frames on the mouse release
+  assert.equal(afterInput.length, 9, 'and one more for the whole burst');
+});
+
+test('a bounded flush onto a fresh surface asks for a full frame and holds the present until it lands', async () => {
+  const { native, app, wnd, node, flushes } = await mount(
+    h(
+      'box',
+      { style: { flexGrow: 1, backgroundColor: '#ffffff' } },
+      box({ width: 20, height: 20, backgroundColor: '#e74c3c' }),
+    ),
+  );
+  const inner = node.children[0].children[0];
+  // the window grows underneath the tree without the 'resize' listener
+  // hearing about it: the next frame paints a bounded claim onto a backing
+  // surface that is brand new and empty everywhere else
+  wnd._nativeResized({ width: 70, height: 60, x: 0, y: 0 });
+  inner.invalidate(false, inner, 'props');
+  app._tickFrames();
+  assert.equal(flushes.count, 2);
+  assert.ok(node._lastDamageRects, 'the claim was bounded');
+  assert.equal(
+    native.of('createSurfaceIOSurface').length,
+    4,
+    'the surface was replaced under it',
+  );
+  assert.equal(wnd._holdPresent, true, 'so the present is held');
+  const before = flips(native);
+  wnd.present();
+  assert.equal(flips(native), before, 'garbage never reaches the glass');
+  assert.equal(app._rafQueue.length, 1, 'a full frame is on its way');
+  app._tickFrames();
+  assert.equal(flushes.count, 3);
+  assert.equal(node._lastDamageRects, null, 'and it is a full one');
+  assert.equal(wnd._holdPresent, false);
+  wnd.present();
+  assert.equal(flips(native), before + 1, 'which presents');
+});
+
+test('a live resize lays out with the floors it has, and measures fresh ones once the drag ends', async () => {
+  const { native, app, wnd, node, flushes } = await mount(
+    h(
+      'box',
+      { style: { flexGrow: 1, flexDirection: 'row' } },
+      box({ flexGrow: 1, backgroundColor: '#3498db' }),
+      box({ flexGrow: 1, backgroundColor: '#e74c3c' }),
+    ),
+  );
+  let measured = 0;
+  const apply = node._applyContentFloors.bind(node);
+  node._applyContentFloors = (...a) => {
+    measured += 1;
+    return apply(...a);
+  };
+  // a drag: five live ticks, no pump between them
+  for (let i = 1; i <= 5; i += 1) {
+    native.setWindowFrame(wnd._h, null, null, 100 + i * 4, 80 + i * 2);
+  }
+  assert.equal(flushes.count, 6, 'every tick laid out and painted');
+  assert.equal(measured, 0, 'without measuring the floors again');
+  assert.equal(wnd.liveResizing, true);
+  assert.equal(node._floorsCatchUp, true, 'one catch-up frame is owed');
+  // the release: the pump runs, ends the live resize, ticks the frames
+  app._endLiveResizes();
+  app._tickFrames();
+  assert.equal(measured, 1, 'measured once, after the drag');
+  assert.equal(flushes.count, 7, 'one catch-up frame');
+  assert.equal(flushes.full, 7);
+  assert.equal(node._floorsCatchUp, false);
+  // a scripted resize — not live — measures on the spot
+  app._routeGeometry({
+    type: 'window-resize',
+    windowNumber: wnd.windowNumber,
+    width: 90,
+    height: 70,
+    x: 0,
+    y: 0,
+    live: false,
+  });
+  assert.equal(measured, 2);
+  assert.equal(flushes.count, 8);
+});
+
+test('a live resize over content the floors have not seen measures them', async () => {
+  const { native, app, wnd, node, root } = await mount(
+    box({ flexGrow: 1, backgroundColor: '#3498db' }),
+  );
+  let measured = 0;
+  const apply = node._applyContentFloors.bind(node);
+  node._applyContentFloors = (...a) => {
+    measured += 1;
+    return apply(...a);
+  };
+  // a row mounts mid-drag: its floor does not exist yet, and a frame laid
+  // out without one is the collapse the floors exist to prevent
+  root.render(
+    h(
+      'window',
+      { width: 100, height: 80 },
+      box({ flexGrow: 1, backgroundColor: '#3498db' }),
+      box({ height: 20, backgroundColor: '#2ecc71' }),
+    ),
+  );
+  native.setWindowFrame(wnd._h, null, null, 110, 90);
+  assert.equal(measured, 1, 'measured on the tick, live or not');
+  app._endLiveResizes();
+  app._tickFrames();
+  assert.equal(measured, 1, 'and nothing was owed after');
+});
+
+// --- a window nobody can see -----------------------------------------------------
+
+test('a window that is not on glass owes no frame and no present until it is back', async () => {
+  const { native, app, wnd, node, flushes } = await mount(
+    box({ flexGrow: 1, backgroundColor: '#3498db' }),
+  );
+  const inner = node.children[0];
+  native.visible = false; // ordered out, miniaturized, the app hidden
+  inner.invalidate(false, inner, 'props');
+  app._tickFrames();
+  assert.equal(flushes.count, 1, 'the frame waits');
+  assert.equal(app._rafQueue.length, 1, 'in the queue');
+  const before = flips(native);
+  // …and a paint that got in through another route stays off the glass
+  wnd._dirty = true;
+  wnd.present();
+  assert.equal(flips(native), before, 'no present while hidden');
+  assert.equal(wnd._dirty, true, 'but it is still owed');
+
+  native.visible = true;
+  app._tickFrames();
+  assert.equal(flushes.count, 2, 'one catch-up frame');
+  wnd.present();
+  assert.equal(flips(native), before + 1, 'presented on return');
+  assert.equal(app._rafQueue.length, 0);
+});
+
+test('an unmapped window is not on glass either', async () => {
+  const { app, node, flushes, wnd } = await mount(
+    box({ flexGrow: 1, backgroundColor: '#3498db' }),
+  );
+  wnd.unmap();
+  node.children[0].invalidate(false, node.children[0], 'props');
+  app._tickFrames();
+  assert.equal(flushes.count, 1);
+  wnd.map();
+  app._tickFrames();
+  assert.equal(flushes.count, 2);
+});
+
+// --- the cadence ------------------------------------------------------------------
+
+test('a frame lands on the first pump tick at or after the interval, not the one after', async () => {
+  const { app } = await mount(box({ flexGrow: 1 }));
+  app._frameInterval = 16;
+  app._pumpInterval = 8;
+  let ran = 0;
+  app._requestFrame(() => {
+    ran += 1;
+  });
+  // a tick that arrives 10ms after the last frame is the one before the
+  // interval — too early
+  app._rafLast = performance.now() - 10;
+  app._tickFrames();
+  assert.equal(ran, 0);
+  // 13ms is the tick that straddles it: with the gate at exactly 16 timer
+  // drift would push this frame to the tick after, 24ms out
+  app._rafLast = performance.now() - 13;
+  app._tickFrames();
+  assert.equal(ran, 1);
+});
+
+// --- the wheel ----------------------------------------------------------------------
+
+test('a wheel notch is answered on the event, like a press', async () => {
+  const { app, wnd, node, flushes } = await mount(
+    h(
+      'box',
+      { style: { flexGrow: 1, overflow: 'scroll' } },
+      ...Array.from({ length: 20 }, (_, i) =>
+        box({ height: 30, backgroundColor: i % 2 ? '#ffffff' : '#eeeeee' }),
+      ),
+    ),
+    { width: 100, height: 100 },
+  );
+  const scroller = node.children[0];
+  assert.equal(scroller.scrollY, 0);
+  app._route({
+    type: 'wheel',
+    windowNumber: wnd.windowNumber,
+    x: 50,
+    y: 50,
+    gx: 50,
+    gy: 50,
+    dx: 0,
+    dy: -3,
+    precise: false,
+    time: 1,
+  });
+  assert.ok(scroller.scrollY > 0, 'the notch scrolled');
+  assert.equal(
+    flushes.count,
+    2,
+    'and the frame went out before the route returned',
+  );
+});

--- a/test/paint-reach.test.js
+++ b/test/paint-reach.test.js
@@ -1,0 +1,244 @@
+// The two frame-cost rules a large tree lives by, on the headless mock:
+//
+//   - a subtree's paint reach (`_subtreeBounds`) is computed once and kept
+//     until something that moves it says so, because a bounded frame asks
+//     every subtree on the way to its rect and walking each one made a
+//     one-cell repaint cost the whole tree (1.25ms at 3,600 nodes, 0.37ms
+//     cached — scripts/bench/presenters.js, `tree`);
+//   - how many damage rects a frame keeps is the backend's call
+//     (`window.damageRectCap`): four where a pass costs the X server a clip
+//     mask, more where a pass is a client-side clip and a culled walk.
+import assert from 'node:assert';
+import { test } from 'node:test';
+import React from 'react';
+
+import { createRoot } from '../src/index.js';
+import { Node } from '../src/node.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+async function mount(children, props = {}) {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  root.render(h('window', { width: 300, height: 200, ...props }, children));
+  await tick();
+  const wnd = app.windows[0];
+  const node = wnd._reactX11Node;
+  const frame = () => {
+    node._scheduled = false;
+    node.flush();
+  };
+  frame();
+  return { app, root, wnd, node, frame };
+}
+
+const cell = (i) =>
+  h('box', {
+    key: i,
+    style: { flexGrow: 1, flexBasis: 0, backgroundColor: '#dddddd' },
+  });
+// gaps between the cells, so two claims never touch: adjacent claims merge
+// on their slop, and a diagonal of touching cells would coalesce into one
+const row = (r, cols) =>
+  h(
+    'box',
+    {
+      key: r,
+      style: { flexDirection: 'row', flexGrow: 1, flexBasis: 0, gap: 6 },
+    },
+    ...Array.from({ length: cols }, (_, c) => cell(`${r}:${c}`)),
+  );
+
+const grid = (rows, cols) =>
+  h(
+    'box',
+    { style: { flexGrow: 1, gap: 6 } },
+    ...Array.from({ length: rows }, (_, r) => row(r, cols)),
+  );
+
+// --- the paint reach ------------------------------------------------------------
+
+test('a frame of several rects computes each subtree reach once, not once per pass', async () => {
+  const { node, frame, root } = await mount(grid(6, 8));
+  const container = node.children[0];
+  const rows = container.children;
+  // two cells in two rows, far apart: two passes over the tree
+  const a = rows[0].children[1];
+  const b = rows[5].children[6];
+  let computed = 0;
+  const own = Node.prototype._ownPaintBounds;
+  Node.prototype._ownPaintBounds = function (...args) {
+    computed += 1;
+    return own.apply(this, args);
+  };
+  try {
+    a.invalidate(false, a, 'props');
+    b.invalidate(false, b, 'props');
+    assert.equal(node._damage.length, 2, 'two rects');
+    frame();
+    assert.equal(node._lastDamageRects.length, 2, 'two passes');
+    const nodes = 1 + 6 + 6 * 8; // container, rows, cells
+    assert.ok(
+      computed <= nodes + 2,
+      `${computed} reaches computed for ${nodes} nodes over two passes`,
+    );
+    // the same frame without the cache walks every subtree per pass — the
+    // count this test exists to keep from coming back
+    const cached = computed;
+    computed = 0;
+    for (const n of [container, ...rows]) n._paintBoundsCache = null;
+    const sub = Node.prototype._subtreeBounds;
+    Node.prototype._subtreeBounds = function () {
+      this._paintBoundsCache = null;
+      return sub.call(this);
+    };
+    try {
+      a.invalidate(false, a, 'props');
+      b.invalidate(false, b, 'props');
+      frame();
+    } finally {
+      Node.prototype._subtreeBounds = sub;
+    }
+    assert.ok(
+      computed > cached * 1.5,
+      `uncached: ${computed} against ${cached} — the cache is not engaged`,
+    );
+  } finally {
+    Node.prototype._ownPaintBounds = own;
+  }
+  await root.unmount();
+});
+
+test('the reach follows what moves it: layout, a hidden child, a style that reaches further', async () => {
+  const { node, frame, root } = await mount(grid(2, 2));
+  const container = node.children[0];
+  const [r0] = container.children;
+  const leaf = r0.children[0];
+  // prime the caches through a bounded frame
+  leaf.invalidate(false, leaf, 'props');
+  frame();
+  assert.ok(r0._paintBoundsCache, 'the row has a cached reach');
+  assert.ok(container._paintBoundsCache, 'and so does the container');
+
+  // a rect assigned by layout drops the chain above it, so what the row
+  // answers next is the union over the moved leaf
+  const wasRow = r0._subtreeBounds();
+  // …out below the row's bottom edge (still inside the window, so the
+  // frames after stay bounded), where only the leaf can carry the reach
+  const below = r0.abs.y + r0.abs.height + 5;
+  leaf._assignAbs(leaf.abs.x, below, leaf.abs.width, leaf.abs.height);
+  assert.equal(leaf._paintBoundsCache, null);
+  const nowRow = r0._subtreeBounds();
+  assert.notStrictEqual(nowRow, wasRow, 'the row recomputed');
+  assert.equal(
+    nowRow.y + nowRow.height,
+    below + leaf.abs.height,
+    'over the moved leaf',
+  );
+
+  leaf.invalidate(false, leaf, 'props');
+  frame();
+  assert.ok(r0._paintBoundsCache);
+  // a node announcing a change of its own drops it too — the chain above
+  // stays dropped, and the node's own is re-derived for the claim it makes
+  leaf.invalidate(false, leaf, 'props');
+  assert.equal(r0._paintBoundsCache, null);
+  assert.equal(container._paintBoundsCache, null);
+
+  frame();
+  // a state flip reaches the focus ring's extent, stateful or not
+  leaf.invalidate(false, leaf, 'props');
+  frame();
+  assert.ok(r0._paintBoundsCache);
+  leaf.setStyleState(':focus-visible', true);
+  assert.equal(r0._paintBoundsCache, null);
+
+  // a style swap that reaches further — a shadow — is dropped by the swap
+  frame();
+  leaf.invalidate(false, leaf, 'props');
+  frame();
+  assert.ok(r0._paintBoundsCache);
+  const before = leaf._subtreeBounds();
+  leaf.applyProps(
+    {
+      ...leaf.props,
+      style: { ...leaf.props.style, boxShadow: '0 0 8px #000' },
+    },
+    leaf.props,
+  );
+  const after = leaf._subtreeBounds();
+  assert.ok(after.width > before.width, 'the shadow widened the reach');
+  await root.unmount();
+});
+
+test('a pure scroll carries the cached reach along instead of dropping it', async () => {
+  const { node, frame, root } = await mount(
+    h(
+      'box',
+      { style: { flexGrow: 1, overflow: 'scroll' } },
+      ...Array.from({ length: 30 }, (_, i) =>
+        h(
+          'box',
+          { key: i, style: { height: 20, backgroundColor: '#eeeeee' } },
+          h('box', { style: { width: 10, height: 10 } }),
+        ),
+      ),
+    ),
+  );
+  const scroller = node.children[0];
+  const row3 = scroller.children[3];
+  row3.invalidate(false, row3, 'props');
+  frame();
+  const cached = row3._paintBoundsCache;
+  assert.ok(cached, 'a row with a child has a union cached');
+  const y = cached.y;
+  scroller.scrollTo({ y: 15 });
+  frame();
+  assert.strictEqual(row3._paintBoundsCache, cached, 'the same object');
+  assert.equal(cached.y, y - 15, 'moved with the scroll');
+  assert.equal(row3.abs.y, y - 15);
+  await root.unmount();
+});
+
+// --- the damage rect cap ---------------------------------------------------------
+
+test('the backend says how many damage rects a frame keeps; four without a word', async () => {
+  const { node, wnd, frame, root } = await mount(grid(6, 8));
+  const rows = node.children[0].children;
+  const claim = () => {
+    for (let r = 0; r < 6; r += 1) {
+      const c = rows[r].children[r];
+      c.invalidate(false, c, 'props');
+    }
+  };
+  claim();
+  assert.equal(node._damage.length, 4, 'an ntk window keeps the X11 cap');
+  frame();
+
+  wnd.damageRectCap = 16;
+  claim();
+  assert.equal(
+    node._damage.length,
+    6,
+    'a backend that can afford a pass a rect keeps them all',
+  );
+  frame();
+  assert.equal(
+    node._lastDamageRects.length,
+    6,
+    'and paints them as six passes',
+  );
+
+  // the hint is read as a positive integer, nothing else
+  wnd.damageRectCap = 0;
+  claim();
+  assert.equal(node._damage.length, 4);
+  frame();
+  wnd.damageRectCap = 'many';
+  claim();
+  assert.equal(node._damage.length, 4);
+  frame();
+  await root.unmount();
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -1018,6 +1018,14 @@ async function main() {
   // the backend ladder: auto (the default), or one by name
   const native = await createRoot({ backend: 'cocoa' });
   await native.unmount();
+  await (
+    await createRoot({
+      backend: 'cocoa',
+      cocoa: { presenter: 'surface', frameInterval: 8, pumpInterval: 4 },
+    })
+  ).unmount();
+  // @ts-expect-error -- not a presenter
+  await createRoot({ cocoa: { presenter: 'metal' } });
   await (await createRoot({ backend: 'auto' })).unmount();
   await (await createRoot({ backend: 'x11', display: ':1' })).unmount();
   // @ts-expect-error -- not a backend


### PR DESCRIPTION
## Why

The stress scenarios this PR adds to `npm run bench:presenters` measure "state update → pixels" and "interaction → pixels" inside a tree the size of an application screen: 1,200 labelled boxes, 3,662 nodes, on the cocoa surface presenter. They ranked the frame costs, and five of the largest were fixable without touching the layout floors themselves. Full write-up, with reproduction commands, in docs/macos.md under "Measured: the frame clock and the large tree".

## What the numbers say

Surface presenter, 900x700 at 2x, M1 Pro, 4s per cell, driver ticks at 62.5Hz. Median flush unless said otherwise.

| scenario | before | after |
| --- | --- | --- |
| `tree`: one memoized cell per tick | 1.25ms | 0.35ms |
| `tiny`: one of 5,000 cells, 14k nodes | 7.2ms p95 | 1.2ms p95 |
| `multi`: 12 scattered cells per tick | 11.9ms, 1,470kpx repainted | 2.8ms, 264kpx |
| `press`: input → flush | 4.3ms p50, 10.2 p95 | 2.6ms p50, 8.7 p95 |
| `scroll`: wheel notch, input → flush | 15.2ms p50 | 1.9ms p50 |
| `resize`: one tick of a 40-tick drag | 71ms, 2 full frames each, then 80 frames on the mouse release | 28ms, 1 frame, then 1 catch-up frame |
| `occluded`: hidden window, a cell per tick | 207 frames, 50% of a core | 0 frames |
| `layout`: every cell reflows per tick | 44ms, 18fps | 44ms, unchanged |

The resize freeze had a concrete cause: inside AppKit's resize loop no microtask runs until the mouse is released, and every tick queued two of them, a redundant full-frame invalidate and a second flush, so a drag left dozens of 44ms frames to run on the release.

## What changed

- **The paint reach is cached** in `src/nodes.js`. A bounded frame asked every subtree on the way to its rect whether it reached in, and each answer walked the subtree, so a one-cell repaint cost the whole tree. The union is kept until something that moves it announces itself: layout, a child-list change, a style swap, a state flip, `invalidate`. Shared with X11; the protocol bench is unchanged by it. `REACT_X11_NO_BOUNDS_CACHE=1` is the escape hatch, documented in docs/debugging.md.
- **The damage rect cap is the backend's**, `window.damageRectCap`. Four rects is what a pass costs the X server; a cocoa pass is one CoreGraphics clip and a culled walk, so its window keeps sixteen.
- **A resize tick is one frame.** A replaced backing surface asks for a full frame only when the flush that found it was bounded, and holds the present until that frame lands; the geometry microtask flush is coalesced per burst.
- **A live resize defers the content floors** and measures them once after the drag, under `window.liveResizing`, which only the cocoa window sets from AppKit's flag and the pump clears. A content change mid-drag takes the measured path. X11 never sets the flag.
- **A window that is not on glass owes nothing**: frames and presents wait until it is back. The frame gate lands on the first pump tick at or after the interval rather than alternating between the tick before and the one after; the wheel is answered on the event, like a press, because AppKit already delivers scroll events at the display's rate. `createRoot({ cocoa: { frameInterval, pumpInterval, presenter } })` is typed and documented; `--frame=8` on this 120Hz panel runs transitions at 102fps instead of 51 and halves hover latency.

## Keeping it so

- `npm run bench:presenters -- --check` is a **structural** gate, `scripts/bench/presenters-gate.json`: full-window frames, the share of the window one cell repaints, frames per resize tick, backing surfaces per tick, frames for a hidden window. Never milliseconds, so it reads the same on a shared runner.
- `npm run bench:touched` reads the diff against the base, matches it against the hot-path list in `scripts/bench/touched.js`, and runs only the gates the change owes: the X11 protocol and pixel gates for a `nodes.js` change, the cocoa gate as well on a mac, nothing for a docs change. `--dry` says which.
- CI: a new `bench-cocoa` job on `macos-14` runs the touched runner against the PR base and appends the timing table to the job summary; a push to master runs every scenario. The Linux `bench` job is unchanged.
- AGENTS.md carries the policy: what counts as a hot path, what to run, and to put before/after rows in a PR that means to move the frame clock.

## Validation

- `npm test`: 1,750 pass; the six failures are the known macOS appearance-ladder cases that need the desktop. New: `test/cocoa-frames.test.js` over a fake bridge, `test/paint-reach.test.js` on the mock.
- `npm run bench -- --check` and `npm run bench:pixels -- --check`: no X11 regression.
- `npm run stress:check`: every panel rendered, damage bounded.
- A live XQuartz drive of the stress app through ten resize requests and three tab clicks: 17 frames, no errors, the render correct.
- `npm run bench:presenters -- --check`: all 26 rules hold.

## Follow-ups

Ranked in docs/macos.md and in #442: a full relayout of a large tree is still 44ms and half of it is the content floors; the swapchain still allocates two IOSurfaces per resize tick, freed on GC, which is windowkit/appkit#7; the frame interval is a guess at the display, windowkit/appkit#8; a window behind another app's window still paints, windowkit/appkit#9; the paint cache is off on this backend.
