### PR TITLE
feat(cocoa): transitions and loops run in the render server on the layer presenter; reduce motion from System Settings

### DIFF
--- a/docs/architecture/animation.md
+++ b/docs/architecture/animation.md
@@ -1,0 +1,680 @@
+# Animation in styles: timelines, opacity, transforms, and who interpolates
+
+_Design document, 2026-09-06. Written against master at c9ce902 (react-x11
+2.6.1, ntk ^8.7.0, `@windowkit/appkit` ^0.4.0). File:line references will
+drift with the code; the shape of the argument should not._
+
+---
+
+## 0. TL;DR
+
+The style vocabulary already has two animation shapes — `transition` (a
+change, over so many ms) and `animation` (a loop between two values) — and
+one runtime that drives both: the window's frame clock, JS interpolation,
+a damage claim per frame. That runtime is correct on every backend and is
+the fallback everything below degrades to.
+
+What an author cannot write today, in order of how often it comes up:
+
+1. **A fade.** There is no `opacity`. The ecosystem page opens by saying so.
+2. **A move that does not reflow.** There is no `translate`/`rotate`/`scale`;
+   the Switch thumb slides on `start` and pays a yoga pass per frame for it.
+3. **A timeline that ends.** `animation` loops forever by definition; an
+   entrance, a shake, a pulse-three-times have no spelling.
+4. **More than two stops**, an easing on a transition, a delay, a spring.
+5. **Motion that survives a busy JS thread.** On macOS the retained layer
+   presenter can hand a transition to Core Animation and stop scheduling
+   frames for it; today it sets layer properties per frame like everything
+   else.
+
+The proposal is one vocabulary, four additions, and one execution rule:
+
+- **Easing** becomes cubic-bezier control points under the hood, with names
+  as aliases and springs as a second kind. This is the load-bearing change:
+  it is what lets a JS evaluator and Core Animation agree on the same
+  declaration (§3.1 has the numbers — mapping today's ease-out to CA's
+  _named_ ease-out is 22% off at the peak; to control points it is 0.3%).
+- **`transition`** grows a per-property object form with `easing` and
+  `delay`, and `all` for the shorthand's slot.
+- **`animation`** grows `keyframes`, `repeat` (default `Infinity`, so every
+  existing loop keeps its meaning), `delay`, and `key` to re-trigger. A
+  finite one rests at the declared value when it ends — the rule loops
+  already follow, which turns out to be CSS's `fill-mode: none` for free.
+- **`opacity`, `translateX`, `translateY`, `rotate`, `scaleX`, `scaleY`** as
+  paint-only style properties on both backends. Free on a layer; an
+  offscreen composite on X11, bounded to the subtree, with fast paths for
+  the common cases (a leaf's opacity, a pure translate).
+- **The presenter decides who interpolates.** The node model stays the one
+  source of truth for _what_ is animating and _when it ends_. A presenter
+  may take a property it can express on the node's own layer; anything it
+  declines runs on the JS loop exactly as now. The layer presenter takes
+  paint properties, opacity and transforms; layout properties stay on the
+  JS loop everywhere, because yoga has to run.
+
+Five bridge verbs stand between the layer presenter and that offload
+(§4.4). The first — control-point timing functions — is a prerequisite,
+not an enhancement: without it every existing transition would change its
+look the day it moved to the render server.
+
+**Status, 2026-09-06.** Bridge items 1–8 shipped in `@windowkit/appkit`
+0.5.0 (§4.4). Landed in react-x11 on top of it: the presenter seam of §4.1
+and the PropBox rows of §4.2 (`animate`/`cancel` in
+src/cocoa/presenter.js, the `offloaded` entries in nodes.js), with additive
+retargets for lengths and presentation-value retargets for colours, and
+reduce motion on the Cocoa backend (src/desktopsettings.js's `fromMacOS`).
+The vocabulary of §3 — easing, timelines, `opacity`, transforms — is still
+to come; the control-point tables it needs exist (`EASING_CONTROL_POINTS`).
+
+## 1. What exists
+
+### 1.1 The vocabulary
+
+`transition: number | { [prop]: ms }` — a number covers every animatable
+property, an object picks them (docs/styling.md "Transitions"). One fixed
+ease-out cubic (`ease`, src/styles.js:1121). A transition starts from what
+is on screen, so an interrupted one reverses from where it got to
+(`_retarget`, src/nodes.js:2066), and it starts at `now()` rather than the
+last frame's timestamp, so an idle window does not find it already over
+(#80). Nothing before a node's first frame transitions — an inserted
+element appears at its style (`_placed`, test/transition-mount.test.js).
+Layout properties may transition and cost a layout pass per frame; enums,
+`zIndex`, `boxShadow` and `backgroundImage` snap (`NOT_ANIMATABLE`,
+src/styles.js:726).
+
+`animation: { [prop]: { from?, to, duration, easing?, alternate? } }` — a
+loop (#352). `from` defaults to the declared value, which is also where the
+property rests whenever the loop is not running. Four named easings,
+`linear` by default because a cycle that eases out stutters at the wrap.
+Phase is a modulo of elapsed time (`animationValueAt`, src/styles.js:965).
+An equal declaration keeps its phase across re-renders (`sameAnimation`).
+It stops when the window is unmapped, minimized or obscured, when anything
+above the node hides it, when the node unmounts or the style drops it, and
+under reduced motion (`_loopsAllowed`, src/nodes.js:2288) — and every one
+of those restarts it from the top when it goes away.
+
+### 1.2 The runtime
+
+One path for both shapes. `_retarget` puts an entry per property into
+`node._anim` and the node into `root._animating`; `flush` calls
+`_advanceAnimations(now())` (src/nodes.js:11090), which claims damage for
+each animating node _before_ ticking it (a finished tick deletes the entry,
+and with it the only way to tell a layout animation from a paint one —
+`damageForAnimation`, src/nodes.js:620), ticks, and sets `needsPaint`. The
+window keeps asking for frames while `_animating` is non-empty; the
+animation _is_ the repaint loop. `interpolate` (src/styles.js:990) lerps
+numbers, percentages of the same unit, and colours — premultiplied, so a
+fade from `transparent` does not pass through grey.
+
+`withFrameClock` in `react-x11/test` freezes the clock; the loop tests
+(test/animation-loop.test.js) and the transition tests in test/style.test.js
+drive it by hand.
+
+### 1.3 Where the pixels come from
+
+Three presentation paths, and the animation runtime is identical on all of
+them:
+
+| backend                                      | a frame is                                                             | can anything interpolate for us?                      |
+| -------------------------------------------- | ---------------------------------------------------------------------- | ----------------------------------------------------- |
+| X11 (ntk / XRender)                          | damage rects → paint walk → XRender                                    | no                                                    |
+| Cocoa, `surface` presenter (**the default**) | the same paint walk into an IOSurface swapchain                        | no — one bitmap per window                            |
+| Cocoa, `layers` presenter (opt-in)           | dirty nodes → per-node visuals → one `CATransaction` of property diffs | **yes** — the render server animates layer properties |
+
+The layer presenter (src/cocoa/presenter.js) keeps a visual per drawn node:
+a **PropBox** for a plain `<box>` (frame, zPosition, hidden, masksToBounds,
+cornerRadius, backgroundColor, borderWidth, borderColor — zero raster), a
+**Raster** for everything else (the node's own paint replayed into a bitmap
+that becomes the layer's `contents`), shape layers for `<svg>`, an overlay
+for scrollbars, and a clip host whose `bounds.origin` is the scroll offset.
+A JS-driven transition on this presenter works today by construction: each
+tick invalidates the node, the frame re-diffs its properties and sends the
+changed ones under `disableActions`. It is the same cost model as X11 with
+a cheaper sink.
+
+It is opt-in — `createRoot({ cocoa: { presenter: 'layers' } })` or
+`REACT_X11_COCOA_PRESENTER=layers` — while docs/macos.md's measure-first
+gate is open. Everything in §4 is about that presenter; on the surface
+presenter there is nothing to hand an animation to.
+
+### 1.4 What the bridge can already do
+
+`@windowkit/appkit`'s verbs, as react-x11 reaches them through `native`
+(src/cocoa/native.js):
+
+- `addAnimation(layer, keyPath, opts, key)` — a `CABasicAnimation`:
+  `from`/`to` (numbers, `[x, y]` points, `[r, g, b, a]` colours), `duration`
+  in **seconds**, `repeat` (a count, or `Infinity`), `autoreverse`, `timing`
+  as one of four **named** curves (`linear`, `easeIn`, `easeOut`,
+  `easeInEaseOut`; anything else is CA's default), and `hold` for
+  `fillMode: forwards` + `removedOnCompletion: NO`.
+- `removeAnimation(layer, key)`, `removeAllAnimations(layer)`.
+- `txBegin({ duration, timing, disableActions })` / `txCommit()` — the
+  implicit-animation route: set a property inside a transaction with a
+  duration and CA animates it.
+- `setLayerProps` accepts `opacity`, `anchorPoint`, `position`, `bounds`,
+  the shadow quartet, and `transform` as
+  `{ translateX, translateY, rotate (radians), scale | scaleX, scaleY }`,
+  composed translate → rotate → scale — CSS's order for the individual
+  transform properties, and the shape §3.4 proposes.
+
+What it cannot do, each of which §4.4 turns into an issue: a timing function
+from control points; a keyframe animation; a spring; a delay (`beginTime`);
+an additive animation; a completion callback; reading a presentation value;
+and the desktop's reduce-motion switch, which on Cocoa never reaches
+`desktopSettings().animations` at all (src/desktopsettings.js reads
+XSETTINGS and nothing else, so a mac reports `animations: true` whatever
+the user set).
+
+## 2. What cannot be said
+
+Concrete, from the examples and the widget set:
+
+- **Fade in a tooltip, a toast, a menu.** No `opacity`. The ecosystem page
+  tells people to animate a colour instead, and every entry on that page
+  exists partly because of this hole.
+- **Hover lift.** `':hover': { scaleX: 1.02, scaleY: 1.02 }` — a paint-only
+  state change that today has no property to change. A state block cannot
+  touch layout, so growing the box is not an option either.
+- **The Switch thumb.** `transition: { start: 120 }` is a layout pass per
+  frame on every backend and can never be offloaded, because `start` is
+  yoga's. As `translateX` it is a paint property: no layout on X11, a
+  `transform.translation.x` animation in the render server on layers.
+- **A shake on a bad password.** Six stops in 300ms, once, and again on the
+  next attempt. Neither shape has a spelling for "once" or for "again".
+- **An entrance.** Slide up and fade in on mount. Nothing may transition
+  before the first frame (correctly — the mount rule), and the loop shape
+  never ends.
+- **A spinner.** `rotate` from 0 to 360, forever — the one loop that is
+  obviously a transform, and the one with no property to loop.
+- **A staggered list.** Delay per row. No `delay`.
+- **A transition with a curve.** `ease-in-out` on a panel slide; a spring on
+  a drag release so it carries the velocity. One fixed curve.
+- **"It kept animating while the app was busy."** Any transition on macOS
+  stalls with the JS thread. docs/macos.md calls this the qualitative gap
+  Tier L exists for; it is not reachable until the presenter takes the
+  animation.
+
+Out of scope here, so nobody expects them: **exit animations** (keeping a
+node mounted after React removed it is a reconciler feature — a deferred
+`removeChild` — and deserves its own design; `onAnimationEnd` below is the
+seam it will need), and **window-level opacity** (a `<popup>` fade is
+`_NET_WM_WINDOW_OPACITY` on X11 and `NSWindow.alphaValue` on Cocoa, a
+different mechanism from a node's).
+
+## 3. The vocabulary
+
+### 3.1 Easing, shared
+
+```ts
+type Easing =
+  | 'linear'
+  | 'ease'
+  | 'ease-in'
+  | 'ease-out'
+  | 'ease-in-out'
+  | [x1: number, y1: number, x2: number, y2: number] // cubic-bezier
+  | {
+      spring: {
+        stiffness?: number;
+        damping?: number;
+        mass?: number;
+        velocity?: number;
+      };
+    };
+```
+
+**The canonical form is the four control points.** Names are aliases
+resolved once, in `styles.js`, to the beziers they already are:
+
+| name          | control points         | today                                   |
+| ------------- | ---------------------- | --------------------------------------- |
+| `linear`      | `[0, 0, 1, 1]`         | `t`                                     |
+| `ease-out`    | `[0.33, 1, 0.68, 1]`   | `1 - (1 - t)^3`, the transition default |
+| `ease-in`     | `[0.32, 0, 0.67, 0]`   | `t^3`                                   |
+| `ease-in-out` | `[0.65, 0, 0.35, 1]`   | the piecewise cubic                     |
+| `ease`        | `[0.25, 0.1, 0.25, 1]` | — (CSS's default, new)                  |
+
+Why this and not the polynomials: **the two evaluators have to agree.** A
+declaration that runs on the JS loop on X11 and in the render server on
+layers must look the same, and CA's only timing primitive is a cubic
+bezier. Sampled at a thousand points (scratch script, not committed), the
+existing curves against their bezier twins differ by at most 0.003
+(ease-out, ease-in) and 0.0095 (ease-in-out) — invisible. The existing
+ease-out against CA's **named** `easeOut` (`[0, 0, 0.58, 1]`) differs by
+**0.216** at t = 0.35 — a visibly different animation. So the bridge's four
+named curves are not a mapping target; control points are, and the JS side
+gets a bezier solver (Newton with a bisection fallback, the shape every
+browser ships, ~40 lines, pure, pinned by a table test against CSS's
+published samples).
+
+**Springs** are the second kind, not a curve: no duration, a settling time
+derived from the physics, and the reason they exist is interruption — a
+retarget carries the current velocity, which is what makes a dragged thing
+let go feel like it was let go. CA's names (`mass`, `stiffness`,
+`damping`, `initialVelocity`) are physical units and are also popmotion's
+and Framer's; use them. A spring is only ever between two values, so it is
+an easing for `transition` and for a two-stop `animation`; a keyframe
+timeline takes beziers per segment. The JS evaluator is the closed-form
+damped oscillator, settling at a displacement threshold; CA's is
+`CASpringAnimation` and reports `settlingDuration`, which is what the
+completion timer uses. Springs are the last thing to land (§7); the
+vocabulary is fixed now so nothing built before them has to move.
+
+### 3.2 `transition`
+
+```js
+transition: 120                                          // as today: everything, ease-out
+transition: { backgroundColor: 120, borderColor: 120 }   // as today
+transition: {
+  all: 120,                                              // the shorthand's slot
+  start: { duration: 160, easing: 'ease-in-out', delay: 40 },
+  scaleX: { easing: { spring: { stiffness: 400, damping: 30 } } },
+}
+```
+
+A property's value is `ms | { duration?, easing?, delay? }`; `all` is the
+default for every animatable property not named, and is not a style
+property, so the object stays one grammar. `duration` may be omitted only
+with a spring. The default easing stays `ease-out` — a change that ends
+looks right slowing into its value — and the default delay is 0.
+
+`transitionFor` returns `{ duration, easing, delay }` instead of a number.
+(The `.d.ts` already declares that shape — `{ duration; delay? } | null`,
+src/style.d.ts:93 — and the JavaScript returns a number: one of #120's
+drifts, closed by this change rather than by editing the declaration.)
+
+`delay` is a start time, nothing more: the transition still reads its
+`from` from what is on screen _when it starts_, so a retarget during the
+delay is a retarget of a transition that has not moved.
+
+### 3.3 `animation`: a timeline, which may end
+
+```js
+animation: {
+  // today's loop, unchanged
+  backgroundColor: { to: '$accent', duration: 900, alternate: true },
+  // an entrance: from somewhere, to the declared value, once
+  opacity:    { from: 0, duration: 200, repeat: 1 },
+  translateY: { from: 8, duration: 200, repeat: 1, easing: 'ease-out' },
+  // a shake, and again on the next attempt
+  translateX: { keyframes: [0, -6, 6, -6, 6, 0], duration: 300, repeat: 1, key: attempt },
+  // a spinner
+  rotate: { from: 0, to: 360, duration: 800 },
+  // a staggered pulse
+  scaleX: { to: 1.1, duration: 600, alternate: true, delay: index * 80 },
+}
+```
+
+Per property, as now — CA needs one animation per key path too, and CSS's
+one-`@keyframes`-many-properties shape would only be a way to write the
+same duration several times. Options:
+
+| key          |                                                                                                                                             |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `from`, `to` | the two-stop form. **Exactly one may be omitted** and defaults to the declared value                                                        |
+| `keyframes`  | the many-stop form, instead of `from`/`to`: values evenly spaced, or `{ at: 0..1, value, easing? }` for placed stops and per-segment curves |
+| `duration`   | one pass, ms                                                                                                                                |
+| `easing`     | over the pass; `linear` default, as now                                                                                                     |
+| `delay`      | before the first pass only                                                                                                                  |
+| `repeat`     | passes; **`Infinity` by default**, so a declaration written today means what it meant                                                       |
+| `alternate`  | as now                                                                                                                                      |
+| `key`        | identity: a changed `key` restarts the timeline from the top, which is how a finite one is played again                                     |
+
+**Where it rests is the declared value — and that is the whole fill-mode
+story.** Loops already have this rule: the property is at its declared
+value before the first frame, off screen, under reduced motion. A finite
+timeline ends and the property is at its declared value. So an entrance is
+"declare the end state, arrive from somewhere else"; a shake ends where it
+began because the author wrote `0` at both ends. There is no `fill:
+'forwards'`, deliberately: a held last frame means the style lies about the
+property from then on, and the author who wants that value can write it.
+A finite timeline whose last stop is not the declared value snaps at the
+end, visibly — which is the declaration being honest, not a bug.
+
+**Start and restart.** A timeline starts on the style swap that introduces
+it — a mount, or a later change — the same moment loops start today. An
+equal declaration keeps its phase (`sameAnimation`, extended to
+`keyframes`, `repeat`, `delay`, `key`); a changed one restarts. A finished
+finite timeline stays finished across re-renders of the same declaration;
+`key` is the one field whose only job is to differ. (`key` reads well in a
+React codebase; `run` was the alternative.)
+
+**Completion.** `onTransitionEnd({ property })` and `onAnimationEnd({
+property })` as element props, per property, fired when the JS clock says
+so — on every presenter, including one that offloaded the pixels, so a
+component can chain or unmount without knowing where the animation ran.
+Loops never fire it. An interrupted transition does not fire it either
+(CSS agrees: `transitioncancel` is a different event, and nothing here
+needs it yet).
+
+**Reduced motion.** The existing split holds and is the simple rule:
+**`animation` is motion for its own sake and never starts under reduced
+motion, finite or not; `transition` is the answer to an input and always
+runs.** A shake and an entrance are the kind of thing the switch exists
+for, and the still frame is the declared value — the same design decision
+`<ProgressBar indeterminate>` already makes for its loop.
+
+### 3.4 `opacity` and the individual transforms
+
+Six paint-only style properties, on both backends:
+
+| property                   | value      | notes                                                      |
+| -------------------------- | ---------- | ---------------------------------------------------------- |
+| `opacity`                  | 0..1       | **group** opacity of the subtree, CSS semantics            |
+| `translateX`, `translateY` | logical px |                                                            |
+| `rotate`                   | degrees    | the bridge takes radians; the presenter converts           |
+| `scaleX`, `scaleY`         | factor     | no `scale` — `<box scale>` is already the zoom (see below) |
+
+Composed translate → rotate → scale about the box centre — CSS's order for
+its individual transform properties and exactly what the bridge's
+`transform` object does. A `transformOrigin` is the obvious later seam;
+centre is CA's default anchor and the case every hover lift and spinner
+wants.
+
+Paint-only means: **state blocks may set them.** A `:hover` that scales a
+card by 2% is a repaint of one node, no layout — the property that was
+missing from the "hover is a repaint, not a render" story. It also means
+layout is untouched: the box yoga computed is where the node _is_; the
+transform is where it is _drawn_, and where the pointer finds it. Hit
+testing maps the point through the inverse (the walk in `events.js` tests
+node rects; a transformed node tests the inverse-mapped point against its
+own rect and passes the mapped point to its children). `paintBounds()` is
+the transformed box's bounding rect, which is what damage, culling and
+`_subtreeBounds()` already consume. `opacity: 0` still hits, as in CSS;
+`pointerEvents: 'none'` is the property for not hitting.
+
+**Not the zoom.** `<box scale={2}>` multiplies every length in the subtree
+and reshapes text at the size it will be drawn at (src/nodes.js:1778,
+docs/scale.md); it is layout, and it is expensive to change. `scaleX` is
+paint: the rasterized subtree stretched. They are two different tools and
+the transform is the one that animates cheaply; the docs say so in one
+place so the names stop looking like a mistake.
+
+Both animate (they are numbers), both may transition, both go in
+timelines. That is the whole point of choosing individual properties over
+a `transform: 'rotate(45deg) …'` string: the per-property machinery
+interpolates them with no matrix decomposition, and each is one CA key
+path (`opacity`, `transform.translation.x`, `transform.rotation.z`,
+`transform.scale.x`).
+
+### 3.5 Deliberately not proposed
+
+- **CSS strings** (`'200ms ease-in-out'`, `'rotate(45deg)'`). The style
+  language here is numbers and objects; a second grammar inside strings is
+  a parser and a source of errors that arrive as a thing that does not move.
+- **`fill-mode`.** §3.3.
+- **A per-frame callback in the style.** `animation` describes the motion
+  and the renderer runs it — the offload in §4 depends on that being true.
+  The imperative seam for a 2D per-frame draw is still open
+  (docs/styling.md, last paragraph of "Loops"); a `<canvas>` with a value
+  from popmotion is the answer meanwhile, and this proposal makes that
+  cheaper rather than replacing it.
+- **Exit animations.** §2.
+
+## 4. Who interpolates
+
+### 4.1 The rule
+
+**The node model is the source of truth for what is animating and when it
+ends. A presenter may take the pixels.** Concretely, `_retarget` and
+`_updateLoops` keep doing everything they do — the `_anim` entry, the
+start time, `sameAnimation`, the loop-stop rules — and then ask:
+
+```js
+presenter.animate?.(node, prop, entry); // → true: the presenter interpolates
+```
+
+A presenter that answers `true` owns the frames for that entry: the node
+is **not** added to `root._animating` for it, no damage is claimed per
+frame, and the window's frame clock stays idle. The model value goes out
+as it does now — the resolved target, in the disabled-actions transaction
+— and the presenter has attached the motion to the layer. Completion is a
+timer at `delay + duration` (or the spring's settling time), which fires
+`onTransitionEnd`/`onAnimationEnd` and, for a finite timeline, lets the
+property rest. A presenter that answers `false`, has no `animate`, or is the
+X11 painter, gets the JS loop exactly as today. **Every entry has the JS
+loop as its fallback**, so correctness never depends on coverage — the
+same rule the layer presenter already applies to painting (raster per node
+when the property vocabulary runs out).
+
+Retarget and stop go through the same seam: `presenter.cancel(node, prop)`
+before a new `animate`, and from every loop-stop path.
+
+### 4.2 What the layer presenter takes
+
+A property qualifies when it maps to a property **of the node's own layer**
+and changing it does not re-raster that layer:
+
+| style property                                | key path                         | PropBox | Raster         |
+| --------------------------------------------- | -------------------------------- | ------- | -------------- |
+| `backgroundColor`, `borderColor`              | `backgroundColor`, `borderColor` | yes     | no — re-raster |
+| `borderWidth`, `borderRadius`                 | `borderWidth`, `cornerRadius`    | yes     | no             |
+| `opacity`                                     | `opacity`                        | yes     | **yes**        |
+| `translateX/Y`, `rotate`, `scaleX/Y`          | `transform.*`                    | yes     | **yes**        |
+| `boxShadow` components (once it interpolates) | `shadowOpacity/Radius/Offset`    | later   | —              |
+| `color` on `<text>`                           | —                                | —       | no             |
+| any layout property                           | —                                | no      | no             |
+
+The last row is the important one. **Layout properties stay on the JS loop
+on every presenter**, because yoga has to run for the frame to be right —
+a `width` that grows moves its siblings. The one tempting exception, an
+absolutely positioned node's `left`/`top`/`start` as the layer's
+`position`, is deferred: once `translateX` exists, the Switch thumb and
+its kind have a paint property to slide on, which is cheaper on X11 too
+and needs no exception. The `Raster` rows are what make transforms and
+opacity worth more than they look: a paragraph, an image or a registered
+element fades and moves in the render server with its bitmap untouched.
+
+**Mechanics** (per property, inside the frame's transaction):
+
+1. Model value out as today: `visual.set({ backgroundColor: to })` under
+   `disableActions`.
+2. `addAnimation(layer, keyPath, { from, to, duration: ms / 1000, timing:
+[x1, y1, x2, y2], delay }, key)`. CA renders `from` → `to` over the
+   model value and removes itself on completion, leaving the model showing
+   — the standard explicit-animation pattern, no `hold`.
+3. Timer for completion.
+
+**Loops** are `repeat: Infinity` with `autoreverse` for `alternate`, and
+cost **zero JS frames** — the spinner, the pulse and the indeterminate bar
+become a render-server timer. The loop-stop rules still run (they are the
+one truth about whether a loop may run), and each one is a
+`removeAnimation`; a resume is a fresh `addAnimation`, phase reset, as the
+JS loop does now. CA stops compositing an occluded window on its own, so
+the rule costs nothing there and keeps the two backends identical in what
+they promise.
+
+**Interruption** — the "reverse from where it got to" property, which
+test/style.test.js pins for the JS loop and which has to hold here:
+
+- Numeric key paths (`opacity`, `transform.*`, `borderWidth`,
+  `cornerRadius`): **additive** animations, CA's own idiom. The model goes
+  straight to the new target; the animation is `from: old − new, to: 0,
+additive: true`. Several in flight sum, so a retarget mid-flight is
+  continuous and carries its shape — with no readback of anything. This
+  needs the bridge's `additive` flag (§4.4).
+- Colours (CA cannot add colours): the JS side computes where the running
+  animation is from its own clock and the same bezier — within a frame of
+  CA's truth, since both evaluate the same curve — and starts the next one
+  there. `presentationValue(layer, keyPath)` (§4.4) makes it exact later;
+  it is not on the critical path.
+
+**What the presenter needs from the node** is what `_syncPropBox` already
+reads plus the animated entry; the table above is a static map from style
+property to key path plus a check of `visual.isRaster`. It is a small
+addition to src/cocoa/presenter.js, and the cocoa-mock presenter in the
+tests records `addAnimation` calls the same way it records `setLayerProps`.
+
+### 4.3 The surface presenter, and X11
+
+Nothing to offload: one bitmap per window, painted by the X11 walk. The JS
+loop runs. This design is one more row in the measure-first gate's
+argument for making layers the default; it does not move the gate itself.
+
+### 4.4 Bridge additions (`@windowkit/appkit`)
+
+In the order the offload needs them:
+
+1. **`timing: [x1, y1, x2, y2]`** on `addAnimation` and `txBegin` —
+   `CAMediaTimingFunction functionWithControlPoints:`. **Prerequisite**:
+   §3.1's numbers say the named curves would change every existing
+   transition's look.
+2. **`additive: true`** — one line on the `CABasicAnimation`. What makes
+   retargeting continuous without readback.
+3. **`delay`** — `beginTime = CACurrentMediaTime() + delay`, with
+   `fillMode: backwards` so the layer shows `from` during the delay.
+4. **Keyframes** — `values`, `keyTimes`, `timingFunctions` (one bezier per
+   segment), `calculationMode: linear` (a `CAKeyframeAnimation`).
+5. **Springs** — `CASpringAnimation` with `mass`/`stiffness`/`damping`/
+   `initialVelocity`, returning `settlingDuration` so JS can time completion.
+6. **`presentationValue(layer, keyPath)`** — `presentationLayer` readback;
+   exactness for colour retargets.
+7. **Completion callback** — the animation delegate's `animationDidStop:
+finished:` forwarded through the event callback; makes
+   `onTransitionEnd` exact rather than timer-derived. Optional.
+8. **Reduce motion** — `NSWorkspace.accessibilityDisplayShouldReduceMotion`
+   plus its notification, into `desktopSettings().animations` on the Cocoa
+   app. Independent of this design and already wrong without it.
+
+Each is a verb, not policy, which is the shape the bridge's contract asks
+for (docs/macos.md, "The channel is already node-granular").
+
+Filed as [windowkit/appkit#29](https://github.com/windowkit/appkit/issues/29);
+[windowkit/appkit#30](https://github.com/windowkit/appkit/pull/30) implements
+items 1–7 plus `speed`/`timeOffset` (merged); item 8 is
+[windowkit/appkit#31](https://github.com/windowkit/appkit/issues/31), implemented
+by [windowkit/appkit#32](https://github.com/windowkit/appkit/pull/32). Two
+things the bridge work found that the presenter has to know: CA interpolates
+colours in the display's space, so a colour read back mid-flight is not the
+component midpoint; and a paused animation sampled at exactly its duration
+reads as its start, so an end is sampled a millisecond early.
+
+## 5. What `opacity` and transforms cost on X11
+
+Both are **group** operations on a subtree, and a group needs an offscreen:
+per-op alpha on overlapping children double-blends where they overlap, and
+per-op transforms would rotate each child about its own centre. So:
+
+1. Paint the subtree into an ntk `Surface` the size of `paintBounds()` in
+   device pixels — the same surface family the paint cache and #433's
+   `CocoaSurface` use, behind `app.createSurface` on the Cocoa surface
+   backend and ntk's pixmap on X11.
+2. Composite it back with `ctx.globalAlpha = opacity` and the transform set
+   on the context. ntk's `drawImage` already routes a transformed draw
+   through `SetPictureTransform` with a filter and scales the composite by
+   `globalAlpha` (node_modules/ntk/lib/renderingcontext_2d.js:2046,
+   :4599) — server-side, no readback. Rotation's filter quality and the
+   transformed bounding box are the two things to verify with a pixel test
+   rather than assume.
+
+Per animated frame that is one pixmap the size of the subtree plus one
+composite — bounded to the thing that moves, the way every claim here is.
+Two fast paths cover most of what apps write and skip the offscreen
+entirely:
+
+- **A pure translate**: `ctx.translate` and paint the subtree through it.
+  Every child paints through the same context, clips included. That is
+  the shake, the slide, the entrance, the Switch thumb.
+- **Opacity on a leaf** (a `<box>` with no children, or a `<text>`):
+  multiply the alpha into the fill, border and ink. One node, no group.
+
+`opacity: 1` and identity transforms cost nothing, which keeps the
+properties safe to leave in a style. The offscreen surface is per node,
+kept between frames of one animation and dropped when it ends, and it is
+the paint cache's budget that bounds it (src/paintcache.js's byte budget
+is the pattern; the surface here is not content-keyed, it is a frame
+scratch).
+
+Damage: `damageForAnimation` already claims _before_ the tick; a transform
+animation claims the union of the old and new bounding rects, which is
+what an absolutely positioned layout transition already does through its
+parent.
+
+## 6. Where the code goes
+
+- **src/styles.js** — `resolveEasing` (names → control points → a bezier
+  function; the spring solver), `transitionFor` → `{ duration, easing,
+delay }`, `parseAnimation` (`keyframes`, `repeat`, `delay`, `key`; the
+  validation messages name the option and the property as now),
+  `animationValueAt` over a keyframe list (segment lookup, per-segment
+  easing, `repeat` as a cap on the cycle count), `sameAnimation` over the
+  new fields, and the six new properties in `PAINT_PROPS` — which puts
+  them in state blocks and out of `NOT_ANIMATABLE` for free.
+- **src/nodes.js** — `_retarget` (easing and delay on the entry; the
+  presenter seam), `_tickAnimations` (finite end → rest at the target,
+  completion events), `_updateLoops` (cancel through the presenter),
+  `paint` (the group path and its two fast paths around
+  `_paintBackground`/`paintContent`/`_paintChildren`), `paintBounds()`
+  and `_subtreeBounds()` (transformed boxes), `damageForAnimation`.
+- **src/events.js** — the inverse-mapped hit test.
+- **src/cocoa/presenter.js** — `animate`/`cancel`, the key-path table,
+  `opacity` and `transform` on both visual kinds; the mock presenter
+  records them.
+- **src/types/style.d.ts, src/style.d.ts, test/types/api.tsx** — `Easing`,
+  `Transition`, `AnimationSpec`, the six properties, the two events.
+- **docs/styling.md** ("Transitions", "Loops" → "Timelines"),
+  **docs/macos.md** (the "Animations and transforms" section becomes a
+  pointer here plus the measured result), **docs/ecosystem/animation.md**
+  (delete the "no opacity" constraint; the page shrinks), **docs/system.md**
+  (reduced motion covers finite timelines), **docs/elements.md** (`scale`
+  vs `scaleX`, the events).
+- **Widgets and examples** — Switch on `translateX`; Tooltip fades;
+  ProgressBar unchanged; a shake in the configurator's password field;
+  the website demos that use `transition` still pass `check-demos`.
+- **Tests** — bezier table vs CSS samples and vs the polynomials
+  (test/style.test.js); finite timelines, keyframes, `key` restart, rest at
+  the declared value, `delay` (test/animation-loop.test.js); the mock
+  presenter: a `backgroundColor` transition on a PropBox schedules zero
+  frames and one `addAnimation` with control points, `color` on a `<text>`
+  falls back to the loop, a loop stop removes the animation; pixels: group
+  opacity over overlapping children against a reference composite, a
+  rotate against a pre-rotated reference, the translate fast path
+  byte-identical to the offscreen path (the differential oracle
+  test/dirty-rect.test.js already has, applied here); the hit test through
+  a transform. And a **structural** row in `scripts/bench/presenters-gate.json`:
+  JS frames scheduled per 120ms hover transition on layers — 0 with the
+  offload, ~8 without — the same kind of number the gate already judges.
+
+## 7. Sequencing
+
+Each step ships on both backends and is useful alone; the offload is
+additive on top and can proceed in parallel from step 1.
+
+1. **Easing vocabulary and the `transition` object form** (`all`, per-property
+   `{ duration, easing, delay }`). Small; the bezier solver and its table
+   test are most of it.
+2. **Timelines**: `keyframes`, `repeat`, `delay`, `key`, the completion
+   events, reduced motion over finite timelines.
+3. **`opacity`**: the group path with the leaf fast path on X11 and the
+   surface presenter; `opacity` on both visuals on layers.
+4. **Transforms**: translate first (fast path only, no offscreen — most of
+   the value for a fraction of the work), then rotate and scale over the
+   offscreen with the inverse hit test. Switch moves to `translateX`.
+5. **Layer offload**: bridge items 1–3 (`windowkit/appkit` PRs), then the
+   presenter seam and its mock tests, the gate row, and a measured
+   before/after on a real display the way docs/macos.md "Measured" records
+   them. Items 4–7 follow as the timeline and spring features reach the
+   presenter.
+6. **Springs**: the JS solver, bridge item 5, `easing: { spring }` on
+   transitions.
+
+## 8. Open questions
+
+- **`key` vs `run`** for the restart token (§3.3). Cheap to decide, hard to
+  rename later.
+- **Should a finite timeline snap or ease into the declared value** when its
+  last stop differs? This document says snap, because it is honest and CSS
+  does the same; the alternative — an implicit last stop at the declared
+  value — hides a mismatch behind a nicer default.
+- **Additive colours.** CA cannot; the clock-estimated `from` is within a
+  frame, and the readback verb closes it. Decide whether a frame's error
+  on a 120ms colour retarget is ever visible before building the verb.
+- **Transforms and text selection, carets, scroll**: a transformed
+  `<textinput>` maps its pointer through the inverse like everything else,
+  but its caret and selection geometry are computed in layout space. The
+  first cut may reject transforms on nodes that own an editing surface, or
+  accept a documented gap; a real display will say which.
+- **Whether `opacity` on X11 should take the offscreen at all** for a
+  subtree above a size, or fall back to per-node alpha with the
+  double-blend documented. The paint cache's item cap (`MAX_ITEM_PIXELS`)
+  is the precedent for "past this size, do the simple thing".

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -912,14 +912,35 @@ more path building follows a stroke that consumed it. `test/cocoa-stroke-chunkin
 The existing declarative vocabulary is the seam: `transition:` and
 `animation:` in styles. On X11 they run on the frame clock (JS
 interpolation, repaint per frame — including the premultiplied-lerp
-rule). The Cocoa presenter maps the same declarations to
-`CATransaction`/`CABasicAnimation` on the affected layer properties, and
-the render server interpolates. Semantics to pin when this lands
-(Phase 5): timing-function parity, transition-interrupt behavior
-(CA's additive animations vs. the JS loop's retargeting), and the
-completion moment `onStatesChange`-style code can observe. Until then,
-the JS frame loop works on Cocoa too — correctness first, offload as the
-measured upgrade.
+rule), and so do they on the surface presenter. **The layer presenter
+hands them to the render server** where the node's own layer expresses
+the property — a plain `<box>`'s `backgroundColor`, `borderColor`,
+`borderWidth` and `borderRadius` — and schedules no frames for them: the
+style goes to its target, which is the layer's model value, and the frame
+that sends it attaches an explicit animation carrying the pixels there
+(`CocoaLayerPresenter.animate`, `@windowkit/appkit` >= 0.5). A loop is one
+repeating animation and costs no JS frames at all. Everything else — a
+colour on text, a layout property, any node that paints as a raster — stays
+on the frame clock, byte-identical to before; the presenter can only decline,
+never break.
+
+The three semantics [the design](architecture/animation.md) said to pin:
+
+- **Timing parity** is control points, not names. `transition`'s ease-out
+  is cubic-bezier(0.33, 1, 0.68, 1) to within 0.003 and the loop easings
+  map the same way (`EASING_CONTROL_POINTS`, styles.js), where CA's named
+  `easeOut` is a different curve — test/style.test.js pins both facts.
+- **Interruption**: a length retargets _additively_ — the model goes to the
+  new target and a delta animation `(old − new) → 0` joins the one still
+  running — so a change of mind mid-flight is continuous with nothing read
+  back; a colour cannot be additive and restarts from the presentation
+  value the bridge reports.
+- **Completion** is the bridge's `animation-end` event, so the node model
+  drops the entry when the render server says so, not when a timer guesses.
+
+Not offloaded yet, in the order they would pay: `opacity` and transforms
+(they do not exist as style properties — the design's §3.4), an absolutely
+positioned node's offsets as `position`, and `boxShadow`'s components.
 
 Two style capabilities currently rejected everywhere become cheap on
 layers and are proposed as **capability-gated additions** rather than

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -995,6 +995,11 @@ window. The alternative an app would otherwise write, `setInterval` →
 damage heuristics decide, at a cadence unrelated to when the window can
 present.
 
+On the macOS layer presenter a loop — or a transition — on a plain box's
+colour, border width or radius is handed to Core Animation instead and
+costs no frames at all; anything else runs as above
+([macos.md](macos.md#animations-and-transforms-the-api-the-model-unlocks)).
+
 **And it stops itself**, which is the whole reason this is core's job. A
 forever-loop keeping a frame clock alive is invisible when it is wrong, so
 every way of going off the screen is wired to it:

--- a/docs/system.md
+++ b/docs/system.md
@@ -308,8 +308,13 @@ miss: a moving thing on screen is what some people cannot read past, which is
 why the desktop offers the switch at all. **Draw the caret solid rather than not
 at all** — that is what the built-in controls do.
 
-[XSETTINGS](appearance.md#what-each-rung-can-actually-answer) is the only source; there is no portal
-interface for any of this. On a desktop with no settings daemon — a bare
+[XSETTINGS](appearance.md#what-each-rung-can-actually-answer) is the only source on X11; there is no
+portal interface for any of this. On the macOS backend the one of these the
+system publishes is read from it: **Reduce motion** (System Settings ›
+Accessibility › Display) arrives as `animations: false` with
+`source: 'macos'`, live — flipping the switch stops a spinner that is already
+going round — and the other fields keep the defaults there, since macOS has
+no equivalent to hand over. On a desktop with no settings daemon — a bare
 `startx`, most window managers, XQuartz — `source` is null and the numbers above
 are this renderer's own defaults. They are deliberately not GTK's, which blinks
 on a 1200ms cycle and drags at 8px: the point is to follow a desktop that

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "node": ">=20.19"
       },
       "optionalDependencies": {
-        "@windowkit/appkit": "^0.4.0",
+        "@windowkit/appkit": "^0.5.0",
         "dbus-native": "^0.15.1",
         "x11-dri": "^0.7.0"
       },
@@ -1514,9 +1514,9 @@
       }
     },
     "node_modules/@windowkit/appkit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@windowkit/appkit/-/appkit-0.4.0.tgz",
-      "integrity": "sha512-SAOOsXZ0MydSVRUlLfmM5FcXL0crzE8P4Jj5Qq9SGh2AXoAW1GipHYjI9tR3ozdHXM+pFVmSb6dbas+tLeQ6uQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@windowkit/appkit/-/appkit-0.5.0.tgz",
+      "integrity": "sha512-K9/LTMdd794EIVNeegjl91YpIU0DLF1xAyrx6kHCRxIeWHJT77JpVGSEjlHy2+0IB040g3AZjAerJZUgZhROeQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "yoga-layout": "^3.2.1"
   },
   "optionalDependencies": {
-    "@windowkit/appkit": "^0.4.0",
+    "@windowkit/appkit": "^0.5.0",
     "dbus-native": "^0.15.1",
     "x11-dri": "^0.7.0"
   },

--- a/src/cocoa/app.js
+++ b/src/cocoa/app.js
@@ -55,6 +55,12 @@ export class CocoaApp {
     // window paces itself on its own display (`frameIntervalFor`)
     this._frameInterval = options.cocoa?.frameInterval ?? null;
     this._pumpInterval = PUMP_INTERVAL_MS;
+    // src/desktopsettings.js's subscribers to the accessibility display
+    // options — "reduce motion" — which arrive as a backend event
+    this._a11yListeners = new Set();
+    // the layer presenter's animations, by the id the bridge reports their
+    // end under (`animation-end`, src/cocoa/presenter.js)
+    this._animationEnds = new Map();
     // the one-shot that runs a frame due between two pump ticks, and when
     // it is due (`_armFrameTimer`)
     this._frameTimer = null;
@@ -552,6 +558,13 @@ export class CocoaApp {
       case 'menu-activate':
         this._activeGlobalMenu?.activate(ev.id);
         return this._afterInput();
+      case 'accessibility-display-changed':
+        return this._routeAccessibility(ev);
+      case 'animation-end':
+        // the presenter that added the animation registered for its id; an
+        // id nobody knows is an animation already forgotten (cancelled, or
+        // its layer dropped), and the bridge's report is just late
+        return this._animationEnds.get(ev.id)?.(ev);
       default:
         return undefined;
     }
@@ -714,6 +727,27 @@ export class CocoaApp {
     const wnd = this._window(ev);
     if (!wnd || wnd.destroyed) return;
     wnd._occluded = ev.visible === false;
+  }
+
+  _routeAccessibility(ev) {
+    for (const fn of [...this._a11yListeners]) fn(ev);
+  }
+
+  /**
+   * System Settings › Accessibility › Display, as the bridge reports it —
+   * `{ reduceMotion, reduceTransparency, increaseContrast,
+   * differentiateWithoutColor, invertColors }` — or null over a bridge (or
+   * a test fake) that does not answer. The seam src/desktopsettings.js reads
+   * "reduce motion" through; `watchAccessibilityDisplay` is its other half.
+   */
+  accessibilityDisplayOptions() {
+    return this._native.accessibilityDisplayOptions?.() ?? null;
+  }
+
+  /** Subscribe to the options changing while the app runs. */
+  watchAccessibilityDisplay(fn) {
+    this._a11yListeners.add(fn);
+    return () => this._a11yListeners.delete(fn);
   }
 
   _routeClose(ev) {

--- a/src/cocoa/presenter.js
+++ b/src/cocoa/presenter.js
@@ -32,6 +32,7 @@ import {
   damageToPaint,
   intersectRects,
 } from '../nodes.js';
+import { EASING_CONTROL_POINTS, TRANSITION_CONTROL_POINTS } from '../styles.js';
 import { CocoaContext2D } from './context2d.js';
 
 const RASTER_PAD = 2; // antialiasing/italic overhang outside the ink bounds
@@ -324,9 +325,8 @@ const EDGE_PROPS = [
   'borderEndWidth',
 ];
 
-function stylePaintsPlain(node) {
+function stylePaintsPlain(node, style = node.style ?? {}) {
   if (node.kind !== 'box') return false;
-  const style = node.style ?? {};
   if (style.backgroundImage || style.boxShadow || style.outlineWidth) {
     return false;
   }
@@ -338,6 +338,26 @@ function stylePaintsPlain(node) {
     return false;
   return uniformRadius(style.borderRadius) !== null;
 }
+
+/**
+ * Style property → the key path on a PropBox's own layer, for the
+ * animations the presenter takes off the frame clock and hands to the
+ * render server (docs/architecture/animation.md §4.2). Only what the layer
+ * expresses as a property of itself qualifies: a colour on `<text>` is a
+ * re-raster per frame, a layout property moves the siblings, and both stay
+ * on the JS loop. `scaled` values go out in points, as `_syncPropBox`
+ * sends them.
+ */
+const ANIMATED_KEY_PATHS = Object.freeze({
+  backgroundColor: { keyPath: 'backgroundColor', colour: true },
+  borderColor: { keyPath: 'borderColor', colour: true },
+  borderWidth: { keyPath: 'borderWidth', scaled: true },
+  borderRadius: { keyPath: 'cornerRadius', scaled: true },
+});
+
+// the ids the bridge reports an animation's end under: unique per process,
+// looked up per app (`_animationEnds`)
+let animationSeq = 0;
 
 function uniformRadius(radius) {
   if (radius === undefined) return 0;
@@ -439,6 +459,10 @@ export class CocoaLayerPresenter {
     this.visuals = new Map(); // node -> Visual
     this.rasters = new Map(); // node -> RasterState
     this.bars = new Map(); // scroller node -> Map(axis -> { layer, raster })
+    // animations taken off the frame clock: accepted and waiting for the
+    // frame that attaches them, and running in the render server
+    this.pendingAnimations = new Map(); // node -> Map(prop -> entry)
+    this.liveAnimations = new Map(); // node -> Map(id -> { prop, key, entry })
     // Claims since the last frame — taken at the top of `frame()`, the way
     // the X11 path takes its damage before painting, so a claim made from
     // inside a paint lands in the next frame instead of being cleared with
@@ -548,6 +572,7 @@ export class CocoaLayerPresenter {
           visual.destroy();
           this.visuals.delete(node);
           this._dropRaster(node);
+          this._dropAnimations(node, false);
           const bars = this.bars.get(node);
           if (bars) {
             for (const entry of bars.values()) {
@@ -612,7 +637,13 @@ export class CocoaLayerPresenter {
     if (visual && visual.isRaster !== wantsRaster) {
       visual.destroy();
       this._dropRaster(node);
+      // a layer that turns into a raster takes its animations with it; the
+      // frame clock can still run them over the bitmap
+      if (wantsRaster) this._dropAnimations(node, true);
       visual = null;
+    }
+    if (wantsRaster && this.pendingAnimations.has(node)) {
+      this._dropAnimations(node, true);
     }
     if (!visual) {
       visual = new Visual(this, node);
@@ -728,6 +759,163 @@ export class CocoaLayerPresenter {
           ])
         : [0, 0, 0, 0],
     });
+    // after the model value went out, inside the same transaction
+    this._applyAnimations(node, visual);
+  }
+
+  // --- animations the render server runs -----------------------------------
+  //
+  // The node model keeps deciding what is animating and when it ends
+  // (nodes.js `_retarget` / `_updateLoops`); what moves here is who
+  // interpolates. Taken means the node's style goes to its target — the
+  // layer's model value, sent by the next frame's property diff — and that
+  // frame attaches an explicit animation carrying the pixels there; no frame
+  // after it is scheduled for the property, and a loop costs no JS frames at
+  // all. Declined means the frame clock runs it exactly as before, so
+  // nothing here is load-bearing for correctness.
+
+  /**
+   * Take `prop`'s animation for `node`, or decline. Decided against the
+   * *target* style: a `:hover` that adds a shadow turns the node into a
+   * raster in the same swap that starts a fade, and a raster's background
+   * is in its bitmap, not on its layer.
+   */
+  animate(node, prop, entry) {
+    const map = ANIMATED_KEY_PATHS[prop];
+    if (!map || !stylePaintsPlain(node, node._targetStyle ?? node.style)) {
+      return false;
+    }
+    if (this._value(map, entry.from) == null) return false;
+    if (this._value(map, entry.to) == null) return false;
+    let pending = this.pendingAnimations.get(node);
+    if (!pending) this.pendingAnimations.set(node, (pending = new Map()));
+    pending.set(prop, entry);
+    return true;
+  }
+
+  /** Stop what runs for `prop` on `node`: a loop the window lost sight of,
+   *  a declaration that changed, a transition the clock takes back. */
+  cancel(node, prop) {
+    this.pendingAnimations.get(node)?.delete(prop);
+    this._removeLive(node, prop);
+  }
+
+  _ends() {
+    const app = this.window.app;
+    return (app._animationEnds ??= new Map());
+  }
+
+  /** A style value as the layer takes it — a colour as components, a
+   *  length in points — or null for one the layer cannot animate. */
+  _value(map, value) {
+    if (map.colour) {
+      return typeof value === 'string'
+        ? (this.window.app._parseColor(value) ?? null)
+        : null;
+    }
+    return typeof value === 'number'
+      ? value / (map.scaled ? this.scale : 1)
+      : null;
+  }
+
+  /** The frame's half: attach what `animate` accepted, after the model
+   *  value went out, inside the same transaction. */
+  _applyAnimations(node, visual) {
+    const pending = this.pendingAnimations.get(node);
+    if (!pending) return;
+    this.pendingAnimations.delete(node);
+    for (const [prop, entry] of pending) {
+      const map = ANIMATED_KEY_PATHS[prop];
+      const id = `rx${++animationSeq}`;
+      const key = `${prop}:${id}`;
+      const opts = { duration: entry.duration / 1000, id };
+      if (entry.loop) {
+        // a loop replaces whatever ran for the property: its declaration
+        // changed, and a loop restarts from the top when it does
+        this._removeLive(node, prop);
+        opts.from = this._value(map, entry.from);
+        opts.to = this._value(map, entry.to);
+        opts.timing = EASING_CONTROL_POINTS[entry.easing];
+        opts.repeat = Infinity;
+        opts.autoreverse = entry.alternate;
+      } else if (map.colour) {
+        // From where the pixels are — which is what "an interrupted
+        // transition reverses from where it got to" means here. A colour
+        // cannot be additive, so the one before it is replaced.
+        this._removeLive(node, prop);
+        const shown = this.native.presentationValue?.(
+          visual.layer,
+          map.keyPath,
+        );
+        opts.from = Array.isArray(shown) ? shown : this._value(map, entry.from);
+        opts.to = this._value(map, entry.to);
+        opts.timing = TRANSITION_CONTROL_POINTS;
+      } else {
+        // Additive: a delta over the model value, (old − new) → 0, and the
+        // ones before it keep running and sum. Continuity on a retarget with
+        // nothing read back, however many are in flight.
+        opts.from = this._value(map, entry.from) - this._value(map, entry.to);
+        opts.to = 0;
+        opts.additive = true;
+        opts.timing = TRANSITION_CONTROL_POINTS;
+      }
+      this.native.addAnimation(visual.layer, map.keyPath, opts, key);
+      // looked up after the removals above, which may have pruned the map
+      let live = this.liveAnimations.get(node);
+      if (!live) this.liveAnimations.set(node, (live = new Map()));
+      live.set(id, { prop, key, entry });
+      this._ends().set(id, (ev) => this._animationEnded(node, id, ev));
+    }
+  }
+
+  /** Every animation running for `prop` on `node`, off the layer and out
+   *  of the books. */
+  _removeLive(node, prop) {
+    const live = this.liveAnimations.get(node);
+    if (!live) return;
+    const visual = this.visuals.get(node);
+    for (const [id, run] of live) {
+      if (run.prop !== prop) continue;
+      live.delete(id);
+      this._ends().delete(id);
+      if (visual) this.native.removeAnimation(visual.layer, run.key);
+    }
+    if (live.size === 0) this.liveAnimations.delete(node);
+  }
+
+  /** The bridge's `animation-end` for one of ours — it ran out, or CA
+   *  dropped it. An older additive one ending changes nothing: the node
+   *  checks the entry is still the one it holds. */
+  _animationEnded(node, id) {
+    this._ends().delete(id);
+    const live = this.liveAnimations.get(node);
+    const run = live?.get(id);
+    if (!run) return;
+    live.delete(id);
+    if (live.size === 0) this.liveAnimations.delete(node);
+    node._offloadEnded(run.prop, run.entry);
+  }
+
+  /** The layer is going — the visual is destroyed, or turns into a raster —
+   *  and every animation on it goes with it. What was still waiting for a
+   *  frame goes back to the frame clock when the node stays (`reclaim`);
+   *  what was running is over, and the model shows. */
+  _dropAnimations(node, reclaim) {
+    const pending = this.pendingAnimations.get(node);
+    if (pending) {
+      this.pendingAnimations.delete(node);
+      for (const [prop, entry] of pending) {
+        if (reclaim) node._offloadDeclined(prop, entry);
+        else node._offloadEnded(prop, entry);
+      }
+    }
+    const live = this.liveAnimations.get(node);
+    if (!live) return;
+    this.liveAnimations.delete(node);
+    for (const [id, run] of live) {
+      this._ends().delete(id);
+      node._offloadEnded(run.prop, run.entry);
+    }
   }
 
   /**

--- a/src/cocoa/window.js
+++ b/src/cocoa/window.js
@@ -93,16 +93,22 @@ export class CocoaWindow {
 
     // The retained layer presenter (docs/macos.md Tier L), behind
     // REACT_X11_COCOA_PRESENTER=layers while the surface path is the
-    // measured default. Its two hooks exist only in this mode, so the
-    // feature detection in nodes.js keeps the surface path byte-identical;
-    // the scroll blit is shadowed off because a layer frame has no backing
-    // bitmap to blit.
+    // measured default. Its hooks exist only in this mode, so the feature
+    // detection in nodes.js keeps the surface path byte-identical; the
+    // scroll blit is shadowed off because a layer frame has no backing
+    // bitmap to blit. The last two are the animation seam: a transition or
+    // a loop the presenter takes runs in the render server and schedules no
+    // frames here (docs/architecture/animation.md §4).
     if (app._presenterMode === 'layers') {
       this._presenter = new CocoaLayerPresenter(this);
       this.presentFrame = (windowNode) => this._presenter.frame(windowNode);
       this.noteInvalidate = (damage, layoutChanged) =>
         this._presenter.noteInvalidate(damage, layoutChanged);
       this.scrollRegion = null;
+      this.animateNode = (node, prop, entry) =>
+        this._presenter.animate(node, prop, entry);
+      this.cancelNodeAnimation = (node, prop) =>
+        this._presenter.cancel(node, prop);
     }
     app._registerWindow(this);
   }

--- a/src/desktopsettings.js
+++ b/src/desktopsettings.js
@@ -17,7 +17,11 @@
 // XQuartz — the defaults below stand.
 //
 // So this reads the map `xsettings.js` already maintains, rather than
-// standing up a source of its own.
+// standing up a source of its own. The one exception is macOS, which has no
+// XSETTINGS and answers exactly one of these — "reduce motion", through
+// `NSWorkspace` — so the Cocoa app exposes that behind a two-method seam
+// (`accessibilityDisplayOptions`, `watchAccessibilityDisplay`) and this
+// module reads it the way it reads the map: synchronously, cached, live.
 //
 // ## Two of these are read synchronously, which is what shapes the module
 //
@@ -85,6 +89,22 @@ function positive(map, key) {
  * conversion, and forgetting to is a caret that blinks at half speed and
  * looks broken rather than wrong.
  */
+/**
+ * macOS's accessibility display options → the settings. Only `animations`
+ * comes from the system there: it is the one of these macOS publishes at all
+ * (System Settings › Accessibility › Display › Reduce motion, which the
+ * bridge reads from `NSWorkspace`), and the rest keep this renderer's
+ * defaults rather than being guessed from something that is not them. Pure,
+ * and exported for the test.
+ */
+export function fromMacOS(options) {
+  return Object.freeze({
+    ...DEFAULTS,
+    animations: options?.reduceMotion !== true,
+    source: 'macos',
+  });
+}
+
 export function fromXSettings(map) {
   if (!map) return DEFAULTS;
   const cycle = positive(map, 'Net/CursorBlinkTime');
@@ -126,7 +146,9 @@ export function desktopSettings(app) {
   const session = sessions.get(app);
   if (!session) return DEFAULTS;
   if (!session.snapshot) {
-    session.snapshot = fromXSettings(xsettings(app));
+    session.snapshot = session.macos
+      ? fromMacOS(app.accessibilityDisplayOptions())
+      : fromXSettings(xsettings(app));
   }
   return session.snapshot;
 }
@@ -141,6 +163,16 @@ export function beginDesktopSettings(app) {
   if (sessions.has(app)) return;
   const session = { snapshot: null, listeners: new Set(), stop: null };
   sessions.set(app, session);
+  // The Cocoa app: the answer is synchronous from the start, and the change
+  // arrives as a backend event rather than a property on a selection owner.
+  if (typeof app?.accessibilityDisplayOptions === 'function') {
+    session.macos = true;
+    session.stop = app.watchAccessibilityDisplay?.(() => {
+      session.snapshot = null;
+      notify(session);
+    });
+    return;
+  }
   beginXSettings(app).then(
     () => {
       if (!sessions.has(app)) return;

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -2089,7 +2089,7 @@ export class Node {
         const duration = transitionFor(target, prop);
         if (duration <= 0) continue;
         if (interpolate(from, to, 0.5) === null) continue; // no midpoint: snap
-        (this._anim ??= new Map()).set(prop, {
+        const entry = {
           from,
           to,
           duration,
@@ -2098,8 +2098,23 @@ export class Node {
           // be seconds old — and the first tick would then find the
           // transition already over and jump straight to the end
           start: now(),
-        });
-        this.root?._startAnimating(this);
+        };
+        const previous = this._anim?.get(prop);
+        (this._anim ??= new Map()).set(prop, entry);
+        // A presenter that can run it in the render server takes it here:
+        // the node's style then goes straight to the target — the layer's
+        // model value — and the one frame that sends it carries the
+        // animation with it (src/cocoa/presenter.js). Declined, or with no
+        // such presenter, the window's frame clock runs it as it always has.
+        if (this._offload(prop, entry)) {
+          entry.offloaded = true;
+          this.root?.invalidate(false, damageForAnimation(this), 'animation');
+        } else {
+          // …and one the presenter had must not keep running underneath the
+          // values the clock is about to write
+          if (previous?.offloaded) this._cancelOffload(prop, previous);
+          this.root?._startAnimating(this);
+        }
       }
     }
     // After the transitions, before the style is assembled: a loop that just
@@ -2191,8 +2206,75 @@ export class Node {
 
   _animatedValues() {
     const values = {};
-    for (const [prop, a] of this._anim) values[prop] = a.value ?? a.from;
+    for (const [prop, a] of this._anim) {
+      // an offloaded property shows its target: the render server draws the
+      // motion over the model value, and the model is the style
+      if (!a.offloaded) values[prop] = a.value ?? a.from;
+    }
     return values;
+  }
+
+  // --- the presenter's half of an animation ---------------------------------
+  //
+  // Three feature-detected hooks on the window (src/cocoa/window.js, layers
+  // mode only): `animateNode(node, prop, entry)` answers true when the
+  // presenter will run the entry itself, `cancelNodeAnimation(node, prop)`
+  // stops what it runs for the property, and the presenter calls back
+  // through `_offloadEnded` / `_offloadDeclined` below. An entry the
+  // presenter took is `offloaded`: it stays in `_anim` — so a retarget, a
+  // loop-stop rule and `sameAnimation` all see it — but it contributes no
+  // value to the style, is skipped by the tick, and keeps the node out of the
+  // window's animating set. The X11 path has none of these hooks and is
+  // byte-identical (docs/architecture/animation.md §4).
+
+  _offload(prop, entry) {
+    const wnd = this.root?.window;
+    if (typeof wnd?.animateNode !== 'function') return false;
+    return wnd.animateNode(this, prop, entry) === true;
+  }
+
+  _cancelOffload(prop, entry) {
+    if (!entry?.offloaded) return;
+    this.root?.window?.cancelNodeAnimation?.(this, prop);
+  }
+
+  /** The presenter is done with `entry` — it ran out, or its layer went.
+   *  A transition is over either way (the model is the target). A loop
+   *  never ends on its own, so a loop that comes back this way lost its
+   *  layer, and the frame clock takes it over rather than letting it stop. */
+  _offloadEnded(prop, entry) {
+    if (this._anim?.get(prop) !== entry) return;
+    if (entry.loop && !this.destroyed) {
+      this._offloadDeclined(prop, entry);
+      return;
+    }
+    this._anim.delete(prop);
+    if (!this._anim.size) this.root?._animating.delete(this);
+  }
+
+  /** The presenter could not run `entry` after all — the node turned into a
+   *  raster between the swap and the frame. The frame clock takes it from
+   *  the top; the property's declared start is where the pixels still are. */
+  _offloadDeclined(prop, entry) {
+    if (this._anim?.get(prop) !== entry || this.destroyed) return;
+    entry.offloaded = false;
+    entry.start = now();
+    this.style = { ...this._targetStyle, ...this._animatedValues() };
+    this.root?._startAnimating(this);
+  }
+
+  /** Keep the frame clock running only for what the clock itself animates;
+   *  an offloaded-only node needs one frame — the one that sends the model
+   *  and the animation — and not a loop of them. */
+  _scheduleAnimationFrames() {
+    for (const a of this._anim?.values() ?? []) {
+      if (!a.offloaded) {
+        this.root?._startAnimating(this);
+        return;
+      }
+    }
+    this.root?._animating.delete(this);
+    this.root?.invalidate(false, damageForAnimation(this), 'animation');
   }
 
   /**
@@ -2241,6 +2323,7 @@ export class Node {
         if (!a.loop) continue;
         if (running && specs.some((spec) => spec.prop === prop)) continue;
         anim.delete(prop);
+        this._cancelOffload(prop, a);
         changed = true;
         if (isLayoutProp(prop)) layoutTouched = true;
       }
@@ -2253,13 +2336,28 @@ export class Node {
         // spinner that jumps back to the start whenever anything above it
         // re-rendered — which is the frame after every state change in the
         // app.
-        if (current?.loop && sameAnimation(current, spec)) continue;
-        (this._anim ??= new Map()).set(spec.prop, {
+        if (current?.loop && sameAnimation(current, spec)) {
+          // A loop the clock started before the window had a presenter —
+          // one declared at mount runs from `_setRoot`, before `realize` —
+          // moves over the first time a presenter can take it. Its phase is
+          // the render server's from here, which is what a restart costs.
+          if (!current.offloaded && this._offload(spec.prop, current)) {
+            current.offloaded = true;
+            changed = true;
+          }
+          continue;
+        }
+        // a changed declaration, or a transition the loop takes over from:
+        // whatever the presenter ran for the property stops first
+        if (current?.offloaded) this._cancelOffload(spec.prop, current);
+        const entry = {
           ...spec,
           loop: true,
           start: now(),
           value: animationValueAt(spec, 0),
-        });
+        };
+        (this._anim ??= new Map()).set(spec.prop, entry);
+        if (this._offload(spec.prop, entry)) entry.offloaded = true;
         changed = true;
         if (isLayoutProp(spec.prop)) layoutTouched = true;
       }
@@ -2273,7 +2371,7 @@ export class Node {
     // a stop has to leave the frame clock idle, and a tick is exactly what
     // there may never be another of.
     if (!this._anim?.size) this.root?._animating.delete(this);
-    if (running) this.root?._startAnimating(this);
+    if (running) this._scheduleAnimationFrames();
     if (!write) return true;
     if (layoutTouched && this.yoga) {
       applyLayoutStyle(this.yoga, this.style, before);
@@ -2320,19 +2418,23 @@ export class Node {
   _tickAnimations(now) {
     if (!this._anim?.size) return false;
     let layoutChanged = false;
+    let ticking = 0; // entries the clock runs, as against the presenter's
     const before = this.style;
     for (const [prop, a] of this._anim) {
+      if (a.offloaded) continue;
       if (a.loop) {
         // No end to test for and no rounding to accumulate: the phase is a
         // modulo of the elapsed time, so a bar that has been going for an
         // hour is exactly where the clock says.
         a.value = animationValueAt(a, now - a.start);
         if (isLayoutProp(prop)) layoutChanged = true;
+        ticking++;
         continue;
       }
       const t = a.duration > 0 ? Math.min(1, (now - a.start) / a.duration) : 1;
       a.value = t >= 1 ? a.to : (interpolate(a.from, a.to, ease(t)) ?? a.to);
       if (t >= 1) this._anim.delete(prop);
+      else ticking++;
       if (isLayoutProp(prop)) layoutChanged = true;
     }
     this.style = this._anim.size
@@ -2355,7 +2457,7 @@ export class Node {
     // it *per frame*: a transitioned `color` is a new ink every frame, for
     // this node and for everything inheriting from it.
     if (inheritedTextChanged(this.style, before)) this._retextSubtree();
-    return this._anim.size > 0;
+    return ticking > 0;
   }
 
   /**

--- a/src/styles.js
+++ b/src/styles.js
@@ -788,6 +788,23 @@ const EASINGS = {
 
 export const EASING_NAMES = Object.freeze(Object.keys(EASINGS));
 
+/**
+ * The same curves as cubic-bezier control points, for a presenter whose
+ * render server evaluates them itself (src/cocoa/presenter.js). The two
+ * evaluators have to agree on one declaration, and they do: each polynomial
+ * above and its bezier twin differ by at most 0.01 over the unit interval
+ * (test/style.test.js pins it). Core Animation's *named* curves are not
+ * these — its `easeOut` is (0, 0, 0.58, 1), 0.22 away from `ease` at
+ * t = 0.35 — which is why the presenter sends points rather than names. A
+ * new easing lands in both tables or in neither.
+ */
+export const EASING_CONTROL_POINTS = Object.freeze({
+  linear: Object.freeze([0, 0, 1, 1]),
+  'ease-in': Object.freeze([0.32, 0, 0.67, 0]),
+  'ease-out': Object.freeze([0.33, 1, 0.68, 1]),
+  'ease-in-out': Object.freeze([0.65, 0, 0.35, 1]),
+});
+
 /** A value that is still a `$token` reference, or mentions one. */
 const unresolvedValue = (v) => isToken(v) || mentionsToken(v);
 
@@ -1119,6 +1136,8 @@ export function tint(color, alpha) {
 // ease-out cubic: fast to start, settles gently — the shape almost every UI
 // toolkit defaults to for state changes
 export const ease = (t) => 1 - (1 - t) ** 3;
+/** …and the same curve as control points, for the presenter (above). */
+export const TRANSITION_CONTROL_POINTS = EASING_CONTROL_POINTS['ease-out'];
 
 /**
  * Theme tokens. A style value of `'$name'` resolves against the nearest

--- a/src/types/system.d.ts
+++ b/src/types/system.d.ts
@@ -234,9 +234,11 @@ export interface DesktopSettings {
   readonly doubleClickDistance: number;
   /** How far a press moves before it is a drag rather than a click. */
   readonly dragThreshold: number;
-  /** `'xsettings'`, or null where no settings daemon answered and these are
-   *  the renderer's own defaults. */
-  readonly source: 'xsettings' | 'test' | null;
+  /** `'xsettings'`; `'macos'` on the Cocoa backend, where only `animations`
+   *  comes from the system (reduce motion) and the rest are the defaults; or
+   *  null where no settings daemon answered and these are the renderer's own
+   *  defaults. */
+  readonly source: 'xsettings' | 'macos' | 'test' | null;
 }
 
 /**

--- a/test/cocoa-desktop-settings.test.js
+++ b/test/cocoa-desktop-settings.test.js
@@ -1,0 +1,183 @@
+// The desktop's "reduce motion" on the Cocoa backend (src/desktopsettings.js
+// over CocoaApp's accessibility seam, @windowkit/appkit >= 0.5): read
+// synchronously from the bridge, live through the backend event, and what a
+// looping animation does about it. Headless: a recording fake bridge, so
+// this runs everywhere and says nothing about System Settings itself — only
+// that what the bridge reports reaches `desktopSettings()` and the loops.
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert';
+import React from 'react';
+
+import { createRoot } from '../src/index.js';
+import { CocoaApp } from '../src/cocoa/app.js';
+import {
+  beginDesktopSettings,
+  desktopSettings,
+  endDesktopSettings,
+  fromMacOS,
+  watchDesktopSettings,
+} from '../src/desktopsettings.js';
+import { setScaleForTests } from '../src/scale.js';
+import { setScreensForTests } from '../src/screens.js';
+import { setCompositingForTests } from '../src/compositing.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+const OPTIONS = {
+  reduceMotion: false,
+  reduceTransparency: false,
+  increaseContrast: false,
+  differentiateWithoutColor: false,
+  invertColors: false,
+};
+
+/** A bridge shaped like @windowkit/appkit's, answering what a window's
+ *  construction and the accessibility seam ask, and delivering events. */
+function fakeNative(options = {}) {
+  let cb = null;
+  let seq = 0;
+  const base = {
+    options: { ...OPTIONS, ...options },
+    /** Tell the app the options changed, the way the bridge does. */
+    change(next) {
+      Object.assign(base.options, next);
+      cb?.({ type: 'accessibility-display-changed', ...base.options });
+    },
+    accessibilityDisplayOptions: () => ({ ...base.options }),
+    setBackendEventCallback(fn) {
+      cb = fn;
+    },
+    initApp() {},
+    listScreens: () => [
+      {
+        x: 0,
+        y: 0,
+        width: 1440,
+        height: 900,
+        scale: 2,
+        fps: 60,
+        visible: { x: 0, y: 0, width: 1440, height: 875 },
+        primary: true,
+      },
+    ],
+    createWindow2: (o) => ({ id: ++seq, options: { ...o } }),
+    windowNumber: (handle) => handle.id,
+    windowRootLayer: (handle) => ({ root: handle.id }),
+    getWindowFrame: (handle) => ({
+      x: 0,
+      y: 0,
+      width: handle.options.width,
+      height: handle.options.height,
+    }),
+    windowIsVisible: () => true,
+    createSurfaceIOSurface: (width, height, scale) => ({
+      handle: { id: ++seq, width, height, scale },
+      iosurfaceId: seq,
+    }),
+    createSurface: (width, height, scale) => ({
+      id: ++seq,
+      width,
+      height,
+      scale,
+    }),
+    surfaceSize: (handle) => ({
+      width: handle.width,
+      height: handle.height,
+      scale: handle.scale,
+    }),
+  };
+  return new Proxy(base, {
+    get: (target, key) => (key in target ? target[key] : () => undefined),
+  });
+}
+
+function appOver(native) {
+  const app = new CocoaApp(native);
+  setScaleForTests(app, 2, 'cocoa');
+  setScreensForTests(app, {
+    monitors: [{ x: 0, y: 0, width: 2880, height: 1800 }],
+    workArea: { x: 0, y: 0, width: 2880, height: 1750 },
+  });
+  setCompositingForTests(app, true);
+  native.setBackendEventCallback((ev) => app._route(ev));
+  return app;
+}
+
+const roots = [];
+afterEach(async () => {
+  for (const root of roots.splice(0)) await root.unmount();
+});
+
+test('fromMacOS: reduce motion is the one field the system answers', () => {
+  const still = fromMacOS({ ...OPTIONS, reduceMotion: true });
+  assert.strictEqual(still.animations, false);
+  assert.strictEqual(still.source, 'macos');
+  assert.strictEqual(still.caretBlinkMs, fromMacOS(null).caretBlinkMs);
+  assert.strictEqual(fromMacOS({ ...OPTIONS }).animations, true);
+  // a bridge that does not answer is a desktop that said nothing
+  assert.strictEqual(fromMacOS(null).animations, true);
+  assert.strictEqual(fromMacOS(null).source, 'macos');
+});
+
+test('the Cocoa app answers synchronously, and a change reaches the subscribers', () => {
+  const native = fakeNative({ reduceMotion: true });
+  const app = appOver(native);
+  beginDesktopSettings(app);
+  assert.strictEqual(desktopSettings(app).animations, false);
+  assert.strictEqual(desktopSettings(app).source, 'macos');
+
+  let heard = 0;
+  const off = watchDesktopSettings(app, () => heard++);
+  native.change({ reduceMotion: false });
+  assert.strictEqual(heard, 1);
+  assert.strictEqual(desktopSettings(app).animations, true);
+  native.change({ increaseContrast: true });
+  assert.strictEqual(heard, 2, 'every change notifies; the reader decides');
+  assert.strictEqual(desktopSettings(app).animations, true);
+
+  off();
+  native.change({ reduceMotion: true });
+  assert.strictEqual(heard, 2);
+  assert.strictEqual(desktopSettings(app).animations, false, 'still read');
+  endDesktopSettings(app);
+  native.change({ reduceMotion: false });
+  assert.strictEqual(heard, 2, 'nothing after the end');
+});
+
+test('a loop never starts under reduce motion, and starts when the switch flips', async () => {
+  const native = fakeNative({ reduceMotion: true });
+  const app = appOver(native);
+  const root = await createRoot({ app });
+  roots.push(root);
+  root.render(
+    h(
+      'window',
+      { width: 200, height: 100 },
+      h('box', {
+        style: {
+          width: 80,
+          height: 20,
+          backgroundColor: '#ff0000',
+          animation: {
+            backgroundColor: { to: '#00ff00', duration: 900, alternate: true },
+          },
+        },
+      }),
+    ),
+  );
+  await tick();
+  const wnd = [...app._windows.values()][0];
+  const windowNode = wnd._reactX11Node;
+  app._tickFrames(); // the first flush arms the loop's watch
+  const box = windowNode.children[0];
+  assert.ok(windowNode._loopNodes.has(box), 'the loop is registered');
+  assert.ok(!box._anim?.size, 'and not running');
+  assert.strictEqual(box.style.backgroundColor, '#ff0000', 'resting');
+
+  native.change({ reduceMotion: false });
+  assert.ok(box._anim?.get('backgroundColor')?.loop, 'running now');
+
+  native.change({ reduceMotion: true });
+  assert.ok(!box._anim?.size, 'and stopped again');
+});

--- a/test/cocoa-presenter.test.js
+++ b/test/cocoa-presenter.test.js
@@ -15,7 +15,12 @@ import { cssColorStraight } from 'ntk';
 
 import { registerElement, unregisterElement } from '../src/host.js';
 import { Node } from '../src/node.js';
-import { renderX11, cleanup, screen } from '../src/testing/index.js';
+import {
+  renderX11,
+  cleanup,
+  screen,
+  withFrameClock,
+} from '../src/testing/index.js';
 import { CocoaLayerPresenter } from '../src/cocoa/presenter.js';
 import { CocoaContext2D } from '../src/cocoa/context2d.js';
 
@@ -65,6 +70,7 @@ class SceneNode extends Node {
 function fakeBridge() {
   const calls = [];
   let surfaces = 0;
+  let presentation = null; // what presentationValue answers
   const native = new Proxy(
     {},
     {
@@ -75,6 +81,7 @@ function fakeBridge() {
           if (name.startsWith('create') && name.endsWith('Layer')) {
             return { layer: calls.length };
           }
+          if (name === 'presentationValue') return presentation;
           if (name === 'createSurface') {
             return { surface: ++surfaces, width: args[0], height: args[1] };
           }
@@ -89,6 +96,9 @@ function fakeBridge() {
   return {
     native,
     calls,
+    setPresentation: (value) => {
+      presentation = value;
+    },
     /** The arguments after the surface handle, per call of `name`. */
     argsOf: (name) =>
       calls.filter((c) => c.name === name).map((c) => c.args.slice(1)),
@@ -103,7 +113,11 @@ function presenterFor({ windowNode, app }) {
   const presenter = new CocoaLayerPresenter({
     _native: bridge.native,
     scale: 1,
-    app: { fonts: app.fonts, _parseColor: (c) => cssColorStraight(String(c)) },
+    app: {
+      fonts: app.fonts,
+      _parseColor: (c) => cssColorStraight(String(c)),
+      _animationEnds: new Map(),
+    },
     _layer: { layer: 'root' },
   });
   windowNode.window.noteInvalidate = (damage, layoutChanged) =>
@@ -330,4 +344,231 @@ test('a claim made from inside a frame lands in the next one', async () => {
   );
   presenter.frame(windowNode);
   assert.strictEqual(outer.rasters, 2);
+});
+
+// --- animations the render server runs --------------------------------------
+//
+// The presenter's half of docs/architecture/animation.md §4: a transition or
+// a loop on a property the node's own layer expresses goes to the bridge as
+// an explicit animation — control points for the curve, additive for a
+// length, from the presentation value for a colour — and schedules no
+// frames; what the layer cannot express stays on the frame clock, exactly as
+// before. The bridge is the recording fake, so what is pinned is the call
+// that goes out and the node model's bookkeeping around it.
+
+const plainBox = (style) =>
+  h('box', {
+    style: { width: 120, height: 60, backgroundColor: '#ff0000', ...style },
+  });
+
+/** A plain box over the presenter, its window wired the way layers mode
+ *  wires it (src/cocoa/window.js), one frame in. */
+async function mountAnimated(style) {
+  const mounted = await renderX11(plainBox(style), { backend: 'mock' });
+  const { presenter, bridge } = presenterFor(mounted);
+  const wnd = mounted.windowNode.window;
+  wnd.animateNode = (node, prop, entry) => presenter.animate(node, prop, entry);
+  wnd.cancelNodeAnimation = (node, prop) => presenter.cancel(node, prop);
+  presenter.frame(mounted.windowNode);
+  bridge.calls.length = 0; // mount traffic
+  return {
+    ...mounted,
+    presenter,
+    bridge,
+    node: mounted.windowNode.children[0],
+    ends: presenter.window.app._animationEnds,
+    rerender: (next) => mounted.rerender(plainBox(next)),
+  };
+}
+
+const fade = { transition: { backgroundColor: 120 } };
+const pulse = {
+  animation: {
+    backgroundColor: { to: '#00ff00', duration: 900, alternate: true },
+  },
+};
+const sentBackgrounds = (bridge) =>
+  bridge
+    .argsOf('setLayerProps')
+    .flatMap(([p]) => (p.backgroundColor ? [p.backgroundColor] : []));
+
+test('a transition on a plain box runs in the render server: the model, one animation, no frames', async () => {
+  const m = await mountAnimated(fade);
+  await m.rerender({ ...fade, backgroundColor: '#0000ff' });
+  const entry = m.node._anim.get('backgroundColor');
+  assert.ok(entry?.offloaded, 'the presenter took it');
+  assert.strictEqual(m.windowNode._animating.size, 0, 'no frame clock for it');
+  assert.strictEqual(
+    m.node.style.backgroundColor,
+    '#0000ff',
+    'the style is the model value, not the start',
+  );
+
+  m.presenter.frame(m.windowNode);
+  assert.deepStrictEqual(sentBackgrounds(m.bridge).at(-1), [0, 0, 1, 1]);
+  const anims = m.bridge.argsOf('addAnimation');
+  assert.strictEqual(anims.length, 1);
+  const [keyPath, opts, key] = anims[0];
+  assert.strictEqual(keyPath, 'backgroundColor');
+  assert.deepStrictEqual(opts.from, [1, 0, 0, 1]);
+  assert.deepStrictEqual(opts.to, [0, 0, 1, 1]);
+  assert.strictEqual(opts.duration, 0.12);
+  assert.deepStrictEqual(opts.timing, [0.33, 1, 0.68, 1], 'control points');
+  assert.strictEqual(typeof opts.id, 'string');
+  assert.ok(key.startsWith('backgroundColor:'));
+  m.presenter.frame(m.windowNode);
+  assert.strictEqual(
+    m.bridge.argsOf('addAnimation').length,
+    1,
+    'attached once',
+  );
+
+  // the bridge reports the end: the entry goes, the model was there all along
+  m.ends.get(opts.id)({ type: 'animation-end', id: opts.id, finished: true });
+  assert.ok(!m.node._anim?.size);
+  assert.strictEqual(m.presenter.liveAnimations.size, 0);
+});
+
+test('a length retargets additively: the new delta joins the one still running', async () => {
+  const edge = { borderColor: '#000000', transition: { borderWidth: 100 } };
+  const m = await mountAnimated({ ...edge, borderWidth: 2 });
+  await m.rerender({ ...edge, borderWidth: 6 });
+  m.presenter.frame(m.windowNode);
+  await m.rerender({ ...edge, borderWidth: 3 });
+  m.presenter.frame(m.windowNode);
+  const anims = m.bridge.argsOf('addAnimation');
+  assert.deepStrictEqual(
+    anims.map(([kp, o]) => [kp, o.from, o.to, o.additive]),
+    [
+      ['borderWidth', -4, 0, true],
+      ['borderWidth', 3, 0, true],
+    ],
+  );
+  assert.notStrictEqual(anims[0][2], anims[1][2], 'distinct keys');
+  assert.strictEqual(
+    m.bridge.argsOf('removeAnimation').length,
+    0,
+    'the first keeps running and sums with the second',
+  );
+  m.ends.get(anims[0][1].id)({ finished: true });
+  assert.ok(
+    m.node._anim.get('borderWidth')?.offloaded,
+    'the older one ending leaves the newer in place',
+  );
+  m.ends.get(anims[1][1].id)({ finished: true });
+  assert.ok(!m.node._anim?.size);
+});
+
+test('a colour retargets from where the pixels are, replacing the one before it', async () => {
+  const m = await mountAnimated(fade);
+  await m.rerender({ ...fade, backgroundColor: '#0000ff' });
+  m.presenter.frame(m.windowNode);
+  const [, , firstKey] = m.bridge.argsOf('addAnimation')[0];
+  m.bridge.setPresentation([0.5, 0, 0.5, 1]); // mid-flight, as the bridge reports it
+  await m.rerender({ ...fade, backgroundColor: '#00ff00' });
+  m.presenter.frame(m.windowNode);
+  const anims = m.bridge.argsOf('addAnimation');
+  assert.strictEqual(anims.length, 2);
+  assert.deepStrictEqual(anims[1][1].from, [0.5, 0, 0.5, 1]);
+  assert.deepStrictEqual(anims[1][1].to, [0, 1, 0, 1]);
+  assert.deepStrictEqual(m.bridge.argsOf('removeAnimation'), [[firstKey]]);
+});
+
+test('what the layer cannot express stays on the frame clock', async () => {
+  const clock = withFrameClock();
+  try {
+    // a per-edge border makes the box a raster: its background is in the bitmap
+    const raster = { borderTopWidth: 1, borderColor: '#000000', ...fade };
+    const m = await mountAnimated(raster);
+    await m.rerender({ ...raster, backgroundColor: '#0000ff' });
+    assert.ok(m.windowNode._animating.has(m.node), 'the clock runs it');
+    assert.ok(!m.node._anim.get('backgroundColor').offloaded);
+    assert.deepStrictEqual(
+      cssColorStraight(m.node.style.backgroundColor),
+      [1, 0, 0, 1],
+      'from the start, as the clock always did',
+    );
+    m.presenter.frame(m.windowNode);
+    assert.strictEqual(m.bridge.argsOf('addAnimation').length, 0);
+  } finally {
+    clock.restore();
+  }
+});
+
+test('a loop is one repeating animation in the render server, and stops with the node', async () => {
+  const m = await mountAnimated(pulse);
+  // declared at mount it started on the clock, before the presenter was
+  // wired; the next swap with the same declaration moves it over
+  await m.rerender(pulse);
+  const entry = m.node._anim.get('backgroundColor');
+  assert.ok(entry?.loop && entry.offloaded);
+  assert.strictEqual(m.windowNode._animating.size, 0);
+  assert.strictEqual(
+    m.node.style.backgroundColor,
+    '#ff0000',
+    'the model rests at the declared value',
+  );
+  m.presenter.frame(m.windowNode);
+  const [[keyPath, opts, key]] = m.bridge.argsOf('addAnimation');
+  assert.strictEqual(keyPath, 'backgroundColor');
+  assert.deepStrictEqual(
+    [
+      opts.from,
+      opts.to,
+      opts.repeat,
+      opts.autoreverse,
+      opts.timing,
+      opts.duration,
+    ],
+    [[1, 0, 0, 1], [0, 1, 0, 1], Infinity, true, [0, 0, 1, 1], 0.9],
+  );
+  m.presenter.frame(m.windowNode);
+  assert.strictEqual(m.bridge.argsOf('addAnimation').length, 1, 'phase kept');
+
+  await m.rerender({ ...pulse, display: 'none' });
+  assert.deepStrictEqual(m.bridge.argsOf('removeAnimation'), [[key]]);
+  assert.ok(!m.node._anim?.size);
+  m.presenter.frame(m.windowNode);
+  assert.strictEqual(m.presenter.liveAnimations.size, 0);
+});
+
+test('a layer that turns into a raster hands its loop back to the clock', async () => {
+  const m = await mountAnimated(pulse);
+  await m.rerender(pulse);
+  m.presenter.frame(m.windowNode);
+  assert.strictEqual(m.bridge.argsOf('addAnimation').length, 1);
+  await m.rerender({ ...pulse, borderTopWidth: 1, borderColor: '#000000' });
+  m.presenter.frame(m.windowNode);
+  const entry = m.node._anim.get('backgroundColor');
+  assert.ok(entry?.loop && !entry.offloaded, 'the clock has it again');
+  assert.ok(m.windowNode._animating.has(m.node));
+  assert.strictEqual(m.presenter.liveAnimations.size, 0);
+});
+
+test('a transition whose layer turns raster before its frame goes to the clock', async () => {
+  const clock = withFrameClock();
+  try {
+    const m = await mountAnimated(fade);
+    await m.rerender({ ...fade, backgroundColor: '#0000ff' });
+    assert.ok(m.node._anim.get('backgroundColor').offloaded);
+    // a second swap before the frame: the target now paints as a raster
+    await m.rerender({
+      ...fade,
+      backgroundColor: '#0000ff',
+      borderTopWidth: 1,
+      borderColor: '#000000',
+    });
+    m.presenter.frame(m.windowNode);
+    const entry = m.node._anim.get('backgroundColor');
+    assert.ok(entry && !entry.offloaded);
+    assert.ok(m.windowNode._animating.has(m.node));
+    assert.strictEqual(
+      m.node.style.backgroundColor,
+      '#ff0000',
+      'from the declared start',
+    );
+    assert.strictEqual(m.bridge.argsOf('addAnimation').length, 0);
+  } finally {
+    clock.restore();
+  }
 });

--- a/test/style.test.js
+++ b/test/style.test.js
@@ -1235,3 +1235,48 @@ test('a popup written under a theme does not trip the no-theme warning', async (
 
   await x11Root.unmount();
 });
+
+test("each named easing is its cubic-bezier twin, and the transition curve is not CA's named one", async () => {
+  const {
+    EASING_CONTROL_POINTS,
+    TRANSITION_CONTROL_POINTS,
+    animationsOf,
+    ease,
+  } = await import('../src/styles.js');
+  // cubic-bezier(x1, y1, x2, y2) at x, the way a browser (or the render
+  // server) evaluates it: solve the x polynomial for t, then read y
+  const bezier = (x1, y1, x2, y2) => {
+    const poly = (a1, a2, t) =>
+      ((1 - 3 * a2 + 3 * a1) * t * t + (3 * a2 - 6 * a1) * t + 3 * a1) * t;
+    return (x) => {
+      let lo = 0;
+      let hi = 1;
+      let t = x;
+      for (let i = 0; i < 40; i++) {
+        t = (lo + hi) / 2;
+        if (poly(x1, x2, t) < x) lo = t;
+        else hi = t;
+      }
+      return poly(y1, y2, t);
+    };
+  };
+  const apart = (f, g) => {
+    let max = 0;
+    for (let i = 0; i <= 200; i++) {
+      const t = i / 200;
+      max = Math.max(max, Math.abs(f(t) - g(t)));
+    }
+    return max;
+  };
+  for (const [name, points] of Object.entries(EASING_CONTROL_POINTS)) {
+    const [spec] = animationsOf({
+      left: 0,
+      animation: { left: { to: 1, duration: 1000, easing: name } },
+    });
+    assert.ok(apart(spec.ease, bezier(...points)) < 0.01, name);
+  }
+  assert.ok(apart(ease, bezier(...TRANSITION_CONTROL_POINTS)) < 0.01);
+  // Core Animation's named easeOut is (0, 0, 0.58, 1): a different curve,
+  // which is why the presenter sends points rather than a name
+  assert.ok(apart(ease, bezier(0, 0, 0.58, 1)) > 0.2);
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -1446,6 +1446,10 @@ function _System() {
 
   const feel: DesktopSettings = useDesktopSettings();
   const blinkFor: number = feel.caretBlink ? feel.caretBlinkMs : 0;
+  // where the numbers came from: a settings daemon, the macOS accessibility
+  // panel (reduce motion only), a test, or nobody
+  const feelSource: 'xsettings' | 'macos' | 'test' | null = feel.source;
+  void feelSource;
   void [
     feel.doubleClickMs,
     feel.doubleClickDistance,


### PR DESCRIPTION
The design for animation in styles, and the first two things it unlocks now that `@windowkit/appkit` 0.5.0 ships the bridge verbs it asked for (windowkit/appkit#30, windowkit/appkit#32).

## The design

[`docs/architecture/animation.md`](docs/architecture/animation.md): what the `transition` / `animation` vocabulary cannot say today, a proposed vocabulary — easing as cubic-bezier control points with names as aliases, a per-property `{ duration, easing, delay }` form for transitions, `keyframes` / `repeat` / `delay` / `key` for timelines that may end, `opacity` and the individual transforms as paint-only properties on both backends — and one execution rule: **the node model stays the source of truth for what is animating and when it ends; a presenter may take the pixels.** §4.4 is the bridge list, all of which landed in 0.5.0.

## What lands here

**Dependency**: `@windowkit/appkit` `^0.5.0`, lockfile regenerated.

**Transitions and loops run in the render server on the layer presenter** (docs/macos.md "Animations and transforms"). Three feature-detected hooks on the Cocoa window in layers mode — `animateNode`, `cancelNodeAnimation`, and the presenter's calls back into the node — and the X11 path has none of them, byte-identical:

- `CocoaLayerPresenter.animate(node, prop, entry)` takes a transition or a loop on a **plain box's** `backgroundColor`, `borderColor`, `borderWidth`, `borderRadius` — what the node's own layer expresses as a property of itself — and declines everything else (a colour on text, any layout property, any node that paints as a raster), which then runs on the frame clock exactly as before. Decided against the *target* style, because a `:hover` that adds a shadow turns the node into a raster in the same swap that starts the fade.
- Taken means: the node's style goes straight to the target, which is the layer's model value; the one frame that sends it attaches the explicit animation in the same transaction; no frame after that is scheduled for it. A loop is one `repeat: Infinity` animation and costs **zero JS frames**. An entry the presenter took stays in `_anim` as `offloaded` — a retarget, every loop-stop rule and `sameAnimation` still see it — but contributes no value, is skipped by the tick, and keeps the node out of the window's animating set.
- **Timing parity** is control points, never names: `EASING_CONTROL_POINTS` in styles.js beside `EASINGS`, `TRANSITION_CONTROL_POINTS` beside `ease`, and a test that each polynomial and its bezier twin are within 0.01 over the unit interval while CA's named `easeOut` is 0.2 away.
- **Interruption**: a length retargets additively — the model goes to the new target, a delta animation `(old − new) → 0` joins the ones still running — so a change of mind mid-flight is continuous with nothing read back; a colour cannot be additive and restarts from the presentation value the bridge reports.
- **Completion** is the bridge's `animation-end` event, routed by id through `CocoaApp._animationEnds`, so the entry goes when the render server says so. An older additive animation ending leaves the newer one in place.
- Every way a layer can go away is covered: a visual that turns into a raster hands a pending transition back to the clock (`_offloadDeclined`) and a running loop too (a loop never ends by itself, so an end for one means its layer went); a node the frame no longer sees drops its animations; a loop declared at mount starts on the clock before the window has a presenter and moves over at the first swap that can take it.

**Reduce motion on the Cocoa backend** (docs/system.md). `desktopSettings()` gets a macOS source: `animations` is `!reduceMotion` from `NSWorkspace` through the bridge, read synchronously and live — the `accessibility-display-changed` event flips it while the app runs, which stops a spinner already going round, the way the XSETTINGS watch does on X11. Only that field comes from the system there; the rest keep the defaults, and `source: 'macos'` says so. Before this, a mac reported `animations: true` whatever the user set.

## Verification

- `npm test` green on macOS apart from two glyph-run tests that fail against a stale bridge copy in this worktree's `node_modules` and pass against the real 0.5.0 — not this change. `npm run lint`, `prettier --check .`, `npm run typecheck` (the `DesktopSettings.source` union gained `'macos'`, with a line in the type test).
- New tests. `test/cocoa-presenter.test.js`: a background transition on a plain box sends the model and one animation with control points and schedules no frames, the end event clears the entry; a length retargets additively with the first animation still running and distinct keys; a colour retargets from the presentation value and replaces the one before it; a per-edge border keeps a transition on the clock; a loop is one repeating animation with `autoreverse`, keeps its phase across a re-render, and `display: none` removes it; a layer turning raster hands a loop back to the clock; a transition whose layer turns raster before its frame goes to the clock. `test/cocoa-desktop-settings.test.js`: `fromMacOS`, the synchronous read and the live change through the app, and a loop that never starts under reduce motion and starts when the switch flips. `test/style.test.js`: the easing parity.
- The three benches the diff owes (`npm run bench:touched`): the X11 protocol gate — no regressions; the pixel gate — unchanged; the Cocoa presenter gate — every rule passes except `covered`, which fails on this machine for origin/master too: alternating runs of that one scenario gave 354 and 355 frames on master against 309 and 355 on the branch, so AppKit is simply not reporting our own cover window as occluding here, and the macOS CI runner is the judge of that rule.
- **On a real display**, over the installed 0.5.0 bridge, with `presenter: 'layers'`: a box's `backgroundColor` transition ran with the entry `offloaded`, the animating set empty and the style at the model value; `presentationValue` mid-flight read `0.46,0.10,0.39` → `0.18,0.08,0.72` → `0.06,0.05,0.92` → `0.01,0.01,0.99` (red to blue, easing out); the end event left the entry gone and the registry empty; a retarget mid-flight left one live animation per node and settled on the model; `desktopSettings()` answered `source: 'macos'` with `animations: true` on this machine. The Reduce motion switch itself was not flipped here — it is this machine's accessibility setting — so the live change is covered by the fake-bridge test and the bridge's own test seam.

## Not here, in the order the design sequences them

The easing vocabulary and the transition object form, timelines (`keyframes`, `repeat`, `delay`, `key`, the completion events), `opacity`, the transforms, and springs — the design's §3, each on both backends. The offload extends to each as it lands: `opacity` and the transforms on raster visuals too, which is where it pays most.
