### PR TITLE
feat(calendar): the desktop's calendar in core, on three rungs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -107,6 +107,11 @@
   backend's notification centre, `org.freedesktop.Notifications`,
   `osascript`, `notify-send`), updating a banner in place, what the user
   did with it, and why the shell-out rungs cannot report back.
+- [desktop-calendar.md](desktop-calendar.md) — the user's real events, with
+  no credential and no OAuth: `useDesktopCalendarEvents()`, the three-rung
+  ladder (EventKit through the bridge, EventKit through an `osascript` child,
+  Evolution Data Server over the bus), why `end` is exclusive everywhere, and
+  why `'denied'` and `'unavailable'` are different words.
 - [eyedropper.md](eyedropper.md) — sample a colour from the screen:
   `useEyedropper()`/`pickScreenColor()`, the two-rung ladder (the portal's
   own picker, a crosshair grab on plain X11), the interface `version`

--- a/docs/desktop-calendar.md
+++ b/docs/desktop-calendar.md
@@ -1,0 +1,265 @@
+# The desktop's calendar
+
+The user's real events — iCloud, Google, Microsoft, CalDAV, a subscribed
+feed, the local one — without asking for a single credential and without an
+OAuth flow, because the desktop already did all of that. Every account in
+System Settings › Internet Accounts, every account in GNOME's Online
+Accounts, is in a store this can read.
+
+```jsx
+import { useDesktopCalendarEvents } from 'react-x11';
+
+function Month({ from, to }) {
+  const { byDay, status, openSettings } = useDesktopCalendarEvents({
+    from,
+    to,
+    watch: true,
+  });
+
+  if (status === 'unavailable') return null; // no calendar on this machine
+  if (status === 'denied')
+    return <Button label="Open Settings" onPress={openSettings} />;
+
+  return (
+    <Calendar
+      dayContent={(day) =>
+        byDay
+          .get(day)
+          ?.slice(0, 3)
+          .map((ev) => (
+            <box
+              key={ev.uid}
+              style={{
+                width: 4,
+                height: 4,
+                borderRadius: 2,
+                backgroundColor: ev.calendar.color ?? '$accent',
+              }}
+            />
+          ))
+      }
+    />
+  );
+}
+```
+
+`<Calendar>` is the grid from
+[`@react-x11/components`](ecosystem.md); the `'YYYY-MM-DD'` keys are the one
+contract between the two packages, which is why `byDay` is here and the grid
+is there. Nothing here draws anything.
+
+## The ladder
+
+The [file dialog](filedialog.md)'s shape again, chosen in order and never by
+naming a backend:
+
+|     |                                  |                                                                                                                                                                                                                                           |
+| --- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | **EventKit through the bridge**  | The [cocoa backend](macos.md), where the app the tree renders through carries `calendars` (`@windowkit/appkit` >= 0.8). One `EKEventStore` for every account, recurrences expanded by the framework, and one notification for any change. |
+| 2   | **EventKit through `osascript`** | A Mac with no bridge — every XQuartz install, and a cocoa app over an older bridge. A long-lived `osascript -l JavaScript` child holds the same store and answers JSON lines. Same framework, slower transport.                           |
+| 3   | **EDS over the session bus**     | `org.gnome.evolution.dataserver.Sources5` / `Calendar8` — the store every GNOME calendar UI reads, and the one GNOME Online Accounts feeds. Recurrences are expanded here, with `ical.js`.                                                |
+| 4   | **nothing**                      | `desktopCalendar()` answers `null` and the hook says `'unavailable'`. An ordinary answer about a machine, not a failure.                                                                                                                  |
+
+```ts
+await calendarBackend(); // 'cocoa' | 'osascript' | 'eds' | null
+```
+
+`calendarBackend()` reads nothing, spawns nothing and prompts nothing, so it
+is safe on a settings screen that wants to say where the events come from.
+
+**Rung 2 outranks rung 3 on a Mac**, which is deliberate: EventKit is that
+machine's real store, and an Evolution Data Server installed beside it would
+be a second, emptier one.
+
+## The imperative half
+
+```ts
+import { desktopCalendar } from 'react-x11';
+
+const cal = await desktopCalendar(); //  DesktopCalendar | null, never rejects
+if (!cal) return; //  nothing on this machine
+try {
+  const calendars = await cal.listCalendars();
+  const { events, errors } = await cal.eventsBetween(from, to, { calendars });
+  const stop = await cal.watch(from, to, () => reload());
+} finally {
+  await cal.close();
+}
+```
+
+`close()` matters on every rung: it stops the views EDS handed out, drops
+this handle's share of the `osascript` child, and releases the bus reference.
+`useDesktopCalendarEvents` does it for you.
+
+`{ required: true }` turns the `null` into a typed `NoCalendarServiceError`
+for a caller who would rather branch in a `catch`, and `{ backend }` pins one
+rung and fails rather than falling past it — which is what a test and a "why
+is this slow" investigation both want.
+
+## One shape, whichever rung answered
+
+```ts
+interface DesktopCalendarInfo {
+  uid: string;
+  name: string;
+  enabled: boolean; //  always true on macOS: no such state to report
+  color?: string; //  '#3584e4'
+  backend?: string; //  'caldav' | 'local' | 'exchange' | 'subscription' | …
+  readOnly: boolean;
+  account?: string; //  the Online Accounts / EKSource entry it came from
+}
+
+interface DesktopEvent {
+  uid: string;
+  summary: string;
+  location?: string;
+  description?: string;
+  start: Date;
+  end: Date; //  exclusive
+  allDay: boolean;
+  recurring: boolean;
+  calendar: { uid: string; name: string; color?: string };
+}
+```
+
+Three things the rungs had to agree on, and they are the whole of why this is
+one module rather than three:
+
+- **`end` is exclusive.** EventKit reports an all-day event as ending at
+  23:59:59 of its last day; iCalendar (so EDS) ends it at the next midnight.
+  An app cannot branch on which store it happens to be reading, so the macOS
+  rungs normalise on the way out and `byDay` may assume it.
+- **A change is "something moved", not a patch.** EDS names the objects that
+  changed and EventKit's notification names nothing at all — and neither can
+  say what a recurrence master edited three months away did to the range on
+  screen. So `watch` reports a change and the only correct answer is to query
+  again.
+- **"Not allowed to look" is not "no events".** Without the grant EventKit
+  answers an empty list, which is a lie an app would draw.
+
+## `byDay`
+
+```ts
+const days = byDay(events); //  Map<'YYYY-MM-DD', DesktopEvent[]>
+days.get(dayKey(new Date())); //  today's
+```
+
+Keyed by **local** day, because a grid draws the user's days. An event lands
+under every day it touches, not only under its start — an all-day span
+crosses several and a timed one can cross midnight. The hook returns the same
+map as `byDay` on its result, already memoised.
+
+## The grant
+
+Only the macOS rungs have one; EDS is reachable or it is not.
+
+```ts
+await cal.access(); //  the permission vocabulary; never prompts
+await cal.requestAccess(); //  the system's prompt, once
+await cal.openSettings(); //  System Settings › Privacy & Security › Calendars
+```
+
+**The first read asks.** `listCalendars()` and `eventsBetween()` raise the
+prompt when the status is `'prompt'`, the way the notification centre's first
+post asks — so a picker the user never opens never prompts, and
+`enabled: false` on the hook is how a button defers it. A refusal is a typed
+`CalendarAccessError` carrying the status, never an empty list.
+
+`'denied'` is the **user's** answer and `'unavailable'` is the **machine's**.
+They are separate words because only one of them has a switch behind it: show
+an Open Settings button on `'denied'` and on nothing else
+([permissions.md](permissions.md) has the same rule for `'unknown'`).
+
+`'write-only'` — macOS 14's partial grant — is a refusal to a reader, so it
+rejects like a denial, but by its own name: an app that also saves events can
+tell the two apart.
+
+### Attribution, and what raises the prompt
+
+TCC attributes a prompt to the **responsible process**: a bare `node` is
+attributed to its responsible process (the terminal, an IDE) or to `node`
+itself, and an `osascript` child is attributed to `osascript` — not to the
+app that spawned it, which is why the second rung's grant is shared with
+every other script on that Mac that has asked. A bundled app is attributed to
+itself and must carry `NSCalendarsFullAccessUsageDescription` (and
+`NSCalendarsWriteOnlyAccessUsageDescription` where it asks for the narrower
+grant) or the request never prompts. See [packaging.md](packaging.md).
+
+Measured on macOS 15.2, with the grant undecided:
+
+- `EKEventStore.authorizationStatusForEntityType` answers from an unbundled
+  process with **no prompt** — a status read is always safe.
+- Creating the store never prompts either; only a request does.
+- Without the grant, `calendarsForEntityType` answers an **empty array** and
+  `eventsMatchingPredicate` an empty one — no error. That is the whole reason
+  the ladder checks the status first rather than reporting "no events".
+- The `osascript` child starts and answers its first line in ~130 ms.
+
+## `useDesktopCalendarEvents()`
+
+```ts
+const {
+  events,
+  byDay,
+  calendars,
+  errors,
+  status,
+  backend,
+  error,
+  refresh,
+  openSettings,
+} = useDesktopCalendarEvents({ from, to, calendars?, watch?, enabled? });
+```
+
+| `status`        |                                                                          |
+| --------------- | ------------------------------------------------------------------------ |
+| `'idle'`        | `enabled: false` — nothing has been asked, including the grant           |
+| `'loading'`     | a read is in flight; the first one may be showing the system's prompt    |
+| `'ready'`       | `events` is this range                                                   |
+| `'denied'`      | the user's answer. `openSettings()` is the way back                      |
+| `'unavailable'` | the machine's answer: no rung. Hide the feature rather than reporting it |
+
+`errors` is none of those: calendars that would not answer while others did.
+One unreachable CalDAV server must not blank a whole month of the user's own
+local calendar, so it is reported beside the events rather than instead of
+them. It is always empty on the macOS rungs, where there is one store.
+
+**`from` and `to` are read by their timestamps, not their identity**, so
+`from={new Date(y, m, 1)}` inline in the render body is fine and does not
+re-query every paint. That is the mistake this hook is shaped to survive.
+
+## What differs between the rungs
+
+- **Recurrences.** EventKit expands them; EDS answers with unexpanded masters
+  and `ical.js` expands them here. A malformed `RRULE` with no `UNTIL` is
+  guarded at 2000 occurrences on that rung.
+- **`enabled`.** EDS reports whether the user switched a calendar off;
+  EventKit has no such state — a calendar unchecked in Calendar.app is still
+  in the store — so it is always `true` there.
+- **The change signal.** EDS names the calendar, the kind (`ObjectsAdded`,
+  `ObjectsModified`, `ObjectsRemoved`) and a count; EventKit's is one
+  `'changed'` with a null calendar and no count, because its notification
+  names nothing and a rung must not invent one.
+- **The range.** EventKit's predicate spans at most four years, so a longer
+  one is asked for in pieces and merged (an occurrence on a seam is reported
+  once). EDS takes any range.
+- **What the app is on the bus.** The EDS rung borrows react-x11's shared
+  session bus ([dbus.md](dbus.md)), so an app is one name on the bus however
+  many features it turns on.
+
+## `ical.js`
+
+A regular dependency, loaded behind one lazy `import('ical.js')` with a
+static specifier: it is 268 KB of a 1.2 MB package, has no dependencies of
+its own, no native code and no install script (MPL-2.0, file-level copyleft).
+The `import()` keeps it off the startup path — an app that never opens a
+calendar never parses it — while a static specifier is something a bundler
+or a single-executable build can still follow, which the run-time-built
+specifier an optional dependency needs is not. Neither macOS rung loads it.
+
+## Writing
+
+Not yet — [#504](https://github.com/sidorares/react-x11/issues/504)'s third
+milestone. The bridge has `saveEvent`/`removeEvent` with the recurrence span
+(`@windowkit/appkit` >= 0.8) and EDS has `CreateObjects`/`ModifyObjects`/
+`RemoveObjects`, so the shape is known; what is here reads.

--- a/docs/desktop-calendar.md
+++ b/docs/desktop-calendar.md
@@ -176,16 +176,35 @@ tell the two apart.
 
 ### Attribution, and what raises the prompt
 
-TCC attributes a prompt to the **responsible process**: a bare `node` is
-attributed to its responsible process (the terminal, an IDE) or to `node`
-itself, and an `osascript` child is attributed to `osascript` — not to the
-app that spawned it, which is why the second rung's grant is shared with
-every other script on that Mac that has asked. A bundled app is attributed to
-itself and must carry `NSCalendarsFullAccessUsageDescription` (and
-`NSCalendarsWriteOnlyAccessUsageDescription` where it asks for the narrower
-grant) or the request never prompts. See [packaging.md](packaging.md).
+**The grant does not belong to `osascript`.** It belongs to whatever owns the
+process tree. Measured on macOS 15.2 by raising the prompt for real through
+the second rung and reading `tccd`'s own record of it
+(`log show --predicate 'subsystem == "com.apple.TCC"'`), the attribution is
+three processes, not one:
 
-Measured on macOS 15.2, with the grant undecided:
+```
+AUTHREQ_ATTRIBUTION: service=kTCCServiceCalendar
+  responsible = the app that owns the tree   (Terminal, iTerm, the IDE — here
+                                              com.anthropic.claude-code)
+  accessing   = com.apple.osascript          (/usr/bin/osascript — the child)
+  requesting  = com.apple.calaccessd         (CalendarDaemon, doing the check)
+```
+
+`responsible` is what TCC keys the decision on and what the dialog names, so:
+
+- The second rung's grant is **shared with everything that terminal or IDE
+  runs** — not with every `osascript` on the Mac, and not with this app
+  alone. Two react-x11 apps started from the same terminal share one answer;
+  the same app launched from Finder asks again.
+- A bare `node` on the bridge rung lands in the same place: attributed to its
+  responsible process, or to `node` itself where it has none.
+- **A bundled app is its own responsible process**, which is the only way to
+  get a prompt that names the app and a grant that is the app's — and it must
+  carry `NSCalendarsFullAccessUsageDescription` (plus
+  `NSCalendarsWriteOnlyAccessUsageDescription` where it asks for the narrower
+  grant) or the request never prompts. See [packaging.md](packaging.md).
+
+Also measured on macOS 15.2, with the grant undecided:
 
 - `EKEventStore.authorizationStatusForEntityType` answers from an unbundled
   process with **no prompt** — a status read is always safe.
@@ -211,13 +230,13 @@ const {
 } = useDesktopCalendarEvents({ from, to, calendars?, watch?, enabled? });
 ```
 
-| `status`        |                                                                          |
-| --------------- | ------------------------------------------------------------------------ |
-| `'idle'`        | `enabled: false` — nothing has been asked, including the grant           |
-| `'loading'`     | a read is in flight; the first one may be showing the system's prompt    |
-| `'ready'`       | `events` is this range                                                   |
-| `'denied'`      | the user's answer. `openSettings()` is the way back                      |
-| `'unavailable'` | the machine's answer: no rung. Hide the feature rather than reporting it |
+| `status`        |                                                                                                                        |
+| --------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `'idle'`        | `enabled: false` — nothing has been asked, including the grant                                                         |
+| `'loading'`     | a read is in flight; the first one may be showing the system's prompt                                                  |
+| `'ready'`       | `events` is this range                                                                                                 |
+| `'denied'`      | the user's answer. `openSettings()` is the way back                                                                    |
+| `'unavailable'` | the machine's answer: no rung — or a request TCC would not even ask (above). Hide the feature rather than reporting it |
 
 `errors` is none of those: calendars that would not answer while others did.
 One unreachable CalDAV server must not blank a whole month of the user's own

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -537,6 +537,7 @@ consumer, so the work is tracked rather than rediscovered.
 | **activation policy / app name**  | **shipped** — `createRoot({ cocoa: { activationPolicy, appName } })`                                                                          | — (bridge 0.5)                                      | react-x11#464 → windowkit/appkit#15 (done)                      |
 | **permissions** (TCC)             | **shipped** — `usePermission()`/`requestPermission()` over the bridge; `openPrivacySettings` on any Mac                                       | — (bridge 0.5); Linux portals are #466's other half | react-x11#466 → windowkit/appkit#19 (done)                      |
 | **notifications**                 | **shipped** — `notify()` over `UNUserNotificationCenter` in a bundle, `osascript` for a bare `node`; `org.freedesktop.Notifications` on Linux | — (bridge 0.5)                                      | react-x11#469 → windowkit/appkit#26 (done)                      |
+| **calendar** (EventKit)           | **shipped** — `useDesktopCalendarEvents()` over `EKEventStore`, an `osascript` child under XQuartz; Evolution Data Server on Linux            | — (bridge 0.8)                                      | react-x11#504 → windowkit/appkit#39, #40 (done); writes are #41 |
 
 Two of these have a **freedesktop counterpart worth having in core with no
 bridge at all**, because they are D-Bus like the portal and the global menu

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -56,21 +56,24 @@ type PermissionKind =
   | 'accessibility'
   | 'input-monitoring'
   | 'automation'
-  | 'location';
+  | 'location'
+  | 'calendars'
+  | 'reminders';
 
 type PermissionStatus =
-  'granted' | 'denied' | 'restricted' | 'prompt' | 'unknown';
+  'granted' | 'denied' | 'restricted' | 'prompt' | 'write-only' | 'unknown';
 ```
 
-A status is one of five words, and two of them are not the platform's:
+A status is one of six words, and two of them are not the platform's:
 
-|                |                                                                                                                |
-| -------------- | -------------------------------------------------------------------------------------------------------------- |
-| `'granted'`    | use it                                                                                                         |
-| `'denied'`     | the user said no; `openPrivacySettings()` is the way back                                                      |
-| `'restricted'` | MDM or parental controls — the user **cannot** grant it, so no Settings button                                 |
-| `'prompt'`     | not decided yet — `request()` would ask                                                                        |
-| `'unknown'`    | nothing here can say. A fact about the machine, not the permission, and the reason a status query never throws |
+|                |                                                                                                                                                                                                                                  |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `'granted'`    | use it                                                                                                                                                                                                                           |
+| `'denied'`     | the user said no; `openPrivacySettings()` is the way back                                                                                                                                                                        |
+| `'restricted'` | MDM or parental controls — the user **cannot** grant it, so no Settings button                                                                                                                                                   |
+| `'prompt'`     | not decided yet — `request()` would ask                                                                                                                                                                                          |
+| `'write-only'` | macOS 14's partial grant for `calendars` and `reminders`: the app may **save** an item it cannot read. A grant to a writer and a refusal to a reader, so it crosses as its own word rather than being flattened into one of them |
+| `'unknown'`    | nothing here can say. A fact about the machine, not the permission, and the reason a status query never throws                                                                                                                   |
 
 A request answers with the **status after the user answered**, never a bare
 boolean, because `'denied'` and `'restricted'` want different UI.
@@ -110,24 +113,29 @@ permissionBackend(); // 'cocoa' | null, synchronously
 Not every kind has a prompt of its own, and the shape of the request follows
 the framework's:
 
-| kind                   | status                | the "prompt"                                                                                                            |
-| ---------------------- | --------------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `camera`, `microphone` | all five              | the system's in-process dialog; the answer arrives when the user clicks                                                 |
-| `screen-recording`     | never `'prompt'`      | the system's go-to-Settings dialog, shown once; the request resolves at once, and a new grant needs a **restart**       |
-| `accessibility`        | never `'prompt'`      | the go-to-Settings dialog; resolves at once, and the grant applies live                                                 |
-| `input-monitoring`     | `'prompt'` while open | posts the prompt and resolves at once                                                                                   |
-| `automation`           | per **target**        | `{ target: 'com.apple.finder' }` — the bundle id of a **running** app, or the call throws; asking blocks until answered |
-| `location`             | all five              | `requestWhenInUseAuthorization`, answered through the run loop                                                          |
-| `files-and-folders`    | —                     | no API: reading the folder _is_ the prompt and `EPERM` the denial; `openPrivacySettings` reaches the pane               |
-| `full-disk-access`     | —                     | no API; `openPrivacySettings('full-disk-access')`                                                                       |
+| kind                   | status                | the "prompt"                                                                                                                                        |
+| ---------------------- | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `camera`, `microphone` | all five              | the system's in-process dialog; the answer arrives when the user clicks                                                                             |
+| `screen-recording`     | never `'prompt'`      | the system's go-to-Settings dialog, shown once; the request resolves at once, and a new grant needs a **restart**                                   |
+| `accessibility`        | never `'prompt'`      | the go-to-Settings dialog; resolves at once, and the grant applies live                                                                             |
+| `input-monitoring`     | `'prompt'` while open | posts the prompt and resolves at once                                                                                                               |
+| `automation`           | per **target**        | `{ target: 'com.apple.finder' }` — the bundle id of a **running** app, or the call throws; asking blocks until answered                             |
+| `location`             | all five              | `requestWhenInUseAuthorization`, answered through the run loop                                                                                      |
+| `calendars`            | plus `'write-only'`   | EventKit's own prompt. `{ access: 'write-only' }` asks the narrower one; the grant is what [desktop-calendar.md](desktop-calendar.md) reads through |
+| `reminders`            | plus `'write-only'`   | the same store, a separate grant. `{ access: 'write-only' }` is a `TypeError` here: reminders have no such grant                                    |
+| `files-and-folders`    | —                     | no API: reading the folder _is_ the prompt and `EPERM` the denial; `openPrivacySettings` reaches the pane                                           |
+| `full-disk-access`     | —                     | no API; `openPrivacySettings('full-disk-access')`                                                                                                   |
 
 **Attribution is the thing to know.** A bare `node` process is attributed to
 its _responsible process_ — the terminal, an IDE — or to `node` itself, and
 prompts with no usage-description strings. A bundled app must carry the keys
 (`NSCameraUsageDescription`, `NSMicrophoneUsageDescription`,
-`NSLocationUsageDescription`, `NSAppleEventsUsageDescription`) in its
-`Info.plist` — without them the request never prompts, or TCC ends the
-process. See [packaging.md](packaging.md).
+`NSLocationUsageDescription`, `NSAppleEventsUsageDescription`,
+`NSCalendarsFullAccessUsageDescription`,
+`NSCalendarsWriteOnlyAccessUsageDescription`,
+`NSRemindersFullAccessUsageDescription`) in its `Info.plist` — without them
+the request never prompts, or TCC ends the process. See
+[packaging.md](packaging.md).
 
 ## What differs between the rungs
 

--- a/docs/system.md
+++ b/docs/system.md
@@ -383,6 +383,14 @@ two desktop standards with a claim on core — are now built: **notifications**
 freedesktop StatusNotifierItem half still tracked in
 [#353](https://github.com/sidorares/react-x11/issues/353).
 
+**The user's calendar.** Their real events, from the accounts the desktop
+already holds — EventKit on macOS, Evolution Data Server on a freedesktop
+session — are [desktop-calendar.md](desktop-calendar.md):
+`useDesktopCalendarEvents()`, keyed the way a calendar grid asks. It is not a
+system _setting_, which is why it is its own page rather than a hook here,
+but it is the same kind of thing as the rest of this one: something the
+desktop knows that an app would otherwise ask the user to type in again.
+
 **A launcher badge, and permission prompts.** An unread count on the icon
 (freedesktop `com.canonical.Unity.LauncherEntry`, one D-Bus signal; macOS
 `dockTile.badgeLabel`) and camera/mic/location authorization (the freedesktop

--- a/examples/calendar.jsx
+++ b/examples/calendar.jsx
@@ -44,10 +44,13 @@ import {
 const DIM = '$textMuted';
 const DAY_MS = 24 * 60 * 60 * 1000;
 
-/** Midnight on the Monday of the week `offset` weeks from this one. */
-function weekStart(offset) {
-  const now = new Date();
-  const monday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+/** Midnight on the Monday of the week `offset` weeks from `today`'s. */
+function weekStart(today, offset) {
+  const monday = new Date(
+    today.getFullYear(),
+    today.getMonth(),
+    today.getDate(),
+  );
   monday.setDate(monday.getDate() - ((monday.getDay() + 6) % 7) + offset * 7);
   return monday;
 }
@@ -90,9 +93,12 @@ function Day({ date, events }) {
   );
 }
 
-function App() {
+/** `today` is a seam, not a prop an app would pass: the week on screen is
+ *  this week, and a test needs one that does not move (AGENTS.md's sensible
+ *  default with a seam). */
+export default function App({ today = new Date() }) {
   const [offset, setOffset] = useState(0);
-  const from = weekStart(offset);
+  const from = weekStart(today, offset);
   const to = new Date(from.getTime() + 7 * DAY_MS);
 
   const { byDay, calendars, errors, status, backend, openSettings, refresh } =

--- a/examples/calendar.jsx
+++ b/examples/calendar.jsx
@@ -1,0 +1,188 @@
+// This week, out of the calendars the desktop already has.
+//
+//   REACT_X11_BACKEND=cocoa npm run examples:calendar   # EventKit, through the bridge
+//   npm run examples:calendar                           # XQuartz: an osascript child
+//                                                       # Linux: Evolution Data Server
+//
+// The point is that this app has no accounts, no tokens and no OAuth flow,
+// and still shows the user's real Google/iCloud/Exchange/CalDAV events: the
+// desktop did all of that, and `useDesktopCalendarEvents()` reads what it
+// holds (docs/desktop-calendar.md).
+//
+// ## What to try
+//
+//   Run it        the first read raises the system's permission prompt on a
+//                 Mac — once, and only because a read asked. Allow it and
+//                 the week fills in; refuse and the app says so and offers
+//                 the Settings pane, because `'denied'` is the user's answer
+//                 and it is one they can change.
+//
+//   ← / →         another week. The dates are new `Date`s every render and
+//                 the hook reads them by value, so paging is one query, not
+//                 one per frame.
+//
+//   Move an event in Calendar (or GNOME Calendar) while this is open: the
+//                 store posts a change, `watch` reports it, and the week
+//                 re-queries itself. Nothing here patches an event — a
+//                 recurrence master edited months away can change today.
+//
+// ## The footer is the interesting line
+//
+// It says which rung answered. On one machine that is the bridge, on the
+// next the same app is talking to an `osascript` child holding the same
+// framework, and on a Linux box it is D-Bus — with the same events in the
+// same shape, an exclusive `end` on all three.
+import React, { useMemo, useState } from 'react';
+
+import {
+  Button,
+  createRoot,
+  dayKey,
+  useDesktopCalendarEvents,
+} from '../src/index.js';
+
+const DIM = '$textMuted';
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Midnight on the Monday of the week `offset` weeks from this one. */
+function weekStart(offset) {
+  const now = new Date();
+  const monday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  monday.setDate(monday.getDate() - ((monday.getDay() + 6) % 7) + offset * 7);
+  return monday;
+}
+
+const time = (date) =>
+  date.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+
+function Day({ date, events }) {
+  const heading = date.toLocaleDateString(undefined, {
+    weekday: 'long',
+    day: 'numeric',
+    month: 'short',
+  });
+  return (
+    <box style={{ flexDirection: 'column', gap: 2 }}>
+      <text style={{ fontWeight: 'bold', fontSize: 12 }}>{heading}</text>
+      {events.length === 0 && (
+        <text style={{ color: DIM, fontSize: 11, marginLeft: 8 }}>—</text>
+      )}
+      {events.map((ev) => (
+        <box
+          key={`${ev.uid}-${ev.start.getTime()}`}
+          style={{ flexDirection: 'row', gap: 6, alignItems: 'center' }}
+        >
+          <box
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: 3,
+              backgroundColor: ev.calendar.color ?? '$accent',
+            }}
+          />
+          <text style={{ color: DIM, fontSize: 11, width: 90 }}>
+            {ev.allDay ? 'all day' : `${time(ev.start)}–${time(ev.end)}`}
+          </text>
+          <text style={{ fontSize: 12 }}>{ev.summary || '(no title)'}</text>
+        </box>
+      ))}
+    </box>
+  );
+}
+
+function App() {
+  const [offset, setOffset] = useState(0);
+  const from = weekStart(offset);
+  const to = new Date(from.getTime() + 7 * DAY_MS);
+
+  const { byDay, calendars, errors, status, backend, openSettings, refresh } =
+    useDesktopCalendarEvents({ from, to, watch: true });
+
+  const days = useMemo(
+    () =>
+      Array.from({ length: 7 }, (_, i) => {
+        const date = new Date(
+          from.getFullYear(),
+          from.getMonth(),
+          from.getDate() + i,
+        );
+        return { date, events: byDay.get(dayKey(date)) ?? [] };
+      }),
+    [byDay, from],
+  );
+
+  return (
+    <window title="This week" width={460} height={520}>
+      <box
+        style={{ flexDirection: 'column', gap: 10, padding: 14, flexGrow: 1 }}
+      >
+        <box style={{ flexDirection: 'row', gap: 8, alignItems: 'center' }}>
+          <Button
+            label="◀"
+            size="small"
+            onPress={() => setOffset((n) => n - 1)}
+          />
+          <Button
+            label="▶"
+            size="small"
+            onPress={() => setOffset((n) => n + 1)}
+          />
+          <text style={{ fontSize: 13, fontWeight: 'bold' }}>
+            {from.toLocaleDateString(undefined, {
+              day: 'numeric',
+              month: 'long',
+            })}
+          </text>
+          <box style={{ flexGrow: 1 }} />
+          <Button label="Refresh" size="small" onPress={refresh} />
+        </box>
+
+        {status === 'unavailable' && (
+          <text style={{ color: DIM, fontSize: 12 }}>
+            No calendar service on this machine — no EventKit bridge, not a Mac,
+            and no Evolution Data Server on the session bus.
+          </text>
+        )}
+
+        {status === 'denied' && (
+          <box style={{ flexDirection: 'column', gap: 6 }}>
+            <text style={{ fontSize: 12 }}>
+              This app may not read your calendars.
+            </text>
+            <Button label="Open Settings" primary onPress={openSettings} />
+          </box>
+        )}
+
+        {status === 'loading' && (
+          <text style={{ color: DIM, fontSize: 12 }}>Reading…</text>
+        )}
+
+        {status === 'ready' &&
+          days.map((day) => (
+            <Day key={dayKey(day.date)} date={day.date} events={day.events} />
+          ))}
+
+        {errors.map((err) => (
+          <text
+            key={err.calendar.uid}
+            style={{ color: '$warning', fontSize: 11 }}
+          >
+            {err.calendar.name} did not answer: {err.message}
+          </text>
+        ))}
+
+        <box style={{ flexGrow: 1 }} />
+        <text style={{ color: DIM, fontSize: 11 }}>
+          {backend
+            ? `${backend} — ${calendars.length} calendar${calendars.length === 1 ? '' : 's'}`
+            : 'no calendar backend here'}
+        </text>
+      </box>
+    </window>
+  );
+}
+
+if (!process.env.REACT_X11_NO_AUTORUN && !import.meta.hot) {
+  const root = await createRoot({ cocoa: { appName: 'This week' } });
+  root.render(<App />);
+}

--- a/examples/calendar.jsx
+++ b/examples/calendar.jsx
@@ -104,17 +104,22 @@ export default function App({ today = new Date() }) {
   const { byDay, calendars, errors, status, backend, openSettings, refresh } =
     useDesktopCalendarEvents({ from, to, watch: true });
 
+  // Keyed on the timestamp, not the `Date`: `from` is a new object every
+  // render, and a memo keyed on it would rebuild the week every paint —
+  // the same mistake the hook's own `from`/`to` are shaped to survive.
+  const fromMs = from.getTime();
   const days = useMemo(
     () =>
       Array.from({ length: 7 }, (_, i) => {
+        const at = new Date(fromMs);
         const date = new Date(
-          from.getFullYear(),
-          from.getMonth(),
-          from.getDate() + i,
+          at.getFullYear(),
+          at.getMonth(),
+          at.getDate() + i,
         );
         return { date, events: byDay.get(dayKey(date)) ?? [] };
       }),
-    [byDay, from],
+    [byDay, fromMs],
   );
 
   return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.9.0",
       "license": "MIT",
       "dependencies": {
+        "ical.js": "^2.2.1",
         "linebreak": "^1.1.0",
         "ntk": "^8.7.0",
         "react-reconciler": "^0.33.0",
@@ -39,7 +40,7 @@
         "node": ">=20.19"
       },
       "optionalDependencies": {
-        "@windowkit/appkit": "^0.7.0",
+        "@windowkit/appkit": "^0.8.0",
         "dbus-native": "^0.15.1",
         "x11-dri": "^0.7.0"
       },
@@ -1515,9 +1516,9 @@
       }
     },
     "node_modules/@windowkit/appkit": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@windowkit/appkit/-/appkit-0.7.0.tgz",
-      "integrity": "sha512-1QKY2juGtM4Fbvp2yrvmbxJuSwfpX/WoQpcD5aImo+astaWG8VURG3OhfT7zD8eFshc2f9aiQ18LULzJXA2KFA==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@windowkit/appkit/-/appkit-0.8.0.tgz",
+      "integrity": "sha512-jBcd2n7R2grvWrmSpKsCFgUn3UmQuGXGYrnw/nL+Wkv+gPMHShNac91sDkudXbS6TRMzUDtKVExSLa3NHLlaZQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -3213,6 +3214,12 @@
       "engines": {
         "node": ">=20.19.0"
       }
+    },
+    "node_modules/ical.js": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ical.js/-/ical.js-2.2.1.tgz",
+      "integrity": "sha512-yK/UlPbEs316igb/tjRgbFA8ZV75rCsBJp/hWOatpyaPNlgw0dGDmU+FoicOcwX4xXkeXOkYiOmCqNPFpNPkQg==",
+      "license": "MPL-2.0"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "examples:tooltips": "tsx examples/tooltips.jsx",
     "examples:chat": "tsx examples/chat.jsx",
     "examples:clipboard": "tsx examples/clipboard.jsx",
+    "examples:calendar": "tsx examples/calendar.jsx",
     "labs:urischeme": "tsx examples/labs/urischeme.jsx",
     "filedialog:probe": "node scripts/filedialog-probe.mjs",
     "a11y:probe": "node scripts/a11y-probe.mjs",
@@ -92,13 +93,14 @@
     "node": ">=20.19"
   },
   "dependencies": {
+    "ical.js": "^2.2.1",
     "linebreak": "^1.1.0",
     "ntk": "^8.7.0",
     "react-reconciler": "^0.33.0",
     "yoga-layout": "^3.2.1"
   },
   "optionalDependencies": {
-    "@windowkit/appkit": "^0.7.0",
+    "@windowkit/appkit": "^0.8.0",
     "dbus-native": "^0.15.1",
     "x11-dri": "^0.7.0"
   },

--- a/src/cocoa/app.js
+++ b/src/cocoa/app.js
@@ -25,6 +25,7 @@ import { CocoaGLArea, cocoaGLConfig, resolveCocoaGLRuntime } from './glarea.js';
 import { CocoaDockMenu } from './dock.js';
 import { CocoaGlobalMenuExport } from './globalmenu.js';
 import { CocoaStatusItem } from './statusitem.js';
+import { CocoaCalendars } from './calendar.js';
 import { CocoaNotifications } from './notifications.js';
 import { CocoaPaneHost } from './panehost.js';
 import { CocoaPermissions } from './permissions.js';
@@ -175,6 +176,17 @@ export class CocoaApp {
       typeof native.postNotification === 'function' &&
       typeof native.notificationSettings === 'function'
         ? new CocoaNotifications(this)
+        : null;
+
+    // EventKit (src/cocoa/calendar.js). Present exactly when the bridge has
+    // it (>= 0.8), and its presence is the top rung of
+    // src/desktopcalendar.js's ladder for this app — an older bridge leaves
+    // the ladder to find `osascript` instead, which answers the same
+    // questions out of the same framework.
+    this.calendars =
+      typeof native.calendars === 'function' &&
+      typeof native.eventsBetween === 'function'
+        ? new CocoaCalendars(this)
         : null;
 
     // The GL policy, glbackend.js's shape. No GLX exists here, so the
@@ -766,6 +778,12 @@ export class CocoaApp {
       case 'notification-action':
       case 'notification-dismissed':
         this.notifications?.route(ev);
+        return this._afterInput();
+      case 'calendar-store-changed':
+        // EventKit's own notification, which names nothing that changed. A
+        // watcher's answer is to query again, and that query's result is a
+        // render, so the frame goes out the way an input's does.
+        this.calendars?.route(ev);
         return this._afterInput();
       case 'animation-end':
         // the presenter that added the animation registered for its id; an

--- a/src/cocoa/calendar.js
+++ b/src/cocoa/calendar.js
@@ -1,0 +1,186 @@
+// The user's calendars on the cocoa backend — EventKit (`EKEventStore`)
+// through @windowkit/appkit (>= 0.8), the top rung of
+// src/desktopcalendar.js's ladder. `CocoaApp.calendars` is this object and
+// its *presence* is the capability, the rule `filePanels`, `permissions` and
+// `notifications` follow, so the ladder never names a backend.
+//
+// EventKit is the macOS counterpart of Evolution Data Server plus GNOME
+// Online Accounts in one framework: every account the user added in System
+// Settings > Internet Accounts — iCloud, Google, Exchange, CalDAV, a
+// subscribed feed — is served by one store, the desktop did the OAuth, and
+// the app never sees a credential.
+//
+// Three things about the framework shape the code here:
+//
+// - **It expands recurrences itself.** `predicateForEventsWithStartDate…`
+//   answers occurrences, so there is no `ical.js` on this rung and no
+//   recurrence arithmetic to get wrong. The EDS rung pays for that
+//   client-side; this one does not.
+// - **The predicate spans at most four years** (the framework's own limit),
+//   so a longer range is asked for in chunks and the pieces are merged —
+//   `chunkSpan` in ../desktopcalendar.js, shared with the `osascript` rung
+//   because it is the same framework underneath.
+// - **An all-day event ends at the last second of its last day.** Every
+//   other rung, and `byDay`, read `end` as exclusive, so it is normalised
+//   here — at the edge, once, rather than in every consumer.
+//
+// A change to anything in the store arrives as one `calendar-store-changed`
+// backend event that names nothing, so `watch` reports `kind: 'changed'`
+// with a null calendar and no count. Re-query; do not try to patch.
+
+import {
+  calendarBackendName,
+  chunkSpan,
+  hexFromComponents,
+  sortEvents,
+  withExclusiveEnd,
+} from '../desktopcalendar.js';
+
+/** `EKCalendar` as the shape every rung answers with. */
+export function calendarInfo(cal) {
+  return {
+    uid: String(cal.id),
+    name: cal.title ?? '',
+    // EventKit has no "unchecked in the sidebar" state to report — a
+    // calendar hidden in Calendar.app is still in the store — so every
+    // calendar here is enabled, which is what `enabled` means to a caller
+    // filtering the list.
+    enabled: true,
+    color: hexFromComponents(cal.color),
+    backend: calendarBackendName(cal.type),
+    readOnly: cal.allowsModifications === false || cal.immutable === true,
+    // The account the calendar came from, which is what the EDS rung's
+    // `account` is too: an `EKSource` is the Internet Accounts entry.
+    account: cal.source?.title ?? undefined,
+  };
+}
+
+/** One occurrence from the bridge as the shape every rung answers with. */
+export function desktopEvent(ev, byId) {
+  const meta = byId.get(String(ev.calendar));
+  const start = new Date(ev.start);
+  return {
+    uid: String(ev.id ?? ev.itemId ?? `${ev.calendar}:${ev.start}`),
+    summary: ev.title ?? '',
+    location: ev.location ?? undefined,
+    description: ev.notes ?? undefined,
+    start,
+    end: withExclusiveEnd(new Date(ev.end), Boolean(ev.allDay)),
+    allDay: Boolean(ev.allDay),
+    recurring: Boolean(ev.recurring),
+    calendar: meta
+      ? { uid: meta.uid, name: meta.name, color: meta.color }
+      : { uid: String(ev.calendar), name: '' },
+  };
+}
+
+export class CocoaCalendars {
+  constructor(app) {
+    this.app = app;
+    this._native = app._native;
+    this.backend = 'cocoa';
+    this._watchers = new Set();
+  }
+
+  /**
+   * The TCC grant, read without prompting. `'write-only'` is macOS 14's
+   * partial grant, which is a refusal to a reader — but its own word, so a
+   * caller that only saves events can tell it from a denial.
+   */
+  async access() {
+    return this.app.permissions
+      ? this.app.permissions.status('calendars')
+      : 'unknown';
+  }
+
+  /** The system prompt, once per app; the status after the user answered. */
+  async requestAccess() {
+    return this.app.permissions
+      ? this.app.permissions.request('calendars')
+      : 'unknown';
+  }
+
+  listCalendars() {
+    return new Promise((resolve, reject) => {
+      this._native.calendars((err, list) =>
+        err ? reject(err) : resolve((list ?? []).map(calendarInfo)),
+      );
+    });
+  }
+
+  _events(range) {
+    return new Promise((resolve, reject) => {
+      this._native.eventsBetween(range, (err, events) =>
+        err ? reject(err) : resolve(events ?? []),
+      );
+    });
+  }
+
+  /**
+   * The occurrences in a range, already expanded by the framework.
+   *
+   * `errors` is always empty here: there is one store, and a failure in it
+   * is a failure of the whole read rather than of one account. The EDS rung
+   * is the one where a single unreachable CalDAV server must not blank the
+   * month.
+   */
+  async eventsBetween(from, to, options = {}) {
+    const metas = options.calendars ?? (await this.listCalendars());
+    // "These calendars, of which there are none" is not "every calendar",
+    // which is what an empty filter means to the predicate underneath. A
+    // caller whose filter matched nothing must get nothing.
+    if (options.calendars && metas.length === 0) {
+      return { events: [], errors: [] };
+    }
+    const byId = new Map(metas.map((meta) => [meta.uid, meta]));
+    const ids = options.calendars ? metas.map((meta) => meta.uid) : undefined;
+
+    const events = [];
+    const seen = new Set();
+    for (const [start, end] of chunkSpan(from, to)) {
+      const raw = await this._events({ start, end, calendars: ids });
+      for (const one of raw) {
+        // An occurrence that straddles a chunk boundary is reported by both
+        // predicates; the caller must not see it twice.
+        const key = `${one.id} ${one.start}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        events.push(desktopEvent(one, byId));
+      }
+    }
+    return { events: sortEvents(events), errors: [] };
+  }
+
+  /**
+   * `EKEventStoreChangedNotification`, as the ladder's change signal.
+   *
+   * The notification names neither the calendar nor what happened — a
+   * detail EventKit does not have — so the change carries a null calendar
+   * and no count, and re-querying is the only correct answer. Every watcher
+   * hears every change, whatever range it asked for, because a change
+   * outside a range can still move what is inside it (a recurrence master
+   * edited months away).
+   */
+  async watch(from, to, onChange) {
+    const entry = { onChange };
+    this._watchers.add(entry);
+    return async () => {
+      this._watchers.delete(entry);
+    };
+  }
+
+  /** `calendar-store-changed`, routed from the app's backend callback. */
+  route() {
+    for (const entry of [...this._watchers]) {
+      try {
+        entry.onChange({ calendar: null, kind: 'changed', count: null });
+      } catch {
+        // a watcher that throws is not the other watchers' problem
+      }
+    }
+  }
+
+  /** Nothing to release: the store belongs to the process, and a handle's
+   *  own watchers are dropped by the stop function `watch` returned. */
+  async close() {}
+}

--- a/src/cocoa/permissions.js
+++ b/src/cocoa/permissions.js
@@ -13,23 +13,32 @@
 // bundled app must carry the usage-description keys
 // (`NSCameraUsageDescription` and friends) or a request never prompts.
 
-/** Apple's four words as the ladder's. */
+/** Apple's words as the ladder's. `writeOnly` is macOS 14's partial grant
+ *  for EventKit — a grant to a writer, a refusal to a reader — and stays its
+ *  own word for exactly that reason. */
 const STATUS = Object.freeze({
   authorized: 'granted',
   denied: 'denied',
   restricted: 'restricted',
   notDetermined: 'prompt',
+  writeOnly: 'write-only',
 });
 
 export function statusFromBridge(status) {
   return STATUS[status] ?? 'unknown';
 }
 
-/** The bridge's options for a kind: `automation` carries its target. */
+/** The bridge's options for a kind: `automation` carries its target, and
+ *  `calendars` the level being asked for (`reminders` has no write-only
+ *  grant, and the bridge refuses one with a TypeError). */
 function bridgeOptions(kind, options = {}) {
-  return kind === 'automation' && options.target != null
-    ? { target: String(options.target) }
-    : undefined;
+  if (kind === 'automation' && options.target != null) {
+    return { target: String(options.target) };
+  }
+  if (kind === 'calendars' && options.access != null) {
+    return { access: String(options.access) };
+  }
+  return undefined;
 }
 
 export class CocoaPermissions {

--- a/src/desktopcalendar.js
+++ b/src/desktopcalendar.js
@@ -783,14 +783,44 @@ function watch() {
 
 function request(id) {
   var s = eventStore();
-  var done = function () { emit({ id: id, ok: statusWord() }); };
-  // macOS 14 split the one request in two; before it there was only the
-  // entity-type form.
-  if (typeof s.requestFullAccessToEventsWithCompletion === 'function') {
-    s.requestFullAccessToEventsWithCompletion(done);
-  } else {
-    s.requestAccessToEntityTypeCompletion($.EKEntityTypeEvent, done);
+  var answered = false;
+  var reply = function () {
+    if (answered) return;
+    answered = true;
+    emit({ id: id, ok: statusWord() });
+  };
+  // The completion is asked for and answered on if it ever comes — but it is
+  // never waited on. **Measured on macOS 15.2: an osascript process is never
+  // called back**, not even when the grant is already held, so a rung that
+  // waited for it would hang forever on its first read. The status is what
+  // the caller wanted anyway, and it is the one thing that cannot be lost.
+  try {
+    // macOS 14 split the one request in two; before it there was only the
+    // entity-type form.
+    if (typeof s.requestFullAccessToEventsWithCompletion === 'function') {
+      s.requestFullAccessToEventsWithCompletion(reply);
+    } else {
+      s.requestAccessToEntityTypeCompletion($.EKEntityTypeEvent, reply);
+    }
+  } catch (e) {
+    // whatever the framework refused, the poll below still answers
   }
+  // So the answer is the status, watched until it stops being undecided.
+  // The deadline is for the case that has no dialog at all: TCC declines to
+  // ask for a platform binary, and for a responsible app whose hardened
+  // runtime lacks com.apple.security.personal-information.calendars — and
+  // then nothing will ever change. 'prompt' is the honest answer there, and
+  // the JS side does not remember it, so a later read asks again.
+  var waited = 0;
+  $.NSTimer.scheduledTimerWithTimeIntervalRepeatsBlock(0.25, true,
+    function (timer) {
+      waited += 0.25;
+      if (answered) { timer.invalidate; return; }
+      if (statusWord() !== 'prompt' || waited >= 30) {
+        timer.invalidate;
+        reply();
+      }
+    });
 }
 
 function handle(msg) {
@@ -1320,6 +1350,11 @@ export class DesktopCalendar {
       });
     }
     const status = await this._asked;
+    // An undecided answer is not an answer: it means the request was made
+    // and nothing came back — TCC declining to ask (see the JXA program's
+    // `request`). Remembering it would keep a whole session behind a
+    // decision the user may make in Settings a moment later.
+    if (status === 'prompt') this._asked = null;
     if (status !== 'granted' && status !== 'unknown') {
       throw new CalendarAccessError(status);
     }

--- a/src/desktopcalendar.js
+++ b/src/desktopcalendar.js
@@ -92,9 +92,14 @@ export class NoCalendarServiceError extends Error {
  * `status` is the permission vocabulary (docs/permissions.md): `'denied'`,
  * `'restricted'` (MDM or parental controls), `'write-only'` (macOS 14's
  * partial grant — a real grant to a writer, a refusal to a reader), or
- * `'unknown'`. Separate from {@link NoCalendarServiceError} on purpose:
- * this one is the user's answer, and the user can change it —
- * `openPrivacySettings('calendars')` puts them in front of the switch.
+ * `'prompt'` where the request was made and nothing came back, which is TCC
+ * declining to ask rather than the user declining to allow. `'unknown'` is
+ * not among them: where nothing can say, the read is allowed to try and
+ * whatever it hits is the answer.
+ *
+ * Separate from {@link NoCalendarServiceError} on purpose: this one is
+ * about a decision, and a decision can be changed —
+ * `openPrivacySettings('calendars')` puts the user in front of the switch.
  */
 export class CalendarAccessError extends Error {
   constructor(status, cause) {

--- a/src/desktopcalendar.js
+++ b/src/desktopcalendar.js
@@ -1,0 +1,1375 @@
+// The calendars the user's desktop already has — read, not owned.
+//
+// The point of this module is that an app gets the user's real events —
+// iCloud, Google, Microsoft, CalDAV, local — without asking for a single
+// credential and without an OAuth flow, because the desktop already did all
+// of that. Every account in System Settings > Internet Accounts, every
+// account in GNOME's Online Accounts, is already in a store this can read.
+//
+// docs/filedialog.md's ladder again, chosen in order and never by name:
+//
+//   1. **EventKit through the bridge** — the cocoa backend, where the app
+//      the tree renders through carries `calendars` (src/cocoa/calendar.js).
+//      One framework for every account, recurrences expanded by it, and one
+//      notification for any change.
+//   2. **EventKit through `osascript`** — macOS with no bridge, which is
+//      every XQuartz install and every cocoa app over a bridge older than
+//      0.8. A long-lived `osascript -l JavaScript` child holds an
+//      `EKEventStore` and answers JSON lines: the same framework, a slower
+//      transport, and the rung that shipped before the bridge did.
+//   3. **EDS over the session bus** — `org.gnome.evolution.dataserver.*`,
+//      the store every GNOME calendar UI reads and the one GNOME Online
+//      Accounts feeds. Recurrences are expanded here with `ical.js`,
+//      because EDS answers with unexpanded masters.
+//   4. **nothing** — `desktopCalendar()` answers `null`, which is an
+//      ordinary answer about a machine rather than a failure. Only
+//      `{ required: true }` turns it into a typed rejection.
+//
+// ## What the ladder had to agree on
+//
+// - **`end` is exclusive.** EventKit reports an all-day event ending at the
+//   last second of its last day and iCalendar ends it at the next midnight;
+//   an app cannot branch on which store it happens to be reading, so the
+//   macOS rungs normalise (`withExclusiveEnd`) and `byDay` may assume it.
+// - **A change is "something moved", not a patch.** EDS names the objects,
+//   EventKit's notification names nothing at all, and a recurrence master
+//   edited three months away changes what today looks like either way. So
+//   `watch` reports a change and the answer is always to query again.
+// - **"Not allowed to look" is not "no events".** The macOS rungs need the
+//   TCC grant; without it a read would answer an empty list, which is a lie.
+//   They ask on the first read and reject with {@link CalendarAccessError}
+//   when the answer is no, and `'denied'` (the user's answer) stays apart
+//   from `null` (the machine's).
+//
+// Nothing here opens a D-Bus connection of its own: `sessionBus()` hands
+// over react-x11's shared one, so an app is one name on the bus however many
+// features it turns on. Nothing here writes, either — issue #504's third
+// milestone.
+
+import { hasService } from './portal.js';
+import { openPrivacySettings } from './permissions.js';
+import { sessionBus } from './bus.js';
+import { liveApps } from './trace-registry.js';
+
+const SOURCES_NAME = 'org.gnome.evolution.dataserver.Sources5';
+const SOURCES_PATH = '/org/gnome/evolution/dataserver/SourceManager';
+const OBJECT_MANAGER = 'org.freedesktop.DBus.ObjectManager';
+const FACTORY_NAME = 'org.gnome.evolution.dataserver.Calendar8';
+const FACTORY_PATH = '/org/gnome/evolution/dataserver/CalendarFactory';
+const FACTORY_IFACE = 'org.gnome.evolution.dataserver.CalendarFactory';
+const CAL_IFACE = 'org.gnome.evolution.dataserver.Calendar';
+const VIEW_IFACE = 'org.gnome.evolution.dataserver.CalendarView';
+
+// --------------------------------------------------------------------------
+// What "nothing here can answer" looks like
+// --------------------------------------------------------------------------
+
+/**
+ * No calendar service on this machine: no bridge, not a Mac, and no
+ * Evolution Data Server on the session bus.
+ *
+ * A **typed** rejection, the {@link NoFileDialogError} rule — a caller keeps
+ * the feature behind it rather than crashing. Only `{ required: true }`
+ * raises it; by default `desktopCalendar()` answers `null`, because a
+ * machine with no calendar service is an ordinary machine.
+ */
+export class NoCalendarServiceError extends Error {
+  constructor(cause) {
+    super(
+      'react-x11: no desktop calendar here — this backend has no EventKit ' +
+        'bridge, this is not macOS, and there is no Evolution Data Server ' +
+        'on the session bus. Call desktopCalendar() without `required` and ' +
+        'branch on null, or calendarBackend() to ask first.',
+      { cause },
+    );
+    this.name = 'NoCalendarServiceError';
+  }
+}
+
+/**
+ * The user has not allowed this app to read their calendars.
+ *
+ * `status` is the permission vocabulary (docs/permissions.md): `'denied'`,
+ * `'restricted'` (MDM or parental controls), `'write-only'` (macOS 14's
+ * partial grant — a real grant to a writer, a refusal to a reader), or
+ * `'unknown'`. Separate from {@link NoCalendarServiceError} on purpose:
+ * this one is the user's answer, and the user can change it —
+ * `openPrivacySettings('calendars')` puts them in front of the switch.
+ */
+export class CalendarAccessError extends Error {
+  constructor(status, cause) {
+    super(
+      `react-x11: this app may not read the desktop's calendars (${status}). ` +
+        'On macOS that is the Calendars privacy setting: openPrivacySettings' +
+        "('calendars') opens the pane. Read cal.access() to branch before " +
+        'asking.',
+      { cause },
+    );
+    this.name = 'CalendarAccessError';
+    this.status = status;
+  }
+}
+
+// --------------------------------------------------------------------------
+// One shape, whichever rung answered
+// --------------------------------------------------------------------------
+
+const pad = (n) => String(n).padStart(2, '0');
+
+/**
+ * The local calendar day a `Date` falls on, as `'YYYY-MM-DD'`.
+ *
+ * The **format** is the contract between this and a calendar grid — these
+ * keys index straight into `<Calendar dayContent>` in
+ * `@react-x11/components` — so it is local time, not UTC: a grid draws the
+ * user's days.
+ */
+export function dayKey(date) {
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+}
+
+/**
+ * Occurrences grouped by the local day they appear on — which is what a
+ * calendar grid actually renders.
+ *
+ * ```js
+ * const days = byDay(events);
+ * days.get(dayKey(new Date()));      // today's
+ * ```
+ *
+ * An all-day event spans `[start, end)` across possibly several days and a
+ * timed one can cross midnight, so an event lands under **every** day it
+ * touches rather than only under its start.
+ */
+export function byDay(events) {
+  const days = new Map();
+  for (const event of events) {
+    // `end` is exclusive, so a one-day all-day event ending at the next
+    // midnight must not also mark the next day.
+    const lastMs = Math.max(event.start.getTime(), event.end.getTime() - 1);
+    const last = new Date(lastMs);
+    const cursor = new Date(
+      event.start.getFullYear(),
+      event.start.getMonth(),
+      event.start.getDate(),
+    );
+    while (cursor <= last) {
+      const key = dayKey(cursor);
+      const list = days.get(key);
+      if (list) list.push(event);
+      else days.set(key, [event]);
+      cursor.setDate(cursor.getDate() + 1);
+    }
+  }
+  return days;
+}
+
+/** By start, ascending. Every rung answers sorted, across its calendars. */
+export function sortEvents(events) {
+  return events.sort((a, b) => a.start.getTime() - b.start.getTime());
+}
+
+/**
+ * An all-day end as the exclusive one the rest of the ladder means.
+ *
+ * EventKit reports an all-day event as ending at 23:59:59 of its last day;
+ * iCalendar (so EDS) ends it at the next midnight. `byDay` and every caller
+ * that subtracts to get a duration read `end` as exclusive, so the macOS
+ * rungs round the reported end up to the next local midnight — and an end
+ * that is *already* midnight is already exclusive and must not gain a day.
+ */
+export function withExclusiveEnd(end, allDay) {
+  if (!allDay || !(end instanceof Date) || Number.isNaN(end.getTime())) {
+    return end;
+  }
+  const atMidnight =
+    end.getHours() === 0 &&
+    end.getMinutes() === 0 &&
+    end.getSeconds() === 0 &&
+    end.getMilliseconds() === 0;
+  if (atMidnight) return end;
+  return new Date(end.getFullYear(), end.getMonth(), end.getDate() + 1);
+}
+
+/** `[r, g, b, a]` in 0..1, as EventKit gives a calendar's colour, to the
+ *  `'#rrggbb'` the EDS rung reads out of a keyfile. Alpha is dropped: a
+ *  calendar colour is opaque, and a marker drawn in it should be too. */
+export function hexFromComponents(color) {
+  if (!Array.isArray(color) || color.length < 3) return undefined;
+  const channel = (v) =>
+    Math.max(0, Math.min(255, Math.round(Number(v) * 255)))
+      .toString(16)
+      .padStart(2, '0');
+  return `#${channel(color[0])}${channel(color[1])}${channel(color[2])}`;
+}
+
+/** EventKit's `EKCalendarType` word as the lower-case one EDS's keyfile
+ *  uses for the same thing — `caldav`, `local`, `exchange`. */
+export function calendarBackendName(type) {
+  return typeof type === 'string' && type ? type.toLowerCase() : undefined;
+}
+
+/**
+ * EventKit's event predicate spans at most four years, so a longer range is
+ * asked for in pieces. 1400 days is comfortably inside that limit and a
+ * whole number of days, so a chunk boundary never lands mid-event for an
+ * all-day one.
+ */
+const MAX_SPAN_MS = 1400 * 24 * 60 * 60 * 1000;
+
+/** `[[startMs, endMs], …]`, each at most {@link MAX_SPAN_MS}. */
+export function chunkSpan(from, to) {
+  const start = from instanceof Date ? from.getTime() : Number(from);
+  const end = to instanceof Date ? to.getTime() : Number(to);
+  if (!(end > start)) return [[start, end]];
+  const chunks = [];
+  for (let at = start; at < end; at += MAX_SPAN_MS) {
+    chunks.push([at, Math.min(at + MAX_SPAN_MS, end)]);
+  }
+  return chunks;
+}
+
+// --------------------------------------------------------------------------
+// Rung 3: Evolution Data Server, over the session bus
+// --------------------------------------------------------------------------
+
+/**
+ * `E_CAL_CLIENT_VIEW_FLAGS_NONE`. A view is created with `NOTIFY_INITIAL`
+ * instead, which makes `Start()` replay everything already matching the
+ * query as `ObjectsAdded` — the current contents, announced as if they had
+ * just changed.
+ *
+ * That is the wrong signal for a watcher whose answer to a change is to run
+ * the query again: the re-query tears the view down, starts a new one, and
+ * is told the same thing again, for as long as the app is open. Flags of
+ * NONE is the whole of "only tell me what changes from here".
+ */
+const VIEW_FLAGS_NONE = 0;
+
+/** `20260807T113000Z` — what the S-expression query wants. */
+function icalStamp(d) {
+  return (
+    `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}T` +
+    `${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}${pad(d.getUTCSeconds())}Z`
+  );
+}
+
+/** The query EDS understands for "anything happening between these two". */
+function rangeQuery(from, to) {
+  return `(occur-in-time-range? (make-time "${icalStamp(from)}") (make-time "${icalStamp(to)}"))`;
+}
+
+/**
+ * A source's whole configuration is an ini-style keyfile carried in one
+ * D-Bus property, so it has to be parsed to find out whether a source is
+ * even a calendar (as opposed to an address book, a mail account or a task
+ * list).
+ */
+export function parseKeyFile(text) {
+  const out = {};
+  let section = null;
+  for (const raw of text.split('\n')) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    if (line.startsWith('[') && line.endsWith(']')) {
+      section = line.slice(1, -1);
+      out[section] = out[section] ?? {};
+      continue;
+    }
+    if (!section) continue;
+    const eq = line.indexOf('=');
+    if (eq === -1) continue;
+    const key = line.slice(0, eq).trim();
+    if (key.includes('[')) continue; // a DisplayName[ru] translation
+    out[section][key] = line.slice(eq + 1).trim();
+  }
+  return out;
+}
+
+/**
+ * `ical.js`, loaded once and lazily.
+ *
+ * A **regular dependency** behind a static specifier: 268 KB of the 1.2 MB
+ * package is what loads, it has no dependencies of its own and no native
+ * code, and a bundler or a single-executable build can follow a static
+ * specifier where it cannot follow the run-time-built one an optional
+ * dependency needs. The `import()` keeps it off the startup path — an app
+ * that never opens a calendar never parses it — and this rung is the only
+ * caller: EventKit expands its own recurrences.
+ */
+let icalModule = null;
+async function loadIcal() {
+  if (!icalModule) {
+    icalModule = import('ical.js').then((mod) => {
+      // CJS-with-a-default under some resolutions, a namespace under others.
+      const resolved = typeof mod.parse === 'function' ? mod : mod.default;
+      if (!resolved || typeof resolved.parse !== 'function') {
+        icalModule = null;
+        throw new TypeError('ical.js did not export what was expected');
+      }
+      return resolved;
+    });
+  }
+  return icalModule;
+}
+
+/**
+ * The desktop's calendars, over a bus someone else owns.
+ *
+ * Two services are involved: `Sources5` is the registry (which calendars
+ * exist, their names and colours) and `Calendar8` the store (open a
+ * calendar, query a range, watch it). Nothing here closes the connection,
+ * because nothing here opened it.
+ */
+export class EdsCalendars {
+  constructor(bus) {
+    this.backend = 'eds';
+    this._bus = bus;
+    this._open = new Map();
+    this._views = [];
+    this._timezones = new Set();
+  }
+
+  /** EDS is reachable or it is not; there is no grant to ask for. */
+  async access() {
+    return 'granted';
+  }
+
+  async requestAccess() {
+    return 'granted';
+  }
+
+  /** Every calendar the desktop knows about, colour included. */
+  async listCalendars() {
+    const om = await this._bus
+      .getService(SOURCES_NAME)
+      .getInterface(SOURCES_PATH, OBJECT_MANAGER);
+    const managed = await om.GetManagedObjects();
+
+    const calendars = [];
+    for (const interfaces of Object.values(managed)) {
+      const src = interfaces['org.gnome.evolution.dataserver.Source'];
+      if (!src) continue;
+      const cfg = parseKeyFile(String(src.Data ?? ''));
+      // no [Calendar] section means an address book, a task list or mail
+      if (!cfg.Calendar) continue;
+      const ds = cfg['Data Source'] ?? {};
+      calendars.push({
+        uid: String(src.UID ?? ''),
+        name: ds.DisplayName ?? '',
+        enabled: ds.Enabled !== 'false',
+        color: cfg.Calendar.Color,
+        backend: cfg.Calendar.BackendName,
+        readOnly: !interfaces['org.gnome.evolution.dataserver.Source.Writable'],
+        account: cfg['GNOME Online Accounts']?.Account,
+      });
+    }
+    return calendars;
+  }
+
+  async _openCalendar(uid) {
+    const existing = this._open.get(uid);
+    if (existing) return existing;
+
+    const factory = await this._bus
+      .getService(FACTORY_NAME)
+      .getInterface(FACTORY_PATH, FACTORY_IFACE);
+    const [path, busName] = await factory.OpenCalendar(uid);
+    const cal = await this._bus
+      .getService(busName)
+      .getInterface(path, CAL_IFACE);
+    await cal.Open();
+
+    const entry = { cal, busName };
+    this._open.set(uid, entry);
+    return entry;
+  }
+
+  /**
+   * Events reference timezones by id, but the payload rarely carries the
+   * matching VTIMEZONE — so definitions are fetched on demand and registered
+   * with ical.js. A backend that has none leaves the time floating, which is
+   * ical.js's own fallback and better than refusing the event.
+   */
+  async _ensureTimezone(ICAL, cal, tzid) {
+    if (!tzid || this._timezones.has(tzid) || ICAL.TimezoneService.has(tzid)) {
+      return;
+    }
+    this._timezones.add(tzid);
+    try {
+      const vtz = await cal.GetTimezone(tzid);
+      const comp = new ICAL.Component(ICAL.parse(vtz));
+      const sub =
+        comp.name === 'vtimezone'
+          ? comp
+          : comp.getFirstSubcomponent('vtimezone');
+      if (sub) ICAL.TimezoneService.register(tzid, new ICAL.Timezone(sub));
+    } catch {
+      /* no definition for it; ical.js falls back to floating time */
+    }
+  }
+
+  /**
+   * Expanded occurrences between two `Date`s, across the calendars given (or
+   * every enabled one). Sorted by start.
+   *
+   * A backend that is offline or broken contributes an entry in `errors`
+   * rather than throwing: one unreachable CalDAV server must not blank a
+   * whole month of the user's own local calendar.
+   */
+  async eventsBetween(from, to, options = {}) {
+    const ICAL = await loadIcal();
+    const list =
+      options.calendars ??
+      (await this.listCalendars()).filter((c) => c.enabled);
+    const query = rangeQuery(from, to);
+
+    const perCalendar = await Promise.all(
+      list.map(async (meta) => {
+        try {
+          const { cal } = await this._openCalendar(meta.uid);
+          const objects = await cal.GetObjectList(query);
+          return {
+            events: await this._expand(ICAL, cal, objects, from, to, meta),
+            error: null,
+          };
+        } catch (err) {
+          return {
+            events: [],
+            error: {
+              calendar: meta,
+              message: err instanceof Error ? err.message : String(err),
+            },
+          };
+        }
+      }),
+    );
+
+    const events = [];
+    const errors = [];
+    for (const chunk of perCalendar) {
+      events.push(...chunk.events);
+      if (chunk.error) errors.push(chunk.error);
+    }
+    return { events: sortEvents(events), errors };
+  }
+
+  async _expand(ICAL, cal, objects, from, to, meta) {
+    const out = [];
+    for (const ics of objects) {
+      let comp;
+      try {
+        comp = new ICAL.Component(ICAL.parse(ics));
+      } catch {
+        continue; // one unparseable object is not the range's problem
+      }
+
+      // Register any VTIMEZONE shipped inline, then any referenced by id.
+      for (const vtz of comp.getAllSubcomponents('vtimezone')) {
+        const tz = new ICAL.Timezone(vtz);
+        if (!ICAL.TimezoneService.has(tz.tzid)) {
+          ICAL.TimezoneService.register(tz.tzid, tz);
+        }
+      }
+
+      const vevents =
+        comp.name === 'vevent' ? [comp] : comp.getAllSubcomponents('vevent');
+      for (const ve of vevents) {
+        for (const prop of ['dtstart', 'dtend']) {
+          const p = ve.getFirstProperty(prop);
+          if (p) await this._ensureTimezone(ICAL, cal, p.getParameter('tzid'));
+        }
+        const event = new ICAL.Event(ve);
+        // folded in by the recurrence iterator below
+        if (event.isRecurrenceException()) continue;
+
+        const push = (startTime, endTime) => {
+          const start = startTime.toJSDate();
+          const end = endTime ? endTime.toJSDate() : start;
+          if (end < from || start >= to) return;
+          out.push({
+            uid: event.uid,
+            summary: event.summary || '',
+            location: event.location || undefined,
+            description: event.description || undefined,
+            start,
+            end,
+            allDay: event.startDate.isDate,
+            recurring: event.isRecurring(),
+            calendar: { uid: meta.uid, name: meta.name, color: meta.color },
+          });
+        };
+
+        if (!event.isRecurring()) {
+          push(event.startDate, event.endDate);
+          continue;
+        }
+
+        const duration = event.duration;
+        const it = event.iterator();
+        let next;
+        // A malformed RRULE with no UNTIL and a tiny interval can iterate
+        // forever; the range check below normally ends it, and this is the
+        // backstop for the case where it cannot.
+        let guard = 0;
+        while ((next = it.next()) && guard++ < 2000) {
+          if (next.toJSDate() >= to) break;
+          const end = next.clone();
+          end.addDuration(duration);
+          if (end.toJSDate() < from) continue;
+          const details = event.getOccurrenceDetails(next);
+          push(details.startDate, details.endDate);
+        }
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Live updates: `onChange` fires whenever anything in the range moves.
+   *
+   * **Changes only.** What is in the range already is what `eventsBetween`
+   * answered; `onChange` fires for what happens after that. See
+   * {@link VIEW_FLAGS_NONE} for the loop that reporting the initial contents
+   * as a change costs a caller who re-queries on one.
+   */
+  async watch(from, to, onChange, options = {}) {
+    const list =
+      options.calendars ??
+      (await this.listCalendars()).filter((c) => c.enabled);
+    const query = rangeQuery(from, to);
+    const started = [];
+
+    for (const meta of list) {
+      try {
+        const { cal, busName } = await this._openCalendar(meta.uid);
+        const viewPath = await cal.GetView(query);
+        const view = await this._bus
+          .getService(busName)
+          .getInterface(viewPath, VIEW_IFACE);
+
+        // Belt to `VIEW_FLAGS_NONE`'s braces, for a backend that would not
+        // take the flags: `Complete` closes the initial delivery, so anything
+        // before it is the replay rather than a change. Only armed when
+        // `SetFlags` failed — a view that never reports `Complete` would
+        // otherwise be watched in silence, and losing live updates is the
+        // worse half of the trade.
+        let replaying = false;
+        try {
+          await view.SetFlags(VIEW_FLAGS_NONE);
+        } catch {
+          replaying = true;
+        }
+        await view.$subscribe('Complete', () => {
+          replaying = false;
+        });
+
+        for (const signal of [
+          'ObjectsAdded',
+          'ObjectsModified',
+          'ObjectsRemoved',
+        ]) {
+          await view.$subscribe(signal, (objects) => {
+            if (replaying) return;
+            onChange({
+              calendar: meta,
+              kind: signal,
+              count: Array.isArray(objects) ? objects.length : 0,
+            });
+          });
+        }
+        await view.Start();
+        started.push(view);
+        this._views.push(view);
+      } catch {
+        /* skip a calendar that will not open; the others still update */
+      }
+    }
+
+    return async () => {
+      for (const view of started) {
+        this._views = this._views.filter((v) => v !== view);
+        await stopView(view);
+      }
+    };
+  }
+
+  /** Stop every view this instance started. Does **not** touch the bus. */
+  async close() {
+    const views = this._views;
+    this._views = [];
+    for (const view of views) await stopView(view);
+    this._open.clear();
+  }
+}
+
+async function stopView(view) {
+  try {
+    await view.Stop();
+    await view.Dispose();
+  } catch {
+    /* already gone */
+  }
+}
+
+// --------------------------------------------------------------------------
+// Rung 2: EventKit through an `osascript` child
+// --------------------------------------------------------------------------
+
+/**
+ * One JXA program: hold an `EKEventStore`, answer JSON lines on stdin with
+ * JSON lines on stdout, and push one more whenever macOS says the store
+ * changed.
+ *
+ * **Why a child at all.** EventKit is a framework, not a service: there is
+ * no bus to call and no command-line tool that answers this. `osascript -l
+ * JavaScript` is the interpreter every Mac has that can hold framework
+ * objects, and JXA passes a JS function where the framework wants a block —
+ * which is what makes the completion handler and the change observer
+ * possible at all.
+ *
+ * **Why long-lived.** A process per query would pay ~450 ms of interpreter
+ * and framework start-up each time, and — more to the point — could not
+ * observe a change, because the observer only fires while a run loop is
+ * running. One child per process, ref-counted, is the same bargain
+ * `sessionBus()` makes.
+ *
+ * **What it writes and where.** `console.log` in JXA has gone to stderr in
+ * some macOS releases and stdout in others, so replies are written to
+ * stdout's file handle directly and stderr is left for the noise AppKit
+ * prints into every process that touches it.
+ *
+ * **It leaves when its parent has.** Eight orphaned appearance watchers were
+ * once found on one machine, days old, reparented to launchd by apps that
+ * died without running an exit handler; the same 5-second `getppid()` check
+ * is here for the same reason.
+ *
+ * Exported so a test can pin the source; it cannot be executed off a Mac.
+ */
+export const MACOS_CALENDAR_PROGRAM = `
+ObjC.import('EventKit');
+ObjC.import('AppKit');
+ObjC.import('stdlib');
+ObjC.import('unistd');
+
+var stdout = $.NSFileHandle.fileHandleWithStandardOutput;
+function emit(o) {
+  var s = JSON.stringify(o) + '\\n';
+  stdout.writeData($.NSString.alloc.initWithUTF8String(s)
+    .dataUsingEncoding($.NSUTF8StringEncoding));
+}
+// A nil ObjC object is callable in JXA rather than null, and an unset
+// property on an unsaved object is a plain undefined, so both are checked.
+function str(v) {
+  try {
+    if (v === undefined || v === null) return null;
+    if (typeof v === 'string') return v;
+    if (typeof v.isNil === 'function' && v.isNil()) return null;
+    var s = ObjC.unwrap(v);
+    return typeof s === 'string' ? s : null;
+  } catch (e) { return null; }
+}
+function ms(d) {
+  try {
+    if (!d || (typeof d.isNil === 'function' && d.isNil())) return null;
+    return Math.round(Number(d.timeIntervalSince1970) * 1000);
+  } catch (e) { return null; }
+}
+
+// EKAuthorizationStatus, as react-x11's permission vocabulary. 3 is
+// authorized before macOS 14 and fullAccess after it; 4 is the write-only
+// grant macOS 14 added, which is a refusal to a reader and its own word.
+var STATUS = ['prompt', 'restricted', 'denied', 'granted', 'write-only'];
+function statusWord() {
+  var n = Number($.EKEventStore.authorizationStatusForEntityType($.EKEntityTypeEvent));
+  return STATUS[n] || 'unknown';
+}
+
+var store = null;
+function eventStore() {
+  // Creating the store never prompts; only a request does.
+  if (store === null) store = $.EKEventStore.alloc.init;
+  return store;
+}
+
+var TYPES = ['local', 'calDAV', 'exchange', 'subscription', 'birthday'];
+function colorOf(cal) {
+  try {
+    var c = cal.color;
+    if (!c || (typeof c.isNil === 'function' && c.isNil())) return null;
+    var s = c.colorUsingColorSpace($.NSColorSpace.sRGBColorSpace);
+    if (!s || (typeof s.isNil === 'function' && s.isNil())) return null;
+    return [Number(s.redComponent), Number(s.greenComponent),
+            Number(s.blueComponent), Number(s.alphaComponent)];
+  } catch (e) { return null; }
+}
+function calendarObjects() {
+  return eventStore().calendarsForEntityType($.EKEntityTypeEvent);
+}
+function listCalendars() {
+  var cals = calendarObjects();
+  var out = [];
+  for (var i = 0; i < Number(cals.count); i++) {
+    var c = cals.objectAtIndex(i);
+    var source = null;
+    try {
+      if (c.source && !(typeof c.source.isNil === 'function' && c.source.isNil())) {
+        source = { id: str(c.source.sourceIdentifier), title: str(c.source.title) };
+      }
+    } catch (e) {}
+    out.push({
+      id: str(c.calendarIdentifier),
+      title: str(c.title),
+      color: colorOf(c),
+      type: TYPES[Number(c.type)] || null,
+      source: source,
+      allowsModifications: !!c.allowsContentModifications,
+      immutable: !!c.immutable,
+      subscribed: !!c.subscribed
+    });
+  }
+  return out;
+}
+function eventsBetween(startMs, endMs, ids) {
+  var filter = $();
+  if (ids && ids.length) {
+    var wanted = {};
+    for (var k = 0; k < ids.length; k++) wanted[ids[k]] = true;
+    var all = calendarObjects();
+    var picked = $.NSMutableArray.alloc.init;
+    for (var i = 0; i < Number(all.count); i++) {
+      var c = all.objectAtIndex(i);
+      if (wanted[str(c.calendarIdentifier)]) picked.addObject(c);
+    }
+    // An empty selection means "these calendars, of which none are here" —
+    // not "every calendar", which is what a nil filter means.
+    if (Number(picked.count) === 0) return [];
+    filter = picked;
+  }
+  var pred = eventStore().predicateForEventsWithStartDateEndDateCalendars(
+    $.NSDate.dateWithTimeIntervalSince1970(startMs / 1000),
+    $.NSDate.dateWithTimeIntervalSince1970(endMs / 1000), filter);
+  var evs = eventStore().eventsMatchingPredicate(pred);
+  var out = [];
+  if (!evs || (typeof evs.isNil === 'function' && evs.isNil())) return out;
+  for (var j = 0; j < Number(evs.count); j++) {
+    var e = evs.objectAtIndex(j);
+    var cal = null;
+    try { cal = str(e.calendar.calendarIdentifier); } catch (err) {}
+    out.push({
+      id: str(e.eventIdentifier),
+      calendar: cal,
+      title: str(e.title),
+      location: str(e.location),
+      notes: str(e.notes),
+      start: ms(e.startDate),
+      end: ms(e.endDate),
+      allDay: !!e.allDay,
+      recurring: !!e.hasRecurrenceRules
+    });
+  }
+  return out;
+}
+
+var watching = false;
+function watch() {
+  if (watching) return true;
+  watching = true;
+  $.NSNotificationCenter.defaultCenter.addObserverForNameObjectQueueUsingBlock(
+    'EKEventStoreChangedNotification', eventStore(),
+    $.NSOperationQueue.mainQueue, function () { emit({ event: 'changed' }); });
+  return true;
+}
+
+function request(id) {
+  var s = eventStore();
+  var done = function () { emit({ id: id, ok: statusWord() }); };
+  // macOS 14 split the one request in two; before it there was only the
+  // entity-type form.
+  if (typeof s.requestFullAccessToEventsWithCompletion === 'function') {
+    s.requestFullAccessToEventsWithCompletion(done);
+  } else {
+    s.requestAccessToEntityTypeCompletion($.EKEntityTypeEvent, done);
+  }
+}
+
+function handle(msg) {
+  switch (msg.op) {
+    case 'status': return statusWord();
+    case 'calendars': return listCalendars();
+    case 'events': return eventsBetween(msg.start, msg.end, msg.calendars);
+    case 'watch': return watch();
+    case 'ping': return 'pong';
+    default: throw new Error('unknown op ' + msg.op);
+  }
+}
+
+var stdin = $.NSFileHandle.fileHandleWithStandardInput;
+var buffered = '';
+$.NSNotificationCenter.defaultCenter.addObserverForNameObjectQueueUsingBlock(
+  $.NSFileHandleDataAvailableNotification, stdin, $.NSOperationQueue.mainQueue,
+  function () {
+    var data = stdin.availableData;
+    // Zero bytes is end of file: the parent closed the pipe, or died.
+    if (!data || Number(data.length) === 0) $.exit(0);
+    buffered += ObjC.unwrap($.NSString.alloc.initWithDataEncoding(
+      data, $.NSUTF8StringEncoding));
+    var at;
+    while ((at = buffered.indexOf('\\n')) !== -1) {
+      var line = buffered.slice(0, at);
+      buffered = buffered.slice(at + 1);
+      if (!line.trim()) continue;
+      var msg;
+      try { msg = JSON.parse(line); } catch (e) { continue; }
+      if (msg.op === 'quit') $.exit(0);
+      if (msg.op === 'request') { request(msg.id); continue; }
+      try {
+        emit({ id: msg.id, ok: handle(msg) });
+      } catch (e) {
+        emit({ id: msg.id, error: String(e && e.message ? e.message : e) });
+      }
+    }
+    stdin.waitForDataInBackgroundAndNotify;
+  });
+stdin.waitForDataInBackgroundAndNotify;
+
+emit({ ready: true, status: statusWord() });
+
+// An app that dies without its exit handler (a signal, a crash) leaves this
+// process behind, reparented to launchd, for as long as the machine is up.
+$.NSTimer.scheduledTimerWithTimeIntervalRepeatsBlock(5, true, function () {
+  if ($.getppid() === 1) $.exit(0);
+});
+$.NSRunLoop.currentRunLoop.run();
+`;
+
+/** How long to wait for the child's first line before giving up on it. */
+const CHILD_READY_TIMEOUT_MS = 10_000;
+
+/**
+ * Test seam, not public: what spawns the child. A fake here also lets the
+ * rung run off a Mac, where the real one cannot, so the protocol is tested
+ * on CI rather than on whoever has a Mac.
+ */
+let spawnChild = null;
+export function _setCalendarSpawnForTests(fn) {
+  _closeCalendarChild();
+  spawnChild = fn;
+}
+
+/**
+ * The `osascript` child, and the request/reply protocol over its pipes.
+ *
+ * One per process, ref-counted: several hooks in one app share a store the
+ * way they share a bus connection. A reply is matched by id; a line with no
+ * id is a push (the store changed).
+ */
+class CalendarChild {
+  constructor(proc) {
+    this.proc = proc;
+    this.seq = 0;
+    this.refs = 0;
+    this.pending = new Map();
+    this.watchers = new Set();
+    this.exited = null;
+    this._buffered = '';
+    this._hello = null;
+
+    // The program's first line is `{ ready: true, status }`, so "it started"
+    // and "the framework answered" are the same event: a child that spawns
+    // and then fails inside osascript never says hello, and this rung stands
+    // down rather than hanging on a pipe.
+    this.ready = new Promise((resolve, reject) => {
+      this._hello = { resolve, reject };
+    });
+    // Nothing may await this before `acquireChild` does; an unhandled
+    // rejection here would be reported against a promise nobody asked for.
+    this.ready.catch(() => {});
+
+    proc.stdout?.setEncoding?.('utf8');
+    proc.stdout?.on('data', (chunk) => this._onData(chunk));
+    proc.on('error', (err) => this._die(err));
+    proc.on('exit', () => this._die(new Error('the calendar helper exited')));
+  }
+
+  _onData(chunk) {
+    this._buffered += chunk;
+    let at;
+    while ((at = this._buffered.indexOf('\n')) !== -1) {
+      const line = this._buffered.slice(0, at).trim();
+      this._buffered = this._buffered.slice(at + 1);
+      if (!line) continue;
+      let msg;
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        continue; // noise from a framework that logs into every process
+      }
+      if (msg.ready) {
+        this._hello.resolve(msg);
+        continue;
+      }
+      if (msg.event === 'changed') {
+        for (const fn of [...this.watchers]) {
+          try {
+            fn();
+          } catch {
+            /* one watcher's failure is not another's */
+          }
+        }
+        continue;
+      }
+      const entry = this.pending.get(msg.id);
+      if (!entry) continue;
+      this.pending.delete(msg.id);
+      if (msg.error) entry.reject(new Error(msg.error));
+      else entry.resolve(msg.ok);
+    }
+  }
+
+  _die(err) {
+    if (this.exited) return;
+    this.exited = err;
+    this._hello.reject(err);
+    for (const entry of this.pending.values()) entry.reject(err);
+    this.pending.clear();
+    this.watchers.clear();
+    if (shared === this) shared = null;
+    // A child that never said hello is still running; a child that exited
+    // does not mind being killed again.
+    this.proc.kill?.();
+  }
+
+  send(message) {
+    if (this.exited) return Promise.reject(this.exited);
+    const id = ++this.seq;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      try {
+        this.proc.stdin.write(`${JSON.stringify({ ...message, id })}\n`);
+      } catch (err) {
+        this.pending.delete(id);
+        reject(err);
+      }
+    });
+  }
+
+  release() {
+    if (--this.refs > 0) return;
+    if (shared === this) shared = null;
+    try {
+      this.proc.stdin?.end();
+    } catch {
+      /* already gone */
+    }
+    this.proc.kill?.();
+  }
+}
+
+let shared = null;
+
+/** The shared child, started if it is not running. Rejects if it will not
+ *  start or does not say hello, which is this Mac saying it cannot answer. */
+async function acquireChild() {
+  if (shared && !shared.exited) {
+    shared.refs++;
+    return shared;
+  }
+  let proc;
+  if (spawnChild) {
+    proc = await spawnChild();
+  } else {
+    const { spawn } = await import('node:child_process');
+    // stderr is ignored on purpose: AppKit logs into every process that
+    // touches it, and none of it is an answer to anything asked here.
+    proc = spawn(
+      'osascript',
+      ['-l', 'JavaScript', '-e', MACOS_CALENDAR_PROGRAM],
+      { stdio: ['pipe', 'pipe', 'ignore'] },
+    );
+  }
+  // Deliberately **not** `unref`'d, unlike the appearance watcher: this one
+  // is asked questions and answers them, so a process that let the loop
+  // drain while a read was in flight would exit in the middle of it. It is
+  // an open resource, like the bus connection — `close()` ends it, and the
+  // exit handler below is the backstop for an app that forgot to.
+  const child = new CalendarChild(proc);
+  const timer = setTimeout(() => {
+    child._die(new Error('the calendar helper did not start'));
+  }, CHILD_READY_TIMEOUT_MS);
+  timer.unref?.();
+  try {
+    await child.ready;
+  } finally {
+    clearTimeout(timer);
+  }
+
+  child.refs = 1;
+  shared = child;
+  return child;
+}
+
+/** Kill the shared child, if any. Called on exit, and by the tests. */
+export function _closeCalendarChild() {
+  const child = shared;
+  shared = null;
+  if (!child) return;
+  child.refs = 0;
+  try {
+    child.proc.stdin?.end();
+  } catch {
+    /* already gone */
+  }
+  child.proc.kill?.();
+}
+
+process.on('exit', () => {
+  _closeCalendarChild();
+});
+
+/** EventKit over the child: the same answers as the bridge, a slower way. */
+export class OsascriptCalendars {
+  constructor(child) {
+    this.backend = 'osascript';
+    this._child = child;
+  }
+
+  access() {
+    return this._child.send({ op: 'status' });
+  }
+
+  requestAccess() {
+    return this._child.send({ op: 'request' });
+  }
+
+  async listCalendars() {
+    const list = await this._child.send({ op: 'calendars' });
+    return (list ?? []).map((cal) => ({
+      uid: String(cal.id),
+      name: cal.title ?? '',
+      enabled: true,
+      color: hexFromComponents(cal.color),
+      backend: calendarBackendName(cal.type),
+      readOnly: cal.allowsModifications === false || cal.immutable === true,
+      account: cal.source?.title ?? undefined,
+    }));
+  }
+
+  async eventsBetween(from, to, options = {}) {
+    const metas = options.calendars ?? (await this.listCalendars());
+    // The same rule as the bridge rung: a filter that matched nothing means
+    // nothing, not everything.
+    if (options.calendars && metas.length === 0) {
+      return { events: [], errors: [] };
+    }
+    const byId = new Map(metas.map((meta) => [meta.uid, meta]));
+    const ids = options.calendars ? metas.map((meta) => meta.uid) : undefined;
+
+    const events = [];
+    const seen = new Set();
+    for (const [start, end] of chunkSpan(from, to)) {
+      const raw = await this._child.send({
+        op: 'events',
+        start,
+        end,
+        calendars: ids,
+      });
+      for (const one of raw ?? []) {
+        const key = `${one.id} ${one.start}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        const at = new Date(one.start);
+        const meta = byId.get(String(one.calendar));
+        events.push({
+          uid: String(one.id ?? `${one.calendar}:${one.start}`),
+          summary: one.title ?? '',
+          location: one.location ?? undefined,
+          description: one.notes ?? undefined,
+          start: at,
+          end: withExclusiveEnd(new Date(one.end), Boolean(one.allDay)),
+          allDay: Boolean(one.allDay),
+          recurring: Boolean(one.recurring),
+          calendar: meta
+            ? { uid: meta.uid, name: meta.name, color: meta.color }
+            : { uid: String(one.calendar ?? ''), name: '' },
+        });
+      }
+    }
+    return { events: sortEvents(events), errors: [] };
+  }
+
+  /** The store's own notification, which names nothing: see
+   *  `CocoaCalendars.watch` for why a change carries no calendar. */
+  async watch(from, to, onChange) {
+    await this._child.send({ op: 'watch' });
+    const fn = () => onChange({ calendar: null, kind: 'changed', count: null });
+    this._child.watchers.add(fn);
+    return async () => {
+      this._child.watchers.delete(fn);
+    };
+  }
+
+  /** Nothing: the child is shared and ref-counted, and the handle's own
+   *  `close()` is what releases this share of it. Releasing here too would
+   *  count one handle twice and kill a child another is still using. */
+  async close() {}
+}
+
+// --------------------------------------------------------------------------
+// Choosing a rung
+// --------------------------------------------------------------------------
+
+/**
+ * The app whose EventKit bridge to read, or null.
+ *
+ * Never a backend check: an app that can read calendars says so by carrying
+ * `calendars` (src/cocoa/app.js), and this asks the connections the renderer
+ * is drawing through — the rule `permissions` and `filePanels` follow.
+ */
+function calendarsApp(app) {
+  if (app) return app.calendars ? app : null;
+  const apps = liveApps().filter((one) => one.calendars);
+  if (apps.length <= 1) return apps[0] ?? null;
+  const showing = apps.filter((one) => (one._rootChildren ?? []).length > 0);
+  return showing.length === 1 ? showing[0] : null;
+}
+
+/** `osascript` on this machine's PATH, without running it. */
+async function haveOsascript() {
+  if (spawnChild) return true;
+  if (process.platform !== 'darwin') return false;
+  const { access } = await import('node:fs/promises');
+  const dirs = (process.env.PATH ?? '/usr/bin:/bin').split(':');
+  for (const dir of dirs) {
+    if (!dir) continue;
+    try {
+      await access(`${dir}/osascript`);
+      return true;
+    } catch {
+      /* not in this one */
+    }
+  }
+  return false;
+}
+
+/**
+ * Which rung this machine lands on, without reading anything.
+ *
+ * ```js
+ * switch (await calendarBackend()) {
+ *   case null: return <NoCalendarHere />;
+ * }
+ * ```
+ *
+ * Useful for a settings screen that wants to say where the events come from,
+ * and for the tests. It acquires a bus ref and releases it, so it is cheap
+ * but not free — and it never spawns the `osascript` child or raises a
+ * permission prompt.
+ *
+ * @returns {Promise<'cocoa'|'osascript'|'eds'|null>}
+ */
+export async function calendarBackend(options = {}) {
+  if (calendarsApp(options.app)) return 'cocoa';
+  if (await haveOsascript()) return 'osascript';
+  const ref = await sessionBus();
+  if (ref) {
+    try {
+      if (await hasService(SOURCES_NAME, ref)) return 'eds';
+    } finally {
+      await ref.release();
+    }
+  }
+  return null;
+}
+
+/**
+ * The desktop's calendars, on the best rung this machine has.
+ *
+ * ```js
+ * const cal = await desktopCalendar();
+ * if (!cal) return;                              // no calendars here
+ * try {
+ *   const { events } = await cal.eventsBetween(from, to);
+ * } finally {
+ *   await cal.close();
+ * }
+ * ```
+ *
+ * **Never rejects for anything about the machine** — `null` is the answer
+ * where nothing can read a calendar, the way `permissionStatus()` answers
+ * `'unknown'`. `{ required: true }` turns that into a
+ * {@link NoCalendarServiceError} for a caller who would rather branch on a
+ * `catch`, and `{ backend }` pins one rung and fails rather than falling
+ * through it, which is what a test and a "why is it slow" investigation
+ * both want.
+ *
+ * The handle owns something on every rung — a bus reference, a watcher, a
+ * share of the `osascript` child — so `close()` it. `useDesktopCalendarEvents`
+ * does that for you.
+ *
+ * @returns {Promise<DesktopCalendar | null>}
+ */
+export async function desktopCalendar(options = {}) {
+  const { app, backend, required = false } = options;
+
+  if (!backend || backend === 'cocoa') {
+    const found = calendarsApp(app);
+    if (found) return new DesktopCalendar(found.calendars, async () => {});
+  }
+
+  if (!backend || backend === 'osascript') {
+    if (await haveOsascript()) {
+      try {
+        const child = await acquireChild();
+        return new DesktopCalendar(new OsascriptCalendars(child), async () => {
+          child.release();
+        });
+      } catch (err) {
+        // osascript is there but would not run the program: a machine
+        // answering "no", not a reason to crash the app.
+        if (backend === 'osascript') {
+          if (required) throw new NoCalendarServiceError(err);
+          return null;
+        }
+      }
+    }
+  }
+
+  if (!backend || backend === 'eds') {
+    const ref = await sessionBus();
+    if (ref) {
+      let found = false;
+      try {
+        found = await hasService(SOURCES_NAME, ref);
+      } catch {
+        found = false;
+      }
+      if (found) {
+        return new DesktopCalendar(new EdsCalendars(ref.bus), () =>
+          ref.release(),
+        );
+      }
+      await ref.release();
+    }
+  }
+
+  if (required) throw new NoCalendarServiceError();
+  return null;
+}
+
+// --------------------------------------------------------------------------
+// The handle: one shape, and the grant asked for once
+// --------------------------------------------------------------------------
+
+/**
+ * What `desktopCalendar()` hands back: one API over whichever rung answered.
+ *
+ * The rungs are mechanism — a bridge call, a JSON line, a D-Bus view — and
+ * the policy is here, in one place, because it is the same policy on all of
+ * them: **the first read asks for the grant** (the notification centre's
+ * rule: the first post asks), a refusal is a typed rejection rather than an
+ * empty list, and the handle's own watches are the ones `close()` stops.
+ */
+export class DesktopCalendar {
+  constructor(rung, release) {
+    this._rung = rung;
+    this._release = release;
+    this._stops = new Set();
+    this._closed = false;
+    this._asked = null;
+  }
+
+  /** `'cocoa'`, `'osascript'` or `'eds'` — which rung answered. */
+  get backend() {
+    return this._rung.backend;
+  }
+
+  /**
+   * May this app read the calendars, as far as anything can say without
+   * asking the user: the permission vocabulary, `'granted'` on a rung with
+   * no such gate (EDS).
+   */
+  access() {
+    return this._rung.access();
+  }
+
+  /** Raise the system's prompt where there is one; the status after the
+   *  user answered. Reads do this for you on the first one. */
+  requestAccess() {
+    this._asked = null;
+    return this._rung.requestAccess();
+  }
+
+  /** System Settings > Privacy & Security > Calendars, for a refusal the
+   *  user can still change their mind about. `false` off macOS. */
+  openSettings() {
+    return openPrivacySettings('calendars');
+  }
+
+  async _ensureAccess() {
+    if (this._closed) throw new Error('react-x11: this calendar is closed');
+    if (!this._asked) {
+      this._asked = (async () => {
+        let status = await this._rung.access();
+        // "Not decided yet" is the one state where reading means asking.
+        if (status === 'prompt') status = await this._rung.requestAccess();
+        return status;
+      })().catch((err) => {
+        this._asked = null;
+        throw err;
+      });
+    }
+    const status = await this._asked;
+    if (status !== 'granted' && status !== 'unknown') {
+      throw new CalendarAccessError(status);
+    }
+  }
+
+  /** Every calendar the desktop knows about. */
+  async listCalendars() {
+    await this._ensureAccess();
+    return this._rung.listCalendars();
+  }
+
+  /**
+   * The occurrences between two `Date`s, expanded, sorted by start, each
+   * tagged with the calendar it came from.
+   *
+   * `end` is **exclusive** on every rung. `errors` names the calendars that
+   * would not answer — one unreachable CalDAV server is not a failure of
+   * the month — and is empty on the macOS rungs, where there is one store.
+   */
+  async eventsBetween(from, to, options = {}) {
+    await this._ensureAccess();
+    return this._rung.eventsBetween(from, to, options);
+  }
+
+  /**
+   * Call `onChange` when something in the store moves, and return the
+   * function that stops watching.
+   *
+   * Deliberately thin: **re-query rather than patch**. EDS names what
+   * changed and EventKit does not, and neither can say what a recurrence
+   * master edited months away did to this range.
+   */
+  async watch(from, to, onChange, options = {}) {
+    await this._ensureAccess();
+    const stop = await this._rung.watch(from, to, onChange, options);
+    const once = async () => {
+      if (!this._stops.delete(once)) return;
+      await stop();
+    };
+    this._stops.add(once);
+    return once;
+  }
+
+  /** Stop this handle's watches and release what it holds. Idempotent. */
+  async close() {
+    if (this._closed) return;
+    this._closed = true;
+    for (const stop of [...this._stops]) await stop();
+    this._stops.clear();
+    await this._rung.close?.();
+    await this._release();
+  }
+}

--- a/src/desktopcalendarhooks.js
+++ b/src/desktopcalendarhooks.js
@@ -174,10 +174,13 @@ export function useDesktopCalendarEvents(options) {
         setError(err instanceof Error ? err : new Error(String(err)));
         setEvents(NO_EVENTS);
         // The user's refusal and the machine's silence are different words:
-        // one has a Settings switch behind it and the other does not.
-        setStatus(
-          err instanceof CalendarAccessError ? 'denied' : 'unavailable',
-        );
+        // one has a Settings switch behind it and the other does not. A
+        // request that came back still undecided is the machine's — TCC
+        // would not even ask — so it is 'unavailable', not a refusal the
+        // user could take back.
+        const refused =
+          err instanceof CalendarAccessError && err.status !== 'prompt';
+        setStatus(refused ? 'denied' : 'unavailable');
       }
     })();
 

--- a/src/desktopcalendarhooks.js
+++ b/src/desktopcalendarhooks.js
@@ -1,0 +1,256 @@
+// `useDesktopCalendarEvents()` — the desktop's calendar as rendering state:
+// the occurrences in a range, grouped the way a calendar grid asks for them,
+// re-read when the store moves.
+//
+// The imperative half in `desktopcalendar.js` is complete; what a component
+// wants on top is binding — the tree's connection, a handle that is closed
+// when the view goes away, the grant asked for on the first read rather than
+// at start-up — not another rung.
+//
+// ```jsx
+// const { byDay } = useDesktopCalendarEvents({ from, to, watch: true });
+//
+// <Calendar
+//   dayContent={(day) =>
+//     byDay.get(day)?.slice(0, 3).map((ev) => (
+//       <box key={ev.uid} style={{ width: 4, height: 4, borderRadius: 2,
+//                                  backgroundColor: ev.calendar.color ?? '$accent' }} />
+//     ))
+//   }
+// />
+// ```
+//
+// `<Calendar>` is `@react-x11/components`; the `'YYYY-MM-DD'` keys are the
+// one contract between the two packages, which is why `byDay` is here and
+// the grid is there.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import { useAppOrNull } from './appcontext.js';
+import {
+  CalendarAccessError,
+  byDay as groupByDay,
+  desktopCalendar,
+} from './desktopcalendar.js';
+import { openPrivacySettings } from './permissions.js';
+
+const NO_EVENTS = [];
+const NO_CALENDARS = [];
+const NO_ERRORS = [];
+
+/** The calendars a caller asked for by uid, or every enabled one. `onlyKey`
+ *  is the comma-joined list, because an array prop is a new identity every
+ *  render and these effects are keyed on it. */
+function pickCalendars(all, onlyKey) {
+  if (!onlyKey) return all.filter((c) => c.enabled);
+  const wanted = new Set(onlyKey.split(','));
+  return all.filter((c) => wanted.has(c.uid));
+}
+
+/**
+ * The user's desktop calendar events, as rendering state.
+ *
+ * **`from` and `to` are read by their timestamps, not their identity**, so
+ * `new Date(...)` inline in the render body is fine and will not re-query on
+ * every paint. That is the mistake this hook would otherwise invite, and it
+ * costs a round trip per frame.
+ *
+ * `status` is the whole answer:
+ *
+ * - `'idle'` — `enabled: false`, nothing asked yet.
+ * - `'loading'` — a read is in flight. The first one may be showing the
+ *   system's permission prompt: the first read is what asks, so that a
+ *   picker the user never opens never prompts.
+ * - `'ready'` — `events` is this range.
+ * - `'denied'` — the **user's** answer. `openSettings()` puts them in front
+ *   of the switch; do not show that button on any other status.
+ * - `'unavailable'` — the **machine's** answer: no bridge, not a Mac, no
+ *   Evolution Data Server on the bus. An ordinary state, not a failure —
+ *   hide the feature rather than reporting it.
+ *
+ * `errors` is different from all of them: calendars that would not answer
+ * while others did, which is one unreachable CalDAV server rather than a
+ * failed read.
+ */
+export function useDesktopCalendarEvents(options) {
+  const { from, to, calendars: only, watch = false, enabled = true } = options;
+  const app = useAppOrNull();
+
+  const [cal, setCal] = useState(null);
+  const [backend, setBackend] = useState(null);
+  const [events, setEvents] = useState(NO_EVENTS);
+  const [found, setFound] = useState(NO_CALENDARS);
+  const [errors, setErrors] = useState(NO_ERRORS);
+  const [status, setStatus] = useState('idle');
+  const [error, setError] = useState(null);
+  const [nonce, setNonce] = useState(0);
+  const live = useRef(true);
+
+  const refresh = useCallback(() => setNonce((n) => n + 1), []);
+  const openSettings = useCallback(() => openPrivacySettings('calendars'), []);
+
+  // Timestamps, not the `Date` objects: a caller writing
+  // `from={new Date(y, m, 1)}` in the render body hands us a new identity
+  // every paint, and an effect keyed on that would re-query every frame.
+  const fromMs = from.getTime();
+  const toMs = to.getTime();
+  const onlyKey = only ? only.join(',') : '';
+
+  useEffect(() => {
+    live.current = true;
+    return () => {
+      live.current = false;
+    };
+  }, []);
+
+  // The handle, opened once per connection: the `osascript` child and the
+  // bus reference behind it are shared, and one hook must not open a second
+  // of either every time the month changes.
+  useEffect(() => {
+    if (!enabled) {
+      setCal(null);
+      setBackend(null);
+      setStatus('idle');
+      return undefined;
+    }
+
+    let alive = true;
+    let handle = null;
+    setStatus('loading');
+    desktopCalendar({ app }).then(
+      (opened) => {
+        if (!alive) {
+          void opened?.close();
+          return;
+        }
+        handle = opened;
+        setCal(opened);
+        setBackend(opened ? opened.backend : null);
+        if (!opened) {
+          setEvents(NO_EVENTS);
+          setStatus('unavailable');
+        }
+      },
+      (err) => {
+        if (!alive) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setStatus('unavailable');
+      },
+    );
+
+    return () => {
+      alive = false;
+      setCal(null);
+      void handle?.close();
+    };
+  }, [app, enabled]);
+
+  // The query.
+  useEffect(() => {
+    if (!cal) return undefined;
+
+    let alive = true;
+    void (async () => {
+      setStatus('loading');
+      setError(null);
+      try {
+        const all = await cal.listCalendars();
+        if (!alive) return;
+        setFound(all);
+
+        const result = await cal.eventsBetween(
+          new Date(fromMs),
+          new Date(toMs),
+          {
+            calendars: pickCalendars(all, onlyKey),
+          },
+        );
+        if (!alive) return;
+        setEvents(result.events);
+        setErrors(result.errors);
+        setStatus('ready');
+      } catch (err) {
+        if (!alive) return;
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setEvents(NO_EVENTS);
+        // The user's refusal and the machine's silence are different words:
+        // one has a Settings switch behind it and the other does not.
+        setStatus(
+          err instanceof CalendarAccessError ? 'denied' : 'unavailable',
+        );
+      }
+    })();
+
+    return () => {
+      alive = false;
+    };
+    // `refresh` is stable; `nonce` is what a manual refresh moves.
+  }, [cal, fromMs, toMs, onlyKey, nonce]);
+
+  // The subscription is a **separate** effect, and deliberately not keyed on
+  // `nonce`: a change has to re-run the query, and only the query. Watching
+  // from inside the effect the change re-runs means every notification tears
+  // the views down and starts new ones — which is a loop as soon as anything
+  // is delivered while a view is starting, and was one for as long as EDS's
+  // `Start()` reported the range's existing contents as a change.
+  useEffect(() => {
+    if (!cal || !watch) return undefined;
+
+    let alive = true;
+    let stopWatching = null;
+    void (async () => {
+      try {
+        const all = await cal.listCalendars();
+        if (!alive) return;
+        stopWatching = await cal.watch(
+          new Date(fromMs),
+          new Date(toMs),
+          () => {
+            // Re-query rather than patch: a recurrence master edited months
+            // away changes what this range looks like.
+            if (alive && live.current) refresh();
+          },
+          { calendars: pickCalendars(all, onlyKey) },
+        );
+        if (!alive) await stopWatching();
+      } catch {
+        // No grant, no service, nothing to watch. The query effect above is
+        // what reports that to the caller; a second copy would only race.
+      }
+    })();
+
+    return () => {
+      alive = false;
+      void (async () => {
+        if (stopWatching) await stopWatching();
+      })();
+    };
+  }, [cal, watch, fromMs, toMs, onlyKey, refresh]);
+
+  const grouped = useMemo(() => groupByDay(events), [events]);
+
+  return useMemo(
+    () => ({
+      events,
+      byDay: grouped,
+      calendars: found,
+      errors,
+      status,
+      backend,
+      error,
+      refresh,
+      openSettings,
+    }),
+    [
+      events,
+      grouped,
+      found,
+      errors,
+      status,
+      backend,
+      error,
+      refresh,
+      openSettings,
+    ],
+  );
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -29,6 +29,7 @@ export * from './types/launcher.js';
 export * from './types/tray.js';
 export * from './types/permissions.js';
 export * from './types/notifications.js';
+export * from './types/desktopcalendar.js';
 
 /**
  * The XID of the X11 window a ref points at, or `null` if there is not one

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,15 @@ export {
   notify,
 } from './notifications.js';
 export { useNotifier } from './notificationhooks.js';
+export {
+  CalendarAccessError,
+  NoCalendarServiceError,
+  byDay,
+  calendarBackend,
+  dayKey,
+  desktopCalendar,
+} from './desktopcalendar.js';
+export { useDesktopCalendarEvents } from './desktopcalendarhooks.js';
 export { parseUriList } from './transfer.js';
 export { useApp, useClipboard, useSupports } from './appcontext.js';
 export { BusUnavailableError, closeBus, sessionBus, systemBus } from './bus.js';

--- a/src/permissionhooks.js
+++ b/src/permissionhooks.js
@@ -42,30 +42,33 @@ import {
 export function usePermission(kind, options = {}) {
   const app = useAppOrNull();
   const target = options.target;
+  // `calendars` only: which level to ask for. Part of the effect keys
+  // because asking for a narrower grant is asking a different question.
+  const access = options.access;
   const available = permissionBackend({ app }) !== null;
   const [status, setStatus] = useState('unknown');
   const inflight = useRef(null);
 
   const refresh = useCallback(async () => {
-    const next = await permissionStatus(kind, { app, target });
+    const next = await permissionStatus(kind, { app, target, access });
     setStatus(next);
     return next;
-  }, [kind, app, target]);
+  }, [kind, app, target, access]);
 
   useEffect(() => {
     let alive = true;
-    permissionStatus(kind, { app, target }).then(
+    permissionStatus(kind, { app, target, access }).then(
       (next) => alive && setStatus(next),
       () => alive && setStatus('unknown'),
     );
     return () => {
       alive = false;
     };
-  }, [kind, app, target]);
+  }, [kind, app, target, access]);
 
   const request = useCallback(() => {
     if (inflight.current) return inflight.current;
-    const run = requestPermission(kind, { app, target })
+    const run = requestPermission(kind, { app, target, access })
       .then((next) => {
         setStatus(next);
         return next;
@@ -75,7 +78,7 @@ export function usePermission(kind, options = {}) {
       });
     inflight.current = run;
     return run;
-  }, [kind, app, target]);
+  }, [kind, app, target, access]);
 
   const openSettings = useCallback(
     () => openPrivacySettings(kind, { app }),

--- a/src/permissions.js
+++ b/src/permissions.js
@@ -23,18 +23,24 @@
 //
 // ## Two things the vocabulary decides
 //
-// - A status is one of five words. `'granted'`, `'denied'` and
+// - A status is one of six words. `'granted'`, `'denied'` and
 //   `'restricted'` (MDM or parental controls: the user cannot grant it) are
 //   the platform's; `'prompt'` is "not decided yet — a request would ask";
 //   `'unknown'` is "nothing here can say", which is a fact about the machine
 //   rather than about the permission, and the reason a query never throws.
+//   `'write-only'` is the sixth and the odd one: macOS 14's partial grant
+//   for `calendars` and `reminders`, where the app may save an item it
+//   cannot read. It crosses as its own word rather than being flattened
+//   into one of the other two, because it is a grant to a writer and a
+//   refusal to a reader and only the caller knows which it is.
 // - A request answers with the status **after** the user has, never with a
 //   bare boolean, because `'restricted'` and `'denied'` want different UI —
 //   one is a Settings switch the user can flip, the other is not.
 
 import { liveApps } from './trace-registry.js';
 
-/** The kinds a status can be asked for. `automation` wants `{ target }`. */
+/** The kinds a status can be asked for. `automation` wants `{ target }`;
+ *  `calendars` takes `{ access: 'write-only' }` for the narrower grant. */
 export const PERMISSION_KINDS = Object.freeze([
   'camera',
   'microphone',
@@ -43,6 +49,8 @@ export const PERMISSION_KINDS = Object.freeze([
   'input-monitoring',
   'automation',
   'location',
+  'calendars',
+  'reminders',
 ]);
 
 /** The Settings panes, the kinds above plus the two that have no API at all
@@ -55,6 +63,8 @@ const SETTINGS_PANES = Object.freeze({
   'input-monitoring': 'Privacy_ListenEvent',
   automation: 'Privacy_Automation',
   location: 'Privacy_LocationServices',
+  calendars: 'Privacy_Calendars',
+  reminders: 'Privacy_Reminders',
   'files-and-folders': 'Privacy_FilesAndFolders',
   'full-disk-access': 'Privacy_AllFiles',
 });

--- a/src/types/desktopcalendar.d.ts
+++ b/src/types/desktopcalendar.d.ts
@@ -87,8 +87,10 @@ export declare class NoCalendarServiceError extends Error {
 }
 
 /**
- * The user has not allowed this app to read their calendars — their answer,
- * not the machine's, and one `openPrivacySettings('calendars')` can change.
+ * The app may not read the calendars. `status` says why: `'denied'` and
+ * `'restricted'` and `'write-only'` are decisions, and `'prompt'` is a
+ * request that came back with nothing — TCC declining to ask, which the
+ * hook reports as `'unavailable'` rather than as a refusal.
  */
 export declare class CalendarAccessError extends Error {
   readonly name: 'CalendarAccessError';

--- a/src/types/desktopcalendar.d.ts
+++ b/src/types/desktopcalendar.d.ts
@@ -1,0 +1,205 @@
+/**
+ * The calendars the user's desktop already has — EventKit on macOS,
+ * Evolution Data Server on a freedesktop session. See
+ * docs/desktop-calendar.md.
+ */
+
+import type { NtkApp } from './nodes.js';
+import type { PermissionStatus } from './permissions.js';
+
+/** Which rung answered: the EventKit bridge, an `osascript` child holding
+ *  an `EKEventStore`, or Evolution Data Server over the session bus. */
+export type CalendarBackend = 'cocoa' | 'osascript' | 'eds';
+
+/** One calendar the desktop knows about. */
+export interface DesktopCalendarInfo {
+  uid: string;
+  /** The name shown in the desktop's own calendar UI. */
+  name: string;
+  /** Whether the desktop has it switched on. Always true on macOS, which
+   *  has no such state to report. */
+  enabled: boolean;
+  /** `'#3584e4'` — the colour that UI draws it in, worth carrying into a
+   *  day marker. */
+  color?: string;
+  /** `caldav`, `google`, `local`, `exchange`, `subscription`, `birthday`…
+   *  the store's own word, lower-cased. */
+  backend?: string;
+  readOnly: boolean;
+  /** The account it came from, where one is named — a GNOME Online Accounts
+   *  entry, or an `EKSource` (`'iCloud'`, `'Google'`). */
+  account?: string;
+}
+
+/** One occurrence, with any recurrence already expanded. */
+export interface DesktopEvent {
+  uid: string;
+  summary: string;
+  location?: string;
+  description?: string;
+  start: Date;
+  /** **Exclusive**, on every rung: an all-day event on the 10th ends at
+   *  midnight on the 11th. The macOS rungs normalise what EventKit reports
+   *  (the last second of the last day) so a caller never has to ask. */
+  end: Date;
+  allDay: boolean;
+  recurring: boolean;
+  calendar: { uid: string; name: string; color?: string };
+}
+
+/** A calendar that would not answer. One broken backend is not a failure. */
+export interface DesktopCalendarError {
+  calendar: DesktopCalendarInfo;
+  message: string;
+}
+
+export interface EventsResult {
+  events: DesktopEvent[];
+  /** Empty on the macOS rungs, where there is one store. */
+  errors: DesktopCalendarError[];
+}
+
+/**
+ * What `watch` reports. Deliberately thin: re-query rather than patch.
+ *
+ * `'changed'` with a null calendar and no count is EventKit's — its
+ * notification names nothing, and a rung must not invent a count.
+ */
+export interface CalendarChange {
+  calendar: DesktopCalendarInfo | null;
+  kind: 'ObjectsAdded' | 'ObjectsModified' | 'ObjectsRemoved' | 'changed';
+  count: number | null;
+}
+
+export interface EventsOptions {
+  /** Restrict to these calendars. Default: every enabled one. */
+  calendars?: DesktopCalendarInfo[];
+}
+
+/**
+ * Nothing on this machine can read a calendar. Raised only by
+ * `desktopCalendar({ required: true })`; the default answer is `null`,
+ * because a machine with no calendar service is an ordinary machine.
+ */
+export declare class NoCalendarServiceError extends Error {
+  readonly name: 'NoCalendarServiceError';
+  readonly cause?: unknown;
+}
+
+/**
+ * The user has not allowed this app to read their calendars — their answer,
+ * not the machine's, and one `openPrivacySettings('calendars')` can change.
+ */
+export declare class CalendarAccessError extends Error {
+  readonly name: 'CalendarAccessError';
+  readonly status: PermissionStatus;
+  readonly cause?: unknown;
+}
+
+/** A handle on the desktop's calendars. `close()` it. */
+export interface DesktopCalendar {
+  readonly backend: CalendarBackend;
+  /** The grant, without prompting; `'granted'` on a rung with no such gate. */
+  access(): Promise<PermissionStatus>;
+  /** Raise the system's prompt where there is one. Reads do this on the
+   *  first one, so a picker the user never opens never prompts. */
+  requestAccess(): Promise<PermissionStatus>;
+  /** System Settings › Privacy & Security › Calendars. `false` off macOS. */
+  openSettings(): Promise<boolean>;
+  listCalendars(): Promise<DesktopCalendarInfo[]>;
+  /** Occurrences in `[from, to)`, sorted by start. Rejects with
+   *  {@link CalendarAccessError} where the user said no. */
+  eventsBetween(
+    from: Date,
+    to: Date,
+    options?: EventsOptions,
+  ): Promise<EventsResult>;
+  /** Call `onChange` when something moves; the returned function stops. */
+  watch(
+    from: Date,
+    to: Date,
+    onChange: (change: CalendarChange) => void,
+    options?: EventsOptions,
+  ): Promise<() => Promise<void>>;
+  close(): Promise<void>;
+}
+
+export interface DesktopCalendarOptions {
+  /** The connection whose backend to ask, when there are several. */
+  app?: NtkApp;
+  /** Pin one rung and fail rather than fall through it. */
+  backend?: CalendarBackend;
+  /** Reject with {@link NoCalendarServiceError} instead of answering null. */
+  required?: boolean;
+}
+
+/**
+ * The desktop's calendars, on the best rung this machine has — or `null`,
+ * which is an ordinary answer about a machine.
+ */
+export declare function desktopCalendar(
+  options?: DesktopCalendarOptions,
+): Promise<DesktopCalendar | null>;
+
+/** Which rung this machine lands on, without reading anything, spawning
+ *  anything or prompting. */
+export declare function calendarBackend(
+  options?: Pick<DesktopCalendarOptions, 'app'>,
+): Promise<CalendarBackend | null>;
+
+/** The local calendar day a `Date` falls on, as `'YYYY-MM-DD'` — the key
+ *  `byDay` uses and `<Calendar dayContent>` is handed. */
+export declare function dayKey(date: Date): string;
+
+/** Occurrences grouped by the local day they appear on. An event lands
+ *  under every day it touches, not only under its start. */
+export declare function byDay(
+  events: DesktopEvent[],
+): Map<string, DesktopEvent[]>;
+
+/**
+ * `'idle'` before anything is asked, `'denied'` for the user's refusal and
+ * `'unavailable'` for the machine's silence — separate words, because only
+ * one of them has a Settings switch behind it.
+ */
+export type DesktopCalendarStatus =
+  'idle' | 'loading' | 'ready' | 'denied' | 'unavailable';
+
+export interface UseDesktopCalendarEventsOptions {
+  /** Start of the window to read, inclusive. */
+  from: Date;
+  /** End of the window, exclusive. */
+  to: Date;
+  /** Restrict to these calendar uids. Default: every enabled calendar. */
+  calendars?: string[];
+  /** Re-query when the desktop says something changed. */
+  watch?: boolean;
+  /** Set false to hold off entirely — and to not prompt: a picker that is
+   *  not open yet has no business asking for the user's calendar. */
+  enabled?: boolean;
+}
+
+export interface UseDesktopCalendarEventsResult {
+  events: DesktopEvent[];
+  /** The same events, keyed by `'YYYY-MM-DD'`, ready for `dayContent`. */
+  byDay: Map<string, DesktopEvent[]>;
+  /** Every calendar found, for a legend or a filter. */
+  calendars: DesktopCalendarInfo[];
+  /** Calendars that would not answer while others did. Not fatal. */
+  errors: DesktopCalendarError[];
+  status: DesktopCalendarStatus;
+  /** Which rung answered, once one has. */
+  backend: CalendarBackend | null;
+  /** Why there are no events, when there is a reason worth showing. */
+  error: Error | null;
+  /** Re-query now. */
+  refresh: () => void;
+  /** System Settings › Privacy & Security › Calendars — for `'denied'`, and
+   *  for no other status. */
+  openSettings: () => Promise<boolean>;
+}
+
+/** The user's desktop calendar events, as rendering state. */
+export declare function useDesktopCalendarEvents(
+  options: UseDesktopCalendarEventsOptions,
+): UseDesktopCalendarEventsResult;

--- a/src/types/permissions.d.ts
+++ b/src/types/permissions.d.ts
@@ -12,7 +12,9 @@ export type PermissionKind =
   | 'accessibility'
   | 'input-monitoring'
   | 'automation'
-  | 'location';
+  | 'location'
+  | 'calendars'
+  | 'reminders';
 
 /** The panes `openPrivacySettings` reaches: every kind, plus the two with no
  * API because reading the folder is the prompt. */
@@ -23,10 +25,12 @@ export type PrivacyPane =
  * `'granted'`, `'denied'` and `'restricted'` (MDM or parental controls — the
  * user cannot grant it) are the platform's; `'prompt'` is not decided yet, a
  * request would ask; `'unknown'` is "nothing here can say", a fact about the
- * machine rather than the permission.
+ * machine rather than the permission. `'write-only'` is macOS 14's partial
+ * grant for `calendars`/`reminders`: a grant to a writer, a refusal to a
+ * reader, and only the caller knows which it is.
  */
 export type PermissionStatus =
-  'granted' | 'denied' | 'restricted' | 'prompt' | 'unknown';
+  'granted' | 'denied' | 'restricted' | 'prompt' | 'write-only' | 'unknown';
 
 export interface PermissionOptions {
   /** The connection whose backend to ask, when there are several. */
@@ -34,6 +38,10 @@ export interface PermissionOptions {
   /** `automation` only: the bundle id of the app to send Apple Events to.
    * Only a running target has an answer. */
   target?: string;
+  /** `calendars` only: which grant to ask for. `'write-only'` is macOS 14's
+   * narrower prompt — the app may save events it cannot read. `reminders`
+   * has no such grant and refuses one. */
+  access?: 'full' | 'write-only';
 }
 
 /**
@@ -96,5 +104,5 @@ export interface Permission {
 /** A permission for a component: the status as render state. */
 export declare function usePermission(
   kind: PermissionKind,
-  options?: Pick<PermissionOptions, 'target'>,
+  options?: Pick<PermissionOptions, 'target' | 'access'>,
 ): Permission;

--- a/test/calendar-example.test.js
+++ b/test/calendar-example.test.js
@@ -1,0 +1,177 @@
+// examples/calendar.jsx carries its own test (AGENTS.md, "every app carries
+// its own tests"): the week app driven over a calendar rung attached to the
+// mock backend, asserting the two things the example exists to show — the
+// user's real events landing on the right days, and the app changing what it
+// draws with the rung rather than with the platform.
+//
+// The rung here is an object with the four verbs `desktopCalendar()` looks
+// for, hung on the app the tree renders through. That is the whole capability
+// test (src/desktopcalendar.js `calendarsApp`), so this also pins that the
+// ladder finds a capability on *an app*, not on a backend it recognises.
+import assert from 'node:assert';
+import { afterEach, test } from 'node:test';
+import React from 'react';
+
+import {
+  act,
+  cleanup,
+  createMockApp,
+  renderX11,
+  textOf,
+} from '../src/testing/index.js';
+
+process.env.REACT_X11_NO_AUTORUN = '1';
+const { default: App } = await import('../examples/calendar.jsx');
+
+const h = React.createElement;
+const FONTS = { '': { ascent: 12, descent: 3, widths: { '': 7 } } };
+
+// A Wednesday, so the week on screen is Monday the 7th to Sunday the 13th.
+const TODAY = new Date(2026, 8, 9, 10, 0);
+
+const CALENDARS = [
+  {
+    uid: 'home',
+    name: 'Home',
+    enabled: true,
+    color: '#34aadc',
+    backend: 'caldav',
+    readOnly: false,
+    account: 'iCloud',
+  },
+  {
+    uid: 'holidays',
+    name: 'Australian Holidays',
+    enabled: true,
+    color: '#1badf8',
+    backend: 'subscription',
+    readOnly: true,
+    account: 'Subscribed Calendars',
+  },
+];
+
+function occurrence(over) {
+  return {
+    uid: 'e1',
+    summary: 'Standup',
+    start: new Date(2026, 8, 9, 9, 0),
+    end: new Date(2026, 8, 9, 9, 15),
+    allDay: false,
+    recurring: false,
+    calendar: { uid: 'home', name: 'Home', color: '#34aadc' },
+    ...over,
+  };
+}
+
+/** A rung with the four verbs the ladder asks for, and a change it can
+ *  announce. `access` is what decides which of the app's three faces the
+ *  test sees. */
+function fakeRung({ access = 'granted', events = [], calendars = CALENDARS }) {
+  const watchers = new Set();
+  return {
+    backend: 'cocoa',
+    reads: 0,
+    watchers,
+    access: async () => access,
+    requestAccess: async () => access,
+    listCalendars: async () => calendars,
+    async eventsBetween() {
+      this.reads++;
+      return { events, errors: [] };
+    },
+    async watch(from, to, onChange) {
+      watchers.add(onChange);
+      return async () => watchers.delete(onChange);
+    },
+    change: () =>
+      watchers.forEach((fn) =>
+        fn({ calendar: null, kind: 'changed', count: null }),
+      ),
+    close: async () => {},
+  };
+}
+
+async function mount(rung) {
+  const app = createMockApp({ fonts: FONTS });
+  app.calendars = rung;
+  const tree = await renderX11(h(App, { today: TODAY }), { app });
+  // the handle opens, the grant is read, the events arrive
+  for (let i = 0; i < 6; i++) await act(async () => {});
+  return tree;
+}
+
+afterEach(cleanup);
+
+const HOLIDAYS = {
+  uid: 'holidays',
+  name: 'Australian Holidays',
+  color: '#1badf8',
+};
+
+test('the week shows the events, on the days they happen', async () => {
+  const rung = fakeRung({
+    events: [
+      occurrence(), //  Wednesday the 9th, inside
+      occurrence({
+        uid: 'e2',
+        summary: 'Labour Day',
+        allDay: true,
+        start: new Date(2026, 8, 7),
+        end: new Date(2026, 8, 8), //  exclusive: Monday the 7th only
+        calendar: HOLIDAYS,
+      }),
+      occurrence({
+        uid: 'e3',
+        summary: 'Father’s Day',
+        allDay: true,
+        start: new Date(2026, 8, 6),
+        end: new Date(2026, 8, 7), //  the Sunday *before* this week
+        calendar: HOLIDAYS,
+      }),
+    ],
+  });
+  const tree = await mount(rung);
+  const text = textOf(tree.windowNode);
+
+  assert.match(text, /Standup/);
+  assert.match(text, /09:00.*09:15/, 'a timed event shows its span');
+  assert.match(text, /Labour Day/);
+  assert.match(text, /all day/, 'and an all-day one says so instead');
+  // The week is what is drawn, not the whole result: an exclusive end means
+  // the 6th's all-day event belongs to the previous week and to no day here.
+  assert.doesNotMatch(text, /Father’s Day/);
+  // the footer says which rung answered, which is the point of the app
+  assert.match(text, /cocoa — 2 calendars/);
+  // The headings are the user's locale, so they are not asserted as strings.
+  // What is structural: Monday's event is drawn before Wednesday's, which is
+  // the grouping working rather than the list being printed in order.
+  assert.ok(
+    text.indexOf('Labour Day') < text.indexOf('Standup'),
+    'Monday before Wednesday',
+  );
+});
+
+test('a refusal offers the Settings pane; nothing else does', async () => {
+  const denied = fakeRung({ access: 'denied' });
+  const tree = await mount(denied);
+  const text = textOf(tree.windowNode);
+  assert.match(text, /may not read your calendars/);
+  assert.match(text, /Open Settings/);
+  assert.equal(denied.reads, 0, 'and it did not read anything');
+
+  await cleanup();
+  const fine = await mount(fakeRung({ events: [occurrence()] }));
+  assert.doesNotMatch(textOf(fine.windowNode), /Open Settings/);
+});
+
+test('a change in the store re-queries the week', async () => {
+  const rung = fakeRung({ events: [occurrence()] });
+  const tree = await mount(rung);
+  const before = rung.reads;
+  assert.ok(before > 0);
+
+  await act(async () => rung.change());
+  for (let i = 0; i < 4; i++) await act(async () => {});
+  assert.ok(rung.reads > before, 'the week read itself again');
+  assert.match(textOf(tree.windowNode), /Standup/);
+});

--- a/test/desktop-calendar.test.js
+++ b/test/desktop-calendar.test.js
@@ -1,0 +1,1195 @@
+// The desktop's calendars (src/desktopcalendar.js, docs/desktop-calendar.md):
+// the shape every rung agrees on, the EDS rung over an in-process broker, the
+// EventKit rung over a recording fake bridge, the `osascript` rung over a fake
+// child speaking the same JSON lines, and the ladder that picks between them.
+//
+// Three things are deliberately not here, and none of them can be:
+//
+// - **The real EventKit.** The bridge's own tests own the framework; what is
+//   tested here is the translation into one shape and the policy above it.
+// - **The system's permission prompt.** A test that raised one would wait for
+//   a human, and on a developer's own Mac it would record a TCC decision for
+//   whatever process happened to be running the suite. Every test here either
+//   pins a rung with a fake behind it or forces the platform, so nothing on
+//   this machine is ever asked. See docs/desktop-calendar.md for the prompt
+//   measured by hand.
+// - **Service activation.** EDS is D-Bus-activatable; the broker is not.
+import assert from 'node:assert';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { afterEach, describe, test } from 'node:test';
+import React from 'react';
+
+import { CocoaApp } from '../src/cocoa/app.js';
+import { calendarInfo, desktopEvent } from '../src/cocoa/calendar.js';
+import {
+  CalendarAccessError,
+  MACOS_CALENDAR_PROGRAM,
+  NoCalendarServiceError,
+  _closeCalendarChild,
+  _setCalendarSpawnForTests,
+  byDay,
+  calendarBackend,
+  chunkSpan,
+  dayKey,
+  desktopCalendar,
+  hexFromComponents,
+  parseKeyFile,
+  withExclusiveEnd,
+} from '../src/desktopcalendar.js';
+import { useDesktopCalendarEvents } from '../src/desktopcalendarhooks.js';
+import { createRoot } from '../src/index.js';
+import { PERMISSION_KINDS, privacySettingsUrl } from '../src/permissions.js';
+import { setCompositingForTests } from '../src/compositing.js';
+import { setScaleForTests } from '../src/scale.js';
+import { setScreensForTests } from '../src/screens.js';
+import { fakeEds, NOTIFY_INITIAL } from './helpers/fake-eds.js';
+import { transportAvailable, withBus } from './helpers/with-bus.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setTimeout(resolve, 2));
+
+const haveTransport = await transportAvailable();
+const needsBroker = haveTransport
+  ? {}
+  : { skip: 'dbus-native is not installed (expected on Node < 22.12)' };
+
+/** Poll until `check` answers, flushing timers and microtasks between tries.
+ *  Every rung here settles across ticks — a bus round trip, a pipe, a
+ *  promise chain — so a single `await` would be reading the first frame. */
+async function until(check, message, timeout = 5000) {
+  const deadline = Date.now() + timeout;
+  for (;;) {
+    const value = await check();
+    if (value) return value;
+    if (Date.now() > deadline) {
+      throw new Error(`timed out waiting for ${message}`);
+    }
+    await tick();
+  }
+}
+
+/** Run `fn` on a machine that is not a Mac, so the ladder cannot reach the
+ *  `osascript` rung — which on the machine writing this would spawn a real
+ *  child and ask the user for their calendar. */
+async function asLinux(fn) {
+  const saved = process.platform;
+  Object.defineProperty(process, 'platform', { value: 'linux' });
+  try {
+    return await fn();
+  } finally {
+    Object.defineProperty(process, 'platform', { value: saved });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The shape every rung agrees on
+// ---------------------------------------------------------------------------
+
+/** A minimal event, built in *local* time so the assertions below do not
+ *  depend on the machine's timezone. */
+function event(uid, start, end, allDay = false) {
+  return {
+    uid,
+    summary: uid,
+    start,
+    end,
+    allDay,
+    recurring: false,
+    calendar: { uid: 'cal', name: 'Cal' },
+  };
+}
+
+describe('one shape, whichever rung answered', () => {
+  test('a source keyfile parses into sections', () => {
+    const cfg = parseKeyFile(
+      [
+        '[Data Source]',
+        'DisplayName=Work',
+        'DisplayName[ru]=Работа',
+        'Enabled=true',
+        '',
+        '# a comment',
+        '[Calendar]',
+        'BackendName=caldav',
+        'Color=#3584e4',
+      ].join('\n'),
+    );
+    assert.equal(cfg['Data Source'].DisplayName, 'Work');
+    assert.equal(cfg.Calendar.Color, '#3584e4');
+    assert.equal(cfg.Calendar.BackendName, 'caldav');
+    // a translated key is not the key
+    assert.equal(cfg['Data Source']['DisplayName[ru]'], undefined);
+  });
+
+  test('an event lands on the day it happens', () => {
+    const days = byDay([
+      event('standup', new Date(2026, 7, 7, 9, 0), new Date(2026, 7, 7, 9, 15)),
+    ]);
+    assert.deepEqual([...days.keys()], ['2026-08-07']);
+    assert.equal(days.get('2026-08-07').length, 1);
+    assert.equal(dayKey(new Date(2026, 7, 7, 23, 59)), '2026-08-07');
+  });
+
+  test('a multi-day event lands on every day it touches', () => {
+    // an all-day span is [start, end): the 10th, 11th and 12th, not the 13th
+    const days = byDay([
+      event('conf', new Date(2026, 7, 10), new Date(2026, 7, 13), true),
+    ]);
+    assert.deepEqual(
+      [...days.keys()].sort(),
+      ['2026-08-10', '2026-08-11', '2026-08-12'],
+      'the exclusive end does not mark a fourth day',
+    );
+  });
+
+  test('an event crossing midnight lands on both days', () => {
+    const days = byDay([
+      event('party', new Date(2026, 7, 7, 22, 0), new Date(2026, 7, 8, 2, 0)),
+    ]);
+    assert.deepEqual([...days.keys()].sort(), ['2026-08-07', '2026-08-08']);
+  });
+
+  test("EventKit's last-second end becomes the exclusive one", () => {
+    // what the store reports for a one-day all-day event on the 10th
+    const reported = new Date(2026, 7, 10, 23, 59, 59);
+    const end = withExclusiveEnd(reported, true);
+    assert.equal(end.getTime(), new Date(2026, 7, 11).getTime());
+    // and one that is already exclusive must not gain a day
+    const midnight = new Date(2026, 7, 11);
+    assert.equal(
+      withExclusiveEnd(midnight, true).getTime(),
+      midnight.getTime(),
+    );
+    // a timed event is never touched, whatever the clock says
+    assert.equal(withExclusiveEnd(reported, false), reported);
+
+    const days = byDay([event('holiday', new Date(2026, 7, 10), end, true)]);
+    assert.deepEqual([...days.keys()], ['2026-08-10'], 'one day, not two');
+  });
+
+  test('a span longer than EventKit allows is asked for in pieces', () => {
+    const from = new Date(2020, 0, 1);
+    const to = new Date(2030, 0, 1);
+    const chunks = chunkSpan(from, to);
+    assert.ok(chunks.length > 2, 'a decade is more than one predicate');
+    assert.equal(chunks[0][0], from.getTime());
+    assert.equal(chunks.at(-1)[1], to.getTime());
+    for (const [start, end] of chunks) {
+      assert.ok(
+        end - start <= 1400 * 24 * 60 * 60 * 1000,
+        'each piece is inside the four-year limit',
+      );
+    }
+    // and the pieces join up, so nothing between them is lost
+    for (let i = 1; i < chunks.length; i++) {
+      assert.equal(chunks[i][0], chunks[i - 1][1]);
+    }
+    // a month is one query
+    assert.equal(
+      chunkSpan(new Date(2026, 7, 1), new Date(2026, 8, 1)).length,
+      1,
+    );
+  });
+
+  test("EventKit's colour components become the EDS rung's hex", () => {
+    assert.equal(hexFromComponents([0.2078, 0.5176, 0.894, 1]), '#3584e4');
+    assert.equal(hexFromComponents(null), undefined);
+    assert.equal(hexFromComponents([1, 1]), undefined);
+  });
+
+  test('a calendar and an event from the bridge take the common shape', () => {
+    const info = calendarInfo({
+      id: 'ABC',
+      title: 'Work',
+      color: [0.878, 0.105, 0.141, 1],
+      type: 'calDAV',
+      source: { id: 'S1', title: 'Google' },
+      allowsModifications: false,
+      immutable: false,
+      subscribed: false,
+    });
+    assert.deepEqual(info, {
+      uid: 'ABC',
+      name: 'Work',
+      enabled: true,
+      color: '#e01b24',
+      backend: 'caldav',
+      readOnly: true,
+      account: 'Google',
+    });
+
+    const one = desktopEvent(
+      {
+        id: 'E1',
+        calendar: 'ABC',
+        title: 'Standup',
+        location: 'Kitchen',
+        notes: null,
+        start: new Date(2026, 7, 7, 9).getTime(),
+        end: new Date(2026, 7, 7, 9, 15).getTime(),
+        allDay: false,
+        recurring: true,
+      },
+      new Map([[info.uid, info]]),
+    );
+    assert.equal(one.summary, 'Standup');
+    assert.equal(one.location, 'Kitchen');
+    assert.equal(one.description, undefined, 'no notes is absent, not ""');
+    assert.equal(one.recurring, true);
+    assert.equal(one.calendar.color, '#e01b24');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The permission vocabulary the calendar needs
+// ---------------------------------------------------------------------------
+
+describe('the two new permission kinds', () => {
+  test('calendars and reminders are kinds, with panes of their own', () => {
+    assert.ok(PERMISSION_KINDS.includes('calendars'));
+    assert.ok(PERMISSION_KINDS.includes('reminders'));
+    assert.match(privacySettingsUrl('calendars'), /Privacy_Calendars$/);
+    assert.match(privacySettingsUrl('reminders'), /Privacy_Reminders$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rung 1: EventKit through the bridge
+// ---------------------------------------------------------------------------
+
+const CAL_PERSONAL = {
+  id: 'personal',
+  title: 'Personal',
+  color: [0.2078, 0.5176, 0.894, 1],
+  type: 'local',
+  source: { id: 'local', title: 'On My Mac' },
+  allowsModifications: true,
+  immutable: false,
+  subscribed: false,
+};
+const CAL_WORK = {
+  id: 'work',
+  title: 'Work',
+  color: [0.878, 0.105, 0.141, 1],
+  type: 'calDAV',
+  source: { id: 'goog', title: 'Google' },
+  allowsModifications: false,
+  immutable: false,
+  subscribed: false,
+};
+
+/** A bridge that records what it was asked, with EventKit's verbs on it.
+ *  `calendars: false` is a bridge older than 0.8 — the capability is absent
+ *  and the ladder must step past it rather than fail. */
+function fakeNative({
+  status = 'authorized',
+  answer = null,
+  calendars = [CAL_PERSONAL, CAL_WORK],
+  events = [],
+  hasCalendars = true,
+} = {}) {
+  let seq = 0;
+  const base = {
+    calls: [],
+    backendEvents: null,
+    of: (name) =>
+      base.calls.filter((c) => c[0] === name).map((c) => c.slice(1)),
+    authorizationStatus(kind, opts) {
+      base.calls.push(['authorizationStatus', kind, opts]);
+      return status;
+    },
+    requestAuthorization(kind, ...rest) {
+      const cb = rest.pop();
+      base.calls.push(['requestAuthorization', kind, rest[0]]);
+      const settled = answer ?? status;
+      setImmediate(() => cb(settled === 'authorized', settled));
+    },
+    openPrivacySettings(kind) {
+      base.calls.push(['openPrivacySettings', kind]);
+    },
+    calendars(cb) {
+      base.calls.push(['calendars']);
+      setImmediate(() => cb(null, calendars));
+    },
+    eventsBetween(range, cb) {
+      base.calls.push(['eventsBetween', range]);
+      setImmediate(() =>
+        cb(null, typeof events === 'function' ? events(range) : events),
+      );
+    },
+    setBackendEventCallback(fn) {
+      base.backendEvents = fn;
+    },
+    initApp() {},
+    listScreens: () => [
+      { x: 0, y: 0, width: 1440, height: 900, scale: 2, fps: 60 },
+    ],
+    createWindow2: (o) => ({ id: ++seq, options: { ...o } }),
+    windowNumber: (handle) => handle.id,
+    windowRootLayer: (handle) => ({ root: handle.id }),
+    getWindowFrame: (handle) => ({
+      x: 0,
+      y: 0,
+      width: handle.options.width,
+      height: handle.options.height,
+    }),
+    windowIsVisible: () => true,
+    createSurfaceIOSurface: (width, height, scale) => ({
+      handle: { id: ++seq, width, height, scale },
+      iosurfaceId: seq,
+    }),
+    createSurface: (width, height, scale) => ({
+      id: ++seq,
+      width,
+      height,
+      scale,
+    }),
+    surfaceSize: (handle) => ({
+      width: handle.width,
+      height: handle.height,
+      scale: handle.scale,
+    }),
+  };
+  return new Proxy(base, {
+    get: (target, key) => {
+      // An older bridge has neither verb, and `typeof … === 'function'` on
+      // the app is the whole capability test.
+      if (!hasCalendars && (key === 'calendars' || key === 'eventsBetween')) {
+        return undefined;
+      }
+      return key in target ? target[key] : () => undefined;
+    },
+  });
+}
+
+function appOver(native) {
+  const app = new CocoaApp(native);
+  setScaleForTests(app, 2, 'cocoa');
+  setScreensForTests(app, {
+    monitors: [{ x: 0, y: 0, width: 2880, height: 1800 }],
+    workArea: { x: 0, y: 0, width: 2880, height: 1750 },
+  });
+  setCompositingForTests(app, true);
+  return app;
+}
+
+const AUGUST = [new Date(2026, 7, 1), new Date(2026, 8, 1)];
+
+/** One occurrence as the bridge reports it: epoch ms, all-day ending at the
+ *  last second of its last day. */
+function bridgeEvent(over = {}) {
+  return {
+    id: 'E1',
+    calendar: 'personal',
+    title: 'Standup',
+    location: null,
+    notes: null,
+    start: new Date(2026, 7, 7, 9).getTime(),
+    end: new Date(2026, 7, 7, 9, 15).getTime(),
+    allDay: false,
+    recurring: false,
+    ...over,
+  };
+}
+
+const handles = [];
+const roots = [];
+afterEach(async () => {
+  for (const handle of handles.splice(0)) await handle.close();
+  for (const root of roots.splice(0)) await root.unmount();
+  _setCalendarSpawnForTests(null);
+  _closeCalendarChild();
+});
+
+async function open(options) {
+  const cal = await desktopCalendar(options);
+  if (cal) handles.push(cal);
+  return cal;
+}
+
+describe('the cocoa rung', () => {
+  test('the app carrying the bridge is the rung, and it is found by that', async () => {
+    const app = appOver(fakeNative());
+    assert.equal(await calendarBackend({ app }), 'cocoa');
+    const cal = await open({ app });
+    assert.equal(cal.backend, 'cocoa');
+
+    const older = appOver(fakeNative({ hasCalendars: false }));
+    assert.equal(older.calendars, null, 'a bridge before 0.8 has no rung');
+  });
+
+  test('calendars and events come back in the common shape', async () => {
+    const native = fakeNative({ events: [bridgeEvent()] });
+    const app = appOver(native);
+    const cal = await open({ app });
+
+    const list = await cal.listCalendars();
+    assert.deepEqual(
+      list.map((c) => [c.uid, c.name, c.color, c.readOnly]),
+      [
+        ['personal', 'Personal', '#3584e4', false],
+        ['work', 'Work', '#e01b24', true],
+      ],
+    );
+
+    const { events, errors } = await cal.eventsBetween(AUGUST[0], AUGUST[1]);
+    assert.deepEqual(errors, [], 'one store: a failure is the whole read');
+    assert.equal(events.length, 1);
+    assert.equal(events[0].summary, 'Standup');
+    assert.equal(events[0].calendar.name, 'Personal');
+    assert.equal(events[0].calendar.color, '#3584e4');
+
+    // the range crossed as epoch ms, and every calendar meant no filter
+    const [range] = native.of('eventsBetween').at(-1);
+    assert.equal(range.start, AUGUST[0].getTime());
+    assert.equal(range.end, AUGUST[1].getTime());
+    assert.equal(range.calendars, undefined);
+  });
+
+  test('an all-day event ends where every other rung ends it', async () => {
+    const native = fakeNative({
+      events: [
+        bridgeEvent({
+          id: 'holiday',
+          allDay: true,
+          start: new Date(2026, 7, 10).getTime(),
+          end: new Date(2026, 7, 12, 23, 59, 59).getTime(),
+        }),
+      ],
+    });
+    const cal = await open({ app: appOver(native) });
+    const { events } = await cal.eventsBetween(AUGUST[0], AUGUST[1]);
+    assert.equal(
+      events[0].end.getTime(),
+      new Date(2026, 7, 13).getTime(),
+      'exclusive, so byDay marks the 10th to the 12th',
+    );
+    assert.deepEqual(
+      [...byDay(events).keys()],
+      ['2026-08-10', '2026-08-11', '2026-08-12'],
+    );
+  });
+
+  test('a decade is chunked, and an occurrence on a seam is not doubled', async () => {
+    const seam = chunkSpan(new Date(2020, 0, 1), new Date(2030, 0, 1));
+    const onSeam = seam[1][0];
+    const native = fakeNative({
+      // every chunk answers with the event that sits on the first seam
+      events: () => [bridgeEvent({ id: 'seam', start: onSeam, end: onSeam })],
+    });
+    const cal = await open({ app: appOver(native) });
+    const { events } = await cal.eventsBetween(
+      new Date(2020, 0, 1),
+      new Date(2030, 0, 1),
+    );
+    assert.equal(native.of('eventsBetween').length, seam.length);
+    assert.equal(events.length, 1, 'the same occurrence, reported once');
+  });
+
+  test('a filter names the calendars it wants, and nothing else', async () => {
+    const native = fakeNative({ events: [] });
+    const cal = await open({ app: appOver(native) });
+    const list = await cal.listCalendars();
+    await cal.eventsBetween(AUGUST[0], AUGUST[1], {
+      calendars: list.filter((c) => c.uid === 'work'),
+    });
+    const [range] = native.of('eventsBetween').at(-1);
+    assert.deepEqual(range.calendars, ['work']);
+  });
+
+  test('a filter that matched nothing means nothing, not everything', async () => {
+    // an empty calendar list is what a nil predicate means to EventKit —
+    // every calendar — so the rung must not send one
+    const native = fakeNative({ events: [bridgeEvent()] });
+    const cal = await open({ app: appOver(native) });
+    const { events } = await cal.eventsBetween(AUGUST[0], AUGUST[1], {
+      calendars: [],
+    });
+    assert.deepEqual(events, []);
+    assert.equal(native.of('eventsBetween').length, 0, 'and asked nothing');
+  });
+
+  test('the store’s notification is a change with nothing named', async () => {
+    const native = fakeNative();
+    const app = appOver(native);
+    const cal = await open({ app });
+    const seen = [];
+    const stop = await cal.watch(AUGUST[0], AUGUST[1], (c) => seen.push(c));
+
+    // exactly what the bridge's own callback does with the event
+    app._route({ type: 'calendar-store-changed' });
+    assert.deepEqual(seen, [{ calendar: null, kind: 'changed', count: null }]);
+
+    await stop();
+    app._route({ type: 'calendar-store-changed' });
+    assert.equal(seen.length, 1, 'stopped means stopped');
+  });
+
+  test('close() drops this handle’s watches and leaves the app’s alone', async () => {
+    const native = fakeNative();
+    const app = appOver(native);
+    const first = await desktopCalendar({ app });
+    const second = await desktopCalendar({ app });
+    const seen = [];
+    await first.watch(AUGUST[0], AUGUST[1], () => seen.push('first'));
+    await second.watch(AUGUST[0], AUGUST[1], () => seen.push('second'));
+
+    await first.close();
+    app._route({ type: 'calendar-store-changed' });
+    assert.deepEqual(seen, ['second']);
+    await second.close();
+  });
+});
+
+describe('the grant, on a rung that has one', () => {
+  test('the first read asks, and only the first', async () => {
+    const native = fakeNative({
+      status: 'notDetermined',
+      answer: 'authorized',
+    });
+    const cal = await open({ app: appOver(native) });
+
+    assert.equal(await cal.access(), 'prompt', 'reading a status never asks');
+    assert.equal(native.of('requestAuthorization').length, 0);
+
+    await cal.listCalendars();
+    await cal.eventsBetween(AUGUST[0], AUGUST[1]);
+    assert.deepEqual(
+      native.of('requestAuthorization'),
+      [['calendars', undefined]],
+      'two reads, one prompt',
+    );
+  });
+
+  test('a refusal is a typed rejection, not an empty list', async () => {
+    const native = fakeNative({ status: 'denied' });
+    const cal = await open({ app: appOver(native) });
+    assert.equal(await cal.access(), 'denied');
+    await assert.rejects(
+      () => cal.eventsBetween(AUGUST[0], AUGUST[1]),
+      (err) => {
+        assert.ok(err instanceof CalendarAccessError);
+        assert.equal(err.status, 'denied');
+        return true;
+      },
+    );
+    assert.equal(native.of('calendars').length, 0, 'and nothing was read');
+  });
+
+  test("macOS 14's write-only grant is a refusal to a reader, by its own name", async () => {
+    const native = fakeNative({ status: 'writeOnly' });
+    const cal = await open({ app: appOver(native) });
+    assert.equal(await cal.access(), 'write-only');
+    await assert.rejects(
+      () => cal.listCalendars(),
+      (err) => err.status === 'write-only',
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rung 2: EventKit through an `osascript` child
+// ---------------------------------------------------------------------------
+
+/**
+ * A child that speaks the program's protocol without being it.
+ *
+ * The program itself cannot run off a Mac, and running it on one would ask
+ * the user for their calendar — so what is pinned here is the protocol and
+ * the plumbing around it: one child shared and ref-counted, a reply matched
+ * by id, a push that is not a reply, and a death that fails what was in
+ * flight. `MACOS_CALENDAR_PROGRAM` is asserted as source, and measured by
+ * hand (docs/desktop-calendar.md).
+ */
+function fakeOsascript({
+  status = 'granted',
+  calendars = [],
+  events = [],
+  hello = true,
+} = {}) {
+  const child = new EventEmitter();
+  const out = new PassThrough({ encoding: 'utf8' });
+  child.stdout = out;
+  child.asked = [];
+  child.watching = false;
+  child.alive = true;
+  child.status = status;
+
+  const emit = (obj) => out.write(`${JSON.stringify(obj)}\n`);
+  child.change = () => emit({ event: 'changed' });
+
+  let buffered = '';
+  child.stdin = {
+    write(chunk) {
+      buffered += chunk;
+      let at;
+      while ((at = buffered.indexOf('\n')) !== -1) {
+        const line = buffered.slice(0, at);
+        buffered = buffered.slice(at + 1);
+        if (!line.trim()) continue;
+        const msg = JSON.parse(line);
+        child.asked.push(msg);
+        // Answering on a later tick is not decoration: a rung that read its
+        // own reply synchronously would be a different program.
+        setImmediate(() => {
+          if (!child.alive) return;
+          switch (msg.op) {
+            case 'status':
+              return emit({ id: msg.id, ok: child.status });
+            case 'request':
+              child.status =
+                child.status === 'prompt' ? 'granted' : child.status;
+              return emit({ id: msg.id, ok: child.status });
+            case 'calendars':
+              return emit({ id: msg.id, ok: calendars });
+            case 'events':
+              return emit({
+                id: msg.id,
+                ok: typeof events === 'function' ? events(msg) : events,
+              });
+            case 'watch':
+              child.watching = true;
+              return emit({ id: msg.id, ok: true });
+            default:
+              return emit({ id: msg.id, error: `unknown op ${msg.op}` });
+          }
+        });
+      }
+      return true;
+    },
+    end() {
+      child.kill();
+    },
+  };
+  child.kill = () => {
+    if (!child.alive) return;
+    child.alive = false;
+    child.emit('exit', 0, null);
+  };
+  child.unref = () => {};
+  if (hello) {
+    setImmediate(() => emit({ ready: true, status: child.status }));
+  }
+  return child;
+}
+
+describe('the osascript rung', () => {
+  test('the program is a JXA program that answers lines', () => {
+    // Pinned as source because it cannot be executed here: it is the rung's
+    // whole implementation, and a silent edit to it is a silent regression.
+    assert.match(MACOS_CALENDAR_PROGRAM, /ObjC\.import\('EventKit'\)/);
+    assert.match(MACOS_CALENDAR_PROGRAM, /EKEventStoreChangedNotification/);
+    assert.match(
+      MACOS_CALENDAR_PROGRAM,
+      /requestFullAccessToEventsWithCompletion/,
+      'macOS 14+ asks with the new selector',
+    );
+    assert.match(
+      MACOS_CALENDAR_PROGRAM,
+      /requestAccessToEntityTypeCompletion/,
+      'and the old one is still there for macOS 13',
+    );
+    assert.match(
+      MACOS_CALENDAR_PROGRAM,
+      /getppid/,
+      'and it leaves when its parent has',
+    );
+  });
+
+  test('one child answers, in the common shape', async () => {
+    let child = null;
+    _setCalendarSpawnForTests(() => {
+      child = fakeOsascript({
+        calendars: [
+          {
+            id: 'personal',
+            title: 'Personal',
+            color: [0.2078, 0.5176, 0.894, 1],
+            type: 'local',
+            source: { title: 'On My Mac' },
+            allowsModifications: true,
+          },
+        ],
+        events: [
+          {
+            id: 'E1',
+            calendar: 'personal',
+            title: 'Standup',
+            location: 'Kitchen',
+            notes: null,
+            start: new Date(2026, 7, 7, 9).getTime(),
+            end: new Date(2026, 7, 7, 9, 15).getTime(),
+            allDay: false,
+            recurring: false,
+          },
+        ],
+      });
+      return child;
+    });
+
+    assert.equal(await calendarBackend(), 'osascript');
+    const cal = await open({});
+    assert.equal(cal.backend, 'osascript');
+
+    const list = await cal.listCalendars();
+    assert.deepEqual(
+      list.map((c) => [c.uid, c.name, c.color]),
+      [['personal', 'Personal', '#3584e4']],
+    );
+    const { events } = await cal.eventsBetween(AUGUST[0], AUGUST[1]);
+    assert.equal(events[0].summary, 'Standup');
+    assert.equal(events[0].location, 'Kitchen');
+    assert.equal(events[0].calendar.name, 'Personal');
+
+    // epoch ms on the wire, and the range as asked
+    const asked = child.asked.find((m) => m.op === 'events');
+    assert.equal(asked.start, AUGUST[0].getTime());
+    assert.equal(asked.end, AUGUST[1].getTime());
+  });
+
+  test('two handles share one child, and the last one out closes it', async () => {
+    const spawned = [];
+    _setCalendarSpawnForTests(() => {
+      const child = fakeOsascript();
+      spawned.push(child);
+      return child;
+    });
+
+    const first = await desktopCalendar({});
+    const second = await desktopCalendar({});
+    assert.equal(spawned.length, 1, 'one process, however many handles');
+
+    await first.close();
+    assert.equal(spawned[0].alive, true, 'the other handle is still using it');
+    await second.close();
+    assert.equal(spawned[0].alive, false);
+
+    // and the next handle starts a new one rather than talking to a corpse
+    const third = await desktopCalendar({});
+    assert.equal(spawned.length, 2);
+    await third.close();
+  });
+
+  test('the change push is not a reply, and stops when the watch does', async () => {
+    let child = null;
+    _setCalendarSpawnForTests(() => (child = fakeOsascript()));
+    const cal = await open({});
+    const seen = [];
+    const stop = await cal.watch(AUGUST[0], AUGUST[1], (c) => seen.push(c));
+    assert.equal(child.watching, true, 'the observer was armed once');
+
+    child.change();
+    await tick();
+    assert.deepEqual(seen, [{ calendar: null, kind: 'changed', count: null }]);
+
+    await stop();
+    child.change();
+    await tick();
+    assert.equal(seen.length, 1);
+  });
+
+  test('a child that dies fails what was in flight rather than hanging', async () => {
+    let child = null;
+    _setCalendarSpawnForTests(() => (child = fakeOsascript()));
+    const cal = await open({});
+    const pending = cal.listCalendars();
+    child.kill();
+    await assert.rejects(() => pending, /exited/);
+  });
+
+  test('a child that never says hello is this Mac saying no', async () => {
+    _setCalendarSpawnForTests(() => {
+      const child = fakeOsascript({ hello: false });
+      // osascript itself failing: it starts and leaves without a word
+      setImmediate(() => child.kill());
+      return child;
+    });
+    assert.equal(await desktopCalendar({}), null);
+    await assert.rejects(
+      () => desktopCalendar({ required: true }),
+      NoCalendarServiceError,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Rung 3: Evolution Data Server, over an in-process broker
+// ---------------------------------------------------------------------------
+
+const ICS_ONE = [
+  'BEGIN:VCALENDAR',
+  'VERSION:2.0',
+  'BEGIN:VEVENT',
+  'UID:standup',
+  'SUMMARY:Standup',
+  'LOCATION:Kitchen',
+  'DTSTART:20260807T090000Z',
+  'DTEND:20260807T091500Z',
+  'END:VEVENT',
+  'END:VCALENDAR',
+].join('\r\n');
+
+const ICS_WEEKLY = [
+  'BEGIN:VCALENDAR',
+  'VERSION:2.0',
+  'BEGIN:VEVENT',
+  'UID:sync',
+  'SUMMARY:Weekly sync',
+  'DTSTART:20260803T100000Z',
+  'DTEND:20260803T110000Z',
+  'RRULE:FREQ=WEEKLY;COUNT=4',
+  'END:VEVENT',
+  'END:VCALENDAR',
+].join('\r\n');
+
+const UTC_AUGUST = [
+  new Date(Date.UTC(2026, 7, 1)),
+  new Date(Date.UTC(2026, 8, 1)),
+];
+
+/** A broker, a fake EDS on it, and a handle pinned to that rung. */
+async function withEds(options, fn) {
+  await withBus(async (address) => {
+    const eds = await fakeEds(address, options);
+    await asLinux(async () => {
+      const cal = await desktopCalendar({ backend: 'eds' });
+      try {
+        await fn(cal, eds);
+      } finally {
+        await cal?.close();
+      }
+    });
+    eds.stop();
+  });
+}
+
+describe('the EDS rung', { ...needsBroker, concurrency: 1 }, () => {
+  test('it is found on the bus, and lists what is a calendar', async () => {
+    await withEds({}, async (cal) => {
+      assert.equal(cal.backend, 'eds');
+      const list = await cal.listCalendars();
+      assert.deepEqual(
+        list.map((c) => c.name).sort(),
+        ['Personal', 'Work'],
+        'the address book is not a calendar',
+      );
+      const work = list.find((c) => c.uid === 'work');
+      assert.equal(work.color, '#e01b24');
+      assert.equal(work.backend, 'caldav');
+      assert.equal(work.readOnly, true, 'no Writable interface');
+      assert.equal(list.find((c) => c.uid === 'personal').readOnly, false);
+    });
+  });
+
+  test('it reads events through the bus name the factory gave it', async () => {
+    await withEds({ objects: { personal: [ICS_ONE] } }, async (cal, eds) => {
+      const { events, errors } = await cal.eventsBetween(...UTC_AUGUST);
+      assert.deepEqual(errors, []);
+      assert.equal(events.length, 1);
+      assert.equal(events[0].summary, 'Standup');
+      assert.equal(events[0].location, 'Kitchen');
+      assert.equal(events[0].calendar.color, '#3584e4');
+      // the calendar was opened before it was queried, as EDS requires
+      const members = eds.calls.map((c) => c[0]);
+      assert.ok(members.indexOf('Open') < members.indexOf('GetObjectList'));
+    });
+  });
+
+  test('a recurring event is expanded client-side by ical.js', async () => {
+    await withEds({ objects: { personal: [ICS_WEEKLY] } }, async (cal) => {
+      const { events } = await cal.eventsBetween(...UTC_AUGUST);
+      // COUNT=4 from 3 August, weekly: the 3rd, 10th, 17th and 24th
+      assert.equal(events.length, 4, 'the RRULE was expanded');
+      assert.ok(events.every((e) => e.recurring));
+      assert.deepEqual(
+        events.map((e) => e.start.toISOString().slice(0, 10)),
+        ['2026-08-03', '2026-08-10', '2026-08-17', '2026-08-24'],
+      );
+
+      const narrow = await cal.eventsBetween(
+        new Date(Date.UTC(2026, 7, 9)),
+        new Date(Date.UTC(2026, 7, 18)),
+      );
+      assert.deepEqual(
+        narrow.events.map((e) => e.start.toISOString().slice(0, 10)),
+        ['2026-08-10', '2026-08-17'],
+        'occurrences outside the window are not returned',
+      );
+    });
+  });
+
+  test('one broken backend does not sink the others', async () => {
+    // the failure this is written against: an offline CalDAV server blanking
+    // a whole month of the user's own local calendar
+    await withEds(
+      { objects: { personal: [ICS_ONE] }, broken: ['work'] },
+      async (cal) => {
+        const { events, errors } = await cal.eventsBetween(...UTC_AUGUST);
+        assert.equal(events.length, 1, 'the working calendar still loaded');
+        assert.equal(errors.length, 1);
+        assert.equal(errors[0].calendar.uid, 'work');
+        assert.match(errors[0].message, /cannot open work/);
+      },
+    );
+  });
+
+  test('watch does not report the contents the range already had', async () => {
+    await withEds(
+      { objects: { personal: [ICS_ONE], work: [ICS_WEEKLY] } },
+      async (cal, eds) => {
+        const changes = [];
+        await cal.watch(...UTC_AUGUST, (c) => changes.push(c));
+
+        // The replay, if there were one, is already on the wire; a change
+        // made after it is what proves the watch is live at all.
+        eds.views.get('personal').emit('ObjectsModified', [ICS_ONE]);
+        await until(() => changes.length > 0, 'a change to arrive');
+
+        assert.equal(changes.length, 1, 'Start() replayed nothing at us');
+        assert.equal(changes[0].kind, 'ObjectsModified');
+        assert.equal(changes[0].count, 1);
+        assert.equal(changes[0].calendar.uid, 'personal');
+        // and this is why: the views were told to notify changes only
+        assert.equal(eds.views.get('personal').flags, 0);
+        assert.equal(eds.views.get('work').flags, 0);
+      },
+    );
+  });
+
+  test('a backend that refuses the flags still replays into silence', async () => {
+    await withEds(
+      { objects: { personal: [ICS_ONE] }, refusesFlags: ['personal'] },
+      async (cal, eds) => {
+        const changes = [];
+        await cal.watch(...UTC_AUGUST, (c) => changes.push(c));
+        const view = eds.views.get('personal');
+        assert.equal(view.flags, NOTIFY_INITIAL, 'it replayed');
+
+        // `Complete` closed the delivery, so this one gets through — and its
+        // arrival is what says the replay before it did not.
+        view.emit('ObjectsAdded', [ICS_ONE]);
+        await until(() => changes.length > 0, 'a change after the replay');
+        assert.equal(changes.length, 1);
+        assert.equal(changes[0].kind, 'ObjectsAdded');
+      },
+    );
+  });
+
+  test('the stop function stops and disposes the views it started', async () => {
+    // what the hook's subscription effect runs on cleanup — a month the user
+    // paged away from must not leave a live view behind
+    await withEds({ objects: { personal: [ICS_ONE] } }, async (cal, eds) => {
+      const stop = await cal.watch(...UTC_AUGUST, () => {});
+      await stop();
+      assert.ok(eds.views.get('personal').stopped, 'the view was stopped');
+      assert.ok(eds.views.get('personal').disposed, 'and disposed');
+    });
+  });
+
+  test('there is no grant to ask for, so nothing is asked', async () => {
+    await withEds({}, async (cal) => {
+      assert.equal(await cal.access(), 'granted');
+      assert.equal(await cal.requestAccess(), 'granted');
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The ladder
+// ---------------------------------------------------------------------------
+
+describe('the ladder', () => {
+  test('the bridge outranks the child, and a pinned rung does not fall through', async () => {
+    const app = appOver(fakeNative());
+    let spawned = 0;
+    _setCalendarSpawnForTests(() => {
+      spawned++;
+      return fakeOsascript();
+    });
+
+    const cal = await open({ app });
+    assert.equal(cal.backend, 'cocoa');
+    assert.equal(spawned, 0, 'the child is never started when the bridge is');
+
+    const pinned = await open({ app, backend: 'osascript' });
+    assert.equal(pinned.backend, 'osascript', 'and can still be asked for');
+  });
+
+  test('a machine with nothing answers null, and only asks to throw', async () => {
+    await asLinux(async () => {
+      // no bridge in the tree, not a Mac, and no EDS on the bus
+      const saved = process.env.DBUS_SESSION_BUS_ADDRESS;
+      process.env.DBUS_SESSION_BUS_ADDRESS = 'unix:path=/nonexistent/no-bus';
+      try {
+        assert.equal(await calendarBackend(), null);
+        assert.equal(await desktopCalendar(), null);
+        await assert.rejects(
+          () => desktopCalendar({ required: true }),
+          (err) => {
+            assert.ok(err instanceof NoCalendarServiceError);
+            assert.match(err.message, /calendarBackend/);
+            return true;
+          },
+        );
+      } finally {
+        if (saved === undefined) delete process.env.DBUS_SESSION_BUS_ADDRESS;
+        else process.env.DBUS_SESSION_BUS_ADDRESS = saved;
+      }
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useDesktopCalendarEvents
+// ---------------------------------------------------------------------------
+
+describe('useDesktopCalendarEvents', () => {
+  function probe(app, options) {
+    let seen = null;
+    function Probe() {
+      seen = useDesktopCalendarEvents(options);
+      return h('box');
+    }
+    return { Probe, read: () => seen };
+  }
+
+  async function mount(app, options) {
+    const { Probe, read } = probe(app, options);
+    const root = await createRoot({ app });
+    roots.push(root);
+    root.render(h('window', { width: 200, height: 200 }, h(Probe)));
+    await tick();
+    return read;
+  }
+
+  test('it settles on ready, grouped the way a grid asks', async () => {
+    const native = fakeNative({
+      events: [
+        bridgeEvent(),
+        bridgeEvent({
+          id: 'E2',
+          title: 'Retro',
+          start: new Date(2026, 7, 7, 15).getTime(),
+          end: new Date(2026, 7, 7, 16).getTime(),
+        }),
+      ],
+    });
+    const read = await mount(appOver(native), {
+      from: AUGUST[0],
+      to: AUGUST[1],
+    });
+
+    await until(() => read().status === 'ready', 'the first read');
+    assert.equal(read().backend, 'cocoa');
+    assert.equal(read().events.length, 2);
+    assert.equal(read().calendars.length, 2);
+    assert.deepEqual([...read().byDay.keys()], ['2026-08-07']);
+    assert.deepEqual(
+      read()
+        .byDay.get('2026-08-07')
+        .map((e) => e.summary),
+      ['Standup', 'Retro'],
+      'in time order, which is what a day cell renders',
+    );
+    for (const key of read().byDay.keys()) {
+      assert.match(key, /^\d{4}-\d{2}-\d{2}$/);
+    }
+  });
+
+  test("the user's refusal and the machine's silence are different words", async () => {
+    const denied = await mount(appOver(fakeNative({ status: 'denied' })), {
+      from: AUGUST[0],
+      to: AUGUST[1],
+    });
+    await until(() => denied().status === 'denied', 'a refusal');
+    assert.ok(denied().error instanceof CalendarAccessError);
+    assert.equal(denied().backend, 'cocoa', 'there is a rung; it said no');
+
+    await asLinux(async () => {
+      const saved = process.env.DBUS_SESSION_BUS_ADDRESS;
+      process.env.DBUS_SESSION_BUS_ADDRESS = 'unix:path=/nonexistent/no-bus';
+      try {
+        const none = await mount(appOver(fakeNative({ hasCalendars: false })), {
+          from: AUGUST[0],
+          to: AUGUST[1],
+        });
+        await until(() => none().status === 'unavailable', 'no rung at all');
+        assert.equal(none().backend, null);
+        assert.deepEqual(none().events, []);
+      } finally {
+        if (saved === undefined) delete process.env.DBUS_SESSION_BUS_ADDRESS;
+        else process.env.DBUS_SESSION_BUS_ADDRESS = saved;
+      }
+    });
+  });
+
+  test('enabled: false asks nothing at all — not even the grant', async () => {
+    const native = fakeNative({ status: 'notDetermined' });
+    const read = await mount(appOver(native), {
+      from: AUGUST[0],
+      to: AUGUST[1],
+      enabled: false,
+    });
+    await tick();
+    await tick();
+    assert.equal(read().status, 'idle');
+    assert.equal(native.of('requestAuthorization').length, 0);
+    assert.equal(native.of('calendars').length, 0);
+  });
+
+  test('a change re-queries, and unmounting stops the watch', async () => {
+    let round = 0;
+    const native = fakeNative({
+      events: () => (round++ === 0 ? [bridgeEvent()] : []),
+    });
+    const app = appOver(native);
+    const read = await mount(app, {
+      from: AUGUST[0],
+      to: AUGUST[1],
+      watch: true,
+    });
+    await until(() => read().status === 'ready', 'the first read');
+    assert.equal(read().events.length, 1);
+
+    app._route({ type: 'calendar-store-changed' });
+    await until(() => read().events.length === 0, 'the re-query');
+
+    const root = roots.pop();
+    await root.unmount();
+    // nothing left listening: the app's capability has no watchers, so a
+    // change after the unmount reaches nobody and cannot re-render
+    assert.equal(app.calendars._watchers.size, 0);
+  });
+
+  test('the two dates are read by value, so a fresh Date is not a re-query', async () => {
+    const native = fakeNative({ events: [] });
+    const app = appOver(native);
+    let seen = null;
+    let renders = 0;
+    function Probe() {
+      renders++;
+      // exactly the mistake the hook is written to survive
+      seen = useDesktopCalendarEvents({
+        from: new Date(2026, 7, 1),
+        to: new Date(2026, 8, 1),
+      });
+      return h('box');
+    }
+    const root = await createRoot({ app });
+    roots.push(root);
+    root.render(h('window', { width: 200, height: 200 }, h(Probe)));
+    await until(() => seen?.status === 'ready', 'the first read');
+
+    const before = native.of('eventsBetween').length;
+    root.render(h('window', { width: 200, height: 200 }, h(Probe)));
+    await tick();
+    await tick();
+    assert.ok(renders > 1, 'it did render again');
+    assert.equal(
+      native.of('eventsBetween').length,
+      before,
+      'and did not query again',
+    );
+  });
+});

--- a/test/desktop-calendar.test.js
+++ b/test/desktop-calendar.test.js
@@ -43,8 +43,10 @@ import { PERMISSION_KINDS, privacySettingsUrl } from '../src/permissions.js';
 import { setCompositingForTests } from '../src/compositing.js';
 import { setScaleForTests } from '../src/scale.js';
 import { setScreensForTests } from '../src/screens.js';
+import { _resetBusState } from '../src/bus.js';
+import { _resetServiceCache } from '../src/portal.js';
 import { fakeEds, NOTIFY_INITIAL } from './helpers/fake-eds.js';
-import { transportAvailable, withBus } from './helpers/with-bus.js';
+import { transportAvailable, withBus, withNoBus } from './helpers/with-bus.js';
 
 const h = React.createElement;
 const tick = () => new Promise((resolve) => setTimeout(resolve, 2));
@@ -805,11 +807,15 @@ describe('the osascript rung', () => {
       setImmediate(() => child.kill());
       return child;
     });
-    assert.equal(await desktopCalendar({}), null);
-    await assert.rejects(
-      () => desktopCalendar({ required: true }),
-      NoCalendarServiceError,
-    );
+    // The fall-through reaches the EDS rung, which dials the session bus —
+    // so this runs inside the helper that puts that back afterwards.
+    await withNoBus(async () => {
+      assert.equal(await desktopCalendar({}), null);
+      await assert.rejects(
+        () => desktopCalendar({ required: true }),
+        NoCalendarServiceError,
+      );
+    });
   });
 });
 
@@ -851,6 +857,12 @@ const UTC_AUGUST = [
 /** A broker, a fake EDS on it, and a handle pinned to that rung. */
 async function withEds(options, fn) {
   await withBus(async (address) => {
+    // The shared connection is process-wide and `withBus` points the
+    // environment at the broker without touching it, so anything dialled
+    // earlier is still what `sessionBus()` would hand back. Dropping it here
+    // is what makes these tests independent of what ran before them.
+    _resetBusState();
+    _resetServiceCache();
     const eds = await fakeEds(address, options);
     await asLinux(async () => {
       const cal = await desktopCalendar({ backend: 'eds' });
@@ -1017,25 +1029,23 @@ describe('the ladder', () => {
   });
 
   test('a machine with nothing answers null, and only asks to throw', async () => {
-    await asLinux(async () => {
+    // `withNoBus` rather than a hand-rolled env swap: dialling a bus that is
+    // not there leaves the shared connection in a state the *next* test
+    // inherits, and putting the environment back does not undo that. It is
+    // what the helper's teardown exists for, and CI is where a suite that
+    // forgot it fails (the EDS rung, first test, nothing on the bus).
+    await withNoBus(async () => {
       // no bridge in the tree, not a Mac, and no EDS on the bus
-      const saved = process.env.DBUS_SESSION_BUS_ADDRESS;
-      process.env.DBUS_SESSION_BUS_ADDRESS = 'unix:path=/nonexistent/no-bus';
-      try {
-        assert.equal(await calendarBackend(), null);
-        assert.equal(await desktopCalendar(), null);
-        await assert.rejects(
-          () => desktopCalendar({ required: true }),
-          (err) => {
-            assert.ok(err instanceof NoCalendarServiceError);
-            assert.match(err.message, /calendarBackend/);
-            return true;
-          },
-        );
-      } finally {
-        if (saved === undefined) delete process.env.DBUS_SESSION_BUS_ADDRESS;
-        else process.env.DBUS_SESSION_BUS_ADDRESS = saved;
-      }
+      assert.equal(await calendarBackend(), null);
+      assert.equal(await desktopCalendar(), null);
+      await assert.rejects(
+        () => desktopCalendar({ required: true }),
+        (err) => {
+          assert.ok(err instanceof NoCalendarServiceError);
+          assert.match(err.message, /calendarBackend/);
+          return true;
+        },
+      );
     });
   });
 });
@@ -1106,21 +1116,14 @@ describe('useDesktopCalendarEvents', () => {
     assert.ok(denied().error instanceof CalendarAccessError);
     assert.equal(denied().backend, 'cocoa', 'there is a rung; it said no');
 
-    await asLinux(async () => {
-      const saved = process.env.DBUS_SESSION_BUS_ADDRESS;
-      process.env.DBUS_SESSION_BUS_ADDRESS = 'unix:path=/nonexistent/no-bus';
-      try {
-        const none = await mount(appOver(fakeNative({ hasCalendars: false })), {
-          from: AUGUST[0],
-          to: AUGUST[1],
-        });
-        await until(() => none().status === 'unavailable', 'no rung at all');
-        assert.equal(none().backend, null);
-        assert.deepEqual(none().events, []);
-      } finally {
-        if (saved === undefined) delete process.env.DBUS_SESSION_BUS_ADDRESS;
-        else process.env.DBUS_SESSION_BUS_ADDRESS = saved;
-      }
+    await withNoBus(async () => {
+      const none = await mount(appOver(fakeNative({ hasCalendars: false })), {
+        from: AUGUST[0],
+        to: AUGUST[1],
+      });
+      await until(() => none().status === 'unavailable', 'no rung at all');
+      assert.equal(none().backend, null);
+      assert.deepEqual(none().events, []);
     });
   });
 

--- a/test/helpers/fake-eds.js
+++ b/test/helpers/fake-eds.js
@@ -1,0 +1,269 @@
+// Evolution Data Server on the test bus.
+//
+// `withBus()` gives a broker; this owns the two names EDS owns on it —
+// `Sources5` (the registry) and `Calendar8` (the factory) — and answers the
+// calls src/desktopcalendar.js's EDS rung makes, the way EDS answers them:
+// the registry through `org.freedesktop.DBus.ObjectManager`, a calendar
+// through a factory that hands back an object path **and a different bus
+// name**, and a view whose `Start()` replays what the query already matched.
+//
+// That last one is the reason this is a real bus rather than a stub object.
+// The replay arrives as a signal after `Start()` has returned, so a fake
+// that answered synchronously would pass whether or not the rung subscribed
+// first and whether or not it asked for `E_CAL_CLIENT_VIEW_FLAGS_NONE` — and
+// the loop that flag prevents (re-query → new view → replay → re-query) is
+// the bug the rung is shaped around.
+//
+// **What the broker cannot do**, from its own docs: no security policy, no
+// service activation, no fd passing. Activation is the one that matters
+// here — EDS is D-Bus-activatable in real life, so `hasService()`'s
+// `ListActivatableNames` branch is exercised against a real daemon or not at
+// all. Do not read a green suite as covering it.
+
+const SOURCES_NAME = 'org.gnome.evolution.dataserver.Sources5';
+const SOURCES_PATH = '/org/gnome/evolution/dataserver/SourceManager';
+const SOURCE_IFACE = 'org.gnome.evolution.dataserver.Source';
+const WRITABLE_IFACE = 'org.gnome.evolution.dataserver.Source.Writable';
+const FACTORY_NAME = 'org.gnome.evolution.dataserver.Calendar8';
+const FACTORY_PATH = '/org/gnome/evolution/dataserver/CalendarFactory';
+const FACTORY_IFACE = 'org.gnome.evolution.dataserver.CalendarFactory';
+const CAL_IFACE = 'org.gnome.evolution.dataserver.Calendar';
+const VIEW_IFACE = 'org.gnome.evolution.dataserver.CalendarView';
+
+/** The name the factory hands back — a *different* one from its own, as the
+ *  real factory does (each backend runs in its own subprocess). A rung that
+ *  assumed the factory's name would fail here, which is the point. */
+const BACKEND_NAME =
+  'org.gnome.evolution.dataserver.Subprocess.Backend.Calendarx1';
+
+/** `E_CAL_CLIENT_VIEW_FLAGS_NOTIFY_INITIAL` — what EDS creates a view with,
+ *  and why `Start()` announces the range's current contents. */
+export const NOTIFY_INITIAL = 1;
+
+/** One source's keyfile, the ini blob a Source carries its whole config in. */
+export function keyfile({
+  name,
+  color,
+  backend = 'local',
+  enabled = true,
+  kind = 'Calendar',
+  account,
+}) {
+  return [
+    '[Data Source]',
+    `DisplayName=${name}`,
+    `Enabled=${enabled}`,
+    ...(account ? ['', '[GNOME Online Accounts]', `Account=${account}`] : []),
+    '',
+    `[${kind}]`,
+    `BackendName=${backend}`,
+    ...(color ? [`Color=${color}`] : []),
+  ].join('\n');
+}
+
+const DEFAULT_SOURCES = [
+  { uid: 'personal', name: 'Personal', color: '#3584e4', writable: true },
+  { uid: 'work', name: 'Work', color: '#e01b24', backend: 'caldav' },
+  // an address book: no [Calendar] section, so not a calendar at all
+  { uid: 'contacts', name: 'Contacts', kind: 'Address Book' },
+];
+
+async function connect(dbus, address) {
+  const bus = dbus.createClient({ busAddress: address });
+  await new Promise((resolve, reject) => {
+    bus.connection.once('connect', resolve);
+    bus.connection.once('error', reject);
+  });
+  await bus.listNames();
+  return bus;
+}
+
+/**
+ * Start a fake Evolution Data Server against `address`.
+ *
+ * ```js
+ * const eds = await fakeEds(address, { objects: { personal: [ICS_ONE] } });
+ * eds.views.get('personal').emit('ObjectsModified', [ICS_ONE]);
+ * ```
+ *
+ * - `sources` — what the registry reports. Defaults to two calendars and an
+ *   address book, so "the address book is not a calendar" is always tested.
+ * - `objects` — `uid -> [ics]`, what that calendar's `GetObjectList` answers
+ *   and what its view replays.
+ * - `broken` — uids whose `OpenCalendar` fails, standing in for an offline
+ *   backend.
+ * - `refusesFlags` — uids whose view refuses `SetFlags`, standing in for a
+ *   backend that replays its contents whatever it is asked.
+ *
+ * `views` fills in as views are handed out, keyed by calendar uid, so a test
+ * can make something change after the initial delivery is over. `calls`
+ * records every method the rung invoked.
+ */
+export async function fakeEds(address, options = {}) {
+  const {
+    sources = DEFAULT_SOURCES,
+    objects = {},
+    broken = [],
+    refusesFlags = [],
+  } = options;
+  const dbus = (await import('dbus-native')).default;
+  const bus = await connect(dbus, address);
+
+  const eds = {
+    bus,
+    calls: [],
+    views: new Map(),
+    stop: () => bus.connection.end(),
+  };
+  const record = (member, ...args) => eds.calls.push([member, ...args]);
+
+  await bus.requestName(SOURCES_NAME, 0);
+  await bus.requestName(FACTORY_NAME, 0);
+  await bus.requestName(BACKEND_NAME, 0);
+
+  // --- the registry: one exported object per source, under a manager ------
+  sources.forEach((source, index) => {
+    const path = `${SOURCES_PATH}/Sources/${index + 1}`;
+    bus.exportInterface({ UID: source.uid, Data: keyfile(source) }, path, {
+      name: SOURCE_IFACE,
+      methods: {},
+      signals: {},
+      properties: { UID: 's', Data: 's' },
+    });
+    // The marker interface is the whole of "the user may write to this one".
+    if (source.writable) {
+      bus.exportInterface({}, path, {
+        name: WRITABLE_IFACE,
+        methods: {},
+        signals: {},
+        properties: {},
+      });
+    }
+  });
+  bus.exportObjectManager(SOURCES_PATH);
+
+  // --- one calendar object and one view per source ------------------------
+  const exportCalendar = (uid) => {
+    const path = `/org/gnome/evolution/dataserver/Calendar/${uid}`;
+    const viewPath = `${path}/view`;
+
+    bus.exportInterface(
+      {
+        Open: () => record('Open', uid),
+        GetObjectList: (query) => {
+          record('GetObjectList', uid, query);
+          return objects[uid] ?? [];
+        },
+        GetTimezone: (tzid) => {
+          record('GetTimezone', uid, tzid);
+          // No definition here: ical.js falls back to floating time, which
+          // is the branch worth having under test.
+          throw new Error(`no definition for ${tzid}`);
+        },
+        GetView: (query) => {
+          record('GetView', uid, query);
+          return viewPath;
+        },
+      },
+      path,
+      {
+        name: CAL_IFACE,
+        methods: {
+          Open: ['', '', [], []],
+          GetObjectList: ['s', 'as', ['query'], ['objects']],
+          GetTimezone: ['s', 's', ['tzid'], ['object']],
+          GetView: ['s', 'o', ['query'], ['view']],
+        },
+        signals: {},
+        properties: {},
+      },
+    );
+
+    const view = {
+      flags: NOTIFY_INITIAL,
+      started: false,
+      stopped: false,
+      disposed: false,
+      emit: (signal, objs) =>
+        bus.sendSignal(viewPath, VIEW_IFACE, signal, 'as', [objs]),
+    };
+    eds.views.set(uid, view);
+
+    bus.exportInterface(
+      {
+        SetFlags: (flags) => {
+          record('SetFlags', uid, flags);
+          if (refusesFlags.includes(uid)) throw new Error('SetFlags: no');
+          view.flags = flags;
+        },
+        Start: () => {
+          record('Start', uid);
+          view.started = true;
+          // EDS replays what the query already matches, unless the flags
+          // said not to — and `Complete` closes the delivery either way.
+          const initial = objects[uid] ?? [];
+          if (view.flags & NOTIFY_INITIAL && initial.length) {
+            view.emit('ObjectsAdded', initial);
+          }
+          bus.sendSignal(viewPath, VIEW_IFACE, 'Complete', 'us', [0, '']);
+        },
+        Stop: () => {
+          record('Stop', uid);
+          view.stopped = true;
+        },
+        Dispose: () => {
+          record('Dispose', uid);
+          view.disposed = true;
+        },
+      },
+      viewPath,
+      {
+        name: VIEW_IFACE,
+        methods: {
+          SetFlags: ['u', '', ['flags'], []],
+          Start: ['', '', [], []],
+          Stop: ['', '', [], []],
+          Dispose: ['', '', [], []],
+        },
+        signals: {
+          ObjectsAdded: ['as', 'objects'],
+          ObjectsModified: ['as', 'objects'],
+          ObjectsRemoved: ['as', 'uids'],
+          Complete: ['us', 'status', 'message'],
+        },
+        properties: {},
+      },
+    );
+    return path;
+  };
+
+  for (const source of sources) {
+    if (source.kind && source.kind !== 'Calendar') continue;
+    exportCalendar(source.uid);
+  }
+
+  // --- the factory --------------------------------------------------------
+  bus.exportInterface(
+    {
+      OpenCalendar: (uid) => {
+        record('OpenCalendar', uid);
+        if (broken.includes(uid)) throw new Error(`cannot open ${uid}`);
+        return [
+          `/org/gnome/evolution/dataserver/Calendar/${uid}`,
+          BACKEND_NAME,
+        ];
+      },
+    },
+    FACTORY_PATH,
+    {
+      name: FACTORY_IFACE,
+      methods: {
+        OpenCalendar: ['s', 'os', ['uid'], ['path', 'bus_name']],
+      },
+      signals: {},
+      properties: {},
+    },
+  );
+
+  return eds;
+}

--- a/test/permissions.test.js
+++ b/test/permissions.test.js
@@ -101,18 +101,21 @@ afterEach(async () => {
 });
 
 describe('the vocabulary', () => {
-  test('Apple’s four words become the ladder’s, and anything else is unknown', () => {
+  test('Apple’s words become the ladder’s, and anything else is unknown', () => {
     assert.equal(statusFromBridge('authorized'), 'granted');
     assert.equal(statusFromBridge('denied'), 'denied');
     assert.equal(statusFromBridge('restricted'), 'restricted');
     assert.equal(statusFromBridge('notDetermined'), 'prompt');
+    // macOS 14's partial EventKit grant, kept as its own word: a grant to a
+    // writer and a refusal to a reader (docs/desktop-calendar.md)
+    assert.equal(statusFromBridge('writeOnly'), 'write-only');
     assert.equal(statusFromBridge('surprise'), 'unknown');
   });
 
   test('a kind that is not one is a TypeError, not a machine answer', async () => {
     await assert.rejects(() => permissionStatus('bluetooth'), TypeError);
     await assert.rejects(() => requestPermission('bluetooth'), TypeError);
-    assert.equal(PERMISSION_KINDS.length, 7);
+    assert.equal(PERMISSION_KINDS.length, 9);
   });
 
   test('the Settings deep link, per pane and for the Privacy pane itself', () => {

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -22,6 +22,13 @@ import type {
   NotificationBackend,
   NotificationCloseReason,
   NotificationHandle,
+  CalendarBackend,
+  CalendarChange,
+  DesktopCalendar,
+  DesktopCalendarInfo,
+  DesktopCalendarStatus,
+  DesktopEvent,
+  EventsResult,
   BusHandle,
   BusKind,
   BusRef,
@@ -57,6 +64,13 @@ import {
   notificationBackend,
   notify,
   useNotifier,
+  CalendarAccessError,
+  NoCalendarServiceError,
+  byDay,
+  calendarBackend,
+  dayKey,
+  desktopCalendar,
+  useDesktopCalendarEvents,
   Checkbox,
   closeBus,
   Icon,
@@ -1331,6 +1345,11 @@ function _DeepLinks() {
     const mic = usePermission('microphone');
     mic.request().then((s: PermissionStatus) => s);
     void mic.available;
+    const calendarGrant = usePermission('calendars', { access: 'write-only' });
+    const granted: PermissionStatus = calendarGrant.status;
+    void granted;
+    // @ts-expect-error — the two levels are the only ones
+    usePermission('calendars', { access: 'read-only' });
     void opened;
     void rung;
     void status;
@@ -1348,6 +1367,43 @@ function _DeepLinks() {
     await banner.update({ body: 'opened' });
     await banner.close();
     const notifRung: NotificationBackend | null = await notificationBackend();
+
+    // --- the desktop's calendar ---------------------------------------
+    const rungHere: CalendarBackend | null = await calendarBackend();
+    void rungHere;
+    const desktop: DesktopCalendar | null = await desktopCalendar();
+    if (desktop) {
+      const found: DesktopCalendarInfo[] = await desktop.listCalendars();
+      const result: EventsResult = await desktop.eventsBetween(
+        new Date(),
+        new Date(),
+        { calendars: found },
+      );
+      const days: Map<string, DesktopEvent[]> = byDay(result.events);
+      void days.get(dayKey(new Date()));
+      const stop = await desktop.watch(
+        new Date(),
+        new Date(),
+        (change: CalendarChange) => void change.kind,
+      );
+      await stop();
+      const grant: PermissionStatus = await desktop.access();
+      void grant;
+      await desktop.close();
+    }
+    const week = useDesktopCalendarEvents({
+      from: new Date(),
+      to: new Date(),
+      watch: true,
+    });
+    const state: DesktopCalendarStatus = week.status;
+    void state;
+    void week.byDay.get('2026-09-08');
+    void week.openSettings();
+    void CalendarAccessError;
+    void NoCalendarServiceError;
+    // @ts-expect-error — a range is two dates, and both are required
+    useDesktopCalendarEvents({ from: new Date() });
     const notifier = useNotifier({ urgency: 'low' });
     void notifier.available;
     void notifier.backend;

--- a/website/scripts/sync-docs.mjs
+++ b/website/scripts/sync-docs.mjs
@@ -194,6 +194,7 @@ const ORDER = [
   'eyedropper.md',
   'permissions.md',
   'notifications.md',
+  'desktop-calendar.md',
   'appearance.md',
   'system.md',
   'remote.md',


### PR DESCRIPTION
Closes #504 — its first two milestones. Writes (#504's third) and the
`CalendarSource` seam (its fourth) are not here.

The user's real events — iCloud, Google, Exchange, CalDAV, a subscribed feed,
the local one — with no credential and no OAuth flow, because the desktop
already did that. `useDesktopCalendarEvents()` and `desktopCalendar()`, over
`docs/filedialog.md`'s ladder, chosen in order and never by naming a backend:

| | | |
| --- | --- | --- |
| 1 | **EventKit through the bridge** | the cocoa backend, where the app the tree renders through carries `calendars` (`@windowkit/appkit` >= 0.8) |
| 2 | **EventKit through `osascript`** | a Mac with no bridge — every XQuartz install — as a long-lived `osascript -l JavaScript` child holding the same store |
| 3 | **EDS over the session bus** | the store every GNOME calendar UI reads, moved here from `@react-x11/components` |
| 4 | **nothing** | `null`, and the hook says `'unavailable'` — an ordinary answer about a machine |

## The same app, on two rungs, against this machine's calendars

`examples/calendar.jsx` (new), rendered by `scripts/cocoa-drive.mjs` and by
`scripts/capture.js` at e697cd0 — the footer is the interesting line:

- **the cocoa backend** — the week of 28 September, with this machine's one
  real event that week (an all-day entry from a subscribed calendar) under
  Sunday the 4th, drawn in that calendar's own colour. Footer:
  `cocoa — 4 calendars`.
- **the X11 backend, under XQuartz** — the same week, the same event, the
  same day, drawn from the same store through a different transport. Footer:
  `osascript — 4 calendars`.

Same event, same day, same shape, two rungs. (Images to follow — the
screenshot uploader's session needs refreshing.)

## What the rungs had to agree on

- **`end` is exclusive.** EventKit reports an all-day event ending at
  23:59:59 of its last day and iCalendar ends it at the next midnight; an app
  cannot branch on which store it is reading, so the macOS rungs normalise
  and `byDay` may assume it.
- **A change is "something moved", not a patch.** EDS names the objects,
  EventKit's notification names nothing at all, and neither can say what a
  recurrence master edited months away did to the range on screen. So
  `CalendarChange` gains `kind: 'changed'` with a null calendar and no count.
- **"Not allowed to look" is not "no events".** Without the grant EventKit
  answers an empty list, which is a lie an app would draw. The first read
  asks; a refusal is a typed `CalendarAccessError`; `'denied'` (the user's
  answer) stays apart from `'unavailable'` (the machine's).

## What measuring the prompt found

The last acceptance criterion asked for the TCC prompt to be raised once for
real rather than asserted from the rule. It was, on macOS 15.2, and it
changed two things:

- **The request's completion never arrives on the `osascript` rung.**
  `requestFullAccessToEventsWithCompletion:` from an `osascript` process is
  never called back — not when refused, and not even when the grant is
  already held; retaining the block does not help. The rung waited for it, so
  its first read hung forever. It now answers from the status, polled, with a
  30s deadline for the case TCC declines to ask at all (a platform binary; a
  responsible app whose hardened runtime lacks the entitlement). That
  deadline's `'prompt'` is the machine's silence, not a refusal, so the hook
  reports `'unavailable'` and nothing remembers it.
- **The attribution is three processes, not one.** `tccd` records
  `responsible` (the app that owns the tree — a terminal, an IDE),
  `accessing` (`osascript`) and `requesting` (`calaccessd`), and keys the
  decision on the responsible one. So the second rung's grant is shared with
  everything that terminal runs — not with every `osascript` on the Mac,
  which is what `docs/desktop-calendar.md` had asserted before it was
  measured.

Both are in `docs/desktop-calendar.md`, with the four things measured with
the grant still undecided (a status read never prompts; creating the store
never prompts; an ungranted read answers an empty list rather than an error;
the child starts in ~130 ms).

## What moved, and what it cost

`src/desktop-calendar/{eds,ical,index}.ts` from `@react-x11/components` moves
whole, with its three paid-for decisions intact — the bus is not ours, watch
reports changes rather than contents, re-query rather than patch. Its 477-line
test is replaced rather than ported: the EDS rung now runs against an
**in-process broker** (`test/helpers/fake-eds.js`, a real `ObjectManager`, a
factory that hands back a different bus name, a view whose `Start()` replays
over the wire) instead of a stub object, so the view flags and the replay
ordering are exercised for real rather than assumed. The sibling package's
subpath, its page and its optional dependency are deleted there, in its own
PR, with the floor bump to whatever release carries this.

`ical.js` becomes a regular dependency behind one lazy `import()` with a
static specifier: 268 KB of a 1.2 MB package, no dependencies, no native
code, MPL-2.0. The EDS rung needs a recurrence expander and neither macOS
rung does, so it stays off the startup path — but a bundler or the
single-executable build can follow a static specifier where it cannot follow
the run-time-built one an optional dependency needs.

`calendars` and `reminders` join `PermissionKind`, and macOS 14's partial
grant crosses as its own word, `'write-only'` — a grant to a writer and a
refusal to a reader, and only the caller knows which it is.

## Tests

`test/desktop-calendar.test.js` (41) and `test/calendar-example.test.js` (3):
the shape every rung agrees on, the cocoa rung over a recording fake bridge,
the `osascript` rung over a fake child speaking the same JSON lines (so it
runs on CI), the EDS rung over the broker, the ladder, and the hook. Five
mutations were checked to fail: a no-op `withExclusiveEnd`, a view left
replaying, no dedupe across a chunk seam, a refusal not raised, and the grant
asked for on every read.

Full suite green apart from the six `appearance.test.js` failures that fail
on `master` on this Mac too.

