### PR TITLE
fix(types): declare `scale` on DrawnNode, and say which unit `abs` is in

### DIFF
--- a/src/types/nodes.d.ts
+++ b/src/types/nodes.d.ts
@@ -18,8 +18,17 @@ export interface DrawnNode {
    * was registered under. What queries and paint order match on:
    * `screen.all((n) => n.kind === 'gauge')`. */
   readonly kind: string;
-  /** Position and size within the owning window, valid after layout. */
+  /** Position and size within the owning window, valid after layout. In
+   * **device pixels**, like everything painted — a mouse event's `x`/`y`
+   * are logical, `scale` apart (docs/scale.md). `ev.nativeEvent.x`/`y` are
+   * the same point as `ev.x`/`y` already in this unit, which is what a
+   * pointer measured against a laid-out box wants. */
   readonly abs: Rect;
+  /** Device pixels per logical pixel for this node: the display's scale
+   * times any `scale` prop above it, resolved once and constant for the
+   * node's life. The number that converts between `abs` and the logical
+   * unit an app writes styles and reads events in. */
+  readonly scale: number;
   readonly parent: DrawnNode | null;
   readonly children: readonly DrawnNode[];
   /** Take the keyboard focus, if this node is focusable. Returns the node,
@@ -42,14 +51,18 @@ export interface DrawnNode {
   readonly direction: 'ltr' | 'rtl';
   /** Whether `node` is this node or a descendant of it (DOM `contains`). */
   contains(node: DrawnNode | null): boolean;
+  /** The boxes this node occupies, in **logical** pixels — already divided
+   * by `scale`, so they compare directly with an event's `x`/`y`. One rect
+   * for a box; one per line for wrapped text. */
   getClientRects(): Rect[];
 
   // --- text geometry (docs/elements.md, "Selection") ------------------------
   //
   // Every drawn node answers these; an element with no text answers `null`,
   // `0` and `[]`. Indices are **code points** and rectangles are in the
-  // owning window's coordinates — the same space as `abs` and a mouse
-  // event's `x`/`y`.
+  // owning window's coordinates — the same space as `abs`, which is device
+  // pixels: this seam speaks that unit deliberately, so a point taken from
+  // an event arrives through `ev.nativeEvent` or multiplied by `scale`.
 
   /** This element's text, or null when it has none. */
   textContent(): string | null;

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -327,6 +327,11 @@ function Elements() {
   // issue #271: the resolved direction, which is what a widget measuring a
   // pointer against this box has to read
   const _dir: 'ltr' | 'rtl' | undefined = boxRef.current?.direction;
+  // the unit `abs` is in, for a pointer measured against it: without this a
+  // component reads `ev.x` against a device-pixel box and the gesture comes
+  // out at half speed on a retina panel
+  const _scale: number | undefined = boxRef.current?.scale;
+  const _box: number | undefined = boxRef.current?.abs.width;
   const _holds = () => boxRef.current?.contains(inputRef.current);
   // issue #253: the question the wheel asks a scroller on its way out
   const _room: boolean | undefined = scrollRef.current?.canScroll(0, 48);


### PR DESCRIPTION
A ref hands back a `DrawnNode` whose `abs` is **device** pixels, while the events an app reads are **logical** — `docs/scale.md` says so, and `src/types/events.d.ts` says so on `SyntheticEvent.x`. The node type said neither: no `scale` member to convert with, and an `abs` doc that named no unit at all.

Every consumer that has had to convert widened the type by hand. `@react-x11/components` carries two of them: `<Reorder>` and `<Tabs>` share an `OpaqueNode` interface whose comment is literally "what `DrawnNode` does not declare", and this week's `src/internal/units.ts` says the same thing again — "`scale` is on every retained node at run time but not on the public `DrawnNode` type". The consumer that did **not** widen it is the one that shipped the bug: `<ColorPicker>` subtracted a device-pixel box from a logical pointer, so on a retina panel a press at the middle of its saturation area read as a quarter of the way in from the corner and the thumb stopped following the pointer.

So this declares what is already there at run time — `getPublicInstance` hands back the retained node, which has carried `scale` since the scale work landed — and names the unit everywhere the type touches geometry:

- `readonly scale: number`, next to `abs` so the pairing is visible.
- `abs`: device pixels, with `ev.nativeEvent.x`/`y` named as the same point in that unit.
- `getClientRects()`: logical, already divided, so it compares directly with `ev.x`.
- the text-geometry block: it speaks device pixels deliberately, and a point taken from an event has to arrive through `nativeEvent` or a multiply.

Types and comments only — no runtime change, and no new API surface, since every one of these values was already reachable through a cast. `test/types/api.tsx` gains the two assertions a consumer needs to compile without one.
