### PR TITLE
fix(components): a native control keeps AppKit's height in a taller box

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -408,6 +408,17 @@ their own so an override wins by position, and forward any remaining props
 to the host box. `Radio` is the exception: it takes only the props listed
 below, and the group around it carries the layout.
 
+Under a **native bezel** — the Cocoa backend
+([macos.md](macos.md#native-controls)) — `style` sizes the box the control
+_sits in_ rather than the control itself. A `<Button>` or a `<Select>` keeps
+AppKit's own height and is centred in whatever footprint the layout gives it,
+so `style={{ height: 44 }}`, a `height: '100%'` in a taller parent or a
+`flexGrow: 1` leave a 22pt control in a 44pt slot instead of stretching a
+bezel the system draws at one size. The slack around it is not part of the
+control: a press up there does nothing, as it does in AppKit. Drawn controls
+stretch as they always have — their chrome is drawn to the box and their
+label is centred in it, so a stretched drawn control is merely roomy.
+
 ```jsx
 import { Button, Checkbox, RadioGroup, Radio, Switch, ProgressBar } from 'react-x11';
 

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -752,6 +752,15 @@ Wiring, shaped as theme policy rather than per-widget forks:
   native variant renders a bezel-image node sized by the cell's natural
   metrics. Hover/press/focus continue to drive it — pressed bezels are
   re-keyed images, and the press state still lands on the press frame.
+- A native control is **two boxes**: the footprint the caller's `style`
+  sizes, and the control itself — bezel, title and press wash — at AppKit's
+  metrics, centred in it. One box could not be both, because a cell's title
+  is _placed_ against the bezel's bottom edge rather than centred in the
+  box, and a `height`, a `flexGrow` or a parent's align-stretch moved the
+  box without moving the bezel the system draws at one size: the label
+  ended up below the control it names (#510). The role, the handlers, the
+  focus ring and the ref stay on the control, so the slack around it is
+  slack — a press there does nothing, as it does in AppKit.
 - The palette gains a macOS system theme whose tokens read semantic
   `NSColor`s (accent, text, separators) so _drawn_ content — cards,
   tables, custom widgets — sits harmoniously beside native bezels, and

--- a/src/components/Button.js
+++ b/src/components/Button.js
@@ -7,10 +7,12 @@ import { useAppOrNull } from '../appcontext.js';
 import {
   ABS_FILL,
   Bezel,
+  NATIVE_BAND,
   NATIVE_RING,
   TITLE_BASELINE,
   bezelNatural,
   bezelShadow,
+  nativeFootprintStyle,
   nativeTitleStyle,
   pressWash,
   useNativeControls,
@@ -94,64 +96,73 @@ export function Button({
       'box',
       {
         theme,
-        role: 'button',
-        ...props,
-        ...boxProps,
-        style: [
-          controlStyle,
-          {
-            flexDirection: 'row',
-            alignItems: 'center',
-            justifyContent: 'center',
-            gap: small ? 6 : 8,
-            // AppKit's metrics, not the palette's: a native bezel is
-            // designed at its own height, and stretching it is what this
-            // mode exists to avoid. Width still follows the label.
-            height: nat.height,
-            paddingLeft: small ? 10 : 14,
-            paddingRight: small ? 10 : 14,
-            // The natural box is the bezel's footprint, shadow included;
-            // the body is what the title is placed against — and placed,
-            // not centred (`TITLE_BASELINE`). A label centred by its
-            // capitals sat 1pt low beside a native button.
-            paddingTop: shadow.top,
-            paddingBottom: shadow.bottom + TITLE_BASELINE[controlSize],
-            // The keyboard ring is the renderer's, on this box — shaped by
-            // the bezel's corners and hugging it, as AppKit's is
-            // (`NATIVE_RING`), rather than the palette's offset rectangle.
-            borderRadius: small ? 5 : 6,
-            ':focus-visible': {
-              outlineWidth: NATIVE_RING.width,
-              outlineOffset: NATIVE_RING.offset,
-            },
-            color: disabled
-              ? theme.textMuted
-              : primary
-                ? theme.accentText
-                : theme.text,
-          },
-          style,
-        ],
+        // The footprint the caller's style sizes; the button below keeps
+        // AppKit's height inside it, centred (`nativeFootprintStyle`).
+        style: [nativeFootprintStyle(nat), style],
       },
-      h(Bezel, {
-        kind: 'push',
-        controlSize,
-        enabled: !disabled,
-        // the Return-key accent fill is AppKit's own "default button"
-        isDefault: primary && !disabled,
-        style: ABS_FILL,
-      }),
-      labelContent(children ?? label, nativeTitleStyle(controlSize)),
-      // The press answer. Last child on purpose: `:active` marks the
-      // pressed node and its ancestors, and the topmost child is what the
-      // press lands on. No hover tint — AppKit buttons have none.
-      h('box', {
-        style: [
-          ABS_FILL,
-          { borderRadius: small ? 5 : 6 },
-          !disabled && { ':active': { backgroundColor: pressWash(theme) } },
-        ],
-      }),
+      h(
+        'box',
+        {
+          theme,
+          role: 'button',
+          ...props,
+          ...boxProps,
+          style: [
+            controlStyle,
+            NATIVE_BAND,
+            {
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: small ? 6 : 8,
+              // AppKit's metrics, not the palette's: a native bezel is
+              // designed at its own height, and stretching it is what this
+              // mode exists to avoid. Width still follows the label.
+              height: nat.height,
+              paddingLeft: small ? 10 : 14,
+              paddingRight: small ? 10 : 14,
+              // The natural box is the bezel's footprint, shadow included;
+              // the body is what the title is placed against — and placed,
+              // not centred (`TITLE_BASELINE`). A label centred by its
+              // capitals sat 1pt low beside a native button.
+              paddingTop: shadow.top,
+              paddingBottom: shadow.bottom + TITLE_BASELINE[controlSize],
+              // The keyboard ring is the renderer's, on this box — shaped by
+              // the bezel's corners and hugging it, as AppKit's is
+              // (`NATIVE_RING`), rather than the palette's offset rectangle.
+              borderRadius: small ? 5 : 6,
+              ':focus-visible': {
+                outlineWidth: NATIVE_RING.width,
+                outlineOffset: NATIVE_RING.offset,
+              },
+              color: disabled
+                ? theme.textMuted
+                : primary
+                  ? theme.accentText
+                  : theme.text,
+            },
+          ],
+        },
+        h(Bezel, {
+          kind: 'push',
+          controlSize,
+          enabled: !disabled,
+          // the Return-key accent fill is AppKit's own "default button"
+          isDefault: primary && !disabled,
+          style: ABS_FILL,
+        }),
+        labelContent(children ?? label, nativeTitleStyle(controlSize)),
+        // The press answer. Last child on purpose: `:active` marks the
+        // pressed node and its ancestors, and the topmost child is what the
+        // press lands on. No hover tint — AppKit buttons have none.
+        h('box', {
+          style: [
+            ABS_FILL,
+            { borderRadius: small ? 5 : 6 },
+            !disabled && { ':active': { backgroundColor: pressWash(theme) } },
+          ],
+        }),
+      ),
     );
   }
   const background = !solid

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -9,11 +9,13 @@ import { Icon } from './Icon.js';
 import {
   ABS_FILL,
   Bezel,
+  NATIVE_BAND,
   NATIVE_MENU,
   NATIVE_RING,
   TITLE_BASELINE,
   bezelNatural,
   bezelShadow,
+  nativeFootprintStyle,
   nativeTitleStyle,
   pressWash,
   useNativeControls,
@@ -438,7 +440,11 @@ export function Select({
     if (open) scrollRef.current?.scrollIntoView(activeRef.current);
   }, [open, activeIndex]);
 
-  return h(
+  // AppKit's own popup metrics, which the trigger below is laid out at —
+  // and only the trigger: the footprint it sits in is the caller's to size.
+  const nat = nativeControls ? bezelNatural(app, 'popup') : null;
+
+  const trigger = h(
     'box',
     {
       theme,
@@ -465,7 +471,8 @@ export function Select({
               flexDirection: 'row',
               alignItems: 'center',
               gap: 8,
-              height: bezelNatural(app, 'popup').height,
+              ...NATIVE_BAND,
+              height: nat.height,
               paddingLeft: TRIGGER_PAD_LEFT,
               paddingRight: 26,
               // The title sits where NSPopUpButtonCell puts it — on the
@@ -515,7 +522,10 @@ export function Select({
             ':hover': { backgroundColor: theme.surfaceHover },
             ':active': { backgroundColor: theme.surfaceActive },
           },
-        style,
+        // The caller's style, on the trigger where the trigger is the whole
+        // control. Under a native bezel it sizes the footprint below instead
+        // and the trigger keeps AppKit's height (`nativeFootprintStyle`).
+        !nativeControls && style,
       ],
     },
     // `pressed` while the menu is down: AppKit's popup answers being open
@@ -635,4 +645,11 @@ export function Select({
         ),
       ),
   );
+
+  // The bezel and its title are one unit at NSPopUpButton's height; the box
+  // around them is what a `height`, a `flexGrow` or a parent's align-stretch
+  // is free to make taller, with the control centred in it (issue #510).
+  return nativeControls
+    ? h('box', { theme, style: [nativeFootprintStyle(nat), style] }, trigger)
+    : trigger;
 }

--- a/src/components/native.js
+++ b/src/components/native.js
@@ -102,6 +102,47 @@ export function nativeTitleStyle(controlSize = 'regular') {
 }
 
 /**
+ * The **footprint** a native control sits in: the box the caller's style
+ * sizes, with the control — bezel, title and press wash, one unit at
+ * AppKit's own metrics — centred inside it.
+ *
+ * Two boxes rather than one, because the title is *placed* and not centred:
+ * it rides `TITLE_BASELINE` above the bezel body's bottom edge, and that is
+ * only where the cell puts it while the box is exactly `bezelNatural` tall.
+ * The caller's style is applied last and flex stretches a box regardless, so
+ * it was not always: `style={{ height: 44 }}`, a `height: '100%'` in a taller
+ * parent and a bare `flexGrow: 1` each made the box taller, and the two
+ * halves — the bezel absolutely filling it, the title glued to its bottom —
+ * came apart, the label landing below the control it names (issue #510). The
+ * drawn path never had this, because it centres its label: a stretched drawn
+ * control is merely roomy, where a stretched native one was broken.
+ *
+ * So the height a caller can move belongs to a box the control sits in, and
+ * the control keeps AppKit's. The default here is exactly today's box — an
+ * untouched control lays out as it always did, and the explicit height still
+ * resists a row's align-stretch — and the caller's style, applied after it,
+ * moves the footprint alone. The control stretches across it (align-stretch,
+ * the default), so a footprint given a width is a bezel that wide.
+ *
+ * The control, not the footprint, stays the *control*: the role, the
+ * handlers, the focus ring and the ref go on it, so a press in the slack
+ * above a 22pt popup in a 46pt hole does nothing at all — as it does in
+ * AppKit — rather than firing a button with no visible answer to the press.
+ */
+export function nativeFootprintStyle(nat) {
+  return { height: nat.height, justifyContent: 'center' };
+}
+
+/**
+ * The rest of what a native control's own box says about its size: nothing
+ * shrinks it. A squashed bezel is as wrong as a stretched one, and a
+ * footprint shorter than the control is a caller asking for something the
+ * cell's metrics cannot answer — so it overflows, visibly, rather than
+ * quietly drawing a title where the bezel is not.
+ */
+export const NATIVE_BAND = Object.freeze({ flexShrink: 0 });
+
+/**
  * NSMenu's geometry, for the menu a native popup bezel opens — read off
  * `NSMenu.size` on macOS 15 rather than off a screenshot, so it is the
  * menu's own arithmetic: a row is 22pt, the sheet pads 5pt top and bottom,

--- a/test/native-control-footprint.test.js
+++ b/test/native-control-footprint.test.js
@@ -1,0 +1,241 @@
+// A native control in a box taller than its bezel (issue #510).
+//
+// The title of a native `<Button>`/`<Select>` is *placed*, not centred: it
+// rides `TITLE_BASELINE` above the bezel body's bottom edge, which is where
+// NSButtonCell puts it and is only right while the box is exactly the
+// bezel's natural height. It was not always: the caller's `style` is applied
+// last and flex stretches a box regardless, so `height: 44`, a `height:
+// '100%'` in a taller parent or a bare `flexGrow: 1` made the box taller —
+// and the bezel, an absolutely-filled `<canvas>` AppKit draws its cell into
+// at the cell's own height, parted company with the title glued to the box's
+// bottom. The label landed below the control it names.
+//
+// So a native control is two boxes now: the footprint the caller sizes, and
+// the control itself at AppKit's metrics, centred in it. What is pinned here
+// is that arrangement, in the layout the renderer actually computes — the
+// bezels themselves are Cocoa-only and verified against the live backend.
+//
+// The load-bearing assertion is the **bezel's own height**: a title placed
+// against a box says nothing while the bezel fills that same box, since both
+// were wrong together. A bezel that is not 22pt is a bezel whose pixels sit
+// somewhere other than where the title was placed.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+
+import { Button, Select, createRoot } from '../src/index.js';
+import { NATIVE_RING, TITLE_BASELINE } from '../src/components/native.js';
+import { createMockApp, pressButton } from '../src/testing/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+const settle = async () => {
+  await tick();
+  await tick();
+};
+
+/**
+ * AppKit's metrics, as a store the widgets can read off a mock app: a 22pt
+ * control whose shadow rows are **not** symmetric, so a title placed against
+ * the wrong edge cannot come out right by luck.
+ */
+const NATURAL = Object.freeze({ width: 60, height: 22 });
+const SHADOW = Object.freeze({ top: 1, bottom: 2 });
+/** how far the title's baseline sits above the bottom of the bezel's box */
+const TITLE_UP = SHADOW.bottom + TITLE_BASELINE.regular;
+
+function bezelledApp() {
+  const app = createMockApp();
+  app.nativeBezels = {
+    natural: () => ({ ...NATURAL }),
+    shadow: () => ({ ...SHADOW }),
+    // the blit `Bezel`'s onDraw makes; the mock's ctx records it and draws
+    // nothing, which is all this test needs from the pixels
+    get: () => ({ surface: {}, sx: 0, sy: 0, sw: 1, sh: 1 }),
+  };
+  return app;
+}
+
+async function mount(element, { app = bezelledApp() } = {}) {
+  const root = await createRoot({ app });
+  root.render(h('window', { width: 400, height: 300 }, element));
+  await settle();
+  return { app, root, tree: app.windows[0]._reactX11Node };
+}
+
+/** every node under `tree`, in tree order, the popup windows excluded */
+function nodes(tree) {
+  const out = [];
+  const walk = (n) => {
+    out.push(n);
+    for (const c of n.children) if (!c.isWindow) walk(c);
+  };
+  walk(tree);
+  return out;
+}
+
+const byRole = (tree, role) =>
+  nodes(tree).filter((n) => n.props?.role === role);
+
+/** the control, the box it sits in, its bezel and its title */
+function parts(tree, role) {
+  const control = byRole(tree, role)[0];
+  assert.ok(control, `no ${role} in the tree`);
+  const footprint = nodes(tree).find((n) => n.children.includes(control));
+  const bezel = control.children.find((c) => c.kind === 'canvas');
+  const title = control.children.find((c) => c.kind === 'text');
+  return { control, footprint, bezel, title };
+}
+
+const OPTIONS = [
+  { value: 'Cocoa', label: 'Cocoa' },
+  { value: 'X11', label: 'X11' },
+];
+
+/** the four shapes from the issue, and the untouched control beside them */
+const CASES = [
+  {
+    name: 'untouched',
+    box: 22,
+    wrap: (control) => control({}),
+  },
+  {
+    name: 'style={{ height: 44 }}',
+    box: 44,
+    wrap: (control) => control({ height: 44 }),
+  },
+  {
+    name: "height: '100%' of a 44pt parent",
+    box: 44,
+    wrap: (control) =>
+      h('box', { style: { height: 44 } }, control({ height: '100%' })),
+  },
+  {
+    name: 'flexGrow: 1 in a 90pt column, no height named',
+    box: 90,
+    wrap: (control) =>
+      h('box', { style: { height: 90 } }, control({ flexGrow: 1 })),
+  },
+];
+
+for (const { name, box, wrap } of CASES) {
+  test(`a native button is AppKit's height, centred in a box — ${name}`, async () => {
+    const { root, tree } = await mount(
+      wrap((style) => h(Button, { style }, 'Done')),
+    );
+    const { control, footprint, bezel, title } = parts(tree, 'button');
+
+    assert.equal(footprint.abs.height, box, 'the caller sizes the footprint');
+    assert.equal(control.abs.height, NATURAL.height, 'the control does not');
+    assert.equal(
+      bezel.abs.height,
+      NATURAL.height,
+      'and neither does the bezel',
+    );
+    assert.equal(
+      control.abs.y - footprint.abs.y,
+      Math.floor((box - NATURAL.height) / 2),
+      'the control is centred in the footprint',
+    );
+    // the title against the bezel it belongs to, not against the footprint
+    assert.equal(title.abs.y, bezel.abs.y + bezel.abs.height - TITLE_UP);
+    // and the bezel spans the footprint's width, so a wide box is a wide button
+    assert.equal(bezel.abs.width, footprint.abs.width);
+    await root.unmount();
+  });
+
+  test(`a native popup is too — ${name}`, async () => {
+    const { root, tree } = await mount(
+      wrap((style) => h(Select, { options: OPTIONS, value: 'Cocoa', style })),
+    );
+    const { control, footprint, bezel, title } = parts(tree, 'combobox');
+
+    assert.equal(footprint.abs.height, box);
+    assert.equal(control.abs.height, NATURAL.height);
+    assert.equal(bezel.abs.height, NATURAL.height);
+    assert.equal(
+      control.abs.y - footprint.abs.y,
+      Math.floor((box - NATURAL.height) / 2),
+    );
+    assert.equal(title.abs.y, bezel.abs.y + bezel.abs.height - TITLE_UP);
+    await root.unmount();
+  });
+}
+
+// …and the keyboard ring goes with it. It is the control's own outline, on
+// the node the focus lands on, so it follows the bezel's box: a ring drawn
+// round a 44pt footprint with a 22pt control in it would be the rectangle
+// beside a rectangle that `NATIVE_RING` was written to avoid.
+test("the ring and the focus are the control's, not the footprint's", async () => {
+  const { root, tree } = await mount(
+    h(Button, { style: { height: 44 } }, 'Done'),
+  );
+  const { control, footprint } = parts(tree, 'button');
+
+  assert.equal(control.props.focusable, true, 'the control takes the focus');
+  assert.equal(footprint.props.focusable, undefined, 'the footprint does not');
+  assert.deepEqual(control.style[':focus-visible'], {
+    outlineWidth: NATIVE_RING.width,
+    outlineOffset: NATIVE_RING.offset,
+  });
+  assert.equal(footprint.style[':focus-visible'], undefined);
+  assert.equal(control.abs.height, NATURAL.height, 'so the ring is 22pt tall');
+  await root.unmount();
+});
+
+// The footprint is a slot, not a bigger button. A press in the slack above a
+// 22pt control in a 44pt slot does nothing at all — which is what AppKit does
+// with a cell in an oversized frame, and the honest answer here: the press
+// wash is the control's, so a button that fired from up there would act with
+// no visible answer to the press that acted.
+//
+// The slot is the test's own box, not the widget's, so the press lands on
+// the same point either way: before this it was the button's own top edge.
+test('the press belongs to the control, not to the slack around it', async () => {
+  const presses = [];
+  const slot = React.createRef();
+  const { app, root, tree } = await mount(
+    h(
+      'box',
+      { ref: slot, style: { height: 44 } },
+      h(
+        Button,
+        { style: { height: '100%' }, onPress: () => presses.push('press') },
+        'Done',
+      ),
+    ),
+  );
+  const { control } = parts(tree, 'button');
+  const wnd = app.windows[0];
+
+  pressButton(wnd, slot.current.abs.x + 20, slot.current.abs.y + 2);
+  await settle();
+  assert.deepEqual(
+    presses,
+    [],
+    'the slack above the control is not the button',
+  );
+
+  pressButton(wnd, control.abs.x + 20, control.abs.y + 11);
+  await settle();
+  assert.deepEqual(presses, ['press'], 'the control is');
+  await root.unmount();
+});
+
+// Nothing above reaches a backend without bezels: the drawn control is one
+// box, and the caller's style still sizes the box that *is* the control —
+// which is why a stretched drawn control was only ever roomy.
+test('the drawn control is one box, sized by the caller', async () => {
+  const { root, tree } = await mount(
+    h(Button, { style: { height: 44 } }, 'Done'),
+    { app: createMockApp() },
+  );
+  const button = byRole(tree, 'button')[0];
+  assert.equal(button.abs.height, 44);
+  assert.deepEqual(
+    button.children.map((c) => c.kind),
+    ['text'],
+    'no bezel, no wash, no footprint around it',
+  );
+  await root.unmount();
+});


### PR DESCRIPTION
Fixes #510.

A native `<Button>` or `<Select>` in a box taller than its bezel drew the
bezel in one place and its title a couple of rows below it, outside the
control.

### Before

![before](https://github.com/user-attachments/assets/d4805e83-2d14-4fcd-9fde-a9d74624e34a)

### After

![after](https://github.com/user-attachments/assets/db72ffaa-f4b4-4353-866a-b15addeb3d81)

Both rendered by this branch's own code on the Cocoa backend, macOS 15,
scale 2 — the four shapes from the issue's table, with the untouched control
beside them. Driven with `scripts/cocoa-drive.mjs` and the window's own
snapshot.

### What was wrong

The title is placed, not centred: it rides `TITLE_BASELINE` above the bezel
body's bottom edge, which is where NSButtonCell puts it and is only right
while the box is exactly the cell's natural height. The caller's `style` is
applied last and flex stretches a box regardless, so it was not always
— `style={{ height: 44 }}`, a `height: '100%'` in a taller parent, and a
bare `flexGrow: 1` that names no height at all each made the box taller. The
bezel is an absolutely-filled `<canvas>` AppKit draws its cell into at the
cell's own size, and the title was glued to the box's bottom edge, so the
two parted company and the gap grew with the box. The drawn path never had
this, because it centres its label: a stretched drawn control is merely
roomy, where a stretched native one was broken.

### What changed

A native control is two boxes now. The **footprint** is what the caller's
style sizes; the **control** — bezel, title and press wash — keeps AppKit's
metrics and is centred in it. The default footprint is exactly today's box,
so an untouched control lays out as it always did, and an explicit height
still resists a row's align-stretch.

The role, the handlers, the focus ring and the ref stay on the control, and
two things follow that AppKit also does. The keyboard ring hugs the bezel
rather than drawing a rectangle round a 44pt slot with a 22pt control in it,
which is the ring beside a ring `NATIVE_RING` was written to avoid. And a
press in the slack around the control does nothing at all, rather than
firing a button whose press wash could not answer it.

### Tests

`test/native-control-footprint.test.js`, against a mock bezel store, in the
layout the renderer actually computes. The load-bearing assertion is the
bezel's **own height**: a title placed against a box says nothing while the
bezel fills that same box, since both were wrong together. Nine of the
eleven cases fail on master with this branch's test file; the two that pass
are the guards for the drawn path.

`npm test`: 2160 tests, the six macOS-only appearance failures already on
master. Lint, format, typecheck and the docs site build are green.

### Not in this PR

`<Html>` in `@react-x11/components` reserves a box from the document's font
size and mounts the widget at 100% of it, which is how this reached every
document with a form in it. Whether that reservation should ask for the
control's natural size instead is the separate matter the issue describes,
and belongs on that repo.

