### PR TITLE
fix(cocoa): a pane's frame gate folds a burst of geometry into one frame

### DIFF
--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1241,6 +1241,19 @@ renderer's own and are listed at the end.
   blurred shadow, whose blur is a pass over the mask, stays live. The `icons`
   row is the gain, and the larger cost left in that scenario is the React
   re-render of 300 unmemoized components. `test/cocoa-paint-cache.test.js`.
+- **A pane's frame gate is real** (`CocoaPaneWindow.frameInFlight`). The
+  early flush a discrete input gets (`flushPendingFrames`, src/frames.js) is
+  safe because it is gated on the last frame having landed — that gate is
+  what folds a burst into one paced frame — and the pane window answered it
+  with a constant `false`. So every message the host had queued while the
+  pane was busy painting got a full frame of its own: a forty-tick resize of
+  `examples/frame.jsx`'s pane, whose frame costs 250–320ms, stepped through
+  42 presents at 42 intermediate sizes and reached the final one twelve
+  seconds after the drag had ended, each step the previous IOSurface
+  stretched to the layer's new frame. A pane hears nothing back from the
+  host, so a present now counts as in flight for one frame interval; the
+  same burst is one frame at the size it ended on, plus the one the first
+  message was answered with. `test/cocoa-frames.test.js`.
 
 **What is left, in order of what it costs:**
 

--- a/src/cocoa/panewindow.js
+++ b/src/cocoa/panewindow.js
@@ -50,6 +50,7 @@ export class CocoaPaneWindow {
     this._dirty = false;
     this._flushDamage = 'full';
     this._seq = 0;
+    this._presentedAt = -Infinity;
     this._reactX11Node = null;
     app._registerWindow(this);
   }
@@ -98,8 +99,24 @@ export class CocoaPaneWindow {
     return this.app._requestFrame(cb);
   }
 
+  /**
+   * Whether the host may still be showing the frame before the last one —
+   * the gate `flushPendingFrames` (src/frames.js) is written around: a
+   * discrete input paints on the spot only when the last frame has landed,
+   * which is what folds a burst into one paced frame instead of a frame per
+   * event. On X11 the server says when a present was shown; a pane hears
+   * nothing back from the host, which flips the layer on its next pump tick
+   * and has Core Animation scan it out at the following refresh — so a
+   * present counts as in flight for one frame interval. Without a gate here
+   * every message the host queued while the pane was busy was answered
+   * with a full frame of its own: a forty-tick resize of a pane whose frame
+   * costs 300ms stepped through forty sizes for twelve seconds after the
+   * drag had ended, each one the previous surface stretched to the layer.
+   */
   frameInFlight() {
-    return false;
+    return (
+      performance.now() - this._presentedAt < this.app.frameIntervalFor(null)
+    );
   }
 
   // Three buffers, not two. A pane is cross-process: the host keeps
@@ -214,6 +231,7 @@ export class CocoaPaneWindow {
       width: this.width,
       height: this.height,
     });
+    this._presentedAt = performance.now();
     this._shownIndex = this._drawIndex;
     // the next buffer round the ring — two behind what the host will be
     // showing, so it is safe to write even before the host has switched

--- a/test/cocoa-frames.test.js
+++ b/test/cocoa-frames.test.js
@@ -181,6 +181,13 @@ async function mount(
   await tick();
   const wnd = [...app._windows.values()][0];
   const node = wnd._reactX11Node;
+  const flushes = countFlushes(node);
+  app._tickFrames();
+  return { native, app, root, wnd, node, flushes };
+}
+
+/** Frames that painted, and how many of them were full. */
+function countFlushes(node) {
   const flushes = { count: 0, full: 0 };
   const flush = node.flush.bind(node);
   node.flush = (...a) => {
@@ -193,8 +200,43 @@ async function mount(
     }
     return out;
   };
+  return flushes;
+}
+
+/**
+ * The pane's end of a `<Frame>`: the app in pane mode, its window over the
+ * shared ring rather than an NSWindow, geometry and input arriving as
+ * channel messages and presents leaving as them (src/cocoa/panewindow.js).
+ * `deliver` is the host speaking; `sent` is what the pane said back.
+ */
+async function mountPane(children, { width = 100, height = 80 } = {}) {
+  const native = fakeBridge({});
+  const app = new CocoaApp(native, { pane: true });
+  setScaleForTests(app, 2, 'cocoa');
+  setScreensForTests(app, {
+    monitors: [{ x: 0, y: 0, width: 2880, height: 1800 }],
+    workArea: { x: 0, y: 0, width: 2880, height: 1750 },
+  });
+  setCompositingForTests(app, true);
+  app._frameInterval = 0;
+  const sent = [];
+  let onMessage = null;
+  app.attachPaneChannel({
+    send: (msg) => sent.push(msg),
+    onMessage: (cb) => {
+      onMessage = cb;
+    },
+  });
+  const root = await createRoot({ app });
+  roots.push(root);
+  root.render(h('window', { width, height, embeddable: true }, children));
+  await tick();
+  const wnd = [...app._windows.values()][0];
+  const node = wnd._reactX11Node;
+  const flushes = countFlushes(node);
   app._tickFrames();
-  return { native, app, root, wnd, node, flushes };
+  const presents = () => sent.filter((m) => m.type === 'pane-present');
+  return { app, wnd, node, flushes, presents, deliver: (m) => onMessage(m) };
 }
 
 const box = (style) => h('box', { style });
@@ -641,6 +683,48 @@ test('a frame lands on the first pump tick at or after the interval, not the one
   app._rafLast = performance.now() - 13;
   app._tickFrames();
   assert.equal(ran, 1);
+});
+
+// --- a pane -------------------------------------------------------------------------
+
+test('a pane answers a burst of geometry with one frame, not one per message', async () => {
+  const { app, wnd, flushes, presents, deliver } = await mountPane(
+    box({ flexGrow: 1, backgroundColor: '#3498db' }),
+  );
+  assert.equal(flushes.count, 1, 'the mount frame');
+  // The gate on, at any interval: what is under test is that a present
+  // counts as in flight at all, not for how long.
+  app._frameInterval = 1e9;
+  // A pane that was busy painting finds the host's messages queued behind
+  // it — one resize tick per 16ms of the drag — and Node hands them over
+  // back to back. The first, after a quiet interval, is answered on the
+  // spot, like a press…
+  deliver({ type: 'pane-rect', width: 104, height: 82, scale: 2 });
+  assert.equal(flushes.count, 2, 'answered on the spot');
+  assert.equal(presents().length, 1, 'and presented');
+  assert.equal(wnd.frameInFlight(), true, 'which is now in flight');
+  // …and the rest of the burst finds that present in flight: each one
+  // resizes the window and asks for a frame, none of them paints
+  for (let i = 2; i <= 8; i += 1) {
+    deliver({ type: 'pane-rect', width: 100 + i * 4, height: 80 + i * 2 });
+  }
+  assert.equal(wnd.width, 264, 'the window is the size the burst ended on');
+  assert.equal(flushes.count, 2, 'without a frame per message');
+  assert.equal(presents().length, 1);
+  // the pump: one paced frame, at that size
+  app._rafLast = -Infinity;
+  app._tickFrames();
+  app._presentAll();
+  assert.equal(flushes.count, 3, 'one catch-up frame');
+  assert.equal(flushes.full, 3, 'a full one');
+  const last = presents().at(-1);
+  assert.equal(presents().length, 2);
+  assert.deepEqual([last.width, last.height], [264, 192]);
+  // the interval passes: the next lone message is answered on the spot again
+  wnd._presentedAt = -Infinity;
+  deliver({ type: 'pane-rect', width: 140, height: 100 });
+  assert.equal(flushes.count, 4);
+  assert.equal(presents().length, 3);
 });
 
 // --- the wheel ----------------------------------------------------------------------


### PR DESCRIPTION
## What you see

Resize the window of `examples/frame.jsx` and the pane catches up in steps: each intermediate size is painted in turn, and until each one lands the host shows the previous IOSurface stretched to the layer's new frame. The pane's Mandelbrot frame costs 250 to 320 ms, which is what makes it visible.

Reproduced on the Cocoa backend with a scripted forty-tick resize (16 ms apart, 960x600 to 1210x750) and the window's own `snapshot()` every 200 ms afterwards, with a trace on the pane channel:

| | before | after |
| --- | --- | --- |
| `pane-rect` messages the host sent | 41 | 41 |
| pane presents until the final size | 42, one per intermediate size | 4 |
| final size reached | 12 s after the resize ended | 0.5 s after |
| set aspect in the snapshots (stretch) | 0.862 → 0.803 over 24 shots | settled by the third shot |

## Why

`flushPendingFrames` (src/frames.js) paints a discrete input's response on the spot, and that is safe only because it is gated on `wnd.frameInFlight()`: a window whose last frame has not landed keeps its scheduled frame, which is what folds a burst into one paced catch-up frame. `CocoaPaneWindow.frameInFlight()` returned a constant `false`. The pane channel routes every `pane-rect` through `_afterInput()`, and Node hands the messages queued behind a long paint over back to back, so each one was answered with a full layout and paint of its own before the next was read. The trace shows it as `pane-rect answered` immediately followed by the next `pane-rect` at the same millisecond, forty times.

The host is fine as it is (one message per tick, coalesced by the receiver), and X11 panes never had this: a ConfigureNotify goes through `invalidate` and the frame clock, not the input flush.

## The fix

A pane hears nothing back from the host, which flips the layer on its next pump tick and has Core Animation scan it out at the following refresh, so a present now counts as in flight for one frame interval (`frameIntervalFor(null)`: the explicit `frameInterval`, else the primary display's period). The first message after a quiet interval is still answered on the spot, like a press; the rest of a burst resize the window and ask for a frame, and the pump paints once at the size the burst ended on.

- `src/cocoa/panewindow.js`: `_presentedAt`, stamped in `present()`; `frameInFlight()` reads it.
- `test/cocoa-frames.test.js`: a pane-mode mount over the fake bridge and the burst test. Checked against the old code: it fails there on the first assertion after the burst (eight flushes instead of two).
- `docs/macos.md`: a bullet in the measured section with the numbers above.

Not changed here: the host stretches the stale surface to the new layer frame while it waits for the pane. With a slow pane that is still one stretched step per frame the pane takes; whether the layer should show the old surface unscaled instead is a separate call.
