### PR TITLE
fix(cocoa): each monitor publishes its own usable rect

### DIFF
--- a/docs/system.md
+++ b/docs/system.md
@@ -87,7 +87,7 @@ yet_ and keep the last one rather than writing it.
 server with neither extension. `null` is a headless mock with no display at
 all.
 
-### `available` is an approximation, and the only one here
+### `available` is an approximation on X11, and the only one here
 
 `_NET_WORKAREA` — the desktop minus the docks and panels that reserved space —
 is published **for the whole virtual desktop**, not per monitor. That is an
@@ -100,6 +100,12 @@ A true per-monitor work area means reading `_NET_WM_STRUT_PARTIAL` off every
 window on the screen and intersecting the reservations that land on each head
 — a full window-tree walk, redone whenever any panel changes. If you need
 that, `useApp().X` is the escape hatch.
+
+**On macOS it is exact.** `NSScreen.visibleFrame` is per screen already — that
+display's own menu bar and Dock taken off — so each monitor carries its real
+usable rect and no approximation runs. `workArea` there is still one rect,
+because the field is one rect by definition; it is the primary screen's, and
+on a multi-display Mac `screens[n].available` is the answer to prefer.
 
 ### Mirroring
 

--- a/src/cocoa/app.js
+++ b/src/cocoa/app.js
@@ -724,6 +724,46 @@ export class CocoaApp {
 }
 
 /**
+ * `listScreens()` turned into the screen layout `src/screens.js` publishes.
+ *
+ * **One scale for every screen, and it is the app's.** macOS lays all the
+ * displays out in a single global point space, and `app.scale` is this
+ * app's points-to-device-pixels factor for the whole of it — window
+ * origins, event coordinates, these rects. Converting a 1x external
+ * display by *its own* 1 while windows on it still report `points * 2`
+ * would put the monitor somewhere no window ever is, and `monitorAt()`
+ * would answer with the wrong head. (What backing scale a window on a
+ * mixed-DPI desk should raster at is a real and separate question; the
+ * layout is not where it is answered.)
+ *
+ * **A usable rect per monitor.** `NSScreen.visibleFrame` is per screen —
+ * that display's own menu bar and Dock taken off — so each monitor carries
+ * its `visible` and `usable()` takes it as a rect. Publishing only the
+ * primary's, the way `_NET_WORKAREA` forces on X11, applied the primary's
+ * *width* as a bound to every other head: a second display wider than the
+ * built-in had its right edge pulled in by the difference, and every
+ * anchored popup that reached past it was clamped back (issue #453).
+ */
+export function screenLayout(screens, scale) {
+  const rect = (r) => ({
+    x: Math.round(r.x * scale),
+    y: Math.round(r.y * scale),
+    width: Math.round(r.width * scale),
+    height: Math.round(r.height * scale),
+  });
+  const primary = screens?.[0];
+  return {
+    monitors: (screens ?? []).map((screen) => ({
+      ...rect(screen),
+      ...(screen.visible ? { visible: rect(screen.visible) } : null),
+    })),
+    // Still published for `useScreens().workArea`, which is one rect for
+    // the desktop by definition; the primary's is the closest macOS has.
+    workArea: primary?.visible ? rect(primary.visible) : null,
+  };
+}
+
+/**
  * Build the app and seed the platform stores the way the mock seeds them —
  * `beginScale`/`beginScreens`/`beginCompositing` find a session already
  * open and leave it alone, so `createRoot`'s shared flow runs unchanged.
@@ -733,25 +773,7 @@ export async function createCocoaApp(options = {}) {
   const app = new CocoaApp(native, options);
 
   setScaleForTests(app, app.scale, 'cocoa');
-  const s = app.scale;
-  const monitors = app._screens.map((screen) => ({
-    x: Math.round(screen.x * s),
-    y: Math.round(screen.y * s),
-    width: Math.round(screen.width * s),
-    height: Math.round(screen.height * s),
-  }));
-  const primary = app._screens[0];
-  setScreensForTests(app, {
-    monitors,
-    workArea: primary
-      ? {
-          x: Math.round(primary.visible.x * s),
-          y: Math.round(primary.visible.y * s),
-          width: Math.round(primary.visible.width * s),
-          height: Math.round(primary.visible.height * s),
-        }
-      : null,
-  });
+  setScreensForTests(app, screenLayout(app._screens, app.scale));
   setCompositingForTests(app, true);
 
   app.start(options.cocoa ?? {});

--- a/src/screens.js
+++ b/src/screens.js
@@ -72,12 +72,17 @@
  * Letting the WM have the last word costs a clamped-to-the-edge window one
  * correction it would have made anyway.
  *
- * **A per-monitor work area.** `_NET_WORKAREA` is one rect for the whole
- * virtual desktop. Deriving a real per-monitor one means reading
+ * **A per-monitor work area, on X11.** `_NET_WORKAREA` is one rect for the
+ * whole virtual desktop. Deriving a real per-monitor one means reading
  * `_NET_WM_STRUT_PARTIAL` off every window on the screen and intersecting
  * the reservations that fall on each head — a full window-tree walk, redone
  * whenever any panel changes. `available` below is the per-axis
  * approximation instead, and says so.
+ *
+ * A backend that *does* know each monitor's usable rect says so directly
+ * instead: a `visible` rect on the monitor record, which `usable()` prefers
+ * over the whole-desktop compromise. Cocoa's `NSScreen.visibleFrame` is
+ * exactly that, so the macOS backend never goes through the approximation.
  */
 
 import { requireExtension } from './extensions.js';
@@ -206,9 +211,36 @@ function monitorAt(monitors, point) {
   return best;
 }
 
+/** The overlap of two rects, or `null` where they do not touch. */
+function intersect(a, b) {
+  const x0 = Math.max(a.x, b.x);
+  const y0 = Math.max(a.y, b.y);
+  const x1 = Math.min(a.x + a.width, b.x + b.width);
+  const y1 = Math.min(a.y + a.height, b.y + b.height);
+  if (x1 <= x0 || y1 <= y0) return null;
+  return { x: x0, y: y0, width: x1 - x0, height: y1 - y0 };
+}
+
 /**
- * The monitor rect clamped per axis by `_NET_WORKAREA` — see the note on
- * per-monitor work areas at the top of the file.
+ * The usable part of one monitor.
+ *
+ * Two ways to get there, and the first one is the real answer:
+ *
+ * - A monitor record may carry its **own** usable rect as `visible`, in the
+ *   same screen coordinates as the monitor itself. That is what Cocoa's
+ *   `NSScreen.visibleFrame` is — per screen, minus that screen's menu bar
+ *   and Dock — and it is taken as a rect, intersected with the monitor in
+ *   case a backend reports one that overhangs.
+ * - Otherwise the monitor rect clamped **per axis** by `_NET_WORKAREA`,
+ *   which is one rect for the whole virtual desktop and so cannot be
+ *   positioned against a single head — see the note at the top of the file.
+ *
+ * The distinction matters the moment the monitors differ in size. A global
+ * work area no wider than the primary, applied as a width bound to a wider
+ * second display, moves that display's right edge inward by the difference
+ * and every anchored popup with it. On X11 the property spans the virtual
+ * desktop and the clamp is a no-op on the width, which is why the
+ * approximation held there and only there.
  *
  * Always **only** a rect. A monitor record carries a name, a primary flag and
  * physical sizes as well, and spreading it here put all of that inside
@@ -221,6 +253,7 @@ function usable(monitor, work) {
     width: monitor.width,
     height: monitor.height,
   };
+  if (monitor.visible) return intersect(rect, monitor.visible) ?? rect;
   if (!work) return rect;
   rect.width = Math.min(rect.width, work.width);
   rect.height = Math.min(rect.height, work.height);
@@ -756,6 +789,8 @@ export function endScreens(app) {
  * `monitors` entries may carry the RandR fields (`name`, `primary`,
  * `widthMM`, `heightMM`, `refreshRate`, `rotation`) as well as the rect, so
  * a test can state a named two-head desktop without a server that has RandR.
+ * An entry may also carry its own `visible` rect — the monitor's usable
+ * area, which takes precedence over the whole-desktop `workArea`.
  */
 export function setScreensForTests(app, { monitors = null, workArea = null }) {
   let session = sessions.get(app);

--- a/test/cocoa-frames.test.js
+++ b/test/cocoa-frames.test.js
@@ -30,7 +30,7 @@ import assert from 'node:assert';
 import { afterEach, test } from 'node:test';
 import React from 'react';
 
-import { CocoaApp } from '../src/cocoa/app.js';
+import { CocoaApp, screenLayout } from '../src/cocoa/app.js';
 import { CocoaPaneHost } from '../src/cocoa/panehost.js';
 import { setCompositingForTests } from '../src/compositing.js';
 import { createRoot } from '../src/index.js';
@@ -928,4 +928,76 @@ test('a wheel notch is answered on the event, like a press', async () => {
     2,
     'and the frame went out before the route returned',
   );
+});
+
+// --- the screen layout ------------------------------------------------------
+
+// Issue #453: the layout used to publish the primary screen's `visibleFrame`
+// as *the* work area for every head, and `usable()` reads a desktop-wide
+// work area as a per-axis bound — so a second display wider than the
+// built-in had the built-in's width applied to it, and every anchored popup
+// past that line was clamped back. `NSScreen.visibleFrame` is per screen, so
+// each monitor carries its own instead.
+test('each monitor carries its own usable rect, in the app’s one scale', () => {
+  // a 2x built-in with a menu bar, and a wider 1x display to its right;
+  // `listScreens` reports both in the one global point space, top-left
+  const layout = screenLayout(
+    [
+      {
+        x: 0,
+        y: 0,
+        width: 1440,
+        height: 900,
+        scale: 2,
+        visible: { x: 0, y: 25, width: 1440, height: 875 },
+        primary: true,
+      },
+      {
+        x: 1440,
+        y: 0,
+        width: 2560,
+        height: 1440,
+        scale: 1,
+        visible: { x: 1440, y: 0, width: 2560, height: 1440 },
+      },
+    ],
+    2,
+  );
+
+  assert.deepStrictEqual(layout.monitors, [
+    {
+      x: 0,
+      y: 0,
+      width: 2880,
+      height: 1800,
+      visible: { x: 0, y: 50, width: 2880, height: 1750 },
+    },
+    // the external head converts with the APP's scale, not its own 1: a
+    // window on it reports `points * 2` like every other window, so a rect
+    // in points would sit where no window ever is and `monitorAt()` would
+    // answer with the wrong head
+    {
+      x: 2880,
+      y: 0,
+      width: 5120,
+      height: 2880,
+      visible: { x: 2880, y: 0, width: 5120, height: 2880 },
+    },
+  ]);
+  // one rect for the desktop is still published for `useScreens().workArea`,
+  // and the primary's is the closest macOS has to one
+  assert.deepStrictEqual(layout.workArea, {
+    x: 0,
+    y: 50,
+    width: 2880,
+    height: 1750,
+  });
+});
+
+test('a screen the bridge reports no visible rect for carries none', () => {
+  const layout = screenLayout([{ x: 0, y: 0, width: 800, height: 600 }], 1);
+  assert.deepStrictEqual(layout.monitors, [
+    { x: 0, y: 0, width: 800, height: 600 },
+  ]);
+  assert.strictEqual(layout.workArea, null);
 });

--- a/test/popup-anchor.test.js
+++ b/test/popup-anchor.test.js
@@ -69,6 +69,76 @@ test('`at` anchors to a rect inside the node, in the node’s coordinates', () =
   assert.deepStrictEqual([whole.x, whole.y], [100 + 10, 50 + 20 + 300 + 2]);
 });
 
+// The bug behind issue #453: on Cocoa the whole layout was seeded with the
+// primary screen's `visibleFrame` as *the* work area, and `usable()` applies
+// a desktop-wide work area as a per-axis bound on whichever monitor was
+// picked. A second display wider than the built-in therefore kept its own
+// `x` and inherited the primary's `width`, and every popup that reached past
+// that short right edge was silently pulled back to it.
+test('a popup on a wider second display is not clamped to the primary’s width', () => {
+  const twoHeads = (workArea) => {
+    const app = {};
+    setScreensForTests(app, {
+      monitors: [
+        {
+          x: 0,
+          y: 0,
+          width: 1440,
+          height: 900,
+          visible: { x: 0, y: 25, width: 1440, height: 875 },
+        },
+        {
+          x: 1440,
+          y: 0,
+          width: 2560,
+          height: 1440,
+          visible: { x: 1440, y: 0, width: 2560, height: 1440 },
+        },
+      ],
+      workArea,
+    });
+    return app;
+  };
+  // a trigger three quarters of the way across the external display
+  const trigger = (app) => ({
+    abs: { x: 100, y: 50, width: 200, height: 30 },
+    root: { window: { x: 2900, y: 100 } },
+    app,
+  });
+
+  const at = anchorRect(trigger(twoHeads(null)), { width: 300, height: 200 });
+  assert.deepStrictEqual(
+    [at.x, at.y],
+    [3000, 100 + 50 + 30 + 2],
+    'placed where it was asked, well inside the 1440..4000 head',
+  );
+
+  // and the primary's work area riding along as the desktop's — which is
+  // what the Cocoa backend published — changes nothing, because each head
+  // now carries its own usable rect
+  const withPrimaryWorkArea = anchorRect(
+    trigger(twoHeads({ x: 0, y: 25, width: 1440, height: 875 })),
+    { width: 300, height: 200 },
+  );
+  assert.strictEqual(withPrimaryWorkArea.x, 3000);
+
+  // the same layout with no per-monitor rects is the old behaviour, and is
+  // what the assertion above is worth: 1440 as a width bound puts the
+  // external head's right edge at 2880, and the popup back at 2580.
+  const app = {};
+  setScreensForTests(app, {
+    monitors: [
+      { x: 0, y: 0, width: 1440, height: 900 },
+      { x: 1440, y: 0, width: 2560, height: 1440 },
+    ],
+    workArea: { x: 0, y: 25, width: 1440, height: 875 },
+  });
+  assert.strictEqual(
+    anchorRect(trigger(app), { width: 300, height: 200 }).x,
+    2580,
+  );
+});
+
 test('a sub-rect flips and clamps as if it were the node', () => {
   // an editor filling the screen, with the caret near the bottom of it: what
   // has to flip is the popup at *the caret*, and the editor's own bottom edge

--- a/test/system-hooks.test.js
+++ b/test/system-hooks.test.js
@@ -327,6 +327,72 @@ describe('useScreens', () => {
     ]);
   });
 
+  // A backend that knows each head's own usable rect (Cocoa's
+  // `visibleFrame`) hands it over instead, and then the per-axis
+  // compromise above does not apply at all — including the part of it that
+  // made the primary's *width* a bound on a wider second display.
+  test('a monitor’s own visible rect wins over the desktop work area', async () => {
+    const { app } = await renderX11(h('box'), { backend: 'mock' });
+    setScreensForTests(app, {
+      monitors: [
+        {
+          name: 'built-in',
+          x: 0,
+          y: 0,
+          width: 1440,
+          height: 900,
+          visible: { x: 0, y: 25, width: 1440, height: 875 },
+        },
+        {
+          name: 'external',
+          x: 1440,
+          y: 0,
+          width: 2560,
+          height: 1440,
+          visible: { x: 1440, y: 0, width: 2560, height: 1440 },
+        },
+      ],
+      // the primary's, standing in for a desktop-wide one — which is what
+      // the Cocoa backend used to publish for every head
+      workArea: { x: 0, y: 25, width: 1440, height: 875 },
+    });
+    const { screens } = screensSnapshot(app);
+    assert.deepEqual(
+      screens.map((s) => s.available),
+      [
+        { x: 0, y: 25, width: 1440, height: 875 },
+        // and NOT 1440 wide, which is what the per-axis clamp gave it
+        { x: 1440, y: 0, width: 2560, height: 1440 },
+      ],
+    );
+  });
+
+  // A `visible` a backend reports outside its own monitor is taken as the
+  // overlap, so `available` is never a rect off the head it belongs to.
+  test('a visible rect that overhangs its monitor is intersected', async () => {
+    const { app } = await renderX11(h('box'), { backend: 'mock' });
+    setScreensForTests(app, {
+      monitors: [
+        {
+          x: 100,
+          y: 0,
+          width: 800,
+          height: 600,
+          // wider than its head on both sides, and a menu bar's worth
+          // shorter at the top
+          visible: { x: 0, y: 50, width: 1000, height: 400 },
+        },
+      ],
+    });
+    const [screen] = screensSnapshot(app).screens;
+    assert.deepEqual(screen.available, {
+      x: 100,
+      y: 50,
+      width: 800,
+      height: 400,
+    });
+  });
+
   // The no-work-area branch is the one that had the bug, so it gets its own
   // case: with nothing to clamp against, `available` is still only a rect.
   test('available is a rect with no work area either', async () => {


### PR DESCRIPTION
Fixes #453.

## The bug

`anchorRect` finishes by clamping into the anchor node's available area, and
`availableArea` gets that from `usable`, which applies the desktop's work
area as a **per-axis bound** on whichever monitor was picked. That is the
honest compromise for `_NET_WORKAREA`, which EWMH defines over the whole
virtual screen and so cannot be positioned against a single head — on X11 the
property is never narrower than one monitor, and the width clamp is a no-op.

The Cocoa backend put something else in that slot: the **primary screen's**
`visibleFrame`. A second display wider than the built-in therefore kept its
own `x` and inherited the primary's `width`, so `right = area.x + area.width`
fell short by the difference and every anchored popup that reached past that
line was pulled back to it — silently, since nothing about the result says it
was clamped. Correct on the primary, wrong on the second display, by an
amount that depends on where the owner window sits and how wide the popup is.

The issue's read of the chain is right, and this is the fix it suggests.

## The fix

`NSScreen.visibleFrame` **is** per screen — that display's own menu bar and
Dock taken off — so the backend hands the real thing over instead of the
primary's standing in for it:

- a monitor record may carry its own `visible` rect, and `usable` prefers it
  outright, intersected with the monitor in case a backend reports one that
  overhangs;
- `createCocoaApp`'s seeding, now `screenLayout`, gives every monitor its own
  `visible`. The desktop-wide `workArea` is still published, because
  `useScreens().workArea` is one rect by definition and the primary's is the
  closest macOS has to one — it just no longer bounds the other heads.

X11 is untouched: no monitor record there carries `visible`, so every X path
runs the same per-axis code it did. `useScreens` picks the fix up with the
popups, since `screen.available` is the same `usable` call — an app that
sized a window from the second display's `available` inherited the bug.

## The second half of the issue, and why it is not here

The issue also proposes converting each screen with **its own** `scale`
rather than the primary's. I believe that would break `monitorAt` rather than
fix it, so `screenLayout` keeps the single factor and now documents why.

macOS lays every display out in **one** global point space, and `app.scale`
is this app's points-to-device-pixels factor for the whole of it: window
origins, event coordinates and these rects are all points times `app.scale`.
Take a 2x built-in at points 0,0 1440x900 and a 1x external to its right at
points 1440,0. A window at point x 1500 reports `x = 3000`. Converting the
external head by the app's 2 puts it at 2880..8000 — the window is inside it.
Converting it by its own 1 leaves it at 1440..3360 in a space where nothing
is measured that way, and `monitorAt` starts answering with the wrong head.

What backing scale a window on a mixed-DPI desk should *raster* at is a real
and separate question. It is about `CocoaWindow.scale`, not about the layout,
and it is not what moves popups.

## Tests

Three, each checked against the unfixed code first:

- `test/popup-anchor.test.js` — an anchored popup three quarters of the way
  across a wider second head lands where it was asked. The same layout
  **without** per-monitor rects is asserted to give the old, wrong answer, so
  the first assertion cannot pass by accident.
- `test/system-hooks.test.js` — `screen.available` prefers a monitor's own
  visible rect over the desktop work area, and intersects one that overhangs
  its head.
- `test/cocoa-frames.test.js` — `screenLayout` over a fake two-head
  `listScreens`: each monitor carries its own converted `visible`, both
  convert with the app's one scale, and the published `workArea` is the
  primary's.

Full suite green apart from the six `appearance.test.js` cases that fail on
macOS on every branch.

I have no second display to confirm the end-to-end symptom on, so the
evidence here is the unit level plus the source chain — same standing as the
issue's own diagnosis.
