### PR TITLE
fix(select): a caption is one line, elided rather than wrapped

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -644,6 +644,15 @@ Behavior: the menu opens on the **press** — Space and Enter toggle it too;
 Escape, focus loss, or picking closes it; the option list scrolls when taller
 than 220px; the trigger participates in Tab traversal.
 
+**A caption is one line.** The trigger is as wide as the form made it and the
+value in it can be any length, so a caption with no room left ends in a `…`
+rather than wrapping to a second line — which there is no height for: the
+trigger is one row of label, and under a native popup bezel it is AppKit's
+own fixed height, so the wrapped line drew outside the control. The menu is
+sized to its longest option rather than to the trigger, so its rows are
+whole; where the screen is narrower than that longest label and the sheet is
+clamped to it, they end in a `…` too.
+
 The menu is the **same surface a menu is**: an ARGB popup rounded at
 `radiusPopup` with a hairline border where the display composites, and the
 active option is the same pill at `radiusPopupItem`, inset from the sheet's

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -582,7 +582,17 @@ implements it over CoreText:
   Both backends therefore agree on where a line may break and on what a
   `<text>` in a flex item is allowed to shrink to
   (`brokenAtEveryOpportunity`, src/cocoa/fonts.js;
-  test/cocoa-text-floor.test.js).
+  test/cocoa-text-floor.test.js). **A paragraph that elides is asked a
+  different question**, and the engine answers it here too: it has somewhere
+  to put the text it cannot show, so its floor is the `…` it would end in
+  rather than its longest word. Eliding needs a width, which the zero offer
+  is not, so the cap and the cut are made in the text — the first
+  `maxLines - 1` broken lines and then the mark, in the face of the run the
+  cut fell in — and CoreText is asked for neither
+  (`cappedToEllipsis`). Left to elide unbounded it keeps the line count and
+  puts everything over it back on the last line, which floored every
+  `textOverflow: 'ellipsis'` label at max-content and made it overflow
+  sideways rather than give way.
 - **Carets/hit/selection**: `CTLineGetStringIndexForPosition`,
   `CTLineGetOffsetForStringIndex`, line origins → `indexAt`,
   `caretPosition`, `rangeBands` — the `<textinput>`/selection surface,

--- a/src/cocoa/fonts.js
+++ b/src/cocoa/fonts.js
@@ -217,6 +217,58 @@ function brokenAtEveryOpportunity(spans) {
   return out;
 }
 
+/** What a paragraph ends in when it did not fit. A face without the mark
+ *  gets a substituted one from CoreText, where ntk falls back to three
+ *  dots of its own — a difference only a face missing U+2026 can show. */
+const ELLIPSIS = '\u2026';
+
+/**
+ * The broken spans as a paragraph that **elides**: the first `maxLines - 1`
+ * lines, then a line that is only the ellipsis — set in the font of the run
+ * the cut fell in, as ntk sets it.
+ *
+ * This is the min-content floor of a paragraph that ends in a `…`. It is not
+ * the same question as a wrapping one's: a paragraph that may wrap has to be
+ * at least its longest word, because there is nowhere else for that word to
+ * go, while one that elides has somewhere — an offer narrower than its text
+ * is answered by cutting the text, so the width it *needs* is the mark that
+ * says so. ntk answers exactly that (a `<text textWrap="nowrap"
+ * textOverflow="ellipsis">` measures 30.472 at an offer of zero, which is
+ * the width of `…` in the same face, to the third decimal), and the two
+ * engines are supposed to measure a tree the same way.
+ *
+ * The cut is made here rather than by the native for a reason worth
+ * keeping: eliding is a question about a width, and the min-content probe
+ * has none to give. Asked to elide with no bound, CoreText keeps the line
+ * count but puts everything that was over it back on the last line — a
+ * `<Select>` caption floored at 472.5 against a max-content of 506.9, which
+ * pinned every eliding label on this backend at its full width and made it
+ * overflow sideways rather than give way — react-x11 #512.
+ */
+function cappedToEllipsis(broken, maxLines) {
+  // A cap below one keeps one, as `_maxLines` does: nothing renders no
+  // paragraph at all, and a floor of zero is not a measurement.
+  const cap = Math.max(1, Math.floor(maxLines));
+  const lines = [[]];
+  for (const span of broken) {
+    if (span.text === '\n') lines.push([]);
+    else lines.at(-1).push(span);
+  }
+  // Nothing over the cap is nothing to stand for: a paragraph that fits in
+  // its lines is measured as the lines, ellipsis or not.
+  if (lines.length <= cap) return broken;
+
+  const cut = lines[cap - 1]?.[0] ?? broken[0];
+  const out = [];
+  for (const line of lines.slice(0, cap - 1)) {
+    if (out.length) out.push({ ...out.at(-1), text: '\n' });
+    out.push(...line);
+  }
+  if (out.length) out.push({ ...out.at(-1), text: '\n' });
+  out.push({ ...cut, text: ELLIPSIS });
+  return out;
+}
+
 const ALIGN_FLUSH = { left: 0, center: 0.5, right: 1 };
 
 function flushFor(align, direction) {
@@ -890,17 +942,28 @@ export class CocoaFontManager {
     // columns came out 823px and 34px wide. `brokenAtEveryOpportunity` is
     // the answer instead.
     const minContent = Number.isFinite(maxWidth) && maxWidth <= 0;
-    const laid = minContent
-      ? brokenAtEveryOpportunity(nativeSpans)
-      : nativeSpans;
+    // Whether this paragraph is one that ends in a `…`. Both halves: ntk
+    // elides off the line *count*, so an ellipsis with nothing to cap can
+    // never fire (nodes.js `_maxLines`), and neither can this.
+    const elides = overflow === 'ellipsis' && Number.isFinite(maxLines);
+    // An eliding paragraph's floor is the mark, not its longest word, and
+    // it is cut here because the native cannot cut without a width to cut
+    // to — see `cappedToEllipsis`. The cap and the ellipsis are in the text
+    // that comes back, so the request carries neither.
+    const probe = minContent && elides && nativeSpans.length > 0;
+    const laid = probe
+      ? cappedToEllipsis(brokenAtEveryOpportunity(nativeSpans), maxLines)
+      : minContent
+        ? brokenAtEveryOpportunity(nativeSpans)
+        : nativeSpans;
     const raw = this._native.createLayout({
       spans: laid,
       maxWidth:
         Number.isFinite(maxWidth) && maxWidth > 0 ? maxWidth : undefined,
       align: flushFor(align, direction),
       lineHeight: typeof lineHeight === 'number' ? lineHeight : undefined,
-      maxLines: Number.isFinite(maxLines) ? maxLines : undefined,
-      ellipsis: overflow === 'ellipsis',
+      maxLines: probe || !Number.isFinite(maxLines) ? undefined : maxLines,
+      ellipsis: !probe && overflow === 'ellipsis',
       rtl: direction === 'rtl',
     });
     // the text the native actually laid out: a min-content measurement's

--- a/src/components/Select.js
+++ b/src/components/Select.js
@@ -60,6 +60,25 @@ const ITEM_PAD_RIGHT = ITEM_PAD;
 // fit in.
 const itemHeight = (fontSize) => capBand(fontSize) + ITEM_PAD * 2;
 
+// A caption is one line. `<text>` wraps by default — right for a paragraph,
+// wrong for the value a control is showing: a trigger is a fixed height (the
+// bezel's own, in native mode), so a caption too long for the box wrapped to
+// a second line and drew it *outside* the control, above the bezel. The rows
+// of the menu are the same shape for the same reason: `metrics.row` tall,
+// whatever is in them.
+//
+// A `…` rather than a clip, because the width is not the label's to
+// negotiate — a dropdown is as wide as the form made it — so the honest
+// answer to a caption that does not fit is to say that it did not, which is
+// what NSPopUpButtonCell does with a title too long for its cell. It is
+// also what makes the label *give way*: an eliding `nowrap` floors at the
+// mark it would end in, where a clipping one keeps its full width and
+// pushes whatever contains it wider (nodes.js, `_wrapWidth`).
+const ONE_LINE = Object.freeze({
+  textWrap: 'nowrap',
+  textOverflow: 'ellipsis',
+});
+
 /**
  * The menu's geometry: the palette's, or — where the trigger is a native
  * popup bezel — NSMenu's, so the sheet that drops from it is the one the
@@ -230,6 +249,7 @@ function Option({
       {
         style: [
           capTrim,
+          ONE_LINE,
           {
             color: active ? theme.hoverText : theme.text,
             fontSize: metrics.fontSize,
@@ -543,6 +563,7 @@ export function Select({
       {
         style: [
           capTrim,
+          ONE_LINE,
           nativeControls && nativeTitleStyle('regular'),
           { color: current ? theme.text : theme.textMuted },
         ],

--- a/test/cocoa-text-floor.test.js
+++ b/test/cocoa-text-floor.test.js
@@ -9,12 +9,25 @@
 // out 823px and 34px wide and the second one left the window, where the same
 // tree on X11 wrapped at the longest word.
 //
+// A paragraph that **elides** is the other half of the same question, and
+// it was still wrong after that, #512: a `<text textWrap="nowrap"
+// textOverflow="ellipsis">` reaches the engine as `maxLines: 1, ellipsis:
+// true`, and eliding needs a width the min-content probe has none of. Handed
+// none, CoreText keeps the line count and puts everything that was over it
+// back on the last line — a caption measured 472.5 against a max-content of
+// 506.9, so every eliding label on this backend held its box open at its
+// full width and overflowed sideways instead of giving way. An eliding
+// paragraph does not need its longest word: it has somewhere to put the
+// text it cannot show. Its floor is the mark, which is what ntk answers to
+// the third decimal, so the cut is made here and the native is asked for
+// neither a cap nor an elision.
+//
 // Two layers, as in cocoa-glyph-runs.test.js. The first runs everywhere: a
 // fake bridge, asserting what reaches `createLayout` — which is the whole of
 // what this engine decides, since CoreText only shapes what it is handed.
 // The second runs where the real bridge loads and measures the pixels: the
-// floor is the longest word, to the same fraction as measuring that word
-// alone.
+// floor is the longest word, or the ellipsis where the text elides, to the
+// same fraction as measuring either alone.
 import assert from 'node:assert';
 import { describe, test } from 'node:test';
 
@@ -118,6 +131,108 @@ describe('the min-content floor', () => {
     assert.deepStrictEqual(textsOf(native), ['supercalifragilistic']);
   });
 
+  test('an eliding paragraph floors at the mark, not at its longest word', () => {
+    const native = fakeNative();
+    const fonts = new CocoaFontManager(native);
+    fonts.layout([{ text: 'Plain boxes. On the render server.' }], base, {
+      maxWidth: 0,
+      maxLines: 1,
+      overflow: 'ellipsis',
+    });
+
+    assert.deepStrictEqual(textsOf(native), ['\u2026']);
+    // the cap and the cut are in the text, so the request carries neither —
+    // asking the native to elide is asking it to do the one thing it cannot
+    // do without a width
+    const call = native.layouts.at(-1);
+    assert.strictEqual(call.maxWidth, undefined);
+    assert.strictEqual(call.maxLines, undefined);
+    assert.strictEqual(call.ellipsis, false);
+  });
+
+  test('a cap of two keeps the first line and then the mark', () => {
+    const native = fakeNative();
+    const fonts = new CocoaFontManager(native);
+    fonts.layout([{ text: 'Plain boxes. On the render server.' }], base, {
+      maxWidth: 0,
+      maxLines: 2,
+      overflow: 'ellipsis',
+    });
+    assert.deepStrictEqual(textsOf(native), ['Plain', '\n', '\u2026']);
+  });
+
+  test('a paragraph inside its cap is not given a mark it does not need', () => {
+    const native = fakeNative();
+    const fonts = new CocoaFontManager(native);
+    fonts.layout([{ text: 'Plain boxes.' }], base, {
+      maxWidth: 0,
+      maxLines: 3,
+      overflow: 'ellipsis',
+    });
+    // two lines under a cap of three: nothing is over it, so nothing stands
+    // for anything and the floor is the longest word, as it is for a
+    // paragraph that wraps
+    assert.deepStrictEqual(textsOf(native), ['Plain', '\n', 'boxes.']);
+  });
+
+  test('a word that cannot break is its whole self, mark or no mark', () => {
+    const native = fakeNative();
+    const fonts = new CocoaFontManager(native);
+    fonts.layout([{ text: 'supercalifragilistic' }], base, {
+      maxWidth: 0,
+      maxLines: 1,
+      overflow: 'ellipsis',
+    });
+    assert.deepStrictEqual(textsOf(native), ['supercalifragilistic']);
+  });
+
+  test('the mark is set in the font of the run the cut fell in', () => {
+    const native = fakeNative();
+    const fonts = new CocoaFontManager(native);
+    fonts.layout(
+      [{ text: 'small ' }, { text: 'BIG ', size: 28 }, { text: 'after' }],
+      base,
+      { maxWidth: 0, maxLines: 2, overflow: 'ellipsis' },
+    );
+    const spans = native.layouts.at(-1).spans;
+    assert.deepStrictEqual(
+      spans.map((sp) => sp.text),
+      ['small', '\n', '\u2026'],
+    );
+    // the second line is where the cut fell, so the mark wears its face —
+    // ntk picks the ellipsis against the cut run's own coverage
+    assert.strictEqual(spans[2].font.size, 28);
+  });
+
+  test('an elision with a width to work to is left to the native', () => {
+    const native = fakeNative();
+    const fonts = new CocoaFontManager(native);
+    const text = 'Plain boxes. On the render server.';
+    fonts.layout([{ text }], base, {
+      maxWidth: 194,
+      maxLines: 1,
+      overflow: 'ellipsis',
+    });
+    const call = native.layouts.at(-1);
+    assert.deepStrictEqual(textsOf(native), [text]);
+    assert.strictEqual(call.maxWidth, 194);
+    assert.strictEqual(call.maxLines, 1);
+    assert.strictEqual(call.ellipsis, true);
+  });
+
+  test('an ellipsis with nothing to cap cannot fire, here either', () => {
+    const native = fakeNative();
+    const fonts = new CocoaFontManager(native);
+    // `maxLines: undefined` is how an uncapped paragraph arrives (nodes.js
+    // sends `_maxLines()` only when it is finite), and ntk elides off the
+    // line count — so this is a plain min-content measurement
+    fonts.layout([{ text: 'Plain boxes.' }], base, {
+      maxWidth: 0,
+      overflow: 'ellipsis',
+    });
+    assert.deepStrictEqual(textsOf(native), ['Plain', '\n', 'boxes.']);
+  });
+
   test('a hard newline in the text is an opportunity like any other', () => {
     const native = fakeNative();
     const fonts = new CocoaFontManager(native);
@@ -183,6 +298,49 @@ describe(
         `wrapped at its floor, the widest line is ${wrapped.width}`,
       );
       assert.ok(wrapped.height > maxContent / minContent, 'many lines');
+    });
+
+    test('and when it elides, the floor is the mark itself', () => {
+      const fonts = new CocoaFontManager(bridge);
+      const elided = fonts.layout([{ text: TEXT }], base, {
+        maxWidth: 0,
+        maxLines: 1,
+        overflow: 'ellipsis',
+      });
+      const mark = fonts.layout([{ text: '\u2026' }], base, {}).width;
+      const wrapping = fonts.layout([{ text: TEXT }], base, {
+        maxWidth: 0,
+      }).width;
+
+      assert.ok(
+        Math.abs(elided.width - mark) < 0.5,
+        `floored at ${elided.width}, the mark is ${mark}`,
+      );
+      assert.ok(
+        elided.width < wrapping / 4,
+        `an eliding label gives way further than a wrapping one ` +
+          `(${elided.width} against ${wrapping})`,
+      );
+      // one line, and a line of the height the paragraph has anywhere else:
+      // a floor is a width answer, and must not shorten the box
+      assert.strictEqual(elided.lines.length, 1);
+      assert.strictEqual(
+        elided.height,
+        fonts.layout([{ text: TEXT }], base, {}).height,
+      );
+    });
+
+    test('a bounded elision is untouched by any of that', () => {
+      const fonts = new CocoaFontManager(bridge);
+      const at = (maxWidth) =>
+        fonts.layout([{ text: TEXT }], base, {
+          maxWidth,
+          maxLines: 1,
+          overflow: 'ellipsis',
+        }).width;
+      const room = fonts.layout([{ text: TEXT }], base, {}).width / 3;
+      assert.ok(at(room) <= room, `elided to ${at(room)} inside ${room}`);
+      assert.ok(at(room) > room / 2, 'and used the room it was given');
     });
 
     test('a paragraph offered a pixel still breaks inside its words', () => {

--- a/test/select-caption.test.js
+++ b/test/select-caption.test.js
@@ -1,0 +1,191 @@
+// A `<Select>`'s caption is one line.
+//
+// It wrapped. A `<text>` is a paragraph by default — offer it less width
+// than its string wants and it breaks at the nearest opportunity and comes
+// back taller — which is right for prose and wrong for the value a control
+// is showing. The trigger's height does not follow it there: under a native
+// popup bezel it is AppKit's own (`bezelNatural`), so a caption like
+// "Local / Unix socket" in a field too narrow for it put "Local / Unix"
+// *above* the control, outside the bezel, with "socket" inside. On the drawn
+// theme nothing overflowed and the bug was quieter for it: one field in a
+// row of fields simply came out twice the height of the rest.
+//
+// The menu never had it, which is why the trigger's version survived: the
+// sheet is sized to its longest option (`menuWidth`), so every row has room
+// by construction. Every row except on a screen narrower than that longest
+// label, which is the one case `menuWidth` clamps — and a menu row is a
+// fixed height too.
+//
+// So both are one line, and both end in a `…` when the line runs out. What
+// is pinned here is that pair: the caption stays on one line and the trigger
+// stays the height of one whatever it is showing, and the menu still shows
+// every option whole — an ellipsis in *there* would mean the sizing had gone
+// wrong rather than the room having run out.
+//
+// Eliding is what lets the caption *give way* rather than push the trigger
+// wider, and that half rests on a floor the two font engines had to be made
+// to agree on: an eliding label measures at the mark it would end in, not at
+// its longest word. The Cocoa engine answered max-content until #512 and
+// turned this wrap into an overflow the other way — the title drawn over
+// the arrow capsule. That half is pinned in test/cocoa-text-floor.test.js,
+// where the engine is.
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import React from 'react';
+
+import {
+  cleanup,
+  renderX11,
+  screen,
+  textOf,
+  userEvent,
+  within,
+} from '../src/testing/index.js';
+import { Select } from '../src/index.js';
+
+const require = createRequire(import.meta.url);
+const FONT_DIR = path.join(
+  path.dirname(require.resolve('katex/package.json')),
+  'dist',
+  'fonts',
+);
+// KaTeX Main covers U+2026, so the elided line really ends in a `…` rather
+// than in ntk's fallback for a face without one.
+const FONTS = { 'sans-serif': path.join(FONT_DIR, 'KaTeX_Main-Regular.ttf') };
+
+const h = React.createElement;
+
+// Wider than the 140px trigger below at 14px, and made of several words, so
+// there is a break opportunity for the old behaviour to wrap at.
+const LONG = 'Local / Unix socket';
+const OPTIONS = [LONG, 'TCP', 'TLS'];
+
+afterEach(cleanup);
+
+/** Two `<Select>`s in a column too narrow for one of them. */
+const pair = () =>
+  h(
+    'box',
+    { style: { width: 140, padding: 10, gap: 8 } },
+    h(Select, {
+      'data-testname': 'long',
+      value: LONG,
+      options: OPTIONS,
+    }),
+    h(Select, { 'data-testname': 'short', value: 'TCP', options: OPTIONS }),
+  );
+
+/** The caption inside a trigger or a row, and the paragraph it came out as
+ *  — `_placedLayout` is the one on screen, elision and all. */
+function captionOf(node) {
+  const [text] = within(node).all((n) => n.kind === 'text');
+  return { text, layout: text._placedLayout().layout };
+}
+
+const ellipsisRun = (layout) =>
+  layout.lines.at(-1).runs.find((run) => run.ellipsis) ?? null;
+
+test('a caption with no room left is elided, not wrapped', async () => {
+  await renderX11(pair(), { width: 400, height: 200, fonts: FONTS });
+
+  const long = screen.getByTestName('long');
+  const { layout } = captionOf(long);
+
+  assert.equal(layout.lines.length, 1, 'one line');
+  assert.equal(layout.truncated, true);
+  assert.ok(ellipsisRun(layout), 'and it ends in a `…`');
+});
+
+test('so the trigger is the height it would be showing anything else', async () => {
+  await renderX11(pair(), { width: 400, height: 200, fonts: FONTS });
+
+  const long = screen.getByTestName('long');
+  const short = screen.getByTestName('short');
+  assert.equal(
+    long.abs.height,
+    short.abs.height,
+    `"${LONG}" ${long.abs.height} vs "TCP" ${short.abs.height}`,
+  );
+  // and the caption is inside the control rather than over its edge, which
+  // is what the native bezel's fixed height turns a second line into
+  const { text } = captionOf(long);
+  assert.ok(
+    text.abs.y >= long.abs.y &&
+      text.abs.y + text.abs.height <= long.abs.y + long.abs.height,
+    `caption at ${text.abs.y}..${text.abs.y + text.abs.height}, ` +
+      `trigger ${long.abs.y}..${long.abs.y + long.abs.height}`,
+  );
+});
+
+test('a caption that fits is left alone', async () => {
+  await renderX11(
+    h(
+      'box',
+      { style: { width: 300, padding: 10 } },
+      h(Select, { 'data-testname': 'roomy', value: LONG, options: OPTIONS }),
+    ),
+    { width: 400, height: 200, fonts: FONTS },
+  );
+
+  const { layout } = captionOf(screen.getByTestName('roomy'));
+  assert.equal(layout.truncated, false);
+  assert.equal(ellipsisRun(layout), null);
+});
+
+test('and the menu still shows every option whole', async () => {
+  await renderX11(pair(), { width: 400, height: 300, fonts: FONTS });
+
+  await userEvent.click(screen.getByTestName('long'));
+
+  const options = screen.getAllByRole('option');
+  assert.equal(options.length, OPTIONS.length);
+  for (const option of options) {
+    const { text, layout } = captionOf(option);
+    assert.equal(
+      layout.truncated,
+      false,
+      `"${textOf(text)}" elided in a menu ${text.abs.width}px wide`,
+    );
+    assert.equal(layout.lines.length, 1);
+  }
+});
+
+test('a menu the screen clamps elides its rows rather than wrapping them', async () => {
+  // The one case `menuWidth` cannot size its way out of: the longest label
+  // is wider than the display, so the sheet is clamped and the row it was
+  // measured for no longer fits in it. Wrapping there was the trigger's bug
+  // one surface along — three lines of label in a 22-or-30px row, drawn
+  // over the two options under it.
+  const WIDE = 'Local / Unix socket connection to the daemon process';
+  await renderX11(
+    h(
+      'box',
+      { style: { width: 120, padding: 10 } },
+      h(Select, {
+        'data-testname': 'clamped',
+        value: 'TCP',
+        options: [WIDE, 'TCP'],
+      }),
+    ),
+    {
+      width: 180,
+      height: 260,
+      screen: { width: 200, height: 300 },
+      fonts: FONTS,
+    },
+  );
+
+  await userEvent.click(screen.getByTestName('clamped'));
+
+  const [row] = screen.getAllByRole('option');
+  const { text, layout } = captionOf(row);
+  assert.equal(layout.lines.length, 1, `"${textOf(text)}" over one line`);
+  assert.equal(layout.truncated, true);
+  assert.ok(ellipsisRun(layout), 'and says so with a `…`');
+  assert.ok(
+    text.abs.height <= row.abs.height,
+    `label ${text.abs.height}px tall in a ${row.abs.height}px row`,
+  );
+});


### PR DESCRIPTION
A `Select` on cocoa whose caption is longer than its trigger word-wrapped, and the line that wrapped drew outside the bezel.

![select-before](https://github.com/user-attachments/assets/2033962f-3213-4b70-90be-939b08cc7c94)

![select-after](https://github.com/user-attachments/assets/7215aeed-b910-4828-9357-12c33ce95a4d)

Master above, this branch below. Same scene both sides — a 118px trigger showing "Local / Unix socket" — each rendered on the Cocoa backend by its own checkout.

## The caption

A `<text>` is a paragraph by default, so a value too long for its box breaks at the nearest opportunity and comes back taller. The trigger's height does not follow it there: under a native popup bezel it is AppKit's own, so the first line landed above the control. On the drawn theme nothing overflowed and the bug was quieter for it — one field in a row of fields simply came out twice the height of the rest.

So the caption is `textWrap: 'nowrap'` with `textOverflow: 'ellipsis'`, which is what NSPopUpButtonCell does with a title too long for its cell. A `…` rather than a clip, because the width is not the label's to negotiate: a dropdown is as wide as the form made it, so the honest answer to a caption that does not fit is to say that it did not.

The menu's rows get the same, for the same reason — a row is `metrics.row` tall whatever is in it. It never showed there, because the sheet is sized to its longest option; except where the screen is narrower than that option and `menuWidth` clamps it, which put three lines of label in a 30px row, over the two options beneath.

## The floor underneath it

Eliding is only half of giving way. The other half is the automatic minimum, which a `<text>` reports by measuring itself at an offer of zero — and the Cocoa font engine did not answer that the way `_wrapWidth` describes. A min-content probe has no width and eliding needs one; asked to elide unbounded, CoreText keeps the line count but puts everything that was over it back on the last line. So an eliding label floored at max-content: 472.5 device px for that caption, against a max-content of 506.9 and a content box of 164.

Which turned this wrap into an overflow the other way, and not only in `Select` — every `textWrap: 'nowrap'` label with an ellipsis on this backend inherits it, `Table`'s columns and `FileDialog`'s path included.

![columns-before](https://github.com/user-attachments/assets/988e7771-8536-47f9-b8ac-573ca3f2e408)

![columns-after](https://github.com/user-attachments/assets/0c58b024-76e2-41fe-86bb-171ae4299dc9)

Two `flexGrow: 1, flexBasis: 0` cells of eliding text in an 840px row. Master gives them 476 and 472 device px and the second leaves the window; this branch splits the row, and both cells end in a `…`.

An eliding paragraph's floor is the mark it would end in rather than its longest word, because unlike a wrapping one it has somewhere to put what it cannot show. ntk answers exactly that — 30.472 at an offer of zero, which is the width of `…` in that face to the third decimal — and the two engines are meant to measure a tree the same way. So `cappedToEllipsis` makes the cut in the *text*, as #481 already makes the breaks: the first lines under the cap, then a line that is only the ellipsis, set in the face of the run the cut fell in, with the cap and the elision left off the native request. A paragraph already inside its cap comes back unbroken, so nothing gains a mark it does not need.

Numbers over the real bridge at 26px: max-content 506.9, wrapping floor 124.8, eliding floor 16.1 — which is the width of the mark.

## Tests

`test/select-caption.test.js`, five. Three fail without the widget change: two lines where there should be one, a 54px trigger beside the 36px one showing a shorter value, and a clamped menu row three lines deep in a 30px row. Two are guards — a caption that fits is untouched, and the menu still shows every option whole, since an ellipsis in there would mean the sizing had gone wrong rather than the room having run out.

`test/cocoa-text-floor.test.js` gains seven, in both the layers that file already had. Four fail without the engine change: the fake-bridge assertions that the request carries neither a cap nor an elision and that the mark wears the cut run's face, and the real-bridge one that the floor is the mark. Three are guards — a paragraph inside its cap, an unbreakable word, and a bounded elision still going to the native untouched.

The suite is otherwise green: the nine failures on this machine are the standing ones, six in `appearance.test.js` that pass in CI and three in `desktop-calendar.test.js` that want `ical.js` installed. Lint, prettier and typecheck are clean, and the behaviour is documented in docs/components.md and docs/macos.md.

