### PR TITLE
fix(cocoa): the layer presenter replays an element's paint override and re-rasters on bare-rect claims

### DIFF
--- a/docs/macos.md
+++ b/docs/macos.md
@@ -757,7 +757,12 @@ with no D-Bus in sight. The macOS adapter consumes precisely that:
 The escape hatches all reduce to one rule stated in Tier L: **a node
 whose content is painted code gets a raster visual** — a bitmap-backed
 layer, the CG canvas2d context translated to its box, redraw on the
-node's own damage claims, `contentsScale` from the window.
+node's own damage claims, `contentsScale` from the window. A claim that
+names the node re-rasters that node; a bare rect — an element's
+`invalidate(false, rect)` for the box a dragged item moved through, the
+region `scrollContents` shifts, the strip an animation ticks in —
+re-rasters every raster visual whose ink it touches, the same
+conservative answer the damage model gives a rect on X11.
 
 - `<canvas onDraw>`: `paintContent` runs against the CG ctx; a new
   `onDraw` closure invalidates the node (existing rule); `putImageData`
@@ -767,10 +772,13 @@ node's own damage claims, `contentsScale` from the window.
   (name, size) and tints per ink via `CGContextClipToMask` + fill, so
   the a8-coverage economics survive (ink stays out of the raster key).
 - `registerElement` + `Node.paint(ctx)` subclasses (all seven components
-  elements): work unchanged through the raster visual. The
-  `Context2D` dialect the consumers exercise — including `fillRects`,
-  `drawGlyphs`, `positioned`, `layoutSubtree`, `vw/vh/em` — is part of
-  the ctx contract on both backends.
+  elements): work unchanged through the raster visual. An element that
+  overrides `paint` — `super.paint(ctx)` for the box, then its scene —
+  has its content nowhere but in that override, so the raster replays
+  the override itself, with the child walk held back (the children have
+  visuals of their own). The `Context2D` dialect the consumers exercise
+  — including `fillRects`, `drawGlyphs`, `positioned`, `layoutSubtree`,
+  `vw/vh/em` — is part of the ctx contract on both backends.
 - `ntk.Surface` offscreen allocation (charts, terminal, flow): the Cocoa
   app object supplies one. `app.createSurface(options)` answers ntk's
   `Surface` contract over a CG bitmap (`src/cocoa/surface.js`, issue

--- a/scripts/bench/presenters.js
+++ b/scripts/bench/presenters.js
@@ -1024,6 +1024,112 @@ const SCENARIOS = {
   },
 };
 
+/**
+ * A registered element that draws its own scene — the components' <Flow>
+ * shape: `paint` overridden, `super.paint` for the box, the scene after it
+ * — panned by `scrollContents` every tick. Its content exists only through
+ * that override, so this is the raster visual's contract (docs/macos.md
+ * §"Custom drawing on a layer tree") as a number: the pane must re-raster
+ * on the claim, and the label beside it must not. The surface presenter
+ * blits the surviving band and repaints the exposed strip.
+ */
+const PANE_CELL = 28;
+const PANE_GAP = 12;
+const PANE_TINTS = ['#4c6ef5', '#12b886', '#fd7e14', '#be4bdb'];
+
+function definePane(NodeClass) {
+  return class BenchPaneNode extends NodeClass {
+    constructor(props, app) {
+      super('benchpane', props, app);
+      this.offset = 0; // device pixels the scene has moved right
+    }
+
+    pan(dx) {
+      this.offset += dx;
+      // "the pixels in here moved by dx; the strip is new"
+      this.scrollContents(this.contentBox(), dx, 0);
+    }
+
+    paint(ctx) {
+      super.paint(ctx);
+      const box = this.contentBox();
+      if (!(box.width > 0 && box.height > 0)) return;
+      const damage = this.paintDamage();
+      const s = this.scale;
+      const cell = PANE_CELL * s;
+      const pitch = (PANE_CELL + PANE_GAP) * s;
+      const phase = ((this.offset % pitch) + pitch) % pitch;
+      ctx.save();
+      ctx.beginPath();
+      ctx.rect(box.x, box.y, box.width, box.height);
+      ctx.clip();
+      let row = 0;
+      for (let y = box.y + PANE_GAP * s; y < box.y + box.height; y += pitch) {
+        let col = 0;
+        for (let x = box.x + phase - pitch; x < box.x + box.width; x += pitch) {
+          const r = { x, y, width: cell, height: cell };
+          col += 1;
+          if (
+            damage &&
+            !(
+              r.x < damage.x + damage.width &&
+              damage.x < r.x + r.width &&
+              r.y < damage.y + damage.height &&
+              damage.y < r.y + r.height
+            )
+          ) {
+            continue;
+          }
+          ctx.fillStyle = PANE_TINTS[(row + col) % PANE_TINTS.length];
+          ctx.fillRect(r.x, r.y, r.width, r.height);
+          ctx.strokeStyle = '#1f2933';
+          ctx.lineWidth = s;
+          ctx.beginPath();
+          ctx.moveTo(r.x + cell, r.y + cell / 2);
+          ctx.lineTo(r.x + pitch, r.y + cell / 2 + cell / 3);
+          ctx.stroke();
+        }
+        row += 1;
+      }
+      ctx.restore();
+    }
+  };
+}
+
+SCENARIOS.pane = {
+  latency: true,
+  tree: () =>
+    windowOf(
+      [
+        e(
+          'box',
+          { style: { flexGrow: 1, padding: 16, gap: 12 } },
+          e(
+            'text',
+            { style: { color: '#7f8c8d' } },
+            'a label beside the pane — it must not re-raster on a pan',
+          ),
+          e('benchpane', {
+            style: {
+              flexGrow: 1,
+              borderWidth: 1,
+              borderColor: '#c3ccd8',
+              backgroundColor: '#ffffff',
+            },
+          }),
+        ),
+      ],
+      'bench pane',
+    ),
+  drive(ctx) {
+    const pane = ctx.find((n) => n.kind === 'benchpane');
+    if (!pane) return;
+    const step = Math.round(2 * (pane.scale || 1));
+    ctx.stamp();
+    pane.pan(ctx.tick % 120 < 60 ? step : -step); // sweep right, then back
+  },
+};
+
 // ---------------------------------------------------------------------------
 // Child: run one (scenario, presenter/backend) and print a JSON line.
 // ---------------------------------------------------------------------------
@@ -1033,6 +1139,14 @@ async function runChild() {
   const scenario = SCENARIOS[name];
   process.env.REACT_X11_NO_AUTORUN = '1';
   const { createRoot } = await import('../../src/index.js');
+  // the `pane` scenario's element, registered before anything renders —
+  // harmless to every other scenario, and the registry is per process
+  const { Node } = await import('../../src/node.js');
+  const { registerElement } = await import('../../src/host.js');
+  const BenchPaneNode = definePane(Node);
+  registerElement('benchpane', {
+    create: (props, app) => new BenchPaneNode(props, app),
+  });
   const { Icon } = await import('../../src/components/Icon.js');
   const store = makeStore(COLS * ROWS);
   const deps = { Icon, store };

--- a/src/cocoa/presenter.js
+++ b/src/cocoa/presenter.js
@@ -19,12 +19,14 @@
 //
 // Sibling order is zPosition, assigned from the node's own paintOrder() —
 // no sublayer-list surgery, ever. Dirt arrives on the invalidate channel
-// (`noteInvalidate`): a node means that node, null means everything (the
-// same "no bound named repaints everything" rule the X11 damage model has),
-// and geometry is re-diffed every frame because comparing four numbers is
-// cheaper than knowing.
+// (`noteInvalidate`): a node means that node, a bare rect means every
+// raster whose ink it touches, null means everything (the same "no bound
+// named repaints everything" rule the X11 damage model has), and geometry
+// is re-diffed every frame because comparing four numbers is cheaper than
+// knowing.
 import { cssColorStraight } from 'ntk';
 
+import { Node } from '../nodes.js';
 import { CocoaContext2D } from './context2d.js';
 
 const RASTER_PAD = 2; // antialiasing/italic overhang outside the ink bounds
@@ -254,14 +256,47 @@ class ShapeRecorder {
   }
 }
 
-/** Paint everything a node draws itself — Node.paint minus the children. */
+/**
+ * Paint everything a node draws itself — Node.paint minus the children.
+ *
+ * An element that overrides `paint` (every drawing element in
+ * @react-x11/components does: `super.paint(ctx)` for the box, then the
+ * scene) has its content nowhere but in that override, so the override is
+ * what a raster replays — with the children held back by `_ownPaintOnly`,
+ * the one presenter-side flag `Node._paintChildren` honours, because they
+ * have visuals of their own. Everything else paints piecewise, which is
+ * what `Node.paint` would do minus the child walk.
+ */
 function paintSelf(node, ctx) {
+  if (node.paint !== Node.prototype.paint) {
+    node._ownPaintOnly = true;
+    try {
+      node.paint(ctx);
+    } finally {
+      node._ownPaintOnly = false;
+    }
+    return;
+  }
   node._paintShadow(ctx);
   node._paintBackground(ctx);
   node.paintContent(ctx);
   node._paintBorder(ctx);
   node._paintOutline(ctx);
 }
+
+/** Do two rects share any area? Touching edges do not count. */
+function rectsOverlap(a, b) {
+  return (
+    a.x < b.x + b.width &&
+    b.x < a.x + a.width &&
+    a.y < b.y + b.height &&
+    b.y < a.y + a.height
+  );
+}
+
+// Past this many bare-rect claims in one frame the overlap test costs more
+// than it saves, and the answer is the one a null claim gives: everything.
+const MAX_DIRTY_RECTS = 64;
 
 const EDGE_PROPS = [
   'borderTopColor',
@@ -393,8 +428,14 @@ export class CocoaLayerPresenter {
     this.visuals = new Map(); // node -> Visual
     this.rasters = new Map(); // node -> RasterState
     this.bars = new Map(); // scroller node -> Map(axis -> { layer, raster })
-    this.dirty = new Set();
+    // Claims since the last frame — taken at the top of `frame()`, the way
+    // the X11 path takes its damage before painting, so a claim made from
+    // inside a paint lands in the next frame instead of being cleared with
+    // this one.
+    this.dirty = new Set(); // nodes
+    this.dirtyRects = []; // bare rects, window coordinates
     this.dirtyAll = true; // first frame rasters everything
+    this._claims = null; // the frame in progress: { all, nodes, rects }
     this.rootVisual = {
       layer: window._layer,
     };
@@ -415,12 +456,58 @@ export class CocoaLayerPresenter {
       // say which node that was. Everything re-rasters; a scroll names its
       // node and stays off this path.
       this.dirtyAll = true;
+    } else if (damage.width > 0 && damage.height > 0) {
+      // A bare rect with no layout behind it is a claim about pixels — an
+      // element's `invalidate(false, rect)` for the box a dragged node
+      // moved through, the region `scrollContents` shifts, the strip an
+      // animation ticks in — and it cannot name the node it came from
+      // either. The frame re-rasters every raster visual whose ink the
+      // rect touches (the same conservative answer the damage model gives
+      // a rect: whatever draws there repaints); property boxes carry no
+      // raster and re-diff every frame regardless. Copied, because a
+      // caller's rect is very often a live `abs` about to be laid out.
+      if (this.dirtyRects.length >= MAX_DIRTY_RECTS) {
+        this.dirtyAll = true;
+      } else {
+        this.dirtyRects.push({
+          x: damage.x,
+          y: damage.y,
+          width: damage.width,
+          height: damage.height,
+        });
+      }
     }
+  }
+
+  /** The claims a frame consumes, cleared for the next one. */
+  _takeClaims() {
+    const claims = {
+      all: this.dirtyAll,
+      nodes: this.dirty,
+      rects: this.dirtyAll ? [] : this.dirtyRects,
+    };
+    this.dirtyAll = false;
+    this.dirty = new Set();
+    this.dirtyRects = [];
+    return claims;
+  }
+
+  /** Does this frame re-raster the visual covering `rect` for `node`? */
+  _needsRaster(node, rect) {
+    const claims = this._claims;
+    if (!claims) return true; // outside a frame: nothing is known to be current
+    if (claims.all || claims.nodes.has(node)) return true;
+    for (const claimed of claims.rects) {
+      if (rectsOverlap(claimed, rect)) return true;
+    }
+    return false;
   }
 
   /** The whole frame: one walk, one transaction, property diffs only. */
   frame(windowNode) {
     const native = this.native;
+    const claims = (this._claims = this._takeClaims());
+    let presented = false;
     native.txBegin({ disableActions: true });
     try {
       this._syncWindowBackground(windowNode);
@@ -441,11 +528,24 @@ export class CocoaLayerPresenter {
           }
         }
       }
+      presented = true;
     } finally {
       native.txCommit();
+      this._claims = null;
+      // a frame that threw half-way presents what it got to; the claims it
+      // was answering are still owed, so the next frame answers them again
+      if (!presented) this._restoreClaims(claims);
     }
-    this.dirty.clear();
-    this.dirtyAll = false;
+  }
+
+  _restoreClaims(claims) {
+    this.dirtyAll ||= claims.all;
+    for (const node of claims.nodes) this.dirty.add(node);
+    if (this.dirtyRects.length + claims.rects.length > MAX_DIRTY_RECTS) {
+      this.dirtyAll = true;
+    } else {
+      this.dirtyRects.push(...claims.rects);
+    }
   }
 
   _dropRaster(node) {
@@ -611,9 +711,8 @@ export class CocoaLayerPresenter {
     const s = this.scale;
     if (
       !sizeChanged &&
-      !this.dirtyAll &&
-      !this.dirty.has(node) &&
-      visual.shapeSignature
+      visual.shapeSignature &&
+      !this._needsRaster(node, rect)
     ) {
       return true; // shapes are current
     }
@@ -759,7 +858,7 @@ export class CocoaLayerPresenter {
       }
       this._dropSvgShapes(visual);
     }
-    if (!this.dirtyAll && !this.dirty.has(node) && !sizeChanged) return;
+    if (!sizeChanged && !this._needsRaster(node, rect)) return;
     const ctx = raster.ensure(this, rect.width, rect.height, this.window.scale);
     ctx.save();
     try {

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -4553,6 +4553,11 @@ export class Node {
   }
 
   _paintChildren(ctx) {
+    // A retained presenter replays a node's `paint` into a visual of that
+    // node's own — its children have visuals of their own, so it sets this
+    // for the duration of the call (src/cocoa/presenter.js, `paintSelf`).
+    // Never set on the X11 or surface paths, where a frame is one walk.
+    if (this._ownPaintOnly) return;
     const order = this.paintOrder();
     if (order.length === 0) return;
     const clip = this.clipsChildren() && this._childrenCanOverflow();

--- a/test/cocoa-presenter.test.js
+++ b/test/cocoa-presenter.test.js
@@ -1,0 +1,234 @@
+// The retained layer presenter (src/cocoa/presenter.js) over a recording
+// bridge: what it rasters, and when. The node tree, its layout and the
+// invalidate channel are the real ones — the mock harness mounts the tree —
+// and only the Core Animation bridge is faked, so this runs on every
+// platform and says nothing about pixels. What it does pin is the contract
+// docs/macos.md §"Custom drawing on a layer tree" makes: a registered
+// element that overrides `paint` works unchanged through the raster visual,
+// and a damage claim — a node or a bare rect — is what re-rasters it.
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import { cssColorStraight } from 'ntk';
+
+import { registerElement, unregisterElement } from '../src/host.js';
+import { Node } from '../src/node.js';
+import { renderX11, cleanup, screen } from '../src/testing/index.js';
+import { CocoaLayerPresenter } from '../src/cocoa/presenter.js';
+import { CocoaContext2D } from '../src/cocoa/context2d.js';
+
+const h = React.createElement;
+
+/**
+ * A scene element the way @react-x11/components draws one: `super.paint`
+ * for the box, then its own content — in `paint`, not `paintContent`, which
+ * is the shape the presenter has to replay. Counts the two paths apart: a
+ * paint into the presenter's CG context is a raster, anything else is the
+ * mock window's own frame.
+ */
+class SceneNode extends Node {
+  constructor(props, app) {
+    super('scene', props, app);
+    this.rasters = 0;
+    this.painted = 0;
+    this._claimedFromPaint = false;
+  }
+
+  paint(ctx) {
+    super.paint(ctx);
+    if (ctx instanceof CocoaContext2D) this.rasters++;
+    else this.painted++;
+    ctx.fillStyle = '#c0392b';
+    ctx.fillRect(this.abs.x, this.abs.y, 10, 10);
+    // an element that discovers mid-raster that it owes another pass — the
+    // claim is made while the presenter is inside its frame
+    if (
+      this.props.claimOnPaint &&
+      ctx instanceof CocoaContext2D &&
+      !this._claimedFromPaint
+    ) {
+      this._claimedFromPaint = true;
+      this.invalidate(false, this.abs, 'props');
+    }
+  }
+}
+
+/** A bridge that records every call and answers the few that need a handle. */
+function fakeBridge() {
+  const calls = [];
+  let surfaces = 0;
+  const native = new Proxy(
+    {},
+    {
+      get(_, name) {
+        if (typeof name !== 'string') return undefined;
+        return (...args) => {
+          calls.push(name);
+          if (name.startsWith('create') && name.endsWith('Layer')) {
+            return { layer: calls.length };
+          }
+          if (name === 'createSurface') {
+            return { surface: ++surfaces, width: args[0], height: args[1] };
+          }
+          if (name === 'surfaceSize') {
+            return { width: args[0].width, height: args[0].height };
+          }
+          return undefined;
+        };
+      },
+    },
+  );
+  return {
+    native,
+    calls,
+    uploads: () => calls.filter((name) => name === 'surfaceToLayer').length,
+  };
+}
+
+/** The presenter over a fake cocoa window, wired to the mounted tree's
+ * invalidate channel the way src/cocoa/window.js wires it in layers mode. */
+function presenterFor({ windowNode, app }) {
+  const bridge = fakeBridge();
+  const presenter = new CocoaLayerPresenter({
+    _native: bridge.native,
+    scale: 1,
+    app: { fonts: app.fonts, _parseColor: (c) => cssColorStraight(String(c)) },
+    _layer: { layer: 'root' },
+  });
+  windowNode.window.noteInvalidate = (damage, layoutChanged) =>
+    presenter.noteInvalidate(damage, layoutChanged);
+  return { presenter, bridge };
+}
+
+const registered = new Set();
+function register(type, definition) {
+  registerElement(type, definition);
+  registered.add(type);
+}
+
+afterEach(async () => {
+  await cleanup();
+  for (const type of registered) unregisterElement(type);
+  registered.clear();
+});
+
+async function mountScene(props = {}) {
+  register('scene', {
+    create: (p, app) => new SceneNode(p, app),
+    semanticNames: ['name', 'claimOnPaint'],
+  });
+  const mounted = await renderX11(
+    h(
+      'box',
+      { style: { flexGrow: 1 } },
+      h(
+        'scene',
+        { name: 'outer', style: { width: 200, height: 100 }, ...props },
+        h('scene', { name: 'inner', style: { width: 50, height: 20 } }),
+      ),
+    ),
+    { backend: 'mock' },
+  );
+  const byName = (name) =>
+    screen.all((n) => n.kind === 'scene' && n.props.name === name)[0];
+  return { ...mounted, outer: byName('outer'), inner: byName('inner') };
+}
+
+test('an element that overrides paint() is replayed by its raster, without its children', async () => {
+  const mounted = await mountScene();
+  const { outer, inner, windowNode } = mounted;
+  // the surface path is what it was: the parent's walk painted the child
+  assert.ok(
+    inner.painted > 0,
+    'the mock frame painted the child through its parent',
+  );
+  assert.strictEqual(outer._ownPaintOnly, undefined);
+
+  const { presenter, bridge } = presenterFor(mounted);
+  presenter.frame(windowNode);
+
+  assert.strictEqual(
+    outer.rasters,
+    1,
+    'the override is what the raster replays',
+  );
+  // once for its own visual — a second paint would be the parent's walk
+  assert.strictEqual(
+    inner.rasters,
+    1,
+    'the child paints only into its own visual',
+  );
+  assert.ok(
+    presenter.visuals.get(inner)?.isRaster,
+    'the child is a raster of its own',
+  );
+  assert.strictEqual(bridge.uploads(), 2, 'one upload per raster visual');
+  assert.strictEqual(
+    outer._ownPaintOnly,
+    false,
+    'the flag is only up during the replay',
+  );
+  assert.strictEqual(inner._ownPaintOnly, false);
+
+  // nothing claimed since: nothing re-rasters
+  presenter.frame(windowNode);
+  assert.strictEqual(outer.rasters, 1);
+  assert.strictEqual(inner.rasters, 1);
+  assert.strictEqual(bridge.uploads(), 2);
+});
+
+test('a bare-rect claim re-rasters the visuals its ink touches, and nothing else', async () => {
+  const mounted = await mountScene();
+  const { outer, inner, windowNode } = mounted;
+  const { presenter } = presenterFor(mounted);
+  presenter.frame(windowNode);
+  assert.deepStrictEqual([outer.rasters, inner.rasters], [1, 1]);
+
+  // the box a dragged node moved through, well away from the inner element
+  outer.invalidate(
+    false,
+    { x: outer.abs.x + 150, y: outer.abs.y + 60, width: 8, height: 8 },
+    'props',
+  );
+  presenter.frame(windowNode);
+  assert.deepStrictEqual([outer.rasters, inner.rasters], [2, 1]);
+
+  // a pan: the region scrollContents shifts is a claim on that rect — the
+  // inner pane re-rasters, and so does the outer one under it, because a
+  // rect cannot say whose pixels changed and everything drawing there does
+  inner.scrollContents(inner.contentBox(), 3, 0);
+  presenter.frame(windowNode);
+  assert.deepStrictEqual([outer.rasters, inner.rasters], [3, 2]);
+
+  // a claim that touches neither
+  outer.invalidate(false, { x: 600, y: 500, width: 20, height: 20 }, 'props');
+  presenter.frame(windowNode);
+  assert.deepStrictEqual([outer.rasters, inner.rasters], [3, 2]);
+
+  // an empty rect claims nothing
+  outer.invalidate(false, { ...outer.abs, width: 0 }, 'props');
+  presenter.frame(windowNode);
+  assert.deepStrictEqual([outer.rasters, inner.rasters], [3, 2]);
+
+  // a rect with a layout change behind it is still everything
+  presenter.noteInvalidate({ x: 600, y: 500, width: 20, height: 20 }, true);
+  presenter.frame(windowNode);
+  assert.deepStrictEqual([outer.rasters, inner.rasters], [4, 3]);
+});
+
+test('a claim made from inside a frame lands in the next one', async () => {
+  const mounted = await mountScene({ claimOnPaint: true });
+  const { outer, inner, windowNode } = mounted;
+  const { presenter } = presenterFor(mounted);
+  presenter.frame(windowNode);
+  assert.deepStrictEqual([outer.rasters, inner.rasters], [1, 1]);
+  // the outer element claimed its own box while the first frame replayed it
+  presenter.frame(windowNode);
+  assert.strictEqual(
+    outer.rasters,
+    2,
+    'the mid-frame claim was not cleared with the frame',
+  );
+  presenter.frame(windowNode);
+  assert.strictEqual(outer.rasters, 2);
+});


### PR DESCRIPTION
In layers mode a registered element that overrides `paint` drew nothing: `paintSelf` replayed the piecewise painters plus `paintContent`, and every drawing element in @react-x11/components puts its scene in a `paint` override after `super.paint`. The Flow pane in the components' `examples/flow-stress.tsx` was blank, at zero `paint` calls per frame. And `noteInvalidate` dropped a bare damage rect whenever `layoutChanged` was false, which is exactly what an element's `invalidate(false, rect)` and the region `scrollContents` shifts look like, so even a correctly rastered element never re-rastered on a pan or a drag.

Two changes in `src/cocoa/presenter.js` and one seam in `src/nodes.js`:

- The raster visual replays `node.paint` when it is overridden, under a per-node `_ownPaintOnly` flag that `Node._paintChildren` honours, because the children have visuals of their own. Everything else still paints piecewise. Nothing on the X11 or surface paths ever sets the flag.
- A bare rect with no layout change behind it is recorded, and the frame re-rasters every raster visual whose ink rect overlaps one of them, falling back to everything past 64 rects in a frame. Property boxes carry no raster and re-diff every frame regardless.
- Claims are taken at the top of `frame` the way the X11 path takes its damage before painting, so a claim made from inside a paint lands in the next frame, and a frame that throws hands its claims back.

`docs/macos.md`, "Custom drawing on a layer tree", states both rules. `test/cocoa-presenter.test.js` runs the presenter over a recording bridge on the mock harness's tree; each of the four changes fails at least one of its three tests when reverted. `scripts/bench/presenters.js` gains a `pane` scenario: a registered element panning its scene by `scrollContents`, the Flow shape.

## Verification

`npm run bench:presenters -- --scenario=pane`, 3 s cells at 2x, bridge 0.4.0:

| presenter | fps | flush avg | upload per frame |
|---|---|---|---|
| surface | 56.3 | 1.07 ms | 1.0x 2219 kpx |
| layers | 57.0 | 5.36 ms | 1.0x 2232 kpx |

Before the fix the layers row had no uploads and a stale picture.

The components' `examples/flow-stress.tsx` against this branch in layers mode, 300-node scene: the pane paints on every pan tick and every drag step, and the dragged node moves and lands selected. Rendered by this branch:

![flow-layers-rebased](https://github.com/user-attachments/assets/26e61fdb-0cb1-4c3a-81a0-5c0c73bd2ce0)

`npm test` passes apart from the six documented macOS appearance failures, and `npm run bench:pixels -- --check` reports pixels unchanged, so the X11 and surface paths render what they did.

## Not in this PR

On layers `paintDamage` is null, so a drag step re-rasters the whole 2.1 Mpx pane: about 3 fps against 31 steps per second on the surface presenter. Keeping the raster bitmap, clipping to the claimed rects and setting the window's paint damage around the replay would let the element cull the way it does on X11.

