### PR TITLE
perf(cocoa): a stroke of many subpaths goes out in chunks (#456)

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -181,6 +181,23 @@ from a bounded repaint — culled by a reach nobody updated — this is the
 first thing to try, and a fix that lands here is a change nobody announced
 through `invalidate`. Read once at startup; answers only to `1`.
 
+## `REACT_X11_NO_STROKE_CHUNKING=1` (macOS)
+
+Makes the Cocoa 2d context hand every stroke to CoreGraphics in one
+`CGContextStrokePath`, instead of splitting a path with many subpaths into
+several — [docs/macos.md](macos.md#stroking-a-path-with-many-subpaths) for
+what the split buys (a 4,000-subpath stroke goes from 986ms to 113ms) and
+the one thing it costs (the antialiased fringe where two subpaths' strokes
+overlap is half-covered twice rather than covered once, and reads a little
+lighter). Set this to compare the two on the same build, or as first aid if
+a drawing that strokes thousands of subpaths ever looks wrong at its seams.
+`ctx.strokeChunking = false` is the same switch for one context. Read once
+at startup, like the switches above, and answers only to `1`.
+
+Nothing on X11 reads it: there a stroke is one coverage mask over the
+path's bounding box, so a bigger path is _fewer_ uploads and the split
+would be a loss.
+
 ## `REACT_X11_NO_TRANSPARENCY=1`
 
 Makes every display answer the way one with no 32-bit visual does:

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -808,6 +808,64 @@ on X11 instead of replaying its whole scene into a clip.
   layer-aware visual instead of raster (a chart that wants its series
   as shape layers, say). The raster default means nobody _has_ to.
 
+### Stroking a path with many subpaths
+
+`CGContextStrokePath` is **quadratic in the number of subpaths** in the
+path it is handed. Measured on this machine — closed 13-vertex rings
+scattered over a 1024×1024 surface, a 2px line, one `ctx.stroke()`:
+
+| rings | vertices | one stroke | chunked (what ships) |
+| ----: | -------: | ---------: | -------------------: |
+|   500 |    6,500 |      20 ms |                14 ms |
+| 1,000 |   13,000 |      59 ms |                29 ms |
+| 2,000 |   26,000 |     208 ms |                56 ms |
+| 4,000 |   52,000 |     986 ms |               113 ms |
+
+The subpath count is the driver, not the vertex count: one 26,000-vertex
+subpath strokes in 4ms where two thousand 13-vertex ones take 208. It was
+found rasterizing vector map tiles — a `buildings` layer is one feature of
+a couple of thousand building outlines, accumulated into one path
+(react-x11 issue #456).
+
+So `CocoaContext2D.stroke` splits such a path into several
+`CGContextStrokePath` calls, cut at subpath boundaries — a chunk closes at
+the first `moveTo` past 512 points or 128 subpaths, which is within 5% of
+the best chunk for every shape swept. **The backend picks the size, not the
+caller**, because the right size is a fact about CoreGraphics that no
+caller can know, and because the X11 context wants the exact opposite: there
+a stroke is an a8 coverage mask over the path's bounding box uploaded with
+one `PutImage`, so a bigger path is _fewer_ uploads over the same pixels,
+and batching for one backend pessimizes the other.
+
+Two things are deliberately left whole, both because splitting them would
+be a loss:
+
+- **A hairline** — a device-space width of 1 or less, so `lineWidth` times
+  the CTM's scale. Below that width CoreGraphics strokes through a path
+  that is already linear in the subpath count (the 2,000-ring path above
+  costs 7ms at 1px, whole), and splitting it is a **2× regression**: the
+  per-call setup with nothing to win back.
+- **Anything that composites** — a translucent `strokeStyle`, a
+  `globalAlpha` below 1, a live shadow. Each chunk paints separately, so a
+  pixel that two subpaths' strokes each half cover is inked twice at half
+  coverage rather than once at full, and reads a little lighter. That is
+  the one visible difference chunking can make, and it is confined to the
+  seams where subpaths overlap under an opaque ink, where blending the same
+  colour twice changes only the antialiased fringe. `ctx.strokeChunking =
+false` turns the split off for a caller that needs those seams exact, and
+  `REACT_X11_NO_STROKE_CHUNKING=1` for a whole process.
+
+`fill` is not chunked and cannot be: the winding rule is a property of the
+path as a whole, so a hole in a shape stops being a hole once its ring is
+in a different call.
+
+The path is recorded in JS alongside the native one so a chunk can be
+re-issued — a flat number array, reused across paths. It costs an ordinary
+paint nothing measurable (20,000 rounded-rect fill+strokes: 601ms before,
+597ms after; 20,000 twelve-segment polylines: 113ms before, 116ms after),
+and the record is what puts the whole path back if a `fill`, a `clip` or
+more path building follows a stroke that consumed it. `test/cocoa-stroke-chunking.test.js`.
+
 ## Animations and transforms: the API the model unlocks
 
 The existing declarative vocabulary is the seam: `transition:` and

--- a/src/cocoa/context2d.js
+++ b/src/cocoa/context2d.js
@@ -93,6 +93,61 @@ const PICT_OP = Object.freeze({ Src: 1, Over: 3 });
 const RENDER = Object.freeze({ PictOp: PICT_OP });
 
 /**
+ * The path, recorded alongside the native one, so `stroke` can re-issue it
+ * in pieces — `CGContextStrokePath` is QUADRATIC in the number of subpaths
+ * in the path it is given (issue #456). Measured here, 13-vertex closed
+ * rings scattered over a 1024x1024 surface at a 2px line, one stroke call:
+ *
+ *    500 rings  20ms | 1000 rings  59ms | 2000 rings 208ms | 4000 rings 986ms
+ *
+ * Splitting the same geometry into strokes of a few hundred subpaths is
+ * linear in it: 14ms, 29ms, 56ms, 113ms. The driver is the subpath count,
+ * not the vertex count — one 26,000-vertex subpath strokes in 4ms where
+ * two thousand 13-vertex ones take 208. The full table, the two shapes
+ * left whole and why, are in docs/macos.md
+ * §"Stroking a path with many subpaths".
+ *
+ * Note the X11 context wants the opposite — there a stroke is an a8
+ * coverage mask over the path's bounding box uploaded with one PutImage,
+ * so a bigger path is fewer uploads over the same pixels. That is why this
+ * lives in the backend: a caller that batches for one backend pessimizes
+ * the other, and it cannot know which it is drawing on.
+ *
+ * The commands are a flat number array — `[op, ...args, op, ...args]` —
+ * reused across paths, so a path build is three pushes into a packed
+ * double array per point next to the napi call it already makes.
+ */
+const P_MOVE = 0;
+const P_LINE = 1;
+const P_CURVE = 2;
+const P_QUAD = 3;
+const P_CLOSE = 4;
+const P_RECT = 5;
+const P_ROUND = 6;
+const P_ARC = 7;
+const P_ELLIPSE = 8;
+/** how many numbers each op carries, and what it costs a chunk's budget */
+const P_ARGS = [2, 2, 6, 4, 0, 4, 8, 6, 4];
+const P_POINTS = [1, 1, 3, 2, 0, 4, 8, 8, 4];
+
+/**
+ * A chunk closes at the first subpath boundary past either budget. Swept
+ * over the shapes above: 512 points is within 5% of the best chunk for
+ * every one of them, and the subpath cap catches the degenerate shape the
+ * point budget misses — thousands of 3- and 4-point subpaths, where 512
+ * points is already 128 strokes' worth of setup.
+ */
+const STROKE_CHUNK_POINTS = 512;
+const STROKE_CHUNK_SUBPATHS = 128;
+
+/**
+ * The off switch, for a process that cannot reach the context — the same
+ * line `ctx.strokeChunking = false` draws, and what a bench comparing the
+ * two sets. Read once.
+ */
+const NO_STROKE_CHUNKING = process.env.REACT_X11_NO_STROKE_CHUNKING === '1';
+
+/**
  * A solid ink for `drawGlyphs` — ntk's `createSolidPicture` answers an
  * XRender picture; here it is the colour itself. Premultiplied 0..1 in, as
  * XRender solids are (the identity for the opaque inks text uses), straight
@@ -136,6 +191,11 @@ export class CocoaContext2D {
       ctm: [1, 0, 0, 1, 0, 0],
     };
     this._onDirty = null;
+    // the recorded path, and whether the native one still matches it (a
+    // chunked stroke leaves only its last chunk behind)
+    this._cmds = [];
+    this._pathStale = false;
+    this._strokeChunking = !NO_STROKE_CHUNKING;
   }
 
   _s() {
@@ -152,6 +212,10 @@ export class CocoaContext2D {
       n.ctxSetGlobalAlpha(surface, st.globalAlpha);
       n.ctxSetLineDash(surface, st.dash, st.dashOffset);
       this._stack.length = 0;
+      // the path went with the surface it was built on; nothing may
+      // replay it onto the new one
+      this._cmds.length = 0;
+      this._pathStale = false;
     }
     return surface;
   }
@@ -216,6 +280,26 @@ export class CocoaContext2D {
       this._state.globalAlpha = value;
       this._native.ctxSetGlobalAlpha(this._s(), value);
     }
+  }
+
+  /**
+   * Whether a stroke of a path with many subpaths may go out as several
+   * `CGContextStrokePath` calls — on by default, because the alternative
+   * is quadratic (see P_MOVE above) and every path small enough for the
+   * difference to be invisible is below the threshold anyway.
+   *
+   * Set it false for a path whose subpaths OVERLAP and whose seams have to
+   * composite exactly: chunked, a pixel the strokes of two subpaths each
+   * half cover is inked twice at half coverage rather than once at full,
+   * and reads a little lighter. `REACT_X11_NO_STROKE_CHUNKING=1` is the
+   * same switch for a whole process.
+   */
+  get strokeChunking() {
+    return this._strokeChunking;
+  }
+
+  set strokeChunking(value) {
+    this._strokeChunking = !!value;
   }
 
   get font() {
@@ -389,20 +473,96 @@ export class CocoaContext2D {
 
   // --- paths ---------------------------------------------------------------
 
+  /**
+   * The surface to build or paint the current path on, with the native
+   * path restored first if a chunked stroke consumed it. Lazy on purpose:
+   * a caller that strokes and then starts a new path — which is every
+   * caller in a paint loop — never pays for the rebuild.
+   */
+  _path() {
+    const surface = this._s();
+    if (this._pathStale) {
+      this._pathStale = false;
+      this._native.ctxBeginPath(surface);
+      this._emit(surface, 0, this._cmds.length);
+    }
+    return surface;
+  }
+
+  /** replay recorded commands `[from, to)` into the native path */
+  _emit(surface, from, to) {
+    const c = this._cmds;
+    const n = this._native;
+    for (let i = from; i < to;) {
+      const op = c[i];
+      const a = i + 1;
+      if (op === P_MOVE) n.ctxMoveTo(surface, c[a], c[a + 1]);
+      else if (op === P_LINE) n.ctxLineTo(surface, c[a], c[a + 1]);
+      else if (op === P_CURVE)
+        n.ctxCurveTo(
+          surface,
+          c[a],
+          c[a + 1],
+          c[a + 2],
+          c[a + 3],
+          c[a + 4],
+          c[a + 5],
+        );
+      else if (op === P_QUAD)
+        n.ctxQuadTo(surface, c[a], c[a + 1], c[a + 2], c[a + 3]);
+      else if (op === P_CLOSE) n.ctxClosePath(surface);
+      else if (op === P_RECT)
+        n.ctxRect(surface, c[a], c[a + 1], c[a + 2], c[a + 3]);
+      else if (op === P_ROUND)
+        n.ctxRoundRect(
+          surface,
+          c[a],
+          c[a + 1],
+          c[a + 2],
+          c[a + 3],
+          c[a + 4],
+          c[a + 5],
+          c[a + 6],
+          c[a + 7],
+        );
+      else if (op === P_ARC)
+        n.ctxArc(
+          surface,
+          c[a],
+          c[a + 1],
+          c[a + 2],
+          c[a + 3],
+          c[a + 4],
+          !!c[a + 5],
+        );
+      else if (op === P_ELLIPSE)
+        n.ctxEllipse(surface, c[a], c[a + 1], c[a + 2], c[a + 3]);
+      i += 1 + P_ARGS[op];
+    }
+  }
+
   beginPath() {
+    this._cmds.length = 0;
+    this._pathStale = false;
     this._native.ctxBeginPath(this._s());
   }
 
   moveTo(x, y) {
-    this._native.ctxMoveTo(this._s(), x, y);
+    const surface = this._path();
+    this._cmds.push(P_MOVE, x, y);
+    this._native.ctxMoveTo(surface, x, y);
   }
 
   lineTo(x, y) {
-    this._native.ctxLineTo(this._s(), x, y);
+    const surface = this._path();
+    this._cmds.push(P_LINE, x, y);
+    this._native.ctxLineTo(surface, x, y);
   }
 
   rect(x, y, w, h) {
-    this._native.ctxRect(this._s(), x, y, w, h);
+    const surface = this._path();
+    this._cmds.push(P_RECT, x, y, w, h);
+    this._native.ctxRect(surface, x, y, w, h);
   }
 
   roundRect(x, y, w, h, radii) {
@@ -413,37 +573,45 @@ export class CocoaContext2D {
     else if (r.length === 3) r = [r[0], r[1], r[2], r[1]];
     const cap = Math.min(Math.abs(w) / 2, Math.abs(h) / 2);
     const clamp = (v) => Math.max(0, Math.min(Number(v) || 0, cap));
-    this._native.ctxRoundRect(
-      this._s(),
-      x,
-      y,
-      w,
-      h,
+    const surface = this._path();
+    const [r0, r1, r2, r3] = [
       clamp(r[0]),
       clamp(r[1]),
       clamp(r[2]),
       clamp(r[3]),
-    );
+    ];
+    this._cmds.push(P_ROUND, x, y, w, h, r0, r1, r2, r3);
+    this._native.ctxRoundRect(surface, x, y, w, h, r0, r1, r2, r3);
   }
 
   arc(x, y, radius, start, end, anticlockwise = false) {
-    this._native.ctxArc(this._s(), x, y, radius, start, end, anticlockwise);
+    const surface = this._path();
+    this._cmds.push(P_ARC, x, y, radius, start, end, anticlockwise ? 1 : 0);
+    this._native.ctxArc(surface, x, y, radius, start, end, anticlockwise);
   }
 
   ellipse(x, y, rx, ry) {
-    this._native.ctxEllipse(this._s(), x, y, rx, ry);
+    const surface = this._path();
+    this._cmds.push(P_ELLIPSE, x, y, rx, ry);
+    this._native.ctxEllipse(surface, x, y, rx, ry);
   }
 
   bezierCurveTo(c1x, c1y, c2x, c2y, x, y) {
-    this._native.ctxCurveTo(this._s(), c1x, c1y, c2x, c2y, x, y);
+    const surface = this._path();
+    this._cmds.push(P_CURVE, c1x, c1y, c2x, c2y, x, y);
+    this._native.ctxCurveTo(surface, c1x, c1y, c2x, c2y, x, y);
   }
 
   quadraticCurveTo(cx, cy, x, y) {
-    this._native.ctxQuadTo(this._s(), cx, cy, x, y);
+    const surface = this._path();
+    this._cmds.push(P_QUAD, cx, cy, x, y);
+    this._native.ctxQuadTo(surface, cx, cy, x, y);
   }
 
   closePath() {
-    this._native.ctxClosePath(this._s());
+    const surface = this._path();
+    this._cmds.push(P_CLOSE);
+    this._native.ctxClosePath(surface);
   }
 
   // --- painting ------------------------------------------------------------
@@ -477,17 +645,87 @@ export class CocoaContext2D {
   _replayPath(path) {
     const cmds = path?._cmds;
     if (!Array.isArray(cmds)) return false;
-    const n = this._native;
-    const s = this._s();
-    n.ctxBeginPath(s);
+    this.beginPath();
     for (const c of cmds) {
-      if (c.type === 'M') n.ctxMoveTo(s, c.x, c.y);
-      else if (c.type === 'L') n.ctxLineTo(s, c.x, c.y);
+      if (c.type === 'M') this.moveTo(c.x, c.y);
+      else if (c.type === 'L') this.lineTo(c.x, c.y);
       else if (c.type === 'C')
-        n.ctxCurveTo(s, c.x1, c.y1, c.x2, c.y2, c.x, c.y);
-      else if (c.type === 'Q') n.ctxQuadTo(s, c.x1, c.y1, c.x, c.y);
-      else if (c.type === 'Z') n.ctxClosePath(s);
+        this.bezierCurveTo(c.x1, c.y1, c.x2, c.y2, c.x, c.y);
+      else if (c.type === 'Q') this.quadraticCurveTo(c.x1, c.y1, c.x, c.y);
+      else if (c.type === 'Z') this.closePath();
     }
+    return true;
+  }
+
+  /**
+   * Whether a stroke of the current path may be split into several
+   * `CGContextStrokePath` calls. Two things say no:
+   *
+   * - A hairline. At or below a device-space width of 1 CoreGraphics
+   *   strokes through a path that is already linear in the subpath count
+   *   — 2,000 rings cost 7ms whole — and splitting it is a 2x LOSS, the
+   *   per-call setup with nothing to win back.
+   * - Anything that composites. Each chunk paints separately, so where two
+   *   subpaths' strokes overlap, a translucent ink, a globalAlpha or a
+   *   shadow blends twice and reads darker where one call blends the union
+   *   once. An opaque ink is exact everywhere the coverage is full, which
+   *   is what the geometry that gets big looks like; what is left is the
+   *   antialiased fringe at those same overlaps, half-covered twice
+   *   instead of covered once, which reads a little lighter — the one
+   *   difference `strokeChunking` exists to turn off.
+   */
+  _chunkableStroke() {
+    if (!this._strokeChunking) return false;
+    const st = this._state;
+    const [a, b, c, d] = st.ctm;
+    const scale = Math.sqrt(Math.abs(a * d - b * c));
+    if (!(st.lineWidth * scale > 1)) return false;
+    if (st.globalAlpha < 1) return false;
+    if (parseColor(st.strokeStyle)[3] < 1) return false;
+    if (st.shadowBlur > 0 && parseColor(st.shadowColor)[3] > 0) return false;
+    return true;
+  }
+
+  /**
+   * Stroke the recorded path as a series of chunks, cut at subpath
+   * boundaries so every chunk carries the `moveTo` its segments start
+   * from. Answers false when there was nothing to split, leaving the
+   * native path untouched for the caller's single stroke.
+   */
+  _strokeChunks(surface) {
+    if (!this._chunkableStroke()) return false;
+    const cmds = this._cmds;
+    const n = this._native;
+    let start = 0;
+    let points = 0;
+    let subpaths = 0;
+    let split = false;
+    for (let i = 0; i < cmds.length;) {
+      const op = cmds[i];
+      if (
+        op === P_MOVE &&
+        i > start &&
+        (points >= STROKE_CHUNK_POINTS || subpaths >= STROKE_CHUNK_SUBPATHS)
+      ) {
+        n.ctxBeginPath(surface);
+        this._emit(surface, start, i);
+        n.ctxStroke(surface);
+        split = true;
+        start = i;
+        points = 0;
+        subpaths = 0;
+      }
+      if (op === P_MOVE) subpaths++;
+      points += P_POINTS[op];
+      i += 1 + P_ARGS[op];
+    }
+    if (!split) return false;
+    n.ctxBeginPath(surface);
+    this._emit(surface, start, cmds.length);
+    n.ctxStroke(surface);
+    // the native path is the last chunk now; _path() puts the whole one
+    // back if anything asks for it
+    this._pathStale = true;
     return true;
   }
 
@@ -495,6 +733,7 @@ export class CocoaContext2D {
     const hasPath = pathOrRule != null && typeof pathOrRule === 'object';
     const rule = hasPath ? maybeRule : pathOrRule;
     if (hasPath && !this._replayPath(pathOrRule)) return;
+    this._path();
     const style = this._state.fillStyle;
     if (style instanceof LinearGradient) {
       const { coords, flat } = style._normalized();
@@ -518,7 +757,14 @@ export class CocoaContext2D {
       return;
     }
     this._applyStroke();
-    this._native.ctxStroke(this._s());
+    // one call per chunk where the path has enough subpaths to be worth it
+    // — see P_MOVE and _chunkableStroke above — and one for everything
+    // else. The chunks are issued from the record, so a stroke that splits
+    // never pays for the restore a previous split owed: `_path()` is asked
+    // for the surface only on the whole-path route.
+    if (!this._strokeChunks(this._s())) {
+      this._native.ctxStroke(this._path());
+    }
     this._dirty();
   }
 
@@ -530,7 +776,7 @@ export class CocoaContext2D {
     ) {
       return;
     }
-    this._native.ctxClip(this._s());
+    this._native.ctxClip(this._path());
   }
 
   fillRect(x, y, w, h) {

--- a/test/cocoa-stroke-chunking.test.js
+++ b/test/cocoa-stroke-chunking.test.js
@@ -1,0 +1,437 @@
+// `CGContextStrokePath` is quadratic in the number of subpaths in the path
+// it is handed (issue #456): two thousand 13-vertex rings at a 2px line
+// cost 202ms in one call where five hundred cost 20ms. The Cocoa context
+// splits such a stroke into several calls, and this is what that split
+// promises — the same geometry, in the same order, cut only where a
+// subpath starts, and only where the split cannot change what lands.
+//
+// Two layers, as elsewhere in the Cocoa tests. The first runs everywhere:
+// a fake bridge records what reaches the natives, which is the whole of
+// what the JS decides. The second runs where @windowkit/appkit loads and
+// ends in pixels.
+import assert from 'node:assert';
+import { describe, test } from 'node:test';
+
+import { CocoaContext2D } from '../src/cocoa/context2d.js';
+import { loadNative } from '../src/cocoa/native.js';
+
+/** a bridge that records the path and paint calls, and no-ops the rest */
+function fakeNative() {
+  const calls = [];
+  const native = {
+    calls,
+    ctxBeginPath: () => calls.push(['begin']),
+    ctxMoveTo: (s, x, y) => calls.push(['M', x, y]),
+    ctxLineTo: (s, x, y) => calls.push(['L', x, y]),
+    ctxRect: (s, x, y, w, h) => calls.push(['rect', x, y, w, h]),
+    ctxArc: (s, x, y, r, a0, a1, ccw) =>
+      calls.push(['arc', x, y, r, a0, a1, ccw]),
+    ctxEllipse: (s, x, y, rx, ry) => calls.push(['ellipse', x, y, rx, ry]),
+    ctxRoundRect: (s, ...a) => calls.push(['round', ...a]),
+    ctxCurveTo: (s, ...a) => calls.push(['C', ...a]),
+    ctxQuadTo: (s, ...a) => calls.push(['Q', ...a]),
+    ctxClosePath: () => calls.push(['Z']),
+    ctxStroke: () => calls.push(['stroke']),
+    ctxFill: (s, eo) => calls.push(['fill', !!eo]),
+    ctxClip: () => calls.push(['clip']),
+  };
+  return new Proxy(native, {
+    get: (t, k) => (k in t ? t[k] : () => undefined),
+  });
+}
+
+function context() {
+  const native = fakeNative();
+  const surface = { fake: true };
+  const ctx = new CocoaContext2D(
+    native,
+    () => surface,
+    () => 1,
+  );
+  ctx.lineWidth = 2; // above the hairline, so chunking is on the table
+  native.calls.length = 0;
+  return { ctx, native };
+}
+
+/** `count` closed rings of `verts` points each, drawn into `ctx` */
+function rings(ctx, count, verts) {
+  ctx.beginPath();
+  for (let i = 0; i < count; i++) {
+    ctx.moveTo(i, 0);
+    for (let v = 1; v < verts; v++) ctx.lineTo(i + v, v);
+    ctx.closePath();
+  }
+}
+
+const strokes = (calls) => calls.filter((c) => c[0] === 'stroke').length;
+/** the path calls of the nth stroke, the `begin` that opened it dropped */
+function chunk(calls, n) {
+  const out = [];
+  let seen = 0;
+  let current = [];
+  for (const call of calls) {
+    if (call[0] === 'begin') current = [];
+    else if (call[0] === 'stroke') {
+      if (seen++ === n) return current;
+    } else current.push(call);
+  }
+  return out;
+}
+// the path calls, in order, as one string — a mismatch prints a diff a
+// person can read rather than six thousand tuples
+const PAINT = new Set(['begin', 'stroke', 'fill', 'clip']);
+const geometry = (calls) =>
+  calls
+    .filter((c) => !PAINT.has(c[0]))
+    .map((c) => c.join(' '))
+    .join('|');
+const geometryCount = (calls) => calls.filter((c) => !PAINT.has(c[0])).length;
+
+// --- what gets split ----------------------------------------------------------
+
+test('a path small enough is one stroke, and nothing is replayed', () => {
+  const { ctx, native } = context();
+  rings(ctx, 20, 13); // 260 points, 20 subpaths — under both budgets
+  ctx.stroke();
+  assert.equal(strokes(native.calls), 1);
+  assert.equal(native.calls.filter((c) => c[0] === 'begin').length, 1);
+});
+
+test('thousands of subpaths go out in chunks, each opened by its own moveTo', () => {
+  const { ctx, native } = context();
+  rings(ctx, 2000, 13); // 26,000 points
+  const built = geometryCount(native.calls);
+  native.calls.length = 0;
+  ctx.stroke();
+  const n = strokes(native.calls);
+  // 512 points is 40 rings, so ~50 chunks — the point is that it is many
+  // and bounded, not the exact number
+  assert.ok(n > 30 && n < 80, `${n} chunks`);
+  for (let i = 0; i < n; i++) {
+    assert.equal(
+      chunk(native.calls, i)[0][0],
+      'M',
+      `chunk ${i} starts at a moveTo`,
+    );
+  }
+  // the geometry that reached the bridge is the path, once, in order
+  assert.equal(geometryCount(native.calls), built);
+});
+
+test('the chunks are the path, in order, and nothing else', () => {
+  const { ctx, native } = context();
+  rings(ctx, 300, 9);
+  const built = geometry(native.calls);
+  native.calls.length = 0;
+  ctx.stroke();
+  assert.ok(strokes(native.calls) > 1);
+  assert.equal(geometry(native.calls), built);
+
+  // and the unsplit route issues the same geometry once, at build time
+  const plain = context();
+  plain.ctx.strokeChunking = false;
+  rings(plain.ctx, 300, 9);
+  assert.equal(geometry(plain.native.calls), built);
+  plain.native.calls.length = 0;
+  plain.ctx.stroke();
+  assert.equal(strokes(plain.native.calls), 1);
+  assert.equal(geometry(plain.native.calls), '');
+});
+
+test('a chunk closes on the subpath budget as well as the point one', () => {
+  const { ctx, native } = context();
+  rings(ctx, 400, 2); // 800 points: one chunk on points, four on subpaths
+  native.calls.length = 0;
+  ctx.stroke();
+  assert.equal(strokes(native.calls), 4);
+  assert.equal(chunk(native.calls, 0).filter((c) => c[0] === 'M').length, 128);
+});
+
+test('every path verb survives the round trip', () => {
+  const { ctx, native } = context();
+  ctx.beginPath();
+  for (let i = 0; i < 200; i++) {
+    ctx.moveTo(i, 0);
+    ctx.lineTo(i, 1);
+    ctx.bezierCurveTo(1, 2, 3, 4, 5, 6);
+    ctx.quadraticCurveTo(7, 8, 9, 10);
+    ctx.rect(i, i, 4, 5);
+    ctx.roundRect(i, i, 10, 10, 2);
+    ctx.arc(i, i, 3, 0, Math.PI, true);
+    ctx.ellipse(i, i, 2, 3);
+    ctx.closePath();
+  }
+  const built = geometry(native.calls);
+  native.calls.length = 0;
+  ctx.stroke();
+  assert.ok(strokes(native.calls) > 1);
+  assert.equal(geometry(native.calls), built);
+});
+
+// --- what is left whole -------------------------------------------------------
+
+test('a hairline is never chunked — CoreGraphics is already linear there', () => {
+  const { ctx, native } = context();
+  ctx.lineWidth = 1;
+  rings(ctx, 2000, 13);
+  native.calls.length = 0;
+  ctx.stroke();
+  assert.equal(strokes(native.calls), 1);
+});
+
+test('the hairline is a device width: a transform decides it', () => {
+  const under = context();
+  under.ctx.lineWidth = 0.4;
+  under.ctx.scale(2, 2); // 0.8 device
+  rings(under.ctx, 2000, 13);
+  under.native.calls.length = 0;
+  under.ctx.stroke();
+  assert.equal(strokes(under.native.calls), 1);
+
+  const over = context();
+  over.ctx.lineWidth = 0.6;
+  over.ctx.scale(2, 2); // 1.2 device
+  rings(over.ctx, 2000, 13);
+  over.native.calls.length = 0;
+  over.ctx.stroke();
+  assert.ok(strokes(over.native.calls) > 1);
+});
+
+test('anything that composites is left whole — the seams would blend twice', () => {
+  for (const paint of [
+    (ctx) => (ctx.strokeStyle = 'rgba(0,0,0,0.5)'),
+    (ctx) => (ctx.globalAlpha = 0.5),
+    (ctx) => {
+      ctx.shadowColor = '#000';
+      ctx.shadowBlur = 4;
+    },
+  ]) {
+    const { ctx, native } = context();
+    paint(ctx);
+    rings(ctx, 2000, 13);
+    native.calls.length = 0;
+    ctx.stroke();
+    assert.equal(strokes(native.calls), 1);
+  }
+});
+
+test('an opaque ink with a transparent shadow colour still chunks', () => {
+  const { ctx, native } = context();
+  ctx.shadowBlur = 4; // the default shadowColor is transparent
+  rings(ctx, 2000, 13);
+  native.calls.length = 0;
+  ctx.stroke();
+  assert.ok(strokes(native.calls) > 1);
+});
+
+test('strokeChunking = false is the way out, and it round-trips', () => {
+  const { ctx, native } = context();
+  assert.equal(ctx.strokeChunking, true);
+  ctx.strokeChunking = false;
+  assert.equal(ctx.strokeChunking, false);
+  rings(ctx, 2000, 13);
+  native.calls.length = 0;
+  ctx.stroke();
+  assert.equal(strokes(native.calls), 1);
+});
+
+// --- the path the caller still has -------------------------------------------
+
+test('a fill after a chunked stroke fills the whole path, not the last chunk', () => {
+  const { ctx, native } = context();
+  rings(ctx, 300, 9);
+  const built = geometry(native.calls);
+  native.calls.length = 0;
+  ctx.stroke();
+  const afterStroke = native.calls.length;
+  ctx.fill();
+  const rebuilt = native.calls.slice(afterStroke);
+  assert.equal(rebuilt[0][0], 'begin');
+  assert.equal(geometry(rebuilt), built);
+  assert.deepEqual(rebuilt[rebuilt.length - 1], ['fill', false]);
+});
+
+test('a clip after a chunked stroke clips to the whole path', () => {
+  const { ctx, native } = context();
+  rings(ctx, 300, 9);
+  const built = geometry(native.calls);
+  native.calls.length = 0;
+  ctx.stroke();
+  const afterStroke = native.calls.length;
+  ctx.clip();
+  const rebuilt = native.calls.slice(afterStroke);
+  assert.equal(geometry(rebuilt), built);
+  assert.deepEqual(rebuilt[rebuilt.length - 1], ['clip']);
+});
+
+test('more path building after a chunked stroke extends the whole path', () => {
+  const { ctx, native } = context();
+  rings(ctx, 300, 9);
+  const built = geometry(native.calls);
+  native.calls.length = 0;
+  ctx.stroke();
+  const afterStroke = native.calls.length;
+  ctx.lineTo(999, 999);
+  const rebuilt = native.calls.slice(afterStroke);
+  assert.equal(geometry(rebuilt), `${built}|L 999 999`);
+});
+
+test('a second stroke of the same path draws it whole again', () => {
+  const { ctx, native } = context();
+  rings(ctx, 300, 9);
+  const built = geometry(native.calls);
+  native.calls.length = 0;
+  ctx.stroke();
+  const first = geometry(native.calls);
+  native.calls.length = 0;
+  ctx.stroke();
+  assert.equal(geometry(native.calls), first);
+  assert.equal(first, built);
+});
+
+test('beginPath forgets the record — a small path after a big one is one stroke', () => {
+  const { ctx, native } = context();
+  rings(ctx, 2000, 13);
+  ctx.stroke();
+  rings(ctx, 5, 4);
+  native.calls.length = 0;
+  ctx.stroke();
+  assert.equal(strokes(native.calls), 1);
+  assert.equal(geometry(native.calls), '', 'nothing replayed');
+});
+
+test('a replaced surface drops the record with the path it was built on', () => {
+  const native = fakeNative();
+  let gen = 1;
+  const ctx = new CocoaContext2D(
+    native,
+    () => ({ fake: true }),
+    () => gen,
+  );
+  ctx.lineWidth = 2;
+  rings(ctx, 300, 9);
+  ctx.stroke();
+  gen = 2;
+  native.calls.length = 0;
+  ctx.fill();
+  assert.equal(geometry(native.calls), '');
+});
+
+test('a Path2D handed to stroke chunks the same way', () => {
+  const { ctx, native } = context();
+  const cmds = [];
+  for (let i = 0; i < 300; i++) {
+    cmds.push({ type: 'M', x: i, y: 0 });
+    for (let v = 1; v < 9; v++) cmds.push({ type: 'L', x: i + v, y: v });
+    cmds.push({ type: 'Z' });
+  }
+  native.calls.length = 0;
+  ctx.stroke({ _cmds: cmds });
+  assert.ok(strokes(native.calls) > 1);
+  // built once, then replayed as chunks
+  assert.equal(geometryCount(native.calls), cmds.length * 2);
+});
+
+// --- over the real bridge -----------------------------------------------------
+
+let bridge = null;
+if (process.platform === 'darwin') {
+  try {
+    bridge = loadNative();
+  } catch {
+    bridge = null;
+  }
+}
+
+describe(
+  'over the real bridge',
+  {
+    skip: bridge ? false : 'the @windowkit/appkit bridge is not loadable here',
+  },
+  () => {
+    const W = 512;
+    const H = 512;
+
+    /** 256 closed rings on a grid, far enough apart that no two strokes meet */
+    const grid = (radius) => {
+      const out = [];
+      for (let gy = 0; gy < 16; gy++) {
+        for (let gx = 0; gx < 16; gx++) {
+          const cx = (gx + 0.5) * (W / 16);
+          const cy = (gy + 0.5) * (H / 16);
+          const ring = [];
+          for (let v = 0; v < 12; v++) {
+            const a = (v / 12) * Math.PI * 2;
+            ring.push(cx + Math.cos(a) * radius, cy + Math.sin(a) * radius);
+          }
+          out.push(ring);
+        }
+      }
+      return out;
+    };
+
+    const paint = (data, chunking) => {
+      const surface = bridge.createSurface(W, H, 1);
+      const ctx = new CocoaContext2D(
+        bridge,
+        () => surface,
+        () => 1,
+      );
+      ctx.strokeChunking = chunking;
+      ctx.fillStyle = '#fff';
+      ctx.fillRect(0, 0, W, H);
+      ctx.strokeStyle = '#204060';
+      ctx.lineWidth = 2;
+      ctx.beginPath();
+      for (const ring of data) {
+        ctx.moveTo(ring[0], ring[1]);
+        for (let i = 2; i < ring.length; i += 2)
+          ctx.lineTo(ring[i], ring[i + 1]);
+        ctx.closePath();
+      }
+      ctx.stroke();
+      return Buffer.from(bridge.ctxGetImageData(surface, 0, 0, W, H));
+    };
+
+    test('chunked and whole draw the same picture where subpaths do not overlap', () => {
+      const data = grid(8);
+      const chunked = paint(data, true);
+      const whole = paint(data, false);
+      let ink = 0;
+      let differing = 0;
+      for (let i = 0; i < whole.length; i += 4) {
+        if (whole[i] !== 255 || whole[i + 1] !== 255) ink++;
+        for (let c = 0; c < 4; c++) {
+          if (chunked[i + c] !== whole[i + c]) {
+            differing++;
+            break;
+          }
+        }
+      }
+      assert.ok(ink > 5000, `the rings drew: ${ink} inked pixels`);
+      assert.equal(differing, 0, `${differing} pixels differ`);
+    });
+
+    test('a chunked stroke inks the pixels a whole one does', () => {
+      // the geometry above, at a size where the rings touch: chunking is
+      // allowed to differ at the seams and nowhere else, and never by much
+      const data = grid(18);
+      const chunked = paint(data, true);
+      const whole = paint(data, false);
+      let worst = 0;
+      let differing = 0;
+      for (let i = 0; i < whole.length; i++) {
+        const d = Math.abs(chunked[i] - whole[i]);
+        if (d) {
+          differing++;
+          worst = Math.max(worst, d);
+        }
+      }
+      assert.ok(
+        differing < whole.length / 20,
+        `${((100 * differing) / whole.length).toFixed(1)}% of channels differ`,
+      );
+      assert.ok(worst < 96, `worst channel delta ${worst}`);
+    });
+  },
+);


### PR DESCRIPTION
Fixes #456.

## What was measured

`CGContextStrokePath` is **quadratic in the number of subpaths** in the path it is handed. Closed 13-vertex rings scattered over a 1024×1024 surface, a 2px line, one `ctx.stroke()`, this machine:

| rings | vertices | before | after |
| ----: | -------: | -----: | ----: |
|   500 |    6,500 |  20 ms | 14 ms |
| 1,000 |   13,000 |  59 ms | 29 ms |
| 2,000 |   26,000 | 208 ms | 56 ms |
| 4,000 |   52,000 | 986 ms | 113 ms |

The subpath count is the driver, not the vertex count: one 26,000-vertex subpath strokes in 4ms where two thousand 13-vertex ones take 208.

The issue also asked which of two things to do. Both, as it turns out — the chunking, and the note in `docs/macos.md`, since the surprising part really is that the two backends want opposite things.

## What changed

`CocoaContext2D.stroke` splits a path with many subpaths into several `CGContextStrokePath` calls, cut at subpath boundaries so each chunk carries the `moveTo` its segments start from. A chunk closes at the first `moveTo` past **512 points or 128 subpaths** — within 5% of the best chunk for every shape swept, including the degenerate one the point budget alone misses, thousands of 3- and 4-point subpaths.

The backend picks the size rather than the caller, per the issue: the right size is a fact about CoreGraphics that no caller can know, and the X11 context wants the opposite, so a caller that batches for one backend pessimizes the other.

Two shapes are left whole, both measured, both because splitting them would be a loss:

- **A hairline** — a device-space width of 1 or less, so `lineWidth` times the CTM's scale. Below that width CoreGraphics is already linear in the subpath count: the 2,000-ring path costs 7ms whole. Splitting it is a **2× regression**, per-call setup with nothing to win back. This one is easy to get wrong — it is the user-space width times the transform, not either alone.
- **Anything that composites** — a translucent `strokeStyle`, a `globalAlpha` below 1, a live shadow. Each chunk paints separately, so overlapping subpaths would blend twice and read darker.

`fill` is not chunked and cannot be: the winding rule is a property of the path as a whole, so a hole stops being a hole once its ring is in a different call.

## The one visual difference, honestly

Under an opaque ink the split is exact wherever coverage is full. What is left is the **antialiased fringe** where two subpaths' strokes overlap — half covered twice instead of covered once, so it reads a little lighter. Below, a 64×64 crop at 6×: a whole stroke, a chunked one, and their difference amplified 5×. Overlapping rings under an opaque 2px ink, the worst case the guards allow — 0.6% of channels differ, worst 26/255, all of it at ring intersections.

`ctx.strokeChunking = false` turns the split off for one context, `REACT_X11_NO_STROKE_CHUNKING=1` for a process.

## Cost to everything else

The path is recorded in JS alongside the native one so a chunk can be re-issued — a flat number array, reused across paths — and the record is what restores the whole path when a `fill`, a `clip` or more path building follows a stroke that consumed it. The restore is lazy, so a caller that strokes and then starts a new path never pays for it.

An ordinary paint measures the same: 20,000 rounded-rect fill+strokes go 601ms → 597ms, 20,000 twelve-segment polylines 113ms → 116ms.

## Testing

`test/cocoa-stroke-chunking.test.js`, both layers. Over a fake bridge: the cuts land at `moveTo`, the chunks reassemble into the path in order with every path verb round-tripping, both budgets close a chunk, each guard holds, and a `fill`/`clip`/further building after a chunked stroke sees the whole path. Over the real bridge, in pixels: chunked and whole draw the same picture where subpaths do not overlap, byte for byte, and stay within a bound where they do.

Mutation-checked — turning chunking off, dropping the hairline guard, dropping the composite guard, cutting mid-subpath and never restoring the path each fail a distinct set of these.

`npm test` is green on the six-failure `appearance.test.js` macOS baseline; `prettier --check .`, `eslint .`, `tsc`, and the website build all pass.


![seams](https://github.com/user-attachments/assets/758c928e-6214-4d8f-8036-a3d26ddbf181)
