### PR TITLE
test(cocoa): a tick takes the moment it happens, so the frame-clock tests stop racing the runner

### DIFF
--- a/src/cocoa/app.js
+++ b/src/cocoa/app.js
@@ -612,9 +612,15 @@ export class CocoaApp {
     );
   }
 
-  _tickFrames() {
+  /**
+   * Run every frame that is due at `now`. The pump tick and the frame
+   * timer read the clock; a test names the moment, so that what a tick
+   * decides is a fact about that moment and not about how long the test
+   * took to ask — a shared runner stalls for milliseconds between two
+   * lines.
+   */
+  _tickFrames(now = performance.now()) {
     if (!this._rafQueue.length) return;
-    const now = performance.now();
     // Each window keeps its own clock, so a window on a 120Hz panel paints
     // every refresh while one on a 60Hz monitor paints every other pump
     // tick. Decided once per clock per tick: every frame a window queued

--- a/test/cocoa-frames.test.js
+++ b/test/cocoa-frames.test.js
@@ -658,6 +658,12 @@ test('an explicit frameInterval applies to every window, whatever its display', 
   assert.equal(app.frameIntervalFor(null), 8);
 });
 
+// The clock tests name the moment a tick happens (`_tickFrames(now)`): what
+// the tick decides is then arithmetic on `now`, and a shared runner that
+// stalls for a few milliseconds between two lines of a test — which it does
+// — moves nothing. What stays in real time is the timer itself: that it
+// fires, and that it stands down.
+
 test('two windows keep two clocks: the one on the faster display paints while the other waits', async () => {
   const {
     app,
@@ -678,14 +684,15 @@ test('two windows keep two clocks: the one on the faster display paints while th
   slow.requestAnimationFrame(() => (slowRan += 1));
   // 9ms since either last painted: past the 120Hz gate (8.3 - 1), short
   // of the 60Hz one (16.7 - 1)
-  fast._rafLast = performance.now() - 9;
-  slow._rafLast = performance.now() - 9;
-  app._tickFrames();
+  const now = performance.now();
+  fast._rafLast = now - 9;
+  slow._rafLast = now - 9;
+  app._tickFrames(now);
   assert.equal(fastRan, 2, 'every frame the fast window queued');
   assert.equal(slowRan, 0);
   assert.equal(app._rafQueue.length, 1, 'the slow one waits');
-  slow._rafLast = performance.now() - 16;
-  app._tickFrames();
+  slow._rafLast = now - 16;
+  app._tickFrames(now);
   assert.equal(slowRan, 1);
   assert.equal(app._rafQueue.length, 0);
   clearTimeout(app._frameTimer);
@@ -704,22 +711,27 @@ test('a frame a tick just missed lands a moment later, not a tick later', async 
   // a tick that arrives 10ms after the last frame is too early, and the
   // next tick, at 18, would be two milliseconds late: the frame gets a
   // timer of its own for the five that remain
-  app._rafLast = performance.now() - 10;
-  app._tickFrames();
+  const now = performance.now();
+  app._rafLast = now - 10;
+  app._tickFrames(now);
   assert.equal(ran, 0);
   assert.ok(app._frameTimer, 'a timer');
-  let wait = app._frameTimerAt - performance.now();
-  assert.ok(wait > 4 && wait <= 6, `due in ${wait}ms`);
+  assert.ok(
+    Math.abs(app._frameTimerAt - (now + 5)) < 1e-9,
+    `due in ${app._frameTimerAt - now}ms`,
+  );
   // 13ms is the tick that straddles it: gated at the interval, timer drift
   // used to push this frame to the tick after, 24ms out — and gated at
   // half a pump it was taken early. The timer is re-armed for the two
   // milliseconds that remain.
-  app._rafLast = performance.now() - 13;
-  app._tickFrames();
+  app._rafLast = now - 13;
+  app._tickFrames(now);
   assert.equal(ran, 0, 'not on this tick');
   assert.ok(app._frameTimer, 'but on the timer');
-  wait = app._frameTimerAt - performance.now();
-  assert.ok(wait > 0 && wait <= 3, `due in ${wait}ms`);
+  assert.ok(
+    Math.abs(app._frameTimerAt - (now + 2)) < 1e-9,
+    `due in ${app._frameTimerAt - now}ms`,
+  );
   await new Promise((resolve) => setTimeout(resolve, 6));
   assert.equal(ran, 1, 'which ran it');
   assert.equal(app._frameTimer, null);
@@ -733,14 +745,19 @@ test('a display whose period is not a multiple of the pump paints at its own per
   app._pumpInterval = 8;
   let ran = 0;
   app._requestFrame(() => (ran += 1));
-  const last = performance.now() - 8;
+  const now = performance.now();
+  const last = now - 8;
   app._rafLast = last;
-  app._tickFrames();
+  app._tickFrames(now);
   assert.equal(ran, 0, 'the first tick is too early');
   assert.ok(app._frameTimer, 'and the frame is owed a timer');
-  const wait = app._frameTimerAt - performance.now();
-  assert.ok(wait > 3 && wait <= 6, `due in ${wait}ms — the 5.3 that remain`);
-  await new Promise((resolve) => setTimeout(resolve, 9));
+  // for the 5.3 that remain, less the millisecond of slack under the gate
+  assert.ok(
+    Math.abs(app._frameTimerAt - (last + 1000 / 75 - 1)) < 1e-9,
+    `due in ${app._frameTimerAt - now}ms`,
+  );
+  // the timer's tick, a little after the moment it was due, ran it
+  app._tickFrames(app._frameTimerAt + 0.5);
   assert.equal(ran, 1);
   // the clock kept the display's period: the next frame is due one
   // interval after the last was, not one after the moment this one ran
@@ -748,6 +765,9 @@ test('a display whose period is not a multiple of the pump paints at its own per
     Math.abs(app._rafLast - (last + 1000 / 75)) < 1e-9,
     `${app._rafLast - last}`,
   );
+  // and the timer, when it fires, finds nothing owed and stands down
+  await new Promise((resolve) => setTimeout(resolve, 9));
+  assert.equal(app._frameTimer, null);
 });
 
 test('a frame that arrives more than an interval late re-anchors the clock', async () => {
@@ -755,11 +775,11 @@ test('a frame that arrives more than an interval late re-anchors the clock', asy
   app._frameInterval = 16;
   let ran = 0;
   app._requestFrame(() => (ran += 1));
-  app._rafLast = performance.now() - 100;
-  const before = performance.now();
-  app._tickFrames();
+  const now = performance.now();
+  app._rafLast = now - 100;
+  app._tickFrames(now);
   assert.equal(ran, 1);
-  assert.ok(app._rafLast >= before, 'stamped now, owing nothing for the gap');
+  assert.equal(app._rafLast, now, 'stamped now, owing nothing for the gap');
   assert.equal(app._frameTimer, null);
 });
 
@@ -768,8 +788,9 @@ test('closing the app drops the timer a frame was owed', async () => {
   app._frameInterval = 16;
   app._pumpInterval = 8;
   app._requestFrame(() => {});
-  app._rafLast = performance.now() - 13;
-  app._tickFrames();
+  const now = performance.now();
+  app._rafLast = now - 13;
+  app._tickFrames(now);
   assert.ok(app._frameTimer);
   await app.close();
   assert.equal(app._frameTimer, null);


### PR DESCRIPTION
[#487's `test (24)` job](https://github.com/sidorares/react-x11/actions/runs/34039523930/job/101566592899) failed twice on `a display whose period is not a multiple of the pump paints at its own period` — `due in -0.76ms` on the first attempt and `due in 1.29ms` on the second, against an assertion that wants the timer due in more than 3ms. Nothing in that PR reaches the frame clock; the same test on Node 20 and 22 passed both times, and it passes on master.

**What the test measured.** It set the last frame 8ms into the past, ticked, and then read how long the timer it armed had left *against a fresh `performance.now()`*. The timer is due 4.33ms after the tick — the 5.33 of a 75Hz period that remain, less the millisecond of slack under the gate — so the assertion's floor of 3ms left 1.3ms for everything between the test's two clock reads: the tick, `setTimeout`, two asserts. The runner took 5.1ms and 3.0ms over it. Its neighbour, `a frame a tick just missed lands a moment later, not a tick later`, had a millisecond of headroom on the same read, and every `_rafLast = performance.now() - N` in these tests carried the same shape of margin against the tick's own clock read: two to four milliseconds, on a shared 4-vCPU runner running three test processes.

**The fix.** `_tickFrames` takes the moment it happens — `_tickFrames(now = performance.now())` — the way `_frameDue`, `_frameWait` and `_armFrameTimer` already did. The pump and the frame timer read the clock as before; the clock tests name it, and what a tick decides is then arithmetic on `now`: the timer is due at `now + 5` exactly, at `last + 13.33 - 1` exactly, the stamp after a late frame is `now` exactly. A runner that stalls between two lines of a test moves nothing. What stays in real time is what has to: that the timer fires, runs the frame it was armed for, and stands down — and a timer due first fires first, so the test's own longer wait cannot overtake it.

The 75Hz test's second half changes shape. It waited 9ms for the real timer and then asserted the clock kept the display's period, which holds unless the timer fires more than an interval late — a 14ms stall, rarer than the one that bit but the same kind of thing. Now it runs the timer's tick itself, a little after the moment the timer was due, asserts the period, and then watches the real timer fire into an empty queue and stand down. The `just missed` test keeps a real timer running a real frame.

**Mutation check.** With a 5ms busy-wait injected into `_armFrameTimer` — a stall where the runner's was — the old file fails both timer tests with CI's exact signature (`due in -0.70ms — the 5.3 that remain`, `due in -0.07ms`) and the new file passes.

Locally: the file 8/8 on Node 20, 22 and 24; lint, `prettier --check .` and typecheck pass; the full suite under Node 24 is 2011 pass plus the six known macOS-only `appearance.test.js` failures. Twenty CPU hogs on a 10-core Mac never reproduced the stall; the injection is what did.

For #487 itself: once this is in, `@dependabot rebase` picks it up.
