### PR TITLE
fix(cocoa): a drag preview popup is never a dragging destination, so the drop reaches the window beneath it

### DIFF
--- a/docs/drag-and-drop.md
+++ b/docs/drag-and-drop.md
@@ -534,9 +534,14 @@ Platform notes:
   the pointer as it does on X11, and because a `<popup>` here is a
   non-activating panel at the pop-up-menu window level — above every other
   application's windows, which sit at the normal level — it is what the
-  desktop sees while the pointer is over Finder or a browser. What AppKit's
-  own session carries is still a blank image: the drag has no bitmap of the
-  system's, only the preview you draw.
+  desktop sees while the pointer is over Finder or a browser. It is also
+  the first window AppKit would find when the pointer comes back over one
+  of yours, so a `<popup dragPreview>` registers no pasteboard types at
+  all: AppKit routes a drag only to a window registered for a type it
+  carries, and looks past the preview to the window beneath — the same
+  exclusion the router makes on X11, made where AppKit can see it. What
+  AppKit's own session carries is still a blank image: the drag has no
+  bitmap of the system's, only the preview you draw.
 - **macOS / XQuartz** — X client to X client works. Dragging from **Finder**
   into an X11 window does not, and never has:
   [XQuartz#173](https://github.com/XQuartz/XQuartz/issues/173). That is the
@@ -604,7 +609,9 @@ For anyone watching the wire, or debugging against another toolkit:
 - `XdndAware` (version 5) is written on every **top-level** window
   unconditionally at realize time. Child windows — `<glarea>`, a nested
   `<window>` — never advertise, per XDND v3+; drags over them arrive at the
-  top-level and are routed down in JavaScript.
+  top-level and are routed down in JavaScript. A `<popup dragPreview>`
+  never advertises either: it follows the pointer, and a window that is
+  never under it has nothing to accept.
 - A window with **no drop targets mounted** answers with a refusal covering
   the whole window, so a well-behaved source stops asking while the pointer
   stays inside it. What an app that never uses drag and drop still pays:

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -10473,8 +10473,18 @@ export class WindowNode extends Scrollable(Node) {
    * and advertising lazily would race sources that cache the window list
    * at drag start. A window with no registered drop targets answers "not
    * accepting" once per entry instead (DropSession).
+   *
+   * The one exception is a `<popup dragPreview>`. It follows the pointer,
+   * so for the whole gesture it is the frontmost window under it, and it
+   * must never be what the drag is over. Where react-x11 picks the target
+   * itself (src/dnd.js `topLevelAt`) it is skipped by name; where the OS
+   * picks — AppKit routes a drag to the frontmost window registered for a
+   * type it carries, and looks past one that registered none — the only
+   * way to say so is to register nothing (#488). So a preview gets none of
+   * this: no session, no registry entry, no property.
    */
   _initDnd() {
+    if (this.props.dragPreview) return;
     const wnd = this.window;
     const X = this.app?.X;
     // A backend with drop machinery of its own (the cocoa backend's

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -436,8 +436,11 @@ export interface WindowProps
   xi2?: boolean | 'auto';
   /**
    * Mark this window as a drag preview: the drag router never treats it as
-   * the window under the pointer, so a `<popup dragPreview>` can follow the
-   * pointer without swallowing its own drag. See `useDragSource`.
+   * the window under the pointer, and it is never a drop destination — on
+   * the cocoa backend, where AppKit picks the destination, that is what
+   * lets a drop reach the window beneath it. A `<popup dragPreview>` can
+   * therefore follow the pointer without swallowing its own drag. Read when
+   * the window is created. See `useDragSource`.
    */
   dragPreview?: boolean;
   /**

--- a/test/cocoa-dnd.test.js
+++ b/test/cocoa-dnd.test.js
@@ -530,6 +530,115 @@ describe('the drag side', () => {
     assert.equal(app._windows.size, 1, 'the release takes it down');
   });
 
+  test('the preview is never a dragging destination, so the drop reaches the window beneath it', async () => {
+    // The regression this exists for (#488). On this backend AppKit picks
+    // the destination, and the preview — a panel at the pop-up-menu level
+    // following the pointer — is the frontmost window under it for the
+    // whole gesture. Registered, it would be the one asked, refuse (its
+    // tree has no `dropAccept`) and take the drop with it; the list
+    // beneath would never hear of the drag. AppKit routes a drag only to
+    // views registered for a type it carries and looks past a window with
+    // none, so the preview registers nothing — the same exclusion the X11
+    // router makes in `topLevelAt`, made where AppKit can see it.
+    const native = fakeNative();
+    const app = appOver(native);
+    const root = await createRoot({ app });
+    roots.push(root);
+    const log = [];
+    const row = { id: 1 };
+    const Row = () => {
+      const { dragProps, isDragging, position } = useDragSource({
+        data: { 'application/x-demo-row': row },
+        actions: ['move'],
+      });
+      return h(
+        React.Fragment,
+        null,
+        h('box', {
+          ...dragProps,
+          style: {
+            position: 'absolute',
+            left: 0,
+            top: 0,
+            width: 100,
+            height: 100,
+          },
+        }),
+        isDragging &&
+          h(
+            'popup',
+            {
+              dragPreview: true,
+              x: position.x + 14,
+              y: position.y + 14,
+              width: 90,
+              height: 20,
+            },
+            h('box', { style: { width: 90, height: 20 } }),
+          ),
+      );
+    };
+    root.render(
+      h(
+        'window',
+        { width: 400, height: 200 },
+        h(Row),
+        h('box', {
+          dropAccept: ['application/x-demo-row'],
+          onDragOver: (e) => e.accept('move'),
+          onDrop: (e) => log.push(['drop', e.items['application/x-demo-row']]),
+          style: {
+            position: 'absolute',
+            left: 200,
+            top: 0,
+            width: 150,
+            height: 150,
+          },
+        }),
+      ),
+    );
+    await settle(app);
+    const list = wndOf(app);
+    press(list, 50, 50);
+    move(list, 70, 50); // past the threshold
+    assert.equal(native.of('beginDrag').length, 1, 'AppKit has the gesture');
+    const preview = [...app._windows.values()][1];
+    assert.ok(preview, 'the preview is up');
+
+    // what AppKit sees: the list is a destination, the preview is not
+    const registered = native.of('registerDropTypes').map(([id]) => id);
+    assert.ok(registered.includes(list.windowNumber), 'the list registered');
+    assert.ok(
+      !registered.includes(preview.windowNumber),
+      'the preview registered no types',
+    );
+    assert.equal(preview._dropTransport, undefined, 'and has no drop side');
+
+    // so the drag comes back over the list, through the preview
+    const local = {
+      local: true,
+      sourceWindowNumber: list.windowNumber,
+      types: [],
+      operations: ['move'],
+    };
+    native.emit(dragEvent('drag-enter', list.windowNumber, 250, 30, local));
+    assert.deepEqual(native.of('setDropResponse').at(-1)[1], {
+      accept: true,
+      operation: 'move',
+    });
+    native.emit(dragEvent('drag-perform', list.windowNumber, 250, 30, local));
+    await tick();
+    assert.deepEqual(log, [['drop', row]], 'the list was told');
+    native.emit({
+      type: 'drag-session-ended',
+      x: 250,
+      y: 30,
+      operation: 'move',
+      dropped: true,
+    });
+    assert.equal(app._windows.size, 1, 'the release takes the preview down');
+  });
+
   test('a drop on our own window keeps the payload by reference', async () => {
     const native = fakeNative();
     const app = appOver(native);


### PR DESCRIPTION
Fixes #488.

## What was wrong

On the cocoa backend a `<popup dragPreview>` took the hover and the drop meant for the window under it. `nodes.js`'s realize gives every parentless window drop machinery, a popup is one, and so the preview registered itself as an `NSDraggingDestination`. On X11 that is harmless because react-x11 picks the target itself and `topLevelAt` skips previews by name. On cocoa AppKit picks, and nothing told it to look past the preview: it follows the pointer at the pop-up-menu window level, so for the whole gesture it was the frontmost registered window under the pointer. `draggingUpdated:` and `performDragOperation:` went to the preview's own `DropSession`, whose tree holds only the ghost, so the answer was a refusal every time and the real target below never heard of the drag. The one-second stall on release is consistent with AppKit's slide-back animation for a refused drop, which runs inside its tracking loop.

## What changed

- `_initDnd` returns before doing anything for a window whose props say `dragPreview`: no session, no top-level registry entry, no `XdndAware`, and on cocoa no `attachDropTransport`, so `registerDropTypes` is never called for it. The bridge documents the consequence: until a window registers, AppKit routes it no drag events and looks past it to the window beneath.
- Both backends, on purpose. A preview only exists during one of our own drags and is never the thing under the pointer, so an `XdndAware` on it advertised something that could never be accepted. `topLevelAt`'s own skip stays as the statement of the invariant.
- The `dragPreview` declaration comment and two passages in `docs/drag-and-drop.md` say so.

## Verified

- A new regression in `test/cocoa-dnd.test.js`, over the recording fake bridge the file already uses: a draggable row with a `<popup dragPreview>` preview and a `dropAccept` box beside it. It asserts that the list window registered pasteboard types and the preview did not, that the preview has no drop transport, and that a local `drag-enter` and `drag-perform` on the list are accepted and deliver the payload by reference. On master it fails at "the preview registered no types", which is the issue's `[1, 1, 5]` evidence.
- `npm test`: 2012 pass, 6 fail, the known macOS-only `appearance.test.js` baseline. `npm run lint`, `npm run typecheck` and `prettier --check .` are clean.
- Not verified: the gesture on a real display. This machine has no CGEvent posting rights, so a real AppKit drag could not be driven from a script. Worth one manual pass with a `<ReorderList>` on cocoa before merge.

## Follow-up elsewhere

`@react-x11/components` currently draws the ghost inside the list on cocoa as a workaround. Once this ships, the popup can become the default on both backends again, as the issue notes.
