### PR TITLE
fix(examples): the stress frame log survives a frame painted on layers only

### DIFF
--- a/examples/stress/perf.js
+++ b/examples/stress/perf.js
@@ -14,6 +14,10 @@
 
 const fmt = (rects) => {
   if (!rects) return 'FULL WINDOW';
+  // An empty list: every claim the frame made was answered on a layer of its
+  // own (the Cocoa presenter — a hover's background, say), so the bitmap
+  // painted nothing. Not the same as a frame that claimed nothing.
+  if (rects.length === 0) return 'LAYERS ONLY';
   const one = (r) => `${r.width}x${r.height} @ ${r.x},${r.y}`;
   // A frame paints a list of rects, and the whole point of the list is that it
   // can be smaller than the box around it — so when there is more than one,


### PR DESCRIPTION
On the Cocoa backend, hovering a tab in `examples/stress` crashed the app:

```
TypeError: Cannot destructure property 'x' from null or undefined value
      at boxOf  examples/stress/perf.js:29
      at fmt    examples/stress/perf.js:23
      at        src/nodes/window/flush.js:56   ← watchFrames' flush wrapper
      at _tickFrames  src/cocoa/app.js:720
```

The layer presenter answers a hover's background change on a layer of its own, so `_takeDamage` records an **empty** list of damage rects — the bitmap painted nothing. That is distinct from `null`, which means a full repaint. The frame log's formatter handled `null` and a single rect, and passed the empty list on to `boxOf`, which reads the first rect.

An empty list now prints as `LAYERS ONLY`. The same logger is used by `examples/icons.jsx`, `examples/animation.jsx` and `scripts/check-stress.jsx`, so they are covered too. X11 never produces an empty list, which is why `npm run stress:check` on the in-process server could not have caught this.

## Verification

- **Real Cocoa backend**, scale 2: a driver posting mouse moves over all six tabs through the appkit pump. Unfixed, it throws the reported error. Fixed, it logs thirteen `LAYERS ONLY  0.0kpx … [animation+style-state]` frames and keeps running.
- **Deterministic:** a fake window reporting an empty damage list through `watchFrames` passes on this branch and throws the original error on master.
- `npm run stress:check` passes; prettier clean.
