### PR TITLE
fix(cocoa): a refused drop ends on the release — the drag session slides back nothing, instead of animating for a second first

### DIFF
--- a/docs/drag-and-drop.md
+++ b/docs/drag-and-drop.md
@@ -545,7 +545,13 @@ Platform notes:
   on X11, made where the window server can see it. It registers no
   pasteboard types either, having nothing to accept with. What AppKit's own
   session carries is still a blank image: the drag has no bitmap of the
-  system's, only the preview you draw.
+  system's, only the preview you draw. For the same reason the session's
+  slide-back is off: left on, AppKit animates that blank image home over
+  about a second _before_ it reports the release, so a drop nothing took
+  reached `onDragEnd` — and the preview stayed frozen where the pointer let
+  go — only after a pause spent animating nothing. The release ends the
+  gesture the moment it happens, as on X11, and a return animation is the
+  app's to draw from `onDragEnd`.
 - **macOS / XQuartz** — X client to X client works. Dragging from **Finder**
   into an X11 window does not, and never has:
   [XQuartz#173](https://github.com/XQuartz/XQuartz/issues/173). That is the

--- a/src/cocoa/dnd.js
+++ b/src/cocoa/dnd.js
@@ -208,6 +208,19 @@ const wire = (value) =>
  * first item under its UTI, thunks as promises the bridge asks `provide`
  * to keep. The files thunk alone resolves now, because the items cannot
  * be counted without it.
+ *
+ * No image, and so no slide-back. The picture of the drag is the app's own
+ * `<popup dragPreview>`; what the system session carries is a blank 1×1.
+ * Left at AppKit's default, a refused or cancelled drop plays
+ * `animatesToStartingPositionsOnCancelOrFail`'s slide home **before**
+ * `draggingSession:endedAtPoint:operation:` — the callback that is
+ * `drag-session-ended`, which `onDragEnd` and the preview's unmount wait
+ * on — so the button was up for about a second with the gesture still
+ * open and the preview frozen where the pointer let go, while AppKit
+ * animated nothing back to the press (#494). Off, the release ends the
+ * gesture the moment it happens, as on X11, and the return is the app's
+ * to animate from `onDragEnd`. Not a seam: there is no system image for
+ * a caller to want slid back.
  */
 export function dragSpec(session, native, scale) {
   const types = session.types;
@@ -241,6 +254,7 @@ export function dragSpec(session, native, scale) {
     y: session.press.y / scale,
     items,
     operations: session.actions,
+    slideBack: false,
     provide: (uti) => wire(session._resolve(reverse.get(uti) ?? uti)),
   };
 }

--- a/test/cocoa-dnd.test.js
+++ b/test/cocoa-dnd.test.js
@@ -654,6 +654,44 @@ describe('the drag side', () => {
     assert.equal(app._windows.size, 1, 'the release takes the preview down');
   });
 
+  test('a refused drop ends on the release: the session is told to slide nothing back', async () => {
+    // The regression this exists for (#494). The spec hands AppKit no
+    // image — the picture of the drag is the app's own `<popup
+    // dragPreview>` — yet left at its default the session's
+    // `animatesToStartingPositionsOnCancelOrFail` plays its slide home
+    // *before* `draggingSession:endedAtPoint:operation:`, the callback
+    // `drag-session-ended` is. A drop nothing took therefore reached
+    // `onDragEnd` about a second after the button came up, the preview
+    // frozen where the pointer let go, while AppKit animated a blank 1×1
+    // back to the press. The spec turns it off: the release is the end of
+    // the gesture, as on X11, and the return is the app's to draw.
+    const native = fakeNative();
+    const app = appOver(native);
+    const root = await createRoot({ app });
+    roots.push(root);
+    root.render(
+      h(
+        'window',
+        { width: 300, height: 200 },
+        h('box', {
+          draggable: true,
+          dragData: { 'text/plain': 'a row' },
+          style: { width: 100, height: 100 },
+        }),
+      ),
+    );
+    await settle(app);
+    const wnd = wndOf(app);
+    press(wnd, 50, 50);
+    move(wnd, 70, 50); // past the threshold
+    const [[, spec]] = native.of('beginDrag');
+    assert.equal(spec.slideBack, false, "nothing of the system's to slide");
+    assert.ok(
+      !('image' in spec) && !('surface' in spec),
+      'and indeed no image was handed over',
+    );
+  });
+
   test('a drop on our own window keeps the payload by reference', async () => {
     const native = fakeNative();
     const app = appOver(native);


### PR DESCRIPTION
## What

On the cocoa backend a drop nothing accepted took about a second to end. `onDragEnd` did not fire until then, the app's `<popup dragPreview>` stayed frozen where the pointer let go, and `<ReorderList>`'s return animation in `@react-x11/components` started only after the pause, which read as a freeze. On X11 the same release ends immediately.

## Why

`beginDraggingSessionWithItems:` leaves `animatesToStartingPositionsOnCancelOrFail` at `YES`. On a cancelled or refused drop AppKit plays that slide home **before** `draggingSession:endedAtPoint:operation:`, which is the callback `drag-session-ended` and everything downstream of it wait on. The image it slides back does not exist: `dragSpec` hands the session pasteboard items only, and the visible preview is the app's own popup. The delay was pure cost.

## Fix

`dragSpec` passes `slideBack: false`, the switch `@windowkit/appkit` 0.6.0 already has in `src/backend.mm`, where it sets the session's `animatesToStartingPositionsOnCancelOrFail`. The release ends the gesture the moment it happens, as on X11, and the return is the app's to animate from `onDragEnd`. Not made a seam: there is no system image for a caller to want slid back, and an option to slide back nothing would be a decision forwarded rather than made.

- `src/cocoa/dnd.js` — the option, and the reasoning in `dragSpec`'s comment
- `test/cocoa-dnd.test.js` — a regression in the #494 shape: the spec carries `slideBack: false` beside no image
- `docs/drag-and-drop.md` — the macOS platform note says why the slide-back is off

## Verification

- `test/cocoa-dnd.test.js`: 13 pass. Mutation check: with the option removed, the new test fails with `actual: undefined, expected: false`.
- Full suite locally: 1998 pass, 6 fail — the six `appearance.test.js` failures that are the known macOS-only local baseline and pass in CI.
- `eslint` and `prettier --check .` are clean.
- Not measured live: a real `NSDraggingSession` needs a real pointer gesture, which this machine cannot synthesise. The evidence for the timing is the bridge source and AppKit's documented behaviour of the property, as the issue lays out.

Fixes #494
