### PR TITLE
fix(cocoa): a <glarea> is placed at once, not animated into place

### DIFF
--- a/src/cocoa/glarea.js
+++ b/src/cocoa/glarea.js
@@ -161,7 +161,7 @@ export class CocoaGLArea {
     if (this.destroyed) return;
     this.rect = rect;
     const s = this.scale;
-    this._native.setLayerProps(this.layer, {
+    this._setLayerProps({
       frame: [rect.x / s, rect.y / s, rect.width / s, rect.height / s],
       // above both presenters' content: the surface presenter's contents
       // live on the root layer itself, the layers presenter's visuals top
@@ -193,8 +193,25 @@ export class CocoaGLArea {
   }
 
   map() {
-    if (!this.destroyed) {
-      this._native.setLayerProps(this.layer, { hidden: false });
+    if (!this.destroyed) this._setLayerProps({ hidden: false });
+  }
+
+  /**
+   * Everything this layer is handed goes out with Core Animation's implicit
+   * actions off. The layer is ours, not a presenter's, so no frame's
+   * transaction covers it, and a bare set animates each key for a quarter
+   * of a second from wherever the layer was: the surface grew into place
+   * at mount and trailed every step of a live resize. A present needs
+   * nothing here — `setLayerContentsIOSurface` opens its own transaction
+   * for the flip.
+   */
+  _setLayerProps(props) {
+    const native = this._native;
+    native.txBegin({ disableActions: true });
+    try {
+      native.setLayerProps(this.layer, props);
+    } finally {
+      native.txCommit();
     }
   }
 

--- a/src/cocoa/panehost.js
+++ b/src/cocoa/panehost.js
@@ -29,11 +29,21 @@ export class CocoaPaneHost {
       return;
     }
     this._rect = { ...rect };
-    this._native.setLayerProps(this.layer, {
-      frame: [rect.x / s, rect.y / s, rect.width / s, rect.height / s],
-      zPosition: 1e7,
-      hidden: false,
-    });
+    // Actions off: the layer is ours, not a presenter's, so no frame's
+    // transaction covers it, and a bare set tweens the pane into place at
+    // mount and after every resize — the trap CocoaGLArea._setLayerProps
+    // describes.
+    const native = this._native;
+    native.txBegin({ disableActions: true });
+    try {
+      native.setLayerProps(this.layer, {
+        frame: [rect.x / s, rect.y / s, rect.width / s, rect.height / s],
+        zPosition: 1e7,
+        hidden: false,
+      });
+    } finally {
+      native.txCommit();
+    }
   }
 
   /**

--- a/test/cocoa-frames.test.js
+++ b/test/cocoa-frames.test.js
@@ -148,8 +148,16 @@ function fakeBridge({ screens } = {}) {
     },
     createLayer: () => ({ layer: ++seq }),
     addSublayer() {},
-    setLayerProps() {},
+    setLayerProps(layer, props) {
+      calls.push(['setLayerProps', layer, props]);
+    },
     removeFromSuperlayer() {},
+    txBegin(options) {
+      calls.push(['txBegin', options]);
+    },
+    txCommit() {
+      calls.push(['txCommit']);
+    },
     copySurfaceRegion(src, dst, rects) {
       calls.push(['copy', rects ? rects.length / 4 : 'all']);
     },
@@ -1001,6 +1009,31 @@ test('the host drops a present of a buffer the pane has since retired, and shows
   assert.throws(() => host.present(fresh.id), /not a layer/);
   host.destroy();
   wnd.destroy();
+});
+
+test('the host places the pane with implicit animations off', () => {
+  // The layer is the host's, not a presenter's, so no frame's transaction
+  // covers it: each set opens its own with actions off, or Core Animation
+  // tweens the pane into place at mount and after every resize.
+  const native = fakeBridge();
+  const host = new CocoaPaneHost(
+    { _native: native },
+    { _layer: { root: 1 }, scale: 2 },
+  );
+  host.setRect({ x: 20, y: 20, width: 360, height: 200 });
+  host.setRect({ x: 20, y: 20, width: 560, height: 320 });
+  const place = (frame) => [
+    ['txBegin', { disableActions: true }],
+    ['setLayerProps', host.layer, { frame, zPosition: 1e7, hidden: false }],
+    ['txCommit'],
+  ];
+  assert.deepEqual(
+    native.calls.filter(([name]) =>
+      ['txBegin', 'setLayerProps', 'txCommit'].includes(name),
+    ),
+    [...place([10, 10, 180, 100]), ...place([10, 10, 280, 160])],
+  );
+  host.destroy();
 });
 
 // --- the wheel ----------------------------------------------------------------------

--- a/test/cocoa-glarea.test.js
+++ b/test/cocoa-glarea.test.js
@@ -1,0 +1,139 @@
+// <glarea> on the Cocoa backend (src/cocoa/glarea.js) over the fake bridge:
+// the real CocoaApp, window and node tree, and a GL runtime with nothing
+// behind it, so what a test pins is the layer calls that went out.
+//
+// The surface is a sublayer of the window's root layer, placed outside
+// either presenter's frame. Core Animation animates every animatable key a
+// standalone layer is handed outside a disabled-actions transaction — a
+// quarter of a second, from wherever the layer was — so each of those sets
+// has to open its own. Without one the surface grew into place at mount
+// and trailed every step of a live resize.
+import { test, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+
+import { createRoot } from '../src/index.js';
+import { fakeCocoaApp, tick } from './helpers/cocoa-bridge.js';
+
+const h = React.createElement;
+
+const roots = [];
+afterEach(async () => {
+  for (const root of roots.splice(0)) await root.unmount();
+});
+
+/** A GL runtime with nothing behind it: targets are ids, draws are no-ops. */
+function fakeGLRuntime() {
+  let seq = 1000;
+  const noop = () => {};
+  return {
+    gl: {
+      viewport: noop,
+      clearColor: noop,
+      clear: noop,
+      flush: noop,
+      bindFramebuffer: noop,
+      COLOR_BUFFER_BIT: 0x4000,
+      DEPTH_BUFFER_BIT: 0x100,
+    },
+    glVersion: '4.1',
+    frameInterval: 16,
+    ctx: {
+      createTarget: () => {
+        const id = ++seq;
+        return { iosurfaceId: id, fbo: id, destroy: noop };
+      },
+      bindTarget: noop,
+    },
+  };
+}
+
+const findGLArea = (node) =>
+  node.isGlArea ? node : (node.children ?? []).map(findGLArea).find(Boolean);
+
+/**
+ * A `<glarea>` inset 10px in a 200x120 `<window>` at scale 2, mounted, its
+ * surface created and a frame run.
+ */
+async function mountGLArea() {
+  const { native, app } = fakeCocoaApp();
+  // the runtime chooseGLConfig resolves, settled before anything asks: no
+  // x11-dri and no CGL context, so this runs on any OS
+  const runtime = fakeGLRuntime();
+  app._cocoaGL = runtime;
+  app._cocoaGLPromise = Promise.resolve(runtime);
+  const root = await createRoot({ app });
+  roots.push(root);
+  root.render(
+    h(
+      'window',
+      { width: 200, height: 120 },
+      h(
+        'box',
+        { style: { flexGrow: 1, padding: 10 } },
+        h('glarea', { style: { flexGrow: 1 } }),
+      ),
+    ),
+  );
+  await tick();
+  const wnd = [...app._windows.values()][0];
+  const node = findGLArea(wnd._reactX11Node);
+  for (let i = 0; i < 10 && !node.window; i++) await tick();
+  assert.ok(node.window, 'the surface was created');
+  const frame = () => {
+    app._tickFrames();
+    app._presentAll();
+  };
+  frame();
+  return { native, wnd, node, frame };
+}
+
+/**
+ * Every `setLayerProps` on `layer`, in order, each with whether a
+ * disabled-actions transaction was open around it.
+ */
+function layerSets(native, layer) {
+  const open = [];
+  const sets = [];
+  for (const { name, args } of native.calls) {
+    if (name === 'txBegin') open.push(args[0]?.disableActions === true);
+    else if (name === 'txCommit') open.pop();
+    else if (name === 'setLayerProps' && args[0] === layer) {
+      sets.push({ props: args[1], still: open.includes(true) });
+    }
+  }
+  return sets;
+}
+
+test('the surface is placed at mount without an implicit animation', async () => {
+  const { native, node } = await mountGLArea();
+  const layer = node.window.layer;
+  const sets = layerSets(native, layer);
+  assert.ok(sets.length > 0);
+  assert.deepEqual(
+    sets.filter((s) => !s.still).map((s) => s.props),
+    [],
+    'every set went out with actions off',
+  );
+  // in points: the 10px inset of the 200x120 window, flipped for GL's rows
+  assert.deepEqual(layer.props.frame, [10, 10, 180, 100]);
+  assert.deepEqual(layer.props.transform, { scaleY: -1 });
+  assert.equal(layer.props.hidden, false);
+});
+
+test('a window resize moves the surface without an implicit animation', async () => {
+  const { native, wnd, node, frame } = await mountGLArea();
+  const layer = node.window.layer;
+  const mounted = layerSets(native, layer).length;
+  // device px, the unit CocoaWindow.resize takes: 300x180 points
+  wnd.resize(600, 360);
+  frame();
+  const sets = layerSets(native, layer).slice(mounted);
+  assert.ok(sets.length > 0, 'the resize reached the layer');
+  assert.deepEqual(
+    sets.filter((s) => !s.still).map((s) => s.props),
+    [],
+    'every set went out with actions off',
+  );
+  assert.deepEqual(layer.props.frame, [10, 10, 280, 160]);
+});


### PR DESCRIPTION
## Symptom

On the Cocoa backend a `<glarea>` animated into place: at launch it visibly grew into its laid-out rect, and during a live window resize it jiggled through a run of small, overlapping resize animations.

## Cause

The GL surface is a sublayer of the window's root layer, placed outside either presenter's frame. `CocoaGLArea.setState` and `map` sent its frame, flip transform and zPosition through a bare `setLayerProps`, and Core Animation gives a standalone layer an implicit 0.25s animation for every animatable key set outside a disabled-actions transaction. The layer presenter and promotion never hit this because each wraps its whole frame in `txBegin({ disableActions: true })`; the GL present was already safe because the bridge's `setLayerContentsIOSurface` brackets the flip itself.

## Fix

- `src/cocoa/glarea.js`: every set on the layer goes through `CocoaGLArea._setLayerProps`, which opens a disabled-actions transaction around it.
- `src/cocoa/panehost.js`: the `<Frame>` pane host placed its sublayer the same way, and `setRect` gets the same bracket.

## Measured

On the real bridge, appkit 0.9.0 via `REACT_X11_CALAYERS_PATH`, a probe sampled the GL layer's presentation values every ~4ms — where the render server is actually drawing it — and counted the samples that match no frame set from JS, that is, an animation in flight:

| | before | after |
|---|---|---|
| mount | 35 of 83 samples | 0 of 97 |
| one window resize | 52 of 101 | 0 of 102 |
| drag-like run of 20 resizes, 16ms apart | 123 of 138 | 0 of 133 |

The pane host change is pinned by its unit test only; it was not probed live.

## Tests

- `test/cocoa-glarea.test.js`, new: mounts a `<glarea>` under the real `CocoaApp` over the fake bridge, with a GL runtime that has nothing behind it, so it runs on any OS. It checks that every layer set at mount and after a window resize goes out inside a disabled-actions transaction and lands at the laid-out rect. Both tests fail without the fix.
- `test/cocoa-frames.test.js`: the fake now records `txBegin`, `txCommit` and `setLayerProps`, and a new test pins the pane host's bracket. It fails without the fix.
- Full suite on macOS: 2345 of 2351 pass; the six failures are `test/appearance.test.js`, the known macOS baseline.

## Bench

`npm run bench:touched` owes the Cocoa presenters gate for `src/cocoa/`. Every rule holds except `covered/surface`, which fails the same way on origin/master on this Mac: 354 and 353 frames on master against 353 and 354 on the branch, run alternately with `--check --scenario=covered`. The WindowServer here does not deliver the occlusion change for the bench's cover window, and the scenario mounts no `<glarea>` or `<Frame>`. The `bench-cocoa` job is the judge of that rule.

## Not in this PR

`CocoaGLArea` has no `unmap()`, so `GlAreaNode.setHidden(true)` — Suspense hiding — most likely leaves the GL layer drawn over the fallback on Cocoa. That is a separate fix.
