### PR TITLE
fix(scroll): hold a scrollTo made before the pane's first layout

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -1140,6 +1140,20 @@ node fully visible, and is safe to call from an effect right after that
 node mounts: the request is resolved on the next layout pass, when the
 node actually has geometry.
 
+So is a `scrollTo` made before the pane's first layout. Until a pass has
+measured the content there is nothing to clamp the offset to, so it is held,
+and that pass applies it, clamped to what it found, before the frame paints:
+restoring a list's position from a mount-time `useLayoutEffect` shows the
+list at that position in its first frame. A `scrollBy` after it moves on
+from the held offset. Once the pass is over, after that frame, `onScroll`
+reports where the pane landed, if it moved; until then `scrollX`/`scrollY`
+keep their old values. On a pane that has been laid out, `scrollTo` moves
+the offset and
+fires `onScroll` inside the call, clamped to the content as the last layout
+measured it — so a `scrollTo` past the end of rows added in the same commit
+stops at the old end, and `scrollIntoView` on the new last row is what
+reaches it.
+
 ### On a `<window>`
 
 `<window style={{ overflow: 'scroll' }}>` scrolls the window's own content,

--- a/docs/react-features.md
+++ b/docs/react-features.md
@@ -72,13 +72,26 @@ So an adjustment made in `useEffect` flickers. This is not a timing race you
 can get lucky with — updates from a layout effect are folded into the frame
 being prepared, and updates from a passive effect are not.
 
+That holds for a correction computed from React state. One computed from
+**geometry** is a layout behind: a layout effect runs after the commit and
+before the layout pass, so `abs` there is still the previous frame's rect
+(zeros, on mount), and anything measured from it describes the frame
+before. For a size, let the element report it with `onLayout`
+([below](#measuring-a-node)); for a style that depends on one, write a
+container query ([styling.md](styling.md#container-queries)), which the
+pass answers in the same frame. `scrollIntoView`, and a `scrollTo` on a pane
+that has not been laid out yet, measure nothing when you call them — the
+pass resolves them — so they are safe here
+([elements.md](elements.md#scrolling)).
+
 The same boundary is why an event handler feels instant: react-x11 lands the
 React update caused by a click or a keystroke **before** the frame goes out,
 so the response and the default action paint together rather than a frame
 apart.
 
 ```jsx
-// good — the corrected size is in the first frame the user sees
+// good — `tooTall` and `fits` are React state, so the corrected rows paint
+// in the same frame as the state that asked for them
 useLayoutEffect(() => {
   if (tooTall) setRows(fits);
 }, [tooTall, fits]);

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -6704,6 +6704,7 @@ export const Scrollable = (Base) =>
       this._scrollMeasureDirty = true;
       if (this.isScroller()) return;
       this._scrollIntoViewTarget = null;
+      this._scrollToTarget = null;
       this._childOrigin = null;
       if (this.scrollX === 0 && this.scrollY === 0) return;
       this.scrollX = 0;
@@ -6771,10 +6772,16 @@ export const Scrollable = (Base) =>
         this._scrollMeasureDirty = false;
         this.yoga.markLayoutSeen();
       }
+      // A scrollTo held for this pass lands first, so a node asked into view
+      // in the same frame is brought in from where that scroll put the pane:
+      // the order the two have on a laid-out pane, where scrollTo applies at
+      // once and scrollIntoView waits for the pass.
+      const heldFrom = this._resolveScrollTo();
       this._resolveScrollIntoView();
       this.scrollY = clampScroll(this.scrollY, this._maxScroll('y'));
       this.scrollX = clampScroll(this.scrollX, this._maxScroll('x'));
       this._reportViewport();
+      if (heldFrom) this._reportScrollTo(heldFrom);
       // `scrollX` is how far the content has moved **from its start**, which
       // is the right-hand edge in RTL — so scrolling shifts the children the
       // other way. Keeping it a distance rather than a coordinate is what
@@ -7003,6 +7010,26 @@ export const Scrollable = (Base) =>
     }
 
     _scrollToDevice(want) {
+      // A pane no layout pass has placed as a scroller has no extent to
+      // clamp against: on mount `contentHeight` and `abs` are still the
+      // zeros they were built with, so the clamp below would turn any offset
+      // into 0 and drop the request — which is what restoring a list's
+      // position from a mount-time effect runs into, and so does a box that
+      // starts scrolling in the same commit. The offset is held instead, the
+      // way `scrollIntoView` holds its node, and `_resolveScrollTo` applies
+      // it against what the pass measures. `_childOrigin` is the witness:
+      // the first pass that places this pane's children as a scroller
+      // writes it, and a style that stops scrolling clears it. Nothing is
+      // armed for the blit, since that pass is a layout change rather than a
+      // pure scroll, and `onScroll` waits for the pass as well.
+      if (this._childOrigin == null && this.isScroller()) {
+        this._scrollToTarget = {
+          x: want.x ?? this._scrollToTarget?.x,
+          y: want.y ?? this._scrollToTarget?.y,
+        };
+        this._invalidateLayout('scroll');
+        return;
+      }
       const next = {
         x:
           want.x == null
@@ -7059,18 +7086,7 @@ export const Scrollable = (Base) =>
       }
       this.scrollX = next.x;
       this.scrollY = next.y;
-      // the handler is application code: logical, like every payload —
-      // finder.jsx's row virtualisation divides scrollY by a row height it
-      // wrote in a style, and those must be the same unit
-      const s = this.scale;
-      this.props.onScroll?.({
-        scrollX: next.x / s,
-        scrollY: next.y / s,
-        contentWidth: this.contentWidth / s,
-        contentHeight: this.contentHeight / s,
-        viewportWidth: this.abs.width / s,
-        viewportHeight: this.abs.height / s,
-      });
+      this.props.onScroll?.(this._scrollEvent());
       // A scroll reflows this viewport's contents and nothing else, and the
       // viewport clips them, so the damage is this node's own rect. It is a
       // layout change all the same — children's absolute positions move — hence
@@ -7081,6 +7097,60 @@ export const Scrollable = (Base) =>
       // exposed strip and blits the rest — see WindowNode.)
       this.root?.invalidate(true, this, 'scroll');
       if (root) root._scrollClaim = null;
+    }
+
+    /**
+     * Apply the offset a `scrollTo` asked for before this pane's first
+     * layout (see `_scrollToDevice`), clamped to the extent the pass has
+     * just measured. Returns the offsets it moved the pane from, for the
+     * `onScroll` that follows the pass, or null when nothing was held.
+     */
+    _resolveScrollTo() {
+      const target = this._scrollToTarget;
+      if (!target) return null;
+      this._scrollToTarget = null;
+      const from = { x: this.scrollX, y: this.scrollY };
+      if (target.x != null) {
+        this.scrollX = clampScroll(target.x, this._maxScroll('x'));
+      }
+      if (target.y != null) {
+        this.scrollY = clampScroll(target.y, this._maxScroll('y'));
+      }
+      return from;
+    }
+
+    /**
+     * `onScroll` for a held scroll the pass has resolved, when the pass
+     * left the pane somewhere other than `from`. Deferred like `onViewport`,
+     * since a setState from the handler would re-enter the pass, so it
+     * arrives after the frame that first shows the new offset. The payload
+     * is read on delivery, not now: a wheel landing in between has already
+     * reported where it went, and a payload from before it would leave the
+     * handler behind the pane.
+     */
+    _reportScrollTo(from) {
+      if (from.x === this.scrollX && from.y === this.scrollY) return;
+      setImmediate(() => {
+        const notify = this.props.onScroll;
+        if (this.destroyed || !notify) return;
+        callHandler(this, 'onScroll', notify, this._scrollEvent());
+      });
+    }
+
+    /** `onScroll`'s payload, for the offsets in force. The handler is
+     * application code, so it is logical like every payload: finder.jsx's
+     * row virtualisation divides scrollY by a row height it wrote in a
+     * style, and those must be the same unit. */
+    _scrollEvent() {
+      const s = this.scale;
+      return {
+        scrollX: this.scrollX / s,
+        scrollY: this.scrollY / s,
+        contentWidth: this.contentWidth / s,
+        contentHeight: this.contentHeight / s,
+        viewportWidth: this.abs.width / s,
+        viewportHeight: this.abs.height / s,
+      };
     }
 
     /**
@@ -7104,10 +7174,10 @@ export const Scrollable = (Base) =>
     scrollBy(by) {
       const s = this.scale;
       if (typeof by === 'number')
-        return this._scrollToDevice({ y: this.scrollY + by * s });
+        return this._scrollToDevice({ y: this._scrollBase('y') + by * s });
       this._scrollToDevice({
-        x: by?.x == null ? undefined : this.scrollX + by.x * s,
-        y: by?.y == null ? undefined : this.scrollY + by.y * s,
+        x: by?.x == null ? undefined : this._scrollBase('x') + by.x * s,
+        y: by?.y == null ? undefined : this._scrollBase('y') + by.y * s,
       });
     }
 
@@ -7115,9 +7185,18 @@ export const Scrollable = (Base) =>
      * is what keeps the scroll blit on the pixel grid at any scale. */
     _scrollByDevice(dx, dy) {
       this._scrollToDevice({
-        x: dx ? this.scrollX + dx : undefined,
-        y: dy ? this.scrollY + dy : undefined,
+        x: dx ? this._scrollBase('x') + dx : undefined,
+        y: dy ? this._scrollBase('y') + dy : undefined,
       });
+    }
+
+    /** Where a relative scroll starts on one axis: the offset in force, or
+     * the one a `scrollTo` is holding for the first layout, so a `scrollBy`
+     * after it moves on from there, as it would on a laid-out pane. */
+    _scrollBase(axis) {
+      const held = this._scrollToTarget?.[axis];
+      if (held != null) return held;
+      return axis === 'x' ? this.scrollX : this.scrollY;
     }
 
     /**

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -649,6 +649,11 @@ export interface BoxProps
 
 /** What `overflow: 'scroll'` adds, on a `<box>` or a `<window>`. */
 export interface ScrollProps {
+  /**
+   * The offsets moved: the wheel, the keys, a bar, `scrollTo`/`scrollBy`.
+   * A `scrollTo` held for the pane's first layout reports once that layout
+   * has applied it, after the frame that shows it.
+   */
   onScroll?: (ev: ScrollEvent) => void;
   /** Fired from layout, so it arrives for a list nobody has scrolled yet. */
   onViewport?: (ev: ViewportEvent) => void;

--- a/src/types/nodes.d.ts
+++ b/src/types/nodes.d.ts
@@ -123,7 +123,13 @@ export interface ScrollableNode extends DrawnNode {
   readonly scrollY: number;
   readonly contentWidth: number;
   readonly contentHeight: number;
-  /** A number scrolls the vertical axis; an object moves either or both. */
+  /**
+   * A number scrolls the vertical axis; an object moves either or both,
+   * clamped to the content. Made before the pane's first layout, when there
+   * is no content to clamp to yet, the offset is held and that layout
+   * applies it — so a mount-time effect can restore a position — and
+   * `onScroll` reports it once it has.
+   */
   scrollTo(to: number | ScrollTarget): void;
   scrollBy(by: number | ScrollTarget): void;
   /**

--- a/test/scroll-before-layout.test.js
+++ b/test/scroll-before-layout.test.js
@@ -1,0 +1,354 @@
+// A `scrollTo` made before a scroll pane's first layout pass. There is no
+// extent to clamp against yet (`contentHeight` and `abs` are still zeros),
+// so the offset is held and that pass applies it, clamped to what it
+// measured, the way `scrollIntoView` resolves its node. Restoring a list's
+// position from a mount-time effect is the case this is for; the clamp used
+// to turn it into 0. A pane that has been laid out keeps the immediate path:
+// the offset moves, `onScroll` fires and the blit arms inside the call.
+//
+// Production scheduling throughout (createMockApp + createRoot, setImmediate
+// ticks, no act), because what is asserted is which frame shows what.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React, { useLayoutEffect, useState } from 'react';
+import { createRoot } from '../src/index.js';
+import { hooks } from '../src/trace-registry.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+// the commit, the frame it schedules, and the reports deferred past it
+const settle = async () => {
+  for (let i = 0; i < 6; i++) await tick();
+};
+const COLORS = ['#ff0000', '#00ff00', '#0000ff'];
+
+/**
+ * Mount one scroll pane and run `effect(pane, cells)` from a mount-time
+ * `useLayoutEffect`, before the pane has been laid out. The defaults are the
+ * repro: a 100px pane over three 80px rows, 240 of content, so the furthest
+ * it scrolls is 140.
+ *
+ * `frames` is every frame painted during the mount, as the pane and its
+ * third cell stood right after it (the tracer's `frame` hook), with that
+ * frame's fills; `scrolls` is every `onScroll`, with how many frames had
+ * painted when it arrived.
+ */
+async function mount({
+  effect = () => {},
+  size = { width: 200, height: 100 },
+  pane = { height: 100 },
+  cell = (i) => ({ height: 80, flexShrink: 0, backgroundColor: COLORS[i] }),
+  count = 3,
+} = {}) {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const ref = React.createRef();
+  const cells = Array.from({ length: count }, () => React.createRef());
+  const frames = [];
+  const scrolls = [];
+  function Pane() {
+    useLayoutEffect(() => {
+      effect(
+        ref.current,
+        cells.map((c) => c.current),
+      );
+    }, []);
+    return h(
+      'box',
+      {
+        ref,
+        style: { overflow: 'scroll', ...pane },
+        onScroll: (ev) => scrolls.push({ ev, frames: frames.length }),
+      },
+      ...cells.map((c, i) => h('box', { key: i, ref: c, style: cell(i) })),
+    );
+  }
+  const outer = hooks.frame;
+  hooks.frame = () => {
+    const third = cells[2].current.abs;
+    frames.push({
+      scrollX: ref.current.scrollX,
+      scrollY: ref.current.scrollY,
+      third: { x: third.x, y: third.y },
+      fills: app.windows[0].ctx.ops
+        .splice(0)
+        .filter(([op]) => op === 'fillRect'),
+    });
+  };
+  try {
+    x11Root.render(h('window', size, h(Pane)));
+    await settle();
+  } finally {
+    hooks.frame = outer;
+  }
+  const wnd = app.windows[0];
+  return {
+    x11Root,
+    wnd,
+    root: wnd._reactX11Node,
+    pane: ref.current,
+    cells,
+    frames,
+    scrolls,
+  };
+}
+
+test('a scrollTo from a mount-time layout effect is in the first painted frame', async () => {
+  const { x11Root, pane, frames } = await mount({
+    effect: (p) => p.scrollTo(140),
+  });
+  const [first] = frames;
+  assert.ok(first, 'the window painted');
+  assert.strictEqual(first.scrollY, 140, 'the first frame is already scrolled');
+  assert.strictEqual(
+    first.third.y,
+    20,
+    'the third row is laid out at 160 - 140',
+  );
+  assert.ok(
+    first.fills.some(([, , y, , , color]) => y === 20 && color === COLORS[2]),
+    `and painted there: ${JSON.stringify(first.fills)}`,
+  );
+  assert.strictEqual(pane.scrollY, 140, 'where it stays');
+  await x11Root.unmount();
+});
+
+test('a held target past the content clamps to the furthest the pane goes', async () => {
+  const { x11Root, frames } = await mount({
+    effect: (p) => p.scrollTo(1000),
+  });
+  assert.strictEqual(frames[0].scrollY, 140, '240 of content in a 100px pane');
+  await x11Root.unmount();
+});
+
+test('onScroll reports a held scroll once it lands, after the frame that shows it', async () => {
+  const { x11Root, scrolls } = await mount({
+    effect: (p) => p.scrollTo(1000),
+  });
+  assert.strictEqual(scrolls.length, 1, 'once');
+  assert.deepStrictEqual(
+    scrolls[0].ev,
+    {
+      scrollX: 0,
+      scrollY: 140,
+      contentWidth: 200,
+      contentHeight: 240,
+      viewportWidth: 200,
+      viewportHeight: 100,
+    },
+    'with the clamped offset and the sizes the pass measured',
+  );
+  assert.ok(
+    scrolls[0].frames >= 1,
+    'deferred past the pass, so it arrives after the frame it painted',
+  );
+  await x11Root.unmount();
+
+  // the last request wins, and this one leaves the pane where it started:
+  // nothing moved, so nothing is reported, as for a scrollTo to the offset
+  // a laid-out pane is already at
+  const still = await mount({
+    effect: (p) => {
+      p.scrollTo(140);
+      p.scrollTo(0);
+    },
+  });
+  assert.strictEqual(still.frames[0].scrollY, 0);
+  assert.deepStrictEqual(still.scrolls, []);
+  await still.x11Root.unmount();
+});
+
+test('a scrollBy after a held scrollTo moves on from the held offset', async () => {
+  const { x11Root, frames } = await mount({
+    effect: (p) => {
+      p.scrollTo(140);
+      p.scrollBy(-40);
+    },
+  });
+  assert.strictEqual(frames[0].scrollY, 100);
+  await x11Root.unmount();
+});
+
+test('a held scrollTo lands before a scrollIntoView made in the same frame, as on a laid-out pane', async () => {
+  // From 140 the second row (80 to 160) is cut off at the top, so bringing
+  // it into view scrolls back to its top edge, 80. Resolved in the other
+  // order the pane would end at 140.
+  const held = await mount({
+    effect: (p, cells) => {
+      p.scrollTo(140);
+      p.scrollIntoView(cells[1]);
+    },
+  });
+  assert.strictEqual(held.frames[0].scrollY, 80);
+  await held.x11Root.unmount();
+
+  const laidOut = await mount();
+  laidOut.pane.scrollTo(140);
+  laidOut.pane.scrollIntoView(laidOut.cells[1].current);
+  await settle();
+  assert.strictEqual(
+    laidOut.pane.scrollY,
+    80,
+    'the answer a laid-out pane gives',
+  );
+  await laidOut.x11Root.unmount();
+});
+
+for (const direction of ['ltr', 'rtl']) {
+  test(`a held scrollTo lands on both axes, and clamps on both (${direction})`, async () => {
+    // Three 120x150 cells in a row, in a 200x100 pane: 360x150 of content,
+    // 160 to scroll across and 50 down. `scrollX` counts from the start
+    // edge, the right-hand one in RTL, where yoga lays the row out leftwards
+    // (the third cell at -160) and a growing offset carries it right.
+    const rtl = direction === 'rtl';
+    const thirdAt = (scrollX) => (rtl ? -160 + scrollX : 240 - scrollX);
+    for (const [want, x, y] of [
+      [{ x: 100, y: 30 }, 100, 30],
+      [{ x: 1000, y: 1000 }, 160, 50],
+    ]) {
+      const { x11Root, frames } = await mount({
+        // one axis per call: the second leaves the first's held axis alone,
+        // as it would the offset of a laid-out pane
+        effect: (p) => {
+          p.scrollTo({ x: want.x });
+          p.scrollTo(want.y);
+        },
+        pane: { height: 100, flexDirection: 'row', direction },
+        cell: () => ({ width: 120, height: 150, flexShrink: 0 }),
+      });
+      const [first] = frames;
+      assert.deepStrictEqual(
+        { scrollX: first.scrollX, scrollY: first.scrollY, third: first.third },
+        { scrollX: x, scrollY: y, third: { x: thirdAt(x), y: -y } },
+        `scrollTo({ x: ${want.x} }), then scrollTo(${want.y})`,
+      );
+      await x11Root.unmount();
+    }
+  });
+}
+
+// A 100px box over three 80px rows whose overflow the test drives, for the
+// held request's life across a style that starts or stops scrolling.
+const rows = () =>
+  Array.from({ length: 3 }, (_, i) =>
+    h('box', { key: i, style: { height: 80, flexShrink: 0 } }),
+  );
+
+async function mountToggle(Pane) {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const render = async (props) => {
+    x11Root.render(h('window', { width: 200, height: 100 }, h(Pane, props)));
+    await settle();
+  };
+  return { x11Root, render };
+}
+
+test('a box that starts scrolling in the same commit holds its scrollTo too', async () => {
+  // laid out already, but never as a scroller, so no extent was measured
+  const ref = React.createRef();
+  function Pane({ scroll }) {
+    useLayoutEffect(() => {
+      if (scroll) ref.current.scrollTo(140);
+    }, [scroll]);
+    return h(
+      'box',
+      { ref, style: { overflow: scroll ? 'scroll' : 'hidden', height: 100 } },
+      ...rows(),
+    );
+  }
+  const { x11Root, render } = await mountToggle(Pane);
+  await render({ scroll: false });
+  await render({ scroll: true });
+  assert.strictEqual(ref.current.scrollY, 140);
+  await x11Root.unmount();
+});
+
+test('a scrollTo on a box that does not scroll is not held for when it does', async () => {
+  // everything scrolling is inert until the style says scroll
+  const ref = React.createRef();
+  function Pane({ scroll }) {
+    useLayoutEffect(() => {
+      ref.current.scrollTo(140);
+    }, []);
+    return h(
+      'box',
+      { ref, style: { overflow: scroll ? 'scroll' : 'hidden', height: 100 } },
+      ...rows(),
+    );
+  }
+  const { x11Root, render } = await mountToggle(Pane);
+  await render({ scroll: false });
+  await render({ scroll: true });
+  assert.strictEqual(ref.current.scrollY, 0);
+  await x11Root.unmount();
+});
+
+test('a held scrollTo goes with the scrolling when the box stops first', async () => {
+  // a box that stops scrolling drops its offset, as in CSS, and one it was
+  // still holding for the pass goes too, rather than landing whenever the
+  // box next scrolls
+  const ref = React.createRef();
+  function Pane({ again }) {
+    const [scroll, setScroll] = useState(true);
+    useLayoutEffect(() => {
+      ref.current.scrollTo(140);
+      setScroll(false);
+    }, []);
+    return h(
+      'box',
+      {
+        ref,
+        style: { overflow: scroll || again ? 'scroll' : 'hidden', height: 100 },
+      },
+      ...rows(),
+    );
+  }
+  const { x11Root, render } = await mountToggle(Pane);
+  await render({ again: false });
+  await render({ again: true });
+  assert.strictEqual(ref.current.scrollY, 0);
+  await x11Root.unmount();
+});
+
+test('a scrollTo on a laid-out pane still moves, reports and arms the blit inside the call', async () => {
+  // big enough for the blit's area gate: a 400x400 pane over 20 rows of 40
+  const { x11Root, wnd, root, pane, scrolls } = await mount({
+    size: { width: 400, height: 400 },
+    pane: { flexGrow: 1 },
+    cell: () => ({ height: 40, flexShrink: 0 }),
+    count: 20,
+  });
+  wnd.calls.length = 0;
+  pane.scrollTo(48);
+  assert.strictEqual(pane.scrollY, 48, 'moved at once');
+  assert.deepStrictEqual(
+    scrolls.map((s) => s.ev),
+    [
+      {
+        scrollX: 0,
+        scrollY: 48,
+        contentWidth: 400,
+        contentHeight: 800,
+        viewportWidth: 400,
+        viewportHeight: 400,
+      },
+    ],
+    'reported at once',
+  );
+  assert.deepStrictEqual(
+    pane._pendingBlitFrom,
+    { x: 0, y: 0 },
+    'armed from the offsets on screen',
+  );
+  assert.deepStrictEqual(pane._blitLedger, [], 'with its ledger open');
+  assert.ok(root._pendingScrolls.has(pane), 'and queued for the frame');
+  await tick();
+  assert.deepStrictEqual(
+    wnd.calls.filter(([name]) => name === 'scrollRegion'),
+    [['scrollRegion', { x: 0, y: 0, width: 400, height: 400 }, 0, -48]],
+    'which blits',
+  );
+  await x11Root.unmount();
+});


### PR DESCRIPTION
A `scrollTo` on a scroll pane that no layout pass has placed yet is now held and resolved by that pass, the way `scrollIntoView` already is. Before this it clamped against `contentHeight` and `abs` from the last layout, both still zero before the first one, so the offset became 0 and the request was lost. Restoring a list's position from a mount-time `useLayoutEffect` is the common case.

**Repro**, mock backend, production scheduling: a 100px `overflow: 'scroll'` pane over three 80px rows, and a mount-time layout effect calling `scrollTo` with 140. On master the pane stays at scrollY 0. With this branch it paints at 140 in its first frame. The same effect calling `scrollIntoView` on the third row already ended at 140.

| origin/master 852356d | this branch |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/7c3ae8e9-abd6-4567-9d94-21ad8d45946b) | ![after](https://github.com/user-attachments/assets/e5d86604-7fc3-4d88-90d9-47e2b07cb2e2) |

Each shot is rendered headless into node-x11's in-process X server by its own tree's source: twelve rows, with a layout effect restoring offset 170.

### What changed

- `_scrollToDevice` holds the offset in `_scrollToTarget` when the pane has never been placed as a scroller. `_childOrigin == null` is the witness: the first scroller pass writes it, and a style that stops scrolling clears it. The hold asks for a layout pass, as `scrollIntoView` does. It also covers a box that starts scrolling in the same commit as its `scrollTo`, which lost the request the same way.
- `_absolutizeChildren` applies it in `_resolveScrollTo` after `measureScrollContent`, clamped to the fresh extent, before `scrollIntoView` resolves. That is the order the two have on a laid-out pane.
- A `scrollBy` after a held `scrollTo` moves on from the held offset. `scrollX` and `scrollY` keep their old values until the pass, so they are never out of range.
- **A pane that has been laid out keeps the immediate path.** The offset moves, `onScroll` fires and the blit arms inside the call. The only edit on that path is that the payload now comes from a shared `_scrollEvent`, with the same values.

### What `onScroll` reports for a held scroll

It fires once the pass has resolved the scroll, deferred past the pass like `onViewport`, since a setState from the handler would re-enter it. So it arrives just after the first frame that shows the new offset, with the clamped offset and the sizes that pass measured. A held scroll that leaves the pane where it was reports nothing. The payload is read on delivery, so a wheel event landing in between cannot be overtaken by an older report. This is documented in docs/elements.md and in the `scrollTo` and `onScroll` JSDoc.

### RTL

`scrollX` stays a distance from the start edge, so held horizontal offsets clamp and place the same way in both directions. The tests run both axes under `ltr` and `rtl`, including a target past the content.

### Tests

test/scroll-before-layout.test.js has 11 tests, all with production scheduling, recording painted frames through the tracer's `hooks.frame` slot:

- A mount-time `scrollTo` with 140 is at 140 in the first painted frame, with the third row laid out and filled at y 20. A target of 1000 clamps to 140.
- `onScroll` arrives once, after that frame, with the clamped offset and fresh sizes, and not at all when the pane did not move.
- `scrollBy` composes with a held `scrollTo`, and a held `scrollTo` resolves before a `scrollIntoView` from the same frame, matching a laid-out pane.
- Both axes in `ltr` and `rtl`. A box that starts scrolling in the same commit holds its request, a box that does not scroll holds nothing, and a held request goes when the box stops scrolling.
- The fence: `scrollTo` with 48 on a laid-out 400px pane moves and reports inside the call, arms `_pendingBlitFrom` at the old offsets with an empty `_blitLedger`, joins `_pendingScrolls`, and blits by -48.

**Mutation check.** Each mutant is an origin/master archive with this change laid over it and one decision undone:

| mutant | result |
| --- | --- |
| revert the fix | 8 of 11 fail; the 3 fences for unchanged behaviour pass |
| hold on every scroller, laid out or not | the blit fence fails |
| `scrollBy` ignores the held offset | the `scrollBy` test fails |
| resolve `scrollIntoView` first | the ordering test fails |
| report when nothing moved | the `onScroll` test fails |
| report inside the pass | the `onScroll` test fails |
| a style that stops scrolling keeps the target | its test fails |
| hold on a box that does not scroll | its test fails |
| never apply the held target | 8 fail |
| the first request wins | 2 fail |
| drop an axis a later call omits | both direction tests fail |
| no layout request from the hold | survives: every route into the hold already has a pass pending |
| no clamp before `scrollIntoView` | survives: the clamp after it gives the same result |

Both survivors are kept on purpose: the hold should not depend on some other change having scheduled its pass, and `scrollIntoView` should start from an offset the pane can actually have.

### Docs

- docs/react-features.md, "Effects, and the paint boundary": the `useLayoutEffect` row holds for corrections computed from React state, not from geometry. `abs` in a layout effect is the previous frame's, zeros on mount, so a measurement there is one layout behind. It points at `onLayout` and container queries.
- docs/elements.md, scrolling: a `scrollTo` made before the first layout is resolved by that layout. It also states the limit this PR leaves alone: on a laid-out pane `scrollTo` clamps against the last layout, so scrolling past rows added in the same commit stops at the old end, and `scrollIntoView` on the new last row reaches it.

### Checks

`npm test`: 2254 tests, 2248 pass. The 6 failures are the known macOS-only ones in test/appearance.test.js. `npm run lint`, `npm run format:check` and `npm run typecheck` pass.

### Not in this PR

- A `scrollTo` on a laid-out pane still clamps against the previous layout's extent, as described above. A fix has to work with the blit bookkeeping, so it is being looked at separately.
- `scrollIntoView` and the layout clamp still move the offset without firing `onScroll`. That is being fixed separately too, building on `_reportScrollTo` and `_scrollEvent` from here.

