### PR TITLE
fix(cocoa): a width offer of zero is the min-content question, not an unbounded line

### DIFF
--- a/docs/macos.md
+++ b/docs/macos.md
@@ -568,7 +568,18 @@ implements it over CoreText:
   attribute ranges — the nested-`<text>` model transfers directly).
 - **Metrics for yoga**: the same framesetter answers `measureContent`,
   so measure and render cannot disagree. Whole-pixel answers, per the
-  yoga content-floor rules.
+  yoga content-floor rules. **A width offer of zero is the min-content
+  question**, not a degenerate layout — it is how yoga measures the floor
+  under `minWidth: 'auto'` — and CoreText cannot be asked it directly: its
+  breaker makes progress whatever width it is given, so a paragraph offered
+  zero (or a pixel) comes back broken _inside_ its words. So the engine
+  breaks the text itself, at the UAX#14 opportunities of the same
+  `linebreak` package ntk wraps with, and has CoreText shape and measure the
+  result — one unbreakable run per line, whose widest is the longest word.
+  Both backends therefore agree on where a line may break and on what a
+  `<text>` in a flex item is allowed to shrink to
+  (`brokenAtEveryOpportunity`, src/cocoa/fonts.js;
+  test/cocoa-text-floor.test.js).
 - **Carets/hit/selection**: `CTLineGetStringIndexForPosition`,
   `CTLineGetOffsetForStringIndex`, line origins → `indexAt`,
   `caretPosition`, `rangeBands` — the `<textinput>`/selection surface,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.6.1",
       "license": "MIT",
       "dependencies": {
+        "linebreak": "^1.1.0",
         "ntk": "^8.7.0",
         "react-reconciler": "^0.33.0",
         "yoga-layout": "^3.2.1"

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "node": ">=20.19"
   },
   "dependencies": {
+    "linebreak": "^1.1.0",
     "ntk": "^8.7.0",
     "react-reconciler": "^0.33.0",
     "yoga-layout": "^3.2.1"

--- a/src/cocoa/fonts.js
+++ b/src/cocoa/fonts.js
@@ -25,6 +25,7 @@
 import { readFileSync } from 'node:fs';
 import { inflateSync } from 'node:zlib';
 
+import LineBreaker from 'linebreak';
 import { cssColorStraight, Font } from 'ntk';
 
 import { loadNative } from './native.js';
@@ -142,6 +143,78 @@ class CocoaTextLayout {
   caretPosition(cp) {
     return this._native.layoutCaret(this._handle, this._cuOf(cp));
   }
+}
+
+/**
+ * What a break at the end of a run consumes: the trailing whitespace ntk's
+ * tokenizer strips — a line's width never counts it, on either engine — and
+ * a hard line break, which is an opportunity the text already spells out and
+ * must not become a second one (an empty line in the measurement).
+ */
+const RUN_TAIL = /[ \t\u00a0]*(?:\r\n|[\n\r\u2028\u2029])?[ \t\u00a0]*$/;
+
+/**
+ * The same spans with a hard break at every UAX#14 line-break opportunity,
+ * and the whitespace each break consumes dropped: one unbreakable run per
+ * line. Laid out with no width bound, the widest line is then the longest
+ * word — which is the answer to "how narrow can you be?", CSS's min-content.
+ *
+ * **Why the text is broken here rather than by asking CoreText for a narrow
+ * line.** CoreText's line breaker must make progress whatever width it is
+ * given, so a paragraph offered zero (or a pixel) comes back broken *inside*
+ * its words: the caption in examples/animation.jsx measures 61 lines and 13px
+ * wide, a floor of one character. A floor under the longest word is worse
+ * than no floor at all — it lets a flex column shrink to where the text has
+ * nowhere left to wrap. Breaking the text here asks CoreText only to shape
+ * and measure, which is the half of it that has no opinion.
+ *
+ * The opportunities come from the `linebreak` package **ntk breaks its own
+ * lines with**, so the two engines agree on where a line may break and a
+ * tree measures the same on both backends.
+ */
+function brokenAtEveryOpportunity(spans) {
+  const text = spans.map((span) => span.text).join('');
+  if (!text) return spans;
+  // Each run is [start, end) with its trailing whitespace trimmed off, so a
+  // line is as wide as its ink — the same measurement ntk reports, which
+  // strips the trailing run too.
+  const runs = [];
+  const breaker = new LineBreaker(text);
+  let start = 0;
+  for (let bk = breaker.nextBreak(); bk; bk = breaker.nextBreak()) {
+    const run = text.slice(start, bk.position);
+    runs.push([start, bk.position - (RUN_TAIL.exec(run)?.[0].length ?? 0)]);
+    start = bk.position;
+  }
+  if (start < text.length) runs.push([start, text.length]);
+  if (runs.length < 2) return spans; // one run: nothing may break anyway
+
+  // Where each span sits in that text, so a run can be cut out of the spans
+  // it crosses — a break between two `<text>` children of different sizes is
+  // an ordinary opportunity, and the two sides keep their own faces.
+  const placed = [];
+  let at = 0;
+  for (const span of spans) {
+    placed.push({ span, start: at, end: (at += span.text.length) });
+  }
+  const out = [];
+  let previous = spans[0];
+  runs.forEach(([from, to], i) => {
+    // The separator carries the attributes of the span before it: the native
+    // needs a font on every span, and a newline draws nothing.
+    if (i > 0) out.push({ ...previous, text: '\n' });
+    for (const p of placed) {
+      const a = Math.max(from, p.start);
+      const b = Math.min(to, p.end);
+      if (b <= a) continue;
+      previous = p.span;
+      out.push({
+        ...p.span,
+        text: p.span.text.slice(a - p.start, b - p.start),
+      });
+    }
+  });
+  return out;
 }
 
 const ALIGN_FLUSH = { left: 0, center: 0.5, right: 1 };
@@ -809,8 +882,19 @@ export class CocoaFontManager {
         ...(color == null ? {} : { color: parseColor(color) }),
       });
     }
+    // A width offer of zero is a question, not a degenerate layout: yoga
+    // asks it to find the node's min-content floor (`minWidth: 'auto'`,
+    // nodes.js). It used to fall into the `undefined` below and answer
+    // max-content — the whole paragraph on one line — so a `<text>` in a
+    // flex item held its container open at its longest line and two equal
+    // columns came out 823px and 34px wide. `brokenAtEveryOpportunity` is
+    // the answer instead.
+    const minContent = Number.isFinite(maxWidth) && maxWidth <= 0;
+    const laid = minContent
+      ? brokenAtEveryOpportunity(nativeSpans)
+      : nativeSpans;
     const raw = this._native.createLayout({
-      spans: nativeSpans,
+      spans: laid,
       maxWidth:
         Number.isFinite(maxWidth) && maxWidth > 0 ? maxWidth : undefined,
       align: flushFor(align, direction),
@@ -819,7 +903,14 @@ export class CocoaFontManager {
       ellipsis: overflow === 'ellipsis',
       rtl: direction === 'rtl',
     });
-    const layout = new CocoaTextLayout(this._native, raw, text);
+    // the text the native actually laid out: a min-content measurement's
+    // line and run ranges are indices into the broken text, and the two have
+    // to agree for `indexAt`/`caretPosition` to mean anything at all
+    const layout = new CocoaTextLayout(
+      this._native,
+      raw,
+      minContent ? laid.map((span) => span.text).join('') : text,
+    );
     layout._contextInk = contextInk;
     this._layouts.set(signature, layout);
     if (this._layouts.size > 64) {

--- a/test/cocoa-text-floor.test.js
+++ b/test/cocoa-text-floor.test.js
@@ -1,0 +1,203 @@
+// The Cocoa text engine's answer to "how narrow can you be?" — the
+// min-content floor yoga measures every `<text>` for (`minWidth: 'auto'`,
+// nodes.js `contentSpan`), which arrives at `fonts.layout()` as a width
+// offer of zero.
+//
+// It used to be read as "no bound at all" and answered with the whole
+// paragraph on one line, so a `<text>` held its flex item open at its
+// longest line: two `flexGrow: 1, flexBasis: 0` columns in a 400px row came
+// out 823px and 34px wide and the second one left the window, where the same
+// tree on X11 wrapped at the longest word.
+//
+// Two layers, as in cocoa-glyph-runs.test.js. The first runs everywhere: a
+// fake bridge, asserting what reaches `createLayout` — which is the whole of
+// what this engine decides, since CoreText only shapes what it is handed.
+// The second runs where the real bridge loads and measures the pixels: the
+// floor is the longest word, to the same fraction as measuring that word
+// alone.
+import assert from 'node:assert';
+import { describe, test } from 'node:test';
+
+import { CocoaFontManager } from '../src/cocoa/fonts.js';
+import { loadNative } from '../src/cocoa/native.js';
+
+// --- the fake bridge ----------------------------------------------------------
+
+/**
+ * A bridge shaped like the font and layout natives `layout()` reaches:
+ * handles by family and size, and a `createLayout` that records what it was
+ * given rather than shaping anything.
+ */
+function fakeNative() {
+  const layouts = [];
+  return {
+    layouts,
+    matchFont: ({ families, size }) => ({ family: families[0], size }),
+    fontApplyVariations: (handle) => handle,
+    createLayout(options) {
+      layouts.push(options);
+      return { handle: layouts.length, width: 0, height: 0, lines: [] };
+    },
+  };
+}
+
+/** The text of each span the native was handed, last call. */
+const textsOf = (native) => native.layouts.at(-1).spans.map((s) => s.text);
+
+describe('the min-content floor', () => {
+  const base = { family: 'sans-serif', size: 14 };
+
+  test('a width offer of zero breaks the text at every opportunity', () => {
+    const native = fakeNative();
+    const fonts = new CocoaFontManager(native);
+    fonts.layout([{ text: 'Plain boxes. On the render server.' }], base, {
+      maxWidth: 0,
+    });
+
+    assert.deepStrictEqual(textsOf(native), [
+      'Plain',
+      '\n',
+      'boxes.',
+      '\n',
+      'On',
+      '\n',
+      'the',
+      '\n',
+      'render',
+      '\n',
+      'server.',
+    ]);
+    // The space each break consumed is gone rather than sitting at the end
+    // of a line: CoreText's line width would count it, and ntk's does not.
+    assert.strictEqual(
+      native.layouts.at(-1).maxWidth,
+      undefined,
+      'the breaks are in the text, so the layout itself is unbounded',
+    );
+  });
+
+  test('a real width is not broken up — CoreText wraps it', () => {
+    const native = fakeNative();
+    const fonts = new CocoaFontManager(native);
+    const text = 'Plain boxes. On the render server.';
+    fonts.layout([{ text }], base, { maxWidth: 194 });
+    assert.deepStrictEqual(textsOf(native), [text]);
+    assert.strictEqual(native.layouts.at(-1).maxWidth, 194);
+  });
+
+  test('no width at all is still max-content: one line, nothing broken', () => {
+    const native = fakeNative();
+    const fonts = new CocoaFontManager(native);
+    const text = 'Plain boxes. On the render server.';
+    fonts.layout([{ text }], base, {});
+    assert.deepStrictEqual(textsOf(native), [text]);
+    assert.strictEqual(native.layouts.at(-1).maxWidth, undefined);
+  });
+
+  test('a break between two spans leaves each side its own face', () => {
+    const native = fakeNative();
+    const fonts = new CocoaFontManager(native);
+    fonts.layout(
+      [{ text: 'small ' }, { text: 'BIG', size: 28 }, { text: ' after' }],
+      base,
+      { maxWidth: 0 },
+    );
+    const spans = native.layouts.at(-1).spans;
+    assert.deepStrictEqual(
+      spans.map((s) => s.text),
+      ['small', '\n', 'BIG', '\n', 'after'],
+    );
+    assert.strictEqual(spans[2].font.size, 28, 'the big span kept its size');
+    assert.strictEqual(spans[4].font.size, 14);
+  });
+
+  test('a word that cannot break is one run, whatever it is offered', () => {
+    const native = fakeNative();
+    const fonts = new CocoaFontManager(native);
+    fonts.layout([{ text: 'supercalifragilistic' }], base, { maxWidth: 0 });
+    assert.deepStrictEqual(textsOf(native), ['supercalifragilistic']);
+  });
+
+  test('a hard newline in the text is an opportunity like any other', () => {
+    const native = fakeNative();
+    const fonts = new CocoaFontManager(native);
+    fonts.layout([{ text: 'one\ntwo three' }], base, { maxWidth: 0 });
+    assert.deepStrictEqual(textsOf(native), [
+      'one',
+      '\n',
+      'two',
+      '\n',
+      'three',
+    ]);
+  });
+});
+
+// --- over the real bridge -----------------------------------------------------
+
+let bridge = null;
+try {
+  bridge = loadNative();
+} catch {
+  bridge = null;
+}
+
+describe(
+  'over the real bridge',
+  {
+    skip: bridge ? false : 'the @windowkit/appkit bridge is not loadable here',
+  },
+  () => {
+    const base = { family: 'sans-serif', size: 14 };
+    const TEXT =
+      'Plain boxes. On the macOS layer presenter these run in the render server.';
+
+    test('the floor is the longest word, not the whole line', () => {
+      const fonts = new CocoaFontManager(bridge);
+      const at = (maxWidth) =>
+        fonts.layout([{ text: TEXT }], base, { maxWidth });
+
+      const maxContent = at(undefined).width;
+      const minContent = at(0).width;
+      const longestWord = Math.max(
+        ...TEXT.split(' ').map(
+          (word) => fonts.layout([{ text: word }], base, {}).width,
+        ),
+      );
+
+      assert.ok(
+        Math.abs(minContent - longestWord) < 0.5,
+        `min-content ${minContent} is the longest word ${longestWord}`,
+      );
+      assert.ok(
+        minContent < maxContent / 4,
+        `min-content ${minContent} is far under max-content ${maxContent}`,
+      );
+      // …and it is a floor the text can actually be laid out at: wrapped at
+      // it, no word is left hanging over the edge. The allowance is one
+      // space: CoreText's line width counts a line's trailing whitespace and
+      // ntk's does not, which is why the floor is measured with the breaks
+      // in the text rather than read off a wrap.
+      const wrapped = at(minContent);
+      assert.ok(
+        wrapped.width <= minContent + base.size,
+        `wrapped at its floor, the widest line is ${wrapped.width}`,
+      );
+      assert.ok(wrapped.height > maxContent / minContent, 'many lines');
+    });
+
+    test('a paragraph offered a pixel still breaks inside its words', () => {
+      // The reason the text is broken in the engine rather than by asking
+      // CoreText for a narrow line: below the floor, CoreText's breaker
+      // makes progress by splitting words, which is a floor of one
+      // character. ntk does the same under its own floor, so this is not a
+      // disagreement — it is why zero cannot be spelled as "very small".
+      const fonts = new CocoaFontManager(bridge);
+      const pixel = fonts.layout([{ text: TEXT }], base, { maxWidth: 1 });
+      const floor = fonts.layout([{ text: TEXT }], base, { maxWidth: 0 });
+      assert.ok(
+        pixel.width < floor.width / 3,
+        `a pixel offer measures ${pixel.width}, the floor is ${floor.width}`,
+      );
+    });
+  },
+);


### PR DESCRIPTION
Yoga measures a leaf's min-content floor by offering it no width at all — that is how `minWidth: 'auto'` is resolved. The Cocoa text engine read that offer as "no bound" and answered max-content: the whole paragraph on one line.

So a `<text>` held its flex item open at its longest line. Two columns with equal grow and a zero basis in a 400 px row measured 823 px and 34 px, and the second one left the window. The same tree on X11 wraps at the longest word.

![floor-before](https://github.com/user-attachments/assets/26d0d038-14fe-4907-a2e8-256b7fc63b3f)

Before, on this Mac: one column, running off the edge, and the second nowhere on screen.

![floor-after](https://github.com/user-attachments/assets/0590c867-7c19-47a3-a01c-f68116636593)

After, the same tree unchanged.

**Why the text is broken in the engine rather than asked of CoreText.** CoreText's line breaker has to make progress whatever width it is given, so a paragraph offered zero — or a pixel — comes back broken *inside* its words: the caption above measures 61 lines and 13 px wide, a floor of one character. A floor under the longest word is worse than no floor, because it lets a column shrink to where the text has nowhere left to wrap. The native treats a `maxWidth` of zero as unbounded too, so this could not be fixed by passing the offer straight through.

Instead the engine breaks the text itself at the UAX#14 opportunities of the same `linebreak` package **ntk wraps its own lines with**, drops the whitespace each break consumes the way ntk's line measurement does, and hands CoreText one unbreakable run per line to shape and measure. The widest line is then the longest word. The two engines now agree on where a line may break and on how narrow a `<text>` may be, which is the property that matters: a tree measures the same on both backends.

`linebreak` joins `dependencies`. It is already in the tree as ntk's own dependency, so nothing new is installed, and sharing it is the point rather than a convenience.

Nothing else moves: a real width still goes to CoreText to wrap, and no width at all is still max-content on one line.

**Test.** `test/cocoa-text-floor.test.js`, in the two layers `cocoa-glyph-runs.test.js` uses. Over a fake bridge, which runs everywhere including Linux CI: an offer of zero reaches the native as one span per unbreakable run separated by hard breaks, with the consumed whitespace gone and no width bound; a real width and no width at all are passed through untouched; a break between two spans leaves each side its own face. Over the real bridge, skipped where it cannot load: the measured floor is the longest word to within half a pixel and under a quarter of max-content, and wrapping at that floor leaves no word hanging over the edge.

Two things the test records that are worth knowing. A hard newline already in the text is an opportunity, so it must not become a second one and an empty line in the measurement. And CoreText counts a line's trailing whitespace where ntk does not, which is a small pre-existing difference in the width of a wrapped paragraph, left alone here.

Found while rendering `examples/animation.jsx` for #480. That PR says `minWidth: 0` on its columns and captions, which is the CSS idiom anyway, so it does not depend on this one.

Locally: the new suite, lint, typecheck and `prettier --check .` pass. The full suite is 1958 pass and 7 fail — the six known macOS-only `appearance.test.js` failures that pass in CI, and one `globalmenu.test.js` timeout on a real bus that passes 22/22 when that file runs alone.

