### PR TITLE
feat(cocoa): activateWindow raises the app; survey the desktop-integration gaps

### DIFF
--- a/docs/macos.md
+++ b/docs/macos.md
@@ -501,7 +501,7 @@ successor the way wayland.md carries its measurements.
 | file dialogs (portal → osascript → drawn)          | `NSOpenPanel`/`NSSavePanel` replace the osascript rung                                                     | upgrades                                                                    |
 | a11y (AT-SPI over D-Bus)                           | `NSAccessibility` protocol, virtual `NSAccessibilityElement` tree fed from the same `a11y.js` model        | maps; the model carries, the bridge is new (the Chromium/Flutter shape)     |
 | idle / keep-awake                                  | `IOPMAssertion` / `NSProcessInfo` activity                                                                 | maps                                                                        |
-| startup notification, `activateWindow`             | `NSApp.activate`, `NSRunningApplication`; Launch Services owns launch UX                                   | mostly dissolves                                                            |
+| startup notification, `activateWindow`             | `NSApp.activate` + `makeKeyAndOrderFront:`, `NSRunningApplication`; Launch Services owns launch UX         | `activateWindow` **shipped** (`CocoaApp.raiseWindow`); startup dissolves    |
 | URI schemes / single instance (`application.js`)   | Apple Events (`kAEGetURL`) + Launch Services registration; single-instance is the platform default         | maps; same hooks (`onAppOpen`/`onAppActivate`), new plumbing                |
 | tray                                               | `NSStatusItem`                                                                                             | **gained** — X11 has no core tray today                                     |
 | `<glarea>` (GLX / direct CGL)                      | `CAOpenGLLayer`/`NSOpenGLContext` (deprecated but functional), or ANGLE/Metal later                        | bends; ntk's existing `cgl` direct backend is prior art                     |
@@ -514,6 +514,38 @@ opposite conclusion: macOS _keeps_ client-side placement, so `anchor.js`
 stays the single source of truth on this backend — the math that had to
 move into Wayland's positioner stays exactly where it is here, reading
 `NSScreen` geometry instead of Xinerama.
+
+## Desktop integrations: what an app does outside its own windows
+
+The handful of things an app says to the desktop rather than draws — a file
+dialog, a permission prompt, a drag to another app, a tray icon, a Dock badge,
+a raise from a launcher. This is the survey of where each stands on the cocoa
+backend, what already works (including the crude `osascript`/shell rungs that
+need no bridge), and what is blocked on a native addition — each gap has a
+`@windowkit/appkit` ticket for the bridge and a react-x11 ticket for the
+consumer, so the work is tracked rather than rediscovered.
+
+| integration                       | today on cocoa                                                              | the better way (bridge gap)                                           | tickets                                                  |
+| --------------------------------- | --------------------------------------------------------------------------- | --------------------------------------------------------------------- | -------------------------------------------------------- |
+| **file open/save**                | works — the `osascript` rung (`docs/filedialog.md`), a separate process     | in-process `NSOpenPanel`/`NSSavePanel`                                | react-x11#461 → windowkit/appkit#14                      |
+| **raise / app switcher**          | **shipped** — `activateWindow()` = `NSApp.activate` + order-front           | —                                                                     | this PR (`CocoaApp.raiseWindow`)                         |
+| **deep links** (`useAppOpen`)     | an app can call `activateWindow` itself; the OS cannot hand it a URL yet    | Apple Events (`kAEGetURL`, open-docs)                                 | react-x11#465 → windowkit/appkit#18                      |
+| **drag & drop** (external)        | absent — DnD is XDND-only; `_initDnd` needs `setProperty` no `NSWindow` has | `NSDraggingSource`/`Destination`                                      | react-x11#462 → windowkit/appkit#16                      |
+| **system tray**                   | absent                                                                      | `NSStatusItem`                                                        | react-x11#463 (macOS half of #353) → windowkit/appkit#17 |
+| **Dock badge / attention / menu** | absent (X11 has `states: ['demands_attention']`; no badge on either)        | `dockTile.badgeLabel`, `requestUserAttention`, `applicationDockMenu`  | react-x11#464 → windowkit/appkit#15                      |
+| **activation policy / app name**  | fixed `.regular`, the process name                                          | `setActivationPolicy`, Dock/menu name                                 | react-x11#464 → windowkit/appkit#15                      |
+| **permissions** (TCC)             | none; crude `open x-apple.systempreferences:` only _directs_ the user       | `AVCaptureDevice`/`CGRequestScreenCaptureAccess`/`AXIsProcessTrusted` | react-x11#466 → windowkit/appkit#19                      |
+
+Two of these have a **freedesktop counterpart worth having in core with no
+bridge at all**, because they are D-Bus like the portal and the global menu
+already are: the Dock badge (`com.canonical.Unity.LauncherEntry`, one signal
+under the app's `.desktop` id) and the permission prompts (the per-device
+portals — `org.freedesktop.portal.Camera`, `.Location`). Both are tracked on
+the react-x11 tickets above so the cross-backend API is designed once.
+
+The pattern for every rung here is `docs/filedialog.md`'s ladder: the desktop's
+own mechanism where there is one, a crude shell-out beneath it, and a typed
+"cannot do this here" at the floor — never a silent no-op.
 
 ## Text: the engine contract
 

--- a/docs/system.md
+++ b/docs/system.md
@@ -373,7 +373,18 @@ are D-Bus services a third party can wrap without anything from here.
 Notifications and StatusNotifierItem are the two with a claim on core, because
 they are desktop standards rather than one vendor's service — and the tray in
 particular is cheap here, since its menu is [dbusmenu](globalmenu.md), which
-this renderer already speaks.
+this renderer already speaks. Tray tracked in
+[#353](https://github.com/sidorares/react-x11/issues/353) and, for the macOS
+`NSStatusItem` side, [#463](https://github.com/sidorares/react-x11/issues/463).
+
+**A launcher badge, and permission prompts.** An unread count on the icon
+(freedesktop `com.canonical.Unity.LauncherEntry`, one D-Bus signal; macOS
+`dockTile.badgeLabel`) and camera/mic/location authorization (the freedesktop
+device portals; macOS TCC) are both cross-backend integrations with a D-Bus
+half that needs nothing from a native bridge — tracked in
+[#464](https://github.com/sidorares/react-x11/issues/464) and
+[#466](https://github.com/sidorares/react-x11/issues/466). Attention (the taskbar
+urgency / Dock bounce) already exists on X11 as `states: ['demands_attention']`.
 
 **Session lifecycle** — "we are suspending, save now", and "I have unsaved work,
 do not log out yet". The X-native answer (XSMP) is effectively dead and the live

--- a/src/activate.js
+++ b/src/activate.js
@@ -143,6 +143,18 @@ export function activateWindow(target, { timestamp, source } = {}) {
   const app = node?.app ?? node?.root?.app ?? wnd?.app ?? soleApp();
 
   const chosen = wnd ?? (windowIdOf(node) === null ? inferWindow(app) : null);
+
+  // The cocoa backend has no window manager and no `_NET_ACTIVE_WINDOW` to
+  // send — the raise is `NSApp.activate` plus ordering the window front,
+  // which the app object performs (src/cocoa/app.js `raiseWindow`).
+  // Feature-detected so the X11 path below is untouched, and so this stops
+  // reporting the false success the no-op X stub would: on cocoa `app.X` is
+  // a shim whose `InternAtom`/`SendClientMessage` go nowhere yet still let
+  // the code below return `true`.
+  if (app && typeof app.raiseWindow === 'function') {
+    return app.raiseWindow(chosen);
+  }
+
   const xid = windowIdOf(chosen) ?? windowIdOf(node);
   const X = ntkWindowOf(chosen)?.X ?? wnd?.X ?? app?.X;
   const root = X?.display?.screen?.[0]?.root;

--- a/src/cocoa/app.js
+++ b/src/cocoa/app.js
@@ -294,6 +294,33 @@ export class CocoaApp {
   }
 
   /**
+   * Bring this app and one of its windows to the front — the cocoa answer to
+   * `activateWindow()` (src/activate.js), the raise a deep link's
+   * `useAppOpen`/`useAppActivate` handler performs.
+   *
+   * There is no window manager here and no `_NET_ACTIVE_WINDOW` to send:
+   * `activateApp()` is `NSApp.activate` and `showWindow(h, true)` re-issues
+   * `makeKeyAndOrderFront:`, which is the whole of a raise on this backend.
+   * The X11 path weighs a launch timestamp against focus-stealing
+   * prevention; macOS has no such negotiation from a client, so the
+   * timestamp is not a parameter here.
+   *
+   * `target` is whatever `activate.js` resolved — a `CocoaWindow`, the
+   * `WindowNode` that owns one, or nothing when there is no window to raise.
+   * Returns whether a window was actually raised, matching the X path's
+   * "was the request issued" contract (and so *not* the false success the
+   * no-op `X.SendClientMessage` stub would report).
+   */
+  raiseWindow(target) {
+    if (this._closed) return false;
+    const wnd = target && target._h != null ? target : (target?.window ?? null);
+    if (!wnd || wnd.destroyed || wnd._h == null) return false;
+    this._native.activateApp();
+    this._native.showWindow(wnd._h, true);
+    return true;
+  }
+
+  /**
    * The pane's end of the frame channel (childmain hands it over,
    * feature-detected so the X11 pane path never notices): geometry and
    * input come in, pane-present goes out.

--- a/test/cocoa-activate.test.js
+++ b/test/cocoa-activate.test.js
@@ -1,0 +1,95 @@
+// `activateWindow()` on the cocoa backend (docs/macos.md §"Windowing
+// semantics", the `activateWindow` row).
+//
+// There is no window manager and no `_NET_ACTIVE_WINDOW` here: the raise is
+// `NSApp.activate` + `makeKeyAndOrderFront:`, which `CocoaApp.raiseWindow`
+// performs against the bridge. The whole of this runs over a recording fake
+// bridge — the shape of cocoa-surface.test.js — so it says nothing about
+// glass, only that the right native calls go out and that the return value
+// is the honest "did a window get raised" the X11 path promises.
+//
+// The regression it pins: before this wiring, `activateWindow(cocoaWindow)`
+// returned `true` while doing nothing, because `app.X` is a shim whose
+// `SendClientMessage` is a no-op — the exact "every layer reports success"
+// failure the activate.js header warns about.
+import assert from 'node:assert';
+import { test } from 'node:test';
+
+import { CocoaApp } from '../src/cocoa/app.js';
+import { activateWindow } from '../src/activate.js';
+
+/** A bridge shaped like @windowkit/appkit's, recording every call and
+ * answering the few a window's construction needs a handle for. */
+function fakeNative() {
+  const calls = [];
+  let seq = 0;
+  return new Proxy(
+    { calls, of: (name) => calls.filter((c) => c[0] === name) },
+    {
+      get(base, name) {
+        if (name in base) return base[name];
+        if (typeof name !== 'string') return undefined;
+        return (...args) => {
+          calls.push([name, ...args]);
+          if (name === 'listScreens') {
+            return [
+              { x: 0, y: 0, width: 1440, height: 900, scale: 2, fps: 60 },
+            ];
+          }
+          if (name === 'createWindow2') return { h: ++seq };
+          if (name === 'windowNumber') return args[0].h;
+          if (name === 'windowRootLayer') return { layer: args[0].h };
+          if (name === 'getWindowFrame') {
+            return { x: 0, y: 0, width: 640, height: 480 };
+          }
+          return undefined;
+        };
+      },
+    },
+  );
+}
+
+test('activateWindow raises the named window: NSApp.activate, then order front', () => {
+  const native = fakeNative();
+  const app = new CocoaApp(native);
+  const wnd = app.createWindow({ width: 640, height: 480, title: 'x' });
+
+  native.calls.length = 0; // ignore construction traffic
+  assert.equal(activateWindow(wnd), true);
+
+  // activateApp comes before showWindow, and showWindow asks to make the
+  // window key (the `true` second argument) — an actual raise, not a
+  // background order-front.
+  const raise = native.calls.map((c) => c[0]);
+  assert.ok(
+    raise.indexOf('activateApp') >= 0 &&
+      raise.indexOf('showWindow') > raise.indexOf('activateApp'),
+    `activateApp then showWindow, got ${raise.join(', ')}`,
+  );
+  const [show] = native.of('showWindow');
+  assert.equal(show[1], wnd._h, 'the named window');
+  assert.equal(show[2], true, 'made key — a real raise');
+});
+
+test('a destroyed window raises nothing and says so', () => {
+  const native = fakeNative();
+  const app = new CocoaApp(native);
+  const wnd = app.createWindow({ width: 200, height: 100 });
+  wnd.destroy();
+
+  native.calls.length = 0;
+  assert.equal(activateWindow(wnd), false);
+  assert.equal(native.of('activateApp').length, 0, 'no app activation either');
+});
+
+test('raiseWindow accepts the WindowNode that owns the window', () => {
+  const native = fakeNative();
+  const app = new CocoaApp(native);
+  const wnd = app.createWindow({ width: 200, height: 100 });
+
+  native.calls.length = 0;
+  // the shape activate.js hands over when it infers the window: a node whose
+  // `.window` is the CocoaWindow
+  assert.equal(app.raiseWindow({ window: wnd }), true);
+  assert.equal(native.of('showWindow')[0][1], wnd._h);
+});


### PR DESCRIPTION
Surveys the macOS desktop integrations against `docs/macos.md`, ships the one
that needed no bridge addition, and tracks the rest as paired bridge/consumer
issues.

## What ships here

`activateWindow()` now raises the app on the **cocoa** backend. It went through
`app.X` — whose `SendClientMessage` is a no-op stub there — so it reported
success while raising nothing, the exact "every layer reports success" failure
`activate.js` exists to prevent. It now routes through a new
`CocoaApp.raiseWindow()`: `NSApp.activate` (the bridge's `activateApp`) then
`makeKeyAndOrderFront:` (`showWindow(h, true)`). Feature-detected on the app, so
the X11 path is byte-for-byte untouched, and the return value is once again the
honest "was a window raised".

This is the raise a deep link's `useAppOpen`/`useAppActivate` handler performs;
the Apple-Events plumbing that would fire those handlers from the OS is a
separate bridge gap (below).

Verified against the real `@windowkit/appkit` bridge (the call reaches
`activateApp` then `showWindow(true)`), plus a headless test over a recording
fake bridge (`test/cocoa-activate.test.js`). No rendering change, so no
screenshots. `npm test`, `lint`, `format:check`, `typecheck` green.

## The survey, and the gaps

`docs/macos.md` gains a table mapping every integration an app does outside its
own windows to its status on cocoa and its bridge gap. The pattern throughout
is `docs/filedialog.md`'s ladder: the desktop's own mechanism, a crude
shell-out beneath it, a typed error at the floor — never a silent no-op.

Each gap is filed as a `@windowkit/appkit` bridge ticket + a react-x11 consumer
ticket that links it:

| integration                 | react-x11                                              | bridge                       |
| --------------------------- | ------------------------------------------------------ | ---------------------------- |
| native file open/save panel | #461                                                   | windowkit/appkit#14          |
| drag & drop (external)      | #462                                                   | windowkit/appkit#16          |
| system tray (`NSStatusItem`) | #463 (macOS half of #353)                             | windowkit/appkit#17          |
| Dock badge / attention / menu, activation policy | #464                              | windowkit/appkit#15          |
| deep links → `useAppOpen`   | #465                                                   | windowkit/appkit#18          |
| permissions (TCC)           | #466                                                   | windowkit/appkit#19          |

Two of these have a **freedesktop counterpart that needs no bridge** and is
implementable in core the way the portal and global menu already are: the
launcher badge (`com.canonical.Unity.LauncherEntry`) and the permission prompts
(the device portals). Both are noted on the tickets so the cross-backend API is
designed once.
