### PR TITLE
feat(cocoa): globalCompositeOperation on the 2d context, and a row memcpy for a surface composited at a translate

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1079,6 +1079,29 @@ one thing to know: a bitmap has one graphics state, so `getContext('2d')`
 there answers the same context every time and its `destroy()` is a no-op
 (docs/macos.md "Custom drawing on a layer tree").
 
+If the surface is **opaque** — every pixel of it written, which a terminal's
+grid or a tiled scene is — say so, and the present stops blending:
+
+```js
+paintContent(ctx) {
+  const box = this.contentBox();
+  ctx.globalCompositeOperation = 'copy';
+  ctx.drawImage(this.surface, box.x, box.y);
+  ctx.globalCompositeOperation = 'source-over';
+}
+```
+
+`copy` is canvas's "replace these pixels, do not read what is under them",
+and it means the same thing on both backends: XRender's `PictOp.Src` on
+X11, and on Cocoa a row memcpy in place of the CGImage the blend would
+otherwise be built from — a 125x45 terminal grid composites in 0.42ms
+rather than 1.37 (docs/macos.md "Compositing a surface at a translate").
+Set it back, or set it inside a `save`/`restore` pair: it is context state,
+and the context is the window's. It is only right for a surface with no
+transparency to show through, and it is refused rather than approximated by
+a backend that cannot draw it — assign it and read the property back if you
+want to know which you got.
+
 Two things it lines up with. The deltas you are handed are already whole
 pixels — the sub-pixel carry described above exists so that a shift is
 always expressible — so an element scrolling this way never has a fraction

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -937,6 +937,79 @@ paint nothing measurable (20,000 rounded-rect fill+strokes: 601ms before,
 and the record is what puts the whole path back if a `fill`, a `clip` or
 more path building follows a stroke that consumed it. `test/cocoa-stroke-chunking.test.js`.
 
+### Compositing a surface at a translate
+
+An element that owns a surface presents it every frame: the terminal's
+grid, a retained scene, anything that rasters once and shows the result
+many times. `ctx.drawImage(surface, x, y)` is how it says so, and on this
+backend that was `CGBitmapContextCreateImage` of the whole source plus
+`CGContextDrawImage` — a CGImage built and a blend run, every frame, for
+pixels that were only ever going to be copied. In
+sidorares/react-x11-components#69 §6's profile it is 1.7ms of a 6ms
+`<Terminal backend="vt">` frame, the second-largest line after the cell
+background fills.
+
+The context takes canvas's own way of saying "do not blend, replace" —
+
+```js
+ctx.globalCompositeOperation = 'copy';
+ctx.drawImage(surface, x, y);
+```
+
+— and, where that is all it is, sends the composite as a row memcpy
+(`blitSurface`) instead. `scripts/cocoa-composite-probe.mjs` prices the
+two routes against the real bridge; on an M1 Pro, 200 composites a cell:
+
+| source          | destination       | CGImage draw |  memcpy |
+| --------------- | ----------------- | -----------: | ------: |
+| 125×45 grid @2x | the whole surface |       1.37ms |  0.42ms |
+| 125×45 grid @2x | a third of it     |       0.36ms |  0.14ms |
+| 125×45 grid @2x | one row's damage  |      0.033ms | 0.012ms |
+| 80×24 grid @2x  | the whole surface |       0.35ms |  0.18ms |
+
+`globalCompositeOperation` itself is `ctxSetBlendMode`, and the vocabulary
+is the **bridge's** rather than a table kept on this side: the names are
+canvas's own, and the verb answers whether the mode is now the one asked
+for. So this backend never goes stale against a bridge that grows an op,
+and never claims one it would not draw. 0.7.0 knows the whole canvas set
+— the Porter-Duff ops ntk maps to XRender's, plus the separable and
+non-separable blend modes CoreGraphics has and XRender does not, which a
+caller reaching for `multiply` should know are macOS-only until ntk grows
+them. Two things about it are worth knowing. A bridge without the verb —
+anything before 0.7.0 — **refuses** everything but `source-over` rather
+than accepting it and drawing something else, so the detection a caller
+writes is canvas's own: assign, then read the property back. An op
+applies inside what the draw covers rather than across the whole surface —
+a browser's `copy` clears everything the drawing missed, where
+`kCGBlendModeCopy` and XRender's `Src` both leave it alone, so the two
+backends agree with each other and differ from a browser together. And the
+`op` argument a `drawGlyphs` call carries is still ignored; text composites
+through the context's mode like everything else.
+
+The blit is an optimization and never a difference, so every way the
+memcpy would not be exactly what the draw produces turns it off and the
+draw happens: an op other than `copy`, a transform that is not a
+whole-pixel translate, a `globalAlpha` below 1, a live shadow, a
+destination size that differs from the source's, a fractional source
+rect, and a surface composited into itself.
+
+The clip is the interesting one. A memcpy cannot see a CGContext's clip,
+and a paint pass is clipped to its damage rect — so the context tracks
+the clip **as a rect** beside the CTM it already tracked, and hands it to
+the verb. It tracks only what it can state exactly: a single `rect` path
+under an axis-aligned transform landing on whole pixels. A rounded
+corner, an arc, a polygon, two rects, a half-pixel edge or a rotation all
+resolve to "there is a clip and I cannot name it", which turns the blit
+off until a `restore()` pops back past it. The clips a paint pass
+actually sets — the damage rect, a square-cornered `overflow` — are the
+ones it recognises.
+
+`test/cocoa-composite.test.js` pins both halves: the decisions over a
+fake bridge — including a bridge with neither verb and one whose
+vocabulary is smaller, which is what the feature detection is for — in
+CI, and, where the real bridge loads, that the blit and the draw are
+pixel-identical.
+
 ## Animations and transforms: the API the model unlocks
 
 The existing declarative vocabulary is the seam: `transition:` and
@@ -1341,10 +1414,13 @@ write pixels ✅, hand to a layer as contents without a copy ✅
 (`createSurfaceIOSurface` + `setLayerContentsIOSurface`), draw one
 surface into another ✅ (`ctxDrawSurface`), shift a band in place ✅
 (`scrollSurface`), copy rects between same-size surfaces ✅
-(`copySurfaceRegion`). Still 🆕: a pattern fill (`createPattern`, which
-`<Flow>`'s grid tiles ask for), radial gradients, a blend op for
-`PictOp.Src`, and an explicit free (a surface goes with its handle's
-finalizer). The alternative — rasterize JS-side and use the raw-buffer
+(`copySurfaceRegion`), the blend mode a `globalCompositeOperation` sets ✅
+(`ctxSetBlendMode`, 0.7.0) and a row memcpy between surfaces of any two
+sizes ✅ (`blitSurface`, 0.7.0 — issue #498; the context feature-detects
+both, so an older bridge draws every composite as a CGImage under
+source-over). Still 🆕: a pattern fill (`createPattern`,
+which `<Flow>`'s grid tiles ask for), radial gradients, and an explicit
+free (a surface goes with its handle's finalizer). The alternative — rasterize JS-side and use the raw-buffer
 upload — stays open; the API supports both so the choice can be
 measured.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "node": ">=20.19"
       },
       "optionalDependencies": {
-        "@windowkit/appkit": "^0.6.0",
+        "@windowkit/appkit": "^0.7.0",
         "dbus-native": "^0.15.1",
         "x11-dri": "^0.7.0"
       },
@@ -1515,9 +1515,9 @@
       }
     },
     "node_modules/@windowkit/appkit": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@windowkit/appkit/-/appkit-0.6.0.tgz",
-      "integrity": "sha512-T9zZhODZYhsciVx3IeZHrhKzX+BM7rbBXgr+XbaXYt1v0VROxbQ7lqSEmiocIs21jod3NsjLhyw59i9MCkbUPw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@windowkit/appkit/-/appkit-0.7.0.tgz",
+      "integrity": "sha512-1QKY2juGtM4Fbvp2yrvmbxJuSwfpX/WoQpcD5aImo+astaWG8VURG3OhfT7zD8eFshc2f9aiQ18LULzJXA2KFA==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "yoga-layout": "^3.2.1"
   },
   "optionalDependencies": {
-    "@windowkit/appkit": "^0.6.0",
+    "@windowkit/appkit": "^0.7.0",
     "dbus-native": "^0.15.1",
     "x11-dri": "^0.7.0"
   },

--- a/scripts/cocoa-composite-probe.mjs
+++ b/scripts/cocoa-composite-probe.mjs
@@ -1,0 +1,128 @@
+// What the memcpy `copy` is worth, against the real Cocoa bridge (issue #498).
+//
+// `test/cocoa-composite.test.js` pins the invariant — the blit and the
+// CGImage draw are the same picture — over a fake bridge in CI and over the
+// real one where it loads. This is the other question, the one a test
+// cannot answer: how much time the two routes actually cost, on this
+// machine, at the sizes an element compositing a surface of its own works
+// at.
+//
+//   node scripts/cocoa-composite-probe.mjs [iterations]
+//
+// The shape measured is `<Terminal backend="vt">`'s present
+// (sidorares/react-x11-components#69 §6): a grid-sized surface composited
+// into the window at a translate, every frame. Three destinations per size
+// — the whole surface, a one-row damage rect, and a third of the grid —
+// since a paint pass is clipped to its damage and the clip is the argument
+// the blit needs to be given.
+//
+// Requires @windowkit/appkit 0.7.0 or newer, where `ctxSetBlendMode` and
+// `blitSurface` arrived; on a bridge without them it says so and exits,
+// since the fallback is what it would otherwise be measuring twice.
+import { CocoaContext2D } from '../src/cocoa/context2d.js';
+import { loadNative } from '../src/cocoa/native.js';
+
+const ITERATIONS = Number(process.argv[2] ?? 200);
+
+let bridge;
+try {
+  bridge = loadNative();
+} catch (err) {
+  console.error(err.message);
+  process.exit(1);
+}
+for (const verb of ['ctxSetBlendMode', 'blitSurface']) {
+  if (typeof bridge[verb] !== 'function') {
+    console.error(
+      `this @windowkit/appkit has no ${verb}() — nothing to compare against.\n` +
+        'Point REACT_X11_CALAYERS_PATH at a build that has it.',
+    );
+    process.exit(1);
+  }
+}
+
+/** A grid of cells, drawn once — the terminal's surface between presents. */
+function grid(cols, rows, cw, ch) {
+  const surface = bridge.createSurface(cols * cw, rows * ch, 2);
+  const ctx = new CocoaContext2D(
+    bridge,
+    () => surface,
+    () => 1,
+  );
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      const t = ((r * cols + c) % 16) / 16;
+      ctx.fillStyle = `rgb(${20 + t * 200}, ${40 + t * 120}, ${60 + t * 90})`;
+      ctx.fillRect(c * cw, r * ch, cw, ch);
+    }
+  }
+  return { surface, width: cols * cw, height: rows * ch };
+}
+
+/** `fn` per iteration, in milliseconds, the best of three sweeps — a
+ *  composite is a memory-bound loop and the machine's other tenants only
+ *  ever add to it. */
+function time(fn) {
+  let best = Infinity;
+  for (let sweep = 0; sweep < 3; sweep++) {
+    fn(); // warm
+    const t0 = performance.now();
+    for (let i = 0; i < ITERATIONS; i++) fn();
+    best = Math.min(best, (performance.now() - t0) / ITERATIONS);
+  }
+  return best;
+}
+
+const SIZES = [
+  { label: '125x45 @2x (the PRD grid)', cols: 125, rows: 45, cw: 16, ch: 36 },
+  { label: '80x24 @2x', cols: 80, rows: 24, cw: 16, ch: 36 },
+  { label: '125x45 @1x', cols: 125, rows: 45, cw: 8, ch: 18 },
+];
+
+console.log(`${ITERATIONS} composites per cell, best of 3 sweeps\n`);
+const rows = [];
+for (const size of SIZES) {
+  const src = grid(size.cols, size.rows, size.cw, size.ch);
+  const dst = bridge.createSurface(src.width + 64, src.height + 96, 2);
+  const damages = [
+    { label: 'whole', rect: null },
+    { label: 'one row', rect: [0, 0, src.width, size.ch] },
+    { label: 'a third', rect: [0, 0, src.width, Math.round(src.height / 3)] },
+  ];
+  for (const damage of damages) {
+    const run = (blits) => {
+      const native = blits
+        ? bridge
+        : new Proxy(bridge, {
+            get: (t, k) => (k === 'blitSurface' ? undefined : t[k]),
+          });
+      const ctx = new CocoaContext2D(
+        native,
+        () => dst,
+        () => 1,
+      );
+      ctx.globalCompositeOperation = 'copy';
+      return () => {
+        ctx.save();
+        ctx.translate(32, 48);
+        if (damage.rect) {
+          ctx.beginPath();
+          ctx.rect(...damage.rect);
+          ctx.clip();
+        }
+        ctx.drawImage({ _surfaceHandle: src.surface }, 0, 0);
+        ctx.restore();
+      };
+    };
+    const drawn = time(run(false));
+    const blitted = time(run(true));
+    rows.push({
+      size: size.label,
+      damage: damage.label,
+      'CGImage draw (ms)': drawn.toFixed(3),
+      'memcpy (ms)': blitted.toFixed(3),
+      saved: `${(100 * (1 - blitted / drawn)).toFixed(0)}%`,
+    });
+  }
+}
+console.table(rows);

--- a/src/cocoa/context2d.js
+++ b/src/cocoa/context2d.js
@@ -85,12 +85,22 @@ const clamp01 = (v) => Math.min(1, Math.max(0, Number(v) || 0));
 /**
  * The Render ops text draws with, numbered as XRender numbers them so a
  * caller's `ctx.Render?.PictOp?.Over ?? 3` reads the same on both
- * backends. Every op draws as Over here: the bridge composites glyph
- * coverage with the context's fill and offers no blend-mode switch, and
- * for the opaque inks text uses Src and Over agree.
+ * backends. The `op` a `drawGlyphs` call names is ignored here: the bridge
+ * composites glyph coverage with the context's fill through the context's
+ * own blend mode — `globalCompositeOperation`, below — and for the opaque
+ * inks text uses Src and Over agree.
  */
 const PICT_OP = Object.freeze({ Src: 1, Over: 3 });
 const RENDER = Object.freeze({ PictOp: PICT_OP });
+
+/**
+ * `_state.clip` when the clip in force is not one this class can name — a
+ * rounded corner, a glyph, an arc, or a rect under a rotation. Null means
+ * nothing is clipped and a rect means that rect, in surface pixels; this
+ * means "there is one and I cannot tell you where", which is the answer
+ * that turns the memcpy blit off (see `_blit`).
+ */
+const NON_RECT = Symbol('non-rectangular clip');
 
 /**
  * The path, recorded alongside the native one, so `stroke` can re-issue it
@@ -189,7 +199,18 @@ export class CocoaContext2D {
       shadowOffsetY: 0,
       shadowColor: 'rgba(0,0,0,0)',
       ctm: [1, 0, 0, 1, 0, 0],
+      gco: 'source-over',
+      // null: nothing clipped. A rect (surface pixels): that rect. NON_RECT:
+      // a clip this class cannot name.
+      clip: null,
     };
+    // What this bridge can do, asked once. Both verbs arrived together in
+    // @windowkit/appkit 0.7.0, and anything older is a bridge that draws
+    // every composite as `source-over` through a CGImage — so the property
+    // refuses what it cannot honour rather than lying about it, and the
+    // blit path is simply never taken.
+    this._blendModes = typeof native.ctxSetBlendMode === 'function';
+    this._blits = typeof native.blitSurface === 'function';
     this._onDirty = null;
     // the recorded path, and whether the native one still matches it (a
     // chunked stroke leaves only its last chunk behind)
@@ -211,6 +232,13 @@ export class CocoaContext2D {
       n.ctxSetLineJoin(surface, st.lineJoin);
       n.ctxSetGlobalAlpha(surface, st.globalAlpha);
       n.ctxSetLineDash(surface, st.dash, st.dashOffset);
+      // a fresh surface is already at source-over, so only a context
+      // holding another op has anything to say
+      if (this._blendModes && st.gco !== 'source-over') {
+        n.ctxSetBlendMode(surface, st.gco);
+      }
+      // a fresh surface is unclipped, whatever the old one had in force
+      st.clip = null;
       this._stack.length = 0;
       // the path went with the surface it was built on; nothing may
       // replay it onto the new one
@@ -280,6 +308,47 @@ export class CocoaContext2D {
       this._state.globalAlpha = value;
       this._native.ctxSetGlobalAlpha(this._s(), value);
     }
+  }
+
+  get globalCompositeOperation() {
+    return this._state.gco;
+  }
+
+  /**
+   * The vocabulary is the **bridge's**, not a table kept here: the names are
+   * canvas's own, `ctxSetBlendMode` answers false for one it does not have,
+   * and that answer is what decides whether the assignment sticks. So this
+   * class never goes stale against a bridge that grows an op, and never
+   * claims one it would not actually draw.
+   *
+   * Which makes the detection a caller writes canvas's own — an unknown
+   * value is *ignored* there too, leaving the op in force — so the way to
+   * ask is to assign and read back:
+   *
+   *     ctx.globalCompositeOperation = 'copy';
+   *     if (ctx.globalCompositeOperation === 'copy') { ... }
+   *
+   * A bridge with no `ctxSetBlendMode` at all — @windowkit/appkit before
+   * 0.7.0 — draws everything as source-over, so source-over is the one
+   * value that sticks on it. That is exactly true rather than a fallback.
+   *
+   * One divergence from a browser, shared with ntk and so the same on both
+   * backends: an op applies inside what the draw covers, not across the
+   * whole surface. A browser's `copy` clears everything the drawing missed;
+   * `kCGBlendModeCopy` and XRender's `Src` both leave it alone.
+   */
+  set globalCompositeOperation(value) {
+    if (typeof value !== 'string') return;
+    if (!this._blendModes) {
+      if (value === 'source-over') this._state.gco = value;
+      return;
+    }
+    // false is the bridge saying it left its own mode alone; anything else
+    // means the mode is now `value`, and the two must not drift — a JS state
+    // ahead of the native one would take the memcpy path in `_blit` for a
+    // composite the fallback draw would have blended.
+    if (this._native.ctxSetBlendMode(this._s(), value) === false) return;
+    this._state.gco = value;
   }
 
   /**
@@ -776,7 +845,68 @@ export class CocoaContext2D {
     ) {
       return;
     }
+    this._state.clip = this._clipAfter();
     this._native.ctxClip(this._path());
+  }
+
+  /**
+   * The current path as a whole-pixel rect in surface coordinates, or null
+   * for anything else. CoreGraphics owns the real clip and this is only a
+   * shadow of it, kept for the one caller that draws *around* the context —
+   * `_blit`, whose memcpy cannot see a CGContext's clip at all.
+   *
+   * So the answer has to be exact, never merely close: a rect that does not
+   * land on whole pixels is refused rather than rounded, because rounding
+   * out would copy pixels the clip excludes and rounding in would leave a
+   * seam of whatever the destination held. The clips a paint pass actually
+   * sets — the damage rect, a scroll viewport, a square-cornered `overflow`
+   * — are whole pixels under a translate, and those are the ones this
+   * recognises.
+   */
+  _pathRect() {
+    const cmds = this._cmds;
+    if (cmds.length !== 5 || cmds[0] !== P_RECT) return null;
+    const [, x, y, w, h] = cmds;
+    const [a, b, c, d, e, f] = this._state.ctm;
+    if (b !== 0 || c !== 0) return null; // rotated or skewed: not a rect here
+    const x0 = a * x + e;
+    const y0 = d * y + f;
+    const x1 = a * (x + w) + e;
+    const y1 = d * (y + h) + f;
+    const rect = {
+      x: Math.min(x0, x1),
+      y: Math.min(y0, y1),
+      width: Math.abs(x1 - x0),
+      height: Math.abs(y1 - y0),
+    };
+    for (const v of [rect.x, rect.y, rect.width, rect.height]) {
+      if (!Number.isInteger(v)) return null;
+    }
+    return rect;
+  }
+
+  /** The clip `clip()` is about to leave in force: the current one
+   *  intersected with the path, or NON_RECT as soon as either is one. */
+  _clipAfter() {
+    const current = this._state.clip;
+    if (current === NON_RECT) return NON_RECT;
+    const rect = this._pathRect();
+    if (!rect) return NON_RECT;
+    if (!current) return rect;
+    const x = Math.max(current.x, rect.x);
+    const y = Math.max(current.y, rect.y);
+    return {
+      x,
+      y,
+      width: Math.max(
+        0,
+        Math.min(current.x + current.width, rect.x + rect.width) - x,
+      ),
+      height: Math.max(
+        0,
+        Math.min(current.y + current.height, rect.y + rect.height) - y,
+      ),
+    };
   }
 
   fillRect(x, y, w, h) {
@@ -843,8 +973,94 @@ export class CocoaContext2D {
       dw = sw;
       dh = sh;
     }
-    this._native.ctxDrawSurface(this._s(), src, sx, sy, sw, sh, dx, dy, dw, dh);
+    if (!this._blit(src, sx, sy, sw, sh, dx, dy, dw, dh)) {
+      this._native.ctxDrawSurface(
+        this._s(),
+        src,
+        sx,
+        sy,
+        sw,
+        sh,
+        dx,
+        dy,
+        dw,
+        dh,
+      );
+    }
     this._dirty();
+  }
+
+  /**
+   * `drawImage` as a row memcpy, for the one shape where a copy is all it
+   * ever was: a surface composited into another at a translate, whole
+   * pixels, same size in as out, under `globalCompositeOperation = 'copy'`.
+   * Answers false for everything else, and the caller draws.
+   *
+   * That shape is what an element with a surface of its own presents every
+   * frame — a terminal's grid, a retained scene — and the CoreGraphics
+   * route to it is `CGBitmapContextCreateImage` of the whole source plus
+   * `CGContextDrawImage`: 1.7ms of a 6ms frame for a 125x45 terminal, where
+   * the memcpy is 1.0 (sidorares/react-x11-components#69 §6). The saving is
+   * per frame rather than per flood, which is why the frame pacer (#497)
+   * had to land first for it to be worth anything.
+   *
+   * Every condition below is a way the memcpy would differ from the draw,
+   * and a difference is a bug rather than a slower frame — so each is a
+   * refusal, never a fixup:
+   *
+   * - **the op.** Only `copy` writes the source over the destination
+   *   without reading it. `source-over` is a blend, and blending is what
+   *   CoreGraphics is for.
+   * - **the transform.** A pure translate at whole pixels. A scale or a
+   *   rotation resamples; a fractional offset resamples too (surfaces are
+   *   created with `kCGInterpolationMedium`).
+   * - **`globalAlpha`, and a shadow.** Both are things `CGContextDrawImage`
+   *   does to the source on its way down that a memcpy does not do at all.
+   * - **the clip.** A memcpy cannot see a CGContext's clip, so the rect it
+   *   copies is intersected with the one this class tracked — and a clip it
+   *   could not track (NON_RECT) means it does not know, so it draws.
+   * - **the same surface twice.** Overlapping memcpy rows have no defined
+   *   result. The check here is on the handle; the bridge's is on the
+   *   backing store, which also catches two handles onto one bitmap — the
+   *   two ends of a shared IOSurface — and throws rather than corrupting it.
+   */
+  _blit(src, sx, sy, sw, sh, dx, dy, dw, dh) {
+    if (!this._blits) return false;
+    const st = this._state;
+    if (st.gco !== 'copy') return false;
+    if (st.clip === NON_RECT) return false;
+    if (st.globalAlpha < 1) return false;
+    if (st.shadowBlur > 0 && parseColor(st.shadowColor)[3] > 0) return false;
+    if (sw !== dw || sh !== dh) return false;
+    const [a, b, c, d, e, f] = st.ctm;
+    if (a !== 1 || b !== 0 || c !== 0 || d !== 1) return false;
+    const x = dx + e;
+    const y = dy + f;
+    if (
+      !Number.isInteger(x) ||
+      !Number.isInteger(y) ||
+      !Number.isInteger(sx) ||
+      !Number.isInteger(sy) ||
+      !Number.isInteger(sw) ||
+      !Number.isInteger(sh)
+    ) {
+      return false;
+    }
+    const dst = this._s();
+    if (dst === src) return false;
+    const clip = st.clip;
+    this._native.blitSurface(
+      src,
+      sx,
+      sy,
+      sw,
+      sh,
+      dst,
+      x,
+      y,
+      clip ? [clip.x, clip.y, clip.width, clip.height] : null,
+    );
+    return true;
   }
 
   /**

--- a/test/cocoa-composite.test.js
+++ b/test/cocoa-composite.test.js
@@ -1,0 +1,530 @@
+// `globalCompositeOperation` on the Cocoa context, and the row memcpy the
+// `copy` op unlocks for a surface composited at a translate (issue #498).
+//
+// Two layers, as elsewhere in the Cocoa tests. The first runs everywhere: a
+// fake bridge records what reaches the natives, which is the whole of what
+// the JS decides — including what it decides when the bridge is an older
+// @windowkit/appkit with neither verb, since that is what feature detection
+// is for. The second runs where the bridge loads and ends in pixels, where
+// the only thing worth pinning is that the blit and the draw agree.
+import assert from 'node:assert';
+import { describe, test } from 'node:test';
+
+import { CocoaContext2D } from '../src/cocoa/context2d.js';
+import { loadNative } from '../src/cocoa/native.js';
+
+/**
+ * A bridge shaped like @windowkit/appkit's surface natives. `verbs: false`
+ * is anything before 0.7.0, which has neither `ctxSetBlendMode` nor
+ * `blitSurface`; `vocabulary` is the set of ops the blend verb claims, so a
+ * test can also be a bridge that knows fewer than this one does.
+ */
+const CANVAS_OPS = [
+  'source-over',
+  'copy',
+  'destination-over',
+  'source-in',
+  'destination-in',
+  'source-out',
+  'destination-out',
+  'source-atop',
+  'destination-atop',
+  'xor',
+  'lighter',
+  'multiply',
+];
+
+function fakeNative({ verbs = true, vocabulary = new Set(CANVAS_OPS) } = {}) {
+  const calls = [];
+  let seq = 0;
+  const native = {
+    calls,
+    of: (name) => calls.filter((c) => c[0] === name).map((c) => c.slice(1)),
+    createSurface(width, height, scale) {
+      return { id: ++seq, width, height, scale };
+    },
+    surfaceSize: (handle) => ({ width: handle.width, height: handle.height }),
+    ctxDrawSurface(dst, src, ...rest) {
+      calls.push(['ctxDrawSurface', dst.id, src.id, ...rest]);
+    },
+    ctxRect(handle, ...rect) {
+      calls.push(['ctxRect', ...rect]);
+    },
+    ctxClip() {
+      calls.push(['ctxClip']);
+    },
+    ctxSave() {
+      calls.push(['ctxSave']);
+    },
+    ctxRestore() {
+      calls.push(['ctxRestore']);
+    },
+  };
+  if (verbs) {
+    // @windowkit/appkit 0.7.0's contract: the names are canvas's own, and
+    // the answer is whether the mode is now that one. `vocabulary` is what
+    // this bridge claims to know, so a test can be a bridge that knows less.
+    native.ctxSetBlendMode = (handle, mode) => {
+      calls.push(['ctxSetBlendMode', mode]);
+      return vocabulary.has(mode);
+    };
+    native.blitSurface = (src, sx, sy, w, h, dst, dx, dy, clip) =>
+      calls.push(['blitSurface', src.id, sx, sy, w, h, dst.id, dx, dy, clip]);
+  }
+  // Everything else the context syncs is a no-op — but the two verbs this
+  // is about are exactly what the context feature-detects, so a bridge
+  // without them has to answer undefined rather than a no-op function.
+  const absent = new Set(verbs ? [] : ['ctxSetBlendMode', 'blitSurface']);
+  return new Proxy(native, {
+    get: (target, key) =>
+      absent.has(key)
+        ? undefined
+        : key in target
+          ? target[key]
+          : () => undefined,
+  });
+}
+
+/** A context over a fresh 200x100 destination, and a 40x20 source to draw. */
+function context(options) {
+  const native = fakeNative(options);
+  const dst = native.createSurface(200, 100, 1);
+  const src = native.createSurface(40, 20, 1);
+  const ctx = new CocoaContext2D(
+    native,
+    () => dst,
+    () => 1,
+  );
+  native.calls.length = 0;
+  return { ctx, native, dst, src: { _surfaceHandle: src } };
+}
+
+/** The one blit a test expects, as [sx, sy, w, h, dx, dy, clip]. */
+const blit = (native) => {
+  const calls = native.of('blitSurface');
+  assert.equal(calls.length, 1, `${calls.length} blits`);
+  const [, sx, sy, w, h, , dx, dy, clip] = calls[0];
+  return [sx, sy, w, h, dx, dy, clip];
+};
+const drew = (native) => native.of('ctxDrawSurface').length;
+
+// --- the property -------------------------------------------------------------
+
+test('the default is source-over, and it goes nowhere near the bridge', () => {
+  const { ctx, native } = context();
+  assert.equal(ctx.globalCompositeOperation, 'source-over');
+  assert.equal(native.of('ctxSetBlendMode').length, 0);
+});
+
+test('the op goes to the bridge as canvas spells it — there is no table here', () => {
+  const { ctx, native } = context();
+  for (const op of CANVAS_OPS) ctx.globalCompositeOperation = op;
+  assert.deepEqual(
+    native.of('ctxSetBlendMode').map(([mode]) => mode),
+    CANVAS_OPS,
+  );
+  assert.equal(ctx.globalCompositeOperation, 'multiply');
+});
+
+test('an op the bridge refuses leaves the one in force, as canvas does', () => {
+  // the bridge answering false is the whole mechanism: it left its own mode
+  // alone, so this must leave its own state alone too
+  const { ctx, native } = context({
+    vocabulary: new Set(['source-over', 'copy']),
+  });
+  ctx.globalCompositeOperation = 'copy';
+  native.calls.length = 0;
+  for (const bad of ['xor', 'multiply', 'Copy', '', 'banana']) {
+    ctx.globalCompositeOperation = bad;
+    assert.equal(ctx.globalCompositeOperation, 'copy', String(bad));
+  }
+  assert.equal(native.of('ctxSetBlendMode').length, 5, 'each one was asked');
+});
+
+test('a value that is not a string never reaches the bridge', () => {
+  const { ctx, native } = context();
+  ctx.globalCompositeOperation = 'copy';
+  native.calls.length = 0;
+  for (const bad of [null, undefined, 3, {}]) {
+    ctx.globalCompositeOperation = bad;
+    assert.equal(ctx.globalCompositeOperation, 'copy', String(bad));
+  }
+  assert.equal(native.of('ctxSetBlendMode').length, 0);
+});
+
+test('on a bridge without the verb only source-over sticks — read it back', () => {
+  const { ctx, native } = context({ verbs: false });
+  ctx.globalCompositeOperation = 'copy';
+  assert.equal(ctx.globalCompositeOperation, 'source-over');
+  ctx.globalCompositeOperation = 'source-over';
+  assert.equal(ctx.globalCompositeOperation, 'source-over');
+  assert.equal(native.of('ctxSetBlendMode').length, 0);
+});
+
+test('save/restore carries the op, and a replaced surface is re-synced', () => {
+  const { ctx, native } = context();
+  ctx.globalCompositeOperation = 'copy';
+  ctx.save();
+  ctx.globalCompositeOperation = 'xor';
+  ctx.restore();
+  // the JS state is back; the native gstate came back with ctxRestore
+  assert.equal(ctx.globalCompositeOperation, 'copy');
+
+  let gen = 1;
+  const surface = native.createSurface(8, 8, 1);
+  const fresh = new CocoaContext2D(
+    native,
+    () => surface,
+    () => gen,
+  );
+  fresh.globalCompositeOperation = 'copy';
+  native.calls.length = 0;
+  gen = 2;
+  fresh.fillRect(0, 0, 1, 1);
+  assert.deepEqual(native.of('ctxSetBlendMode'), [['copy']]);
+  assert.equal(fresh.globalCompositeOperation, 'copy');
+});
+
+// --- the blit -----------------------------------------------------------------
+
+test("under 'copy' at a whole-pixel translate the composite is a memcpy", () => {
+  const { ctx, native, src } = context();
+  ctx.globalCompositeOperation = 'copy';
+  ctx.translate(30, 12);
+  ctx.drawImage(src, 5, 7);
+  assert.deepEqual(blit(native), [0, 0, 40, 20, 35, 19, null]);
+  assert.equal(drew(native), 0);
+});
+
+test('a source rect draws that rect, and the size may be named twice', () => {
+  const { ctx, native, src } = context();
+  ctx.globalCompositeOperation = 'copy';
+  ctx.drawImage(src, 4, 6, 10, 8, 100, 50, 10, 8);
+  assert.deepEqual(blit(native), [4, 6, 10, 8, 100, 50, null]);
+  ctx.drawImage(src, 1, 2, 40, 20);
+  const [, sx, sy, w, hh, , dx, dy] = native.of('blitSurface')[1];
+  assert.deepEqual([sx, sy, w, hh, dx, dy], [0, 0, 40, 20, 1, 2]);
+});
+
+test('the paint still reports its damage — the blit is not a side door', () => {
+  const { ctx, src } = context();
+  let dirty = 0;
+  ctx._onDirty = () => dirty++;
+  ctx.globalCompositeOperation = 'copy';
+  ctx.drawImage(src, 0, 0);
+  ctx.globalCompositeOperation = 'source-over';
+  ctx.drawImage(src, 0, 0);
+  assert.equal(dirty, 2);
+});
+
+test('a bridge without blitSurface draws every time', () => {
+  const { ctx, native, src } = context({ verbs: false });
+  ctx.globalCompositeOperation = 'copy';
+  ctx.drawImage(src, 10, 10);
+  assert.equal(native.of('blitSurface').length, 0);
+  assert.equal(drew(native), 1);
+});
+
+describe('what makes it draw instead', () => {
+  /** Sets up a `copy` blit, lets `set` spoil it, and asks who drew. */
+  const spoiled = (set) => {
+    const { ctx, native, src } = context();
+    ctx.globalCompositeOperation = 'copy';
+    set(ctx, src, native);
+    ctx.drawImage(src, 10, 10);
+    return { blits: native.of('blitSurface').length, draws: drew(native) };
+  };
+  const drawsInstead = (name, set) =>
+    test(name, () => assert.deepEqual(spoiled(set), { blits: 0, draws: 1 }));
+
+  drawsInstead('source-over — a blend is what CoreGraphics is for', (ctx) => {
+    ctx.globalCompositeOperation = 'source-over';
+  });
+  drawsInstead('a scale — the draw resamples and the memcpy cannot', (ctx) => {
+    ctx.scale(2, 2);
+  });
+  drawsInstead('a rotation', (ctx) => ctx.rotate(Math.PI / 2));
+  drawsInstead('a fractional translate', (ctx) => ctx.translate(0.5, 0));
+  drawsInstead('globalAlpha below 1', (ctx) => {
+    ctx.globalAlpha = 0.99;
+  });
+  drawsInstead('a shadow that would ink', (ctx) => {
+    ctx.shadowBlur = 4;
+    ctx.shadowColor = '#000';
+  });
+  test('a shadow set to a transparent colour still blits', () => {
+    assert.deepEqual(
+      spoiled((ctx) => {
+        ctx.shadowBlur = 4;
+      }),
+      { blits: 1, draws: 0 },
+    );
+  });
+  test('a scaled destination rect draws; the same size blits', () => {
+    const { ctx, native, src } = context();
+    ctx.globalCompositeOperation = 'copy';
+    ctx.drawImage(src, 0, 0, 40, 20, 0, 0, 80, 40);
+    assert.equal(drew(native), 1);
+    assert.equal(native.of('blitSurface').length, 0);
+  });
+  test('a fractional source rect draws — a half pixel has no row', () => {
+    const { ctx, native, src } = context();
+    ctx.globalCompositeOperation = 'copy';
+    ctx.drawImage(src, 0.5, 0, 10, 8, 0, 0, 10, 8);
+    assert.equal(drew(native), 1);
+  });
+  test('a surface composited into itself draws', () => {
+    const { ctx, native, dst } = context();
+    ctx.globalCompositeOperation = 'copy';
+    ctx.drawImage({ _surfaceHandle: dst }, 0, 0);
+    assert.equal(native.of('blitSurface').length, 0);
+    assert.equal(drew(native), 1);
+  });
+});
+
+// --- the clip -----------------------------------------------------------------
+
+/** The clip a paint pass sets: `beginPath` + `rect` + `clip`. */
+function clipTo(ctx, x, y, w, h) {
+  ctx.beginPath();
+  ctx.rect(x, y, w, h);
+  ctx.clip();
+}
+
+describe('the clip a memcpy cannot see', () => {
+  test('a rect clip rides along as the rect the blit is held to', () => {
+    const { ctx, native, src } = context();
+    ctx.globalCompositeOperation = 'copy';
+    clipTo(ctx, 20, 10, 100, 40);
+    ctx.drawImage(src, 0, 0);
+    assert.deepEqual(blit(native)[6], [20, 10, 100, 40]);
+  });
+
+  test('the clip is in surface pixels: the transform is applied to it', () => {
+    const { ctx, native, src } = context();
+    ctx.globalCompositeOperation = 'copy';
+    ctx.translate(8, 4);
+    clipTo(ctx, 20, 10, 100, 40);
+    ctx.drawImage(src, 0, 0);
+    const [, , , , dx, dy, clip] = blit(native);
+    assert.deepEqual([dx, dy], [8, 4]);
+    assert.deepEqual(clip, [28, 14, 100, 40]);
+  });
+
+  test('two clips intersect, and a restore brings the outer one back', () => {
+    const { ctx, native, src } = context();
+    ctx.globalCompositeOperation = 'copy';
+    clipTo(ctx, 20, 10, 100, 40);
+    ctx.save();
+    clipTo(ctx, 60, 0, 100, 30);
+    ctx.drawImage(src, 0, 0);
+    assert.deepEqual(blit(native)[6], [60, 10, 60, 20]);
+    ctx.restore();
+    ctx.drawImage(src, 0, 0);
+    assert.deepEqual(native.of('blitSurface')[1][8], [20, 10, 100, 40]);
+  });
+
+  test('clips that do not meet leave an empty rect, not a wrong one', () => {
+    const { ctx, native, src } = context();
+    ctx.globalCompositeOperation = 'copy';
+    clipTo(ctx, 0, 0, 10, 10);
+    clipTo(ctx, 50, 50, 10, 10);
+    ctx.drawImage(src, 0, 0);
+    assert.deepEqual(blit(native)[6], [50, 50, 0, 0]);
+  });
+
+  test('a surface replaced under the context takes the clip with it', () => {
+    const native = fakeNative();
+    let gen = 1;
+    let surface = native.createSurface(200, 100, 1);
+    const ctx = new CocoaContext2D(
+      native,
+      () => surface,
+      () => gen,
+    );
+    const src = { _surfaceHandle: native.createSurface(40, 20, 1) };
+    ctx.globalCompositeOperation = 'copy';
+    clipTo(ctx, 0, 0, 10, 10);
+    surface = native.createSurface(200, 100, 1);
+    gen = 2;
+    native.calls.length = 0;
+    ctx.drawImage(src, 0, 0);
+    assert.equal(blit(native)[6], null);
+  });
+
+  describe('a clip this class cannot name turns the blit off', () => {
+    const cannotName = (name, set) =>
+      test(name, () => {
+        const { ctx, native, src } = context();
+        ctx.globalCompositeOperation = 'copy';
+        ctx.beginPath();
+        set(ctx);
+        ctx.clip();
+        ctx.drawImage(src, 0, 0);
+        assert.equal(native.of('blitSurface').length, 0);
+        assert.equal(drew(native), 1);
+      });
+
+    cannotName('a rounded rect', (ctx) => ctx.roundRect(0, 0, 40, 40, 6));
+    cannotName('an arc', (ctx) => ctx.arc(20, 20, 10, 0, Math.PI * 2));
+    cannotName('a polygon', (ctx) => {
+      ctx.moveTo(0, 0);
+      ctx.lineTo(10, 0);
+      ctx.lineTo(10, 10);
+      ctx.closePath();
+    });
+    cannotName('two rects, which is a union rather than a rect', (ctx) => {
+      ctx.rect(0, 0, 10, 10);
+      ctx.rect(20, 20, 10, 10);
+    });
+    cannotName('a rect on half pixels', (ctx) => ctx.rect(0.5, 0, 10, 10));
+    cannotName('a rect under a rotation', (ctx) => {
+      ctx.rotate(0.3);
+      ctx.rect(0, 0, 10, 10);
+    });
+
+    test('and it stays off for every clip inside it', () => {
+      const { ctx, native, src } = context();
+      ctx.globalCompositeOperation = 'copy';
+      ctx.beginPath();
+      ctx.arc(20, 20, 10, 0, Math.PI * 2);
+      ctx.clip();
+      clipTo(ctx, 0, 0, 10, 10);
+      ctx.drawImage(src, 0, 0);
+      assert.equal(native.of('blitSurface').length, 0);
+    });
+
+    test('a restore past it puts the blit back', () => {
+      const { ctx, native, src } = context();
+      ctx.globalCompositeOperation = 'copy';
+      clipTo(ctx, 20, 10, 100, 40);
+      ctx.save();
+      ctx.beginPath();
+      ctx.arc(20, 20, 10, 0, Math.PI * 2);
+      ctx.clip();
+      ctx.restore();
+      ctx.drawImage(src, 0, 0);
+      assert.deepEqual(blit(native)[6], [20, 10, 100, 40]);
+    });
+  });
+});
+
+// --- and in pixels ------------------------------------------------------------
+
+let bridge = null;
+try {
+  bridge = loadNative();
+} catch {
+  bridge = null;
+}
+const hasVerbs =
+  bridge &&
+  typeof bridge.blitSurface === 'function' &&
+  typeof bridge.ctxSetBlendMode === 'function';
+
+describe(
+  'against the real bridge',
+  {
+    skip: hasVerbs
+      ? false
+      : bridge
+        ? 'this @windowkit/appkit is older than 0.7.0'
+        : 'the @windowkit/appkit bridge is not loadable here',
+  },
+  () => {
+    const W = 128;
+    const H = 96;
+    const SW = 61;
+    const SH = 37;
+
+    /** A source surface whose every pixel is a function of where it is, so
+     *  a blit landing one row or column off is a difference. */
+    const source = () => {
+      const s = bridge.createSurface(SW, SH, 1);
+      for (let y = 0; y < SH; y++) {
+        for (let x = 0; x < SW; x++) {
+          bridge.ctxSetFillColor(s, x / SW, y / SH, ((x + y) % 8) / 8, 1);
+          bridge.ctxFillRect(s, x, y, 1, 1);
+        }
+      }
+      return s;
+    };
+
+    /** Composite `src` at (dx, dy) into a fresh destination, `blits` saying
+     *  which route: the memcpy, or the CGImage draw the bridge would take
+     *  without it. Returns the destination's pixels. */
+    const composite = ({ src, dx, dy, clip, blits, translate = [0, 0] }) => {
+      const dst = bridge.createSurface(W, H, 1);
+      const native = blits
+        ? bridge
+        : new Proxy(bridge, {
+            get: (t, k) => (k === 'blitSurface' ? undefined : t[k]),
+          });
+      const ctx = new CocoaContext2D(
+        native,
+        () => dst,
+        () => 1,
+      );
+      ctx.fillStyle = '#2b8a3e';
+      ctx.fillRect(0, 0, W, H);
+      ctx.globalCompositeOperation = 'copy';
+      assert.equal(ctx.globalCompositeOperation, 'copy');
+      ctx.translate(translate[0], translate[1]);
+      if (clip) {
+        ctx.beginPath();
+        ctx.rect(clip[0], clip[1], clip[2], clip[3]);
+        ctx.clip();
+      }
+      ctx.drawImage({ _surfaceHandle: src }, dx, dy);
+      return Buffer.from(bridge.ctxGetImageData(dst, 0, 0, W, H));
+    };
+
+    const agree = (name, options) =>
+      test(name, () => {
+        const src = source();
+        const blitted = composite({ ...options, src, blits: true });
+        const drawn = composite({ ...options, src, blits: false });
+        let differing = 0;
+        for (let i = 0; i < drawn.length; i++) {
+          if (blitted[i] !== drawn[i]) differing++;
+        }
+        assert.equal(differing, 0, `${differing} channels differ`);
+        // and the source actually landed: the ground is one colour, so a
+        // no-op blit would be a destination of nothing but it
+        let ink = 0;
+        for (let i = 0; i < blitted.length; i += 4) {
+          if (blitted[i] !== 43 || blitted[i + 1] !== 138) ink++;
+        }
+        assert.ok(ink > 100, `the source landed: ${ink} pixels`);
+      });
+
+    agree('at the origin', { dx: 0, dy: 0 });
+    agree('at an offset', { dx: 21, dy: 13 });
+    agree('under a translate', { dx: 5, dy: 7, translate: [30, 20] });
+    agree('clipped to a rect it straddles', {
+      dx: 20,
+      dy: 20,
+      clip: [30, 30, 20, 12],
+    });
+    agree('clipped and translated', {
+      dx: 4,
+      dy: 4,
+      translate: [16, 8],
+      clip: [20, 10, 40, 40],
+    });
+    agree('hanging off the right and bottom edges', { dx: W - 12, dy: H - 9 });
+
+    test('the memcpy writes the source alpha, where a blend would not', () => {
+      // a translucent source: `copy` replaces the destination's alpha with
+      // the source's, which is the whole difference between it and
+      // source-over, and the memcpy has to make that difference too
+      const src = bridge.createSurface(8, 8, 1);
+      bridge.ctxSetFillColor(src, 1, 0, 0, 0.5);
+      bridge.ctxFillRect(src, 0, 0, 8, 8);
+      const px = composite({ src, dx: 4, dy: 4, blits: true });
+      const at = (x, y) => [...px.slice((y * W + x) * 4, (y * W + x) * 4 + 4)];
+      assert.deepEqual(at(6, 6), [255, 0, 0, 128]);
+      assert.deepEqual(at(0, 0), [43, 138, 62, 255]);
+    });
+  },
+);

--- a/test/cocoa-scroll-blit.test.js
+++ b/test/cocoa-scroll-blit.test.js
@@ -275,6 +275,17 @@ function pixelBridge() {
       );
     },
     ctxSetLineWidth() {},
+    // The blend mode is modelled only as far as this raster goes: `normal`
+    // is what it already draws, and anything else would change the picture
+    // in a way it cannot, so it is unmodelled the way the proxy below means
+    // it. It has to be *present* either way — the context feature-detects
+    // it by name, and a probe that throws is a bridge nobody can hold.
+    ctxSetBlendMode(s, mode) {
+      if (mode !== 'source-over') {
+        throw new Error(`pixelBridge: unmodelled blend mode ${mode}`);
+      }
+      return true;
+    },
     ctxSetLineCap() {},
     ctxSetLineJoin() {},
     ctxSetGlobalAlpha() {},


### PR DESCRIPTION
Fixes #498.

An element that owns a surface presents it every frame — a terminal's grid, a retained scene — and `ctx.drawImage(surface, x, y)` is how it says so. On the Cocoa backend that was `CGBitmapContextCreateImage` of the whole source plus `CGContextDrawImage`: a CGImage built and a blend run, every frame, for pixels that were only ever going to be copied. In sidorares/react-x11-components#69 §6's profile it is 1.7ms of a 6ms `<Terminal backend="vt">` frame, second only to the cell background fills.

## What this side does

`CocoaContext2D` grows **`globalCompositeOperation`** over the bridge's `ctxSetBlendMode`. The vocabulary is the bridge's rather than a table kept on this side: the names are canvas's own, the verb answers whether the mode is now the one asked for, and that answer decides whether the assignment sticks — so this backend never goes stale against a bridge that grows an op, and never claims one it would not draw. Under `copy`, and only where the memcpy is exactly what the draw would have produced, `drawImage` goes out as **`blitSurface`** instead.

```js
paintContent(ctx) {
  const box = this.contentBox();
  ctx.globalCompositeOperation = 'copy';
  ctx.drawImage(this.surface, box.x, box.y);
  ctx.globalCompositeOperation = 'source-over';
}
```

`scripts/cocoa-composite-probe.mjs` prices the two routes against the real bridge. M1 Pro, `@windowkit/appkit` 0.7.0, 200 composites a cell, best of three sweeps:

| source | destination | CGImage draw | memcpy | saved |
|---|---|---:|---:|---:|
| 125×45 grid @2x | the whole surface | 1.37ms | 0.42ms | 69% |
| 125×45 grid @2x | a third of it | 0.36ms | 0.14ms | 61% |
| 125×45 grid @2x | one row's damage | 0.033ms | 0.012ms | 65% |
| 80×24 grid @2x | the whole surface | 0.35ms | 0.18ms | 48% |
| 125×45 grid @1x | the whole surface | 0.23ms | 0.11ms | 54% |

## Three things worth knowing

**The property refuses what the bridge cannot draw**, rather than accepting it and drawing something else. On an older `@windowkit/appkit` only `source-over` sticks, and the detection a caller writes is canvas's own — assign, then read the property back.

**The blit is an optimization and never a difference.** Each of these turns it off and the draw happens: an op other than `copy`, a transform that is not a whole-pixel translate, a `globalAlpha` below 1, a live shadow, a destination size that differs from the source's, a fractional source rect, and a surface composited into itself.

**The clip is the catch.** A memcpy cannot see a CGContext's clip, and a paint pass is clipped to its damage — so the context now tracks the clip as a rect beside the CTM it already tracked, and hands it to the verb. It tracks only what it can state exactly: a single `rect` path under an axis-aligned transform landing on whole pixels. A rounded corner, an arc, a polygon, two rects, a half-pixel edge or a rotation all resolve to "there is a clip and I cannot name it", which turns the blit off until a `restore()` pops back past it. The clips a paint pass actually sets — the damage rect, a square-cornered `overflow` — are the ones it recognises.

## The bridge half

windowkit/appkit#37, released as **0.7.0** — this PR bumps the optional dependency to `^0.7.0`, which is the only reason the fast path is live rather than inert. The two verbs:

- **`ctxSetBlendMode(surface, mode) -> boolean`** — `CGContextSetBlendMode` under canvas's names, answering false for a name it does not have, which is what this side reads.
- **`blitSurface(src, sx, sy, w, h, dst, dx, dy, clip?) -> [x, y, w, h] | null`** — a row memcpy between surfaces of any two sizes, no blending, device pixels with a top-left origin. `clip` is `[x, y, w, h]` in the **destination's** pixels, since a memcpy can see neither the destination's CTM nor its clip; the rect copied is the destination rect intersected with that clip and both surfaces' bounds. Two handles onto one bitmap are refused on the backing store, so the two ends of a shared IOSurface cannot slip through.

Two places the shipped verbs improved on the sketch that was attached here earlier, and this side now uses both: the blend verb's **boolean** return, which replaced a canvas→CoreGraphics name table that had already gone stale against it, and the same-bitmap check moving from the handle to the backing store.

## Tests

`test/cocoa-composite.test.js`, in two layers, the shape the other Cocoa tests use.

The first runs everywhere and is what CI sees — the test matrix is `ubuntu-latest`, where the darwin-only bridge is not installed at all: a fake bridge records what reaches the natives — the names, the refusals, the clip arithmetic — **including a bridge with neither verb, and one whose vocabulary is smaller than 0.7.0's**, since that is what the feature detection is for.

The second runs where a bridge carrying the verbs loads — locally, and on any macOS checkout — and ends in pixels: the blit and the CGImage draw are byte-identical at the origin, at an offset, under a translate, clipped, clipped and translated, and hanging off the right and bottom edges — plus that `copy` writes the source's alpha, which is the whole difference between it and `source-over`.

Mutation-checked: dropping the clip from the blit fails 7, landing the destination a row low fails 9, removing the `globalAlpha` guard fails 1, ignoring the blend verb's refusal fails 1, and letting a verbless bridge accept any op fails 1.

`test/cocoa-scroll-blit.test.js`'s `pixelBridge` learns `ctxSetBlendMode`, because it throws on any drawing verb it does not model — including when one is merely probed for.

Full suite against 0.7.0: 2097 pass, 6 fail — the `appearance.test.js` six that fail on master on this machine and pass in CI.
