### PR TITLE
fix(cocoa): a drag renders from the callback that reports it, so the preview follows the pointer

### DIFF
--- a/docs/drag-and-drop.md
+++ b/docs/drag-and-drop.md
@@ -440,6 +440,7 @@ return (
     {isDragging && (
       <popup
         dragPreview
+        transparent
         x={position.x + 14}
         y={position.y + 14}
         width={180}
@@ -458,6 +459,14 @@ return (
 `null` otherwise. **`dragPreview` on the `<popup>` is required**: it tells
 the router that this window is the preview, not something under the
 pointer, and without it the drag would immediately land on its own preview.
+
+`transparent` is not required, but a preview usually wants it: the popup is
+a real window, so a card with a `borderRadius` on an opaque one shows the
+window's own ground in the four corners the radius gives up. With it, the
+corners are the desktop, antialiased — and where no compositor is running
+the window falls back to filling itself square, which is what it looked
+like anyway. See
+[`transparent`](elements.md#transparent--rounded-corners-and-translucency).
 
 ## The two transports
 

--- a/docs/drag-and-drop.md
+++ b/docs/drag-and-drop.md
@@ -513,11 +513,21 @@ Platform notes:
   are UTIs, and react-x11's MIME vocabulary maps onto them through the OS's
   own type database — a private `application/x-myapp-…` travels between two
   react-x11 apps as a `dyn.*` type every process computes alike. Two things
-  differ from X11: the payload is read **at the drop** (the pasteboard is the
+  differ from X11. The payload is read **at the drop** (the pasteboard is the
   source's promise, and it may withdraw it once its session ends), so
-  `getData()` answers from that read; and there is no drag image of your
-  own yet — AppKit's session carries a blank one, and a `<popup dragPreview>`
-  does not follow the pointer there.
+  `getData()` answers from that read. And the gesture runs inside AppKit's
+  own tracking loop, which owns the thread from the threshold to the
+  release: no timer of ours fires and no frame clock ticks in between, so
+  every frame of a drag is painted from the callback that reported it, and
+  every render a drag schedules — a `<popup dragPreview>` following
+  `useDragSource().position`, a `useDropTarget` hint, an insertion marker —
+  is dispatched at discrete priority and landed there. The preview follows
+  the pointer as it does on X11, and because a `<popup>` here is a
+  non-activating panel at the pop-up-menu window level — above every other
+  application's windows, which sit at the normal level — it is what the
+  desktop sees while the pointer is over Finder or a browser. What AppKit's
+  own session carries is still a blank image: the drag has no bitmap of the
+  system's, only the preview you draw.
 - **macOS / XQuartz** — X client to X client works. Dragging from **Finder**
   into an X11 window does not, and never has:
   [XQuartz#173](https://github.com/XQuartz/XQuartz/issues/173). That is the

--- a/examples/dnd-source.jsx
+++ b/examples/dnd-source.jsx
@@ -15,7 +15,10 @@
 //     serialisation), and 'move' removes the card from the shelf.
 //   - useDragSource: `isDragging` + `position` drive a live drag preview in
 //     a `<popup dragPreview>` following the pointer — a React tree, not a
-//     bitmap — and a `:dragging` style block dims the source card.
+//     bitmap — and a `:dragging` style block dims the source card. The
+//     preview popup is `transparent` so the card's rounded corners are the
+//     preview's own: an opaque window would show its ground in the four
+//     corners the radius gives up.
 import React, { useState } from 'react';
 import { createRoot, createStyles, useDragSource } from '../src/index.js';
 
@@ -50,6 +53,7 @@ function Card({ file, onMoved }) {
       {isDragging && (
         <popup
           dragPreview
+          transparent
           x={position.x + 14}
           y={position.y + 14}
           width={180}

--- a/src/cocoa/app.js
+++ b/src/cocoa/app.js
@@ -16,6 +16,7 @@ import { cssColorStraight } from 'ntk';
 
 import { deliverActivate, deliverOpen } from '../application.js';
 import { flushPendingFrames } from '../frames.js';
+import { flushSyncWork } from '../priority.js';
 import { setCompositingForTests } from '../compositing.js';
 import { setScreensForTests } from '../screens.js';
 import { setScaleForTests } from '../scale.js';
@@ -638,9 +639,21 @@ export class CocoaApp {
     for (const wnd of this._windows.values()) wnd.present();
   }
 
-  /** After any synchronously dispatched input: paint the response now (the
-   * same early flush a discrete event gets on X11) and put it on glass. */
+  /**
+   * After any synchronously dispatched input: land React's half of the
+   * response, paint it (the same early flush a discrete event gets on X11 —
+   * `discrete` in events.js) and put it on glass.
+   *
+   * `flushSyncWork` is not belt and braces. A discrete-priority update is
+   * committed on a **microtask**, and a microtask does not run until the
+   * call that dispatched the event returns to Node — which, inside one of
+   * AppKit's modal loops (a live resize, menu tracking, a dragging
+   * session), is after the whole gesture. Without it a handler's own
+   * `setState` reaches the screen when the gesture ends, and the gesture is
+   * exactly when it was worth showing.
+   */
   _afterInput() {
+    flushSyncWork();
     flushPendingFrames();
     this._presentAll();
   }
@@ -694,10 +707,14 @@ export class CocoaApp {
       case 'drag-perform':
         return this._routeDrop(ev);
       case 'drag-session-began':
+        // `draggingSession:willBeginAtPoint:`, dispatched from inside
+        // `beginDrag` — before the `onDragStart` handler's own render has
+        // been asked for, so there is nothing to flush yet. The frame that
+        // shows the drag beginning goes out from `CocoaWindow.beginDrag`,
+        // on the way back past it.
         return undefined;
       case 'drag-session-moved':
-        this._activeDrag?.nativeMoved(ev);
-        return undefined;
+        return this._routeDragMoved(ev);
       case 'drag-session-ended':
         return this._routeDragEnded(ev);
       case 'app-open-urls':
@@ -910,6 +927,20 @@ export class CocoaApp {
     const wnd = this._window(ev);
     if (!wnd || wnd.destroyed) return;
     wnd._dropTransport?.handle(ev);
+    this._afterInput();
+  }
+
+  /**
+   * `draggingSession:movedToPoint:` — the source's own view of the gesture,
+   * and the only thing that arrives while AppKit tracks it: the pointer's
+   * `mousemove` stops, `pump2` does not return until the drop, and no timer
+   * or microtask of ours runs in between. So the frame belongs to the
+   * callback, like the destination's (`_routeDrop`) — that is what lets a
+   * `<popup dragPreview>` follow the pointer, and an `onDrag` that moves an
+   * insertion marker move it during the drag rather than on the release.
+   */
+  _routeDragMoved(ev) {
+    this._activeDrag?.nativeMoved(ev);
     this._afterInput();
   }
 

--- a/src/cocoa/dnd.js
+++ b/src/cocoa/dnd.js
@@ -44,6 +44,7 @@
 // identifier for a MIME type no declared type claims is computed alike by
 // every process — how `application/x-myapp-…` travels between two react-x11
 // apps) and back (`pasteboardTypeInfo`).
+import { runWithPriority, DiscreteEventPriority } from '../priority.js';
 import {
   TEXT_TARGETS,
   TYPE_GROUPS,
@@ -254,6 +255,15 @@ export class CocoaDropTransport {
     this.session = session;
     this.node = node;
     this._registered = null;
+    // AppKit tracks the whole drag on this thread: the pump does not return
+    // until the drop, so nothing an enter/over dispatch schedules — a
+    // `useDropTarget` lighting its "drop here" label, any handler's
+    // `setState` — has a frame tick or a microtask to land on. Discrete is
+    // the one lane the app can land by hand from inside the callback
+    // (src/cocoa/app.js `_afterInput`), which is where the answer to
+    // AppKit's question is painted. The renderer's own `:drag-over` needs
+    // none of this and never did.
+    session.hoverPriority = DiscreteEventPriority;
     this.refreshTypes();
   }
 
@@ -326,7 +336,8 @@ export class CocoaDropTransport {
 
   _leave(ev) {
     const drag = this._local(ev);
-    this.session.localLeave();
+    // the leaving half of the same stream, in the same lane as the enter
+    runWithPriority(DiscreteEventPriority, () => this.session.localLeave());
     if (drag) drag.accepted = false;
   }
 

--- a/src/cocoa/window.js
+++ b/src/cocoa/window.js
@@ -312,13 +312,23 @@ export class CocoaWindow {
    * The source side: hand a DragSession's gesture to an NSDraggingSession
    * (see src/cocoa/dnd.js for what the spec carries). Returns at once; the
    * session reports back as `drag-session-*` events.
+   *
+   * And the pump stops here. AppKit tracks the gesture on this thread, so
+   * `pump2` does not return until the drop and no timer of ours runs in
+   * between — the frame that shows the drag has begun (a `<popup
+   * dragPreview>` mounted by `onDragStart`, a source dimmed by
+   * `:dragging`) has to go out on the way past. Motion is otherwise paced
+   * on the frame clock and not flushed per event (`_routeMotion`); this is
+   * the one motion whose answer has no next tick to wait for.
    */
   beginDrag(session) {
     if (this.destroyed) return null;
-    return this._native.beginDrag(
+    const began = this._native.beginDrag(
       this._h,
       dragSpec(session, this._native, this.scale),
     );
+    this.app._afterInput();
+    return began;
   }
 
   setTransientFor() {

--- a/src/dnd.js
+++ b/src/dnd.js
@@ -258,6 +258,13 @@ export class DropSession {
     // FIFO gate: messages queue behind atom interning and XdndEnter's
     // async type-list resolution, so a Position never overtakes its Enter.
     this._chain = Promise.resolve();
+    // The lane an enter/over dispatch schedules its renders in. Continuous
+    // by default, because a drag hovering is a stream like the pointer's
+    // own and the frame clock paces it. A transport whose backend *stops*
+    // that clock for the duration of the drag raises it — the cocoa one
+    // does (src/cocoa/dnd.js), because inside AppKit's tracking loop a
+    // render scheduled for the next frame lands after the drop.
+    this.hoverPriority = ContinuousEventPriority;
     this._reset();
   }
 
@@ -470,7 +477,7 @@ export class DropSession {
       action: this.requestedAction,
       freeze: false,
     };
-    runWithPriority(ContinuousEventPriority, () => {
+    runWithPriority(this.hoverPriority, () => {
       this._updateDragPath(path, native);
       // onDragOver may override the declarative answer, synchronously —
       // same latency budget as any event handler, no render awaited
@@ -1258,20 +1265,6 @@ export class DragSession {
       Array.isArray(actions) && actions.length > 0 ? actions : ['copy'];
     this.currentAction = this.actions[0];
     this._resolved = new Map();
-    const ev = this.node.events.dispatch('DragStart', source, native, {
-      types: this.types,
-      action: this.currentAction,
-      source: 'internal',
-      screenX: (native.rootx ?? native.x) / this.node.events.scale,
-      screenY: (native.rooty ?? native.y) / this.node.events.scale,
-    });
-    if (ev.defaultPrevented) {
-      this._reset();
-      return false;
-    }
-    this.phase = 'dragging';
-    source.setStyleState(':dragging', true);
-    this._setCursor('grab');
     // A backend with a drag session of its own (the cocoa backend's
     // NSDraggingSession, src/cocoa/dnd.js) takes the gesture from here:
     // the pointer's motion and release stop arriving and come back as
@@ -1279,7 +1272,34 @@ export class DragSession {
     // comes through that window's destination events, routed to this
     // session's live payload by `app._activeDrag`.
     const wnd = this.node.window;
-    if (typeof wnd?.beginDrag === 'function') {
+    const nativeSession = typeof wnd?.beginDrag === 'function';
+    // …and it owns the thread for the *whole* gesture, so anything this
+    // dispatch schedules for later has no later: the `<popup dragPreview>`
+    // an `onDragStart` setState renders would otherwise be created after
+    // the drop. Discrete priority puts the update in the one lane a
+    // backend can land by hand from inside a callback (`flushSyncWork`,
+    // src/cocoa/app.js `_afterInput`). Where the frame clock keeps running,
+    // the motion this arrived on is paced like any other and the update
+    // keeps the priority the dispatcher gave it.
+    const startEvent = () =>
+      this.node.events.dispatch('DragStart', source, native, {
+        types: this.types,
+        action: this.currentAction,
+        source: 'internal',
+        screenX: (native.rootx ?? native.x) / this.node.events.scale,
+        screenY: (native.rooty ?? native.y) / this.node.events.scale,
+      });
+    const ev = nativeSession
+      ? runWithPriority(DiscreteEventPriority, startEvent)
+      : startEvent();
+    if (ev.defaultPrevented) {
+      this._reset();
+      return false;
+    }
+    this.phase = 'dragging';
+    source.setStyleState(':dragging', true);
+    this._setCursor('grab');
+    if (nativeSession) {
       this._nativeSession = true;
       this.app._activeDrag = this;
       try {
@@ -1295,7 +1315,12 @@ export class DragSession {
   }
 
   /** `drag-session-moved` on a native session: the source's `onDrag`, in
-   * global device pixels, with whether a window of ours has accepted. */
+   * global device pixels, with whether a window of ours has accepted.
+   *
+   * Discrete priority, like the start: this is the only news of the gesture
+   * that arrives while the native session owns the thread, so the render it
+   * schedules has to be landable from inside the callback. A preview that
+   * follows the pointer is exactly a render per position. */
   nativeMoved(ev) {
     if (this.phase !== 'dragging' || !this._nativeSession) return;
     const s = this.node.scale;
@@ -1312,18 +1337,20 @@ export class DragSession {
     };
     const source = this.source;
     if (source && !source.destroyed && source.props.onDrag) {
-      callHandler(
-        source,
-        'onDrag',
-        source.props.onDrag,
-        this.node.events._makeEvent('drag', native, source, {
-          types: this.types,
-          action: this.currentAction,
-          source: this.localSession ? 'internal' : 'external',
-          accepted: this.accepted,
-          screenX: rootX / this.node.events.scale,
-          screenY: rootY / this.node.events.scale,
-        }),
+      runWithPriority(DiscreteEventPriority, () =>
+        callHandler(
+          source,
+          'onDrag',
+          source.props.onDrag,
+          this.node.events._makeEvent('drag', native, source, {
+            types: this.types,
+            action: this.currentAction,
+            source: this.localSession ? 'internal' : 'external',
+            accepted: this.accepted,
+            screenX: rootX / this.node.events.scale,
+            screenY: rootY / this.node.events.scale,
+          }),
+        ),
       );
     }
   }
@@ -1343,10 +1370,20 @@ export class DragSession {
     const rootY = Math.round((ev.y ?? 0) * s);
     const operation =
       ev.operation && ev.operation !== 'none' ? ev.operation : null;
-    this._end(
-      { x: rootX - origin.x, y: rootY - origin.y, rootx: rootX, rooty: rootY },
-      ev.dropped ? operation : null,
-      Boolean(ev.dropped),
+    // the release, and the last callback before the thread comes back:
+    // `onDragEnd` takes the preview down, and that is a discrete answer to
+    // the button like any other
+    runWithPriority(DiscreteEventPriority, () =>
+      this._end(
+        {
+          x: rootX - origin.x,
+          y: rootY - origin.y,
+          rootx: rootX,
+          rooty: rootY,
+        },
+        ev.dropped ? operation : null,
+        Boolean(ev.dropped),
+      ),
     );
   }
 

--- a/test/cocoa-dnd.test.js
+++ b/test/cocoa-dnd.test.js
@@ -9,7 +9,7 @@ import assert from 'node:assert';
 import { afterEach, describe, test } from 'node:test';
 import React from 'react';
 
-import { createRoot } from '../src/index.js';
+import { createRoot, useDragSource, useDropTarget } from '../src/index.js';
 import { CocoaApp } from '../src/cocoa/app.js';
 import {
   BASE_DROP_UTIS,
@@ -85,8 +85,10 @@ function fakeNative() {
     windowNumber: (handle) => handle.id,
     windowRootLayer: (handle) => ({ root: handle.id }),
     getWindowFrame: (handle) => ({
-      x: 0,
-      y: 0,
+      // where it was asked for: a popup's position arrives as createWindow2
+      // options and is read back through the frame (`_refreshOrigin`)
+      x: handle.options.x ?? 0,
+      y: handle.options.y ?? 0,
       width: handle.options.width,
       height: handle.options.height,
     }),
@@ -299,6 +301,35 @@ describe('the drop side', () => {
     assert.equal(zone.current.states[':drag-over'], false, 'the path cleared');
   });
 
+  test("a target's own render lands inside the callback, not on the release", async () => {
+    // The other half of #482: a `useDropTarget` label ("drop here") is a
+    // React render, and AppKit's tracking loop has stopped the pump — so it
+    // has to land on the callback that asked the question. `:drag-over` is
+    // the renderer's own and never needed one; this is what it looks like
+    // when the app renders the answer itself. No awaits below, on purpose.
+    const native = fakeNative();
+    const app = appOver(native);
+    const root = await createRoot({ app });
+    roots.push(root);
+    const label = React.createRef();
+    const Zone = () => {
+      const { dropProps, isOver } = useDropTarget({ accept: ['files'] });
+      return h(
+        'box',
+        { ...dropProps, style: { width: 300, height: 200 } },
+        isOver && h('box', { ref: label, style: { width: 80, height: 20 } }),
+      );
+    };
+    root.render(h('window', { width: 300, height: 200 }, h(Zone)));
+    await settle(app);
+    const n = [...app._windows.values()][0].windowNumber;
+
+    native.emit(dragEvent('drag-enter', n, 10, 10));
+    assert.ok(label.current, 'the hint is up while the pointer is over it');
+    native.emit({ type: 'drag-exit', windowNumber: n });
+    assert.equal(label.current, null, 'and gone when it leaves');
+  });
+
   test('a type nothing accepts is refused from dropAccept data alone, and exit clears', async () => {
     const native = fakeNative();
     const app = appOver(native);
@@ -352,6 +383,8 @@ describe('the drag side', () => {
       buttons: 256,
       time: 2,
     });
+  /** the app's first window — the one the tree is rendered into */
+  const wndOf = (app) => [...app._windows.values()][0];
 
   test('crossing the threshold hands the gesture to AppKit with the payload as pasteboard items', async () => {
     const native = fakeNative();
@@ -427,6 +460,74 @@ describe('the drag side', () => {
     assert.equal(source.current.states[':dragging'], false);
     assert.equal(app._activeDrag, null);
     assert.ok(!log.some((l) => l[0] === 'click'));
+  });
+
+  test('the preview follows the pointer while AppKit owns the thread', async () => {
+    // The regression this exists for (#482): once `beginDrag` hands the
+    // gesture over, AppKit tracks it on this thread — `pump2` does not
+    // return until the drop, so no timer, no frame tick and no microtask of
+    // ours runs in between. Every assertion below is therefore made with
+    // **no await and no `_tickFrames`**: what does not reach the screen
+    // inside the callback does not reach it until the gesture is over.
+    const native = fakeNative();
+    const app = appOver(native);
+    const root = await createRoot({ app });
+    roots.push(root);
+    const Draggable = () => {
+      const { dragProps, isDragging, position } = useDragSource({
+        data: { 'text/plain': 'a row' },
+      });
+      return h(
+        React.Fragment,
+        null,
+        h('box', {
+          ...dragProps,
+          style: {
+            position: 'absolute',
+            left: 0,
+            top: 0,
+            width: 100,
+            height: 100,
+          },
+        }),
+        isDragging &&
+          h('popup', {
+            dragPreview: true,
+            x: position.x + 14,
+            y: position.y + 14,
+            width: 90,
+            height: 20,
+          }),
+      );
+    };
+    root.render(h('window', { width: 300, height: 200 }, h(Draggable)));
+    await settle(app);
+    assert.equal(app._windows.size, 1, 'the window, and no preview yet');
+
+    press(wndOf(app), 50, 50);
+    move(wndOf(app), 70, 50); // past the threshold
+    assert.equal(native.of('beginDrag').length, 1, 'AppKit has the gesture');
+    const preview = [...app._windows.values()][1];
+    assert.ok(preview, 'the preview is on screen before AppKit takes over');
+    // press at device (70, 50), scale 2 → screen point 35, plus the offset,
+    // and a popup's x/y prop is logical where a window records device
+    assert.deepEqual([preview.x, preview.y], [(35 + 14) * 2, (25 + 14) * 2]);
+
+    native.emit({ type: 'drag-session-moved', x: 200, y: 60 });
+    assert.deepEqual(
+      [preview.x, preview.y],
+      [(200 + 14) * 2, (60 + 14) * 2],
+      'and it follows the pointer, on the callback that reported it',
+    );
+
+    native.emit({
+      type: 'drag-session-ended',
+      x: 200,
+      y: 60,
+      operation: 'copy',
+      dropped: true,
+    });
+    assert.equal(app._windows.size, 1, 'the release takes it down');
   });
 
   test('a drop on our own window keeps the payload by reference', async () => {


### PR DESCRIPTION
Refs #482 — this fixes the reported symptom. The issue's other listed cause is deliberately left, with a reason, below.

## What was wrong

On the cocoa backend a drag had no visible subject. `onDragStart` and `onDrag` fired with the right screen coordinates and the drop landed, but nothing the app rendered in response reached the screen — so a `<popup dragPreview>` following `useDragSource().position`, the pattern `docs/drag-and-drop.md` teaches and `examples/dnd-source.jsx` demonstrates, drew nothing. Not "stopped tracking": on master the preview window is never created at all.

## Why

The run loop, not the preview. Once `beginDrag` hands the gesture over, AppKit tracks it in a loop of its own **inside** the pump call. Two things measured against the real bridge before touching anything:

- a bare `native.beginDrag` on a real window returns at once, and a 25ms `setInterval` then does not fire again for **31 seconds**, until the drag ends. Node's loop is frozen for the whole gesture.
- a microtask queued inside a backend event callback does **not** drain until the pump call that dispatched it returns to Node. React's sync-lane commit is scheduled as a microtask, so during a drag it never happens.

`docs/macos.md` already names this risk under "The run loop is the one architectural risk in the whole plan": drag sessions freeze JS, and while the timer pump is the model the answer is to flush from the callbacks themselves. The destination side already did that. The source side did not — and neither side landed React's half.

## What changed

- `drag-session-moved` flushes a frame, like `_routeDrop` next door.
- `_afterInput` calls `flushSyncWork` before painting — the same pair `discrete` uses on X11. That is what lets a handler's own `setState` reach the screen from inside any of AppKit's modal loops, live resize included.
- `flushSyncWork` lands only the sync lane, so the drag's dispatches ask for that lane. `DragStart`, `onDrag` and `onDragEnd` run at discrete priority **when the window has a native drag session**, and `DropSession` grew a `hoverPriority` field the cocoa transport raises from continuous to discrete. A drag hovering is a stream like the pointer's own and belongs on the frame clock — unless the backend has stopped that clock, which is exactly this case.
- The frame that shows the drag *beginning* goes out from `CocoaWindow.beginDrag` on the way past: motion is otherwise paced and not flushed per event, and that is the last moment before the thread is gone.

All three priority changes are load-bearing — removing any one of them makes the new test fail again.

## The other half of the issue, on purpose

The blank image AppKit's session carries is not fixed here. Its premise in the issue is that a preview popup is "still nothing over a foreign window", and on this backend that turns out to be false: a react-x11 popup is a non-activating panel at the pop-up-menu window level. Checked with CGWindowListCopyWindowInfo while one was on screen — it reports layer 101, where Finder's and Chrome's ordinary windows report layer 0 — and the window server orders across applications strictly by layer. So the preview is drawn over other applications, and a bitmap handed to `beginDrag` would double-draw with the preview every app following the docs already renders.

Worth having later as a native-feel option with a seam for which subtree is rasterised; not as an unconditional default. Happy to leave #482 open for that half.

## Verified

- `npm test`: 1992 pass, 6 fail — the known macOS-only `appearance.test.js` baseline, the same six on master. `npm run lint`, `npm run typecheck` and `prettier --check .` are clean.
- Two new regressions in `test/cocoa-dnd.test.js` assert with no await and no frame tick, which is all a drag gets: a preview popup that exists at the threshold and moves on the callback that reported the motion, and a `useDropTarget` hint that renders on enter. Both fail on master.
- The two probes above, against the real bridge on this Mac.
- **Not** verified: the drag as a user sees it. A real AppKit drag needs a real button held down, this machine has no CGEvent posting rights, and the session grabs the pointer for its duration. Worth one manual pass with `npm run examples:dnd-source` on cocoa before merge.

## Follow-up in the second commit: the preview is transparent now

Once the preview follows the pointer you can see it, and what you see is a card with a `borderRadius` inside an **opaque** window — so the four corners the radius gives up show the window's own ground, near black under a dark theme. `examples/dnd-source.jsx` and the snippet in `docs/drag-and-drop.md` now write `<popup dragPreview transparent>`.

Measured by snapshotting both variants on cocoa and reading the pixels: the opaque popup's corner is opaque white, the transparent one's is clear, with alpha ramping 0, 9, 141, 223, 251, 255 along the arc. It degrades the way every other transparent window here does — with no compositor the window fills itself square, which is what it looked like anyway.
