### PR TITLE
feat(cocoa): layer promotion — the animated few on their own layers above the surface presenter

### DIFF
--- a/docs/architecture/animation.md
+++ b/docs/architecture/animation.md
@@ -507,9 +507,15 @@ tests records `addAnimation` calls the same way it records `setLayerProps`.
 
 ### 4.3 The surface presenter, and X11
 
-Nothing to offload: one bitmap per window, painted by the X11 walk. The JS
-loop runs. This design is one more row in the measure-first gate's
-argument for making layers the default; it does not move the gate itself.
+X11 has nothing to offload: one bitmap per window, painted by the X11
+walk, and the JS loop runs. The surface presenter started there too, and
+now takes the same table as §4.2 by **layer promotion** (issue #483,
+docs/macos.md §"Layer promotion"): a plain box with a transition or a loop
+on an offloadable property gets a CALayer of its own above the window's
+bitmap for as long as it animates, where nothing is painted over it, and
+the same `LayerAnimations` books run it in the render server. The bitmap
+keeps the frame for everything else. What this moved in the measure-first
+gate's argument is recorded there, measured.
 
 ### 4.4 Bridge additions (`@windowkit/appkit`)
 

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -335,11 +335,12 @@ it first:
   natively, which is the fastest possible detector for event/text/input
   contract gaps.
 
-What Tier S cannot do, structurally: offload animation (every transition
-frame is a JS-side repaint + upload), make scrolling cheap (the blit
+What Tier S cannot do, structurally: make scrolling cheap (the blit
 becomes a `memmove` + upload), or exploit retina (2× is 4× the raster
 and 4× the upload). It is a correct port with X11's cost model on
-hardware that offers a better one.
+hardware that offers a better one. Offloading an animation it can — not
+structurally, but for the few nodes that animate, which get a layer of
+their own above the bitmap (§"Layer promotion" below, issue #483).
 
 ### Tier L — layer presenter (retained, the design target)
 
@@ -934,11 +935,12 @@ that sends it attaches an explicit animation carrying the pixels there
 repeating animation and costs no JS frames at all. Everything else — a
 colour on text, a layout property, any node that paints as a raster — stays
 on the frame clock, byte-identical to before; the presenter can only decline,
-never break.
-`examples/animation.jsx` is the demonstration: under
-`REACT_X11_COCOA_PRESENTER=layers` its frame counter reads 0 while the
-plain-box loops keep going, and they keep going through a deliberate two
-second block of the JS thread.
+never break. **The surface presenter takes the same animations** by
+promoting the node to a layer of its own for as long as it animates —
+the next section — so `examples/animation.jsx` is the demonstration on
+either: its frame counter reads 0 while the plain-box loops keep going,
+and they keep going through a deliberate two second block of the JS
+thread.
 
 The three semantics [the design](architecture/animation.md) said to pin:
 
@@ -976,6 +978,164 @@ Both wait until the presenter exists; they are listed because "hardware
 composited layers with animation and transformations" is half the reason
 to build Tier L, and the API shape (style props + capability gates)
 should be agreed before someone builds a macOS-only thing.
+
+## Layer promotion: the animated few on their own layers above the surface presenter
+
+The presenter choice above is all-or-nothing, and for the shape of app
+that most wants the retained tier — a large scene with one or two
+animated elements in it — neither answer was right. `surface` could not
+offload an animation at all: every transition frame was a JS repaint plus
+an upload, and a stalled JS thread stopped the animation dead. `layers`
+offloaded it and paid for the whole rest of the scene: a pan is a
+whole-scene re-raster (`scrollRegion` is nulled in layers mode), and every
+raster visual carries its own bitmap. The hybrid is what browsers call
+**layer promotion**, and it is the surface presenter's default (issue
+#483): keep the bitmap for the scene, and give the handful of nodes that
+actually animate a CALayer of their own above it. `src/cocoa/promotion.js`
+is the whole of it.
+
+**Why it was cheap here.** The mechanism already shipped, for `<glarea>`.
+The surface presenter's pixels are the window root layer's `contents`,
+and a layer's contents draw _below_ its sublayers — so a promoted sublayer
+composites over the bitmap for free, and there was no compositing to
+write. The hole in the 2D raster was already an idiom (`GlAreaNode.paint`
+is empty): a promoted node is skipped by the paint walk (`Node._promoted`),
+so the walk paints what is behind it and nothing else. The animation
+seam was already presenter-agnostic — `animateNode` / `cancelNodeAnimation`
+are feature-detected on the window, and `_offloadDeclined` hands a
+property back to the frame clock whenever a presenter cannot take it — and
+the bookkeeping of what the render server runs was one class
+(`LayerAnimations`, presenter.js) once it was lifted out of the layer
+presenter; the two differ only in which node has a layer.
+
+**What a promoted node is.** A property box — its background, border and
+radius as properties of its layer, the same `propBoxProps` the layer
+presenter sends, which is exactly the vocabulary the render server
+animates. Its children, if it has any, ride the layer as one raster
+sublayer painted by the node's own `_paintChildren` walk (a `Visual` and a
+`RasterState` from the layer presenter, used standalone), repainted for the
+claims that reach into it and for a change in where the children sit —
+the hover card in `examples/animation.jsx` promotes with its two captions.
+A promoted node inside a promoted node leaves a hole in its parent's
+raster and sits on a layer of its own above it; every promoted layer is
+flat on the window root, ordered by paint order. Hit testing never moves:
+the node tree stays the source of truth for input on every presenter, so
+promotion changes pixels and nothing else.
+
+**The policy** is not inferred from the scene, and there is no style prop
+to get wrong: a node is promoted because it has a transition or a loop on
+a property a layer can express — a plain `<box>`'s `backgroundColor`,
+`borderColor`, `borderWidth`, `borderRadius` — for as long as it has one
+and a second after, and returns to the bitmap then. The second is
+`IDLE_GRACE_MS`: a hover card fades in and, a moment later, out; a palette
+step ends one transition and starts the next; a toast pulses again.
+Demoting on the last frame of each cost a layer and a repaint of the hole
+per round trip — the first run of the bench made 96 layers for 48 cards —
+and a second is longer than any such gap. Nothing can promote two hundred
+nodes by mistake, and there is nothing to document on a backend that may
+decline it.
+
+**The hard part is z-order.** A promoted layer sits above _all_ the 2D
+content, so promotion is only correct where nothing paints over the node.
+Browsers answer the general case with overlap testing that cascades
+promotions upward through the stacking context — precisely the machinery
+worth not having. The cheap rule instead: a node is promoted only when
+nothing painted after it in the walk reaches into its bounds — no later
+sibling at any level (a later subtree counts where it puts ink, so a
+layout-only container laid over the node is no overlap, and a later
+subtree that is itself promoted is on a layer above and does not count),
+no ancestor's border ring or focus ring (both are painted after the
+children), no scrollbar — and only when every clipping ancestor holds the
+whole of it, because the layer would not be clipped. All of it is
+answered from `paintOrder()` and the cached paint reach, and the same test
+runs again every frame, later-painted nodes first, so a node that becomes
+overlapped, hidden, clipped or non-plain (a `:hover` that adds a shadow)
+returns to the bitmap in the frame that finds it, the animation handed
+back to the clock. Overlays, toasts, drag ghosts, spinners and floating
+cards pass by construction; a hover fade on a row in the middle of a list
+does not, and stays on the clock. Declining is always safe — the frame
+clock runs the animation exactly as it does with promotion off — and a
+refusal is remembered until the next layout, so the same scene does not
+cost a frame's decline per retarget.
+
+**The frame.** `WindowNode.flush()` gives the presenter its word in after
+layout and before the damage is taken (`window.prepareFrame`, feature-
+detected like `presentFrame`): whatever it moves onto or off a layer
+claims the bitmap under it in that same frame, so a node is never painted
+at its target before a declined animation restarts from its start, and a
+demoted node is back in the bitmap in the frame its layer goes. A
+promoted node's own claims — a retarget, a hover flip, a caption changing
+inside it — are answered on the layer and cost the bitmap nothing: the
+`noteInvalidate` channel the layer presenter listens on answers `true`,
+`WindowNode.invalidate` records a frame with nothing in it for the bitmap,
+and the frame runs the presenter's half and paints no pixel (`hovertree`
+below: 0kpx a frame). The scroll blit's safety gate skips a promoted node
+for the same reason — its pixels are not in the bitmap the band is cut
+from — which is what makes a pan under a pulsing toast a blit
+(`pananim`), on a backend where the toast's per-frame claim used to poison
+every notch.
+
+**What to expect, and how to stop it.** An animation on a plain box
+costs one frame to start and, a second after the last one ends, one to
+come back, and the render server draws every frame between — through a
+busy JS thread, at the display's rate — while the bitmap keeps the frame
+for everything else, the scroll blit included. What it costs is a CALayer
+and, for a node with children, a bitmap the size of their reach, for as
+long as the node animates and the second after.
+`createRoot({ cocoa: { promote: false } })` or `REACT_X11_COCOA_PROMOTE=0`
+keeps every animation on the frame clock, which is what the presenter
+bench's `surface` column measures; `true` / `=1` turns it on regardless
+of the bridge. `test/cocoa-promotion.test.js` pins the contract over the
+fake bridge; `test/animation-example.test.js` walks the example through
+it.
+
+**One thing it found, and the bridge it needs.** A promoted node is the
+same node drawn two ways in turn, and the two had to agree to the pixel
+or every hover would flash. They did not: a layer's `backgroundColor` went
+through `@windowkit/appkit`'s `CGColorCreateGenericRGB` while its surfaces
+are sRGB, so `#dbe7f4` rastered as (219, 231, 244) and composited as
+(228, 236, 245) — paler, on every layer the layer presenter ever set, and
+a colour animation there landed on a model value that did not match its
+own `to`. The bridge fix — `MakeColor` in sRGB, the readback to match,
+and a `colorSpace()` verb that says so — is a line and a verb in
+`@windowkit/appkit`, and ships with the bridge's next release; against it
+the same card differs by at most six units of one channel, in the
+antialiasing. Promotion is on by
+default **only where the bridge answers `'sRGB'`** — on 0.5 it stays off
+unless asked for — so nobody gets the flash for free, and a bridge upgrade
+turns it on.
+
+**Measured**, 2026-09-06, this machine (a 120Hz panel; the window on a
+60Hz monitor where it says 59fps), 4s per cell, `npm run bench:presenters
+-- --scenario=anim,animtree,hovertree,pananim,scroll,tree`; `surface` is
+promotion off, `promoted` on. Frames are what the JS side painted;
+`ticks` are the scenario's own changes (a palette step every 15, a hover
+flip or a wheel notch every one).
+
+| scenario    | column   | frames / ticks | flush avg / p95 | damage a frame     | cpu  | what it says                                       |
+| ----------- | -------- | -------------- | --------------- | ------------------ | ---- | -------------------------------------------------- |
+| `anim`      | surface  | 455 / 235      | 2.17 / 2.51ms   | 2170kpx            | 46%  | every frame of every fade, all 48 cards            |
+|             | promoted | 16 / 241       | 2.80 / 6.92ms   | 136kpx             | 17%  | one frame a palette step; 48 layers, made once     |
+|             | layers   | 16 / 241       | 2.21 / 3.26ms   | —                  | 17%  |                                                    |
+| `animtree`  | surface  | 208 / 120      | 14.58 / 16.97ms | 2031kpx            | 108% | cannot keep up: the fades repaint the grid         |
+|             | promoted | 243 / 243      | 0.91 / 1.87ms   | 13kpx              | 54%  | the grid's one cell a tick; the fades cost nothing |
+|             | layers   | 244 / 244      | 2.75 / 3.75ms   | —                  | 67%  | a visual per node of the grid                      |
+| `hovertree` | surface  | 476 / 242      | 0.28 / 0.38ms   | 43kpx              | 14%  | input→flush p50 2.80ms                             |
+|             | promoted | 242 / 242      | 0.31 / 0.39ms   | 0kpx               | 11%  | p50 2.86ms; the bitmap paints nothing              |
+|             | layers   | 241 / 241      | 1.38 / 1.65ms   | —                  | 22%  | p50 2.75ms                                         |
+| `pananim`   | surface  | 702 / 243      | 0.65 / 1.82ms   | 817kpx, 31% full   | 24%  | the toast's claim poisons every notch's blit       |
+|             | promoted | 219 / 242      | 1.57 / 2.01ms   | 525kpx, 0% full    | 22%  | the blit, exactly `scroll`'s                       |
+|             | layers   | 220 / 243      | 1.89 / 2.28ms   | 2520kpx, 100% full | 17%  | a whole-scene re-raster a notch                    |
+| `scroll`    | promoted | 220 / 243      | 1.45 / 1.86ms   | 525kpx             | 20%  | as surface: 1.49 / 2.01ms, 525kpx, 21%             |
+| `tree`      | promoted | 243 / 243      | 0.47 / 0.65ms   | 4kpx               | 49%  | as surface: 0.42 / 0.57ms, 4kpx, 47%               |
+
+So both halves at once: the animation's frames match `layers`, the flush
+and the scroll match `surface`, and `animtree` and `pananim` beat both.
+The 54% left in `animtree` is the React commit of a 3,700-node tree per
+tick, which `tree` prices at 47% with no animation at all. The gate keeps
+it: `scripts/bench/presenters-gate.json`'s `promoted` rules judge the
+promoted column on frames per tick, full frames and damage share, next to
+the surface column's own.
 
 ## Running as an app bundle
 

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1096,11 +1096,10 @@ through `@windowkit/appkit`'s `CGColorCreateGenericRGB` while its surfaces
 are sRGB, so `#dbe7f4` rastered as (219, 231, 244) and composited as
 (228, 236, 245) — paler, on every layer the layer presenter ever set, and
 a colour animation there landed on a model value that did not match its
-own `to`. The bridge fix — `MakeColor` in sRGB, the readback to match,
-and a `colorSpace()` verb that says so — is a line and a verb in
-`@windowkit/appkit`, and ships with the bridge's next release; against it
-the same card differs by at most six units of one channel, in the
-antialiasing. Promotion is on by
+own `to`. [windowkit/appkit#33](https://github.com/windowkit/appkit/pull/33)
+makes every colour crossing the bridge sRGB and adds `colorSpace()` to
+say so; against it the same card differs by at most six units of one
+channel, in the antialiasing. Promotion is on by
 default **only where the bridge answers `'sRGB'`** — on 0.5 it stays off
 unless asked for — so nobody gets the flash for free, and a bridge upgrade
 turns it on.

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1098,11 +1098,12 @@ are sRGB, so `#dbe7f4` rastered as (219, 231, 244) and composited as
 a colour animation there landed on a model value that did not match its
 own `to`. [windowkit/appkit#33](https://github.com/windowkit/appkit/pull/33)
 makes every colour crossing the bridge sRGB and adds `colorSpace()` to
-say so; against it the same card differs by at most six units of one
-channel, in the antialiasing. Promotion is on by
-default **only where the bridge answers `'sRGB'`** — on 0.5 it stays off
-unless asked for — so nobody gets the flash for free, and a bridge upgrade
-turns it on.
+say so, and shipped as `@windowkit/appkit` 0.5.1, the range this package
+asks for; against it the same card differs by at most six units of one
+channel, in the antialiasing. Promotion is on by default **only where the
+bridge answers `'sRGB'`** — on 0.5.0 it stays off unless asked for — so
+nobody gets the flash for free, and the bridge upgrade is what turned it
+on.
 
 **Measured**, 2026-09-06, this machine (a 120Hz panel; the window on a
 60Hz monitor where it says 59fps), 4s per cell, `npm run bench:presenters

--- a/docs/styling.md
+++ b/docs/styling.md
@@ -995,12 +995,14 @@ window. The alternative an app would otherwise write, `setInterval` →
 damage heuristics decide, at a cadence unrelated to when the window can
 present.
 
-On the macOS layer presenter a loop — or a transition — on a plain box's
-colour, border width or radius is handed to Core Animation instead and
-costs no frames at all; anything else runs as above
-([macos.md](macos.md#animations-and-transforms-the-api-the-model-unlocks)).
-`examples/animation.jsx` has both shapes side by side, with a frame counter
-in the terminal that shows the difference.
+On macOS a loop — or a transition — on a plain box's colour, border width
+or radius is handed to Core Animation instead and costs no frames at all:
+the layer presenter runs it on the node's own layer, and the surface
+presenter promotes the node to a layer of its own above the window for as
+long as it animates, where nothing is painted over it
+([macos.md](macos.md#layer-promotion-the-animated-few-on-their-own-layers-above-the-surface-presenter)).
+Anything else runs as above. `examples/animation.jsx` has both shapes side
+by side, with a frame counter in the terminal that shows the difference.
 
 **And it stops itself**, which is the whole reason this is core's job. A
 forever-loop keeping a frame clock alive is invisible when it is wrong, so

--- a/examples/animation.jsx
+++ b/examples/animation.jsx
@@ -7,17 +7,24 @@
 // the terminal beside the window prints how many frames a second the JS
 // side is painting. That number is the difference between the backends:
 //
-//   On X11, and on the macOS surface presenter, every animation is a frame
-//   this process paints, at the display's rate, for as long as anything
-//   moves. The counter reads ~60, and "Block JS for 2 s" freezes all of it.
+//   On X11 every animation is a frame this process paints, at the
+//   display's rate, for as long as anything moves. The counter reads ~60,
+//   and "Block JS for 2 s" freezes all of it.
 //
-//   On the macOS layer presenter a plain <box>'s colour, border width and
-//   radius are handed to Core Animation (react-x11 #472): the style goes
-//   straight to its target, the render server draws the way there, and no
-//   frame is scheduled for it. Untick "position · text ink · ProgressBar"
-//   and the counter reads 0 while the three tiles keep pulsing; press the
-//   button and they pulse straight through the block.
+//   On macOS a plain <box>'s colour, border width and radius are handed to
+//   Core Animation (react-x11 #472): the style goes straight to its
+//   target, the render server draws the way there, and no frame is
+//   scheduled for it. The surface presenter — the default — does it by
+//   promotion (#483): the three tiles, the chip and the hovered card get a
+//   layer of their own above the window's bitmap for as long as they
+//   animate, and the bitmap keeps the frame for everything else. The layer
+//   presenter has a layer for every box to begin with. Either way, untick
+//   "position · text ink · ProgressBar" and the counter reads 0 while the
+//   three tiles keep pulsing; press the button and they pulse straight
+//   through the block.
 //
+//   REACT_X11_COCOA_PROMOTE=0 npm run examples:animation           # macOS,
+//                                              # every animation on the clock
 //   REACT_X11_COCOA_PRESENTER=layers npm run examples:animation   # macOS
 //   REACT_X11_BACKEND=x11 npm run examples:animation              # XQuartz
 //
@@ -280,8 +287,8 @@ function Loops() {
             <box data-testname="round" style={[s.tile, layer && s.round]} />
           </box>
           <text style={s.hint}>
-            Plain boxes. On the macOS layer presenter these run in the render
-            server and cost no frames; everywhere else, the frame clock.
+            Plain boxes. On macOS these run in the render server and cost no
+            frames; everywhere else, the frame clock.
           </text>
         </box>
 
@@ -391,13 +398,17 @@ if (!process.env.REACT_X11_NO_AUTORUN) {
       onRoot={(node) => {
         if (watcher) return;
         // The window's animation seam exists only where a presenter can take
-        // an animation (src/cocoa/window.js, layers mode); its absence is
-        // every other backend, where the frame clock runs all of it.
-        const offloads = typeof node.window?.animateNode === 'function';
+        // an animation (src/cocoa/window.js: the layer presenter, and the
+        // surface presenter's promotion); its absence is every other
+        // backend, where the frame clock runs all of it.
+        const wnd = node.window;
+        const offloads = typeof wnd?.animateNode === 'function';
         process.stdout.write(
-          offloads
-            ? '\n  layer presenter: the plain-box loops run in the render server\n'
-            : '\n  frame clock: every animation is a frame this process paints\n',
+          !offloads
+            ? '\n  frame clock: every animation is a frame this process paints\n'
+            : wnd._promotion
+              ? '\n  surface presenter: the plain-box loops run in the render server, on layers of their own\n'
+              : '\n  layer presenter: the plain-box loops run in the render server\n',
         );
         // The stress app's frame instrument, silenced — a line per frame is
         // the wrong unit here. Frames per second is the number, and it is

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "node": ">=20.19"
       },
       "optionalDependencies": {
-        "@windowkit/appkit": "^0.5.0",
+        "@windowkit/appkit": "^0.5.1",
         "dbus-native": "^0.15.1",
         "x11-dri": "^0.7.0"
       },
@@ -1515,9 +1515,9 @@
       }
     },
     "node_modules/@windowkit/appkit": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@windowkit/appkit/-/appkit-0.5.0.tgz",
-      "integrity": "sha512-K9/LTMdd794EIVNeegjl91YpIU0DLF1xAyrx6kHCRxIeWHJT77JpVGSEjlHy2+0IB040g3AZjAerJZUgZhROeQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@windowkit/appkit/-/appkit-0.5.1.tgz",
+      "integrity": "sha512-ciu/0PjLw7ZWyAieIUO2/VKXJv9XevJNucC5Gvc37HIuJ0TOlp2QIJVX+IFxInzE/kdqhnQ6m/dEgW33kAM0nA==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "yoga-layout": "^3.2.1"
   },
   "optionalDependencies": {
-    "@windowkit/appkit": "^0.5.0",
+    "@windowkit/appkit": "^0.5.1",
     "dbus-native": "^0.15.1",
     "x11-dri": "^0.7.0"
   },

--- a/scripts/bench/presenters-gate.json
+++ b/scripts/bench/presenters-gate.json
@@ -2,32 +2,109 @@
   "//": [
     "The cocoa frame-clock gate: what a frame must and must not do, judged on",
     "the surface presenter by `npm run bench:presenters -- --check`. Counts",
-    "and shares of the window, never milliseconds — a timing on a shared",
+    "and shares of the window, never milliseconds \u2014 a timing on a shared",
     "runner says nothing, a full-window repaint for one cell says everything.",
     "maxDamageShare is the repainted area per painting frame as a fraction of",
     "the window in device pixels, so it reads the same at 1x and 2x. A rule",
-    "that has to loosen is a decision to record in the PR that loosens it."
+    "that has to loosen is a decision to record in the PR that loosens it.",
+    "`promoted` is judged on the promoted column \u2014 the surface presenter with",
+    "layer promotion (src/cocoa/promotion.js): the animations' frames must match",
+    "the layer presenter's and the flush and the scroll the surface's. Frames",
+    "per tick is the animation half (a palette step or a hover flip costs one",
+    "frame, the fades between them none); damage share and full frames are the",
+    "bitmap half; scroll and tree must keep what the surface column keeps."
   ],
   "rules": {
-    "color": { "maxFullPct": 0, "maxDamageShare": 0.03, "minFrames": 30 },
-    "tree": { "maxFullPct": 0, "maxDamageShare": 0.005, "minFrames": 30 },
-    "leaf": { "maxFullPct": 0, "maxDamageShare": 0.005, "minFrames": 30 },
-    "multi": { "maxFullPct": 0, "maxDamageShare": 0.15, "minFrames": 30 },
+    "color": {
+      "maxFullPct": 0,
+      "maxDamageShare": 0.03,
+      "minFrames": 30
+    },
+    "tree": {
+      "maxFullPct": 0,
+      "maxDamageShare": 0.005,
+      "minFrames": 30
+    },
+    "leaf": {
+      "maxFullPct": 0,
+      "maxDamageShare": 0.005,
+      "minFrames": 30
+    },
+    "multi": {
+      "maxFullPct": 0,
+      "maxDamageShare": 0.15,
+      "minFrames": 30
+    },
     "press": {
       "maxFullPct": 0,
       "maxDamageShare": 0.01,
       "minFrames": 30,
       "minInputs": 20
     },
-    "scroll": { "maxFullPct": 0, "maxDamageShare": 0.35, "minFrames": 30 },
-    "anim": { "maxFullPct": 0, "minFrames": 30 },
+    "scroll": {
+      "maxFullPct": 0,
+      "maxDamageShare": 0.35,
+      "minFrames": 30
+    },
+    "anim": {
+      "maxFullPct": 0,
+      "minFrames": 30
+    },
     "resize": {
       "maxFlushesPerResize": 1.05,
       "maxSettleFlushes": 1,
       "maxSurfacesPerResize": 2
     },
-    "occluded": { "maxFrames": 0 },
-    "covered": { "maxFrames": 0 },
-    "idle": { "maxFrames": 0 }
+    "occluded": {
+      "maxFrames": 0
+    },
+    "covered": {
+      "maxFrames": 0
+    },
+    "idle": {
+      "maxFrames": 0
+    },
+    "animtree": {
+      "maxFullPct": 0,
+      "minFrames": 30
+    },
+    "hovertree": {
+      "maxFullPct": 0,
+      "minFrames": 30,
+      "minInputs": 20
+    }
+  },
+  "promoted": {
+    "anim": {
+      "maxFullPct": 0,
+      "maxFramesPerTick": 0.2,
+      "maxDamageShare": 0.1
+    },
+    "animtree": {
+      "maxFullPct": 0,
+      "maxFramesPerTick": 1.1,
+      "maxDamageShare": 0.02
+    },
+    "hovertree": {
+      "maxFullPct": 0,
+      "maxFramesPerTick": 1.1,
+      "maxDamageShare": 0.005,
+      "minInputs": 20
+    },
+    "pananim": {
+      "maxFullPct": 0,
+      "maxFramesPerTick": 1.1,
+      "maxDamageShare": 0.35
+    },
+    "scroll": {
+      "maxFullPct": 0,
+      "maxDamageShare": 0.35,
+      "minFrames": 30
+    },
+    "tree": {
+      "maxFullPct": 0,
+      "maxDamageShare": 0.005,
+      "minFrames": 30
+    }
   }
 }

--- a/scripts/bench/presenters-gate.json
+++ b/scripts/bench/presenters-gate.json
@@ -78,7 +78,7 @@
     "anim": {
       "maxFullPct": 0,
       "maxFramesPerTick": 0.2,
-      "maxDamageShare": 0.1
+      "maxDamageShare": 0.15
     },
     "animtree": {
       "maxFullPct": 0,

--- a/scripts/bench/presenters.js
+++ b/scripts/bench/presenters.js
@@ -347,6 +347,49 @@ function scrollList() {
   );
 }
 
+/**
+ * A toast whose colour transitions every 800ms, from its own timer. A
+ * transition rather than a loop, on purpose: a loop is stopped by the
+ * desktop's reduce-motion switch, which CI's macOS runners have on, and
+ * the scenario is about the pan under an animation, not about which shape
+ * the animation takes. The first change comes a frame after the mount, so
+ * the toast is on its layer before the bench settles; 800ms between
+ * changes is under the second a promoted node waits before coming back,
+ * so it stays there.
+ */
+function PulsingToast() {
+  const [on, setOn] = React.useState(false);
+  React.useEffect(() => {
+    // after the first frame, not before it: a node nobody has seen yet
+    // takes no transition (nodes.js, `_placed`), and a change that lands
+    // before the mount frame would leave the toast in the bitmap until the
+    // next one
+    let timer = setTimeout(function flip() {
+      setOn((v) => !v);
+      timer = setTimeout(flip, 800);
+    }, 200);
+    return () => clearTimeout(timer);
+  }, []);
+  return e(
+    'box',
+    {
+      style: {
+        position: 'absolute',
+        right: 24,
+        bottom: 24,
+        width: 220,
+        height: 44,
+        borderRadius: 10,
+        paddingLeft: 16,
+        justifyContent: 'center',
+        backgroundColor: on ? '#6c5ce7' : '#2d3436',
+        transition: { backgroundColor: 240 },
+      },
+    },
+    e('text', { style: { color: '#ffffff' } }, 'saving…'),
+  );
+}
+
 /** A wheel notch over the scroller, down for 60 ticks and back up. */
 function wheelNotch(ctx) {
   const { win, stamp } = ctx;
@@ -581,45 +624,20 @@ const SCENARIOS = {
     drive: wheelNotch,
   },
 
-  /** The same pan, under a toast that pulses — a loop on a plain box
-   *  floating over the list's corner, a later sibling of the scroller. The
-   *  case neither presenter serves: the surface presenter's loop keeps the
-   *  frame clock at the display's rate whether the wheel turns or not, and
-   *  the layer presenter's pan is a whole-scene re-raster. Promoted, the
-   *  toast costs nothing and the pan keeps the blit — `frames` against
-   *  `ticks`, and `damage`, are the numbers. */
+  /** The same pan, under a toast that pulses — a plain box floating over
+   *  the list's corner, a later sibling of the scroller, its colour
+   *  transitioning every 800ms. The case neither presenter serves: on the
+   *  surface presenter a toast over the viewport costs the pan its blit
+   *  (its pixels would be dragged along), and every frame of its fade is a
+   *  frame; the layer presenter's pan is a whole-scene re-raster.
+   *  Promoted, the toast is off the bitmap, so the pan keeps the blit and
+   *  the fades cost nothing — `damage` and `frames` against `ticks` are
+   *  the numbers. */
   pananim: {
     latency: true,
     tree: () =>
       windowOf(
-        [
-          scrollList(),
-          e(
-            'box',
-            {
-              key: 'toast',
-              style: {
-                position: 'absolute',
-                right: 24,
-                bottom: 24,
-                width: 220,
-                height: 44,
-                borderRadius: 10,
-                paddingLeft: 16,
-                justifyContent: 'center',
-                backgroundColor: '#2d3436',
-                animation: {
-                  backgroundColor: {
-                    to: '#6c5ce7',
-                    duration: 900,
-                    alternate: true,
-                  },
-                },
-              },
-            },
-            e('text', { style: { color: '#ffffff' } }, 'saving…'),
-          ),
-        ],
+        [scrollList(), e(PulsingToast, { key: 'toast' })],
         'bench pananim',
       ),
     drive: wheelNotch,

--- a/scripts/bench/presenters.js
+++ b/scripts/bench/presenters.js
@@ -24,9 +24,12 @@
 //             that answered it (the "answer the input" number), and → the
 //             end of the present that put it on glass. p50/p95/max.
 //
-//   npm run bench:presenters                    # every scenario, both
+//   npm run bench:presenters                    # every scenario, every
+//                                               # presenter
 //   npm run bench:presenters -- --scenario=cards --seconds=8
 //   npm run bench:presenters -- --columns=surface   # one presenter only
+//                                               # (surface = promotion off,
+//                                               # promoted = on, layers)
 //   npm run bench:presenters -- --x11           # extra column via $DISPLAY
 //   npm run bench:presenters -- --cells=2400    # bigger stress trees
 //   npm run bench:presenters -- --at=200,200    # the window at a point (on
@@ -48,6 +51,14 @@
 // a real application screen — `--cells` boxes, each with a label — because a
 // path that is cheap on twelve nodes and quadratic on a thousand only shows
 // there.
+//
+// The `promoted` column is the surface presenter with layer promotion
+// (src/cocoa/promotion.js, issue #483), which the `surface` column runs
+// with promotion off; `animtree`, `hovertree` and `pananim` are its
+// scenarios — the animated few above a large scene, and a pan under
+// something that animates — and what they have to show is both halves at
+// once: the animation's frames matching `layers`, the flush and the scroll
+// matching `surface`.
 //
 // Comparisons hold within a run (same machine, same session); absolute
 // numbers travel about as well as any timing does — that is, they don't.
@@ -278,6 +289,106 @@ function centreOf(node, scale) {
   ];
 }
 
+/** The `anim` scenario's 48 cards: absolutely placed, a 240ms colour
+ * transition each, the palette rotating every 15 ticks. */
+function fadingCards(tick) {
+  const CARD_W = 130;
+  const CARD_H = 70;
+  const GAP = 12;
+  const PAD = 16;
+  const step = Math.floor(tick / 15);
+  const perRow = Math.max(1, Math.floor((W - 2 * PAD + GAP) / (CARD_W + GAP)));
+  const cards = [];
+  for (let i = 0; i < 48; i += 1) {
+    cards.push(
+      e('box', {
+        key: i,
+        style: {
+          position: 'absolute',
+          left: PAD + (i % perRow) * (CARD_W + GAP),
+          top: PAD + Math.floor(i / perRow) * (CARD_H + GAP),
+          width: CARD_W,
+          height: CARD_H,
+          backgroundColor: HOT[(i + step) % HOT.length],
+          borderRadius: 8,
+          transition: { backgroundColor: 240 },
+        },
+      }),
+    );
+  }
+  return cards;
+}
+
+/** The `scroll` scenario's list: 300 rows in a scroller. */
+function scrollList() {
+  return e(
+    'box',
+    { key: 'list', style: { flexGrow: 1, overflow: 'scroll' } },
+    ...Array.from({ length: 300 }, (_, i) =>
+      e(
+        'box',
+        {
+          key: i,
+          style: {
+            height: 28,
+            paddingLeft: 16,
+            flexDirection: 'row',
+            alignItems: 'center',
+            backgroundColor: i % 2 ? '#f6f8fb' : '#ffffff',
+          },
+        },
+        e(
+          'text',
+          { style: { color: '#444444' } },
+          `row ${i} — some list content`,
+        ),
+      ),
+    ),
+  );
+}
+
+/** A wheel notch over the scroller, down for 60 ticks and back up. */
+function wheelNotch(ctx) {
+  const { win, stamp } = ctx;
+  const scroller = ctx.find((n) => n.isScroller?.());
+  if (!scroller) return;
+  const x = scroller.abs.x + scroller.abs.width / 2;
+  const y = scroller.abs.y + scroller.abs.height / 2;
+  const down = ctx.tick % 120 < 60; // sweep down, then back up
+  stamp();
+  if (ctx.app._routeWheel && ctx.wnd) {
+    // the bridge's event shape, in points: the same route a real notch
+    // takes, so what the app does with a wheel is in the number
+    const s = ctx.wnd.scale;
+    ctx.app._routeWheel({
+      type: 'wheel',
+      windowNumber: ctx.wnd.windowNumber,
+      x: x / s,
+      y: y / s,
+      gx: (ctx.wnd.x + x) / s,
+      gy: (ctx.wnd.y + y) / s,
+      dx: 0,
+      dy: down ? -3 : 3,
+      precise: false,
+      time: performance.now(),
+    });
+    return;
+  }
+  win.emit('wheel', {
+    name: 'wheel',
+    x,
+    y,
+    rootx: 0,
+    rooty: 0,
+    buttons: 0,
+    deltaX: 0,
+    deltaY: down ? 3 : -3,
+    deltaMode: 'line',
+    smooth: false,
+    source: 'button',
+  });
+}
+
 const SCENARIOS = {
   /** Paint-only bounded change: one 100px box recolours. The layers
    *  presenter should answer with one backgroundColor prop and zero
@@ -466,76 +577,52 @@ const SCENARIOS = {
    *  scenario: the notch goes through the window's event path. */
   scroll: {
     latency: true,
+    tree: () => windowOf([scrollList()], 'bench scroll'),
+    drive: wheelNotch,
+  },
+
+  /** The same pan, under a toast that pulses — a loop on a plain box
+   *  floating over the list's corner, a later sibling of the scroller. The
+   *  case neither presenter serves: the surface presenter's loop keeps the
+   *  frame clock at the display's rate whether the wheel turns or not, and
+   *  the layer presenter's pan is a whole-scene re-raster. Promoted, the
+   *  toast costs nothing and the pan keeps the blit — `frames` against
+   *  `ticks`, and `damage`, are the numbers. */
+  pananim: {
+    latency: true,
     tree: () =>
       windowOf(
         [
+          scrollList(),
           e(
             'box',
-            { style: { flexGrow: 1, overflow: 'scroll' } },
-            ...Array.from({ length: 300 }, (_, i) =>
-              e(
-                'box',
-                {
-                  key: i,
-                  style: {
-                    height: 28,
-                    paddingLeft: 16,
-                    flexDirection: 'row',
-                    alignItems: 'center',
-                    backgroundColor: i % 2 ? '#f6f8fb' : '#ffffff',
+            {
+              key: 'toast',
+              style: {
+                position: 'absolute',
+                right: 24,
+                bottom: 24,
+                width: 220,
+                height: 44,
+                borderRadius: 10,
+                paddingLeft: 16,
+                justifyContent: 'center',
+                backgroundColor: '#2d3436',
+                animation: {
+                  backgroundColor: {
+                    to: '#6c5ce7',
+                    duration: 900,
+                    alternate: true,
                   },
                 },
-                e(
-                  'text',
-                  { style: { color: '#444444' } },
-                  `row ${i} — some list content`,
-                ),
-              ),
-            ),
+              },
+            },
+            e('text', { style: { color: '#ffffff' } }, 'saving…'),
           ),
         ],
-        'bench scroll',
+        'bench pananim',
       ),
-    drive(ctx) {
-      const { win, stamp } = ctx;
-      const scroller = ctx.find((n) => n.isScroller?.());
-      if (!scroller) return;
-      const x = scroller.abs.x + scroller.abs.width / 2;
-      const y = scroller.abs.y + scroller.abs.height / 2;
-      const down = ctx.tick % 120 < 60; // sweep down, then back up
-      stamp();
-      if (ctx.app._routeWheel && ctx.wnd) {
-        // the bridge's event shape, in points: the same route a real notch
-        // takes, so what the app does with a wheel is in the number
-        const s = ctx.wnd.scale;
-        ctx.app._routeWheel({
-          type: 'wheel',
-          windowNumber: ctx.wnd.windowNumber,
-          x: x / s,
-          y: y / s,
-          gx: (ctx.wnd.x + x) / s,
-          gy: (ctx.wnd.y + y) / s,
-          dx: 0,
-          dy: down ? -3 : 3,
-          precise: false,
-          time: performance.now(),
-        });
-        return;
-      }
-      win.emit('wheel', {
-        name: 'wheel',
-        x,
-        y,
-        rootx: 0,
-        rooty: 0,
-        buttons: 0,
-        deltaX: 0,
-        deltaY: down ? 3 : -3,
-        deltaMode: 'line',
-        smooth: false,
-        source: 'button',
-      });
-    },
+    drive: wheelNotch,
   },
 
   /** Pointer wiggle over a hover-styled grid, through the REAL NSApp event
@@ -891,37 +978,98 @@ const SCENARIOS = {
    *  animation frames run — fps and damage are the animation path's, and
    *  cpu is what a screen of gentle fades costs. */
   anim: {
-    tree: (tick) => {
-      const CARD_W = 130;
-      const CARD_H = 70;
-      const GAP = 12;
-      const PAD = 16;
-      const step = Math.floor(tick / 15);
-      const perRow = Math.max(
-        1,
-        Math.floor((W - 2 * PAD + GAP) / (CARD_W + GAP)),
-      );
-      const cards = [];
-      for (let i = 0; i < 48; i += 1) {
-        cards.push(
-          e('box', {
-            key: i,
-            style: {
-              position: 'absolute',
-              left: PAD + (i % perRow) * (CARD_W + GAP),
-              top: PAD + Math.floor(i / perRow) * (CARD_H + GAP),
-              width: CARD_W,
-              height: CARD_H,
-              backgroundColor: HOT[(i + step) % HOT.length],
-              borderRadius: 8,
-              transition: { backgroundColor: 240 },
-            },
-          }),
-        );
-      }
-      return windowOf(
-        [e('box', { style: { flexGrow: 1 } }, ...cards)],
+    tree: (tick) =>
+      windowOf(
+        [e('box', { style: { flexGrow: 1 } }, ...fadingCards(tick))],
         'bench anim',
+      ),
+  },
+
+  /** The same 48 fading cards floating over the big tree, with a cell of
+   *  the tree recolouring per tick underneath them — the animated few
+   *  above a busy scene, which is what promotion is for: the surface
+   *  presenter repaints every card every frame of every fade, the layer
+   *  presenter pays a visual per node of the tree, and the promoted
+   *  column should pay the tree's one-cell frame plus one frame per
+   *  palette step. `frames` against `ticks` is the number. */
+  animtree: {
+    tree: (tick) =>
+      windowOf(
+        [
+          header(`animtree — ${COLS}x${ROWS} cells under 48 fades`),
+          grid({ hot: hotOne(tick) }),
+          e(
+            'box',
+            {
+              key: 'fades',
+              style: {
+                position: 'absolute',
+                left: 0,
+                top: 0,
+                right: 0,
+                bottom: 0,
+              },
+            },
+            ...fadingCards(tick),
+          ),
+        ],
+        'bench animtree',
+      ),
+  },
+
+  /** The hover cards in a row above the big tree, the pointer alternating
+   *  between two of them through the NSApp queue: a `:hover` fade of one
+   *  card while a thousand cells sit under it. input→flush is the answer
+   *  to the pointer; `frames` is what the fade cost after it. */
+  hovertree: {
+    latency: true,
+    input: 'native',
+    tree: () =>
+      windowOf(
+        [
+          e(
+            'box',
+            {
+              key: 'cards',
+              style: {
+                padding: 12,
+                flexDirection: 'row',
+                gap: 12,
+                alignItems: 'flex-start',
+              },
+            },
+            ...Array.from({ length: 6 }, (_, i) =>
+              e('box', {
+                key: i,
+                style: {
+                  width: 120,
+                  height: 44,
+                  borderRadius: 8,
+                  backgroundColor: '#ffffff',
+                  borderWidth: 1,
+                  borderColor: '#c3ccd8',
+                  transition: { backgroundColor: 240, borderColor: 240 },
+                  ':hover': {
+                    backgroundColor: '#dbe7f4',
+                    borderColor: '#0984e3',
+                  },
+                },
+              }),
+            ),
+          ),
+          grid({ rows: Math.floor(ROWS / 2) }),
+        ],
+        'bench hovertree',
+      ),
+    drive(ctx) {
+      const cards = ctx.findAll((n) => n.style?.[':hover'] !== undefined);
+      const target = ctx.tick % 2 ? cards[0] : cards[3];
+      if (!target) return;
+      ctx.stamp();
+      ctx.native.postMouseEvent(
+        ctx.wnd._h,
+        'move',
+        ...centreOf(target, ctx.wnd.scale),
       );
     },
   },
@@ -1224,6 +1372,7 @@ async function runChild() {
     uploadPx: 0,
     props: 0,
     layersMade: 0,
+    animations: 0,
     presents: 0,
     presentMs: 0,
     surfaces: 0,
@@ -1262,6 +1411,10 @@ async function runChild() {
     });
     wrap('createLayer', (orig, ...a) => {
       stats.layersMade += 1;
+      return orig(...a);
+    });
+    wrap('addAnimation', (orig, ...a) => {
+      stats.animations += 1;
       return orig(...a);
     });
     // the IOSurface swapchain's present path: a flip plus a damage-sized
@@ -1441,9 +1594,7 @@ async function runChild() {
   const rss1 = process.memoryUsage().rss;
 
   if (SHOTS && wnd) {
-    wnd.snapshot(
-      `/tmp/bench-${name}-${process.env.REACT_X11_COCOA_PRESENTER ?? 'surface'}.png`,
-    );
+    wnd.snapshot(`/tmp/bench-${name}-${columnLabel()}.png`);
   }
 
   const sorted = [...stats.flushMs].sort((a, b) => a - b);
@@ -1481,6 +1632,7 @@ async function runChild() {
     uploadMsPerFrame: frames ? stats.uploadMs / frames : 0,
     propsPerFrame: frames ? stats.props / frames : 0,
     layersMade: stats.layersMade,
+    animations: stats.animations,
     latP50: q(lat, 0.5),
     latP95: q(lat, 0.95),
     latMax: lat.at(-1) ?? null,
@@ -1511,7 +1663,7 @@ function runCell(name, env) {
         ? [
             '--cpu-prof',
             `--cpu-prof-dir=${process.env.PROF_DIR ?? '/tmp'}`,
-            `--cpu-prof-name=${name}-${env.REACT_X11_COCOA_PRESENTER ?? env.REACT_X11_BACKEND ?? 'cell'}.cpuprofile`,
+            `--cpu-prof-name=${name}-${env.REACT_X11_BACKEND ?? columnLabel(env)}.cpuprofile`,
           ]
         : []),
       new URL(import.meta.url).pathname,
@@ -1548,6 +1700,12 @@ function runCell(name, env) {
 // touched, and what a timing on someone else's machine cannot say.
 // ---------------------------------------------------------------------------
 
+/** Which column a cell's environment is: the presenter, and promotion. */
+function columnLabel(env = process.env) {
+  if (env.REACT_X11_COCOA_PRESENTER === 'layers') return 'layers';
+  return env.REACT_X11_COCOA_PROMOTE === '0' ? 'surface' : 'promoted';
+}
+
 const GATE_PATH = new URL('./presenters-gate.json', import.meta.url);
 
 function loadGate() {
@@ -1583,6 +1741,13 @@ function judge(name, r, rules) {
     rule(
       r.frames <= rules.maxFrames,
       `${r.frames} frames (max ${rules.maxFrames})`,
+    );
+  }
+  if (rules.maxFramesPerTick !== undefined) {
+    const per = r.ticks ? r.frames / r.ticks : Infinity;
+    rule(
+      per <= rules.maxFramesPerTick,
+      `${per.toFixed(2)} frames per tick (max ${rules.maxFramesPerTick})`,
     );
   }
   if (rules.minInputs !== undefined) {
@@ -1628,22 +1793,43 @@ if (CHILD) {
   await runChild();
 } else {
   const gate = CHECK ? loadGate() : null;
-  // the gate judges the default presenter over the scenarios it has rules
-  // for; the timing table still prints, for the human reading the log
+  // the gate judges the surface presenter over the scenarios `rules` names
+  // and the promoted column over `promoted`'s; the timing table still
+  // prints, for the human reading the log
+  const gateRules = (label) =>
+    label === 'surface'
+      ? gate?.rules
+      : label === 'promoted'
+        ? gate?.promoted
+        : null;
   const names = ONLY
     ? ONLY.split(',')
     : gate
-      ? Object.keys(gate.rules)
+      ? [
+          ...new Set([
+            ...Object.keys(gate.rules),
+            ...Object.keys(gate.promoted ?? {}),
+          ]),
+        ]
       : Object.keys(SCENARIOS);
   const columnNames = COLUMNS
     ? COLUMNS.split(',')
     : gate
-      ? ['surface']
-      : ['surface', 'layers', ...(WITH_X11 ? ['x11'] : [])];
+      ? ['surface', 'promoted']
+      : ['surface', 'promoted', 'layers', ...(WITH_X11 ? ['x11'] : [])];
   const verdicts = [];
   const summary = [];
+  // `surface` is the frame clock for every animation — promotion off, so the
+  // column keeps meaning what it always did; `promoted` is the default
   const envOf = {
-    surface: { REACT_X11_COCOA_PRESENTER: 'surface' },
+    surface: {
+      REACT_X11_COCOA_PRESENTER: 'surface',
+      REACT_X11_COCOA_PROMOTE: '0',
+    },
+    promoted: {
+      REACT_X11_COCOA_PRESENTER: 'surface',
+      REACT_X11_COCOA_PROMOTE: '1',
+    },
     layers: { REACT_X11_COCOA_PRESENTER: 'layers' },
     x11: { REACT_X11_BACKEND: 'x11' },
   };
@@ -1677,16 +1863,21 @@ if (CHILD) {
         continue;
       }
       const r = runCell(name, env);
+      const rules = gateRules(label)?.[name];
       if (r.error) {
         console.log(`  ${label.padEnd(9)} FAILED: ${r.error}`);
-        if (gate?.rules[name] && label === 'surface') {
-          verdicts.push({ name, ok: false, what: `did not run: ${r.error}` });
+        if (rules) {
+          verdicts.push({
+            name: `${name}/${label}`,
+            ok: false,
+            what: `did not run: ${r.error}`,
+          });
         }
         continue;
       }
-      if (gate?.rules[name] && label === 'surface') {
-        for (const v of judge(name, r, gate.rules[name])) {
-          verdicts.push({ name, ...v });
+      if (rules) {
+        for (const v of judge(name, r, rules)) {
+          verdicts.push({ name: `${name}/${label}`, ...v });
         }
       }
       const upload =
@@ -1707,6 +1898,9 @@ if (CHILD) {
       const notes = [];
       if (r.nodes) notes.push(`${r.nodes} nodes`);
       if (r.frames === 0) notes.push('no frames');
+      else if (r.ticks) notes.push(`${r.frames} frames for ${r.ticks} ticks`);
+      if (r.animations) notes.push(`${r.animations} animations handed to CA`);
+      if (r.layersMade) notes.push(`${r.layersMade} layers made`);
       if (r.presents) notes.push(`${r.presents} presents`);
       if (r.surfaces) {
         notes.push(
@@ -1738,7 +1932,7 @@ if (CHILD) {
   if (gate) {
     console.log('\ngate');
     for (const v of verdicts) {
-      console.log(`  ${v.ok ? 'ok  ' : 'FAIL'} ${v.name.padEnd(9)} ${v.what}`);
+      console.log(`  ${v.ok ? 'ok  ' : 'FAIL'} ${v.name.padEnd(18)} ${v.what}`);
     }
     const failed = verdicts.filter((v) => !v.ok);
     console.log(

--- a/src/cocoa/app.js
+++ b/src/cocoa/app.js
@@ -118,6 +118,22 @@ export class CocoaApp {
       options.cocoa?.presenter ??
       process.env.REACT_X11_COCOA_PRESENTER ??
       'surface';
+    // With the surface presenter, whether the nodes that animate get a
+    // layer of their own above the bitmap (src/cocoa/promotion.js). On by
+    // default — an animation the render server runs survives a busy JS
+    // thread, and the bitmap keeps the frame for everything else — where
+    // the bridge draws a layer's colour and a rastered one the same, which
+    // it says with `colorSpace()`: before it (@windowkit/appkit 0.5) a
+    // layer's colour was Generic RGB against sRGB surfaces, and a node
+    // moving between its layer and the bitmap changed shade on the way.
+    // Off (`cocoa.promote: false`, REACT_X11_COCOA_PROMOTE=0) keeps every
+    // animation on the frame clock, which is what the presenter bench's
+    // `surface` column measures; on (`true`, `=1`) is on regardless.
+    const promoteEnv = process.env.REACT_X11_COCOA_PROMOTE;
+    this._promote =
+      options.cocoa?.promote ??
+      (promoteEnv === '1' ||
+        (promoteEnv !== '0' && native.colorSpace?.() === 'sRGB'));
 
     // the app's own bridge, so an app over a fake one (the tests) needs no
     // real bridge on the machine — the manager's default loads it only when

--- a/src/cocoa/app.js
+++ b/src/cocoa/app.js
@@ -123,9 +123,10 @@ export class CocoaApp {
     // default — an animation the render server runs survives a busy JS
     // thread, and the bitmap keeps the frame for everything else — where
     // the bridge draws a layer's colour and a rastered one the same, which
-    // it says with `colorSpace()`: before it (@windowkit/appkit 0.5) a
-    // layer's colour was Generic RGB against sRGB surfaces, and a node
-    // moving between its layer and the bitmap changed shade on the way.
+    // it says with `colorSpace()` (@windowkit/appkit >= 0.5.1, the range
+    // package.json asks for): before it a layer's colour was Generic RGB
+    // against sRGB surfaces, and a node moving between its layer and the
+    // bitmap changed shade on the way.
     // Off (`cocoa.promote: false`, REACT_X11_COCOA_PROMOTE=0) keeps every
     // animation on the frame clock, which is what the presenter bench's
     // `surface` column measures; on (`true`, `=1`) is on regardless.

--- a/src/cocoa/presenter.js
+++ b/src/cocoa/presenter.js
@@ -35,7 +35,7 @@ import {
 import { EASING_CONTROL_POINTS, TRANSITION_CONTROL_POINTS } from '../styles.js';
 import { CocoaContext2D } from './context2d.js';
 
-const RASTER_PAD = 2; // antialiasing/italic overhang outside the ink bounds
+export const RASTER_PAD = 2; // antialiasing/italic overhang outside the ink bounds
 
 /**
  * A recording "context" for ntk's SvgView.draw: instead of rasterizing, it
@@ -325,7 +325,13 @@ const EDGE_PROPS = [
   'borderEndWidth',
 ];
 
-function stylePaintsPlain(node, style = node.style ?? {}) {
+/**
+ * Does `style` draw as a plain box — the property vocabulary of a layer
+ * (background, a uniform solid border, one radius), nothing that needs a
+ * raster? What decides whether a node is a PropBox on the layer presenter,
+ * and whether the surface presenter can promote it (src/cocoa/promotion.js).
+ */
+export function stylePaintsPlain(node, style = node.style ?? {}) {
   if (node.kind !== 'box') return false;
   if (style.backgroundImage || style.boxShadow || style.outlineWidth) {
     return false;
@@ -359,13 +365,13 @@ const ANIMATED_KEY_PATHS = Object.freeze({
 // looked up per app (`_animationEnds`)
 let animationSeq = 0;
 
-function uniformRadius(radius) {
+export function uniformRadius(radius) {
   if (radius === undefined) return 0;
   if (typeof radius === 'number') return radius;
   return null; // per-corner shapes go to raster
 }
 
-class Visual {
+export class Visual {
   constructor(presenter, node) {
     this.presenter = presenter;
     this.node = node;
@@ -409,7 +415,7 @@ class Visual {
   }
 }
 
-class RasterState {
+export class RasterState {
   constructor() {
     this.surface = null;
     this.gen = 0;
@@ -450,6 +456,218 @@ class RasterState {
   }
 }
 
+/**
+ * A plain box as the properties of its layer — what a PropBox visual sends
+ * on the layer presenter and what a promoted node's layer is set from on
+ * the surface presenter (src/cocoa/promotion.js): one function, so a box
+ * reads the same on either. `parentOrigin` is what `frame` is relative to,
+ * in window coordinates; everything goes out in points.
+ */
+export function propBoxProps(node, app, scale, parentOrigin, order) {
+  const abs = node.abs;
+  const style = node.style ?? {};
+  const border = typeof style.borderWidth === 'number' ? style.borderWidth : 0;
+  const colour = (value) =>
+    value ? (app._parseColor(String(value)) ?? [0, 0, 0, 0]) : [0, 0, 0, 0];
+  return {
+    frame: [
+      (abs.x - parentOrigin.x) / scale,
+      (abs.y - parentOrigin.y) / scale,
+      Math.max(0, abs.width) / scale,
+      Math.max(0, abs.height) / scale,
+    ],
+    zPosition: order,
+    hidden: Boolean(node.hidden),
+    masksToBounds: Boolean(node.clipsChildren?.()) && !node.isScroller?.(),
+    cornerRadius: (uniformRadius(style.borderRadius) ?? 0) / scale,
+    backgroundColor: colour(style.backgroundColor),
+    borderWidth: border / scale,
+    borderColor: colour(style.borderColor),
+  };
+}
+
+// --- animations the render server runs ---------------------------------------
+//
+// The node model keeps deciding what is animating and when it ends
+// (nodes.js `_retarget` / `_updateLoops`); what moves here is who
+// interpolates. Taken means the node's style goes to its target — the
+// layer's model value, sent by the next frame's property diff — and that
+// frame attaches an explicit animation carrying the pixels there; no frame
+// after it is scheduled for the property, and a loop costs no JS frames at
+// all. Declined means the frame clock runs it exactly as before, so
+// nothing here is load-bearing for correctness.
+//
+// Kept apart from the presenter because two of them hand animations over:
+// the layer presenter, where every plain box has a layer, and the surface
+// presenter's promotion (src/cocoa/promotion.js), where only the nodes
+// that animate do. They differ in which node has a layer and agree on
+// everything from there — `layerOf(node)` is the whole of the difference.
+
+/**
+ * The animations one presenter has handed to the render server: what
+ * `take` accepted and is waiting for the frame that attaches it, and what
+ * is running on a layer. `onIdle(node)`, when given, hears that the last
+ * animation running for a node ended on the bridge's word — the one end
+ * no frame follows on its own.
+ */
+export class LayerAnimations {
+  constructor({ native, app, scale, layerOf, onIdle = null }) {
+    this.native = native;
+    this.app = app;
+    this.scale = scale;
+    this.layerOf = layerOf;
+    this.onIdle = onIdle;
+    this.pending = new Map(); // node -> Map(prop -> entry)
+    this.live = new Map(); // node -> Map(id -> { prop, key, entry })
+  }
+
+  /**
+   * Take `prop`'s animation for `node`, or decline. Decided against the
+   * *target* style: a `:hover` that adds a shadow turns the node into a
+   * raster in the same swap that starts a fade, and a raster's background
+   * is in its bitmap, not on its layer.
+   */
+  take(node, prop, entry) {
+    const map = ANIMATED_KEY_PATHS[prop];
+    if (!map || !stylePaintsPlain(node, node._targetStyle ?? node.style)) {
+      return false;
+    }
+    if (this._value(map, entry.from) == null) return false;
+    if (this._value(map, entry.to) == null) return false;
+    let pending = this.pending.get(node);
+    if (!pending) this.pending.set(node, (pending = new Map()));
+    pending.set(prop, entry);
+    return true;
+  }
+
+  /** Stop what runs for `prop` on `node`: a loop the window lost sight of,
+   *  a declaration that changed, a transition the clock takes back. */
+  cancel(node, prop) {
+    this.pending.get(node)?.delete(prop);
+    this._removeLive(node, prop);
+  }
+
+  /** Is anything taken for `node` — waiting for a frame, or running? */
+  has(node) {
+    return this.pending.has(node) || this.live.has(node);
+  }
+
+  _ends() {
+    return (this.app._animationEnds ??= new Map());
+  }
+
+  /** A style value as the layer takes it — a colour as components, a
+   *  length in points — or null for one the layer cannot animate. */
+  _value(map, value) {
+    if (map.colour) {
+      return typeof value === 'string'
+        ? (this.app._parseColor(value) ?? null)
+        : null;
+    }
+    return typeof value === 'number'
+      ? value / (map.scaled ? this.scale : 1)
+      : null;
+  }
+
+  /** The frame's half: attach what `take` accepted to `layer`, after the
+   *  model value went out, inside the same transaction. */
+  apply(node, layer) {
+    const pending = this.pending.get(node);
+    if (!pending) return;
+    this.pending.delete(node);
+    for (const [prop, entry] of pending) {
+      const map = ANIMATED_KEY_PATHS[prop];
+      const id = `rx${++animationSeq}`;
+      const key = `${prop}:${id}`;
+      const opts = { duration: entry.duration / 1000, id };
+      if (entry.loop) {
+        // a loop replaces whatever ran for the property: its declaration
+        // changed, and a loop restarts from the top when it does
+        this._removeLive(node, prop);
+        opts.from = this._value(map, entry.from);
+        opts.to = this._value(map, entry.to);
+        opts.timing = EASING_CONTROL_POINTS[entry.easing];
+        opts.repeat = Infinity;
+        opts.autoreverse = entry.alternate;
+      } else if (map.colour) {
+        // From where the pixels are — which is what "an interrupted
+        // transition reverses from where it got to" means here. A colour
+        // cannot be additive, so the one before it is replaced.
+        this._removeLive(node, prop);
+        const shown = this.native.presentationValue?.(layer, map.keyPath);
+        opts.from = Array.isArray(shown) ? shown : this._value(map, entry.from);
+        opts.to = this._value(map, entry.to);
+        opts.timing = TRANSITION_CONTROL_POINTS;
+      } else {
+        // Additive: a delta over the model value, (old − new) → 0, and the
+        // ones before it keep running and sum. Continuity on a retarget with
+        // nothing read back, however many are in flight.
+        opts.from = this._value(map, entry.from) - this._value(map, entry.to);
+        opts.to = 0;
+        opts.additive = true;
+        opts.timing = TRANSITION_CONTROL_POINTS;
+      }
+      this.native.addAnimation(layer, map.keyPath, opts, key);
+      // looked up after the removals above, which may have pruned the map
+      let live = this.live.get(node);
+      if (!live) this.live.set(node, (live = new Map()));
+      live.set(id, { prop, key, entry });
+      this._ends().set(id, (ev) => this._animationEnded(node, id, ev));
+    }
+  }
+
+  /** Every animation running for `prop` on `node`, off the layer and out
+   *  of the books. */
+  _removeLive(node, prop) {
+    const live = this.live.get(node);
+    if (!live) return;
+    const layer = this.layerOf(node);
+    for (const [id, run] of live) {
+      if (run.prop !== prop) continue;
+      live.delete(id);
+      this._ends().delete(id);
+      if (layer) this.native.removeAnimation(layer, run.key);
+    }
+    if (live.size === 0) this.live.delete(node);
+  }
+
+  /** The bridge's `animation-end` for one of ours — it ran out, or CA
+   *  dropped it. An older additive one ending changes nothing: the node
+   *  checks the entry is still the one it holds. */
+  _animationEnded(node, id) {
+    this._ends().delete(id);
+    const live = this.live.get(node);
+    const run = live?.get(id);
+    if (!run) return;
+    live.delete(id);
+    if (live.size === 0) this.live.delete(node);
+    node._offloadEnded(run.prop, run.entry);
+    if (!this.has(node)) this.onIdle?.(node);
+  }
+
+  /** The layer is going — the visual is destroyed, or turns into a raster —
+   *  and every animation on it goes with it. What was still waiting for a
+   *  frame goes back to the frame clock when the node stays (`reclaim`);
+   *  what was running is over, and the model shows. */
+  drop(node, reclaim) {
+    const pending = this.pending.get(node);
+    if (pending) {
+      this.pending.delete(node);
+      for (const [prop, entry] of pending) {
+        if (reclaim) node._offloadDeclined(prop, entry);
+        else node._offloadEnded(prop, entry);
+      }
+    }
+    const live = this.live.get(node);
+    if (!live) return;
+    this.live.delete(node);
+    for (const [id, run] of live) {
+      this._ends().delete(id);
+      node._offloadEnded(run.prop, run.entry);
+    }
+  }
+}
+
 export class CocoaLayerPresenter {
   constructor(window) {
     this.window = window;
@@ -459,10 +677,13 @@ export class CocoaLayerPresenter {
     this.visuals = new Map(); // node -> Visual
     this.rasters = new Map(); // node -> RasterState
     this.bars = new Map(); // scroller node -> Map(axis -> { layer, raster })
-    // animations taken off the frame clock: accepted and waiting for the
-    // frame that attaches them, and running in the render server
-    this.pendingAnimations = new Map(); // node -> Map(prop -> entry)
-    this.liveAnimations = new Map(); // node -> Map(id -> { prop, key, entry })
+    // animations taken off the frame clock, by the node's own layer
+    this.animations = new LayerAnimations({
+      native: this.native,
+      app: window.app,
+      scale: this.scale,
+      layerOf: (node) => this.visuals.get(node)?.layer ?? null,
+    });
     // Claims since the last frame — taken at the top of `frame()`, the way
     // the X11 path takes its damage before painting, so a claim made from
     // inside a paint lands in the next frame instead of being cleared with
@@ -572,7 +793,7 @@ export class CocoaLayerPresenter {
           visual.destroy();
           this.visuals.delete(node);
           this._dropRaster(node);
-          this._dropAnimations(node, false);
+          this.animations.drop(node, false);
           const bars = this.bars.get(node);
           if (bars) {
             for (const entry of bars.values()) {
@@ -639,11 +860,11 @@ export class CocoaLayerPresenter {
       this._dropRaster(node);
       // a layer that turns into a raster takes its animations with it; the
       // frame clock can still run them over the bitmap
-      if (wantsRaster) this._dropAnimations(node, true);
+      if (wantsRaster) this.animations.drop(node, true);
       visual = null;
     }
-    if (wantsRaster && this.pendingAnimations.has(node)) {
-      this._dropAnimations(node, true);
+    if (wantsRaster && this.animations.pending.has(node)) {
+      this.animations.drop(node, true);
     }
     if (!visual) {
       visual = new Visual(this, node);
@@ -731,191 +952,23 @@ export class CocoaLayerPresenter {
 
   _syncPropBox(node, visual, parentOrigin, order) {
     const abs = node.abs;
-    const style = node.style ?? {};
-    const s = this.scale;
     visual.origin = { x: abs.x, y: abs.y };
-    const border =
-      typeof style.borderWidth === 'number' ? style.borderWidth : 0;
-    visual.set({
-      frame: [
-        (abs.x - parentOrigin.x) / s,
-        (abs.y - parentOrigin.y) / s,
-        Math.max(0, abs.width) / s,
-        Math.max(0, abs.height) / s,
-      ],
-      zPosition: order,
-      hidden: Boolean(node.hidden),
-      masksToBounds: Boolean(node.clipsChildren?.()) && !node.isScroller?.(),
-      cornerRadius: (uniformRadius(style.borderRadius) ?? 0) / s,
-      backgroundColor: style.backgroundColor
-        ? (this.window.app._parseColor(String(style.backgroundColor)) ?? [
-            0, 0, 0, 0,
-          ])
-        : [0, 0, 0, 0],
-      borderWidth: border / s,
-      borderColor: style.borderColor
-        ? (this.window.app._parseColor(String(style.borderColor)) ?? [
-            0, 0, 0, 0,
-          ])
-        : [0, 0, 0, 0],
-    });
+    visual.set(
+      propBoxProps(node, this.window.app, this.scale, parentOrigin, order),
+    );
     // after the model value went out, inside the same transaction
-    this._applyAnimations(node, visual);
+    this.animations.apply(node, visual.layer);
   }
 
-  // --- animations the render server runs -----------------------------------
-  //
-  // The node model keeps deciding what is animating and when it ends
-  // (nodes.js `_retarget` / `_updateLoops`); what moves here is who
-  // interpolates. Taken means the node's style goes to its target — the
-  // layer's model value, sent by the next frame's property diff — and that
-  // frame attaches an explicit animation carrying the pixels there; no frame
-  // after it is scheduled for the property, and a loop costs no JS frames at
-  // all. Declined means the frame clock runs it exactly as before, so
-  // nothing here is load-bearing for correctness.
-
-  /**
-   * Take `prop`'s animation for `node`, or decline. Decided against the
-   * *target* style: a `:hover` that adds a shadow turns the node into a
-   * raster in the same swap that starts a fade, and a raster's background
-   * is in its bitmap, not on its layer.
-   */
+  /** The window's animation seam (src/cocoa/window.js): take `prop`'s
+   *  animation for `node` off the frame clock, or decline. */
   animate(node, prop, entry) {
-    const map = ANIMATED_KEY_PATHS[prop];
-    if (!map || !stylePaintsPlain(node, node._targetStyle ?? node.style)) {
-      return false;
-    }
-    if (this._value(map, entry.from) == null) return false;
-    if (this._value(map, entry.to) == null) return false;
-    let pending = this.pendingAnimations.get(node);
-    if (!pending) this.pendingAnimations.set(node, (pending = new Map()));
-    pending.set(prop, entry);
-    return true;
+    return this.animations.take(node, prop, entry);
   }
 
-  /** Stop what runs for `prop` on `node`: a loop the window lost sight of,
-   *  a declaration that changed, a transition the clock takes back. */
+  /** …and stop what runs for `prop` on `node`. */
   cancel(node, prop) {
-    this.pendingAnimations.get(node)?.delete(prop);
-    this._removeLive(node, prop);
-  }
-
-  _ends() {
-    const app = this.window.app;
-    return (app._animationEnds ??= new Map());
-  }
-
-  /** A style value as the layer takes it — a colour as components, a
-   *  length in points — or null for one the layer cannot animate. */
-  _value(map, value) {
-    if (map.colour) {
-      return typeof value === 'string'
-        ? (this.window.app._parseColor(value) ?? null)
-        : null;
-    }
-    return typeof value === 'number'
-      ? value / (map.scaled ? this.scale : 1)
-      : null;
-  }
-
-  /** The frame's half: attach what `animate` accepted, after the model
-   *  value went out, inside the same transaction. */
-  _applyAnimations(node, visual) {
-    const pending = this.pendingAnimations.get(node);
-    if (!pending) return;
-    this.pendingAnimations.delete(node);
-    for (const [prop, entry] of pending) {
-      const map = ANIMATED_KEY_PATHS[prop];
-      const id = `rx${++animationSeq}`;
-      const key = `${prop}:${id}`;
-      const opts = { duration: entry.duration / 1000, id };
-      if (entry.loop) {
-        // a loop replaces whatever ran for the property: its declaration
-        // changed, and a loop restarts from the top when it does
-        this._removeLive(node, prop);
-        opts.from = this._value(map, entry.from);
-        opts.to = this._value(map, entry.to);
-        opts.timing = EASING_CONTROL_POINTS[entry.easing];
-        opts.repeat = Infinity;
-        opts.autoreverse = entry.alternate;
-      } else if (map.colour) {
-        // From where the pixels are — which is what "an interrupted
-        // transition reverses from where it got to" means here. A colour
-        // cannot be additive, so the one before it is replaced.
-        this._removeLive(node, prop);
-        const shown = this.native.presentationValue?.(
-          visual.layer,
-          map.keyPath,
-        );
-        opts.from = Array.isArray(shown) ? shown : this._value(map, entry.from);
-        opts.to = this._value(map, entry.to);
-        opts.timing = TRANSITION_CONTROL_POINTS;
-      } else {
-        // Additive: a delta over the model value, (old − new) → 0, and the
-        // ones before it keep running and sum. Continuity on a retarget with
-        // nothing read back, however many are in flight.
-        opts.from = this._value(map, entry.from) - this._value(map, entry.to);
-        opts.to = 0;
-        opts.additive = true;
-        opts.timing = TRANSITION_CONTROL_POINTS;
-      }
-      this.native.addAnimation(visual.layer, map.keyPath, opts, key);
-      // looked up after the removals above, which may have pruned the map
-      let live = this.liveAnimations.get(node);
-      if (!live) this.liveAnimations.set(node, (live = new Map()));
-      live.set(id, { prop, key, entry });
-      this._ends().set(id, (ev) => this._animationEnded(node, id, ev));
-    }
-  }
-
-  /** Every animation running for `prop` on `node`, off the layer and out
-   *  of the books. */
-  _removeLive(node, prop) {
-    const live = this.liveAnimations.get(node);
-    if (!live) return;
-    const visual = this.visuals.get(node);
-    for (const [id, run] of live) {
-      if (run.prop !== prop) continue;
-      live.delete(id);
-      this._ends().delete(id);
-      if (visual) this.native.removeAnimation(visual.layer, run.key);
-    }
-    if (live.size === 0) this.liveAnimations.delete(node);
-  }
-
-  /** The bridge's `animation-end` for one of ours — it ran out, or CA
-   *  dropped it. An older additive one ending changes nothing: the node
-   *  checks the entry is still the one it holds. */
-  _animationEnded(node, id) {
-    this._ends().delete(id);
-    const live = this.liveAnimations.get(node);
-    const run = live?.get(id);
-    if (!run) return;
-    live.delete(id);
-    if (live.size === 0) this.liveAnimations.delete(node);
-    node._offloadEnded(run.prop, run.entry);
-  }
-
-  /** The layer is going — the visual is destroyed, or turns into a raster —
-   *  and every animation on it goes with it. What was still waiting for a
-   *  frame goes back to the frame clock when the node stays (`reclaim`);
-   *  what was running is over, and the model shows. */
-  _dropAnimations(node, reclaim) {
-    const pending = this.pendingAnimations.get(node);
-    if (pending) {
-      this.pendingAnimations.delete(node);
-      for (const [prop, entry] of pending) {
-        if (reclaim) node._offloadDeclined(prop, entry);
-        else node._offloadEnded(prop, entry);
-      }
-    }
-    const live = this.liveAnimations.get(node);
-    if (!live) return;
-    this.liveAnimations.delete(node);
-    for (const [id, run] of live) {
-      this._ends().delete(id);
-      node._offloadEnded(run.prop, run.entry);
-    }
+    this.animations.cancel(node, prop);
   }
 
   /**

--- a/src/cocoa/promotion.js
+++ b/src/cocoa/promotion.js
@@ -1,0 +1,708 @@
+// Layer promotion — the surface presenter's answer to an animation it cannot
+// otherwise take off the frame clock (issue #483): the few nodes that
+// animate get a CALayer of their own above the window's bitmap, and the
+// rest of the scene stays exactly the frame it was.
+//
+// The mechanism is the one `<glarea>` already uses. The surface presenter's
+// pixels are the window root layer's `contents`, and a layer's contents
+// draw below its sublayers — so a sublayer on the root composites over the
+// bitmap for free, and the paint walk leaves a hole where the node was
+// (`Node._promoted`, the way `GlAreaNode.paint` is empty). The node itself
+// is a property box, its background, border and radius as properties of
+// the layer — exactly the vocabulary the render server animates
+// (`LayerAnimations`) — and its children, if it has any, are one raster
+// sublayer painted by the node's own `_paintChildren` walk. Hit testing
+// never moves: the node tree stays the source of truth for input on every
+// presenter, so promotion changes pixels and nothing else.
+//
+// The policy is not inferred from the scene. A node is promoted because it
+// has a transition or a loop on a property a layer can express, for as
+// long as it has one and a moment after (`IDLE_GRACE_MS`), and returns to
+// the bitmap then; nothing in a style asks for it, and nothing can promote
+// two hundred nodes by mistake. What it is careful about is z-order, which is the hard
+// part: a promoted layer sits above ALL the 2D content, so a node is
+// promoted only when nothing painted after it in the walk reaches into its
+// bounds — no later sibling at any level, no ancestor's border ring or
+// focus ring, no scrollbar — and only when every clipping ancestor holds
+// the whole of it, because the layer would not be clipped. Declining is
+// always safe: the frame clock runs the animation exactly as it does
+// without this file. And the same test runs again every frame, so a node
+// that becomes overlapped, hidden, clipped or non-plain returns to the
+// bitmap in the frame that finds it, the animation handed back to the
+// clock. Overlays, toasts, drag ghosts, spinners and floating cards pass by
+// construction; a hover fade on a row in the middle of a list does not,
+// and stays on the clock. docs/macos.md §"Layer promotion" is the account.
+import {
+  BoxNode,
+  addDamageRect,
+  damageToPaint,
+  intersectRects,
+} from '../nodes.js';
+import { resolveBorderWidths } from '../styles.js';
+import {
+  LayerAnimations,
+  RASTER_PAD,
+  RasterState,
+  Visual,
+  propBoxProps,
+  stylePaintsPlain,
+} from './presenter.js';
+
+const ORIGIN = Object.freeze({ x: 0, y: 0 });
+
+// How long a node that has stopped animating keeps its layer. A hover card
+// fades in and, a moment later, out; a palette step ends one transition and
+// starts the next; a toast pulses again. Demoting on the last frame of each
+// would cost a layer and a repaint of the hole per round trip, and both are
+// frames the bitmap pays for — the presenter bench's `anim` made 96 layers
+// for 48 cards. A second is longer than any such gap and shorter than a
+// user's attention span for a layer that is only holding still.
+const IDLE_GRACE_MS = 1000;
+
+// Past this many bare-rect claims on one raster the passes cost more than
+// the repaint they save (the layer presenter's rule, per raster).
+const MAX_DIRTY_RECTS = 16;
+
+const rectsOverlap = (a, b) =>
+  a.x < b.x + b.width &&
+  b.x < a.x + a.width &&
+  a.y < b.y + b.height &&
+  b.y < a.y + a.height;
+
+const containsRect = (outer, inner) =>
+  inner.x >= outer.x &&
+  inner.y >= outer.y &&
+  inner.x + inner.width <= outer.x + outer.width &&
+  inner.y + inner.height <= outer.y + outer.height;
+
+const insetRect = (rect, by) => ({
+  x: rect.x + by,
+  y: rect.y + by,
+  width: rect.width - 2 * by,
+  height: rect.height - 2 * by,
+});
+
+function unionRect(a, b) {
+  if (!a) return b;
+  if (!b) return a;
+  const x = Math.min(a.x, b.x);
+  const y = Math.min(a.y, b.y);
+  return {
+    x,
+    y,
+    width: Math.max(a.x + a.width, b.x + b.width) - x,
+    height: Math.max(a.y + a.height, b.y + b.height) - y,
+  };
+}
+
+/** A rect grown outward to whole pixels — a pass clears and clips to its
+ * edges, and a fractional edge would antialias the clip into a seam. */
+function wholePixels(rect) {
+  const x = Math.floor(rect.x);
+  const y = Math.floor(rect.y);
+  return {
+    x,
+    y,
+    width: Math.ceil(rect.x + rect.width) - x,
+    height: Math.ceil(rect.y + rect.height) - y,
+  };
+}
+
+/** The widest of a node's four borders, or 0. */
+function borderReach(node) {
+  const style = node.style ?? {};
+  const w = resolveBorderWidths(style, node.direction);
+  return Math.max(0, w.top, w.right, w.bottom, w.left);
+}
+
+/** Would `_paintOutline` draw a ring on this node right now? Counted as
+ * ink whatever its colour: a wrong "no" here is a ring drawn under a layer. */
+function paintsOutline(node) {
+  const style = node.style ?? {};
+  if (style.outlineWidth === undefined && !node.states?.[':focus-visible']) {
+    return null;
+  }
+  return node._outline?.() ?? null;
+}
+
+/** A `<box>` painting as core paints one — not an element with a paint of
+ * its own, whose content exists nowhere but in that override. */
+const plainBox = (node) =>
+  node.kind === 'box' && node.paint === BoxNode.prototype.paint;
+
+/**
+ * Does this node put any ink of its own on the bitmap? A layout-only box —
+ * no background, no border, no shadow, no ring — overlaps nothing, however
+ * big its rect; everything else is taken to paint its whole box.
+ */
+function paintsSomething(node) {
+  if (!plainBox(node)) return true;
+  const style = node.style ?? {};
+  if (style.backgroundColor || style.backgroundImage || style.boxShadow) {
+    return true;
+  }
+  if (borderReach(node) > 0 || paintsOutline(node)) return true;
+  return Boolean(node.isScroller?.());
+}
+
+/**
+ * Can this node be a property box on a layer at all — the static half of
+ * the answer, the same whatever the scene around it does: a plain box by
+ * its target style, not a scroller (its bars and clip host are the layer
+ * presenter's business), no ring lit on it, no paint of its own.
+ */
+function promotableNode(node) {
+  if (node.destroyed || !plainBox(node)) return false;
+  if (!stylePaintsPlain(node, node._targetStyle ?? node.style)) return false;
+  if (node.isScroller?.()) return false;
+  return !paintsOutline(node);
+}
+
+/** The strip a scrollbar's track occupies, with the pad the thumb's
+ * antialiasing needs. Mirrors the layer presenter's bar strip. */
+function scrollbarStrip(bar, scale) {
+  const pad = Math.ceil(2 * scale);
+  return bar.axis === 'x'
+    ? {
+        x: bar.trackStart - pad,
+        y: bar.crossStart - pad,
+        width: bar.trackLength + 2 * pad,
+        height: bar.height + 2 * pad,
+      }
+    : {
+        x: bar.crossStart - pad,
+        y: bar.trackStart - pad,
+        width: bar.width + 2 * pad,
+        height: bar.trackLength + 2 * pad,
+      };
+}
+
+/**
+ * The surface window's promoted nodes: which ones have a layer, what each
+ * layer shows, and the animations the render server runs on them.
+ * `frame()` is the whole of the per-frame work, called by the window from
+ * nodes.js's `prepareFrame` seam — after layout, before the damage is taken.
+ */
+export class CocoaPromotion {
+  constructor(window) {
+    this.window = window;
+    this.native = window._native;
+    this.scale = window.scale;
+    this.app = window.app;
+    this.fonts = window.app.fonts;
+    this.rootVisual = { layer: window._layer };
+    this.promoted = new Map(); // node -> { visual, content, dirty }
+    // nodes whose animation was taken and have no layer yet: the frame
+    // decides, against the scene as laid out
+    this.candidates = new Set();
+    // a refusal, by the layout it was decided in: the same scene answers
+    // the same way, and every refusal a frame makes restarts the entry
+    this.denied = new WeakMap(); // node -> layout generation
+    this.layoutGen = 0;
+    // nodes whose last animation ended, waiting out the grace before the
+    // frame that takes them back into the bitmap; and the ones that frame
+    // is owed for
+    this.idle = new Map(); // node -> timer
+    this.releasing = new Set();
+    this.animations = new LayerAnimations({
+      native: this.native,
+      app: this.app,
+      scale: this.scale,
+      layerOf: (node) => this.promoted.get(node)?.visual.layer ?? null,
+      onIdle: (node) => this._idle(node),
+    });
+    this._claiming = false;
+  }
+
+  // --- the window's animation seam -------------------------------------------
+
+  /**
+   * Take `prop`'s animation for `node` off the frame clock, or decline.
+   * Taken here means only that the node is a candidate: whether it gets a
+   * layer is decided by the next frame, with the scene laid out, and a
+   * frame that decides against it hands the entry back to the clock from
+   * the top — before anything was painted at the target, so nothing shows.
+   */
+  animate(node, prop, entry) {
+    if (this.window.destroyed) return false;
+    if (!this.promoted.has(node)) {
+      if (this.denied.get(node) === this.layoutGen) return false;
+      if (!promotableNode(node)) return false;
+    }
+    if (!this.animations.take(node, prop, entry)) return false;
+    if (this.promoted.has(node)) this._keep(node);
+    else this.candidates.add(node);
+    return true;
+  }
+
+  /** Stop what runs for `prop` on `node`. The layer stays: a node with
+   *  nothing left running on it waits out the grace like one whose
+   *  animation ended, and the frame after that takes it back. */
+  cancel(node, prop) {
+    this.animations.cancel(node, prop);
+    if (this.promoted.has(node) && !this.animations.has(node)) {
+      this._idle(node);
+    }
+  }
+
+  /** Nothing runs on `node`'s layer any more: keep it for the grace, then
+   *  ask for the frame that takes the node back into the bitmap. */
+  _idle(node) {
+    if (!this.promoted.has(node) || this.idle.has(node)) return;
+    const timer = setTimeout(() => {
+      this.idle.delete(node);
+      this._release(node);
+    }, IDLE_GRACE_MS);
+    timer.unref?.();
+    this.idle.set(node, timer);
+  }
+
+  /** Something runs on `node`'s layer again: it stays. */
+  _keep(node) {
+    const timer = this.idle.get(node);
+    if (timer) {
+      clearTimeout(timer);
+      this.idle.delete(node);
+    }
+    this.releasing.delete(node);
+  }
+
+  _release(node) {
+    if (!this.promoted.has(node) || node.destroyed) return;
+    if (this.animations.has(node)) return; // taken again meanwhile
+    this.releasing.add(node);
+    const root = this.window._reactX11Node;
+    if (root && !root.destroyed) root.invalidate(false, node, 'animation');
+  }
+
+  /** Every idle node back into the bitmap on the next frame, grace or no
+   *  grace — for the tests, which do not wait a second. */
+  releaseIdle() {
+    for (const node of [...this.idle.keys()]) {
+      clearTimeout(this.idle.get(node));
+      this.idle.delete(node);
+      this._release(node);
+    }
+  }
+
+  // --- the invalidate channel ----------------------------------------------
+
+  /**
+   * A claim against the bitmap, seen on its way there: what it says about
+   * a promoted node's own layer needs no note — the model is re-diffed
+   * every frame — but its children's raster repaints only what is claimed
+   * inside it. A node claim inside a promoted subtree is a pass over that
+   * node's reach; a layout change anywhere in the subtree, or a claim with
+   * no bound, repaints the raster in full; a bare rect repaints that part
+   * of every raster it reaches into (the layer presenter's rule).
+   */
+  noteInvalidate(damage, layoutChanged) {
+    if (this._claiming || this.promoted.size === 0) return false;
+    if (damage == null) {
+      for (const p of this.promoted.values()) p.dirty.all = true;
+      return false;
+    }
+    if (damage.kind) {
+      let owner = null;
+      for (let n = damage; n && !n.isWindow; n = n.parent) {
+        if (this.promoted.has(n)) {
+          owner = n;
+          break;
+        }
+      }
+      if (!owner) return false;
+      const p = this.promoted.get(owner);
+      if (layoutChanged) {
+        p.dirty.all = true;
+        return false;
+      }
+      if (owner !== damage) this._dirtyRect(p, damage.paintBounds());
+      // answered here — the model re-diffed, the raster repainted — and the
+      // bitmap owes nothing: it holds a hole where this node is
+      return true;
+    }
+    if (!(damage.width > 0 && damage.height > 0)) return false;
+    for (const p of this.promoted.values()) {
+      if (p.content && rectsOverlap(p.content.rect, damage)) {
+        this._dirtyRect(p, damage);
+      }
+    }
+    return false;
+  }
+
+  _dirtyRect(p, rect) {
+    if (p.dirty.all) return;
+    if (p.dirty.rects.length >= MAX_DIRTY_RECTS) {
+      p.dirty.all = true;
+      return;
+    }
+    // copied: a caller's rect is very often a live `abs` about to move
+    p.dirty.rects.push({
+      x: rect.x,
+      y: rect.y,
+      width: rect.width,
+      height: rect.height,
+    });
+  }
+
+  // --- the frame -------------------------------------------------------------
+
+  /**
+   * The presenter's half of a frame. Three passes, all inside one
+   * disabled-actions transaction: every promoted node is asked again
+   * whether it may stay, the candidates are decided, and what remains is
+   * synced — frame, properties, the animations waiting to attach, the
+   * children's raster. A node taken off a layer here is painted back into
+   * the bitmap by this same frame, which is why this runs before the
+   * damage is taken (`_claim`).
+   */
+  frame(root, layoutRan) {
+    if (layoutRan) this.layoutGen++;
+    if (this.promoted.size === 0 && this.candidates.size === 0) return;
+    const native = this.native;
+    native.txBegin({ disableActions: true });
+    try {
+      // Later-painted first: a node painted after this one that is coming
+      // off its layer is what this one would be overlapped by, and the
+      // answer has to be known in the same frame, not the next.
+      const keyed = this._inPaintOrder([...this.promoted.keys()]);
+      for (let i = keyed.length - 1; i >= 0; i--) {
+        const { node, key } = keyed[i];
+        if (!this._mayStay(node, key)) this._demote(node, root, true);
+      }
+      if (this.candidates.size) {
+        const candidates = this._inPaintOrder([...this.candidates]);
+        this.candidates.clear();
+        for (let i = candidates.length - 1; i >= 0; i--) {
+          const { node, key } = candidates[i];
+          if (this.promoted.has(node) || !this.animations.has(node)) continue;
+          if (key && promotableNode(node) && this._clear(node)) {
+            this._promote(node, root);
+          } else {
+            this.denied.set(node, this.layoutGen);
+            this.animations.drop(node, true);
+          }
+        }
+      }
+      const order = this._inPaintOrder([...this.promoted.keys()]);
+      for (let i = 0; i < order.length; i++) {
+        this._sync(order[i].node, i, root, layoutRan);
+      }
+    } finally {
+      native.txCommit();
+    }
+  }
+
+  _mayStay(node, key) {
+    if (!key || !promotableNode(node)) return false;
+    if (this.releasing.has(node)) return false; // its grace ran out
+    return this._clear(node);
+  }
+
+  _promote(node, root) {
+    const visual = new Visual(this, node);
+    visual.attach(this.rootVisual);
+    this.promoted.set(node, {
+      visual,
+      content: null,
+      dirty: { all: true, rects: [] },
+    });
+    node._promoted = true;
+    // the bitmap under it repaints without it, from this frame on
+    this._claim(root, node.paintBounds());
+  }
+
+  /**
+   * Off its layer and back into the bitmap, in this frame. `reclaim` hands
+   * what was waiting for a frame back to the clock; what was running is
+   * over either way, and the model shows — a loop comes back to the clock
+   * through `_offloadEnded`'s own rule.
+   */
+  _demote(node, root, reclaim) {
+    const p = this.promoted.get(node);
+    if (!p) return;
+    this.promoted.delete(node);
+    this._keep(node);
+    node._promoted = false;
+    this.animations.drop(node, reclaim && !node.destroyed);
+    this._dropContent(p);
+    p.visual.destroy();
+    if (!node.destroyed && node.abs) this._claim(root, node.paintBounds());
+  }
+
+  _dropContent(p) {
+    if (!p.content) return;
+    this.native.removeFromSuperlayer(p.content.layer);
+    p.content.raster.release(this.native);
+    p.content = null;
+  }
+
+  /** A claim of our own against the bitmap, kept off our own books. */
+  _claim(root, rect) {
+    if (!root || root.destroyed) return;
+    this._claiming = true;
+    try {
+      root.invalidate(false, rect, 'animation');
+    } finally {
+      this._claiming = false;
+    }
+  }
+
+  // --- where a node stands in the walk ----------------------------------------
+
+  /**
+   * The node's place in the window's paint order — its index in each
+   * ancestor's `paintOrder()`, top down — or null when the walk would not
+   * reach it: hidden, `display: none`, or not attached to a window.
+   */
+  _paintKey(node) {
+    const key = [];
+    for (let n = node; !n.isWindow; n = n.parent) {
+      const parent = n.parent;
+      if (!parent) return null;
+      const i = parent.paintOrder().indexOf(n);
+      if (i < 0) return null;
+      key.push(i);
+    }
+    return key.reverse();
+  }
+
+  _inPaintOrder(nodes) {
+    const keyed = nodes.map((node) => ({ node, key: this._paintKey(node) }));
+    keyed.sort((a, b) => {
+      if (!a.key || !b.key) return (a.key ? 1 : 0) - (b.key ? 1 : 0);
+      const n = Math.min(a.key.length, b.key.length);
+      for (let i = 0; i < n; i++) {
+        if (a.key[i] !== b.key[i]) return a.key[i] - b.key[i];
+      }
+      return a.key.length - b.key.length;
+    });
+    return keyed;
+  }
+
+  /**
+   * Is nothing painted over this node, and is all of it visible? Walked up
+   * the chain: at every level, what the parent paints after the child on
+   * the way to this node — later siblings, then the parent's own border and
+   * ring, then its bars — must keep out of the node's reach, and the
+   * parent's clip, if it has one, must hold the whole of it.
+   */
+  _clear(node) {
+    // the exact reach, not `paintBounds()`: that one carries the damage
+    // model's pixel of slop, and a section laid out flush under a card
+    // would read as reaching into it
+    const bounds = node._subtreeBounds();
+    for (let n = node; !n.isWindow; n = n.parent) {
+      const parent = n.parent;
+      if (!parent) return false;
+      const order = parent.paintOrder();
+      for (let j = order.indexOf(n) + 1; j < order.length; j++) {
+        if (this._reaches(order[j], bounds)) return false;
+      }
+      if (!parent.isWindow) {
+        const border = borderReach(parent);
+        if (
+          border > 0 &&
+          !containsRect(insetRect(parent.abs, border), bounds)
+        ) {
+          return false;
+        }
+        const ring = paintsOutline(parent);
+        if (ring) {
+          const inside = Math.max(0, ring.width / 2 - ring.offset) + 1;
+          if (!containsRect(insetRect(parent.abs, inside), bounds))
+            return false;
+        }
+        if (parent.clipsChildren?.()) {
+          const radius = parent.style?.borderRadius;
+          const clip =
+            typeof radius === 'number' && radius > 0
+              ? insetRect(parent.abs, radius)
+              : parent.abs;
+          if (!containsRect(clip, bounds)) return false;
+        }
+      }
+      if (typeof parent._scrollbars === 'function') {
+        for (const bar of parent._scrollbars()) {
+          if (rectsOverlap(scrollbarStrip(bar, this.scale), bounds)) {
+            return false;
+          }
+        }
+      }
+    }
+    return true;
+  }
+
+  /**
+   * Does anything in `n`'s subtree put ink inside `rect`? A promoted
+   * subtree does not: it is on a layer of its own, above this one since it
+   * is painted later. A subtree whose reach misses the rect is answered
+   * from the cached reach without a walk.
+   */
+  _reaches(n, rect) {
+    if (!rectsOverlap(n._subtreeBounds(), rect)) return false;
+    if (this.promoted.has(n)) return false;
+    if (paintsSomething(n) && rectsOverlap(n._ownPaintBounds(), rect)) {
+      return true;
+    }
+    if (n.kind === 'text') return true; // its spans are its own ink
+    for (const child of n.paintOrder()) {
+      if (this._reaches(child, rect)) return true;
+    }
+    return false;
+  }
+
+  // --- what the layer shows ----------------------------------------------------
+
+  _sync(node, order, root, layoutRan) {
+    const p = this.promoted.get(node);
+    p.visual.set(propBoxProps(node, this.app, this.scale, ORIGIN, order));
+    // after the model value went out, inside the same transaction
+    this.animations.apply(node, p.visual.layer);
+    this._syncContent(node, p, root, layoutRan);
+  }
+
+  /**
+   * The children, rastered into one sublayer at their reach: the node's own
+   * `_paintChildren` walk, translated so the reach lands at the bitmap's
+   * origin, with `paintDamage()` naming each pass the way the window's
+   * paint does. Repainted for the claims that reached into it since the
+   * last frame, for a change of size, and for any change in where the
+   * children sit inside the node — a layout pass can move them without a
+   * claim naming any of them, so a layout frame compares their rects.
+   */
+  _syncContent(node, p, root, layoutRan) {
+    const abs = node.abs;
+    let reach = null;
+    for (const child of node.paintOrder()) {
+      if (child._promoted) continue; // on a layer of its own
+      reach = unionRect(reach, child._subtreeBounds());
+    }
+    if (reach && node.clipsChildren?.()) reach = intersectRects(reach, abs);
+    if (!reach || !(reach.width > 0 && reach.height > 0)) {
+      this._dropContent(p);
+      p.dirty = { all: true, rects: [] };
+      return;
+    }
+    const rect = {
+      x: Math.floor(reach.x) - RASTER_PAD,
+      y: Math.floor(reach.y) - RASTER_PAD,
+      width: Math.ceil(reach.width) + RASTER_PAD * 2,
+      height: Math.ceil(reach.height) + RASTER_PAD * 2,
+    };
+    let content = p.content;
+    if (!content) {
+      const layer = this.native.createLayer();
+      this.native.addSublayer(p.visual.layer, layer);
+      content = p.content = {
+        layer,
+        raster: new RasterState(),
+        rect: null,
+        layoutKey: null,
+        props: {},
+      };
+    }
+    const s = this.scale;
+    const frame = [
+      (rect.x - abs.x) / s,
+      (rect.y - abs.y) / s,
+      rect.width / s,
+      rect.height / s,
+    ];
+    if (
+      !content.props.frame ||
+      frame.some((v, i) => v !== content.props.frame[i])
+    ) {
+      content.props.frame = frame;
+      this.native.setLayerProps(content.layer, { frame, zPosition: 0 });
+    }
+    const raster = content.raster;
+    const sizeChanged =
+      raster.width !== rect.width || raster.height !== rect.height;
+    const layoutKey =
+      layoutRan || !content.layoutKey ? layoutKeyOf(node) : null;
+    const moved =
+      content.rect && (content.rect.x !== rect.x || content.rect.y !== rect.y);
+    const full =
+      p.dirty.all ||
+      sizeChanged ||
+      (layoutKey !== null && layoutKey !== content.layoutKey) ||
+      (moved && p.dirty.rects.length > 0);
+    let passes = null;
+    if (full) {
+      passes = [null];
+    } else if (p.dirty.rects.length) {
+      for (const claimed of p.dirty.rects) {
+        const hit = intersectRects(wholePixels(claimed), rect);
+        if (hit) passes = addDamageRect(passes, hit);
+      }
+      if (passes) passes = damageToPaint(passes);
+    }
+    p.dirty = { all: false, rects: [] };
+    content.rect = rect;
+    if (layoutKey !== null) content.layoutKey = layoutKey;
+    if (!passes) return;
+    const ctx = raster.ensure(this, rect.width, rect.height, s);
+    ctx.save();
+    try {
+      ctx.translate(-rect.x, -rect.y);
+      for (const pass of passes) {
+        const area = pass ?? rect;
+        ctx.save();
+        try {
+          if (pass) {
+            ctx.beginPath();
+            ctx.rect(area.x, area.y, area.width, area.height);
+            ctx.clip();
+          }
+          ctx.clearRect(area.x, area.y, area.width, area.height);
+          root._paintDamage = pass;
+          node._paintChildren(ctx);
+        } finally {
+          root._paintDamage = null;
+          ctx.restore();
+        }
+      }
+    } finally {
+      ctx.restore();
+    }
+    this.native.surfaceToLayer(raster.surface, content.layer);
+  }
+
+  /** Everything off the root layer and freed: the window is going. */
+  destroy() {
+    for (const timer of this.idle.values()) clearTimeout(timer);
+    this.idle.clear();
+    this.releasing.clear();
+    for (const [node, p] of this.promoted) {
+      node._promoted = false;
+      this.animations.drop(node, false);
+      this._dropContent(p);
+      p.visual.destroy();
+    }
+    this.promoted.clear();
+    this.candidates.clear();
+  }
+}
+
+/**
+ * Where a node's drawn descendants sit inside it, as one string: the same
+ * arrangement gives the same key, and a raster painted for one is good for
+ * the other. Promoted subtrees are left out — they are on layers of their
+ * own — and so is anything that is not layout, which claims for itself.
+ */
+function layoutKeyOf(node) {
+  const ox = node.abs.x;
+  const oy = node.abs.y;
+  let key = '';
+  const walk = (n) => {
+    for (const child of n.paintOrder()) {
+      if (child._promoted) continue;
+      const a = child.abs;
+      key += `${a.x - ox},${a.y - oy},${a.width},${a.height};`;
+      if (child.kind !== 'text') walk(child);
+    }
+  };
+  walk(node);
+  return key;
+}

--- a/src/cocoa/window.js
+++ b/src/cocoa/window.js
@@ -9,6 +9,7 @@
 import { CocoaContext2D } from './context2d.js';
 import { CocoaDropTransport, dragSpec } from './dnd.js';
 import { CocoaLayerPresenter } from './presenter.js';
+import { CocoaPromotion } from './promotion.js';
 
 let nextWindowId = 1;
 
@@ -110,6 +111,22 @@ export class CocoaWindow {
         this._presenter.animate(node, prop, entry);
       this.cancelNodeAnimation = (node, prop) =>
         this._presenter.cancel(node, prop);
+    } else if (app._promote) {
+      // Layer promotion (src/cocoa/promotion.js): the surface presenter
+      // keeps the frame, and the nodes that animate get a layer of their
+      // own above it. The same two animation hooks as layers mode; the
+      // invalidate channel, for what the promoted rasters repaint; and the
+      // frame's word in before the paint, where a node is moved onto or off
+      // its layer and the bitmap under it claimed in the same frame.
+      this._promotion = new CocoaPromotion(this);
+      this.animateNode = (node, prop, entry) =>
+        this._promotion.animate(node, prop, entry);
+      this.cancelNodeAnimation = (node, prop) =>
+        this._promotion.cancel(node, prop);
+      this.noteInvalidate = (damage, layoutChanged) =>
+        this._promotion.noteInvalidate(damage, layoutChanged);
+      this.prepareFrame = (root, layoutRan) =>
+        this._promotion.frame(root, layoutRan);
     }
     app._registerWindow(this);
   }
@@ -224,6 +241,7 @@ export class CocoaWindow {
       this.app.cancelAttention(this._attentionRequest);
       this._attentionRequest = null;
     }
+    this._promotion?.destroy();
     this._native.destroyWindow2(this._h);
     this._releaseBacking();
   }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -188,7 +188,16 @@ export interface RootOptions {
    * The Cocoa backend's knobs (docs/macos.md). `presenter` picks the frame
    * path: `'surface'` (the measured default — one bitmap per window, the
    * X11 paint machinery over an IOSurface swapchain) or `'layers'` (one
-   * CALayer per drawn node, opt-in while it is measured).
+   * CALayer per drawn node, opt-in while it is measured). `promote` is the
+   * surface presenter's layer promotion: a plain `<box>` with a transition
+   * or a loop on its colour, border or radius gets a CALayer of its own
+   * above the bitmap for as long as it animates, and the render server
+   * draws the motion — no frames, and it keeps moving while the JS thread
+   * is busy. On by default where the bridge draws a layer's colour and a
+   * rastered one alike (`@windowkit/appkit` with `colorSpace()`; off on
+   * 0.5, where the two shades differed); `true` turns it on regardless,
+   * `false` keeps every animation on the frame clock.
+   * `REACT_X11_COCOA_PROMOTE=1` / `=0` say the same from the environment.
    * `frameInterval` is how often a scheduled frame may paint, in ms. By
    * default each window paces itself on the display it is on — 8.3ms on
    * a 120Hz panel, 16.7 on a 60Hz monitor, the screen's own refresh rate
@@ -208,6 +217,7 @@ export interface RootOptions {
    */
   cocoa?: {
     presenter?: 'surface' | 'layers';
+    promote?: boolean;
     frameInterval?: number;
     pumpInterval?: number;
     appName?: string;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -194,9 +194,10 @@ export interface RootOptions {
    * above the bitmap for as long as it animates, and the render server
    * draws the motion — no frames, and it keeps moving while the JS thread
    * is busy. On by default where the bridge draws a layer's colour and a
-   * rastered one alike (`@windowkit/appkit` with `colorSpace()`; off on
-   * 0.5, where the two shades differed); `true` turns it on regardless,
-   * `false` keeps every animation on the frame clock.
+   * rastered one alike (`@windowkit/appkit` >= 0.5.1, which says so with
+   * `colorSpace()`; off on 0.5.0, where the two shades differed); `true`
+   * turns it on regardless, `false` keeps every animation on the frame
+   * clock.
    * `REACT_X11_COCOA_PROMOTE=1` / `=0` say the same from the environment.
    * `frameInterval` is how often a scheduled frame may paint, in ms. By
    * default each window paces itself on the display it is on — 8.3ms on

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -1913,6 +1913,10 @@ export class Node {
     this._floorMeasureMode = null;
     this.root = null; // owning WindowNode once attached
     this.hidden = false;
+    // Composited on a layer of its own above the window's bitmap, by a
+    // presenter that can (src/cocoa/promotion.js): the paint walk leaves a
+    // hole where it is, and the presenter draws it — the `<glarea>` idiom.
+    this._promoted = false;
     this.destroyed = false;
     // absolute rect within the owning window, filled by absolutize()
     this.abs = { x: 0, y: 0, width: 0, height: 0 };
@@ -2285,10 +2289,11 @@ export class Node {
 
   // --- the presenter's half of an animation ---------------------------------
   //
-  // Three feature-detected hooks on the window (src/cocoa/window.js, layers
-  // mode only): `animateNode(node, prop, entry)` answers true when the
-  // presenter will run the entry itself, `cancelNodeAnimation(node, prop)`
-  // stops what it runs for the property, and the presenter calls back
+  // Two feature-detected hooks on the window (src/cocoa/window.js: the
+  // layer presenter, and the surface presenter's layer promotion —
+  // src/cocoa/promotion.js): `animateNode(node, prop, entry)` answers true
+  // when the presenter will run the entry itself, `cancelNodeAnimation(node,
+  // prop)` stops what it runs for the property, and the presenter calls back
   // through `_offloadEnded` / `_offloadDeclined` below. An entry the
   // presenter took is `offloaded`: it stays in `_anim` — so a retarget, a
   // loop-stop rule and `sameAnimation` all see it — but it contributes no
@@ -5315,6 +5320,7 @@ export class Node {
       ctx.clip();
     }
     for (const child of order) {
+      if (child._promoted) continue; // on a layer of its own: a hole here
       if (child._offscreen()) continue;
       if (child._outsideDamage()) continue;
       child.paint(ctx);
@@ -11552,6 +11558,13 @@ export class WindowNode extends Scrollable(Node) {
       watchDesktopSettings(this.app, () => this._refreshLoops()),
     ];
     this._loopVisibilityChanged();
+    // The window has a presenter now, which it did not when a loop declared
+    // at mount started on the clock (`_setRoot` runs before `realize`):
+    // every loop is asked again here, so one a presenter can take moves
+    // over on the window's first frame rather than at the next swap that
+    // happens to re-resolve its style. Where nothing can take it, the
+    // second look at an unchanged declaration is a no-op.
+    this._refreshLoops();
   }
 
   _unwatchLoops() {
@@ -11725,8 +11738,19 @@ export class WindowNode extends Scrollable(Node) {
     // A retained presenter keeps a per-node diff instead of damage rects,
     // and this is the one channel every change already announces itself on
     // (docs/macos.md §"One renderer, two presenters"). Feature-detected: an
-    // ntk window has no ear here and the X11 path is byte-identical.
-    this.window?.noteInvalidate?.(damage, layoutChanged, reason);
+    // ntk window has no ear here and the X11 path is byte-identical. A
+    // presenter that answers `true` has taken the claim onto a layer of its
+    // own (src/cocoa/promotion.js): the bitmap owes nothing for it, and the
+    // frame that is still owed — for the presenter's half, `prepareFrame` —
+    // paints nothing unless something else claims.
+    const taken =
+      this.window?.noteInvalidate?.(damage, layoutChanged, reason) === true;
+    if (taken && !layoutChanged) {
+      this._damage ??= [];
+      this.needsPaint = true;
+      this._scheduleFrame();
+      return;
+    }
     if (layoutChanged) {
       this.needsLayout = true;
       // The content floors are measured from the tree, so anything that
@@ -11832,6 +11856,11 @@ export class WindowNode extends Scrollable(Node) {
       this._damage = addDamageRect(this._damage, bounds, this._damageRectCap());
     }
     this.needsPaint = true;
+    this._scheduleFrame();
+  }
+
+  /** A frame, on the window's clock. */
+  _scheduleFrame() {
     // Recorded before the `_scheduled` gate, not inside it: the debt is
     // "this window has damage", which a discrete event may pay off early
     // (see frames.js). Tying it to whether a callback is outstanding would
@@ -11959,6 +11988,13 @@ export class WindowNode extends Scrollable(Node) {
       for (const node of this._reflowed) node._reflowBefore = null;
       this._reflowed.clear();
     }
+    // A presenter compositing part of the tree on layers of its own — the
+    // surface presenter's promoted nodes (src/cocoa/promotion.js) — gets
+    // its word in here: after layout, so it sees where everything landed,
+    // and before the damage is taken, so a node it moves onto or off a
+    // layer claims the bitmap under it in this very frame. Feature-detected
+    // like `presentFrame`; an ntk window has no such half.
+    this.window.prepareFrame?.(this, layoutRan);
     // any node this pass laid out may be what an open popup is anchored to
     if (layoutRan) this._notifyAnchorChange();
     // after layout (the claims above included), before the damage is taken:
@@ -12504,6 +12540,11 @@ export class WindowNode extends Scrollable(Node) {
           if (!check(child)) return false;
           continue;
         }
+        // A node on a layer of its own (src/cocoa/promotion.js) has no
+        // pixels in the bitmap the band is cut from, so nothing of it can
+        // be dragged along — a pulsing toast over a list is what promotion
+        // is for, and this is the half of it that keeps the pan a blit.
+        if (child._promoted) continue;
         if (rectsOverlap(child._subtreeBounds(), vp)) return false;
       }
       return true;
@@ -12706,6 +12747,14 @@ export class WindowNode extends Scrollable(Node) {
       this._lastReasons = EMPTY_REASONS;
     }
     if (damage === FULL_DAMAGE || !damage) return null;
+    // an empty list: every claim this frame made was answered on a layer of
+    // its own (`invalidate`, the presenter's `true`), and the bitmap paints
+    // nothing — which is not the same as nothing having been claimed
+    if (damage.length === 0) {
+      this._lastDamageRects = [];
+      this._lastDamage = { x: 0, y: 0, width: 0, height: 0 };
+      return [];
+    }
     const rects = [];
     for (const claimed of damage) {
       const clamped = this._clampDamage(claimed, width, height);

--- a/test/animation-example.test.js
+++ b/test/animation-example.test.js
@@ -7,8 +7,9 @@
 // that drifted from the code would be worse than no example, so every one
 // of them is a test.
 //
-// Headless: the in-process X server for the frame-clock half, and the mock
-// harness with the layer presenter over a recording bridge for the offload.
+// Headless: the in-process X server for the frame-clock half, the mock
+// harness with the layer presenter over a recording bridge for the offload,
+// and a CocoaApp over a fake bridge for the surface presenter's promotion.
 import { test, afterEach, describe } from 'node:test';
 import assert from 'node:assert/strict';
 import React from 'react';
@@ -23,6 +24,7 @@ import {
   withFrameClock,
 } from '../src/testing/index.js';
 import { setDesktopSettingsForTests } from '../src/desktopsettings.js';
+import { fakeCocoaApp, pointerOver } from './helpers/cocoa-bridge.js';
 import { animatingPresenterFor } from './helpers/layer-presenter.js';
 
 process.env.REACT_X11_NO_AUTORUN = '1';
@@ -149,6 +151,86 @@ describe('examples/animation', () => {
     }
   });
 
+  test('on the surface presenter the plain-box loops, the chip and the hovered card get layers of their own, and cost no frames', async () => {
+    const clock = withFrameClock();
+    try {
+      const { app, native } = fakeCocoaApp();
+      const { windowNode } = await mount({ app });
+      const promotion = windowNode.window._promotion;
+      assert.ok(promotion, 'the surface window promotes');
+      await act();
+      const promoted = () =>
+        [...promotion.promoted.keys()]
+          .map((n) => n.props['data-testname'] ?? n.kind)
+          .sort();
+      // declared at mount, the three loops moved over on the first frame
+      assert.deepEqual(promoted(), ['breathe', 'pulse', 'round']);
+      assert.deepEqual(
+        onTheClock(windowNode),
+        ['color', 'start'],
+        'the other column stays on the clock',
+      );
+      const taken = native
+        .of('addAnimation')
+        .map(([, keyPath, opts]) => [keyPath, opts.repeat, opts.autoreverse])
+        .sort();
+      assert.deepEqual(taken, [
+        ['backgroundColor', Infinity, true],
+        ['borderWidth', Infinity, true],
+        ['cornerRadius', Infinity, true],
+      ]);
+      // every promoted layer is a sublayer of the window root, and the
+      // three tiles kept their paint order
+      const rootLayer = windowNode.window._layer;
+      for (const { visual } of promotion.promoted.values()) {
+        assert.equal(visual.layer.parent, rootLayer);
+      }
+
+      // the hover card answers on a layer of its own — text and all
+      const card = screen.getByText('hover, press').parent;
+      pointerOver(app, card);
+      await act();
+      assert.ok(card._promoted, 'promoted for the fade');
+      assert.ok(
+        promotion.promoted.get(card).content,
+        'its two captions ride the layer as one raster',
+      );
+      assert.equal(
+        native
+          .of('addAnimation')
+          .filter(
+            ([layer]) => layer === promotion.promoted.get(card).visual.layer,
+          ).length,
+        2,
+        'backgroundColor and borderColor, in the render server',
+      );
+      assert.ok(!windowNode._animating.has(card));
+
+      // …and the chip, a plain box inside a bordered card: promoted on the
+      // click, above its card's raster
+      const chip = screen.getByTestName('chip');
+      pointerOver(app, chip, { press: true });
+      await act();
+      assert.ok(chip._promoted);
+      assert.deepEqual([...chip._anim.keys()].sort(), [
+        'backgroundColor',
+        'borderColor',
+        'borderRadius',
+        'borderWidth',
+      ]);
+      assert.ok([...chip._anim.values()].every((a) => a.offloaded));
+
+      // untick the clock column, and nothing is left for the frame clock
+      const column = screen.getByRole('checkbox', { name: /position/ });
+      pointerOver(app, column, { press: true, dx: -column.abs.width / 2 + 16 });
+      await act();
+      assert.equal(windowNode._animating.size, 0, 'zero frames a second');
+      assert.ok(promotion.animations.live.size >= 3, 'the tiles, still going');
+    } finally {
+      clock.restore();
+    }
+  });
+
   test('on the layer presenter the plain-box loops cost no frames', async () => {
     const clock = withFrameClock();
     try {
@@ -182,7 +264,7 @@ describe('examples/animation', () => {
       await act();
       assert.equal(windowNode._animating.size, 0, 'zero frames a second');
       assert.equal(
-        presenter.liveAnimations.size,
+        presenter.animations.live.size,
         3,
         'three tiles, still going',
       );

--- a/test/cocoa-presenter.test.js
+++ b/test/cocoa-presenter.test.js
@@ -367,7 +367,7 @@ test('a transition on a plain box runs in the render server: the model, one anim
   // the bridge reports the end: the entry goes, the model was there all along
   m.ends.get(opts.id)({ type: 'animation-end', id: opts.id, finished: true });
   assert.ok(!m.node._anim?.size);
-  assert.strictEqual(m.presenter.liveAnimations.size, 0);
+  assert.strictEqual(m.presenter.animations.live.size, 0);
 });
 
 test('a length retargets additively: the new delta joins the one still running', async () => {
@@ -470,7 +470,7 @@ test('a loop is one repeating animation in the render server, and stops with the
   assert.deepStrictEqual(m.bridge.argsOf('removeAnimation'), [[key]]);
   assert.ok(!m.node._anim?.size);
   m.presenter.frame(m.windowNode);
-  assert.strictEqual(m.presenter.liveAnimations.size, 0);
+  assert.strictEqual(m.presenter.animations.live.size, 0);
 });
 
 test('a layer that turns into a raster hands its loop back to the clock', async () => {
@@ -483,7 +483,7 @@ test('a layer that turns into a raster hands its loop back to the clock', async 
   const entry = m.node._anim.get('backgroundColor');
   assert.ok(entry?.loop && !entry.offloaded, 'the clock has it again');
   assert.ok(m.windowNode._animating.has(m.node));
-  assert.strictEqual(m.presenter.liveAnimations.size, 0);
+  assert.strictEqual(m.presenter.animations.live.size, 0);
 });
 
 test('a transition whose layer turns raster before its frame goes to the clock', async () => {

--- a/test/cocoa-promotion.test.js
+++ b/test/cocoa-promotion.test.js
@@ -548,8 +548,8 @@ test('promotion is on by default where the bridge draws layer and raster colours
   try {
     const srgb = fakeCocoaBridge();
     assert.equal(new CocoaApp(srgb)._promote, true);
-    // @windowkit/appkit 0.5 has no colorSpace verb: a layer's colour was a
-    // different shade from the same colour rastered, and a node moving
+    // @windowkit/appkit 0.5.0 has no colorSpace verb: a layer's colour was
+    // a different shade from the same colour rastered, and a node moving
     // between the two would show it
     const older = new Proxy(srgb, {
       get: (t, k) => (k === 'colorSpace' ? undefined : t[k]),

--- a/test/cocoa-promotion.test.js
+++ b/test/cocoa-promotion.test.js
@@ -1,0 +1,580 @@
+// Layer promotion (src/cocoa/promotion.js) over a fake bridge: the real
+// CocoaApp, its surface window and swapchain, the node tree and its frame
+// clock — only Core Animation and CoreGraphics are faked, so what a test
+// pins is the call that went out and the frame it went out in. What the
+// file is about is the contract issue #483 sets: a node with an animation a
+// layer can express gets a layer above the bitmap and costs no frames; the
+// paint walk leaves a hole under it in the same frame; anything painted
+// over it, clipping it, or ringing it keeps it on the clock; and every way
+// off a layer lands back in the bitmap in the frame that finds it.
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+
+import { CocoaApp } from '../src/cocoa/app.js';
+import { withFrameClock } from '../src/testing/index.js';
+import {
+  cleanupCocoa,
+  fakeCocoaBridge,
+  mountCocoa,
+  tick,
+} from './helpers/cocoa-bridge.js';
+
+const h = React.createElement;
+
+afterEach(cleanupCocoa);
+
+// device pixels: the window is scale 2
+const px = (v) => v * 2;
+
+/** The `ctxFillRect` calls that painted exactly `rect` (device pixels),
+ *  on any surface, or on `surface` when given. */
+const fillsOf = (native, rect, surface = null) =>
+  native
+    .of('ctxFillRect')
+    .filter(
+      ([s, x, y, w, hh]) =>
+        (surface === null || s.id === surface.id) &&
+        x === rect.x &&
+        y === rect.y &&
+        w === rect.width &&
+        hh === rect.height,
+    ).length;
+
+const rootLayer = (m) => m.wnd._layer;
+const layerOf = (m, node) => m.promotion.promoted.get(node)?.visual.layer;
+const box = (style, ...children) => h('box', { style }, ...children);
+/** …with a key, for the tests that render a list of them. */
+const kbox = (key, style, ...children) => h('box', { key, style }, ...children);
+const at = (left, top, width, height, more = {}) => ({
+  position: 'absolute',
+  left,
+  top,
+  width,
+  height,
+  ...more,
+});
+
+const fade = at(10, 10, 40, 20, {
+  backgroundColor: '#ff0000',
+  transition: { backgroundColor: 120 },
+});
+const pulse = at(10, 10, 40, 20, {
+  backgroundColor: '#ff0000',
+  animation: {
+    backgroundColor: { to: '#00ff00', duration: 900, alternate: true },
+  },
+});
+
+test('a transition on a plain box: a layer above the bitmap, the animation in the render server, a hole under it, no frames', async () => {
+  const m = await mountCocoa(box(fade));
+  const node = m.node.children[0];
+  const rect = { x: px(10), y: px(10), width: px(40), height: px(20) };
+  assert.equal(fillsOf(m.native, rect), 1, 'the mount painted it');
+  assert.equal(m.wnd.animateNode !== undefined, true, 'the seam is there');
+
+  await m.render(box({ ...fade, backgroundColor: '#0000ff' }));
+  const entry = node._anim.get('backgroundColor');
+  assert.ok(entry?.offloaded, 'taken off the clock at the swap');
+  assert.equal(m.node._animating.size, 0);
+  assert.equal(node.style.backgroundColor, '#0000ff', 'the model');
+  assert.equal(node._promoted, false, 'decided by the frame, not the swap');
+
+  const before = m.frames.count;
+  m.frame();
+  assert.equal(m.frames.count, before + 1, 'the one frame that sends it');
+  assert.equal(node._promoted, true);
+  const layer = layerOf(m, node);
+  assert.equal(layer.parent, rootLayer(m), 'a sublayer of the window root');
+  assert.deepEqual(layer.props.frame, [10, 10, 40, 20], 'in points');
+  assert.deepEqual(layer.props.backgroundColor, [0, 0, 1, 1]);
+  const anims = m.native.of('addAnimation');
+  assert.equal(anims.length, 1);
+  const [animLayer, keyPath, opts] = anims[0];
+  assert.equal(animLayer, layer);
+  assert.equal(keyPath, 'backgroundColor');
+  assert.deepEqual(
+    [opts.from, opts.to],
+    [
+      [1, 0, 0, 1],
+      [0, 0, 1, 1],
+    ],
+  );
+  // the hole: this frame repainted the bitmap under the node, without it
+  const damage = m.node._lastDamageRects;
+  assert.ok(
+    damage?.some(
+      (r) =>
+        r.x <= rect.x &&
+        r.y <= rect.y &&
+        r.x + r.width >= rect.x + rect.width &&
+        r.y + r.height >= rect.y + rect.height,
+    ),
+    `the frame's damage covers the node: ${JSON.stringify(damage)}`,
+  );
+  assert.equal(fillsOf(m.native, rect), 1, 'and the walk did not paint it');
+  assert.equal(m.node._animating.size, 0, 'nothing for the clock');
+
+  // more frames change nothing about it
+  m.frame();
+  assert.equal(m.native.of('addAnimation').length, 1, 'attached once');
+  assert.equal(m.native.of('createLayer').length, 1);
+
+  // a retarget while it is up there is answered on the layer: the frame
+  // paints nothing into the bitmap
+  await m.render(box({ ...fade, backgroundColor: '#00ff00' }));
+  m.frame();
+  assert.deepEqual(m.node._lastDamageRects, [], 'nothing for the bitmap');
+  assert.equal(fillsOf(m.native, rect), 1);
+  assert.equal(m.native.of('addAnimation').length, 2);
+  assert.deepEqual(layer.props.backgroundColor, [0, 1, 0, 1]);
+});
+
+test('the render server reporting the end leaves the layer for the grace, then one frame takes the node back into the bitmap', async () => {
+  const m = await mountCocoa(box(fade));
+  const node = m.node.children[0];
+  const rect = { x: px(10), y: px(10), width: px(40), height: px(20) };
+  await m.render(box({ ...fade, backgroundColor: '#0000ff' }));
+  m.frame();
+  const layer = layerOf(m, node);
+  const [, , opts] = m.native.of('addAnimation')[0];
+
+  const frames = m.frames.count;
+  m.native.emit({ type: 'animation-end', id: opts.id, finished: true });
+  assert.ok(!node._anim?.size, 'the entry is gone');
+  assert.equal(node._promoted, true, 'the layer stays for the grace');
+  assert.equal(m.promotion.idle.size, 1);
+  await tick();
+  m.frame();
+  assert.equal(m.frames.count, frames, 'and no frame was asked for');
+
+  // a new transition inside the grace keeps it, with no layer churn
+  await m.render(box({ ...fade, backgroundColor: '#00ff00' }));
+  assert.equal(m.promotion.idle.size, 0);
+  m.frame();
+  assert.equal(m.native.of('createLayer').length, 1);
+  assert.equal(m.native.of('addAnimation').length, 2);
+  const [, , second] = m.native.of('addAnimation')[1];
+  m.native.emit({ type: 'animation-end', id: second.id, finished: true });
+
+  // the grace runs out
+  m.promotion.releaseIdle();
+  await tick();
+  m.frame();
+  assert.equal(m.frames.count, frames + 2, 'one frame for the release');
+  assert.equal(node._promoted, false);
+  assert.equal(layer.parent, null, 'the layer is off the root');
+  assert.equal(m.promotion.promoted.size, 0);
+  assert.equal(fillsOf(m.native, rect), 2, 'painted back in, at the model');
+  assert.equal(m.node._animating.size, 0);
+});
+
+test('a pan under a promoted toast keeps its blit', async () => {
+  const rows = () =>
+    box(
+      { flexGrow: 1, overflow: 'scroll' },
+      ...Array.from({ length: 60 }, (_, i) =>
+        h('box', {
+          key: i,
+          style: { height: 28, backgroundColor: i % 2 ? '#f6f8fb' : '#ffffff' },
+        }),
+      ),
+    );
+  const toast = at(120, 90, 60, 20, {
+    right: 10,
+    bottom: 10,
+    borderRadius: 6,
+    backgroundColor: '#2d3436',
+    animation: {
+      backgroundColor: { to: '#6c5ce7', duration: 900, alternate: true },
+    },
+  });
+  for (const promote of [false, true]) {
+    // big enough for the blit's worth-it heuristics: a notch is 48px of a
+    // 600px viewport
+    const m = await mountCocoa(
+      [
+        kbox('rows', rows().props.style, ...rows().props.children),
+        kbox('toast', toast),
+      ],
+      {
+        promote,
+        width: 400,
+        height: 300,
+      },
+    );
+    const scroller = m.node.children[0];
+    const s = m.wnd.scale;
+    const x = (scroller.abs.x + scroller.abs.width / 2) / s;
+    const y = (scroller.abs.y + scroller.abs.height / 2) / s;
+    assert.equal(m.node.children[1]._promoted, promote);
+    const blits = m.native.of('scrollSurface').length;
+    m.app._routeWheel({
+      type: 'wheel',
+      windowNumber: m.wnd.windowNumber,
+      x,
+      y,
+      gx: x,
+      gy: y,
+      dx: 0,
+      dy: -1,
+      precise: false,
+      time: performance.now(),
+    });
+    await tick();
+    m.frame();
+    assert.equal(
+      m.native.of('scrollSurface').length - blits,
+      promote ? 1 : 0,
+      `promote ${promote}: a toast in the bitmap is dragged by a blit, one on a layer is not`,
+    );
+    await cleanupCocoa();
+  }
+});
+
+test('a loop keeps its layer for as long as it runs, and gives it back when it stops', async () => {
+  const m = await mountCocoa(box(pulse));
+  const node = m.node.children[0];
+  // declared at mount the loop started on the clock, before the window had
+  // a presenter; the window's first frame re-asks every loop (`_watchLoops`)
+  assert.ok(node._anim.get('backgroundColor')?.offloaded);
+  assert.equal(node._promoted, true, 'from the first frame');
+  assert.equal(m.node._animating.size, 0);
+  const [, keyPath, opts, key] = m.native.of('addAnimation')[0];
+  assert.equal(keyPath, 'backgroundColor');
+  assert.equal(opts.repeat, Infinity);
+  assert.equal(opts.autoreverse, true);
+  m.frame();
+  assert.equal(m.native.of('addAnimation').length, 1, 'phase kept');
+
+  await m.render(box({ ...pulse, display: 'none' }));
+  assert.deepEqual(
+    m.native.of('removeAnimation').map(([, k]) => k),
+    [key],
+  );
+  m.frame();
+  assert.equal(node._promoted, false, 'hidden: off its layer');
+  assert.equal(m.promotion.promoted.size, 0);
+  assert.equal(m.node._animating.size, 0);
+});
+
+test('a later sibling reaching into the node keeps it on the clock, until the layout changes', async () => {
+  const clock = withFrameClock();
+  try {
+    const over = at(30, 15, 40, 20, { backgroundColor: '#00ff00' });
+    const m = await mountCocoa([kbox('a', fade), kbox('b', over)]);
+    const node = m.node.children[0];
+    await m.render([
+      kbox('a', { ...fade, backgroundColor: '#0000ff' }),
+      kbox('b', over),
+    ]);
+    assert.ok(node._anim.get('backgroundColor').offloaded, 'taken at the swap');
+    m.frame();
+    // …and declined by the frame, from the top: the clock has it
+    const entry = node._anim.get('backgroundColor');
+    assert.ok(entry && !entry.offloaded);
+    assert.ok(m.node._animating.has(node));
+    assert.equal(node._promoted, false);
+    assert.equal(m.native.of('createLayer').length, 0);
+    assert.equal(m.native.of('addAnimation').length, 0);
+    assert.equal(
+      node.style.backgroundColor,
+      '#ff0000',
+      'painted from the declared start, never at the target',
+    );
+    clock.advance(200);
+    m.frame();
+    assert.equal(node.style.backgroundColor, '#0000ff');
+
+    // the same scene answers at the swap, with no frame spent on it
+    await m.render([
+      kbox('a', { ...fade, backgroundColor: '#00ffff' }),
+      kbox('b', over),
+    ]);
+    assert.ok(!node._anim.get('backgroundColor').offloaded);
+    assert.equal(m.promotion.candidates.size, 0);
+    clock.advance(200);
+    m.frame();
+
+    // the sibling moves away: a layout, and the next swap is promoted
+    const away = { ...over, left: 120 };
+    await m.render([
+      kbox('a', { ...fade, backgroundColor: '#00ffff' }),
+      kbox('b', away),
+    ]);
+    m.frame();
+    await m.render([
+      kbox('a', { ...fade, backgroundColor: '#ff00ff' }),
+      kbox('b', away),
+    ]);
+    assert.ok(node._anim.get('backgroundColor').offloaded);
+    m.frame();
+    assert.equal(node._promoted, true);
+    assert.equal(m.native.of('addAnimation').length, 1);
+  } finally {
+    clock.restore();
+  }
+});
+
+test('a later subtree only counts where it puts ink: a layout-only box over the node is no overlap', async () => {
+  const m = await mountCocoa([
+    kbox('a', fade),
+    // a container laid over the node with nothing painted in it, and a
+    // child of its own well clear of the node
+    kbox(
+      'b',
+      at(0, 0, 200, 120),
+      box(at(150, 80, 20, 20, { backgroundColor: '#00ff00' })),
+    ),
+  ]);
+  const node = m.node.children[0];
+  await m.render([
+    kbox('a', { ...fade, backgroundColor: '#0000ff' }),
+    kbox(
+      'b',
+      at(0, 0, 200, 120),
+      box(at(150, 80, 20, 20, { backgroundColor: '#00ff00' })),
+    ),
+  ]);
+  m.frame();
+  assert.equal(node._promoted, true);
+});
+
+test("an ancestor's border ring is painted after the node: promoted only clear of it", async () => {
+  const card = at(10, 10, 100, 60, { borderWidth: 4, borderColor: '#000000' });
+  // a chip over the ring, and one inside the padding box
+  for (const [left, promoted] of [
+    [-2, false],
+    [10, true],
+  ]) {
+    const chip = at(left, 10, 40, 20, {
+      backgroundColor: '#ff0000',
+      transition: { backgroundColor: 120 },
+    });
+    const m = await mountCocoa(box(card, box(chip)));
+    const node = m.node.children[0].children[0];
+    await m.render(box(card, box({ ...chip, backgroundColor: '#0000ff' })));
+    m.frame();
+    assert.equal(node._promoted, promoted, `left ${left}`);
+    await cleanupCocoa();
+  }
+});
+
+test('a clipping ancestor has to hold the whole of it', async () => {
+  const clip = at(10, 10, 100, 60, { overflow: 'hidden' });
+  for (const [left, promoted] of [
+    [80, false],
+    [20, true],
+  ]) {
+    const chip = at(left, 10, 40, 20, {
+      backgroundColor: '#ff0000',
+      transition: { backgroundColor: 120 },
+    });
+    const m = await mountCocoa(box(clip, box(chip)));
+    const node = m.node.children[0].children[0];
+    await m.render(box(clip, box({ ...chip, backgroundColor: '#0000ff' })));
+    m.frame();
+    assert.equal(node._promoted, promoted, `left ${left}`);
+    await cleanupCocoa();
+  }
+});
+
+test('what the layer cannot express takes the node back to the bitmap, the loop to the clock', async () => {
+  const m = await mountCocoa(box(pulse));
+  const node = m.node.children[0];
+  assert.equal(node._promoted, true);
+  const layer = layerOf(m, node);
+  await m.render(box({ ...pulse, boxShadow: '0 2px 4px #00000080' }));
+  m.frame();
+  assert.equal(node._promoted, false);
+  assert.equal(layer.parent, null);
+  const entry = node._anim.get('backgroundColor');
+  assert.ok(entry?.loop && !entry.offloaded, 'the clock has the loop');
+  assert.ok(m.node._animating.has(node));
+});
+
+test('the frame that finds a later sibling over the node takes it off its layer and paints it back', async () => {
+  const m = await mountCocoa([
+    kbox('a', pulse),
+    kbox('b', at(120, 80, 20, 20, { backgroundColor: '#00ff00' })),
+  ]);
+  const node = m.node.children[0];
+  const rect = { x: px(10), y: px(10), width: px(40), height: px(20) };
+  assert.equal(node._promoted, true);
+  const layer = layerOf(m, node);
+  const fills = fillsOf(m.native, rect);
+  await m.render([
+    kbox('a', pulse),
+    kbox('b', at(30, 15, 20, 20, { backgroundColor: '#00ff00' })),
+  ]);
+  m.frame();
+  assert.equal(node._promoted, false);
+  assert.equal(layer.parent, null);
+  assert.equal(fillsOf(m.native, rect), fills + 1, 'in the same frame');
+  assert.ok(m.node._animating.has(node), 'the loop runs on the clock');
+});
+
+test('children ride the layer as one raster, repainted for their own claims only', async () => {
+  const card = at(10, 10, 120, 40, {
+    padding: 8,
+    backgroundColor: '#ffffff',
+    borderWidth: 1,
+    borderColor: '#cccccc',
+    transition: { backgroundColor: 120 },
+  });
+  const label = (text) => h('text', { style: { color: '#333333' } }, text);
+  const m = await mountCocoa(box(card, label('hello')));
+  const node = m.node.children[0];
+  await m.render(box({ ...card, backgroundColor: '#eeeeee' }, label('hello')));
+  m.frame();
+  assert.equal(node._promoted, true);
+  const layer = layerOf(m, node);
+  const content = m.promotion.promoted.get(node).content;
+  assert.ok(content, 'a raster for the text');
+  assert.equal(content.layer.parent, layer, "inside the node's layer");
+  assert.equal(content.layer.contents, content.raster.surface.id);
+  const uploads = () =>
+    m.native.of('surfaceToLayer').filter(([, l]) => l === content.layer).length;
+  assert.equal(uploads(), 1);
+
+  // a retarget of the box itself: the layer's model moves, the raster does not
+  await m.render(box({ ...card, backgroundColor: '#dddddd' }, label('hello')));
+  m.frame();
+  assert.equal(uploads(), 1);
+  assert.equal(m.native.of('addAnimation').length, 2);
+
+  // the text changes: its claim reaches the raster
+  await m.render(
+    box({ ...card, backgroundColor: '#dddddd' }, label('changed')),
+  );
+  m.frame();
+  assert.equal(uploads(), 2);
+});
+
+test("a promoted node inside a promoted node: a hole in the parent's raster, and a layer above its parent's", async () => {
+  const card = at(10, 10, 120, 60, {
+    padding: 12,
+    backgroundColor: '#ffffff',
+    borderWidth: 1,
+    borderColor: '#cccccc',
+    transition: { backgroundColor: 120 },
+  });
+  const chip = {
+    width: 30,
+    height: 20,
+    backgroundColor: '#ff0000',
+    transition: { backgroundColor: 120 },
+  };
+  const m = await mountCocoa(box(card, box(chip)));
+  const cardNode = m.node.children[0];
+  const chipNode = cardNode.children[0];
+  await m.render(
+    box(
+      { ...card, backgroundColor: '#eeeeee' },
+      box({ ...chip, backgroundColor: '#0000ff' }),
+    ),
+  );
+  m.frame();
+  assert.equal(cardNode._promoted, true);
+  assert.equal(chipNode._promoted, true);
+  const cardLayer = layerOf(m, cardNode);
+  const chipLayer = layerOf(m, chipNode);
+  assert.equal(chipLayer.parent, rootLayer(m), 'flat on the root');
+  assert.ok(chipLayer.props.zPosition > cardLayer.props.zPosition);
+  assert.equal(
+    m.promotion.promoted.get(cardNode).content,
+    null,
+    'nothing left for the card to raster',
+  );
+  const chipRect = {
+    x: chipNode.abs.x,
+    y: chipNode.abs.y,
+    width: chipNode.abs.width,
+    height: chipNode.abs.height,
+  };
+  assert.equal(fillsOf(m.native, chipRect), 1, 'painted once, at the mount');
+});
+
+test('unmounting a promoted node takes its layer off the root', async () => {
+  const m = await mountCocoa([
+    kbox('a', pulse),
+    kbox('b', at(100, 80, 20, 20)),
+  ]);
+  const node = m.node.children[0];
+  assert.equal(node._promoted, true);
+  const layer = layerOf(m, node);
+  await m.render([kbox('b', at(100, 80, 20, 20))]);
+  assert.ok(node.destroyed);
+  m.frame();
+  assert.equal(layer.parent, null);
+  assert.equal(m.promotion.promoted.size, 0);
+  assert.equal(m.promotion.animations.live.size, 0);
+});
+
+test('a loop that stops leaves its node on the layer for the grace, then the bitmap takes it back', async () => {
+  const m = await mountCocoa(box(pulse));
+  const node = m.node.children[0];
+  const rect = { x: px(10), y: px(10), width: px(40), height: px(20) };
+  // declared at mount, promoted on the first frame: the bitmap never held it
+  assert.equal(node._promoted, true);
+  assert.equal(fillsOf(m.native, rect), 0);
+  await m.render(box({ ...pulse, animation: undefined }));
+  assert.equal(m.native.of('removeAnimation').length, 1, 'stopped');
+  m.frame();
+  assert.equal(node._promoted, true, 'held for the grace');
+  assert.equal(m.promotion.idle.size, 1);
+  assert.equal(fillsOf(m.native, rect), 0, 'not painted back yet');
+  m.promotion.releaseIdle();
+  await tick();
+  m.frame();
+  assert.equal(node._promoted, false);
+  assert.equal(fillsOf(m.native, rect), 1, 'painted, at the resting style');
+  assert.equal(m.promotion.idle.size, 0);
+});
+
+test('the window going takes every layer with it', async () => {
+  const m = await mountCocoa(box(pulse));
+  const node = m.node.children[0];
+  const layer = layerOf(m, node);
+  assert.ok(layer.parent);
+  await m.root.unmount();
+  assert.equal(layer.parent, null);
+  assert.equal(node._promoted, false);
+});
+
+test('promotion is on by default where the bridge draws layer and raster colours alike, and off before that', () => {
+  const env = process.env.REACT_X11_COCOA_PROMOTE;
+  delete process.env.REACT_X11_COCOA_PROMOTE;
+  try {
+    const srgb = fakeCocoaBridge();
+    assert.equal(new CocoaApp(srgb)._promote, true);
+    // @windowkit/appkit 0.5 has no colorSpace verb: a layer's colour was a
+    // different shade from the same colour rastered, and a node moving
+    // between the two would show it
+    const older = new Proxy(srgb, {
+      get: (t, k) => (k === 'colorSpace' ? undefined : t[k]),
+    });
+    assert.equal(new CocoaApp(older)._promote, false);
+    assert.equal(
+      new CocoaApp(older, { cocoa: { promote: true } })._promote,
+      true,
+      'asked for, it is on regardless',
+    );
+    process.env.REACT_X11_COCOA_PROMOTE = '1';
+    assert.equal(new CocoaApp(older)._promote, true);
+    process.env.REACT_X11_COCOA_PROMOTE = '0';
+    assert.equal(new CocoaApp(srgb)._promote, false);
+  } finally {
+    if (env === undefined) delete process.env.REACT_X11_COCOA_PROMOTE;
+    else process.env.REACT_X11_COCOA_PROMOTE = env;
+  }
+});
+
+test('cocoa.promote: false leaves the surface window with no animation seam', async () => {
+  const m = await mountCocoa(box(pulse), { promote: false });
+  const node = m.node.children[0];
+  assert.equal(m.wnd.animateNode, undefined);
+  assert.equal(m.promotion, null);
+  assert.ok(m.node._animating.has(node), 'the clock runs it');
+  assert.equal(m.native.of('createLayer').length, 0);
+});

--- a/test/helpers/cocoa-bridge.js
+++ b/test/helpers/cocoa-bridge.js
@@ -1,0 +1,353 @@
+// A @windowkit/appkit-shaped bridge under a real CocoaApp: windows with a
+// number and a frame, the surface swapchain, a layer tree that remembers
+// its shape, and the font natives a `<text>` needs — so the surface
+// presenter runs end to end over it, headless, on any OS, and a test pins
+// what reached the natives and which frame it reached them in. The window
+// half is test/cocoa-frames.test.js's fake, the font half
+// test/cocoa-glyph-runs.test.js's; the layer half models what
+// src/cocoa/promotion.js and the layer presenter both assert against.
+import React from 'react';
+
+import { CocoaApp } from '../../src/cocoa/app.js';
+import { setCompositingForTests } from '../../src/compositing.js';
+import { createRoot } from '../../src/index.js';
+import { setScaleForTests } from '../../src/scale.js';
+import { setScreensForTests } from '../../src/screens.js';
+
+const h = React.createElement;
+
+export function fakeCocoaBridge({ screens } = {}) {
+  const calls = [];
+  const released = new Set();
+  const fonts = new Map();
+  let seq = 0;
+  let backendCb = null;
+  let presentation = null;
+  const fontFor = (key, props) => {
+    let font = fonts.get(key);
+    if (!font) fonts.set(key, (font = { key, ...props }));
+    return font;
+  };
+  const base = {
+    calls,
+    released,
+    /** every recorded call of `name`, as its argument list */
+    of: (name) => calls.filter((c) => c.name === name).map((c) => c.args),
+    visible: true,
+    emit: (ev) => backendCb?.(ev),
+    setPresentation: (value) => {
+      presentation = value;
+    },
+
+    // --- the app and its windows ---------------------------------------------
+    listScreens: () =>
+      screens ?? [
+        {
+          x: 0,
+          y: 0,
+          width: 1440,
+          height: 900,
+          scale: 2,
+          visible: { x: 0, y: 0, width: 1440, height: 875 },
+          primary: true,
+        },
+      ],
+    initApp() {},
+    setBackendEventCallback(cb) {
+      backendCb = cb;
+    },
+    createWindow2(options) {
+      const id = ++seq;
+      return {
+        id,
+        options: { ...options },
+        root: { layer: `root${id}`, props: {}, sublayers: [], parent: null },
+      };
+    },
+    windowNumber: (handle) => handle.id,
+    windowRootLayer: (handle) => handle.root,
+    getWindowFrame: (handle) => ({
+      x: handle.options.x ?? 0,
+      y: handle.options.y ?? 0,
+      width: handle.options.width,
+      height: handle.options.height,
+    }),
+    showWindow() {},
+    hideWindow() {},
+    destroyWindow2() {},
+    windowIsVisible: () => base.visible,
+    setWindowFrame(handle, x, y, width, height) {
+      if (typeof x === 'number') handle.options.x = x;
+      if (typeof y === 'number') handle.options.y = y;
+      if (typeof width === 'number') handle.options.width = width;
+      if (typeof height === 'number') handle.options.height = height;
+      backendCb?.({
+        type: 'window-resize',
+        windowNumber: handle.id,
+        width: handle.options.width,
+        height: handle.options.height,
+        x: handle.options.x ?? 0,
+        y: handle.options.y ?? 0,
+        live: false,
+      });
+    },
+
+    // --- surfaces --------------------------------------------------------------
+    createSurfaceIOSurface(width, height, scale) {
+      const id = ++seq;
+      return { handle: { id, width, height, scale }, iosurfaceId: id };
+    },
+    createSurface(width, height, scale) {
+      return { id: ++seq, width, height, scale };
+    },
+    releaseSurface(handle) {
+      released.add(handle.id);
+    },
+    surfaceSize: (handle) => ({
+      width: handle.width,
+      height: handle.height,
+      scale: handle.scale,
+    }),
+    setLayerContentsIOSurface(layer, id) {
+      if (released.has(id)) {
+        throw new Error('IOSurfaceLookup: no surface with that id');
+      }
+    },
+    scrollSurface: () => true,
+
+    // --- native bezels (the shape of cocoa-bezel-cache.test.js's fake) ---------
+    measureControl: () => ({ width: 20, height: 20 }),
+    drawControlIntoSurface() {},
+    // every pixel inked, so the bezel scan finds the whole frame
+    ctxGetImageData: (surface, x, y, w, hh) =>
+      new Uint8Array(w * hh * 4).fill(255),
+
+    // --- layers ----------------------------------------------------------------
+    createLayer: () => ({
+      layer: ++seq,
+      props: {},
+      sublayers: [],
+      parent: null,
+    }),
+    addSublayer(parent, child) {
+      if (child.parent) {
+        child.parent.sublayers = child.parent.sublayers.filter(
+          (l) => l !== child,
+        );
+      }
+      child.parent = parent;
+      parent.sublayers.push(child);
+    },
+    removeFromSuperlayer(layer) {
+      if (!layer.parent) return;
+      layer.parent.sublayers = layer.parent.sublayers.filter(
+        (l) => l !== layer,
+      );
+      layer.parent = null;
+    },
+    setLayerProps(layer, props) {
+      Object.assign(layer.props, props);
+    },
+    surfaceToLayer(surface, layer) {
+      layer.contents = surface.id;
+    },
+    presentationValue: () => presentation,
+    // the bridge draws a layer's colour and a rastered one in the same
+    // space (windowkit/appkit's colorSpace verb), which is what lets the
+    // surface presenter promote by default
+    colorSpace: () => 'sRGB',
+    txBegin() {},
+    txCommit() {},
+
+    // --- fonts (the shape of cocoa-glyph-runs.test.js's fake) ------------------
+    matchFont({ families, size, weight, italic }) {
+      const family = families[0];
+      return fontFor(`${family}|${weight}|${italic}|${size}`, {
+        ps: `${family}-${weight}${italic ? 'Italic' : ''}`,
+        family,
+        size,
+      });
+    },
+    fontMetrics(f) {
+      return {
+        ascent: f.size * 0.8,
+        descent: f.size * 0.2,
+        leading: f.size * 0.1,
+        capHeight: f.size * 0.7,
+        xHeight: f.size * 0.5,
+        size: f.size,
+        familyName: f.family,
+        postScriptName: f.ps,
+      };
+    },
+    fontHasGlyph: (f, text) => text.codePointAt(0) < 0x80,
+    fontGlyphForCodepoint: (f, cp) => (cp < 0x80 ? cp + 1 : null),
+    fontGlyphAdvances: (f, glyphs) =>
+      Float64Array.from(glyphs, () => f.size * 0.6),
+    fontFallbackFor: (f) => f,
+    fontWithSize: (f, size) =>
+      fontFor(`${f.ps}@${size}`, { ps: f.ps, family: f.family, size }),
+    // one line, 8px a code point, the ascent and descent of the metrics
+    // above: enough for a `<text>` to measure, lay out and be painted
+    createLayout({ spans }) {
+      const text = spans.map((span) => span.text).join('');
+      const size = spans[0]?.size ?? 14;
+      const width = [...text].length * 8;
+      const height = Math.round(size * 1.1);
+      return {
+        handle: { layout: ++seq },
+        width,
+        height,
+        lines: [
+          {
+            start: 0,
+            end: text.length,
+            x: 0,
+            y: 0,
+            width,
+            height,
+            baseline: size * 0.8,
+            ascent: size * 0.8,
+            descent: size * 0.2,
+          },
+        ],
+      };
+    },
+    layoutIndexAt: () => 0,
+    layoutCaret: () => ({ x: 0, y: 0, height: 14 }),
+    fontShapeText(f, text) {
+      const cps = [...text].map((ch) => ch.codePointAt(0));
+      return {
+        width: cps.length * 8,
+        runs: cps.length
+          ? [
+              {
+                font: null,
+                glyphs: Uint16Array.from(cps, (cp) => cp + 1),
+                positions: Float64Array.from(cps.flatMap((_, i) => [i * 8, 0])),
+                advances: Float64Array.from(cps, () => 8),
+              },
+            ]
+          : [],
+      };
+    },
+  };
+  // every call is recorded, answered by the base where it has an answer
+  return new Proxy(base, {
+    get(target, name) {
+      if (typeof name !== 'string') return target[name];
+      if (name in target && typeof target[name] !== 'function') {
+        return target[name];
+      }
+      return (...args) => {
+        calls.push({ name, args });
+        return name in target ? target[name](...args) : undefined;
+      };
+    },
+  });
+}
+
+export const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+const mounted = [];
+
+/** Take down everything `mountCocoa` made — for an `afterEach`. */
+export async function cleanupCocoa() {
+  for (const root of mounted.splice(0)) await root.unmount();
+}
+
+/**
+ * A `<window>` with `children` under a CocoaApp over the fake, at scale 2
+ * and with no pump: a frame runs when the test says so (`frame()`), and
+ * the cadence gate is off. `render(next)` re-renders the window's children.
+ */
+/**
+ * A CocoaApp over the fake, seeded the way `createCocoaApp` seeds the
+ * platform stores — scale 2, one screen, a compositor — with no pump: a
+ * frame runs when the test says so (`app._tickFrames()`), and the cadence
+ * gate is off. `cocoa` is the `createRoot({ cocoa })` bag.
+ */
+export function fakeCocoaApp(cocoa = {}, { native = fakeCocoaBridge() } = {}) {
+  const app = new CocoaApp(native, { cocoa });
+  setScaleForTests(app, 2, 'cocoa');
+  setScreensForTests(app, {
+    monitors: [{ x: 0, y: 0, width: 2880, height: 1800 }],
+    workArea: { x: 0, y: 0, width: 2880, height: 1750 },
+  });
+  setCompositingForTests(app, true);
+  app._frameInterval = 0;
+  native.setBackendEventCallback((ev) => app._route(ev));
+  return { native, app };
+}
+
+/**
+ * The pointer over `node`, through the bridge's own event shape (points,
+ * window-relative) — the route a real NSEvent takes. `press` adds a
+ * button down and up there.
+ */
+export function pointerOver(app, node, { press = false, dx = 0, dy = 0 } = {}) {
+  const wnd = node.root.window;
+  const s = wnd.scale;
+  const x = (node.abs.x + node.abs.width / 2 + dx) / s;
+  const y = (node.abs.y + node.abs.height / 2 + dy) / s;
+  const ev = (type, extra = {}) => ({
+    type,
+    windowNumber: wnd.windowNumber,
+    x,
+    y,
+    gx: wnd.x / s + x,
+    gy: wnd.y / s + y,
+    time: performance.now(),
+    ...extra,
+  });
+  app._route(ev('mousemove'));
+  if (press) {
+    app._route(ev('mousedown', { button: 1 }));
+    app._route(ev('mouseup', { button: 1 }));
+  }
+}
+
+export async function mountCocoa(
+  children,
+  { width = 200, height = 120, promote, presenter, ...attrs } = {},
+) {
+  const cocoa = {};
+  if (promote !== undefined) cocoa.promote = promote;
+  if (presenter !== undefined) cocoa.presenter = presenter;
+  const { native, app } = fakeCocoaApp(cocoa);
+  const root = await createRoot({ app });
+  mounted.push(root);
+  const windowOf = (kids) => h('window', { width, height, ...attrs }, kids);
+  root.render(windowOf(children));
+  await tick();
+  const wnd = [...app._windows.values()][0];
+  const node = wnd._reactX11Node;
+  const frames = { count: 0 };
+  const flush = node.flush.bind(node);
+  node.flush = (...a) => {
+    const painting =
+      node.needsPaint || node.needsLayout || node._animating.size > 0;
+    const out = flush(...a);
+    if (painting) frames.count += 1;
+    return out;
+  };
+  const frame = () => {
+    app._tickFrames();
+    app._presentAll();
+  };
+  frame();
+  return {
+    native,
+    app,
+    root,
+    wnd,
+    node,
+    frames,
+    frame,
+    promotion: wnd._promotion ?? null,
+    render: async (next) => {
+      root.render(windowOf(next));
+      await tick();
+    },
+  };
+}

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -1063,6 +1063,7 @@ async function main() {
       backend: 'cocoa',
       cocoa: {
         presenter: 'surface',
+        promote: false,
         frameInterval: 8,
         pumpInterval: 4,
         exitOnQuit: false,


### PR DESCRIPTION
Closes #483.

The surface presenter could not offload an animation at all, and the layer presenter offloaded it by paying for the whole rest of the scene. This is the hybrid browsers call **layer promotion**: the bitmap keeps the frame for the scene, and a plain `<box>` with a transition or a loop on a property a layer can express (`backgroundColor`, `borderColor`, `borderWidth`, `borderRadius`) gets a CALayer of its own above it for as long as it animates and a second after. The render server draws the motion through a busy JS thread, and no frame is scheduled for it. `docs/macos.md` §"Layer promotion" is the account.

`examples/animation.jsx` under the default presenter, the clock column unticked: the three tiles, the chip and the hovered card are on layers of their own, nothing is on the frame clock, and the counter read 2 frames in 2 s.

![animation-promoted](https://github.com/user-attachments/assets/e858373f-89a5-41bb-b2f7-7b7ce4d4c92e)

### What it is

- **The mechanism is the `<glarea>` idiom.** The surface's pixels are the root layer's `contents`, which draw below its sublayers, so a promoted sublayer composites over the bitmap for free; the paint walk leaves a hole where the node is (`Node._promoted`). The node is a property box (`propBoxProps`, shared with the layer presenter) and its children ride the layer as one raster painted by its own `_paintChildren` walk. A promoted node inside a promoted node leaves a hole in its parent's raster and sits above it.
- **The animations the render server runs are one class now**, `LayerAnimations`, lifted out of the layer presenter; the two presenters differ only in `layerOf(node)`.
- **The policy** is not inferred from the scene and has no style prop: a node is promoted because it has a transition or a loop on an offloadable property. The layer stays a second after the last one ends (`IDLE_GRACE_MS`): demoting on the last frame churned a layer and a hole repaint per hover and per palette step (the first bench run made 96 layers for 48 cards).
- **Z-order, the hard part, by the cheap rule:** promote only when nothing painted after the node in the walk reaches into its bounds — no later sibling at any level (a later subtree counts where it puts ink; one that is itself promoted is on a layer above), no ancestor's border ring or focus ring, no scrollbar — and only when every clipping ancestor holds all of it. Re-verified every frame, later-painted nodes first, so a node that becomes overlapped, hidden, clipped or non-plain returns to the bitmap in the frame that finds it; declining is always safe and a refusal is remembered until the next layout.
- **The frame.** `WindowNode.flush` gives the presenter its word in after layout and before the damage is taken (`window.prepareFrame`, feature-detected like `presentFrame`), so holes are claimed in the frame that opens them. A promoted node's own claims are answered on the layer and cost the bitmap nothing (`noteInvalidate` → `true`; a frame with nothing in it for the bitmap). The scroll blit's safety gate skips a promoted node, which is what makes a pan under a pulsing toast a blit — the case neither presenter served. Loops declared at mount are re-offered on the window's first frame, on either presenter.

### Measured

`npm run bench:presenters` grows a `promoted` column (`surface` now pins promotion off, so it stays the baseline) and three scenarios: `animtree` (the 48 fades over the `--cells` tree with a cell recolouring per tick), `hovertree` (hover fades above the tree), `pananim` (the `scroll` pan under a pulsing toast). 4 s per cell on this machine:

| scenario | column | frames / ticks | flush avg / p95 | damage a frame | cpu |
| --- | --- | --- | --- | --- | --- |
| `anim` | surface | 455 / 235 | 2.17 / 2.51ms | 2170kpx | 46% |
| | promoted | 16 / 241 | 2.80 / 6.92ms | 136kpx | 17% |
| | layers | 16 / 241 | 2.21 / 3.26ms | — | 17% |
| `animtree` | surface | 208 / 120 | 14.58 / 16.97ms | 2031kpx | 108% |
| | promoted | 243 / 243 | 0.91 / 1.87ms | 13kpx | 54% |
| | layers | 244 / 244 | 2.75 / 3.75ms | — | 67% |
| `hovertree` | surface | 476 / 242 | 0.28 / 0.38ms | 43kpx | 14% |
| | promoted | 242 / 242 | 0.31 / 0.39ms | 0kpx | 11% |
| | layers | 241 / 241 | 1.38 / 1.65ms | — | 22% |
| `pananim` | surface | 702 / 243 | 0.65 / 1.82ms | 817kpx, 31% full | 24% |
| | promoted | 219 / 242 | 1.57 / 2.01ms | 525kpx, 0% full | 22% |
| | layers | 220 / 243 | 1.89 / 2.28ms | 2520kpx, 100% full | 17% |

Both halves at once: the animation's frames match `layers` (`anim` exactly), the flush and the scroll match `surface` (`scroll` and `tree` are unchanged), and `animtree` and `pananim` beat both. The gate's new `promoted` rules keep it.

### What it found

A promoted node is the same node drawn two ways in turn, and the two had to agree to the pixel. They did not: `@windowkit/appkit` 0.5 makes layer colours with `CGColorCreateGenericRGB` while its surfaces are sRGB, so `#dbe7f4` rastered as (219, 231, 244) and composited as (228, 236, 245) — on every layer the layer presenter ever set, and a colour animation there landed beside its own `to`. Two identical cards, the left one on a layer, on 0.5 and on the fix:

![parity](https://github.com/user-attachments/assets/ca8791a2-b3f5-467a-a3b3-dea98a19b773)

![parity-fixed](https://github.com/user-attachments/assets/0cac989b-65d7-41e7-82fc-a295e53382d3)

[windowkit/appkit#33](https://github.com/windowkit/appkit/pull/33) makes every colour crossing the bridge sRGB (`MakeColor` → `CGColorCreateSRGB`, the text layer's default ink with it, `presentationValue` reading back in sRGB) and adds `colorSpace()` so a caller can feature-detect it; it shipped as `@windowkit/appkit` **0.5.1**, and this PR pins `^0.5.1`. Against the published build the card differs by at most six units of one channel, in the antialiasing. **Promotion is on by default only where the bridge answers `'sRGB'`** — so on 0.5.1 it is on, on 0.5.0 it stays off unless asked for (`cocoa.promote: true`, `REACT_X11_COCOA_PROMOTE=1`; `false` / `=0` keep every animation on the clock regardless), and nobody gets the flash for free.

### Tests

- `test/cocoa-promotion.test.js` over a fake bridge (`test/helpers/cocoa-bridge.js`: windows, the swapchain, a layer tree that remembers its shape, fonts, bezels) with the real `CocoaApp`/`CocoaWindow`: the layer, the animation and the hole in one frame with no frames after; the grace and the release; a loop's whole life; a later sibling, a layout-only container, a border ring, a clipping ancestor; the same-frame demotion when something moves over the node; children as a raster repainted for their own claims; nested promotion; unmount; the window going; a pan under a promoted toast keeping its blit; the default's gate on the bridge; the off switch.
- `test/animation-example.test.js` walks the example over the same bridge.
- The full suite, lint, typecheck and format are green (the six macOS-only `appearance.test.js` failures are this machine's known baseline).



