### PR TITLE
fix(paint): a glyph's antialiased edge is not culled at a damage edge

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1133,7 +1133,11 @@ when you say nothing.
 **Painting: `paintDamage()`.** The rect this pass covers, in the owning
 window's coordinates — the same space as `abs`, in device pixels — or `null`
 when the frame is unbounded and everything has to be drawn. Cull
-against it exactly as core culls the tree:
+against it the way core culls the tree, where a pixel short of the rect
+still counts as inside it: antialiasing puts ink just past the bounds you
+computed, and the pass is clipped to the rect, so drawing a near miss costs
+one draw and loses nothing. Here `overlaps(a, b, 1)` asks whether two rects
+come within a pixel of each other:
 
 ```js
 class FlowNode extends Node {
@@ -1142,11 +1146,11 @@ class FlowNode extends Node {
     // thing: nothing bounds you, draw the lot
     const damage = this.paintDamage();
     for (const cell of this.gridCells()) {
-      if (damage && !overlaps(cell, damage)) continue;
+      if (damage && !overlaps(cell, damage, 1)) continue;
       this.drawCell(ctx, cell);
     }
     for (const edge of this.edges) {
-      if (damage && !overlaps(edge.routedBounds, damage)) continue;
+      if (damage && !overlaps(edge.routedBounds, damage, 1)) continue;
       this.drawEdge(ctx, edge);
     }
     // …nodes, minimap, controls
@@ -1262,7 +1266,7 @@ class FlowNode extends Node {
     // …and this is the exposed strip, not the pane. Nothing here changes.
     const damage = this.paintDamage();
     for (const item of this.scene()) {
-      if (damage && !overlaps(item.bounds, damage)) continue;
+      if (damage && !overlaps(item.bounds, damage, 1)) continue;
       this.draw(ctx, item);
     }
   }

--- a/src/node.d.ts
+++ b/src/node.d.ts
@@ -504,8 +504,10 @@ export declare class Node {
    * An element whose node is one node never needs it; being painted at all
    * means it is inside the pass. An element that draws a **scene** into one
    * node culls against it the way core culls the tree, instead of redrawing
-   * the scene into a clip that throws most of it away. Window coordinates,
-   * the same space as `abs`; read-only.
+   * the scene into a clip that throws most of it away. Core counts a pixel
+   * short of the rect as inside it, for the antialiasing that inks just
+   * past a shape's bounds. Window coordinates, the same space as `abs`;
+   * read-only.
    */
   paintDamage(): Rect | null;
   /**

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -522,7 +522,6 @@ function rectsBounds(rects) {
   return out;
 }
 
-/** Do two rects share any area? Touching edges do not count. */
 /** Does `rect` reach into any of the four `radius`-sized corner squares of
  * `box` — the only part of a rounded border a translation cannot keep? */
 function cornerSquaresOverlap(box, radius, rect) {
@@ -542,12 +541,17 @@ function cornerSquaresOverlap(box, radius, rect) {
   return corners.some((square) => rectsOverlap(square, rect));
 }
 
-function rectsOverlap(a, b) {
+/**
+ * Do two rects share any area? Touching edges do not count. With a
+ * `margin`, do they come within that many pixels of each other: the same
+ * question asked of either one grown by `margin` on every side.
+ */
+function rectsOverlap(a, b, margin = 0) {
   return (
-    a.x < b.x + b.width &&
-    b.x < a.x + a.width &&
-    a.y < b.y + b.height &&
-    b.y < a.y + a.height
+    a.x < b.x + b.width + margin &&
+    b.x < a.x + a.width + margin &&
+    a.y < b.y + b.height + margin &&
+    b.y < a.y + a.height + margin
   );
 }
 
@@ -5625,12 +5629,20 @@ export class Node {
    * saving comes from — the clip alone would still put every request on the
    * wire for the server to throw away.
    *
-   * Tested against the subtree's bounds, not `abs`: see `paintBounds`.
+   * Tested against the subtree's bounds, not `abs`: see `paintBounds`. And
+   * with the pixel of `DAMAGE_SLOP` to spare. A claim is grown by it before
+   * it gets here, but a rect that never was a claim — the strip a scroll
+   * blit exposes, a scrollbar's repair — is exact, and antialiasing puts
+   * ink just outside a glyph's box (`_childrenCanOverflow` allows the same
+   * pixel). Text whose box ends where such a rect begins inks its first
+   * column; culled, that column keeps what was under the text where a full
+   * repaint has the ink. The pass is clipped to the rect, so painting the
+   * text lets that ink land and nothing else.
    */
   _outsideDamage() {
     const damage = this.root?._paintDamage;
     if (!damage) return false;
-    return !rectsOverlap(this._subtreeBounds(), damage);
+    return !rectsOverlap(this._subtreeBounds(), damage, DAMAGE_SLOP);
   }
 
   /**

--- a/test/scroll-blit.test.js
+++ b/test/scroll-blit.test.js
@@ -1119,3 +1119,163 @@ for (const direction of ['ltr', 'rtl']) {
     }
   });
 }
+
+// --- ink a pixel past its box, where a strip begins ----------------------
+//
+// Antialiasing puts a glyph's ink a fraction of a pixel outside its box, so
+// text whose box ends exactly where a pass begins inks the pass's first
+// column, and the cull that skips subtrees outside the pass has to let it.
+// A claim is grown by a pixel before anything is culled against it; the
+// strip a blit exposes is not a claim, and is exact. Right-to-left text ends
+// at its box's right edge, and a pane whose content moves left exposes its
+// strip on the right, so a title whose edge was at the viewport's lands on
+// the strip's. Found in the schedule example at scale 2: one pixel, 255 in
+// the blitted frame and 253 in a full repaint.
+
+test('text whose box ends where a strip begins keeps its antialiased edge, frame by frame', async (t) => {
+  // two windows, a server each: one blits, and its twin, with no
+  // scrollRegion to call, repaints the whole viewport on every scroll
+  const apps = [await createHeadlessApp(), await createHeadlessApp()];
+  const x11Roots = [];
+  try {
+    for (const app of apps) x11Roots.push(await createRoot({ app, scale: 2 }));
+    const twins = [];
+    for (const x11Root of x11Roots) {
+      const ref = React.createRef();
+      const titles = [];
+      const instance = await new Promise((resolve) =>
+        x11Root.render(
+          h(
+            'window',
+            { width: 330, height: 90, style: { backgroundColor: '#ffffff' } },
+            h(
+              'box',
+              {
+                ref,
+                style: {
+                  overflow: 'scroll',
+                  flexGrow: 1,
+                  flexDirection: 'row',
+                  direction: 'rtl',
+                },
+              },
+              // 200 device pixels a card in a 660 viewport: at none of the
+              // positions below does a title's box end on the pane's left
+              // edge. The off-screen cull makes no allowance for ink past a
+              // box, so the two windows can disagree about that column for a
+              // reason of its own.
+              ...Array.from({ length: 8 }, (_, i) =>
+                h(
+                  'box',
+                  { key: i, style: { width: 100, flexShrink: 0, padding: 8 } },
+                  h(
+                    'text',
+                    {
+                      ref: (node) => (titles[i] = node),
+                      style: { fontSize: 12, color: '#20304a' },
+                    },
+                    'in between',
+                  ),
+                ),
+              ),
+            ),
+          ),
+          resolve,
+        ),
+      );
+      twins.push({
+        instance,
+        root: instance._reactX11Node,
+        pane: ref.current,
+        titles,
+      });
+    }
+    const [blit, full] = twins;
+    if (typeof blit.instance.scrollRegion !== 'function') {
+      t.skip('installed ntk has no Window.scrollRegion yet');
+      return;
+    }
+    full.instance.scrollRegion = undefined;
+    let blits = 0;
+    const realScrollRegion = blit.instance.scrollRegion.bind(blit.instance);
+    blit.instance.scrollRegion = (...args) => {
+      const ok = realScrollRegion(...args);
+      if (ok) blits += 1;
+      return ok;
+    };
+    const W = 660;
+    const H = 180;
+    const paint = ({ root }) => {
+      root._scheduled = false;
+      root.flush();
+    };
+    const settled = () => Promise.all(apps.map(settle));
+    twins.forEach(paint);
+    await settled();
+
+    const landings = [];
+    const scrollTo = async (x) => {
+      const before = blits;
+      for (const twin of twins) {
+        twin.pane._scrollByDevice(x - twin.pane.scrollX, 0);
+        paint(twin);
+      }
+      await settled();
+      const [a, b] = await Promise.all(
+        twins.map(({ root }) => readPixels(root._ctx, W, H)),
+      );
+      const rects = blit.root._lastDamageRects ?? [];
+      // the premise, where it holds: a title's box ends on a strip's left
+      // edge, and a full repaint inks the column past it
+      for (const title of blit.titles) {
+        const { x: tx, y: ty, width, height } = title.abs;
+        const edge = tx + width;
+        const strip = rects.find(
+          (r) => r.x === edge && r.y <= ty && r.y + r.height >= ty + height,
+        );
+        if (!strip || blits === before) continue;
+        let ink = 255;
+        for (let y = ty; y < ty + height; y++) {
+          ink = Math.min(ink, b.data[(y * W + edge) * 4]);
+        }
+        assert.ok(ink < 255, `the title ending at ${edge} inks past its box`);
+        landings.push(x);
+      }
+      let count = 0;
+      let first = null;
+      for (let i = 0; i < a.data.length; i += 4) {
+        if (
+          a.data[i] === b.data[i] &&
+          a.data[i + 1] === b.data[i + 1] &&
+          a.data[i + 2] === b.data[i + 2] &&
+          a.data[i + 3] === b.data[i + 3]
+        ) {
+          continue;
+        }
+        count += 1;
+        first ??= { x: (i / 4) % W, y: Math.floor(i / 4 / W) };
+      }
+      assert.strictEqual(
+        count,
+        0,
+        `scrollX ${x}: the blitted frame differs from a full repaint in ` +
+          `${count} pixels, first at ${JSON.stringify(first)}; damage ` +
+          JSON.stringify(rects),
+      );
+    };
+    // from 430, content moving left in steps of 1 to 5 pixels and two of
+    // about 200, onto the three scroll positions that put a title's edge on
+    // the viewport's — 416, 216 and 16 — and one step on from each
+    for (const x of [430, 429, 427, 424, 419, 416, 415, 216, 211, 16, 13]) {
+      await scrollTo(x);
+    }
+    assert.deepStrictEqual(
+      landings,
+      [415, 211, 13],
+      'where a title’s box ended on the left edge of a blitted strip',
+    );
+  } finally {
+    for (const x11Root of x11Roots) await x11Root.unmount();
+    for (const app of apps) await app.close();
+  }
+});


### PR DESCRIPTION
A bounded repaint culls every subtree whose bounds miss the pass's rect, and `_outsideDamage` tested them exactly. A claim is grown by `DAMAGE_SLOP` before it gets there, but a rect that never was a claim, the strip a scroll blit exposes or a scrollbar's repair, is exact. Antialiasing puts a glyph's ink a fraction of a pixel past its box, so text whose box ended where such a rect began was culled, and the rect's first column kept what was under the text where a full repaint has the ink.

Found on 2026-09-10 while verifying #524 on top of #523: `examples/schedule.jsx` under `direction: 'rtl'` at scale 2 in a 640x400 window, blitting, against a twin with `scrollRegion` removed. A 2px step onto scrollX 83, scrollY 150 left pixel 3,578 at 255 where the full repaint has 253. The frame's damage rect `{x: 3, y: 113, w: 16, h: 672}` covered it, and the deepest node there, `talk-thu-studio-5`, has a title whose box ends exactly at x 3.

### Fix

`_outsideDamage` counts a subtree a pixel short of the rect as reaching into it, the allowance `_childrenCanOverflow` already makes for the same reason. The pass is clipped to its rect, so painting such a node lets its spill land and nothing else. `rectsOverlap` takes an optional margin for it, and gets back the doc comment that had drifted onto `cornerSquaresOverlap`.

`docs/extending.md` told an element that culls a scene of its own to cull against `paintDamage` exactly as core does. Its two samples now allow the same pixel, and so does the type's doc comment.

### Test

`test/scroll-blit.test.js`: a right-to-left pane of titles at scale 2, mounted twice on two in-process servers, one window blitting and one with `scrollRegion` removed. Eleven scroll positions, the content moving left in steps of 1, 2, 3, 5 and about 200, every frame read back from both windows and compared. Three of the positions land a title's box on the left edge of the strip the blit exposed, and the test asserts that premise as well: the frame blitted, the strip is in its damage, and the full repaint inks the column past the box. A scene that stopped exercising the edge fails instead of passing.

Mutation check, the new test against the old cull:

- margin dropped from `_outsideDamage` only: fails at scrollX 415, one pixel at 659,38, in the strip `{x: 659, y: 0, w: 1, h: 180}`
- origin/master's `src` with each frame logged instead of asserted: exactly the three landings differ, one pixel each, at scrollX 415, 211 and 13, each in its strip's first column. The other eight frames match.

### Benches

`npm run bench:touched`:

- protocol: no regressions against the baseline. The one scenario that read higher in that run, the 500-row scroll at 231 requests against a baseline of 224, reads 226 to 238 on master and 233 to 237 on this branch over three alternating runs each: jitter, with 81 composites in every run.
- pixels: unchanged, and "partial repaint vs full" identical
- presenters: one rule failed in that run, `hovertree/promoted` full-window frames, where a single full frame fails a maximum of 0%. Run again alone, alternating, all seven hovertree rules held on master and on this branch, twice each. This change decides only which nodes a bounded pass paints, never whether a frame is full, and the macOS CI job is the judge.

### Not fixed here

The same sweep of the schedule finds a second one-pixel mismatch that this does not fix. `_offscreen` culls a node whose box ends exactly at the window's edge or a clipping ancestor's, with the same exact test, so a title whose box ends at the pane's left edge loses its spill in every pass, full repaints included. When the content then moves right, the blit carries that column into the band, and a full repaint of the new frame inks it: pixel 2,648 at scrollX 82, scrollY 80, 255 against 253. Giving `_offscreen` the same allowance is a different trade. It runs on every frame, full ones included, and `src/anchor.js` asks it about carets, so it is left for a change of its own. The new test keeps clear of that configuration and says why.

A glyph whose ink overhangs its advance by more than a pixel is out of reach of a one-pixel allowance: KaTeX Main's `f`, right-aligned at scale 2, inks two device pixels past its box. `_childrenCanOverflow`'s inset has the same limit.

### Local runs

- the ten paint and scroll test files: 178 of 178 pass
- `npm test`: 2235 of 2241 pass. The six failures are test/appearance.test.js's desktop-appearance ladder, which this Mac's own appearance answers; untouched master fails the same six here, and CI runs Linux.
- `npm run lint`, `npm run format:check`: clean
