### PR TITLE
perf(cocoa): release on the flip, the display's frame rate, occlusion, the paint cache

### DIFF
--- a/docs/macos.md
+++ b/docs/macos.md
@@ -649,12 +649,14 @@ callbacks fire on link ticks, commits wrap in explicit `CATransaction`s,
 and the "answer the input" early-flush (`flushPendingFrames` on handler
 unwind) maps to committing the transaction before the pump returns to
 AppKit — same policy, new mechanism. What runs today is the timer pump
-with a frame interval over it (`frameInterval`, 16ms by default; the gate
-is the interval less half a pump, so a frame lands on the first tick at or
-after it rather than alternating between the tick before and the tick
-after), discrete input and the wheel flushed on the event, and a
-window that is not on glass deferring its frames — see "Measured" below
-for what each of those was worth.
+with a frame interval over it (`frameInterval`; by default the period of
+the display each window is on, as `listScreens` reports it — 8.3ms on a
+120Hz panel, 16.7 on a 60Hz monitor — and the gate is the interval less
+half a pump, so a frame lands on the first tick at or after it rather
+than alternating between the tick before and the tick after), discrete
+input and the wheel flushed on the event, and a window that is not on
+glass deferring its frames — see "Measured" below for what each of those
+was worth.
 
 ## Native controls
 
@@ -1154,10 +1156,10 @@ Five changes, each fenced by a test:
   the measured path.
 - **A window nobody can see owes nothing** (`CocoaWindow._visible`): frames
   for a window that is ordered out or miniaturized wait in the queue and
-  its present waits with them; one catch-up frame when it is back. Occlusion
-  by another application's window is not read yet — the bridge does not
-  forward `windowDidChangeOcclusionState`, and that is the one place to add
-  it. The frame gate also moved from "one interval since the last frame" to
+  its present waits with them; one catch-up frame when it is back. (A
+  window entirely behind another application's window joined that rule in
+  the pass after this one — see below.) The frame gate also moved from
+  "one interval since the last frame" to
   "the first pump tick at or after it", which took a 16/24/16/24ms cadence
   to a steady 16 (52 → 56fps against the 62.5Hz driver), and the wheel is
   answered on the event like a press — AppKit already delivers scroll
@@ -1172,6 +1174,74 @@ hidden window against `scripts/bench/presenters-gate.json`, and
 that reaches a hot path. CI's `bench-cocoa` job does the same on a macOS
 runner.
 
+**What was left, in order of what it cost** — the list that became #442,
+and the pass below.
+
+## Measured: after the frame-clock pass
+
+Written 2026-09-03 against react-x11 2.5.0 and `@windowkit/appkit` 0.4.0
+(windowkit/appkit#10, which shipped the bridge half of #442: `releaseSurface`,
+every surface's bytes accounted to V8, `fps` on `listScreens`, and
+`window-occlusion` events), same machine, same bench, the surface presenter.
+Four of the six items are closed by it; the two that remain are the
+renderer's own and are listed at the end.
+
+| what                                                          | before                  | after                 |
+| ------------------------------------------------------------- | ----------------------- | --------------------- |
+| a 40-tick resize burst, no yield between ticks — rss during   | +572 to +655MB          | +12 to +14MB          |
+| `anim` on the 120Hz panel                                     | 55.7fps, 32% cpu (16ms) | 113.5fps, 49% (8.3ms) |
+| `hover` on the 120Hz panel, input → flush p50 / p95           | 7.2ms / 16.8            | 3.1 / 9.2             |
+| `icons` — 300 mono icons re-tinted per tick, flush avg / p95  | 2.98ms / 3.35, 72% cpu  | 2.07 / 2.42, 67%      |
+| `covered` — the big tree behind another window, cell per tick | a frame per tick        | 0 frames              |
+
+- **The retired pair is released on the flip** (`CocoaWindow._releaseBacking`,
+  `releaseSurface`). A resize tick allocates two window-sized IOSurfaces and
+  used to leave the two it replaced to their handles' finalizers — which run
+  on the event loop, and inside AppKit's resize loop the event loop does not
+  run, so a drag held every pair it ever made until the release. The bridge's
+  accounting alone (`napi_adjust_external_memory`) makes the collection
+  prompt once the loop is back; the explicit free is what bounds the peak
+  while it is not, which is the number in the table. The row is a script
+  driving forty `setWindowFrame`s synchronously, the way the modal loop
+  delivers them; the bench's `resize` cell yields between ticks and its rss
+  column is collection noise either way now. `CocoaSurface.destroy()` and
+  the layer presenter's rasters release the same way, and a bridge without
+  the verb gets the drop it always had. `test/cocoa-frames.test.js`,
+  `test/cocoa-surface.test.js`.
+- **Each window paces itself on its own display** (`CocoaApp.frameIntervalFor`,
+  `_frameDue`). The default interval is `1000 / fps` of the screen under the
+  window's centre, re-read when it moves; `createRoot({ cocoa: { frameInterval
+} })` still overrides it for every window. The frame queue keeps a clock per
+  window, so a window on the 120Hz panel paints every refresh while one on a
+  60Hz monitor paints every other pump tick. What it is worth is the `anim`
+  and `hover` rows: twice the frames for half again the CPU, and input →
+  flush halved, on the panel that can show it. One honest limit: the 8ms
+  pump quantizes the cadence, so a 75Hz monitor (13.3ms) paints at 62.5fps
+  — the gate is the interval less half a pump, and 9.3ms falls on the 16ms
+  tick. `pumpInterval` is the seam; the display link (§"Input and the run
+  loop") is the mechanism that would make the period exact.
+- **A window entirely behind another application's window owes nothing**
+  (`CocoaApp._routeOcclusion`, `CocoaWindow._visible`). AppKit's
+  `windowDidChangeOcclusionState` arrives as `window-occlusion`; off, the
+  window's frames wait in the queue and its present with them, exactly as an
+  ordered-out window's do; on, the next pump tick runs one catch-up frame.
+  `map()` resets the flag, since a show is a claim to be on glass and AppKit
+  corrects it a pump later. The bench's new `covered` scenario opens a window
+  of our own over the tree and is in the gate at zero frames. What is not
+  free while covered is the React commit itself: the scenario's 41% CPU is
+  `root.render` of a 3,662-node tree per tick, and no frame clock can take
+  that.
+- **The paint cache is on** (`paintCacheFor` accepts an app with
+  `createSurface`; `PaintCache.coverage`). Entries are `CocoaSurface`s
+  through `react-x11/ntk`'s `Surface`, composited with one `ctxDrawSurface`.
+  This backend has no coverage surface, so a mono drawing is cached as
+  argb32 with its colour in the key — `paintCached(ctx, box, ink)` now says
+  which colour to paint in — one entry per colour rather than one for all of
+  them, still one render per colour instead of one per cell per frame. A
+  blurred shadow, whose blur is a pass over the mask, stays live. The `icons`
+  row is the gain, and the larger cost left in that scenario is the React
+  re-render of 300 unmemoized components. `test/cocoa-paint-cache.test.js`.
+
 **What is left, in order of what it costs:**
 
 1. **A full relayout of a large tree: 44ms at 3,600 nodes, 320ms at
@@ -1185,31 +1255,14 @@ runner.
    below it — is the change that would take a panel toggle or a theme
    switch on a big screen from 18fps to 40. Bounded, not small; it touches
    the passes `test/content-floors.test.js` pins.
-2. **The swapchain is reallocated per resize tick** — two window-sized
-   IOSurfaces, 20MB at 900x700@2x, freed on GC. Allocation is 0.1ms; the
-   cost is memory (`rss +80MB` over a 40-tick drag) and the GC that
-   eventually returns it. Two fixes, both in the bridge: report native
-   memory to V8 (`napi_adjust_external_memory`) so collection is prompt, or
-   a `releaseSurface` verb so the window frees the old pair on the flip.
-   Over-allocating the chain to a rounded-up size would need
-   `contentsRect` on the layer, which `setLayerProps` does not take yet.
-3. **The frame interval is a guess at the display.** 16ms is right on a
-   60Hz panel and half the rate of a 120Hz one; `createRoot({ cocoa: {
-frameInterval: 8 } })` is the seam, and on this 120Hz panel it is worth
-   taking: `anim` runs at 102fps instead of 51 for 40% of a core instead of
-   36, and hover's input → flush goes from 5.4ms p50 / 18 p95 to 2.8 / 10
-   (`npm run bench:presenters -- --frame=8`). The honest default is the
-   display's own period — `NSScreen.maximumFramesPerSecond`, which
-   `listScreens` should report.
-4. **The paint cache is off on this backend** (`paintCacheFor` gates on an
-   X `Render` extension), so 300 mono icons re-tinted per tick are 300
-   live canvas paints (`icons`: 2.9ms). `CocoaSurface` exists now; wiring
-   the cache over `app.createSurface` (argb only — the a8 coverage entries
-   need a tint in the key here) is the remaining step.
-5. **Nothing is drawn at a level of detail.** `tiny` shapes and draws 5,000
+2. **Nothing is drawn at a level of detail.** `tiny` shapes and draws 5,000
    five-pixel labels nobody can read. A box smaller than a pixel already
    costs one fill; text below a legible size could cost one strip. Not
-   started.
+   started, and the win is bounded by item 1 for the relayout half.
+3. **The pump quantizes the frame period** (above): a display whose period
+   is not a multiple of 8ms paints at the tick after it. A finer pump costs
+   input polling; the display link costs the run-loop work §"Input and the
+   run loop" describes.
 
 ## Testing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "node": ">=20.19"
       },
       "optionalDependencies": {
-        "@windowkit/appkit": "^0.3.0",
+        "@windowkit/appkit": "^0.4.0",
         "dbus-native": "^0.15.1",
         "x11-dri": "^0.7.0"
       },
@@ -1514,9 +1514,9 @@
       }
     },
     "node_modules/@windowkit/appkit": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@windowkit/appkit/-/appkit-0.3.0.tgz",
-      "integrity": "sha512-2d/mQcb5vEAR5QWQeRfp9bLFaEK56neOSjiUC72Nk7ekJ+eTMrzSYxzwkXpsbWqOSUQ4xHUpuE45oJuScNzdfQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@windowkit/appkit/-/appkit-0.4.0.tgz",
+      "integrity": "sha512-SAOOsXZ0MydSVRUlLfmM5FcXL0crzE8P4Jj5Qq9SGh2AXoAW1GipHYjI9tR3ozdHXM+pFVmSb6dbas+tLeQ6uQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "yoga-layout": "^3.2.1"
   },
   "optionalDependencies": {
-    "@windowkit/appkit": "^0.3.0",
+    "@windowkit/appkit": "^0.4.0",
     "dbus-native": "^0.15.1",
     "x11-dri": "^0.7.0"
   },

--- a/scripts/bench/presenters-gate.json
+++ b/scripts/bench/presenters-gate.json
@@ -27,6 +27,7 @@
       "maxSurfacesPerResize": 2
     },
     "occluded": { "maxFrames": 0 },
+    "covered": { "maxFrames": 0 },
     "idle": { "maxFrames": 0 }
   }
 }

--- a/scripts/bench/presenters.js
+++ b/scripts/bench/presenters.js
@@ -29,6 +29,9 @@
 //   npm run bench:presenters -- --columns=surface   # one presenter only
 //   npm run bench:presenters -- --x11           # extra column via $DISPLAY
 //   npm run bench:presenters -- --cells=2400    # bigger stress trees
+//   npm run bench:presenters -- --at=200,200    # the window at a point (on
+//                                               # the screen whose rate you
+//                                               # mean to measure)
 //   npm run bench:presenters -- --prof --scenario=tree --columns=surface
 //                                               # a .cpuprofile per cell
 //   npm run bench:presenters -- --shots         # snapshot each run's last
@@ -69,6 +72,10 @@ const CELLS = Number(flag('cells', 1200));
 const COLUMNS = flag('columns', null);
 const SIZE = flag('size', '900x700');
 const FRAME = flag('frame', null); // cocoa frame interval, ms
+// --at=x,y: where to put the window, in points, top-left global — on a
+// desk with a 120Hz panel and a 75Hz monitor the default frame interval is
+// the display's, so which screen the window lands on is part of the result
+const AT = flag('at', null);
 // --check: the structural gate (scripts/bench/presenters-gate.json) — counts
 // and areas the frame clock and the damage model must keep, judged per
 // scenario and never in milliseconds, so the answer is the same on a shared
@@ -975,6 +982,38 @@ const SCENARIOS = {
     },
   },
 
+  /** The same tree and tick, in a window that is on screen but entirely
+   *  behind another window — one of our own, opened over it in setup, the
+   *  way another application's would sit. AppKit reports the difference
+   *  (`windowDidChangeOcclusionState`, bridge 0.4) and a covered window
+   *  owes what a hidden one does: no frames, no presents. */
+  covered: {
+    cocoaOnly: true,
+    tree: (tick) =>
+      windowOf(
+        [header('covered'), grid({ hot: hotOne(tick) })],
+        'bench covered',
+      ),
+    setup(ctx) {
+      // points, top-left global; padded so the cover takes the title bar
+      // and the shadow with it, whatever AppKit added around the content
+      const f = ctx.native.getWindowFrame(ctx.wnd._h);
+      const pad = 80;
+      const cover = ctx.native.createWindow2({
+        x: f.x - pad,
+        y: f.y - pad,
+        width: f.width + 2 * pad,
+        height: f.height + 2 * pad,
+        title: 'bench cover',
+        kind: 'normal',
+        resizable: false,
+        backgroundColor: [0.25, 0.25, 0.25, 1],
+      });
+      ctx.native.showWindow(cover, true);
+      ctx.cover = cover; // kept so it is not collected out from over us
+    },
+  },
+
   /** Nothing happens: the big tree on screen, no ticks. What the app costs
    *  at rest is the pump and nothing else — `cpu` and `pump` are the
    *  columns, and `frames` must be zero. */
@@ -1114,6 +1153,10 @@ async function runChild() {
 
   const wnd = cocoa ? [...app._windows.values()][0] : null;
   const win = node.window;
+  if (AT && wnd) {
+    const [x, y] = AT.split(',').map(Number);
+    wnd.move(x * wnd.scale, y * wnd.scale);
+  }
   {
     const flush = node.flush.bind(node);
     node.flush = (...a) => {
@@ -1307,6 +1350,7 @@ function runCell(name, env) {
       `--cells=${CELLS}`,
       `--size=${SIZE}`,
       ...(FRAME ? [`--frame=${FRAME}`] : []),
+      ...(AT ? [`--at=${AT}`] : []),
       ...(SHOTS ? ['--shots'] : []),
     ],
     {

--- a/src/cocoa/app.js
+++ b/src/cocoa/app.js
@@ -29,12 +29,13 @@ import { CocoaWindow } from './window.js';
 import { decodeKey, modifierMask } from './keymap.js';
 import { loadNative } from './native.js';
 
-// The frame interval: how often a scheduled frame may paint, in ms. 16 is a
-// 60Hz display's period. `createRoot({ cocoa: { frameInterval } })` sets it
-// — 8 on a 120Hz panel paints every refresh — and the honest default is the
-// display's own period, which the bridge does not report yet
-// (NSScreen.maximumFramesPerSecond); until it does, 60Hz is the floor every
-// Mac clears rather than a ceiling half of them hit.
+// The frame interval: how often a scheduled frame may paint, in ms. The
+// default is the period of the display the window is on — `listScreens`
+// reports each panel's `fps` (NSScreen.maximumFramesPerSecond, bridge 0.4),
+// so a 120Hz panel paints every 8.3ms and a 60Hz monitor every 16.7 —
+// and `createRoot({ cocoa: { frameInterval } })` overrides it for every
+// window. 16 stands in where the OS cannot say (`fps: 0`) and under a
+// bridge that does not report it: a 60Hz floor every Mac clears.
 const RAF_INTERVAL_MS = 16;
 const PUMP_INTERVAL_MS = 8;
 
@@ -45,8 +46,11 @@ export class CocoaApp {
     this._windows = new Map(); // windowNumber -> CocoaWindow
     this._grabWindow = null;
     this._rafQueue = []; // [{ cb, wnd }]
+    // the app's own frame clock, for a frame no window owns (a pane's)
     this._rafLast = 0;
-    this._frameInterval = options.cocoa?.frameInterval ?? RAF_INTERVAL_MS;
+    // an explicit interval applies to every window; null means each
+    // window paces itself on its own display (`frameIntervalFor`)
+    this._frameInterval = options.cocoa?.frameInterval ?? null;
     this._pumpInterval = PUMP_INTERVAL_MS;
     this._geometryFlushQueued = false;
     this._shadowStale = new Set();
@@ -254,6 +258,35 @@ export class CocoaApp {
   }
 
   /**
+   * How often `wnd` may paint, in ms: the explicit `frameInterval` when the
+   * root was given one, else the period of the screen under the window's
+   * centre — the display's own rate is the only honest cadence, and on a
+   * desk with a 120Hz panel and a 60Hz monitor the two windows differ. A
+   * window on no screen (mid-drag between two, or off the edge) and a
+   * screen the OS reports no rate for take the primary's, then 16ms.
+   */
+  frameIntervalFor(wnd) {
+    if (this._frameInterval != null) return this._frameInterval;
+    const s = this.scale;
+    const screens = this._screens ?? [];
+    let screen = null;
+    if (wnd) {
+      const cx = (wnd.x + wnd.width / 2) / s;
+      const cy = (wnd.y + wnd.height / 2) / s;
+      screen =
+        screens.find(
+          (sc) =>
+            cx >= sc.x &&
+            cx < sc.x + sc.width &&
+            cy >= sc.y &&
+            cy < sc.y + sc.height,
+        ) ?? null;
+    }
+    const fps = screen?.fps || screens[0]?.fps || 0;
+    return fps > 0 ? 1000 / fps : RAF_INTERVAL_MS;
+  }
+
+  /**
    * The pane's end of the frame channel (childmain hands it over,
    * feature-detected so the X11 pane path never notices): geometry and
    * input come in, pane-present goes out.
@@ -331,27 +364,46 @@ export class CocoaApp {
     return this._rafQueue.length;
   }
 
+  /**
+   * Whether `clock` — a window, or the app for a frame no window owns —
+   * is due a frame at `now`, and if so, stamps it. The gate is the interval
+   * less half a pump, so a frame lands on the first pump tick at or after
+   * the interval. Gated at exactly one interval, timer drift put every
+   * other frame a tick late — 16ms frames arriving as 16, 24, 16, 24 —
+   * which a 60Hz display shows as a 50fps stutter, and which the presenter
+   * bench measured as 52fps against a 62.5Hz driver.
+   */
+  _frameDue(clock, now) {
+    const interval =
+      clock === this ? this.frameIntervalFor(null) : clock._frameInterval;
+    if (now - clock._rafLast < interval - this._pumpInterval / 2) return false;
+    clock._rafLast = now;
+    return true;
+  }
+
   _tickFrames() {
     if (!this._rafQueue.length) return;
     const now = performance.now();
-    // The gate is the interval less half a pump, so a frame lands on the
-    // first pump tick at or after the interval. Gated at exactly one
-    // interval, timer drift put every other frame a tick late — 16ms frames
-    // arriving as 16, 24, 16, 24 — which a 60Hz display shows as a 50fps
-    // stutter, and which the presenter bench measured as 52fps against a
-    // 62.5Hz driver.
-    if (now - this._rafLast < this._frameInterval - this._pumpInterval / 2) {
-      return;
-    }
-    this._rafLast = now;
+    // Each window keeps its own clock, so a window on a 120Hz panel paints
+    // every refresh while one on a 60Hz monitor paints every other pump
+    // tick. Decided once per clock per tick: every frame a window queued
+    // runs when it is due, not just the first.
+    const due = new Map();
     const queue = this._rafQueue;
     this._rafQueue = [];
     for (const entry of queue) {
+      const clock = entry.wnd ?? this;
+      if (!due.has(clock)) due.set(clock, this._frameDue(clock, now));
+      if (!due.get(clock)) {
+        this._rafQueue.push(entry);
+        continue;
+      }
       // A window nobody can see owes no frame: its callback waits here until
       // it is back on glass, and the damage it answers accumulates on the
       // node — one catch-up frame then, instead of a full paint per tick
       // into a backing store no one reads. `_visible` is the window's own
-      // rule (mapped, not ordered out, not miniaturized).
+      // rule (mapped, not ordered out, not miniaturized, not entirely
+      // behind another application's window).
       if (entry.wnd && !entry.wnd._visible()) {
         this._rafQueue.push(entry);
         continue;
@@ -405,6 +457,8 @@ export class CocoaApp {
         return this._routeFocus(ev, 'focus');
       case 'window-blur':
         return this._routeFocus(ev, 'blur');
+      case 'window-occlusion':
+        return this._routeOcclusion(ev);
       case 'menu-activate':
         this._activeGlobalMenu?.activate(ev.id);
         return this._afterInput();
@@ -557,6 +611,19 @@ export class CocoaApp {
         if (!this._closed) this._afterInput();
       });
     }
+  }
+
+  /**
+   * `windowDidChangeOcclusionState`: `visible` is "some pixel of the window
+   * is on glass". Off, the window's frames wait in the queue and its
+   * present waits with them (`CocoaWindow._visible`); on, the next pump
+   * tick runs the catch-up frame and puts it on glass — no early flush,
+   * since nothing was asked for and the pump is at most one interval away.
+   */
+  _routeOcclusion(ev) {
+    const wnd = this._window(ev);
+    if (!wnd || wnd.destroyed) return;
+    wnd._occluded = ev.visible === false;
   }
 
   _routeClose(ev) {

--- a/src/cocoa/presenter.js
+++ b/src/cocoa/presenter.js
@@ -354,6 +354,9 @@ class RasterState {
 
   ensure(presenter, width, height, scale) {
     if (!this.surface || this.width !== width || this.height !== height) {
+      // the layer holds its own copy of what it shows, so the bitmap a
+      // resize retires can go now rather than with the handle's finalizer
+      this.release(presenter.native);
       this.surface = presenter.native.createSurface(width, height, scale);
       this.width = width;
       this.height = height;
@@ -368,6 +371,16 @@ class RasterState {
       }
     }
     return this.ctx;
+  }
+
+  /** Free the bitmap now (bridge 0.4's `releaseSurface`); older bridges
+   * free it from the handle's finalizer, and this is then just the drop. */
+  release(native) {
+    const surface = this.surface;
+    this.surface = null;
+    if (surface && typeof native.releaseSurface === 'function') {
+      native.releaseSurface(surface);
+    }
   }
 }
 
@@ -417,11 +430,12 @@ export class CocoaLayerPresenter {
         if (!seen.has(node)) {
           visual.destroy();
           this.visuals.delete(node);
-          this.rasters.delete(node);
+          this._dropRaster(node);
           const bars = this.bars.get(node);
           if (bars) {
             for (const entry of bars.values()) {
               native.removeFromSuperlayer(entry.layer);
+              entry.raster.release(native);
             }
             this.bars.delete(node);
           }
@@ -432,6 +446,13 @@ export class CocoaLayerPresenter {
     }
     this.dirty.clear();
     this.dirtyAll = false;
+  }
+
+  _dropRaster(node) {
+    const raster = this.rasters.get(node);
+    if (!raster) return;
+    raster.release(this.native);
+    this.rasters.delete(node);
   }
 
   _syncWindowBackground(windowNode) {
@@ -460,7 +481,7 @@ export class CocoaLayerPresenter {
     let visual = this.visuals.get(node);
     if (visual && visual.isRaster !== wantsRaster) {
       visual.destroy();
-      this.rasters.delete(node);
+      this._dropRaster(node);
       visual = null;
     }
     if (!visual) {

--- a/src/cocoa/surface.js
+++ b/src/cocoa/surface.js
@@ -33,9 +33,11 @@
 //   composite differently.
 // - **No Picture.** `picture()` is X's compositing handle; here a surface
 //   composites through `ctx.drawImage`, and asking for the picture says so.
-// - **Freed on collection.** The bridge frees the bitmap from the handle's
-//   finalizer; `destroy()` drops the handle and refuses further use, so the
-//   memory goes with the next GC rather than on the call.
+// - **Freed on `destroy()`.** The bridge's `releaseSurface` (0.4) frees the
+//   bitmap on the call and hands its bytes back to V8's account; the
+//   handle's finalizer stays as the safety net for a surface that is
+//   dropped without one. Under an older bridge the memory goes with the
+//   next GC, as it always did.
 //
 // Units are device pixels, like the window's backing store: a caller sizes
 // one from `contentBox()` numbers, which are device pixels already
@@ -217,8 +219,12 @@ export class CocoaSurface {
   destroy() {
     if (this._destroyed) return;
     this._destroyed = true;
+    const handle = this._surfaceHandle;
     this._surfaceHandle = null;
     this._ctx = null;
+    if (typeof this._native.releaseSurface === 'function') {
+      this._native.releaseSurface(handle);
+    }
   }
 
   [Symbol.dispose]() {

--- a/src/cocoa/window.js
+++ b/src/cocoa/window.js
@@ -26,6 +26,12 @@ export class CocoaWindow {
     this._surfaceGen = 0;
     this._ctx = null;
     this._dirty = false;
+    // AppKit's occlusion state, as the delegate reports it (`_visible`).
+    this._occluded = false;
+    // This window's frame clock: when it last painted, and how often it may
+    // — the period of the display it is on (`_refreshFrameInterval`).
+    this._rafLast = 0;
+    this._frameInterval = 0;
 
     const s = this.scale;
     // Snapped to whole POINTS: AppKit rounds window sizes to the point
@@ -73,6 +79,7 @@ export class CocoaWindow {
     this.windowNumber = this._native.windowNumber(this._h);
     this._layer = this._native.windowRootLayer(this._h);
     this._refreshOrigin();
+    this._refreshFrameInterval();
     if (attributes.sizeHints) this.setSizeHints(attributes.sizeHints);
 
     // How many damage rects a frame may keep before merging them (nodes.js,
@@ -124,6 +131,18 @@ export class CocoaWindow {
     this._screenOrigin = { x: this.x, y: this.y };
   }
 
+  /**
+   * How often this window may paint: the period of the display it is on,
+   * asked of the app (`frameIntervalFor`), which reads the screen list the
+   * bridge reported. Re-read whenever the window moves, because a drag
+   * from a 120Hz panel to a 60Hz monitor halves the rate it is worth
+   * painting at — and a window that straddles two answers for the one
+   * under its centre.
+   */
+  _refreshFrameInterval() {
+    this._frameInterval = this.app.frameIntervalFor(this);
+  }
+
   /** Native geometry changed (delegate event, points). */
   _nativeResized(points) {
     const s = this.scale;
@@ -132,6 +151,7 @@ export class CocoaWindow {
     this.x = Math.round(points.x * s);
     this.y = Math.round(points.y * s);
     this._screenOrigin = { x: this.x, y: this.y };
+    this._refreshFrameInterval();
     // AppKit's inLiveResize, as the delegate reported it: the renderer
     // answers a live tick with the layout floors it has and measures fresh
     // ones after the drag (nodes.js, `_deferContentFloors`). Cleared by
@@ -159,6 +179,7 @@ export class CocoaWindow {
     this.y = Math.round(y);
     this._native.setWindowFrame(this._h, x / s, y / s, null, null);
     this._screenOrigin = { x: this.x, y: this.y };
+    this._refreshFrameInterval();
   }
 
   // --- lifecycle -----------------------------------------------------------
@@ -166,10 +187,17 @@ export class CocoaWindow {
   map() {
     if (this.destroyed) return;
     this.mapped = true;
+    // Showing is a claim that the window is on glass; if it comes up behind
+    // another application's window, AppKit's occlusion event says so on the
+    // next pump and the frames wait from then. Reset here rather than kept,
+    // so a window that was hidden behind one, unmapped and mapped again
+    // does not wait on an event that may already have been delivered.
+    this._occluded = false;
     // A popup must not take the keyboard from its owner; a toplevel's first
     // map is the app coming up and takes it.
     this._native.showWindow(this._h, !this._popup);
     this._refreshOrigin();
+    this._refreshFrameInterval();
   }
 
   unmap() {
@@ -184,7 +212,7 @@ export class CocoaWindow {
     this.mapped = false;
     this.app._unregisterWindow(this);
     this._native.destroyWindow2(this._h);
-    this._surface = null;
+    this._releaseBacking();
   }
 
   // --- window-manager-ish surface (feature-detected by nodes.js) -----------
@@ -247,6 +275,14 @@ export class CocoaWindow {
    * the just-shown frame's damage across — a damage-sized memcpy replacing
    * a window-sized upload. Falls back to the single plain surface where
    * IOSurface creation fails.
+   *
+   * A new size retires the pair, and the retired pair is released on the
+   * spot (`_releaseBacking`): a resize tick allocates two window-sized
+   * IOSurfaces, 20MB at 900x700@2x, and left to the handles' finalizers a
+   * forty-tick drag held 800MB until a collection happened to run — the
+   * `rss +80MB` docs/macos.md measured. The layer keeps its own reference
+   * to whichever IOSurface it is still showing, so the free is safe while
+   * that frame is on glass.
    */
   _ensureSurface() {
     const w = this.width;
@@ -257,7 +293,7 @@ export class CocoaWindow {
       this._surfaceSize?.height !== h
     ) {
       const hadSurface = Boolean(this._surface);
-      this._chain = null;
+      this._releaseBacking();
       try {
         const a = this._native.createSurfaceIOSurface(w, h, this.scale);
         const b = this._native.createSurfaceIOSurface(w, h, this.scale);
@@ -286,6 +322,26 @@ export class CocoaWindow {
       if (hadSurface) this._freshSurface = true;
     }
     return this._surface;
+  }
+
+  /**
+   * Free the backing store now — the swapchain pair, or the plain surface
+   * the fallback holds — rather than when V8 collects the handles. Bridges
+   * before 0.4 have no `releaseSurface`; there the finalizer is still the
+   * only owner, and this is the drop it always was.
+   */
+  _releaseBacking() {
+    const release = this._native.releaseSurface;
+    if (typeof release === 'function') {
+      if (this._chain) {
+        release.call(this._native, this._chain.back.handle);
+        release.call(this._native, this._chain.front.handle);
+      } else if (this._surface) {
+        release.call(this._native, this._surface);
+      }
+    }
+    this._chain = null;
+    this._surface = null;
   }
 
   /**
@@ -326,12 +382,15 @@ export class CocoaWindow {
    * its last paint stays unpresented until it is back on glass, where one
    * catch-up frame covers everything that changed in between.
    *
-   * Occlusion by another application's window is not read here yet: AppKit
-   * reports it through `windowDidChangeOcclusionState`, which the bridge
-   * does not forward. When it does, this is the one place to add it.
+   * Occlusion by another application's window counts too: a window that
+   * is entirely behind one is visible by `isVisible`'s measure and still
+   * costs every frame its tree produces, and AppKit knows the difference.
+   * `windowDidChangeOcclusionState` arrives as the bridge's
+   * `window-occlusion` event (`CocoaApp._routeOcclusion`), `visible` being
+   * "some pixel of it is on glass"; `_occluded` is the last word of it.
    */
   _visible() {
-    if (this.destroyed || !this.mapped) return false;
+    if (this.destroyed || !this.mapped || this._occluded) return false;
     return this._native.windowIsVisible(this._h) !== false;
   }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -185,11 +185,13 @@ export interface RootOptions {
    * path: `'surface'` (the measured default — one bitmap per window, the
    * X11 paint machinery over an IOSurface swapchain) or `'layers'` (one
    * CALayer per drawn node, opt-in while it is measured).
-   * `frameInterval` is how often a scheduled frame may paint, in ms —
-   * 16 by default, a 60Hz display's period; 8 paints every refresh of a
-   * 120Hz panel. `pumpInterval` is the AppKit event pump's cadence, in
-   * ms (8 by default), which is the floor under input latency. Ignored
-   * off macOS and when {@link RootOptions.app} is passed.
+   * `frameInterval` is how often a scheduled frame may paint, in ms. By
+   * default each window paces itself on the display it is on — 8.3ms on
+   * a 120Hz panel, 16.7 on a 60Hz monitor, the screen's own refresh rate
+   * as the bridge reports it, 16 where the OS cannot say. A number here
+   * applies to every window instead. `pumpInterval` is the AppKit event
+   * pump's cadence, in ms (8 by default), which is the floor under input
+   * latency. Ignored off macOS and when {@link RootOptions.app} is passed.
    */
   cocoa?: {
     presenter?: 'surface' | 'layers';

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -4496,10 +4496,16 @@ export class Node {
    *     format,          // 'argb32', or 'a8' for coverage that gets tinted
    *     tint,            // the colour an 'a8' surface is painted through
    *   }
-   *   paintCached(ctx, box) -> void   // draw at the origin of `box`
+   *   paintCached(ctx, box, ink) -> void   // draw at the origin of `box`
    *
    * Returning null opts out for this frame, which is the right answer
    * whenever the paint depends on something the key cannot see.
+   *
+   * `ink` is the colour a mono drawing — one that asked for `'a8'` — must
+   * paint in: white where the surface is coverage and the tint arrives at
+   * blit time, the tint itself on a backend without coverage surfaces,
+   * where the cache bakes the colour into an argb32 entry and puts it in
+   * the key (src/paintcache.js). A multi-colour drawing ignores it.
    *
    * **The key is the entire correctness surface.** It must name every input
    * `paintCached` reads, derived from the same values `applyProps` compares
@@ -6472,7 +6478,7 @@ export class CanvasNode extends Node {
     };
   }
 
-  paintCached(ctx, box) {
+  paintCached(ctx, box, ink = '#ffffff') {
     const onDraw = this.props.onDraw;
     if (typeof onDraw !== 'function') return;
     ctx.save();
@@ -6481,8 +6487,9 @@ export class CanvasNode extends Node {
     ctx.clip();
     ctx.translate(box.x, box.y);
     // Into a coverage surface only the alpha of a paint survives and the
-    // tint arrives at blit time, so any opaque colour renders the same mask.
-    if (this.props.mono) this._presetMono(ctx, '#ffffff');
+    // tint arrives at blit time, so any opaque colour renders the same mask
+    // — and the cache says white then, or the tint where it bakes colour.
+    if (this.props.mono) this._presetMono(ctx, ink);
     try {
       onDraw(ctx, {
         width: box.width,

--- a/src/paintcache.js
+++ b/src/paintcache.js
@@ -22,6 +22,14 @@
 // Multi-colour drawings bake their colours in, which is right, because those
 // colours belong to the drawing. `SvgView.paintKind` decides which is which.
 //
+// Coverage needs a backend that composites a mask through a colour, which
+// X Render does and the Cocoa backend's surfaces do not (src/cocoa/
+// surface.js — no `a8`). There a mono drawing is cached as argb32 with its
+// colour in the key: one entry per colour it is seen in rather than one for
+// all of them, which is still one render per colour instead of one per
+// cell per frame. A coverage-only plan — a blurred shadow, whose blur is a
+// pass over the mask — stays live on that backend.
+//
 // ## Self-limiting, on purpose
 //
 // X gives no back-pressure: the first sign of overspending is `BadAlloc` on
@@ -35,6 +43,12 @@
 // SyntaxError — the whole renderer, not just the cache. Same shape as the
 // `typeof wnd?.scrollRegion !== 'function'` guard for ntk without #139.
 import * as ntk from 'ntk';
+
+// The surface this cache draws into is `react-x11/ntk`'s: ntk's pixmap on
+// an X connection, the app's own (`app.createSurface`) on a backend that
+// makes them — the Cocoa backend's CG bitmap. One import, so the cache
+// names neither.
+import { Surface } from './ntk.js';
 
 /** Stale pixels are undebuggable, and every other optimization here has an
  * escape hatch — see NO_SCROLL_BLIT. */
@@ -145,6 +159,9 @@ export class PaintCache {
     this.app = app;
     this.budget = budget;
     this.verify = verify;
+    /** whether an `a8` entry can be painted through a colour here — X
+     * Render composites a mask through the fill; nothing else does yet */
+    this.coverage = Boolean(app?.display?.Render);
     /** key -> entry. Map iteration is insertion order, so re-inserting on
      * access makes this an LRU list for free — same trick as getGlyphPage. */
     this.entries = new Map();
@@ -193,7 +210,7 @@ export class PaintCache {
     return this.drawing(ctx, {
       ...plan,
       label: `<${node.kind}>`,
-      draw: (sctx, box) => node.paintCached(sctx, box),
+      draw: (sctx, box, ink) => node.paintCached(sctx, box, ink),
       live: () => node.paintContent(ctx),
     });
   }
@@ -211,9 +228,22 @@ export class PaintCache {
    *
    * `maxPixels` overrides the per-item cap for a caller whose drawing is
    * legitimately box-sized rather than icon-sized.
+   *
+   * `draw` is handed the ink a mono drawing paints in as its third
+   * argument: white into a coverage surface, where only the alpha survives
+   * and the tint arrives at blit time, and the tint itself on a backend
+   * without coverage, where the entry bakes its colour and carries it in
+   * the key (`_bakeTint`).
    */
   drawing(ctx, plan) {
     if (!isDeviceSpace(ctx)) return plan.live(ctx);
+    if (plan.format === 'a8' && !this.coverage) {
+      // A plan whose `after` pass works on the mask — a blurred shadow —
+      // has no argb32 equivalent: it paints live, which is what the frame
+      // owed with no cache at all.
+      if (plan.after) return plan.live(ctx);
+      plan = this._bakeTint(plan);
+    }
 
     if (plan.width * plan.height > (plan.maxPixels ?? MAX_ITEM_PIXELS)) {
       this.stats.tooBig++;
@@ -254,9 +284,30 @@ export class PaintCache {
     return this._blit(ctx, entry, plan);
   }
 
+  /**
+   * A coverage plan on a backend that cannot composite coverage, as an
+   * argb32 plan that paints its tint: the same pixels, one entry per colour
+   * instead of one per drawing.
+   */
+  _bakeTint(plan) {
+    const tint = plan.tint;
+    return {
+      ...plan,
+      format: 'argb32',
+      key: `${plan.key}|ink:${tint}`,
+      draw: (sctx, box) => plan.draw(sctx, box, tint),
+    };
+  }
+
+  /** The colour a drawing paints in: white into coverage, the tint into a
+   * baked entry, and nothing a multi-colour drawing reads. */
+  static inkFor(plan) {
+    return plan.format === 'a8' ? '#ffffff' : (plan.tint ?? '#ffffff');
+  }
+
   _render(plan) {
     try {
-      const surface = new ntk.Surface(this.app, {
+      const surface = new Surface(this.app, {
         width: plan.width,
         height: plan.height,
         format: plan.format,
@@ -264,7 +315,11 @@ export class PaintCache {
       const box = { x: 0, y: 0, width: plan.width, height: plan.height };
       const state = { digest: 0x811c9dc5 };
       surface.render((sctx) =>
-        plan.draw(this.verify ? recordingContext(sctx, state) : sctx, box),
+        plan.draw(
+          this.verify ? recordingContext(sctx, state) : sctx,
+          box,
+          PaintCache.inkFor(plan),
+        ),
       );
       // `after` may hand back a *different* surface than it was given — a
       // blurred shadow bakes its convolution into a second one and destroys
@@ -310,18 +365,17 @@ export class PaintCache {
     const state = { digest: 0x811c9dc5 };
     let scratch = null;
     try {
-      scratch = new ntk.Surface(this.app, {
+      scratch = new Surface(this.app, {
         width: plan.width,
         height: plan.height,
         format: plan.format,
       });
       scratch.render((sctx) =>
-        plan.draw(recordingContext(sctx, state), {
-          x: 0,
-          y: 0,
-          width: plan.width,
-          height: plan.height,
-        }),
+        plan.draw(
+          recordingContext(sctx, state),
+          { x: 0, y: 0, width: plan.width, height: plan.height },
+          PaintCache.inkFor(plan),
+        ),
       );
     } catch {
       return; // verification is best-effort; never break a frame over it
@@ -365,6 +419,12 @@ export class PaintCache {
  * cannot, and the answer is simply that nothing is cached. */
 export const paintCacheSupported = () => typeof ntk.Surface === 'function';
 
+/** Whether `app` can make an offscreen surface at all: an X connection
+ * with the Render extension (ntk's pixmap surface), or a backend with a
+ * surface of its own — the Cocoa app's `createSurface` (docs/macos.md). */
+const canMakeSurfaces = (app) =>
+  Boolean(app?.display?.Render) || typeof app?.createSurface === 'function';
+
 /**
  * The cache for an app, created on first use. Null when caching is off, when
  * the installed ntk is too old, or when the app cannot make surfaces — the
@@ -372,6 +432,6 @@ export const paintCacheSupported = () => typeof ntk.Surface === 'function';
  * there must paint live.
  */
 export function paintCacheFor(app) {
-  if (DISABLED || !paintCacheSupported() || !app?.display?.Render) return null;
+  if (DISABLED || !paintCacheSupported() || !canMakeSurfaces(app)) return null;
   return (app._paintCache ??= new PaintCache(app));
 }

--- a/src/svgnodes.js
+++ b/src/svgnodes.js
@@ -294,13 +294,14 @@ export class SvgNode extends Node {
     };
   }
 
-  paintCached(ctx, box) {
+  paintCached(ctx, box, ink = '#ffffff') {
     const view = this._ensureView();
     if (!view) return;
     // Into a coverage surface, only the alpha of a paint survives, and the
-    // tint arrives at blit time — so any opaque colour renders the same mask.
+    // tint arrives at blit time — so any opaque colour renders the same
+    // mask, and the cache says white then, or the tint where it bakes colour.
     view.draw(ctx, box.x, box.y, box.width, box.height, {
-      color: view.paintKind === 'mono' ? '#ffffff' : this._currentColor(),
+      color: view.paintKind === 'mono' ? ink : this._currentColor(),
     });
   }
 }

--- a/test/cocoa-frames.test.js
+++ b/test/cocoa-frames.test.js
@@ -8,8 +8,17 @@
 //   - a live-resize tick is ONE full frame, and its microtasks add none;
 //   - a bounded flush onto a fresh backing surface asks for a full frame and
 //     holds the present until it lands, so garbage is never on glass;
-//   - a window nobody can see owes no frame and no present;
+//   - a window nobody can see owes no frame and no present — ordered out,
+//     miniaturized, or entirely behind another application's window;
 //   - a wheel notch is answered on the event, like a press.
+//
+// And three more from the pass after it (#442, over bridge 0.4):
+//
+//   - the pair a resize retires is released on the spot, not on GC;
+//   - a window paces itself on the display it is on, and each window on
+//     its own;
+//   - an occlusion event holds the frames and the present until the
+//     window is back on glass.
 import assert from 'node:assert';
 import { afterEach, test } from 'node:test';
 import React from 'react';
@@ -33,7 +42,7 @@ const h = React.createElement;
  * from inside the call), surfaces are handles with a size, and every verb
  * that decides something is recorded.
  */
-function fakeBridge() {
+function fakeBridge({ screens } = {}) {
   const calls = [];
   let seq = 0;
   let backendCb = null;
@@ -41,17 +50,19 @@ function fakeBridge() {
     calls,
     of: (name) => calls.filter((c) => c[0] === name),
     visible: true,
-    listScreens: () => [
-      {
-        x: 0,
-        y: 0,
-        width: 1440,
-        height: 900,
-        scale: 2,
-        visible: { x: 0, y: 0, width: 1440, height: 875 },
-        primary: true,
-      },
-    ],
+    emit: (ev) => backendCb?.(ev),
+    listScreens: () =>
+      screens ?? [
+        {
+          x: 0,
+          y: 0,
+          width: 1440,
+          height: 900,
+          scale: 2,
+          visible: { x: 0, y: 0, width: 1440, height: 875 },
+          primary: true,
+        },
+      ],
     createWindow2(options) {
       const handle = { id: ++seq, options: { ...options } };
       calls.push(['createWindow2', options.width, options.height]);
@@ -60,8 +71,8 @@ function fakeBridge() {
     windowNumber: (handle) => handle.id,
     windowRootLayer: (handle) => ({ root: handle.id }),
     getWindowFrame: (handle) => ({
-      x: 0,
-      y: 0,
+      x: handle.options.x ?? 0,
+      y: handle.options.y ?? 0,
       width: handle.options.width,
       height: handle.options.height,
     }),
@@ -77,6 +88,8 @@ function fakeBridge() {
     },
     initApp() {},
     setWindowFrame(handle, x, y, width, height) {
+      if (typeof x === 'number') handle.options.x = x;
+      if (typeof y === 'number') handle.options.y = y;
       if (typeof width === 'number') handle.options.width = width;
       if (typeof height === 'number') handle.options.height = height;
       calls.push([
@@ -91,8 +104,8 @@ function fakeBridge() {
         windowNumber: handle.id,
         width: handle.options.width,
         height: handle.options.height,
-        x: 0,
-        y: 0,
+        x: handle.options.x ?? 0,
+        y: handle.options.y ?? 0,
         live: true,
       });
     },
@@ -104,6 +117,9 @@ function fakeBridge() {
     createSurface(width, height, scale) {
       calls.push(['createSurface', width, height]);
       return { id: ++seq, width, height, scale };
+    },
+    releaseSurface(handle) {
+      calls.push(['releaseSurface', handle.id]);
     },
     surfaceSize: (handle) => ({
       width: handle.width,
@@ -145,8 +161,11 @@ afterEach(async () => {
  * (`app._tickFrames()`), and the cadence gate is off unless a test turns
  * it on.
  */
-async function mount(children, { width = 100, height = 80 } = {}) {
-  const native = fakeBridge();
+async function mount(
+  children,
+  { width = 100, height = 80, screens, frameInterval = 0, ...attrs } = {},
+) {
+  const native = fakeBridge({ screens });
   const app = new CocoaApp(native);
   setScaleForTests(app, 2, 'cocoa');
   setScreensForTests(app, {
@@ -154,11 +173,11 @@ async function mount(children, { width = 100, height = 80 } = {}) {
     workArea: { x: 0, y: 0, width: 2880, height: 1750 },
   });
   setCompositingForTests(app, true);
-  app._frameInterval = 0;
+  app._frameInterval = frameInterval;
   native.setBackendEventCallback((ev) => app._route(ev));
   const root = await createRoot({ app });
   roots.push(root);
-  root.render(h('window', { width, height }, children));
+  root.render(h('window', { width, height, ...attrs }, children));
   await tick();
   const wnd = [...app._windows.values()][0];
   const node = wnd._reactX11Node;
@@ -378,6 +397,71 @@ test('a window that is not on glass owes no frame and no present until it is bac
   assert.equal(app._rafQueue.length, 0);
 });
 
+test("a window entirely behind another application's window owes nothing until it is back", async () => {
+  const { native, app, wnd, node, flushes } = await mount(
+    box({ flexGrow: 1, backgroundColor: '#3498db' }),
+  );
+  const inner = node.children[0];
+  // windowDidChangeOcclusionState: no pixel of this window is on glass
+  native.emit({
+    type: 'window-occlusion',
+    windowNumber: wnd.windowNumber,
+    visible: false,
+  });
+  assert.equal(wnd._visible(), false);
+  inner.invalidate(false, inner, 'props');
+  app._tickFrames();
+  assert.equal(flushes.count, 1, 'the frame waits');
+  assert.equal(app._rafQueue.length, 1, 'in the queue');
+  const before = flips(native);
+  wnd._dirty = true;
+  wnd.present();
+  assert.equal(flips(native), before, 'no present while covered');
+  assert.equal(wnd._dirty, true, 'but it is still owed');
+
+  // the cover moves away
+  native.emit({
+    type: 'window-occlusion',
+    windowNumber: wnd.windowNumber,
+    visible: true,
+  });
+  assert.equal(wnd._visible(), true);
+  app._tickFrames();
+  assert.equal(flushes.count, 2, 'one catch-up frame');
+  wnd.present();
+  assert.equal(flips(native), before + 1, 'presented on return');
+  assert.equal(app._rafQueue.length, 0);
+});
+
+test('mapping a window is a claim that it is on glass, whatever the last occlusion event said', async () => {
+  const { native, wnd } = await mount(box({ flexGrow: 1 }));
+  native.emit({
+    type: 'window-occlusion',
+    windowNumber: wnd.windowNumber,
+    visible: false,
+  });
+  wnd.unmap();
+  assert.equal(wnd._visible(), false);
+  // the show fires its own occlusion event a pump later; until it lands
+  // the frames must not wait on the one delivered before the hide
+  wnd.map();
+  assert.equal(wnd._occluded, false);
+  assert.equal(wnd._visible(), true);
+});
+
+test('an occlusion event for a window that is gone is nothing', async () => {
+  const { native, app, wnd } = await mount(box({ flexGrow: 1 }));
+  const number = wnd.windowNumber;
+  wnd.destroy();
+  native.emit({
+    type: 'window-occlusion',
+    windowNumber: number,
+    visible: false,
+  });
+  native.emit({ type: 'window-occlusion', windowNumber: 999, visible: false });
+  assert.equal(app._windows.size, 0);
+});
+
 test('an unmapped window is not on glass either', async () => {
   const { app, node, flushes, wnd } = await mount(
     box({ flexGrow: 1, backgroundColor: '#3498db' }),
@@ -391,7 +475,153 @@ test('an unmapped window is not on glass either', async () => {
   assert.equal(flushes.count, 2);
 });
 
+// --- the swapchain's memory ------------------------------------------------------
+
+test('the pair a resize retires is released on the spot, and the last pair with the window', async () => {
+  const { native, wnd } = await mount(
+    box({ flexGrow: 1, backgroundColor: '#3498db' }),
+  );
+  const made = () => native.of('createSurfaceIOSurface').length;
+  const released = () => native.of('releaseSurface').length;
+  assert.equal(made(), 2, 'the mount pair');
+  assert.equal(released(), 0);
+  // five ticks of a drag: each retires the pair before it
+  for (let i = 1; i <= 5; i += 1) {
+    native.setWindowFrame(wnd._h, null, null, 100 + i * 4, 80 + i * 2);
+  }
+  assert.equal(made(), 12);
+  assert.equal(released(), 10, 'every retired handle, at the tick');
+  // never the pair in use: the live back buffer and the frame on glass
+  const live = [wnd._chain.back.handle.id, wnd._chain.front.handle.id];
+  for (const [, id] of native.of('releaseSurface')) {
+    assert.ok(!live.includes(id), `released a live surface ${id}`);
+  }
+  wnd.destroy();
+  assert.equal(released(), 12, 'and the last pair goes with the window');
+  assert.equal(wnd._chain, null);
+  assert.equal(wnd._surface, null);
+});
+
+test('a bridge without releaseSurface leaves the retired pair to the finalizer', async () => {
+  const { native, wnd } = await mount(
+    box({ flexGrow: 1, backgroundColor: '#3498db' }),
+  );
+  delete native.releaseSurface; // the Proxy answers a no-op for it now
+  native.setWindowFrame(wnd._h, null, null, 120, 90);
+  assert.equal(native.of('releaseSurface').length, 0);
+  assert.equal(native.of('createSurfaceIOSurface').length, 4);
+  wnd.destroy();
+});
+
 // --- the cadence ------------------------------------------------------------------
+
+const twoScreens = [
+  {
+    x: 0,
+    y: 0,
+    width: 1440,
+    height: 900,
+    scale: 2,
+    visible: { x: 0, y: 0, width: 1440, height: 875 },
+    primary: true,
+    fps: 120,
+  },
+  {
+    x: 1440,
+    y: 0,
+    width: 2560,
+    height: 1440,
+    scale: 2,
+    visible: { x: 1440, y: 0, width: 2560, height: 1440 },
+    primary: false,
+    fps: 60,
+  },
+];
+
+test('a window paces itself on the display it is on', async () => {
+  const { app, wnd, native } = await mount(box({ flexGrow: 1 }), {
+    screens: twoScreens,
+    frameInterval: null,
+  });
+  // on the 120Hz panel: one frame per refresh
+  assert.ok(
+    Math.abs(wnd._frameInterval - 1000 / 120) < 1e-9,
+    `${wnd._frameInterval}`,
+  );
+  // dragged onto the 60Hz monitor (points; the window is 50x40 there)
+  native.setWindowFrame(wnd._h, 1500, 100, null, null);
+  assert.ok(Math.abs(wnd._frameInterval - 1000 / 60) < 1e-9);
+  // and back, by the renderer's own move
+  wnd.move(0, 0);
+  assert.ok(Math.abs(wnd._frameInterval - 1000 / 120) < 1e-9);
+  // a frame no window owns takes the primary's period
+  assert.ok(Math.abs(app.frameIntervalFor(null) - 1000 / 120) < 1e-9);
+});
+
+test('a screen the OS reports no rate for, and a bridge that reports none, pace at 60Hz', async () => {
+  const silent = twoScreens.map((sc) => ({ ...sc, fps: 0 }));
+  const { wnd: a } = await mount(box({ flexGrow: 1 }), {
+    screens: silent,
+    frameInterval: null,
+  });
+  assert.equal(a._frameInterval, 16);
+  const { wnd: b } = await mount(box({ flexGrow: 1 }), {
+    frameInterval: null, // the default screens carry no fps at all
+  });
+  assert.equal(b._frameInterval, 16);
+  // a window off every screen takes the primary's rate
+  const { wnd: c, native } = await mount(box({ flexGrow: 1 }), {
+    screens: twoScreens,
+    frameInterval: null,
+  });
+  native.setWindowFrame(c._h, -5000, -5000, null, null);
+  assert.ok(Math.abs(c._frameInterval - 1000 / 120) < 1e-9);
+});
+
+test('an explicit frameInterval applies to every window, whatever its display', async () => {
+  const { wnd, native, app } = await mount(box({ flexGrow: 1 }), {
+    screens: twoScreens,
+    frameInterval: 8,
+  });
+  assert.equal(wnd._frameInterval, 8);
+  native.setWindowFrame(wnd._h, 1500, 100, null, null);
+  assert.equal(wnd._frameInterval, 8);
+  assert.equal(app.frameIntervalFor(null), 8);
+});
+
+test('two windows keep two clocks: the one on the faster display paints while the other waits', async () => {
+  const {
+    app,
+    wnd: fast,
+    native,
+  } = await mount(box({ flexGrow: 1 }), {
+    screens: twoScreens,
+    frameInterval: null,
+  });
+  app._pumpInterval = 8;
+  const slow = app.createWindow({ width: 100, height: 80, x: 3000, y: 200 });
+  slow.map();
+  assert.ok(Math.abs(slow._frameInterval - 1000 / 60) < 1e-9);
+  let fastRan = 0;
+  let slowRan = 0;
+  fast.requestAnimationFrame(() => (fastRan += 1));
+  fast.requestAnimationFrame(() => (fastRan += 1));
+  slow.requestAnimationFrame(() => (slowRan += 1));
+  // 9ms since either last painted: past the 120Hz gate (8.3 - 4), short
+  // of the 60Hz one (16.7 - 4)
+  fast._rafLast = performance.now() - 9;
+  slow._rafLast = performance.now() - 9;
+  app._tickFrames();
+  assert.equal(fastRan, 2, 'every frame the fast window queued');
+  assert.equal(slowRan, 0);
+  assert.equal(app._rafQueue.length, 1, 'the slow one waits');
+  slow._rafLast = performance.now() - 14;
+  app._tickFrames();
+  assert.equal(slowRan, 1);
+  assert.equal(app._rafQueue.length, 0);
+  slow.destroy();
+  void native;
+});
 
 test('a frame lands on the first pump tick at or after the interval, not the one after', async () => {
   const { app } = await mount(box({ flexGrow: 1 }));

--- a/test/cocoa-paint-cache.test.js
+++ b/test/cocoa-paint-cache.test.js
@@ -1,0 +1,257 @@
+// The paint cache on the Cocoa backend (#442, item 5): the same cache as
+// X11's (test/paint-cache.test.js) over `CocoaSurface` instead of a pixmap,
+// reached through `react-x11/ntk`'s `Surface`. Over a fake bridge, like
+// cocoa-frames.test.js: what reaches the natives is the whole of what the
+// glue decides, and the cache's own stats say what it did.
+//
+// What differs here, and is pinned: this backend has no coverage surface,
+// so a mono drawing is cached as argb32 with its colour in the key — one
+// entry per colour, each drawn in that colour — and a blurred shadow, whose
+// blur is a pass over the mask, stays live.
+import assert from 'node:assert';
+import { afterEach, test } from 'node:test';
+import React from 'react';
+
+import { CocoaApp } from '../src/cocoa/app.js';
+import { setCompositingForTests } from '../src/compositing.js';
+import { createRoot } from '../src/index.js';
+import { paintCacheFor } from '../src/paintcache.js';
+import { setScaleForTests } from '../src/scale.js';
+import { setScreensForTests } from '../src/screens.js';
+
+process.env.NO_AT_BRIDGE ??= '1';
+
+const h = React.createElement;
+
+function fakeBridge() {
+  const calls = [];
+  let seq = 0;
+  let backendCb = null;
+  const native = {
+    calls,
+    of: (name) => calls.filter((c) => c[0] === name),
+    listScreens: () => [
+      {
+        x: 0,
+        y: 0,
+        width: 1440,
+        height: 900,
+        scale: 1,
+        visible: { x: 0, y: 0, width: 1440, height: 875 },
+        primary: true,
+      },
+    ],
+    createWindow2(options) {
+      return { id: ++seq, options: { ...options } };
+    },
+    windowNumber: (handle) => handle.id,
+    windowRootLayer: (handle) => ({ root: handle.id }),
+    getWindowFrame: (handle) => ({
+      x: 0,
+      y: 0,
+      width: handle.options.width,
+      height: handle.options.height,
+    }),
+    windowIsVisible: () => true,
+    setBackendEventCallback(cb) {
+      backendCb = cb;
+    },
+    emit: (ev) => backendCb?.(ev),
+    createSurfaceIOSurface(width, height, scale) {
+      const id = ++seq;
+      return { handle: { id, width, height, scale }, iosurfaceId: id };
+    },
+    createSurface(width, height, scale) {
+      const handle = { id: ++seq, width, height, scale };
+      calls.push(['createSurface', handle.id, width, height]);
+      return handle;
+    },
+    releaseSurface(handle) {
+      calls.push(['releaseSurface', handle.id]);
+    },
+    surfaceSize: (handle) => ({
+      width: handle.width,
+      height: handle.height,
+      scale: handle.scale,
+    }),
+    ctxSetFillColor(handle, r, g, b, a) {
+      calls.push(['ctxSetFillColor', handle.id, r, g, b, a]);
+    },
+    ctxDrawSurface(dst, src, ...rest) {
+      calls.push(['ctxDrawSurface', dst.id, src.id, ...rest]);
+    },
+  };
+  return new Proxy(native, {
+    get: (target, key) => (key in target ? target[key] : () => undefined),
+  });
+}
+
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+const roots = [];
+afterEach(async () => {
+  for (const root of roots.splice(0)) await root.unmount();
+});
+
+async function mount(children) {
+  const native = fakeBridge();
+  const app = new CocoaApp(native);
+  setScaleForTests(app, 1, 'cocoa');
+  setScreensForTests(app, {
+    monitors: [{ x: 0, y: 0, width: 1440, height: 900 }],
+    workArea: { x: 0, y: 0, width: 1440, height: 875 },
+  });
+  setCompositingForTests(app, true);
+  app._frameInterval = 0;
+  native.setBackendEventCallback((ev) => app._route(ev));
+  const root = await createRoot({ app });
+  roots.push(root);
+  const render = (kids) =>
+    root.render(h('window', { width: 200, height: 200 }, ...kids));
+  render(children);
+  await tick();
+  const wnd = [...app._windows.values()][0];
+  const node = wnd._reactX11Node;
+  app._tickFrames();
+  const frame = async (kids) => {
+    if (kids) render(kids);
+    await tick();
+    app._tickFrames();
+  };
+  const repaint = async () => {
+    node.invalidate(true, null, 'expose');
+    app._tickFrames();
+  };
+  return { native, app, root, wnd, node, frame, repaint };
+}
+
+const SQUARE = (paint) =>
+  `<svg viewBox="0 0 10 10"><rect width="10" height="10" fill="${paint}"/></svg>`;
+
+const TWO_COLOUR =
+  '<svg viewBox="0 0 10 10">' +
+  '<rect width="10" height="5" fill="#ff0000"/>' +
+  '<rect y="5" width="10" height="5" fill="#0000ff"/></svg>';
+
+/** `count` cells of one drawing in a row, in `color`. */
+const wall = (source, count, color) =>
+  Array.from({ length: count }, (_, i) =>
+    h('svg', {
+      key: i,
+      source,
+      style: {
+        position: 'absolute',
+        left: i * 20,
+        top: 0,
+        width: 16,
+        height: 16,
+        color,
+      },
+    }),
+  );
+
+test('a Cocoa app gets a cache: its surfaces are its own, not an X pixmap', async () => {
+  const { app, node } = await mount(wall(TWO_COLOUR, 4));
+  const cache = node._paintCache;
+  assert.ok(cache, 'the window node has a cache');
+  assert.equal(cache, paintCacheFor(app), 'one per app');
+  assert.equal(cache.coverage, false, 'and no coverage surfaces');
+  // the gate, without a whole app: a backend that makes surfaces qualifies
+  assert.ok(paintCacheFor({ createSurface() {} }));
+  assert.equal(paintCacheFor({ display: {} }), null);
+});
+
+test('identical drawings share one rendered copy, composited through the bridge', async () => {
+  const { native, node, repaint } = await mount(wall(TWO_COLOUR, 4));
+  const cache = node._paintCache;
+  assert.equal(cache.entries.size, 1, 'four cells, one entry');
+  assert.equal(cache.stats.renders, 1);
+  const [entry] = cache.entries.values();
+  assert.equal(entry.surface.format, 'argb32');
+  const made = native.of('createSurface');
+  assert.equal(made.length, 1, 'one CG bitmap, icon-sized');
+  assert.deepEqual(made[0].slice(2), [16, 16]);
+  // three cells composited from it on the first frame (the first cell was
+  // the sighting that armed the gate), four on a repaint
+  const blits = () =>
+    native.of('ctxDrawSurface').filter((c) => c[2] === made[0][1]).length;
+  assert.equal(blits(), 3);
+  await repaint();
+  assert.equal(cache.stats.renders, 1, 'nothing re-rendered');
+  assert.equal(blits(), 7);
+});
+
+test('a mono drawing bakes its colour: one entry per colour, each drawn in it', async () => {
+  const { native, node, frame, repaint } = await mount(
+    wall(SQUARE('currentColor'), 4, '#ff0000'),
+  );
+  const cache = node._paintCache;
+  assert.equal(cache.entries.size, 1);
+  const [red] = cache.entries.keys();
+  assert.match(red, /\|ink:#ff0000$/, 'the tint is in the key');
+  const [entry] = cache.entries.values();
+  assert.equal(entry.surface.format, 'argb32', 'no a8 here');
+  // the drawing went into the entry's surface in red, not in coverage white
+  const fills = native
+    .of('ctxSetFillColor')
+    .filter((c) => c[1] === entry.surface._surfaceHandle.id);
+  assert.ok(fills.length, 'a fill was set on the entry surface');
+  assert.deepEqual(fills.at(-1).slice(2), [1, 0, 0, 1]);
+
+  // recoloured: a second entry, drawn in blue — never the red one tinted.
+  // The first frame after the change paints live (a style change rebuilds
+  // the document, and a rebuilt document opts out for that frame — see
+  // SvgNode.paintCachePlan); the entry lands on the next.
+  await frame(wall(SQUARE('currentColor'), 4, '#0000ff'));
+  assert.equal(cache.entries.size, 1, 'the rebuilt document painted live');
+  await repaint();
+  assert.equal(cache.entries.size, 2, 'a new entry for the new colour');
+  assert.equal(cache.stats.renders, 2);
+  const blue = [...cache.entries.values()].at(-1);
+  assert.notEqual(blue, entry);
+  const blueFills = native
+    .of('ctxSetFillColor')
+    .filter((c) => c[1] === blue.surface._surfaceHandle.id);
+  assert.deepEqual(blueFills.at(-1).slice(2), [0, 0, 1, 1]);
+});
+
+test('a blurred shadow stays live: coverage-only work has no argb32 form here', async () => {
+  const { native, node, repaint } = await mount([
+    h('box', {
+      style: {
+        position: 'absolute',
+        left: 40,
+        top: 40,
+        width: 60,
+        height: 40,
+        backgroundColor: '#ffffff',
+        boxShadow: '0 2px 8px rgba(0,0,0,0.5)',
+      },
+    }),
+    ...wall(TWO_COLOUR, 2),
+  ]);
+  const cache = node._paintCache;
+  await repaint();
+  await repaint();
+  assert.equal(cache.entries.size, 1, 'the icons, and nothing for the shadow');
+  assert.equal(cache.stats.failed, 0, 'and no render was even attempted');
+  assert.equal(
+    native.of('createSurface').length,
+    1,
+    'one surface: the icon entry',
+  );
+});
+
+test('an evicted or unmounted entry hands its bitmap back to the bridge', async () => {
+  const { native, node, root } = await mount(wall(TWO_COLOUR, 4));
+  const cache = node._paintCache;
+  const [entry] = cache.entries.values();
+  const id = entry.surface._surfaceHandle.id;
+  cache.destroy();
+  assert.ok(
+    native.of('releaseSurface').some((c) => c[1] === id),
+    'released through the bridge, not left to the finalizer',
+  );
+  await root.unmount();
+  roots.splice(0);
+});

--- a/test/cocoa-surface.test.js
+++ b/test/cocoa-surface.test.js
@@ -295,6 +295,22 @@ test('drawImage composites one surface into another through ctxDrawSurface, in e
   assert.equal(native.of('ctxDrawSurface').length, 3);
 });
 
+test('destroy releases the bitmap through the bridge when it can, and once', () => {
+  const native = fakeNative();
+  const released = [];
+  native.releaseSurface = (handle) => released.push(handle.id);
+  const surface = new CocoaSurface(appOver(native), { width: 4, height: 4 });
+  const id = surface._surfaceHandle.id;
+  surface.destroy();
+  surface.destroy();
+  assert.deepEqual(released, [id], 'freed on the call, not on collection');
+  // a bridge without the verb: the finalizer owns it, and destroy is a drop
+  const older = fakeNative();
+  const other = new CocoaSurface(appOver(older), { width: 4, height: 4 });
+  assert.doesNotThrow(() => other.destroy());
+  assert.equal(other._surfaceHandle, null);
+});
+
 test('destroy drops the handle, refuses further drawing with a reason, and is idempotent', () => {
   const native = fakeNative();
   const surface = new CocoaSurface(appOver(native), { width: 8, height: 8 });


### PR DESCRIPTION
The react-x11 half of #442, over `@windowkit/appkit` 0.4.0. windowkit/appkit#10 shipped the bridge half: `releaseSurface`, every surface's bytes accounted to V8, `fps` on `listScreens`, and `window-occlusion` events. This takes all four, bumps the dependency, and wires the paint cache over `CocoaSurface`. Items 1 and 6 of the issue, the incremental content floors and drawing at a level of detail, stay open.

### What changed

- **The swapchain releases the pair it retires on the flip** (`CocoaWindow._releaseBacking`). A resize tick allocates two window-sized IOSurfaces and used to leave the two it replaced to their handles' finalizers, which run on the event loop, and inside AppKit's resize loop the event loop does not run. The bridge's accounting makes the collection prompt once the loop is back; the explicit free is what bounds the peak while it is not. `CocoaSurface.destroy()` and the layer presenter's rasters release the same way, and a bridge without the verb gets the drop it always had.
- **Each window paces its frames on the display it is on** (`CocoaApp.frameIntervalFor`, `_frameDue`). The default interval is `1000 / fps` of the screen under the window's centre, re-read when it moves, with a clock per window in the frame queue; `createRoot({ cocoa: { frameInterval } })` still overrides it for every window. One honest limit: the 8ms pump quantizes the cadence, so a 75Hz monitor paints at 62.5fps. `pumpInterval` is the seam; docs/macos.md says so.
- **A window entirely behind another application's window owes nothing** (`CocoaApp._routeOcclusion`, `CocoaWindow._visible`). The occlusion event holds the window's frames and its present the way an ordered-out window's are held; `map()` resets the flag since a show is a claim to be on glass. A new `covered` bench scenario opens a window of our own over the tree and is in the gate at zero frames.
- **The paint cache is on** (`paintCacheFor` accepts an app with `createSurface`; `PaintCache.coverage`). This backend has no coverage surface, so a mono drawing is cached as argb32 with its colour in the key, and the node protocol's `paintCached(ctx, box, ink)` now says which colour to paint in. A blurred shadow, whose blur is a pass over the mask, stays live.
- The bench grows `--at=x,y` to place the window on the screen whose rate is being measured.

### Measured

Surface presenter, 900x700 at 2x, M1 Pro, `npm run bench:presenters`. The resize row is a script driving forty `setWindowFrame`s synchronously, the way the modal loop delivers them.

| what | before | after |
| --- | --- | --- |
| a 40-tick resize burst, no yield: rss during | +572 to +655MB | +12 to +14MB |
| `anim` on the 120Hz panel | 55.7fps, 32% cpu | 113.5fps, 49% cpu |
| `hover` on the 120Hz panel, input to flush p50 / p95 | 7.2ms / 16.8 | 3.1 / 9.2 |
| `icons`, 300 mono icons re-tinted per tick, flush avg / p95 | 2.98ms / 3.35 | 2.07 / 2.42 |
| `covered`, the big tree behind another window | a frame per tick | 0 frames |

The `anim` and `hover` "before" rows are `--frame=16` on this branch with the window on the 120Hz panel, the old default there. docs/macos.md "Measured: after the frame-clock pass" records the rest.

### Testing

- `test/cocoa-frames.test.js`: the retired pair is released at the tick and never the live one, the last pair goes with the window, a bridge without the verb is left alone; a window paces on its display, moves between displays, falls back to 16ms, two windows keep two clocks; an occlusion event holds frames and the present, mapping resets it, an event for a gone window is nothing.
- `test/cocoa-surface.test.js`: `destroy()` releases once.
- `test/cocoa-paint-cache.test.js`, new: a Cocoa app gets a cache over its own surfaces, identical drawings share one bitmap composited through `ctxDrawSurface`, a mono drawing bakes its colour with one entry per colour drawn in it, a blurred shadow stays live, a destroyed cache hands its bitmaps back.
- `npm test`: 1765 pass; the six failures are the appearance tests that fail on this machine and pass in CI, unchanged.
- `npm run bench:presenters -- --check`: all 27 rules hold, `covered` included.

Refs #442
