### PR TITLE
fix(scroll): the blit follows RTL content

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -974,6 +974,13 @@ onDraw>`, `value`, `placeholder`. `children` and event handlers are
   blit, a border/borderRadius on the scroll pane, an overlapping
   non-descendant, a debug overlay or DevTools highlight all bail.
 
+  The shift is the content's move, not the offsets': `scrollX` counts from
+  the start edge, so under `direction: 'rtl'` a growing offset carries the
+  content _right_, and a delta written as "against the offset" moves the
+  band, the exposed strip, the dragged thumb and the ledger's claims the
+  wrong way. `Node._blitShift` is where offsets become that move — read it
+  rather than subtracting offsets.
+
   A claim landing inside the viewport used to bail too. It now goes into a
   per-frame **ledger** on the scrolling node (issue #398), recorded at
   `invalidate` time — _before_ rects coalesce and hide it, the reason the

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -3434,14 +3434,26 @@ export class Node {
   }
 
   /**
-   * How far the blit this viewport has pending will move the pixels it
-   * keeps: the delta `_applyScrollBlits` hands `scrollRegion`, from the
-   * offsets captured when the blit was armed to the ones in force now. Only
-   * meaningful while `_blitLedgerOpen()`.
+   * How far the blit this viewport has pending moves the pixels it keeps:
+   * the delta `_applyScrollBlits` hands `scrollRegion`, from the offsets
+   * captured when the blit was armed to the ones in force now. `from` is
+   * that origin, for a caller that has already taken it off the node.
+   *
+   * It is the content's own move, and along x that is not always against
+   * the offset. `scrollX` is a distance from the start edge, which is the
+   * right-hand one under `direction: 'rtl'`, so there `_absolutizeChildren`
+   * carries the children right as it grows — and the band the blit keeps,
+   * the strip it exposes, the thumb it drags along and the claims in the
+   * ledger all go the way the children went.
    */
-  _blitShift() {
-    const from = this._pendingBlitFrom;
-    return { x: from.x - this.scrollX, y: from.y - this.scrollY };
+  _blitShift(from = this._pendingBlitFrom) {
+    const dx = this.scrollX - from.x;
+    // 0 - x rather than -x: negating +0 yields -0, which survives into
+    // request buffers and test comparisons
+    return {
+      x: this.direction === 'rtl' ? 0 + dx : 0 - dx,
+      y: 0 - (this.scrollY - from.y),
+    };
   }
 
   /**
@@ -6755,8 +6767,9 @@ export const Scrollable = (Base) =>
       // is the right-hand edge in RTL — so scrolling shifts the children the
       // other way. Keeping it a distance rather than a coordinate is what
       // makes `scrollTo({x: 0})` mean "back to the beginning" in both
-      // directions, and keeps every clamp, every max and the blit's arithmetic
-      // in one sign.
+      // directions, and keeps every clamp and every max in one sign. What
+      // moves pixels with the content does not share it: the scroll blit
+      // asks `_blitShift`, which asks the direction.
       const ox = rtl ? originX + this.scrollX : originX - this.scrollX;
       const oy = originY - this.scrollY;
       // The layout diff and a scroll would double-report each other: a scroll
@@ -12656,8 +12669,11 @@ export class WindowNode extends Scrollable(Node) {
     // shift is a copy
     if (!isIntegerRect(vp)) return;
     if (!Number.isInteger(from.x) || !Number.isInteger(from.y)) return;
-    const dx = node.scrollX - from.x;
-    const dy = node.scrollY - from.y;
+    // How far the kept pixels move, which is how far the content moved —
+    // the sense `scrollRegion` takes and `_applyContentsBlit` is handed.
+    // Not the change in the offsets: along x in RTL the two agree only in
+    // size (`_blitShift`).
+    const { x: dx, y: dy } = node._blitShift(from);
     if (!Number.isInteger(dx) || !Number.isInteger(dy)) return;
     if (dx === 0 && dy === 0) return;
     // one axis at a time: a diagonal scroll needs an L of strips whose
@@ -12703,8 +12719,8 @@ export class WindowNode extends Scrollable(Node) {
     for (const claim of ledger ?? []) {
       const moved = claim.pre
         ? {
-            x: claim.x - dx,
-            y: claim.y - dy,
+            x: claim.x + dx,
+            y: claim.y + dy,
             width: claim.width,
             height: claim.height,
           }
@@ -12719,8 +12735,9 @@ export class WindowNode extends Scrollable(Node) {
     if (repairArea > area * BLIT_MAX_CLAIM_AREA) return;
     if (!this._scrollBlitSafe(node, vp)) return;
     let rects = keep;
-    // the strip the shift exposed, full breadth — it also covers the corner
-    // gutter beside the bars, whose old pixels the blit did not overwrite
+    // the strip the shift exposed, on the side the pixels moved away from,
+    // full breadth — it also covers the corner gutter beside the bars, whose
+    // old pixels the blit did not overwrite
     const axis = dy !== 0 ? 'y' : 'x';
     const delta = dy !== 0 ? dy : dx;
     rects = addDamageRect(
@@ -12728,12 +12745,12 @@ export class WindowNode extends Scrollable(Node) {
       axis === 'y'
         ? {
             x: vp.x,
-            y: delta > 0 ? vp.y + vp.height - delta : vp.y,
+            y: delta > 0 ? vp.y : vp.y + vp.height + delta,
             width: vp.width,
             height: Math.abs(delta),
           }
         : {
-            x: delta > 0 ? vp.x + vp.width - delta : vp.x,
+            x: delta > 0 ? vp.x : vp.x + vp.width + delta,
             y: vp.y,
             width: Math.abs(delta),
             height: vp.height,
@@ -12760,8 +12777,8 @@ export class WindowNode extends Scrollable(Node) {
       node.scrollY = savedY;
       if (oldBar) {
         rects = addDamageRect(rects, {
-          x: oldBar.x - 1 - dx,
-          y: oldBar.y - 1 - dy,
+          x: oldBar.x - 1 + dx,
+          y: oldBar.y - 1 + dy,
           width: oldBar.width + 2,
           height: oldBar.height + 2,
         });
@@ -12778,7 +12795,7 @@ export class WindowNode extends Scrollable(Node) {
       const track = scrollbarTrackRect(crossBar);
       rects = addDamageRect(rects, track);
       const dragged = intersectRects(
-        { ...track, x: track.x - dx, y: track.y - dy },
+        { ...track, x: track.x + dx, y: track.y + dy },
         vp,
       );
       if (dragged) rects = addDamageRect(rects, dragged);
@@ -12797,10 +12814,7 @@ export class WindowNode extends Scrollable(Node) {
       if (inside) painted += inside.width * inside.height;
     }
     if (painted > area * SCROLL_BLIT_MAX_REPAINT) return;
-    // scroll offsets grow down/right; the pixels move the other way
-    // (0 - x rather than -x: negating +0 yields -0, which survives into
-    // request buffers and test comparisons)
-    if (!wnd.scrollRegion({ ...vp }, 0 - dx, 0 - dy)) return;
+    if (!wnd.scrollRegion({ ...vp }, dx, dy)) return;
     this._damage = rects;
   }
 

--- a/test/scroll-blit.test.js
+++ b/test/scroll-blit.test.js
@@ -892,3 +892,230 @@ test('a claim between two scrolls cannot re-arm the blit mid-frame (#295)', asyn
       JSON.stringify(root._lastDamageRects),
   );
 });
+
+// --- right-to-left panes -------------------------------------------------
+//
+// `scrollX` is a distance from the start edge, and under `direction: 'rtl'`
+// that edge is the right-hand one, so a growing offset carries the content
+// right (`_absolutizeChildren`). The blit has to go the way the content went:
+// the band it keeps, the strip it exposes, the thumb it drags along and the
+// ledger's claims all used to follow the offset's sign instead, and moved
+// the wrong way in RTL. Each test runs in both directions and reads its
+// expectation off where the content actually went.
+
+// 20 columns of 40px in a 400x400 window: `mount`, turned on its side.
+async function mountRow(direction) {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const ref = React.createRef();
+  x11Root.render(
+    h(
+      'window',
+      { width: 400, height: 400 },
+      h(
+        'box',
+        {
+          ref,
+          style: {
+            overflow: 'scroll',
+            flexGrow: 1,
+            flexDirection: 'row',
+            direction,
+          },
+        },
+        ...Array.from({ length: 20 }, (_, i) =>
+          h('box', {
+            key: i,
+            style: {
+              width: 40,
+              flexShrink: 0,
+              backgroundColor: i % 2 ? '#ffffff' : '#eef1f5',
+            },
+          }),
+        ),
+      ),
+    ),
+  );
+  const wnd = app.windows[0];
+  await tick();
+  return { x11Root, wnd, root: wnd._reactX11Node, ref };
+}
+
+for (const direction of ['ltr', 'rtl']) {
+  test(`a horizontal blit moves the pixels the way the content moved (${direction})`, async () => {
+    const { x11Root, wnd, root, ref } = await mountRow(direction);
+    const first = ref.current.children[0];
+    const was = first.abs.x;
+    wnd.calls.length = 0;
+    ref.current.scrollTo({ x: 48 });
+    await tick();
+    const moved = first.abs.x - was;
+    // the premise: scrolling towards the end carries the content away from
+    // the start edge, which is the right-hand one in RTL
+    assert.strictEqual(moved, direction === 'rtl' ? 48 : -48);
+    assert.deepStrictEqual(blits(wnd), [
+      ['scrollRegion', { x: 0, y: 0, width: 400, height: 400 }, moved, 0],
+    ]);
+    // the strip the shift exposed is on the side the content moved away
+    // from, and it is repainted top to bottom
+    const rects = root._lastDamageRects;
+    assert.ok(rects, 'the frame stayed bounded');
+    const strip = moved > 0 ? 0 : 400 + moved;
+    for (const x of [strip, strip + 47]) {
+      for (const y of [0, 200, 399]) {
+        assert.ok(
+          covers(rects, x, y),
+          `damage misses the exposed strip at ${x},${y}: ` +
+            JSON.stringify(rects),
+        );
+      }
+    }
+    const area = rects.reduce((sum, r) => sum + r.width * r.height, 0);
+    assert.ok(
+      area < 400 * 400 * 0.25,
+      `repainted ${area}px² — the strip and thumb rects, not the viewport ` +
+        JSON.stringify(rects),
+    );
+    await x11Root.unmount();
+  });
+
+  test(`a horizontal blit repaints the thumb it dragged along (${direction})`, async () => {
+    const { x11Root, wnd, root, ref } = await mountRow(direction);
+    // start mid-row, so the dragged copy of the old thumb stays on screen
+    ref.current.scrollTo({ x: 96 });
+    await tick();
+    const sv = ref.current;
+    const first = sv.children[0];
+    const was = first.abs.x;
+    const before = sv._scrollbar('x');
+    wnd.calls.length = 0;
+    sv.scrollTo({ x: 144 });
+    await tick();
+    assert.strictEqual(blits(wnd).length, 1, 'the fast path fired');
+    const moved = first.abs.x - was;
+    const after = sv._scrollbar('x');
+    const rects = root._lastDamageRects;
+    // the new thumb, and every column of the copy of the old one, which
+    // rode the blit as far as the content did
+    const y = before.y + before.height / 2;
+    const xs = [after.x + 3];
+    const end = Math.min(400, before.x + before.width + moved);
+    for (let x = Math.max(0, before.x + moved); x < end; x += 4) xs.push(x);
+    for (const x of xs) {
+      assert.ok(
+        covers(rects, x, y),
+        `damage misses thumb pixel at ${x},${y}: ${JSON.stringify(rects)}`,
+      );
+    }
+    await x11Root.unmount();
+  });
+
+  test(`a claim inside a horizontal pane is repainted where the blit moved it (${direction})`, async () => {
+    const { x11Root, wnd, root, ref } = await mountRow(direction);
+    const first = ref.current.children[0];
+    const was = first.abs.x;
+    wnd.calls.length = 0;
+    ref.current.scrollTo({ x: 48 });
+    // a second change lands in the same frame, inside the viewport, at the
+    // rect it occupies *before* the shift — near the left edge, clear of
+    // the box a strip on the wrong side merges into with the thumb rects
+    root.invalidate(false, { x: 40, y: 120, width: 40, height: 120 });
+    await tick();
+    assert.strictEqual(blits(wnd).length, 1, 'the fast path fired');
+    const moved = first.abs.x - was;
+    // the blit moved those pixels as far as it moved the content, so the
+    // repaint has to follow them there
+    assert.ok(
+      covers(root._lastDamageRects, 60 + moved, 130),
+      `damage misses the moved region: ` +
+        JSON.stringify(root._lastDamageRects),
+    );
+    await x11Root.unmount();
+  });
+
+  test(`a blitted horizontal scroll is byte-identical to the repaint it replaced (${direction})`, async (t) => {
+    const app = await createHeadlessApp();
+    const x11Root = await createRoot({ app });
+    try {
+      const ref = React.createRef();
+      const instance = await new Promise((resolve) =>
+        x11Root.render(
+          h(
+            'window',
+            { width: 400, height: 300, style: { backgroundColor: '#f5f6fa' } },
+            h(
+              'box',
+              {
+                ref,
+                style: {
+                  overflow: 'scroll',
+                  flexGrow: 1,
+                  flexDirection: 'row',
+                  direction,
+                },
+              },
+              ...Array.from({ length: 40 }, (_, i) =>
+                h(
+                  'box',
+                  {
+                    key: i,
+                    style: {
+                      width: 40,
+                      flexShrink: 0,
+                      padding: 6,
+                      backgroundColor: i % 2 ? '#ffffff' : '#dbe4ee',
+                    },
+                  },
+                  h(
+                    'text',
+                    { style: { fontSize: 12, color: '#20304a' } },
+                    `${i}`,
+                  ),
+                ),
+              ),
+            ),
+          ),
+          resolve,
+        ),
+      );
+      if (typeof instance.scrollRegion !== 'function') {
+        t.skip('installed ntk has no Window.scrollRegion yet');
+        return;
+      }
+      const root = instance._reactX11Node;
+      const frame = () => {
+        root._scheduled = false;
+        root.flush();
+      };
+      frame();
+      await settle(app);
+
+      // scroll through the fast path, and prove it really took it
+      let blitCalls = 0;
+      const realScrollRegion = instance.scrollRegion.bind(instance);
+      instance.scrollRegion = (...args) => {
+        blitCalls += 1;
+        return realScrollRegion(...args);
+      };
+      ref.current.scrollTo({ x: 48 });
+      frame();
+      await settle(app);
+      assert.strictEqual(blitCalls, 1, 'the fast path fired');
+      assert.ok(root._lastDamageRects, 'and the frame stayed bounded');
+      const blitted = await readPixels(root._ctx, 400, 300);
+
+      // repaint the same state from scratch: the ground truth
+      root.invalidate(false);
+      frame();
+      await settle(app);
+      const repainted = await readPixels(root._ctx, 400, 300);
+      assert.ok(
+        Buffer.from(blitted.data).equals(Buffer.from(repainted.data)),
+        'blitted pixels differ from a full repaint of the same state',
+      );
+    } finally {
+      await x11Root.unmount();
+      await app.close();
+    }
+  });
+}


### PR DESCRIPTION
Under `direction: 'rtl'`, `scrollX` is a distance from the right-hand edge, and `Scrollable._absolutizeChildren` places the children at `originX + scrollX`: a growing offset moves RTL content right. `WindowNode._applyScrollBlits` still worked in the offsets' sign. It took `dx = node.scrollX - from.x` and handed `scrollRegion` `-dx` whatever the direction, so on a horizontally scrolling RTL pane it:

- shifted the kept band left while the content moved right,
- claimed the exposed strip on the right, where nothing was exposed,
- repaired the thumb it dragged along at the LTR place, leaving the dragged copy on screen,
- moved the ledger's pre-layout claims the same wrong way.

Every notch left the pane scrambled until something else repainted it.

## The fix

`Node._blitShift` turns the offsets into the content's move, asking the direction the way `_absolutizeChildren` does. `_applyScrollBlits` reads `dx` and `dy` from it, so there they mean how far the pixels move: the sense `scrollRegion` takes and `_applyContentsBlit` is already handed. The `CopyArea`, the strip, the thumb repair, the cross-bar repair and the ledger all follow from that one delta, and the strip arithmetic is now the same shape as `_applyContentsBlit`'s.

- `_applyContentsBlit` needed no change. `scrollContents` takes pixel deltas from the element, which say where the pixels went in either direction.
- Vertical scrolling was never affected: only x is mirrored.
- LTR is unchanged. The new horizontal tests run in both directions, and every LTR one passes on master too.

AGENTS.md gets a paragraph in the scroll-blit notes: read `_blitShift` rather than subtracting offsets.

## Screenshots

An RTL pane scrolled three notches of 48px through the blit, in the in-process X server, rendered by master's code and by this branch's. Against a full repaint of the same state, master's frame differs in 18,148 of 64,000 pixels and this branch's in none. Re-rendered after the rebase onto #523, both images come out the same to the byte.

![rtl-scroll-blit](https://github.com/user-attachments/assets/f243347d-226e-4bc3-909d-47a3fe9da3bf)

## Tests

New in `test/scroll-blit.test.js`, each run for `ltr` and for `rtl`:

- **a horizontal blit moves the pixels the way the content moved**: the `scrollRegion` dx equals the first column's `abs.x` delta, +48 in RTL and -48 in LTR, and the exposed strip is repainted on the side the content left.
- **a horizontal blit repaints the thumb it dragged along**: every column of the dragged copy of the old thumb is inside the frame's damage.
- **a claim inside a horizontal pane is repainted where the blit moved it**: the ledger's pre-layout claim.
- **a blitted horizontal scroll is byte-identical to the repaint it replaced**: the RTL copy of the pixel test, against the real in-process X server.

### Mutation check

Each piece put back to the old offset-signed arithmetic on its own, the rest left fixed, then `test/scroll-blit.test.js`:

| mutation                                 | RTL tests that fail              |
| ---------------------------------------- | -------------------------------- |
| `scrollRegion` handed the negated offset | moves the pixels, byte-identical |
| strip on the offset-signed side          | moves the pixels, byte-identical |
| thumb repaired against the offset        | dragged thumb, byte-identical    |
| ledger claims moved against the offset   | claim                            |
| `_blitShift` without the direction       | all four                         |
| master's `src/nodes.js`                  | all four                         |

Every LTR test passes under every mutation. The RTL claim test first passed against master by accident: the wrong-side strip merges with the thumb rects into a box over the right 62% of the pane, and that box covered its probe point. The claim now sits near the left edge, clear of it.

## On top of #523

#523 merged first, and this branch is rebased onto it.

- **The textual conflict** was `Node._blitShift`. #523 added one for `_placeSticky` with the LTR arithmetic, `from.x - this.scrollX`, where this PR adds the direction-aware one, and this branch's is kept. `_placeSticky` calls it with no argument, which reads `_pendingBlitFrom` as #523's did, so an RTL blit now finds a sticky node's pixels where the blit actually moved them.
- **A conflict git could not see.** #523's `fix(scroll)` commit repairs the copy of the cross bar that the blit drags along, at `track.x - dx`, written when `dx` was the change in the offsets. Here `dx` is how far the pixels move, so the rebase makes it `track.x + dx`. Put the old sign back and #523's own test, "the cross bar is repaired where the blit dragged it, not only on its track", fails.

`examples/schedule.jsx` scrolled across headless, three notches of 48px, each notch compared with a full repaint of the same state:

|                                  | LTR                                  | RTL                                                              |
| -------------------------------- | ------------------------------------ | ---------------------------------------------------------------- |
| master                           | notches 1 and 2 blit, exact          | no notch blits: 8 ledger claims a notch, every one repaints in full |
| this branch                      | notches 1 and 2 blit, exact          | notches 1 and 2 blit, exact                                      |
| this branch, cross bar's old sign | 260 wrong pixels every blitted notch | the same, mirrored                                               |

The third notch takes the full repaint in both directions. The 260 pixels are the vertical bar's copy, dragged 48px across and never repaired: x 584 to 589 in a 640-wide window, and 50 to 55 in RTL.

## Checks

On the rebased head CI is green: lint, docs, bench, bench-cocoa and the test matrix. Locally, on the rebased tree, `test/scroll-blit.test.js`, `test/sticky.test.js` and `test/schedule-example.test.js` pass 69 of 69; against master's source, the four new RTL tests fail and every other test passes.

Before the rebase, locally:

- `npm test`: 2195 of 2201 passed. The six failures are in `test/appearance.test.js` and fail the same way on origin/master on this machine.
- `npm run lint`, `npm run format:check`, `npm run typecheck`: clean.
- `npm run bench:touched`: no regressions against the protocol baseline and unchanged pixel hashes. The Cocoa presenters gate failed one rule, `covered`, as origin/master does on this machine.
