### PR TITLE
fix(devtools): raise the frame budget hook sources are read off

### DIFF
--- a/docs/devtools.md
+++ b/docs/devtools.md
@@ -198,6 +198,25 @@ Notes for maintainers:
 - `localStorage`/`sessionStorage` are **defined** on the global rather than
   assigned: reading `global.localStorage` first is what makes node print
   its `--localstorage-file` warning on every DevTools run.
+- **Hook names and sources need a deeper stack than V8 keeps.** React reads
+  each hook's location — and the custom-hook nesting the names come from —
+  off a stack captured at the hook dispatch, and `Error.stackTraceLimit` is
+  10 by default. A loader leaves frames of its own between the hook and its
+  call site (`tsx`, which every `npm run examples:*` goes through, costs
+  about ten), so the identifying frames fall off the end: `hookSource`
+  comes back `{fileName: null, lineNumber: null, …}`, the frontend logs
+  "Hook source code location not found", and the element shows its hooks
+  with no names and no source lines (#514). `prepare()` raises the limit to
+  50 when the bridge is enabled, and only upwards, so an app that asked for
+  more keeps it. `test/devtools-hooks.test.js` squeezes the budget and
+  asserts the names and sources still come back over the bridge.
+- **Selecting a component with hooks can blank the DevTools window.** That
+  is the standalone app's own renderer process aborting, upstream of
+  anything the host sends: it happens with every hook source complete, and
+  under runtimes with no loader at all. Turning ⚙ → Components → "Always
+  parse hook names for the selected element" off makes it intermittent
+  rather than reliable; restarting `npx react-devtools` reconnects to the
+  app, which is unaffected.
 - `test/devtools.test.js` drives the real backend over a socket for all of
   the above; the fake-agent tests in `test/smoke.test.js` prove the drawing
   but not that the backend still asks for it.

--- a/src/DevToolsIntegration.js
+++ b/src/DevToolsIntegration.js
@@ -111,6 +111,14 @@ export function createStorage(persist) {
  */
 export async function prepare() {
   try {
+    // Each hook's source location is read off a stack captured at the hook
+    // dispatch, and V8 keeps ten frames — fewer than a loader leaves
+    // between the hook and its call site. Under `tsx` (which every
+    // `npm run examples:*` uses) that costs about ten frames, so the call
+    // site falls off the end, `hookSource` comes back null, and DevTools
+    // shows the element's hooks with no names and no source lines.
+    // Upwards only: an app that asked for more keeps it.
+    if (Error.stackTraceLimit < 50) Error.stackTraceLimit = 50;
     // react-devtools-core's backend bundle expects browser-ish globals
     global.self ??= global;
     global.window ??= global;

--- a/test/devtools-hooks.test.js
+++ b/test/devtools-hooks.test.js
@@ -1,0 +1,133 @@
+// Hook source locations, over the same real bridge devtools.test.js drives.
+//
+// React works out where each hook was called by capturing a stack at the
+// hook dispatch (react-debug-tools' inspectHooksOfFiber) and reading the
+// frames below it — that is also how it recovers the custom-hook nesting
+// the frontend shows names for. V8 keeps ten frames by default, and a
+// loader leaves frames of its own between the hook and its call site:
+// `tsx`, which every `npm run examples:*` goes through, costs about ten. So
+// the identifying frames fall off the end, `hookSource` comes back all
+// nulls, the nesting collapses, and DevTools shows the element's hooks with
+// no names and no source lines.
+//
+// The frame budget is squeezed here rather than a loader stacked up: it is
+// the same thing from React's side — the identifying frames are not in the
+// captured stack — and it does not depend on how many frames the test
+// runner happens to add. Five is where this tree loses them; a real app
+// under `tsx` loses them at the default ten.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import React from 'react';
+import { createMockApp } from './helpers/mock-app.js';
+import { fakeDevTools, unrefFurtherTimers } from './helpers/fake-devtools.js';
+
+/** Every hook in the tree the backend sent back, nested ones included. */
+function flatten(hooks, out = []) {
+  for (const hook of hooks ?? []) {
+    out.push(hook);
+    flatten(hook.subHooks, out);
+  }
+  return out;
+}
+
+test('hook sources survive a stack too short to reach the call site', async (t) => {
+  const devtools = await fakeDevTools();
+  const stateDir = await fs.mkdtemp(path.join(os.tmpdir(), 'react-x11-dth-'));
+  process.env.REACT_X11_DEVTOOLS = '1';
+  process.env.REACT_X11_DEVTOOLS_PORT = String(devtools.port);
+  process.env.REACT_X11_DEVTOOLS_STATE = path.join(stateDir, 'devtools.json');
+  const limitBefore = Error.stackTraceLimit;
+  t.after(async () => {
+    delete process.env.REACT_X11_DEVTOOLS;
+    delete process.env.REACT_X11_DEVTOOLS_PORT;
+    delete process.env.REACT_X11_DEVTOOLS_STATE;
+    Error.stackTraceLimit = limitBefore;
+    unrefFurtherTimers();
+    await devtools.close();
+    await fs.rm(stateDir, { recursive: true, force: true });
+  });
+
+  // what a loader costs, in the one number React's stack capture reads
+  Error.stackTraceLimit = 5;
+  // imported after the environment is set: the hook installs from here
+  const { createRoot } = await import('../src/index.js');
+
+  // two levels of custom hooks, which is ordinary for an app's own and is
+  // where the frames run out first
+  function useLabel() {
+    return React.useState('idle')[0];
+  }
+  function useStatus() {
+    const label = useLabel();
+    return React.useMemo(() => label.toUpperCase(), [label]);
+  }
+  function Panel() {
+    const status = useStatus();
+    return React.createElement('box', {
+      style: { width: 60, height: 20 },
+      accessibleName: status,
+    });
+  }
+
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  x11Root.render(
+    React.createElement(
+      'window',
+      { width: 200, height: 100 },
+      React.createElement(Panel),
+    ),
+  );
+  await devtools.connected;
+  await devtools.waitFor('operations');
+
+  const hook = globalThis.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  const [rendererID] = [...hook.rendererInterfaces.keys()];
+  const renderer = hook.rendererInterfaces.get(rendererID);
+  const box = app.windows[0]._reactX11Node.children[0];
+  // Panel is what rendered the box, so it heads the box's owners list
+  const hostID = renderer.getElementIDForHostInstance(box);
+  const [owner] = renderer.getOwnersList(hostID);
+  assert.strictEqual(owner.displayName, 'Panel');
+
+  devtools.send('inspectElement', {
+    id: owner.id,
+    rendererID,
+    path: null,
+    requestID: 1,
+    forceFullData: true,
+  });
+  const inspected = await devtools.waitFor('inspectedElement');
+  assert.strictEqual(inspected.payload.type, 'full-data');
+  // hooks come over the bridge dehydrated: the tree itself is under `data`
+  const hooks = flatten(inspected.payload.value?.hooks?.data);
+
+  assert.deepStrictEqual(
+    hooks.map((h) => h.name).sort(),
+    ['Label', 'Memo', 'State', 'Status'],
+    'the custom hooks are named, not just the built-ins they wrap',
+  );
+  const incomplete = hooks.filter(
+    (h) => h.hookSource?.fileName == null || h.hookSource?.lineNumber == null,
+  );
+  assert.deepStrictEqual(
+    incomplete.map((h) => h.name),
+    [],
+    'and every one of them knows where it was called',
+  );
+  assert.ok(
+    hooks.every((h) =>
+      h.hookSource.fileName.endsWith('devtools-hooks.test.js'),
+    ),
+    'at the call site in the app, not at a frame inside React',
+  );
+  assert.ok(
+    Error.stackTraceLimit >= 50,
+    'which is what enabling the bridge raises the frame budget for',
+  );
+
+  await x11Root.unmount();
+});

--- a/test/devtools.test.js
+++ b/test/devtools.test.js
@@ -16,52 +16,11 @@ import os from 'node:os';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { WebSocketServer } from 'ws';
 import React from 'react';
 import { createMockApp } from './helpers/mock-app.js';
+import { fakeDevTools, unrefFurtherTimers } from './helpers/fake-devtools.js';
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-
-/** The DevTools frontend, near enough: a socket that records what the app
- * says and can say things back. The bridge batches, so everything here
- * waits for an event rather than assuming it has arrived. */
-async function fakeDevTools() {
-  const server = new WebSocketServer({ port: 0 });
-  await new Promise((resolve) => server.on('listening', resolve));
-  const received = [];
-  let socket = null;
-  const connected = new Promise((resolve) => {
-    server.on('connection', (ws) => {
-      socket = ws;
-      ws.on('message', (data) => received.push(JSON.parse(data.toString())));
-      resolve(ws);
-    });
-  });
-  return {
-    port: server.address().port,
-    connected,
-    received,
-    send: (event, payload) => socket.send(JSON.stringify({ event, payload })),
-    async waitFor(event, timeout = 5000) {
-      const deadline = Date.now() + timeout;
-      for (;;) {
-        const hit = received.find((m) => m.event === event);
-        if (hit) return hit;
-        if (Date.now() > deadline) {
-          throw new Error(
-            `timed out waiting for "${event}"; saw ` +
-              [...new Set(received.map((m) => m.event))].join(', '),
-          );
-        }
-        await sleep(20);
-      }
-    },
-    async close() {
-      socket?.close();
-      await new Promise((resolve) => server.close(resolve));
-    },
-  };
-}
 
 test('the DevTools backend drives the overlays, the picker and the style editor', async (t) => {
   const devtools = await fakeDevTools();
@@ -74,16 +33,7 @@ test('the DevTools backend drives the overlays, the picker and the style editor'
     delete process.env.REACT_X11_DEVTOOLS;
     delete process.env.REACT_X11_DEVTOOLS_PORT;
     delete process.env.REACT_X11_DEVTOOLS_STATE;
-    // A backend whose socket closes reconnects forever (handleClose ->
-    // scheduleRetry), which is what an app wants and what would keep this
-    // process alive after the last assertion. Every timer from here on is
-    // unref'd, so the retries continue without being a reason to stay up.
-    const realSetTimeout = global.setTimeout;
-    global.setTimeout = (fn, ms, ...rest) => {
-      const timer = realSetTimeout(fn, ms, ...rest);
-      timer.unref?.();
-      return timer;
-    };
+    unrefFurtherTimers();
     await devtools.close();
     await fs.rm(stateDir, { recursive: true, force: true });
   });

--- a/test/helpers/fake-devtools.js
+++ b/test/helpers/fake-devtools.js
@@ -1,0 +1,57 @@
+// The DevTools frontend, near enough: a socket that records what the app
+// says and can say things back. The bridge batches, so everything here
+// waits for an event rather than assuming it has arrived.
+import { WebSocketServer } from 'ws';
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+export async function fakeDevTools() {
+  const server = new WebSocketServer({ port: 0 });
+  await new Promise((resolve) => server.on('listening', resolve));
+  const received = [];
+  let socket = null;
+  const connected = new Promise((resolve) => {
+    server.on('connection', (ws) => {
+      socket = ws;
+      ws.on('message', (data) => received.push(JSON.parse(data.toString())));
+      resolve(ws);
+    });
+  });
+  return {
+    port: server.address().port,
+    connected,
+    received,
+    send: (event, payload) => socket.send(JSON.stringify({ event, payload })),
+    async waitFor(event, timeout = 5000) {
+      const deadline = Date.now() + timeout;
+      for (;;) {
+        const hit = received.find((m) => m.event === event);
+        if (hit) return hit;
+        if (Date.now() > deadline) {
+          throw new Error(
+            `timed out waiting for "${event}"; saw ` +
+              [...new Set(received.map((m) => m.event))].join(', '),
+          );
+        }
+        await sleep(20);
+      }
+    },
+    async close() {
+      socket?.close();
+      await new Promise((resolve) => server.close(resolve));
+    },
+  };
+}
+
+/** A backend whose socket closes reconnects forever (handleClose ->
+ * scheduleRetry), which is what an app wants and what would keep a test
+ * process alive after the last assertion. Unref every timer from here on,
+ * so the retries continue without being a reason to stay up. */
+export function unrefFurtherTimers() {
+  const realSetTimeout = global.setTimeout;
+  global.setTimeout = (fn, ms, ...rest) => {
+    const timer = realSetTimeout(fn, ms, ...rest);
+    timer.unref?.();
+    return timer;
+  };
+}


### PR DESCRIPTION
Fixes #514.

React derives each hook's source location — and the custom-hook nesting the
hook *names* come from — by capturing a stack at the hook dispatch
(`react-debug-tools`' `inspectHooksOfFiber`). V8's default
`Error.stackTraceLimit` is 10, and a loader leaves frames of its own between
the hook and its call site: `tsx`, which every `npm run examples:*` goes
through, costs about ten. The identifying frames fall off the end, so the
backend reports `hookSource: {fileName: null, lineNumber: null, …}`, the
frontend's `getHookSourceLocationKey` throws `Hook source code location not
found`, and the inspected element shows its hooks unnamed and unsourced.

`prepare()` now raises the limit to 50 when the bridge is being enabled, and
only upwards, so an app that already asked for more keeps it.

## What it looks like over the bridge

The DevTools UI itself is an Electron app I can't capture here, so this is
the payload behind it: one `inspectElement` response for a component behind
two levels of custom hooks, with the frame budget squeezed to where this
tree loses them.

Before — the nesting is gone and every source is null:

```json
[
 { "name": "State", "hookSource": { "fileName": null, "lineNumber": null } },
 { "name": "Memo",  "hookSource": { "fileName": null, "lineNumber": null } }
]
```

After — the custom hooks are back, each with its call site:

```json
[
 { "name": "Status", "hookSource": { "fileName": "…/devtools-hooks.test.js", "lineNumber": 67 },
   "subHooks": [
    { "name": "Label", "hookSource": { "fileName": "…", "lineNumber": 63 },
      "subHooks": [ { "name": "State", "hookSource": { "fileName": "…", "lineNumber": 60 } } ] },
    { "name": "Memo", "hookSource": { "fileName": "…", "lineNumber": 64 } } ] }
]
```

## Tests

`test/devtools-hooks.test.js` drives the same real backend over a socket
that `test/devtools.test.js` does, inspects a component two custom hooks
deep, and asserts the names and sources come back complete. It squeezes
`Error.stackTraceLimit` rather than stacking up a loader: it is the same
thing from React's side and does not depend on how many frames the runner
adds. Reverted against the fix it fails with `[ 'Memo', 'State' ]` where
`[ 'Label', 'Memo', 'State', 'Status' ]` was expected — the reported symptom.

The fake-frontend socket moved out of `test/devtools.test.js` into
`test/helpers/fake-devtools.js` so both files use it; nothing about it
changed.

Full suite: 2171 pass, 6 fail — the six `appearance.test.js` cases that fail
on macOS and pass in CI, unchanged on master. `prettier --check .`, `eslint`
and `tsc` are clean.

## Not fixed here

The DevTools window going blank when you select a component is the
standalone app's renderer process aborting, upstream of anything the host
sends — it happens with every hook source complete and under runtimes with
no loader. `docs/devtools.md` gains a note saying so, next to the note about
the stack budget.