### PR TITLE
feat: a `scale` prop zooms a subtree, CSS zoom semantics

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -153,6 +153,12 @@ mount: [drag-and-drop.md](drag-and-drop.md).
 dragged over, copied and handed to the PRIMARY selection. See
 [Selecting text](#selecting-text) below.
 
+`scale` zooms a subtree, CSS `zoom` rather than a transform: every length
+under the element — and the element's own style — is multiplied by it, and
+text is shaped at the size it will be drawn at. It is what an element owning
+a viewport (a graph pane, a map) mounts its content inside. Windows take no
+`scale`: [scale.md](scale.md#a-subtree-of-its-own).
+
 ---
 
 ## `<window>`

--- a/docs/events.md
+++ b/docs/events.md
@@ -116,6 +116,13 @@ const root = await createRoot({
 `nativeEvent.rootx/rooty` are screen coordinates — useful for anchoring a
 `<popup>` at the pointer.
 
+`x`/`y`/`localX`/`localY` and the wheel deltas are logical pixels in **the
+target's** unit — the display scale, times any `scale` prop above it
+([scale.md](scale.md#a-subtree-of-its-own)). With no `scale` in the tree
+that is one unit for the whole window; with one, a handler on an unzoomed
+ancestor is reading the zoomed target's pixels, and `ev.nativeEvent.x`/`y`
+are the way back to the window's own.
+
 **A Ctrl chord is read from the keysym, not the code point.** `codepoint`
 comes from the _shifted_ keysym, so Ctrl+Shift+Z arrives as `Z` and Ctrl+Z as
 `z`; a handler that compares code points misses half of its own shortcut.

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -138,7 +138,10 @@ And what you read:
   On a 1x display the two units coincide — which is exactly how an element
   that mixes them passes every headless test and then hovers, drags and
   frames at half the distance on a retina panel.
-  `renderX11(element, { scale: 2 })` is the test that catches it.
+  `renderX11(element, { scale: 2 })` is the test that catches it. It is a
+  per-node number rather than a per-window one — an enclosing `scale` prop
+  zooms a subtree ([scale.md](scale.md#a-subtree-of-its-own)) — so read it
+  off the node rather than caching one for the tree.
 - `this.resolvedTextStyle()` — the text style this node resolves to, ready to
   hand to `app.fonts.layout` (below).
 - `this.direction` — which way this node reads, resolved: `'ltr'` or

--- a/docs/scale.md
+++ b/docs/scale.md
@@ -58,6 +58,11 @@ shaped, measured and rasterized at 28px. Text on a retina panel is _sharper_,
 not bigger-blurrier — the same reason every native toolkit renders this way
 instead of transform-scaling a 1x picture.
 
+"Logical" is per node rather than per window as soon as a `scale` prop is in
+the tree: everything in the first list is divided by the scale of the node
+it is about, which is the display's until an enclosing `scale` says
+otherwise. See "A subtree of its own" below.
+
 ## How `'auto'` decides
 
 X11 never grew a scale protocol, so the answer is scattered across four
@@ -171,6 +176,74 @@ everything else on this window system.
 Static-at-startup is the other honest limitation: a mid-session change of
 `Xft.dpi` or a monitor swap does not re-scale running windows. Rare enough
 that GTK3 apps mostly share it; restart the app.
+
+## A subtree of its own
+
+The display scale is one number for the whole window. `scale` on an element
+is a second factor for one **subtree** of it:
+
+```jsx
+<box scale={zoom} style={{ width: w / zoom, height: h / zoom }}>
+  <NodeBody /> // written in plain logical pixels, unaware of the zoom
+</box>
+```
+
+The semantics are CSS's `zoom`, not a transform:
+
+- A node's **effective scale** is its parent's times its own `scale` prop,
+  so nested props multiply and the display scale is the floor they multiply.
+  `node.scale` is that number, and every path that already asked for it —
+  `scaleResolvedStyle` at the end of the style funnel, the caret and
+  scrollbar constants, shadows and gradients, a registered element's own
+  `paint()` — follows with no second mechanism.
+- **The node's own style scales too.** `scale={2}` on a box with
+  `padding: 8` gets 16 device pixels of padding, not 8 with bigger children
+  inside it. That is what makes the caller's job the one-liner above: divide
+  the size you want the box to occupy by the zoom, and write everything
+  inside it at 1x.
+- **Text is shaped at the size it is drawn at.** A `fontSize: 14` inside
+  `scale={2}` is shaped, measured and rasterized at 28 — the same thing the
+  display scale does, for the same reason. A zoomed-in graph is not a
+  stretched screenshot of a zoomed-out one.
+- **Yoga lays out the scaled numbers** like any others, so a zoomed subtree
+  wraps, flexes and measures its content floors at the size it is drawn.
+
+What it is for: an element that owns a viewport — a graph pane, a canvas, a
+map — and mounts application content inside it. The pane draws its own
+world, and the React subtree beside it has to follow the same zoom;
+`ctx.scale()` cannot do that here (see "Why multiply values instead of
+transforming the context" below) and a layer transform on the Cocoa
+presenter would draw a zoomed body whose hit testing still lived at the
+unzoomed rects.
+
+### What a boundary costs
+
+**Events are in the target's unit.** `ev.x`, `ev.y`, `localX`/`localY` and
+`getClientRects()` on a node inside a zoomed subtree are all divided by
+_that node's_ scale, so they agree with each other and with the styles it
+was written in — a handler inside the subtree needs to know nothing. The
+trade-off is CSS `zoom`'s: a handler on an **unzoomed ancestor** reads a
+coordinate in the zoomed descendant's unit, because the target is what
+decides. When a pane needs its own coordinates for a hit that landed inside
+the content it hosts, `ev.nativeEvent` is the way back — device pixels of
+the window, which `/ node.scale` converts to whichever unit is wanted.
+`screenX`/`screenY` are unaffected: they are desktop coordinates, and the
+desktop has one scale.
+
+A wheel notch scrolls `48` of the target's logical pixels, so content under
+the pointer travels the distance the zoom says it should.
+
+**A real X window is its own root.** `<window>` and `<popup>` take no
+`scale` prop and ignore an enclosing one: their geometry is the server's, a
+window manager sees no zoom, and a menu opened from a zoomed card should
+come up at the size the rest of the app's menus are. `<glarea>` and
+`<foreign>` do inherit — their boxes are laid out by the parent like any
+other child's.
+
+**Quantise a gesture-driven zoom.** Every distinct factor is a distinct
+font size to shape and cache, so a wheel handler feeding the raw accumulator
+into `scale` makes a new set of glyphs per frame. Round to a step — 5%, or
+a ladder of preset zooms — and the cache does its job.
 
 ## Prior art, and where this sits
 

--- a/src/events.js
+++ b/src/events.js
@@ -78,7 +78,16 @@ class SyntheticEvent {
     // by, and `localX` below subtracts an `abs` divided the same way
     // (src/scale.js). Everything *internal* — hit testing, drag
     // thresholds, the scroll accumulator — keeps reading `native`.
-    const s = manager.scale;
+    //
+    // **The target's** unit, not the window's, so that a subtree zoomed by
+    // a `scale` prop reads its own: `ev.x` then compares with the target's
+    // `getClientRects()`, which divides by the same factor, and `localX`
+    // lands on the styles that node was written with. This is CSS `zoom`'s
+    // trade-off rather than a transform's, and the corner it costs is
+    // named in docs/scale.md — a handler on an *unzoomed* ancestor reads a
+    // coordinate in the zoomed descendant's unit, because the target is
+    // what decides. `nativeEvent` is the way back to the window's pixels.
+    const s = target?.scale ?? manager.scale;
     this._manager = manager;
     this._targetNode = target;
     this.type = type;
@@ -802,8 +811,14 @@ export class EventManager {
       // `ev.deltaX/Y` are logical (what handlers read); the scroll they
       // become moves device pixels, and truncating *after* the multiply is
       // what keeps the blit on whole device pixels at fractional scales.
-      const owedX = this._wheelOwed.x + ev.deltaX * this.scale;
-      const owedY = this._wheelOwed.y + ev.deltaY * this.scale;
+      // The target's scale, the same unit the event's coordinates are in
+      // (`SyntheticEvent`), so a notch over a subtree zoomed by a `scale`
+      // prop moves a notch of *its* pixels — the content under the pointer
+      // travels the distance the zoom says, which is what CSS `zoom` does
+      // and what a pane whose rows are twice the size needs.
+      const wheelScale = target.scale;
+      const owedX = this._wheelOwed.x + ev.deltaX * wheelScale;
+      const owedY = this._wheelOwed.y + ev.deltaY * wheelScale;
       const dx = Math.trunc(owedX);
       const dy = Math.trunc(owedY);
       this._wheelOwed = { x: owedX - dx, y: owedY - dy };
@@ -822,9 +837,12 @@ export class EventManager {
       for (let n = target; n; n = n.parent) {
         if (n.canScroll?.(dx, dy)) {
           // built-in scrollers take the device delta whole; a registered
-          // element's own scrollBy speaks the public (logical) unit
+          // element's own scrollBy speaks the public (logical) unit — and
+          // *that node's* logical unit, since `scrollBy` multiplies by its
+          // own scale on the way back in, which is the only division that
+          // round-trips exactly across a scale boundary
           if (n._scrollByDevice) n._scrollByDevice(dx, dy);
-          else n.scrollBy({ x: dx / this.scale, y: dy / this.scale });
+          else n.scrollBy({ x: dx / n.scale, y: dy / n.scale });
           break;
         }
         if (n === this.node) break;

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -283,6 +283,7 @@ const INVALIDATE_REASONS = new Set([
   'outline', // …and the same for an outline a style swap took away
   'theme', // a theme/token change restyled a subtree
   'direction', // the reading direction moved: sides, glyph order, bar edge
+  'scale', // a `scale` prop zoomed a subtree: every length in it moved
   'animation', // a transition frame
   'scroll', // scrollTo/scrollBy/scrollIntoView, textarea/textinput panning
   'text', // text content, input value or caret editing
@@ -1722,6 +1723,33 @@ function shallowEqual(a, b) {
   return ka.length === kb.length && ka.every((k) => a[k] === b[k]);
 }
 
+/**
+ * A node's own `scale` prop as a factor: what it multiplies the scale it
+ * inherits by (`Node.scale`). Absent means 1, which is every node in a tree
+ * that never mentions it.
+ *
+ * A zero, a negative or a NaN is a mistake rather than a design — it would
+ * lay the subtree out at nothing, or at infinity — and in development it
+ * says so where the mistake is, rather than as a blank pane three frames
+ * later. Production falls back to 1 for the same reason a bad token keeps
+ * the property dropped: a GUI that carries on is worth more than one that
+ * dies on a fraction somebody divided by.
+ */
+function scaleFactorOf(props, kind) {
+  const own = props?.scale;
+  if (own === undefined) return 1;
+  if (typeof own === 'number' && Number.isFinite(own) && own > 0) return own;
+  if (DEV) {
+    throw new Error(
+      `react-x11: <${kind} scale={${JSON.stringify(own)}}> — a subtree ` +
+        'scale is a positive number, the factor this subtree is zoomed by ' +
+        '(2 draws it twice the size, 0.5 half), and leaving it out means 1. ' +
+        'See docs/scale.md, "A subtree of its own".',
+    );
+  }
+  return 1;
+}
+
 /** The half of `Node._joinsYoga` that is about the child alone — a real X
  * window (`<window>`, `<popup>`) or a node built without a box at all (a text
  * chunk) sits outside whatever parent it lands in. This is what
@@ -1735,16 +1763,93 @@ export class Node {
   }
 
   /**
-   * Device pixels per logical pixel for this node's connection — resolved
-   * once by `createRoot` (src/scale.js) and constant for the node's life,
-   * which is what makes the instance cache below sound. `this.style` and
-   * `this.abs` are already device pixels; this is for the values that never
-   * pass through a style — a paint constant like the caret's width, or an
-   * event coordinate on its way back to logical. A registered element that
-   * draws with its own constants multiplies them by this.
+   * Device pixels per logical pixel **for this node** — the display scale
+   * `createRoot` resolved (src/scale.js), times every `scale` prop between
+   * this node and its window. `this.style` and `this.abs` are already
+   * device pixels; this is for the values that never pass through a style —
+   * a paint constant like the caret's width, or an event coordinate on its
+   * way back to logical. A registered element that draws with its own
+   * constants multiplies them by this.
+   *
+   * The `scale` prop is CSS `zoom`, not a transform: it multiplies the
+   * inherited factor, and the node's *own* style scales with it. So
+   * everything downstream of the style funnel follows with no second
+   * mechanism — yoga lays out the scaled numbers like any others, paint
+   * reads the scaled style, the caret and the scrollbar read this getter,
+   * and text is shaped at the size it will be drawn at rather than
+   * rasterized once and stretched (docs/scale.md, "A subtree of its own").
+   *
+   * **A real X window is its own root.** `<window>` and `<popup>` geometry
+   * is the server's, in the display's pixels — `scaleWindowGeometry` reads
+   * `scaleOf(app)` directly and a WM sees no zoom — so the cascade stops
+   * there and a menu opened from a zoomed card comes up at the app's own
+   * size. Everything else inherits, including `<glarea>` and `<foreign>`,
+   * whose boxes are laid out by the parent like any other child's.
+   *
+   * Cached per node, dropped by `_rescaleSubtree` — the same contract
+   * `theme` and `direction` have, for the same reason.
    */
   get scale() {
-    return (this._scaleCache ??= scaleOf(this.app));
+    if (this._scaleCache !== undefined) return this._scaleCache;
+    if (this.isWindow) return (this._scaleCache = scaleOf(this.app));
+    const base = this.parent ? this.parent.scale : scaleOf(this.app);
+    return (this._scaleCache = base * scaleFactorOf(this.props, this.kind));
+  }
+
+  /**
+   * The effective scale of this node moved — its own `scale` prop changed,
+   * or it was attached under an ancestor whose scale is not the one it
+   * resolved against while detached.
+   *
+   * Everything below inherits, so the whole subtree is restyled; the early
+   * out is the answer not having moved, which is what makes the call at
+   * each of the attach sites free in the overwhelmingly common case of a
+   * tree with no `scale` prop in it at all.
+   *
+   * `mounting` is `insertBefore` attaching a subtree that has never been in
+   * the tree, and means the same thing it means to `_themeChanged`: resolve
+   * everything, claim nothing (issue #402). A node that has never painted
+   * has no stale pixels to cover, and where it lands is claimed by the
+   * child-list protocol.
+   */
+  _rescaleSubtree(mounting = false) {
+    if (!this._rescaleMoved()) return;
+    // One claim for the whole walk: `_invalidateLayout` bounds the subtree
+    // as it stands and queues the after-layout claim, so the per-node
+    // repeats the recursion below would make are the same rect over again.
+    if (!mounting) this._invalidateLayout('scale');
+    this._rescaled(mounting);
+  }
+
+  /** Drop the cached scale and re-ask; true when the answer moved. The
+   *  getter is the only place the rule lives, so a `<window>` — which
+   *  resolves the display scale whatever it is written inside — answers
+   *  false here and the walk stops at it. */
+  _rescaleMoved() {
+    const before = this._scaleCache;
+    this._scaleCache = undefined;
+    return this.scale !== before;
+  }
+
+  /** …the walk itself, for a node whose scale is already known to have
+   *  moved. Restyle in the new unit, then carry it down: an ordinary
+   *  descendant's scale is a product of this one, so it moved too. */
+  _rescaled(mounting) {
+    // both hold a size in device pixels at the old scale
+    this._textBase = undefined;
+    this._textScaled = null;
+    const prevStyle = this.style;
+    const style = this._syncStyle(this.props, mounting);
+    if (this.yoga && style !== prevStyle) {
+      applyLayoutStyle(this.yoga, style, prevStyle);
+    }
+    if (localTextStyleChanged(style, prevStyle)) this._textContentChanged();
+    // its own claims are bounded, so this runs on a mount too — the same
+    // rule `_themeChanged` follows
+    this._retext();
+    for (const child of this.children) {
+      if (child._rescaleMoved()) child._rescaled(mounting);
+    }
   }
 
   constructor(kind, props, app, { yoga = true } = {}) {
@@ -1813,6 +1918,11 @@ export class Node {
     // inherits. Undefined means "never asked", which is load-bearing — see
     // `_retext`
     this._resolvedText = undefined;
+    // `inheritedTextStyle`'s cache at a *scale boundary* — a node whose
+    // `scale` prop puts it in a different unit from its parent, so the
+    // device size it inherits has to be re-expressed. Null everywhere else,
+    // which is every node in a tree with no `scale` prop in it.
+    this._textScaled = null;
     // `direction`'s cache, same contract as `_resolvedText`'s: undefined means
     // "never asked", which is what lets `_redirectSubtree` stop at a node
     // nothing below has resolved through
@@ -2435,7 +2545,26 @@ export class Node {
    * `insertBefore` re-resolves the subtree against the real one.
    */
   get inheritedTextStyle() {
-    if (this.parent) return this.parent.resolvedTextStyle();
+    if (this.parent) {
+      const inherited = this.parent.resolvedTextStyle();
+      // A **scale boundary** — this node's `scale` prop, or a `<popup>`
+      // written inside a zoomed subtree, which goes back to the display's
+      // own unit. What comes down the cascade is already device pixels at
+      // the parent's scale (that is the point of resolving the theme's size
+      // once, at the root), so re-expressing it here is the only place a
+      // second multiply is right: a `fontSize: 14` theme inside a
+      // `scale={2}` box is 28 logical, 28 device at 1x, and the descendants
+      // below inherit that without compounding it again.
+      const from = this.parent.scale;
+      const to = this.scale;
+      if (from === to) return inherited;
+      const size = (inherited.size * to) / from;
+      const cached = this._textScaled;
+      if (cached?.from !== inherited || cached.style.size !== size) {
+        this._textScaled = { from: inherited, style: { ...inherited, size } };
+      }
+      return this._textScaled.style;
+    }
     const theme = this.theme;
     const color = theme.text;
     // A palette can reach a node as a bare `theme` **prop** rather than a
@@ -2888,6 +3017,9 @@ export class Node {
     // it can see its ancestors now, so any token in its style can resolve.
     // With no theme anywhere there is nothing to resolve and nothing to walk
     if (this.theme || child.props.theme) child._themeChanged(mounting);
+    // …and the same for the scale: a subtree styled while detached resolved
+    // against the app's, and only now can see the `scale` props above it.
+    child._rescaleSubtree(mounting);
     this._textContentChanged();
     this._childListChanged(before);
     a11yHooks.attached?.(this, child);
@@ -3080,6 +3212,11 @@ export class Node {
     const themeChanged = newProps.theme !== prev.theme;
     this.props = newProps;
     if (themeChanged) this._themeChanged();
+    // Ahead of the `_syncStyle` below, because the funnel that runs
+    // multiplies by `this.scale` and this is what makes it read the new
+    // factor. The walk restyles this node too, so the call after it hits
+    // the identity check and costs nothing twice.
+    if (newProps.scale !== prev.scale) this._rescaleSubtree();
     const style = this._syncStyle(newProps);
     let layoutChanged = false;
     // hoisted styles hit the identity check and skip the whole update

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -188,6 +188,19 @@ export interface DrawnProps<T = DrawnNode>
     SelectionProps<T>,
     EventHandlers<T> {
   ref?: Ref<T>;
+  /**
+   * Zoom this subtree, CSS `zoom` rather than a transform: every length
+   * under here — and this element's *own* style — is multiplied by it, so
+   * `scale={2}` is a card twice the size with text shaped at twice the size
+   * inside it, not a 1x picture stretched. Nested props multiply, and the
+   * display scale is the floor they multiply
+   * ([scale.md](scale.md#a-subtree-of-its-own)).
+   *
+   * A positive number; leaving it out means 1. `<window>` and `<popup>`
+   * take no `scale`: a real X window is its own root, so a menu opened from
+   * a zoomed card comes up at the app's own size.
+   */
+  scale?: number;
 }
 
 /**

--- a/test/subtree-scale.test.js
+++ b/test/subtree-scale.test.js
@@ -1,0 +1,292 @@
+// `scale` on an element: CSS `zoom` for one subtree, on top of the display
+// scale everything else in the renderer already runs at (src/scale.js,
+// docs/scale.md "A subtree of its own").
+//
+// The contract in one line: a node's effective scale is its parent's times
+// its own `scale` prop, and its *own* style scales with it — so a zoomed
+// card is a bigger card with bigger text and bigger checkboxes in it, not a
+// bigger card with the same 14px form spilling out of the clip.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+import { createRoot } from '../src/index.js';
+import { renderX11 } from '../src/testing/index.js';
+import { createMockApp, spinWheel } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+async function mount(element, { scale = 1 } = {}) {
+  const app = createMockApp();
+  const root = await createRoot({ app, scale });
+  root.render(element);
+  await tick();
+  const wnd = app.windows[0];
+  wnd?.flushFrame?.();
+  await tick();
+  return { app, root, wnd, node: wnd?._reactX11Node };
+}
+
+const child = (node, i = 0) => node.children[i];
+const box = (r) => ({ x: r.x, y: r.y, width: r.width, height: r.height });
+
+test('the scaled node lays out at its own zoomed style, and so do its children', async () => {
+  const { root, node } = await mount(
+    h(
+      'window',
+      { title: 't', width: 400, height: 300 },
+      h(
+        'box',
+        { scale: 2, style: { margin: 10, padding: 8, width: 100, height: 50 } },
+        h('box', { style: { width: 20, height: 20 } }),
+      ),
+    ),
+  );
+  const zoomed = child(node);
+  // CSS `zoom`: the node's own margin, padding and size are doubled too
+  assert.deepStrictEqual(box(zoomed.abs), {
+    x: 20,
+    y: 20,
+    width: 200,
+    height: 100,
+  });
+  assert.deepStrictEqual(box(child(zoomed).abs), {
+    x: 36,
+    y: 36,
+    width: 40,
+    height: 40,
+  });
+  assert.strictEqual(zoomed.scale, 2);
+  assert.strictEqual(child(zoomed).scale, 2);
+  await root.unmount();
+});
+
+test('nested scales multiply, and a sibling outside is untouched', async () => {
+  const { root, node } = await mount(
+    h(
+      'window',
+      { title: 't', width: 400, height: 300 },
+      h(
+        'box',
+        { scale: 2, style: { width: 100, height: 100 } },
+        h('box', { scale: 1.5, style: { width: 10, height: 10 } }),
+      ),
+      h('box', { style: { width: 10, height: 10 } }),
+    ),
+  );
+  const outer = child(node, 0);
+  const inner = child(outer);
+  assert.strictEqual(inner.scale, 3);
+  assert.strictEqual(inner.abs.width, 30);
+  const plain = child(node, 1);
+  assert.strictEqual(plain.scale, 1);
+  assert.strictEqual(plain.abs.width, 10);
+  await root.unmount();
+});
+
+test('the display scale is the floor the prop multiplies', async () => {
+  const { root, node } = await mount(
+    h(
+      'window',
+      { title: 't', width: 400, height: 300 },
+      h('box', { scale: 1.5, style: { width: 100, height: 20 } }),
+    ),
+    { scale: 2 },
+  );
+  const zoomed = child(node);
+  assert.strictEqual(zoomed.scale, 3);
+  assert.strictEqual(zoomed.abs.width, 300);
+  await root.unmount();
+});
+
+test('text sizes follow the zoom — the theme font size and an explicit one', async () => {
+  const { root, node } = await mount(
+    h(
+      'window',
+      { title: 't', width: 400, height: 300 },
+      h(
+        'box',
+        { scale: 2 },
+        h('text', null, 'themed'),
+        h('text', { style: { fontSize: 10 } }, 'sized'),
+        // an element two deep inherits the already-device size and must not
+        // multiply it a second time
+        h('box', null, h('text', null, 'deep')),
+      ),
+      h('text', null, 'outside'),
+    ),
+  );
+  const zoomed = child(node, 0);
+  // DefaultTheme.fontSize is 14 logical
+  assert.strictEqual(child(zoomed, 0).resolvedTextStyle().size, 28);
+  assert.strictEqual(child(zoomed, 1).resolvedTextStyle().size, 20);
+  assert.strictEqual(child(child(zoomed, 2)).resolvedTextStyle().size, 28);
+  assert.strictEqual(child(node, 1).resolvedTextStyle().size, 14);
+  await root.unmount();
+});
+
+test('re-zooming a mounted subtree lands exactly where a fresh mount at that zoom does', async () => {
+  const tree = (zoom) =>
+    h(
+      'window',
+      { title: 't', width: 400, height: 300 },
+      h(
+        'box',
+        { scale: zoom, style: { padding: 6, alignSelf: 'flex-start' } },
+        h('box', { style: { width: 40, height: 12, margin: 3 } }),
+        h('text', { style: { fontSize: 11 } }, 'label'),
+      ),
+    );
+  const live = await mount(tree(1));
+  live.root.render(tree(1.6));
+  await tick();
+  live.wnd.flushFrame?.();
+  await tick();
+  const fresh = await mount(tree(1.6));
+
+  const shape = (node) => ({
+    scale: node.scale,
+    abs: box(node.abs),
+    size: node.resolvedTextStyle().size,
+    kids: node.children.map(shape),
+  });
+  assert.deepStrictEqual(shape(child(live.node)), shape(child(fresh.node)));
+  await live.root.unmount();
+  await fresh.root.unmount();
+});
+
+test('a node mounted into a zoomed subtree later resolves against it', async () => {
+  const tree = (extra) =>
+    h(
+      'window',
+      { title: 't', width: 400, height: 300 },
+      h(
+        'box',
+        { scale: 2 },
+        h('box', { key: 'a', style: { width: 10, height: 10 } }),
+        extra ? h('box', { key: 'b', style: { width: 30, height: 10 } }) : null,
+      ),
+    );
+  const { root, node, wnd } = await mount(tree(false));
+  root.render(tree(true));
+  await tick();
+  wnd.flushFrame?.();
+  await tick();
+  const added = child(child(node), 1);
+  assert.strictEqual(added.scale, 2);
+  assert.strictEqual(added.abs.width, 60);
+  await root.unmount();
+});
+
+test('a `<popup>` written inside a zoomed subtree is not zoomed: a window is its own root', async () => {
+  const tree = (zoom) =>
+    h(
+      'window',
+      { title: 't', width: 400, height: 300 },
+      h(
+        'box',
+        { scale: zoom },
+        h('text', null, 'card'),
+        h(
+          'popup',
+          { width: 100, height: 40 },
+          h('box', { style: { width: 20, height: 20 } }),
+        ),
+      ),
+    );
+  const { root, node, wnd } = await mount(tree(2));
+  const zoomed = child(node);
+  const popup = zoomed.children.find((n) => n.isWindow);
+  assert.strictEqual(popup.scale, 1);
+  assert.strictEqual(child(popup).scale, 1);
+  assert.strictEqual(child(popup).abs.width, 20);
+  // the menu's text goes back to the app's own size, not the card's
+  assert.strictEqual(popup.resolvedTextStyle().size, 14);
+  // …and a live re-zoom walks past it rather than through it
+  root.render(tree(3));
+  await tick();
+  wnd.flushFrame?.();
+  await tick();
+  assert.strictEqual(zoomed.scale, 3);
+  assert.strictEqual(popup.scale, 1);
+  assert.strictEqual(child(popup).scale, 1);
+  assert.strictEqual(child(popup).abs.width, 20);
+  await root.unmount();
+});
+
+test('the public rects and pointer coordinates are in the target’s own unit', async () => {
+  const seen = [];
+  const { root, wnd, node } = await mount(
+    h(
+      'window',
+      { title: 't', width: 400, height: 300 },
+      h(
+        'box',
+        { scale: 2, style: { margin: 5 } },
+        h('box', {
+          style: { width: 50, height: 30 },
+          onMouseDown: (ev) => seen.push([ev.x, ev.y, ev.localX, ev.localY]),
+        }),
+      ),
+    ),
+  );
+  const inner = child(child(node));
+  // device rect: margin 5 x 2 = 10, size 50 x 2 = 100
+  assert.deepStrictEqual(box(inner.abs), {
+    x: 10,
+    y: 10,
+    width: 100,
+    height: 60,
+  });
+  // …and the same rect, read back through the public API, is the logical
+  // one the subtree was written in
+  const [rect] = inner.getClientRects();
+  assert.deepStrictEqual(box(rect), { x: 5, y: 5, width: 50, height: 30 });
+  // a press at device (30, 30) — 15,15 in the subtree's unit, 10,10 into it
+  wnd.emit('mousedown', { x: 30, y: 30, keycode: 1, buttons: 0 });
+  assert.deepStrictEqual(seen, [[15, 15, 10, 10]]);
+  await root.unmount();
+});
+
+test('a wheel inside a zoomed scroller moves the zoomed distance', async () => {
+  const { root, wnd, node } = await mount(
+    h(
+      'window',
+      { title: 't', width: 200, height: 200 },
+      h(
+        'box',
+        { scale: 2 },
+        h(
+          'box',
+          { style: { width: 50, height: 50, overflow: 'scroll' } },
+          h('box', { style: { width: 50, height: 400 } }),
+        ),
+      ),
+    ),
+  );
+  const scroller = child(child(node));
+  spinWheel(wnd, 20, 20, { deltaY: 1 });
+  await tick();
+  // one notch is WHEEL_NOTCH_PX (48) of the scroller's own logical pixels,
+  // which are two device pixels each here
+  assert.strictEqual(scroller.scrollY, 48 * 2);
+  // and the handler-facing offset is that subtree's logical unit again
+  assert.strictEqual(scroller.getClientRects()[0].width, 50);
+  await root.unmount();
+});
+
+test('a scale that is not a positive number is a mistake, and says so', async () => {
+  const origError = console.error;
+  console.error = () => {};
+  try {
+    for (const bad of [0, -2, Number.NaN, '2']) {
+      await assert.rejects(
+        () => renderX11(h('box', { scale: bad }), { backend: 'mock' }),
+        /a subtree scale is a positive number/,
+        `scale={${JSON.stringify(bad)}} should be rejected`,
+      );
+    }
+  } finally {
+    console.error = origError;
+  }
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -465,6 +465,17 @@ const _div = <div />;
 const _img = <img />;
 // @ts-expect-error — <box> has no 'className'
 const _classy = <box className="nope" />;
+// `scale` zooms a subtree (docs/scale.md): a number on any drawn element,
+// never on a window, which is its own scale root.
+const _zoomed = (
+  <box scale={1.5}>
+    <text scale={2}>zoomed</text>
+  </box>
+);
+// @ts-expect-error — a subtree scale is a number, not a CSS-ish string
+const _badZoom = <box scale="150%" />;
+// @ts-expect-error — <window> takes no scale; createRoot({ scale }) is that
+const _zoomedWindow = <window title="t" scale={2} />;
 // Size is style everywhere except <window>, so the elements that measure
 // themselves do not get to take it flat either (issue #118).
 // @ts-expect-error — <image> is sized by style, not by a width prop


### PR DESCRIPTION
Closes #449.

## What it is

`scale` on a drawn element is a second factor on top of the display scale,
for one **subtree**. A node's effective scale is its parent's times its own
prop, and the node's own style scales with it — CSS `zoom` semantics:

```jsx
<box scale={zoom} style={{ width: w / zoom, height: h / zoom }}>
  <NodeBody />   // written in plain logical pixels, unaware of the zoom
</box>
```

That is the whole consumer-side change an element that owns a viewport needs.
`@react-x11/components`' `<Flow>` mounts a node type's `render` subtree in an
absolutely positioned box beside the pane; the box followed the pane's zoom
and its contents did not, so a zoomed-in graph drew a bigger card with the
same 14px checkboxes clipped inside it.

**Before** — master, same scene: the box changes width, the card inside does
not move at all.

![before](https://github.com/user-attachments/assets/e7921dc5-6947-46e0-a247-c55b2ed37be9)

**After** — this branch: paddings, radii, checkbox squares, the switch, the
slider track and knob, the button height and every glyph follow the zoom.

![after](https://github.com/user-attachments/assets/2e1c8e97-1db9-4639-a237-8a80e423f148)

Both rendered headlessly by this branch's own code, into node-x11's
in-process X server, through `scripts/capture.js`.

## Why not a transform

The reasons docs/scale.md already gives for the display scale. ntk gates its
solid fills, strokes and glyph runs on an identity transform, so a
`ctx.scale` would rasterize every box in the subtree as polygons; and its
text model sizes glyphs from the font while only *positioning* them through
the transform, so scaled-transform text comes out moved but not grown. A
CALayer transform on the Cocoa presenter would draw a zoomed body whose hit
testing still lived in the node tree at the unzoomed rects — docs/macos.md
already defers transformed subtrees with events.

Multiplying at the style funnel instead means every path that already asks a
node for `this.scale` follows with no second mechanism: `scaleResolvedStyle`
at the end of that funnel, the caret and scrollbar constants, shadows and
gradients, the Cocoa raster layers, and yoga, which lays out the scaled
styles like any others. Text is shaped, measured and rasterized at the size
it will be drawn at.

## The four places that carry it

Mirroring the inherited, cached, per-subtree value core already has in
`direction`:

- **`get scale()`** — `parent.scale * props.scale`, cached per node. A real
  X window is its own root: `<window>` and `<popup>` geometry is the
  server's and a window manager sees no zoom, so a menu opened from a zoomed
  card comes up at the app's own size. `<glarea>` and `<foreign>` inherit,
  since their boxes are laid out by the parent like any other child's.
- **`_rescaleSubtree`** — drop the cache; if the answer moved, restyle the
  subtree through the same funnel, push the result into yoga, re-resolve its
  text, and claim the region once for the walk. Called from `applyProps` on
  a changed prop and from `insertBefore`, where a subtree styled while
  detached meets the `scale` props above it for the first time.
- **`inheritedTextStyle`** — at a scale boundary the inherited **device**
  size is re-expressed by `this.scale / parent.scale`, so a theme's
  `fontSize` grows with the zoom while descendants, which inherit an
  already-resolved size, never compound it.
- **`SyntheticEvent`** — native coordinates are divided by the **target's**
  scale rather than the window's, so `ev.x`/`localX` and that node's
  `getClientRects` agree inside a zoomed subtree.

## The open points in the issue

- **Event units.** Settled as the target's, which is what makes a handler
  inside the subtree need to know nothing. The CSS `zoom` trade-off — a
  handler on an unzoomed ancestor reads the zoomed descendant's unit — is
  written down in docs/scale.md along with the way back, `ev.nativeEvent`.
  `screenX`/`screenY` stay in the desktop's unit, because the desktop has
  one scale. The wheel path takes the target's scale for the same reason,
  and the fallback to a registered element's public `scrollBy` divides by
  **that node's** scale, which is the only division that round-trips across
  a boundary.
- **Invalidate reason.** `'scale'` is registered.
- **Glyph cache churn.** Documented on the prop: quantise a gesture-driven
  zoom to a step, or every frame is a new font size to shape.
- **Types.** `scale?: number` on `DrawnProps`, which is every drawn element
  and no window — the runtime rule exactly. Three lines in the type test,
  two of them `@ts-expect-error`.
- **Naming.** Kept as `scale`. It is the same quantity `createRoot` and
  `node.scale` already name, and the prop multiplies it rather than
  competing with it; a second word for one number would be the thing to
  explain.

## Verification

`test/subtree-scale.test.js` — 10 tests: the node's own style scaling, nested
factors multiplying, the display scale as the floor, theme and explicit font
sizes with no compounding at depth, a live re-zoom landing pixel-identical to
a fresh mount at that zoom, a node mounted into a zoomed subtree later, a
`<popup>` staying at the app's scale across a re-zoom, public rects and
pointer coordinates in the target's unit, a wheel notch, and the DEV error
for a non-positive factor. Each was mutation-checked: reverting any one of
the four pieces fails a test that names it.

Suite `1797/1803`, the six failures being the appearance tests that need a
Linux desktop. Lint, `prettier --check .`, `tsc` and the docs site build are
all green. The screenshot script clicks the "Draft" checkbox of each card at
its own rect afterwards and all three fire, which is hit testing at the zoom.

