### PR TITLE
feat: onLayout on every drawn element — the rect a layout pass produced

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -137,6 +137,16 @@ stay inside it, focus is restored when it unmounts), `disabled` (never
 focusable, and the trigger for a `:disabled` style block), and the event
 handlers listed in [events.md](events.md).
 
+`onLayout` is the one handler that reports layout rather than input: after a
+layout pass moved or resized the element it gets `{x, y, width, height}` in
+logical pixels — the position within the parent _as laid out_, so a scroll
+does not fire it — once after the first layout and then only when something
+changed. It arrives after the pass, so state set from it is safe. It is how
+a component reacts to its size when the reaction is not a style
+([react-features.md](react-features.md#measuring-a-node)); where it is one,
+a `'@container'` block answers in the same frame
+([styling.md](styling.md#container-queries)).
+
 Every element also takes `role` and the `aria-*` props — the web's
 accessibility vocabulary, read by the built-in AT-SPI bridge so screen
 readers see the tree. They are inert where no assistive technology is
@@ -1001,7 +1011,9 @@ pixels, and so is an arrow key ([events.md](events.md#wheel)).
 list nobody has scrolled yet. That is what a virtualized list needs before
 it can decide how many rows are worth building: layout runs on the frame
 clock, after the commit that mounted the node, so an effect cannot read the
-size off the ref. `Table` is built on it.
+size off the ref. `Table` is built on it. `onLayout`
+([Interaction props](#interaction-props)) is the same signal on any element;
+`onViewport` adds the content size a scroller measures.
 
 `scrollIntoView(node)` scrolls the minimum amount that makes a descendant
 node fully visible, and is safe to call from an effect right after that

--- a/docs/react-features.md
+++ b/docs/react-features.md
@@ -96,10 +96,12 @@ produced. On the very first render of a node, that is nothing yet.
 
 What to do instead:
 
-- **Let the element tell you.** `<box onViewport>` fires when the
-  viewport or content size changes, with `width`/`height`/`contentWidth`/
-  `contentHeight`. `<window onResize>` fires when the window is resized.
-  These are the supported way to react to a size.
+- **Let the element tell you.** `onLayout` fires on any element after a
+  layout pass moved or resized it, with `width`/`height` (and `x`/`y`
+  within the parent) in logical pixels — once after the first layout, then
+  on change. `<box onViewport>` adds a scroller's content size, and
+  `<window onResize>` fires when the window is resized. These are the
+  supported way to react to a size.
 - **Read `abs` from a ref in a handler or a later effect**, not during the
   render that created the node.
 - **Take a getter, not a value.** `useWindowId(ref)` and `useAnchor()` return
@@ -109,17 +111,19 @@ What to do instead:
 ```jsx
 const [cols, setCols] = useState(1);
 
-<box
-  style={{ overflow: 'scroll' }}
-  onViewport={({ width }) => setCols(Math.max(1, (width / 200) | 0))}
->
+<box onLayout={({ width }) => setCols(Math.max(1, (width / 200) | 0))}>
   {items.map(…)}
 </box>;
 ```
 
+When what depends on the size is a _style_ rather than a decision about what
+to render, write it as a container query block instead
+([styling.md](styling.md#container-queries)): it applies in the same frame,
+where a state set from `onLayout` re-renders a frame later.
+
 If you are porting a component that measures itself and adjusts, this is the
-part to rewrite. See [elements.md](elements.md) for `onViewport` and
-`onResize`, and [components.md](components.md) for `useAnchor`.
+part to rewrite. See [elements.md](elements.md) for `onLayout`, `onViewport`
+and `onResize`, and [components.md](components.md) for `useAnchor`.
 
 ## What a ref gives you
 

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -1137,6 +1137,12 @@ threshold (a scroll, a hover, a resize between two breakpoints) pays one
 size read per container and nothing else. A frame where one does pays what
 the same change would have cost had React made it.
 
+When what depends on the size is not a style — how many rows to build, which
+component to render — the same size reaches React through `onLayout` on any
+element ([react-features.md](react-features.md#measuring-a-node)). It
+arrives after the pass, so the reaction lands a frame later than a block
+would; that is the reason to write a style as a block where one can.
+
 ### A block must not move the size it asks about
 
 CSS makes this impossible by construction: `container-type: inline-size` is

--- a/examples/container-queries.jsx
+++ b/examples/container-queries.jsx
@@ -171,11 +171,11 @@ function Card({ item }) {
 }
 
 function Pane({ name, items }) {
-  // `onViewport` is the React-side seam: the same width the blocks compare
-  // against, for a decision that is not a style
+  // `onLayout` is the React-side seam: the same width the blocks compare
+  // against, for a decision that is not a style — here, only a caption
   const [width, setWidth] = useState(null);
   return (
-    <box style={s.pane} onViewport={(v) => setWidth(Math.round(v.width))}>
+    <box style={s.pane} onLayout={(ev) => setWidth(Math.round(ev.width))}>
       <text style={s.paneTitle}>
         {name}
         {width == null ? '' : ` · ${width}px`}

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -4012,9 +4012,56 @@ export class Node {
       this.yoga.getComputedWidth(),
       this.yoga.getComputedHeight(),
     );
+    if (this.props.onLayout) this._reportLayout();
     for (const child of this.children) {
       if (!child.isWindow) child.absolutize(this.abs.x, this.abs.y);
     }
+  }
+
+  /**
+   * `onLayout`: the rect a layout pass gave this node, reported when it
+   * changed — React Native's contract, and the seam for a decision that is
+   * not a style (docs/react-features.md): how many columns to build, which
+   * component to render. Where the decision *is* a style, a container
+   * query answers it in the same frame instead (docs/styling.md).
+   *
+   * `x`/`y` are the position **within the parent as laid out** — yoga's
+   * answer, which a scroll does not move — rather than the window
+   * coordinates `abs` holds: a list scrolling under the pointer must not
+   * re-render every row on every notch. Logical pixels, this node's own,
+   * the same division `measure()` makes.
+   *
+   * Deferred, like `onViewport`: this runs inside the layout pass, and a
+   * `setState` from the handler would re-enter it. One report per frame,
+   * because `absolutize` runs once, after the container blocks have
+   * settled — a card whose block changed its height reports the height it
+   * ended the frame at, not the one it had between passes.
+   */
+  _reportLayout() {
+    const s = this.scale;
+    const next = {
+      x: this.yoga.getComputedLeft() / s,
+      y: this.yoga.getComputedTop() / s,
+      width: this.abs.width / s,
+      height: this.abs.height / s,
+    };
+    const last = this._lastLayout;
+    if (
+      last &&
+      last.x === next.x &&
+      last.y === next.y &&
+      last.width === next.width &&
+      last.height === next.height
+    ) {
+      return;
+    }
+    this._lastLayout = next;
+    setImmediate(() => {
+      // the handler as it is *now*: React may have re-rendered in between
+      const notify = this.props.onLayout;
+      if (this.destroyed || !notify) return;
+      callHandler(this, 'onLayout', notify, next);
+    });
   }
 
   /**
@@ -6364,6 +6411,7 @@ export const Scrollable = (Base) =>
         this.yoga.getComputedWidth(),
         this.yoga.getComputedHeight(),
       );
+      if (this.props.onLayout) this._reportLayout();
       this._absolutizeChildren(this.abs.x, this.abs.y);
     }
 

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -23,6 +23,7 @@ import type {
   SubmitEvent,
   SyntheticEvent,
   ViewportEvent,
+  LayoutEvent,
   WheelEvent,
   WindowResizeEvent,
 } from './events.js';
@@ -188,6 +189,15 @@ export interface DrawnProps<T = DrawnNode>
     SelectionProps<T>,
     EventHandlers<T> {
   ref?: Ref<T>;
+  /**
+   * After a layout pass moved or resized this element: `{x, y, width,
+   * height}` in logical pixels, the position within the parent as laid out
+   * — so scrolling does not fire it. Once after the first layout, then only
+   * on change; deferred past the pass, so `setState` in it is safe. The
+   * seam for a decision that is not a style; where it is one, a
+   * `'@container'` block answers in the same frame (docs/styling.md).
+   */
+  onLayout?: (ev: LayoutEvent) => void;
   /**
    * Zoom this subtree, CSS `zoom` rather than a transform: every length
    * under here — and this element's *own* style — is multiplied by it, so

--- a/src/types/events.d.ts
+++ b/src/types/events.d.ts
@@ -335,6 +335,20 @@ export interface ScrollEvent {
   viewportHeight: number;
 }
 
+/**
+ * `onLayout` on any drawn element: the rect a layout pass gave it, in its
+ * own logical pixels — `x`/`y` the position **within the parent as laid
+ * out**, which scrolling does not move. Reported after the first layout and
+ * then only when it changes, deferred past the pass so state set from it is
+ * safe. See docs/react-features.md#measuring-a-node.
+ */
+export interface LayoutEvent {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
 /** `<box onViewport>` — fired from layout, not from scrolling. */
 export interface ViewportEvent {
   width: number;

--- a/test/on-layout.test.js
+++ b/test/on-layout.test.js
@@ -1,0 +1,200 @@
+// `onLayout` on any drawn element: the rect a layout pass gave it, reported
+// after the first layout and then when it changes — React Native's contract,
+// and the React-side seam beside the container queries (docs/styling.md).
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React, { useState } from 'react';
+import { createRoot } from '../src/index.js';
+import { createStyles } from '../src/styles.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+// the layout pass runs on one tick and the report is deferred past it
+const settle = async () => {
+  await tick();
+  await tick();
+  await tick();
+};
+const nodeOf = (app) => app.windows[0]._reactX11Node;
+
+async function resize(app, width, height = 300) {
+  const wnd = app.windows[0];
+  wnd.width = width;
+  wnd.height = height;
+  wnd.emit('resize', { width, height });
+  await settle();
+}
+
+test('reports the rect after the first layout, then only when it changes', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const calls = [];
+  const render = (handler) =>
+    x11Root.render(
+      h(
+        'window',
+        { width: 400, height: 300 },
+        h(
+          'box',
+          { style: { padding: 10, flexGrow: 1 } },
+          h('box', {
+            style: { height: 40, ':hover': { backgroundColor: 'red' } },
+            focusable: true,
+            onLayout: handler,
+          }),
+        ),
+      ),
+    );
+  render((ev) => calls.push(ev));
+  await settle();
+  assert.deepStrictEqual(
+    calls,
+    [{ x: 10, y: 10, width: 380, height: 40 }],
+    'once, with the rect the pass produced: inside the padding, the full width',
+  );
+
+  // a repaint-only change says nothing
+  const box = nodeOf(app).children[0].children[0];
+  box.setStyleState(':hover', true);
+  await settle();
+  assert.strictEqual(calls.length, 1, 'hover is a repaint, not a layout');
+
+  // nor does a render that hands over a new handler for the same layout
+  render((ev) => calls.push(ev));
+  await settle();
+  assert.strictEqual(calls.length, 1, 'a fresh inline arrow is not a change');
+
+  // the window narrows, so the box does
+  await resize(app, 300);
+  assert.strictEqual(calls.length, 2);
+  assert.deepStrictEqual(calls[1], { x: 10, y: 10, width: 280, height: 40 });
+  await x11Root.unmount();
+});
+
+test('a scroll moves the element on screen but not in its layout, so it does not fire', async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const calls = [];
+  x11Root.render(
+    h(
+      'window',
+      { width: 200, height: 100 },
+      h(
+        'box',
+        { style: { overflow: 'scroll', flexGrow: 1 } },
+        h('box', { key: 'a', style: { height: 80 } }),
+        h('box', {
+          key: 'b',
+          style: { height: 80 },
+          onLayout: (ev) => calls.push(ev),
+        }),
+      ),
+    ),
+  );
+  await settle();
+  const scroller = nodeOf(app).children[0];
+  const b = scroller.children[1];
+  assert.strictEqual(calls.length, 1);
+  assert.deepStrictEqual(calls[0], {
+    x: 0,
+    y: 80,
+    width: b.abs.width,
+    height: 80,
+  });
+  const before = b.abs.y;
+  scroller.scrollTo({ y: 30 });
+  await settle();
+  assert.strictEqual(b.abs.y, before - 30, 'the pane did scroll');
+  assert.strictEqual(calls.length, 1, 'and the row said nothing');
+  await x11Root.unmount();
+});
+
+test("in the element's own logical pixels, under a scale", async () => {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const calls = [];
+  x11Root.render(
+    h(
+      'window',
+      { width: 400, height: 300 },
+      h(
+        'box',
+        { scale: 2, style: { padding: 5 } },
+        h('box', {
+          style: { width: 50, height: 20 },
+          onLayout: (ev) => calls.push(ev),
+        }),
+      ),
+    ),
+  );
+  await settle();
+  const inner = nodeOf(app).children[0].children[0];
+  assert.strictEqual(inner.abs.width, 100, '50 logical is 100 device pixels');
+  assert.deepStrictEqual(calls, [{ x: 5, y: 5, width: 50, height: 20 }]);
+  await x11Root.unmount();
+});
+
+test('state set from the handler re-renders once and does not loop', async () => {
+  let reports = 0;
+  function Columns() {
+    const [cols, setCols] = useState(1);
+    return h(
+      'box',
+      {
+        style: { flexGrow: 1, flexDirection: 'row' },
+        onLayout: (ev) => {
+          reports += 1;
+          setCols(Math.max(1, Math.floor(ev.width / 100)));
+        },
+      },
+      ...Array.from({ length: cols }, (_, i) =>
+        h('box', { key: i, style: { flexGrow: 1, height: 10 } }),
+      ),
+    );
+  }
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(h('window', { width: 350, height: 300 }, h(Columns)));
+  await settle();
+  await settle();
+  const row = nodeOf(app).children[0];
+  assert.strictEqual(row.children.length, 3, 'three columns fit in 350');
+  assert.strictEqual(
+    reports,
+    1,
+    'the re-render changed the children, not the row',
+  );
+  await resize(app, 550);
+  await settle();
+  assert.strictEqual(row.children.length, 5);
+  assert.strictEqual(reports, 2);
+  await x11Root.unmount();
+});
+
+test('reports the rect the container blocks settled on, once', async () => {
+  // the card is 50 tall until its container is known to be wide, which the
+  // first layout pass is what establishes — the report carries the height
+  // the frame ended at, not the one between the passes
+  const s = createStyles({
+    pane: { container: true, width: 500 },
+    card: { height: 50, '@container width >= 400': { height: 100 } },
+  });
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const calls = [];
+  x11Root.render(
+    h(
+      'window',
+      { width: 800, height: 300 },
+      h(
+        'box',
+        { style: s.pane },
+        h('box', { style: s.card, onLayout: (ev) => calls.push(ev) }),
+      ),
+    ),
+  );
+  await settle();
+  assert.deepStrictEqual(calls, [{ x: 0, y: 0, width: 500, height: 100 }]);
+  await x11Root.unmount();
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -346,6 +346,7 @@ function Elements() {
         style={[s.responsive, { overflow: 'scroll' }]}
         onScroll={(ev: ScrollEvent) => void ev.scrollY}
         onViewport={(ev) => void ev.contentHeight}
+        onLayout={(ev) => void (ev.x + ev.y + ev.width + ev.height)}
       >
         <box style={{ height: 800 }} />
       </box>


### PR DESCRIPTION
Follows #470, now merged: rebased onto `master` so the diff is the `onLayout` change alone.

`onLayout` on every drawn element: after a layout pass moved or resized the element, the handler gets `{x, y, width, height}` in the element's own logical pixels — once after the first layout, then only when it changes. It is the React-side seam the container-queries design record named as the thing to ship beside the blocks: the same size a `'@container'` block compares against, for a decision that is not a style — how many rows to build, which component to render.

## The contract

- **Position is yoga's, within the parent as laid out.** Not `abs`: a scroll moves every row on screen and must not re-render each of them on every notch. This is React Native's `onLayout`, and the reason a scroll fires nothing.
- **Deferred past the pass**, like `onViewport`, so `setState` in the handler is safe and cannot re-enter the layout that is still running. A state change that re-lays out the children does not report again unless the element's own rect moved.
- **One report per frame, with the rect the frame settled on.** `absolutize` runs once, after the container blocks have re-resolved, so a card whose block changed its height reports the final height rather than the one between passes.
- **Logical pixels, divided by the element's own `scale`**, the way `measure()` divides — `width: 50` under `scale={2}` reports 50.
- A new inline handler on a re-render is not a change; a repaint-only change such as a hover is not either.
- `<window>` and `<popup>` keep `onResize`; `onLayout` is on `DrawnProps`.

## Docs

`elements.md` places it under Interaction props and beside `onViewport`, whose extra is the content size a scroller measures. `react-features.md`'s "Measuring a node" now leads with it, and says when a container query block is the better tool: it applies in the same frame, where a state set from `onLayout` re-renders a frame later. The container-queries section in `styling.md` points the other way. The example's pane captions move from `onViewport` onto it.

## Tests

`test/on-layout.test.js`: the first report and the silence on hover, on a new handler and on a scroll; a resize reporting the new rect; logical pixels under `scale`; state set from the handler changing the children without looping; and the rect reported once, after the container blocks settled. Full suite locally: the six `appearance.test.js` failures are the known macOS-only baseline.

