### PR TITLE
perf(cocoa): a bare-rect claim repaints only that part of a raster, and the element sees the pass

### DIFF
--- a/docs/macos.md
+++ b/docs/macos.md
@@ -761,8 +761,12 @@ node's own damage claims, `contentsScale` from the window. A claim that
 names the node re-rasters that node; a bare rect — an element's
 `invalidate(false, rect)` for the box a dragged item moved through, the
 region `scrollContents` shifts, the strip an animation ticks in —
-re-rasters every raster visual whose ink it touches, the same
-conservative answer the damage model gives a rect on X11.
+repaints every raster visual whose ink it touches, the same
+conservative answer the damage model gives a rect on X11 — and only that
+part of each: the raster keeps its bitmap as the visual's composition
+cache, the pass clears and clips to the claim, and `paintDamage()` names
+it, so an element culls a drag step or an animation tick the way it does
+on X11 instead of replaying its whole scene into a clip.
 
 - `<canvas onDraw>`: `paintContent` runs against the CG ctx; a new
   `onDraw` closure invalidates the node (existing rule); `putImageData`

--- a/scripts/bench/presenters.js
+++ b/scripts/bench/presenters.js
@@ -1037,11 +1037,18 @@ const PANE_CELL = 28;
 const PANE_GAP = 12;
 const PANE_TINTS = ['#4c6ef5', '#12b886', '#fd7e14', '#be4bdb'];
 
+const rectsTouch = (a, b) =>
+  a.x < b.x + b.width &&
+  b.x < a.x + a.width &&
+  a.y < b.y + b.height &&
+  b.y < a.y + a.height;
+
 function definePane(NodeClass) {
   return class BenchPaneNode extends NodeClass {
     constructor(props, app) {
       super('benchpane', props, app);
       this.offset = 0; // device pixels the scene has moved right
+      this.hot = -1; // the cell a drag is holding, by index
     }
 
     pan(dx) {
@@ -1050,83 +1057,133 @@ function definePane(NodeClass) {
       this.scrollContents(this.contentBox(), dx, 0);
     }
 
+    /** Move the hot cell: the cell it leaves and the cell it lands on are
+     * the two claims — the box a dragged node moved through, and nothing
+     * else about the pane. */
+    poke(tick) {
+      const cells = [...this.cells()];
+      if (!cells.length) return;
+      const from = cells[this.hot];
+      this.hot = (tick * 7) % cells.length;
+      const to = cells[this.hot];
+      for (const c of [from, to]) {
+        if (!c) continue;
+        // the cell plus the edge it draws to the next column, and a pixel
+        // of antialiasing on every side
+        this.invalidate(
+          false,
+          { x: c.x - 1, y: c.y - 1, width: c.pitch + 2, height: c.cell + 2 },
+          'props',
+        );
+      }
+    }
+
+    *cells() {
+      const box = this.contentBox();
+      const s = this.scale;
+      const cell = PANE_CELL * s;
+      const pitch = (PANE_CELL + PANE_GAP) * s;
+      const phase = ((this.offset % pitch) + pitch) % pitch;
+      let row = 0;
+      for (let y = box.y + PANE_GAP * s; y < box.y + box.height; y += pitch) {
+        let col = 0;
+        for (let x = box.x + phase - pitch; x < box.x + box.width; x += pitch) {
+          yield { x, y, width: cell, height: cell, row, col, cell, pitch };
+          col += 1;
+        }
+        row += 1;
+      }
+    }
+
     paint(ctx) {
       super.paint(ctx);
       const box = this.contentBox();
       if (!(box.width > 0 && box.height > 0)) return;
       const damage = this.paintDamage();
       const s = this.scale;
-      const cell = PANE_CELL * s;
-      const pitch = (PANE_CELL + PANE_GAP) * s;
-      const phase = ((this.offset % pitch) + pitch) % pitch;
       ctx.save();
       ctx.beginPath();
       ctx.rect(box.x, box.y, box.width, box.height);
       ctx.clip();
-      let row = 0;
-      for (let y = box.y + PANE_GAP * s; y < box.y + box.height; y += pitch) {
-        let col = 0;
-        for (let x = box.x + phase - pitch; x < box.x + box.width; x += pitch) {
-          const r = { x, y, width: cell, height: cell };
-          col += 1;
-          if (
-            damage &&
-            !(
-              r.x < damage.x + damage.width &&
-              damage.x < r.x + r.width &&
-              r.y < damage.y + damage.height &&
-              damage.y < r.y + r.height
-            )
-          ) {
-            continue;
-          }
-          ctx.fillStyle = PANE_TINTS[(row + col) % PANE_TINTS.length];
-          ctx.fillRect(r.x, r.y, r.width, r.height);
-          ctx.strokeStyle = '#1f2933';
-          ctx.lineWidth = s;
-          ctx.beginPath();
-          ctx.moveTo(r.x + cell, r.y + cell / 2);
-          ctx.lineTo(r.x + pitch, r.y + cell / 2 + cell / 3);
-          ctx.stroke();
+      let index = 0;
+      for (const r of this.cells()) {
+        const hot = index === this.hot;
+        index += 1;
+        // culled against the cell's whole reach: the edge runs to the
+        // next column
+        if (damage && !rectsTouch({ ...r, width: r.pitch }, damage)) {
+          continue;
         }
-        row += 1;
+        ctx.fillStyle = hot
+          ? '#e03131'
+          : PANE_TINTS[(r.row + r.col) % PANE_TINTS.length];
+        ctx.fillRect(r.x, r.y, r.width, r.height);
+        ctx.strokeStyle = '#1f2933';
+        ctx.lineWidth = s;
+        ctx.beginPath();
+        ctx.moveTo(r.x + r.cell, r.y + r.cell / 2);
+        ctx.lineTo(r.x + r.pitch, r.y + r.cell / 2 + r.cell / 3);
+        ctx.stroke();
       }
       ctx.restore();
     }
   };
 }
 
+const paneTree = (title) =>
+  windowOf(
+    [
+      e(
+        'box',
+        { style: { flexGrow: 1, padding: 16, gap: 12 } },
+        e(
+          'text',
+          { style: { color: '#7f8c8d' } },
+          'a label beside the pane — it must not re-raster on a pan',
+        ),
+        e('benchpane', {
+          style: {
+            flexGrow: 1,
+            borderWidth: 1,
+            borderColor: '#c3ccd8',
+            backgroundColor: '#ffffff',
+          },
+        }),
+      ),
+    ],
+    title,
+  );
+
 SCENARIOS.pane = {
   latency: true,
-  tree: () =>
-    windowOf(
-      [
-        e(
-          'box',
-          { style: { flexGrow: 1, padding: 16, gap: 12 } },
-          e(
-            'text',
-            { style: { color: '#7f8c8d' } },
-            'a label beside the pane — it must not re-raster on a pan',
-          ),
-          e('benchpane', {
-            style: {
-              flexGrow: 1,
-              borderWidth: 1,
-              borderColor: '#c3ccd8',
-              backgroundColor: '#ffffff',
-            },
-          }),
-        ),
-      ],
-      'bench pane',
-    ),
+  tree: () => paneTree('bench pane'),
   drive(ctx) {
     const pane = ctx.find((n) => n.kind === 'benchpane');
     if (!pane) return;
     const step = Math.round(2 * (pane.scale || 1));
     ctx.stamp();
     pane.pan(ctx.tick % 120 < 60 ? step : -step); // sweep right, then back
+  },
+};
+
+/**
+ * The drag shape on the same pane: a hot cell moves every tick and the
+ * element claims the cell it left and the cell it landed on — two small
+ * rects, the box a dragged node moved through. The surface presenter
+ * repaints those rects of the window; the layers presenter repaints those
+ * rects of the pane's raster and hands the bitmap back, with
+ * `paintDamage()` letting the element cull, instead of replaying the whole
+ * scene into a clip. Compare `flush` against `pane`, whose claim is the
+ * whole content box.
+ */
+SCENARIOS.drag = {
+  latency: true,
+  tree: () => paneTree('bench drag'),
+  drive(ctx) {
+    const pane = ctx.find((n) => n.kind === 'benchpane');
+    if (!pane) return;
+    ctx.stamp();
+    pane.poke(ctx.tick);
   },
 };
 

--- a/src/cocoa/presenter.js
+++ b/src/cocoa/presenter.js
@@ -19,14 +19,19 @@
 //
 // Sibling order is zPosition, assigned from the node's own paintOrder() —
 // no sublayer-list surgery, ever. Dirt arrives on the invalidate channel
-// (`noteInvalidate`): a node means that node, a bare rect means every
-// raster whose ink it touches, null means everything (the same "no bound
+// (`noteInvalidate`): a node means that node, a bare rect means that part
+// of every raster it touches, null means everything (the same "no bound
 // named repaints everything" rule the X11 damage model has), and geometry
 // is re-diffed every frame because comparing four numbers is cheaper than
 // knowing.
 import { cssColorStraight } from 'ntk';
 
-import { Node } from '../nodes.js';
+import {
+  Node,
+  addDamageRect,
+  damageToPaint,
+  intersectRects,
+} from '../nodes.js';
 import { CocoaContext2D } from './context2d.js';
 
 const RASTER_PAD = 2; // antialiasing/italic overhang outside the ink bounds
@@ -284,19 +289,25 @@ function paintSelf(node, ctx) {
   node._paintOutline(ctx);
 }
 
-/** Do two rects share any area? Touching edges do not count. */
-function rectsOverlap(a, b) {
-  return (
-    a.x < b.x + b.width &&
-    b.x < a.x + a.width &&
-    a.y < b.y + b.height &&
-    b.y < a.y + a.height
-  );
-}
-
 // Past this many bare-rect claims in one frame the overlap test costs more
 // than it saves, and the answer is the one a null claim gives: everything.
 const MAX_DIRTY_RECTS = 64;
+
+// The pass list of a raster that repaints in full: one pass, unbounded.
+const FULL_PASS = Object.freeze([null]);
+
+/** A rect grown outward to whole pixels — a pass clears and clips to its
+ * edges, and a fractional edge would antialias the clip into a seam. */
+function wholePixels(rect) {
+  const x = Math.floor(rect.x);
+  const y = Math.floor(rect.y);
+  return {
+    x,
+    y,
+    width: Math.ceil(rect.x + rect.width) - x,
+    height: Math.ceil(rect.y + rect.height) - y,
+  };
+}
 
 const EDGE_PROPS = [
   'borderTopColor',
@@ -461,11 +472,12 @@ export class CocoaLayerPresenter {
       // element's `invalidate(false, rect)` for the box a dragged node
       // moved through, the region `scrollContents` shifts, the strip an
       // animation ticks in — and it cannot name the node it came from
-      // either. The frame re-rasters every raster visual whose ink the
-      // rect touches (the same conservative answer the damage model gives
-      // a rect: whatever draws there repaints); property boxes carry no
-      // raster and re-diff every frame regardless. Copied, because a
-      // caller's rect is very often a live `abs` about to be laid out.
+      // either. The frame repaints that part of every raster visual whose
+      // ink the rect touches (the same conservative answer the damage model
+      // gives a rect: whatever draws there repaints, clipped to it);
+      // property boxes carry no raster and re-diff every frame regardless.
+      // Copied, because a caller's rect is very often a live `abs` about
+      // to be laid out.
       if (this.dirtyRects.length >= MAX_DIRTY_RECTS) {
         this.dirtyAll = true;
       } else {
@@ -492,15 +504,33 @@ export class CocoaLayerPresenter {
     return claims;
   }
 
+  /**
+   * What this frame repaints of the raster covering `rect` for `node`: null
+   * for nothing, `FULL_PASS` for all of it, otherwise the window-space rects
+   * the frame's bare claims cover inside it, shaped exactly as the X11 path
+   * shapes its damage list: whole pixels, disjoint, at most a few of them,
+   * and one box instead of several when the several fill most of it —
+   * because a node painted in two overlapping passes blends translucent ink
+   * over itself, and because each pass is a full replay of the node's paint
+   * that only its own culling makes cheap. A pan's shifted region and the
+   * two strips beside it come out as the one pass they are.
+   */
+  _rasterPasses(node, rect, sizeChanged) {
+    const claims = this._claims;
+    if (sizeChanged || !claims || claims.all || claims.nodes.has(node)) {
+      return FULL_PASS;
+    }
+    let passes = null;
+    for (const claimed of claims.rects) {
+      const hit = intersectRects(wholePixels(claimed), rect);
+      if (hit) passes = addDamageRect(passes, hit);
+    }
+    return passes && damageToPaint(passes);
+  }
+
   /** Does this frame re-raster the visual covering `rect` for `node`? */
   _needsRaster(node, rect) {
-    const claims = this._claims;
-    if (!claims) return true; // outside a frame: nothing is known to be current
-    if (claims.all || claims.nodes.has(node)) return true;
-    for (const claimed of claims.rects) {
-      if (rectsOverlap(claimed, rect)) return true;
-    }
-    return false;
+    return this._rasterPasses(node, rect, false) !== null;
   }
 
   /** The whole frame: one walk, one transaction, property diffs only. */
@@ -858,13 +888,38 @@ export class CocoaLayerPresenter {
       }
       this._dropSvgShapes(visual);
     }
-    if (!sizeChanged && !this._needsRaster(node, rect)) return;
+    const passes = this._rasterPasses(node, rect, sizeChanged);
+    if (!passes) return;
     const ctx = raster.ensure(this, rect.width, rect.height, this.window.scale);
+    // The bitmap is this visual's composition cache, the way the window's
+    // backing store is the surface presenter's: a pass over part of it
+    // clears and clips to that part and leaves the rest as last frame drew
+    // it, and `paintDamage()` names the pass, so an element culls a drag
+    // step or an animation tick exactly as it does on X11 (docs/extending.md,
+    // "Drawing a scene into one node") instead of replaying its whole scene
+    // into a clip that throws almost all of it away. The full pass is the
+    // same loop with nothing to clip.
+    const root = node.root;
     ctx.save();
     try {
-      ctx.clearRect(0, 0, rect.width, rect.height);
       ctx.translate(-rect.x, -rect.y);
-      paintSelf(node, ctx);
+      for (const pass of passes) {
+        const area = pass ?? rect;
+        ctx.save();
+        try {
+          if (pass) {
+            ctx.beginPath();
+            ctx.rect(area.x, area.y, area.width, area.height);
+            ctx.clip();
+          }
+          ctx.clearRect(area.x, area.y, area.width, area.height);
+          if (root) root._paintDamage = pass;
+          paintSelf(node, ctx);
+        } finally {
+          if (root) root._paintDamage = null;
+          ctx.restore();
+        }
+      }
     } finally {
       ctx.restore();
     }

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -409,7 +409,7 @@ function insetRect(rect, by) {
 }
 
 /** The overlap of two rects, or null when they have none. */
-function intersectRects(a, b) {
+export function intersectRects(a, b) {
   const x = Math.max(a.x, b.x);
   const y = Math.max(a.y, b.y);
   const right = Math.min(a.x + a.width, b.x + b.width);
@@ -552,7 +552,7 @@ function coalesceRects(rects) {
  * neighbours go first and far-apart rects last. That merge can itself overlap a
  * third rect, so the result is coalesced again.
  */
-function addDamageRect(rects, add, cap = MAX_DAMAGE_RECTS) {
+export function addDamageRect(rects, add, cap = MAX_DAMAGE_RECTS) {
   let out = coalesceRects(
     (rects ?? []).concat([
       { x: add.x, y: add.y, width: add.width, height: add.height },
@@ -591,7 +591,7 @@ function addDamageRect(rects, add, cap = MAX_DAMAGE_RECTS) {
  * answers cover every claimed pixel, so this is a cost decision and never a
  * correctness one.
  */
-function damageToPaint(rects) {
+export function damageToPaint(rects) {
   if (rects.length < 2) return rects;
   const box = rectsBounds(rects);
   let sum = 0;

--- a/test/cocoa-presenter.test.js
+++ b/test/cocoa-presenter.test.js
@@ -5,7 +5,9 @@
 // platform and says nothing about pixels. What it does pin is the contract
 // docs/macos.md §"Custom drawing on a layer tree" makes: a registered
 // element that overrides `paint` works unchanged through the raster visual,
-// and a damage claim — a node or a bare rect — is what re-rasters it.
+// a damage claim — a node or a bare rect — is what re-rasters it, and a
+// bare rect repaints only that part of the raster, with `paintDamage()`
+// naming the pass the way the X11 path does.
 import { test, afterEach } from 'node:test';
 import assert from 'node:assert';
 import React from 'react';
@@ -24,20 +26,26 @@ const h = React.createElement;
  * for the box, then its own content — in `paint`, not `paintContent`, which
  * is the shape the presenter has to replay. Counts the two paths apart: a
  * paint into the presenter's CG context is a raster, anything else is the
- * mock window's own frame.
+ * mock window's own frame — and records what `paintDamage()` answered on
+ * each raster, which is what a scene culls against.
  */
 class SceneNode extends Node {
   constructor(props, app) {
     super('scene', props, app);
     this.rasters = 0;
     this.painted = 0;
+    this.damages = [];
     this._claimedFromPaint = false;
   }
 
   paint(ctx) {
     super.paint(ctx);
-    if (ctx instanceof CocoaContext2D) this.rasters++;
-    else this.painted++;
+    if (ctx instanceof CocoaContext2D) {
+      this.rasters++;
+      this.damages.push(this.paintDamage());
+    } else {
+      this.painted++;
+    }
     ctx.fillStyle = '#c0392b';
     ctx.fillRect(this.abs.x, this.abs.y, 10, 10);
     // an element that discovers mid-raster that it owes another pass — the
@@ -63,7 +71,7 @@ function fakeBridge() {
       get(_, name) {
         if (typeof name !== 'string') return undefined;
         return (...args) => {
-          calls.push(name);
+          calls.push({ name, args });
           if (name.startsWith('create') && name.endsWith('Layer')) {
             return { layer: calls.length };
           }
@@ -81,7 +89,10 @@ function fakeBridge() {
   return {
     native,
     calls,
-    uploads: () => calls.filter((name) => name === 'surfaceToLayer').length,
+    /** The arguments after the surface handle, per call of `name`. */
+    argsOf: (name) =>
+      calls.filter((c) => c.name === name).map((c) => c.args.slice(1)),
+    uploads: () => calls.filter((c) => c.name === 'surfaceToLayer').length,
   };
 }
 
@@ -134,6 +145,14 @@ async function mountScene(props = {}) {
   return { ...mounted, outer: byName('outer'), inner: byName('inner') };
 }
 
+/** A rect inside `node`, offset from its corner — window coordinates. */
+const within = (node, x, y, width, height) => ({
+  x: node.abs.x + x,
+  y: node.abs.y + y,
+  width,
+  height,
+});
+
 test('an element that overrides paint() is replayed by its raster, without its children', async () => {
   const mounted = await mountScene();
   const { outer, inner, windowNode } = mounted;
@@ -169,6 +188,11 @@ test('an element that overrides paint() is replayed by its raster, without its c
     'the flag is only up during the replay',
   );
   assert.strictEqual(inner._ownPaintOnly, false);
+  assert.deepStrictEqual(
+    outer.damages,
+    [null],
+    'the first frame is an unbounded pass',
+  );
 
   // nothing claimed since: nothing re-rasters
   presenter.frame(windowNode);
@@ -185,11 +209,7 @@ test('a bare-rect claim re-rasters the visuals its ink touches, and nothing else
   assert.deepStrictEqual([outer.rasters, inner.rasters], [1, 1]);
 
   // the box a dragged node moved through, well away from the inner element
-  outer.invalidate(
-    false,
-    { x: outer.abs.x + 150, y: outer.abs.y + 60, width: 8, height: 8 },
-    'props',
-  );
+  outer.invalidate(false, within(outer, 150, 60, 8, 8), 'props');
   presenter.frame(windowNode);
   assert.deepStrictEqual([outer.rasters, inner.rasters], [2, 1]);
 
@@ -214,6 +234,85 @@ test('a bare-rect claim re-rasters the visuals its ink touches, and nothing else
   presenter.noteInvalidate({ x: 600, y: 500, width: 20, height: 20 }, true);
   presenter.frame(windowNode);
   assert.deepStrictEqual([outer.rasters, inner.rasters], [4, 3]);
+});
+
+test('a bare-rect claim repaints only that part of the raster, and the element sees the pass', async () => {
+  const mounted = await mountScene();
+  const { outer, inner, windowNode } = mounted;
+  const { presenter, bridge } = presenterFor(mounted);
+  presenter.frame(windowNode);
+  bridge.calls.length = 0;
+
+  const box = within(outer, 150, 60, 8, 8);
+  outer.invalidate(false, box, 'props');
+  presenter.frame(windowNode);
+  assert.strictEqual(outer.rasters, 2);
+  assert.deepStrictEqual(
+    outer.damages.at(-1),
+    box,
+    'paintDamage() names the pass, in window coordinates',
+  );
+  assert.strictEqual(
+    windowNode._paintDamage,
+    null,
+    'the damage belongs to the pass alone',
+  );
+  // the bitmap keeps everything outside the claim: only the claim is
+  // cleared, and the replay is clipped to it — under the raster's own
+  // translate, so the coordinates are the window's
+  const rect = [box.x, box.y, box.width, box.height];
+  assert.deepStrictEqual(bridge.argsOf('ctxClearRect'), [rect]);
+  assert.ok(
+    bridge.argsOf('ctxRect').some((a) => a.every((v, i) => v === rect[i])),
+    'the clip path is the claim',
+  );
+  assert.ok(bridge.argsOf('ctxClip').length >= 1, 'and it is applied');
+  assert.strictEqual(bridge.uploads(), 1, 'the bitmap is handed back once');
+  assert.strictEqual(inner.rasters, 1, 'the inner visual was never touched');
+
+  // a claim that names the node is the whole raster again
+  outer.invalidate(false, outer, 'props');
+  presenter.frame(windowNode);
+  assert.strictEqual(outer.rasters, 3);
+  assert.strictEqual(outer.damages.at(-1), null);
+
+  // a fractional claim is grown to whole pixels, the way the X11 path snaps
+  // its damage: a clip on a fractional edge antialiases into a seam
+  outer.invalidate(false, within(outer, 100.4, 30.6, 8.2, 8.2), 'props');
+  presenter.frame(windowNode);
+  assert.deepStrictEqual(outer.damages.at(-1), within(outer, 100, 30, 9, 9));
+});
+
+test('overlapping claims merge into one pass, disjoint ones stay apart', async () => {
+  const mounted = await mountScene();
+  const { outer, windowNode } = mounted;
+  const { presenter } = presenterFor(mounted);
+  presenter.frame(windowNode);
+
+  // two overlapping rects: one pass over their union, because a node
+  // painted twice over the same pixels blends translucent ink over itself
+  const a = within(outer, 20, 40, 30, 30);
+  outer.invalidate(false, a, 'props');
+  outer.invalidate(false, within(outer, 30, 50, 30, 30), 'props');
+  presenter.frame(windowNode);
+  assert.strictEqual(outer.rasters, 2, 'one pass');
+  assert.deepStrictEqual(outer.damages.at(-1), { ...a, width: 40, height: 40 });
+
+  // two disjoint rects: two passes, each its own claim
+  const c = within(outer, 120, 70, 10, 10);
+  outer.invalidate(false, a, 'props');
+  outer.invalidate(false, c, 'props');
+  presenter.frame(windowNode);
+  assert.strictEqual(outer.rasters, 4, 'two passes');
+  assert.deepStrictEqual(outer.damages.slice(-2), [a, c]);
+
+  // a pan's shape — the shifted region and the strip beside it, edge to
+  // edge — fills its box, and is one pass the way it is on X11
+  outer.invalidate(false, within(outer, 10, 30, 100, 40), 'props');
+  outer.invalidate(false, within(outer, 10, 70, 100, 10), 'props');
+  presenter.frame(windowNode);
+  assert.strictEqual(outer.rasters, 5, 'one pass');
+  assert.deepStrictEqual(outer.damages.at(-1), within(outer, 10, 30, 100, 50));
 });
 
 test('a claim made from inside a frame lands in the next one', async () => {


### PR DESCRIPTION
The follow-up #448 left out. On the layers presenter a bare-rect claim re-rastered the whole visual it touched with `paintDamage` answering null, so a drag step in the components' Flow pane replayed all 300 nodes and 745 edges into a 2.1 Mpx bitmap, about 3 steps per second against 30 on the surface presenter.

A raster visual's bitmap now stays what it was outside the rects the frame claimed. Each pass clears and clips to one claimed rect and replays the node's paint with the window's paint damage set to it, so an element that culls against `paintDamage` does on layers exactly what it does on X11. The pass list is shaped the way `_takeDamage` shapes the X11 damage list, through the same helpers now exported from nodes.js: whole pixels, disjoint, at most four rects, and one box when several nearly fill it, so a pan's shifted region and its two strips stay one pass and translucent ink never blends over itself. A claim that names the node, a layout change and a size change still repaint the whole raster.

`docs/macos.md` states the rule in the custom-drawing section. `test/cocoa-presenter.test.js` gains two tests over the recording bridge: the pass is the claim, in window coordinates, with the clear and the clip on it and nothing else of the bitmap touched; overlapping claims merge, disjoint ones stay apart, a box-filling pair becomes one pass, and a fractional claim is grown to whole pixels. Each rule fails its test when reverted. `scripts/bench/presenters.js` gains a `drag` scenario on the same pane element as `pane`: a hot cell moves every tick and the element claims the cell it left and the one it landed on.

## Verification

The components' `examples/flow-stress.tsx` against this branch, layers presenter, 300-node scene, driven by 30 drag events at 16 ms:

| | before, #448 | this branch |
|---|---|---|
| drag steps per second | about 3 | 27.6 |
| pane paints per drag step | 1, whole scene | 1, culled to the claim |

The surface presenter does the same gesture at 58.7 steps per second.

`npm run bench:presenters -- --scenario=drag`, 3 s cells at 2x, bridge 0.4.0, layers row: flush 13.7 ms with the whole-raster replay, 9.4 ms with this branch. A profile of that frame says where the rest goes: CoreGraphics paint 0.12 ms for the three cells drawn, the bitmap handoff 0.05 ms, and the CATransaction commit 9.3 ms, on a WindowServer at 47% under a load average of 8. That commit is the cost of handing a whole 2.3 Mpx bitmap to the render server per frame, whatever was repainted, and it is not touched here. Absolute layers numbers were about three times faster on this machine this morning under a quieter WindowServer; compare within a run.

Rendered by this branch after the drag:

![flow-layers-partial](https://github.com/user-attachments/assets/4649d452-3bd2-49c6-91cb-b8b562227037)

`npm test` passes apart from the six documented macOS appearance failures, and `npm run bench:pixels -- --check` reports pixels unchanged.

## Next, not here

- The commit cost above: an IOSurface-backed raster with a flip and a damage-sized catch-up copy, the way the window's swapchain already presents, would make a partial pass cost what it paints.
- The pan: `scrollContents` claims the whole content box because the presenter has no `scrollRegion`, so a pan is still a whole-scene replay at about 4 fps against 49 on the surface presenter. Shifting the raster's own bitmap with the bridge's `scrollSurface` and narrowing the claim to the exposed strips is the layers form of the surface path's blit.

