### PR TITLE
feat: frame pacing — a CPU-time budget over a window's frames, opt-in per window, glarea or root, on both backends

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,21 @@ no override-redirect staging (issue #4).
   a node. **Never import `yoga-layout`'s default entry** — it is a
   top-level await, and one import costs every app the single-executable
   build (docs/packaging.md); `test/yoga.test.js` enforces this.
+- `src/pacing.js` — frame pacing: `frameRate`'s policies and the token
+  bucket over paint time behind them (docs/architecture/frame-pacing.md).
+  Pure — no node, no backend, a clock it is handed — and off by default:
+  `'display'` answers every claim with "now" for one property read, and a
+  streaming window opts into `'adaptive'`. It sits **above** both frame
+  clocks (`WindowNode._scheduleFrame`, `GlAreaNode.requestFrame` delay the
+  `requestAnimationFrame` request; the clock still gates the frame), and it
+  prices the JS thread's time — the flush, plus the Cocoa present, which
+  reports its cost back — never the server's, which the X11 fence already
+  paces. Three things are easy to undo: a claim raised _during_ a flush is
+  scheduled after it, so the frame that raised it is the one priced; the
+  discrete-input flush pays a held claim's debt and stands its wait down,
+  so answering an input is never held; and a wait under a millisecond is
+  carried as debt rather than armed, so a cheap frame after a flood lands
+  on the tick it always would have.
 - `src/anchor.js` — where a `<popup>` goes: `anchorRect` and the screen
   area it flips and clamps against. Core rather than widget code because
   **both** callers need it and only one is a widget — a `<popup anchor>`

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,10 @@
   `<box>`, `<text>`, `<textinput>`, `<textarea>`, `<image>`, `<canvas>`,
   `<svg>`, `<foreign>`, their props and refs — including
   [selecting read-only text](elements.md#selecting-text) with `selectable`.
+- [architecture/frame-pacing.md](architecture/frame-pacing.md) — the
+  design record behind `frameRate`: why a window fed off an input path
+  paints screens nobody sees, the token bucket over paint time that holds
+  it to a budget, where it lives on both backends, and what it measured.
 - [styling.md](styling.md) — the `style` prop: layout and paint properties,
   `:hover`/`:focus`/`:active`/`:disabled` blocks, transitions, theme tokens,
   window size and container queries, `createStyles`, and

--- a/docs/architecture/frame-pacing.md
+++ b/docs/architecture/frame-pacing.md
@@ -1,0 +1,255 @@
+# Frame pacing: a budget over paint time, not a count of updates
+
+_Design record, 2026-09-07. Written against master at 25d6869 (react-x11
+2.8.3, ntk ^8.7.0, `@windowkit/appkit` ^0.6.0), for the `frameRate` prop
+that shipped with it. The user-facing account is
+[elements.md](../elements.md#framerate--pacing-the-frames-under-a-flood);
+this is why it is shaped the way it is, where it sits, and what it
+measured. The problem was found in `@react-x11/components`'s vt terminal
+(sidorares/react-x11-components#69, "PRD: adaptive frame pacing"), whose
+§6 lists what core would have to grow; this document is core's half of it,
+made generic._
+
+---
+
+## 0. TL;DR
+
+- A window fed off an input path — a terminal under `cat`, a chart on a
+  socket, a simulation, a scene drawing as fast as it can — claims a repaint
+  every time its data moves. The frame clock decides _when_ a frame may go
+  out and says nothing about whether it is worth painting, so on a 120Hz
+  panel such a window paints 120 times a second. Where a frame costs
+  milliseconds of the JS thread (full-window CoreGraphics on macOS), the
+  thread paints screens nobody sees and the producer gets what is left:
+  measured on a streaming terminal, 60% of wall time in paint and a flood
+  four times slower on macOS than under XQuartz on the same machine.
+- The fix prices frames in **CPU time**, not in updates: a token bucket
+  over paint time. Credit accrues at `budget` per millisecond of wall time
+  up to a burst; a frame spends what it measurably cost; a claim that finds
+  the bucket in debt waits for it to reach zero and no longer. Idle is
+  immediate, cheap is unthrottled, one expensive frame among cheap ones is
+  free, and a flood that ends is un-throttled on its next claim.
+- It lives **above both frame clocks**, in `WindowNode._scheduleFrame` and
+  `GlAreaNode.requestFrame`: a held claim delays the `requestAnimationFrame`
+  request, and the clock — ntk's fence or vertical blank on X11, the display
+  period on macOS — still gates the frame itself. Nothing changes what a
+  frame paints.
+- **Opt-in.** `'display'` — every frame the clock gives, after React's own
+  batching — is the default; `'adaptive'` is what a streaming window asks
+  for, on the `<window>` or `<glarea>`, for a root, or from
+  `REACT_X11_FRAME_RATE`.
+- Beside it, `Node.opaqueRect()`: an element that composites an opaque
+  bitmap over its box says so, and a pass inside it skips the fills that
+  were under it — the other fifth of the terminal's frame.
+
+## 1. The problem, measured
+
+The components PRD's numbers, on an M1 Pro with a 120Hz panel, a 1000×700
+window at 2×, a 125×45 terminal grid and 300,000 distinct lines `cat`-ed
+into its pty:
+
+| variant                                       |  flood | paints/s | paint share |
+| --------------------------------------------- | -----: | -------: | ----------: |
+| Cocoa, defaults                               | 3.50 s |      110 |         60% |
+| Cocoa, `cocoa: { frameInterval: 33.3 }`       | 1.08 s |       34 |         21% |
+| X11 (XQuartz), defaults                       | 0.85 s |       35 |          7% |
+| Cocoa, an element-owned pacer at a 25% budget | 0.95 s |       35 |         20% |
+
+Three facts fall out of it. **Frame count is the lever**: both backends
+run the clock at the display's period, but the X11 frame is _fenced_ — ntk
+does not start the next until the server has consumed the last, and the
+server takes ~28ms to composite a screenful of glyphs, so the terminal
+paints 35 times a second by backpressure. The Cocoa backend has no
+equivalent: its "server" is CoreGraphics on the JS thread and the frame is
+due whenever the display is. **Per-frame cost is full-area memory passes,
+not glyphs**: of a 6ms Cocoa frame, 2.0ms is the cell backgrounds, 1.7ms
+the surface-to-window composite, 0.95ms the swapchain catch-up copy,
+0.7ms two background fills under the opaque surface — and 0.26ms the
+glyphs. **A fixed cap is the wrong tool**: `frameInterval: 33.3` recovers
+most of the gap and costs every window on the root its 120Hz, including
+the ones whose frames are cheap.
+
+## 2. The rule
+
+The PRD's rule was "defer a claim until `lastPaintEnd + cost × (1/budget −
+1)`", from the last frame's cost. That is the right steady state and the
+wrong transient: it holds the frame after a single expensive one — the one
+relayout in a blit-scrolled list — for three times its cost, on a scroll
+that should stay at 120Hz because everything else in it is a memmove and a
+strip. The user's requirement was exactly that case: _budget CPU price,
+not the number of updates; a scroll that is mostly blits stays at 120Hz
+with rare repaints._
+
+The token bucket is the same rule with a burst (`src/pacing.js`,
+`FramePacer`):
+
+```
+credit  += budget × (now − lastAccrual), capped at burst
+frame:   credit −= cost                        // what the flush measured
+claim:   wait = credit ≥ 0 ? 0 : −credit / budget
+         wait = min(wait, lastEnd + 1000/minFps − now)   // the floor
+         wait = max(wait, lastStart + 1000/maxFps − now) // the ceiling
+```
+
+- With the bucket at zero, a frame of cost `c` leaves it at `−c(1 −
+budget)` and the next claim waits `c(1/budget − 1)` — the PRD's rule, in
+  steady state under a flood. Over a long stream the paint share converges
+  on the budget exactly (`test/pacing.test.js`, "converges on the budget").
+- The **burst** is what absorbs the rare expensive frame: a single frame up
+  to the burst never earns a wait, and only a stream drains it. The burst
+  is the floor's interval (50ms at `minFps: 20`), 50ms without a floor —
+  one frame up to the longest wait the pacer may impose is always free.
+- The debt is bounded by one frame's cost, so a flood that ends is
+  un-throttled after that one wait. An average would have kept throttling
+  the prompt that appears when the flood stops.
+- Waits under a millisecond are not armed: a timer cannot keep them and a
+  clock tick would swallow them. The debt carries to the next claim, so a
+  run of sub-millisecond frames claimed back to back still pays once it is
+  worth a timer, and a cheap frame after a flood lands on the tick it would
+  have landed on anyway.
+
+**Cost is the JS thread's time.** The flush — layout, the paint passes, the
+requests or the CoreGraphics work — bracketed in `WindowNode.flush`, plus on
+macOS the present that runs after it (`CocoaWindow.present` reports the
+flip and its catch-up copy back to the node). Not the server's: on X11 the
+fence already paces to that, and the pacer is deliberately inert where a
+backend has backpressure of its own. The PRD's Q5 asked whether a core seam
+reporting the whole flush's cost would make the rule exact on both
+backends; the answer is that the thread's time _is_ the cost the rule is
+about, because it is what the producer is starved of.
+
+## 3. Where it lives, and what it composes with
+
+The pacer is per frame source: one on each `WindowNode` (popups included)
+and one on each `GlAreaNode`, whose frames run on a clock of their own.
+`_scheduleFrame` asks it before requesting the window's callback; a claim
+raised by the frame on itself — an animation stepping, a container query
+settling, a promotion moving a node — is answered once the frame is over,
+so the frame that raised it is the one priced.
+
+- **The clocks.** A held claim delays the `requestAnimationFrame` request
+  by the wait; the clock then gates the frame as it always did. On macOS a
+  request between two pump ticks used to wait for the next tick to look at
+  it, up to a pump interval on top of the wait; `CocoaApp._requestFrame`
+  now arms the same one-shot a tick arms for a frame it just missed, at the
+  moment the clock is due, so a paced claim lands at its wait rather than
+  its wait rounded up to the pump. On X11 ntk's clock is untouched.
+- **Discrete input.** A click or a key paints the window at once
+  (`flushPendingFrames`, [events.md](../events.md)), held claims included —
+  a held claim is damage like any other, and the early flush stands the
+  wait down. The debt is paid then. Answering the input is never held.
+- **Animations.** A transition's frames go through the same claims and are
+  paced like any other; at the default nothing changes, and under
+  `'adaptive'` cheap transition frames never wait. A layer promotion's
+  animations run in the render server and schedule no frames at all.
+- **Hidden and occluded windows** schedule no frames; the bucket refills
+  while they wait, so the catch-up frame is immediate.
+- **`cocoa: { frameInterval }`** is still the clock's own cap on macOS and
+  applies to everything on the clock; `frameRate` is the policy above it,
+  per window, on both backends. `maxFps` is the cap an app should write.
+
+## 4. The API
+
+`frameRate` on `<window>`, `<popup>` and `<glarea>`; `createRoot({
+frameRate })` for a root's default; `REACT_X11_FRAME_RATE` over both. A
+preset name, a number (a ceiling and nothing else), or `{ budget, minFps,
+maxFps }` with the ones left out taken from `'display'`. A `<glarea>` takes
+its window's policy unless it names one. Resolved in `src/pacing.js`
+(`resolveFrameRate`, `resolveFramePolicy`), validated at the call that
+passed the value — a bad root option fails at `createRoot`, a bad prop at
+the window — with the choices in the error.
+
+Decided, and why (the PRD's §11, answered for core):
+
+- **The name** is `frameRate`: it is what an author thinks in, and the
+  numeric form reads as a cap.
+- **The environment overrides the prop**, as `REACT_X11_BACKEND` does: an
+  A/B run and a field diagnosis must not need a code change in every app.
+- **A number is a ceiling over the default**, not over `'adaptive'`. With
+  `'display'` the default, `frameRate={30}` has to mean "never more than
+  30" and nothing else; adaptive-and-capped is spelled with the numbers.
+- **The default is `'display'`.** A UI answers its input as quickly as it
+  can unless it says otherwise; the pacer is what a window that streams
+  asks for. It costs the default path one property read per claim.
+- **Several windows pace themselves.** Four floods at once can take four
+  budgets; a shared budget is a process-level clock and is not built.
+
+Observability: `REACT_X11_TRACE=requests` prints `waited=` on every frame
+the pacer held ([debugging.md](../debugging.md)), the `frame` trace hook
+carries it, and the pacer's counters — frames, held, coalesced, the last
+cost and the last wait — are on the node for a bench to print.
+
+## 5. The opaque-content hint
+
+Of the terminal's 6ms frame, 0.7ms was two background fills under a
+surface that covers every pixel of them, and on X11 the same fills are
+composites the server ran for nothing. Core had no way to know.
+`Node.opaqueRect()` is the element's word: the rect it writes opaque pixels
+over on every paint, in whole pixels; a pass inside it is painted without
+the clear, the window's background, and the backgrounds of the node and its
+ancestors. Clipping ancestors shrink the cover to what reaches the surface,
+a rounded one by its radius all round. The element claims its damage as a
+rect inside the answer, because a node claim carries a pixel of slop that
+lies outside it ([extending.md](../extending.md#an-element-that-covers-its-box)).
+Pinned by `test/opaque-content.test.js`: the fills skipped are exactly
+those, and a covered pass leaves the pixels a full repaint leaves.
+
+## 6. What is not here, and why
+
+Two of the PRD's four seams need the native bridge first, and the third
+needs a design of its own. Each is filed rather than folklore:
+
+- **`globalCompositeOperation` on the Cocoa context, with a memcpy for
+  `'copy'`** (the 1.7ms surface-to-window composite). `@windowkit/appkit`
+  0.6.0 has no blend-mode verb, and its one memcpy, `copySurfaceRegion`,
+  refuses surfaces of unequal size — it is the swapchain's catch-up copy,
+  not a blit. Both verbs are the bridge's to grow; the property is declared
+  optional on `Context2D` in the meantime, so an element asks for it
+  rather than assumes it.
+- **Element-owned layer contents** (`presentSurface()` on a node over an
+  IOSurface-backed `Surface`, so the terminal's surface _is_ its layer and
+  the present and the swapchain copy disappear). The bridge has the
+  primitives — `createSurfaceIOSurface`, `setLayerContentsIOSurface` — but
+  a layer showing an IOSurface the element then draws into again tears; it
+  needs a two-buffer chain of its own, a flip on present, and the promotion
+  policy of `src/cocoa/promotion.js` extended to "this node presents a
+  surface" with the same z-order rule. A design document first.
+- **An adaptive tick-skip in the Cocoa clock.** Not needed: with the pacer
+  above the clock the clock has no tick to skip — a window that is holding
+  a claim has no callback queued.
+
+## 7. Measured
+
+`npm run bench:presenters -- --scenario=stream` is the flood in core's own
+terms: a window-sized element that answers `opaqueRect()`, painting a
+120×40 grid of cell fills, claimed every 2ms from a timer — the producer —
+with `--frame-rate` choosing the policy. Read `cpu` and the paint share
+against `claims/s`, which is how often the producer got the thread.
+
+On the M1 Pro's 120Hz panel, a 900×700 window at 2× (the stream pane is
+the window less a header), six seconds a cell, `--columns=surface`:
+
+| `--frame-rate` |   fps | flush avg | paint share of wall | cpu | producer: claims/s |
+| -------------- | ----: | --------: | ------------------: | --: | -----------------: |
+| `display`      | 120.0 |    4.84ms |                 58% | 72% |                244 |
+| `adaptive`     |  36.1 |    5.79ms |                 21% | 27% |                529 |
+| `30`           |  29.7 |    6.47ms |                 19% | 24% |                539 |
+| `throughput`   |   8.8 |   10.26ms |                  9% | 13% |                592 |
+
+Read across a row. At the default the window paints every refresh and the
+thread spends 58% of its time doing it; the producer, a 2ms timer that
+would fire 500 times a second on an idle thread, fires 244 — the flood is
+starving the thing that feeds it, which is the whole finding. Under
+`'adaptive'` the pacer holds 330 of 341 claims (the first eleven are the
+burst), paints 36 times a second, keeps paint at the budget — 21% where
+the rule says 25%, the difference being the clock rounding each wait up to
+the next tick — and the producer gets 529 of its 500-per-second, which is
+to say all of it. The cap at 30 lands where it says. `'throughput'` is the
+other end: 9% of the thread, one frame every 100ms. The per-frame cost
+rises as frames get rarer (a cold cache, a core the OS clocks down between
+frames), which is why the row is priced in share and not in milliseconds.
+
+What the table does not show is as important: a scroll under `'adaptive'`
+paints at 120Hz like the default, because its frames cost a fraction of a
+millisecond (`test/frame-pacing.test.js`, "cheap frames never wait"), and
+a click during the flood is answered on the click.

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -47,7 +47,11 @@ REACT_X11_TRACE=summary npm run examples:dashboard
   it is a server round trip, and a paint that builds in 0.3ms
   against 20ms there _is_ a server-side problem (software-fallback RENDER
   ops, a virtualized GPU) rather than a renderer one.
-  `npm run bench:frames` reports the same split as a summary.
+  `npm run bench:frames` reports the same split as a summary. A frame the
+  frame pacer held ([elements.md](elements.md#framerate--pacing-the-frames-under-a-flood))
+  carries `waited=18.0ms` — how long the claim waited before the clock got
+  it; a frame that was not held carries nothing, so the default's lines are
+  the lines they always were.
 - `chrome:/tmp/trace.json` — [Chrome Trace Event
   JSON](https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU),
   written at exit. Open it in Perfetto or `about:tracing`: React commits

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -193,6 +193,7 @@ A real X11 window; the flex, paint and event root for its subtree.
 | `theme`                     | palette that `$token` style values resolve against, for this subtree                                                                                                                                    |
 | `embeddable`                | created but never self-mapped: the window waits for an embedder ([`<foreign>`](embedding.md) on the other side), which maps it after the reparent. What a [`<Frame>`](frame.md) pane's root window sets |
 | `hidden`                    | realized and laid out, never mapped while true (below)                                                                                                                                                  |
+| `frameRate`                 | how the window paces its frames under a stream of changes: `'display'` (the default), `'adaptive'`, `'throughput'`, a ceiling in fps, or `{ budget, minFps, maxFps }` (below)                           |
 
 Windows may be nested inside other windows (real X11 child windows).
 **Ref**: the live ntk `Window` — `getContext('2d')`,
@@ -360,6 +361,87 @@ On a `<popup>` the pair of unmap/map is the whole story. On a managed
 `<window>` an unmap is ICCCM's _withdraw_ — the window manager forgets the
 window, and the re-map is a fresh `MapRequest`, so a WM may frame or place
 it anew and `states` are re-declared rather than remembered.
+
+### `frameRate` — pacing the frames under a flood
+
+```jsx
+<window frameRate="adaptive">…</window>
+```
+
+By default a window paints every frame the clock gives it: on X11 as often
+as the server keeps up, on macOS at the display's own rate. That is right
+for a UI that answers input — a keystroke, a hover, a scroll — where every
+frame is one someone is waiting for. It is wrong for a window whose content
+changes faster than anyone can read it: a terminal under `cat`, a chart fed
+by a socket, a simulation ticking as fast as it can. On a 120Hz panel such a
+window paints 120 times a second, and where a frame costs a few
+milliseconds of the JS thread — full-window CoreGraphics passes on macOS —
+most of that thread goes to painting screens nobody sees, and the producer
+gets what is left. Measured on a streaming terminal, that was a flood four
+times slower on macOS than under XQuartz on the same machine, and the whole
+difference was frame count times per-frame cost.
+
+`frameRate` prices frames in CPU time rather than counting them. A window
+under `'adaptive'` keeps a budget: painting may take a quarter of the wall
+time while the window is busy. Credit accrues at that rate, a frame spends
+what it measurably cost — the flush, and on macOS the present — and a claim
+that finds the window in debt waits for the credit to reach zero, and no
+longer. Four things follow, and they are what the tests pin:
+
+- **Idle is immediate.** A quiet window has a full bucket, so the first
+  claim after a pause — a keystroke, a click — paints on the next tick,
+  whatever the last frame cost.
+- **Cheap is unthrottled.** A frame that costs less than the credit it
+  accrued leaves the bucket where it was. A blit-scrolled list keeps the
+  display's rate: its frames are memmoves and a strip.
+- **A rare expensive frame is free.** The bucket holds a burst — 50ms of
+  paint, the floor's interval — so the one relayout in a scroll costs
+  credit, the credit refills, and nothing waited. Only a _stream_ of
+  expensive frames drains it, and then each waits `cost × (1/budget − 1)`:
+  a 6ms frame is followed by 18ms of the thread for everything else.
+- **A flood that ends is un-throttled at once.** The debt is never more than
+  one frame's cost, so the prompt that appears when the flood stops waits
+  for that and nothing more.
+
+Two more numbers bound the rule. `minFps` is the floor: whatever the debt,
+the screen is never more than `1000 / minFps` ms behind the last paint — a
+promise about staleness, not a rate, since a single frame can take longer.
+`maxFps` is a ceiling on top of the display's, cheap frames included — the
+knob every terminal already has.
+
+| value                        | `budget` | `minFps` | `maxFps` | when                                                                                   |
+| ---------------------------- | -------: | -------: | -------: | -------------------------------------------------------------------------------------- |
+| `'display'` (the default)    |        1 |     none |     none | a UI answering input: every frame the clock gives, after React's own batching          |
+| `'adaptive'`                 |     0.25 |       20 |     none | a window fed off an input path: a terminal, a live chart, a scene that streams         |
+| `'throughput'`               |      0.1 |       10 |       30 | output matters more than the display: the screen may lag by up to 100ms during a flood |
+| a number, `60`               |        1 |     none |       60 | a ceiling and nothing else — the fixed cap                                             |
+| `{ budget, minFps, maxFps }` |          |          |          | the three numbers, any subset; the ones left out are `'display'`'s                     |
+
+A budget below 1 with no `minFps` warns in development: after an expensive
+frame the next may wait three times its cost with nothing to bound it, and
+`{ budget, minFps: 20 }` is what `'adaptive'` does.
+
+Three sources, in order of precedence: **`REACT_X11_FRAME_RATE`** in the
+environment (`adaptive`, `display`, `throughput` or a number) overrides
+everything, the way `REACT_X11_BACKEND` does, so an A/B run and a field
+diagnosis need no code change; then **the prop**; then
+**`createRoot({ frameRate })`**, the default for every window of that root;
+then `'display'`. A `<popup>` paces itself the same way, from its own prop.
+A [`<glarea>`](#glarea) takes the window's policy for its own frames unless
+it names one.
+
+What the pacer does not do. It never changes what a frame paints: a held
+claim's damage accumulates on the window exactly as it does between two
+ticks of the clock, and the frame that follows paints all of it. It never
+holds the answer to an input: a click or a key paints the window at once
+(the early flush in [events.md](events.md)), held claims included, and the
+debt is paid then. And it prices the JS thread's time only — on X11 the
+server's work is fenced by the frame clock already, so the pacer rarely
+holds a frame there; where a backend has backpressure of its own, the
+pacer is inert. `REACT_X11_TRACE=requests` prints `waited=` on every frame
+the pacer held ([debugging.md](debugging.md)), and
+[architecture/frame-pacing.md](architecture/frame-pacing.md) is the design
+record, with the measurements.
 
 ### `onResize` fires for moves
 
@@ -1756,6 +1838,13 @@ enabled (`+iglx` / `AllowIndirectGLX` — off by default on many).
 - `clearColor` — CSS colour or `[r, g, b, a]` floats (default black).
 - `frameLoop` — `'demand'` (default) redraws on prop, size and expose
   changes only; `'always'` renders continuously on ntk's frame clock.
+- `frameRate` — how those frames are paced when they are expensive: the
+  same values as [`<window frameRate>`](#framerate--pacing-the-frames-under-a-flood),
+  priced by what `onDraw` and the swap cost the JS thread. Defaults to the
+  owning window's, so a `<window frameRate="adaptive">` paces the scene in
+  it too; name `'display'` here for a scene that wants every frame while the
+  window around it streams. A `frameLoop` of `'always'` under `'adaptive'`
+  is a loop at the budget rather than at the display.
 - `glx` — a visual spec for ntk's `chooseGLXConfig`, e.g.
   `{ DEPTH_SIZE: 24 }`. One query per app, shared by every `<glarea>`.
 - `onError(err)` — no GL surface (no GLX, no matching visual). Without a

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -111,6 +111,7 @@ that only draws needs a constructor and a `paint`. What you may override:
 | ------------------------------ | ------------------------------------------------------------------------------------------------------------ |
 | `paint(ctx)`                   | draw. Call `super.paint(ctx)` first for background, border and clip, then draw inside `this.abs`.            |
 | `paintContent(ctx)`            | draw _between_ the background and the children — where the built-ins draw, and what a scroller needs (below) |
+| `opaqueRect()`                 | the rect you cover with opaque pixels on every paint, so a pass inside it skips the fills under you (below)  |
 | `applyProps(next, prev)`       | props changed. Call `super.applyProps(next, prev)`; invalidate if you cache anything derived.                |
 | `paintChanged(next, prev)`     | did anything you draw change? Only for an element that claims its own damage (below)                         |
 | `measureContent(constraints)`  | your content has a size of its own (below). Leaves only — an element that measures has no children.          |
@@ -1316,6 +1317,45 @@ drawing it live, the shift you want is
 [`copyWithin`](#scrolling-the-pixels-not-just-the-offset) on that surface —
 same idea, one layer in.
 
+### An element that covers its box
+
+A terminal, a media frame, a chart with a retained surface: an element that
+composites a bitmap of its own over its whole content box, every paint,
+leaves nothing of what was painted under it. Core does not know that. A
+pass inside the element still fills the window's background, the
+background of every ancestor and the element's own before `paintContent`
+composites the bitmap over all three — composites the server ran for
+nothing on X11, and on macOS full-area CoreGraphics passes that were a
+fifth of a streaming terminal's frame.
+
+`opaqueRect()` is the element's word for it:
+
+```js
+class TerminalNode extends Node {
+  opaqueRect() {
+    return this.contentBox(); // every pixel of it, alpha one, every paint
+  }
+
+  _screenChanged() {
+    // a rect inside the answer, not the node: a node claim is inflated by
+    // a pixel of slop, which is outside the rect and so never covered
+    this.invalidate(false, this.contentBox(), 'content');
+  }
+}
+```
+
+A pass that lies inside the answer is painted without the fills that would
+be under it — the window's background, this node's own and every
+ancestor's. Whole pixels only, window coordinates like `abs`: a fractional
+edge is antialiased and an antialiased pixel is not opaque, so core takes
+the whole pixels inside what you answer. A clipping ancestor shrinks the
+cover to what reaches the surface, a rounded one by its radius all round.
+The promise is yours to keep — every pixel, alpha one, on every paint,
+whatever the props — and an element that is translucent, or paints a
+background only sometimes, answers `null`, the default. The answer is read
+per pass, so it may follow `contentBox()`, and it costs nothing on a pass
+it does not cover.
+
 ### Drawing once instead of every frame
 
 A drawing that does not change between frames does not have to be redrawn
@@ -1476,3 +1516,11 @@ declare module 'react-x11/jsx-runtime' {
 
 `test/types/extend.tsx` in this repo compiles exactly that, so the story
 stays true as the declarations move.
+
+The drawing side is declared too. `Context2D` from `react-x11/node` is the
+canvas-shaped subset **both** backends implement — ntk's context over
+XRender and the cocoa backend's over CoreGraphics — so `paintContent(ctx:
+Context2D)` type-checks every call an element makes, and a member only one
+backend has is optional there (`globalCompositeOperation`, X11 only) or
+absent. `paintCachePlan`, `paintCached`, `opaqueRect` and the rest of the
+contract above are on the class, with `PaintCachePlan` for the plan.

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -698,9 +698,26 @@ with a frame interval over it (`frameInterval`; by default the period of
 the display each window is on, as `listScreens` reports it — 8.3ms on a
 120Hz panel, 16.7 on a 60Hz monitor — with a frame that falls between
 two pump ticks given a one-shot timer of its own, so the period is the
-display's whatever the pump's cadence), discrete input and the wheel
-flushed on the event, and a window that is not on glass deferring its
-frames — see "Measured" below for what each of those was worth.
+display's whatever the pump's cadence — and, since the frame pacer, a
+frame asked for between two ticks armed on the spot rather than looked at
+by the next tick), discrete input and the wheel flushed on the event, and
+a window that is not on glass deferring its frames — see "Measured" below
+for what each of those was worth.
+
+What the clock cannot know is whether a frame is worth painting. It has no
+fence: the X11 frame waits for the server to consume the last one, and a
+window fed off an input path — a streaming terminal — self-paces to what
+the server can composite; here the "server" is CoreGraphics on the JS
+thread and the frame is due whenever the display is, so the same window
+paints every refresh and the thread paints screens nobody reads. That is
+`frameRate`'s job ([elements.md](elements.md#framerate--pacing-the-frames-under-a-flood),
+[architecture/frame-pacing.md](architecture/frame-pacing.md)): a window
+under `'adaptive'` holds a claim while its recent frames have spent more
+than their share of the thread, priced by what the flush _and the present_
+cost — `CocoaWindow.present` reports the flip and its catch-up copy back
+to the node, because a damage-sized memcpy per frame is a millisecond the
+flush never saw. Off by default; `cocoa: { frameInterval }` stays the
+clock's own cap over everything on it.
 
 ## Native controls
 
@@ -1720,6 +1737,34 @@ the fills and the line draws, which only not repainting can take away: a
 paint cache over the cells that did not change, or the layers presenter —
 then yoga's own pass at about a millisecond per thousand nodes, and React's
 commit of a tree that re-renders unmemoized.
+
+## Measured: the flood, under the frame pacer
+
+Written 2026-09-07 against react-x11 2.8.3 and `@windowkit/appkit` 0.6.0,
+same machine, the surface presenter, `npm run bench:presenters --
+--scenario=stream --columns=surface`: a window-sized element repainting its
+whole box on every claim, claimed every 2ms by a timer standing in for a
+producer — the shape of a terminal under `cat`. The rows are `--frame-rate`
+([elements.md](elements.md#framerate--pacing-the-frames-under-a-flood)).
+
+| `--frame-rate` |   fps | paint share of wall | cpu | producer: claims/s |
+| -------------- | ----: | ------------------: | --: | -----------------: |
+| `display`      | 120.0 |                 58% | 72% |                244 |
+| `adaptive`     |  36.1 |                 21% | 27% |                529 |
+| `30`           |  29.7 |                 19% | 24% |                539 |
+| `throughput`   |   8.8 |                  9% | 13% |                592 |
+
+The default paints every refresh and starves its producer of half its
+ticks; `'adaptive'` holds paint at the budget and gives the producer all of
+them. The design and the rest of the numbers are in
+[architecture/frame-pacing.md](architecture/frame-pacing.md). Two things
+here are the backend's own: `CocoaWindow.present` reports the flip and its
+catch-up copy to the node, so the frame is priced by what the thread
+spent and not just by the flush; and `CocoaApp._requestFrame` arms the
+frame timer for a request that arrives between two pump ticks, so a held
+claim lands at its wait rather than at its wait rounded up to the pump.
+The structural gate is unchanged: every rule holds at the default, which
+is what every scenario but `stream` runs at.
 
 ## Testing
 

--- a/scripts/bench/presenters.js
+++ b/scripts/bench/presenters.js
@@ -32,6 +32,8 @@
 //                                               # promoted = on, layers)
 //   npm run bench:presenters -- --x11           # extra column via $DISPLAY
 //   npm run bench:presenters -- --cells=2400    # bigger stress trees
+//   npm run bench:presenters -- --scenario=stream --frame-rate=adaptive
+//                                               # the flood, under the pacer
 //   npm run bench:presenters -- --at=200,200    # the window at a point (on
 //                                               # the screen whose rate you
 //                                               # mean to measure)
@@ -83,6 +85,10 @@ const CELLS = Number(flag('cells', 1200));
 const COLUMNS = flag('columns', null);
 const SIZE = flag('size', '900x700');
 const FRAME = flag('frame', null); // cocoa frame interval, ms
+// --frame-rate=display|adaptive|throughput|<fps>: the frame pacer's policy
+// for the root (docs/elements.md "frameRate"), what the `stream` scenario
+// is for; every other scenario runs at the default unless told otherwise
+const FRAME_RATE = flag('frame-rate', null);
 // --at=x,y: where to put the window, in points, top-left global — on a
 // desk with a 120Hz panel and a 75Hz monitor the default frame interval is
 // the display's, so which screen the window lands on is part of the result
@@ -432,7 +438,38 @@ function wheelNotch(ctx) {
   });
 }
 
+let streamTimer = null;
+
 const SCENARIOS = {
+  /** A flood: a window-sized element whose content changes faster than
+   *  the display refreshes — a terminal under `cat`, a chart on a socket,
+   *  a simulation. A timer claims it every 2ms, standing in for the
+   *  producer; every claim repaints the whole box (`defineStreamPane`, a
+   *  few milliseconds of CoreGraphics at 2x). With the default `frameRate`
+   *  the clock paints every refresh and the thread paints screens nobody
+   *  reads; `--frame-rate=adaptive` is the pacer (docs/elements.md
+   *  "frameRate"). Read fps and cpu against `claims/s` — how often the
+   *  producer got the thread — and the pacer's own counters in the notes. */
+  stream: {
+    tree: () =>
+      windowOf([
+        header('stream — a window-sized element claiming every 2ms'),
+        e('streampane', { key: 'pane', style: { flexGrow: 1 } }),
+      ]),
+    setup(ctx) {
+      const pane = ctx.find((n) => n.kind === 'streampane');
+      ctx.extra.claims = 0;
+      ctx.extra.pacing = pane.root._pacer.stats;
+      if (streamTimer) clearInterval(streamTimer);
+      streamTimer = setInterval(() => {
+        pane.tick += 1;
+        pane.invalidate(false, pane.contentBox(), 'content');
+        ctx.extra.claims += 1;
+      }, 2);
+    },
+    // the timer is the flood; the tick re-renders nothing
+    drive() {},
+  },
   /** Paint-only bounded change: one 100px box recolours. The layers
    *  presenter should answer with one backgroundColor prop and zero
    *  rasters; the surface presenter with a bounded repaint plus a
@@ -1209,6 +1246,48 @@ const rectsTouch = (a, b) =>
   a.y < b.y + b.height &&
   b.y < a.y + a.height;
 
+/**
+ * The `stream` scenario's element: a window-sized pane that repaints its
+ * whole box on every claim — a 120×40 grid of cell fills, two colours, the
+ * pattern shifted by a tick so every cell changes — the shape of a
+ * terminal under a flood, or a chart redrawn per sample. It answers
+ * `opaqueRect()`, as such an element should, so the fills under it are
+ * skipped; what is left is its own full-area pass, which is the cost the
+ * pacer prices.
+ */
+function defineStreamPane(NodeClass) {
+  return class StreamPaneNode extends NodeClass {
+    constructor(props, app) {
+      super('streampane', props, app);
+      this.tick = 0;
+    }
+
+    opaqueRect() {
+      return this.contentBox();
+    }
+
+    paintContent(ctx) {
+      const { x, y, width, height } = this.contentBox();
+      const cols = 120;
+      const rows = 40;
+      const cw = width / cols;
+      const ch = height / rows;
+      const lit = [];
+      const dark = [];
+      for (let r = 0; r < rows; r += 1) {
+        for (let c = 0; c < cols; c += 1) {
+          const cell = (r * cols + c + this.tick) % 3 === 0 ? lit : dark;
+          cell.push(x + c * cw, y + r * ch, cw, ch);
+        }
+      }
+      ctx.fillStyle = '#1e1e2e';
+      ctx.fillRects(dark);
+      ctx.fillStyle = '#89b4fa';
+      ctx.fillRects(lit);
+    }
+  };
+}
+
 function definePane(NodeClass) {
   return class BenchPaneNode extends NodeClass {
     constructor(props, app) {
@@ -1373,9 +1452,20 @@ async function runChild() {
   const { Icon } = await import('../../src/components/Icon.js');
   const store = makeStore(COLS * ROWS);
   const deps = { Icon, store };
-  const root = await createRoot(
-    FRAME ? { cocoa: { frameInterval: Number(FRAME) } } : {},
-  );
+  const StreamPaneNode = defineStreamPane(Node);
+  registerElement('streampane', {
+    create: (props, app) => new StreamPaneNode(props, app),
+  });
+  const root = await createRoot({
+    ...(FRAME ? { cocoa: { frameInterval: Number(FRAME) } } : {}),
+    ...(FRAME_RATE
+      ? {
+          frameRate: Number.isFinite(Number(FRAME_RATE))
+            ? Number(FRAME_RATE)
+            : FRAME_RATE,
+        }
+      : {}),
+  });
   const app = root.app;
   const cocoa = Boolean(app._native);
 
@@ -1627,7 +1717,10 @@ async function runChild() {
     scale: win?.scale ?? 1,
     frames,
     fps: frames / elapsed,
+    // the flush's share of wall time — what the frame pacer budgets
+    flushPct: (100 * sum(sorted)) / (elapsed * 1000),
     ticks: tick,
+    elapsed,
     flushAvg: sorted.length ? sum(sorted) / sorted.length : null,
     flushP95: q(sorted, 0.95),
     flushMax: sorted.at(-1) ?? null,
@@ -1691,6 +1784,7 @@ function runCell(name, env) {
       `--cells=${CELLS}`,
       `--size=${SIZE}`,
       ...(FRAME ? [`--frame=${FRAME}`] : []),
+      ...(FRAME_RATE ? [`--frame-rate=${FRAME_RATE}`] : []),
       ...(AT ? [`--at=${AT}`] : []),
       ...(SHOTS ? ['--shots'] : []),
     ],
@@ -1933,6 +2027,14 @@ if (CHILD) {
       if (Math.abs(r.rssMb) >= 8)
         notes.push(`rss ${r.rssMb > 0 ? '+' : ''}${r.rssMb.toFixed(0)}MB`);
       const x = r.extra ?? {};
+      if (x.pacing) {
+        const p = x.pacing;
+        notes.push(
+          `frameRate ${p.mode}: paint ${r.flushPct.toFixed(0)}% of wall, ` +
+            `${p.frames} frames, ${p.deferred} held (last wait ${p.lastWaitMs.toFixed(1)}ms, ` +
+            `last cost ${p.lastCostMs.toFixed(1)}ms); ${Math.round(x.claims / r.elapsed)} claims/s`,
+        );
+      }
       if (x.resizes) {
         notes.push(
           `${x.resizes} resizes: ${(x.resizeMs / x.resizes).toFixed(1)}ms avg, ${x.resizeMax.toFixed(1)}ms max, ` +

--- a/src/Reconciler.js
+++ b/src/Reconciler.js
@@ -33,6 +33,7 @@ import {
   windowAttributes,
   setTextStripBelow,
 } from './nodes.js';
+import { setFrameRateDefault } from './pacing.js';
 import { hasDropProps } from './dnd.js';
 import { AppProvider } from './appcontext.js';
 import {
@@ -795,6 +796,12 @@ export async function createRoot(options = {}) {
   // of as glyphs (nodes.js, `TextNode._paintsStrip`): six logical pixels by
   // default, 0 for glyphs at every size.
   setTextStripBelow(app, rest.textStripBelow);
+
+  // How this root's windows pace their frames when their content changes
+  // faster than the display refreshes (src/pacing.js): `'display'` — every
+  // frame the clock gives — unless the root says otherwise; a window's own
+  // `frameRate` prop wins over this, and REACT_X11_FRAME_RATE over both.
+  setFrameRateDefault(app, rest.frameRate);
 
   // Whether a subtree coming back out of hiding — a `<Suspense>` boundary
   // resolving, an `<Activity>` shown again — takes the keyboard back with it

--- a/src/cocoa/app.js
+++ b/src/cocoa/app.js
@@ -537,8 +537,25 @@ export class CocoaApp {
     for (const wnd of this._windows.values()) wnd.liveResizing = false;
   }
 
+  /**
+   * `requestAnimationFrame`, for a window or for the app's own clock. A
+   * frame asked for between two pump ticks used to wait for the next tick
+   * to look at it — up to a pump interval on top of whatever the clock
+   * owed. Now, while the pump runs, the first request into an empty queue
+   * arms the same one-shot a tick arms for a frame it just missed
+   * (`_armFrameTimer`), at the moment the clock is due; a request for a
+   * clock due after the next tick leaves it to the tick, as before. What
+   * a frame is and how many there are does not change — the clock still
+   * gates every one — only when it is looked at, which is what makes a
+   * paced claim (src/pacing.js) land at its wait rather than at its wait
+   * rounded up to the pump.
+   */
   _requestFrame(cb, wnd = null) {
     this._rafQueue.push({ cb, wnd });
+    if (this._pump && this._rafQueue.length === 1) {
+      const now = performance.now();
+      this._armFrameTimer(Math.max(1, this._frameWait(wnd ?? this, now)), now);
+    }
     return this._rafQueue.length;
   }
 

--- a/src/cocoa/window.js
+++ b/src/cocoa/window.js
@@ -574,13 +574,28 @@ export class CocoaWindow {
     return this.app._requestFrame(cb, this);
   }
 
-  /** Push the backing surface at the WindowServer, if anything drew. */
+  /**
+   * Push the backing surface at the WindowServer, if anything drew — and
+   * tell the window node what it cost. The flip is cheap; the catch-up
+   * copy behind it is a damage-sized memcpy, and on a window whose every
+   * frame repaints most of itself that is a millisecond of the JS thread
+   * per frame that the flush never saw. The frame pacer prices the frame
+   * by the thread's time, so the present reports in (src/pacing.js,
+   * `WindowNode._notePresentCost`).
+   */
   present() {
-    if (this._presenter) return; // layers upload as they sync
-    if (!this._dirty || !this._surface || this.destroyed) return;
+    const started = performance.now();
+    if (!this._presentNow()) return;
+    this._reactX11Node?._notePresentCost?.(performance.now() - started);
+  }
+
+  /** The present itself: true when a frame reached the layer. */
+  _presentNow() {
+    if (this._presenter) return false; // layers upload as they sync
+    if (!this._dirty || !this._surface || this.destroyed) return false;
     // …and if anyone would see it. `_dirty` stays set, so the pump asks
     // again next tick and the frame goes out the moment the window is back.
-    if (this._holdPresent || !this._visible()) return;
+    if (this._holdPresent || !this._visible()) return false;
     this._dirty = false;
     if (this._chain) {
       const shown = this._chain.back;
@@ -608,7 +623,7 @@ export class CocoaWindow {
             ]),
       );
       if (this._transparentWindow) this.app._shadowStale.add(this);
-      return;
+      return true;
     }
     this._native.surfaceToLayer(this._surface, this._layer);
     // AppKit derives a transparent window's shadow from the content's
@@ -619,6 +634,7 @@ export class CocoaWindow {
     // the frame BEFORE this one and keeps the square rim for menus that
     // paint once and are only hovered after.
     if (this._transparentWindow) this.app._shadowStale.add(this);
+    return true;
   }
 
   snapshot(path) {

--- a/src/debug.js
+++ b/src/debug.js
@@ -399,7 +399,7 @@ function createSession({ sink, path }) {
       }
     },
 
-    frame({ rects, reasons, start, end, landed }) {
+    frame({ rects, reasons, start, end, landed, waited }) {
       frames += 1;
       const full = !rects;
       const area = full
@@ -421,7 +421,12 @@ function createSession({ sink, path }) {
         // timings cannot show. Either way it is paint-vs-everything-else.
         const wait =
           typeof landed === 'number' ? ` landed=${landed.toFixed(1)}ms` : '';
-        line(`frame ${frames}: ${where}${why}${wait}`);
+        // How long the frame pacer held this frame's claim before letting
+        // the clock have it (src/pacing.js) — only under an adaptive
+        // `frameRate`, and only for a frame that was held, so the default
+        // path's lines are the lines they always were.
+        const held = waited > 0 ? ` waited=${waited.toFixed(1)}ms` : '';
+        line(`frame ${frames}: ${where}${why}${wait}${held}`);
       }
       record({
         name: 'frame',
@@ -437,6 +442,7 @@ function createSession({ sink, path }) {
           area,
           reasons: reasons ?? [],
           landedMs: typeof landed === 'number' ? +landed.toFixed(2) : undefined,
+          waitedMs: waited > 0 ? +waited.toFixed(2) : undefined,
         },
       });
     },

--- a/src/glnodes.js
+++ b/src/glnodes.js
@@ -11,6 +11,7 @@ import { cssColorStraight } from 'ntk';
 export { directGLFailure, hasDirectGL } from './glbackend.js';
 
 import { Node } from './nodes.js';
+import { FramePacer, resolveFrameRate } from './pacing.js';
 
 // One visual query per (app, spec): GetFBConfigs is a round trip and every
 // <glarea> in an app wants the same answer.
@@ -99,6 +100,9 @@ const px = (v) => Math.max(1, Math.round(v || 0));
  * - `clearColor` — CSS colour or `[r, g, b, a]` floats (default black).
  * - `frameLoop` — `'demand'` (default: redraw on prop/size/expose changes)
  *   or `'always'` (drive ntk's frame clock continuously).
+ * - `frameRate` — how the frames are paced when they are expensive
+ *   (src/pacing.js): a preset, a cap, or the three numbers, the same
+ *   vocabulary as `<window frameRate>`. Defaults to the owning window's.
  * - `glx` — a `chooseGLXConfig` spec, e.g. `{ DEPTH_SIZE: 24 }`.
  *
  * The X child window is stacked above everything drawn in the parent, so 2D
@@ -114,10 +118,34 @@ export class GlAreaNode extends Node {
     this._frameScheduled = false;
     this._created = false;
     this._pointerDirty = true;
+    // The frame pacer (src/pacing.js), the surface's own: a scene's frames
+    // are drawn on a clock of their own, and what one costs — `onDraw` and
+    // the swap, on this thread — is what decides whether the next may
+    // start at once. The policy is this element's `frameRate`, else the
+    // owning window's, read at each request so a change on either follows.
+    this._pacer = new FramePacer();
+    this._ownPolicy = null;
+    this._syncFramePolicy();
   }
 
   get isGlArea() {
     return true;
+  }
+
+  /** The policy this surface paces by: its own prop, else the window's. */
+  _framePolicy() {
+    if (this.props.frameRate !== undefined && this.props.frameRate !== null) {
+      return this._ownPolicy;
+    }
+    return this.root?._framePolicy ?? this._pacer.policy;
+  }
+
+  _syncFramePolicy() {
+    const value = this.props.frameRate;
+    this._ownPolicy =
+      value === undefined || value === null
+        ? null
+        : resolveFrameRate(value, '<glarea frameRate>');
   }
 
   _setRoot(root) {
@@ -275,8 +303,21 @@ export class GlAreaNode extends Node {
     this.requestFrame();
   }
 
-  /** Draw one frame on the child window's next frame tick. */
+  /**
+   * Draw one frame on the child window's next frame tick — after whatever
+   * wait the pacer asks for (src/pacing.js). Off by default it answers
+   * "now"; under an adaptive policy a scene whose frames cost more than
+   * their share of the thread is held between them, and a `frameLoop` of
+   * `'always'` becomes a loop at the budget rather than at the display.
+   */
   requestFrame() {
+    if (!this.window || this.destroyed || this._frameScheduled) return;
+    this._pacer.configure(this._framePolicy());
+    if (this._pacer.defer(() => this._requestFrameNow())) return;
+    this._requestFrameNow();
+  }
+
+  _requestFrameNow() {
     if (!this.window || this.destroyed || this._frameScheduled) return;
     this._frameScheduled = true;
     const schedule =
@@ -290,13 +331,28 @@ export class GlAreaNode extends Node {
   }
 
   _drawFrame() {
+    const pacer = this._pacer;
+    pacer.began();
+    let drawn = false;
+    try {
+      drawn = this._drawFrameNow();
+    } finally {
+      pacer.ended(undefined, drawn);
+    }
+    // after the frame is priced, so the loop's next frame is judged by
+    // this one rather than by the one before
+    if (drawn && this.props.frameLoop === 'always') this.requestFrame();
+  }
+
+  /** The frame itself; true when it drew. */
+  _drawFrameNow() {
     const gl = this.gl;
-    if (!gl || this.destroyed) return;
+    if (!gl || this.destroyed) return false;
     const direct = gl.backend === 'direct';
     // On the direct backend every buffer may still be held by the display,
     // and drawing into one before it comes back would paint what is on
     // screen. `onFrameAvailable` asks for this frame again when one frees.
-    if (direct && gl.canRender && !gl.canRender()) return;
+    if (direct && gl.canRender && !gl.canRender()) return false;
     // binds this surface — the GPU context is shared between every <glarea>
     // on the connection — and picks up a resize
     gl.makeCurrent?.();
@@ -325,7 +381,7 @@ export class GlAreaNode extends Node {
     }
     this.props.onDraw?.(gl, info);
     gl.SwapBuffers();
-    if (this.props.frameLoop === 'always') this.requestFrame();
+    return true;
   }
 
   /**
@@ -357,7 +413,9 @@ export class GlAreaNode extends Node {
   }
 
   applyProps(newProps, oldProps) {
+    const before = oldProps ?? this.props;
     super.applyProps(newProps, oldProps);
+    if (newProps.frameRate !== before.frameRate) this._syncFramePolicy();
     // onDraw/clearColor are read at frame time, so any update is a new frame
     this.requestFrame();
   }
@@ -375,6 +433,7 @@ export class GlAreaNode extends Node {
   destroySubtree() {
     if (this.destroyed) return;
     super.destroySubtree();
+    this._pacer.cancel();
     this.gl?.destroy?.();
     this.gl = null;
     this.window?.destroy?.();

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -9,7 +9,7 @@
 
 import type { ReactNode, RefObject } from 'react';
 import type { DrawnNode, NtkApp, NtkWindow } from './types/nodes.js';
-import type { ReactX11Elements } from './types/elements.js';
+import type { FrameRate, ReactX11Elements } from './types/elements.js';
 
 export * from './types/style.js';
 export * from './types/events.js';
@@ -232,6 +232,15 @@ export interface RootOptions {
    * run each. 6 by default; 0 paints glyphs at every size.
    */
   textStripBelow?: number;
+  /**
+   * How this root's windows pace their frames when their content changes
+   * faster than the display refreshes — the default for every `<window>`
+   * and `<glarea>` that names no `frameRate` of its own. `'display'` (every
+   * frame the clock gives) unless said otherwise; `'adaptive'` holds paints
+   * to a quarter of the time under a flood. `REACT_X11_FRAME_RATE` overrides
+   * it, and the props, from the environment. See {@link FrameRate}.
+   */
+  frameRate?: FrameRate;
   /** `':1'`, `'host:0.0'`, or a unix socket path. Defaults to `$DISPLAY`. */
   display?: string;
   /**

--- a/src/node.d.ts
+++ b/src/node.d.ts
@@ -25,8 +25,178 @@ import type {
   WheelEvent,
 } from './types/events.js';
 
-/** ntk's 2d context. Typed loosely — it is ntk's API, not ours. */
-export type Context2D = unknown;
+/** A gradient, as `createLinearGradient` answers with. */
+export interface CanvasGradientLike {
+  addColorStop(offset: number, color: string): void;
+}
+
+/** An RGBA pixel block, as `createImageData` answers with. */
+export interface ImageDataLike {
+  readonly data: Uint8ClampedArray;
+  readonly width: number;
+  readonly height: number;
+}
+
+/**
+ * The 2d context a node paints into — the canvas-shaped subset **both**
+ * backends implement: ntk's `RenderingContext2D` over XRender on X11, and
+ * `CocoaContext2D` over CoreGraphics on macOS. Declared as the contract an
+ * element may rely on rather than as either class: what is here is on
+ * both, and a member one backend has and the other does not is optional
+ * here or absent. Coordinates are device pixels in the owning window's
+ * space — `abs`, `contentBox()` — unless a transform says otherwise.
+ * Anything ntk documents beyond this is reachable at runtime and is
+ * ntk's to change.
+ */
+export interface Context2D {
+  fillStyle: string | CanvasGradientLike;
+  strokeStyle: string | CanvasGradientLike;
+  lineWidth: number;
+  lineCap: 'butt' | 'round' | 'square';
+  lineJoin: 'miter' | 'round' | 'bevel';
+  globalAlpha: number;
+  /** A CSS font shorthand, `'13px sans-serif'`. */
+  font: string;
+  shadowBlur: number;
+  shadowOffsetX: number;
+  shadowOffsetY: number;
+  shadowColor: string;
+  /**
+   * X11 only: XRender's compositing operator — `'source-over'` (the
+   * default), `'copy'`, and the rest ntk documents. Absent on the cocoa
+   * backend, whose bridge has no blend-mode verb yet; test for it with
+   * `'globalCompositeOperation' in ctx`.
+   */
+  globalCompositeOperation?: string;
+  save(): void;
+  restore(): void;
+  translate(x: number, y: number): void;
+  scale(x: number, y: number): void;
+  rotate(angle: number): void;
+  transform(
+    a: number,
+    b: number,
+    c: number,
+    d: number,
+    e: number,
+    f: number,
+  ): void;
+  setTransform(
+    a: number,
+    b: number,
+    c: number,
+    d: number,
+    e: number,
+    f: number,
+  ): void;
+  resetTransform(): void;
+  getTransform(): {
+    a: number;
+    b: number;
+    c: number;
+    d: number;
+    e: number;
+    f: number;
+  };
+  setLineDash(segments: number[]): void;
+  getLineDash(): number[];
+  beginPath(): void;
+  closePath(): void;
+  moveTo(x: number, y: number): void;
+  lineTo(x: number, y: number): void;
+  bezierCurveTo(
+    cp1x: number,
+    cp1y: number,
+    cp2x: number,
+    cp2y: number,
+    x: number,
+    y: number,
+  ): void;
+  quadraticCurveTo(cpx: number, cpy: number, x: number, y: number): void;
+  arc(
+    x: number,
+    y: number,
+    radius: number,
+    startAngle: number,
+    endAngle: number,
+    anticlockwise?: boolean,
+  ): void;
+  rect(x: number, y: number, width: number, height: number): void;
+  roundRect(
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    radii: number | number[],
+  ): void;
+  fill(fillRule?: 'nonzero' | 'evenodd'): void;
+  stroke(): void;
+  clip(fillRule?: 'nonzero' | 'evenodd'): void;
+  fillRect(x: number, y: number, width: number, height: number): void;
+  /** Many rectangles in one operation — one request on X11, one
+   * CoreGraphics call on macOS. `[x, y, w, h]` quadruples, flat or nested. */
+  fillRects(rects: number[] | number[][]): void;
+  strokeRect(x: number, y: number, width: number, height: number): void;
+  clearRect(x: number, y: number, width: number, height: number): void;
+  fillText(text: string, x: number, y: number): void;
+  measureText(text: string): { width: number; [key: string]: unknown };
+  /**
+   * Composite an offscreen `Surface` (`react-x11/ntk`) — whole at a point,
+   * whole into a rect, or a source rect of it into a destination rect: the
+   * canvas overloads. One composite either way.
+   */
+  drawImage(image: unknown, dx: number, dy: number): void;
+  drawImage(
+    image: unknown,
+    dx: number,
+    dy: number,
+    dw: number,
+    dh: number,
+  ): void;
+  drawImage(
+    image: unknown,
+    sx: number,
+    sy: number,
+    sw: number,
+    sh: number,
+    dx: number,
+    dy: number,
+    dw: number,
+    dh: number,
+  ): void;
+  createLinearGradient(
+    x0: number,
+    y0: number,
+    x1: number,
+    y1: number,
+  ): CanvasGradientLike;
+  createImageData(width: number, height: number): ImageDataLike;
+  /** Raw pixels, straight RGBA, written transform- and clip-free — the
+   * canvas contract (docs/elements.md "<canvas>"). */
+  putImageData(data: ImageDataLike, x: number, y: number): void;
+}
+
+/**
+ * What `paintCachePlan` answers with: draw this node's content once into a
+ * surface under `key`, and composite that until the key changes
+ * (docs/extending.md "Drawing once instead of every frame").
+ */
+export interface PaintCachePlan {
+  /** Identity: the same key must mean the same pixels. Name every input
+   * `paintCached` reads. */
+  key: string;
+  /** Where the surface goes, in device pixels — window coordinates. */
+  x: number;
+  y: number;
+  /** Its size, in device pixels. */
+  width: number;
+  height: number;
+  /** `'argb32'` (the default), or `'a8'` for coverage tinted at composite
+   * time — one rendered copy per key serves every ink. */
+  format?: 'argb32' | 'a8';
+  /** The colour an `'a8'` surface is painted through. */
+  tint?: string;
+}
 
 /** How an axis is bounded when layout asks an element for its size.
  * `'exactly'` — the style decided this axis; `'at-most'` — that many pixels
@@ -284,6 +454,48 @@ export declare class Node {
   /** Draw. A subclass calls `super.paint(ctx)` first, for the background,
    * border and clip, then draws inside `this.abs`. */
   paint(ctx: Context2D): void;
+  /**
+   * Draw between the background and the children — where every built-in
+   * draws, and the seam to override rather than `paint`: `paint` draws the
+   * background, then this, then the children, the border and the focus
+   * ring, and a scroller's bars, and an element that overrides `paint`
+   * has to keep all of that in the right order itself. Draws inside
+   * `contentBox()`; the clip is already set. The default draws nothing.
+   */
+  paintContent(ctx: Context2D): void;
+  /**
+   * The paint-cache protocol, with `paintCached`: implement both or
+   * neither. Answer a plan to have this frame's content drawn once into a
+   * surface under `plan.key` and composited from it until the key changes,
+   * or `null` to opt out this frame — the right answer whenever the paint
+   * depends on something the key cannot see (a caret, a hover, anything
+   * animating). The key is the whole correctness surface.
+   */
+  paintCachePlan?(ctx: Context2D): PaintCachePlan | null;
+  /**
+   * Draw the content the plan named, at the **origin of `box`** — surface
+   * coordinates, not `this.abs`. `ink` is the colour a mono drawing (one
+   * that asked for `'a8'`) must paint in: white where the surface is
+   * coverage and the tint arrives at composite time, the tint itself on a
+   * backend without coverage surfaces. A multi-colour drawing ignores it.
+   * `paintDamage()` is null in here: a cached copy is drawn whole.
+   */
+  paintCached?(ctx: Context2D, box: Rect, ink?: string): void;
+  /**
+   * The rect this element writes opaque pixels over on every paint — in
+   * window coordinates like `abs`, whole pixels — or `null`, the default,
+   * which promises nothing.
+   *
+   * A pass that lies inside it is painted without the fills that would be
+   * under it: the window's background, this node's own and every
+   * ancestor's. That is what an element with a retained surface it draws
+   * whole — a terminal, a media frame, a chart — answers with, and it then
+   * claims its damage as a **rect inside the answer** rather than as the
+   * node, which is inflated by a pixel of slop and so never covered. The
+   * promise is the element's to keep: every pixel, alpha one, on every
+   * paint, whatever the props. A translucent element answers `null`.
+   */
+  opaqueRect(): Rect | null;
   /**
    * The rect this paint pass is repainting, or null when it is repainting
    * the whole window — and null outside a paint, which means the same

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -88,6 +88,7 @@ import {
 } from './dnd.js';
 import { TYPE_GROUPS } from './transfer.js';
 import { addPendingFrame, clearPendingFrame } from './frames.js';
+import { FramePacer, resolveFramePolicy } from './pacing.js';
 import { createClientMessages } from './clientmessage.js';
 import {
   argbVisual,
@@ -411,6 +412,17 @@ function insetRect(rect, by) {
     width: rect.width - 2 * by,
     height: rect.height - 2 * by,
   };
+}
+
+/** The whole pixels inside `rect` — a fractional edge left out — or null
+ * when none are. */
+function innerPixels(rect) {
+  const x = Math.ceil(rect.x);
+  const y = Math.ceil(rect.y);
+  const right = Math.floor(rect.x + rect.width);
+  const bottom = Math.floor(rect.y + rect.height);
+  if (right <= x || bottom <= y) return null;
+  return { x, y, width: right - x, height: bottom - y };
 }
 
 /** The overlap of two rects, or null when they have none. */
@@ -3501,6 +3513,7 @@ export class Node {
     // next tick, so a spinner that unmounts leaves the clock idle even if
     // nothing else ever asks for a frame
     this.root?._animating.delete(this);
+    this.root?._opaqueNodes?.delete(this);
     // a surface that goes away takes its selection with it, and the app-wide
     // claim on being the one showing one goes with it too
     this._textSelection?.destroy();
@@ -3510,7 +3523,11 @@ export class Node {
 
   _setRoot(root) {
     if (this.root === root) return;
+    // an element answering `opaqueRect()` is one the window asks per pass
+    const opaque = this.opaqueRect !== Node.prototype.opaqueRect;
+    if (opaque) this.root?._opaqueNodes?.delete(this);
     this.root = root;
+    if (opaque) root?._opaqueNodes?.add(this);
     // A node is styled in its constructor, before it has a window — so this
     // is where a loop declared by the very first style finds a frame clock
     // to run on.
@@ -4259,6 +4276,32 @@ export class Node {
   }
 
   /**
+   * The rect this element writes opaque pixels over on every paint — in
+   * window coordinates like `abs`, in whole pixels — or null, the default,
+   * which promises nothing.
+   *
+   * What it buys: a pass that lies inside it is painted without the fills
+   * that would be under it — the window's background, this node's own and
+   * every ancestor's — because not one of those pixels survives. On the
+   * Cocoa backend those fills are full-area CoreGraphics passes, and for a
+   * streaming terminal they were a fifth of the frame; on X11 they are
+   * composites the server ran for nothing. An element with a retained
+   * surface it draws whole — a terminal, a media frame, a chart — answers
+   * with the rect it covers, and claims its damage as a **rect inside it**
+   * rather than as the node: a node claim is inflated by a pixel of slop,
+   * which is outside the rect and so never covered.
+   *
+   * The promise is the element's to keep: every pixel of the rect, alpha
+   * one, on every paint of this node, whatever the props. A translucent
+   * element, or one that draws a background only sometimes, answers null.
+   * The answer is read at paint time, so it may follow `contentBox()`, and
+   * a fractional edge is not opaque — core takes the whole pixels inside.
+   */
+  opaqueRect() {
+    return null;
+  }
+
+  /**
    * "The pixels in `rect` moved by (dx, dy); the rest of it is new" — the
    * public form of the dance `<box overflow="scroll">` has been doing since
    * issue #138, for an element with a viewport of its own (issue #303).
@@ -4915,6 +4958,9 @@ export class Node {
   }
 
   _paintBackground(ctx) {
+    // under an element that covers this pass with opaque pixels, this fill
+    // is never seen (`WindowNode._coverFor`)
+    if (this.root?._coverChain?.has(this)) return;
     const { backgroundColor, borderRadius = 0 } = this.style;
     const fill = (style) => {
       ctx.fillStyle = style;
@@ -9343,6 +9389,22 @@ export class WindowNode extends Scrollable(Node) {
     this.needsLayout = true;
     this.needsPaint = true;
     this._scheduled = false;
+    // The frame pacer (src/pacing.js): whether a claim waits before its
+    // frame is scheduled, priced by what the last frames cost. Off unless
+    // the `frameRate` prop, the root's default or the environment says
+    // otherwise — resolved again whenever the prop changes.
+    this._pacer = new FramePacer();
+    this._framePolicy = null;
+    this._syncFramePolicy();
+    // a claim raised by the frame on itself is scheduled once the frame is
+    // over and its cost is known (`flush`)
+    this._inFlush = false;
+    this._claimAfterFlush = false;
+    // the nodes answering `opaqueRect()`, and — during a paint pass one of
+    // them covers — that node with its ancestors, whose fills are skipped
+    // (`_coverFor`, `Node._paintBackground`)
+    this._opaqueNodes = new Set();
+    this._coverChain = null;
     // Nodes that want the `attention` event (ntk#37) — an
     // `unstable_onAttention` prop,
     // an `:attention` block, or both. Built before the EventManager so the
@@ -11212,6 +11274,7 @@ export class WindowNode extends Scrollable(Node) {
     if (this.destroyed) return;
     this.destroyed = true;
     clearPendingFrame(this);
+    this._pacer.cancel();
     this._unwatchCompositing?.();
     this._unwatchCompositing = null;
     // before endWindowState below, which is the session this is subscribed to
@@ -11252,6 +11315,7 @@ export class WindowNode extends Scrollable(Node) {
     if (Boolean(newProps.trapFocus) !== Boolean(before.trapFocus)) {
       this._syncFocusScope();
     }
+    if (newProps.frameRate !== before.frameRate) this._syncFramePolicy();
     // a <window onDrop> is a whole-window dropzone; same edge as Node
     if (hasDropProps(newProps) !== hasDropProps(before)) {
       if (hasDropProps(newProps)) this._registerDropTarget(this);
@@ -11871,16 +11935,40 @@ export class WindowNode extends Scrollable(Node) {
     this._scheduleFrame();
   }
 
-  /** A frame, on the window's clock. */
+  /**
+   * A frame, on the window's clock — after whatever wait the pacer asks
+   * for (src/pacing.js). Off by default, the pacer answers "now" for one
+   * property read; under an adaptive policy a claim that finds the window
+   * in debt for its last frames is held on a one-shot, and every claim
+   * until then folds into it. Nothing here changes what the frame paints:
+   * the damage accumulates on the node exactly as it does between two
+   * ticks of the clock.
+   */
   _scheduleFrame() {
-    // Recorded before the `_scheduled` gate, not inside it: the debt is
-    // "this window has damage", which a discrete event may pay off early
-    // (see frames.js). Tying it to whether a callback is outstanding would
-    // hide the second of two clicks a few milliseconds apart — the first
-    // one's frame is still scheduled, so this returns here, and the early
-    // flush would find nothing to paint.
+    // Recorded before either gate, not inside them: the debt is "this
+    // window has damage", which a discrete event may pay off early (see
+    // frames.js). Tying it to whether a callback is outstanding would hide
+    // the second of two clicks a few milliseconds apart — the first one's
+    // frame is still scheduled, so this returns here, and the early flush
+    // would find nothing to paint. A held claim is a debt too: the early
+    // flush paints it, and `flush` stands the wait down.
     addPendingFrame(this);
+    // A claim the frame raises on itself — an animation stepping, a
+    // container query settling, a promotion moving a node — is answered
+    // once the frame is over, so the pacer prices the frame that raised it
+    // and not the one before.
+    if (this._inFlush) {
+      this._claimAfterFlush = true;
+      return;
+    }
     if (this._scheduled) return;
+    if (this._pacer.defer(() => this._requestFrame())) return;
+    this._requestFrame();
+  }
+
+  /** The callback on the window's clock. */
+  _requestFrame() {
+    if (this._scheduled || this.destroyed || !this.window) return;
     this._scheduled = true;
     const schedule =
       typeof this.window.requestAnimationFrame === 'function'
@@ -11892,12 +11980,68 @@ export class WindowNode extends Scrollable(Node) {
     });
   }
 
+  /**
+   * The policy this window paces its frames by: the environment, then the
+   * `frameRate` prop, then the root's `createRoot({ frameRate })`, then
+   * `'display'` (src/pacing.js). A bad value throws here — at mount or at
+   * the prop change — naming the value and the choices.
+   */
+  _syncFramePolicy() {
+    const policy = resolveFramePolicy(
+      this.props.frameRate,
+      this.app,
+      `<${this.kind} frameRate>`,
+    );
+    this._framePolicy = policy;
+    this._pacer.configure(policy);
+  }
+
+  /**
+   * The backend's half of a frame's cost, where it has one: the Cocoa
+   * present — the swapchain flip and its catch-up copy — runs after the
+   * flush returns, on the same thread, and is part of what the frame cost
+   * (src/cocoa/window.js reports it). An ntk window's present is one
+   * request, and reports nothing.
+   */
+  _notePresentCost(ms) {
+    this._pacer.charge(ms);
+  }
+
+  /**
+   * A frame: layout if owed, then the paint passes — or the presenter's
+   * frame — then the backend's word. Runs on the window's clock through
+   * `_scheduleFrame`, and early, synchronously, for a discrete input
+   * (frames.js). Every route lands here, so this is where a frame is
+   * priced: the pacer brackets the work, and what it cost is what the
+   * next claim is judged against (src/pacing.js).
+   */
   flush() {
     // Whatever this frame turns out to owe, it is this call's to pay — and
     // a window that returns below because it is destroyed or unrealized
     // owes nothing at all.
     clearPendingFrame(this);
+    // …and a wait the pacer had armed for it has nothing left to wait for:
+    // whichever route got here first pays the same debt.
+    this._pacer.cancel();
     if (this.destroyed || !this.yoga || !this.window) return;
+    const pacer = this._pacer;
+    pacer.began();
+    this._inFlush = true;
+    let painted = false;
+    try {
+      painted = this._flushFrame();
+    } finally {
+      this._inFlush = false;
+      pacer.ended(undefined, painted);
+      if (this._claimAfterFlush) {
+        this._claimAfterFlush = false;
+        if (!this.destroyed) this._scheduleFrame();
+      }
+    }
+  }
+
+  /** The frame itself. True when it painted or presented something. */
+  _flushFrame() {
     // A frame is scheduled a tick before it is painted, and the connection
     // can go in between: an app closing its own client, a server exit, a
     // test closing the app it lent the root. Nothing unmounts the tree on
@@ -11905,7 +12049,7 @@ export class WindowNode extends Scrollable(Node) {
     // socket, and the first request it makes throws out of the frame clock
     // where there is nothing waiting to catch it. There is no screen left to
     // paint to, so this owes nothing either.
-    if (this.app?.X?._closing) return;
+    if (this.app?.X?._closing) return false;
     // a transientFor whose owner was not realized yet at commit time. The
     // frame after the mount is the first moment refs have attached, so the
     // common "two <window>s in one tree" case resolves here rather than
@@ -12016,7 +12160,7 @@ export class WindowNode extends Scrollable(Node) {
     // …and the next commit's claims name the arrangement this frame leaves
     // behind again, from before whatever scroll comes with them
     this._laidOut = false;
-    if (!this.needsPaint) return;
+    if (!this.needsPaint) return false;
     this.needsPaint = false;
     const damage = this._takeDamage(width, height);
     if (debugPaint === 'full' && !damage && width > 0 && height > 0) {
@@ -12040,9 +12184,9 @@ export class WindowNode extends Scrollable(Node) {
     if (typeof this.window.presentFrame === 'function') {
       this.window.presentFrame(this, damage);
       this.app._reactX11Startup?.painted();
-      return;
+      return true;
     }
-    if (typeof this.window.getContext !== 'function') return; // headless mock
+    if (typeof this.window.getContext !== 'function') return false; // headless mock
     // ntk getContext creates a fresh context (with window-event
     // subscriptions) on every call — cache one per window
     const ctx = (this._ctx ??= this.window.getContext('2d'));
@@ -12082,6 +12226,8 @@ export class WindowNode extends Scrollable(Node) {
         // server work separate cleanly in a trace only when both are in it —
         // a slow virtualized GPU shows up here, not in `end`.
         landed: this.window.frameLatency,
+        // how long the pacer held this frame's claim, ms; 0 when it did not
+        waited: this._pacer.pendingWait,
       });
     }
     // A frame that actually painted, which is the moment the app is up
@@ -12089,6 +12235,7 @@ export class WindowNode extends Scrollable(Node) {
     // session clears itself off the app — which is the same bargain the
     // trace hook above makes with the frame loop.
     this.app._reactX11Startup?.painted();
+    return true;
   }
 
   /**
@@ -12564,8 +12711,50 @@ export class WindowNode extends Scrollable(Node) {
     return check(this);
   }
 
+  /**
+   * The node whose `opaqueRect()` holds the whole of `rect`, or null: the
+   * pass needs no fill under that node. Whole pixels only — a fractional
+   * edge is antialiased, and an antialiased pixel is not opaque. A clipping
+   * ancestor shrinks the answer to what reaches the surface, a rounded one
+   * by its radius all round, since the corner squares are exactly the
+   * pixels a rounded clip gives up. A handful of nodes answer at all, so
+   * this is a few rect tests per pass.
+   */
+  _coverFor(rect) {
+    const nodes = this._opaqueNodes;
+    if (nodes.size === 0) return null;
+    for (const node of nodes) {
+      if (node.destroyed || node.hidden || node._promoted) continue;
+      if (node.style?.display === 'none' || !(node.abs?.width > 0)) continue;
+      let cover = node.opaqueRect();
+      if (!cover) continue;
+      cover = innerPixels(cover);
+      for (let n = node.parent; cover && n && n !== this; n = n.parent) {
+        if (n.hidden || n.style?.display === 'none') {
+          cover = null;
+          break;
+        }
+        if (n.clipsChildren()) {
+          const radius = n.style?.borderRadius ?? 0;
+          cover = intersectRects(
+            cover,
+            radius > 0 ? insetRect(n.abs, radius) : n.abs,
+          );
+        }
+      }
+      if (cover && rectContains(cover, rect)) return node;
+    }
+    return null;
+  }
+
   /** Repaint one damage rect, or the whole window when `damage` is null. */
   _paintRegion(ctx, damage, width, height) {
+    // An element that covers the pass with opaque pixels (`Node.opaqueRect`)
+    // makes every fill under it wasted work — the clear, the window's
+    // background, the node's own and its ancestors'. The first two are
+    // skipped here; `_paintBackground` skips the chain's while
+    // `_coverChain` names it.
+    const cover = this._coverFor(damage ?? { x: 0, y: 0, width, height });
     // A transparent window erases where an opaque one paints over. Its
     // backing store holds premultiplied ARGB, and compositing a translucent
     // background onto the previous frame would compound towards opaque
@@ -12578,7 +12767,7 @@ export class WindowNode extends Scrollable(Node) {
     // `transparencyEffective`, not `_transparent`: an ARGB window with
     // nothing compositing it must not clear, because the server would show
     // those zeroed pixels as black rather than as the desktop.
-    if (this.transparencyEffective) {
+    if (this.transparencyEffective && !cover) {
       if (damage) {
         ctx.clearRect(damage.x, damage.y, damage.width, damage.height);
       } else {
@@ -12600,7 +12789,12 @@ export class WindowNode extends Scrollable(Node) {
       ctx.rect(damage.x, damage.y, damage.width, damage.height);
       ctx.clip();
     }
-    this._paintWindowBackground(ctx, damage, width, height);
+    if (!cover) this._paintWindowBackground(ctx, damage, width, height);
+    if (cover) {
+      const chain = new Set();
+      for (let n = cover; n; n = n.parent) chain.add(n);
+      this._coverChain = chain;
+    }
     this._paintDamage = damage;
     try {
       this._paintChildren(ctx);
@@ -12644,6 +12838,7 @@ export class WindowNode extends Scrollable(Node) {
       }
     } finally {
       this._paintDamage = null;
+      this._coverChain = null;
       if (damage) ctx.restore();
     }
   }

--- a/src/pacing.js
+++ b/src/pacing.js
@@ -1,0 +1,454 @@
+// Frame pacing — how often a window (or a `<glarea>`) paints while its
+// content changes faster than anyone can read it, priced in CPU time rather
+// than counted in updates.
+//
+// The frame clock decides *when* a frame may go out: the display's period
+// on the Cocoa backend, the server fence or the vertical blank on X11. It
+// says nothing about whether the frame is worth painting. A window fed off
+// an input path — a terminal under `cat`, a chart on a socket, a simulation
+// — claims a repaint every time its data moves, and with nothing between the
+// claim and the clock it paints every refresh: on a 120Hz panel whose frames
+// cost 6ms of CoreGraphics each, that is 70% of the JS thread spent painting
+// screens nobody sees, and the producer — the pty reader, the parser — gets
+// what is left. The X11 fence hides the same problem behind backpressure;
+// the Cocoa clock has none.
+//
+// The rule here is a token bucket over paint time. Credit accrues at
+// `budget` milliseconds per millisecond of wall time — a budget of 0.25 is
+// "painting may take a quarter of the time" — up to a burst allowance; a
+// frame spends its measured cost; a claim that finds the bucket in debt
+// waits for it to refill to zero, and no longer. Four properties follow,
+// and they are what the tests pin:
+//
+//   - **Idle is immediate.** A quiet window has a full bucket, so the first
+//     claim after a pause — a keystroke, a click — paints on the next tick,
+//     whatever the last frame cost.
+//   - **Cheap is unthrottled.** A frame that costs less than the credit it
+//     accrued leaves the bucket where it was. A blit-scrolled list on a 120Hz
+//     panel keeps 120Hz: the frames are memmoves and a strip.
+//   - **A rare expensive frame is free.** The burst is what absorbs the one
+//     relayout in a scroll: it costs the credit, the credit refills, and no
+//     frame waited. Only a *stream* of expensive frames drains the bucket —
+//     and then the wait after each is `cost × (1/budget − 1)`, which holds
+//     paint at exactly the budget's share of wall time.
+//   - **A flood that ends is un-throttled at once.** The debt is at most one
+//     frame's cost, so the prompt that appears when the flood stops waits
+//     for that and nothing more — where an averaged rate would keep
+//     throttling it.
+//
+// A floor (`minFps`) bounds the wait whatever the debt — the screen is never
+// more than `1000 / minFps` behind the last paint — and a ceiling (`maxFps`)
+// holds even cheap frames to a rate, the knob every terminal has.
+//
+// **Cost is the JS thread's time**: the flush (layout, paint, the requests
+// or the CoreGraphics work) plus, on Cocoa, the present that follows it.
+// Not the server's — on X11 the fence already paces to that, and the pacer
+// is deliberately inert where a backend has backpressure of its own. The
+// clock is injected so that the whole rule runs under a fake one in tests.
+//
+// Off by default: `'display'` is the built-in, and paints every frame the
+// clock gives, after React's own batching — a UI answers its input as
+// quickly as it can unless it says otherwise. `'adaptive'` is what a window
+// that streams asks for. docs/architecture/frame-pacing.md is the account.
+
+export const DEFAULT_FRAME_RATE = 'display';
+
+/**
+ * The presets, as the three numbers they stand for. `budget` is the share
+ * of wall time paints may take while the window is busy; `minFps` is the
+ * floor (0: none); `maxFps` the ceiling (0: none).
+ */
+export const FRAME_RATE_PRESETS = Object.freeze({
+  display: Object.freeze({ mode: 'display', budget: 1, minFps: 0, maxFps: 0 }),
+  adaptive: Object.freeze({
+    mode: 'adaptive',
+    budget: 0.25,
+    minFps: 20,
+    maxFps: 0,
+  }),
+  throughput: Object.freeze({
+    mode: 'throughput',
+    budget: 0.1,
+    minFps: 10,
+    maxFps: 30,
+  }),
+});
+
+const FIELDS = ['budget', 'minFps', 'maxFps'];
+
+// How much paint time a window with no floor may spend before the pacer
+// starts charging for it (with a floor, the floor's interval is the burst:
+// one frame up to the longest wait the pacer may impose is always free).
+const DEFAULT_BURST_MS = 50;
+
+// A wait shorter than this is not armed: a timer cannot keep it, and the
+// frame clock's own period would swallow it. The debt carries to the next
+// claim instead, so a run of sub-millisecond frames claimed back to back
+// still pays for itself once the debt is worth a timer — the budget holds
+// on average — while a cheap frame after a flood lands on the tick it would
+// have landed on anyway.
+const MIN_WAIT_MS = 1;
+
+const warned = new Set();
+function warnOnce(message) {
+  if (process.env.NODE_ENV === 'production' || warned.has(message)) return;
+  warned.add(message);
+  console.warn(message);
+}
+
+const describe = (value) =>
+  typeof value === 'string' ? JSON.stringify(value) : String(value);
+
+const HOW =
+  "'display' (every frame the clock gives — the default), 'adaptive' " +
+  "(paints stay under a quarter of the time, 20fps floor), 'throughput' " +
+  '(a tenth, 10fps floor, 30fps ceiling), a number (a ceiling in frames ' +
+  'per second), or { budget, minFps, maxFps } — see docs/elements.md ' +
+  '"frameRate".';
+
+/**
+ * A `frameRate` value — a preset name, a number, or the three numbers — as
+ * the policy it stands for: `{ mode, budget, minFps, maxFps }`, frozen.
+ * `mode` is the preset's name, or `'custom'` for a number or an object.
+ *
+ * A number is a ceiling over the default: `60` is "never more than 60fps",
+ * and nothing else changes. An object names any of the three; the ones it
+ * leaves out are the default's, so `{ budget: 0.25 }` has no floor — which
+ * is worth a warning, because a budget with no floor can hold a frame for
+ * as long as the last one cost, three times over.
+ *
+ * `where` names the call site in the error, since the same value arrives
+ * as a prop, a root option and an environment variable.
+ */
+export function resolveFrameRate(value, where = 'frameRate') {
+  if (value === undefined || value === null) value = DEFAULT_FRAME_RATE;
+  if (typeof value === 'string') {
+    const preset = FRAME_RATE_PRESETS[value];
+    if (!preset) {
+      throw new Error(
+        `react-x11: ${where} ${describe(value)} is not a frame rate — ${HOW}`,
+      );
+    }
+    return preset;
+  }
+  const base = FRAME_RATE_PRESETS[DEFAULT_FRAME_RATE];
+  if (typeof value === 'number') {
+    if (!(value > 0)) {
+      throw new Error(
+        `react-x11: ${where} ${describe(value)} — a number is a ceiling in ` +
+          `frames per second, so it has to be above zero; ${HOW}`,
+      );
+    }
+    if (!Number.isFinite(value)) return base;
+    return Object.freeze({ ...base, mode: 'custom', maxFps: value });
+  }
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(
+      `react-x11: ${where} ${describe(value)} is not a frame rate — ${HOW}`,
+    );
+  }
+  const unknown = Object.keys(value).filter((k) => !FIELDS.includes(k));
+  if (unknown.length) {
+    throw new Error(
+      `react-x11: ${where} has no ${unknown.map((k) => JSON.stringify(k)).join(', ')} ` +
+        `— the three numbers are budget, minFps and maxFps; ${HOW}`,
+    );
+  }
+  const num = (name, check, what) => {
+    const v = value[name];
+    if (v === undefined) return base[name];
+    if (typeof v !== 'number' || !Number.isFinite(v) || !check(v)) {
+      throw new Error(
+        `react-x11: ${where}.${name} ${describe(v)} — ${what}; ${HOW}`,
+      );
+    }
+    return v;
+  };
+  const policy = Object.freeze({
+    mode: 'custom',
+    budget: num(
+      'budget',
+      (v) => v > 0 && v <= 1,
+      'the share of wall time paints may take, above 0 and at most 1',
+    ),
+    minFps: num('minFps', (v) => v >= 0, 'a floor in frames per second, or 0'),
+    maxFps: num(
+      'maxFps',
+      (v) => v >= 0,
+      'a ceiling in frames per second, or 0',
+    ),
+  });
+  if (policy.minFps > 0 && policy.maxFps > 0 && policy.minFps > policy.maxFps) {
+    throw new Error(
+      `react-x11: ${where} puts the floor (minFps ${policy.minFps}) above the ` +
+        `ceiling (maxFps ${policy.maxFps}) — the floor is how stale the screen ` +
+        'may get, the ceiling how often it may paint, so minFps <= maxFps.',
+    );
+  }
+  if (policy.budget < 1 && policy.minFps === 0) {
+    warnOnce(
+      `react-x11: ${where} sets budget ${policy.budget} with no minFps — ` +
+        'after an expensive frame the next may wait ' +
+        `${(1 / policy.budget - 1).toFixed(1)}× its cost with nothing to bound ` +
+        "it. Name a floor: { budget, minFps: 20 } is what 'adaptive' does.",
+    );
+  }
+  return policy;
+}
+
+/** Whether two resolved policies pace the same way. */
+export function sameFramePolicy(a, b) {
+  return (
+    a === b ||
+    (Boolean(a && b) &&
+      a.budget === b.budget &&
+      a.minFps === b.minFps &&
+      a.maxFps === b.maxFps)
+  );
+}
+
+const ENV = 'REACT_X11_FRAME_RATE';
+
+/**
+ * The environment's say: `REACT_X11_FRAME_RATE=adaptive` (or `display`,
+ * `throughput`, or a number). It overrides every window's prop and the root
+ * option, the way `REACT_X11_BACKEND` overrides `createRoot({ backend })`:
+ * an A/B run and a field diagnosis must not need a code change. Undefined
+ * when unset or empty; garbage throws with the fix, at the first window.
+ */
+export function frameRateFromEnv(env = process.env) {
+  const raw = env[ENV];
+  if (raw === undefined || raw === '') return undefined;
+  const text = raw.trim();
+  const n = Number(text);
+  return text !== '' && Number.isFinite(n) ? n : text;
+}
+
+const defaults = new WeakMap();
+
+/**
+ * `createRoot({ frameRate })`: the default for every window this root opens
+ * that names none of its own. Validated here, so a bad value fails at the
+ * call that passed it rather than at the first window it reaches.
+ */
+export function setFrameRateDefault(app, value) {
+  if (value === undefined) {
+    defaults.delete(app);
+    return;
+  }
+  resolveFrameRate(value, 'createRoot({ frameRate })');
+  defaults.set(app, value);
+}
+
+export const frameRateDefaultFor = (app) => defaults.get(app);
+
+/**
+ * The policy a window resolves to: the environment first, then its own
+ * prop, then the root's default, then the built-in. `where` labels a bad
+ * prop in the error; the other two sources are labelled by their names.
+ */
+export function resolveFramePolicy(prop, app, where = '<window frameRate>') {
+  const env = frameRateFromEnv();
+  if (env !== undefined) return resolveFrameRate(env, ENV);
+  if (prop !== undefined && prop !== null) return resolveFrameRate(prop, where);
+  const fallback = frameRateDefaultFor(app);
+  if (fallback !== undefined) {
+    return resolveFrameRate(fallback, 'createRoot({ frameRate })');
+  }
+  return FRAME_RATE_PRESETS[DEFAULT_FRAME_RATE];
+}
+
+/** The real clock: `performance.now()`, and a one-shot that never holds the
+ * process open — a deferral pending when the last window closes must not
+ * keep an otherwise finished process alive. */
+export const realClock = Object.freeze({
+  now: () => performance.now(),
+  after(ms, fn) {
+    const timer = setTimeout(fn, Math.max(1, ms));
+    timer.unref?.();
+    return () => clearTimeout(timer);
+  },
+});
+
+/**
+ * The pacer one frame source owns — a `WindowNode`, a `GlAreaNode`. The
+ * source asks `defer(fn)` before scheduling a frame: `false` means "now",
+ * and the source schedules as it always did; `true` means the pacer has
+ * armed a one-shot that will call `fn` when the frame may start, and a
+ * second `defer` before then is coalesced into it. The source brackets each
+ * frame with `began()`/`ended()`, and reports work outside that bracket —
+ * the Cocoa present — with `charge()`. Any frame that runs by another route
+ * (a discrete input's early flush) calls `cancel()`, so a deferral never
+ * fires for a frame that has already been painted.
+ *
+ * `clock` is `{ now(), after(ms, fn) → cancel }`, replaceable for a test;
+ * every method reads it at call time.
+ */
+export class FramePacer {
+  constructor(
+    policy = FRAME_RATE_PRESETS[DEFAULT_FRAME_RATE],
+    clock = realClock,
+  ) {
+    this.clock = clock;
+    this.policy = null;
+    this._timer = null;
+    this._startedAt = null;
+    this._armedWait = 0;
+    this.stats = {
+      mode: DEFAULT_FRAME_RATE,
+      budget: 1,
+      minFps: 0,
+      maxFps: 0,
+      /** frames that painted */
+      frames: 0,
+      /** claims that armed a wait */
+      deferred: 0,
+      /** claims folded into a wait already armed */
+      coalesced: 0,
+      /** what the last painted frame cost, ms (flush plus present) */
+      lastCostMs: 0,
+      /** the wait the last painted frame followed, ms; 0 when none */
+      lastWaitMs: 0,
+    };
+    this.configure(policy);
+  }
+
+  /**
+   * Take a (new) policy. A change starts from a full bucket: `'display'`
+   * takes effect on the next claim rather than after the next paint, and a
+   * tighter budget charges from now rather than for a debt run up under the
+   * old rule. The same policy again is a no-op, so a caller may sync every
+   * frame.
+   */
+  configure(policy) {
+    if (sameFramePolicy(this.policy, policy)) return;
+    this.policy = policy;
+    this._minGap = policy.maxFps > 0 ? 1000 / policy.maxFps : 0;
+    this._maxWait = policy.minFps > 0 ? 1000 / policy.minFps : Infinity;
+    this._burst = Number.isFinite(this._maxWait)
+      ? this._maxWait
+      : DEFAULT_BURST_MS;
+    this._credit = this._burst;
+    this._creditAt = this.clock.now();
+    this._lastStart = -Infinity;
+    this._lastEnd = -Infinity;
+    const s = this.stats;
+    s.mode = policy.mode;
+    s.budget = policy.budget;
+    s.minFps = policy.minFps;
+    s.maxFps = policy.maxFps;
+  }
+
+  /** Whether this policy can ever hold a frame. `'display'` cannot, and
+   * costs the frame source one property read per claim. */
+  get active() {
+    return this.policy.budget < 1 || this._minGap > 0;
+  }
+
+  _accrue(now) {
+    if (now > this._creditAt) {
+      this._credit = Math.min(
+        this._burst,
+        this._credit + this.policy.budget * (now - this._creditAt),
+      );
+      this._creditAt = now;
+    }
+  }
+
+  /** How long a frame claimed at `now` has to wait, in ms; 0 for now. */
+  wait(now = this.clock.now()) {
+    if (!this.active) return 0;
+    this._accrue(now);
+    const { budget } = this.policy;
+    // the debt, paid back at the budget's rate
+    let wait = this._credit >= 0 ? 0 : -this._credit / budget;
+    // the floor: whatever the debt, a frame is due within `maxWait` of the
+    // last frame's end — a promise about staleness, not a rate
+    if (Number.isFinite(this._maxWait)) {
+      wait = Math.min(wait, Math.max(0, this._lastEnd + this._maxWait - now));
+    }
+    // the ceiling: not sooner than a period after the last frame *started*,
+    // cheap frames included — a rate, measured start to start
+    if (this._minGap > 0) {
+      wait = Math.max(wait, this._lastStart + this._minGap - now);
+    }
+    return wait >= MIN_WAIT_MS ? wait : 0;
+  }
+
+  /**
+   * Hold `fn` until the frame may start, or answer `false` for "schedule it
+   * now". At most one wait is armed; a claim while one is armed is folded
+   * into it and answers `true` too.
+   */
+  defer(fn, now = this.clock.now()) {
+    if (this._timer) {
+      this.stats.coalesced += 1;
+      return true;
+    }
+    const wait = this.wait(now);
+    if (!(wait > 0)) return false;
+    this.stats.deferred += 1;
+    this._armedWait = wait;
+    this._timer = this.clock.after(wait, () => {
+      this._timer = null;
+      fn();
+    });
+    return true;
+  }
+
+  /** Whether a wait is armed. */
+  get deferring() {
+    return this._timer !== null;
+  }
+
+  /** The wait the frame now running followed, ms — read inside the frame,
+   * before `ended` files it under the frame's stats. 0 when none. */
+  get pendingWait() {
+    return this._armedWait;
+  }
+
+  /** A frame ran by another route: the wait, if any, has nothing to do. */
+  cancel() {
+    if (!this._timer) return;
+    this._timer();
+    this._timer = null;
+    // the frame that runs instead was not held by the pacer
+    this._armedWait = 0;
+  }
+
+  /** A frame is starting. */
+  began(now = this.clock.now()) {
+    this._startedAt = now;
+  }
+
+  /**
+   * The frame is over. `painted` false is a flush that found nothing to
+   * paint: its cost is charged like any work on the thread, but it is not
+   * a frame — the ceiling measures from the last frame that *was* one.
+   */
+  ended(now = this.clock.now(), painted = true) {
+    const startedAt = this._startedAt ?? now;
+    this._startedAt = null;
+    const cost = Math.max(0, now - startedAt);
+    this._accrue(now);
+    this._credit -= cost;
+    this._lastEnd = now;
+    if (!painted) return;
+    this._lastStart = startedAt;
+    const s = this.stats;
+    s.frames += 1;
+    s.lastCostMs = cost;
+    s.lastWaitMs = this._armedWait;
+    this._armedWait = 0;
+  }
+
+  /** Work the frame cost outside `began`/`ended` — the present on Cocoa,
+   * which runs after the flush returns. Extends the last frame. */
+  charge(ms, now = this.clock.now()) {
+    if (!(ms > 0)) return;
+    this._accrue(now);
+    this._credit -= ms;
+    this._lastEnd = now;
+    this.stats.lastCostMs += ms;
+  }
+}

--- a/src/pacing.js
+++ b/src/pacing.js
@@ -289,7 +289,7 @@ export class FramePacer {
     policy = FRAME_RATE_PRESETS[DEFAULT_FRAME_RATE],
     clock = realClock,
   ) {
-    this.clock = clock;
+    this._clock = clock;
     this.policy = null;
     this._timer = null;
     this._startedAt = null;
@@ -328,15 +328,37 @@ export class FramePacer {
     this._burst = Number.isFinite(this._maxWait)
       ? this._maxWait
       : DEFAULT_BURST_MS;
-    this._credit = this._burst;
-    this._creditAt = this.clock.now();
-    this._lastStart = -Infinity;
-    this._lastEnd = -Infinity;
+    this._reset();
     const s = this.stats;
     s.mode = policy.mode;
     s.budget = policy.budget;
     s.minFps = policy.minFps;
     s.maxFps = policy.maxFps;
+  }
+
+  /** A full bucket, and no frame yet, as of the clock's now. */
+  _reset() {
+    this._credit = this._burst;
+    this._creditAt = this._clock.now();
+    this._lastStart = -Infinity;
+    this._lastEnd = -Infinity;
+  }
+
+  get clock() {
+    return this._clock;
+  }
+
+  /**
+   * A new clock starts the pacer afresh in that clock's time. Every
+   * timestamp the rule keeps — when credit last accrued, when the last
+   * frame started and ended — is in the old clock's terms, and a test that
+   * hands over a fake clock mid-life would otherwise wait for it to catch
+   * up with `performance.now()` before any credit accrued: minutes into a
+   * suite on a slow runner, which is exactly where it was found.
+   */
+  set clock(value) {
+    this._clock = value;
+    this._reset();
   }
 
   /** Whether this policy can ever hold a frame. `'display'` cannot, and

--- a/src/trace-registry.js
+++ b/src/trace-registry.js
@@ -51,9 +51,10 @@ export function onApp(fn) {
  * of an unset hook is one property read — which is the whole design: the
  * frame loop must not pay for a tracer nobody started.
  *
- *  - `frame({ root, rects, reasons, start, end })` — after a window painted.
- *    `rects` is the damage list, null for a full repaint; times come from
- *    `performance.now()`.
+ *  - `frame({ root, rects, reasons, start, end, landed, waited })` — after
+ *    a window painted. `rects` is the damage list, null for a full repaint;
+ *    times come from `performance.now()`; `waited` is how long the frame
+ *    pacer held the claim, 0 when it did not (src/pacing.js).
  *  - `commitStart()` / `commitEnd()` — around a React commit.
  */
 export const hooks = {

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -278,6 +278,47 @@ export type WindowType =
   | 'desktop'
   | (string & {});
 
+/**
+ * How a window paces its frames when its content changes faster than the
+ * display refreshes — a terminal under a flood, a chart on a socket, a
+ * simulation. Priced in CPU time, not counted in updates: a frame costs
+ * what the flush (and on macOS the present) took of this thread, and a
+ * claim waits only while recent frames have spent more than their share.
+ * A scroll that is mostly blits keeps the display's rate; only a stream of
+ * expensive frames earns a wait (docs/elements.md "frameRate").
+ *
+ * - `'display'` — every frame the clock gives, after React's own
+ *   batching. **The default.**
+ * - `'adaptive'` — paints stay under a quarter of the time while busy, and
+ *   the screen is never more than 50ms behind (a 20fps floor). Idle claims
+ *   and cheap frames never wait.
+ * - `'throughput'` — a tenth, a 10fps floor and a 30fps ceiling: fewer,
+ *   later frames for a window whose output matters more than its display.
+ * - a number — a ceiling in frames per second, nothing else.
+ * - `{ budget, minFps, maxFps }` — the three numbers the presets are made
+ *   of, any subset; the rest are `'display'`'s (so name a `minFps` with a
+ *   `budget` below 1).
+ *
+ * `createRoot({ frameRate })` sets the default for every window of a root,
+ * and `REACT_X11_FRAME_RATE` overrides both from the environment.
+ */
+export type FrameRate =
+  | 'display'
+  | 'adaptive'
+  | 'throughput'
+  | number
+  | {
+      /** Share of wall time paints may take while busy, above 0 and at
+       * most 1. */
+      budget?: number;
+      /** The floor: the screen is never more than `1000 / minFps` ms behind
+       * the last paint. 0 for none. */
+      minFps?: number;
+      /** A ceiling in frames per second, cheap frames included. 0 for
+       * none. */
+      maxFps?: number;
+    };
+
 export interface WindowProps
   extends
     CommonProps,
@@ -289,6 +330,10 @@ export interface WindowProps
   ref?: Ref<NtkWindow>;
   /** Window title (UTF-8, via `WM_NAME` + `_NET_WM_NAME`). */
   title?: string;
+  /** How this window paces its frames under a stream of changes — see
+   * {@link FrameRate}. `'display'` unless the root or the environment says
+   * otherwise. A `<popup>` paces itself the same way. */
+  frameRate?: FrameRate;
   /**
    * Created but never self-mapped: this window is waiting to be embedded
    * (XEmbed / `<foreign>` on the other side), and from the reparent on,
@@ -865,6 +910,15 @@ export interface GlAreaProps extends DrawnProps<DrawnNode> {
   clearColor?: Color | [number, number, number, number];
   /** `'demand'` (default) redraws on change; `'always'` runs continuously. */
   frameLoop?: FrameLoop;
+  /**
+   * How the surface's frames are paced when they are expensive — the same
+   * vocabulary as {@link WindowProps.frameRate}, priced by what `onDraw`
+   * and the swap cost this thread. Defaults to the owning window's, so a
+   * `<window frameRate="adaptive">` paces the scene inside it too; set it
+   * here for a scene that wants every frame (`'display'`) while the window
+   * around it streams, or the other way round.
+   */
+  frameRate?: FrameRate;
   /** Visual spec for ntk's `chooseGLXConfig`, e.g. `{ DEPTH_SIZE: 24 }`. */
   glx?: Record<string, unknown>;
   /** Runs once, with the context current: one-time state, uploads, lists. */

--- a/test/cocoa-frames.test.js
+++ b/test/cocoa-frames.test.js
@@ -783,6 +783,91 @@ test('a frame that arrives more than an interval late re-anchors the clock', asy
   assert.equal(app._frameTimer, null);
 });
 
+test('a frame requested between ticks gets its timer while the pump runs', async () => {
+  const { app } = await mount(box({ flexGrow: 1 }));
+  app._frameInterval = 16;
+  app._pumpInterval = 8;
+  // no pump: a request waits for a tick, as every hand-driven test relies on
+  let ran = 0;
+  const now = performance.now();
+  app._rafLast = now - 13;
+  app._requestFrame(() => (ran += 1));
+  assert.equal(app._frameTimer, null, 'nothing armed without a pump');
+  app._tickFrames(now);
+  assert.equal(ran, 0);
+  clearTimeout(app._frameTimer);
+  app._frameTimer = null;
+  app._rafQueue.length = 0;
+  // the pump running: the same request arms the one-shot at the moment
+  // the clock is due — two milliseconds out — rather than waiting up to a
+  // pump interval for a tick to look at it
+  app._pump = setInterval(() => {}, 1e6);
+  try {
+    app._rafLast = performance.now() - 13;
+    app._requestFrame(() => (ran += 1));
+    assert.ok(app._frameTimer, 'a timer');
+    assert.ok(
+      app._frameTimerAt - performance.now() < 3.5,
+      `due in ${app._frameTimerAt - performance.now()}ms`,
+    );
+    await new Promise((resolve) => setTimeout(resolve, 8));
+    assert.equal(ran, 1, 'which ran it');
+    // a clock already due gets a millisecond, not a tick
+    app._rafLast = performance.now() - 100;
+    app._requestFrame(() => (ran += 1));
+    assert.ok(app._frameTimer);
+    assert.ok(app._frameTimerAt - performance.now() <= 1.5);
+    await new Promise((resolve) => setTimeout(resolve, 6));
+    assert.equal(ran, 2);
+    // a second request into a queue that already has one arms nothing more
+    app._rafLast = performance.now() - 13;
+    app._requestFrame(() => (ran += 1));
+    const at = app._frameTimerAt;
+    app._requestFrame(() => (ran += 1));
+    assert.equal(app._frameTimerAt, at, 'the one timer stands');
+    await new Promise((resolve) => setTimeout(resolve, 8));
+    assert.equal(ran, 4);
+    // and a clock due after the next tick is left to the tick
+    app._rafLast = performance.now();
+    app._requestFrame(() => (ran += 1));
+    assert.equal(app._frameTimer, null, 'the tick decides');
+  } finally {
+    clearInterval(app._pump);
+    app._pump = null;
+    if (app._frameTimer) clearTimeout(app._frameTimer);
+    app._frameTimer = null;
+  }
+});
+
+test('the present reports its cost to the window node', async () => {
+  const { app, wnd, node } = await mount(
+    box({ flexGrow: 1, backgroundColor: '#3498db' }),
+  );
+  const charged = [];
+  node._notePresentCost = (ms) => charged.push(ms);
+  // the mount frame's present
+  app._presentAll();
+  assert.equal(charged.length, 1, 'one present, one report');
+  assert.ok(charged[0] >= 0);
+  // nothing drew: nothing presented, nothing reported
+  app._presentAll();
+  assert.equal(charged.length, 1);
+  // a frame that drew, presented
+  node.invalidate(false, node.children[0], 'content');
+  node.flush();
+  app._presentAll();
+  assert.equal(charged.length, 2);
+  // …and one nobody can see is held, so it costs nothing yet
+  wnd._occluded = true;
+  node.invalidate(false, node.children[0], 'content');
+  node.flush();
+  app._presentAll();
+  assert.equal(charged.length, 2, 'held, not presented');
+  wnd._occluded = false;
+  app._presentAll();
+  assert.equal(charged.length, 3, 'presented once the window is back');
+});
+
 test('closing the app drops the timer a frame was owed', async () => {
   const { app } = await mount(box({ flexGrow: 1 }));
   app._frameInterval = 16;

--- a/test/frame-pacing.test.js
+++ b/test/frame-pacing.test.js
@@ -1,0 +1,330 @@
+// Frame pacing on a window (src/pacing.js under nodes.js): where a
+// window's frame is scheduled, what it costs, and what that decides. The
+// mock app, a fake clock on the pacer, and a paint whose cost the test
+// sets — so a "flood" is a loop and a "wait" is a timer the test can see,
+// with no display and no sleeping. The default is pinned first, because
+// it is the promise every existing app rests on: nothing waits.
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+import React from 'react';
+
+import { createRoot } from '../src/index.js';
+import { flushPendingFrames } from '../src/frames.js';
+import { hooks } from '../src/trace-registry.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+/** The pacer's clock, moved by hand; `after` fires when `advance` reaches it. */
+function fakeClock() {
+  let t = 1000;
+  const timers = [];
+  return {
+    now: () => t,
+    after(ms, fn) {
+      const entry = { at: t + ms, ms, fn, live: true };
+      timers.push(entry);
+      return () => {
+        entry.live = false;
+      };
+    },
+    armed: () => timers.filter((e) => e.live),
+    advance(ms) {
+      t += ms;
+      for (const e of timers.filter((e) => e.live && e.at <= t)) {
+        e.live = false;
+        e.fn();
+      }
+    },
+  };
+}
+
+const roots = [];
+afterEach(async () => {
+  delete process.env.REACT_X11_FRAME_RATE;
+  hooks.frame = null;
+  for (const root of roots.splice(0)) await root.unmount();
+});
+
+/**
+ * A window with one box, the pacer on a fake clock, and a frame that
+ * costs `cost` ms of that clock. `claim()` is what a streaming element
+ * does: a bounded invalidate of the box. `frame()` claims once and lets
+ * the frame run through the real scheduling — the wait if the pacer asks
+ * for one, then the window's callback — and answers what it waited.
+ */
+async function mount({ cost = 6, rootOptions = {}, ...props } = {}) {
+  const app = createMockApp();
+  const root = await createRoot({ app, ...rootOptions });
+  roots.push(root);
+  const tree = (extra = {}) =>
+    h(
+      'window',
+      { width: 200, height: 120, ...props, ...extra },
+      h('box', { style: { width: 100, height: 50, backgroundColor: '#eee' } }),
+    );
+  root.render(tree());
+  await tick();
+  const node = app.windows[0]._reactX11Node;
+  const clock = fakeClock();
+  node._pacer.clock = clock;
+  const box = node.children[0];
+  let painted = 0;
+  const flushFrame = node._flushFrame.bind(node);
+  node._flushFrame = (...args) => {
+    const out = flushFrame(...args);
+    if (out) {
+      painted += 1;
+      clock.advance(cost);
+    }
+    return out;
+  };
+  const ctx = {
+    app,
+    root,
+    node,
+    box,
+    clock,
+    claim: () => box.invalidate(false, box.contentBox(), 'content'),
+    frames: () => painted,
+    setCost: (ms) => {
+      cost = ms;
+    },
+    async frame() {
+      ctx.claim();
+      let waited = 0;
+      if (!node._scheduled) {
+        const [w] = clock.armed();
+        assert.ok(w, 'held on a wait');
+        waited = w.ms;
+        clock.advance(w.ms);
+        assert.equal(node._scheduled, true, 'the wait put it on the clock');
+      }
+      await tick();
+      return waited;
+    },
+    rerender: async (extra) => {
+      root.render(tree(extra));
+      await tick();
+    },
+  };
+  return ctx;
+}
+
+// --- the default -----------------------------------------------------------------
+
+test("the default is 'display': every claim schedules its frame at once, whatever the last one cost", async () => {
+  const { node, clock, claim, frames } = await mount({ cost: 60 });
+  assert.equal(node._framePolicy.mode, 'display');
+  assert.equal(node._pacer.active, false);
+  for (let i = 0; i < 10; i += 1) {
+    claim();
+    assert.equal(node._scheduled, true, 'the frame is on the clock');
+    assert.equal(clock.armed().length, 0, 'and nothing waits');
+    await tick();
+    assert.equal(frames(), i + 1);
+  }
+  assert.equal(node._pacer.stats.deferred, 0);
+  assert.equal(node._pacer.stats.frames, 11, 'the mount frame, then ten');
+  assert.equal(node._pacer.stats.lastCostMs, 60);
+});
+
+// --- the sources -------------------------------------------------------------------
+
+test('the prop, the root option and the environment each set the policy, in that order of precedence', async () => {
+  const a = await mount({ frameRate: 'adaptive' });
+  assert.equal(a.node._framePolicy.mode, 'adaptive');
+  assert.equal(a.node._pacer.stats.budget, 0.25);
+
+  const b = await mount({ rootOptions: { frameRate: 'throughput' } });
+  assert.equal(b.node._framePolicy.mode, 'throughput', 'the root default');
+  const c = await mount({
+    frameRate: 30,
+    rootOptions: { frameRate: 'throughput' },
+  });
+  assert.equal(c.node._framePolicy.mode, 'custom', 'the prop wins');
+  assert.equal(c.node._framePolicy.maxFps, 30);
+
+  process.env.REACT_X11_FRAME_RATE = 'display';
+  const d = await mount({
+    frameRate: 'adaptive',
+    rootOptions: { frameRate: 'throughput' },
+  });
+  assert.equal(d.node._framePolicy.mode, 'display', 'the environment wins');
+});
+
+test('a prop change re-resolves the policy; the same value again does not reset it', async () => {
+  const ctx = await mount({ frameRate: 'adaptive', cost: 6 });
+  const { node, rerender } = ctx;
+  for (let i = 0; i < 30; i += 1) await ctx.frame();
+  assert.ok(node._pacer.wait() > 0, 'in debt');
+  await rerender({ frameRate: 'adaptive' });
+  assert.ok(node._pacer.wait() > 0, 'the same policy keeps the debt');
+  await rerender({ frameRate: 'display' });
+  assert.equal(node._framePolicy.mode, 'display');
+  assert.equal(node._pacer.wait(), 0, 'and the new one starts afresh');
+});
+
+test('a bad value throws at the window, naming the value and the choices', async () => {
+  const app = createMockApp();
+  const errors = [];
+  const root = await createRoot({
+    app,
+    onUncaughtError: (err) => errors.push(err),
+  });
+  roots.push(root);
+  root.render(h('window', { width: 100, height: 80, frameRate: 'fast' }));
+  await tick();
+  assert.equal(errors.length, 1);
+  assert.match(
+    errors[0].message,
+    /<window frameRate> "fast" is not a frame rate/,
+  );
+  assert.match(errors[0].message, /'display'.*'adaptive'.*'throughput'/);
+});
+
+test('a bad root default fails at createRoot', async () => {
+  const app = createMockApp();
+  await assert.rejects(
+    createRoot({ app, frameRate: { budget: 2 } }),
+    /createRoot\({ frameRate }\)\.budget 2/,
+  );
+});
+
+// --- the rule, on a window ---------------------------------------------------------
+
+test("under 'adaptive' a flood of expensive frames is held to the budget, and the claims fold into the wait", async () => {
+  const ctx = await mount({ frameRate: 'adaptive', cost: 6 });
+  const { node, clock, claim, frames } = ctx;
+  // the burst goes first: the early frames are not held
+  assert.equal(await ctx.frame(), 0);
+  assert.equal(frames(), 1);
+  // a flood: a claim the moment each frame ends, forty times
+  const waits = [];
+  for (let i = 0; i < 40; i += 1) {
+    claim();
+    if (node._scheduled) {
+      waits.push(0);
+      await tick();
+      continue;
+    }
+    // held: no callback on the clock, one wait armed, further claims fold
+    const [wait] = clock.armed();
+    assert.ok(wait, 'a wait is armed');
+    claim();
+    claim();
+    assert.equal(clock.armed().length, 1, 'one wait for the three claims');
+    waits.push(wait.ms);
+    clock.advance(wait.ms);
+    assert.equal(node._scheduled, true, 'the wait put the frame on the clock');
+    await tick();
+  }
+  assert.equal(frames(), 41);
+  // the burst (50ms of paint at a quarter) covers the first ten or so
+  const held = waits.filter((w) => w > 0);
+  assert.ok(held.length >= 25, `${held.length} of 40 frames waited`);
+  // the first held frame pays whatever the burst left; from then on each
+  // waits three times what it cost
+  for (const w of held.slice(1)) assert.ok(Math.abs(w - 18) < 1e-6, `${w}`);
+  const s = node._pacer.stats;
+  assert.equal(s.deferred, held.length);
+  assert.equal(s.coalesced, held.length * 2);
+  assert.ok(Math.abs(s.lastWaitMs - 18) < 1e-6);
+  assert.equal(s.lastCostMs, 6);
+});
+
+test('cheap frames never wait, and one relayout among them is free', async () => {
+  const ctx = await mount({ frameRate: 'adaptive', cost: 0.4 });
+  const { node, clock, frames } = ctx;
+  // a scroll's worth of cheap frames, one per 120Hz tick
+  for (let i = 0; i < 200; i += 1) {
+    assert.equal(await ctx.frame(), 0, `frame ${i}`);
+    clock.advance(1000 / 120 - 0.4);
+  }
+  assert.equal(frames(), 200);
+  assert.equal(node._pacer.stats.deferred, 0);
+  // the one relayout in it
+  ctx.setCost(30);
+  assert.equal(await ctx.frame(), 0);
+  ctx.setCost(0.4);
+  assert.equal(await ctx.frame(), 0, 'the frame after a 30ms one is not held');
+  assert.equal(node._pacer.stats.deferred, 0);
+});
+
+test('a discrete input paints a held frame at once, and the wait stands down', async () => {
+  const ctx = await mount({ frameRate: 'adaptive', cost: 6 });
+  const { node, clock, claim, frames } = ctx;
+  for (let i = 0; i < 30; i += 1) await ctx.frame();
+  const before = frames();
+  claim();
+  assert.equal(node._scheduled, false, 'held');
+  const [wait] = clock.armed();
+  assert.ok(wait);
+  // the early flush a click or a key gets (frames.js): the debt is paid now
+  flushPendingFrames();
+  assert.equal(frames(), before + 1, 'painted on the input');
+  assert.equal(wait.live, false, 'the wait was cancelled');
+  assert.equal(node._pacer.deferring, false);
+  assert.equal(node._pacer.stats.lastWaitMs, 0, 'that frame was not held');
+  // …and the window is not stuck: the next claim is held or scheduled
+  claim();
+  assert.ok(node._scheduled || clock.armed().length === 1);
+  clock.advance(100);
+  await tick();
+  assert.equal(frames(), before + 2);
+});
+
+test('a claim the frame raises on itself is priced by that frame', async () => {
+  const ctx = await mount({ frameRate: 'adaptive', cost: 0.5 });
+  const { node, clock, box } = ctx;
+  // spend the burst with expensive frames, then rest exactly until the
+  // next is owed nothing — the bucket at zero, not refilled…
+  ctx.setCost(6);
+  for (let i = 0; i < 20; i += 1) await ctx.frame();
+  clock.advance(node._pacer.wait());
+  assert.equal(node._pacer.wait(), 0);
+  // …then a frame that claims again from inside itself — what an animation
+  // step or a container query does — and costs 6ms
+  const flushFrame = node._flushFrame;
+  node._flushFrame = (...a) => {
+    box.invalidate(false, box.contentBox(), 'content');
+    return flushFrame(...a);
+  };
+  ctx.claim();
+  assert.equal(node._scheduled, true);
+  await tick();
+  node._flushFrame = flushFrame;
+  // the inner claim was answered after the frame, against those 6ms: the
+  // burst is spent, so it is held
+  assert.equal(node._scheduled, false, 'not on the clock yet');
+  assert.equal(clock.armed().length, 1, 'held on the wait');
+});
+
+test('unmounting cancels a held frame', async () => {
+  const ctx = await mount({ frameRate: 'adaptive', cost: 6 });
+  const { node, clock, claim, root } = ctx;
+  for (let i = 0; i < 30; i += 1) await ctx.frame();
+  claim();
+  const [wait] = clock.armed();
+  assert.ok(wait?.live, 'held');
+  await root.unmount();
+  roots.length = 0;
+  assert.equal(wait.live, false);
+  assert.equal(node.destroyed, true);
+});
+
+test('the frame trace names the wait a frame followed', async () => {
+  const seen = [];
+  hooks.frame = (info) => seen.push(info.waited);
+  const ctx = await mount({ frameRate: 'adaptive', cost: 6 });
+  for (let i = 0; i < 40; i += 1) await ctx.frame();
+  assert.ok(
+    seen.some((w) => w === 0),
+    'the burst frames waited on nothing',
+  );
+  assert.ok(
+    seen.some((w) => Math.abs(w - 18) < 1e-6),
+    `the paced ones waited 18ms: ${seen.slice(-3)}`,
+  );
+});

--- a/test/glarea.test.js
+++ b/test/glarea.test.js
@@ -311,3 +311,100 @@ test('a wheel over the surface is a synthetic Wheel at the <glarea>', async () =
     await app.close();
   }
 });
+
+test('a <glarea> paces its frames by the window it is in, or by its own frameRate', async () => {
+  const { app } = await createGlApp();
+  const x11Root = await createRoot({ app });
+  try {
+    let drawn = 0;
+    const instance = await render(
+      h(
+        'window',
+        { width: 320, height: 240, frameRate: 'adaptive' },
+        h('glarea', {
+          key: 'gl',
+          frameLoop: 'always',
+          onDraw: () => {
+            drawn += 1;
+          },
+          style: { flexGrow: 1 },
+        }),
+      ),
+      x11Root,
+    );
+    await waitFor(() => drawn > 0, 'the first frame');
+    const node = instance._reactX11Node;
+    const area = node.children[0];
+    assert.equal(area.kind, 'glarea');
+    // no frameRate of its own: the window's policy is the surface's
+    assert.equal(area._pacer.policy.mode, 'adaptive');
+    assert.equal(area._pacer.stats.budget, 0.25);
+    // the loop runs on the child window's clock; a frame is priced by what
+    // onDraw and the swap cost this thread, and a cheap scene never waits
+    await waitFor(() => drawn > 5, 'the loop');
+    assert.equal(area._pacer.stats.deferred, 0);
+    assert.ok(area._pacer.stats.frames >= 5);
+    // an expensive scene is held: the pacer's clock, moved by the draw
+    // (8ms of GL encoding a frame) and by the waits it asks for — the
+    // real wait is a short real timer, so the loop keeps going
+    let t = 5000;
+    const waits = [];
+    area._pacer.clock = {
+      now: () => t,
+      after(ms, fn) {
+        waits.push(ms);
+        const timer = setTimeout(() => {
+          t += ms;
+          fn();
+        }, 1);
+        return () => clearTimeout(timer);
+      },
+    };
+    const before = drawn;
+    const onDraw = () => {
+      drawn += 1;
+      t += 8;
+    };
+    x11Root.render(
+      h(
+        'window',
+        { width: 320, height: 240, frameRate: 'adaptive' },
+        h('glarea', {
+          key: 'gl',
+          frameLoop: 'always',
+          onDraw,
+          style: { flexGrow: 1 },
+        }),
+      ),
+    );
+    await waitFor(() => drawn > before + 12, 'a dozen expensive frames');
+    assert.ok(area._pacer.stats.deferred > 0, 'held');
+    // three times the cost, once the burst is spent
+    assert.ok(Math.abs(waits.at(-1) - 24) < 1e-6, `waited ${waits.at(-1)}`);
+    assert.ok(
+      waits.every((w) => w <= 24 + 1e-6),
+      `never more than that: ${waits.slice(-3)}`,
+    );
+    // its own frameRate wins over the window's
+    x11Root.render(
+      h(
+        'window',
+        { width: 320, height: 240, frameRate: 'adaptive' },
+        h('glarea', {
+          key: 'gl',
+          frameLoop: 'always',
+          frameRate: 'display',
+          onDraw,
+          style: { flexGrow: 1 },
+        }),
+      ),
+    );
+    await waitFor(() => area._pacer.policy.mode === 'display', 'its own');
+    assert.equal(area._pacer.active, false);
+    await x11Root.unmount();
+    await settle(app);
+    assert.equal(area._pacer.deferring, false, 'a wait dies with the node');
+  } finally {
+    await app.close();
+  }
+});

--- a/test/opaque-content.test.js
+++ b/test/opaque-content.test.js
@@ -1,0 +1,255 @@
+// `Node.opaqueRect()` — an element that covers its box with opaque pixels
+// on every paint tells the window so, and a pass inside that rect is
+// painted without the fills that would be under it: the window's
+// background, the element's own, its ancestors'. Two halves here. On the
+// mock app, which records every drawing call, that the fills are the
+// exact ones skipped and nothing else. On the in-process X server, the
+// invariant that makes the skip safe: a covered pass leaves the pixels a
+// full repaint of the same tree leaves, byte for byte — the same test
+// dirty-rect.test.js makes of every partial repaint.
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import { afterEach, test } from 'node:test';
+import React from 'react';
+
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient, StaticFontSource } from 'ntk';
+
+import { registerElement, unregisterElement } from '../src/host.js';
+import { createRoot } from '../src/index.js';
+import { Node } from '../src/node.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+/** A pane that fills its whole box, opaquely, every paint — a terminal's
+ * shape — and says so. `translucent` makes it a pane that must not. */
+class PaneNode extends Node {
+  constructor(props, app) {
+    super('opaquepane', props, app);
+  }
+
+  opaqueRect() {
+    return this.props.translucent ? null : this.abs;
+  }
+
+  paintContent(ctx) {
+    const { x, y, width, height } = this.abs;
+    ctx.fillStyle = this.props.translucent
+      ? 'rgba(0, 0, 255, 0.5)'
+      : (this.props.ink ?? '#123456');
+    ctx.fillRect(x, y, width, height);
+  }
+}
+
+registerElement('opaquepane', {
+  create: (props, app) => new PaneNode(props, app),
+});
+process.on('exit', () => unregisterElement('opaquepane'));
+
+const roots = [];
+afterEach(async () => {
+  for (const root of roots.splice(0)) await root.unmount();
+});
+
+/** The colours filled, in order: a `fillRect`, or a rounded box's `fill`. */
+const fillsOf = (ctx) =>
+  ctx.ops
+    .filter((op) => op[0] === 'fillRect' || op[0] === 'fill')
+    .map((op) => (op[0] === 'fillRect' ? op[5] : op[1]));
+
+/** A window with a padded, coloured box around the pane, on the mock. */
+async function mountMock(paneProps = {}, boxStyle = {}) {
+  const app = createMockApp();
+  const root = await createRoot({ app });
+  roots.push(root);
+  root.render(
+    h(
+      'window',
+      { width: 200, height: 120, style: { backgroundColor: '#ffffff' } },
+      h(
+        'box',
+        {
+          style: {
+            flexGrow: 1,
+            padding: 10,
+            backgroundColor: '#dddddd',
+            ...boxStyle,
+          },
+        },
+        h('opaquepane', { style: { flexGrow: 1 }, ...paneProps }),
+      ),
+    ),
+  );
+  await tick();
+  const wnd = app.windows[0];
+  const node = wnd._reactX11Node;
+  const ctx = wnd.getContext('2d');
+  const pane = node.children[0].children[0];
+  return { app, root, node, ctx, box: node.children[0], pane };
+}
+
+test('a pass inside the opaque rect skips the fills under it', async () => {
+  const { node, ctx, box, pane } = await mountMock();
+  assert.ok(node._opaqueNodes.has(pane), 'registered on attach');
+  // the mount frame: the pane is inside the box's padding, so the full
+  // pass is not covered — the window and the box both fill
+  const mount = fillsOf(ctx);
+  assert.deepEqual(mount, ['#ffffff', '#dddddd', '#123456']);
+  ctx.ops.length = 0;
+  // a claim inside the pane, as a rect: only the pane paints
+  pane.invalidate(false, pane.contentBox(), 'content');
+  node.flush();
+  assert.deepEqual(
+    fillsOf(ctx),
+    ['#123456'],
+    'no window background, no box background',
+  );
+  assert.deepEqual(node._lastDamageRects, [pane.abs]);
+  ctx.ops.length = 0;
+  // a claim of the pane as a node is a pixel wider than the pane — that
+  // pixel is the box's, and the box paints it
+  pane.invalidate(false, pane, 'content');
+  node.flush();
+  assert.deepEqual(fillsOf(ctx), ['#ffffff', '#dddddd', '#123456']);
+  ctx.ops.length = 0;
+  // a claim on the box reaches outside the pane: every fill again
+  box.invalidate(false, box, 'content');
+  node.flush();
+  assert.deepEqual(fillsOf(ctx), ['#ffffff', '#dddddd', '#123456']);
+  assert.equal(node._coverChain, null, 'cleared after the pass');
+});
+
+test('an element that answers null, or is hidden, covers nothing', async () => {
+  const { node, ctx, pane } = await mountMock({ translucent: true });
+  assert.ok(node._opaqueNodes.has(pane), 'it overrides, so it is asked');
+  ctx.ops.length = 0;
+  pane.invalidate(false, pane.contentBox(), 'content');
+  node.flush();
+  assert.deepEqual(fillsOf(ctx), [
+    '#ffffff',
+    '#dddddd',
+    'rgba(0, 0, 255, 0.5)',
+  ]);
+});
+
+test('a clipping ancestor shrinks the cover to what reaches the surface', async () => {
+  // a rounded, clipping box: its corner squares are given up by the clip,
+  // so a pass in a corner is not covered while one in the middle is
+  const { node, ctx, pane } = await mountMock(
+    {},
+    { overflow: 'hidden', borderRadius: 8, padding: 0 },
+  );
+  ctx.ops.length = 0;
+  const { x, y, width, height } = pane.abs;
+  pane.invalidate(
+    false,
+    { x: x + 20, y: y + 20, width: 40, height: 40 },
+    'content',
+  );
+  node.flush();
+  assert.deepEqual(fillsOf(ctx), ['#123456'], 'the middle');
+  ctx.ops.length = 0;
+  pane.invalidate(false, { x, y, width: 4, height: 4 }, 'content');
+  node.flush();
+  assert.deepEqual(
+    fillsOf(ctx),
+    ['#ffffff', '#dddddd', '#123456'],
+    'the corner',
+  );
+  // and the whole pane, which reaches every corner
+  ctx.ops.length = 0;
+  pane.invalidate(false, { x, y, width, height }, 'content');
+  node.flush();
+  assert.equal(fillsOf(ctx).length, 3);
+});
+
+test('unmounting the element takes it out of the set', async () => {
+  const { node, root, pane } = await mountMock();
+  assert.ok(node._opaqueNodes.has(pane));
+  root.render(h('window', { width: 200, height: 120 }));
+  await tick();
+  assert.equal(node._opaqueNodes.size, 0);
+});
+
+// --- pixels ---------------------------------------------------------------------------
+
+const require = createRequire(import.meta.url);
+const fontDir = join(
+  dirname(require.resolve('katex/package.json')),
+  'dist',
+  'fonts',
+);
+
+async function headlessApp() {
+  const server = xserver.createServer({ width: 300, height: 300 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const fontSource = new StaticFontSource();
+  fontSource.add(readFileSync(join(fontDir, 'KaTeX_Main-Regular.ttf')), {
+    family: 'Test Main',
+  });
+  fontSource.alias('sans-serif', 'Test Main');
+  return createClient({ stream: clientEnd, fontSource });
+}
+
+const readPixels = (ctx, w, h) =>
+  new Promise((resolve, reject) =>
+    ctx.getImageData(0, 0, w, h, (err, data) =>
+      err ? reject(err) : resolve(data),
+    ),
+  );
+
+const settled = (app) =>
+  new Promise((resolve, reject) =>
+    app.X.GetInputFocus((err) => (err ? reject(err) : resolve())),
+  );
+
+test('a covered pass leaves the pixels a full repaint leaves', async () => {
+  const W = 160;
+  const H = 120;
+  const app = await headlessApp();
+  const root = await createRoot({ app });
+  const tree = (ink) =>
+    h(
+      'window',
+      { width: W, height: H, style: { backgroundColor: '#ffffff' } },
+      h(
+        'box',
+        { style: { flexGrow: 1, padding: 12, backgroundColor: '#dddddd' } },
+        h('opaquepane', { style: { flexGrow: 1 }, ink }),
+      ),
+    );
+  // the render callback hands back the root child's public instance — the
+  // live ntk window, which knows its node (the way react-x11/test finds it)
+  const windowNode = await new Promise((resolve) =>
+    root.render(tree('#123456'), (inst) => resolve(inst._reactX11Node)),
+  );
+  windowNode.flush();
+  await settled(app);
+  const ctx = windowNode.window.getContext('2d');
+  const pane = windowNode.children[0].children[0];
+  // change the ink and repaint through the covered pass
+  pane.props = { ...pane.props, ink: '#654321' };
+  pane.invalidate(false, pane.contentBox(), 'content');
+  windowNode.flush();
+  assert.deepEqual(windowNode._lastDamageRects, [pane.abs], 'a bounded pass');
+  await settled(app);
+  const partial = await readPixels(ctx, W, H);
+  // the same tree painted whole
+  windowNode.invalidate(false, null, 'content');
+  windowNode.flush();
+  await settled(app);
+  const full = await readPixels(ctx, W, H);
+  assert.ok(Buffer.from(partial.data).equals(Buffer.from(full.data)));
+  // and it is the new ink that is there, not the old
+  const at = (data, x, y) => [
+    ...data.data.subarray((y * W + x) * 4, (y * W + x) * 4 + 3),
+  ];
+  assert.deepEqual(at(full, W / 2, H / 2), [0x65, 0x43, 0x21]);
+  assert.deepEqual(at(full, 4, 4), [0xdd, 0xdd, 0xdd]);
+  await root.unmount();
+});

--- a/test/pacing.test.js
+++ b/test/pacing.test.js
@@ -465,6 +465,30 @@ test('a new policy starts from a full bucket; the same one again is a no-op', ()
   assert.equal(pacer.stats.mode, 'display');
 });
 
+test('a new clock starts the pacer afresh in its own time', () => {
+  const late = fakeClock(600000); // ten minutes into a suite
+  const pacer = new FramePacer(ADAPTIVE, late);
+  stream(pacer, late, { n: 30, cost: 6 });
+  assert.ok(pacer.wait() > 0, 'in debt on the old clock');
+  const clock = fakeClock(1000);
+  pacer.clock = clock;
+  assert.equal(pacer.clock, clock);
+  // a full bucket, no last frame: the rule's timestamps are all the new
+  // clock's, so credit accrues from its first millisecond
+  assert.equal(pacer.wait(), 0);
+  const waits = stream(pacer, clock, { n: 60, cost: 6 });
+  assert.equal(waits[0], 0, 'the burst is back');
+  for (const w of waits.slice(-10)) assert.ok(Math.abs(w - 18) < 1e-6, `${w}`);
+  // and a ceiling measured from a frame on the old clock does not hold
+  // the first frame on the new one for ten minutes
+  const capped = new FramePacer(resolveFrameRate(30), late);
+  capped.began();
+  late.advance(1);
+  capped.ended();
+  capped.clock = fakeClock(1000);
+  assert.equal(capped.wait(), 0);
+});
+
 test('charge extends the last frame — the present on Cocoa', () => {
   const clock = fakeClock();
   const pacer = new FramePacer(ADAPTIVE, clock);

--- a/test/pacing.test.js
+++ b/test/pacing.test.js
@@ -1,0 +1,506 @@
+// Frame pacing, alone: the policy resolver and the token-bucket pacer
+// (src/pacing.js), under a fake clock — no window, no backend, no timers.
+// The four properties the module header promises are pinned here one by
+// one, because each is what somebody will otherwise re-derive as a bug:
+// idle is immediate, cheap is unthrottled, a rare expensive frame is free,
+// and a flood that ends is un-throttled on its next claim.
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+
+import {
+  DEFAULT_FRAME_RATE,
+  FRAME_RATE_PRESETS,
+  FramePacer,
+  frameRateDefaultFor,
+  frameRateFromEnv,
+  realClock,
+  resolveFramePolicy,
+  resolveFrameRate,
+  sameFramePolicy,
+  setFrameRateDefault,
+} from '../src/pacing.js';
+
+/** A clock the test moves by hand; `after` fires when `advance` crosses it. */
+function fakeClock(start = 0) {
+  let t = start;
+  const timers = [];
+  return {
+    now: () => t,
+    after(ms, fn) {
+      const entry = { at: t + ms, ms, fn, cancelled: false };
+      timers.push(entry);
+      return () => {
+        entry.cancelled = true;
+      };
+    },
+    timers,
+    /** the waits armed and not cancelled */
+    armed: () => timers.filter((e) => !e.cancelled),
+    set(ms) {
+      t = ms;
+    },
+    advance(ms) {
+      t += ms;
+      const due = timers.filter((e) => !e.cancelled && e.at <= t);
+      for (const e of due) {
+        e.cancelled = true; // fired
+        e.fn();
+      }
+    },
+  };
+}
+
+const ADAPTIVE = FRAME_RATE_PRESETS.adaptive;
+
+/** Run `n` frames of `cost` ms back to back, each claimed the moment the
+ * last one ends and painted after whatever wait the pacer asks. Returns
+ * the waits, in order. */
+function stream(pacer, clock, { n, cost }) {
+  const waits = [];
+  for (let i = 0; i < n; i += 1) {
+    const wait = pacer.wait();
+    waits.push(wait);
+    clock.advance(wait);
+    pacer.began();
+    clock.advance(cost);
+    pacer.ended();
+  }
+  return waits;
+}
+
+const warnings = [];
+const realWarn = console.warn;
+console.warn = (...args) => warnings.push(args.join(' '));
+afterEach(() => {
+  warnings.length = 0;
+  delete process.env.REACT_X11_FRAME_RATE;
+});
+process.on('exit', () => {
+  console.warn = realWarn;
+});
+
+// --- resolveFrameRate ---------------------------------------------------------
+
+test('the presets are the three numbers, and the default is display', () => {
+  assert.equal(DEFAULT_FRAME_RATE, 'display');
+  assert.deepEqual(resolveFrameRate(undefined), FRAME_RATE_PRESETS.display);
+  assert.deepEqual(resolveFrameRate('display'), {
+    mode: 'display',
+    budget: 1,
+    minFps: 0,
+    maxFps: 0,
+  });
+  assert.deepEqual(resolveFrameRate('adaptive'), {
+    mode: 'adaptive',
+    budget: 0.25,
+    minFps: 20,
+    maxFps: 0,
+  });
+  assert.deepEqual(resolveFrameRate('throughput'), {
+    mode: 'throughput',
+    budget: 0.1,
+    minFps: 10,
+    maxFps: 30,
+  });
+  assert.ok(Object.isFrozen(resolveFrameRate('adaptive')));
+});
+
+test('a number is a ceiling over the default, and nothing else', () => {
+  assert.deepEqual(resolveFrameRate(60), {
+    mode: 'custom',
+    budget: 1,
+    minFps: 0,
+    maxFps: 60,
+  });
+  assert.deepEqual(resolveFrameRate(Infinity), FRAME_RATE_PRESETS.display);
+  assert.throws(() => resolveFrameRate(0), /above zero/);
+  assert.throws(() => resolveFrameRate(-30), /above zero/);
+  assert.throws(() => resolveFrameRate(NaN), /above zero/);
+});
+
+test('an object names any of the three; the rest are the default', () => {
+  assert.deepEqual(resolveFrameRate({ budget: 0.5, minFps: 15 }), {
+    mode: 'custom',
+    budget: 0.5,
+    minFps: 15,
+    maxFps: 0,
+  });
+  assert.deepEqual(resolveFrameRate({ maxFps: 30 }), {
+    mode: 'custom',
+    budget: 1,
+    minFps: 0,
+    maxFps: 30,
+  });
+  assert.deepEqual(resolveFrameRate({}), {
+    mode: 'custom',
+    budget: 1,
+    minFps: 0,
+    maxFps: 0,
+  });
+});
+
+test('a bad value says what it is and what the choices are', () => {
+  assert.throws(
+    () => resolveFrameRate('fast', '<window frameRate>'),
+    /<window frameRate> "fast" is not a frame rate — 'display'.*'adaptive'.*'throughput'.*a number.*budget, minFps, maxFps/,
+  );
+  assert.throws(() => resolveFrameRate([30]), /is not a frame rate/);
+  assert.throws(
+    () => resolveFrameRate({ fps: 30 }),
+    /has no "fps" — the three numbers are budget, minFps and maxFps/,
+  );
+  assert.throws(
+    () => resolveFrameRate({ budget: 0 }),
+    /budget 0 — the share of wall time.*above 0 and at most 1/,
+  );
+  assert.throws(() => resolveFrameRate({ budget: 1.5 }), /budget 1.5/);
+  assert.throws(() => resolveFrameRate({ minFps: -1 }), /minFps -1/);
+  assert.throws(() => resolveFrameRate({ maxFps: '30' }), /maxFps "30"/);
+  assert.throws(
+    () => resolveFrameRate({ minFps: 60, maxFps: 30 }),
+    /floor \(minFps 60\) above the ceiling \(maxFps 30\)/,
+  );
+});
+
+test('a budget with no floor warns once, naming the fix', () => {
+  resolveFrameRate({ budget: 0.25 }, '<window frameRate>');
+  resolveFrameRate({ budget: 0.25 }, '<window frameRate>');
+  assert.equal(warnings.length, 1);
+  assert.match(warnings[0], /budget 0.25 with no minFps/);
+  assert.match(warnings[0], /3\.0× its cost/);
+  assert.match(warnings[0], /minFps: 20/);
+});
+
+test('sameFramePolicy compares the numbers, not the identity', () => {
+  assert.ok(
+    sameFramePolicy(resolveFrameRate(60), resolveFrameRate({ maxFps: 60 })),
+  );
+  assert.ok(!sameFramePolicy(resolveFrameRate(60), resolveFrameRate(30)));
+  assert.ok(sameFramePolicy(ADAPTIVE, ADAPTIVE));
+  assert.ok(!sameFramePolicy(null, ADAPTIVE));
+});
+
+// --- the sources ----------------------------------------------------------------
+
+test('REACT_X11_FRAME_RATE is a preset name or a number, and unset when empty', () => {
+  assert.equal(frameRateFromEnv({}), undefined);
+  assert.equal(frameRateFromEnv({ REACT_X11_FRAME_RATE: '' }), undefined);
+  assert.equal(
+    frameRateFromEnv({ REACT_X11_FRAME_RATE: 'adaptive' }),
+    'adaptive',
+  );
+  assert.equal(frameRateFromEnv({ REACT_X11_FRAME_RATE: '30' }), 30);
+  assert.equal(frameRateFromEnv({ REACT_X11_FRAME_RATE: ' 60 ' }), 60);
+  assert.equal(frameRateFromEnv({ REACT_X11_FRAME_RATE: 'fast' }), 'fast');
+});
+
+test('the environment beats the prop, the prop beats the root, the root beats the default', () => {
+  const app = {};
+  assert.equal(resolveFramePolicy(undefined, app).mode, 'display');
+  setFrameRateDefault(app, 'throughput');
+  assert.equal(frameRateDefaultFor(app), 'throughput');
+  assert.equal(resolveFramePolicy(undefined, app).mode, 'throughput');
+  assert.equal(resolveFramePolicy('adaptive', app).mode, 'adaptive');
+  process.env.REACT_X11_FRAME_RATE = 'display';
+  assert.equal(resolveFramePolicy('adaptive', app).mode, 'display');
+  process.env.REACT_X11_FRAME_RATE = '45';
+  assert.equal(resolveFramePolicy('adaptive', app).maxFps, 45);
+  process.env.REACT_X11_FRAME_RATE = 'fast';
+  assert.throws(
+    () => resolveFramePolicy('adaptive', app),
+    /REACT_X11_FRAME_RATE "fast" is not a frame rate/,
+  );
+  setFrameRateDefault(app, undefined);
+  assert.equal(frameRateDefaultFor(app), undefined);
+});
+
+test('a bad root default fails at createRoot, not at the first window', () => {
+  assert.throws(
+    () => setFrameRateDefault({}, 'quick'),
+    /createRoot\({ frameRate }\) "quick" is not a frame rate/,
+  );
+});
+
+// --- the pacer -----------------------------------------------------------------------
+
+test("'display' never holds a frame, whatever the last one cost", () => {
+  const clock = fakeClock();
+  const pacer = new FramePacer(resolveFrameRate('display'), clock);
+  assert.equal(pacer.active, false);
+  const waits = stream(pacer, clock, { n: 20, cost: 60 });
+  assert.deepEqual(waits, new Array(20).fill(0));
+  assert.equal(
+    pacer.defer(() => {}),
+    false,
+    'schedule it now',
+  );
+  assert.equal(pacer.stats.frames, 20);
+  assert.equal(pacer.stats.lastCostMs, 60);
+  assert.equal(pacer.stats.deferred, 0);
+});
+
+test('idle is immediate: a claim after a pause never waits', () => {
+  const clock = fakeClock();
+  const pacer = new FramePacer(ADAPTIVE, clock);
+  stream(pacer, clock, { n: 30, cost: 40 }); // in debt by now
+  assert.ok(pacer.wait() > 0, 'a flood is being paced');
+  clock.advance(500);
+  assert.equal(pacer.wait(), 0);
+});
+
+test('cheap is unthrottled: blit-sized frames at 120Hz keep 120Hz', () => {
+  const clock = fakeClock();
+  const pacer = new FramePacer(ADAPTIVE, clock);
+  for (let i = 0; i < 600; i += 1) {
+    assert.equal(pacer.wait(), 0, `frame ${i}`);
+    pacer.began();
+    clock.advance(0.5);
+    pacer.ended();
+    clock.advance(1000 / 120 - 0.5);
+  }
+  assert.equal(pacer.stats.deferred, 0);
+});
+
+test('a rare expensive frame is free: the burst absorbs one relayout in a scroll', () => {
+  const clock = fakeClock();
+  const pacer = new FramePacer(ADAPTIVE, clock);
+  // a hundred cheap scroll frames, then one 30ms relayout, then cheap again
+  for (let i = 0; i < 100; i += 1) {
+    pacer.began();
+    clock.advance(0.4);
+    pacer.ended();
+    clock.advance(8);
+  }
+  pacer.began();
+  clock.advance(30);
+  pacer.ended();
+  assert.equal(pacer.wait(), 0, 'the frame after it does not wait');
+  for (let i = 0; i < 20; i += 1) {
+    assert.equal(pacer.wait(), 0);
+    pacer.began();
+    clock.advance(0.4);
+    pacer.ended();
+    clock.advance(8);
+  }
+});
+
+test('a stream of expensive frames is held to the budget: cost × (1/budget − 1)', () => {
+  const clock = fakeClock();
+  const pacer = new FramePacer(ADAPTIVE, clock);
+  const waits = stream(pacer, clock, { n: 60, cost: 6 });
+  // the burst (50ms of paint at 0.25) is spent over the first frames…
+  assert.equal(waits[0], 0);
+  // …and from then on every frame waits three times what it cost
+  const paced = waits.slice(-40);
+  for (const w of paced) assert.ok(Math.abs(w - 18) < 1e-6, `waited ${w}`);
+  assert.equal(pacer.stats.deferred, 0, 'wait() alone arms nothing');
+  assert.equal(pacer.stats.frames, 60);
+  assert.equal(pacer.stats.lastCostMs, 6);
+});
+
+test('the paint share of wall time converges on the budget', () => {
+  for (const [name, cost] of [
+    ['adaptive', 6],
+    ['throughput', 6],
+    ['adaptive', 2.5],
+  ]) {
+    const clock = fakeClock();
+    const pacer = new FramePacer(resolveFrameRate(name), clock);
+    const from = clock.now();
+    const n = 400;
+    stream(pacer, clock, { n, cost });
+    const share = (n * cost) / (clock.now() - from);
+    const { budget, minFps, maxFps } = resolveFrameRate(name);
+    // the burst is paid for in the first frames, so a long stream lands a
+    // little above the budget, never below it
+    const expected =
+      maxFps > 0 ? Math.min(budget, (cost * maxFps) / 1000) : budget;
+    assert.ok(
+      share >= expected - 1e-9 && share < expected * 1.1,
+      `${name} at ${cost}ms: paint took ${(share * 100).toFixed(1)}% (budget ${budget * 100}%, floor ${minFps})`,
+    );
+  }
+});
+
+test('the floor bounds the wait whatever the debt', () => {
+  const clock = fakeClock();
+  const pacer = new FramePacer(ADAPTIVE, clock);
+  const waits = stream(pacer, clock, { n: 20, cost: 40 });
+  // 40ms at a quarter would wait 120; the 20fps floor says 50
+  for (const w of waits.slice(-10)) assert.ok(Math.abs(w - 50) < 1e-6, `${w}`);
+});
+
+test('the ceiling holds cheap frames to a rate, start to start', () => {
+  const clock = fakeClock();
+  const pacer = new FramePacer(resolveFrameRate(30), clock);
+  assert.equal(pacer.active, true);
+  assert.equal(pacer.wait(), 0, 'the first frame');
+  pacer.began();
+  clock.advance(0.5);
+  pacer.ended();
+  assert.ok(Math.abs(pacer.wait() - (1000 / 30 - 0.5)) < 1e-9);
+  clock.advance(20);
+  assert.ok(Math.abs(pacer.wait() - (1000 / 30 - 20.5)) < 1e-9);
+  clock.advance(20);
+  assert.equal(pacer.wait(), 0);
+  // a ceiling with a budget: the longer of the two waits wins
+  const both = new FramePacer(
+    resolveFrameRate({ budget: 0.25, minFps: 20, maxFps: 30 }),
+    clock,
+  );
+  const waits = stream(both, clock, { n: 40, cost: 6 });
+  for (const w of waits.slice(-10)) {
+    assert.ok(Math.abs(w - (1000 / 30 - 6)) < 1e-6, `${w}`);
+  }
+});
+
+test('a flood that ends is un-throttled on its next claim', () => {
+  const clock = fakeClock();
+  const pacer = new FramePacer(ADAPTIVE, clock);
+  stream(pacer, clock, { n: 60, cost: 6 });
+  // the flood stops: the prompt that follows waits for the last frame's
+  // debt and nothing more…
+  const last = pacer.wait();
+  assert.ok(last > 0 && last <= 18, `${last}`);
+  clock.advance(last);
+  pacer.began();
+  clock.advance(0.3);
+  pacer.ended();
+  // …and the next cheap frame is immediate
+  assert.equal(pacer.wait(), 0);
+});
+
+test('a wait under a millisecond is not armed; the debt carries over', () => {
+  const clock = fakeClock();
+  const pacer = new FramePacer(ADAPTIVE, clock);
+  stream(pacer, clock, { n: 60, cost: 6 });
+  clock.advance(pacer.wait()); // the debt is paid
+  // sub-millisecond frames claimed back to back: each would owe 3x its
+  // cost, under the millisecond a timer can keep — so they run, and the
+  // debt they run up is collected once it is worth a timer
+  let waited = 0;
+  let waits = 0;
+  for (let i = 0; i < 40; i += 1) {
+    const wait = pacer.wait();
+    if (wait > 0) {
+      assert.ok(wait >= 1, `${wait}`);
+      waited += wait;
+      waits += 1;
+      clock.advance(wait);
+    }
+    pacer.began();
+    clock.advance(0.3);
+    pacer.ended();
+  }
+  assert.ok(waits > 0 && waits < 40, `${waits} waits for 40 frames`);
+  // …and the share still lands on the budget
+  const share = (40 * 0.3) / (40 * 0.3 + waited);
+  assert.ok(share > 0.2 && share < 0.3, `${share}`);
+});
+
+test('a no-op flush charges its time but is not a frame', () => {
+  const clock = fakeClock();
+  const pacer = new FramePacer(resolveFrameRate(30), clock);
+  pacer.began();
+  clock.advance(1);
+  pacer.ended(undefined, true);
+  clock.advance(10);
+  pacer.began();
+  clock.advance(0.1);
+  pacer.ended(undefined, false); // found nothing to paint
+  assert.equal(pacer.stats.frames, 1);
+  // the ceiling still measures from the frame that painted
+  assert.ok(Math.abs(pacer.wait() - (1000 / 30 - 11.1)) < 1e-9);
+});
+
+test('defer arms one wait, coalesces the claims under it, and cancel drops it', () => {
+  const clock = fakeClock();
+  const pacer = new FramePacer(ADAPTIVE, clock);
+  stream(pacer, clock, { n: 30, cost: 6 });
+  let fired = 0;
+  const fn = () => (fired += 1);
+  assert.equal(pacer.defer(fn), true);
+  assert.equal(pacer.deferring, true);
+  assert.equal(pacer.stats.deferred, 1);
+  assert.equal(clock.armed().length, 1);
+  assert.ok(Math.abs(clock.armed()[0].ms - 18) < 1e-6);
+  assert.equal(pacer.defer(fn), true, 'folded into the wait');
+  assert.equal(pacer.defer(fn), true);
+  assert.equal(pacer.stats.coalesced, 2);
+  assert.equal(clock.armed().length, 1, 'one timer');
+  clock.advance(18);
+  assert.equal(fired, 1);
+  assert.equal(pacer.deferring, false);
+  // the frame that follows a wait records it
+  pacer.began();
+  clock.advance(6);
+  pacer.ended();
+  assert.ok(Math.abs(pacer.stats.lastWaitMs - 18) < 1e-6);
+  // a wait a discrete flush made moot
+  assert.equal(pacer.defer(fn), true);
+  pacer.cancel();
+  assert.equal(pacer.deferring, false);
+  assert.equal(clock.armed().length, 0);
+  clock.advance(100);
+  assert.equal(fired, 1, 'cancelled, so never fired');
+  pacer.began();
+  clock.advance(0.2);
+  pacer.ended();
+  assert.equal(pacer.stats.lastWaitMs, 0, 'this frame waited on nothing');
+});
+
+test('a new policy starts from a full bucket; the same one again is a no-op', () => {
+  const clock = fakeClock();
+  const pacer = new FramePacer(ADAPTIVE, clock);
+  stream(pacer, clock, { n: 30, cost: 6 });
+  assert.ok(pacer.wait() > 0);
+  pacer.configure(resolveFrameRate('adaptive'));
+  assert.ok(pacer.wait() > 0, 'the same numbers: nothing reset');
+  pacer.configure(resolveFrameRate('throughput'));
+  assert.equal(pacer.wait(), 0, 'a new policy: the debt is forgiven');
+  assert.equal(pacer.stats.mode, 'throughput');
+  assert.equal(pacer.stats.budget, 0.1);
+  pacer.configure(resolveFrameRate('display'));
+  assert.equal(pacer.active, false);
+  assert.equal(pacer.stats.mode, 'display');
+});
+
+test('charge extends the last frame — the present on Cocoa', () => {
+  const clock = fakeClock();
+  const pacer = new FramePacer(ADAPTIVE, clock);
+  // 4ms flushes alone are too cheap to pace at 8ms intervals…
+  for (let i = 0; i < 40; i += 1) {
+    pacer.began();
+    clock.advance(1.5);
+    pacer.ended();
+    clock.advance(6.8);
+  }
+  assert.equal(pacer.wait(), 0);
+  // …but with a 4.5ms present after each, they are a flood
+  for (let i = 0; i < 40; i += 1) {
+    const wait = pacer.wait();
+    clock.advance(wait);
+    pacer.began();
+    clock.advance(1.5);
+    pacer.ended();
+    clock.advance(4.5);
+    pacer.charge(4.5);
+  }
+  assert.equal(pacer.stats.lastCostMs, 6);
+  assert.ok(Math.abs(pacer.wait() - 18) < 1e-6, `${pacer.wait()}`);
+  pacer.charge(0);
+  pacer.charge(-1);
+  assert.equal(pacer.stats.lastCostMs, 6, 'nothing to charge');
+});
+
+test('the real clock is performance.now and an unref timer', async () => {
+  assert.ok(Math.abs(realClock.now() - performance.now()) < 50);
+  let ran = 0;
+  const cancel = realClock.after(1, () => (ran += 1));
+  cancel();
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  assert.equal(ran, 0);
+  realClock.after(1, () => (ran += 1));
+  await new Promise((resolve) => setTimeout(resolve, 10));
+  assert.equal(ran, 1);
+});

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -17,6 +17,7 @@ import type { ReloadEvent } from 'react-x11/refresh';
 import type { RefreshOptions } from 'react-x11/refresh/loader';
 import type {
   AbortSignalLike,
+  FrameRate,
   PermissionStatus,
   NotificationBackend,
   NotificationCloseReason,
@@ -556,6 +557,21 @@ const _xi2Eager = <window xi2 />;
 const _xi2Never = <window xi2={false} />;
 // @ts-expect-error — 'auto' is the only string the selection understands
 const _xi2Bogus = <window xi2="lazy" />;
+// frameRate: a preset, a ceiling, or the three numbers — on a window, a
+// popup and a GL surface alike (docs/elements.md "frameRate")
+const _paceDefault = <window frameRate="display" />;
+const _paceAdaptive = <window frameRate="adaptive" />;
+const _paceThroughput = <popup frameRate="throughput" />;
+const _paceCap = <window frameRate={60} />;
+const _paceNumbers = <window frameRate={{ budget: 0.25, minFps: 20 }} />;
+const _paceCeilingOnly = <window frameRate={{ maxFps: 30 }} />;
+const _paceScene = <glarea frameRate="display" onDraw={() => {}} />;
+const _paceValue: FrameRate = { budget: 0.1, minFps: 10, maxFps: 30 };
+void _paceValue;
+// @ts-expect-error — not a preset
+const _paceBogus = <window frameRate="fast" />;
+// @ts-expect-error — the three numbers are budget, minFps and maxFps
+const _paceUnknown = <window frameRate={{ fps: 60 }} />;
 
 // --- popups ----------------------------------------------------------------
 
@@ -1072,6 +1088,13 @@ async function main() {
   ).unmount();
   // @ts-expect-error -- not a presenter
   await createRoot({ cocoa: { presenter: 'metal' } });
+  // the pacing default for every window of a root, both backends
+  await (await createRoot({ frameRate: 'adaptive' })).unmount();
+  await (
+    await createRoot({ frameRate: { budget: 0.2, minFps: 15 } })
+  ).unmount();
+  // @ts-expect-error -- a preset name, a number or the three numbers
+  await createRoot({ frameRate: true });
   await (await createRoot({ backend: 'auto' })).unmount();
   await (await createRoot({ backend: 'x11', display: ':1' })).unmount();
   // @ts-expect-error -- not a backend

--- a/test/types/extend.tsx
+++ b/test/types/extend.tsx
@@ -24,7 +24,9 @@ import type {
   A11ySceneAction,
   A11ySceneItem,
   A11yTextState,
+  Context2D,
   MeasureConstraints,
+  PaintCachePlan,
   TextStyle,
 } from '../../src/node.js';
 import type { Rect } from '../../src/types/nodes.js';
@@ -78,12 +80,71 @@ declare module '../../src/jsx-runtime.js' {
   }
 }
 
+// The drawing contract is declared, not `unknown` (#496's typing gaps): a
+// retained-surface element writes against the context both backends
+// implement, answers for the rect it covers, and caches its content — and
+// every one of those is checked.
+class SurfacePaneNode extends Node {
+  constructor(props: Record<string, unknown>, app: never) {
+    super('surfacepane', props, app);
+  }
+
+  paintContent(ctx: Context2D): void {
+    const { x, y, width, height } = this.contentBox();
+    ctx.fillStyle = '#000';
+    ctx.fillRect(x, y, width, height);
+    ctx.fillRects([x, y, 4, 4, x + 8, y, 4, 4]);
+    ctx.fillRects([
+      [x, y, 4, 4],
+      [x + 8, y, 4, 4],
+    ]);
+    ctx.save();
+    ctx.translate(x, y);
+    ctx.beginPath();
+    ctx.roundRect(0, 0, width, height, 4);
+    ctx.clip();
+    ctx.font = '13px sans-serif';
+    const measured: number = ctx.measureText('ab').width;
+    ctx.fillText('ab', measured, 0);
+    const gradient = ctx.createLinearGradient(0, 0, width, 0);
+    gradient.addColorStop(0, '#fff');
+    ctx.fillStyle = gradient;
+    ctx.fill('evenodd');
+    ctx.drawImage(null, 0, 0);
+    ctx.drawImage(null, 0, 0, width, height);
+    ctx.drawImage(null, 0, 0, 8, 8, 0, 0, width, height);
+    const pixels = ctx.createImageData(4, 4);
+    pixels.data[0] = 255;
+    ctx.putImageData(pixels, x, y);
+    // X11 only, so it is asked for rather than assumed
+    if ('globalCompositeOperation' in ctx)
+      ctx.globalCompositeOperation = 'copy';
+    ctx.restore();
+    // @ts-expect-error — not on both backends; ntk's own surface is
+    ctx.drawGlyphs();
+  }
+
+  opaqueRect(): Rect | null {
+    return this.contentBox();
+  }
+
+  paintCachePlan(_ctx: Context2D): PaintCachePlan | null {
+    const { x, y, width, height } = this.contentBox();
+    return { key: `pane:${width}x${height}`, x, y, width, height };
+  }
+
+  paintCached(ctx: Context2D, box: Rect, ink?: string): void {
+    ctx.fillStyle = ink ?? '#fff';
+    ctx.fillRect(0, 0, box.width, box.height);
+  }
+}
+
 class SparklineNode extends Node {
   constructor(props: Record<string, unknown>, app: never) {
     super('sparkline', props, app);
   }
 
-  paint(ctx: unknown): void {
+  paint(ctx: Context2D): void {
     super.paint(ctx);
     // the subclass surface docs/extending.md promises
     const _rect: number = this.abs.width;
@@ -517,7 +578,7 @@ class LogViewNode extends Node {
     ];
   }
 
-  paint(ctx: unknown): void {
+  paint(ctx: Context2D): void {
     super.paint(ctx);
     const range = this.selectionRange;
     if (!range) return;


### PR DESCRIPTION
## What

The react-x11 half of sidorares/react-x11-components#69 ("PRD: adaptive frame pacing in the vt backend"), made generic: a window fed off an input path — a terminal under `cat`, a chart on a socket, a simulation, a `<glarea>` scene drawing as fast as it can — can now be **paced by what its frames cost the JS thread**, on both backends, from one prop.

```jsx
<window frameRate="adaptive">…</window>      // paints stay under a quarter of the time while busy
<window frameRate={60}>…</window>            // a ceiling, nothing else
<glarea frameRate="display" … />             // a scene that wants every frame inside a streaming window
createRoot({ frameRate: 'adaptive' })        // the default for a root
REACT_X11_FRAME_RATE=adaptive node app.js    // an A/B run, over both
```

**Opt-in.** The default is `'display'`: every frame the clock gives, after React's own batching — nothing changes for an existing app, and the default path pays one property read per claim.

## Why

The PRD measured a `<Terminal backend="vt">` flood four times slower on the Cocoa backend than under XQuartz on the same machine — 60% of wall time in paint at 110 fps — and the whole gap was frame count × per-frame cost. The X11 frame is fenced by the server, so a flood self-paces to what the server can composite; the Cocoa clock is the display's period and every frame's pixel work runs on the JS thread, so the same flood paints every refresh and starves the producer that feeds it.

The PRD's own fix was a pacer inside the terminal element. Core is the right place: any UI that streams — dashboards, 3D, terminals — has the same problem, and the frame source is where the cost is known.

## How

- **A token bucket over paint time** (`src/pacing.js`), not a count of updates. Credit accrues at `budget` per ms of wall time up to a burst; a frame spends what it measurably cost — the flush, plus on macOS the present, which now reports its flip and catch-up copy back to the node; a claim that finds the bucket in debt waits for it to reach zero and no longer, clamped by a floor (`minFps`) and a ceiling (`maxFps`). Idle is immediate, cheap is unthrottled, one expensive frame among cheap ones is free (the one relayout in a blit-scrolled list — the scroll keeps 120Hz), and a flood that ends is un-throttled on its next claim. Sub-millisecond waits are carried as debt rather than armed.
- **Above both clocks.** `WindowNode._scheduleFrame` and `GlAreaNode.requestFrame` delay the `requestAnimationFrame` request; the clock still gates the frame. A held claim's damage accumulates as between two ticks; a click or key paints the window at once, held claims included (the discrete flush stands the wait down); a claim the frame raises on itself is priced by that frame. On macOS, `CocoaApp._requestFrame` arms the frame timer for a request that arrives between two pump ticks, so a wait lands at its wait rather than its wait rounded up to the pump.
- **`Node.opaqueRect()`** (PRD §6.1): an element that composites an opaque bitmap over its box says so, and a pass inside it skips the clear, the window's background and the backgrounds of the node and its ancestors — the fills the PRD priced at a fifth of the terminal's frame. Whole pixels, clipped by clipping ancestors (a rounded one by its radius), claimed as a rect inside the answer.
- **The typing gaps** (PRD §6, "found on the way"): `Context2D` is now the canvas-shaped subset both backends implement instead of `unknown`; `paintContent`, `paintCachePlan`, `paintCached` (with `PaintCachePlan`) and `opaqueRect` are declared on `Node`.

## Measured

`npm run bench:presenters -- --scenario=stream --columns=surface --frame-rate=…` — a window-sized element repainting its whole box on every claim, claimed every 2ms by a timer standing in for the producer. M1 Pro, 120Hz, 900×700 at 2×, 6s a cell:

| `--frame-rate` |   fps | flush avg | paint share of wall | cpu | producer: claims/s |
| -------------- | ----: | --------: | ------------------: | --: | -----------------: |
| `display`      | 120.0 |    4.84ms |                 58% | 72% |                244 |
| `adaptive`     |  36.1 |    5.79ms |                 21% | 27% |                529 |
| `30`           |  29.7 |    6.47ms |                 19% | 24% |                539 |
| `throughput`   |   8.8 |   10.26ms |                  9% | 13% |                592 |

The default starves its producer of half its ticks; `'adaptive'` holds paint at the budget and gives the producer all of them. The structural presenters gate runs at the default and is unchanged.

## Not here, and why (each a follow-up)

- **`globalCompositeOperation` + a memcpy `'copy'` on the Cocoa context** (§6.2) — #498: `@windowkit/appkit` 0.6.0 has no blend-mode verb, and its one memcpy, `copySurfaceRegion`, refuses surfaces of unequal size — both verbs are the bridge's to grow first. The property is declared optional on `Context2D` so an element asks rather than assumes.
- **Element-owned layer contents** (§6.4) — #499: the bridge has the primitives, but a layer showing an IOSurface the element draws into again tears; it needs a two-buffer surface of its own and the promotion policy extended. A design document first.
- **An adaptive tick-skip in the Cocoa clock** (§6.3's other half): not needed — with the pacer above the clock, a window holding a claim has no callback queued.

## Checks

- `npm test` (2056 pass; the six failures are the known macOS-only appearance-ladder ones, unchanged), `npm run lint`, `npm run format:check`, `npm run typecheck`.
- New: `test/pacing.test.js` (the rule under a fake clock), `test/frame-pacing.test.js` (the window: sources, the default, the flood, the discrete flush, unmount, the trace), `test/opaque-content.test.js` (the fills skipped are exactly those; a covered pass equals a full repaint, byte for byte), `<glarea>` pacing in `test/glarea.test.js`, the present cost and the prompt timer in `test/cocoa-frames.test.js`.
- Benches (`npm run bench:touched` owes all three for a `nodes.js` + `src/cocoa/` change): the X11 protocol gate — no regressions against the baseline; the pixel gate — unchanged; the Cocoa presenters gate — all 51 rules hold, run on a real display. The `stream` scenario is new and has no gate rule: it is a timing measurement, and the table above is its output.
