### PR TITLE
fix(scroll): onScroll reports the offsets a layout pass moves

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -1154,6 +1154,18 @@ measured it — so a `scrollTo` past the end of rows added in the same commit
 stops at the old end, and `scrollIntoView` on the new last row is what
 reaches it.
 
+`onScroll` fires for **every** move of the offsets, not only the ones a call
+made. The wheel, the keys, a bar and `scrollTo`/`scrollBy` on a laid-out
+pane report inside the call. Layout moves the offsets on its own, and a
+browser fires `scroll` for each: the held `scrollTo` above landing, a
+`scrollIntoView` resolving (focus landing on a row below the fold is one),
+and the clamp that pulls the offset back when the content shrinks or the
+viewport grows under it, as when rows are filtered out of a list scrolled
+to its end. Those report once the pass is over, like `onViewport`: after
+the frame that shows the new offset, and only if the pass moved it. The
+payload is read when the report is delivered, so a handler that mirrors the
+offset into state, as `Table` does, ends where the pane did.
+
 ### On a `<window>`
 
 `<window style={{ overflow: 'scroll' }}>` scrolls the window's own content,

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -6772,16 +6772,23 @@ export const Scrollable = (Base) =>
         this._scrollMeasureDirty = false;
         this.yoga.markLayoutSeen();
       }
+      // The moves layout makes on its own, with nobody's call to report them
+      // from: a `scrollTo` held for this pane's first pass landing, a
+      // `scrollIntoView` resolving against the geometry this pass produced,
+      // and the clamp pulling the offset back when the content shrank, or
+      // the viewport grew, under it. A browser fires `scroll` for each, so
+      // `onScroll` hears of them too, once the pass is over.
+      const from = { x: this.scrollX, y: this.scrollY };
       // A scrollTo held for this pass lands first, so a node asked into view
       // in the same frame is brought in from where that scroll put the pane:
       // the order the two have on a laid-out pane, where scrollTo applies at
       // once and scrollIntoView waits for the pass.
-      const heldFrom = this._resolveScrollTo();
+      this._resolveScrollTo();
       this._resolveScrollIntoView();
       this.scrollY = clampScroll(this.scrollY, this._maxScroll('y'));
       this.scrollX = clampScroll(this.scrollX, this._maxScroll('x'));
       this._reportViewport();
-      if (heldFrom) this._reportScrollTo(heldFrom);
+      this._reportScrollTo(from);
       // `scrollX` is how far the content has moved **from its start**, which
       // is the right-hand edge in RTL — so scrolling shifts the children the
       // other way. Keeping it a distance rather than a coordinate is what
@@ -7102,31 +7109,31 @@ export const Scrollable = (Base) =>
     /**
      * Apply the offset a `scrollTo` asked for before this pane's first
      * layout (see `_scrollToDevice`), clamped to the extent the pass has
-     * just measured. Returns the offsets it moved the pane from, for the
-     * `onScroll` that follows the pass, or null when nothing was held.
+     * just measured. Its `onScroll` is the pass's, like every move layout
+     * makes (see `_absolutizeChildren`).
      */
     _resolveScrollTo() {
       const target = this._scrollToTarget;
-      if (!target) return null;
+      if (!target) return;
       this._scrollToTarget = null;
-      const from = { x: this.scrollX, y: this.scrollY };
       if (target.x != null) {
         this.scrollX = clampScroll(target.x, this._maxScroll('x'));
       }
       if (target.y != null) {
         this.scrollY = clampScroll(target.y, this._maxScroll('y'));
       }
-      return from;
     }
 
     /**
-     * `onScroll` for a held scroll the pass has resolved, when the pass
-     * left the pane somewhere other than `from`. Deferred like `onViewport`,
-     * since a setState from the handler would re-enter the pass, so it
-     * arrives after the frame that first shows the new offset. The payload
-     * is read on delivery, not now: a wheel landing in between has already
-     * reported where it went, and a payload from before it would leave the
-     * handler behind the pane.
+     * `onScroll` for an offset a layout pass moved — a held `scrollTo`
+     * landing, a `scrollIntoView` resolving, or the clamp when the content
+     * shrank or the viewport grew (see `_absolutizeChildren`) — when the
+     * pass left the pane somewhere other than `from`. Deferred like
+     * `onViewport`, since a setState from the handler would re-enter the
+     * pass, so it arrives after the frame that first shows the new offset.
+     * The payload is read on delivery, not now: a wheel landing in between
+     * has already reported where it went, and a payload from before it
+     * would leave the handler behind the pane.
      */
     _reportScrollTo(from) {
       if (from.x === this.scrollX && from.y === this.scrollY) return;
@@ -7276,7 +7283,8 @@ export const Scrollable = (Base) =>
      * only exist after a layout pass, so a caller reacting to a mount (a
      * list widget moving its selection, say) would otherwise measure a node
      * that has no geometry yet. `absolutize` resolves it against freshly
-     * computed yoga positions.
+     * computed yoga positions, and `onScroll` reports the move once that
+     * pass is over (`_reportScrollTo`).
      */
     scrollIntoView(node) {
       if (!node || !this.isScroller()) return;

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -651,9 +651,13 @@ export interface BoxProps
 /** What `overflow: 'scroll'` adds, on a `<box>` or a `<window>`. */
 export interface ScrollProps {
   /**
-   * The offsets moved: the wheel, the keys, a bar, `scrollTo`/`scrollBy`.
-   * A `scrollTo` held for the pane's first layout reports once that layout
-   * has applied it, after the frame that shows it.
+   * The offsets moved, by any route. The wheel, the keys, a bar and
+   * `scrollTo`/`scrollBy` report inside the call. Layout reports once its
+   * pass is over, after the frame that shows the move: a `scrollTo` held
+   * for the pane's first layout landing, a `scrollIntoView` resolving, or
+   * the offset pulled back when the content shrinks or the viewport grows
+   * under it. Each report carries the offsets in force when it is
+   * delivered.
    */
   onScroll?: (ev: ScrollEvent) => void;
   /** Fired from layout, so it arrives for a list nobody has scrolled yet. */

--- a/src/types/nodes.d.ts
+++ b/src/types/nodes.d.ts
@@ -141,7 +141,8 @@ export interface ScrollableNode extends DrawnNode {
   /**
    * Scroll the minimum amount on both axes that makes a descendant fully
    * visible. Safe to call right after that node mounts — the request is
-   * resolved on the next layout pass, when it has geometry.
+   * resolved on the next layout pass, when it has geometry, and `onScroll`
+   * reports the move once that pass is over.
    */
   scrollIntoView(node: DrawnNode): void;
 }

--- a/test/scroll-from-layout.test.js
+++ b/test/scroll-from-layout.test.js
@@ -1,0 +1,389 @@
+// `onScroll` for the offsets a layout pass moves rather than a call:
+// `scrollIntoView` resolving against the geometry the pass produced, and the
+// clamp that pulls an offset back when the content shrinks, or the viewport
+// grows, under it. A browser fires `scroll` for both. Neither happens inside
+// anything the app called, so the report is deferred past the pass, the way
+// `onViewport` and `onLayout` are, and reads its payload when it is
+// delivered. The immediate routes (the wheel, the keys, a bar, `scrollTo`,
+// `scrollBy`) still report inside the call.
+//
+// Production scheduling throughout (createMockApp + createRoot, setImmediate
+// ticks, no act), because what is asserted is which frame shows what, and
+// when the handler hears of it.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import React, { useLayoutEffect } from 'react';
+import { createRoot } from '../src/index.js';
+import { hooks } from '../src/trace-registry.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+// the commit, the frame it schedules, and the reports deferred past it
+const settle = async () => {
+  for (let i = 0; i < 6; i++) await tick();
+};
+
+/**
+ * One scroll pane over `count` rows, in a window. The defaults are the
+ * repro: a 100px pane over three 80px rows, 240 of content, so the furthest
+ * it scrolls is 140. `effect(pane, rows)` runs from a mount-time layout
+ * effect, before the pane has been laid out.
+ *
+ * `frames` is the pane's `scrollY` (device pixels) as each painted frame
+ * left it (the tracer's `frame` hook, which runs after the paint), and
+ * `scrolls` is every `onScroll`, with how many frames had painted when it
+ * arrived and the `tag` of the render whose handler heard it; a render with
+ * `tag: null` has no handler at all. `nextFrame` runs once, right after the
+ * next frame paints: after that frame's layout pass, before anything the
+ * pass deferred. `errors` collects what the handler reporting caught.
+ */
+async function mount(
+  t,
+  {
+    effect,
+    count = 3,
+    size = { width: 200, height: 100 },
+    pane = { height: 100 },
+    row = () => ({ height: 80, flexShrink: 0 }),
+    scale = 1,
+    errors,
+  } = {},
+) {
+  const app = createMockApp();
+  const options = { app };
+  if (scale !== 1) options.scale = scale;
+  if (errors) {
+    options.onUncaughtError = (error, info) =>
+      errors.push(`${info?.handler}: ${error?.message}`);
+  }
+  const x11Root = await createRoot(options);
+  const ref = React.createRef();
+  const rows = [];
+  const m = {
+    x11Root,
+    rows,
+    frames: [],
+    scrolls: [],
+    nextFrame: null,
+    get pane() {
+      return ref.current;
+    },
+    async render(props) {
+      x11Root.render(h('window', size, h(Pane, props)));
+      await settle();
+    },
+  };
+  function Pane({ count, tag }) {
+    useLayoutEffect(() => {
+      effect?.(ref.current, rows);
+    }, []);
+    return h(
+      'box',
+      {
+        ref,
+        style: { overflow: 'scroll', ...pane },
+        onScroll:
+          tag === null
+            ? undefined
+            : (ev) => m.scrolls.push({ ev, frames: m.frames.length, tag }),
+      },
+      ...Array.from({ length: count }, (_, i) =>
+        h('box', {
+          key: i,
+          ref: (node) => {
+            rows[i] = node;
+          },
+          style: row(i),
+        }),
+      ),
+    );
+  }
+  const outer = hooks.frame;
+  hooks.frame = () => {
+    m.frames.push(ref.current?.scrollY);
+    const next = m.nextFrame;
+    m.nextFrame = null;
+    next?.();
+  };
+  t.after(async () => {
+    hooks.frame = outer;
+    await x11Root.unmount();
+  });
+  await m.render({ count });
+  m.wnd = app.windows[0];
+  return m;
+}
+
+for (const scale of [1, 2]) {
+  test(`a scrollIntoView from a mount-time layout effect reports where the pass took the pane (scale ${scale})`, async (t) => {
+    const m = await mount(t, {
+      effect: (pane, rows) => pane.scrollIntoView(rows[2]),
+      scale,
+    });
+    assert.strictEqual(
+      m.pane.scrollY,
+      140 * scale,
+      'the third row brought into view: 240 - 100',
+    );
+    assert.deepStrictEqual(
+      m.scrolls.map((s) => s.ev),
+      [
+        {
+          scrollX: 0,
+          scrollY: 140,
+          contentWidth: 200,
+          contentHeight: 240,
+          viewportWidth: 200,
+          viewportHeight: 100,
+        },
+      ],
+      'once, in logical pixels, with the sizes the pass measured',
+    );
+    assert.strictEqual(m.frames[0], 140 * scale, 'the first frame shows it');
+    assert.ok(
+      m.scrolls[0].frames >= 1,
+      'and the report comes after that frame, not inside the pass',
+    );
+  });
+}
+
+test('a scrollIntoView on a laid-out pane reports once the pass has moved it, and not when it had nowhere to go', async (t) => {
+  const m = await mount(t);
+  assert.deepStrictEqual(m.scrolls, [], 'a mount at the top moved nothing');
+  m.pane.scrollIntoView(m.rows[2]);
+  assert.deepStrictEqual(
+    m.scrolls,
+    [],
+    'the call moves nothing: the pass does',
+  );
+  await settle();
+  assert.strictEqual(m.pane.scrollY, 140);
+  assert.deepStrictEqual(
+    m.scrolls.map((s) => s.ev.scrollY),
+    [140],
+  );
+
+  // already fully in view, so the pass leaves the offset where it is
+  m.pane.scrollIntoView(m.rows[2]);
+  await settle();
+  assert.strictEqual(m.pane.scrollY, 140);
+  assert.strictEqual(m.scrolls.length, 1, 'nothing moved, nothing to report');
+
+  // and back towards the start: the least that shows the first row is its top
+  m.pane.scrollIntoView(m.rows[0]);
+  await settle();
+  assert.deepStrictEqual(
+    m.scrolls.map((s) => s.ev.scrollY),
+    [140, 0],
+  );
+});
+
+for (const direction of ['ltr', 'rtl']) {
+  test(`on the x axis, counted from the start edge (${direction})`, async (t) => {
+    // three 120px cells in a row, in a 200px pane: 360 across, 160 to
+    // scroll, with the third cell's far edge at the content's far end
+    const m = await mount(t, {
+      pane: { height: 100, flexDirection: 'row', direction },
+      row: () => ({ width: 120, flexShrink: 0 }),
+    });
+    m.pane.scrollIntoView(m.rows[2]);
+    await settle();
+    assert.strictEqual(m.pane.scrollX, 160);
+    assert.deepStrictEqual(
+      m.scrolls.map((s) => s.ev),
+      [
+        {
+          scrollX: 160,
+          scrollY: 0,
+          contentWidth: 360,
+          contentHeight: 100,
+          viewportWidth: 200,
+          viewportHeight: 100,
+        },
+      ],
+    );
+  });
+}
+
+test('the clamp reports where it left the pane when the content shrinks under the offset', async (t) => {
+  const m = await mount(t);
+  m.pane.scrollTo(50);
+  assert.deepStrictEqual(
+    m.scrolls.map((s) => s.ev.scrollY),
+    [50],
+    'the scrollTo reported inside the call',
+  );
+
+  // 160 of content: 60 to scroll, still past 50, so the offset stands
+  await m.render({ count: 2 });
+  assert.strictEqual(m.pane.scrollY, 50);
+  assert.strictEqual(
+    m.scrolls.length,
+    1,
+    'the content shrank, but not under the offset',
+  );
+
+  // 80 of content in a 100px pane: nothing left to scroll
+  await m.render({ count: 1 });
+  assert.strictEqual(m.pane.scrollY, 0);
+  assert.deepStrictEqual(
+    m.scrolls.map((s) => s.ev),
+    [
+      {
+        scrollX: 0,
+        scrollY: 50,
+        contentWidth: 200,
+        contentHeight: 240,
+        viewportWidth: 200,
+        viewportHeight: 100,
+      },
+      {
+        scrollX: 0,
+        scrollY: 0,
+        contentWidth: 200,
+        contentHeight: 80,
+        viewportWidth: 200,
+        viewportHeight: 100,
+      },
+    ],
+  );
+});
+
+test('so does the clamp when the viewport grows past what is left below the offset', async (t) => {
+  const m = await mount(t, { pane: { flexGrow: 1 } });
+  m.pane.scrollTo(140);
+  await settle();
+  // a 200px pane over 240 of content goes 40 down at most
+  m.wnd.width = 200;
+  m.wnd.height = 200;
+  m.wnd.emit('resize', { width: 200, height: 200 });
+  await settle();
+  assert.strictEqual(m.pane.scrollY, 40);
+  assert.deepStrictEqual(
+    m.scrolls.map((s) => s.ev),
+    [
+      {
+        scrollX: 0,
+        scrollY: 140,
+        contentWidth: 200,
+        contentHeight: 240,
+        viewportWidth: 200,
+        viewportHeight: 100,
+      },
+      {
+        scrollX: 0,
+        scrollY: 40,
+        contentWidth: 200,
+        contentHeight: 240,
+        viewportWidth: 200,
+        viewportHeight: 200,
+      },
+    ],
+  );
+});
+
+test('the payload is read when the report is delivered, not when the pass queued it', async (t) => {
+  // A scroll landing between the frame and the report (a wheel notch, a
+  // key) has already reported where it went, and a payload from the pass
+  // would leave the handler behind the pane.
+  const m = await mount(t);
+  m.pane.scrollIntoView(m.rows[2]);
+  m.nextFrame = () => m.pane.scrollTo(100);
+  await settle();
+  assert.strictEqual(m.pane.scrollY, 100);
+  assert.deepStrictEqual(
+    m.scrolls.map((s) => s.ev.scrollY),
+    [100, 100],
+    "the scrollTo inside its call, then the pass's report, read on delivery",
+  );
+});
+
+test('the handler that hears it is the one in the props when it is delivered', async (t) => {
+  // React may commit between the pass and the report, and a new handler
+  // takes the report; a pane that has dropped its handler reports nothing
+  const errors = [];
+  const m = await mount(t, { errors });
+  m.pane.scrollIntoView(m.rows[2]);
+  let rendered;
+  // a microtask queued after the frame runs before the next setImmediate
+  m.nextFrame = () =>
+    queueMicrotask(() => {
+      rendered = m.render({ count: 3, tag: 'new' });
+    });
+  await settle();
+  await rendered;
+  assert.deepStrictEqual(
+    m.scrolls.map((s) => [s.tag, s.ev.scrollY]),
+    [['new', 140]],
+  );
+
+  m.pane.scrollIntoView(m.rows[0]);
+  m.nextFrame = () =>
+    queueMicrotask(() => {
+      rendered = m.render({ count: 3, tag: null });
+    });
+  await settle();
+  await rendered;
+  assert.strictEqual(m.pane.scrollY, 0, 'the pass did move it');
+  assert.strictEqual(m.scrolls.length, 1, 'with no handler left, no report');
+  assert.deepStrictEqual(errors, [], 'and nothing called in its place');
+});
+
+test('a pane unmounted before its report is due hears nothing', async (t) => {
+  const m = await mount(t);
+  m.pane.scrollIntoView(m.rows[2]);
+  let unmounted;
+  // after the frame, before the report: a microtask queued there runs
+  // before the next setImmediate does
+  m.nextFrame = () =>
+    queueMicrotask(() => {
+      unmounted = m.x11Root.unmount();
+    });
+  await settle();
+  await unmounted;
+  assert.strictEqual(m.frames.length, 2, 'the pass did run and paint');
+  assert.deepStrictEqual(m.scrolls, []);
+});
+
+test('a scrollTo on a laid-out pane still reports inside the call, and the pass after it adds nothing', async (t) => {
+  // big enough for the blit's area gate: a 400x400 pane over 20 rows of 40
+  const m = await mount(t, {
+    size: { width: 400, height: 400 },
+    pane: { flexGrow: 1 },
+    row: () => ({ height: 40, flexShrink: 0 }),
+    count: 20,
+  });
+  m.wnd.calls.length = 0;
+  m.pane.scrollTo(48);
+  assert.deepStrictEqual(
+    m.scrolls.map((s) => s.ev),
+    [
+      {
+        scrollX: 0,
+        scrollY: 48,
+        contentWidth: 400,
+        contentHeight: 800,
+        viewportWidth: 400,
+        viewportHeight: 400,
+      },
+    ],
+    'reported inside the call',
+  );
+  assert.deepStrictEqual(
+    m.pane._pendingBlitFrom,
+    { x: 0, y: 0 },
+    'armed from the offsets on screen',
+  );
+  await settle();
+  assert.deepStrictEqual(
+    m.wnd.calls.filter(([name]) => name === 'scrollRegion'),
+    [['scrollRegion', { x: 0, y: 0, width: 400, height: 400 }, 0, -48]],
+    'the frame blitted',
+  );
+  assert.strictEqual(
+    m.scrolls.length,
+    1,
+    'and the pass that laid it out moved nothing further',
+  );
+});

--- a/test/table.test.js
+++ b/test/table.test.js
@@ -171,6 +171,55 @@ test('scrolling swaps which rows exist', async () => {
   await x11Root.unmount();
 });
 
+test('rows that shrink under a body scrolled to its end leave no gap', async () => {
+  // The body clamps its offset when the rows it scrolls get fewer, and the
+  // table re-slices from `onScroll`, which reports that clamp (a move made
+  // by layout, not by a call) once the pass is over. Before it did, the
+  // slice stayed where the old offset had put it, and the top of the
+  // viewport was a band with no row in it.
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const render = (n) =>
+    x11Root.render(
+      h(
+        'window',
+        { width: 300, height: 200 },
+        h(Table, { columns: COLUMNS, rows: makeRows(n) }),
+      ),
+    );
+  render(100);
+  await settle();
+  const body = find(root(app), (n) => n.isScroller?.());
+  body.scrollTo({ y: 100 * 24 });
+  await settle();
+  render(95);
+  await settle();
+  await settle();
+
+  const view = body.abs;
+  assert.strictEqual(body.scrollY, 95 * 24 - view.height, 'at the new end');
+  const rows = [];
+  const walk = (n) => {
+    if (n.props.role === 'row') rows.push(n.abs);
+    n.children.forEach((c) => !c.isWindow && walk(c));
+  };
+  walk(body);
+  // the stretches of the viewport, from its top, that no built row covers
+  const gaps = [];
+  let at = view.y;
+  for (const r of rows.sort((a, b) => a.y - b.y)) {
+    if (at >= view.y + view.height) break;
+    if (r.y > at) {
+      gaps.push([at - view.y, Math.min(r.y, view.y + view.height) - view.y]);
+    }
+    at = Math.max(at, r.y + r.height);
+  }
+  if (at < view.y + view.height) gaps.push([at - view.y, view.height]);
+  assert.deepStrictEqual(gaps, [], 'every line of the viewport shows a row');
+
+  await x11Root.unmount();
+});
+
 test('clicking a header sorts, and clicking again reverses', async () => {
   const changes = [];
   const app = await mount({ onSortChange: (next) => changes.push(next) }, 4);


### PR DESCRIPTION
A layout pass moves a scroll pane's offset in two places that no call reports: `scrollIntoView` resolving against the geometry the pass produced, and the clamp that pulls the offset back when the content shrinks, or the viewport grows, under it. Neither fired `onScroll`, so a list that mirrors its offset from `onScroll` fell out of step with its pane. A browser fires `scroll` for both. This follows #528, which added `_reportScrollTo` and `_scrollEvent` for a held `scrollTo`: one report after the pass now covers all three moves.

**Repro**, mock backend, production scheduling: a 100px `overflow: 'scroll'` pane over three 80px rows, and a mount-time layout effect calling `scrollIntoView` on the third row. On master the pane ends at scrollY 140 and `onScroll` never fires. With this branch it fires once, after the first frame that shows 140, with that offset and the sizes the pass measured.

**What it did to `Table`**: scrolled to its end and then given fewer rows, a `Table` built its slice from the offset it had last heard, which the clamp had since moved. Going from 100 rows to 95 left an 8px band at the top of the viewport with no row in it, and going to 20 left the body empty. Both stayed that way until the next wheel event. The TanStack virtual adapter in docs/ecosystem/layout.md feeds `observeElementOffset` from `onScroll` and fell behind the same way.

| origin/master 8b2d1bf | this branch |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/31a36623-a762-41fa-a425-8e6a4bf846e8) | ![after](https://github.com/user-attachments/assets/f4c7a581-0e3d-4b8a-8bbe-b8d83ac5602a) |

Each shot is rendered headless into node-x11's in-process X server by its own tree's source: a `Table` of 100 rows scrolled to its end, then given 20.

### What changed

- `_absolutizeChildren` records the offsets before the pass moves them and hands them to `_reportScrollTo` once the clamp is done. One report covers every move the pass makes: a held `scrollTo` landing, `scrollIntoView` resolving, and the clamp. `_resolveScrollTo` no longer returns where it moved from, since the pass records that for all three.
- `_reportScrollTo` is the one from #528: deferred past the pass like `onViewport`, the handler and the payload read on delivery, nothing for a pane that has been destroyed, and nothing when the pass left the offset where it was.
- **The immediate path is unchanged.** The wheel, the keys, a bar, and `scrollTo` or `scrollBy` on a laid-out pane still move the offset, fire `onScroll` and arm the blit inside the call.
- Not reported: a box that stops scrolling still resets its offset to 0 without an `onScroll`, since it is no longer a scroll pane.

A scroll that lands between the pass and its report, such as a wheel notch, has already reported where it went. The pass's report then reads that same offset on delivery, so the handler hears it twice rather than hearing an older offset last.

### Tests

test/scroll-from-layout.test.js has 11 tests, all with production scheduling, recording painted frames through the tracer's `hooks.frame` slot:

- The repro at scale 1 and 2: one report, after the frame that shows 140, in logical pixels.
- `scrollIntoView` on a laid-out pane: nothing inside the call, one report after the pass, none when the target is already in view, and one on the way back to the start.
- The x axis under `ltr` and `rtl`, with `scrollX` counted from the start edge.
- The clamp when the content shrinks under the offset, silent while the content still reaches past it, and when the viewport grows.
- Delivery: a `scrollTo` landing between the frame and the report makes the report read its offset. A handler swapped in by a commit in between takes the report, and a pane whose handler was removed reports nothing and calls nothing.
- A pane unmounted before its report is due hears nothing.
- The fence: `scrollTo` with 48 on a laid-out 400px pane reports inside the call, arms `_pendingBlitFrom`, blits by -48, and the pass after it adds no second report.

test/table.test.js gains the 100 to 95 case: after the shrink, every line of the body's viewport is under a built row.

**Mutation check.** Each mutant is this commit's tree with one decision undone, run against test/scroll-from-layout.test.js, #528's test/scroll-before-layout.test.js and test/table.test.js:

| mutant | result |
| --- | --- |
| revert to master, #528 alone | 10 of 36 fail: every layout route and the `Table` gap. #528's 11 tests pass, and so do the unmount test and the immediate-path fence, which hold on master too |
| no report after the pass | 11 fail, #528's held-scroll report among them |
| record the offsets after the held `scrollTo` lands | #528's held-scroll report test fails |
| record them after `scrollIntoView` resolves, so only the clamp reports | 8 fail |
| compare before the clamp | both clamp tests and the `Table` gap fail |
| report inside the pass | 6 fail |
| read the payload when queued | the delivery test fails |
| read the handler when queued | the handler test fails |
| no destroyed guard | the unmount test fails |
| no missing-handler guard | the handler test fails, and #528's file fails on the handler error it reports |
| report whether or not anything moved | 11 fail, both fences among them |
| compare y only | both x-axis tests fail |
| compare x only | 9 fail |
| payload not divided by the scale | the scale 2 repro fails |
| defer the immediate path too | 3 fail, both fences among them |
| compare against the offsets on screen while a blit is armed | 4 fail, the fence among them |

All 16 are caught.

### Docs

- docs/elements.md, scrolling: `onScroll` fires for every move of the offsets, which moves report inside the call and which after the pass, and that the payload is read on delivery. It follows #528's paragraph on the held `scrollTo`.
- The `onScroll` JSDoc says the same, and the `scrollIntoView` JSDoc says its move is reported once the pass is over.

### Checks

`npm test`: 2273 tests, 2267 pass. The 6 failures are the known macOS-only ones in test/appearance.test.js. `npm run lint`, `npm run format:check` and `npm run typecheck` pass.

### Not in this PR

- A `Table` catches up with a large shrink over several frames: it takes its first row from the offset without limiting it to the rows it has, so each report brings it only part of the way. That is a fix to `Table` itself.
- On a laid-out pane `scrollTo` still clamps against the previous layout's extent, as #528 describes.

