### PR TITLE
docs(packaging): the two macOS distribution tracks — App Sandbox rules out bun, so a store build is node's SEA

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -141,8 +141,9 @@
 - [security.md](security.md) — the threat model, plainly: X11 has no
   isolation between clients, `$XAUTHORITY` is a password, and what
   react-x11 does and does not defend against.
-- [packaging.md](packaging.md) — four ways to ship an app, with the two
-  esbuild flags that are load-bearing and the one tier that does not work.
+- [packaging.md](packaging.md) — five ways to ship an app, the esbuild flags
+  that are load-bearing, and the two macOS distribution tracks: Developer ID
+  takes node or bun, the App Store's sandbox takes node only.
 - [devtools.md](devtools.md) — React DevTools integration and other
   debugging aids.
 - [debugging.md](debugging.md) — runtime diagnostics: protocol tracing

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1284,12 +1284,52 @@ built, and nowhere else without three more steps.
 
 - **Signing.** The binary is unsigned. Gatekeeper lets an unsigned app run
   from a build directory, but not one that arrived in a download (the
-  quarantine attribute) — for that it wants a Developer ID signature and
-  notarization: `codesign --deep --force --sign "Developer ID Application: …"`
-  then `notarytool submit`. For a copy handed to a colleague, an ad-hoc
-  signature (`codesign --deep --force --sign - Guestbook.app`) and
+  quarantine attribute) — for that it wants a Developer ID signature with
+  the hardened runtime, then notarization. Sign **inside-out, and not
+  with `--deep`**: Apple DTS says not to use it ("Signing a Mac Product
+  For Distribution" and "Creating distribution-signed code for Mac",
+  forums threads 128166 and 701514) and to sign nested code first, with
+  entitlements on the main executable only. So: the addon in `Resources`,
+  without entitlements, then the app with them:
+
+  ```sh
+  ID="Developer ID Application: NAME (TEAMID)"
+  codesign --force --timestamp --sign "$ID" Guestbook.app/Contents/Resources/calayers.node
+  codesign --force --timestamp --options runtime --entitlements bun.plist \
+    --sign "$ID" Guestbook.app
+  ditto -c -k --keepParent Guestbook.app Guestbook.zip
+  xcrun notarytool submit Guestbook.zip --keychain-profile notary --wait
+  xcrun stapler staple Guestbook.app
+  ```
+
+  `bun.plist` is the five entitlements from Bun's "Code signing on macOS"
+  (`allow-jit`, `allow-unsigned-executable-memory`,
+  `disable-executable-page-protection`, `allow-dyld-environment-variables`,
+  `disable-library-validation`). For a copy handed to a colleague, the
+  same two `codesign` lines with `--sign -` and
   `xattr -dr com.apple.quarantine` on the receiving end are the short
-  path. Sign the addon in `Resources` too; `--deep` finds it.
+  path. The machine this was written on has no signing identity: the
+  ad-hoc steps were run, the Developer ID ones are Apple's documentation —
+  [packaging.md](packaging.md#developer-id-or-the-app-store) keeps the
+  line between the two.
+
+- **The Mac App Store is a different bundle.** The store requires App
+  Sandbox, and a `bun build --compile` binary does not start under it.
+  Measured 2026-09-08 (macOS 15.2, bun 1.4.0): this bundle re-signed with
+  only `com.apple.security.app-sandbox` dies every time — `SIGTRAP` in
+  `_libsecinit_appsandbox` for the bare binary, `SIGABRT` in HIServices'
+  `_RegisterApplication` inside the bundle, after the kernel logs
+  `Sandbox: Guestbook deny(1) mach-lookup com.apple.coreservices.launchservicesd`
+  (oven-sh/bun#15661, open). The same example as a node single executable
+  (`node --build-sea`, node 26) in this bundle's shape — same plist, same
+  `calayers.node` in `Resources` — runs sandboxed, launched by `open`,
+  registered with Launch Services, in its own container, with no sandbox
+  denial logged. So a store build is packaging.md's tier 3 inside its
+  tier 5, signed with "Apple Distribution", packaged with `productbuild`
+  and uploaded with Transporter; the recipe, the two esbuild defines the
+  form example needs today, and what was and was not run are in
+  [packaging.md](packaging.md#developer-id-or-the-app-store). Bun stays
+  fine for Developer ID, which needs no sandbox.
 - **Architecture.** `bun build --compile` targets one CPU and the bridge's
   prebuilds are one per CPU; the script builds for the machine it runs on.
   A universal bundle is two builds and `lipo` — for the executable and for
@@ -1298,7 +1338,8 @@ built, and nowhere else without three more steps.
   addon relative to `process.execPath`, so the bundle can be moved, zipped
   and dragged into `/Applications`. Nothing in it refers to the repo.
 - **Size.** About 70MB, nearly all of it bun's runtime; the example and
-  react-x11 are a few hundred kilobytes of it.
+  react-x11 are a few hundred kilobytes of it. The node SEA of the same
+  example, the store shape, is 142MB.
 
 **The tab bar under bun.** Without a bundle, a window opened by `bun` is in
 the `bun` defaults domain, and once anything has turned on the tab bar for
@@ -1963,6 +2004,9 @@ run against today's renderer with no core changes.
    portability bites in practice.
 6. **Bun on the Cocoa backend** — N-API under Bun is expected to work;
    verify early (Phase 1) since single-file packaging is a stated goal.
+   Answered in two halves: `make-app.sh` is that single file and it runs,
+   and it cannot be the App Store one — a bun binary does not start under
+   App Sandbox (§Distributing the bundle), so that build is node's SEA.
 7. **`@react-x11/components` on Cocoa** — the seven registered elements
    should light up via the raster path untouched; the X-only corners
    (tray-host, embed, media-player embedding, `serverTime`) need
@@ -1984,6 +2028,13 @@ run against today's renderer with no core changes.
   `CADisplayLink` (macOS 14+).
 - libuv — "Embedding libuv in other event loops" (the run-loop drain's
   recipe, pointed at AppKit).
+- Distribution: Apple, "App Sandbox" (the store requirement) and "Porting
+  just-in-time compilers to Apple silicon" (`allow-jit` matters only under
+  the hardened runtime); Apple DTS on the forums, "Signing a Mac Product
+  For Distribution" (thread 128166) and "Creating distribution-signed code
+  for Mac" (701514) — inside-out signing, no `--deep`; Bun, "Code signing
+  on macOS" in the executables guide; Node, `tools/osx-entitlements.plist`;
+  oven-sh/bun#15661 for bun under App Sandbox.
 - WebKit/Gecko form-control rendering via offscreen `NSCell` drawing —
   the native-bezel technique the POC reproduces.
 - `node-calayers` POC — `~/tmp/node-calayers` (to be published; §"the

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -123,7 +123,7 @@ reports `available: false`; `notify()` then takes the `osascript` rung, whose
 banners are Script Editor's. To get the real thing, run as a bundle: the
 executable in `Name.app/Contents/MacOS/`, an `Info.plist` that names it and
 carries `CFBundleIdentifier`, and a signature
-(`codesign --force --deep --sign - Name.app` is enough locally). See
+(`codesign --force --sign - Name.app` is enough locally). See
 [packaging.md](packaging.md).
 
 ## `useNotifier()`

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,7 +1,8 @@
 # Packaging and distribution
 
 Five ways to ship a react-x11 app, cheapest first. Every recipe here was
-run; where something does not work, the reason is measured rather than
+run — except the two that need a signing identity, which say so — and
+where something does not work, the reason is measured rather than
 guessed.
 
 | tier                            | works                      | cost                            |
@@ -10,7 +11,7 @@ guessed.
 | 2. a single `.mjs`              | yes, with one esbuild flag | one file, ~7 MB                 |
 | 3. Node single executable (SEA) | yes, as CommonJS           | one file, ~142 MB               |
 | 4. AppImage / `.deb`            | yes, wrapping tier 1 or 2  | packaging metadata              |
-| 5. a macOS `.app`               | yes, wrapping tier 1 or 2  | a plist, and a signing identity |
+| 5. a macOS `.app`               | yes, wrapping tier 2 or 3  | a plist, and a signing identity |
 
 ## Tier 1 — `npm install`
 
@@ -117,9 +118,14 @@ What the CommonJS format costs you, in your own code:
   to fail the build. esbuild names the file and line, so this is a
   five-second fix rather than a mystery.
 - **`import.meta.url` is `undefined`.** Anything resolving paths through it
-  needs `process.execPath` or a literal. react-x11 already guards its own
-  use of it (the version string DevTools shows falls back rather than
-  throwing); check your app for the same pattern.
+  needs `process.execPath` or a literal. react-x11 guards its own uses on
+  the X11 path (the version string DevTools shows falls back rather than
+  throwing) but not yet on the cocoa one: `src/cocoa/native.js` calls
+  `createRequire(import.meta.url)` when that backend loads, and
+  `createRequire(undefined)` throws `ERR_INVALID_ARG_VALUE`. Until that is
+  fixed in code, `--define:import.meta.url='"file:///dev/null"'` at build
+  time is the workaround ([tier 5](#developer-id-or-the-app-store) has the
+  whole recipe); check your app for the same pattern.
 - **Runtime module loading is out.** Inside a SEA, `require()` _and_
   `import()` resolve **built-in modules only** — a `data:` or `file:` URL
   import fails with `ERR_UNKNOWN_BUILTIN_MODULE`. A bundle has nothing left
@@ -160,7 +166,7 @@ way — which is why this section is short rather than absent.
 ## Tier 5 — a macOS `.app`
 
 The cocoa backend's counterpart to tier 4, and the same shape: a wrapper
-around tier 1 or tier 2 whose content is metadata. It matters more than it
+around tier 2 or tier 3 whose content is metadata. It matters more than it
 looks, because several integrations are not features you enable but things
 macOS grants **a bundle** and refuses a loose executable — the notification
 centre first among them ([notifications.md](notifications.md)).
@@ -240,6 +246,204 @@ Editor, and `useNotifier().backend` says `osascript` so an app can tell the
 difference ([notifications.md](notifications.md)). Nothing else about the
 bundle depends on the certificate.
 
+### Developer ID, or the App Store
+
+Past the ad-hoc signature there are two ways out of the building, and they
+want different runtimes. Measured 2026-09-08 on macOS 15.2 with bun 1.4.0
+and node 26. The machine has no signing identity, so the line through this
+section is the ad-hoc one: everything on the near side of it was run, and
+everything past it is Apple's documentation, marked as such.
+
+|                  | Developer ID — a download                          | Mac App Store                                        |
+| ---------------- | -------------------------------------------------- | ---------------------------------------------------- |
+| App Sandbox      | optional                                           | required                                             |
+| hardened runtime | required, by notarization                          | not required                                         |
+| runtime          | node or bun                                        | node — bun does not start under the sandbox          |
+| shape            | this tier around tier 2 or 3, or bun's `--compile` | tier 3: a SEA, an executable that takes no arguments |
+| identity         | Developer ID Application                           | Apple Distribution, plus an installer identity       |
+| then             | `notarytool`, `stapler`                            | `productbuild`, Transporter                          |
+
+**The sandbox is where bun stops.** Apple's App Sandbox page: "To
+distribute a macOS app through the Mac App Store, you must enable the App
+Sandbox capability" — one entitlement, `com.apple.security.app-sandbox`.
+The form example's bundle, as `make-app.sh` builds it with
+`bun build --compile` and re-signed with only that entitlement, crashes at
+launch every time:
+
+- **the bare binary**, outside any bundle: `SIGTRAP` in
+  `_libsecinit_appsandbox`, the libSystem initializer that applies the
+  sandbox — before a line of JavaScript runs;
+- **inside the bundle**: `SIGABRT` in HIServices' `_RegisterApplication`,
+  under `-[NSApplication init]`, after the kernel logs
+  `Sandbox: Guestbook deny(1) mach-lookup com.apple.coreservices.launchservicesd`.
+
+Measured not to be the cause: how it is launched (exec'd from a shell, in
+the foreground under a watchdog, or by `open`), the plist (the example's
+and a minimal one), and where the bundle sits. Upstream:
+[oven-sh/bun#15661][bun-15661], "Cannot run Bun within macOS sandbox", open
+since December 2024 — its "status code 5" is this SIGTRAP.
+
+The same example, sandboxed with the same entitlement and the same ad-hoc
+signature, runs as node: as an esbuild `.mjs` (tier 2) under a copied
+`node` binary, and as a `node --build-sea` executable (tier 3). Both stayed
+up with the window on screen and logged no `Sandbox: … deny` line at all;
+the SEA, launched by `open`, registers with Launch Services as itself and
+gets its container:
+
+```
+$ open SeaGuestbook.app
+"LSDisplayName"="SeaGuestbook"
+"CFBundleIdentifier"="com.example.seaguestbook"
+container: ~/Library/Containers/com.example.seaguestbook
+```
+
+The control: a five-line Swift AppKit app (`NSApplication.shared`, print
+the container id), ad-hoc-signed with the same entitlement, runs and
+reports its container. So an ad-hoc signature plus the entitlement is a
+valid local sandbox test, and no certificate is needed for this part.
+
+**The SEA is the store shape.** Launch Services starts a bundle's
+executable with no arguments, so a copied `node` has nothing to run; the
+SEA carries its main. (The sandbox also moves the working directory into
+the container — `ProbeNode probe.mjs` with a relative path failed with
+`MODULE_NOT_FOUND` at `~/Library/Containers/…/Data/probe.mjs`, an absolute
+one ran — and a SEA has no path to get wrong.) Its build is tier 3's, with
+two esbuild defines that the form example needs today:
+
+```sh
+esbuild sea-main.js --bundle --platform=node --format=cjs --jsx=automatic --outfile=app.cjs \
+  --define:process.env.REACT_X11_NO_AUTORUN='"1"' \
+  --define:import.meta.url='"file:///dev/null"'
+node --build-sea sea.json   # { "main": "app.cjs", "output": "Guestbook", "disableExperimentalSEAWarning": true }
+```
+
+- **`REACT_X11_NO_AUTORUN`.** `index.jsx` mounts itself under that guard
+  with a top-level `await createRoot()`, which `cjs` cannot express;
+  without the define esbuild stops at
+  `Top-level await is currently not supported with the "cjs" output format`.
+  Defined, the guard is a constant and the branch is dropped at build
+  time; the entry mounts `App` itself, in an async function:
+
+  ```js
+  // sea-main.js — main.js's job, as CommonJS
+  const path = require('node:path');
+  const contents = path.resolve(path.dirname(process.execPath), '..');
+  process.env.REACT_X11_CALAYERS_PATH ??= path.join(
+    contents,
+    'Resources',
+    'calayers.node',
+  );
+  process.env.REACT_X11_BACKEND ??= 'cocoa';
+  (async () => {
+    const [{ createRoot }, { default: App }, React] = await Promise.all([
+      import('react-x11'),
+      import('./index.jsx'),
+      import('react'),
+    ]);
+    const root = await createRoot();
+    root.render(React.createElement(App));
+  })().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+  ```
+
+- **`import.meta.url`.** esbuild's `cjs` output leaves `import.meta`
+  empty, and `src/cocoa/native.js` calls `createRequire(import.meta.url)`
+  when the cocoa backend loads — `createRequire(undefined)` throws
+  `ERR_INVALID_ARG_VALUE`. Any string URL satisfies it; the addon is then
+  found through `REACT_X11_CALAYERS_PATH`, an absolute path, so the base
+  is never used. Fixing that in react-x11 is a separate task; once it
+  lands, drop this define.
+
+The bundle is then tier 5's — the plist, the SEA at
+`Contents/MacOS/Guestbook`, `calayers.node` in `Contents/Resources` — and
+the signature is two commands, in this order:
+
+```sh
+codesign --force --sign - Guestbook.app/Contents/Resources/calayers.node
+codesign --force --sign - --entitlements sandbox.plist Guestbook.app
+open Guestbook.app
+```
+
+where `sandbox.plist` holds the one key. That is what ran.
+
+**Sign inside-out, and never `--deep`.** Apple DTS, in "Signing a Mac
+Product For Distribution" and "Creating distribution-signed code for Mac"
+([forums 128166][dts-128166], [701514][dts-701514]): "Do not use the
+`--deep` argument … it will cause problems when signing a complex
+program". Sign each code item separately, dependencies first — the addon
+before the app, because the app's signature seals the addon's — and put
+entitlements on the main executable only: "Do not apply entitlements to
+library code. It doesn't do anything useful and can prevent your code from
+running." `--deep` applies one set of options to every item, which is the
+wrong thing the moment the app has entitlements and the addon must not.
+
+**Developer ID — not run.** For a download outside the store, Gatekeeper
+wants a Developer ID signature with the hardened runtime, then
+notarization:
+
+```sh
+ID="Developer ID Application: NAME (TEAMID)"
+codesign --force --timestamp --sign "$ID" Guestbook.app/Contents/Resources/calayers.node
+codesign --force --timestamp --options runtime --entitlements developer-id.plist \
+  --sign "$ID" Guestbook.app
+ditto -c -k --keepParent Guestbook.app Guestbook.zip
+xcrun notarytool submit Guestbook.zip --keychain-profile notary --wait
+xcrun stapler staple Guestbook.app
+```
+
+`developer-id.plist` is the upstream list for the runtime you ship. Bun's
+"Code signing on macOS" ([the executables guide][bun-codesign]) and Node's
+[`tools/osx-entitlements.plist`][node-entitlements] name the same five:
+`com.apple.security.cs.allow-jit`, `allow-unsigned-executable-memory`,
+`disable-executable-page-protection`, `allow-dyld-environment-variables`
+and `disable-library-validation`. Node's file has a sixth,
+`com.apple.security.get-task-allow` — a debugging entitlement, and the
+`node` you copy from a release carries it (`codesign -d --entitlements -`
+on node 26 lists all six). Never ship it; a re-sign replaces node's
+entitlements wholesale, so it only ever appears if your plist names it.
+
+What the hardened runtime needs was measured with an ad-hoc signature and
+`--options runtime`, which is the real thing: a copied `node` signed with
+no entitlements aborts at startup —
+`Fatal process out of memory: Failed to reserve virtual memory for CodeRange`,
+V8 unable to map executable memory — and runs with `allow-jit` alone; a
+`bun build --compile` binary ran with none, with `allow-jit` alone, and
+with all five (whether its JIT was on was not measured). So `allow-jit` is
+the load-bearing one for node, and the other four are what upstream
+ships, not what this page found necessary. The Developer ID identity,
+`notarytool` and `stapler` were not run: the machine has none.
+
+**Mac App Store — not run.** Sign the same bundle, inside-out, with the
+store identity, and package it as an installer:
+
+```sh
+ID="Apple Distribution: NAME (TEAMID)"
+codesign --force --timestamp --sign "$ID" Guestbook.app/Contents/Resources/calayers.node
+codesign --force --timestamp --entitlements store.plist --sign "$ID" Guestbook.app
+productbuild --sign "3rd Party Mac Developer Installer: NAME (TEAMID)" \
+  --component Guestbook.app /Applications Guestbook.pkg
+xcrun altool --upload-app -f Guestbook.pkg -t macos --apiKey KEY --apiIssuer ISSUER   # or Transporter
+```
+
+`store.plist` is `com.apple.security.app-sandbox` plus what the app
+actually needs — `network.client`, `files.user-selected.read-write` — and
+none of the hardened-runtime keys: the store does not require the hardened
+runtime, and Apple's "Porting just-in-time compilers to Apple silicon" is
+explicit that `allow-jit` "is required only when an app adopts the
+Hardened Runtime capability". `Contents/embedded.provisionprofile` is
+needed only for restricted entitlements (iCloud, push, app groups) or
+TestFlight. The ad-hoc half of this — the sandboxed SEA bundle, launched
+by `open`, registered, contained, zero denials — is what was measured; the
+identity, `productbuild --sign` and the upload are Apple's documentation.
+
+[bun-15661]: https://github.com/oven-sh/bun/issues/15661
+[dts-128166]: https://developer.apple.com/forums/thread/128166
+[dts-701514]: https://developer.apple.com/forums/thread/701514
+[bun-codesign]: https://bun.com/docs/bundler/executables#code-signing-on-macos
+[node-entitlements]: https://github.com/nodejs/node/blob/main/tools/osx-entitlements.plist
+
 ## Checklist
 
 - Pick the format deliberately: `--format=esm` (tier 2, needs the banner) or
@@ -250,21 +454,30 @@ bundle depends on the certificate.
 - Set `wmClass` and match it in `StartupWMClass`.
 - On macOS, ship a `.app` (tier 5) rather than a bare executable, and sign it
   with a real identity if you want the notification centre.
+- For the Mac App Store, build tier 3 — a node SEA — and sandbox it: bun does
+  not start under App Sandbox. Developer ID takes either runtime.
+- Sign nested code first and the app last, entitlements on the app only, and
+  never `--deep`.
 - Test on a display you did not develop on. Fonts are the usual surprise:
   family resolution goes through `fc-match`, so `sans-serif` is a different
   face on the target ([remote.md](remote.md#the-other-x-servers), issue #86).
 
 ## Upstream
 
-One thing would delete the rest of the friction here:
+Two things would delete the rest of the friction here:
 
 - **node-x11: ESM sources** ([node-x11#246][x11-246]). That removes tier 2's
   banner, which is now the only real trap on the page. Note the tempting
   cheaper version does not work: `node:`-prefixed requires change nothing,
   because esbuild wraps a CommonJS module either way and its `require` shim
   throws in ESM output regardless of the specifier — measured, not assumed.
+- **bun: App Sandbox** ([oven-sh/bun#15661][bun-15661]). Until a
+  `bun build --compile` binary can start sandboxed, a Mac App Store build is
+  node's SEA and bun is a Developer ID runtime only.
 
 ESM support for a SEA's embedded main would be welcome in Node, but it is no
-longer load-bearing: tier 3 works as CommonJS.
+longer load-bearing: tier 3 works as CommonJS. What is load-bearing, and
+local: `src/cocoa/native.js`'s `createRequire(import.meta.url)`, which a SEA
+cannot evaluate — the second define in tier 5 until it is fixed.
 
 [x11-246]: https://github.com/sidorares/node-x11/issues/246


### PR DESCRIPTION
Tier 5 of packaging.md gains a section on what happens past the ad-hoc
signature, and macos.md's "Distributing the bundle" is brought in line
with it. Measured 2026-09-08 on macOS 15.2 with bun 1.4.0 and node 26.

A bun build --compile executable inside a .app, re-signed with only the
com.apple.security.app-sandbox entitlement, crashes at launch every
time: SIGTRAP in _libsecinit_appsandbox for the bare binary, SIGABRT in
HIServices' _RegisterApplication inside the bundle, after the kernel
denies a mach-lookup of launchservicesd. Upstream is oven-sh/bun#15661,
open. The same example runs sandboxed as an esbuild .mjs under a copied
node binary, and as a node --build-sea single executable: launched by
open, registered with Launch Services, in its own container, with no
sandbox denial logged. A five-line Swift AppKit app ad-hoc-signed with
the same entitlement also runs, so an ad-hoc signature plus the
entitlement is a valid local sandbox test and no certificate is needed
for that part.

App Sandbox is mandatory for the Mac App Store, so a store build is
node-based: tier 3's single executable, which is also the store shape
because Launch Services starts a bundle's executable with no arguments.
Bun stays fine for Developer ID, which needs no sandbox. The SEA of
examples/form needs two esbuild defines today, both documented with
their reason: REACT_X11_NO_AUTORUN, because the example mounts with a
top-level await that cjs cannot express, and import.meta.url, because
the cocoa bridge loader resolves the addon through it and a SEA leaves
import.meta empty. A separate task fixes the second in code; the page
says to drop that define once it lands.

Signing follows Apple DTS rather than --deep, which both threads say not
to use: sign nested code inside-out, the addon first and without
entitlements, then the app with them. Developer ID adds the hardened
runtime, notarytool and stapler; the store path is Apple Distribution,
productbuild and Transporter, with no hardened runtime required. Under
the hardened runtime, ad-hoc, a copied node with no entitlements aborts
in V8 and runs with allow-jit alone, while bun's compiled binary ran
with none.

Nothing past the ad-hoc signature was run: this machine has no signing
identity, and both pages say so. Also drops the one --deep left in
notifications.md and refreshes the packaging line in the docs index.
