### PR TITLE
feat(foreign): refuse where there is no embedding; useSupports('embedding') asks first

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ no override-redirect staging (issue #4).
   docs/glx.md.
 - `src/foreignnodes.js` — `<foreign>`: another process's window, embedded.
   A second `drawn: false` node, over ntk's `XEmbedSocket` (docs/embedding.md).
-  Two things here are not obvious and are commented at length. **Teardown is
+  Three things here are not obvious and are commented at length. **Teardown is
   synchronous** — `WindowNode` destroys its own X window in the same turn, and
   `DestroyWindow` takes every inferior with it, so a release that waits for a
   round trip releases a window that is already gone; the client is reparented
@@ -80,7 +80,12 @@ no override-redirect staging (issue #4).
   would read as the toplevel losing focus and would put every key past the
   React tree before any handler saw it. The X focus stays on our window and
   forwarding happens in `defaultKeyDown`/`defaultKeyUp`, which is what makes
-  the rule "app chords first, everything else forwards" mechanical.
+  the rule "app chords first, everything else forwards" mechanical. And **it
+  refuses where there is no embedding**: the Cocoa app and the headless mock
+  both carry an X stub and a `createWindow` that takes a parent, so "there
+  is an app" says nothing. `realize()` asks `canEmbed` (`src/embedding.js`,
+  shared with `useSupports('embedding')`), and a no is one `onError` and an
+  empty box — never an `onReady` with no id (#531).
 - `src/frame/` — `<Frame>`: a pane of the application in its own process,
   its window embedded over `<foreign>` (docs/frame.md). Four small files
   along the seams: `protocol.js` (pure — the six messages, the callback

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -1971,7 +1971,15 @@ the raw form, and `@react-x11/components/three` for a scene graph.
 
 **X11 only.** Cross-process window embedding does not exist on macOS —
 there is no equivalent of handing another application's window to your
-layout, and none is planned. On the Cocoa backend this element is inert.
+layout, and none is planned. Where there is none — the Cocoa backend, and
+the headless mock tests render on — this element refuses: it lays out as an
+empty box and draws nothing, never calls `onReady`, and calls `onError` once
+to say why. Ask before rendering one:
+
+```jsx
+const embedding = useSupports('embedding');
+```
+
 `<Frame>`, which uses it on X11 to host a pane of your _own_ application,
 does work on both ([frame.md](frame.md)) — it just gets there another way.
 
@@ -1995,14 +2003,17 @@ a react-x11 app a _host_ rather than a drawer of its own pixels. Needs ntk
   this node instead, which is what `xterm -into WID` and `mpv --wid=WID`
   need.
 - `onReady({ windowId })` — this node's own container id, offered before
-  anything is embedded, so a program can be spawned into it.
+  anything is embedded, so a program can be spawned into it. Never called
+  where there is no embedding, so the id is always a real window's.
 - `onEmbedded({ id, xembed, version })` — a client is in. `xembed: false`
   is a client that set no `_XEMBED_INFO` and got plain reparenting, which
   is the common case rather than the fallback.
 - `onClientGone()` — destroyed, or reparented away by someone else.
 - `onRequestFocus()` — the client asked for the focus. It is then given
   through the focus manager, so the rest of the tree observes it normally.
-- `onError(err)` — the embed failed. Without a handler, a console warning.
+- `onError(err)` — the embed failed, or — once, at mount — this backend has
+  no embedding at all. Without a handler, a console warning; for the second
+  kind, one per app however many `<foreign>`s ask.
 - `focusable` — default `true`, like `<textinput>`.
 - `backgroundColor` in the `style` is what shows in the rect with no client
   in it: the container window's background, painted by the server.

--- a/docs/embedding.md
+++ b/docs/embedding.md
@@ -3,10 +3,12 @@
 > **X11 only.** Cross-process window embedding does not exist on macOS:
 > there is no way to take another application's window into your own view
 > hierarchy, and this is not a gap waiting to be filled — the platform does
-> not offer the primitive. On the Cocoa backend `<foreign>` is inert. What
-> does work there is [`<Frame>`](frame.md), which embeds a pane of _your
-> own_ application, and reaches the same place through shared surfaces
-> instead of reparenting.
+> not offer the primitive. On the Cocoa backend `<foreign>` refuses: it lays
+> out as an empty box, never calls `onReady`, and calls `onError` once — and
+> `useSupports('embedding')` is false there, so a component can ask before
+> rendering one. What does work there is [`<Frame>`](frame.md), which embeds
+> a pane of _your own_ application, and reaches the same place through
+> shared surfaces instead of reparenting.
 
 Everything else react-x11 draws, it draws itself. `<foreign>` is the one
 element that shows somebody else's pixels: another process's top-level X

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -98,7 +98,9 @@ wayland.md declares its walls:
   the XEmbed half of `<Frame>`, `@react-x11/components`' tray-host and its
   mpv/VLC `--wid` embedding have no equivalent; `<Frame>` on macOS becomes
   a parented toplevel or an in-process pane, exactly the fate wayland.md
-  assigns it.
+  assigns it. A `<foreign>` rendered here says so — one `onError`, no
+  `onReady`, an empty box — and `useSupports('embedding')` is false, so a
+  component can ask before rendering one (#531).
 - **XQuartz is not deprecated by this.** react-x11 already runs on macOS
   today through XQuartz; that path remains the way to run the X11 backend
   (and the WM example) on a Mac. This backend is for shipping _native_
@@ -1766,8 +1768,8 @@ additive or mechanical:
    the usual corrective error). `createRoot({ app })` keeps working and
    is how tests inject mocks of either flavor.
 2. **Capabilities.** `useSupports` grows `'nativeControls'`,
-   `'globalMenu'`, `'transforms'` (when built) beside `'transparency'`
-   and `'shaders'`; same store-and-settle semantics.
+   `'embedding'` (false here), `'globalMenu'`, `'transforms'` (when built)
+   beside `'transparency'` and `'shaders'`; same store-and-settle semantics.
 3. **Inert props policy** (wayland.md open question 1, now decided the
    way it leaned): same JSX everywhere; a prop with no meaning on this
    backend (`wmClass`, `xi2`, `onClientMessage`, X-only states) is

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -354,6 +354,12 @@ operations. No server, no connection, much faster, and no pixels — good for
 asserting on layout and on the node tree, which is most tests. Input
 injection is not available and says so.
 
+With no connection there is also nothing to embed into, so the mock answers
+the way the Cocoa backend does: `useSupports('embedding')` is false, and a
+`<foreign>` in the tree lays out as an empty box and reports one `onError`
+rather than failing the mount. A component that asks before rendering one
+mounts its fallback here; one that does not still mounts.
+
 A batch records as the fills it stands for: `ctx.fillRects([[x, y, w, h], …])`
 leaves one `fillRect` operation per rectangle, because the only difference
 between them is a request count and there is no server here to send it to. So

--- a/examples/finder.jsx
+++ b/examples/finder.jsx
@@ -21,7 +21,9 @@
 //                        same group vocabulary the drop uses, deliberately.
 //   Open terminal here   spawns `xterm -into` a `<foreign>` pane, so another
 //                        process's window sits in this window's layout. Ctrl+T
-//                        is the app's, not the terminal's — see below.
+//                        is the app's, not the terminal's — see below. X11
+//                        only: where `useSupports('embedding')` is false, on
+//                        Cocoa, neither the item nor the chord is there.
 //
 // ## Why there is no tree
 //
@@ -66,6 +68,7 @@ import {
   createRoot,
   createStyles,
   useClipboard,
+  useSupports,
 } from '../src/index.js';
 
 const ROW_H = 22; // fixed, because windowing needs it to be
@@ -442,6 +445,10 @@ export function FinderPanel({ backend, start }) {
   const [generation, setGeneration] = useState(0);
   const [status, setStatus] = useState('');
   const [terminal, setTerminal] = useState(false);
+  // A terminal pane is another process's window, which only a backend with
+  // cross-process embedding can host. Where there is none the pane is not
+  // offered at all, rather than opened with nothing that can ever fill it.
+  const embedding = useSupports('embedding');
   const [pending, startTransition] = useTransition();
 
   const places = useMemo(
@@ -528,12 +535,16 @@ export function FinderPanel({ backend, start }) {
       { label: 'Paste', onSelect: paste },
       { type: 'separator' },
       { label: 'Refresh', onSelect: () => setGeneration((g) => g + 1) },
-      {
-        label: terminal ? 'Close terminal' : 'Open terminal here',
-        onSelect: () => setTerminal((on) => !on),
-      },
+      ...(embedding
+        ? [
+            {
+              label: terminal ? 'Close terminal' : 'Open terminal here',
+              onSelect: () => setTerminal((on) => !on),
+            },
+          ]
+        : []),
     ],
-    [selected, copy, paste, go, terminal],
+    [selected, copy, paste, go, terminal, embedding],
   );
 
   return (
@@ -543,7 +554,7 @@ export function FinderPanel({ backend, start }) {
       // terminal eating it — docs/embedding.md. It still will not fire while
       // the pointer is inside the pane, which is X's rule rather than ours.
       onKeyDown={(ev) => {
-        if (ev.ctrlKey && ev.key === 't') {
+        if (embedding && ev.ctrlKey && ev.key === 't') {
           ev.preventDefault();
           setTerminal((on) => !on);
         }

--- a/src/appcontext.js
+++ b/src/appcontext.js
@@ -26,6 +26,7 @@ import {
   compositingActive,
   watchCompositing,
 } from './compositing.js';
+import { canEmbed } from './embedding.js';
 import { hasDirectGL, watchDirectGL } from './glbackend.js';
 
 const AppContext = createContext(null);
@@ -57,16 +58,26 @@ export function useApp() {
   return app;
 }
 
-const SUPPORTS_FEATURES = new Set([
-  'transparency',
-  'shaders',
-  'nativeControls',
-]);
-
-// 'nativeControls' is a property of the backend, decided before the first
-// render and never changing after — so its subscription has nothing to
-// deliver and its snapshot is a property test.
+// 'nativeControls' and 'embedding' are properties of the backend, decided
+// before the first render and never changing after — so their subscription
+// has nothing to deliver and their snapshot is a property test.
 const NEVER_CHANGES = () => () => {};
+
+// What `useSupports` watches and reads, per feature. `read` answers a
+// boolean, so the snapshot is stable for a given state — returning the
+// visual object for 'transparency' would tear on every render.
+const FEATURES = {
+  transparency: {
+    watch: watchCompositing,
+    read: (app) => compositingActive(app) && Boolean(argbVisual(app)),
+  },
+  shaders: { watch: watchDirectGL, read: hasDirectGL },
+  nativeControls: {
+    watch: NEVER_CHANGES,
+    read: (app) => Boolean(app.nativeBezels),
+  },
+  embedding: { watch: NEVER_CHANGES, read: canEmbed },
+};
 
 /**
  * Can this **display** do something, as a value a component can branch on?
@@ -127,40 +138,41 @@ const NEVER_CHANGES = () => () => {};
  * first render already reads the final answer. A policy raised after
  * connecting has missed that probe, and re-renders its readers when it
  * settles rather than leaving them with two different answers.
+ *
+ * `'embedding'` is true when this connection can take another process's
+ * window into its own — the X11 backend; never Cocoa, which has no such
+ * primitive, and never the headless mock. It is the question to ask before
+ * rendering a `<foreign>`, which refuses with one `onError` where the answer
+ * is no:
+ *
+ * ```jsx
+ * const embedding = useSupports('embedding');
+ * <box style={{ flexGrow: 1 }}>
+ *   {embedding ? <foreign onReady={spawnInto} /> : <text>X11 only</text>}
+ * </box>
+ * ```
+ *
+ * Like `'nativeControls'`, it is a property of the backend and never changes.
  */
 export function useSupports(feature) {
   const app = useApp();
-  if (!SUPPORTS_FEATURES.has(feature)) {
+  const spec = Object.hasOwn(FEATURES, feature) ? FEATURES[feature] : null;
+  if (!spec) {
     throw new Error(
       `react-x11: useSupports(${JSON.stringify(feature)}) — unknown feature ` +
-        `(expected one of ${[...SUPPORTS_FEATURES].join(', ')})`,
+        `(expected one of ${Object.keys(FEATURES).join(', ')})`,
     );
   }
-  // Both features go through the same store, so the hooks below run in the
+  // Every feature goes through the same store, so the hooks below run in the
   // same order whatever is being asked about. Where compositing comes and
   // goes for as long as the app runs, the backend settles at most once — and
   // watching that one moment is what keeps two components rendered either
   // side of it from disagreeing (see watchDirectGL).
   const subscribe = useCallback(
-    (onChange) =>
-      feature === 'nativeControls'
-        ? NEVER_CHANGES()
-        : feature === 'shaders'
-          ? watchDirectGL(app, onChange)
-          : watchCompositing(app, onChange),
-    [app, feature],
+    (onChange) => spec.watch(app, onChange),
+    [app, spec],
   );
-  // a boolean, so the snapshot is stable for a given state — returning the
-  // visual object here would tear on every render
-  const snapshot = useCallback(
-    () =>
-      feature === 'nativeControls'
-        ? Boolean(app.nativeBezels)
-        : feature === 'shaders'
-          ? hasDirectGL(app)
-          : compositingActive(app) && Boolean(argbVisual(app)),
-    [app, feature],
-  );
+  const snapshot = useCallback(() => spec.read(app), [app, spec]);
   return useSyncExternalStore(subscribe, snapshot, snapshot);
 }
 

--- a/src/embedding.js
+++ b/src/embedding.js
@@ -1,0 +1,31 @@
+// Whether a connection can take another process's window into its own.
+//
+// `<foreign>` asks before it builds a socket, and `useSupports('embedding')`
+// asks for a component deciding whether to render one. One function for
+// both, because the two have to agree: a hook that said yes over an element
+// that then refused, or the reverse, is the bug this closes (issue #531).
+//
+// A feature test on the connection, not a question about which backend this
+// is — and not "is there an `X`", which is true everywhere: the Cocoa app
+// carries an X stub for the modules with an X escape hatch, and the headless
+// mock carries the same one. Both also have a `createWindow` that takes a
+// parent, which is how `<foreign>` used to get as far as a socket over them.
+// So each part of embedding is asked about by name: a container window to
+// hold the client, `ReparentWindow` to move somebody else's window into it,
+// and the save set, which keeps that window alive if this process dies
+// holding it — the promise docs/embedding.md makes about a window we do not
+// own.
+//
+// A leaf module on purpose, for glbackend.js's reason: it imports nothing of
+// ours, so both `appcontext.js` and the node layer can use it without the
+// two importing each other.
+
+/** Can `app` host another client's window inside one of its own? */
+export function canEmbed(app) {
+  const X = app?.X;
+  return (
+    typeof app?.createWindow === 'function' &&
+    typeof X?.ReparentWindow === 'function' &&
+    typeof X?.ChangeSaveSet === 'function'
+  );
+}

--- a/src/foreignnodes.js
+++ b/src/foreignnodes.js
@@ -33,11 +33,17 @@
 import { XEMBED, XEmbedSocket } from 'ntk';
 
 import { isFocusable } from './a11y.js';
+import { canEmbed } from './embedding.js';
 import { lastInputTime } from './inputtime.js';
 import { Node } from './nodes/node.js';
 import { pixelFor } from './nodes/window/capabilities.js';
 
 const px = (v) => Math.max(1, Math.round(v || 0));
+
+// Apps already told, by a <foreign> with no `onError`, that they cannot
+// embed. Once per app: the answer belongs to the backend, so the second pane
+// to ask carries no news — the same rule as a display with no ARGB visual.
+const warnedCannotEmbed = new WeakSet();
 
 /**
  * `<foreign>` — another client's top-level window, laid out as an element.
@@ -89,6 +95,18 @@ const px = (v) => Math.max(1, Math.round(v || 0));
  * pointer is *over* the embedded client the client receives keys directly
  * and no handler of ours runs. Chords work everywhere else in the window,
  * which is the trade a proxy would make in reverse.
+ *
+ * ### Where there is no embedding
+ *
+ * All of this needs a connection that can reparent somebody else's window,
+ * and two apps this node meets have none: the Cocoa backend and the headless
+ * mock. Both carry an X stub and a `createWindow` that takes a parent, which
+ * used to be enough to build a socket over them — on Cocoa around a child GL
+ * surface whose `id` is undefined, handed out through `onReady` and spawned
+ * `xterm -into undefined` with; on the mock, a throw from inside the commit.
+ * So `realize()` asks `canEmbed` first, the question
+ * `useSupports('embedding')` answers too, and a no is final: no container, no
+ * `onReady`, one `onError`, and an empty box in the layout.
  */
 export class ForeignNode extends Node {
   constructor(props, app) {
@@ -97,8 +115,12 @@ export class ForeignNode extends Node {
     this.socket = null;
     /** `{ id, xembed, version }` while a client is in, else null */
     this.client = null;
-    /** the error that stopped an embed, if one did */
+    /** the error that stopped an embed, if one did — or, where this
+     * connection cannot embed at all, the refusal */
     this.error = null;
+    // set once `realize()` finds this connection cannot embed, and final:
+    // the backend does not change under a node
+    this._refused = false;
     /** geometry last sent to the X windows */
     this.rect = null;
     // an embedded client is a control the user can Tab to, like a
@@ -133,9 +155,10 @@ export class ForeignNode extends Node {
    * where React can discard the work.
    */
   realize() {
-    if (this.socket || this.destroyed) return;
+    if (this.socket || this.destroyed || this._refused) return;
     const parent = this.root?.window;
-    if (!parent || typeof this.app?.createWindow !== 'function') return;
+    if (!parent) return;
+    if (!canEmbed(this.app)) return this._refuse();
     const rect = this._geometry();
     this.rect = rect;
     const socket = new XEmbedSocket(parent, {
@@ -157,6 +180,36 @@ export class ForeignNode extends Node {
     // after `_start`, which maps the container itself — both paths do,
     // because a client cannot be viewable inside an unmapped one
     this._syncMapped();
+  }
+
+  /**
+   * This connection cannot embed: say so once, and be an empty box.
+   *
+   * On a microtask for `onReady`'s reason: this runs in the commit phase, and
+   * the ordinary answer to the news is to set state. Nothing else needs
+   * undoing — with no socket, every other path through this node (layout,
+   * props, focus, keys, teardown) already finds nothing to act on.
+   */
+  _refuse() {
+    this._refused = true;
+    const err = new Error(
+      'react-x11: <foreign> needs the X11 backend — this one has no ' +
+        'cross-process window embedding, so nothing can be put in it. Ask ' +
+        "useSupports('embedding') before rendering one.",
+    );
+    this.error = err;
+    // The client is the whole reason this node is a Tab stop by default, and
+    // one that can never arrive would leave a dead one. `focusable` still
+    // wins, as it does on a box.
+    this.focusableByDefault = false;
+    queueMicrotask(() => {
+      if (this.destroyed) return;
+      if (this.props.onError) this.props.onError(err);
+      else if (this.app && !warnedCannotEmbed.has(this.app)) {
+        warnedCannotEmbed.add(this.app);
+        console.warn(err.message);
+      }
+    });
   }
 
   /**

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -163,8 +163,14 @@ export function useClipboard(): Clipboard;
  * branches on it through the theme's `controls: 'auto'` policy; this is for
  * application code composing its own controls to sit beside native ones. It
  * is a property of the backend and never changes over the app's life.
+ *
+ * `'embedding'` is whether this connection can take another process's window
+ * into its own — X11, never Cocoa or the headless mock. Ask it before
+ * rendering a `<foreign>`, which refuses with one `onError` where it is
+ * false. Also a property of the backend, and it never changes either.
  */
-export type SupportsFeature = 'transparency' | 'shaders' | 'nativeControls';
+export type SupportsFeature =
+  'transparency' | 'shaders' | 'nativeControls' | 'embedding';
 
 /**
  * Can this **display** do something? `'transparency'` is true when the

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -973,7 +973,9 @@ export interface ForeignProps extends DrawnProps<DrawnNode> {
    */
   windowId?: number;
   /** The container window's id, offered as soon as it exists, so a program
-   * can be spawned into it. Fires before there is anything embedded. */
+   * can be spawned into it. Fires before there is anything embedded — and
+   * never on a backend with no embedding (`useSupports('embedding')`), so the
+   * id is always a real window's. */
   onReady?: (info: { windowId: number; node: DrawnNode }) => void;
   /** A client is in. */
   onEmbedded?: (info: EmbeddedInfo) => void;
@@ -982,7 +984,8 @@ export interface ForeignProps extends DrawnProps<DrawnNode> {
   /** `XEMBED_REQUEST_FOCUS`: the client wants the focus. It is given through
    * the focus manager unless a handler prevents it by focusing elsewhere. */
   onRequestFocus?: (info: { node: DrawnNode }) => void;
-  /** The embed failed — no such window, or it went away mid-handshake.
+  /** The embed failed — no such window, or it went away mid-handshake — or
+   * this backend cannot embed at all, which is reported once, at mount.
    * Without a handler the failure is a console warning. */
   onError?: (err: Error) => void;
 }

--- a/test/cocoa-foreign.test.js
+++ b/test/cocoa-foreign.test.js
@@ -1,0 +1,57 @@
+// <foreign> on the Cocoa backend (src/foreignnodes.js), over the fake bridge.
+//
+// macOS has no cross-process window embedding, and the element has to say so
+// rather than half-work. It used to half-work (issue #531): the CocoaApp has
+// an X stub and a `createWindow` that takes a parent, which was enough for a
+// socket to be built around a child GL surface whose `id` is undefined, and
+// for `onReady({ windowId: undefined })` to go out — which a caller spawns
+// `xterm -into undefined` with. The mock-backend half of the same contract is
+// at the end of test/foreign.test.js.
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import React from 'react';
+
+import { createRoot, useSupports } from '../src/index.js';
+import { fakeCocoaApp, tick } from './helpers/cocoa-bridge.js';
+
+const h = React.createElement;
+
+test('<foreign> refuses on Cocoa rather than hand out an id it does not have', async () => {
+  const { app } = fakeCocoaApp();
+  // every window asked for with a parent — the container a socket builds,
+  // which here was a child surface rather than an X window
+  const children = [];
+  const createWindow = app.createWindow.bind(app);
+  app.createWindow = (attrs) => {
+    if (attrs?.parent) children.push(attrs);
+    return createWindow(attrs);
+  };
+  const root = await createRoot({ app });
+  const ready = [];
+  const errors = [];
+  let embedding = null;
+  function Pane() {
+    embedding = useSupports('embedding');
+    return h('foreign', {
+      style: { flexGrow: 1 },
+      onReady: (info) => ready.push(info),
+      onError: (err) => errors.push(err),
+    });
+  }
+  try {
+    root.render(h('window', { width: 200, height: 120 }, h(Pane)));
+    await tick();
+    await tick();
+    assert.equal(embedding, false);
+    assert.equal(
+      ready.length,
+      0,
+      `onReady was called with windowId ${ready.map((r) => r.windowId)}`,
+    );
+    assert.equal(errors.length, 1, 'one onError');
+    assert.match(errors[0].message, /<foreign> needs the X11 backend/);
+    assert.equal(children.length, 0, 'no container was created');
+  } finally {
+    await root.unmount();
+  }
+});

--- a/test/finder.test.js
+++ b/test/finder.test.js
@@ -13,8 +13,10 @@ import assert from 'node:assert/strict';
 import React from 'react';
 
 import {
+  act,
   renderX11,
   cleanup,
+  fireEvent,
   screen,
   waitFor,
   userEvent,
@@ -172,6 +174,32 @@ describe('examples/finder', () => {
         backend.spawned[0].windowId > 0,
       `spawned into ${backend.spawned[0].windowId}`,
     );
+  });
+
+  test('no terminal is offered where the backend cannot host one', async () => {
+    const backend = fakeBackend({ '/home/me': [entry('notes.txt')] });
+    const { app, rerender } = await renderX11(h(FinderPanel, { backend }), {
+      width: 820,
+      height: 560,
+    });
+    // The Cocoa backend's shape — an X stub with no ReparentWindow in it —
+    // with input still injectable, which the mock backend cannot offer.
+    // Embedding is a property of the backend, read when the panel mounts, so
+    // the panel is mounted afresh under a new key.
+    app.X.ReparentWindow = undefined;
+    await rerender(h(FinderPanel, { key: 'no-embedding', backend }));
+    await waitFor(() => screen.getByText('notes.txt'));
+
+    await userEvent.click(row('notes.txt'));
+    await userEvent.key(0x74, { modifiers: ['Control'] }); // Ctrl+T
+    await act(() => fireEvent.contextMenu(row('notes.txt')));
+    await waitFor(() => screen.getByText('Refresh'));
+
+    // neither way in opens a pane: the chord does nothing, and the menu does
+    // not carry the item at all
+    assert.equal(screen.queryByText('Open terminal here'), null);
+    assert.equal(screen.queryByText('terminal — /home/me'), null);
+    assert.equal(backend.spawned.length, 0);
   });
 
   test('a listing is cached per backend, not globally', async () => {

--- a/test/foreign.test.js
+++ b/test/foreign.test.js
@@ -7,6 +7,9 @@
 // thinks it is: a mock can only report the calls we chose to make, and the
 // bug this element is most able to cause is destroying somebody else's
 // window, which shows up as the window being *gone*, not as a call.
+//
+// The last few tests are the other side: backends with no embedding at all,
+// where the claim is what the element does *not* do.
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
@@ -14,8 +17,15 @@ import React from 'react';
 import xserver from 'x11/lib/xserver/index.js';
 import { XEMBED, createClient, StaticFontSource } from 'ntk';
 
-import { createRoot } from '../src/index.js';
-import { act } from '../src/testing/index.js';
+import { isFocusable } from '../src/a11y.js';
+import { canEmbed } from '../src/embedding.js';
+import { createRoot, useSupports } from '../src/index.js';
+import {
+  act,
+  createMockApp,
+  renderX11,
+  waitFor,
+} from '../src/testing/index.js';
 
 const h = React.createElement;
 
@@ -739,4 +749,202 @@ test('<foreign> takes no children', async () => {
   } finally {
     await teardown(x11Root, app, other);
   }
+});
+
+// --- where there is no embedding -----------------------------------------
+//
+// A connection that cannot take in a window it does not own. The mock
+// backend is one, and it is what the headless tests of every library built
+// on this render on, so a component with a `<foreign>` in it has to mount
+// there. The Cocoa backend is the other: test/cocoa-foreign.test.js.
+
+const nextTurn = () => new Promise((resolve) => setImmediate(resolve));
+
+test('<foreign> refuses where there is no embedding: one onError, no onReady, an empty box', async () => {
+  const ready = [];
+  const errors = [];
+  const pane = (props = {}) =>
+    h('foreign', {
+      style: { width: 120, height: 80 },
+      onReady: (info) => ready.push(info),
+      onError: (err) => errors.push(err),
+      ...props,
+    });
+  // this used to throw from inside the commit, reading `X` off a mock
+  // window that has no `app`
+  const {
+    app,
+    window: wnd,
+    rerender,
+    unmount,
+  } = await renderX11(pane(), { backend: 'mock' });
+  try {
+    await nextTurn();
+    assert.equal(
+      ready.length,
+      0,
+      `onReady was called with windowId ${ready.map((r) => r.windowId)}`,
+    );
+    assert.equal(errors.length, 1, 'one onError');
+    assert.match(errors[0].message, /<foreign> needs the X11 backend/);
+    assert.match(errors[0].message, /useSupports\('embedding'\)/);
+
+    const node = foreignNode(wnd);
+    assert.ok(node.error === errors[0], 'the node carries the refusal');
+    // nothing was made to embed into: the toplevel is the only window
+    assert.equal(app.windows.length, 1);
+    // an empty box — laid out where its style puts it…
+    assert.deepEqual([node.abs.width, node.abs.height], [120, 80]);
+    // …and not a Tab stop, since the client that would make it one never
+    // arrives
+    assert.equal(isFocusable(node), false);
+
+    // a window id is not a second try: the refusal is the backend's
+    await rerender(pane({ windowId: 0x400001 }));
+    await nextTurn();
+    assert.equal(errors.length, 1, 'still one onError');
+    assert.equal(ready.length, 0);
+  } finally {
+    await unmount();
+  }
+});
+
+test('a <foreign> mounted into a live window refuses after the commit, not inside it', async () => {
+  // The other way in: a pane mounted into a window that already exists — the
+  // pane a new tab opens — realizes from `_setRoot` while React is still
+  // placing it. Its owner mounts in the same commit, and the ordinary answer
+  // to the news is to set the owner's state; from inside the commit, that is
+  // an update to a component React has not finished mounting, and React
+  // says so.
+  const logged = [];
+  const original = console.error;
+  console.error = (...args) => logged.push(args.join(' '));
+  let mounted = null;
+  try {
+    function Pane() {
+      const [status, setStatus] = React.useState('starting');
+      return h('box', { style: { flexGrow: 1 } }, [
+        h('text', { key: 'status' }, status),
+        h('foreign', {
+          key: 'pane',
+          style: { flexGrow: 1 },
+          onError: () => setStatus('no embedding here'),
+        }),
+      ]);
+    }
+    mounted = await renderX11(h('box', {}), { backend: 'mock' });
+    await mounted.rerender(h(Pane));
+    await waitFor(() => mounted.getByText('no embedding here'));
+  } finally {
+    console.error = original;
+    await mounted?.unmount();
+  }
+  assert.deepEqual(logged, []);
+});
+
+test('a keyed reorder is not a second try either', async () => {
+  const errors = [];
+  const row = (order) =>
+    h(
+      'box',
+      { style: { flexDirection: 'row', flexGrow: 1 } },
+      order.map((key) =>
+        key === 'pane'
+          ? h('foreign', {
+              key,
+              style: { flexGrow: 1 },
+              onError: (err) => errors.push(err),
+            })
+          : h('box', { key, style: { flexGrow: 1 } }),
+      ),
+    );
+  const { rerender, unmount } = await renderX11(row(['pane', 'side']), {
+    backend: 'mock',
+  });
+  try {
+    await nextTurn();
+    // React moves the pane rather than the box, and a moved node is re-rooted
+    // — which is where a <foreign> inserted into a live tree realizes
+    await rerender(row(['side', 'pane']));
+    await nextTurn();
+    assert.equal(errors.length, 1, 'one onError');
+  } finally {
+    await unmount();
+  }
+});
+
+test('a pane unmounted before its refusal is due hears nothing', async () => {
+  // An app that closes on the first refusal it hears. `unmount()` commits
+  // synchronously inside that handler, so the second pane is gone before its
+  // own refusal is delivered — and a handler for a pane that no longer
+  // exists has nobody left to tell.
+  const heard = [];
+  const x11Root = await createRoot({ app: createMockApp() });
+  x11Root.render(
+    h('window', { width: 320, height: 240 }, [
+      h('foreign', {
+        key: 'a',
+        style: { flexGrow: 1 },
+        onError: () => {
+          heard.push('a');
+          void x11Root.unmount();
+        },
+      }),
+      h('foreign', {
+        key: 'b',
+        style: { flexGrow: 1 },
+        onError: () => heard.push('b'),
+      }),
+    ]),
+  );
+  for (let i = 0; i < 20 && heard.length === 0; i++) await nextTurn();
+  await nextTurn();
+  assert.deepEqual(heard, ['a']);
+});
+
+test('with no onError, a backend that cannot embed warns once, however many panes ask', async () => {
+  const warnings = [];
+  const original = console.warn;
+  console.warn = (...args) => warnings.push(args.join(' '));
+  try {
+    const { unmount } = await renderX11(
+      h('box', { style: { flexDirection: 'row', flexGrow: 1 } }, [
+        h('foreign', { key: 'a', style: { flexGrow: 1 } }),
+        h('foreign', { key: 'b', style: { flexGrow: 1 } }),
+      ]),
+      { backend: 'mock' },
+    );
+    await nextTurn();
+    await unmount();
+  } finally {
+    console.warn = original;
+  }
+  const refusals = warnings.filter((w) =>
+    w.includes('<foreign> needs the X11 backend'),
+  );
+  assert.equal(refusals.length, 1, refusals.join('\n'));
+});
+
+test("useSupports('embedding') answers the question <foreign> asks", async () => {
+  const answer = async (options) => {
+    let seen = null;
+    function Probe() {
+      seen = useSupports('embedding');
+      return null;
+    }
+    const { unmount } = await renderX11(h(Probe), options);
+    await unmount();
+    return seen;
+  };
+  assert.equal(await answer({ backend: 'mock' }), false);
+  assert.equal(await answer({}), true, 'on the in-process X server');
+  // The save set is part of the answer, not a detail of it: a connection
+  // that could move somebody else's window in, but not keep it alive when
+  // this process dies, cannot keep the promise docs/embedding.md makes.
+  const createWindow = () => {};
+  assert.equal(canEmbed({ createWindow, X: { ReparentWindow() {} } }), false);
+  assert.equal(
+    canEmbed({ createWindow, X: { ReparentWindow() {}, ChangeSaveSet() {} } }),
+    true,
+  );
 });

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -1263,15 +1263,17 @@ async function main() {
   void [n, perOpcode, one.stats.errors, one.stop()];
 }
 
-// the two things a display can be asked about, both plain booleans — one is
-// about the machine and the compositor, the other about the backend this
-// connection got
+// the things a display can be asked about, all plain booleans — about the
+// machine and the compositor, the backend this connection got, what that
+// backend draws controls with and whether it can host another app's window
 function _Supports() {
   const canBlend: boolean = useSupports('transparency');
   const shaders: boolean = useSupports('shaders');
+  const bezels: boolean = useSupports('nativeControls');
+  const embedding: boolean = useSupports('embedding');
   // @ts-expect-error — not a feature useSupports knows
   useSupports('webgpu');
-  void [canBlend, shaders];
+  void [canBlend, shaders, bezels, embedding];
   return null;
 }
 


### PR DESCRIPTION
Closes #531.

On the Cocoa backend a `<foreign>` with no `windowId` realized as if it could embed and called `onReady` with `windowId: undefined`; on the headless mock the same element threw from inside the commit. Both apps carry an X stub and a `createWindow` that takes a parent, and having `createWindow` was the only gate.

## What changes

- **`<foreign>` refuses where there is no embedding.** `realize()` asks `canEmbed` first: the connection needs `createWindow`, `ReparentWindow` and `ChangeSaveSet`, the three things embedding is made of. Where they are missing the node never builds a socket. No container, no `onReady`, one `onError` on a microtask, and an empty box that is no longer a Tab stop by default. With no handler, one console warning per app however many panes ask.
- **`useSupports('embedding')`** beside `'transparency'`, `'shaders'` and `'nativeControls'`: true on X11, false on Cocoa and on the mock. It reads the same `canEmbed`, so the hook and the element cannot disagree. `useSupports` now keeps its features in a table instead of two nested ternaries, which a fourth branch would have made unreadable.
- **The mock takes the same path**, so a library's headless tests can mount a component that contains a `<foreign>`.
- `examples/finder.jsx` asks the hook. Where the answer is no, "Open terminal here" is not in the menu and Ctrl+T does nothing; on Cocoa it was about to spawn `xterm -into undefined` too.
- Docs: `elements.md`, `embedding.md`, `macos.md`, `testing.md`, the `.d.ts` files and the type test, and the `foreignnodes.js` entry in AGENTS.md.

`src/embedding.js` is a leaf module for the reason `glbackend.js` is one: `appcontext.js` and the node layer both need it without importing each other.

## Verified

- Live on macOS 15: the issue's Cocoa repro now prints `useSupports(embedding) = false` and one `onError`, where it printed `onReady undefined CocoaGLArea`. On XQuartz with the X11 backend the hook is true, `onReady` carries a real window id, and a real `xterm -into` that id arrives as `onEmbedded`. The mock repro reports `onError` and mounts.
- `npm test`: 2397 of 2410 pass and 7 are skipped. The 6 failures are the macOS-only ones in `appearance.test.js`, which fail the same way on master's `src`. Typecheck, lint and `prettier --check .` are clean.
- Mutation check. Each mutant is a scratch tree with one decision undone, run against the three test files:

| mutant | caught by |
| --- | --- |
| master's `src` and example with the new tests | all 8 new tests |
| the refused node stays a Tab stop | refuses where there is no embedding |
| no `onError` warns per node, not per app | warns once, however many panes ask |
| `realize()` forgets it refused | a keyed reorder is not a second try |
| `onError` inside the commit, not on a microtask | mounted into a live window; unmounted before its refusal |
| the refusal reports to an unmounted pane | unmounted before its refusal is due |
| embedding without the save set | `useSupports('embedding')` answers the question |
| the node does not carry the refusal | refuses where there is no embedding |
| no gate in `realize()` | 5 of the new tests |
| `useSupports('embedding')` always true | the Cocoa test, the hook test, finder |
| finder: Ctrl+T ignores the capability | no terminal is offered |
| finder: the menu ignores the capability | no terminal is offered |

Not changed: `<Frame>` on a backend with neither a pane host nor embedding, which today means only the mock, still forks its pane before the `<foreign>` refuses. It then fails through its existing embed-error path.
