### PR TITLE
fix(cocoa): load the native bridge without import.meta.url, which a SEA bundle lacks

### DIFF
--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -118,20 +118,25 @@ What the CommonJS format costs you, in your own code:
   to fail the build. esbuild names the file and line, so this is a
   five-second fix rather than a mystery.
 - **`import.meta.url` is `undefined`.** Anything resolving paths through it
-  needs `process.execPath` or a literal. react-x11 guards its own uses on
-  the X11 path (the version string DevTools shows falls back rather than
-  throwing) but not yet on the cocoa one: `src/cocoa/native.js` calls
-  `createRequire(import.meta.url)` when that backend loads, and
-  `createRequire(undefined)` throws `ERR_INVALID_ARG_VALUE`. Until that is
-  fixed in code, `--define:import.meta.url='"file:///dev/null"'` at build
-  time is the workaround ([tier 5](#developer-id-or-the-app-store) has the
-  whole recipe); check your app for the same pattern.
-- **Runtime module loading is out.** Inside a SEA, `require()` _and_
-  `import()` resolve **built-in modules only** — a `data:` or `file:` URL
-  import fails with `ERR_UNKNOWN_BUILTIN_MODULE`. A bundle has nothing left
-  to resolve, so this only bites if you meant to load something later. It
-  also closes the obvious workaround for the old ESM problem: you cannot
-  carry an ESM bundle as a SEA asset and import it.
+  needs `process.execPath` or a literal. react-x11 guards its own uses (the
+  version string DevTools shows falls back rather than throwing, and the
+  cocoa backend's addon loader is built from `process.execPath` when there
+  is no module URL — see the cocoa note below); check your app for the same
+  pattern. Two features cannot be guarded, because what they resolve through
+  it has to exist on disk: `<Frame>` forks a child entry, and
+  click-to-component opens your source. Neither works in a SEA, and each
+  fails when first used rather than at startup: a pane hands its `fallback`
+  a `spawn`-phase `ERR_INVALID_URL` (and is an empty box without one), and
+  `createRoot()` with `REACT_X11_CLICK_TO_COMPONENT` set rejects with
+  `ERR_INVALID_ARG_TYPE`. Both measured on the SEA below.
+- **Runtime module loading is out.** Inside a SEA, the embedded main's
+  `require()` _and_ `import()` resolve **built-in modules only** — a `data:`
+  or `file:` URL import fails with `ERR_UNKNOWN_BUILTIN_MODULE`. A bundle has
+  nothing left to resolve, so this only bites if you meant to load something
+  later. It also closes the obvious workaround for the old ESM problem: you
+  cannot carry an ESM bundle as a SEA asset and import it. The one door left
+  open is `createRequire(process.execPath)` from `node:module` — a full
+  CommonJS loader rooted at the executable, and how the cocoa addon gets in.
 - **Assets are not files.** `sea.getAsset()` reads what the config's
   `assets` map embedded; fonts are the usual case, and `StaticFontSource`
   takes bytes directly ([ntk's fonts guide][ntk-fonts]).
@@ -139,6 +144,27 @@ What the CommonJS format costs you, in your own code:
 On macOS the binary must be re-signed before it runs
 (`codesign --remove-signature myapp && codesign --sign - myapp`); on Linux
 nothing extra. Measured on Node 26.
+
+**The cocoa backend works in a SEA, with the addon beside the binary.** The
+native bridge is a `.node` file: the blob cannot carry it and the embedded
+main's `require()` cannot load it, so react-x11 loads it through
+`createRequire(process.execPath)` — the loader Node's SEA documentation
+prescribes — which resolves from the executable's own directory. Either
+point `REACT_X11_CALAYERS_PATH` at the addon (the `@windowkit/appkit`
+package directory or its `calayers.node` prebuild, the way
+`examples/form/main.js` names it inside a compiled bundle), or ship
+`node_modules/@windowkit/appkit` next to the executable and let the bare
+name resolve. With neither, the error is the backend's usual one, naming
+both attempts. Verified with a `createRoot({ backend: 'cocoa' })` app built
+by the recipe above: it mounts a window on the Core Animation backend all
+three ways, and the sandboxed store build in
+[tier 5](#developer-id-or-the-app-store) — this recipe inside a bundle —
+ran without the define it used to need. Earlier releases made that loader
+at import time, from
+`import.meta.url`, and every cocoa SEA died with `ERR_INVALID_ARG_VALUE`
+before the backend could say what it was loading; on a release you cannot
+move off, `--define:import.meta.url='"file:///dev/null"'` at bundle time is
+the workaround, and `test/cocoa-native.test.js` keeps the fix.
 
 [ntk-fonts]: https://github.com/sidorares/ntk/blob/master/docs/fonts.md
 
@@ -308,12 +334,11 @@ SEA carries its main. (The sandbox also moves the working directory into
 the container — `ProbeNode probe.mjs` with a relative path failed with
 `MODULE_NOT_FOUND` at `~/Library/Containers/…/Data/probe.mjs`, an absolute
 one ran — and a SEA has no path to get wrong.) Its build is tier 3's, with
-two esbuild defines that the form example needs today:
+one esbuild define that the form example needs today:
 
 ```sh
 esbuild sea-main.js --bundle --platform=node --format=cjs --jsx=automatic --outfile=app.cjs \
-  --define:process.env.REACT_X11_NO_AUTORUN='"1"' \
-  --define:import.meta.url='"file:///dev/null"'
+  --define:process.env.REACT_X11_NO_AUTORUN='"1"'
 node --build-sea sea.json   # { "main": "app.cjs", "output": "Guestbook", "disableExperimentalSEAWarning": true }
 ```
 
@@ -348,13 +373,15 @@ node --build-sea sea.json   # { "main": "app.cjs", "output": "Guestbook", "disab
   });
   ```
 
-- **`import.meta.url`.** esbuild's `cjs` output leaves `import.meta`
-  empty, and `src/cocoa/native.js` calls `createRequire(import.meta.url)`
-  when the cocoa backend loads — `createRequire(undefined)` throws
-  `ERR_INVALID_ARG_VALUE`. Any string URL satisfies it; the addon is then
-  found through `REACT_X11_CALAYERS_PATH`, an absolute path, so the base
-  is never used. Fixing that in react-x11 is a separate task; once it
-  lands, drop this define.
+- **`import.meta.url` needs no define any more.** This recipe used to
+  carry a second one, `--define:import.meta.url='"file:///dev/null"'`,
+  because the cocoa backend's addon loader was made from `import.meta.url`
+  at import and a SEA has none. The loader is now made from
+  `process.execPath` when the URL is missing
+  ([tier 3](#tier-3--node-single-executable)), and the addon is found
+  through `REACT_X11_CALAYERS_PATH` as before. On a react-x11 whose
+  `src/cocoa/native.js` still calls `createRequire(import.meta.url)` at
+  module scope, put the define back.
 
 The bundle is then tier 5's — the plist, the SEA at
 `Contents/MacOS/Guestbook`, `calayers.node` in `Contents/Resources` — and
@@ -476,8 +503,6 @@ Two things would delete the rest of the friction here:
   node's SEA and bun is a Developer ID runtime only.
 
 ESM support for a SEA's embedded main would be welcome in Node, but it is no
-longer load-bearing: tier 3 works as CommonJS. What is load-bearing, and
-local: `src/cocoa/native.js`'s `createRequire(import.meta.url)`, which a SEA
-cannot evaluate — the second define in tier 5 until it is fixed.
+longer load-bearing: tier 3 works as CommonJS.
 
 [x11-246]: https://github.com/sidorares/node-x11/issues/246

--- a/src/cocoa/native.js
+++ b/src/cocoa/native.js
@@ -11,9 +11,26 @@
 // is CommonJS + a .node binary, so `createRequire` is the honest loader.
 import { createRequire } from 'node:module';
 
-const require = createRequire(import.meta.url);
-
 const PACKAGE = '@windowkit/appkit';
+
+// The loader is made on first use, and from the executable when there is
+// no module URL to make it from. A bundle built for Node's single-executable
+// format (docs/packaging.md, tier 3) is CommonJS, and esbuild leaves
+// `import.meta` an empty object in that output — so a module-scope
+// `createRequire(import.meta.url)` threw ERR_INVALID_ARG_VALUE the moment
+// the backend loaded, in every cocoa app shipped as a SEA, before this
+// could say what it was trying to load. `createRequire(process.execPath)`
+// is the loader Node's SEA docs prescribe (the embedded main's `__filename`
+// *is* the executable), and it answers both specs below: an absolute
+// REACT_X11_CALAYERS_PATH resolves from anywhere, and the bare package name
+// resolves through a `node_modules` beside the binary. Made lazily, a
+// loader that cannot be made at all is reported by the error at the bottom
+// rather than by a throw at import.
+let require = null;
+function load(spec) {
+  require ??= createRequire(import.meta.url ?? process.execPath);
+  return require(spec);
+}
 
 let cached = null;
 
@@ -30,7 +47,7 @@ export function loadNative() {
   const path = process.env.REACT_X11_CALAYERS_PATH;
   for (const spec of [path, PACKAGE].filter(Boolean)) {
     try {
-      const mod = require(spec);
+      const mod = load(spec);
       // the package's index.js exports the raw addon as `native`; a direct
       // path to a built checkout may be the addon itself
       cached = mod.native ?? mod;

--- a/test/cocoa-native.test.js
+++ b/test/cocoa-native.test.js
@@ -1,0 +1,98 @@
+// The cocoa backend's native-bridge loader (src/cocoa/native.js), under the
+// one condition nothing else in this suite creates: a bundle with no
+// `import.meta.url`. Node's single-executable format (docs/packaging.md,
+// tier 3) runs its embedded main as CommonJS, and esbuild's `cjs` output
+// leaves `import.meta` an empty object (its `empty-import-meta` warning), so
+// a `createRequire(import.meta.url)` at module scope threw
+// ERR_INVALID_ARG_VALUE the moment the backend loaded — every cocoa app
+// shipped as a SEA, before the loader could say what it was looking for.
+//
+// The module is re-read here with esbuild's rewrite applied by hand —
+// `import.meta` becomes an empty `import_meta` — which pins the same shape a
+// bundler produces without needing one in the test: the module must import,
+// `REACT_X11_CALAYERS_PATH` must still load, and with nothing to load the
+// error must still be the backend's own, naming what it tried, rather than
+// the loader's complaint about its missing URL.
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { after, before, describe, test } from 'node:test';
+import { pathToFileURL } from 'node:url';
+
+const SOURCE = new URL('../src/cocoa/native.js', import.meta.url);
+
+/**
+ * `fn` as the loader sees a mac — it refuses any other platform before it
+ * looks at a path, and CI runs this on Linux — with REACT_X11_CALAYERS_PATH
+ * naming `path`. Both are restored: a developer's shell may already name a
+ * bridge of its own.
+ */
+function asMac(path, fn) {
+  const platform = process.platform;
+  const env = process.env.REACT_X11_CALAYERS_PATH;
+  Object.defineProperty(process, 'platform', { value: 'darwin' });
+  process.env.REACT_X11_CALAYERS_PATH = path;
+  try {
+    return fn();
+  } finally {
+    Object.defineProperty(process, 'platform', { value: platform });
+    if (env === undefined) delete process.env.REACT_X11_CALAYERS_PATH;
+    else process.env.REACT_X11_CALAYERS_PATH = env;
+  }
+}
+
+describe('src/cocoa/native.js in a CommonJS bundle, without import.meta.url', () => {
+  let dir;
+  let bundled;
+
+  before(() => {
+    const source = readFileSync(SOURCE, 'utf8');
+    assert.ok(
+      source.includes('import.meta.url'),
+      'the loader is built from import.meta.url',
+    );
+    assert.doesNotMatch(
+      source,
+      /from\s+['"]\./,
+      'the module is copied out of the tree, so it can have no relative imports',
+    );
+    dir = mkdtempSync(join(tmpdir(), 'react-x11-sea-'));
+    writeFileSync(
+      join(dir, 'native.mjs'),
+      'const import_meta = {};\n' +
+        source.replaceAll('import.meta', 'import_meta'),
+    );
+    // shaped like @windowkit/appkit's index.js: the addon under `native`
+    writeFileSync(
+      join(dir, 'bridge.cjs'),
+      'module.exports = { native: { addon: true } };\n',
+    );
+    bundled = pathToFileURL(join(dir, 'native.mjs')).href;
+  });
+
+  after(() => rmSync(dir, { recursive: true, force: true }));
+
+  test('imports, and REACT_X11_CALAYERS_PATH still loads', async () => {
+    const { loadNative } = await import(`${bundled}?loads`);
+    assert.deepEqual(asMac(join(dir, 'bridge.cjs'), loadNative), {
+      addon: true,
+    });
+  });
+
+  test("with nothing to load, the error is the backend's, naming what it tried", async () => {
+    const { loadNative } = await import(`${bundled}?nothing`);
+    const missing = join(dir, 'missing.node');
+    assert.throws(
+      () => asMac(missing, loadNative),
+      (err) => {
+        assert.match(err.message, /needs the @windowkit\/appkit native bridge/);
+        assert.ok(err.message.includes(`\n  ${missing}: `), err.message);
+        assert.ok(err.message.includes('\n  @windowkit/appkit: '), err.message);
+        // the loader's own complaint, which is what a SEA used to die with
+        assert.doesNotMatch(err.message, /must be a file URL/);
+        return true;
+      },
+    );
+  });
+});


### PR DESCRIPTION
src/cocoa/native.js made its `require` at module scope, with
`createRequire(import.meta.url)`. In a Node single-executable application,
docs/packaging.md tier 3, esbuild `--format=cjs` and then `node --build-sea`,
esbuild leaves `import.meta` an empty object, so `import.meta.url` is
undefined and the cocoa backend died with ERR_INVALID_ARG_VALUE the moment it
loaded: every cocoa app shipped as a SEA, before the loader could say what it
was trying to load. The docs promised that react-x11 guards its own uses of
`import.meta.url`; this one was not guarded.

The loader is now made on first use, from `import.meta.url` with
`process.execPath` as the fallback. A require built from the executable is
the loader Node's SEA documentation prescribes, since the embedded main's
`__filename` is the executable, and it serves both specs: an absolute
REACT_X11_CALAYERS_PATH resolves from anywhere, and the bare package name
resolves through a node_modules beside the binary. Made lazily, a loader
that cannot be built at all is reported by the backend's own "none could be
loaded" error rather than by a throw at import.

Verified on a real SEA of a cocoa app on macOS. The unmodified source dies
with ERR_INVALID_ARG_VALUE. Fixed, the app mounts a window on the Core
Animation backend with REACT_X11_CALAYERS_PATH at the package directory, at
the calayers.node prebuild, or unset with the package beside the binary;
with nothing to load it prints the backend's usual error naming both
attempts.

The other two module-level uses fail lazily and stay as they are.
src/frame/index.js resolves its child entry at first spawn, so a pane in a
SEA hands its fallback a spawn-phase ERR_INVALID_URL. src/ClickToComponent.js
is only reached through the dynamic import behind
REACT_X11_CLICK_TO_COMPONENT, and createRoot then rejects with
ERR_INVALID_ARG_TYPE. Neither feature can work without files on disk. Both
measured on the same SEA.

test/cocoa-native.test.js re-reads the loader with esbuild's rewrite applied
by hand, `import.meta` becoming an empty `import_meta`, imports the copy from
a temp dir, and pins that REACT_X11_CALAYERS_PATH still loads and that the
failure is the backend's error naming both attempts. Mutation-checked, both
tests fail with ERR_INVALID_ARG_VALUE against the old loader.

docs/packaging.md tier 3 now says which uses react-x11 guards, how <Frame>
and click-to-component fail in a SEA, that createRequire from
process.execPath is the one loader a SEA leaves open, and carries a cocoa
paragraph with the three addon placements plus the --define workaround for
older releases. Tier 5's store recipe, which #505 wrote against the unfixed
loader, drops its second define, and the Upstream note that named the loader
as the local blocker goes with it; the sandboxed store-shape bundle of the
form example was rebuilt without the define and ran, contained, on the Core
Animation backend.

