### PR TITLE
fix(paint): a glyph's antialiased edge is not culled at a pane's edge

### DIFF
--- a/src/anchor.js
+++ b/src/anchor.js
@@ -93,9 +93,10 @@ function deviceAt(at, s) {
 
 /**
  * Has the thing this popup points at scrolled out of view? The check paint
- * culling uses (`Node._offscreen`), asked about the sub-rect rather than
- * about the node: an editor scrolls its own text, so the caret leaves the
- * viewport a long time before the editor does.
+ * culling uses (`Node._offscreen`), without the pixel paint allows for ink
+ * past a box, and asked about the sub-rect rather than about the node: an
+ * editor scrolls its own text, so the caret leaves the viewport a long time
+ * before the editor does.
  *
  * A degenerate rect counts as its own thinnest visible version — a caret is
  * a line with no width and a `{x, y}` anchor is a point with neither, and

--- a/src/components/anchor.js
+++ b/src/components/anchor.js
@@ -64,7 +64,7 @@ function sameAnchorRect(a, b) {
  * it floating over content it no longer belongs to, detached from anything
  * the user can see it points at. So once the trigger is entirely past a
  * clipping ancestor's own bounds or past the owner window itself
- * (`Node._offscreen()`, the same check paint culling uses), tracking calls
+ * (`Node._offscreen()`, paint culling's check less its slop), tracking calls
  * `onOutOfView` instead of measuring — closing the popup, or hiding it, is
  * the caller's call — and does not resume until re-opened. With no
  * `onOutOfView` this just stops updating rather than snapping to a rect

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -5616,7 +5616,7 @@ export class Node {
     }
     for (const child of order) {
       if (child._promoted) continue; // on a layer of its own: a hole here
-      if (child._offscreen()) continue;
+      if (child._offscreen(child.abs, DAMAGE_SLOP)) continue;
       if (child._outsideDamage()) continue;
       child.paint(ctx);
     }
@@ -5668,21 +5668,34 @@ export class Node {
    * (`src/anchor.js`): a popup pointed at a caret has to know when *the
    * caret* has scrolled out of the editor, which happens many screens before
    * the editor itself goes anywhere.
+   *
+   * `slop` is how near counts as reaching in. The paint walk passes
+   * `DAMAGE_SLOP`, for the reason `_outsideDamage` does: antialiasing puts
+   * a glyph's ink a fraction of a pixel past its box, so right-aligned or
+   * RTL text whose box ends exactly at a pane's edge, or the window's, inks
+   * the first column inside it. Culled, that column goes without the ink in
+   * every pass, full repaints included, and the scroll blit carries it: a
+   * notch that moves the text in shows the bare column where a full repaint
+   * paints the text, and a notch the other way carries the ink onto a
+   * column whose full repaint culls it. The pixel's cost is a node whose box
+   * touches the edge, such as a list row abutting the viewport, painted and
+   * clipped away; its children further out are still culled. Anchoring
+   * asks with none, since a caret a pixel past the viewport is out of view.
    */
-  _offscreen(rect = this.abs) {
+  _offscreen(rect = this.abs, slop = 0) {
     const window = this.root?.abs;
     if (!window) return false;
     const { x, y, width, height } = rect;
     if (
-      x + width <= 0 ||
-      y + height <= 0 ||
-      x >= window.width ||
-      y >= window.height
+      x + width <= -slop ||
+      y + height <= -slop ||
+      x >= window.width + slop ||
+      y >= window.height + slop
     ) {
       return true;
     }
     for (let n = this.parent; n && n !== this.root; n = n.parent) {
-      if (n.clipsChildren() && !rectsOverlap(rect, n.abs)) return true;
+      if (n.clipsChildren() && !rectsOverlap(rect, n.abs, slop)) return true;
     }
     return false;
   }

--- a/test/anchor-tracking.test.js
+++ b/test/anchor-tracking.test.js
@@ -196,6 +196,44 @@ test('a tracked popup closes once its trigger scrolls entirely out of view', asy
   await x11Root.unmount();
 });
 
+// Where "entirely out of view" begins, to the pixel. Anchoring asks the
+// paint walk's off-screen test without the pixel paint allows for ink past
+// a box (`Node._offscreen`): a trigger with one row inside the viewport is
+// in view, and one whose box ends on the viewport's edge is not, whatever
+// its antialiasing puts in the row past it.
+test('a tracked popup stays while one row of its trigger shows, and closes when none does', async () => {
+  const app = createMockApp();
+  const triggerRef = React.createRef();
+  const popupRef = React.createRef();
+  const closedRef = { current: 0 };
+  const x11Root = await renderScrolledTrigger(app, {
+    triggerRef,
+    element: h(Harness, { triggerRef, popupRef, closedRef }),
+  });
+
+  const wnd = app.windows[0];
+  const scroller = wnd._reactX11Node.children.find((n) => n.kind === 'box');
+  const before = popupRef.current.y;
+
+  // the trigger sits at content y 40..60: at 59 its last row is the
+  // viewport's first
+  scroller.scrollTo({ y: 59 });
+  await waitFor(
+    () => popupRef.current?.y === before - 59,
+    'the popup following the trigger to its last visible row',
+  );
+  assert.strictEqual(closedRef.current, 0, 'a row of the trigger still shows');
+
+  // at 60 its box ends on the viewport's top edge, and none of it shows
+  scroller.scrollTo({ y: 60 });
+  await waitFor(
+    () => closedRef.current > 0,
+    'onClose firing once the trigger’s box ended on the viewport’s edge',
+  );
+
+  await x11Root.unmount();
+});
+
 test("a tracked popup follows the trigger's own layout moving under it", async () => {
   const app = createMockApp();
   const triggerRef = React.createRef();

--- a/test/scroll-blit.test.js
+++ b/test/scroll-blit.test.js
@@ -1161,9 +1161,7 @@ test('text whose box ends where a strip begins keeps its antialiased edge, frame
               },
               // 200 device pixels a card in a 660 viewport: at none of the
               // positions below does a title's box end on the pane's left
-              // edge. The off-screen cull makes no allowance for ink past a
-              // box, so the two windows can disagree about that column for a
-              // reason of its own.
+              // edge. That edge is the off-screen cull's, tested below.
               ...Array.from({ length: 8 }, (_, i) =>
                 h(
                   'box',
@@ -1279,3 +1277,194 @@ test('text whose box ends where a strip begins keeps its antialiased edge, frame
     for (const app of apps) await app.close();
   }
 });
+
+// --- ink a pixel past its box, at the pane's edge ------------------------
+//
+// The same pixel where the viewport itself ends. The cull that skips a
+// subtree entirely outside the window or a clipping ancestor made no
+// allowance for it, so a title whose box ended exactly at the pane's left
+// edge was culled in every pass, full repaints included, and the column
+// inside the edge went without its ink. The blit carries that column: a
+// notch that moves the title in shows it bare where a full repaint paints
+// the title, and a notch the other way carries the ink onto a column whose
+// full repaint culls it. Found in the schedule example at scale 2, one
+// pixel either way.
+//
+// No padding on the side a card's title ends at, so the card's box ends
+// where the title's does, and a cull that made the allowance for text alone
+// would never reach the title. The pane runs on the window's edge and
+// inside it, because the cull tests the window and a clipping ancestor
+// apart.
+
+for (const [inset, where, stops] of [
+  // content moving right, scrollX up in RTL, onto the position that ends a
+  // title's box on the pane's left edge, then two pixels on; then moving
+  // left, from a frame where a title's box ends three pixels inside the
+  // pane, onto the position that ends it on the edge
+  [0, 'on the window’s edge', [330, 335, 340, 342, 551, 543, 540]],
+  [20, 'inside the window', [370, 375, 380, 382, 591, 583, 580]],
+]) {
+  test(`text whose box ends at a pane’s edge keeps its antialiased edge, frame by frame (the pane ${where})`, async (t) => {
+    // two windows, a server each, as above
+    const apps = [await createHeadlessApp(), await createHeadlessApp()];
+    const x11Roots = [];
+    try {
+      for (const app of apps) {
+        x11Roots.push(await createRoot({ app, scale: 2 }));
+      }
+      const twins = [];
+      for (const x11Root of x11Roots) {
+        const ref = React.createRef();
+        const titles = [];
+        const instance = await new Promise((resolve) =>
+          x11Root.render(
+            h(
+              'window',
+              { width: 330, height: 90, style: { backgroundColor: '#ffffff' } },
+              h(
+                'box',
+                { style: { flexGrow: 1, flexDirection: 'row' } },
+                inset > 0 &&
+                  h('box', { style: { width: inset, flexShrink: 0 } }),
+                h(
+                  'box',
+                  {
+                    ref,
+                    style: {
+                      overflow: 'scroll',
+                      flexGrow: 1,
+                      flexDirection: 'row',
+                      direction: 'rtl',
+                    },
+                  },
+                  ...Array.from({ length: 8 }, (_, i) =>
+                    h(
+                      'box',
+                      {
+                        key: i,
+                        style: {
+                          width: 100,
+                          flexShrink: 0,
+                          paddingTop: 8,
+                          paddingBottom: 8,
+                          paddingEnd: 8,
+                        },
+                      },
+                      h(
+                        'text',
+                        {
+                          ref: (node) => (titles[i] = node),
+                          style: { fontSize: 12, color: '#20304a' },
+                        },
+                        'in between',
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            resolve,
+          ),
+        );
+        twins.push({
+          instance,
+          root: instance._reactX11Node,
+          pane: ref.current,
+          titles,
+        });
+      }
+      const [blit, full] = twins;
+      if (typeof blit.instance.scrollRegion !== 'function') {
+        t.skip('installed ntk has no Window.scrollRegion yet');
+        return;
+      }
+      full.instance.scrollRegion = undefined;
+      let blits = 0;
+      const realScrollRegion = blit.instance.scrollRegion.bind(blit.instance);
+      blit.instance.scrollRegion = (...args) => {
+        const ok = realScrollRegion(...args);
+        if (ok) blits += 1;
+        return ok;
+      };
+      const W = 660;
+      const H = 180;
+      const paint = ({ root }) => {
+        root._scheduled = false;
+        root.flush();
+      };
+      const settled = () => Promise.all(apps.map(settle));
+      twins.forEach(paint);
+      await settled();
+
+      const differ = [];
+      const edges = [];
+      for (const x of stops) {
+        const before = blits;
+        for (const twin of twins) {
+          twin.pane._scrollByDevice(x - twin.pane.scrollX, 0);
+          paint(twin);
+        }
+        await settled();
+        const [a, b] = await Promise.all(
+          twins.map(({ root }) => readPixels(root._ctx, W, H)),
+        );
+        let count = 0;
+        let first = null;
+        for (let i = 0; i < a.data.length; i += 4) {
+          if (
+            a.data[i] === b.data[i] &&
+            a.data[i + 1] === b.data[i + 1] &&
+            a.data[i + 2] === b.data[i + 2] &&
+            a.data[i + 3] === b.data[i + 3]
+          ) {
+            continue;
+          }
+          count += 1;
+          first ??= { x: (i / 4) % W, y: Math.floor(i / 4 / W) };
+        }
+        if (count > 0) {
+          differ.push(
+            `scrollX ${x}: ${count} pixels, first at ${JSON.stringify(first)};` +
+              ` damage ${JSON.stringify(blit.root._lastDamageRects ?? [])}`,
+          );
+        }
+        // the premise: a blitted frame with a title's box ending on the
+        // pane's left edge or just inside it, and where it ends inside, a
+        // full repaint inks the column past it
+        if (blits === before) continue;
+        const left = blit.pane.abs.x;
+        for (const title of blit.titles) {
+          const { x: tx, y: ty, width, height } = title.abs;
+          const edge = tx + width;
+          if (edge < left || edge > left + 3) continue;
+          edges.push([x, edge - left]);
+          if (edge === left) continue;
+          let ink = 255;
+          for (let y = ty; y < ty + height; y++) {
+            ink = Math.min(ink, b.data[(y * W + edge) * 4]);
+          }
+          assert.ok(ink < 255, `the title ending at ${edge} inks past its box`);
+        }
+      }
+      assert.deepStrictEqual(
+        differ,
+        [],
+        'the frames where the blitted window differs from a full repaint',
+      );
+      assert.deepStrictEqual(
+        edges,
+        [
+          [stops[2], 0],
+          [stops[3], 2],
+          [stops[5], 3],
+          [stops[6], 0],
+        ],
+        'where a blitted frame had a title’s box end on the pane’s left ' +
+          'edge, or just inside it',
+      );
+    } finally {
+      for (const x11Root of x11Roots) await x11Root.unmount();
+      for (const app of apps) await app.close();
+    }
+  });
+}


### PR DESCRIPTION
Follow-up to #527, which gave the damage cull its pixel of slop. The paint walk's other cull, `Node._offscreen`, skipped a subtree whose box ended exactly at the window's edge or at a clipping ancestor's, with nothing to spare. Antialiasing puts a glyph's ink a fraction of a pixel past its box, so right-aligned or RTL text whose box ended on a pane's edge lost its ink in the first column inside, in every pass, full repaints included.

That column on its own is a pixel nobody sees, but the scroll blit carries it:

- Content moving toward the ink side brings the bare column in. One notch on, a full repaint paints the title and its ink, and the blitted frame still shows the column it copied.
- Content moving away carries the ink onto the edge column, where a full repaint culls the title.

Reproduced on master with examples/schedule.jsx's `SchedulePanel` in an RTL box, 640 by 400 at scale 2, as twin windows compared frame by frame. The 2px step onto scrollX 82, scrollY 80 differs at pixel 2,648: 255 blitted, 253 repainted. The step back onto the edge, from a frame both windows had painted whole, differs at 0,647 the other way. The blit carried both pixels from the frame before, and no damage rect covered either. With this branch the same 153-step sweep agrees on every frame, 75 of them blitted.

## The fix

`_offscreen` takes an optional `slop`, how near counts as reaching in, and applies it to the window's edges and to every clipping ancestor. `_paintChildren` passes `DAMAGE_SLOP`, the pixel `_outsideDamage` has allowed since #527. The default stays exact, because `src/anchor.js` asks the same question about a caret or a trigger, and one whose box ends on the viewport's edge has scrolled out of view.

## Weighed against

- **Text nodes only.** A title's parent box can end where the title does, and the walk culls the parent before it ever reaches the title. The new test's cards have no padding on the ink side for exactly this, and a text-only mutant fails it.
- **Growing the blit's exposed strip into the band by `DAMAGE_SLOP`.** That repairs content moving toward the ink side only. Moving away, the wrong column sits at the pane's other edge, so the blit would need a second repaint band there on every blitted frame: another pass, and another rect to merge with the scrollbar repairs on the way to `SCROLL_BLIT_MAX_REPAINT`. It would also leave full repaints without the ink, only consistently.
- **What the allowance costs.** A node whose box touches an edge from outside is painted and clipped away; its children further out are still culled. Measured with 30 rows of 40px in a 400px pane: at every aligned offset the walk paints one more row box per edge a row touches, and no more text. ntk drops the row's fill before it reaches the wire, since the clip rejects it whole. Over 8 blitted notches, 294 requests on master and 294 here; over 8 full repaints, 420 and 422.

## Tests

- test/scroll-blit.test.js, after #527's test and modelled on it: twin windows with a server each, one blitting and its twin without `scrollRegion`, compared every frame at scale 2. An RTL pane of cards whose titles end at their card's own right edge. Content moves onto the scroll position that ends a title's box on the pane's left edge and then two pixels on; later it comes back onto the edge from a frame whose ink column is right. It runs twice, with the pane on the window's edge, where both culls apply, and inset from it, where only the clipping ancestor's does. The differing frames are collected and asserted empty, and a premise checks that each landing blitted and that the text inks past its box.
- test/anchor-tracking.test.js: a tracked popup stays while one row of its trigger shows, at scrollY 59, and closes when none does, at 60. That pins the exact default.
- #527's fixture comment said its positions avoid the pane's edge because the off-screen cull made no allowance there. It now says that edge is tested below.

## Mutation check

Each mutant is origin/master 8b2d1bf with this branch's five files copied over it and one decision changed, built outside the worktree. A failing scroll test lists every frame that differed: 342 moves a title two pixels in off the pane's edge, and 540 moves one back onto it; 382 and 580 are the same moves in the inset pane.

| Mutant | Pane on the window's edge | Pane inset | Anchor boundary |
|---|---|---|---|
| none | passes | passes | passes |
| the tests over master | fails at 342 and 540 | fails at 382 and 580 | passes |
| window's edge exact | fails at 342 and 540 | passes | passes |
| clipping ancestor exact | fails at 342 and 540 | fails at 382 and 580 | passes |
| slop for text nodes only | fails at 342 and 540 | fails at 382 and 580 | passes |
| slop by default, anchoring included | passes | passes | fails, stays open at 60 |
| default culling a pixel early | passes | passes | fails, closes at 59 |

## Benches and suite

- `npm run bench:touched`, which src/nodes.js owes all three gates. Protocol: "no regressions against the baseline". Pixels: "pixels unchanged".
- Presenters, the Cocoa structural gate: the `bench:touched` run overlapped a full `npm test` and failed 13 rules, mostly full-window-frame shares. Rerun alone and alternating, the full gate went branch 13 failed, master 0, branch 0, master 2, with the 15-minute load average at 14.7 across the first. Then each of the eight scenarios that had failed on the branch ran alone, twice on each side with the order flipped, and every rule held on both.
- `npm test` on the rebased branch: 2257 of 2264 pass. The six failures are test/appearance.test.js, which fails the same six on master on this Mac. One more, test/screencolor.test.js's "a second pick on the same connection is refused, loudly", hit its 60s timeout while a mutant run shared the machine; alone it passes 23 of 23, three runs alternating with master.
