### PR TITLE
feat(glarea): the pointer over a surface is the tree's — presses, drags and clicks at the <glarea>, on both backends

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,11 @@ no override-redirect staging (issue #4).
 - `src/glnodes.js` — `<glarea>`: the GL surface. A child X window on a
   GLX visual (ntk's `chooseGLXConfig`), positioned by the parent's yoga
   rect, drawing `onDraw` frames on its own frame clock. First step of
-  docs/glx.md.
+  docs/glx.md. It **selects no pointer input**: X then reports the pointer
+  over it to the owning window, whose hit test asks the window's surfaces
+  before its tree (`_surfaces`, `hitSurface`). So a listener on the
+  surface's `window` is a bug — ntk selects what a window is listened to
+  for, and the event stops reaching the tree.
 - `src/foreignnodes.js` — `<foreign>`: another process's window, embedded.
   A second `drawn: false` node, over ntk's `XEmbedSocket` (docs/embedding.md).
   Three things here are not obvious and are commented at length. **Teardown is

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -1940,26 +1940,43 @@ and its X window follows that rect. The window is stacked above everything
 drawn in the parent, so 2D content cannot overlap it — a HUD needs a
 sibling `<popup>`.
 
-**The wheel reaches it; the rest of the pointer does not, yet.** Pointer
-events over the surface are delivered to its own X window rather than to the
-one the tree is hit-tested in, which is why nothing over a `<glarea>` used to
-reach an application at all. The surface now selects the wheel there and
-hands it back to the window's event manager, naming itself as the target —
-so `onWheel` is an ordinary synthetic event at this node: deltas in pixels,
-bubbling to the ancestors, `preventDefault()` to keep it from the default
-scroll action. It is named rather than hit-tested because a window-owning
-child is not in its parent's paint order, so a hit test would answer with
-the box behind the surface.
+**The pointer over the surface is the tree's**, on both backends, exactly
+as over a `<box>`: `onMouseDown`, `onMouseMove`, `onMouseUp`, `onClick` (a
+double click is `detail: 2`), `onContextMenu`, `onMouseEnter` and
+`onMouseLeave`, `:hover` and `:active`, and `onWheel` fire at the
+`<glarea>` and bubble to its ancestors; a press focuses the nearest
+focusable one, and `ev.capturePointer()` keeps a drag that wanders off the
+surface. The window's hit test knows the surface is on top — a point inside
+its rect lands on the `<glarea>`, not on whatever the tree has behind it —
+and `pointerEvents: 'none'` on it lets the pointer through to that instead.
 
 ```jsx
-<glarea onWheel={(ev) => zoom(ev.deltaY)} />
+<glarea
+  onMouseDown={(ev) => {
+    ev.capturePointer();
+    orbit.start(ev.x, ev.y);
+  }}
+  onMouseMove={(ev) => orbit.drag(ev.x, ev.y)}
+  onWheel={(ev) => zoom(ev.deltaY)}
+/>
 ```
 
-Two limits worth knowing. Smooth deltas are not part of it: XI2 is selected
-on the window the manager owns rather than on this child, so a touchpad's
-fractions arrive as whole notches from buttons 4-7. And clicks, motion and
-hover still do not — a scene that needs picking has to read the pointer some
-other way.
+How it gets there differs underneath and nowhere above. On X11 the surface
+is a child window that **selects no input of its own**, so the server
+reports what happens over it to the window the tree lives in — in that
+window's coordinates, under that window's grab, and with its XI2 selection,
+so the wheel over a surface is the same wheel as anywhere else in the
+window. On the Cocoa backend the surface is a layer and the events were the
+window's all along.
+
+One rule follows for an element built on `<glarea>`: **do not listen for
+the pointer on `node.window`**. ntk selects whatever its window is listened
+to for, and X then delivers the event there instead of to the tree — every
+press, and the wheel with them, since both are ButtonPress. Listening there
+was the only way to hear a press over a surface before core delivered it;
+`node.forwardsPointer` is `true` where it does
+(`GlAreaNode.prototype.forwardsPointer` from `react-x11/node`, to ask
+without rendering), and is the switch for dropping such a listener.
 
 `onDraw` is the raw escape hatch; for a scene, put 3D elements inside
 (below) and let the renderer drive the GL. See `examples/viewer3d.jsx` for

--- a/docs/events.md
+++ b/docs/events.md
@@ -7,7 +7,9 @@ events dispatched over the drawn node tree with DOM-like semantics.
 
 1. **Hit test**: front-to-back walk of the stacking-ordered tree (zIndex,
    then document order), respecting `overflow` clipping and
-   `pointerEvents="none"`.
+   `pointerEvents="none"`. A `<glarea>` is asked first: its surface is
+   stacked above everything 2D in the window, so a point over one lands on
+   it ([elements.md](elements.md#glarea)).
 2. **Capture phase**: `on<Event>Capture` handlers from the window down to
    the target.
 3. **Target + bubble phase**: `on<Event>` handlers from the target up.

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1451,6 +1451,17 @@ and the owning `WindowNode` realizes it in the commit phase
 start. The ordering constraint — no X calls in the render phase, because the
 render phase is discardable — is the part that is easy to get wrong.
 
+Input is the other thing a child window decides without being asked. X
+delivers a device event to the first window up the hierarchy that selected
+it, so a window that selects nothing hands the pointer over it to the window
+the tree lives in — which is how a `<glarea>`'s presses reach the tree — and
+one that selects `ButtonPress` keeps every press for itself. Select only
+what the element needs from the server, and remember that ntk selects
+whatever a window is listened to for. The owning window's hit test knows
+about `<glarea>` surfaces and asks them before the tree
+(`GlAreaNode.hitSurface`); it does not know about a registered element's
+window, so a point over one lands on whatever the tree has behind it.
+
 `ForeignNode` (`src/foreignnodes.js`) is the same shape with the stakes
 raised, and it is the one to read if your element touches a resource you did
 not create. Three things it has to do that a GL surface does not:

--- a/docs/gl.md
+++ b/docs/gl.md
@@ -102,6 +102,15 @@ costs kilobytes per frame while a compiled list costs one `CallList`. Names
 are yours to choose — `GenLists` is a round trip, and this is the backend
 where round trips are the thing to avoid.
 
+## Input
+
+The pointer over a surface is the tree's, on every backend: `onMouseDown`,
+`onMouseMove`, `onMouseUp`, `onClick`, `onWheel` and the rest fire at the
+`<glarea>` and bubble, with `ev.localX`/`localY` measured from its corner —
+which is what a scene picks with. Nothing needs to listen on the surface's
+own window, and nothing should: on X11 a listener there takes the event
+away from the tree ([elements.md](elements.md#glarea) says why).
+
 ## When there is no surface at all
 
 `onError(err)` fires when no GL context could be made: no GLX, indirect

--- a/examples/viewer3d.jsx
+++ b/examples/viewer3d.jsx
@@ -339,8 +339,17 @@ export function ViewerPanel({
     [model, shading, triangles, spin],
   );
 
+  // A drag is the one thing that has to redraw between renders: the moves
+  // write the camera ref, and a `'demand'` surface draws only when a prop
+  // changes — so the loop runs for as long as the drag does, and the press
+  // and the release are the drag's only two renders.
+  const [dragging, setDragging] = useState(false);
   const onMouseDown = useCallback((ev) => {
+    // the orbit keeps going when the pointer leaves the stage, and the
+    // release ends it wherever it lands
+    ev.capturePointer();
     drag.current = { x: ev.x, y: ev.y };
+    setDragging(true);
   }, []);
   const onMouseMove = useCallback((ev) => {
     const from = drag.current;
@@ -352,6 +361,7 @@ export function ViewerPanel({
   }, []);
   const onMouseUp = useCallback(() => {
     drag.current = null;
+    setDragging(false);
   }, []);
   const onWheel = useCallback((ev) => {
     const cam = camera.current;
@@ -388,7 +398,7 @@ export function ViewerPanel({
             style={{ flexGrow: 1 }}
             data-testname="stage"
             clearColor="#0b1021"
-            frameLoop={spin ? 'always' : 'demand'}
+            frameLoop={spin || dragging ? 'always' : 'demand'}
             glx={{ DEPTH_SIZE: 24 }}
             onCreated={onCreated}
             onDraw={onDraw}

--- a/src/cocoa/glarea.js
+++ b/src/cocoa/glarea.js
@@ -14,7 +14,10 @@
 // `destroy()`, `requestAnimationFrame`. On X11 that child is a real X
 // window stacked above the parent's drawing; here it is a sublayer of the
 // window's root layer with a high zPosition — the same "GL sits above the
-// 2D" semantics, by the same mechanism the platform gives us.
+// 2D" semantics, by the same mechanism the platform gives us. The layer
+// takes no input: pointer events are the NSWindow's, and the window's hit
+// test answers the surface for a point over it (`GlAreaNode.hitSurface`),
+// which is where X11's event propagation ends up too.
 //
 // ## The API ladder
 //
@@ -142,7 +145,6 @@ export class CocoaGLArea {
     this.scale = this.parent.scale ?? app.scale ?? 1;
     this.destroyed = false;
     this._reactX11Node = null;
-    this.onWheel = options.onWheel ?? null;
     this.layer = this._native.createLayer();
     this._native.addSublayer(this.parent._layer, this.layer);
     this.rect = null;

--- a/src/events.js
+++ b/src/events.js
@@ -47,6 +47,10 @@ const WHEEL_BUTTONS = new Set([4, 5, 6, 7]);
  */
 export const WHEEL_NOTCH_PX = 48;
 const RIGHT_BUTTON = 3;
+// A LeaveNotify's detail (core protocol): the pointer went to an ancestor of
+// the window it left, or into a window inside it — see `_leftIntoSurface`.
+const NOTIFY_ANCESTOR = 0;
+const NOTIFY_INFERIOR = 2;
 
 /** How many leading entries two node paths share. */
 function sharedPrefix(a, b) {
@@ -637,8 +641,32 @@ export class EventManager {
     return node.isWindow ? node.window : node;
   }
 
+  /**
+   * The node a pointer event landed on: a surface first, then the tree,
+   * front to back. A `<glarea>` is stacked above every 2D thing in its
+   * window, so a point inside one is over it whatever the tree's order says
+   * (`GlAreaNode.hitSurface`).
+   */
   _hit(ev) {
-    return this.node.hitTest(ev.x, ev.y) ?? this.node;
+    return (
+      this._surfaceAt(ev.x, ev.y) ?? this.node.hitTest(ev.x, ev.y) ?? this.node
+    );
+  }
+
+  /**
+   * The frontmost of this window's surfaces a point is over, or null. The
+   * newest is on top on both backends (`GlAreaNode._create`). An empty list
+   * is one length read on the motion path, which is all a window with no
+   * `<glarea>` pays for this.
+   */
+  _surfaceAt(x, y) {
+    const surfaces = this.node._surfaces;
+    if (!surfaces?.length) return null;
+    for (let i = surfaces.length - 1; i >= 0; i--) {
+      const hit = surfaces[i].hitSurface(x, y);
+      if (hit) return hit;
+    }
+    return null;
   }
 
   _path(target) {
@@ -742,16 +770,7 @@ export class EventManager {
    * way somewhere rather than one, and React must be free to interrupt the
    * render it started for the notch before.
    */
-  /**
-   * @param {object} native ntk's wheel event, in this window's coordinates
-   * @param {object} [over] the node the wheel happened over, when the caller
-   *   already knows. A `<glarea>` owns its own X window, so the server
-   *   delivers the event *there* and the surface hands it back translated
-   *   (src/glnodes.js) — and a hit test would answer with the box behind it,
-   *   because a window-owning child is not in its parent's paint order.
-   *   Knowing beats guessing; everything after this line is the same.
-   */
-  _onWheel(native, over = null) {
+  _onWheel(native) {
     // The first wheel is what says this window wants smooth scrolling. It was
     // created on core events — an XI2 selection costs four times as many
     // bytes per *pointer move*, which a window that is never scrolled would
@@ -765,7 +784,7 @@ export class EventManager {
     // outside gets, and for the same reason (`_pressOutside`).
     if (this._dismissOutside(native)) return;
     runWithPriority(ContinuousEventPriority, () => {
-      const target = over ?? this._hit(native);
+      const target = this._hit(native);
       // Shift turns a vertical wheel sideways — the convention for the mouse
       // and the touchpad that have no horizontal axis. Read off the delta
       // rather than off the source: a plain wheel mouse on an XI2 connection
@@ -1043,6 +1062,13 @@ export class EventManager {
   }
 
   _onMouseOut(native) {
+    // The pointer went into one of this window's surfaces, not out of the
+    // window: X reports crossing into a child window as leaving this one,
+    // but the input over a surface still arrives here — it selects none of
+    // its own — and the next motion names it. Answered as a leave, every
+    // ancestor was told the pointer had gone and then that it was back, and
+    // `onMouseOut` that it had left a window it was still in.
+    if (this._leftIntoSurface(native)) return;
     runWithPriority(ContinuousEventPriority, () => {
       this._updateHover([], native);
       // the pointer is somewhere else entirely: whatever it was heading for
@@ -1059,6 +1085,40 @@ export class EventManager {
         this._makeEvent('mouseOut', native, this.node),
       );
     });
+  }
+
+  /**
+   * Whether a LeaveNotify leaves the pointer in one of this window's
+   * surfaces rather than out of the window.
+   *
+   * A real server says "into a window inside this one" with detail
+   * NotifyInferior, and says it twice over a surface: when the pointer moves
+   * onto it, and when a grab ends with the pointer on it (mode NotifyUngrab)
+   * — which every click and every wheel notch over a surface does, since the
+   * press's implicit grab is this window's. node-x11's in-process server
+   * says it with detail NotifyAncestor and the child named instead, and
+   * sends no crossings for grabs at all.
+   *
+   * Either way the point says which inferior, and only a surface's rect
+   * makes it ours: a nested `<window>` or a `<foreign>` takes its own input,
+   * so leaving for one of those is still a leave. So is a grab taken
+   * elsewhere while the pointer is over a surface — detail NotifyVirtual or
+   * NonlinearVirtual, the surface named as the child it left from — since
+   * the pointer is the grab's now. The Cocoa backend's leave carries no
+   * detail, and is always one.
+   */
+  _leftIntoSurface(native) {
+    if (!native) return false;
+    const into =
+      native.detail === NOTIFY_INFERIOR ||
+      (native.detail === NOTIFY_ANCESTOR && Boolean(native.child));
+    if (!into) return false;
+    const wnd = this.node.window;
+    const { x, y } = native;
+    if (x < 0 || y < 0 || x >= (wnd?.width ?? 0) || y >= (wnd?.height ?? 0)) {
+      return false;
+    }
+    return this._surfaceAt(x, y) !== null;
   }
 
   /**

--- a/src/glnodes.js
+++ b/src/glnodes.js
@@ -107,6 +107,10 @@ const px = (v) => Math.max(1, Math.round(v || 0));
  *
  * The X child window is stacked above everything drawn in the parent, so 2D
  * content cannot overlap it — put HUD content in a sibling `<popup>`.
+ *
+ * Pointer input over the surface is the tree's, on both backends: a press,
+ * a drag or a wheel over it is a synthetic event *at this node*, bubbling
+ * to its ancestors like anyone else's (`hitSurface` says how).
  */
 export class GlAreaNode extends Node {
   constructor(props, app) {
@@ -199,6 +203,7 @@ export class GlAreaNode extends Node {
     recordGlxFailure(this.app, err);
     this.gl = null;
     if (this.window) {
+      this._leaveSurfaces();
       this.window.destroy?.();
       this.window = null;
       this.rect = null;
@@ -222,26 +227,32 @@ export class GlAreaNode extends Node {
       // GL draws into the window itself: no 2d backing pixmap, and the
       // frame clock is ours to drive
       backingStore: false,
-      // The wheel, and only the wheel. A GL surface owns a real X window, so
-      // the pointer events over it are delivered *there* rather than to the
-      // window the rest of the tree is hit-tested in — which is why nothing
-      // over a `<glarea>` reached an application before. Selecting it here
-      // and handing it back to the owning window's manager (`_onWheel`
-      // below) is the whole of it: from there the event is an ordinary
-      // synthetic `Wheel` at this node, so it bubbles, `preventDefault()`
-      // takes it back for a scene that zooms instead, and the default action
-      // scrolls the nearest container the way it does anywhere else.
+      // No pointer input is selected here, and that is the whole of how the
+      // pointer over the surface reaches the tree. X reports a device event
+      // to the first window up the hierarchy that selected it, so a press,
+      // a motion or a wheel over this window arrives at the owning window
+      // instead — in its coordinates and under its implicit grab, so a drag
+      // that leaves the surface keeps coming — and its event manager takes
+      // it from there like any other (`hitSurface` names this node).
       //
-      // Selected unconditionally rather than when a handler is declared: the
-      // default action is what a reader expects from a wheel over a page,
-      // and an element that wants it back has `preventDefault()`. One
-      // ButtonPress per notch is not a cost worth a conditional.
-      onWheel: (ev) => this._onWheel(ev),
+      // Selecting one here takes it away from the tree, which is how the
+      // wheel alone used to be handled: the surface selected ButtonPress to
+      // hear it and handed it back, and so every *press* on the surface
+      // ended here too, with the drag and the release that should have
+      // followed it. A listener on `node.window` does the same — ntk selects
+      // what a window is listened to for — which is what `forwardsPointer`
+      // exists to tell an element built on this one.
     });
     this.window = wnd;
     this.rect = rect;
     this.config = config;
     wnd._reactX11Node = this;
+    // Above everything 2D in the owning window on both backends, and above
+    // every surface made before this one: X stacks a new child window over
+    // its siblings, and Core Animation a layer added later over one at the
+    // same zPosition. The window's hit test reads the list in that order
+    // (`EventManager._surfaceAt`).
+    this.root?._surfaces?.push(this);
     this.gl = wnd.getContext('opengl', config);
     // a buffer freed by the display is a frame that can be drawn again
     if (typeof this.gl?.onFrameAvailable !== 'undefined') {
@@ -385,31 +396,71 @@ export class GlAreaNode extends Node {
   }
 
   /**
-   * A wheel over the surface, handed to the window the tree lives in.
+   * `true`: pointer input over this surface is the tree's on this backend —
+   * dispatched through the owning window's event manager, at this node, and
+   * bubbling from it like anyone else's.
    *
-   * ntk reports the position inside *this* window; the manager hit-tests in
-   * the owning window's space, so the node's own origin goes back on. Both
-   * are device pixels — the scale is applied at the far end, where a handler
-   * reads `ev.x` (src/events.js).
+   * It is here to be asked by an element built on `<glarea>` that listens on
+   * `node.window` for the pointer, which it had to do before core delivered
+   * it. That listener has to go wherever this is true: on X11 it selects the
+   * event on the surface's own window, and X then delivers it *there*
+   * instead of to the tree (see `_create`) — every press, and the wheel with
+   * them, since both are ButtonPress.
    *
-   * Smooth deltas are not part of this yet: XI2 is selected on the window
-   * the manager owns, not on this child, so a touchpad's fractions arrive
-   * here as whole notches from buttons 4-7.
+   * A getter on the class rather than a flag on each instance, so it can be
+   * read without rendering anything: `GlAreaNode.prototype.forwardsPointer`,
+   * from `react-x11/node`.
    */
-  _onWheel(native) {
-    const events = this.root?.events;
-    if (!events || this.destroyed) return;
-    events._onWheel(
-      {
-        ...native,
-        x: (native.x ?? 0) + this.abs.x,
-        y: (native.y ?? 0) + this.abs.y,
-      },
-      // named rather than hit-tested: a window-owning child is not in its
-      // parent's paint order, so the hit test would answer with the box
-      // behind this surface
-      this,
-    );
+  get forwardsPointer() {
+    return true;
+  }
+
+  /**
+   * This node, if a point in the owning window's space is over the surface.
+   *
+   * A point that is, is over it whatever the tree's own order says: X stacks
+   * the child window above the parent's drawing, and the Cocoa backend puts
+   * the layer at a zPosition over both presenters. So the window asks its
+   * surfaces before it hit-tests its tree (`EventManager._hit`), and a point
+   * inside lands here rather than on the box behind — which is all a tree
+   * walk can find, a window-owning node not being in its parent's paint
+   * order. It is the same answer X gives: the event it propagates to the
+   * owning window names this window as the child the pointer is in.
+   *
+   * The rect is the one last sent to the surface rather than `abs`, since
+   * the surface covers whole pixels and the server decides by those. No
+   * surface, no answer: not made yet, given up after `onError`, or hidden
+   * with something around it — and `pointerEvents: 'none'` here or above
+   * lets the pointer through to what the tree has behind, as it does for
+   * any node.
+   */
+  hitSurface(x, y) {
+    const rect = this.rect;
+    if (!this.window || !rect) return null;
+    if (
+      x < rect.x ||
+      y < rect.y ||
+      x >= rect.x + rect.width ||
+      y >= rect.y + rect.height
+    ) {
+      return null;
+    }
+    for (let n = this; n; n = n.parent) {
+      if (n.destroyed || n.hidden) return null;
+      if (n.style?.display === 'none' || n.style?.pointerEvents === 'none') {
+        return null;
+      }
+      if (n.isWindow) break;
+    }
+    return this;
+  }
+
+  /** Out of the owning window's hit test: nothing covers the rect any more,
+   * and what the tree has behind it answers again. */
+  _leaveSurfaces() {
+    const surfaces = this.root?._surfaces;
+    const at = surfaces ? surfaces.indexOf(this) : -1;
+    if (at !== -1) surfaces.splice(at, 1);
   }
 
   applyProps(newProps, oldProps) {
@@ -432,6 +483,7 @@ export class GlAreaNode extends Node {
 
   destroySubtree() {
     if (this.destroyed) return;
+    this._leaveSurfaces();
     super.destroySubtree();
     this._pacer.cancel();
     this.gl?.destroy?.();

--- a/src/node.d.ts
+++ b/src/node.d.ts
@@ -820,5 +820,16 @@ export declare class WindowNode extends Node {}
 export declare class PopupNode extends WindowNode {}
 /** The precedents for an element owning a real child X window — a surface of
  * its own, and one holding somebody else's window. */
-export declare class GlAreaNode extends Node {}
+export declare class GlAreaNode extends Node {
+  /**
+   * `true`: the pointer over the surface is dispatched through the owning
+   * window's event manager, at this node, on this backend. So an element
+   * built on `<glarea>` must not listen for the pointer on `node.window` —
+   * on X11 that selects the event on the surface's own window, and X then
+   * delivers it there instead of to the tree. Readable without rendering,
+   * as `GlAreaNode.prototype.forwardsPointer`; absent on a core that does
+   * not deliver it.
+   */
+  readonly forwardsPointer: true;
+}
 export declare class ForeignNode extends Node {}

--- a/src/nodes/window/window.js
+++ b/src/nodes/window/window.js
@@ -191,6 +191,11 @@ export class WindowNode extends Scrollable(Node) {
     // behind one `size` read on the motion path, and a tree that never asked
     // for attention must not pay a property walk to find that out.
     this._attentionNodes = new Set();
+    // The GL surfaces in this window, bottom to top: `<glarea>`s, stacked
+    // above everything 2D here, which the hit test therefore asks before the
+    // tree (`EventManager._surfaceAt`). A surface joins when its window is
+    // made and leaves when it goes (src/glnodes.js).
+    this._surfaces = [];
     this.events = new EventManager(this);
     // ids of the child windows in the order the *server* stacks them,
     // bottom to top — see _restackWindowChildren

--- a/src/types/elements.d.ts
+++ b/src/types/elements.d.ts
@@ -915,6 +915,12 @@ export interface SvgProps extends DrawnProps<DrawnNode> {
 
 export type FrameLoop = 'demand' | 'always';
 
+/**
+ * `<glarea>`: a GL surface in the layout. The pointer over it is the tree's,
+ * as over any node — the handlers it inherits (`onMouseDown`, `onClick`,
+ * `onWheel`, …) fire at the `<glarea>` and bubble, on both backends — and
+ * `GlAreaNode.forwardsPointer` says so at run time (docs/elements.md).
+ */
 export interface GlAreaProps extends DrawnProps<DrawnNode> {
   /** CSS colour, or `[r, g, b, a]` floats. Default black. */
   clearColor?: Color | [number, number, number, number];
@@ -937,17 +943,6 @@ export interface GlAreaProps extends DrawnProps<DrawnNode> {
   onDraw?: (gl: any, info: DrawInfo) => void;
   /** No GL surface — no GLX, or no matching visual. */
   onError?: (err: Error) => void;
-  /**
-   * The wheel over the surface. Inherited from `EventHandlers` like every
-   * other element's, and listed here because it is the **only** pointer
-   * event a `<glarea>` currently reports: the surface owns its own X window,
-   * so it selects the wheel there and hands it to the window's event manager
-   * (see docs/elements.md). Deltas are pixels, `preventDefault()` takes the
-   * default scroll action back, and it bubbles from this node.
-   */
-  onWheel?: (ev: WheelEvent<DrawnNode>) => void;
-  /** A click inside the surface that hit no mesh. */
-  onPointerMissed?: (ev: MouseEvent<DrawnNode>) => void;
 }
 
 // --- embedding -------------------------------------------------------------

--- a/test/cocoa-glarea.test.js
+++ b/test/cocoa-glarea.test.js
@@ -154,10 +154,15 @@ test('the pointer over the surface is dispatched at the <glarea>, and bubbles', 
   const app = node.app;
   assert.equal(node.forwardsPointer, true);
   pointerOver(app, node, { press: true });
-  assert.deepEqual(seen, [
-    ['area', 'mouseDown', node],
-    ['box', 'mouseDown', node],
-    ['area', 'click', node],
-  ]);
+  // targets by identity: a failed deepEqual over nodes util.inspects the
+  // whole tree, and hangs the file instead of failing it
+  assert.deepEqual(
+    seen.map(([who, type, target]) => [who, type, target === node]),
+    [
+      ['area', 'mouseDown', true],
+      ['box', 'mouseDown', true],
+      ['area', 'click', true],
+    ],
+  );
   void native;
 });

--- a/test/cocoa-glarea.test.js
+++ b/test/cocoa-glarea.test.js
@@ -13,7 +13,7 @@ import assert from 'node:assert/strict';
 import React from 'react';
 
 import { createRoot } from '../src/index.js';
-import { fakeCocoaApp, tick } from './helpers/cocoa-bridge.js';
+import { fakeCocoaApp, pointerOver, tick } from './helpers/cocoa-bridge.js';
 
 const h = React.createElement;
 
@@ -53,9 +53,10 @@ const findGLArea = (node) =>
 
 /**
  * A `<glarea>` inset 10px in a 200x120 `<window>` at scale 2, mounted, its
- * surface created and a frame run.
+ * surface created and a frame run. `area` and `box` are extra props for the
+ * surface and the box around it.
  */
-async function mountGLArea() {
+async function mountGLArea({ area = {}, box = {} } = {}) {
   const { native, app } = fakeCocoaApp();
   // the runtime chooseGLConfig resolves, settled before anything asks: no
   // x11-dri and no CGL context, so this runs on any OS
@@ -70,8 +71,8 @@ async function mountGLArea() {
       { width: 200, height: 120 },
       h(
         'box',
-        { style: { flexGrow: 1, padding: 10 } },
-        h('glarea', { style: { flexGrow: 1 } }),
+        { style: { flexGrow: 1, padding: 10 }, ...box },
+        h('glarea', { style: { flexGrow: 1 }, ...area }),
       ),
     ),
   );
@@ -136,4 +137,27 @@ test('a window resize moves the surface without an implicit animation', async ()
     'every set went out with actions off',
   );
   assert.deepEqual(layer.props.frame, [10, 10, 280, 160]);
+});
+
+test('the pointer over the surface is dispatched at the <glarea>, and bubbles', async () => {
+  // The layer takes no input — pointer events are the NSWindow's — and the
+  // window's hit test asks its surfaces before its tree, so a press over the
+  // surface lands on the <glarea>: the node X11's event propagation arrives
+  // at too. It used to land on the box *behind* the surface, which is all a
+  // tree walk can find, and the surface's own handlers never ran.
+  const seen = [];
+  const log = (who) => (ev) => seen.push([who, ev.type, ev.target]);
+  const { native, node } = await mountGLArea({
+    area: { onMouseDown: log('area'), onClick: log('area') },
+    box: { onMouseDown: log('box') },
+  });
+  const app = node.app;
+  assert.equal(node.forwardsPointer, true);
+  pointerOver(app, node, { press: true });
+  assert.deepEqual(seen, [
+    ['area', 'mouseDown', node],
+    ['box', 'mouseDown', node],
+    ['area', 'click', node],
+  ]);
+  void native;
 });

--- a/test/glarea.test.js
+++ b/test/glarea.test.js
@@ -288,6 +288,10 @@ const POINTER_INPUT =
 async function mountSurface(build) {
   const { app, server } = await createGlApp();
   const x11Root = await createRoot({ app });
+  const close = async () => {
+    await x11Root.unmount();
+    await app.close();
+  };
   let drew = false;
   const instance = await render(
     build(() => {
@@ -295,14 +299,22 @@ async function mountSurface(build) {
     }),
     x11Root,
   );
-  // the GL window is made once the visual query answers
-  await waitFor(() => drew, 'the first frame');
-  await settle(app);
   const windowNode = instance._reactX11Node;
   const find = (n) =>
     n.kind === 'glarea' ? n : n.children.map(find).find(Boolean);
   const area = find(windowNode);
-  assert.ok(area?.window, 'the surface has a window of its own');
+  try {
+    // the GL window is made once the visual query answers
+    await waitFor(() => drew, 'the first frame');
+    await settle(app);
+    assert.ok(area?.window, 'the surface has a window of its own');
+  } catch (err) {
+    // A mount that never settled still holds a connection, and a process
+    // with one open never exits: a regression here would hang the suite
+    // rather than fail it.
+    await close();
+    throw err;
+  }
   const at = (x, y) => {
     const wnd = windowNode.window;
     const origin = wnd._screenOrigin ?? { x: wnd.x ?? 0, y: wnd.y ?? 0 };

--- a/test/glarea.test.js
+++ b/test/glarea.test.js
@@ -8,11 +8,13 @@ import { createRequire } from 'node:module';
 import { test } from 'node:test';
 
 import React from 'react';
+import x11 from 'x11';
 import xserver from 'x11/lib/xserver/index.js';
 import { createClient, StaticFontSource } from 'ntk';
 
 import { createRoot } from '../src/index.js';
 import { WHEEL_NOTCH_PX } from '../src/events.js';
+import { GlAreaNode } from '../src/glnodes.js';
 
 const require = createRequire(import.meta.url);
 const { createGlxExtension, RecordingBackend } = require('x11/browser/glx');
@@ -39,7 +41,7 @@ async function createGlApp({ indirectContexts = true } = {}) {
     fontSource: new StaticFontSource(),
     onXError: (err) => xErrors.push(err),
   });
-  return { app, backend, xErrors };
+  return { app, backend, xErrors, server };
 }
 
 const render = (element, x11Root) =>
@@ -251,6 +253,9 @@ test('a failed <glarea> leaves no X window over the fallback', async () => {
       null,
       'and no child window: an unpainted one would cover whatever replaces it',
     );
+    // …nor one for the hit test to answer with: a point there is the tree's
+    assert.deepEqual(instance._reactX11Node._surfaces, []);
+    assert.equal(area.hitSurface(10, 10), null);
 
     await x11Root.unmount();
     await settle(app);
@@ -259,56 +264,462 @@ test('a failed <glarea> leaves no X window over the fallback', async () => {
   }
 });
 
-test('a wheel over the surface is a synthetic Wheel at the <glarea>', async () => {
-  // The surface owns its own X window, so the server delivers the wheel
-  // there and nothing in the parent's hit testing can see it — the element
-  // selects it and hands it back, naming itself as the target. Without the
-  // naming, the box *behind* the surface is what a hit test answers with (a
-  // window-owning child is not in its parent's paint order), which is
-  // silently wrong rather than broken: the handler simply never runs.
-  const { app } = await createGlApp();
+// --- the pointer over the surface ---------------------------------------------
+//
+// Every test below injects through the in-process server rather than
+// emitting on an ntk window, because *where X delivers each event* is the
+// whole of this feature: the surface selects no pointer input, so the server
+// reports what happens over it to the window the tree lives in — in that
+// window's coordinates, under that window's implicit grab — and the window's
+// hit test names the <glarea>. An `emit` on a window would skip the one step
+// that used to go wrong: the surface selected ButtonPress to hear the wheel,
+// and every press over it then ended at the surface.
+
+const POINTER_INPUT =
+  x11.eventMask.ButtonPress |
+  x11.eventMask.ButtonRelease |
+  x11.eventMask.PointerMotion;
+
+/**
+ * `build(onDraw)` mounted, its surface made and a frame drawn. `at(x, y)`
+ * parks the pointer at a point of the window, `press`/`release` a button —
+ * all through the server.
+ */
+async function mountSurface(build) {
+  const { app, server } = await createGlApp();
   const x11Root = await createRoot({ app });
-  try {
-    const seen = [];
-    let drew = false;
-    const instance = await render(
+  let drew = false;
+  const instance = await render(
+    build(() => {
+      drew = true;
+    }),
+    x11Root,
+  );
+  // the GL window is made once the visual query answers
+  await waitFor(() => drew, 'the first frame');
+  await settle(app);
+  const windowNode = instance._reactX11Node;
+  const find = (n) =>
+    n.kind === 'glarea' ? n : n.children.map(find).find(Boolean);
+  const area = find(windowNode);
+  assert.ok(area?.window, 'the surface has a window of its own');
+  const at = (x, y) => {
+    const wnd = windowNode.window;
+    const origin = wnd._screenOrigin ?? { x: wnd.x ?? 0, y: wnd.y ?? 0 };
+    server.injectPointerMove(origin.x + x, origin.y + y);
+  };
+  return {
+    app,
+    windowNode,
+    area,
+    at,
+    press: (button = 1) => server.injectButton(button, true),
+    release: (button = 1) => server.injectButton(button, false),
+    async close() {
+      await x11Root.unmount();
+      await app.close();
+    },
+  };
+}
+
+test('the pointer over the surface is dispatched at the <glarea>, and bubbles', async () => {
+  const seen = [];
+  const log = (who) => (ev) =>
+    seen.push({
+      who,
+      type: ev.type,
+      target: ev.target,
+      at: [ev.x, ev.y],
+      local: [ev.localX, ev.localY],
+      button: ev.button,
+      detail: ev.detail,
+    });
+  const s = await mountSurface((onDraw) =>
+    h(
+      'window',
+      { width: 320, height: 240 },
       h(
-        'window',
-        { width: 320, height: 240 },
+        'box',
+        {
+          style: { flexGrow: 1, padding: 20 },
+          focusable: true,
+          onMouseDown: log('pane'),
+          onClick: log('pane'),
+        },
         h('glarea', {
           style: { flexGrow: 1 },
-          onWheel: (ev) => seen.push(ev),
-          onDraw: () => {
-            drew = true;
-          },
+          onDraw,
+          onMouseDown: log('area'),
+          onMouseMove: log('area'),
+          onMouseUp: log('area'),
+          onClick: log('area'),
         }),
       ),
-      x11Root,
+    ),
+  );
+  try {
+    const { area } = s;
+    const pane = area.parent;
+    const of = (who, type) =>
+      seen.filter((e) => e.who === who && e.type === type);
+    assert.equal(area.forwardsPointer, true);
+    assert.equal(
+      GlAreaNode.prototype.forwardsPointer,
+      true,
+      'askable without rendering anything',
     );
-    // the GL window is made once the visual query answers, so wait for the
-    // first frame the way the tests above do
-    await waitFor(() => drew, 'the first frame');
-    await settle(app);
-    const area = instance._reactX11Node.children[0];
-    assert.equal(area.kind, 'glarea');
-    assert.ok(area.window, 'the surface has a window of its own');
+    // the mechanism, pinned: the surface's own window selects no pointer
+    // input, so none of it stops there
+    assert.equal(area.window.eventMask & POINTER_INPUT, 0);
 
-    area.window.emit('wheel', {
-      x: 20,
-      y: 30,
-      deltaX: 0,
-      deltaY: 1,
-      buttons: 0,
+    s.at(60, 70);
+    await waitFor(() => of('area', 'mouseMove').length > 0, 'a move over it');
+    s.press();
+    await waitFor(() => of('area', 'mouseDown').length > 0, 'the press');
+    s.at(90, 100);
+    await waitFor(() => of('area', 'mouseMove').length > 1, 'the drag');
+    s.release();
+    await waitFor(() => of('area', 'click').length > 0, 'the click');
+
+    const [down] = of('area', 'mouseDown');
+    assert.equal(down.target, area, 'the <glarea>, not the box behind it');
+    // the owning window's coordinates, and the surface's own corner
+    assert.deepEqual(down.at, [60, 70]);
+    assert.deepEqual(down.local, [40, 50]);
+    assert.equal(down.button, 1);
+    assert.equal(of('pane', 'mouseDown')[0]?.target, area, 'it bubbled');
+    assert.deepEqual(of('area', 'mouseMove').at(-1).at, [90, 100]);
+    assert.equal(of('area', 'mouseUp').length, 1);
+    const [click] = of('area', 'click');
+    assert.equal(click.target, area);
+    assert.equal(click.detail, 1);
+    assert.equal(of('pane', 'click')[0]?.target, area);
+    // and the press focused the nearest focusable ancestor, as anywhere
+    assert.equal(pane.focused, true);
+  } finally {
+    await s.close();
+  }
+});
+
+test('a drag that leaves the surface keeps coming, to whatever holds it', async () => {
+  // The press lands on the owning window, so the implicit grab is that
+  // window's: motion and the release keep arriving however far the pointer
+  // goes. Before, the grab was the surface's — it had taken the press — and
+  // it had selected neither, so a drag off a <glarea> was simply lost.
+  for (const capture of [false, true]) {
+    const seen = [];
+    const log = (who) => (ev) =>
+      seen.push({ who, type: ev.type, target: ev.target, x: ev.x });
+    const s = await mountSurface((onDraw) =>
+      h(
+        'window',
+        {
+          width: 320,
+          height: 240,
+          onMouseMove: log('window'),
+          onClick: log('window'),
+        },
+        h(
+          'box',
+          { style: { flexDirection: 'row', flexGrow: 1 } },
+          h('glarea', {
+            key: 'gl',
+            style: { width: 150 },
+            onDraw,
+            onMouseDown: (ev) => {
+              if (capture) ev.capturePointer();
+              log('area')(ev);
+            },
+            onMouseMove: log('area'),
+            onMouseUp: log('area'),
+            onClick: log('area'),
+          }),
+          h('box', {
+            key: 'side',
+            style: { flexGrow: 1 },
+            onMouseMove: log('side'),
+          }),
+        ),
+      ),
+    );
+    try {
+      const { area, windowNode } = s;
+      const side = area.parent.children[1];
+      const moved = (x) =>
+        seen.some((e) => e.type === 'mouseMove' && e.x === x);
+      s.at(40, 40);
+      await waitFor(() => moved(40), 'a move over the surface');
+      s.press();
+      await waitFor(() => seen.some((e) => e.type === 'mouseDown'), 'press');
+      s.at(200, 40); // over the box beside the surface
+      await waitFor(() => moved(200), 'a move beside it');
+      s.at(500, 400); // out of the window altogether
+      await waitFor(() => moved(500), 'a move outside the window');
+      s.release();
+      await waitFor(
+        () => seen.some((e) => e.type === 'click'),
+        'the click the release makes',
+      );
+      const moveAt = (who, x) =>
+        seen.find((e) => e.who === who && e.type === 'mouseMove' && e.x === x);
+      const click = seen.find((e) => e.type === 'click');
+      if (capture) {
+        assert.equal(moveAt('area', 200)?.target, area, capture);
+        assert.equal(moveAt('area', 500)?.target, area);
+        assert.equal(moveAt('side', 200), undefined, 'the box heard nothing');
+        const up = seen.find((e) => e.type === 'mouseUp');
+        assert.equal(up?.who, 'area');
+        assert.equal(up?.target, area);
+        assert.equal(click.target, area, 'released on the captor');
+      } else {
+        // uncaptured, a move is whatever it is over — the box beside, then
+        // the window itself — as for a drag that started anywhere else
+        assert.equal(moveAt('side', 200)?.target, side);
+        assert.equal(moveAt('window', 500)?.target, windowNode.window);
+        assert.equal(moveAt('area', 500), undefined);
+        // and the click is the nearest common ancestor's, the window's
+        assert.equal(click.who, 'window');
+        assert.equal(click.target, windowNode.window);
+      }
+    } finally {
+      await s.close();
+    }
+  }
+});
+
+test('a double click on the surface counts, and the right button asks for its context menu', async () => {
+  const seen = [];
+  const log = (ev) =>
+    seen.push({
+      type: ev.type,
+      target: ev.target,
+      button: ev.button,
+      detail: ev.detail,
     });
-    await new Promise((resolve) => setTimeout(resolve, 20));
+  const s = await mountSurface((onDraw) =>
+    h(
+      'window',
+      { width: 320, height: 240 },
+      h('glarea', {
+        style: { flexGrow: 1 },
+        onDraw,
+        onClick: log,
+        onContextMenu: log,
+      }),
+    ),
+  );
+  try {
+    s.at(100, 100);
+    s.press();
+    s.release();
+    s.press();
+    s.release();
+    const clicks = () => seen.filter((e) => e.type === 'click');
+    await waitFor(() => clicks().length === 2, 'two clicks');
+    assert.deepEqual(
+      clicks().map((e) => [e.target, e.detail]),
+      [
+        [s.area, 1],
+        [s.area, 2],
+      ],
+    );
+    s.press(3);
+    s.release(3);
+    await waitFor(
+      () => seen.some((e) => e.type === 'contextMenu'),
+      'the context menu',
+    );
+    const menu = seen.find((e) => e.type === 'contextMenu');
+    assert.equal(menu.target, s.area);
+    assert.equal(menu.button, 3);
+  } finally {
+    await s.close();
+  }
+});
 
-    assert.equal(seen.length, 1, 'the handler on the <glarea> ran');
+test('a wheel notch over the surface is one Wheel at the <glarea>, and no press', async () => {
+  // Buttons 4-7 are the core protocol's wheel. ntk makes a `wheel` of the
+  // press on the owning window and the manager drops the press itself on the
+  // button path, so a notch over a surface is one event — not a Wheel plus a
+  // click nobody made.
+  const seen = [];
+  const log = (ev) =>
+    seen.push({ type: ev.type, target: ev.target, deltaY: ev.deltaY });
+  const s = await mountSurface((onDraw) =>
+    h(
+      'window',
+      { width: 320, height: 240 },
+      h('glarea', {
+        style: { flexGrow: 1 },
+        onDraw,
+        onWheel: log,
+        onMouseDown: log,
+        onMouseUp: log,
+        onClick: log,
+      }),
+    ),
+  );
+  try {
+    s.at(100, 100);
+    s.press(5);
+    s.release(5);
+    await waitFor(() => seen.length > 0, 'the wheel');
+    await settle(s.app);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.deepEqual(
+      seen.map((e) => e.type),
+      ['wheel'],
+    );
+    assert.equal(seen[0].target, s.area);
     // pixels, not notches — the same conversion every other wheel gets
     assert.equal(seen[0].deltaY, WHEEL_NOTCH_PX);
-    assert.equal(seen[0].deltaX, 0);
   } finally {
-    await x11Root.unmount();
-    await app.close();
+    await s.close();
+  }
+});
+
+test('the pointer crossing onto the surface is not a leave', async () => {
+  // X reports the crossing into a child window as the parent's LeaveNotify.
+  // Over a surface that is not the pointer leaving anything the tree can
+  // see: the motion still arrives at the window and names the <glarea>. So
+  // the ancestors stay hovered — they used to be told the pointer had gone
+  // and then that it was back — and the window hears no mouseOut.
+  const counts = {
+    paneEnter: 0,
+    paneLeave: 0,
+    areaEnter: 0,
+    areaLeave: 0,
+    windowOut: 0,
+  };
+  const bump = (key) => () => {
+    counts[key] += 1;
+  };
+  const s = await mountSurface((onDraw) =>
+    h(
+      'window',
+      { width: 320, height: 240, onMouseOut: bump('windowOut') },
+      h(
+        'box',
+        {
+          style: { flexGrow: 1, padding: 40 },
+          onMouseEnter: bump('paneEnter'),
+          onMouseLeave: bump('paneLeave'),
+        },
+        h('glarea', {
+          style: { flexGrow: 1 },
+          onDraw,
+          onMouseEnter: bump('areaEnter'),
+          onMouseLeave: bump('areaLeave'),
+        }),
+      ),
+    ),
+  );
+  try {
+    const { area } = s;
+    const pane = area.parent;
+    s.at(10, 10); // the pane's padding
+    await waitFor(() => counts.paneEnter === 1, 'the pane hovered');
+    s.at(100, 100); // onto the surface
+    await waitFor(() => counts.areaEnter === 1, 'the surface hovered');
+    assert.equal(counts.paneLeave, 0, 'the pane was never left');
+    assert.equal(counts.windowOut, 0, 'nor the window');
+    assert.equal(area.states[':hover'], true);
+    assert.equal(pane.states[':hover'], true);
+    s.at(10, 10); // and back off it
+    await waitFor(() => counts.areaLeave === 1, 'the surface left');
+    assert.deepEqual(
+      [counts.paneEnter, counts.paneLeave, counts.windowOut],
+      [1, 0, 0],
+    );
+  } finally {
+    await s.close();
+  }
+});
+
+test('a grab that ends over the surface is not a leave; one taken elsewhere is', async () => {
+  // The one test here that emits rather than injects: the in-process server
+  // sends no crossings for grabs, so these are the LeaveNotify shapes Xvfb
+  // sent the owning window, replayed on it.
+  //
+  // Every click and wheel notch over a surface ends the press's implicit
+  // grab — the owning window's — with the pointer still on the surface:
+  // detail NotifyInferior, mode NotifyUngrab, no child. Taken for a leave,
+  // hover went out from under the pointer after every click. A grab taken
+  // by another window while the pointer is on the surface is a real leave:
+  // detail NotifyNonlinearVirtual, mode NotifyGrab, the surface as child.
+  const counts = { paneLeave: 0, areaEnter: 0, areaLeave: 0, windowOut: 0 };
+  const bump = (key) => () => {
+    counts[key] += 1;
+  };
+  const s = await mountSurface((onDraw) =>
+    h(
+      'window',
+      { width: 320, height: 240, onMouseOut: bump('windowOut') },
+      h(
+        'box',
+        {
+          style: { flexGrow: 1, padding: 40 },
+          onMouseLeave: bump('paneLeave'),
+        },
+        h('glarea', {
+          style: { flexGrow: 1 },
+          onDraw,
+          onMouseEnter: bump('areaEnter'),
+          onMouseLeave: bump('areaLeave'),
+        }),
+      ),
+    ),
+  );
+  try {
+    s.at(100, 100);
+    await waitFor(() => counts.areaEnter === 1, 'the surface hovered');
+    const wnd = s.windowNode.window;
+    const leave = (fields) =>
+      wnd.emit('mouseout', { x: 100, y: 100, buttons: 0, ...fields });
+    leave({ detail: 2, mode: 2, child: 0 }); // the ungrab after a click
+    assert.deepEqual(
+      [counts.areaLeave, counts.paneLeave, counts.windowOut],
+      [0, 0, 0],
+      'still over the surface',
+    );
+    leave({ detail: 4, mode: 1, child: s.area.window.id }); // a grab elsewhere
+    assert.deepEqual(
+      [counts.areaLeave, counts.paneLeave, counts.windowOut],
+      [1, 1, 1],
+      'the pointer is the grab’s now',
+    );
+  } finally {
+    await s.close();
+  }
+});
+
+test("pointerEvents: 'none' on the surface lets the pointer through to the tree behind it", async () => {
+  const seen = [];
+  const s = await mountSurface((onDraw) =>
+    h(
+      'window',
+      { width: 320, height: 240 },
+      h(
+        'box',
+        {
+          style: { flexGrow: 1, padding: 20 },
+          onMouseDown: (ev) => seen.push(ev.target),
+        },
+        h('glarea', {
+          style: { flexGrow: 1, pointerEvents: 'none' },
+          onDraw,
+        }),
+      ),
+    ),
+  );
+  try {
+    s.at(100, 100);
+    s.press();
+    s.release();
+    await waitFor(() => seen.length > 0, 'the press');
+    assert.equal(seen[0], s.area.parent, 'the box behind the surface took it');
+  } finally {
+    await s.close();
   }
 });
 

--- a/test/glarea.test.js
+++ b/test/glarea.test.js
@@ -73,6 +73,28 @@ const getAttributes = (app, wid) =>
     ),
   );
 
+/**
+ * Nodes are compared by identity and named in the message, never handed to
+ * `assert.equal`: a failed comparison `util.inspect`s both sides, a node
+ * reaches the whole tree, the app and its connection, and the report then
+ * takes minutes — a regression hangs the suite instead of failing it. Found
+ * by planting one.
+ */
+const nameOf = (v) =>
+  v == null
+    ? String(v)
+    : v.kind
+      ? `<${v.kind}>`
+      : v.id != null
+        ? `window ${v.id}`
+        : typeof v;
+function same(actual, expected, what) {
+  assert.ok(
+    actual === expected,
+    `${what}: got ${nameOf(actual)}, want ${nameOf(expected)}`,
+  );
+}
+
 test('<glarea> gets a GL child window and draws a frame', async () => {
   const { app, backend, xErrors } = await createGlApp();
   const x11Root = await createRoot({ app });
@@ -255,7 +277,7 @@ test('a failed <glarea> leaves no X window over the fallback', async () => {
     );
     // …nor one for the hit test to answer with: a point there is the tree's
     assert.deepEqual(instance._reactX11Node._surfaces, []);
-    assert.equal(area.hitSurface(10, 10), null);
+    same(area.hitSurface(10, 10), null, 'a failed surface, under the pointer');
 
     await x11Root.unmount();
     await settle(app);
@@ -394,18 +416,18 @@ test('the pointer over the surface is dispatched at the <glarea>, and bubbles', 
     await waitFor(() => of('area', 'click').length > 0, 'the click');
 
     const [down] = of('area', 'mouseDown');
-    assert.equal(down.target, area, 'the <glarea>, not the box behind it');
+    same(down.target, area, 'the <glarea>, not the box behind it');
     // the owning window's coordinates, and the surface's own corner
     assert.deepEqual(down.at, [60, 70]);
     assert.deepEqual(down.local, [40, 50]);
     assert.equal(down.button, 1);
-    assert.equal(of('pane', 'mouseDown')[0]?.target, area, 'it bubbled');
+    same(of('pane', 'mouseDown')[0]?.target, area, 'it bubbled');
     assert.deepEqual(of('area', 'mouseMove').at(-1).at, [90, 100]);
     assert.equal(of('area', 'mouseUp').length, 1);
     const [click] = of('area', 'click');
-    assert.equal(click.target, area);
+    same(click.target, area, 'the click');
     assert.equal(click.detail, 1);
-    assert.equal(of('pane', 'click')[0]?.target, area);
+    same(of('pane', 'click')[0]?.target, area, 'the click, bubbled');
     // and the press focused the nearest focusable ancestor, as anywhere
     assert.equal(pane.focused, true);
   } finally {
@@ -476,22 +498,22 @@ test('a drag that leaves the surface keeps coming, to whatever holds it', async 
         seen.find((e) => e.who === who && e.type === 'mouseMove' && e.x === x);
       const click = seen.find((e) => e.type === 'click');
       if (capture) {
-        assert.equal(moveAt('area', 200)?.target, area, capture);
-        assert.equal(moveAt('area', 500)?.target, area);
-        assert.equal(moveAt('side', 200), undefined, 'the box heard nothing');
+        same(moveAt('area', 200)?.target, area, 'captured, beside it');
+        same(moveAt('area', 500)?.target, area, 'captured, outside');
+        assert.ok(!moveAt('side', 200), 'the box heard nothing');
         const up = seen.find((e) => e.type === 'mouseUp');
         assert.equal(up?.who, 'area');
-        assert.equal(up?.target, area);
-        assert.equal(click.target, area, 'released on the captor');
+        same(up?.target, area, 'the release');
+        same(click.target, area, 'released on the captor');
       } else {
         // uncaptured, a move is whatever it is over — the box beside, then
         // the window itself — as for a drag that started anywhere else
-        assert.equal(moveAt('side', 200)?.target, side);
-        assert.equal(moveAt('window', 500)?.target, windowNode.window);
-        assert.equal(moveAt('area', 500), undefined);
+        same(moveAt('side', 200)?.target, side, 'a move beside it');
+        same(moveAt('window', 500)?.target, windowNode.window, 'outside');
+        assert.ok(!moveAt('area', 500), 'not the surface’s, outside it');
         // and the click is the nearest common ancestor's, the window's
         assert.equal(click.who, 'window');
-        assert.equal(click.target, windowNode.window);
+        same(click.target, windowNode.window, 'the click');
       }
     } finally {
       await s.close();
@@ -529,10 +551,10 @@ test('a double click on the surface counts, and the right button asks for its co
     const clicks = () => seen.filter((e) => e.type === 'click');
     await waitFor(() => clicks().length === 2, 'two clicks');
     assert.deepEqual(
-      clicks().map((e) => [e.target, e.detail]),
+      clicks().map((e) => [e.target === s.area, e.detail]),
       [
-        [s.area, 1],
-        [s.area, 2],
+        [true, 1],
+        [true, 2],
       ],
     );
     s.press(3);
@@ -542,7 +564,7 @@ test('a double click on the surface counts, and the right button asks for its co
       'the context menu',
     );
     const menu = seen.find((e) => e.type === 'contextMenu');
-    assert.equal(menu.target, s.area);
+    same(menu.target, s.area, 'the context menu');
     assert.equal(menu.button, 3);
   } finally {
     await s.close();
@@ -582,7 +604,7 @@ test('a wheel notch over the surface is one Wheel at the <glarea>, and no press'
       seen.map((e) => e.type),
       ['wheel'],
     );
-    assert.equal(seen[0].target, s.area);
+    same(seen[0].target, s.area, 'the wheel');
     // pixels, not notches — the same conversion every other wheel gets
     assert.equal(seen[0].deltaY, WHEEL_NOTCH_PX);
   } finally {
@@ -729,7 +751,7 @@ test("pointerEvents: 'none' on the surface lets the pointer through to the tree 
     s.press();
     s.release();
     await waitFor(() => seen.length > 0, 'the press');
-    assert.equal(seen[0], s.area.parent, 'the box behind the surface took it');
+    same(seen[0], s.area.parent, 'the box behind the surface took it');
   } finally {
     await s.close();
   }

--- a/test/types/api.tsx
+++ b/test/types/api.tsx
@@ -10,7 +10,7 @@ import React, { useRef, useState } from 'react';
 import { startTrace } from 'react-x11/debug';
 import { XK_MULTI_KEY, isDeadKeysym, keysymFromName } from 'react-x11/keysyms';
 import { Surface } from 'react-x11/ntk';
-import type { Context2D } from 'react-x11/node';
+import type { Context2D, GlAreaNode } from 'react-x11/node';
 import { onReload, performReactRefresh } from 'react-x11/refresh';
 import { registerRefresh, createTransformer } from 'react-x11/refresh/loader';
 import type { ReloadEvent } from 'react-x11/refresh';
@@ -780,12 +780,24 @@ function RawGl() {
       onCreated={(gl) => gl.Enable(gl.DEPTH_TEST)}
       onDraw={(gl, { width }) => gl.Viewport(0, 0, width, width)}
       onError={(err) => void err.message}
-      // the wheel reaches a GL surface (it selects it and hands it to the
-      // window's manager), and carries pixels like every other wheel
+      // the pointer over a GL surface is the tree's, as over any node: the
+      // wheel carries pixels, a press a button and a click count, and a
+      // drag can hold on to the surface
       onWheel={(ev) => void (ev.deltaY + ev.deltaX)}
+      onMouseDown={(ev) => {
+        ev.capturePointer();
+        void (ev.button + ev.detail + ev.localX);
+      }}
+      onClick={(ev) => void ev.detail}
     />
   );
 }
+
+// what an element built on <glarea> asks before listening on `node.window`
+// for the pointer itself — true wherever core delivers it to the tree
+declare const surfaceNode: GlAreaNode;
+const _forwardsPointer: true = surfaceNode.forwardsPointer;
+void _forwardsPointer;
 
 function Embedded({ id }: { id: number }) {
   return (

--- a/test/viewer3d.test.js
+++ b/test/viewer3d.test.js
@@ -86,7 +86,7 @@ async function glApp() {
     fontSource: source,
     onXError: () => {},
   });
-  return { app, backend };
+  return { app, backend, server };
 }
 
 const render = (element, root) =>
@@ -106,7 +106,7 @@ const count = (backend, name) =>
   names(backend).filter((c) => c === name).length;
 
 async function mountViewer(extra = {}) {
-  const { app, backend } = await glApp();
+  const { app, backend, server } = await glApp();
   const root = await createRoot({ app });
   const instance = await render(
     h(
@@ -117,8 +117,13 @@ async function mountViewer(extra = {}) {
     root,
   );
   await waitFor(() => count(backend, 'clear') > 0, 'the first frame');
-  return { app, backend, root, instance };
+  return { app, backend, server, root, instance };
 }
+
+const findKind = (node, kind) =>
+  node.kind === kind
+    ? node
+    : node.children.map((c) => findKind(c, kind)).find(Boolean);
 
 describe('examples/viewer3d', () => {
   test('one-time GL state is set once, not per frame', async () => {
@@ -194,5 +199,37 @@ describe('examples/viewer3d', () => {
       settled,
       'on demand, nothing redraws until something changes',
     );
+  });
+
+  test('a drag over the stage orbits the model, even with Spin off', async () => {
+    // The handlers are on the <glarea>, and on X11 they never ran: the
+    // surface selected the wheel's button presses, and with them every
+    // press. Injected through the server, so this is the route a real drag
+    // takes. Spin is off, so the frames showing the new pitch are the drag's
+    // own — a `'demand'` surface draws on a prop change, and the camera is a
+    // ref, which is why the viewer loops for as long as a drag lasts.
+    const { backend, server, instance } = await mountViewer({
+      initialSpin: false,
+    });
+    const stage = findKind(instance._reactX11Node, 'glarea');
+    const degrees = (rad) => (rad * 180) / Math.PI;
+    // the pitch is the rotation about x; yaw is about y
+    const pitch = () =>
+      backend.calls.findLast(
+        (c) => c[0] === 'rotate' && c[2] === 1 && c[3] === 0 && c[4] === 0,
+      )?.[1];
+    assert.ok(Math.abs(pitch() - degrees(0.35)) < 1e-3, `from ${pitch()}`);
+    // the window sits at the screen's origin: there is no WM to move it
+    const x = Math.round(stage.abs.x + stage.abs.width / 2);
+    const y = Math.round(stage.abs.y + stage.abs.height / 2);
+    server.injectPointerMove(x, y);
+    server.injectButton(1, true);
+    // 50px down is half a radian of pitch (examples/viewer3d.jsx)
+    server.injectPointerMove(x, y + 50);
+    await waitFor(
+      () => Math.abs(pitch() - degrees(0.85)) < 1e-3,
+      'a frame at the dragged pitch',
+    );
+    server.injectButton(1, false);
   });
 });


### PR DESCRIPTION
Upstream half of sidorares/react-x11-components#101 (a GL renderer behind `<Map>`), finding 6 of its `docs/prd-maps-gl.md`: pointer input over a `<glarea>` never reached the tree on X11, except the wheel.

## What was wrong

The X11 surface is a child window that **selected `ButtonPress`** so it could hear the wheel and hand it back. That selection is what swallowed everything else. X delivers a device event to the first window up the hierarchy that selected it, so every press over a surface ended at the child window. The drag and the release that followed went nowhere, because the implicit grab was the child's and it had selected neither.

`examples/viewer3d.jsx` is the visible casualty: its orbit handlers sit on the `<glarea>` and never ran on X11.

The Cocoa backend had the same gap from the other side. The window's hit test skips a window-owning node, since it isn't in its parent's paint order. So a press over the surface landed on the box *behind* it, and the `<glarea>`'s own handlers never ran there either.

## What this does

**The surface selects no pointer input.** X then reports the pointer over it to the owning window, in that window's coordinates, under that window's implicit grab and with its XI2 selection. The event takes the window's own path: presses, motion, release, click and multi-click, context menu, hover, capture, focus-on-press, drag and drop, the wheel's default action. Nothing is forwarded, translated or duplicated.

**The window's hit test asks its surfaces first** (`EventManager._hit` → `_surfaceAt` → `GlAreaNode.hitSurface`). A surface is stacked above everything 2D in its window on both backends (X stacks the child window over the parent's drawing; Cocoa puts the layer at zPosition 1e7). So a point inside its rect lands on the `<glarea>` itself. This is the same child X names in the event it propagates. Newest surface on top, as X and Core Animation stack them. `pointerEvents: 'none'` lets the pointer through to the tree behind, and a hidden or failed surface answers nothing.

**A crossing onto a surface is not a leave.** X reports the pointer entering a child window as the parent's `LeaveNotify` (detail `NotifyInferior`). It sends the same shape again, with mode `NotifyUngrab`, after every click and every wheel notch over the surface, when the press's implicit grab ends. Treated as a leave, it told every ancestor the pointer had gone and come back, and it fired `<window onMouseOut>`. `_leftIntoSurface` recognises it (the in-process server says the same thing with `NotifyAncestor` and the child named). A grab taken elsewhere while over a surface (`NotifyNonlinearVirtual`, `NotifyGrab`) is still a leave.

Removed as dead: `GlAreaNode._onWheel`, the `over` parameter of `EventManager._onWheel` (its only caller), and the `onWheel` a Cocoa surface stored and never read. Also `onPointerMissed` from `GlAreaProps`: a scene-graph leftover since #379 that core never implemented. components' three canvas has its own prop of that name and does not pass it to `<glarea>`.

## The contract, and how components adopts it

- **`node.forwardsPointer === true`** on a `<glarea>` node, on both backends, declared in `src/node.d.ts`. It's a getter on the class, so `GlAreaNode.prototype.forwardsPointer` (from `react-x11/node`) answers without rendering. It's `undefined` on an older core.
- It means the pointer over the surface is dispatched through the owning window's event manager, at this node, and bubbles. **An element built on `<glarea>` must not listen for the pointer on `node.window`.** ntk selects whatever a window is listened to for, so on X11 such a listener takes the event away from the tree: every press, and the wheel with them, since both are ButtonPress.
- **components `<GlMap>`**: return early from `_attachPointer` (`src/maps/gl/view.ts`) when `node.forwardsPointer`. The pane box's handlers already serve Cocoa, and now serve X11 through bubbling. Until then, a `<GlMap>` on X11 with this core keeps its own presses but loses the wheel to its child-window listener.
- **components three**: `ScenePointer.attach(node.window)` (`src/three/canvas.ts`) is the same pattern and has the same switch. Picking can move to the `<glarea>`'s `onMouseDown`/`onMouseMove`/`onMouseUp`/`onMouseLeave`, whose `localX`/`localY` are measured from the surface's corner.

## Verified

- **Real server (Xvfb `:99`, indirect GLX, XTEST).** First a raw node-x11 probe of X's own semantics, with a child window selecting nothing versus selecting ButtonPress (today's `<glarea>`):
  - Selecting nothing: motion, press, a drag out of the child and out of the parent, release and wheel all reach the parent with `child` naming the surface.
  - Selecting ButtonPress: the press lands on the child and the drag and release vanish.

  It also recorded the four `LeaveNotify` shapes the leave rule tells apart, which the new tests replay:

  | crossing | detail | mode | `child` |
  | --- | --- | --- | --- |
  | pointer moves onto the surface | Inferior (2) | Normal (0) | none |
  | a click or wheel's grab ends over it | Inferior (2) | Ungrab (2) | none |
  | a drag's grab ends outside | Ancestor (0) | Ungrab (2) | none |
  | another window grabs while over it | NonlinearVirtual (4) | Grab (1) | the surface |

  Then the real thing: a react-x11 `<glarea>` with handlers, driven by XTEST. Enter, press, a captured drag out of the window, release and click all land at the `<glarea>`. Hover stays on the surface through clicks and wheel notches, and stays after the window upgrades itself to XI2 on the first wheel. Presses, motion and the wheel keep arriving after that upgrade, so XI2 events propagate from the surface too.
- **Harness** (`test/glarea.test.js`, through the in-process server's real injection and implicit grabs):
  - press, move, release and click at the `<glarea>`, bubbling, with window and local coordinates and focus-on-press
  - a drag leaving the surface, captured and uncaptured
  - double click `detail: 2`, and right button → `ContextMenu`
  - a wheel notch as exactly one `Wheel` and no press
  - the crossing onto the surface, and the replayed Xvfb ungrab/grab crossings
  - `pointerEvents: 'none'`, a failed surface leaving the hit test, `forwardsPointer`, and the surface's own event mask selecting no pointer input
- **Cocoa** (`test/cocoa-glarea.test.js`, fake bridge): a press over the surface dispatched at the `<glarea>`, bubbling, clicking there.
- **The example**: `test/viewer3d.test.js` drags the stage through the server and waits for a frame at the dragged pitch, with Spin off. The viewer now loops for the length of a drag (press and release are its only renders), since a demand surface redraws on a prop change and the camera is a ref. It also captures the pointer, so an orbit continues off the stage.
- **Mutation checks**, each in a scratch copy of `src/`: each new test is the one that catches its bug.
  - hit test skipping surfaces: 5 X11 tests and the Cocoa file go red
  - surface selecting ButtonPress again: 5 red
  - leave into a surface treated as a leave: the crossing test goes red
  - `mode` excluded from the rule: the ungrab replay goes red
  - any named child treated as "into": the grab replay goes red
- **Suite, types, lint, format** (on the branch rebased onto #543): `npm test`: 2422 of 2428 pass. The 6 failures are all `test/appearance.test.js`, which fails identically on master on this machine (environment, not this change). `npm run typecheck`, `npm run lint` and `npm run format:check` pass.
- **Benches owed** (`npm run bench:touched`):
  - pixels: "pixels unchanged"
  - protocol: "no regressions against the baseline". It had to be run as `REACT_X11_BACKEND=x11 node --expose-gc … protocol.js --check`, because on darwin the bootstrap relaunch onto a worker rejects `--expose-gc` (`ERR_WORKER_INVALID_EXEC_ARGV`, pre-existing). CI's Linux job runs it the normal way.
  - presenters: every rule ok except `covered/surface` (353 frames, max 0), which fails identically on master here. The covering window does not occlude on this desktop.

No screenshots: nothing renders differently; this changes which node an event is dispatched at.

## Two follow-up commits, test hygiene

Both were found by planting regressions in #546, which builds on this PR and copies these helpers.

- 9a813a1: a surface test whose mount never drew its first frame threw before anything closed the connection. The process then never exits, so a regression there would have hung the suite rather than failed it.
- 2760572: the tests handed nodes to `assert.equal`/`deepEqual`. A failed comparison `util.inspect`s both sides, and a node reaches the whole tree, the app and its connection, so a caught regression took minutes to report. Nodes are now compared with `===` and named by kind in the message.
