### PR TITLE
fix(scroll): held sticky nodes no longer cost a pane its scroll blit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -989,10 +989,22 @@ onDraw>`, `value`, `placeholder`. `children` and event handlers are
   blit translates the previous frame's rendering, which is correct
   everywhere the content did not change; the ledger is the list of places
   it did. It still bails when a claim covers the viewport, when there are
-  more than `BLIT_MAX_CLAIMS` of them, or when what they add up to
-  (`BLIT_MAX_CLAIM_AREA`, and `SCROLL_BLIT_MAX_REPAINT` once the damage cap
-  has merged them with the strip and the scrollbar column) stops being
-  cheaper than the one pass it replaced. The case this exists for is the
+  more than `BLIT_MAX_CLAIMS` regions in it, or when what they add to the
+  exposed strip (`BLIT_MAX_CLAIM_AREA`, and `SCROLL_BLIT_MAX_REPAINT` once
+  the frame's rects are assembled) stops being cheaper than the one pass it
+  replaced. Both are measured as pixels, not as rects: a claim that overlaps
+  an entry and covers exactly the box around the two folds into it, and the
+  area is a union, so a pixel two claims share — or a claim and the strip —
+  counts once. Summing them priced a held sticky header at twice its rect
+  plus its held children. And everything the frame repairs besides the
+  thumb is cut at the edge of the band the scrolled bar's thumb travels in:
+  the thumb's rects are thin and run along the viewport's edge, and a rect
+  reaching into the band — a column held down the pane's side, the strip at
+  the end the thumb has come to — merged with them into a box reaching back
+  across the viewport. The halves of a cut that met nothing are rejoined, so
+  a plain pane's frame is the rects it always was. Of 79 mixed notches across
+  the timetable in `examples/schedule.jsx`, 14 blitted before these three and
+  all 79 do after. The case this exists for is the
   **virtualized list**, whose own re-slice commit claims inside the viewport
   on every scroll frame by construction — the spacers resize and the
   entering rows mount — so the fast path used to fire on the first wheel
@@ -1015,7 +1027,18 @@ onDraw>`, `value`, `placeholder`. `children` and event handlers are
   fail, and does (887 requests and 3.28 Mpx against a 437 / 0.65 baseline).
   The virtualized-list scenario beside it is fenced the same way, and is
   what prices the ledger: ten notches cost 295 requests / 0.56 Mpx with it
-  and 785 / 3.20 without.
+  and 785 / 3.20 without. The band cut moved it to 284 / 0.40, and its
+  composites from 70 to 90: a row that meets the thumb is two passes now,
+  where it was one box stretched down the thumb's length.
+
+  One thing breaks the invariant that is not the blit's. ntk places a glyph
+  by rounding its run's origin plus its offset, and in floating point the
+  last bits of that sum — so which way an offset within an ulp of .5 rounds
+  — depend on the origin's magnitude: a run copied 48 px along can sit a
+  pixel off from the same run drawn there. It is rare, one glyph at one
+  notch, and happens more in RTL, where right-aligned runs start on
+  fractions. The timetable's pixel test steers clear of the notches where
+  it does. Rounding the offsets against a whole-pixel origin in ntk ends it.
 
   **Where scrolling actually spent its time was neither of those.** Profiling a
   50,000-row table found the cost in ntk's `clip()`: intersecting a clip
@@ -1115,8 +1138,12 @@ onDraw>`, `value`, `placeholder`. `children` and event handlers are
     — and the reach it lands at, into the blitting pane's ledger and
     clipped to it. A node that rode the scroll lands exactly where the blit
     put its pixels and claims nothing, which is what keeps a pane of
-    headers on the fast path. `test/sticky.test.js` fences both halves, and
-    the blitted frame against a full repaint.
+    headers on the fast path. A held one's two rects overlap by all but the
+    notch and fold into one ledger entry, its held children's inside it,
+    so it costs the blit its own rect whichever way the pane scrolls.
+    `test/sticky.test.js` fences both halves, and the blitted frame against
+    a full repaint; `test/schedule-example.test.js` does the same for a
+    pane of them, notch by notch.
   - **It paints over its siblings.** `paintOrder()` lifts a sticky child
     over its siblings of the same `zIndex`, hit testing walks the same order
     backwards, and the Cocoa layer presenter takes zPosition from it.

--- a/scripts/bench/baseline.json
+++ b/scripts/bench/baseline.json
@@ -130,15 +130,15 @@
     "churn": 0
   },
   "scroll: 10 notches over a virtualized list": {
-    "requests": 295,
-    "bytesOut": 14104,
-    "bytesIn": 3032,
-    "replies": 44,
-    "composites": 70,
-    "compositePixels": 561760,
+    "requests": 284,
+    "bytesOut": 13184,
+    "bytesIn": 3192,
+    "replies": 43,
+    "composites": 90,
+    "compositePixels": 397540,
     "filteredComposites": 0,
     "convolvedPixels": 0,
-    "stalls": 12,
+    "stalls": 11,
     "dupQueries": 0,
     "churn": 0
   },

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -388,7 +388,9 @@ const BLIT_CONTENTS = Object.freeze({ contents: true });
 // before the frame gives up and repaints the viewport instead (issue #398).
 // A virtualized list's scroll frame changes a handful of regions — the two
 // spacers and the entering rows — and past that the blit plus a scatter of
-// repaints stops being cheaper than the one pass it replaced.
+// repaints stops being cheaper than the one pass it replaced. The area is
+// what the regions add to the strip the frame repaints anyway, a pixel two
+// of them share counted once.
 const BLIT_MAX_CLAIMS = 8;
 const BLIT_MAX_CLAIM_AREA = 0.25;
 
@@ -472,6 +474,85 @@ function scrollbarTrackRect(bar) {
   return insetRect(rect, -1);
 }
 
+/**
+ * The band a scrollbar's thumb travels in, as the line along the track's
+ * inner edge and the viewport edge beyond it: `bottom` for a horizontal
+ * bar, `right` for a vertical one, `left` for the vertical bar of an RTL
+ * viewport. A whole pixel, just outside the track's slop, so the parts a
+ * rect is cut into still meet on a pixel boundary once they are snapped.
+ */
+function scrollbarBand(bar, vp) {
+  const track = scrollbarTrackRect(bar);
+  if (bar.axis === 'x') {
+    return track.y + track.height / 2 > vp.y + vp.height / 2
+      ? { edge: 'bottom', at: Math.floor(track.y) }
+      : { edge: 'top', at: Math.ceil(track.y + track.height) };
+  }
+  return track.x + track.width / 2 > vp.x + vp.width / 2
+    ? { edge: 'right', at: Math.floor(track.x) }
+    : { edge: 'left', at: Math.ceil(track.x + track.width) };
+}
+
+/**
+ * Rects sharing a whole edge joined into the one rect they make, until no
+ * two do. Exact — a join is the union of the two, so the list stays
+ * disjoint — and it only saves a pass: a rect cut at a band's line whose
+ * parts met nothing on either side comes back whole.
+ */
+function joinAlongEdges(rects) {
+  const out = [...rects];
+  for (let joined = true; joined;) {
+    joined = false;
+    for (let i = 0; i < out.length && !joined; i++) {
+      for (let j = i + 1; j < out.length && !joined; j++) {
+        const a = out[i];
+        const b = out[j];
+        let union = null;
+        if (
+          a.x === b.x &&
+          a.width === b.width &&
+          (a.y + a.height === b.y || b.y + b.height === a.y)
+        ) {
+          const y = Math.min(a.y, b.y);
+          union = { x: a.x, y, width: a.width, height: a.height + b.height };
+        } else if (
+          a.y === b.y &&
+          a.height === b.height &&
+          (a.x + a.width === b.x || b.x + b.width === a.x)
+        ) {
+          const x = Math.min(a.x, b.x);
+          union = { x, y: a.y, width: a.width + b.width, height: a.height };
+        }
+        if (!union) continue;
+        out.splice(j, 1);
+        out[i] = union;
+        joined = true;
+      }
+    }
+  }
+  return out;
+}
+
+/** `rect` cut along a band's line: the part on the band's side of it and
+ * the rest, either of them null where the line misses the rect. */
+function splitAtBand(rect, band) {
+  const vertical = band.edge === 'left' || band.edge === 'right';
+  const start = vertical ? rect.x : rect.y;
+  const end = start + (vertical ? rect.width : rect.height);
+  const at = Math.min(Math.max(band.at, start), end);
+  const piece = (from, to) => {
+    if (to <= from) return null;
+    return vertical
+      ? { x: from, y: rect.y, width: to - from, height: rect.height }
+      : { x: rect.x, y: from, width: rect.width, height: to - from };
+  };
+  const before = piece(start, at);
+  const after = piece(at, end);
+  return band.edge === 'right' || band.edge === 'bottom'
+    ? { inside: after, outside: before }
+    : { inside: before, outside: after };
+}
+
 // REACT_X11_DEBUG_PAINT: each frame strokes its damage rects in the next of
 // these, so a region repainting every frame strobes visibly.
 const FLASH_COLORS = [
@@ -513,6 +594,46 @@ function unionRect(a, b) {
 
 function rectArea(r) {
   return Math.max(0, r.width) * Math.max(0, r.height);
+}
+
+/**
+ * The area a list of rects covers, a pixel under several of them counted
+ * once. Exact, column by column: between each pair of neighbouring x
+ * edges, the rects spanning that column merge their y extents. Asked about
+ * a handful of rects at a time.
+ */
+function unionArea(rects) {
+  const xs = rects.flatMap((r) => [r.x, r.x + r.width]).sort((a, b) => a - b);
+  let total = 0;
+  for (let i = 1; i < xs.length; i++) {
+    const left = xs[i - 1];
+    const right = xs[i];
+    if (right <= left) continue;
+    const spans = rects
+      .filter((r) => r.x <= left && r.x + r.width >= right)
+      .sort((a, b) => a.y - b.y);
+    let covered = 0;
+    let reach = -Infinity;
+    for (const r of spans) {
+      const from = Math.max(r.y, reach);
+      const to = r.y + r.height;
+      if (to > from) covered += to - from;
+      reach = Math.max(reach, to);
+    }
+    total += covered * (right - left);
+  }
+  return total;
+}
+
+/** Do two overlapping rects cover exactly the box around them — one inside
+ * the other, or the two spanning the same extent along one axis? */
+function unionIsBox(a, b) {
+  return (
+    rectContains(a, b) ||
+    rectContains(b, a) ||
+    (a.x === b.x && a.width === b.width) ||
+    (a.y === b.y && a.height === b.height)
+  );
 }
 
 /** The box around a non-empty list of rects. */
@@ -3423,17 +3544,38 @@ export class Node {
    * run — the diff's, the reflow queue's — already names where it landed.
    * Read off the window rather than passed in, so a claim from application
    * code reached during the layout pass is filed on the right side of it.
+   *
+   * A region the ledger already holds is not another one. A claim that
+   * overlaps an entry and covers exactly the box around the two of them is
+   * folded into it: the same pixels, one entry. A held sticky node claims
+   * one rect twice — where it was, and where it is a delta along — and
+   * every sticky node held inside it claims inside those, so kept apart, a
+   * pane holding a few of them ran out of entries on regions it had already
+   * counted. Only between claims on the same side of the layout pass: the
+   * blit moves one kind and not the other.
    */
   _recordBlitClaim(rect) {
     const ledger = this._blitLedger;
-    if (!ledger || ledger.length >= BLIT_MAX_CLAIMS) return false;
+    if (!ledger) return false;
     const inside = intersectRects(rect, this.abs);
     // beside the band the blit moves: those pixels are painted the ordinary
     // way, out of the frame's own damage
     if (!inside) return true;
+    const pre = !this.root?._laidOut;
+    let claim = { ...inside, pre };
+    for (let i = ledger.length - 1; i >= 0; i--) {
+      const entry = ledger[i];
+      if (entry.pre !== pre || !rectsOverlap(entry, claim)) continue;
+      if (!unionIsBox(entry, claim)) continue;
+      claim = { ...unionRect(entry, claim), pre };
+      ledger.splice(i, 1);
+      // grown, it can fold an entry already passed over
+      i = ledger.length;
+    }
     // …and a claim that covers the viewport leaves the blit nothing to keep
-    if (rectContains(inside, this.abs)) return false;
-    ledger.push({ ...inside, pre: !this.root?._laidOut });
+    if (rectContains(claim, this.abs)) return false;
+    if (ledger.length >= BLIT_MAX_CLAIMS) return false;
+    ledger.push(claim);
     return true;
   }
 
@@ -12419,7 +12561,9 @@ export class WindowNode extends Scrollable(Node) {
    * neighbours lands exactly there and claims nothing, which is what keeps
    * a pane of headers on the blit path; a held one claims two header-sized
    * rects, written into the blitting pane's ledger and clipped to it the
-   * way `_reflowed`'s claims are.
+   * way `_reflowed`'s claims are. They overlap by all but the scroll's
+   * delta, and the ledger folds them into one entry (`_recordBlitClaim`),
+   * with every held child's claims inside it.
    */
   _placeSticky() {
     const nodes = [];
@@ -12826,34 +12970,14 @@ export class WindowNode extends Scrollable(Node) {
     // no more complicated, so a mid-viewport change — a row upgrading from
     // skeleton to content while the list scrolls — rides the fast path too
     // instead of falling back to the whole viewport.
-    const repairs = [];
-    let repairArea = 0;
-    for (const claim of ledger ?? []) {
-      const moved = claim.pre
-        ? {
-            x: claim.x + dx,
-            y: claim.y + dy,
-            width: claim.width,
-            height: claim.height,
-          }
-        : claim;
-      const inside = intersectRects(moved, vp);
-      if (!inside) continue;
-      repairs.push(inside);
-      repairArea += inside.width * inside.height;
-    }
-    // past this the blit plus a scatter of repaints is no longer cheaper
-    // than the one full-viewport pass it replaced
-    if (repairArea > area * BLIT_MAX_CLAIM_AREA) return;
-    if (!this._scrollBlitSafe(node, vp)) return;
-    let rects = keep;
-    // the strip the shift exposed, on the side the pixels moved away from,
+    //
+    // The strip the shift exposed, on the side the pixels moved away from,
     // full breadth — it also covers the corner gutter beside the bars, whose
-    // old pixels the blit did not overwrite
+    // old pixels the blit did not overwrite — is repainted on every frame
+    // the blit serves, whatever the ledger holds.
     const axis = dy !== 0 ? 'y' : 'x';
     const delta = dy !== 0 ? dy : dx;
-    rects = addDamageRect(
-      rects,
+    const strip =
       axis === 'y'
         ? {
             x: vp.x,
@@ -12866,8 +12990,56 @@ export class WindowNode extends Scrollable(Node) {
             y: vp.y,
             width: Math.abs(delta),
             height: vp.height,
-          },
-    );
+          };
+    const repairs = [];
+    for (const claim of ledger ?? []) {
+      const moved = claim.pre
+        ? {
+            x: claim.x + dx,
+            y: claim.y + dy,
+            width: claim.width,
+            height: claim.height,
+          }
+        : claim;
+      const inside = intersectRects(moved, vp);
+      if (inside) repairs.push(inside);
+    }
+    // Past this the blit plus a scatter of repaints is no longer cheaper
+    // than the one full-viewport pass it replaced. Priced as what the
+    // repairs add to the strip: a pixel under two of them, or under one and
+    // the strip, is painted once. Summed, a held sticky header paid for its
+    // rect twice — it claims where it was and where it is, a delta apart —
+    // then again for each sticky node held inside it, and scrolled back up
+    // it paid a third time for the strip the blit dragged its copy across.
+    const repairArea = repairs.length
+      ? unionArea([strip, ...repairs]) - rectArea(strip)
+      : 0;
+    if (repairArea > area * BLIT_MAX_CLAIM_AREA) return;
+    if (!this._scrollBlitSafe(node, vp)) return;
+    // The band the scrolled bar's thumb travels in is repaired on its own.
+    // The thumb's rects are thin and run along the viewport's edge, and a
+    // rect reaching into the band from inside — a column held down the
+    // pane's whole height, the strip at the end the thumb has come to —
+    // merged with them into the box around both, which reaches back across
+    // the viewport. Cut at the band's line instead, each part coalesces on
+    // its own side of it, and the band stays a band.
+    //
+    // Assembled uncapped, so the parts of a cut stay apart until every rect
+    // is in: a cap merge would pick the two halves of one rect first — they
+    // waste nothing — and put the overlap back. The halves that met nothing
+    // on either side are rejoined after, which is the rect uncut and one
+    // pass fewer, and only then is the frame capped.
+    const scrolledBar = node._scrollbar(axis);
+    const band = scrolledBar ? scrollbarBand(scrolledBar, vp) : null;
+    let rects = keep;
+    const add = (rect) => {
+      const { inside, outside } = band
+        ? splitAtBand(rect, band)
+        : { inside: null, outside: rect };
+      if (outside) rects = addDamageRect(rects, outside, Infinity);
+      if (inside) rects = addDamageRect(rects, inside, Infinity);
+    };
+    add(strip);
     // Scrollbar repair. The scrolled axis's thumb moved *and* the blit
     // dragged a copy of the old thumb along: repaint the dragged copy's
     // rect and the new thumb's rect — small rects, where the full track
@@ -12878,7 +13050,6 @@ export class WindowNode extends Scrollable(Node) {
     // scrolling both ways otherwise trails a smear of old thumb behind its
     // bar, a row per pixel scrolled. Both lie along the strip on the far
     // edge, so their merge stays a band.
-    const scrolledBar = node._scrollbar(axis);
     if (scrolledBar) {
       const savedX = node.scrollX;
       const savedY = node.scrollY;
@@ -12888,38 +13059,51 @@ export class WindowNode extends Scrollable(Node) {
       node.scrollX = savedX;
       node.scrollY = savedY;
       if (oldBar) {
-        rects = addDamageRect(rects, {
-          x: oldBar.x - 1 + dx,
-          y: oldBar.y - 1 + dy,
-          width: oldBar.width + 2,
-          height: oldBar.height + 2,
-        });
+        rects = addDamageRect(
+          rects,
+          {
+            x: oldBar.x - 1 + dx,
+            y: oldBar.y - 1 + dy,
+            width: oldBar.width + 2,
+            height: oldBar.height + 2,
+          },
+          Infinity,
+        );
       }
-      rects = addDamageRect(rects, {
-        x: scrolledBar.x - 1,
-        y: scrolledBar.y - 1,
-        width: scrolledBar.width + 2,
-        height: scrolledBar.height + 2,
-      });
+      rects = addDamageRect(
+        rects,
+        {
+          x: scrolledBar.x - 1,
+          y: scrolledBar.y - 1,
+          width: scrolledBar.width + 2,
+          height: scrolledBar.height + 2,
+        },
+        Infinity,
+      );
     }
     const crossBar = node._scrollbar(axis === 'y' ? 'x' : 'y');
     if (crossBar) {
       const track = scrollbarTrackRect(crossBar);
-      rects = addDamageRect(rects, track);
+      add(track);
       const dragged = intersectRects(
         { ...track, x: track.x + dx, y: track.y + dy },
         vp,
       );
-      if (dragged) rects = addDamageRect(rects, dragged);
+      if (dragged) add(dragged);
     }
-    for (const repair of repairs) rects = addDamageRect(rects, repair);
+    for (const repair of repairs) add(repair);
+    rects = joinAlongEdges(rects).reduce(
+      (capped, rect) => addDamageRect(capped, rect),
+      [],
+    );
     // The last gate, and the only one that has to wait until the rects are
-    // assembled: the frame carries at most MAX_DAMAGE_RECTS of them, so a
-    // repair that does not sit beside the strip is merged with whatever is
-    // nearest — the scrollbar column, most often — and the box of that
-    // merge can reach back across the viewport. When it does, the blit is
-    // buying a shift and paying for the viewport anyway, so let the plain
-    // repaint scrollTo already claimed have the frame.
+    // assembled: damage rects must not overlap, and the frame carries at
+    // most MAX_DAMAGE_RECTS of them, so repairs that meet — a column and a
+    // row at a corner — or that the cap has to pair up are merged into the
+    // box around them, and that box can reach back across the viewport.
+    // When it does, the blit is buying a shift and paying for the viewport
+    // anyway, so let the plain repaint scrollTo already claimed have the
+    // frame.
     let painted = 0;
     for (const rect of rects) {
       const inside = intersectRects(rect, vp);

--- a/test/schedule-example.test.js
+++ b/test/schedule-example.test.js
@@ -258,9 +258,16 @@ function disagreement(a, b, width) {
 // across whichever axis a notch does not move, and the blit drags that bar's
 // pixels along with the talks: a notch across left a copy of the vertical
 // thumb 48 pixels in from its track, a 6 by 44 sliver at the top of the
-// pane, at the other edge in RTL. The shipped programme at 640 by 400,
-// because in the small one's window the blit declines every notch, and a
-// declined notch compares nothing. Each pass sets its direction rather than
+// pane, at the other edge in RTL. And every node `position: 'sticky'` holds
+// claims where it was and where it is, two rects a notch apart with its
+// held children inside them. Summed, a held header's claims ran past the
+// quarter of the viewport the ledger allows; the times column, held down
+// the pane's whole height, merged with the thumb along the bottom into most
+// of the viewport; mid-push, six held nodes ran the ledger out of entries.
+// Each of those notches declined the blit, and a declined notch compares
+// nothing, so every notch here is asserted to have blitted first. The
+// shipped programme at 640 by 400, because in the small one's window the
+// blit declines every notch. Each pass sets its direction rather than
 // taking the locale's, so it knows which way the pixels go.
 for (const direction of ['ltr', 'rtl']) {
   test(`a notch the scroll blit serves paints what a full repaint does, ${direction}`, async () => {
@@ -298,16 +305,43 @@ for (const direction of ['ltr', 'rtl']) {
           ` x ${box?.x0} to ${box?.x1}, y ${box?.y0} to ${box?.y1}`,
       );
     };
+    // Scrolling on carries the content toward the start edge, left in LTR
+    // and right in RTL.
+    const across = (d) => (direction === 'rtl' ? d : -d);
+    // The notches stay off scrollX 96. There, in RTL, one glyph of a room's
+    // name rounds a pixel to one side where it is drawn and to the other
+    // where it was copied from: ntk places a glyph by rounding its origin
+    // plus its offset, and in floating point the last bits of that sum move
+    // with the origin's magnitude. A copy of it is a pixel off a repaint,
+    // blit or no blit — hidden by a notch that repaints most of the
+    // viewport, which this one no longer does.
+    //
     // across, with the times, the corner and the day's name held at the
-    // start edge: the vertical bar is the one dragged. Scrolling on carries
-    // the content toward the start edge, left in LTR and right in RTL.
-    const across = direction === 'rtl' ? 48 : -48;
-    await notch({ x: 48 }, [across, 0]);
-    await notch({ x: 96 }, [across, 0]);
+    // start edge: the vertical bar is the one dragged
+    await notch({ x: 48 }, [across(48), 0]);
+    const times = byName('times-thu');
+    const held =
+      direction === 'rtl'
+        ? pane.abs.x + pane.abs.width - (times.abs.x + times.abs.width)
+        : times.abs.x - pane.abs.x;
+    assert.equal(held, 0, 'the times are held at the start edge');
+    // down and back up with Thursday's header held at the top: its two
+    // rects, and a notch up drags its copy down across the strip
+    await notch({ y: 13 }, [0, -13]);
+    await notch({ y: 61 }, [0, -48]);
+    await notch({ y: 13 }, [0, 48]);
+    assert.equal(byName('header-thu').abs.y, pane.abs.y, 'the header is held');
+    // back across and on, the exposed strip running down the held times
+    await notch({ x: 35 }, [across(-13), 0]);
+    await notch({ x: 83 }, [across(48), 0]);
     // down, through Thursday's header being pushed off by Friday's: the
     // horizontal bar is dragged up off its track
     await scroll(pane, { y: 801 });
     await notch({ y: 849 }, [0, -48]);
     await notch({ y: 801 }, [0, 48]);
+    // across in the middle of the push, both days' times, corners and
+    // names held: twelve claims, a handful of regions
+    await notch({ x: 35 }, [across(-48), 0]);
+    await notch({ x: 83 }, [across(48), 0]);
   });
 }

--- a/test/scroll-blit.test.js
+++ b/test/scroll-blit.test.js
@@ -92,9 +92,25 @@ test('scrolling back up exposes a strip at the top', async () => {
   assert.deepStrictEqual(blits(wnd), [
     ['scrollRegion', { x: 0, y: 0, width: 400, height: 400 }, 0, 48],
   ]);
-  const strip = root._lastDamageRects.find((r) => r.width === 400);
-  assert.strictEqual(strip.y, 0);
-  assert.ok(strip.height >= 48);
+  // every pixel of the top 48 rows — across the content, and beside it in
+  // the band the thumb travels, which is repaired along with the thumb
+  const rects = root._lastDamageRects;
+  const hit = (x, y) =>
+    rects.some(
+      (r) => x >= r.x && x < r.x + r.width && y >= r.y && y < r.y + r.height,
+    );
+  for (let y = 0; y < 48; y++) {
+    for (let x = 0; x < 400; x++) {
+      assert.ok(
+        hit(x, y),
+        `the strip misses ${x},${y}: ${JSON.stringify(rects)}`,
+      );
+    }
+  }
+  // …and not the box around the strip and the thumb under it, which the
+  // strip used to merge with at this end of the track: 74% of the viewport
+  const area = rects.reduce((sum, r) => sum + r.width * r.height, 0);
+  assert.ok(area < 400 * 400 * 0.2, `repainted ${JSON.stringify(rects)}`);
 });
 
 test('several scrollTo calls in one frame blit once, by the net delta', async () => {
@@ -149,17 +165,51 @@ test('other damage inside the viewport is repainted where the shift leaves it', 
   );
 });
 
-test('a repaint the damage cap merged back across the viewport is not worth blitting', async () => {
+// Full-width rows at opposite ends of the viewport both reach into the band
+// the scrolled bar's thumb travels in. They used to merge with the thumb's
+// rects there, and the box of that merge was most of the viewport again;
+// cut at the band's line, the rows and the band repaint as themselves.
+test('repairs at opposite ends of the viewport keep the blit, and stay apart', async () => {
   const { wnd, root, ref } = await mount();
   await tick();
   const rows = root.children[0].children;
   wnd.calls.length = 0;
   ref.current.scrollTo(48);
-  // full-width rows at opposite ends of the viewport: the frame carries
-  // four damage rects, so these merge with each other and with the
-  // scrollbar column, and the box of that merge is the viewport back again
   root.invalidate(false, rows[1]);
   root.invalidate(false, rows[8]);
+  await tick();
+  assert.strictEqual(blits(wnd).length, 1, 'the blit fired');
+  const rects = root._lastDamageRects;
+  // both rows where the shift left them, 48 up, edge to edge
+  for (const [x, y] of [
+    [0, 40 - 48 + 20],
+    [399, 40 - 48 + 20],
+    [0, 320 - 48 + 20],
+    [399, 320 - 48 + 20],
+  ]) {
+    assert.ok(
+      covers(rects, x, y),
+      `misses ${x},${y}: ${JSON.stringify(rects)}`,
+    );
+  }
+  const area = rects.reduce((sum, r) => sum + r.width * r.height, 0);
+  assert.ok(
+    area < 400 * 400 * 0.4,
+    `the rows, the strip and the band: ${JSON.stringify(rects)}`,
+  );
+});
+
+// Damage rects must not overlap, so two claims that meet at a corner
+// coalesce into the box around them — here most of the viewport, for a
+// column and a row a sliver wide. The blit would buy a shift and pay for
+// the viewport anyway.
+test('claims that coalesce back across the viewport are not worth blitting', async () => {
+  const { wnd, root, ref } = await mount();
+  await tick();
+  wnd.calls.length = 0;
+  ref.current.scrollTo(48);
+  root.invalidate(false, { x: 0, y: 0, width: 10, height: 400 });
+  root.invalidate(false, { x: 0, y: 340, width: 390, height: 10 });
   await tick();
   assert.strictEqual(blits(wnd).length, 0, 'the blit would not pay: no blit');
 });
@@ -180,12 +230,40 @@ test('a claim that covers the viewport keeps the full repaint', async () => {
 test('more changes than the ledger carries keep the full repaint', async () => {
   const { wnd, root, ref } = await mount();
   await tick();
-  const rows = root.children[0].children;
   wnd.calls.length = 0;
   ref.current.scrollTo(48);
-  for (let i = 0; i < 10; i++) root.invalidate(false, rows[i]);
+  // ten separate regions — small, apart, none a part of another
+  for (let i = 0; i < 10; i++) {
+    root.invalidate(false, { x: 10 + 36 * i, y: 150, width: 20, height: 20 });
+  }
   await tick();
   assert.strictEqual(blits(wnd).length, 0, 'past the ledger cap: no blit');
+});
+
+// A claim inside one the ledger already holds is the same region again — a
+// held sticky header claims where it was and where it is, a delta apart,
+// and every sticky node held inside it claims inside those. They fold into
+// the entry they are part of rather than spending one each.
+test('changes inside a change the ledger holds do not count against it', async () => {
+  const { wnd, root, ref } = await mount();
+  await tick();
+  wnd.calls.length = 0;
+  ref.current.scrollTo(48);
+  for (let i = 0; i < 10; i++) {
+    root.invalidate(false, {
+      x: 40 + i,
+      y: 120 + i,
+      width: 120 - 2 * i,
+      height: 40 - 2 * i,
+    });
+  }
+  await tick();
+  assert.strictEqual(blits(wnd).length, 1, 'ten claims, one region: blitted');
+  assert.ok(
+    covers(root._lastDamageRects, 50, 130 - 48),
+    `the region, where the shift left it: ` +
+      JSON.stringify(root._lastDamageRects),
+  );
 });
 
 test('changes covering most of the viewport keep the full repaint', async () => {

--- a/test/sticky.test.js
+++ b/test/sticky.test.js
@@ -815,6 +815,42 @@ test('a held header keeps the blit, and repaints only where it was and where it 
   assert.ok(area(rects) < 400 * 400 * 0.3, JSON.stringify(rects));
 });
 
+// A header a fifth of the pane tall. It claims where it was and where it
+// is, two rects a notch apart, and summed those came to more than the
+// quarter of the viewport the ledger allows; scrolled back up, the band the
+// blit dragged its copy down across is the exposed strip, which the frame
+// repaints anyway. Priced as what they add to the strip, both notches cost
+// the header's own rect.
+test('a tall held header costs the blit its own rect, whichever way the pane scrolls', async () => {
+  const pane = React.createRef();
+  const header = React.createRef();
+  const { wnd, root } = await mount(
+    h(
+      'box',
+      { ref: pane, style: { overflow: 'scroll', flexGrow: 1 } },
+      h('box', { style: { height: 200, flexShrink: 0 } }),
+      section(0, header, { rows: 20, header: { height: 80 } }),
+    ),
+    { width: 400, height: 400 },
+  );
+  pane.current.scrollTo(248);
+  await frame();
+  for (const to of [296, 248]) {
+    wnd.calls.length = 0;
+    pane.current.scrollTo(to);
+    await frame();
+    assert.strictEqual(top(header.current, pane.current), 0, 'held');
+    assert.strictEqual(blits(wnd).length, 1, `the notch to ${to} blitted`);
+    const rects = root._lastDamageRects;
+    const covers = (x, y) =>
+      rects.some(
+        (r) => x >= r.x && x < r.x + r.width && y >= r.y && y < r.y + r.height,
+      );
+    assert.ok(covers(5, 5) && covers(395, 75), JSON.stringify(rects));
+    assert.ok(area(rects) < 400 * 400 * 0.4, JSON.stringify(rects));
+  }
+});
+
 // --- the pixels, against the real ntk and an in-process X server ----------
 
 const require = createRequire(import.meta.url);


### PR DESCRIPTION
## Summary

The timetable in `examples/schedule.jsx` declined the scroll blit on most notches. In a sweep of 79, one axis at a time, both directions, steps of 1 to 48 px, 14 blitted and the rest repainted the whole viewport. Every notch it served was byte-identical to a full repaint, so this was a cost problem, not a correctness one. Three things priced a pane of held sticky nodes out of the fast path.

- **The ledger counted a region more than once.** A node held by `position: 'sticky'` claims where it was and where it is, one rect a notch apart, and every sticky node held inside it claims inside those. Mid-push, six held nodes spent twelve entries and ran past `BLIT_MAX_CLAIMS`. `_recordBlitClaim` now folds a claim into an entry it overlaps when the two cover exactly the box around them. The pixels are the same and the entry is one. It folds only between claims on the same side of the layout pass.
- **`BLIT_MAX_CLAIM_AREA` summed the claims.** That paid for a held header twice and for its held children again: 45% of the viewport for a header covering 20%. A notch up paid a third time, for the strip the blit dragged the header's copy across. The gate now prices what the repairs add to the exposed strip, as a union, so a held header costs its own rect whichever way the pane scrolls.
- **Repairs merged with the scrollbar.** The held times column runs down into the band the horizontal thumb travels in, and overlapping damage rects merge into their box. The column, the day's name beside it and the thumb's rects became a box over most of the viewport, past `SCROLL_BLIT_MAX_REPAINT`. The strip at the end of the track did the same with no sticky node at all. Everything the frame repairs besides the thumb's own rects is now cut at the band's line and coalesces on its own side of it. The rects are assembled uncapped and the halves of a cut that met nothing are rejoined, so a plain pane's frame is the rects it always was.

All 79 notches blit now. AGENTS.md's scroll-blit and sticky sections say what changed.

## Measurements

The sweep, `SchedulePanel` at 640×400, counted in the in-process server:

|                              | blitted | requests | composites | Composite Mpx | painted Mpx |
| ---------------------------- | ------: | -------: | ---------: | ------------: | ----------: |
| master                       |      14 |    16583 |       5538 |         47.12 |       15.30 |
| this                         |      79 |    13567 |       5050 |         15.79 |        4.48 |
| `REACT_X11_NO_SCROLL_BLIT=1` |       0 |    17330 |       5679 |         53.14 |       17.34 |

Timed on Xvfb, a real X.Org server: the client's flush plus the server executing it, fenced, each notch the median of five runs.

|                              |  sweep | per notch |
| ---------------------------- | -----: | --------: |
| master                       | 255 ms |   3.27 ms |
| this                         | 200 ms |   2.56 ms |
| `REACT_X11_NO_SCROLL_BLIT=1` | 275 ms |   3.45 ms |

The in-process server is not the place to time this. Its CopyArea is JavaScript over the whole viewport, and there even master's blitted notches take longer than a full repaint.

**The bench's virtualized list is rebaselined.** `scroll: 10 notches over a virtualized list` goes to 284 requests from 295, 0.40 Composite Mpx from 0.56, and 90 composites from 70. A row that meets the thumb is two passes now, where it was one box stretched down the thumb's length. Only that entry of `scripts/bench/baseline.json` changed, written by a filtered `--save`; without it, `--check` fails on the composites. `scroll: 10 notches over 500 rows` reads the same as master's.

## The invariant, and a glyph that is not the blit's

Every notch that blits is compared with a full repaint of the same state. On ntk 8.8.0, one glyph at one notch in LTR, and at fourteen in RTL, comes out a pixel off. Every wrong pixel is the previous frame's, carried by the shift, inside one text run.

The cause is in ntk. `positionGlyphs` rounds a glyph's origin plus its offset, and in floating point the last bits of that sum depend on the origin's magnitude. A run copied 48 px along can therefore round a glyph differently from the same run drawn there. RTL meets it more, since right-aligned runs start on fractions. Master hid it behind repaints of most of the viewport.

With `positionGlyphs` rounding against the origin's whole pixels, the fraction snapped to 1/256 px, in a scratch copy of ntk, all 79 notches are byte-identical in both directions. The same sweep against Xvfb reproduced the LTR flip exactly, so it is not the in-process server either. That fix is for ntk to take.

So the schedule test from #526 keeps its notches off scrollX 96, where RTL meets the flip. #526's notch there passed only because that frame repainted the room names anyway.

What is left of the cost: overlapping repairs still coalesce into the box around them, which the repaint gate prices. The held times column and the day's name beside it make an L that repaints about a quarter of the viewport on a notch across.

## Tests

- `test/schedule-example.test.js`: #526's sweep now covers every case above in both directions: the held header down and back up, the held times across and back, the push, and across mid-push. Each notch is asserted to blit, then compared with a full repaint.
- `test/sticky.test.js`: a held header a fifth of the pane tall costs its own rect, scrolled either way.
- `test/scroll-blit.test.js`:
  - Nested claims fold into one ledger entry.
  - Rows at opposite ends of the viewport keep the blit and stay apart.
  - A plain pane's strip at the top of the track no longer merges with the thumb under it.
  - The ledger cap is now pinned with separate regions, since rows that overlap fold.
  - The repaint gate is pinned by two thin claims that meet at a corner.

Mutation-checked. Against master's code, the six cases that pin new behaviour fail and the rest pass. Reverting each mechanism alone fails at least one test:

- Dropping the band's inside part fails thirteen, seven of them pixel comparisons.
- Removing the band fails five.
- No fold, the plain sum and the plain union fail three each.
- No rejoin fails one: the plain pane's strip.
- Folding across the layout pass fails one: the virtualized list's area bound.

- [x] `node --test` for scroll-blit, sticky, schedule-example, scroll-before-layout, scroll-from-layout, anchor-tracking and table: 119 of 119
- [x] `npm test`: 2273 of 2279; the six that fail are the macOS `appearance.test.js` cases, which fail on master too
- [x] `npm run bench -- --check`: no regressions against the baseline. One run on this base flagged `hover: checkbox enter/leave x5` with a single full-window frame while the full suite ran beside it; alone it reads 0.00 Mpx here and on master, three runs each
- [x] `npm run format:check`, `eslint`, `tsc`
