### PR TITLE
fix(cocoa): a drag preview is transparent to the pointer, which is what lets the drop reach the window beneath it

### DIFF
--- a/docs/drag-and-drop.md
+++ b/docs/drag-and-drop.md
@@ -535,13 +535,17 @@ Platform notes:
   non-activating panel at the pop-up-menu window level — above every other
   application's windows, which sit at the normal level — it is what the
   desktop sees while the pointer is over Finder or a browser. It is also
-  the first window AppKit would find when the pointer comes back over one
-  of yours, so a `<popup dragPreview>` registers no pasteboard types at
-  all: AppKit routes a drag only to a window registered for a type it
-  carries, and looks past the preview to the window beneath — the same
-  exclusion the router makes on X11, made where AppKit can see it. What
-  AppKit's own session carries is still a blank image: the drag has no
-  bitmap of the system's, only the preview you draw.
+  the first window the window server finds when the pointer comes back
+  over one of yours, and AppKit does not look past it: a window with no
+  dragged types registered is still the one found, the drag then has no
+  destination, and the window beneath never hears of it. So the popup is
+  made transparent to the pointer — `dragPreview` sets the bridge's
+  `ignoresMouseEvents` (@windowkit/appkit 0.6.0) — and the hit passes
+  through it to the window it covers: the same exclusion the router makes
+  on X11, made where the window server can see it. It registers no
+  pasteboard types either, having nothing to accept with. What AppKit's own
+  session carries is still a blank image: the drag has no bitmap of the
+  system's, only the preview you draw.
 - **macOS / XQuartz** — X client to X client works. Dragging from **Finder**
   into an X11 window does not, and never has:
   [XQuartz#173](https://github.com/XQuartz/XQuartz/issues/173). That is the

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "node": ">=20.19"
       },
       "optionalDependencies": {
-        "@windowkit/appkit": "^0.5.1",
+        "@windowkit/appkit": "^0.6.0",
         "dbus-native": "^0.15.1",
         "x11-dri": "^0.7.0"
       },
@@ -1515,9 +1515,9 @@
       }
     },
     "node_modules/@windowkit/appkit": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@windowkit/appkit/-/appkit-0.5.1.tgz",
-      "integrity": "sha512-ciu/0PjLw7ZWyAieIUO2/VKXJv9XevJNucC5Gvc37HIuJ0TOlp2QIJVX+IFxInzE/kdqhnQ6m/dEgW33kAM0nA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@windowkit/appkit/-/appkit-0.6.0.tgz",
+      "integrity": "sha512-T9zZhODZYhsciVx3IeZHrhKzX+BM7rbBXgr+XbaXYt1v0VROxbQ7lqSEmiocIs21jod3NsjLhyw59i9MCkbUPw==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "yoga-layout": "^3.2.1"
   },
   "optionalDependencies": {
-    "@windowkit/appkit": "^0.5.1",
+    "@windowkit/appkit": "^0.6.0",
     "dbus-native": "^0.15.1",
     "x11-dri": "^0.7.0"
   },

--- a/src/cocoa/window.js
+++ b/src/cocoa/window.js
@@ -68,6 +68,16 @@ export class CocoaWindow {
       attributes.visual !== undefined || attributes.transparent;
     this._transparentWindow = Boolean(transparent);
     if (transparent) options.opaque = false;
+    // A `<popup dragPreview>` follows the pointer, so for the whole gesture
+    // it is the window the window server finds under it — and AppKit does
+    // not look past a window that registered no dragged types: the drag
+    // simply has no destination, and the window beneath never hears of it.
+    // Transparent to the pointer, the preview is passed over and the hit
+    // reaches what it covers (#488; @windowkit/appkit >= 0.6.0, an older
+    // bridge ignores the option). The drop side is excluded separately:
+    // nodes.js `_initDnd` gives a preview no DropSession and registers
+    // nothing.
+    if (attributes.dragPreview) options.ignoresMouseEvents = true;
     // The root layer's background is the "what newly exposed area shows"
     // attribute an X window has — worth seeding on an opaque window so a
     // resize flashes the right colour. On a transparent one it would sit

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -10477,11 +10477,13 @@ export class WindowNode extends Scrollable(Node) {
    * The one exception is a `<popup dragPreview>`. It follows the pointer,
    * so for the whole gesture it is the frontmost window under it, and it
    * must never be what the drag is over. Where react-x11 picks the target
-   * itself (src/dnd.js `topLevelAt`) it is skipped by name; where the OS
-   * picks — AppKit routes a drag to the frontmost window registered for a
-   * type it carries, and looks past one that registered none — the only
-   * way to say so is to register nothing (#488). So a preview gets none of
-   * this: no session, no registry entry, no property.
+   * itself (src/dnd.js `topLevelAt`) it is skipped by name. Where the OS
+   * picks, registering nothing is not enough: AppKit finds the window
+   * under the pointer first and does not look past one with no dragged
+   * types — the drag then has no destination at all — so the cocoa window
+   * is made transparent to the pointer instead (src/cocoa/window.js,
+   * `ignoresMouseEvents`, #488). A preview still gets none of this: no
+   * session, no registry entry, no property, nothing to refuse with.
    */
   _initDnd() {
     if (this.props.dragPreview) return;

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -436,11 +436,12 @@ export interface WindowProps
   xi2?: boolean | 'auto';
   /**
    * Mark this window as a drag preview: the drag router never treats it as
-   * the window under the pointer, and it is never a drop destination — on
-   * the cocoa backend, where AppKit picks the destination, that is what
-   * lets a drop reach the window beneath it. A `<popup dragPreview>` can
-   * therefore follow the pointer without swallowing its own drag. Read when
-   * the window is created. See `useDragSource`.
+   * the window under the pointer, it is never a drop destination, and on
+   * the cocoa backend — where the window server picks the window under the
+   * pointer — it is made transparent to the pointer, so a drop reaches the
+   * window beneath it. A `<popup dragPreview>` can therefore follow the
+   * pointer without swallowing its own drag. Read when the window is
+   * created. See `useDragSource`.
    */
   dragPreview?: boolean;
   /**

--- a/test/cocoa-dnd.test.js
+++ b/test/cocoa-dnd.test.js
@@ -531,15 +531,18 @@ describe('the drag side', () => {
   });
 
   test('the preview is never a dragging destination, so the drop reaches the window beneath it', async () => {
-    // The regression this exists for (#488). On this backend AppKit picks
-    // the destination, and the preview — a panel at the pop-up-menu level
-    // following the pointer — is the frontmost window under it for the
-    // whole gesture. Registered, it would be the one asked, refuse (its
-    // tree has no `dropAccept`) and take the drop with it; the list
-    // beneath would never hear of the drag. AppKit routes a drag only to
-    // views registered for a type it carries and looks past a window with
-    // none, so the preview registers nothing — the same exclusion the X11
-    // router makes in `topLevelAt`, made where AppKit can see it.
+    // The regression this exists for (#488). On this backend the window
+    // server picks the window under the pointer, and the preview — a panel
+    // at the pop-up-menu level following the pointer — is that window for
+    // the whole gesture. Registered, it would be the one asked, refuse (its
+    // tree has no `dropAccept`) and take the drop with it; unregistered, it
+    // is still the one found and the drag has no destination at all — the
+    // list beneath never hears of it either way, which is what 2.8.1
+    // shipped and the issue was reopened for. So the preview is made
+    // transparent to the pointer (`ignoresMouseEvents`, the bridge's
+    // window-server exclusion) and registers nothing, having nothing to
+    // accept with — the exclusion the X11 router makes in `topLevelAt`,
+    // made where the window server can see it.
     const native = fakeNative();
     const app = appOver(native);
     const root = await createRoot({ app });
@@ -613,6 +616,18 @@ describe('the drag side', () => {
       'the preview registered no types',
     );
     assert.equal(preview._dropTransport, undefined, 'and has no drop side');
+    // and what the window server sees: the preview is transparent to the
+    // pointer, the list takes it
+    assert.equal(
+      preview._h.options.ignoresMouseEvents,
+      true,
+      'the preview was created transparent to the pointer',
+    );
+    assert.equal(
+      list._h.options.ignoresMouseEvents,
+      undefined,
+      'the list takes the pointer',
+    );
 
     // so the drag comes back over the list, through the preview
     const local = {


### PR DESCRIPTION
Fixes #488.

## What was still wrong after 2.8.1

#490 stopped a `<popup dragPreview>` registering any dragged types, on the belief that AppKit then looks past it to the window beneath. It does not. The window server picks the window under the pointer first, registered or not, and a window with no destination leaves the drag with none at all: the list beneath never hears of it, and the release runs the refused-drop slide-back. That is why the reopen reads the same as the original report. The core example never showed it because its preview sits 14px down-right of the pointer; `@react-x11/components`' `<ReorderList>` keeps the pointer inside the ghost, which is the failing case.

Verified on a probe panel shaped like the bridge's popup, asked through the window server's own hit test — the table is in windowkit/appkit#35. Unregistered, registered, and transparent over its clear half all find the panel; only `ignoresMouseEvents` finds the window beneath.

## What changed

- `@windowkit/appkit` `^0.5.1` → `^0.6.0`, the release that adds `ignoresMouseEvents` on `createWindow2`, `setWindowIgnoresMouseEvents`, its readback on `getWindowFrame`, and `windowNumberAtPoint` — windowkit/appkit#35.
- `src/cocoa/window.js`: a window whose attributes say `dragPreview` is created with `ignoresMouseEvents: true`. `windowAttributes` already passes the prop through, so that is the whole mechanism. An older bridge ignores the option, so nothing is gated.
- `_initDnd`'s early return stays: a preview still gets no DropSession and registers nothing, having nothing to accept with. Its comment, the macOS bullet in `docs/drag-and-drop.md`, the `dragPreview` declaration comment and the #488 regression's comment now say what is true.
- The #488 regression additionally asserts that the preview's creation options carry the flag and the list's do not.

## Verified

- On the real bridge with 0.6.0: a `<window>` at 200,200 with a `<popup dragPreview>` over its middle and a plain `<popup>` below it. `getWindowFrame` reports the preview with `ignoresMouseEvents: true`; the window server's answer for a hit inside the preview is the window, inside the plain popup the popup, beside them the window. With the one line removed, the hit inside the preview is the preview.
- Mutation check on the regression: with the line removed it fails at "the preview was created transparent to the pointer".
- `npm test`: 2012 pass, 6 fail, the known macOS-only `appearance.test.js` baseline. `npm run lint`, `npm run typecheck` and `prettier --check .` are clean.
- Not verified: a hand-driven drag, which this machine cannot post. The reopen's author offered to test against a real `<ReorderList>` drag. Once this ships, the popup can become the ghost's default on both backends again, as the issue notes.
