### PR TITLE
fix(scroll): a scrollTo reaches rows added in the same commit

### DIFF
--- a/docs/elements.md
+++ b/docs/elements.md
@@ -1145,19 +1145,25 @@ node fully visible, and is safe to call from an effect right after that
 node mounts: the request is resolved on the next layout pass, when the
 node actually has geometry.
 
-So is a `scrollTo` made before the pane's first layout. Until a pass has
-measured the content there is nothing to clamp the offset to, so it is held,
-and that pass applies it, clamped to what it found, before the frame paints:
-restoring a list's position from a mount-time `useLayoutEffect` shows the
-list at that position in its first frame. A `scrollBy` after it moves on
-from the held offset. Once the pass is over, after that frame, `onScroll`
-reports where the pane landed, if it moved; until then `scrollX`/`scrollY`
-keep their old values. On a pane that has been laid out, `scrollTo` moves
-the offset and
-fires `onScroll` inside the call, clamped to the content as the last layout
-measured it — so a `scrollTo` past the end of rows added in the same commit
-stops at the old end, and `scrollIntoView` on the new last row is what
-reaches it.
+`scrollTo` answers inside the call, from the extent the last layout pass
+measured: the offset moves and `onScroll` fires before it returns. When a
+pass is already owed, the part of the request that extent could not answer
+is kept as well, and the pass answers it again against the content it
+measures, before the frame paints. Two cases need that:
+
+- A pane no pass has laid out yet has no extent at all. Restoring a list's
+  position from a mount-time `useLayoutEffect` shows the list at that
+  position in its first frame.
+- Rows added in the commit the request comes from are not in the extent
+  yet. A log that follows its new lines with `scrollTo(Infinity)` from a
+  layout effect shows each one at the end, in the first frame that has it.
+
+`Infinity` means the end, wherever the pass finds it, and the End key goes
+there the same way. Prefer it to `contentHeight`, which is the last pass's
+measurement too: a target computed from it falls short when a commit adds
+more than a viewport. A `scrollBy` made before that pass moves on from where
+the pass puts the pane. Until the pass, `scrollX`/`scrollY` read the call's
+answer, and `onScroll` reports the pass's once it is over.
 
 `onScroll` fires for **every** move of the offsets, not only the ones a call
 made. The wheel, the keys, a bar and `scrollTo`/`scrollBy` on a laid-out

--- a/docs/react-features.md
+++ b/docs/react-features.md
@@ -79,10 +79,11 @@ before the layout pass, so `abs` there is still the previous frame's rect
 before. For a size, let the element report it with `onLayout`
 ([below](#measuring-a-node)); for a style that depends on one, write a
 container query ([styling.md](styling.md#container-queries)), which the
-pass answers in the same frame. `scrollIntoView`, and a `scrollTo` on a pane
-that has not been laid out yet, measure nothing when you call them — the
-pass resolves them — so they are safe here
-([elements.md](elements.md#scrolling)).
+pass answers in the same frame. `scrollIntoView` measures nothing when you
+call it, and neither does the part of a `scrollTo` past the extent the last
+pass measured, which is what `scrollTo(Infinity)` asks for when it follows
+rows this commit added. The pass answers both against the geometry it
+produces, so they are safe here ([elements.md](elements.md#scrolling)).
 
 The same boundary is why an event handler feels instant: react-x11 lands the
 React update caused by a click or a keystroke **before** the frame goes out,

--- a/examples/chat.jsx
+++ b/examples/chat.jsx
@@ -68,6 +68,7 @@ import React, {
   use,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useOptimistic,
   useRef,
@@ -741,14 +742,20 @@ class PaneBoundary extends React.Component {
  * there. Scroll up and new lines stop yanking the view — the check is
  * against the *previous* frame's offset, because by the time the effect runs
  * the content is already taller.
+ *
+ * A layout effect, so a new line and the scroll that shows it paint in one
+ * frame. And `Infinity` rather than `contentHeight`, which is the last
+ * layout's measurement and does not have this commit's lines in it yet: the
+ * layout pass answers `scrollTo(Infinity)` against the content it measures
+ * (docs/elements.md#scrolling).
  */
 function Scrollback({ channel, messages }) {
   const ref = useRef(null);
   const pinned = useRef(true);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const node = ref.current;
-    if (node && pinned.current) node.scrollTo(node.contentHeight);
+    if (node && pinned.current) node.scrollTo(Infinity);
   }, [messages]);
 
   return (

--- a/src/nodes.js
+++ b/src/nodes.js
@@ -7654,6 +7654,30 @@ const SCROLLBAR_SLOP = 4;
 
 const clampScroll = (v, max) => Math.min(Math.max(0, v), max);
 
+/**
+ * One axis of a scroll request held for a pass
+ * (`Scrollable._holdScrollTo`): `{ base, steps }`, the request the extent in
+ * hand could not answer and the relative ones made after it. `to` is the new
+ * request on this axis (null leaves the axis alone), `step` its delta when
+ * it was relative.
+ */
+function holdAxis(held, to, step, owed, max) {
+  if (to == null) return held ?? null;
+  if (held && step != null) {
+    return { base: held.base, steps: [...held.steps, step] };
+  }
+  return owed && to > max ? { base: to, steps: [] } : null;
+}
+
+/** Where a held axis lands against the extent a pass measured: the base,
+ *  clamped, then each step from there, clamped in turn — the answers a pane
+ *  that already had this extent would have given one request at a time. */
+function replayHeld({ base, steps }, max) {
+  let at = clampScroll(base, max);
+  for (const step of steps) at = clampScroll(at + step, max);
+  return at;
+}
+
 // Every box and every window now answers `_scrollbars()`, and almost none of
 // them has any: the shared empty keeps that answer allocation-free on a path
 // walked per node per hit test.
@@ -8147,40 +8171,20 @@ export const Scrollable = (Base) =>
       );
     }
 
-    _scrollToDevice(want) {
-      // A pane no layout pass has placed as a scroller has no extent to
-      // clamp against: on mount `contentHeight` and `abs` are still the
-      // zeros they were built with, so the clamp below would turn any offset
-      // into 0 and drop the request — which is what restoring a list's
-      // position from a mount-time effect runs into, and so does a box that
-      // starts scrolling in the same commit. The offset is held instead, the
-      // way `scrollIntoView` holds its node, and `_resolveScrollTo` applies
-      // it against what the pass measures. `_childOrigin` is the witness:
-      // the first pass that places this pane's children as a scroller
-      // writes it, and a style that stops scrolling clears it. Nothing is
-      // armed for the blit, since that pass is a layout change rather than a
-      // pure scroll, and `onScroll` waits for the pass as well.
-      if (this._childOrigin == null && this.isScroller()) {
-        this._scrollToTarget = {
-          x: want.x ?? this._scrollToTarget?.x,
-          y: want.y ?? this._scrollToTarget?.y,
-        };
-        this._invalidateLayout('scroll');
-        return;
-      }
+    _scrollToDevice(want, by = null) {
+      const maxX = this._maxScroll('x');
+      const maxY = this._maxScroll('y');
       const next = {
-        x:
-          want.x == null
-            ? this.scrollX
-            : clampScroll(want.x, this._maxScroll('x')),
-        y:
-          want.y == null
-            ? this.scrollY
-            : clampScroll(want.y, this._maxScroll('y')),
+        x: want.x == null ? this.scrollX : clampScroll(want.x, maxX),
+        y: want.y == null ? this.scrollY : clampScroll(want.y, maxY),
       };
-      if (next.x === this.scrollX && next.y === this.scrollY) return;
+      const moved = next.x !== this.scrollX || next.y !== this.scrollY;
+      const holding = this._holdScrollTo(want, by, maxX, maxY);
+      if (!moved && !holding) return;
       const root = this.root;
-      if (root) {
+      // A pane no pass has placed arms nothing: its first pass is a layout
+      // change rather than a pure scroll.
+      if (root && this._childOrigin != null) {
         // Arming is the one moment the evidence still exists: the viewport
         // claim recorded below coalesces earlier claims into itself
         // (addDamageRect keeps the list disjoint), after which a change
@@ -8224,7 +8228,7 @@ export const Scrollable = (Base) =>
       }
       this.scrollX = next.x;
       this.scrollY = next.y;
-      this.props.onScroll?.(this._scrollEvent());
+      if (moved) this.props.onScroll?.(this._scrollEvent());
       // A scroll reflows this viewport's contents and nothing else, and the
       // viewport clips them, so the damage is this node's own rect. It is a
       // layout change all the same — children's absolute positions move — hence
@@ -8238,21 +8242,59 @@ export const Scrollable = (Base) =>
     }
 
     /**
-     * Apply the offset a `scrollTo` asked for before this pane's first
-     * layout (see `_scrollToDevice`), clamped to the extent the pass has
-     * just measured. Its `onScroll` is the pass's, like every move layout
-     * makes (see `_absolutizeChildren`).
+     * Keep the part of a request the extent in hand cannot answer, for the
+     * pass that will measure one that can. `_scrollToDevice` clamps against
+     * `contentWidth`/`contentHeight` and `abs` as the last pass left them,
+     * and two kinds of pane have nothing better there yet:
+     *
+     * - one no pass has placed as a scroller (`_childOrigin` is the
+     *   witness): on mount those are still the zeros they were built with,
+     *   and a box that starts scrolling in the same commit never measured
+     *   them. Restoring a list's position from a mount-time effect is the
+     *   case.
+     * - one whose next pass is already owed (`needsLayout`): rows mounted in
+     *   the commit the request comes from are not in the extent yet, so a
+     *   follow to the end from a layout effect stopped at the old end.
+     *
+     * What the extent in hand can answer still lands at once, with its
+     * `onScroll` and its blit origin. The request is kept as well, and
+     * `_resolveScrollTo` answers it again against what the pass measures,
+     * before anything is placed.
+     *
+     * Per axis, a request replaces whatever was held on that axis, and a
+     * relative one (`by`) made while something is held is kept as a step
+     * after it, so the pass replays the frame's requests the way a pane with
+     * a fresh extent would have taken them. Returns whether anything is
+     * held.
+     */
+    _holdScrollTo(want, by, maxX, maxY) {
+      const root = this.root;
+      const owed =
+        this.isScroller() &&
+        (this._childOrigin == null ||
+          (root != null && root.needsLayout && !root._inFlush));
+      const was = this._scrollToTarget;
+      const x = holdAxis(was?.x, want.x, by?.x, owed, maxX);
+      const y = holdAxis(was?.y, want.y, by?.y, owed, maxY);
+      this._scrollToTarget = x || y ? { x, y } : null;
+      if (!this._scrollToTarget) return false;
+      if (root) (root._heldScrolls ??= new Set()).add(this);
+      return true;
+    }
+
+    /**
+     * Answer a held request (`_holdScrollTo`) against the extent this pass
+     * has just measured: each held axis's base, clamped, then each step
+     * after it, clamped in turn. Its `onScroll` is the pass's, like every
+     * move layout makes (see `_absolutizeChildren`).
      */
     _resolveScrollTo() {
-      const target = this._scrollToTarget;
-      if (!target) return;
+      const held = this._scrollToTarget;
+      if (!held) return;
       this._scrollToTarget = null;
-      if (target.x != null) {
-        this.scrollX = clampScroll(target.x, this._maxScroll('x'));
-      }
-      if (target.y != null) {
-        this.scrollY = clampScroll(target.y, this._maxScroll('y'));
-      }
+      this.root?._heldScrolls?.delete(this);
+      if (held.x) this.scrollX = replayHeld(held.x, this._maxScroll('x'));
+      if (held.y) this.scrollY = replayHeld(held.y, this._maxScroll('y'));
     }
 
     /**
@@ -8311,30 +8353,32 @@ export const Scrollable = (Base) =>
      * `scrollTo`. */
     scrollBy(by) {
       const s = this.scale;
-      if (typeof by === 'number')
-        return this._scrollToDevice({ y: this._scrollBase('y') + by * s });
-      this._scrollToDevice({
-        x: by?.x == null ? undefined : this._scrollBase('x') + by.x * s,
-        y: by?.y == null ? undefined : this._scrollBase('y') + by.y * s,
-      });
+      const step =
+        typeof by === 'number'
+          ? { y: by * s }
+          : {
+              x: by?.x == null ? undefined : by.x * s,
+              y: by?.y == null ? undefined : by.y * s,
+            };
+      this._scrollToDevice(
+        {
+          x: step.x == null ? undefined : this.scrollX + step.x,
+          y: step.y == null ? undefined : this.scrollY + step.y,
+        },
+        step,
+      );
     }
 
     /** The wheel's and the key handler's entry: whole device pixels, which
      * is what keeps the scroll blit on the pixel grid at any scale. */
     _scrollByDevice(dx, dy) {
-      this._scrollToDevice({
-        x: dx ? this._scrollBase('x') + dx : undefined,
-        y: dy ? this._scrollBase('y') + dy : undefined,
-      });
-    }
-
-    /** Where a relative scroll starts on one axis: the offset in force, or
-     * the one a `scrollTo` is holding for the first layout, so a `scrollBy`
-     * after it moves on from there, as it would on a laid-out pane. */
-    _scrollBase(axis) {
-      const held = this._scrollToTarget?.[axis];
-      if (held != null) return held;
-      return axis === 'x' ? this.scrollX : this.scrollY;
+      this._scrollToDevice(
+        {
+          x: dx ? this.scrollX + dx : undefined,
+          y: dy ? this.scrollY + dy : undefined,
+        },
+        { x: dx || undefined, y: dy || undefined },
+      );
     }
 
     /**
@@ -8400,7 +8444,8 @@ export const Scrollable = (Base) =>
         case XK_HOME:
           return this._scrollToDevice({ y: 0 });
         case XK_END:
-          return this._scrollToDevice({ y: this._maxScroll('y') });
+          // the end the pass measures, if one is owed (`_holdScrollTo`)
+          return this._scrollToDevice({ y: Infinity });
         case XK_SPACE:
           return this._scrollByDevice(0, ev.shiftKey ? -page : page);
         default:
@@ -13858,6 +13903,15 @@ export class WindowNode extends Scrollable(Node) {
       // …and placed nodes against the arrangement that walk produced: where
       // one goes depends on where its pane and its parent landed
       if (this._placedNodes.size !== 0) this._placeNodes();
+      // A held scroll request the walk never reached goes, rather than
+      // landing on some later pass. A pane no pass has placed yet keeps it:
+      // its first placement is the pass it is waiting for.
+      if (this._heldScrolls?.size) {
+        for (const node of this._heldScrolls) {
+          if (node._childOrigin != null) node._scrollToTarget = null;
+        }
+        this._heldScrolls.clear();
+      }
       this.needsLayout = false;
       this.needsPaint = true;
       // The other half of a contained reflow: the pre-mutation arrangement was

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -653,11 +653,11 @@ export interface ScrollProps {
   /**
    * The offsets moved, by any route. The wheel, the keys, a bar and
    * `scrollTo`/`scrollBy` report inside the call. Layout reports once its
-   * pass is over, after the frame that shows the move: a `scrollTo` held
-   * for the pane's first layout landing, a `scrollIntoView` resolving, or
-   * the offset pulled back when the content shrinks or the viewport grows
-   * under it. Each report carries the offsets in force when it is
-   * delivered.
+   * pass is over, after the frame that shows the move: a held `scrollTo`
+   * landing (one made before the pane's first layout, or past the extent
+   * the last pass measured), a `scrollIntoView` resolving, or the offset
+   * pulled back when the content shrinks or the viewport grows under it.
+   * Each report carries the offsets in force when it is delivered.
    */
   onScroll?: (ev: ScrollEvent) => void;
   /** Fired from layout, so it arrives for a list nobody has scrolled yet. */

--- a/src/types/nodes.d.ts
+++ b/src/types/nodes.d.ts
@@ -125,12 +125,20 @@ export interface ScrollableNode extends DrawnNode {
   readonly contentHeight: number;
   /**
    * A number scrolls the vertical axis; an object moves either or both,
-   * clamped to the content. Made before the pane's first layout, when there
-   * is no content to clamp to yet, the offset is held and that layout
-   * applies it — so a mount-time effect can restore a position — and
-   * `onScroll` reports it once it has.
+   * clamped to the content. It answers at once from the extent the last
+   * layout pass measured. While a pass is owed — before the pane's first
+   * layout, or in the commit that added its new rows — whatever it asks past
+   * that extent is held too, and the pass answers it again against the
+   * content it measures, before the frame paints: `scrollTo(Infinity)` from
+   * a layout effect follows new rows to the end in the frame that shows
+   * them. `onScroll` reports the call's answer at once, and the pass's once
+   * that pass is over.
    */
   scrollTo(to: number | ScrollTarget): void;
+  /**
+   * The same, by a delta. Made while a `scrollTo` is held for the pass, it
+   * moves on from where the pass puts the pane.
+   */
   scrollBy(by: number | ScrollTarget): void;
   /**
    * Is there room to move on the axis a delta names? What the wheel's

--- a/test/chat.test.js
+++ b/test/chat.test.js
@@ -334,6 +334,34 @@ describe('examples/chat', () => {
     assert.equal(composer('#general').value, 'half a thought');
   });
 
+  test('the log keeps a sent message in view once it overflows', async () => {
+    // The follow is `scrollTo(Infinity)` from a layout effect, and the
+    // frame's layout pass answers it against the content it measures.
+    // Clamped against the last pass's extent instead, every send landed one
+    // line short of the end, with the message just sent below the fold.
+    await mount(testTransport());
+    const pane = log('#general');
+    let overflowed = 0;
+    for (let i = 0; overflowed < 3 && i < 40; i++) {
+      const text = `msg ${i}.`;
+      await userEvent.type(composer('#general'), `${text}\n`);
+      await waitFor(() => {
+        const [line] = within(pane).getAllByText(text);
+        assert.ok(line.abs?.height > 0, `${text} is not laid out yet`);
+      });
+      const end = pane.contentHeight - pane.abs.height;
+      if (end <= 0) continue;
+      overflowed += 1;
+      assert.equal(pane.scrollY, end, `${text} left the log short of its end`);
+      const [line] = within(pane).getAllByText(text);
+      assert.ok(
+        line.abs.y + line.abs.height <= pane.abs.y + pane.abs.height,
+        `${text} is below the fold`,
+      );
+    }
+    assert.equal(overflowed, 3, 'the log never overflowed');
+  });
+
   // Deliberately not tested here: the #202/#323 promise that a hidden pane
   // stops taking keys. This app cannot isolate it — the only way to hide a
   // channel is to click another one, and that click moves the focus itself,

--- a/test/scroll-to-pending-layout.test.js
+++ b/test/scroll-to-pending-layout.test.js
@@ -1,0 +1,326 @@
+// A `scrollTo` on a pane that has been laid out, made from the commit that
+// grew its content: the chat and log pattern, where a row is appended and a
+// `useLayoutEffect` then scrolls to the end. The new row is mounted but not
+// yet measured when the effect runs, since layout happens on the frame
+// clock, after the commit.
+//
+// Production scheduling throughout (createMockApp + createRoot, setImmediate
+// ticks, no act), because what is asserted is which frame shows what.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import React, { useLayoutEffect, useState } from 'react';
+import xserver from 'x11/lib/xserver/index.js';
+import { createClient, StaticFontSource } from 'ntk';
+import { createRoot } from '../src/index.js';
+import { hooks } from '../src/trace-registry.js';
+import { createMockApp } from './helpers/mock-app.js';
+
+const h = React.createElement;
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+// the commit, the frame it schedules, and the reports deferred past it
+const settle = async () => {
+  for (let i = 0; i < 6; i++) await tick();
+};
+
+/**
+ * A 100px pane over `count` 80px rows in a 200x100 window: 240 of content,
+ * so the furthest it scrolls is 140. `grow()` commits one more row, and
+ * `follow(pane, rows)` runs from that commit's layout effect, with the new
+ * row mounted but not laid out.
+ *
+ * `frames` is every frame painted after the mount, with the pane's offset
+ * and extent as it stood right after it (the tracer's `frame` hook), and
+ * `scrolls` every `onScroll`, with how many frames had painted when it
+ * arrived.
+ */
+async function mountLog({
+  follow = () => {},
+  count = 3,
+  size = { width: 200, height: 100 },
+  pane = { height: 100 },
+  row = () => ({ height: 80, flexShrink: 0 }),
+} = {}) {
+  const app = createMockApp();
+  const x11Root = await createRoot({ app });
+  const ref = React.createRef();
+  const rows = [];
+  const frames = [];
+  const scrolls = [];
+  let setCount;
+  function Log() {
+    const [n, setN] = useState(count);
+    setCount = setN;
+    while (rows.length < n) rows.push(React.createRef());
+    useLayoutEffect(() => {
+      if (n > count) {
+        follow(
+          ref.current,
+          rows.slice(0, n).map((r) => r.current),
+        );
+      }
+    }, [n]);
+    return h(
+      'box',
+      {
+        ref,
+        style: { overflow: 'scroll', ...pane },
+        onScroll: (ev) => scrolls.push({ ev, frames: frames.length }),
+      },
+      ...Array.from({ length: n }, (_, i) =>
+        h('box', { key: i, ref: rows[i], style: row(i) }),
+      ),
+    );
+  }
+  x11Root.render(h('window', size, h(Log)));
+  await settle();
+  const outer = hooks.frame;
+  hooks.frame = () => {
+    frames.push({
+      scrollY: ref.current.scrollY,
+      contentHeight: ref.current.contentHeight,
+    });
+  };
+  const wnd = app.windows[0];
+  return {
+    app,
+    wnd,
+    root: wnd._reactX11Node,
+    pane: ref.current,
+    frames,
+    scrolls,
+    grow: async (rows = 1) => {
+      setCount((n) => n + rows);
+      await settle();
+    },
+    done: async () => {
+      hooks.frame = outer;
+      await x11Root.unmount();
+    },
+  };
+}
+
+test('a scrollTo past the old end, from the commit that added a row, reaches the new end', async () => {
+  const log = await mountLog({ follow: (pane) => pane.scrollTo(1000) });
+  assert.strictEqual(log.pane.scrollY, 0);
+  await log.grow();
+  assert.strictEqual(log.pane.contentHeight, 320);
+  assert.strictEqual(log.pane.scrollY, 220, '320 of content in a 100px pane');
+  assert.deepStrictEqual(
+    log.frames.map((f) => f.scrollY),
+    [220],
+    'in the frame that shows the new row',
+  );
+  await log.done();
+});
+
+test('scrollIntoView on the new row reaches the new end in the same frame', async () => {
+  const log = await mountLog({
+    follow: (pane, rows) => pane.scrollIntoView(rows.at(-1)),
+  });
+  await log.grow();
+  assert.strictEqual(log.pane.scrollY, 220);
+  assert.deepStrictEqual(
+    log.frames.map((f) => f.scrollY),
+    [220],
+  );
+  await log.done();
+});
+
+test('scrollTo(contentHeight), the chat example’s follow, reaches the new end', async () => {
+  // examples/chat.jsx: `node.scrollTo(node.contentHeight)` from a layout
+  // effect. `contentHeight` is the last pass's measurement too, so this is
+  // the same stale clamp reached through a stale target.
+  const log = await mountLog({
+    follow: (pane) => pane.scrollTo(pane.contentHeight),
+  });
+  await log.grow();
+  assert.strictEqual(log.pane.scrollY, 220);
+  await log.done();
+});
+
+test('a scrollBy after a held scrollTo moves on from where the pass puts it', async () => {
+  // a follow to the end, then a notch back up before the frame: a reader
+  // leaving a log that is still growing lands 48 short of the new end, not
+  // of the old one
+  const log = await mountLog({
+    follow: (pane) => {
+      pane.scrollTo(1000);
+      pane.scrollBy(-48);
+    },
+  });
+  await log.grow();
+  assert.strictEqual(log.pane.scrollY, 172, '220 - 48');
+  await log.done();
+});
+
+test('notches past the old end go as far as they would on the new extent', async () => {
+  // at the old end, two notches down in the commit that brought two rows:
+  // 400 of content, so the pane can go the whole 96 past 140
+  const log = await mountLog({
+    follow: (pane) => {
+      pane.scrollBy(48);
+      pane.scrollBy(48);
+    },
+  });
+  log.pane.scrollTo(1000);
+  await settle();
+  assert.strictEqual(log.pane.scrollY, 140, 'at the old end');
+  await log.grow(2);
+  assert.strictEqual(log.pane.contentHeight, 400);
+  assert.strictEqual(log.pane.scrollY, 236, '140 + 2 × 48');
+  await log.done();
+});
+
+// --- pixel truth: a held answer rides the blit ------------------------------
+//
+// The pass answers a held request before anything is placed, and the blit
+// was armed by the immediate half from the offsets on screen, so a frame that
+// stays a blit shifts by the whole move and not by the part the old extent
+// allowed. Against the real ntk and the in-process X server, like the
+// byte-identical tests in scroll-blit.test.js.
+
+const require = createRequire(import.meta.url);
+
+async function createHeadlessApp() {
+  const server = xserver.createServer({ width: 640, height: 480 });
+  const [serverEnd, clientEnd] = xserver.createStreamPair();
+  server.addClientStream(serverEnd);
+  const fontSource = new StaticFontSource();
+  fontSource.add(
+    readFileSync(
+      join(
+        dirname(require.resolve('katex/package.json')),
+        'dist',
+        'fonts',
+        'KaTeX_Main-Regular.ttf',
+      ),
+    ),
+    { family: 'Test Main' },
+  );
+  fontSource.alias('sans-serif', 'Test Main');
+  return await createClient({ stream: clientEnd, fontSource });
+}
+
+const roundTrip = (app) =>
+  new Promise((resolve, reject) =>
+    app.X.GetInputFocus((err) => (err ? reject(err) : resolve())),
+  );
+
+const readPixels = (ctx, w, h) =>
+  new Promise((resolve, reject) =>
+    ctx.getImageData(0, 0, w, h, (err, data) =>
+      err ? reject(err) : resolve(data),
+    ),
+  );
+
+const textRow = (i) =>
+  h(
+    'box',
+    {
+      key: i,
+      style: {
+        height: 40,
+        flexShrink: 0,
+        padding: 6,
+        backgroundColor: i % 2 ? '#ffffff' : '#dbe4ee',
+      },
+    },
+    h('text', { style: { fontSize: 12, color: '#20304a' } }, `row ${i}`),
+  );
+
+test('a held answer in a frame that blits shifts by the whole move, byte-identical to a repaint', async (t) => {
+  const app = await createHeadlessApp();
+  const x11Root = await createRoot({ app });
+  try {
+    const ref = React.createRef();
+    function Log({ extra }) {
+      useLayoutEffect(() => {
+        // a notch past the old end, from the commit that grew the content
+        if (extra > 0) ref.current.scrollBy(48);
+      }, [extra]);
+      return h(
+        'box',
+        { ref, style: { overflow: 'scroll', flexGrow: 1 } },
+        ...Array.from({ length: 20 }, (_, i) => textRow(i)),
+        // a row arriving below the fold: the footer's claim lies outside the
+        // viewport, so the frame stays a blit candidate — and a short one,
+        // since the ledger sums the entering row's claims, which overlap
+        h(
+          'box',
+          { key: 'footer', style: { flexShrink: 0 } },
+          ...Array.from({ length: extra }, (_, i) =>
+            h('box', {
+              key: i,
+              style: { height: 20, flexShrink: 0, backgroundColor: '#ffd966' },
+            }),
+          ),
+        ),
+      );
+    }
+    const tree = (extra) =>
+      h(
+        'window',
+        { width: 400, height: 300, style: { backgroundColor: '#f5f6fa' } },
+        h(Log, { extra }),
+      );
+    const instance = await new Promise((resolve) =>
+      x11Root.render(tree(0), resolve),
+    );
+    if (typeof instance.scrollRegion !== 'function') {
+      t.skip('installed ntk has no Window.scrollRegion yet');
+      return;
+    }
+    const root = instance._reactX11Node;
+    const frame = () => {
+      root._scheduled = false;
+      root.flush();
+    };
+    frame();
+    await roundTrip(app);
+    const pane = ref.current;
+    // 20 short of the old end: 800 of content in a 300px pane
+    pane.scrollTo(480);
+    frame();
+    await roundTrip(app);
+    assert.strictEqual(pane.scrollY, 480);
+
+    const shifts = [];
+    const realScrollRegion = instance.scrollRegion.bind(instance);
+    instance.scrollRegion = (rect, dx, dy) => {
+      shifts.push([dx, dy]);
+      return realScrollRegion(rect, dx, dy);
+    };
+    await new Promise((resolve) => x11Root.render(tree(1), resolve));
+    assert.strictEqual(pane.scrollY, 500, 'the old extent answers 20 at once');
+    frame();
+    await roundTrip(app);
+    assert.strictEqual(pane.contentHeight, 820);
+    assert.strictEqual(
+      pane.scrollY,
+      520,
+      'and the pass the rest: 528, clamped to the new end',
+    );
+    assert.deepStrictEqual(
+      shifts,
+      [[0, -40]],
+      'one blit, by the whole move from the offsets on screen',
+    );
+    assert.ok(root._lastDamageRects, 'the frame stayed bounded');
+    const blitted = await readPixels(root._ctx, 400, 300);
+
+    root.invalidate(false);
+    frame();
+    await roundTrip(app);
+    const repainted = await readPixels(root._ctx, 400, 300);
+    assert.ok(
+      Buffer.from(blitted.data).equals(Buffer.from(repainted.data)),
+      'blitted pixels differ from a full repaint of the same state',
+    );
+  } finally {
+    await x11Root.unmount();
+    await app.close();
+  }
+});


### PR DESCRIPTION
A `scrollTo` on a laid-out pane clamped against the extent the last layout pass measured. Rows mounted in the commit the request came from are not in that extent yet, so the chat and log pattern stopped at the old end: append a line, then follow it to the end from a layout effect. A 100px pane over three 80px rows, given a fourth row and `scrollTo(1000)` in the same commit, landed at 140 while the new maximum was 220.

`examples/chat.jsx` hit it on every send. Sending is a discrete event, and a sync-lane commit flushes passive effects before the frame, so its `useEffect` follow ran against the old extent. Driven through `renderX11`, each of 19 sends past the first screenful left the log one line short of its end, with the message just sent below the fold.

| master | this branch |
| --- | --- |
| ![chat-follow-before](https://github.com/user-attachments/assets/9881d598-1d4c-4ab1-84b5-26b767b8a8fc) | ![chat-follow-after](https://github.com/user-attachments/assets/44f0744f-cf00-40bd-9046-27b1da4ecfd1) |

Both shots come from the same script: the chat example on the in-process X server, 720 by 520, with twenty-four messages sent through the composer. On master the log stops 19px short of its end, so "message 24" is cut off below the fold; here it is in view.

## What changes

The call still answers at once from the extent in hand: the offset moves, `onScroll` fires, and the scroll blit arms from the offsets on screen, exactly as before. When a layout pass is already owed and the request asks past that extent, it is also held, per axis, as a base plus the relative steps made after it. The pass replays it against the extent it measures, right after `measureScrollContent` and before any child is placed, so the layout diff, the blit ledger and the blit itself all see the final offset. The move is reported through the pass's `onScroll`, the one #530 added for `scrollIntoView` and the clamp.

- **#528 folds into the same rule.** A pane no pass has placed has no extent at all. It keeps its hold until its first placement and arms nothing, as before. The relative base #528 kept is replaced by the replay, which also gets a `scrollBy` after an overshoot right.
- **Holds don't outlive their pass.** A held request the pass never reached is dropped rather than landing on some later pass, unless its pane has never been placed.
- **End targets the pass's end.** It sends `Infinity`, so End reaches the end the pass measures.
- **The chat example** follows with `scrollTo(Infinity)` from a layout effect, so a new line and the scroll that shows it paint in one frame.
- **Docs and types.** `docs/elements.md#scrolling` describes the rule where it used to document the limit, `docs/react-features.md` says the call is safe in a layout effect, and the types carry it on `scrollTo`, `scrollBy` and `onScroll`.

## The scroll blit

The blit shifts what is on screen from the offsets armed at the frame's first scroll, and none of that bookkeeping moves. A pixel test on the in-process X server holds an answer in a frame that still blits: `scrollBy(48)` at 480 answers 500 at once, the pass replays it to 528 and clamps it to the new end, 520. `scrollRegion` gets the whole shift, -40, and the frame matches a full repaint byte for byte. I checked the test against two wrong implementations. Re-arming the blit at the call's offsets fails it, on the pixels alone once the shift assertion is removed. Answering after the children are placed fails it on the pixels. In a scroll-only frame a hold resolves to the offset the call already answered and reports nothing, and every scroll and blit test passes unchanged.

## Tests

- `test/scroll-to-pending-layout.test.js` has six tests. They cover the repro, the chat example's own idiom, a notch back up after a follow landing 48 short of the new end, two notches past the old end going the whole 96, the `scrollIntoView` control, and the pixel test above.
- `test/chat.test.js` checks that the log keeps each sent message in view once it overflows. On master's code it fails at the first overflowing send. On this code it passes even with the old `useEffect` follow, so the fix does not depend on the example's change.
- #528's eleven tests pass unchanged.
- `npm test`, `npm run lint`, `npm run format:check` and `npm run typecheck` all pass, apart from the six macOS-only failures in `test/appearance.test.js` that master has too.

